### PR TITLE
Fix failing CI build

### DIFF
--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -445,7 +445,7 @@ describe('AuthService', () => {
   describe('linkMethod', () => {
     const linkDto = {
       idToken: 'new-token',
-      loginType: 'github' as const,
+      loginType: 'social' as const,
     };
 
     it('should verify token and create new auth method', async () => {
@@ -469,7 +469,7 @@ describe('AuthService', () => {
 
       const result = await service.linkMethod('user-id', linkDto);
 
-      expect(web3AuthVerifier.verifyIdToken).toHaveBeenCalledWith('new-token', 'pub-key', 'github');
+      expect(web3AuthVerifier.verifyIdToken).toHaveBeenCalledWith('new-token', 'pub-key', 'social');
       expect(authMethodRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
           userId: 'user-id',

--- a/apps/api/src/auth/services/web3auth-verifier.service.spec.ts
+++ b/apps/api/src/auth/services/web3auth-verifier.service.spec.ts
@@ -174,7 +174,7 @@ describe('Web3AuthVerifierService', () => {
     });
 
     it('should return wallet address if no verifierId', () => {
-      const payload = { wallets: [{ address: '0x123abc' }] };
+      const payload = { wallets: [{ type: 'ethereum', address: '0x123abc' }] };
 
       const result = service.extractIdentifier(payload);
 
@@ -182,7 +182,7 @@ describe('Web3AuthVerifierService', () => {
     });
 
     it('should return public key as last resort', () => {
-      const payload = { wallets: [{ public_key: 'pubkey123' }] };
+      const payload = { wallets: [{ type: 'ethereum', public_key: 'pubkey123' }] };
 
       const result = service.extractIdentifier(payload);
 


### PR DESCRIPTION
- Change loginType from 'github' to 'social' in LinkMethodDto test (github is a social provider)
- Add required 'type' property to Web3AuthWallet test objects