### PR TITLE
chore: fix status line configuration path

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,6 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "node \"$PWD/.claude/hooks/statusline.js\""
+    "command": "~/.claude/hooks/statusline.js"
   }
 }


### PR DESCRIPTION
## Summary
- Fix statusLine command to use global hooks path (`~/.claude/hooks/statusline.js`) instead of `$PWD` variable expansion which was not working correctly

## Test plan
- [x] Verified status line displays correctly after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)