### PR TITLE
chore: add test-results to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ yarn-error.log*
 # Test coverage
 coverage/
 
+# Playwright test results
+test-results/
+
 # Playwright screenshots
 .playwright-mcp/*.png
 


### PR DESCRIPTION
## Summary
- Add `test-results/` to `.gitignore` to exclude Playwright auto-generated test result files from version control

## Test plan
- [x] Verify `.gitignore` includes `test-results/`
- [x] Confirm test-results folder is no longer tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)