### PR TITLE
chore(ci): add PR title lint to enforce conventional commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,9 +12,9 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # Conventional Commits pattern: type(optional-scope): description
+          # Conventional Commits pattern: type(optional-scope)(optional-!) : description
           # Types must match commitlint config used by husky
-          pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .+'
+          pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?(!)?: .+'
 
           if [[ ! "$PR_TITLE" =~ $pattern ]]; then
             echo "::error::PR title does not follow Conventional Commits format."


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that validates PR titles against Conventional Commits format
- Prevents malformed squash-merge commit messages from breaking Release Please changelog parsing (as happened with #65)

## Test plan
- [ ] Open a PR with a non-conventional title (e.g., "Fix something") — check should fail
- [ ] Edit the title to conventional format (e.g., "fix: something") — check should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)