### PR TITLE
fix(ci): restart Caddy after web deploy to fix stale bind mount

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -218,5 +218,9 @@ jobs:
             # Start/restart services
             docker compose -f docker-compose.staging.yml up -d
 
+            # Restart Caddy to pick up refreshed web files bind mount
+            # (scp rm:true recreates the host dir, breaking the old mount inode)
+            docker compose -f docker-compose.staging.yml restart caddy
+
             # Cleanup old images
             docker image prune -f


### PR DESCRIPTION
## Summary
- The `scp-action` with `rm: true` deletes and recreates `/opt/cipherbox/web`, changing the directory inode
- Caddy's bind mount still references the old inode, causing it to serve 404s for the entire web app
- Adding `docker compose restart caddy` after `up -d` ensures it picks up the new mount

## Test plan
- [ ] Push a `v*-staging*` tag and verify the web app loads after deploy
- [ ] Confirm Caddy container sees files in `/srv/web` without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging deployment workflow to improve service initialization reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->