### PR TITLE
docs: add Phase 33 Windows async FilePointer resolution

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -34,6 +34,7 @@ Decimal phases appear between their surrounding integers in numeric order.
 - [ ] **Phase 30: Web App Observability** - Error tracking service, error boundaries, client-side telemetry (NEEDS DISCUSSION)
 - [ ] **Phase 31: Structural Decomposition** - Split monolithic files (useSharedNavigation, FileBrowser, folder.service) into focused modules (NEEDS DISCUSSION)
 - [ ] **Phase 32: FUSE Async FilePointer Resolution** - Channel-based async resolution to prevent Finder disconnects from blocking FUSE thread
+- [ ] **Phase 33: Windows Async FilePointer Resolution** - Port Phase 32's channel-based async FilePointer resolution to the WinFsp backend
 
 ## Phase Details
 
@@ -356,10 +357,25 @@ Plans:
 
 **Plans**: TBD
 
+### Phase 33: Windows Async FilePointer Resolution
+
+**Goal**: WinFsp FilePointer resolution no longer blocks the filesystem thread, eliminating Explorer hangs during metadata refresh on Windows
+**Depends on**: Phase 32 (macOS implementation establishes the pattern; Windows ports it to platform/windows/)
+**Requirements**: None (performance improvement, Windows parity)
+**Research flag**: Skip -- direct port of Phase 32 pattern to Windows-specific code paths
+**Success Criteria** (what must be TRUE):
+
+1. FilePointer resolution in platform/windows/ spawns async tasks via channel pair instead of blocking
+2. Windows Explorer operations do not hang during background metadata refresh
+3. Resolution latency bounded by timeout rather than O(N \* network_timeout)
+4. Windows desktop E2E tests pass with the async resolution path
+
+**Plans**: TBD
+
 ## Progress
 
 **Execution Order:**
-Phases execute in numeric order: 18 -> 19 -> 19.1 -> 19.2 -> 20 -> 21 -> 22 -> 23 -> 24 -> 25 -> 26 -> 27 -> 28 -> 29 -> 30 -> 31 -> 32
+Phases execute in numeric order: 18 -> 19 -> 19.1 -> 19.2 -> 20 -> 21 -> 22 -> 23 -> 24 -> 25 -> 26 -> 27 -> 28 -> 29 -> 30 -> 31 -> 32 -> 33
 
 | Phase                                     | Milestone | Plans Complete | Status      | Completed  |
 | ----------------------------------------- | --------- | -------------- | ----------- | ---------- |
@@ -376,10 +392,11 @@ Phases execute in numeric order: 18 -> 19 -> 19.1 -> 19.2 -> 20 -> 21 -> 22 -> 2
 | 26. Observability & UX Tuning             | v1.1      | 2/2            | Complete    | 2026-03-26 |
 | 27. Writable Shares (PoC)                 | v1.1      | 3/3            | Complete    | 2026-03-26 |
 | 28. Code Hygiene & Logging                | v1.1      | 4/4            | Complete    | 2026-03-28 |
-| 29. Infrastructure Hardening              | v1.1      | 3/3 | Complete    | 2026-03-28 |
+| 29. Infrastructure Hardening              | v1.1      | 3/3            | Complete    | 2026-03-28 |
 | 30. Web App Observability                 | v1.1      | 0/TBD          | Not started | -          |
 | 31. Structural Decomposition              | v1.1      | 0/TBD          | Not started | -          |
 | 32. FUSE Async FilePointer Resolution     | v1.1      | 0/TBD          | Not started | -          |
+| 33. Windows Async FilePointer Resolution  | v1.1      | 0/TBD          | Not started | -          |
 
 ### Phase 27: Writable Shares (PoC)
 

--- a/.planning/phases/33-windows-async-filepointer-resolution/33-CONTEXT.md
+++ b/.planning/phases/33-windows-async-filepointer-resolution/33-CONTEXT.md
@@ -1,0 +1,121 @@
+# Phase 33: Windows Async FilePointer Resolution - Context
+
+**Gathered:** 2026-03-28
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Port Phase 32's channel-based async FilePointer resolution to the Windows WinFsp backend. The same blocking pattern exists in `crates/fuse/src/platform/windows/` — `block_with_timeout()` calls during FilePointer resolution stall the WinFsp callback thread, causing Explorer hangs during metadata refresh.
+
+**Scope:** Windows WinFsp backend only. macOS FUSE-T/SMB changes are handled in Phase 32 (can execute in parallel since code paths are platform-specific).
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+All decisions mirror Phase 32 — this is a direct port of the same pattern to Windows-specific code.
+
+### Resolution Strategy
+
+- **D-01:** Use channel-based async resolution, mirroring the pattern established in Phase 32 (and the existing content prefetch pattern). Spawn tokio tasks for IPNS resolve + IPFS fetch, send results via mpsc channel, drain in next WinFsp callback.
+
+### Stale Data Handling
+
+- **D-02:** Unresolved FilePointers appear as zero-size placeholder files in Explorer. File name and directory entry visible immediately; size/content available after async resolution.
+
+### Resolution Priority
+
+- **D-03:** Eagerly resolve all unresolved FilePointers as soon as refresh completions are drained.
+
+### Error Resilience
+
+- **D-04:** Retry failed resolutions 3 times with exponential backoff. File stays as zero-size placeholder during retries.
+
+### Deduplication Guard
+
+- **D-05:** Add `resolving_file_pointers: HashSet<u64>` (keyed by inode) to prevent duplicate resolution tasks.
+
+### Open-While-Resolving Behavior
+
+- **D-06:** When `read()` hits an unresolved FilePointer with in-flight resolution, block with ~5s timeout. Return appropriate NTSTATUS error on timeout. Explorer retries automatically.
+
+### Claude's Discretion
+
+- Exact WinFsp NTSTATUS error code for unresolved files (STATUS_DEVICE_NOT_READY vs STATUS_IO_DEVICE_ERROR)
+- Whether shared code can be extracted to platform-independent module or stays duplicated
+- Backoff parameters matching Phase 32
+
+</decisions>
+
+<canonical_refs>
+
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Windows WinFsp Implementation
+
+- `crates/fuse/src/platform/windows/read_ops.rs` — Windows read operations with blocking prefetch pattern (the code to modify)
+- `crates/fuse/src/platform/windows/dir_ops.rs` — Windows readdir with content prefetch
+- `crates/fuse/src/platform/windows/operations.rs` — WinFsp callback dispatch, async content download helper
+- `crates/fuse/src/platform/windows/write_ops.rs` — Windows write operations with FilePointer construction
+
+### Shared Code
+
+- `crates/fuse/src/lib.rs` — `CipherBoxFs` struct (shared between platforms), `block_with_timeout()`, channel patterns
+- `crates/fuse/src/inode.rs` — `resolve_file_pointer()`, `get_unresolved_file_pointers()` (shared)
+- `crates/core/src/folder.rs` — `FilePointer` struct definition
+
+### Phase 32 Reference (macOS implementation to mirror)
+
+- `.planning/phases/32-fuse-async-filepointer-resolution/32-CONTEXT.md` — Original decisions and pattern
+- Phase 32 PLAN.md files (once created) — Implementation approach to port
+
+</canonical_refs>
+
+<code_context>
+
+## Existing Code Insights
+
+### Reusable Assets
+
+- **Content prefetch pattern** (already in Windows code): `platform/windows/read_ops.rs` has the same `prefetching` HashSet + background task + channel drain pattern as macOS. This confirms the pattern ports cleanly.
+- **`CipherBoxFs` struct fields** (`lib.rs`): The `content_rx`, `prefetching`, and channel infrastructure are platform-independent. New FilePointer resolution channels will also be shared.
+- **`InodeTable` methods** (`inode.rs`): `resolve_file_pointer()`, `get_unresolved_file_pointers()` are platform-independent. No Windows-specific changes needed.
+
+### Established Patterns
+
+- **WinFsp callbacks run on a thread pool** (unlike FUSE-T's single thread), but blocking still degrades performance by exhausting the pool.
+- **Windows uses `winfsp::filesystem` trait** instead of `fuser::Filesystem`. Different callback signatures but same logical operations.
+- **NTSTATUS error codes** used instead of POSIX errno.
+
+### Integration Points
+
+- **`platform/windows/read_ops.rs`**: Main file to modify — add FilePointer resolution channel drain and async dispatch.
+- **`platform/windows/dir_ops.rs`**: May need FilePointer resolution drain in readdir path (same as macOS).
+- **`lib.rs` CipherBoxFs**: New channel fields are platform-independent — added once, used by both platforms.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Keep changes strictly in `platform/windows/` where possible — this phase should be safe to execute in parallel with Phase 32 on macOS
+- If Phase 32 introduces shared abstractions (e.g., a `PendingFilePointer` enum), reuse them rather than duplicating
+- Testing must happen on a Windows machine
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — this phase is tightly scoped as a direct port.
+
+</deferred>
+
+---
+
+_Phase: 33-windows-async-filepointer-resolution_
+_Context gathered: 2026-03-28_


### PR DESCRIPTION
## Summary
- Adds Phase 33 to ROADMAP.md — Windows WinFsp port of Phase 32's async FilePointer resolution
- Includes CONTEXT.md with all decisions (mirrors Phase 32 decisions adapted for WinFsp)
- Phase 33 can execute in parallel with Phase 32 since changes are in platform-specific code paths

## Purpose
Quick merge so Phase 33 planning/execution can start on a Windows machine independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 33 to the roadmap for Windows async FilePointer resolution implementation
  * Created planning context document outlining the Windows implementation approach, including technical decisions for async task spawning, inter-process communication, retry logic, and deduplication strategies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->