### PR TITLE
docs: cleanup deferred items, security backlog, and add Phase 34

### DIFF
--- a/.planning/DEFERRED.md
+++ b/.planning/DEFERRED.md
@@ -126,4 +126,4 @@ These were deferred but have since been completed:
 | Pagination on shares endpoints (L4)    | Phase 14 security review | Phase 14       |
 | Structured logging wrapper for web app | -                        | Phase 28       |
 
-<!-- Deferred inventory: 2026-03-28 -->
+<!-- Deferred inventory: 2026-03-29 -->

--- a/.planning/DEFERRED.md
+++ b/.planning/DEFERRED.md
@@ -1,6 +1,6 @@
 # Deferred Items Inventory
 
-**Last updated:** 2026-03-28
+**Last updated:** 2026-03-29
 
 Items deferred across milestones v1.0 (phases 11-17.1) and v1.1 (phases 18-27).
 Cross-referenced with `.planning/todos/pending/` and security review findings.
@@ -101,11 +101,10 @@ From `.planning/todos/done/2026-02-21-phase14-security-review-deferred.md`:
 
 ### Code Quality
 
-| Item                                            | Source Phase | Notes                                          |
-| ----------------------------------------------- | ------------ | ---------------------------------------------- |
-| DTS circular build dependency (crypto <-> core) | 19.1         | Workaround in place; not fixed                 |
-| Structured logging wrapper for web app          | -            | 50+ direct `console.*` calls (see CONCERNS.md) |
-| Desktop FUSE automated tests                    | -            | Manual testing only (see CONCERNS.md)          |
+| Item                                            | Source Phase | Notes                                 |
+| ----------------------------------------------- | ------------ | ------------------------------------- |
+| DTS circular build dependency (crypto <-> core) | 19.1         | Workaround in place; not fixed        |
+| Desktop FUSE automated tests                    | -            | Manual testing only (see CONCERNS.md) |
 
 ## Items Implemented in Later Phases
 
@@ -125,5 +124,6 @@ These were deferred but have since been completed:
 | Performance baselines                  | Phase 18                 | Phase 22       |
 | Link sharing                           | Phase 14                 | Phase 15       |
 | Pagination on shares endpoints (L4)    | Phase 14 security review | Phase 14       |
+| Structured logging wrapper for web app | -                        | Phase 28       |
 
 <!-- Deferred inventory: 2026-03-28 -->

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -35,6 +35,7 @@ Decimal phases appear between their surrounding integers in numeric order.
 - [x] **Phase 31: Structural Decomposition** - Split monolithic files (useSharedNavigation, FileBrowser, folder.service) into focused modules (completed 2026-03-28)
 - [x] **Phase 32: FUSE Async FilePointer Resolution** - Channel-based async resolution to prevent Finder disconnects from blocking FUSE thread (completed 2026-03-28)
 - [x] **Phase 33: Windows Async FilePointer Resolution** - Port Phase 32's channel-based async FilePointer resolution to the WinFsp backend (completed 2026-03-28)
+- [ ] **Phase 34: E2E Test Expansion & Staging Baselines** - Streaming playback, media preview, batch download, and shared teardown E2E tests; BYO-IPFS load test and Faro metrics baselines on staging
 
 ## Phase Details
 
@@ -389,10 +390,42 @@ Plans:
 - [x] 33-01-PLAN.md -- Shared async FilePointer resolution infrastructure (PendingFilePointer, channel pair, drain method, modified drain_refresh_completions)
 - [x] 33-02-PLAN.md -- Windows WinFsp callback wiring (drain calls in open/read/readdir, read-while-resolving poll, STATUS_DEVICE_NOT_READY)
 
+### Phase 34: E2E Test Expansion & Staging Baselines
+
+**Goal**: Expand E2E test coverage to untested features and capture staging baselines with new instrumentation
+**Depends on**: Phase 33 (all code changes complete; this is a testing/validation phase)
+**Requirements**: None (test coverage and baseline capture)
+**Success Criteria** (what must be TRUE):
+
+1. AES-CTR streaming playback E2E tests cover mode selection, SW interception, seeking, and progress
+2. Batch download zip E2E tests cover multi-file selection and zip generation
+3. Media preview E2E tests cover PDF viewer, video player, and audio player
+4. Shared deleteAccount teardown wired into all E2E spec afterAll hooks
+5. BYO-IPFS load test baselines captured on staging
+6. Staging metrics baselines captured with Phase 30 Faro instrumentation
+
+**Todos consumed:**
+
+- `.planning/todos/pending/2026-03-28-add-aes-ctr-streaming-playback-e2e-tests.md`
+- `.planning/todos/pending/2026-03-28-add-batch-download-zip-e2e-tests.md`
+- `.planning/todos/pending/2026-03-28-add-media-preview-e2e-test-suite.md`
+- `.planning/todos/pending/2026-03-28-add-shared-deleteaccount-teardown-to-all-e2e-specs.md`
+- `.planning/todos/pending/2026-03-28-byo-ipfs-load-test-baselines-on-staging.md`
+- `.planning/todos/pending/2026-03-28-run-staging-metrics-baselines-with-new-instrumentation.md`
+
+**Plans:** TBD
+
+Plans:
+
+- [ ] 34-01-PLAN.md -- Shared E2E teardown helper and deleteAccount wiring across all specs
+- [ ] 34-02-PLAN.md -- AES-CTR streaming playback and media preview E2E suites
+- [ ] 34-03-PLAN.md -- Batch download zip E2E tests
+- [ ] 34-04-PLAN.md -- BYO-IPFS load test baselines and staging metrics capture
+
 ## Progress
 
 **Execution Order:**
-Phases execute in numeric order: 18 -> 19 -> 19.1 -> 19.2 -> 20 -> 21 -> 22 -> 23 -> 24 -> 25 -> 26 -> 27 -> 28 -> 29 -> 30 -> 31 -> 32 -> 33
+Phases execute in numeric order: 18 -> 19 -> 19.1 -> 19.2 -> 20 -> 21 -> 22 -> 23 -> 24 -> 25 -> 26 -> 27 -> 28 -> 29 -> 30 -> 31 -> 32 -> 33 -> 34
 
 | Phase                                     | Milestone | Plans Complete | Status      | Completed  |
 | ----------------------------------------- | --------- | -------------- | ----------- | ---------- |
@@ -414,6 +447,7 @@ Phases execute in numeric order: 18 -> 19 -> 19.1 -> 19.2 -> 20 -> 21 -> 22 -> 2
 | 31. Structural Decomposition              | v1.1      | 3/3            | Complete    | 2026-03-28 |
 | 32. FUSE Async FilePointer Resolution     | v1.1      | 3/3            | Complete    | 2026-03-28 |
 | 33. Windows Async FilePointer Resolution  | v1.1      | 2/2            | Complete    | 2026-03-28 |
+| 34. E2E Test Expansion & Baselines        | v1.1      | 0/4            | Not Started | -          |
 
 ### Phase 27: Writable Shares (PoC)
 

--- a/.planning/security/LOW-SEVERITY-BACKLOG.md
+++ b/.planning/security/LOW-SEVERITY-BACKLOG.md
@@ -1,11 +1,11 @@
 # Security Review - LOW Severity Issues Backlog
 
 **Date:** 2026-01-21
-**Source:** Phase 5 Security Review (REVIEW-2026-01-21-phase5.md)
-**Status:** Deferred for future work
+**Source:** Phase 5 Security Review + Phase 9 Desktop Security Review
+**Last audited:** 2026-03-29
+**Status:** 12 open, 7 resolved
 
-These issues were identified during the Phase 5 security review but have low severity
-and are deferred for future implementation.
+Items 1-12 from Phase 5, items 13-19 from Phase 9. Resolved items are struck through.
 
 ---
 
@@ -259,10 +259,11 @@ Consider addressing these when:
 
 ---
 
-## 13. Auth Controller Missing Explicit ThrottlerGuard
+## ~~13. Auth Controller Missing Explicit ThrottlerGuard~~ — RESOLVED
 
 **Location:** `apps/api/src/auth/auth.controller.ts:42`
 **Added:** 2026-02-08 (Phase 9 Desktop Security Review, L-1)
+**Resolved:** ThrottlerGuard now applied with `@Throttle({ default: { limit: 10, ttl: 60000 } })` on login endpoint.
 
 **Issue:** The auth controller does not have `@UseGuards(ThrottlerGuard)`, unlike the IPNS controller. While global ThrottlerModule exists, NestJS requires the guard to be applied per-controller.
 
@@ -270,10 +271,11 @@ Consider addressing these when:
 
 ---
 
-## 14. IPNS Name in Query Parameter Not URL-Encoded
+## ~~14. IPNS Name in Query Parameter Not URL-Encoded~~ — RESOLVED
 
-**Location:** `apps/desktop/src-tauri/src/api/ipns.rs:29`
+**Location:** `crates/api-client/src/ipns.rs` (moved from `apps/desktop/src-tauri/src/api/ipns.rs`)
 **Added:** 2026-02-08 (Phase 9 Desktop Security Review, L-2)
+**Resolved:** Phase 23 (Rust SDK extraction) — `urlencoding::encode()` now used.
 
 **Issue:** `format!("/ipns/resolve?ipnsName={}", ipns_name)` -- no URL encoding. Currently safe (IPNS names are `[a-z0-9]`) but establishes a fragile pattern.
 
@@ -281,10 +283,11 @@ Consider addressing these when:
 
 ---
 
-## 15. Debug eprintln! Statements Leak Filenames to stderr
+## ~~15. Debug eprintln! Statements Leak Filenames to stderr~~ — RESOLVED
 
-**Location:** `apps/desktop/src-tauri/src/fuse/operations.rs:1638-1641` and others
+**Location:** `crates/fuse/src/` (moved from `apps/desktop/src-tauri/src/fuse/`)
 **Added:** 2026-02-08 (Phase 9 Desktop Security Review, L-3)
+**Resolved:** Removed before Phase 9 merge. Confirmed in `.planning/todos/done/2026-02-10-remove-debug-eprintln-statements.md`.
 
 **Issue:** Multiple `eprintln!(">>>` statements bypass log-level filtering and leak filenames (sensitive in a privacy-focused app). Already noted in project memory as pre-merge cleanup.
 
@@ -292,10 +295,11 @@ Consider addressing these when:
 
 ---
 
-## 16. Private Key Logged by Length in auth.ts
+## ~~16. Private Key Logged by Length in auth.ts~~ — RESOLVED
 
-**Location:** `apps/desktop/src/auth.ts:167`
+**Location:** `apps/desktop/src/auth.ts`
 **Added:** 2026-02-08 (Phase 9 Desktop Security Review, L-4)
+**Resolved:** Phase 28 (Code Hygiene & Logging) — console.log removed.
 
 **Issue:** `console.log('Got private key, length:', privateKey.length)` -- logs the length (always 64 hex chars), not the key itself. Not a secret leak, but establishes a risky log-adjacent pattern.
 
@@ -303,10 +307,11 @@ Consider addressing these when:
 
 ---
 
-## 17. Ed25519 Stack Key Copy Not Zeroized
+## ~~17. Ed25519 Stack Key Copy Not Zeroized~~ — RESOLVED
 
-**Location:** `apps/desktop/src-tauri/src/crypto/ed25519.rs:50-56`
+**Location:** `crates/crypto/src/ed25519.rs` (moved from `apps/desktop/src-tauri/src/crypto/`)
 **Added:** 2026-02-08 (Phase 9 Desktop Security Review, L-5)
+**Resolved:** Phase 23 (Rust SDK extraction) — `key_bytes.zeroize()` called after `SigningKey::from_bytes()`.
 
 **Issue:** `key_bytes: [u8; 32]` stack copy of Ed25519 private key is not zeroized (the `SigningKey` itself IS auto-zeroized via the `zeroize` feature).
 
@@ -328,10 +333,11 @@ Consider addressing these when:
 
 ---
 
-## 19. Sync Daemon Error Messages Exposed Raw in Tray Status
+## ~~19. Sync Daemon Error Messages Exposed Raw in Tray Status~~ — RESOLVED
 
-**Location:** `apps/desktop/src-tauri/src/sync/mod.rs:158-161`
+**Location:** `apps/desktop/src-tauri/src/sync/mod.rs`, `crates/sdk/src/sync.rs`
 **Added:** 2026-02-08 (Phase 9 Desktop Security Review, L-7)
+**Resolved:** `sanitize_error()` in `crates/sdk/src/sync.rs` strips paths, tokens, and truncates to 80 chars.
 
 **Issue:** Raw error strings (potentially containing API URLs, CIDs, internal info) passed to tray status display.
 
@@ -340,3 +346,4 @@ Consider addressing these when:
 ---
 
 _Generated from security:review command - Phase 5, Phase 9_
+_Last audited: 2026-03-29 — 7 items resolved (#13-19), 12 items open (#1-12)_


### PR DESCRIPTION
## Summary
- **DEFERRED.md**: Moved "Structured logging wrapper" from active deferred to implemented (Phase 28). Verified all 12 pending todos — all still genuinely pending.
- **LOW-SEVERITY-BACKLOG.md**: Audited all 19 items. Marked 7 Phase 9 items (#13-19) as resolved — fixes landed across Phases 23, 28, and other work but backlog was never updated. 12 Phase 5 items remain open (all low-severity input validation).
- **ROADMAP.md**: Added Phase 34 (E2E Test Expansion & Staging Baselines) consolidating 6 testing todos: streaming playback, media preview, batch download, shared teardown, BYO-IPFS load tests, and Faro metrics baselines.

## Test plan
- [x] Review DEFERRED.md implemented items table
- [x] Review LOW-SEVERITY-BACKLOG.md resolved markings match actual code state
- [x] Review Phase 34 scope and plan breakdown in ROADMAP.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)