### PR TITLE
ci: run E2E tests on feature PRs that touch web-relevant paths

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -13,6 +13,7 @@ jobs:
       desktop: ${{ steps.check.outputs.desktop || steps.release-check.outputs.desktop }}
       prev_tag: ${{ steps.check.outputs.prev_tag || steps.release-check.outputs.prev_tag }}
       is_release: ${{ steps.release-check.outputs.is_release }}
+      web_changed: ${{ steps.web-check.outputs.changed }}
     steps:
       - name: Check if release PR
         id: release-check
@@ -25,8 +26,26 @@ jobs:
             echo "is_release=false" >> "$GITHUB_OUTPUT"
             echo "desktop=false" >> "$GITHUB_OUTPUT"
             echo "prev_tag=" >> "$GITHUB_OUTPUT"
-            echo "Not a release PR — skipping change detection"
           fi
+
+      - name: Check for web-relevant changes (all PRs)
+        id: web-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHANGED_FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[].filename')
+          WEB_CHANGED=false
+          WEB_PATTERNS=("apps/web/" "apps/api/" "packages/" "tests/web-e2e/")
+          for pattern in "${WEB_PATTERNS[@]}"; do
+            if echo "$CHANGED_FILES" | grep -Fq "$pattern"; then
+              echo "Web-relevant change detected matching: ${pattern}"
+              WEB_CHANGED=true
+              break
+            fi
+          done
+          echo "changed=${WEB_CHANGED}" >> "$GITHUB_OUTPUT"
+          echo "Web-relevant changes: ${WEB_CHANGED}"
 
       - uses: actions/checkout@v4
         if: steps.release-check.outputs.is_release == 'true'
@@ -93,9 +112,18 @@ jobs:
           echo "desktop=${DESKTOP_CHANGED}" >> "$GITHUB_OUTPUT"
           echo "Desktop changes detected: ${DESKTOP_CHANGED}"
 
+  run-web-e2e:
+    name: Run Web E2E (Feature PR)
+    needs: detect-changes
+    if: |
+      !startsWith(github.head_ref, 'release-please--') &&
+      needs.detect-changes.outputs.web_changed == 'true'
+    uses: ./.github/workflows/e2e.yml
+    secrets: inherit
+
   verify-e2e:
     name: Verify E2E Passed
-    needs: detect-changes
+    needs: [detect-changes, run-web-e2e]
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -106,9 +134,22 @@ jobs:
           echo "::error::detect-changes must succeed before E2E verification."
           exit 1
 
-      - name: Skip (not a release PR)
-        if: "!startsWith(github.head_ref, 'release-please--')"
-        run: echo "Not a release PR — E2E gate not applicable"
+      - name: Verify Web E2E (feature PR with web changes)
+        if: |
+          !startsWith(github.head_ref, 'release-please--') &&
+          needs.detect-changes.outputs.web_changed == 'true'
+        run: |
+          if [ "${{ needs.run-web-e2e.result }}" != "success" ]; then
+            echo "::error::Web E2E Tests did not pass (result: ${{ needs.run-web-e2e.result }})"
+            exit 1
+          fi
+          echo "Web E2E: passed on feature PR"
+
+      - name: Skip (no web changes)
+        if: |
+          !startsWith(github.head_ref, 'release-please--') &&
+          needs.detect-changes.outputs.web_changed != 'true'
+        run: echo "No web-relevant changes — E2E not required"
 
       - name: Wait for Web E2E and verify it passed
         if: startsWith(github.head_ref, 'release-please--')


### PR DESCRIPTION
## Summary
- The release gate's "Verify E2E Passed" check was auto-passing for non-release PRs with "Not a release PR — E2E gate not applicable", allowing PRs to merge without E2E verification
- Now detects web-relevant path changes (`apps/web/`, `apps/api/`, `packages/`, `tests/web-e2e/`) on all PRs
- For feature PRs with web changes: runs E2E inline via `workflow_call` to `e2e.yml` and gates on the result
- Release PR behavior unchanged (still polls for E2E on main)

## How it works
1. `detect-changes` job now runs a web-path check on **all** PRs (not just release PRs)
2. New `run-web-e2e` job calls `e2e.yml` via `workflow_call` when web paths are changed and it's not a release PR
3. `verify-e2e` checks the `run-web-e2e` result for feature PRs instead of auto-passing

## Test plan
- [ ] This PR itself should trigger the new path: it changes `.github/workflows/` which doesn't match web patterns, so E2E should skip with "No web-relevant changes"
- [ ] A PR touching `tests/web-e2e/` or `apps/web/` should trigger the full E2E run before merge is allowed
- [ ] Release PRs should continue to use the existing polling behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to detect web-related changes and conditionally run end-to-end tests only when necessary, improving CI/CD efficiency and reducing redundant test execution on non-web modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->