### PR TITLE
chore(ci): update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    labels:
+      - 'dependencies'
+      - 'ci'
+    commit-message:
+      prefix: 'chore(ci)'

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -13,11 +13,11 @@ jobs:
       web: ${{ steps.filter.outputs.web }}
       desktop: ${{ steps.filter.outputs.desktop }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           base: ${{ (github.event.before != '' && github.event.before != '0000000000000000000000000000000000000000' && github.event.before) || 'HEAD~1' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       src: ${{ steps.filter.outputs.src }}
       desktop: ${{ steps.filter.outputs.desktop }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -44,13 +44,13 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -67,13 +67,13 @@ jobs:
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -115,13 +115,13 @@ jobs:
           --health-retries 10
           --health-start-period 30s
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -185,13 +185,13 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -285,13 +285,13 @@ jobs:
           --health-retries 10
           --health-start-period 30s
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -336,7 +336,7 @@ jobs:
         run: pnpm --filter @cipherbox/api-client test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./apps/api/coverage/lcov.info,./packages/crypto/coverage/lcov.info,./packages/core/coverage/lcov.info,./packages/sdk-core/coverage/lcov.info,./packages/sdk/coverage/lcov.info,./packages/api-client/coverage/lcov.info
@@ -344,7 +344,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Cache coverage for base branch upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-lcov
           path: |
@@ -401,13 +401,13 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -500,13 +500,13 @@ jobs:
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -532,7 +532,7 @@ jobs:
       needs.changes.outputs.desktop == 'true'
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install WinFsp
         shell: powershell
@@ -552,7 +552,7 @@ jobs:
       - name: Install Rust toolchain
         run: rustup default stable
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -575,7 +575,7 @@ jobs:
       needs.changes.outputs.desktop == 'true'
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install FUSE-T
         run: |
@@ -595,7 +595,7 @@ jobs:
       - name: Install Rust toolchain
         run: rustup default stable
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -622,7 +622,7 @@ jobs:
       needs.changes.outputs.desktop == 'true'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
@@ -640,7 +640,7 @@ jobs:
       - name: Install Rust toolchain
         run: rustup default stable
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -665,7 +665,7 @@ jobs:
           --lcov --output-path desktop-lcov.info
 
       - name: Upload desktop coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: desktop-lcov.info
@@ -680,7 +680,7 @@ jobs:
       (needs.changes.outputs.desktop == 'true' || needs.changes.outputs.src == 'true')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
@@ -693,12 +693,12 @@ jobs:
         run: rustup default stable
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 

--- a/.github/workflows/codecov-base.yml
+++ b/.github/workflows/codecov-base.yml
@@ -17,7 +17,7 @@ jobs:
     name: Upload base coverage to Codecov
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download coverage from latest CI run
         env:
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: hashFiles('**/lcov.info') != ''
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: apps/api/coverage/lcov.info,packages/crypto/coverage/lcov.info,packages/core/coverage/lcov.info,packages/sdk-core/coverage/lcov.info,packages/sdk/coverage/lcov.info,packages/api-client/coverage/lcov.info

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -23,20 +23,20 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.staging_tag || github.ref_name }}
 
       - name: Set lowercase image name
         run: echo "API_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/cipherbox-api" >> "$GITHUB_ENV"
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/api/Dockerfile
@@ -52,20 +52,20 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.staging_tag || github.ref_name }}
 
       - name: Set lowercase image name
         run: echo "TEE_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/cipherbox-tee-worker" >> "$GITHUB_ENV"
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/tee-worker/Dockerfile
@@ -80,11 +80,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.staging_tag || github.ref_name }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -120,15 +120,15 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.staging_tag || github.ref_name }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -156,7 +156,7 @@ jobs:
           GRAFANA_STACK_ID: ${{ vars.GRAFANA_STACK_ID }}
 
       - name: Upload web dist as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: web-dist
           path: apps/web/dist/
@@ -191,7 +191,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.staging_tag || github.ref_name }}
 
@@ -201,11 +201,11 @@ jobs:
           sudo mkdir -p /usr/local/lib/pkgconfig
           sudo ln -sf "/Library/Application Support/fuse-t/pkgconfig/fuse-t.pc" /usr/local/lib/pkgconfig/fuse.pc
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -251,7 +251,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.staging_tag || github.ref_name }}
 
@@ -290,7 +290,7 @@ jobs:
       - name: Install Rust toolchain
         run: rustup default stable
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -299,11 +299,11 @@ jobs:
           key: windows-cargo-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock') }}
           restore-keys: windows-cargo-
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -350,7 +350,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.staging_tag || github.ref_name }}
 
@@ -370,7 +370,7 @@ jobs:
       - name: Install Rust toolchain
         run: rustup default stable
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -379,11 +379,11 @@ jobs:
           key: linux-cargo-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock') }}
           restore-keys: linux-cargo-
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -431,12 +431,12 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.staging_tag || github.ref_name }}
 
       - name: Download web dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: web-dist
           path: web-dist/
@@ -571,7 +571,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.staging_tag || github.ref_name }}
 

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.sha }}
 
@@ -95,11 +95,11 @@ jobs:
 
       # --- Setup Node.js + pnpm (needed for frontend build before cargo) ---
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -127,7 +127,7 @@ jobs:
       - name: Install Rust toolchain
         run: rustup default stable
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -498,7 +498,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: desktop-e2e-logs-${{ matrix.platform }}
           path: |

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -97,15 +97,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -224,7 +224,7 @@ jobs:
 
       - name: Upload metrics report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: load-test-metrics-${{ inputs.scenario }}-${{ inputs.client_count }}clients
           path: tests/load/metrics-*.json

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -28,7 +28,7 @@ jobs:
             echo "Not a release PR — skipping change detection"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.release-check.outputs.is_release == 'true'
         with:
           fetch-depth: 0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}

--- a/.github/workflows/tag-staging.yml
+++ b/.github/workflows/tag-staging.yml
@@ -13,7 +13,7 @@ jobs:
     name: Validate Release Tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
     outputs:
       staging_tag: ${{ steps.rc.outputs.staging_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -54,17 +54,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: |

--- a/.planning/todos/pending/2026-03-30-check-remaining-github-actions-for-node-24-updates-before-june-deadline.md
+++ b/.planning/todos/pending/2026-03-30-check-remaining-github-actions-for-node-24-updates-before-june-deadline.md
@@ -1,0 +1,33 @@
+---
+created: 2026-03-30T01:30:00.000Z
+title: Check remaining GitHub Actions for Node 24 updates before June deadline
+area: ci
+files:
+  - .github/workflows/deploy-staging.yml
+  - .github/workflows/release-please.yml
+  - .github/workflows/desktop-e2e.yml
+---
+
+## Problem
+
+GitHub forces Node.js 24 for all actions starting 2026-06-02. PR #402 updated 11 actions but these remain on older versions without Node 24 support:
+
+- `googleapis/release-please-action@v4` — currently at v4.4.0
+- `tauri-apps/tauri-action@v0` — currently at action-v0.6.2
+- `ikalnytskyi/action-setup-postgres@v8` — currently at v8
+- `appleboy/scp-action@v0.1.7`
+- `appleboy/ssh-action@v1.2.0`
+
+These may publish Node 24-compatible releases before the deadline.
+
+## Solution
+
+Before 2026-06-01, check each action for new releases:
+
+```bash
+for action in googleapis/release-please-action tauri-apps/tauri-action ikalnytskyi/action-setup-postgres appleboy/scp-action appleboy/ssh-action; do
+  gh api "repos/${action}/releases/latest" --jq '.tag_name'
+done
+```
+
+Update any that have new major versions. If any haven't released Node 24 support by then, set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` in the workflow env as a workaround and monitor for breakage.


### PR DESCRIPTION
## Summary
Update all GitHub Actions to latest major versions that support Node.js 24, addressing the deprecation warning:

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 starting June 2nd, 2026.

| Action | Old | New |
|--------|-----|-----|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| actions/cache | v4 | v5 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/create-github-app-token | v1 | v3 |
| docker/login-action | v3 | v4 |
| docker/build-push-action | v5 | v7 |
| dorny/paths-filter | v3 | v4 |
| codecov/codecov-action | v5 | v6 |
| pnpm/action-setup | v4 | v5 |

Actions unchanged (already at latest or no Node 24 update available):
- `googleapis/release-please-action@v4`
- `ikalnytskyi/action-setup-postgres@v8`
- `tauri-apps/tauri-action@v0`
- `appleboy/scp-action@v0.1.7` / `appleboy/ssh-action@v1.2.0`

## Test plan
- [ ] CI passes on this PR (the updated actions run themselves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple CI/CD GitHub Actions to newer major versions across workflows to keep builds and deployments current.
  * Added Dependabot configuration to automate weekly GitHub Actions updates.
* **Documentation**
  * Added a maintenance TODO outlining checks and fallback guidance for upcoming Node compatibility updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->