### PR TITLE
fix(tee): remove bash default syntax from compose image reference

### DIFF
--- a/apps/tee-worker/docker-compose.phala.yml
+++ b/apps/tee-worker/docker-compose.phala.yml
@@ -5,7 +5,7 @@
 # Never delete and recreate -- app_id changes would invalidate all epoch keys.
 services:
   tee-worker:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-OWNER}/cipherbox-tee-worker:${TAG:-latest}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/cipherbox-tee-worker:${TAG:-latest}
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
     ports:


### PR DESCRIPTION
## Summary

- Removes `:-OWNER` bash default syntax from `docker-compose.phala.yml` image reference
- `envsubst` doesn't support `${VAR:-default}` — it either produces an empty string or a malformed reference
- The CI workflow already exports `GITHUB_REPOSITORY_OWNER` lowercased before running `envsubst`, so plain `${GITHUB_REPOSITORY_OWNER}` resolves correctly

Fixes Phala CVM deploy error: `repository name (OWNER/cipherbox-tee-worker) must be lowercase`

## Test plan

- [ ] Trigger staging deploy and verify TEE CVM pulls the correct image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image deployment configuration to require explicit environment variable specification, removing fallback defaults for improved deployment consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->