### PR TITLE
fix(web): trigger sync after upload, fix E2E duplicate row failures

### DIFF
--- a/apps/web/src/components/file-browser/FileBrowser.tsx
+++ b/apps/web/src/components/file-browser/FileBrowser.tsx
@@ -133,7 +133,7 @@ export function FileBrowser() {
             +folder
           </button>
           <div className="toolbar-upload">
-            <UploadZone folderId={currentFolderId} />
+            <UploadZone folderId={currentFolderId} onUploadComplete={actions.handleSync} />
           </div>
           <SyncIndicator />
         </div>

--- a/apps/web/src/components/file-browser/FileBrowser.tsx
+++ b/apps/web/src/components/file-browser/FileBrowser.tsx
@@ -133,7 +133,12 @@ export function FileBrowser() {
             +folder
           </button>
           <div className="toolbar-upload">
-            <UploadZone folderId={currentFolderId} onUploadComplete={actions.handleSync} />
+            <UploadZone
+              folderId={currentFolderId}
+              onUploadComplete={() => {
+                void actions.handleSync().catch(() => {});
+              }}
+            />
           </div>
           <SyncIndicator />
         </div>

--- a/tests/web-e2e/page-objects/file-browser/file-list.page.ts
+++ b/tests/web-e2e/page-objects/file-browser/file-list.page.ts
@@ -17,18 +17,19 @@ export class FileListPage {
   }
 
   /**
-   * Get all file list items.
+   * Get all file list items (excludes upload progress rows).
    */
   fileItems(): Locator {
-    return this.page.locator('.file-list-item');
+    return this.page.locator('.file-list-item:not(.upload-inline-row)');
   }
 
   /**
    * Get a specific item by name (file or folder).
-   * Uses the item text content to locate.
+   * Excludes upload progress rows to avoid strict mode violations
+   * during the brief overlap between upload completion and real file appearance.
    */
   getItem(name: string): Locator {
-    return this.page.locator('.file-list-item', { hasText: name }).filter({
+    return this.page.locator('.file-list-item:not(.upload-inline-row)', { hasText: name }).filter({
       has: this.page.locator('.file-list-item-name', { hasText: name }),
     });
   }

--- a/tests/web-e2e/page-objects/file-browser/file-list.page.ts
+++ b/tests/web-e2e/page-objects/file-browser/file-list.page.ts
@@ -7,6 +7,8 @@ import { type Page, type Locator } from '@playwright/test';
  * Uses semantic selectors (getByRole, getByText) for maintainability.
  */
 export class FileListPage {
+  private static readonly ROW_SELECTOR = '.file-list-item:not(.upload-inline-row)';
+
   constructor(private readonly page: Page) {}
 
   /**
@@ -20,7 +22,7 @@ export class FileListPage {
    * Get all file list items (excludes upload progress rows).
    */
   fileItems(): Locator {
-    return this.page.locator('.file-list-item:not(.upload-inline-row)');
+    return this.page.locator(FileListPage.ROW_SELECTOR);
   }
 
   /**
@@ -29,7 +31,7 @@ export class FileListPage {
    * during the brief overlap between upload completion and real file appearance.
    */
   getItem(name: string): Locator {
-    return this.page.locator('.file-list-item:not(.upload-inline-row)', { hasText: name }).filter({
+    return this.page.locator(FileListPage.ROW_SELECTOR, { hasText: name }).filter({
       has: this.page.locator('.file-list-item-name', { hasText: name }),
     });
   }


### PR DESCRIPTION
## Summary

Fixes 8 E2E test failures caused by inline upload progress rows (PR #410).

- **Wire `onUploadComplete` to `handleSync`** in FileBrowser so uploaded files appear immediately via IPNS refresh instead of waiting up to 30s for the next sync poll
- **Exclude `.upload-inline-row` from E2E file list locators** to prevent Playwright strict mode violations when both the upload progress row and real file row briefly coexist during the 1s completion flash window

### Root cause

After PR #410, upload progress rows render as `.file-list-item` elements inline in the file list. E2E locators (`getItem`, `fileItems`) matched both upload rows AND real file rows, causing `strict mode violation: resolved to 2 elements`. Additionally, the app relied on 30s IPNS polling to show uploaded files — no immediate refresh was triggered after upload.

## Test plan

- [x] `full-workflow.spec.ts` — 16/16 passed (previously 8 failed at upload steps)
- [x] `recycle-bin.spec.ts` — 8/8 passed
- [x] `sharing-workflow.spec.ts` — 25/25 passed
- [x] `invite-link-workflow.spec.ts` — 21/21 passed
- [x] `media-preview.spec.ts` — all passed
- [x] `streaming-playback.spec.ts` — all passed
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File uploads now reliably trigger a synchronization after completion so newly uploaded files appear in the list automatically.

* **Tests**
  * End-to-end tests updated to ignore transient upload progress rows, improving stability during uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->