### PR TITLE
fix(web): reverse upload dedup to prevent real file rows disappearing

### DIFF
--- a/apps/web/src/components/file-browser/FileList.tsx
+++ b/apps/web/src/components/file-browser/FileList.tsx
@@ -150,11 +150,13 @@ export function FileList({
   const realFileNames = new Set(
     items.filter((item) => item.type === 'file').map((item) => item.name)
   );
-  const completingNames = new Set(
-    uploadEntries.filter((e) => e.status === 'complete').map((e) => e.filename)
+  const completeUploadIds = new Set(
+    uploadEntries
+      .filter((e) => e.status === 'complete' && realFileNames.has(e.filename))
+      .map((e) => e.id)
   );
   const filteredUploadEntries = uploadVirtualEntries.filter(
-    (entry) => !(completingNames.has(entry.name) && realFileNames.has(entry.name))
+    (entry) => !completeUploadIds.has(entry.id)
   );
 
   // Merge and sort all items together

--- a/apps/web/src/components/file-browser/FileList.tsx
+++ b/apps/web/src/components/file-browser/FileList.tsx
@@ -144,16 +144,21 @@ export function FileList({
     _uploading: true as const,
   }));
 
-  // Filter out real files that match completing uploads to prevent duplicates (Pitfall 5)
+  // Prevent duplicate rows: when a real file already exists, hide the completing
+  // upload row instead of the real file row. This ensures the real file is never
+  // removed from the DOM during the 1-second completion flash. (Pitfall 5)
+  const realFileNames = new Set(
+    items.filter((item) => item.type === 'file').map((item) => item.name)
+  );
   const completingNames = new Set(
     uploadEntries.filter((e) => e.status === 'complete').map((e) => e.filename)
   );
-  const filteredItems = items.filter(
-    (item) => !(item.type === 'file' && completingNames.has(item.name))
+  const filteredUploadEntries = uploadVirtualEntries.filter(
+    (entry) => !(completingNames.has(entry.name) && realFileNames.has(entry.name))
   );
 
   // Merge and sort all items together
-  const allItems = [...filteredItems, ...uploadVirtualEntries];
+  const allItems = [...items, ...filteredUploadEntries];
   const sortedItems = sortItems(allItems as FolderChild[]);
 
   // Select-all uses real item count only (upload rows are not selectable)


### PR DESCRIPTION
## Summary
- Reverses the Pitfall 5 dedup filter in `FileList.tsx` — when a real file and a completing upload share the same name, the **upload row** is now hidden instead of the **real file row**
- Fixes a race condition where React could process the folder store update and upload status update in separate render cycles, briefly removing real file rows from the DOM during the 1-second completion flash
- Resolves intermittent E2E failures in `full-workflow.spec.ts:380` (3.3) and `sharing-workflow.spec.ts:412` (7.1)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm --filter @cipherbox/web build` succeeds
- [x] `full-workflow.spec.ts` test 3.3 ("Upload files to documents folder") passes locally
- [x] `sharing-workflow.spec.ts` test 7.1 ("Alice adds file after sharing") passes locally — full sharing suite 25/25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate entries in the file list by preserving real file rows and suppressing the completing-upload virtual entries when a real file with the same name exists, ensuring completed uploads no longer mask or remove the actual files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->