### PR TITLE
fix(web): replace encrypting pulse with shimmer to prevent progress flash

### DIFF
--- a/apps/web/src/components/file-browser/UploadListItem.tsx
+++ b/apps/web/src/components/file-browser/UploadListItem.tsx
@@ -108,7 +108,7 @@ export function UploadListItem({ fileId, onRetry }: UploadListItemProps) {
         <div className="upload-inline-name-wrapper">
           <span className="file-list-item-name">{file.filename}</span>
           <div
-            className={`upload-inline-progress-track ${isEncrypting ? 'upload-inline-progress-track--pulse' : ''}`}
+            className={`upload-inline-progress-track ${isEncrypting ? 'upload-inline-progress-track--encrypting' : ''}`}
           >
             <div
               className="upload-inline-progress-fill"

--- a/apps/web/src/styles/upload.css
+++ b/apps/web/src/styles/upload.css
@@ -181,7 +181,7 @@
   }
 }
 
-.upload-inline-progress-track--pulse {
+.upload-inline-progress-track--encrypting {
   background: linear-gradient(
     90deg,
     var(--color-border-dim) 30%,
@@ -192,7 +192,7 @@
   animation: upload-inline-shimmer 1.5s ease-in-out infinite;
 }
 
-.upload-inline-progress-track--pulse .upload-inline-progress-fill {
+.upload-inline-progress-track--encrypting .upload-inline-progress-fill {
   /* Hide the fill during encryption — the track shimmer IS the indicator */
   opacity: 0;
 }
@@ -200,11 +200,11 @@
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
   .upload-inline-progress-fill,
-  .upload-inline-progress-track--pulse {
+  .upload-inline-progress-track--encrypting {
     animation: none;
     transition: none;
   }
-  .upload-inline-progress-track--pulse .upload-inline-progress-fill {
+  .upload-inline-progress-track--encrypting .upload-inline-progress-fill {
     opacity: 1;
   }
 }

--- a/apps/web/src/styles/upload.css
+++ b/apps/web/src/styles/upload.css
@@ -158,7 +158,7 @@
 .upload-inline-progress-fill {
   height: 100%;
   background-color: var(--color-green-primary);
-  transition: width 0.2s ease;
+  transition: width 0.2s ease, opacity 0.15s ease;
 }
 
 .upload-inline-progress-fill[data-status='complete'] {
@@ -169,28 +169,43 @@
   background-color: var(--color-error);
 }
 
-/* Encrypting pulse animation */
-@keyframes upload-inline-pulse {
-  0%,
-  100% {
-    opacity: 1;
+/* Encrypting shimmer animation — indeterminate progress on the track, not the fill.
+   The fill stays at width:0% during encryption so there's no jarring 100%→0% jump
+   when the first real progress event arrives. */
+@keyframes upload-inline-shimmer {
+  0% {
+    background-position: -200% 0;
   }
-  50% {
-    opacity: 0.4;
+  100% {
+    background-position: 200% 0;
   }
 }
 
+.upload-inline-progress-track--pulse {
+  background: linear-gradient(
+    90deg,
+    var(--color-border-dim) 30%,
+    var(--color-green-primary) 50%,
+    var(--color-border-dim) 70%
+  );
+  background-size: 200% 100%;
+  animation: upload-inline-shimmer 1.5s ease-in-out infinite;
+}
+
 .upload-inline-progress-track--pulse .upload-inline-progress-fill {
-  width: 100% !important;
-  animation: upload-inline-pulse 1.5s ease-in-out infinite;
+  /* Hide the fill during encryption — the track shimmer IS the indicator */
+  opacity: 0;
 }
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
   .upload-inline-progress-fill,
-  .upload-inline-progress-track--pulse .upload-inline-progress-fill {
+  .upload-inline-progress-track--pulse {
     animation: none;
     transition: none;
+  }
+  .upload-inline-progress-track--pulse .upload-inline-progress-fill {
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- Replaced the encrypting state's `width: 100% !important` opacity pulse with a shimmer gradient on the progress track
- The fill bar is hidden during encryption and fades in at its actual progress value when uploading begins
- This eliminates the jarring flash-to-full-then-reset visual artifact during batch uploads

**Root cause:** The encrypting CSS forced the progress fill to 100% width with `!important`, then the first real progress event removed the pulse class and the inline style snapped the bar to 0% — creating a visible flash.

## Test plan
- [ ] Upload a batch of files and verify the encrypting state shows a shimmer animation (not a full bar)
- [ ] Verify the progress bar transitions smoothly from encrypting to uploading with no flash
- [ ] Verify `prefers-reduced-motion` disables the shimmer animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced upload progress indicator with an improved shimmer animation effect for a more polished appearance
  * Improved accessibility by respecting user motion sensitivity preferences during file uploads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->