### PR TITLE
feat: desktop vault settings integration - phase 40

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,9 @@
-pnpm commitlint --edit $1
+#!/bin/sh
+# Entire CLI hooks
+# Commit-msg hook: strip trailer if no user content (allows aborting empty commits)
+entire hooks git commit-msg "$1" || exit 1
+# Chain: run pre-existing hook
+_entire_hook_dir="$(dirname "$0")"
+if [ -x "$_entire_hook_dir/commit-msg.pre-entire" ]; then
+    "$_entire_hook_dir/commit-msg.pre-entire" "$@"
+fi

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -142,4 +142,4 @@ See `.planning/REQUIREMENTS.md` for full requirements.
 
 ---
 
-Last updated: 2026-03-30 after Phase 37 Parallel Batch Upload Pipeline completed
+Last updated: 2026-03-31 after Phase 40 Desktop Vault Settings Integration completed

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -545,8 +545,16 @@ Plans:
 - [x] 39-03-PLAN.md — Consumer integration: wire settings into delete, versioning, and retention
 - [x] 39-04-PLAN.md — Vault settings tab UI in Settings page
 
+### Phase 40: Desktop vault settings integration
+
+**Goal:** Propagate user-configurable vault settings (from Phase 39) to the Rust SDK and desktop app. Add `deriveVaultSettingsIpnsKeypair()` to `crates/crypto`, add `VaultSettings` type to `crates/core`, load and decrypt settings during desktop login, and wire loaded values into FUSE operations replacing hardcoded `MAX_VERSIONS_PER_FILE` and `VERSION_COOLDOWN_MS` constants.
+**Requirements**: None (follow-up to Phase 39)
+**Depends on:** Phase 39
+
+Plans: _not yet planned_
+
 ---
 
 _Roadmap created: 2026-03-07_
 _Last updated: 2026-03-31_
-_Total M1.1 phases: 18 (18-35 complete) | Concern resolution: 5 phases | Post-milestone: 4 phases (36-39)_
+_Total M1.1 phases: 18 (18-35 complete) | Concern resolution: 5 phases | Post-milestone: 5 phases (36-40)_

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -551,12 +551,12 @@ Plans:
 **Requirements**: None (follow-up to Phase 39)
 **Depends on:** Phase 39
 
-**Plans:** 1/2 plans executed
+**Plans:** 2/2 plans complete
 
 Plans:
 
 - [x] 40-01-PLAN.md — HKDF vault settings derivation + VaultSettings type and validation in Rust crates
-- [ ] 40-02-PLAN.md — Load settings in desktop auth flow and wire into FUSE operations
+- [x] 40-02-PLAN.md — Load settings in desktop auth flow and wire into FUSE operations
 
 ---
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -551,7 +551,12 @@ Plans:
 **Requirements**: None (follow-up to Phase 39)
 **Depends on:** Phase 39
 
-Plans: _not yet planned_
+**Plans:** 2 plans
+
+Plans:
+
+- [ ] 40-01-PLAN.md — HKDF vault settings derivation + VaultSettings type and validation in Rust crates
+- [ ] 40-02-PLAN.md — Load settings in desktop auth flow and wire into FUSE operations
 
 ---
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -551,11 +551,11 @@ Plans:
 **Requirements**: None (follow-up to Phase 39)
 **Depends on:** Phase 39
 
-**Plans:** 2 plans
+**Plans:** 1/2 plans executed
 
 Plans:
 
-- [ ] 40-01-PLAN.md — HKDF vault settings derivation + VaultSettings type and validation in Rust crates
+- [x] 40-01-PLAN.md — HKDF vault settings derivation + VaultSettings type and validation in Rust crates
 - [ ] 40-02-PLAN.md — Load settings in desktop auth flow and wire into FUSE operations
 
 ---

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v1.1
 milestone_name: milestone
-status: Executing Phase 39
-last_updated: '2026-03-31T03:22:00.000Z'
+status: Phase complete — ready for verification
+last_updated: "2026-03-31T13:34:58.266Z"
 last_activity: 2026-03-31
 progress:
-  total_phases: 24
-  completed_phases: 23
-  total_plans: 94
-  completed_plans: 94
+  total_phases: 25
+  completed_phases: 22
+  total_plans: 96
+  completed_plans: 89
 ---
 
 # Project State
@@ -88,6 +88,7 @@ Plan: 4 of 4 (all complete)
 | Phase 35 P03 | 8min  | 4 tasks  | 14 files |
 | Phase 35 P05 | 5min  | 3 tasks  | 3 files  |
 | Phase 37 P02 | 5min  | 2 tasks  | 5 files  |
+| Phase 40 P01 | 4min | 2 tasks | 6 files |
 
 ## Accumulated Context
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,8 +2,8 @@
 gsd_state_version: 1.0
 milestone: v1.1
 milestone_name: milestone
-status: Phase complete — ready for verification
-last_updated: "2026-03-31T13:46:13.841Z"
+status: Milestone complete
+last_updated: '2026-03-31T13:53:08.841Z'
 last_activity: 2026-03-31
 progress:
   total_phases: 25
@@ -23,8 +23,8 @@ See: .planning/PROJECT.md (updated 2026-03-07)
 
 ## Current Position
 
-Phase: 39 (user-configurable-vault-parameters) — REVIEW
-Plan: 4 of 4 (all complete)
+Phase: 40
+Plan: Not started
 
 ## Performance Metrics
 
@@ -88,8 +88,8 @@ Plan: 4 of 4 (all complete)
 | Phase 35 P03 | 8min  | 4 tasks  | 14 files |
 | Phase 35 P05 | 5min  | 3 tasks  | 3 files  |
 | Phase 37 P02 | 5min  | 2 tasks  | 5 files  |
-| Phase 40 P01 | 4min | 2 tasks | 6 files |
-| Phase 40 P02 | 7min | 2 tasks | 8 files |
+| Phase 40 P01 | 4min  | 2 tasks  | 6 files  |
+| Phase 40 P02 | 7min  | 2 tasks  | 8 files  |
 
 ## Accumulated Context
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,13 +3,13 @@ gsd_state_version: 1.0
 milestone: v1.1
 milestone_name: milestone
 status: Phase complete — ready for verification
-last_updated: "2026-03-31T13:34:58.266Z"
+last_updated: "2026-03-31T13:46:13.841Z"
 last_activity: 2026-03-31
 progress:
   total_phases: 25
-  completed_phases: 22
+  completed_phases: 23
   total_plans: 96
-  completed_plans: 89
+  completed_plans: 90
 ---
 
 # Project State
@@ -89,6 +89,7 @@ Plan: 4 of 4 (all complete)
 | Phase 35 P05 | 5min  | 3 tasks  | 3 files  |
 | Phase 37 P02 | 5min  | 2 tasks  | 5 files  |
 | Phase 40 P01 | 4min | 2 tasks | 6 files |
+| Phase 40 P02 | 7min | 2 tasks | 8 files |
 
 ## Accumulated Context
 

--- a/.planning/phases/40-desktop-vault-settings-integration/40-01-PLAN.md
+++ b/.planning/phases/40-desktop-vault-settings-integration/40-01-PLAN.md
@@ -1,0 +1,496 @@
+---
+phase: 40-desktop-vault-settings-integration
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - crates/crypto/src/hkdf.rs
+  - crates/crypto/src/lib.rs
+  - crates/crypto/tests/cross_language.rs
+  - tests/vectors/crypto/hkdf.json
+  - crates/core/src/vault_settings.rs
+  - crates/core/src/lib.rs
+autonomous: true
+requirements: []
+
+must_haves:
+  truths:
+    - 'derive_vault_settings_ipns_keypair() produces valid 32-byte Ed25519 keys and a k51-prefixed IPNS name'
+    - "Rust HKDF derivation with info 'cipherbox-vault-settings-v1' produces identical output to TypeScript deriveVaultSettingsIpnsKeypair()"
+    - 'VaultSettings struct deserializes camelCase JSON from TypeScript correctly'
+    - 'validate_vault_settings() clamps out-of-range values and returns defaults for corrupt input'
+  artifacts:
+    - path: 'crates/crypto/src/hkdf.rs'
+      provides: 'derive_vault_settings_ipns_keypair() function'
+      contains: 'VAULT_SETTINGS_HKDF_INFO'
+    - path: 'crates/core/src/vault_settings.rs'
+      provides: 'VaultSettings struct, DEFAULT_VAULT_SETTINGS, validate_vault_settings()'
+      exports:
+        ['VaultSettings', 'DeleteBehavior', 'DEFAULT_VAULT_SETTINGS', 'validate_vault_settings']
+    - path: 'tests/vectors/crypto/hkdf.json'
+      provides: 'Cross-language test vector for cipherbox-vault-settings-v1'
+      contains: 'cipherbox-vault-settings-v1'
+    - path: 'crates/crypto/tests/cross_language.rs'
+      provides: 'Match arm for vault-settings HKDF vector'
+      contains: 'cipherbox-vault-settings-v1'
+  key_links:
+    - from: 'crates/crypto/src/hkdf.rs'
+      to: 'tests/vectors/crypto/hkdf.json'
+      via: 'cross_language.rs test loads vector and calls derive_vault_settings_ipns_keypair'
+      pattern: 'derive_vault_settings_ipns_keypair'
+    - from: 'crates/core/src/vault_settings.rs'
+      to: 'packages/core/src/vault/settings.ts'
+      via: 'identical validation logic and defaults'
+      pattern: 'validate_vault_settings'
+---
+
+<objective>
+Add vault settings HKDF derivation to cipherbox-crypto and VaultSettings domain type to cipherbox-core.
+
+Purpose: Establish the cryptographic foundation (IPNS keypair derivation) and domain types (VaultSettings struct with validation) needed for the desktop app to load and use user-configurable vault settings. Cross-language parity with TypeScript is verified via shared test vectors.
+
+Output: New `derive_vault_settings_ipns_keypair()` in crypto crate, new `vault_settings` module in core crate, updated cross-language test vector file, all tests passing.
+</objective>
+
+<execution_context>
+@/Users/michael/Code/cipher-box/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/michael/Code/cipher-box/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/40-desktop-vault-settings-integration/40-CONTEXT.md
+@.planning/phases/40-desktop-vault-settings-integration/40-RESEARCH.md
+</context>
+
+<interfaces>
+<!-- Key types and contracts the executor needs. Extracted from codebase. -->
+
+From crates/crypto/src/hkdf.rs (existing derivation pattern):
+
+```rust
+// Internal helper all public functions delegate to:
+fn derive_ipns_keypair(
+    user_private_key: &[u8; 32],
+    info: &[u8],
+) -> Result<(Zeroizing<Vec<u8>>, Vec<u8>, String), CryptoError>
+
+// Example public wrapper (vault):
+pub fn derive_vault_ipns_keypair(
+    user_private_key: &[u8; 32],
+) -> Result<(Zeroizing<Vec<u8>>, Vec<u8>, String), CryptoError> {
+    derive_ipns_keypair(user_private_key, VAULT_HKDF_INFO)
+}
+```
+
+From crates/crypto/src/lib.rs (re-exports):
+
+```rust
+pub use hkdf::{
+    derive_bin_ipns_keypair, derive_file_ipns_keypair, derive_registry_ipns_keypair,
+    derive_vault_ipns_keypair, derive_vault_key_ipns_keypair,
+};
+```
+
+From packages/core/src/vault/types.ts (TypeScript reference type):
+
+```typescript
+export type VaultSettings = {
+  version: 'v1';
+  recycleBinRetentionDays: number;
+  deleteBehavior: 'bin' | 'permanent';
+  maxVersionsPerFile: number;
+  versionCooldownMinutes: number;
+};
+```
+
+From packages/core/src/vault/settings.ts (TypeScript validation reference):
+
+```typescript
+export const DEFAULT_VAULT_SETTINGS: VaultSettings = {
+  version: 'v1',
+  recycleBinRetentionDays: 30,
+  deleteBehavior: 'bin',
+  maxVersionsPerFile: 10,
+  versionCooldownMinutes: 15,
+};
+export function validateVaultSettings(input: unknown): VaultSettings {
+  // Clamp: recycleBinRetentionDays 0-365, maxVersionsPerFile 0-100, versionCooldownMinutes 0-1440
+  // Unknown version -> defaults, corrupt input -> defaults
+}
+```
+
+From tests/vectors/crypto/hkdf.json (existing vector format):
+
+```json
+{
+  "description": "HKDF vault IPNS keypair derivation (info: cipherbox-vault-ipns-v1)",
+  "private_key": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+  "info": "cipherbox-vault-ipns-v1",
+  "expected_ed25519_private_key": "f7834c13e4470ae91e19870f3e741794250d68700fa4ac50589ea90a95f9fdcd",
+  "expected_ed25519_public_key": "f1aacff3867ca17fb8b800d20539288e012afe92303ef1e8001fe1a9a0a96854",
+  "expected_ipns_name": "k51qzi5uqu5dm7fenqm7yzmi6tnm1098vdb0tjgm1full4pr0go19dk41asevo"
+}
+```
+
+From crates/crypto/tests/cross_language.rs (routing pattern):
+
+```rust
+let (derived_priv, derived_pub, ipns_name) = match v.info.as_str() {
+    "cipherbox-vault-ipns-v1" => cipherbox_crypto::derive_vault_ipns_keypair(&pk).unwrap(),
+    // ... other arms ...
+    other => panic!("Unknown HKDF info string: {}", other),
+};
+```
+
+</interfaces>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add derive_vault_settings_ipns_keypair to crypto crate with cross-language vector</name>
+  <files>crates/crypto/src/hkdf.rs, crates/crypto/src/lib.rs, crates/crypto/tests/cross_language.rs, tests/vectors/crypto/hkdf.json</files>
+  <read_first>
+    - crates/crypto/src/hkdf.rs (current HKDF module with 5 existing derivation functions)
+    - crates/crypto/src/lib.rs (current re-exports)
+    - crates/crypto/tests/cross_language.rs (cross-language test with info-string routing)
+    - tests/vectors/crypto/hkdf.json (existing test vectors)
+    - packages/crypto/src/vault/derive-ipns.ts (TypeScript reference: VAULT_SETTINGS_HKDF_INFO = "cipherbox-vault-settings-v1")
+  </read_first>
+  <behavior>
+    - Test: derive_vault_settings_ipns_keypair with test key [0xAB; 32] returns 32-byte private key, 32-byte public key, and k-prefixed IPNS name
+    - Test: derive_vault_settings_ipns_keypair is deterministic (same input -> same output)
+    - Test: vault-settings derivation produces different output than vault, vault-key, registry, and bin derivations
+    - Test: cross-language vector with standard test key 0102...1f20 and info "cipherbox-vault-settings-v1" matches TypeScript output
+  </behavior>
+  <action>
+    **Step 0: Generate the cross-language test vector from TypeScript.**
+
+    Run a small Node.js script using the existing @cipherbox/crypto package to derive the vault-settings IPNS keypair with the standard test key `0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20` and output the hex-encoded ed25519 private key, public key, and IPNS name. Use this command:
+
+    ```bash
+    cd /Users/michael/Code/cipher-box
+    pnpm --filter @cipherbox/crypto exec tsx -e "
+      import { deriveVaultSettingsIpnsKeypair } from './src/vault/derive-ipns';
+      const key = new Uint8Array([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32]);
+      deriveVaultSettingsIpnsKeypair(key).then(r => {
+        console.log(JSON.stringify({
+          priv: Buffer.from(r.privateKey).toString('hex'),
+          pub: Buffer.from(r.publicKey).toString('hex'),
+          ipns: r.ipnsName
+        }));
+      });
+    "
+    ```
+
+    Record the output values for the test vector.
+
+    **Step 1: Add test vector to `tests/vectors/crypto/hkdf.json`.**
+
+    Append a new entry to the existing JSON array:
+    ```json
+    {
+      "description": "HKDF vault settings IPNS keypair derivation (info: cipherbox-vault-settings-v1)",
+      "private_key": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+      "info": "cipherbox-vault-settings-v1",
+      "expected_ed25519_private_key": "<from Step 0>",
+      "expected_ed25519_public_key": "<from Step 0>",
+      "expected_ipns_name": "<from Step 0>"
+    }
+    ```
+
+    **Step 2: Add HKDF constant and derivation function to `crates/crypto/src/hkdf.rs`.**
+
+    After the existing `BIN_HKDF_INFO` constant (line 36), add:
+    ```rust
+    /// HKDF info for vault settings IPNS keypair derivation.
+    const VAULT_SETTINGS_HKDF_INFO: &[u8] = b"cipherbox-vault-settings-v1";
+    ```
+
+    After the existing `derive_bin_ipns_keypair` function (after line 136), add:
+    ```rust
+    /// Derive the deterministic Ed25519 IPNS keypair for vault settings.
+    ///
+    /// This IPNS name stores the encrypted user-configurable vault parameters
+    /// (retention period, delete behavior, versioning limits). Zero-knowledge:
+    /// the server never sees the plaintext settings.
+    ///
+    /// Uses HKDF info "cipherbox-vault-settings-v1" for domain separation.
+    ///
+    /// Returns (ed25519_private_key, ed25519_public_key, ipns_name).
+    pub fn derive_vault_settings_ipns_keypair(
+        user_private_key: &[u8; 32],
+    ) -> Result<(Zeroizing<Vec<u8>>, Vec<u8>, String), CryptoError> {
+        derive_ipns_keypair(user_private_key, VAULT_SETTINGS_HKDF_INFO)
+    }
+    ```
+
+    Add unit tests in the existing `mod tests` block:
+    ```rust
+    #[test]
+    fn derive_vault_settings_returns_32_byte_keys() {
+        let (priv_key, pub_key, name) = derive_vault_settings_ipns_keypair(&test_private_key()).unwrap();
+        assert_eq!(priv_key.len(), 32);
+        assert_eq!(pub_key.len(), 32);
+        assert!(name.starts_with('k'));
+    }
+
+    #[test]
+    fn derive_vault_settings_is_deterministic() {
+        let key = test_private_key();
+        let (priv1, pub1, name1) = derive_vault_settings_ipns_keypair(&key).unwrap();
+        let (priv2, pub2, name2) = derive_vault_settings_ipns_keypair(&key).unwrap();
+        assert_eq!(*priv1, *priv2);
+        assert_eq!(pub1, pub2);
+        assert_eq!(name1, name2);
+    }
+
+    #[test]
+    fn vault_settings_differs_from_other_derivations() {
+        let key = test_private_key();
+        let (_, settings_pub, settings_name) = derive_vault_settings_ipns_keypair(&key).unwrap();
+        let (_, vault_pub, vault_name) = derive_vault_ipns_keypair(&key).unwrap();
+        let (_, vault_key_pub, vault_key_name) = derive_vault_key_ipns_keypair(&key).unwrap();
+        let (_, bin_pub, bin_name) = derive_bin_ipns_keypair(&key).unwrap();
+        assert_ne!(settings_pub, vault_pub);
+        assert_ne!(settings_name, vault_name);
+        assert_ne!(settings_pub, vault_key_pub);
+        assert_ne!(settings_name, vault_key_name);
+        assert_ne!(settings_pub, bin_pub);
+        assert_ne!(settings_name, bin_name);
+    }
+    ```
+
+    **Step 3: Add re-export to `crates/crypto/src/lib.rs`.**
+
+    In the `pub use hkdf::{ ... }` block, add `derive_vault_settings_ipns_keypair` to the import list.
+
+    **Step 4: Add match arm to `crates/crypto/tests/cross_language.rs`.**
+
+    In the `hkdf_cross_language` test function, add a new match arm before the `other => panic!` fallback:
+    ```rust
+    "cipherbox-vault-settings-v1" => {
+        cipherbox_crypto::derive_vault_settings_ipns_keypair(&pk).unwrap()
+    }
+    ```
+
+    Per D-01: Uses info string `b"cipherbox-vault-settings-v1"`, follows exact pattern of existing derive_*_ipns_keypair functions, cross-language parity verified via shared test vectors.
+
+  </action>
+  <verify>
+    <automated>cd /Users/michael/Code/cipher-box && cargo test -p cipherbox-crypto -- vault_settings && cargo test -p cipherbox-crypto --test cross_language -- hkdf</automated>
+  </verify>
+  <acceptance_criteria>
+    - crates/crypto/src/hkdf.rs contains `const VAULT_SETTINGS_HKDF_INFO: &[u8] = b"cipherbox-vault-settings-v1";`
+    - crates/crypto/src/hkdf.rs contains `pub fn derive_vault_settings_ipns_keypair(`
+    - crates/crypto/src/lib.rs contains `derive_vault_settings_ipns_keypair`
+    - tests/vectors/crypto/hkdf.json contains `"info": "cipherbox-vault-settings-v1"`
+    - crates/crypto/tests/cross_language.rs contains `"cipherbox-vault-settings-v1" =>`
+    - `cargo test -p cipherbox-crypto -- vault_settings` exits 0
+    - `cargo test -p cipherbox-crypto --test cross_language -- hkdf` exits 0
+  </acceptance_criteria>
+  <done>derive_vault_settings_ipns_keypair produces valid keys, is deterministic, differs from other derivations, and matches TypeScript output via cross-language test vector</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Add VaultSettings type and validation to core crate</name>
+  <files>crates/core/src/vault_settings.rs, crates/core/src/lib.rs</files>
+  <read_first>
+    - crates/core/src/lib.rs (current module declarations and re-exports)
+    - packages/core/src/vault/types.ts lines 73-84 (TypeScript VaultSettings type definition)
+    - packages/core/src/vault/settings.ts (TypeScript DEFAULT_VAULT_SETTINGS and validateVaultSettings)
+  </read_first>
+  <behavior>
+    - Test: DEFAULT_VAULT_SETTINGS has version "v1", recycleBinRetentionDays 30, deleteBehavior Bin, maxVersionsPerFile 10, versionCooldownMinutes 15
+    - Test: validate_vault_settings with valid JSON returns correct VaultSettings
+    - Test: validate_vault_settings clamps recycleBinRetentionDays above 365 to 365
+    - Test: validate_vault_settings clamps recycleBinRetentionDays below 0 to 0
+    - Test: validate_vault_settings clamps maxVersionsPerFile above 100 to 100
+    - Test: validate_vault_settings clamps versionCooldownMinutes above 1440 to 1440
+    - Test: validate_vault_settings returns defaults for null/non-object input
+    - Test: validate_vault_settings returns defaults for unknown version (e.g., "v99")
+    - Test: VaultSettings deserializes from camelCase JSON correctly (serde round-trip)
+    - Test: validate_vault_settings with missing fields uses defaults for missing fields
+  </behavior>
+  <action>
+    **Step 1: Create `crates/core/src/vault_settings.rs`.**
+
+    ```rust
+    //! User-configurable vault settings.
+    //!
+    //! Settings are stored as ECIES-encrypted JSON in an IPNS entry.
+    //! The server never sees plaintext settings (zero-knowledge).
+    //! Mirrors @cipherbox/core VaultSettings TypeScript type.
+
+    use serde::{Deserialize, Serialize};
+
+    /// Delete behavior for vault files.
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub enum DeleteBehavior {
+        Bin,
+        Permanent,
+    }
+
+    /// User-configurable vault settings.
+    ///
+    /// JSON field names use camelCase to match TypeScript serialization.
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct VaultSettings {
+        /// Schema version for future migrations.
+        pub version: String,
+        /// Recycle bin retention period in days (0-365; 0 = immediate purge).
+        pub recycle_bin_retention_days: u32,
+        /// Delete behavior: Bin = soft delete, Permanent = immediate hard delete.
+        pub delete_behavior: DeleteBehavior,
+        /// Maximum number of past versions retained per file (0-100).
+        pub max_versions_per_file: u32,
+        /// Cooldown period for version creation in minutes (0-1440).
+        pub version_cooldown_minutes: u32,
+    }
+
+    /// Default vault settings matching current hardcoded behavior.
+    pub const DEFAULT_VAULT_SETTINGS: VaultSettings = VaultSettings {
+        version: String::new(), // Will be set below in default_vault_settings()
+        recycle_bin_retention_days: 30,
+        delete_behavior: DeleteBehavior::Bin,
+        max_versions_per_file: 10,
+        version_cooldown_minutes: 15,
+    };
+    ```
+
+    IMPORTANT: Since `String::new()` is not const-stable in all contexts, use a function instead:
+
+    ```rust
+    /// Returns the default vault settings.
+    pub fn default_vault_settings() -> VaultSettings {
+        VaultSettings {
+            version: "v1".to_string(),
+            recycle_bin_retention_days: 30,
+            delete_behavior: DeleteBehavior::Bin,
+            max_versions_per_file: 10,
+            version_cooldown_minutes: 15,
+        }
+    }
+    ```
+
+    Add the validation function:
+
+    ```rust
+    /// Validate and sanitize vault settings from parsed JSON.
+    ///
+    /// Clamps out-of-range numeric values to valid bounds.
+    /// Returns default settings for corrupt or non-object input.
+    /// Returns default settings if version is not "v1" (unknown version guard).
+    pub fn validate_vault_settings(input: &serde_json::Value) -> VaultSettings {
+        let defaults = default_vault_settings();
+
+        let obj = match input.as_object() {
+            Some(o) => o,
+            None => return defaults,
+        };
+
+        // Unknown version guard
+        if let Some(version) = obj.get("version") {
+            if version.as_str() != Some("v1") {
+                return defaults;
+            }
+        }
+
+        let recycle_bin_retention_days = obj
+            .get("recycleBinRetentionDays")
+            .and_then(|v| v.as_u64())
+            .map(|v| clamp(v as u32, 0, 365))
+            .unwrap_or(defaults.recycle_bin_retention_days);
+
+        let delete_behavior = obj
+            .get("deleteBehavior")
+            .and_then(|v| v.as_str())
+            .and_then(|s| match s {
+                "bin" => Some(DeleteBehavior::Bin),
+                "permanent" => Some(DeleteBehavior::Permanent),
+                _ => None,
+            })
+            .unwrap_or(defaults.delete_behavior);
+
+        let max_versions_per_file = obj
+            .get("maxVersionsPerFile")
+            .and_then(|v| v.as_u64())
+            .map(|v| clamp(v as u32, 0, 100))
+            .unwrap_or(defaults.max_versions_per_file);
+
+        let version_cooldown_minutes = obj
+            .get("versionCooldownMinutes")
+            .and_then(|v| v.as_u64())
+            .map(|v| clamp(v as u32, 0, 1440))
+            .unwrap_or(defaults.version_cooldown_minutes);
+
+        VaultSettings {
+            version: "v1".to_string(),
+            recycle_bin_retention_days,
+            delete_behavior,
+            max_versions_per_file,
+            version_cooldown_minutes,
+        }
+    }
+
+    fn clamp(value: u32, min: u32, max: u32) -> u32 {
+        value.min(max).max(min)
+    }
+    ```
+
+    Add comprehensive unit tests in a `#[cfg(test)] mod tests` block covering all the behaviors listed above. Ensure the serde round-trip test serializes a VaultSettings to JSON and verifies camelCase field names (`"maxVersionsPerFile"` not `"max_versions_per_file"`).
+
+    **Step 2: Register module and add re-exports in `crates/core/src/lib.rs`.**
+
+    Add `pub mod vault_settings;` to the module declarations.
+
+    Add to the re-exports section:
+    ```rust
+    pub use vault_settings::{VaultSettings, DeleteBehavior, default_vault_settings, validate_vault_settings};
+    ```
+
+    Per D-02: Struct matches TypeScript type fields exactly (version, recycleBinRetentionDays, deleteBehavior, maxVersionsPerFile, versionCooldownMinutes). Clamping rules: 0-365 for retention, 0-100 for versions, 0-1440 for cooldown. Unknown version guard returns defaults.
+
+  </action>
+  <verify>
+    <automated>cd /Users/michael/Code/cipher-box && cargo test -p cipherbox-core -- vault_settings</automated>
+  </verify>
+  <acceptance_criteria>
+    - crates/core/src/vault_settings.rs exists and contains `pub struct VaultSettings`
+    - crates/core/src/vault_settings.rs contains `pub enum DeleteBehavior`
+    - crates/core/src/vault_settings.rs contains `pub fn default_vault_settings() -> VaultSettings`
+    - crates/core/src/vault_settings.rs contains `pub fn validate_vault_settings(`
+    - crates/core/src/vault_settings.rs contains `#[serde(rename_all = "camelCase")]` on VaultSettings struct
+    - crates/core/src/lib.rs contains `pub mod vault_settings;`
+    - crates/core/src/lib.rs contains `pub use vault_settings::`
+    - `cargo test -p cipherbox-core -- vault_settings` exits 0 with all tests passing
+    - Serde round-trip test confirms JSON output uses `"maxVersionsPerFile"` (camelCase)
+  </acceptance_criteria>
+  <done>VaultSettings struct with serde camelCase serialization, default_vault_settings() returning v1 defaults, validate_vault_settings() with clamping and unknown-version guard, all unit tests passing</done>
+</task>
+
+</tasks>
+
+<verification>
+cargo test -p cipherbox-crypto -- vault_settings
+cargo test -p cipherbox-crypto --test cross_language -- hkdf
+cargo test -p cipherbox-core -- vault_settings
+cargo test --workspace (full suite green)
+</verification>
+
+<success_criteria>
+
+1. derive_vault_settings_ipns_keypair() exists in cipherbox-crypto, is re-exported, and passes unit tests
+2. Cross-language HKDF test vector for "cipherbox-vault-settings-v1" exists and passes
+3. VaultSettings struct, DeleteBehavior enum, default_vault_settings(), validate_vault_settings() exist in cipherbox-core
+4. All workspace tests pass (cargo test --workspace)
+   </success_criteria>
+
+<output>
+After completion, create `.planning/phases/40-desktop-vault-settings-integration/40-01-SUMMARY.md`
+</output>

--- a/.planning/phases/40-desktop-vault-settings-integration/40-01-SUMMARY.md
+++ b/.planning/phases/40-desktop-vault-settings-integration/40-01-SUMMARY.md
@@ -1,0 +1,115 @@
+---
+phase: 40-desktop-vault-settings-integration
+plan: 01
+subsystem: crypto
+tags: [hkdf, ed25519, ipns, serde, vault-settings, rust]
+
+# Dependency graph
+requires:
+  - phase: 39-user-configurable-vault-parameters
+    provides: TypeScript VaultSettings type, deriveVaultSettingsIpnsKeypair, validateVaultSettings
+provides:
+  - derive_vault_settings_ipns_keypair() in cipherbox-crypto crate
+  - VaultSettings struct with serde camelCase serialization in cipherbox-core crate
+  - default_vault_settings() and validate_vault_settings() functions
+  - Cross-language test vector for cipherbox-vault-settings-v1
+affects: [40-02-PLAN, desktop-fuse, desktop-settings-sync]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: [HKDF domain-separated derivation, serde camelCase round-trip, cross-language test vectors]
+
+key-files:
+  created:
+    - crates/core/src/vault_settings.rs
+  modified:
+    - crates/crypto/src/hkdf.rs
+    - crates/crypto/src/lib.rs
+    - crates/crypto/tests/cross_language.rs
+    - tests/vectors/crypto/hkdf.json
+    - crates/core/src/lib.rs
+
+key-decisions:
+  - 'Used function default_vault_settings() instead of const DEFAULT_VAULT_SETTINGS since String::new() is not const-stable'
+  - 'validate_vault_settings takes &serde_json::Value for flexibility with arbitrary JSON input'
+  - 'Negative numeric values in JSON fall back to defaults via as_u64() returning None'
+
+patterns-established:
+  - 'HKDF vault-settings derivation: same pattern as vault, vault-key, registry, bin, file'
+  - 'VaultSettings camelCase serde: Rust struct mirrors TypeScript type field names exactly'
+
+requirements-completed: []
+
+# Metrics
+duration: 4min
+completed: 2026-03-31
+---
+
+# Phase 40 Plan 01: Crypto Foundation for Desktop Vault Settings Summary
+
+**HKDF vault-settings IPNS derivation in cipherbox-crypto and VaultSettings domain type with validation in cipherbox-core, cross-language parity verified via shared test vectors**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-03-31T13:29:06Z
+- **Completed:** 2026-03-31T13:33:35Z
+- **Tasks:** 2
+- **Files modified:** 6
+
+## Accomplishments
+
+- Added derive_vault_settings_ipns_keypair() to cipherbox-crypto with HKDF info "cipherbox-vault-settings-v1" for domain separation
+- Cross-language test vector generated from TypeScript and verified against Rust implementation
+- VaultSettings struct with serde camelCase serialization matching TypeScript type exactly
+- validate_vault_settings() with clamping (0-365 retention, 0-100 versions, 0-1440 cooldown) and unknown-version guard
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add derive_vault_settings_ipns_keypair to crypto crate** - `593f065` (test: TDD RED) + `14675d2` (feat: TDD GREEN)
+2. **Task 2: Add VaultSettings type and validation to core crate** - `5f2450b` (feat)
+
+## Files Created/Modified
+
+- `crates/crypto/src/hkdf.rs` - Added VAULT_SETTINGS_HKDF_INFO constant and derive_vault_settings_ipns_keypair() function with 3 unit tests
+- `crates/crypto/src/lib.rs` - Added derive_vault_settings_ipns_keypair to re-exports
+- `crates/crypto/tests/cross_language.rs` - Added match arm for cipherbox-vault-settings-v1 info string
+- `tests/vectors/crypto/hkdf.json` - Added vault settings test vector with expected keys and IPNS name
+- `crates/core/src/vault_settings.rs` - New module with VaultSettings struct, DeleteBehavior enum, default_vault_settings(), validate_vault_settings() with 13 unit tests
+- `crates/core/src/lib.rs` - Added vault_settings module declaration and re-exports
+
+## Decisions Made
+
+- Used `default_vault_settings()` function instead of `const DEFAULT_VAULT_SETTINGS` because `String::new()` is not const-stable in all Rust editions
+- `validate_vault_settings` takes `&serde_json::Value` (not a typed struct) to handle arbitrary/corrupt JSON input gracefully
+- Negative numeric values in JSON trigger `as_u64()` returning `None`, which falls back to defaults (matching TypeScript `Number.isFinite` behavior)
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+- TypeScript tsx runner failed with ESM module resolution error (`ERR_PACKAGE_PATH_NOT_EXPORTED` for @libp2p/crypto). Used vitest runner instead to generate the cross-language test vector.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- cipherbox-crypto exports `derive_vault_settings_ipns_keypair` for Plan 02 desktop integration
+- cipherbox-core exports `VaultSettings`, `DeleteBehavior`, `default_vault_settings`, `validate_vault_settings` for Plan 02 desktop usage
+- Cross-language parity confirmed: identical keys/IPNS names from same input in both Rust and TypeScript
+
+## Self-Check: PASSED
+
+All 6 files verified present. All 3 commits verified in git log.
+
+---
+
+_Phase: 40-desktop-vault-settings-integration_
+_Completed: 2026-03-31_

--- a/.planning/phases/40-desktop-vault-settings-integration/40-02-PLAN.md
+++ b/.planning/phases/40-desktop-vault-settings-integration/40-02-PLAN.md
@@ -1,0 +1,533 @@
+---
+phase: 40-desktop-vault-settings-integration
+plan: 02
+type: execute
+wave: 2
+depends_on: ['40-01']
+files_modified:
+  - crates/sdk/src/state.rs
+  - crates/fuse/src/lib.rs
+  - crates/fuse/src/constants.rs
+  - crates/fuse/src/read_ops.rs
+  - crates/fuse/src/platform/windows/write_ops.rs
+  - apps/desktop/src-tauri/src/commands/auth.rs
+  - apps/desktop/src-tauri/src/fuse/mod.rs
+  - apps/desktop/src-tauri/src/fuse/windows/mod.rs
+autonomous: true
+requirements: []
+
+must_haves:
+  truths:
+    - 'Desktop app loads vault settings during login via IPNS resolve + ECIES decrypt'
+    - 'Login succeeds with default settings when no IPNS record exists (new user or never configured)'
+    - 'FUSE versioning uses user-configured maxVersionsPerFile instead of hardcoded 10'
+    - 'FUSE versioning uses user-configured versionCooldownMinutes (converted to ms) instead of hardcoded 15 minutes'
+    - 'Settings are accessible from both macOS and Windows FUSE code paths'
+  artifacts:
+    - path: 'crates/sdk/src/state.rs'
+      provides: 'vault_settings field on KeyState'
+      contains: 'vault_settings'
+    - path: 'crates/fuse/src/lib.rs'
+      provides: 'max_versions_per_file and version_cooldown_ms fields on CipherBoxFS'
+      contains: 'max_versions_per_file'
+    - path: 'apps/desktop/src-tauri/src/commands/auth.rs'
+      provides: 'Vault settings loading in complete_auth_setup'
+      contains: 'load_vault_settings'
+  key_links:
+    - from: 'apps/desktop/src-tauri/src/commands/auth.rs'
+      to: 'crates/sdk/src/state.rs'
+      via: 'stores loaded VaultSettings in KeyState.vault_settings'
+      pattern: 'vault_settings.*write'
+    - from: 'apps/desktop/src-tauri/src/fuse/mod.rs'
+      to: 'crates/fuse/src/lib.rs'
+      via: 'reads vault_settings from KeyState and passes to CipherBoxFS constructor'
+      pattern: 'max_versions_per_file'
+    - from: 'crates/fuse/src/read_ops.rs'
+      to: 'crates/fuse/src/lib.rs'
+      via: 'uses fs.max_versions_per_file and fs.version_cooldown_ms instead of constants'
+      pattern: "self\\.max_versions_per_file|self\\.version_cooldown_ms"
+---
+
+<objective>
+Wire vault settings into the desktop app's auth flow and FUSE operations.
+
+Purpose: Load user-configurable vault settings at login (ECIES-encrypted IPNS entry, graceful fallback to defaults) and replace hardcoded FUSE versioning constants with loaded values, so the desktop app honors settings configured via the web app.
+
+Output: KeyState holds VaultSettings, complete_auth_setup loads settings, CipherBoxFS uses configurable versioning parameters, both macOS and Windows code paths updated.
+</objective>
+
+<execution_context>
+@/Users/michael/Code/cipher-box/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/michael/Code/cipher-box/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/40-desktop-vault-settings-integration/40-CONTEXT.md
+@.planning/phases/40-desktop-vault-settings-integration/40-RESEARCH.md
+@.planning/phases/40-desktop-vault-settings-integration/40-01-SUMMARY.md
+</context>
+
+<interfaces>
+<!-- Types created by Plan 01 that this plan depends on -->
+
+From crates/crypto (added by Plan 01):
+
+```rust
+pub fn derive_vault_settings_ipns_keypair(
+    user_private_key: &[u8; 32],
+) -> Result<(Zeroizing<Vec<u8>>, Vec<u8>, String), CryptoError>
+```
+
+From crates/core (added by Plan 01):
+
+```rust
+pub struct VaultSettings {
+    pub version: String,
+    pub recycle_bin_retention_days: u32,
+    pub delete_behavior: DeleteBehavior,
+    pub max_versions_per_file: u32,
+    pub version_cooldown_minutes: u32,
+}
+pub enum DeleteBehavior { Bin, Permanent }
+pub fn default_vault_settings() -> VaultSettings;
+pub fn validate_vault_settings(input: &serde_json::Value) -> VaultSettings;
+```
+
+From crates/sdk/src/state.rs (current KeyState):
+
+```rust
+pub struct KeyState {
+    pub api: Arc<ApiClient>,
+    pub private_key: RwLock<Option<Vec<u8>>>,
+    pub public_key: RwLock<Option<Vec<u8>>>,
+    pub root_folder_key: RwLock<Option<Vec<u8>>>,
+    pub root_ipns_name: RwLock<Option<String>>,
+    pub root_ipns_private_key: RwLock<Option<Vec<u8>>>,
+    pub user_id: RwLock<Option<String>>,
+    pub tee_keys: RwLock<Option<TeeKeysResponse>>,
+    pub is_authenticated: RwLock<bool>,
+}
+```
+
+From crates/fuse/src/lib.rs (current CipherBoxFS - relevant fields):
+
+```rust
+pub struct CipherBoxFS {
+    pub inodes: inode::InodeTable,
+    // ... many fields ...
+    pub tee_public_key: Option<Vec<u8>>,
+    pub tee_key_epoch: Option<u32>,
+    // ADD: max_versions_per_file, version_cooldown_ms
+}
+```
+
+From crates/fuse/src/constants.rs (to be replaced):
+
+```rust
+pub const MAX_VERSIONS_PER_FILE: usize = 10;
+pub const VERSION_COOLDOWN_MS: u64 = 15 * 60 * 1000;
+```
+
+From crates/api-client (existing):
+
+```rust
+// crates/api-client/src/ipns.rs
+pub async fn resolve_ipns(api: &ApiClient, ipns_name: &str) -> Result<ResolveResponse, ApiError>
+// crates/api-client/src/ipfs.rs
+pub async fn fetch_content(api: &ApiClient, cid: &str) -> Result<Vec<u8>, ApiError>
+```
+
+From crates/crypto/src/ecies.rs (existing):
+
+```rust
+pub fn unwrap_key(wrapped: &[u8], private_key: &[u8]) -> Result<Vec<u8>, CryptoError>
+```
+
+From apps/desktop/src-tauri/src/fuse/mod.rs (macOS mount_filesystem signature):
+
+```rust
+pub async fn mount_filesystem(
+    state: &AppState, rt: tokio::runtime::Handle,
+    private_key: Vec<u8>, public_key: Vec<u8>, root_folder_key: Vec<u8>,
+    root_ipns_name: String, root_ipns_private_key: Option<Vec<u8>>,
+    tee_public_key: Option<Vec<u8>>, tee_key_epoch: Option<u32>,
+) -> Result<std::thread::JoinHandle<()>, String>
+```
+
+From apps/web/src/services/vault-settings.service.ts (TypeScript load pattern):
+
+```typescript
+// Pattern: derive IPNS keypair -> resolve IPNS -> fetch IPFS -> ECIES unwrap -> JSON parse -> validate
+// Fallback to DEFAULT_VAULT_SETTINGS on any error
+```
+
+</interfaces>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add vault_settings field to KeyState and load settings in auth flow</name>
+  <files>crates/sdk/src/state.rs, apps/desktop/src-tauri/src/commands/auth.rs</files>
+  <read_first>
+    - crates/sdk/src/state.rs (current KeyState struct, new(), clear(), tests)
+    - apps/desktop/src-tauri/src/commands/auth.rs lines 90-266 (complete_auth_setup function)
+    - apps/desktop/src-tauri/src/commands/vault.rs lines 148-221 (fetch_and_decrypt_vault pattern for IPNS resolve + decrypt)
+    - apps/web/src/services/vault-settings.service.ts (TypeScript loadVaultSettings for reference pattern)
+    - crates/api-client/src/ipns.rs (resolve_ipns signature)
+    - crates/api-client/src/ipfs.rs (fetch_content signature)
+    - crates/crypto/src/ecies.rs (unwrap_key signature)
+  </read_first>
+  <action>
+    **Step 1: Add vault_settings field to KeyState in `crates/sdk/src/state.rs`.**
+
+    Add import at top of file:
+    ```rust
+    use cipherbox_core::VaultSettings;
+    ```
+
+    Add field to the `KeyState` struct (after `tee_keys`):
+    ```rust
+    /// User-configurable vault settings (retention, versioning, delete behavior).
+    /// Non-optional: defaults to default_vault_settings() when not loaded from IPNS.
+    pub vault_settings: RwLock<VaultSettings>,
+    ```
+
+    Update `KeyState::new()` to initialize with defaults:
+    ```rust
+    vault_settings: RwLock::new(cipherbox_core::default_vault_settings()),
+    ```
+
+    Update `KeyState::clear()` to reset to defaults (NOT zero - settings are non-sensitive config):
+    ```rust
+    *self.vault_settings.write().await = cipherbox_core::default_vault_settings();
+    ```
+
+    Update the existing tests:
+    - In `new_creates_state_with_none_fields`: add assertion `assert_eq!(*state.vault_settings.read().await, cipherbox_core::default_vault_settings());`
+    - In `clear_zeros_all_sensitive_byte_fields`: set vault_settings to a non-default value before clear, verify it resets to defaults after clear
+
+    **Step 2: Add `load_vault_settings` helper function in `apps/desktop/src-tauri/src/commands/auth.rs`.**
+
+    Add this async function (can be placed near `fetch_and_decrypt_vault`):
+
+    ```rust
+    /// Load user-configurable vault settings from encrypted IPNS entry.
+    ///
+    /// Pattern: derive IPNS keypair -> resolve IPNS -> fetch IPFS -> ECIES unwrap -> parse JSON -> validate.
+    /// Returns default settings on any failure (IPNS not found, decrypt error, parse error).
+    /// Per D-03 and D-05: graceful fallback, desktop is read-only for settings.
+    async fn load_vault_settings(
+        api: &std::sync::Arc<cipherbox_api_client::ApiClient>,
+        private_key: &[u8; 32],
+    ) -> cipherbox_core::VaultSettings {
+        let result: Result<cipherbox_core::VaultSettings, String> = async {
+            // 1. Derive IPNS keypair for vault settings
+            let (_priv_key, _pub_key, ipns_name) =
+                cipherbox_crypto::hkdf::derive_vault_settings_ipns_keypair(private_key)
+                    .map_err(|e| format!("HKDF derivation failed: {:?}", e))?;
+
+            // 2. Resolve IPNS name to CID
+            let resolved = cipherbox_api_client::ipns::resolve_ipns(api, &ipns_name)
+                .await
+                .map_err(|e| format!("IPNS resolve failed: {}", e))?;
+
+            // 3. Fetch encrypted blob from IPFS
+            let encrypted = cipherbox_api_client::ipfs::fetch_content(api, &resolved.cid)
+                .await
+                .map_err(|e| format!("IPFS fetch failed: {}", e))?;
+
+            // 4. ECIES decrypt with user's private key (NOT AES-GCM - vault settings use ECIES wrapKey)
+            let plaintext = cipherbox_crypto::ecies::unwrap_key(&encrypted, private_key)
+                .map_err(|e| format!("ECIES unwrap failed: {:?}", e))?;
+
+            // 5. Parse JSON and validate
+            let parsed: serde_json::Value = serde_json::from_slice(&plaintext)
+                .map_err(|e| format!("JSON parse failed: {}", e))?;
+
+            Ok(cipherbox_core::validate_vault_settings(&parsed))
+        }
+        .await;
+
+        match result {
+            Ok(settings) => {
+                log::info!(
+                    "Vault settings loaded: maxVersions={}, cooldown={}min, retention={}d, delete={:?}",
+                    settings.max_versions_per_file,
+                    settings.version_cooldown_minutes,
+                    settings.recycle_bin_retention_days,
+                    settings.delete_behavior
+                );
+                settings
+            }
+            Err(e) => {
+                log::warn!("Vault settings load failed (using defaults): {}", e);
+                cipherbox_core::default_vault_settings()
+            }
+        }
+    }
+    ```
+
+    **Step 3: Call load_vault_settings in `complete_auth_setup()`.**
+
+    In `complete_auth_setup()`, AFTER step 5 (fetch_and_decrypt_vault) and BEFORE step 6 (mark as authenticated), add vault settings loading:
+
+    ```rust
+    // 5b. Load vault settings (non-blocking, graceful fallback to defaults)
+    {
+        let pk_slice: &[u8] = &private_key_bytes;
+        if let Ok(pk_arr) = <[u8; 32]>::try_from(pk_slice) {
+            let settings = load_vault_settings(&state.sdk.api, &pk_arr).await;
+            *state.sdk.vault_settings.write().await = settings;
+        } else {
+            log::warn!("Private key not 32 bytes, using default vault settings");
+        }
+    }
+    ```
+
+    Add `serde_json` to the imports if not already present in the file.
+
+    Per D-03: Load during complete_auth_setup alongside vault key decryption. Graceful fallback to defaults on any failure. Per D-05: read-only on desktop, no save functionality.
+
+  </action>
+  <verify>
+    <automated>cd /Users/michael/Code/cipher-box && cargo test -p cipherbox-sdk -- state && cargo check -p cipherbox-desktop 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - crates/sdk/src/state.rs contains `pub vault_settings: RwLock<VaultSettings>`
+    - crates/sdk/src/state.rs contains `vault_settings: RwLock::new(cipherbox_core::default_vault_settings())`
+    - crates/sdk/src/state.rs clear() contains `vault_settings` reset
+    - apps/desktop/src-tauri/src/commands/auth.rs contains `async fn load_vault_settings(`
+    - apps/desktop/src-tauri/src/commands/auth.rs contains `cipherbox_crypto::ecies::unwrap_key` (NOT decrypt_metadata_from_ipfs_public)
+    - apps/desktop/src-tauri/src/commands/auth.rs contains `cipherbox_core::validate_vault_settings`
+    - apps/desktop/src-tauri/src/commands/auth.rs complete_auth_setup contains `load_vault_settings`
+    - `cargo test -p cipherbox-sdk -- state` exits 0
+    - `cargo check -p cipherbox-desktop` compiles without errors
+  </acceptance_criteria>
+  <done>KeyState has vault_settings field initialized to defaults, complete_auth_setup loads settings from IPNS with ECIES decrypt and graceful fallback, SDK state tests pass, desktop compiles</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Replace hardcoded FUSE constants with configurable values from VaultSettings</name>
+  <files>crates/fuse/src/lib.rs, crates/fuse/src/constants.rs, crates/fuse/src/read_ops.rs, crates/fuse/src/platform/windows/write_ops.rs, apps/desktop/src-tauri/src/fuse/mod.rs, apps/desktop/src-tauri/src/fuse/windows/mod.rs</files>
+  <read_first>
+    - crates/fuse/src/lib.rs lines 468-499 (CipherBoxFS struct definition)
+    - crates/fuse/src/constants.rs (current MAX_VERSIONS_PER_FILE and VERSION_COOLDOWN_MS)
+    - crates/fuse/src/read_ops.rs lines 19, 728, 749-755 (macOS versioning logic using constants)
+    - crates/fuse/src/platform/windows/write_ops.rs lines 16, 750, 771-772 (Windows versioning logic using constants)
+    - apps/desktop/src-tauri/src/fuse/mod.rs lines 190-211 (macOS CipherBoxFS construction)
+    - apps/desktop/src-tauri/src/fuse/windows/mod.rs lines 321-350 (Windows CipherBoxFS construction)
+    - apps/desktop/src-tauri/src/commands/auth.rs lines 147-207 (mount_filesystem call in complete_auth_setup)
+  </read_first>
+  <action>
+    **Step 1: Add configurable fields to CipherBoxFS in `crates/fuse/src/lib.rs`.**
+
+    Add two new public fields to the `CipherBoxFS` struct (after `tee_key_epoch`):
+    ```rust
+    /// Maximum number of past versions to keep per file (from user vault settings).
+    pub max_versions_per_file: usize,
+    /// Version creation cooldown in milliseconds (from user vault settings).
+    pub version_cooldown_ms: u64,
+    ```
+
+    **Step 2: Update `crates/fuse/src/constants.rs`.**
+
+    Keep `MAX_VERSIONS_PER_FILE` and `VERSION_COOLDOWN_MS` as default fallback constants but add a comment marking them as defaults only:
+    ```rust
+    /// Default maximum versions per file (used as fallback if settings not loaded).
+    /// User-configurable value is stored in CipherBoxFS.max_versions_per_file.
+    pub const DEFAULT_MAX_VERSIONS_PER_FILE: usize = 10;
+
+    /// Default version cooldown in milliseconds (used as fallback if settings not loaded).
+    /// User-configurable value is stored in CipherBoxFS.version_cooldown_ms.
+    pub const DEFAULT_VERSION_COOLDOWN_MS: u64 = 15 * 60 * 1000;
+    ```
+
+    Rename the constants from `MAX_VERSIONS_PER_FILE` to `DEFAULT_MAX_VERSIONS_PER_FILE` and `VERSION_COOLDOWN_MS` to `DEFAULT_VERSION_COOLDOWN_MS`. This rename ensures any missed references cause compile errors.
+
+    **Step 3: Update `crates/fuse/src/read_ops.rs` to use CipherBoxFS fields.**
+
+    At line 19, update the import: remove `MAX_VERSIONS_PER_FILE, VERSION_COOLDOWN_MS` from the `use crate::constants::` import. If nothing else from constants is imported on that line, update accordingly.
+
+    At line 728, change:
+    ```rust
+    // OLD: now_ms.saturating_sub(newest.timestamp) >= VERSION_COOLDOWN_MS
+    // NEW:
+    now_ms.saturating_sub(newest.timestamp) >= fs.version_cooldown_ms
+    ```
+
+    At line 749, change:
+    ```rust
+    // OLD: let pruned: Vec<String> = if versions.len() > MAX_VERSIONS_PER_FILE {
+    // NEW:
+    let pruned: Vec<String> = if versions.len() > fs.max_versions_per_file {
+    ```
+
+    At line 750, change:
+    ```rust
+    // OLD: versions.split_off(MAX_VERSIONS_PER_FILE).into_iter().map(|v| v.cid).collect()
+    // NEW:
+    versions.split_off(fs.max_versions_per_file).into_iter().map(|v| v.cid).collect()
+    ```
+
+    At line 755, change:
+    ```rust
+    // OLD: log::info!("Pruned {} version(s) for ino {} (exceeded max {})", pruned.len(), ino, MAX_VERSIONS_PER_FILE);
+    // NEW:
+    log::info!("Pruned {} version(s) for ino {} (exceeded max {})", pruned.len(), ino, fs.max_versions_per_file);
+    ```
+
+    Note: `fs` is the `&mut CipherBoxFS` that is `self` or `&self` in the FUSE callback context. Check whether these references use `self` or a local `fs` binding and adjust accordingly. The `release` callback in read_ops.rs takes `&mut self`, so use `self.max_versions_per_file` and `self.version_cooldown_ms`.
+
+    **Step 4: Update `crates/fuse/src/platform/windows/write_ops.rs` to use CipherBoxFS fields.**
+
+    At line 16, remove the import of `MAX_VERSIONS_PER_FILE, VERSION_COOLDOWN_MS` from `use crate::constants::`.
+
+    At line 750, change:
+    ```rust
+    // OLD: now_ms.saturating_sub(newest.timestamp) >= VERSION_COOLDOWN_MS
+    // NEW:
+    now_ms.saturating_sub(newest.timestamp) >= fs.version_cooldown_ms
+    ```
+
+    At line 771, change:
+    ```rust
+    // OLD: let pruned: Vec<String> = if versions.len() > MAX_VERSIONS_PER_FILE {
+    // NEW:
+    let pruned: Vec<String> = if versions.len() > fs.max_versions_per_file {
+    ```
+
+    At line 772, change:
+    ```rust
+    // OLD: versions.split_off(MAX_VERSIONS_PER_FILE).into_iter().map(|v| v.cid).collect()
+    // NEW:
+    versions.split_off(fs.max_versions_per_file).into_iter().map(|v| v.cid).collect()
+    ```
+
+    Note: Check whether the Windows write_ops uses `fs` or `self` as the CipherBoxFS reference and adjust accordingly.
+
+    **Step 5: Update `mount_filesystem` parameters and CipherBoxFS construction.**
+
+    **macOS (`apps/desktop/src-tauri/src/fuse/mod.rs`):**
+
+    Add two new parameters to `mount_filesystem` signature:
+    ```rust
+    pub async fn mount_filesystem(
+        state: &AppState,
+        rt: tokio::runtime::Handle,
+        private_key: Vec<u8>,
+        public_key: Vec<u8>,
+        root_folder_key: Vec<u8>,
+        root_ipns_name: String,
+        root_ipns_private_key: Option<Vec<u8>>,
+        tee_public_key: Option<Vec<u8>>,
+        tee_key_epoch: Option<u32>,
+        max_versions_per_file: usize,   // NEW
+        version_cooldown_ms: u64,        // NEW
+    ) -> Result<std::thread::JoinHandle<()>, String> {
+    ```
+
+    In the CipherBoxFS construction (around line 190), add the new fields:
+    ```rust
+    let fs = CipherBoxFS {
+        // ... existing fields ...
+        tee_public_key, tee_key_epoch,
+        max_versions_per_file,    // NEW
+        version_cooldown_ms,       // NEW
+        refresh_rx, refresh_tx,
+        // ... rest ...
+    };
+    ```
+
+    **Windows (`apps/desktop/src-tauri/src/fuse/windows/mod.rs`):**
+
+    Add the same two new parameters to `mount_filesystem` signature (same pattern as macOS).
+
+    In the CipherBoxFS construction (around line 321), add the new fields identically.
+
+    **Step 6: Update `complete_auth_setup` in `apps/desktop/src-tauri/src/commands/auth.rs` to pass settings to mount.**
+
+    In the `#[cfg(any(feature = "fuse", feature = "winfsp"))]` block where `mount_filesystem` is called (around line 197-207), read vault settings and pass to mount:
+
+    ```rust
+    // Read vault settings for FUSE
+    let vault_settings = state.sdk.vault_settings.read().await;
+    let max_versions = vault_settings.max_versions_per_file as usize;
+    // CRITICAL: Convert minutes to milliseconds (per Pitfall 4 in RESEARCH.md)
+    let cooldown_ms = vault_settings.version_cooldown_minutes as u64 * 60 * 1000;
+    drop(vault_settings);
+    ```
+
+    Then pass these to the `mount_filesystem` call:
+    ```rust
+    match crate::fuse::mount_filesystem(
+        state,
+        rt,
+        private_key,
+        public_key,
+        root_folder_key,
+        root_ipns_name,
+        root_ipns_private_key,
+        tee_public_key,
+        tee_key_epoch,
+        max_versions,       // NEW
+        cooldown_ms,        // NEW
+    ).await {
+    ```
+
+    **Step 7: Verify no remaining references to old constant names.**
+
+    Run `grep -rn "MAX_VERSIONS_PER_FILE\|VERSION_COOLDOWN_MS" crates/fuse/src/` to confirm no references to the old (un-prefixed) constant names remain. Only `DEFAULT_MAX_VERSIONS_PER_FILE` and `DEFAULT_VERSION_COOLDOWN_MS` should exist in `constants.rs`.
+
+    Per D-04: Hardcoded constants replaced with CipherBoxFS fields loaded from VaultSettings. Settings stored in KeyState, read during mount setup, passed to CipherBoxFS constructor. Both macOS and Windows paths updated.
+
+  </action>
+  <verify>
+    <automated>cd /Users/michael/Code/cipher-box && cargo check -p cipherbox-fuse && cargo check -p cipherbox-desktop && grep -rn "use crate::constants::{.*MAX_VERSIONS_PER_FILE\|use crate::constants::{.*VERSION_COOLDOWN_MS" crates/fuse/src/read_ops.rs crates/fuse/src/platform/windows/write_ops.rs; echo "Exit: $?"</automated>
+  </verify>
+  <acceptance_criteria>
+    - crates/fuse/src/lib.rs CipherBoxFS struct contains `pub max_versions_per_file: usize`
+    - crates/fuse/src/lib.rs CipherBoxFS struct contains `pub version_cooldown_ms: u64`
+    - crates/fuse/src/constants.rs contains `DEFAULT_MAX_VERSIONS_PER_FILE` (renamed from MAX_VERSIONS_PER_FILE)
+    - crates/fuse/src/constants.rs contains `DEFAULT_VERSION_COOLDOWN_MS` (renamed from VERSION_COOLDOWN_MS)
+    - crates/fuse/src/read_ops.rs does NOT import `MAX_VERSIONS_PER_FILE` or `VERSION_COOLDOWN_MS` from constants
+    - crates/fuse/src/read_ops.rs uses `self.version_cooldown_ms` or `fs.version_cooldown_ms` (not constant)
+    - crates/fuse/src/read_ops.rs uses `self.max_versions_per_file` or `fs.max_versions_per_file` (not constant)
+    - crates/fuse/src/platform/windows/write_ops.rs does NOT import `MAX_VERSIONS_PER_FILE` or `VERSION_COOLDOWN_MS` from constants
+    - crates/fuse/src/platform/windows/write_ops.rs uses CipherBoxFS fields for versioning
+    - apps/desktop/src-tauri/src/fuse/mod.rs mount_filesystem signature includes `max_versions_per_file: usize, version_cooldown_ms: u64`
+    - apps/desktop/src-tauri/src/fuse/windows/mod.rs mount_filesystem signature includes same new parameters
+    - apps/desktop/src-tauri/src/commands/auth.rs contains `version_cooldown_minutes as u64 * 60 * 1000` (minutes to ms conversion)
+    - `cargo check -p cipherbox-fuse` succeeds
+    - `cargo check -p cipherbox-desktop` succeeds
+  </acceptance_criteria>
+  <done>FUSE versioning uses user-configurable values from VaultSettings instead of hardcoded constants, both macOS and Windows paths updated, minutes-to-milliseconds conversion correct, full compilation succeeds</done>
+</task>
+
+</tasks>
+
+<verification>
+cargo check -p cipherbox-fuse
+cargo check -p cipherbox-desktop
+cargo test -p cipherbox-sdk -- state
+cargo test --workspace
+grep -rn "MAX_VERSIONS_PER_FILE\b" crates/fuse/src/read_ops.rs crates/fuse/src/platform/windows/write_ops.rs (should return 0 results)
+grep -rn "VERSION_COOLDOWN_MS\b" crates/fuse/src/read_ops.rs crates/fuse/src/platform/windows/write_ops.rs (should return 0 results)
+</verification>
+
+<success_criteria>
+
+1. KeyState has vault_settings field, initialized to defaults, reset on clear()
+2. complete_auth_setup loads vault settings via derive IPNS -> resolve -> fetch -> ECIES unwrap -> validate, with graceful fallback
+3. CipherBoxFS has max_versions_per_file and version_cooldown_ms fields replacing hardcoded constants
+4. Both macOS read_ops.rs and Windows write_ops.rs use CipherBoxFS fields, not imported constants
+5. mount_filesystem on both platforms accepts and passes through the configurable values
+6. Minutes-to-milliseconds conversion is correct (versionCooldownMinutes _ 60 _ 1000)
+7. Full workspace compilation and tests pass
+   </success_criteria>
+
+<output>
+After completion, create `.planning/phases/40-desktop-vault-settings-integration/40-02-SUMMARY.md`
+</output>

--- a/.planning/phases/40-desktop-vault-settings-integration/40-02-SUMMARY.md
+++ b/.planning/phases/40-desktop-vault-settings-integration/40-02-SUMMARY.md
@@ -1,0 +1,126 @@
+---
+phase: 40-desktop-vault-settings-integration
+plan: 02
+subsystem: desktop
+tags: [rust, fuse, tauri, vault-settings, ecies, ipns, hkdf]
+
+# Dependency graph
+requires:
+  - phase: 40-desktop-vault-settings-integration (plan 01)
+    provides: VaultSettings type, default_vault_settings(), validate_vault_settings(), derive_vault_settings_ipns_keypair()
+  - phase: 39-user-configurable-vault-parameters
+    provides: Web app vault settings save/load via IPNS, TypeScript reference implementation
+provides:
+  - KeyState.vault_settings field initialized to defaults and loaded during auth
+  - load_vault_settings() helper with ECIES decrypt and graceful fallback
+  - CipherBoxFS.max_versions_per_file and version_cooldown_ms configurable fields
+  - mount_filesystem accepts versioning parameters on both macOS and Windows
+affects: [desktop-e2e, vault-settings-verification, fuse-versioning]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: [IPNS-encrypted-settings-load-with-graceful-fallback, minutes-to-ms-conversion-at-boundary]
+
+key-files:
+  created: []
+  modified:
+    - crates/sdk/src/state.rs
+    - apps/desktop/src-tauri/src/commands/auth.rs
+    - crates/fuse/src/lib.rs
+    - crates/fuse/src/constants.rs
+    - crates/fuse/src/read_ops.rs
+    - crates/fuse/src/platform/windows/write_ops.rs
+    - apps/desktop/src-tauri/src/fuse/mod.rs
+    - apps/desktop/src-tauri/src/fuse/windows/mod.rs
+
+key-decisions:
+  - 'vault_settings is non-optional RwLock<VaultSettings> with default initialization (not Option) since defaults are always valid'
+  - 'Minutes-to-milliseconds conversion done at FUSE mount boundary, not inside FUSE crate (clean separation)'
+  - 'Constants renamed to DEFAULT_ prefix to force compile errors on any missed references'
+
+patterns-established:
+  - 'IPNS settings load pattern: derive keypair -> resolve IPNS -> fetch IPFS -> ECIES unwrap -> validate -> fallback to defaults'
+  - 'Non-sensitive config fields reset to defaults (not zeroed) in KeyState.clear()'
+
+requirements-completed: []
+
+# Metrics
+duration: 7min
+completed: 2026-03-31
+---
+
+# Phase 40 Plan 02: Desktop Vault Settings Integration Summary
+
+**Wired vault settings into desktop auth flow with ECIES-encrypted IPNS load and replaced hardcoded FUSE versioning constants with user-configurable values**
+
+## Performance
+
+- **Duration:** 7 min
+- **Started:** 2026-03-31T13:37:19Z
+- **Completed:** 2026-03-31T13:44:40Z
+- **Tasks:** 2
+- **Files modified:** 8
+
+## Accomplishments
+
+- KeyState now holds VaultSettings (non-optional, defaults on init, reset on clear)
+- complete_auth_setup loads vault settings via IPNS resolve + ECIES decrypt with graceful fallback to defaults
+- CipherBoxFS uses configurable max_versions_per_file and version_cooldown_ms instead of hardcoded constants
+- Both macOS and Windows FUSE code paths updated to use user-configurable versioning parameters
+- Minutes-to-milliseconds conversion correctly applied at the FUSE mount boundary
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add vault_settings field to KeyState and load settings in auth flow** - `c22cbf351` (feat)
+2. **Task 2: Replace hardcoded FUSE constants with configurable values from VaultSettings** - `0887399d7` (feat)
+
+## Files Created/Modified
+
+- `crates/sdk/src/state.rs` - Added vault_settings: RwLock<VaultSettings> field to KeyState with init/clear
+- `apps/desktop/src-tauri/src/commands/auth.rs` - Added load_vault_settings() helper and call in complete_auth_setup
+- `crates/fuse/src/lib.rs` - Added max_versions_per_file and version_cooldown_ms fields to CipherBoxFS
+- `crates/fuse/src/constants.rs` - Renamed to DEFAULT_MAX_VERSIONS_PER_FILE and DEFAULT_VERSION_COOLDOWN_MS
+- `crates/fuse/src/read_ops.rs` - Replaced constant imports with CipherBoxFS field references
+- `crates/fuse/src/platform/windows/write_ops.rs` - Replaced constant imports with CipherBoxFS field references
+- `apps/desktop/src-tauri/src/fuse/mod.rs` - Added max_versions_per_file and version_cooldown_ms params to macOS mount_filesystem
+- `apps/desktop/src-tauri/src/fuse/windows/mod.rs` - Added same params to Windows mount_filesystem
+
+## Decisions Made
+
+- **vault_settings as non-optional field:** Using `RwLock<VaultSettings>` (not `Option<>`) since defaults are always valid and simplify all read sites
+- **Minutes-to-ms conversion at mount boundary:** The FUSE crate works in milliseconds internally; the conversion from VaultSettings.version_cooldown_minutes happens once when reading from KeyState before passing to mount_filesystem
+- **DEFAULT_ prefix rename for constants:** Renaming MAX_VERSIONS_PER_FILE to DEFAULT_MAX_VERSIONS_PER_FILE forces compile errors on any missed reference sites, making the migration safe
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Known Stubs
+
+None - all data flows are fully wired (settings loaded from IPNS at auth, passed through to FUSE mount).
+
+## Next Phase Readiness
+
+- Desktop app now honors vault settings configured via the web app
+- Settings are read-only on desktop (per D-05 decision from research)
+- Phase 40 execution complete: crypto foundation (plan 01) + auth/FUSE integration (plan 02)
+
+## Self-Check: PASSED
+
+All 8 modified files verified present. Both task commits (c22cbf351, 0887399d7) verified in git history.
+
+---
+
+_Phase: 40-desktop-vault-settings-integration_
+_Completed: 2026-03-31_

--- a/.planning/phases/40-desktop-vault-settings-integration/40-CONTEXT.md
+++ b/.planning/phases/40-desktop-vault-settings-integration/40-CONTEXT.md
@@ -1,0 +1,131 @@
+# Phase 40: Desktop vault settings integration - Context
+
+**Gathered:** 2026-03-31
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Propagate user-configurable vault settings (Phase 39) to the Rust SDK and desktop app. The web app already stores VaultSettings as an encrypted IPNS entry; the desktop app must derive the same IPNS keypair, resolve/decrypt the settings blob, and use the values to drive FUSE file operations (versioning limits, cooldown) instead of hardcoded constants.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### HKDF derivation parity
+
+- **D-01:** Add `VAULT_SETTINGS_HKDF_INFO = b"cipherbox-vault-settings-v1"` to `crates/crypto/src/hkdf.rs` and implement `derive_vault_settings_ipns_keypair()` following the existing pattern. Must produce identical IPNS names as the TypeScript `deriveVaultSettingsIpnsKeypair()` — verify with shared test vectors.
+
+### VaultSettings type in Rust
+
+- **D-02:** Add `VaultSettings` struct to `crates/core` matching the TypeScript type: `version`, `recycleBinRetentionDays`, `deleteBehavior`, `maxVersionsPerFile`, `versionCooldownMinutes`. Include `validateVaultSettings()` with same clamping rules (0-365, 0-100, 0-1440) and unknown-version guard.
+
+### Settings loading during login
+
+- **D-03:** Load vault settings in `complete_auth_setup()` alongside vault key decryption. Pattern: derive IPNS keypair -> resolve IPNS -> fetch from IPFS -> ECIES decrypt with userPrivateKey -> parse JSON -> validate. Graceful fallback to defaults on any failure (same as web app).
+
+### Wiring into FUSE operations
+
+- **D-04:** Replace hardcoded `MAX_VERSIONS_PER_FILE` and `VERSION_COOLDOWN_MS` in `crates/fuse/src/constants.rs` with values loaded from VaultSettings. Store settings in `KeyState` or a new `VaultSettingsState` accessible to the FUSE mount.
+
+### Settings are read-only on desktop
+
+- **D-05:** Desktop app only reads vault settings (no save/edit UI). Users configure settings via the web app's Vault tab. Desktop picks up changes on next login or when IPNS polling detects an update.
+
+### Claude's Discretion
+
+- Whether to add VaultSettings to existing `KeyState` or create a separate state struct
+- Whether to add IPNS polling for settings changes (vs load-once-at-login)
+- Error handling granularity for settings load failures
+- Test vector file format and location
+
+</decisions>
+
+<canonical_refs>
+
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### TypeScript reference implementation (Phase 39)
+
+- `packages/crypto/src/vault/derive-ipns.ts` — `deriveVaultSettingsIpnsKeypair()` with info string `cipherbox-vault-settings-v1`
+- `packages/core/src/vault/settings.ts` — `VaultSettings` type, `DEFAULT_VAULT_SETTINGS`, `validateVaultSettings()`
+- `packages/core/src/vault/types.ts:73-83` — `VaultSettings` type definition
+- `apps/web/src/services/vault-settings.service.ts` — `loadVaultSettings()` / `saveVaultSettings()` (ECIES encrypt/decrypt + IPNS)
+
+### Rust HKDF derivation (existing pattern)
+
+- `crates/crypto/src/hkdf.rs` — All HKDF info strings and derivation functions (vault, vault-key, registry, bin, file)
+- `crates/crypto/src/ecies.rs` — ECIES encrypt/decrypt for key wrapping
+
+### Desktop login flow
+
+- `apps/desktop/src-tauri/src/commands/auth.rs:94-266` — `complete_auth_setup()` where vault is initialized
+- `apps/desktop/src-tauri/src/commands/vault.rs:148-221` — `fetch_and_decrypt_vault()` for IPNS resolve + decrypt pattern
+
+### FUSE constants (to be replaced)
+
+- `crates/fuse/src/constants.rs:12` — `MAX_VERSIONS_PER_FILE = 10`
+- `crates/fuse/src/constants.rs:16` — `VERSION_COOLDOWN_MS = 15 * 60 * 1000`
+
+### Shared test vectors
+
+- `tests/vectors/` — Existing cross-platform test vector files (Rust + TypeScript)
+
+### IPNS resolution
+
+- `crates/api-client/src/ipns.rs:14-54` — `resolve_ipns()` via backend API
+- `crates/core/src/decrypt.rs:10-51` — Metadata decryption pattern (JSON `{iv, data}` -> AES-GCM)
+
+</canonical_refs>
+
+<code_context>
+
+## Existing Code Insights
+
+### Reusable Assets
+
+- `derive_vault_ipns_keypair()` pattern in `crates/crypto/src/hkdf.rs` — exact same structure, just different info string
+- ECIES decrypt in `crates/crypto/src/ecies.rs` — for unwrapping the settings blob
+- `fetch_content()` in `crates/api-client/src/ipfs.rs` — fetch encrypted blob from IPFS by CID
+- `resolve_ipns()` in `crates/api-client/src/ipns.rs` — resolve IPNS name to CID
+
+### Established Patterns
+
+- Vault settings blob is ECIES-encrypted with user's secp256k1 publicKey (same as BYO config, vault key blob)
+- IPNS resolution goes through CipherBox backend API, not direct DHT
+- Desktop stores in-memory state in `KeyState` (Arc<RwLock<...>> pattern)
+- Cross-platform test vectors in `tests/vectors/` JSON files verify TypeScript/Rust parity
+
+### Integration Points
+
+- `crates/crypto/src/hkdf.rs` — add new info string + derivation function
+- `crates/core/src/` — add new `vault_settings.rs` module with type + validation
+- `crates/sdk/src/state.rs` — add VaultSettings to KeyState or new struct
+- `apps/desktop/src-tauri/src/commands/auth.rs` — load settings in `complete_auth_setup()`
+- `crates/fuse/src/constants.rs` — replace hardcoded values with loaded settings
+- `tests/vectors/` — add vault-settings derivation test vector
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Note: the encrypted vault settings blob uses the same format as BYO-IPFS config (JSON -> ECIES wrapKey -> IPFS), NOT the folder metadata format (JSON -> AES-GCM encrypt). The decrypt path uses `unwrapKey` (ECIES), not `decrypt_metadata_from_ipfs_public` (AES-GCM).
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- Settings save/edit UI in desktop app (users configure via web only for now)
+- Real-time settings polling (load-once-at-login is sufficient initially)
+
+</deferred>
+
+---
+
+_Phase: 40-desktop-vault-settings-integration_
+_Context gathered: 2026-03-31_

--- a/.planning/phases/40-desktop-vault-settings-integration/40-RESEARCH.md
+++ b/.planning/phases/40-desktop-vault-settings-integration/40-RESEARCH.md
@@ -1,0 +1,555 @@
+# Phase 40: Desktop vault settings integration - Research
+
+**Researched:** 2026-03-31
+**Domain:** Rust SDK / Desktop FUSE / Cross-language crypto parity
+**Confidence:** HIGH
+
+## Summary
+
+Phase 40 propagates user-configurable vault settings (created in Phase 39's TypeScript web app) to the Rust SDK and desktop app. The work is a mechanical replication of three established patterns: (1) HKDF IPNS keypair derivation (5 existing derivation functions in `crates/crypto/src/hkdf.rs`), (2) IPNS-resolve-then-ECIES-decrypt loading (as done for vault key blob and BYO config), and (3) cross-language test vectors (existing JSON-based parity framework in `tests/vectors/`).
+
+The implementation touches four Rust crates (`crypto`, `core`, `fuse`, `sdk`) and the desktop app's auth flow. The FUSE crate currently uses two hardcoded constants (`MAX_VERSIONS_PER_FILE = 10`, `VERSION_COOLDOWN_MS = 15 * 60 * 1000`) that must be replaced with values loaded from the user's encrypted vault settings. The settings blob format is ECIES-encrypted JSON (same as BYO config), NOT AES-GCM encrypted (which is used for folder metadata). This distinction is critical.
+
+**Primary recommendation:** Follow the exact existing patterns for each layer. No new libraries or architectural changes needed. The work is purely additive Rust code mirroring well-tested TypeScript implementations with cross-language vector verification.
+
+<user_constraints>
+
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+- **D-01:** Add `VAULT_SETTINGS_HKDF_INFO = b"cipherbox-vault-settings-v1"` to `crates/crypto/src/hkdf.rs` and implement `derive_vault_settings_ipns_keypair()` following the existing pattern. Must produce identical IPNS names as the TypeScript `deriveVaultSettingsIpnsKeypair()` -- verify with shared test vectors.
+
+- **D-02:** Add `VaultSettings` struct to `crates/core` matching the TypeScript type: `version`, `recycleBinRetentionDays`, `deleteBehavior`, `maxVersionsPerFile`, `versionCooldownMinutes`. Include `validateVaultSettings()` with same clamping rules (0-365, 0-100, 0-1440) and unknown-version guard.
+
+- **D-03:** Load vault settings in `complete_auth_setup()` alongside vault key decryption. Pattern: derive IPNS keypair -> resolve IPNS -> fetch from IPFS -> ECIES decrypt with userPrivateKey -> parse JSON -> validate. Graceful fallback to defaults on any failure (same as web app).
+
+- **D-04:** Replace hardcoded `MAX_VERSIONS_PER_FILE` and `VERSION_COOLDOWN_MS` in `crates/fuse/src/constants.rs` with values loaded from VaultSettings. Store settings in `KeyState` or a new `VaultSettingsState` accessible to the FUSE mount.
+
+- **D-05:** Desktop app only reads vault settings (no save/edit UI). Users configure settings via the web app's Vault tab. Desktop picks up changes on next login or when IPNS polling detects an update.
+
+### Claude's Discretion
+
+- Whether to add VaultSettings to existing `KeyState` or create a separate state struct
+- Whether to add IPNS polling for settings changes (vs load-once-at-login)
+- Error handling granularity for settings load failures
+- Test vector file format and location
+
+### Deferred Ideas (OUT OF SCOPE)
+
+- Settings save/edit UI in desktop app (users configure via web only for now)
+- Real-time settings polling (load-once-at-login is sufficient initially)
+
+</user_constraints>
+
+## Standard Stack
+
+### Core
+
+No new dependencies needed. The phase uses only existing crates already in the Cargo workspace.
+
+| Library                | Version   | Purpose                                 | Why Standard                            |
+| ---------------------- | --------- | --------------------------------------- | --------------------------------------- |
+| `cipherbox-crypto`     | workspace | HKDF derivation, ECIES unwrap           | Already has 5 HKDF derivation functions |
+| `cipherbox-core`       | workspace | Domain types (new VaultSettings module) | All CipherBox domain types live here    |
+| `cipherbox-sdk`        | workspace | KeyState management                     | Holds all in-memory key/config state    |
+| `cipherbox-fuse`       | workspace | FUSE constants, CipherBoxFS struct      | Where versioning logic lives            |
+| `cipherbox-api-client` | workspace | IPNS resolve, IPFS fetch                | HTTP calls to backend                   |
+| `serde` / `serde_json` | workspace | JSON deserialization of settings blob   | Standard Rust serialization             |
+
+### Supporting
+
+| Library   | Version   | Purpose                          | When to Use                                 |
+| --------- | --------- | -------------------------------- | ------------------------------------------- |
+| `zeroize` | workspace | Clear sensitive data from memory | When handling decrypted settings blob bytes |
+| `hex`     | workspace | Hex encoding for test vectors    | In cross-language test assertions           |
+
+### Alternatives Considered
+
+None. All libraries are already in the workspace and are the only sensible choice.
+
+## Architecture Patterns
+
+### Recommended Project Structure (new/modified files)
+
+```
+crates/
+  crypto/src/
+    hkdf.rs                    # ADD: VAULT_SETTINGS_HKDF_INFO + derive_vault_settings_ipns_keypair()
+    lib.rs                     # ADD: re-export derive_vault_settings_ipns_keypair
+  core/src/
+    vault_settings.rs          # NEW: VaultSettings struct, DEFAULT_VAULT_SETTINGS, validate_vault_settings()
+    lib.rs                     # ADD: pub mod vault_settings, re-exports
+  sdk/src/
+    state.rs                   # ADD: vault_settings field to KeyState
+  fuse/src/
+    constants.rs               # MODIFY: make constants non-const or remove, add configurable fields
+    lib.rs                     # ADD: vault settings fields to CipherBoxFS struct
+    read_ops.rs                # MODIFY: use fs.max_versions_per_file / fs.version_cooldown_ms instead of constants
+    platform/windows/write_ops.rs  # MODIFY: same as read_ops.rs
+apps/desktop/
+  src-tauri/src/
+    commands/auth.rs           # MODIFY: load vault settings in complete_auth_setup()
+    commands/vault.rs          # ADD: load_vault_settings() helper function
+    fuse/mod.rs                # MODIFY: pass vault settings to CipherBoxFS
+tests/vectors/crypto/
+  hkdf.json                   # ADD: vault-settings test vector entry
+```
+
+### Pattern 1: HKDF Derivation (copy existing pattern exactly)
+
+**What:** Add a new constant + public function following the identical pattern of the 5 existing derivations.
+**When to use:** Adding any new IPNS-addressed content type.
+**Example:**
+
+```rust
+// Source: crates/crypto/src/hkdf.rs (existing pattern)
+/// HKDF info for vault settings IPNS keypair derivation.
+const VAULT_SETTINGS_HKDF_INFO: &[u8] = b"cipherbox-vault-settings-v1";
+
+/// Derive the deterministic Ed25519 IPNS keypair for vault settings.
+///
+/// Uses HKDF info "cipherbox-vault-settings-v1" for domain separation.
+pub fn derive_vault_settings_ipns_keypair(
+    user_private_key: &[u8; 32],
+) -> Result<(Zeroizing<Vec<u8>>, Vec<u8>, String), CryptoError> {
+    derive_ipns_keypair(user_private_key, VAULT_SETTINGS_HKDF_INFO)
+}
+```
+
+### Pattern 2: VaultSettings Type (mirror TypeScript exactly)
+
+**What:** Rust struct with serde deserialization matching the TypeScript `VaultSettings` type.
+**When to use:** Any domain type that must round-trip between TypeScript and Rust.
+**Example:**
+
+```rust
+// Source: packages/core/src/vault/types.ts (TypeScript reference)
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VaultSettings {
+    pub version: String,
+    #[serde(rename = "recycleBinRetentionDays")]
+    pub recycle_bin_retention_days: u32,
+    #[serde(rename = "deleteBehavior")]
+    pub delete_behavior: DeleteBehavior,
+    #[serde(rename = "maxVersionsPerFile")]
+    pub max_versions_per_file: u32,
+    #[serde(rename = "versionCooldownMinutes")]
+    pub version_cooldown_minutes: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum DeleteBehavior {
+    Bin,
+    Permanent,
+}
+```
+
+### Pattern 3: ECIES Decrypt Load Flow (same as BYO config / vault key blob)
+
+**What:** Derive IPNS keypair, resolve IPNS to CID, fetch IPFS, ECIES unwrap, parse JSON.
+**When to use:** Loading any zero-knowledge encrypted config stored on IPFS.
+**Example:**
+
+```rust
+// Source: apps/desktop/src-tauri/src/commands/vault.rs (existing pattern)
+pub async fn load_vault_settings(
+    api: &ApiClient,
+    private_key: &[u8; 32],
+) -> VaultSettings {
+    let result: Result<VaultSettings, String> = async {
+        let (_priv, _pub, ipns_name) =
+            cipherbox_crypto::hkdf::derive_vault_settings_ipns_keypair(private_key)
+                .map_err(|e| format!("HKDF: {:?}", e))?;
+        let resolved = cipherbox_api_client::ipns::resolve_ipns(api, &ipns_name)
+            .await.map_err(|e| format!("{}", e))?;
+        let encrypted = cipherbox_api_client::ipfs::fetch_content(api, &resolved.cid)
+            .await.map_err(|e| format!("{}", e))?;
+        let plaintext = cipherbox_crypto::ecies::unwrap_key(&encrypted, private_key)
+            .map_err(|e| format!("ECIES: {:?}", e))?;
+        let parsed: serde_json::Value = serde_json::from_slice(&plaintext)
+            .map_err(|e| format!("JSON: {}", e))?;
+        Ok(cipherbox_core::vault_settings::validate_vault_settings(&parsed))
+    }.await;
+
+    match result {
+        Ok(settings) => settings,
+        Err(e) => {
+            log::warn!("Vault settings load failed (using defaults): {}", e);
+            cipherbox_core::vault_settings::DEFAULT_VAULT_SETTINGS
+        }
+    }
+}
+```
+
+### Pattern 4: CipherBoxFS Configurable Fields (replacing constants)
+
+**What:** Add fields to CipherBoxFS struct, pass values from mount setup, use in version logic.
+**When to use:** Replacing any hardcoded constant with user-configurable value.
+**Example:**
+
+```rust
+// In CipherBoxFS struct (crates/fuse/src/lib.rs)
+pub max_versions_per_file: usize,
+pub version_cooldown_ms: u64,
+
+// In read_ops.rs / write_ops.rs, change:
+//   now_ms.saturating_sub(newest.timestamp) >= VERSION_COOLDOWN_MS
+// to:
+//   now_ms.saturating_sub(newest.timestamp) >= fs.version_cooldown_ms
+
+// In read_ops.rs / write_ops.rs, change:
+//   if versions.len() > MAX_VERSIONS_PER_FILE
+// to:
+//   if versions.len() > fs.max_versions_per_file
+```
+
+### Anti-Patterns to Avoid
+
+- **Using AES-GCM decrypt for vault settings:** Vault settings use ECIES (wrapKey/unwrapKey), NOT AES-GCM. The `decrypt_metadata_from_ipfs_public()` function is for folder metadata only.
+- **Making settings load failure fatal:** The web app gracefully falls back to defaults on any settings load error. The desktop must do the same.
+- **Blocking the FUSE thread for settings:** Settings are loaded during auth, before FUSE mount. Never load settings lazily from a FUSE callback.
+- **Using `snake_case` JSON field names:** The TypeScript serializes with `camelCase` field names (`maxVersionsPerFile`). Use `#[serde(rename = "...")]` or `#[serde(rename_all = "camelCase")]` on the Rust struct.
+
+## Don't Hand-Roll
+
+| Problem                | Don't Build           | Use Instead                                          | Why                                                |
+| ---------------------- | --------------------- | ---------------------------------------------------- | -------------------------------------------------- |
+| HKDF-SHA256 derivation | Custom HKDF           | `crate::hkdf::derive_ipns_keypair()` internal helper | Already exists, battle-tested, handles zeroization |
+| ECIES decryption       | Manual ECIES          | `cipherbox_crypto::ecies::unwrap_key()`              | Cross-compatible with `eciesjs` npm package        |
+| JSON field name casing | Manual rename         | `#[serde(rename_all = "camelCase")]`                 | Automatic, less error-prone                        |
+| Validation clamping    | Manual if/else chains | Dedicated `validate_vault_settings()` function       | Mirrors TypeScript exactly, testable               |
+
+## Common Pitfalls
+
+### Pitfall 1: ECIES vs AES-GCM Decrypt Confusion
+
+**What goes wrong:** Using `decrypt_metadata_from_ipfs_public()` (AES-GCM) to decrypt vault settings (ECIES-encrypted).
+**Why it happens:** Both follow "fetch from IPFS -> decrypt" pattern but use different crypto.
+**How to avoid:** The CONTEXT.md explicitly notes the settings blob uses `unwrapKey` (ECIES), not `decrypt_metadata_from_ipfs_public` (AES-GCM).
+**Warning signs:** Decryption error on valid settings blob, "AES-GCM tag mismatch" error.
+
+### Pitfall 2: JSON Field Name Casing Mismatch
+
+**What goes wrong:** Rust deserialization fails because TypeScript writes `maxVersionsPerFile` but Rust struct has `max_versions_per_file`.
+**Why it happens:** Rust conventions use snake_case, TypeScript uses camelCase.
+**How to avoid:** Use `#[serde(rename_all = "camelCase")]` on the struct or individual `#[serde(rename = "...")]` attributes.
+**Warning signs:** Serde parse error "missing field", all settings fall back to defaults.
+
+### Pitfall 3: Constants Used in Both macOS and Windows Code Paths
+
+**What goes wrong:** Updating `read_ops.rs` but forgetting `platform/windows/write_ops.rs`.
+**Why it happens:** The versioning logic is duplicated across platform-specific write operation files.
+**How to avoid:** Search for ALL usages of `MAX_VERSIONS_PER_FILE` and `VERSION_COOLDOWN_MS` before marking done.
+**Warning signs:** Hardcoded values still in Windows code path after changes.
+
+**Files using these constants:**
+
+- `crates/fuse/src/read_ops.rs:19` (import), lines 728, 749-750, 755
+- `crates/fuse/src/platform/windows/write_ops.rs:16` (import), lines 750, 771-772
+
+### Pitfall 4: Version Cooldown Unit Mismatch
+
+**What goes wrong:** `versionCooldownMinutes` is in minutes (TypeScript/settings), but `VERSION_COOLDOWN_MS` is in milliseconds (Rust FUSE).
+**Why it happens:** Different units at different layers.
+**How to avoid:** Convert minutes to milliseconds when storing in CipherBoxFS: `settings.version_cooldown_minutes as u64 * 60 * 1000`.
+**Warning signs:** Cooldown is either way too short (using raw minutes as ms) or way too long (double conversion).
+
+### Pitfall 5: Test Vector Must Be Generated from TypeScript First
+
+**What goes wrong:** Writing the Rust derivation function and test, but no cross-language verification.
+**Why it happens:** The test vector for `cipherbox-vault-settings-v1` does not yet exist in `tests/vectors/crypto/hkdf.json`.
+**How to avoid:** Generate the expected output from TypeScript first (run the existing `@cipherbox/crypto` vault-settings test with a known key), add to the shared vectors JSON, then verify Rust produces identical output.
+**Warning signs:** Rust tests pass in isolation but cross-language parity test panics with "Unknown HKDF info string: cipherbox-vault-settings-v1".
+
+### Pitfall 6: IPNS Resolve 404 for New Users
+
+**What goes wrong:** New users (or users who never configured settings via web) have no IPNS record for vault settings. `resolve_ipns()` returns `IpnsNotFound` error.
+**Why it happens:** Settings IPNS record only exists after the user saves settings in the web app.
+**How to avoid:** Catch `IpnsNotFound` (or any error) and fall back to `DEFAULT_VAULT_SETTINGS`. This is the same pattern the web app uses.
+**Warning signs:** Login fails for users who haven't configured vault settings.
+
+## Code Examples
+
+### Existing HKDF Pattern (verified from source)
+
+```rust
+// Source: crates/crypto/src/hkdf.rs lines 27-36 (existing constants)
+const VAULT_HKDF_INFO: &[u8] = b"cipherbox-vault-ipns-v1";
+const VAULT_KEY_HKDF_INFO: &[u8] = b"cipherbox-vault-key-ipns-v1";
+const REGISTRY_HKDF_INFO: &[u8] = b"cipherbox-device-registry-ipns-v1";
+const BIN_HKDF_INFO: &[u8] = b"cipherbox-recycle-bin-ipns-v1";
+const FILE_HKDF_INFO_PREFIX: &str = "cipherbox-file-ipns-v1:";
+
+// Source: crates/crypto/src/hkdf.rs lines 81-85 (vault derivation)
+pub fn derive_vault_ipns_keypair(
+    user_private_key: &[u8; 32],
+) -> Result<(Zeroizing<Vec<u8>>, Vec<u8>, String), CryptoError> {
+    derive_ipns_keypair(user_private_key, VAULT_HKDF_INFO)
+}
+```
+
+### Existing ECIES Unwrap (verified from source)
+
+```rust
+// Source: crates/crypto/src/ecies.rs lines 35-46
+pub fn unwrap_key(wrapped: &[u8], private_key: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    if private_key.len() != SECP256K1_PRIVATE_KEY_SIZE {
+        return Err(CryptoError::InvalidPrivateKey);
+    }
+    if wrapped.len() < ECIES_MIN_CIPHERTEXT_SIZE {
+        return Err(CryptoError::EciesUnwrappingFailed);
+    }
+    ecies::decrypt(private_key, wrapped).map_err(|_| CryptoError::EciesUnwrappingFailed)
+}
+```
+
+### Existing Vault Key Load Pattern (verified from source)
+
+```rust
+// Source: apps/desktop/src-tauri/src/commands/vault.rs lines 190-208
+// Resolve vault key IPNS, fetch v2 blob, extract rootFolderKey
+let resolved = cipherbox_api_client::ipns::resolve_ipns(&state.sdk.api, &vault_key_ipns_name)
+    .await.map_err(|e| format!("Vault key IPNS resolve failed: {}", e))?;
+let blob_bytes = cipherbox_api_client::ipfs::fetch_content(&state.sdk.api, &resolved.cid)
+    .await.map_err(|e| format!("IPFS fetch failed for vault key blob: {}", e))?;
+```
+
+### TypeScript VaultSettings Load (reference for Rust port)
+
+```typescript
+// Source: apps/web/src/services/vault-settings.service.ts lines 38-68
+export async function loadVaultSettings(userPrivateKey: Uint8Array): Promise<VaultSettings> {
+  const inner = async (): Promise<VaultSettings> => {
+    const keypair = await deriveVaultSettingsIpnsKeypair(userPrivateKey);
+    const resolved = await resolveIpnsRecord(keypair.ipnsName);
+    if (!resolved?.cid) return { ...DEFAULT_VAULT_SETTINGS };
+    const encrypted = await fetchFromIpfs(resolved.cid);
+    const plaintext = await unwrapKey(encrypted, userPrivateKey);
+    let parsed: unknown;
+    try {
+      const json = new TextDecoder().decode(plaintext);
+      parsed = JSON.parse(json);
+    } finally {
+      clearBytes(plaintext);
+    }
+    return validateVaultSettings(parsed);
+  };
+  try {
+    const result = await Promise.race([
+      inner(),
+      new Promise<VaultSettings>((resolve) =>
+        setTimeout(() => resolve({ ...DEFAULT_VAULT_SETTINGS }), LOAD_TIMEOUT_MS)
+      ),
+    ]);
+    return result;
+  } catch {
+    return { ...DEFAULT_VAULT_SETTINGS };
+  }
+}
+```
+
+### Existing CipherBoxFS Struct Fields (where to add settings)
+
+```rust
+// Source: crates/fuse/src/lib.rs lines 470-498
+pub struct CipherBoxFS {
+    pub inodes: inode::InodeTable,
+    pub metadata_cache: cache::MetadataCache,
+    pub content_cache: cache::ContentCache,
+    pub api: Arc<ApiClient>,
+    pub private_key: Zeroizing<Vec<u8>>,
+    pub public_key: Zeroizing<Vec<u8>>,
+    pub root_folder_key: Zeroizing<Vec<u8>>,
+    pub root_ipns_name: String,
+    pub rt: tokio::runtime::Handle,
+    // ... (channels, caches, coordinator)
+    pub tee_public_key: Option<Vec<u8>>,
+    pub tee_key_epoch: Option<u32>,
+    // ADD HERE:
+    // pub max_versions_per_file: usize,
+    // pub version_cooldown_ms: u64,
+}
+```
+
+### Cross-Language Test Vector Format (verified from source)
+
+```json
+// Source: tests/vectors/crypto/hkdf.json (add new entry)
+{
+  "description": "HKDF vault settings IPNS keypair derivation (info: cipherbox-vault-settings-v1)",
+  "private_key": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+  "info": "cipherbox-vault-settings-v1",
+  "expected_ed25519_private_key": "<generate from TypeScript>",
+  "expected_ed25519_public_key": "<generate from TypeScript>",
+  "expected_ipns_name": "<generate from TypeScript>"
+}
+```
+
+### Cross-Language Test Router (add new match arm)
+
+```rust
+// Source: crates/crypto/tests/cross_language.rs lines 200-218
+// Add new match arm:
+"cipherbox-vault-settings-v1" => {
+    cipherbox_crypto::derive_vault_settings_ipns_keypair(&pk).unwrap()
+}
+```
+
+## Discretion Recommendations
+
+### VaultSettings in KeyState (Recommended: Add to existing KeyState)
+
+**Recommendation:** Add a `vault_settings` field to `KeyState` rather than creating a separate struct.
+
+**Rationale:**
+
+- `KeyState` already holds all auth-time loaded state (private key, root folder key, root IPNS name, TEE keys)
+- Vault settings are loaded during `complete_auth_setup()` alongside these other values
+- The settings are cleared on logout (same lifecycle as KeyState fields)
+- Adding a separate struct would require a second `Arc<RwLock<...>>` in `AppState` with identical lifecycle management
+- The field type should be `RwLock<VaultSettings>` (non-optional, defaults to `DEFAULT_VAULT_SETTINGS`)
+
+### IPNS Polling for Settings (Recommended: Load-once-at-login only)
+
+**Recommendation:** Load-once-at-login is sufficient. Skip IPNS polling for settings.
+
+**Rationale:**
+
+- Settings change rarely (user action in web app required)
+- Desktop picks up new settings on next login
+- Polling adds complexity for minimal benefit
+- Deferred in CONTEXT.md scope anyway
+
+### Error Handling Granularity (Recommended: Single catch-all with log)
+
+**Recommendation:** Wrap the entire load flow in a single `match/Err` that logs the error and returns defaults.
+
+**Rationale:**
+
+- Mirrors the TypeScript pattern exactly (try/catch returning defaults)
+- Granular error handling provides no user-facing benefit (settings are invisible to users)
+- Log the error for debugging but never fail auth over settings
+
+### Test Vector Format (Recommended: Add entry to existing hkdf.json)
+
+**Recommendation:** Add a single new entry to `tests/vectors/crypto/hkdf.json` with the `cipherbox-vault-settings-v1` info string.
+
+**Rationale:**
+
+- All HKDF derivation test vectors live in one file
+- Cross-language test already iterates all entries with info-string routing
+- Adding a new file would require loader changes in both TypeScript and Rust
+- Generate expected values by running TypeScript derivation with the standard test key (`0102...1f20`)
+
+## State of the Art
+
+| Old Approach                            | Current Approach                     | When Changed                        | Impact                             |
+| --------------------------------------- | ------------------------------------ | ----------------------------------- | ---------------------------------- |
+| Hardcoded `MAX_VERSIONS_PER_FILE = 10`  | User-configurable via vault settings | Phase 39 (web) + Phase 40 (desktop) | Users can tune versioning behavior |
+| Hardcoded `VERSION_COOLDOWN_MS = 15min` | User-configurable via vault settings | Phase 39 (web) + Phase 40 (desktop) | Users can tune version cooldown    |
+| No vault settings concept               | Encrypted IPNS-stored settings blob  | Phase 39                            | Zero-knowledge user preferences    |
+
+## Validation Architecture
+
+### Test Framework
+
+| Property           | Value                                                                                                |
+| ------------------ | ---------------------------------------------------------------------------------------------------- |
+| Framework          | cargo test (Rust) + vitest (TypeScript cross-reference)                                              |
+| Config file        | Cargo.toml workspace settings                                                                        |
+| Quick run command  | `cargo test -p cipherbox-crypto -- vault_settings && cargo test -p cipherbox-core -- vault_settings` |
+| Full suite command | `cargo test --workspace`                                                                             |
+
+### Phase Requirements -> Test Map
+
+No formal requirement IDs for this phase (follow-up to Phase 39), but the following behaviors need verification:
+
+| Behavior                                        | Test Type   | Automated Command                                              | File Exists?              |
+| ----------------------------------------------- | ----------- | -------------------------------------------------------------- | ------------------------- |
+| HKDF derivation produces valid 32-byte keys     | unit        | `cargo test -p cipherbox-crypto -- vault_settings`             | No (Wave 0)               |
+| Cross-language HKDF parity with TypeScript      | unit        | `cargo test -p cipherbox-crypto --test cross_language -- hkdf` | Yes (needs new match arm) |
+| VaultSettings default values correct            | unit        | `cargo test -p cipherbox-core -- vault_settings`               | No (Wave 0)               |
+| validate_vault_settings clamps out-of-range     | unit        | `cargo test -p cipherbox-core -- vault_settings`               | No (Wave 0)               |
+| validate_vault_settings handles corrupt input   | unit        | `cargo test -p cipherbox-core -- vault_settings`               | No (Wave 0)               |
+| CipherBoxFS uses configurable versioning values | integration | Compile-time verification (constants removed)                  | N/A                       |
+
+### Sampling Rate
+
+- **Per task commit:** `cargo test -p cipherbox-crypto -- vault_settings && cargo test -p cipherbox-core -- vault_settings`
+- **Per wave merge:** `cargo test --workspace`
+- **Phase gate:** Full suite green before `/gsd:verify-work`
+
+### Wave 0 Gaps
+
+- [ ] `crates/crypto/src/hkdf.rs` -- add `derive_vault_settings` unit tests
+- [ ] `crates/crypto/tests/cross_language.rs` -- add `cipherbox-vault-settings-v1` match arm
+- [ ] `tests/vectors/crypto/hkdf.json` -- add vault-settings test vector (generated from TypeScript)
+- [ ] `crates/core/src/vault_settings.rs` -- add unit tests for defaults, validation, clamping
+
+## Environment Availability
+
+Step 2.6: SKIPPED (no external dependencies identified). This phase is purely code/config changes within the existing Rust/TypeScript workspace. All tools (cargo, pnpm, rustc) are confirmed available.
+
+## Project Constraints (from CLAUDE.md)
+
+- **Terminology:** Use `privateKey`, `publicKey` (not `privkey`, `pubkey`)
+- **Security:** Never store `privateKey` in persistent storage; use `Uint8Array` for binary data; clear sensitive data from memory
+- **Code:** TypeScript for JS code, `camelCase` for API fields, `snake_case` for database columns
+- **API workflow:** Run `pnpm api:generate` after modifying API endpoints (not applicable here -- no API changes)
+- **Git:** Never push directly to `main`; use feature branches; conventional commits
+- **ECIES for key wrapping:** Always use ECIES for key wrapping (confirmed for vault settings blob)
+- **AES-256-GCM for content encryption:** Only for file/folder content, NOT for vault settings
+- **Desktop defaults to staging API:** No need for local API for testing
+
+## Open Questions
+
+1. **Test vector generation timing**
+   - What we know: The vault-settings HKDF test vector must be generated from the TypeScript reference implementation using the standard test key `0102...1f20`.
+   - What's unclear: Whether to generate it in Wave 0 via a vitest helper script or manually compute and hardcode it.
+   - Recommendation: Use a simple vitest test with `console.log` to output the expected hex values, then add to `hkdf.json`. This ensures TypeScript is the source of truth.
+
+## Sources
+
+### Primary (HIGH confidence)
+
+- `crates/crypto/src/hkdf.rs` -- All 5 existing HKDF derivation functions (pattern template)
+- `crates/crypto/src/ecies.rs` -- ECIES unwrap_key (decryption primitive)
+- `crates/fuse/src/constants.rs` -- Current hardcoded MAX_VERSIONS_PER_FILE and VERSION_COOLDOWN_MS
+- `crates/fuse/src/lib.rs` -- CipherBoxFS struct definition with all current fields
+- `crates/sdk/src/state.rs` -- KeyState struct definition
+- `crates/fuse/src/read_ops.rs` -- Versioning logic using constants (macOS/Linux)
+- `crates/fuse/src/platform/windows/write_ops.rs` -- Versioning logic using constants (Windows)
+- `packages/crypto/src/vault/derive-ipns.ts` -- TypeScript reference for deriveVaultSettingsIpnsKeypair
+- `packages/core/src/vault/settings.ts` -- TypeScript reference for VaultSettings type and validation
+- `packages/core/src/vault/types.ts` -- TypeScript VaultSettings type definition
+- `apps/web/src/services/vault-settings.service.ts` -- TypeScript reference for loadVaultSettings pattern
+- `apps/desktop/src-tauri/src/commands/auth.rs` -- complete_auth_setup() integration point
+- `apps/desktop/src-tauri/src/commands/vault.rs` -- fetch_and_decrypt_vault() pattern reference
+- `apps/desktop/src-tauri/src/fuse/mod.rs` -- mount_filesystem() where CipherBoxFS is constructed
+- `crates/api-client/src/ipns.rs` -- resolve_ipns() function
+- `crates/api-client/src/ipfs.rs` -- fetch_content() function
+- `tests/vectors/crypto/hkdf.json` -- Existing cross-language test vector format
+- `crates/crypto/tests/cross_language.rs` -- Cross-language test with info-string routing
+
+### Secondary (MEDIUM confidence)
+
+- None required. All findings are from direct source code inspection.
+
+### Tertiary (LOW confidence)
+
+- None. No external research needed for this phase.
+
+## Metadata
+
+**Confidence breakdown:**
+
+- Standard stack: HIGH -- all libraries already in workspace, no new dependencies
+- Architecture: HIGH -- 100% based on existing patterns in codebase (5 HKDF functions, vault key load, BYO config load)
+- Pitfalls: HIGH -- all identified from direct source code analysis of exact files being modified
+
+**Research date:** 2026-03-31
+**Valid until:** 2026-04-30 (stable; all patterns are internal to the project)

--- a/.planning/phases/40-desktop-vault-settings-integration/40-VALIDATION.md
+++ b/.planning/phases/40-desktop-vault-settings-integration/40-VALIDATION.md
@@ -1,0 +1,78 @@
+---
+phase: 40
+slug: desktop-vault-settings-integration
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-03-31
+---
+
+# Phase 40 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property               | Value                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Framework**          | vitest (TS), cargo test (Rust)                                                                               |
+| **Config file**        | `vitest.config.ts`, `Cargo.toml` (workspace)                                                                 |
+| **Quick run command**  | `cargo test -p cipherbox-crypto -p cipherbox-core --lib && pnpm --filter @cipherbox/crypto test`             |
+| **Full suite command** | `cargo test -p cipherbox-crypto -p cipherbox-core -p cipherbox-fuse && pnpm --filter @cipherbox/crypto test` |
+| **Estimated runtime**  | ~30 seconds                                                                                                  |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run quick run command
+- **After every plan wave:** Run full suite command
+- **Before `/gsd:verify-work`:** Full suite must be green
+- **Max feedback latency:** 30 seconds
+
+---
+
+## Per-Task Verification Map
+
+| Task ID  | Plan | Wave | Requirement | Test Type   | Automated Command                                      | File Exists | Status     |
+| -------- | ---- | ---- | ----------- | ----------- | ------------------------------------------------------ | ----------- | ---------- |
+| 40-01-01 | 01   | 1    | N/A         | unit        | `cargo test -p cipherbox-crypto derive_vault_settings` | ❌ W0       | ⬜ pending |
+| 40-01-02 | 01   | 1    | N/A         | unit        | `cargo test -p cipherbox-core vault_settings`          | ❌ W0       | ⬜ pending |
+| 40-02-01 | 02   | 2    | N/A         | integration | `cargo test -p cipherbox-fuse vault_settings`          | ❌ W0       | ⬜ pending |
+| 40-02-02 | 02   | 2    | N/A         | cross-lang  | `cargo test -p cipherbox-crypto hkdf_vector`           | ❌ W0       | ⬜ pending |
+
+_Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky_
+
+---
+
+## Wave 0 Requirements
+
+- [ ] Cross-language HKDF test vector for `cipherbox-vault-settings-v1` context string
+- [ ] Rust unit test stubs for `derive_vault_settings_ipns_keypair()`
+- [ ] Rust unit test stubs for `VaultSettings` type and deserialization
+
+_Existing vitest and cargo test infrastructure covers framework needs._
+
+---
+
+## Manual-Only Verifications
+
+| Behavior                                     | Requirement | Why Manual                             | Test Instructions                                                          |
+| -------------------------------------------- | ----------- | -------------------------------------- | -------------------------------------------------------------------------- |
+| Desktop login loads vault settings from IPNS | N/A         | Requires running desktop app with auth | Start desktop app, login, verify settings loaded in FUSE log output        |
+| FUSE respects loaded MAX_VERSIONS_PER_FILE   | N/A         | Requires mounted FUSE filesystem       | Mount, create file, modify N+1 times, verify version count matches setting |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 30s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/40-desktop-vault-settings-integration/40-VERIFICATION.md
+++ b/.planning/phases/40-desktop-vault-settings-integration/40-VERIFICATION.md
@@ -1,0 +1,101 @@
+---
+phase: 40-desktop-vault-settings-integration
+verified: 2026-03-31T14:00:00Z
+status: passed
+score: 9/9 must-haves verified
+---
+
+# Phase 40: Desktop Vault Settings Integration Verification Report
+
+**Phase Goal:** Propagate user-configurable vault settings (from Phase 39) to the Rust SDK and desktop app. Add `derive_vault_settings_ipns_keypair()` to `crates/crypto`, add `VaultSettings` type to `crates/core`, load and decrypt settings during desktop login, and wire loaded values into FUSE operations replacing hardcoded `MAX_VERSIONS_PER_FILE` and `VERSION_COOLDOWN_MS` constants.
+**Verified:** 2026-03-31T14:00:00Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| #   | Truth                                                                                                                                   | Status   | Evidence                                                                                                                                                                                                                                                                                                      |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `derive_vault_settings_ipns_keypair()` produces valid 32-byte Ed25519 keys and a k51-prefixed IPNS name                                 | VERIFIED | `crates/crypto/src/hkdf.rs:139` — function exists; unit tests `derive_vault_settings_returns_32_byte_keys`, `derive_vault_settings_is_deterministic`, `vault_settings_differs_from_other_derivations` all pass (3 passed)                                                                                     |
+| 2   | Rust HKDF derivation with info `cipherbox-vault-settings-v1` produces identical output to TypeScript `deriveVaultSettingsIpnsKeypair()` | VERIFIED | Cross-language vector at `tests/vectors/crypto/hkdf.json:43-48` populated from TypeScript; `cargo test -p cipherbox-crypto --test cross_language -- hkdf` passes (1/1)                                                                                                                                        |
+| 3   | `VaultSettings` struct deserializes camelCase JSON from TypeScript correctly                                                            | VERIFIED | `crates/core/src/vault_settings.rs:21` — `#[serde(rename_all = "camelCase")]` on struct; 13 unit tests pass including serde round-trip confirming `"maxVersionsPerFile"` JSON key                                                                                                                             |
+| 4   | `validate_vault_settings()` clamps out-of-range values and returns defaults for corrupt input                                           | VERIFIED | `crates/core/src/vault_settings.rs:51`; tests for clamping retention (0-365), versions (0-100), cooldown (0-1440), null input, unknown version, missing fields — all 13 pass                                                                                                                                  |
+| 5   | Desktop app loads vault settings during login via IPNS resolve + ECIES decrypt                                                          | VERIFIED | `apps/desktop/src-tauri/src/commands/auth.rs:95-201` — `load_vault_settings()` uses `cipherbox_api_client::ipns::resolve_ipns` + `cipherbox_api_client::ipfs::fetch_content` + `cipherbox_crypto::ecies::unwrap_key` + `cipherbox_core::validate_vault_settings`; called in `complete_auth_setup` at line 200 |
+| 6   | Login succeeds with default settings when no IPNS record exists (new user or never configured)                                          | VERIFIED | `auth.rs:138-140` — `Err(e)` branch logs warning and returns `cipherbox_core::default_vault_settings()`; any error in the 5-step chain falls back to defaults                                                                                                                                                 |
+| 7   | FUSE versioning uses user-configured `maxVersionsPerFile` instead of hardcoded 10                                                       | VERIFIED | `crates/fuse/src/read_ops.rs:747-753` uses `fs.max_versions_per_file`; `crates/fuse/src/platform/windows/write_ops.rs:771-772` uses `fs.max_versions_per_file`; no remaining bare `MAX_VERSIONS_PER_FILE` references in either file                                                                           |
+| 8   | FUSE versioning uses user-configured `versionCooldownMinutes` (converted to ms) instead of hardcoded 15 minutes                         | VERIFIED | `auth.rs:266` — `version_cooldown_minutes as u64 * 60 * 1000` conversion; `read_ops.rs:726` uses `fs.version_cooldown_ms`; `windows/write_ops.rs:750` uses `fs.version_cooldown_ms`                                                                                                                           |
+| 9   | Settings are accessible from both macOS and Windows FUSE code paths                                                                     | VERIFIED | macOS `apps/desktop/src-tauri/src/fuse/mod.rs:60-61,203` — new params in signature and CipherBoxFS construction; Windows `apps/desktop/src-tauri/src/fuse/windows/mod.rs:46-47,338-339` — same params in both places                                                                                          |
+
+**Score:** 9/9 truths verified
+
+### Required Artifacts
+
+| Artifact                                         | Expected                                                                                   | Status   | Details                                                                                                                                                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `crates/crypto/src/hkdf.rs`                      | `derive_vault_settings_ipns_keypair()` + `VAULT_SETTINGS_HKDF_INFO`                        | VERIFIED | Line 39: `const VAULT_SETTINGS_HKDF_INFO: &[u8] = b"cipherbox-vault-settings-v1";` Line 139: `pub fn derive_vault_settings_ipns_keypair(`                              |
+| `crates/crypto/src/lib.rs`                       | Re-exports `derive_vault_settings_ipns_keypair`                                            | VERIFIED | Line 24: `derive_vault_settings_ipns_keypair,` in `pub use hkdf::{}` block                                                                                             |
+| `crates/core/src/vault_settings.rs`              | `VaultSettings`, `DeleteBehavior`, `default_vault_settings()`, `validate_vault_settings()` | VERIFIED | All 4 items present; `#[serde(rename_all = "camelCase")]` on struct and enum; 13 unit tests pass                                                                       |
+| `crates/core/src/lib.rs`                         | `pub mod vault_settings` + re-exports                                                      | VERIFIED | Line 14: `pub mod vault_settings;` Line 25: `pub use vault_settings::{VaultSettings, DeleteBehavior, default_vault_settings, validate_vault_settings};`                |
+| `tests/vectors/crypto/hkdf.json`                 | Cross-language vector for `cipherbox-vault-settings-v1`                                    | VERIFIED | Lines 42-49: complete entry with `private_key`, `info`, `expected_ed25519_private_key`, `expected_ed25519_public_key`, `expected_ipns_name` all populated              |
+| `crates/crypto/tests/cross_language.rs`          | Match arm for `cipherbox-vault-settings-v1`                                                | VERIFIED | Lines 217-218: `"cipherbox-vault-settings-v1" => { cipherbox_crypto::derive_vault_settings_ipns_keypair(&pk).unwrap() }`                                               |
+| `crates/sdk/src/state.rs`                        | `vault_settings: RwLock<VaultSettings>` on `KeyState`                                      | VERIFIED | Line 55: field present; line 73: init with `default_vault_settings()`; line 122: clear() resets to defaults; lines 149,206: tests assert vault_settings init and reset |
+| `crates/fuse/src/lib.rs`                         | `max_versions_per_file` and `version_cooldown_ms` on `CipherBoxFS`                         | VERIFIED | Lines 486,488: `pub max_versions_per_file: usize` and `pub version_cooldown_ms: u64`                                                                                   |
+| `crates/fuse/src/constants.rs`                   | Renamed to `DEFAULT_MAX_VERSIONS_PER_FILE` / `DEFAULT_VERSION_COOLDOWN_MS`                 | VERIFIED | Lines 13,17: only `DEFAULT_` prefixed constants present; bare names absent                                                                                             |
+| `crates/fuse/src/read_ops.rs`                    | Uses `fs.version_cooldown_ms` and `fs.max_versions_per_file`                               | VERIFIED | Lines 726,747-753: CipherBoxFS field references; no imported constant names remain                                                                                     |
+| `crates/fuse/src/platform/windows/write_ops.rs`  | Uses CipherBoxFS fields for versioning                                                     | VERIFIED | Lines 750,771-772: `fs.version_cooldown_ms` and `fs.max_versions_per_file`                                                                                             |
+| `apps/desktop/src-tauri/src/commands/auth.rs`    | `load_vault_settings()` + call in `complete_auth_setup`                                    | VERIFIED | Lines 95-140: full helper with 5-step pattern; line 200-201: call and store in KeyState; line 266: minutes-to-ms conversion                                            |
+| `apps/desktop/src-tauri/src/fuse/mod.rs`         | `mount_filesystem` signature includes new params                                           | VERIFIED | Lines 60-61: `max_versions_per_file: usize` and `version_cooldown_ms: u64`; line 203: passed to CipherBoxFS constructor                                                |
+| `apps/desktop/src-tauri/src/fuse/windows/mod.rs` | Same new params on Windows `mount_filesystem`                                              | VERIFIED | Lines 46-47: params in signature; lines 338-339: passed to CipherBoxFS constructor                                                                                     |
+
+### Key Link Verification
+
+| From                       | To                               | Via                                                                                  | Status   | Details                                                                                                                                                                        |
+| -------------------------- | -------------------------------- | ------------------------------------------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `auth.rs`                  | `state.rs`                       | Stores loaded VaultSettings in `KeyState.vault_settings`                             | WIRED    | `auth.rs:200-201`: `let settings = load_vault_settings(...).await; *state.sdk.vault_settings.write().await = settings;`                                                        |
+| `auth.rs` → `fuse/mod.rs`  | `fuse/src/lib.rs`                | Reads vault_settings from KeyState and passes to CipherBoxFS constructor             | WIRED    | `auth.rs:262-281`: reads `vault_settings`, computes `max_versions` + `cooldown_ms`, passes both to `mount_filesystem`; `fuse/mod.rs:203` uses them in CipherBoxFS construction |
+| `read_ops.rs`              | `lib.rs (CipherBoxFS)`           | Uses `fs.max_versions_per_file` and `fs.version_cooldown_ms`                         | WIRED    | `read_ops.rs:726,747-753`: both field references present; grep confirms no old constant imports remain                                                                         |
+| `windows/write_ops.rs`     | `lib.rs (CipherBoxFS)`           | Uses CipherBoxFS fields for Windows versioning                                       | WIRED    | `windows/write_ops.rs:750,771-772`: both field references present                                                                                                              |
+| `hkdf.rs`                  | `tests/vectors/crypto/hkdf.json` | `cross_language.rs` test loads vector and calls `derive_vault_settings_ipns_keypair` | WIRED    | `cross_language.rs:217-218`: match arm routes `cipherbox-vault-settings-v1` to the function; test passes                                                                       |
+| `vault_settings.rs` (Rust) | `settings.ts` (TypeScript)       | Identical validation logic and defaults                                              | VERIFIED | Defaults match (v1, 30d retention, bin delete, 10 versions, 15 min cooldown); clamping bounds 0-365/0-100/0-1440 match TypeScript reference                                    |
+
+### Data-Flow Trace (Level 4)
+
+Not applicable for this phase. The artifacts are Rust library code, FUSE daemon configuration, and auth flow wiring — not UI components rendering dynamic data. Data is loaded into a Rust struct (`VaultSettings`) and passed as constructor arguments to `CipherBoxFS`; there is no separate rendering layer to trace.
+
+### Behavioral Spot-Checks
+
+| Behavior                                   | Command                                                                                                                               | Result              | Status |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ------ |
+| crypto vault_settings unit tests           | `cargo test -p cipherbox-crypto -- vault_settings`                                                                                    | 3 passed, 0 failed  | PASS   |
+| cross-language HKDF vector test            | `cargo test -p cipherbox-crypto --test cross_language -- hkdf`                                                                        | 1 passed, 0 failed  | PASS   |
+| core vault_settings unit tests             | `cargo test -p cipherbox-core -- vault_settings`                                                                                      | 13 passed, 0 failed | PASS   |
+| SDK state tests (including vault_settings) | `cargo test -p cipherbox-sdk -- state`                                                                                                | 5 passed, 0 failed  | PASS   |
+| cipherbox-fuse compilation                 | `cargo check -p cipherbox-fuse`                                                                                                       | Finished — 0 errors | PASS   |
+| cipherbox-desktop compilation              | `cargo check -p cipherbox-desktop`                                                                                                    | Finished — 0 errors | PASS   |
+| No old constant names in FUSE ops          | `grep -rn "MAX_VERSIONS_PER_FILE\b\|VERSION_COOLDOWN_MS\b" crates/fuse/src/read_ops.rs crates/fuse/src/platform/windows/write_ops.rs` | 0 matches           | PASS   |
+
+### Requirements Coverage
+
+No requirement IDs declared in Plan 01 or Plan 02 frontmatter (`requirements: []` in both). Phase 40 is an internal follow-up to Phase 39 with no tracked requirements. No orphaned requirements identified.
+
+### Anti-Patterns Found
+
+None. Scanned all phase-modified files for TODOs, FIXMEs, placeholders, empty implementations, and stub patterns. No issues found.
+
+- `constants.rs` retains `DEFAULT_MAX_VERSIONS_PER_FILE` and `DEFAULT_VERSION_COOLDOWN_MS` as named fallback defaults — these are not stubs; they are documented as defaults and are not used in the main code paths (the CipherBoxFS fields carry the live values).
+- `validate_vault_settings` returns `default_vault_settings()` on errors — intentional fallback behavior, fully documented, not a stub.
+
+### Human Verification Required
+
+None. All observable truths for this phase are verifiable programmatically (compilation, unit tests, source presence, grep checks). Runtime integration (actual IPNS resolve during login with a real vault settings entry) is out of scope for static verification and covered by the graceful fallback path.
+
+### Gaps Summary
+
+No gaps. All 9 truths verified, all 14 artifacts confirmed at all three levels (exist, substantive, wired), all 6 key links confirmed wired, all spot-checks pass.
+
+---
+
+_Verified: 2026-03-31T14:00:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/.planning/phases/40-desktop-vault-settings-integration/40-VERIFICATION.md
+++ b/.planning/phases/40-desktop-vault-settings-integration/40-VERIFICATION.md
@@ -89,11 +89,14 @@ None. Scanned all phase-modified files for TODOs, FIXMEs, placeholders, empty im
 
 ### Human Verification Required
 
-None. All observable truths for this phase are verifiable programmatically (compilation, unit tests, source presence, grep checks). Runtime integration (actual IPNS resolve during login with a real vault settings entry) is out of scope for static verification and covered by the graceful fallback path.
+Two runtime checks remain outstanding (not coverable by static verification):
+
+1. **FUSE mount respects custom vault settings** — verify that user-configured values (e.g., `maxVersionsPerFile=5`) propagate to the mounted filesystem and take effect on file writes.
+2. **Defaults used when no IPNS entry exists** — verify that a fresh user (no vault settings published) gets `default_vault_settings()` and mounts successfully.
 
 ### Gaps Summary
 
-No gaps. All 9 truths verified, all 14 artifacts confirmed at all three levels (exist, substantive, wired), all 6 key links confirmed wired, all spot-checks pass.
+All 9 truths verified, all 14 artifacts confirmed, all 6 key links wired, all spot-checks pass. Two runtime integration checks (listed above) are pending manual verification.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cipherbox-fuse"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64 0.22.1",
  "cipherbox-api-client",

--- a/apps/desktop/src-tauri/src/commands/auth.rs
+++ b/apps/desktop/src-tauri/src/commands/auth.rs
@@ -259,6 +259,13 @@ pub(crate) async fn complete_auth_setup(
         let tee_key_epoch = tee_keys.as_ref().map(|tk| tk.current_epoch);
         drop(tee_keys);
 
+        // Read vault settings for FUSE versioning parameters
+        let vault_settings = state.sdk.vault_settings.read().await;
+        let max_versions = vault_settings.max_versions_per_file as usize;
+        // CRITICAL: Convert minutes to milliseconds (per Pitfall 4 in RESEARCH.md)
+        let cooldown_ms = vault_settings.version_cooldown_minutes as u64 * 60 * 1000;
+        drop(vault_settings);
+
         let rt = tokio::runtime::Handle::current();
         match crate::fuse::mount_filesystem(
             state,
@@ -270,6 +277,8 @@ pub(crate) async fn complete_auth_setup(
             root_ipns_private_key,
             tee_public_key,
             tee_key_epoch,
+            max_versions,
+            cooldown_ms,
         ).await {
             Ok(_handle) => {
                 *state.mount_status.write().await = crate::state::MountStatus::Mounted;

--- a/apps/desktop/src-tauri/src/commands/auth.rs
+++ b/apps/desktop/src-tauri/src/commands/auth.rs
@@ -96,29 +96,33 @@ async fn load_vault_settings(
     api: &std::sync::Arc<cipherbox_api_client::ApiClient>,
     private_key: &[u8; 32],
 ) -> cipherbox_core::VaultSettings {
-    let result: Result<cipherbox_core::VaultSettings, String> = async {
-        let (_priv_key, _pub_key, ipns_name) =
-            cipherbox_crypto::hkdf::derive_vault_settings_ipns_keypair(private_key)
-                .map_err(|e| format!("HKDF derivation failed: {:?}", e))?;
+    let result: Result<cipherbox_core::VaultSettings, String> = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        async {
+            let (_priv_key, _pub_key, ipns_name) =
+                cipherbox_crypto::hkdf::derive_vault_settings_ipns_keypair(private_key)
+                    .map_err(|e| format!("HKDF derivation failed: {:?}", e))?;
 
-        let resolved = cipherbox_api_client::ipns::resolve_ipns(api, &ipns_name)
-            .await
-            .map_err(|e| format!("IPNS resolve failed: {}", e))?;
+            let resolved = cipherbox_api_client::ipns::resolve_ipns(api, &ipns_name)
+                .await
+                .map_err(|e| format!("IPNS resolve failed: {}", e))?;
 
-        let encrypted = cipherbox_api_client::ipfs::fetch_content(api, &resolved.cid)
-            .await
-            .map_err(|e| format!("IPFS fetch failed: {}", e))?;
+            let encrypted = cipherbox_api_client::ipfs::fetch_content(api, &resolved.cid)
+                .await
+                .map_err(|e| format!("IPFS fetch failed: {}", e))?;
 
-        // NOT AES-GCM — vault settings use ECIES wrapKey
-        let plaintext = cipherbox_crypto::ecies::unwrap_key(&encrypted, private_key)
-            .map_err(|e| format!("ECIES unwrap failed: {:?}", e))?;
+            // NOT AES-GCM — vault settings use ECIES wrapKey
+            let plaintext = cipherbox_crypto::ecies::unwrap_key(&encrypted, private_key)
+                .map_err(|e| format!("ECIES unwrap failed: {:?}", e))?;
 
-        let parsed: serde_json::Value = serde_json::from_slice(&plaintext)
-            .map_err(|e| format!("JSON parse failed: {}", e))?;
+            let parsed: serde_json::Value = serde_json::from_slice(&plaintext)
+                .map_err(|e| format!("JSON parse failed: {}", e))?;
 
-        Ok(cipherbox_core::validate_vault_settings(&parsed))
-    }
-    .await;
+            Ok(cipherbox_core::validate_vault_settings(&parsed))
+        },
+    )
+    .await
+    .unwrap_or_else(|_| Err("vault settings load timed out after 10s".to_string()));
 
     match result {
         Ok(settings) => {

--- a/apps/desktop/src-tauri/src/commands/auth.rs
+++ b/apps/desktop/src-tauri/src/commands/auth.rs
@@ -87,6 +87,61 @@ pub async fn handle_auth_complete(
     .await
 }
 
+/// Load user-configurable vault settings from encrypted IPNS entry.
+///
+/// Pattern: derive IPNS keypair -> resolve IPNS -> fetch IPFS -> ECIES unwrap -> parse JSON -> validate.
+/// Returns default settings on any failure (IPNS not found, decrypt error, parse error).
+/// Per D-03 and D-05: graceful fallback, desktop is read-only for settings.
+async fn load_vault_settings(
+    api: &std::sync::Arc<cipherbox_api_client::ApiClient>,
+    private_key: &[u8; 32],
+) -> cipherbox_core::VaultSettings {
+    let result: Result<cipherbox_core::VaultSettings, String> = async {
+        // 1. Derive IPNS keypair for vault settings
+        let (_priv_key, _pub_key, ipns_name) =
+            cipherbox_crypto::hkdf::derive_vault_settings_ipns_keypair(private_key)
+                .map_err(|e| format!("HKDF derivation failed: {:?}", e))?;
+
+        // 2. Resolve IPNS name to CID
+        let resolved = cipherbox_api_client::ipns::resolve_ipns(api, &ipns_name)
+            .await
+            .map_err(|e| format!("IPNS resolve failed: {}", e))?;
+
+        // 3. Fetch encrypted blob from IPFS
+        let encrypted = cipherbox_api_client::ipfs::fetch_content(api, &resolved.cid)
+            .await
+            .map_err(|e| format!("IPFS fetch failed: {}", e))?;
+
+        // 4. ECIES decrypt with user's private key (NOT AES-GCM - vault settings use ECIES wrapKey)
+        let plaintext = cipherbox_crypto::ecies::unwrap_key(&encrypted, private_key)
+            .map_err(|e| format!("ECIES unwrap failed: {:?}", e))?;
+
+        // 5. Parse JSON and validate
+        let parsed: serde_json::Value = serde_json::from_slice(&plaintext)
+            .map_err(|e| format!("JSON parse failed: {}", e))?;
+
+        Ok(cipherbox_core::validate_vault_settings(&parsed))
+    }
+    .await;
+
+    match result {
+        Ok(settings) => {
+            log::info!(
+                "Vault settings loaded: maxVersions={}, cooldown={}min, retention={}d, delete={:?}",
+                settings.max_versions_per_file,
+                settings.version_cooldown_minutes,
+                settings.recycle_bin_retention_days,
+                settings.delete_behavior
+            );
+            settings
+        }
+        Err(e) => {
+            log::warn!("Vault settings load failed (using defaults): {}", e);
+            cipherbox_core::default_vault_settings()
+        }
+    }
+}
+
 /// Shared post-auth setup used by both `handle_auth_complete` and `handle_test_login_complete`.
 ///
 /// Stores tokens and keys, initializes/fetches vault, registers device, mounts FUSE,
@@ -136,6 +191,17 @@ pub(crate) async fn complete_auth_setup(
             fetch_and_decrypt_vault(state).await?;
         }
         Err(e) => return Err(e),
+    }
+
+    // 5b. Load vault settings (non-blocking, graceful fallback to defaults)
+    {
+        let pk_slice: &[u8] = &private_key_bytes;
+        if let Ok(pk_arr) = <[u8; 32]>::try_from(pk_slice) {
+            let settings = load_vault_settings(&state.sdk.api, &pk_arr).await;
+            *state.sdk.vault_settings.write().await = settings;
+        } else {
+            log::warn!("Private key not 32 bytes, using default vault settings");
+        }
     }
 
     // 6. Mark as authenticated

--- a/apps/desktop/src-tauri/src/commands/auth.rs
+++ b/apps/desktop/src-tauri/src/commands/auth.rs
@@ -97,26 +97,22 @@ async fn load_vault_settings(
     private_key: &[u8; 32],
 ) -> cipherbox_core::VaultSettings {
     let result: Result<cipherbox_core::VaultSettings, String> = async {
-        // 1. Derive IPNS keypair for vault settings
         let (_priv_key, _pub_key, ipns_name) =
             cipherbox_crypto::hkdf::derive_vault_settings_ipns_keypair(private_key)
                 .map_err(|e| format!("HKDF derivation failed: {:?}", e))?;
 
-        // 2. Resolve IPNS name to CID
         let resolved = cipherbox_api_client::ipns::resolve_ipns(api, &ipns_name)
             .await
             .map_err(|e| format!("IPNS resolve failed: {}", e))?;
 
-        // 3. Fetch encrypted blob from IPFS
         let encrypted = cipherbox_api_client::ipfs::fetch_content(api, &resolved.cid)
             .await
             .map_err(|e| format!("IPFS fetch failed: {}", e))?;
 
-        // 4. ECIES decrypt with user's private key (NOT AES-GCM - vault settings use ECIES wrapKey)
+        // NOT AES-GCM — vault settings use ECIES wrapKey
         let plaintext = cipherbox_crypto::ecies::unwrap_key(&encrypted, private_key)
             .map_err(|e| format!("ECIES unwrap failed: {:?}", e))?;
 
-        // 5. Parse JSON and validate
         let parsed: serde_json::Value = serde_json::from_slice(&plaintext)
             .map_err(|e| format!("JSON parse failed: {}", e))?;
 
@@ -193,15 +189,12 @@ pub(crate) async fn complete_auth_setup(
         Err(e) => return Err(e),
     }
 
-    // 5b. Load vault settings (non-blocking, graceful fallback to defaults)
-    {
-        let pk_slice: &[u8] = &private_key_bytes;
-        if let Ok(pk_arr) = <[u8; 32]>::try_from(pk_slice) {
-            let settings = load_vault_settings(&state.sdk.api, &pk_arr).await;
-            *state.sdk.vault_settings.write().await = settings;
-        } else {
-            log::warn!("Private key not 32 bytes, using default vault settings");
-        }
+    // 5b. Load vault settings (graceful fallback to defaults)
+    if let Ok(pk_arr) = <[u8; 32]>::try_from(private_key_bytes.as_slice()) {
+        let settings = load_vault_settings(&state.sdk.api, &pk_arr).await;
+        *state.sdk.vault_settings.write().await = settings;
+    } else {
+        log::warn!("Private key not 32 bytes, using default vault settings");
     }
 
     // 6. Mark as authenticated

--- a/apps/desktop/src-tauri/src/fuse/mod.rs
+++ b/apps/desktop/src-tauri/src/fuse/mod.rs
@@ -57,6 +57,8 @@ pub async fn mount_filesystem(
     root_ipns_private_key: Option<Vec<u8>>,
     tee_public_key: Option<Vec<u8>>,
     tee_key_epoch: Option<u32>,
+    max_versions_per_file: usize,
+    version_cooldown_ms: u64,
 ) -> Result<std::thread::JoinHandle<()>, String> {
     let mount_path = mount_point();
 
@@ -198,6 +200,7 @@ pub async fn mount_filesystem(
         next_fh: std::sync::atomic::AtomicU64::new(1),
         open_files: HashMap::new(),
         temp_dir, tee_public_key, tee_key_epoch,
+        max_versions_per_file, version_cooldown_ms,
         refresh_rx, refresh_tx,
         prefetching: std::collections::HashSet::new(),
         content_rx, content_tx,

--- a/apps/desktop/src-tauri/src/fuse/windows/mod.rs
+++ b/apps/desktop/src-tauri/src/fuse/windows/mod.rs
@@ -43,6 +43,8 @@ mod mount_impl {
         root_ipns_private_key: Option<Vec<u8>>,
         tee_public_key: Option<Vec<u8>>,
         tee_key_epoch: Option<u32>,
+        max_versions_per_file: usize,
+        version_cooldown_ms: u64,
     ) -> Result<std::thread::JoinHandle<()>, String> {
         let mount_path = crate::fuse::mount_point();
 
@@ -333,6 +335,8 @@ mod mount_impl {
             temp_dir,
             tee_public_key,
             tee_key_epoch,
+            max_versions_per_file,
+            version_cooldown_ms,
             refresh_rx,
             refresh_tx,
             prefetching: std::collections::HashSet::new(),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod bin;
 pub mod vault_blob;
 pub mod ipns;
 pub mod decrypt;
+pub mod vault_settings;
 pub mod error;
 
 // Re-export primary types and functions
@@ -21,4 +22,5 @@ pub use bin::{RecycleBinMetadata, BinEntry, BinItemType, encrypt_bin_metadata, d
 pub use vault_blob::{serialize_vault_blob_v2, deserialize_vault_blob_v2, detect_blob_version};
 pub use ipns::{IpnsRecord, create_ipns_record, marshal_ipns_record};
 pub use decrypt::{decrypt_metadata_from_ipfs_public, decrypt_file_metadata_from_ipfs_public};
+pub use vault_settings::{VaultSettings, DeleteBehavior, default_vault_settings, validate_vault_settings};
 pub use error::CoreError;

--- a/crates/core/src/vault_settings.rs
+++ b/crates/core/src/vault_settings.rs
@@ -66,7 +66,7 @@ pub fn validate_vault_settings(input: &serde_json::Value) -> VaultSettings {
     let recycle_bin_retention_days = obj
         .get("recycleBinRetentionDays")
         .and_then(|v| v.as_u64())
-        .map(|v| clamp(v as u32, 0, 365))
+        .map(|v| (v as u32).clamp(0, 365))
         .unwrap_or(defaults.recycle_bin_retention_days);
 
     let delete_behavior = obj
@@ -82,13 +82,13 @@ pub fn validate_vault_settings(input: &serde_json::Value) -> VaultSettings {
     let max_versions_per_file = obj
         .get("maxVersionsPerFile")
         .and_then(|v| v.as_u64())
-        .map(|v| clamp(v as u32, 0, 100))
+        .map(|v| (v as u32).clamp(0, 100))
         .unwrap_or(defaults.max_versions_per_file);
 
     let version_cooldown_minutes = obj
         .get("versionCooldownMinutes")
         .and_then(|v| v.as_u64())
-        .map(|v| clamp(v as u32, 0, 1440))
+        .map(|v| (v as u32).clamp(0, 1440))
         .unwrap_or(defaults.version_cooldown_minutes);
 
     VaultSettings {
@@ -98,10 +98,6 @@ pub fn validate_vault_settings(input: &serde_json::Value) -> VaultSettings {
         max_versions_per_file,
         version_cooldown_minutes,
     }
-}
-
-fn clamp(value: u32, min: u32, max: u32) -> u32 {
-    value.min(max).max(min)
 }
 
 #[cfg(test)]

--- a/crates/core/src/vault_settings.rs
+++ b/crates/core/src/vault_settings.rs
@@ -1,0 +1,267 @@
+//! User-configurable vault settings.
+//!
+//! Settings are stored as ECIES-encrypted JSON in an IPNS entry.
+//! The server never sees plaintext settings (zero-knowledge).
+//! Mirrors @cipherbox/core VaultSettings TypeScript type.
+
+use serde::{Deserialize, Serialize};
+
+/// Delete behavior for vault files.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum DeleteBehavior {
+    Bin,
+    Permanent,
+}
+
+/// User-configurable vault settings.
+///
+/// JSON field names use camelCase to match TypeScript serialization.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultSettings {
+    /// Schema version for future migrations.
+    pub version: String,
+    /// Recycle bin retention period in days (0-365; 0 = immediate purge).
+    pub recycle_bin_retention_days: u32,
+    /// Delete behavior: Bin = soft delete, Permanent = immediate hard delete.
+    pub delete_behavior: DeleteBehavior,
+    /// Maximum number of past versions retained per file (0-100).
+    pub max_versions_per_file: u32,
+    /// Cooldown period for version creation in minutes (0-1440).
+    pub version_cooldown_minutes: u32,
+}
+
+/// Returns the default vault settings matching current hardcoded behavior.
+pub fn default_vault_settings() -> VaultSettings {
+    VaultSettings {
+        version: "v1".to_string(),
+        recycle_bin_retention_days: 30,
+        delete_behavior: DeleteBehavior::Bin,
+        max_versions_per_file: 10,
+        version_cooldown_minutes: 15,
+    }
+}
+
+/// Validate and sanitize vault settings from parsed JSON.
+///
+/// Clamps out-of-range numeric values to valid bounds.
+/// Returns default settings for corrupt or non-object input.
+/// Returns default settings if version is not "v1" (unknown version guard).
+pub fn validate_vault_settings(input: &serde_json::Value) -> VaultSettings {
+    let defaults = default_vault_settings();
+
+    let obj = match input.as_object() {
+        Some(o) => o,
+        None => return defaults,
+    };
+
+    // Unknown version guard
+    if let Some(version) = obj.get("version") {
+        if version.as_str() != Some("v1") {
+            return defaults;
+        }
+    }
+
+    let recycle_bin_retention_days = obj
+        .get("recycleBinRetentionDays")
+        .and_then(|v| v.as_u64())
+        .map(|v| clamp(v as u32, 0, 365))
+        .unwrap_or(defaults.recycle_bin_retention_days);
+
+    let delete_behavior = obj
+        .get("deleteBehavior")
+        .and_then(|v| v.as_str())
+        .and_then(|s| match s {
+            "bin" => Some(DeleteBehavior::Bin),
+            "permanent" => Some(DeleteBehavior::Permanent),
+            _ => None,
+        })
+        .unwrap_or(defaults.delete_behavior);
+
+    let max_versions_per_file = obj
+        .get("maxVersionsPerFile")
+        .and_then(|v| v.as_u64())
+        .map(|v| clamp(v as u32, 0, 100))
+        .unwrap_or(defaults.max_versions_per_file);
+
+    let version_cooldown_minutes = obj
+        .get("versionCooldownMinutes")
+        .and_then(|v| v.as_u64())
+        .map(|v| clamp(v as u32, 0, 1440))
+        .unwrap_or(defaults.version_cooldown_minutes);
+
+    VaultSettings {
+        version: "v1".to_string(),
+        recycle_bin_retention_days,
+        delete_behavior,
+        max_versions_per_file,
+        version_cooldown_minutes,
+    }
+}
+
+fn clamp(value: u32, min: u32, max: u32) -> u32 {
+    value.min(max).max(min)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn default_vault_settings_has_correct_values() {
+        let defaults = default_vault_settings();
+        assert_eq!(defaults.version, "v1");
+        assert_eq!(defaults.recycle_bin_retention_days, 30);
+        assert_eq!(defaults.delete_behavior, DeleteBehavior::Bin);
+        assert_eq!(defaults.max_versions_per_file, 10);
+        assert_eq!(defaults.version_cooldown_minutes, 15);
+    }
+
+    #[test]
+    fn validate_with_valid_json_returns_correct_settings() {
+        let input = json!({
+            "version": "v1",
+            "recycleBinRetentionDays": 60,
+            "deleteBehavior": "permanent",
+            "maxVersionsPerFile": 20,
+            "versionCooldownMinutes": 30
+        });
+        let result = validate_vault_settings(&input);
+        assert_eq!(result.version, "v1");
+        assert_eq!(result.recycle_bin_retention_days, 60);
+        assert_eq!(result.delete_behavior, DeleteBehavior::Permanent);
+        assert_eq!(result.max_versions_per_file, 20);
+        assert_eq!(result.version_cooldown_minutes, 30);
+    }
+
+    #[test]
+    fn validate_clamps_retention_days_above_365() {
+        let input = json!({
+            "version": "v1",
+            "recycleBinRetentionDays": 500
+        });
+        let result = validate_vault_settings(&input);
+        assert_eq!(result.recycle_bin_retention_days, 365);
+    }
+
+    #[test]
+    fn validate_clamps_retention_days_below_0() {
+        // JSON u64 can't be negative, so test with missing field
+        // For negative values, serde_json::as_u64() returns None -> default
+        let input = json!({
+            "version": "v1",
+            "recycleBinRetentionDays": -5
+        });
+        let result = validate_vault_settings(&input);
+        // Negative value fails as_u64(), falls back to default 30
+        assert_eq!(result.recycle_bin_retention_days, 30);
+    }
+
+    #[test]
+    fn validate_retention_days_zero_is_valid() {
+        let input = json!({
+            "version": "v1",
+            "recycleBinRetentionDays": 0
+        });
+        let result = validate_vault_settings(&input);
+        assert_eq!(result.recycle_bin_retention_days, 0);
+    }
+
+    #[test]
+    fn validate_clamps_max_versions_above_100() {
+        let input = json!({
+            "version": "v1",
+            "maxVersionsPerFile": 200
+        });
+        let result = validate_vault_settings(&input);
+        assert_eq!(result.max_versions_per_file, 100);
+    }
+
+    #[test]
+    fn validate_clamps_cooldown_above_1440() {
+        let input = json!({
+            "version": "v1",
+            "versionCooldownMinutes": 2000
+        });
+        let result = validate_vault_settings(&input);
+        assert_eq!(result.version_cooldown_minutes, 1440);
+    }
+
+    #[test]
+    fn validate_returns_defaults_for_null_input() {
+        let input = json!(null);
+        let result = validate_vault_settings(&input);
+        assert_eq!(result, default_vault_settings());
+    }
+
+    #[test]
+    fn validate_returns_defaults_for_non_object_input() {
+        let input = json!("not an object");
+        let result = validate_vault_settings(&input);
+        assert_eq!(result, default_vault_settings());
+
+        let input = json!(42);
+        let result = validate_vault_settings(&input);
+        assert_eq!(result, default_vault_settings());
+
+        let input = json!([1, 2, 3]);
+        let result = validate_vault_settings(&input);
+        assert_eq!(result, default_vault_settings());
+    }
+
+    #[test]
+    fn validate_returns_defaults_for_unknown_version() {
+        let input = json!({
+            "version": "v99",
+            "recycleBinRetentionDays": 60
+        });
+        let result = validate_vault_settings(&input);
+        assert_eq!(result, default_vault_settings());
+    }
+
+    #[test]
+    fn serde_round_trip_uses_camel_case() {
+        let settings = VaultSettings {
+            version: "v1".to_string(),
+            recycle_bin_retention_days: 45,
+            delete_behavior: DeleteBehavior::Permanent,
+            max_versions_per_file: 25,
+            version_cooldown_minutes: 60,
+        };
+
+        let json_str = serde_json::to_string(&settings).unwrap();
+        assert!(json_str.contains("\"maxVersionsPerFile\""));
+        assert!(json_str.contains("\"recycleBinRetentionDays\""));
+        assert!(json_str.contains("\"deleteBehavior\""));
+        assert!(json_str.contains("\"versionCooldownMinutes\""));
+        // Verify no snake_case in output
+        assert!(!json_str.contains("max_versions_per_file"));
+        assert!(!json_str.contains("recycle_bin_retention_days"));
+
+        // Deserialize back
+        let parsed: VaultSettings = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed, settings);
+    }
+
+    #[test]
+    fn deserialize_from_camel_case_json() {
+        let json_str = r#"{"version":"v1","recycleBinRetentionDays":30,"deleteBehavior":"bin","maxVersionsPerFile":10,"versionCooldownMinutes":15}"#;
+        let settings: VaultSettings = serde_json::from_str(json_str).unwrap();
+        assert_eq!(settings, default_vault_settings());
+    }
+
+    #[test]
+    fn validate_with_missing_fields_uses_defaults() {
+        let input = json!({
+            "version": "v1"
+        });
+        let result = validate_vault_settings(&input);
+        assert_eq!(result.version, "v1");
+        assert_eq!(result.recycle_bin_retention_days, 30);
+        assert_eq!(result.delete_behavior, DeleteBehavior::Bin);
+        assert_eq!(result.max_versions_per_file, 10);
+        assert_eq!(result.version_cooldown_minutes, 15);
+    }
+}

--- a/crates/crypto/src/hkdf.rs
+++ b/crates/crypto/src/hkdf.rs
@@ -240,4 +240,39 @@ mod tests {
         let result = derive_file_ipns_keypair(&test_private_key(), "123456789");
         assert!(matches!(result, Err(CryptoError::InvalidFileId)));
     }
+
+    #[test]
+    fn derive_vault_settings_returns_32_byte_keys() {
+        let (priv_key, pub_key, name) =
+            derive_vault_settings_ipns_keypair(&test_private_key()).unwrap();
+        assert_eq!(priv_key.len(), 32);
+        assert_eq!(pub_key.len(), 32);
+        assert!(name.starts_with('k'));
+    }
+
+    #[test]
+    fn derive_vault_settings_is_deterministic() {
+        let key = test_private_key();
+        let (priv1, pub1, name1) = derive_vault_settings_ipns_keypair(&key).unwrap();
+        let (priv2, pub2, name2) = derive_vault_settings_ipns_keypair(&key).unwrap();
+        assert_eq!(*priv1, *priv2);
+        assert_eq!(pub1, pub2);
+        assert_eq!(name1, name2);
+    }
+
+    #[test]
+    fn vault_settings_differs_from_other_derivations() {
+        let key = test_private_key();
+        let (_, settings_pub, settings_name) =
+            derive_vault_settings_ipns_keypair(&key).unwrap();
+        let (_, vault_pub, vault_name) = derive_vault_ipns_keypair(&key).unwrap();
+        let (_, vault_key_pub, vault_key_name) = derive_vault_key_ipns_keypair(&key).unwrap();
+        let (_, bin_pub, bin_name) = derive_bin_ipns_keypair(&key).unwrap();
+        assert_ne!(settings_pub, vault_pub);
+        assert_ne!(settings_name, vault_name);
+        assert_ne!(settings_pub, vault_key_pub);
+        assert_ne!(settings_name, vault_key_name);
+        assert_ne!(settings_pub, bin_pub);
+        assert_ne!(settings_name, bin_name);
+    }
 }

--- a/crates/crypto/src/hkdf.rs
+++ b/crates/crypto/src/hkdf.rs
@@ -35,6 +35,9 @@ const REGISTRY_HKDF_INFO: &[u8] = b"cipherbox-device-registry-ipns-v1";
 /// HKDF info for recycle bin IPNS keypair derivation.
 const BIN_HKDF_INFO: &[u8] = b"cipherbox-recycle-bin-ipns-v1";
 
+/// HKDF info for vault settings IPNS keypair derivation.
+const VAULT_SETTINGS_HKDF_INFO: &[u8] = b"cipherbox-vault-settings-v1";
+
 /// HKDF info prefix for per-file IPNS keypair derivation.
 const FILE_HKDF_INFO_PREFIX: &str = "cipherbox-file-ipns-v1:";
 
@@ -122,6 +125,21 @@ pub fn derive_registry_ipns_keypair(
     user_private_key: &[u8; 32],
 ) -> Result<(Zeroizing<Vec<u8>>, Vec<u8>, String), CryptoError> {
     derive_ipns_keypair(user_private_key, REGISTRY_HKDF_INFO)
+}
+
+/// Derive the deterministic Ed25519 IPNS keypair for vault settings.
+///
+/// This IPNS name stores the encrypted user-configurable vault parameters
+/// (retention period, delete behavior, versioning limits). Zero-knowledge:
+/// the server never sees the plaintext settings.
+///
+/// Uses HKDF info "cipherbox-vault-settings-v1" for domain separation.
+///
+/// Returns (ed25519_private_key, ed25519_public_key, ipns_name).
+pub fn derive_vault_settings_ipns_keypair(
+    user_private_key: &[u8; 32],
+) -> Result<(Zeroizing<Vec<u8>>, Vec<u8>, String), CryptoError> {
+    derive_ipns_keypair(user_private_key, VAULT_SETTINGS_HKDF_INFO)
 }
 
 /// Derive the deterministic Ed25519 IPNS keypair for the recycle bin.

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -21,6 +21,7 @@ pub use error::CryptoError;
 pub use hkdf::{
     derive_bin_ipns_keypair, derive_file_ipns_keypair, derive_registry_ipns_keypair,
     derive_vault_ipns_keypair, derive_vault_key_ipns_keypair,
+    derive_vault_settings_ipns_keypair,
 };
 pub use ipns_name::derive_ipns_name;
 pub use utils::{clear_bytes, generate_file_key, generate_iv, generate_random_bytes};

--- a/crates/crypto/tests/cross_language.rs
+++ b/crates/crypto/tests/cross_language.rs
@@ -214,6 +214,9 @@ fn hkdf_cross_language() {
                 let file_id = &info["cipherbox-file-ipns-v1:".len()..];
                 cipherbox_crypto::derive_file_ipns_keypair(&pk, file_id).unwrap()
             }
+            "cipherbox-vault-settings-v1" => {
+                cipherbox_crypto::derive_vault_settings_ipns_keypair(&pk).unwrap()
+            }
             other => panic!("Unknown HKDF info string: {}", other),
         };
 

--- a/crates/fuse/src/constants.rs
+++ b/crates/fuse/src/constants.rs
@@ -8,14 +8,6 @@ use std::time::Duration;
 /// Total storage quota in bytes (500 MiB).
 pub const QUOTA_BYTES: u64 = 500 * 1024 * 1024;
 
-/// Default maximum versions per file (used as fallback if settings not loaded).
-/// User-configurable value is stored in CipherBoxFS.max_versions_per_file.
-pub const DEFAULT_MAX_VERSIONS_PER_FILE: usize = 10;
-
-/// Default version cooldown in milliseconds (used as fallback if settings not loaded).
-/// User-configurable value is stored in CipherBoxFS.version_cooldown_ms.
-pub const DEFAULT_VERSION_COOLDOWN_MS: u64 = 15 * 60 * 1000;
-
 /// Maximum time for file content download in open().
 /// Large files (e.g., 64MB) can take 30-60s from staging IPFS.
 /// This blocks the NFS thread, but since the content is cached after

--- a/crates/fuse/src/constants.rs
+++ b/crates/fuse/src/constants.rs
@@ -8,12 +8,13 @@ use std::time::Duration;
 /// Total storage quota in bytes (500 MiB).
 pub const QUOTA_BYTES: u64 = 500 * 1024 * 1024;
 
-/// Maximum number of past versions to keep per file.
-pub const MAX_VERSIONS_PER_FILE: usize = 10;
+/// Default maximum versions per file (used as fallback if settings not loaded).
+/// User-configurable value is stored in CipherBoxFS.max_versions_per_file.
+pub const DEFAULT_MAX_VERSIONS_PER_FILE: usize = 10;
 
-/// Cooldown period for desktop FUSE version creation (15 minutes in milliseconds).
-/// Only creates a new version entry if the most recent version is older than this.
-pub const VERSION_COOLDOWN_MS: u64 = 15 * 60 * 1000;
+/// Default version cooldown in milliseconds (used as fallback if settings not loaded).
+/// User-configurable value is stored in CipherBoxFS.version_cooldown_ms.
+pub const DEFAULT_VERSION_COOLDOWN_MS: u64 = 15 * 60 * 1000;
 
 /// Maximum time for file content download in open().
 /// Large files (e.g., 64MB) can take 30-60s from staging IPFS.

--- a/crates/fuse/src/helpers.rs
+++ b/crates/fuse/src/helpers.rs
@@ -153,6 +153,148 @@ pub fn apply_versioning(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cipherbox_core::folder::VersionEntry;
+
+    fn make_version(cid: &str, timestamp: u64) -> VersionEntry {
+        VersionEntry {
+            cid: cid.to_string(),
+            file_key_encrypted: "enc_key".to_string(),
+            file_iv: "iv".to_string(),
+            size: 1024,
+            timestamp,
+            encryption_mode: "aes-256-gcm".to_string(),
+        }
+    }
+
+    #[test]
+    fn no_old_cid_skips_versioning() {
+        let (versions, pruned) = apply_versioning(
+            None, &None, "k", "iv", 100, "aes-256-gcm", 1000, 10, 0, 1,
+        );
+        assert!(versions.is_none());
+        assert!(pruned.is_empty());
+    }
+
+    #[test]
+    fn empty_old_cid_skips_versioning() {
+        let (versions, pruned) = apply_versioning(
+            None, &Some(String::new()), "k", "iv", 100, "aes-256-gcm", 1000, 10, 0, 1,
+        );
+        assert!(versions.is_none());
+        assert!(pruned.is_empty());
+    }
+
+    #[test]
+    fn first_write_creates_version() {
+        let (versions, pruned) = apply_versioning(
+            None,
+            &Some("QmOldCid".to_string()),
+            "enc_key", "iv", 2048, "aes-256-gcm",
+            1000, 10, 0, 1,
+        );
+        let v = versions.unwrap();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].cid, "QmOldCid");
+        assert_eq!(v[0].size, 2048);
+        assert_eq!(v[0].timestamp, 1000);
+        assert!(pruned.is_empty());
+    }
+
+    #[test]
+    fn cooldown_active_skips_versioning() {
+        let existing = vec![make_version("QmV1", 900)];
+        let (versions, pruned) = apply_versioning(
+            Some(existing),
+            &Some("QmOldCid".to_string()),
+            "k", "iv", 100, "aes-256-gcm",
+            999,   // only 99ms since last version
+            10,
+            500,   // 500ms cooldown
+            1,
+        );
+        // Should return existing versions unchanged
+        let v = versions.unwrap();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].cid, "QmV1");
+        assert!(pruned.is_empty());
+    }
+
+    #[test]
+    fn cooldown_expired_creates_version() {
+        let existing = vec![make_version("QmV1", 500)];
+        let (versions, pruned) = apply_versioning(
+            Some(existing),
+            &Some("QmOldCid".to_string()),
+            "k", "iv", 100, "aes-256-gcm",
+            1001,  // 501ms since last version
+            10,
+            500,   // 500ms cooldown
+            1,
+        );
+        let v = versions.unwrap();
+        assert_eq!(v.len(), 2);
+        // Newest first
+        assert_eq!(v[0].cid, "QmOldCid");
+        assert_eq!(v[1].cid, "QmV1");
+        assert!(pruned.is_empty());
+    }
+
+    #[test]
+    fn exceeding_max_versions_prunes_oldest() {
+        let existing: Vec<VersionEntry> = (0..3)
+            .map(|i| make_version(&format!("QmV{}", i), 1000 - i * 100))
+            .collect();
+        let (versions, pruned) = apply_versioning(
+            Some(existing),
+            &Some("QmNew".to_string()),
+            "k", "iv", 100, "aes-256-gcm",
+            5000,  // well past cooldown
+            3,     // max 3 versions
+            0,     // no cooldown
+            1,
+        );
+        let v = versions.unwrap();
+        assert_eq!(v.len(), 3);
+        assert_eq!(v[0].cid, "QmNew");
+        // Pruned the oldest one
+        assert_eq!(pruned.len(), 1);
+        assert_eq!(pruned[0], "QmV2");
+    }
+
+    #[test]
+    fn empty_existing_versions_with_old_cid_creates_version() {
+        // Empty vec (not None) — file has version array but no entries yet
+        let (versions, pruned) = apply_versioning(
+            Some(vec![]),
+            &Some("QmOldCid".to_string()),
+            "k", "iv", 100, "aes-256-gcm",
+            1000, 10, 0, 1,
+        );
+        let v = versions.unwrap();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].cid, "QmOldCid");
+        assert!(pruned.is_empty());
+    }
+
+    #[test]
+    fn max_versions_zero_prunes_all() {
+        let (versions, pruned) = apply_versioning(
+            None,
+            &Some("QmOldCid".to_string()),
+            "k", "iv", 100, "aes-256-gcm",
+            1000, 0, 0, 1,
+        );
+        // max_versions=0: the new entry is created then immediately pruned
+        let v = versions.unwrap();
+        assert!(v.is_empty());
+        assert_eq!(pruned.len(), 1);
+        assert_eq!(pruned[0], "QmOldCid");
+    }
+}
+
 /// Convert VersionEntry list to VersionCidEntry list for bin entries.
 /// Filters out entries with empty CIDs and returns None if the result is empty.
 pub fn versions_to_bin_entries(

--- a/crates/fuse/src/helpers.rs
+++ b/crates/fuse/src/helpers.rs
@@ -119,38 +119,40 @@ pub fn apply_versioning(
         old_file_cid.as_ref().is_some_and(|c| !c.is_empty())
     };
 
-    if !should_version {
+    let mut versions = if should_version {
+        match old_file_cid {
+            Some(ref old_c) if !old_c.is_empty() => {
+                let version_entry = cipherbox_core::folder::VersionEntry {
+                    cid: old_c.clone(),
+                    file_key_encrypted: old_encrypted_key.to_string(),
+                    file_iv: old_iv.to_string(),
+                    size: old_size,
+                    timestamp: now_ms,
+                    encryption_mode: old_mode.to_string(),
+                };
+                let mut versions = vec![version_entry];
+                versions.extend(existing_versions.unwrap_or_default());
+                log::debug!("Created version entry for ino {} (total versions: {})", ino, versions.len());
+                versions
+            }
+            _ => existing_versions.unwrap_or_default(),
+        }
+    } else {
         if existing_versions.is_some() {
             log::debug!("Version cooldown active for ino {} -- skipping version creation", ino);
         }
-        return (existing_versions, vec![]);
-    }
+        existing_versions.unwrap_or_default()
+    };
 
-    match old_file_cid {
-        Some(ref old_c) if !old_c.is_empty() => {
-            let version_entry = cipherbox_core::folder::VersionEntry {
-                cid: old_c.clone(),
-                file_key_encrypted: old_encrypted_key.to_string(),
-                file_iv: old_iv.to_string(),
-                size: old_size,
-                timestamp: now_ms,
-                encryption_mode: old_mode.to_string(),
-            };
-            let mut versions = vec![version_entry];
-            versions.extend(existing_versions.unwrap_or_default());
-            let pruned: Vec<String> = if versions.len() > max_versions {
-                versions.split_off(max_versions).into_iter().map(|v| v.cid).collect()
-            } else {
-                vec![]
-            };
-            if !pruned.is_empty() {
-                log::info!("Pruned {} version(s) for ino {} (exceeded max {})", pruned.len(), ino, max_versions);
-            }
-            log::debug!("Created version entry for ino {} (total versions: {})", ino, versions.len());
-            (Some(versions), pruned)
-        }
-        _ => (existing_versions, vec![]),
+    let pruned: Vec<String> = if versions.len() > max_versions {
+        versions.split_off(max_versions).into_iter().map(|v| v.cid).collect()
+    } else {
+        vec![]
+    };
+    if !pruned.is_empty() {
+        log::info!("Pruned {} version(s) for ino {} (exceeded max {})", pruned.len(), ino, max_versions);
     }
+    (if versions.is_empty() { None } else { Some(versions) }, pruned)
 }
 
 #[cfg(test)]
@@ -288,10 +290,32 @@ mod tests {
             1000, 0, 0, 1,
         );
         // max_versions=0: the new entry is created then immediately pruned
-        let v = versions.unwrap();
-        assert!(v.is_empty());
+        assert!(versions.is_none());
         assert_eq!(pruned.len(), 1);
         assert_eq!(pruned[0], "QmOldCid");
+    }
+
+    #[test]
+    fn cooldown_still_prunes_excess_versions() {
+        // Simulate max_versions lowered from 5 to 2 — existing history has 4 entries
+        let existing: Vec<VersionEntry> = (0..4)
+            .map(|i| make_version(&format!("QmV{}", i), 1000 - i * 100))
+            .collect();
+        let (versions, pruned) = apply_versioning(
+            Some(existing),
+            &Some("QmOldCid".to_string()),
+            "k", "iv", 100, "aes-256-gcm",
+            1001,  // only 1ms since last version
+            2,     // max 2 versions (lowered)
+            500,   // cooldown active — no new version created
+            1,
+        );
+        // Should prune excess even though no new version was added
+        let v = versions.unwrap();
+        assert_eq!(v.len(), 2);
+        assert_eq!(pruned.len(), 2);
+        assert_eq!(pruned[0], "QmV2");
+        assert_eq!(pruned[1], "QmV3");
     }
 }
 

--- a/crates/fuse/src/helpers.rs
+++ b/crates/fuse/src/helpers.rs
@@ -90,6 +90,69 @@ pub fn build_folder_path(fs: &crate::CipherBoxFS, folder_ino: u64) -> String {
     parts.join(" / ")
 }
 
+/// Evaluate whether a new version should be created and prune excess versions.
+///
+/// Shared across all platforms (macOS, Linux, Windows) to ensure consistent
+/// versioning behavior regardless of the FUSE/WinFSP backend.
+///
+/// Returns `(versions, pruned_cids)` where `pruned_cids` contains CIDs of
+/// versions that exceeded `max_versions` and should be unpinned.
+pub fn apply_versioning(
+    existing_versions: Option<Vec<cipherbox_core::folder::VersionEntry>>,
+    old_file_cid: &Option<String>,
+    old_encrypted_key: &str,
+    old_iv: &str,
+    old_size: u64,
+    old_mode: &str,
+    now_ms: u64,
+    max_versions: usize,
+    cooldown_ms: u64,
+    ino: u64,
+) -> (Option<Vec<cipherbox_core::folder::VersionEntry>>, Vec<String>) {
+    let should_version = if let Some(ref versions) = existing_versions {
+        if let Some(newest) = versions.first() {
+            now_ms.saturating_sub(newest.timestamp) >= cooldown_ms
+        } else {
+            old_file_cid.as_ref().is_some_and(|c| !c.is_empty())
+        }
+    } else {
+        old_file_cid.as_ref().is_some_and(|c| !c.is_empty())
+    };
+
+    if !should_version {
+        if existing_versions.is_some() {
+            log::debug!("Version cooldown active for ino {} -- skipping version creation", ino);
+        }
+        return (existing_versions, vec![]);
+    }
+
+    match old_file_cid {
+        Some(ref old_c) if !old_c.is_empty() => {
+            let version_entry = cipherbox_core::folder::VersionEntry {
+                cid: old_c.clone(),
+                file_key_encrypted: old_encrypted_key.to_string(),
+                file_iv: old_iv.to_string(),
+                size: old_size,
+                timestamp: now_ms,
+                encryption_mode: old_mode.to_string(),
+            };
+            let mut versions = vec![version_entry];
+            versions.extend(existing_versions.unwrap_or_default());
+            let pruned: Vec<String> = if versions.len() > max_versions {
+                versions.split_off(max_versions).into_iter().map(|v| v.cid).collect()
+            } else {
+                vec![]
+            };
+            if !pruned.is_empty() {
+                log::info!("Pruned {} version(s) for ino {} (exceeded max {})", pruned.len(), ino, max_versions);
+            }
+            log::debug!("Created version entry for ino {} (total versions: {})", ino, versions.len());
+            (Some(versions), pruned)
+        }
+        _ => (existing_versions, vec![]),
+    }
+}
+
 /// Convert VersionEntry list to VersionCidEntry list for bin entries.
 /// Filters out entries with empty CIDs and returns None if the result is empty.
 pub fn versions_to_bin_entries(

--- a/crates/fuse/src/lib.rs
+++ b/crates/fuse/src/lib.rs
@@ -482,6 +482,10 @@ pub struct CipherBoxFS {
     pub temp_dir: PathBuf,
     pub tee_public_key: Option<Vec<u8>>,
     pub tee_key_epoch: Option<u32>,
+    /// Maximum number of past versions to keep per file (from user vault settings).
+    pub max_versions_per_file: usize,
+    /// Version creation cooldown in milliseconds (from user vault settings).
+    pub version_cooldown_ms: u64,
     pub refresh_rx: std::sync::mpsc::Receiver<PendingRefresh>,
     pub refresh_tx: std::sync::mpsc::Sender<PendingRefresh>,
     pub mutated_folders: HashMap<u64, std::time::Instant>,

--- a/crates/fuse/src/platform/windows/write_ops.rs
+++ b/crates/fuse/src/platform/windows/write_ops.rs
@@ -13,7 +13,7 @@ pub mod implementation {
     use widestring::U16CStr;
     use winfsp::FspError;
 
-    use crate::constants::{MAX_VERSIONS_PER_FILE, VERSION_COOLDOWN_MS};
+    // Versioning constants now read from CipherBoxFS fields (user-configurable)
     use crate::file_handle::OpenFileHandle;
     use crate::helpers::mime_from_extension;
     use crate::inode::{FileAttrs, InodeData, InodeKind, ROOT_INO};
@@ -747,7 +747,7 @@ pub mod implementation {
 
                     let should_version = if let Some(ref versions) = existing_versions {
                         if let Some(newest) = versions.first() {
-                            now_ms.saturating_sub(newest.timestamp) >= VERSION_COOLDOWN_MS
+                            now_ms.saturating_sub(newest.timestamp) >= fs.version_cooldown_ms
                         } else {
                             old_file_cid.as_ref().is_some_and(|c| !c.is_empty())
                         }
@@ -768,8 +768,8 @@ pub mod implementation {
                                 };
                                 let mut versions = vec![version_entry];
                                 versions.extend(existing_versions.unwrap_or_default());
-                                let pruned: Vec<String> = if versions.len() > MAX_VERSIONS_PER_FILE {
-                                    versions.split_off(MAX_VERSIONS_PER_FILE).into_iter().map(|v| v.cid).collect()
+                                let pruned: Vec<String> = if versions.len() > fs.max_versions_per_file {
+                                    versions.split_off(fs.max_versions_per_file).into_iter().map(|v| v.cid).collect()
                                 } else {
                                     vec![]
                                 };

--- a/crates/fuse/src/platform/windows/write_ops.rs
+++ b/crates/fuse/src/platform/windows/write_ops.rs
@@ -719,7 +719,7 @@ pub mod implementation {
                         .map_err(|e| format!("Key wrapping failed: {}", e))?;
                     cipherbox_crypto::utils::clear_bytes(&mut file_key);
 
-                    let (old_file_cid, _old_encrypted_key, _old_iv, old_size, old_mode,
+                    let (old_file_cid, old_encrypted_key, old_iv, old_size, old_mode,
                          existing_versions, file_ipns_private_key, file_meta_ipns_name) =
                         fs.inodes.get(ino).map(|inode| match &inode.kind {
                             InodeKind::File {
@@ -745,44 +745,18 @@ pub mod implementation {
                         .unwrap_or_default()
                         .as_millis() as u64;
 
-                    let should_version = if let Some(ref versions) = existing_versions {
-                        if let Some(newest) = versions.first() {
-                            now_ms.saturating_sub(newest.timestamp) >= fs.version_cooldown_ms
-                        } else {
-                            old_file_cid.as_ref().is_some_and(|c| !c.is_empty())
-                        }
-                    } else {
-                        old_file_cid.as_ref().is_some_and(|c| !c.is_empty())
-                    };
-
-                    let (new_versions, pruned_cids) = if should_version {
-                        if let Some(ref old_c) = old_file_cid {
-                            if !old_c.is_empty() {
-                                let version_entry = cipherbox_core::folder::VersionEntry {
-                                    cid: old_c.clone(),
-                                    file_key_encrypted: _old_encrypted_key.clone(),
-                                    file_iv: _old_iv.clone(),
-                                    size: old_size,
-                                    timestamp: now_ms,
-                                    encryption_mode: old_mode.clone(),
-                                };
-                                let mut versions = vec![version_entry];
-                                versions.extend(existing_versions.unwrap_or_default());
-                                let pruned: Vec<String> = if versions.len() > fs.max_versions_per_file {
-                                    versions.split_off(fs.max_versions_per_file).into_iter().map(|v| v.cid).collect()
-                                } else {
-                                    vec![]
-                                };
-                                (Some(versions), pruned)
-                            } else {
-                                (existing_versions, vec![])
-                            }
-                        } else {
-                            (existing_versions, vec![])
-                        }
-                    } else {
-                        (existing_versions, vec![])
-                    };
+                    let (new_versions, pruned_cids) = crate::helpers::apply_versioning(
+                        existing_versions,
+                        &old_file_cid,
+                        &old_encrypted_key,
+                        &old_iv,
+                        old_size,
+                        &old_mode,
+                        now_ms,
+                        fs.max_versions_per_file,
+                        fs.version_cooldown_ms,
+                        ino,
+                    );
 
                     let versions_for_meta = new_versions.as_ref()
                         .filter(|v| !v.is_empty())

--- a/crates/fuse/src/read_ops.rs
+++ b/crates/fuse/src/read_ops.rs
@@ -15,9 +15,7 @@ pub(crate) mod implementation {
     use std::time::{Duration, SystemTime};
 
     use crate::CipherBoxFS;
-    use crate::constants::{
-        CONTENT_DOWNLOAD_TIMEOUT, MAX_VERSIONS_PER_FILE, VERSION_COOLDOWN_MS,
-    };
+    use crate::constants::CONTENT_DOWNLOAD_TIMEOUT;
 
     const FILEPOINTER_POLL_TIMEOUT: Duration = Duration::from_secs(5);
     const FILEPOINTER_POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -725,7 +723,7 @@ pub(crate) mod implementation {
 
                     let should_version = if let Some(ref versions) = existing_versions {
                         if let Some(newest) = versions.first() {
-                            now_ms.saturating_sub(newest.timestamp) >= VERSION_COOLDOWN_MS
+                            now_ms.saturating_sub(newest.timestamp) >= fs.version_cooldown_ms
                         } else {
                             old_file_cid.as_ref().is_some_and(|c| !c.is_empty())
                         }
@@ -746,13 +744,13 @@ pub(crate) mod implementation {
                                 };
                                 let mut versions = vec![version_entry];
                                 versions.extend(existing_versions.unwrap_or_default());
-                                let pruned: Vec<String> = if versions.len() > MAX_VERSIONS_PER_FILE {
-                                    versions.split_off(MAX_VERSIONS_PER_FILE).into_iter().map(|v| v.cid).collect()
+                                let pruned: Vec<String> = if versions.len() > fs.max_versions_per_file {
+                                    versions.split_off(fs.max_versions_per_file).into_iter().map(|v| v.cid).collect()
                                 } else {
                                     vec![]
                                 };
                                 if !pruned.is_empty() {
-                                    log::info!("Pruned {} version(s) for ino {} (exceeded max {})", pruned.len(), ino, MAX_VERSIONS_PER_FILE);
+                                    log::info!("Pruned {} version(s) for ino {} (exceeded max {})", pruned.len(), ino, fs.max_versions_per_file);
                                 }
                                 log::debug!("Created version entry for ino {} (total versions: {})", ino, versions.len());
                                 (Some(versions), pruned)

--- a/crates/fuse/src/read_ops.rs
+++ b/crates/fuse/src/read_ops.rs
@@ -721,51 +721,18 @@ pub(crate) mod implementation {
                         .unwrap_or_default()
                         .as_millis() as u64;
 
-                    let should_version = if let Some(ref versions) = existing_versions {
-                        if let Some(newest) = versions.first() {
-                            now_ms.saturating_sub(newest.timestamp) >= fs.version_cooldown_ms
-                        } else {
-                            old_file_cid.as_ref().is_some_and(|c| !c.is_empty())
-                        }
-                    } else {
-                        old_file_cid.as_ref().is_some_and(|c| !c.is_empty())
-                    };
-
-                    let (new_versions, pruned_cids) = if should_version {
-                        if let Some(ref old_c) = old_file_cid {
-                            if !old_c.is_empty() {
-                                let version_entry = cipherbox_core::folder::VersionEntry {
-                                    cid: old_c.clone(),
-                                    file_key_encrypted: old_encrypted_key.clone(),
-                                    file_iv: old_iv.clone(),
-                                    size: old_size,
-                                    timestamp: now_ms,
-                                    encryption_mode: old_mode.clone(),
-                                };
-                                let mut versions = vec![version_entry];
-                                versions.extend(existing_versions.unwrap_or_default());
-                                let pruned: Vec<String> = if versions.len() > fs.max_versions_per_file {
-                                    versions.split_off(fs.max_versions_per_file).into_iter().map(|v| v.cid).collect()
-                                } else {
-                                    vec![]
-                                };
-                                if !pruned.is_empty() {
-                                    log::info!("Pruned {} version(s) for ino {} (exceeded max {})", pruned.len(), ino, fs.max_versions_per_file);
-                                }
-                                log::debug!("Created version entry for ino {} (total versions: {})", ino, versions.len());
-                                (Some(versions), pruned)
-                            } else {
-                                (existing_versions, vec![])
-                            }
-                        } else {
-                            (existing_versions, vec![])
-                        }
-                    } else {
-                        if existing_versions.is_some() {
-                            log::debug!("Version cooldown active for ino {} -- skipping version creation", ino);
-                        }
-                        (existing_versions, vec![])
-                    };
+                    let (new_versions, pruned_cids) = crate::helpers::apply_versioning(
+                        existing_versions,
+                        &old_file_cid,
+                        &old_encrypted_key,
+                        &old_iv,
+                        old_size,
+                        &old_mode,
+                        now_ms,
+                        fs.max_versions_per_file,
+                        fs.version_cooldown_ms,
+                        ino,
+                    );
 
                     let versions_for_meta = new_versions.as_ref()
                         .filter(|v| !v.is_empty())

--- a/crates/sdk/src/state.rs
+++ b/crates/sdk/src/state.rs
@@ -9,6 +9,7 @@ use zeroize::Zeroize;
 
 use cipherbox_api_client::ApiClient;
 use cipherbox_api_client::TeeKeysResponse;
+use cipherbox_core::VaultSettings;
 
 /// Sync status for external notification via generic callback.
 #[derive(Debug, Clone, PartialEq)]
@@ -49,6 +50,10 @@ pub struct KeyState {
     /// Current and previous TEE public keys for IPNS key encryption.
     pub tee_keys: RwLock<Option<TeeKeysResponse>>,
 
+    /// User-configurable vault settings (retention, versioning, delete behavior).
+    /// Non-optional: defaults to default_vault_settings() when not loaded from IPNS.
+    pub vault_settings: RwLock<VaultSettings>,
+
     /// Whether the user is fully authenticated with vault keys decrypted.
     pub is_authenticated: RwLock<bool>,
 }
@@ -65,6 +70,7 @@ impl KeyState {
             root_ipns_private_key: RwLock::new(None),
             user_id: RwLock::new(None),
             tee_keys: RwLock::new(None),
+            vault_settings: RwLock::new(cipherbox_core::default_vault_settings()),
             is_authenticated: RwLock::new(false),
         }
     }
@@ -113,6 +119,7 @@ impl KeyState {
         *self.root_ipns_name.write().await = None;
         *self.user_id.write().await = None;
         *self.tee_keys.write().await = None;
+        *self.vault_settings.write().await = cipherbox_core::default_vault_settings();
         *self.is_authenticated.write().await = false;
 
         // Clear access token from API client
@@ -139,6 +146,7 @@ mod tests {
         assert!(state.root_ipns_private_key.read().await.is_none());
         assert!(state.user_id.read().await.is_none());
         assert!(state.tee_keys.read().await.is_none());
+        assert_eq!(*state.vault_settings.read().await, cipherbox_core::default_vault_settings());
         assert!(!*state.is_authenticated.read().await);
     }
 
@@ -176,9 +184,18 @@ mod tests {
         *state.user_id.write().await = Some("user-abc".to_string());
         *state.is_authenticated.write().await = true;
 
+        // Set vault settings to non-default values
+        *state.vault_settings.write().await = cipherbox_core::VaultSettings {
+            version: "v1".to_string(),
+            recycle_bin_retention_days: 60,
+            delete_behavior: cipherbox_core::DeleteBehavior::Permanent,
+            max_versions_per_file: 50,
+            version_cooldown_minutes: 30,
+        };
+
         state.clear().await;
 
-        // All fields should be None / false after clear.
+        // All fields should be None / false / defaults after clear.
         assert!(state.private_key.read().await.is_none());
         assert!(state.public_key.read().await.is_none());
         assert!(state.root_folder_key.read().await.is_none());
@@ -186,6 +203,7 @@ mod tests {
         assert!(state.root_ipns_name.read().await.is_none());
         assert!(state.user_id.read().await.is_none());
         assert!(state.tee_keys.read().await.is_none());
+        assert_eq!(*state.vault_settings.read().await, cipherbox_core::default_vault_settings());
         assert!(!*state.is_authenticated.read().await);
     }
 

--- a/tests/vectors/crypto/hkdf.json
+++ b/tests/vectors/crypto/hkdf.json
@@ -38,5 +38,13 @@
     "expected_ed25519_private_key": "ef2a6ae6d80ac927ca37898d27965ea9cb159024f8ca06a0caab1c638bf714b8",
     "expected_ed25519_public_key": "21815e843e30268e38b244610253a7f516e27134052d59d4b4a612c88cdf9620",
     "expected_ipns_name": "k51qzi5uqu5dh0nhi2flvmcl6fg4wxphm80itjhq7yvzw0jddg57q0ydw9s940"
+  },
+  {
+    "description": "HKDF vault settings IPNS keypair derivation (info: cipherbox-vault-settings-v1)",
+    "private_key": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+    "info": "cipherbox-vault-settings-v1",
+    "expected_ed25519_private_key": "2355be2482684b3fcdff1c1bb35cdf8ee5b7a65ae77808f7ed6aaebc3c338e79",
+    "expected_ed25519_public_key": "3a381eb24a6f872d5a08f1fb2564ad040e633346471bb639c5fcb805dae20a21",
+    "expected_ipns_name": "k51qzi5uqu5dhmts1dkbomz1yvmoez92fcpoaflg4yimqd0dz1cec7en7jx8v5"
   }
 ]


### PR DESCRIPTION
## Summary

- Add HKDF-derived IPNS keypair for vault settings with cross-language test vectors
- Add `VaultSettings` type with validation, clamping, and serde round-trip support to `cipherbox-core`
- Load encrypted vault settings from IPNS during desktop auth flow with graceful fallback to defaults
- Replace hardcoded FUSE versioning constants with user-configurable values from vault settings
- Extract shared `apply_versioning()` helper to eliminate platform-specific code duplication (macOS + Windows)
- Code cleanup: use `u32::clamp()` from std, remove dead constants, strip redundant comments

## Test plan

- [x] `cipherbox-core` vault_settings unit tests (13 tests: defaults, validation, clamping, serde round-trip, unknown version guard)
- [x] `cipherbox-crypto` HKDF derivation tests (determinism, domain separation, cross-language vectors)
- [x] `cipherbox-fuse` compiles with removed constants (no dead code references)
- [ ] Manual: verify FUSE mount respects custom vault settings when set via web app
- [ ] Manual: verify default settings used when no vault settings IPNS entry exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Desktop app now loads user-configured vault settings during login, enabling personalized file versioning behavior (max versions per file and version cooldown periods) instead of using fixed defaults.

* **Chores**
  * Updated project planning and roadmap documentation for Phase 40: Desktop vault settings integration.
  * Expanded test infrastructure with new cross-language derivation vectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->