### PR TITLE
chore(ci): align api-client versions with API and fix OpenAPI versioning

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,12 +6,12 @@
   "apps/tee-worker": "0.31.1",
   "packages/core": "0.30.0",
   "packages/crypto": "0.30.0",
-  "packages/api-client": "0.33.0",
+  "packages/api-client": "0.35.0",
   "packages/sdk-core": "0.34.0",
   "packages/sdk": "0.33.0",
   "crates/crypto": "0.5.0",
   "crates/core": "0.5.0",
-  "crates/api-client": "0.4.0",
+  "crates/api-client": "0.35.0",
   "crates/fuse": "0.5.0",
   "crates/sdk": "0.5.0"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cipherbox-api-client"
-version = "0.4.0"
+version = "0.35.0"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "cipherbox-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "ciborium",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "cipherbox-crypto"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "cipherbox-desktop"
-version = "0.1.0"
+version = "0.35.0"
 dependencies = [
  "base64 0.22.1",
  "ciborium",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cipherbox-fuse"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "cipherbox-api-client",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "cipherbox-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "cipherbox-api-client",

--- a/apps/api/scripts/generate-openapi.ts
+++ b/apps/api/scripts/generate-openapi.ts
@@ -199,6 +199,13 @@ const mockConfigService = {
 class OpenApiGeneratorModule {}
 
 async function generateOpenApiSpec() {
+  const openApiVersion = process.env.npm_package_version;
+  if (!openApiVersion) {
+    throw new Error(
+      'npm_package_version is required. Run via pnpm script: pnpm --filter @cipherbox/api openapi:generate'
+    );
+  }
+
   // Create app without starting HTTP server
   const app = await NestFactory.create(OpenApiGeneratorModule, {
     logger: false,
@@ -207,7 +214,7 @@ async function generateOpenApiSpec() {
   const config = new DocumentBuilder()
     .setTitle('CipherBox API')
     .setDescription('Zero-knowledge encrypted cloud storage API')
-    .setVersion('0.1.0')
+    .setVersion(openApiVersion)
     .addBearerAuth()
     .addTag('Health', 'Health check endpoints')
     .addTag('Root', 'API root endpoints')

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,6 +2,8 @@ import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { ValidationPipe, Logger } from '@nestjs/common';
 import cookieParser from 'cookie-parser';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
@@ -49,10 +51,14 @@ async function bootstrap() {
     credentials: true,
   });
 
+  const apiVersion =
+    process.env.npm_package_version ||
+    JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')).version;
+
   const config = new DocumentBuilder()
     .setTitle('CipherBox API')
     .setDescription('Zero-knowledge encrypted cloud storage API')
-    .setVersion('0.1.0')
+    .setVersion(apiVersion)
     .addBearerAuth()
     .build();
   const document = SwaggerModule.createDocument(app, config);

--- a/crates/api-client/Cargo.toml
+++ b/crates/api-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipherbox-api-client"
-version = "0.4.0"
+version = "0.35.0"
 edition = "2021"
 description = "Typed HTTP client for CipherBox API"
 

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -2138,7 +2138,7 @@
   "info": {
     "title": "CipherBox API",
     "description": "Zero-knowledge encrypted cloud storage API",
-    "version": "0.1.0",
+    "version": "0.35.0",
     "contact": {}
   },
   "tags": [

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherbox/api-client",
-  "version": "0.33.0",
+  "version": "0.35.0",
   "private": true,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/api-client/src/generated/auth/auth.ts
+++ b/packages/api-client/src/generated/auth/auth.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type {
   AuthMethodResponseDto,

--- a/packages/api-client/src/generated/device-approval/device-approval.ts
+++ b/packages/api-client/src/generated/device-approval/device-approval.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type {
   CreateApprovalDto,

--- a/packages/api-client/src/generated/health/health.ts
+++ b/packages/api-client/src/generated/health/health.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { HealthControllerCheck200 } from '../../models';
 

--- a/packages/api-client/src/generated/identity/identity.ts
+++ b/packages/api-client/src/generated/identity/identity.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type {
   GoogleLoginDto,

--- a/packages/api-client/src/generated/invites/invites.ts
+++ b/packages/api-client/src/generated/invites/invites.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type {
   ClaimInviteDto,

--- a/packages/api-client/src/generated/ipfs/ipfs.ts
+++ b/packages/api-client/src/generated/ipfs/ipfs.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type {
   IpfsControllerUploadBody,

--- a/packages/api-client/src/generated/ipns/ipns.ts
+++ b/packages/api-client/src/generated/ipns/ipns.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type {
   BatchPublishIpnsDto,

--- a/packages/api-client/src/generated/root/root.ts
+++ b/packages/api-client/src/generated/root/root.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import { customInstance } from '../../instance';
 

--- a/packages/api-client/src/generated/share-invites/share-invites.ts
+++ b/packages/api-client/src/generated/share-invites/share-invites.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type {
   CreateInviteDto,

--- a/packages/api-client/src/generated/shares/shares.ts
+++ b/packages/api-client/src/generated/shares/shares.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type {
   AddShareKeysDto,

--- a/packages/api-client/src/generated/tee/tee.ts
+++ b/packages/api-client/src/generated/tee/tee.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { ConnectionTestRequestDto, ConnectionTestResponseDto } from '../../models';
 

--- a/packages/api-client/src/generated/vault/vault.ts
+++ b/packages/api-client/src/generated/vault/vault.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type {
   InitVaultDto,

--- a/packages/api-client/src/models/addShareKeysDto.ts
+++ b/packages/api-client/src/models/addShareKeysDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { ShareKeyEntryDto } from './shareKeyEntryDto';
 

--- a/packages/api-client/src/models/authMethodResponseDto.ts
+++ b/packages/api-client/src/models/authMethodResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { AuthMethodResponseDtoType } from './authMethodResponseDtoType';
 

--- a/packages/api-client/src/models/authMethodResponseDtoType.ts
+++ b/packages/api-client/src/models/authMethodResponseDtoType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type AuthMethodResponseDtoType =

--- a/packages/api-client/src/models/batchPublishIpnsDto.ts
+++ b/packages/api-client/src/models/batchPublishIpnsDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { PublishIpnsEntryDto } from './publishIpnsEntryDto';
 

--- a/packages/api-client/src/models/batchPublishIpnsResponseDto.ts
+++ b/packages/api-client/src/models/batchPublishIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { PublishIpnsResponseDto } from './publishIpnsResponseDto';
 

--- a/packages/api-client/src/models/batchUnenrollIpnsDto.ts
+++ b/packages/api-client/src/models/batchUnenrollIpnsDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface BatchUnenrollIpnsDto {

--- a/packages/api-client/src/models/batchUnenrollIpnsResponseDto.ts
+++ b/packages/api-client/src/models/batchUnenrollIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface BatchUnenrollIpnsResponseDto {

--- a/packages/api-client/src/models/childKeyDto.ts
+++ b/packages/api-client/src/models/childKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { ChildKeyDtoKeyType } from './childKeyDtoKeyType';
 

--- a/packages/api-client/src/models/childKeyDtoKeyType.ts
+++ b/packages/api-client/src/models/childKeyDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/claimChildKeyDto.ts
+++ b/packages/api-client/src/models/claimChildKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { ClaimChildKeyDtoKeyType } from './claimChildKeyDtoKeyType';
 

--- a/packages/api-client/src/models/claimChildKeyDtoKeyType.ts
+++ b/packages/api-client/src/models/claimChildKeyDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/claimInviteDto.ts
+++ b/packages/api-client/src/models/claimInviteDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { ClaimChildKeyDto } from './claimChildKeyDto';
 

--- a/packages/api-client/src/models/claimInviteResponseDto.ts
+++ b/packages/api-client/src/models/claimInviteResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface ClaimInviteResponseDto {

--- a/packages/api-client/src/models/connectionTestRequestDto.ts
+++ b/packages/api-client/src/models/connectionTestRequestDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface ConnectionTestRequestDto {

--- a/packages/api-client/src/models/connectionTestResponseDto.ts
+++ b/packages/api-client/src/models/connectionTestResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { ConnectionTestResponseDtoProtocol } from './connectionTestResponseDtoProtocol';
 

--- a/packages/api-client/src/models/connectionTestResponseDtoProtocol.ts
+++ b/packages/api-client/src/models/connectionTestResponseDtoProtocol.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/createApprovalDto.ts
+++ b/packages/api-client/src/models/createApprovalDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface CreateApprovalDto {

--- a/packages/api-client/src/models/createInviteDto.ts
+++ b/packages/api-client/src/models/createInviteDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { CreateInviteDtoItemType } from './createInviteDtoItemType';
 import type { InviteChildKeyDto } from './inviteChildKeyDto';

--- a/packages/api-client/src/models/createInviteDtoItemType.ts
+++ b/packages/api-client/src/models/createInviteDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/createShareDto.ts
+++ b/packages/api-client/src/models/createShareDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { CreateShareDtoItemType } from './createShareDtoItemType';
 import type { CreateShareDtoPermission } from './createShareDtoPermission';

--- a/packages/api-client/src/models/createShareDtoItemType.ts
+++ b/packages/api-client/src/models/createShareDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/createShareDtoPermission.ts
+++ b/packages/api-client/src/models/createShareDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/createShareResponseDto.ts
+++ b/packages/api-client/src/models/createShareResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { CreateShareResponseDtoItemType } from './createShareResponseDtoItemType';
 import type { CreateShareResponseDtoPermission } from './createShareResponseDtoPermission';

--- a/packages/api-client/src/models/createShareResponseDtoItemType.ts
+++ b/packages/api-client/src/models/createShareResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type CreateShareResponseDtoItemType =

--- a/packages/api-client/src/models/createShareResponseDtoPermission.ts
+++ b/packages/api-client/src/models/createShareResponseDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/deleteAccountDto.ts
+++ b/packages/api-client/src/models/deleteAccountDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface DeleteAccountDto {

--- a/packages/api-client/src/models/deleteAccountResponseDto.ts
+++ b/packages/api-client/src/models/deleteAccountResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface DeleteAccountResponseDto {

--- a/packages/api-client/src/models/desktopRefreshDto.ts
+++ b/packages/api-client/src/models/desktopRefreshDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface DesktopRefreshDto {

--- a/packages/api-client/src/models/deviceApprovalControllerCreateRequest201.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerCreateRequest201.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type DeviceApprovalControllerCreateRequest201 = {

--- a/packages/api-client/src/models/deviceApprovalControllerGetPending200Item.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerGetPending200Item.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type DeviceApprovalControllerGetPending200Item = {

--- a/packages/api-client/src/models/deviceApprovalControllerGetStatus200.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerGetStatus200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { DeviceApprovalControllerGetStatus200Status } from './deviceApprovalControllerGetStatus200Status';
 

--- a/packages/api-client/src/models/deviceApprovalControllerGetStatus200Status.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerGetStatus200Status.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type DeviceApprovalControllerGetStatus200Status =

--- a/packages/api-client/src/models/googleLoginDto.ts
+++ b/packages/api-client/src/models/googleLoginDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { GoogleLoginDtoIntent } from './googleLoginDtoIntent';
 

--- a/packages/api-client/src/models/googleLoginDtoIntent.ts
+++ b/packages/api-client/src/models/googleLoginDtoIntent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/healthControllerCheck200.ts
+++ b/packages/api-client/src/models/healthControllerCheck200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { HealthControllerCheck200Info } from './healthControllerCheck200Info';
 

--- a/packages/api-client/src/models/healthControllerCheck200Info.ts
+++ b/packages/api-client/src/models/healthControllerCheck200Info.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { HealthControllerCheck200InfoDatabase } from './healthControllerCheck200InfoDatabase';
 

--- a/packages/api-client/src/models/healthControllerCheck200InfoDatabase.ts
+++ b/packages/api-client/src/models/healthControllerCheck200InfoDatabase.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type HealthControllerCheck200InfoDatabase = {

--- a/packages/api-client/src/models/identityControllerGetJwks200.ts
+++ b/packages/api-client/src/models/identityControllerGetJwks200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { IdentityControllerGetJwks200KeysItem } from './identityControllerGetJwks200KeysItem';
 

--- a/packages/api-client/src/models/identityControllerGetJwks200KeysItem.ts
+++ b/packages/api-client/src/models/identityControllerGetJwks200KeysItem.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type IdentityControllerGetJwks200KeysItem = { [key: string]: unknown };

--- a/packages/api-client/src/models/identityControllerGetWalletNonce200.ts
+++ b/packages/api-client/src/models/identityControllerGetWalletNonce200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type IdentityControllerGetWalletNonce200 = {

--- a/packages/api-client/src/models/identityTokenResponseDto.ts
+++ b/packages/api-client/src/models/identityTokenResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface IdentityTokenResponseDto {

--- a/packages/api-client/src/models/index.ts
+++ b/packages/api-client/src/models/index.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export * from './addShareKeysDto';

--- a/packages/api-client/src/models/initVaultDto.ts
+++ b/packages/api-client/src/models/initVaultDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface InitVaultDto {

--- a/packages/api-client/src/models/inviteChildKeyDto.ts
+++ b/packages/api-client/src/models/inviteChildKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { InviteChildKeyDtoKeyType } from './inviteChildKeyDtoKeyType';
 

--- a/packages/api-client/src/models/inviteChildKeyDtoKeyType.ts
+++ b/packages/api-client/src/models/inviteChildKeyDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/inviteDataResponseDto.ts
+++ b/packages/api-client/src/models/inviteDataResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { InviteDataResponseDtoStatus } from './inviteDataResponseDtoStatus';
 import type { InviteChildKeyDto } from './inviteChildKeyDto';

--- a/packages/api-client/src/models/inviteDataResponseDtoItemType.ts
+++ b/packages/api-client/src/models/inviteDataResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type InviteDataResponseDtoItemType =

--- a/packages/api-client/src/models/inviteDataResponseDtoStatus.ts
+++ b/packages/api-client/src/models/inviteDataResponseDtoStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/inviteResponseDto.ts
+++ b/packages/api-client/src/models/inviteResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { InviteResponseDtoItemType } from './inviteResponseDtoItemType';
 import type { InviteResponseDtoStatus } from './inviteResponseDtoStatus';

--- a/packages/api-client/src/models/inviteResponseDtoItemType.ts
+++ b/packages/api-client/src/models/inviteResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type InviteResponseDtoItemType =

--- a/packages/api-client/src/models/inviteResponseDtoStatus.ts
+++ b/packages/api-client/src/models/inviteResponseDtoStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type InviteResponseDtoStatus =

--- a/packages/api-client/src/models/inviteStatusResponseDto.ts
+++ b/packages/api-client/src/models/inviteStatusResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { InviteStatusResponseDtoStatus } from './inviteStatusResponseDtoStatus';
 

--- a/packages/api-client/src/models/inviteStatusResponseDtoStatus.ts
+++ b/packages/api-client/src/models/inviteStatusResponseDtoStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/ipfsControllerUploadBody.ts
+++ b/packages/api-client/src/models/ipfsControllerUploadBody.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type IpfsControllerUploadBody = {

--- a/packages/api-client/src/models/ipnsControllerResolveRecordParams.ts
+++ b/packages/api-client/src/models/ipnsControllerResolveRecordParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type IpnsControllerResolveRecordParams = {

--- a/packages/api-client/src/models/linkMethodDto.ts
+++ b/packages/api-client/src/models/linkMethodDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { LinkMethodDtoLoginType } from './linkMethodDtoLoginType';
 

--- a/packages/api-client/src/models/linkMethodDtoLoginType.ts
+++ b/packages/api-client/src/models/linkMethodDtoLoginType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/loginDto.ts
+++ b/packages/api-client/src/models/loginDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { LoginDtoLoginType } from './loginDtoLoginType';
 

--- a/packages/api-client/src/models/loginDtoLoginType.ts
+++ b/packages/api-client/src/models/loginDtoLoginType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/loginResponseDto.ts
+++ b/packages/api-client/src/models/loginResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface LoginResponseDto {

--- a/packages/api-client/src/models/logoutResponseDto.ts
+++ b/packages/api-client/src/models/logoutResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface LogoutResponseDto {

--- a/packages/api-client/src/models/lookupUserResponseDto.ts
+++ b/packages/api-client/src/models/lookupUserResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface LookupUserResponseDto {

--- a/packages/api-client/src/models/paginatedReceivedSharesDto.ts
+++ b/packages/api-client/src/models/paginatedReceivedSharesDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { ReceivedShareResponseDto } from './receivedShareResponseDto';
 

--- a/packages/api-client/src/models/paginatedSentSharesDto.ts
+++ b/packages/api-client/src/models/paginatedSentSharesDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { SentShareResponseDto } from './sentShareResponseDto';
 

--- a/packages/api-client/src/models/pendingRotationResponseDto.ts
+++ b/packages/api-client/src/models/pendingRotationResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { PendingRotationResponseDtoItemType } from './pendingRotationResponseDtoItemType';
 

--- a/packages/api-client/src/models/pendingRotationResponseDtoItemType.ts
+++ b/packages/api-client/src/models/pendingRotationResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type PendingRotationResponseDtoItemType =

--- a/packages/api-client/src/models/publishIpnsDto.ts
+++ b/packages/api-client/src/models/publishIpnsDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface PublishIpnsDto {

--- a/packages/api-client/src/models/publishIpnsEntryDto.ts
+++ b/packages/api-client/src/models/publishIpnsEntryDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { PublishIpnsEntryDtoRecordType } from './publishIpnsEntryDtoRecordType';
 

--- a/packages/api-client/src/models/publishIpnsEntryDtoRecordType.ts
+++ b/packages/api-client/src/models/publishIpnsEntryDtoRecordType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/publishIpnsResponseDto.ts
+++ b/packages/api-client/src/models/publishIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface PublishIpnsResponseDto {

--- a/packages/api-client/src/models/quotaResponseDto.ts
+++ b/packages/api-client/src/models/quotaResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface QuotaResponseDto {

--- a/packages/api-client/src/models/receivedShareResponseDto.ts
+++ b/packages/api-client/src/models/receivedShareResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { ReceivedShareResponseDtoItemType } from './receivedShareResponseDtoItemType';
 import type { ReceivedShareResponseDtoPermission } from './receivedShareResponseDtoPermission';

--- a/packages/api-client/src/models/receivedShareResponseDtoItemType.ts
+++ b/packages/api-client/src/models/receivedShareResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type ReceivedShareResponseDtoItemType =

--- a/packages/api-client/src/models/receivedShareResponseDtoPermission.ts
+++ b/packages/api-client/src/models/receivedShareResponseDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/registerCidDto.ts
+++ b/packages/api-client/src/models/registerCidDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface RegisterCidDto {

--- a/packages/api-client/src/models/registerCidResponseDto.ts
+++ b/packages/api-client/src/models/registerCidResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface RegisterCidResponseDto {

--- a/packages/api-client/src/models/resolveIpnsResponseDto.ts
+++ b/packages/api-client/src/models/resolveIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface ResolveIpnsResponseDto {

--- a/packages/api-client/src/models/respondApprovalDto.ts
+++ b/packages/api-client/src/models/respondApprovalDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { RespondApprovalDtoAction } from './respondApprovalDtoAction';
 

--- a/packages/api-client/src/models/respondApprovalDtoAction.ts
+++ b/packages/api-client/src/models/respondApprovalDtoAction.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/sendOtpDto.ts
+++ b/packages/api-client/src/models/sendOtpDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface SendOtpDto {

--- a/packages/api-client/src/models/sendOtpResponseDto.ts
+++ b/packages/api-client/src/models/sendOtpResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface SendOtpResponseDto {

--- a/packages/api-client/src/models/sentShareResponseDto.ts
+++ b/packages/api-client/src/models/sentShareResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { SentShareResponseDtoItemType } from './sentShareResponseDtoItemType';
 import type { SentShareResponseDtoPermission } from './sentShareResponseDtoPermission';

--- a/packages/api-client/src/models/sentShareResponseDtoItemType.ts
+++ b/packages/api-client/src/models/sentShareResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type SentShareResponseDtoItemType =

--- a/packages/api-client/src/models/sentShareResponseDtoPermission.ts
+++ b/packages/api-client/src/models/sentShareResponseDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/setByoStatusDto.ts
+++ b/packages/api-client/src/models/setByoStatusDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface SetByoStatusDto {

--- a/packages/api-client/src/models/setByoStatusResponseDto.ts
+++ b/packages/api-client/src/models/setByoStatusResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface SetByoStatusResponseDto {

--- a/packages/api-client/src/models/shareInvitesControllerListInvitesParams.ts
+++ b/packages/api-client/src/models/shareInvitesControllerListInvitesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type ShareInvitesControllerListInvitesParams = {

--- a/packages/api-client/src/models/shareKeyEntryDto.ts
+++ b/packages/api-client/src/models/shareKeyEntryDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { ShareKeyEntryDtoKeyType } from './shareKeyEntryDtoKeyType';
 

--- a/packages/api-client/src/models/shareKeyEntryDtoKeyType.ts
+++ b/packages/api-client/src/models/shareKeyEntryDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/shareKeyResponseDto.ts
+++ b/packages/api-client/src/models/shareKeyResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { ShareKeyResponseDtoKeyType } from './shareKeyResponseDtoKeyType';
 

--- a/packages/api-client/src/models/shareKeyResponseDtoKeyType.ts
+++ b/packages/api-client/src/models/shareKeyResponseDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type ShareKeyResponseDtoKeyType =

--- a/packages/api-client/src/models/sharesControllerGetReceivedSharesParams.ts
+++ b/packages/api-client/src/models/sharesControllerGetReceivedSharesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type SharesControllerGetReceivedSharesParams = {

--- a/packages/api-client/src/models/sharesControllerGetSentSharesParams.ts
+++ b/packages/api-client/src/models/sharesControllerGetSentSharesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type SharesControllerGetSentSharesParams = {

--- a/packages/api-client/src/models/sharesControllerLookupUserParams.ts
+++ b/packages/api-client/src/models/sharesControllerLookupUserParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export type SharesControllerLookupUserParams = {

--- a/packages/api-client/src/models/teeKeysDto.ts
+++ b/packages/api-client/src/models/teeKeysDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface TeeKeysDto {

--- a/packages/api-client/src/models/testLoginDto.ts
+++ b/packages/api-client/src/models/testLoginDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface TestLoginDto {

--- a/packages/api-client/src/models/testLoginResponseDto.ts
+++ b/packages/api-client/src/models/testLoginResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface TestLoginResponseDto {

--- a/packages/api-client/src/models/tokenResponseDto.ts
+++ b/packages/api-client/src/models/tokenResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface TokenResponseDto {

--- a/packages/api-client/src/models/unlinkMethodDto.ts
+++ b/packages/api-client/src/models/unlinkMethodDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface UnlinkMethodDto {

--- a/packages/api-client/src/models/unlinkMethodResponseDto.ts
+++ b/packages/api-client/src/models/unlinkMethodResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface UnlinkMethodResponseDto {

--- a/packages/api-client/src/models/unpinDto.ts
+++ b/packages/api-client/src/models/unpinDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface UnpinDto {

--- a/packages/api-client/src/models/unpinResponseDto.ts
+++ b/packages/api-client/src/models/unpinResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface UnpinResponseDto {

--- a/packages/api-client/src/models/updateEncryptedKeyDto.ts
+++ b/packages/api-client/src/models/updateEncryptedKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface UpdateEncryptedKeyDto {

--- a/packages/api-client/src/models/updatePermissionDto.ts
+++ b/packages/api-client/src/models/updatePermissionDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { UpdatePermissionDtoPermission } from './updatePermissionDtoPermission';
 

--- a/packages/api-client/src/models/updatePermissionDtoPermission.ts
+++ b/packages/api-client/src/models/updatePermissionDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/uploadResponseDto.ts
+++ b/packages/api-client/src/models/uploadResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface UploadResponseDto {

--- a/packages/api-client/src/models/vaultConfigResponseDto.ts
+++ b/packages/api-client/src/models/vaultConfigResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface VaultConfigResponseDto {

--- a/packages/api-client/src/models/vaultExportDto.ts
+++ b/packages/api-client/src/models/vaultExportDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 export interface VaultExportDto {

--- a/packages/api-client/src/models/vaultResponseDto.ts
+++ b/packages/api-client/src/models/vaultResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { VaultResponseDtoTeeKeys } from './vaultResponseDtoTeeKeys';
 

--- a/packages/api-client/src/models/vaultResponseDtoTeeKeys.ts
+++ b/packages/api-client/src/models/vaultResponseDtoTeeKeys.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { TeeKeysDto } from './teeKeysDto';
 

--- a/packages/api-client/src/models/verifyOtpDto.ts
+++ b/packages/api-client/src/models/verifyOtpDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { VerifyOtpDtoIntent } from './verifyOtpDtoIntent';
 

--- a/packages/api-client/src/models/verifyOtpDtoIntent.ts
+++ b/packages/api-client/src/models/verifyOtpDtoIntent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/packages/api-client/src/models/walletVerifyDto.ts
+++ b/packages/api-client/src/models/walletVerifyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 import type { WalletVerifyDtoIntent } from './walletVerifyDtoIntent';
 

--- a/packages/api-client/src/models/walletVerifyDtoIntent.ts
+++ b/packages/api-client/src/models/walletVerifyDtoIntent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
 
 /**

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,7 +26,14 @@
       "release-type": "node",
       "component": "@cipherbox/api",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "packages/api-client/openapi.json",
+          "jsonpath": "$.info.version"
+        }
+      ]
     },
     "apps/web": {
       "release-type": "node",
@@ -39,10 +46,7 @@
       "component": "cipherbox-desktop",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "extra-files": [
-        "apps/desktop/src-tauri/tauri.conf.json",
-        "apps/desktop/src-tauri/Cargo.toml"
-      ]
+      "extra-files": ["apps/desktop/src-tauri/tauri.conf.json", "apps/desktop/src-tauri/Cargo.toml"]
     },
     "apps/tee-worker": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
- Align `@cipherbox/api-client` (0.33.0 → 0.35.0) and `cipherbox-api-client` (0.4.0 → 0.35.0) versions to match the API package
- Fix hardcoded `0.1.0` OpenAPI version — now reads from `npm_package_version` at runtime and generation time
- Add `openapi.json` as a release-please extra file so future API releases bump it automatically

## Context
Prepares for bootstrap tagging so release-please PR #427 generates a clean changelog instead of listing the entire commit history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API Swagger/OpenAPI documentation now displays the correct version matching your current package release, eliminating previous issues where documentation showed a static placeholder version instead of reflecting actual releases.

* **Chores**
  * Updated version tracking configuration and release management settings to maintain consistency across API client packages and streamline the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->