### PR TITLE
feat(api): expose API version on /health endpoint

### DIFF
--- a/.github/scripts/pr-release-preview.js
+++ b/.github/scripts/pr-release-preview.js
@@ -247,6 +247,9 @@ async function run() {
   const packageCommitTypes = new Map();
 
   for (const commit of commits) {
+    // Skip merge commits — they have 2+ parents and carry no release intent
+    if (commit.parents && commit.parents.length > 1) continue;
+
     const message = commit.commit.message;
     const firstLine = message.split('\n')[0];
     const sha = commit.sha;

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -247,7 +247,8 @@ All M2 blockers resolved. See `.planning/milestones/m2/m2-v1.0-production-MILEST
 | #          | Description                                                   | Date       | Commit     | Directory                                                                                                           |
 | ---------- | ------------------------------------------------------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------- |
 | 260327-2ab | Extract shared-write operations from web UI into SDK packages | 2026-03-27 | see branch | [260327-2ab-extract-shared-write-operations-from-web](./quick/260327-2ab-extract-shared-write-operations-from-web/) |
+| 260401-5ft | Expose the API version on the /health endpoint                | 2026-04-01 | ba5e9de    | [260401-5ft-expose-the-api-version-on-the-api-health](./quick/260401-5ft-expose-the-api-version-on-the-api-health/) |
 
 ---
 
-Last activity: 2026-03-31
+Last activity: 2026-04-01 - Completed quick task 260401-5ft: expose the api version on the api /health endpoint

--- a/.planning/phases/41-package-and-app-versioning-and-release-cycles/41-CONTEXT.md
+++ b/.planning/phases/41-package-and-app-versioning-and-release-cycles/41-CONTEXT.md
@@ -168,6 +168,7 @@ Restructure how all monorepo components (apps, JS packages, Rust crates) are ver
 - Extract "Build shared packages" composite action — identical 5-step pnpm build sequence appears 12 times across 6 workflow files; extract to `.github/actions/build-shared-packages/action.yml`
 - Extract desktop platform build jobs into reusable workflow — macOS/Windows/Linux build jobs are near-identical in both `desktop-release.yml` and `deploy-staging.yml`; could use matrix strategy or reusable workflow
 - PR release preview N+1 API calls — `pr-release-preview.js` fetches commit file details one-by-one (GitHub PR commits endpoint doesn't include files); would need GraphQL batch query to optimize
+- Preserve manually-added release labels across runs — currently the script removes labels for non-computed components on each run, so manual overrides (D-18) must be reapplied after the last commit; could track auto-applied vs manual provenance to preserve them
 
 </deferred>
 

--- a/.planning/quick/260401-5ft-expose-the-api-version-on-the-api-health/260401-5ft-PLAN.md
+++ b/.planning/quick/260401-5ft-expose-the-api-version-on-the-api-health/260401-5ft-PLAN.md
@@ -1,0 +1,153 @@
+---
+phase: quick
+plan: 260401-5ft
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - apps/api/src/health/health.controller.ts
+  - apps/api/src/health/health.controller.spec.ts
+autonomous: true
+requirements: [expose-api-version-on-health]
+
+must_haves:
+  truths:
+    - 'GET /health returns version field in JSON response'
+    - 'Version matches the value from apps/api/package.json'
+    - 'Existing health check behavior (database ping, status) is preserved'
+  artifacts:
+    - path: 'apps/api/src/health/health.controller.ts'
+      provides: 'Health endpoint with version in response'
+      contains: 'version'
+    - path: 'apps/api/src/health/health.controller.spec.ts'
+      provides: 'Unit test for health controller version field'
+  key_links:
+    - from: 'apps/api/src/health/health.controller.ts'
+      to: 'apps/api/package.json'
+      via: 'readFileSync or import to read version'
+      pattern: 'version'
+---
+
+<objective>
+Add the API version (from apps/api/package.json) to the /health endpoint response.
+
+Purpose: Expose the running API version for monitoring, debugging, and deployment verification.
+Output: Updated health controller returning version alongside existing health indicators, with unit test.
+</objective>
+
+<execution_context>
+@/Users/michael/Code/cipher-box/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/michael/Code/cipher-box/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@apps/api/src/health/health.controller.ts
+@apps/api/src/health/health.module.ts
+@apps/api/src/main.ts
+
+<interfaces>
+<!-- Key types the executor needs -->
+
+From @nestjs/terminus:
+
+```typescript
+export type HealthCheckStatus = 'error' | 'ok' | 'shutting_down';
+export interface HealthCheckResult {
+  status: HealthCheckStatus;
+  info?: HealthIndicatorResult;
+  error?: HealthIndicatorResult;
+  details: HealthIndicatorResult;
+}
+```
+
+Current health controller (apps/api/src/health/health.controller.ts):
+
+```typescript
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { HealthCheck, HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
+
+@ApiTags('Health')
+@Controller('health')
+export class HealthController {
+  constructor(
+    private health: HealthCheckService,
+    private db: TypeOrmHealthIndicator
+  ) {}
+
+  @Get()
+  @HealthCheck()
+  @ApiOperation({ summary: 'Check API and database health' })
+  @ApiResponse({ status: 200, description: 'Health check passed' })
+  @ApiResponse({ status: 503, description: 'Health check failed' })
+  check() {
+    return this.health.check([() => this.db.pingCheck('database')]);
+  }
+}
+```
+
+Version reading pattern from main.ts (lines 54-56):
+
+```typescript
+const apiVersion =
+  process.env.npm_package_version ||
+  JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')).version;
+```
+
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add version to /health endpoint response with unit test</name>
+  <files>apps/api/src/health/health.controller.ts, apps/api/src/health/health.controller.spec.ts</files>
+  <behavior>
+    - Test 1: GET /health response includes a `version` field matching the package.json version string
+    - Test 2: GET /health response still includes `status`, `info`, and `details` fields (existing Terminus behavior preserved)
+    - Test 3: The version field is a valid semver string (matches /^\d+\.\d+\.\d+/)
+  </behavior>
+  <action>
+    1. Modify `apps/api/src/health/health.controller.ts`:
+       - Read version from package.json using the same pattern as main.ts: `process.env.npm_package_version || JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8')).version`. Note the path needs `../..` because the controller is in `src/health/` not `src/`.
+       - Alternative (simpler): Since NestJS compiles to `dist/`, use a lazy-loaded module-scoped constant that reads version once at module load time. The cleanest NestJS approach: read version in the controller constructor or as a class property, using `require('../../package.json').version` (works in CommonJS dist output) or `readFileSync` with `join(__dirname, '..', '..', 'package.json')`.
+       - Make the `check()` method async, await `this.health.check(...)`, then spread the result with `version` added: `return { ...result, version }`.
+       - The response shape becomes: `{ status, info, error, details, version }`.
+
+    2. Create `apps/api/src/health/health.controller.spec.ts`:
+       - Use NestJS `Test.createTestingModule` to create a testing module.
+       - Mock `HealthCheckService` with a `check` method that resolves to a standard HealthCheckResult: `{ status: 'ok', info: { database: { status: 'up' } }, error: {}, details: { database: { status: 'up' } } }`.
+       - Mock `TypeOrmHealthIndicator` (required constructor injection).
+       - Assert `result.version` is a string matching semver pattern.
+       - Assert `result.status` is `'ok'`.
+       - Assert `result.info` and `result.details` are preserved from the mock.
+
+    IMPORTANT: Do NOT use `pnpm api:generate` for this change. The /health endpoint is not authenticated and the DTO response shape is implicit (spread of HealthCheckResult + version). The api-client does not consume the health endpoint.
+
+  </action>
+  <verify>
+    <automated>cd /Users/michael/Code/cipher-box && pnpm --filter @cipherbox/api exec jest --testPathPattern health.controller.spec --no-coverage</automated>
+  </verify>
+  <done>GET /health returns `{ status, info, error, details, version }` where version is the semver string from apps/api/package.json. Unit test passes confirming version presence and existing fields preserved.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `curl http://localhost:3000/health` returns JSON with a `version` field (e.g., `"version": "0.35.0"`)
+- Unit test passes: `pnpm --filter @cipherbox/api exec jest --testPathPattern health.controller.spec --no-coverage`
+- Existing health check behavior unchanged: `status`, `info`, `error`, `details` all present
+- API builds without errors: `pnpm --filter @cipherbox/api build`
+</verification>
+
+<success_criteria>
+
+- /health endpoint returns version field matching package.json version
+- All existing health check fields preserved
+- Unit test covers version presence and existing field preservation
+- API compiles and existing tests pass
+  </success_criteria>
+
+<output>
+After completion, create `.planning/quick/260401-5ft-expose-the-api-version-on-the-api-health/260401-5ft-SUMMARY.md`
+</output>

--- a/.planning/quick/260401-5ft-expose-the-api-version-on-the-api-health/260401-5ft-SUMMARY.md
+++ b/.planning/quick/260401-5ft-expose-the-api-version-on-the-api-health/260401-5ft-SUMMARY.md
@@ -1,0 +1,15 @@
+# Quick Task 260401-5ft: Expose API version on /health endpoint
+
+**Status:** Complete
+**Date:** 2026-04-01
+**Commit:** ba5e9de
+
+## Changes
+
+- **`apps/api/src/health/health.controller.ts`** — Added `version` field to health endpoint response. Reads from `npm_package_version` env var (set by pnpm) with fallback to `package.json`. Response shape: `{ status, info, error, details, version }`.
+- **`apps/api/src/health/health.controller.spec.ts`** — New unit test verifying version field presence (semver pattern) and preservation of existing health check fields.
+
+## Verification
+
+- Unit tests pass: `pnpm --filter @cipherbox/api exec jest --testPathPattern health.controller.spec --no-coverage`
+- No API client regeneration needed (health endpoint not in generated client)

--- a/.planning/quick/260401-5ft-expose-the-api-version-on-the-api-health/260401-5ft-SUMMARY.md
+++ b/.planning/quick/260401-5ft-expose-the-api-version-on-the-api-health/260401-5ft-SUMMARY.md
@@ -12,4 +12,4 @@
 ## Verification
 
 - Unit tests pass: `pnpm --filter @cipherbox/api exec jest --testPathPattern health.controller.spec --no-coverage`
-- No API client regeneration needed (health endpoint not in generated client)
+- OpenAPI spec and generated API client updated: `packages/api-client/openapi.json`, `packages/api-client/src/models/healthControllerCheck200.ts`

--- a/apps/api/scripts/generate-openapi.ts
+++ b/apps/api/scripts/generate-openapi.ts
@@ -277,7 +277,7 @@ async function generateOpenApiSpec() {
                       },
                     },
                   },
-                  version: { type: 'string', example: '0.35.0' },
+                  version: { type: 'string', example: openApiVersion },
                 },
               },
             },

--- a/apps/api/scripts/generate-openapi.ts
+++ b/apps/api/scripts/generate-openapi.ts
@@ -248,9 +248,25 @@ async function generateOpenApiSpec() {
             'application/json': {
               schema: {
                 type: 'object',
+                required: ['status', 'details', 'version'],
                 properties: {
                   status: { type: 'string', example: 'ok' },
                   info: {
+                    type: 'object',
+                    properties: {
+                      database: {
+                        type: 'object',
+                        properties: {
+                          status: { type: 'string', example: 'up' },
+                        },
+                      },
+                    },
+                  },
+                  error: {
+                    type: 'object',
+                    additionalProperties: true,
+                  },
+                  details: {
                     type: 'object',
                     properties: {
                       database: {

--- a/apps/api/scripts/generate-openapi.ts
+++ b/apps/api/scripts/generate-openapi.ts
@@ -261,6 +261,7 @@ async function generateOpenApiSpec() {
                       },
                     },
                   },
+                  version: { type: 'string', example: '0.35.0' },
                 },
               },
             },

--- a/apps/api/src/health/health.controller.spec.ts
+++ b/apps/api/src/health/health.controller.spec.ts
@@ -30,16 +30,20 @@ describe('HealthController', () => {
     controller = module.get(HealthController);
   });
 
-  it('should return version field matching semver pattern', async () => {
+  it('should return version field from package.json', async () => {
     const result = await controller.check();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const packageJson = require('../../package.json');
+    const expectedVersion = process.env.npm_package_version ?? packageJson.version;
     expect(result.version).toBeDefined();
-    expect(result.version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(result.version).toBe(expectedVersion);
   });
 
   it('should preserve existing health check fields', async () => {
     const result = await controller.check();
     expect(result.status).toBe('ok');
     expect(result.info).toEqual({ database: { status: 'up' } });
+    expect(result.error).toEqual({});
     expect(result.details).toEqual({ database: { status: 'up' } });
   });
 });

--- a/apps/api/src/health/health.controller.spec.ts
+++ b/apps/api/src/health/health.controller.spec.ts
@@ -1,0 +1,45 @@
+import { Test } from '@nestjs/testing';
+import { HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
+import { HealthController } from './health.controller';
+
+describe('HealthController', () => {
+  let controller: HealthController;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [
+        {
+          provide: HealthCheckService,
+          useValue: {
+            check: jest.fn().mockResolvedValue({
+              status: 'ok',
+              info: { database: { status: 'up' } },
+              error: {},
+              details: { database: { status: 'up' } },
+            }),
+          },
+        },
+        {
+          provide: TypeOrmHealthIndicator,
+          useValue: { pingCheck: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(HealthController);
+  });
+
+  it('should return version field matching semver pattern', async () => {
+    const result = await controller.check();
+    expect(result.version).toBeDefined();
+    expect(result.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('should preserve existing health check fields', async () => {
+    const result = await controller.check();
+    expect(result.status).toBe('ok');
+    expect(result.info).toEqual({ database: { status: 'up' } });
+    expect(result.details).toEqual({ database: { status: 'up' } });
+  });
+});

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,12 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { HealthCheck, HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
-import { readFileSync } from 'fs';
-import { join } from 'path';
-
-const apiVersion =
-  process.env.npm_package_version ||
-  JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8')).version;
+import { API_VERSION } from '../version';
 
 @ApiTags('Health')
 @Controller('health')
@@ -23,6 +18,6 @@ export class HealthController {
   @ApiResponse({ status: 503, description: 'Health check failed' })
   async check() {
     const result = await this.health.check([() => this.db.pingCheck('database')]);
-    return { ...result, version: apiVersion };
+    return { ...result, version: API_VERSION };
   }
 }

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,6 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { HealthCheck, HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const apiVersion =
+  process.env.npm_package_version ||
+  JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8')).version;
 
 @ApiTags('Health')
 @Controller('health')
@@ -15,7 +21,8 @@ export class HealthController {
   @ApiOperation({ summary: 'Check API and database health' })
   @ApiResponse({ status: 200, description: 'Health check passed' })
   @ApiResponse({ status: 503, description: 'Health check failed' })
-  check() {
-    return this.health.check([() => this.db.pingCheck('database')]);
+  async check() {
+    const result = await this.health.check([() => this.db.pingCheck('database')]);
+    return { ...result, version: apiVersion };
   }
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,9 +2,8 @@ import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { ValidationPipe, Logger } from '@nestjs/common';
 import cookieParser from 'cookie-parser';
-import { readFileSync } from 'fs';
-import { join } from 'path';
 import { AppModule } from './app.module';
+import { API_VERSION } from './version';
 
 async function bootstrap() {
   const isDev = process.env.NODE_ENV === 'development' || !process.env.NODE_ENV;
@@ -51,14 +50,10 @@ async function bootstrap() {
     credentials: true,
   });
 
-  const apiVersion =
-    process.env.npm_package_version ||
-    JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')).version;
-
   const config = new DocumentBuilder()
     .setTitle('CipherBox API')
     .setDescription('Zero-knowledge encrypted cloud storage API')
-    .setVersion(apiVersion)
+    .setVersion(API_VERSION)
     .addBearerAuth()
     .build();
   const document = SwaggerModule.createDocument(app, config);

--- a/apps/api/src/version.ts
+++ b/apps/api/src/version.ts
@@ -1,0 +1,6 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export const API_VERSION: string =
+  process.env.npm_package_version ||
+  JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')).version;

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -2122,6 +2122,10 @@
                           }
                         }
                       }
+                    },
+                    "version": {
+                      "type": "string",
+                      "example": "0.35.0"
                     }
                   }
                 }

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -2104,12 +2104,31 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["status", "details", "version"],
                   "properties": {
                     "status": {
                       "type": "string",
                       "example": "ok"
                     },
                     "info": {
+                      "type": "object",
+                      "properties": {
+                        "database": {
+                          "type": "object",
+                          "properties": {
+                            "status": {
+                              "type": "string",
+                              "example": "up"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "error": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "details": {
                       "type": "object",
                       "properties": {
                         "database": {

--- a/packages/api-client/src/models/healthControllerCheck200.ts
+++ b/packages/api-client/src/models/healthControllerCheck200.ts
@@ -10,4 +10,5 @@ import type { HealthControllerCheck200Info } from './healthControllerCheck200Inf
 export type HealthControllerCheck200 = {
   status?: string;
   info?: HealthControllerCheck200Info;
+  version?: string;
 };

--- a/packages/api-client/src/models/healthControllerCheck200.ts
+++ b/packages/api-client/src/models/healthControllerCheck200.ts
@@ -6,9 +6,13 @@
  * OpenAPI spec version: 0.35.0
  */
 import type { HealthControllerCheck200Info } from './healthControllerCheck200Info';
+import type { HealthControllerCheck200Error } from './healthControllerCheck200Error';
+import type { HealthControllerCheck200Details } from './healthControllerCheck200Details';
 
 export type HealthControllerCheck200 = {
-  status?: string;
+  status: string;
   info?: HealthControllerCheck200Info;
-  version?: string;
+  error?: HealthControllerCheck200Error;
+  details: HealthControllerCheck200Details;
+  version: string;
 };

--- a/packages/api-client/src/models/healthControllerCheck200Details.ts
+++ b/packages/api-client/src/models/healthControllerCheck200Details.ts
@@ -3,12 +3,10 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.1.0
+ * OpenAPI spec version: 0.35.0
  */
+import type { HealthControllerCheck200DetailsDatabase } from './healthControllerCheck200DetailsDatabase';
 
 export type HealthControllerCheck200Details = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
+  database?: HealthControllerCheck200DetailsDatabase;
 };

--- a/packages/api-client/src/models/healthControllerCheck200DetailsDatabase.ts
+++ b/packages/api-client/src/models/healthControllerCheck200DetailsDatabase.ts
@@ -6,4 +6,6 @@
  * OpenAPI spec version: 0.35.0
  */
 
-export type HealthControllerCheck200Error = { [key: string]: unknown };
+export type HealthControllerCheck200DetailsDatabase = {
+  status?: string;
+};

--- a/packages/api-client/src/models/index.ts
+++ b/packages/api-client/src/models/index.ts
@@ -42,6 +42,7 @@ export * from './googleLoginDto';
 export * from './googleLoginDtoIntent';
 export * from './healthControllerCheck200';
 export * from './healthControllerCheck200Details';
+export * from './healthControllerCheck200DetailsDatabase';
 export * from './healthControllerCheck200Error';
 export * from './healthControllerCheck200Info';
 export * from './healthControllerCheck200InfoDatabase';


### PR DESCRIPTION
## Summary
- Adds `version` field to `/health` endpoint response, read from `package.json`
- Updates the manually-defined health endpoint in the OpenAPI generation script to include the version property
- Regenerates API client with updated spec

## Test plan
- [x] Unit tests pass: `pnpm --filter @cipherbox/api exec jest --testPathPattern health.controller.spec`
- [x] `curl localhost:3000/health` returns `version` field
- [x] Release preview labels correctly attribute `feat` to `@cipherbox/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `/health` endpoint now includes the API version in its response payload, enabling clients to identify the running API version alongside existing health status information.

* **Tests**
  * Added unit test coverage to verify the version field is present, valid, and does not impact existing health check functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->