### PR TITLE
fix(ci): correct openapi.json extra-files path for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,7 +30,7 @@
       "extra-files": [
         {
           "type": "json",
-          "path": "packages/api-client/openapi.json",
+          "path": "../../packages/api-client/openapi.json",
           "jsonpath": "$.info.version"
         }
       ]


### PR DESCRIPTION
## Summary
- Fix `extra-files` path for `openapi.json` in release-please config — paths are relative to the package dir (`apps/api/`), so `packages/api-client/openapi.json` resolved to `apps/api/packages/api-client/openapi.json` (doesn't exist)
- Use `../../packages/api-client/openapi.json` to correctly escape the package directory

This caused the release PR (#430) to bump `apps/api/package.json` to `0.36.0` without updating `openapi.json`, which then failed the "Verify API Spec & Client" check.

## Test plan
- [ ] After merge, release-please should update `openapi.json` version in the release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the post-merge release automation workflow and consolidated release orchestration to use PR-based preview and configuration management.
  * Enhanced the release preview workflow with improved concurrency handling and automatic configuration updates for better release coordination.
  * Corrected the path reference for API client version detection in release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->