### PR TITLE
chore(ci): move openapi.json extra-files to api-client package

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,14 +26,7 @@
       "release-type": "node",
       "component": "@cipherbox/api",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true,
-      "extra-files": [
-        {
-          "type": "json",
-          "path": "../../packages/api-client/openapi.json",
-          "jsonpath": "$.info.version"
-        }
-      ]
+      "bump-minor-pre-major": true
     },
     "apps/web": {
       "release-type": "node",
@@ -70,7 +63,14 @@
       "release-type": "node",
       "component": "@cipherbox/api-client",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "openapi.json",
+          "jsonpath": "$.info.version"
+        }
+      ]
     },
     "packages/sdk-core": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
- Move `openapi.json` extra-files config from `apps/api` to `packages/api-client` where the file actually lives
- Path is now simply `openapi.json` — no relative escaping needed

Fixes the release-please error from the `../../` path in #432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)