### PR TITLE
chore(api): use static version example in health endpoint OpenAPI spec

### DIFF
--- a/apps/api/scripts/generate-openapi.ts
+++ b/apps/api/scripts/generate-openapi.ts
@@ -277,7 +277,7 @@ async function generateOpenApiSpec() {
                       },
                     },
                   },
-                  version: { type: 'string', example: openApiVersion },
+                  version: { type: 'string', example: '1.0.0' },
                 },
               },
             },

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -2144,7 +2144,7 @@
                     },
                     "version": {
                       "type": "string",
-                      "example": "0.35.0"
+                      "example": "1.0.0"
                     }
                   }
                 }


### PR DESCRIPTION
## Summary
- Replace dynamic `openApiVersion` with static `1.0.0` in the health endpoint's version example field
- Prevents the OpenAPI spec from drifting on release bumps (follow-up to #434)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the health endpoint response to use a fixed version value instead of a dynamically computed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->