### PR TITLE
fix(web): replace emoji sidebar icons with consistent inline SVGs

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -248,7 +248,8 @@ All M2 blockers resolved. See `.planning/milestones/m2/m2-v1.0-production-MILEST
 | ---------- | ------------------------------------------------------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------- |
 | 260327-2ab | Extract shared-write operations from web UI into SDK packages | 2026-03-27 | see branch | [260327-2ab-extract-shared-write-operations-from-web](./quick/260327-2ab-extract-shared-write-operations-from-web/) |
 | 260401-5ft | Expose the API version on the /health endpoint                | 2026-04-01 | ba5e9de    | [260401-5ft-expose-the-api-version-on-the-api-health](./quick/260401-5ft-expose-the-api-version-on-the-api-health/) |
+| 260401-kyv | Fix sidebar icons to be consistent                            | 2026-04-01 | 749065d    | [260401-kyv-fix-sidebar-icons-to-be-consistent](./quick/260401-kyv-fix-sidebar-icons-to-be-consistent/)             |
 
 ---
 
-Last activity: 2026-04-01 - Completed quick task 260401-5ft: expose the api version on the api /health endpoint
+Last activity: 2026-04-01 - Completed quick task 260401-kyv: fix sidebar icons to be consistent

--- a/.planning/quick/260401-kyv-fix-sidebar-icons-to-be-consistent/260401-kyv-PLAN.md
+++ b/.planning/quick/260401-kyv-fix-sidebar-icons-to-be-consistent/260401-kyv-PLAN.md
@@ -1,0 +1,149 @@
+---
+phase: quick
+plan: 260401-kyv
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - apps/web/src/components/layout/NavItem.tsx
+  - apps/web/src/styles/layout.css
+autonomous: true
+requirements: [sidebar-icon-consistency]
+
+must_haves:
+  truths:
+    - 'All four sidebar icons (Files, Shared, Bin, Settings) render as monochrome SVGs that inherit text color'
+    - 'Icons are visually consistent across platforms (no emoji rendering variance)'
+    - 'Active and hover states change icon color via CSS inheritance (currentColor)'
+  artifacts:
+    - path: 'apps/web/src/components/layout/NavItem.tsx'
+      provides: 'Inline SVG icon components replacing emoji ICON_MAP'
+      contains: 'currentColor'
+    - path: 'apps/web/src/styles/layout.css'
+      provides: 'Updated .nav-item-icon styles for SVG sizing'
+      contains: '.nav-item-icon'
+  key_links:
+    - from: 'NavItem.tsx SVG icons'
+      to: 'layout.css .nav-item color'
+      via: 'currentColor fill/stroke on SVGs inherits from parent .nav-item color'
+      pattern: 'currentColor'
+---
+
+<objective>
+Replace mixed Unicode emoji/symbol sidebar navigation icons with uniform inline SVG React components.
+
+Purpose: Emoji render differently across platforms (colorful on macOS, monochrome on others) and the settings gear (U+2699) is a basic Unicode symbol while others are full emoji. This creates visual inconsistency in the terminal/hacker aesthetic. Inline SVGs with currentColor will render identically everywhere and inherit the green-on-black color scheme.
+
+Output: Consistent monochrome SVG sidebar icons that respond to CSS color states (normal, hover, active).
+</objective>
+
+<execution_context>
+@/Users/michael/Code/cipher-box/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/michael/Code/cipher-box/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@apps/web/src/components/layout/NavItem.tsx
+@apps/web/src/components/layout/AppSidebar.tsx
+@apps/web/src/styles/layout.css
+
+<interfaces>
+<!-- NavItem interface consumed by AppSidebar -->
+From apps/web/src/components/layout/NavItem.tsx:
+```typescript
+interface NavItemProps {
+  to: string;
+  icon: 'folder' | 'shared' | 'bin' | 'settings';
+  label: string;
+  active: boolean;
+}
+
+// Current approach: ICON_MAP maps icon string -> Unicode emoji string
+// Target approach: ICON_MAP maps icon string -> JSX.Element (inline SVG)
+
+````
+
+From apps/web/src/components/layout/AppSidebar.tsx:
+```typescript
+// Uses NavItem with these icon values:
+// "folder" (Files), "shared" (Shared), "bin" (Bin), "settings" (Settings)
+````
+
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Replace emoji ICON_MAP with inline SVG components and update CSS</name>
+  <files>apps/web/src/components/layout/NavItem.tsx, apps/web/src/styles/layout.css</files>
+  <action>
+In NavItem.tsx:
+
+1. Change `ICON_MAP` from `Record<NavItemProps['icon'], string>` to `Record<NavItemProps['icon'], JSX.Element>` (import `type { JSX }` from React if needed for the type, or use `React.ReactNode`).
+
+2. Replace each emoji entry with a small inline SVG element. All SVGs should be 16x16 viewBox, use `fill="currentColor"` or `stroke="currentColor"` (as appropriate for the icon style), and have `aria-hidden="true"` since the label provides the accessible name. Use simple, recognizable shapes that match a terminal/monochrome aesthetic:
+   - **folder**: A folder outline. `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M1.5 2.5h4l1.5 1.5h7.5v9h-13v-10.5z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round"/></svg>`
+   - **shared**: A link/chain icon (two interlocking oval links). `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6.5 9.5l3-3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/><path d="M8.5 10.5l-1 1a2.12 2.12 0 01-3 0v0a2.12 2.12 0 010-3l1-1" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/><path d="M7.5 5.5l1-1a2.12 2.12 0 013 0v0a2.12 2.12 0 010 3l-1 1" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/></svg>`
+   - **bin**: A trash can outline. `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M3 4.5h10M6.5 4.5V3a.5.5 0 01.5-.5h2a.5.5 0 01.5.5v1.5M4 4.5l.5 8.5a1 1 0 001 1h5a1 1 0 001-1l.5-8.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/></svg>`
+   - **settings**: A gear/cog outline. `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="2" stroke="currentColor" strokeWidth="1.2"/><path d="M8 1.5v1.5M8 13v1.5M1.5 8H3M13 8h1.5M3.05 3.05l1.06 1.06M11.89 11.89l1.06 1.06M3.05 12.95l1.06-1.06M11.89 4.11l1.06-1.06" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/></svg>`
+
+3. Replace the render from `<span className="nav-item-icon">{iconEmoji}</span>` to `<span className="nav-item-icon">{ICON_MAP[icon]}</span>` (remove the intermediate `iconEmoji` variable — just use ICON_MAP[icon] directly).
+
+4. Update the JSDoc comment from "Renders a sidebar navigation link with emoji icon" to "Renders a sidebar navigation link with SVG icon."
+
+In layout.css:
+
+5. Update the `.nav-item-icon` rule to work with SVGs instead of emoji text:
+   ```css
+   .nav-item-icon {
+     display: flex;
+     align-items: center;
+     justify-content: center;
+     width: 16px;
+     height: 16px;
+     flex-shrink: 0;
+   }
+   ```
+   Remove the `font-family` and `font-size` properties since they only applied to text-based emoji.
+   </action>
+   <verify>
+   <automated>cd /Users/michael/Code/cipher-box && pnpm --filter web exec tsc --noEmit 2>&1 | head -30</automated>
+   </verify>
+   <done>All four sidebar nav icons render as inline SVGs using currentColor. No emoji or Unicode characters remain in NavItem.tsx. TypeScript compiles without errors. The icon type union ('folder' | 'shared' | 'bin' | 'settings') is unchanged so AppSidebar requires zero modifications.</done>
+   </task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <what-built>Replaced all four sidebar emoji icons with monochrome inline SVGs that inherit text color via currentColor. Icons: folder (outline), link/chain (shared), trash can (bin), gear/cog (settings).</what-built>
+  <how-to-verify>
+    1. Start the web dev server: `pnpm --filter web dev`
+    2. Open http://localhost:5173 and log in
+    3. Verify the sidebar shows four navigation items with monochrome SVG icons (not colorful emoji)
+    4. Verify all four icons are visually consistent — same stroke weight, same size, same color
+    5. Hover over each nav item — icon color should change along with the text (both inherit from parent)
+    6. Click a nav item — active state should show the icon in the brighter/primary text color
+    7. Confirm the icons match the terminal/hacker aesthetic (thin strokes, monochrome green)
+  </how-to-verify>
+  <resume-signal>Type "approved" or describe any icon that needs adjustment (e.g., "bin icon too thin", "settings gear not recognizable")</resume-signal>
+</task>
+
+</tasks>
+
+<verification>
+- TypeScript compiles without errors: `pnpm --filter web exec tsc --noEmit`
+- No emoji/Unicode icon characters remain: grep for `\uD83D\|\u2699\|ICON_MAP.*string` in NavItem.tsx should return nothing
+- SVGs use currentColor: grep for `currentColor` in NavItem.tsx returns matches for all four icons
+</verification>
+
+<success_criteria>
+
+- All four sidebar icons are inline SVGs (no emoji, no Unicode symbols)
+- Icons use currentColor for fill/stroke, inheriting color from CSS
+- Icon appearance is consistent across all four nav items (same size, stroke weight, style)
+- Hover and active states affect icon color through CSS inheritance
+- No changes needed to AppSidebar.tsx — the icon prop type union is preserved
+  </success_criteria>
+
+<output>
+After completion, create `.planning/quick/260401-kyv-fix-sidebar-icons-to-be-consistent/260401-kyv-SUMMARY.md`
+</output>

--- a/.planning/quick/260401-kyv-fix-sidebar-icons-to-be-consistent/260401-kyv-SUMMARY.md
+++ b/.planning/quick/260401-kyv-fix-sidebar-icons-to-be-consistent/260401-kyv-SUMMARY.md
@@ -1,0 +1,111 @@
+---
+phase: quick
+plan: 260401-kyv
+subsystem: ui
+tags: [react, svg, sidebar, icons, css]
+
+# Dependency graph
+requires: []
+provides:
+  - Monochrome inline SVG sidebar icons replacing platform-dependent emoji
+  - currentColor-based icon color inheritance for hover/active CSS states
+affects: [sidebar, navigation, layout]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - 'Inline SVG with currentColor for icon color inheritance from parent CSS'
+    - 'ReactNode ICON_MAP pattern for type-safe icon rendering'
+
+key-files:
+  created: []
+  modified:
+    - apps/web/src/components/layout/NavItem.tsx
+    - apps/web/src/styles/layout.css
+
+key-decisions:
+  - 'Used stroke-based SVGs (fill="none", stroke="currentColor") for consistent thin-line terminal aesthetic'
+  - 'Kept ICON_MAP pattern but changed value type from string to ReactNode for inline SVG elements'
+  - 'Used 16x16 viewBox with strokeWidth="1.2" across all four icons for visual consistency'
+
+patterns-established:
+  - 'Inline SVG icon pattern: 16x16 viewBox, fill="none", stroke="currentColor", strokeWidth="1.2", aria-hidden="true"'
+
+requirements-completed: [sidebar-icon-consistency]
+
+# Metrics
+duration: 5min
+completed: 2026-04-01
+---
+
+# Quick Plan 260401-kyv: Fix Sidebar Icons Summary
+
+**Replaced four emoji sidebar icons with monochrome inline SVGs using currentColor for platform-consistent rendering**
+
+## Performance
+
+- **Duration:** 5 min
+- **Started:** 2026-04-01T13:10:00Z
+- **Completed:** 2026-04-01T13:15:13Z
+- **Tasks:** 2 (1 auto + 1 human-verify checkpoint)
+- **Files modified:** 2
+
+## Accomplishments
+
+- Replaced all four sidebar navigation emoji icons (folder, shared/link, bin/trash, settings/gear) with inline SVG elements
+- Icons now render identically across platforms (no emoji rendering variance between macOS/Windows/Linux)
+- SVG icons inherit text color via currentColor, enabling hover and active state transitions through CSS without separate icon color rules
+- Updated `.nav-item-icon` CSS from text/emoji styling (font-family, font-size) to flex container for SVG alignment
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Replace emoji ICON_MAP with inline SVG components and update CSS** - `6f6cacb` (fix)
+
+**Plan metadata:** (this commit)
+
+## Files Created/Modified
+
+- `apps/web/src/components/layout/NavItem.tsx` - Changed ICON_MAP from `Record<..., string>` (emoji) to `Record<..., ReactNode>` (inline SVGs); removed intermediate `iconEmoji` variable; updated JSDoc
+- `apps/web/src/styles/layout.css` - Replaced `.nav-item-icon` font-family/font-size rules with flex container layout (display: flex, align-items: center, 16x16 sizing)
+
+## Decisions Made
+
+- Used stroke-only SVGs (fill="none") with thin strokeWidth="1.2" to match the terminal/hacker monochrome aesthetic
+- Kept the existing ICON_MAP lookup pattern rather than extracting separate icon components, since four small SVGs do not warrant individual files
+- All SVGs use aria-hidden="true" because the adjacent `.nav-item-label` span already provides accessible text
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None
+
+## Known Stubs
+
+None - all four icons are fully implemented with proper SVG paths and CSS styling.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- Sidebar icons are complete and visually verified by human review
+- No follow-up work needed unless icon designs are revised in a future design pass
+
+---
+
+_Plan: 260401-kyv (quick)_
+_Completed: 2026-04-01_
+
+## Self-Check: PASSED
+
+- FOUND: apps/web/src/components/layout/NavItem.tsx
+- FOUND: apps/web/src/styles/layout.css
+- FOUND: 260401-kyv-SUMMARY.md
+- FOUND: 6f6cacb (task 1 commit)

--- a/apps/web/src/components/layout/NavItem.tsx
+++ b/apps/web/src/components/layout/NavItem.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 
 interface NavItemProps {
@@ -7,25 +8,68 @@ interface NavItemProps {
   active: boolean;
 }
 
-const ICON_MAP: Record<NavItemProps['icon'], string> = {
-  folder: '\uD83D\uDCC1',
-  shared: '\uD83D\uDD17',
-  bin: '\uD83D\uDDD1',
-  settings: '\u2699',
+const ICON_MAP: Record<NavItemProps['icon'], ReactNode> = {
+  folder: (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path
+        d="M1.5 2.5h4l1.5 1.5h7.5v9h-13v-10.5z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
+  shared: (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M6.5 9.5l3-3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <path
+        d="M8.5 10.5l-1 1a2.12 2.12 0 01-3 0v0a2.12 2.12 0 010-3l1-1"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M7.5 5.5l1-1a2.12 2.12 0 013 0v0a2.12 2.12 0 010 3l-1 1"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+    </svg>
+  ),
+  bin: (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path
+        d="M3 4.5h10M6.5 4.5V3a.5.5 0 01.5-.5h2a.5.5 0 01.5.5v1.5M4 4.5l.5 8.5a1 1 0 001 1h5a1 1 0 001-1l.5-8.5"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
+  settings: (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="8" cy="8" r="2" stroke="currentColor" strokeWidth="1.2" />
+      <path
+        d="M8 1.5v1.5M8 13v1.5M1.5 8H3M13 8h1.5M3.05 3.05l1.06 1.06M11.89 11.89l1.06 1.06M3.05 12.95l1.06-1.06M11.89 4.11l1.06-1.06"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+    </svg>
+  ),
 };
 
 /**
  * Navigation item component.
- * Renders a sidebar navigation link with emoji icon.
+ * Renders a sidebar navigation link with SVG icon.
  */
 export function NavItem({ to, icon, label, active }: NavItemProps) {
-  const iconEmoji = ICON_MAP[icon];
-
   const className = active ? 'nav-item nav-item--active' : 'nav-item';
 
   return (
     <Link to={to} className={className} data-testid={`nav-item-${label.toLowerCase()}`}>
-      <span className="nav-item-icon">{iconEmoji}</span>
+      <span className="nav-item-icon">{ICON_MAP[icon]}</span>
       <span className="nav-item-label">{label}</span>
     </Link>
   );

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -159,8 +159,12 @@
 }
 
 .nav-item-icon {
-  font-family: var(--font-family-mono);
-  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
 }
 
 /* Storage Quota */

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,17 +3,56 @@
   "separate-pull-requests": false,
   "pull-request-title-pattern": "chore: release v${version}",
   "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "fix", "section": "Bug Fixes" },
-    { "type": "build", "section": "Build System" },
-    { "type": "perf", "section": "Performance Improvements" },
-    { "type": "revert", "section": "Reverts" },
-    { "type": "docs", "section": "Documentation", "hidden": true },
-    { "type": "style", "section": "Styles", "hidden": true },
-    { "type": "chore", "section": "Miscellaneous", "hidden": true },
-    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
-    { "type": "test", "section": "Tests", "hidden": true },
-    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "build",
+      "section": "Build System"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "section": "Styles",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    }
   ],
   "packages": {
     ".": {
@@ -32,14 +71,18 @@
       "release-type": "node",
       "component": "@cipherbox/web",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "0.37.0"
     },
     "apps/desktop": {
       "release-type": "node",
       "component": "cipherbox-desktop",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "extra-files": ["apps/desktop/src-tauri/tauri.conf.json", "apps/desktop/src-tauri/Cargo.toml"]
+      "extra-files": [
+        "apps/desktop/src-tauri/tauri.conf.json",
+        "apps/desktop/src-tauri/Cargo.toml"
+      ]
     },
     "apps/tee-worker": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
- Replaced mixed Unicode emoji/symbol sidebar icons with uniform inline SVG icons
- All 4 nav icons (Files, Shared, Bin, Settings) now use stroke-based SVGs with `currentColor` and consistent `strokeWidth="1.2"`
- Updated `.nav-item-icon` CSS from font-based text styling to flex container for SVG containment

## Test plan
- [ ] Verify all 4 sidebar icons render as monochrome SVGs matching the terminal aesthetic
- [ ] Hover over each nav item — icon color should change with the text
- [ ] Active nav item should show icon in brighter/primary color
- [ ] Check icons are visually consistent in size and stroke weight

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Sidebar navigation icons replaced with consistent monochrome inline SVGs (replacing emoji) for uniform cross-platform appearance and proper sizing/alignment.
* **Documentation**
  * Project planning/state updated to record the completed quick task and its verification notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->