### PR TITLE
fix(ci): ignore OpenAPI version comment in generated TS file diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
             exit 1
           fi
           # Compare generated TS files (ignore version comment — differs on release PRs)
-          git diff --exit-code -I 'OpenAPI spec version' packages/api-client/src/generated/ packages/api-client/src/models/ \
+          git diff --exit-code -I '^ \* OpenAPI spec version: [0-9]' packages/api-client/src/generated/ packages/api-client/src/models/ \
             || (echo "Generated API client is out of date. Run 'pnpm api:generate' and commit changes." && exit 1)
 
   migration-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,8 +164,8 @@ jobs:
             echo "Generated API client is out of date. Run 'pnpm api:generate' and commit changes."
             exit 1
           fi
-          # Compare generated TS files exactly
-          git diff --exit-code packages/api-client/src/generated/ packages/api-client/src/models/ \
+          # Compare generated TS files (ignore version comment — differs on release PRs)
+          git diff --exit-code -I 'OpenAPI spec version' packages/api-client/src/generated/ packages/api-client/src/models/ \
             || (echo "Generated API client is out of date. Run 'pnpm api:generate' and commit changes." && exit 1)
 
   migration-check:


### PR DESCRIPTION
## Summary
- The `Verify API Spec & Client` CI step fails on the release-please branch because version bumps (e.g. 0.35.0 → 0.36.0) change the `* OpenAPI spec version:` comment in every generated TS file
- The `openapi.json` check already excludes `info.version` — this applies the same treatment to generated TS files using `git diff -I 'OpenAPI spec version'`

## Test plan
- [ ] Verify the release-please branch CI passes after merge
- [ ] Verify that actual schema changes (not just version comments) are still caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI validation updated to ignore version-only differences in generated API client files.
  * Prevents pipeline failures caused solely by changes to version metadata in generated outputs, allowing builds to proceed when no functional code changes are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->