### PR TITLE
chore(ci): validate release tag before staging deployment

### DIFF
--- a/.github/workflows/tag-staging.yml
+++ b/.github/workflows/tag-staging.yml
@@ -24,7 +24,13 @@ jobs:
           ref: main
           fetch-depth: 0
       - id: main
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          SHA=$(git rev-parse HEAD)
+          if ! git tag --points-at "$SHA" | grep -qE '^(cipher-box-v|@cipherbox/)'; then
+            echo "::error::No release tag found on main HEAD (${SHA:0:7}). Wait for release-please to merge before tagging staging."
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
   web-e2e:
     needs: resolve-main

--- a/.github/workflows/tag-staging.yml
+++ b/.github/workflows/tag-staging.yml
@@ -26,7 +26,7 @@ jobs:
       - id: main
         run: |
           SHA=$(git rev-parse HEAD)
-          if ! git tag --points-at "$SHA" | grep -qE '^(cipher-box-v|@cipherbox/)'; then
+          if ! git tag --points-at "$SHA" | grep -qE '^(cipher-box-v|cipherbox-.*-v|@cipherbox/)'; then
             echo "::error::No release tag found on main HEAD (${SHA:0:7}). Wait for release-please to merge before tagging staging."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Adds a release tag check in the `Resolve main SHA` step of the Tag Staging Release workflow
- Fails fast with a clear error if no release-please tag (`cipher-box-v*` or `@cipherbox/*`) exists on main HEAD
- Prevents staging deployments from unversioned commits without reverting to the old manual tag-selection approach

## Test plan
- [ ] Trigger `Tag Staging Release` workflow — should succeed since current main HEAD has release tags
- [ ] Verify the workflow would fail on a commit without release tags (e.g., after a feature PR merges but before release-please runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Enhanced release validation process to ensure proper tag requirements are met before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->