### PR TITLE
docs: backfill phase 38 and 39 summaries

### DIFF
--- a/.planning/phases/38-retire-deprecated-web-services/38-01-SUMMARY.md
+++ b/.planning/phases/38-retire-deprecated-web-services/38-01-SUMMARY.md
@@ -1,0 +1,11 @@
+# Plan 38-01 Summary: Migrate folder.service callers to SDK imports
+
+## Status: COMPLETE
+
+## Changes Made
+
+Migrated all callers of `folder.service.ts` to `@cipherbox/sdk` / `@cipherbox/sdk-core` imports. Extracted `addFileToFolder`, `addFilesToFolder`, `replaceFileInFolder` into `@cipherbox/sdk-core`. Web hooks now import SDK functions directly and pass store-extracted state as explicit params, following the established pattern from `useSharedWriteOps.ts`.
+
+## Delivered In
+
+PR #422 — merged 2026-03-31

--- a/.planning/phases/38-retire-deprecated-web-services/38-02-SUMMARY.md
+++ b/.planning/phases/38-retire-deprecated-web-services/38-02-SUMMARY.md
@@ -1,0 +1,11 @@
+# Plan 38-02 Summary: Migrate bin.service callers to SDK client
+
+## Status: COMPLETE
+
+## Changes Made
+
+Migrated all callers of `bin.service.ts` to `@cipherbox/sdk` client methods. Added `purgeExpired()` method to `CipherBoxClient` and `purgeExpiredEntries()` function in `packages/sdk/src/bin/index.ts`. Improved bin load/purge flows and store synchronization to reduce stale recycle-bin state.
+
+## Delivered In
+
+PR #422 — merged 2026-03-31

--- a/.planning/phases/38-retire-deprecated-web-services/38-03-SUMMARY.md
+++ b/.planning/phases/38-retire-deprecated-web-services/38-03-SUMMARY.md
@@ -1,0 +1,11 @@
+# Plan 38-03 Summary: Fix @cipherbox/crypto circular devDependency
+
+## Status: COMPLETE
+
+## Changes Made
+
+Removed circular `@cipherbox/core` devDependency from `@cipherbox/crypto`. `vault-ipns.test.ts` now uses hardcoded test vectors instead of cross-package imports.
+
+## Delivered In
+
+PR #422 — merged 2026-03-31

--- a/.planning/phases/38-retire-deprecated-web-services/38-04-SUMMARY.md
+++ b/.planning/phases/38-retire-deprecated-web-services/38-04-SUMMARY.md
@@ -1,0 +1,11 @@
+# Plan 38-04 Summary: Delete deprecated services and clean up barrel exports
+
+## Status: COMPLETE
+
+## Changes Made
+
+Deleted `folder.service.ts` (1,059 LOC) and `bin.service.ts` (971 LOC) — 2,030 lines of deprecated code removed. Cleaned up barrel exports in `apps/web/src/services/index.ts`. Net result: -1,671 lines (503 added, 2,174 removed).
+
+## Delivered In
+
+PR #422 — merged 2026-03-31

--- a/.planning/phases/38-retire-deprecated-web-services/38-CONTEXT.md
+++ b/.planning/phases/38-retire-deprecated-web-services/38-CONTEXT.md
@@ -1,7 +1,7 @@
 # Phase 38: Retire deprecated web services - Context
 
 **Gathered:** 2026-03-31
-**Status:** Ready for planning
+**Status:** Complete (2026-03-31, PR #422)
 
 <domain>
 ## Phase Boundary

--- a/.planning/phases/39-user-configurable-vault-parameters/39-01-SUMMARY.md
+++ b/.planning/phases/39-user-configurable-vault-parameters/39-01-SUMMARY.md
@@ -1,0 +1,11 @@
+# Plan 39-01 Summary: Core types and validation for VaultSettings
+
+## Status: COMPLETE
+
+## Changes Made
+
+Added `VaultSettings` type to `@cipherbox/core` with defaults matching current hardcoded values (30-day retention, 10 max versions, 15min cooldown, soft-delete). Implemented `DEFAULT_VAULT_SETTINGS` and `validateVaultSettings()`. Added 143-line unit test suite for validation, defaults, and edge cases.
+
+## Delivered In
+
+PR #423 — merged 2026-03-31

--- a/.planning/phases/39-user-configurable-vault-parameters/39-02-SUMMARY.md
+++ b/.planning/phases/39-user-configurable-vault-parameters/39-02-SUMMARY.md
@@ -1,0 +1,11 @@
+# Plan 39-02 Summary: Vault settings store and IPNS persistence
+
+## Status: COMPLETE
+
+## Changes Made
+
+Added `deriveVaultSettingsIpnsKeypair` HKDF derivation to `@cipherbox/crypto` with domain-separated key derivation. Created vault settings Zustand store (`vault-settings.store.ts`) and IPNS load/save service (`vault-settings.service.ts`), following the established BYO-IPFS config pattern.
+
+## Delivered In
+
+PR #423 — merged 2026-03-31

--- a/.planning/phases/39-user-configurable-vault-parameters/39-CONTEXT.md
+++ b/.planning/phases/39-user-configurable-vault-parameters/39-CONTEXT.md
@@ -1,7 +1,7 @@
 # Phase 39: User-configurable vault parameters - Context
 
 **Gathered:** 2026-03-31
-**Status:** Ready for planning
+**Status:** Complete (2026-03-31, PR #423)
 
 <domain>
 ## Phase Boundary


### PR DESCRIPTION
## Summary
- Adds stub summaries for phases 38 and 39 that shipped outside the GSD workflow (PRs #422, #423)
- Updates context status from "Ready for planning" to "Complete" for both phases
- Brings `/gsd:stats` completion tracking in line with actual project state (26/26 phases)

## Test plan
- [ ] `/gsd:stats` shows phases 38 and 39 as Complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user-configurable vault parameters including retention duration, version limits, and cooldown settings with sensible defaults.
  * Vault settings are now persistently stored and can be customized per installation.

* **Chores**
  * Completed retirement of deprecated internal services with streamlined SDK-based architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->