### PR TITLE
fix(web): improve file browser empty state handling during uploads

### DIFF
--- a/apps/web/src/components/file-browser/FileBrowser.tsx
+++ b/apps/web/src/components/file-browser/FileBrowser.tsx
@@ -10,6 +10,7 @@ import { useDropUpload } from '../../hooks/useDropUpload';
 import { isFilePointer, isPreviewableFile, isTextFile } from '../../utils/fileTypes';
 import { useVaultStore } from '../../stores/vault.store';
 import { useSyncStore } from '../../stores/sync.store';
+import { useUploadStore } from '../../stores/upload.store';
 import { FileList } from './FileList';
 import { EmptyState } from './EmptyState';
 import { ContextMenu } from './ContextMenu';
@@ -93,6 +94,15 @@ export function FileBrowser() {
   const children = currentFolder?.children ?? [];
   const hasChildren = children.length > 0;
 
+  // Show FileList (with progress rows) instead of EmptyState when uploads are
+  // actively targeting this folder, even if the folder has no committed children yet.
+  const hasUploadsForFolder = useUploadStore((s) => {
+    for (const f of s.files.values()) {
+      if (f.targetFolderId === currentFolderId) return true;
+    }
+    return false;
+  });
+
   const deleteMessage =
     actions.confirmDialog.item?.type === 'folder'
       ? `Are you sure you want to delete "${actions.confirmDialog.item?.name}"? This will also delete all files and subfolders inside. This cannot be undone.`
@@ -168,7 +178,7 @@ export function FileBrowser() {
         </div>
       )}
 
-      {!isLoading && hasChildren && (
+      {!isLoading && (hasChildren || hasUploadsForFolder) && (
         <FileList
           items={children}
           selectedIds={actions.selectedIds}
@@ -187,9 +197,10 @@ export function FileBrowser() {
         />
       )}
 
-      {!isLoading && (initialSyncComplete || currentFolderId !== 'root') && !hasChildren && (
-        <EmptyState folderId={currentFolderId} />
-      )}
+      {!isLoading &&
+        (initialSyncComplete || currentFolderId !== 'root') &&
+        !hasChildren &&
+        !hasUploadsForFolder && <EmptyState folderId={currentFolderId} />}
 
       {actions.multiSelectActive && actions.selectedIds.size > 1 && (
         <SelectionActionBar

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -72,7 +72,7 @@
       "component": "@cipherbox/web",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.37.0"
+      "release-as": "0.38.0"
     },
     "apps/desktop": {
       "release-type": "node",


### PR DESCRIPTION
## What changed

This fixes the empty-folder upload flow in the web file browser. When a file is dropped into an empty folder, the UI now switches immediately from the empty-state placeholder to the normal file list so the upload progress row can appear right away.

## Details

- Detects active uploads targeting the current folder
- Renders `FileList` while uploads are in progress, even before the folder metadata contains committed children
- Preserves the empty-state view when the folder is truly empty and idle