### PR TITLE
fix(api): use Google sub for linked account resolution

### DIFF
--- a/.github/scripts/pr-release-preview.js
+++ b/.github/scripts/pr-release-preview.js
@@ -71,6 +71,13 @@ const RUST_DEPS = {
   'crates/core': ['crates/crypto'],
   'crates/fuse': ['crates/api-client', 'crates/core', 'crates/crypto'],
   'crates/sdk': ['crates/api-client', 'crates/core', 'crates/crypto'],
+  'apps/desktop': [
+    'crates/api-client',
+    'crates/core',
+    'crates/crypto',
+    'crates/fuse',
+    'crates/sdk',
+  ],
 };
 
 /** API lock group members (D-05) */

--- a/.learnings/2026-04-02-release-please-subdir-extra-files-and-desktop-cascades.md
+++ b/.learnings/2026-04-02-release-please-subdir-extra-files-and-desktop-cascades.md
@@ -1,0 +1,36 @@
+# Release Please Subdir Extra Files And Desktop Cascades
+
+**Date:** 2026-04-02
+
+## Original Prompt
+
+> You jsut created a PR containing an API fix <https://github.com/FSM1/cipher-box/pull/445>
+>
+> The release preview manifest correctly updates the dependent rust crates, but for some reason the actual desktop app is not bumped, even though one or more of its dependencies have been updated.
+>
+> Why?
+>
+> ok please apply both of these fixes now
+>
+> Are these incurrect `extra files` patterns present in any of the other release please configs? Can you also log a learning according to the readme ?
+
+## What I Learned
+
+- In this repo, `release-please-config.json` is the only Release Please config file, and `apps/desktop` is the only component currently using `extra-files`.
+- For manifest components in subdirectories, `extra-files` paths must be relative to the component path, not the repo root. For `apps/desktop`, `src-tauri/tauri.conf.json` works, while `apps/desktop/src-tauri/tauri.conf.json` does not.
+- The desktop release preview logic is partly custom. Rust crate bumps do not automatically cascade into `apps/desktop` unless that dependency edge is explicitly modeled in `.github/scripts/pr-release-preview.js`.
+- The desktop package can appear released while the actual Tauri app version lags if `package.json` is bumped but the Tauri `Cargo.toml` and `tauri.conf.json` are not updated.
+
+## What Would Have Helped
+
+- Checking `release-please-config.json` and `.github/scripts/pr-release-preview.js` first instead of assuming Release Please alone handled all dependency propagation.
+- Verifying whether `extra-files` are repo-relative or component-relative before trusting the manifest config.
+- Comparing `apps/desktop/package.json` against `apps/desktop/src-tauri/Cargo.toml` and `apps/desktop/src-tauri/tauri.conf.json` earlier.
+
+## Key Files
+
+- `release-please-config.json`
+- `.github/scripts/pr-release-preview.js`
+- `apps/desktop/package.json`
+- `apps/desktop/src-tauri/Cargo.toml`
+- `apps/desktop/src-tauri/tauri.conf.json`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,12 @@ type(optional-scope): description
 
 Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
 
+Commitlint setup details:
+
+- `commitlint.config.js` extends `@commitlint/config-conventional`.
+- A custom `subject-no-parens` rule rejects parenthesized text in the commit subject because Release Please can misparse it as a malformed scope and silently skip the commit.
+- The husky `commit-msg` hook enforces these rules locally before commits are created.
+
 **Releases & Versioning:**
 
 - All packages share a single unified version (tracked in `.release-please-manifest.json`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,26 @@ When working on `apps/api` code:
 
 3. **Commit the regenerated client files** (`packages/api-client/src/generated/` and `packages/api-client/src/models/`) along with your API changes.
 
+## Dependency Bootstrapping
+
+- Agents should treat missing workspace dependencies as routine setup, not a user decision point.
+- If validation, code generation, builds, or tests fail because dependencies are missing (`node_modules` absent, `jest`/`tsup`/`tsc` not found, workspace packages unavailable), agents should proactively run the appropriate install command from the repo root before asking the user anything.
+- For this monorepo, default to:
+
+  ```bash
+  pnpm install
+  ```
+
+- After installing, run the repo-wide build when downstream tests or packages depend on built workspace outputs:
+
+  ```bash
+  pnpm build
+  ```
+
+- If the full repo build is unnecessarily heavy for the task, agents should at minimum build the shared `/packages` workspace outputs required by the failing command before retrying it.
+- After installing/building, retry the command that was previously blocked.
+- If package-manager security prompts block native/build scripts, agents should surface that clearly and then request user guidance only if approval is actually required to continue.
+
 ## Code Generation Guidelines
 
 1. Use TypeScript for all JavaScript code

--- a/apps/api/src/auth/controllers/identity.controller.spec.ts
+++ b/apps/api/src/auth/controllers/identity.controller.spec.ts
@@ -197,6 +197,32 @@ describe('IdentityController', () => {
         })
       );
     });
+
+    it('should include google sub in link verification JWT claims', async () => {
+      googleOAuthService.verifyGoogleToken.mockResolvedValue({
+        email: 'user@gmail.com',
+        sub: 'google-123',
+      });
+      jwtIssuerService.signIdentityJwt.mockResolvedValue('cipherbox-link-jwt');
+
+      const result = await controller.googleLogin({
+        idToken: 'google-token',
+        intent: 'link',
+      });
+
+      expect(result).toEqual({
+        idToken: 'cipherbox-link-jwt',
+        userId: '',
+        isNewUser: false,
+        email: 'user@gmail.com',
+      });
+      expect(jwtIssuerService.signIdentityJwt).toHaveBeenCalledWith(
+        'link-verification',
+        'user@gmail.com',
+        { providerSubject: 'google-123' }
+      );
+      expect(authMethodRepository.findOne).not.toHaveBeenCalled();
+    });
   });
 
   describe('sendOtp', () => {

--- a/apps/api/src/auth/controllers/identity.controller.spec.ts
+++ b/apps/api/src/auth/controllers/identity.controller.spec.ts
@@ -154,7 +154,9 @@ describe('IdentityController', () => {
       expect(googleOAuthService.verifyGoogleToken).toHaveBeenCalledWith('google-token');
       // Verify hashIdentifier was called with sub (NOT email)
       expect(siweService.hashIdentifier).toHaveBeenCalledWith(googleSub);
-      expect(jwtIssuerService.signIdentityJwt).toHaveBeenCalledWith('new-user-id', googleEmail);
+      expect(jwtIssuerService.signIdentityJwt).toHaveBeenCalledWith('new-user-id', googleEmail, {
+        providerSubject: 'google-123',
+      });
       // Verify auth method created with hash + display
       expect(authMethodRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/apps/api/src/auth/controllers/identity.controller.ts
+++ b/apps/api/src/auth/controllers/identity.controller.ts
@@ -106,7 +106,9 @@ export class IdentityController {
     );
 
     // 5. Sign CipherBox identity JWT for the Core Kit login handoff.
-    const idToken = await this.jwtIssuerService.signIdentityJwt(user.id, normalizedEmail);
+    const idToken = await this.jwtIssuerService.signIdentityJwt(user.id, normalizedEmail, {
+      providerSubject: googlePayload.sub,
+    });
 
     this.logger.log(`Google login: userId=${user.id}, isNew=${isNewUser}`);
 

--- a/apps/api/src/auth/controllers/identity.controller.ts
+++ b/apps/api/src/auth/controllers/identity.controller.ts
@@ -88,7 +88,8 @@ export class IdentityController {
     if (dto.intent === 'link') {
       const idToken = await this.jwtIssuerService.signIdentityJwt(
         'link-verification',
-        normalizedEmail
+        normalizedEmail,
+        { providerSubject: googlePayload.sub }
       );
       this.logger.log(`Google link verification: email=${normalizedEmail}`);
       return { idToken, userId: '', isNewUser: false, email: normalizedEmail };
@@ -104,7 +105,7 @@ export class IdentityController {
       'google'
     );
 
-    // 5. Sign CipherBox identity JWT (include email for auth method identifier)
+    // 5. Sign CipherBox identity JWT for the Core Kit login handoff.
     const idToken = await this.jwtIssuerService.signIdentityJwt(user.id, normalizedEmail);
 
     this.logger.log(`Google login: userId=${user.id}, isNew=${isNewUser}`);

--- a/apps/api/src/auth/services/auth-method.service.spec.ts
+++ b/apps/api/src/auth/services/auth-method.service.spec.ts
@@ -193,8 +193,12 @@ describe('AuthMethodService', () => {
 
     it('should verify CipherBox JWT and create new auth method with identifierHash', async () => {
       const mockUser = { id: 'user-id', publicKey: 'pub-key' };
-      const mockPayload = { sub: 'user-123', email: 'user@example.com' };
-      const identifierHash = sha256Hex('user@example.com');
+      const mockPayload = {
+        sub: 'link-verification',
+        email: 'user@example.com',
+        providerSubject: 'google-sub-123',
+      };
+      const identifierHash = sha256Hex('google-sub-123');
       const mockMethod = {
         id: 'new-am',
         type: 'google',
@@ -230,8 +234,12 @@ describe('AuthMethodService', () => {
 
     it('should use identifierHash for duplicate check', async () => {
       const mockUser = { id: 'user-id', publicKey: 'pub-key' };
-      const mockPayload = { sub: 'user-123', email: 'user@example.com' };
-      const identifierHash = sha256Hex('user@example.com');
+      const mockPayload = {
+        sub: 'link-verification',
+        email: 'user@example.com',
+        providerSubject: 'google-sub-123',
+      };
+      const identifierHash = sha256Hex('google-sub-123');
       const existingMethod = {
         id: 'existing',
         type: 'google',
@@ -252,8 +260,12 @@ describe('AuthMethodService', () => {
 
     it('should use identifierHash for cross-account collision check', async () => {
       const mockUser = { id: 'user-id', publicKey: 'pub-key' };
-      const mockPayload = { sub: 'user-123', email: 'user@example.com' };
-      const identifierHash = sha256Hex('user@example.com');
+      const mockPayload = {
+        sub: 'link-verification',
+        email: 'user@example.com',
+        providerSubject: 'google-sub-123',
+      };
+      const identifierHash = sha256Hex('google-sub-123');
       const otherAccountMethod = {
         id: 'other-am',
         type: 'google',
@@ -280,7 +292,11 @@ describe('AuthMethodService', () => {
 
     it('should include "Google account" in cross-account collision message for google type', async () => {
       const mockUser = { id: 'user-id', publicKey: 'pub-key' };
-      const mockPayload = { sub: 'user-123', email: 'user@example.com' };
+      const mockPayload = {
+        sub: 'link-verification',
+        email: 'user@example.com',
+        providerSubject: 'google-sub-123',
+      };
 
       jwtIssuerService.getJwksData.mockReturnValue({ keys: [] });
       (jose.createLocalJWKSet as jest.Mock).mockReturnValue('mock-jwks');
@@ -289,11 +305,26 @@ describe('AuthMethodService', () => {
       authMethodRepository.findOne.mockResolvedValueOnce({
         id: 'other-am',
         type: 'google',
-        identifierHash: sha256Hex('user@example.com'),
+        identifierHash: sha256Hex('google-sub-123'),
         userId: 'other-user-id',
       });
 
       await expect(service.linkMethod('user-id', linkDto)).rejects.toThrow('Google account');
+    });
+
+    it('should reject google linking when providerSubject is missing', async () => {
+      const mockUser = { id: 'user-id', publicKey: 'pub-key' };
+
+      jwtIssuerService.getJwksData.mockReturnValue({ keys: [] });
+      (jose.createLocalJWKSet as jest.Mock).mockReturnValue('mock-jwks');
+      (jose.jwtVerify as jest.Mock).mockResolvedValue({
+        payload: { sub: 'link-verification', email: 'user@example.com' },
+      });
+      userRepository.findOne.mockResolvedValue(mockUser);
+
+      await expect(service.linkMethod('user-id', linkDto)).rejects.toThrow(
+        'Cannot determine Google subject from JWT'
+      );
     });
 
     it('should include "email" in cross-account collision message for email type', async () => {

--- a/apps/api/src/auth/services/auth-method.service.ts
+++ b/apps/api/src/auth/services/auth-method.service.ts
@@ -115,7 +115,7 @@ export class AuthMethodService {
    */
   private async verifyCipherBoxJwt(
     idToken: string
-  ): Promise<{ sub?: string; verifierId?: string; email?: string }> {
+  ): Promise<{ sub?: string; verifierId?: string; email?: string; providerSubject?: string }> {
     try {
       const jwksData = this.jwtIssuerService.getJwksData();
       const jwks = jose.createLocalJWKSet(jwksData);
@@ -128,6 +128,7 @@ export class AuthMethodService {
         sub: payload.sub,
         verifierId: payload.sub,
         email: payload.email as string | undefined,
+        providerSubject: payload.providerSubject as string | undefined,
       };
     } catch (error) {
       this.logger.warn(
@@ -149,9 +150,14 @@ export class AuthMethodService {
 
     // 2. Determine type and identifier, hash for lookup
     const authMethodType = linkDto.loginType;
-    const identifier = payload.email || payload.sub;
+    const identifier =
+      authMethodType === 'google' ? payload.providerSubject : (payload.email ?? payload.sub);
     if (!identifier) {
-      throw new BadRequestException('Cannot determine identifier from JWT');
+      throw new BadRequestException(
+        authMethodType === 'google'
+          ? 'Cannot determine Google subject from JWT'
+          : 'Cannot determine identifier from JWT'
+      );
     }
     const identifierHash = this.siweService.hashIdentifier(identifier);
 

--- a/apps/api/src/auth/services/jwt-issuer.service.spec.ts
+++ b/apps/api/src/auth/services/jwt-issuer.service.spec.ts
@@ -88,5 +88,16 @@ describe('JwtIssuerService', () => {
 
       expect(jwt).toBe('mock-jwt-token');
     });
+
+    it('should sign JWT with providerSubject when provided', async () => {
+      configService.get.mockReturnValue(undefined);
+      await service.onModuleInit();
+
+      const jwt = await service.signIdentityJwt('link-verification', 'test@example.com', {
+        providerSubject: 'google-sub-123',
+      });
+
+      expect(jwt).toBe('mock-jwt-token');
+    });
   });
 });

--- a/apps/api/src/auth/services/jwt-issuer.service.ts
+++ b/apps/api/src/auth/services/jwt-issuer.service.ts
@@ -51,12 +51,20 @@ export class JwtIssuerService implements OnModuleInit {
   /**
    * Sign a CipherBox identity JWT for Web3Auth custom verifier consumption.
    *
-   * Claims: iss=cipherbox, aud=web3auth, sub=userId, email (optional), exp=5min
+   * Claims: iss=cipherbox, aud=web3auth, sub=userId, email (optional),
+   * providerSubject (optional), exp=5min.
    */
-  async signIdentityJwt(userId: string, email?: string): Promise<string> {
+  async signIdentityJwt(
+    userId: string,
+    email?: string,
+    extraClaims?: { providerSubject?: string }
+  ): Promise<string> {
     const claims: Record<string, unknown> = { sub: userId };
     if (email) {
       claims.email = email;
+    }
+    if (extraClaims?.providerSubject) {
+      claims.providerSubject = extraClaims.providerSubject;
     }
     return new jose.SignJWT(claims)
       .setProtectedHeader({ alg: 'RS256', kid: KID })

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -65,7 +65,8 @@
       "release-type": "node",
       "component": "@cipherbox/api",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "0.36.1"
     },
     "apps/web": {
       "release-type": "node",
@@ -88,7 +89,8 @@
       "release-type": "node",
       "component": "cipherbox-tee-worker",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "0.31.2"
     },
     "packages/core": {
       "release-type": "node",
@@ -106,19 +108,22 @@
       "release-type": "node",
       "component": "@cipherbox/api-client",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "0.36.1"
     },
     "packages/sdk-core": {
       "release-type": "node",
       "component": "@cipherbox/sdk-core",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "0.34.1"
     },
     "packages/sdk": {
       "release-type": "node",
       "component": "@cipherbox/sdk",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "0.33.1"
     },
     "crates/crypto": {
       "release-type": "rust",
@@ -136,19 +141,22 @@
       "release-type": "rust",
       "component": "cipherbox-api-client",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "0.35.1"
     },
     "crates/fuse": {
       "release-type": "rust",
       "component": "cipherbox-fuse",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "0.5.1"
     },
     "crates/sdk": {
       "release-type": "rust",
       "component": "cipherbox-sdk",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "0.5.1"
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -80,7 +80,11 @@
       "component": "cipherbox-desktop",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "extra-files": ["src-tauri/tauri.conf.json", "src-tauri/Cargo.toml"]
+      "extra-files": [
+        "src-tauri/tauri.conf.json",
+        "src-tauri/Cargo.toml"
+      ],
+      "release-as": "0.37.0"
     },
     "apps/tee-worker": {
       "release-type": "node",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -80,10 +80,7 @@
       "component": "cipherbox-desktop",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "extra-files": [
-        "apps/desktop/src-tauri/tauri.conf.json",
-        "apps/desktop/src-tauri/Cargo.toml"
-      ]
+      "extra-files": ["src-tauri/tauri.conf.json", "src-tauri/Cargo.toml"]
     },
     "apps/tee-worker": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

Fix Google auth linking so linked sign-in resolves the existing CipherBox account using the stable Google `sub` claim instead of email.

## Changes

- include Google `sub` in the temporary CipherBox identity JWT used during link verification
- store and validate linked Google auth methods using `sub`-derived hashes
- add regression coverage for Google link verification and Google-linked login resolution

## Validation

- `pnpm --filter @cipherbox/api test`
- `pnpm --filter @cipherbox/api build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google account linking and identity handling to use the provider's stable subject, reducing linking/collision errors.

* **Tests**
  * Expanded unit and controller tests covering Google login, linking, and JWT signing behaviors.

* **Documentation**
  * Added dependency bootstrapping guidance for automated workflows and clarified commit message linting and package build guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->