### PR TITLE
feat: IPNS signature storage and verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build packages (needed for API dependency on @cipherbox/crypto)
+        run: pnpm --filter @cipherbox/crypto build
+
       - name: Generate OpenAPI spec and API client
         run: pnpm api:generate
         env:

--- a/.planning/DEFERRED.md
+++ b/.planning/DEFERRED.md
@@ -126,11 +126,12 @@ From `.planning/security/REVIEW-20260402-172126.md`:
 
 ### Code Quality
 
-| Item                                         | Source Phase | Notes                                                                  |
-| -------------------------------------------- | ------------ | ---------------------------------------------------------------------- |
-| Full retirement of folder.service.ts         | 31           | 1,059 lines, 9 importers; migrate callers to SDK methods               |
-| Full retirement of bin.service.ts            | 31           | 971 lines, only `initializeBin` + `purgeExpired` still used by 2 hooks |
-| Remove crypto -> core circular devDependency | 19.1         | Test-only import; refactor vault-ipns test to use hardcoded vectors    |
+| Item                                         | Source Phase | Notes                                                                                                                              |
+| -------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Full retirement of folder.service.ts         | 31           | 1,059 lines, 9 importers; migrate callers to SDK methods                                                                           |
+| Full retirement of bin.service.ts            | 31           | 971 lines, only `initializeBin` + `purgeExpired` still used by 2 hooks                                                             |
+| Remove crypto -> core circular devDependency | 19.1         | Test-only import; refactor vault-ipns test to use hardcoded vectors                                                                |
+| Deduplicate `uint8ToBase64` helper           | PR #448      | Duplicated in sdk-core/file, sdk-core/folder, web/ipns.service; extract to shared util in `@cipherbox/crypto` or `@cipherbox/core` |
 
 ## Items Implemented in Later Phases
 

--- a/.planning/DEFERRED.md
+++ b/.planning/DEFERRED.md
@@ -28,6 +28,16 @@ From `.planning/todos/done/2026-02-21-phase14-security-review-deferred.md`:
 | L1  | Low      | `/shares/lookup` enables public key enumeration -- always return 200    | Open        |
 | L4  | Low      | No pagination on shares endpoints -- add limit/offset                   | Implemented |
 
+## Security Review Findings (Deferred from IPNS Signature Storage PR #448)
+
+From `.planning/security/REVIEW-20260402-172126.md`:
+
+| ID  | Severity | Item                                                                                                       | Status   |
+| --- | -------- | ---------------------------------------------------------------------------------------------------------- | -------- |
+| S1  | Medium   | Validate signedRecord on publish: parse embedded CID/sequence and reject mismatches with dto fields        | Open     |
+| S2  | Medium   | Signature verification silently skipped when server omits fields (downgrade) -- enforce once data is ready | Deferred |
+| S3  | Medium   | Inconsistent private key zeroization -- establish caller-owns-key convention across SDK                    | Deferred |
+
 ## Deferred by Category
 
 ### Sharing & Collaboration

--- a/.planning/security/REVIEW-20260402-172126.md
+++ b/.planning/security/REVIEW-20260402-172126.md
@@ -34,56 +34,31 @@ The IPNS signature storage feature maintains CipherBox's zero-knowledge property
 
 ### High Priority
 
-#### 1. Call-Stack Overflow in Web App Base64 Encoding
+#### 1. Call-Stack Overflow in Web App Base64 Encoding -- RESOLVED
 
 - **Severity:** HIGH
 - **Location:** `apps/web/src/services/ipns.service.ts:54`
+- **Status:** Fixed. Replaced spread operator with loop-based encoding matching SDK-core pattern.
 - **Description:** The spread operator in `btoa(String.fromCharCode(...recordBytes))` pushes every byte onto the call stack. V8's argument limit is ~65,536. The SDK-core version at `packages/sdk-core/src/ipns/index.ts:60-64` already uses a safe loop-based approach, but the web app was not updated.
 - **Impact:** `RangeError: Maximum call stack size exceeded` crash on IPNS publish if the record exceeds the stack argument limit.
-- **Recommendation:** Replace with loop-based encoding:
-  ```typescript
-  let binary = '';
-  for (let i = 0; i < recordBytes.length; i++) {
-    binary += String.fromCharCode(recordBytes[i]);
-  }
-  const recordBase64 = btoa(binary);
-  ```
 
-#### 2. Web App Does Not Send publicKey on IPNS Publish
+#### 2. Web App Does Not Send publicKey on IPNS Publish -- RESOLVED
 
 - **Severity:** HIGH
 - **Location:** `apps/web/src/services/ipns.service.ts:57-64`
+- **Status:** Fixed. Added `deriveEd25519PublicKey` import and publicKey derivation + transmission in `createAndPublishIpnsRecord`.
 - **Description:** The web app's `createAndPublishIpnsRecord` does not derive or send the `publicKey` field. The SDK-core version (`packages/sdk-core/src/ipns/index.ts:57-69`) derives the public key and sends it. Without the public key, the backend cannot store signature data, so the resolve-side verification (including the new pubKey-to-ipnsName binding) silently degrades to the unverified path.
 - **Impact:** IPNS records published from the web app lack signature data on resolve, making all verification dead code for those records.
-- **Recommendation:** Add public key derivation and transmission matching the SDK-core implementation:
-
-  ```typescript
-  import { deriveEd25519PublicKey } from '@cipherbox/crypto';
-
-  // After marshaling the record:
-  const publicKeyBytes = deriveEd25519PublicKey(params.ipnsPrivateKey);
-  let pkBinary = '';
-  for (let i = 0; i < publicKeyBytes.length; i++) {
-    pkBinary += String.fromCharCode(publicKeyBytes[i]);
-  }
-  const publicKey = btoa(pkBinary);
-
-  // Include in API call:
-  const response = await ipnsControllerPublishRecord({
-    ...existingFields,
-    publicKey,
-  });
-  ```
 
 ### Medium Priority
 
-#### 3. No Server-Side publicKey-to-ipnsName Binding Verification
+#### 3. No Server-Side publicKey-to-ipnsName Binding Verification -- RESOLVED
 
 - **Severity:** MEDIUM
 - **Location:** `apps/api/src/ipns/ipns.service.ts:67-77`
+- **Status:** Fixed. Added `@cipherbox/crypto` as API dependency. Server now calls `deriveIpnsName(publicKeyBytes)` and rejects with 400 if the derived name does not match `dto.ipnsName`.
 - **Description:** The server validates that publicKey is 32 bytes and base64-encoded, and prevents changes after first write (line 233-235). However, it never verifies that publicKey cryptographically derives to the claimed ipnsName. On first publish, a malicious client could store any 32-byte value.
 - **Impact:** Defense-in-depth gap. The "first write wins" immutability check (line 233) mitigates ongoing attacks, and the client-side binding check (now applied) is the primary defense. The vulnerability window is limited to the first publish for each IPNS name.
-- **Recommendation:** If `deriveIpnsName` can be imported server-side without heavy dependencies, add validation on first publish. Otherwise, document the reliance on client-side verification and first-write immutability.
 
 #### 4. Signature Verification Silently Skipped on Downgrade (Known Design Decision)
 
@@ -93,36 +68,37 @@ The IPNS signature storage feature maintains CipherBox's zero-knowledge property
 - **Impact:** A compromised server can bypass all verification by simply stripping signature fields. This is a known design decision for backward compatibility with older records.
 - **Recommendation:** Once all records reliably include signature data, consider adding an enforcement option. No immediate action required per project owner's direction.
 
-#### 5. Inconsistent Private Key Zeroization
+#### 5. Inconsistent Private Key Zeroization -- DEFERRED
 
 - **Severity:** MEDIUM
 - **Location:** Multiple SDK-core functions
+- **Status:** Deferred. Functions that receive keys by reference (`updateFolderMetadataAndPublish`, `updateFileMetadata`) do not own the key lifetime -- zeroing here would break callers that still need the key. The convention is: the function that generates or unwraps a key is responsible for zeroing it (as `createSubfolder` and `createFileMetadata` already do). Callers at the UI layer should adopt this pattern.
 - **Description:** Some functions zero Ed25519 private keys after use (`createFileMetadata` at `packages/sdk-core/src/file/index.ts:141`, `createSubfolder` at `packages/sdk-core/src/folder/index.ts:160`) while others do not (`createAndPublishIpnsRecord`, `updateFolderMetadataAndPublish`, `updateFileMetadata`).
 - **Impact:** Ed25519 private keys may persist in the JS heap longer than necessary. Low practical exploitability in browser environments but inconsistent with the project's own patterns.
-- **Recommendation:** Establish a clear ownership convention: the function that unwraps or generates a key is responsible for zeroing it in a `finally` block.
 
 ### Low Priority / Recommendations
 
-#### 6. MaxLength Mismatch on ipnsName Between DTOs
+#### 6. MaxLength Mismatch on ipnsName Between DTOs -- RESOLVED
 
 - **Severity:** LOW
+- **Status:** Fixed. Changed `@MaxLength(70)` to `@MaxLength(76)` on both `PublishIpnsDto` and `PublishIpnsEntryDto`.
 - **Location:** `apps/api/src/ipns/dto/publish.dto.ts:32` (and line 144)
 - **Description:** Publish DTO uses `@MaxLength(70)` while resolve DTO uses `@MaxLength(76)`. The regex allows `bafzaa` + up to 70 chars = 76 total. Publish is too restrictive.
 - **Recommendation:** Change to `@MaxLength(76)` on both `PublishIpnsDto` and `PublishIpnsEntryDto`.
 
-#### 7. Protobuf Parser Missing Bounds Check for Fixed-Width Wire Types
+#### 7. Protobuf Parser Missing Bounds Check for Fixed-Width Wire Types -- RESOLVED
 
 - **Severity:** LOW
+- **Status:** Fixed. Added `if (pos + N > buf.length) throw` guards for wire types 1 and 5.
 - **Location:** `apps/api/src/ipns/ipns-record-parser.ts:107-111`
 - **Description:** Wire types 5 (32-bit) and 1 (64-bit) skip forward without checking remaining buffer length. IPNS records don't use these wire types in practice.
-- **Recommendation:** Add `if (pos + N > buf.length) throw` guards for completeness.
 
-#### 8. `deriveEd25519PublicKey` Lacks Input Length Validation
+#### 8. `deriveEd25519PublicKey` Lacks Input Length Validation -- RESOLVED
 
 - **Severity:** LOW
+- **Status:** Fixed. Added `ED25519_PRIVATE_KEY_SIZE` check with `CryptoError` throw, matching the pattern in `signEd25519`.
 - **Location:** `packages/crypto/src/ed25519/keygen.ts:43-45`
 - **Description:** Unlike `signEd25519` which validates key length, this function passes input directly to `@noble/ed25519`. A 64-byte libp2p-format key would silently produce incorrect results.
-- **Recommendation:** Add `if (privateKey.length !== 32) throw` guard.
 
 ## Positive Observations
 
@@ -289,22 +265,20 @@ Based on project security rules:
 
 ## Recommendations Summary
 
-| Priority | Recommendation                                               | Effort |
-| -------- | ------------------------------------------------------------ | ------ |
-| P0       | Fix web app call-stack overflow in base64 encoding           | LOW    |
-| P0       | Add publicKey derivation and transmission to web app publish | LOW    |
-| P1       | Add server-side publicKey-to-ipnsName derivation check       | MEDIUM |
-| P1       | Establish consistent private key zeroization convention      | MEDIUM |
-| P2       | Fix MaxLength mismatch on ipnsName in publish DTOs           | LOW    |
-| P2       | Add bounds checks for wire types 1/5 in protobuf parser      | LOW    |
-| P2       | Add input length validation to deriveEd25519PublicKey        | LOW    |
+| Priority | Recommendation                                               | Effort | Status   |
+| -------- | ------------------------------------------------------------ | ------ | -------- |
+| P0       | Fix web app call-stack overflow in base64 encoding           | LOW    | RESOLVED |
+| P0       | Add publicKey derivation and transmission to web app publish | LOW    | RESOLVED |
+| P1       | Add server-side publicKey-to-ipnsName derivation check       | MEDIUM | RESOLVED |
+| P1       | Establish consistent private key zeroization convention      | MEDIUM | DEFERRED |
+| P2       | Fix MaxLength mismatch on ipnsName in publish DTOs           | LOW    | RESOLVED |
+| P2       | Add bounds checks for wire types 1/5 in protobuf parser      | LOW    | RESOLVED |
+| P2       | Add input length validation to deriveEd25519PublicKey        | LOW    | RESOLVED |
 
-## Next Steps
+## Remaining Items
 
-1. Fix the two web app issues (findings 1 and 2) -- these are the only ones with real functional impact
-2. Fix the MaxLength mismatch (finding 6) -- trivial one-liner
-3. Add deriveEd25519PublicKey input validation (finding 8) -- trivial one-liner
-4. Consider server-side pubKey binding once dependency cost is assessed
+- Finding #4 (signature verification downgrade): Known design decision, deferred until all records reliably include signature data.
+- Finding #5 (key zeroization convention): Deferred -- functions receiving keys by reference should not zero them; the caller that generates/unwraps the key is responsible.
 
 ---
 

--- a/.planning/security/REVIEW-20260402-172126.md
+++ b/.planning/security/REVIEW-20260402-172126.md
@@ -1,0 +1,312 @@
+# Security Review Report
+
+**Date:** 2026-04-02
+**Scope:** All changes on branch `feat/store-ipns-crypto-data-in-db` (4 commits, ~30 non-generated files)
+**Reviewer:** Claude (security:review command)
+
+## Executive Summary
+
+The IPNS signature storage feature maintains CipherBox's zero-knowledge property -- private keys are never exposed to the server, and ECIES wrapping is correctly applied for TEE enrollment. The pubKey-to-ipnsName binding fix (applied during this session) closes the main cryptographic gap. Two functional issues remain in the web app: missing publicKey on publish and a call-stack overflow in base64 encoding.
+
+**Risk Level:** MEDIUM
+
+## Files Reviewed
+
+| File                                               | Crypto Operations                                                                | Risk Level |
+| -------------------------------------------------- | -------------------------------------------------------------------------------- | ---------- |
+| `apps/api/src/ipns/ipns.service.ts`                | publicKey validation, signedRecord storage, conflict detection, write-share auth | MEDIUM     |
+| `apps/api/src/ipns/ipns-record-parser.ts`          | Protobuf parsing of IPNS records                                                 | LOW        |
+| `apps/api/src/ipns/dto/publish.dto.ts`             | Input validation (base64, length)                                                | LOW        |
+| `apps/api/src/ipns/entities/folder-ipns.entity.ts` | bytea column storage                                                             | LOW        |
+| `apps/api/src/republish/republish.service.ts`      | TEE key pass-through                                                             | LOW        |
+| `apps/api/src/migrations/*.ts`                     | DDL statements                                                                   | LOW        |
+| `packages/crypto/src/ed25519/keygen.ts`            | Ed25519 public key derivation                                                    | LOW        |
+| `packages/sdk-core/src/ipns/index.ts`              | IPNS signing, verification, pubKey binding                                       | MEDIUM     |
+| `apps/web/src/services/ipns.service.ts`            | IPNS signing, verification, pubKey binding                                       | HIGH       |
+| `packages/sdk-core/src/file/index.ts`              | publicKey pass-through                                                           | LOW        |
+| `packages/sdk-core/src/folder/index.ts`            | publicKey pass-through                                                           | LOW        |
+| `packages/sdk-core/src/vault/index.ts`             | publicKey pass-through                                                           | LOW        |
+| `tests/desktop-e2e/scripts/test-round-trip.sh`     | Test secret handling                                                             | LOW        |
+| `tests/desktop-e2e/scripts/test-round-trip.ps1`    | Test secret handling                                                             | LOW        |
+| `packages/sdk-core/scripts/verify-filepointer.mjs` | Test key usage                                                                   | LOW        |
+
+## Findings
+
+### High Priority
+
+#### 1. Call-Stack Overflow in Web App Base64 Encoding
+
+- **Severity:** HIGH
+- **Location:** `apps/web/src/services/ipns.service.ts:54`
+- **Description:** The spread operator in `btoa(String.fromCharCode(...recordBytes))` pushes every byte onto the call stack. V8's argument limit is ~65,536. The SDK-core version at `packages/sdk-core/src/ipns/index.ts:60-64` already uses a safe loop-based approach, but the web app was not updated.
+- **Impact:** `RangeError: Maximum call stack size exceeded` crash on IPNS publish if the record exceeds the stack argument limit.
+- **Recommendation:** Replace with loop-based encoding:
+  ```typescript
+  let binary = '';
+  for (let i = 0; i < recordBytes.length; i++) {
+    binary += String.fromCharCode(recordBytes[i]);
+  }
+  const recordBase64 = btoa(binary);
+  ```
+
+#### 2. Web App Does Not Send publicKey on IPNS Publish
+
+- **Severity:** HIGH
+- **Location:** `apps/web/src/services/ipns.service.ts:57-64`
+- **Description:** The web app's `createAndPublishIpnsRecord` does not derive or send the `publicKey` field. The SDK-core version (`packages/sdk-core/src/ipns/index.ts:57-69`) derives the public key and sends it. Without the public key, the backend cannot store signature data, so the resolve-side verification (including the new pubKey-to-ipnsName binding) silently degrades to the unverified path.
+- **Impact:** IPNS records published from the web app lack signature data on resolve, making all verification dead code for those records.
+- **Recommendation:** Add public key derivation and transmission matching the SDK-core implementation:
+
+  ```typescript
+  import { deriveEd25519PublicKey } from '@cipherbox/crypto';
+
+  // After marshaling the record:
+  const publicKeyBytes = deriveEd25519PublicKey(params.ipnsPrivateKey);
+  let pkBinary = '';
+  for (let i = 0; i < publicKeyBytes.length; i++) {
+    pkBinary += String.fromCharCode(publicKeyBytes[i]);
+  }
+  const publicKey = btoa(pkBinary);
+
+  // Include in API call:
+  const response = await ipnsControllerPublishRecord({
+    ...existingFields,
+    publicKey,
+  });
+  ```
+
+### Medium Priority
+
+#### 3. No Server-Side publicKey-to-ipnsName Binding Verification
+
+- **Severity:** MEDIUM
+- **Location:** `apps/api/src/ipns/ipns.service.ts:67-77`
+- **Description:** The server validates that publicKey is 32 bytes and base64-encoded, and prevents changes after first write (line 233-235). However, it never verifies that publicKey cryptographically derives to the claimed ipnsName. On first publish, a malicious client could store any 32-byte value.
+- **Impact:** Defense-in-depth gap. The "first write wins" immutability check (line 233) mitigates ongoing attacks, and the client-side binding check (now applied) is the primary defense. The vulnerability window is limited to the first publish for each IPNS name.
+- **Recommendation:** If `deriveIpnsName` can be imported server-side without heavy dependencies, add validation on first publish. Otherwise, document the reliance on client-side verification and first-write immutability.
+
+#### 4. Signature Verification Silently Skipped on Downgrade (Known Design Decision)
+
+- **Severity:** MEDIUM
+- **Location:** `packages/sdk-core/src/ipns/index.ts:212-214` and `apps/web/src/services/ipns.service.ts:173-175`
+- **Description:** When the server omits signature fields, verification is skipped and the CID is accepted with `signatureVerified: false`. No caller currently enforces `signatureVerified === true`.
+- **Impact:** A compromised server can bypass all verification by simply stripping signature fields. This is a known design decision for backward compatibility with older records.
+- **Recommendation:** Once all records reliably include signature data, consider adding an enforcement option. No immediate action required per project owner's direction.
+
+#### 5. Inconsistent Private Key Zeroization
+
+- **Severity:** MEDIUM
+- **Location:** Multiple SDK-core functions
+- **Description:** Some functions zero Ed25519 private keys after use (`createFileMetadata` at `packages/sdk-core/src/file/index.ts:141`, `createSubfolder` at `packages/sdk-core/src/folder/index.ts:160`) while others do not (`createAndPublishIpnsRecord`, `updateFolderMetadataAndPublish`, `updateFileMetadata`).
+- **Impact:** Ed25519 private keys may persist in the JS heap longer than necessary. Low practical exploitability in browser environments but inconsistent with the project's own patterns.
+- **Recommendation:** Establish a clear ownership convention: the function that unwraps or generates a key is responsible for zeroing it in a `finally` block.
+
+### Low Priority / Recommendations
+
+#### 6. MaxLength Mismatch on ipnsName Between DTOs
+
+- **Severity:** LOW
+- **Location:** `apps/api/src/ipns/dto/publish.dto.ts:32` (and line 144)
+- **Description:** Publish DTO uses `@MaxLength(70)` while resolve DTO uses `@MaxLength(76)`. The regex allows `bafzaa` + up to 70 chars = 76 total. Publish is too restrictive.
+- **Recommendation:** Change to `@MaxLength(76)` on both `PublishIpnsDto` and `PublishIpnsEntryDto`.
+
+#### 7. Protobuf Parser Missing Bounds Check for Fixed-Width Wire Types
+
+- **Severity:** LOW
+- **Location:** `apps/api/src/ipns/ipns-record-parser.ts:107-111`
+- **Description:** Wire types 5 (32-bit) and 1 (64-bit) skip forward without checking remaining buffer length. IPNS records don't use these wire types in practice.
+- **Recommendation:** Add `if (pos + N > buf.length) throw` guards for completeness.
+
+#### 8. `deriveEd25519PublicKey` Lacks Input Length Validation
+
+- **Severity:** LOW
+- **Location:** `packages/crypto/src/ed25519/keygen.ts:43-45`
+- **Description:** Unlike `signEd25519` which validates key length, this function passes input directly to `@noble/ed25519`. A 64-byte libp2p-format key would silently produce incorrect results.
+- **Recommendation:** Add `if (privateKey.length !== 32) throw` guard.
+
+## Positive Observations
+
+1. **Zero-knowledge property maintained.** Server never sees plaintext private keys. `encryptedIpnsPrivateKey` is always ECIES-wrapped ciphertext. Server stores it as bytea and passes directly to TEE.
+
+2. **Client-side signing is correct.** `createIpnsRecord` signs locally with Ed25519 before any server transmission. Only signed records and public keys are sent.
+
+3. **IPNS signature prefix is correct.** `IPNS_SIGNATURE_PREFIX` correctly encodes `"ipns-signature:"` per the IPFS IPNS spec.
+
+4. **pubKey-to-ipnsName binding is checked (after fix).** Both `resolveIpnsRecord` implementations verify the returned public key derives to the requested IPNS name, preventing key substitution attacks.
+
+5. **Ed25519 verification is done correctly.** `verifyEd25519` validates signature (64 bytes) and public key (32 bytes) lengths before calling `@noble/ed25519`. Returns `false` on exceptions -- no error oracles.
+
+6. **SHA-512 properly configured for @noble/ed25519 v2.x.** Both `keygen.ts` and `sign.ts` configure `ed.etc.sha512Sync`.
+
+7. **Public key immutability after first write.** Line 233-235 of `ipns.service.ts` prevents publicKey from being changed once stored.
+
+8. **Write-share authorization correctly gated.** Write-share recipients cannot overwrite TEE enrollment fields (`encryptedIpnsPrivateKey`, `keyEpoch`) -- guarded at line 248.
+
+9. **Auth guards applied.** Controller uses `@UseGuards(JwtAuthGuard, ThrottlerGuard)` at class level. Rate limiting configured per-endpoint.
+
+10. **Input validation thorough.** DTOs use `class-validator` with regex patterns, base64 validation, length constraints. Batch endpoint caps at 200 entries.
+
+11. **Protobuf parser well-bounded.** Varint has `shift > 63n` overflow guard, length-delimited fields check `end > buf.length`, unrecognized wire types throw.
+
+12. **Migrations are safe.** Hardcoded DDL, no user input interpolation, idempotent `IF NOT EXISTS` / `IF EXISTS` guards.
+
+13. **No sensitive data in logs.** Log messages use only ipnsName, CID, and sequence numbers.
+
+14. **TEE key pass-through is clean.** Republish service receives encrypted key as Buffer, base64-encodes for TEE request, never interprets contents.
+
+## Test Cases
+
+### Ed25519 Public Key Derivation
+
+```typescript
+describe('deriveEd25519PublicKey security', () => {
+  it('derives correct public key from 32-byte seed', () => {
+    const keypair = generateEd25519Keypair();
+    const derived = deriveEd25519PublicKey(keypair.privateKey);
+    expect(derived).toEqual(keypair.publicKey);
+  });
+
+  it('derivation is deterministic', () => {
+    const seed = new Uint8Array(32).fill(42);
+    expect(deriveEd25519PublicKey(seed)).toEqual(deriveEd25519PublicKey(seed));
+  });
+
+  it('should reject 64-byte libp2p-format key', () => {
+    // After adding validation:
+    expect(() => deriveEd25519PublicKey(new Uint8Array(64))).toThrow();
+  });
+});
+```
+
+### IPNS Signature Verification
+
+```typescript
+describe('verifyIpnsSignature security', () => {
+  it('verifies valid signature with correct IPNS prefix', async () => {
+    const keypair = generateEd25519Keypair();
+    const cborData = new Uint8Array([0x01, 0x02, 0x03]);
+    const signedData = concatBytes(IPNS_SIGNATURE_PREFIX, cborData);
+    const sig = await signEd25519(signedData, keypair.privateKey);
+    expect(await verifyIpnsSignature(toB64(sig), toB64(cborData), toB64(keypair.publicKey))).toBe(
+      true
+    );
+  });
+
+  it('rejects signature from different key', async () => {
+    const kp1 = generateEd25519Keypair();
+    const kp2 = generateEd25519Keypair();
+    const data = new Uint8Array([0x01]);
+    const sig = await signEd25519(concatBytes(IPNS_SIGNATURE_PREFIX, data), kp1.privateKey);
+    expect(await verifyIpnsSignature(toB64(sig), toB64(data), toB64(kp2.publicKey))).toBe(false);
+  });
+
+  it('rejects tampered CBOR data', async () => {
+    const kp = generateEd25519Keypair();
+    const data = new Uint8Array([0x01, 0x02, 0x03]);
+    const sig = await signEd25519(concatBytes(IPNS_SIGNATURE_PREFIX, data), kp.privateKey);
+    const tampered = new Uint8Array([0x01, 0x02, 0x04]);
+    expect(await verifyIpnsSignature(toB64(sig), toB64(tampered), toB64(kp.publicKey))).toBe(false);
+  });
+});
+```
+
+### Resolve pubKey-to-ipnsName Binding
+
+```typescript
+describe('resolveIpnsRecord key binding', () => {
+  it('rejects response where pubKey does not derive to requested ipnsName', async () => {
+    // Mock server returning valid signature from a different keypair
+    vi.mocked(ipnsControllerResolveRecord).mockResolvedValue({
+      success: true,
+      cid: 'QmAttackerCid',
+      sequenceNumber: '1',
+      signatureV2: validSigFromWrongKey,
+      data: validCborData,
+      pubKey: wrongPublicKey,
+    });
+    await expect(resolveIpnsRecord('k51legitimate-name')).rejects.toThrow('does not match');
+  });
+
+  it('returns signatureVerified: false when signature fields missing', async () => {
+    vi.mocked(ipnsControllerResolveRecord).mockResolvedValue({
+      success: true,
+      cid: 'QmSomeCid',
+      sequenceNumber: '1',
+    });
+    const result = await resolveIpnsRecord('k51name');
+    expect(result?.signatureVerified).toBe(false);
+  });
+});
+```
+
+### Base64 Encoding Safety
+
+```typescript
+describe('base64 encoding safety', () => {
+  it('loop-based encoding handles records > 65536 bytes', () => {
+    const large = new Uint8Array(100_000).fill(0x42);
+    let binary = '';
+    for (let i = 0; i < large.length; i++) binary += String.fromCharCode(large[i]);
+    const decoded = Uint8Array.from(atob(btoa(binary)), (c) => c.charCodeAt(0));
+    expect(decoded).toEqual(large);
+  });
+});
+```
+
+### Server-Side Authorization
+
+```typescript
+describe('IpnsService authorization', () => {
+  it('rejects publicKey change on existing IPNS entry', async () => {
+    // First publish with publicKey A, second with publicKey B
+    // Expect BadRequestException
+  });
+
+  it('write-share recipient cannot update encryptedIpnsPrivateKey', async () => {
+    // User with write share publishes with encryptedIpnsPrivateKey
+    // TEE fields on owner record remain unchanged
+  });
+
+  it('rejects publish when expectedSequenceNumber does not match', async () => {
+    // Existing at seq 5, publish with expected "3"
+    // Expect ConflictException
+  });
+});
+```
+
+## Compliance Checklist
+
+Based on project security rules:
+
+- [x] No privateKey in localStorage/sessionStorage
+- [x] No sensitive keys logged
+- [x] No unencrypted keys sent to server
+- [x] ECIES used for key wrapping (encryptedIpnsPrivateKey)
+- [x] AES-256-GCM used for content encryption (not in scope but verified consistent)
+- [x] Server has zero knowledge of plaintext
+- [x] IPNS keys encrypted with TEE public key before transmission
+- [x] TEE pass-through never decrypts key material
+
+## Recommendations Summary
+
+| Priority | Recommendation                                               | Effort |
+| -------- | ------------------------------------------------------------ | ------ |
+| P0       | Fix web app call-stack overflow in base64 encoding           | LOW    |
+| P0       | Add publicKey derivation and transmission to web app publish | LOW    |
+| P1       | Add server-side publicKey-to-ipnsName derivation check       | MEDIUM |
+| P1       | Establish consistent private key zeroization convention      | MEDIUM |
+| P2       | Fix MaxLength mismatch on ipnsName in publish DTOs           | LOW    |
+| P2       | Add bounds checks for wire types 1/5 in protobuf parser      | LOW    |
+| P2       | Add input length validation to deriveEd25519PublicKey        | LOW    |
+
+## Next Steps
+
+1. Fix the two web app issues (findings 1 and 2) -- these are the only ones with real functional impact
+2. Fix the MaxLength mismatch (finding 6) -- trivial one-liner
+3. Add deriveEd25519PublicKey input validation (finding 8) -- trivial one-liner
+4. Consider server-side pubKey binding once dependency cost is assessed
+
+---
+
+_Generated by security:review command_
+_This review is automated guidance, not a substitute for professional security audit_

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -31,6 +31,7 @@
     "@nestjs/terminus": "^11.0.0",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
+    "@cipherbox/crypto": "workspace:*",
     "@sendgrid/mail": "^8.1.6",
     "argon2": "^0.44.0",
     "bullmq": "^5.67.3",

--- a/apps/api/src/ipns/dto/publish.dto.ts
+++ b/apps/api/src/ipns/dto/publish.dto.ts
@@ -29,7 +29,7 @@ export class PublishIpnsDto {
   @Matches(/^(k51qzi5uqu5[a-z0-9]{40,60}|bafzaa[a-z2-7]{50,70})$/, {
     message: 'ipnsName must be a valid CIDv1 libp2p-key (k51qzi5uqu5... or bafzaa...)',
   })
-  @MaxLength(70)
+  @MaxLength(76)
   ipnsName!: string;
 
   @ApiProperty({
@@ -141,7 +141,7 @@ export class PublishIpnsEntryDto {
   @Matches(/^(k51qzi5uqu5[a-z0-9]{40,60}|bafzaa[a-z2-7]{50,70})$/, {
     message: 'ipnsName must be a valid CIDv1 libp2p-key (k51qzi5uqu5... or bafzaa...)',
   })
-  @MaxLength(70)
+  @MaxLength(76)
   ipnsName!: string;
 
   @ApiProperty({

--- a/apps/api/src/ipns/dto/publish.dto.ts
+++ b/apps/api/src/ipns/dto/publish.dto.ts
@@ -43,6 +43,17 @@ export class PublishIpnsDto {
   record!: string;
 
   @ApiProperty({
+    description: 'Base64-encoded raw 32-byte Ed25519 public key for this IPNS name',
+    required: false,
+    example: 'AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=',
+  })
+  @IsString()
+  @IsOptional()
+  @IsBase64()
+  @MaxLength(100)
+  publicKey?: string;
+
+  @ApiProperty({
     description: 'CID of the encrypted metadata this record points to',
     example: 'bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4',
   })
@@ -142,6 +153,17 @@ export class PublishIpnsEntryDto {
   @IsBase64()
   @MaxLength(10000)
   record!: string;
+
+  @ApiProperty({
+    description: 'Base64-encoded raw 32-byte Ed25519 public key for this IPNS name',
+    required: false,
+    example: 'AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=',
+  })
+  @IsString()
+  @IsOptional()
+  @IsBase64()
+  @MaxLength(100)
+  publicKey?: string;
 
   @ApiProperty({
     description: 'CID of the encrypted metadata this record points to',

--- a/apps/api/src/ipns/entities/folder-ipns.entity.ts
+++ b/apps/api/src/ipns/entities/folder-ipns.entity.ts
@@ -46,6 +46,20 @@ export class FolderIpns {
   sequenceNumber!: string; // TypeORM returns bigint as string
 
   /**
+   * Canonical signed IPNS record bytes for the latest publish.
+   * Used to return verifiable signature data on DB-cached resolves.
+   */
+  @Column({ type: 'bytea', name: 'signed_record', nullable: true })
+  signedRecord!: Buffer | null;
+
+  /**
+   * Raw 32-byte Ed25519 public key for this IPNS name.
+   * Used to complete signature verification when published records omit field 7.
+   */
+  @Column({ type: 'bytea', name: 'public_key', nullable: true })
+  publicKey!: Buffer | null;
+
+  /**
    * ECIES-wrapped Ed25519 private key for TEE republishing
    * Encrypted with TEE public key, only decryptable by TEE
    * Nullable until TEE integration is implemented (Phase 7+)

--- a/apps/api/src/ipns/ipns-record-parser.spec.ts
+++ b/apps/api/src/ipns/ipns-record-parser.spec.ts
@@ -253,7 +253,7 @@ describe('parseIpnsRecord', () => {
       expect(result.pubKey).toEqual(rawKey);
     });
 
-    it('should drop all sig fields when pubKey extraction fails (non-Ed25519 key)', () => {
+    it('should keep signatureV2 and data when pubKey extraction fails (non-Ed25519 key)', () => {
       // Wrong prefix — not a standard libp2p Ed25519 key
       const badKey = new Uint8Array(36).fill(0xff);
       const sig = new Uint8Array(64).fill(0xaa);
@@ -267,13 +267,12 @@ describe('parseIpnsRecord', () => {
       ]);
       const result = parseIpnsRecord(buf);
 
-      // All-or-nothing: pubKey failed so all sig fields dropped
       expect(result.pubKey).toBeUndefined();
-      expect(result.signatureV2).toBeUndefined();
-      expect(result.data).toBeUndefined();
+      expect(result.signatureV2).toEqual(sig);
+      expect(result.data).toEqual(data);
     });
 
-    it('should drop all sig fields when wrapped key has wrong length', () => {
+    it('should keep signatureV2 and data when wrapped key has wrong length', () => {
       // Too short (20 bytes instead of 36)
       const shortKey = new Uint8Array([0x08, 0x01, 0x12, 0x20, ...new Uint8Array(16)]);
       const sig = new Uint8Array(64).fill(0xcc);
@@ -288,8 +287,25 @@ describe('parseIpnsRecord', () => {
       const result = parseIpnsRecord(buf);
 
       expect(result.pubKey).toBeUndefined();
-      expect(result.signatureV2).toBeUndefined();
-      expect(result.data).toBeUndefined();
+      expect(result.signatureV2).toEqual(sig);
+      expect(result.data).toEqual(data);
+    });
+
+    it('should keep signatureV2 and data when field 7 is absent', () => {
+      const sig = new Uint8Array(64).fill(0x22);
+      const data = new Uint8Array(48).fill(0x33);
+
+      const buf = new Uint8Array([
+        ...encodeLengthDelimited(1, new TextEncoder().encode('/ipfs/QmDerived')),
+        ...encodeVarintField(5, 7n),
+        ...encodeLengthDelimited(8, sig),
+        ...encodeLengthDelimited(9, data),
+      ]);
+      const result = parseIpnsRecord(buf);
+
+      expect(result.pubKey).toBeUndefined();
+      expect(result.signatureV2).toEqual(sig);
+      expect(result.data).toEqual(data);
     });
 
     it('should parse all signature fields together', () => {

--- a/apps/api/src/ipns/ipns-record-parser.ts
+++ b/apps/api/src/ipns/ipns-record-parser.ts
@@ -8,12 +8,12 @@
  *   field 8 (SignatureV2) – length-delimited, Ed25519 signature bytes
  *   field 9 (Data)        – length-delimited, CBOR-encoded signed data
  *
- * Signature fields (7/8/9) are returned as an all-or-nothing bundle:
- * if any field is missing or pubKey extraction fails, all are omitted.
+ * SignatureV2 (field 8) and data (field 9) are returned independently.
+ * The public key (field 7) may be omitted by some publishers, in which case
+ * callers can supplement it from trusted cached metadata.
  *
  * Wire format reference: https://protobuf.dev/programming-guides/encoding/
  */
-
 export interface ParsedIpnsRecord {
   value: string;
   sequence: bigint;
@@ -117,14 +117,11 @@ export function parseIpnsRecord(buf: Uint8Array): ParsedIpnsRecord {
     throw new Error('IPNS record missing Value field');
   }
 
-  // If signatureV2 and data are present but pubKey extraction failed,
-  // drop all signature fields — partial signature data is unverifiable
-  const hasCompleteSigData = signatureV2 && data && rawPubKey;
   return {
     value,
     sequence,
-    signatureV2: hasCompleteSigData ? signatureV2 : undefined,
-    data: hasCompleteSigData ? data : undefined,
-    pubKey: hasCompleteSigData ? rawPubKey : undefined,
+    signatureV2,
+    data,
+    pubKey: rawPubKey,
   };
 }

--- a/apps/api/src/ipns/ipns-record-parser.ts
+++ b/apps/api/src/ipns/ipns-record-parser.ts
@@ -105,9 +105,11 @@ export function parseIpnsRecord(buf: Uint8Array): ParsedIpnsRecord {
       }
       pos = end;
     } else if (wireType === 5) {
-      pos += 4; // 32-bit
+      if (pos + 4 > buf.length) throw new Error('Buffer underflow reading 32-bit field');
+      pos += 4;
     } else if (wireType === 1) {
-      pos += 8; // 64-bit
+      if (pos + 8 > buf.length) throw new Error('Buffer underflow reading 64-bit field');
+      pos += 8;
     } else {
       throw new Error(`Unsupported wire type ${wireType}`);
     }

--- a/apps/api/src/ipns/ipns.service.spec.ts
+++ b/apps/api/src/ipns/ipns.service.spec.ts
@@ -202,6 +202,16 @@ describe('IpnsService', () => {
       );
     });
 
+    it('should throw BadRequestException when publicKey does not derive to ipnsName', async () => {
+      // Use a valid 32-byte key that does NOT derive to testIpnsName
+      const wrongPublicKey = Buffer.from(new Uint8Array(32).fill(0xff)).toString('base64');
+      const invalidDto = createDto({ publicKey: wrongPublicKey });
+
+      await expect(service.publishRecord(testUserId, invalidDto)).rejects.toThrow(
+        'publicKey does not correspond to the given ipnsName'
+      );
+    });
+
     it('should allow publishing without encryptedIpnsPrivateKey for new folder (Phase 6 - TEE optional)', async () => {
       mockFolderIpnsRepo.findOne.mockResolvedValue(null);
       mockFolderIpnsRepo.create.mockReturnValue({

--- a/apps/api/src/ipns/ipns.service.spec.ts
+++ b/apps/api/src/ipns/ipns.service.spec.ts
@@ -834,6 +834,52 @@ describe('IpnsService', () => {
       expect(result!.data).toBe(Buffer.from(dataBytes).toString('base64'));
     });
 
+    it('should enrich network result with cached signature fields when sequences are equal', async () => {
+      const mockRecordBytes = new Uint8Array([1, 2, 3]);
+      const cachedSigBytes = new Uint8Array(64).fill(0xaa);
+      const cachedDataBytes = new Uint8Array(48).fill(0xbb);
+
+      // Network returns record WITHOUT signature fields
+      mockDelegatedRoutingClient.resolve.mockResolvedValue(mockRecordBytes);
+      mockParseIpnsRecord.mockReturnValue({
+        value: '/ipfs/bafyNETWORK',
+        sequence: 10n,
+      });
+
+      // DB cache has same sequence WITH signedRecord containing signature data
+      const signedRecordBytes = new Uint8Array([4, 5, 6]);
+      mockFolderIpnsRepo.findOne.mockResolvedValue({
+        ...mockFolderEntity,
+        latestCid: 'bafyNETWORK',
+        sequenceNumber: '10',
+        signedRecord: signedRecordBytes,
+        publicKey: testPublicKeyBytes,
+      });
+
+      // parseCachedRecord will call parseIpnsRecordBytes on the signedRecord
+      // Second call to mockParseIpnsRecord is for the cached signedRecord
+      mockParseIpnsRecord
+        .mockReturnValueOnce({
+          value: '/ipfs/bafyNETWORK',
+          sequence: 10n,
+        })
+        .mockReturnValueOnce({
+          value: '/ipfs/bafyNETWORK',
+          sequence: 10n,
+          signatureV2: cachedSigBytes,
+          data: cachedDataBytes,
+        });
+
+      const result = await service.resolveRecord(testIpnsName);
+
+      expect(result).not.toBeNull();
+      expect(result!.cid).toBe('bafyNETWORK');
+      expect(result!.sequenceNumber).toBe('10');
+      expect(result!.signatureV2).toBe(Buffer.from(cachedSigBytes).toString('base64'));
+      expect(result!.data).toBe(Buffer.from(cachedDataBytes).toString('base64'));
+      expect(result!.pubKey).toBe(testPublicKey);
+    });
+
     describe('resolve latency metrics', () => {
       it('should observe ipnsResolveDuration with source=network on successful network resolution', async () => {
         const mockRecordBytes = new Uint8Array([1, 2, 3]);

--- a/apps/api/src/ipns/ipns.service.spec.ts
+++ b/apps/api/src/ipns/ipns.service.spec.ts
@@ -48,6 +48,9 @@ describe('IpnsService', () => {
   const testIpnsName = 'k51qzi5uqu5dg12345abcdef67890';
   const testMetadataCid = 'bafkreigaknpexyvxt76zgkitavbwx6ejgfheup5oybpm77f3pxzrvwpfdi';
   const testRecord = btoa('test-ipns-record-bytes'); // base64 encoded
+  const testRecordBytes = Buffer.from('test-ipns-record-bytes');
+  const testPublicKeyBytes = Buffer.from(new Uint8Array(32).map((_, index) => index + 1));
+  const testPublicKey = testPublicKeyBytes.toString('base64');
   const testEncryptedIpnsPrivateKey = 'a'.repeat(128); // 64 bytes hex
   const testKeyEpoch = 1;
 
@@ -57,6 +60,8 @@ describe('IpnsService', () => {
     ipnsName: testIpnsName,
     latestCid: testMetadataCid,
     sequenceNumber: '5',
+    signedRecord: null,
+    publicKey: testPublicKeyBytes,
     encryptedIpnsPrivateKey: Buffer.from(testEncryptedIpnsPrivateKey, 'hex'),
     keyEpoch: testKeyEpoch,
     isRoot: false,
@@ -129,6 +134,7 @@ describe('IpnsService', () => {
     const createDto = (overrides?: Partial<PublishIpnsDto>): PublishIpnsDto => ({
       ipnsName: testIpnsName,
       record: testRecord,
+      publicKey: testPublicKey,
       metadataCid: testMetadataCid,
       encryptedIpnsPrivateKey: testEncryptedIpnsPrivateKey,
       keyEpoch: testKeyEpoch,
@@ -149,6 +155,12 @@ describe('IpnsService', () => {
         testIpnsName,
         expect.any(Uint8Array)
       );
+      expect(mockFolderIpnsRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signedRecord: testRecordBytes,
+          publicKey: testPublicKeyBytes,
+        })
+      );
     });
 
     it('should publish record for existing folder and increment sequence', async () => {
@@ -162,6 +174,12 @@ describe('IpnsService', () => {
 
       expect(result.success).toBe(true);
       expect(result.sequenceNumber).toBe('6');
+      expect(mockFolderIpnsRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signedRecord: testRecordBytes,
+          publicKey: testPublicKeyBytes,
+        })
+      );
     });
 
     it('should throw BadRequestException for invalid base64 record', async () => {
@@ -172,6 +190,14 @@ describe('IpnsService', () => {
       );
       await expect(service.publishRecord(testUserId, invalidDto)).rejects.toThrow(
         'Invalid base64-encoded record'
+      );
+    });
+
+    it('should throw BadRequestException for invalid publicKey size', async () => {
+      const invalidDto = createDto({ publicKey: Buffer.from([1, 2, 3]).toString('base64') });
+
+      await expect(service.publishRecord(testUserId, invalidDto)).rejects.toThrow(
+        'publicKey must be a raw 32-byte Ed25519 public key'
       );
     });
 
@@ -369,16 +395,19 @@ describe('IpnsService', () => {
         keyEpoch: testKeyEpoch,
       });
 
-      expect(mockFolderIpnsRepo.create).toHaveBeenCalledWith({
-        userId: testUserId,
-        ipnsName: testIpnsName,
-        latestCid: testMetadataCid,
-        sequenceNumber: '1',
-        encryptedIpnsPrivateKey: Buffer.from(testEncryptedIpnsPrivateKey, 'hex'),
-        keyEpoch: testKeyEpoch,
-        isRoot: false,
-        recordType: 'folder',
-      });
+      expect(mockFolderIpnsRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: testUserId,
+          ipnsName: testIpnsName,
+          latestCid: testMetadataCid,
+          sequenceNumber: '1',
+          signedRecord: testRecordBytes,
+          encryptedIpnsPrivateKey: Buffer.from(testEncryptedIpnsPrivateKey, 'hex'),
+          keyEpoch: testKeyEpoch,
+          isRoot: false,
+          recordType: 'folder',
+        })
+      );
     });
 
     it('should increment sequence number for existing folder', async () => {
@@ -618,10 +647,21 @@ describe('IpnsService', () => {
       mockDelegatedRoutingClient.resolve.mockRejectedValue(
         new HttpException('Failed to resolve', HttpStatus.BAD_GATEWAY)
       );
+      const sigBytes = new Uint8Array(64).fill(0xab);
+      const dataBytes = new Uint8Array(48).fill(0xcd);
+      const pubKeyBytes = new Uint8Array(32).fill(0xef);
+      mockParseIpnsRecord.mockReturnValue({
+        value: '/ipfs/bafyCACHED',
+        sequence: 42n,
+        signatureV2: sigBytes,
+        data: dataBytes,
+        pubKey: pubKeyBytes,
+      });
       const cachedFolder = {
         ...mockFolderEntity,
         latestCid: 'bafyCACHED',
         sequenceNumber: '42',
+        signedRecord: Buffer.from([9, 9, 9]),
       };
       mockFolderIpnsRepo.findOne.mockResolvedValue(cachedFolder);
 
@@ -630,6 +670,9 @@ describe('IpnsService', () => {
       expect(result).not.toBeNull();
       expect(result!.cid).toBe('bafyCACHED');
       expect(result!.sequenceNumber).toBe('42');
+      expect(result!.signatureV2).toBe(Buffer.from(sigBytes).toString('base64'));
+      expect(result!.data).toBe(Buffer.from(dataBytes).toString('base64'));
+      expect(result!.pubKey).toBe(Buffer.from(pubKeyBytes).toString('base64'));
       expect(mockFolderIpnsRepo.findOne).toHaveBeenCalledWith({
         where: { ipnsName: testIpnsName },
       });
@@ -700,16 +743,25 @@ describe('IpnsService', () => {
       // Network returns stale record (seq 3)
       const mockRecordBytes = new Uint8Array([1, 2, 3]);
       mockDelegatedRoutingClient.resolve.mockResolvedValue(mockRecordBytes);
-      mockParseIpnsRecord.mockReturnValue({
-        value: '/ipfs/bafySTALE',
-        sequence: 3n,
-      });
+      mockParseIpnsRecord
+        .mockReturnValueOnce({
+          value: '/ipfs/bafySTALE',
+          sequence: 3n,
+        })
+        .mockReturnValueOnce({
+          value: '/ipfs/bafyFRESH',
+          sequence: 10n,
+          signatureV2: new Uint8Array(64).fill(1),
+          data: new Uint8Array(48).fill(2),
+          pubKey: new Uint8Array(32).fill(3),
+        });
 
       // DB has newer record (seq 10)
       mockFolderIpnsRepo.findOne.mockResolvedValue({
         ...mockFolderEntity,
         latestCid: 'bafyFRESH',
         sequenceNumber: '10',
+        signedRecord: Buffer.from([4, 5, 6]),
       });
 
       const result = await service.resolveRecord(testIpnsName);
@@ -717,6 +769,7 @@ describe('IpnsService', () => {
       expect(result).not.toBeNull();
       expect(result!.cid).toBe('bafyFRESH');
       expect(result!.sequenceNumber).toBe('10');
+      expect(result!.signatureV2).toBeDefined();
     });
 
     it('should prefer network result when it has equal or higher sequence than DB', async () => {
@@ -739,6 +792,35 @@ describe('IpnsService', () => {
       expect(result).not.toBeNull();
       expect(result!.cid).toBe('bafyNETWORK');
       expect(result!.sequenceNumber).toBe('10');
+    });
+
+    it('should enrich network signature data with cached publicKey when field 7 is absent', async () => {
+      const mockRecordBytes = new Uint8Array([1, 2, 3]);
+      const sigBytes = new Uint8Array(64).fill(0x12);
+      const dataBytes = new Uint8Array(48).fill(0x34);
+
+      mockDelegatedRoutingClient.resolve.mockResolvedValue(mockRecordBytes);
+      mockParseIpnsRecord.mockReturnValue({
+        value: '/ipfs/bafyNETWORK',
+        sequence: 10n,
+        signatureV2: sigBytes,
+        data: dataBytes,
+      });
+      mockFolderIpnsRepo.findOne.mockResolvedValue({
+        ...mockFolderEntity,
+        latestCid: 'bafyDB',
+        sequenceNumber: '10',
+        signedRecord: null,
+        publicKey: testPublicKeyBytes,
+      });
+
+      const result = await service.resolveRecord(testIpnsName);
+
+      expect(result).not.toBeNull();
+      expect(result!.cid).toBe('bafyNETWORK');
+      expect(result!.pubKey).toBe(testPublicKey);
+      expect(result!.signatureV2).toBe(Buffer.from(sigBytes).toString('base64'));
+      expect(result!.data).toBe(Buffer.from(dataBytes).toString('base64'));
     });
 
     describe('resolve latency metrics', () => {
@@ -788,6 +870,7 @@ describe('IpnsService', () => {
           ...mockFolderEntity,
           latestCid: 'bafyFRESH',
           sequenceNumber: '10',
+          signedRecord: null,
         });
 
         await service.resolveRecord(testIpnsName);
@@ -901,6 +984,7 @@ describe('IpnsService', () => {
         ...mockFolderEntity,
         latestCid: 'bafyFRESH',
         sequenceNumber: '10',
+        signedRecord: null,
       });
 
       await service.resolveRecord(testIpnsName);

--- a/apps/api/src/ipns/ipns.service.spec.ts
+++ b/apps/api/src/ipns/ipns.service.spec.ts
@@ -45,7 +45,8 @@ describe('IpnsService', () => {
 
   // Test data
   const testUserId = '550e8400-e29b-41d4-a716-446655440000';
-  const testIpnsName = 'k51qzi5uqu5dg12345abcdef67890';
+  // Derived from testPublicKeyBytes via deriveIpnsName (must match for server-side validation)
+  const testIpnsName = 'k51qzi5uqu5dg7hrs1jyr49oygapxsw71v7pv43rk8lemejo9h2m3hkzvww8io';
   const testMetadataCid = 'bafkreigaknpexyvxt76zgkitavbwx6ejgfheup5oybpm77f3pxzrvwpfdi';
   const testRecord = btoa('test-ipns-record-bytes'); // base64 encoded
   const testRecordBytes = Buffer.from('test-ipns-record-bytes');

--- a/apps/api/src/ipns/ipns.service.ts
+++ b/apps/api/src/ipns/ipns.service.ts
@@ -63,12 +63,27 @@ export class IpnsService {
         throw new BadRequestException('Invalid base64-encoded record');
       }
 
+      let publicKeyBytes: Uint8Array | undefined;
+      if (dto.publicKey !== undefined) {
+        try {
+          publicKeyBytes = Uint8Array.from(atob(dto.publicKey), (c) => c.charCodeAt(0));
+        } catch {
+          throw new BadRequestException('Invalid base64-encoded publicKey');
+        }
+
+        if (publicKeyBytes.length !== 32) {
+          throw new BadRequestException('publicKey must be a raw 32-byte Ed25519 public key');
+        }
+      }
+
       // Save to DB first so resolve always has a fallback, even if delegated
       // routing fails (e.g. rate-limited, network error, DHT propagation delay).
       const folder = await this.upsertFolderIpns(
         userId,
         dto.ipnsName,
         dto.metadataCid,
+        recordBytes,
+        publicKeyBytes,
         dto.encryptedIpnsPrivateKey,
         dto.keyEpoch,
         recordType,
@@ -174,6 +189,8 @@ export class IpnsService {
     userId: string,
     ipnsName: string,
     metadataCid: string,
+    signedRecord: Uint8Array,
+    publicKey?: Uint8Array,
     encryptedIpnsPrivateKey?: string,
     keyEpoch?: number,
     recordType: 'folder' | 'file' = 'folder',
@@ -213,9 +230,15 @@ export class IpnsService {
     }
 
     if (existing) {
+      if (publicKey && existing.publicKey && !existing.publicKey.equals(Buffer.from(publicKey))) {
+        throw new BadRequestException('publicKey does not match the existing IPNS entry');
+      }
+
       // Update existing entry
       existing.latestCid = metadataCid;
       existing.sequenceNumber = (BigInt(existing.sequenceNumber) + 1n).toString();
+      existing.signedRecord = Buffer.from(signedRecord);
+      existing.publicKey = publicKey ? Buffer.from(publicKey) : existing.publicKey;
       existing.recordType = recordType;
       existing.updatedAt = new Date();
 
@@ -259,6 +282,8 @@ export class IpnsService {
       ipnsName,
       latestCid: metadataCid,
       sequenceNumber: '1',
+      signedRecord: Buffer.from(signedRecord),
+      publicKey: publicKey ? Buffer.from(publicKey) : null,
       encryptedIpnsPrivateKey: encryptedIpnsPrivateKey
         ? Buffer.from(encryptedIpnsPrivateKey, 'hex')
         : null,
@@ -386,19 +411,24 @@ export class IpnsService {
       const cached = await this.folderIpnsRepository.findOne({
         where: { ipnsName },
       });
+      const cachedResult = this.parseCachedRecord(cached);
 
-      if (result && cached?.latestCid) {
+      if (result && cached?.publicKey) {
+        result = this.withCachedPublicKey(result, cached.publicKey);
+      }
+
+      if (result && cachedResult) {
         // Both sources available — prefer the one with the higher sequence number
         const networkSeq = BigInt(result.sequenceNumber);
-        const dbSeq = BigInt(cached.sequenceNumber);
+        const dbSeq = BigInt(cachedResult.sequenceNumber);
         if (dbSeq > networkSeq) {
           this.logger.log(
-            `DB cache has newer sequence (${dbSeq} > ${networkSeq}) for ${ipnsName}, using DB: ${cached.latestCid}`
+            `DB cache has newer sequence (${dbSeq} > ${networkSeq}) for ${ipnsName}, using DB: ${cachedResult.cid}`
           );
           timerSource = 'db';
           source = 'network_stale';
           resolveFound = true;
-          return { cid: cached.latestCid, sequenceNumber: cached.sequenceNumber };
+          return cachedResult;
         }
         timerSource = 'network';
         resolveFound = true;
@@ -412,12 +442,12 @@ export class IpnsService {
       }
 
       // Delegated routing returned null (404) or threw BAD_GATEWAY — try DB cache
-      if (cached?.latestCid) {
-        this.logger.log(`Resolved ${ipnsName} from DB cache: ${cached.latestCid}`);
+      if (cachedResult) {
+        this.logger.log(`Resolved ${ipnsName} from DB cache: ${cachedResult.cid}`);
         timerSource = 'db';
         source = 'db_cache';
         resolveFound = true;
-        return { cid: cached.latestCid, sequenceNumber: cached.sequenceNumber };
+        return cachedResult;
       }
 
       return null;
@@ -474,5 +504,57 @@ export class IpnsService {
       this.logger.error(`Failed to parse IPNS record: ${error}`);
       throw new HttpException('Invalid IPNS record format', HttpStatus.BAD_GATEWAY);
     }
+  }
+
+  private parseCachedRecord(cached: FolderIpns | null): {
+    cid: string;
+    sequenceNumber: string;
+    signatureV2?: string;
+    data?: string;
+    pubKey?: string;
+  } | null {
+    if (!cached?.latestCid) {
+      return null;
+    }
+
+    if (cached.signedRecord) {
+      try {
+        return this.withCachedPublicKey(
+          this.parseIpnsRecordBytes(cached.signedRecord),
+          cached.publicKey ?? undefined
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.warn(`Failed to parse cached signed record for ${cached.ipnsName}: ${message}`);
+      }
+    }
+
+    return { cid: cached.latestCid, sequenceNumber: cached.sequenceNumber };
+  }
+
+  private withCachedPublicKey(
+    result: {
+      cid: string;
+      sequenceNumber: string;
+      signatureV2?: string;
+      data?: string;
+      pubKey?: string;
+    },
+    publicKey?: Buffer
+  ): {
+    cid: string;
+    sequenceNumber: string;
+    signatureV2?: string;
+    data?: string;
+    pubKey?: string;
+  } {
+    if (result.pubKey || !result.signatureV2 || !result.data || !publicKey) {
+      return result;
+    }
+
+    return {
+      ...result,
+      pubKey: publicKey.toString('base64'),
+    };
   }
 }

--- a/apps/api/src/ipns/ipns.service.ts
+++ b/apps/api/src/ipns/ipns.service.ts
@@ -437,6 +437,15 @@ export class IpnsService {
           resolveFound = true;
           return cachedResult;
         }
+        // Equal sequence: enrich network result with cached signature fields if missing
+        if (dbSeq === networkSeq && !result.signatureV2 && cachedResult.signatureV2) {
+          result = {
+            ...result,
+            signatureV2: cachedResult.signatureV2,
+            data: cachedResult.data,
+            pubKey: result.pubKey ?? cachedResult.pubKey,
+          };
+        }
         timerSource = 'network';
         resolveFound = true;
         return result;

--- a/apps/api/src/ipns/ipns.service.ts
+++ b/apps/api/src/ipns/ipns.service.ts
@@ -24,6 +24,7 @@ import { DelegatedRoutingClient } from './delegated-routing.client';
 import { MetricsService } from '../metrics/metrics.service';
 import { parseIpnsRecord } from './ipns-record-parser';
 import { SharesService } from '../shares/shares.service';
+import { deriveIpnsName } from '@cipherbox/crypto';
 
 @Injectable()
 export class IpnsService {
@@ -73,6 +74,12 @@ export class IpnsService {
 
         if (publicKeyBytes.length !== 32) {
           throw new BadRequestException('publicKey must be a raw 32-byte Ed25519 public key');
+        }
+
+        // Verify the public key cryptographically derives to the claimed IPNS name
+        const derivedName = await deriveIpnsName(publicKeyBytes);
+        if (derivedName !== dto.ipnsName) {
+          throw new BadRequestException('publicKey does not correspond to the given ipnsName');
         }
       }
 

--- a/apps/api/src/migrations/1743200000000-AddSignedRecordToFolderIpns.ts
+++ b/apps/api/src/migrations/1743200000000-AddSignedRecordToFolderIpns.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Migration: Add signed_record column to folder_ipns table.
+ *
+ * Stores the canonical signed IPNS record bytes for the latest publish so
+ * DB-cached resolves can return signature data for client-side verification.
+ */
+export class AddSignedRecordToFolderIpns1743200000000 implements MigrationInterface {
+  name = 'AddSignedRecordToFolderIpns1743200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = 'folder_ipns' AND column_name = 'signed_record'
+        ) THEN
+          ALTER TABLE "folder_ipns"
+          ADD COLUMN "signed_record" bytea;
+        END IF;
+      END $$;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "folder_ipns" DROP COLUMN IF EXISTS "signed_record"
+    `);
+  }
+}

--- a/apps/api/src/migrations/1743300000000-AddPublicKeyToFolderIpns.ts
+++ b/apps/api/src/migrations/1743300000000-AddPublicKeyToFolderIpns.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Migration: Add public_key column to folder_ipns table.
+ *
+ * Stores the raw Ed25519 public key so network-resolved IPNS records can still
+ * be verified when the published protobuf omits field 7.
+ */
+export class AddPublicKeyToFolderIpns1743300000000 implements MigrationInterface {
+  name = 'AddPublicKeyToFolderIpns1743300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = 'folder_ipns' AND column_name = 'public_key'
+        ) THEN
+          ALTER TABLE "folder_ipns"
+          ADD COLUMN "public_key" bytea;
+        END IF;
+      END $$;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "folder_ipns" DROP COLUMN IF EXISTS "public_key"
+    `);
+  }
+}

--- a/apps/api/src/republish/republish.service.spec.ts
+++ b/apps/api/src/republish/republish.service.spec.ts
@@ -204,7 +204,10 @@ describe('RepublishService', () => {
       // Verify FolderIpns sync
       expect(folderIpnsRepository.update).toHaveBeenCalledWith(
         { userId: 'user-uuid-1', ipnsName: 'k51test123' },
-        { sequenceNumber: '6' }
+        {
+          sequenceNumber: '6',
+          signedRecord: Buffer.from('signed-record-bytes'),
+        }
       );
     });
 

--- a/apps/api/src/republish/republish.service.ts
+++ b/apps/api/src/republish/republish.service.ts
@@ -158,7 +158,8 @@ export class RepublishService {
             await this.syncFolderIpnsSequence(
               entry.userId,
               entry.ipnsName,
-              result.newSequenceNumber
+              result.newSequenceNumber,
+              result.signedRecord
             );
 
             totalSucceeded++;
@@ -371,12 +372,16 @@ export class RepublishService {
   private async syncFolderIpnsSequence(
     userId: string,
     ipnsName: string,
-    newSequenceNumber: string
+    newSequenceNumber: string,
+    signedRecordBase64: string
   ): Promise<void> {
     try {
       await this.folderIpnsRepository.update(
         { userId, ipnsName },
-        { sequenceNumber: newSequenceNumber }
+        {
+          sequenceNumber: newSequenceNumber,
+          signedRecord: Buffer.from(signedRecordBase64, 'base64'),
+        }
       );
     } catch (error) {
       // Non-fatal: log and continue

--- a/apps/web/src/services/ipns.service.ts
+++ b/apps/web/src/services/ipns.service.ts
@@ -26,10 +26,10 @@ import { logger } from '../lib/logger';
  * The record is signed locally using the Ed25519 private key, then
  * the backend relays it to the IPFS network via delegated routing.
  *
- * @param params.ipnsPrivateKey - Ed25519 private key (64 bytes in libp2p format)
+ * @param params.ipnsPrivateKey - 32-byte Ed25519 private key seed
  * @param params.ipnsName - IPNS name (k51.../bafzaa... format)
  * @param params.metadataCid - CID of the encrypted metadata blob
- * @param params.sequenceNumber - Current sequence number (will be incremented before publish)
+ * @param params.sequenceNumber - Sequence number for this publish
  * @param params.encryptedIpnsPrivateKey - Hex ECIES-wrapped key for TEE (first publish only)
  * @param params.keyEpoch - TEE key epoch (required with encryptedIpnsPrivateKey)
  * @param params.expectedSequenceNumber - Pre-increment sequence number for conflict detection (folder records only)

--- a/apps/web/src/services/ipns.service.ts
+++ b/apps/web/src/services/ipns.service.ts
@@ -6,7 +6,7 @@
  */
 
 import { createIpnsRecord, marshalIpnsRecord, IPNS_SIGNATURE_PREFIX } from '@cipherbox/core';
-import { verifyEd25519, concatBytes } from '@cipherbox/crypto';
+import { verifyEd25519, concatBytes, deriveIpnsName } from '@cipherbox/crypto';
 import {
   ipnsControllerPublishRecord,
   ipnsControllerPublishBatch,
@@ -159,6 +159,16 @@ export async function resolveIpnsRecord(
       if (!valid) {
         throw new Error('IPNS signature verification failed - record may be tampered');
       }
+
+      // Verify the returned public key derives to the requested IPNS name
+      const pubKeyBytes = Uint8Array.from(atob(response.pubKey), (c) => c.charCodeAt(0));
+      const derivedName = await deriveIpnsName(pubKeyBytes);
+      if (derivedName !== ipnsName) {
+        throw new Error(
+          'IPNS public key does not match requested name - possible key substitution'
+        );
+      }
+
       signatureVerified = true;
     } else {
       logger.warn('[IPNS] IPNS resolve returned without signature data, skipping verification');

--- a/apps/web/src/services/ipns.service.ts
+++ b/apps/web/src/services/ipns.service.ts
@@ -99,6 +99,7 @@ export async function batchPublishIpnsRecords(
   records: Array<{
     ipnsName: string;
     recordBase64: string;
+    publicKey?: string;
     metadataCid: string;
     encryptedIpnsPrivateKey?: string;
     keyEpoch?: number;
@@ -111,6 +112,7 @@ export async function batchPublishIpnsRecords(
     records: records.map((r) => ({
       ipnsName: r.ipnsName,
       record: r.recordBase64,
+      publicKey: r.publicKey,
       metadataCid: r.metadataCid,
       encryptedIpnsPrivateKey: r.encryptedIpnsPrivateKey,
       keyEpoch: r.keyEpoch,

--- a/apps/web/src/services/ipns.service.ts
+++ b/apps/web/src/services/ipns.service.ts
@@ -6,7 +6,12 @@
  */
 
 import { createIpnsRecord, marshalIpnsRecord, IPNS_SIGNATURE_PREFIX } from '@cipherbox/core';
-import { verifyEd25519, concatBytes, deriveIpnsName } from '@cipherbox/crypto';
+import {
+  verifyEd25519,
+  concatBytes,
+  deriveIpnsName,
+  deriveEd25519PublicKey,
+} from '@cipherbox/crypto';
 import {
   ipnsControllerPublishRecord,
   ipnsControllerPublishBatch,
@@ -49,14 +54,25 @@ export async function createAndPublishIpnsRecord(params: {
 
   // 2. Marshal to bytes for transport
   const recordBytes = marshalIpnsRecord(record);
+  const publicKeyBytes = deriveEd25519PublicKey(params.ipnsPrivateKey);
 
-  // 3. Base64 encode for API transmission
-  const recordBase64 = btoa(String.fromCharCode(...recordBytes));
+  // 3. Base64 encode for API transmission (loop-based to avoid call stack overflow on large records)
+  let recordBinary = '';
+  for (let i = 0; i < recordBytes.length; i++) {
+    recordBinary += String.fromCharCode(recordBytes[i]);
+  }
+  const recordBase64 = btoa(recordBinary);
+  let pkBinary = '';
+  for (let i = 0; i < publicKeyBytes.length; i++) {
+    pkBinary += String.fromCharCode(publicKeyBytes[i]);
+  }
+  const publicKey = btoa(pkBinary);
 
   // 4. Call backend API to relay to IPFS network
   const response = await ipnsControllerPublishRecord({
     ipnsName: params.ipnsName,
     record: recordBase64,
+    publicKey,
     metadataCid: params.metadataCid,
     encryptedIpnsPrivateKey: params.encryptedIpnsPrivateKey,
     keyEpoch: params.keyEpoch,

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -2161,7 +2161,7 @@
   "info": {
     "title": "CipherBox API",
     "description": "Zero-knowledge encrypted cloud storage API",
-    "version": "0.35.0",
+    "version": "0.36.1",
     "contact": {}
   },
   "tags": [
@@ -2807,6 +2807,11 @@
             "description": "Base64-encoded marshaled IPNS record",
             "example": "CiQBqKAFp..."
           },
+          "publicKey": {
+            "type": "string",
+            "description": "Base64-encoded raw 32-byte Ed25519 public key for this IPNS name",
+            "example": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA="
+          },
           "metadataCid": {
             "type": "string",
             "description": "CID of the encrypted metadata this record points to",
@@ -2863,6 +2868,11 @@
             "type": "string",
             "description": "Base64-encoded marshaled IPNS record",
             "example": "CiQBqKAFp..."
+          },
+          "publicKey": {
+            "type": "string",
+            "description": "Base64-encoded raw 32-byte Ed25519 public key for this IPNS name",
+            "example": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA="
           },
           "metadataCid": {
             "type": "string",

--- a/packages/api-client/src/generated/auth/auth.ts
+++ b/packages/api-client/src/generated/auth/auth.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type {
   AuthMethodResponseDto,

--- a/packages/api-client/src/generated/device-approval/device-approval.ts
+++ b/packages/api-client/src/generated/device-approval/device-approval.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type {
   CreateApprovalDto,

--- a/packages/api-client/src/generated/health/health.ts
+++ b/packages/api-client/src/generated/health/health.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { HealthControllerCheck200 } from '../../models';
 

--- a/packages/api-client/src/generated/identity/identity.ts
+++ b/packages/api-client/src/generated/identity/identity.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type {
   GoogleLoginDto,

--- a/packages/api-client/src/generated/invites/invites.ts
+++ b/packages/api-client/src/generated/invites/invites.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type {
   ClaimInviteDto,

--- a/packages/api-client/src/generated/ipfs/ipfs.ts
+++ b/packages/api-client/src/generated/ipfs/ipfs.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type {
   IpfsControllerUploadBody,

--- a/packages/api-client/src/generated/ipns/ipns.ts
+++ b/packages/api-client/src/generated/ipns/ipns.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type {
   BatchPublishIpnsDto,

--- a/packages/api-client/src/generated/root/root.ts
+++ b/packages/api-client/src/generated/root/root.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import { customInstance } from '../../instance';
 

--- a/packages/api-client/src/generated/share-invites/share-invites.ts
+++ b/packages/api-client/src/generated/share-invites/share-invites.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type {
   CreateInviteDto,

--- a/packages/api-client/src/generated/shares/shares.ts
+++ b/packages/api-client/src/generated/shares/shares.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type {
   AddShareKeysDto,

--- a/packages/api-client/src/generated/tee/tee.ts
+++ b/packages/api-client/src/generated/tee/tee.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { ConnectionTestRequestDto, ConnectionTestResponseDto } from '../../models';
 

--- a/packages/api-client/src/generated/vault/vault.ts
+++ b/packages/api-client/src/generated/vault/vault.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type {
   InitVaultDto,

--- a/packages/api-client/src/models/addShareKeysDto.ts
+++ b/packages/api-client/src/models/addShareKeysDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { ShareKeyEntryDto } from './shareKeyEntryDto';
 

--- a/packages/api-client/src/models/authMethodResponseDto.ts
+++ b/packages/api-client/src/models/authMethodResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { AuthMethodResponseDtoType } from './authMethodResponseDtoType';
 

--- a/packages/api-client/src/models/authMethodResponseDtoType.ts
+++ b/packages/api-client/src/models/authMethodResponseDtoType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type AuthMethodResponseDtoType =

--- a/packages/api-client/src/models/batchPublishIpnsDto.ts
+++ b/packages/api-client/src/models/batchPublishIpnsDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { PublishIpnsEntryDto } from './publishIpnsEntryDto';
 

--- a/packages/api-client/src/models/batchPublishIpnsResponseDto.ts
+++ b/packages/api-client/src/models/batchPublishIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { PublishIpnsResponseDto } from './publishIpnsResponseDto';
 

--- a/packages/api-client/src/models/batchUnenrollIpnsDto.ts
+++ b/packages/api-client/src/models/batchUnenrollIpnsDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface BatchUnenrollIpnsDto {

--- a/packages/api-client/src/models/batchUnenrollIpnsResponseDto.ts
+++ b/packages/api-client/src/models/batchUnenrollIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface BatchUnenrollIpnsResponseDto {

--- a/packages/api-client/src/models/childKeyDto.ts
+++ b/packages/api-client/src/models/childKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { ChildKeyDtoKeyType } from './childKeyDtoKeyType';
 

--- a/packages/api-client/src/models/childKeyDtoKeyType.ts
+++ b/packages/api-client/src/models/childKeyDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/claimChildKeyDto.ts
+++ b/packages/api-client/src/models/claimChildKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { ClaimChildKeyDtoKeyType } from './claimChildKeyDtoKeyType';
 

--- a/packages/api-client/src/models/claimChildKeyDtoKeyType.ts
+++ b/packages/api-client/src/models/claimChildKeyDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/claimInviteDto.ts
+++ b/packages/api-client/src/models/claimInviteDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { ClaimChildKeyDto } from './claimChildKeyDto';
 

--- a/packages/api-client/src/models/claimInviteResponseDto.ts
+++ b/packages/api-client/src/models/claimInviteResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface ClaimInviteResponseDto {

--- a/packages/api-client/src/models/connectionTestRequestDto.ts
+++ b/packages/api-client/src/models/connectionTestRequestDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface ConnectionTestRequestDto {

--- a/packages/api-client/src/models/connectionTestResponseDto.ts
+++ b/packages/api-client/src/models/connectionTestResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { ConnectionTestResponseDtoProtocol } from './connectionTestResponseDtoProtocol';
 

--- a/packages/api-client/src/models/connectionTestResponseDtoProtocol.ts
+++ b/packages/api-client/src/models/connectionTestResponseDtoProtocol.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/createApprovalDto.ts
+++ b/packages/api-client/src/models/createApprovalDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface CreateApprovalDto {

--- a/packages/api-client/src/models/createInviteDto.ts
+++ b/packages/api-client/src/models/createInviteDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { CreateInviteDtoItemType } from './createInviteDtoItemType';
 import type { InviteChildKeyDto } from './inviteChildKeyDto';

--- a/packages/api-client/src/models/createInviteDtoItemType.ts
+++ b/packages/api-client/src/models/createInviteDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/createShareDto.ts
+++ b/packages/api-client/src/models/createShareDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { CreateShareDtoItemType } from './createShareDtoItemType';
 import type { CreateShareDtoPermission } from './createShareDtoPermission';

--- a/packages/api-client/src/models/createShareDtoItemType.ts
+++ b/packages/api-client/src/models/createShareDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/createShareDtoPermission.ts
+++ b/packages/api-client/src/models/createShareDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/createShareResponseDto.ts
+++ b/packages/api-client/src/models/createShareResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { CreateShareResponseDtoItemType } from './createShareResponseDtoItemType';
 import type { CreateShareResponseDtoPermission } from './createShareResponseDtoPermission';

--- a/packages/api-client/src/models/createShareResponseDtoItemType.ts
+++ b/packages/api-client/src/models/createShareResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type CreateShareResponseDtoItemType =

--- a/packages/api-client/src/models/createShareResponseDtoPermission.ts
+++ b/packages/api-client/src/models/createShareResponseDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/deleteAccountDto.ts
+++ b/packages/api-client/src/models/deleteAccountDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface DeleteAccountDto {

--- a/packages/api-client/src/models/deleteAccountResponseDto.ts
+++ b/packages/api-client/src/models/deleteAccountResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface DeleteAccountResponseDto {

--- a/packages/api-client/src/models/desktopRefreshDto.ts
+++ b/packages/api-client/src/models/desktopRefreshDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface DesktopRefreshDto {

--- a/packages/api-client/src/models/deviceApprovalControllerCreateRequest201.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerCreateRequest201.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type DeviceApprovalControllerCreateRequest201 = {

--- a/packages/api-client/src/models/deviceApprovalControllerGetPending200Item.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerGetPending200Item.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type DeviceApprovalControllerGetPending200Item = {

--- a/packages/api-client/src/models/deviceApprovalControllerGetStatus200.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerGetStatus200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { DeviceApprovalControllerGetStatus200Status } from './deviceApprovalControllerGetStatus200Status';
 

--- a/packages/api-client/src/models/deviceApprovalControllerGetStatus200Status.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerGetStatus200Status.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type DeviceApprovalControllerGetStatus200Status =

--- a/packages/api-client/src/models/googleLoginDto.ts
+++ b/packages/api-client/src/models/googleLoginDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { GoogleLoginDtoIntent } from './googleLoginDtoIntent';
 

--- a/packages/api-client/src/models/googleLoginDtoIntent.ts
+++ b/packages/api-client/src/models/googleLoginDtoIntent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/healthControllerCheck200.ts
+++ b/packages/api-client/src/models/healthControllerCheck200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { HealthControllerCheck200Info } from './healthControllerCheck200Info';
 import type { HealthControllerCheck200Error } from './healthControllerCheck200Error';

--- a/packages/api-client/src/models/healthControllerCheck200Details.ts
+++ b/packages/api-client/src/models/healthControllerCheck200Details.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { HealthControllerCheck200DetailsDatabase } from './healthControllerCheck200DetailsDatabase';
 

--- a/packages/api-client/src/models/healthControllerCheck200DetailsDatabase.ts
+++ b/packages/api-client/src/models/healthControllerCheck200DetailsDatabase.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type HealthControllerCheck200DetailsDatabase = {

--- a/packages/api-client/src/models/healthControllerCheck200Error.ts
+++ b/packages/api-client/src/models/healthControllerCheck200Error.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type HealthControllerCheck200Error = { [key: string]: unknown };

--- a/packages/api-client/src/models/healthControllerCheck200Info.ts
+++ b/packages/api-client/src/models/healthControllerCheck200Info.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { HealthControllerCheck200InfoDatabase } from './healthControllerCheck200InfoDatabase';
 

--- a/packages/api-client/src/models/healthControllerCheck200InfoDatabase.ts
+++ b/packages/api-client/src/models/healthControllerCheck200InfoDatabase.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type HealthControllerCheck200InfoDatabase = {

--- a/packages/api-client/src/models/identityControllerGetJwks200.ts
+++ b/packages/api-client/src/models/identityControllerGetJwks200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { IdentityControllerGetJwks200KeysItem } from './identityControllerGetJwks200KeysItem';
 

--- a/packages/api-client/src/models/identityControllerGetJwks200KeysItem.ts
+++ b/packages/api-client/src/models/identityControllerGetJwks200KeysItem.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type IdentityControllerGetJwks200KeysItem = { [key: string]: unknown };

--- a/packages/api-client/src/models/identityControllerGetWalletNonce200.ts
+++ b/packages/api-client/src/models/identityControllerGetWalletNonce200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type IdentityControllerGetWalletNonce200 = {

--- a/packages/api-client/src/models/identityTokenResponseDto.ts
+++ b/packages/api-client/src/models/identityTokenResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface IdentityTokenResponseDto {

--- a/packages/api-client/src/models/index.ts
+++ b/packages/api-client/src/models/index.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export * from './addShareKeysDto';

--- a/packages/api-client/src/models/initVaultDto.ts
+++ b/packages/api-client/src/models/initVaultDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface InitVaultDto {

--- a/packages/api-client/src/models/inviteChildKeyDto.ts
+++ b/packages/api-client/src/models/inviteChildKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { InviteChildKeyDtoKeyType } from './inviteChildKeyDtoKeyType';
 

--- a/packages/api-client/src/models/inviteChildKeyDtoKeyType.ts
+++ b/packages/api-client/src/models/inviteChildKeyDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/inviteDataResponseDto.ts
+++ b/packages/api-client/src/models/inviteDataResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { InviteDataResponseDtoStatus } from './inviteDataResponseDtoStatus';
 import type { InviteChildKeyDto } from './inviteChildKeyDto';

--- a/packages/api-client/src/models/inviteDataResponseDtoItemType.ts
+++ b/packages/api-client/src/models/inviteDataResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type InviteDataResponseDtoItemType =

--- a/packages/api-client/src/models/inviteDataResponseDtoStatus.ts
+++ b/packages/api-client/src/models/inviteDataResponseDtoStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/inviteResponseDto.ts
+++ b/packages/api-client/src/models/inviteResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { InviteResponseDtoItemType } from './inviteResponseDtoItemType';
 import type { InviteResponseDtoStatus } from './inviteResponseDtoStatus';

--- a/packages/api-client/src/models/inviteResponseDtoItemType.ts
+++ b/packages/api-client/src/models/inviteResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type InviteResponseDtoItemType =

--- a/packages/api-client/src/models/inviteResponseDtoStatus.ts
+++ b/packages/api-client/src/models/inviteResponseDtoStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type InviteResponseDtoStatus =

--- a/packages/api-client/src/models/inviteStatusResponseDto.ts
+++ b/packages/api-client/src/models/inviteStatusResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { InviteStatusResponseDtoStatus } from './inviteStatusResponseDtoStatus';
 

--- a/packages/api-client/src/models/inviteStatusResponseDtoStatus.ts
+++ b/packages/api-client/src/models/inviteStatusResponseDtoStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/ipfsControllerUploadBody.ts
+++ b/packages/api-client/src/models/ipfsControllerUploadBody.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type IpfsControllerUploadBody = {

--- a/packages/api-client/src/models/ipnsControllerResolveRecordParams.ts
+++ b/packages/api-client/src/models/ipnsControllerResolveRecordParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type IpnsControllerResolveRecordParams = {

--- a/packages/api-client/src/models/linkMethodDto.ts
+++ b/packages/api-client/src/models/linkMethodDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { LinkMethodDtoLoginType } from './linkMethodDtoLoginType';
 

--- a/packages/api-client/src/models/linkMethodDtoLoginType.ts
+++ b/packages/api-client/src/models/linkMethodDtoLoginType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/loginDto.ts
+++ b/packages/api-client/src/models/loginDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { LoginDtoLoginType } from './loginDtoLoginType';
 

--- a/packages/api-client/src/models/loginDtoLoginType.ts
+++ b/packages/api-client/src/models/loginDtoLoginType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/loginResponseDto.ts
+++ b/packages/api-client/src/models/loginResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface LoginResponseDto {

--- a/packages/api-client/src/models/logoutResponseDto.ts
+++ b/packages/api-client/src/models/logoutResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface LogoutResponseDto {

--- a/packages/api-client/src/models/lookupUserResponseDto.ts
+++ b/packages/api-client/src/models/lookupUserResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface LookupUserResponseDto {

--- a/packages/api-client/src/models/paginatedReceivedSharesDto.ts
+++ b/packages/api-client/src/models/paginatedReceivedSharesDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { ReceivedShareResponseDto } from './receivedShareResponseDto';
 

--- a/packages/api-client/src/models/paginatedSentSharesDto.ts
+++ b/packages/api-client/src/models/paginatedSentSharesDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { SentShareResponseDto } from './sentShareResponseDto';
 

--- a/packages/api-client/src/models/pendingRotationResponseDto.ts
+++ b/packages/api-client/src/models/pendingRotationResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { PendingRotationResponseDtoItemType } from './pendingRotationResponseDtoItemType';
 

--- a/packages/api-client/src/models/pendingRotationResponseDtoItemType.ts
+++ b/packages/api-client/src/models/pendingRotationResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type PendingRotationResponseDtoItemType =

--- a/packages/api-client/src/models/publishIpnsDto.ts
+++ b/packages/api-client/src/models/publishIpnsDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface PublishIpnsDto {
@@ -11,6 +11,8 @@ export interface PublishIpnsDto {
   ipnsName: string;
   /** Base64-encoded marshaled IPNS record */
   record: string;
+  /** Base64-encoded raw 32-byte Ed25519 public key for this IPNS name */
+  publicKey?: string;
   /** CID of the encrypted metadata this record points to */
   metadataCid: string;
   /** Hex-encoded ECIES-wrapped Ed25519 private key for TEE republishing (required on first publish) */

--- a/packages/api-client/src/models/publishIpnsEntryDto.ts
+++ b/packages/api-client/src/models/publishIpnsEntryDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { PublishIpnsEntryDtoRecordType } from './publishIpnsEntryDtoRecordType';
 
@@ -12,6 +12,8 @@ export interface PublishIpnsEntryDto {
   ipnsName: string;
   /** Base64-encoded marshaled IPNS record */
   record: string;
+  /** Base64-encoded raw 32-byte Ed25519 public key for this IPNS name */
+  publicKey?: string;
   /** CID of the encrypted metadata this record points to */
   metadataCid: string;
   /** Hex-encoded ECIES-wrapped Ed25519 private key for TEE republishing */

--- a/packages/api-client/src/models/publishIpnsEntryDtoRecordType.ts
+++ b/packages/api-client/src/models/publishIpnsEntryDtoRecordType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/publishIpnsResponseDto.ts
+++ b/packages/api-client/src/models/publishIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface PublishIpnsResponseDto {

--- a/packages/api-client/src/models/quotaResponseDto.ts
+++ b/packages/api-client/src/models/quotaResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface QuotaResponseDto {

--- a/packages/api-client/src/models/receivedShareResponseDto.ts
+++ b/packages/api-client/src/models/receivedShareResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { ReceivedShareResponseDtoItemType } from './receivedShareResponseDtoItemType';
 import type { ReceivedShareResponseDtoPermission } from './receivedShareResponseDtoPermission';

--- a/packages/api-client/src/models/receivedShareResponseDtoItemType.ts
+++ b/packages/api-client/src/models/receivedShareResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type ReceivedShareResponseDtoItemType =

--- a/packages/api-client/src/models/receivedShareResponseDtoPermission.ts
+++ b/packages/api-client/src/models/receivedShareResponseDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/registerCidDto.ts
+++ b/packages/api-client/src/models/registerCidDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface RegisterCidDto {

--- a/packages/api-client/src/models/registerCidResponseDto.ts
+++ b/packages/api-client/src/models/registerCidResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface RegisterCidResponseDto {

--- a/packages/api-client/src/models/resolveIpnsResponseDto.ts
+++ b/packages/api-client/src/models/resolveIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface ResolveIpnsResponseDto {

--- a/packages/api-client/src/models/respondApprovalDto.ts
+++ b/packages/api-client/src/models/respondApprovalDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { RespondApprovalDtoAction } from './respondApprovalDtoAction';
 

--- a/packages/api-client/src/models/respondApprovalDtoAction.ts
+++ b/packages/api-client/src/models/respondApprovalDtoAction.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/sendOtpDto.ts
+++ b/packages/api-client/src/models/sendOtpDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface SendOtpDto {

--- a/packages/api-client/src/models/sendOtpResponseDto.ts
+++ b/packages/api-client/src/models/sendOtpResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface SendOtpResponseDto {

--- a/packages/api-client/src/models/sentShareResponseDto.ts
+++ b/packages/api-client/src/models/sentShareResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { SentShareResponseDtoItemType } from './sentShareResponseDtoItemType';
 import type { SentShareResponseDtoPermission } from './sentShareResponseDtoPermission';

--- a/packages/api-client/src/models/sentShareResponseDtoItemType.ts
+++ b/packages/api-client/src/models/sentShareResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type SentShareResponseDtoItemType =

--- a/packages/api-client/src/models/sentShareResponseDtoPermission.ts
+++ b/packages/api-client/src/models/sentShareResponseDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/setByoStatusDto.ts
+++ b/packages/api-client/src/models/setByoStatusDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface SetByoStatusDto {

--- a/packages/api-client/src/models/setByoStatusResponseDto.ts
+++ b/packages/api-client/src/models/setByoStatusResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface SetByoStatusResponseDto {

--- a/packages/api-client/src/models/shareInvitesControllerListInvitesParams.ts
+++ b/packages/api-client/src/models/shareInvitesControllerListInvitesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type ShareInvitesControllerListInvitesParams = {

--- a/packages/api-client/src/models/shareKeyEntryDto.ts
+++ b/packages/api-client/src/models/shareKeyEntryDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { ShareKeyEntryDtoKeyType } from './shareKeyEntryDtoKeyType';
 

--- a/packages/api-client/src/models/shareKeyEntryDtoKeyType.ts
+++ b/packages/api-client/src/models/shareKeyEntryDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/shareKeyResponseDto.ts
+++ b/packages/api-client/src/models/shareKeyResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { ShareKeyResponseDtoKeyType } from './shareKeyResponseDtoKeyType';
 

--- a/packages/api-client/src/models/shareKeyResponseDtoKeyType.ts
+++ b/packages/api-client/src/models/shareKeyResponseDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type ShareKeyResponseDtoKeyType =

--- a/packages/api-client/src/models/sharesControllerGetReceivedSharesParams.ts
+++ b/packages/api-client/src/models/sharesControllerGetReceivedSharesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type SharesControllerGetReceivedSharesParams = {

--- a/packages/api-client/src/models/sharesControllerGetSentSharesParams.ts
+++ b/packages/api-client/src/models/sharesControllerGetSentSharesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type SharesControllerGetSentSharesParams = {

--- a/packages/api-client/src/models/sharesControllerLookupUserParams.ts
+++ b/packages/api-client/src/models/sharesControllerLookupUserParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export type SharesControllerLookupUserParams = {

--- a/packages/api-client/src/models/teeKeysDto.ts
+++ b/packages/api-client/src/models/teeKeysDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface TeeKeysDto {

--- a/packages/api-client/src/models/testLoginDto.ts
+++ b/packages/api-client/src/models/testLoginDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface TestLoginDto {

--- a/packages/api-client/src/models/testLoginResponseDto.ts
+++ b/packages/api-client/src/models/testLoginResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface TestLoginResponseDto {

--- a/packages/api-client/src/models/tokenResponseDto.ts
+++ b/packages/api-client/src/models/tokenResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface TokenResponseDto {

--- a/packages/api-client/src/models/unlinkMethodDto.ts
+++ b/packages/api-client/src/models/unlinkMethodDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface UnlinkMethodDto {

--- a/packages/api-client/src/models/unlinkMethodResponseDto.ts
+++ b/packages/api-client/src/models/unlinkMethodResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface UnlinkMethodResponseDto {

--- a/packages/api-client/src/models/unpinDto.ts
+++ b/packages/api-client/src/models/unpinDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface UnpinDto {

--- a/packages/api-client/src/models/unpinResponseDto.ts
+++ b/packages/api-client/src/models/unpinResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface UnpinResponseDto {

--- a/packages/api-client/src/models/updateEncryptedKeyDto.ts
+++ b/packages/api-client/src/models/updateEncryptedKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface UpdateEncryptedKeyDto {

--- a/packages/api-client/src/models/updatePermissionDto.ts
+++ b/packages/api-client/src/models/updatePermissionDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { UpdatePermissionDtoPermission } from './updatePermissionDtoPermission';
 

--- a/packages/api-client/src/models/updatePermissionDtoPermission.ts
+++ b/packages/api-client/src/models/updatePermissionDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/uploadResponseDto.ts
+++ b/packages/api-client/src/models/uploadResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface UploadResponseDto {

--- a/packages/api-client/src/models/vaultConfigResponseDto.ts
+++ b/packages/api-client/src/models/vaultConfigResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface VaultConfigResponseDto {

--- a/packages/api-client/src/models/vaultExportDto.ts
+++ b/packages/api-client/src/models/vaultExportDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 export interface VaultExportDto {

--- a/packages/api-client/src/models/vaultResponseDto.ts
+++ b/packages/api-client/src/models/vaultResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { VaultResponseDtoTeeKeys } from './vaultResponseDtoTeeKeys';
 

--- a/packages/api-client/src/models/vaultResponseDtoTeeKeys.ts
+++ b/packages/api-client/src/models/vaultResponseDtoTeeKeys.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { TeeKeysDto } from './teeKeysDto';
 

--- a/packages/api-client/src/models/verifyOtpDto.ts
+++ b/packages/api-client/src/models/verifyOtpDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { VerifyOtpDtoIntent } from './verifyOtpDtoIntent';
 

--- a/packages/api-client/src/models/verifyOtpDtoIntent.ts
+++ b/packages/api-client/src/models/verifyOtpDtoIntent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/api-client/src/models/walletVerifyDto.ts
+++ b/packages/api-client/src/models/walletVerifyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 import type { WalletVerifyDtoIntent } from './walletVerifyDtoIntent';
 

--- a/packages/api-client/src/models/walletVerifyDtoIntent.ts
+++ b/packages/api-client/src/models/walletVerifyDtoIntent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.35.0
+ * OpenAPI spec version: 0.36.1
  */
 
 /**

--- a/packages/crypto/src/__tests__/ed25519.test.ts
+++ b/packages/crypto/src/__tests__/ed25519.test.ts
@@ -5,7 +5,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { generateEd25519Keypair, signEd25519, verifyEd25519 } from '../ed25519';
+import {
+  generateEd25519Keypair,
+  deriveEd25519PublicKey,
+  signEd25519,
+  verifyEd25519,
+} from '../ed25519';
 import {
   ED25519_PUBLIC_KEY_SIZE,
   ED25519_PRIVATE_KEY_SIZE,
@@ -30,6 +35,12 @@ describe('Ed25519 Key Generation', () => {
     expect(keypair1.publicKey).not.toEqual(keypair2.publicKey);
     // Private keys should be different
     expect(keypair1.privateKey).not.toEqual(keypair2.privateKey);
+  });
+
+  it('derives the same public key from a private key seed', () => {
+    const keypair = generateEd25519Keypair();
+
+    expect(deriveEd25519PublicKey(keypair.privateKey)).toEqual(keypair.publicKey);
   });
 });
 

--- a/packages/crypto/src/__tests__/ed25519.test.ts
+++ b/packages/crypto/src/__tests__/ed25519.test.ts
@@ -42,6 +42,15 @@ describe('Ed25519 Key Generation', () => {
 
     expect(deriveEd25519PublicKey(keypair.privateKey)).toEqual(keypair.publicKey);
   });
+
+  it('throws on invalid private key length for public key derivation', () => {
+    expect(() => deriveEd25519PublicKey(new Uint8Array(31))).toThrow(
+      'Invalid private key size for public key derivation'
+    );
+    expect(() => deriveEd25519PublicKey(new Uint8Array(64))).toThrow(
+      'Invalid private key size for public key derivation'
+    );
+  });
 });
 
 describe('Ed25519 Signing', () => {

--- a/packages/crypto/src/ed25519/index.ts
+++ b/packages/crypto/src/ed25519/index.ts
@@ -4,5 +4,5 @@
  * Ed25519 key generation, signing, and verification for IPNS operations.
  */
 
-export { generateEd25519Keypair, type Ed25519Keypair } from './keygen';
+export { generateEd25519Keypair, deriveEd25519PublicKey, type Ed25519Keypair } from './keygen';
 export { signEd25519, verifyEd25519 } from './sign';

--- a/packages/crypto/src/ed25519/keygen.ts
+++ b/packages/crypto/src/ed25519/keygen.ts
@@ -7,6 +7,8 @@
 
 import * as ed from '@noble/ed25519';
 import { sha512 } from '@noble/hashes/sha512';
+import { CryptoError } from '../types';
+import { ED25519_PRIVATE_KEY_SIZE } from '../constants';
 
 // Enable sync methods (required for @noble/ed25519 v2.x)
 // This configures the library to use synchronous SHA-512 hashing
@@ -39,7 +41,17 @@ export function generateEd25519Keypair(): Ed25519Keypair {
 
 /**
  * Derives the Ed25519 public key from a 32-byte private key seed.
+ *
+ * @param privateKey - 32-byte Ed25519 private key seed
+ * @returns 32-byte Ed25519 public key
+ * @throws CryptoError if privateKey is not 32 bytes
  */
 export function deriveEd25519PublicKey(privateKey: Uint8Array): Uint8Array {
+  if (privateKey.length !== ED25519_PRIVATE_KEY_SIZE) {
+    throw new CryptoError(
+      'Invalid private key size for public key derivation',
+      'INVALID_PRIVATE_KEY_SIZE'
+    );
+  }
   return ed.getPublicKey(privateKey);
 }

--- a/packages/crypto/src/ed25519/keygen.ts
+++ b/packages/crypto/src/ed25519/keygen.ts
@@ -36,3 +36,10 @@ export function generateEd25519Keypair(): Ed25519Keypair {
     privateKey,
   };
 }
+
+/**
+ * Derives the Ed25519 public key from a 32-byte private key seed.
+ */
+export function deriveEd25519PublicKey(privateKey: Uint8Array): Uint8Array {
+  return ed.getPublicKey(privateKey);
+}

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -59,7 +59,7 @@ export { encryptAesCtr, decryptAesCtr, decryptAesCtrRange } from './aes';
 export { wrapKey, unwrapKey, reWrapKey } from './ecies';
 
 // Ed25519 signing for IPNS
-export { generateEd25519Keypair, type Ed25519Keypair } from './ed25519';
+export { generateEd25519Keypair, deriveEd25519PublicKey, type Ed25519Keypair } from './ed25519';
 export { signEd25519, verifyEd25519 } from './ed25519/sign';
 
 // IPNS name derivation (kept in crypto as a pure crypto utility)

--- a/packages/crypto/tsup.config.ts
+++ b/packages/crypto/tsup.config.ts
@@ -1,13 +1,22 @@
 import { defineConfig } from 'tsup';
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['cjs', 'esm'],
-  dts: true,
-  clean: true,
-  sourcemap: true,
-  // Bundle all dependencies into the CJS output so CommonJS consumers
-  // (NestJS API, Jest) don't hit ERR_PACKAGE_PATH_NOT_EXPORTED or
-  // "Unexpected token export" from ESM-only deps (@noble/*, @libp2p/*, ipns, multiformats).
-  noExternal: [/.*/],
-});
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs'],
+    clean: true,
+    sourcemap: true,
+    dts: true,
+    // Bundle all dependencies into the CJS output so CommonJS consumers
+    // (NestJS API, Jest) don't hit ERR_PACKAGE_PATH_NOT_EXPORTED or
+    // "Unexpected token export" from ESM-only deps (@noble/*, @libp2p/*, ipns, multiformats).
+    noExternal: [/.*/],
+  },
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    sourcemap: true,
+    dts: true,
+    // ESM output leaves deps external — Vite/browser bundlers handle them natively.
+  },
+]);

--- a/packages/crypto/tsup.config.ts
+++ b/packages/crypto/tsup.config.ts
@@ -6,4 +6,8 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: true,
+  // Bundle ESM-only dependencies into the CJS output so consumers
+  // like the NestJS API (CommonJS) can require('@cipherbox/crypto')
+  // without hitting ERR_PACKAGE_PATH_NOT_EXPORTED errors.
+  noExternal: ['@libp2p/crypto', '@libp2p/peer-id', 'multiformats'],
 });

--- a/packages/crypto/tsup.config.ts
+++ b/packages/crypto/tsup.config.ts
@@ -6,8 +6,8 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: true,
-  // Bundle ESM-only dependencies into the CJS output so consumers
-  // like the NestJS API (CommonJS) can require('@cipherbox/crypto')
-  // without hitting ERR_PACKAGE_PATH_NOT_EXPORTED errors.
-  noExternal: ['@libp2p/crypto', '@libp2p/peer-id', 'multiformats'],
+  // Bundle all dependencies into the CJS output so CommonJS consumers
+  // (NestJS API, Jest) don't hit ERR_PACKAGE_PATH_NOT_EXPORTED or
+  // "Unexpected token export" from ESM-only deps (@noble/*, @libp2p/*, ipns, multiformats).
+  noExternal: [/.*/],
 });

--- a/packages/sdk-core/scripts/verify-filepointer.mjs
+++ b/packages/sdk-core/scripts/verify-filepointer.mjs
@@ -25,14 +25,18 @@ function parseArgs(argv) {
     i += 1;
   }
 
+  if (values.has('secret')) {
+    throw new Error('Do not pass --secret on CLI. Set TEST_SECRET in environment.');
+  }
+
   const apiUrl = values.get('api-url');
-  const secret = values.get('secret') || process.env.TEST_SECRET;
+  const secret = process.env.TEST_SECRET;
   const email = values.get('email');
   const fileName = values.get('file-name');
 
-  if (!apiUrl || !email || !fileName) {
+  if (!apiUrl || !email || !fileName || !secret) {
     throw new Error(
-      'Usage: verify-filepointer.mjs --api-url <url> --email <email> --file-name <name> [--expected-content <text>]'
+      'Usage: verify-filepointer.mjs --api-url <url> --email <email> --file-name <name> [--expected-content <text>] (requires TEST_SECRET env var)'
     );
   }
 

--- a/packages/sdk-core/scripts/verify-filepointer.mjs
+++ b/packages/sdk-core/scripts/verify-filepointer.mjs
@@ -26,13 +26,13 @@ function parseArgs(argv) {
   }
 
   const apiUrl = values.get('api-url');
-  const secret = values.get('secret');
+  const secret = values.get('secret') || process.env.TEST_SECRET;
   const email = values.get('email');
   const fileName = values.get('file-name');
 
-  if (!apiUrl || !secret || !email || !fileName) {
+  if (!apiUrl || !email || !fileName) {
     throw new Error(
-      'Usage: verify-filepointer.mjs --api-url <url> --secret <secret> --email <email> --file-name <name> [--expected-content <text>]'
+      'Usage: verify-filepointer.mjs --api-url <url> --email <email> --file-name <name> [--expected-content <text>]'
     );
   }
 

--- a/packages/sdk-core/src/__tests__/ipns.test.ts
+++ b/packages/sdk-core/src/__tests__/ipns.test.ts
@@ -19,6 +19,7 @@ vi.mock('@cipherbox/core', () => ({
 vi.mock('@cipherbox/crypto', () => ({
   verifyEd25519: vi.fn().mockResolvedValue(true),
   deriveEd25519PublicKey: vi.fn().mockReturnValue(new Uint8Array(32).fill(7)),
+  deriveIpnsName: vi.fn().mockResolvedValue('k51resolve'),
   concatBytes: vi.fn((...args: Uint8Array[]) => {
     const total = args.reduce((sum, a) => sum + a.length, 0);
     const result = new Uint8Array(total);
@@ -137,6 +138,64 @@ describe('IPNS operations', () => {
       vi.mocked(ipnsControllerResolveRecord).mockRejectedValue(new Error('Server error'));
 
       await expect(resolveIpnsRecord('k51error')).rejects.toThrow('Server error');
+    });
+
+    it('verifies signature and pubKey-to-ipnsName binding when signature fields present', async () => {
+      const { ipnsControllerResolveRecord } = await import('@cipherbox/api-client');
+      const { verifyEd25519, deriveIpnsName } = await import('@cipherbox/crypto');
+      vi.mocked(ipnsControllerResolveRecord).mockResolvedValue({
+        success: true,
+        cid: 'QmSignedCid',
+        sequenceNumber: '10',
+        signatureV2: btoa('fake-sig-bytes'),
+        data: btoa('fake-cbor-data'),
+        pubKey: btoa('fake-pubkey-bytes'),
+      });
+      vi.mocked(deriveIpnsName).mockResolvedValue('k51verified');
+
+      const result = await resolveIpnsRecord('k51verified');
+
+      expect(verifyEd25519).toHaveBeenCalled();
+      expect(deriveIpnsName).toHaveBeenCalled();
+      expect(result).not.toBeNull();
+      expect(result!.signatureVerified).toBe(true);
+      expect(result!.cid).toBe('QmSignedCid');
+    });
+
+    it('throws when pubKey does not derive to requested ipnsName', async () => {
+      const { ipnsControllerResolveRecord } = await import('@cipherbox/api-client');
+      const { deriveIpnsName } = await import('@cipherbox/crypto');
+      vi.mocked(ipnsControllerResolveRecord).mockResolvedValue({
+        success: true,
+        cid: 'QmFakedCid',
+        sequenceNumber: '1',
+        signatureV2: btoa('sig'),
+        data: btoa('data'),
+        pubKey: btoa('wrongkey'),
+      });
+      vi.mocked(deriveIpnsName).mockResolvedValue('k51different-name');
+
+      await expect(resolveIpnsRecord('k51requested-name')).rejects.toThrow(
+        'IPNS public key does not match requested name'
+      );
+    });
+
+    it('throws when signature verification fails', async () => {
+      const { ipnsControllerResolveRecord } = await import('@cipherbox/api-client');
+      const { verifyEd25519 } = await import('@cipherbox/crypto');
+      vi.mocked(ipnsControllerResolveRecord).mockResolvedValue({
+        success: true,
+        cid: 'QmTampered',
+        sequenceNumber: '1',
+        signatureV2: btoa('bad-sig'),
+        data: btoa('data'),
+        pubKey: btoa('key'),
+      });
+      vi.mocked(verifyEd25519).mockResolvedValue(false);
+
+      await expect(resolveIpnsRecord('k51tampered')).rejects.toThrow(
+        'IPNS signature verification failed'
+      );
     });
   });
 });

--- a/packages/sdk-core/src/__tests__/ipns.test.ts
+++ b/packages/sdk-core/src/__tests__/ipns.test.ts
@@ -18,6 +18,7 @@ vi.mock('@cipherbox/core', () => ({
 // Mock crypto functions
 vi.mock('@cipherbox/crypto', () => ({
   verifyEd25519: vi.fn().mockResolvedValue(true),
+  deriveEd25519PublicKey: vi.fn().mockReturnValue(new Uint8Array(32).fill(7)),
   concatBytes: vi.fn((...args: Uint8Array[]) => {
     const total = args.reduce((sum, a) => sum + a.length, 0);
     const result = new Uint8Array(total);
@@ -55,6 +56,7 @@ describe('IPNS operations', () => {
         expect.objectContaining({
           ipnsName: 'k51testname',
           metadataCid: 'QmMetaCid',
+          publicKey: btoa(String.fromCharCode(...new Uint8Array(32).fill(7))),
         }),
         undefined
       );
@@ -83,6 +85,7 @@ describe('IPNS operations', () => {
         expect.objectContaining({
           encryptedIpnsPrivateKey: 'aabbccdd',
           keyEpoch: 3,
+          publicKey: btoa(String.fromCharCode(...new Uint8Array(32).fill(7))),
         }),
         undefined
       );

--- a/packages/sdk-core/src/file/index.ts
+++ b/packages/sdk-core/src/file/index.ts
@@ -40,6 +40,7 @@ function uint8ToBase64(bytes: Uint8Array): string {
 export type FileIpnsRecordPayload = {
   ipnsName: string;
   recordBase64: string;
+  publicKey?: string;
   metadataCid: string;
   encryptedIpnsPrivateKey?: string;
   keyEpoch?: number;
@@ -128,6 +129,7 @@ export async function createFileMetadata(params: {
       ipnsRecord: {
         ipnsName: ipnsKeypair.ipnsName,
         recordBase64,
+        publicKey: uint8ToBase64(ipnsKeypair.publicKey),
         metadataCid,
         encryptedIpnsPrivateKey: teeEncryptedIpnsPrivateKey,
         keyEpoch,

--- a/packages/sdk-core/src/folder/index.ts
+++ b/packages/sdk-core/src/folder/index.ts
@@ -9,6 +9,7 @@
 import {
   generateEd25519Keypair,
   deriveIpnsName,
+  deriveEd25519PublicKey,
   generateRandomBytes,
   wrapKey,
   bytesToHex,
@@ -174,6 +175,7 @@ export async function updateFolderMetadataAndPublish(params: {
   children: FolderChild[];
   folderKey: Uint8Array;
   ipnsPrivateKey: Uint8Array;
+  ipnsPublicKey?: Uint8Array;
   ipnsName: string;
   sequenceNumber: bigint;
   ctx: SdkContext;
@@ -204,6 +206,7 @@ export async function updateFolderMetadataAndPublish(params: {
       try {
         await createAndPublishIpnsRecord({
           ipnsPrivateKey: params.ipnsPrivateKey,
+          ipnsPublicKey: params.ipnsPublicKey,
           ipnsName: params.ipnsName,
           metadataCid: cid,
           sequenceNumber: newSeq,
@@ -370,6 +373,7 @@ async function buildFolderIpnsRecord(params: {
   children: FolderChild[];
   folderKey: Uint8Array;
   ipnsPrivateKey: Uint8Array;
+  ipnsPublicKey?: Uint8Array;
   ipnsName: string;
   sequenceNumber: bigint;
   ctx: SdkContext;
@@ -399,12 +403,16 @@ async function buildFolderIpnsRecord(params: {
   );
   const recordBytes = marshalIpnsRecord(record);
   const recordBase64 = uint8ToBase64(recordBytes);
+  const publicKey = uint8ToBase64(
+    params.ipnsPublicKey ?? deriveEd25519PublicKey(params.ipnsPrivateKey)
+  );
 
   return {
     cid,
     record: {
       ipnsName: params.ipnsName,
       recordBase64,
+      publicKey,
       metadataCid: cid,
       encryptedIpnsPrivateKey: params.encryptedIpnsPrivateKey,
       keyEpoch: params.keyEpoch,
@@ -428,6 +436,7 @@ export async function addFileToFolder(params: {
   children: FolderChild[];
   folderKey: Uint8Array;
   ipnsPrivateKey: Uint8Array;
+  ipnsPublicKey?: Uint8Array;
   ipnsName: string;
   sequenceNumber: bigint;
   fileId: string;
@@ -462,6 +471,7 @@ export async function addFileToFolder(params: {
     children,
     folderKey: params.folderKey,
     ipnsPrivateKey: params.ipnsPrivateKey,
+    ipnsPublicKey: params.ipnsPublicKey,
     ipnsName: params.ipnsName,
     sequenceNumber: params.sequenceNumber,
     ctx: params.ctx,
@@ -493,6 +503,7 @@ export async function addFilesToFolder(params: {
   children: FolderChild[];
   folderKey: Uint8Array;
   ipnsPrivateKey: Uint8Array;
+  ipnsPublicKey?: Uint8Array;
   ipnsName: string;
   sequenceNumber: bigint;
   files: Array<{
@@ -536,6 +547,7 @@ export async function addFilesToFolder(params: {
     children,
     folderKey: params.folderKey,
     ipnsPrivateKey: params.ipnsPrivateKey,
+    ipnsPublicKey: params.ipnsPublicKey,
     ipnsName: params.ipnsName,
     sequenceNumber: params.sequenceNumber,
     ctx: params.ctx,

--- a/packages/sdk-core/src/ipns/index.ts
+++ b/packages/sdk-core/src/ipns/index.ts
@@ -28,10 +28,10 @@ import { withPerf } from '../perf';
  * The record is signed locally using the Ed25519 private key, then
  * the backend relays it to the IPFS network via delegated routing.
  *
- * @param params.ipnsPrivateKey - Ed25519 private key (64 bytes in libp2p format)
+ * @param params.ipnsPrivateKey - 32-byte Ed25519 private key seed
  * @param params.ipnsName - IPNS name (k51.../bafzaa... format)
  * @param params.metadataCid - CID of the encrypted metadata blob
- * @param params.sequenceNumber - Current sequence number (will be incremented before publish)
+ * @param params.sequenceNumber - Sequence number for this publish
  * @param params.encryptedIpnsPrivateKey - Hex ECIES-wrapped key for TEE (first publish only)
  * @param params.keyEpoch - TEE key epoch (required with encryptedIpnsPrivateKey)
  * @param params.expectedSequenceNumber - Pre-increment sequence number for conflict detection (folder records only)

--- a/packages/sdk-core/src/ipns/index.ts
+++ b/packages/sdk-core/src/ipns/index.ts
@@ -7,7 +7,7 @@
  */
 
 import { createIpnsRecord, marshalIpnsRecord, IPNS_SIGNATURE_PREFIX } from '@cipherbox/core';
-import { verifyEd25519, concatBytes } from '@cipherbox/crypto';
+import { verifyEd25519, concatBytes, deriveEd25519PublicKey } from '@cipherbox/crypto';
 import {
   ipnsControllerPublishRecord,
   ipnsControllerPublishBatch,
@@ -33,6 +33,7 @@ import { withPerf } from '../perf';
  */
 export async function createAndPublishIpnsRecord(params: {
   ipnsPrivateKey: Uint8Array;
+  ipnsPublicKey?: Uint8Array;
   ipnsName: string;
   metadataCid: string;
   sequenceNumber: bigint;
@@ -53,6 +54,7 @@ export async function createAndPublishIpnsRecord(params: {
 
     // 2. Marshal to bytes for transport
     const recordBytes = marshalIpnsRecord(record);
+    const publicKeyBytes = params.ipnsPublicKey ?? deriveEd25519PublicKey(params.ipnsPrivateKey);
 
     // 3. Base64 encode for API transmission (loop-based to avoid call stack overflow on large records)
     let binary = '';
@@ -60,6 +62,11 @@ export async function createAndPublishIpnsRecord(params: {
       binary += String.fromCharCode(recordBytes[i]);
     }
     const recordBase64 = btoa(binary);
+    binary = '';
+    for (let i = 0; i < publicKeyBytes.length; i++) {
+      binary += String.fromCharCode(publicKeyBytes[i]);
+    }
+    const publicKey = btoa(binary);
 
     // 4. Call backend API to relay to IPFS network
     const apiOptions = params.ctx?.axiosInstance
@@ -69,6 +76,7 @@ export async function createAndPublishIpnsRecord(params: {
       {
         ipnsName: params.ipnsName,
         record: recordBase64,
+        publicKey,
         metadataCid: params.metadataCid,
         encryptedIpnsPrivateKey: params.encryptedIpnsPrivateKey,
         keyEpoch: params.keyEpoch,
@@ -98,6 +106,7 @@ export async function batchPublishIpnsRecords(
   records: Array<{
     ipnsName: string;
     recordBase64: string;
+    publicKey?: string;
     metadataCid: string;
     encryptedIpnsPrivateKey?: string;
     keyEpoch?: number;
@@ -114,6 +123,7 @@ export async function batchPublishIpnsRecords(
         records: records.map((r) => ({
           ipnsName: r.ipnsName,
           record: r.recordBase64,
+          publicKey: r.publicKey,
           metadataCid: r.metadataCid,
           encryptedIpnsPrivateKey: r.encryptedIpnsPrivateKey,
           keyEpoch: r.keyEpoch,

--- a/packages/sdk-core/src/ipns/index.ts
+++ b/packages/sdk-core/src/ipns/index.ts
@@ -7,7 +7,12 @@
  */
 
 import { createIpnsRecord, marshalIpnsRecord, IPNS_SIGNATURE_PREFIX } from '@cipherbox/core';
-import { verifyEd25519, concatBytes, deriveEd25519PublicKey } from '@cipherbox/crypto';
+import {
+  verifyEd25519,
+  concatBytes,
+  deriveEd25519PublicKey,
+  deriveIpnsName,
+} from '@cipherbox/crypto';
 import {
   ipnsControllerPublishRecord,
   ipnsControllerPublishBatch,
@@ -198,6 +203,16 @@ export async function resolveIpnsRecord(
         if (!valid) {
           throw new Error('IPNS signature verification failed - record may be tampered');
         }
+
+        // Verify the returned public key derives to the requested IPNS name
+        const pubKeyBytes = Uint8Array.from(atob(response.pubKey), (c) => c.charCodeAt(0));
+        const derivedName = await deriveIpnsName(pubKeyBytes);
+        if (derivedName !== ipnsName) {
+          throw new Error(
+            'IPNS public key does not match requested name - possible key substitution'
+          );
+        }
+
         signatureVerified = true;
       } else {
         console.warn('IPNS resolve returned without signature data, skipping verification');

--- a/packages/sdk-core/src/vault/index.ts
+++ b/packages/sdk-core/src/vault/index.ts
@@ -37,6 +37,7 @@ export async function publishVaultKeyBlob(params: {
   const { cid } = await addToIpfs(params.ctx, new Uint8Array(v2Blob));
   const result = await createAndPublishIpnsRecord({
     ipnsPrivateKey: vaultKeyKeypair.privateKey,
+    ipnsPublicKey: vaultKeyKeypair.publicKey,
     ipnsName: vaultKeyKeypair.ipnsName,
     metadataCid: cid,
     sequenceNumber: 0n,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@cipherbox/crypto':
+        specifier: workspace:*
+        version: link:../../packages/crypto
       '@nestjs/bullmq':
         specifier: ^11.0.4
         version: 11.0.4(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.12)(bullmq@5.67.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2576,7 +2576,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.91':
     resolution:
@@ -2586,7 +2585,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.91':
     resolution:
@@ -2596,7 +2594,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.91':
     resolution:
@@ -2606,7 +2603,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.91':
     resolution:
@@ -2616,7 +2612,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.91':
     resolution:
@@ -3013,7 +3008,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@opentelemetry/api-logs@0.213.0':
     resolution:
@@ -3441,7 +3435,6 @@ packages:
       }
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.2':
     resolution:
@@ -3450,7 +3443,6 @@ packages:
       }
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.2':
     resolution:
@@ -3459,7 +3451,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.55.2':
     resolution:
@@ -3468,7 +3459,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.2':
     resolution:
@@ -3477,7 +3467,6 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.2':
     resolution:
@@ -3486,7 +3475,6 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.2':
     resolution:
@@ -3495,7 +3483,6 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.2':
     resolution:
@@ -3504,7 +3491,6 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.2':
     resolution:
@@ -3513,7 +3499,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.2':
     resolution:
@@ -3522,7 +3507,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.2':
     resolution:
@@ -3531,7 +3515,6 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.2':
     resolution:
@@ -3540,7 +3523,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.55.2':
     resolution:
@@ -3549,7 +3531,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.2':
     resolution:
@@ -3969,7 +3950,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.10.0':
     resolution:
@@ -3979,7 +3959,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.10.0':
     resolution:
@@ -3989,7 +3968,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.10.0':
     resolution:
@@ -3999,7 +3977,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.10.0':
     resolution:
@@ -4009,7 +3986,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.10.0':
     resolution:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -66,14 +66,14 @@
       "component": "@cipherbox/api",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.36.1"
+      "release-as": "0.37.0"
     },
     "apps/web": {
       "release-type": "node",
       "component": "@cipherbox/web",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.38.0"
+      "release-as": "0.39.0"
     },
     "apps/desktop": {
       "release-type": "node",
@@ -97,27 +97,29 @@
       "release-type": "node",
       "component": "@cipherbox/core",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "0.30.1"
     },
     "packages/crypto": {
       "release-type": "node",
       "component": "@cipherbox/crypto",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "0.31.0"
     },
     "packages/api-client": {
       "release-type": "node",
       "component": "@cipherbox/api-client",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.36.1"
+      "release-as": "0.37.0"
     },
     "packages/sdk-core": {
       "release-type": "node",
       "component": "@cipherbox/sdk-core",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.34.1"
+      "release-as": "0.35.0"
     },
     "packages/sdk": {
       "release-type": "node",
@@ -143,7 +145,7 @@
       "component": "cipherbox-api-client",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.35.1"
+      "release-as": "0.36.0"
     },
     "crates/fuse": {
       "release-type": "rust",

--- a/tests/desktop-e2e/scripts/test-round-trip.ps1
+++ b/tests/desktop-e2e/scripts/test-round-trip.ps1
@@ -76,7 +76,6 @@ function Invoke-FilePointerVerifier {
     $verifierPath = Join-Path $RepoRoot "packages/sdk-core/scripts/verify-filepointer.mjs"
     $output = & node $verifierPath `
         --api-url $ApiUrl `
-        --secret $TestSecret `
         --email $TestEmail `
         --file-name $TestFile `
         --expected-content $TestContent 2>&1 | Out-String

--- a/tests/desktop-e2e/scripts/test-round-trip.ps1
+++ b/tests/desktop-e2e/scripts/test-round-trip.ps1
@@ -74,6 +74,7 @@ Ensure-VerifierRuntime
 
 function Invoke-FilePointerVerifier {
     $verifierPath = Join-Path $RepoRoot "packages/sdk-core/scripts/verify-filepointer.mjs"
+    $env:TEST_SECRET = $TestSecret
     $output = & node $verifierPath `
         --api-url $ApiUrl `
         --email $TestEmail `

--- a/tests/desktop-e2e/scripts/test-round-trip.sh
+++ b/tests/desktop-e2e/scripts/test-round-trip.sh
@@ -52,7 +52,6 @@ ensure_verifier_runtime() {
 run_filepointer_verifier() {
   TEST_SECRET="$SECRET" node "$REPO_ROOT/packages/sdk-core/scripts/verify-filepointer.mjs" \
     --api-url "$API_URL" \
-    --secret "$SECRET" \
     --email "$TEST_EMAIL" \
     --file-name "$TEST_FILE" \
     --expected-content "$TEST_CONTENT"


### PR DESCRIPTION
## Summary

- Store IPNS signed records and Ed25519 public keys in the backend database for verifiable DB-cached resolves
- Add client-side IPNS signature verification with pubKey-to-ipnsName binding on resolve
- Add server-side publicKey-to-ipnsName cryptographic validation on publish
- Add Ed25519 public key derivation function to `@cipherbox/crypto`
- Pass IPNS publicKey through SDK-core file, folder, and vault operations
- Security review with 6 of 8 findings resolved

### Changes by package

**`apps/api`** — New `signed_record` and `public_key` columns on `FolderIpns` entity with migrations. Publish endpoint accepts optional `publicKey`, validates it is 32 bytes and derives to the claimed `ipnsName`. Resolve endpoint returns signature data from DB cache. Protobuf parser extracts signature fields. Republish service passes signed records through.

**`apps/web`** — Web app IPNS service now derives and sends `publicKey` on publish, uses loop-based base64 encoding (fixes call-stack overflow), and verifies pubKey-to-ipnsName binding on resolve.

**`packages/sdk-core`** — `resolveIpnsRecord` verifies Ed25519 signatures and checks pubKey-to-ipnsName binding. `createAndPublishIpnsRecord` sends publicKey. File, folder, and vault operations pass publicKey through.

**`packages/crypto`** — New `deriveEd25519PublicKey` function with input length validation.

**`packages/api-client`** — Regenerated from updated OpenAPI spec (new `publicKey` field on publish DTOs).

## Test plan

- [x] `@cipherbox/crypto` — 143 tests pass (includes Ed25519 keygen/sign/verify)
- [x] `@cipherbox/sdk-core` — 148 tests pass (includes IPNS resolve with signature verification)
- [x] `@cipherbox/api` build succeeds
- [x] `@cipherbox/web` build succeeds
- [x] E2E: publish from web app includes publicKey in API request
- [x] E2E: resolve returns signature data and passes pubKey-to-ipnsName check
- [x] E2E: server rejects publicKey that doesn't derive to ipnsName

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optionally include Ed25519 public keys with IPNS publishes; SDKs expose public-key derivation and publish APIs.
* **Bug Fixes**
  * Safer base64 encoding to avoid call-stack/RangeError.
  * Stronger signature vs. name validation to prevent key substitution.
  * Protobuf parser now enforces buffer bounds.
* **Database**
  * Persist signed IPNS records and Ed25519 public keys; migrations added.
* **Tests**
  * Updated/added tests for key derivation, publish/resolve, parser, and republish flows.
* **Documentation**
  * Added a security review report and deferred-items summary.
* **Tooling**
  * Build/CI and CLI verifier updated to use TEST_SECRET env; packaging config split for CJS/ESM.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->