### PR TITLE
fix(api): include @cipherbox/crypto in API Docker build

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -7,10 +7,12 @@ RUN corepack enable && corepack prepare pnpm@10 --activate
 WORKDIR /app
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/api/package.json apps/api/
+COPY packages/crypto/package.json packages/crypto/
 RUN pnpm install --frozen-lockfile --filter @cipherbox/api...
 COPY apps/api/ apps/api/
+COPY packages/crypto/ packages/crypto/
 COPY tsconfig.base.json ./
-RUN pnpm --filter @cipherbox/api build
+RUN pnpm --filter @cipherbox/crypto build && pnpm --filter @cipherbox/api build
 
 # Create standalone deployment (flat node_modules, no symlinks)
 RUN pnpm --filter @cipherbox/api deploy /deploy --prod --legacy

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -66,14 +66,14 @@
       "component": "@cipherbox/api",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.37.0"
+      "release-as": "0.37.1"
     },
     "apps/web": {
       "release-type": "node",
       "component": "@cipherbox/web",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.39.0"
+      "release-as": "0.40.0"
     },
     "apps/desktop": {
       "release-type": "node",
@@ -84,7 +84,7 @@
         "src-tauri/tauri.conf.json",
         "src-tauri/Cargo.toml"
       ],
-      "release-as": "0.37.0"
+      "release-as": "0.38.0"
     },
     "apps/tee-worker": {
       "release-type": "node",
@@ -112,14 +112,14 @@
       "component": "@cipherbox/api-client",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.37.0"
+      "release-as": "0.37.1"
     },
     "packages/sdk-core": {
       "release-type": "node",
       "component": "@cipherbox/sdk-core",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.35.0"
+      "release-as": "0.35.1"
     },
     "packages/sdk": {
       "release-type": "node",
@@ -152,7 +152,7 @@
       "component": "cipherbox-fuse",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.5.1"
+      "release-as": "0.5.2"
     },
     "crates/sdk": {
       "release-type": "rust",


### PR DESCRIPTION
## Summary
- Add `packages/crypto/` to the API Dockerfile build context and build it before the API
- The API gained `@cipherbox/crypto` as a production dependency in #448, but the Dockerfile wasn't updated to include it, breaking the staging Docker build

## Test plan
- [ ] Merge and trigger staging deploy — verify API Docker image builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker image build updated to include building the crypto component as part of the image compilation, improving build consistency.
  * Release version pins updated for several components (apps and packages/crates) to new patch/minor versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->