### PR TITLE
fix(desktop): detect remote file edits and re-resolve IPNS in FUSE mount

### DIFF
--- a/.planning/debug/fuse-stale-file-after-web-edit.md
+++ b/.planning/debug/fuse-stale-file-after-web-edit.md
@@ -1,0 +1,57 @@
+---
+status: awaiting_human_verify
+trigger: 'After editing a text file in the CipherBox web UI and saving, the FUSE-mounted desktop folder still shows the original file content.'
+created: 2026-04-13T00:00:00Z
+updated: 2026-04-13T00:00:00Z
+---
+
+## Current Focus
+
+hypothesis: CONFIRMED and FIXED - populate_folder now detects modified_at changes and marks files for re-resolution
+test: unit test passes; awaiting human verification with real desktop + web workflow
+expecting: user confirms FUSE mount picks up web UI file edits within ~30s
+next_action: user verifies end-to-end with real FUSE mount
+
+## Symptoms
+
+expected: After saving a file edit in the web UI, opening the same file from the FUSE-mounted folder should show the updated content.
+actual: The FUSE mount still shows the original (pre-edit) version of the file. The web UI does show the updated version.
+errors: No error messages reported.
+reproduction: 1. Upload a text file via the desktop mounted folder. 2. Open the web UI, edit the text file, save. 3. Close editor, reopen to confirm changes persisted to IPFS. 4. Open the file from the mounted folder — original content still displayed.
+started: Current behavior being tested.
+
+## Eliminated
+
+## Evidence
+
+- timestamp: 2026-04-13T00:10:00Z
+  checked: SyncDaemon::poll() in crates/sdk/src/sync.rs
+  found: SyncDaemon detects IPNS sequence changes but only logs them. Does NOT actively invalidate caches or trigger re-population. Comments say "Cache will refresh on next access."
+  implication: The sync daemon is passive - it relies on metadata cache TTL expiry for refresh.
+
+- timestamp: 2026-04-13T00:15:00Z
+  checked: MetadataCache TTL in crates/fuse/src/cache.rs
+  found: Metadata cache has 30s TTL. When stale, readdir fires background refresh via drain_refresh_completions.
+  implication: Folder metadata does get refreshed after 30s, but folder metadata only contains FilePointers (name, fileMetaIpnsName), not the actual file CID.
+
+- timestamp: 2026-04-13T00:20:00Z
+  checked: populate_folder() in crates/fuse/src/inode.rs line 428-444
+  found: When processing FilePointer entries, if an existing inode has file_meta_resolved=true, the code at line 443 keeps the existing InodeKind unchanged. This preserves the old CID, encrypted_file_key, iv, size, etc.
+  implication: ROOT CAUSE - Once a file's per-file IPNS metadata is resolved, it is NEVER re-resolved even when the folder metadata refreshes. The old CID persists indefinitely.
+
+- timestamp: 2026-04-13T00:22:00Z
+  checked: drain_refresh_completions() in crates/fuse/src/lib.rs line 642-727
+  found: After populate_folder, it spawns async resolution ONLY for unresolved file pointers (file_meta_resolved=false). Already-resolved files are skipped.
+  implication: Confirms the gap - the refresh path only resolves NEW files, never re-resolves existing files that may have updated content.
+
+- timestamp: 2026-04-13T00:25:00Z
+  checked: Content cache in crates/fuse/src/cache.rs
+  found: ContentCache is keyed by CID (content-addressed). Even if it expired, the read path would re-fetch the SAME old CID because the inode still points to it.
+  implication: Content cache is not the issue. The issue is upstream - the inode's CID reference is stale.
+
+## Resolution
+
+root_cause: In populate_folder() (inode.rs:443), when a folder metadata refresh occurs, files that were already resolved (file_meta_resolved=true) have their InodeKind preserved as-is. This means the CID, encrypted_file_key, iv, and size from the initial resolution are never updated. When a file is edited via the web UI (which publishes a new file metadata IPNS record with a new CID), the FUSE mount's folder refresh detects the folder change but populate_folder skips re-resolving the file's individual IPNS metadata because it's already marked as resolved. The old CID continues to be served on read.
+fix: In populate_folder() (inode.rs), when processing a FilePointer for an already-resolved file, compare the incoming modified_at timestamp with the existing inode's mtime. If modified_at is newer, mark the file as unresolved (file_meta_resolved=false) with cleared CID, preserving IPNS keys. This causes drain_refresh_completions to spawn a new async IPNS resolution for the file, picking up the new CID. Added a dedicated test (test_populate_folder_resets_resolved_file_on_modified_at_change) verifying the three-phase behavior: initial populate -> resolve -> re-populate with newer modified_at resets to unresolved.
+verification: Unit tests pass (37/37). Awaiting human verification with real FUSE mount.
+files_changed: [crates/fuse/src/inode.rs]

--- a/apps/web/src/hooks/useFileOperations.ts
+++ b/apps/web/src/hooks/useFileOperations.ts
@@ -456,26 +456,22 @@ export function useFileOperations() {
         const store = useFolderStore.getState();
         store.updateFolderChildren(parentId, updatedChildren);
 
-        // 7b. Lazy migration: persist wrapped IPNS key to folder metadata on IPFS
-        if (migratedIpnsPrivateKeyEncrypted) {
-          updateFolderMetadataAndPublish({
-            children: updatedChildren,
-            folderKey: parentFolder.folderKey,
-            ipnsPrivateKey: parentFolder.ipnsPrivateKey,
-            ipnsName: parentFolder.ipnsName,
-            sequenceNumber: parentFolder.sequenceNumber,
-            ctx: getSdkClient().getContext(),
+        // 7b. Republish folder metadata so other clients (e.g. FUSE desktop mount)
+        // see the updated modifiedAt on the FilePointer and re-resolve the file.
+        updateFolderMetadataAndPublish({
+          children: updatedChildren,
+          folderKey: parentFolder.folderKey,
+          ipnsPrivateKey: parentFolder.ipnsPrivateKey,
+          ipnsName: parentFolder.ipnsName,
+          sequenceNumber: parentFolder.sequenceNumber,
+          ctx: getSdkClient().getContext(),
+        })
+          .then(({ newSequenceNumber }) => {
+            useFolderStore.getState().updateFolderSequence(parentId, newSequenceNumber);
           })
-            .then(({ newSequenceNumber }) => {
-              useFolderStore.getState().updateFolderSequence(parentId, newSequenceNumber);
-            })
-            .catch((err) => {
-              logger.warn(
-                '[FileOps] Lazy IPNS key migration: folder re-publish failed, will retry:',
-                err
-              );
-            });
-        }
+          .catch((err) => {
+            logger.warn('[FileOps] Folder metadata re-publish after file edit failed:', err);
+          });
 
         // 8. Re-wrap new file key for share recipients (fire-and-forget)
         (async () => {

--- a/crates/fuse/src/inode.rs
+++ b/crates/fuse/src/inode.rs
@@ -426,12 +426,30 @@ impl InodeTable {
                     let modified = UNIX_EPOCH + Duration::from_millis(file_pointer.modified_at);
 
                     // Check if the existing inode already has resolved metadata
+                    // AND whether the file has been modified since last resolution.
+                    // When a file is edited via another client (e.g. web UI), the
+                    // folder metadata is republished with an updated modified_at
+                    // timestamp for the FilePointer.  If we detect a newer timestamp,
+                    // we mark the file as unresolved so that its per-file IPNS
+                    // record is re-fetched, picking up the new CID.
                     let (_resolved, existing_kind) = if let Some(existing) = existing_ino
                         .and_then(|ino| self.inodes.get(&ino))
                     {
                         match &existing.kind {
                             InodeKind::File { file_meta_resolved: true, .. } => {
-                                (true, Some(existing.kind.clone()))
+                                // Compare the incoming modified_at with the
+                                // existing inode's mtime to detect remote edits.
+                                if modified > existing.attr.mtime {
+                                    log::info!(
+                                        "File '{}': modified_at changed (remote edit detected), marking for re-resolution",
+                                        file_pointer.name
+                                    );
+                                    // Return the existing kind so we can
+                                    // preserve keys but reset resolved flag
+                                    (true, None)
+                                } else {
+                                    (true, Some(existing.kind.clone()))
+                                }
                             }
                             _ => (false, None),
                         }
@@ -439,9 +457,41 @@ impl InodeTable {
                         (false, None)
                     };
 
-                    // If already resolved from a previous population cycle, keep existing data
+                    // If already resolved and not modified, keep existing data.
+                    // If resolved but modified_at changed, create a new unresolved
+                    // kind that preserves the IPNS keys from the existing inode.
                     let kind = if let Some(existing_kind) = existing_kind {
                         existing_kind
+                    } else if _resolved {
+                        // File was resolved but modified_at changed -- keep IPNS
+                        // keys from existing inode but mark as unresolved.
+                        let existing = existing_ino
+                            .and_then(|ino| self.inodes.get(&ino));
+                        let (prev_ipns_key, prev_ipns_key_enc_hex, prev_ipns_name) = match existing.map(|e| &e.kind) {
+                            Some(InodeKind::File {
+                                file_ipns_private_key,
+                                file_ipns_key_encrypted_hex,
+                                file_meta_ipns_name,
+                                ..
+                            }) => (
+                                file_ipns_private_key.clone(),
+                                file_ipns_key_encrypted_hex.clone(),
+                                file_meta_ipns_name.clone(),
+                            ),
+                            _ => (None, None, Some(file_pointer.file_meta_ipns_name.clone())),
+                        };
+                        InodeKind::File {
+                            cid: String::new(),
+                            encrypted_file_key: String::new(),
+                            iv: String::new(),
+                            size: 0,
+                            encryption_mode: "GCM".to_string(),
+                            file_meta_ipns_name: prev_ipns_name,
+                            file_meta_resolved: false,
+                            file_ipns_private_key: prev_ipns_key,
+                            file_ipns_key_encrypted_hex: prev_ipns_key_enc_hex,
+                            versions: None,
+                        }
                     } else {
                         // Decrypt file IPNS private key from FilePointer if available,
                         // falling back to HKDF derivation for legacy files only.
@@ -929,6 +979,96 @@ mod tests {
                 assert!(!file_meta_resolved, "FilePointer should not be resolved yet");
                 assert!(file_ipns_key_encrypted_hex.is_none(), "Legacy FilePointer should have no cached encrypted hex");
                 assert!(file_ipns_private_key.is_none(), "Legacy FilePointer with zeroed key should have no derived private key");
+            }
+            _ => panic!("Expected File kind"),
+        }
+    }
+
+    #[test]
+    fn test_populate_folder_resets_resolved_file_on_modified_at_change() {
+        let mut table = InodeTable::new();
+
+        // Initial population with a FilePointer
+        let metadata_v1 = FolderMetadata {
+            version: "v2".to_string(),
+            children: vec![
+                FolderChild::File(cipherbox_core::folder::FilePointer {
+                    id: "file-1".to_string(),
+                    name: "hello.txt".to_string(),
+                    file_meta_ipns_name: "k51qzi5uqu5dljtg5upm7x7ugan9lql3ewyknv4r4mhhkwzn8n7cnbd1unfwgx".to_string(),
+                    ipns_private_key_encrypted: None,
+                    created_at: 1700000000000,
+                    modified_at: 1700000000000,
+                }),
+            ],
+        };
+
+        let private_key = vec![0u8; 32];
+        let public_key = vec![0u8; 33];
+        table.populate_folder(ROOT_INO, &metadata_v1, &private_key, &public_key, false).unwrap();
+
+        let child_ino = table.get(ROOT_INO).unwrap().children.as_ref().unwrap()[0];
+
+        // Simulate resolution: mark file as resolved with a CID
+        table.resolve_file_pointer(
+            child_ino,
+            "bafyOLDcid".to_string(),
+            "enckey".to_string(),
+            "iv123".to_string(),
+            42,
+            "GCM".to_string(),
+            None,
+        );
+
+        // Verify it's resolved
+        let child = table.get(child_ino).unwrap();
+        match &child.kind {
+            InodeKind::File { file_meta_resolved, cid, .. } => {
+                assert!(file_meta_resolved);
+                assert_eq!(cid, "bafyOLDcid");
+            }
+            _ => panic!("Expected File kind"),
+        }
+
+        // Now re-populate with SAME modified_at -- should keep existing resolved data
+        table.populate_folder(ROOT_INO, &metadata_v1, &private_key, &public_key, true).unwrap();
+
+        let child = table.get(child_ino).unwrap();
+        match &child.kind {
+            InodeKind::File { file_meta_resolved, cid, .. } => {
+                assert!(file_meta_resolved, "File should remain resolved when modified_at unchanged");
+                assert_eq!(cid, "bafyOLDcid", "CID should be unchanged");
+            }
+            _ => panic!("Expected File kind"),
+        }
+
+        // Now re-populate with NEWER modified_at -- should reset to unresolved
+        let metadata_v2 = FolderMetadata {
+            version: "v2".to_string(),
+            children: vec![
+                FolderChild::File(cipherbox_core::folder::FilePointer {
+                    id: "file-1".to_string(),
+                    name: "hello.txt".to_string(),
+                    file_meta_ipns_name: "k51qzi5uqu5dljtg5upm7x7ugan9lql3ewyknv4r4mhhkwzn8n7cnbd1unfwgx".to_string(),
+                    ipns_private_key_encrypted: None,
+                    created_at: 1700000000000,
+                    modified_at: 1700001000000, // 1000s later
+                }),
+            ],
+        };
+
+        table.populate_folder(ROOT_INO, &metadata_v2, &private_key, &public_key, true).unwrap();
+
+        let child = table.get(child_ino).unwrap();
+        match &child.kind {
+            InodeKind::File { file_meta_resolved, cid, file_meta_ipns_name, .. } => {
+                assert!(!file_meta_resolved, "File should be unresolved after modified_at change");
+                assert!(cid.is_empty(), "CID should be cleared for re-resolution");
+                assert_eq!(
+                    file_meta_ipns_name.as_deref(),
+                    Some("k51qzi5uqu5dljtg5upm7x7ugan9lql3ewyknv4r4mhhkwzn8n7cnbd1unfwgx"),
+                    "IPNS name should be preserved for re-resolution"
+                );
             }
             _ => panic!("Expected File kind"),
         }

--- a/crates/fuse/src/inode.rs
+++ b/crates/fuse/src/inode.rs
@@ -432,7 +432,7 @@ impl InodeTable {
                     // timestamp for the FilePointer.  If we detect a newer timestamp,
                     // we mark the file as unresolved so that its per-file IPNS
                     // record is re-fetched, picking up the new CID.
-                    let (_resolved, existing_kind) = if let Some(existing) = existing_ino
+                    let (was_resolved, existing_kind) = if let Some(existing) = existing_ino
                         .and_then(|ino| self.inodes.get(&ino))
                     {
                         match &existing.kind {
@@ -444,8 +444,11 @@ impl InodeTable {
                                         "File '{}': modified_at changed (remote edit detected), marking for re-resolution",
                                         file_pointer.name
                                     );
-                                    // Return the existing kind so we can
-                                    // preserve keys but reset resolved flag
+                                    // Do not return the existing kind here.
+                                    // Instead, signal that we had a resolved inode
+                                    // and force the later code to rebuild an
+                                    // unresolved file kind after re-looking up the
+                                    // existing inode so its IPNS keys can be preserved.
                                     (true, None)
                                 } else {
                                     (true, Some(existing.kind.clone()))
@@ -462,23 +465,29 @@ impl InodeTable {
                     // kind that preserves the IPNS keys from the existing inode.
                     let kind = if let Some(existing_kind) = existing_kind {
                         existing_kind
-                    } else if _resolved {
+                    } else if was_resolved {
                         // File was resolved but modified_at changed -- keep IPNS
-                        // keys from existing inode but mark as unresolved.
+                        // keys from existing inode but mark as unresolved, unless
+                        // the FilePointer identity (IPNS name) changed, which
+                        // means this is a different file reusing the same name.
                         let existing = existing_ino
                             .and_then(|ino| self.inodes.get(&ino));
-                        let (prev_ipns_key, prev_ipns_key_enc_hex, prev_ipns_name) = match existing.map(|e| &e.kind) {
+                        let (prev_ipns_key, prev_ipns_key_enc_hex, prev_ipns_name, same_pointer) = match existing.map(|e| &e.kind) {
                             Some(InodeKind::File {
                                 file_ipns_private_key,
                                 file_ipns_key_encrypted_hex,
                                 file_meta_ipns_name,
                                 ..
-                            }) => (
-                                file_ipns_private_key.clone(),
-                                file_ipns_key_encrypted_hex.clone(),
-                                file_meta_ipns_name.clone(),
-                            ),
-                            _ => (None, None, Some(file_pointer.file_meta_ipns_name.clone())),
+                            }) => {
+                                let same = file_meta_ipns_name.as_deref() == Some(file_pointer.file_meta_ipns_name.as_str());
+                                (
+                                    file_ipns_private_key.clone(),
+                                    file_ipns_key_encrypted_hex.clone(),
+                                    file_meta_ipns_name.clone(),
+                                    same,
+                                )
+                            }
+                            _ => (None, None, None, false),
                         };
                         InodeKind::File {
                             cid: String::new(),
@@ -486,10 +495,18 @@ impl InodeTable {
                             iv: String::new(),
                             size: 0,
                             encryption_mode: "GCM".to_string(),
-                            file_meta_ipns_name: prev_ipns_name,
+                            file_meta_ipns_name: if same_pointer {
+                                prev_ipns_name.or(Some(file_pointer.file_meta_ipns_name.clone()))
+                            } else {
+                                Some(file_pointer.file_meta_ipns_name.clone())
+                            },
                             file_meta_resolved: false,
-                            file_ipns_private_key: prev_ipns_key,
-                            file_ipns_key_encrypted_hex: prev_ipns_key_enc_hex,
+                            file_ipns_private_key: if same_pointer { prev_ipns_key } else { None },
+                            file_ipns_key_encrypted_hex: if same_pointer {
+                                prev_ipns_key_enc_hex
+                            } else {
+                                file_pointer.ipns_private_key_encrypted.clone()
+                            },
                             versions: None,
                         }
                     } else {
@@ -988,6 +1005,8 @@ mod tests {
     fn test_populate_folder_resets_resolved_file_on_modified_at_change() {
         let mut table = InodeTable::new();
 
+        let ipns_name = "k51qzi5uqu5dljtg5upm7x7ugan9lql3ewyknv4r4mhhkwzn8n7cnbd1unfwgx";
+
         // Initial population with a FilePointer
         let metadata_v1 = FolderMetadata {
             version: "v2".to_string(),
@@ -995,7 +1014,7 @@ mod tests {
                 FolderChild::File(cipherbox_core::folder::FilePointer {
                     id: "file-1".to_string(),
                     name: "hello.txt".to_string(),
-                    file_meta_ipns_name: "k51qzi5uqu5dljtg5upm7x7ugan9lql3ewyknv4r4mhhkwzn8n7cnbd1unfwgx".to_string(),
+                    file_meta_ipns_name: ipns_name.to_string(),
                     ipns_private_key_encrypted: None,
                     created_at: 1700000000000,
                     modified_at: 1700000000000,
@@ -1020,12 +1039,27 @@ mod tests {
             None,
         );
 
-        // Verify it's resolved
+        // Pre-populate IPNS key material on the resolved inode so we can
+        // verify it is preserved (or cleared) after re-population.
+        if let Some(inode) = table.inodes.get_mut(&child_ino) {
+            if let InodeKind::File {
+                ref mut file_ipns_private_key,
+                ref mut file_ipns_key_encrypted_hex,
+                ..
+            } = inode.kind {
+                *file_ipns_private_key = Some(Zeroizing::new(vec![1u8; 32]));
+                *file_ipns_key_encrypted_hex = Some("abcdef1234".to_string());
+            }
+        }
+
+        // Verify it's resolved with keys
         let child = table.get(child_ino).unwrap();
         match &child.kind {
-            InodeKind::File { file_meta_resolved, cid, .. } => {
+            InodeKind::File { file_meta_resolved, cid, file_ipns_private_key, file_ipns_key_encrypted_hex, .. } => {
                 assert!(file_meta_resolved);
                 assert_eq!(cid, "bafyOLDcid");
+                assert!(file_ipns_private_key.is_some(), "IPNS private key should be set");
+                assert_eq!(file_ipns_key_encrypted_hex.as_deref(), Some("abcdef1234"));
             }
             _ => panic!("Expected File kind"),
         }
@@ -1042,14 +1076,15 @@ mod tests {
             _ => panic!("Expected File kind"),
         }
 
-        // Now re-populate with NEWER modified_at -- should reset to unresolved
+        // Now re-populate with NEWER modified_at (same IPNS name) -- should reset
+        // to unresolved but preserve IPNS keys since it's the same file pointer.
         let metadata_v2 = FolderMetadata {
             version: "v2".to_string(),
             children: vec![
                 FolderChild::File(cipherbox_core::folder::FilePointer {
                     id: "file-1".to_string(),
                     name: "hello.txt".to_string(),
-                    file_meta_ipns_name: "k51qzi5uqu5dljtg5upm7x7ugan9lql3ewyknv4r4mhhkwzn8n7cnbd1unfwgx".to_string(),
+                    file_meta_ipns_name: ipns_name.to_string(),
                     ipns_private_key_encrypted: None,
                     created_at: 1700000000000,
                     modified_at: 1700001000000, // 1000s later
@@ -1061,13 +1096,73 @@ mod tests {
 
         let child = table.get(child_ino).unwrap();
         match &child.kind {
-            InodeKind::File { file_meta_resolved, cid, file_meta_ipns_name, .. } => {
+            InodeKind::File {
+                file_meta_resolved, cid, file_meta_ipns_name,
+                file_ipns_private_key, file_ipns_key_encrypted_hex, ..
+            } => {
                 assert!(!file_meta_resolved, "File should be unresolved after modified_at change");
                 assert!(cid.is_empty(), "CID should be cleared for re-resolution");
                 assert_eq!(
                     file_meta_ipns_name.as_deref(),
-                    Some("k51qzi5uqu5dljtg5upm7x7ugan9lql3ewyknv4r4mhhkwzn8n7cnbd1unfwgx"),
+                    Some(ipns_name),
                     "IPNS name should be preserved for re-resolution"
+                );
+                assert!(file_ipns_private_key.is_some(), "IPNS private key should be preserved for same pointer");
+                assert_eq!(
+                    file_ipns_key_encrypted_hex.as_deref(), Some("abcdef1234"),
+                    "IPNS encrypted key hex should be preserved for same pointer"
+                );
+            }
+            _ => panic!("Expected File kind"),
+        }
+
+        // Now simulate a file replacement: same name but different IPNS name.
+        // IPNS keys should be cleared since this is a different file.
+        let new_ipns_name = "k51qzi5uqu5dREPLACEDfileDIFFERENTipnsNAMEabcdef123456789";
+        let metadata_v3 = FolderMetadata {
+            version: "v2".to_string(),
+            children: vec![
+                FolderChild::File(cipherbox_core::folder::FilePointer {
+                    id: "file-2".to_string(),
+                    name: "hello.txt".to_string(),
+                    file_meta_ipns_name: new_ipns_name.to_string(),
+                    ipns_private_key_encrypted: Some("newencryptedkey".to_string()),
+                    created_at: 1700000000000,
+                    modified_at: 1700002000000, // even later
+                }),
+            ],
+        };
+
+        // First resolve the inode again so we enter the was_resolved path
+        table.resolve_file_pointer(
+            child_ino,
+            "bafyRESOLVED".to_string(),
+            "enckey2".to_string(),
+            "iv456".to_string(),
+            99,
+            "GCM".to_string(),
+            None,
+        );
+
+        table.populate_folder(ROOT_INO, &metadata_v3, &private_key, &public_key, true).unwrap();
+
+        let child = table.get(child_ino).unwrap();
+        match &child.kind {
+            InodeKind::File {
+                file_meta_resolved, file_meta_ipns_name,
+                file_ipns_private_key, file_ipns_key_encrypted_hex, ..
+            } => {
+                assert!(!file_meta_resolved, "File should be unresolved after pointer replacement");
+                assert_eq!(
+                    file_meta_ipns_name.as_deref(),
+                    Some(new_ipns_name),
+                    "IPNS name should be updated to new pointer's name"
+                );
+                assert!(file_ipns_private_key.is_none(), "IPNS private key should be cleared for different pointer");
+                assert_eq!(
+                    file_ipns_key_encrypted_hex.as_deref(),
+                    Some("newencryptedkey"),
+                    "IPNS encrypted key should come from new FilePointer"
                 );
             }
             _ => panic!("Expected File kind"),

--- a/crates/fuse/src/inode.rs
+++ b/crates/fuse/src/inode.rs
@@ -439,7 +439,11 @@ impl InodeTable {
                             InodeKind::File { file_meta_resolved: true, .. } => {
                                 // Compare the incoming modified_at with the
                                 // existing inode's mtime to detect remote edits.
-                                if modified > existing.attr.mtime {
+                                // Use != rather than > to handle clock skew
+                                // between clients (a remote edit from a client
+                                // with a behind clock could produce a smaller
+                                // modified_at).
+                                if modified != existing.attr.mtime {
                                     log::info!(
                                         "File '{}': modified_at changed (remote edit detected), marking for re-resolution",
                                         file_pointer.name

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -2161,7 +2161,7 @@
   "info": {
     "title": "CipherBox API",
     "description": "Zero-knowledge encrypted cloud storage API",
-    "version": "0.36.1",
+    "version": "0.37.1",
     "contact": {}
   },
   "tags": [

--- a/packages/api-client/src/generated/auth/auth.ts
+++ b/packages/api-client/src/generated/auth/auth.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type {
   AuthMethodResponseDto,

--- a/packages/api-client/src/generated/device-approval/device-approval.ts
+++ b/packages/api-client/src/generated/device-approval/device-approval.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type {
   CreateApprovalDto,

--- a/packages/api-client/src/generated/health/health.ts
+++ b/packages/api-client/src/generated/health/health.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { HealthControllerCheck200 } from '../../models';
 

--- a/packages/api-client/src/generated/identity/identity.ts
+++ b/packages/api-client/src/generated/identity/identity.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type {
   GoogleLoginDto,

--- a/packages/api-client/src/generated/invites/invites.ts
+++ b/packages/api-client/src/generated/invites/invites.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type {
   ClaimInviteDto,

--- a/packages/api-client/src/generated/ipfs/ipfs.ts
+++ b/packages/api-client/src/generated/ipfs/ipfs.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type {
   IpfsControllerUploadBody,

--- a/packages/api-client/src/generated/ipns/ipns.ts
+++ b/packages/api-client/src/generated/ipns/ipns.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type {
   BatchPublishIpnsDto,

--- a/packages/api-client/src/generated/root/root.ts
+++ b/packages/api-client/src/generated/root/root.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import { customInstance } from '../../instance';
 

--- a/packages/api-client/src/generated/share-invites/share-invites.ts
+++ b/packages/api-client/src/generated/share-invites/share-invites.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type {
   CreateInviteDto,

--- a/packages/api-client/src/generated/shares/shares.ts
+++ b/packages/api-client/src/generated/shares/shares.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type {
   AddShareKeysDto,

--- a/packages/api-client/src/generated/tee/tee.ts
+++ b/packages/api-client/src/generated/tee/tee.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { ConnectionTestRequestDto, ConnectionTestResponseDto } from '../../models';
 

--- a/packages/api-client/src/generated/vault/vault.ts
+++ b/packages/api-client/src/generated/vault/vault.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type {
   InitVaultDto,

--- a/packages/api-client/src/models/addShareKeysDto.ts
+++ b/packages/api-client/src/models/addShareKeysDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { ShareKeyEntryDto } from './shareKeyEntryDto';
 

--- a/packages/api-client/src/models/authMethodResponseDto.ts
+++ b/packages/api-client/src/models/authMethodResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { AuthMethodResponseDtoType } from './authMethodResponseDtoType';
 

--- a/packages/api-client/src/models/authMethodResponseDtoType.ts
+++ b/packages/api-client/src/models/authMethodResponseDtoType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type AuthMethodResponseDtoType =

--- a/packages/api-client/src/models/batchPublishIpnsDto.ts
+++ b/packages/api-client/src/models/batchPublishIpnsDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { PublishIpnsEntryDto } from './publishIpnsEntryDto';
 

--- a/packages/api-client/src/models/batchPublishIpnsResponseDto.ts
+++ b/packages/api-client/src/models/batchPublishIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { PublishIpnsResponseDto } from './publishIpnsResponseDto';
 

--- a/packages/api-client/src/models/batchUnenrollIpnsDto.ts
+++ b/packages/api-client/src/models/batchUnenrollIpnsDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface BatchUnenrollIpnsDto {

--- a/packages/api-client/src/models/batchUnenrollIpnsResponseDto.ts
+++ b/packages/api-client/src/models/batchUnenrollIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface BatchUnenrollIpnsResponseDto {

--- a/packages/api-client/src/models/childKeyDto.ts
+++ b/packages/api-client/src/models/childKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { ChildKeyDtoKeyType } from './childKeyDtoKeyType';
 

--- a/packages/api-client/src/models/childKeyDtoKeyType.ts
+++ b/packages/api-client/src/models/childKeyDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/claimChildKeyDto.ts
+++ b/packages/api-client/src/models/claimChildKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { ClaimChildKeyDtoKeyType } from './claimChildKeyDtoKeyType';
 

--- a/packages/api-client/src/models/claimChildKeyDtoKeyType.ts
+++ b/packages/api-client/src/models/claimChildKeyDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/claimInviteDto.ts
+++ b/packages/api-client/src/models/claimInviteDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { ClaimChildKeyDto } from './claimChildKeyDto';
 

--- a/packages/api-client/src/models/claimInviteResponseDto.ts
+++ b/packages/api-client/src/models/claimInviteResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface ClaimInviteResponseDto {

--- a/packages/api-client/src/models/connectionTestRequestDto.ts
+++ b/packages/api-client/src/models/connectionTestRequestDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface ConnectionTestRequestDto {

--- a/packages/api-client/src/models/connectionTestResponseDto.ts
+++ b/packages/api-client/src/models/connectionTestResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { ConnectionTestResponseDtoProtocol } from './connectionTestResponseDtoProtocol';
 

--- a/packages/api-client/src/models/connectionTestResponseDtoProtocol.ts
+++ b/packages/api-client/src/models/connectionTestResponseDtoProtocol.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/createApprovalDto.ts
+++ b/packages/api-client/src/models/createApprovalDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface CreateApprovalDto {

--- a/packages/api-client/src/models/createInviteDto.ts
+++ b/packages/api-client/src/models/createInviteDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { CreateInviteDtoItemType } from './createInviteDtoItemType';
 import type { InviteChildKeyDto } from './inviteChildKeyDto';

--- a/packages/api-client/src/models/createInviteDtoItemType.ts
+++ b/packages/api-client/src/models/createInviteDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/createShareDto.ts
+++ b/packages/api-client/src/models/createShareDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { CreateShareDtoItemType } from './createShareDtoItemType';
 import type { CreateShareDtoPermission } from './createShareDtoPermission';

--- a/packages/api-client/src/models/createShareDtoItemType.ts
+++ b/packages/api-client/src/models/createShareDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/createShareDtoPermission.ts
+++ b/packages/api-client/src/models/createShareDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/createShareResponseDto.ts
+++ b/packages/api-client/src/models/createShareResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { CreateShareResponseDtoItemType } from './createShareResponseDtoItemType';
 import type { CreateShareResponseDtoPermission } from './createShareResponseDtoPermission';

--- a/packages/api-client/src/models/createShareResponseDtoItemType.ts
+++ b/packages/api-client/src/models/createShareResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type CreateShareResponseDtoItemType =

--- a/packages/api-client/src/models/createShareResponseDtoPermission.ts
+++ b/packages/api-client/src/models/createShareResponseDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/deleteAccountDto.ts
+++ b/packages/api-client/src/models/deleteAccountDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface DeleteAccountDto {

--- a/packages/api-client/src/models/deleteAccountResponseDto.ts
+++ b/packages/api-client/src/models/deleteAccountResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface DeleteAccountResponseDto {

--- a/packages/api-client/src/models/desktopRefreshDto.ts
+++ b/packages/api-client/src/models/desktopRefreshDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface DesktopRefreshDto {

--- a/packages/api-client/src/models/deviceApprovalControllerCreateRequest201.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerCreateRequest201.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type DeviceApprovalControllerCreateRequest201 = {

--- a/packages/api-client/src/models/deviceApprovalControllerGetPending200Item.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerGetPending200Item.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type DeviceApprovalControllerGetPending200Item = {

--- a/packages/api-client/src/models/deviceApprovalControllerGetStatus200.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerGetStatus200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { DeviceApprovalControllerGetStatus200Status } from './deviceApprovalControllerGetStatus200Status';
 

--- a/packages/api-client/src/models/deviceApprovalControllerGetStatus200Status.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerGetStatus200Status.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type DeviceApprovalControllerGetStatus200Status =

--- a/packages/api-client/src/models/googleLoginDto.ts
+++ b/packages/api-client/src/models/googleLoginDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { GoogleLoginDtoIntent } from './googleLoginDtoIntent';
 

--- a/packages/api-client/src/models/googleLoginDtoIntent.ts
+++ b/packages/api-client/src/models/googleLoginDtoIntent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/healthControllerCheck200.ts
+++ b/packages/api-client/src/models/healthControllerCheck200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { HealthControllerCheck200Info } from './healthControllerCheck200Info';
 import type { HealthControllerCheck200Error } from './healthControllerCheck200Error';

--- a/packages/api-client/src/models/healthControllerCheck200Details.ts
+++ b/packages/api-client/src/models/healthControllerCheck200Details.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { HealthControllerCheck200DetailsDatabase } from './healthControllerCheck200DetailsDatabase';
 

--- a/packages/api-client/src/models/healthControllerCheck200DetailsDatabase.ts
+++ b/packages/api-client/src/models/healthControllerCheck200DetailsDatabase.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type HealthControllerCheck200DetailsDatabase = {

--- a/packages/api-client/src/models/healthControllerCheck200Error.ts
+++ b/packages/api-client/src/models/healthControllerCheck200Error.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type HealthControllerCheck200Error = { [key: string]: unknown };

--- a/packages/api-client/src/models/healthControllerCheck200Info.ts
+++ b/packages/api-client/src/models/healthControllerCheck200Info.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { HealthControllerCheck200InfoDatabase } from './healthControllerCheck200InfoDatabase';
 

--- a/packages/api-client/src/models/healthControllerCheck200InfoDatabase.ts
+++ b/packages/api-client/src/models/healthControllerCheck200InfoDatabase.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type HealthControllerCheck200InfoDatabase = {

--- a/packages/api-client/src/models/identityControllerGetJwks200.ts
+++ b/packages/api-client/src/models/identityControllerGetJwks200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { IdentityControllerGetJwks200KeysItem } from './identityControllerGetJwks200KeysItem';
 

--- a/packages/api-client/src/models/identityControllerGetJwks200KeysItem.ts
+++ b/packages/api-client/src/models/identityControllerGetJwks200KeysItem.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type IdentityControllerGetJwks200KeysItem = { [key: string]: unknown };

--- a/packages/api-client/src/models/identityControllerGetWalletNonce200.ts
+++ b/packages/api-client/src/models/identityControllerGetWalletNonce200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type IdentityControllerGetWalletNonce200 = {

--- a/packages/api-client/src/models/identityTokenResponseDto.ts
+++ b/packages/api-client/src/models/identityTokenResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface IdentityTokenResponseDto {

--- a/packages/api-client/src/models/index.ts
+++ b/packages/api-client/src/models/index.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export * from './addShareKeysDto';

--- a/packages/api-client/src/models/initVaultDto.ts
+++ b/packages/api-client/src/models/initVaultDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface InitVaultDto {

--- a/packages/api-client/src/models/inviteChildKeyDto.ts
+++ b/packages/api-client/src/models/inviteChildKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { InviteChildKeyDtoKeyType } from './inviteChildKeyDtoKeyType';
 

--- a/packages/api-client/src/models/inviteChildKeyDtoKeyType.ts
+++ b/packages/api-client/src/models/inviteChildKeyDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/inviteDataResponseDto.ts
+++ b/packages/api-client/src/models/inviteDataResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { InviteDataResponseDtoStatus } from './inviteDataResponseDtoStatus';
 import type { InviteChildKeyDto } from './inviteChildKeyDto';

--- a/packages/api-client/src/models/inviteDataResponseDtoItemType.ts
+++ b/packages/api-client/src/models/inviteDataResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type InviteDataResponseDtoItemType =

--- a/packages/api-client/src/models/inviteDataResponseDtoStatus.ts
+++ b/packages/api-client/src/models/inviteDataResponseDtoStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/inviteResponseDto.ts
+++ b/packages/api-client/src/models/inviteResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { InviteResponseDtoItemType } from './inviteResponseDtoItemType';
 import type { InviteResponseDtoStatus } from './inviteResponseDtoStatus';

--- a/packages/api-client/src/models/inviteResponseDtoItemType.ts
+++ b/packages/api-client/src/models/inviteResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type InviteResponseDtoItemType =

--- a/packages/api-client/src/models/inviteResponseDtoStatus.ts
+++ b/packages/api-client/src/models/inviteResponseDtoStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type InviteResponseDtoStatus =

--- a/packages/api-client/src/models/inviteStatusResponseDto.ts
+++ b/packages/api-client/src/models/inviteStatusResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { InviteStatusResponseDtoStatus } from './inviteStatusResponseDtoStatus';
 

--- a/packages/api-client/src/models/inviteStatusResponseDtoStatus.ts
+++ b/packages/api-client/src/models/inviteStatusResponseDtoStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/ipfsControllerUploadBody.ts
+++ b/packages/api-client/src/models/ipfsControllerUploadBody.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type IpfsControllerUploadBody = {

--- a/packages/api-client/src/models/ipnsControllerResolveRecordParams.ts
+++ b/packages/api-client/src/models/ipnsControllerResolveRecordParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type IpnsControllerResolveRecordParams = {

--- a/packages/api-client/src/models/linkMethodDto.ts
+++ b/packages/api-client/src/models/linkMethodDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { LinkMethodDtoLoginType } from './linkMethodDtoLoginType';
 

--- a/packages/api-client/src/models/linkMethodDtoLoginType.ts
+++ b/packages/api-client/src/models/linkMethodDtoLoginType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/loginDto.ts
+++ b/packages/api-client/src/models/loginDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { LoginDtoLoginType } from './loginDtoLoginType';
 

--- a/packages/api-client/src/models/loginDtoLoginType.ts
+++ b/packages/api-client/src/models/loginDtoLoginType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/loginResponseDto.ts
+++ b/packages/api-client/src/models/loginResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface LoginResponseDto {

--- a/packages/api-client/src/models/logoutResponseDto.ts
+++ b/packages/api-client/src/models/logoutResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface LogoutResponseDto {

--- a/packages/api-client/src/models/lookupUserResponseDto.ts
+++ b/packages/api-client/src/models/lookupUserResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface LookupUserResponseDto {

--- a/packages/api-client/src/models/paginatedReceivedSharesDto.ts
+++ b/packages/api-client/src/models/paginatedReceivedSharesDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { ReceivedShareResponseDto } from './receivedShareResponseDto';
 

--- a/packages/api-client/src/models/paginatedSentSharesDto.ts
+++ b/packages/api-client/src/models/paginatedSentSharesDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { SentShareResponseDto } from './sentShareResponseDto';
 

--- a/packages/api-client/src/models/pendingRotationResponseDto.ts
+++ b/packages/api-client/src/models/pendingRotationResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { PendingRotationResponseDtoItemType } from './pendingRotationResponseDtoItemType';
 

--- a/packages/api-client/src/models/pendingRotationResponseDtoItemType.ts
+++ b/packages/api-client/src/models/pendingRotationResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type PendingRotationResponseDtoItemType =

--- a/packages/api-client/src/models/publishIpnsDto.ts
+++ b/packages/api-client/src/models/publishIpnsDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface PublishIpnsDto {

--- a/packages/api-client/src/models/publishIpnsEntryDto.ts
+++ b/packages/api-client/src/models/publishIpnsEntryDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { PublishIpnsEntryDtoRecordType } from './publishIpnsEntryDtoRecordType';
 

--- a/packages/api-client/src/models/publishIpnsEntryDtoRecordType.ts
+++ b/packages/api-client/src/models/publishIpnsEntryDtoRecordType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/publishIpnsResponseDto.ts
+++ b/packages/api-client/src/models/publishIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface PublishIpnsResponseDto {

--- a/packages/api-client/src/models/quotaResponseDto.ts
+++ b/packages/api-client/src/models/quotaResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface QuotaResponseDto {

--- a/packages/api-client/src/models/receivedShareResponseDto.ts
+++ b/packages/api-client/src/models/receivedShareResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { ReceivedShareResponseDtoItemType } from './receivedShareResponseDtoItemType';
 import type { ReceivedShareResponseDtoPermission } from './receivedShareResponseDtoPermission';

--- a/packages/api-client/src/models/receivedShareResponseDtoItemType.ts
+++ b/packages/api-client/src/models/receivedShareResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type ReceivedShareResponseDtoItemType =

--- a/packages/api-client/src/models/receivedShareResponseDtoPermission.ts
+++ b/packages/api-client/src/models/receivedShareResponseDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/registerCidDto.ts
+++ b/packages/api-client/src/models/registerCidDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface RegisterCidDto {

--- a/packages/api-client/src/models/registerCidResponseDto.ts
+++ b/packages/api-client/src/models/registerCidResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface RegisterCidResponseDto {

--- a/packages/api-client/src/models/resolveIpnsResponseDto.ts
+++ b/packages/api-client/src/models/resolveIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface ResolveIpnsResponseDto {

--- a/packages/api-client/src/models/respondApprovalDto.ts
+++ b/packages/api-client/src/models/respondApprovalDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { RespondApprovalDtoAction } from './respondApprovalDtoAction';
 

--- a/packages/api-client/src/models/respondApprovalDtoAction.ts
+++ b/packages/api-client/src/models/respondApprovalDtoAction.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/sendOtpDto.ts
+++ b/packages/api-client/src/models/sendOtpDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface SendOtpDto {

--- a/packages/api-client/src/models/sendOtpResponseDto.ts
+++ b/packages/api-client/src/models/sendOtpResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface SendOtpResponseDto {

--- a/packages/api-client/src/models/sentShareResponseDto.ts
+++ b/packages/api-client/src/models/sentShareResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { SentShareResponseDtoItemType } from './sentShareResponseDtoItemType';
 import type { SentShareResponseDtoPermission } from './sentShareResponseDtoPermission';

--- a/packages/api-client/src/models/sentShareResponseDtoItemType.ts
+++ b/packages/api-client/src/models/sentShareResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type SentShareResponseDtoItemType =

--- a/packages/api-client/src/models/sentShareResponseDtoPermission.ts
+++ b/packages/api-client/src/models/sentShareResponseDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/setByoStatusDto.ts
+++ b/packages/api-client/src/models/setByoStatusDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface SetByoStatusDto {

--- a/packages/api-client/src/models/setByoStatusResponseDto.ts
+++ b/packages/api-client/src/models/setByoStatusResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface SetByoStatusResponseDto {

--- a/packages/api-client/src/models/shareInvitesControllerListInvitesParams.ts
+++ b/packages/api-client/src/models/shareInvitesControllerListInvitesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type ShareInvitesControllerListInvitesParams = {

--- a/packages/api-client/src/models/shareKeyEntryDto.ts
+++ b/packages/api-client/src/models/shareKeyEntryDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { ShareKeyEntryDtoKeyType } from './shareKeyEntryDtoKeyType';
 

--- a/packages/api-client/src/models/shareKeyEntryDtoKeyType.ts
+++ b/packages/api-client/src/models/shareKeyEntryDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/shareKeyResponseDto.ts
+++ b/packages/api-client/src/models/shareKeyResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { ShareKeyResponseDtoKeyType } from './shareKeyResponseDtoKeyType';
 

--- a/packages/api-client/src/models/shareKeyResponseDtoKeyType.ts
+++ b/packages/api-client/src/models/shareKeyResponseDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type ShareKeyResponseDtoKeyType =

--- a/packages/api-client/src/models/sharesControllerGetReceivedSharesParams.ts
+++ b/packages/api-client/src/models/sharesControllerGetReceivedSharesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type SharesControllerGetReceivedSharesParams = {

--- a/packages/api-client/src/models/sharesControllerGetSentSharesParams.ts
+++ b/packages/api-client/src/models/sharesControllerGetSentSharesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type SharesControllerGetSentSharesParams = {

--- a/packages/api-client/src/models/sharesControllerLookupUserParams.ts
+++ b/packages/api-client/src/models/sharesControllerLookupUserParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export type SharesControllerLookupUserParams = {

--- a/packages/api-client/src/models/teeKeysDto.ts
+++ b/packages/api-client/src/models/teeKeysDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface TeeKeysDto {

--- a/packages/api-client/src/models/testLoginDto.ts
+++ b/packages/api-client/src/models/testLoginDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface TestLoginDto {

--- a/packages/api-client/src/models/testLoginResponseDto.ts
+++ b/packages/api-client/src/models/testLoginResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface TestLoginResponseDto {

--- a/packages/api-client/src/models/tokenResponseDto.ts
+++ b/packages/api-client/src/models/tokenResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface TokenResponseDto {

--- a/packages/api-client/src/models/unlinkMethodDto.ts
+++ b/packages/api-client/src/models/unlinkMethodDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface UnlinkMethodDto {

--- a/packages/api-client/src/models/unlinkMethodResponseDto.ts
+++ b/packages/api-client/src/models/unlinkMethodResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface UnlinkMethodResponseDto {

--- a/packages/api-client/src/models/unpinDto.ts
+++ b/packages/api-client/src/models/unpinDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface UnpinDto {

--- a/packages/api-client/src/models/unpinResponseDto.ts
+++ b/packages/api-client/src/models/unpinResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface UnpinResponseDto {

--- a/packages/api-client/src/models/updateEncryptedKeyDto.ts
+++ b/packages/api-client/src/models/updateEncryptedKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface UpdateEncryptedKeyDto {

--- a/packages/api-client/src/models/updatePermissionDto.ts
+++ b/packages/api-client/src/models/updatePermissionDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { UpdatePermissionDtoPermission } from './updatePermissionDtoPermission';
 

--- a/packages/api-client/src/models/updatePermissionDtoPermission.ts
+++ b/packages/api-client/src/models/updatePermissionDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/uploadResponseDto.ts
+++ b/packages/api-client/src/models/uploadResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface UploadResponseDto {

--- a/packages/api-client/src/models/vaultConfigResponseDto.ts
+++ b/packages/api-client/src/models/vaultConfigResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface VaultConfigResponseDto {

--- a/packages/api-client/src/models/vaultExportDto.ts
+++ b/packages/api-client/src/models/vaultExportDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 export interface VaultExportDto {

--- a/packages/api-client/src/models/vaultResponseDto.ts
+++ b/packages/api-client/src/models/vaultResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { VaultResponseDtoTeeKeys } from './vaultResponseDtoTeeKeys';
 

--- a/packages/api-client/src/models/vaultResponseDtoTeeKeys.ts
+++ b/packages/api-client/src/models/vaultResponseDtoTeeKeys.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { TeeKeysDto } from './teeKeysDto';
 

--- a/packages/api-client/src/models/verifyOtpDto.ts
+++ b/packages/api-client/src/models/verifyOtpDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { VerifyOtpDtoIntent } from './verifyOtpDtoIntent';
 

--- a/packages/api-client/src/models/verifyOtpDtoIntent.ts
+++ b/packages/api-client/src/models/verifyOtpDtoIntent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/api-client/src/models/walletVerifyDto.ts
+++ b/packages/api-client/src/models/walletVerifyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 import type { WalletVerifyDtoIntent } from './walletVerifyDtoIntent';
 

--- a/packages/api-client/src/models/walletVerifyDtoIntent.ts
+++ b/packages/api-client/src/models/walletVerifyDtoIntent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.36.1
+ * OpenAPI spec version: 0.37.1
  */
 
 /**

--- a/packages/sdk-core/scripts/edit-filepointer.mjs
+++ b/packages/sdk-core/scripts/edit-filepointer.mjs
@@ -89,8 +89,8 @@ async function authenticate(apiUrl, email, secret) {
 
   const payload = await response.json();
 
-  if (!payload.accessToken || !payload.privateKeyHex) {
-    throw new Error('test-login response missing accessToken or privateKeyHex');
+  if (!payload.accessToken || !payload.privateKeyHex || !payload.publicKeyHex) {
+    throw new Error('test-login response missing accessToken, privateKeyHex, or publicKeyHex');
   }
 
   return payload;

--- a/packages/sdk-core/scripts/edit-filepointer.mjs
+++ b/packages/sdk-core/scripts/edit-filepointer.mjs
@@ -1,0 +1,258 @@
+/**
+ * edit-filepointer.mjs -- Edit a file's content via the SDK.
+ *
+ * Authenticates via test-login, finds the target file in the vault,
+ * encrypts new content, uploads to IPFS, updates the file's IPNS
+ * metadata record, and republishes folder metadata with an updated
+ * modified_at timestamp so other clients (e.g. FUSE mount) detect
+ * the change.
+ *
+ * Usage:
+ *   TEST_SECRET=<secret> node edit-filepointer.mjs \
+ *     --api-url http://localhost:3000 \
+ *     --email dev-key@cipherbox.local \
+ *     --file-name hello.txt \
+ *     --new-content "Updated content from SDK"
+ */
+
+import { createAxiosInstance } from '../../api-client/dist/index.mjs';
+import {
+  loadVaultKeyBlob,
+  loadFolderMetadata,
+  resolveFileMetadata,
+  updateFileMetadata,
+  replaceFileInFolder,
+  updateFolderMetadataAndPublish,
+} from '../dist/index.mjs';
+import {
+  encryptAesGcm,
+  generateFileKey,
+  generateIv,
+  wrapKey,
+  unwrapKey,
+  bytesToHex,
+  hexToBytes,
+  deriveVaultIpnsKeypair,
+  clearBytes,
+} from '../../crypto/dist/index.mjs';
+import { addToIpfs } from '../dist/index.mjs';
+
+function parseArgs(argv) {
+  const values = new Map();
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+
+    const key = token.slice(2);
+    const value = argv[i + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    values.set(key, value);
+    i += 1;
+  }
+
+  if (values.has('secret')) {
+    throw new Error('Do not pass --secret on CLI. Set TEST_SECRET in environment.');
+  }
+
+  const apiUrl = values.get('api-url');
+  const secret = process.env.TEST_SECRET;
+  const email = values.get('email');
+  const fileName = values.get('file-name');
+  const newContent = values.get('new-content');
+
+  if (!apiUrl || !email || !fileName || !secret || !newContent) {
+    throw new Error(
+      'Usage: edit-filepointer.mjs --api-url <url> --email <email> --file-name <name> --new-content <text> (requires TEST_SECRET env var)'
+    );
+  }
+
+  return { apiUrl, secret, email, fileName, newContent };
+}
+
+async function authenticate(apiUrl, email, secret) {
+  const response = await fetch(`${apiUrl}/auth/test-login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, secret }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`test-login failed (${response.status}): ${body}`);
+  }
+
+  const payload = await response.json();
+
+  if (!payload.accessToken || !payload.privateKeyHex) {
+    throw new Error('test-login response missing accessToken or privateKeyHex');
+  }
+
+  return payload;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const auth = await authenticate(args.apiUrl, args.email, args.secret);
+  const accessToken = auth.accessToken;
+  const userPrivateKey = Uint8Array.from(Buffer.from(auth.privateKeyHex, 'hex'));
+  const userPublicKey = Uint8Array.from(Buffer.from(auth.publicKeyHex, 'hex'));
+
+  const axiosInstance = createAxiosInstance({
+    baseUrl: args.apiUrl,
+    getAccessToken: async () => accessToken,
+  });
+
+  const ctx = {
+    apiUrl: args.apiUrl,
+    getAccessToken: async () => accessToken,
+    axiosInstance,
+  };
+
+  // 1. Load vault key blob to get rootFolderKey
+  const vaultKeyBlob = await loadVaultKeyBlob({ userPrivateKey, ctx });
+  if (!vaultKeyBlob) {
+    throw new Error('Vault key blob not found');
+  }
+
+  // 2. Get vault info for rootIpnsName
+  const vaultResponse = await axiosInstance.get('/vault');
+  const rootIpnsName = vaultResponse.data.rootIpnsName;
+  if (!rootIpnsName) {
+    throw new Error('Vault response missing rootIpnsName');
+  }
+
+  // 3. Load root folder metadata
+  const folder = await loadFolderMetadata({
+    ipnsName: rootIpnsName,
+    folderKey: vaultKeyBlob.rootFolderKey,
+    ctx,
+  });
+  if (!folder) {
+    throw new Error(`Root folder metadata not found for ${rootIpnsName}`);
+  }
+
+  // 4. Find the target file's FilePointer
+  const filePointer = folder.metadata.children.find(
+    (child) => child.type === 'file' && child.name === args.fileName
+  );
+  if (!filePointer) {
+    throw new Error(`FilePointer not found for ${args.fileName}`);
+  }
+  if (!filePointer.fileMetaIpnsName) {
+    throw new Error(`FilePointer for ${args.fileName} is missing fileMetaIpnsName`);
+  }
+
+  // 5. Resolve current file metadata
+  const { metadata: currentMetadata } = await resolveFileMetadata(
+    filePointer.fileMetaIpnsName,
+    vaultKeyBlob.rootFolderKey,
+    ctx
+  );
+
+  // 6. Decrypt the file IPNS private key from FilePointer
+  if (!filePointer.ipnsPrivateKeyEncrypted) {
+    throw new Error('FilePointer missing ipnsPrivateKeyEncrypted (legacy files not supported)');
+  }
+  const fileIpnsPrivateKey = await unwrapKey(
+    hexToBytes(filePointer.ipnsPrivateKeyEncrypted),
+    userPrivateKey
+  );
+
+  // 7. Encrypt new content
+  const plaintext = new TextEncoder().encode(args.newContent);
+  const fileKey = generateFileKey();
+  const iv = generateIv();
+  let newCid;
+  let wrappedKeyHex;
+  let ivHex;
+
+  try {
+    const ciphertext = await encryptAesGcm(plaintext, fileKey, iv);
+    const wrappedKey = await wrapKey(fileKey, userPublicKey);
+    wrappedKeyHex = bytesToHex(wrappedKey);
+    ivHex = bytesToHex(iv);
+
+    // 8. Upload encrypted content to IPFS
+    const uploadResult = await addToIpfs(ctx, ciphertext);
+    newCid = uploadResult.cid;
+  } finally {
+    clearBytes(fileKey);
+  }
+
+  // 9. Update file metadata IPNS record
+  let ipnsRecord;
+  try {
+    ({ ipnsRecord } = await updateFileMetadata({
+      fileIpnsPrivateKey,
+      fileMetaIpnsName: filePointer.fileMetaIpnsName,
+      folderKey: vaultKeyBlob.rootFolderKey,
+      currentMetadata,
+      updates: {
+        cid: newCid,
+        fileKeyEncrypted: wrappedKeyHex,
+        fileIv: ivHex,
+        size: plaintext.length,
+        encryptionMode: 'GCM',
+      },
+      createVersion: true,
+      ctx,
+    }));
+  } finally {
+    fileIpnsPrivateKey.fill(0);
+  }
+
+  // 10. Publish only the file IPNS record
+  await replaceFileInFolder({
+    children: folder.metadata.children,
+    fileId: filePointer.id,
+    fileIpnsRecord: ipnsRecord,
+    ctx,
+  });
+
+  // 11. Republish folder metadata with updated modified_at so other clients
+  // (e.g. FUSE mount) detect the change via the FilePointer timestamp.
+  const updatedChildren = folder.metadata.children.map((child) => {
+    if (child.type === 'file' && child.id === filePointer.id) {
+      return { ...child, modifiedAt: Date.now() };
+    }
+    return child;
+  });
+
+  // Derive root folder IPNS keypair for republishing
+  const rootIpnsKeypair = await deriveVaultIpnsKeypair(userPrivateKey);
+
+  const { newSequenceNumber } = await updateFolderMetadataAndPublish({
+    children: updatedChildren,
+    folderKey: vaultKeyBlob.rootFolderKey,
+    ipnsPrivateKey: rootIpnsKeypair.privateKey,
+    ipnsName: rootIpnsName,
+    sequenceNumber: folder.sequenceNumber,
+    ctx,
+  });
+
+  // Zero sensitive key material
+  rootIpnsKeypair.privateKey.fill(0);
+
+  console.log(
+    JSON.stringify({
+      fileName: args.fileName,
+      oldCid: currentMetadata.cid,
+      newCid,
+      newContentLength: plaintext.length,
+      folderSequenceNumber: newSequenceNumber.toString(),
+      fileMetaIpnsName: filePointer.fileMetaIpnsName,
+    })
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});

--- a/packages/sdk-core/scripts/edit-filepointer.mjs
+++ b/packages/sdk-core/scripts/edit-filepointer.mjs
@@ -48,7 +48,7 @@ function parseArgs(argv) {
 
     const key = token.slice(2);
     const value = argv[i + 1];
-    if (!value || value.startsWith('--')) {
+    if (value === undefined || value.startsWith('--')) {
       throw new Error(`Missing value for --${key}`);
     }
 
@@ -66,7 +66,7 @@ function parseArgs(argv) {
   const fileName = values.get('file-name');
   const newContent = values.get('new-content');
 
-  if (!apiUrl || !email || !fileName || !secret || !newContent) {
+  if (!apiUrl || !email || !fileName || !secret || newContent === undefined) {
     throw new Error(
       'Usage: edit-filepointer.mjs --api-url <url> --email <email> --file-name <name> --new-content <text> (requires TEST_SECRET env var)'
     );

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -66,7 +66,7 @@
       "component": "@cipherbox/api",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.37.1"
+      "release-as": "0.38.0"
     },
     "apps/web": {
       "release-type": "node",
@@ -112,14 +112,14 @@
       "component": "@cipherbox/api-client",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.37.1"
+      "release-as": "0.38.0"
     },
     "packages/sdk-core": {
       "release-type": "node",
       "component": "@cipherbox/sdk-core",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.35.1"
+      "release-as": "0.36.0"
     },
     "packages/sdk": {
       "release-type": "node",

--- a/tests/desktop-e2e/scripts/run-all.sh
+++ b/tests/desktop-e2e/scripts/run-all.sh
@@ -98,6 +98,21 @@ else
 fi
 echo ""
 
+# ---- Step 6: Cross-client sync ----
+echo "--- Step 6: Cross-client sync ---"
+set +e
+TEST_SECRET="$TEST_SECRET" bash "$SCRIPT_DIR/test-cross-client-sync.sh" "$MOUNT_POINT" "$API_URL"
+SYNC_FAILURES=$?
+set -e
+
+if [ "$SYNC_FAILURES" -eq 0 ]; then
+  echo "Cross-client sync: ALL PASSED"
+else
+  echo "Cross-client sync: $SYNC_FAILURES FAILURE(S)"
+  TOTAL_FAIL=$((TOTAL_FAIL + SYNC_FAILURES))
+fi
+echo ""
+
 # ---- Summary ----
 echo "============================================"
 echo "  Summary"

--- a/tests/desktop-e2e/scripts/test-cross-client-sync.sh
+++ b/tests/desktop-e2e/scripts/test-cross-client-sync.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test-cross-client-sync.sh -- Verify FUSE mount picks up file edits made via SDK.
+#
+# Usage: ./test-cross-client-sync.sh [mount-point] [api-url]
+#   mount-point  Path to FUSE mount (default: $HOME/CipherBox)
+#   api-url      Backend API URL (default: http://localhost:3000)
+#
+# Environment:
+#   TEST_SECRET  Shared secret for test-login (default: e2e-test-secret-ci-only)
+#
+# This test exercises the cross-client sync path:
+# 1. Write a file via the FUSE mount (desktop client)
+# 2. Edit the file via the SDK (simulating a web UI edit)
+# 3. Wait for the FUSE mount to detect the change (IPNS polling)
+# 4. Read the file from the FUSE mount and verify updated content
+#
+# Exit code: number of failed tests (0 = all passed).
+
+MP="${1:-$HOME/CipherBox}"
+API_URL="${2:-http://localhost:3000}"
+SECRET="${TEST_SECRET:-e2e-test-secret-ci-only}"
+TEST_EMAIL="dev-key@cipherbox.local"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TEST_FILE="sync-test-${RANDOM}.txt"
+ORIGINAL_CONTENT="Original content from FUSE mount"
+EDITED_CONTENT="Edited content from SDK client"
+
+PASS=0
+FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "PASS: $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "FAIL: $1"
+}
+
+ensure_runtime() {
+  if [ -f "$REPO_ROOT/packages/sdk-core/dist/index.mjs" ] && \
+     [ -f "$REPO_ROOT/packages/api-client/dist/index.mjs" ] && \
+     [ -f "$REPO_ROOT/packages/crypto/dist/index.mjs" ]; then
+    return
+  fi
+
+  echo "Building SDK dependencies..."
+  pnpm --dir "$REPO_ROOT" --filter @cipherbox/crypto build
+  pnpm --dir "$REPO_ROOT" --filter @cipherbox/core build
+  pnpm --dir "$REPO_ROOT" --filter @cipherbox/api-client build
+  pnpm --dir "$REPO_ROOT" --filter @cipherbox/sdk-core build
+}
+
+run_verify() {
+  TEST_SECRET="$SECRET" node "$REPO_ROOT/packages/sdk-core/scripts/verify-filepointer.mjs" \
+    --api-url "$API_URL" \
+    --email "$TEST_EMAIL" \
+    --file-name "$TEST_FILE" \
+    --expected-content "$1"
+}
+
+run_edit() {
+  TEST_SECRET="$SECRET" node "$REPO_ROOT/packages/sdk-core/scripts/edit-filepointer.mjs" \
+    --api-url "$API_URL" \
+    --email "$TEST_EMAIL" \
+    --file-name "$TEST_FILE" \
+    --new-content "$1"
+}
+
+echo "=== Cross-Client Sync Tests ==="
+echo "Mount point: $MP"
+echo "API URL:     $API_URL"
+echo "Test email:  $TEST_EMAIL"
+echo "Test file:   $TEST_FILE"
+echo ""
+
+ensure_runtime
+
+# ---- Test 1: Write file via FUSE mount ----
+echo "--- Test 1: Write file via FUSE mount ---"
+printf '%s' "$ORIGINAL_CONTENT" > "$MP/$TEST_FILE"
+sleep 2
+# Trigger FUSE readdir to drain upload completions
+ls "$MP" > /dev/null 2>&1 || true
+
+FUSE_CONTENT=$(cat "$MP/$TEST_FILE" 2>/dev/null || echo "")
+if [ "$FUSE_CONTENT" = "$ORIGINAL_CONTENT" ]; then
+  pass "Write file via FUSE mount"
+else
+  fail "Write file via FUSE mount (got: '$FUSE_CONTENT')"
+fi
+
+# ---- Test 2: Wait for file to be visible via SDK ----
+echo "--- Test 2: Wait for file to be visible via SDK ---"
+SDK_VERIFY_OK=0
+for attempt in $(seq 1 24); do
+  # Trigger FUSE readdir each iteration to drain upload completions
+  stat "$MP/$TEST_FILE" > /dev/null 2>&1 || true
+  ls "$MP" > /dev/null 2>&1 || true
+  sleep 5
+  if VERIFY_OUTPUT=$(run_verify "$ORIGINAL_CONTENT" 2>&1); then
+    SDK_VERIFY_OK=1
+    break
+  fi
+  echo "  SDK verify attempt $attempt: $VERIFY_OUTPUT"
+done
+
+if [ "$SDK_VERIFY_OK" -eq 1 ]; then
+  pass "File visible and decryptable via SDK"
+  echo "  $VERIFY_OUTPUT"
+else
+  fail "File not visible via SDK after 120s"
+  echo "FATAL: Cannot proceed without SDK-visible file."
+  echo ""
+  echo "=== Cross-Client Sync Results ==="
+  echo "  Passed: $PASS"
+  echo "  Failed: $FAIL"
+  echo "=================================="
+  # Cleanup
+  rm -f "$MP/$TEST_FILE" 2>/dev/null || true
+  exit "$FAIL"
+fi
+
+# ---- Test 3: Edit file via SDK ----
+echo "--- Test 3: Edit file via SDK ---"
+if EDIT_OUTPUT=$(run_edit "$EDITED_CONTENT" 2>&1); then
+  pass "Edit file via SDK"
+  echo "  $EDIT_OUTPUT"
+else
+  fail "Edit file via SDK ($EDIT_OUTPUT)"
+  echo "FATAL: Cannot test sync without successful edit."
+  echo ""
+  echo "=== Cross-Client Sync Results ==="
+  echo "  Passed: $PASS"
+  echo "  Failed: $FAIL"
+  echo "=================================="
+  # Cleanup
+  rm -f "$MP/$TEST_FILE" 2>/dev/null || true
+  exit "$FAIL"
+fi
+
+# ---- Test 4: Verify edit persisted via SDK ----
+echo "--- Test 4: Verify edit persisted via SDK ---"
+sleep 2
+if VERIFY_EDIT_OUTPUT=$(run_verify "$EDITED_CONTENT" 2>&1); then
+  pass "Edited content verified via SDK"
+  echo "  $VERIFY_EDIT_OUTPUT"
+else
+  fail "Edited content not verified via SDK ($VERIFY_EDIT_OUTPUT)"
+fi
+
+# ---- Test 5: Wait for FUSE mount to pick up edited content ----
+echo "--- Test 5: Wait for FUSE mount to detect edit ---"
+# The FUSE mount polls folder metadata every 30s. After detecting a newer
+# modified_at on the FilePointer, it re-resolves the file's IPNS record
+# to pick up the new CID. Allow up to 120s for two full polling cycles.
+SYNC_OK=0
+for attempt in $(seq 1 24); do
+  sleep 5
+  # Force a fresh read by stat-ing the file (invalidates macOS file cache)
+  stat "$MP/$TEST_FILE" > /dev/null 2>&1 || true
+  FUSE_CONTENT=$(cat "$MP/$TEST_FILE" 2>/dev/null || echo "")
+  if [ "$FUSE_CONTENT" = "$EDITED_CONTENT" ]; then
+    SYNC_OK=1
+    echo "  Sync detected on attempt $attempt ($(( attempt * 5 ))s)"
+    break
+  fi
+  echo "  Sync poll attempt $attempt: content still original"
+done
+
+if [ "$SYNC_OK" -eq 1 ]; then
+  pass "FUSE mount picked up edited content"
+else
+  fail "FUSE mount still shows original content after 120s (got: '$FUSE_CONTENT')"
+fi
+
+# ---- Cleanup ----
+echo "--- Cleanup ---"
+rm -f "$MP/$TEST_FILE" 2>/dev/null || true
+sleep 2
+
+# ---- Summary ----
+echo ""
+echo "=== Cross-Client Sync Results ==="
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "=================================="
+
+exit "$FAIL"

--- a/tests/desktop-e2e/scripts/test-cross-client-sync.sh
+++ b/tests/desktop-e2e/scripts/test-cross-client-sync.sh
@@ -44,15 +44,16 @@ fail() {
 ensure_runtime() {
   if [ -f "$REPO_ROOT/packages/sdk-core/dist/index.mjs" ] && \
      [ -f "$REPO_ROOT/packages/api-client/dist/index.mjs" ] && \
+     [ -f "$REPO_ROOT/packages/core/dist/index.mjs" ] && \
      [ -f "$REPO_ROOT/packages/crypto/dist/index.mjs" ]; then
-    return
+    return 0
   fi
 
   echo "Building SDK dependencies..."
-  pnpm --dir "$REPO_ROOT" --filter @cipherbox/crypto build
-  pnpm --dir "$REPO_ROOT" --filter @cipherbox/core build
-  pnpm --dir "$REPO_ROOT" --filter @cipherbox/api-client build
-  pnpm --dir "$REPO_ROOT" --filter @cipherbox/sdk-core build
+  pnpm --dir "$REPO_ROOT" --filter @cipherbox/crypto build && \
+    pnpm --dir "$REPO_ROOT" --filter @cipherbox/core build && \
+    pnpm --dir "$REPO_ROOT" --filter @cipherbox/api-client build && \
+    pnpm --dir "$REPO_ROOT" --filter @cipherbox/sdk-core build
 }
 
 run_verify() {
@@ -78,7 +79,10 @@ echo "Test email:  $TEST_EMAIL"
 echo "Test file:   $TEST_FILE"
 echo ""
 
-ensure_runtime
+ensure_runtime || {
+  echo "FATAL: Failed to build SDK dependencies."
+  exit 1
+}
 
 # ---- Test 1: Write file via FUSE mount ----
 echo "--- Test 1: Write file via FUSE mount ---"


### PR DESCRIPTION
## Summary

- **Root cause:** `populate_folder()` in `crates/fuse/src/inode.rs` preserved the existing resolved inode (with old CID) when a file's `modified_at` timestamp changed, so FUSE never picked up file edits made via the web UI.
- **Fix:** Compare incoming `modified_at` with the inode's `mtime` — if newer, mark the file as unresolved so the next `drain_refresh_completions` cycle re-resolves its IPNS record and fetches the new CID.
- Includes a new unit test covering both cases (unchanged and changed `modified_at`).

## Test plan

- [ ] Upload a text file via the FUSE-mounted folder
- [ ] Edit the file in the web UI, save
- [ ] Wait ~30-60s for metadata cache TTL
- [ ] Open the file from the mount — should show updated content
- [ ] `cargo test --package cipherbox-fuse` — all 37 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of remotely edited files so updated content is re-fetched and stale resolved metadata is reset while preserving per-file key material when applicable.
  * Folder metadata is now republished after local file edits to propagate updates.

* **New Features**
  * Added a CLI script to perform end-to-end "edit file via SDK" workflows.

* **Tests**
  * Added unit test for resetting resolved file state on newer remote modifications.
  * Added cross-client end-to-end sync test and integrated it into the test runner.

* **Documentation**
  * Added a debug note describing the stale-content scenario and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->