### PR TITLE
fix(desktop): trigger metadata refresh from lookup/open, fix e2e sync test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cipherbox-fuse"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64 0.22.1",
  "cipherbox-api-client",

--- a/apps/desktop/src-tauri/src/fuse/mod.rs
+++ b/apps/desktop/src-tauri/src/fuse/mod.rs
@@ -216,6 +216,7 @@ pub async fn mount_filesystem(
         max_versions_per_file, version_cooldown_ms,
         refresh_rx, refresh_tx,
         prefetching: std::collections::HashSet::new(),
+        refreshing_metadata: std::collections::HashSet::new(),
         content_rx, content_tx,
         filepointer_rx, filepointer_tx,
         resolving_file_pointers: std::collections::HashSet::new(),

--- a/apps/desktop/src-tauri/src/fuse/windows/mod.rs
+++ b/apps/desktop/src-tauri/src/fuse/windows/mod.rs
@@ -340,6 +340,7 @@ mod mount_impl {
             refresh_rx,
             refresh_tx,
             prefetching: std::collections::HashSet::new(),
+            refreshing_metadata: std::collections::HashSet::new(),
             content_rx,
             content_tx,
             filepointer_rx,

--- a/crates/fuse/src/dir_ops.rs
+++ b/crates/fuse/src/dir_ops.rs
@@ -61,7 +61,8 @@ pub(crate) mod implementation {
         };
 
         // Fire background refresh (non-blocking, results applied on next readdir)
-        if let Some((ipns_name, folder_key)) = stale_info.filter(|_| offset == 0) {
+        if let Some((ipns_name, folder_key)) = stale_info.filter(|(n, _)| offset == 0 && !fs.refreshing_metadata.contains(n)) {
+            fs.refreshing_metadata.insert(ipns_name.clone());
             let api = fs.api.clone();
             let rt = fs.rt.clone();
             let tx = fs.refresh_tx.clone();

--- a/crates/fuse/src/dir_ops.rs
+++ b/crates/fuse/src/dir_ops.rs
@@ -63,35 +63,7 @@ pub(crate) mod implementation {
         // Fire background refresh (non-blocking, results applied on next readdir)
         if let Some((ipns_name, folder_key)) = stale_info.filter(|(n, _)| offset == 0 && !fs.refreshing_metadata.contains(n)) {
             fs.refreshing_metadata.insert(ipns_name.clone());
-            let api = fs.api.clone();
-            let rt = fs.rt.clone();
-            let tx = fs.refresh_tx.clone();
-            let refresh_ino = ino;
-            rt.spawn(async move {
-                match cipherbox_api_client::ipns::resolve_ipns(&api, &ipns_name).await {
-                    Ok(resolve_resp) => {
-                        match cipherbox_api_client::ipfs::fetch_content(&api, &resolve_resp.cid).await {
-                            Ok(encrypted_bytes) => {
-                                match cipherbox_core::decrypt::decrypt_metadata_from_ipfs_public(
-                                    &encrypted_bytes, &folder_key,
-                                ) {
-                                    Ok(metadata) => {
-                                        let _ = tx.send(crate::PendingRefresh {
-                                            ino: refresh_ino,
-                                            ipns_name,
-                                            metadata,
-                                            cid: resolve_resp.cid,
-                                        });
-                                    }
-                                    Err(e) => log::warn!("Refresh decrypt failed: {}", e),
-                                }
-                            }
-                            Err(e) => log::warn!("Refresh fetch failed: {}", e),
-                        }
-                    }
-                    Err(e) => log::warn!("Refresh resolve failed for {}: {}", ipns_name, e),
-                }
-            });
+            crate::spawn_metadata_refresh(&fs.rt, fs.api.clone(), fs.refresh_tx.clone(), ino, ipns_name, folder_key);
         }
 
         // 3. Return current (possibly stale) entries immediately

--- a/crates/fuse/src/lib.rs
+++ b/crates/fuse/src/lib.rs
@@ -503,6 +503,7 @@ pub struct CipherBoxFS {
     pub refresh_tx: std::sync::mpsc::Sender<PendingRefresh>,
     pub mutated_folders: HashMap<u64, std::time::Instant>,
     pub prefetching: std::collections::HashSet<String>,
+    pub refreshing_metadata: std::collections::HashSet<String>,
     pub content_rx: std::sync::mpsc::Receiver<PendingContent>,
     pub content_tx: std::sync::mpsc::Sender<PendingContent>,
     pub filepointer_rx: std::sync::mpsc::Receiver<PendingFilePointer>,
@@ -643,6 +644,7 @@ impl CipherBoxFS {
         let cutoff = std::time::Instant::now() - std::time::Duration::from_secs(30);
         self.mutated_folders.retain(|_, ts| *ts > cutoff);
         while let Ok(refresh) = self.refresh_rx.try_recv() {
+            self.refreshing_metadata.remove(&refresh.ipns_name);
             if self.mutated_folders.contains_key(&refresh.ino) || self.publish_queue.contains_key(&refresh.ino) {
                 self.metadata_cache.set(&refresh.ipns_name, refresh.metadata.clone(), refresh.cid);
                 continue;

--- a/crates/fuse/src/lib.rs
+++ b/crates/fuse/src/lib.rs
@@ -70,11 +70,16 @@ where
 
 /// Pending folder refresh result sent from background tasks.
 #[cfg(any(feature = "fuse", feature = "winfsp"))]
-pub struct PendingRefresh {
-    pub ino: u64,
-    pub ipns_name: String,
-    pub metadata: cipherbox_core::folder::FolderMetadata,
-    pub cid: String,
+pub enum PendingRefresh {
+    Success {
+        ino: u64,
+        ipns_name: String,
+        metadata: cipherbox_core::folder::FolderMetadata,
+        cid: String,
+    },
+    Failure {
+        ipns_name: String,
+    },
 }
 
 /// Pending content prefetch result sent from background tasks.
@@ -112,6 +117,54 @@ pub struct UploadComplete {
     pub pruned_cids: Vec<String>,
     /// Write generation at the time this upload was started.
     pub write_generation: u64,
+}
+
+/// Spawn a background metadata refresh task that resolves IPNS, fetches content,
+/// decrypts metadata, and sends the result (success or failure) over `tx`.
+/// On any error path, sends `PendingRefresh::Failure` so the caller's
+/// `refreshing_metadata` set is always cleaned up.
+#[cfg(any(feature = "fuse", feature = "winfsp"))]
+pub fn spawn_metadata_refresh(
+    rt: &tokio::runtime::Handle,
+    api: std::sync::Arc<cipherbox_api_client::ApiClient>,
+    tx: std::sync::mpsc::Sender<PendingRefresh>,
+    ino: u64,
+    ipns_name: String,
+    folder_key: zeroize::Zeroizing<Vec<u8>>,
+) {
+    rt.spawn(async move {
+        let result: Result<(cipherbox_core::folder::FolderMetadata, String), String> = async {
+            let resolve_resp = cipherbox_api_client::ipns::resolve_ipns(&api, &ipns_name)
+                .await
+                .map_err(|e| format!("resolve: {}", e))?;
+            let encrypted_bytes =
+                cipherbox_api_client::ipfs::fetch_content(&api, &resolve_resp.cid)
+                    .await
+                    .map_err(|e| format!("fetch: {}", e))?;
+            let metadata = cipherbox_core::decrypt::decrypt_metadata_from_ipfs_public(
+                &encrypted_bytes,
+                &folder_key,
+            )
+            .map_err(|e| format!("decrypt: {}", e))?;
+            Ok((metadata, resolve_resp.cid))
+        }
+        .await;
+
+        match result {
+            Ok((metadata, cid)) => {
+                let _ = tx.send(PendingRefresh::Success {
+                    ino,
+                    ipns_name,
+                    metadata,
+                    cid,
+                });
+            }
+            Err(e) => {
+                log::warn!("Metadata refresh failed for {}: {}", ipns_name, e);
+                let _ = tx.send(PendingRefresh::Failure { ipns_name });
+            }
+        }
+    });
 }
 
 /// Entry in the debounced publish queue.
@@ -644,19 +697,26 @@ impl CipherBoxFS {
         let cutoff = std::time::Instant::now() - std::time::Duration::from_secs(30);
         self.mutated_folders.retain(|_, ts| *ts > cutoff);
         while let Ok(refresh) = self.refresh_rx.try_recv() {
-            self.refreshing_metadata.remove(&refresh.ipns_name);
-            if self.mutated_folders.contains_key(&refresh.ino) || self.publish_queue.contains_key(&refresh.ino) {
-                self.metadata_cache.set(&refresh.ipns_name, refresh.metadata.clone(), refresh.cid);
+            let (ino, ipns_name, metadata, cid) = match refresh {
+                PendingRefresh::Success { ino, ipns_name, metadata, cid } => (ino, ipns_name, metadata, cid),
+                PendingRefresh::Failure { ipns_name } => {
+                    self.refreshing_metadata.remove(&ipns_name);
+                    continue;
+                }
+            };
+            self.refreshing_metadata.remove(&ipns_name);
+            if self.mutated_folders.contains_key(&ino) || self.publish_queue.contains_key(&ino) {
+                self.metadata_cache.set(&ipns_name, metadata.clone(), cid);
                 continue;
             }
-            self.metadata_cache.set(&refresh.ipns_name, refresh.metadata.clone(), refresh.cid.clone());
-            if let Err(e) = self.inodes.populate_folder(refresh.ino, &refresh.metadata, &self.private_key, &self.public_key, true) {
-                log::warn!("Drain refresh apply failed for ino {}: {}", refresh.ino, e);
+            self.metadata_cache.set(&ipns_name, metadata.clone(), cid.clone());
+            if let Err(e) = self.inodes.populate_folder(ino, &metadata, &self.private_key, &self.public_key, true) {
+                log::warn!("Drain refresh apply failed for ino {}: {}", ino, e);
             }
             // Spawn async resolution for unresolved FilePointers in this folder
-            let unresolved = self.inodes.get_unresolved_file_pointers_for_parent(refresh.ino);
+            let unresolved = self.inodes.get_unresolved_file_pointers_for_parent(ino);
             if !unresolved.is_empty() {
-                let folder_key = self.inodes.get(refresh.ino).and_then(|i| match &i.kind {
+                let folder_key = self.inodes.get(ino).and_then(|i| match &i.kind {
                     inode::InodeKind::Root { .. } => Some(self.root_folder_key.to_vec()),
                     inode::InodeKind::Folder { folder_key, .. } => Some(folder_key.to_vec()),
                     _ => None,
@@ -667,7 +727,7 @@ impl CipherBoxFS {
                         Err(_) => {
                             log::warn!(
                                 "FilePointer resolution skipped for folder ino {}: folder_key length is {} (expected 32)",
-                                refresh.ino,
+                                ino,
                                 fk.len()
                             );
                             continue;

--- a/crates/fuse/src/platform/windows/dir_ops.rs
+++ b/crates/fuse/src/platform/windows/dir_ops.rs
@@ -36,6 +36,11 @@ pub mod implementation {
             .get(ino)
             .ok_or(status_object_name_not_found())?;
 
+        // Extract values from inode before mutable borrow of fs below
+        let parent_ino = inode.parent_ino;
+        let children = inode.children.clone().unwrap_or_default();
+        let inode_attr = inode.attr.clone();
+
         // Check if metadata is stale and fire background refresh
         let stale_info: Option<(String, zeroize::Zeroizing<Vec<u8>>)> =
             match &inode.kind {
@@ -57,6 +62,9 @@ pub mod implementation {
                 }
                 _ => None,
             };
+
+        // Drop inode borrow so we can mutably borrow fs
+        drop(inode);
 
         if let Some((ipns_name, folder_key)) = stale_info.filter(|(n, _)| !fs.refreshing_metadata.contains(n)) {
             fs.refreshing_metadata.insert(ipns_name.clone());
@@ -91,13 +99,10 @@ pub mod implementation {
             });
         }
 
-        let parent_ino = inode.parent_ino;
-        let children = inode.children.clone().unwrap_or_default();
-
         let mut entries: Vec<(U16CString, FileInfo)> = Vec::new();
 
         if let Ok(name) = U16CString::from_str(".") {
-            entries.push((name, fill_file_info(&inode.attr)));
+            entries.push((name, fill_file_info(&inode_attr)));
         }
 
         if let Some(parent) = fs.inodes.get(parent_ino) {

--- a/crates/fuse/src/platform/windows/dir_ops.rs
+++ b/crates/fuse/src/platform/windows/dir_ops.rs
@@ -68,35 +68,7 @@ pub mod implementation {
 
         if let Some((ipns_name, folder_key)) = stale_info.filter(|(n, _)| !fs.refreshing_metadata.contains(n)) {
             fs.refreshing_metadata.insert(ipns_name.clone());
-            let api = fs.api.clone();
-            let rt = fs.rt.clone();
-            let tx = fs.refresh_tx.clone();
-            let refresh_ino = ino;
-            rt.spawn(async move {
-                match cipherbox_api_client::ipns::resolve_ipns(&api, &ipns_name).await {
-                    Ok(resolve_resp) => {
-                        match cipherbox_api_client::ipfs::fetch_content(&api, &resolve_resp.cid).await {
-                            Ok(encrypted_bytes) => {
-                                match cipherbox_core::decrypt::decrypt_metadata_from_ipfs_public(
-                                    &encrypted_bytes, &folder_key,
-                                ) {
-                                    Ok(metadata) => {
-                                        let _ = tx.send(crate::PendingRefresh {
-                                            ino: refresh_ino,
-                                            ipns_name,
-                                            metadata,
-                                            cid: resolve_resp.cid,
-                                        });
-                                    }
-                                    Err(e) => log::warn!("Refresh decrypt failed: {}", e),
-                                }
-                            }
-                            Err(e) => log::warn!("Refresh fetch failed: {}", e),
-                        }
-                    }
-                    Err(e) => log::warn!("Refresh resolve failed for {}: {}", ipns_name, e),
-                }
-            });
+            crate::spawn_metadata_refresh(&fs.rt, fs.api.clone(), fs.refresh_tx.clone(), ino, ipns_name, folder_key);
         }
 
         let mut entries: Vec<(U16CString, FileInfo)> = Vec::new();

--- a/crates/fuse/src/platform/windows/dir_ops.rs
+++ b/crates/fuse/src/platform/windows/dir_ops.rs
@@ -58,7 +58,8 @@ pub mod implementation {
                 _ => None,
             };
 
-        if let Some((ipns_name, folder_key)) = stale_info {
+        if let Some((ipns_name, folder_key)) = stale_info.filter(|(n, _)| !fs.refreshing_metadata.contains(n)) {
+            fs.refreshing_metadata.insert(ipns_name.clone());
             let api = fs.api.clone();
             let rt = fs.rt.clone();
             let tx = fs.refresh_tx.clone();

--- a/crates/fuse/src/platform/windows/read_ops.rs
+++ b/crates/fuse/src/platform/windows/read_ops.rs
@@ -108,10 +108,71 @@ pub mod implementation {
 
         fs.drain_upload_completions();
         fs.drain_content_prefetches();
+        fs.drain_refresh_completions();
         fs.drain_filepointer_completions();
 
-        let (ino, _parent_ino) = resolve_path(&fs, &path)
+        let (ino, parent_ino) = resolve_path(&fs, &path)
             .ok_or(status_object_name_not_found())?;
+
+        // Check if parent folder metadata is stale and fire background refresh.
+        // This mirrors read_directory's staleness check so that file opens also
+        // trigger metadata refresh, not only directory listings.
+        let stale_info: Option<(u64, String, zeroize::Zeroizing<Vec<u8>>)> = {
+            if let Some(parent_inode) = fs.inodes.get(parent_ino) {
+                match &parent_inode.kind {
+                    InodeKind::Root { ipns_name, .. } => {
+                        ipns_name.as_ref().and_then(|name| {
+                            if fs.metadata_cache.get(name).is_none() {
+                                Some((parent_ino, name.clone(), fs.root_folder_key.clone()))
+                            } else {
+                                None
+                            }
+                        })
+                    }
+                    InodeKind::Folder { ipns_name, folder_key, .. } => {
+                        if fs.metadata_cache.get(ipns_name).is_none() {
+                            Some((parent_ino, ipns_name.clone(), folder_key.clone()))
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        };
+
+        if let Some((refresh_ino, ipns_name, folder_key)) = stale_info {
+            let api = fs.api.clone();
+            let rt = fs.rt.clone();
+            let tx = fs.refresh_tx.clone();
+            rt.spawn(async move {
+                match cipherbox_api_client::ipns::resolve_ipns(&api, &ipns_name).await {
+                    Ok(resolve_resp) => {
+                        match cipherbox_api_client::ipfs::fetch_content(&api, &resolve_resp.cid).await {
+                            Ok(encrypted_bytes) => {
+                                match cipherbox_core::decrypt::decrypt_metadata_from_ipfs_public(
+                                    &encrypted_bytes, &folder_key,
+                                ) {
+                                    Ok(metadata) => {
+                                        let _ = tx.send(crate::PendingRefresh {
+                                            ino: refresh_ino,
+                                            ipns_name,
+                                            metadata,
+                                            cid: resolve_resp.cid,
+                                        });
+                                    }
+                                    Err(e) => log::warn!("Open refresh decrypt failed: {}", e),
+                                }
+                            }
+                            Err(e) => log::warn!("Open refresh fetch failed: {}", e),
+                        }
+                    }
+                    Err(e) => log::debug!("Open refresh resolve failed for {}: {}", ipns_name, e),
+                }
+            });
+        }
 
         let inode = fs
             .inodes

--- a/crates/fuse/src/platform/windows/read_ops.rs
+++ b/crates/fuse/src/platform/windows/read_ops.rs
@@ -145,34 +145,7 @@ pub mod implementation {
 
         if let Some((refresh_ino, ipns_name, folder_key)) = stale_info.filter(|(_, n, _)| !fs.refreshing_metadata.contains(n)) {
             fs.refreshing_metadata.insert(ipns_name.clone());
-            let api = fs.api.clone();
-            let rt = fs.rt.clone();
-            let tx = fs.refresh_tx.clone();
-            rt.spawn(async move {
-                match cipherbox_api_client::ipns::resolve_ipns(&api, &ipns_name).await {
-                    Ok(resolve_resp) => {
-                        match cipherbox_api_client::ipfs::fetch_content(&api, &resolve_resp.cid).await {
-                            Ok(encrypted_bytes) => {
-                                match cipherbox_core::decrypt::decrypt_metadata_from_ipfs_public(
-                                    &encrypted_bytes, &folder_key,
-                                ) {
-                                    Ok(metadata) => {
-                                        let _ = tx.send(crate::PendingRefresh {
-                                            ino: refresh_ino,
-                                            ipns_name,
-                                            metadata,
-                                            cid: resolve_resp.cid,
-                                        });
-                                    }
-                                    Err(e) => log::warn!("Open refresh decrypt failed: {}", e),
-                                }
-                            }
-                            Err(e) => log::warn!("Open refresh fetch failed: {}", e),
-                        }
-                    }
-                    Err(e) => log::debug!("Open refresh resolve failed for {}: {}", ipns_name, e),
-                }
-            });
+            crate::spawn_metadata_refresh(&fs.rt, fs.api.clone(), fs.refresh_tx.clone(), refresh_ino, ipns_name, folder_key);
         }
 
         let inode = fs

--- a/crates/fuse/src/platform/windows/read_ops.rs
+++ b/crates/fuse/src/platform/windows/read_ops.rs
@@ -143,7 +143,8 @@ pub mod implementation {
             }
         };
 
-        if let Some((refresh_ino, ipns_name, folder_key)) = stale_info {
+        if let Some((refresh_ino, ipns_name, folder_key)) = stale_info.filter(|(_, n, _)| !fs.refreshing_metadata.contains(n)) {
+            fs.refreshing_metadata.insert(ipns_name.clone());
             let api = fs.api.clone();
             let rt = fs.rt.clone();
             let tx = fs.refresh_tx.clone();

--- a/crates/fuse/src/read_ops.rs
+++ b/crates/fuse/src/read_ops.rs
@@ -181,7 +181,8 @@ pub(crate) mod implementation {
         };
 
         // Non-blocking stale metadata refresh (same as readdir's staleness check)
-        if let Some((ipns_name, folder_key)) = needs_refresh {
+        if let Some((ipns_name, folder_key)) = needs_refresh.filter(|(n, _)| !fs.refreshing_metadata.contains(n)) {
+            fs.refreshing_metadata.insert(ipns_name.clone());
             let api = fs.api.clone();
             let rt = fs.rt.clone();
             let tx = fs.refresh_tx.clone();
@@ -214,7 +215,8 @@ pub(crate) mod implementation {
         }
 
         // Non-blocking lazy load: fire background fetch
-        if let Some((ipns_name, folder_key)) = needs_load {
+        if let Some((ipns_name, folder_key)) = needs_load.filter(|(n, _)| !fs.refreshing_metadata.contains(n)) {
+            fs.refreshing_metadata.insert(ipns_name.clone());
             let api = fs.api.clone();
             let rt = fs.rt.clone();
             let tx = fs.refresh_tx.clone();

--- a/crates/fuse/src/read_ops.rs
+++ b/crates/fuse/src/read_ops.rs
@@ -142,7 +142,10 @@ pub(crate) mod implementation {
         }
 
         // Check if parent is a folder with unloaded children (lazy loading)
-        let needs_load = {
+        // OR if the parent folder metadata is stale and needs a background refresh.
+        // This mirrors readdir's staleness check so that file access (stat, open)
+        // also triggers metadata refresh, not only directory listings.
+        let (needs_load, needs_refresh) = {
             if let Some(parent_inode) = fs.inodes.get(parent) {
                 match &parent_inode.kind {
                     InodeKind::Folder {
@@ -152,18 +155,63 @@ pub(crate) mod implementation {
                         ..
                     } => {
                         if !children_loaded {
-                            Some((ipns_name.clone(), folder_key.clone()))
+                            (Some((ipns_name.clone(), folder_key.clone())), None)
+                        } else if fs.metadata_cache.get(ipns_name).is_none() {
+                            (None, Some((ipns_name.clone(), folder_key.clone())))
                         } else {
-                            None
+                            (None, None)
                         }
                     }
-                    _ => None,
+                    InodeKind::Root { ipns_name, .. } => {
+                        let stale = ipns_name.as_ref().and_then(|name| {
+                            if fs.metadata_cache.get(name).is_none() {
+                                Some((name.clone(), fs.root_folder_key.clone()))
+                            } else {
+                                None
+                            }
+                        });
+                        (None, stale)
+                    }
+                    _ => (None, None),
                 }
             } else {
                 reply.error(libc::ENOENT);
                 return;
             }
         };
+
+        // Non-blocking stale metadata refresh (same as readdir's staleness check)
+        if let Some((ipns_name, folder_key)) = needs_refresh {
+            let api = fs.api.clone();
+            let rt = fs.rt.clone();
+            let tx = fs.refresh_tx.clone();
+            let refresh_ino = parent;
+            rt.spawn(async move {
+                match cipherbox_api_client::ipns::resolve_ipns(&api, &ipns_name).await {
+                    Ok(resolve_resp) => {
+                        match cipherbox_api_client::ipfs::fetch_content(&api, &resolve_resp.cid).await {
+                            Ok(encrypted_bytes) => {
+                                match cipherbox_core::decrypt::decrypt_metadata_from_ipfs_public(
+                                    &encrypted_bytes, &folder_key,
+                                ) {
+                                    Ok(metadata) => {
+                                        let _ = tx.send(crate::PendingRefresh {
+                                            ino: refresh_ino,
+                                            ipns_name,
+                                            metadata,
+                                            cid: resolve_resp.cid,
+                                        });
+                                    }
+                                    Err(e) => log::warn!("Lookup refresh decrypt failed: {}", e),
+                                }
+                            }
+                            Err(e) => log::warn!("Lookup refresh fetch failed: {}", e),
+                        }
+                    }
+                    Err(e) => log::debug!("Lookup refresh resolve failed for {}: {}", ipns_name, e),
+                }
+            });
+        }
 
         // Non-blocking lazy load: fire background fetch
         if let Some((ipns_name, folder_key)) = needs_load {

--- a/crates/fuse/src/read_ops.rs
+++ b/crates/fuse/src/read_ops.rs
@@ -183,69 +183,13 @@ pub(crate) mod implementation {
         // Non-blocking stale metadata refresh (same as readdir's staleness check)
         if let Some((ipns_name, folder_key)) = needs_refresh.filter(|(n, _)| !fs.refreshing_metadata.contains(n)) {
             fs.refreshing_metadata.insert(ipns_name.clone());
-            let api = fs.api.clone();
-            let rt = fs.rt.clone();
-            let tx = fs.refresh_tx.clone();
-            let refresh_ino = parent;
-            rt.spawn(async move {
-                match cipherbox_api_client::ipns::resolve_ipns(&api, &ipns_name).await {
-                    Ok(resolve_resp) => {
-                        match cipherbox_api_client::ipfs::fetch_content(&api, &resolve_resp.cid).await {
-                            Ok(encrypted_bytes) => {
-                                match cipherbox_core::decrypt::decrypt_metadata_from_ipfs_public(
-                                    &encrypted_bytes, &folder_key,
-                                ) {
-                                    Ok(metadata) => {
-                                        let _ = tx.send(crate::PendingRefresh {
-                                            ino: refresh_ino,
-                                            ipns_name,
-                                            metadata,
-                                            cid: resolve_resp.cid,
-                                        });
-                                    }
-                                    Err(e) => log::warn!("Lookup refresh decrypt failed: {}", e),
-                                }
-                            }
-                            Err(e) => log::warn!("Lookup refresh fetch failed: {}", e),
-                        }
-                    }
-                    Err(e) => log::debug!("Lookup refresh resolve failed for {}: {}", ipns_name, e),
-                }
-            });
+            crate::spawn_metadata_refresh(&fs.rt, fs.api.clone(), fs.refresh_tx.clone(), parent, ipns_name, folder_key);
         }
 
         // Non-blocking lazy load: fire background fetch
         if let Some((ipns_name, folder_key)) = needs_load.filter(|(n, _)| !fs.refreshing_metadata.contains(n)) {
             fs.refreshing_metadata.insert(ipns_name.clone());
-            let api = fs.api.clone();
-            let rt = fs.rt.clone();
-            let tx = fs.refresh_tx.clone();
-            let refresh_ino = parent;
-            rt.spawn(async move {
-                match cipherbox_api_client::ipns::resolve_ipns(&api, &ipns_name).await {
-                    Ok(resolve_resp) => {
-                        match cipherbox_api_client::ipfs::fetch_content(&api, &resolve_resp.cid).await {
-                            Ok(encrypted_bytes) => {
-                                match cipherbox_core::decrypt::decrypt_metadata_from_ipfs_public(
-                                    &encrypted_bytes, &folder_key,
-                                ) {
-                                    Ok(metadata) => {
-                                        let _ = tx.send(crate::PendingRefresh {
-                                            ino: refresh_ino,
-                                            ipns_name,
-                                            metadata,
-                                            cid: resolve_resp.cid,
-                                        });
-                                    }
-                                    Err(e) => log::warn!("Lookup prefetch decrypt failed: {}", e),
-                                }
-                            }
-                            Err(e) => log::warn!("Lookup prefetch fetch failed: {}", e),
-                        }
-                    }
-                    Err(e) => log::debug!("Lookup prefetch resolve failed for {}: {}", ipns_name, e),
-                }
-            });
+            crate::spawn_metadata_refresh(&fs.rt, fs.api.clone(), fs.refresh_tx.clone(), parent, ipns_name, folder_key);
             reply.error(libc::ENOENT);
             return;
         }

--- a/tests/desktop-e2e/scripts/run-all.ps1
+++ b/tests/desktop-e2e/scripts/run-all.ps1
@@ -112,6 +112,26 @@ if ($BinExitCode -eq 0) {
 }
 Write-Host ""
 
+# ---- Step 6: Cross-client sync ----
+Write-Host "--- Step 6: Cross-client sync ---"
+$SyncExitCode = 0
+try {
+    $env:TEST_SECRET = $TestSecret
+    & "$PSScriptRoot\test-cross-client-sync.ps1" -MountPoint $MountPoint -ApiUrl $ApiUrl
+    $SyncExitCode = $LASTEXITCODE
+} catch {
+    Write-Host "Cross-client sync script error: $($_.Exception.Message)"
+    $SyncExitCode = 1
+}
+
+if ($SyncExitCode -eq 0) {
+    Write-Host "Cross-client sync: ALL PASSED"
+} else {
+    Write-Host "Cross-client sync: $SyncExitCode FAILURE(S)"
+    $TotalFail += $SyncExitCode
+}
+Write-Host ""
+
 # ---- Summary ----
 Write-Host "============================================"
 Write-Host "  Summary"

--- a/tests/desktop-e2e/scripts/test-cross-client-sync.ps1
+++ b/tests/desktop-e2e/scripts/test-cross-client-sync.ps1
@@ -1,0 +1,248 @@
+# test-cross-client-sync.ps1 -- Verify FUSE mount picks up file edits made via SDK (Windows).
+#
+# Usage: .\test-cross-client-sync.ps1 [-MountPoint <path>] [-ApiUrl <url>]
+#   -MountPoint   Path to FUSE mount (default: $env:USERPROFILE\CipherBox)
+#   -ApiUrl       Backend API URL (default: http://localhost:3000)
+#
+# Environment:
+#   TEST_SECRET   Shared secret for test-login (default: e2e-test-secret-ci-only)
+#
+# This test exercises the cross-client sync path:
+# 1. Write a file via the FUSE mount (desktop client)
+# 2. Edit the file via the SDK (simulating a web UI edit)
+# 3. Wait for the FUSE mount to detect the change (IPNS polling)
+# 4. Read the file from the FUSE mount and verify updated content
+#
+# Exit code: number of failed tests (0 = all passed).
+
+param(
+    [string]$MountPoint = "$env:USERPROFILE\CipherBox",
+    [string]$ApiUrl = "http://localhost:3000"
+)
+
+$TestSecret = if ($env:TEST_SECRET) { $env:TEST_SECRET } else { "e2e-test-secret-ci-only" }
+
+$ErrorActionPreference = "Continue"
+
+$TestEmail = "dev-key@cipherbox.local"
+$RepoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\..\.."))
+$TestFile = "sync-test-$(Get-Random).txt"
+$OriginalContent = "Original content from FUSE mount"
+$EditedContent = "Edited content from SDK client"
+
+$Pass = 0
+$Fail = 0
+
+function Test-Pass {
+    param([string]$Name)
+    $script:Pass++
+    Write-Host "PASS: $Name"
+}
+
+function Test-Fail {
+    param([string]$Name)
+    $script:Fail++
+    Write-Host "FAIL: $Name"
+}
+
+function Ensure-SdkRuntime {
+    $paths = @(
+        "packages/sdk-core/dist/index.mjs",
+        "packages/api-client/dist/index.mjs",
+        "packages/core/dist/index.mjs",
+        "packages/crypto/dist/index.mjs"
+    )
+
+    $allExist = $true
+    foreach ($p in $paths) {
+        if (-not (Test-Path (Join-Path $RepoRoot $p))) {
+            $allExist = $false
+            break
+        }
+    }
+
+    if ($allExist) { return }
+
+    Write-Host "Building SDK dependencies..."
+    & pnpm --dir $RepoRoot --filter @cipherbox/crypto build
+    if ($LASTEXITCODE -ne 0) { throw "Failed to build @cipherbox/crypto" }
+    & pnpm --dir $RepoRoot --filter @cipherbox/core build
+    if ($LASTEXITCODE -ne 0) { throw "Failed to build @cipherbox/core" }
+    & pnpm --dir $RepoRoot --filter @cipherbox/api-client build
+    if ($LASTEXITCODE -ne 0) { throw "Failed to build @cipherbox/api-client" }
+    & pnpm --dir $RepoRoot --filter @cipherbox/sdk-core build
+    if ($LASTEXITCODE -ne 0) { throw "Failed to build @cipherbox/sdk-core" }
+}
+
+function Invoke-SdkVerify {
+    param([string]$ExpectedContent)
+    $verifierPath = Join-Path $RepoRoot "packages/sdk-core/scripts/verify-filepointer.mjs"
+    $env:TEST_SECRET = $TestSecret
+    $output = & node $verifierPath `
+        --api-url $ApiUrl `
+        --email $TestEmail `
+        --file-name $TestFile `
+        --expected-content $ExpectedContent 2>&1 | Out-String
+    return @($LASTEXITCODE, $output.Trim())
+}
+
+function Invoke-SdkEdit {
+    param([string]$NewContent)
+    $editorPath = Join-Path $RepoRoot "packages/sdk-core/scripts/edit-filepointer.mjs"
+    $env:TEST_SECRET = $TestSecret
+    $output = & node $editorPath `
+        --api-url $ApiUrl `
+        --email $TestEmail `
+        --file-name $TestFile `
+        --new-content $NewContent 2>&1 | Out-String
+    return @($LASTEXITCODE, $output.Trim())
+}
+
+Write-Host "=== Cross-Client Sync Tests ==="
+Write-Host "Mount point: $MountPoint"
+Write-Host "API URL:     $ApiUrl"
+Write-Host "Test email:  $TestEmail"
+Write-Host "Test file:   $TestFile"
+Write-Host ""
+
+try {
+    Ensure-SdkRuntime
+} catch {
+    Write-Host "FATAL: Failed to build SDK dependencies ($_)"
+    exit 1
+}
+
+# ---- Test 1: Write file via FUSE mount ----
+Write-Host "--- Test 1: Write file via FUSE mount ---"
+try {
+    Set-Content -Path "$MountPoint\$TestFile" -Value $OriginalContent -NoNewline -ErrorAction Stop
+    Start-Sleep -Seconds 2
+    # Trigger readdir to drain upload completions
+    Get-ChildItem -Path $MountPoint -ErrorAction SilentlyContinue | Out-Null
+} catch {
+    Test-Fail "Write file via FUSE mount ($_)"
+    Write-Host "FATAL: Cannot proceed without FUSE write."
+    Write-Host ""
+    Write-Host "=== Cross-Client Sync Results ==="
+    Write-Host "  Passed: $Pass"
+    Write-Host "  Failed: $Fail"
+    Write-Host "=================================="
+    exit $Fail
+}
+
+$FuseContent = $null
+try { $FuseContent = (Get-Content -Path "$MountPoint\$TestFile" -Raw -ErrorAction Stop) } catch {}
+if ($FuseContent -eq $OriginalContent) {
+    Test-Pass "Write file via FUSE mount"
+} else {
+    Test-Fail "Write file via FUSE mount (got: '$FuseContent')"
+}
+
+# ---- Test 2: Wait for file to be visible via SDK ----
+Write-Host "--- Test 2: Wait for file to be visible via SDK ---"
+$SdkVerifyOk = $false
+$VerifyOutput = ""
+for ($attempt = 1; $attempt -le 24 -and -not $SdkVerifyOk; $attempt++) {
+    # Trigger readdir each iteration to drain upload completions
+    try { Get-Item "$MountPoint\$TestFile" -ErrorAction SilentlyContinue | Out-Null } catch {}
+    Get-ChildItem -Path $MountPoint -ErrorAction SilentlyContinue | Out-Null
+    Start-Sleep -Seconds 5
+    $result = Invoke-SdkVerify -ExpectedContent $OriginalContent
+    $exitCode = [int]$result[0]
+    $VerifyOutput = [string]$result[1]
+    if ($exitCode -eq 0) {
+        $SdkVerifyOk = $true
+    } else {
+        Write-Host "  SDK verify attempt ${attempt}: $VerifyOutput"
+    }
+}
+
+if ($SdkVerifyOk) {
+    Test-Pass "File visible and decryptable via SDK"
+    Write-Host "  $VerifyOutput"
+} else {
+    Test-Fail "File not visible via SDK after 120s"
+    Write-Host "FATAL: Cannot proceed without SDK-visible file."
+    Write-Host ""
+    Write-Host "=== Cross-Client Sync Results ==="
+    Write-Host "  Passed: $Pass"
+    Write-Host "  Failed: $Fail"
+    Write-Host "=================================="
+    try { Remove-Item -Path "$MountPoint\$TestFile" -Force -ErrorAction SilentlyContinue } catch {}
+    exit $Fail
+}
+
+# ---- Test 3: Edit file via SDK ----
+Write-Host "--- Test 3: Edit file via SDK ---"
+$editResult = Invoke-SdkEdit -NewContent $EditedContent
+$editExit = [int]$editResult[0]
+$editOutput = [string]$editResult[1]
+if ($editExit -eq 0) {
+    Test-Pass "Edit file via SDK"
+    Write-Host "  $editOutput"
+} else {
+    Test-Fail "Edit file via SDK ($editOutput)"
+    Write-Host "FATAL: Cannot test sync without successful edit."
+    Write-Host ""
+    Write-Host "=== Cross-Client Sync Results ==="
+    Write-Host "  Passed: $Pass"
+    Write-Host "  Failed: $Fail"
+    Write-Host "=================================="
+    try { Remove-Item -Path "$MountPoint\$TestFile" -Force -ErrorAction SilentlyContinue } catch {}
+    exit $Fail
+}
+
+# ---- Test 4: Verify edit persisted via SDK ----
+Write-Host "--- Test 4: Verify edit persisted via SDK ---"
+Start-Sleep -Seconds 2
+$verifyEditResult = Invoke-SdkVerify -ExpectedContent $EditedContent
+$verifyEditExit = [int]$verifyEditResult[0]
+$verifyEditOutput = [string]$verifyEditResult[1]
+if ($verifyEditExit -eq 0) {
+    Test-Pass "Edited content verified via SDK"
+    Write-Host "  $verifyEditOutput"
+} else {
+    Test-Fail "Edited content not verified via SDK ($verifyEditOutput)"
+}
+
+# ---- Test 5: Wait for FUSE mount to pick up edited content ----
+Write-Host "--- Test 5: Wait for FUSE mount to detect edit ---"
+# The FUSE mount polls folder metadata every 30s. After detecting a newer
+# modified_at on the FilePointer, it re-resolves the file's IPNS record
+# to pick up the new CID. Allow up to 120s for two full polling cycles.
+# IMPORTANT: Get-ChildItem triggers readdir which is the ONLY operation
+# that calls drain_refresh_completions() -> populate_folder().
+$SyncOk = $false
+for ($attempt = 1; $attempt -le 24 -and -not $SyncOk; $attempt++) {
+    Start-Sleep -Seconds 5
+    # Trigger readdir to drain refresh completions and detect modified_at changes
+    Get-ChildItem -Path $MountPoint -ErrorAction SilentlyContinue | Out-Null
+    $FuseContent = $null
+    try { $FuseContent = (Get-Content -Path "$MountPoint\$TestFile" -Raw -ErrorAction Stop) } catch {}
+    if ($FuseContent -eq $EditedContent) {
+        $SyncOk = $true
+        Write-Host "  Sync detected on attempt $attempt ($($attempt * 5)s)"
+    } else {
+        Write-Host "  Sync poll attempt ${attempt}: content still original"
+    }
+}
+
+if ($SyncOk) {
+    Test-Pass "FUSE mount picked up edited content"
+} else {
+    Test-Fail "FUSE mount still shows original content after 120s (got: '$FuseContent')"
+}
+
+# ---- Cleanup ----
+Write-Host "--- Cleanup ---"
+try { Remove-Item -Path "$MountPoint\$TestFile" -Force -ErrorAction SilentlyContinue } catch {}
+Start-Sleep -Seconds 2
+
+# ---- Summary ----
+Write-Host ""
+Write-Host "=== Cross-Client Sync Results ==="
+Write-Host "  Passed: $Pass"
+Write-Host "  Failed: $Fail"
+Write-Host "=================================="
+
+exit $Fail

--- a/tests/desktop-e2e/scripts/test-cross-client-sync.ps1
+++ b/tests/desktop-e2e/scripts/test-cross-client-sync.ps1
@@ -210,8 +210,8 @@ Write-Host "--- Test 5: Wait for FUSE mount to detect edit ---"
 # The FUSE mount polls folder metadata every 30s. After detecting a newer
 # modified_at on the FilePointer, it re-resolves the file's IPNS record
 # to pick up the new CID. Allow up to 120s for two full polling cycles.
-# IMPORTANT: Get-ChildItem triggers readdir which is the ONLY operation
-# that calls drain_refresh_completions() -> populate_folder().
+# IMPORTANT: Get-ChildItem triggers readdir which is a reliable operation
+# for calling drain_refresh_completions() -> populate_folder().
 $SyncOk = $false
 for ($attempt = 1; $attempt -le 24 -and -not $SyncOk; $attempt++) {
     Start-Sleep -Seconds 5

--- a/tests/desktop-e2e/scripts/test-cross-client-sync.sh
+++ b/tests/desktop-e2e/scripts/test-cross-client-sync.sh
@@ -165,7 +165,11 @@ echo "--- Test 5: Wait for FUSE mount to detect edit ---"
 SYNC_OK=0
 for attempt in $(seq 1 24); do
   sleep 5
-  # Force a fresh read by stat-ing the file (invalidates macOS file cache)
+  # Trigger readdir to drain refresh completions -- this is the ONLY FUSE
+  # operation that calls drain_refresh_completions() -> populate_folder(),
+  # which detects modified_at changes and marks files for re-resolution.
+  # Without this, stat/cat alone never trigger a metadata refresh.
+  ls "$MP" > /dev/null 2>&1 || true
   stat "$MP/$TEST_FILE" > /dev/null 2>&1 || true
   FUSE_CONTENT=$(cat "$MP/$TEST_FILE" 2>/dev/null || echo "")
   if [ "$FUSE_CONTENT" = "$EDITED_CONTENT" ]; then

--- a/tests/desktop-e2e/scripts/test-cross-client-sync.sh
+++ b/tests/desktop-e2e/scripts/test-cross-client-sync.sh
@@ -165,10 +165,10 @@ echo "--- Test 5: Wait for FUSE mount to detect edit ---"
 SYNC_OK=0
 for attempt in $(seq 1 24); do
   sleep 5
-  # Trigger readdir to drain refresh completions -- this is the ONLY FUSE
-  # operation that calls drain_refresh_completions() -> populate_folder(),
-  # which detects modified_at changes and marks files for re-resolution.
-  # Without this, stat/cat alone never trigger a metadata refresh.
+  # Trigger readdir to reliably drain refresh completions via
+  # drain_refresh_completions() -> populate_folder(), which detects
+  # modified_at changes and marks files for re-resolution. We use `ls`
+  # here because it is a dependable refresh trigger during polling.
   ls "$MP" > /dev/null 2>&1 || true
   stat "$MP/$TEST_FILE" > /dev/null 2>&1 || true
   FUSE_CONTENT=$(cat "$MP/$TEST_FILE" 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

- **Root cause**: The cross-client sync e2e test (added in #454) polled with `stat` + `cat` but never did `ls` on the mount directory. Only `readdir` (triggered by `ls`) calls `drain_refresh_completions()` → `populate_folder()`, which is the only code path that detects `modified_at` changes on FilePointers and triggers IPNS re-resolution. Without it, the FUSE mount never detected remote edits during the 120s polling window.

- **FUSE layer fix**: `handle_lookup` (macOS/Linux) and `handle_open` (Windows) now also check for stale parent folder metadata and spawn background refresh — matching `readdir`'s existing behaviour. This means file access (`stat`, `open`, `cat`) will eventually pick up remote edits without requiring an explicit directory listing.

- **Test fix**: Added `ls` to the Test 5 polling loop in the bash script (most reliable trigger since `DIR_TTL=0` means the kernel never caches directory results).

- **Windows parity**: Added the missing `test-cross-client-sync.ps1` and wired it into `run-all.ps1` as Step 6.

## Changed files

| File | Change |
|------|--------|
| `crates/fuse/src/read_ops.rs` | `handle_lookup` now checks parent folder metadata staleness and spawns background refresh for loaded folders (not just lazy-load) |
| `crates/fuse/src/platform/windows/read_ops.rs` | `handle_open` now calls `drain_refresh_completions()` and checks parent folder staleness |
| `tests/desktop-e2e/scripts/test-cross-client-sync.sh` | Added `ls` to Test 5 polling loop to trigger `readdir` |
| `tests/desktop-e2e/scripts/test-cross-client-sync.ps1` | New Windows PowerShell version of cross-client sync test |
| `tests/desktop-e2e/scripts/run-all.ps1` | Added Step 6 (cross-client sync) to Windows test suite |

## Test plan

- [ ] Desktop E2E tests pass on macOS (cross-client sync Test 5 no longer times out)
- [ ] Desktop E2E tests pass on Linux (same fix)
- [ ] Desktop E2E tests pass on Windows (new PS1 test runs as Step 6)
- [ ] Existing FUSE unit tests pass (37/37 verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic background refresh for folder metadata now triggers from more operations, improving mount consistency and timely updates.

* **Bug Fixes**
  * Prevents duplicate concurrent metadata refreshes and better clears in-flight refresh state for more reliable sync visibility.

* **Tests**
  * Added end-to-end cross-client sync tests and orchestration for Windows and macOS to validate updates across clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->