### PR TITLE
fix(auth): use Web3Auth devnet network for production builds

### DIFF
--- a/apps/desktop/src/auth.ts
+++ b/apps/desktop/src/auth.ts
@@ -55,7 +55,7 @@ const NETWORK_MAP: Record<string, (typeof WEB3AUTH_NETWORK)[keyof typeof WEB3AUT
   local: WEB3AUTH_NETWORK.DEVNET,
   ci: WEB3AUTH_NETWORK.DEVNET,
   staging: WEB3AUTH_NETWORK.DEVNET,
-  production: WEB3AUTH_NETWORK.MAINNET,
+  production: WEB3AUTH_NETWORK.DEVNET,
 };
 
 let coreKit: Web3AuthMPCCoreKit | null = null;

--- a/apps/web/src/lib/web3auth/core-kit.ts
+++ b/apps/web/src/lib/web3auth/core-kit.ts
@@ -7,7 +7,7 @@ const NETWORK_MAP: Record<string, (typeof WEB3AUTH_NETWORK)[keyof typeof WEB3AUT
   local: WEB3AUTH_NETWORK.DEVNET,
   ci: WEB3AUTH_NETWORK.DEVNET,
   staging: WEB3AUTH_NETWORK.DEVNET,
-  production: WEB3AUTH_NETWORK.DEVNET,
+  production: WEB3AUTH_NETWORK.MAINNET,
 };
 
 let instance: Web3AuthMPCCoreKit | null = null;

--- a/apps/web/src/lib/web3auth/core-kit.ts
+++ b/apps/web/src/lib/web3auth/core-kit.ts
@@ -7,7 +7,7 @@ const NETWORK_MAP: Record<string, (typeof WEB3AUTH_NETWORK)[keyof typeof WEB3AUT
   local: WEB3AUTH_NETWORK.DEVNET,
   ci: WEB3AUTH_NETWORK.DEVNET,
   staging: WEB3AUTH_NETWORK.DEVNET,
-  production: WEB3AUTH_NETWORK.MAINNET,
+  production: WEB3AUTH_NETWORK.DEVNET,
 };
 
 let instance: Web3AuthMPCCoreKit | null = null;

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -73,7 +73,7 @@
       "component": "@cipherbox/web",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.40.0"
+      "release-as": "0.41.0"
     },
     "apps/desktop": {
       "release-type": "node",
@@ -84,7 +84,7 @@
         "src-tauri/tauri.conf.json",
         "src-tauri/Cargo.toml"
       ],
-      "release-as": "0.39.0"
+      "release-as": "0.40.0"
     },
     "apps/tee-worker": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

- Production builds set `VITE_ENVIRONMENT=production`, which mapped to `WEB3AUTH_NETWORK.MAINNET` in the network config
- The Web3Auth client ID is registered on `sapphire_devnet`, causing a network mismatch error on login: `Client network mismatch, clientId ... belongs to network: sapphire_devnet, and app is configured on network: sapphire_mainnet`
- Changed `production` mapping to `DEVNET` in both web and desktop Core Kit configs to match the actual client ID registration

## Test plan

- [ ] Production desktop build initializes Web3Auth without network mismatch error
- [ ] Web app production deploy initializes Web3Auth without network mismatch error
- [ ] Login flows (Google, Email, Wallet) work in production builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated production environment network configuration for both web and desktop applications

* **Chores**
  * Incremented web app version to 0.41.0
  * Incremented desktop app version to 0.40.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FSM1/cipher-box/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->