### PR TITLE
fix(web): resolve bin view column header layout conflict

### DIFF
--- a/apps/web/src/components/file-browser/BinBrowser.tsx
+++ b/apps/web/src/components/file-browser/BinBrowser.tsx
@@ -359,7 +359,7 @@ export function BinBrowser() {
       {isLoaded && hasEntries && (
         <div className="file-list bin-list" role="grid" data-testid="bin-list">
           {/* Column headers */}
-          <div className="file-list-header bin-list-header" role="row">
+          <div className="bin-list-header" role="row">
             <button
               type="button"
               className="bin-column-header bin-column-name"


### PR DESCRIPTION
## Summary
- Remove the `file-list-header` class from the bin header element to fix a CSS specificity conflict
- The base `.file-list-header` defines a 3-column grid which was overriding the bin-specific 5-column grid, causing column headers ([NAME], [SIZE], [LOCATION], [DELETED], [TIME LEFT]) to wrap across two rows instead of displaying in a single row

## Test plan
- [x] Verified fix locally against staging API
- [x] Open the Bin view with at least one deleted item and confirm all 5 column headers display in a single horizontal row
- [x] Confirm column sorting still works (click NAME, DELETED, SIZE, TIME LEFT headers)
- [x] Confirm bin list item rows still align with headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual styling of the bin browser header for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FSM1/cipher-box/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->