### PR TITLE
chore(infra): switch staging TEE worker from Phala Cloud to local Docker

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -88,48 +88,6 @@ jobs:
             ${{ env.TEE_IMAGE }}:latest-staging
             ${{ env.TEE_IMAGE }}:${{ env.DEPLOY_TAG }}
 
-  deploy-tee-phala:
-    name: Deploy TEE Worker to Phala Cloud
-    needs: [build-tee]
-    runs-on: ubuntu-latest
-    environment: staging
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.staging_tag || github.ref_name }}
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Install Phala CLI
-        run: npm install -g phala
-
-      - name: Deploy CVM to Phala Cloud
-        env:
-          PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
-          TEE_WORKER_SECRET: ${{ secrets.STAGING_TEE_WORKER_SECRET }}
-        run: |
-          set -euo pipefail
-          OWNER="${{ github.repository_owner }}"
-          export GITHUB_REPOSITORY_OWNER="${OWNER,,}"
-          export TAG="${{ env.DEPLOY_TAG }}"
-
-          # Substitute env vars in compose file
-          envsubst < apps/tee-worker/docker-compose.phala.yml > /tmp/docker-compose.phala.yml
-
-          # Deploy or update CVM (--cvm-id targets existing CVM for update)
-          # CRITICAL: Never delete and recreate -- app_id changes would invalidate all epoch keys
-          phala deploy \
-            --cvm-id cipherbox-tee-staging \
-            -c /tmp/docker-compose.phala.yml \
-            -n cipherbox-tee-staging \
-            -e "TEE_WORKER_SECRET=${TEE_WORKER_SECRET}" \
-            --wait
-
-          # Output CVM info for debugging
-          phala cvms get cipherbox-tee-staging || true
-
   build-web:
     name: Build Web App
     runs-on: ubuntu-latest
@@ -431,7 +389,7 @@ jobs:
 
   deploy-vps:
     name: Deploy to Staging VPS
-    needs: [build-api, build-tee, build-web, deploy-tee-phala]
+    needs: [build-api, build-tee, build-web]
     runs-on: ubuntu-latest
     environment: staging
     permissions:
@@ -470,10 +428,7 @@ jobs:
           THROTTLE_BYPASS_SECRET=${{ secrets.STAGING_THROTTLE_BYPASS_SECRET }}
           REDIS_HOST=redis
           REDIS_PORT=6379
-          # TEE_WORKER_URL: Set PHALA_TEE_WORKER_URL in GitHub staging environment vars
-          # after first CVM deploy. Format: https://{app-id}-3001.dstack-prod{N}.phala.network
-          # Get the URL: phala cvms get cipherbox-tee-staging
-          TEE_WORKER_URL=${{ vars.PHALA_TEE_WORKER_URL }}
+          TEE_WORKER_URL=http://tee-worker:3001
           TEE_WORKER_SECRET=${{ secrets.STAGING_TEE_WORKER_SECRET }}
           REDIS_PASSWORD=${{ secrets.STAGING_REDIS_PASSWORD }}
           GRAFANA_LOKI_URL=${{ vars.GRAFANA_LOKI_URL }}

--- a/docker/docker-compose.staging.yml
+++ b/docker/docker-compose.staging.yml
@@ -93,6 +93,7 @@ services:
     environment:
       PORT: 3001
       TEE_MODE: simulator
+      CIPHERBOX_ENVIRONMENT: staging
       TEE_WORKER_SECRET: ${TEE_WORKER_SECRET}
     logging: *default-logging
     healthcheck:

--- a/docker/docker-compose.staging.yml
+++ b/docker/docker-compose.staging.yml
@@ -87,9 +87,25 @@ services:
           memory: 2G
           cpus: '1.0'
 
-  # TEE worker runs on Phala Cloud CVM (not in this compose stack)
-  # Endpoint configured via TEE_WORKER_URL in .env.staging
-  # Deploy separately: phala deploy -c apps/tee-worker/docker-compose.phala.yml -n cipherbox-tee-staging
+  tee-worker:
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-OWNER}/cipherbox-tee-worker:${TAG:-latest}
+    restart: unless-stopped
+    environment:
+      PORT: 3001
+      TEE_MODE: simulator
+      TEE_WORKER_SECRET: ${TEE_WORKER_SECRET}
+    logging: *default-logging
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:3001/health || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: '0.5'
 
   someguy:
     image: ghcr.io/ipfs/someguy:v0.11.1


### PR DESCRIPTION
## Summary
- Replace Phala Cloud CVM deployment with a locally-hosted TEE worker running in simulator mode on the staging VPS
- Reduces hosting costs by eliminating the Phala Cloud dependency for staging
- Add `tee-worker` service to `docker-compose.staging.yml` (simulator mode, internal network only)
- Remove `deploy-tee-phala` CI job and Phala CLI dependency from `deploy-staging.yml`
- Point `TEE_WORKER_URL` to internal Docker network (`http://tee-worker:3001`)

**Breaking:** Existing IPNS keys encrypted with the Phala CVM epoch public key will not be decryptable by the simulator. Staging users will need to re-register.

## Test plan
- [ ] Deploy to staging and verify TEE worker health endpoint responds (`/health`)
- [ ] Verify API connects to TEE worker on startup (check logs for epoch initialization)
- [ ] Register a new vault and confirm IPNS republishing works end-to-end
- [ ] Confirm `PHALA_CLOUD_API_KEY` secret can be removed from GitHub staging environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)