### PR TITLE
fix: bind pinning provider fetch fallback to globalThis for browser compatibility

### DIFF
--- a/.planning/ENVIRONMENTS.md
+++ b/.planning/ENVIRONMENTS.md
@@ -17,12 +17,12 @@ CipherBox requires isolated environments to prevent cross-environment interferen
 
 ## Environment Matrix
 
-| Environment    | IPFS Mode      | Web3Auth Network | IPNS Routing           | Database            | TEE Republishing     | Isolation Level            |
-| -------------- | -------------- | ---------------- | ---------------------- | ------------------- | -------------------- | -------------------------- |
-| **Local Dev**  | Kubo (offline) | Sapphire Devnet  | Mock service           | Local Postgres      | **Disabled**         | Full                       |
-| **CI E2E**     | Kubo (offline) | Sapphire Devnet  | Mock service (per-run) | Ephemeral Postgres  | **Disabled**         | Full per-run               |
-| **Staging**    | Kubo (online)  | Sapphire Devnet  | Self-hosted Someguy    | Managed Postgres    | **Phala Cloud CVM** (production infra, free tier) | Shared with Local/CI users |
-| **Production** | Kubo (managed) | Sapphire Mainnet | delegated-ipfs.dev     | Production Postgres | **Active** (mainnet) | Full                       |
+| Environment    | IPFS Mode      | Web3Auth Network | IPNS Routing           | Database            | TEE Republishing                      | Isolation Level            |
+| -------------- | -------------- | ---------------- | ---------------------- | ------------------- | ------------------------------------- | -------------------------- |
+| **Local Dev**  | Kubo (offline) | Sapphire Devnet  | Mock service           | Local Postgres      | **Disabled**                          | Full                       |
+| **CI E2E**     | Kubo (offline) | Sapphire Devnet  | Mock service (per-run) | Ephemeral Postgres  | **Disabled**                          | Full per-run               |
+| **Staging**    | Kubo (online)  | Sapphire Devnet  | Self-hosted Someguy    | Managed Postgres    | **Docker simulator** (on staging VPS) | Shared with Local/CI users |
+| **Production** | Kubo (managed) | Sapphire Mainnet | delegated-ipfs.dev     | Production Postgres | **Active** (mainnet)                  | Full                       |
 
 ## Solution: Environment-Aware Key Derivation
 
@@ -405,17 +405,16 @@ export const web3AuthOptions: Web3AuthOptions = {
 
 ### API (NestJS)
 
-| Variable                | Local                   | CI                      | Staging               | Production                   |
-| ----------------------- | ----------------------- | ----------------------- | --------------------- | ---------------------------- |
-| `NODE_ENV`              | development             | test                    | production            | production                   |
-| `CIPHERBOX_ENVIRONMENT` | local                   | ci                      | staging               | production                   |
-| `DB_DATABASE`           | cipherbox_local         | cipherbox_ci            | cipherbox_staging     | cipherbox_prod               |
-| `IPFS_PROVIDER`         | local                   | local                   | local                 | local                        |
-| `DELEGATED_ROUTING_URL` | <http://localhost:3001> | <http://localhost:3001> | <http://someguy:8190> | <https://delegated-ipfs.dev> |
-| `JWT_SECRET`            | dev-secret              | ci-secret               | secrets.JWT_STAGING   | secrets.JWT_PROD             |
-| `TEE_ENABLED`           | **false**               | **false**               | true                  | true                         |
-| `TEE_PROVIDER`          | -                       | -                       | phala                 | phala                        |
-| `PHALA_API_URL`         | -                       | -                       | cloud.phala.network   | cloud.phala.network          |
+| Variable                | Local                      | CI                      | Staging                           | Production                   |
+| ----------------------- | -------------------------- | ----------------------- | --------------------------------- | ---------------------------- |
+| `NODE_ENV`              | development                | test                    | production                        | production                   |
+| `CIPHERBOX_ENVIRONMENT` | local                      | ci                      | staging                           | production                   |
+| `DB_DATABASE`           | cipherbox_local            | cipherbox_ci            | cipherbox_staging                 | cipherbox_prod               |
+| `IPFS_PROVIDER`         | local                      | local                   | local                             | local                        |
+| `DELEGATED_ROUTING_URL` | <http://localhost:3001>    | <http://localhost:3001> | <http://someguy:8190>             | <https://delegated-ipfs.dev> |
+| `JWT_SECRET`            | dev-secret                 | ci-secret               | secrets.JWT_STAGING               | secrets.JWT_PROD             |
+| `TEE_WORKER_URL`        | optional (local simulator) | -                       | <http://tee-worker:3001>          | Phala CVM HTTPS endpoint     |
+| `TEE_WORKER_SECRET`     | optional (local simulator) | -                       | secrets.STAGING_TEE_WORKER_SECRET | secrets (prod)               |
 
 ## TEE Infrastructure by Environment
 
@@ -423,12 +422,12 @@ The TEE (Trusted Execution Environment) layer handles IPNS republishing to preve
 
 ### TEE Environment Matrix
 
-| Environment    | TEE Infrastructure     | IPNS Republishing | Monitoring        | Cleanup                    |
-| -------------- | ---------------------- | ----------------- | ----------------- | -------------------------- |
-| **Local Dev**  | None                   | Not needed        | None              | User resets to clean slate |
-| **CI E2E**     | None                   | Not needed        | None              | Ephemeral per-run          |
-| **Staging**    | Phala Cloud CVM (prod infra, free tier) | Every 3 hours     | Integration tests | Periodic DHT cleanup       |
-| **Production** | Active (Phala mainnet) | Every 3 hours     | Full alerting     | Automated stale detection  |
+| Environment    | TEE Infrastructure             | IPNS Republishing | Monitoring        | Cleanup                    |
+| -------------- | ------------------------------ | ----------------- | ----------------- | -------------------------- |
+| **Local Dev**  | None                           | Not needed        | None              | User resets to clean slate |
+| **CI E2E**     | None                           | Not needed        | None              | Ephemeral per-run          |
+| **Staging**    | Docker simulator (staging VPS) | Every 3 hours     | Integration tests | Periodic DHT cleanup       |
+| **Production** | Active (Phala mainnet)         | Every 3 hours     | Full alerting     | Automated stale detection  |
 
 ### Local Development: No TEE
 
@@ -449,8 +448,8 @@ TEE_ENABLED=false
 
 **When working on TEE features locally:**
 
-- Use staging environment for TEE development/testing
-- Or run mock TEE service (future: `tools/mock-tee-service`)
+- Run the real TEE worker in Docker simulator mode (same image as staging): build from `apps/tee-worker/Dockerfile`, run with `TEE_MODE=simulator`, and point the API at it via `TEE_WORKER_URL` + `TEE_WORKER_SECRET`
+- Simulator keys are HKDF-derived from a fixed seed, so they are deterministic across restarts
 
 ### CI E2E Testing: No TEE
 
@@ -476,72 +475,56 @@ env:
 - Each test suite starts with fresh vault state
 - IPNS sequence numbers start at 1 for each test user
 
-### Staging Environment: Active TEE with Phala Cloud CVM
+### Staging Environment: Active TEE with Local Docker Simulator
 
-**Purpose:** Integration testing of full CipherBox + TEE + public IPFS stack using hardware-backed key derivation
+**Purpose:** Integration testing of the full CipherBox + TEE + public IPFS stack with real republish cycles (simulator-mode key derivation, not hardware-backed)
 
 **Infrastructure:**
 
-The staging TEE worker runs as a Phala Cloud CVM (Confidential Virtual Machine) on Phala's production infrastructure (free tier, $20 credit). Phala Cloud has no separate testnet — the free tier runs on the same production nodes (Intel TDX hardware) as paid deployments.
+The staging TEE worker runs as a Docker Compose service on the staging VPS in simulator mode. The Phase 35 Phala Cloud CVM deployment was retired in PR #472 (f270d843a, 2026-05-27) to eliminate Phala Cloud hosting costs for staging. Phala Cloud CVM remains the production design — `apps/tee-worker/docker-compose.phala.yml` and the `TEE_MODE=cvm` code path are kept for that purpose.
 
-| Property          | Value                                                              |
-| ----------------- | ------------------------------------------------------------------ |
-| CVM Name          | `cipherbox-tee-staging`                                            |
-| Image             | `ghcr.io/{owner}/cipherbox-tee-worker:{tag}` (GHCR)               |
-| Endpoint          | `https://{app-id}-3001.dstack-prod{N}.phala.network`               |
-| Key Derivation    | Hardware-backed via `DstackClient.getKey()` (`@phala/dstack-sdk`)  |
-| Socket            | `/var/run/dstack.sock` (mounted inside CVM)                        |
-| TEE Mode          | `TEE_MODE=cvm` (env var inside CVM)                               |
-| CI/CD             | `deploy-tee-phala` job in `deploy-staging.yml`                     |
-
-```yaml
-# apps/tee-worker/docker-compose.phala.yml (deployed to Phala Cloud)
-services:
-  tee-worker:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/cipherbox-tee-worker:${TAG:-latest}
-    volumes:
-      - /var/run/dstack.sock:/var/run/dstack.sock
-    environment:
-      TEE_MODE: cvm
-      PORT: 3001
-    ports:
-      - "3001:3001"
-```
+| Property       | Value                                                                                    |
+| -------------- | ---------------------------------------------------------------------------------------- |
+| Service        | `tee-worker` in `docker/docker-compose.staging.yml`                                      |
+| Image          | `ghcr.io/{owner}/cipherbox-tee-worker:{tag}` (GHCR)                                      |
+| Endpoint       | `http://tee-worker:3001` (internal Docker network only)                                  |
+| Key Derivation | HKDF-SHA256 from a deterministic seed (simulator mode)                                   |
+| TEE Mode       | `TEE_MODE=simulator`, `CIPHERBOX_ENVIRONMENT=staging`                                    |
+| CI/CD          | Deployed by the `deploy-vps` job in `deploy-staging.yml` alongside the rest of the stack |
 
 ```yaml
 # docker/docker-compose.staging.yml (on staging VPS)
-# TEE worker is NOT deployed locally -- it runs externally on Phala Cloud
-# Only API, web, and supporting services are deployed on the staging VPS
+tee-worker:
+  image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-OWNER}/cipherbox-tee-worker:${TAG:-latest}
+  restart: unless-stopped
+  environment:
+    PORT: 3001
+    TEE_MODE: simulator
+    CIPHERBOX_ENVIRONMENT: staging
+    TEE_WORKER_SECRET: ${TEE_WORKER_SECRET}
 ```
 
 **Configuration:**
 
 ```bash
-# apps/api/.env.staging
-TEE_ENABLED=true
-TEE_PROVIDER=phala
-TEE_WORKER_URL=https://{app-id}-3001.dstack-prod{N}.phala.network  # External Phala Cloud CVM endpoint
-PHALA_API_URL=https://cloud.phala.network/api/v1
-PHALA_CONTRACT_ID=${{ secrets.PHALA_CONTRACT_ID_STAGING }}
-PHALA_API_KEY=${{ secrets.PHALA_API_KEY_STAGING }}
-
-# Republish schedule (production-like)
-TEE_REPUBLISH_INTERVAL_HOURS=3
-TEE_KEY_EPOCH_ROTATION_WEEKS=4
+# .env.staging (generated by deploy-staging.yml)
+TEE_WORKER_URL=http://tee-worker:3001
+TEE_WORKER_SECRET=<from STAGING_TEE_WORKER_SECRET environment secret>
 ```
 
-**CVM Identity Preservation:**
+**Simulator Caveats:**
 
-> **CRITICAL:** Do NOT delete and recreate the CVM. Each CVM has a unique identity derived from the hardware attestation. Deleting a CVM destroys the TEE keypair, orphaning all IPNS records encrypted with the old public key. Instead, use `phala cvms update` to deploy new image versions to the existing CVM.
+- Keys are NOT hardware-backed: they are deterministically derived (HKDF-SHA256) from a seed, so the zero-knowledge guarantee does not hold in staging — the operator could derive the keys. Acceptable for integration testing only.
+- Key epochs and the 4-week rotation grace period behave identically to CVM mode.
 
-**Migration Note (Phase 35):**
+**Infrastructure History (Phases 35 and post-35):**
 
-Phase 35 migrated the staging TEE from a local Docker container running in simulator mode (HKDF-based deterministic keys from `TEE_SIMULATOR_SEED`) to a real Phala Cloud CVM with hardware-backed key derivation. This means:
+Phase 35 migrated the staging TEE from a local Docker simulator to a real Phala Cloud CVM with hardware-backed key derivation (`dstack` SDK). PR #472 later reversed this for staging to cut costs, returning to the Docker simulator on the VPS. Consequences of the reversal:
 
-- TEE public keys are now derived from hardware attestation (not a seed)
-- All existing `encryptedIpnsPrivateKey` values encrypted with the old simulator key are invalid
-- Users must re-publish from client to re-encrypt IPNS keys with the new CVM public key
-- The staging API's `TEE_WORKER_URL` changed from `http://tee-worker:3001` (local) to an external HTTPS Phala Cloud endpoint
+- TEE public keys are again derived from the simulator seed (not hardware attestation)
+- `encryptedIpnsPrivateKey` values encrypted with the CVM-era epoch public key cannot be decrypted by the simulator — staging users from that era must re-register/re-publish
+- The staging API's `TEE_WORKER_URL` changed back from the external Phala HTTPS endpoint to internal `http://tee-worker:3001`
+- The CVM deployment path (`TEE_MODE=cvm`, `docker-compose.phala.yml`, dstack SDK) is no longer exercised by any deployed environment until production launches
 
 **Staging-Specific Challenges:**
 
@@ -556,7 +539,7 @@ Phase 35 migrated the staging TEE from a local Docker container running in simul
    - No automatic cleanup (IPNS records naturally expire after 24h without republish)
 
 3. **TEE Key Epochs**
-   - Staging TEE uses production-infra keys on free tier (same hardware as paid deployments)
+   - Staging TEE uses deterministic simulator keys (HKDF from seed, not hardware-backed)
    - 4-week grace period still applies
 
 **Staging Cleanup Strategy:**
@@ -609,9 +592,13 @@ describe('TEE IPNS Republishing', () => {
 
 **Infrastructure:**
 
-- Phala Cloud mainnet contract
+- Phala Cloud CVM (hardware-backed key derivation via dstack SDK; deployed with `apps/tee-worker/docker-compose.phala.yml`, `TEE_MODE=cvm`)
 - Dedicated republishing cron (scales with user count)
 - Full observability stack
+
+**CVM Identity Preservation:**
+
+> **CRITICAL:** Do NOT delete and recreate the CVM. Each CVM has a unique identity derived from the hardware attestation. Deleting a CVM destroys the TEE keypair, orphaning all IPNS records encrypted with the old public key. Instead, use `phala cvms update` to deploy new image versions to the existing CVM.
 
 **Configuration:**
 
@@ -679,13 +666,13 @@ TEE_ALERT_STALE_THRESHOLD_HOURS=12
 
 ### Diagnosis
 
-1. Check TEE service health: `curl https://api.phala.network/health`
+1. Check TEE worker health: `curl $TEE_WORKER_URL/health` (staging: internal to the VPS Docker network — check via SSH or container healthcheck status; production: Phala CVM HTTPS endpoint)
 2. Check backend cron status: `systemctl status cipherbox-republish`
 3. Query stale records: `SELECT COUNT(*) FROM folder_ipns WHERE last_republish_at < NOW() - INTERVAL '20 hours'`
 
 ### Resolution
 
-1. If TEE service down: Wait for Phala recovery, records have 24h TTL buffer
+1. If TEE worker down: restart the container (staging) or wait for Phala recovery (production); records have 24h TTL buffer
 2. If cron stopped: Restart cron, monitor catch-up
 3. If specific records failing: Check encryptedIpnsPrivateKey validity, may need user to re-publish
 
@@ -887,7 +874,7 @@ Records encrypted with an expired epoch that were not re-encrypted during the gr
 
 #### Phase 3: Staging Integration Testing
 
-- [ ] Deploy TEE to staging with Phala Cloud credentials
+- [ ] Deploy TEE worker to staging (Docker simulator on the staging VPS since PR #472)
 - [ ] Create integration test suite for republishing
 - [ ] Implement staging cleanup job
 - [ ] Add CI job for periodic staging health check

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -182,11 +182,11 @@ The TypeScript and Rust SDKs implement the same data model and crypto operations
 - Write path: `write()` -> temp file -> `release()` -> encrypt + upload (background)
 - Read path: `open()` -> async prefetch -> `read()` -> cache check -> return or EIO
 
-### TEE Worker (`tee-worker/`)
+### TEE Worker (`apps/tee-worker/`)
 
-**Purpose:** Automatic IPNS republishing without user devices online. Runs in Phala Cloud CVM.
+**Purpose:** Automatic IPNS republishing without user devices online. Runs as a Docker simulator on the staging VPS (since PR #472); Phala Cloud CVM in production.
 
-**Entry point:** `tee-worker/src/index.ts`
+**Entry point:** `apps/tee-worker/src/index.ts`
 
 **Framework:** Express.js (standalone, not part of pnpm workspace)
 
@@ -360,9 +360,9 @@ type FileMetadata = {
 
 **TEE Worker:**
 
-- Location: `tee-worker/src/index.ts`
+- Location: `apps/tee-worker/src/index.ts`
 - Dev: `pnpm --filter cipherbox-tee-worker dev`
-- Deployed: Phala Cloud CVM
+- Deployed: Docker Compose service on the staging VPS, simulator mode (Phala Cloud CVM in production)
 
 **API Client Generation:**
 

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -166,7 +166,7 @@ Previous known bugs (upload modal stuck, auth refresh race) were fixed in PRs #5
 **Phala Cloud CVM deployment (single provider):**
 
 - Files: `apps/tee-worker/src/services/tee-keys.ts`, `apps/tee-worker/src/index.ts`
-- Why fragile: Phase 35 migrated TEE to Phala Cloud CVM using the dstack SDK (`@phala/dstack-sdk`). There is no fallback TEE provider — the previous AWS Nitro fallback option was not implemented. The dstack SDK is dynamically imported only inside `TEE_MODE=cvm`, making it unavailable for local testing without a CVM.
+- Why fragile: Phase 35 migrated TEE to Phala Cloud CVM using the dstack SDK (`@phala/dstack-sdk`). There is no fallback TEE provider — the previous AWS Nitro fallback option was not implemented. The dstack SDK is dynamically imported only inside `TEE_MODE=cvm`, making it unavailable for local testing without a CVM. Since PR #472 reverted staging to simulator mode, no deployed environment exercises the CVM path until production launches — it can bitrot silently.
 - Safe modification: Key derivation and signing logic is tested via unit tests with `TEE_MODE=test`. Production CVM changes require Phala console deployment.
 - Test coverage: `apps/tee-worker/src/__tests__/tee-keys.test.ts` covers the test-mode derivation path. The CVM code path itself is not unit-testable outside a real Phala CVM.
 
@@ -225,7 +225,7 @@ Previous known bugs (upload modal stuck, auth refresh race) were fixed in PRs #5
 **@phala/dstack-sdk:**
 
 - Risk: Phala-specific SDK for CVM key derivation. Tightly coupled to Phala Cloud infrastructure. No alternative provider is implemented.
-- Impact: If Phala Cloud has an outage or breaking API change, the TEE republishing pipeline stops. No fallback means IPNS records eventually expire (48-hour TTL).
+- Impact: If Phala Cloud has an outage or breaking API change, the production TEE republishing pipeline stops (staging is unaffected since PR #472 — it runs simulator mode). No fallback means IPNS records eventually expire (48-hour TTL).
 - Migration plan: Abstract key derivation behind an interface so alternative providers (AWS Nitro Enclaves, Azure Confidential Computing) can be plugged in. Currently blocked by the complexity of re-implementing key derivation + epoch management for a second provider.
 
 ## Missing Critical Features

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -36,13 +36,13 @@
 
 **TEE Providers:**
 
-- Phala Cloud CVM (Primary) - TEE-based IPNS key decryption and record signing
-  - Worker: `tee-worker/src/`
+- Phala Cloud CVM (production target) - TEE-based IPNS key decryption and record signing. Staging runs the same worker as a local Docker service in simulator mode since PR #472.
+  - Worker: `apps/tee-worker/src/`
   - Routes: `GET /health`, `GET /public-key`, `POST /republish`, `POST /migrate`, `POST /connection-test`
-  - Features: Intel SGX hardware attestation, key epoch rotation
+  - Features: Intel TDX hardware attestation (CVM mode only), key epoch rotation
   - Schedule: Every 6 hours via backend cron
   - Enrollment: `apps/api/src/republish/republish.service.ts`
-  - Docker Compose: `tee-worker/docker-compose.yml` (mounts `/var/run/tappd.sock` for TEE attestation)
+  - Docker Compose: `apps/tee-worker/docker-compose.phala.yml` for CVM (mounts `/var/run/dstack.sock`); `docker/docker-compose.staging.yml` for the staging simulator
   - Env: `TEE_WORKER_URL`, `TEE_WORKER_SECRET`, `TEE_MODE` (cvm/simulator)
   - Auth: Shared secret via `TEE_WORKER_SECRET`
 

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -95,11 +95,11 @@ defineConfig({
 
 ### TEE Worker (`apps/tee-worker/`)
 
-| Component          | Framework | Purpose                                                                    |
-| ------------------ | --------- | -------------------------------------------------------------------------- |
-| `apps/tee-worker`  | Express 4 | Standalone TEE worker deployed as Phala Cloud CVM -- IPNS republishing     |
+| Component         | Framework | Purpose                                                                                                 |
+| ----------------- | --------- | ------------------------------------------------------------------------------------------------------- |
+| `apps/tee-worker` | Express 4 | Standalone TEE worker -- IPNS republishing (Docker simulator in staging, Phala Cloud CVM in production) |
 
-The tee-worker is part of the pnpm workspace (since Phase 35 migration to `apps/`). It uses workspace dependencies for shared packages (`@cipherbox/crypto`, `@cipherbox/core`, `@cipherbox/sdk-core`) and is deployed independently as a Phala Cloud CVM via Docker (node:20-alpine).
+The tee-worker is part of the pnpm workspace (since Phase 35 migration to `apps/`). It uses workspace dependencies for shared packages (`@cipherbox/crypto`, `@cipherbox/core`, `@cipherbox/sdk-core`) and is deployed as a Docker service (node:20-alpine) — simulator mode on the staging VPS since PR #472; Phala Cloud CVM (`TEE_MODE=cvm`) is the production target.
 
 ### Test Suites (`tests/`)
 
@@ -164,7 +164,7 @@ Used by both TypeScript (`@cipherbox/crypto`) and Rust (`cipherbox-crypto`) to v
 
 **Deployment:**
 
-- phala CLI 1.1.13+ - Phala Cloud CVM deployment and management (CI/CD only, `npm install -g phala`)
+- phala CLI 1.1.13+ - Phala Cloud CVM deployment and management (`npm install -g phala`; no longer used in CI since PR #472 retired the staging CVM — kept for manual CVM management and future production deploys)
 
 **Code Quality:**
 
@@ -306,9 +306,9 @@ Used by both TypeScript (`@cipherbox/crypto`) and Rust (`cipherbox-crypto`) to v
 
 **Shared workspace packages:**
 
-- `@cipherbox/crypto` workspace:* - Cryptographic primitives (ECIES, Ed25519, HKDF, IPNS)
-- `@cipherbox/core` workspace:* - Domain types, metadata schemas, IPNS record creation
-- `@cipherbox/sdk-core` workspace:* - Stateless orchestration (pinning providers, IPFS operations)
+- `@cipherbox/crypto` workspace:\* - Cryptographic primitives (ECIES, Ed25519, HKDF, IPNS)
+- `@cipherbox/core` workspace:\* - Domain types, metadata schemas, IPNS record creation
+- `@cipherbox/sdk-core` workspace:\* - Stateless orchestration (pinning providers, IPFS operations)
 
 **TEE-specific dependencies:**
 
@@ -482,7 +482,7 @@ pnpm --filter @cipherbox/api migration:generate   # Generate migration from enti
 
 - VPS at 76.13.151.200 (Hostinger)
 - Docker Compose: API (node:22-alpine) + supporting services
-- TEE Worker: External Phala Cloud CVM (node:20-alpine Docker image on GHCR)
+- TEE Worker: local Docker Compose service in simulator mode (node:20-alpine image on GHCR; was an external Phala Cloud CVM until PR #472)
 - Caddy reverse proxy for HTTPS
 - Domains: `api-staging.cipherbox.cc`, `app-staging.cipherbox.cc`
 - Container registry: `ghcr.io`
@@ -510,7 +510,7 @@ pnpm --filter @cipherbox/api migration:generate   # Generate migration from enti
 | `ci.yml`             | PR to main                           | Lint, typecheck, test, build, API spec verify, migration drift check, Cargo check/test on 3 platforms, vector parity |
 | `e2e.yml`            | Push to main, dispatch               | Web E2E tests with Playwright                                                                                        |
 | `release-please.yml` | Push to main                         | Create/update release PR, publish GitHub Releases                                                                    |
-| `deploy-staging.yml` | Push `staging-v*` tag, workflow_call | Build Docker images, deploy API/web to staging VPS, deploy TEE worker to Phala Cloud CVM                             |
+| `deploy-staging.yml` | Push `staging-v*` tag, workflow_call | Build Docker images, deploy API/web/TEE worker to staging VPS                                                        |
 | `build-desktop.yml`  | -                                    | Desktop app build                                                                                                    |
 | `desktop-e2e.yml`    | -                                    | Desktop E2E tests                                                                                                    |
 | `load-test.yml`      | -                                    | Load test runs                                                                                                       |

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -53,7 +53,7 @@ cipher-box/
 │   │       │   └── updater.rs     # Auto-updater
 │   │       ├── vendor/fuser/      # Vendored fuser crate (socket-read patch for FUSE-T)
 │   │       └── Cargo.toml         # Desktop crate dependencies
-│   ├── tee-worker/                # TEE IPNS republishing worker (Phala Cloud CVM)
+│   ├── tee-worker/                # TEE IPNS republishing worker (simulator in staging, Phala Cloud CVM in production)
 │   │   └── src/
 │   │       ├── __tests__/         # Unit tests (Vitest)
 │   │       ├── middleware/        # Auth middleware (auth.ts)
@@ -309,7 +309,7 @@ cipher-box/
 
 **`apps/tee-worker/`:**
 
-- Purpose: Standalone TEE worker deployed as Phala Cloud CVM for automatic IPNS republishing every 3 hours
+- Purpose: Standalone TEE worker for automatic IPNS republishing every 3 hours (Docker simulator on the staging VPS since PR #472; Phala Cloud CVM in production)
 - Contains: Express routes, IPNS signer, key manager, SSRF validation, migration worker, Prometheus metrics
 - Uses shared workspace packages: `@cipherbox/crypto`, `@cipherbox/core`, `@cipherbox/sdk-core`
 - Uses `@phala/dstack-sdk` for hardware-backed key derivation inside CVM

--- a/.planning/phases/19.1-extract-core-crypto-sdk-as-shared-package/19.1-UAT.md
+++ b/.planning/phases/19.1-extract-core-crypto-sdk-as-shared-package/19.1-UAT.md
@@ -90,6 +90,7 @@ blocked: 0
   - 'Browser-context regression test for external pinning mode (jsdom/playwright) — Node-based tests cannot catch this-binding bugs'
     debug_session: ''
     source_phase: '21-byo-ipfs-node-support'
+    resolution: 'Fixed in 9789efa8f on fix/pinning-provider-fetch-binding - fetchFn fallback bound in both providers, this-sensitive regression tests added'
 
 - truth: 'Recycle bin rows show the deleted file size'
   status: failed

--- a/.planning/phases/19.1-extract-core-crypto-sdk-as-shared-package/19.1-UAT.md
+++ b/.planning/phases/19.1-extract-core-crypto-sdk-as-shared-package/19.1-UAT.md
@@ -1,0 +1,112 @@
+---
+status: complete
+phase: 19.1-extract-core-crypto-sdk-as-shared-package
+source: 19.1-VERIFICATION.md (human_verification items)
+started: 2026-06-10T00:00:00Z
+updated: 2026-06-10T13:05:00Z
+---
+
+## Current Test
+
+[testing complete]
+
+## Tests
+
+### 1. Upload a file to the root folder
+
+expected: Upload completes, file appears in the root folder view automatically (no manual refresh), no console errors related to SDK events or IPNS publishing
+result: pass
+note: Passed under pinning mode "cipherbox" (default relay path). First attempt under the account's prior "external only" mode failed instantly — see Gaps (bug belongs to Phase 21 BYO-node surface, not a 19.1 SDK regression).
+
+### 2. Create a new subfolder
+
+expected: New subfolder appears in the folder tree immediately after creation, no console errors
+result: pass
+
+### 3. Move the file into the subfolder
+
+expected: File disappears from root and appears inside the subfolder; folder tree updates automatically
+result: pass
+
+### 4. Rename the subfolder
+
+expected: Subfolder shows the new name immediately in the tree and breadcrumbs; contents unaffected
+result: pass
+
+### 5. Delete the file to recycle bin
+
+expected: File is removed from the subfolder view and the operation completes without errors
+result: pass
+note: Delete confirm dialog copy says "This cannot be undone" but the file goes to the recycle bin and is restorable — misleading copy (cosmetic, see Gaps)
+
+### 6. Recycle bin shows the deleted file
+
+expected: Opening the recycle bin shows the deleted file listed
+result: pass
+note: Bin row shows size "0 B" for a 2.1 KB file (minor, see Gaps); origin path and retention (30d) display correctly
+
+### 7. Restore the file from the recycle bin
+
+expected: Restore action completes without errors and the file leaves the recycle bin
+result: pass
+
+### 8. Restored file returns to its original folder
+
+expected: The restored file is back in the subfolder it was deleted from
+result: pass
+
+### 9. Logout and re-login lifecycle
+
+expected: After logout the SDK client is destroyed (no stale state); after re-login the vault loads correctly and all previously created folders/files are visible
+result: pass
+note: Logout returns to login screen with folder store cleared (folders={}). Re-login restores full vault (all folders/files incl. items created this session) with zero console errors. Verified twice — once after full browser restart, once same-SPA-session logout/re-login. An earlier RangeError flood during one re-login was traced to test instrumentation (console/XHR wrappers), not the app: 2/2 clean attempts pass.
+
+## Summary
+
+total: 9
+passed: 9
+issues: 0
+pending: 0
+skipped: 0
+blocked: 0
+
+## Gaps
+
+- truth: 'Uploads succeed when vault pinning mode is "external only" or "dual-pin" (BYO IPFS node)'
+  status: failed
+  reason: 'Upload fails instantly at 0% with no network request. Error stored on upload row: "Failed to execute ''fetch'' on ''Window'': Illegal invocation"'
+  severity: major
+  test: 1
+  root_cause: 'KuboProvider and PsaProvider default to unbound globalThis.fetch (packages/sdk-core/src/pinning/kubo-provider.ts:22, psa-provider.ts:41) and invoke it as this.fetchFn(url) — native fetch called with this=provider instance throws Illegal invocation in browsers. Node fetch is not this-sensitive, so all automated tests pass; only real browsers hit it. packages/sdk/src/client.ts:90-94 constructs providers without passing fetchFn. Browser-only, latent since Phase 21 (byo-ipfs-node-support).'
+  artifacts:
+  - path: 'packages/sdk-core/src/pinning/kubo-provider.ts'
+    issue: 'this.fetchFn = options?.fetchFn ?? globalThis.fetch — unbound native fetch'
+  - path: 'packages/sdk-core/src/pinning/psa-provider.ts'
+    issue: 'same unbound-fetch fallback pattern'
+  - path: 'packages/sdk/src/client.ts'
+    issue: 'provider construction never passes fetchFn'
+    missing:
+  - 'Bind the fallback: globalThis.fetch.bind(globalThis) in kubo-provider.ts and psa-provider.ts (PinataProvider uses bare fetch(...) calls and is unaffected)'
+  - 'Browser-context regression test for external pinning mode (jsdom/playwright) — Node-based tests cannot catch this-binding bugs'
+    debug_session: ''
+    source_phase: '21-byo-ipfs-node-support'
+
+- truth: 'Recycle bin rows show the deleted file size'
+  status: failed
+  reason: 'Bin row for uat-19-1-test.txt showed "0 B"; actual size 2.1 KB (correct again after restore — display/metadata issue in bin view only)'
+  severity: minor
+  test: 6
+  root_cause: ''
+  artifacts: []
+  missing: []
+  debug_session: ''
+
+- truth: 'Delete confirmation copy matches actual behavior (file is recoverable from bin for 30d)'
+  status: failed
+  reason: 'Dialog says "This cannot be undone." but the file is restorable from the recycle bin (verified by tests 6-8)'
+  severity: cosmetic
+  test: 5
+  root_cause: ''
+  artifacts: []
+  missing: []
+  debug_session: ''

--- a/.planning/phases/19.1-extract-core-crypto-sdk-as-shared-package/19.1-VERIFICATION.md
+++ b/.planning/phases/19.1-extract-core-crypto-sdk-as-shared-package/19.1-VERIFICATION.md
@@ -1,7 +1,7 @@
 ---
 phase: 19.1-extract-core-crypto-sdk-as-shared-package
 verified: 2026-03-20T07:05:00Z
-status: human_needed
+status: passed
 score: 11/11 must-haves verified (REQUIREMENTS.md has stale pending status for SDK-08 and SDK-09)
 human_verification:
   - test: 'End-to-end user flow verification'
@@ -17,8 +17,8 @@ human_verification:
 **Phase Goal:** Web app's crypto and file operation logic is extracted into a five-package layered SDK architecture (@cipherbox/crypto, @cipherbox/core, @cipherbox/api-client, @cipherbox/sdk-core, @cipherbox/sdk) enabling load testing, integration testing, and future CLI usage without a browser context.
 
 **Verified:** 2026-03-20T07:05:00Z
-**Status:** human_needed — all automated checks pass; two items require live browser verification
-**Re-verification:** No — initial verification
+**Status:** passed — all automated checks pass; human verification completed 2026-06-10 via driven-browser UAT (see 19.1-UAT.md, 9/9 passed)
+**Re-verification:** Yes — human UAT completed 2026-06-10 (browser session driven via Puppeteer, results in 19.1-UAT.md)
 
 ---
 

--- a/.planning/phases/21-byo-ipfs-node-support/21-UAT.md
+++ b/.planning/phases/21-byo-ipfs-node-support/21-UAT.md
@@ -1,14 +1,14 @@
 ---
-status: partial
+status: diagnosed
 phase: 21-byo-ipfs-node-support
 source: 21-VERIFICATION.md (human_verification items)
 started: 2026-06-10T16:05:00Z
-updated: 2026-06-10T16:45:00Z
+updated: 2026-06-10T16:35:00Z
 ---
 
 ## Current Test
 
-[testing paused — 3 items outstanding, blocked on local TEE worker env]
+[testing complete]
 
 ## Tests
 
@@ -16,54 +16,97 @@ updated: 2026-06-10T16:45:00Z
 
 expected: Settings shows tabs incl. STORAGE; STORAGE shows pinning mode radio; selecting external/dual reveals endpoint and auth token fields; connection test button fires a TEE-routed probe and shows inline results
 result: pass
-note: Four tabs render (LINKED METHODS, SECURITY, STORAGE, VAULT — VAULT added post-phase-21 by phase 39/40, not a deviation). Radio selection works; endpoint/token fields hidden under cipherbox mode and revealed under external. Connection test fires POST /tee/connection-test and renders the inline result (.connection-test-result) — observed rendering a failure result correctly.
+note: Four tabs render (LINKED METHODS, SECURITY, STORAGE, VAULT — VAULT added by phases 39/40, not a deviation). Radio selection works; endpoint/token fields hidden under cipherbox mode, revealed under external. Save button correctly gated on a successful connection test (StorageTab.tsx:414).
 
 ### 2. TEE-routed connection test credential flow
 
 expected: Entering endpoint+token and clicking test triggers ECIES encryption of credentials, POST to /tee/connection-test, and displays latency/success. No plaintext credentials in network traffic.
 result: pass
-note: Core security property VERIFIED with captured request bodies — the request contained only {"encryptedConfig":"<ECIES hex blob>","epoch":1}; the dummy token "uat-secret-token-DO-NOT-LEAK-12345" never appeared in plaintext anywhere in network traffic. Latency/success display could not be observed locally: the TEE worker round-trip is env-blocked (see Gaps) — the inline error path rendered correctly instead.
+note: Request body contained only {"encryptedConfig":"<ECIES hex blob>","epoch":1} — dummy token never appeared in plaintext (verified with captured request bodies). With the local TEE worker running (simulator mode, epoch 1 key matches DB), the inline result rendered "> connected (10ms) // detected: kubo kubo/0.40.0/882b7d2/docker". Failure path also renders inline (observed against a worker missing the route).
 
 ### 3. Advisory quota badge visible for BYO users
 
 expected: With isByoUser=true, quota bar shows ADVISORY badge and advisory hint instead of enforced quota display
-result: blocked
-blocked_by: server
-reason: 'isByoUser is set by saving external/dual mode, but the save button is gated on a successful connection test (StorageTab.tsx:414) which requires a working TEE worker — not available locally'
+result: issue
+reported: "Badge and hint render correctly when is_byo_user=true is set directly in the DB ('ADVISORY' + 'storage is managed by your node. this total is approximate.'). But nothing in apps/web ever calls PATCH /vault/byo-status — saving external/dual mode does not set the flag, so the badge is unreachable through the product flow."
+severity: major
 
 ### 4. Migration progress UI polling and controls
 
 expected: After saving a provider change, MigrationProgress appears immediately and polls every 5 seconds; pause/resume/cancel work; completed state shows success
-result: blocked
-blocked_by: server
-reason: 'Partially observed: MigrationProgress renders ("migrating: 0/39 pins") and /migration/status polling was captured. But the migration job is stuck at 0/39 server-side (MigrationProcessor: TEE_WORKER_URL or TEE_WORKER_SECRET not configured), so pause/resume/cancel and the completed state could not be exercised'
+result: pass
+note: Component renders, polls every 5s while active, pause and resume both work (verified live against a running 57-CID migration), completed state shows success message. Cancel intentionally not exercised (would have killed the real migration). Three defects observed — see Gaps: stale-job polling never restarts after save; API batch timeout causes double-counted stats; completed message shows contradictory numbers ("57 pins transferred" + "33 pins failed" on a 57-CID job).
 
 ### 5. BYO config loads at login and activates pinWithMode for uploads
 
-expected: Logging in with a BYO-configured account, uploads use the active pinning mode; secondary/primary pin to the BYO node is attempted
-result: blocked
-blocked_by: server
-reason: 'Full app flow blocked: cannot save external mode locally (connection-test gate). However the underlying provider path is now VERIFIED in a real browser: the actual kubo-provider.ts source (with the fix from 9789efa8f) pinned and unpinned data against the byo-ipfs-kubo Docker node (localhost:5002) using native fetch, confirmed node-side via ipfs pin ls (recursive). Negative control: the pre-fix unbound-fetch pattern throws "Illegal invocation" in the same browser. Remaining unverified: the in-app wiring from saved config to pinWithMode at upload time'
+expected: Logging in with a BYO-configured account, uploads use the active pinning mode; pin to the BYO node is attempted
+result: pass
+note: After saving external mode and re-logging in, uploaded uat-21-byo-upload.txt (4 KB) through the app. Upload completed with zero /ipfs/upload relay calls (content and metadata went directly to the node) and new pins appeared on byo-ipfs-kubo (verified via ipfs pin ls diff). Depends on the unbound-fetch fix (9789efa8f) — pre-fix this path threw Illegal invocation.
 
 ## Summary
 
 total: 5
-passed: 2
-issues: 0
+passed: 4
+issues: 1
 pending: 0
 skipped: 0
-blocked: 3
+blocked: 0
 
 ## Gaps
 
-[none — no code defects found; 3 items blocked by local environment]
+- truth: 'Saving external/dual pinning mode marks the user as BYO so the advisory quota display activates'
+  status: failed
+  reason: 'Badge rendering pipeline verified working end-to-end (API advisory field -> quota.store -> StorageQuota.tsx:39), but the web app contains no caller of PATCH /vault/byo-status. The flag must be self-reported by the client (vault params are encrypted; the server cannot infer pinning mode), and the StorageTab save flow never does it.'
+  severity: major
+  test: 3
+  root_cause: 'Missing integration: StorageTab save flow does not call vault byo-status endpoint after persisting pinning config. grep confirms zero references to byo-status/isByoUser in apps/web/src.'
+  artifacts:
+  - path: 'apps/web/src/components/settings/StorageTab.tsx'
+    issue: 'save flow persists pinning config but never PATCHes /vault/byo-status'
+    missing:
+  - 'Call vault byo-status (true) when saving external/dual mode, (false) when reverting to cipherbox'
+    debug_session: ''
 
-## Environment Blockers
+- truth: 'MigrationProgress starts polling when a new migration begins after a previous one ended in a terminal state'
+  status: failed
+  reason: 'With a prior failed job on record, the component fetched once at mount, saw terminal status, stopped polling permanently (MigrationProgress.tsx:44), and kept displaying the stale job as "migrating: 0/39 pins" while a new 57-CID migration ran server-side. Remounting (navigating away and back) was required to pick up the running job.'
+  severity: minor
+  test: 4
+  root_cause: 'Poll loop exits permanently on terminal status and the save flow has no signal to restart it; also a failed job renders with the "migrating:" label.'
+  artifacts:
+  - path: 'apps/web/src/components/settings/MigrationProgress.tsx'
+    issue: 'poll() returns permanently on TERMINAL_STATUSES; no restart trigger from save; failed status rendered as "migrating:"'
+    missing:
+  - 'Restart polling after a provider-change save (lift a restart signal into MigrationProgress or key the component on migration id)'
+  - 'Render failed jobs as failed, not "migrating:"'
+    debug_session: ''
 
-All three blocked items trace to one root: no real TEE worker runs locally.
+- truth: 'Migration statistics are accurate (migrated + failed <= total)'
+  status: failed
+  reason: 'Completed job recorded 44 migrated + 33 failed on a 57-CID migration (77 > 57); UI showed "migration complete. 57 pins transferred." alongside "33 pins failed". API-side batch call aborts at 120s while TEE worker batches can exceed that (observed 130s), the worker continues processing, and retried batches double-count.'
+  severity: minor
+  test: 4
+  root_cause: 'MigrationProcessor HTTP timeout (120s) shorter than worst-case worker batch duration; aborted batches are retried while the worker already processed them, double-counting stats. Worker-side per-CID failures also re-counted on retry.'
+  artifacts:
+  - path: 'apps/api/src/migration (MigrationProcessor)'
+    issue: 'batch timeout shorter than worker batch worst case; no idempotency on retried batch accounting'
+    missing:
+  - 'Raise/remove batch timeout or make batch accounting idempotent (e.g. worker reports per-CID results keyed by CID; API upserts)'
+    debug_session: ''
 
-- TEE_WORKER_URL (default localhost:3001) collides with tools/mock-ipns-routing, which answers /health (so TeeService reports "healthy, epoch: undefined") but 404s /connection-test
-- TEE_WORKER_SECRET is unset, so MigrationProcessor refuses to process jobs (one migration stuck at 0/39 from the 2026-06-10 pinning-mode switch)
-- apps/tee-worker exists and exposes /connection-test, but binding it locally needs a free port (3002), a shared secret with the API, and epoch/key alignment with the DB (DB has epoch 1; a fresh simulator would mint a different keypair)
+## Environment Notes
 
-Unblocking these would also enable phase 35's 6 outstanding TEE UAT items.
+Local TEE worker now runs in Docker (image built from apps/tee-worker):
+container `cipherbox-tee-worker`, host port 3002, TEE_MODE=simulator,
+CIPHERBOX_ENVIRONMENT=development. Simulator keys are HKDF-derived from a
+fixed seed, so its epoch-1 public key matches the DB exactly. The API must
+run with TEE_WORKER_URL=http://localhost:3002 and the matching
+TEE_WORKER_SECRET (currently passed as process env to pnpm dev; persist to
+apps/api/.env to keep). Endpoint for the BYO node must be the host LAN IP
+(http://192.168.133.12:5002), reachable from both the browser and the TEE
+container — localhost is not, from inside the container.
+
+Account state changed during testing: pinning mode saved as "external only"
+(http://192.168.133.12:5002) and vaults.is_byo_user set to true (manually,
+matching the now-real BYO configuration). 2026-03 dev-data CIDs that no
+longer resolve account for most genuine migration failures.

--- a/.planning/phases/21-byo-ipfs-node-support/21-UAT.md
+++ b/.planning/phases/21-byo-ipfs-node-support/21-UAT.md
@@ -1,0 +1,69 @@
+---
+status: partial
+phase: 21-byo-ipfs-node-support
+source: 21-VERIFICATION.md (human_verification items)
+started: 2026-06-10T16:05:00Z
+updated: 2026-06-10T16:45:00Z
+---
+
+## Current Test
+
+[testing paused — 3 items outstanding, blocked on local TEE worker env]
+
+## Tests
+
+### 1. Settings page STORAGE tab functional test
+
+expected: Settings shows tabs incl. STORAGE; STORAGE shows pinning mode radio; selecting external/dual reveals endpoint and auth token fields; connection test button fires a TEE-routed probe and shows inline results
+result: pass
+note: Four tabs render (LINKED METHODS, SECURITY, STORAGE, VAULT — VAULT added post-phase-21 by phase 39/40, not a deviation). Radio selection works; endpoint/token fields hidden under cipherbox mode and revealed under external. Connection test fires POST /tee/connection-test and renders the inline result (.connection-test-result) — observed rendering a failure result correctly.
+
+### 2. TEE-routed connection test credential flow
+
+expected: Entering endpoint+token and clicking test triggers ECIES encryption of credentials, POST to /tee/connection-test, and displays latency/success. No plaintext credentials in network traffic.
+result: pass
+note: Core security property VERIFIED with captured request bodies — the request contained only {"encryptedConfig":"<ECIES hex blob>","epoch":1}; the dummy token "uat-secret-token-DO-NOT-LEAK-12345" never appeared in plaintext anywhere in network traffic. Latency/success display could not be observed locally: the TEE worker round-trip is env-blocked (see Gaps) — the inline error path rendered correctly instead.
+
+### 3. Advisory quota badge visible for BYO users
+
+expected: With isByoUser=true, quota bar shows ADVISORY badge and advisory hint instead of enforced quota display
+result: blocked
+blocked_by: server
+reason: 'isByoUser is set by saving external/dual mode, but the save button is gated on a successful connection test (StorageTab.tsx:414) which requires a working TEE worker — not available locally'
+
+### 4. Migration progress UI polling and controls
+
+expected: After saving a provider change, MigrationProgress appears immediately and polls every 5 seconds; pause/resume/cancel work; completed state shows success
+result: blocked
+blocked_by: server
+reason: 'Partially observed: MigrationProgress renders ("migrating: 0/39 pins") and /migration/status polling was captured. But the migration job is stuck at 0/39 server-side (MigrationProcessor: TEE_WORKER_URL or TEE_WORKER_SECRET not configured), so pause/resume/cancel and the completed state could not be exercised'
+
+### 5. BYO config loads at login and activates pinWithMode for uploads
+
+expected: Logging in with a BYO-configured account, uploads use the active pinning mode; secondary/primary pin to the BYO node is attempted
+result: blocked
+blocked_by: server
+reason: 'Full app flow blocked: cannot save external mode locally (connection-test gate). However the underlying provider path is now VERIFIED in a real browser: the actual kubo-provider.ts source (with the fix from 9789efa8f) pinned and unpinned data against the byo-ipfs-kubo Docker node (localhost:5002) using native fetch, confirmed node-side via ipfs pin ls (recursive). Negative control: the pre-fix unbound-fetch pattern throws "Illegal invocation" in the same browser. Remaining unverified: the in-app wiring from saved config to pinWithMode at upload time'
+
+## Summary
+
+total: 5
+passed: 2
+issues: 0
+pending: 0
+skipped: 0
+blocked: 3
+
+## Gaps
+
+[none — no code defects found; 3 items blocked by local environment]
+
+## Environment Blockers
+
+All three blocked items trace to one root: no real TEE worker runs locally.
+
+- TEE_WORKER_URL (default localhost:3001) collides with tools/mock-ipns-routing, which answers /health (so TeeService reports "healthy, epoch: undefined") but 404s /connection-test
+- TEE_WORKER_SECRET is unset, so MigrationProcessor refuses to process jobs (one migration stuck at 0/39 from the 2026-06-10 pinning-mode switch)
+- apps/tee-worker exists and exposes /connection-test, but binding it locally needs a free port (3002), a shared secret with the API, and epoch/key alignment with the DB (DB has epoch 1; a fresh simulator would mint a different keypair)
+
+Unblocking these would also enable phase 35's 6 outstanding TEE UAT items.

--- a/.planning/phases/21-byo-ipfs-node-support/21-VERIFICATION.md
+++ b/.planning/phases/21-byo-ipfs-node-support/21-VERIFICATION.md
@@ -1,7 +1,7 @@
 ---
 phase: 21-byo-ipfs-node-support
 verified: 2026-03-25T02:15:00Z
-status: human_needed
+status: passed
 score: 5/5 success criteria verified
 re_verification:
   previous_status: gaps_found

--- a/.planning/phases/35-phala-testnet-tee-migration/35-UAT.md
+++ b/.planning/phases/35-phala-testnet-tee-migration/35-UAT.md
@@ -1,0 +1,77 @@
+---
+status: complete
+phase: 35-phala-testnet-tee-migration
+source: 35-VERIFICATION.md (human_verification items)
+started: 2026-06-10T21:30:00Z
+updated: 2026-06-10T22:05:00Z
+---
+
+## Current Test
+
+[testing complete]
+
+## Tests
+
+### 1. Phala Cloud CVM is live and healthy
+
+expected: curl https://011f138783487e4c43ea104cfcbacf817ac4f31b-3001.dstack-pha-prod5.phala.network/health returns {"healthy":true,"mode":"cvm"}
+result: skipped
+note: Obsolete — superseded by f270d843a "chore(infra): switch staging TEE worker from Phala Cloud to local Docker" (#472, 2026-05-27), which intentionally retired the Phala Cloud CVM for staging (cost reduction). The endpoint is confirmed dead (TLS handshake failure — service decommissioned), which is the expected state post-retirement, not a regression. The CVM was verified live at phase completion per 35-06-SUMMARY; the phase goal (prove the CVM deployment path end-to-end on testnet) was achieved and the infra decision was later reversed for staging. The CVM compose file (apps/tee-worker/docker-compose.phala.yml) remains for production use. See test 3 for verification of the current staging TEE infra.
+
+### 2. GitHub staging environment has PHALA_CLOUD_API_KEY secret and PHALA_TEE_WORKER_URL variable
+
+expected: Both visible in GitHub repo Settings -> Environments -> staging; PHALA_TEE_WORKER_URL matches the CVM endpoint
+result: pass
+note: Verified via gh api (environments/staging/secrets and /variables): PHALA_CLOUD_API_KEY present in secrets; PHALA_TEE_WORKER_URL present with value exactly matching the expected endpoint. Both are now orphaned — zero references remain in any workflow since #472 removed the deploy-tee-phala job (see Gaps).
+
+### 3. Current staging TEE worker is deployed and running (post-472 equivalent of test 1)
+
+expected: The staging TEE worker (local Docker, simulator mode) deployed by the current pipeline is started and serving on the staging VPS
+result: pass
+note: Verified via the deploy evidence chain — tag-staging run 26481149698 (staging-20260526-release-2, all 15 jobs success); Deploy-to-Staging-VPS job logs show "Container cipherbox-staging-tee-worker-1 Started" with image ghcr.io/fsm1/cipherbox-tee-worker:staging-20260526-release-2 and TEE*WORKER_URL=http://tee-worker:3001; live staging API (https://api-staging.cipherbox.cc/health) reports version 0.37.1, exactly matching apps/api at the deployed tag (46d0668cc), confirming staging runs the post-472 stack. Compose defines a healthcheck and restart unless-stopped for the service. The identical simulator code path was exercised live (health, connection-test, migration, republish key validation) during phase 21 UAT on 2026-06-10. Current-moment container health on the VPS is not externally reachable (port 3001 internal-only; API initializeFromTee logs-but-does-not-throw on worker failure) — checkable via Grafana Cloud (cipherbox.grafana.net, cipherbox_tee*\* metrics) or SSH if ever in doubt.
+
+## Summary
+
+total: 3
+passed: 2
+issues: 0
+pending: 0
+skipped: 1
+blocked: 0
+
+## Gaps
+
+- truth: 'CI configuration contains only secrets/variables that are consumed by workflows'
+  status: failed
+  reason: 'PHALA_CLOUD_API_KEY (secret) and PHALA_TEE_WORKER_URL (variable) remain configured in the GitHub staging environment but nothing references them — #472 removed the deploy-tee-phala job, the only consumer. The API key is a live credential for a retired service lingering in CI config.'
+  severity: minor
+  test: 2
+  root_cause: '#472 (f270d843a) removed the workflow consumers but did not clean up the GitHub environment entries (not version-controlled, easy to miss in a code-only PR).'
+  artifacts:
+  - path: 'GitHub repo Settings -> Environments -> staging'
+    issue: 'orphaned PHALA_CLOUD_API_KEY secret and PHALA_TEE_WORKER_URL variable'
+    missing:
+  - 'Delete both entries (or revoke the Phala API key first if the account still exists)'
+    debug_session: ''
+
+- truth: 'ENVIRONMENTS.md accurately documents the staging TEE worker infrastructure'
+  status: failed
+  reason: 'ENVIRONMENTS.md still documents staging TEE as "Phala Cloud CVM (production infra, free tier)" (lines 24, 430, and the entire section at 479-545 including TEE_WORKER_URL=https://{app-id}-3001.dstack-prod{N}.phala.network), contradicting the deployed reality since #472: local Docker container in simulator mode on the staging VPS, TEE_WORKER_URL=http://tee-worker:3001.'
+  severity: minor
+  test: 1
+  root_cause: '#472 changed the staging TEE infra but only updated deploy-staging.yml and docker-compose.staging.yml; CLAUDE.md was refreshed later (#476) but .planning/ENVIRONMENTS.md was missed.'
+  artifacts:
+  - path: '.planning/ENVIRONMENTS.md'
+    issue: 'staging TEE rows/sections describe the retired Phala Cloud CVM deployment'
+    missing:
+  - 'Update staging TEE references to local Docker simulator on VPS; keep Phala Cloud CVM content under the production section only'
+    debug_session: ''
+
+## Environment Notes
+
+Both original human items concerned external state and were verified remotely:
+GitHub environment config via gh api (note: variables endpoint paginates at 10
+by default — use per_page=100; PHALA_TEE_WORKER_URL was on page 2), CVM
+endpoint via direct curl (TLS handshake failure = decommissioned), staging
+deploy state via gh run logs for run 26481149698 and the live staging API
+/health version match. No staging credentials were needed or used.

--- a/.planning/phases/35-phala-testnet-tee-migration/35-UAT.md
+++ b/.planning/phases/35-phala-testnet-tee-migration/35-UAT.md
@@ -66,6 +66,7 @@ blocked: 0
     missing:
   - 'Update staging TEE references to local Docker simulator on VPS; keep Phala Cloud CVM content under the production section only'
     debug_session: ''
+    resolution: 'Fixed in b15cf2748 - ENVIRONMENTS.md staging TEE section reworked around the Docker simulator, CVM identity warning moved to production, fictional TEE env vars replaced with real ones; stale claims in codebase STACK/STRUCTURE/ARCHITECTURE/CONCERNS/INTEGRATIONS docs also corrected'
 
 ## Environment Notes
 

--- a/.planning/phases/35-phala-testnet-tee-migration/35-VERIFICATION.md
+++ b/.planning/phases/35-phala-testnet-tee-migration/35-VERIFICATION.md
@@ -1,7 +1,7 @@
 ---
 phase: 35-phala-testnet-tee-migration
 verified: 2026-03-29T16:42:51Z
-status: human_needed
+status: passed
 score: 22/24 must-haves verified
 human_verification:
   - test: 'Confirm Phala Cloud CVM is currently live and healthy'
@@ -23,86 +23,86 @@ human_verification:
 
 ### Observable Truths
 
-| # | Truth | Status | Evidence |
-|---|-------|--------|----------|
-| 1 | TEE worker lives at apps/tee-worker/ and is covered by apps/* workspace glob | VERIFIED | `apps/tee-worker/` exists; root `tee-worker/` removed; pnpm-workspace.yaml has `apps/*` |
-| 2 | TEE worker imports IPNS record creation from @cipherbox/core | VERIFIED | `ipns-signer.ts` imports `createIpnsRecord, marshalIpnsRecord` from `@cipherbox/core` |
-| 3 | TEE worker imports ECIES operations from @cipherbox/crypto | VERIFIED | `key-manager.ts` imports `unwrapKey, wrapKey` from `@cipherbox/crypto` |
-| 4 | Migration worker uses KuboProvider/PsaProvider from @cipherbox/sdk-core | VERIFIED | `migration-worker.ts` imports `KuboProvider, PsaProvider` from `@cipherbox/sdk-core` |
-| 5 | Vendored deps (eciesjs, @noble/ed25519, ipns, @libp2p/crypto, multiformats) removed | VERIFIED | None of the removed packages appear in package.json or any src/ file |
-| 6 | KuboProvider and PsaProvider accept optional fetchFn and timeoutMs | VERIFIED | Both providers accept `ProviderOptions` in constructor; `types.ts` defines `FetchFn` and `ProviderOptions` |
-| 7 | All CI/CD, Docker, compose references updated from tee-worker/ to apps/tee-worker/ | VERIFIED | No stale root-level `tee-worker/` references found in .github/ or docker/ |
-| 8 | TEE worker builds successfully with tsc | VERIFIED | `tsc --noEmit` completes with zero errors |
-| 9 | TEE key derivation unit tests exist and pass | VERIFIED | `tee-keys.test.ts` (112 lines), all 56 tests pass via `pnpm --filter cipherbox-tee-worker test` |
-| 10 | ECIES epoch fallback orchestration tests exist and pass | VERIFIED | `key-manager.test.ts` (220 lines) with real ECIES crypto, imports `decryptWithFallback` |
-| 11 | Auth middleware and republish route tests exist and pass | VERIFIED | `auth.test.ts` (143 lines), `republish.test.ts` (289 lines), all pass |
-| 12 | dstack SDK installed as real dependency | VERIFIED | `@phala/dstack-sdk: ^0.5.7` in package.json, dynamic import in `tee-keys.ts` CVM mode |
-| 13 | CVM code path handles both SDK return types defensively | VERIFIED | `tee-keys.ts` checks `'key' in keyResult` then falls back to `asUint8Array()` |
-| 14 | Phala CVM docker-compose mounts /var/run/dstack.sock | VERIFIED | `docker-compose.phala.yml` and `docker-compose.yml` both mount `dstack.sock`; no `tappd.sock` references |
-| 15 | Prometheus metrics endpoint with cipherbox_tee_* prefix | VERIFIED | `metrics.ts` middleware, `/metrics` route wired in `index.ts`; metric names use `cipherbox_tee_*` prefix |
-| 16 | Structured JSON logger replaces console.log/console.error | VERIFIED | `logger.ts` exists; no `console.log`/`console.error` in src/ (excluding test files) |
-| 17 | Staging docker-compose no longer runs a local tee-worker container | VERIFIED | `grep -c "tee-worker:" docker/docker-compose.staging.yml` returns 0 |
-| 18 | CI/CD pipeline has Phala CVM deployment step | VERIFIED | `deploy-tee-phala` job in deploy-staging.yml; runs `phala deploy -n cipherbox-tee-staging --wait` |
-| 19 | TEE_WORKER_URL points to external Phala endpoint | VERIFIED | `deploy-staging.yml` uses `${{ vars.PHALA_TEE_WORKER_URL }}` instead of `http://tee-worker:3001` |
-| 20 | STACK.md documents dstack SDK and Phala CVM | VERIFIED | `@phala/dstack-sdk` and "Phala Cloud CVM" appear in `.planning/codebase/STACK.md` |
-| 21 | ENVIRONMENTS.md documents staging TEE as external Phala Cloud CVM | VERIFIED | "Phala Cloud CVM" (6x), "dstack.sock", "cipherbox-tee-staging", "CVM Identity Preservation", "Migration Note (Phase 35)" all present |
-| 22 | STRUCTURE.md reflects tee-worker at apps/ | VERIFIED | "apps/tee-worker" appears 4 times; no root-level `tee-worker/` entry |
-| 23 | Phala Cloud CVM is live and healthy on testnet | NEEDS HUMAN | External service -- CVM endpoint is live per 35-06-SUMMARY but cannot verify without credentials |
-| 24 | GitHub staging environment has PHALA_CLOUD_API_KEY and PHALA_TEE_WORKER_URL configured | NEEDS HUMAN | GitHub environment secrets/vars not accessible locally |
+| #   | Truth                                                                                  | Status      | Evidence                                                                                                                             |
+| --- | -------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | TEE worker lives at apps/tee-worker/ and is covered by apps/\* workspace glob          | VERIFIED    | `apps/tee-worker/` exists; root `tee-worker/` removed; pnpm-workspace.yaml has `apps/*`                                              |
+| 2   | TEE worker imports IPNS record creation from @cipherbox/core                           | VERIFIED    | `ipns-signer.ts` imports `createIpnsRecord, marshalIpnsRecord` from `@cipherbox/core`                                                |
+| 3   | TEE worker imports ECIES operations from @cipherbox/crypto                             | VERIFIED    | `key-manager.ts` imports `unwrapKey, wrapKey` from `@cipherbox/crypto`                                                               |
+| 4   | Migration worker uses KuboProvider/PsaProvider from @cipherbox/sdk-core                | VERIFIED    | `migration-worker.ts` imports `KuboProvider, PsaProvider` from `@cipherbox/sdk-core`                                                 |
+| 5   | Vendored deps (eciesjs, @noble/ed25519, ipns, @libp2p/crypto, multiformats) removed    | VERIFIED    | None of the removed packages appear in package.json or any src/ file                                                                 |
+| 6   | KuboProvider and PsaProvider accept optional fetchFn and timeoutMs                     | VERIFIED    | Both providers accept `ProviderOptions` in constructor; `types.ts` defines `FetchFn` and `ProviderOptions`                           |
+| 7   | All CI/CD, Docker, compose references updated from tee-worker/ to apps/tee-worker/     | VERIFIED    | No stale root-level `tee-worker/` references found in .github/ or docker/                                                            |
+| 8   | TEE worker builds successfully with tsc                                                | VERIFIED    | `tsc --noEmit` completes with zero errors                                                                                            |
+| 9   | TEE key derivation unit tests exist and pass                                           | VERIFIED    | `tee-keys.test.ts` (112 lines), all 56 tests pass via `pnpm --filter cipherbox-tee-worker test`                                      |
+| 10  | ECIES epoch fallback orchestration tests exist and pass                                | VERIFIED    | `key-manager.test.ts` (220 lines) with real ECIES crypto, imports `decryptWithFallback`                                              |
+| 11  | Auth middleware and republish route tests exist and pass                               | VERIFIED    | `auth.test.ts` (143 lines), `republish.test.ts` (289 lines), all pass                                                                |
+| 12  | dstack SDK installed as real dependency                                                | VERIFIED    | `@phala/dstack-sdk: ^0.5.7` in package.json, dynamic import in `tee-keys.ts` CVM mode                                                |
+| 13  | CVM code path handles both SDK return types defensively                                | VERIFIED    | `tee-keys.ts` checks `'key' in keyResult` then falls back to `asUint8Array()`                                                        |
+| 14  | Phala CVM docker-compose mounts /var/run/dstack.sock                                   | VERIFIED    | `docker-compose.phala.yml` and `docker-compose.yml` both mount `dstack.sock`; no `tappd.sock` references                             |
+| 15  | Prometheus metrics endpoint with cipherbox*tee*\* prefix                               | VERIFIED    | `metrics.ts` middleware, `/metrics` route wired in `index.ts`; metric names use `cipherbox_tee_*` prefix                             |
+| 16  | Structured JSON logger replaces console.log/console.error                              | VERIFIED    | `logger.ts` exists; no `console.log`/`console.error` in src/ (excluding test files)                                                  |
+| 17  | Staging docker-compose no longer runs a local tee-worker container                     | VERIFIED    | `grep -c "tee-worker:" docker/docker-compose.staging.yml` returns 0                                                                  |
+| 18  | CI/CD pipeline has Phala CVM deployment step                                           | VERIFIED    | `deploy-tee-phala` job in deploy-staging.yml; runs `phala deploy -n cipherbox-tee-staging --wait`                                    |
+| 19  | TEE_WORKER_URL points to external Phala endpoint                                       | VERIFIED    | `deploy-staging.yml` uses `${{ vars.PHALA_TEE_WORKER_URL }}` instead of `http://tee-worker:3001`                                     |
+| 20  | STACK.md documents dstack SDK and Phala CVM                                            | VERIFIED    | `@phala/dstack-sdk` and "Phala Cloud CVM" appear in `.planning/codebase/STACK.md`                                                    |
+| 21  | ENVIRONMENTS.md documents staging TEE as external Phala Cloud CVM                      | VERIFIED    | "Phala Cloud CVM" (6x), "dstack.sock", "cipherbox-tee-staging", "CVM Identity Preservation", "Migration Note (Phase 35)" all present |
+| 22  | STRUCTURE.md reflects tee-worker at apps/                                              | VERIFIED    | "apps/tee-worker" appears 4 times; no root-level `tee-worker/` entry                                                                 |
+| 23  | Phala Cloud CVM is live and healthy on testnet                                         | NEEDS HUMAN | External service -- CVM endpoint is live per 35-06-SUMMARY but cannot verify without credentials                                     |
+| 24  | GitHub staging environment has PHALA_CLOUD_API_KEY and PHALA_TEE_WORKER_URL configured | NEEDS HUMAN | GitHub environment secrets/vars not accessible locally                                                                               |
 
 **Score:** 22/24 truths verified (2 require human confirmation of live external service state)
 
 ### Required Artifacts
 
-| Artifact | Expected | Status | Details |
-|----------|----------|--------|---------|
-| `apps/tee-worker/package.json` | Workspace deps on shared packages | VERIFIED | Has `@cipherbox/crypto`, `@cipherbox/core`, `@cipherbox/sdk-core`, `@phala/dstack-sdk`, `prom-client`; no vendored crypto deps |
-| `apps/tee-worker/src/services/ipns-signer.ts` | Thin wrapper around @cipherbox/core | VERIFIED | 34 lines; imports `createIpnsRecord, marshalIpnsRecord` from `@cipherbox/core` |
-| `apps/tee-worker/src/services/key-manager.ts` | ECIES via @cipherbox/crypto | VERIFIED | Imports `unwrapKey, wrapKey` from `@cipherbox/crypto`; epoch fallback logic intact |
-| `packages/sdk-core/src/pinning/kubo-provider.ts` | KuboProvider with fetchFn injection | VERIFIED | Accepts `ProviderOptions`; uses `this.fetchFn` throughout |
-| `packages/sdk-core/src/pinning/psa-provider.ts` | PsaProvider with fetchFn injection | VERIFIED | Accepts `ProviderOptions`; uses `this.fetchFn` throughout |
-| `apps/tee-worker/vitest.config.ts` | Vitest config with node environment | VERIFIED | `defineConfig` with `environment: 'node'` |
-| `apps/tee-worker/src/__tests__/tee-keys.test.ts` | Key derivation tests | VERIFIED | 112 lines; tests determinism, epoch isolation, key format, caching, production guard |
-| `apps/tee-worker/src/__tests__/key-manager.test.ts` | Epoch fallback tests | VERIFIED | 220 lines; imports `decryptWithFallback`; real ECIES crypto |
-| `apps/tee-worker/src/__tests__/auth.test.ts` | Auth middleware tests | VERIFIED | 143 lines; tests valid/missing/wrong/malformed token |
-| `apps/tee-worker/src/__tests__/republish.test.ts` | Republish route tests | VERIFIED | 289 lines; batch processing, epoch upgrade, base64 |
-| `apps/tee-worker/src/services/tee-keys.ts` | Defensive CVM key derivation | VERIFIED | Dynamic import of dstack-sdk; handles both SDK return types |
-| `apps/tee-worker/docker-compose.phala.yml` | Phala Cloud CVM compose | VERIFIED | Mounts `dstack.sock`; `TEE_MODE=cvm`; identity preservation comment |
-| `apps/tee-worker/src/middleware/metrics.ts` | Express metrics middleware | VERIFIED | `prom-client` Histogram/Counter; `cipherbox_tee_*` prefix |
-| `apps/tee-worker/src/services/logger.ts` | Structured JSON logger | VERIFIED | Zero external deps; `JSON.stringify` to stdout/stderr |
-| `apps/tee-worker/src/routes/metrics.ts` | GET /metrics endpoint | VERIFIED | `register.metrics()` response |
-| `docker/docker-compose.staging.yml` | Staging compose without local tee-worker | VERIFIED | No `tee-worker:` service block; comment referencing external CVM |
-| `.github/workflows/deploy-staging.yml` | Deploy workflow with Phala CVM step | VERIFIED | `deploy-tee-phala` job; `phala deploy`; `PHALA_TEE_WORKER_URL` |
-| `.planning/codebase/STACK.md` | Stack docs with Phala CVM | VERIFIED | Contains `@phala/dstack-sdk`, "Phala Cloud CVM" (6x) |
-| `.planning/ENVIRONMENTS.md` | Environments docs with Phala CVM | VERIFIED | CVM identity preservation warning and migration note |
-| `.planning/codebase/STRUCTURE.md` | Structure docs with apps/tee-worker | VERIFIED | No root-level entry; `apps/tee-worker` referenced 4 times |
+| Artifact                                            | Expected                                 | Status   | Details                                                                                                                        |
+| --------------------------------------------------- | ---------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `apps/tee-worker/package.json`                      | Workspace deps on shared packages        | VERIFIED | Has `@cipherbox/crypto`, `@cipherbox/core`, `@cipherbox/sdk-core`, `@phala/dstack-sdk`, `prom-client`; no vendored crypto deps |
+| `apps/tee-worker/src/services/ipns-signer.ts`       | Thin wrapper around @cipherbox/core      | VERIFIED | 34 lines; imports `createIpnsRecord, marshalIpnsRecord` from `@cipherbox/core`                                                 |
+| `apps/tee-worker/src/services/key-manager.ts`       | ECIES via @cipherbox/crypto              | VERIFIED | Imports `unwrapKey, wrapKey` from `@cipherbox/crypto`; epoch fallback logic intact                                             |
+| `packages/sdk-core/src/pinning/kubo-provider.ts`    | KuboProvider with fetchFn injection      | VERIFIED | Accepts `ProviderOptions`; uses `this.fetchFn` throughout                                                                      |
+| `packages/sdk-core/src/pinning/psa-provider.ts`     | PsaProvider with fetchFn injection       | VERIFIED | Accepts `ProviderOptions`; uses `this.fetchFn` throughout                                                                      |
+| `apps/tee-worker/vitest.config.ts`                  | Vitest config with node environment      | VERIFIED | `defineConfig` with `environment: 'node'`                                                                                      |
+| `apps/tee-worker/src/__tests__/tee-keys.test.ts`    | Key derivation tests                     | VERIFIED | 112 lines; tests determinism, epoch isolation, key format, caching, production guard                                           |
+| `apps/tee-worker/src/__tests__/key-manager.test.ts` | Epoch fallback tests                     | VERIFIED | 220 lines; imports `decryptWithFallback`; real ECIES crypto                                                                    |
+| `apps/tee-worker/src/__tests__/auth.test.ts`        | Auth middleware tests                    | VERIFIED | 143 lines; tests valid/missing/wrong/malformed token                                                                           |
+| `apps/tee-worker/src/__tests__/republish.test.ts`   | Republish route tests                    | VERIFIED | 289 lines; batch processing, epoch upgrade, base64                                                                             |
+| `apps/tee-worker/src/services/tee-keys.ts`          | Defensive CVM key derivation             | VERIFIED | Dynamic import of dstack-sdk; handles both SDK return types                                                                    |
+| `apps/tee-worker/docker-compose.phala.yml`          | Phala Cloud CVM compose                  | VERIFIED | Mounts `dstack.sock`; `TEE_MODE=cvm`; identity preservation comment                                                            |
+| `apps/tee-worker/src/middleware/metrics.ts`         | Express metrics middleware               | VERIFIED | `prom-client` Histogram/Counter; `cipherbox_tee_*` prefix                                                                      |
+| `apps/tee-worker/src/services/logger.ts`            | Structured JSON logger                   | VERIFIED | Zero external deps; `JSON.stringify` to stdout/stderr                                                                          |
+| `apps/tee-worker/src/routes/metrics.ts`             | GET /metrics endpoint                    | VERIFIED | `register.metrics()` response                                                                                                  |
+| `docker/docker-compose.staging.yml`                 | Staging compose without local tee-worker | VERIFIED | No `tee-worker:` service block; comment referencing external CVM                                                               |
+| `.github/workflows/deploy-staging.yml`              | Deploy workflow with Phala CVM step      | VERIFIED | `deploy-tee-phala` job; `phala deploy`; `PHALA_TEE_WORKER_URL`                                                                 |
+| `.planning/codebase/STACK.md`                       | Stack docs with Phala CVM                | VERIFIED | Contains `@phala/dstack-sdk`, "Phala Cloud CVM" (6x)                                                                           |
+| `.planning/ENVIRONMENTS.md`                         | Environments docs with Phala CVM         | VERIFIED | CVM identity preservation warning and migration note                                                                           |
+| `.planning/codebase/STRUCTURE.md`                   | Structure docs with apps/tee-worker      | VERIFIED | No root-level entry; `apps/tee-worker` referenced 4 times                                                                      |
 
 ### Key Link Verification
 
-| From | To | Via | Status | Details |
-|------|----|-----|--------|---------|
-| `apps/tee-worker/src/services/ipns-signer.ts` | `@cipherbox/core` | `import { createIpnsRecord, marshalIpnsRecord }` | WIRED | Line 9 of ipns-signer.ts |
-| `apps/tee-worker/src/services/key-manager.ts` | `@cipherbox/crypto` | `import { unwrapKey, wrapKey }` | WIRED | Line 12 of key-manager.ts |
-| `apps/tee-worker/src/services/migration-worker.ts` | `@cipherbox/sdk-core` | `import { KuboProvider, PsaProvider }` | WIRED | Line 18 of migration-worker.ts |
-| `apps/tee-worker/src/__tests__/key-manager.test.ts` | `key-manager.ts` | `import { decryptWithFallback, reEncryptForEpoch }` | WIRED | Lines 15-19 |
-| `apps/tee-worker/src/__tests__/republish.test.ts` | `routes/republish.ts` | Dynamic import in test helper | WIRED | Line 80 |
-| `apps/tee-worker/src/services/tee-keys.ts` | `@phala/dstack-sdk` | Dynamic import in CVM mode | WIRED | Line 45 |
-| `apps/tee-worker/src/middleware/metrics.ts` | Metric naming (cipherbox_tee) | `cipherbox_tee_*` prefix | WIRED | Lines 14, 22, 29 |
-| `docker/docker-compose.staging.yml` | Phala Cloud CVM | TEE_WORKER_URL comment | WIRED | Line 91 (comment) |
-| `.github/workflows/deploy-staging.yml` | `docker-compose.phala.yml` | `phala deploy` command | WIRED | Lines 109; `deploy-tee-phala` job |
-| `.planning/codebase/STACK.md` | `apps/tee-worker/package.json` | Documents `@phala/dstack-sdk ^0.5.7` | WIRED | Line 316 |
+| From                                                | To                             | Via                                                 | Status | Details                           |
+| --------------------------------------------------- | ------------------------------ | --------------------------------------------------- | ------ | --------------------------------- |
+| `apps/tee-worker/src/services/ipns-signer.ts`       | `@cipherbox/core`              | `import { createIpnsRecord, marshalIpnsRecord }`    | WIRED  | Line 9 of ipns-signer.ts          |
+| `apps/tee-worker/src/services/key-manager.ts`       | `@cipherbox/crypto`            | `import { unwrapKey, wrapKey }`                     | WIRED  | Line 12 of key-manager.ts         |
+| `apps/tee-worker/src/services/migration-worker.ts`  | `@cipherbox/sdk-core`          | `import { KuboProvider, PsaProvider }`              | WIRED  | Line 18 of migration-worker.ts    |
+| `apps/tee-worker/src/__tests__/key-manager.test.ts` | `key-manager.ts`               | `import { decryptWithFallback, reEncryptForEpoch }` | WIRED  | Lines 15-19                       |
+| `apps/tee-worker/src/__tests__/republish.test.ts`   | `routes/republish.ts`          | Dynamic import in test helper                       | WIRED  | Line 80                           |
+| `apps/tee-worker/src/services/tee-keys.ts`          | `@phala/dstack-sdk`            | Dynamic import in CVM mode                          | WIRED  | Line 45                           |
+| `apps/tee-worker/src/middleware/metrics.ts`         | Metric naming (cipherbox_tee)  | `cipherbox_tee_*` prefix                            | WIRED  | Lines 14, 22, 29                  |
+| `docker/docker-compose.staging.yml`                 | Phala Cloud CVM                | TEE_WORKER_URL comment                              | WIRED  | Line 91 (comment)                 |
+| `.github/workflows/deploy-staging.yml`              | `docker-compose.phala.yml`     | `phala deploy` command                              | WIRED  | Lines 109; `deploy-tee-phala` job |
+| `.planning/codebase/STACK.md`                       | `apps/tee-worker/package.json` | Documents `@phala/dstack-sdk ^0.5.7`                | WIRED  | Line 316                          |
 
 ### Behavioral Spot-Checks
 
-| Behavior | Command | Result | Status |
-|----------|---------|--------|--------|
-| All 4 TEE test files (56 tests) pass | `pnpm --filter cipherbox-tee-worker test` | `5 passed, 56 tests passed, 8 todo` | PASS |
-| TypeScript compiles with zero errors | `pnpm exec tsc --noEmit` | (no output = success) | PASS |
-| Shared packages build successfully | `pnpm --filter @cipherbox/crypto build` etc. | All 4 packages built successfully | PASS |
+| Behavior                             | Command                                      | Result                              | Status |
+| ------------------------------------ | -------------------------------------------- | ----------------------------------- | ------ |
+| All 4 TEE test files (56 tests) pass | `pnpm --filter cipherbox-tee-worker test`    | `5 passed, 56 tests passed, 8 todo` | PASS   |
+| TypeScript compiles with zero errors | `pnpm exec tsc --noEmit`                     | (no output = success)               | PASS   |
+| Shared packages build successfully   | `pnpm --filter @cipherbox/crypto build` etc. | All 4 packages built successfully   | PASS   |
 
 ### Requirements Coverage
 
-No requirements from REQUIREMENTS.md are mapped to Phase 35. All 6 plan `requirements` fields are empty arrays `[]`. This is consistent with Phase 35 being an infrastructure migration (no new functional requirements -- implements existing REQ-* items via platform change). PERF-04 (TEE republish batch duration histogram) is listed as completed in REQUIREMENTS.md and is satisfied by the `cipherbox_tee_republish_entries_total` counter added in plan 03.
+No requirements from REQUIREMENTS.md are mapped to Phase 35. All 6 plan `requirements` fields are empty arrays `[]`. This is consistent with Phase 35 being an infrastructure migration (no new functional requirements -- implements existing REQ-\* items via platform change). PERF-04 (TEE republish batch duration histogram) is listed as completed in REQUIREMENTS.md and is satisfied by the `cipherbox_tee_republish_entries_total` counter added in plan 03.
 
 No orphaned requirements found.
 
@@ -131,6 +131,7 @@ One informational note: the `republish.test.ts` file dynamically imports the rep
 No gaps found. All 22 automatable must-haves are verified. The 2 remaining items (live CVM health, GitHub env config) require human confirmation of external service state that cannot be checked programmatically without credentials.
 
 The phase goal is substantively achieved:
+
 - TEE worker migrated to `apps/tee-worker/` with shared package integration (plans 01)
 - 56 passing unit tests covering all TEE-specific orchestration logic (plan 02)
 - dstack SDK, Prometheus metrics, structured logging added (plan 03)

--- a/packages/sdk-core/src/__tests__/pinning/kubo-provider.test.ts
+++ b/packages/sdk-core/src/__tests__/pinning/kubo-provider.test.ts
@@ -177,4 +177,35 @@ describe('KuboProvider', () => {
       expect(mockFetch.mock.calls[0][0]).not.toContain('//api');
     });
   });
+
+  describe('browser this-binding regression', () => {
+    it('default fetchFn works when global fetch is this-sensitive (browser native fetch)', async () => {
+      // Browser native fetch throws "Illegal invocation" when invoked with a
+      // `this` other than the global object (e.g. as `this.fetchFn(...)` on a
+      // provider instance). Node's fetch is not this-sensitive, so a plain
+      // vi.fn() stub can never catch a missing .bind — this mock reproduces
+      // the browser contract.
+      const calls: unknown[] = [];
+      function strictFetch(this: unknown, ...args: unknown[]) {
+        if (this !== globalThis && this !== undefined) {
+          throw new TypeError("Failed to execute 'fetch' on 'Window': Illegal invocation");
+        }
+        calls.push(args);
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ Hash: 'bafyBound', Size: '7' })),
+        });
+      }
+      vi.stubGlobal('fetch', strictFetch);
+      try {
+        // Construct AFTER stubbing — the constructor captures globalThis.fetch
+        const boundProvider = new KuboProvider(endpoint);
+        const result = await boundProvider.pin(new Uint8Array([1, 2, 3]));
+        expect(result).toEqual({ cid: 'bafyBound', size: 7 });
+        expect(calls).toHaveLength(1);
+      } finally {
+        vi.stubGlobal('fetch', mockFetch);
+      }
+    });
+  });
 });

--- a/packages/sdk-core/src/__tests__/pinning/psa-provider.test.ts
+++ b/packages/sdk-core/src/__tests__/pinning/psa-provider.test.ts
@@ -191,4 +191,30 @@ describe('PsaProvider', () => {
       await expect(provider.get('bafyAny')).rejects.toThrow('does not support content retrieval');
     });
   });
+
+  describe('browser this-binding regression', () => {
+    it('default fetchFn works when global fetch is this-sensitive (browser native fetch)', async () => {
+      // Mirrors browser native fetch, which throws "Illegal invocation" when
+      // invoked with a `this` other than the global object. Guards against
+      // regressing the .bind(globalThis) on the default fetchFn fallback.
+      function strictFetch(this: unknown) {
+        if (this !== globalThis && this !== undefined) {
+          throw new TypeError("Failed to execute 'fetch' on 'Window': Illegal invocation");
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ pin: { cid: 'bafyBound' }, status: 'pinned' }),
+        });
+      }
+      vi.stubGlobal('fetch', strictFetch);
+      try {
+        // Construct AFTER stubbing — the constructor captures globalThis.fetch
+        const boundProvider = new PsaProvider(endpoint, authToken);
+        const result = await boundProvider.pinByCid('bafyBound');
+        expect(result.cid).toBe('bafyBound');
+      } finally {
+        vi.stubGlobal('fetch', mockFetch);
+      }
+    });
+  });
 });

--- a/packages/sdk-core/src/pinning/kubo-provider.ts
+++ b/packages/sdk-core/src/pinning/kubo-provider.ts
@@ -19,7 +19,10 @@ export class KuboProvider implements PinningProvider {
     // Normalize: strip trailing slash
     this.endpoint = endpoint.replace(/\/+$/, '');
     this.authToken = authToken;
-    this.fetchFn = options?.fetchFn ?? globalThis.fetch;
+    // Bind the fallback: invoking native fetch as `this.fetchFn(...)` sets `this`
+    // to the provider instance, which throws "Illegal invocation" in browsers
+    // (Node's fetch is not this-sensitive, so only real browsers hit it).
+    this.fetchFn = options?.fetchFn ?? globalThis.fetch.bind(globalThis);
     this.timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
 

--- a/packages/sdk-core/src/pinning/psa-provider.ts
+++ b/packages/sdk-core/src/pinning/psa-provider.ts
@@ -38,7 +38,10 @@ export class PsaProvider implements PinningProvider {
     // Normalize: strip trailing slash
     this.endpoint = endpoint.replace(/\/+$/, '');
     this.authToken = authToken;
-    this.fetchFn = options?.fetchFn ?? globalThis.fetch;
+    // Bind the fallback: invoking native fetch as `this.fetchFn(...)` sets `this`
+    // to the provider instance, which throws "Illegal invocation" in browsers
+    // (Node's fetch is not this-sensitive, so only real browsers hit it).
+    this.fetchFn = options?.fetchFn ?? globalThis.fetch.bind(globalThis);
     this.timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -73,7 +73,7 @@
       "component": "@cipherbox/web",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.41.0"
+      "release-as": "0.42.0"
     },
     "apps/desktop": {
       "release-type": "node",
@@ -119,7 +119,7 @@
       "component": "@cipherbox/sdk-core",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.36.1"
+      "release-as": "0.36.2"
     },
     "packages/sdk": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

- **The fix:** `KuboProvider` and `PsaProvider` defaulted to unbound `globalThis.fetch` and invoked it as `this.fetchFn(...)`. Native browser fetch called with `this` set to the provider instance throws `TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation`, which broke **all uploads for accounts with external/dual pinning mode** — instant 0% failure with no network request and no console output (the error was swallowed by a silent catch in the upload pipeline). Node's fetch is not this-sensitive, so no automated test ever caught it; the bug was latent since Phase 21. Fix: `globalThis.fetch.bind(globalThis)` in both providers.
- **Regression tests:** added this-sensitive fetch stubs to both provider test suites that reproduce the exact production failure pre-fix (`PinataProvider` uses bare `fetch(...)` calls and was never affected).
- **UAT debt cleared 18 → 0:** completed human UAT records for phases 19.1 (9/9 pass), 21 (4/5 pass, 3 gaps diagnosed), and 35 (Phala items resolved against post-#472 infra). The fix was verified end-to-end in a real browser against a local Kubo node, including an in-app upload in external-only mode with zero relay calls.
- **Docs:** updated stale planning docs that still described the staging TEE worker as a Phala Cloud CVM — staging has run a local Docker simulator on the VPS since #472; Phala Cloud CVM remains the production design.

## Diagnosed gaps recorded for follow-up (not fixed here)

- Web app never calls `PATCH /vault/byo-status`, so the advisory quota badge is unreachable through the product flow (major, 21-UAT)
- `MigrationProgress` stops polling permanently after a terminal job; failed jobs render as "migrating:" (minor, 21-UAT)
- Migration stats double-count when the API 120s batch timeout fires mid-batch (minor, 21-UAT)
- Orphaned `PHALA_CLOUD_API_KEY` secret + `PHALA_TEE_WORKER_URL` variable in the GitHub staging environment (minor, 35-UAT)

## Test plan

- [x] `pnpm --filter @cipherbox/sdk-core test` — including new browser this-binding regression tests, proven to fail pre-fix
- [x] Live browser verification: negative control reproduced Illegal invocation; fixed provider pinned successfully to a real Kubo node (`ipfs pin ls` confirmed recursive pin)
- [x] In-app upload under external-only pinning mode: completed with pins landing on the BYO node and zero relay calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser compatibility issue in SDK that prevented fetch-based pinning operations from completing successfully.

* **Version Updates**
  * Web app upgraded to 0.42.0
  * SDK Core updated to 0.36.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->