### PR TITLE
fix: resolve UAT audit findings in BYO pinning and migration flows

### DIFF
--- a/.planning/phases/35-phala-testnet-tee-migration/35-UAT.md
+++ b/.planning/phases/35-phala-testnet-tee-migration/35-UAT.md
@@ -42,11 +42,12 @@ blocked: 0
 ## Gaps
 
 - truth: 'CI configuration contains only secrets/variables that are consumed by workflows'
-  status: failed
+  status: not-applicable
   reason: 'PHALA_CLOUD_API_KEY (secret) and PHALA_TEE_WORKER_URL (variable) remain configured in the GitHub staging environment but nothing references them — #472 removed the deploy-tee-phala job, the only consumer. The API key is a live credential for a retired service lingering in CI config.'
   severity: minor
   test: 2
   root_cause: '#472 (f270d843a) removed the workflow consumers but did not clean up the GitHub environment entries (not version-controlled, easy to miss in a code-only PR).'
+  resolution: 'Marked not-applicable 2026-06-11 (audit-fix F-08): Phala credits are expected, which would bring back the Phala Cloud staging TEE infra — the entries stay inert intentionally and will be consumed again when the deploy-tee-phala path returns.'
   artifacts:
   - path: 'GitHub repo Settings -> Environments -> staging'
     issue: 'orphaned PHALA_CLOUD_API_KEY secret and PHALA_TEE_WORKER_URL variable'

--- a/apps/api/src/migration/migration.processor.spec.ts
+++ b/apps/api/src/migration/migration.processor.spec.ts
@@ -362,6 +362,33 @@ describe('MigrationProcessor', () => {
       );
     });
 
+    it('should use a 300s batch timeout exceeding worst-case TEE batch duration (~130s)', async () => {
+      const timeoutSpy = jest.spyOn(AbortSignal, 'timeout');
+
+      const migration = { ...baseMigration, status: 'running' as const };
+      mockMigrationRepo.findOneOrFail
+        .mockResolvedValueOnce(migration)
+        .mockResolvedValueOnce(migration)
+        .mockResolvedValueOnce(migration);
+
+      mockPinnedCidRepo.find.mockResolvedValue(makePinnedCids(1));
+      mockConfigService.get
+        .mockReturnValueOnce('https://tee.example.com')
+        .mockReturnValueOnce('secret-token');
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ succeeded: ['bafkrei0'], failed: [] }),
+      });
+      mockMigrationRepo.update.mockResolvedValue({ affected: 1 });
+
+      await processor.process(makeJob(testMigrationId));
+
+      expect(timeoutSpy).toHaveBeenCalledWith(300_000);
+
+      timeoutSpy.mockRestore();
+    });
+
     it('should pause migration on TEE 401 auth failure', async () => {
       const migration = { ...baseMigration, status: 'running' as const };
       mockMigrationRepo.findOneOrFail

--- a/apps/api/src/migration/migration.processor.ts
+++ b/apps/api/src/migration/migration.processor.ts
@@ -80,7 +80,11 @@ export class MigrationProcessor extends WorkerHost {
             sourceConfigEncrypted: migration.sourceConfigEncrypted,
             destConfigEncrypted: migration.destConfigEncrypted,
           }),
-          signal: AbortSignal.timeout(120_000), // 2 min per batch
+          // 5 min per batch. Observed worst-case TEE batch duration is ~130s;
+          // the timeout must comfortably exceed it, otherwise an in-flight batch
+          // gets aborted client-side and counted as failed even though the TEE
+          // worker completes it (double-counting race).
+          signal: AbortSignal.timeout(300_000),
         });
 
         if (!response.ok) {

--- a/apps/api/src/migration/migration.service.spec.ts
+++ b/apps/api/src/migration/migration.service.spec.ts
@@ -298,7 +298,7 @@ describe('MigrationService', () => {
 
   describe('updateProgress', () => {
     it('should increment migratedCids and failedCids counters', async () => {
-      const migration = { ...mockMigrationEntity, migratedCids: 2, failedCids: 1 };
+      const migration = { ...mockMigrationEntity, totalCids: 10, migratedCids: 2, failedCids: 1 };
       mockMigrationRepo.findOneOrFail.mockResolvedValue(migration);
       mockMigrationRepo.save.mockResolvedValue(migration);
 
@@ -346,6 +346,78 @@ describe('MigrationService', () => {
       expect(mockMigrationRepo.save).toHaveBeenCalledWith(
         expect.objectContaining({
           failedCidList: 'bafkrei0,bafkrei1',
+        })
+      );
+    });
+
+    it('should dedupe failedCidList and derive failedCids from the deduped list', async () => {
+      // bafkrei0 already recorded as failed; the same batch is re-reported
+      // (e.g. HTTP timeout abort followed by a retry of the same batch).
+      const migration = {
+        ...mockMigrationEntity,
+        totalCids: 5,
+        migratedCids: 0,
+        failedCids: 1,
+        failedCidList: 'bafkrei0',
+      };
+      mockMigrationRepo.findOneOrFail.mockResolvedValue(migration);
+      mockMigrationRepo.save.mockResolvedValue(migration);
+
+      await service.updateProgress(testMigrationId, 0, 2, ['bafkrei0', 'bafkrei1']);
+
+      expect(mockMigrationRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          failedCidList: 'bafkrei0,bafkrei1',
+          failedCids: 2, // deduped list length, NOT 1 + 2 = 3
+        })
+      );
+    });
+
+    it('should clamp migratedCids so migrated + failed never exceeds totalCids', async () => {
+      // Double-reported batch: a 5-CID batch timed out (counted as 5 failed),
+      // then the TEE worker actually completed it and reports 5 migrated.
+      const migration = {
+        ...mockMigrationEntity,
+        totalCids: 5,
+        migratedCids: 3,
+        failedCids: 5,
+        failedCidList: 'bafkrei0,bafkrei1,bafkrei2,bafkrei3,bafkrei4',
+      };
+      mockMigrationRepo.findOneOrFail.mockResolvedValue(migration);
+      mockMigrationRepo.save.mockResolvedValue(migration);
+
+      await service.updateProgress(testMigrationId, 5, 0);
+
+      expect(mockMigrationRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          // migratedCids capped at totalCids - failedCids = 0, not 3 + 5 = 8
+          migratedCids: 0,
+          failedCids: 5,
+        })
+      );
+      const saved = mockMigrationRepo.save.mock.calls[0][0];
+      expect(saved.migratedCids + saved.failedCids).toBeLessThanOrEqual(saved.totalCids);
+    });
+
+    it('should keep totals within totalCids when duplicate failed reports arrive', async () => {
+      // All 3 CIDs already failed once; the identical failure report arrives again.
+      const migration = {
+        ...mockMigrationEntity,
+        totalCids: 3,
+        migratedCids: 0,
+        failedCids: 3,
+        failedCidList: 'bafkrei0,bafkrei1,bafkrei2',
+      };
+      mockMigrationRepo.findOneOrFail.mockResolvedValue(migration);
+      mockMigrationRepo.save.mockResolvedValue(migration);
+
+      await service.updateProgress(testMigrationId, 0, 3, ['bafkrei0', 'bafkrei1', 'bafkrei2']);
+
+      expect(mockMigrationRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          migratedCids: 0,
+          failedCids: 3, // unchanged — duplicates deduped
+          failedCidList: 'bafkrei0,bafkrei1,bafkrei2',
         })
       );
     });

--- a/apps/api/src/migration/migration.service.ts
+++ b/apps/api/src/migration/migration.service.ts
@@ -166,12 +166,27 @@ export class MigrationService {
     });
 
     migration.migratedCids += migratedDelta;
-    migration.failedCids += failedDelta;
 
     if (failedCids && failedCids.length > 0) {
       const existingList = migration.failedCidList ? migration.failedCidList.split(',') : [];
       existingList.push(...failedCids);
-      migration.failedCidList = existingList.join(',');
+      const dedupedList = [...new Set(existingList)];
+      migration.failedCidList = dedupedList.join(',');
+      // The deduped list is the source of truth for the failed count, so
+      // re-reported CIDs (e.g. retried batches) never inflate it.
+      migration.failedCids = dedupedList.length;
+    } else {
+      migration.failedCids += failedDelta;
+    }
+
+    // Clamp so migrated + failed never exceeds totalCids. Guards against
+    // double-reported batches (e.g. an HTTP timeout abort counted as failed
+    // while the TEE worker actually completed the batch and it later succeeds).
+    if (
+      migration.totalCids > 0 &&
+      migration.migratedCids + migration.failedCids > migration.totalCids
+    ) {
+      migration.migratedCids = Math.max(0, migration.totalCids - migration.failedCids);
     }
 
     await this.migrationRepo.save(migration);

--- a/apps/web/src/components/settings/MigrationProgress.tsx
+++ b/apps/web/src/components/settings/MigrationProgress.tsx
@@ -59,6 +59,7 @@ export function MigrationProgress() {
   const isActive = migration.status === 'running' || migration.status === 'pending';
   const isPaused = migration.status === 'paused';
   const isComplete = migration.status === 'completed';
+  const isFailed = migration.status === 'failed';
 
   const handlePause = async () => {
     await migrationApi.pause(migration.id);
@@ -104,6 +105,10 @@ export function MigrationProgress() {
       {isComplete ? (
         <p className="migration-progress-text migration-complete">
           {`> migration complete. ${migration.totalCids} pins transferred.`}
+        </p>
+      ) : isFailed ? (
+        <p className="migration-failed-text">
+          {`> migration failed: ${migration.migratedCids}/${migration.totalCids} pins migrated`}
         </p>
       ) : (
         <p className="migration-progress-text">

--- a/apps/web/src/components/settings/StorageTab.tsx
+++ b/apps/web/src/components/settings/StorageTab.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { type ConnectionTestResult, type PinningMode } from '@cipherbox/sdk-core';
+import { vaultControllerSetByoStatus } from '@cipherbox/api-client';
 import {
   wrapKey,
   unwrapKey,
@@ -17,6 +18,7 @@ import { ConnectionTest } from './ConnectionTest';
 import { MigrationProgress } from './MigrationProgress';
 import { migrationApi } from '../../lib/api/migration';
 import { reconfigurePinning } from '../../lib/sdk-provider';
+import { logger } from '../../lib/logger';
 
 /** Local storage key for the BYO config IPNS name (not sensitive -- public identifier) */
 const BYO_IPNS_NAME_KEY = 'cipherbox-byo-ipns-name';
@@ -255,6 +257,15 @@ export function StorageTab() {
         );
 
         await migrationApi.start(sourceConfigEncrypted, destConfigEncrypted);
+      }
+
+      // Sync BYO advisory-quota flag on the server (external/dual = BYO enabled).
+      // Non-fatal: the pinning config is already saved; failure only delays the
+      // advisory badge until the next save.
+      try {
+        await vaultControllerSetByoStatus({ isByo: mode !== 'cipherbox' });
+      } catch (err) {
+        logger.warn('[BYO] failed to update byo-status flag', err);
       }
 
       useQuotaStore.getState().fetchQuota();

--- a/apps/web/src/components/settings/StorageTab.tsx
+++ b/apps/web/src/components/settings/StorageTab.tsx
@@ -77,6 +77,9 @@ export function StorageTab() {
   const [isSaving, setIsSaving] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [saveError, setSaveError] = useState<string | null>(null);
+  // Incremented each time a new migration starts to remount MigrationProgress,
+  // restarting its poll loop (it stops permanently on terminal statuses)
+  const [migrationRunId, setMigrationRunId] = useState(0);
 
   const vaultKeypair = useAuthStore((s) => s.vaultKeypair);
   const teeKeys = useAuthStore((s) => s.teeKeys);
@@ -257,6 +260,7 @@ export function StorageTab() {
         );
 
         await migrationApi.start(sourceConfigEncrypted, destConfigEncrypted);
+        setMigrationRunId((id) => id + 1);
       }
 
       // Sync BYO advisory-quota flag on the server (external/dual = BYO enabled).
@@ -435,7 +439,7 @@ export function StorageTab() {
       )}
 
       {/* Migration Progress (shown when active migration exists) */}
-      <MigrationProgress />
+      <MigrationProgress key={migrationRunId} />
     </div>
   );
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -84,7 +84,7 @@
         "src-tauri/tauri.conf.json",
         "src-tauri/Cargo.toml"
       ],
-      "release-as": "0.41.0"
+      "release-as": "0.42.0"
     },
     "apps/tee-worker": {
       "release-type": "node",
@@ -112,14 +112,14 @@
       "component": "@cipherbox/api-client",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.38.0"
+      "release-as": "0.38.1"
     },
     "packages/sdk-core": {
       "release-type": "node",
       "component": "@cipherbox/sdk-core",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.36.2"
+      "release-as": "0.36.3"
     },
     "packages/sdk": {
       "release-type": "node",
@@ -152,7 +152,7 @@
       "component": "cipherbox-fuse",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.5.3"
+      "release-as": "0.5.4"
     },
     "crates/sdk": {
       "release-type": "rust",


### PR DESCRIPTION
## Summary

Closes out the outstanding `/gsd:audit-fix` findings from the cross-phase UAT/verification audit (sources: phase 21 BYO IPFS UAT, phase 35 Phala TEE UAT). Four findings resolved — three code fixes and one documentation disposition.

## Changes

### F-03 — BYO quota badge was unreachable (high)

`StorageTab` save flow now calls `PATCH /vault/byo-status` (`vaultControllerSetByoStatus`) after persisting the pinning config: `isByo: true` for external/dual mode, `false` for cipherbox. The call is non-fatal — a failure logs a warning and never trips the save error. The existing `fetchQuota()` immediately after picks up the advisory flag, so the quota badge updates in the same save.

**Key files:** `apps/web/src/components/settings/StorageTab.tsx`

### F-04 — stale failed migration rendered as active, polling never restarted (medium)

- `MigrationProgress` now renders terminal failed jobs as `> migration failed: X/Y pins migrated` (error styling) instead of the active-looking `migrating: X/Y pins`.
- `StorageTab` remounts `MigrationProgress` (React `key` keyed on a `migrationRunId` counter incremented after `migrationApi.start`) so a new migration restarts the poll loop instead of displaying the previous terminal job until remount.

**Key files:** `apps/web/src/components/settings/MigrationProgress.tsx`, `apps/web/src/components/settings/StorageTab.tsx`

### F-05 — migration stats double-counted on batch timeout race (medium)

- Batch HTTP timeout raised 120s → 300s; observed worst-case TEE batch duration is ~130s, so the old timeout aborted in-flight batches client-side and counted them failed while the TEE worker completed them (observed: 77 results on a 57-CID migration).
- `MigrationService.updateProgress` is now self-consistent: `failedCidList` is deduped and becomes the source of truth for the failed count, and `migratedCids` is clamped so `migrated + failed` never exceeds `totalCids` on double-reported batches.

**Key files:** `apps/api/src/migration/migration.processor.ts`, `apps/api/src/migration/migration.service.ts`

### F-08 — orphaned Phala staging credentials (medium)

Marked not-applicable in `35-UAT.md`: Phala credits are expected, the staging TEE will likely return to Phala Cloud, so `PHALA_CLOUD_API_KEY` / `PHALA_TEE_WORKER_URL` stay inert intentionally.

## Verification

- [x] `apps/api` migration specs: 38/38 passing (3 new dedup/clamp tests + a 300s timeout assertion)
- [x] `apps/web` test suite: 23/23 passing
- [x] `tsc --noEmit` and eslint clean on all touched files
- No API contract changes (no DTO/controller/endpoint signatures touched) — no client regeneration needed
- Not covered by automated tests (no component-test infra in apps/web): visual confirmation of the failed-migration text and badge activation after save

## Key Decisions

- F-05 stays within existing columns — no schema change. The deduped `failedCidList` is the failure source of truth; per-CID success tracking (full idempotency) was deliberately deferred.
- Remount-via-`key` chosen over lifting poll state for F-04 — smallest change that restarts polling in the product flow.
- Audit findings F-01/F-02/F-06/F-07/F-09 were verified already fixed on main; F-10 below severity threshold.

## TDD Audit

| Test commit | Impl commit | gate_status |
| ----------- | ----------- | ----------- |
| — | `779510385` fix(web): resolve F-03 — wire byo-status flag into storage tab save flow | missing |
| — | `e4276235d` fix(web): resolve F-04 — render failed migrations distinctly and restart progress polling on new migration | missing |
| — | `97ee0a56f` fix(api): resolve F-05 — raise migration batch timeout and make progress accounting idempotent | missing |
| — | `aadc6c9e0` chore(planning): resolve F-08 — mark orphaned phala staging credentials not applicable | missing |

Aggregate: 0 skill, 0 fallback, 0 exempt — 4 missing (audit-fix pipeline commits; F-05 tests landed with the impl commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

gate_status: skill=0, fallback=0, exempt=0, missing=4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated failed migration status display showing migrated/total counts
  * Storage settings now sync BYO enablement status to server

* **Bug Fixes**
  * Increased TEE service request timeout to 5 minutes to prevent premature operation failures
  * Fixed migration progress tracking to prevent double-counting of failed batches
  * Deduplicated failed CID reporting for accurate failure counts

* **Tests**
  * Added timeout verification coverage for migration processing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->