### PR TITLE
docs: protocol and privacy hardening exploration, plus v1.1 audit

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -10,8 +10,8 @@ Requirements for IPFS infrastructure milestone. Each maps to roadmap phases.
 ### IPNS Reliability
 
 - [x] **IPNS-01**: Self-hosted Someguy deployed alongside Kubo, replacing delegated-ipfs.dev as primary IPNS routing provider
-- [ ] **IPNS-02**: IPNS resolution uses DB-first strategy with async Kubo DHT verification via self-hosted Someguy
-- [ ] **IPNS-03**: Recovery tool resolves IPNS via self-hosted Someguy instead of delegated-ipfs.dev
+- [x] **IPNS-02**: IPNS resolution uses DB-first strategy with async Kubo DHT verification via self-hosted Someguy
+- [x] **IPNS-03**: Recovery tool resolves IPNS via self-hosted Someguy instead of delegated-ipfs.dev
 - [x] **IPNS-04**: System degrades gracefully when DHT resolution is slow (timeout + DB fallback within 2s)
 
 ### Vault Migration
@@ -54,8 +54,8 @@ Requirements for IPFS infrastructure milestone. Each maps to roadmap phases.
 - [x] **SDK-05**: sdk-core IPFS/IPNS functions accept SdkContext (apiUrl + getAccessToken) instead of reading browser globals
 - [x] **SDK-06**: @cipherbox/sdk provides stateful CipherBoxClient class with internal folder tree, key cache, and event emission
 - [x] **SDK-07**: SDK bin operations (add, restore, permanent delete, empty) and share operations (create, revoke) work through stateful client
-- [ ] **SDK-08**: Web app creates CipherBoxClient on vault load and destroys on logout; Zustand stores subscribe to SDK events
-- [ ] **SDK-09**: React hooks refactored to thin wrappers calling SDK client methods instead of service functions directly
+- [x] **SDK-08**: Web app creates CipherBoxClient on vault load and destroys on logout; Zustand stores subscribe to SDK events
+- [x] **SDK-09**: React hooks refactored to thin wrappers calling SDK client methods instead of service functions directly
 - [x] **SDK-10**: All transitional re-exports removed from @cipherbox/crypto; domain type imports enforced at compile time
 - [x] **SDK-11**: Release Please configured for independent per-package versioning
 
@@ -142,8 +142,8 @@ Which phases cover which requirements. Updated during roadmap creation.
 | Requirement | Phase      | Status   |
 | ----------- | ---------- | -------- |
 | IPNS-01     | Phase 19   | Complete |
-| IPNS-02     | Phase 19   | Pending  |
-| IPNS-03     | Phase 19   | Pending  |
+| IPNS-02     | Phase 19   | Complete |
+| IPNS-03     | Phase 19   | Complete |
 | IPNS-04     | Phase 19   | Complete |
 | VAULT-01    | Phase 20   | Complete |
 | VAULT-02    | Phase 20   | Complete |
@@ -174,8 +174,8 @@ Which phases cover which requirements. Updated during roadmap creation.
 | SDK-05      | Phase 19.1 | Complete |
 | SDK-06      | Phase 19.1 | Complete |
 | SDK-07      | Phase 19.1 | Complete |
-| SDK-08      | Phase 19.1 | Pending  |
-| SDK-09      | Phase 19.1 | Pending  |
+| SDK-08      | Phase 19.1 | Complete |
+| SDK-09      | Phase 19.1 | Complete |
 | SDK-10      | Phase 19.1 | Complete |
 | SDK-11      | Phase 19.1 | Complete |
 | RSDK-01     | Phase 23   | Complete |
@@ -217,4 +217,4 @@ Which phases cover which requirements. Updated during roadmap creation.
 ---
 
 _Requirements defined: 2026-03-07_
-_Last updated: 2026-03-26 after Phase 27 completion (SHARE-01 through SHARE-10 all complete)_
+_Last updated: 2026-06-11 by milestone audit (IPNS-02/03, SDK-08/09 checkboxes reconciled with phase verifications)_

--- a/.planning/notes/ipns-write-auth-is-cryptographic.md
+++ b/.planning/notes/ipns-write-auth-is-cryptographic.md
@@ -1,0 +1,46 @@
+---
+title: IPNS write authorization is cryptographic, not server-enforced
+created: 2026-06-11
+area: architecture
+related:
+  - .planning/seeds/blind-share-social-graph.md
+  - .planning/todos/pending/2026-02-22-crdt-ipns-inbox-sharing.md
+---
+
+## Finding
+
+The CipherBox API does not authorize IPNS writes. Authorization to publish to an
+IPNS name is possession of that name's Ed25519 private key — real DHT resolvers
+verify the record signature against the `ipnsName` (which is the encoded public
+key). A write-share recipient can publish solely because they hold the
+ECIES-wrapped IPNS private key. The server is not in that trust path.
+
+## What the server actually does on publish
+
+- The publish path keys the canonical DB row by `(userId, ipnsName)`
+  (`apps/api/src/ipns/ipns.service.ts:351-353`).
+- When a write-share recipient publishes to the owner's `ipnsName`, they have no
+  row of their own, so `findActiveWriteShare` redirects the update onto the
+  owner's row (`ipns.service.ts:213-218`). This is DB-row routing, not a security
+  check — strip it and the recipient's publish merely forks a duplicate row under
+  their own `userId`.
+- The resolve path keys by `ipnsName` alone (`ipns.service.ts:418-419`); it never
+  consults the share edge.
+- `publishRecord` validates base64 and, only when `publicKey` is supplied, that it
+  derives to the `ipnsName` (`ipns.service.ts:68-83`). It never verifies the
+  record's Ed25519 signature, and it self-increments the sequence number
+  (`ipns.service.ts:246`) instead of reading it from the signed record — the
+  acknowledged cause of DB-seq vs record-seq divergence (`ipns.service.ts:543`).
+
+## Implications
+
+- The owner→recipient social edge stored in `shares` is a caching/routing
+  dependency, not a security boundary.
+- It is not even sufficient for revocation: a revoked recipient still physically
+  holds the IPNS private key, so real revocation requires key rotation (which the
+  rotation path already performs).
+- The social graph can therefore be blinded without weakening write control — see
+  the `blind-share-social-graph` seed. The enabling change (server verifies the
+  record signature against the `ipnsName` and keys the record by `ipnsName`) also
+  closes the sequence-integrity gap, so the privacy and protocol-hardening threads
+  converge on one change.

--- a/.planning/phases/18-performance-instrumentation/18-VALIDATION.md
+++ b/.planning/phases/18-performance-instrumentation/18-VALIDATION.md
@@ -1,10 +1,11 @@
 ---
 phase: 18
 slug: performance-instrumentation
-status: draft
-nyquist_compliant: false
-wave_0_complete: false
+status: validated
+nyquist_compliant: true
+wave_0_complete: true
 created: 2026-03-07
+validated: 2026-06-11
 ---
 
 # Phase 18 — Validation Strategy
@@ -36,15 +37,15 @@ created: 2026-03-07
 
 ## Per-Task Verification Map
 
-| Task ID  | Plan | Wave | Requirement | Test Type | Automated Command                                                         | File Exists       | Status  |
-| -------- | ---- | ---- | ----------- | --------- | ------------------------------------------------------------------------- | ----------------- | ------- |
-| 18-01-01 | 01   | 1    | PERF-01     | unit      | `cd apps/api && npx jest src/metrics/metrics.service.spec.ts -x`          | W0                | pending |
-| 18-01-02 | 01   | 1    | PERF-01     | unit      | `cd apps/api && npx jest src/ipns/ipns.service.spec.ts -x`                | Existing (update) | pending |
-| 18-01-03 | 01   | 1    | PERF-01     | unit      | `cd apps/api && npx jest src/ipfs/ipfs.controller.spec.ts -x`             | Existing (update) | pending |
-| 18-01-04 | 01   | 1    | PERF-02     | existing  | `cd apps/api && npx jest src/metrics/http-metrics.interceptor.spec.ts -x` | W0                | pending |
-| 18-02-01 | 02   | 1    | PERF-03     | manual    | Verify `alloy-config.river` has prometheus.scrape "kubo" block            | N/A (config)      | pending |
-| 18-02-02 | 02   | 1    | PERF-03     | manual    | Verify `cipherbox-staging.json` has Kubo Health panels                    | N/A (JSON)        | pending |
-| 18-03-01 | 03   | 1    | PERF-04     | unit      | `cd apps/api && npx jest src/republish/republish.processor.spec.ts -x`    | Existing (update) | pending |
+| Task ID  | Plan | Wave | Requirement | Test Type | Automated Command                                                         | File Exists    | Status |
+| -------- | ---- | ---- | ----------- | --------- | ------------------------------------------------------------------------- | -------------- | ------ |
+| 18-01-01 | 01   | 1    | PERF-01     | unit      | `cd apps/api && npx jest src/metrics/metrics.service.spec.ts -x`          | Yes (9 tests)  | green  |
+| 18-01-02 | 01   | 1    | PERF-01     | unit      | `cd apps/api && npx jest src/ipns/ipns.service.spec.ts -x`                | Yes (71 tests) | green  |
+| 18-01-03 | 01   | 1    | PERF-01     | unit      | `cd apps/api && npx jest src/ipfs/ipfs.controller.spec.ts -x`             | Yes (20 tests) | green  |
+| 18-01-04 | 01   | 1    | PERF-02     | unit      | `cd apps/api && npx jest src/metrics/http-metrics.interceptor.spec.ts -x` | Yes (25 tests) | green  |
+| 18-02-01 | 02   | 1    | PERF-03     | manual    | Verify `alloy-config.river` has prometheus.scrape "kubo" block            | N/A (config)   | green  |
+| 18-02-02 | 02   | 1    | PERF-03     | manual    | Verify `cipherbox-staging.json` has Kubo Health panels                    | N/A (JSON)     | green  |
+| 18-03-01 | 03   | 1    | PERF-04     | unit      | `cd apps/api && npx jest src/republish/republish.processor.spec.ts -x`    | Yes (11 tests) | green  |
 
 _Status: pending · green · red · flaky_
 
@@ -52,8 +53,8 @@ _Status: pending · green · red · flaky_
 
 ## Wave 0 Requirements
 
-- [ ] `apps/api/src/metrics/metrics.service.spec.ts` — stubs for PERF-01, PERF-04: verify new histograms are registered and observable
-- [ ] `apps/api/src/metrics/http-metrics.interceptor.spec.ts` — stubs for PERF-02: verify interceptor records duration
+- [x] `apps/api/src/metrics/metrics.service.spec.ts` — stubs for PERF-01, PERF-04: verify new histograms are registered and observable (created during execution, 9 tests)
+- [x] `apps/api/src/metrics/http-metrics.interceptor.spec.ts` — stubs for PERF-02: verify interceptor records duration (created by validation audit 2026-06-11, 25 tests)
 
 _Existing spec files for ipns.service, ipfs.controller, and republish.processor need updates to mock and verify new histogram calls._
 
@@ -71,11 +72,21 @@ _Existing spec files for ipns.service, ipfs.controller, and republish.processor 
 
 ## Validation Sign-Off
 
-- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
-- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
-- [ ] Wave 0 covers all MISSING references
-- [ ] No watch-mode flags
-- [ ] Feedback latency < 30s
-- [ ] `nyquist_compliant: true` set in frontmatter
+- [x] All tasks have `<automated>` verify or Wave 0 dependencies
+- [x] Sampling continuity: no 3 consecutive tasks without automated verify
+- [x] Wave 0 covers all MISSING references
+- [x] No watch-mode flags
+- [x] Feedback latency < 30s
+- [x] `nyquist_compliant: true` set in frontmatter
 
-**Approval:** pending
+**Approval:** validated 2026-06-11 via /gsd-validate-phase
+
+## Validation Audit 2026-06-11
+
+| Metric     | Count |
+| ---------- | ----- |
+| Gaps found | 1     |
+| Resolved   | 1     |
+| Escalated  | 0     |
+
+Audit notes: All four unit suites confirmed green (111 pre-existing tests + 25 new). The single gap — missing `http-metrics.interceptor.spec.ts` (PERF-02 Wave 0 item) — was filled with 25 tests covering success/error paths, duration calculation, method and status-code label dimensions, and `/metrics` self-exclusion. Manual PERF-03 items verified directly: `prometheus.scrape "kubo"` block present at `docker/alloy-config.river:83`; Kubo Health panels present in `cipherbox-staging.json`. PERF-02 baseline document `.planning/baselines/18-performance-baselines.md` is populated with staging p50/p95/p99 values.

--- a/.planning/seeds/blind-share-social-graph.md
+++ b/.planning/seeds/blind-share-social-graph.md
@@ -1,0 +1,61 @@
+---
+title: Blind the share social graph via capability-based shares
+trigger_condition: A privacy-hardening milestone is scoped, or the sharing subsystem is reworked for any reason.
+planted_date: 2026-06-11
+area: privacy
+related:
+  - .planning/notes/ipns-write-auth-is-cryptographic.md
+  - .planning/todos/pending/2026-02-22-crdt-ipns-inbox-sharing.md
+---
+
+## Idea
+
+The only remaining privacy gap on the API is the social graph. `shares(sharer_id,
+recipient_id, permission, created_at, revoked_at)` is a directed, typed,
+timestamped owner→recipient edge list that resolves to real identities
+(`users.publicKey` → `auth_methods.identifier`), with per-share item counts
+(`share_keys`) and a plaintext `item_name`. Blind it by moving to capability-based
+shares where the server stores no recipient identity.
+
+## Why this is now a small lever, not a redesign
+
+Per the `ipns-write-auth-is-cryptographic` note, the server does not authorize
+writes — `findActiveWriteShare` only routes a recipient's publish onto the owner's
+DB row. The enabling change is therefore narrow:
+
+- Server verifies the inbound IPNS record's Ed25519 signature against the
+  `ipnsName`, and keys the canonical record by `ipnsName` (not `userId`).
+- Once the publish path is self-authorizing, `recipient_id` is no longer needed
+  for writes, and the same change fixes the sequence self-increment / divergence
+  bug.
+
+A share then becomes `{ipnsName + ECIES-wrapped folderKey [+ wrapped IPNS
+privateKey for write]}` handed to the recipient out-of-band — the invite /
+URL-fragment primitive already exists for link shares. Revocation = key rotation
+(already required).
+
+## Open design questions (resolve at plan time)
+
+- Discovery model — where "what's shared with me" lives without a server edge:
+  - Vault-synced capabilities: recipient stores received capabilities in their own
+    encrypted vault blob; server sees zero graph; a wiped device with no vault
+    recovery loses the list until re-shared.
+  - Blinded inbox: per-recipient inbox keyed by a recipient-derived pseudonym;
+    server-backed listing survives device loss and stays unlinkable. This is the
+    existing CRDT-IPNS-inbox todo (`2026-02-22-crdt-ipns-inbox-sharing.md`) — fold
+    that exploration in here when chosen.
+- Server-side IPNS record validation in Nest: which library validates Ed25519
+  signature + sequence + validity against the signed bytes.
+- Quota / pin attribution for shared content once the edge is gone (`pinned_cids`
+  is per-`userId`).
+- What `GET /shares/received` and revocation become without `recipient_id`; stop
+  the link-share claim path from writing `claimed_by`.
+- Residual traffic correlation: JWT-authed `GET /ipns/resolve?ipnsName=` still ties
+  a recipient's 30s polling to specific shares — full blinding may require
+  unauthenticated, padded, or proxied resolves.
+
+## Lower-hanging hardening (independent of the redesign)
+
+- Drop the plaintext `item_name` from `shares` and `share_invites`.
+- Stop co-storing `recipientPublicKey` in the same row as the wrapped key — the
+  wrapping target currently sits in plaintext beside the ciphertext.

--- a/.planning/seeds/blind-share-social-graph.md
+++ b/.planning/seeds/blind-share-social-graph.md
@@ -10,7 +10,7 @@ related:
 
 ## Idea
 
-The only remaining privacy gap on the API is the social graph. `shares(sharer_id,
+The social graph is the largest remaining privacy gap on the API — not the only one (plaintext `item_name` and `recipientPublicKey` co-storage are listed under Lower-hanging hardening below), but the one that needs a redesign rather than a dropped column. `shares(sharer_id,
 recipient_id, permission, created_at, revoked_at)` is a directed, typed,
 timestamped owner→recipient edge list that resolves to real identities
 (`users.publicKey` → `auth_methods.identifier`), with per-share item counts

--- a/.planning/todos/pending/2026-06-11-fuse-mkdir-parent-publish-orphan.md
+++ b/.planning/todos/pending/2026-06-11-fuse-mkdir-parent-publish-orphan.md
@@ -1,0 +1,37 @@
+---
+created: 2026-06-11
+title: FUSE mkdir orphans the new folder when parent publish conflicts
+area: desktop-fuse
+severity: high
+files:
+  - crates/fuse/src/platform/windows/write_ops.rs
+  - crates/fuse/src/write_ops.rs
+---
+
+## Problem
+
+In `handle_mkdir` the child folder's IPNS record publishes first (seq 0), then the
+parent folder metadata CAS-publishes. On a parent-publish conflict the code only
+warns, claiming "debounced publish will retry" — but `handle_mkdir` never calls
+`queue_publish` / adds the parent to `mutated_folders` (`write_ops.rs:601-610`), so
+nothing actually retries. This is the existing TODO at
+`crates/fuse/src/platform/windows/write_ops.rs:194` (agent reports an identical
+macOS path around `write_ops.rs:584`).
+
+Consequence: the child IPNS record exists remotely as an orphan, but its IPNS
+private key and folder key live only in the parent metadata that was never
+published. After restart the new folder is irrecoverable. A crash before the
+spawned thread runs loses the directory entirely.
+
+Severity: data loss / orphaned remote state.
+
+## Solution
+
+TBD — key considerations:
+
+- On parent-publish conflict, actually enqueue the parent for retry
+  (`queue_publish` / `mutated_folders`) instead of only logging.
+- Make mkdir atomic or replayable so the child is never published without its
+  parent reference committing — ties into the FUSE persisted-journal gap
+  (`2026-06-11-fuse-release-data-loss-before-remote-commit.md`).
+- Verify the macOS path line number by grep before fixing; confirm both platforms.

--- a/.planning/todos/pending/2026-06-11-fuse-release-data-loss-before-remote-commit.md
+++ b/.planning/todos/pending/2026-06-11-fuse-release-data-loss-before-remote-commit.md
@@ -1,0 +1,37 @@
+---
+created: 2026-06-11
+title: FUSE release() reports success then can silently lose data
+area: desktop-fuse
+severity: high
+files:
+  - crates/fuse/src/read_ops.rs
+  - crates/fuse/src/platform/windows/write_ops.rs
+  - packages/sdk/src/queue.rs
+---
+
+## Problem
+
+`flush` is a no-op (`read_ops.rs:852-854`). `release` replies OK to the OS, spawns
+a detached upload thread, then immediately zeroizes and deletes the local temp file
+(`read_ops.rs:835-848`). Upload failure in that thread is `log::error!`-only
+(`read_ops.rs:832-834`). Same pattern on Windows (`windows/write_ops.rs:821-865`).
+
+After the OS-acknowledged close, the only copy of the data is in-memory ciphertext
+in a detached thread. A crash, a kill, or an upload failure = silent permanent data
+loss after the user (and the OS) were told the write succeeded.
+
+Severity: data loss with false durability ack.
+
+## Solution
+
+TBD — key considerations:
+
+- Do not delete/zeroize the temp file until the remote commit (IPFS add + pin +
+  IPNS publish) is durably confirmed.
+- Add a persisted pending-upload journal so a crash can resume on restart. The SDK
+  `WriteQueue` is memory-only and not wired into the FUSE/desktop path
+  (`packages/sdk/src/queue.rs:6-7`) — this is the place to fix that.
+- Surface upload failure to the user instead of swallowing it.
+- Constraint: macOS FUSE callbacks are single-threaded and cannot block on network
+  I/O, so durability must be provided by an out-of-callback durable queue, not by
+  blocking `release`.

--- a/.planning/todos/pending/2026-06-11-ipfs-unpin-missing-ownership-check.md
+++ b/.planning/todos/pending/2026-06-11-ipfs-unpin-missing-ownership-check.md
@@ -1,0 +1,41 @@
+---
+created: 2026-06-11
+title: IPFS unpin has no ownership check — any user can delete any CID
+area: api
+severity: high
+files:
+  - apps/api/src/ipfs/ipfs.controller.ts
+  - apps/api/src/ipfs/providers/local.provider.ts
+  - apps/api/src/vault/entities/pinned-cid.entity.ts
+---
+
+## Problem
+
+`POST /ipfs/unpin` calls Kubo `pin/rm` directly with no check that the caller owns
+the CID (`ipfs.controller.ts:144-148`). On the shared Kubo node this lets any
+authenticated user unpin (and so make eligible for GC) another user's content. The
+victim's `pinned_cids` row and quota charge persist, so the content is gone but
+still billed.
+
+The upload compensation path has the same flaw: on a failed `recordPin` it issues
+`unpinFile(result.cid)` (`ipfs.controller.ts:122`) which calls the global
+`pin/rm` (`local.provider.ts:87`) without checking whether another user also
+references that CID — content-addressed dedup means CIDs can be shared across
+users.
+
+Severity: security / cross-tenant data destruction.
+
+## Solution
+
+TBD — key considerations:
+
+- Before unpinning, verify the caller owns a `pinned_cids(userId, cid)` row
+  (`pinned-cid.entity.ts`) for that CID.
+- Reference-count across users: only issue the global Kubo `pin/rm` when no other
+  user's `pinned_cids` row still references the CID; otherwise just delete the
+  caller's row.
+- Pairs with the quota-decrement todo
+  (`2026-06-11-server-quota-never-decremented-on-unpin.md`) — ownership check,
+  row delete, and quota update should land together.
+- Zero-knowledge constraint preserved: ownership is tracked purely via
+  `pinned_cids(userId, cid)`, which the server already holds; no plaintext needed.

--- a/.planning/todos/pending/2026-06-11-ipns-409-retry-lost-update.md
+++ b/.planning/todos/pending/2026-06-11-ipns-409-retry-lost-update.md
@@ -1,0 +1,41 @@
+---
+created: 2026-06-11
+title: IPNS 409-retry republishes stale children, silently losing concurrent writes
+area: sdk
+severity: high
+files:
+  - packages/sdk-core/src/folder/index.ts
+  - packages/sdk-core/src/file/index.ts
+related:
+  - .planning/notes/ipns-write-auth-is-cryptographic.md
+  - .planning/seeds/blind-share-social-graph.md
+---
+
+## Problem
+
+On a 409 sequence-mismatch, `updateFolderMetadataAndPublish` re-resolves only the
+sequence number and republishes the same CID — built from the stale in-memory
+children — with a bumped sequence, without ever re-fetching or merging the
+concurrent writer's metadata (`folder/index.ts:196-232`). It retries once. So the
+server's CAS check is defeated: a second device's or write-share recipient's
+changes are silently overwritten (lost update).
+
+Related: there is no CAS at all for file IPNS records — `updateFileMetadata` does
+resolve-then-`seq+1`-publish with a TOCTOU window (`file/index.ts:225-231`), so
+concurrent file replaces clobber each other's `versions[]` and content pointers.
+
+Severity: silent data loss for multi-device and writable-share users.
+
+## Solution
+
+TBD — key considerations:
+
+- On 409, re-fetch the remote folder metadata and merge (union children, reconcile
+  per-entry) before republishing — do not bump the sequence on stale state.
+- Conflict resolution must be client-side: the zero-knowledge server cannot merge
+  encrypted metadata (see `ipns-write-auth-is-cryptographic` note).
+- Folder metadata is a single encrypted blob with no per-entry merge granularity
+  today; a principled fix likely needs a merge/CRDT model — connects to the
+  `blind-share-social-graph` seed and the CRDT-IPNS-inbox todo
+  (`2026-02-22-crdt-ipns-inbox-sharing.md`).
+- Extend CAS coverage to file records, not just folder records.

--- a/.planning/todos/pending/2026-06-11-server-quota-never-decremented-on-unpin.md
+++ b/.planning/todos/pending/2026-06-11-server-quota-never-decremented-on-unpin.md
@@ -1,0 +1,36 @@
+---
+created: 2026-06-11
+title: Server quota is never decremented — deletes leak quota until lockout
+area: api
+severity: high
+files:
+  - apps/api/src/vault/vault.service.ts
+  - apps/api/src/ipfs/ipfs.controller.ts
+  - apps/web/src/services/delete.service.ts
+---
+
+## Problem
+
+`recordUnpin` (`vault.service.ts:225-230`) has zero callers. `POST /ipfs/unpin`
+only talks to Kubo (`ipfs.controller.ts:144-148`) and never removes the
+`pinned_cids` row, so `SUM(pinned_cids.size_bytes)` only ever grows. `checkQuota`
+(`vault.service.ts:188-201`) therefore monotonically approaches the limit and
+eventually locks the user out permanently, even after they delete content. The web
+client decrements quota only in local state (`delete.service.ts:17-21`), masking
+the bug in the UI.
+
+Severity: correctness — users get bricked by normal delete usage.
+
+## Solution
+
+TBD — key considerations:
+
+- Wire `recordUnpin` into the unpin/delete path so the `pinned_cids` row is removed
+  (and the quota sum drops) when content is unpinned.
+- Land together with the ownership check
+  (`2026-06-11-ipfs-unpin-missing-ownership-check.md`) so unpin authorization, row
+  deletion, and quota update are consistent.
+- Decide ordering and reconciliation between the DB row delete and the Kubo unpin
+  (define which happens first and what sweeps orphans if the second fails) — there
+  is currently no orphan-reconciliation job for pins whose metadata reference was
+  lost.

--- a/.planning/v1.1-MILESTONE-AUDIT.md
+++ b/.planning/v1.1-MILESTONE-AUDIT.md
@@ -86,7 +86,7 @@ Audited 2026-06-11. Scope: phases 18–35 (per ROADMAP progress table; phases 36
 
 ## Verdict: gaps_found
 
-All 66 requirements have working implementations per phase verifications and the cross-phase integration trace. The blockers are process gaps, not code gaps: Phase 18 was never verified, leaving its four PERF requirements orphaned (assigned but covered by no VERIFICATION.md), and phases 31/32 lack VERIFICATION.md.
+62 of 66 requirements are verified through phase VERIFICATION.md tables and the cross-phase integration trace. The remaining four (PERF-01..04) have working implementations only by strong indirect evidence — histograms wired per the integration trace, baselines built on by Phases 22/26 — but remain orphaned because Phase 18 has no VERIFICATION.md to verify them directly. The blockers are process gaps, not code gaps: beyond Phase 18, phases 31/32 also lack VERIFICATION.md.
 
 ## Requirements Coverage (3-source cross-reference)
 

--- a/.planning/v1.1-MILESTONE-AUDIT.md
+++ b/.planning/v1.1-MILESTONE-AUDIT.md
@@ -1,0 +1,164 @@
+---
+milestone: v1.1
+audited: 2026-06-11
+status: gaps_found
+scores:
+  requirements: 62/66
+  phases: 17/20
+  integration: 43/43
+  flows: 6/6
+gaps:
+  requirements:
+    - id: 'PERF-01'
+      status: 'orphaned'
+      phase: '18-performance-instrumentation'
+      claimed_by_plans: ['18-01-SUMMARY.md']
+      completed_by_plans: ['18-01-SUMMARY.md']
+      verification_status: 'missing'
+      evidence: 'Histograms exist and are wired (confirmed by integration trace + Phase 19/22/26 verifications) but no phase VERIFICATION.md covers them'
+    - id: 'PERF-02'
+      status: 'orphaned'
+      phase: '18-performance-instrumentation'
+      claimed_by_plans: ['18-01-SUMMARY.md', '18-02-SUMMARY.md']
+      completed_by_plans: ['18-01-SUMMARY.md', '18-02-SUMMARY.md']
+      verification_status: 'missing'
+      evidence: 'Baselines referenced by Phase 22/26 work but never directly verified'
+    - id: 'PERF-03'
+      status: 'orphaned'
+      phase: '18-performance-instrumentation'
+      claimed_by_plans: ['18-02-SUMMARY.md']
+      completed_by_plans: ['18-02-SUMMARY.md']
+      verification_status: 'missing'
+      evidence: 'Kubo + Someguy scrape targets confirmed in Alloy config by integration trace, but unverified by any phase'
+    - id: 'PERF-04'
+      status: 'orphaned'
+      phase: '18-performance-instrumentation'
+      claimed_by_plans: ['18-01-SUMMARY.md']
+      completed_by_plans: ['18-01-SUMMARY.md']
+      verification_status: 'missing'
+      evidence: 'cipherbox_republish_batch_duration_seconds histogram exists per integration trace, but unverified by any phase'
+  integration: []
+  flows: []
+  phases:
+    - '18-performance-instrumentation: no VERIFICATION.md (unverified phase)'
+    - '31-structural-decomposition: no VERIFICATION.md (VALIDATION.md exists, compliant)'
+    - '32-fuse-async-filepointer-resolution: no VERIFICATION.md and no VALIDATION.md'
+tech_debt:
+  - phase: 19.1-extract-core-crypto-sdk-as-shared-package
+    items:
+      - 'useFolderMutations.ts still imports folderService validation helpers (getDepth, isDescendantOf, calculateSubtreeDepth) and reWrapForRecipients — accepted deviation'
+  - phase: 19.2-ipfs-upload-performance-optimization
+    items:
+      - 'Pre-existing TODO in docker-compose.yml:37 (unrelated to phase)'
+  - phase: 21-byo-ipfs-node-support
+    items:
+      - 'BYO-04 settings UI flagged human-verification-needed in VERIFICATION.md'
+  - phase: 23-rust-sdk-extraction
+    items:
+      - 'TODO: mkdir publish retry (crates/fuse/src/platform/windows/write_ops.rs:194)'
+  - phase: 27-writable-shares-poc
+    items:
+      - 'Verification status human_needed — UAT pending human confirmation'
+  - phase: 30-web-app-observability
+    items:
+      - 'Logger transport integration deferred until Phase 28 ships'
+      - 'Faro disabled when VITE_FARO_URL absent (local dev)'
+  - phase: 33-windows-async-filepointer-resolution
+    items:
+      - 'macOS mount-time pre-population uses global get_unresolved_file_pointers() instead of scoped variant (info severity)'
+  - phase: 34-e2e-test-expansion-staging-baselines
+    items:
+      - 'staging-journey-timing.json missing faro_enabled field from plan spec (metadata only)'
+  - phase: 35-phala-testnet-tee-migration
+    items:
+      - 'Phala Cloud CVM health check requires human verification of live service'
+      - 'GitHub staging environment secrets/vars configuration requires human verification'
+nyquist:
+  compliant_phases: ['21', '22', '23', '24', '25', '31', '35']
+  partial_phases: ['18', '19', '19.1', '19.2', '20', '26', '27', '33']
+  missing_phases: ['28', '29', '30', '32', '34']
+  overall: partial
+---
+
+# Milestone v1.1 Audit — CipherBox IPFS Infrastructure
+
+Audited 2026-06-11. Scope: phases 18–35 (per ROADMAP progress table; phases 36–41 are post-v1.1 and excluded from requirement scoring, though their verification status is noted below).
+
+## Verdict: gaps_found
+
+All 66 requirements have working implementations per phase verifications and the cross-phase integration trace. The blockers are process gaps, not code gaps: Phase 18 was never verified, leaving its four PERF requirements orphaned (assigned but covered by no VERIFICATION.md), and phases 31/32 lack VERIFICATION.md.
+
+## Requirements Coverage (3-source cross-reference)
+
+62/66 satisfied. Cross-referenced REQUIREMENTS.md traceability, phase VERIFICATION.md tables, and SUMMARY.md `requirements-completed` frontmatter.
+
+| Group          | Reqs | Status       | Notes                                                                                                                                                                                                                                                                                              |
+| -------------- | ---- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| IPNS-01..04    | 4    | satisfied    | Phase 19 verification passed all four. IPNS-02/03 checkboxes were stale in REQUIREMENTS.md — updated during this audit                                                                                                                                                                             |
+| VAULT-01..06   | 6    | satisfied    | Phase 20 passed after GAP-01 closure; VAULT-02 exceeds original requirement (DB fallback fully removed)                                                                                                                                                                                            |
+| BYO-01..07     | 7    | satisfied    | Phase 21 re-verified 5/5; BYO-04 UI flagged human-verification                                                                                                                                                                                                                                     |
+| PERF-01..04    | 4    | **orphaned** | Phase 18 has no VERIFICATION.md. Strong indirect evidence (histograms wired per integration trace; Phase 22/26 build on baselines) but never directly verified                                                                                                                                     |
+| PERF-05..09    | 5    | satisfied    | Phases 22 and 19.2 verified; PERF-09 with three-point before/after comparison (p95 −13%, throughput +7%)                                                                                                                                                                                           |
+| SDK-01..11     | 11   | satisfied    | Phase 19.1 passed with human UAT 2026-06-10. SDK-08/09 were unchecked in REQUIREMENTS.md and missing from SUMMARY frontmatter, but verification cites concrete evidence (useAuth.ts initSdkClient, clear-user-stores.ts destroySdkClient, refactored hooks) — checkboxes updated during this audit |
+| RSDK-01..10    | 10   | satisfied    | Phase 23 VERIFICATION said gaps_found (RSDK-06/08 partial: Windows WinFsp in desktop, 9 orphaned FUSE files). **Re-checked against current code 2026-06-11: closed by phases 25/33** — crates/fuse/src/platform/windows/ contains the ops modules; desktop fuse/ reduced to thin mod.rs shims      |
+| BUGFIX, TEST   | 5    | satisfied    | Phase 24 passed                                                                                                                                                                                                                                                                                    |
+| DESKTOP-01..02 | 2    | satisfied    | Phase 25 passed                                                                                                                                                                                                                                                                                    |
+| OBS-01..02     | 2    | satisfied    | Phase 26 passed (17 alert rules, timeout constants tuned to 2–3x p99)                                                                                                                                                                                                                              |
+| SHARE-01..10   | 10   | satisfied    | Phase 27 verified all ten; phase status human_needed (UAT confirmation outstanding)                                                                                                                                                                                                                |
+
+No other orphans: every remaining REQ-ID appears in at least one phase VERIFICATION.
+
+## Phase Verification Status
+
+17/20 in-scope phases verified (counting Phase 23 as closed after this audit's code re-check).
+
+| Phase                                                | Verification          | Notes                                                                       |
+| ---------------------------------------------------- | --------------------- | --------------------------------------------------------------------------- |
+| 18                                                   | **MISSING**           | Blocker — PERF-01..04 orphaned                                              |
+| 19, 19.1, 20, 22, 24, 25, 26, 28, 29, 30, 33, 34, 35 | passed                | 35 has two human-confirmation items (live CVM, staging secrets)             |
+| 19.2, 21, 27                                         | passed (human_needed) | Re-verified with full scores; human UAT items outstanding                   |
+| 23                                                   | gaps_found → closed   | RSDK-06/08 gaps closed by phases 25/33; verified in current code this audit |
+| 31                                                   | **MISSING**           | VALIDATION.md exists (compliant, wave_0 complete) but no VERIFICATION.md    |
+| 32                                                   | **MISSING**           | Neither VERIFICATION.md nor VALIDATION.md                                   |
+
+Post-v1.1 (informational): 36, 37, 40, 41 passed; 38, 39 have no VERIFICATION.md.
+
+## Cross-Phase Integration
+
+Integration checker traced 43 cross-phase exports — all connected, 0 orphaned, 0 missing. All sensitive API routes gated with JwtAuthGuard. All 6 E2E flows wired end-to-end:
+
+1. Login → vault blob v2 load → rootFolderKey unwrap → CipherBoxClient init → folder load
+2. Upload → encrypt → dual-pin (BYO-aware) → IPNS publish via API → TEE enrollment
+3. Share create (read/write) → recipient access → write-share ops with conflict retry
+4. Desktop FUSE create → TEE enrollment → async FilePointer resolution
+5. SDK layering clean both stacks (TS: sdk → sdk-core → api-client/core/crypto; Rust crates equivalent) — no violations
+6. Client + API metrics → Prometheus (Alloy scrape incl. Kubo + Someguy) → Grafana dashboards → alerts
+
+Caveat: the checker's requirement-status column contained errors (it marked completed phases "NOT_STARTED"); only its wiring/flow trace was used for this audit. Requirement statuses above come from phase verifications.
+
+## Nyquist Compliance
+
+Overall: partial. 7 compliant, 8 partial, 5 missing (of 20 in-scope phases).
+
+| Status                                        | Phases                             |
+| --------------------------------------------- | ---------------------------------- |
+| COMPLIANT                                     | 21, 22, 23, 24, 25, 31, 35         |
+| PARTIAL (VALIDATION.md exists, not compliant) | 18, 19, 19.1, 19.2, 20, 26, 27, 33 |
+| MISSING (no VALIDATION.md)                    | 28, 29, 30, 32, 34                 |
+
+## Tech Debt Summary
+
+13 items across 9 phases (see frontmatter for the full list). Highlights:
+
+- Phase 35: two human-confirmation items (live Phala CVM health, GitHub staging secrets) — operational checks, not code gaps
+- Phase 23: one TODO (mkdir publish retry on Windows write path)
+- Phase 30: logger transport deferral and Faro-off-by-default in local dev
+- Resolved since verification: Phase 19's duplicate MetricsService imports (fixed in current code, confirmed this audit)
+
+## Recommended Actions
+
+1. `/gsd-validate-phase 18` — retroactively verify PERF-01..04; this closes all four requirement gaps without a new phase
+2. `/gsd-validate-phase 32` — only phase with neither VERIFICATION nor VALIDATION
+3. `/gsd-validate-phase 31` — VERIFICATION gap only (Nyquist already compliant)
+4. Optionally `/gsd-validate-phase 28 29 30 34` for the remaining Nyquist-missing phases
+5. Human items before completing: Phase 35 CVM/secrets confirmation; BYO-04 and Phase 27 UAT confirmations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cipherbox-fuse"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "base64 0.22.1",
  "cipherbox-api-client",

--- a/apps/api/src/metrics/http-metrics.interceptor.spec.ts
+++ b/apps/api/src/metrics/http-metrics.interceptor.spec.ts
@@ -1,27 +1,63 @@
 import { HttpMetricsInterceptor } from './http-metrics.interceptor';
 import { MetricsService } from './metrics.service';
-import { ExecutionContext, CallHandler } from '@nestjs/common';
-import { BadRequestException } from '@nestjs/common';
-import { of, throwError } from 'rxjs';
+import {
+  ExecutionContext,
+  CallHandler,
+  HttpArgumentsHost,
+  BadRequestException,
+} from '@nestjs/common';
+import { Observable, of, throwError } from 'rxjs';
 import { Request, Response } from 'express';
+
+// Typed test doubles — narrow mocks instead of broad `any` casts, so the
+// suite keeps compile-time guarantees and stays lint-clean.
+
+function createRequest(method: string, routePath?: string): Request {
+  const req: Pick<Request, 'method' | 'route'> = {
+    method,
+    route: routePath === undefined ? undefined : ({ path: routePath } as Request['route']),
+  };
+  return req as Request;
+}
+
+function createResponse(statusCode: number): Response {
+  const res: Pick<Response, 'statusCode'> = { statusCode };
+  return res as Response;
+}
+
+function createExecutionContext(req: Request, res?: Response): ExecutionContext {
+  const httpHost: HttpArgumentsHost = {
+    getRequest: <T = Request>() => req as unknown as T,
+    getResponse: <T = Response>() => res as unknown as T,
+    getNext: <T>() => undefined as unknown as T,
+  };
+  return {
+    switchToHttp: () => httpHost,
+  } as Partial<ExecutionContext> as ExecutionContext;
+}
+
+function createCallHandler(result: Observable<unknown>): CallHandler {
+  return { handle: () => result };
+}
 
 describe('HttpMetricsInterceptor', () => {
   let interceptor: HttpMetricsInterceptor;
   let metricsService: MetricsService;
-  let mockHttpRequestDuration: any;
+  let mockHttpRequestDuration: { labels: jest.Mock };
+  let observeSpy: jest.Mock;
 
   beforeEach(() => {
-    // Mock the histogram that records duration
+    // Mock the histogram that records duration: labels() returns an object
+    // exposing the observe spy the interceptor calls with the duration.
+    observeSpy = jest.fn();
     mockHttpRequestDuration = {
-      labels: jest.fn().mockReturnValue({
-        observe: jest.fn(),
-      }),
+      labels: jest.fn().mockReturnValue({ observe: observeSpy }),
     };
 
-    // Create a mock MetricsService
+    // Create a mock MetricsService exposing only the histogram under test.
     metricsService = {
       httpRequestDuration: mockHttpRequestDuration,
-    } as any;
+    } as unknown as MetricsService;
 
     interceptor = new HttpMetricsInterceptor(metricsService);
 
@@ -36,36 +72,19 @@ describe('HttpMetricsInterceptor', () => {
 
   describe('HTTP request success path', () => {
     it('should record request duration with correct labels on successful response', (done) => {
-      const mockRequest = {
-        method: 'GET',
-        route: {
-          path: '/api/vault',
-        },
-      } as any as Request;
-
-      const mockResponse = {
-        statusCode: 200,
-      } as any as Response;
-
-      const mockContext = {
-        switchToHttp: jest.fn().mockReturnValue({
-          getRequest: jest.fn().mockReturnValue(mockRequest),
-          getResponse: jest.fn().mockReturnValue(mockResponse),
-        }),
-      } as any as ExecutionContext;
-
-      const mockNext = {
-        handle: jest.fn().mockReturnValue(of({})),
-      } as any as CallHandler;
+      const mockContext = createExecutionContext(
+        createRequest('GET', '/api/vault'),
+        createResponse(200)
+      );
+      const mockNext = createCallHandler(of({}));
 
       interceptor.intercept(mockContext, mockNext).subscribe(() => {
         // Verify labels were called with correct method, route, and status code
         expect(mockHttpRequestDuration.labels).toHaveBeenCalledWith('GET', '/api/vault', '200');
 
         // Verify observe was called with a plausible duration (>= 0)
-        const observeCall = mockHttpRequestDuration.labels().observe;
-        expect(observeCall).toHaveBeenCalled();
-        const durationArg = observeCall.mock.calls[0][0];
+        expect(observeSpy).toHaveBeenCalled();
+        const durationArg = observeSpy.mock.calls[0][0];
         expect(durationArg).toBeGreaterThanOrEqual(0);
         expect(typeof durationArg).toBe('number');
 
@@ -74,27 +93,11 @@ describe('HttpMetricsInterceptor', () => {
     });
 
     it('should exclude /metrics endpoint from recording', (done) => {
-      const mockRequest = {
-        method: 'GET',
-        route: {
-          path: '/metrics',
-        },
-      } as any as Request;
-
-      const mockResponse = {
-        statusCode: 200,
-      } as any as Response;
-
-      const mockContext = {
-        switchToHttp: jest.fn().mockReturnValue({
-          getRequest: jest.fn().mockReturnValue(mockRequest),
-          getResponse: jest.fn().mockReturnValue(mockResponse),
-        }),
-      } as any as ExecutionContext;
-
-      const mockNext = {
-        handle: jest.fn().mockReturnValue(of({})),
-      } as any as CallHandler;
+      const mockContext = createExecutionContext(
+        createRequest('GET', '/metrics'),
+        createResponse(200)
+      );
+      const mockNext = createCallHandler(of({}));
 
       interceptor.intercept(mockContext, mockNext).subscribe(() => {
         // /metrics should NOT be recorded
@@ -105,25 +108,11 @@ describe('HttpMetricsInterceptor', () => {
     });
 
     it('should record unmatched routes as /:unmatched', (done) => {
-      const mockRequest = {
-        method: 'POST',
-        route: undefined, // No matched route
-      } as any as Request;
-
-      const mockResponse = {
-        statusCode: 404,
-      } as any as Response;
-
-      const mockContext = {
-        switchToHttp: jest.fn().mockReturnValue({
-          getRequest: jest.fn().mockReturnValue(mockRequest),
-          getResponse: jest.fn().mockReturnValue(mockResponse),
-        }),
-      } as any as ExecutionContext;
-
-      const mockNext = {
-        handle: jest.fn().mockReturnValue(of({})),
-      } as any as CallHandler;
+      const mockContext = createExecutionContext(
+        createRequest('POST', undefined), // No matched route
+        createResponse(404)
+      );
+      const mockNext = createCallHandler(of({}));
 
       interceptor.intercept(mockContext, mockNext).subscribe(() => {
         // Unmatched routes should be labeled as /:unmatched
@@ -136,24 +125,10 @@ describe('HttpMetricsInterceptor', () => {
 
   describe('HTTP request error path', () => {
     it('should record request duration on NestJS exception with getStatus', (done) => {
-      const mockRequest = {
-        method: 'DELETE',
-        route: {
-          path: '/api/files/:id',
-        },
-      } as any as Request;
-
-      const mockContext = {
-        switchToHttp: jest.fn().mockReturnValue({
-          getRequest: jest.fn().mockReturnValue(mockRequest),
-          getResponse: jest.fn(),
-        }),
-      } as any as ExecutionContext;
-
-      const testError = new BadRequestException('Invalid input');
-      const mockNext = {
-        handle: jest.fn().mockReturnValue(throwError(() => testError)),
-      } as any as CallHandler;
+      const mockContext = createExecutionContext(createRequest('DELETE', '/api/files/:id'));
+      const mockNext = createCallHandler(
+        throwError(() => new BadRequestException('Invalid input'))
+      );
 
       interceptor.intercept(mockContext, mockNext).subscribe({
         error: () => {
@@ -170,25 +145,9 @@ describe('HttpMetricsInterceptor', () => {
     });
 
     it('should default to 500 status code for unrecognized exceptions', (done) => {
-      const mockRequest = {
-        method: 'PUT',
-        route: {
-          path: '/api/vault/update',
-        },
-      } as any as Request;
-
-      const mockContext = {
-        switchToHttp: jest.fn().mockReturnValue({
-          getRequest: jest.fn().mockReturnValue(mockRequest),
-          getResponse: jest.fn(),
-        }),
-      } as any as ExecutionContext;
-
+      const mockContext = createExecutionContext(createRequest('PUT', '/api/vault/update'));
       // Plain Error object without getStatus
-      const testError = new Error('Database connection failed');
-      const mockNext = {
-        handle: jest.fn().mockReturnValue(throwError(() => testError)),
-      } as any as CallHandler;
+      const mockNext = createCallHandler(throwError(() => new Error('Database connection failed')));
 
       interceptor.intercept(mockContext, mockNext).subscribe({
         error: () => {
@@ -205,23 +164,8 @@ describe('HttpMetricsInterceptor', () => {
     });
 
     it('should handle null exception gracefully (default to 500)', (done) => {
-      const mockRequest = {
-        method: 'GET',
-        route: {
-          path: '/api/health',
-        },
-      } as any as Request;
-
-      const mockContext = {
-        switchToHttp: jest.fn().mockReturnValue({
-          getRequest: jest.fn().mockReturnValue(mockRequest),
-          getResponse: jest.fn(),
-        }),
-      } as any as ExecutionContext;
-
-      const mockNext = {
-        handle: jest.fn().mockReturnValue(throwError(() => null)),
-      } as any as CallHandler;
+      const mockContext = createExecutionContext(createRequest('GET', '/api/health'));
+      const mockNext = createCallHandler(throwError(() => null));
 
       interceptor.intercept(mockContext, mockNext).subscribe({
         error: () => {
@@ -236,27 +180,11 @@ describe('HttpMetricsInterceptor', () => {
 
   describe('Duration calculation', () => {
     it('should calculate duration in seconds from nanoseconds', (done) => {
-      const mockRequest = {
-        method: 'POST',
-        route: {
-          path: '/api/login',
-        },
-      } as any as Request;
-
-      const mockResponse = {
-        statusCode: 200,
-      } as any as Response;
-
-      const mockContext = {
-        switchToHttp: jest.fn().mockReturnValue({
-          getRequest: jest.fn().mockReturnValue(mockRequest),
-          getResponse: jest.fn().mockReturnValue(mockResponse),
-        }),
-      } as any as ExecutionContext;
-
-      const mockNext = {
-        handle: jest.fn().mockReturnValue(of({})),
-      } as any as CallHandler;
+      const mockContext = createExecutionContext(
+        createRequest('POST', '/api/login'),
+        createResponse(200)
+      );
+      const mockNext = createCallHandler(of({}));
 
       // Simulate 250 milliseconds duration (250_000_000 nanoseconds)
       const startNs = BigInt(1000_000_000);
@@ -269,8 +197,7 @@ describe('HttpMetricsInterceptor', () => {
       });
 
       interceptor.intercept(mockContext, mockNext).subscribe(() => {
-        const observeCall = mockHttpRequestDuration.labels().observe;
-        const duration = observeCall.mock.calls[0][0];
+        const duration = observeSpy.mock.calls[0][0];
 
         // Should be 0.25 seconds (250ms)
         expect(duration).toBeCloseTo(0.25, 2);
@@ -280,27 +207,11 @@ describe('HttpMetricsInterceptor', () => {
     });
 
     it('should record very small durations (microseconds)', (done) => {
-      const mockRequest = {
-        method: 'GET',
-        route: {
-          path: '/api/ping',
-        },
-      } as any as Request;
-
-      const mockResponse = {
-        statusCode: 200,
-      } as any as Response;
-
-      const mockContext = {
-        switchToHttp: jest.fn().mockReturnValue({
-          getRequest: jest.fn().mockReturnValue(mockRequest),
-          getResponse: jest.fn().mockReturnValue(mockResponse),
-        }),
-      } as any as ExecutionContext;
-
-      const mockNext = {
-        handle: jest.fn().mockReturnValue(of({})),
-      } as any as CallHandler;
+      const mockContext = createExecutionContext(
+        createRequest('GET', '/api/ping'),
+        createResponse(200)
+      );
+      const mockNext = createCallHandler(of({}));
 
       // Simulate 100 nanoseconds (0.0000001 seconds)
       const startNs = BigInt(1000);
@@ -313,8 +224,7 @@ describe('HttpMetricsInterceptor', () => {
       });
 
       interceptor.intercept(mockContext, mockNext).subscribe(() => {
-        const observeCall = mockHttpRequestDuration.labels().observe;
-        const duration = observeCall.mock.calls[0][0];
+        const duration = observeSpy.mock.calls[0][0];
 
         // Should be 100e-9 seconds = 0.0000001
         expect(duration).toBeGreaterThanOrEqual(0);
@@ -328,27 +238,11 @@ describe('HttpMetricsInterceptor', () => {
   describe('Various HTTP methods', () => {
     ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'].forEach((method) => {
       it(`should record ${method} requests correctly`, (done) => {
-        const mockRequest = {
-          method,
-          route: {
-            path: '/api/resource',
-          },
-        } as any as Request;
-
-        const mockResponse = {
-          statusCode: 200,
-        } as any as Response;
-
-        const mockContext = {
-          switchToHttp: jest.fn().mockReturnValue({
-            getRequest: jest.fn().mockReturnValue(mockRequest),
-            getResponse: jest.fn().mockReturnValue(mockResponse),
-          }),
-        } as any as ExecutionContext;
-
-        const mockNext = {
-          handle: jest.fn().mockReturnValue(of({})),
-        } as any as CallHandler;
+        const mockContext = createExecutionContext(
+          createRequest(method, '/api/resource'),
+          createResponse(200)
+        );
+        const mockNext = createCallHandler(of({}));
 
         interceptor.intercept(mockContext, mockNext).subscribe(() => {
           expect(mockHttpRequestDuration.labels).toHaveBeenCalledWith(
@@ -366,27 +260,11 @@ describe('HttpMetricsInterceptor', () => {
   describe('Various HTTP status codes', () => {
     [200, 201, 204, 400, 401, 403, 404, 500, 502, 503].forEach((status) => {
       it(`should record ${status} status code correctly`, (done) => {
-        const mockRequest = {
-          method: 'GET',
-          route: {
-            path: '/api/test',
-          },
-        } as any as Request;
-
-        const mockResponse = {
-          statusCode: status,
-        } as any as Response;
-
-        const mockContext = {
-          switchToHttp: jest.fn().mockReturnValue({
-            getRequest: jest.fn().mockReturnValue(mockRequest),
-            getResponse: jest.fn().mockReturnValue(mockResponse),
-          }),
-        } as any as ExecutionContext;
-
-        const mockNext = {
-          handle: jest.fn().mockReturnValue(of({})),
-        } as any as CallHandler;
+        const mockContext = createExecutionContext(
+          createRequest('GET', '/api/test'),
+          createResponse(status)
+        );
+        const mockNext = createCallHandler(of({}));
 
         interceptor.intercept(mockContext, mockNext).subscribe(() => {
           expect(mockHttpRequestDuration.labels).toHaveBeenCalledWith(

--- a/apps/api/src/metrics/http-metrics.interceptor.spec.ts
+++ b/apps/api/src/metrics/http-metrics.interceptor.spec.ts
@@ -1,0 +1,403 @@
+import { HttpMetricsInterceptor } from './http-metrics.interceptor';
+import { MetricsService } from './metrics.service';
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { BadRequestException } from '@nestjs/common';
+import { of, throwError } from 'rxjs';
+import { Request, Response } from 'express';
+
+describe('HttpMetricsInterceptor', () => {
+  let interceptor: HttpMetricsInterceptor;
+  let metricsService: MetricsService;
+  let mockHttpRequestDuration: any;
+
+  beforeEach(() => {
+    // Mock the histogram that records duration
+    mockHttpRequestDuration = {
+      labels: jest.fn().mockReturnValue({
+        observe: jest.fn(),
+      }),
+    };
+
+    // Create a mock MetricsService
+    metricsService = {
+      httpRequestDuration: mockHttpRequestDuration,
+    } as any;
+
+    interceptor = new HttpMetricsInterceptor(metricsService);
+
+    // Mock process.hrtime.bigint globally
+    jest.spyOn(process.hrtime, 'bigint').mockImplementation(() => BigInt(0));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('HTTP request success path', () => {
+    it('should record request duration with correct labels on successful response', (done) => {
+      const mockRequest = {
+        method: 'GET',
+        route: {
+          path: '/api/vault',
+        },
+      } as any as Request;
+
+      const mockResponse = {
+        statusCode: 200,
+      } as any as Response;
+
+      const mockContext = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getRequest: jest.fn().mockReturnValue(mockRequest),
+          getResponse: jest.fn().mockReturnValue(mockResponse),
+        }),
+      } as any as ExecutionContext;
+
+      const mockNext = {
+        handle: jest.fn().mockReturnValue(of({})),
+      } as any as CallHandler;
+
+      interceptor.intercept(mockContext, mockNext).subscribe(() => {
+        // Verify labels were called with correct method, route, and status code
+        expect(mockHttpRequestDuration.labels).toHaveBeenCalledWith('GET', '/api/vault', '200');
+
+        // Verify observe was called with a plausible duration (>= 0)
+        const observeCall = mockHttpRequestDuration.labels().observe;
+        expect(observeCall).toHaveBeenCalled();
+        const durationArg = observeCall.mock.calls[0][0];
+        expect(durationArg).toBeGreaterThanOrEqual(0);
+        expect(typeof durationArg).toBe('number');
+
+        done();
+      });
+    });
+
+    it('should exclude /metrics endpoint from recording', (done) => {
+      const mockRequest = {
+        method: 'GET',
+        route: {
+          path: '/metrics',
+        },
+      } as any as Request;
+
+      const mockResponse = {
+        statusCode: 200,
+      } as any as Response;
+
+      const mockContext = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getRequest: jest.fn().mockReturnValue(mockRequest),
+          getResponse: jest.fn().mockReturnValue(mockResponse),
+        }),
+      } as any as ExecutionContext;
+
+      const mockNext = {
+        handle: jest.fn().mockReturnValue(of({})),
+      } as any as CallHandler;
+
+      interceptor.intercept(mockContext, mockNext).subscribe(() => {
+        // /metrics should NOT be recorded
+        expect(mockHttpRequestDuration.labels).not.toHaveBeenCalled();
+
+        done();
+      });
+    });
+
+    it('should record unmatched routes as /:unmatched', (done) => {
+      const mockRequest = {
+        method: 'POST',
+        route: undefined, // No matched route
+      } as any as Request;
+
+      const mockResponse = {
+        statusCode: 404,
+      } as any as Response;
+
+      const mockContext = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getRequest: jest.fn().mockReturnValue(mockRequest),
+          getResponse: jest.fn().mockReturnValue(mockResponse),
+        }),
+      } as any as ExecutionContext;
+
+      const mockNext = {
+        handle: jest.fn().mockReturnValue(of({})),
+      } as any as CallHandler;
+
+      interceptor.intercept(mockContext, mockNext).subscribe(() => {
+        // Unmatched routes should be labeled as /:unmatched
+        expect(mockHttpRequestDuration.labels).toHaveBeenCalledWith('POST', '/:unmatched', '404');
+
+        done();
+      });
+    });
+  });
+
+  describe('HTTP request error path', () => {
+    it('should record request duration on NestJS exception with getStatus', (done) => {
+      const mockRequest = {
+        method: 'DELETE',
+        route: {
+          path: '/api/files/:id',
+        },
+      } as any as Request;
+
+      const mockContext = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getRequest: jest.fn().mockReturnValue(mockRequest),
+          getResponse: jest.fn(),
+        }),
+      } as any as ExecutionContext;
+
+      const testError = new BadRequestException('Invalid input');
+      const mockNext = {
+        handle: jest.fn().mockReturnValue(throwError(() => testError)),
+      } as any as CallHandler;
+
+      interceptor.intercept(mockContext, mockNext).subscribe({
+        error: () => {
+          // Verify error status code (400) was recorded
+          expect(mockHttpRequestDuration.labels).toHaveBeenCalledWith(
+            'DELETE',
+            '/api/files/:id',
+            '400'
+          );
+
+          done();
+        },
+      });
+    });
+
+    it('should default to 500 status code for unrecognized exceptions', (done) => {
+      const mockRequest = {
+        method: 'PUT',
+        route: {
+          path: '/api/vault/update',
+        },
+      } as any as Request;
+
+      const mockContext = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getRequest: jest.fn().mockReturnValue(mockRequest),
+          getResponse: jest.fn(),
+        }),
+      } as any as ExecutionContext;
+
+      // Plain Error object without getStatus
+      const testError = new Error('Database connection failed');
+      const mockNext = {
+        handle: jest.fn().mockReturnValue(throwError(() => testError)),
+      } as any as CallHandler;
+
+      interceptor.intercept(mockContext, mockNext).subscribe({
+        error: () => {
+          // Should default to 500
+          expect(mockHttpRequestDuration.labels).toHaveBeenCalledWith(
+            'PUT',
+            '/api/vault/update',
+            '500'
+          );
+
+          done();
+        },
+      });
+    });
+
+    it('should handle null exception gracefully (default to 500)', (done) => {
+      const mockRequest = {
+        method: 'GET',
+        route: {
+          path: '/api/health',
+        },
+      } as any as Request;
+
+      const mockContext = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getRequest: jest.fn().mockReturnValue(mockRequest),
+          getResponse: jest.fn(),
+        }),
+      } as any as ExecutionContext;
+
+      const mockNext = {
+        handle: jest.fn().mockReturnValue(throwError(() => null)),
+      } as any as CallHandler;
+
+      interceptor.intercept(mockContext, mockNext).subscribe({
+        error: () => {
+          // null exception should default to 500
+          expect(mockHttpRequestDuration.labels).toHaveBeenCalledWith('GET', '/api/health', '500');
+
+          done();
+        },
+      });
+    });
+  });
+
+  describe('Duration calculation', () => {
+    it('should calculate duration in seconds from nanoseconds', (done) => {
+      const mockRequest = {
+        method: 'POST',
+        route: {
+          path: '/api/login',
+        },
+      } as any as Request;
+
+      const mockResponse = {
+        statusCode: 200,
+      } as any as Response;
+
+      const mockContext = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getRequest: jest.fn().mockReturnValue(mockRequest),
+          getResponse: jest.fn().mockReturnValue(mockResponse),
+        }),
+      } as any as ExecutionContext;
+
+      const mockNext = {
+        handle: jest.fn().mockReturnValue(of({})),
+      } as any as CallHandler;
+
+      // Simulate 250 milliseconds duration (250_000_000 nanoseconds)
+      const startNs = BigInt(1000_000_000);
+      const endNs = BigInt(1250_000_000); // 250ms later
+      let callCount = 0;
+
+      (process.hrtime.bigint as jest.Mock).mockImplementation(() => {
+        callCount++;
+        return callCount === 1 ? startNs : endNs;
+      });
+
+      interceptor.intercept(mockContext, mockNext).subscribe(() => {
+        const observeCall = mockHttpRequestDuration.labels().observe;
+        const duration = observeCall.mock.calls[0][0];
+
+        // Should be 0.25 seconds (250ms)
+        expect(duration).toBeCloseTo(0.25, 2);
+
+        done();
+      });
+    });
+
+    it('should record very small durations (microseconds)', (done) => {
+      const mockRequest = {
+        method: 'GET',
+        route: {
+          path: '/api/ping',
+        },
+      } as any as Request;
+
+      const mockResponse = {
+        statusCode: 200,
+      } as any as Response;
+
+      const mockContext = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getRequest: jest.fn().mockReturnValue(mockRequest),
+          getResponse: jest.fn().mockReturnValue(mockResponse),
+        }),
+      } as any as ExecutionContext;
+
+      const mockNext = {
+        handle: jest.fn().mockReturnValue(of({})),
+      } as any as CallHandler;
+
+      // Simulate 100 nanoseconds (0.0000001 seconds)
+      const startNs = BigInt(1000);
+      const endNs = BigInt(1100);
+      let callCount = 0;
+
+      (process.hrtime.bigint as jest.Mock).mockImplementation(() => {
+        callCount++;
+        return callCount === 1 ? startNs : endNs;
+      });
+
+      interceptor.intercept(mockContext, mockNext).subscribe(() => {
+        const observeCall = mockHttpRequestDuration.labels().observe;
+        const duration = observeCall.mock.calls[0][0];
+
+        // Should be 100e-9 seconds = 0.0000001
+        expect(duration).toBeGreaterThanOrEqual(0);
+        expect(duration).toBeLessThan(0.001); // Small duration
+
+        done();
+      });
+    });
+  });
+
+  describe('Various HTTP methods', () => {
+    ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'].forEach((method) => {
+      it(`should record ${method} requests correctly`, (done) => {
+        const mockRequest = {
+          method,
+          route: {
+            path: '/api/resource',
+          },
+        } as any as Request;
+
+        const mockResponse = {
+          statusCode: 200,
+        } as any as Response;
+
+        const mockContext = {
+          switchToHttp: jest.fn().mockReturnValue({
+            getRequest: jest.fn().mockReturnValue(mockRequest),
+            getResponse: jest.fn().mockReturnValue(mockResponse),
+          }),
+        } as any as ExecutionContext;
+
+        const mockNext = {
+          handle: jest.fn().mockReturnValue(of({})),
+        } as any as CallHandler;
+
+        interceptor.intercept(mockContext, mockNext).subscribe(() => {
+          expect(mockHttpRequestDuration.labels).toHaveBeenCalledWith(
+            method,
+            '/api/resource',
+            '200'
+          );
+
+          done();
+        });
+      });
+    });
+  });
+
+  describe('Various HTTP status codes', () => {
+    [200, 201, 204, 400, 401, 403, 404, 500, 502, 503].forEach((status) => {
+      it(`should record ${status} status code correctly`, (done) => {
+        const mockRequest = {
+          method: 'GET',
+          route: {
+            path: '/api/test',
+          },
+        } as any as Request;
+
+        const mockResponse = {
+          statusCode: status,
+        } as any as Response;
+
+        const mockContext = {
+          switchToHttp: jest.fn().mockReturnValue({
+            getRequest: jest.fn().mockReturnValue(mockRequest),
+            getResponse: jest.fn().mockReturnValue(mockResponse),
+          }),
+        } as any as ExecutionContext;
+
+        const mockNext = {
+          handle: jest.fn().mockReturnValue(of({})),
+        } as any as CallHandler;
+
+        interceptor.intercept(mockContext, mockNext).subscribe(() => {
+          expect(mockHttpRequestDuration.labels).toHaveBeenCalledWith(
+            'GET',
+            '/api/test',
+            String(status)
+          );
+
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Captures a `/gsd:explore` session on IPNS idempotency/ACID hardening and share
privacy, plus pre-existing v1.1 milestone-audit and phase-18 validation artifacts
that were sitting in the working tree. Docs/planning only — no runtime behavior
changes — aside from one added `apps/api` unit test and a `Cargo.lock` bump.

## Exploration artifacts (first commit)

**Key finding:** the API does not authorize IPNS writes. Write control is
cryptographic — possession of the IPNS private key — so `findActiveWriteShare` is
DB-row routing, not a security boundary, and the resolve path ignores the share
edge entirely. The `sharer -> recipient` social graph (the one remaining privacy
gap on the API) can therefore be blinded without weakening write control. The
enabling change — server verifies the record's Ed25519 signature against the
`ipnsName` and keys records by `ipnsName` — also fixes the sequence
self-increment / divergence bug, so the privacy and protocol-hardening threads
converge on a single change.

- `notes/ipns-write-auth-is-cryptographic.md` — the finding, with file:line evidence
- `seeds/blind-share-social-graph.md` — capability-based blinded shares; discovery
  model left open (vault-synced vs blinded inbox), cross-linked to the existing
  CRDT-IPNS-inbox todo

**Acute idempotency/ACID bugs found, captured as todos for triage:**

| Todo | Area | Severity |
| ---- | ---- | -------- |
| IPFS unpin missing ownership check — cross-user delete | api | high (security) |
| Server quota never decremented on unpin — eventual lockout | api | high |
| FUSE release() data loss before remote commit | desktop-fuse | high |
| FUSE mkdir parent-publish orphan | desktop-fuse | high |
| IPNS 409-retry lost update | sdk | high |

Each todo carries file:line evidence, the failure window, and a solution direction
(zero-knowledge and macOS-single-thread constraints noted).

## Batched audit/validation (second commit)

- `.planning/v1.1-MILESTONE-AUDIT.md` (new) plus `REQUIREMENTS.md` and phase-18
  `18-VALIDATION.md` updates
- `apps/api/src/metrics/http-metrics.interceptor.spec.ts` (new test)
- `Cargo.lock`

## Notes for reviewers

- Findings are static-analysis (sub-agent) results. The one unverified path —
  the macOS `mkdir` line number — is flagged in its todo for a grep before fixing.
- No code fixes here: the bugs are captured as todos, not addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated milestone checklists and traceability for v1.1 and published a complete v1.1 milestone audit.
  * Marked Phase 18 validated with updated verification details.
  * Added architecture/privacy notes on cryptographic IPNS write authorization and blinding the share social graph.
  * Added TODOs documenting high-severity issues (FUSE mkdir/release orphans, IPNS lost-update, unpin/ownership & quota gaps, sequence-integrity concerns).

* **Tests**
  * Added a test suite validating HTTP request metrics, labels, error handling, and duration calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->