### PR TITLE
docs: generate and verify project documentation

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v1.1
 milestone_name: milestone
 status: Milestone complete
-last_updated: '2026-04-01T00:00:00.000Z'
-last_activity: 2026-04-01
+last_updated: '2026-06-11T22:57:00.930Z'
+last_activity: 2026-06-12
 progress:
   total_phases: 26
   completed_phases: 26
@@ -252,4 +252,4 @@ All M2 blockers resolved. See `.planning/milestones/m2/m2-v1.0-production-MILEST
 
 ---
 
-Last activity: 2026-04-01 - Completed quick task 260401-kyv: fix sidebar icons to be consistent
+Last activity: 2026-06-12

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+<!-- generated-by: gsd-doc-writer -->
+
+# Contributing to CipherBox
+
+See [docs/GETTING-STARTED.md](docs/GETTING-STARTED.md) for prerequisites and first-run instructions,
+and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for local development setup.
+
+## Branch Conventions
+
+Never push directly to `main`. All changes must go through feature branches and pull requests.
+
+Branch naming prefixes:
+
+- `feat/` — new features
+- `fix/` — bug fixes
+- `docs/` — documentation updates
+- `refactor/` — code refactoring
+- `chore/` — maintenance tasks
+
+## Commit Messages
+
+Commits must follow [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```text
+type(optional-scope): description
+```
+
+Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+
+Two rules that CI enforces and will reject:
+
+- **PR title must match the Conventional Commits pattern** — validated by `.github/workflows/pr-title.yml`
+  on every open/edit/sync event.
+- **No parenthesized text in the subject line** — e.g., `feat: add export (zip format)` is rejected.
+  Release Please misparses parentheses as a malformed scope, causing silent release failures.
+  Use dashes or brackets instead: `feat: add export - zip format` or `feat: add export [zip]`.
+
+Local commitlint runs via lint-staged but the `commit-msg` husky hook is currently an Entire CLI
+wrapper and does **not** run commitlint locally. Follow the format regardless — CI will reject
+non-conforming PR titles.
+
+## Pull Request Process
+
+- Open a PR from your feature branch against `main`.
+- The PR title must satisfy the Conventional Commits pattern above (CI checks it automatically).
+- Ensure all CI checks pass: lint, type-check, and unit tests all run on every PR targeting `main`.
+- Request review from a maintainer; PRs require at least one approval before merging.
+
+## Coding Standards
+
+Lint-staged enforces the following on every commit:
+
+| File type                        | Tools applied                                           |
+| -------------------------------- | ------------------------------------------------------- |
+| `*.ts`, `*.tsx`, `*.js`, `*.jsx` | ESLint (auto-fix), Prettier                             |
+| `*.json`, `*.yml`, `*.yaml`      | Prettier                                                |
+| `*.md`                           | markdownlint (auto-fix, ignores `.planning/`), Prettier |
+
+Run checks manually:
+
+```bash
+pnpm lint        # ESLint across all packages
+pnpm lint:fix    # ESLint with auto-fix
+pnpm lint:md     # markdownlint across all *.md files
+```
+
+Markdownlint is strict — common violations to avoid:
+
+- Use proper `##` headings; never use `**bold text**` as a heading substitute (MD036).
+- Always include blank lines before and after fenced code blocks and lists (MD031/MD032).
+
+## API Changes
+
+When modifying `apps/api` — DTOs, controllers, or entities — regenerate the typed client before
+committing:
+
+```bash
+pnpm api:generate
+```
+
+This regenerates `packages/api-client/src/generated/`, `packages/api-client/src/models/`, and
+`packages/api-client/openapi.json`. Stage these files alongside your API changes.
+
+A pre-commit hook (`scripts/check-api-client.sh`) blocks commits where API source files are staged
+but the generated `packages/api-client/openapi.json` has unstaged changes.
+
+## Testing
+
+See [docs/TESTING.md](docs/TESTING.md) for how to run the test suite and coverage requirements.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- generated-by: gsd-doc-writer -->
+
 <p align="center">
   <img src="./cipherbox logo.png" alt="CipherBox Logo" width="450"/>
 </p>
@@ -8,46 +10,66 @@
 
 ## What is CipherBox
 
-CipherBox is a **technology demonstrator** for privacy-first cloud storage. All encryption happens client-side — the server never sees plaintext data, file names, or encryption keys. Files are stored on IPFS for decentralized persistence, keys are derived deterministically via Web3Auth so the same user always gets the same vault regardless of login method, and data can be exported for independent recovery without CipherBox.
+CipherBox is a privacy-first encrypted cloud storage system. All encryption happens
+client-side — the server never sees plaintext data, file names, or encryption keys. Files are stored
+on IPFS for decentralized persistence, keys are derived deterministically via Web3Auth so the same
+user always gets the same vault regardless of login method, and data can be exported for independent
+recovery without CipherBox.
 
 ## Acknowledgements
 
-This project is inspired by discussions and planning while working on [ChainSafe Files](https://github.com/chainsafe/ui-monorepo). A massive shout-out to all the colleagues I got to work with on the original ChainSafe Files project, who unknowingly contributed to this phoenix rising out of the ashes.
+This project is inspired by discussions and planning while working on
+[ChainSafe Files](https://github.com/chainsafe/ui-monorepo). A massive shout-out to all the
+colleagues who worked on the original ChainSafe Files project.
 
 ## Features
 
-- **Authentication** — Web3Auth MPC Core Kit: email OTP, Google OAuth, magic link, external wallet (SIWE). MFA via device factor with BIP39 recovery phrase.
-- **Encryption** — Client-side AES-256-GCM for files and metadata. ECIES secp256k1 key wrapping (per-file, per-folder random keys). AES-256-CTR streaming for large media files. Web Worker offloading for batch encryption.
-- **File Management** — Upload, download, rename, move, delete. Batch upload pipeline with concurrent encryption and pinning. Nested folders up to 20 levels. Drag-and-drop. File versioning with point-in-time restore (up to 10 versions per file).
-- **Sharing** — User-to-user sharing with ECIES re-wrapping (read-only and read-write). Invite-link sharing with time-limited access tokens. Multi-recipient sharing. Lazy key rotation on revoke.
+- **Authentication** — Web3Auth MPC Core Kit: email OTP, Google OAuth, magic link, external wallet
+  (SIWE). MFA via device factor with BIP39 recovery phrase.
+- **Encryption** — Client-side AES-256-GCM for files and metadata. ECIES secp256k1 key wrapping
+  (per-file, per-folder random keys). AES-256-CTR streaming for large media files. Web Worker
+  offloading for batch encryption.
+- **File Management** — Upload, download, rename, move, delete. Batch upload pipeline with concurrent
+  encryption and pinning. Nested folders up to 20 levels. Drag-and-drop. File versioning with
+  point-in-time restore (up to 10 versions per file).
+- **Sharing** — User-to-user sharing with ECIES re-wrapping (read-only and read-write). Invite-link
+  sharing with time-limited access tokens. Multi-recipient sharing. Lazy key rotation on revoke.
 - **Recycle Bin** — 30-day soft-delete with restore and permanent delete.
-- **Search** — Client-side encrypted search index across file and folder names. Fuzzy matching with Cmd/Ctrl+K shortcut.
+- **Search** — Client-side encrypted search index across file and folder names. Fuzzy matching with
+  Cmd/Ctrl+K shortcut.
 - **Media Preview** — Image, PDF, video (streaming CTR decryption), and audio preview.
-- **Sync** — Multi-device via IPNS polling (~30s). Conflict detection and resolution (sequence-number based).
-- **Desktop** — macOS, Linux, and Windows via Tauri v2 + FUSE-T/libfuse3/WinFsp virtual filesystem mount. Background sync with system tray. SMB backend on macOS.
-- **TEE Republishing** — Automatic IPNS record refresh every 6 hours via Phala Cloud. Zero-knowledge: keys decrypted only inside hardware enclaves.
-- **Data Portability** — Full vault export (JSON + encrypted blobs). Standalone recovery with private key — no CipherBox required.
-- **Observability** — Structured logging (web), Prometheus metrics endpoint (API), Grafana Faro integration, load testing infrastructure.
-- **BYO IPFS** — Bring-your-own IPFS node support via server-relay flow. Dual-pin mode with automatic migration.
+- **Sync** — Multi-device via IPNS polling (~30s). Conflict detection and resolution
+  (sequence-number based).
+- **Desktop** — macOS, Linux, and Windows via Tauri v2 + FUSE-T/libfuse3/WinFsp virtual filesystem
+  mount. Background sync with system tray. SMB backend on macOS.
+- **TEE Republishing** — Automatic IPNS record refresh every 6 hours via Phala Cloud. Zero-knowledge:
+  keys decrypted only inside hardware enclaves.
+- **Data Portability** — Full vault export (JSON + encrypted blobs). Standalone recovery with
+  `privateKey` — no CipherBox required.
+- **Observability** — Structured logging (web), Prometheus metrics endpoint (API), Grafana Faro
+  integration, load testing infrastructure.
+- **BYO IPFS** — Bring-your-own IPFS node support via server-relay flow. Dual-pin mode with
+  automatic migration.
 
 ## Architecture Overview
 
 ```text
-┌──────────────┐     ┌──────────────┐     ┌───────────────┐
-│  Web / Desktop│────>│  CipherBox   │────>│  PostgreSQL   │
-│   (Client)   │     │    API       │     │  (Metadata)   │
-└──────┬───────┘     └──────┬───────┘     └───────────────┘
-       │                    │
-       │ Encrypted          │ Relay
-       │ blobs              │
-       v                    v
+┌───────────────┐     ┌──────────────┐     ┌───────────────┐
+│ Web / Desktop │────>│ CipherBox API│────>│  PostgreSQL   │
+│   (Client)   │     │  (NestJS)    │     │  (Metadata)   │
+└──────┬────────┘     └──────┬───────┘     └───────────────┘
+       │                     │
+       │ Encrypted blobs      │ Relay
+       v                     v
 ┌──────────────┐     ┌───────────────┐
 │    IPFS      │     │  TEE Worker   │
 │  (Storage)   │     │ (IPNS Refresh)│
 └──────────────┘     └───────────────┘
 ```
 
-The client encrypts everything locally. The API is a zero-knowledge relay — it stores encrypted keys and routes IPFS/IPNS operations but never accesses plaintext. For full cryptographic details, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+The client encrypts everything locally. The API is a zero-knowledge relay — it stores encrypted
+keys and routes IPFS/IPNS operations but never accesses plaintext. See
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for cryptographic details.
 
 ## Tech Stack
 
@@ -56,7 +78,7 @@ The client encrypts everything locally. The API is a zero-knowledge relay — it
 | **Frontend**       | React 18 + TypeScript + Tailwind CSS                            |
 | **Backend**        | Node.js + NestJS + TypeScript                                   |
 | **Database**       | PostgreSQL 16                                                   |
-| **Job Queue**      | BullMQ + Redis                                                  |
+| **Job Queue**      | BullMQ + Redis 7                                                |
 | **Key Derivation** | Web3Auth MPC Core Kit                                           |
 | **Storage**        | IPFS via Kubo                                                   |
 | **Desktop**        | Tauri v2 + FUSE-T (macOS) / libfuse3 (Linux) / WinFsp (Windows) |
@@ -69,10 +91,10 @@ The client encrypts everything locally. The API is a zero-knowledge relay — it
 ```text
 cipher-box/
 ├── apps/
-│   ├── api/              # NestJS backend
-│   ├── web/              # React frontend
-│   ├── desktop/          # Tauri v2 desktop app
-│   └── tee-worker/       # Phala Cloud TEE worker
+│   ├── api/              # NestJS backend (@cipherbox/api)
+│   ├── web/              # React frontend (@cipherbox/web)
+│   ├── desktop/          # Tauri v2 desktop app (@cipherbox/desktop)
+│   └── tee-worker/       # Phala Cloud TEE worker (cipherbox-tee-worker)
 ├── packages/
 │   ├── core/             # Shared TypeScript types and metadata schemas
 │   ├── crypto/           # Shared encryption library (AES, ECIES, key derivation)
@@ -80,14 +102,14 @@ cipher-box/
 │   ├── sdk/              # Stateful SDK client (CipherBoxClient)
 │   └── api-client/       # Generated OpenAPI typed client
 ├── crates/
-│   ├── core/             # Shared Rust types and metadata schemas
+│   ├── core/             # Shared Rust types
 │   ├── crypto/           # Rust encryption library
 │   ├── sdk/              # Rust SDK (stateful orchestration, sync daemon)
-│   ├── fuse/             # FUSE filesystem implementation (macOS + Windows)
+│   ├── fuse/             # FUSE filesystem implementation
 │   └── api-client/       # Rust API client
 ├── tests/
-│   ├── web-e2e/          # Playwright E2E tests (14 suites)
-│   ├── sdk-e2e/          # SDK integration tests (11 suites)
+│   ├── web-e2e/          # Playwright web E2E tests
+│   ├── sdk-e2e/          # SDK integration tests
 │   ├── desktop-e2e/      # Desktop E2E tests
 │   ├── load/             # Load and performance tests
 │   └── vectors/          # Crypto test vectors
@@ -96,27 +118,62 @@ cipher-box/
 
 ## Getting Started
 
+### Prerequisites
+
+- Node.js 20+
+- pnpm 10+
+- Docker (for PostgreSQL, IPFS, Redis)
+- Rust toolchain (desktop app only)
+
+### Quick Start
+
 ```bash
+# 1. Start infrastructure services
 docker compose -f docker/docker-compose.yml up -d
+
+# 2. Install dependencies
 pnpm install
-pnpm dev   # starts API (:3000) + web (:5173)
+
+# 3. Copy environment files
+cp apps/api/.env.example apps/api/.env
+cp apps/web/.env.example apps/web/.env
+
+# 4. Start API and web app
+pnpm dev
 ```
 
-See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for full setup instructions including desktop app, testing, and environment configuration.
+- API: <http://localhost:3000>
+- Web: <http://localhost:5173>
+
+See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for full setup including the desktop app, testing,
+and environment configuration.
 
 ## Documentation
 
 | Document                                                                   | Description                                        |
 | :------------------------------------------------------------------------- | :------------------------------------------------- |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)                               | Encryption hierarchy, key derivation, threat model |
-| [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)                                 | Local setup, running, testing                      |
-| [docs/AUTHENTICATION_ARCHITECTURE.md](docs/AUTHENTICATION_ARCHITECTURE.md) | Auth flow details                                  |
-| [docs/METADATA_SCHEMAS.md](docs/METADATA_SCHEMAS.md)                       | All metadata object schemas                        |
+| [docs/AUTHENTICATION_ARCHITECTURE.md](docs/AUTHENTICATION_ARCHITECTURE.md) | Auth flow, Web3Auth integration                    |
 | [docs/FILESYSTEM_SPECIFICATION.md](docs/FILESYSTEM_SPECIFICATION.md)       | Filesystem rules, naming, and constraints          |
-| [docs/VAULT_EXPORT_FORMAT.md](docs/VAULT_EXPORT_FORMAT.md)                 | Export/recovery data format                        |
-| [docs/DATABASE_EVOLUTION_PROTOCOL.md](docs/DATABASE_EVOLUTION_PROTOCOL.md) | Migration discipline                               |
+| [docs/METADATA_SCHEMAS.md](docs/METADATA_SCHEMAS.md)                       | All metadata object schemas                        |
+| [docs/METADATA_EVOLUTION_PROTOCOL.md](docs/METADATA_EVOLUTION_PROTOCOL.md) | Metadata versioning and migration                  |
+| [docs/DATABASE_EVOLUTION_PROTOCOL.md](docs/DATABASE_EVOLUTION_PROTOCOL.md) | Migration discipline, TypeORM rules                |
 | [docs/CAPACITY.md](docs/CAPACITY.md)                                       | Storage quotas and limits                          |
+| [docs/VAULT_EXPORT_FORMAT.md](docs/VAULT_EXPORT_FORMAT.md)                 | Export/recovery data format                        |
+| [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)                                 | Local dev setup, environment, workflow             |
 | [tests/TESTING_STRATEGY.md](tests/TESTING_STRATEGY.md)                     | SDK E2E and load testing architecture              |
+
+## Security
+
+CipherBox is zero-knowledge by design:
+
+- The server never holds plaintext data, file names, or unencrypted keys.
+- `privateKey` is never stored in localStorage, sessionStorage, or sent to the server.
+- All key wrapping uses ECIES secp256k1; all content encryption uses AES-256-GCM.
+- IPNS private keys are encrypted with the TEE `publicKey` before transmission and are decrypted
+  only inside hardware enclaves (`keyEpoch`-scoped, rotated every 4 weeks).
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full threat model.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,73 @@
+<!-- generated-by: gsd-doc-writer -->
+
+# Security Policy
+
+## Supported Versions
+
+CipherBox follows independent per-package versioning managed by Release Please.
+The table below lists the **current released versions** derived from `.release-please-manifest.json`.
+Only the latest release of each component receives security fixes.
+
+| Component             | Current Version | Supported |
+| --------------------- | --------------- | --------- |
+| cipher-box (root)     | 0.38.6          | Yes       |
+| apps/api              | 0.37.1          | Yes       |
+| apps/web              | 0.41.0          | Yes       |
+| apps/desktop          | 0.41.0          | Yes       |
+| apps/tee-worker       | 0.31.1          | Yes       |
+| packages/crypto       | 0.31.0          | Yes       |
+| packages/core         | 0.30.0          | Yes       |
+| All previous releases | —               | No        |
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Use [GitHub Private Vulnerability Reporting](https://github.com/FSM1/cipher-box/security/advisories/new)
+to submit a report confidentially. <!-- VERIFY: private vulnerability reporting is enabled for this repository -->
+
+Include as much of the following as is available:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept (even partial)
+- Affected component(s) and version(s)
+- Any suggested mitigations
+
+<!-- VERIFY: response SLA — the following timeline is a best-effort target, not a contractual commitment -->
+
+**Response expectations:**
+
+- Acknowledgement within 5 business days
+- Initial triage and severity assessment within 10 business days
+- Coordinated disclosure after a fix is available or 90 days from report, whichever comes first
+
+## Security Model and Scope
+
+CipherBox is an end-to-end encrypted storage system. A brief summary of the threat model:
+
+- **Client-side encryption only.** Files and metadata are encrypted in the browser or desktop app
+  before leaving the device. The server stores and relays only ciphertext.
+- **Zero-knowledge server.** The API never receives plaintext file contents, file names, or unencrypted
+  keys. It cannot decrypt user data.
+- **TEE republishing.** IPNS record republishing is performed inside a Trusted Execution Environment
+  (TEE). The TEE decrypts the IPNS private key in hardware for the duration of a single signing
+  operation and immediately discards it.
+- **Key wrapping.** All sensitive keys are wrapped with ECIES before leaving the client. Content is
+  encrypted with AES-256-GCM.
+
+For the full architecture, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
+### In scope
+
+- Vulnerabilities that could expose plaintext user data or private keys
+- Authentication or authorization bypasses in the API
+- Cryptographic weaknesses in key derivation, wrapping, or content encryption
+- TEE isolation failures that could allow key extraction
+- Vulnerabilities in the Tauri desktop app (FUSE layer, IPC, OAuth redirect handling)
+
+### Out of scope
+
+- Denial-of-service attacks against public infrastructure
+- Social engineering of maintainers
+- Vulnerabilities in third-party dependencies (report those upstream; mention them here if they affect CipherBox directly)
+- Issues in deferred features (billing, mobile apps) that are not yet implemented

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,54 @@
+<!-- generated-by: gsd-doc-writer -->
+
+# @cipherbox/api
+
+NestJS backend for CipherBox. Zero-knowledge relay: issues auth tokens, proxies IPFS uploads and IPNS reads/writes through Kubo, manages TEE key state, and serves share/vault/pinning endpoints. The server never holds plaintext content or unencrypted keys.
+
+Part of the [CipherBox monorepo](../../README.md).
+
+## Module overview
+
+| Module            | Purpose                                                                |
+| ----------------- | ---------------------------------------------------------------------- |
+| `auth`            | Web3Auth token exchange, JWT issuance, Argon2 password handling        |
+| `ipfs`            | File upload/download relay to Kubo                                     |
+| `ipns`            | IPNS record publish/resolve relay; delegated routing client            |
+| `republish`       | BullMQ queue that schedules TEE-driven IPNS republishing every 6 hours |
+| `tee`             | `teePublicKey` state, key-rotation log, TEE attestation endpoints      |
+| `shares`          | File/folder share creation, invite management                          |
+| `vault`           | Vault export/import coordination                                       |
+| `device-approval` | Multi-device approval flow                                             |
+| `health`          | `@nestjs/terminus` health checks                                       |
+| `metrics`         | Prometheus metrics via `prom-client`                                   |
+
+## Key scripts
+
+```bash
+pnpm dev                  # Start with watch mode (NestJS)
+pnpm build                # Compile to dist/
+pnpm start:prod           # Run compiled output
+pnpm lint                 # ESLint
+pnpm test                 # Unit tests (jest)
+pnpm test:e2e             # End-to-end tests
+pnpm migrate:dev          # Run pending TypeORM migrations
+pnpm migration:generate   # Generate a new migration from entity diff
+pnpm migration:revert     # Revert the last migration
+```
+
+## Client regeneration
+
+After modifying any endpoint, DTO, or controller, regenerate the typed API client from the monorepo root:
+
+```bash
+pnpm api:generate
+```
+
+This generates the OpenAPI spec, rebuilds `@cipherbox/api-client`, and runs lint fixes. Commit the regenerated files alongside your API changes — a pre-commit hook enforces this.
+
+## Configuration
+
+All environment variables are documented in [../../docs/CONFIGURATION.md](../../docs/CONFIGURATION.md) (or `docs/CONFIGURATION.md` from the monorepo root). Copy `.env.example` to `.env` for local development.
+
+## Database migrations
+
+Migration discipline and TypeORM rules are documented in [../../docs/DATABASE_EVOLUTION_PROTOCOL.md](../../docs/DATABASE_EVOLUTION_PROTOCOL.md). Always generate migrations via `pnpm migration:generate` — never edit entity files without a corresponding migration.

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,0 +1,93 @@
+<!-- generated-by: gsd-doc-writer -->
+
+# @cipherbox/desktop
+
+Tauri-based desktop application for CipherBox. Provides a native app shell around the
+Web3Auth-based login flow and mounts an encrypted virtual filesystem at `~/CipherBox`
+using FUSE-T (macOS), libfuse/fuse3 (Linux), or WinFsp (Windows).
+
+Part of the [CipherBox monorepo](../../README.md).
+
+## Prerequisites
+
+- **Node.js** >= 18 with **pnpm** (managed at monorepo root)
+- **Rust** toolchain channel `1.88` — managed by `src-tauri/rust-toolchain.toml`; install via [rustup](https://rustup.rs/)
+- **Tauri CLI v2** — installed as a dev dependency; no global install required
+
+Platform FUSE dependencies:
+
+- **macOS** — [FUSE-T](https://www.fuse-t.org/) (SMB backend; NFS backend is not used)
+- **Linux** — `libfuse3-3` and `fuse3` (listed as `.deb` dependencies in `tauri.conf.json`)
+- **Windows** — [WinFsp](https://winfsp.dev/) (bundled installer in `resources/winfsp-*.msi`)
+
+## Development
+
+```bash
+# From the monorepo root — runs vite dev + Tauri
+pnpm --filter desktop dev
+```
+
+By default the app targets the **staging API** (`https://api-staging.cipherbox.cc`).
+To use a local API, set in `apps/desktop/.env`:
+
+```env
+VITE_API_URL=http://localhost:3000
+VITE_ENVIRONMENT=local
+```
+
+And pass the Rust env variable:
+
+```bash
+CIPHERBOX_API_URL=http://localhost:3000 pnpm --filter desktop dev
+```
+
+## Build
+
+```bash
+# From the monorepo root — produces platform-native installer
+pnpm --filter desktop build
+```
+
+The Tauri build runs `pnpm vite build` for the frontend, then compiles the Rust backend
+and bundles the installer. Output lands in `src-tauri/target/release/bundle/`.
+
+Available npm scripts:
+
+| Script  | Description                                            |
+| ------- | ------------------------------------------------------ |
+| `dev`   | Start Tauri dev mode (hot-reload webview + Rust watch) |
+| `build` | Build production installer for the current platform    |
+| `vite`  | Run the Vite dev server standalone (no Tauri shell)    |
+
+## Directory Structure
+
+```text
+apps/desktop/
+  src/               # TypeScript/Vite frontend (auth UI, Web3Auth integration)
+  src-tauri/
+    src/
+      fuse/          # FUSE filesystem implementation (macOS/Linux)
+      commands/      # Tauri IPC command handlers
+      registry/      # Device registry (IPNS-based)
+      sync/          # Background sync tasks
+      tray/          # System tray integration
+    vendor/fuser/    # Vendored fuser 0.16 with patched channel.rs for FUSE-T socket compat
+    tauri.conf.json  # Product name, bundle targets, updater, deep-link config
+    Cargo.toml       # Rust dependencies; fuse/winfsp features are platform-gated
+```
+
+Workspace crates consumed by this app (from `../../crates/`):
+
+| Crate                  | Role                                           |
+| ---------------------- | ---------------------------------------------- |
+| `cipherbox-fuse`       | Platform-agnostic FUSE/WinFsp filesystem logic |
+| `cipherbox-core`       | Core domain types and IPFS/IPNS operations     |
+| `cipherbox-crypto`     | Client-side encryption (ECIES, AES-256-GCM)    |
+| `cipherbox-sdk`        | High-level vault operations                    |
+| `cipherbox-api-client` | Generated HTTP client for the CipherBox API    |
+
+## Configuration
+
+See [../../docs/CONFIGURATION.md](../../docs/CONFIGURATION.md) for the full environment
+variable reference. Key variables for local development are `VITE_API_URL`,
+`VITE_ENVIRONMENT`, `CIPHERBOX_API_URL`, and `VITE_TEST_LOGIN_SECRET`.

--- a/apps/tee-worker/README.md
+++ b/apps/tee-worker/README.md
@@ -1,0 +1,62 @@
+<!-- generated-by: gsd-doc-writer -->
+
+# cipherbox-tee-worker
+
+Express HTTP server that runs inside a Trusted Execution Environment to republish IPNS records on behalf of CipherBox users without ever holding plaintext keys outside the enclave.
+
+## Security Model
+
+The API server sends each user's `encryptedIpnsPrivateKey` (ECIES-wrapped with the current `teePublicKey`) to this worker. The worker decrypts the key inside hardware, signs the IPNS record, and immediately zeroes the plaintext from memory. The host process and CipherBox API server never see the raw IPNS private key.
+
+See [../../docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md) for the full system architecture.
+
+## TEE Modes
+
+| `TEE_MODE`            | When used                         | Key derivation                              |
+| --------------------- | --------------------------------- | ------------------------------------------- |
+| `simulator` (default) | Local development, staging Docker | HKDF-SHA256 from a fixed seed               |
+| `cvm`                 | Production — Phala Cloud CVM      | Phala dstack SDK hardware-backed derivation |
+
+Setting `TEE_MODE=simulator` when `CIPHERBOX_ENVIRONMENT=production` (or `NODE_ENV=production`) throws at startup to prevent accidental simulator use in production.
+
+## Key Epoch Rotation
+
+Each `teePublicKey` is tied to a `keyEpoch` — a sequential integer that increments roughly every 4 weeks. During rotation, the worker supports a grace period by falling back to the previous epoch when decryption with the current epoch fails. This allows clients with keys encrypted under the old `teePublicKey` to continue working seamlessly. Grace-period keys are re-encrypted with the current epoch key on successful republish.
+
+## HTTP Routes
+
+| Method | Path               | Auth | Description                                 |
+| ------ | ------------------ | ---- | ------------------------------------------- |
+| GET    | `/health`          | No   | Liveness check                              |
+| GET    | `/metrics`         | No   | Prometheus metrics                          |
+| GET    | `/public-key`      | Yes  | `teePublicKey` for a given `keyEpoch`       |
+| POST   | `/republish`       | Yes  | Batch IPNS signing                          |
+| POST   | `/migrate`         | Yes  | Batch CID migration between IPFS providers  |
+| POST   | `/connection-test` | Yes  | Server-side IPFS endpoint reachability test |
+
+## Scripts
+
+```bash
+pnpm dev        # tsx watch — hot-reload development server
+pnpm build      # tsc — compile to dist/
+pnpm start      # node dist/index.js — run compiled output
+pnpm test       # vitest run
+pnpm test:watch # vitest — watch mode
+```
+
+## Environment Variables
+
+| Variable                | Required | Default     | Description                                     |
+| ----------------------- | -------- | ----------- | ----------------------------------------------- |
+| `TEE_MODE`              | No       | `simulator` | `simulator` or `cvm`                            |
+| `TEE_CURRENT_EPOCH`     | Yes      | —           | Active `keyEpoch` integer                       |
+| `TEE_WORKER_SECRET`     | Yes      | —           | Shared secret for bearer auth                   |
+| `PORT`                  | No       | `3001`      | HTTP listen port                                |
+| `IPFS_GATEWAY_URL`      | No       | —           | IPFS gateway for CID migration                  |
+| `CIPHERBOX_ENVIRONMENT` | No       | —           | Set to `production` to enable production guards |
+
+See [../../docs/CONFIGURATION.md](../../docs/CONFIGURATION.md) for the full configuration reference.
+
+## Deployment
+
+See [../../docs/DEPLOYMENT.md](../../docs/DEPLOYMENT.md) for Docker and Phala Cloud CVM deployment instructions.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,48 @@
+<!-- generated-by: gsd-doc-writer -->
+
+# @cipherbox/web
+
+Browser client for CipherBox — a privacy-first encrypted cloud storage UI built with React, Vite, and Web3Auth.
+
+Part of the [CipherBox monorepo](../../README.md).
+
+## Purpose
+
+This app handles the full user-facing experience: Web3Auth MPC login, client-side file encryption, vault/file management, sharing flows, and IPNS polling sync. The server never receives plaintext or unencrypted keys.
+
+## Structure
+
+```text
+src/
+  components/    UI components (auth, file-browser, vault, settings, mfa, layout)
+  routes/        Page-level route components (FilesPage, SharedPage, BinPage, Login, …)
+  stores/        Zustand state stores (vault, folder, upload, download, share, sync, …)
+  services/      Business logic (encryption, IPNS sync, download, sharing, device registry)
+  workers/
+    encrypt.worker.ts   Web Worker — encrypts file chunks off the main thread
+    decrypt-sw.ts       Service Worker — streams decrypted file downloads
+  hooks/         React hooks
+  lib/           Low-level utilities and helpers
+  utils/         Shared utility functions
+```
+
+## Scripts
+
+| Command           | Description                              |
+| ----------------- | ---------------------------------------- |
+| `pnpm dev`        | Start Vite dev server                    |
+| `pnpm build`      | Type-check, build app and service worker |
+| `pnpm preview`    | Preview production build locally         |
+| `pnpm lint`       | ESLint on `src/**/*.{ts,tsx}`            |
+| `pnpm test`       | Run Vitest test suite                    |
+| `pnpm test:watch` | Run Vitest in watch mode                 |
+
+## Environment Variables
+
+All `VITE_*` variables required at build time. See [docs/CONFIGURATION.md](../../docs/CONFIGURATION.md) for the full list.
+
+## Further Reading
+
+- [Getting Started](../../docs/GETTING-STARTED.md)
+- [Architecture](../../docs/ARCHITECTURE.md)
+- [Development Guide](../../docs/DEVELOPMENT.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,280 +1,397 @@
+<!-- generated-by: gsd-doc-writer -->
+
 # Architecture
 
-CipherBox implements layered, zero-knowledge encryption where **all user data is encrypted client-side before leaving the device**. The server and storage layer never see plaintext — not file contents, not file names, not folder names, not timestamps, not plaintext file sizes (encrypted blob sizes are visible for storage accounting).
+CipherBox implements layered, zero-knowledge encryption where **all user data is encrypted
+client-side before leaving the device**. The server and storage layer never see plaintext —
+not file contents, not file names, not folder names, not timestamps, not plaintext file sizes
+(encrypted blob sizes are visible for storage accounting).
 
 ## System Overview
 
 ```text
-User Device (Web/Desktop)
-        ↓ Auth (4 methods)
-CipherBox Backend (JWT)
-        ↓
-Web3Auth Network (Key Derivation)
-        ↓ ECDSA Private Key (RAM only!)
-User Device ← Vault Data ← PostgreSQL
-        ↓ Encrypted Keys
-IPFS (Kubo) ← Encrypted Files
-        ↑
-TEE (Phala Cloud CVM) ← IPNS Republish (every 6h)
+User Device (Web / Desktop)
+        |
+        | Web3Auth key derivation (secp256k1)
+        v
+CipherBox API  (NestJS, JWT auth)
+        |                           |
+        v                           v
+PostgreSQL                       Kubo (IPFS)
+(users, vaults,                  (encrypted blobs
+ IPNS schedules,                  pinned by CID)
+ device approvals,                     |
+ share metadata)                       v
+        |                       IPNS (folder metadata,
+        |                        per-file metadata,
+        |                        device registry)
+        v
+TEE Worker (Phala Cloud CVM)
+  IPNS republish every 6 hours
+  even when all devices are offline
 ```
 
-**Key Properties:**
+**Key properties:**
 
-- Same user identity → same keypair → same vault (auth methods share a vault when they resolve to the same CipherBox `userId`; see [Authentication Architecture](AUTHENTICATION_ARCHITECTURE.md))
-- TEE republishes IPNS records even when all devices are offline
+- All encryption and decryption is performed on the client. The server is zero-knowledge.
+- The same Web3Auth-derived keypair is always produced for a given identity, so the same vault
+  is accessible from any device.
+- The TEE republishes IPNS records on a fixed schedule so vault metadata remains resolvable
+  even when all user devices are offline.
+
+## Component Map
+
+```text
+apps/
+  api          NestJS backend — auth, vault registry, IPFS relay,
+                 IPNS relay, TEE coordination, sharing, device approval
+  web          React + Vite browser client — full vault UI,
+                 Zustand stores, Web Crypto worker
+  desktop      Tauri + Rust — macOS/Linux FUSE mount, Windows WinFsp
+                 (feature-gated in crates/fuse), native keychain, system tray
+  tee-worker   Express HTTP service — runs in Phala Cloud CVM,
+                 IPNS key decryption and batch signing
+
+packages/
+  crypto       Pure crypto primitives: AES-256-GCM/CTR, ECIES,
+                 Ed25519, HKDF-SHA256, key generation utilities
+  core         Domain types and metadata: folder/file/bin metadata
+                 encrypt/decrypt, vault init, IPNS record construction,
+                 device registry, BYO-IPFS config
+  sdk-core     Stateless operations: upload, download, IPFS/IPNS calls,
+                 folder CRUD, pinning providers (Kubo, PSA, Pinata, dual)
+  sdk          Stateful CipherBoxClient with Zustand-compatible events,
+                 folder state cache, share and bin operations
+  api-client   Generated OpenAPI client (@cipherbox/api-client)
+
+crates/
+  crypto       Rust crypto mirrors (used by desktop Tauri backend)
+  core         Rust domain mirrors
+  fuse         FUSE filesystem crate; depends on fuser 0.16 (vendored patched source at apps/desktop/src-tauri/vendor/fuser/)
+  sdk          Rust SDK for desktop native operations
+  api-client   Rust API client
+```
 
 ## Key Derivation
 
-Two paths produce the same `VaultKey` (a secp256k1 keypair):
+Two paths produce the same VaultKey (a secp256k1 keypair):
 
 ```text
-┌─────────────────────────────────────────────────────────────────────┐
-│                       KEY DERIVATION                                │
-├─────────────────────────┬───────────────────────────────────────────┤
-│  Web3Auth (Social Login)│  Web3Auth (External Wallet via SIWE)     │
-│                         │                                           │
-│  Google/Email/etc.      │  1. Wallet signs SIWE (EIP-4361) message │
-│        ↓                │  2. Backend verifies SIWE, issues JWT    │
-│  Web3Auth Network       │  3. Web3Auth Core Kit validates JWT      │
-│        ↓                │  4. Web3Auth Network                     │
-│  secp256k1 keypair      │        ↓                                  │
-│  (deterministic)        │  secp256k1 keypair (deterministic)       │
-│                         │                                           │
-│                         │                                           │
-├─────────────────────────┴───────────────────────────────────────────┤
-│                              ↓                                      │
-│                   VaultKey (secp256k1)                               │
-│          ┌─────────────────────────────────────┐                    │
-│          │ Private Key: 32 bytes (RAM only!)   │                    │
-│          │ Public Key:  65 bytes (uncompressed) │                   │
-│          └─────────────────────────────────────┘                    │
-└─────────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────┬──────────────────────────────────────────────┐
+│  Web3Auth (Social Login)        │  Web3Auth (External Wallet via SIWE)         │
+│                                 │                                              │
+│  Google / Email / Passkey       │  1. Wallet signs EIP-4361 SIWE message       │
+│           |                     │  2. CipherBox backend verifies SIWE,         │
+│           v                     │     issues JWT                               │
+│  Web3Auth Network               │  3. Web3Auth Core Kit validates JWT          │
+│  (threshold key derivation)     │  4. Web3Auth Network                         │
+│           |                     │           |                                  │
+│           v                     │           v                                  │
+│  secp256k1 keypair              │  secp256k1 keypair (deterministic)           │
+│  (deterministic)                │                                              │
+└─────────────────────────────────┴──────────────────────────────────────────────┘
+                                  |
+                                  v
+                     VaultKey (secp256k1)
+              ┌───────────────────────────────────┐
+              │  privateKey: 32 bytes (RAM only!)  │
+              │  publicKey:  65 bytes (0x04 prefix)│
+              └───────────────────────────────────┘
 ```
+
+The VaultKey `publicKey` is stored as the user's primary identifier in the `users` table.
+The `privateKey` never leaves RAM and is never sent to the server. See
+[Authentication Architecture](AUTHENTICATION_ARCHITECTURE.md) for full auth flow detail.
 
 ## Encryption Hierarchy
 
-Keys below the VaultKey are either **randomly generated** or **HKDF-derived**, then **ECIES-wrapped** with the user's public key. IPNS keypairs (vault, device-registry, per-file) are derived deterministically via HKDF-SHA256 from the user's private key (see [Cryptographic Primitives](#cryptographic-primitives)). Content encryption keys (rootFolderKey, per-folder keys, per-file keys) are randomly generated. Compromising one file key reveals nothing about other file keys.
+Content encryption keys (`rootFolderKey`, per-folder `folderKey`, per-file `fileKey`) are
+randomly generated. IPNS keypairs are deterministically derived via HKDF-SHA256 from the
+user's `privateKey`. All keys that must be stored are ECIES-wrapped with the user's
+`publicKey`. Compromising one `fileKey` reveals nothing about sibling keys.
 
 ```text
-    VaultKey (secp256k1 keypair)
-    │
-    │  ECIES-unwrap
-    ├──────────────────────────────────────────┐
-    │                                          │
-    ▼                                          ▼
- rootFolderKey (random 32B)          rootIpnsPrivateKey (Ed25519, HKDF-derived)
-    │                                          │
-    │  AES-256-GCM decrypt                     │  Signs IPNS records
-    ▼                                          ▼
- Root Folder Metadata (encrypted JSON)     IPNS publish/resolve
-    │
-    │  Contains per-child entries:
-    │
-    ├── File Pointer Entries ────────────────────────────────────────────┐
-    │     name (encrypted)           ◄── only visible after              │
-    │     timestamps (encrypted)         decrypting metadata             │
-    │     fileMetaIpnsName (k51...)  ─────────────────────────────────────┤
-    │          │                                                        │
-    │          ▼                                                        │
-    │     File Metadata (per-file IPNS record, encrypted JSON)          │
-    │         fileKeyEncrypted ─ ECIES-unwrap ──► fileKey (32B)         │
-    │         fileIv (12B)                             │                │
-    │         cid (IPFS ref)          AES-256-GCM decrypt               │
-    │                                                    ▼              │
-    │                                             File Contents          │
-    │                                                                   │
-    ├── Subfolder Entries ──────────────────────────────────────────────┤
-    │     name (encrypted)        ◄── only visible after                │
-    │     timestamps (encrypted)      decrypting metadata               │
-    │     folderKeyEncrypted ── ECIES-unwrap ──► folderKey              │
-    │     ipnsPrivateKeyEncrypted ─ ECIES-unwrap ► ipnsKey              │
-    │     ipnsName (k51...)                                             │
-    │          │                                                        │
-    │          ▼                                                        │
-    │     Subfolder Metadata (same structure, recursive)                │
-    └───────────────────────────────────────────────────────────────────┘
+VaultKey (secp256k1)
+    |
+    |  ECIES-unwrap (client only)
+    |
+    +----> rootFolderKey (random 32B, AES-256-GCM)
+    |          |
+    |          v
+    |      Root Folder Metadata (encrypted JSON)
+    |          |
+    |          +----> FilePointer entries
+    |          |          nameEncrypted, timestamps (encrypted)
+    |          |          fileMetaIpnsName  --> per-file IPNS record
+    |          |                                    fileKey (ECIES-wrapped)
+    |          |                                    cid (IPFS blob ref)
+    |          |
+    |          +----> Subfolder entries
+    |                     nameEncrypted, timestamps (encrypted)
+    |                     folderKey (ECIES-wrapped)
+    |                     encryptedIpnsPrivateKey (ECIES-wrapped)
+    |                     ipnsName (k51..., public)
+    |
+    +----> rootIpnsKeypair (Ed25519, HKDF-derived)
+               |
+               v
+           Signs root folder IPNS records
 ```
+
+The `encryptedIpnsPrivateKey` for each folder is stored in both the folder's parent metadata
+(for client-side re-publish) and in `ipns_republish_schedule` (so the TEE can republish
+on schedule without decrypting folder contents).
 
 ## Visibility Model
 
 ```text
-┌─────────────────────────────────────────────────────────────────┐
-│                    FULLY ENCRYPTED                               │
-│   (requires user's private key + folder key to access)          │
-│                                                                  │
-│   ✓ File contents              ✓ File names                     │
-│   ✓ Folder names               ✓ Folder structure / child list  │
-│   ✓ File sizes                 ✓ Creation timestamps            │
-│   ✓ Modification timestamps    ✓ All encryption keys            │
-│   ✓ IPNS private keys          ✓ File-to-folder relationships   │
-├─────────────────────────────────────────────────────────────────┤
-│                    VISIBLE (Plaintext)                           │
-│   (required for IPFS/IPNS protocol operation)                   │
-│                                                                  │
-│   • IPFS CIDs (content-addressed hashes, no semantic meaning)  │
-│   • IPNS names (k51... public identifiers for folders)         │
-│   • Encrypted blob sizes (approximate original sizes)          │
-│   • Encryption IVs (required for decryption, not secret)       │
-│   • User's secp256k1 public key                                │
-├─────────────────────────────────────────────────────────────────┤
-│                    NEVER STORED (RAM Only)                       │
-│                                                                  │
-│   • User's private key          • Decrypted file names          │
-│   • Decrypted folder metadata   • Decrypted file contents       │
-│   • Plaintext file/folder keys  • Wallet signatures             │
-└─────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│                    FULLY ENCRYPTED                            │
+│  (requires privateKey + folderKey to access)                 │
+│                                                              │
+│  File contents          File names                           │
+│  Folder names           Folder structure / child list        │
+│  File sizes             Creation and modification timestamps │
+│  All encryption keys    IPNS private keys                    │
+│  File-to-folder relationships                                │
+├──────────────────────────────────────────────────────────────┤
+│                    VISIBLE (plaintext)                        │
+│  (required for IPFS/IPNS protocol operation)                 │
+│                                                              │
+│  IPFS CIDs (content-addressed hashes, no semantic meaning)  │
+│  IPNS names (k51... public identifiers)                      │
+│  Encrypted blob sizes (approximate original sizes)          │
+│  Encryption IVs (required for decryption, not secret)       │
+│  User's secp256k1 publicKey                                  │
+├──────────────────────────────────────────────────────────────┤
+│                    NEVER STORED (RAM only)                    │
+│                                                              │
+│  privateKey              Decrypted file names                │
+│  Decrypted folder metadata  Decrypted file contents          │
+│  Plaintext file/folder keys  Wallet signatures               │
+└──────────────────────────────────────────────────────────────┘
 ```
 
 ## Cryptographic Primitives
 
-| Purpose                             | Algorithm                  | Parameters                               |
-| :---------------------------------- | :------------------------- | :--------------------------------------- |
-| File & metadata encryption          | AES-256-GCM                | 256-bit key, 96-bit IV, 128-bit auth tag |
-| Key wrapping                        | ECIES (secp256k1)          | Ephemeral keypair + AES-GCM              |
-| Deterministic key derivation (IPNS) | HKDF-SHA256                | 32-byte output, context-specific salt    |
-| IPNS record signing                 | Ed25519                    | 32-byte seed, 64-byte signatures         |
-| Random generation                   | `crypto.getRandomValues()` | CSPRNG (Web Crypto API)                  |
+| Purpose                           | Algorithm                  | Parameters                               |
+| :-------------------------------- | :------------------------- | :--------------------------------------- |
+| File and metadata encryption      | AES-256-GCM                | 256-bit key, 96-bit IV, 128-bit auth tag |
+| Random-access media decryption    | AES-256-CTR                | 256-bit key, 128-bit IV, 64-bit nonce    |
+| Key wrapping                      | ECIES (secp256k1)          | Ephemeral keypair + AES-GCM              |
+| Deterministic IPNS key derivation | HKDF-SHA256                | 32-byte output, context-specific salt    |
+| IPNS record signing               | Ed25519                    | 32-byte seed, 64-byte signatures         |
+| Random generation                 | `crypto.getRandomValues()` | CSPRNG (Web Crypto API)                  |
+
+All browser-side crypto uses the Web Crypto API or audited libraries (`@noble/*`, `eciesjs`).
+Desktop Rust mirrors use `aes-gcm`, `ecies`, and `ed25519-dalek`. Error messages are kept generic to prevent
+oracle attacks. See `packages/crypto/src/` for the canonical implementations.
 
 ## Data Flows
 
 ### File Upload
 
 ```text
-  ┌──────────────────────────────────────────────────────────────┐
-  │                    FILE UPLOAD FLOW                           │
-  │                                                              │
-  │  1. User selects "document.pdf"                              │
-  │         │                                                    │
-  │         ▼                                                    │
-  │  2. Generate random fileKey (32 bytes)                       │
-  │     Generate random IV (12 bytes)                            │
-  │         │                                                    │
-  │         ▼                                                    │
-  │  3. AES-256-GCM encrypt(plaintext, fileKey, IV)              │
-  │     → ciphertext ‖ auth_tag (16 bytes)                       │
-  │         │                                                    │
-  │         ▼                                                    │
-  │  4. ECIES wrap(fileKey, userPublicKey)                        │
-  │     → ephemeral_pubkey ‖ wrapped_key ‖ tag                   │
-  │         │                                                    │
-  │         ▼                                                    │
-  │  5. Clear plaintext fileKey from memory                      │
-  │         │                                                    │
-  │         ▼                                                    │
-  │  6. Upload encrypted blob → IPFS (Kubo) → returns CID     │
-  │         │                                                    │
-  │         ▼                                                    │
-  │  7. Create per-file FileMetadata entry (own IPNS record):    │
-  │       { cid, fileKeyEncrypted, fileIv, size, ... }           │
-  │         │                                                    │
-  │         ▼                                                    │
-  │  8. Add FilePointer to folder metadata children:             │
-  │       { type: "file", nameEncrypted, nameIv,                 │
-  │         fileMetaIpnsName, ipnsPrivateKeyEncrypted? }         │
-  │         │                                                    │
-  │         ▼                                                    │
-  │  9. Re-encrypt folder metadata with folderKey (AES-256-GCM)  │
-  │         │                                                    │
-  │         ▼                                                    │
-  │ 10. Upload encrypted metadata → IPFS → new CID              │
-  │         │                                                    │
-  │         ▼                                                    │
-  │ 11. Publish IPNS record: /ipns/k51... → /ipfs/<new CID>     │
-  │     (signed with folder's Ed25519 private key)               │
-  └──────────────────────────────────────────────────────────────┘
+1. Generate random fileKey (32 bytes) and IV (12 bytes)
+2. AES-256-GCM encrypt(plaintext, fileKey, IV) → ciphertext || auth_tag
+3. ECIES wrap(fileKey, publicKey) → encryptedFileKey
+4. Clear plaintext fileKey from memory
+5. Upload ciphertext to IPFS via CipherBox API relay → returns CID
+6. Create per-file FileMetadata: { cid, encryptedFileKey, fileIv, size, ... }
+7. Publish FileMetadata as a new IPNS record (per-file ipnsName)
+8. Add FilePointer to parent folder metadata children:
+     { type: "file", nameEncrypted, nameIv, fileMetaIpnsName }
+9. Re-encrypt folder metadata with folderKey (AES-256-GCM)
+10. Upload encrypted metadata to IPFS → new CID
+11. Publish IPNS record: /ipns/k51... → /ipfs/<newCID>
+    signed with folder's Ed25519 ipnsPrivateKey
 ```
 
-## Defense in Depth
-
-Each file key is protected by multiple nested layers. An attacker must break through all layers to access any file content:
+### File Download
 
 ```text
-   File Content
-     └─ encrypted with ──► fileKey (random, unique per file)
-         └─ ECIES-wrapped with ──► User's Public Key
-             └─ stored inside ──► Folder Metadata
-                 └─ encrypted with ──► folderKey (random, unique per folder)
-                     └─ ECIES-wrapped with ──► User's Public Key
-                         └─ stored on ──► Server (zero-knowledge)
+1. Resolve IPNS record for the target folder → CID
+2. Fetch encrypted folder metadata blob from IPFS
+3. Decrypt folder metadata with folderKey (AES-256-GCM)
+4. Locate the target FilePointer; resolve its fileMetaIpnsName → CID
+5. Fetch encrypted FileMetadata blob from IPFS
+6. Decrypt FileMetadata; extract encryptedFileKey and cid
+7. ECIES unwrap(encryptedFileKey, privateKey) → fileKey
+8. Fetch encrypted file blob from IPFS using cid
+9. AES-256-GCM decrypt(ciphertext, fileKey, fileIv) → plaintext
+10. Clear fileKey from memory
 ```
 
-## Threat Model
-
-With full access to IPFS and the CipherBox server but without the user's private key:
+### TEE IPNS Republish (every 6 hours)
 
 ```text
-  IPFS (public network):
-
-    /ipfs/bafybei3a7x...   ← encrypted blob (file? folder? unknown)
-    /ipfs/bafybei9f2k...   ← encrypted blob (file? folder? unknown)
-    /ipfs/bafybeiqw8m...   ← encrypted blob (file? folder? unknown)
-
-  Without the user's private key:
-    ✗ Cannot read file contents
-    ✗ Cannot read file or folder names
-    ✗ Cannot determine folder structure
-    ✗ Cannot read timestamps or file sizes
-    ✗ Cannot determine which blobs are files vs. folders
-    ✓ Can see encrypted blob sizes (approximates original size)
-    ✓ Can see IPNS update frequency (usage pattern)
+CipherBox API (RepublishService)
+    |
+    | Reads ipns_republish_schedule rows where next_republish_at <= now
+    |   Each row contains:
+    |     ipnsName, encryptedIpnsPrivateKey, keyEpoch, latestCid, sequenceNumber
+    |
+    v
+TEE Worker (POST /republish)
+    |
+    | For each entry:
+    |   1. Decrypt encryptedIpnsPrivateKey with epoch-derived TEE key (RAM only)
+    |   2. Build IPNS record pointing to latestCid
+    |   3. Sign with decrypted Ed25519 ipnsPrivateKey
+    |   4. Discard ipnsPrivateKey immediately
+    |   5. If keyEpoch < currentEpoch, re-encrypt with currentEpoch TEE key
+    |      → returns upgradedEncryptedKey and upgradedKeyEpoch
+    |
+    v
+CipherBox API
+    | Receives signed IPNS records
+    | Publishes each via Kubo delegated routing
+    | Updates schedule rows: next_republish_at += 6h
+    | Persists any upgraded key epochs to ipns_republish_schedule
 ```
 
-## Key Design Decisions
+The TEE worker runs as an isolated Express service inside a Phala Cloud CVM. It never
+writes to a database; all state flows through the API. In staging the TEE runs in Docker
+simulator mode. See [tee-worker/src/index.ts](../apps/tee-worker/src/index.ts) for the
+route listing.
 
-### 1. Web3Auth for Key Derivation
+### TEE Key Rotation and keyEpoch Grace Period
 
-```text
-Any auth method → CipherBox backend resolves userId → Web3Auth → Same ECDSA keypair
-```
+The TEE derives its per-epoch secp256k1 keypair from a root secret inside the CVM. When a
+new `teePublicKey` is registered (epoch N+1), the previous epoch (N) enters a 4-week grace
+period. During this period the API accepts `encryptedIpnsPrivateKey` values encrypted with
+either epoch. At each republish cycle the TEE automatically re-encrypts epoch-N keys to
+epoch-(N+1) (the `upgradedEncryptedKey` field). After the grace period ends, the previous
+epoch key is deprecated.
 
-### 2. Layered Encryption
+Key epoch state is tracked in the `tee_key_state` table (columns `current_epoch`,
+`previous_epoch`, `grace_period_ends_at`). See `apps/api/src/tee/tee-key-state.entity.ts`.
 
-```text
-File (AES-256-GCM) → Metadata (AES-256-GCM) → Keys (ECIES)
-```
+## API Modules (apps/api)
 
-### 3. Per-Folder IPNS
+The NestJS backend is decomposed into focused modules. Each module owns its database entities
+via TypeORM repositories. Redis (BullMQ) backs the republish and migration job queues.
 
-```text
-Root IPNS → Folder1 IPNS → Folder2 IPNS (modular sharing-ready)
-```
+| Module            | Purpose                                                                  |
+| :---------------- | :----------------------------------------------------------------------- |
+| `auth`            | Web3Auth JWT login, SIWE wallet auth, refresh tokens, account linking    |
+| `vault`           | Vault init, encrypted key blobs, storage quota, config endpoint          |
+| `ipfs`            | IPFS blob relay (upload / fetch / unpin) via Kubo HTTP API               |
+| `ipns`            | IPNS publish / resolve relay, folder IPNS registration                   |
+| `tee`             | TEE key state, TEE worker HTTP proxy, key rotation                       |
+| `republish`       | BullMQ-backed 6-hour IPNS republish scheduler                            |
+| `device-approval` | Cross-device new-device approval flow (IPNS-based registry)              |
+| `shares`          | Share creation, invite links, share key distribution                     |
+| `migration`       | BullMQ-backed CID migration between pinning providers                    |
+| `health`          | Health check endpoint                                                    |
+| `metrics`         | Prometheus metrics registry (`prom-client`) and HTTP metrics interceptor |
 
-### 4. IPNS Polling Sync
+## Client Applications
 
-```text
-30s polling, no push infrastructure (MVP simple)
-```
+### Web App (apps/web)
 
-### 5. Zero-Knowledge Keys
+React + Vite SPA. State is managed with Zustand stores:
 
-```text
-Server holds: Encrypted root key only
-Client holds: Private key (RAM only)
-```
+| Store                   | Responsibility                                           |
+| :---------------------- | :------------------------------------------------------- |
+| `vault.store`           | Root vault key material (RAM only), vault init state     |
+| `folder.store`          | Folder tree, current path, folder children               |
+| `upload.store`          | Upload queue, progress tracking                          |
+| `download.store`        | Download queue, progress tracking                        |
+| `sync.store`            | IPNS poll status (30-second interval), conflict tracking |
+| `share.store`           | Active shares, invite state                              |
+| `bin.store`             | Recycle bin metadata                                     |
+| `device-registry.store` | Known devices, device approval state                     |
+| `auth.store`            | Auth session, Web3Auth instance                          |
+| `quota.store`           | Storage quota used / available                           |
+| `vault-settings.store`  | BYO-IPFS pinning config, recycle bin settings            |
 
-### 6. TEE-Based IPNS Republishing
+Encryption is offloaded to a `encrypt.worker.ts` Web Worker to keep the main thread
+responsive. Decryption of streamed media uses `decrypt-sw.ts` (a Service Worker) for
+AES-256-CTR random-access range decryption.
 
-```text
-IPNS records expire after ~24h → backend scheduler triggers republish every 6h
-Client encrypts ipnsPrivateKey with TEE public key (ECIES)
-TEE decrypts in hardware, signs, zeroes key immediately
-Provider: Phala Cloud CVM (hardware-backed key derivation via dstack SDK)
-```
+### Desktop App (apps/desktop)
 
-## User Journey Example
+Tauri v2 shell wrapping the same React web frontend. The Rust native backend handles:
 
-```text
-1. Signup (Google) → Web3Auth derives KeyA
-2. Upload file → Encrypt → IPFS CID → IPNS publish
-3. Phone login (Email) → Web3Auth derives KeyA (same!)
-4. Phone polls IPNS → Sees file → Downloads & decrypts
-5. Export vault → JSON with CIDs + encrypted root key
-6. CipherBox gone? → Use export + private key → Full recovery
-```
+- **FUSE virtual filesystem** — mounts the encrypted vault at `~/CipherBox`. On macOS
+  uses FUSE-T's SMB backend (avoids a macOS Sequoia NFS write bug). A vendored fuser 0.16
+  with a patched `channel.rs` handles FUSE-T's Unix socket framing.
+- **Native keychain** — device ID and session tokens stored in macOS Keychain (release
+  builds) or ephemeral memory (debug builds, avoids signature prompts on each rebuild).
+- **Device registry** — registers the device in the encrypted IPNS-based device registry
+  on first login; delegates crypto to the Rust `sdk` and `core` crates.
+- **Debounced publish** — file mutations coalesce with a 1.5s debounce / 10s safety valve
+  before triggering IPNS metadata re-publish.
+
+FUSE callbacks run single-threaded. Network I/O is prohibited in FUSE callbacks (except
+`release()` which spawns a background Tokio task). See the `apps/desktop` `CLAUDE.md` for
+FUSE architecture details.
+
+## Sharing Model
+
+File and folder sharing is client-side key distribution. The owner wraps the target
+`folderKey` (or `fileKey`) with the recipient's `publicKey` using ECIES and stores the
+result as a `ShareKey` in the `shares` table. The recipient fetches the `ShareKey`, unwraps
+it with their own `privateKey`, and then has direct access to the shared content.
+
+The server stores only the ECIES-wrapped `ShareKey` ciphertext — it cannot access the
+plaintext key. Invite links are one-time tokens that deliver the wrapped key to a recipient
+who registers their `publicKey`.
+
+Share key types (`file`, `folder`, `file-ipns`, `folder-ipns`) control whether the
+recipient can read only or also write (subfolder IPNS key required for write).
+
+## BYO-IPFS Pinning
+
+Users can configure their own IPFS pinning backend instead of (or in addition to) the
+default CipherBox Kubo node. Supported pinning modes:
+
+- `cipherbox` — default; all pins managed by CipherBox's Kubo node.
+- `external` — all pins sent to a user-configured endpoint (PSA-compatible, Kubo HTTP API,
+  or Pinata).
+- `dual` — pins sent to both CipherBox and the external provider simultaneously.
+
+The `ByoIpfsConfig` is stored encrypted in the user's vault settings IPNS record and never
+sent to the server in plaintext. The `sdk-core` `pinning/` module implements
+`KuboProvider`, `PsaProvider`, `PinataProvider`, and `DualPinProvider`.
+
+## Database Schema (PostgreSQL)
+
+Managed via TypeORM migrations. See [DATABASE_EVOLUTION_PROTOCOL.md](DATABASE_EVOLUTION_PROTOCOL.md)
+for migration discipline rules.
+
+| Table                     | Purpose                                                                            |
+| :------------------------ | :--------------------------------------------------------------------------------- |
+| `users`                   | One row per identity; unique `publicKey` column (UUID primary key)                 |
+| `auth_methods`            | Linked auth providers per user (Web3Auth, SIWE wallet)                             |
+| `refresh_tokens`          | HTTP-only cookie refresh token store (7-day TTL)                                   |
+| `vaults`                  | Encrypted vault key blobs and root IPNS name per user                              |
+| `pinned_cids`             | CIDs pinned by the user for quota tracking                                         |
+| `folder_ipns`             | IPNS name → owner mapping, used for access control                                 |
+| `ipns_republish_schedule` | Per-folder republish entries: encryptedIpnsPrivateKey, keyEpoch, next_republish_at |
+| `tee_key_state`           | Singleton row: current and previous TEE key epochs + grace period                  |
+| `tee_key_rotation_log`    | Audit log of epoch rotations                                                       |
+| `device_approvals`        | Cross-device approval requests                                                     |
+| `shares`                  | Share records: sharer, recipient, target IPNS name                                 |
+| `share_keys`              | ECIES-wrapped key material per share entry                                         |
+| `share_invites`           | One-time invite tokens for share delivery                                          |
+| `pin_migrations`          | BullMQ-backed CID migration job state                                              |
 
 ## Further Reading
 
-- [Frozen Specifications](../.planning/milestones/m0/Documentation/) — PRD, Technical Architecture, API Specification, Data Flows, Client Specification
-- [Authentication Architecture](AUTHENTICATION_ARCHITECTURE.md) — detailed auth flow documentation
-- [Metadata Schemas](METADATA_SCHEMAS.md) — all metadata object schemas with field tables
-- [Vault Export Format](VAULT_EXPORT_FORMAT.md) — export/recovery data format
+Detailed specifications are maintained in separate documents:
+
+- [AUTHENTICATION_ARCHITECTURE.md](AUTHENTICATION_ARCHITECTURE.md) — Web3Auth flows,
+  SIWE wallet auth, JWT / refresh token lifecycle, multi-auth method linking
+- [FILESYSTEM_SPECIFICATION.md](FILESYSTEM_SPECIFICATION.md) — encrypted filesystem design,
+  IPNS metadata structure, FUSE mount behavior
+- [METADATA_SCHEMAS.md](METADATA_SCHEMAS.md) — all metadata object schemas with field
+  types and encryption status
+- [METADATA_EVOLUTION_PROTOCOL.md](METADATA_EVOLUTION_PROTOCOL.md) — versioning rules for
+  evolving metadata schemas without breaking existing vaults
+- [DATABASE_EVOLUTION_PROTOCOL.md](DATABASE_EVOLUTION_PROTOCOL.md) — TypeORM migration
+  discipline, naming conventions, do-and-don't rules
+- [CAPACITY.md](CAPACITY.md) — storage limits, quota accounting, capacity planning
+- [VAULT_EXPORT_FORMAT.md](VAULT_EXPORT_FORMAT.md) — vault export/import format spec
+- [DEVELOPMENT.md](DEVELOPMENT.md) — local dev setup, environment variables, workflow

--- a/docs/CAPACITY.md
+++ b/docs/CAPACITY.md
@@ -214,7 +214,7 @@ DHT propagation errors do not affect client-facing operations (fire-and-forget).
 **TEE Republishing:**
 
 - Independent scaling path. Add TEE workers to increase IPNS republish batch throughput.
-- Each TEE worker processes a batch of IPNS names every 3 hours.
+- Each TEE worker processes a batch of IPNS names every 6 hours.
 - Batch duration grows linearly with IPNS name count. Monitor `cipherbox_republish_batch_duration_seconds`.
 
 ---
@@ -256,11 +256,11 @@ ipns_names = users * (1 + avg_folders_per_user + avg_files_per_user)
 
 | Users  | Folders/User | Files/User | Total IPNS Names | TEE Republish Batch Size |
 | ------ | ------------ | ---------- | ---------------- | ------------------------ |
-| 100    | 10           | 100        | ~11,100          | ~11,100 every 3h         |
-| 1,000  | 10           | 100        | ~111,000         | ~111,000 every 3h        |
-| 10,000 | 10           | 100        | ~1,110,000       | ~1,110,000 every 3h      |
+| 100    | 10           | 100        | ~11,100          | ~11,100 every 6h         |
+| 1,000  | 10           | 100        | ~111,000         | ~111,000 every 6h        |
+| 10,000 | 10           | 100        | ~1,110,000       | ~1,110,000 every 6h      |
 
-TEE republish batch duration scales linearly with IPNS name count. At current Someguy publish throughput (~15 ops/s), 111,000 names would take ~2 hours to republish -- within the 3-hour window. At 1.1M names, multiple TEE workers or batching optimizations would be needed.
+TEE republish batch duration scales linearly with IPNS name count. At current Someguy publish throughput (~15 ops/s), 111,000 names would take ~2 hours to republish -- within the 6-hour window. At 1.1M names, multiple TEE workers or batching optimizations would be needed.
 
 ### 4.3 Database Growth
 
@@ -271,7 +271,7 @@ TEE republish batch duration scales linearly with IPNS name count. At current So
 | folder_ipns   | users x (folders + files) | ~111,000            | ~1,110,000           |
 | device_tokens | users x avg_devices       | ~2,000              | ~20,000              |
 
-The `folder_ipns` table is the largest growth driver. With proper indexing (already in place on `ipns_name` and `owner_public_key`), queries remain efficient at millions of rows.
+The `folder_ipns` table is the largest growth driver. With proper indexing (already in place on `user_id`, with a unique constraint on `(user_id, ipns_name)`), queries remain efficient at millions of rows.
 
 ### 4.4 Cost Estimates (Single Server Deployment)
 
@@ -296,7 +296,7 @@ These are rough estimates for a self-hosted tech demo deployment, not production
 
 ## 5. Load Test Thresholds
 
-Automated pass/fail thresholds are defined in `tests/load/src/harness/thresholds.ts` and integrated into all 5 load test scenarios. Thresholds are 2-3x observed baselines to avoid CI flakiness while still catching significant regressions.
+Automated pass/fail thresholds are defined in `tests/load/src/harness/thresholds.ts` and integrated into all 8 load test scenarios. Thresholds are 2-3x observed baselines to avoid CI flakiness while still catching significant regressions.
 
 | Scenario           | Operation    | p95 Threshold | Error Rate Max | Rationale                                 |
 | ------------------ | ------------ | ------------- | -------------- | ----------------------------------------- |
@@ -334,7 +334,7 @@ Automated pass/fail thresholds are defined in `tests/load/src/harness/thresholds
 - `tests/load/src/harness/thresholds.ts` -- Threshold checking module (ThresholdConfig, checkThresholds)
 - `tests/load/src/harness/metrics.ts` -- MetricsCollector with percentile calculation
 - `tests/load/src/harness/client-pool.ts` -- Multi-client pool management
-- `tests/load/src/scenarios/` -- 5 load test scenarios with threshold assertions
+- `tests/load/src/scenarios/` -- 8 load test scenarios with threshold assertions
 - `.github/workflows/load-test.yml` -- CI workflow for staging load tests
 
 ### Architecture

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,275 @@
+<!-- generated-by: gsd-doc-writer -->
+
+# Configuration Reference
+
+Environment variables and configuration files for all CipherBox monorepo applications.
+For local development setup instructions, see [DEVELOPMENT.md](DEVELOPMENT.md).
+
+## Table of Contents
+
+- [API (`apps/api`)](#api-appsapi)
+- [Web (`apps/web`)](#web-appsweb)
+- [Desktop (`apps/desktop`)](#desktop-appsdesktop)
+- [TEE Worker (`apps/tee-worker`)](#tee-worker-appstee-worker)
+- [Docker Compose (local dev)](#docker-compose-local-dev)
+- [Docker Compose (staging)](#docker-compose-staging)
+- [Observability (staging)](#observability-staging)
+
+---
+
+## API (`apps/api`)
+
+NestJS server. Configuration is loaded via `@nestjs/config` (`ConfigModule.forRoot`) and read
+from `.env` at startup. Copy `apps/api/.env.example` to `apps/api/.env` before first run.
+
+### Database
+
+| Variable      | Required | Default     | Description              |
+| :------------ | :------- | :---------- | :----------------------- |
+| `DB_HOST`     | No       | `localhost` | PostgreSQL host          |
+| `DB_PORT`     | No       | `5432`      | PostgreSQL port          |
+| `DB_USERNAME` | No       | `postgres`  | PostgreSQL user          |
+| `DB_PASSWORD` | No       | `postgres`  | PostgreSQL password      |
+| `DB_DATABASE` | No       | `cipherbox` | PostgreSQL database name |
+
+### Redis
+
+| Variable         | Required | Default     | Description                                         |
+| :--------------- | :------- | :---------- | :-------------------------------------------------- |
+| `REDIS_HOST`     | No       | `localhost` | Redis host                                          |
+| `REDIS_PORT`     | No       | `6379`      | Redis port                                          |
+| `REDIS_PASSWORD` | No       | —           | Redis password (omit for password-less connections) |
+
+The local dev `docker/docker-compose.yml` maps the Redis container port to `6380` on the host,
+so set `REDIS_PORT=6380` when using the local stack.
+
+### Auth
+
+| Variable            | Required | Default | Description                                                                                    |
+| :------------------ | :------- | :------ | :--------------------------------------------------------------------------------------------- |
+| `JWT_SECRET`        | **Yes**  | —       | HMAC secret used to sign and verify JWT access tokens. Startup fails if absent.                |
+| `TEST_LOGIN_SECRET` | No       | —       | When set, enables the `/auth/test-login` endpoint for E2E test usage. Never set in production. |
+
+### CORS
+
+| Variable               | Required | Default                                       | Description                                                                                                     |
+| :--------------------- | :------- | :-------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- |
+| `CORS_ALLOWED_ORIGINS` | No       | `http://localhost:5173,http://localhost:4173` | Comma-separated list of allowed origins. Supports `*` wildcards (e.g., `https://cipher-box-pr-*.onrender.com`). |
+
+### IPFS
+
+| Variable                 | Required | Default                 | Description                                                                 |
+| :----------------------- | :------- | :---------------------- | :-------------------------------------------------------------------------- |
+| `IPFS_LOCAL_API_URL`     | No       | `http://localhost:5001` | Kubo RPC API endpoint. The API relays all IPFS operations through this URL. |
+| `IPFS_LOCAL_GATEWAY_URL` | No       | `http://localhost:8080` | IPFS HTTP gateway for content retrieval.                                    |
+
+### IPNS / Delegated Routing
+
+| Variable                         | Required | Default                      | Description                                                      |
+| :------------------------------- | :------- | :--------------------------- | :--------------------------------------------------------------- |
+| `DELEGATED_ROUTING_URL`          | No       | `https://delegated-ipfs.dev` | Primary HTTP delegated routing backend for IPNS publish/resolve. |
+| `DELEGATED_ROUTING_FALLBACK_URL` | No       | —                            | Optional secondary backend. Used if the primary request fails.   |
+
+### TEE Integration
+
+| Variable            | Required | Default                 | Description                                                                |
+| :------------------ | :------- | :---------------------- | :------------------------------------------------------------------------- |
+| `TEE_WORKER_URL`    | No       | `http://localhost:3001` | URL of the TEE worker service. The API forwards IPNS republish jobs here.  |
+| `TEE_WORKER_SECRET` | No       | `""` (empty)            | Shared secret sent as `Authorization: Bearer` when calling the TEE worker. |
+
+### Rate Limiting
+
+| Variable                 | Required | Default | Description                                                                                                                                     |
+| :----------------------- | :------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `THROTTLE_BYPASS_SECRET` | No       | —       | When present, requests carrying `X-Throttle-Bypass: <secret>` skip rate limits. Bypass is blocked at the code level when `NODE_ENV=production`. |
+
+### Application
+
+| Variable                     | Required | Default       | Description                                                                                                                          |
+| :--------------------------- | :------- | :------------ | :----------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                       | No       | `3000`        | HTTP listen port.                                                                                                                    |
+| `NODE_ENV`                   | No       | `development` | Runtime environment (`development`, `test`, `production`). Controls log verbosity, rate-limit thresholds, and TypeORM query logging. |
+| `RECYCLE_BIN_RETENTION_DAYS` | No       | `30`          | Days before soft-deleted items are permanently purged. Must be a positive integer; falls back to `30` on invalid input.              |
+
+---
+
+## Web (`apps/web`)
+
+Vite + React SPA. All configuration is injected as `VITE_*` environment variables at build time.
+Copy `apps/web/.env.example` to `apps/web/.env` before first run.
+
+| Variable                  | Required | Default                       | Description                                                                                                                    |
+| :------------------------ | :------- | :---------------------------- | :----------------------------------------------------------------------------------------------------------------------------- |
+| `VITE_API_URL`            | No       | `http://localhost:3000`       | Base URL of the CipherBox API.                                                                                                 |
+| `VITE_WEB3AUTH_CLIENT_ID` | **Yes**  | —                             | Web3Auth project client ID for key derivation and authentication. <!-- VERIFY: obtain from Web3Auth dashboard -->              |
+| `VITE_GOOGLE_CLIENT_ID`   | No       | —                             | Google OAuth client ID for the Google Sign-In provider via Web3Auth. <!-- VERIFY: obtain from Google Cloud Console -->         |
+| `VITE_ENVIRONMENT`        | No       | `local`                       | Deployment environment label (`local`, `staging`, `production`). Used to show the staging banner in the UI.                    |
+| `VITE_APP_VERSION`        | No       | (derived from crypto version) | Application version string injected at build time. Falls back to the internal crypto library version when absent.              |
+| `VITE_FARO_URL`           | No       | —                             | Grafana Faro collector endpoint. When absent, frontend observability is disabled. <!-- VERIFY: set to your Faro ingest URL --> |
+
+---
+
+## Desktop (`apps/desktop`)
+
+Tauri + Vite + React application. Uses the same `VITE_*` convention as the web app.
+Copy `apps/desktop/.env.example` to `apps/desktop/.env` before first run.
+
+### Build-time (Vite) variables
+
+| Variable                  | Required | Default                 | Description                                                                                         |
+| :------------------------ | :------- | :---------------------- | :-------------------------------------------------------------------------------------------------- |
+| `VITE_API_URL`            | No       | `http://localhost:3000` | Base URL of the CipherBox API.                                                                      |
+| `VITE_WEB3AUTH_CLIENT_ID` | **Yes**  | —                       | Web3Auth project client ID. <!-- VERIFY: obtain from Web3Auth dashboard -->                         |
+| `VITE_GOOGLE_CLIENT_ID`   | No       | —                       | Google OAuth client ID. <!-- VERIFY: obtain from Google Cloud Console -->                           |
+| `VITE_ENVIRONMENT`        | No       | `local`                 | Deployment environment label.                                                                       |
+| `VITE_TEST_LOGIN_SECRET`  | No       | —                       | Enables the test-login path inside the desktop app for E2E testing. Never set in production builds. |
+
+### Runtime (Rust backend) variables
+
+The Tauri Rust backend loads `apps/desktop/.env` at startup and resolves the API base URL in
+this order:
+
+1. Runtime env `CIPHERBOX_API_URL` (manual override)
+2. Runtime env `VITE_API_URL`
+3. Compile-time `VITE_API_URL` (baked into release builds by CI)
+4. Fallback `http://localhost:3000`
+
+| Variable            | Required | Default | Description                                                                                                                     |
+| :------------------ | :------- | :------ | :------------------------------------------------------------------------------------------------------------------------------ |
+| `CIPHERBOX_API_URL` | No       | —       | Runtime override for the API base URL used by the Rust backend (sync engine, FUSE mount). Takes precedence over `VITE_API_URL`. |
+
+### Tauri configuration (`apps/desktop/src-tauri/tauri.conf.json`)
+
+Static build-time configuration — not environment-variable driven.
+
+| Key                                 | Value                         | Description                                  |
+| :---------------------------------- | :---------------------------- | :------------------------------------------- |
+| `productName`                       | `CipherBox`                   | Application display name.                    |
+| `identifier`                        | `com.cipherbox.desktop`       | Bundle identifier used on macOS and Linux.   |
+| `plugins.updater.endpoints`         | GitHub Releases `latest.json` | Auto-updater manifest URL.                   |
+| `plugins.deep-link.desktop.schemes` | `cipherbox`                   | Custom URL scheme registered with the OS.    |
+| `build.devUrl`                      | `http://localhost:1420`       | Vite dev server URL used during `tauri dev`. |
+
+The updater `pubkey` in `tauri.conf.json` is the Minisign public key used to verify update
+artifacts — it is safe to commit and is not a secret.
+
+---
+
+## TEE Worker (`apps/tee-worker`)
+
+Standalone Express server. Runs inside a Phala Cloud CVM in production and in a local
+Docker container (simulator mode) in development and staging.
+
+Copy `apps/tee-worker/.env.example` to `apps/tee-worker/.env` for local development.
+
+| Variable                | Required | Default           | Description                                                                                                                                                                 |
+| :---------------------- | :------- | :---------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                  | No       | `3001`            | HTTP listen port.                                                                                                                                                           |
+| `NODE_ENV`              | No       | —                 | Runtime environment. Setting `production` while `TEE_MODE=simulator` is blocked at startup.                                                                                 |
+| `TEE_MODE`              | No       | `simulator`       | Key derivation mode. `simulator` uses HKDF from a fixed seed (development/testing). `cvm` uses Phala dstack SDK for hardware-backed key derivation (production).            |
+| `CIPHERBOX_ENVIRONMENT` | No       | —                 | Explicit environment label (`staging`, `production`). Used alongside `NODE_ENV` to enforce that `TEE_MODE=simulator` is never used in production.                           |
+| `TEE_WORKER_SECRET`     | **Yes**  | —                 | Shared secret for Bearer token authentication on all protected routes. Must match the `TEE_WORKER_SECRET` set in the API.                                                   |
+| `TEE_CURRENT_EPOCH`     | No       | `1`               | The current `keyEpoch` number. The TEE worker exposes the `teePublicKey` for this epoch on `GET /public-key`. Used by the migration route to identify the active key epoch. |
+| `IPFS_GATEWAY_URL`      | No       | `https://ipfs.io` | IPFS gateway URL used when fetching CIDs during CID migration operations.                                                                                                   |
+
+### TEE mode semantics
+
+The `TEE_MODE` variable determines how epoch keypairs are derived:
+
+- **`simulator`** — HKDF-SHA256 derivation from a fixed seed. Deterministic across restarts.
+  Used for local development and staging. Never allowed when `NODE_ENV=production` or
+  `CIPHERBOX_ENVIRONMENT=production`.
+- **`cvm`** — Phala dstack `DstackClient.getKey()` call. Hardware-backed, non-extractable.
+  Required for production Phala Cloud CVM deployments.
+
+---
+
+## Docker Compose (local dev)
+
+File: `docker/docker-compose.yml`
+
+Starts PostgreSQL, IPFS (Kubo), Redis, Someguy (delegated routing), and a mock IPNS routing
+server for local development. Environment variables can be overridden with a `.env` file in the
+`docker/` directory or by setting them in the shell before running `docker compose up`.
+
+| Variable      | Default     | Description                                               |
+| :------------ | :---------- | :-------------------------------------------------------- |
+| `DB_USERNAME` | `postgres`  | PostgreSQL superuser name.                                |
+| `DB_PASSWORD` | `postgres`  | PostgreSQL superuser password.                            |
+| `DB_DATABASE` | `cipherbox` | Database name to create.                                  |
+| `DB_PORT`     | `5432`      | Host port mapped to PostgreSQL 5432 inside the container. |
+| `REDIS_PORT`  | `6380`      | Host port mapped to Redis 6379 inside the container.      |
+
+Service ports exposed to the host:
+
+| Service                     | Port(s)                        | Notes                          |
+| :-------------------------- | :----------------------------- | :----------------------------- |
+| PostgreSQL                  | `5432` (configurable)          |                                |
+| IPFS API                    | `5001`                         | Bound to all interfaces in dev |
+| IPFS Gateway                | `8080`                         | Bound to all interfaces in dev |
+| Redis                       | `6380` (configurable)          |                                |
+| Someguy (delegated routing) | `8190` (HTTP), `4004` (libp2p) |                                |
+| Mock IPNS routing           | `3001` (localhost only)        |                                |
+
+---
+
+## Docker Compose (staging)
+
+File: `docker/docker-compose.staging.yml`
+
+Deploys the full stack including the API, IPFS, Redis, PostgreSQL, TEE worker, Someguy, Caddy
+reverse proxy, and Grafana Alloy for log/metrics forwarding.
+
+The API service reads its environment from `.env.staging` (passed via `env_file`). <!-- VERIFY: create .env.staging on the staging host with all required API variables -->
+
+### Required staging variables
+
+These variables must be set in `.env.staging` (API) or directly in the Docker Compose
+environment block (infrastructure services):
+
+| Variable                 | Service          | Notes                                                          |
+| :----------------------- | :--------------- | :------------------------------------------------------------- |
+| `DB_USERNAME`            | postgres         | Defaults to `cipherbox`                                        |
+| `DB_PASSWORD`            | postgres         | **Required** — no default in staging                           |
+| `DB_DATABASE`            | postgres         | Defaults to `cipherbox_staging`                                |
+| `JWT_SECRET`             | api              | **Required** — any strong random string                        |
+| `REDIS_PASSWORD`         | redis / api      | **Required** — staging Redis runs with `requirepass`           |
+| `TEE_WORKER_SECRET`      | tee-worker / api | Must match between both services                               |
+| `CORS_ALLOWED_ORIGINS`   | api              | Set to the deployed web app origin(s)                          |
+| `IPFS_LOCAL_API_URL`     | api              | Typically `http://ipfs:5001` inside compose network            |
+| `IPFS_LOCAL_GATEWAY_URL` | api              | Typically `http://ipfs:8080` inside compose network            |
+| `DELEGATED_ROUTING_URL`  | api              | Set to `http://someguy:8190` to use the local Someguy instance |
+| `TEE_WORKER_URL`         | api              | Typically `http://tee-worker:3001` inside compose network      |
+
+### Phala Cloud CVM (production TEE worker)
+
+File: `apps/tee-worker/docker-compose.phala.yml`
+
+Used for production TEE deployments on Phala Cloud. Key constraint: always **update** the
+existing CVM using the same `--name` value — never delete and recreate. Recreating changes the
+`app_id`, which invalidates all epoch-derived keys.
+
+| Variable                  | Source           | Notes                                     |
+| :------------------------ | :--------------- | :---------------------------------------- |
+| `TEE_WORKER_SECRET`       | host environment | Injected at deploy time                   |
+| `GITHUB_REPOSITORY_OWNER` | host environment | Used to resolve the container image path  |
+| `TAG`                     | host environment | Image tag to deploy; defaults to `latest` |
+
+---
+
+## Observability (staging)
+
+Grafana Alloy (`docker/docker-compose.staging.yml` `alloy` service) ships logs and metrics
+to Grafana Cloud. The following variables are passed to the Alloy container:
+
+| Variable                      | Description                                                                           |
+| :---------------------------- | :------------------------------------------------------------------------------------ |
+| `GRAFANA_LOKI_URL`            | Loki push endpoint <!-- VERIFY: Grafana Cloud Loki ingest URL -->                     |
+| `GRAFANA_LOKI_USERNAME`       | Loki basic-auth username <!-- VERIFY: Grafana Cloud username -->                      |
+| `GRAFANA_LOKI_API_KEY`        | Loki API key / password <!-- VERIFY: Grafana Cloud API key -->                        |
+| `GRAFANA_PROMETHEUS_URL`      | Prometheus remote-write endpoint <!-- VERIFY: Grafana Cloud Prometheus ingest URL --> |
+| `GRAFANA_PROMETHEUS_USERNAME` | Prometheus basic-auth username <!-- VERIFY: Grafana Cloud username -->                |
+| `GRAFANA_PROMETHEUS_API_KEY`  | Prometheus API key / password <!-- VERIFY: Grafana Cloud API key -->                  |
+
+These values are stored as secrets in the staging deployment environment and are never committed
+to the repository.

--- a/docs/DATABASE_EVOLUTION_PROTOCOL.md
+++ b/docs/DATABASE_EVOLUTION_PROTOCOL.md
@@ -232,6 +232,8 @@ All entity files are relative to `apps/api/src/`.
 | `1742000000000` | `AddPinMigrations.ts`                | Create table       | `pin_migrations`                                                             |
 | `1743000000000` | `AddWritableShares.ts`               | Add columns        | `shares`                                                                     |
 | `1743100000000` | `WidenShareKeyType.ts`               | Alter column       | `share_keys`                                                                 |
+| `1743200000000` | `AddSignedRecordToFolderIpns.ts`     | Add column         | `folder_ipns`                                                                |
+| `1743300000000` | `AddPublicKeyToFolderIpns.ts`        | Add column         | `folder_ipns`                                                                |
 
 ---
 
@@ -346,9 +348,9 @@ During the creation of this protocol, the `device_approvals` table was identifie
 - **Migration files:** `apps/api/src/migrations/`
 - **FullSchema baseline:** `apps/api/src/migrations/1700000000000-FullSchema.ts`
 - **Entity files:** `apps/api/src/{module}/entities/*.entity.ts`
-- **TypeORM config:** `apps/api/src/app.module.ts` (lines 85-87 for `synchronize`/`migrations`/`migrationsRun`)
+- **TypeORM config:** `apps/api/src/app.module.ts` (lines 101-103 for `synchronize`/`migrations`/`migrationsRun`)
 - **Migration runner:** `apps/api/src/run-migrations.ts`
-- **Deploy workflow:** `.github/workflows/deploy-staging.yml` (line 287)
+- **Deploy workflow:** `.github/workflows/deploy-staging.yml` (lines 519-520)
 - **Metadata Evolution Protocol:** [docs/METADATA_EVOLUTION_PROTOCOL.md](METADATA_EVOLUTION_PROTOCOL.md)
 - **Metadata Schema Reference:** [docs/METADATA_SCHEMAS.md](METADATA_SCHEMAS.md)
 - **Phase 14 learnings:** `.learnings/2026-02-22-staging-migration-missing-create-table.md`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,268 @@
+<!-- generated-by: gsd-doc-writer -->
+
+# Deployment
+
+This document covers the release pipeline, staging deployment, TEE worker deployment, desktop app packaging, and landing page deployment for CipherBox.
+
+## Release Pipeline (Release Please)
+
+CipherBox uses [Release Please](https://github.com/googleapis/release-please) for automated changelog generation, version bumping, and GitHub Release creation. Configuration is in `release-please-config.json` and version state is tracked in `.release-please-manifest.json`.
+
+### How it works
+
+On every push to `main`, the `release-please.yml` workflow runs and creates or updates a release PR accumulating conventional commits. When the release PR is merged, Release Please:
+
+1. Bumps each changed package's version in its manifest file
+2. Updates `CHANGELOG.md` entries
+3. Creates a GitHub Release with a component-scoped tag
+
+### Versioned packages
+
+All packages use `include-component-in-tag: true` and `bump-minor-pre-major: true`. Tags follow the pattern `{component}-v{version}`.
+
+| Package path          | Component tag prefix      | Release type |
+| --------------------- | ------------------------- | ------------ |
+| `.` (root)            | `cipher-box-v`            | node         |
+| `apps/api`            | `@cipherbox/api-v`        | node         |
+| `apps/web`            | `@cipherbox/web-v`        | node         |
+| `apps/desktop`        | `cipherbox-desktop-v`     | node         |
+| `apps/tee-worker`     | `cipherbox-tee-worker-v`  | node         |
+| `packages/core`       | `@cipherbox/core-v`       | node         |
+| `packages/crypto`     | `@cipherbox/crypto-v`     | node         |
+| `packages/api-client` | `@cipherbox/api-client-v` | node         |
+| `packages/sdk-core`   | `@cipherbox/sdk-core-v`   | node         |
+| `packages/sdk`        | `@cipherbox/sdk-v`        | node         |
+| `crates/crypto`       | `cipherbox-crypto-v`      | rust         |
+| `crates/core`         | `cipherbox-core-v`        | rust         |
+| `crates/api-client`   | `cipherbox-api-client-v`  | rust         |
+| `crates/fuse`         | `cipherbox-fuse-v`        | rust         |
+| `crates/sdk`          | `cipherbox-sdk-v`         | rust         |
+
+For `apps/desktop`, Release Please additionally propagates the version to `src-tauri/tauri.conf.json` and `src-tauri/Cargo.toml` via the `extra-files` config.
+
+### Release PR title pattern
+
+```text
+chore: release v${version}
+```
+
+### Latest release flag
+
+After creating all batch releases, the `release-please.yml` workflow clears the "latest" flag from every release it creates. The desktop release workflow (`desktop-staging-release.yml`) marks the desktop release as latest so that `/releases/latest/` resolves to the desktop download (used by the Tauri auto-updater).
+
+### Release gate (E2E prerequisite)
+
+Before a release PR can be merged, the `release-gate.yml` workflow verifies that E2E tests have passed on the current `main` HEAD:
+
+- Detects which packages changed (web/desktop path patterns) since the previous release tag
+- Polls the `ci-e2e.yml` workflow run to confirm Web E2E and/or Desktop E2E passed
+- Falls back to the most recent CI E2E run where those tests actually executed
+
+## Staging Deployment
+
+### Triggering a staging deploy
+
+Staging deploys are triggered manually via the `tag-staging.yml` workflow (workflow dispatch in GitHub Actions). The workflow:
+
+1. Resolves the current `main` HEAD SHA
+2. Verifies that `main` HEAD carries a release tag (pattern: `cipher-box-v*`, `cipherbox-*-v*`, or `@cipherbox/*`) — you must wait for a release-please PR to merge before tagging staging
+3. Runs Web E2E (`web-e2e.yml`) and Desktop E2E (`desktop-e2e.yml`) against the resolved SHA in parallel
+4. Requires `staging-approval` environment approval
+5. Creates a tag of the form `staging-YYYYMMDD-release-N` (N is a per-day sequential counter) and pushes it
+6. Calls `deploy-staging.yml` as a reusable workflow
+
+The `staging-` prefix avoids collision with release-please tag patterns.
+
+### Deploy workflow (`deploy-staging.yml`)
+
+Triggered by `staging-*` tag pushes or by `tag-staging.yml` via `workflow_call`. The workflow runs these jobs in parallel then converges:
+
+- **Build & Push API Image** — builds `apps/api/Dockerfile` from repo root, pushes to `ghcr.io/{owner}/cipherbox-api` with three tags: `{api-version}`, `latest-staging`, `{staging-tag}`
+- **Build & Push TEE Worker Image** — builds `apps/tee-worker/Dockerfile` from repo root, pushes to `ghcr.io/{owner}/cipherbox-tee-worker` with the same tagging scheme
+- **Build Web App** — installs deps, builds shared packages, then builds `@cipherbox/web` with staging env vars injected at build time; uploads `apps/web/dist/` as a workflow artifact
+- **Build Desktop App (macOS / Windows / Linux)** — see [Desktop App Packaging](#desktop-app-packaging) below
+- **Deploy to Staging VPS** — waits for the three build jobs above, then SCPs files to the VPS and runs Docker Compose (see [VPS Deployment](#vps-deployment))
+- **Provision Grafana Dashboard** — waits for VPS deploy, then pushes `docker/grafana/dashboards/cipherbox-staging.json` to Grafana Cloud
+
+### VPS deployment
+
+The `deploy-vps` job:
+
+1. Downloads the web dist artifact
+2. Generates `.env.staging` from GitHub Actions secrets/vars and appends image tags and component versions
+3. SCPs `.env.staging`, `docker/docker-compose.staging.yml`, `docker/Caddyfile`, and `docker/alloy-config.river` to `/opt/cipherbox/` on the staging VPS <!-- VERIFY: VPS host address is in STAGING_HOST secret -->
+4. Copies the web dist to `/opt/cipherbox/web/` (with `rm: true` to replace previous dist)
+5. On the VPS: logs in to GHCR, pulls new images, runs database migrations (`node dist/run-migrations.js`), brings services up with `docker compose up -d`, restarts Caddy, and prunes old images
+
+### Docker Compose services (staging)
+
+Configuration: `docker/docker-compose.staging.yml`
+
+| Service      | Image                                        | Description                                                                   |
+| ------------ | -------------------------------------------- | ----------------------------------------------------------------------------- |
+| `api`        | `ghcr.io/{owner}/cipherbox-api:{tag}`        | NestJS API, port 3000 (loopback only)                                         |
+| `postgres`   | `postgres:16-alpine`                         | PostgreSQL database, port 5432 (loopback only)                                |
+| `redis`      | `redis:7-alpine`                             | Redis (password-protected), port 6379 (loopback only)                         |
+| `ipfs`       | `ipfs/kubo:v0.40.0`                          | Kubo IPFS node (pebbleds profile), p2p port 4001 public, API/gateway loopback |
+| `tee-worker` | `ghcr.io/{owner}/cipherbox-tee-worker:{tag}` | TEE worker in `TEE_MODE=simulator` for staging                                |
+| `someguy`    | `ghcr.io/ipfs/someguy:v0.11.1`               | Delegated IPFS routing (accelerated DHT), p2p port 4004 public                |
+| `caddy`      | `caddy:2-alpine`                             | Reverse proxy / TLS termination / web app static serving                      |
+| `alloy`      | `grafana/alloy:v1.6.1`                       | Log and metrics shipper to Grafana Cloud                                      |
+
+The `api` service health-checks depend on both `postgres` and `redis` being healthy before starting.
+
+### Rollback procedure
+
+To revert a staging deployment, re-run `tag-staging.yml` pointing at the commit you want, or on the VPS:
+
+```bash
+cd /opt/cipherbox/docker
+# Set TAG to the previous staging tag
+export TAG=staging-YYYYMMDD-release-N
+docker compose -f docker-compose.staging.yml pull
+docker compose -f docker-compose.staging.yml up -d
+```
+
+<!-- VERIFY: confirm rollback steps with ops team for production procedure -->
+
+## TEE Worker Deployment
+
+The TEE worker handles IPNS republishing every 6 hours. It runs in two modes:
+
+| Mode                 | Environment | Description                                        |
+| -------------------- | ----------- | -------------------------------------------------- |
+| `TEE_MODE=simulator` | Staging     | Runs as a plain Docker container (no hardware TEE) |
+| `TEE_MODE=cvm`       | Production  | Runs inside a Phala Cloud CVM (confidential VM)    |
+
+### Staging TEE (simulator mode)
+
+In staging the `tee-worker` service in `docker/docker-compose.staging.yml` sets `TEE_MODE=simulator`. No Phala infrastructure is required.
+
+### Production TEE (Phala Cloud CVM)
+
+Configuration: `apps/tee-worker/docker-compose.phala.yml`
+
+The TEE worker runs as a Phala Cloud CVM with the dstack socket mounted at `/var/run/dstack.sock`. Deploy using the Phala CLI:
+
+```bash
+phala deploy -c apps/tee-worker/docker-compose.phala.yml -n cipherbox-tee-staging --wait
+```
+
+**Critical:** Always **update** the existing CVM — never delete and recreate. Deleting changes the `app_id`, which would invalidate all existing epoch keys.
+
+The image is pulled from GHCR: `ghcr.io/{owner}/cipherbox-tee-worker:{tag}`.
+
+Environment variables required for the Phala CVM:
+
+| Variable            | Description                              |
+| ------------------- | ---------------------------------------- |
+| `TEE_WORKER_SECRET` | Shared secret between API and TEE worker |
+
+## Desktop App Packaging
+
+The desktop app (Tauri, `apps/desktop`) is built for macOS, Windows, and Linux as part of the staging deploy workflow. There is also a dedicated `desktop-staging-release.yml` workflow triggered by `cipherbox-desktop-v*` tags.
+
+### Build matrix
+
+| Platform | Runner           | FUSE driver                     | Feature flag        |
+| -------- | ---------------- | ------------------------------- | ------------------- |
+| macOS    | `macos-latest`   | FUSE-T (installed via Homebrew) | default             |
+| Windows  | `windows-latest` | WinFsp v2.1 (downloaded MSI)    | `--features winfsp` |
+| Linux    | `ubuntu-22.04`   | libfuse3 (apt)                  | `--features fuse`   |
+
+### Build steps (all platforms)
+
+1. Check out the staging tag
+2. Install platform FUSE driver (FUSE-T / WinFsp / libfuse3)
+3. Install Rust toolchain (stable)
+4. Install Node.js 22 and pnpm dependencies (`--frozen-lockfile`)
+5. Build shared packages: `@cipherbox/crypto`, `@cipherbox/core`, `@cipherbox/api-client`, `@cipherbox/sdk-core`, `@cipherbox/sdk`
+6. Run `tauri-apps/tauri-action@v0` from `apps/desktop` with signing keys and staging env vars injected
+
+### Signing
+
+Desktop builds are signed with `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` from GitHub Actions secrets. macOS and Windows builds in staging are **unsigned** (no code-signing certificate) — users must right-click > Open (macOS) or click "More info" > "Run anyway" (Windows) on first launch.
+
+### Auto-updater
+
+`includeUpdaterJson: true` is set for all platforms, generating a `latest.json` updater manifest. The Tauri auto-updater checks `/releases/latest/` (GitHub Releases) which resolves to the most recent desktop release (marked latest by `desktop-staging-release.yml`'s `mark-latest` job).
+
+### Version propagation
+
+Release Please bumps the version in `apps/desktop/package.json` and propagates it to `apps/desktop/src-tauri/tauri.conf.json` and `apps/desktop/src-tauri/Cargo.toml` via the `extra-files` config in `release-please-config.json`.
+
+## Landing Page Deployment
+
+The landing page (`landing/`) is deployed in two ways:
+
+### IPFS via deploy-landing.yml
+
+Triggered on push to `main` affecting `landing/**`. The workflow:
+
+1. Builds the landing page with `npm run build`
+2. SCPs the dist to the staging VPS
+3. Pins to IPFS via Kubo (`ipfs add -Qr --pin`)
+4. Updates a Cloudflare DNSLink TXT record (`_dnslink.cipherbox.cc`) to point to the new CID <!-- VERIFY: confirm domain is cipherbox.cc -->
+
+### Render (render.yaml)
+
+`render.yaml` also defines a static Render service (`cipherbox-landing`) built from `landing/dist`. This serves as an alternative / fallback hosting with PR preview deployments enabled. <!-- VERIFY: confirm active Render deployment URL -->
+
+## Monitoring
+
+Monitoring is documented in detail in `docker/MONITORING.md`. Summary:
+
+- **Grafana Alloy** runs as a Docker Compose sidecar, shipping logs (Docker json-file driver) to Grafana Cloud Loki and scraping the API's `/metrics` endpoint every 30 seconds for Prometheus metrics to Grafana Cloud Mimir
+- **Dashboard** provisioned automatically by `deploy-staging.yml` from `docker/grafana/dashboards/cipherbox-staging.json`
+- **Better Stack Uptime** monitors `https://api-staging.cipherbox.cc/health` every 3 minutes <!-- VERIFY: confirm uptime monitor is active -->
+
+### Required Grafana secrets (GitHub Actions `staging` environment)
+
+| Secret / Variable             | Description                                            |
+| ----------------------------- | ------------------------------------------------------ |
+| `GRAFANA_LOKI_URL`            | Loki push endpoint                                     |
+| `GRAFANA_LOKI_USERNAME`       | Numeric Loki instance ID                               |
+| `GRAFANA_LOKI_API_KEY`        | Loki publisher API key                                 |
+| `GRAFANA_PROMETHEUS_URL`      | Prometheus remote write endpoint                       |
+| `GRAFANA_PROMETHEUS_USERNAME` | Numeric Prometheus instance ID                         |
+| `GRAFANA_PROMETHEUS_API_KEY`  | Prometheus publisher API key                           |
+| `GRAFANA_API_KEY`             | Grafana Cloud API key for dashboard provisioning       |
+| `GRAFANA_URL`                 | Grafana Cloud instance URL <!-- VERIFY: actual URL --> |
+| `GRAFANA_DS_METRICS_UID`      | Prometheus datasource UID in Grafana                   |
+| `GRAFANA_DS_LOGS_UID`         | Loki datasource UID in Grafana                         |
+
+## Environment Variables for Staging
+
+The staging VPS deploy generates `.env.staging` from GitHub Actions secrets and vars. The full list of required environment variables is documented in `docs/CONFIGURATION.md`.
+
+Key secrets required in the GitHub Actions `staging` environment:
+
+| Secret                               | Description                                    |
+| ------------------------------------ | ---------------------------------------------- |
+| `STAGING_SSH_KEY`                    | SSH private key for VPS access                 |
+| `STAGING_DB_PASSWORD`                | PostgreSQL password                            |
+| `STAGING_JWT_SECRET`                 | JWT signing secret                             |
+| `STAGING_TEE_WORKER_SECRET`          | Shared secret between API and TEE worker       |
+| `STAGING_REDIS_PASSWORD`             | Redis password                                 |
+| `STAGING_TEST_LOGIN_SECRET`          | Test login bypass secret (non-production only) |
+| `STAGING_THROTTLE_BYPASS_SECRET`     | Rate-limit bypass secret                       |
+| `TAURI_SIGNING_PRIVATE_KEY`          | Desktop app update signing key                 |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Desktop app update signing key password        |
+| `CLOUDFLARE_API_TOKEN`               | Cloudflare API token for DNSLink updates       |
+| `CLOUDFLARE_ZONE_ID`                 | Cloudflare zone ID for the landing page domain |
+| `DNSLINK_RECORD_ID`                  | DNS record ID for `_dnslink.cipherbox.cc`      |
+
+Key vars (non-secret):
+
+| Variable                  | Description                                                     |
+| ------------------------- | --------------------------------------------------------------- |
+| `STAGING_HOST`            | VPS hostname/IP <!-- VERIFY -->                                 |
+| `STAGING_USER`            | VPS SSH username <!-- VERIFY -->                                |
+| `STAGING_API_URL`         | Public API URL injected into web/desktop builds <!-- VERIFY --> |
+| `STAGING_DB_USERNAME`     | PostgreSQL username                                             |
+| `CORS_ALLOWED_ORIGINS`    | Comma-separated allowed CORS origins                            |
+| `VITE_WEB3AUTH_CLIENT_ID` | Web3Auth client ID                                              |
+| `GOOGLE_CLIENT_ID`        | Google OAuth client ID                                          |
+| `VITE_FARO_URL`           | Grafana Faro endpoint                                           |
+| `GRAFANA_STACK_ID`        | Grafana stack identifier                                        |
+| `SENDGRID_FROM_EMAIL`     | SendGrid sender address                                         |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -98,16 +98,16 @@ The `deploy-vps` job:
 
 Configuration: `docker/docker-compose.staging.yml`
 
-| Service      | Image                                        | Description                                                                   |
-| ------------ | -------------------------------------------- | ----------------------------------------------------------------------------- |
-| `api`        | `ghcr.io/{owner}/cipherbox-api:{tag}`        | NestJS API, port 3000 (loopback only)                                         |
-| `postgres`   | `postgres:16-alpine`                         | PostgreSQL database, port 5432 (loopback only)                                |
-| `redis`      | `redis:7-alpine`                             | Redis (password-protected), port 6379 (loopback only)                         |
-| `ipfs`       | `ipfs/kubo:v0.40.0`                          | Kubo IPFS node (pebbleds profile), p2p port 4001 public, API/gateway loopback |
-| `tee-worker` | `ghcr.io/{owner}/cipherbox-tee-worker:{tag}` | TEE worker in `TEE_MODE=simulator` for staging                                |
-| `someguy`    | `ghcr.io/ipfs/someguy:v0.11.1`               | Delegated IPFS routing (accelerated DHT), p2p port 4004 public                |
-| `caddy`      | `caddy:2-alpine`                             | Reverse proxy / TLS termination / web app static serving                      |
-| `alloy`      | `grafana/alloy:v1.6.1`                       | Log and metrics shipper to Grafana Cloud                                      |
+| Service      | Image                                        | Description                                                                                                                              |
+| ------------ | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `api`        | `ghcr.io/{owner}/cipherbox-api:{tag}`        | NestJS API, port 3000 (loopback only)                                                                                                    |
+| `postgres`   | `postgres:16-alpine`                         | PostgreSQL database, port 5432 (loopback only)                                                                                           |
+| `redis`      | `redis:7-alpine`                             | Redis (password-protected), port 6379 (loopback only)                                                                                    |
+| `ipfs`       | `ipfs/kubo:v0.40.0`                          | Kubo IPFS node (pebbleds profile), p2p port 4001 public, API/gateway loopback                                                            |
+| `tee-worker` | `ghcr.io/{owner}/cipherbox-tee-worker:{tag}` | TEE worker in `TEE_MODE=simulator` for staging                                                                                           |
+| `someguy`    | `ghcr.io/ipfs/someguy:v0.11.1`               | Delegated IPFS routing (accelerated DHT), p2p port 4004 public, routing API 8190 internal-only (unlike local dev, where it is published) |
+| `caddy`      | `caddy:2-alpine`                             | Reverse proxy / TLS termination / web app static serving                                                                                 |
+| `alloy`      | `grafana/alloy:v1.6.1`                       | Log and metrics shipper to Grafana Cloud                                                                                                 |
 
 The `api` service health-checks depend on both `postgres` and `redis` being healthy before starting.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -15,14 +15,21 @@ Start the required services:
 docker compose -f docker/docker-compose.yml up -d
 ```
 
-This starts:
+This starts the `cipherbox-infrastructure` compose project (containers are named `cipherbox-<service>`):
 
-| Service           | Port                       | Purpose                           |
-| :---------------- | :------------------------- | :-------------------------------- |
-| PostgreSQL 16     | 5432                       | Database                          |
-| IPFS (Kubo)       | 5001 (API), 8080 (Gateway) | Decentralized storage             |
-| Redis 7           | 6380                       | BullMQ job queue                  |
-| Mock IPNS Routing | 3001                       | Local IPNS resolution for dev/E2E |
+| Service             | Image                                 | Host Port(s)                                     | Purpose                                  |
+| :------------------ | :------------------------------------ | :----------------------------------------------- | :--------------------------------------- |
+| `postgres`          | `postgres:16-alpine`                  | 5432 (`DB_PORT`)                                 | Database                                 |
+| `ipfs`              | `ipfs/kubo:v0.40.0`                   | 5001 (API), 8080 (gateway), 4001 tcp/udp (swarm) | Decentralized storage (Kubo)             |
+| `redis`             | `redis:7-alpine`                      | 6380 (`REDIS_PORT`) → container 6379             | BullMQ job queue                         |
+| `someguy`           | `ghcr.io/ipfs/someguy:v0.11.1`        | 8190 (routing API), 4004 tcp/udp (libp2p swarm)  | Delegated IPFS routing (accelerated DHT) |
+| `mock-ipns-routing` | built from `tools/mock-ipns-routing/` | 3001 (loopback only)                             | Local IPNS resolution for dev/E2E        |
+
+Notes:
+
+- The IPFS node runs with the `server,pebbleds` datastore profile. If you have an `ipfs_data` volume created before the pebbleds switch, recreate it first: `docker compose -f docker/docker-compose.yml down -v --remove-orphans`.
+- The `ipfs` and `someguy` containers are each capped at 2 GB memory / 1 CPU.
+- The staging stack runs a different set of containers (adds `api`, `tee-worker`, `caddy`, `alloy`; drops `mock-ipns-routing`) — see [DEPLOYMENT.md](DEPLOYMENT.md).
 
 ## Environment
 
@@ -163,7 +170,7 @@ Set the required environment variables and start the worker:
 TEE_MODE=simulator TEE_WORKER_SECRET=dev-secret pnpm --filter cipherbox-tee-worker dev
 ```
 
-The worker listens on port `3001` by default. The API authenticates to the TEE worker using a shared `Bearer` token — set the same value in `apps/api/.env`:
+The worker listens on port `3001` by default. Note that the `mock-ipns-routing` container also binds `127.0.0.1:3001` — when running the worker alongside the local Docker infrastructure, pick a free port (e.g. `PORT=3002`) and point `TEE_WORKER_URL` at it. The API authenticates to the TEE worker using a shared `Bearer` token — set the same value in `apps/api/.env`:
 
 ```bash
 TEE_WORKER_SECRET=dev-secret

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -119,13 +119,13 @@ pnpm --filter @cipherbox/crypto test
 Playwright auto-starts API + web via `webServer` config (requires infra services: Postgres, IPFS, Redis):
 
 ```bash
-pnpm test:e2e
+pnpm test:web-e2e
 ```
 
 Headed mode (shows browser):
 
 ```bash
-pnpm test:e2e:headed
+pnpm test:web-e2e:headed
 ```
 
 ### Desktop E2E
@@ -143,7 +143,7 @@ After modifying API endpoints, DTOs, or controllers, regenerate the typed client
 pnpm api:generate
 ```
 
-This generates the OpenAPI spec from the API, creates the typed client at `apps/web/src/api/`, and runs lint fixes. Always commit the regenerated files with your API changes.
+This generates the OpenAPI spec from the API, creates the typed client at `packages/api-client/`, and runs lint fixes. Always commit the regenerated files with your API changes.
 
 ## Code Quality
 
@@ -152,3 +152,30 @@ This generates the OpenAPI spec from the API, creates the typed client at `apps/
 - **Type checking:** `pnpm typecheck`
 - **Formatting:** Prettier (runs via lint-staged on commit)
 - **Commits:** [Conventional Commits](https://www.conventionalcommits.org/) enforced by commitlint (`feat:`, `fix:`, `docs:`, etc.)
+
+## Running the TEE Worker (Simulator Mode)
+
+The TEE worker (`apps/tee-worker`) republishes IPNS records. In production it runs inside a Phala Cloud CVM; locally it runs in **simulator mode**, which uses a deterministic HKDF-SHA256 seed instead of hardware-backed key derivation.
+
+Set the required environment variables and start the worker:
+
+```bash
+TEE_MODE=simulator TEE_WORKER_SECRET=dev-secret pnpm --filter cipherbox-tee-worker dev
+```
+
+The worker listens on port `3001` by default. The API authenticates to the TEE worker using a shared `Bearer` token — set the same value in `apps/api/.env`:
+
+```bash
+TEE_WORKER_SECRET=dev-secret
+TEE_WORKER_URL=http://localhost:3001
+```
+
+Key variables:
+
+| Variable            | Required | Notes                                           |
+| :------------------ | :------- | :---------------------------------------------- |
+| `TEE_MODE`          | Yes      | `simulator` (local) or `cvm` (Phala Cloud prod) |
+| `TEE_WORKER_SECRET` | Yes      | Shared secret for Bearer token auth             |
+| `PORT`              | No       | Defaults to `3001`                              |
+
+`TEE_MODE=simulator` is blocked at runtime if `NODE_ENV=production` or `CIPHERBOX_ENVIRONMENT=production` to prevent accidental use of the fixed seed in production.

--- a/docs/FILESYSTEM_SPECIFICATION.md
+++ b/docs/FILESYSTEM_SPECIFICATION.md
@@ -19,7 +19,7 @@ The target invariant is that the strictest platform constraint (Windows) should 
 
 | Platform | Storage    | Lookup                           | Implementation                                                |
 | -------- | ---------- | -------------------------------- | ------------------------------------------------------------- |
-| Web      | As-entered | Case-sensitive (`===`)           | `folder.service.ts`, `sdk-core/folder`                        |
+| Web      | As-entered | Case-sensitive (`===`)           | `sdk-core/src/folder/tree.ts`                                 |
 | macOS    | As-entered | NFC-normalized                   | `inode.rs:normalize_name()` via `unicode-normalization` crate |
 | Linux    | As-entered | NFC-normalized                   | Same `fuse` feature as macOS; case-sensitive                  |
 | Windows  | As-entered | Case-insensitive (lowercase key) | `inode.rs:normalize_name()` via `.to_lowercase()`             |
@@ -92,11 +92,11 @@ CipherBox filters platform-specific system files that should never be created, s
 
 ### Storage Quota
 
-| Limit       | Value   | Enforcement                                        | Constant                            |
-| ----------- | ------- | -------------------------------------------------- | ----------------------------------- |
-| Total quota | 500 MiB | Server-side (`vault.service.ts`), client pre-check | `QUOTA_LIMIT_BYTES` / `QUOTA_BYTES` |
+| Limit       | Value   | Enforcement                                        | Constant                                                                  |
+| ----------- | ------- | -------------------------------------------------- | ------------------------------------------------------------------------- |
+| Total quota | 500 MiB | Server-side (`vault.service.ts`), client pre-check | `QUOTA_LIMIT_BYTES` (API); `QUOTA_BYTES` (`crates/fuse/src/constants.rs`) |
 
-**Rationale:** Technology demonstrator limit. Quota tracks encrypted blob sizes (not plaintext sizes). BYO-IPFS users bypass this limit (advisory only) since they manage their own storage.
+**Rationale:** Quota tracks encrypted blob sizes (not plaintext sizes). BYO-IPFS users bypass this limit (advisory only) since they manage their own storage.
 
 ## Folder Structure
 
@@ -110,9 +110,8 @@ CipherBox filters platform-specific system files that should never be created, s
 
 **Enforcement points:**
 
-- `folder.service.ts:170` — `createFolder` checks `parentDepth >= MAX_FOLDER_DEPTH`
-- `folder.service.ts:759` — `moveFolder` checks `destDepth + 1 + subtreeDepth > MAX_FOLDER_DEPTH`
-- `useFolderMutations.ts:73` — duplicate check in React hooks layer
+- `useFolderMutations.ts:102` — `createFolder` checks `parentDepth >= MAX_FOLDER_DEPTH`
+- `useFolderMutations.ts:283` — `moveFolder` checks `destDepth + 1 + subtreeDepth > MAX_FOLDER_DEPTH`
 
 ### Duplicate Names
 
@@ -131,10 +130,10 @@ if (nameExists) throw new Error('An item with this name already exists');
 
 ## File Versioning
 
-| Limit             | Value      | Enforcement        | Constant                |
-| ----------------- | ---------- | ------------------ | ----------------------- |
-| Max versions/file | 10         | SDK and FUSE layer | `MAX_VERSIONS_PER_FILE` |
-| Version cooldown  | 15 minutes | Desktop FUSE only  | `VERSION_COOLDOWN_MS`   |
+| Limit             | Value      | Enforcement        | Constant                                      |
+| ----------------- | ---------- | ------------------ | --------------------------------------------- |
+| Max versions/file | 10         | SDK and FUSE layer | `MAX_VERSIONS_PER_FILE`                       |
+| Version cooldown  | 15 minutes | Desktop FUSE only  | `version_cooldown_ms` (struct field, runtime) |
 
 **Rationale:** Version history is stored inside the file's IPNS metadata. Each version entry contains a CID, key, IV, and timestamp. Capping at 10 prevents metadata bloat. The 15-minute cooldown on desktop prevents rapid saves (e.g., auto-save in text editors) from consuming all version slots.
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -1,0 +1,176 @@
+<!-- generated-by: gsd-doc-writer -->
+
+# Getting Started with CipherBox
+
+CipherBox is a privacy-first encrypted cloud storage system using IPFS/IPNS and Web3Auth.
+This guide takes you from a fresh checkout to a running local stack.
+
+## Prerequisites
+
+| Tool           | Version    | Notes                                          |
+| :------------- | :--------- | :--------------------------------------------- |
+| Node.js        | 20+        | Used by all JS/TS workspaces                   |
+| pnpm           | 10.33.0    | Declared in `packageManager` field             |
+| Docker         | Any recent | Runs PostgreSQL, IPFS, Redis, and mock routing |
+| Rust toolchain | stable     | Desktop app only (`apps/desktop`)              |
+
+No `.nvmrc` is present; use your system Node version manager to select Node 20+.
+
+For the desktop app, also install the platform FUSE driver:
+
+- **macOS:** `brew install macos-fuse-t/homebrew-cask/fuse-t`
+- **Windows:** [WinFSP](https://winfsp.dev/)
+- **Linux:** `libfuse3-dev` (or the equivalent for your distribution)
+
+## Installation
+
+```bash
+git clone https://github.com/YOUR_ORG/cipher-box.git
+cd cipher-box
+pnpm install
+```
+
+## Local Infrastructure
+
+All required backing services are defined in `docker/docker-compose.yml`. Start them before
+running any application:
+
+```bash
+docker compose -f docker/docker-compose.yml up -d
+```
+
+This starts the following services:
+
+| Service                     | Port(s)                                  | Purpose                               |
+| :-------------------------- | :--------------------------------------- | :------------------------------------ |
+| PostgreSQL 16               | 5432                                     | Primary database                      |
+| IPFS (Kubo v0.40.0)         | 5001 (API), 8080 (Gateway), 4001 (Swarm) | Decentralized file storage            |
+| Redis 7                     | 6380 (host) → 6379 (container)           | BullMQ job queue                      |
+| Someguy (delegated routing) | 8190 (HTTP), 4004 (libp2p)               | IPFS DHT routing                      |
+| Mock IPNS routing           | 3001                                     | Local IPNS resolution for dev and E2E |
+
+Wait for all containers to be healthy before starting the applications:
+
+```bash
+docker compose -f docker/docker-compose.yml ps
+```
+
+## Environment Setup
+
+Copy the example environment files for each application you intend to run:
+
+```bash
+cp apps/api/.env.example apps/api/.env
+cp apps/web/.env.example apps/web/.env
+```
+
+At minimum, set `JWT_SECRET` in `apps/api/.env` — startup fails without it. The default values
+for all other variables in the `.env.example` files match the local Docker Compose stack.
+
+For the full list of variables and their descriptions, see [CONFIGURATION.md](CONFIGURATION.md).
+
+### Redis port note
+
+The Docker Compose file maps the Redis container port to **6380** on the host. Ensure
+`apps/api/.env` contains `REDIS_PORT=6380` (this is already set in `.env.example`).
+
+## Running the Web Stack
+
+Start the API and web app together:
+
+```bash
+pnpm dev
+```
+
+This runs `@cipherbox/api` and `@cipherbox/web` concurrently via `concurrently`.
+
+Or run each individually:
+
+```bash
+pnpm --filter @cipherbox/api dev
+pnpm --filter @cipherbox/web dev
+```
+
+Default URLs:
+
+- API: `http://localhost:3000`
+- Web: `http://localhost:5173`
+
+## Running the Desktop App
+
+The desktop app requires the Rust toolchain and a FUSE driver (see Prerequisites above).
+
+```bash
+cp apps/desktop/.env.example apps/desktop/.env
+pnpm --filter @cipherbox/desktop dev
+```
+
+The desktop app targets the **staging API by default**. To develop against your local API,
+edit `apps/desktop/.env`:
+
+```env
+VITE_API_URL=http://localhost:3000
+VITE_ENVIRONMENT=local
+```
+
+Also pass the API URL to the Rust backend:
+
+```bash
+CIPHERBOX_API_URL=http://localhost:3000 pnpm --filter @cipherbox/desktop dev
+```
+
+## Running the TEE Worker
+
+The TEE worker handles IPNS republishing. It is not required for basic web app development.
+
+```bash
+pnpm --filter cipherbox-tee-worker dev
+```
+
+## First-Use Walkthrough
+
+1. Start infrastructure: `docker compose -f docker/docker-compose.yml up -d`
+2. Start the web stack: `pnpm dev`
+3. Open `http://localhost:5173` in your browser
+4. Log in using Web3Auth (social login or wallet)
+5. On first login a new encrypted vault is created — you will be prompted to save your
+   recovery factor
+6. Upload a file using the drag-and-drop interface or the upload button
+7. The file is encrypted client-side and stored on IPFS; the metadata is published to IPNS
+
+## Common Setup Issues
+
+### `JWT_SECRET` is missing
+
+The API exits immediately at startup if `JWT_SECRET` is not set in `apps/api/.env`. Set it
+to any non-empty string for local development.
+
+### Redis connection refused
+
+The Docker Compose stack maps Redis to port 6380, not the default 6379. Confirm
+`REDIS_PORT=6380` in `apps/api/.env`.
+
+### IPFS container unhealthy
+
+The IPFS container has a 30-second start period. If `docker compose ps` shows it as unhealthy
+immediately after starting, wait 30–60 seconds and check again. If it remains unhealthy:
+
+```bash
+docker compose -f docker/docker-compose.yml logs ipfs
+```
+
+### pnpm version mismatch
+
+The `packageManager` field pins pnpm to `10.33.0`. If your global pnpm differs, enable
+[Corepack](https://nodejs.org/api/corepack.html) to use the pinned version automatically:
+
+```bash
+corepack enable
+```
+
+## Next Steps
+
+- [DEVELOPMENT.md](DEVELOPMENT.md) — build commands, code style, branch conventions, PR process
+- [CONFIGURATION.md](CONFIGURATION.md) — full environment variable reference for all apps
+- [ARCHITECTURE.md](ARCHITECTURE.md) — system architecture and component overview
+- [TESTING.md](TESTING.md) — how to run unit tests and E2E tests

--- a/docs/METADATA_EVOLUTION_PROTOCOL.md
+++ b/docs/METADATA_EVOLUTION_PROTOCOL.md
@@ -23,7 +23,7 @@ CipherBox metadata is encrypted client-side and stored on IPFS. Once written, re
 
 1. **Old records are permanent.** A new client version must be able to read metadata written by any prior version.
 2. **Clients of different versions coexist.** A user may have the desktop app on v1.3 and the web app on v1.4. Both must read and write metadata the other can understand.
-3. **Two implementations must agree.** The TypeScript crypto library (`packages/crypto/`) and the Rust desktop implementation (`apps/desktop/src-tauri/src/crypto/`) must produce byte-identical JSON for the same logical data.
+3. **Two implementations must agree.** The TypeScript crypto library (`packages/crypto/`) and the Rust desktop implementation (`crates/core/src/`) must produce byte-identical JSON for the same logical data.
 
 This protocol establishes formal rules for evolving metadata schemas. It replaces the informal pattern of adding optional fields without documentation that was used through Phase 13.
 
@@ -130,9 +130,9 @@ Complete this checklist for every metadata schema change. This is the most impor
 
 ### 4.2 TypeScript Implementation
 
-- [ ] Update type definition in `packages/crypto/src/{domain}/types.ts`
+- [ ] Update type definition in `packages/core/src/{domain}/types.ts`
 - [ ] If optional: use `field?: Type` syntax
-- [ ] Update validator in `packages/crypto/src/{domain}/metadata.ts` or `schema.ts`
+- [ ] Update validator in `packages/core/src/{domain}/metadata.ts` or `schema.ts`
 - [ ] If optional: validator accepts `undefined`/missing field
 - [ ] If optional: validator applies default value when constructing the return object
 - [ ] If breaking: validator checks `version` field and branches accordingly
@@ -140,7 +140,7 @@ Complete this checklist for every metadata schema change. This is the most impor
 
 ### 4.3 Rust Implementation
 
-- [ ] Update struct in `apps/desktop/src-tauri/src/crypto/folder.rs` (or relevant file)
+- [ ] Update struct in `crates/core/src/folder.rs` (or relevant file)
 - [ ] If optional: use `Option<T>` with `#[serde(default)]` and `#[serde(skip_serializing_if = "Option::is_none")]`
 - [ ] If new enum variant: ensure `#[serde(rename_all = "...")]` handles casing correctly
 - [ ] Verify JSON round-trip: serialize then deserialize produces identical output
@@ -151,7 +151,7 @@ Complete this checklist for every metadata schema change. This is the most impor
 - [ ] Generate test JSON from TypeScript, deserialize in Rust (or vice versa)
 - [ ] Verify old-format JSON (without new field) deserializes correctly in both implementations
 - [ ] Verify new-format JSON (with new field) serializes identically in both implementations
-- [ ] Run: `pnpm test` (TypeScript) and `cargo test --features fuse` (Rust)
+- [ ] Run: `pnpm test` (TypeScript) and `cargo test -p cipherbox-core` (Rust)
 
 ### 4.5 Downstream Updates
 
@@ -266,11 +266,10 @@ The recovery tool (`apps/web/public/recovery.html`) is a standalone HTML file th
 
 - **Metadata Schema Reference:** [docs/METADATA_SCHEMAS.md](METADATA_SCHEMAS.md) -- field tables, encryption, storage, and source file cross-references for all 10 metadata objects
 - **Vault Export Format:** [docs/VAULT_EXPORT_FORMAT.md](VAULT_EXPORT_FORMAT.md) -- recovery procedure and ECIES ciphertext format
-- **Technical Architecture:** `00-Preliminary-R&D/Documentation/TECHNICAL_ARCHITECTURE.md` -- encryption hierarchy and key management design
-- **Data Flows:** `00-Preliminary-R&D/Documentation/DATA_FLOWS.md` -- sequence diagrams and test vectors
+- **Technical Architecture:** [docs/ARCHITECTURE.md](ARCHITECTURE.md) -- encryption hierarchy and key management design
 
 ---
 
 _Protocol version: 1.0_
 _Last updated: 2026-02-21_
-_Applies to: All metadata objects in `packages/crypto/` and `apps/desktop/src-tauri/src/crypto/`_
+_Applies to: All metadata objects in `packages/core/src/` and `crates/core/src/`_

--- a/docs/METADATA_SCHEMAS.md
+++ b/docs/METADATA_SCHEMAS.md
@@ -31,7 +31,7 @@ CipherBox stores all metadata encrypted client-side using AES-256-GCM or ECIES b
 Metadata exists in two implementations that must produce byte-identical JSON (camelCase field names):
 
 - **TypeScript** -- `packages/crypto/src/` (web app, shared crypto library)
-- **Rust** -- `apps/desktop/src-tauri/src/crypto/` (desktop app, uses `serde(rename_all = "camelCase")`)
+- **Rust** -- `crates/core/src/` (desktop app, uses `serde(rename_all = "camelCase")`)
 
 This document defines the canonical schema for every metadata object in the system. For rules governing how these schemas evolve over time, see [METADATA_EVOLUTION_PROTOCOL.md](METADATA_EVOLUTION_PROTOCOL.md).
 
@@ -71,9 +71,9 @@ Folder metadata and file metadata share the same encrypted envelope format for I
 
 **Source files:**
 
-- TS folder: `packages/crypto/src/folder/types.ts:53-58` (`EncryptedFolderMetadata`)
-- TS file: `packages/crypto/src/file/types.ts:75-80` (`EncryptedFileMetadata`)
-- Rust: inline struct in `apps/desktop/src-tauri/src/fuse/operations.rs` (defined locally)
+- TS folder: `packages/core/src/folder/types.ts:53-58` (`EncryptedFolderMetadata`)
+- TS file: `packages/core/src/file/types.ts:79-84` (`EncryptedFileMetadata`)
+- Rust: inline struct in `crates/fuse/src/operations.rs` (defined locally)
 
 **Encoding note:** The `iv` field is hex-encoded. The `data` field uses standard base64 (not base64url, not hex). Mixing up encodings causes decryption failures.
 
@@ -96,9 +96,9 @@ The top-level metadata object for each folder. Contains an array of children (su
 
 **Source files:**
 
-- TS types: `packages/crypto/src/folder/types.ts:15-20`
-- TS validator: `packages/crypto/src/folder/metadata.ts:32-78`
-- Rust: `apps/desktop/src-tauri/src/crypto/folder.rs:78-84`
+- TS types: `packages/core/src/folder/types.ts:15-20`
+- TS validator: `packages/core/src/folder/metadata.ts:38-96`
+- Rust: `crates/core/src/folder.rs:85-91`
 
 **Version history:**
 
@@ -122,8 +122,8 @@ Discriminated union type for children within a folder.
 
 **Source files:**
 
-- TS: `packages/crypto/src/folder/types.ts:25`
-- Rust: `apps/desktop/src-tauri/src/crypto/folder.rs:66-73` (serde internally tagged enum with `#[serde(tag = "type", rename_all = "lowercase")]`)
+- TS: `packages/core/src/folder/types.ts:25`
+- Rust: `crates/core/src/folder.rs:72-80` (serde internally tagged enum with `#[serde(tag = "type", rename_all = "lowercase")]`)
 
 ---
 
@@ -150,8 +150,8 @@ A subfolder child within folder metadata. Contains ECIES-wrapped keys for access
 
 **Source files:**
 
-- TS: `packages/crypto/src/folder/types.ts:31-47`
-- Rust: `apps/desktop/src-tauri/src/crypto/folder.rs:28-45`
+- TS: `packages/core/src/folder/types.ts:31-47`
+- Rust: `crates/core/src/folder.rs:29-46`
 
 **Version history:** Unchanged since initial design.
 
@@ -179,8 +179,8 @@ A slim file reference within v2 folder metadata. Points to a file's own IPNS rec
 
 **Source files:**
 
-- TS: `packages/crypto/src/file/types.ts:57-73`
-- Rust: `apps/desktop/src-tauri/src/crypto/folder.rs:50-70`
+- TS: `packages/core/src/file/types.ts:57-73`
+- Rust: `crates/core/src/folder.rs:50-70`
 
 **Version history:** Added in Phase 12.6 (replaced inline `FileEntry` in v2 folders). `ipnsPrivateKeyEncrypted` added in v0.14.0 (random IPNS key migration).
 
@@ -211,9 +211,9 @@ Per-file metadata stored in a file's own IPNS record. Contains all crypto materi
 
 **Source files:**
 
-- TS types: `packages/crypto/src/file/types.ts:30-51`
-- TS validator: `packages/crypto/src/file/metadata.ts:93-188`
-- Rust: `apps/desktop/src-tauri/src/crypto/folder.rs:166-192`
+- TS types: `packages/core/src/file/types.ts:30-51`
+- TS validator: `packages/core/src/file/metadata.ts:98-193`
+- Rust: `crates/core/src/folder.rs:173-199` (re-exported via `file.rs`)
 
 **Version history:**
 
@@ -262,9 +262,9 @@ A single past version of a file. Embedded in the `versions` array of `FileMetada
 
 **Source files:**
 
-- TS types: `packages/crypto/src/file/types.ts:10-23`
-- TS validator: `packages/crypto/src/file/metadata.ts:32-87`
-- Rust: `apps/desktop/src-tauri/src/crypto/folder.rs:145-160`
+- TS types: `packages/core/src/file/types.ts:10-23`
+- TS validator: `packages/core/src/file/metadata.ts:37-92`
+- Rust: `crates/core/src/folder.rs:152-167` (re-exported via `file.rs`)
 
 **Version history:** Added in Phase 13 (File Versioning).
 
@@ -303,7 +303,7 @@ Key-only binary envelope storing the ECIES-wrapped `rootFolderKey`. Written once
 
 - TS: `packages/core/src/vault/blob.ts` (`serializeVaultBlobV2`, `deserializeVaultBlobV2`, `detectBlobVersion`)
 - Return type: `Uint8Array` (raw ECIES-encrypted `rootFolderKey`)
-- Rust: `apps/desktop/src-tauri/src/crypto/vault_blob.rs`
+- Rust: `crates/core/src/vault_blob.rs`
 
 **Detection:** `detectBlobVersion(blob)` returns `2` if `blob[0] === 0x02`, else `1` (v1 JSON). v1 blobs start with `0x7B` (`{`).
 
@@ -394,7 +394,7 @@ An individual device record within the `DeviceRegistry`. Tracks authentication s
 **Validator constraints:**
 
 - `deviceId`: exactly 64 hex characters (SHA-256 output)
-- `publicKey`: exactly 130 hex characters (uncompressed secp256k1 point: `04` prefix + 64 bytes)
+- `publicKey`: exactly 64 hex characters (32-byte Ed25519 public key)
 - `ipHash`: exactly 64 hex characters (SHA-256 output)
 - `name`: max 200 characters
 - `appVersion`: max 50 characters
@@ -405,8 +405,8 @@ An individual device record within the `DeviceRegistry`. Tracks authentication s
 
 **Source files:**
 
-- TS types: `packages/crypto/src/registry/types.ts:21-46`
-- TS validator: `packages/crypto/src/registry/schema.ts:63-136`
+- TS types: `packages/core/src/registry/types.ts:21-46`
+- TS validator: `packages/core/src/registry/schema.ts:63-136`
 
 **Version history:** Added in Phase 12.2 (Encrypted Device Registry).
 
@@ -416,17 +416,17 @@ An individual device record within the `DeviceRegistry`. Tracks authentication s
 
 TypeScript and Rust implementations must produce identical JSON for the same logical data.
 
-| Schema            | TypeScript          | Rust                                   | Notes                          |
-| ----------------- | ------------------- | -------------------------------------- | ------------------------------ |
-| FolderMetadata    | `folder/types.ts`   | `crypto/folder.rs`                     | Both platforms                 |
-| FolderChild       | `folder/types.ts`   | `crypto/folder.rs` (serde tagged enum) | Both platforms                 |
-| FolderEntry       | `folder/types.ts`   | `crypto/folder.rs`                     | Both platforms                 |
-| FilePointer       | `file/types.ts`     | `crypto/folder.rs`                     | Both platforms                 |
-| FileMetadata      | `file/types.ts`     | `crypto/folder.rs`                     | Both platforms                 |
-| VersionEntry      | `file/types.ts`     | `crypto/folder.rs`                     | Both platforms                 |
-| VaultKeyBlob (v2) | `vault/blob.ts`     | `crypto/vault_blob.rs`                 | Both platforms (binary format) |
-| DeviceRegistry    | `registry/types.ts` | --                                     | TypeScript only                |
-| DeviceEntry       | `registry/types.ts` | --                                     | TypeScript only                |
+| Schema            | TypeScript          | Rust                                            | Notes                          |
+| ----------------- | ------------------- | ----------------------------------------------- | ------------------------------ |
+| FolderMetadata    | `folder/types.ts`   | `crates/core/src/folder.rs`                     | Both platforms                 |
+| FolderChild       | `folder/types.ts`   | `crates/core/src/folder.rs` (serde tagged enum) | Both platforms                 |
+| FolderEntry       | `folder/types.ts`   | `crates/core/src/folder.rs`                     | Both platforms                 |
+| FilePointer       | `file/types.ts`     | `crates/core/src/folder.rs`                     | Both platforms                 |
+| FileMetadata      | `file/types.ts`     | `crates/core/src/folder.rs`                     | Both platforms                 |
+| VersionEntry      | `file/types.ts`     | `crates/core/src/folder.rs`                     | Both platforms                 |
+| VaultKeyBlob (v2) | `vault/blob.ts`     | `crates/core/src/vault_blob.rs`                 | Both platforms (binary format) |
+| DeviceRegistry    | `registry/types.ts` | --                                              | TypeScript only                |
+| DeviceEntry       | `registry/types.ts` | --                                              | TypeScript only                |
 
 **Rust serialization strategy:** All Rust structs use `#[serde(rename_all = "camelCase")]` to produce camelCase JSON field names matching the TypeScript convention. The `FolderChild` enum uses `#[serde(tag = "type", rename_all = "lowercase")]` for internally tagged union serialization.
 
@@ -442,11 +442,11 @@ CipherBox uses two strategies for Ed25519 IPNS keypairs:
 
 Used for the root vault, vault key blob, and device registry where discoverability from the private key alone is required.
 
-| Purpose              | Salt           | HKDF Info                           | Stores                                      | Source File                                   |
-| -------------------- | -------------- | ----------------------------------- | ------------------------------------------- | --------------------------------------------- |
-| Root folder IPNS     | `CipherBox-v1` | `cipherbox-vault-ipns-v1`           | v1 folder metadata `{iv, data}`             | `packages/crypto/src/vault/derive-ipns.ts`    |
-| Vault key blob IPNS  | `CipherBox-v1` | `cipherbox-vault-key-ipns-v1`       | v2 key blob (ECIES-wrapped `rootFolderKey`) | `packages/crypto/src/vault/derive-ipns.ts`    |
-| Device registry IPNS | `CipherBox-v1` | `cipherbox-device-registry-ipns-v1` | ECIES-encrypted registry                    | `packages/crypto/src/registry/derive-ipns.ts` |
+| Purpose              | Salt           | HKDF Info                           | Stores                                      | Source File                                 |
+| -------------------- | -------------- | ----------------------------------- | ------------------------------------------- | ------------------------------------------- |
+| Root folder IPNS     | `CipherBox-v1` | `cipherbox-vault-ipns-v1`           | v1 folder metadata `{iv, data}`             | `packages/crypto/src/vault/derive-ipns.ts`  |
+| Vault key blob IPNS  | `CipherBox-v1` | `cipherbox-vault-key-ipns-v1`       | v2 key blob (ECIES-wrapped `rootFolderKey`) | `packages/crypto/src/vault/derive-ipns.ts`  |
+| Device registry IPNS | `CipherBox-v1` | `cipherbox-device-registry-ipns-v1` | ECIES-encrypted registry                    | `packages/core/src/registry/derive-ipns.ts` |
 
 **Root folder vs vault key blob:** These are two separate IPNS names derived from the same private key with different HKDF info strings. The root folder IPNS stores standard folder metadata (updated on every folder operation). The vault key blob IPNS stores the ECIES-wrapped `rootFolderKey` (written once at vault init, read on every login). This separation prevents folder publishes from overwriting the key blob.
 
@@ -465,10 +465,10 @@ secp256k1 privateKey (32 bytes)
 
 Used for subfolders and new files. The private key is ECIES-wrapped with the vault owner's public key and stored in the parent folder's metadata.
 
-| Purpose       | Storage Location                      | Source File                               |
-| ------------- | ------------------------------------- | ----------------------------------------- |
-| Subfolder     | `FolderEntry.ipnsPrivateKeyEncrypted` | `packages/crypto/src/ed25519/keygen.ts`   |
-| Per-file IPNS | `FilePointer.ipnsPrivateKeyEncrypted` | `packages/crypto/src/file/derive-ipns.ts` |
+| Purpose       | Storage Location                      | Source File                             |
+| ------------- | ------------------------------------- | --------------------------------------- |
+| Subfolder     | `FolderEntry.ipnsPrivateKeyEncrypted` | `packages/crypto/src/ed25519/keygen.ts` |
+| Per-file IPNS | `FilePointer.ipnsPrivateKeyEncrypted` | `packages/core/src/file/derive-ipns.ts` |
 
 **Migration:** Legacy files without `ipnsPrivateKeyEncrypted` fall back to HKDF derivation. Lazy migration writes the encrypted key when folder metadata is next published. Recovery traverses the folder tree via `fileMetaIpnsName` and never derives IPNS names independently, so the random-key approach is safe.
 

--- a/docs/SHARING.md
+++ b/docs/SHARING.md
@@ -1,0 +1,332 @@
+<!-- generated-by: gsd-doc-writer -->
+
+# CipherBox Sharing Specification
+
+This document specifies the implemented file and folder sharing feature in CipherBox: user-to-user direct sharing and link-based sharing (invite links). Both flows are zero-knowledge — the server stores only ECIES-wrapped ciphertext and never sees a plaintext key.
+
+Sharing is a v1.0 feature (read and write permission levels are both supported).
+
+## Related documentation
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — system overview and encryption primitives
+- [AUTHENTICATION_ARCHITECTURE.md](AUTHENTICATION_ARCHITECTURE.md) — vault keypair derivation (secp256k1)
+- [FILESYSTEM_SPECIFICATION.md](FILESYSTEM_SPECIFICATION.md) — folder/file metadata schema
+- [DATABASE_EVOLUTION_PROTOCOL.md](DATABASE_EVOLUTION_PROTOCOL.md) — migration discipline
+
+---
+
+## Design principles
+
+1. **Zero-knowledge server.** The CipherBox API stores only ECIES ciphertext. It has no ability to decrypt a shared key, read a shared file, or observe the plaintext name of a shared item beyond the `itemName` stored for UX display.
+2. **Client-side re-wrapping.** All sharing operations begin with the sharer decrypting a key on their device and re-encrypting it for the recipient's public key. The server receives only the output ciphertext.
+3. **IPNS as share boundary.** A share record is anchored to a single `ipnsName`. Sharing a folder shares the folder's IPNS root; subfolders and files within it have their own keys propagated as child keys.
+4. **Lazy key rotation on revocation.** Revoking a share is a soft-delete. The sharer's key is not rotated immediately; rotation happens the next time the sharer modifies the shared folder (`executeLazyRotation` in `apps/web/src/services/share.service.ts`).
+
+---
+
+## Cryptographic primitives
+
+All key wrapping uses ECIES over secp256k1 (package `@cipherbox/crypto`, source at `packages/crypto/src/ecies/`).
+
+| Operation                       | Function                                               | File                                   |
+| ------------------------------- | ------------------------------------------------------ | -------------------------------------- |
+| Wrap a key for a public key     | `wrapKey(plainKey, publicKey)`                         | `packages/crypto/src/ecies/encrypt.ts` |
+| Unwrap a key with a private key | `unwrapKey(ciphertext, privateKey)`                    | `packages/crypto/src/ecies/decrypt.ts` |
+| Unwrap then re-wrap in one call | `reWrapKey(ciphertext, ownerPrivKey, recipientPubKey)` | `packages/crypto/src/ecies/rewrap.ts`  |
+
+`reWrapKey` zeros the intermediate plaintext key via `fill(0)` before returning or on any error path, preventing key material from lingering in memory.
+
+---
+
+## Share key types
+
+Defined in `apps/api/src/shares/types.ts`:
+
+| Type           | Value           | Meaning                                                        |
+| -------------- | --------------- | -------------------------------------------------------------- |
+| `ChildKeyType` | `'file'`        | `fileKey` for a specific file                                  |
+| `ChildKeyType` | `'folder'`      | `folderKey` for a subfolder                                    |
+| `ChildKeyType` | `'file-ipns'`   | IPNS private key for a file's metadata IPNS name               |
+| `ShareKeyType` | `'folder-ipns'` | IPNS private key for a subfolder IPNS name (write shares only) |
+
+`ShareKeyType` is the superset: `['file', 'folder', 'file-ipns', 'folder-ipns']`. `ChildKeyType` excludes `'folder-ipns'` because that key type is only stored after a share is created (it is added when a subfolder's write access is granted, not during initial share creation).
+
+---
+
+## Data model
+
+Three database tables back the sharing feature.
+
+### `shares`
+
+Source: `apps/api/src/shares/entities/share.entity.ts`
+
+Primary sharing record. A unique partial index (`WHERE revoked_at IS NULL`) on `(sharer_id, recipient_id, ipns_name)` prevents duplicate active shares for the same triple while allowing revoked historical records to coexist (`apps/api/src/migrations/1740300000000-SharesPartialUniqueIndex.ts`).
+
+| Column                | Type           | Description                                                                                             |
+| --------------------- | -------------- | ------------------------------------------------------------------------------------------------------- |
+| `id`                  | `uuid`         | Primary key                                                                                             |
+| `sharer_id`           | `uuid`         | FK to `users.id` (CASCADE delete)                                                                       |
+| `recipient_id`        | `uuid`         | FK to `users.id` (CASCADE delete)                                                                       |
+| `item_type`           | `varchar(10)`  | `'folder'` or `'file'`                                                                                  |
+| `ipns_name`           | `varchar(255)` | IPNS name of the shared item (e.g., `k51...`)                                                           |
+| `item_name`           | `varchar(255)` | Plaintext display name (minimal privacy impact — server already knows involved user IDs)                |
+| `encrypted_key`       | `bytea`        | `folderKey` (for folder shares) or parent `folderKey` (for file shares) wrapped via ECIES for recipient |
+| `permission`          | `varchar(10)`  | `'read'` (default) or `'write'`                                                                         |
+| `encrypted_ipns_key`  | `bytea`        | IPNS private key wrapped via ECIES for recipient; `NULL` for read-only shares                           |
+| `hidden_by_recipient` | `boolean`      | Recipient has dismissed this share from their view                                                      |
+| `revoked_at`          | `timestamp`    | `NULL` = active; set = soft-deleted pending key rotation                                                |
+| `created_at`          | `timestamp`    | —                                                                                                       |
+| `updated_at`          | `timestamp`    | —                                                                                                       |
+
+### `share_keys`
+
+Source: `apps/api/src/shares/entities/share-key.entity.ts`
+
+Stores individual child keys (file keys, subfolder keys, IPNS keys) for a share. A unique constraint on `(share_id, key_type, item_id)` prevents duplicate entries.
+
+| Column          | Type           | Description                                           |
+| --------------- | -------------- | ----------------------------------------------------- |
+| `id`            | `uuid`         | Primary key                                           |
+| `share_id`      | `uuid`         | FK to `shares.id` (CASCADE delete)                    |
+| `key_type`      | `varchar(12)`  | One of the four `ShareKeyType` values                 |
+| `item_id`       | `varchar(255)` | UUID of the file or subfolder this key belongs to     |
+| `encrypted_key` | `bytea`        | ECIES ciphertext of the key wrapped for the recipient |
+| `created_at`    | `timestamp`    | —                                                     |
+
+The `key_type` column was widened from `varchar(10)` to `varchar(12)` in migration `1743100000000-WidenShareKeyType.ts` to accommodate `'folder-ipns'` (11 characters).
+
+### `share_invites`
+
+Source: `apps/api/src/shares/entities/share-invite.entity.ts`
+
+Short-lived records backing link-based sharing. The token is a 22-character URL-safe base64 string (`randomBytes(16).toString('base64url')`). The default TTL is 7 days. Expired invites are hard-deleted on access.
+
+| Column                 | Type           | Description                                                                                                                   |
+| ---------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | `uuid`         | Primary key                                                                                                                   |
+| `token`                | `varchar(44)`  | Unique URL-safe base64 token                                                                                                  |
+| `sharer_id`            | `uuid`         | FK to `users.id` (CASCADE delete)                                                                                             |
+| `item_type`            | `varchar(10)`  | `'folder'` or `'file'`                                                                                                        |
+| `ipns_name`            | `varchar(255)` | IPNS name of the shared item                                                                                                  |
+| `item_name`            | `varchar(255)` | Plaintext display name                                                                                                        |
+| `encrypted_key`        | `bytea`        | Item key wrapped with the ephemeral public key                                                                                |
+| `encrypted_child_keys` | `jsonb`        | Array of `{keyType, itemId, encryptedKey}` wrapped with ephemeral public key; `NULL` for single-file invites with no children |
+| `status`               | `varchar(20)`  | `'active'`, `'claimed'`, or `'revoked'`                                                                                       |
+| `max_claims`           | `integer`      | Maximum number of times this invite can be claimed (default `1`)                                                              |
+| `claim_count`          | `integer`      | Number of times the invite has been claimed                                                                                   |
+| `claimed_by`           | `uuid`         | User ID of the claimer (set on claim)                                                                                         |
+| `expires_at`           | `timestamp`    | Expiry timestamp                                                                                                              |
+| `created_at`           | `timestamp`    | —                                                                                                                             |
+
+---
+
+## User-to-user sharing flow
+
+### Overview
+
+The sharer looks up the recipient's `publicKey` via the API, re-wraps keys on their device, and POSTs the ciphertext to the server. The recipient retrieves the wrapped keys at login and decrypts them locally.
+
+### Step-by-step
+
+1. **Recipient lookup.** The sharer calls `GET /shares/lookup?publicKey=0x04...` to verify the recipient is a registered CipherBox user. The endpoint validates the uncompressed secp256k1 format (`0x04` + 128 hex characters). Source: `apps/api/src/shares/shares.controller.ts` → `lookupUser`.
+
+2. **Key collection.** The sharer's client traverses the item's metadata tree and re-wraps every key for the recipient's `publicKey`:
+   - For a folder: unwrap `folderKeyEncrypted` → `reWrapKey(ciphertext, ownerPrivKey, recipientPubKey)` for the root folder, plus all descendant subfolder keys and file keys via `collectChildKeys` (`apps/web/src/lib/crypto/key-wrapping.ts`).
+   - For a file: re-wrap the parent `folderKey` (recipient needs it to decrypt file metadata) and the `fileKey` as a `'file'` child key.
+   - For write permission: additionally re-wrap the IPNS private key of the shared item so the recipient can publish to that IPNS name.
+
+3. **Create share.** The sharer POSTs to `POST /shares` with `CreateShareDto`:
+
+   ```json
+   {
+     "recipientPublicKey": "04abc...",
+     "itemType": "folder",
+     "ipnsName": "k51...",
+     "itemName": "Project Files",
+     "encryptedKey": "<hex ECIES ciphertext>",
+     "permission": "read",
+     "childKeys": [
+       { "keyType": "folder", "itemId": "<uuid>", "encryptedKey": "<hex>" },
+       { "keyType": "file", "itemId": "<uuid>", "encryptedKey": "<hex>" },
+       { "keyType": "file-ipns", "itemId": "<uuid>", "encryptedKey": "<hex>" }
+     ]
+   }
+   ```
+
+   Source: `apps/api/src/shares/dto/create-share.dto.ts`. For write permission, include `"permission": "write"` and the `"encryptedIpnsKey"` field. Omitting `encryptedIpnsKey` with `"permission": "write"` returns HTTP 400; including it with `"permission": "read"` also returns HTTP 400.
+
+4. **Server stores share and child keys.** `SharesService.createShare` (`apps/api/src/shares/shares.service.ts`) validates the recipient exists, checks for duplicate active shares, creates the `shares` row, and bulk-inserts `share_keys` rows for the provided `childKeys`.
+
+5. **Recipient access.** On the recipient's device, `GET /shares/received` returns active non-hidden shares with `sharerPublicKey`, `encryptedKey`, `permission`, and `encryptedIpnsKey`. The recipient decrypts `encryptedKey` with their own `privateKey` to obtain the `folderKey` for the shared item, then fetches child keys via `GET /shares/:shareId/keys`.
+
+### Post-upload key propagation
+
+When a sharer adds files or subfolders inside an already-shared folder, the new keys must be distributed to existing recipients. The function `reWrapForRecipients` in `apps/web/src/services/share.service.ts` handles this as a fire-and-forget operation after each upload or subfolder creation:
+
+1. `findCoveringShares` walks the folder ancestor chain to find shares that cover the modified folder (the share may be on a parent folder, not the immediate folder).
+2. For each covering share recipient, `wrapKey(plaintextKey, recipientPubKey)` produces the wrapped key.
+3. `POST /shares/:shareId/keys` adds the new `ShareKey` rows.
+
+---
+
+## Link sharing flow (invite links)
+
+Link sharing does not require the sharer to know the recipient's `publicKey` upfront. Instead, an ephemeral secp256k1 keypair acts as a cryptographic bridge.
+
+### Security model
+
+The ephemeral private key is placed in the URL hash fragment (`#/invite/:token?key=<hex>`). Hash fragments are never sent to the server by browsers, ensuring the server has no ability to decrypt the ciphertext stored in `share_invites.encrypted_key`. Source: `apps/web/src/services/invite.service.ts` → `buildInviteUrl`.
+
+### Invite creation
+
+Source: `apps/web/src/services/invite.service.ts` → `createInviteLink`
+
+1. Generate ephemeral secp256k1 keypair via `secp256k1.keygen()`.
+2. Unwrap the item's key using the sharer's `privateKey`.
+3. Wrap the plaintext key with the ephemeral `publicKey` via `wrapKey`.
+4. For folders: traverse children with `collectChildKeys`, wrapping each descendant key with the ephemeral `publicKey`.
+5. For files: wrap the parent `folderKey` as the root `encryptedKey` and the `fileKey` as a `'file'` child key.
+6. POST to `POST /shares/invites` (`CreateInviteDto`): server stores the invite with a 7-day expiry.
+7. Build URL: `${origin}${pathname}#/invite/${token}?key=${ephemeralPrivKeyHex}`.
+8. Zero the ephemeral private key from memory (`fill(0)`) in a `finally` block.
+
+### Recipient claim flow
+
+Source: `apps/web/src/routes/InvitePage.tsx` and `apps/web/src/services/invite.service.ts` → `claimInvite`
+
+1. The recipient opens the URL; `InvitePage` reads the ephemeral private key from the hash fragment into a `ref` and immediately replaces the URL to remove the key from the address bar.
+2. `GET /invites/:token` (unauthenticated) checks whether the invite is active. The server returns only `{ status: 'active' }` or HTTP 404 — no file name or sharer identity is revealed before authentication (prevents token-existence oracle attacks).
+3. If valid, the page presents a login CTA. After the recipient authenticates, auto-claim begins.
+4. `GET /invites/:token/data` (authenticated) returns `encryptedKey`, `encryptedChildKeys`, `itemType`, `ipnsName`, `itemName`.
+5. Client unwraps `encryptedKey` with the ephemeral private key, then re-wraps with the recipient's own `publicKey`.
+6. All `encryptedChildKeys` are unwrapped and re-wrapped in the same pass.
+7. `POST /invites/:token/claim` sends the re-wrapped keys. The server atomically increments `claim_count` (`UPDATE ... WHERE status = 'active' AND claim_count < max_claims`) to enforce single-claim. A `Share` record and `ShareKey` rows are created inside a database transaction.
+8. On success, the recipient is redirected to `/shared`.
+
+The ephemeral private key is zeroed in a `finally` block after the claim call (`ephemeralPrivKey.fill(0)`).
+
+### Public endpoint design
+
+`GET /invites/:token` intentionally leaks no information beyond whether the token is active. Expired, claimed, and revoked states all produce HTTP 404 from the server. Error reason discrimination (`'expired'` vs `'claimed'`) comes only from the HTTP 409 response of the claim endpoint, not the status check.
+
+---
+
+## Permission levels
+
+| Permission | folderKey | encryptedIpnsKey | Can read files | Can write (add/modify) files |
+| ---------- | --------- | ---------------- | -------------- | ---------------------------- |
+| `'read'`   | Provided  | `NULL`           | Yes            | No                           |
+| `'write'`  | Provided  | Provided         | Yes            | Yes                          |
+
+For write permission, the `encryptedIpnsKey` column stores the IPNS private key for the shared item's IPNS name, wrapped with the recipient's `publicKey`. This allows the recipient to publish updated metadata to the IPNS name.
+
+The permission level can be changed by the sharer after the share is created via `PATCH /shares/:shareId/permission` (`UpdatePermissionDto`). Upgrading to write requires supplying `encryptedIpnsKey`; the API returns HTTP 400 if it is absent. Downgrading to read clears `encryptedIpnsKey` on the server.
+
+---
+
+## Revocation and lazy key rotation
+
+### Revocation (soft-delete)
+
+`DELETE /shares/:shareId` sets `revoked_at` to the current timestamp. The share record remains in the database. The recipient continues to see their cached copy of the data until the sharer performs a key rotation.
+
+### Lazy rotation protocol
+
+Key rotation is deferred to the sharer's next folder modification. Before any write to a shared folder, the client checks `GET /shares/pending-rotations`. If any revoked shares exist for that folder, `executeLazyRotation` (`apps/web/src/services/share.service.ts`) runs:
+
+1. Generate a new random 32-byte `folderKey`.
+2. Fetch the revoked share IDs for the folder and the currently active shares.
+3. For each **remaining** (non-revoked) share recipient, re-wrap the new `folderKey` with their `publicKey` via `wrapKey` and call `PATCH /shares/:shareId/encrypted-key`.
+4. If any re-wrap fails, abort the rotation (throw) to prevent inconsistent state — the new `folderKey` is zeroed.
+5. Hard-delete revoked share records via `DELETE /shares/:shareId/complete-rotation`.
+6. Invalidate the sent shares cache so the next check fetches fresh state.
+
+The actual folder metadata re-encryption (decrypt with old key, re-encrypt with new key, publish IPNS) is performed by the caller (`folder.service.ts`) which holds the IPNS private key.
+
+### Complete rotation API
+
+`DELETE /shares/:shareId/complete-rotation` hard-deletes a revoked share row. It requires `revokedAt` to be non-null (HTTP 409 if the share has not been revoked first). Only the sharer can call this endpoint.
+
+---
+
+## Recipient-side actions
+
+### Hide a share
+
+Recipients can dismiss a share from their view without revoking it: `PATCH /shares/:shareId/hide` sets `hidden_by_recipient = true`. Hidden shares are excluded from `GET /shares/received`. Only the recipient can hide a share (HTTP 403 if the caller is the sharer). There is no unhide endpoint — the share remains accessible via direct API call with the `shareId`.
+
+---
+
+## API surface
+
+All sharing endpoints require JWT authentication unless noted.
+
+### `SharesController` — `/shares`
+
+Source: `apps/api/src/shares/shares.controller.ts`
+
+| Method   | Path                                 | Description                                          |
+| -------- | ------------------------------------ | ---------------------------------------------------- |
+| `POST`   | `/shares`                            | Create a user-to-user share                          |
+| `GET`    | `/shares/received`                   | Paginated list of active, non-hidden received shares |
+| `GET`    | `/shares/sent`                       | Paginated list of active sent shares                 |
+| `GET`    | `/shares/lookup?publicKey=`          | Verify a user exists by their `publicKey`            |
+| `GET`    | `/shares/pending-rotations`          | Revoked shares awaiting key rotation (sharer only)   |
+| `GET`    | `/shares/:shareId/keys`              | Child key list (accessible by sharer or recipient)   |
+| `POST`   | `/shares/:shareId/keys`              | Add child keys to an existing share                  |
+| `PATCH`  | `/shares/:shareId/permission`        | Change permission level (sharer only)                |
+| `DELETE` | `/shares/:shareId`                   | Soft-delete (revoke) a share (sharer only)           |
+| `PATCH`  | `/shares/:shareId/hide`              | Hide a share from recipient's view (recipient only)  |
+| `PATCH`  | `/shares/:shareId/encrypted-key`     | Update wrapped key after lazy rotation (sharer only) |
+| `DELETE` | `/shares/:shareId/complete-rotation` | Hard-delete after key rotation (sharer only)         |
+
+Pagination query parameters: `limit` (max 100) and `offset`.
+
+### `ShareInvitesController` — `/shares/invites`
+
+Source: `apps/api/src/shares/share-invites.controller.ts`
+
+Authenticated management of invite links owned by the current user.
+
+| Method   | Path                        | Description                     |
+| -------- | --------------------------- | ------------------------------- |
+| `POST`   | `/shares/invites`           | Create an invite link           |
+| `GET`    | `/shares/invites?ipnsName=` | List active invites for an item |
+| `DELETE` | `/shares/invites/:inviteId` | Revoke an active invite link    |
+
+### `InvitesController` — `/invites`
+
+Source: `apps/api/src/shares/invites.controller.ts`
+
+Public-facing endpoints for the invite claim flow. Individual endpoints opt in to authentication.
+
+| Method | Path                    | Auth | Description                                               |
+| ------ | ----------------------- | ---- | --------------------------------------------------------- |
+| `GET`  | `/invites/:token`       | None | Status check — returns `{ status: 'active' }` or HTTP 404 |
+| `GET`  | `/invites/:token/data`  | JWT  | Full invite data for the claim flow                       |
+| `POST` | `/invites/:token/claim` | JWT  | Claim the invite with re-wrapped keys                     |
+
+---
+
+## Web UI entry points
+
+| Component           | Path                                                         | Purpose                                                     |
+| ------------------- | ------------------------------------------------------------ | ----------------------------------------------------------- |
+| `ShareDialog`       | `apps/web/src/components/file-browser/ShareDialog.tsx`       | Direct share creation UI (user lookup + key wrapping)       |
+| `InviteLinkTab`     | `apps/web/src/components/file-browser/InviteLinkTab.tsx`     | Invite link creation and management within the share dialog |
+| `SharedFileBrowser` | `apps/web/src/components/file-browser/SharedFileBrowser.tsx` | "Shared with me" view at `/shared` route                    |
+| `InvitePage`        | `apps/web/src/routes/InvitePage.tsx`                         | Invite landing page at `#/invite/:token`                    |
+| `SharedPage`        | `apps/web/src/routes/SharedPage.tsx`                         | Route wrapper for `SharedFileBrowser`                       |
+
+---
+
+## Database migrations
+
+| Migration                  | Timestamp       | Description                                                                         |
+| -------------------------- | --------------- | ----------------------------------------------------------------------------------- |
+| `AddSharesTables`          | `1740250000000` | Create `shares` and `share_keys` tables                                             |
+| `SharesPartialUniqueIndex` | `1740300000000` | Replace absolute unique index with partial index `WHERE revoked_at IS NULL`         |
+| `AddShareInvites`          | `1740400000000` | Create `share_invites` table                                                        |
+| `AddWritableShares`        | `1743000000000` | Add `permission` and `encrypted_ipns_key` columns to `shares`                       |
+| `WidenShareKeyType`        | `1743100000000` | Widen `share_keys.key_type` from `varchar(10)` to `varchar(12)` for `'folder-ipns'` |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,244 @@
+<!-- generated-by: gsd-doc-writer -->
+
+# Testing
+
+CipherBox uses a multi-layer testing strategy documented in full in
+[tests/TESTING_STRATEGY.md](../tests/TESTING_STRATEGY.md). This page summarises
+the test landscape, shows how to run each suite, and maps tests to CI gates.
+
+## Test Landscape
+
+| Suite                        | Location               | Framework        | Trigger         |
+| ---------------------------- | ---------------------- | ---------------- | --------------- |
+| API unit tests               | `apps/api/`            | Jest             | PR to `main`    |
+| `@cipherbox/crypto` unit     | `packages/crypto/`     | Vitest           | PR to `main`    |
+| `@cipherbox/core` unit       | `packages/core/`       | Vitest           | PR to `main`    |
+| `@cipherbox/sdk-core` unit   | `packages/sdk-core/`   | Vitest           | PR to `main`    |
+| `@cipherbox/sdk` unit        | `packages/sdk/`        | Vitest           | PR to `main`    |
+| `@cipherbox/api-client` unit | `packages/api-client/` | Vitest           | PR to `main`    |
+| SDK E2E                      | `tests/sdk-e2e/`       | Vitest           | PR to `main`    |
+| Web E2E                      | `tests/web-e2e/`       | Playwright       | Push to `main`  |
+| Desktop E2E                  | `tests/desktop-e2e/`   | Bash scripts     | Push to `main`  |
+| Load tests                   | `tests/load/`          | Vitest (Node.js) | Manual dispatch |
+| Cross-language vectors       | `tests/vectors/`       | JSON fixtures    | PR to `main`    |
+| Rust crate tests             | `crates/`              | `cargo test`     | PR to `main`    |
+
+## Running Unit Tests
+
+### All workspace unit tests
+
+```bash
+pnpm test
+```
+
+This runs `test` in every workspace in parallel. It does not run E2E, load, or
+desktop tests.
+
+### Per-package unit tests
+
+```bash
+# API (Jest)
+pnpm --filter @cipherbox/api test
+pnpm --filter @cipherbox/api test:cov     # with coverage
+
+# TypeScript packages (Vitest)
+pnpm --filter @cipherbox/crypto test
+pnpm --filter @cipherbox/crypto test:coverage
+
+pnpm --filter @cipherbox/core test
+pnpm --filter @cipherbox/core test:coverage
+
+pnpm --filter @cipherbox/sdk-core test
+pnpm --filter @cipherbox/sdk-core test:coverage
+
+pnpm --filter @cipherbox/sdk test
+pnpm --filter @cipherbox/sdk test:coverage
+
+pnpm --filter @cipherbox/api-client test
+pnpm --filter @cipherbox/api-client test:coverage
+```
+
+Watch mode is available on all Vitest packages:
+
+```bash
+pnpm --filter @cipherbox/crypto test:watch
+```
+
+### Rust crate tests
+
+```bash
+# macOS / Linux (FUSE)
+cargo test --workspace --no-default-features --features fuse
+
+# Windows (WinFsp)
+cargo test --workspace --no-default-features --features winfsp
+```
+
+## Running SDK E2E Tests
+
+SDK E2E tests (`@cipherbox/sdk-e2e`) drive `CipherBoxClient` directly against a
+real API instance — no browser, no Playwright. See
+[tests/TESTING_STRATEGY.md](../tests/TESTING_STRATEGY.md) for the full suite list
+and rate-limit strategy.
+
+### Prerequisites
+
+- PostgreSQL, IPFS (Kubo), and Redis running locally
+- `apps/api/.env` configured with `NODE_ENV=test` and the required database/IPFS
+  variables (see `docs/CONFIGURATION.md`)
+- `tools/mock-ipns-routing` built and running
+
+```bash
+# Build and start mock IPNS routing
+cd tools/mock-ipns-routing && npm install && npm run build
+node dist/index.js &
+
+# Start the API in dev mode
+pnpm --filter @cipherbox/api dev &
+
+# Run the full SDK E2E suite
+pnpm --filter @cipherbox/sdk-e2e test
+```
+
+Run a single suite by test-path pattern:
+
+```bash
+pnpm --filter @cipherbox/sdk-e2e test:single -- --testPathPattern=file-operations
+```
+
+## Running Web E2E Tests
+
+Web E2E tests (`@cipherbox/web-e2e`) use Playwright against the full web app stack.
+See [tests/web-e2e/README.md](../tests/web-e2e/README.md) for setup details.
+
+```bash
+# Full suite (headless Chromium)
+pnpm test:web-e2e
+
+# Headed mode
+pnpm test:web-e2e:headed
+
+# Inside the package directly
+pnpm --filter @cipherbox/web-e2e test
+pnpm --filter @cipherbox/web-e2e test:headed
+pnpm --filter @cipherbox/web-e2e test:debug
+```
+
+The web-e2e suite requires all services running (PostgreSQL, IPFS, Redis, API,
+mock-ipns-routing) and the web app built. The `CI=true` flag switches the reporter
+to HTML, disallows `.only`, and always starts a fresh dev server.
+
+## Running Desktop E2E Tests
+
+Desktop E2E tests exercise the Tauri binary through the FUSE/WinFsp virtual
+filesystem. They are shell-script based and run via `tests/desktop-e2e/scripts/`.
+
+```bash
+# After building the debug binary and starting all backend services:
+bash tests/desktop-e2e/scripts/run-all.sh
+```
+
+Individual scripts: `test-fuse-operations.sh`, `test-round-trip.sh`,
+`test-recycle-bin.sh`, `test-cross-client-sync.sh`, `test-conflict-detection.sh`.
+Windows equivalents use `.ps1` extensions. The binary must be started with
+`--dev-key <hex>` before invoking the test scripts.
+
+## Running Load Tests
+
+Load tests are managed by the `load-test.yml` workflow and are not meant to run
+against production. See [tests/TESTING_STRATEGY.md](../tests/TESTING_STRATEGY.md)
+for scenario descriptions and the rate-limit bypass design.
+
+```bash
+# Run a specific scenario locally (same prerequisites as SDK E2E)
+LOAD_TEST_CLIENTS=5 pnpm --filter @cipherbox/load-tests test -- --testPathPattern=mixed-workload
+```
+
+Against staging, trigger via GitHub Actions → **Load Tests** workflow dispatch,
+selecting the environment, client count, and scenario.
+
+## Cross-Language Vector Parity
+
+The `tests/vectors/` directory contains JSON test fixtures shared between the
+TypeScript and Rust crypto implementations. The `vector-parity` CI job verifies
+that both sides agree on the same inputs and outputs.
+
+```bash
+# Rust side
+cargo test -p cipherbox-crypto --test cross_language --no-default-features
+
+# TypeScript side
+pnpm --filter @cipherbox/crypto test -- --reporter=verbose
+
+# Meta-check (vector files exist, are valid JSON, and are referenced by both sides)
+bash scripts/check-vector-parity.sh
+```
+
+Vector files: `crypto/aes-gcm.json`, `crypto/ecies.json`, `crypto/ed25519.json`,
+`crypto/hkdf.json`, `crypto/ipns-name.json`, `core/vault-blob.json`,
+`core/folder-metadata.json`, `core/ipns-record.json`, `core/bin-metadata.json`.
+
+## Coverage
+
+Coverage is collected on every CI run and uploaded to Codecov. The lcov files from
+all covered packages are combined under separate flags (`api`, `crypto`, `core`,
+`sdk-core`, `sdk`, `api-client`, `desktop`).
+
+### Thresholds
+
+| Package               | Lines | Branches | Functions | Statements          |
+| --------------------- | ----- | -------- | --------- | ------------------- |
+| `apps/api`            | 85%   | 78%      | 85%       | 85%                 |
+| `packages/crypto`     | 80%   | 80%      | 80%       | 80%                 |
+| `packages/core`       | 75%   | 75%      | 80%       | 75%                 |
+| `packages/sdk-core`   | 80%   | 80%      | 80%       | 80%                 |
+| `packages/sdk`        | 65%   | 80%      | 60%       | 65%                 |
+| `packages/api-client` | 0%    | 0%       | 0%        | 0% (generated code) |
+
+Rust coverage uses `cargo-llvm-cov` on the Linux CI runner and is uploaded under
+the `desktop` flag. No numeric threshold is enforced for Rust.
+
+## CI Gates
+
+### `ci.yml` (pull requests to `main`)
+
+Runs on every PR when `apps/`, `packages/`, `tests/`, or workflow files change.
+
+- **lint** — ESLint across all TypeScript
+- **typecheck** — full TypeScript build check
+- **api-spec** — verifies the committed OpenAPI spec and generated client are current
+- **migration-check** — detects entity/migration drift using TypeORM
+- **test** — unit tests with coverage for all packages; uploads lcov to Codecov
+- **sdk-e2e** — full SDK E2E suite against a live API instance
+- **build** — production build of all packages and the web app
+- **cargo-linux / cargo-macos / cargo-windows** — Rust check + test on all platforms
+  (triggered only when Rust sources or `tests/vectors/` change)
+- **vector-parity** — cross-language vector parity check (depends on `cargo-linux`
+  and `test`)
+
+### `ci-e2e.yml` (push to `main`)
+
+Runs after merge to `main`. Detects which surface areas changed and invokes:
+
+- `web-e2e.yml` — if `apps/web/`, `apps/api/`, `packages/`, or `tests/web-e2e/`
+  changed
+- `desktop-e2e.yml` — if `apps/desktop/src-tauri/` or `crates/` changed
+
+### `web-e2e.yml`
+
+Can also be triggered via `workflow_dispatch` or called from the staging release
+pipeline. Runs the Playwright suite against a full stack on Ubuntu (headless
+Chromium, 20-minute timeout). Uploads the Playwright report as an artifact on
+failure.
+
+### `desktop-e2e.yml`
+
+Matrix build across macOS, Linux, and Windows (45-minute timeout per platform).
+Builds the debug Tauri binary, starts all backend services, mounts the virtual
+filesystem, and runs the shell-script test suite.
+
+### `load-test.yml`
+
+Manual dispatch only. Select target environment (`local` or `staging`), client
+count, and scenario. Runs against the `staging` GitHub environment when staging is
+selected; no numeric pass/fail threshold — results are interpreted manually.

--- a/docs/VAULT_EXPORT_FORMAT.md
+++ b/docs/VAULT_EXPORT_FORMAT.md
@@ -265,10 +265,10 @@ After decrypting the `data` field with the folder's AES-256 key and the `iv`, th
 }
 ```
 
-| Field      | Type   | Description                                                                  |
-| ---------- | ------ | ---------------------------------------------------------------------------- |
-| `version`  | string | Schema version: `"v1"` (inline file data) or `"v2"` (per-file IPNS pointers) |
-| `children` | array  | Array of folder and file child entries                                       |
+| Field      | Type   | Description                                                                                                                                |
+| ---------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `version`  | string | Schema version: `"v2"` (per-file IPNS pointers). `"v1"` (inline file data) is a historical format rejected by the reference recovery tool. |
+| `children` | array  | Array of folder and file child entries                                                                                                     |
 
 ### Folder Child Entry
 
@@ -457,10 +457,11 @@ assert export.encryptedRootIpnsPrivateKey is not empty
 
 ### Step 2: Accept Private Key
 
-The user's secp256k1 private key is 32 bytes. It may be provided as:
+The user's secp256k1 private key is 32 bytes. It must be provided as:
 
 - 64-character hex string (with or without `0x` prefix)
-- Base64-encoded string (~44 characters)
+
+> **Note:** Base64 input is not supported by the reference recovery tool (`recovery.html`), which accepts hex only.
 
 ```text
 private_key = parse_key_input(user_input)   // 32 bytes
@@ -546,23 +547,14 @@ subfolder_cid = resolve_ipns(child.ipnsName)
 // 5. Recursively process subfolder's children (this step)
 ```
 
-**If child is a file (v1 -- inline file data):**
+**If child is a file without `fileMetaIpnsName` (v1 -- historical, not supported):**
 
 ```text
-// v1 folder metadata: file data embedded directly in the child entry
-// 1. ECIES-decrypt the file key
-file_key = ecies_decrypt(private_key, hex_to_bytes(child.fileKeyEncrypted))
-// file_key is 32 bytes
-
-// 2. Fetch encrypted file from IPFS
-encrypted_file = http_get("https://ipfs.io/ipfs/{child.cid}")
-
-// 3. Decrypt file content
-iv = hex_to_bytes(child.fileIv)    // 12 bytes
-decrypted_file = aes_256_gcm_decrypt(file_key, iv, encrypted_file)
-
-// 4. Save decrypted_file with name child.name
-//    Preserve folder path from recursive traversal
+// v1 folder metadata: file data embedded directly in the child entry.
+// The reference recovery tool (recovery.html) logs an error and skips
+// these children — v1 inline file recovery is not implemented.
+log_error("Invalid file child '" + child.name + "': missing fileMetaIpnsName (v1 format not supported)")
+continue  // skip; do not attempt recovery
 ```
 
 **If child is a file (v2 -- FilePointer with per-file IPNS):**

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -1,12 +1,10 @@
+<!-- generated-by: gsd-doc-writer -->
+
 # @cipherbox/api-client
 
 Typed HTTP client for the CipherBox API, generated from OpenAPI spec via orval.
 
-## Install
-
-```bash
-pnpm add @cipherbox/api-client
-```
+This is a private internal package consumed by other packages in the monorepo. It is not published to npm.
 
 ## Usage
 
@@ -19,6 +17,20 @@ setApiClientConfig({ baseUrl: 'https://api.cipherbox.cc', getAccessToken: async 
 // Then call generated functions directly
 const result = await ipnsControllerResolveRecord({ ipnsName: 'k51...' });
 ```
+
+`setApiClientConfig` accepts an optional second argument — a pre-built `AxiosInstance` — for consumers that need to share one instance between the singleton path and instance-scoped callers.
+
+You can also use `createAxiosInstance(config)` to create an isolated axios instance (with its own interceptors) without touching the module-level singleton.
+
+## Regenerating the client
+
+After changing API endpoints, DTOs, or controllers, regenerate from the monorepo root:
+
+```bash
+pnpm api:generate
+```
+
+This regenerates `src/generated/` from the OpenAPI spec and rebuilds the package. Commit the updated files alongside any API changes — the pre-commit hook enforces this.
 
 ## Architecture
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,12 +1,10 @@
+<!-- generated-by: gsd-doc-writer -->
+
 # @cipherbox/core
 
 CipherBox domain types, metadata schemas, validators, and metadata encryption.
 
-## Install
-
-```bash
-pnpm add @cipherbox/core
-```
+Part of the [CipherBox monorepo](../../README.md).
 
 ## Usage
 
@@ -29,11 +27,11 @@ import {
 ### File Metadata
 
 - Types: `FileMetadata`, `FilePointer`, `VersionEntry`, `EncryptedFileMetadata`
-- Functions: `encryptFileMetadata`, `decryptFileMetadata`, `validateFileMetadata`, `deriveFileIpnsKeypair`
+- Functions: `encryptFileMetadata`, `decryptFileMetadata`, `validateFileMetadata`, `deriveFileIpnsKeypair`, `generateFileIpnsKeypair`
 
 ### Device Registry
 
-- Types: `DeviceEntry`, `DeviceRegistry`, `DeviceAuthStatus`, `DevicePlatform`
+- Types: `DeviceEntry`, `DeviceRegistry`, `DeviceRegistryVersion`, `DeviceAuthStatus`, `DevicePlatform`
 - Functions: `encryptRegistry`, `decryptRegistry`, `deriveRegistryIpnsKeypair`, `validateDeviceRegistry`
 
 ### Recycle Bin
@@ -41,15 +39,17 @@ import {
 - Types: `BinEntry`, `RecycleBinMetadata`
 - Functions: `encryptBinMetadata`, `decryptBinMetadata`, `deriveBinIpnsKeypair`, `validateBinMetadata`
 
-### Vault Initialization
+### Vault
 
-- Types: `VaultInit`, `EncryptedVaultKeys`
-- Functions: `initializeVault`, `encryptVaultKeys`, `decryptVaultKeys`
+- Types: `VaultInit`, `EncryptedVaultKeys`, `ByoIpfsConfig`, `VaultSettings`
+- Functions: `initializeVault`, `encryptVaultKeys`, `decryptVaultKeys`, `serializeVaultBlobV2`, `deserializeVaultBlobV2`, `detectBlobVersion`, `validateVaultSettings`
+- Constants: `BLOB_V2_VERSION`, `DEFAULT_VAULT_SETTINGS`
 
 ### IPNS Records
 
 - Types: `IPNSRecord`
-- Functions: `createIpnsRecord`, `deriveIpnsName`, `marshalIpnsRecord`, `unmarshalIpnsRecord`
+- Functions: `createIpnsRecord`, `deriveIpnsName`, `marshalIpnsRecord`, `unmarshalIpnsRecord`, `signIpnsData`
+- Constants: `IPNS_SIGNATURE_PREFIX`
 
 ## Architecture
 
@@ -61,6 +61,12 @@ import {
 @cipherbox/sdk-core
     ^
 @cipherbox/sdk
+```
+
+## Testing
+
+```bash
+pnpm test
 ```
 
 ## License

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -1,12 +1,10 @@
+<!-- generated-by: gsd-doc-writer -->
+
 # @cipherbox/crypto
 
 Pure cryptographic primitives and key derivation for the CipherBox ecosystem.
 
-## Install
-
-```bash
-pnpm add @cipherbox/crypto
-```
+Part of the [CipherBox monorepo](../../README.md).
 
 ## Usage
 
@@ -15,30 +13,56 @@ import {
   encryptAesGcm,
   decryptAesGcm,
   generateFileKey,
+  generateIv,
   wrapKey,
   unwrapKey,
 } from '@cipherbox/crypto';
+
+// Encrypt file content
+const fileKey = generateFileKey();
+const iv = generateIv();
+const ciphertext = await encryptAesGcm(plaintext, fileKey, iv);
+
+// Wrap file key with user's public key (ECIES secp256k1)
+const wrappedKey = await wrapKey(fileKey, vaultKey.publicKey);
+
+// Unwrap and decrypt
+const unwrappedKey = await unwrapKey(wrappedKey, vaultKey.privateKey);
+const decrypted = await decryptAesGcm(ciphertext, unwrappedKey, iv);
 ```
 
 ## API
 
-### AES-GCM / AES-CTR
+### AES-256-GCM
 
-- `encryptAesGcm`, `decryptAesGcm`, `sealAesGcm`, `unsealAesGcm`
-- `encryptAesCtr`, `decryptAesCtr`, `decryptAesCtrRange`
+- `encryptAesGcm`, `decryptAesGcm` — encrypt/decrypt with explicit IV
+- `sealAesGcm`, `unsealAesGcm` — prepend IV to ciphertext for self-contained blobs
 
-### ECIES Key Wrapping
+### AES-256-CTR (streaming / random-access)
+
+- `encryptAesCtr`, `decryptAesCtr` — full-stream CTR encryption
+- `decryptAesCtrRange` — random-access decryption for media byte-range requests
+
+### ECIES secp256k1 Key Wrapping
 
 - `wrapKey`, `unwrapKey`, `reWrapKey`
 
 ### Ed25519
 
-- `generateEd25519Keypair`, `signEd25519`, `verifyEd25519`
+- `generateEd25519Keypair`, `deriveEd25519PublicKey`, `signEd25519`, `verifyEd25519`
 
 ### Key Derivation
 
-- `deriveKey`, `deriveContextKey`, `generateFolderKey`, `generateFileKey`
-- `deriveVaultIpnsKeypair`, `deriveIpnsName`
+- `deriveKey`, `deriveContextKey`, `generateFolderKey`
+
+### Vault IPNS Key Derivation
+
+- `deriveVaultIpnsKeypair`, `deriveVaultKeyIpnsKeypair`
+- `deriveByoConfigIpnsKeypair`, `deriveVaultSettingsIpnsKeypair`
+
+### IPNS
+
+- `deriveIpnsName`
 
 ### Device Keys
 
@@ -46,8 +70,13 @@ import {
 
 ### Utilities
 
-- `hexToBytes`, `bytesToHex`, `concatBytes`, `clearBytes`, `clearAll`, `generateRandomBytes`
-- `generateIv`, `generateCtrIv`
+- `generateFileKey`, `generateIv`, `generateCtrIv`, `generateRandomBytes`
+- `hexToBytes`, `bytesToHex`, `concatBytes`, `clearBytes`, `clearAll`
+
+### Types and Constants
+
+- `CryptoError`, `CryptoErrorCode`, `VaultKey`, `EncryptedData`
+- `AES_KEY_SIZE`, `AES_IV_SIZE`, `AES_TAG_SIZE`, `SECP256K1_PUBLIC_KEY_SIZE`, and related constants
 
 ## Architecture
 
@@ -59,6 +88,14 @@ import {
 @cipherbox/sdk-core
     ^
 @cipherbox/sdk
+```
+
+## Testing
+
+```bash
+pnpm test
+pnpm test:watch
+pnpm test:coverage
 ```
 
 ## License

--- a/packages/sdk-core/README.md
+++ b/packages/sdk-core/README.md
@@ -1,34 +1,66 @@
+<!-- generated-by: gsd-doc-writer -->
+
 # @cipherbox/sdk-core
 
 Stateless, folder-aware vault operations for CipherBox. Designed for load testing and integration testing without browser dependencies.
 
-## Install
-
-```bash
-pnpm add @cipherbox/sdk-core
-```
+Part of the [CipherBox monorepo](../../README.md).
 
 ## Usage
 
 ```typescript
 import { uploadFile, downloadAndDecrypt, createSubfolder } from '@cipherbox/sdk-core';
 
-const result = await uploadFile({ data, fileId, mimeType, folderKey, userPublicKey, ctx });
+const result = await uploadFile({ data, fileId, mimeType, folderKey, publicKey, ctx });
 ```
 
 ## API
 
+### Types
+
+- `SdkContext` — injected configuration (`apiUrl`, `getAccessToken`, optional `axiosInstance`)
+- `TeeKeys` — TEE key configuration (`currentPublicKey`, `currentEpoch`, optional previous key/epoch)
+- `IpfsAddResult`, `ProgressCallback`, `DownloadProgressCallback`
+
 ### File Operations
 
 - `uploadFile`, `downloadAndDecrypt`
+- `createFileMetadata`, `resolveFileMetadata`, `updateFileMetadata`
 
 ### Folder Operations
 
+- `fetchAndDecryptMetadata`, `loadFolderMetadata`, `updateFolderMetadataAndPublish`
 - `createSubfolder`, `renameInFolder`, `moveItem`, `deleteFromFolder`
+- `addFilePointerToFolder`, `addFileToFolder`, `addFilesToFolder`, `replaceFileInFolder`
+
+### Tree Utilities
+
+- `getDepth`, `calculateSubtreeDepth`, `isDescendantOf`
 
 ### IPFS/IPNS
 
-- `addToIpfs`, `fetchFromIpfs`, `unpinFromIpfs`, `createAndPublishIpnsRecord`, `batchPublishIpnsRecords`, `resolveIpnsRecord`
+- `addToIpfs`, `fetchFromIpfs`, `unpinFromIpfs`, `registerCid`
+- `createAndPublishIpnsRecord`, `batchPublishIpnsRecords`, `resolveIpnsRecord`, `verifyIpnsSignature`
+
+### Vault
+
+- `publishVaultKeyBlob`, `loadVaultKeyBlob`
+
+### Pinning Providers (BYO-IPFS)
+
+- `KuboProvider`, `PsaProvider`, `PinataProvider`, `DualPinProvider`, `testConnection`
+- Types: `PinningProvider`, `PinResult`, `PinStatus`, `PinningMode`, `ExternalProviderConfig`, `ConnectionTestResult`, `ProviderOptions`, `DualPinResult`
+
+### Encryption Mode
+
+- `selectEncryptionMode`, `normalizeEncryptionMode`
+- Type: `EncryptionMode`
+
+## Testing
+
+```bash
+pnpm test
+```
 
 ## Architecture
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,3 +1,5 @@
+<!-- generated-by: gsd-doc-writer -->
+
 # @cipherbox/sdk
 
 Stateful CipherBox client with full workflow orchestration, event emission, and internal state management.
@@ -19,35 +21,78 @@ const client = new CipherBoxClient({
   vaultKeypair: { publicKey, privateKey },
   rootIpnsName: 'k51qzi5uqu5dg...',
   rootFolderKey,
-  onOperationStart: (op) => console.log('Starting', op),
-  onOperationEnd: (op) => console.log('Done', op),
 });
+
+// Subscribe to typed events
+const unsub = client.on((event) => {
+  if (event.type === 'folder:updated') {
+    store.updateFolder(event.folderId, event.children);
+  }
+});
+
+// Load root folder
+await client.loadFolder(rootIpnsName, rootFolderKey, rootIpnsKeypair);
 
 await client.uploadFile(folderIpnsName, data, fileName, mimeType);
 await client.deleteItem(folderIpnsName, childId);
+
+// Cleanup
+unsub();
+client.destroy();
 ```
 
 ## API
 
 ### Client Lifecycle
 
-- `new CipherBoxClient(config)`, `client.destroy()`
+- `new CipherBoxClient(config: CipherBoxClientConfig)`, `client.destroy()`
 
 ### Folder Operations
 
-- `client.loadFolder()`, `client.createFolder()`, `client.renameItem()`, `client.moveItem()`, `client.deleteItem()`
+- `client.loadFolder(ipnsName, folderKey, ipnsKeypair)`
+- `client.createFolder(parentIpnsName, name)`, `client.renameItem()`, `client.moveItem()`, `client.deleteItem()`
 
 ### File Operations
 
-- `client.uploadFile()`, `client.downloadFile()`, `client.downloadFromIpns()`
+- `client.uploadFile(folderIpnsName, data, fileName, mimeType)`, `client.uploadFiles()` (batch)
+- `client.downloadFile(cid, fileKey)`, `client.downloadFromIpns(fileMetaIpnsName)`
+- `client.updateFile()`
 
 ### Recycle Bin
 
 - `client.loadBin()`, `client.deleteToBin()`, `client.restoreFromBin()`, `client.permanentDelete()`, `client.emptyBin()`
 
+### Share Operations
+
+- Stateful share operations are accessed via `CipherBoxClient`
+- Stateless shared-write helpers for write-share recipients: `uploadToSharedFolder()`, `createSharedSubfolder()`, `renameInSharedFolder()`, `deleteFromSharedFolder()`, `updateSharedFile()`, `updateSharePermission()`, `buildSharedWriteContext()`
+- `ShareKeyCache` — caches decrypted share keys to avoid repeated ECIES operations
+
+### Error Utilities
+
+- `isForbiddenError(err)`, `isConflictError(err)` — error type guards
+- `withRevocationGuard(fn)` — wraps an operation and handles 403 revocation
+- `withConflictRetry(fn)` — retries on 409 conflict with exponential backoff
+
 ### Events
 
-- `const unsub = client.on((event) => { ... })` — single handler receives all typed `SdkEvent` objects (`folder:loaded`, `folder:updated`, `bin:updated`, `error`, etc.)
+`client.on(handler)` — subscribe to all typed `SdkEvent` objects; returns an unsubscribe function.
+
+| Event type                | Payload highlights                                   |
+| ------------------------- | ---------------------------------------------------- |
+| `folder:loaded`           | `folderId`, `ipnsName`, `children`, `sequenceNumber` |
+| `folder:updated`          | `folderId`, `ipnsName`, `children`, `sequenceNumber` |
+| `folder:deleted`          | `folderId`                                           |
+| `file:uploaded`           | `folderId`, `fileName`, `cid`                        |
+| `files:batchUploaded`     | `folderId`, `successes[]`, `failures[]`              |
+| `file:downloaded`         | `cid`                                                |
+| `bin:updated`             | `entries`                                            |
+| `share:reWrapFailed`      | `folderIpnsName`, `failedRecipients`                 |
+| `pin:secondaryFailed`     | `cid`, `providerName`, `error`                       |
+| `ipns:batchPublishFailed` | `ipnsNames`, `error`                                 |
+| `operation:start`         | `operation`                                          |
+| `operation:end`           | `operation`, `durationMs`                            |
+| `error`                   | `operation`, `error`                                 |
 
 ## Architecture
 
@@ -59,7 +104,11 @@ await client.deleteItem(folderIpnsName, childId);
 @cipherbox/sdk-core <----+
     ^
 @cipherbox/sdk  <-- You are here
+    |
+    +-- @cipherbox/crypto (direct)
 ```
+
+Part of the [CipherBox monorepo](../../README.md).
 
 ## License
 

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,73 @@
+<!-- generated-by: gsd-doc-writer -->
+
+# @cipherbox/load-tests
+
+Load tests for the CipherBox API and SDK. Measures upload throughput, IPNS publish
+concurrency, mixed workloads, sustained traffic, spike behaviour, and BYO-IPFS provider
+capacity — all against a live API target.
+
+Part of the [CipherBox monorepo](../../README.md).
+
+## Tooling
+
+[Vitest](https://vitest.dev/) runs the scenarios sequentially (no parallelism). Each test
+has a 10-minute timeout. Results are written to `metrics-*.json` files in this directory.
+
+## Scenarios
+
+| Scenario                | File                                          |
+| ----------------------- | --------------------------------------------- |
+| `upload-throughput`     | `src/scenarios/upload-throughput.test.ts`     |
+| `ipns-publish-storm`    | `src/scenarios/ipns-publish-storm.test.ts`    |
+| `mixed-workload`        | `src/scenarios/mixed-workload.test.ts`        |
+| `sustained-load`        | `src/scenarios/sustained-load.test.ts`        |
+| `spike-test`            | `src/scenarios/spike-test.test.ts`            |
+| `byo-upload-throughput` | `src/scenarios/byo-upload-throughput.test.ts` |
+| `byo-mixed-workload`    | `src/scenarios/byo-mixed-workload.test.ts`    |
+| `byo-capacity-ceiling`  | `src/scenarios/byo-capacity-ceiling.test.ts`  |
+
+## Running Locally
+
+Set the required environment variables, then run a single scenario by name:
+
+```bash
+LOAD_TEST_API_URL=http://localhost:3000 \
+LOAD_TEST_SECRET=<test-login-secret> \
+THROTTLE_BYPASS_SECRET=<throttle-bypass-secret> \
+LOAD_TEST_CLIENTS=5 \
+pnpm exec vitest run --no-coverage mixed-workload
+```
+
+For BYO-IPFS scenarios, also set:
+
+```bash
+BYO_IPFS_ENDPOINT=https://api.pinata.cloud
+BYO_IPFS_AUTH_TOKEN=<token>
+BYO_IPFS_PROTOCOL=pinata   # pinata | psa | kubo
+BYO_IPFS_PROVIDER_NAME=pinata
+```
+
+## Environment Variables
+
+| Variable                 | Required         | Description                                          |
+| ------------------------ | ---------------- | ---------------------------------------------------- |
+| `LOAD_TEST_API_URL`      | Yes              | Base URL of the API under test                       |
+| `LOAD_TEST_SECRET`       | Yes              | `TEST_LOGIN_SECRET` value used to mint test sessions |
+| `THROTTLE_BYPASS_SECRET` | Yes              | Secret to bypass API rate limiting during load runs  |
+| `LOAD_TEST_CLIENTS`      | No (default `5`) | Number of concurrent virtual clients                 |
+| `BYO_IPFS_ENDPOINT`      | byo-\* only      | BYO IPFS provider base URL                           |
+| `BYO_IPFS_AUTH_TOKEN`    | byo-\* only      | Auth token for the BYO provider                      |
+| `BYO_IPFS_PROTOCOL`      | byo-\* only      | Provider protocol: `pinata`, `psa`, or `kubo`        |
+| `BYO_IPFS_PROVIDER_NAME` | byo-\* only      | Label used in metrics output                         |
+
+## CI
+
+The `load-test.yml` workflow (`manual dispatch only`) runs any scenario against `local` or
+`staging`. For `local` it spins up Postgres, Kubo IPFS, and Redis service containers and
+starts the API before executing. Metrics JSON is uploaded as a workflow artifact
+(retained 30 days).
+
+## Related Docs
+
+- [Testing strategy](../TESTING_STRATEGY.md)
+- [Full testing reference](../../docs/TESTING.md)

--- a/tests/sdk-e2e/README.md
+++ b/tests/sdk-e2e/README.md
@@ -1,0 +1,62 @@
+<!-- generated-by: gsd-doc-writer -->
+
+# @cipherbox/sdk-e2e
+
+SDK-level end-to-end tests that exercise the `@cipherbox/sdk` and `@cipherbox/core` packages
+against a live API and IPFS/IPNS stack.
+
+Part of the [CipherBox monorepo](../../README.md).
+
+## What It Covers
+
+Each test suite runs against real API accounts created via `/auth/test-login`:
+
+- `vault-lifecycle` — vault init, export, quota, and deletion
+- `file-operations` — upload, download, rename, delete
+- `folder-crud` — create, rename, move, delete folders
+- `bin-operations` — trash and restore flows
+- `batch-upload` — concurrent multi-file upload
+- `data-integrity` — round-trip content verification
+- `concurrent-operations` — race-condition safety
+- `error-cases` — SDK error handling for bad inputs
+- `ipns-consistency` — IPNS metadata publish/resolve consistency
+- `share-operations` — user-to-user file sharing
+- `invite-link` — invite link create, claim, and revoke
+
+## Prerequisites
+
+A running local stack (API + IPFS node) is required. See
+[../../docs/DEVELOPMENT.md](../../docs/DEVELOPMENT.md) for setup instructions.
+
+## Environment Variables
+
+| Variable                 | Required | Default                                    | Description                           |
+| ------------------------ | -------- | ------------------------------------------ | ------------------------------------- |
+| `SDK_E2E_API_URL`        | No       | `http://localhost:3000`                    | Base URL of the CipherBox API         |
+| `SDK_E2E_SECRET`         | No       | `e2e-test-secret-do-not-use-in-production` | Shared secret for test-login endpoint |
+| `THROTTLE_BYPASS_SECRET` | No       | _(empty)_                                  | Bypass rate-limiting in dev/staging   |
+
+## Running Tests
+
+```bash
+# Run all suites once (no coverage)
+pnpm test
+
+# Watch mode for a single suite during development
+pnpm test:watch
+
+# Run a single suite by filename pattern
+pnpm test:single file-operations
+```
+
+Tests run sequentially (`fileParallelism: false`) with a 120 s timeout per test.
+
+## CI
+
+These tests are not part of the standard `ci-e2e.yml` workflow (which covers web and desktop
+E2E only). They are intended for local verification and targeted staging runs.
+
+## Further Reading
+
+- [../../docs/TESTING.md](../../docs/TESTING.md) — project-wide testing strategy and coverage policy
+- [../TESTING_STRATEGY.md](../TESTING_STRATEGY.md) — E2E layer breakdown and test scope decisions

--- a/tests/web-e2e/README.md
+++ b/tests/web-e2e/README.md
@@ -1,3 +1,5 @@
+<!-- generated-by: gsd-doc-writer -->
+
 # CipherBox E2E Tests
 
 End-to-end tests for CipherBox using Playwright.
@@ -34,7 +36,7 @@ pnpm test
 ### Specific test file
 
 ```bash
-pnpm test tests/auth/login.spec.ts
+pnpm test tests/wallet-login.spec.ts
 ```
 
 ### Single browser
@@ -55,67 +57,80 @@ pnpm test:headed
 pnpm test:debug
 ```
 
-### UI mode (interactive)
+### View last report
 
 ```bash
-pnpm test:ui
+pnpm test:report
 ```
 
 ## Test Structure
 
 ```text
 tests/web-e2e/
-├── fixtures/          # Test fixtures
-│   └── auth.fixture.ts    # Authenticated session fixture
-├── tests/             # Test specs
-│   └── auth/
-│       ├── login.spec.ts   # Login flow tests
-│       ├── logout.spec.ts  # Logout flow tests
-│       └── session.spec.ts # Session persistence tests
-├── utils/             # Test utilities
-│   └── wallet-login-helpers.ts # Wallet login helpers
-└── playwright.config.ts    # Playwright configuration
+├── fixtures/              # Static test assets
+│   └── files/             # Sample files for upload tests (images, PDFs, video, audio)
+├── page-objects/          # Page Object Model classes
+│   ├── login.page.ts      # Login page interactions
+│   ├── base.page.ts       # Base page helpers
+│   ├── dialogs/           # Dialog page objects
+│   ├── file-browser/      # File browser page objects
+│   └── pages/             # Other page objects
+├── tests/                 # Test specs (flat, no subdirectories)
+│   ├── wallet-login.spec.ts
+│   ├── full-workflow.spec.ts
+│   ├── sharing-workflow.spec.ts
+│   ├── mfa-flows.spec.ts
+│   ├── recovery.spec.ts
+│   ├── search-workflow.spec.ts
+│   ├── recycle-bin.spec.ts
+│   ├── conflict-detection.spec.ts
+│   ├── batch-download.spec.ts
+│   ├── writable-shares.spec.ts
+│   ├── invite-link-workflow.spec.ts
+│   ├── media-preview.spec.ts
+│   ├── streaming-playback.spec.ts
+│   └── journey-timing.spec.ts
+├── utils/                 # Test utilities
+│   ├── wallet-login-helpers.ts  # Mock wallet setup and login helpers
+│   ├── api-helpers.ts           # API-level helpers
+│   ├── cleanup-helpers.ts       # Account/data cleanup helpers
+│   ├── conflict-helpers.ts      # Conflict scenario helpers
+│   ├── mfa-helpers.ts           # MFA flow helpers
+│   ├── multi-account-wallet.ts  # Multi-account wallet setup
+│   └── test-files.ts            # Test file references
+└── playwright.config.ts   # Playwright configuration
 ```
 
 ## Authentication in Tests
 
-### Storage State Pattern
+### Mock Wallet Pattern
 
-Most tests use the **storage state pattern** for fast, reliable authentication:
+Tests authenticate using `@johanneskares/wallet-mock`, which installs an EIP-6963 mock
+provider in the browser. This avoids any real Web3Auth modal interaction and works fully
+headless in CI.
 
-1. **First run**: Perform manual login once to generate auth state
-2. **Subsequent runs**: Tests load saved auth state (fast, no Web3Auth interaction)
-
-### Setting up Auth State
-
-#### Option 1: Manual Login (Interactive)
-
-Run a test that requires authentication and complete the Web3Auth flow manually:
-
-```bash
-pnpm test:headed tests/auth/login.spec.ts
-```
-
-This will generate `.auth/user.json` with your authenticated session.
-
-#### Option 2: CI Setup
-
-For CI environments, auth state should be pre-generated and made available to tests. This can be done via:
-
-- Storing auth state as a CI secret
-- Using API-based test authentication endpoint
-- Programmatic Web3Auth authentication
-
-### Using Authenticated Tests
+Each test suite that requires authentication calls `setupMockWallet()` before navigating:
 
 ```typescript
-import { authenticatedTest } from '../fixtures/auth.fixture';
+import { setupMockWallet, createTestAccount } from '../utils/wallet-login-helpers';
 
-authenticatedTest('my test', async ({ authenticatedPage }) => {
-  // Page is already authenticated and on dashboard
-  await authenticatedPage.click('button');
+const account = createTestAccount(); // generates a random private key
+
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await setupMockWallet(page, account); // must be called before navigation
+  await page.goto('/');
 });
 ```
+
+For deterministic tests (e.g., wallet login flow), a well-known Hardhat account key is
+used instead of a random key.
+
+### No Storage State
+
+There is no global setup or stored `.auth/user.json` state. Each test suite sets up its
+own wallet-authenticated session from scratch using the mock wallet.
 
 ## CI Integration
 
@@ -123,7 +138,7 @@ E2E tests run automatically on GitHub Actions for every push and pull request to
 
 ### CI Workflow
 
-The E2E workflow (`.github/workflows/e2e.yml`):
+The E2E workflow (`.github/workflows/web-e2e.yml`):
 
 1. Starts PostgreSQL and IPFS services
 2. Installs dependencies and Playwright browsers
@@ -133,10 +148,9 @@ The E2E workflow (`.github/workflows/e2e.yml`):
 
 ### CI Environment
 
-- **Authentication**: Global setup creates placeholder auth state for CI
-- **Authenticated tests**: Skipped in CI (require manual Web3Auth interaction)
-- **Unauthenticated tests**: Run fully automated (login page, redirects, etc.)
+- **Authentication**: All tests use the mock wallet — no manual Web3Auth interaction required
 - **Services**: PostgreSQL and IPFS run as Docker containers
+- **Parallelism**: Tests run sequentially (`workers: 1`) to share a single browser session
 
 ### Running Tests Locally Like CI
 
@@ -149,29 +163,31 @@ This will:
 
 - Use HTML reporter (instead of interactive list)
 - Fail if any tests are marked `.only`
-- Never reuse existing dev server (always starts fresh)
+- Always start a fresh dev server (never reuses an existing one)
 
 ## Notes
 
-- **Web3Auth Modal Tests**: Tests that interact with the Web3Auth modal may be flaky and are skipped in CI
-- **Protected Routes**: Dashboard and Settings routes require authentication
-- **Logout**: Clears all session data and redirects to login page
-- **Session Persistence**: Auth state persists across page reloads via cookies and localStorage
+- **Chromium only**: Tests target Desktop Chrome; other browsers are not configured
+- **Sequential execution**: `fullyParallel: false`, `workers: 1` — tests run one at a time
+- **No retries**: Flakiness is fixed at the source, not masked with retries
+- **External target**: Set `BASE_URL` to a staging/production URL to skip local server startup
+- **Protected Routes**: Dashboard and file browser routes require wallet authentication
 
 ## Troubleshooting
 
-### "Authentication state not found" Error
+### Mock Wallet Not Detected
 
-This means you need to set up auth state first. Run an interactive test or generate auth state using the setup process.
+`setupMockWallet()` must be called before any `page.goto()`. If the wallet is not detected,
+ensure the call order in `beforeAll`/`beforeEach` is correct.
 
-### Web3Auth Modal Not Appearing
+### Web App Not Starting
 
-- Check that the web app is running (`pnpm dev` in workspace root)
-- Verify Web3Auth client ID is configured
-- Try running in headed mode to see what's happening
+- Verify `pnpm install` has been run at the monorepo root
+- Check that ports 3000 (API), 3001 (mock IPNS routing), and 5173 (web) are free
+- The mock IPNS routing service must be built first: `pnpm build` from the workspace root
 
 ### Tests Timing Out
 
 - Increase timeout in `playwright.config.ts`
-- Check that backend API is running and accessible
-- Verify network connectivity to Web3Auth services
+- Check that the backend API is running and accessible at `http://localhost:3000`
+- For CI, verify the `web-e2e.yml` workflow services started successfully


### PR DESCRIPTION
## Summary

**Documentation generation and verification run** (`/gsd:docs-update`, monorepo profile)

Full documentation pass over the monorepo: 22 docs written or updated, 17 docs fact-checked claim-by-claim against the live codebase, and every verified inaccuracy fixed via a bounded fix loop. A follow-up commit expands the local Docker container documentation and aligns the staging deployment notes.

## Changes

### Regenerated (hand-written predecessors replaced)

- `README.md` — fresh top-level README; demonstrator framing dropped
- `docs/ARCHITECTURE.md` — rewritten against current code; links sibling specs instead of duplicating them

### Created

- `docs/CONFIGURATION.md`, `docs/GETTING-STARTED.md`, `docs/TESTING.md`, `docs/DEPLOYMENT.md`, `CONTRIBUTING.md`
- Gap docs: `SECURITY.md` (vulnerability disclosure policy), `docs/SHARING.md` (spec for the implemented sharing feature, sourced from code)
- Package READMEs: `apps/api`, `apps/desktop`, `apps/tee-worker`, `apps/web`, `tests/load`, `tests/sdk-e2e`

### Supplemented (existing content untouched)

- `docs/DEVELOPMENT.md` — appended TEE worker simulator section; follow-up commit expands the infrastructure table to all 5 local containers (incl. `someguy`) and documents the TEE-worker/mock-IPNS port-3001 collision

### Accuracy fixes to existing hand-written docs

- `docs/CAPACITY.md` — TEE republish interval corrected 3h → 6h (3 places), `folder_ipns` index claims, load-scenario count 5 → 8
- `docs/DATABASE_EVOLUTION_PROTOCOL.md` — 2 missing migrations added (16 total), stale line references
- `docs/FILESYSTEM_SPECIFICATION.md` — phantom `folder.service.ts` references replaced with real enforcement sites, `QUOTA_BYTES` attribution corrected
- `docs/METADATA_EVOLUTION_PROTOCOL.md` — Rust implementation paths corrected to `crates/core/src/`, dead `00-Preliminary-R&D` references removed, cargo test command fixed
- `docs/METADATA_SCHEMAS.md` — systemic `packages/crypto/` → `packages/core/` source corrections (15+), DeviceEntry validator corrected to 64-hex Ed25519, Rust struct citations pointed at `crates/core/src/folder.rs`
- `docs/VAULT_EXPORT_FORMAT.md` — aligned with the reference recovery tool (hex-only keys, v1 marked historical/unsupported)
- Updated package READMEs: `packages/api-client`, `core`, `crypto`, `sdk`, `sdk-core`, `tests/web-e2e` (stale CI workflow name, removed auth pattern, missing exports)

## Requirements Addressed

No tracked REQ-IDs — documentation maintenance run, not a roadmap phase.

## Verification

- [x] 17 docs verified against the codebase by independent verifier agents — 383+ claims checked in round 1, 39 failures found
- [x] Fix loop (2 iterations + manual tail): all failures corrected and re-verified; 0 regressions, 0 remaining
- [x] `docs/AUTHENTICATION_ARCHITECTURE.md` passed clean (20/20) and is intentionally untouched
- [x] Secret-pattern scan over all 28 files: clean
- [x] `pnpm lint:md`: clean
- 20 `VERIFY:` markers flag infra claims not provable from the repo (12 CONFIGURATION, 6 DEPLOYMENT, 2 SECURITY) — reviewer skim recommended

## Key Decisions

- Preservation choices: README + ARCHITECTURE regenerated, DEVELOPMENT supplemented (append-only)
- `CHANGELOG.md` (release-please-owned), `CLAUDE.md`, `AGENTS.md` excluded from doc generation/review scope
- Staging-vs-local `someguy` divergence documented rather than changed: routing API 8190 published locally, internal-only in staging

## TDD Audit

| Test commit | Impl commit | gate_status |
| ----------- | ----------- | ----------- |
| `e01f9ea3d` docs: generate and verify project documentation | — | missing |
| `ab84e6549` docs: expand local container details and align staging notes | — | missing |

Aggregate: 0 skill, 0 fallback, 0 exempt — 2 missing (docs-only commits, no TDD gate applicable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

gate_status: skill=0, fallback=0, exempt=0, missing=2
