### PR TITLE
docs: reconcile backlog against phases 36-44 and promote open security findings

### DIFF
--- a/.planning/BACKLOG.md
+++ b/.planning/BACKLOG.md
@@ -2,6 +2,35 @@
 
 > Pending ideas and deferred work. Consolidated 2026-06-12 from the former `.planning/DEFERRED.md` and `.planning/REFACTORING.md` (gsd-health W019 remediation).
 
+## Status Reconciliation (2026-06-13)
+
+The inventories below are a verbatim snapshot dated 2026-03-31 and predate phases 36-44. They were reviewed against the current codebase on 2026-06-13. The original tables are preserved unchanged for the historical record; the current status of changed items is authoritative here.
+
+### Now implemented (previously listed as open)
+
+| Item                                                           | Section             | Shipped in                                                                                                                        |
+| -------------------------------------------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Full retirement of `folder.service.ts`                         | Code Quality        | Phase 38 / PR #422 — file deleted, 0 importers                                                                                    |
+| Full retirement of `bin.service.ts`                            | Code Quality        | Phase 38 / PR #422 — deleted, logic moved to SDK                                                                                  |
+| Remove crypto → core circular devDependency                    | Code Quality        | Phase 38 / PR #422                                                                                                                |
+| User-configurable bin retention period                         | Data Management     | Phase 39 — per-user `VaultSettings.recycleBinRetentionDays`                                                                       |
+| Auto-merge of non-conflicting folder changes (three-way merge) | Sync & Conflict     | Phase 44 — `mergeChildren` in `sdk-core/folder/merge.ts`                                                                          |
+| M5 — `reWrapForRecipients` surfaces failures                   | Security (Phase 14) | Done — failure toast + `share:reWrapFailed` event. Residual: file-update caller ignores `failedRecipients`; no desktop subscriber |
+| L1 — `/shares/lookup` always returns 200 `{ exists }`          | Security (Phase 14) | Done — no 404/200 oracle                                                                                                          |
+| Tier 3.6 — `InitVaultDto` uses generated type                  | Refactoring         | Done                                                                                                                              |
+| Tier 3.9 — `publishBatch` delegates to shared `publishRecord`  | Refactoring         | Done                                                                                                                              |
+
+### Still open, promoted to actionable todos (2026-06-13)
+
+These were genuinely open and tracked nowhere actionable (only in stale review docs + this snapshot), so they are now `.planning/todos/pending/`:
+
+- **M1** — share `itemName` stored plaintext at rest → `2026-06-13-encrypt-share-itemname-at-rest.md`
+- **S1, S2, S3** — IPNS signed-record validation, verification enforcement, key-zeroization convention → `2026-06-13-ipns-signature-storage-review-deferred.md`
+
+### Still open, remaining in this backlog
+
+All other items below remain open and correctly tracked here: the deferred feature set (sharing, desktop UI, MFA, performance, etc.), the `uint8ToBase64` dedup (Tier 3.3 — confirmed still 4-5 copies, no shared util), and Tier-3 cleanups 3.1, 3.2, 3.4, 3.5, 3.7, 3.8, 3.10, 3.11, 3.12, 3.13, 3.14.
+
 ## Deferred Items Inventory
 
 **Last updated:** 2026-03-31

--- a/.planning/todos/pending/2026-06-13-encrypt-share-itemname-at-rest.md
+++ b/.planning/todos/pending/2026-06-13-encrypt-share-itemname-at-rest.md
@@ -1,0 +1,31 @@
+---
+created: 2026-06-13T14:00
+title: 'Encrypt share itemName at rest (Phase 14 security finding M1)'
+area: shares
+files:
+  - apps/api/src/shares/entities/share.entity.ts
+  - apps/api/src/shares/shares.service.ts
+  - apps/web/src/services/share.service.ts
+---
+
+## Problem
+
+Security finding **M1** from `REVIEW-2026-02-21-phase14.md`, still **open** as of 2026-06-13 (verified against live code). The shares table stores `itemName` (file/folder names) as server-readable plaintext, leaking content metadata for shared items even though the server is otherwise zero-knowledge.
+
+Evidence:
+
+- `apps/api/src/shares/entities/share.entity.ts:45-50` — `itemName` is a plaintext `varchar(255)` (the column comment explicitly notes it is plaintext).
+- `apps/api/src/shares/shares.service.ts:96` — server stores the raw `dto.itemName`.
+- `apps/web/src/services/share.service.ts:117` — client sends the raw name. Contrast: `encryptedKey` in the same flow IS ECIES-wrapped, so the pattern exists.
+
+This was previously bundled in `.planning/todos/done/2026-02-21-phase14-security-review-deferred.md` (M1, M5, L1, L4). M5, L1, and L4 have since been implemented, so that todo was closed — but M1 was never addressed and fell off the actionable queue. This todo re-surfaces it.
+
+## Solution
+
+Encrypt `itemName` with the recipient's public key (ECIES), mirroring the `encryptedKey` flow, and decrypt client-side for display:
+
+- Add an encrypted column (longer field for ciphertext) on the shares entity; migrate the plaintext column.
+- API stores only the ciphertext; no plaintext name is persisted.
+- Client encrypts the name with the recipient pubkey on share creation and decrypts on render.
+
+Note: M1 is documented in `REVIEW-2026-02-21-phase14.md` as an accepted trade-off for the share-discovery UX. Confirm whether to implement or formally accept-and-document before scheduling.

--- a/.planning/todos/pending/2026-06-13-ipns-signature-storage-review-deferred.md
+++ b/.planning/todos/pending/2026-06-13-ipns-signature-storage-review-deferred.md
@@ -1,0 +1,24 @@
+---
+created: 2026-06-13T14:00
+title: 'IPNS signature storage review: enforce signedRecord validation, verification, and key zeroization (S1, S2, S3)'
+area: ipns
+files:
+  - apps/api/src/ipns/ipns.service.ts
+  - packages/sdk-core/src/ipns/index.ts
+  - apps/web/src/services/ipns.service.ts
+  - crates/api-client/src/ipns.rs
+---
+
+## Problem
+
+Three deferred findings from `.planning/security/REVIEW-20260402-172126.md` (IPNS Signature Storage, PR #448), all confirmed **still open** against live code on 2026-06-13. They live only in the security review and the stale `.planning/BACKLOG.md` snapshot, so nothing currently actions them.
+
+- **S1 (Medium) — publish does not validate `signedRecord` vs DTO fields.** On publish the server only base64-decodes `dto.record` (`apps/api/src/ipns/ipns.service.ts:60-65`) and stores it verbatim (`:247`, `:292`); the embedded CID/sequence inside the signed record are never parsed and compared against `metadataCid` / `expectedSequenceNumber`. A parser exists but is resolve-only and treats the DB columns as authoritative, only warning on mismatch.
+- **S2 (Medium) — signature verification is downgrade-able.** sdk-core throws on an invalid signature but skips verification entirely when fields are absent (`packages/sdk-core/src/ipns/index.ts:197-219`). The web path is weaker still — it only `logger.warn`s even when a present signature is INVALID and still returns the CID (`apps/web/src/services/ipns.service.ts:177-205`). No resolve caller checks `signatureVerified` (all call sites read only `.cid` / `.sequenceNumber`), and the Rust client does not verify at all (`crates/api-client/src/ipns.rs`).
+- **S3 (Medium) — inconsistent private-key zeroization; no caller-owns-key convention.** Some paths zeroize generated keys (`packages/sdk-core/src/file/index.ts:180`, `folder/index.ts:172-173`), others do not (`ipns/index.ts:39-98`, `vault/index.ts:32-52`). Phase 44 introduced an active contradiction: `updateFileMetadata` zeroizes a caller-passed key (`file/index.ts:401-403`) while its sibling `updateFolderMetadataAndPublish` does not. Rust uses `Zeroizing`/`ZeroizeOnDrop` widely but several unwrap paths return raw `Vec<u8>` keys with inconsistent caller cleanup (`crates/crypto/src/ecies.rs:35-46`, `crates/fuse/src/lib.rs:993-1050`).
+
+## Solution
+
+- **S1**: On publish, parse the embedded CID + sequence from the signed record and reject (400) when they disagree with the DTO's `metadataCid` / `expectedSequenceNumber`.
+- **S2**: Once signed-record data is reliably populated, enforce verification: fail closed when a signature is present but invalid (web path must reject, not warn), have resolve callers honor `signatureVerified`, and add verification to the Rust client. Treat missing fields explicitly rather than silently skipping.
+- **S3**: Establish and document a caller-owns-key convention across the SDK (zeroize at the boundary that owns the buffer); reconcile the `updateFileMetadata` vs `updateFolderMetadataAndPublish` contradiction; audit the Rust unwrap paths that return raw key bytes.


### PR DESCRIPTION
## Summary

Reconciles `.planning/BACKLOG.md` against the current codebase and rescues open security findings that were tracked nowhere actionable.

Context: `gsd health` (W019) consolidated the former `DEFERRED.md` and `REFACTORING.md` into `BACKLOG.md` on 2026-06-12. I verified that consolidation was **complete and verbatim** — no deferred item was lost. But the snapshot is dated 2026-03-31 and predated phases 36–44, so it listed several shipped items as still-open and left a few genuinely-open security findings buried in a static table.

## Changes

**`BACKLOG.md` — Status Reconciliation section (additive; original tables preserved as history):**

9 items verified implemented since the snapshot (with file/PR evidence from a codebase audit):

- `folder.service.ts` + `bin.service.ts` retirement and the crypto→core circular-devDependency removal — Phase 38 / PR #422
- User-configurable bin retention — Phase 39 (`VaultSettings.recycleBinRetentionDays`)
- Three-way folder merge — Phase 44 (`mergeChildren`)
- Security M5 (`reWrapForRecipients` surfaces failures) and L1 (`/shares/lookup` always returns `{ exists }`)
- Tier-3 refactors 3.6 and 3.9

**Two new `todos/pending/` — open security findings re-verified against live code and promoted:**

- `2026-06-13-encrypt-share-itemname-at-rest.md` — **M1**: share `itemName` still stored plaintext at rest
- `2026-06-13-ipns-signature-storage-review-deferred.md` — **S1/S2/S3**: publish doesn't validate `signedRecord` vs DTO; IPNS signature verification is downgrade-able; key zeroization is inconsistent (Phase 44 introduced a contradiction)

These three medium-severity findings previously lived only in stale review docs + the backlog snapshot, so nothing was actioning them.

## Notes

- Independent of the Phase 42/43/44 feature stack — pure planning hygiene, branched off `main`.
- The audit was static-analysis only; every "implemented" claim is backed by file:line / PR evidence. The remaining open feature and Tier-3 cleanup items correctly stay in the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
