### PR TITLE
fix(web): reconcile SDK folderTree sequence to stop deleted-file resurrection

### DIFF
--- a/apps/web/src/lib/sdk-provider.ts
+++ b/apps/web/src/lib/sdk-provider.ts
@@ -87,16 +87,27 @@ export function reconfigurePinning(pinningConfig?: PinningConfig): void {
  * (which loads folders into Zustand) and SDK operations (which require
  * folders in the SDK's internal state).
  *
- * Only registers if the SDK doesn't already have the folder. The SDK's
- * internal state (sequence number, children, keys) is authoritative once
- * a folder is registered — all mutations go through the SDK.
+ * Registers the folder if the SDK doesn't already track it. If it does, the
+ * SDK's internal state is authoritative for SDK-routed mutations, but is
+ * reconciled forward when the store has observed a strictly-newer IPNS sequence
+ * (e.g. from a direct file replace/version publish) to avoid stale-sequence 409s
+ * and merge-driven resurrection of deleted items.
  */
 export function ensureFolderRegistered(folder: FolderNode): void {
   const client = getSdkClient();
 
-  // Don't overwrite if SDK already has this folder — its internal state
-  // is authoritative (correct sequence number, keys, children from mutations)
-  if (client.hasFolder(folder.ipnsName)) return;
+  // Already tracked: the SDK folderTree is authoritative for SDK-routed
+  // mutations, but the Zustand store can advance *past* it when the web app
+  // publishes folder metadata directly via sdk-core (e.g. file replace/version
+  // edits bump modifiedAt + sequence in the store without routing through the
+  // client). Reconcile so a following SDK mutation (delete/move) doesn't publish
+  // with a stale sequence (→ 409) against a stale base, which the 409 merge would
+  // resolve by resurrecting the just-deleted child. Only adopted when strictly
+  // newer, so SDK-advanced state stays authoritative.
+  if (client.hasFolder(folder.ipnsName)) {
+    client.reconcileFolderState(folder.ipnsName, folder.children, folder.sequenceNumber);
+    return;
+  }
 
   // Guard: don't register placeholder folders with empty key material —
   // would cause crypto/IPNS errors on subsequent mutations

--- a/packages/sdk/src/__tests__/client-extended.test.ts
+++ b/packages/sdk/src/__tests__/client-extended.test.ts
@@ -785,6 +785,65 @@ describe('CipherBoxClient - extended', () => {
       expect(client.hasFolder('new-ipns')).toBe(true);
     });
 
+    describe('reconcileFolderState', () => {
+      const childV1 = {
+        type: 'file' as const,
+        id: 'file1',
+        name: 'f.txt',
+        fileMetaIpnsName: 'k51file',
+        ipnsPrivateKeyEncrypted: 'abc',
+        createdAt: 0,
+        modifiedAt: 100,
+      };
+      const childV2 = { ...childV1, modifiedAt: 200 };
+
+      function registerAt(seq: bigint) {
+        client.registerFolder(
+          'rec-ipns',
+          new Uint8Array(32).fill(0xaa),
+          { publicKey: new Uint8Array(32), privateKey: new Uint8Array(64).fill(0xbb) },
+          [childV1],
+          seq
+        );
+      }
+
+      it('adopts children + sequence when the snapshot is strictly newer', () => {
+        registerAt(5n);
+        // Simulates a direct file-replace publish having advanced the store to seq 6.
+        client.reconcileFolderState('rec-ipns', [childV2], 6n);
+
+        const folder = client.getFolderTree().get('rec-ipns');
+        expect(folder?.sequenceNumber).toBe(6n);
+        expect(folder?.children).toEqual([childV2]);
+        // Keys are preserved across reconciliation.
+        expect(folder?.ipnsKeypair.privateKey.every((b) => b === 0xbb)).toBe(true);
+      });
+
+      it('ignores a snapshot at an equal or older sequence (SDK state stays authoritative)', () => {
+        registerAt(5n);
+        client.reconcileFolderState('rec-ipns', [childV2], 5n); // equal
+        client.reconcileFolderState('rec-ipns', [childV2], 4n); // older
+
+        const folder = client.getFolderTree().get('rec-ipns');
+        expect(folder?.sequenceNumber).toBe(5n);
+        expect(folder?.children).toEqual([childV1]);
+      });
+
+      it('no-ops when the folder is not registered', () => {
+        expect(() => client.reconcileFolderState('absent-ipns', [childV2], 9n)).not.toThrow();
+        expect(client.hasFolder('absent-ipns')).toBe(false);
+      });
+
+      it('copies the children array so later caller mutation does not leak in', () => {
+        registerAt(1n);
+        const live = [childV2];
+        client.reconcileFolderState('rec-ipns', live, 2n);
+        live.push({ ...childV1, id: 'file2' });
+
+        expect(client.getFolderTree().get('rec-ipns')?.children).toEqual([childV2]);
+      });
+    });
+
     it('destroy zeros internal key copies without mutating caller buffers', () => {
       const config = createTestConfig();
       const originalPrivKey = new Uint8Array(config.vaultKeypair.privateKey);

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -301,6 +301,41 @@ export class CipherBoxClient {
     });
   }
 
+  /**
+   * Reconcile an already-registered folder's children + sequence with a newer
+   * snapshot observed outside this client.
+   *
+   * The web app publishes folder metadata directly via sdk-core for some
+   * operations (notably file replace / version edits, which bump `modifiedAt`
+   * and the IPNS sequence in the Zustand store without routing through this
+   * client). That advances the store past the SDK's `folderTree`, which
+   * `registerFolder` otherwise treats as authoritative. A later SDK-routed
+   * mutation (delete, move) would then publish with a stale sequence number
+   * (→ 409) against a stale base snapshot; the 409 merge resolves that by
+   * *resurrecting* the just-deleted child, because edit-beats-delete sees
+   * `remote.modifiedAt > staleBase.modifiedAt`.
+   *
+   * Adopt the snapshot only when it is strictly newer (higher IPNS sequence)
+   * than what the SDK holds, so SDK-routed mutations that have already advanced
+   * the folderTree remain authoritative. Keys, folderKey and metadata are
+   * preserved — only children and sequence move forward. No-op when the folder
+   * is not tracked.
+   *
+   * @param ipnsName - Folder's IPNS name
+   * @param children - Current folder children observed by the caller
+   * @param sequenceNumber - IPNS sequence the caller has observed
+   */
+  reconcileFolderState(ipnsName: string, children: FolderChild[], sequenceNumber: bigint): void {
+    const existing = this.folderTree.get(ipnsName);
+    if (!existing) return;
+    if (sequenceNumber <= existing.sequenceNumber) return;
+
+    existing.children = [...children];
+    existing.sequenceNumber = sequenceNumber;
+    existing.lastLoadedAt = Date.now();
+    this.folderTree.set(ipnsName, existing);
+  }
+
   // ---- Internal state access (for bin/share modules) ----
 
   /** @internal Get the folder tree for bin/share operations */


### PR DESCRIPTION
## Summary

Fixes the deterministic web-e2e failure in **recycle-bin `TC08: permanent delete of versioned file reclaims all quota`** (reproduced on both runs of `1abceb4b8`). After a file is **replaced** and then **soft-deleted**, the item is *resurrected* in the file list (and also moved to the bin), so `waitForItemToDisappear` times out.

## Root cause

A **two-store desync** exposed by the new 409-merge (#488):

- The web app holds folder state in **two** places: the Zustand `useFolderStore` and the SDK client's internal `folderTree`.
- `ensureFolderRegistered` treats the `folderTree` as authoritative and **no-ops once a folder is registered**.
- A **file replace** (`updateFile`) publishes folder metadata **directly via sdk-core**, advancing the store's IPNS sequence and the child's `modifiedAt` — but the SDK `folderTree` is never told, so it stays at the **old sequence and old `modifiedAt`**.
- The subsequent `deleteToBin` reads the **stale `folderTree`**, so it:
  1. publishes the removal at a stale sequence → **409**, then
  2. merges against a stale `baseChildren` (`modifiedAt = t1`) vs remote (`modifiedAt = t2`). The merge's **edit-beats-delete** branch (`folder/merge.ts`) sees `remote.modifiedAt > base.modifiedAt` and **resurrects the just-deleted file**.

The merge is correct given its inputs; the inputs (stale base/sequence) are the defect — so the fix is at the desync, not the merge.

## Fix

- **`packages/sdk/src/client.ts`** — new `reconcileFolderState(ipnsName, children, sequenceNumber)`: advances an already-tracked folder's children + sequence **only when strictly newer** (higher IPNS sequence), preserving keys. SDK-routed mutations stay authoritative.
- **`apps/web/src/lib/sdk-provider.ts`** — `ensureFolderRegistered` reconciles the `folderTree` forward to the store's state instead of no-opping when already registered.

With current state, the delete publishes at the correct sequence → no 409, no merge, file removed. Degrades safely: if the background replace-publish fails, the delete sequence still matches remote and no conflict arises.

## Tests

- `packages/sdk/src/__tests__/client-extended.test.ts` — 4 unit tests for `reconcileFolderState` (adopts-newer, ignores equal/older, no-op-when-absent, copies-array). Full file: 30/30 pass.
- Web `tsc --noEmit` clean; ESLint clean on all changed files.

## Validation

A `web-e2e` run is dispatched against this branch — since TC08 fails deterministically on the base commit, a green run is a definitive confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder state synchronization to prevent conflicts during updates.

* **Tests**
  * Added comprehensive test coverage for folder state reconciliation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->