### PR TITLE
feat: desktop FUSE data-loss bugs and replay hardening

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -706,7 +706,14 @@ Plans:
 **Goal:** Close the desktop FUSE write-durability work that Phase 45 explicitly deferred — the three known data-loss bugs (mkdir orphan on parent-publish conflict, release() false-durability ack, stale-mount recovery on crash), the two replay-path hardening follow-ups from PR #491, and the remaining read_ops/write_ops + journal_helpers test coverage (Phase 45 Tier 2). Behavior-changing: these are correctness/durability fixes, not hygiene.
 **Requirements:** (1) mkdir must durably retry the parent publish on conflict instead of warn-only, so the new child folder is never orphaned remotely; (2) release()/flush must not ack the OS or zeroize+delete the local temp file until the remote commit is durably confirmed or the write is journaled for replay; (3) Linux startup must auto-recover a stale/disconnected FUSE mount (EEXIST/ENOTCONN) instead of failing and notifying; (4) park legacy empty `file_meta_ipns_name` replay entries instead of publishing an empty FilePointer; (5) use a strict (cache-bypassing) IPNS resolve in replay classification so transient failures retain the entry; (6) add the read_ops/write_ops handler test harness (unblock the fuser `ReplySender` limitation) plus the `journal_helpers` builder tests. Preserve all existing crash-recovery semantics.
 **Depends on:** Phase 45
-**Plans:** 0 plans (not yet planned)
+**Plans:** 4 plans
+
+Plans:
+
+- [ ] 46-01-PLAN.md — REQ-6 test harness: vendored `ReplySender` export + `make_test_fs` + `CaptureSender` + journal_helpers builder tests (Wave 1, lands first)
+- [ ] 46-02-PLAN.md — REQ-3 Linux stale-mount recovery: `recover_stale_mount` + mountinfo parser + EEXIST retry (Wave 2)
+- [ ] 46-03-PLAN.md — REQ-4 park legacy empty-name replay entries + REQ-5 strict cache-bypassing replay resolve (Wave 2)
+- [ ] 46-04-PLAN.md — REQ-1/REQ-2 mkdir + release durability characterization tests + Open Question A2 verification (Wave 3, tests-only)
 
 Scope (captured todos):
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v1.1
 milestone_name: milestone
-status: Executing Phase 46
-last_updated: "2026-06-15T06:10:00.000Z"
+status: Phase 46 secured and verified
+last_updated: "2026-06-15T13:00:00.000Z"
 last_activity: 2026-06-15
 progress:
   total_phases: 32
   completed_phases: 30
   total_plans: 134
   completed_plans: 134
-  percent: 95
+  percent: 100
 ---
 
 # Project State
@@ -24,9 +24,9 @@ See: .planning/PROJECT.md (updated 2026-03-07)
 
 ## Current Position
 
-Phase: 46 (desktop-fuse-data-loss-bugs-replay-hardening) — EXECUTING
-Plan: 4 of 4 (all plans implemented; commits pending signer recovery)
-Phases 18-45 complete; 46-47 added 2026-06-15 from grouped desktop + SDK todos
+Phase: 46 (desktop-fuse-data-loss-bugs-replay-hardening) — SECURED + VERIFIED
+Plan: 4 of 4 (committed); simplify + secure (SECURED 12/12) + verify (GOAL MET 6/6) complete
+Phases 18-45 complete; 46-47 added 2026-06-15 from grouped desktop + SDK todos. Phase 46 pending Linux remount-after-SIGKILL UAT.
 
 ## Performance Metrics
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v1.1
 milestone_name: milestone
-status: In progress
-last_updated: "2026-06-15T00:00:00.000Z"
+status: Executing Phase 46
+last_updated: "2026-06-15T06:10:00.000Z"
 last_activity: 2026-06-15
 progress:
   total_phases: 32
   completed_phases: 30
-  total_plans: 130
-  completed_plans: 130
-  percent: 94
+  total_plans: 134
+  completed_plans: 134
+  percent: 95
 ---
 
 # Project State
@@ -20,13 +20,13 @@ progress:
 See: .planning/PROJECT.md (updated 2026-03-07)
 
 **Core value:** Zero-knowledge privacy -- files encrypted client-side, server never sees plaintext
-**Current focus:** Phases 46-47 — desktop FUSE data-loss bugs + SDK folder-state/publish consolidation (planned, not started)
+**Current focus:** Phase 46 — desktop-fuse-data-loss-bugs-replay-hardening
 
 ## Current Position
 
-Phase: 46 (next)
-Plan: Not started
-Phases 18-45 complete; 46-47 added 2026-06-15 from grouped desktop + SDK todos (not yet planned)
+Phase: 46 (desktop-fuse-data-loss-bugs-replay-hardening) — EXECUTING
+Plan: 4 of 4 (all plans implemented; commits pending signer recovery)
+Phases 18-45 complete; 46-47 added 2026-06-15 from grouped desktop + SDK todos
 
 ## Performance Metrics
 

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -23,7 +23,7 @@
     "ui_review": true,
     "research_before_questions": true,
     "skip_discuss": false,
-    "use_worktrees": false
+    "use_worktrees": true
   },
   "git": {
     "branching_strategy": "phase",

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -23,7 +23,7 @@
     "ui_review": true,
     "research_before_questions": true,
     "skip_discuss": false,
-    "use_worktrees": true
+    "use_worktrees": false
   },
   "git": {
     "branching_strategy": "phase",

--- a/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-01-PLAN.md
+++ b/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-01-PLAN.md
@@ -1,0 +1,185 @@
+---
+phase: 46-desktop-fuse-data-loss-bugs-replay-hardening
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - apps/desktop/src-tauri/vendor/fuser/src/lib_impl.rs
+  - crates/fuse/src/test_support.rs
+  - crates/fuse/src/lib.rs
+  - crates/fuse/src/journal_helpers.rs
+autonomous: true
+requirements: [REQ-6]
+must_haves:
+  truths:
+    - "cipherbox-fuse test code can name fuser::ReplySender and implement a capturing sender"
+    - "A test can construct a CipherBoxFS via make_test_fs() and call a metadata-only handler that replies error == 0"
+    - "journal_helpers builders (build_upload_journal_entry, build_mkdir_journal_entry) round-trip under test with a real EC keypair"
+  artifacts:
+    - path: "apps/desktop/src-tauri/vendor/fuser/src/lib_impl.rs"
+      provides: "ReplySender re-export so test senders compile"
+      contains: "pub use reply::ReplySender"
+    - path: "crates/fuse/src/test_support.rs"
+      provides: "make_test_fs() + CaptureSender + reply_error_code helpers"
+      min_lines: 60
+  key_links:
+    - from: "crates/fuse/src/test_support.rs"
+      to: "fuser::ReplySender"
+      via: "impl fuser::ReplySender for CaptureSender"
+      pattern: "impl fuser::ReplySender for CaptureSender"
+    - from: "crates/fuse/src/test_support.rs"
+      to: "cipherbox_sdk::WriteQueue"
+      via: "per-test isolated journal dir"
+      pattern: "WriteQueue::new"
+---
+
+<objective>
+Build the FUSE handler test harness (REQ-6) that unblocks unit testing of read_ops/write_ops handlers and journal_helpers builders. This MUST land first — every other plan in the phase depends on it.
+
+Three deliverables, exactly as worked out in RESEARCH.md "Requirement 6":
+
+1. One-line vendored fuser edit re-exporting `ReplySender` so cipherbox-fuse test code can implement a capturing sender (the BLOCKER per RESEARCH.md:418-420).
+2. A `#[cfg(all(test, feature = "fuse"))]` test-support module providing `make_test_fs()`, `CaptureSender`, and `reply_error_code()`.
+3. journal_helpers builder tests using a REAL EC keypair (zeros are not a valid curve point per Assumption A1, RESEARCH.md:780).
+
+Purpose: handler/builder unit tests are impossible today because `ReplySender` (vendor/fuser/src/reply.rs:35) is not re-exported and `mod reply;` is private. This is pure test infrastructure — no production behavior changes.
+
+Output: vendored export line, `crates/fuse/src/test_support.rs`, two sample passing handler tests, and journal_helpers builder round-trip tests.
+</objective>
+
+<execution_context>
+@/Users/myankelev/Code/random/cipher-box/.claude/gsd-core/workflows/execute-plan.md
+@/Users/myankelev/Code/random/cipher-box/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-RESEARCH.md
+@.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-VALIDATION.md
+@apps/desktop/src-tauri/vendor/fuser/src/lib_impl.rs
+@apps/desktop/src-tauri/vendor/fuser/src/reply.rs
+@crates/fuse/src/lib.rs
+@crates/fuse/src/journal_helpers.rs
+@apps/desktop/src-tauri/src/fuse/mod.rs
+@crates/fuse/Cargo.toml
+@apps/desktop/CLAUDE.md
+</context>
+
+<tasks>
+
+<task type="execute">
+  <name>Task 1: Re-export ReplySender from the vendored fuser crate</name>
+  <files>apps/desktop/src-tauri/vendor/fuser/src/lib_impl.rs</files>
+  <action>
+Append exactly ONE line to `apps/desktop/src-tauri/vendor/fuser/src/lib_impl.rs` immediately after the existing line 28 (`pub use reply::{Reply, ReplyAttr, ReplyData, ReplyEmpty, ReplyEntry, ReplyOpen};`):
+
+  pub use reply::ReplySender;
+
+This surfaces only the trait name; `mod reply;` stays private. Per RESEARCH.md:438-454, this is the minimal vendored edit. DO NOT touch `channel.rs` — it carries the critical FUSE-T `recv(MSG_PEEK)` patch (apps/desktop/CLAUDE.md "Vendored Fuser Crate") and any edit there risks crashing large-file writes. DO NOT modify any abi-gated code. The `abi-7-40` feature stays disabled (RESEARCH.md:432, Assumption A3), so the test sender will only implement `send`, never `open_backing`.
+  </action>
+  <verify>
+    <automated>cd /Users/myankelev/Code/random/cipher-box && grep -c "pub use reply::ReplySender;" apps/desktop/src-tauri/vendor/fuser/src/lib_impl.rs | grep -qx 1 && git diff --stat apps/desktop/src-tauri/vendor/fuser/src/channel.rs | grep -q . && echo CHANNEL_TOUCHED_FAIL || echo OK</automated>
+  </verify>
+  <done>`lib_impl.rs` exports `ReplySender`; `channel.rs` is unmodified (git diff empty).</done>
+</task>
+
+<task type="execute">
+  <name>Task 2: Add make_test_fs + CaptureSender test-support module</name>
+  <files>crates/fuse/src/test_support.rs, crates/fuse/src/lib.rs</files>
+  <action>
+Create `crates/fuse/src/test_support.rs` gated `#![cfg(all(test, feature = "fuse"))]` (or wrap the module declaration in lib.rs with that cfg). Add `mod test_support;` to `crates/fuse/src/lib.rs` under the same `#[cfg(all(test, feature = "fuse"))]` gate so it compiles only during fuse-feature test builds.
+
+The module provides three items, following the recipe in RESEARCH.md "make_test_fs() recipe" (lines 462-518) and "Capturing ReplySender" (lines 540-563):
+
+1. `pub(crate) fn make_test_fs() -> CipherBoxFS` — build the full 29-field struct literal exactly per the recipe. Anchor field names to the real struct literal at apps/desktop/src-tauri/src/fuse/mod.rs:267-291 and the struct def at crates/fuse/src/lib.rs:665-702. Critical field rules from RESEARCH.md:521-536:
+   - `journal_dir` is a per-test UNIQUE subdir under temp_dir using `std::process::id()` PLUS a per-test unique suffix (atomic counter or nanos), created with `create_dir_all` BEFORE `WriteQueue::new` (queue.rs does not create it). Mirror the existing pattern at lib.rs:2106. NEVER point at `default_journal_dir()` (Threat T-46-04).
+   - `public_key`: accept a parameter or expose a `make_test_fs_with_keypair(pubkey, privkey)` variant for builder tests that wrap keys — a 33-byte zero vec is NOT a valid secp256k1 curve point. Default `make_test_fs()` may use zeros for metadata-only handler tests (getattr/access/lookup/unlink/rmdir/rename/flush/xattr) that never call `wrap_key`.
+   - `rt: tokio::runtime::Handle::current()` requires callers be `#[tokio::test]`.
+   - Override the root inode (ROOT_INO = 1, auto-created by InodeTable::new) via `get_mut(ROOT_INO)` to inject `ipns_name: Some("k51test-root")` and `ipns_private_key: Some(...)`, matching mount glue at mod.rs:138-143.
+   - `api`: `Arc::new(ApiClient::new("http://127.0.0.1:1"))` — unroutable so any accidental detached upload thread fails fast.
+
+2. `pub(crate) struct CaptureSender(pub Arc<Mutex<Vec<u8>>>)` with `impl fuser::ReplySender for CaptureSender` implementing only `fn send(&self, data: &[IoSlice<'_>]) -> std::io::Result<()>` by extending the buffer with each slice (RESEARCH.md:545-554). Derive `Clone`.
+
+3. `pub(crate) fn reply_error_code(captured: &Arc<Mutex<Vec<u8>>>) -> i32` reading the fuse_out_header error field at byte offset 4 (`i32::from_le_bytes([buf[4..8]])`); wire format is `len:u32 LE | error:i32 LE | unique:u64 LE`, 16 bytes total, error == 0 == success (RESEARCH.md:556-563, anchored to ll/fuse_abi.rs:932-936). Assert `buf.len() >= 16`.
+
+Add a `pub(crate) fn make_isolated_journal_dir() -> std::path::PathBuf` returning the same unique-per-test dir so other plans' tests can reuse the isolation pattern. Also provide a cleanup helper or document that tests `remove_dir_all` their dir at end. DO NOT introduce any raw plaintext keys into the journal (Threat T-46-01) — the harness only constructs in-memory state.
+  </action>
+  <verify>
+    <automated>cd /Users/myankelev/Code/random/cipher-box && cargo build -p cipherbox-fuse --features fuse --tests 2>&1 | tail -5 && grep -q "impl fuser::ReplySender for CaptureSender" crates/fuse/src/test_support.rs && grep -q "WriteQueue::new" crates/fuse/src/test_support.rs && echo OK</automated>
+  </verify>
+  <done>Test build compiles with the new module; `CaptureSender` implements `fuser::ReplySender`; `make_test_fs` builds a `WriteQueue` against a per-test isolated dir.</done>
+</task>
+
+<task type="execute" tdd="true">
+  <name>Task 3: Sample handler tests + journal_helpers builder round-trip tests</name>
+  <files>crates/fuse/src/lib.rs, crates/fuse/src/journal_helpers.rs</files>
+  <behavior>
+    - getattr_returns_ok_for_root: `handle_getattr(&mut fs, ROOT_INO, reply)` produces a captured reply with `reply_error_code == 0`.
+    - flush_returns_ok: `handle_flush` replies `error == 0` (no-op durability lives on release).
+    - build_upload_journal_entry round-trip: with a REAL EC keypair, builder returns a `JournalEntry` whose `JournalOp::UploadFile.ciphertext_b64` is non-empty and decodes; wrapped key fields are present and ECIES-wrapped (never raw).
+    - build_mkdir_journal_entry round-trip: builder returns a valid mkdir entry referencing the new child.
+  </behavior>
+  <action>
+Add a `#[cfg(all(test, feature = "fuse"))]` test module (or extend the existing one) with two sample `#[tokio::test]` handler tests proving the harness works, using the CaptureSender pattern from RESEARCH.md:566-577:
+
+  - `getattr_returns_ok_for_root` — `<ReplyAttr as Reply>::new(1, CaptureSender(cap.clone()))`, call `crate::read_ops::implementation::handle_getattr(&mut fs, crate::inode::ROOT_INO, reply)`, assert `reply_error_code(&cap) == 0`.
+  - `flush_returns_ok` — same pattern against `handle_flush` (read_ops.rs:978), assert `error == 0`. (This test also satisfies the REQ-2 flush-no-op verification consumed by Plan 04.)
+
+Then add the journal_helpers builder tests. Per RESEARCH.md:588-593 the free helpers (`generate_entry_id`, `current_unix_ms`, `wrap_key_to_hex`) are module-private — test them via the existing `#[cfg(test)] mod tests` at journal_helpers.rs:486-493 OR make them `pub(crate)` and test from lib.rs. Prefer testing in journal_helpers.rs to avoid widening visibility.
+
+  - `build_upload_journal_entry` (journal_helpers.rs:128) and `build_mkdir_journal_entry` (journal_helpers.rs:378): build via `make_test_fs_with_keypair` seeded with a REAL keypair from `ecies` (dev-dep already present at crates/fuse/Cargo.toml:41) — e.g. generate a secp256k1 secret, derive the 33-byte compressed public key — because `wrap_key` (journal_helpers.rs:150,281,295) requires a valid curve point (Assumption A1). Assert the returned entry's `ciphertext_b64` is non-empty and base64-decodes, and that wrapped key material is present (proving keys are ECIES-wrapped, not raw — Threat T-46-02 / V6).
+
+Run ONLY the named tests during development (RAM constraint): never `cargo test` with no filter. Each test cleans its journal dir at the end. Commit with `test(fuse): add handler harness and journal_helpers builder tests` (no parentheses in the subject description, per commitlint custom rule).
+  </action>
+  <verify>
+    <automated>cd /Users/myankelev/Code/random/cipher-box && cargo test -p cipherbox-fuse --features fuse getattr_returns_ok_for_root 2>&1 | tail -5 && cargo test -p cipherbox-fuse --features fuse flush_returns_ok 2>&1 | tail -5 && cargo test -p cipherbox-fuse --features fuse build_upload_journal_entry 2>&1 | tail -5</automated>
+  </verify>
+  <done>`getattr_returns_ok_for_root`, `flush_returns_ok`, and the `build_upload_journal_entry`/`build_mkdir_journal_entry` round-trip tests pass; builder tests use a real EC keypair and assert ciphertext is journaled with keys ECIES-wrapped.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+
+## Trust Boundaries
+
+| Boundary | Description |
+| -------- | ----------- |
+| test threads → on-disk journal dir | Detached upload threads (127.0.0.1:1) and builders write journal files; must stay in isolated temp dirs |
+| in-memory key material → journal file | Builders wrap keys before journalling; tests must not introduce raw keys |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+| --------- | -------- | --------- | ----------- | --------------- |
+| T-46-01 | Information Disclosure | test_support.rs / builder tests | mitigate | Tests reference `ciphertext_b64` only; never construct raw plaintext keys in journal entries (preserve invariant journal_helpers.rs:14-17,286) |
+| T-46-02 | Information Disclosure | journal_helpers builder tests | mitigate | Use a REAL EC keypair so `wrap_key` ECIES-wraps key material; assert wrapped fields present, never raw bytes (journal_helpers.rs:18,477) |
+| T-46-04 | Tampering | make_test_fs journal dir | mitigate | Per-test isolated temp dir keyed by `process::id()` + unique suffix; NEVER `default_journal_dir()`; cleaned at end (RESEARCH.md Pitfall 5) |
+| T-46-SC | Tampering | cargo/no new deps | accept | No new package installs — only the existing `ecies` dev-dep is used; no legitimacy gate needed |
+
+</threat_model>
+
+<verification>
+
+- `cargo build -p cipherbox-fuse --features fuse --tests` compiles with the new module.
+- `git diff apps/desktop/src-tauri/vendor/fuser/src/channel.rs` is EMPTY (FUSE-T patch untouched).
+- Sample handler + builder tests pass when run individually.
+
+</verification>
+
+<success_criteria>
+
+- Vendored fuser re-exports `ReplySender` (one added `pub use` line); `channel.rs` untouched.
+- `make_test_fs()`, `CaptureSender`, `reply_error_code` available to test code under `cfg(all(test, feature = "fuse"))`.
+- `getattr_returns_ok_for_root`, `flush_returns_ok`, and journal_helpers builder round-trip tests pass.
+- Builder tests use a real EC keypair; no raw keys or plaintext enter the journal.
+- Every test uses an isolated per-test journal dir.
+
+</success_criteria>
+
+<output>
+Create `.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-01-SUMMARY.md
+++ b/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-01-SUMMARY.md
@@ -1,0 +1,90 @@
+---
+phase: 46-desktop-fuse-data-loss-bugs-replay-hardening
+plan: 01
+subsystem: desktop-fuse
+tags: [fuse, testing, harness, journal, vendored-fuser]
+requires: []
+provides:
+  - fuser::ReplySender re-export from vendored fuser
+  - crate::test_support harness (make_test_fs / make_test_fs_with_keypair / CaptureSender / reply_error_code / make_isolated_journal_dir)
+  - sample handler tests and journal_helpers builder round-trip tests
+affects:
+  - apps/desktop/src-tauri/vendor/fuser/src/lib_impl.rs
+  - crates/fuse/src/lib.rs
+  - crates/fuse/src/test_support.rs
+  - crates/fuse/src/journal_helpers.rs
+tech-stack:
+  added: []
+  patterns:
+    - per-test isolated journal dir keyed by process id plus monotonic counter
+    - CaptureSender decodes the 16-byte fuse_out_header error field at offset 4
+    - real secp256k1 keypair via ecies dev-dep for ECIES wrap round-trips
+key-files:
+  created:
+    - crates/fuse/src/test_support.rs
+  modified:
+    - apps/desktop/src-tauri/vendor/fuser/src/lib_impl.rs
+    - crates/fuse/src/lib.rs
+    - crates/fuse/src/journal_helpers.rs
+decisions:
+  - Test modules feature-gated on fuse so crate::test_support is in scope
+  - Upload builder test uses an absent inode (ino 4242) to exercise the new-file path
+  - Mkdir builder test calls the builder with a fresh child ino without inserting it; the builder only reads the parent
+metrics:
+  duration: ~12m
+  completed: 2026-06-15
+---
+
+# Phase 46 Plan 01: FUSE Handler Test Harness Summary
+
+REQ-6 test infrastructure that unblocks unit testing of FUSE handlers and journal builders: a one-line vendored-fuser `ReplySender` re-export, a `make_test_fs()` / `CaptureSender` harness, and sample handler plus journal-builder round-trip tests using a real EC keypair.
+
+## What Was Built
+
+### Task 1: vendored fuser ReplySender re-export
+
+Added exactly one line `pub use reply::ReplySender;` after line 28 of `apps/desktop/src-tauri/vendor/fuser/src/lib_impl.rs`. This surfaces only the trait name; `mod reply;` stays private. The FUSE-T `channel.rs` patch was not touched (verified empty diff across all three commits).
+
+### Task 2: test_support harness module
+
+Created `crates/fuse/src/test_support.rs` gated `#[cfg(all(test, feature = "fuse"))]`, declared as a private module in `lib.rs` under the same gate. Provides:
+
+- `make_test_fs()` and `make_test_fs_with_keypair(private_key, public_key)` — build the full 29-field `CipherBoxFS` literal with a per-test isolated journal dir created before `WriteQueue::new`. The root inode is overridden via `get_mut(ROOT_INO)` to carry `ipns_name` and `ipns_private_key`. The API client points at `http://127.0.0.1:1` so any accidental detached upload thread fails fast.
+- `make_isolated_journal_dir()` — unique dir keyed by `process::id()` plus a monotonic `AtomicU64` counter; never `default_journal_dir()` (T-46-04).
+- `CaptureSender(Arc<Mutex<Vec<u8>>>)` implementing `fuser::ReplySender::send` by extending the shared buffer.
+- `reply_error_code()` decoding the `fuse_out_header` error field at byte offset 4.
+
+### Task 3: sample handler and builder tests
+
+- `handler_harness_tests::getattr_returns_ok_for_root` — `handle_getattr` on root replies error == 0.
+- `handler_harness_tests::flush_returns_ok` — `handle_flush` replies error == 0 (also satisfies the REQ-2 flush-no-op check consumed by Plan 04).
+- `journal_helpers::tests::build_upload_journal_entry_round_trips` — with a real keypair, asserts `ciphertext_b64` is non-empty, base64-decodes, differs from plaintext, and `wrapped_key_hex` is non-empty valid hex.
+- `journal_helpers::tests::build_mkdir_journal_entry_round_trips` — asserts the entry references the new child and both child and parent IPNS keys are ECIES-wrapped hex.
+
+## Test Results
+
+All four named tests pass when run individually under the RAM constraint:
+
+```text
+handler_harness_tests::getattr_returns_ok_for_root ... ok
+handler_harness_tests::flush_returns_ok ... ok
+journal_helpers::tests::build_upload_journal_entry_round_trips ... ok
+journal_helpers::tests::build_mkdir_journal_entry_round_trips ... ok
+```
+
+`cargo build -p cipherbox-fuse --features fuse --tests` compiles. No bare `cargo test` was run.
+
+## Deviations from Plan
+
+None of substance. The `CipherBoxFS` struct matched the RESEARCH.md recipe exactly (29 fields, no drift). Two harness conveniences not spelled out in the recipe but consistent with it:
+
+- Root `ipns_private_key` is seeded with `vec![7u8; 32]` rather than zeros so `build_folder_metadata` returns a usable root key for the mkdir builder test.
+- The upload builder test drives the new-file path via an absent inode rather than constructing a full `File` inode, keeping the test minimal.
+
+## Threat Model Compliance
+
+- T-46-01: tests reference `ciphertext_b64` only and assert journalled bytes differ from plaintext; no raw plaintext keys constructed.
+- T-46-02: builder tests use a real secp256k1 keypair so `wrap_key` ECIES-wraps key material; assertions confirm wrapped fields are present and valid hex, never raw.
+- T-46-04: every harness instance uses an isolated per-test journal dir keyed by process id plus a monotonic counter.
+
+## Self-Check: PASTE_BELOW

--- a/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-02-PLAN.md
+++ b/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-02-PLAN.md
@@ -1,0 +1,187 @@
+---
+phase: 46-desktop-fuse-data-loss-bugs-replay-hardening
+plan: 02
+type: execute
+wave: 2
+depends_on: ["46-01"]
+files_modified:
+  - crates/fuse/src/platform/linux.rs
+  - apps/desktop/src-tauri/src/fuse/mod.rs
+autonomous: false
+requirements: [REQ-3]
+must_haves:
+  truths:
+    - "A disconnected/stale Linux FUSE mount at the mount path is detected without relying on path.exists()"
+    - "On a stale mount, the app unmounts it (fusermount3 -u, then lazy -z fallback) before creating/cleaning the mount point"
+    - "create_dir_all EEXIST is mapped to recover-then-retry-once instead of a user-facing 'Failed to create mount point' error"
+    - "macOS and Windows mount paths are unchanged"
+  artifacts:
+    - path: "crates/fuse/src/platform/linux.rs"
+      provides: "recover_stale_mount + /proc/self/mountinfo parser"
+      contains: "pub fn recover_stale_mount"
+    - path: "apps/desktop/src-tauri/src/fuse/mod.rs"
+      provides: "Linux-only stale-mount recovery call before create_dir_all decision"
+      contains: "recover_stale_mount"
+  key_links:
+    - from: "apps/desktop/src-tauri/src/fuse/mod.rs"
+      to: "crates/fuse/src/platform/linux.rs::recover_stale_mount"
+      via: "cfg(target_os = linux) call before create_dir_all"
+      pattern: "recover_stale_mount"
+    - from: "recover_stale_mount"
+      to: "fusermount3 -z"
+      via: "lazy unmount fallback for disconnected mount"
+      pattern: "\\-z"
+---
+
+<objective>
+Add Linux-only stale/disconnected FUSE mount auto-recovery on startup (REQ-3) so a crash that leaves `~/CipherBox` as a disconnected mount no longer surfaces "Failed to create mount point" (EEXIST) and blocks remount.
+
+Root cause (RESEARCH.md "Requirement 3", lines 195-198): a disconnected FUSE mount makes `stat()` return ENOTCONN, so `mount_path.exists()` returns false → the code takes the `create_dir_all` branch → the dirent still exists → EEXIST (os error 17) → user-facing error. Linux-only: macOS FUSE-T leaves a normal dir; Windows uses a different path.
+
+Targeted minimal change per RESEARCH.md:204-225:
+
+1. New `pub fn recover_stale_mount(mount_path: &Path)` in `crates/fuse/src/platform/linux.rs` next to `unmount_filesystem`, using a `/proc/self/mountinfo` parse for authoritative stale detection (NOT `exists()`), then `fusermount3 -u` with `-z` lazy fallback.
+2. Call it from `mount_filesystem` under `#[cfg(target_os = "linux")]` just after the `is_symlink` guard (mod.rs:91), before the `exists()`/`create_dir_all` decision.
+3. Belt-and-suspenders: map `create_dir_all`'s `ErrorKind::AlreadyExists` (EEXIST) to "attempt unmount, then retry once".
+
+Purpose: close the Linux stale-mount data-availability bug; the vault must remount cleanly after a crash. macOS/Windows paths untouched (RESEARCH.md:228-232).
+
+Output: `recover_stale_mount` + mountinfo parser in linux.rs, the Linux-gated wiring in mod.rs, pure unit tests for the parser and the EEXIST-recover decision.
+</objective>
+
+<execution_context>
+@/Users/myankelev/Code/random/cipher-box/.claude/gsd-core/workflows/execute-plan.md
+@/Users/myankelev/Code/random/cipher-box/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-RESEARCH.md
+@.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-VALIDATION.md
+@crates/fuse/src/platform/linux.rs
+@apps/desktop/src-tauri/src/fuse/mod.rs
+@apps/desktop/CLAUDE.md
+</context>
+
+<tasks>
+
+<task type="execute" tdd="true">
+  <name>Task 1: recover_stale_mount + mountinfo parser in linux.rs (TDD)</name>
+  <files>crates/fuse/src/platform/linux.rs</files>
+  <behavior>
+    - mountinfo_detects_stale (parser): given fixture `/proc/self/mountinfo` lines where the mount path appears as a mountpoint → returns true; absent → false.
+    - mountinfo path-with-spaces: a mount path containing a space (escaped `\040` in mountinfo) is still detected correctly.
+    - The parser is a pure function over a `&str` of mountinfo content + the target path — no `/proc` read in the unit test.
+  </behavior>
+  <action>
+Write the parser test FIRST (RED). Add a pure helper, e.g. `pub(crate) fn mountinfo_contains_mountpoint(mountinfo: &str, mount_path: &Path) -> bool`, that scans each mountinfo line and checks whether the mount-point field (field index 4, space-separated) equals `mount_path`. CRITICAL per RESEARCH.md:229-231: mountinfo escapes spaces as `\040` (octal) — un-escape `\040`→space (and tolerate other octal escapes) before comparing, OR use a tolerant comparison; a brittle exact substring will miss spaced paths. Field 5 (the mount point) is the canonical one; field-index parse is more correct than a raw substring but a tolerant approach is acceptable as long as the spaced-path test passes.
+
+Then add `pub fn recover_stale_mount(mount_path: &Path)` (RESEARCH.md:219-224):
+  1. Read `/proc/self/mountinfo` (std::fs::read_to_string). On read error, treat as "not stale" and return Ok(()) — do not block mount.
+  2. If `mountinfo_contains_mountpoint` is true (stale mount present), run `fusermount3 -u <path>`; on non-success run `fusermount3 -z -u <path>` (lazy) — the lazy `-z` is the new fallback the existing `unmount_filesystem` cascade lacks (RESEARCH.md:201-202, "Don't Hand-Roll": extend the cascade with `-z`). Log at info level. Return Ok(()) regardless so the caller's normal `exists()`/clean-stale path runs next; `-z` may leave the old session detaching in the background, which is acceptable since we immediately mount fresh at the same path (RESEARCH.md:230-232).
+
+Reuse `std::process::Command` like the existing `unmount_filesystem` (linux.rs:13-36). This function is Linux-only; it lives in `platform/linux.rs` which is already cfg-gated for Linux. Keep the helper `pub(crate)` and the parser pure so it unit-tests without root.
+
+Commit `feat(fuse): add Linux stale-mount recovery and mountinfo parser`.
+  </action>
+  <verify>
+    <automated>cd /Users/myankelev/Code/random/cipher-box && cargo test -p cipherbox-fuse --features fuse mountinfo_detects_stale 2>&1 | tail -6 && grep -q "pub fn recover_stale_mount" crates/fuse/src/platform/linux.rs && grep -q '"-z"' crates/fuse/src/platform/linux.rs && echo OK</automated>
+  </verify>
+  <done>`mountinfo_detects_stale` (including the spaced-path case) passes; `recover_stale_mount` exists and uses a `fusermount3 -z` lazy fallback.</done>
+</task>
+
+<task type="execute" tdd="true">
+  <name>Task 2: Wire recovery into mount_filesystem + EEXIST recover-then-retry (TDD on decision logic)</name>
+  <files>apps/desktop/src-tauri/src/fuse/mod.rs, crates/fuse/src/platform/linux.rs</files>
+  <behavior>
+    - eexist_triggers_recovery (decision logic, pure): given a `create_dir_all` result that is `Err(ErrorKind::AlreadyExists)`, the decision is "attempt unmount, then retry once"; any other Err propagates; Ok proceeds. Model the unmount as an injected closure/`bool` so the test needs no real mount.
+    - The recovery call is gated `#[cfg(target_os = "linux")]` and is a no-op on macOS/Windows builds.
+  </behavior>
+  <action>
+First add a pure decision helper in linux.rs (or a small `eexist_recovery_decision` fn) testable with a mock unmount closure per RESEARCH.md:238 — e.g. `fn should_recover_then_retry(err_kind: std::io::ErrorKind) -> bool` returning true only for `AlreadyExists`. Write `eexist_triggers_recovery` (RED) asserting AlreadyExists → true, other kinds → false.
+
+Then wire into `mount_filesystem` (apps/desktop/src-tauri/src/fuse/mod.rs:89-110). Insert under `#[cfg(target_os = "linux")]` immediately after the `is_symlink` guard at mod.rs:91, BEFORE the `if !mount_path.exists()` block:
+
+  #[cfg(target_os = "linux")]
+  cipherbox_fuse::platform::linux::recover_stale_mount(&mount_path);
+
+(Use the actual crate path the desktop crate imports the fuse platform module by — confirm the existing `unmount_filesystem` call site in mod.rs:332 for the correct path and mirror it.)
+
+Then make the `create_dir_all` at mod.rs:94 EEXIST-tolerant: on `Err` whose `kind() == ErrorKind::AlreadyExists`, call `recover_stale_mount` again (or `fusermount3` unmount) and retry `create_dir_all` ONCE before mapping to the user-facing error. Keep the non-EEXIST error mapping unchanged. Do NOT alter the macOS branch (mod.rs:113+ `.metadata_never_index`), the unmount dispatch, or any mount-option `cfg(target_os)` arms — this change is strictly additive on the Linux path (RESEARCH.md:228 "no change to macOS/Windows paths").
+
+Optionally soften the notification copy (RESEARCH.md:225) — low priority, only if trivial.
+
+Commit `fix(fuse): auto-recover stale Linux FUSE mount on startup`.
+  </action>
+  <verify>
+    <automated>cd /Users/myankelev/Code/random/cipher-box && cargo test -p cipherbox-fuse --features fuse eexist_triggers_recovery 2>&1 | tail -6 && grep -q "recover_stale_mount" apps/desktop/src-tauri/src/fuse/mod.rs && grep -q 'cfg(target_os = "linux")' apps/desktop/src-tauri/src/fuse/mod.rs && echo OK</automated>
+  </verify>
+  <done>`eexist_triggers_recovery` passes; `mount_filesystem` calls `recover_stale_mount` under a Linux cfg before create_dir_all and retries once on EEXIST; macOS/Windows arms unchanged.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 3: Manual Linux remount-after-crash verification</name>
+  <files>apps/desktop/src-tauri/src/fuse/mod.rs</files>
+  <action>
+This is a manual verification gate — the real disconnected-mount remount cannot be unit-tested (RESEARCH.md:240-241, VALIDATION.md "Manual-Only Verifications"). No code is written in this task; it confirms the Task 1 + Task 2 changes work against a live Linux FUSE mount. The executor presents the `<how-to-verify>` steps and waits for approval.
+  </action>
+  <what-built>Linux stale-mount auto-recovery: `recover_stale_mount` (mountinfo detection + `fusermount3 -u`/`-z` lazy unmount) wired into `mount_filesystem` with EEXIST recover-then-retry. macOS/Windows paths untouched. Pure parser and decision logic are unit-tested; the real disconnected-mount remount cannot be unit-tested.</what-built>
+  <how-to-verify>
+On a Linux host with libfuse3 (use the headless desktop FUSE UAT recipe — `--dev-key` + local stack, see project memory "Headless desktop FUSE UAT recipe"):
+1. Launch the desktop app; confirm the vault mounts at `~/CipherBox`.
+2. SIGKILL the app mid-session: `ps aux | grep cipherbox-desktop | grep -v grep | awk '{print $2}' | xargs kill -9` — this leaves a disconnected/stale mount.
+3. Confirm the mount is stale: `ls ~/CipherBox` returns a "Transport endpoint is not connected" (ENOTCONN) error.
+4. Relaunch the app with the same dev key.
+5. EXPECTED: the vault remounts cleanly, `ls ~/CipherBox` works, and NO "Failed to create mount point" notification appears.
+  </how-to-verify>
+  <verify>
+    <human-check>Vault remounts cleanly after SIGKILL with no "Failed to create mount point" notification.</human-check>
+  </verify>
+  <done>Reviewer confirms the vault remounts cleanly on Linux after a SIGKILL-induced stale mount, with no mount-failed notification.</done>
+  <resume-signal>Type "approved" if the vault remounts cleanly with no mount-failed notification, or describe what happened (e.g. notification text, mount still stale).</resume-signal>
+</task>
+
+</tasks>
+
+<threat_model>
+
+## Trust Boundaries
+
+| Boundary | Description |
+| -------- | ----------- |
+| OS mount table → app startup | A stale kernel FUSE mount at the mount path; recovery shells out to fusermount3 |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+| --------- | -------- | --------- | ----------- | --------------- |
+| T-46-03 | Denial of Service | mount_filesystem on Linux | mitigate | Detect stale mount via /proc/self/mountinfo (not exists() which lies on ENOTCONN), unmount with -u then lazy -z, retry create_dir_all once — restores mount availability after crash |
+| T-46-05 | Tampering | recover_stale_mount shelling to fusermount3 | accept | Fixed argv (`fusermount3`, `-u`/`-z`, the configured mount path); no user-controlled command string; mount path is app-derived (mount_point()) |
+| T-46-SC | Tampering | cargo/no new deps | accept | No package installs; reuses existing std::process + libc; no legitimacy gate needed |
+
+</threat_model>
+
+<verification>
+
+- `cargo test -p cipherbox-fuse --features fuse mountinfo_detects_stale` and `eexist_triggers_recovery` pass (pure, no root).
+- `recover_stale_mount` present in linux.rs with a `-z` lazy fallback; called from mod.rs under `cfg(target_os = "linux")`.
+- macOS/Windows mount arms in mod.rs are byte-identical to before (review diff — only the Linux-gated insert and the EEXIST retry should appear).
+- Manual Linux remount-after-SIGKILL checkpoint approved.
+
+</verification>
+
+<success_criteria>
+
+- Stale Linux mount is detected via mountinfo parse, not path.exists().
+- Stale mount is unmounted (`fusermount3 -u`, then lazy `-z`) before the create/clean decision.
+- EEXIST on create_dir_all triggers recover-then-retry-once, not an immediate error.
+- macOS and Windows mount code paths are unchanged.
+- Linux remount-after-crash verified manually with no mount-failed notification.
+
+</success_criteria>
+
+<output>
+Create `.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-02-SUMMARY.md
+++ b/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-02-SUMMARY.md
@@ -1,0 +1,106 @@
+---
+phase: 46-desktop-fuse-data-loss-bugs-replay-hardening
+plan: 02
+subsystem: desktop-fuse
+tags: [fuse, linux, mount, recovery, mountinfo, eexist]
+requires: [46-01]
+provides:
+  - recover_stale_mount Linux stale/disconnected mount auto-recovery (REQ-3)
+  - mountinfo_contains_mountpoint pure /proc/self/mountinfo parser
+  - should_recover_then_retry EEXIST decision helper
+  - mount_filesystem Linux-gated recovery call + EEXIST recover-then-retry-once
+affects:
+  - crates/fuse/src/platform/linux.rs
+  - apps/desktop/src-tauri/src/fuse/mod.rs
+tech-stack:
+  added: []
+  patterns:
+    - mountinfo field-index parse (field 4 mount point) with octal escape un-escaping
+    - fusermount3 -u with lazy -z fallback layered on the existing unmount cascade
+    - Linux-only cfg gating keeps macOS/Windows mount paths byte-identical
+key-files:
+  created:
+    - .planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-02-SUMMARY.md
+  modified:
+    - crates/fuse/src/platform/linux.rs
+    - apps/desktop/src-tauri/src/fuse/mod.rs
+decisions:
+  - Authoritative stale detection via /proc/self/mountinfo, never path.exists() (lies with ENOTCONN)
+  - Lazy fusermount3 -z fallback added because the existing unmount cascade lacks it
+  - recover_stale_mount is best-effort and returns unit so the caller always proceeds to the clean-stale path
+  - platform module was already pub; no visibility widening needed
+metrics:
+  duration: ~12m
+  completed: 2026-06-15
+---
+
+# Phase 46 Plan 02: Linux Stale-Mount Auto-Recovery Summary
+
+REQ-3: a crash that leaves `~/CipherBox` as a disconnected FUSE mount made
+`stat()` return ENOTCONN, so `mount_path.exists()` returned false, the code took
+the `create_dir_all` branch, and the leftover dirent produced EEXIST (os error
+17) surfaced as a user-facing "Failed to create mount point" error that blocked
+remount. This plan adds Linux-only auto-recovery so the vault remounts cleanly.
+
+## What Was Built
+
+### crates/fuse/src/platform/linux.rs
+
+- `mountinfo_contains_mountpoint(mountinfo: &str, mount_path: &Path) -> bool` — a
+  pure helper that scans each `/proc/self/mountinfo` line, takes the mount-point
+  field (space-separated index 4), un-escapes octal escapes (`\040` to space and
+  general `\NNN`), and compares to the target path. Pure over a `&str`, so it
+  unit-tests without `/proc` or root.
+- `recover_stale_mount(mount_path: &Path)` — reads `/proc/self/mountinfo` (on read
+  error logs and returns, never blocking the mount); if the path is a current
+  mount point, runs `fusermount3 -u <path>`, and on non-success falls back to the
+  lazy `fusermount3 -z -u <path>`. Best-effort: returns unit so the caller always
+  proceeds to its normal clean-stale path.
+- `should_recover_then_retry(err_kind) -> bool` — pure decision helper returning
+  true only for `ErrorKind::AlreadyExists`.
+
+### apps/desktop/src-tauri/src/fuse/mod.rs
+
+- Inserted `#[cfg(target_os = "linux")] cipherbox_fuse::platform::linux::recover_stale_mount(&mount_path);`
+  immediately after the `is_symlink` guard and before the `exists()`/`create_dir_all`
+  decision, mirroring the existing `unmount_filesystem` crate path.
+- Made `create_dir_all` EEXIST-tolerant on Linux: when the error kind is
+  `AlreadyExists`, it calls `recover_stale_mount` again and retries `create_dir_all`
+  once before mapping to the user-facing error. Non-EEXIST errors map unchanged.
+  The macOS `.metadata_never_index` block, the clean-stale `else` branch, and all
+  mount-option cfg arms are untouched.
+
+## Test Results
+
+The named tests live in `platform::linux`, which compiles only on
+`target_os = "linux"`. On the macOS dev host they filter out; the logic was
+validated by extracting byte-identical function bodies and running them under
+`rustc --test`:
+
+```text
+test eexist_triggers_recovery ... ok
+test mountinfo_detects_stale ... ok
+test mountinfo_detects_stale_with_spaced_path ... ok
+test result: ok. 3 passed; 0 failed
+```
+
+`cargo check -p cipherbox-desktop --features fuse` finished clean. The in-crate
+`cargo test` filters run natively on the CI `cargo-linux` job (ubuntu-22.04 with
+libfuse3-dev).
+
+## Manual Verification Required
+
+Task 3 is a blocking human-verify gate: the real disconnected-mount remount
+cannot be unit-tested. On a Linux host, SIGKILL the desktop app mid-session to
+leave a stale mount, then relaunch and confirm the vault remounts cleanly with no
+"Failed to create mount point" notification. See 46-02-PLAN.md Task 3 for the
+full recipe.
+
+## Threat Model Compliance
+
+- T-46-03 (DoS): stale mount detected via mountinfo (not the lying `exists()`),
+  unmounted with `-u` then lazy `-z`, with a single EEXIST retry — restores mount
+  availability after a crash.
+- T-46-05 (Tampering): `recover_stale_mount` shells `fusermount3` with a fixed
+  argv and the app-derived `mount_point()` path; no user-controlled command
+  string.

--- a/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-03-PLAN.md
+++ b/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-03-PLAN.md
@@ -1,0 +1,184 @@
+---
+phase: 46-desktop-fuse-data-loss-bugs-replay-hardening
+plan: 03
+type: execute
+wave: 2
+depends_on: ["46-01"]
+files_modified:
+  - crates/fuse/src/lib.rs
+autonomous: true
+requirements: [REQ-4, REQ-5]
+must_haves:
+  truths:
+    - "A legacy UploadFile replay entry with no per-file IPNS name is parked (retained), never published as an empty FilePointer"
+    - "Replay classification uses a strict cache-bypassing resolve, so a transient (non-404) IPNS resolve failure retains the entry instead of advancing off a stale cached sequence"
+    - "A genuine 404 still classifies NotFound → first-publish; the live publish path's cache-resilient resolve is unchanged"
+    - "classify_resolve_outcome and replay_for_vault_does_not_touch_failed_entries do not regress"
+  artifacts:
+    - path: "crates/fuse/src/lib.rs"
+      provides: "early park-return for None-name replay entries + resolve_sequence_strict + strict call in resolve_ipns_for_replay"
+      contains: "resolve_sequence_strict"
+  key_links:
+    - from: "resolve_ipns_for_replay"
+      to: "PublishCoordinator::resolve_sequence_strict"
+      via: "strict resolve only on the replay classification path"
+      pattern: "resolve_sequence_strict"
+    - from: "replay_upload_entry"
+      to: "record_failure (park)"
+      via: "early Err return when file_meta_ipns_name.is_none()"
+      pattern: "file_meta_ipns_name.is_none\\(\\)"
+---
+
+<objective>
+Two replay-path hardening fixes from the PR #491 follow-ups (RESEARCH.md "Requirement 4" and "Requirement 5"). Both are genuine pre-existing bugs (not already-fixed code) and both are minimal, surgical changes in `crates/fuse/src/lib.rs`.
+
+REQ-4 — Park legacy empty-name replay entries (RESEARCH.md:269-299): `replay_upload_entry` currently builds an empty `FilePointer` (id `"replay-"`, `file_meta_ipns_name ""`) for legacy `None`-name entries and publishes it, then `replay_for_vault` removes the entry as "successfully replayed". Empty-name pointers also collide in `merge_folder_children` (all key on `""`). Fix: early-return `Err` for the `None`-name case so the entry routes through `record_failure` and is retained/parked (D-09), never publishing an empty pointer. Recommendation is PARK (not mint-fresh-IPNS) for lowest blast radius.
+
+REQ-5 — Strict cache-bypassing resolve in replay classification (RESEARCH.md:344-387): `resolve_sequence` falls back to the cache on resolve `Err`, so a transient network blip with a cached value returns `Ok(cached)` → replay publishes at `cached+1` instead of parking. Fix: add a NEW `resolve_sequence_strict` that errs on ANY resolve failure (never cache fallback) and call it ONLY from `resolve_ipns_for_replay`. The LIVE publish path keeps `resolve_sequence` (it WANTS cache resilience — Pitfall 3, RESEARCH.md:703-708).
+
+Purpose: stop replay from publishing unresolvable empty pointers and from advancing IPNS sequence off stale cache during transient failures — both are crash-recovery correctness fixes that preserve D-09 parking semantics.
+
+Output: the early park-return, `resolve_sequence_strict`, the one-line call swap in `resolve_ipns_for_replay`, and characterization/unit tests. `classify_resolve_outcome` is UNCHANGED.
+</objective>
+
+<execution_context>
+@/Users/myankelev/Code/random/cipher-box/.claude/gsd-core/workflows/execute-plan.md
+@/Users/myankelev/Code/random/cipher-box/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-RESEARCH.md
+@.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-VALIDATION.md
+@crates/fuse/src/lib.rs
+@crates/fuse/src/error.rs
+@crates/sdk/src/queue.rs
+</context>
+
+<tasks>
+
+<task type="execute" tdd="true">
+  <name>Task 1: Park legacy None-name replay entries (REQ-4, TDD)</name>
+  <files>crates/fuse/src/lib.rs</files>
+  <behavior>
+    - legacy_empty_name_parks: a `JournalOp::UploadFile` with `file_meta_ipns_name: None` run through `replay_for_vault` against unroutable `http://127.0.0.1:1` is RETAINED, not removed — `load_all_for_vault().len() == 1` after replay (mirrors replay_for_vault_does_not_touch_failed_entries at lib.rs:2102).
+    - empty_name_merge_collision: two `FilePointer`s both with `file_meta_ipns_name: ""` collide to a single entry under `merge_folder_children` (pins the motivation; pure, no network).
+    - The Some-name (normal) path is NOT affected by the new Err branch.
+  </behavior>
+  <action>
+Write `legacy_empty_name_parks` (RED) first. Per RESEARCH.md:271-285, insert an early park-return in `replay_upload_entry` (crates/fuse/src/lib.rs:1828-2012). Place the check so the `None`-name entry never reaches Step 4's empty-FilePointer build. RESEARCH.md recommends inserting after Step 3 (after lib.rs:1984, before Step 4 at lib.rs:1986); per Pitfall 4 (RESEARCH.md:710-715) you MAY move it ABOVE Step 1 (lib.rs:1872, the ciphertext upload) to avoid re-pinning content each mount — pick one and document the choice in the SUMMARY. Either way the guard is:
+
+  // Park legacy entries with no per-file IPNS name rather than publishing an empty,
+  // unresolvable FilePointer (id "replay-", file_meta_ipns_name ""). Returning Err
+  // routes through record_failure → retained on disk; never marks the entry replayed.
+  // No fresh-IPNS minting — lowest risk, no new key material.
+  if file_meta_ipns_name.is_none() {
+      return Err(
+          "legacy UploadFile entry has no per-file IPNS name — parking (no empty FilePointer)"
+              .to_string(),
+      );
+  }
+
+Guard PRECISELY on `file_meta_ipns_name.is_none()` (RESEARCH.md:303-305) so the normal `Some`-name path is untouched. `replay_for_vault` already maps `Err` → `record_failure` (retain/park, lib.rs:1333-1351, queue.rs:283-303) and `Ok` → remove (lib.rs:1325-1332), so no change is needed there.
+
+DO NOT add a metadata migration / sweep for already-published empty-locator pointers — RESEARCH.md:295-299 and Assumption A5 say leave them and document as known residue (note it in the SUMMARY). Adding a sweep is out of scope.
+
+Then add `empty_name_merge_collision` as a pure `merge_folder_children` test (lib.rs:338) per VALIDATION.md, co-located with the existing `merge_folder_children_unions_new_and_existing` at lib.rs:2252.
+
+Use an isolated per-test journal dir (make_isolated_journal_dir from Plan 01, or the lib.rs:2106 pattern). Run ONLY the named tests. Commit `fix(fuse): park legacy empty file-meta-ipns replay entries`.
+  </action>
+  <verify>
+    <automated>cd /Users/myankelev/Code/random/cipher-box && cargo test -p cipherbox-fuse --features fuse legacy_empty_name_parks 2>&1 | tail -6 && cargo test -p cipherbox-fuse --features fuse empty_name_merge_collision 2>&1 | tail -6 && cargo test -p cipherbox-fuse --features fuse replay_for_vault_does_not_touch_failed_entries 2>&1 | tail -6</automated>
+  </verify>
+  <done>`legacy_empty_name_parks` and `empty_name_merge_collision` pass; the existing `replay_for_vault_does_not_touch_failed_entries` still passes (no regression); None-name entries are retained, not removed.</done>
+</task>
+
+<task type="execute" tdd="true">
+  <name>Task 2: resolve_sequence_strict + strict replay classification (REQ-5, TDD)</name>
+  <files>crates/fuse/src/lib.rs</files>
+  <behavior>
+    - strict_resolve_bypasses_cache: with a populated cache (seeded via `record_publish`) and an unroutable API (`http://127.0.0.1:1`), `resolve_sequence_strict` returns `Err` (cache present but bypassed) — unlike `resolve_sequence` which would return `Ok(cached)`.
+    - transient_failure_retains_entry: a replay against the unroutable API where the IPNS name has a cached sequence → `replay_for_vault` RETAINS the entry (len stays 1) instead of advancing off cache.
+    - classify_resolve_outcome_maps_resolve_results (existing, lib.rs:2058) still passes — classification logic is untouched.
+  </behavior>
+  <action>
+Add `pub async fn resolve_sequence_strict` to `PublishCoordinator`, immediately after `resolve_sequence` (crates/fuse/src/lib.rs:299), EXACTLY as specified in RESEARCH.md:353-370:
+
+  /// Strict resolve for replay classification: returns Err on ANY resolve failure,
+  /// never falling back to the cache. A genuine success still updates+returns the
+  /// max(resolved, cached) sequence so a subsequent confirmed publish advances correctly.
+  pub async fn resolve_sequence_strict(
+      &self,
+      api: &cipherbox_api_client::ApiClient,
+      ipns_name: &str,
+  ) -> Result<u64, String> {
+      let resp = cipherbox_api_client::ipns::resolve_ipns(api, ipns_name)
+          .await
+          .map_err(|e| format!("IPNS resolve failed for {}: {}", ipns_name, e))?;
+      let resolved = resp.sequence_number.parse::<u64>().unwrap_or(0);
+      let cached = self.get_cached(ipns_name).unwrap_or(0);
+      let seq = std::cmp::max(resolved, cached);
+      self.update_cache(ipns_name, seq);
+      Ok(seq)
+  }
+
+(Confirm the exact `resolve_ipns` return-type field names and `get_cached`/`update_cache` signatures against the existing `resolve_sequence` body at lib.rs:262-299; adapt if a field name differs but keep the strict-Err-on-failure semantics.)
+
+Then change the single call in `resolve_ipns_for_replay` (lib.rs:216) from `coordinator.resolve_sequence(...)` to `coordinator.resolve_sequence_strict(...)`:
+
+  classify_resolve_outcome(coordinator.resolve_sequence_strict(api, ipns_name).await)
+
+CRITICAL (Pitfall 3, RESEARCH.md:703-708): do NOT touch `resolve_sequence` itself and do NOT change its callers in the live publish path (`spawn_metadata_publish` at lib.rs:401, mkdir at write_ops.rs:629) — they rely on cache fallback during normal operation. Only `resolve_ipns_for_replay` switches to strict. `classify_resolve_outcome` (lib.rs:227) is unchanged, so the 404-substring contract and its test stay intact.
+
+Write `strict_resolve_bypasses_cache` (RED): seed the cache with `record_publish(ipns_name, N)` (lib.rs:301), point a fresh `PublishCoordinator` + `ApiClient::new("http://127.0.0.1:1")`, assert `resolve_sequence_strict(...).await.is_err()`. Add `transient_failure_retains_entry` as a `replay_for_vault` characterization (unroutable API, cached seq present, assert retained). Run ONLY named tests. Commit `fix(fuse): use strict cache-bypassing IPNS resolve in replay`.
+  </action>
+  <verify>
+    <automated>cd /Users/myankelev/Code/random/cipher-box && cargo test -p cipherbox-fuse --features fuse strict_resolve_bypasses_cache 2>&1 | tail -6 && cargo test -p cipherbox-fuse --features fuse transient_failure_retains_entry 2>&1 | tail -6 && cargo test -p cipherbox-fuse --features fuse classify_resolve_outcome_maps_resolve_results 2>&1 | tail -6</automated>
+  </verify>
+  <done>`resolve_sequence_strict` errs despite a seeded cache; transient failure retains the replay entry; `classify_resolve_outcome_maps_resolve_results` still passes; the live publish path's `resolve_sequence` is unmodified.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+
+## Trust Boundaries
+
+| Boundary | Description |
+| -------- | ----------- |
+| journal entry → IPNS publish | Replay decides remove-vs-retain and what sequence to publish at; a wrong decision can regress sequence or publish unresolvable pointers |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+| --------- | -------- | --------- | ----------- | --------------- |
+| T-46-06 | Tampering | resolve_ipns_for_replay / resolve_sequence_strict | mitigate | Strict resolve errs on any failure so a transient blip never advances IPNS sequence off a stale cached value; live-path cache resilience preserved (separate method) |
+| T-46-07 | Information Disclosure | replay_upload_entry empty FilePointer | mitigate | Park None-name entries instead of publishing a `"replay-"`/`""` pointer that is unresolvable and collides in merge; no new key material introduced |
+| T-46-08 | Information Disclosure | replay test fixtures | mitigate | Journal entries reference ciphertext + ECIES-wrapped keys only; tests use isolated temp journal dirs, no raw plaintext keys (preserve queue.rs:6-7 invariant) |
+| T-46-SC | Tampering | cargo/no new deps | accept | No package installs; no legitimacy gate needed |
+
+</threat_model>
+
+<verification>
+
+- `legacy_empty_name_parks`, `empty_name_merge_collision`, `strict_resolve_bypasses_cache`, `transient_failure_retains_entry` pass.
+- Regression: `replay_for_vault_does_not_touch_failed_entries` and `classify_resolve_outcome_maps_resolve_results` still pass.
+- `git diff crates/fuse/src/lib.rs` shows `resolve_sequence` body unchanged and only `resolve_ipns_for_replay` switched to strict.
+- No metadata migration / sweep added (known residue documented in SUMMARY).
+
+</verification>
+
+<success_criteria>
+
+- Legacy None-name replay entries are parked (retained), never published as empty FilePointers.
+- Replay classification uses `resolve_sequence_strict`; transient failures retain the entry.
+- A real 404 still routes to first-publish; live publish path resolve unchanged.
+- `classify_resolve_outcome` and its test do not regress.
+
+</success_criteria>
+
+<output>
+Create `.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-03-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-03-SUMMARY.md
+++ b/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-03-SUMMARY.md
@@ -1,0 +1,114 @@
+---
+phase: 46-desktop-fuse-data-loss-bugs-replay-hardening
+plan: 03
+subsystem: desktop-fuse
+tags: [fuse, replay, ipns, resolve, journal, parking]
+requires: [46-01]
+provides:
+  - REQ-4 early park-return for legacy None-name UploadFile replay entries
+  - REQ-5 resolve_sequence_strict cache-bypassing resolve for replay classification
+affects:
+  - crates/fuse/src/lib.rs
+tech-stack:
+  added: []
+  patterns:
+    - strict resolve errs on any failure, never falls back to cache (replay path only)
+    - precise None-name guard parks legacy entries via record_failure instead of publishing
+    - per-test isolated journal dir + unroutable API for replay characterization
+key-files:
+  created:
+    - .planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-03-SUMMARY.md
+  modified:
+    - crates/fuse/src/lib.rs
+decisions:
+  - REQ-4 guard placed ABOVE Step 1 of replay_upload_entry to avoid re-pinning content every mount (Pitfall 4)
+  - PARK (not mint-fresh-IPNS) chosen for lowest blast radius and no new key material
+  - resolve_sequence kept unchanged; only resolve_ipns_for_replay switches to strict (live path keeps cache resilience)
+  - No metadata sweep for already-published empty-locator pointers (Assumption A5 residue documented)
+metrics:
+  duration: ~13m
+  completed: 2026-06-15
+---
+
+# Phase 46 Plan 03: Replay-Path Hardening Summary
+
+Two replay correctness fixes from the PR #491 follow-ups, both surgical changes in
+`crates/fuse/src/lib.rs`.
+
+## What Was Built
+
+### REQ-4: park legacy None-name replay entries
+
+`replay_upload_entry` previously built an empty `FilePointer` (id `"replay-"`,
+`file_meta_ipns_name ""`) for legacy `None`-name entries and published it, after
+which `replay_for_vault` removed the entry as "successfully replayed". Empty-name
+pointers also collide in `merge_folder_children` (all key on `""`).
+
+The fix is an early guard, placed at the top of `replay_upload_entry` (above the
+ciphertext upload/pin per Pitfall 4, so legacy content is not re-pinned on every
+mount):
+
+```rust
+if file_meta_ipns_name.is_none() {
+    return Err(
+        "legacy UploadFile entry has no per-file IPNS name -- parking (no empty FilePointer)"
+            .to_string(),
+    );
+}
+```
+
+The guard is precise on `file_meta_ipns_name.is_none()`, so the normal `Some`-name
+path is untouched. `replay_for_vault` already maps `Err` to `record_failure`
+(retain/park) and `Ok` to remove, so no change there. No fresh-IPNS minting; no
+new key material.
+
+### REQ-5: strict cache-bypassing resolve in replay classification
+
+`resolve_sequence` falls back to the cache on resolve `Err`, so a transient
+network blip with a cached value returns `Ok(cached)` and replay would publish at
+`cached+1` instead of parking. A new `PublishCoordinator::resolve_sequence_strict`
+errs on any resolve failure (never cache fallback); on success it still returns
+`max(resolved, cached)` and updates the cache. Only `resolve_ipns_for_replay`
+switches to strict. The live publish path (`spawn_metadata_publish`, mkdir) keeps
+`resolve_sequence` for its cache resilience, and `classify_resolve_outcome` is
+unchanged so the 404-first-publish contract holds.
+
+The resolve response field was confirmed as
+`cipherbox_api_client::types::IpnsResolveResponse.sequence_number` (a `String`,
+camelCase serde); the plan's `.parse::<u64>().unwrap_or(0)` is correct as written.
+
+## Test Results
+
+All six tests pass on the macOS dev host:
+
+```text
+test tests::legacy_empty_name_parks ... ok
+test tests::empty_name_merge_collision ... ok
+test tests::strict_resolve_bypasses_cache ... ok
+test tests::transient_failure_retains_entry ... ok
+test tests::replay_for_vault_does_not_touch_failed_entries ... ok
+test tests::classify_resolve_outcome_maps_resolve_results ... ok
+```
+
+`empty_name_merge_collision` pins the motivation by placing one empty-name pointer
+on the local side and one on the remote side of `merge_folder_children`; they
+collapse to a single entry, confirming empty locators cannot coexist across a
+merge.
+
+## Known Residue
+
+Already-published empty-locator FilePointers (from before this fix) are left in
+place per Assumption A5. No metadata migration or sweep was added; that is out of
+scope and documented here as known residue.
+
+## Threat Model Compliance
+
+- T-46-06 (Tampering): strict resolve errs on any failure, so a transient blip
+  never advances IPNS sequence off a stale cached value; the live path keeps its
+  separate cache-resilient method.
+- T-46-07 (Information Disclosure): None-name entries are parked instead of
+  publishing an unresolvable `"replay-"`/`""` pointer that collides in merge; no
+  new key material.
+- T-46-08 (Information Disclosure): tests use isolated temp journal dirs and an
+  unroutable API; journal entries reference ciphertext + ECIES-wrapped keys only,
+  never raw plaintext.

--- a/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-04-PLAN.md
+++ b/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-04-PLAN.md
@@ -1,0 +1,177 @@
+---
+phase: 46-desktop-fuse-data-loss-bugs-replay-hardening
+plan: 04
+type: execute
+wave: 3
+depends_on: ["46-01", "46-03"]
+files_modified:
+  - crates/fuse/src/lib.rs
+autonomous: true
+requirements: [REQ-1, REQ-2]
+must_haves:
+  truths:
+    - "mkdir happy-path journals the entry BEFORE replying (D-04 ordering proven by test)"
+    - "An FsEvent::MkdirConflict drained through drain_upload_completions re-arms the parent for publish (parent_ino in mutated_folders + publish_queue entry)"
+    - "release journals the ciphertext into a fsynced entry BEFORE handle.cleanup deletes the temp file; the entry is recoverable on simulated crash"
+    - "replay re-uploads the journaled ciphertext (pure WriteQueue round-trip decodes to the original)"
+    - "The debounced parent republish path is verified to fetch-and-merge remote children (Open Question A2) or flagged if it blind-overwrites"
+  artifacts:
+    - path: "crates/fuse/src/lib.rs"
+      provides: "REQ-1/REQ-2 characterization tests (tests only, no production rewrites)"
+      contains: "mkdir_conflict_rearms"
+  key_links:
+    - from: "release_journals_before_cleanup test"
+      to: "JournalEntry.ciphertext_b64"
+      via: "assert journal entry on disk before temp-file deletion"
+      pattern: "ciphertext_b64"
+    - from: "mkdir_conflict_rearms test"
+      to: "mutated_folders + publish_queue"
+      via: "drain_upload_completions on FsEvent::MkdirConflict"
+      pattern: "MkdirConflict"
+---
+
+<objective>
+Add the missing characterization tests that prove REQ-1 (mkdir durable conflict retry) and REQ-2 (release durability) ALREADY satisfy the durability contract — plus the Open Question A2 verification sub-task. This is a TESTS + VERIFICATION plan. There are NO production rewrites here.
+
+CRITICAL FRAMING (read before doing anything): RESEARCH.md's central finding is that REQ-1 and REQ-2 are ALREADY FIXED in the current tree by Phase 43/45 (the 2026-06-11 todos predate those landings):
+- REQ-1 mkdir conflict retry already exists via `FsEvent::MkdirConflict` → re-arm (write_ops.rs:670-679, lib.rs:927-933). Pitfall 1 (RESEARCH.md:687-694): a task that "adds queue_publish to the conflict arm" or reintroduces a warn-only arm is WRONG — it is already there.
+- REQ-2 release durability already holds via the D-04 journal-before-ack barrier: ciphertext is captured into the fsynced `JournalEntry.ciphertext_b64` BEFORE `handle.cleanup()` deletes the temp file (read_ops.rs:808-884). Pitfall 2 (RESEARCH.md:696-701): moving `reply.ok()` before `journal.put`, or blocking release on the network, REGRESSES D-04 and is FORBIDDEN.
+
+So this plan: (a) writes characterization tests that LOCK IN the correct current behavior (and would fail if a future change regresses D-04 ordering or the mkdir re-arm), and (b) performs the A2 verification read.
+
+Purpose: prove and protect the already-correct durability semantics with automated tests, and resolve Open Question A2 (does the debounced parent republish fetch-and-merge?).
+
+Output: REQ-1/REQ-2 characterization tests in `crates/fuse/src/lib.rs`, and an A2 verification finding recorded in the SUMMARY.
+</objective>
+
+<execution_context>
+@/Users/myankelev/Code/random/cipher-box/.claude/gsd-core/workflows/execute-plan.md
+@/Users/myankelev/Code/random/cipher-box/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-RESEARCH.md
+@.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-VALIDATION.md
+@crates/fuse/src/lib.rs
+@crates/fuse/src/read_ops.rs
+@crates/fuse/src/write_ops.rs
+@crates/fuse/src/journal_helpers.rs
+@crates/sdk/src/queue.rs
+</context>
+
+<tasks>
+
+<task type="execute" tdd="true">
+  <name>Task 1: REQ-1 mkdir characterization tests (tests only, NO rewrite)</name>
+  <files>crates/fuse/src/lib.rs</files>
+  <behavior>
+    - mkdir_happy_path_puts_journal_entry_then_replies_entry: `handle_mkdir` on the root puts a journal entry to disk AND mutates the parent inode children BEFORE the reply; captured reply `error == 0`. The detached publish thread fails against 127.0.0.1:1 but `journal.put` + reply happen synchronously before the spawn (RESEARCH.md:584-586).
+    - mkdir_conflict_rearms: feeding an `FsEvent::MkdirConflict { parent_ino }` through `drain_upload_completions` results in `parent_ino ∈ mutated_folders` AND a `publish_queue` entry for it (pure in-memory, no network) — RESEARCH.md:91-93.
+  </behavior>
+  <action>
+This is a TESTS-ONLY task. DO NOT modify write_ops.rs, lib.rs production code, or any handler. If you find yourself editing the mkdir conflict arm, STOP — it is already correct (RESEARCH.md Pitfall 1). First diff current `write_ops.rs:670-679` and `lib.rs:927-933` against the todo's claims to confirm the re-arm exists, then only add tests.
+
+Add to the `#[cfg(all(test, feature = "fuse"))]` test module in lib.rs, using `make_test_fs()` from Plan 01:
+
+  - `mkdir_happy_path_puts_journal_entry_then_replies_entry` (`#[tokio::test(flavor = "multi_thread")]` since mkdir spawns): construct a CaptureSender ReplyEntry, call `crate::write_ops::implementation::handle_mkdir(...)` for a new child under ROOT_INO (use a real EC keypair via make_test_fs_with_keypair since mkdir builds folder metadata and wraps keys), assert (1) the parent inode's `children` now contains the new child (write_ops.rs:520-526), (2) at least one journal entry exists on disk via `load_all_for_vault`, and (3) `reply_error_code == 0`. The detached publish targets 127.0.0.1:1 and fails harmlessly; the journal entry is retained (D-11b). Account for the retained entry — do NOT assert journal emptiness (RESEARCH.md:597-601).
+  - `mkdir_conflict_rearms`: build `fs` via make_test_fs, send `crate::FsEvent::MkdirConflict { parent_ino }` on `upload_tx` for an existing folder ino, call `drain_upload_completions` (the drain that processes `upload_rx`), assert `mutated_folders` contains `parent_ino` and `publish_queue` has an entry for it. Pure in-memory; no network. This locks in the re-arm at lib.rs:927-933.
+
+Use isolated per-test journal dirs. `#[tokio::test(flavor = "multi_thread")]` for the mkdir test plus a brief drain if asserting post-spawn state. Run ONLY named tests. Commit `test(fuse): characterize mkdir journal-before-reply and conflict re-arm`.
+  </action>
+  <verify>
+    <automated>cd /Users/myankelev/Code/random/cipher-box && cargo test -p cipherbox-fuse --features fuse mkdir_happy_path 2>&1 | tail -6 && cargo test -p cipherbox-fuse --features fuse mkdir_conflict_rearms 2>&1 | tail -6 && git diff --stat crates/fuse/src/write_ops.rs | grep -q . && echo WRITE_OPS_TOUCHED_FAIL || echo OK</automated>
+  </verify>
+  <done>`mkdir_happy_path_*` and `mkdir_conflict_rearms` pass; `write_ops.rs` is UNCHANGED (tests-only); the mkdir conflict re-arm behavior is locked in.</done>
+</task>
+
+<task type="execute" tdd="true">
+  <name>Task 2: REQ-2 release/replay durability characterization tests (tests only, NO rewrite)</name>
+  <files>crates/fuse/src/lib.rs</files>
+  <behavior>
+    - release_journals_before_cleanup: `handle_release` on a dirty new file leaves a journal entry on disk AND the temp file deleted (handle.cleanup ran) AND captured reply `error == 0`. The detached upload to 127.0.0.1:1 calls `record_failure`, which must NOT remove the entry.
+    - replay_reuploads_ciphertext: a pure WriteQueue round-trip — build an UploadFile entry, persist, reload via `load_all_for_vault`, assert `ciphertext_b64` decodes to the original ciphertext (crash-simulation: never run the spawn).
+    - flush_returns_ok already covered by Plan 01 (reference it; do not duplicate).
+  </behavior>
+  <action>
+TESTS-ONLY task. DO NOT modify read_ops.rs or release ordering. If you are tempted to reorder `reply.ok()`/`journal.put`/`handle.cleanup`, STOP — that regresses D-04 (RESEARCH.md Pitfall 2). First confirm the current ordering at read_ops.rs:808-884 (journal.put at :815 strictly before in-memory mutation, handle.cleanup at :882, reply.ok at :884), then only add tests that would FAIL if that ordering were ever broken.
+
+Add to the lib.rs test module using make_test_fs_with_keypair (release encrypts → needs a real keypair):
+
+  - `release_journals_before_cleanup` (`#[tokio::test(flavor = "multi_thread")]`): open a new file handle, write bytes into its temp file, call `crate::read_ops::implementation::handle_release(...)`. Assert: (1) `load_all_for_vault` returns >= 1 entry whose `JournalOp::UploadFile.ciphertext_b64` is non-empty (journal-before-cleanup proven), (2) the temp file path no longer exists (handle.cleanup ran, read_ops.rs:882), (3) `reply_error_code == 0`. The detached thread fails to 127.0.0.1:1 and calls `record_failure` (read_ops.rs:942) which retains the entry — assert it is STILL present after a brief drain. This is the D-04 ordering lock (RESEARCH.md:165-168).
+  - `replay_reuploads_ciphertext` (pure, no network — VALIDATION.md "Unit-testable now: yes pure WriteQueue round-trip"): build a `JournalOp::UploadFile` with known `ciphertext_b64`, `journal.put`, then a fresh `WriteQueue::new` over the same dir + `load_all_for_vault`, assert the reloaded entry's `ciphertext_b64` base64-decodes to the original ciphertext bytes. Proves the ciphertext survives in the journal independent of the temp file (RESEARCH.md:169-170).
+
+Do NOT close the flush-before-release window (Open Question 2 / RESEARCH.md:139-148): the recommendation is to leave `flush` a no-op and document it as an accepted limitation. Record that decision in the SUMMARY; do NOT journal on flush (it risks regressing D-04 / double-journaling).
+
+Use isolated per-test journal dirs. Run ONLY named tests. Commit `test(fuse): characterize release journal-before-cleanup and replay ciphertext recovery`.
+  </action>
+  <verify>
+    <automated>cd /Users/myankelev/Code/random/cipher-box && cargo test -p cipherbox-fuse --features fuse release_journals_before_cleanup 2>&1 | tail -6 && cargo test -p cipherbox-fuse --features fuse replay_reuploads_ciphertext 2>&1 | tail -6 && git diff --stat crates/fuse/src/read_ops.rs | grep -q . && echo READ_OPS_TOUCHED_FAIL || echo OK</automated>
+  </verify>
+  <done>`release_journals_before_cleanup` and `replay_reuploads_ciphertext` pass; `read_ops.rs` is UNCHANGED; D-04 journal-before-cleanup ordering is locked in by test; flush-window left as documented accepted limitation.</done>
+</task>
+
+<task type="execute">
+  <name>Task 3: A2 verification — does the debounced parent republish fetch-and-merge?</name>
+  <files>crates/fuse/src/lib.rs</files>
+  <action>
+VERIFICATION-ONLY task (Open Question A2, RESEARCH.md:781, 788-792). No code change unless verification reveals a clobber bug, in which case FLAG it for the plan-checker/executor decision rather than silently fixing.
+
+Read the debounced publisher implementation — `flush_publish_queue` and the actual publish it performs for a queued parent inode — in `crates/fuse/src/lib.rs`. Compare it against `spawn_metadata_publish` (lib.rs:440-527), which DOES fetch-merge remote children before republish. Determine: when the `MkdirConflict` re-arm causes the debounced publisher to republish the parent, does that publish path fetch-and-merge remote parent children (so a concurrent remote edit to the parent is preserved), or does it blind-overwrite the parent metadata with local state only?
+
+Record the finding explicitly in `46-04-SUMMARY.md`:
+  - If it fetch-and-merges → A2 RESOLVED, no clobber risk, REQ-1 fully closed. State the function + line anchor that does the merge.
+  - If it blind-overwrites → A2 FLAGGED as a latent clobber bug. Do NOT fix it in this tests-only task; document the exact location and recommend a follow-up (the plan-checker/executor decides whether to bring a fix into scope). Per RESEARCH.md:781 this is the one place REQ-1 could still hide a real bug.
+
+This task has no automated test; its deliverable is the documented A2 finding. (No production edit expected.)
+  </action>
+  <verify>
+    <automated>cd /Users/myankelev/Code/random/cipher-box && test -f .planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-04-SUMMARY.md && grep -qi "A2" .planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-04-SUMMARY.md && echo OK || echo "A2 finding must be recorded in SUMMARY"</automated>
+  </verify>
+  <done>The SUMMARY records whether the debounced parent republish fetch-and-merges (A2 RESOLVED) or blind-overwrites (A2 FLAGGED with location + follow-up recommendation). No production code changed by this task.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+
+## Trust Boundaries
+
+| Boundary | Description |
+| -------- | ----------- |
+| release callback → durable journal | Ciphertext must reach the fsynced journal before the OS ack and temp-file deletion |
+| mkdir conflict → debounced republish | The re-armed parent publish must not clobber concurrent remote parent edits (A2) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+| --------- | -------- | --------- | ----------- | --------------- |
+| T-46-09 | Repudiation/Data Loss | handle_release D-04 ordering | mitigate | Characterization test asserts journal entry exists before temp-file deletion and reply; a future reorder of reply.ok before journal.put fails the test (preserve read_ops.rs:808-884) |
+| T-46-10 | Tampering | debounced parent republish (A2) | mitigate | Verify the republish fetch-and-merges remote children; flag if it blind-overwrites so a concurrent remote parent edit is not clobbered |
+| T-46-08 | Information Disclosure | release/replay test fixtures | mitigate | Tests use real EC keypair only to wrap keys; journal holds ciphertext + ECIES-wrapped keys; isolated temp dirs; no raw plaintext keys |
+| T-46-SC | Tampering | cargo/no new deps | accept | No package installs; tests-only plan; no legitimacy gate needed |
+
+</threat_model>
+
+<verification>
+
+- `mkdir_happy_path_*`, `mkdir_conflict_rearms`, `release_journals_before_cleanup`, `replay_reuploads_ciphertext` pass.
+- `git diff --stat` shows `write_ops.rs` and `read_ops.rs` UNCHANGED (this is a tests + verification plan — Pitfalls 1 and 2).
+- `46-04-SUMMARY.md` records the A2 finding (RESOLVED or FLAGGED with location).
+
+</verification>
+
+<success_criteria>
+
+- mkdir journal-before-reply and conflict re-arm are locked in by passing tests, with no production code change.
+- release journal-before-cleanup (D-04) and replay ciphertext recovery are locked in by passing tests, with no production code change.
+- The flush-before-release window is documented as an accepted limitation.
+- Open Question A2 is resolved or flagged with a precise location.
+
+</success_criteria>
+
+<output>
+Create `.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-04-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-04-SUMMARY.md
+++ b/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-04-SUMMARY.md
@@ -1,0 +1,150 @@
+---
+phase: 46-desktop-fuse-data-loss-bugs-replay-hardening
+plan: 04
+subsystem: desktop-fuse
+tags: [fuse, testing, journal, durability, mkdir, release, replay, A2]
+requires: [46-01, 46-03]
+provides:
+  - REQ-1 mkdir characterization tests (journal-before-reply + conflict re-arm)
+  - REQ-2 release/replay characterization tests (journal-before-cleanup + ciphertext recovery)
+  - Open Question A2 verification finding (RESOLVED)
+affects:
+  - crates/fuse/src/lib.rs
+tech-stack:
+  added: []
+  patterns:
+    - characterization tests that lock in already-correct D-04 ordering and the mkdir re-arm
+    - real secp256k1 keypair via ecies dev-dep for handlers that ECIES-wrap keys
+    - per-test isolated journal dir (reused from 46-01 test_support)
+key-files:
+  created:
+    - .planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-04-SUMMARY.md
+  modified:
+    - crates/fuse/src/lib.rs
+decisions:
+  - Tests-only plan; no production rewrites (REQ-1/REQ-2 already implemented by Phase 43/45)
+  - flush left a no-op (already covered by flush_returns_ok from 46-01); not journalled on flush to avoid regressing D-04
+  - replay test owns its journal dir directly (WriteQueue.journal_dir is pub(crate) to the sdk crate, not reachable from fuse)
+metrics:
+  duration: ~15m
+  completed: 2026-06-15
+---
+
+# Phase 46 Plan 04: REQ-1/REQ-2 Characterization Tests + A2 Verification Summary
+
+This is a tests-plus-verification plan. REQ-1 (mkdir durable conflict retry) and
+REQ-2 (release durability) are ALREADY IMPLEMENTED in the current tree by Phase
+43/45. This plan adds characterization tests that lock in the correct behavior
+(and would fail on a future regression) and resolves Open Question A2. No
+production code was rewritten.
+
+## What Was Built
+
+All additions live in a new `#[cfg(all(test, feature = "fuse"))] mod
+durability_characterization_tests` block appended to `crates/fuse/src/lib.rs`.
+The harness from 46-01 (`make_test_fs`, `make_test_fs_with_keypair`,
+`CaptureSender`, `reply_error_code`, `make_isolated_journal_dir`) is reused; none
+of it was redefined.
+
+### Task 1: REQ-1 mkdir characterization tests
+
+- `mkdir_happy_path_puts_journal_entry_then_replies_entry`
+  (`#[tokio::test(flavor = "multi_thread")]`, real EC keypair). Calls
+  `handle_mkdir` for a new child under `ROOT_INO`. Asserts: (1) the root inode's
+  children now contain the new child named `newdir`, (2) a `MkdirPublish` journal
+  entry exists on disk via `load_all_for_vault`, (3) `reply_error_code == 0`. The
+  detached publish targets 127.0.0.1:1 and fails harmlessly; the entry is
+  retained (D-11b), so journal emptiness is never asserted.
+- `mkdir_conflict_rearms` (`make_test_fs`, pure in-memory). Sends
+  `FsEvent::MkdirConflict { parent_ino }` on the upload channel, drains via
+  `drain_upload_completions`, asserts `parent_ino` is in BOTH `mutated_folders`
+  and `publish_queue`. Locks in the re-arm at `lib.rs:949-955`.
+
+### Task 2: REQ-2 release / replay characterization tests
+
+- `release_journals_before_cleanup`
+  (`#[tokio::test(flavor = "multi_thread")]`, real EC keypair). Creates a file
+  via `handle_create`, writes bytes into its temp file, calls `handle_release`.
+  Asserts: (1) an `UploadFile` journal entry exists with non-empty
+  `ciphertext_b64`, (2) the temp file path no longer exists (`handle.cleanup`
+  ran, `read_ops.rs:882`), (3) `reply_error_code == 0`, and after a brief drain
+  the entry is STILL present (the 127.0.0.1:1 failure calls `record_failure`,
+  which retains it). This is the D-04 journal-before-cleanup ordering lock.
+- `replay_reuploads_ciphertext` (pure, no network). Builds a
+  `JournalOp::UploadFile` with a known `ciphertext_b64`, `put`s it to an isolated
+  dir, then a fresh `WriteQueue::new` over the same dir + `load_all_for_vault`
+  reloads it; asserts the reloaded `ciphertext_b64` base64-decodes to the exact
+  original ciphertext bytes.
+
+The flush-before-release window (Open Question 2) was left as a documented
+accepted limitation: `flush` stays a no-op (already covered by `flush_returns_ok`
+from 46-01). Journaling on flush was deliberately NOT added, since it risks
+regressing D-04 / double-journaling.
+
+### Task 3: A2 verification (READ-ONLY)
+
+See the A2 finding below. No production code was changed by this task.
+
+## A2 Finding: RESOLVED
+
+Open Question A2: when the `MkdirConflict` re-arm causes the debounced publisher
+to republish the parent, does that publish FETCH-AND-MERGE remote parent children
+(preserving a concurrent remote edit) or BLIND-OVERWRITE with local state only?
+
+Verdict: A2 RESOLVED — the debounced parent republish fetch-and-merges. No
+clobber risk; REQ-1 is fully closed.
+
+Path traced:
+
+1. `drain_upload_completions` handles `FsEvent::MkdirConflict` by calling
+   `queue_publish(parent_ino, false)` then `flush_publish_queue`
+   (`lib.rs:949-958`).
+2. `flush_publish_queue` (`lib.rs:976-1009`) builds parent metadata via
+   `build_folder_metadata(folder_ino)` and calls `spawn_metadata_publish(...)`
+   (`lib.rs:992-1001`).
+3. `spawn_metadata_publish` (`lib.rs:407`) first attempts the publish with the
+   local metadata and an `expected_sequence_number`. On
+   `PublishResult::Conflict` (`lib.rs:462`) it resolves the fresh sequence,
+   `resolve_ipns` + `fetch_content` + `decrypt_metadata_from_ipfs_public` the
+   remote parent, and calls `merge_folder_children(&metadata, remote_metadata)`
+   at `lib.rs:485`, then retries the publish with the MERGED metadata.
+
+The merge function is `merge_folder_children` (defined at `lib.rs:360`), invoked
+from `spawn_metadata_publish` at `lib.rs:485`. So a concurrent remote edit to the
+parent folder's children is preserved through the conflict-driven retry. There is
+no blind-overwrite on the re-arm path.
+
+## Test Results
+
+All four named tests pass when run individually under the RAM constraint:
+
+```text
+test durability_characterization_tests::mkdir_happy_path_puts_journal_entry_then_replies_entry ... ok
+test durability_characterization_tests::mkdir_conflict_rearms ... ok
+test durability_characterization_tests::release_journals_before_cleanup ... ok
+test durability_characterization_tests::replay_reuploads_ciphertext ... ok
+```
+
+`git diff --stat crates/fuse/src/write_ops.rs crates/fuse/src/read_ops.rs` is
+EMPTY — production durability code is untouched. No bare `cargo test` was run.
+
+## Deviations from Plan
+
+- The plan suggested reading `fs.journal.journal_dir` in
+  `replay_reuploads_ciphertext`. That field is `pub(crate)` to the
+  `cipherbox_sdk` crate and is not reachable from `cipherbox-fuse`, so the test
+  instead owns its own isolated dir via `make_isolated_journal_dir()` and builds
+  both the `put` and reload `WriteQueue` over it. The round-trip assertion is
+  unchanged.
+
+## Threat Model Compliance
+
+- T-46-09 (release D-04 ordering): `release_journals_before_cleanup` asserts the
+  journal entry with non-empty ciphertext exists AND the temp file is gone after
+  release; a future reorder of `reply.ok()` ahead of `journal.put`, or temp-file
+  deletion before journalling, would fail the test.
+- T-46-10 (debounced parent republish A2): verified fetch-and-merge via
+  `merge_folder_children` (`lib.rs:485`); no clobber risk.
+- T-46-08 (test fixtures): tests use a real EC keypair only to wrap keys; the
+  journal holds ciphertext + ECIES-wrapped keys; isolated temp dirs; no raw
+  plaintext keys constructed.

--- a/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-RESEARCH.md
+++ b/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-RESEARCH.md
@@ -1,0 +1,852 @@
+# Phase 46: Desktop FUSE data-loss bugs + replay hardening - Research
+
+**Researched:** 2026-06-15
+**Domain:** Rust desktop FUSE durability / IPNS replay correctness (crates/fuse, crates/sdk, apps/desktop/src-tauri)
+**Confidence:** HIGH (all findings grounded in current source with file:line anchors)
+
+## Summary
+
+This is a Rust-only correctness/durability phase. Five of the six requirements touch crash-recovery
+semantics; the sixth is test infrastructure that unblocks unit testing the FUSE handlers. The most
+important research finding is that **two of the six "bugs" in the original todos are already largely
+fixed in the current tree** by Phase 43/45 work — the todos predate those landings:
+
+- **Requirement 1 (mkdir orphan)** is already handled on BOTH platforms via `FsEvent::MkdirConflict`
+  + the durable journal entry (D-11a/D-11b). The "warn-only, never retries" TODO referenced in the
+  todo no longer exists at `write_ops.rs:659` or `windows/write_ops.rs:194`. The residual work is a
+  verification/test gap, not a missing retry.
+- **Requirement 2 (release data loss)** is already closed by the D-04 journal-before-ack barrier. The
+  ciphertext is captured into the fsynced `JournalEntry.ciphertext_b64` BEFORE `handle.cleanup()`
+  deletes the temp file, so temp-file deletion does NOT orphan recovery. The residual window is small
+  and specific (see Requirement 2).
+
+Requirements 4 and 5 are genuine, still-present pre-existing bugs (CodeRabbit on PR #491). Requirement
+3 (Linux stale-mount) and Requirement 6 (test harness) are real, unimplemented work.
+
+**Primary recommendation:** Treat requirements 1 and 2 as "verify current behavior + add the missing
+characterization test" rather than rebuilds. Implement 3, 4, 5 as the minimal targeted changes below.
+Implement 6 first (it unblocks unit tests that prove 1, 2, 4, 5).
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+| ---------- | ------------ | -------------- | --------- |
+| mkdir conflict retry (req 1) | FUSE callback + debounced publisher (crates/fuse) | Durable journal (crates/sdk WriteQueue) | Conflict resolution is in-FS-thread state (`mutated_folders`); journal is the crash-recovery backstop |
+| release durability (req 2) | Durable journal (crates/sdk) | FUSE release callback (crates/fuse) | Durability MUST come from the out-of-callback journal — release cannot block on network |
+| Linux stale-mount recovery (req 3) | Desktop mount glue (apps/desktop/src-tauri/src/fuse/mod.rs) | Linux platform unmount (crates/fuse/platform/linux.rs) | Mount lifecycle is Tauri-side; unmount tooling already lives in the fuse crate |
+| replay classification (req 4, 5) | Replay orchestration (crates/fuse/src/lib.rs) | PublishCoordinator (crates/fuse/src/lib.rs) | Replay decides remove-vs-retain; coordinator owns resolve+cache |
+| handler test harness (req 6) | crates/fuse test support + vendored fuser | — | The ReplySender export gate lives in the vendored crate; test sender lives in cipherbox-fuse |
+
+## Requirement 1: mkdir must durably retry parent publish on conflict
+
+### Current Behavior (file:line)
+
+The todo describes a "warn-only, never enqueues retry" arm. **That code no longer exists.** The current
+tree already implements durable retry on BOTH platforms:
+
+- macOS/Linux: `crates/fuse/src/write_ops.rs:670-679` — on `PublishResult::Conflict`, the spawned
+  thread logs the conflict and sends `crate::FsEvent::MkdirConflict { parent_ino }` via `upload_tx`
+  (D-11a). The journal entry is NOT removed (D-11b, comment at `write_ops.rs:672-673`).
+- Windows/WinFsp: `crates/fuse/src/platform/windows/write_ops.rs:261-270` — identical pattern, sends
+  `FsEvent::MkdirConflict { parent_ino: parent_ino_for_conflict }` at line 269, retains journal entry.
+- The event is consumed in `crates/fuse/src/lib.rs:927-933` (`FsEvent::MkdirConflict`): it re-inserts
+  `parent_ino` into `mutated_folders` and calls `self.queue_publish(parent_ino, false)` — exactly the
+  "actually enqueue the parent for retry" the todo asked for.
+- Crash-before-thread-runs is covered separately: the journal entry is fsynced BEFORE `reply.entry()`
+  (`write_ops.rs:555-559`, `windows/write_ops.rs:162-167`), and on next mount `replay_for_vault` →
+  `replay_mkdir_entry` republishes the parent (D-11b).
+
+So the original "child orphaned, key only in unpublished parent metadata, irrecoverable after restart"
+data-loss scenario is already closed by the journal. The parent inode already contains the new child
+in its `children` vec (`write_ops.rs:520-526`) before the journal is built, so the re-armed debounced
+publish carries the child pointer.
+
+### Minimal Change
+
+The retry mechanism exists. The residual gaps to verify/close:
+
+1. **Confirm `MkdirConflict` is actually drained.** `drain_upload_completions` (which processes
+   `upload_rx`) is called from `readdir`/`release` paths. If a vault sits idle with no FUSE traffic
+   after a mkdir conflict, the event may sit in the channel unprocessed until the next callback. This
+   is the same delivery model as `UploadComplete`, so it is consistent with existing semantics — but
+   the plan should confirm no regression and that the debounced safety-valve (10s) still fires.
+2. **The spawned-thread conflict path does NOT merge** (unlike `spawn_metadata_publish` at
+   `lib.rs:440-527` which fetch-merges remote children). It relies on the re-armed debounced publisher
+   to re-resolve sequence and republish. Verify the debounced publisher does a fetch-and-merge so a
+   concurrent remote edit to the parent is not clobbered. If it blind-overwrites, that is a latent
+   bug to fix here.
+
+Net: this requirement is primarily a **characterization-test + verification** task, not a rewrite. Do
+NOT reintroduce a warn-only arm.
+
+### Risk
+
+LOW for the retry mechanism (already present). MEDIUM if step-2 reveals the debounced parent
+republish does not merge — that would be a separate clobber bug.
+
+### Test
+
+- Unit (needs req-6 harness): `handle_mkdir` happy-path — assert journal entry is `put` before reply,
+  and inode/children mutated. Capture reply wire bytes → `error == 0`.
+- Characterization: an `FsEvent::MkdirConflict { parent_ino }` fed through `drain_upload_completions`
+  results in `parent_ino ∈ mutated_folders` and a `publish_queue` entry (pure in-memory, no network).
+- E2E/manual: induce a real parent-publish conflict (concurrent device) and confirm the child folder
+  resolves remotely after the debounce window.
+
+## Requirement 2: release()/flush must not lose data before durable commit
+
+### Current Behavior (file:line)
+
+`handle_release` in `crates/fuse/src/read_ops.rs:773-975`. The relevant durability ordering:
+
+1. `fs.build_upload_journal_entry(ino, &handle, is_new_file)` (`read_ops.rs:808`) reads the plaintext
+   from the temp file (`journal_helpers.rs:134 handle.read_all()`), encrypts it, and base64-encodes the
+   **ciphertext into `JournalOp::UploadFile.ciphertext_b64`** (`journal_helpers.rs:286, 311`).
+2. `fs.journal.put(&result.entry)` (`read_ops.rs:815`) fsyncs the entry to disk (`queue.rs:171-200`,
+   `sync_all()` = F_FULLFSYNC on macOS) — comment "D-04: fsync journal entry to disk BEFORE acking the
+   OS" (`read_ops.rs:814`).
+3. Only AFTER the journal fsync: in-memory inode mutation (`read_ops.rs:818-841`), `pending_content`
+   insert (`843`), `queue_publish` (`845`).
+4. `handle.cleanup()` (`read_ops.rs:882`) zeroizes + deletes the temp file — comment "D-05: zeroize and
+   delete plaintext temp file BEFORE acking OS".
+5. `reply.ok()` (`read_ops.rs:884`) — comment "D-04: ack OS only after local journal fsync is confirmed".
+6. Detached thread (`read_ops.rs:888-956`) uploads ciphertext; on failure calls
+   `spawn_journal.record_failure` (`942`) — NOT a silent `log::error!` swallow. The entry stays in the
+   journal until the parent pointer publish is confirmed on a later mount (comment CR-08 at `926-933`).
+
+**Key finding (answers the todo's central question):** After `release` acks + journals, the
+**ciphertext is fully recoverable on crash** because it lives in the fsynced journal entry, NOT only in
+the deleted temp file. The temp-file deletion at `read_ops.rs:882` does NOT orphan the journal entry —
+the ciphertext was copied into the entry at step 1. On next mount, `replay_upload_entry`
+(`lib.rs:1828`) re-uploads `ciphertext_b64` (`lib.rs:1869-1874`) and re-publishes. The 2026-06-11 todo
+predates the D-04 barrier and describes the pre-Phase-43 state.
+
+`handle_flush` is a no-op (`read_ops.rs:978-980`, `reply.ok()`). This is correct: durability is on
+`release`, and FUSE may call `flush` multiple times per open without a final close. The Windows
+equivalent (`windows/write_ops.rs:837-879`) mirrors the same journal-before-spawn ordering with an
+added `write_generation` bump (`872`).
+
+### Residual data-loss window (post-Phase-43/45)
+
+The remaining gaps are narrow:
+
+1. **`UploadComplete` not journaled-after.** After the background upload succeeds, the content CID is
+   delivered via `FsEvent::UploadComplete` and applied in-memory (`lib.rs:896-925`); the journal entry
+   is intentionally retained (CR-08) until the parent pointer publish confirms on next mount. This is
+   correct but means a successful upload whose parent-publish never confirms re-runs on next mount
+   (idempotent — same plaintext → same CID). No data loss; possible duplicate work. Verify idempotency
+   holds for the versioning path (`apply_versioning` could double-append a version on replay).
+2. **`flush` returning OK without forcing a not-yet-released dirty handle to durability.** If an
+   application calls `fsync`/`flush` and expects durability but never calls `release` (rare, but POSIX
+   permits long-lived open handles), the dirty bytes are only in the temp file, not yet journaled. The
+   journal entry is built on `release`, not `flush`. This is the one true residual gap: a crash after
+   `flush` but before `release` loses the un-released write. Closing it would mean journaling on
+   `flush` too — but that risks regressing the single-thread constraint and double-journaling.
+   **Recommendation:** document this as an accepted limitation (matches every temp-file-backed FUSE
+   design) OR, if in scope, make `flush` journal the current temp-file contents idempotently keyed by
+   `(ino, write_generation)` so a duplicate `release` journal entry is de-duplicated. Lowest-risk is to
+   leave `flush` a no-op and document the window; do not regress D-04.
+
+### Minimal Change
+
+Likely **no functional change** to release ordering — it already satisfies the durability contract.
+Scope this requirement to: (a) add the missing characterization tests proving journal-before-cleanup
+ordering, (b) verify replay idempotency for the versioning path, (c) decide and document the
+flush-window policy. If the flush window must be closed, do it idempotently and behind a test.
+
+### Risk
+
+HIGH if anyone "fixes" release by blocking on the network (violates single-thread constraint) or by
+removing the journal-before-cleanup ordering (regresses D-04). The safe posture is verification +
+tests, not restructuring.
+
+### Test
+
+- Unit (req-6 harness + a real temp WriteQueue dir): `handle_release` on a dirty new file → assert a
+  journal entry exists on disk AND `handle.cleanup()` ran (temp file gone) AND reply `error == 0`,
+  with no live network (the detached upload thread will fail to `http://127.0.0.1:1` and call
+  `record_failure`, which must NOT remove the entry).
+- Characterization: build entry, crash-simulate by NOT running the spawn, reload via
+  `load_all_for_vault`, assert `ciphertext_b64` decodes to the original ciphertext.
+- `handle_flush` returns OK (trivial unit test).
+
+## Requirement 3: Linux startup must auto-recover stale/disconnected FUSE mount
+
+### Current Behavior (file:line)
+
+`mount_filesystem` in `apps/desktop/src-tauri/src/fuse/mod.rs:74-325`, gated `#[cfg(feature = "fuse")]`
+(covers BOTH macOS and Linux; macOS uses FUSE-T). Platform is distinguished by `#[cfg(target_os = ...)]`
+— e.g. mount options at `mod.rs:295` (linux) vs `297` (macos); unmount dispatch at `mod.rs:327`
+(macos) / `332` (linux).
+
+The buggy branch is `mod.rs:89-110` (the todo cited `:65-86`; the file has shifted):
+
+```rust
+if mount_path.is_symlink() { return Err(...) }            // :89-91
+if !mount_path.exists() {                                  // :93
+    std::fs::create_dir_all(&mount_path)                   // :94 → EEXIST on disconnected mount
+        .map_err(|e| format!("Failed to create mount point: {}", e))?;
+    // set 0o700 ...
+} else {
+    // read_dir + remove stale entries, log "Cleaned stale mount point"  // :101-109
+}
+```
+
+Root cause exactly as the todo states: a disconnected FUSE mount makes `stat()` return ENOTCONN, so
+`mount_path.exists()` returns `false` → takes the `create_dir_all` branch → the dirent still exists →
+EEXIST (os error 17) → user-facing "Failed to create mount point". This is Linux-only: macOS FUSE-T
+leaves the path as a normal dir; Windows/WinFsp uses a different mount path entirely.
+
+A reusable unmount helper already exists: `crates/fuse/src/platform/linux.rs:8` `unmount_filesystem()`
+tries `fusermount3 -u`, then `fusermount -u`, then `umount`. It does NOT currently try lazy `-z`.
+
+### Minimal Change
+
+Add a Linux-only stale-mount detection + unmount step before the `create_dir_all` decision. Cleanest
+minimal approach (Linux only, `#[cfg(target_os = "linux")]`), inserted just after the `is_symlink`
+guard at `mod.rs:91`:
+
+1. Detect a stale mount authoritatively: read `/proc/self/mountinfo` and check whether `mount_path`
+   appears as a mountpoint (do NOT rely on `exists()` — it lies for ENOTCONN). Alternatively, treat an
+   `Err(ENOTCONN)` from a direct `std::fs::symlink_metadata`/`statfs` probe as "stale present".
+2. If stale: run `fusermount3 -u <path>`; on failure run `fusermount3 -z -u <path>` (lazy). Then fall
+   through to the normal `exists()` / `create_dir_all` / clean-stale logic, which now succeeds.
+3. Belt-and-suspenders: also map `create_dir_all`'s `ErrorKind::AlreadyExists` (EEXIST) to "attempt
+   unmount, then retry once" rather than erroring out immediately.
+
+Implementation notes:
+
+- Add a `pub fn recover_stale_mount(mount_path: &Path)` to `crates/fuse/src/platform/linux.rs`
+  (next to `unmount_filesystem`) so the `/proc/self/mountinfo` parse + `fusermount3 -u`/`-z` logic is
+  unit-testable in isolation and keeps Tauri glue thin. Call it from `mount_filesystem` under
+  `#[cfg(target_os = "linux")]`.
+- Reuse the existing `fusermount3`/`fusermount` cascade; just add the `-z` lazy fallback for the
+  disconnected case.
+- Secondary (todo's "less alarming copy"): soften the notification string. Optional, low priority.
+
+### Risk
+
+LOW. Linux-only, additive, no change to macOS/Windows paths. The `/proc/self/mountinfo` parse must
+handle the mount path containing spaces (mountinfo escapes them as `\040`) — use a tolerant
+substring/field check. `fusermount3 -z` (lazy) can leave the old session detaching in the background;
+that is acceptable since we immediately mount a fresh session at the same path.
+
+### Test
+
+- Unit: a `/proc/self/mountinfo` parser fed fixture lines (mount present / absent / path-with-spaces)
+  → returns correct "is mounted" boolean. Pure, no root needed.
+- Unit: EEXIST → recover-then-retry decision logic (mock the unmount call behind a closure/trait).
+- E2E/manual ONLY (cannot unit-test a real mount): on Linux, SIGKILL the app mid-mount, relaunch,
+  assert the vault remounts without the "mount failed" notification. This is the Phase-43 Linux UAT
+  recipe; flag as manual.
+
+## Requirement 4: Park legacy empty file_meta_ipns_name replay entries
+
+### Current Behavior (file:line)
+
+`replay_upload_entry` in `crates/fuse/src/lib.rs:1828-2012`. When `file_meta_ipns_name` is `None`
+(legacy pre-Phase-45 `""` sentinel, mapped to `None` by `deser_opt_string` in `queue.rs:22-25`):
+
+- Step 3 (`lib.rs:1899-1984`) is guarded by `if let Some(file_ipns_key_hex_str) = file_ipns_key_hex`
+  and `if let Some(file_meta_ipns_name) = file_meta_ipns_name` — so with `None` name, the per-file IPNS
+  publish is **skipped**.
+- Step 4 (`lib.rs:1986-2001`) still builds a `FolderChild::File` `FilePointer` with
+  `file_meta_ipns_name = file_meta_ipns_name.unwrap_or_default()` = `""` (`lib.rs:1990, 1995`) and
+  `id = format!("replay-{}", "")` = `"replay-"` (`lib.rs:1993`).
+- `fetch_merge_publish_parent` (`lib.rs:2003`) publishes that pointer into the parent. Back in
+  `replay_for_vault`, `Ok(())` → `journal.remove(&entry.id)` (`lib.rs:1331`). The entry is marked
+  successfully replayed.
+
+Consequence (todo): a content CID with no resolvable per-file metadata record, and multiple empty-name
+entries collide under `merge_folder_children`'s `child_ipns_key` keying (`lib.rs:344-348`,
+`file_meta_ipns_name.as_str()` = `""` for all of them → they all map to the same HashMap key
+`lib.rs:351-355`, so only one survives the merge).
+
+`replay_for_vault` decides remove-vs-retain purely on the `Result`: `Ok(())` → `remove`
+(`lib.rs:1325-1332`), `Err(e)` → `record_failure` which retains/parks (`lib.rs:1333-1351`,
+`queue.rs:283-303`).
+
+### Minimal Change (recommend: PARK)
+
+Make `replay_upload_entry` return `Err` for the legacy `None`-name case BEFORE Step 4 builds the empty
+FilePointer. Insert immediately after Step 3 (after `lib.rs:1984`), before Step 4:
+
+```rust
+// Park legacy entries with no per-file IPNS name rather than publishing an empty,
+// unresolvable FilePointer (id "replay-", file_meta_ipns_name ""). Returning Err
+// routes through record_failure → retained on disk; it never marks the entry as
+// successfully replayed. (No fresh-IPNS minting — lowest risk, no new key material.)
+if file_meta_ipns_name.is_none() {
+    return Err(
+        "legacy UploadFile entry has no per-file IPNS name — parking (no empty FilePointer)"
+            .to_string(),
+    );
+}
+```
+
+Why PARK over mint-fresh-IPNS:
+
+- Minting a fresh per-file IPNS name+key changes the stored metadata shape and adds key material +
+  TEE enrollment to a recovery path, with no user to confirm the new identity. Higher blast radius.
+- Parking is a pure control-flow change: the entry is retained, accumulates retries, and eventually
+  parks as `Failed` at `max_retries` (D-09), surfacing a `WriteParked` notification for manual
+  intervention. No new crypto, no schema change.
+
+Caveat the plan must address (from the todo): **already-published empty-locator FilePointers from past
+replays.** Parking new replays does not clean up `"replay-"`/`""` pointers already merged into parent
+metadata. Decide: (a) leave them (they are content-resolvable via CID but lack per-file metadata —
+acceptable, pre-existing) or (b) add a one-time sweep. Recommend (a) — document as known residue;
+do not expand scope into a metadata migration.
+
+### Risk
+
+MEDIUM — this is a crash-recovery behavior change. The new `Err` path must not be reachable for the
+normal (`Some`-name) case. Guard precisely on `file_meta_ipns_name.is_none()`. The existing
+`replay_for_vault_does_not_touch_failed_entries` test (`lib.rs:2102`) must still pass.
+
+### Test
+
+- Unit (`#[tokio::test]`): Step 1 uploads ciphertext first, so use the unroutable API
+  `http://127.0.0.1:1` and assert the entry is RETAINED after `replay_for_vault`, not removed. Build a
+  `JournalOp::UploadFile` with `file_meta_ipns_name: None`; run `replay_for_vault`; assert
+  `load_all_for_vault().len() == 1` (mirrors the existing characterization test at `lib.rs:2102`). If
+  the park check is moved above Step 1, no network is needed at all.
+- Unit: `merge_folder_children` with two `FilePointer`s both having `file_meta_ipns_name: ""` →
+  document/assert the collision (pins the motivation; the parking fix prevents new ones).
+
+## Requirement 5: Strict (cache-bypassing) IPNS resolve in replay classification
+
+### Current Behavior (file:line)
+
+`resolve_ipns_for_replay` (`crates/fuse/src/lib.rs:211-217`) calls
+`coordinator.resolve_sequence(api, ipns_name)` and pipes the `Result<u64, String>` through
+`classify_resolve_outcome` (`lib.rs:227-236`).
+
+`PublishCoordinator::resolve_sequence` (`lib.rs:262-299`) on resolve `Err` falls back to the cache:
+
+```rust
+Err(e) => match self.get_cached(ipns_name) {                 // :283
+    Some(cached) => { log::warn!(...); Ok(cached) }          // :284-291  ← transient failure → Ok(cached)
+    None => Err(format!("IPNS resolve failed and no cached sequence ...")), // :293-296
+},
+```
+
+So a transient (non-404) failure WITH a cached value returns `Ok(cached)` →
+`classify_resolve_outcome(Ok(cached))` → `IpnsResolveOutcome::Found(cached)` (`lib.rs:230`) → replay
+treats it as "record exists, not first publish" (`lib.rs:1941`) and publishes at `cached + 1` instead
+of parking. A network blip thus advances the sequence off a stale cached value rather than retaining
+the entry.
+
+`classify_resolve_outcome` is unit-pinned by `classify_resolve_outcome_maps_resolve_results`
+(`lib.rs:2057-2094`) — that test asserts `Ok(seq)→Found`, not-found/404→`NotFound`,
+other-err→`Error`. It must not regress.
+
+### Minimal Change (recommend: add `resolve_sequence_strict`)
+
+Add a cache-bypassing method on `PublishCoordinator` and call it from `resolve_ipns_for_replay` only.
+This keeps the cache-fallback behavior for the LIVE publish path (`spawn_metadata_publish` at
+`lib.rs:401`, mkdir at `write_ops.rs:629`) unchanged — those WANT cache resilience — while the REPLAY
+classification path becomes strict.
+
+Add after `resolve_sequence` (`lib.rs:299`):
+
+```rust
+/// Strict resolve for replay classification: returns Err on ANY resolve failure,
+/// never falling back to the cache. A genuine success still updates+returns the
+/// max(resolved, cached) sequence so a subsequent confirmed publish advances correctly.
+pub async fn resolve_sequence_strict(
+    &self,
+    api: &cipherbox_api_client::ApiClient,
+    ipns_name: &str,
+) -> Result<u64, String> {
+    let resp = cipherbox_api_client::ipns::resolve_ipns(api, ipns_name)
+        .await
+        .map_err(|e| format!("IPNS resolve failed for {}: {}", ipns_name, e))?;
+    let resolved = resp.sequence_number.parse::<u64>().unwrap_or(0);
+    let cached = self.get_cached(ipns_name).unwrap_or(0);
+    let seq = std::cmp::max(resolved, cached);
+    self.update_cache(ipns_name, seq);
+    Ok(seq)
+}
+```
+
+Then change `resolve_ipns_for_replay` (`lib.rs:216`):
+
+```rust
+classify_resolve_outcome(coordinator.resolve_sequence_strict(api, ipns_name).await)
+```
+
+Now a transient non-404 resolve `Err` → `classify_resolve_outcome(Err(...))` →
+`IpnsResolveOutcome::Error(e)` (`lib.rs:234`) → replay returns Err (`lib.rs:1949-1954`) → entry
+retained. A real 404 still classifies `NotFound` → first publish. `classify_resolve_outcome` is
+unchanged, so its characterization test does not regress.
+
+This is lower-risk than rewriting `resolve_ipns_for_replay` to call `resolve_ipns` directly and
+re-classify inline, because the brittle 404-substring contract stays centralized in the already-tested
+`classify_resolve_outcome`.
+
+### Risk
+
+MEDIUM — crash-recovery behavior change. The risk is over-parking: a flaky network now retains entries
+that previously published off cache. That is the INTENDED safer behavior (retry next mount), and
+`record_failure` still parks at `max_retries` (D-09). Must NOT touch the live publish path's
+`resolve_sequence` (those rely on cache fallback during normal operation).
+
+### Test
+
+- Unit (pure): classification is unchanged, so no new classify test needed. Add a test that
+  `resolve_sequence_strict` returns `Err` when `resolve_ipns` errors even with a populated cache —
+  pre-seed via `record_publish`, point at unroutable `http://127.0.0.1:1`, assert `Err` (cache present
+  but bypassed).
+- Characterization: transient-failure-with-cache → `replay_for_vault` retains the entry (len stays 1);
+  real 404 → first publish path taken. The 404 leg needs a mock returning 404 or is E2E.
+- Regression: `classify_resolve_outcome_maps_resolve_results` (`lib.rs:2057`) must still pass.
+
+## Requirement 6: read_ops/write_ops handler test harness + journal_helpers tests
+
+### Current Behavior (file:line)
+
+Every handler in `crates/fuse/src/read_ops.rs` / `write_ops.rs` lives in
+`pub(crate) mod implementation` gated `#[cfg(feature = "fuse")]` (`read_ops.rs:6-7`) and consumes a
+concrete `fuser::Reply*` value (e.g. `handle_getattr(fs, ino, reply: ReplyAttr)` at `read_ops.rs:249`;
+full list at `read_ops.rs:89-1005` and `write_ops.rs:21-869`).
+
+The only constructor for a reply is the `Reply` trait method `fn new<S: ReplySender>(unique, sender)`
+(`vendor/fuser/src/reply.rs:50-53`, impls e.g. `ReplyEmpty` at `:118-124`, `ReplyAttr` at `:209`,
+`ReplyEntry` at `:175`, `ReplyXattr` at `:640`). `Reply` IS re-exported
+(`vendor/fuser/src/lib_impl.rs:28` `pub use reply::{Reply, ReplyAttr, ReplyData, ReplyEmpty,
+ReplyEntry, ReplyOpen};`), but `ReplySender` (`reply.rs:35`) is **NOT** re-exported, and
+`mod reply;` is private (`lib_impl.rs:45`). So cipherbox-fuse cannot name `ReplySender` and cannot
+implement a capturing sender → cannot build reply objects in unit tests. This is the BLOCKER.
+
+The `ReplySender` trait (`reply.rs:35-41`) requires only:
+
+```rust
+pub trait ReplySender: Send + Sync + Unpin + 'static {
+    fn send(&self, data: &[IoSlice<'_>]) -> std::io::Result<()>;
+    #[cfg(feature = "abi-7-40")]
+    fn open_backing(&self, fd: BorrowedFd<'_>) -> std::io::Result<BackingId>;
+}
+```
+
+The `abi-7-40` feature is NOT enabled — both `crates/fuse/Cargo.toml:33` and
+`apps/desktop/src-tauri/Cargo.toml:55` use `fuser = { version = "0.16", default-features = false,
+features = ["libfuse"] }`, and vendored `default = []` (`vendor/fuser/Cargo.toml:62`). So a test sender
+only implements `send`.
+
+### Vendored fuser ReplySender export
+
+The minimal vendored-crate edit (does NOT touch the FUSE-T `channel.rs` patch):
+
+In `apps/desktop/src-tauri/vendor/fuser/src/lib_impl.rs`, the current line 28 is:
+
+```rust
+pub use reply::{Reply, ReplyAttr, ReplyData, ReplyEmpty, ReplyEntry, ReplyOpen};
+```
+
+Add a `ReplySender` export — append one new line after `:28`:
+
+```rust
+pub use reply::ReplySender;
+```
+
+One added `pub use` line. `mod reply;` stays private; only the trait name is surfaced. No behavior
+change, no impact on `channel.rs` or any abi-gated code.
+
+### make_test_fs() recipe
+
+`CipherBoxFS` (`crates/fuse/src/lib.rs:665-702`) has 29 fields. A test builder, placed in a
+`#[cfg(all(test, feature = "fuse"))]` module in cipherbox-fuse (so handlers and `fuser` types are in
+scope), built inside a `#[tokio::test]` (for `Handle::current()`):
+
+```rust
+fn make_test_fs() -> CipherBoxFS {
+    use std::collections::{HashMap, HashSet};
+    use std::sync::atomic::AtomicU64;
+    use std::sync::mpsc::channel;
+    use zeroize::Zeroizing;
+
+    let journal_dir = std::env::temp_dir()
+        .join("cb-test-journal")
+        .join(format!("{}-{}", std::process::id(), /* unique per test */ 0u64));
+    std::fs::create_dir_all(&journal_dir).unwrap();
+
+    let (refresh_tx, refresh_rx) = channel();
+    let (content_tx, content_rx) = channel();
+    let (filepointer_tx, filepointer_rx) = channel();
+    let (upload_tx, upload_rx) = channel();
+
+    let mut inodes = crate::inode::InodeTable::new(); // root inode ino=1 pre-created (inode.rs:198)
+    // Root must carry ipns_name + ipns_private_key for build_folder_metadata / journal builders.
+    if let Some(root) = inodes.get_mut(crate::inode::ROOT_INO) {
+        root.kind = crate::inode::InodeKind::Root {
+            ipns_name: Some("k51test-root".to_string()),
+            ipns_private_key: Some(Zeroizing::new(vec![0u8; 32])),
+        };
+    }
+
+    CipherBoxFS {
+        inodes,
+        metadata_cache: crate::cache::MetadataCache::new(),
+        content_cache: crate::cache::ContentCache::new(),
+        api: std::sync::Arc::new(cipherbox_api_client::ApiClient::new("http://127.0.0.1:1")),
+        private_key: Zeroizing::new(vec![0u8; 32]),
+        public_key: Zeroizing::new(vec![0u8; 33]), // secp256k1 compressed pubkey = 33 bytes
+        root_folder_key: Zeroizing::new(vec![0u8; 32]),
+        root_ipns_name: "k51test-root".to_string(),
+        rt: tokio::runtime::Handle::current(),
+        next_fh: AtomicU64::new(1),
+        open_files: HashMap::new(),
+        temp_dir: std::env::temp_dir().join("cipherbox-test"),
+        tee_public_key: None,
+        tee_key_epoch: None,
+        max_versions_per_file: 5,
+        version_cooldown_ms: 0,
+        refresh_rx, refresh_tx,
+        mutated_folders: HashMap::new(),
+        prefetching: HashSet::new(),
+        refreshing_metadata: HashSet::new(),
+        content_rx, content_tx,
+        filepointer_rx, filepointer_tx,
+        resolving_file_pointers: HashSet::new(),
+        pending_content: HashMap::new(),
+        upload_rx, upload_tx,
+        publish_coordinator: std::sync::Arc::new(crate::PublishCoordinator::new()),
+        publish_queue: HashMap::new(),
+        journal: cipherbox_sdk::WriteQueue::new(journal_dir, 5),
+    }
+}
+```
+
+Field-by-field notes (anchored to the real struct literal in `apps/desktop/src-tauri/src/fuse/mod.rs:267-291`):
+
+- `public_key` must be 33 bytes (secp256k1 compressed) — ECIES `wrap_key` in the journal builders
+  (`journal_helpers.rs:150, 281, 295`) expects a valid EC public key. A 33-byte zero vec is NOT a valid
+  curve point; for builder tests that call `wrap_key`, generate a real keypair via
+  `cipherbox_crypto::generate_ec_keypair` (or the project's EC keygen) instead of zeros. For
+  metadata-only handler tests (getattr/access/lookup/unlink/rmdir/rename/flush/xattr) that never wrap
+  keys, zeros are fine.
+- `rt: tokio::runtime::Handle::current()` requires the test be `#[tokio::test]` (or
+  `#[tokio::test(flavor = "multi_thread")]` if a handler spawns and you await drain).
+- `journal_dir` must exist before `WriteQueue::new` (constructor does not create it — `queue.rs:157`).
+  Use a per-test unique subdir and clean it up at the end (mirror the existing tests'
+  `std::env::temp_dir().join(...).join(format!("{}", std::process::id()))` pattern at `lib.rs:2106`).
+- Root inode at `ROOT_INO = 1` is auto-created by `InodeTable::new()` (`inode.rs:43, 198`); override
+  its `kind` via `get_mut(ROOT_INO)` to inject `ipns_name`/`ipns_private_key` (matches the desktop
+  mount glue at `mod.rs:138-143`).
+
+### Capturing ReplySender + handler test pattern
+
+```rust
+use std::io::IoSlice;
+use std::sync::{Arc, Mutex};
+use fuser::{Reply, ReplyEmpty, ReplyAttr, ReplyEntry};
+
+#[derive(Clone)]
+struct CaptureSender(Arc<Mutex<Vec<u8>>>);
+
+impl fuser::ReplySender for CaptureSender {
+    fn send(&self, data: &[IoSlice<'_>]) -> std::io::Result<()> {
+        let mut buf = self.0.lock().unwrap();
+        for slice in data { buf.extend_from_slice(slice); }
+        Ok(())
+    }
+}
+
+// Wire format (vendor/fuser/src/ll/fuse_abi.rs:932-936, with_iovec at ll/reply.rs:38-48):
+//   fuse_out_header = { len: u32 LE, error: i32 LE, unique: u64 LE }  (16 bytes total)
+// error == 0 → success; error == -errno → failure.
+fn reply_error_code(captured: &Arc<Mutex<Vec<u8>>>) -> i32 {
+    let buf = captured.lock().unwrap();
+    assert!(buf.len() >= 16, "out-header is 16 bytes");
+    i32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]) // error field at byte offset 4
+}
+```
+
+Then for a metadata-only handler:
+
+```rust
+#[tokio::test]
+async fn getattr_returns_ok_for_root() {
+    let mut fs = make_test_fs();
+    let cap = Arc::new(Mutex::new(Vec::new()));
+    let reply = <ReplyAttr as Reply>::new(/*unique*/ 1, CaptureSender(cap.clone()));
+    crate::read_ops::implementation::handle_getattr(&mut fs, crate::inode::ROOT_INO, reply);
+    assert_eq!(reply_error_code(&cap), 0);
+}
+```
+
+Handlers safely unit-testable WITHOUT network (per the todo's Option A list): `handle_getattr`
+(`read_ops.rs:249`), `handle_access` (`:983`), `handle_lookup` incl `"."`/`".."` (`:122`),
+`handle_getxattr`/`handle_listxattr` (`:993`/`:1005`), `handle_flush` (`:978`), `handle_setattr`
+truncate (`write_ops.rs:21`), `handle_create` (`:140`), `handle_unlink` (`:280`), `handle_rmdir`
+(`:704`), `handle_rename` (`:869`), `handle_mkdir` happy-path (`:440` — uses a real temp `WriteQueue`
+dir; the detached publish thread will fail against `127.0.0.1:1` but `journal.put` + reply happen
+synchronously before the spawn). Leave network-blocking `handle_read` (`:478`) and `handle_open`
+(`:264`, fires async prefetch) to E2E.
+
+`journal_helpers` builder tests are pure-synchronous and need only `make_test_fs` + a real EC keypair:
+`build_upload_journal_entry` (`journal_helpers.rs:128`), `build_mkdir_journal_entry` (`:378`), and the
+free helpers `wrap_key_to_hex` (`:477`), `generate_entry_id` (`:467`), `current_unix_ms` (`:458`).
+Note `generate_entry_id`/`current_unix_ms`/`wrap_key_to_hex` are module-private free fns — test them
+via a `#[cfg(test)] mod tests` inside `journal_helpers.rs` itself (the existing empty module at
+`journal_helpers.rs:486-493`), or make them `pub(crate)`.
+
+### Risk
+
+LOW-MEDIUM. The vendored edit is one `pub use` line. The harness risk is the detached upload threads in
+`handle_release`/`handle_mkdir`/`handle_create` racing test teardown — they target `127.0.0.1:1` and
+fail fast, calling `record_failure` which writes to the journal dir. Tests must not assert journal
+emptiness without accounting for the retained entry, and must clean the per-test journal dir. Use
+`#[tokio::test(flavor = "multi_thread")]` and a brief drain if asserting post-spawn state.
+
+### Test
+
+This requirement IS the test infrastructure. Its own "proof" is that the new handler unit tests
+compile and pass (e.g. `getattr_returns_ok_for_root`, `unlink_nonexistent_returns_enoent`,
+`flush_returns_ok`, `mkdir_happy_path_puts_journal_entry_then_replies_entry`) plus the journal_helpers
+builder round-trip tests.
+
+## Validation Architecture
+
+### Test Framework
+
+| Property | Value |
+| -------- | ----- |
+| Framework | Rust built-in `#[test]` / `#[tokio::test]` (tokio dev-dep already used, e.g. `lib.rs:2101`) |
+| Config file | none — Cargo workspace; per-crate `[dev-dependencies]` |
+| Quick run command | `cargo test -p cipherbox-fuse --features fuse <test_name>` |
+| Full suite command | `cargo test -p cipherbox-fuse --features fuse` and `cargo test -p cipherbox-sdk` |
+
+> Constraint (from project memory): GSD sub-agents must NOT run full concurrent Rust test suites (RAM
+> starvation). Run single named tests during development; reserve the full suite for the phase gate.
+
+### Phase Requirements to Test Map
+
+| Req | Behavior | Test Type | Command | Unit-testable now? |
+| --- | -------- | --------- | ------- | ------------------ |
+| 1 | mkdir conflict re-arms parent publish | characterization (in-memory `FsEvent`) | `cargo test -p cipherbox-fuse --features fuse mkdir_conflict_rearms` | needs req-6 harness for full handler; the `FsEvent` drain test is pure |
+| 1 | mkdir happy-path journals before reply | unit | `... mkdir_happy_path_*` | needs req-6 harness |
+| 2 | release journals ciphertext before temp cleanup | unit | `... release_journals_before_cleanup` | needs req-6 harness + temp journal dir |
+| 2 | replay re-uploads journaled ciphertext | characterization | `... replay_reuploads_ciphertext` | yes (pure WriteQueue round-trip) |
+| 2 | flush is a no-op OK | unit | `... flush_returns_ok` | needs req-6 harness |
+| 3 | mountinfo parser detects stale mount | unit | `... mountinfo_detects_stale` | yes (pure parser) |
+| 3 | EEXIST → recover-then-retry decision | unit | `... eexist_triggers_recovery` | yes (mock unmount closure) |
+| 3 | real Linux remount after SIGKILL | E2E/manual | Linux UAT recipe | NO — manual only |
+| 4 | legacy None-name entry is parked, not removed | characterization | `... legacy_empty_name_parks` | yes (unroutable API, assert retained) |
+| 4 | empty-name FilePointers collide in merge | unit | `... empty_name_merge_collision` | yes (pure `merge_folder_children`) |
+| 5 | `resolve_sequence_strict` errs despite cache | unit | `... strict_resolve_bypasses_cache` | yes (unroutable API + seeded cache) |
+| 5 | transient failure retains replay entry | characterization | `... transient_failure_retains_entry` | yes (unroutable API) |
+| 5 | `classify_resolve_outcome` unchanged | regression | `... classify_resolve_outcome_maps_resolve_results` | yes (already exists, `lib.rs:2057`) |
+| 6 | handler harness compiles + sample handlers pass | unit | `... getattr_returns_ok_for_root` etc. | this IS the deliverable |
+
+### Sampling Rate
+
+- Per task commit: the single named test(s) for that task (`cargo test -p <crate> --features fuse <name>`).
+- Per wave merge: `cargo test -p cipherbox-fuse --features fuse` + `cargo test -p cipherbox-sdk`
+  (run sequentially, not concurrently — RAM constraint).
+- Phase gate: full fuse + sdk suites green before `/gsd-verify-work`; Linux remount verified manually
+  via the headless desktop FUSE UAT recipe.
+
+### Wave 0 Gaps
+
+- [ ] Vendored fuser `pub use reply::ReplySender;` (`vendor/fuser/src/lib_impl.rs:28`) — blocks ALL
+      handler unit tests (req 1, 2, 6). Land FIRST.
+- [ ] `make_test_fs()` + `CaptureSender` test support module in cipherbox-fuse — shared fixture for
+      every handler test.
+- [ ] No new framework install — Rust test harness + tokio dev-dep already present.
+
+## Project Constraints (from CLAUDE.md)
+
+- Rust-only phase; TypeScript out of scope. (Use string-literal style where it maps; this is Rust.)
+- Single-thread FUSE constraint (apps/desktop/CLAUDE.md): NEVER block FUSE callbacks on network I/O;
+  `release()` spawns a detached upload thread; durability comes from the out-of-callback journal.
+- Vendored fuser has a critical `channel.rs:receive()` FUSE-T patch — any vendored edit must be minimal
+  and must not disturb `channel.rs`. The req-6 edit is one `pub use` line in `lib_impl.rs`, untouched
+  `channel.rs`.
+- Security rules: never log/store/transmit unencrypted keys; journal stores only ciphertext +
+  ECIES-wrapped keys (`queue.rs:6-7`, enforced today). Preserve this — no plaintext in the journal.
+- Terminology: `ipnsName`, `ipnsRecord`, `privateKey`, `publicKey`, `folderKey`, `fileKey`,
+  `rootFolderKey`, `keyEpoch`, `teePublicKey` (these map to the Rust field names already in use).
+- Git: feature branch `feat/{slug}`, conventional commits, no parens in subject line.
+- Markdownlint enforced on commit for this file: `###` headings (not bold-as-heading), blank lines
+  around code blocks and lists, no italic "Last updated" footer.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+| ------- | ----------- | ----------- | --- |
+| Durable pending-upload queue | A new memory/disk queue | existing `cipherbox_sdk::WriteQueue` (`crates/sdk/src/queue.rs`) | Already fsync-durable, vault-scoped, retry/park-aware (D-04/D-09) |
+| FUSE reply construction in tests | A from-scratch mock fuser | the vendored `Reply::new` + a tiny `ReplySender` impl | Reply types are already exported; only `ReplySender` needs surfacing |
+| IPNS resolve + classify | Inline `.contains("not found")` | `classify_resolve_outcome` + new `resolve_sequence_strict` | Centralizes the brittle 404 substring contract; already unit-pinned |
+| Linux unmount | Raw `umount` syscall | extend existing `platform/linux.rs::unmount_filesystem` cascade with `-z` | Reuses the fusermount3/fusermount/umount fallback ladder |
+| Mountpoint detection | `path.exists()` | parse `/proc/self/mountinfo` | `exists()` returns false for ENOTCONN disconnected mounts (the root cause) |
+
+## Common Pitfalls
+
+### Pitfall 1: "Fixing" requirement 1/2 by rewriting already-correct code
+
+**What goes wrong:** Reintroducing a warn-only mkdir arm or blocking release on the network.
+**Why it happens:** The 2026-06-11 todos describe pre-Phase-43 state; the bugs are already fixed.
+**How to avoid:** Diff current `write_ops.rs:670-679` and `read_ops.rs:814-884` against the todo claims
+first; scope to verification + tests.
+**Warning signs:** A plan task that says "add queue_publish to the conflict arm" — it's already there
+via `FsEvent::MkdirConflict` → `lib.rs:932`.
+
+### Pitfall 2: Regressing D-04 journal-before-ack
+
+**What goes wrong:** Moving `reply.ok()` before `journal.put`, or removing `handle.cleanup()` ordering.
+**Why it happens:** Reordering to "simplify" release.
+**How to avoid:** Keep `journal.put` (`read_ops.rs:815`) strictly before any in-memory mutation,
+`handle.cleanup`, and `reply.ok`. Add a characterization test that fails if reply precedes journal.
+
+### Pitfall 3: Strict-resolve over-reaching into the live publish path
+
+**What goes wrong:** Replacing `resolve_sequence` (live path) with the strict variant, breaking
+normal-operation cache resilience.
+**How to avoid:** Add `resolve_sequence_strict` as a NEW method; call it ONLY from
+`resolve_ipns_for_replay` (`lib.rs:216`). Leave `spawn_metadata_publish`/mkdir using `resolve_sequence`.
+
+### Pitfall 4: Parking req-4 entries but still uploading ciphertext first
+
+**What goes wrong:** `replay_upload_entry` uploads ciphertext (Step 1, `lib.rs:1872`) BEFORE the
+parking check, so a parked legacy entry still re-pins content each mount.
+**How to avoid:** Acceptable (idempotent CID, content is wanted), but if churn matters, move the
+`file_meta_ipns_name.is_none()` park check ABOVE Step 1. Document the choice.
+
+### Pitfall 5: Test journal dirs colliding across concurrent tests
+
+**What goes wrong:** Shared temp journal dir → cross-test entry contamination.
+**How to avoid:** Per-test unique subdir (`process::id()` + test-unique suffix), cleaned at end —
+mirror `lib.rs:2106-2110`.
+
+## Runtime State Inventory
+
+> This phase changes crash-recovery code paths but does NOT rename/migrate stored data. Inventory of
+> what on-disk/runtime state the changes touch:
+
+| Category | Items Found | Action Required |
+| -------- | ----------- | --------------- |
+| Stored data | On-disk journal entries at `default_journal_dir()` = `<data_local>/cipherbox/cb-journal/*.json` (`mod.rs:62-70`). Req-4/5 change which entries get REMOVED vs RETAINED. Legacy `""`-sentinel entries already deserialize via `deser_opt_string` (`queue.rs:22`). | Code change only — no journal schema migration. New parked entries accumulate as `Failed` (D-09). |
+| Live service config | None — no external service config carries renamed strings. | None |
+| OS-registered state | Linux FUSE mount at `~/CipherBox` (`mount_point()`). Req-3 detects/unmounts stale mounts; no persistent registration changes. | Runtime unmount via `fusermount3` — no persisted state. |
+| Secrets/env vars | None renamed. IPNS keys remain ECIES-wrapped in journal/metadata. | None |
+| Build artifacts | Vendored fuser crate gets one `pub use` line; consumers recompile. No artifact rename. | Recompile only. |
+
+**Already-published empty-locator FilePointers (req 4):** pre-existing residue in parent metadata from
+past replays — NOT auto-cleaned. Decide leave-vs-sweep (recommend leave + document).
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+| ---------- | ----------- | --------- | ------- | -------- |
+| Rust toolchain / cargo | all build+test | ✓ (assumed) | workspace MSRV | — |
+| `fusermount3` | req-3 Linux stale-mount recovery | Linux-only (target machine) | libfuse3 | `fusermount` then `umount` (existing cascade) |
+| `/proc/self/mountinfo` | req-3 stale detection | Linux-only | — | EEXIST fall-through path |
+| Live IPNS/IPFS API | E2E only (not unit) | staging API | — | unit tests use unroutable `http://127.0.0.1:1` |
+
+**Missing with no fallback:** none for unit work. The real Linux mount (req-3 E2E) requires a Linux
+host with libfuse3 — manual UAT only, not gateable in CI unit tests.
+
+## Security Domain
+
+`security_enforcement` is absent in `.planning/config.json` → enabled.
+
+### Applicable ASVS Categories
+
+| ASVS Category | Applies | Standard Control |
+| ------------- | ------- | ---------------- |
+| V2 Authentication | no | Phase does not touch auth |
+| V3 Session Management | no | — |
+| V4 Access Control | no | FUSE access() always grants (encryption is the access control, per apps/desktop/CLAUDE.md) |
+| V5 Input Validation | yes | Journal JSON parse is skip-with-warn, never panics (`queue.rs:248-255`); preserve |
+| V6 Cryptography | yes | ECIES `wrap_key`/`unwrap_key`, AES-256-GCM — never hand-roll; journal stores ciphertext + ECIES-wrapped keys only |
+| V7 Error Handling/Logging | yes | Never log plaintext/raw keys; `sanitize_error` scrubs paths/tokens (`crates/sdk/src/sync.rs`) |
+
+### Known Threat Patterns
+
+| Pattern | STRIDE | Standard Mitigation |
+| ------- | ------ | ------------------- |
+| Plaintext leaking into journal | Information Disclosure | Journal references `ciphertext_b64` only (`journal_helpers.rs:14-17, 286`); preserve invariant |
+| Raw key written to disk | Information Disclosure | Keys ECIES-wrapped once before journalling (`journal_helpers.rs:18, 477`); test sender/test data must not introduce raw keys |
+| Journal file readable by other users | Information Disclosure | 0o600 set atomically at create (`queue.rs:177-182`); journal dir 0o700 (`mod.rs:133`) |
+| Replay double-publish / sequence regression | Tampering | req-5 strict resolve prevents advancing off stale cache; CAS `expected_sequence_number` on publish |
+| Test threads writing to real journal dir | Tampering | per-test isolated temp journal dir; never point tests at `default_journal_dir()` |
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+| --- | ----- | ------- | ------------- |
+| A1 | secp256k1 compressed public key is 33 bytes and `wrap_key` needs a valid curve point | Req 6 make_test_fs | Builder tests calling `wrap_key` with zero pubkey fail; use a real keypair (metadata-only handler tests unaffected) |
+| A2 | The debounced parent republish (after MkdirConflict re-arm) does a fetch-and-merge, not a blind overwrite | Req 1 | If it blind-overwrites, a concurrent remote parent edit is clobbered — a latent bug to fix; plan must verify against the debounced publisher code |
+| A3 | `abi-7-40` feature stays disabled, so `ReplySender::open_backing` need not be implemented in the test sender | Req 6 | If enabled later, the test sender must also impl `open_backing`; gate with the same cfg |
+| A4 | Replay re-upload is fully idempotent including the versioning path (`apply_versioning`) | Req 2 | A non-idempotent version append on replay could double-append; verify `apply_versioning` keying |
+| A5 | Leaving already-published empty-locator FilePointers in place is acceptable | Req 4 | If they cause user-visible breakage, a one-time metadata sweep is needed (scope expansion) |
+
+## Open Questions
+
+1. **Does the debounced publisher merge remote parent children before republish?** (A2)
+   - What we know: the mkdir spawn conflict path does NOT merge; it re-arms the debounce.
+   - What's unclear: whether `flush_publish_queue`'s actual publish does fetch-and-merge like
+     `spawn_metadata_publish` (`lib.rs:440-527`) does.
+   - Recommendation: planner adds a verification task to read the debounced publish implementation.
+2. **Flush durability window policy (req 2).**
+   - What we know: `flush` is a no-op; durability is on `release`.
+   - What's unclear: whether closing the flush-before-release window is in scope.
+   - Recommendation: document as accepted limitation unless the user requires otherwise; do not regress
+     D-04 to close it.
+3. **Cleanup of pre-existing empty-locator FilePointers (req 4).** Leave vs sweep — recommend leave +
+   document; confirm with user in discuss-phase.
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+| ------------ | ---------------- | ------------ | ------ |
+| Memory-only `WriteQueue` (VecDeque) lost on quit | Fsync-durable disk journal (`queue.rs`) | Phase 43 | Releases survive crash; req-2 todo is mostly obsolete |
+| mkdir conflict warn-only | `FsEvent::MkdirConflict` re-arm + retained journal entry | Phase 43 (D-11a/b) | req-1 todo mostly obsolete |
+| `""` sentinel for file_meta_ipns_name | `Option<String>` + `deser_opt_string` compat | Phase 45 (#18) | req-4/5 are the residual cleanup of behavior preserved through #18/#19 |
+| `.contains("not found")` inline classify | typed `IpnsResolveOutcome` + `classify_resolve_outcome` | Phase 45 (#19) | req-5 builds on this; must not regress its test |
+
+**Deprecated/outdated:**
+
+- The line numbers in the 2026-06-11 and Phase-43 todos (`write_ops.rs:601-610`,
+  `windows/write_ops.rs:194`, `read_ops.rs:852`, `mod.rs:65-86`): the files have shifted; use the
+  anchors in THIS document.
+
+## Sources
+
+### Primary (HIGH confidence)
+
+- `crates/fuse/src/lib.rs` — PublishCoordinator (`:240-316`), resolve_ipns_for_replay (`:211`),
+  classify_resolve_outcome (`:227`), replay_for_vault (`:1179`), replay_upload_entry (`:1828`),
+  CipherBoxFS struct (`:665`), MkdirConflict handler (`:927`), existing tests (`:2033-2169+`)
+- `crates/fuse/src/read_ops.rs` — handle_release (`:773`), handle_flush (`:978`), handler list
+- `crates/fuse/src/write_ops.rs` — handle_mkdir conflict arm (`:670`), journal-before-reply (`:555`)
+- `crates/fuse/src/platform/windows/write_ops.rs` — mkdir conflict (`:261`), release (`:837`)
+- `crates/fuse/src/journal_helpers.rs` — builders + free helpers + UploadJournalResult
+- `crates/sdk/src/queue.rs` — WriteQueue, JournalEntry/JournalOp, deser_opt_string, record_failure
+- `crates/fuse/src/error.rs` — IpnsResolveOutcome enum
+- `crates/fuse/src/platform/linux.rs` — unmount_filesystem cascade
+- `apps/desktop/src-tauri/src/fuse/mod.rs` — mount_filesystem, stale-mount branch, CipherBoxFS literal
+- `apps/desktop/src-tauri/vendor/fuser/src/{lib.rs,lib_impl.rs,reply.rs,ll/reply.rs,ll/fuse_abi.rs}` —
+  re-export structure, ReplySender trait, Reply::new, wire format
+- `crates/fuse/Cargo.toml`, `apps/desktop/src-tauri/Cargo.toml`, `vendor/fuser/Cargo.toml` — features
+- `CLAUDE.md`, `apps/desktop/CLAUDE.md` — single-thread constraint, vendored patch, security rules
+
+### Secondary (MEDIUM confidence)
+
+- `.planning/todos/pending/*` — the six source todos (note: several describe pre-Phase-43/45 state)
+
+## Metadata
+
+**Confidence breakdown:**
+
+- Req 1 (already fixed): HIGH — verified both platform conflict arms + event handler in source
+- Req 2 (already durable): HIGH — verified journal-before-cleanup ordering and ciphertext capture
+- Req 3 (Linux stale-mount): HIGH — root cause + existing unmount helper confirmed in source
+- Req 4 (park legacy): HIGH — exact code path and remove-vs-retain decision confirmed
+- Req 5 (strict resolve): HIGH — cache-fallback path and call site confirmed
+- Req 6 (test harness): HIGH — ReplySender gate, wire format, full field list all confirmed in source
+
+**Research date:** 2026-06-15
+**Valid until:** 2026-07-15 (stable Rust internals; re-verify line anchors if the crate is refactored)

--- a/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-SECURITY.md
+++ b/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-SECURITY.md
@@ -1,0 +1,51 @@
+<!-- generated-by: gsd-security-auditor -->
+
+# Phase 46 Security Audit — desktop-fuse-data-loss-bugs-replay-hardening
+
+**ASVS Level:** 1
+**block_on:** high
+**Audited diff:** `4b539b445..HEAD`
+**Result:** SECURED — 10/10 mitigate threats CLOSED, 2/2 accept threats logged.
+
+Implementation files are read-only; this audit only verifies declared mitigations
+from the phase threat register exist in the implemented code.
+
+## Threat Verification
+
+| Threat ID | Category               | Disposition | Status | Evidence |
+| --------- | ---------------------- | ----------- | ------ | -------- |
+| T-46-01   | Information Disclosure | mitigate    | CLOSED | `journal_helpers.rs:535-539` — test asserts decoded `ciphertext_b64 != plaintext`; only `ciphertext_b64` journalled (`:286,311`) |
+| T-46-02   | Information Disclosure | mitigate    | CLOSED | `journal_helpers.rs:497-503` real secp256k1 keypair via `ecies::utils::generate_keypair`; `:541-548,591-598` assert wrapped hex fields present, never raw |
+| T-46-03   | Denial of Service      | mitigate    | CLOSED | `platform/linux.rs:141-187` `recover_stale_mount` reads `/proc/self/mountinfo` (not `exists()`), `fusermount3 -u` then lazy `-z -u`; `:217-226` `create_mount_point_dir` retries `create_dir_all` once on EEXIST. Wired at `fuse/mod.rs:98-99,105-106` |
+| T-46-04   | Tampering              | mitigate    | CLOSED | `test_support.rs:40-49` per-test dir keyed by `process::id()`+`AtomicU64`; comment + code confirm never `default_journal_dir()` |
+| T-46-05   | Tampering              | accept      | LOGGED | See accepted-risks AR-46-05 — `platform/linux.rs:191-199` fixed argv `fusermount3` + app-derived `mount_point()` path; no user-controlled command string |
+| T-46-06   | Tampering              | mitigate    | CLOSED | `lib.rs:308-321` `resolve_sequence_strict` errs on any resolve failure (no cache fallback); live cache-resilient `resolve_sequence` kept separate at `:266-303`; replay routes through strict via `:215-221` |
+| T-46-07   | Information Disclosure | mitigate    | CLOSED | `lib.rs:1882-1887` `replay_upload_entry` returns Err when `file_meta_ipns_name.is_none()` (parks entry → retained), before any publish; no new key material |
+| T-46-08   | Information Disclosure | mitigate    | CLOSED | `test_support.rs:72` isolated temp dir + unroutable API (`:95`); replay/release tests reference `ciphertext_b64` + ECIES-wrapped keys only (`lib.rs:2957-2974,3004-3058`) |
+| T-46-09   | Repudiation/Data Loss  | mitigate    | CLOSED | `lib.rs:2905-2996` `release_journals_before_cleanup` asserts (1) journalled `ciphertext_b64` non-empty, (2) temp file deleted, (3) reply ok, (4) entry retained — a `reply.ok` before `journal.put` reorder fails (1)/(3) |
+| T-46-10   | Tampering              | mitigate    | CLOSED | Only republish-parent path (debounce conflict retry) fetch-and-merges remote children via `merge_folder_children` at `lib.rs:485`; no blind overwrite. A2 traced in 46-04-SUMMARY |
+| T-46-SC   | Tampering              | accept      | LOGGED | See accepted-risks AR-46-SC — no `Cargo.toml`/`Cargo.lock` changes in audited diff; `ecies` is `[dev-dependencies]` (`crates/fuse/Cargo.toml:40-41`), `libc` pre-existing |
+
+## Accepted Risks Log
+
+### AR-46-05 — fusermount3 shell-out in recover_stale_mount
+
+`recover_stale_mount` / `try_fusermount3_unmount` invoke `fusermount3` via
+`std::process::Command`. Accepted: argv is fixed (`fusermount3`, `-u` / `-z -u`)
+and the only path argument is the app-derived `mount_point()` (`~/CipherBox`), not
+a user-controlled string. No shell interpolation (`Command::new` + `.arg`, not a
+shell). Verified `crates/fuse/src/platform/linux.rs:191-199`.
+
+### AR-46-SC — no new third-party dependencies
+
+Accepted: this phase adds no package installs. The audited diff
+(`4b539b445..HEAD`) contains no `Cargo.toml` or `Cargo.lock` changes. The only
+crypto/process primitives used are the existing `ecies` dev-dependency
+(`crates/fuse/Cargo.toml:40-41`, test-only), `std::process`, and the pre-existing
+`libc` Unix target dependency.
+
+## Unregistered Flags
+
+None. No `## Threat Flags` section is present in any 46-0x-SUMMARY.md; the
+summaries' `## Threat Model Compliance` notes map 1:1 to the registered threat IDs.
+No new attack surface appeared during implementation without a threat mapping.

--- a/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-VALIDATION.md
+++ b/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-VALIDATION.md
@@ -1,0 +1,90 @@
+---
+phase: 46
+slug: desktop-fuse-data-loss-bugs-replay-hardening
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-06-15
+---
+
+# Phase 46 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property               | Value                                                              |
+| ---------------------- | ------------------------------------------------------------------ |
+| **Framework**          | Rust built-in `#[test]` / `#[tokio::test]` (tokio dev-dep present) |
+| **Config file**        | none — Cargo workspace; per-crate `[dev-dependencies]`             |
+| **Quick run command**  | `cargo test -p cipherbox-fuse --features fuse <test_name>`         |
+| **Full suite command** | `cargo test -p cipherbox-fuse --features fuse && cargo test -p cipherbox-sdk` |
+| **Estimated runtime**  | ~60 seconds (fuse) + ~30 seconds (sdk)                             |
+
+> Constraint (project memory): GSD sub-agents must NOT run full concurrent Rust
+> test suites — RAM starvation. Run single named tests during development;
+> reserve the full suite for the wave-merge and phase gate, run sequentially.
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run the single named test(s) for that task via `cargo test -p <crate> --features fuse <name>`
+- **After every plan wave:** Run `cargo test -p cipherbox-fuse --features fuse` then `cargo test -p cipherbox-sdk` (sequential, not concurrent)
+- **Before verification:** Full fuse + sdk suites must be green
+- **Max feedback latency:** ~90 seconds
+
+---
+
+## Per-Task Verification Map
+
+| Requirement | Behavior | Test Type | Automated Command | Unit-testable now |
+| ----------- | -------- | --------- | ----------------- | ----------------- |
+| REQ-6 | Vendored fuser `ReplySender` export + `make_test_fs` + `CaptureSender` compile | unit (harness) | `cargo test -p cipherbox-fuse --features fuse getattr_returns_ok_for_root` | this IS the deliverable — land FIRST |
+| REQ-6 | `journal_helpers` builders round-trip | unit | `cargo test -p cipherbox-fuse --features fuse build_upload_journal_entry` | yes (needs harness + real EC keypair) |
+| REQ-1 | mkdir conflict re-arms parent publish (FsEvent drain) | characterization | `cargo test -p cipherbox-fuse --features fuse mkdir_conflict_rearms` | yes (pure in-memory FsEvent) |
+| REQ-1 | mkdir happy-path journals before reply | unit | `cargo test -p cipherbox-fuse --features fuse mkdir_happy_path` | yes (needs harness) |
+| REQ-2 | release journals ciphertext before temp cleanup | unit | `cargo test -p cipherbox-fuse --features fuse release_journals_before_cleanup` | yes (harness + temp journal dir) |
+| REQ-2 | replay re-uploads journaled ciphertext | characterization | `cargo test -p cipherbox-fuse --features fuse replay_reuploads_ciphertext` | yes (pure WriteQueue round-trip) |
+| REQ-2 | flush is a no-op OK | unit | `cargo test -p cipherbox-fuse --features fuse flush_returns_ok` | yes (needs harness) |
+| REQ-3 | mountinfo parser detects stale mount | unit | `cargo test -p cipherbox-fuse --features fuse mountinfo_detects_stale` | yes (pure parser) |
+| REQ-3 | EEXIST → recover-then-retry decision | unit | `cargo test -p cipherbox-fuse --features fuse eexist_triggers_recovery` | yes (mock unmount closure) |
+| REQ-4 | legacy None-name entry is parked, not removed | characterization | `cargo test -p cipherbox-fuse --features fuse legacy_empty_name_parks` | yes (unroutable API, assert retained) |
+| REQ-4 | empty-name FilePointers collide in merge | unit | `cargo test -p cipherbox-fuse --features fuse empty_name_merge_collision` | yes (pure `merge_folder_children`) |
+| REQ-5 | `resolve_sequence_strict` errs despite cache | unit | `cargo test -p cipherbox-fuse --features fuse strict_resolve_bypasses_cache` | yes (unroutable API + seeded cache) |
+| REQ-5 | transient failure retains replay entry | characterization | `cargo test -p cipherbox-fuse --features fuse transient_failure_retains_entry` | yes (unroutable API) |
+| REQ-5 | `classify_resolve_outcome` unchanged | regression | `cargo test -p cipherbox-fuse --features fuse classify_resolve_outcome_maps_resolve_results` | yes (already exists) |
+
+_Status legend: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky_
+
+---
+
+## Wave 0 Requirements
+
+- [ ] Vendored fuser `pub use reply::ReplySender;` (`apps/desktop/src-tauri/vendor/fuser/src/lib_impl.rs:28`) — blocks ALL handler unit tests (REQ-1, REQ-2, REQ-6). Land FIRST.
+- [ ] `make_test_fs()` + `CaptureSender` test-support module in cipherbox-fuse — shared fixture for every handler test.
+- [ ] No new framework install — Rust test harness + tokio dev-dep already present.
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+| -------- | ----------- | ---------- | ----------------- |
+| Real Linux remount after SIGKILL with no "mount failed" notification | REQ-3 | Cannot unit-test a real FUSE mount/disconnect; needs a Linux host with libfuse3 | Headless desktop FUSE UAT recipe: SIGKILL the app mid-mount on Linux, relaunch, assert vault remounts cleanly without the user-facing notification |
+| Induced real parent-publish conflict resolves child folder remotely | REQ-1 | Needs two concurrent devices + live IPNS | Create a folder while a concurrent device edits the same parent; confirm the child resolves remotely after the debounce window |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have automated verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers the `ReplySender` export + shared fixture (MISSING references)
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 90s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-VERIFICATION.md
+++ b/.planning/phases/46-desktop-fuse-data-loss-bugs-replay-hardening/46-VERIFICATION.md
@@ -1,0 +1,121 @@
+---
+phase: 46-desktop-fuse-data-loss-bugs-replay-hardening
+verified: 2026-06-15T12:43:02Z
+status: human_needed
+score: 6/6 must-haves verified
+overrides_applied: 0
+human_verification:
+  - test: "Linux remount-after-SIGKILL: mount the desktop FUSE vault on Linux, SIGKILL the app mid-mount to leave a stale/disconnected mount (stat returns ENOTCONN, Path::exists() lies), then restart the app."
+    expected: "App auto-recovers — recover_stale_mount reads /proc/self/mountinfo, unmounts via fusermount3 -u (or lazy -z -u), create_mount_point_dir succeeds (recover-then-retry on EEXIST), and the vault remounts cleanly with NO user-facing 'Failed to create mount point' error and no notify."
+    why_human: "recover_stale_mount + the mountinfo/EEXIST unit tests are #[cfg(target_os = linux)] and do not compile/run on the macOS verification host. The end-to-end stale-mount recovery (real fusermount3, real ENOTCONN kernel state) cannot be exercised by unit tests on this platform."
+---
+
+# Phase 46: Desktop FUSE data-loss bugs + replay hardening Verification Report
+
+**Phase Goal:** Close the desktop FUSE write-durability work Phase 45 deferred — three data-loss bugs (mkdir orphan on parent-publish conflict, release() false-durability ack, stale-mount recovery on crash), two replay-path hardening follow-ups (PR #491), and remaining read_ops/write_ops + journal_helpers test coverage. Behavior-changing correctness/durability fixes.
+
+**Verified:** 2026-06-15T12:43:02Z
+**Status:** human_needed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth (Requirement) | Status | Evidence |
+| --- | --- | --- | --- |
+| 1 | mkdir durably retries parent publish on conflict — child folder never orphaned remotely | ✓ VERIFIED | Behavior pre-landed (PR #487/#491); Phase 46 adds characterization tests. See REQ-1 note. |
+| 2 | release()/flush does not ack OS or zeroize+delete temp file until remote commit confirmed OR journaled for replay | ✓ VERIFIED | Behavior pre-landed (PR #487); Phase 46 adds characterization tests. See REQ-2 note. |
+| 3 | Linux startup auto-recovers stale/disconnected FUSE mount (EEXIST/ENOTCONN) instead of failing | ✓ VERIFIED (runtime needs Linux UAT) | New production code `recover_stale_mount` + mountinfo parser + EEXIST retry, wired into mount path. |
+| 4 | Legacy empty `file_meta_ipns_name` replay entries parked, never published as empty FilePointer | ✓ VERIFIED | New park-guard in `replay_upload_entry`; `legacy_empty_name_parks` test passes. |
+| 5 | Strict cache-bypassing IPNS resolve in replay classification retains entry on transient failure | ✓ VERIFIED | New `resolve_sequence_strict`; `strict_resolve_bypasses_cache` + `transient_failure_retains_entry` pass. |
+| 6 | read_ops/write_ops handler test harness (ReplySender) + journal_helpers builder tests | ✓ VERIFIED | ReplySender re-export, `make_test_fs`, `CaptureSender`, builder round-trip tests all present and pass. |
+
+**Score:** 6/6 truths verified (REQ-3 runtime path flagged for Linux UAT — see human verification)
+
+### REQ-1 / REQ-2 — behavior pre-landed, Phase 46 characterizes
+
+The roadmap requirement text for REQ-1/REQ-2 describes a behavior change, but the durable mkdir-retry and release-durability behavior was **already implemented in a prior phase** (commit `dcd1becb6`, "feat(fuse): durable write journal with crash-recovery replay" — PR #487, later hardened by PR #491). Phase 46's 46-04-PLAN.md is explicitly "tests-only — characterization tests."
+
+Evidence the production handlers were NOT modified in Phase 46:
+
+- `crates/fuse/src/write_ops.rs` (mkdir handler with conflict-detection, journal-on-mkdir, `FsEvent::MkdirConflict` send, journal cleanup only on confirmed publish): **0 lines changed** in `4b539b445..HEAD`.
+- `crates/fuse/src/read_ops.rs` (`handle_release`: D-04 `journal.put` fsync BEFORE `reply.ok()`, D-05 `handle.cleanup()` only after journal confirmed): **0 lines changed** in `4b539b445..HEAD`.
+- `FsEvent::MkdirConflict` drain → re-arm (`mutated_folders.insert` + `queue_publish`) at `lib.rs:949` was introduced by `dcd1becb6`, not Phase 46.
+
+**Judgment: GOAL MET for REQ-1/REQ-2.** The required durability behavior is present, correct, and now pinned by passing tests (`mkdir_conflict_rearms`, `mkdir_happy_path_puts_journal_entry_then_replies_entry`, `release_journals_before_cleanup`). This is "behavior present + now tested," not "behavior never implemented." The roadmap goal is to *close* the deferred work; the work is closed (landed + characterized). Not a gap.
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+| --- | --- | --- | --- |
+| `crates/fuse/src/platform/linux.rs` | `recover_stale_mount` + mountinfo parser + `should_recover_then_retry` + `create_mount_point_dir` | ✓ VERIFIED | +211 lines new; all fns present; lazy `-z -u` fallback at L176. |
+| `apps/desktop/src-tauri/src/fuse/mod.rs` | Linux-only stale-mount recovery before create_dir_all decision | ✓ VERIFIED | `recover_stale_mount` called L99 (cfg linux); `create_mount_point_dir` L106; macOS/Windows preserved via cfg gates. |
+| `crates/fuse/src/lib.rs` | park-return for None-name entries + `resolve_sequence_strict` + strict call in `resolve_ipns_for_replay` | ✓ VERIFIED | Park-guard L1882; `resolve_sequence_strict` L308 (no cache fallback); used by `resolve_ipns_for_replay` L220. |
+| `apps/desktop/.../vendor/fuser/src/lib_impl.rs` | `pub use reply::ReplySender` | ✓ VERIFIED | Present L29. |
+| `crates/fuse/src/test_support.rs` | `make_test_fs` + `CaptureSender` + `reply_error_code` | ✓ VERIFIED | 151 lines; `impl fuser::ReplySender for CaptureSender` L132; `WriteQueue::new` L123. |
+| `crates/fuse/src/journal_helpers.rs` | `build_upload_journal_entry` + `build_mkdir_journal_entry` + tests | ✓ VERIFIED | Builders L128/L378; round-trip tests L506/L559 pass. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+| --- | --- | --- | --- | --- |
+| `mod.rs` | `linux::recover_stale_mount` | cfg(linux) call before create_dir_all | ✓ WIRED | L98-99 |
+| `recover_stale_mount` | `fusermount3 -z` | lazy unmount fallback | ✓ WIRED | `try_fusermount3_unmount(..., &["-z","-u"])` L176 |
+| `resolve_ipns_for_replay` | `resolve_sequence_strict` | strict resolve on replay path | ✓ WIRED | L220 |
+| `replay_upload_entry` | `record_failure` (park) | early Err on `file_meta_ipns_name.is_none()` | ✓ WIRED | L1882; routes through replay_for_vault record_failure |
+| `test_support.rs` | `fuser::ReplySender` | `impl fuser::ReplySender for CaptureSender` | ✓ WIRED | L132 |
+| `test_support.rs` | `WriteQueue` | per-test isolated journal dir | ✓ WIRED | L123 |
+| MkdirConflict re-arm | debounced publish | `merge_folder_children` fetch-and-merge on Conflict | ✓ WIRED | A2 verified independently: lib.rs:477 fetch_content, lib.rs:485 merge_folder_children, retry with merged metadata — no blind-overwrite. |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+| --- | --- | --- | --- |
+| Full fuse suite | `cargo test -p cipherbox-fuse --features fuse` | 57 passed; 0 failed | ✓ PASS |
+| REQ-4 park | test `legacy_empty_name_parks` | ok | ✓ PASS |
+| REQ-5 strict resolve | tests `strict_resolve_bypasses_cache`, `transient_failure_retains_entry` | ok | ✓ PASS |
+| REQ-1 re-arm | test `mkdir_conflict_rearms` | ok | ✓ PASS |
+| REQ-2 release durability | test `release_journals_before_cleanup` | ok | ✓ PASS |
+| REQ-6 builders | tests `build_upload_journal_entry_round_trips`, `build_mkdir_journal_entry_round_trips` | ok | ✓ PASS |
+| REQ-3 mountinfo/EEXIST unit tests | (cfg linux) | not compiled on macOS host | ? SKIP → human |
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+| --- | --- | --- | --- | --- |
+| REQ-1 | 46-04 | Durable mkdir parent-publish retry | ✓ SATISFIED | Pre-landed (PR #487/#491) + now characterized; behavior present in write_ops.rs + lib.rs drain. |
+| REQ-2 | 46-04 | release() durability before ack | ✓ SATISFIED | Pre-landed (PR #487) + now characterized; D-04/D-05 ordering in handle_release. |
+| REQ-3 | 46-02 | Linux stale-mount auto-recovery | ✓ SATISFIED (runtime → human) | New `recover_stale_mount` wired into mount path; runtime needs Linux UAT. |
+| REQ-4 | 46-03 | Park legacy empty-name replay entries | ✓ SATISFIED | New park-guard; test passes. |
+| REQ-5 | 46-03 | Strict cache-bypassing replay resolve | ✓ SATISFIED | New `resolve_sequence_strict`; tests pass. |
+| REQ-6 | 46-01 | Handler harness + journal_helpers tests | ✓ SATISFIED | ReplySender export + make_test_fs + builders + tests. |
+
+No Phase 46 entries in `.planning/REQUIREMENTS.md` (post-milestone phase tracked via ROADMAP scope todos). No orphaned requirements.
+
+### Anti-Patterns Found
+
+None. No TBD/FIXME/XXX/TODO/HACK/PLACEHOLDER markers in any Phase 46 changed source file (`lib.rs`, `platform/linux.rs`, `mod.rs`, `test_support.rs`, `journal_helpers.rs`).
+
+The `flush` no-op (`handle_flush` returns ok) is a **documented accepted limitation** (46-04-SUMMARY), not a gap: REQ-2 targets `release()`, where the durable journaling happens. Journaling on flush was deliberately omitted to avoid regressing D-04 / double-journaling.
+
+### Human Verification Required
+
+#### 1. Linux remount-after-SIGKILL recovery
+
+**Test:** On a Linux host, mount the desktop FUSE vault, SIGKILL the app mid-mount to leave a stale/disconnected mount (stat returns ENOTCONN, `Path::exists()` returns false), then restart the app.
+**Expected:** App auto-recovers — reads `/proc/self/mountinfo`, unmounts via `fusermount3 -u` (or lazy `-z -u`), `create_mount_point_dir` succeeds via recover-then-retry on EEXIST, vault remounts cleanly with no "Failed to create mount point" error and no notify.
+**Why human:** `recover_stale_mount` and its mountinfo/EEXIST unit tests are `#[cfg(target_os = "linux")]` and do not compile/run on the macOS verification host. End-to-end recovery (real fusermount3, real ENOTCONN kernel state) is not exercisable by unit tests on this platform.
+
+### Gaps Summary
+
+No gaps. All six requirements are delivered as actual code in the checked-out tree and proven by the 57-test suite (0 failures).
+
+The single nuance worth surfacing: REQ-1 and REQ-2 durability behaviors were landed in a prior phase (PR #487/#491) and Phase 46 contributes characterization tests rather than new production logic for those two — exactly as 46-04-PLAN.md states ("tests-only"). Production handlers `write_ops.rs` and `read_ops.rs` are unchanged (0 lines) in the phase diff, and the D-04/D-05/re-arm logic is verifiably present from the prior commit. The phase goal ("close the deferred write-durability work") is met: the behavior exists and is now regression-guarded. This is not a gap.
+
+REQ-3, REQ-4, REQ-5, REQ-6 are genuinely new production code in this phase and are fully wired. The only item not provable on the macOS host is the runtime Linux stale-mount recovery path (REQ-3), routed to human UAT.
+
+---
+
+_Verified: 2026-06-15T12:43:02Z_
+_Verifier: Claude (gsd-verifier)_

--- a/apps/desktop/CLAUDE.md
+++ b/apps/desktop/CLAUDE.md
@@ -108,7 +108,7 @@ File mutations (create, write, delete, rename) trigger IPNS metadata publish via
 - **Keychain prompts in debug builds** — each rebuild changes binary signature. Debug builds skip Keychain entirely (`#[cfg(debug_assertions)]`), using ephemeral UUIDs for device ID.
 - **`opendir` must return non-zero file handles** — SMB treats `fh=0` as invalid.
 - **No FSEvents on FUSE mounts** — Finder won't auto-refresh. CLI-created files appear in `ls` but not Finder until a new window is opened.
-- **Stale mount after crash** — `~/CipherBox` may contain `.DS_Store`. App cleans stale contents before mount. Use `diskutil unmount force ~/CipherBox` if mount is stuck.
+- **Stale mount after crash** — a crashed session can leave `~/CipherBox` as a stale `smbfs` mount and/or stray contents (e.g. `.DS_Store`). On startup the app now auto-recovers: `recover_stale_mount` detects a lingering mount via `mount(8)` and clears it (`umount`, then `diskutil unmount force`); stale contents are also cleaned before remount. If a mount is ever still stuck, the manual remedy remains `diskutil unmount force ~/CipherBox`.
 
 ### FUSE-T Debugging
 

--- a/apps/desktop/src-tauri/src/fuse/mod.rs
+++ b/apps/desktop/src-tauri/src/fuse/mod.rs
@@ -99,21 +99,14 @@ pub async fn mount_filesystem(
     cipherbox_fuse::platform::linux::recover_stale_mount(&mount_path);
 
     if !mount_path.exists() {
-        if let Err(e) = std::fs::create_dir_all(&mount_path) {
-            // Belt-and-suspenders for the Linux stale-mount case: a disconnected
-            // FUSE mount whose dirent still exists surfaces as EEXIST even though
-            // `exists()` returned false. Recover once and retry before erroring.
-            #[cfg(target_os = "linux")]
-            if cipherbox_fuse::platform::linux::should_recover_then_retry(e.kind()) {
-                cipherbox_fuse::platform::linux::recover_stale_mount(&mount_path);
-                std::fs::create_dir_all(&mount_path)
-                    .map_err(|e| format!("Failed to create mount point: {}", e))?;
-            } else {
-                return Err(format!("Failed to create mount point: {}", e));
-            }
-            #[cfg(not(target_os = "linux"))]
-            return Err(format!("Failed to create mount point: {}", e));
-        }
+        // On Linux this recovers once from a stale FUSE mount whose dirent still
+        // exists (surfaces as EEXIST even though `exists()` returned false); on
+        // other platforms it is a plain `create_dir_all`.
+        #[cfg(target_os = "linux")]
+        let create_result = cipherbox_fuse::platform::linux::create_mount_point_dir(&mount_path);
+        #[cfg(not(target_os = "linux"))]
+        let create_result = std::fs::create_dir_all(&mount_path);
+        create_result.map_err(|e| format!("Failed to create mount point: {}", e))?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/apps/desktop/src-tauri/src/fuse/mod.rs
+++ b/apps/desktop/src-tauri/src/fuse/mod.rs
@@ -90,13 +90,19 @@ pub async fn mount_filesystem(
         return Err("Mount point is a symlink -- refusing to proceed".to_string());
     }
 
-    // Linux-only: a crash can leave the mount path as a disconnected/stale FUSE
-    // mount where stat() returns ENOTCONN, so `exists()` lies (returns false)
-    // and `create_dir_all` then fails with EEXIST. Authoritatively detect the
-    // stale mount via /proc/self/mountinfo and unmount it before the create /
-    // clean-stale decision below. Best-effort; never blocks the mount.
+    // A crash can leave the mount path as a stale FUSE mount backed by a dead
+    // in-process server, blocking remount before the create / clean-stale
+    // decision below. We authoritatively detect and clear it per platform:
+    //   - Linux: stat() returns ENOTCONN so `exists()` lies (returns false) and
+    //     `create_dir_all` then fails with EEXIST; detect via
+    //     /proc/self/mountinfo and unmount via `fusermount3 -u`.
+    //   - macOS (FUSE-T/SMB): mount lingers as a stale `smbfs` mount; detect via
+    //     `mount(8)` and clear via `umount`, then `diskutil unmount force`.
+    // Both are best-effort and never block the mount.
     #[cfg(target_os = "linux")]
     cipherbox_fuse::platform::linux::recover_stale_mount(&mount_path);
+    #[cfg(target_os = "macos")]
+    cipherbox_fuse::platform::macos::recover_stale_mount(&mount_path);
 
     if !mount_path.exists() {
         // On Linux this recovers once from a stale FUSE mount whose dirent still

--- a/apps/desktop/src-tauri/src/fuse/mod.rs
+++ b/apps/desktop/src-tauri/src/fuse/mod.rs
@@ -90,9 +90,30 @@ pub async fn mount_filesystem(
         return Err("Mount point is a symlink -- refusing to proceed".to_string());
     }
 
+    // Linux-only: a crash can leave the mount path as a disconnected/stale FUSE
+    // mount where stat() returns ENOTCONN, so `exists()` lies (returns false)
+    // and `create_dir_all` then fails with EEXIST. Authoritatively detect the
+    // stale mount via /proc/self/mountinfo and unmount it before the create /
+    // clean-stale decision below. Best-effort; never blocks the mount.
+    #[cfg(target_os = "linux")]
+    cipherbox_fuse::platform::linux::recover_stale_mount(&mount_path);
+
     if !mount_path.exists() {
-        std::fs::create_dir_all(&mount_path)
-            .map_err(|e| format!("Failed to create mount point: {}", e))?;
+        if let Err(e) = std::fs::create_dir_all(&mount_path) {
+            // Belt-and-suspenders for the Linux stale-mount case: a disconnected
+            // FUSE mount whose dirent still exists surfaces as EEXIST even though
+            // `exists()` returned false. Recover once and retry before erroring.
+            #[cfg(target_os = "linux")]
+            if cipherbox_fuse::platform::linux::should_recover_then_retry(e.kind()) {
+                cipherbox_fuse::platform::linux::recover_stale_mount(&mount_path);
+                std::fs::create_dir_all(&mount_path)
+                    .map_err(|e| format!("Failed to create mount point: {}", e))?;
+            } else {
+                return Err(format!("Failed to create mount point: {}", e));
+            }
+            #[cfg(not(target_os = "linux"))]
+            return Err(format!("Failed to create mount point: {}", e));
+        }
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/apps/desktop/src-tauri/src/fuse/mod.rs
+++ b/apps/desktop/src-tauri/src/fuse/mod.rs
@@ -118,15 +118,19 @@ pub async fn mount_filesystem(
             use std::os::unix::fs::PermissionsExt;
             let _ = std::fs::set_permissions(&mount_path, std::fs::Permissions::from_mode(0o700));
         }
-    } else {
-        if let Ok(entries) = std::fs::read_dir(&mount_path) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir() { let _ = std::fs::remove_dir_all(&path); }
-                else { let _ = std::fs::remove_file(&path); }
-            }
-            log::info!("Cleaned stale mount point: {}", mount_path.display());
+    }
+
+    // Clean crash residue regardless of which branch created/recovered the mount
+    // point: the Linux recovery path (stale mount -> exists() lies ->
+    // create_mount_point_dir EEXIST retry) lands in the create branch above, not
+    // only the plain-exists case. On a freshly created empty dir this is a no-op.
+    if let Ok(entries) = std::fs::read_dir(&mount_path) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() { let _ = std::fs::remove_dir_all(&path); }
+            else { let _ = std::fs::remove_file(&path); }
         }
+        log::info!("Cleaned stale mount point: {}", mount_path.display());
     }
 
     #[cfg(target_os = "macos")]

--- a/apps/desktop/src-tauri/vendor/fuser/src/lib_impl.rs
+++ b/apps/desktop/src-tauri/vendor/fuser/src/lib_impl.rs
@@ -26,6 +26,7 @@ pub use reply::ReplyPoll;
 pub use reply::ReplyXTimes;
 pub use reply::ReplyXattr;
 pub use reply::{Reply, ReplyAttr, ReplyData, ReplyEmpty, ReplyEntry, ReplyOpen};
+pub use reply::ReplySender;
 pub use reply::{
     ReplyBmap, ReplyCreate, ReplyDirectory, ReplyDirectoryPlus, ReplyIoctl, ReplyLock, ReplyLseek,
     ReplyStatfs, ReplyWrite,

--- a/crates/fuse/src/journal_helpers.rs
+++ b/crates/fuse/src/journal_helpers.rs
@@ -488,7 +488,7 @@ fn wrap_key_to_hex(raw_key: &[u8], public_key: &[u8], label: &str) -> String {
 // keypair so `wrap_key` ECIES-wraps key material (Threat T-46-02). Network-free.
 #[cfg(all(test, feature = "fuse"))]
 mod tests {
-    use crate::test_support::make_test_fs_with_keypair;
+    use crate::test_support::{make_isolated_journal_dir, make_test_fs_with_keypair};
     use base64::Engine;
     use zeroize::Zeroizing;
 
@@ -508,8 +508,9 @@ mod tests {
         let fs = make_test_fs_with_keypair(private_key, public_key);
 
         // A fresh write handle backed by a temp file with real content.
-        let temp_dir = std::env::temp_dir().join("cb-test-upload");
-        std::fs::create_dir_all(&temp_dir).unwrap();
+        // Isolated per-test dir keyed by process id + counter so parallel test
+        // binaries never collide on a shared path (T-46-04).
+        let temp_dir = make_isolated_journal_dir();
         let ino = 4242u64; // not present in inodes → treated as a brand-new file
         let mut handle =
             crate::file_handle::OpenFileHandle::new_write(ino, &temp_dir, None).unwrap();
@@ -552,7 +553,6 @@ mod tests {
 
         // Plaintext is carried transiently in memory only, never in the entry.
         assert_eq!(result.plaintext, plaintext);
-        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
     #[tokio::test]

--- a/crates/fuse/src/journal_helpers.rs
+++ b/crates/fuse/src/journal_helpers.rs
@@ -483,11 +483,121 @@ fn wrap_key_to_hex(raw_key: &[u8], public_key: &[u8], label: &str) -> String {
         })
 }
 
-#[cfg(test)]
+// REQ-6: builder round-trip tests. Gated on `feature = "fuse"` because they use
+// the `crate::test_support` harness (itself fuse-feature-gated) and a real EC
+// keypair so `wrap_key` ECIES-wraps key material (Threat T-46-02). Network-free.
+#[cfg(all(test, feature = "fuse"))]
 mod tests {
-    // Unit tests for journal_helpers live in crates/fuse/src/lib.rs (alongside
-    // the existing characterization tests) and in crates/sdk/src/queue.rs
-    // (journal round-trip tests).  This module intentionally has no runtime
-    // network dependencies so there are no tests that require a live
-    // CipherBoxFS instance here.
+    use crate::test_support::make_test_fs_with_keypair;
+    use base64::Engine;
+    use zeroize::Zeroizing;
+
+    /// Generate a real secp256k1 keypair (33-byte compressed pubkey, 32-byte
+    /// secret) via the `ecies` dev-dep. A zero vec is NOT a valid curve point.
+    fn real_keypair() -> (Zeroizing<Vec<u8>>, Zeroizing<Vec<u8>>) {
+        let (sk, pk) = ecies::utils::generate_keypair();
+        (
+            Zeroizing::new(sk.serialize().to_vec()),
+            Zeroizing::new(pk.serialize().to_vec()),
+        )
+    }
+
+    #[tokio::test]
+    async fn build_upload_journal_entry_round_trips() {
+        let (private_key, public_key) = real_keypair();
+        let fs = make_test_fs_with_keypair(private_key, public_key);
+
+        // A fresh write handle backed by a temp file with real content.
+        let temp_dir = std::env::temp_dir().join("cb-test-upload");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let ino = 4242u64; // not present in inodes → treated as a brand-new file
+        let mut handle =
+            crate::file_handle::OpenFileHandle::new_write(ino, &temp_dir, None).unwrap();
+        let plaintext = b"hello cipherbox upload round trip";
+        handle.write_at(0, plaintext).unwrap();
+
+        let result = fs
+            .build_upload_journal_entry(ino, &handle, /* is_new_file */ true)
+            .expect("upload builder must succeed with a real keypair");
+
+        match &result.entry.op {
+            cipherbox_sdk::JournalOp::UploadFile {
+                ciphertext_b64,
+                wrapped_key_hex,
+                ..
+            } => {
+                // Ciphertext is journalled and base64-decodes.
+                assert!(!ciphertext_b64.is_empty(), "ciphertext_b64 must be non-empty");
+                let decoded = base64::engine::general_purpose::STANDARD
+                    .decode(ciphertext_b64)
+                    .expect("ciphertext_b64 must base64-decode");
+                assert!(!decoded.is_empty(), "decoded ciphertext must be non-empty");
+                assert_ne!(
+                    decoded.as_slice(),
+                    plaintext.as_slice(),
+                    "journalled bytes must be ciphertext, never plaintext (T-46-01)"
+                );
+                // The file key is ECIES-wrapped (present, hex-encoded), never raw.
+                assert!(
+                    !wrapped_key_hex.is_empty(),
+                    "wrapped_key_hex must be present and ECIES-wrapped (T-46-02)"
+                );
+                assert!(
+                    hex::decode(wrapped_key_hex).is_ok(),
+                    "wrapped_key_hex must be valid hex"
+                );
+            }
+            other => panic!("expected UploadFile op, got {:?}", other),
+        }
+
+        // Plaintext is carried transiently in memory only, never in the entry.
+        assert_eq!(result.plaintext, plaintext);
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[tokio::test]
+    async fn build_mkdir_journal_entry_round_trips() {
+        let (private_key, public_key) = real_keypair();
+        let fs = make_test_fs_with_keypair(private_key, public_key);
+
+        let parent_ino = crate::inode::ROOT_INO;
+        let child_ino = 9001u64;
+        let child_ipns_private_key = Zeroizing::new(vec![3u8; 32]);
+
+        let result = fs
+            .build_mkdir_journal_entry(
+                parent_ino,
+                child_ino,
+                "newdir",
+                &[5u8; 32],          // folder_key
+                "k51child-newdir",   // child ipns name
+                child_ipns_private_key,
+                "deadbeef",          // encrypted_folder_key_hex
+            )
+            .expect("mkdir builder must succeed against the root parent");
+
+        assert_eq!(result.ino, child_ino, "result must reference the new child");
+        match &result.entry.op {
+            cipherbox_sdk::JournalOp::MkdirPublish {
+                child_ipns_name,
+                name,
+                child_ipns_key_hex,
+                parent_ipns_key_hex,
+                ..
+            } => {
+                assert_eq!(child_ipns_name, "k51child-newdir");
+                assert_eq!(name, "newdir");
+                // Both IPNS keys are ECIES-wrapped (non-empty hex), never raw.
+                assert!(
+                    !child_ipns_key_hex.is_empty() && hex::decode(child_ipns_key_hex).is_ok(),
+                    "child IPNS key must be ECIES-wrapped hex (T-46-02)"
+                );
+                assert!(
+                    !parent_ipns_key_hex.is_empty() && hex::decode(parent_ipns_key_hex).is_ok(),
+                    "parent IPNS key must be ECIES-wrapped hex (T-46-02)"
+                );
+            }
+            other => panic!("expected MkdirPublish op, got {:?}", other),
+        }
+    }
 }

--- a/crates/fuse/src/lib.rs
+++ b/crates/fuse/src/lib.rs
@@ -2985,18 +2985,28 @@ mod durability_characterization_tests {
         );
 
         // The detached upload to 127.0.0.1:1 fails and calls record_failure, which
-        // RETAINS the entry (never silently dropped). Drain briefly and re-check.
-        std::thread::sleep(std::time::Duration::from_millis(200));
-        fs.drain_upload_completions();
-        let after = fs
-            .journal
-            .load_all_for_vault(&vault)
-            .expect("journal load after drain must succeed");
+        // RETAINS the entry (never silently dropped) and increments `retries`.
+        // Poll-drain until that failure is actually recorded rather than relying on
+        // a fixed sleep -- the detached upload's failure timing is nondeterministic
+        // on a busy CI runner.
+        fn is_retained_failure(e: &cipherbox_sdk::JournalEntry) -> bool {
+            matches!(e.op, cipherbox_sdk::JournalOp::UploadFile { .. }) && e.retries >= 1
+        }
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let after = loop {
+            fs.drain_upload_completions();
+            let entries = fs
+                .journal
+                .load_all_for_vault(&vault)
+                .expect("journal load after drain must succeed");
+            if entries.iter().any(is_retained_failure) || std::time::Instant::now() >= deadline {
+                break entries;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        };
         assert!(
-            after
-                .iter()
-                .any(|e| matches!(e.op, cipherbox_sdk::JournalOp::UploadFile { .. })),
-            "the UploadFile entry must be retained after the upload failure (record_failure)"
+            after.iter().any(is_retained_failure),
+            "the UploadFile entry must be retained with a recorded failure (retries >= 1) after record_failure"
         );
     }
 

--- a/crates/fuse/src/lib.rs
+++ b/crates/fuse/src/lib.rs
@@ -217,7 +217,7 @@ async fn resolve_ipns_for_replay(
     api: &cipherbox_api_client::ApiClient,
     ipns_name: &str,
 ) -> crate::error::IpnsResolveOutcome {
-    classify_resolve_outcome(coordinator.resolve_sequence(api, ipns_name).await)
+    classify_resolve_outcome(coordinator.resolve_sequence_strict(api, ipns_name).await)
 }
 
 /// Pure classification of a `resolve_sequence` result into an [`crate::error::IpnsResolveOutcome`].
@@ -300,6 +300,24 @@ impl PublishCoordinator {
                 )),
             },
         }
+    }
+
+    /// Strict resolve for replay classification: returns Err on ANY resolve failure,
+    /// never falling back to the cache. A genuine success still updates+returns the
+    /// max(resolved, cached) sequence so a subsequent confirmed publish advances correctly.
+    pub async fn resolve_sequence_strict(
+        &self,
+        api: &cipherbox_api_client::ApiClient,
+        ipns_name: &str,
+    ) -> Result<u64, String> {
+        let resp = cipherbox_api_client::ipns::resolve_ipns(api, ipns_name)
+            .await
+            .map_err(|e| format!("IPNS resolve failed for {}: {}", ipns_name, e))?;
+        let resolved = resp.sequence_number.parse::<u64>().unwrap_or(0);
+        let cached = self.get_cached(ipns_name).unwrap_or(0);
+        let seq = std::cmp::max(resolved, cached);
+        self.update_cache(ipns_name, seq);
+        Ok(seq)
     }
 
     pub fn record_publish(&self, ipns_name: &str, published_seq: u64) {
@@ -1855,6 +1873,18 @@ async fn replay_upload_entry(
     tee_key_epoch: Option<u32>,
 ) -> Result<(), String> {
     use base64::Engine;
+
+    // REQ-4: park legacy entries with no per-file IPNS name rather than publishing an
+    // empty, unresolvable FilePointer (id "replay-", file_meta_ipns_name ""). Returning
+    // Err routes through record_failure → retained on disk; never marks the entry replayed.
+    // No fresh-IPNS minting — lowest risk, no new key material. Placed above Step 1 (the
+    // ciphertext upload/pin) so legacy entries don't re-pin content on every mount.
+    if file_meta_ipns_name.is_none() {
+        return Err(
+            "legacy UploadFile entry has no per-file IPNS name -- parking (no empty FilePointer)"
+                .to_string(),
+        );
+    }
 
     // CR-01: hex-decode and ecies-unwrap the journaled parent IPNS key.
     // Returns Err if the key is absent/malformed so the entry is retained (T-43-20).

--- a/crates/fuse/src/lib.rs
+++ b/crates/fuse/src/lib.rs
@@ -2362,6 +2362,218 @@ mod tests {
         );
     }
 
+    // REQ-4 motivation: two distinct FilePointers that both carry an EMPTY
+    // file_meta_ipns_name collapse to a single entry under merge_folder_children
+    // (they key on the empty string ""). This pins WHY legacy None-name replay
+    // entries must be parked rather than published as empty FilePointers — an
+    // empty locator is not a unique key and silently clobbers siblings. Pure, no network.
+    #[test]
+    fn empty_name_merge_collision() {
+        use cipherbox_core::folder::{FilePointer, FolderChild, FolderMetadata};
+
+        let empty_a = FolderChild::File(FilePointer {
+            id: "replay-".to_string(),
+            name: "file_a.txt".to_string(),
+            file_meta_ipns_name: String::new(), // empty locator
+            ipns_private_key_encrypted: None,
+            created_at: 1000,
+            modified_at: 2000,
+        });
+        let empty_b = FolderChild::File(FilePointer {
+            id: "replay-".to_string(),
+            name: "file_b.txt".to_string(), // distinct name/timestamps...
+            file_meta_ipns_name: String::new(), // ...but the SAME empty locator
+            ipns_private_key_encrypted: None,
+            created_at: 1001,
+            modified_at: 2001,
+        });
+
+        // One empty-name pointer is local, the other remote. They are distinct files but
+        // share the "" locator key, so merge cannot keep both: the remote loop looks up
+        // local_by_ipns[""], finds the local version, pushes it, and marks "" seen; the
+        // local loop then skips it. Two distinct empty-name files collapse to one.
+        let local_meta = FolderMetadata {
+            version: "v2".to_string(),
+            children: vec![empty_a],
+        };
+        let remote_meta = FolderMetadata {
+            version: "v2".to_string(),
+            children: vec![empty_b],
+        };
+
+        let merged = super::merge_folder_children(&local_meta, remote_meta);
+
+        assert_eq!(
+            merged.children.len(),
+            1,
+            "two distinct empty-name FilePointers collapse to one (they collide on the \"\" key)"
+        );
+    }
+
+    // REQ-4: a legacy UploadFile journal entry with file_meta_ipns_name == None is parked
+    // (retained), never published as an empty FilePointer. The early Err in
+    // replay_upload_entry routes through record_failure, so after replay against an
+    // unroutable API the entry count stays at 1. Mirrors
+    // replay_for_vault_does_not_touch_failed_entries harness.
+    #[cfg(any(feature = "fuse", feature = "winfsp"))]
+    #[tokio::test]
+    async fn legacy_empty_name_parks() {
+        use cipherbox_sdk::{JournalEntry, JournalEntryStatus, JournalOp, WriteQueue};
+        use std::sync::Arc;
+
+        let dir = std::env::temp_dir()
+            .join("cb-req4-legacy-empty-name-parks")
+            .join(format!("{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let journal = WriteQueue::new(dir.clone(), 5);
+        let vault = "k51vaultreq4";
+
+        // Legacy entry: per-file IPNS name is None → must be parked, not published.
+        let entry = JournalEntry {
+            id: "legacy-none-name".to_string(),
+            vault_root_ipns: vault.to_string(),
+            op: JournalOp::UploadFile {
+                ciphertext_b64: base64::Engine::encode(
+                    &base64::engine::general_purpose::STANDARD,
+                    b"ct",
+                ),
+                wrapped_key_hex: hex::encode(b"wk"),
+                iv_hex: hex::encode(b"iv"),
+                file_meta_ipns_name: None,
+                file_ipns_key_hex: None,
+                parent_folder_ipns_name: vault.to_string(),
+                parent_ipns_key_hex: hex::encode(b"ecies-parent-key"),
+                filename: "legacy.txt".to_string(),
+                size: 1,
+                created_at_ms: 1_700_000_000_000,
+            },
+            retries: 0,
+            status: JournalEntryStatus::Pending,
+        };
+        journal.put(&entry).unwrap();
+
+        let api = Arc::new(cipherbox_api_client::ApiClient::new("http://127.0.0.1:1"));
+        let coordinator = Arc::new(super::PublishCoordinator::new());
+
+        super::replay_for_vault(
+            &journal,
+            api,
+            &[0u8; 32],
+            &[0u8; 33],
+            &[0u8; 32],
+            vault,
+            coordinator,
+            None,
+            None,
+        )
+        .await;
+
+        let after = journal.load_all_for_vault(vault).unwrap();
+        assert_eq!(
+            after.len(),
+            1,
+            "legacy None-name entry must be retained (parked), not removed as replayed"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // REQ-5: resolve_sequence_strict returns Err on ANY resolve failure, NEVER falling
+    // back to the cache. Here the cache is seeded via record_publish(N) but the API is
+    // unroutable, so strict resolve must err (unlike resolve_sequence which would return
+    // Ok(cached)).
+    #[cfg(any(feature = "fuse", feature = "winfsp"))]
+    #[tokio::test]
+    async fn strict_resolve_bypasses_cache() {
+        let api = cipherbox_api_client::ApiClient::new("http://127.0.0.1:1");
+        let coordinator = super::PublishCoordinator::new();
+        let ipns_name = "k51strictbypass";
+
+        // Seed the cache: resolve_sequence would now return Ok(42) on failure.
+        coordinator.record_publish(ipns_name, 42);
+
+        let result = coordinator.resolve_sequence_strict(&api, ipns_name).await;
+        assert!(
+            result.is_err(),
+            "strict resolve must err on resolve failure even with a populated cache (got {:?})",
+            result
+        );
+    }
+
+    // REQ-5: a transient (non-404) resolve failure during replay retains the entry rather
+    // than advancing IPNS off a stale cached sequence. The IPNS name has a cached sequence
+    // seeded, but because resolve_ipns_for_replay now uses the strict resolve, the failure
+    // is classified as Error(_) → entry retained (len stays 1). Mirrors the replay-retain
+    // harness.
+    #[cfg(any(feature = "fuse", feature = "winfsp"))]
+    #[tokio::test]
+    async fn transient_failure_retains_entry() {
+        use cipherbox_sdk::{JournalEntry, JournalEntryStatus, JournalOp, WriteQueue};
+        use std::sync::Arc;
+
+        let dir = std::env::temp_dir()
+            .join("cb-req5-transient-failure-retains")
+            .join(format!("{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let journal = WriteQueue::new(dir.clone(), 5);
+        let vault = "k51vaultreq5";
+        let file_meta = "k51filemetareq5";
+
+        // Entry has a per-file IPNS name AND key, so replay reaches the resolve step.
+        let entry = JournalEntry {
+            id: "transient-retain".to_string(),
+            vault_root_ipns: vault.to_string(),
+            op: JournalOp::UploadFile {
+                ciphertext_b64: base64::Engine::encode(
+                    &base64::engine::general_purpose::STANDARD,
+                    b"ct",
+                ),
+                wrapped_key_hex: hex::encode(b"wk"),
+                iv_hex: hex::encode(b"iv"),
+                file_meta_ipns_name: Some(file_meta.to_string()),
+                file_ipns_key_hex: Some(hex::encode(b"ecies-file-key")),
+                parent_folder_ipns_name: vault.to_string(),
+                parent_ipns_key_hex: hex::encode(b"ecies-parent-key"),
+                filename: "transient.txt".to_string(),
+                size: 1,
+                created_at_ms: 1_700_000_000_000,
+            },
+            retries: 0,
+            status: JournalEntryStatus::Pending,
+        };
+        journal.put(&entry).unwrap();
+
+        let api = Arc::new(cipherbox_api_client::ApiClient::new("http://127.0.0.1:1"));
+        let coordinator = Arc::new(super::PublishCoordinator::new());
+        // Seed a cached sequence for the per-file IPNS name. With the OLD cache-fallback
+        // resolve this would let replay advance off the cache; strict resolve must err.
+        coordinator.record_publish(file_meta, 7);
+
+        super::replay_for_vault(
+            &journal,
+            api,
+            &[0u8; 32],
+            &[0u8; 33],
+            &[0u8; 32],
+            vault,
+            coordinator,
+            None,
+            None,
+        )
+        .await;
+
+        let after = journal.load_all_for_vault(vault).unwrap();
+        assert_eq!(
+            after.len(),
+            1,
+            "transient resolve failure must retain the entry (strict resolve, no cache fallback)"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     // T-45-05: not_found_outcome_drives_first_publish
     //
     // Pins the #19 branch contract: given each IpnsResolveOutcome variant, the replay
@@ -2555,5 +2767,295 @@ mod handler_harness_tests {
         let reply = <ReplyEmpty as Reply>::new(1, CaptureSender(cap.clone()));
         crate::read_ops::implementation::handle_flush(reply);
         assert_eq!(reply_error_code(&cap), 0, "flush must reply ok");
+    }
+}
+
+/// REQ-1 / REQ-2 durability characterization tests (Plan 46-04).
+///
+/// These lock in behavior that is ALREADY CORRECT in the production tree; they
+/// would FAIL if a future change regressed the D-04 journal-before-ack barrier
+/// (read_ops.rs handle_release: journal.put → handle.cleanup → reply.ok) or the
+/// mkdir conflict re-arm (write_ops.rs MkdirConflict send → drain → re-queue).
+/// They are tests only — no production code is touched.
+#[cfg(all(test, feature = "fuse"))]
+mod durability_characterization_tests {
+    use crate::test_support::{
+        make_test_fs, make_test_fs_with_keypair, reply_error_code, CaptureSender,
+    };
+    use base64::Engine;
+    use fuser::{Reply, ReplyEntry};
+    use std::sync::{Arc, Mutex};
+    use zeroize::Zeroizing;
+
+    /// Generate a real secp256k1 keypair (33-byte compressed pubkey, 32-byte
+    /// secret) via the `ecies` dev-dep. A zero vec is NOT a valid curve point, so
+    /// handlers that ECIES-wrap keys (mkdir, release) need a real one.
+    fn real_keypair() -> (Zeroizing<Vec<u8>>, Zeroizing<Vec<u8>>) {
+        let (sk, pk) = ecies::utils::generate_keypair();
+        (
+            Zeroizing::new(sk.serialize().to_vec()),
+            Zeroizing::new(pk.serialize().to_vec()),
+        )
+    }
+
+    // ---- REQ-1: mkdir ----
+
+    /// REQ-1 / D-04: `handle_mkdir` journals the MkdirPublish entry to disk and
+    /// mutates the parent (root) inode children BEFORE replying. A future reorder
+    /// that put `reply.entry()` ahead of `journal.put` would leave the parent
+    /// without a durable replay record on crash — this test would catch it.
+    ///
+    /// `multi_thread` because mkdir spawns a detached publish thread; it targets
+    /// the unroutable 127.0.0.1:1 host and fails harmlessly, so the journal entry
+    /// is RETAINED (D-11b) — we assert the entry exists, never emptiness.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mkdir_happy_path_puts_journal_entry_then_replies_entry() {
+        let (private_key, public_key) = real_keypair();
+        let mut fs = make_test_fs_with_keypair(private_key, public_key);
+        let vault = fs.root_ipns_name.clone();
+
+        let cap = Arc::new(Mutex::new(Vec::new()));
+        let reply = <ReplyEntry as Reply>::new(1, CaptureSender(cap.clone()));
+
+        crate::write_ops::implementation::handle_mkdir(
+            &mut fs,
+            crate::inode::ROOT_INO,
+            std::ffi::OsStr::new("newdir"),
+            reply,
+        );
+
+        // (3) Reply is success.
+        assert_eq!(reply_error_code(&cap), 0, "mkdir must reply entry (ok)");
+
+        // (1) The parent (root) inode now lists the new child.
+        let root = fs
+            .inodes
+            .get(crate::inode::ROOT_INO)
+            .expect("root inode present");
+        let children = root.children.clone().unwrap_or_default();
+        assert!(
+            !children.is_empty(),
+            "root must have the new child after mkdir"
+        );
+        let child_ino = children[0];
+        let child = fs.inodes.get(child_ino).expect("child inode present");
+        assert_eq!(child.name, "newdir", "child name must match");
+
+        // (2) At least one journal entry was fsynced before the reply.
+        let entries = fs
+            .journal
+            .load_all_for_vault(&vault)
+            .expect("journal load must succeed");
+        assert!(
+            !entries.is_empty(),
+            "mkdir must journal a MkdirPublish entry before replying (D-04)"
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|e| matches!(e.op, cipherbox_sdk::JournalOp::MkdirPublish { .. })),
+            "the journalled entry must be a MkdirPublish op"
+        );
+    }
+
+    /// REQ-1 / D-11a: an `FsEvent::MkdirConflict` drained through
+    /// `drain_upload_completions` re-arms the debounced publisher — the parent ino
+    /// lands in BOTH `mutated_folders` and `publish_queue`. Pure in-memory; no
+    /// network. This locks in the conflict re-arm at lib.rs:949-955.
+    #[tokio::test]
+    async fn mkdir_conflict_rearms() {
+        let mut fs = make_test_fs();
+        let parent_ino = crate::inode::ROOT_INO;
+
+        // Pre-state: neither map references the parent.
+        assert!(!fs.mutated_folders.contains_key(&parent_ino));
+        assert!(!fs.publish_queue.contains_key(&parent_ino));
+
+        // Signal a parent-publish conflict exactly as the background mkdir thread does.
+        fs.upload_tx
+            .send(crate::FsEvent::MkdirConflict { parent_ino })
+            .expect("send MkdirConflict on upload channel");
+
+        fs.drain_upload_completions();
+
+        assert!(
+            fs.mutated_folders.contains_key(&parent_ino),
+            "MkdirConflict must re-arm mutated_folders for the parent"
+        );
+        assert!(
+            fs.publish_queue.contains_key(&parent_ino),
+            "MkdirConflict must enqueue the parent for debounced republish"
+        );
+    }
+
+    // ---- REQ-2: release / replay ----
+
+    /// REQ-2 / D-04: `handle_release` on a dirty new file journals the ciphertext
+    /// into a fsynced entry BEFORE `handle.cleanup()` deletes the temp file and
+    /// BEFORE `reply.ok()`. Asserts:
+    ///   (1) a journal entry exists whose UploadFile.ciphertext_b64 is non-empty,
+    ///   (2) the temp file path no longer exists (cleanup ran),
+    ///   (3) the reply is success,
+    /// and after draining the detached failure (127.0.0.1:1 → record_failure) the
+    /// entry is STILL present (retained, never silently dropped).
+    ///
+    /// A future reorder that acked the OS before `journal.put`, or that deleted the
+    /// temp file before journalling the ciphertext, would fail (1) or (2).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn release_journals_before_cleanup() {
+        let (private_key, public_key) = real_keypair();
+        let mut fs = make_test_fs_with_keypair(private_key, public_key);
+        let vault = fs.root_ipns_name.clone();
+
+        // Create a new file under root via handle_create so the inode + write
+        // handle exist exactly as the OS would have set them up.
+        let cap_create = Arc::new(Mutex::new(Vec::new()));
+        let reply_create =
+            <fuser::ReplyCreate as Reply>::new(1, CaptureSender(cap_create.clone()));
+        crate::write_ops::implementation::handle_create(
+            &mut fs,
+            crate::inode::ROOT_INO,
+            std::ffi::OsStr::new("note.txt"),
+            0,
+            reply_create,
+        );
+        assert_eq!(reply_error_code(&cap_create), 0, "create must reply ok");
+
+        // Locate the freshly created file inode + its open write handle.
+        let ino = fs
+            .inodes
+            .find_child(crate::inode::ROOT_INO, "note.txt")
+            .expect("created file inode present");
+        let (&fh, _) = fs
+            .open_files
+            .iter()
+            .find(|(_, h)| h.ino == ino && h.temp_path.is_some())
+            .expect("write handle present for new file");
+
+        // Write bytes into the temp file and mark dirty (as handle_write would).
+        let plaintext = b"the quick brown fox";
+        {
+            let handle = fs.open_files.get_mut(&fh).expect("handle present");
+            handle.write_at(0, plaintext).expect("write temp file");
+            handle.dirty = true;
+        }
+        let temp_path = fs
+            .open_files
+            .get(&fh)
+            .and_then(|h| h.temp_path.clone())
+            .expect("temp path present");
+        assert!(temp_path.exists(), "temp file must exist before release");
+
+        // Release the handle.
+        let cap = Arc::new(Mutex::new(Vec::new()));
+        let reply = <fuser::ReplyEmpty as Reply>::new(1, CaptureSender(cap.clone()));
+        crate::read_ops::implementation::handle_release(&mut fs, ino, fh, reply);
+
+        // (3) Reply is success.
+        assert_eq!(reply_error_code(&cap), 0, "release must reply ok");
+
+        // (1) A journal entry exists whose ciphertext_b64 is non-empty.
+        let entries = fs
+            .journal
+            .load_all_for_vault(&vault)
+            .expect("journal load must succeed");
+        let upload = entries
+            .iter()
+            .find_map(|e| match &e.op {
+                cipherbox_sdk::JournalOp::UploadFile { ciphertext_b64, .. } => {
+                    Some(ciphertext_b64.clone())
+                }
+                _ => None,
+            })
+            .expect("release must journal an UploadFile entry before cleanup (D-04)");
+        assert!(
+            !upload.is_empty(),
+            "journalled ciphertext_b64 must be non-empty"
+        );
+
+        // (2) The temp file was deleted by handle.cleanup() (read_ops.rs:882).
+        assert!(
+            !temp_path.exists(),
+            "release must delete the temp file via handle.cleanup()"
+        );
+
+        // The detached upload to 127.0.0.1:1 fails and calls record_failure, which
+        // RETAINS the entry (never silently dropped). Drain briefly and re-check.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        fs.drain_upload_completions();
+        let after = fs
+            .journal
+            .load_all_for_vault(&vault)
+            .expect("journal load after drain must succeed");
+        assert!(
+            after
+                .iter()
+                .any(|e| matches!(e.op, cipherbox_sdk::JournalOp::UploadFile { .. })),
+            "the UploadFile entry must be retained after the upload failure (record_failure)"
+        );
+    }
+
+    /// REQ-2 replay: a pure `WriteQueue` round-trip — the journalled ciphertext
+    /// survives independently of any temp file. Build an UploadFile entry with a
+    /// known ciphertext, `put` it, then a FRESH `WriteQueue` over the same dir
+    /// reloads it and the `ciphertext_b64` base64-decodes to the original bytes.
+    /// No network, no spawn (crash simulation: the upload thread never runs).
+    #[tokio::test]
+    async fn replay_reuploads_ciphertext() {
+        // Isolated journal dir owned by this test — `put` here, reload via a fresh
+        // WriteQueue (no fs handle needed; the round-trip is the unit under test).
+        let journal_dir = crate::test_support::make_isolated_journal_dir();
+        let vault = "k51replay-vault".to_string();
+        let put_queue = cipherbox_sdk::WriteQueue::new(journal_dir.clone(), 5);
+
+        let original_ciphertext: &[u8] = &[0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03];
+        let ciphertext_b64 =
+            base64::engine::general_purpose::STANDARD.encode(original_ciphertext);
+
+        let entry = cipherbox_sdk::JournalEntry {
+            id: "replay-test-entry".to_string(),
+            vault_root_ipns: vault.clone(),
+            op: cipherbox_sdk::JournalOp::UploadFile {
+                ciphertext_b64: ciphertext_b64.clone(),
+                wrapped_key_hex: "deadbeef".to_string(),
+                iv_hex: "00112233445566778899aabb".to_string(),
+                file_meta_ipns_name: None,
+                file_ipns_key_hex: None,
+                parent_folder_ipns_name: vault.clone(),
+                parent_ipns_key_hex: String::new(),
+                filename: "replay.bin".to_string(),
+                size: original_ciphertext.len() as u64,
+                created_at_ms: 1_700_000_000_000,
+            },
+            retries: 0,
+            status: cipherbox_sdk::JournalEntryStatus::Pending,
+        };
+
+        put_queue.put(&entry).expect("journal put must succeed");
+
+        // A FRESH WriteQueue over the same dir — simulates next-mount replay load.
+        let reloaded_queue = cipherbox_sdk::WriteQueue::new(journal_dir, 5);
+        let reloaded = reloaded_queue
+            .load_all_for_vault(&vault)
+            .expect("reload must succeed");
+
+        let reloaded_b64 = reloaded
+            .iter()
+            .find_map(|e| match &e.op {
+                cipherbox_sdk::JournalOp::UploadFile { ciphertext_b64, .. } => {
+                    Some(ciphertext_b64.clone())
+                }
+                _ => None,
+            })
+            .expect("reloaded UploadFile entry present");
+
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&reloaded_b64)
+            .expect("reloaded ciphertext_b64 must base64-decode");
+        assert_eq!(
+            decoded.as_slice(),
+            original_ciphertext,
+            "replay must recover the exact journalled ciphertext bytes"
+        );
     }
 }

--- a/crates/fuse/src/lib.rs
+++ b/crates/fuse/src/lib.rs
@@ -313,7 +313,12 @@ impl PublishCoordinator {
         let resp = cipherbox_api_client::ipns::resolve_ipns(api, ipns_name)
             .await
             .map_err(|e| format!("IPNS resolve failed for {}: {}", ipns_name, e))?;
-        let resolved = resp.sequence_number.parse::<u64>().unwrap_or(0);
+        let resolved = resp.sequence_number.parse::<u64>().map_err(|e| {
+            format!(
+                "Invalid IPNS sequence '{}' for {}: {}",
+                resp.sequence_number, ipns_name, e
+            )
+        })?;
         let cached = self.get_cached(ipns_name).unwrap_or(0);
         let seq = std::cmp::max(resolved, cached);
         self.update_cache(ipns_name, seq);

--- a/crates/fuse/src/lib.rs
+++ b/crates/fuse/src/lib.rs
@@ -25,6 +25,10 @@ pub mod write_ops;
 // Platform-specific modules
 pub mod platform;
 
+// Test-only harness (make_test_fs / CaptureSender / reply_error_code).
+#[cfg(all(test, feature = "fuse"))]
+mod test_support;
+
 // Re-exports
 pub use cache::{ContentCache, MetadataCache};
 pub use error::FuseError;

--- a/crates/fuse/src/lib.rs
+++ b/crates/fuse/src/lib.rs
@@ -2495,3 +2495,35 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 }
+
+// REQ-6: Sample handler tests proving the test_support harness works. Gated on
+// `feature = "fuse"` because they construct `fuser::Reply*` values and use the
+// `crate::test_support` module (which is itself fuse-feature-gated).
+#[cfg(all(test, feature = "fuse"))]
+mod handler_harness_tests {
+    use crate::test_support::{make_test_fs, reply_error_code, CaptureSender};
+    use fuser::{Reply, ReplyAttr, ReplyEmpty};
+    use std::sync::{Arc, Mutex};
+
+    /// getattr on the root inode must reply with error == 0 (success) — the
+    /// metadata-only path needs no network and proves CaptureSender captures the
+    /// out-header.
+    #[tokio::test]
+    async fn getattr_returns_ok_for_root() {
+        let mut fs = make_test_fs();
+        let cap = Arc::new(Mutex::new(Vec::new()));
+        let reply = <ReplyAttr as Reply>::new(1, CaptureSender(cap.clone()));
+        crate::read_ops::implementation::handle_getattr(&mut fs, crate::inode::ROOT_INO, reply);
+        assert_eq!(reply_error_code(&cap), 0, "getattr root must reply ok");
+    }
+
+    /// flush is a no-op that replies error == 0 (durability lives on release).
+    /// Also satisfies the REQ-2 flush-no-op verification consumed by Plan 04.
+    #[tokio::test]
+    async fn flush_returns_ok() {
+        let cap = Arc::new(Mutex::new(Vec::new()));
+        let reply = <ReplyEmpty as Reply>::new(1, CaptureSender(cap.clone()));
+        crate::read_ops::implementation::handle_flush(reply);
+        assert_eq!(reply_error_code(&cap), 0, "flush must reply ok");
+    }
+}

--- a/crates/fuse/src/platform/linux.rs
+++ b/crates/fuse/src/platform/linux.rs
@@ -1,6 +1,7 @@
 //! Linux-specific FUSE mount/unmount using kernel FUSE.
 
 use crate::mount_point;
+use std::path::Path;
 
 /// Unmount the FUSE filesystem on Linux.
 ///
@@ -67,5 +68,204 @@ fn cleanup_temp_dir() {
         if let Err(e) = std::fs::remove_dir_all(&temp_dir) {
             log::warn!("Failed to clean temp directory: {}", e);
         }
+    }
+}
+
+/// Un-escape a `/proc/self/mountinfo` field.
+///
+/// mountinfo encodes whitespace and a few control characters as octal escapes
+/// (`\NNN`), most notably space as `\040`. Decode them so a path comparison
+/// against a real on-disk path matches.
+fn unescape_mountinfo_field(field: &str) -> String {
+    let bytes = field.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        // A backslash followed by exactly three octal digits is an escape.
+        if bytes[i] == b'\\' && i + 3 < bytes.len() {
+            let d0 = bytes[i + 1];
+            let d1 = bytes[i + 2];
+            let d2 = bytes[i + 3];
+            if d0.is_ascii_digit()
+                && d0 <= b'7'
+                && d1.is_ascii_digit()
+                && d1 <= b'7'
+                && d2.is_ascii_digit()
+                && d2 <= b'7'
+            {
+                let value = ((d0 - b'0') << 6) | ((d1 - b'0') << 3) | (d2 - b'0');
+                out.push(value);
+                i += 4;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Returns true if `mount_path` appears as a mount point in the given
+/// `/proc/self/mountinfo` content.
+///
+/// Pure function over the mountinfo text + target path so it is unit-testable
+/// without reading `/proc`. The mount-point is field index 4 (0-based,
+/// space-separated) of each line; mountinfo octal-escapes (e.g. `\040` for
+/// space) are decoded before comparison.
+pub(crate) fn mountinfo_contains_mountpoint(mountinfo: &str, mount_path: &Path) -> bool {
+    for line in mountinfo.lines() {
+        let mut fields = line.split(' ');
+        // Field index 4 is the mount point.
+        if let Some(raw_mountpoint) = fields.nth(4) {
+            let decoded = unescape_mountinfo_field(raw_mountpoint);
+            if Path::new(&decoded) == mount_path {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Best-effort recovery of a stale/disconnected Linux FUSE mount before
+/// (re)mounting at the same path.
+///
+/// A crashed FUSE session leaves the mount point in a disconnected state where
+/// `stat()` returns ENOTCONN, so `Path::exists()` lies (returns false). We
+/// instead consult `/proc/self/mountinfo` authoritatively; if the mount point
+/// is still present we unmount it (`fusermount3 -u`, then lazy `fusermount3 -z
+/// -u` as a fallback for the disconnected case).
+///
+/// This is best-effort: any error (failure to read mountinfo, failed unmount)
+/// is logged and the function returns so the caller proceeds with its normal
+/// `exists()` / `create_dir_all` / clean-stale logic.
+pub fn recover_stale_mount(mount_path: &Path) {
+    let mountinfo = match std::fs::read_to_string("/proc/self/mountinfo") {
+        Ok(contents) => contents,
+        Err(e) => {
+            log::info!(
+                "recover_stale_mount: could not read /proc/self/mountinfo ({}); skipping",
+                e
+            );
+            return;
+        }
+    };
+
+    if !mountinfo_contains_mountpoint(&mountinfo, mount_path) {
+        // Not currently mounted (or not stale); nothing to recover.
+        return;
+    }
+
+    log::info!(
+        "recover_stale_mount: stale mount detected at {}; unmounting",
+        mount_path.display()
+    );
+
+    // Try a normal unmount first.
+    let status = std::process::Command::new("fusermount3")
+        .arg("-u")
+        .arg(mount_path)
+        .status();
+    match status {
+        Ok(s) if s.success() => {
+            log::info!(
+                "recover_stale_mount: unmounted stale mount via fusermount3 -u at {}",
+                mount_path.display()
+            );
+            return;
+        }
+        _ => {
+            log::info!(
+                "recover_stale_mount: fusermount3 -u failed; trying lazy fusermount3 -z -u"
+            );
+        }
+    }
+
+    // Lazy unmount fallback for the disconnected case. -z detaches the mount
+    // now and cleans up references as they are released; acceptable since we
+    // immediately mount a fresh session at the same path.
+    let status = std::process::Command::new("fusermount3")
+        .arg("-z")
+        .arg("-u")
+        .arg(mount_path)
+        .status();
+    match status {
+        Ok(s) if s.success() => {
+            log::info!(
+                "recover_stale_mount: lazily unmounted stale mount via fusermount3 -z -u at {}",
+                mount_path.display()
+            );
+        }
+        _ => {
+            log::info!(
+                "recover_stale_mount: lazy fusermount3 -z -u also failed at {}; proceeding anyway",
+                mount_path.display()
+            );
+        }
+    }
+}
+
+/// Pure decision helper: should a `create_dir_all` error trigger
+/// recover-then-retry-once?
+///
+/// Returns true only for `ErrorKind::AlreadyExists` (EEXIST), which is the
+/// symptom of a disconnected FUSE mount whose dirent still exists. Any other
+/// error kind propagates to the caller unchanged.
+pub(crate) fn should_recover_then_retry(err_kind: std::io::ErrorKind) -> bool {
+    err_kind == std::io::ErrorKind::AlreadyExists
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn mountinfo_detects_stale() {
+        let mountinfo = "\
+36 35 0:30 / / rw,relatime shared:1 - ext4 /dev/sda1 rw
+40 36 0:31 / /home/user/CipherBox rw,nosuid,nodev,relatime shared:2 - fuse.CipherBox CipherBox rw
+41 36 0:32 / /home/user/other rw,relatime shared:3 - ext4 /dev/sdb1 rw\n";
+
+        let target = Path::new("/home/user/CipherBox");
+        assert!(
+            mountinfo_contains_mountpoint(mountinfo, target),
+            "expected the CipherBox mount point to be detected"
+        );
+
+        let absent = Path::new("/home/user/NotMounted");
+        assert!(
+            !mountinfo_contains_mountpoint(mountinfo, absent),
+            "expected an unmounted path to be absent"
+        );
+    }
+
+    #[test]
+    fn mountinfo_detects_stale_with_spaced_path() {
+        // mountinfo escapes the space in "My Vault" as \040.
+        let mountinfo = "\
+36 35 0:30 / / rw,relatime shared:1 - ext4 /dev/sda1 rw
+40 36 0:31 / /home/user/My\\040Vault rw,nosuid,nodev,relatime shared:2 - fuse.CipherBox CipherBox rw\n";
+
+        let target = Path::new("/home/user/My Vault");
+        assert!(
+            mountinfo_contains_mountpoint(mountinfo, target),
+            "expected a mount point with an escaped space (\\040) to be detected"
+        );
+    }
+
+    #[test]
+    fn eexist_triggers_recovery() {
+        assert!(
+            should_recover_then_retry(std::io::ErrorKind::AlreadyExists),
+            "AlreadyExists (EEXIST) must trigger recover-then-retry"
+        );
+        assert!(
+            !should_recover_then_retry(std::io::ErrorKind::NotFound),
+            "NotFound must not trigger recovery"
+        );
+        assert!(
+            !should_recover_then_retry(std::io::ErrorKind::PermissionDenied),
+            "PermissionDenied must not trigger recovery"
+        );
     }
 }

--- a/crates/fuse/src/platform/linux.rs
+++ b/crates/fuse/src/platform/linux.rs
@@ -161,47 +161,41 @@ pub fn recover_stale_mount(mount_path: &Path) {
     );
 
     // Try a normal unmount first.
-    let status = std::process::Command::new("fusermount3")
-        .arg("-u")
-        .arg(mount_path)
-        .status();
-    match status {
-        Ok(s) if s.success() => {
-            log::info!(
-                "recover_stale_mount: unmounted stale mount via fusermount3 -u at {}",
-                mount_path.display()
-            );
-            return;
-        }
-        _ => {
-            log::info!(
-                "recover_stale_mount: fusermount3 -u failed; trying lazy fusermount3 -z -u"
-            );
-        }
+    if try_fusermount3_unmount(mount_path, &["-u"]) {
+        log::info!(
+            "recover_stale_mount: unmounted stale mount via fusermount3 -u at {}",
+            mount_path.display()
+        );
+        return;
     }
+    log::info!("recover_stale_mount: fusermount3 -u failed; trying lazy fusermount3 -z -u");
 
     // Lazy unmount fallback for the disconnected case. -z detaches the mount
     // now and cleans up references as they are released; acceptable since we
     // immediately mount a fresh session at the same path.
-    let status = std::process::Command::new("fusermount3")
-        .arg("-z")
-        .arg("-u")
-        .arg(mount_path)
-        .status();
-    match status {
-        Ok(s) if s.success() => {
-            log::info!(
-                "recover_stale_mount: lazily unmounted stale mount via fusermount3 -z -u at {}",
-                mount_path.display()
-            );
-        }
-        _ => {
-            log::info!(
-                "recover_stale_mount: lazy fusermount3 -z -u also failed at {}; proceeding anyway",
-                mount_path.display()
-            );
-        }
+    if try_fusermount3_unmount(mount_path, &["-z", "-u"]) {
+        log::info!(
+            "recover_stale_mount: lazily unmounted stale mount via fusermount3 -z -u at {}",
+            mount_path.display()
+        );
+    } else {
+        log::info!(
+            "recover_stale_mount: lazy fusermount3 -z -u also failed at {}; proceeding anyway",
+            mount_path.display()
+        );
     }
+}
+
+/// Run `fusermount3 <args> <mount_path>` and report whether it exited
+/// successfully. Spawn/exec failures count as not-successful.
+fn try_fusermount3_unmount(mount_path: &Path, args: &[&str]) -> bool {
+    matches!(
+        std::process::Command::new("fusermount3")
+            .args(args)
+            .arg(mount_path)
+            .status(),
+        Ok(s) if s.success()
+    )
 }
 
 /// Pure decision helper: should a `create_dir_all` error trigger
@@ -212,6 +206,23 @@ pub fn recover_stale_mount(mount_path: &Path) {
 /// error kind propagates to the caller unchanged.
 pub(crate) fn should_recover_then_retry(err_kind: std::io::ErrorKind) -> bool {
     err_kind == std::io::ErrorKind::AlreadyExists
+}
+
+/// Create the mount-point directory, recovering once from a stale FUSE mount.
+///
+/// Belt-and-suspenders for the Linux stale-mount case: a disconnected FUSE
+/// mount whose dirent still exists surfaces as EEXIST from `create_dir_all`
+/// even though `Path::exists()` returned false. On that specific error we
+/// recover the stale mount and retry once; any other error propagates.
+pub fn create_mount_point_dir(mount_path: &Path) -> std::io::Result<()> {
+    match std::fs::create_dir_all(mount_path) {
+        Ok(()) => Ok(()),
+        Err(e) if should_recover_then_retry(e.kind()) => {
+            recover_stale_mount(mount_path);
+            std::fs::create_dir_all(mount_path)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 #[cfg(test)]

--- a/crates/fuse/src/platform/macos.rs
+++ b/crates/fuse/src/platform/macos.rs
@@ -1,6 +1,7 @@
 //! macOS-specific FUSE mount/unmount using FUSE-T with SMB backend.
 
 use crate::mount_point;
+use std::path::Path;
 
 /// Unmount the FUSE filesystem on macOS.
 ///
@@ -46,5 +47,124 @@ fn cleanup_temp_dir() {
         if let Err(e) = std::fs::remove_dir_all(&temp_dir) {
             log::warn!("Failed to clean temp directory: {}", e);
         }
+    }
+}
+
+/// Returns true if `mount_path` appears as a mount point in the given
+/// `mount(8)` output.
+///
+/// Pure function over the `mount` text + target path so it is unit-testable
+/// without spawning `mount`. Each line has the form
+/// `<source> on <mountpoint> (<type>, <opts>)`; the mount point is the text
+/// between " on " and the trailing " (". macOS prints mount-point paths
+/// literally (no octal escaping), so spaces are compared as-is.
+pub(crate) fn mount_output_contains_mountpoint(mount_output: &str, mount_path: &Path) -> bool {
+    for line in mount_output.lines() {
+        if let Some((_, rest)) = line.split_once(" on ") {
+            if let Some((mountpoint, _)) = rest.rsplit_once(" (") {
+                if Path::new(mountpoint) == mount_path {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Best-effort recovery of a stale FUSE-T (SMB) mount before (re)mounting at the
+/// same path.
+///
+/// A crashed FUSE-T session can leave the mount path as a stale `smbfs` mount
+/// backed by a now-dead in-process server, blocking remount until it is
+/// force-unmounted (documented manual remedy: `diskutil unmount force`). We
+/// consult `mount(8)` authoritatively; if the path is still mounted we clear it
+/// (`umount`, then `diskutil unmount force` as a fallback for the stuck case).
+///
+/// macOS analog of `platform::linux::recover_stale_mount`. Best-effort: any
+/// error (failure to run `mount`, failed unmount) is logged and the function
+/// returns so the caller proceeds with its normal `exists()` / `create_dir_all`
+/// / clean-stale logic.
+pub fn recover_stale_mount(mount_path: &Path) {
+    let output = match std::process::Command::new("mount").output() {
+        Ok(o) => o,
+        Err(e) => {
+            log::info!("recover_stale_mount: could not run `mount` ({}); skipping", e);
+            return;
+        }
+    };
+    let mounts = String::from_utf8_lossy(&output.stdout);
+
+    if !mount_output_contains_mountpoint(&mounts, mount_path) {
+        // Not currently mounted; nothing to recover.
+        return;
+    }
+
+    log::info!(
+        "recover_stale_mount: stale mount detected at {}; unmounting",
+        mount_path.display()
+    );
+
+    // Try a normal unmount first.
+    if try_unmount("umount", &[], mount_path) {
+        log::info!(
+            "recover_stale_mount: unmounted stale mount via umount at {}",
+            mount_path.display()
+        );
+        return;
+    }
+    log::info!("recover_stale_mount: umount failed; trying diskutil unmount force");
+
+    // Force fallback for the stuck/disconnected case.
+    if try_unmount("diskutil", &["unmount", "force"], mount_path) {
+        log::info!(
+            "recover_stale_mount: force-unmounted stale mount via diskutil at {}",
+            mount_path.display()
+        );
+    } else {
+        log::info!(
+            "recover_stale_mount: diskutil unmount force also failed at {}; proceeding anyway",
+            mount_path.display()
+        );
+    }
+}
+
+/// Run `<program> <pre_args> <mount_path>` and report whether it exited
+/// successfully. Spawn/exec failures count as not-successful.
+fn try_unmount(program: &str, pre_args: &[&str], mount_path: &Path) -> bool {
+    matches!(
+        std::process::Command::new(program)
+            .args(pre_args)
+            .arg(mount_path)
+            .status(),
+        Ok(s) if s.success()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn mount_output_detects_stale_smbfs() {
+        let mount_output = "\
+/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
+//user@127.0.0.1/share on /Users/me/CipherBox (smbfs, nodev, nosuid, mounted by me)
+map auto_home on /System/Volumes/Data/home (autofs, automounted, nobrowse)\n";
+        assert!(mount_output_contains_mountpoint(mount_output, Path::new("/Users/me/CipherBox")));
+        assert!(!mount_output_contains_mountpoint(mount_output, Path::new("/Users/me/NotMounted")));
+    }
+
+    #[test]
+    fn mount_output_detects_stale_with_spaced_path() {
+        // macOS prints mount-point paths literally (no octal escaping).
+        let mount_output = "//user@127.0.0.1/share on /Users/me/My Vault (smbfs, nodev, nosuid)\n";
+        assert!(mount_output_contains_mountpoint(mount_output, Path::new("/Users/me/My Vault")));
+    }
+
+    #[test]
+    fn mount_output_ignores_substring_paths() {
+        let mount_output = "//x on /Users/me/CipherBoxBackup (smbfs)\n";
+        assert!(!mount_output_contains_mountpoint(mount_output, Path::new("/Users/me/CipherBox")));
     }
 }

--- a/crates/fuse/src/test_support.rs
+++ b/crates/fuse/src/test_support.rs
@@ -1,0 +1,151 @@
+//! Test-only harness for unit-testing FUSE handlers and journal builders.
+//!
+//! This module is compiled only under `#[cfg(all(test, feature = "fuse"))]`.
+//! It provides:
+//!
+//! - [`make_test_fs`] / [`make_test_fs_with_keypair`] — build a fully-populated
+//!   [`CipherBoxFS`] backed by a per-test isolated journal dir, with no live
+//!   network dependency (the API client points at an unroutable host so any
+//!   accidental detached upload thread fails fast).
+//! - [`CaptureSender`] — a [`fuser::ReplySender`] that captures the raw FUSE
+//!   reply bytes into a shared buffer so handler replies can be inspected.
+//! - [`reply_error_code`] — decode the `error` field of the captured
+//!   `fuse_out_header` (offset 4), where `0` means success.
+//!
+//! Security: this harness constructs in-memory state only. It never introduces
+//! raw plaintext keys into the journal (Threat T-46-01) — builder tests use a
+//! real EC keypair so `wrap_key` ECIES-wraps key material (Threat T-46-02).
+
+use std::collections::{HashMap, HashSet};
+use std::io::IoSlice;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::channel;
+use std::sync::{Arc, Mutex};
+
+use zeroize::Zeroizing;
+
+use crate::CipherBoxFS;
+
+/// Monotonic per-test counter so each test gets a unique journal dir even within
+/// the same process.
+static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Return a unique per-test journal dir under the system temp dir.
+///
+/// Keyed by `process::id()` plus a monotonic counter so concurrent tests within
+/// the same process never collide. The dir is created (mirroring the pattern at
+/// `lib.rs` characterization tests). NEVER points at `default_journal_dir()`
+/// (Threat T-46-04).
+pub(crate) fn make_isolated_journal_dir() -> PathBuf {
+    let unique = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir()
+        .join("cb-test-journal")
+        .join(format!("{}-{}", std::process::id(), unique));
+    // queue.rs WriteQueue::new does not create the dir — do it here.
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create isolated journal dir");
+    dir
+}
+
+/// Build a [`CipherBoxFS`] for metadata-only handler tests.
+///
+/// Uses zero keys — fine for handlers that never call `wrap_key`
+/// (getattr/access/lookup/unlink/rmdir/rename/flush/xattr). For builder tests
+/// that wrap keys, use [`make_test_fs_with_keypair`] with a real EC keypair (a
+/// 33-byte zero vec is NOT a valid secp256k1 curve point — Assumption A1).
+///
+/// Must be called from a `#[tokio::test]` because `rt` captures
+/// `tokio::runtime::Handle::current()`.
+pub(crate) fn make_test_fs() -> CipherBoxFS {
+    make_test_fs_with_keypair(Zeroizing::new(vec![0u8; 32]), Zeroizing::new(vec![0u8; 33]))
+}
+
+/// Build a [`CipherBoxFS`] seeded with the provided EC keypair.
+///
+/// `public_key` must be a 33-byte secp256k1 compressed key for the journal
+/// builders' `wrap_key` calls to succeed.
+pub(crate) fn make_test_fs_with_keypair(
+    private_key: Zeroizing<Vec<u8>>,
+    public_key: Zeroizing<Vec<u8>>,
+) -> CipherBoxFS {
+    let journal_dir = make_isolated_journal_dir();
+
+    let (refresh_tx, refresh_rx) = channel();
+    let (content_tx, content_rx) = channel();
+    let (filepointer_tx, filepointer_rx) = channel();
+    let (upload_tx, upload_rx) = channel();
+
+    // Root inode (ino=1) is auto-created by InodeTable::new. Override its kind to
+    // inject ipns_name + ipns_private_key so build_folder_metadata / journal
+    // builders can resolve the root, matching mount glue at mod.rs:138-143.
+    let mut inodes = crate::inode::InodeTable::new();
+    if let Some(root) = inodes.get_mut(crate::inode::ROOT_INO) {
+        root.kind = crate::inode::InodeKind::Root {
+            ipns_name: Some("k51test-root".to_string()),
+            ipns_private_key: Some(Zeroizing::new(vec![7u8; 32])),
+        };
+    }
+
+    CipherBoxFS {
+        inodes,
+        metadata_cache: crate::cache::MetadataCache::new(),
+        content_cache: crate::cache::ContentCache::new(),
+        // Unroutable host: any accidental detached upload thread fails fast.
+        api: Arc::new(cipherbox_api_client::ApiClient::new("http://127.0.0.1:1")),
+        private_key,
+        public_key,
+        root_folder_key: Zeroizing::new(vec![0u8; 32]),
+        root_ipns_name: "k51test-root".to_string(),
+        rt: tokio::runtime::Handle::current(),
+        next_fh: AtomicU64::new(1),
+        open_files: HashMap::new(),
+        temp_dir: std::env::temp_dir().join("cipherbox-test"),
+        tee_public_key: None,
+        tee_key_epoch: None,
+        max_versions_per_file: 5,
+        version_cooldown_ms: 0,
+        refresh_rx,
+        refresh_tx,
+        mutated_folders: HashMap::new(),
+        prefetching: HashSet::new(),
+        refreshing_metadata: HashSet::new(),
+        content_rx,
+        content_tx,
+        filepointer_rx,
+        filepointer_tx,
+        resolving_file_pointers: HashSet::new(),
+        pending_content: HashMap::new(),
+        upload_rx,
+        upload_tx,
+        publish_coordinator: Arc::new(crate::PublishCoordinator::new()),
+        publish_queue: HashMap::new(),
+        journal: cipherbox_sdk::WriteQueue::new(journal_dir, 5),
+    }
+}
+
+/// A [`fuser::ReplySender`] that captures the raw reply bytes into a shared
+/// buffer so handler replies can be inspected in tests.
+#[derive(Clone)]
+pub(crate) struct CaptureSender(pub Arc<Mutex<Vec<u8>>>);
+
+impl fuser::ReplySender for CaptureSender {
+    fn send(&self, data: &[IoSlice<'_>]) -> std::io::Result<()> {
+        let mut buf = self.0.lock().unwrap();
+        for slice in data {
+            buf.extend_from_slice(slice);
+        }
+        Ok(())
+    }
+}
+
+/// Decode the `error` field of a captured `fuse_out_header`.
+///
+/// Wire format (vendor/fuser ll/fuse_abi.rs:932-936):
+///   `fuse_out_header = { len: u32 LE, error: i32 LE, unique: u64 LE }` (16 bytes).
+/// `error == 0` means success; `error == -errno` means failure.
+pub(crate) fn reply_error_code(captured: &Arc<Mutex<Vec<u8>>>) -> i32 {
+    let buf = captured.lock().unwrap();
+    assert!(buf.len() >= 16, "fuse_out_header is 16 bytes");
+    i32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]])
+}


### PR DESCRIPTION
## Phase 46 — Desktop FUSE data-loss bugs + replay hardening

Closes the desktop FUSE write-durability work deferred by Phase 45: three data-loss/durability fixes, two replay-path hardening follow-ups from PR #491, the remaining Rust test coverage (Phase 45 Tier 2), plus cross-platform parity for stale-mount recovery (macOS). Behavior-changing correctness/durability work.

### Changes

**Stale-mount recovery (Linux + macOS)**

- **feat(fuse): auto-recover stale Linux FUSE mount on startup** — a crashed daemon leaves a disconnected mount where `stat()` returns ENOTCONN (so `exists()` lies) and `create_dir_all` then fails with EEXIST. Detect authoritatively via `/proc/self/mountinfo` and clear via `fusermount3 -u` (then lazy `-z -u`); plus a `create_mount_point_dir` EEXIST recover-then-retry belt-and-suspenders.
- **feat(fuse): auto-recover stale FUSE-T mount on macOS startup** — the macOS (FUSE-T/SMB) analog: a crash can leave `~/CipherBox` as a stale `smbfs` mount backed by a dead in-process server. Detect via `mount(8)` and clear via `umount`, then `diskutil unmount force`. Windows (WinFsp) self-heals — its FSD evicts the volume on host death — so no recovery is needed there.

**Replay-path hardening (PR #491 follow-ups)**

- **fix(fuse): park legacy empty file-meta-ipns replay entries** instead of publishing an empty FilePointer.
- **fix(fuse): strict cache-bypassing IPNS resolve** in replay classification so transient failures retain the entry.
- **fix(fuse): fail closed on malformed sequence** — `resolve_sequence_strict` now returns `Err` on an unparseable `sequence_number` instead of `unwrap_or(0)`, so a bad payload retains the entry (addresses CodeRabbit review).

**Durability characterization + Tier-2 tests**

- **test(fuse): characterization tests** pinning mkdir parent-publish-retry and `release()` durability (behavior already correct from PR #487 / PR #491).
- **test(fuse): Tier-2 coverage** — read_ops/write_ops handler harness (unblocks the fuser `ReplySender` limitation) plus `journal_helpers` builder tests.

### Verification

- `cargo test -p cipherbox-fuse --features fuse` → **60 passed**; `cargo clippy --features fuse --tests` clean; `cargo check` for the fuse + desktop crates clean.
- Security: 12/12 threats verified closed (`46-SECURITY.md`).
- Goal-backward verify: 6/6 requirements met (`46-VERIFICATION.md`).
- CodeRabbit: all review threads resolved (test temp-dir isolation; malformed-sequence fail-closed).

### Crash-recovery validation (both platforms confirmed)

- **macOS** — verified via a live test: stood up a real mount, reproduced a stuck/busy mount where plain `umount` returns `Resource busy`, and confirmed `recover_stale_mount` cleared it via the `diskutil unmount force` fallback. The `mount(8)` parser is also unit-tested against the `smbfs` line format.
- **Linux** — confirmed directly on real Linux hardware (mount → `kill -9` → restart → clean auto-recovery), validating the ENOTCONN / `exists()`-lies / EEXIST signature and `fusermount3` recovery the design hinges on.

### Notes

- Touches only Rust/desktop (`crates/fuse`, `apps/desktop`); disjoint from Phase 47 (PR #494).
- Both this and Phase 47 modify `.planning/STATE.md`; expect a trivial conflict when landing the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
