### PR TITLE
fix(test): align edit-filepointer helper with updateFileMetadata internal-publish contract

### DIFF
--- a/packages/sdk-core/scripts/edit-filepointer.mjs
+++ b/packages/sdk-core/scripts/edit-filepointer.mjs
@@ -21,7 +21,6 @@ import {
   loadFolderMetadata,
   resolveFileMetadata,
   updateFileMetadata,
-  replaceFileInFolder,
   updateFolderMetadataAndPublish,
 } from '../dist/index.mjs';
 import {
@@ -185,10 +184,13 @@ async function main() {
     clearBytes(fileKey);
   }
 
-  // 9. Update file metadata IPNS record
-  let ipnsRecord;
+  // 9. Update file metadata — publishes the file IPNS record internally with CAS.
+  // Contract change (#488): updateFileMetadata now publishes the record itself and
+  // returns { ipnsName, metadataCid, newSequenceNumber, prunedCids } — there is no
+  // separate replaceFileInFolder step anymore (it would re-publish with undefined
+  // fields and be rejected by the API DTO). Mirrors apps/web useFileOperations.ts.
   try {
-    ({ ipnsRecord } = await updateFileMetadata({
+    await updateFileMetadata({
       fileIpnsPrivateKey,
       fileMetaIpnsName: filePointer.fileMetaIpnsName,
       folderKey: vaultKeyBlob.rootFolderKey,
@@ -202,20 +204,12 @@ async function main() {
       },
       createVersion: true,
       ctx,
-    }));
+    });
   } finally {
     fileIpnsPrivateKey.fill(0);
   }
 
-  // 10. Publish only the file IPNS record
-  await replaceFileInFolder({
-    children: folder.metadata.children,
-    fileId: filePointer.id,
-    fileIpnsRecord: ipnsRecord,
-    ctx,
-  });
-
-  // 11. Republish folder metadata with updated modified_at so other clients
+  // 10. Republish folder metadata with updated modified_at so other clients
   // (e.g. FUSE mount) detect the change via the FilePointer timestamp.
   const updatedChildren = folder.metadata.children.map((child) => {
     if (child.type === 'file' && child.id === filePointer.id) {
@@ -229,6 +223,9 @@ async function main() {
 
   const { newSequenceNumber } = await updateFolderMetadataAndPublish({
     children: updatedChildren,
+    // Pre-mutation snapshot is the three-way merge base (folder.metadata.children
+    // is the original set; updatedChildren is the post-mutation set).
+    baseChildren: folder.metadata.children,
     folderKey: vaultKeyBlob.rootFolderKey,
     ipnsPrivateKey: rootIpnsKeypair.privateKey,
     ipnsName: rootIpnsName,


### PR DESCRIPTION
## Problem

`test-cross-client-sync` E2E fails on **all three platforms** (Linux/macOS/Windows) at *Test 3: Edit file via SDK* with `Request failed with status code 400` → `FATAL: Cannot test sync without successful edit.` ([run 27555574524](https://github.com/FSM1/cipher-box/actions/runs/27555574524)).

This is **not** caused by the phase-46 docs PR (`#492` touched only `ROADMAP.md`/`STATE.md` and a moved todo — zero code). It is latent contract drift introduced by `#488` that only surfaces on `main`'s E2E job.

## Root cause

`#488` (`feat(sdk-core): handle IPNS write conflicts via 409 merge and file CAS publish`) changed `updateFileMetadata` to **publish the file IPNS record internally** and return `{ ipnsName, metadataCid, newSequenceNumber, prunedCids }` — it no longer returns an `ipnsRecord`.

The test helper `packages/sdk-core/scripts/edit-filepointer.mjs` was never updated:

1. It destructured `{ ipnsRecord }` from `updateFileMetadata` → now `undefined`.
2. Passed it to `replaceFileInFolder`, which spread `undefined` into a batch-publish entry → `{ ipnsName: undefined, record: undefined, metadataCid: undefined, recordType: 'file' }`.
3. The API's `PublishIpnsEntryDto` marks those fields `@IsNotEmpty`, and `main.ts` runs the `ValidationPipe` with `forbidNonWhitelisted: true` → **deterministic 400** in ~0.5s, identical on every platform.

The file's own per-file record publish (step 9, inside `updateFileMetadata`) actually *succeeds* in the API logs — confirming the failure is the redundant follow-up `replaceFileInFolder` call.

## Fix

Bring the helper in line with the production edit path in `apps/web/src/hooks/useFileOperations.ts`:

- Stop destructuring the non-existent `ipnsRecord`; the file record is already published inside `updateFileMetadata`.
- Delete the redundant (and now broken) `replaceFileInFolder` call + its unused import.
- Pass `baseChildren` to `updateFolderMetadataAndPublish` for a proper three-way merge base.

## Verification

- All 3 platform job logs confirm the same deterministic 400 at the edit step.
- `replaceFileInFolder` remains exported (still used by the version-*restore* path via `restoreVersion`, which does return an `ipnsRecord`).
- `node --check` passes; no residual references to removed symbols.
- The built `sdk-core` `dist` `.d.ts` documents the replaced return shape, so the E2E (which imports from `dist`) exercises the new contract.

> Note: the full desktop E2E (Kubo + Postgres + Redis + FUSE mount) was not run locally; CI re-run will confirm. The fix is a 1:1 mirror of the verified production edit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the file metadata update process to reduce redundant operations, improving efficiency of internal metadata publishing and folder synchronization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->