### PR TITLE
fix(web): register folder in SDK folderTree before file edit and version writes

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -253,7 +253,7 @@ Recent for v1.1:
 
 ### Pending Todos
 
-9 items in `.planning/todos/pending/` — see `/gsd:check-todos` for full list. The desktop (6) and SDK (4) groups addressed by Phase 46 (merged) and Phase 47 (PR #494) were moved to `.planning/todos/completed/` on 2026-06-15 and their ROADMAP scope boxes checked. Remaining pending includes the new route-shared-folder-writes follow-up — the lone folder-state mutation not consolidated by Phase 47.
+10 items in `.planning/todos/pending/` — see `/gsd:check-todos` for full list. The desktop (6) and SDK (4) groups addressed by Phase 46 (merged) and Phase 47 (PR #494) were moved to `.planning/todos/completed/` on 2026-06-15 and their ROADMAP scope boxes checked. Remaining pending includes the new route-shared-folder-writes follow-up — the lone folder-state mutation not consolidated by Phase 47 — and the new architecture todo to give the SDK client the root IPNS key so it self-bootstraps/lazy-loads `folderTree` (root cause of the "Folder not loaded" class; the bin-restore gap surfaced while combing the #494 fix).
 
 ### Resolved
 

--- a/.planning/todos/pending/2026-06-16-sdk-client-self-bootstrap-folder-tree-from-root-ipns-key.md
+++ b/.planning/todos/pending/2026-06-16-sdk-client-self-bootstrap-folder-tree-from-root-ipns-key.md
@@ -1,0 +1,86 @@
+---
+created: 2026-06-16T00:00:00.000Z
+title: SDK client self-bootstrap folder tree from root IPNS key
+area: architecture
+severity: medium
+files:
+  - packages/sdk/src/types.ts:44
+  - packages/sdk/src/client.ts:288
+  - packages/sdk/src/client.ts:345
+  - packages/sdk/src/bin/index.ts:323
+  - apps/web/src/hooks/useBin.ts:73
+  - apps/web/src/hooks/useBin.ts:128
+  - apps/web/src/lib/sdk-provider.ts:96
+---
+
+## Problem
+
+`CipherBoxClient` is positioned as the stateful owner of all folder operations
+(holds `folderTree`, `binState`, `keyCache`, `vaultKeypair`, `rootFolderKey`),
+but `CipherBoxClientConfig` (`packages/sdk/src/types.ts:44`) carries
+`rootIpnsName` + `rootFolderKey` + `vaultKeypair` and **NOT** the root IPNS
+private key. The root IPNS keypair lives only in the web `vaultStore`. So the
+client cannot resolve/publish root or lazy-load folders from root on its own —
+the web app must seed `folderTree` via `ensureFolderRegistered`
+(`apps/web/src/lib/sdk-provider.ts:96`) before every folderTree-dependent client
+method (`replaceFile`, `restoreFileVersion`, `deleteFileVersion`,
+`restoreFromBin`, `renameItem`, `deleteItem`, `uploadFile(s)`, `moveItem`,
+`createFolder`, `shareFolder`).
+
+This asymmetry is the root cause of the whole "Folder not loaded" bug class.
+Every folderTree-dependent method throws `'Folder not loaded'` (or
+`'Target folder not loaded'`) when the web forgot to seed it. The PR #494
+regression was simply three of those seeding calls being dropped (fixed on branch
+`fix/owner-edit-folder-not-loaded` by adding `ensureFolderRegistered` to
+`useFileOperations` + `useFileVersions`).
+
+### Concrete still-open instance: bin restore
+
+Restoring a recycle-bin item after a client re-creation (page reload / re-login)
+throws `'Target folder not loaded'` when the item's original parent folder was
+never navigated to that session. Throw site: `packages/sdk/src/bin/index.ts:323`
+(`restoreFromBin` derefs `folderTree.get(targetFolderIpnsName)` to get the parent
+key + ipnsKeypair needed to republish the parent). Web callers
+`apps/web/src/hooks/useBin.ts:73` (`restore`) and `:128` (`restoreMultiple`)
+never register the target folder. **Pre-existing since PR #296**, not a #494
+regression. Not caught by `tests/web-e2e/tests/recycle-bin.spec.ts` because that
+test navigates/uploads first (parent already in `folderTree`) and never reloads.
+
+A localized guard isn't enough here: bin entries carry only
+`originalParentIpnsName`, and after a reload the parent may not be in the Zustand
+store at all, so there is nothing to register. The parent's keys live in *its*
+parent's `FolderEntry`, so loading it by ipnsName requires walking from root.
+
+## Solution
+
+Make the stateful client able to bootstrap and lazy-load on its own, dissolving
+the `ensureFolderRegistered` workaround class:
+
+1. Add `rootIpnsKeypair` (root IPNS private key) to `CipherBoxClientConfig`. The
+   web passes it from `vaultStore` at `initSdkClient`. Security: no new exposure —
+   the client already holds `vaultKeypair.privateKey`, `rootFolderKey`, and every
+   loaded folder's `ipnsPrivateKey` in memory (zeroed on `destroy()`); the root
+   ipns private key is consistent with that.
+2. Have the client self-register root (resolve + register) on init or lazily.
+3. Implement an internal `ensureFolderLoaded(targetIpnsName)` that DFS-walks the
+   folder tree from root, unwrapping each `FolderEntry`'s keys with the vault
+   keypair and loading metadata (`loadFolder`/`loadFolderMetadata`) until the
+   target is registered.
+4. Call `ensureFolderLoaded` inside the folderTree-dependent methods — definitely
+   `restoreFromBin`, and as a safety net for `replaceFile` / `restoreFileVersion`
+   / `deleteFileVersion` / `renameItem` / `deleteItem` / `uploadFile(s)` /
+   `moveItem`. Then the web-side `ensureFolderRegistered` calls can be removed.
+
+### Tests
+
+- SDK unit test for `ensureFolderLoaded`: deep target, target-not-found,
+  already-loaded (no-op).
+- New web E2E: reload → open bin → restore an item whose subfolder parent was
+  never navigated to (the scenario `recycle-bin.spec.ts` misses).
+
+### Related
+
+- `[[route-shared-folder-writes-through-the-sdk-client]]` — adjacent SDK-client
+  ownership cleanup (shared-write paths). Both move state authority into the SDK.
+- The #494 hotfix (`fix/owner-edit-folder-not-loaded`) is the symptom patch this
+  todo would supersede.

--- a/apps/web/src/hooks/useFileOperations.ts
+++ b/apps/web/src/hooks/useFileOperations.ts
@@ -4,7 +4,7 @@ import { useVaultStore } from '../stores/vault.store';
 import { useAuthStore } from '../stores/auth.store';
 import { useQuotaStore } from '../stores/quota.store';
 import { unpinFromIpfs } from '../lib/api/ipfs';
-import { getSdkClient } from '../lib/sdk-provider';
+import { getSdkClient, ensureFolderRegistered } from '../lib/sdk-provider';
 import { reWrapForRecipients } from '../services/share.service';
 import {
   resolveFileMetadata,
@@ -72,6 +72,12 @@ export function useFileOperations() {
         if (!parentFolder) {
           throw new Error('Parent folder not found or vault not initialized');
         }
+
+        // Seed the SDK folderTree from the store before routing through the client.
+        // Navigation/read populate only the Zustand store; client.replaceFile gates on
+        // folderTree.get() and throws 'Folder not loaded' otherwise. No-op if already
+        // tracked. (Mirrors useFolderMutations / useDropUpload.)
+        ensureFolderRegistered(parentFolder);
 
         // 1. Find the FilePointer in parent's children
         const filePointer = parentFolder.children.find(

--- a/apps/web/src/hooks/useFileVersions.ts
+++ b/apps/web/src/hooks/useFileVersions.ts
@@ -5,7 +5,7 @@ import { useAuthStore } from '../stores/auth.store';
 import { useQuotaStore } from '../stores/quota.store';
 import { useVaultSettingsStore } from '../stores/vault-settings.store';
 import { unpinFromIpfs } from '../lib/api/ipfs';
-import { getSdkClient } from '../lib/sdk-provider';
+import { getSdkClient, ensureFolderRegistered } from '../lib/sdk-provider';
 import {
   resolveFileMetadata,
   computeRestoreVersionUpdate,
@@ -58,6 +58,12 @@ export function useFileVersions() {
         if (!parentFolder) {
           throw new Error('Parent folder not found or vault not initialized');
         }
+
+        // Seed the SDK folderTree from the store before routing through the client.
+        // Navigation/read populate only the Zustand store; the client version methods
+        // gate on folderTree.get() and throw 'Folder not loaded' otherwise. No-op if
+        // already tracked. (Mirrors useFolderMutations / useDropUpload.)
+        ensureFolderRegistered(parentFolder);
 
         // Find the FilePointer
         const filePointer = parentFolder.children.find(
@@ -167,6 +173,12 @@ export function useFileVersions() {
         if (!parentFolder) {
           throw new Error('Parent folder not found or vault not initialized');
         }
+
+        // Seed the SDK folderTree from the store before routing through the client.
+        // Navigation/read populate only the Zustand store; the client version methods
+        // gate on folderTree.get() and throw 'Folder not loaded' otherwise. No-op if
+        // already tracked. (Mirrors useFolderMutations / useDropUpload.)
+        ensureFolderRegistered(parentFolder);
 
         // Find the FilePointer
         const filePointer = parentFolder.children.find(


### PR DESCRIPTION
## Summary

**Fixes a regression from #494 (phase 47 SDK folder-state/publish consolidation) that broke the Web E2E suite on `main`.**

#494 re-routed the owner file-edit save and the file-version restore/delete paths through new stateful `CipherBoxClient` methods (`replaceFile`, `restoreFileVersion`, `deleteFileVersion`). Each gates on the in-memory `folderTree`:

```ts
const folder = this.folderTree.get(parentIpnsName);
if (!folder) throw new Error('Folder not loaded');
```

The web app seeds `folderTree` only via `ensureFolderRegistered` (called from the upload/mutation hooks). #494 added the new client calls to `useFileOperations`/`useFileVersions` but **dropped the `ensureFolderRegistered` seeding** there. Navigation/read populate only the Zustand store, never `folderTree` — so after a client re-creation (e.g. page reload) with no intervening mutation, the folder is absent and the save/version op throws synchronously. In the editor the rejected save leaves the modal open, which surfaced as the 30s timeout at `writable-shares.spec.ts:330` (`4.3 Alice edits Bob's file`).

Because **Web E2E does not run on PRs** (only on push to `main`), the regression wasn't caught until #494 merged.

## Changes

Add `ensureFolderRegistered(parentFolder)` before the client call at the three missed sites, mirroring `useFolderMutations`/`useDropUpload`. No-op when the folder is already tracked.

**Key files:**
- `apps/web/src/hooks/useFileOperations.ts` — owner edit-save path (the one the E2E hit)
- `apps/web/src/hooks/useFileVersions.ts` — `restoreVersion` + `deleteVersion` paths (same latent throw)

## Verification

- [x] Web E2E — **green** on this branch via manual dispatch: [run 27579074392](https://github.com/FSM1/cipher-box/actions/runs/27579074392) (`writable-shares 4.3` + full suite passed; previously the only failure on `main`).
- [x] `tsc --noEmit` (apps/web) and `eslint` on both changed files pass.

Confirmed deterministic, not a flake: parent commit `0c2422c8c` passed Web E2E twice; #494's commit `d17d42e5f` failed it; the only diff between them is #494.

## Key Decisions

- Scoped to the regression — the three dropped `ensureFolderRegistered` calls — rather than a broader refactor.
- A full audit of all 21 web call sites of folderTree-dependent client methods found everything else correctly guarded (mutations, uploads, shared-write, bin `permanentDelete`/`emptyBin`); `shareFolder`/`revokeShare` have no web callers.

## Follow-up

The audit surfaced one **pre-existing** gap (since #296, not this regression): recycle-bin **restore** (`useBin.ts`) hits the same `'Folder not loaded'` throw after a reload. Its root cause is architectural — the SDK client config lacks the **root IPNS private key**, so it can't self-bootstrap or lazy-load `folderTree`, which is *why* the `ensureFolderRegistered` workaround exists at all. Captured as a todo for a proper fix (`rootIpnsKeypair` in config + internal `ensureFolderLoaded` lazy walk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of file operations by ensuring proper folder initialization before processing updates, deletions, and restores. Addresses scenarios where operations could fail if the folder structure wasn't pre-loaded.

* **Chores**
  * Updated planning documentation with architecture improvements for folder tree initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->