### PR TITLE
docs: close node 24 actions audit todo - no changes needed

### DIFF
--- a/.planning/todos/completed/2026-03-30-check-remaining-github-actions-for-node-24-updates-before-june-deadline.md
+++ b/.planning/todos/completed/2026-03-30-check-remaining-github-actions-for-node-24-updates-before-june-deadline.md
@@ -31,3 +31,17 @@ done
 ```
 
 Update any that have new major versions. If any haven't released Node 24 support by then, set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` in the workflow env as a workaround and monitor for breakage.
+
+## Resolution (2026-06-16)
+
+Audited all 16 external actions across `.github/workflows/`. **No changes required** — every action is either node24-native or a composite/Docker action unaffected by the runtime migration. CI on `main` is green post-deadline, confirming empirically.
+
+The 5 originally-flagged actions:
+
+- `tauri-apps/tauri-action@v0` — floating `v0` tracks `action-v0.6.2`, `runs.using: node24` (native)
+- `ikalnytskyi/action-setup-postgres@v8` — `runs.using: composite`, unaffected
+- `googleapis/release-please-action` — already bumped to `@v5` (node24-native)
+- `appleboy/scp-action` — already bumped to `@v1.0.0` (composite, unaffected)
+- `appleboy/ssh-action` — already bumped to `@v1.2.5` (composite, unaffected)
+
+No `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workaround needed — nothing is pinned to node20/node16.


### PR DESCRIPTION
## Summary

Closes the long-standing CI todo to verify all GitHub Actions are Node 24-ready before GitHub's 2026-06-02 forced-runtime deadline. **No workflow changes were required** — the audit found every action is already compliant.

Today is past the deadline and CI on `main` is green (Release Please, Codecov, CI E2E all succeed), confirming empirically that nothing broke.

## Audit Result

All 16 external actions across `.github/workflows/` were checked for their `runs.using` runtime and version currency:

| Action | Pinned → resolves to | Runtime | Status |
| --- | --- | --- | --- |
| actions/checkout | v6 → 6.0.3 | node24 | native |
| actions/setup-node | v6 → 6.4.0 | node24 | native |
| actions/cache | v5 → 5.0.5 | node24 | native |
| actions/upload-artifact | v7 → 7.0.1 | node24 | native |
| actions/download-artifact | v8 → 8.0.1 | node24 | native |
| actions/create-github-app-token | v3 → 3.2.0 | node24 | native |
| docker/build-push-action | v7 → 7.2.0 | node24 | native |
| docker/login-action | v4 → 4.2.0 | node24 | native |
| dorny/paths-filter | v4 → 4.0.1 | node24 | native |
| pnpm/action-setup | v6 → 6.0.9 | node24 | native |
| googleapis/release-please-action | v5 → 5.0.0 | node24 | native |
| tauri-apps/tauri-action | v0 → 0.6.2 | node24 | native |
| codecov/codecov-action | v7 → 7.0.0 | composite | unaffected |
| ikalnytskyi/action-setup-postgres | v8 | composite | unaffected |
| appleboy/scp-action | v1.0.0 | composite | unaffected |
| appleboy/ssh-action | v1.2.5 | composite | unaffected |

The five actions originally flagged in the todo are all resolved: `tauri-action@v0` tracks the node24-native 0.6.2; `action-setup-postgres@v8` is composite (unaffected); and `release-please`/`scp-action`/`ssh-action` were bumped to v5/v1.0.0/v1.2.5 since the todo was filed. No `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workaround is needed — nothing is pinned to node20/node16.

## Changes

- Mark the Node 24 actions audit todo complete with a resolution note (`.planning/todos/` move only — no code/workflow changes).

## Verification

- [x] All 16 actions audited against their published `action.yml` runtime via `gh api`
- [x] CI on `main` green post-deadline (independent confirmation)
- [x] No workflow file changes — nothing to regression-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Completed comprehensive audit of GitHub Actions infrastructure confirming no runtime updates required at this time, enabling continued stability across development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->