### PR TITLE
fix(build): emit package declarations with a blocking tsc pass

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json",
     "generate": "orval",
     "lint": "eslint src/**/*.ts",
     "test": "vitest run",

--- a/packages/api-client/tsconfig.build.json
+++ b/packages/api-client/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
+}

--- a/packages/api-client/tsup.config.ts
+++ b/packages/api-client/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['cjs', 'esm'],
-  dts: true,
+  dts: false, // emitted via a blocking tsc pass (build script); tsup's concurrent dts intermittently no-ops on Windows CI
   clean: true,
   sourcemap: true,
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json",
     "lint": "eslint src/**/*.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['cjs', 'esm'],
-  dts: true,
+  dts: false, // emitted via a blocking tsc pass (build script); tsup's concurrent dts intermittently no-ops on Windows CI
   clean: true,
   sourcemap: true,
 });

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json",
     "lint": "eslint src/**/*.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/crypto/tsconfig.build.json
+++ b/packages/crypto/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
+}

--- a/packages/crypto/tsup.config.ts
+++ b/packages/crypto/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig([
     format: ['cjs'],
     clean: true,
     sourcemap: true,
-    dts: true,
+    dts: false, // emitted via a blocking tsc pass (build script); tsup's concurrent dts intermittently no-ops on Windows CI
     // Bundle all dependencies into the CJS output so CommonJS consumers
     // (NestJS API, Jest) don't hit ERR_PACKAGE_PATH_NOT_EXPORTED or
     // "Unexpected token export" from ESM-only deps (@noble/*, @libp2p/*, ipns, multiformats).
@@ -16,7 +16,7 @@ export default defineConfig([
     entry: ['src/index.ts'],
     format: ['esm'],
     sourcemap: true,
-    dts: true,
+    dts: false, // emitted via a blocking tsc pass (build script); tsup's concurrent dts intermittently no-ops on Windows CI
     // ESM output leaves deps external — Vite/browser bundlers handle them natively.
   },
 ]);

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json",
     "lint": "eslint src/**/*.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/sdk-core/tsconfig.build.json
+++ b/packages/sdk-core/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
+}

--- a/packages/sdk-core/tsup.config.ts
+++ b/packages/sdk-core/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['cjs', 'esm'],
-  dts: true,
+  dts: false, // emitted via a blocking tsc pass (build script); tsup's concurrent dts intermittently no-ops on Windows CI
   clean: true,
   sourcemap: true,
 });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json",
     "lint": "eslint src/**/*.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/sdk/tsconfig.build.json
+++ b/packages/sdk/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
+}

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['cjs', 'esm'],
-  dts: true,
+  dts: false, // emitted via a blocking tsc pass (build script); tsup's concurrent dts intermittently no-ops on Windows CI
   clean: true,
   sourcemap: true,
 });

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -66,14 +66,14 @@
       "component": "@cipherbox/api",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.39.0"
+      "release-as": "0.39.1"
     },
     "apps/web": {
       "release-type": "node",
       "component": "@cipherbox/web",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.43.0"
+      "release-as": "0.44.0"
     },
     "apps/desktop": {
       "release-type": "node",
@@ -105,14 +105,14 @@
       "component": "@cipherbox/crypto",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.32.0"
+      "release-as": "0.32.1"
     },
     "packages/api-client": {
       "release-type": "node",
       "component": "@cipherbox/api-client",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.39.0"
+      "release-as": "0.39.1"
     },
     "packages/sdk-core": {
       "release-type": "node",
@@ -126,7 +126,7 @@
       "component": "@cipherbox/sdk",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.35.0"
+      "release-as": "0.35.1"
     },
     "crates/crypto": {
       "release-type": "rust",


### PR DESCRIPTION
## Problem

The `Desktop E2E (windows)` job intermittently fails at the **Build API** step with:

```
Could not find a declaration file for module '@cipherbox/core'.   dist/index.js implicitly has an 'any' type.
Could not find a declaration file for module '@cipherbox/sdk-core'. dist/index.js implicitly has an 'any' type.
```

A plain rerun usually goes green, so it reads as flaky — but it is a **silent build bug**, not test timing.

## Root cause

The workspace packages build with `tsup` using `dts: true`, which runs declaration emit as a **separate pass concurrent with the JS emit**. With `clean: true`, dist is wiped first, then `index.js` (fast esbuild pass) and `index.d.ts` (slow rollup-dts worker) race into the same dir. On Windows CI the dts worker intermittently fails to write `index.d.ts` (file locking / AV scan / timing) — **yet `tsup` still exits 0**.

The smoking gun in the failing run: **`Build desktop frontend` ✓ passed** (it runs the `tsup` package builds) **while `Build API` ✗ failed** on the missing declarations. So tsup left an incomplete dist (`index.js`, no `index.d.ts`) and exited 0; the downstream `nest build` (tsc) then couldn't find the types. Both `core` and `sdk-core` show up because `sdk-core`'s dts pass depends on `core`'s emitted types.

## Fix

Stop relying on tsup's fragile concurrent dts. In each tsup-built package:

- `tsup.config.ts`: `dts: false`
- `package.json`: `"build": "tsup && tsc -p tsconfig.build.json"`
- new `tsconfig.build.json`: `emitDeclarationOnly: true` (test files excluded)

`tsc` runs **after** tsup and **exits non-zero on any emit failure**, so a JS-only dist can no longer slip through with exit 0 — the flake becomes impossible rather than rare.

Applied to all five tsup-built packages (`crypto`, `core`, `api-client`, `sdk-core`, `sdk`) since they share the identical failure mode; fixing only the two that failed today would leave the same latent flake in the rest.

## Verification (local)

- All five packages emit `dist/index.d.ts`.
- `@cipherbox/sdk` build (consumes the other four) — clean.
- `@cipherbox/api` `nest build` (the exact failing CI step) — clean.
- `@cipherbox/web` `tsc -b` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration across multiple packages for improved TypeScript type declaration generation.
  * Adjusted version targets for package releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->