### PR TITLE
docs: v1.1 milestone summary and tracked tech-debt ledger

### DIFF
--- a/.planning/BACKLOG.md
+++ b/.planning/BACKLOG.md
@@ -50,7 +50,7 @@ These were genuinely open and tracked nowhere actionable (only in stale review d
 
 ### Still open, remaining in this backlog
 
-All other items below remain open and correctly tracked here: the deferred feature set (sharing, desktop UI, MFA, performance, etc.), the `uint8ToBase64` dedup (Tier 3.3 — confirmed still 4-5 copies, no shared util), and Tier-3 cleanups 3.1, 3.2, 3.4, 3.5, 3.7, 3.8, 3.10, 3.11, 3.12, 3.13, 3.14.
+All other items below remain open and correctly tracked here: the deferred feature set (sharing, desktop UI, MFA, performance, etc.), the `uint8ToBase64` dedup (Tier 3.3 — confirmed still 3 copies, no shared util), and Tier-3 cleanups 3.1, 3.2, 3.4, 3.5, 3.7, 3.8, 3.10, 3.11, 3.12, 3.13, 3.14.
 
 ## Deferred Items Inventory
 

--- a/.planning/BACKLOG.md
+++ b/.planning/BACKLOG.md
@@ -2,6 +2,27 @@
 
 > Pending ideas and deferred work. Consolidated 2026-06-12 from the former `.planning/DEFERRED.md` and `.planning/REFACTORING.md` (gsd-health W019 remediation).
 
+## v1.1 Tech Debt Close-out (2026-06-18)
+
+A full tech-debt sweep of milestone v1.1 (phases 18–49) — including the phase 42/43 `REVIEW.md`
+code reviews and in-code TODOs — was consolidated and verified against current code. See the
+ledger at [`reports/TECH_DEBT-v1.1.md`](reports/TECH_DEBT-v1.1.md) (companion to
+[`reports/MILESTONE_SUMMARY-v1.1.md`](reports/MILESTONE_SUMMARY-v1.1.md)).
+
+Net-new, verified-open items promoted to `.planning/todos/pending/` (not previously tracked):
+
+- `2026-06-18-phase42-unpin-integrity-review-open-findings.md` — **high**; incl. WR-01 advisory-lock `INT_MIN` overflow (permanent undeletability) and WR-03 stale-outbox re-pin race (data loss), plus 10 more WR/IN items.
+- `2026-06-18-fuse-journal-growth-and-replay-timeout.md` — **high**; WR-06 unbounded journal + full ciphertext in JSON (no GC/purge), WR-07 replay has no network timeout, + IN-03/04/05.
+- `2026-06-18-web-logger-redaction-and-faro-transport-unwired.md` — **med**; logger `redact()` never implemented, `registerFaroTransport` defined but never called (warn/error not reaching Faro).
+- `2026-06-18-unenroll-skips-unloaded-subtrees.md` — **med**; `collectSubtreeIpnsNames` only walks loaded folders.
+- `2026-06-18-gsd-verification-gaps-phases-18-31-32.md` — **med**; phases 18/31/32 still lack `VERIFICATION.md` (PERF-01..04 orphaned).
+
+Verified resolved during the sweep (so they are not re-filed): phase 43 critical findings CR-01..CR-08
+(fixed 2026-06-14) and most of its warnings (closed by phases 45/46); phase 42 WR-04 (Counter is
+acceptable). Already-tracked v1.1 deferrals (sharing, desktop signing, upload-pipeline P37, Kubo ACL,
+`uint8ToBase64` Tier 3.3, etc.) remain in the inventory below and are referenced, not duplicated, by
+the ledger.
+
 ## Status Reconciliation (2026-06-13)
 
 The inventories below are a verbatim snapshot dated 2026-03-31 and predate phases 36-44. They were reviewed against the current codebase on 2026-06-13. The original tables are preserved unchanged for the historical record; the current status of changed items is authoritative here.

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -2,13 +2,15 @@
 
 ## Overview
 
-CipherBox v1.1 transforms the platform from "IPFS as a storage backend with database fallbacks" to "IPFS-native with the database serving only auth." The milestone establishes performance baselines before making changes, replaces the unreliable delegated-ipfs.dev dependency with self-hosted IPNS resolution, migrates rootFolderKey to an IPFS vault blob (achieving true zero-knowledge server), adds BYO-IPFS node support for data sovereignty, and completes performance baselines with client-side instrumentation and load testing after all features are stable.
+CipherBox v1.1 transformed the platform from "IPFS as a storage backend with database fallbacks" to "IPFS-native with the database serving only auth." It established performance baselines before making changes, replaced the unreliable delegated-ipfs.dev dependency with self-hosted Someguy IPNS resolution, migrated rootFolderKey to an IPFS vault blob v2 (achieving a true zero-knowledge server), added BYO-IPFS node support for data sovereignty, and completed performance baselines with client-side instrumentation and load testing.
+
+Scope expanded well beyond those original four thrusts to include a layered TypeScript + Rust SDK extraction, writable shares, FUSE write-durability and data-loss hardening, the production Phala TEE migration, per-package release engineering, and SDK folder-state/sharing consolidation. **Completed 2026-06-18 — 34 phases (18–49), 151 plans.**
 
 ## Milestones
 
 - **v0.1 Staging MVP** - Phases 1-10 (shipped 2026-02-11)
 - **v1.0 Production** - Phases 11-17.1 (shipped 2026-03-05)
-- **v1.1 IPFS Infrastructure** - Phases 18-22 (in progress)
+- **v1.1 IPFS Infrastructure** - Phases 18-49 (completed 2026-06-18)
 
 ## Phases
 
@@ -21,22 +23,38 @@ Decimal phases appear between their surrounding integers in numeric order.
 
 - [x] **Phase 18: Performance Instrumentation** - Server-side Prometheus histograms and Kubo metrics scraping to establish baselines before any architectural changes (completed 2026-03-07)
 - [x] **Phase 19: IPNS Resolution Improvement** - Replace delegated-ipfs.dev with self-hosted Someguy sidecar for reliable IPNS routing, add latency histograms for resolve/publish operations (completed 2026-03-07)
+- [x] **Phase 19.1: Extract Core Crypto SDK as Shared Package** - Split the web app's crypto/file logic into a five-package layered SDK (@cipherbox/crypto, core, api-client, sdk-core, sdk) (INSERTED) (completed 2026-03-21)
 - [x] **Phase 19.2: IPFS Upload Performance Optimization** - Optimize Kubo pinning path (concurrent pins, worker tuning, pin batching) to reduce upload latency (INSERTED) (completed 2026-03-23)
-- [x] **Phase 20: Vault Migration** - Move rootFolderKey to IPFS vault blob v2 format, making the server store zero crypto material (gap closure in progress) (completed 2026-03-24)
-- [x] **Phase 21: BYO-IPFS Node Support** - User-configurable IPFS pinning endpoint with dual-pin strategy, Settings UI, and connection testing (gap closure in progress) (completed 2026-03-25)
+- [x] **Phase 20: Vault Migration** - Move rootFolderKey to IPFS vault blob v2 format, making the server store zero crypto material (completed 2026-03-24)
+- [x] **Phase 21: BYO-IPFS Node Support** - User-configurable IPFS pinning endpoint with dual-pin strategy, Settings UI, and connection testing (completed 2026-03-25)
 - [x] **Phase 22: Performance Baselines Completion** - Client-side timing instrumentation, end-to-end journey timing, Vitest-based load testing, and capacity documentation (completed 2026-03-25)
 - [x] **Phase 23: Rust SDK Extraction** - Extract five Rust crates (crypto, core, api-client, fuse, sdk) mirroring the TypeScript SDK hierarchy, replace duplicated logic in desktop FUSE code, enable unit testing at same granularity as TypeScript (completed 2026-03-24)
 - [x] **Phase 24: Bug Fixes & Test Infrastructure** - Fix known bugs (bin IPNS 404, device registry format error) and strengthen test infrastructure (headless load tests, vault recovery E2E, load test auth refresh) (completed 2026-03-25)
 - [x] **Phase 25: Desktop Enhancements** - Desktop auto-update mechanism and TEE file enrollment for new files (completed 2026-03-25)
 - [x] **Phase 26: Observability & UX Tuning** - Grafana alerting thresholds from existing baselines and timeout tuning for sub-2s UX (completed 2026-03-26)
+- [x] **Phase 27: Writable Shares (PoC)** - Write-permission shares with ECIES-wrapped IPNS key delivery, permission toggle UI, and multi-writer conflict retry (completed 2026-03-27)
 - [x] **Phase 28: Code Hygiene & Logging** - Structured logger wrapper, replace 124 console.\* calls, fix silenced unpin failures, clean any casts, archive legacy POC (completed 2026-03-28)
 - [x] **Phase 29: Infrastructure Hardening** - Wire up IPNS unenrollment on deletion, test login endpoint hardening, IPFS node access control (completed 2026-03-28)
-- [x] **Phase 30: Web App Observability** - Error tracking service, error boundaries, client-side telemetry (completed 2026-03-28)
+- [x] **Phase 30: Web App Observability** - Error tracking service (Grafana Faro), error boundaries, client-side telemetry (completed 2026-03-28)
 - [x] **Phase 31: Structural Decomposition** - Split monolithic files (useSharedNavigation, FileBrowser, folder.service) into focused modules (completed 2026-03-28)
 - [x] **Phase 32: FUSE Async FilePointer Resolution** - Channel-based async resolution to prevent Finder disconnects from blocking FUSE thread (completed 2026-03-28)
 - [x] **Phase 33: Windows Async FilePointer Resolution** - Port Phase 32's channel-based async FilePointer resolution to the WinFsp backend (completed 2026-03-28)
 - [x] **Phase 34: E2E Test Expansion & Staging Baselines** - Streaming playback, media preview, batch download, and shared teardown E2E tests; BYO-IPFS load test and Faro metrics baselines on staging (completed 2026-03-29)
 - [x] **Phase 35: Phala Testnet TEE Migration** - Replace staging TEE simulator with real Phala testnet CVM deployment, validate hardware-backed key derivation and IPNS republishing end-to-end (completed 2026-03-29)
+- [x] **Phase 36: Inline Upload Progress** - Replace the floating upload modal with per-file inline progress rows in the file list (completed 2026-03-30)
+- [x] **Phase 37: Parallel Batch Upload Pipeline** - Parallel encrypt+pin pipeline with a single folder IPNS publish and Web Worker encryption offload (completed 2026-03-30)
+- [x] **Phase 38: Retire Deprecated Web Services** - Migrate all callers from folder.service.ts/bin.service.ts to @cipherbox/sdk and delete them (-2,030 LOC) (completed 2026-03-31)
+- [x] **Phase 39: User-Configurable Vault Parameters** - End-user vault settings (recycle-bin retention, delete behavior, versioning) stored encrypted in vault metadata (completed 2026-04-01)
+- [x] **Phase 40: Desktop Vault Settings Integration** - Propagate user-configurable vault settings to the desktop Rust SDK and FUSE layer (completed 2026-03-31)
+- [x] **Phase 41: Package and App Versioning and Release Cycles** - Per-package semver driven by PR-time conventional-commit analysis, with date-based staging tags (completed 2026-04-01)
+- [x] **Phase 42: API Unpin Integrity** - Ownership-guarded unpin with cross-user CID reference counting and a transactional pending-unpins outbox (completed 2026-06-13)
+- [x] **Phase 43: FUSE Write Durability** - fsync'd ciphertext write journal with crash-recovery replay; fixes silent release() data loss and mkdir orphans (completed 2026-06-14)
+- [x] **Phase 44: IPNS Conflict Handling** - Three-way merge (publishWithCas) for concurrent IPNS writes; loser-becomes-version for file conflicts (completed 2026-06-14)
+- [x] **Phase 45: Desktop FUSE Write-Durability Cleanup** - Journal hygiene refactor (shared builders, typed resolve outcome) plus six crash-recovery safety-net tests (completed 2026-06-15)
+- [x] **Phase 46: Desktop FUSE Data-Loss Bugs + Replay Hardening** - Close three data-loss bugs and add Linux stale-mount auto-recovery + replay hardening (completed 2026-06-15)
+- [x] **Phase 47: SDK Folder-State and Publish-Path Consolidation** - Single SDK-owned folder state and a unified file/folder CAS-retry publish helper (completed 2026-06-17)
+- [x] **Phase 48: SDK Self-Bootstrap Regression Fix and Shared-Folder/Metadata Consolidation** - Sequence-based reconcile, single-ownership shared writes, and ECIES-encrypted shared item names (completed 2026-06-17)
+- [x] **Phase 49: Shared-Folder Move (Intra-Share) and useFolderNavigation Unwrap Consolidation** - Write-recipients move files between subfolders with FileMetadata re-encryption (completed 2026-06-18)
 
 ## Phase Details
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -136,7 +136,7 @@ Phases 18-46 complete and verified. Phase 47 (SDK folder-state/publish consolida
 | Phase 41 P04    | 2min     | 2 tasks | 2 files   |
 | Phase 41 P05    | 3min     | 2 tasks | 3 files   |
 | Phase 45 P01    | 8min     | 2 tasks | 2 files   |
-| Phase 45-desktop-fuse-write-durability-cleanup P45-02 | 8min | 1 tasks | 3 files |
+| Phase 45 P02    | 8min     | 1 tasks | 3 files   |
 | Phase 45 P03 | 7min | 2 tasks | 4 files |
 | Phase 45 P04 | 8min | 1 tasks | 2 files |
 | Phase 45 P05 | 12 | 2 tasks | 1 files |
@@ -147,10 +147,10 @@ Phases 18-46 complete and verified. Phase 47 (SDK folder-state/publish consolida
 | Phase 48 P05 | 8min | 3 tasks | 145 files |
 | Phase 48 P06 | 18min | 3 tasks | 5 files |
 | Phase 49 P01 | 13min | 2 tasks | 5 files |
-| Phase 49-shared-folder-move-intra-share-and-usefoldernavigation-unwra P02 | 15min | 1 tasks | 1 files |
-| Phase 49-shared-folder-move-intra-share-and-usefoldernavigation-unwra P03 | 11min | 4 tasks | 7 files |
-| Phase 49-shared-folder-move-intra-share-and-usefoldernavigation-unwra P04 | 26min | 3 tasks | 5 files |
-| Phase 49-shared-folder-move-intra-share-and-usefoldernavigation-unwra P05 | 12min | 2 tasks | 2 files |
+| Phase 49 P02 | 15min | 1 tasks | 1 files |
+| Phase 49 P03 | 11min | 4 tasks | 7 files |
+| Phase 49 P04 | 26min | 3 tasks | 5 files |
+| Phase 49 P05 | 12min | 2 tasks | 2 files |
 
 ## Accumulated Context
 

--- a/.planning/reports/MILESTONE_SUMMARY-v1.1.md
+++ b/.planning/reports/MILESTONE_SUMMARY-v1.1.md
@@ -1,0 +1,246 @@
+# Milestone v1.1 — Project Summary
+
+**Generated:** 2026-06-18
+**Purpose:** Team onboarding and project review
+**Milestone:** v1.1 IPFS Infrastructure — **COMPLETE** (34 phases, 151 plans, 100%)
+
+---
+
+## 1. Project Overview
+
+**CipherBox** is a production-grade, privacy-first encrypted cloud storage platform built on IPFS/IPNS and Web3Auth. Files are encrypted client-side before they leave the device, and encryption keys live only in client memory — the server is *cryptographically unable* to read user data (zero-knowledge relay).
+
+By the start of v1.1 (post-v1.0, shipped 2026-03-05) the product already had: Web3Auth MPC auth, AES-256-GCM + ECIES encryption, IPFS/IPNS storage, full file/folder CRUD, user-to-user and link sharing, client-side search, MFA, file versioning, recycle bin, and cross-platform desktop apps (macOS/Windows/Linux via Tauri + FUSE/WinFsp).
+
+**v1.1 goal:** make CipherBox more *IPFS-native* and operationally mature. Four headline thrusts:
+
+1. **Reliable IPNS resolution** — replace the flaky `delegated-ipfs.dev` dependency.
+2. **Database minimization** — move vault crypto material (`rootFolderKey`) out of the DB into the IPFS vault blob, so the server holds no key material at all.
+3. **Bring-your-own IPFS** — let users point at their own IPFS node via a server-relay flow.
+4. **Performance baselines & observability** — instrument the whole stack (API, client, IPFS/IPNS, TEE) with Prometheus/Grafana/Faro and document capacity.
+
+Beyond the original four, the milestone absorbed a large body of **architecture and reliability work**: a five-package TypeScript SDK split (mirrored by five Rust crates), writable shares, FUSE write-durability hardening, the production Phala TEE migration, per-package release engineering, and a long tail of correctness fixes around IPNS conflict handling, unpin integrity, and shared-folder state.
+
+This was a large milestone: **222 commits, ~2,100 files touched (+304.7k / −50.5k LOC), spanning 2026-03-07 → 2026-06-18 (~3.5 months).**
+
+---
+
+## 2. Architecture & Technical Decisions
+
+The defining architectural move of v1.1 is a **layered SDK extracted out of the web app**, in both TypeScript and Rust, so that domain logic is framework-agnostic, testable headlessly, and shareable across web + desktop.
+
+### TypeScript SDK (Phase 19.1, refined through 31/38/47/48/49)
+
+Five packages, strict dependency direction `sdk → sdk-core → api-client / core / crypto`:
+
+- **`@cipherbox/crypto`** — pure primitives only (AES-GCM/CTR, ECIES, Ed25519, HKDF, IPNS name derivation). No domain knowledge.
+- **`@cipherbox/core`** — domain types, metadata schemas, validators, metadata encrypt/decrypt, vault blob v2, IPNS record utils.
+- **`@cipherbox/api-client`** — typed HTTP client generated from `openapi.json`, no React deps.
+- **`@cipherbox/sdk-core`** — *stateless* folder/file/IPFS/IPNS operations taking an explicit `SdkContext` (apiUrl + token getter). Built for headless load testing.
+- **`@cipherbox/sdk`** — *stateful* `CipherBoxClient` owning the folder tree, key cache, and event emission. Zustand stores subscribe to SDK events (no component refactor).
+
+- **Decision:** SDK-first decomposition — move framework-agnostic logic *down* into packages, leave React hooks as thin wrappers.
+  - **Why:** Enables headless Node load tests, multi-platform reuse, and a single source of truth for folder state.
+  - **Phases:** 19.1 (split), 31 (decompose hooks), 38 (retire `folder.service.ts`/`bin.service.ts`, −2,030 LOC), 47/48 (single folder-state owner).
+
+### Rust SDK (Phase 23)
+
+Five crates mirroring the TS hierarchy — `cipherbox-crypto`, `cipherbox-core`, `cipherbox-api-client`, `cipherbox-fuse`, `cipherbox-sdk` — in a root Cargo workspace. The desktop app becomes a thin Tauri shell.
+
+- **Decision:** Cross-language JSON test vectors in `tests/vectors/`, with a CI parity gate that fails the build if TS and Rust crypto outputs diverge.
+  - **Why:** Guarantees byte-for-byte interop between web and desktop crypto.
+  - **Phase:** 23 (closed out 2026-06-18 after Windows WinFsp ops migrated in 25/33).
+
+### Zero-knowledge vault (Phase 20)
+
+- **Decision:** Vault blob **v2** — `rootFolderKey` is ECIES-wrapped *inside* the IPFS blob header; the DB crypto columns (`encryptedRootFolderKey`, `encryptedRootIpnsPrivateKey`) are dropped entirely.
+  - **Why:** Server holds zero key material; `encryptedRootIpnsPrivateKey` is HKDF-derivable so it's redundant.
+  - **Outcome:** Exceeded the original requirement — the DB read-fallback was removed completely, not just deprecated.
+
+### IPNS reliability (Phase 19)
+
+- **Decision:** Self-host **Someguy** (v0.11.1, standard DHT mode) as a delegated-routing sidecar, replacing `delegated-ipfs.dev`.
+  - **Why:** Eliminate an unreliable third-party dependency; standard (not accelerated) DHT fits the 768 MB staging VPS.
+
+### BYO-IPFS (Phase 21)
+
+- **Decision:** Client-direct pinning via a `PinningProvider` abstraction (Kubo / PSA / Pinata) with a `DualPinProvider` (primary must-succeed, secondary best-effort). **All IPNS publishes still route through the CipherBox API** regardless of BYO config.
+  - **Why:** Data sovereignty for users while keeping IPNS sequence/conflict control centralized. Credentials are ECIES-encrypted with the TEE public key; the connection test is TEE-routed with SSRF validation.
+
+### Other foundational decisions
+
+- **Concurrent upload pipeline** (19.2, 37): `Promise.allSettled` pin orchestration + Kubo `pebbleds` datastore (−13% p95); parallel encrypt+pin with `p-limit(3)` and a Web Worker for zero-copy encryption, collapsing O(N) IPNS publishes to O(1).
+- **IPNS conflict handling** (44, 47): a generic `publishWithCas` engine with three-way `mergeChildren` (base/local/remote), 4-attempt backoff, and "loser-becomes-version" for file conflicts.
+- **Unpin integrity** (42): ownership-guarded unpin with cross-user CID reference counting and a transactional pending-unpins outbox (BullMQ retry).
+- **FUSE write durability** (43/45/46): an fsync'd ciphertext write journal with crash-recovery replay; never drops a write (parks on retry exhaustion).
+- **Observability stack:** Prometheus histograms (`cipherbox_ipfs_ipns_duration_seconds`, `cipherbox_tee_*`, republish batch) → Alloy scrape (incl. Kubo + Someguy) → Grafana dashboards + 17 alert rules; Grafana **Faro** for web RUM with strict privacy scrubbing (no session replay, publicKey-only identity).
+- **Per-package release engineering** (41): 15 independently-versioned packages, conventional-commit analysis at PR time, date-based staging tags.
+
+---
+
+## 3. Phases Delivered
+
+All 34 phases complete and verified. Grouped by workstream:
+
+| Phase | Name | Status | One-liner |
+| ----- | ---- | ------ | --------- |
+| 18 | Performance Instrumentation | ✅ passed | Prometheus histograms for IPFS/IPNS/TEE latency + Kubo health |
+| 19 | IPNS Resolution Improvement | ✅ passed | Self-hosted Someguy sidecar replaces delegated-ipfs.dev |
+| 19.1 | Extract Core/Crypto SDK | ✅ passed | Five-package TypeScript SDK architecture |
+| 19.2 | IPFS Upload Optimization | ✅ passed | Concurrent pins + pebbleds datastore (−13% p95) |
+| 20 | Vault Migration | ✅ passed | rootFolderKey → IPFS vault blob v2; DB crypto columns dropped |
+| 21 | BYO IPFS Node Support | ✅ passed | User-configurable IPFS node, dual-pin, TEE-routed test |
+| 22 | Performance Baselines Completion | ✅ passed | Client timing API, E2E journey timing, load thresholds, CAPACITY.md |
+| 23 | Rust SDK Extraction | ✅ passed | Five Rust crates mirroring TS SDK + cross-lang vector parity gate |
+| 24 | Bug Fixes & Test Infrastructure | ✅ passed | Bin 404 fix, device-registry v2 migration, headless load tests |
+| 25 | Desktop Enhancements | ✅ passed | Tauri auto-update + TEE enrollment for FUSE-created files |
+| 26 | Observability & UX Tuning | ✅ passed | 17 Grafana alert rules + timeout/retry tuning for sub-2s latency |
+| 27 | Writable Shares PoC | ✅ passed | Write-share recipients get full CRUD with multi-writer conflict retry |
+| 28 | Code Hygiene & Logging | ✅ passed | Structured logger, visible unpin failures, POC archive removed |
+| 29 | Infrastructure Hardening | ✅ passed | Orphaned-IPNS cleanup on delete, test-login hardening |
+| 30 | Web App Observability | ✅ passed | Grafana Faro RUM with privacy scrubbing + error boundary |
+| 31 | Structural Decomposition | ✅ passed | SDK-first migration; hooks become thin UI wrappers |
+| 32 | FUSE Async FilePointer (macOS) | ✅ passed | Non-blocking IPNS resolution; eliminates Finder stalls |
+| 33 | Windows Async FilePointer | ✅ passed | Ports async resolution to WinFsp; eliminates Explorer hangs |
+| 34 | E2E Test Expansion & Staging Baselines | ✅ passed | 16 new E2E tests (streaming/preview/batch) + staging baselines |
+| 35 | Phala Testnet TEE Migration | ✅ passed | TEE worker moved to production Phala Cloud CVM + observability |
+| 36 | Inline Upload Progress | ✅ passed | Per-file inline progress rows replace floating upload modal |
+| 37 | Parallel Batch Upload Pipeline | ✅ passed | Parallel encrypt+pin pipeline, single folder publish, Web Worker |
+| 38 | Retire Deprecated Web Services | ✅ passed | All callers migrated to SDK; −2,030 LOC |
+| 39 | User-Configurable Vault Parameters | ✅ passed | Retention/delete/versioning settings in encrypted vault metadata |
+| 40 | Desktop Vault Settings Integration | ✅ passed | Vault settings propagated to Rust SDK + FUSE layer |
+| 41 | Package & App Versioning / Release Cycles | ✅ passed | Per-package semver, PR-time commit analysis, staging tags |
+| 42 | API Unpin Integrity | ✅ passed | Ownership-guarded unpin, cross-user refcount, pending-unpins outbox |
+| 43 | FUSE Write Durability | ✅ passed | fsync'd write journal + crash-recovery replay; no silent data loss |
+| 44 | IPNS Conflict Handling | ✅ passed | Three-way merge `publishWithCas` for concurrent writes |
+| 45 | Desktop FUSE Durability Cleanup | ✅ passed | Journal hygiene refactor + 6 crash-recovery safety-net tests |
+| 46 | Desktop FUSE Data-Loss Bugs / Replay Hardening | ✅ passed | Closes 3 data-loss bugs; Linux stale-mount auto-recovery |
+| 47 | SDK Folder-State Publish Consolidation | ✅ passed | Single folder-state owner; unified file/folder CAS-retry |
+| 48 | SDK Self-Bootstrap Fix + Shared-Folder Metadata | ✅ passed | Sequence-based reconcile; ECIES-encrypted shared item names |
+| 49 | Shared-Folder Move + useFolderNavigation | ✅ passed | Write-recipients move files intra-share with FileMetadata re-encryption |
+
+---
+
+## 4. Requirements Coverage
+
+**66 v1.1 requirements defined, 66 mapped to phases, all satisfied.**
+
+| Group | Reqs | Status | Notes |
+| ----- | ---- | ------ | ----- |
+| IPNS-01..04 (reliability) | 4 | ✅ | Someguy self-hosted; DB-first resolve with async DHT verify; <2s graceful degrade |
+| VAULT-01..06 (migration) | 6 | ✅ | rootFolderKey in blob v2; DB crypto columns dropped; recovery tool + desktop parse v2 |
+| BYO-01..07 (bring-your-own IPFS) | 7 | ✅ | Pinning Service API, dual-pin, encrypted per-user config, settings UI, advisory quota |
+| PERF-01..09 (baselines) | 9 | ✅ | IPFS/IPNS/TEE histograms, API p50/p95/p99, client timing, E2E journeys, load harness, CAPACITY.md |
+| SDK-01..11 (TS SDK) | 11 | ✅ | Five-package split, SdkContext, stateful client, hooks refactored, per-package Release Please |
+| RSDK-01..10 (Rust SDK) | 10 | ✅ | Five crates, shared test vectors + parity gate, thin Tauri shell |
+| BUGFIX/TEST-01..03 | 5 | ✅ | Bin IPNS fix, device-registry parse, headless load tests, recovery E2E, 401 refresh |
+| DESKTOP-01..02 | 2 | ✅ | Auto-update + FUSE-file TEE enrollment |
+| OBS-01..02 | 2 | ✅ | Grafana alerts on p95 breach; timeouts tuned for sub-2s |
+| SHARE-01..10 (writable shares) | 10 | ✅ | Permission column, encrypted IPNS key, write-authz, toggle UI, [RW] badges, conflict retry |
+
+> **Audit history (honest accounting):** The 2026-06-11 milestone audit returned `gaps_found` — 62/66 requirements verified, with **PERF-01..04 "orphaned"** because Phase 18 lacked a `VERIFICATION.md`, and phases 18/31/32 missing verification docs. These are **process gaps, not code gaps** (the histograms are wired and relied on by phases 22/26). The verification-ledger close-out commits (#512 "complete phases 47-49 after verification", #513 "close out verification ledger for phases 19.2, 23, 27") covered 19.2/23/27 and 47–49 — but **phases 18, 31, and 32 still lack `VERIFICATION.md` as of 2026-06-18**, so PERF-01..04 remain technically orphaned. STATE.md reports the milestone 100% complete on the strength of the indirect evidence; closing these is tracked in [`TECH_DEBT-v1.1.md`](./TECH_DEBT-v1.1.md) §5 and `.planning/todos/pending/2026-06-18-gsd-verification-gaps-phases-18-31-32.md`.
+
+---
+
+## 5. Key Decisions Log
+
+| # | Decision | Phase | Rationale |
+| - | -------- | ----- | --------- |
+| D1 | SDK-first decomposition (logic moves down, hooks stay thin) | 19.1, 31, 38, 47 | Headless testability, multi-platform reuse, single folder-state owner |
+| D2 | Cross-language test vectors + CI parity gate | 23 | Guarantee TS↔Rust crypto byte-parity |
+| D3 | Vault blob v2 — rootFolderKey ECIES-wrapped in IPFS, DB columns dropped | 20 | Server holds zero key material |
+| D4 | Self-hosted Someguy (standard DHT) | 19 | Remove flaky delegated-ipfs.dev; fits 768 MB VPS |
+| D5 | BYO client-direct pins; IPNS always via CipherBox API | 21 | Data sovereignty + centralized IPNS conflict control |
+| D6 | TEE-encrypted BYO credentials + SSRF-validated connection test | 21 | No plaintext creds; safe outbound probing |
+| D7 | Concurrent pins require pebbleds datastore (synergistic) | 19.2 | −13% p95 upload latency |
+| D8 | `p-limit(3)` parallel pipeline + Web Worker zero-copy encryption | 37 | O(N)→O(1) IPNS publishes per batch |
+| D9 | `publishWithCas` + three-way `mergeChildren`; loser-becomes-version | 44, 47 | Deterministic concurrent-write resolution without CRDTs |
+| D10 | Ownership-guarded unpin + cross-user refcount + outbox pattern | 42 | Close unpin authz gap; transactional quota integrity |
+| D11 | fsync'd ciphertext write journal + replay; park on exhaustion | 43, 46 | No silent FUSE data loss; never drop a write |
+| D12 | Async channel-based FilePointer resolution (poll-wait fallback) | 32, 33 | Eliminate Finder/Explorer stalls; `STATUS_DEVICE_NOT_READY` for transient retry |
+| D13 | Grafana Faro RUM, no session replay, publicKey-only identity | 30 | Privacy-preserving web observability, single vendor |
+| D14 | Per-package semver with PR-time commit analysis | 41 | Precise multi-component releases |
+| D15 | ECIES-encrypted shared item names + lazy backfill persist | 48 | Close Phase 14 plaintext `itemName` leak at rest |
+| D16 | Intra-share moves with DEST-first publish + FileMetadata re-key | 49 | Recipients move files across subfolders with decrypt-survival |
+
+---
+
+## 6. Tech Debt & Deferred Items
+
+**Process/verification debt (partly open):** the 2026-06-11 audit's orphaned PERF-01..04 and the missing VERIFICATION.md files for phases 18/31/32 remain **open** as of 2026-06-18 — the ledger close-out covered 19.2/23/27/47–49 but not these three. Tracked in [`TECH_DEBT-v1.1.md`](./TECH_DEBT-v1.1.md) §5 + a pending todo; closeable with `/gsd:validate-phase 18 31 32`. Nyquist compliance at audit time was *partial* (7 compliant / 8 partial / 5 missing of 20 in-scope phases) — a documentation-coverage gap, not a behavior gap.
+
+**Verified-open code debt (new this pass):** a tech-debt sweep of all 34 phases + the phase 42/43 `REVIEW.md` files surfaced 24 verified-open items not previously tracked — most notably two correctness risks in the unpin path (**P42·WR-01** advisory-lock `INT_MIN` overflow → permanent undeletability; **P42·WR-03** stale-outbox re-pin race → data loss) and **P43·WR-06** (unbounded FUSE journal with full ciphertext in JSON, no GC). These are promoted to `.planning/todos/pending/` and catalogued in [`TECH_DEBT-v1.1.md`](./TECH_DEBT-v1.1.md). (Phase 43's 8 critical review findings were already fixed 2026-06-14; phases 45/46 resolved most of its warnings.)
+
+**Carried tech debt (from audit frontmatter + phase deferrals):**
+
+- **Phase 19.1:** `useFolderMutations.ts` still imports `folderService` validation helpers (`getDepth`, `isDescendantOf`, `calculateSubtreeDepth`) and `reWrapForRecipients` — accepted deviation (note: much of `folder.service.ts` was later retired in Phase 38).
+- **Phase 21:** BYO-04 settings UI flagged human-verification-needed.
+- **Phase 23:** TODO — mkdir publish retry on Windows write path (`crates/fuse/src/platform/windows/write_ops.rs`).
+- **Phase 25:** Platform code signing (Apple/Windows), beta/canary channels, retroactive TEE enrollment, delta updates — all deferred.
+- **Phase 27:** UAT human-confirmation outstanding at audit; no attribution/audit trail, no transitive re-sharing, 30s sync interval, lazy key rotation on revoke.
+- **Phase 29:** Native Kubo API ACL (relying on Docker 127.0.0.1 binding); periodic reconciliation job for failed unenrolls.
+- **Phase 30:** Logger transport deferred until Phase 28 shipped (since landed); Faro off in local dev when `VITE_FARO_URL` absent.
+- **Phase 35:** Two operational human-confirmation items — live Phala CVM health, GitHub staging secrets.
+- **Phases 43/44:** Rust FUSE 409-merge parity — live-session rebuild *approximates* TS op-replay but can stomp remote-only changes; full pending-uploads desktop UI deferred.
+- **Phase 42:** Wire `provider.unpin` into BYO client delete flows; writable-share version-prune leak (pre-existing); upload/unpin race is detect-only.
+- **Phase 37:** Adaptive concurrency by file size, AbortSignal cancellation, dual-pin secondary-pin warning events.
+
+**Explicitly deferred to v1.2+ (out of scope by design):** CRDT-based IPNS inbox for share discovery, `folder_ipns` cache made advisory, device-registry off DB, `pinned_cids` elimination, client-direct IPFS upload (bypass relay). Mobile apps, real-time collab, and the Encrypted Productivity Suite remain Milestone 4 (v2.0).
+
+---
+
+## 7. Getting Started
+
+**Run the project (local dev):**
+
+```bash
+docker compose -f docker/docker-compose.yml up -d   # Kubo, Postgres, Someguy, etc.
+pnpm --filter @cipherbox/api dev                     # NestJS API
+pnpm --filter @cipherbox/web dev                      # React web app (Vite, :5173)
+```
+
+See `docs/DEVELOPMENT.md` for full environment setup.
+
+**Regenerate the API client after API changes** (enforced by a pre-commit hook):
+
+```bash
+pnpm api:generate
+```
+
+**Key directories:**
+
+- `apps/api` — NestJS backend (zero-knowledge relay, IPNS publish, shares, quota)
+- `apps/web` — React 18 web app (Zustand stores subscribe to SDK events)
+- `apps/desktop` — Tauri shell; logic delegated to Rust crates
+- `apps/tee-worker` — TEE republisher (Phala Cloud CVM in prod)
+- `packages/{crypto,core,api-client,sdk-core,sdk}` — the TypeScript SDK (dependency order: sdk → sdk-core → api-client/core/crypto)
+- `crates/{crypto,core,api-client,fuse,sdk}` — the Rust SDK mirror
+- `tests/vectors/` — cross-language crypto test vectors (parity-gated in CI)
+- `docs/` — single source of truth (ARCHITECTURE, FILESYSTEM_SPECIFICATION, METADATA_SCHEMAS, CAPACITY, VAULT_EXPORT_FORMAT, …)
+
+**Where to look first:**
+
+- Folder/file operations → `packages/sdk-core` (stateless ops) + `packages/sdk` `CipherBoxClient` (stateful owner of folder tree).
+- Crypto → `packages/crypto` (primitives) / `packages/core` (vault blob v2, metadata, IPNS records).
+- IPNS conflict logic → `publishWithCas` + `mergeChildren` in `packages/sdk-core`.
+- Desktop FUSE → `crates/fuse` (platform modules behind feature flags) + write journal in `crates/sdk`.
+
+**Tests:**
+
+- Web/SDK unit: `pnpm --filter <pkg> test` (vitest — note web `include` is `src/**/*.test.ts` only).
+- Rust: workspace-level `cargo test` (includes cross-language vector parity gate).
+- E2E: Playwright suites in `apps/web` (web-e2e gate runs on main push); desktop E2E script pairs.
+- SDK load: headless vitest harness in `tests/load/` (needs local Docker stack + API).
+
+---
+
+## Stats
+
+- **Timeline:** 2026-03-07 → 2026-06-18 (~3.5 months)
+- **Phases:** 34 / 34 complete (151 / 151 plans; avg ~5.5 min/plan, ~16.5h total execution)
+- **Commits:** 222 (in milestone range, inclusive of start commit)
+- **Files changed:** 2,109 (+304,729 / −50,510)
+- **Contributors:** Michael Yankelev (173 commits), cipherbox-release-bot[bot] (44), dependabot[bot] (5)
+- **Requirements:** 66 / 66 satisfied
+- **Audit (2026-06-11):** `gaps_found` → 19.2/23/27/47–49 closed by ledger close-out; phases 18/31/32 verification gaps still open (tracked). Milestone reported 100% complete in STATE.md
+- **Tech debt:** carried debt catalogued in [`TECH_DEBT-v1.1.md`](./TECH_DEBT-v1.1.md); 5 net-new pending todos filed (24 verified-open items)

--- a/.planning/reports/TECH_DEBT-v1.1.md
+++ b/.planning/reports/TECH_DEBT-v1.1.md
@@ -1,0 +1,111 @@
+# v1.1 Tech Debt — Tracked TODOs
+
+**Generated:** 2026-06-18
+**Scope:** Carried tech debt, deferred items, and known limitations from milestone v1.1 (phases 18–49).
+**Companion:** [`MILESTONE_SUMMARY-v1.1.md`](./MILESTONE_SUMMARY-v1.1.md)
+
+This is the consolidated, verified tech-debt ledger for v1.1. Items were swept from every phase's
+VERIFICATION/CONTEXT/SUMMARY artifacts, the milestone audit, the phase 42/43 `REVIEW.md` code reviews,
+and in-code TODO markers, then **verified against current code** (2026-06-18) so nothing already-fixed is
+re-filed and nothing already-tracked is duplicated.
+
+## Legend
+
+- `[ ]` open · `[x]` verified resolved (kept for the record)
+- 🆕 **new** — not previously tracked; promoted to `.planning/todos/pending/` (filename noted)
+- 📋 **in BACKLOG** — already tracked in [`../BACKLOG.md`](../BACKLOG.md); not duplicated here
+- Tag format: `[P{phase}·{id}·{severity}]`
+
+---
+
+## 1. Unpin integrity & quota — Phase 42 `REVIEW.md` (🆕 all new)
+
+Source: `.planning/phases/42-api-unpin-integrity/42-REVIEW.md` (no resolution section; all verified still present in current `apps/api` code 2026-06-18).
+Promoted to **`.planning/todos/pending/2026-06-18-phase42-unpin-integrity-review-open-findings.md`**.
+
+- [ ] **[P42·WR-01·high]** `abs(hashtext($1))::bigint` raises "integer out of range" for the CID whose `hashtext == INT_MIN`, making that file **permanently undeletable** (500 on every unpin, quota row stuck). Drop `abs()` or cast first: `abs(hashtext($1)::bigint)`. — `apps/api/src/vault/vault.service.ts:262`
+- [ ] **[P42·WR-03·high]** Stale-outbox drain re-pin race: `drainPendingUnpins` unpins every outbox CID unconditionally; if a CID is re-pinned/re-recorded while in `pending_unpins` (re-upload or pin-migration), the next drain removes a **live pin → data loss**. Re-check `pinned_cids` refcount before `unpinFile` and delete the stale outbox row instead. — `apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts:53`
+- [ ] **[P42·WR-02·med]** Upload compensation calls `guardedUnpin` which no-ops (no `pinned_cids` row for caller after a failed insert) → the just-created Kubo pin **leaks permanently**, and a dedupe match can fire `cipherbox_unpin_cross_user_attempts_total`, **polluting the cross-user security alert** on internal DB failures. — `apps/api/src/ipfs/ipfs.controller.ts:128`
+- [ ] **[P42·WR-05·med]** Backfill script snapshots Kubo before querying the DB with no age cutoff → rows for uploads that land in between are deleted as "phantoms" (quota under-count + perpetual drift orphan). Add `pc.pinned_at < NOW() - INTERVAL '1 hour'`. — `scripts/backfill-pinned-cids.ts:88`
+- [ ] **[P42·WR-07·med]** Refcount counts **all** `pinned_cids` rows including BYO advisory rows (pins on the user's own node), so a non-owner BYO recipient registering a shared CID can keep hosted ciphertext pinned **indefinitely after the owner deletes** (server-side retention path controllable by a non-owner). Filter the physical-unpin decision to hosted (non-BYO) rows, or document the consequence in the threat model. — `apps/api/src/vault/vault.service.ts:278`
+- [ ] **[P42·WR-06·low]** Backfill `SELECT` hardcodes `false::boolean AS "isByoUser"`, making the documented defensive BYO re-assert unable to fire. Select the real `v.is_byo_user` column. — `scripts/backfill-pinned-cids.ts:137`
+- [ ] **[P42·IN-01·low]** `fileUnpins.inc()` runs unconditionally — unknown-CID / cross-user no-ops inflate the metric. — `apps/api/src/vault/vault.service.ts:310`
+- [ ] **[P42·IN-02·low]** `UnpinDto.cid` lacks the CID regex/`@MaxLength` that `RegisterCidDto` has. — `apps/api/src/ipfs/dto/unpin.dto.ts`
+- [ ] **[P42·IN-03·low]** `recordUnpin` is dead code (zero non-test callers) — delete or `@deprecated`. — `apps/api/src/vault/vault.service.ts:317`
+- [ ] **[P42·IN-04·low]** `IPFS_PROVIDER` LocalProvider factory duplicated across three modules (cycle workaround) — extract `IpfsProviderCoreModule`. — `vault.module.ts`, `pending-unpin.module.ts`, `ipfs.module.ts`
+- [ ] **[P42·IN-05·low]** Drift report `dbCids` includes BYO advisory CIDs, masking hosted orphans (tied to WR-07). — `pending-unpin.processor.ts:84`
+- [ ] **[P42·IN-06·low]** `outboxRowInserted` set even when `orIgnore` deduped the insert (misnamed; harmless). — `apps/api/src/vault/vault.service.ts`
+- [x] **[P42·WR-04]** ~~`driftOrphanedPinsTotal` Counter vs Gauge~~ — verified acceptable (Counter accumulates per-run orphan observations); no change.
+
+## 2. FUSE write journal — Phase 43 `REVIEW.md` residual (🆕 new)
+
+Source: `.planning/phases/43-fuse-write-durability/43-REVIEW.md`. All **8 critical** findings (CR-01..CR-08) were verified FIXED 2026-06-14. Phases 45/46 then resolved most warnings. Verified-still-open below.
+Promoted to **`.planning/todos/pending/2026-06-18-fuse-journal-growth-and-replay-timeout.md`**.
+
+- [ ] **[P43·WR-06·high]** Unbounded journal growth + full ciphertext base64 embedded in journal JSON: a 2 GB file → ~2.7 GB allocation + multi-GB fsync **on the single FUSE callback thread** (macOS) / under the global WinFsp mutex — blocks the whole filesystem, can OOM. No size cap, no GC of parked `Failed` entries, no purge on logout (other vaults' entries persist forever). Store ciphertext in a sidecar `<id>.bin`, cap/stream, add GC + logout purge. — `crates/sdk/src/queue.rs:36`
+- [ ] **[P43·WR-07·med]** `replay_for_vault` runs inline in mount with no `NETWORK_TIMEOUT` discipline → a hung connection stalls `mount_filesystem` indefinitely; many entries on a slow link delay mount by minutes. Wrap each entry in `tokio::time::timeout` and/or run replay concurrently with mount. — `apps/desktop/src-tauri/src/fuse/mod.rs:278`
+- [ ] **[P43·IN-03·low]** Plaintext `filename`/`name` persisted in journal JSON (0600, local-only) — new at-rest disclosure of vault item names; document in threat model or encrypt. — `crates/sdk/src/queue.rs:62`
+- [ ] **[P43·IN-04·low]** `sanitize_error` only scrubs `/Users/` and `/home/`; `C:\Users\…`, `/var`, `/tmp`, `/private` leak into tray/notification copy. — `crates/sdk/src/sync.rs:271`
+- [ ] **[P43·IN-05·low]** `let _ = journal.remove(...)` swallows removal errors → a failed removal silently replays later (double-publish risk). At minimum `log::warn!`. — `crates/fuse/src/lib.rs:1494`, `:1558`; `write_ops.rs:679`
+- [x] **[P43·WR-01..05, WR-08, WR-09, IN-01, IN-02, IN-06]** Verified resolved by phases 45/46: replay now sorted by `created_at_ms`; BFS folder-key resolution; atomic `0o600` create + parent-dir fsync; mkdir Err rollback; conflict entry-id threading; `deser_opt_string` empty-name guard; `Default` impl removed; retry off-by-one fixed; load skips malformed entries; `record_publish` only post-success.
+
+## 3. Web observability wiring (🆕 new)
+
+Phase 28 specified a redacting logger with a transport hook; Phase 30 was to wire Faro into it. Verified 2026-06-18: **neither the redaction interceptor nor the transport wiring exists** — warn/error logs are not forwarded to Faro and sensitive fields are not stripped from client logs.
+Promoted to **`.planning/todos/pending/2026-06-18-web-logger-redaction-and-faro-transport-unwired.md`**.
+
+- [ ] **[P28·D-03·med]** Logger `redact()` interceptor (strip `privateKey`/`rootFolderKey`/`folderKey`/`fileKey`/`accessToken` from context) never implemented — logger does level filtering only. — `apps/web/src/lib/logger.ts`
+- [ ] **[P30·med]** `registerFaroTransport(logger.transports)` is defined but **never called** (`initFaro()` doesn't call it) → warn/error logs never reach Faro. — `apps/web/src/lib/faro.ts:177`, `apps/web/src/main.tsx`
+- [ ] **[P28·D-04·med]** Logger `transports[]` hook array absent (prerequisite for the above). — `apps/web/src/lib/logger.ts`
+
+## 4. IPNS unenrollment completeness (🆕 new)
+
+- [ ] **[P29·med]** `collectSubtreeIpnsNames` only walks already-loaded folders, so deleting a folder with **unloaded subtrees** leaves nested file IPNS records un-unenrolled (orphaned TEE enrollment + IPNS records). Walk persisted metadata, not just loaded `folderTree`. — `packages/sdk/src/client.ts:232`. Promoted to **`.planning/todos/pending/2026-06-18-unenroll-skips-unloaded-subtrees.md`**. Related (but distinct) BACKLOG item: "Periodic reconciliation job for unenrollment" (📋 phase 29).
+
+## 5. GSD verification / process gaps (🆕 new)
+
+The 2026-06-11 milestone audit flagged these; the verification-ledger close-out commits (#512/#513) covered phases 19.2/23/27/47–49 but **not** 18/31/32. Verified 2026-06-18: still missing.
+Promoted to **`.planning/todos/pending/2026-06-18-gsd-verification-gaps-phases-18-31-32.md`**.
+
+- [ ] **[P18·med]** No `VERIFICATION.md` → requirements **PERF-01..04** remain technically orphaned (histograms wired & relied on by phases 22/26, but never directly verified). Run `/gsd:validate-phase 18`.
+- [ ] **[P32·med]** No `VERIFICATION.md` **and** no `VALIDATION.md` (only phase lacking both). Run `/gsd:validate-phase 32`.
+- [ ] **[P31·med]** Only `31-VALIDATION.md` (status draft, approval pending); no `VERIFICATION.md` for the structural decomposition. Run `/gsd:validate-phase 31`.
+
+## 6. Operational / known limitations (🆕 documented, mostly runbook)
+
+- [ ] **[P35·med]** TEE key-source transition is destructive: switching simulator→CVM (or delete+recreate of a CVM) **invalidates all previously-encrypted `encryptedIpnsPrivateKey` values** and destroys the TEE epoch keys. Document a runbook (always UPDATE the CVM, never delete+recreate) and a re-enrollment path. — `35-05-SUMMARY` / `35-VERIFICATION` truth 21
+- [ ] **[P29·med]** Staging/prod IPFS API (Kubo `:5001`) is bound to all interfaces in `docker-compose.yml` with an unresolved TODO for env-specific hardening (127.0.0.1 binding / reverse proxy + API auth). — `docker/docker-compose.yml:37`. Overlaps 📋 BACKLOG "Kubo API access control (reverse proxy or ACL)".
+- [ ] **[P19.2·info]** Deployment coupling: SDK concurrent pins regress performance (+138% p95 at 50 clients) on `flatfs` — they are **synergistic with the `pebbleds` datastore and must be deployed together**. Both shipped, but document the coupling so a datastore rollback doesn't silently regress uploads. — `19.2-04-SUMMARY`
+
+## 7. Already tracked in `.planning/BACKLOG.md` (📋 not duplicated)
+
+These v1.1 deferrals are already in the backlog inventory and remain correctly tracked there — see [`../BACKLOG.md`](../BACKLOG.md):
+
+- **Sharing (P14/P27):** metadata-embedded sharing, attribution/`lastModifiedBy`, transitive re-sharing, share notifications, immediate key rotation on revoke, faster shared-folder sync, CRDT IPNS inbox.
+- **Desktop (P25/P14/P17):** platform code signing (Apple notarization), beta/canary channels, delta updates, retroactive TEE enrollment, desktop sharing/bin/search UI, `.Trash` integration.
+- **Upload pipeline (P37):** adaptive concurrency, FUSE write-coalescing, accumulated retry batching, AbortSignal cancellation, lazy file reading in the pool.
+- **Observability (P28/P30):** `no-console` ESLint enforcement, Web Worker logging bridge, "Report a problem" button.
+- **Infra/data (P29/P12.6/P17):** periodic unenroll reconciliation job, TEE enrollment drift reconciliation, Kubo API ACL.
+- **Code quality:** `uint8ToBase64` dedup (Tier 3.3 — verified **3 copies** still: `sdk-core/file`, `sdk-core/folder`, `web/file-metadata.service`), plus Tier-3 cleanups 3.1–3.14.
+- **Security review residue (P14/PR #448):** M1 (`itemName` plaintext — note: now mitigated for shares via Phase 48 ECIES `itemNameEncrypted`), M5 (`reWrapForRecipients` residual caller), S1/S2/S3 (IPNS signed-record validation/enforcement/key-zeroization).
+
+## 8. Deferred to v1.2+ (📋 out of scope by design)
+
+Per `REQUIREMENTS.md` and `PROJECT.md`: CRDT-based IPNS inbox for share discovery (IPNS-05), advisory `folder_ipns` CID cache (IPNS-06), device-registry off DB (DB-01), `pinned_cids` elimination (DB-02), client-direct IPFS upload bypassing relay (BYO-08). Milestone 4 (v2.0): Encrypted Productivity Suite, mobile apps, real-time collaboration.
+
+---
+
+## Summary
+
+| Bucket | Count | Tracking |
+| ------ | ----- | -------- |
+| Phase 42 unpin-integrity review (open) | 12 | 🆕 1 new todo |
+| Phase 43 FUSE-journal review (open) | 5 | 🆕 1 new todo |
+| Web observability wiring | 3 | 🆕 1 new todo |
+| IPNS unenroll completeness | 1 | 🆕 1 new todo |
+| GSD verification gaps | 3 | 🆕 1 new todo |
+| Operational / known limitations | 3 | 🆕 documented here |
+| Already in BACKLOG | ~30 | 📋 referenced |
+| Deferred to v1.2+ | — | 📋 referenced |
+
+**Net-new tracked this pass:** 5 pending-todo files in `.planning/todos/pending/` (dated 2026-06-18), covering 24 verified-open items across phases 42, 43, 28/30, 29, and the 18/31/32 process gaps. Two high-severity correctness risks lead the list: **P42·WR-01** (permanent undeletability) and **P42·WR-03** / **P43·WR-06** (data-loss / filesystem-stall).

--- a/.planning/todos/pending/2026-06-18-fuse-journal-growth-and-replay-timeout.md
+++ b/.planning/todos/pending/2026-06-18-fuse-journal-growth-and-replay-timeout.md
@@ -1,0 +1,53 @@
+---
+created: 2026-06-18T00:00:00.000Z
+title: FUSE write-journal unbounded growth + ciphertext-in-JSON, and replay has no network timeout
+area: bug
+severity: high
+source: .planning/phases/43-fuse-write-durability/43-REVIEW.md warnings (criticals fixed 2026-06-14; warnings re-verified against live code 2026-06-18, post phases 45/46)
+files:
+  - crates/sdk/src/queue.rs
+  - crates/fuse/src/read_ops.rs
+  - crates/fuse/src/lib.rs
+  - crates/sdk/src/sync.rs
+  - apps/desktop/src-tauri/src/fuse/mod.rs
+---
+
+## Problem
+
+All 8 critical findings (CR-01..CR-08) in `43-REVIEW.md` were verified FIXED on 2026-06-14, and
+phases 45/46 resolved most warnings (replay ordering, BFS folder-key resolution, atomic 0600 +
+parent-dir fsync, mkdir rollback, conflict entry-id threading, empty-name guard, `Default` removed).
+Re-verified 2026-06-18 — these remain **open**:
+
+- **WR-06 (high)** — Each `UploadFile` journal entry embeds the **entire file ciphertext as base64
+  inside the JSON document**. A 2 GB file → ~2.7 GB allocation in `serde_json::to_vec`, then a
+  multi-GB write + `F_FULLFSYNC` executed **on the single FUSE callback thread** (macOS) / while
+  holding the global WinFsp mutex (Windows) — blocking the whole filesystem for the duration and
+  capable of OOM. There is no size cap, no GC of parked `Failed` entries, and entries from other
+  vaults persist forever after account switch (the journal dir is shared, only ever filtered).
+  (`crates/sdk/src/queue.rs:36`)
+- **WR-07 (med)** — `replay_for_vault` awaits raw `resolve_ipns`/`fetch_content`/`upload_content`
+  per entry with none of the `NETWORK_TIMEOUT` discipline used elsewhere. A hung connection stalls
+  `mount_filesystem` indefinitely; many entries on a slow link delay mount by minutes.
+  (`apps/desktop/src-tauri/src/fuse/mod.rs:278`)
+- **IN-03 (low)** — plaintext `filename`/`name` persisted in journal JSON (new local at-rest
+  disclosure of vault item names; 0600, local-only). (`crates/sdk/src/queue.rs:62`)
+- **IN-04 (low)** — `sanitize_error` only scrubs `/Users/` and `/home/`; `C:\Users\…`, `/var`,
+  `/tmp`, `/private` leak into tray/notification copy. (`crates/sdk/src/sync.rs:271`)
+- **IN-05 (low)** — `let _ = journal.remove(...)` swallows removal errors → silent later replay /
+  double-publish risk. (`crates/fuse/src/lib.rs:1494`, `:1558`; `write_ops.rs:679`)
+
+## Fix
+
+- **WR-06:** store ciphertext in a sidecar `<id>.bin` streamed to disk; JSON holds only path/hash.
+  Cap journaled payload size. Add GC for parked entries (age/size budget) and an explicit purge on
+  logout / account deletion.
+- **WR-07:** wrap each entry's replay in `tokio::time::timeout(NETWORK_TIMEOUT * k, ...)` and/or run
+  replay concurrently with (not before) mount.
+- **IN-03/04/05:** document/encrypt journaled names; extend the path-scrub prefix list + drive-letter
+  pattern; `log::warn!` on removal errors.
+
+## Acceptance
+
+Large-file write no longer blocks the FS thread (sidecar ciphertext); journal has a bounded
+growth/GC story and a logout purge; replay cannot hang the mount.

--- a/.planning/todos/pending/2026-06-18-gsd-verification-gaps-phases-18-31-32.md
+++ b/.planning/todos/pending/2026-06-18-gsd-verification-gaps-phases-18-31-32.md
@@ -1,0 +1,42 @@
+---
+created: 2026-06-18T00:00:00.000Z
+title: Phases 18, 31, 32 lack VERIFICATION.md (PERF-01..04 orphaned); close the v1.1 verification ledger
+area: process
+severity: medium
+source: .planning/v1.1-MILESTONE-AUDIT.md (2026-06-11); re-verified 2026-06-18 — ledger close-out (#512/#513) covered 19.2/23/27/47-49 but not 18/31/32
+files:
+  - .planning/phases/18-performance-instrumentation/
+  - .planning/phases/31-structural-decomposition/
+  - .planning/phases/32-fuse-async-filepointer-resolution/
+---
+
+## Problem
+
+The v1.1 milestone audit returned `gaps_found` on process grounds, not code grounds. The
+verification-ledger close-out commits (#512, #513) resolved phases 19.2/23/27 and 47–49, but
+**18, 31, 32 were not covered**. Verified 2026-06-18 — they still lack verification docs:
+
+- **Phase 18** — no `VERIFICATION.md`. Consequence: requirements **PERF-01..04** are technically
+  orphaned. The histograms are wired and relied on by phases 22/26 (strong indirect evidence), but
+  no phase directly verifies them, so the "66/66 satisfied" claim rests on indirect evidence for
+  these four. (`18-VALIDATION.md` exists.)
+- **Phase 32** — no `VERIFICATION.md` **and** no `VALIDATION.md` (the only phase lacking both).
+- **Phase 31** — only `31-VALIDATION.md` (status: draft, approval: pending); no `VERIFICATION.md`
+  for the structural decomposition.
+
+These are documentation/verification gaps, not behavioral defects, but they leave the milestone's
+"complete + verified" status resting on an incomplete ledger.
+
+## Fix
+
+- `/gsd:validate-phase 18` — directly verifies PERF-01..04, closing all four requirement orphans.
+- `/gsd:validate-phase 32` — the only phase with neither doc.
+- `/gsd:validate-phase 31` — VERIFICATION gap only (Nyquist already compliant).
+
+Then update `REQUIREMENTS.md` traceability and the milestone audit verdict to `passed`. Note: the
+companion `MILESTONE_SUMMARY-v1.1.md` was corrected to stop claiming these were already closed.
+
+## Acceptance
+
+18/31/32 each have a passing `VERIFICATION.md`; PERF-01..04 are no longer orphaned; audit verdict
+flips to `passed`.

--- a/.planning/todos/pending/2026-06-18-phase42-unpin-integrity-review-open-findings.md
+++ b/.planning/todos/pending/2026-06-18-phase42-unpin-integrity-review-open-findings.md
@@ -1,0 +1,51 @@
+---
+created: 2026-06-18T00:00:00.000Z
+title: Phase 42 unpin-integrity code-review findings (WR/IN) are unresolved in current code
+area: bug
+severity: high
+source: .planning/phases/42-api-unpin-integrity/42-REVIEW.md (no resolution section); re-verified against live code 2026-06-18
+files:
+  - apps/api/src/vault/vault.service.ts
+  - apps/api/src/ipfs/ipfs.controller.ts
+  - apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts
+  - apps/api/src/ipfs/dto/unpin.dto.ts
+  - scripts/backfill-pinned-cids.ts
+---
+
+## Problem
+
+`42-REVIEW.md` raised 7 warnings + 6 info findings on the guarded-unpin / pending-unpins
+implementation and has **no resolution section**. Each was re-checked against current code on
+2026-06-18 and confirmed still present. Two are correctness risks:
+
+- **WR-01 (high)** — `vault.service.ts:262` `SELECT abs(hashtext($1))::bigint`. For the CID whose
+  `hashtext == INT_MIN (-2147483648)`, `abs(int4)` raises `ERROR: integer out of range` —
+  deterministically, every unpin of that CID 500s, and its quota row is permanently stuck. The
+  file becomes **permanently undeletable via the API**. (`pg_advisory_xact_lock` accepts signed
+  bigint, so the `abs()` is both unnecessary and the only failure mode.)
+- **WR-03 (high)** — `pending-unpin.processor.ts:53` `drainPendingUnpins` unpins every outbox CID
+  unconditionally. If a CID is re-pinned/re-recorded (re-upload of identical ciphertext, or a
+  pin-migration flow) while still in `pending_unpins`, the next drain pass removes a **live pin**
+  → content eligible for Kubo GC → **data loss**. The D-13 "sub-second window" rationale does not
+  cover the outbox path (window ≥ 5 min, unbounded while Kubo is down).
+
+Medium/low findings: WR-02 (upload-compensation `guardedUnpin` no-op leaks the Kubo pin and can
+fire the cross-user security alert on internal failures), WR-05 (backfill TOCTOU deletes in-flight
+upload rows as phantoms), WR-07 (BYO advisory rows block physical unpin of hosted content
+indefinitely — non-owner-controllable retention path), WR-06 (backfill hardcodes
+`false::boolean AS "isByoUser"`, defeating the defensive re-assert), IN-01 (`fileUnpins.inc()` on
+no-ops), IN-02 (`UnpinDto.cid` missing CID regex/MaxLength), IN-03 (`recordUnpin` dead code),
+IN-04 (`IPFS_PROVIDER` factory duplicated ×3), IN-05 (drift `dbCids` includes BYO), IN-06
+(`outboxRowInserted` misnamed). WR-04 (Counter vs Gauge) was reviewed and judged acceptable.
+
+## Fix
+
+- **WR-01:** drop `abs()` (`SELECT hashtext($1)::bigint`) or cast first (`abs(hashtext($1)::bigint)`).
+- **WR-03:** in the drain loop, `count` `pinned_cids` for the CID before `unpinFile`; if `> 0`, delete
+  the stale outbox row and `continue`.
+- **WR-02/05/06/07 + IN-\*:** apply the per-finding fixes in `42-REVIEW.md` (each has a concrete patch).
+
+## Acceptance
+
+WR-01 and WR-03 fixed with regression tests (INT_MIN CID undeletability; re-pin-during-pending
+drain must not unpin). Remaining WR/IN items resolved or explicitly accepted with a comment.

--- a/.planning/todos/pending/2026-06-18-unenroll-skips-unloaded-subtrees.md
+++ b/.planning/todos/pending/2026-06-18-unenroll-skips-unloaded-subtrees.md
@@ -1,0 +1,31 @@
+---
+created: 2026-06-18T00:00:00.000Z
+title: collectSubtreeIpnsNames skips unloaded subtrees, leaving nested IPNS records un-unenrolled
+area: bug
+severity: medium
+source: Phase 29 (29-02-SUMMARY key-decisions); verified against live code 2026-06-18
+files:
+  - packages/sdk/src/client.ts
+---
+
+## Problem
+
+Phase 29 wired TEE/IPNS unenrollment into all four deletion paths via
+`collectSubtreeIpnsNames`, but the collector only walks **already-loaded** folder state
+(`folderTree.get()` and an early return when a folder is not loaded —
+`packages/sdk/src/client.ts:232`). Deleting a folder whose subtree was never expanded in the
+session returns only the top folder's IPNS name, so **nested file/folder IPNS records below an
+unloaded subtree are never unenrolled**. Those records keep being republished by the TEE (wasting
+compute) and linger until natural expiry.
+
+## Fix
+
+Resolve and traverse the persisted folder metadata for the subtree being deleted (fetch+decrypt
+child folder metadata on demand) rather than relying on the in-memory `folderTree`, so the full set
+of descendant IPNS names is collected regardless of load state. Alternatively, pair with the
+"periodic unenroll reconciliation job" already in BACKLOG as a backstop.
+
+## Acceptance
+
+Deleting a folder with an unloaded subtree unenrolls every descendant file/folder IPNS name (assert
+the unenroll batch count matches the full subtree, not just loaded nodes).

--- a/.planning/todos/pending/2026-06-18-web-logger-redaction-and-faro-transport-unwired.md
+++ b/.planning/todos/pending/2026-06-18-web-logger-redaction-and-faro-transport-unwired.md
@@ -1,0 +1,40 @@
+---
+created: 2026-06-18T00:00:00.000Z
+title: Web logger redaction interceptor missing and Faro transport never wired
+area: observability
+severity: medium
+source: Phase 28 (CONTEXT D-03/D-04) vs Phase 30 (deferred registerFaroTransport); verified against live code 2026-06-18
+files:
+  - apps/web/src/lib/logger.ts
+  - apps/web/src/lib/faro.ts
+  - apps/web/src/main.tsx
+---
+
+## Problem
+
+Phase 28 specified (D-03) a `redact()` interceptor that strips sensitive fields
+(`privateKey`/`rootFolderKey`/`folderKey`/`fileKey`/`accessToken`) from log context, and (D-04) a
+`transports[]` hook array. Phase 30 was to call `registerFaroTransport(logger.transports)` so
+warn/error logs reach Grafana Faro. Verified 2026-06-18:
+
+- `apps/web/src/lib/logger.ts` does **level filtering only** — no `redact()` interceptor and no
+  `transports[]` hook array exist. Sensitive fields passed in log context are not stripped.
+- `registerFaroTransport` **is defined** in `apps/web/src/lib/faro.ts:177` but is **never called**
+  (`initFaro()` in `main.tsx` does not call it), so warn/error logs are **not forwarded to Faro** —
+  client-side error/perf telemetry is silently incomplete.
+
+This is the deferral noted in `30-04-SUMMARY` ("registerFaroTransport deferred because Phase 28
+logger shipped later") that was never closed.
+
+## Fix
+
+1. Add a `transports: LogTransport[]` array to `logger.ts` and invoke each on warn/error.
+2. Add a `redact(context)` interceptor applied before any transport/console emit (reuse the Faro
+   `beforeSend` scrub field list for parity).
+3. Call `registerFaroTransport(logger.transports)` from Faro init (after `initFaro()`), guarded so
+   it is a no-op when Faro is disabled (`VITE_FARO_URL` absent).
+
+## Acceptance
+
+A warn/error log with a sensitive field is redacted in both console and Faro, and a forced error is
+visible in Faro from a build with `VITE_FARO_URL` set.


### PR DESCRIPTION
## What

Docs-only PR adding the **v1.1 IPFS Infrastructure** milestone summary plus a verified, tracked
tech-debt ledger for phases 18–49.

### Added

- **`.planning/reports/MILESTONE_SUMMARY-v1.1.md`** — team-onboarding overview: project context,
  the layered TS+Rust SDK architecture, all 34 phases, key decisions, requirements coverage
  (66/66), tech debt, getting-started, and stats (222 commits, ~2.1k files, +304.7k/−50.5k LOC,
  2026-03-07 → 2026-06-18).
- **`.planning/reports/TECH_DEBT-v1.1.md`** — consolidated, **code-verified** tech-debt ledger
  organized by theme. Cross-references existing `BACKLOG.md` entries (not duplicated) and records
  items verified resolved so they are not re-filed.
- **5 net-new pending todos** in `.planning/todos/pending/` (24 verified-open items).
- **`.planning/BACKLOG.md`** — dated close-out section pointing at the ledger and new todos.

### How the tech debt was derived

A sweep of every phase's VERIFICATION/CONTEXT/SUMMARY artifacts, the milestone audit, the phase
42/43 `REVIEW.md` code reviews, and in-code TODO markers — then **each candidate-open finding was
re-checked against current code (2026-06-18)** so already-fixed items (e.g. all 8 phase-43 critical
findings fixed 2026-06-14; most of its warnings closed by phases 45/46) are excluded.

### Notable verified-open risks now tracked

- `P42·WR-01` (**high**) — advisory-lock `abs(hashtext($1))` overflows for the `INT_MIN` CID →
  that file is **permanently undeletable**.
- `P42·WR-03` (**high**) — stale `pending_unpins` drain can unpin a re-pinned CID → **data loss**.
- `P43·WR-06` (**high**) — FUSE write journal embeds full ciphertext in JSON, no GC/purge →
  large-file writes block the FS thread / can OOM.
- Web: logger `redact()` never implemented and `registerFaroTransport` defined but never called
  (warn/error not reaching Faro).
- Process: phases 18/31/32 still lack `VERIFICATION.md` (PERF-01..04 orphaned) — the ledger
  close-out (`#512`/`#513`) covered 19.2/23/27/47–49 but not these. The milestone summary was
  corrected to stop claiming they were closed.

## Scope

Documentation and planning artifacts only — no source or behavior changes. The verified-open code
findings are captured as todos for follow-up, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Published updated v1.1 milestone report detailing architecture decisions, completion status, and requirements coverage.
  * Consolidated and refreshed v1.1 tech-debt tracking with newly verified findings and newly logged open risks.
  * Added targeted planning notes for remaining work: FUSE journal growth/replay timeouts, unpin-integrity review, IPNS unenrollment completeness, web logger redaction/Faro transport wiring, and missing verification docs.
  * Updated the roadmap and adjusted performance-metrics label naming to match the completed v1.1 phase range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->