### PR TITLE
chore(ci): fix landing page IPFS pin to run inside Kubo container

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -55,7 +55,11 @@ jobs:
             # Kubo runs as a Docker container on the staging host (compose service
             # "ipfs", image ipfs/kubo:v0.40.0) — there is no host-level ipfs CLI, so a
             # bare `ipfs` here fails with "command not found". Run it inside the container.
-            KUBO=$(docker ps -q --filter ancestor=ipfs/kubo:v0.40.0 | head -1)
+            # Capture the container list first, THEN take the first line: piping
+            # `docker ps` straight into `head` can SIGPIPE docker ps (exit 141) under
+            # `pipefail` and abort before the empty-KUBO guard runs.
+            KUBO_IDS=$(docker ps -q --filter ancestor=ipfs/kubo:v0.40.0)
+            KUBO=$(printf '%s\n' "${KUBO_IDS}" | head -n1)
             if [ -z "${KUBO}" ]; then
               echo "::error::No running ipfs/kubo container found on staging host"
               exit 1
@@ -65,9 +69,12 @@ jobs:
             # stdout to stderr so capture_stdout returns ONLY the CID.
             docker cp /tmp/cipherbox-landing "${KUBO}:/tmp/cipherbox-landing" 1>&2
             CID=$(docker exec "${KUBO}" ipfs add -Qr --pin /tmp/cipherbox-landing)
-            docker exec "${KUBO}" rm -rf /tmp/cipherbox-landing
-            rm -rf /tmp/cipherbox-landing
+            # Emit the CID immediately — the pin is already committed to Kubo, so a failure
+            # in the best-effort cleanup below must never drop it from stdout (that would
+            # fail the step and leave DNSLink pointing at the now-stale CID).
             echo "${CID}"
+            docker exec "${KUBO}" rm -rf /tmp/cipherbox-landing || true
+            rm -rf /tmp/cipherbox-landing || true
 
       - name: Validate CID
         run: |

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -51,7 +51,21 @@ jobs:
           key: ${{ secrets.STAGING_SSH_KEY }}
           capture_stdout: true
           script: |
-            CID=$(ipfs add -Qr --pin /tmp/cipherbox-landing)
+            set -euo pipefail
+            # Kubo runs as a Docker container on the staging host (compose service
+            # "ipfs", image ipfs/kubo:v0.40.0) — there is no host-level ipfs CLI, so a
+            # bare `ipfs` here fails with "command not found". Run it inside the container.
+            KUBO=$(docker ps -q --filter ancestor=ipfs/kubo:v0.40.0 | head -1)
+            if [ -z "${KUBO}" ]; then
+              echo "::error::No running ipfs/kubo container found on staging host"
+              exit 1
+            fi
+            # The SCP step landed the build at host /tmp/cipherbox-landing; the container
+            # has no /tmp bind-mount, so copy it in before adding. Redirect docker cp's
+            # stdout to stderr so capture_stdout returns ONLY the CID.
+            docker cp /tmp/cipherbox-landing "${KUBO}:/tmp/cipherbox-landing" 1>&2
+            CID=$(docker exec "${KUBO}" ipfs add -Qr --pin /tmp/cipherbox-landing)
+            docker exec "${KUBO}" rm -rf /tmp/cipherbox-landing
             rm -rf /tmp/cipherbox-landing
             echo "${CID}"
 

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -97,7 +97,9 @@ jobs:
       - name: Summary
         if: always()
         run: |
-          echo "## Landing Page Deployed" >> $GITHUB_STEP_SUMMARY
-          echo "- **CID:** ${CID}" >> $GITHUB_STEP_SUMMARY
-          echo "- **IPFS Gateway:** https://ipfs.io/ipfs/${CID}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Landing Page Deployed"
+            echo "- **CID:** ${CID}"
+            echo "- **IPFS Gateway:** https://ipfs.io/ipfs/${CID}"
+            echo "- **Commit:** ${{ github.sha }}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

The "Deploy Landing Page to IPFS" workflow has failed on **every run since the landing page was added in `#452`** — most recently re-triggered by the phase-53 merge (`#531`), which edited this workflow file (`deploy-landing.yml` is in the trigger `paths`). This is a pre-existing bug, **not** a phase-53 regression: the only two runs ever (2026-04-08 and 2026-06-20) failed identically.

Failing run: https://github.com/FSM1/cipher-box/actions/runs/27886353054

### Root cause

The pin step SSHes into the staging host and runs a bare `ipfs add`, but Kubo runs as a **Docker container** on staging (compose service `ipfs`, image `ipfs/kubo:v0.40.0`) — there is no host-level `ipfs` CLI, so it fails with `ipfs: command not found`. The error text then leaked into the captured CID, breaking the "Validate CID" step with `Value cannot be null`.

## Fix

- Run `ipfs` **inside** the Kubo container: locate it via `docker ps --filter ancestor=ipfs/kubo:v0.40.0` (the convention already used in `web-e2e.yml`), `docker cp` the SCP'd build into the container (no `/tmp` bind-mount exists), then `docker exec … ipfs add`.
- `set -euo pipefail` so a missing container or failed add fails the step loudly instead of leaking garbage into the CID.
- `capture_stdout` still returns only the CID (`docker cp` output redirected to stderr).
- Quote `$GITHUB_STEP_SUMMARY` and consolidate the Summary appends — clears the pre-existing actionlint SC2086/SC2129 warnings in that step.

## Verification

- `actionlint` clean; `zizmor --config .github/zizmor.yml` reports no findings.
- The `docker ps` / `docker exec` pattern matches how the rest of the repo drives Kubo on staging.
- End-to-end pinning can only be confirmed by an actual staging deploy, which runs on push to `main` (not on PRs) — so it will be exercised post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow reliability with improved error handling and artifact management for the landing page IPFS deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->