### PR TITLE
chore(ci): skip stale release-as guard on the release-please PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,19 @@ jobs:
 
       # Stale release-as guard (T-53-05): fail CI if any release-as pin in
       # release-please-config.json equals its shipped manifest version, which
-      # would make release-please self-compare (vX..vX). Runs the pure-function
-      # unit suite, then the guard against the committed config/manifest.
+      # would make release-please self-compare (vX..vX). The pure-function unit
+      # suite is state-independent and always runs.
+      - name: Test stale release-as guard
+        run: node --test .github/scripts/check-stale-release-as.test.js
+
+      # Skip the live check on release-please's own PR: that PR bumps the manifest
+      # UP to each release-as target, so release-as == manifest is the EXPECTED
+      # in-flight release there, not a stale pin. The check still runs on every
+      # other PR, so a genuinely stale pin (already shipped, not removed) is caught
+      # on the next feature PR.
       - name: Check for stale release-as pins
-        run: |
-          node --test .github/scripts/check-stale-release-as.test.js
-          node .github/scripts/check-stale-release-as.js
+        if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+        run: node .github/scripts/check-stale-release-as.js
 
   typecheck:
     name: Typecheck


### PR DESCRIPTION
## Problem

The stale-`release-as` guard (added in phase 53, T-53-05) fails on the **release-please PR** (`#528`), blocking it.

Failing job: https://github.com/FSM1/cipher-box/actions/runs/27887285517/job/82524637074?pr=528

```
STALE: apps/api release-as=0.42.0 == manifest=0.42.0
STALE: apps/desktop release-as=0.43.0 == manifest=0.43.0
STALE: packages/api-client release-as=0.42.0 == manifest=0.42.0
STALE: packages/sdk release-as=0.37.1 == manifest=0.37.1
STALE: crates/fuse release-as=0.7.0 == manifest=0.7.0
```

### Root cause

The guard fails whenever a `release-as` pin equals its manifest version. That is the correct signal **everywhere except the release-please PR**:

- On `main`, every `release-as` is strictly **ahead** of the manifest (e.g. `apps/api` `0.42.0` > `0.41.0`) → guard passes; these are real pending release targets.
- On the release-please PR, release-please bumps each manifest version **up to** its `release-as` target — that's the in-flight release it's preparing — so `release-as == manifest` there is **expected**, not stale.

The guard can't distinguish "about to ship" (release PR) from "already shipped and forgotten" (everywhere else) by value alone — both look equal. The branch is the discriminator.

## Fix

Split the step so the state-independent unit suite always runs, and gate only the **live** check off release-please PRs:

```yaml
      - name: Check for stale release-as pins
        if: ${{ !startsWith(github.head_ref, 'release-please--') }}
        run: node .github/scripts/check-stale-release-as.js
```

`startsWith(… 'release-please--')` covers the current combined PR (`release-please--branches--main`) and any future per-component branches. A genuinely stale pin (already shipped, never removed) is **not** masked — it still surfaces on the next non-release feature PR, since CI runs on every `pull_request` to `main`.

## Verification

- `actionlint` (the `if:` expression validates) and `zizmor --config .github/zizmor.yml` both clean for `ci.yml`.
- Confirmed against live state: `release-as` ahead of manifest on `main` (guard passes), equal on `#528` (guard false-failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
