### PR TITLE
fix(e2e): make desktop e2e helper dirs workspace packages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,36 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.7)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  tests/desktop-e2e:
+    devDependencies:
+      '@cipherbox/crypto':
+        specifier: workspace:*
+        version: link:../../packages/crypto
+      '@cipherbox/sdk-core':
+        specifier: workspace:*
+        version: link:../../packages/sdk-core
+      '@types/node':
+        specifier: ^22.19.7
+        version: 22.19.7
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  tests/e2e-helpers:
+    devDependencies:
+      '@cipherbox/api-client':
+        specifier: workspace:*
+        version: link:../../packages/api-client
+      '@cipherbox/sdk-core':
+        specifier: workspace:*
+        version: link:../../packages/sdk-core
+      '@types/node':
+        specifier: ^22.19.7
+        version: 22.19.7
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   tests/load:
     devDependencies:
       '@cipherbox/api-client':

--- a/tests/desktop-e2e/package.json
+++ b/tests/desktop-e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@cipherbox/desktop-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@cipherbox/crypto": "workspace:*",
+    "@cipherbox/sdk-core": "workspace:*",
+    "@types/node": "^22.19.7",
+    "typescript": "^5.9.3"
+  }
+}

--- a/tests/e2e-helpers/package.json
+++ b/tests/e2e-helpers/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@cipherbox/e2e-helpers",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@cipherbox/api-client": "workspace:*",
+    "@cipherbox/sdk-core": "workspace:*",
+    "@types/node": "^22.19.7",
+    "typescript": "^5.9.3"
+  }
+}


### PR DESCRIPTION
## Problem

Desktop E2E fails on `main` (all 3 platforms) after the phase 52/54 merge:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@cipherbox/sdk-core'
  imported from .../tests/desktop-e2e/scripts/bump-ipns-sequence.ts
```

Failing run: https://github.com/FSM1/cipher-box/actions/runs/27887243716

This is **not** caused by the FUSE mount changes (phase 52) — the FUSE ops all logged success. It's the phase-54 TypeScript migration (`#532`): the migrated helper scripts can't resolve `@cipherbox/*` at runtime. Desktop E2E runs on **main push, not PRs**, so `#532` passed PR CI and only broke after merge.

### Root cause

Phase 54 added TS scripts under `tests/desktop-e2e/scripts` and `tests/e2e-helpers` that import `@cipherbox/*`. Although `pnpm-workspace.yaml` globs `tests/*`, **neither directory had a `package.json`**, so they were not real workspace packages and had no `node_modules` with the `@cipherbox` deps. `tsconfig.scripts.json` maps the paths for **typecheck**, but `tsx` doesn't use that config at **runtime**, so `pnpm exec tsx <script>` fails to resolve the bare specifiers.

This cascades into every failing scenario — round-trip, cross-client-sync, and move-content all run verify/edit/rename helpers that transitively load `tests/e2e-helpers/auth.ts` (which imports `@cipherbox/api-client`).

## Fix

Add a `package.json` to each directory — matching the existing `@cipherbox/web-e2e` / `@cipherbox/sdk-e2e` suites — declaring the `@cipherbox/*` deps they import, so pnpm symlinks them into `node_modules` and `tsx` resolves them at runtime:

- `@cipherbox/desktop-e2e` → `sdk-core`, `crypto`
- `@cipherbox/e2e-helpers` → `api-client`, `sdk-core`

`pnpm-lock.yaml` gains only the two importer entries (it's prettier-formatted, as the repo expects).

## Verification

- Reproduced locally: before, `pnpm exec tsx tests/desktop-e2e/scripts/bump-ipns-sequence.ts` → `ERR_MODULE_NOT_FOUND`; after, it runs past all imports (fails only on `fetch failed` against a dummy API URL).
- `tsc -p tsconfig.scripts.json --noEmit` (the scripts typecheck) passes.
- Symlinks confirmed: `tests/{desktop-e2e,e2e-helpers}/node_modules/@cipherbox/*`.
- Dispatched the full `CI E2E Tests` workflow on this branch for an end-to-end run (Desktop E2E is main-push-only and doesn't run on PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
