### PR TITLE
docs: agent-native milestone exploration notes and seeds

### DIFF
--- a/.planning/notes/next-milestone-agent-native-zk-storage.md
+++ b/.planning/notes/next-milestone-agent-native-zk-storage.md
@@ -1,0 +1,136 @@
+---
+title: "Next-milestone direction — agent-native ZK storage (validation-gated)"
+date: 2026-06-22
+context: "Exploration session reframing the next milestone away from the proposed productivity-suite M4 toward agent-native positioning. Decision record + open validation gate."
+status: exploration / not yet committed to ROADMAP
+supersedes: "Proposed Milestone 4 (encrypted productivity suite) — see .planning/research/m4/"
+---
+
+## Origin
+
+CipherBox should not keep framing itself as a fresh attempt to out-compete Google
+Drive / OneDrive / Proton Drive on consumer ZK storage (an unwinnable head-on fight
+given limited resources). It already has the core ingredients of *private storage
+infrastructure*: zero-knowledge encryption, a programmable SDK, mountable remote
+vaults, sharing, and durable decentralized persistence. The idea: make that existing
+substrate **economically native to AI agents**, using **x402** as a machine-native
+payment/metering rail. Human subscription billing (the M4 Stripe work) still happens
+underneath regardless.
+
+## The reframe (decision)
+
+Do **not** treat this as a full pivot to "x402-metered storage for agents." The
+first-customer / moat is unvalidated, so:
+
+> Make the ZK substrate **agent-ready** with work that pays off regardless, and
+> **validate the agent wedge** before committing the full agent-native build or the
+> "stop competing with Drive" messaging.
+
+This **supersedes / reshapes** the proposed productivity-suite M4. Billing is the
+shared dependency that survives either path. Do **not** strand v1.0 consumers — the
+existing web/desktop vault becomes the **reference client / live demo** of the infra
+("a personal AI assistant over my own files" is itself a consumer product that
+consumes the agent infra). One substrate, two surfaces.
+
+## Decisions made this session
+
+### 1. Agents as first-class tenants is CHEAP on the existing substrate (verified)
+
+The earlier worry that this needed major auth re-architecture was **wrong** —
+verified against `apps/api`:
+
+- Web3Auth is **not used server-side** (`Web3AuthVerifierService` is defined but never
+  called; `auth.service.ts:43-46`). It is purely a client-side key-derivation choice;
+  the server is agnostic to key origin.
+- A production wallet path already exists: `/auth/identity/wallet` (SIWE) →
+  `/auth/login`; JWT subject is a `userId` UUID, claims carry `publicKey` and an
+  optional `scope[]` (a ready hook for capability scoping).
+- `POST /vault/init` accepts a **client-supplied** `ownerPublicKey` + `rootIpnsName`;
+  server stores encrypted blobs only; **no human gates** (no email verify, no MFA, no
+  device approval for new users — MFA only triggers for MFA-enabled users on new
+  devices, which an agent simply never enables).
+- An agent can today: SIWE-auth with its own wallet → JWT → `/vault/init` with its own
+  key → drive the full headless SDK (`CipherBoxClient` is key-injected).
+
+Net: the agent **brings its own wallet**; CipherBox builds **no** custody. Only minor
+conveniences are net-new (a combined SIWE→token endpoint; optional address-as-principal
+lookup). The data + auth plane is essentially ready.
+
+### 2. The revocable capability layer is vital and IN
+
+Today's sharing has a real gap, independent of agents:
+
+- Write-delegation hands over the **raw, un-rotatable Ed25519 IPNS signing key**;
+  deleting the `share_keys` row does **not** cryptographically revoke it (the holder
+  keeps publishing to IPNS; the TEE keeps republishing). 
+- Read revocation is **lazy** (`executeLazyRotation` only rotates on the sharer's next
+  write) and **folder-coarse** — no TTL, no per-file scope.
+
+For a "treat every agent call as hostile" threat model this is a security gap, not a
+UX nit. Build **eager + time-boxed + sub-folder/read-only-scoped + cryptographically
+revocable** capabilities. This is the deepest moat *and* a consumer-security
+improvement — it is **pullable forward** ahead of a full agent milestone. See
+`seeds/agent-capability-layer-revocable-grants.md`.
+
+### 3. x402 is a settlement rail, NOT the storage meter
+
+Two critiques survive independent of everything else:
+
+- **Cost-model mismatch:** storage cost is *standing* per-GB-month + the 6h TEE
+  republish on every folder. There is no request to attach a 402 to for idle data.
+  x402 can only meter discrete ops (upload/download/publish).
+- **Unit economics:** micro-amounts collapse against the ~$0.001 settlement floor +
+  $0.001/tx facilitator fee past 1k tx/mo; per-op on-chain settlement is unit-negative.
+
+So: keep per-GB-month accrual in CipherBox's own usage ledger (it already has quota +
+refcounted `pinned_cids`); use x402 as a **prepaid-credit top-up + `upto` egress
+adapter beside Stripe**, with lease/TTL pins so abandoned data auto-evicts. **MCP** is
+the durable distribution bet; **x402 traction is genuinely uncertain** — the research
+split (one lens: accelerating, 100M+ payments, Stripe Feb 2026, AP2 rail; another:
+contracting ~77–90% off the Nov 2025 peak). Decouple the strategy from x402's survival.
+See `seeds/cipherbox-mcp-server-and-wallet-native-tenancy.md`.
+
+### 4. Moat / first-customer is UNVALIDATED → milestone is validation-gated
+
+No identified agent customer yet, and the *payload* that makes ZK load-bearing is
+undecided (sensitive user PII under revocable grant = strongest moat; agent's own
+memory/RAG = weakest, ZK only nice-to-have; agent-to-agent confidential exchange =
+novel). Therefore: build the no-regret moves now, run a discovery track in parallel,
+and require a design-partner signal before the full pivot. See
+`.planning/research/questions.md`.
+
+## No-regret vs validation-gated
+
+**No-regret (build regardless):**
+
+- Eager/scoped/time-boxed/cryptographically-revocable capabilities (also fixes the
+  current consumer-sharing gap; pullable forward).
+- MCP server over the headless SDK + combined SIWE→token endpoint (cheap; enables
+  building a demo to put in front of design partners).
+- Usage ledger + pluggable settlement (Stripe needed for humans regardless; x402 an
+  optional adapter, never the meter).
+
+**Validation-gated (don't commit the full build until proven):**
+
+- Which payload/customer pulls; design-partner LOI; moat depth vs Storacha / Walrus /
+  Lighthouse; x402's real trajectory; EU-AI-Act timing (high-risk provisions ~Aug 2026).
+
+## Surviving risks (from the adversarial analysis)
+
+- **Falling between two stools** — abandoning consumers before agent revenue exists.
+  Mitigate: consumer app stays as the reference client; stage the messaging shift.
+- **Moat one feature deep** — ZK + delegation; funded incumbents (Mysten/Walrus,
+  Protocol-Labs/Lighthouse, Storacha) are one feature away. Lighthouse already shipped
+  an encrypted-storage MCP. Win on the *combination + the use case where ZK is
+  mandatory*, not the primitive.
+- **Timing** — likely 6–18 months early relative to durable "agent-pays-for-private-
+  file-access" demand.
+
+## Related
+
+- `seeds/agent-capability-layer-revocable-grants.md`
+- `seeds/cipherbox-mcp-server-and-wallet-native-tenancy.md`
+- `seeds/blind-share-social-graph.md` (capability/delegation graph — closely related)
+- `todos/pending/2026-02-22-crdt-ipns-inbox-sharing.md` (serverless share discovery)
+- `.planning/research/questions.md` (the validation gate)
+- `.planning/research/m4/` (the productivity-suite M4 this reframes)

--- a/.planning/research/questions.md
+++ b/.planning/research/questions.md
@@ -1,0 +1,41 @@
+# Research Questions
+
+Open questions captured for deeper investigation. Each should be resolved (with
+evidence) before the dependent decision is committed.
+
+## Agent-native milestone — validation gate (2026-06-22)
+
+Source: exploration session — see `notes/next-milestone-agent-native-zk-storage.md`.
+These gate committing the agent-native milestone to the ROADMAP. Build the no-regret
+moves first; require credible answers to these before the full pivot or the
+"stop competing with Drive" messaging.
+
+- [ ] **Payload / moat:** Which payload makes zero-knowledge *load-bearing* rather than
+  nice-to-have — sensitive user PII under a revocable grant (strongest), the agent's own
+  memory/RAG (weakest, commodity vs web3 storage), or agent-to-agent confidential
+  exchange (novel)? The payload decides the moat and the customer.
+- [ ] **First customer / design-partner LOI:** Is there an identifiable first paying
+  agent-consumer, and will they pay for ZK *specifically* (vs defaulting to
+  Storacha/Lighthouse/Walrus on cost + ecosystem)? Get one LOI before committing.
+- [ ] **Moat depth:** ZK + revocable delegation is ~one feature deep; funded incumbents
+  (Mysten/Walrus, Protocol-Labs/Lighthouse, Storacha) are one feature away, and
+  Lighthouse already shipped an encrypted-storage MCP. What is the durable, hard-to-copy
+  combination (e.g. ZK custody + capability scoping + one-click revoke + audit trail +
+  EU-AI-Act-shaped compliance, productized for a specific vertical)?
+- [ ] **x402 trajectory:** Is x402 adoption accelerating or deflating? Research split
+  this session (one source: 100M+ payments, Stripe Feb 2026, AP2 rail; another:
+  contracting ~77–90% off the Nov 2025 peak, ~0.0001% of stablecoin volume). Need a
+  90-day forward read on MCP-gated x402 *storage/data* demand specifically (not aggregate
+  volume) before betting any GTM on it.
+- [ ] **Regulatory timing:** Do EU AI Act high-risk provisions (~Aug 2026) and PII
+  liability actually convert "provably blind storage" into a *purchase requirement* on a
+  fundable timeline — or is that 6–18 months out?
+- [ ] **Custody / money-transmitter:** Does holding prepaid USDC balances trigger
+  money-transmitter / MSB / custody obligations in target jurisdictions? This gates the
+  prepaid-balance design (favor principal-funded session keys + auto-convert to fiat).
+- [ ] **Cryptographic write-revocation design:** Mediated server-side writes vs per-grant
+  rotatable IPNS subkeys — which fits the current IPNS-anchored share model without a
+  painful metadata migration? (Spike candidate — see
+  `seeds/agent-capability-layer-revocable-grants.md`.)
+- [ ] **Infra-as-product SLAs:** Can a small team underwrite B2B durability/uptime/egress
+  SLAs on IPFS/IPNS + TEE-republish, vs the current consumer-app posture?

--- a/.planning/seeds/agent-capability-layer-revocable-grants.md
+++ b/.planning/seeds/agent-capability-layer-revocable-grants.md
@@ -1,0 +1,53 @@
+---
+title: "Agent capability layer — eager, scoped, cryptographically-revocable grants"
+trigger_condition: "The next milestone (agent-native or otherwise) is scoped, OR the sharing/delegation subsystem is reworked, OR a hostile-agent / compliance threat model is taken on. Pullable FORWARD on its own as a consumer-sharing security fix."
+planted_date: 2026-06-22
+source: "Exploration session 2026-06-22 (see notes/next-milestone-agent-native-zk-storage.md); adversarial analysis of the agent-native repositioning."
+---
+
+## Idea
+
+Replace today's coarse, lazy, leak-prone delegation with **eager, scoped, time-boxed,
+cryptographically-revocable capabilities** — usable for agent↔human and agent↔agent
+access, and a security upgrade for existing consumer sharing.
+
+## Why (the current gap)
+
+- **Write-delegation leaks the raw key.** Granting write ECIES-wraps the folder's
+  **real, un-rotatable Ed25519 IPNS private key** to the recipient (`shared-write.ts`).
+  Deleting the `share_keys` row does **not** cryptographically revoke it: the holder
+  can keep signing IPNS records directly and the TEE keeps republishing them. The owner
+  cannot rotate the IPNS name without re-deriving the folder keypair and re-publishing
+  the parent.
+- **Read revocation is lazy + coarse.** `executeLazyRotation` only rotates on the
+  sharer's *next write* to the folder; there is no TTL/expiry and no scope finer than
+  the IPNS-folder boundary. A revoked party retains decryption until a future write.
+
+For "treat every agent call as hostile," this is a security gap, not a UX nit.
+
+## Shape of the work
+
+- **Eager rotation on revoke** — rotate the wrapped key immediately, not deferred to
+  the next write.
+- **Capability expiry / TTL** — time-boxed grants (TTL on the re-wrapped key / session
+  key); a possible hook is the existing JWT `scope[]` claim.
+- **Finer scope** — per-file and read-only grants, op-count caps; below folder level.
+- **Cryptographic write-revocation** — the core crypto fork: either
+  (a) **mediated writes** (recipient calls a CipherBox/MCP endpoint that performs the
+  IPNS publish server-side via the principal's TEE-republish path, gated by a revocable
+  session — recipient never holds the raw signing key), or
+  (b) **per-grant rotatable IPNS subkeys** (a delegated folder gets its own ephemeral
+  IPNS keypair the parent can swap on revoke, time-boxed via the TEE schedule).
+  Pick one; this is the single biggest design decision and is worth a spike.
+
+## Notes / dependencies
+
+- Likely touches `METADATA_EVOLUTION_PROTOCOL` (share-metadata schema) and the TEE
+  republish scheduling.
+- The ECIES re-wrap-for-a-recipient-pubkey primitive already exists and is the right
+  base — an agent wallet pubkey is just another recipient node in the share graph.
+- Closely related: `seeds/blind-share-social-graph.md` (capability-based shares keyed
+  by IPNS name + CRDT-over-IPNS recipient discovery) and
+  `todos/pending/2026-02-22-crdt-ipns-inbox-sharing.md`.
+- Independent value: this is a genuine improvement to v1.0 consumer sharing security —
+  it does **not** require the agent direction to be worth doing.

--- a/.planning/seeds/cipherbox-mcp-server-and-wallet-native-tenancy.md
+++ b/.planning/seeds/cipherbox-mcp-server-and-wallet-native-tenancy.md
@@ -32,7 +32,7 @@ builds no key custody.
 - **Two-plane identity** over one keypair: payment plane (x402/USDC) + identity plane
   (SIWE over the same address mints a session). The wallet address is an **access
   handle, never a decryption key** — content keys (AES/ECIES) stay separate. Frame it
-  "wallet IS the key," never "keyless."
+  "wallet IS the key to access," never "keyless."
 - **Usage ledger + pluggable settlement** — one internal ledger (extend the existing
   quota + refcounted `pinned_cids` accounting) with adapters: **Stripe for humans**,
   **x402 for agents**. x402 is a **prepaid-credit top-up + `upto` egress** rail, NOT

--- a/.planning/seeds/cipherbox-mcp-server-and-wallet-native-tenancy.md
+++ b/.planning/seeds/cipherbox-mcp-server-and-wallet-native-tenancy.md
@@ -1,0 +1,55 @@
+---
+title: "CipherBox as an MCP server + wallet-native first-class agent tenancy"
+trigger_condition: "The agent wedge is validated (a design partner / first paying agent-consumer identified), OR a cheap demo is needed to put in front of design partners. The MCP + auth-convenience parts are cheap enough to build as enablers ahead of full validation; the x402 settlement adapter waits on proven agent-payment demand."
+planted_date: 2026-06-22
+source: "Exploration session 2026-06-22 (see notes/next-milestone-agent-native-zk-storage.md)."
+---
+
+## Idea
+
+Expose the existing headless ZK substrate to AI agents through the channel agents
+actually consume — an **MCP server** — with a thin wallet-native auth convenience and
+an **optional** x402 settlement adapter. The agent brings its own wallet; CipherBox
+builds no key custody.
+
+## Why it's cheap (verified against apps/api)
+
+- The SDK (`CipherBoxClient`) is already **key-injected and headless** — same code path
+  the desktop FUSE crate and SDK E2E exercise. An agent holding 32 bytes of secp256k1
+  can drive the full vault today.
+- Auth already supports a production wallet path: `/auth/identity/wallet` (SIWE) →
+  `/auth/login`; the server is agnostic to key origin (Web3Auth is client-side only and
+  `Web3AuthVerifierService` is never called server-side).
+- `POST /vault/init` accepts a client-supplied `ownerPublicKey`; no human gates.
+
+## Shape of the work
+
+- **MCP server** over the headless SDK — expose vault read/write/list/share as MCP
+  tools; this is the distribution channel (and how Lighthouse validated "encrypted-
+  storage MCP"). Optionally list in the x402 "Bazaar" for agent discovery.
+- **Combined SIWE→token endpoint** (`/auth/login/wallet`) collapsing the current
+  two-step wallet→idToken→access-token flow into one call for agent onboarding.
+- **Two-plane identity** over one keypair: payment plane (x402/USDC) + identity plane
+  (SIWE over the same address mints a session). The wallet address is an **access
+  handle, never a decryption key** — content keys (AES/ECIES) stay separate. Frame it
+  "wallet IS the key," never "keyless."
+- **Usage ledger + pluggable settlement** — one internal ledger (extend the existing
+  quota + refcounted `pinned_cids` accounting) with adapters: **Stripe for humans**,
+  **x402 for agents**. x402 is a **prepaid-credit top-up + `upto` egress** rail, NOT
+  the storage meter (idle per-GB-month has no request to bill; micro-settlement is
+  unit-negative below the ~$0.001 floor). Lease/TTL pins so abandoned data auto-evicts.
+
+## Cautions
+
+- **Depends on the capability layer** (`seeds/agent-capability-layer-revocable-grants.md`)
+  for any sharing/delegation between agents and principals — don't ship agent write
+  access without cryptographic revocation.
+- **x402 traction is uncertain** (research split: accelerating vs ~80% off peak) — keep
+  it a swappable adapter, gate it on proven agent-payment demand; MCP is the durable
+  bet.
+- **Money-transmitter / custody** exposure if CipherBox holds prepaid USDC balances —
+  prefer principal-funded session keys (CDP / ERC-4337 spend caps) and auto-convert to
+  fiat; get a regulatory read before holding float.
+- Per-task **ephemeral vaults** need an ownership-transfer (re-bind encrypted root to a
+  new principal address without re-encryption) + teardown (unpin + republish-schedule
+  cleanup) flow that does not exist today.


### PR DESCRIPTION
## Summary

Planning-only artifacts from an exploration session on the **next milestone scope** — reframing away from the proposed productivity-suite M4 toward agent-native ZK storage. No code changes; everything is under `.planning/`.

Four artifacts:

- **`notes/next-milestone-agent-native-zk-storage.md`** — the decision record. The reframe is **validation-gated**: build the no-regret core (revocable capabilities, MCP surface) and validate the agent wedge before any full pivot. Captures the key findings: agents-as-first-class-tenants is cheap on the existing substrate (Web3Auth is client-side only; `/auth/identity/wallet` SIWE path + client-supplied `vault/init` key + no human gates); x402 is a **settlement/credit rail, not the storage meter** (idle per-GB-month has no request to bill; micro-settlement is unit-negative); MCP is the durable distribution bet. Supersedes the productivity-suite M4 proposal; billing is the shared dependency.
- **`seeds/agent-capability-layer-revocable-grants.md`** — eager / scoped / time-boxed / cryptographically-revocable grants. Also a **consumer-sharing security fix** (today: write-delegation leaks the raw un-rotatable IPNS key; read-revocation is lazy + folder-coarse) — pullable forward independent of the agent direction.
- **`seeds/cipherbox-mcp-server-and-wallet-native-tenancy.md`** — MCP server over the headless SDK + combined SIWE→token endpoint + x402-as-optional-adapter.
- **`research/questions.md`** — the validation gate (payload/customer, moat depth vs Storacha/Walrus/Lighthouse, x402 trajectory, EU-AI-Act timing, custody/money-transmitter, write-revocation design).

## Scope

- Docs/planning only — nothing committed to the ROADMAP; this is the input to a future `/gsd:new-milestone` decision.
- No code, no `pnpm api:generate` impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added internal planning and research documentation for upcoming milestone phases, including decision records, validation gates, and architectural exploration notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->