### PR TITLE
feat(api): API CID and provider hardening with unpin module dedup

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1005,8 +1005,8 @@ Scope (captured todos):
 Plans:
 **Wave 1** *(parallel-safe — DTO/provider vs module graph)*
 
-- [ ] 57-01-PLAN.md — Data-integrity (coupled WR-02→WR-05): shared `CID_REGEX` + `@MaxLength(255)` on `RegisterCidDto`; `encodeURIComponent`/`URLSearchParams` in `LocalProvider` pin/rm + cat URLs (TDD). Run `pnpm api:generate` if the DTO change alters the OpenAPI spec.
-- [ ] 57-02-PLAN.md — apps/api module dedup: leaf `IpfsProviderModule` (imports ConfigModule, exports `IPFS_PROVIDER`) imported by Ipfs/Vault/PendingUnpin with IN-04 comments corrected; `withCidLock` + `refcountAndMaybeUnpin` helpers routing guardedUnpin (txn + post-commit) and drainRow
+- [x] 57-01-PLAN.md — Data-integrity (coupled WR-02→WR-05): shared `CID_REGEX` + `@MaxLength(255)` on `RegisterCidDto`; `encodeURIComponent`/`URLSearchParams` in `LocalProvider` pin/rm + cat URLs (TDD). Run `pnpm api:generate` if the DTO change alters the OpenAPI spec.
+- [x] 57-02-PLAN.md — apps/api module dedup: leaf `IpfsProviderModule` (imports ConfigModule, exports `IPFS_PROVIDER`) imported by Ipfs/Vault/PendingUnpin with IN-04 comments corrected; `withCidLock` + `refcountAndMaybeUnpin` helpers routing guardedUnpin (txn + post-commit) and drainRow
 
 Verification gate: apps/api jest specs; `pnpm api:generate` + commit regenerated client iff the `RegisterCidDto` change alters the OpenAPI spec.
 
@@ -1085,7 +1085,7 @@ Phases execute in numeric order: 18 -> 19 -> 19.1 -> 19.2 -> 20 -> 21 -> 22 -> 2
 | 54. E2E Test-Infra Typing                 | v1.1-hardening | -         | Planned  | -          |
 | 55. Large Source-File Refactor            | v1.1-hardening | 4/4 | Complete    | 2026-06-21 |
 | 56. FUSE & IPNS Durability Hardening       | v1.1-hardening | -   | Planned     | -          |
-| 57. API CID/Provider Hardening & Dedup     | v1.1-hardening | -   | Planned     | -          |
+| 57. API CID/Provider Hardening & Dedup     | v1.1-hardening | 2/2 | Complete    | 2026-06-22 |
 | 58. IPNS Signature-Verify Coverage         | v1.1-hardening | -   | Planned     | -          |
 
 _Roadmap created: 2026-03-07_

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v1.1
 milestone_name: milestone
-status: Milestone complete
-last_updated: "2026-06-21T23:02:30.009Z"
-last_activity: 2026-06-21
+status: Phase 57 complete
+last_updated: "2026-06-22T00:02:44.029Z"
+last_activity: 2026-06-22
 progress:
   total_phases: 43
-  completed_phases: 40
-  total_plans: 177
-  completed_plans: 177
-  percent: 93
+  completed_phases: 41
+  total_plans: 179
+  completed_plans: 179
+  percent: 95
 ---
 
 # Project State
@@ -20,12 +20,12 @@ progress:
 See: .planning/PROJECT.md (updated 2026-03-07)
 
 **Core value:** Zero-knowledge privacy -- files encrypted client-side, server never sees plaintext
-**Current focus:** Phases 56–58 — deferred-findings hardening (FUSE/IPNS durability, API CID/provider hardening, IPNS signature-verify coverage)
+**Current focus:** Phase 57 — api-cid-and-provider-hardening-and-module-dedup
 
 ## Current Position
 
-Phase: 56
-Plan: Not started
+Phase: 57 — COMPLETE
+Plan: 2 of 2
 Milestone v1.1 hardening block extended 2026-06-21 with deferred-findings Phases 56–58 (HARD-07..09), sourced from the Phase 50–55 / PR #529 + #538 review backlog. Next: run /gsd:plan-phase 56 (recommended order: 56 FUSE/IPNS durability → 57 API CID/provider hardening → 58 IPNS signature-verify coverage; 58 last as it is the most regression-prone and full-SDK-E2E-gated). Note: STATE frontmatter progress counts predate this and were left unreconciled (see todo `2026-06-18-gsd-phase-complete-regresses-state-final-phase.md`).
 
 ## Performance Metrics
@@ -292,7 +292,7 @@ All M2 blockers resolved. See `.planning/milestones/m2/m2-v1.0-production-MILEST
 
 ---
 
-Last activity: 2026-06-21
+Last activity: 2026-06-22
 
 Last session: 2026-06-21T22:27:44.290Z
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,7 +3,7 @@ gsd_state_version: 1.0
 milestone: v1.1
 milestone_name: milestone
 status: Milestone complete
-last_updated: "2026-06-21T22:27:44.298Z"
+last_updated: "2026-06-21T23:02:30.009Z"
 last_activity: 2026-06-21
 progress:
   total_phases: 43

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,7 +3,7 @@ gsd_state_version: 1.0
 milestone: v1.1
 milestone_name: milestone
 status: Milestone complete
-last_updated: "2026-06-21T22:07:32.559Z"
+last_updated: "2026-06-21T22:27:44.298Z"
 last_activity: 2026-06-21
 progress:
   total_phases: 43
@@ -294,7 +294,7 @@ All M2 blockers resolved. See `.planning/milestones/m2/m2-v1.0-production-MILEST
 
 Last activity: 2026-06-21
 
-Last session: 2026-06-21T22:07:32.549Z
+Last session: 2026-06-21T22:27:44.290Z
 
 ## Decisions
 

--- a/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-01-PLAN.md
+++ b/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-01-PLAN.md
@@ -1,0 +1,241 @@
+---
+phase: 57-api-cid-and-provider-hardening-and-module-dedup
+plan: 01
+type: tdd
+wave: 1
+depends_on: []
+files_modified:
+  - apps/api/src/ipfs/dto/cid.constants.ts
+  - apps/api/src/ipfs/dto/unpin.dto.ts
+  - apps/api/src/ipfs/dto/register-cid.dto.ts
+  - apps/api/src/ipfs/dto/register-cid.dto.spec.ts
+  - apps/api/src/ipfs/providers/local.provider.ts
+  - apps/api/src/ipfs/providers/local.provider.spec.ts
+  - packages/api-client/openapi.json
+  - packages/api-client/src/generated
+  - packages/api-client/src/models
+autonomous: true
+requirements: [HARD-08]
+
+must_haves:
+  truths:
+    - "RegisterCidDto rejects a CIDv0 Qm... string longer than 46 chars (the {44,} overflow)"
+    - "RegisterCidDto rejects any cid longer than 255 chars"
+    - "RegisterCidDto accepts a valid CIDv1 bafk... string"
+    - "RegisterCidDto and UnpinDto validate CID via the single shared CID_REGEX constant (one source of truth)"
+    - "LocalProvider URL-encodes the CID in the pin/rm and cat Kubo query strings"
+    - "openapi.json carries maxLength 255 on RegisterCidDto.cid and the regenerated api-client is staged"
+  artifacts:
+    - path: "apps/api/src/ipfs/dto/cid.constants.ts"
+      provides: "Shared CID_REGEX constant (single source of truth for v0+v1 CID validation)"
+      contains: "export const CID_REGEX"
+    - path: "apps/api/src/ipfs/dto/register-cid.dto.spec.ts"
+      provides: "TDD validation suite for RegisterCidDto (D-01/D-02/D-03)"
+      contains: "RegisterCidDto"
+    - path: "apps/api/src/ipfs/dto/register-cid.dto.ts"
+      provides: "Tightened RegisterCidDto cid validation (shared regex + @MaxLength(255))"
+      contains: "@MaxLength(255)"
+    - path: "apps/api/src/ipfs/providers/local.provider.ts"
+      provides: "URL-encoded CID interpolation in pin/rm + cat"
+      contains: "URLSearchParams"
+  key_links:
+    - from: "apps/api/src/ipfs/dto/register-cid.dto.ts"
+      to: "apps/api/src/ipfs/dto/cid.constants.ts"
+      via: "import { CID_REGEX }"
+      pattern: "import.*CID_REGEX.*cid.constants"
+    - from: "apps/api/src/ipfs/dto/unpin.dto.ts"
+      to: "apps/api/src/ipfs/dto/cid.constants.ts"
+      via: "import { CID_REGEX }"
+      pattern: "import.*CID_REGEX.*cid.constants"
+---
+
+<objective>
+Make `apps/api` CID input validation defense-in-depth consistent and encode every CID interpolated into a Kubo query string.
+
+Three coupled changes, all data-integrity (WR-02 → WR-05):
+1. (D-01/D-02/D-03) Extract the existing `UnpinDto.CID_REGEX` into a shared `cid.constants.ts`, import it from BOTH `unpin.dto.ts` and `register-cid.dto.ts`. Tighten the looser `RegisterCidDto` regex (CIDv0 branch `{44,}` → `{44}`) and add `@MaxLength(255)` — bringing it into exact alignment with `UnpinDto`. KEEP the CIDv1 `b[a-z2-7]{58,}` branch (the system uploads CIDv1 via `?cid-version=1`). Stay on the regex approach — do NOT add a `multiformats`-based `@IsCid()` validator.
+2. (D-04) URL-encode the CID in `LocalProvider` pin/rm (`local.provider.ts:87`) and cat (`local.provider.ts:127`) URLs. The pin/add path does NOT interpolate the CID into the URL (CID comes from the Kubo response body) — no change there.
+3. (D-08) Run `pnpm api:generate` and stage the regenerated `@cipherbox/api-client` — the `@MaxLength(255)` addition WILL add `"maxLength": 255` to `RegisterCidDto.cid` in `openapi.json` (confirmed by the existing UnpinDto pattern).
+
+Purpose: Close the CID-validation divergence (latent injection / oversized-string DoS surface) and ensure the unpin path does not trust every upstream writer.
+Output: Shared `CID_REGEX` constant, aligned `RegisterCidDto`, encoded LocalProvider URLs, regenerated api-client.
+</objective>
+
+<execution_context>
+@.claude/gsd-core/workflows/execute-plan.md
+@.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-CONTEXT.md
+@.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-RESEARCH.md
+@.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-PATTERNS.md
+@.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-VALIDATION.md
+@apps/api/src/ipfs/dto/unpin.dto.ts
+@apps/api/src/ipfs/dto/register-cid.dto.ts
+@apps/api/src/ipfs/providers/local.provider.ts
+
+# Project workflow: api:generate discipline + commit regenerated client
+@CLAUDE.md
+</context>
+
+<artifacts_produced>
+New symbols this plan introduces (none exist on the API surface yet — treat absence there as UNKNOWN, not nonexistent):
+
+- `CID_REGEX` — exported regex constant, NEW file `apps/api/src/ipfs/dto/cid.constants.ts`. Value (verbatim from the existing `unpin.dto.ts:7`): `/^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$/`. Imported by `unpin.dto.ts` and `register-cid.dto.ts`.
+- `apps/api/src/ipfs/dto/register-cid.dto.spec.ts` — NEW Jest spec validating `RegisterCidDto` (Wave-0 scaffold, then RED tests).
+- Extended assertions in `apps/api/src/ipfs/providers/local.provider.spec.ts` — encoding behavior for pin/rm + cat.
+- `openapi.json` gains `"maxLength": 255` under `RegisterCidDto.cid`; regenerated `@cipherbox/api-client` files.
+</artifacts_produced>
+
+<tasks>
+
+<task type="tdd" tdd="true">
+  <name>Task 1: RED — RegisterCidDto validation spec + shared CID_REGEX scaffold</name>
+  <read_first>
+    - apps/api/src/ipfs/dto/unpin.dto.ts (the reference DTO — copy its decorator stack and the CID_REGEX value verbatim)
+    - apps/api/src/ipfs/dto/register-cid.dto.ts (the DTO to bring into line)
+    - .planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-PATTERNS.md (sections: cid.constants.ts, register-cid.dto.ts, register-cid.dto.spec.ts — analog local.provider.spec.ts uses plain validate() + plainToInstance, no NestJS TestingModule)
+  </read_first>
+  <files>apps/api/src/ipfs/dto/cid.constants.ts, apps/api/src/ipfs/dto/register-cid.dto.spec.ts</files>
+  <behavior>
+    Wave-0 scaffold + RED tests for D-01/D-02/D-03. Create cid.constants.ts first exporting CID_REGEX (so the spec compiles), then author the failing spec against the CURRENT (loose) RegisterCidDto:
+    - Test 1 (D-02 — must already pass, locks the keep-CIDv1 invariant): accepts a valid CIDv1 bafkreigaknpexyvxt76zgkitavbwx6ejgfheup5oybpm77f3pxzrvwpfdi -> validate() returns 0 errors.
+    - Test 2 (D-01 — RED): rejects a CIDv0 with 47 base58 chars after Qm (the {44,} overflow the current loose regex wrongly accepts) -> validate() returns >=1 error on cid.
+    - Test 3 (D-01 @MaxLength — RED): rejects a cid string longer than 255 chars (e.g. 'b' + 'a'.repeat(300)) -> validate() returns >=1 error on cid.
+    - Test 4 (D-01 — sanity, should pass before and after): a canonical 46-char CIDv0 Qm fixture stays valid -> 0 errors.
+  </behavior>
+  <action>
+    Create apps/api/src/ipfs/dto/cid.constants.ts exporting CID_REGEX with the value copied verbatim from unpin.dto.ts:7 — the v0+v1 regex matching Qm + exactly 44 base58 chars OR b + 58-or-more base32 chars; carry forward the IN-02 explanatory comment (CIDv0 = Qm + 44 base58 = 46 chars fixed; CIDv1 = b + 58+ base32 open, capped by @MaxLength(255); T-50-12). Create apps/api/src/ipfs/dto/register-cid.dto.spec.ts following the local.provider.spec.ts plain-class style: import validate from class-validator, plainToInstance from class-transformer, and RegisterCidDto; a validateDto(plain) helper builds the instance via plainToInstance and returns validate(dto). Write the four behavior tests; each pairs a cid fixture with a sizeBytes (e.g. 100) so only the cid constraint drives the assertion. Tests 2 and 3 MUST FAIL against the current loose, no-MaxLength DTO (that is the RED proof). Do NOT modify register-cid.dto.ts in this task.
+  </action>
+  <verify>
+    <automated>cd apps/api; npx jest --testPathPattern=register-cid 2>&amp;1 | grep -E "fail|✕|Tests:" | head</automated>
+  </verify>
+  <acceptance_criteria>
+    - apps/api/src/ipfs/dto/cid.constants.ts exists and exports CID_REGEX (grep `export const CID_REGEX`).
+    - apps/api/src/ipfs/dto/register-cid.dto.spec.ts exists with 4 tests.
+    - Jest run shows Tests 2 and 3 FAILING (RED); Tests 1 and 4 passing.
+    - Commit: `test(57-01): add failing RegisterCidDto validation spec + shared CID_REGEX`.
+  </acceptance_criteria>
+  <done>cid.constants.ts exports CID_REGEX; register-cid.dto.spec.ts has 4 tests; Tests 2 + 3 FAIL (RED), Tests 1 + 4 pass.</done>
+</task>
+
+<task type="tdd" tdd="true">
+  <name>Task 2: GREEN — align RegisterCidDto + share CID_REGEX across both DTOs</name>
+  <read_first>
+    - apps/api/src/ipfs/dto/register-cid.dto.ts (file under edit)
+    - apps/api/src/ipfs/dto/unpin.dto.ts (file under edit — swap inline regex for the shared import)
+    - apps/api/src/ipfs/dto/cid.constants.ts (created in Task 1)
+    - .planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-PATTERNS.md (section: register-cid.dto.ts target decorator stack + @ApiProperty maxLength metadata; section: unpin.dto.ts before/after import swap)
+  </read_first>
+  <files>apps/api/src/ipfs/dto/register-cid.dto.ts, apps/api/src/ipfs/dto/unpin.dto.ts</files>
+  <action>
+    In register-cid.dto.ts: add MaxLength to the class-validator import; add `import { CID_REGEX } from './cid.constants';`; on the cid field replace the inline @Matches(/^(Qm...{44,}|b...{58,})$/, ...) with @Matches(CID_REGEX, { message: 'cid must be a valid CIDv0 (Qm...) or CIDv1 (b...) string' }); add @MaxLength(255) above @Matches; update @ApiProperty to include the pattern string ^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$ and maxLength: 255 so the OpenAPI spec reflects the constraint (required for D-08 / Task 4). Leave the sizeBytes field and RegisterCidResponseDto untouched. In unpin.dto.ts: remove the local `const CID_REGEX = ...` declaration (and its preceding IN-02 comment now living in cid.constants.ts) and add `import { CID_REGEX } from './cid.constants';` at the top — the UnpinDto class body is otherwise unchanged (it already uses @MaxLength(255) + @Matches(CID_REGEX,...)). Result: ONE regex definition, two importers. Per D-03 do NOT introduce multiformats/@IsCid.
+  </action>
+  <verify>
+    <automated>cd apps/api; npx jest --testPathPattern=register-cid 2>&amp;1 | grep -E "Tests:|✓|✕" | head</automated>
+  </verify>
+  <acceptance_criteria>
+    - All 4 register-cid.dto.spec.ts tests PASS (GREEN).
+    - `grep -l "import { CID_REGEX } from './cid.constants'" apps/api/src/ipfs/dto/unpin.dto.ts apps/api/src/ipfs/dto/register-cid.dto.ts` lists BOTH files.
+    - register-cid.dto.ts contains `@MaxLength(255)` and no longer contains an inline `{44,}` regex literal (`grep -F '{44,}' apps/api/src/ipfs/dto/register-cid.dto.ts` returns nothing).
+    - unpin.dto.ts no longer declares `const CID_REGEX` (`grep -E 'const CID_REGEX' apps/api/src/ipfs/dto/unpin.dto.ts` returns nothing).
+    - `cd apps/api && npx tsc --noEmit` passes (no broken imports).
+    - Commit: `feat(57-01): share CID_REGEX and tighten RegisterCidDto validation`.
+  </acceptance_criteria>
+  <done>All 4 RegisterCidDto tests GREEN; both DTOs import CID_REGEX from cid.constants; no inline regex remains; tsc --noEmit passes.</done>
+</task>
+
+<task type="tdd" tdd="true">
+  <name>Task 3: URL-encode CID in LocalProvider pin/rm + cat (RED→GREEN)</name>
+  <read_first>
+    - apps/api/src/ipfs/providers/local.provider.ts (edit sites: unpinFile line 87 pin/rm, getFile line 127 cat; pin/add at line 49 needs NO change — CID is not in the URL)
+    - apps/api/src/ipfs/providers/local.provider.spec.ts (existing suite — mocks global.fetch; assertions ~line 158 pin/rm URL, ~line 222 cat URL)
+    - .planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-PATTERNS.md (section: local.provider.ts target URLSearchParams form; Pitfall 1 on spec assertions)
+  </read_first>
+  <files>apps/api/src/ipfs/providers/local.provider.spec.ts, apps/api/src/ipfs/providers/local.provider.ts</files>
+  <behavior>
+    - Encoding test (RED then GREEN): with a CID fixture containing a query-significant char (e.g. `bafk&evil=1` or a `%`), unpinFile and getFile build a Kubo URL where the CID is percent-encoded (the captured fetch URL contains `arg=bafk%26evil` style encoding, NOT a raw `&`). This FAILS against the current raw-interpolation code (RED).
+    - Regression test (stays GREEN): for a normal valid CIDv1 fixture (no reserved chars), the captured URLs remain `.../api/v0/pin/rm?arg=<cid>` and `.../api/v0/cat?arg=<cid>` — URLSearchParams produces an identical string, so the existing toBe assertions still pass.
+  </behavior>
+  <action>
+    First (RED): in local.provider.spec.ts add two tests (one for unpinFile/pin-rm, one for getFile/cat) that mock global.fetch, call the method with a CID containing a reserved char, capture the first fetch arg (the URL), and assert the reserved char appears percent-encoded — i.e. the raw reserved char does NOT appear verbatim in the query string. Run to confirm RED. Then (GREEN): in local.provider.ts unpinFile (line ~87) replace the template `${this.apiUrl}/api/v0/pin/rm?arg=${cid}` with a URLSearchParams build — construct `new URLSearchParams({ arg: cid })` and fetch `${this.apiUrl}/api/v0/pin/rm?${params}`; in getFile (line ~127) do the same for `${this.apiUrl}/api/v0/cat?${params}`. Do NOT touch the pin/add path at line 49 (no CID in URL). Keep the POST method and the existing error/not-pinned/not-found handling unchanged. If the pre-existing exact-string toBe assertions at ~158/~222 break for the normal-CID case, prefer leaving them (URLSearchParams output is byte-identical for reserved-char-free CIDs); only relax to toContain if a genuine mismatch surfaces.
+  </action>
+  <verify>
+    <automated>cd apps/api; npx jest --testPathPattern=local.provider 2>&amp;1 | grep -E "Tests:|✓|✕" | head</automated>
+  </verify>
+  <acceptance_criteria>
+    - The two new encoding tests PASS (GREEN) and the full local.provider suite is green (existing pin/rm + cat URL assertions still pass for normal CIDs).
+    - `grep -c "URLSearchParams" apps/api/src/ipfs/providers/local.provider.ts` is >= 2 (pin/rm + cat).
+    - `grep -E 'pin/rm\?arg=\$\{cid\}|cat\?arg=\$\{cid\}' apps/api/src/ipfs/providers/local.provider.ts` returns nothing (raw interpolation removed).
+    - The pin/add line at ~49 is unchanged (still `add?pin=true&cid-version=1`).
+    - Commits: `test(57-01): add failing LocalProvider CID URL-encoding tests` then `feat(57-01): URL-encode CID in LocalProvider pin/rm and cat`.
+  </acceptance_criteria>
+  <done>pin/rm + cat URLs use URLSearchParams; encoding tests + full local.provider suite green; pin/add unchanged.</done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Regenerate + stage @cipherbox/api-client for the RegisterCidDto maxLength (D-08)</name>
+  <read_first>
+    - CLAUDE.md (API Development Workflow section — `pnpm api:generate` regenerates the typed client; pre-commit `scripts/check-api-client.sh` enforces staging the regenerated client alongside DTO/controller changes)
+    - .planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-RESEARCH.md (OpenAPI Impact Analysis — RegisterCidDto.cid currently has NO maxLength; UnpinDto already emits "maxLength": 255 at the analog site, so api:generate WILL add it)
+  </read_first>
+  <files>packages/api-client/openapi.json, packages/api-client/src/generated, packages/api-client/src/models</files>
+  <action>
+    From the repo root run `pnpm api:generate` (generates the OpenAPI spec from the API, regenerates the typed client, builds @cipherbox/api-client, runs lint fixes). This is REQUIRED, not conditional: the @MaxLength(255) + @ApiProperty maxLength metadata added in Task 2 alters RegisterCidDto in openapi.json. After it completes, stage the regenerated files: packages/api-client/openapi.json, packages/api-client/src/generated/, and packages/api-client/src/models/. Confirm the spec diff added maxLength:255 to the RegisterCidDto cid property (see verify). Do NOT hand-edit generated files. If api:generate fails because it needs the API to boot (DB/redis), surface the failure — do not skip the regeneration (the pre-commit check-api-client.sh hook will otherwise block the commit). Commit the DTO change + regenerated client together (or stage both before the final phase commit) so check-api-client.sh passes.
+  </action>
+  <verify>
+    <automated>cd /Users/myankelev/Code/random/cipher-box-wt-phase57; node -e "const s=require('./packages/api-client/openapi.json');const c=s.components.schemas.RegisterCidDto.properties.cid;process.exit(c &amp;&amp; c.maxLength===255?0:1)" &amp;&amp; echo "maxLength:255 present on RegisterCidDto.cid"</automated>
+  </verify>
+  <acceptance_criteria>
+    - openapi.json RegisterCidDto.cid has `"maxLength": 255` (verify command exits 0).
+    - The regenerated packages/api-client/src/generated and src/models reflect the new constraint and are staged.
+    - `pnpm --filter @cipherbox/api-client build` succeeds (no codegen drift).
+    - `git status --porcelain packages/api-client` shows the regenerated files staged (so check-api-client.sh passes).
+    - Commit: `chore(57-01): regenerate api-client for RegisterCidDto maxLength`.
+  </acceptance_criteria>
+  <done>openapi.json RegisterCidDto.cid has maxLength 255; regenerated api-client built + staged; check-api-client.sh passes.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+
+## Trust Boundaries
+
+| Boundary | Description |
+| -------- | ----------- |
+| HTTP client → RegisterCid/Unpin routes | Untrusted user-supplied `cid` string crosses into the NestJS DTO layer |
+| API → Kubo HTTP API | DB-sourced CID interpolated into a Kubo query string (pin/rm, cat); the unpin path must not trust upstream writers |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+| --------- | -------- | --------- | ----------- | --------------- |
+| T-57-01 | Tampering | `RegisterCidDto.cid` (loose `{44,}` regex, no MaxLength) | mitigate | Shared `CID_REGEX` (`{44}` exact CIDv0 branch) + `@MaxLength(255)` at the route boundary (D-01); validated by register-cid.dto.spec Tests 2 + 3 |
+| T-57-02 | Denial of Service | `RegisterCidDto.cid` oversized string | mitigate | `@MaxLength(255)` bounds the input before any processing (D-01, V5 Input Validation); validated by register-cid.dto.spec Test 3 |
+| T-57-03 | Tampering | `LocalProvider` pin/rm + cat URLs (DB-sourced CID interpolated unencoded) | mitigate | `URLSearchParams` percent-encodes the CID at the provider boundary (D-04) — defense-in-depth so the unpin path does not depend on every upstream writer being airtight; validated by local.provider encoding tests. Note: current regexes happen to exclude query-significant chars, so this is latent, not yet exploitable |
+| T-57-SC | Tampering | npm/pip/cargo installs | accept | No new packages installed this phase (RESEARCH Package Legitimacy Audit: N/A); uses existing class-validator / @nestjs deps only |
+
+Block-on-high check: no HIGH-severity threat is left unmitigated. T-57-01/02/03 are defense-in-depth (latent), all mitigated within this plan.
+</threat_model>
+
+<verification>
+- `cd apps/api && npx jest --testPathPattern=register-cid` — all RegisterCidDto validation tests green.
+- `cd apps/api && npx jest --testPathPattern=local.provider` — encoding tests + full local.provider suite green.
+- `cd apps/api && npx tsc --noEmit` — no broken imports from the cid.constants extraction.
+- `node -e` openapi.json assertion (Task 4 verify) — `maxLength: 255` present on RegisterCidDto.cid.
+- Per VALIDATION.md sampling: after the plan wave, `pnpm --filter @cipherbox/api test` (full api suite) must be green before `/gsd-verify-work`.
+</verification>
+
+<success_criteria>
+- ONE shared `CID_REGEX` constant in `cid.constants.ts`, imported by both `unpin.dto.ts` and `register-cid.dto.ts` (no inline regex remains in either DTO).
+- `RegisterCidDto` rejects CIDv0 `{44,}` overflow strings, rejects > 255-char strings, and accepts valid CIDv1 — matching `UnpinDto` exactly.
+- `LocalProvider` pin/rm and cat URLs URL-encode the CID; pin/add unchanged.
+- `openapi.json` carries `maxLength: 255` on `RegisterCidDto.cid` and the regenerated `@cipherbox/api-client` is built + staged (check-api-client.sh passes).
+- Full `apps/api` jest suite green.
+</success_criteria>
+
+<output>
+Create `.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-01-SUMMARY.md
+++ b/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-01-SUMMARY.md
@@ -1,0 +1,149 @@
+---
+phase: 57-api-cid-and-provider-hardening-and-module-dedup
+plan: 01
+subsystem: api
+tags: [cid-validation, ipfs, class-validator, nestjs, url-encoding, openapi]
+
+requires:
+  - phase: 50-api-hardening
+    provides: UnpinDto with CID_REGEX and MaxLength(255) as the reference pattern
+provides:
+  - Shared CID_REGEX constant in cid.constants.ts (single source of truth for CIDv0+CIDv1 regex)
+  - RegisterCidDto aligned with UnpinDto (exact CIDv0 branch, MaxLength 255)
+  - LocalProvider pin/rm and cat URLs percent-encode the CID via URLSearchParams
+  - openapi.json RegisterCidDto.cid carries maxLength:255; regenerated api-client built and staged
+affects:
+  - 57-02 (module-dedup tasks that touch ipfs.module / vault.module / pending-unpin.module)
+
+tech-stack:
+  added: []
+  patterns:
+    - Extract shared regex constants to a dedicated constants file imported by multiple DTOs
+    - URLSearchParams for constructing Kubo query strings (percent-encoding defense-in-depth)
+
+key-files:
+  created:
+    - apps/api/src/ipfs/dto/cid.constants.ts
+    - apps/api/src/ipfs/dto/register-cid.dto.spec.ts
+  modified:
+    - apps/api/src/ipfs/dto/register-cid.dto.ts
+    - apps/api/src/ipfs/dto/unpin.dto.ts
+    - apps/api/src/ipfs/providers/local.provider.ts
+    - apps/api/src/ipfs/providers/local.provider.spec.ts
+    - packages/api-client/openapi.json
+    - packages/api-client/src/generated/ (all files)
+    - packages/api-client/src/models/ (all files)
+
+key-decisions:
+  - 'Keep regex approach (not multiformats/@IsCid) per D-03 — avoids a new runtime dependency'
+  - 'CIDv0 branch tightened to exact {44} chars; CIDv1 b[a-z2-7]{58,} branch kept open-ended (capped by @MaxLength)'
+  - 'URLSearchParams chosen over manual encodeURIComponent for Kubo query strings — idiomatic and covers all reserved chars'
+  - 'api:generate required building @cipherbox/crypto first (dist was missing in worktree); deviation documented'
+
+patterns-established:
+  - 'CID regex lives in cid.constants.ts; DTOs import it — never declare inline'
+  - 'Kubo URL query strings always use URLSearchParams; never raw template interpolation'
+
+requirements-completed: [HARD-08]
+
+duration: 35min
+completed: 2026-06-22
+---
+
+# Phase 57 Plan 01: API CID and Provider Hardening Summary
+
+**Shared CID_REGEX constant extracted to cid.constants.ts; RegisterCidDto tightened to reject CIDv0 overflow and oversized strings; LocalProvider Kubo URLs percent-encode CID via URLSearchParams; openapi.json gains maxLength:255 and regenerated api-client is committed.**
+
+## Performance
+
+- **Duration:** 35 min
+- **Started:** 2026-06-22T00:00:00Z
+- **Completed:** 2026-06-22T00:35:00Z
+- **Tasks:** 4 (with TDD RED+GREEN commits for tasks 1-3)
+- **Files modified:** 9 source files + 131 regenerated api-client files
+
+## Accomplishments
+
+- Single shared `CID_REGEX` in `cid.constants.ts` — both `unpin.dto.ts` and `register-cid.dto.ts` import it; no inline regex remains in either DTO
+- `RegisterCidDto.cid` now rejects CIDv0 strings with extra chars (the `{44,}` overflow) and any string over 255 chars — matching `UnpinDto` exactly
+- `LocalProvider.unpinFile` and `getFile` build Kubo query strings via `URLSearchParams` — percent-encoding is now guaranteed regardless of what upstream writers stored in the DB
+- `openapi.json` carries `"maxLength": 255` on `RegisterCidDto.cid`; regenerated `@cipherbox/api-client` is built and committed; `check-api-client.sh` passes
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1 RED: shared CID_REGEX scaffold + failing spec** - `cb9b8a30a` (test)
+2. **Task 2 GREEN: align RegisterCidDto + share CID_REGEX** - `509c80172` (feat)
+3. **Task 3 RED: failing LocalProvider encoding tests** - `7bf20cc06` (test)
+4. **Task 3 GREEN: URLSearchParams in pin/rm + cat** - `3aace0e9a` (feat)
+5. **Task 4: regenerate api-client** - `88e35a62e` (chore)
+
+## Files Created/Modified
+
+- `apps/api/src/ipfs/dto/cid.constants.ts` - New file; exports `CID_REGEX` (verbatim from unpin.dto.ts) with IN-02 comment
+- `apps/api/src/ipfs/dto/register-cid.dto.spec.ts` - New Jest spec; 4 tests covering CIDv1 accept, CIDv0 overflow reject, 255+ char reject, canonical CIDv0 accept
+- `apps/api/src/ipfs/dto/register-cid.dto.ts` - Added `MaxLength` import, `CID_REGEX` import from cid.constants, `@MaxLength(255)`, fixed `{44,}` to `{44}`, updated `@ApiProperty` with pattern + maxLength
+- `apps/api/src/ipfs/dto/unpin.dto.ts` - Removed inline `const CID_REGEX` declaration; added `import { CID_REGEX } from './cid.constants'`
+- `apps/api/src/ipfs/providers/local.provider.ts` - `unpinFile` and `getFile` now use `new URLSearchParams({ arg: cid })` for Kubo query strings; pin/add unchanged
+- `apps/api/src/ipfs/providers/local.provider.spec.ts` - Added 2 encoding tests (one for pin/rm, one for cat) that assert reserved chars are percent-encoded
+
+## Decisions Made
+
+- Kept the regex approach (not `multiformats/@IsCid`) per D-03 — no new runtime dependency needed
+- CIDv0 branch tightened to exact `{44}` chars; CIDv1 `b[a-z2-7]{58,}` branch retained open-ended (bounded by `@MaxLength(255)`)
+- `URLSearchParams` over manual `encodeURIComponent` — idiomatic, covers all RFC 3986 reserved chars, produces identical output for clean CIDs (no regressions in existing toBe assertions)
+- `api:generate` required building `@cipherbox/crypto` first because the worktree was missing the dist; built it as a one-time prerequisite
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Built @cipherbox/crypto before api:generate**
+
+- **Found during:** Task 4 (api:generate)
+- **Issue:** `pnpm api:generate` failed because `@cipherbox/crypto` dist was absent in the worktree; the generate-openapi.ts script imports `IpnsService` which transitively requires it at runtime
+- **Fix:** Ran `pnpm --filter @cipherbox/crypto build` to produce the dist; then re-ran `pnpm api:generate` (exit 0)
+- **Files modified:** packages/crypto/dist/ (build artifact, not committed)
+- **Verification:** `pnpm api:generate` completed with exit 0; maxLength:255 confirmed in openapi.json
+- **Committed in:** 88e35a62e (Task 4 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 blocking — missing build artifact)
+**Impact on plan:** One-line prerequisite build; no scope creep, no plan changes required.
+
+## Issues Encountered
+
+- Pre-existing `tsc --noEmit` errors in `apps/api` exist for unrelated modules (`@cipherbox/crypto` missing type declarations, `incomingParsed` null checks in ipns.service.ts, missing properties in share entities). These are out-of-scope pre-existing issues; the ipfs/dto changes are clean.
+
+## TDD Gate Compliance
+
+| Gate     | Commit      | Status |
+| -------- | ----------- | ------ |
+| RED (Task 1)  | `cb9b8a30a` (test) | Pass |
+| GREEN (Task 2) | `509c80172` (feat) | Pass |
+| RED (Task 3)  | `7bf20cc06` (test) | Pass |
+| GREEN (Task 3) | `3aace0e9a` (feat) | Pass |
+
+## Known Stubs
+
+None - all wired and functional.
+
+## Threat Surface Scan
+
+No new network endpoints, auth paths, or trust boundaries introduced. Changes harden an existing path (CID input → Kubo URL). No new threat flags.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- Plan 57-01 deliverables are complete; the module-dedup tasks (57-02 if planned) can import `IpfsProviderModule` from the providers barrel once that module is created
+- All 899 apps/api tests pass
+
+---
+
+Phase: 57-api-cid-and-provider-hardening-and-module-dedup
+Completed: 2026-06-22

--- a/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-02-PLAN.md
+++ b/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-02-PLAN.md
@@ -1,0 +1,240 @@
+---
+phase: 57-api-cid-and-provider-hardening-and-module-dedup
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - apps/api/src/ipfs/providers/ipfs-provider.module.ts
+  - apps/api/src/ipfs/providers/index.ts
+  - apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts
+  - apps/api/src/ipfs/ipfs.module.ts
+  - apps/api/src/vault/vault.module.ts
+  - apps/api/src/ipfs/pending-unpin/pending-unpin.module.ts
+  - apps/api/src/ipfs/pending-unpin/unpin-helpers.ts
+  - apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts
+  - apps/api/src/vault/vault.service.ts
+  - apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts
+autonomous: true
+requirements: [HARD-08]
+
+must_haves:
+  truths:
+    - "A single leaf IpfsProviderModule owns the IPFS_PROVIDER factory; the three duplicated factory definitions are deleted"
+    - "IpfsModule, VaultModule, and PendingUnpinModule import IpfsProviderModule instead of self-providing IPFS_PROVIDER"
+    - "The misleading IN-04 accepted-circular-dependency comments are removed from all three modules"
+    - "withCidLock runs the verbatim pg_advisory_xact_lock(hashtext($1)::bigint) SQL with no abs()"
+    - "refcountAndMaybeUnpin skips the Kubo unpin and deletes the outbox row when refcount > 0; unpins then deletes when refcount == 0"
+    - "All three advisory-lock unpin sites route through the shared helpers (guardedUnpin main txn, guardedUnpin post-commit delete, drainRow)"
+  artifacts:
+    - path: "apps/api/src/ipfs/providers/ipfs-provider.module.ts"
+      provides: "Leaf IpfsProviderModule (imports ConfigModule, exports IPFS_PROVIDER)"
+      contains: "export class IpfsProviderModule"
+    - path: "apps/api/src/ipfs/pending-unpin/unpin-helpers.ts"
+      provides: "Shared withCidLock + refcountAndMaybeUnpin advisory-lock primitives"
+      contains: "export async function withCidLock"
+    - path: "apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts"
+      provides: "Test that IpfsProviderModule provides + exports IPFS_PROVIDER"
+      contains: "IpfsProviderModule"
+    - path: "apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts"
+      provides: "Tests for withCidLock SQL + refcountAndMaybeUnpin branching"
+      contains: "withCidLock"
+  key_links:
+    - from: "apps/api/src/ipfs/ipfs.module.ts"
+      to: "apps/api/src/ipfs/providers/ipfs-provider.module.ts"
+      via: "imports: [..., IpfsProviderModule]"
+      pattern: "IpfsProviderModule"
+    - from: "apps/api/src/vault/vault.service.ts"
+      to: "apps/api/src/ipfs/pending-unpin/unpin-helpers.ts"
+      via: "import { withCidLock }"
+      pattern: "withCidLock"
+    - from: "apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts"
+      to: "apps/api/src/ipfs/pending-unpin/unpin-helpers.ts"
+      via: "import { withCidLock, refcountAndMaybeUnpin }"
+      pattern: "refcountAndMaybeUnpin"
+---
+
+<objective>
+De-duplicate the IPFS / unpin module graph in `apps/api`.
+
+Two consolidations, both tech-debt dedup (IN-04 + the unpin-primitive reuse note):
+1. (D-05/D-06) Extract a leaf `IpfsProviderModule` — `@Module({ imports: [ConfigModule], providers: [IPFS_PROVIDER factory], exports: [IPFS_PROVIDER] })`. Import it from `IpfsModule`, `VaultModule`, and `PendingUnpinModule`; DELETE the three duplicated `IPFS_PROVIDER` factory blocks and default-URL strings; DELETE/CORRECT the misleading IN-04 "accepted circular-dependency" comments (the factory depends only on `ConfigService` — no cycle; the real `IpfsModule -> VaultModule` cycle is orthogonal to where `IPFS_PROVIDER` is provided).
+2. (D-07) Extract two shared primitives into `unpin-helpers.ts` and route all three advisory-lock unpin sites through them:
+   - `withCidLock(manager, cid, fn)` — runs the verbatim `SELECT pg_advisory_xact_lock(hashtext($1)::bigint)` (NO `abs()`) as the first statement, then `fn`.
+   - `refcountAndMaybeUnpin(manager, cid, ipfsProvider)` — rechecks refcount, unpins when zero, deletes the outbox row.
+   Sites: `guardedUnpin` main txn (`vault.service.ts:267`) -> `withCidLock`; `guardedUnpin` post-commit delete (`vault.service.ts:322`) -> `withCidLock` + inline outbox delete (Kubo stays OUTSIDE the txn per D-03 ordering — do NOT use `refcountAndMaybeUnpin` here); `drainRow` (`pending-unpin.processor.ts:95`) -> `withCidLock` wrapping `refcountAndMaybeUnpin`.
+
+Purpose: Kill triplicated factory drift (the IN-04 comments are factually wrong) and consolidate the advisory-lock policy so the next INT_MIN-class fix edits ONE place (it had to be hand-propagated across 3 sites once already).
+Output: leaf `IpfsProviderModule`, shared `withCidLock`/`refcountAndMaybeUnpin`, three rewired sites, three corrected modules.
+</objective>
+
+<execution_context>
+@.claude/gsd-core/workflows/execute-plan.md
+@.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-CONTEXT.md
+@.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-RESEARCH.md
+@.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-PATTERNS.md
+@.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-VALIDATION.md
+@apps/api/src/ipfs/ipfs.module.ts
+@apps/api/src/vault/vault.module.ts
+@apps/api/src/ipfs/pending-unpin/pending-unpin.module.ts
+@apps/api/src/vault/vault.service.ts
+@apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts
+@apps/api/src/ipfs/providers/index.ts
+</context>
+
+<artifacts_produced>
+New symbols this plan introduces (none exist on the API surface yet — treat absence there as UNKNOWN, not nonexistent):
+
+- `IpfsProviderModule` — NEW NestJS leaf module class, file `apps/api/src/ipfs/providers/ipfs-provider.module.ts`. imports [ConfigModule], providers [IPFS_PROVIDER factory], exports [IPFS_PROVIDER]. Re-exported from `apps/api/src/ipfs/providers/index.ts`.
+- `withCidLock(manager, cid, fn)` — NEW exported generic async function, file `apps/api/src/ipfs/pending-unpin/unpin-helpers.ts`.
+- `refcountAndMaybeUnpin(manager, cid, ipfsProvider)` — NEW exported async function, same file.
+- `apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts`, `apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts` — NEW Jest specs.
+- Helper placement: `unpin-helpers.ts` lives under `apps/api/src/ipfs/pending-unpin/` — both `vault.service.ts` and `pending-unpin.processor.ts` import it cleanly; no module cycle (it imports only typeorm + entity types + the IpfsProvider interface).
+</artifacts_produced>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Extract leaf IpfsProviderModule + rewire 3 consumers + correct IN-04 comments</name>
+  <read_first>
+    - apps/api/src/ipfs/ipfs.module.ts (forRootAsync DynamicModule with inline factory + IN-04 comment)
+    - apps/api/src/vault/vault.module.ts (inline factory + IN-04 comment)
+    - apps/api/src/ipfs/pending-unpin/pending-unpin.module.ts (inline factory + IN-04 comment)
+    - apps/api/src/ipfs/providers/index.ts (barrel to extend)
+    - apps/api/src/tee/tee.module.ts (leaf-module analog: imports ConfigModule, exports services)
+    - .planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-PATTERNS.md (sections: ipfs-provider.module.ts target; ipfs.module.ts / vault.module.ts / pending-unpin.module.ts targets; IpfsProviderModule spec analog ipfs.controller.spec.ts)
+    - .planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-RESEARCH.md (Pattern 3 + Pitfall 2: IpfsModule must EXPLICITLY keep exports:[IPFS_PROVIDER]; Open Question 2)
+  </read_first>
+  <files>apps/api/src/ipfs/providers/ipfs-provider.module.ts, apps/api/src/ipfs/providers/index.ts, apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts, apps/api/src/ipfs/ipfs.module.ts, apps/api/src/vault/vault.module.ts, apps/api/src/ipfs/pending-unpin/pending-unpin.module.ts</files>
+  <action>
+    Create apps/api/src/ipfs/providers/ipfs-provider.module.ts: a leaf @Module class IpfsProviderModule with imports: [ConfigModule]; providers: a single factory provider providing the IPFS_PROVIDER token via useFactory(configService) reading IPFS_LOCAL_API_URL (default http://localhost:5001) and IPFS_LOCAL_GATEWAY_URL (default http://localhost:8080) and returning new LocalProvider(apiUrl, gatewayUrl); inject: [ConfigService]; exports: [IPFS_PROVIDER]. Import IPFS_PROVIDER from './ipfs-provider.interface' and LocalProvider from './local.provider'. The module must import ONLY ConfigModule (no IpfsModule/VaultModule/PendingUnpinModule — any upstream import recreates the cycle the old comments wrongly claimed). Add `export * from './ipfs-provider.module';` to providers/index.ts.
+    Then rewire the 3 consumers, deleting each inline IPFS_PROVIDER factory block + its default-URL strings + its IN-04 comment:
+    - ipfs.module.ts (forRootAsync return): add IpfsProviderModule to the imports array (alongside ConfigModule, VaultModule); set providers: [] (factory removed); KEEP exports: [IPFS_PROVIDER] explicitly so IpfsController can still inject the token (Pitfall 2 — do NOT rely on implicit re-export). Remove now-unused ConfigService/LocalProvider named imports if nothing else uses them; keep the IPFS_PROVIDER import for the exports array; import IpfsProviderModule from './providers'.
+    - vault.module.ts: add IpfsProviderModule (from '../ipfs/providers') to imports; providers: [VaultService] only (factory removed). Remove the IN-04 comment and unused ConfigService/LocalProvider/IPFS_PROVIDER imports if unused.
+    - pending-unpin.module.ts: add IpfsProviderModule (from '../providers') to imports; providers: [PendingUnpinProcessor] only. Remove the IN-04 comment and unused ConfigService/LocalProvider/IPFS_PROVIDER imports if unused. Leave the OnModuleInit scheduler logic untouched.
+    Finally create apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts (analog ipfs.controller.spec.ts NestJS Test.createTestingModule): compile a TestingModule importing ConfigModule.forRoot with isGlobal false plus IpfsProviderModule, then assert module.get(IPFS_PROVIDER) is defined and is an instance of LocalProvider.
+  </action>
+  <verify>
+    <automated>cd apps/api; npx jest --testPathPattern=ipfs-provider.module 2>&amp;1 | grep -E "Tests:|✓|✕" | head; npx tsc --noEmit 2>&amp;1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - apps/api/src/ipfs/providers/ipfs-provider.module.ts exists and exports class IpfsProviderModule (grep `export class IpfsProviderModule`).
+    - providers/index.ts re-exports it (grep `ipfs-provider.module`).
+    - ipfs-provider.module.spec.ts passes: module.get(IPFS_PROVIDER) is a defined LocalProvider.
+    - The IPFS_PROVIDER useFactory block appears in EXACTLY ONE source file: `grep -rl "provide: IPFS_PROVIDER" apps/api/src` lists only ipfs-provider.module.ts.
+    - No IN-04 accepted-circular-dependency comments remain: `grep -rn "IN-04 (accepted)" apps/api/src` returns nothing.
+    - ipfs.module.ts forRootAsync still has exports: [IPFS_PROVIDER] (explicit re-export).
+    - `cd apps/api && npx tsc --noEmit` passes.
+    - Commit: `refactor(57-02): extract leaf IpfsProviderModule and correct IN-04 comments`.
+  </acceptance_criteria>
+  <done>Single leaf IpfsProviderModule owns the factory; 3 consumers import it; no IN-04 comments remain; provider spec green; tsc passes.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Extract withCidLock + refcountAndMaybeUnpin shared primitives (with tests)</name>
+  <read_first>
+    - apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts (drainRow lines 91-117 — the extraction source for refcountAndMaybeUnpin; advisory-lock SQL at line 95)
+    - apps/api/src/vault/vault.service.ts (guardedUnpin advisory-lock SQL at line 267)
+    - apps/api/src/ipfs/pending-unpin/pending-unpin.processor.spec.ts (mock DataSource/manager + getRepository dispatch pattern, lines ~50-60)
+    - apps/api/src/vault/entities/pinned-cid.entity.ts and pending-unpin.entity.ts (entity types the helper rechecks/deletes)
+    - apps/api/src/ipfs/providers/ipfs-provider.interface.ts (IpfsProvider type + unpinFile signature)
+    - .planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-PATTERNS.md (sections: unpin-helpers.ts target signatures + verbatim SQL; unpin-helpers.spec.ts mock-manager analog)
+    - .planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-RESEARCH.md (Pattern 4 + Pitfall 5: SQL verbatim, NO abs(); Pitfall 3 / Open Question 1: refcountAndMaybeUnpin is for drainRow only)
+  </read_first>
+  <files>apps/api/src/ipfs/pending-unpin/unpin-helpers.ts, apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts</files>
+  <action>
+    Create apps/api/src/ipfs/pending-unpin/unpin-helpers.ts exporting two functions. withCidLock is generic over T, signature (manager: EntityManager, cid: string, fn: () => Promise<T>) => Promise<T>: it runs `await manager.query('SELECT pg_advisory_xact_lock(hashtext($1)::bigint)', [cid])` as the first statement (copy the SQL string VERBATIM from vault.service.ts:267 / pending-unpin.processor.ts:95 — NO abs() before the ::bigint cast; carry the INT_MIN-safe explanatory doc comment), then returns fn(). refcountAndMaybeUnpin signature (manager: EntityManager, cid: string, ipfsProvider: IpfsProvider) => Promise<void>: count PinnedCid rows where { cid }; if refs > 0, delete the PendingUnpin outbox row for { cid } and return (stale row — CID re-pinned); else call ipfsProvider.unpinFile(cid) then delete the PendingUnpin outbox row. Import EntityManager from typeorm, PinnedCid + PendingUnpin from ../../vault/entities, IpfsProvider from ../providers/ipfs-provider.interface. Document in the refcountAndMaybeUnpin doc comment that it must run inside a transaction already holding withCidLock for the same cid, and is for drainRow only (Kubo inside lock) — NOT for the guardedUnpin post-commit site.
+    Create apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts using the pending-unpin.processor.spec.ts mock-manager pattern (plain jest mocks, no NestJS TestingModule):
+    - withCidLock: it executes the exact pg_advisory_xact_lock SQL with [cid] and runs+returns fn — assert mockQuery called with ('SELECT pg_advisory_xact_lock(hashtext($1)::bigint)', [cid]), fn called, return value propagated.
+    - refcountAndMaybeUnpin refs>0: mock PinnedCid.count -> 2; assert ipfsProvider.unpinFile NOT called, PendingUnpin.delete called with { cid }.
+    - refcountAndMaybeUnpin refs===0: mock PinnedCid.count -> 0; assert ipfsProvider.unpinFile called with cid, then PendingUnpin.delete called with { cid }.
+  </action>
+  <verify>
+    <automated>cd apps/api; npx jest --testPathPattern=unpin-helpers 2>&amp;1 | grep -E "Tests:|✓|✕" | head</automated>
+  </verify>
+  <acceptance_criteria>
+    - unpin-helpers.ts exports withCidLock and refcountAndMaybeUnpin (grep `export async function withCidLock` and `export async function refcountAndMaybeUnpin`).
+    - The SQL is verbatim with no abs(): `grep -F "SELECT pg_advisory_xact_lock(hashtext(\$1)::bigint)" apps/api/src/ipfs/pending-unpin/unpin-helpers.ts` matches, and `grep -F "abs(" apps/api/src/ipfs/pending-unpin/unpin-helpers.ts` returns nothing.
+    - All 3 unpin-helpers.spec.ts tests pass (lock SQL, refs>0 skip-unpin, refs===0 unpin).
+    - Commit: `feat(57-02): add shared withCidLock and refcountAndMaybeUnpin primitives`.
+  </acceptance_criteria>
+  <done>unpin-helpers.ts exports both helpers with verbatim no-abs() SQL; all 3 unpin-helpers.spec.ts tests green.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Route all three unpin sites through the shared helpers</name>
+  <read_first>
+    - apps/api/src/vault/vault.service.ts (guardedUnpin: main txn lock line 267; post-commit delete txn lines 321-324; existing import of IPFS_PROVIDER/IpfsProvider at line 16; DataSource at line 4)
+    - apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts (drainRow lines 91-117)
+    - apps/api/src/ipfs/pending-unpin/unpin-helpers.ts (created Task 2)
+    - apps/api/src/vault/vault.service.spec.ts and pending-unpin.processor.spec.ts (existing suites that must stay green after rewiring)
+    - .planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-PATTERNS.md (section: unpin-helpers.ts — post-commit site uses withCidLock ONLY + inline delete; drainRow uses both helpers)
+    - .planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-RESEARCH.md (Pitfall 3: post-commit Kubo call must stay OUTSIDE the inner transaction)
+  </read_first>
+  <files>apps/api/src/vault/vault.service.ts, apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts</files>
+  <action>
+    In vault.service.ts import withCidLock from '../ipfs/pending-unpin/unpin-helpers'. Site 1 (guardedUnpin main transaction): wrap the existing in-transaction body (the ownership check, pinned_cids delete, refcount query, outbox insert) inside withCidLock(manager, cid, async () => { ...existing body... }) so the verbatim lock SQL now comes from the helper; REMOVE the inline `await manager.query('SELECT pg_advisory_xact_lock(...)', [cid])` line 267 (it is now inside withCidLock). Preserve all surrounding semantics (shouldAttemptPhysicalUnpin, rowDeleted, metrics, comments about D-01/D-03/D-05) — only the lock acquisition moves into the helper. Site 2 (guardedUnpin post-commit delete, lines 321-324): keep `await this.ipfsProvider.unpinFile(cid)` OUTSIDE any transaction (D-03 ordering, Pitfall 3 — unchanged); inside the existing `this.dataSource.transaction(async (manager) => { ... })` replace the inline lock query + outbox delete with `await withCidLock(manager, cid, async () => { await manager.getRepository(PendingUnpin).delete({ cid }); })`. Do NOT use refcountAndMaybeUnpin here (no refcount recheck, Kubo already ran outside).
+    In pending-unpin.processor.ts import withCidLock + refcountAndMaybeUnpin from './unpin-helpers'. drainRow: replace the transaction body (inline lock query + refcount recheck + conditional unpin + outbox delete + logging) with `await this.dataSource.transaction(async (manager) => { await withCidLock(manager, cid, () => refcountAndMaybeUnpin(manager, cid, this.ipfsProvider)); });`. The logging lines may be kept by either logging around the helper call or accepting the helper's silent behavior — preserve at least the existing "Drained cid=" / skip-on-refs log intent if the existing processor spec asserts on logs (check the spec first); if the spec asserts log calls, keep a thin log wrapper around refcountAndMaybeUnpin rather than dropping the logs.
+  </action>
+  <verify>
+    <automated>cd apps/api; npx jest --testPathPattern="vault.service|pending-unpin" 2>&amp;1 | grep -E "Tests:|✕" | head</automated>
+  </verify>
+  <acceptance_criteria>
+    - vault.service.ts and pending-unpin.processor.ts import from unpin-helpers (`grep -c "unpin-helpers" apps/api/src/vault/vault.service.ts apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts` both >= 1).
+    - No inline advisory-lock SQL remains at the three sites: `grep -rn "pg_advisory_xact_lock" apps/api/src/vault/vault.service.ts apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts` returns nothing (it now lives only in unpin-helpers.ts).
+    - drainRow uses refcountAndMaybeUnpin (`grep -c refcountAndMaybeUnpin apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts` >= 1); the guardedUnpin post-commit site does NOT (`grep -c refcountAndMaybeUnpin apps/api/src/vault/vault.service.ts` is 0).
+    - The post-commit ipfsProvider.unpinFile(cid) call remains OUTSIDE the inner transaction in guardedUnpin (manual read confirm; Kubo not inside withCidLock).
+    - Existing vault.service and pending-unpin.processor specs stay green.
+    - Commit: `refactor(57-02): route all three unpin sites through shared withCidLock/refcountAndMaybeUnpin`.
+  </acceptance_criteria>
+  <done>All 3 unpin sites import + route through the shared helpers; no inline lock SQL remains; post-commit Kubo stays outside the txn; existing specs green.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+
+## Trust Boundaries
+
+| Boundary | Description |
+| -------- | ----------- |
+| Concurrent unpin requests | Multiple guardedUnpin / drain transactions racing on the same CID's refcount + outbox row |
+| API -> PostgreSQL | Advisory-lock key derivation (hashtext int4 -> bigint) must not overflow for any CID hash |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+| --------- | -------- | --------- | ----------- | --------------- |
+| T-57-04 | Tampering | Advisory-lock primitive drift across 3 sites (the INT_MIN abs() fix was hand-propagated once) | mitigate | Consolidate into a single `withCidLock` whose SQL is the verbatim `hashtext($1)::bigint` (NO abs()); a future fix edits one place. Validated by unpin-helpers.spec lock-SQL test + grep gate (no abs(), no inline SQL at the 3 sites) |
+| T-57-05 | Tampering | Data-loss race: unpinning a CID that was concurrently re-pinned | mitigate | `refcountAndMaybeUnpin` rechecks refcount UNDER the held lock and skips unpin when refs > 0 (drainRow); preserves the Phase 50 WR-01 invariant. Validated by unpin-helpers.spec refs>0 test |
+| T-57-06 | Denial of Service | Kubo network call held inside a long advisory-lock transaction at the post-commit site | accept/mitigate | Post-commit `ipfsProvider.unpinFile` stays OUTSIDE the inner transaction (D-03 ordering); only the outbox-row delete is serialized under `withCidLock`. Enforced by Task 3 acceptance criterion |
+| T-57-07 | Elevation of Privilege / config | Leaf IpfsProviderModule accidentally importing an upstream module (recreating the real cycle) | mitigate | IpfsProviderModule imports ONLY ConfigModule (leaf); acceptance grep confirms single factory source. The factory depends solely on ConfigService |
+| T-57-SC | Tampering | npm/pip/cargo installs | accept | No new packages installed this phase (RESEARCH Package Legitimacy Audit: N/A) |
+
+Block-on-high check: no HIGH-severity threat is left unmitigated. T-57-05 (data-loss race) is the most sensitive — preserved via the under-lock refcount recheck.
+</threat_model>
+
+<verification>
+- `cd apps/api && npx jest --testPathPattern=ipfs-provider.module` — leaf module provides + exports IPFS_PROVIDER.
+- `cd apps/api && npx jest --testPathPattern=unpin-helpers` — withCidLock SQL + refcountAndMaybeUnpin branching green.
+- `cd apps/api && npx jest --testPathPattern="vault.service|pending-unpin"` — rewired sites keep existing suites green.
+- `cd apps/api && npx tsc --noEmit` — module graph + imports compile.
+- Grep gates (see per-task acceptance): single `provide: IPFS_PROVIDER` source, no `IN-04 (accepted)` comments, no inline `pg_advisory_xact_lock` at the 3 sites, no `abs(` in the helper.
+- Per VALIDATION.md sampling: after the plan wave, `pnpm --filter @cipherbox/api test` (full api suite) must be green before `/gsd-verify-work`.
+</verification>
+
+<success_criteria>
+- A single leaf `IpfsProviderModule` owns the `IPFS_PROVIDER` factory; the three duplicated factory blocks and IN-04 comments are gone; `IpfsModule`/`VaultModule`/`PendingUnpinModule` import the leaf module; `IpfsModule` still explicitly exports `IPFS_PROVIDER`.
+- `withCidLock` and `refcountAndMaybeUnpin` exist in `unpin-helpers.ts` with the verbatim INT_MIN-safe SQL (no `abs()`).
+- All three unpin sites route through the shared helpers; the post-commit Kubo call stays outside the transaction (D-03).
+- The advisory-lock SQL exists in exactly one source file.
+- Full `apps/api` jest suite green.
+</success_criteria>
+
+<output>
+Create `.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-02-SUMMARY.md
+++ b/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-02-SUMMARY.md
@@ -1,0 +1,140 @@
+---
+phase: 57-api-cid-and-provider-hardening-and-module-dedup
+plan: "02"
+subsystem: api
+tags: [nestjs, typeorm, ipfs, advisory-lock, module-dedup]
+
+requires:
+  - phase: 50-ipfs-ipns-data-integrity-fixes
+    provides: advisory-lock advisory-lock unpin integrity baseline (WR-01, INT_MIN-safe SQL)
+
+provides:
+  - Leaf IpfsProviderModule (single IPFS_PROVIDER factory source, imported by IpfsModule/VaultModule/PendingUnpinModule)
+  - withCidLock shared primitive (verbatim INT_MIN-safe pg_advisory_xact_lock SQL)
+  - refcountAndMaybeUnpin shared primitive (under-lock refcount recheck + conditional unpin)
+  - All three advisory-lock unpin sites routed through shared helpers
+
+affects:
+  - ipfs module graph
+  - vault unpin path
+  - pending-unpin drain path
+
+tech-stack:
+  added: []
+  patterns:
+    - Leaf NestJS module pattern for shared DI tokens (IpfsProviderModule)
+    - Shared helper functions for cross-service advisory lock primitives
+
+key-files:
+  created:
+    - apps/api/src/ipfs/providers/ipfs-provider.module.ts
+    - apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts
+    - apps/api/src/ipfs/pending-unpin/unpin-helpers.ts
+    - apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts
+  modified:
+    - apps/api/src/ipfs/providers/index.ts
+    - apps/api/src/ipfs/ipfs.module.ts
+    - apps/api/src/vault/vault.module.ts
+    - apps/api/src/ipfs/pending-unpin/pending-unpin.module.ts
+    - apps/api/src/vault/vault.service.ts
+    - apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts
+
+key-decisions:
+  - 'IpfsProviderModule imports only ConfigModule (leaf) — no upstream module imports to avoid recreating real cycle'
+  - 'IpfsModule forRootAsync explicitly keeps exports: [IPFS_PROVIDER] even after delegating factory to IpfsProviderModule (Pitfall 2)'
+  - 'withCidLock uses verbatim SQL with NO abs() — sign-extends int4→bigint safely per INT_MIN-safe fix'
+  - 'Post-commit guardedUnpin site uses withCidLock only (not refcountAndMaybeUnpin) — Kubo stays outside transaction per D-03'
+  - 'drainRow delegates to withCidLock wrapping refcountAndMaybeUnpin — Kubo inside lock per drainRow design'
+
+patterns-established:
+  - 'Leaf module pattern: single DI token with factory in its own @Module, imported by all consumers'
+  - 'Advisory lock via withCidLock helper: all unpin lock acquisitions through single implementation'
+
+requirements-completed: [HARD-08]
+
+duration: 25min
+completed: 2026-06-22
+---
+
+# Phase 57 Plan 02: API Module Dedup and Shared Unpin Primitives Summary
+
+**Triplicated IPFS_PROVIDER factory and duplicated advisory-lock SQL consolidated into a single leaf IpfsProviderModule and withCidLock/refcountAndMaybeUnpin helpers, routing all three unpin sites through one INT_MIN-safe lock primitive**
+
+## Performance
+
+- **Duration:** ~25 min
+- **Started:** 2026-06-22T01:40:00Z
+- **Completed:** 2026-06-22T02:05:00Z
+- **Tasks:** 3
+- **Files modified:** 10
+
+## Accomplishments
+
+- Extracted leaf `IpfsProviderModule` as the single source of the `IPFS_PROVIDER` factory; removed triplicated factory blocks and misleading IN-04 comments from IpfsModule, VaultModule, PendingUnpinModule
+- Created `withCidLock` and `refcountAndMaybeUnpin` in `unpin-helpers.ts` with verbatim INT_MIN-safe SQL and no `abs()` — a future lock fix edits one file instead of three
+- Routed all three advisory-lock unpin sites through the shared helpers; the post-commit Kubo call correctly remains outside the inner transaction (D-03 ordering)
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Extract leaf IpfsProviderModule + rewire consumers** - `7f0e202e8` (refactor)
+2. **Task 2: withCidLock + refcountAndMaybeUnpin primitives** - `d2d2adc73` (feat)
+3. **Task 3: Route three unpin sites through shared helpers** - `94f6a3caf` (refactor)
+4. **Task 3 follow-up: Clean up duplicate doc comment** - `def599b83` (refactor)
+
+## Files Created/Modified
+
+- `apps/api/src/ipfs/providers/ipfs-provider.module.ts` - New leaf @Module owning the single IPFS_PROVIDER factory
+- `apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts` - NestJS TestingModule spec asserting LocalProvider is provided
+- `apps/api/src/ipfs/pending-unpin/unpin-helpers.ts` - withCidLock + refcountAndMaybeUnpin with verbatim lock SQL
+- `apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts` - 3 tests: lock SQL, refs>0 skip-unpin, refs===0 unpin
+- `apps/api/src/ipfs/providers/index.ts` - Added barrel re-export for IpfsProviderModule
+- `apps/api/src/ipfs/ipfs.module.ts` - Replaced inline factory with IpfsProviderModule import; kept explicit exports: [IPFS_PROVIDER]
+- `apps/api/src/vault/vault.module.ts` - Replaced inline factory with IpfsProviderModule import
+- `apps/api/src/ipfs/pending-unpin/pending-unpin.module.ts` - Replaced inline factory with IpfsProviderModule import
+- `apps/api/src/vault/vault.service.ts` - Wrapped guardedUnpin main txn and post-commit txn in withCidLock
+- `apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts` - drainRow uses withCidLock + refcountAndMaybeUnpin
+
+## Decisions Made
+
+- IpfsProviderModule imports only ConfigModule (leaf). The IN-04 comments claimed a cycle existed that justified triplication; that was incorrect — the real cycle is IpfsModule ↔ VaultModule, orthogonal to where IPFS_PROVIDER is provided.
+- IpfsModule.forRootAsync explicitly keeps `exports: [IPFS_PROVIDER]` even though the factory moved to IpfsProviderModule — required so IpfsController can inject the token through the DynamicModule boundary.
+- Post-commit guardedUnpin site uses `withCidLock` only, NOT `refcountAndMaybeUnpin` — the Kubo call must stay outside the transaction per D-03; only the outbox-row delete is serialized under the lock.
+
+## Deviations from Plan
+
+None - plan executed exactly as written. The duplicate doc comment cleanup (fourth commit) was cosmetic cleanup of a comment block that my Edit left doubled; not a behavioral change.
+
+## Grep Gates
+
+- `provide: IPFS_PROVIDER` in non-spec source files: exactly ONE (`ipfs-provider.module.ts`)
+- `IN-04 (accepted)` comments: zero matches
+- `pg_advisory_xact_lock` in `vault.service.ts` and `pending-unpin.processor.ts`: zero actual SQL calls (only doc comments referencing the lock by name)
+- `abs(` in `unpin-helpers.ts`: zero matches in SQL (only in doc comment explaining prohibition)
+- `refcountAndMaybeUnpin` in `vault.service.ts`: 0 (post-commit site uses withCidLock only)
+- `refcountAndMaybeUnpin` in `pending-unpin.processor.ts`: 3 matches (import + drainRow usage)
+
+## Test Results
+
+- Full `apps/api` jest suite: **903 tests, 47 suites, all passing**
+- `tsc --noEmit`: 3 pre-existing errors in `metrics/` and `shares/` (unrelated); zero new errors in changed files
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- Plan 57-02 complete; the module dedup and unpin-primitive consolidation goals are fully achieved
+- A future bug fix to the advisory-lock key derivation or refcount logic edits one location each
+- HARD-08 requirement satisfied; phase 57-03 can proceed if applicable
+
+---
+
+_Phase: 57-api-cid-and-provider-hardening-and-module-dedup_
+_Completed: 2026-06-22_

--- a/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-CONTEXT.md
+++ b/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-CONTEXT.md
@@ -1,0 +1,189 @@
+# Phase 57: API CID and Provider Hardening and Module Dedup - Context
+
+**Gathered:** 2026-06-22
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Make `apps/api` IPFS CID-handling defense-in-depth consistent, and de-duplicate the
+IPFS/unpin module graph. Four findings, all surfaced by the Phase 50 review/`/simplify`
+(WR-02, WR-05, IN-04, + the unpin-primitive reuse note) and **deferred** because the
+affected files were outside Phase 50's confirmed fix scope.
+
+**Requirement:** HARD-08. **Depends on:** Phase 50 (unpin-integrity baseline).
+
+Two findings are correctness/defense-in-depth (CID validation, URL encoding); two are
+tech-debt dedup (provider module, unpin primitive). No new capabilities.
+
+**No open design decisions** — every fix has a locked direction from the source todos +
+ROADMAP; this CONTEXT records them for the planner. (Discussion confirmed nothing was
+genuinely gray; the only latitude is file placement, left to the planner.)
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### CID validation consistency (WR-02)
+
+- **D-01:** Extract the **existing** `UnpinDto` regex into a single shared constant and
+  apply it — plus `@MaxLength(255)` — to `RegisterCidDto.cid`. The current
+  `UnpinDto.CID_REGEX` is `/^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$/` and already
+  covers **CIDv0 (`Qm…` 46 chars) AND CIDv1 (`b…` base32)**. `RegisterCidDto` currently
+  uses the looser `/^(Qm…{44,}|b[a-z2-7]{58,})$/` with **no** `@MaxLength` — change the
+  CIDv0 branch `{44,}`→`{44}` to match unpin, and add `@MaxLength(255)`.
+- **D-02:** The system **uses CIDv1** — `LocalProvider` adds with `?cid-version=1`
+  (`local.provider.ts:49`), so new uploads are CIDv1 `bafk…`. The CIDv1 branch
+  (`b[a-z2-7]{58,}`, open length, capped by `@MaxLength(255)`) MUST stay. Do **not**
+  collapse to a CIDv0-only regex.
+- **D-03:** Keep the **regex** approach (the established IN-02 pattern in `unpin.dto.ts`).
+  Do NOT introduce a `multiformats`-based `@IsCid()` validator — over-engineering for a
+  "make the two DTOs consistent" hardening pass.
+
+### Provider URL encoding (WR-05)
+
+- **D-04:** In `LocalProvider`, encode every CID interpolated into a Kubo query string —
+  `pin/rm?arg=`, the symmetric `pin/add` path, **and** `cat?arg=` (`local.provider.ts:87`,
+  `:127`, and the add path). Use `URLSearchParams` (preferred) or `encodeURIComponent`.
+  Rationale: DB-sourced CIDs reach this path from `drainRow` (`row.cid`) and `guardedUnpin`
+  (`pinned_cids`/`pending_unpins` rows), whose register-cid origin was only loosely
+  validated before D-01 — the unpin path must not depend on every upstream writer being
+  airtight. Pairs with D-01 for defense-in-depth.
+
+### Provider module dedup (IN-04)
+
+- **D-05:** Extract a leaf `IpfsProviderModule` —
+  `@Module({ imports: [ConfigModule], providers: [IPFS_PROVIDER], exports: [IPFS_PROVIDER] })`.
+  Import it from `IpfsModule`, `VaultModule`, and `PendingUnpinModule`; remove the three
+  duplicated `IPFS_PROVIDER` factory definitions and default-URL strings.
+- **D-06:** Delete/correct the misleading IN-04 "accepted circular-dependency" comments in
+  all three modules. The factory depends only on `ConfigService` (a leaf), so a shared
+  provider module creates **no** cycle. The real cycle is `IpfsModule → VaultModule`, which
+  is orthogonal to where `IPFS_PROVIDER` is provided.
+
+### Shared unpin primitive (reuse)
+
+- **D-07:** Extract two shared primitives and route all three unpin sites through them:
+  - `withCidLock(cid, fn)` — acquires `pg_advisory_xact_lock(hashtext($1)::bigint)` with the
+    **existing INT_MIN-safe** key derivation, runs `fn` inside the lock.
+  - `refcountAndMaybeUnpin(manager, cid)` — rechecks refcount, unpins when zero, deletes the
+    outbox row.
+  Sites: `guardedUnpin` main transaction, `guardedUnpin` post-commit delete, and `drainRow`
+  in the pending-unpin processor. **Mechanism is the existing advisory-lock primitive** — this
+  is consolidation, NOT a new locking choice. (Drift already bit once: the INT_MIN `abs()` fix
+  had to be hand-propagated across the 3 sites.)
+
+### Cross-cutting
+
+- **D-08 (api:generate):** Run `pnpm api:generate` and commit the regenerated client **iff**
+  the `RegisterCidDto` change alters the OpenAPI spec (adding `@MaxLength(255)` may add a
+  `maxLength` to the spec). Verify the spec diff after the DTO change; the pre-commit hook
+  `check-api-client.sh` enforces staging the regenerated client alongside API changes.
+
+### Claude's Discretion
+
+- File placement of the shared `CID_REGEX` constant (e.g. a small `cid.constants.ts` under
+  `apps/api/src/ipfs/dto/` or `ipfs/`) and of the `withCidLock`/`refcountAndMaybeUnpin`
+  helpers (a shared location both `vault.service.ts` and `pending-unpin.processor.ts` import).
+- `URLSearchParams` vs `encodeURIComponent` exact form.
+
+### Folded Todos
+
+All four ARE the phase scope (the ROADMAP absorbed them):
+
+- **`2026-06-19-register-cid-dto-validation-inconsistency.md`** (WR-02) → D-01, D-02, D-03.
+- **`2026-06-19-local-provider-unescaped-cid-in-pin-url.md`** (WR-05) → D-04.
+- **`2026-06-19-extract-leaf-ipfs-provider-module.md`** (IN-04) → D-05, D-06.
+- **`2026-06-19-extract-withcidlock-shared-unpin-primitive.md`** → D-07.
+
+</decisions>
+
+<canonical_refs>
+
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Phase scope (folded todos — file/line-level fix directions)
+
+- `.planning/todos/pending/2026-06-19-register-cid-dto-validation-inconsistency.md`
+- `.planning/todos/pending/2026-06-19-local-provider-unescaped-cid-in-pin-url.md`
+- `.planning/todos/pending/2026-06-19-extract-leaf-ipfs-provider-module.md`
+- `.planning/todos/pending/2026-06-19-extract-withcidlock-shared-unpin-primitive.md`
+
+### Source review
+
+- `.planning/phases/50-ipfs-ipns-data-integrity-fixes/50-REVIEW.md` — WR-02, WR-05, IN-04 origins (the unpin-integrity baseline this hardens)
+
+### Target files
+
+- `apps/api/src/ipfs/dto/unpin.dto.ts` — the existing shared-able `CID_REGEX` (v0+v1) + `@MaxLength(255)` template
+- `apps/api/src/ipfs/dto/register-cid.dto.ts` — the loose regex to bring into line
+- `apps/api/src/ipfs/providers/local.provider.ts` — pin/add, pin/rm, cat URL construction
+- `apps/api/src/ipfs/ipfs.module.ts`, `apps/api/src/vault/vault.module.ts`, `apps/api/src/ipfs/pending-unpin/pending-unpin.module.ts` — triplicated `IPFS_PROVIDER` + IN-04 comments
+- `apps/api/src/vault/vault.service.ts` (`guardedUnpin`), `apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts` (`drainRow`) — the 3 unpin sites
+
+### Project docs
+
+- `CLAUDE.md` — API workflow (run `pnpm api:generate` after DTO/controller changes; commit regenerated client)
+
+</canonical_refs>
+
+<code_context>
+
+## Existing Code Insights
+
+### Reusable Assets
+
+- **`UnpinDto.CID_REGEX`** (`apps/api/src/ipfs/dto/unpin.dto.ts:7`) — already the correct
+  v0+v1 regex with `@MaxLength(255)`. D-01 extracts and reuses it; no new regex to design.
+- **`pg_advisory_xact_lock(hashtext($1)::bigint)` + INT_MIN-safe key** — already implemented
+  inline at the 3 unpin sites (Phase 42/50). D-07 consolidates, doesn't reinvent.
+
+### Established Patterns
+
+- **IN-02 regex-based CID validation** via `class-validator` `@Matches` — the existing,
+  intended pattern. Stay on it (D-03).
+- **NestJS leaf module + DI token** — `IPFS_PROVIDER` is a factory provider keyed off
+  `ConfigService`; standard leaf-module extraction (D-05).
+- **api:generate discipline** — DTO changes that alter the OpenAPI spec require regenerating
+  and committing `@cipherbox/api-client`; `check-api-client.sh` pre-commit guard enforces it.
+
+### Integration Points
+
+- The shared `CID_REGEX` constant is imported by both `unpin.dto.ts` and `register-cid.dto.ts`.
+- `IpfsProviderModule` is imported by 3 feature modules.
+- `withCidLock`/`refcountAndMaybeUnpin` are imported by `vault.service.ts` and the
+  pending-unpin processor.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- "Make `RegisterCidDto` validate exactly like `UnpinDto`" — the unpin DTO is the reference.
+- "The unpin path must not trust upstream validation" — encode at the provider boundary (D-04)
+  even though the regexes currently happen to exclude query-significant chars (latent, not yet
+  exploitable).
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — discussion stayed within phase scope.
+
+### Reviewed Todos (not folded)
+
+- `2026-06-20-ipns-publish-validate-embedded-sequence-without-cas.md` and
+  `2026-06-20-ipns-resolve-verify-coverage-and-web-sdk-dedup.md` → **Phase 58** (IPNS
+  Signature-Verify Coverage), not 57.
+- `2026-06-20-cargo-lock-sync-precise-vs-workspace.md` → CI/release track, not this API phase.
+
+</deferred>
+
+---
+
+_Phase: 57-api-cid-and-provider-hardening-and-module-dedup_
+_Context gathered: 2026-06-22_

--- a/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-DISCUSSION-LOG.md
+++ b/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-DISCUSSION-LOG.md
@@ -1,0 +1,39 @@
+# Phase 57: API CID and Provider Hardening and Module Dedup - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-06-22
+**Phase:** 57-api-cid-and-provider-hardening-and-module-dedup
+**Areas discussed:** None — phase assessed as fully locked
+
+---
+
+## Skip assessment
+
+Per the discuss-phase skip rule ("if no meaningful gray areas exist — pure infrastructure,
+clear-cut implementation, all already decided — the phase may not need discussion"), Phase 57
+was assessed and found to have **no open design decisions**. Each of the 4 findings carries a
+locked direction from its source todo + the ROADMAP:
+
+| Finding | Why it's locked |
+| ------- | --------------- |
+| CID validation (WR-02) | The correct v0+v1 regex already exists in `UnpinDto`; the fix is to extract + reuse it with `@MaxLength(255)` on `RegisterCidDto`. No new regex to design. |
+| URL encoding (WR-05) | `encodeURIComponent`/`URLSearchParams` on the provider's CID query params. Mechanical. |
+| Provider module (IN-04) | Standard NestJS leaf-module extraction; the todo specifies the exact module shape. |
+| Unpin primitive | Consolidates the **existing** `pg_advisory_xact_lock` logic into shared helpers; mechanism already chosen. |
+
+One assumption that was checked and corrected during scouting: the codebase **does** use CIDv1
+(`LocalProvider` adds with `cid-version=1`), so the shared regex must retain its CIDv1 branch —
+recorded as D-02 in CONTEXT.md.
+
+## Claude's Discretion
+
+- File placement of the shared `CID_REGEX` constant and the `withCidLock` /
+  `refcountAndMaybeUnpin` helpers.
+- `URLSearchParams` vs `encodeURIComponent` exact form.
+
+## Deferred Ideas
+
+- IPNS publish/resolve signature-verify todos → Phase 58.
+- Cargo.lock release-sync todo → CI/release track.

--- a/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-PATTERNS.md
+++ b/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-PATTERNS.md
@@ -1,0 +1,651 @@
+# Phase 57: API CID and Provider Hardening and Module Dedup - Pattern Map
+
+**Mapped:** 2026-06-22
+**Files analyzed:** 11 (3 new, 8 modified)
+**Analogs found:** 11 / 11
+
+## File Classification
+
+| New/Modified File | Role | Data Flow | Closest Analog | Match Quality |
+| --- | --- | --- | --- | --- |
+| `apps/api/src/ipfs/dto/cid.constants.ts` (NEW) | utility/constant | — | `apps/api/src/ipfs/dto/unpin.dto.ts` | exact (extract from) |
+| `apps/api/src/ipfs/dto/unpin.dto.ts` (EDIT) | dto | request-response | self | exact |
+| `apps/api/src/ipfs/dto/register-cid.dto.ts` (EDIT) | dto | request-response | `apps/api/src/ipfs/dto/unpin.dto.ts` | exact |
+| `apps/api/src/ipfs/providers/local.provider.ts` (EDIT) | service/provider | request-response | self | exact |
+| `apps/api/src/ipfs/providers/ipfs-provider.module.ts` (NEW) | module | — | `apps/api/src/tee/tee.module.ts` | role-match (leaf module) |
+| `apps/api/src/ipfs/providers/index.ts` (EDIT) | barrel | — | self | exact |
+| `apps/api/src/ipfs/ipfs.module.ts` (EDIT) | module | — | self | exact |
+| `apps/api/src/vault/vault.module.ts` (EDIT) | module | — | self | exact |
+| `apps/api/src/ipfs/pending-unpin/pending-unpin.module.ts` (EDIT) | module | — | self | exact |
+| `apps/api/src/ipfs/pending-unpin/unpin-helpers.ts` (NEW) | utility | CRUD + advisory-lock | `apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts` | role-match (extract from) |
+| `apps/api/src/vault/vault.service.ts` (EDIT) | service | CRUD | self | exact |
+| `apps/api/src/ipfs/dto/register-cid.dto.spec.ts` (NEW) | test | — | `apps/api/src/ipfs/providers/local.provider.spec.ts` | role-match (unit, no framework setup) |
+| `apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts` (NEW) | test | — | `apps/api/src/ipfs/pending-unpin/pending-unpin.processor.spec.ts` | exact (mock DataSource/manager) |
+| `apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts` (NEW) | test | — | `apps/api/src/ipfs/ipfs.controller.spec.ts` | role-match (NestJS TestingModule) |
+
+## Pattern Assignments
+
+### `apps/api/src/ipfs/dto/cid.constants.ts` (NEW — utility)
+
+**Analog:** `apps/api/src/ipfs/dto/unpin.dto.ts` (extract `CID_REGEX` from lines 4-7)
+
+**Full source to extract from** (unpin.dto.ts lines 4-7):
+
+```typescript
+// IN-02: CID format regex covers CIDv0 (Qm... base58, 46 chars) and
+// CIDv1 (b... base32, 59+ chars). MaxLength(255) bounds the input to
+// prevent oversized-string DoS at the route boundary (T-50-12).
+const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$/;
+```
+
+**Target `cid.constants.ts`** — export the const, carry the comment:
+
+```typescript
+// IN-02: CID format regex covers CIDv0 (Qm... base58, 46 chars) and
+// CIDv1 (b... base32, 59+ chars). MaxLength(255) bounds the input to
+// prevent oversized-string DoS at the route boundary (T-50-12).
+export const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$/;
+```
+
+---
+
+### `apps/api/src/ipfs/dto/unpin.dto.ts` (EDIT)
+
+**Change:** Replace the local `const CID_REGEX` declaration (line 7) with an import from `./cid.constants`.
+
+**Before** (lines 4-7):
+
+```typescript
+// IN-02: CID format regex covers CIDv0 (Qm... base58, 46 chars) and
+// CIDv1 (b... base32, 59+ chars). MaxLength(255) bounds the input to
+// prevent oversized-string DoS at the route boundary (T-50-12).
+const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$/;
+```
+
+**After:**
+
+```typescript
+import { CID_REGEX } from './cid.constants';
+```
+
+Rest of file unchanged (lines 1-2 imports, lines 9-31 class body stay identical).
+
+---
+
+### `apps/api/src/ipfs/dto/register-cid.dto.ts` (EDIT)
+
+**Analog:** `apps/api/src/ipfs/dto/unpin.dto.ts` — copy its decorator stack exactly.
+
+**Current divergence** (register-cid.dto.ts lines 1-14):
+
+```typescript
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsInt, Min, Max, IsNotEmpty, Matches } from 'class-validator';
+// ...
+@ApiProperty({ description: 'IPFS CID pinned to external provider (CIDv0 or CIDv1)' })
+@IsString()
+@IsNotEmpty()
+@Matches(/^(Qm[1-9A-HJ-NP-Za-km-z]{44,}|b[a-z2-7]{58,})$/, {
+  message: 'cid must be a valid CIDv0 (Qm...) or CIDv1 (bafy...) string',
+})
+cid!: string;
+```
+
+**Target** — add `MaxLength` import, import `CID_REGEX`, update `@ApiProperty` with maxLength metadata, add `@MaxLength(255)`, fix `{44,}` to `{44}`:
+
+```typescript
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsInt, Min, Max, IsNotEmpty, Matches, MaxLength } from 'class-validator';
+import { CID_REGEX } from './cid.constants';
+
+export class RegisterCidDto {
+  @ApiProperty({
+    description: 'IPFS CID pinned to external provider (CIDv0 or CIDv1)',
+    pattern: '^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$',
+    maxLength: 255,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  @Matches(CID_REGEX, { message: 'cid must be a valid CIDv0 (Qm...) or CIDv1 (b...) string' })
+  cid!: string;
+  // sizeBytes field unchanged
+}
+```
+
+**Note:** `@MaxLength(255)` triggers D-08 — `pnpm api:generate` required after this change.
+
+---
+
+### `apps/api/src/ipfs/providers/local.provider.ts` (EDIT)
+
+**Analog:** self — lines 87 and 127 are the two edit sites.
+
+**Current unpinFile** (line 87):
+
+```typescript
+const response = await fetch(`${this.apiUrl}/api/v0/pin/rm?arg=${cid}`, {
+  method: 'POST',
+});
+```
+
+**Current getFile** (line 127):
+
+```typescript
+const response = await fetch(`${this.apiUrl}/api/v0/cat?arg=${cid}`, {
+  method: 'POST',
+});
+```
+
+**Target pattern (URLSearchParams — D-04 preferred form):**
+
+```typescript
+// unpinFile (replace line 87):
+const params = new URLSearchParams({ arg: cid });
+const response = await fetch(`${this.apiUrl}/api/v0/pin/rm?${params}`, { method: 'POST' });
+
+// getFile (replace line 127):
+const params = new URLSearchParams({ arg: cid });
+const response = await fetch(`${this.apiUrl}/api/v0/cat?${params}`, { method: 'POST' });
+```
+
+**pin/add (line 49):** No CID interpolated into the URL — CID comes from the Kubo response body. No change needed.
+
+**Existing spec assertions** (local.provider.spec.ts lines ~158 and ~222): They use `toBe(\`${API_URL}/api/v0/pin/rm?arg=${mockCid}\`)`. `URLSearchParams` produces the same string for valid CIDs (no reserved chars), so existing assertions still pass. A new test for encoding is desirable but not required to pass the suite.
+
+---
+
+### `apps/api/src/ipfs/providers/ipfs-provider.module.ts` (NEW — leaf module)
+
+**Analog:** `apps/api/src/tee/tee.module.ts` (leaf module importing `ConfigModule`, exporting services)
+
+**TeeModule structure** (tee.module.ts lines 1-16):
+
+```typescript
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+// ...
+@Module({
+  imports: [TypeOrmModule.forFeature([...]), ConfigModule],
+  providers: [...],
+  exports: [...],
+})
+export class TeeModule {}
+```
+
+**Target `ipfs-provider.module.ts`** — follows same leaf-module pattern, imports only `ConfigModule`:
+
+```typescript
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { IPFS_PROVIDER } from './ipfs-provider.interface';
+import { LocalProvider } from './local.provider';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [
+    {
+      provide: IPFS_PROVIDER,
+      useFactory: (configService: ConfigService) => {
+        const apiUrl = configService.get<string>('IPFS_LOCAL_API_URL', 'http://localhost:5001');
+        const gatewayUrl = configService.get<string>(
+          'IPFS_LOCAL_GATEWAY_URL',
+          'http://localhost:8080'
+        );
+        return new LocalProvider(apiUrl, gatewayUrl);
+      },
+      inject: [ConfigService],
+    },
+  ],
+  exports: [IPFS_PROVIDER],
+})
+export class IpfsProviderModule {}
+```
+
+**Key:** No `IpfsModule`, `VaultModule`, or `PendingUnpinModule` imports — leaf only imports `ConfigModule`.
+
+---
+
+### `apps/api/src/ipfs/providers/index.ts` (EDIT)
+
+**Current** (lines 1-2):
+
+```typescript
+export * from './ipfs-provider.interface';
+export * from './local.provider';
+```
+
+**Target** — add barrel export for the new module:
+
+```typescript
+export * from './ipfs-provider.interface';
+export * from './local.provider';
+export * from './ipfs-provider.module';
+```
+
+---
+
+### `apps/api/src/ipfs/ipfs.module.ts` (EDIT)
+
+**Analog:** self — remove inline factory, import `IpfsProviderModule`.
+
+**Current factory block** (lines 14-34):
+
+```typescript
+providers: [
+  {
+    // IN-04 (accepted): ... misleading comment ...
+    provide: IPFS_PROVIDER,
+    useFactory: (configService: ConfigService) => { ... },
+    inject: [ConfigService],
+  },
+],
+exports: [IPFS_PROVIDER],
+```
+
+**Target:**
+
+```typescript
+import { IpfsProviderModule } from './providers';
+
+// In forRootAsync() return:
+{
+  module: IpfsModule,
+  imports: [ConfigModule, VaultModule, IpfsProviderModule],
+  controllers: [IpfsController],
+  providers: [],
+  exports: [IPFS_PROVIDER],  // explicit re-export so IpfsController can inject the token
+}
+```
+
+Remove `ConfigService` and `LocalProvider` from imports if no longer used directly. Remove the IN-04 comment block.
+
+---
+
+### `apps/api/src/vault/vault.module.ts` (EDIT)
+
+**Current factory block** (lines 19-39):
+
+```typescript
+providers: [
+  VaultService,
+  // IN-04 (accepted): ... misleading comment ...
+  {
+    provide: IPFS_PROVIDER,
+    useFactory: (configService: ConfigService) => { ... },
+    inject: [ConfigService],
+  },
+],
+```
+
+**Target:**
+
+```typescript
+import { IpfsProviderModule } from '../ipfs/providers';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Vault, PinnedCid, FolderIpns, User, PendingUnpin]),
+    ConfigModule,
+    TeeModule,
+    IpfsProviderModule,
+  ],
+  controllers: [VaultController],
+  providers: [VaultService],
+  exports: [VaultService],
+})
+export class VaultModule {}
+```
+
+Remove `ConfigService` and `LocalProvider` named imports if no longer used. Remove IN-04 comment.
+
+---
+
+### `apps/api/src/ipfs/pending-unpin/pending-unpin.module.ts` (EDIT)
+
+**Current factory block** (lines 17-35):
+
+```typescript
+providers: [
+  PendingUnpinProcessor,
+  {
+    // IN-04 (accepted): ... misleading comment ...
+    provide: IPFS_PROVIDER,
+    useFactory: (configService: ConfigService) => { ... },
+    inject: [ConfigService],
+  },
+],
+```
+
+**Target:**
+
+```typescript
+import { IpfsProviderModule } from '../providers';
+
+@Module({
+  imports: [
+    BullModule.registerQueue({ name: 'pending-unpins' }),
+    TypeOrmModule.forFeature([PendingUnpin, PinnedCid]),
+    ConfigModule,
+    IpfsProviderModule,
+  ],
+  providers: [PendingUnpinProcessor],
+})
+export class PendingUnpinModule implements OnModuleInit { ... }
+```
+
+Remove `ConfigService` and `LocalProvider` named imports if no longer used. Remove IN-04 comment.
+
+---
+
+### `apps/api/src/ipfs/pending-unpin/unpin-helpers.ts` (NEW — utility)
+
+**Analog:** `apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts` lines 91-117 (the `drainRow` method — the pattern to extract from)
+
+**Advisory lock SQL to preserve verbatim** (pending-unpin.processor.ts line 95 and vault.service.ts line 267):
+
+```typescript
+// INT_MIN-safe: do NOT add abs() before ::bigint
+await manager.query(`SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`, [cid]);
+```
+
+**Target `unpin-helpers.ts`:**
+
+```typescript
+import { EntityManager } from 'typeorm';
+import { PendingUnpin } from '../../vault/entities/pending-unpin.entity';
+import { PinnedCid } from '../../vault/entities/pinned-cid.entity';
+import { IpfsProvider } from '../providers/ipfs-provider.interface';
+
+/**
+ * Acquires pg_advisory_xact_lock(hashtext(cid)::bigint) as the first
+ * transactional statement and runs fn inside the lock.
+ *
+ * INT_MIN-safe: hashtext returns int4; casting directly to bigint sign-extends
+ * the value rather than overflowing abs() on INT_MIN (-2147483648). DO NOT
+ * add abs() before the cast — that was the bug fixed in Phase 42/50.
+ */
+export async function withCidLock<T>(
+  manager: EntityManager,
+  cid: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  await manager.query(`SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`, [cid]);
+  return fn();
+}
+
+/**
+ * Under an already-held CID advisory lock: recheck refcount, unpin when zero,
+ * delete the outbox row.
+ *
+ * Must be called within a transaction that has already called withCidLock for
+ * the same CID. Use only for drainRow (Kubo inside lock). Do NOT use at the
+ * guardedUnpin post-commit site where Kubo must remain outside the transaction.
+ */
+export async function refcountAndMaybeUnpin(
+  manager: EntityManager,
+  cid: string,
+  ipfsProvider: IpfsProvider
+): Promise<void> {
+  const refs = await manager.getRepository(PinnedCid).count({ where: { cid } });
+  if (refs > 0) {
+    await manager.getRepository(PendingUnpin).delete({ cid });
+    return; // stale outbox row — CID is re-pinned
+  }
+  await ipfsProvider.unpinFile(cid);
+  await manager.getRepository(PendingUnpin).delete({ cid });
+}
+```
+
+**Post-commit site in vault.service.ts (lines 321-324):** Use `withCidLock` only — no `refcountAndMaybeUnpin`. The Kubo call (`ipfsProvider.unpinFile`) stays OUTSIDE the inner transaction (D-03 ordering):
+
+```typescript
+// Post-commit: Kubo call stays outside transaction (D-03)
+await this.ipfsProvider.unpinFile(cid);
+// Only the outbox-row delete is serialized under the lock:
+await this.dataSource.transaction(async (manager) => {
+  await withCidLock(manager, cid, async () => {
+    await manager.getRepository(PendingUnpin).delete({ cid });
+  });
+});
+```
+
+**drainRow in pending-unpin.processor.ts:** Use both helpers:
+
+```typescript
+private async drainRow(cid: string): Promise<void> {
+  await this.dataSource.transaction(async (manager) => {
+    await withCidLock(manager, cid, () =>
+      refcountAndMaybeUnpin(manager, cid, this.ipfsProvider)
+    );
+  });
+}
+```
+
+---
+
+### `apps/api/src/ipfs/dto/register-cid.dto.spec.ts` (NEW — test)
+
+**Analog:** `apps/api/src/ipfs/providers/local.provider.spec.ts` (no NestJS TestingModule; plain class instantiation + class-validator `validate()`)
+
+**local.provider.spec.ts structure** (lines 1-33):
+
+```typescript
+import { BadRequestException, ... } from '@nestjs/common';
+import { LocalProvider } from './local.provider';
+
+describe('LocalProvider', () => {
+  let provider: LocalProvider;
+  // ...
+  beforeEach(() => {
+    provider = new LocalProvider(API_URL, GATEWAY_URL);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should throw if ...', () => { ... });
+  });
+});
+```
+
+**Target spec pattern for DTOs** — use `class-validator`'s `validate()` instead of class instantiation:
+
+```typescript
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { RegisterCidDto } from './register-cid.dto';
+
+describe('RegisterCidDto', () => {
+  async function validateDto(plain: Partial<RegisterCidDto>) {
+    const dto = plainToInstance(RegisterCidDto, plain);
+    return validate(dto);
+  }
+
+  it('accepts a valid CIDv1', async () => {
+    const errors = await validateDto({ cid: 'bafkreigaknpexyvxt76zgkitavbwx6ejgfheup5oybpm77f3pxzrvwpfdi', sizeBytes: 100 });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects a CIDv0 with {44,} overflow (47 chars after Qm)', async () => { ... });
+
+  it('rejects strings longer than 255 chars', async () => { ... });
+});
+```
+
+---
+
+### `apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts` (NEW — test)
+
+**Analog:** `apps/api/src/ipfs/pending-unpin/pending-unpin.processor.spec.ts` (mock DataSource + manager pattern)
+
+**Mock manager pattern** (pending-unpin.processor.spec.ts lines 50-60):
+
+```typescript
+const mockManagerQuery = jest.fn().mockResolvedValue([]);
+const mockManager = {
+  query: mockManagerQuery,
+  getRepository: jest.fn((Entity: unknown) => {
+    if (Entity === PinnedCid) return mockPinnedCidRepository;
+    if (Entity === PendingUnpin) return mockPendingUnpinRepository;
+    return {};
+  }),
+};
+const mockDataSource = {
+  transaction: jest.fn(async (cb: (manager: unknown) => Promise<unknown>) => cb(mockManager)),
+};
+```
+
+**Target spec pattern** for `withCidLock` and `refcountAndMaybeUnpin` — use the same mock manager without the full NestJS TestingModule:
+
+```typescript
+import { withCidLock, refcountAndMaybeUnpin } from './unpin-helpers';
+import { PinnedCid } from '../../vault/entities/pinned-cid.entity';
+import { PendingUnpin } from '../../vault/entities/pending-unpin.entity';
+
+describe('withCidLock', () => {
+  it('executes pg_advisory_xact_lock SQL with the cid', async () => {
+    const mockQuery = jest.fn().mockResolvedValue([]);
+    const mockManager = { query: mockQuery, getRepository: jest.fn() } as any;
+    const fn = jest.fn().mockResolvedValue('result');
+
+    const result = await withCidLock(mockManager, 'bafk...', fn);
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      'SELECT pg_advisory_xact_lock(hashtext($1)::bigint)',
+      ['bafk...']
+    );
+    expect(fn).toHaveBeenCalled();
+    expect(result).toBe('result');
+  });
+});
+
+describe('refcountAndMaybeUnpin', () => {
+  it('skips unpin and deletes outbox row when refs > 0', async () => { ... });
+  it('calls unpinFile and deletes outbox row when refs === 0', async () => { ... });
+});
+```
+
+---
+
+### `apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts` (NEW — test)
+
+**Analog:** `apps/api/src/ipfs/ipfs.controller.spec.ts` (NestJS `Test.createTestingModule`)
+
+**NestJS TestingModule pattern** (from ipfs.controller.spec.ts):
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+
+describe('IpfsController', () => {
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [...],
+      controllers: [IpfsController],
+    }).compile();
+  });
+});
+```
+
+**Target spec** — compile `IpfsProviderModule` with a mock `ConfigService` and assert the token resolves:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { IpfsProviderModule } from './ipfs-provider.module';
+import { IPFS_PROVIDER } from './ipfs-provider.interface';
+
+describe('IpfsProviderModule', () => {
+  it('provides and exports IPFS_PROVIDER token', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: false }),
+        IpfsProviderModule,
+      ],
+    }).compile();
+
+    const provider = module.get(IPFS_PROVIDER);
+    expect(provider).toBeDefined();
+  });
+});
+```
+
+---
+
+## Shared Patterns
+
+### Advisory Lock SQL (INT_MIN-safe)
+
+**Source:** `apps/api/src/vault/vault.service.ts` line 267; `apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts` line 95
+**Apply to:** `unpin-helpers.ts` `withCidLock` body — verbatim, no modification
+
+```typescript
+await manager.query(`SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`, [cid]);
+```
+
+NEVER add `abs()` before `::bigint`. The cast sign-extends `int4` to `bigint` safely.
+
+### NestJS DTO Decorator Stack
+
+**Source:** `apps/api/src/ipfs/dto/unpin.dto.ts` lines 10-21
+**Apply to:** `register-cid.dto.ts` `cid` field
+
+```typescript
+@ApiProperty({ description: '...', pattern: '...', maxLength: 255 })
+@IsString()
+@IsNotEmpty()
+@MaxLength(255)
+@Matches(CID_REGEX, { message: 'cid must be a valid CIDv0 (Qm...) or CIDv1 (b...) string' })
+cid!: string;
+```
+
+### IPFS_PROVIDER Factory (canonical, deduplicated)
+
+**Source:** All three modules (`ipfs.module.ts` lines 21-31, `vault.module.ts` lines 29-38, `pending-unpin.module.ts` lines 25-35) — identical
+**Apply to:** `ipfs-provider.module.ts` `providers` array — single source of truth
+
+```typescript
+{
+  provide: IPFS_PROVIDER,
+  useFactory: (configService: ConfigService) => {
+    const apiUrl = configService.get<string>('IPFS_LOCAL_API_URL', 'http://localhost:5001');
+    const gatewayUrl = configService.get<string>(
+      'IPFS_LOCAL_GATEWAY_URL',
+      'http://localhost:8080'
+    );
+    return new LocalProvider(apiUrl, gatewayUrl);
+  },
+  inject: [ConfigService],
+}
+```
+
+### Mock Manager Pattern (Jest)
+
+**Source:** `apps/api/src/ipfs/pending-unpin/pending-unpin.processor.spec.ts` lines 50-60
+**Apply to:** `unpin-helpers.spec.ts` — same `mockManager` + `getRepository` dispatch shape
+
+```typescript
+const mockManagerQuery = jest.fn().mockResolvedValue([]);
+const mockManager = {
+  query: mockManagerQuery,
+  getRepository: jest.fn((Entity: unknown) => {
+    if (Entity === PinnedCid) return mockPinnedCidRepository;
+    if (Entity === PendingUnpin) return mockPendingUnpinRepository;
+    return {};
+  }),
+};
+```
+
+## No Analog Found
+
+None — all files have close analogs in the existing codebase.
+
+## Metadata
+
+**Analog search scope:** `apps/api/src/ipfs/`, `apps/api/src/vault/`, `apps/api/src/tee/`
+**Files scanned:** 14
+**Pattern extraction date:** 2026-06-22

--- a/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-RESEARCH.md
+++ b/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-RESEARCH.md
@@ -1,0 +1,568 @@
+# Phase 57: API CID and Provider Hardening and Module Dedup - Research
+
+**Researched:** 2026-06-22
+**Domain:** NestJS API — DTO validation, IPFS provider URL construction, NestJS module architecture, TypeORM advisory locks
+**Confidence:** HIGH
+
+<user_constraints>
+
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+- **D-01:** Extract the existing `UnpinDto` regex into a single shared constant and apply it — plus `@MaxLength(255)` — to `RegisterCidDto.cid`. Change CIDv0 branch `{44,}` to `{44}`.
+- **D-02:** The CIDv1 branch (`b[a-z2-7]{58,}`, open length, capped by `@MaxLength(255)`) MUST stay. Do not collapse to CIDv0-only.
+- **D-03:** Keep the regex approach via `class-validator` `@Matches`. Do NOT introduce a `multiformats`-based `@IsCid()` validator.
+- **D-04:** In `LocalProvider`, encode every CID interpolated into a Kubo query string — `pin/rm?arg=`, the symmetric `pin/add` path (the `/api/v0/add` path does NOT interpolate CID into the URL — the CID is in the response), and `cat?arg=`. Use `URLSearchParams` (preferred) or `encodeURIComponent`.
+- **D-05:** Extract a leaf `IpfsProviderModule` — `@Module({ imports: [ConfigModule], providers: [IPFS_PROVIDER], exports: [IPFS_PROVIDER] })`. Import it from `IpfsModule`, `VaultModule`, and `PendingUnpinModule`; remove the three duplicated factory definitions.
+- **D-06:** Delete/correct the misleading IN-04 "accepted circular-dependency" comments in all three modules.
+- **D-07:** Extract `withCidLock(cid, fn)` and `refcountAndMaybeUnpin(manager, cid)` shared primitives. Route all three advisory-lock unpin sites through them.
+- **D-08 (api:generate):** Run `pnpm api:generate` and commit the regenerated client iff the `RegisterCidDto` change alters the OpenAPI spec.
+
+### Claude's Discretion
+
+- File placement of the shared `CID_REGEX` constant (e.g. `apps/api/src/ipfs/dto/cid.constants.ts` or under `ipfs/`).
+- File placement of `withCidLock`/`refcountAndMaybeUnpin` helpers (a shared location both `vault.service.ts` and `pending-unpin.processor.ts` import).
+- `URLSearchParams` vs `encodeURIComponent` exact form.
+
+### Deferred Ideas (OUT OF SCOPE)
+
+- Phase 58 todos (`2026-06-20-ipns-publish-validate-embedded-sequence-without-cas.md`, `2026-06-20-ipns-resolve-verify-coverage-and-web-sdk-dedup.md`)
+- `2026-06-20-cargo-lock-sync-precise-vs-workspace.md`
+
+</user_constraints>
+
+<phase_requirements>
+
+## Phase Requirements
+
+| ID      | Description                                                                                   | Research Support                                                                                                               |
+| ------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| HARD-08 | API CID/provider hardening — shared CID regex + MaxLength, URL-encoded LocalProvider pin/cat URLs, leaf IpfsProviderModule, shared withCidLock/refcountAndMaybeUnpin | All four sub-tasks researched; exact edit sites, advisory-lock SQL, and OpenAPI impact confirmed from source |
+
+</phase_requirements>
+
+## Summary
+
+Phase 57 is a pure consolidation/hardening pass across four deferred findings from the Phase 50 review: (1) make `RegisterCidDto` CID validation match `UnpinDto` exactly; (2) URL-encode CID interpolations in `LocalProvider`; (3) extract a leaf `IpfsProviderModule` to eliminate the triplicated factory; (4) extract shared `withCidLock`/`refcountAndMaybeUnpin` helpers to deduplicate the three advisory-lock unpin sites.
+
+No new capabilities are added. Every change consolidates existing mechanisms. The CID regex is already correct in `unpin.dto.ts:7` — the task is extraction and application. The advisory lock SQL is already correct in all three sites — the task is consolidation so future drift requires editing one place.
+
+The only integration-touching step is D-08: adding `@MaxLength(255)` to `RegisterCidDto.cid` WILL add a `maxLength` field to the `RegisterCidDto` schema in `openapi.json`. The current `openapi.json` shows `RegisterCidDto` has no `maxLength` on its `cid` property (confirmed from source) while `UnpinDto` already emits `"maxLength": 255`. Therefore `pnpm api:generate` IS required after the DTO change.
+
+**Primary recommendation:** Execute 57-01 (data-integrity, TDD-eligible) and 57-02 (module dedup) as parallel Wave-1 plans. Both touch disjoint file sets. No environment dependencies beyond a working Node.js/NestJS/Jest setup.
+
+## Architectural Responsibility Map
+
+| Capability              | Primary Tier  | Secondary Tier | Rationale                                              |
+| ----------------------- | ------------- | -------------- | ------------------------------------------------------ |
+| CID input validation    | API / Backend | —              | DTO class-validators fire at the NestJS route boundary |
+| URL construction safety | API / Backend | —              | Provider layer; Kubo is an external dependency         |
+| Module wiring           | API / Backend | —              | NestJS DI; affects only the server module graph        |
+| Unpin primitive         | API / Backend | Database       | Advisory lock requires a PG transaction context        |
+
+## Standard Stack
+
+### Core (already installed — no new packages)
+
+| Library          | Version (in use) | Purpose                                        |
+| ---------------- | ---------------- | ---------------------------------------------- |
+| `class-validator` | `^0.14.x`       | `@Matches`, `@MaxLength`, `@IsString` on DTOs  |
+| `@nestjs/common` | `^10.x`          | `@Module`, `@Injectable`, DI tokens            |
+| `@nestjs/config` | `^3.x`           | `ConfigService` for `IPFS_LOCAL_API_URL`       |
+| `typeorm`        | `^0.3.x`         | `DataSource`, `EntityManager` for advisory lock |
+
+No new packages are required. All tools are already in the project.
+
+### Installation
+
+```bash
+# No new packages — phase uses existing deps only
+```
+
+## Package Legitimacy Audit
+
+No new packages are installed in this phase. Section not applicable.
+
+## Architecture Patterns
+
+### System Architecture Diagram
+
+```
+HTTP Request
+     |
+     v
+IpfsController / VaultController / RegisterCidController
+     |
+     v
+DTO Validation (class-validator @Matches CID_REGEX + @MaxLength(255))
+     |                                 ^
+     |                           [shared constant from cid.constants.ts]
+     v
+VaultService.guardedUnpin() / PendingUnpinProcessor.drainRow()
+     |
+     v
+[withCidLock(cid, fn)]  ←  shared helper
+  acquires pg_advisory_xact_lock(hashtext($1)::bigint)
+     |
+     v
+[refcountAndMaybeUnpin(manager, cid)]  ←  shared helper
+  recheck pinned_cids count → conditional unpin → delete outbox row
+     |
+     v
+LocalProvider.unpinFile(cid) / .getFile(cid)
+  fetch(`${apiUrl}/api/v0/pin/rm?arg=${encodeURIComponent(cid)}`)
+  fetch(`${apiUrl}/api/v0/cat?arg=${encodeURIComponent(cid)}`)
+     |
+     v
+Kubo HTTP API
+```
+
+### Recommended Project Structure (additions only)
+
+```
+apps/api/src/
+├── ipfs/
+│   ├── dto/
+│   │   ├── cid.constants.ts      # NEW: exports CID_REGEX shared constant
+│   │   ├── unpin.dto.ts          # EDIT: import CID_REGEX from cid.constants
+│   │   └── register-cid.dto.ts   # EDIT: import CID_REGEX + add @MaxLength(255)
+│   ├── providers/
+│   │   ├── ipfs-provider.module.ts  # NEW: leaf IpfsProviderModule
+│   │   ├── local.provider.ts        # EDIT: URLSearchParams on pin/rm + cat
+│   │   └── index.ts                 # EDIT: export IpfsProviderModule
+│   ├── ipfs.module.ts            # EDIT: remove factory, import IpfsProviderModule
+│   └── pending-unpin/
+│       ├── pending-unpin.module.ts  # EDIT: remove factory, import IpfsProviderModule
+│       └── unpin-helpers.ts         # NEW: withCidLock + refcountAndMaybeUnpin
+└── vault/
+    ├── vault.module.ts           # EDIT: remove factory, import IpfsProviderModule
+    └── vault.service.ts          # EDIT: route guardedUnpin through shared helpers
+```
+
+### Pattern 1: Shared CID_REGEX Constant (D-01..D-03)
+
+**What:** Extract the regex from `UnpinDto` into `cid.constants.ts`, import it in both DTOs.
+
+**Current state (verified from source):**
+
+- `unpin.dto.ts:7`: `const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$/;` — correct, local-only
+- `register-cid.dto.ts:11`: `@Matches(/^(Qm[1-9A-HJ-NP-Za-km-z]{44,}|b[a-z2-7]{58,})$/, ...)` — inline, `{44,}` instead of `{44}`, no `@MaxLength`
+
+**Target `cid.constants.ts`:**
+
+```typescript
+// Source: existing UnpinDto regex (unpin.dto.ts:7) — IN-02 pattern
+// CIDv0: Qm + 44 base58btc chars = 46 chars total (fixed length)
+// CIDv1: b + 58+ base32 chars (open length, capped by @MaxLength(255))
+export const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$/;
+```
+
+**Target `register-cid.dto.ts` additions:**
+
+```typescript
+import { CID_REGEX } from './cid.constants';
+// add @MaxLength(255) import
+@MaxLength(255)
+@Matches(CID_REGEX, { message: 'cid must be a valid CIDv0 (Qm...) or CIDv1 (b...) string' })
+cid!: string;
+```
+
+**Target `unpin.dto.ts` change:** Remove the local `const CID_REGEX` declaration, import from `cid.constants.ts`.
+
+### Pattern 2: URL-Encoded CID in LocalProvider (D-04)
+
+**What:** Replace raw string interpolation with `URLSearchParams` for CID query params.
+
+**Current unpin (line 87):** `fetch(\`${this.apiUrl}/api/v0/pin/rm?arg=${cid}\`, ...)`
+**Current cat (line 127):** `fetch(\`${this.apiUrl}/api/v0/cat?arg=${cid}\`, ...)`
+**pin/add (line 49):** `fetch(\`${this.apiUrl}/api/v0/add?pin=true&cid-version=1\`, ...)` — no CID in URL (CID comes from Kubo response), no change needed here.
+
+**Target pattern (URLSearchParams preferred per D-04):**
+
+```typescript
+// unpinFile
+const params = new URLSearchParams({ arg: cid });
+const response = await fetch(`${this.apiUrl}/api/v0/pin/rm?${params}`, { method: 'POST' });
+
+// getFile
+const params = new URLSearchParams({ arg: cid });
+const response = await fetch(`${this.apiUrl}/api/v0/cat?${params}`, { method: 'POST' });
+```
+
+**Test impact:** `local.provider.spec.ts:158` asserts `expect(url).toBe(\`${API_URL}/api/v0/pin/rm?arg=${mockCid}\`)` and line 222 asserts `expect(url).toBe(\`${API_URL}/api/v0/cat?arg=${mockCid}\`)`. These assertions check the exact URL string. With `URLSearchParams`, the URL becomes `pin/rm?arg=bafk...` which is identical for valid CIDs (no special chars to encode), so the assertions still pass for the existing CID fixture. However, a new test should verify that a CID containing `%` or `&` is correctly encoded. In practice, a cleaner approach is `encodeURIComponent(cid)` which produces identical output for normal CIDs and makes the intent explicit, with no assertion changes needed.
+
+### Pattern 3: Leaf IpfsProviderModule (D-05, D-06)
+
+**What:** New `@Module` that owns the `IPFS_PROVIDER` factory; imported by the three consumer modules.
+
+**Key fact (confirmed from source):** `IPFS_PROVIDER` token is declared in `ipfs-provider.interface.ts:7`. The `IpfsProviderModule` should live in `apps/api/src/ipfs/providers/ipfs-provider.module.ts` and be exported from `apps/api/src/ipfs/providers/index.ts`.
+
+**The real cycle:** `IpfsModule` imports `VaultModule` (to access `VaultService` for the controller). `VaultModule` exports `VaultService`. There is no cycle once `IPFS_PROVIDER` moves to a leaf module — `IpfsProviderModule` only imports `ConfigModule` (a leaf with no upstream deps).
+
+**Target `ipfs-provider.module.ts`:**
+
+```typescript
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { IPFS_PROVIDER } from './ipfs-provider.interface';
+import { LocalProvider } from './local.provider';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [
+    {
+      provide: IPFS_PROVIDER,
+      useFactory: (configService: ConfigService) => {
+        const apiUrl = configService.get<string>('IPFS_LOCAL_API_URL', 'http://localhost:5001');
+        const gatewayUrl = configService.get<string>(
+          'IPFS_LOCAL_GATEWAY_URL',
+          'http://localhost:8080'
+        );
+        return new LocalProvider(apiUrl, gatewayUrl);
+      },
+      inject: [ConfigService],
+    },
+  ],
+  exports: [IPFS_PROVIDER],
+})
+export class IpfsProviderModule {}
+```
+
+**Consumer modules:** Each of `IpfsModule.forRootAsync()`, `VaultModule`, and `PendingUnpinModule` removes the inline factory block and adds `IpfsProviderModule` to its `imports` array.
+
+**Note on `IpfsModule.forRootAsync()`:** The dynamic module returns an object with `imports`, `providers`, etc. After the change, `IPFS_PROVIDER` leaves `providers` (the factory moves to `IpfsProviderModule`) but `IpfsModule` still needs to re-export it. Add `IpfsProviderModule` (or just `IPFS_PROVIDER` via `exports`) so the controller can still inject it. Easiest: keep `exports: [IPFS_PROVIDER]` in the returned DynamicModule, and put `IpfsProviderModule` in `imports`. NestJS resolves the token from the imported module.
+
+### Pattern 4: Shared Unpin Primitives (D-07)
+
+**What:** Two helper functions extracted to a shared file, routing all three advisory-lock sites.
+
+**Three sites confirmed (from source):**
+
+1. `vault.service.ts:267` — main transaction: `SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`
+2. `vault.service.ts:322` — post-commit delete transaction: same lock SQL
+3. `pending-unpin.processor.ts:95` — drain transaction: same lock SQL
+
+**INT_MIN-safe key derivation (exact SQL, verbatim — must not change):**
+
+```sql
+SELECT pg_advisory_xact_lock(hashtext($1)::bigint)
+```
+
+The comment in `vault.service.ts:265-266` explains: `abs()` was previously applied to int4 before the bigint cast, which overflowed for INT_MIN (-2147483648). The fix is the bare `hashtext($1)::bigint` sign-extending cast — no `abs()`. This SQL must be preserved verbatim in `withCidLock`.
+
+**Placement:** `apps/api/src/ipfs/pending-unpin/unpin-helpers.ts` is the most natural location because both unpin sites (`vault.service.ts` and `pending-unpin.processor.ts`) are downstream of the pending-unpin subsystem. Alternatively, `apps/api/src/ipfs/unpin-helpers.ts` (one level up) avoids the pending-unpin subdirectory being a shared-util owner. Both work; the planner should pick one and document it.
+
+**Target signatures:**
+
+```typescript
+import { EntityManager, Repository } from 'typeorm';
+import { PendingUnpin } from '../../vault/entities/pending-unpin.entity';
+import { PinnedCid } from '../../vault/entities/pinned-cid.entity';
+import { IpfsProvider } from '../providers';
+
+/**
+ * Acquires pg_advisory_xact_lock(hashtext(cid)::bigint) as the first
+ * transactional statement and runs fn inside the lock.
+ *
+ * INT_MIN-safe: hashtext returns int4; casting directly to bigint sign-extends
+ * the value rather than overflowing abs() on INT_MIN (-2147483648). DO NOT
+ * add abs() before the cast — that was the bug fixed in Phase 42/50.
+ */
+export async function withCidLock<T>(
+  manager: EntityManager,
+  cid: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  await manager.query(`SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`, [cid]);
+  return fn();
+}
+
+/**
+ * Under an already-held CID advisory lock: recheck refcount, unpin when zero,
+ * delete the outbox row.
+ *
+ * Must be called within a transaction that has already called withCidLock for
+ * the same CID.
+ */
+export async function refcountAndMaybeUnpin(
+  manager: EntityManager,
+  cid: string,
+  ipfsProvider: IpfsProvider
+): Promise<void> {
+  const refs = await manager.getRepository(PinnedCid).count({ where: { cid } });
+  if (refs > 0) {
+    await manager.getRepository(PendingUnpin).delete({ cid });
+    return; // stale outbox row — CID is re-pinned
+  }
+  await ipfsProvider.unpinFile(cid);
+  await manager.getRepository(PendingUnpin).delete({ cid });
+}
+```
+
+**CAUTION — `guardedUnpin` post-commit site (vault.service.ts:319-327):** This site is NOT inside a drainRow-style "one big transaction." The existing code structure is:
+1. Main transaction acquires lock → ownership check → delete pinned_cids → maybe insert outbox → sets `shouldAttemptPhysicalUnpin = true`
+2. Post-commit: `await ipfsProvider.unpinFile(cid)` (outside any transaction)
+3. Then `await this.dataSource.transaction(async (manager) => { ... lock ... delete outbox row ... })`
+
+The `refcountAndMaybeUnpin` helper as sketched above calls `ipfsProvider.unpinFile` inside a transaction. The post-commit site calls Kubo OUTSIDE a transaction for D-03 ordering (Pitfall 3). The helper must NOT be used verbatim for the post-commit site unless the Kubo call is kept outside. The planner needs to decide: either the helper only handles the "recheck + delete outbox" part (with the Kubo call remaining inline at the post-commit site), or the helper has a `skipUnpin: boolean` parameter. The simplest approach: `refcountAndMaybeUnpin` as above covers `drainRow` (where Kubo runs inside the lock), and `withCidLock` alone covers the post-commit delete site (which does only the lock + outbox delete, not a refcount-recheck unpin). See Open Questions.
+
+### Anti-Patterns to Avoid
+
+- **Calling `abs()` on the hashtext value before casting to bigint:** The old bug. The SQL must stay as `hashtext($1)::bigint` with no `abs()`.
+- **Importing `VaultModule` or `IpfsModule` from `IpfsProviderModule`:** The leaf module must only import `ConfigModule`. Any upstream import creates the very cycle the comments claimed (incorrectly) to avoid.
+- **Putting the Kubo `unpinFile()` call inside a long-held advisory lock transaction in the post-commit path:** D-03 requires the Kubo call to stay outside any transaction (post-commit, best-effort). The lock in the post-commit path (site 2 in vault.service) guards only the outbox-row delete.
+
+## Don't Hand-Roll
+
+| Problem                  | Don't Build               | Use Instead                            | Why                                                                              |
+| ------------------------ | ------------------------- | -------------------------------------- | -------------------------------------------------------------------------------- |
+| CID format validation    | New `@IsCid()` decorator  | Shared `CID_REGEX` + `@Matches` (D-03) | `multiformats` is over-engineering for a consistency pass; regex already correct  |
+| URL parameter encoding   | Manual `replace()`        | `URLSearchParams` or `encodeURIComponent` | Platform-correct encoding; handles all reserved chars                            |
+| Advisory lock management | New PG locking mechanism  | Existing `hashtext($1)::bigint` SQL    | Mechanism already correct and tested; consolidation, not replacement              |
+
+## Common Pitfalls
+
+### Pitfall 1: `local.provider.spec.ts` URL assertions break after URLSearchParams
+
+**What goes wrong:** Line 158 of `local.provider.spec.ts` asserts `expect(url).toBe(\`${API_URL}/api/v0/pin/rm?arg=${mockCid}\`)`. With `URLSearchParams`, the URL is `pin/rm?arg=bafk...` — identical for the valid CID fixture, so tests pass. But if a test is added with a CID containing `+` or `=`, `URLSearchParams` encodes them while a raw string does not.
+
+**How to avoid:** Update the assertions to use `expect(url).toContain('pin/rm')` plus separate assertion on the params, OR keep the existing `toBe` assertions (they still pass for standard CIDs) and add a new test for special-char encoding.
+
+### Pitfall 2: `IpfsModule.forRootAsync()` stops exporting `IPFS_PROVIDER` after refactor
+
+**What goes wrong:** `IpfsController` injects `IPFS_PROVIDER`. If `IpfsModule` removes the factory from its providers but does not export `IPFS_PROVIDER` (via `IpfsProviderModule`), the controller can't resolve the token.
+
+**How to avoid:** Keep `exports: [IPFS_PROVIDER]` in the `DynamicModule` return value of `IpfsModule.forRootAsync()`, and add `IpfsProviderModule` to the `imports` array. NestJS re-exports provider tokens from imported modules when they appear in `exports`.
+
+### Pitfall 3: `refcountAndMaybeUnpin` used at post-commit delete site puts Kubo inside a transaction
+
+**What goes wrong:** The `drainRow` helper and the `guardedUnpin` post-commit delete have different Kubo-call positions (inside vs. outside a transaction). A naive extraction that always calls `ipfsProvider.unpinFile` inside the transaction violates D-03 for the post-commit site.
+
+**How to avoid:** The helper as designed (calling Kubo then deleting outbox row) is correct for `drainRow`. For the post-commit site in `guardedUnpin`, only `withCidLock` wraps the outbox-row delete; the Kubo call stays in the outer scope (outside the inner transaction). See Open Questions for the design choice.
+
+### Pitfall 4: Forgetting `pnpm api:generate` after `@MaxLength(255)` on `RegisterCidDto`
+
+**What goes wrong:** `check-api-client.sh` detects `.dto.ts` staged without `openapi.json` staged and fails the pre-commit hook.
+
+**How to avoid:** After committing the DTO change, run `pnpm api:generate` and stage the regenerated `packages/api-client/openapi.json` and client files before the next commit.
+
+### Pitfall 5: `abs()` regression in `withCidLock`
+
+**What goes wrong:** Re-introducing `abs(hashtext($1)::int4)::bigint` causes overflow for INT_MIN CID hashes, allowing concurrent unpin for the same CID.
+
+**How to avoid:** The SQL is `SELECT pg_advisory_xact_lock(hashtext($1)::bigint)` — the `::bigint` cast is applied directly to the `int4` result, sign-extending rather than overflowing. Copy verbatim from `vault.service.ts:267`.
+
+## Code Examples
+
+### Current advisory lock SQL (verified from vault.service.ts:267 and pending-unpin.processor.ts:95)
+
+```typescript
+// INT_MIN-safe: do NOT add abs() before ::bigint
+await manager.query(`SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`, [cid]);
+```
+
+### Current CID_REGEX in unpin.dto.ts:7 (the reference, verified from source)
+
+```typescript
+const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$/;
+```
+
+### Current RegisterCidDto divergence (verified from register-cid.dto.ts:11)
+
+```typescript
+// BEFORE (loose):
+@Matches(/^(Qm[1-9A-HJ-NP-Za-km-z]{44,}|b[a-z2-7]{58,})$/, { ... })
+cid!: string;
+// Missing: @MaxLength(255)
+
+// AFTER (aligned with UnpinDto):
+@MaxLength(255)
+@Matches(CID_REGEX, { message: 'cid must be a valid CIDv0 (Qm...) or CIDv1 (b...) string' })
+cid!: string;
+```
+
+### Current URL construction (verified from local.provider.ts:87,127)
+
+```typescript
+// BEFORE — unpin (line 87):
+const response = await fetch(`${this.apiUrl}/api/v0/pin/rm?arg=${cid}`, { method: 'POST' });
+
+// BEFORE — cat (line 127):
+const response = await fetch(`${this.apiUrl}/api/v0/cat?arg=${cid}`, { method: 'POST' });
+
+// AFTER (URLSearchParams):
+const params = new URLSearchParams({ arg: cid });
+const response = await fetch(`${this.apiUrl}/api/v0/pin/rm?${params}`, { method: 'POST' });
+```
+
+### Current IPFS_PROVIDER factory (identical in all 3 modules, verified from source)
+
+```typescript
+{
+  provide: IPFS_PROVIDER,
+  useFactory: (configService: ConfigService) => {
+    const apiUrl = configService.get<string>('IPFS_LOCAL_API_URL', 'http://localhost:5001');
+    const gatewayUrl = configService.get<string>(
+      'IPFS_LOCAL_GATEWAY_URL',
+      'http://localhost:8080'
+    );
+    return new LocalProvider(apiUrl, gatewayUrl);
+  },
+  inject: [ConfigService],
+},
+```
+
+## State of the Art
+
+| Old Approach                                           | Current Approach                                      | When Changed        | Impact                                              |
+| ------------------------------------------------------ | ----------------------------------------------------- | ------------------- | --------------------------------------------------- |
+| `abs(hashtext($1)::int4)::bigint` (overflow on INT_MIN) | `hashtext($1)::bigint` (sign-extend, safe)           | Phase 42/50         | No overflow for INT_MIN hashes                      |
+| Drain ran refcount recheck without advisory lock        | Drain runs inside advisory lock transaction           | Phase 50 (WR-01 fix) | Serializes drain vs guardedUnpin per CID           |
+| Post-commit outbox delete outside advisory lock         | Post-commit delete inside its own advisory lock txn  | Phase 50 (WR-03 fix) | Prevents racing guardedUnpin removing the retry row |
+
+## OpenAPI Impact Analysis (D-08)
+
+**Confirmed from openapi.json (lines 2646-2659):** `RegisterCidDto` currently has NO `maxLength` on its `cid` property. The current schema is:
+
+```json
+"RegisterCidDto": {
+  "type": "object",
+  "properties": {
+    "cid": { "type": "string", "description": "IPFS CID pinned to external provider (CIDv0 or CIDv1)" },
+    "sizeBytes": { "type": "number", "description": "Size of the pinned content in bytes" }
+  },
+  "required": ["cid", "sizeBytes"]
+}
+```
+
+After adding `@MaxLength(255)`, NestJS/Swagger will emit `"maxLength": 255` on the `cid` property (confirmed from the `UnpinDto` pattern at openapi.json line 2630, which shows `"maxLength": 255` is emitted for `@MaxLength`-decorated fields with the `@ApiProperty` decorator). Adding `@ApiProperty` with `maxLength` metadata is also needed for the spec to reflect it correctly.
+
+**Therefore: D-08 is triggered. `pnpm api:generate` MUST run after the DTO change.** This is an execute-phase step, not a planning step.
+
+## Existing Test Coverage Map
+
+| File                                   | Test file                                  | Pattern                           |
+| -------------------------------------- | ------------------------------------------ | --------------------------------- |
+| `local.provider.ts`                    | `local.provider.spec.ts`                  | Jest, mocks `global.fetch`         |
+| `vault.service.ts`                     | `vault.service.spec.ts`                   | Jest, mock DataSource/repos        |
+| `pending-unpin.processor.ts`           | `pending-unpin.processor.spec.ts`         | Jest, mock DataSource/repos        |
+| `unpin.dto.ts` / `register-cid.dto.ts` | None (DTOs excluded from coverage config) | TDD: new spec file needed          |
+
+**Jest config details (confirmed from `apps/api/jest.config.js`):**
+
+- Test regex: `.*\.spec\.ts$` (spec files only, not `.test.ts`)
+- rootDir: `apps/api/src`
+- Runner: `pnpm --filter @cipherbox/api test` or `cd apps/api && npx jest`
+- Coverage excluded: `**/*.module.ts`, `**/index.ts`, `**/dto/**`, `**/entities/**`
+- Per-file thresholds: `local.provider.ts` (lines: 85, branches: 80), `vault/vault.service.ts` (lines: 90, branches: 77)
+
+**DTOs are excluded from coverage** (`!**/dto/**` in collectCoverageFrom). Spec files for DTO validation still run and count toward global coverage but DTO source lines are not counted in coverage metrics. TDD for the DTO is still correct and desirable.
+
+## Validation Architecture
+
+### Test Framework
+
+| Property           | Value                                      |
+| ------------------ | ------------------------------------------ |
+| Framework          | Jest 29 + ts-jest                          |
+| Config file        | `apps/api/jest.config.js`                  |
+| Quick run command  | `pnpm --filter @cipherbox/api test -- --testPathPattern=ipfs`  |
+| Full suite command | `pnpm --filter @cipherbox/api test`        |
+
+### Phase Requirements → Test Map
+
+| Req ID  | Behavior                                              | Test Type   | Automated Command                                                                                       | File Exists?         |
+| ------- | ----------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------- | -------------------- |
+| HARD-08 | `RegisterCidDto` rejects CIDv0 `{44,}` > 46 chars    | unit        | `pnpm --filter @cipherbox/api test -- --testPathPattern=register-cid`                                  | ❌ Wave 0 (new spec)  |
+| HARD-08 | `RegisterCidDto` rejects strings > 255 chars          | unit        | `pnpm --filter @cipherbox/api test -- --testPathPattern=register-cid`                                  | ❌ Wave 0 (new spec)  |
+| HARD-08 | `RegisterCidDto` accepts valid CIDv1 `bafk...`        | unit        | `pnpm --filter @cipherbox/api test -- --testPathPattern=register-cid`                                  | ❌ Wave 0 (new spec)  |
+| HARD-08 | `LocalProvider.unpinFile` uses `arg=` query param safely | unit     | `pnpm --filter @cipherbox/api test -- --testPathPattern=local.provider`                                | ✅ (update existing)  |
+| HARD-08 | `LocalProvider.getFile` uses `arg=` query param safely   | unit     | `pnpm --filter @cipherbox/api test -- --testPathPattern=local.provider`                                | ✅ (update existing)  |
+| HARD-08 | `withCidLock` executes `pg_advisory_xact_lock` SQL    | unit        | `pnpm --filter @cipherbox/api test -- --testPathPattern=unpin-helpers`                                 | ❌ Wave 0 (new spec)  |
+| HARD-08 | `refcountAndMaybeUnpin` skips unpin when refs > 0     | unit        | `pnpm --filter @cipherbox/api test -- --testPathPattern=unpin-helpers`                                 | ❌ Wave 0 (new spec)  |
+| HARD-08 | `IpfsProviderModule` provides `IPFS_PROVIDER` token   | unit        | `pnpm --filter @cipherbox/api test -- --testPathPattern=ipfs-provider.module`                          | ❌ Wave 0 (new spec)  |
+| HARD-08 | Full api suite green                                  | regression  | `pnpm --filter @cipherbox/api test`                                                                     | ✅ (existing suite)   |
+
+### Sampling Rate
+
+- **Per task commit:** `pnpm --filter @cipherbox/api test -- --testPathPattern=<changed-module> --passWithNoTests`
+- **Per wave merge:** `pnpm --filter @cipherbox/api test`
+- **Phase gate:** Full api suite green + coverage thresholds met before `/gsd-verify-work`
+
+### Wave 0 Gaps
+
+- [ ] `apps/api/src/ipfs/dto/register-cid.dto.spec.ts` — validates D-01 regex tightening and D-01 `@MaxLength(255)` (TDD candidate)
+- [ ] `apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts` — validates `withCidLock` SQL and `refcountAndMaybeUnpin` refcount branching (TDD candidate)
+- [ ] `apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts` — validates `IpfsProviderModule` provides and exports `IPFS_PROVIDER` (can be simple NestJS testing module compile test)
+
+## Security Domain
+
+### Applicable ASVS Categories
+
+| ASVS Category       | Applies | Standard Control                          |
+| ------------------- | ------- | ----------------------------------------- |
+| V2 Authentication   | no      | —                                         |
+| V3 Session Management | no    | —                                         |
+| V4 Access Control   | no      | —                                         |
+| V5 Input Validation | yes     | `@Matches(CID_REGEX)` + `@MaxLength(255)` on all CID-accepting DTOs |
+| V6 Cryptography     | no      | CID is a hash reference, not crypto key   |
+
+### Known Threat Patterns for this stack
+
+| Pattern                       | STRIDE     | Standard Mitigation                                 |
+| ----------------------------- | ---------- | --------------------------------------------------- |
+| Oversized input (DoS via long string) | DoS | `@MaxLength(255)` on all CID DTOs                  |
+| Query-string injection via CID | Tampering  | `URLSearchParams` / `encodeURIComponent` at provider boundary |
+| CIDv0 length spoofing (accept 47+ char Qm strings) | Tampering | `{44}` exact in CIDv0 branch of regex |
+
+## Assumptions Log
+
+| #  | Claim                                                                                     | Section                | Risk if Wrong                               |
+| -- | ----------------------------------------------------------------------------------------- | ---------------------- | ------------------------------------------- |
+| A1 | `pnpm api:generate` uses Swagger/OpenAPI CLI that picks up `@MaxLength` from class-validator decorators automatically | OpenAPI Impact | api:generate step might not be needed if tooling doesn't reflect MaxLength |
+
+**Verification path for A1:** Confirmed by analogy — `UnpinDto`'s `@MaxLength(255)` already appears as `"maxLength": 255` in the current `openapi.json` at line 2630. The pattern is established. Risk is LOW.
+
+## Open Questions
+
+1. **`refcountAndMaybeUnpin` at the post-commit site in `guardedUnpin`**
+   - What we know: The post-commit delete (vault.service.ts:319-327) uses a second transaction that only acquires the lock and deletes the outbox row. It does NOT recheck the refcount (the Kubo unpin already ran outside). The drain's `drainRow` DOES recheck + unpin inside a single transaction.
+   - What's unclear: Should `refcountAndMaybeUnpin` be used at the post-commit site? If so, the helper needs a `{ skipUnpin?: boolean }` option, or a separate helper (`deleteOutboxRow(manager, cid)`) is cleaner.
+   - Recommendation: Extract `withCidLock` as shared (used at all three sites) and extract `refcountAndMaybeUnpin` only for `drainRow` (where Kubo is inside the lock). The post-commit delete site uses only `withCidLock` + inline `manager.getRepository(PendingUnpin).delete({ cid })`. This keeps the post-commit path's D-03 ordering clear.
+
+2. **`IpfsModule.forRootAsync()` export of `IPFS_PROVIDER`**
+   - What we know: `IpfsController` is registered in `IpfsModule` and injects `IPFS_PROVIDER`. After the refactor, the token comes from `IpfsProviderModule` (imported by `IpfsModule`).
+   - What's unclear: Does NestJS automatically re-export provider tokens from imported modules, or must `IpfsModule` explicitly list `IPFS_PROVIDER` in its `exports`?
+   - Recommendation: Explicitly keep `exports: [IPFS_PROVIDER]` in `IpfsModule.forRootAsync()`. NestJS does allow exporting tokens from imported modules when they are explicitly re-exported, but implicit re-export is not guaranteed across all NestJS versions. The safe pattern is explicit.
+
+## Environment Availability
+
+Step 2.6: SKIPPED — this phase is code/config changes only. No external services (no Docker, no Kubo) are required for the unit tests. `pnpm api:generate` is an execute-phase step that requires the NestJS app to start; it is not a research concern.
+
+## Sources
+
+### Primary (HIGH confidence)
+
+- Verified directly from source files in the worktree — all claims about file/line content are confirmed via `Read` or `Bash grep`
+
+### Secondary (MEDIUM confidence)
+
+- NestJS module architecture patterns — confirmed from the existing codebase conventions (multiple modules already follow the `imports: [ConfigModule]` → `providers: [factory]` → `exports: [token]` pattern)
+
+### Tertiary (LOW confidence)
+
+- NestJS re-export behavior for tokens from imported modules — [ASSUMED] based on NestJS DI documentation conventions; the safe path (explicit export) is recommended regardless
+
+## Metadata
+
+**Confidence breakdown:**
+
+- Edit sites (exact lines): HIGH — read directly from source
+- Advisory lock SQL: HIGH — read directly from source (3 sites)
+- OpenAPI impact (maxLength): HIGH — confirmed by UnpinDto analogy in existing openapi.json
+- NestJS module re-export semantics: MEDIUM — based on established codebase pattern
+- `refcountAndMaybeUnpin` scope at post-commit site: MEDIUM — design choice, see Open Questions
+
+**Research date:** 2026-06-22
+**Valid until:** 2026-07-22 (stable NestJS/TypeORM conventions; no fast-moving dependencies)

--- a/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-RESEARCH.md
+++ b/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-RESEARCH.md
@@ -524,17 +524,19 @@ After adding `@MaxLength(255)`, NestJS/Swagger will emit `"maxLength": 255` on t
 
 **Verification path for A1:** Confirmed by analogy — `UnpinDto`'s `@MaxLength(255)` already appears as `"maxLength": 255` in the current `openapi.json` at line 2630. The pattern is established. Risk is LOW.
 
-## Open Questions
+## Open Questions (RESOLVED)
 
 1. **`refcountAndMaybeUnpin` at the post-commit site in `guardedUnpin`**
    - What we know: The post-commit delete (vault.service.ts:319-327) uses a second transaction that only acquires the lock and deletes the outbox row. It does NOT recheck the refcount (the Kubo unpin already ran outside). The drain's `drainRow` DOES recheck + unpin inside a single transaction.
    - What's unclear: Should `refcountAndMaybeUnpin` be used at the post-commit site? If so, the helper needs a `{ skipUnpin?: boolean }` option, or a separate helper (`deleteOutboxRow(manager, cid)`) is cleaner.
    - Recommendation: Extract `withCidLock` as shared (used at all three sites) and extract `refcountAndMaybeUnpin` only for `drainRow` (where Kubo is inside the lock). The post-commit delete site uses only `withCidLock` + inline `manager.getRepository(PendingUnpin).delete({ cid })`. This keeps the post-commit path's D-03 ordering clear.
+   - **RESOLVED (57-02 plan):** `refcountAndMaybeUnpin` is used ONLY at the `drainRow` site (`pending-unpin.processor.ts:95`). The `guardedUnpin` post-commit delete site (`vault.service.ts:319-327`) uses `withCidLock` alone with an inline outbox-row delete, keeping the Kubo unpin outside all transactions per D-03. No `skipUnpin` option is added.
 
 2. **`IpfsModule.forRootAsync()` export of `IPFS_PROVIDER`**
    - What we know: `IpfsController` is registered in `IpfsModule` and injects `IPFS_PROVIDER`. After the refactor, the token comes from `IpfsProviderModule` (imported by `IpfsModule`).
    - What's unclear: Does NestJS automatically re-export provider tokens from imported modules, or must `IpfsModule` explicitly list `IPFS_PROVIDER` in its `exports`?
    - Recommendation: Explicitly keep `exports: [IPFS_PROVIDER]` in `IpfsModule.forRootAsync()`. NestJS does allow exporting tokens from imported modules when they are explicitly re-exported, but implicit re-export is not guaranteed across all NestJS versions. The safe pattern is explicit.
+   - **RESOLVED (57-02 plan):** `IpfsModule` explicitly keeps `exports: [IPFS_PROVIDER]` after importing `IpfsProviderModule` — implicit re-export is not assumed. The `ipfs-provider.module.spec.ts` compile/provides-token test locks this invariant.
 
 ## Environment Availability
 

--- a/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-SECURITY.md
+++ b/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-SECURITY.md
@@ -1,0 +1,67 @@
+---
+phase: 57-api-cid-and-provider-hardening-and-module-dedup
+audited: 2026-06-22T00:00:00Z
+status: secured
+threats_verified: 9
+asvs_level: 2
+block_on: open
+---
+
+# Phase 57 Security Audit — API CID & Provider Hardening + Module Dedup
+
+Retroactive verification of the threat mitigations declared in `57-01-PLAN.md`
+and `57-02-PLAN.md`. Every `mitigate`-disposition threat was confirmed present
+in the implemented code by reading the cited file and running negative-case
+greps (no `abs(`, no inline advisory-lock SQL at the three sites, no raw
+`?arg=${cid}` interpolation, a single non-spec `provide: IPFS_PROVIDER`
+source). Implementation files were treated as read-only.
+
+## Verdict
+
+SECURED. All 8 distinct threats (T-57-SC is shared across both plans) resolve
+to CLOSED. No new unmitigated HIGH-severity issue was found.
+
+- Threats closed: 9/9 register entries (8 distinct IDs)
+- Open (BLOCKER): 0
+- Unregistered flags: 0
+
+## STRIDE Verification Table
+
+| Threat ID | Category | Component | Disposition | Verified | Evidence |
+| --------- | -------- | --------- | ----------- | -------- | -------- |
+| T-57-01 | Tampering | `RegisterCidDto.cid` loose `{44,}` regex, no MaxLength | mitigate | VERIFIED | `cid.constants.ts:4` exports `CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$/` (exact `{44}` CIDv0 branch); `register-cid.dto.ts:3` imports it, `:16` `@MaxLength(255)`, `:17` `@Matches(CID_REGEX, …)`. No inline `{44,}` literal remains (grep returns nothing). |
+| T-57-02 | Denial of Service | `RegisterCidDto.cid` oversized string | mitigate | VERIFIED | `register-cid.dto.ts:16` `@MaxLength(255)` bounds input before processing; `@ApiProperty maxLength: 255` at `:12` propagates the constraint to the OpenAPI spec. |
+| T-57-03 | Tampering | `LocalProvider` pin/rm + cat URLs (DB-sourced CID interpolated) | mitigate | VERIFIED | `local.provider.ts:87` `new URLSearchParams({ arg: cid })` for pin/rm, `:128` for cat; `grep -c URLSearchParams` = 2; no raw `arg=${cid}` remains. pin/add path (`:49`) unchanged (CID comes from Kubo response body, not the URL). |
+| T-57-SC | Tampering | npm/pip/cargo installs | accept | VERIFIED | `git diff main` over 171 changed files shows ZERO `package.json` / `pnpm-lock.yaml` / `Cargo.toml` / `Cargo.lock` changes. No new packages installed. Recorded as accepted risk below. |
+| T-57-04 | Tampering | Advisory-lock primitive drift across 3 sites | mitigate | VERIFIED | Single `withCidLock` at `unpin-helpers.ts:14` runs verbatim SQL `unpin-helpers.ts:19` `SELECT pg_advisory_xact_lock(hashtext($1)::bigint)` with NO `abs()` (the two `abs(` grep hits are doc-comment warnings at `:11-12`, not SQL). No inline `pg_advisory_xact_lock` executes at the three sites — vault.service hits at `:244,:266` are doc comments; both call paths route through `withCidLock`. |
+| T-57-05 | Tampering (data-loss race) | Unpinning a CID concurrently re-pinned | mitigate | VERIFIED (MOST SENSITIVE) | `refcountAndMaybeUnpin` `unpin-helpers.ts:36` counts `PinnedCid` under the held lock; `:37-40` skips `unpinFile` and deletes the stale outbox row when `refs > 0`; `:41-42` unpins then deletes only when `refs === 0`. `pending-unpin.processor.ts:80-82` invokes it inside `dataSource.transaction` wrapped by `withCidLock(manager, cid, …)` — recheck runs under the held per-CID lock. |
+| T-57-06 | Denial of Service | Kubo call held inside a long advisory-lock transaction | accept/mitigate | VERIFIED | `vault.service.ts:314` `await this.ipfsProvider.unpinFile(cid)` runs post-commit, OUTSIDE both transaction blocks, BEFORE the `dataSource.transaction` opened at `:321`. Only the outbox-row delete `:325` runs under `withCidLock`. `refcountAndMaybeUnpin` is correctly NOT used at this site (grep count 0 in vault.service.ts). |
+| T-57-07 | Elevation of Privilege / config | Leaf module accidentally importing an upstream module (recreating the cycle) | mitigate | VERIFIED | `ipfs-provider.module.ts:7` `imports: [ConfigModule]` only; factory injects `[ConfigService]` (`:19`). It is the sole non-spec `provide: IPFS_PROVIDER` source. All three consumers import the leaf: `ipfs.module.ts:13`, `pending-unpin.module.ts:16`, `vault.module.ts:17`; `ipfs.module.ts:16` still explicitly `exports: [IPFS_PROVIDER]`. No `IN-04 (accepted)` comments remain. |
+
+## Accepted Risks Log
+
+| ID | Risk | Rationale | Status |
+| -- | ---- | --------- | ------ |
+| T-57-SC | Supply-chain — new package install | No new npm/cargo dependency was added this phase. `git diff main` shows no manifest/lockfile changes across 171 modified files. Uses only existing `class-validator` / `@nestjs` deps. | Accepted (N/A — nothing installed) |
+| T-57-06 | Kubo network call serialized under DB lock (DoS) | Mitigated by design: the physical `unpinFile` Kubo call is post-commit and outside any transaction; only the cheap outbox-row delete is serialized under `withCidLock`. The residual (a brief lock around a single-row delete) is accepted. | Accepted + mitigated |
+
+## Unregistered Flags
+
+None. Neither `57-01-SUMMARY.md` nor `57-02-SUMMARY.md` declares a
+`## Threat Flags` section. `57-01-SUMMARY.md` carries a `## Threat Surface
+Scan` stating "No new network endpoints, auth paths, or trust boundaries
+introduced … No new threat flags." Phase 57 hardens existing paths (CID input
+to Kubo URL; advisory-lock unpin policy) and de-duplicates module wiring; it
+introduces no new attack surface.
+
+## Methodology
+
+- Static analysis and targeted greps only. The full jest suite (903/903 green)
+  was already run by the executor and was NOT re-run here.
+- Implementation files were read-only; only this phase `57-SECURITY.md` was
+  written. The repo-root `SECURITY.md` was not created or modified.
+- Negative-case gates confirmed: no `abs(` in helper SQL, no inline
+  `pg_advisory_xact_lock` at the three call sites, no raw `?arg=${cid}`
+  interpolation, single non-spec `provide: IPFS_PROVIDER` source, no `{44,}`
+  literal in `register-cid.dto.ts`, no `const CID_REGEX` in `unpin.dto.ts`, no
+  `IN-04 (accepted)` comments.

--- a/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-VALIDATION.md
+++ b/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-VALIDATION.md
@@ -1,0 +1,87 @@
+---
+phase: 57
+slug: api-cid-and-provider-hardening-and-module-dedup
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-06-22
+---
+
+# Phase 57 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property               | Value                                                         |
+| ---------------------- | ------------------------------------------------------------- |
+| **Framework**          | Jest 29 + ts-jest                                             |
+| **Config file**        | `apps/api/jest.config.js`                                     |
+| **Quick run command**  | `pnpm --filter @cipherbox/api test -- --testPathPattern=ipfs` |
+| **Full suite command** | `pnpm --filter @cipherbox/api test`                          |
+| **Estimated runtime**  | ~60 seconds (full api suite)                                  |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `pnpm --filter @cipherbox/api test -- --testPathPattern=<changed-module> --passWithNoTests`
+- **After every plan wave:** Run `pnpm --filter @cipherbox/api test`
+- **Before `/gsd-verify-work`:** Full suite must be green
+- **Max feedback latency:** 60 seconds
+
+---
+
+## Per-Task Verification Map
+
+> Filled by the planner from PLAN.md tasks. Seed rows from RESEARCH.md Validation Architecture below; planner refines task IDs to match final plan structure.
+
+| Task ID   | Plan | Wave | Requirement | Threat Ref | Secure Behavior                                            | Test Type  | Automated Command                                                              | File Exists | Status     |
+| --------- | ---- | ---- | ----------- | ---------- | ---------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------- | ----------- | ---------- |
+| 57-01-\*  | 01   | 1    | HARD-08     | —          | `RegisterCidDto` rejects CIDv0 `{44,}` > 46 chars         | unit       | `pnpm --filter @cipherbox/api test -- --testPathPattern=register-cid`         | ❌ W0       | ⬜ pending |
+| 57-01-\*  | 01   | 1    | HARD-08     | —          | `RegisterCidDto` rejects strings > 255 chars               | unit       | `pnpm --filter @cipherbox/api test -- --testPathPattern=register-cid`         | ❌ W0       | ⬜ pending |
+| 57-01-\*  | 01   | 1    | HARD-08     | —          | `RegisterCidDto` accepts valid CIDv1 `bafk...`             | unit       | `pnpm --filter @cipherbox/api test -- --testPathPattern=register-cid`         | ❌ W0       | ⬜ pending |
+| 57-01-\*  | 01   | 1    | HARD-08     | —          | `LocalProvider.unpinFile` uses `arg=` query param safely   | unit       | `pnpm --filter @cipherbox/api test -- --testPathPattern=local.provider`       | ✅          | ⬜ pending |
+| 57-01-\*  | 01   | 1    | HARD-08     | —          | `LocalProvider.getFile` uses `arg=` query param safely     | unit       | `pnpm --filter @cipherbox/api test -- --testPathPattern=local.provider`       | ✅          | ⬜ pending |
+| 57-02-\*  | 02   | 1    | HARD-08     | —          | `withCidLock` executes `pg_advisory_xact_lock` SQL         | unit       | `pnpm --filter @cipherbox/api test -- --testPathPattern=unpin-helpers`        | ❌ W0       | ⬜ pending |
+| 57-02-\*  | 02   | 1    | HARD-08     | —          | `refcountAndMaybeUnpin` skips unpin when refs > 0          | unit       | `pnpm --filter @cipherbox/api test -- --testPathPattern=unpin-helpers`        | ❌ W0       | ⬜ pending |
+| 57-02-\*  | 02   | 1    | HARD-08     | —          | `IpfsProviderModule` provides + exports `IPFS_PROVIDER`    | unit       | `pnpm --filter @cipherbox/api test -- --testPathPattern=ipfs-provider.module` | ❌ W0       | ⬜ pending |
+| 57-\*\*   | both | 1    | HARD-08     | —          | Full api suite green (regression)                          | regression | `pnpm --filter @cipherbox/api test`                                           | ✅          | ⬜ pending |
+
+_Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky_
+
+---
+
+## Wave 0 Requirements
+
+- [ ] `apps/api/src/ipfs/dto/register-cid.dto.spec.ts` — stubs for HARD-08 (D-01 regex tightening + `@MaxLength(255)`, D-02 CIDv1 acceptance)
+- [ ] `apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts` — stubs for `withCidLock` SQL and `refcountAndMaybeUnpin` refcount branching (D-07)
+- [ ] `apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts` — stubs for `IpfsProviderModule` provides/exports `IPFS_PROVIDER` (D-05)
+- [ ] `local.provider` existing spec extended with URL-encoding assertions for pin/rm + cat (D-04)
+
+_Jest framework already installed; no new framework install needed._
+
+---
+
+## Manual-Only Verifications
+
+| Behavior                                                    | Requirement | Why Manual                                       | Test Instructions                                                                 |
+| ---------------------------------------------------------- | ----------- | ------------------------------------------------ | --------------------------------------------------------------------------------- |
+| `pnpm api:generate` regenerated client matches DTO change   | HARD-08     | Cross-package codegen; pre-commit hook enforces  | Run `pnpm api:generate`; confirm `openapi.json` gains `maxLength: 255` on RegisterCidDto.cid; stage regenerated `@cipherbox/api-client` (D-08) |
+
+_All in-code phase behaviors have automated verification._
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 60s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-VALIDATION.md
+++ b/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-VALIDATION.md
@@ -1,10 +1,11 @@
 ---
 phase: 57
 slug: api-cid-and-provider-hardening-and-module-dedup
-status: draft
-nyquist_compliant: false
-wave_0_complete: false
+status: validated
+nyquist_compliant: true
+wave_0_complete: true
 created: 2026-06-22
+audited: 2026-06-22
 ---
 
 # Phase 57 — Validation Strategy
@@ -85,3 +86,42 @@ _All in-code phase behaviors have automated verification._
 - [ ] `nyquist_compliant: true` set in frontmatter
 
 **Approval:** pending
+
+---
+
+## Retroactive Compliance Audit
+
+> Performed 2026-06-22 (static analysis only — full jest suite already green: 903/903 tests, 47/47 suites). Each must-have requirement from `57-VERIFICATION.md` is mapped to a validating test or a deterministic source assertion below.
+
+### Audit Result
+
+- **Nyquist compliant:** yes
+- **Must-have requirements:** 12
+- **Requirements with validating coverage:** 12
+- **Nyquist gaps:** 0
+
+### Requirement to Test Mapping
+
+| #   | Requirement                                                                                | Validating Coverage                                                                                                  | Verdict |
+| --- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- | ------- |
+| 1   | `RegisterCidDto` rejects CIDv0 `{44,}` overflow (47 chars after `Qm`)                       | `register-cid.dto.spec.ts` — "rejects a CIDv0 with {44,} overflow" asserts `cidErrors.length >= 1`                    | covered |
+| 2   | `RegisterCidDto` rejects strings > 255 chars                                                | `register-cid.dto.spec.ts` — "rejects a cid string longer than 255 chars" (300-char input)                            | covered |
+| 3   | `RegisterCidDto` accepts a valid CIDv1                                                      | `register-cid.dto.spec.ts` — "accepts a valid CIDv1" asserts `errors.length === 0`                                    | covered |
+| 4   | `RegisterCidDto` + `UnpinDto` share a single `CID_REGEX`                                    | grep: `cid.constants.ts` exports `CID_REGEX`; both `register-cid.dto.ts` and `unpin.dto.ts` import it                 | covered |
+| 5   | `LocalProvider` URL-encodes the CID in pin/rm and cat                                       | `local.provider.spec.ts` — "percent-encode ... in pin/rm URL" + "... in cat URL" assert `bafk%26evil%3D1`             | covered |
+| 6   | `openapi.json` gains `maxLength: 255` and regenerated client is committed                   | node assertion: `packages/api-client/openapi.json` RegisterCidDto.cid = `{pattern, maxLength:255}` (committed)         | covered |
+| 7   | A single leaf `IpfsProviderModule` owns the `IPFS_PROVIDER` factory                         | `ipfs-provider.module.spec.ts` (provides + exports as `LocalProvider`) + grep: only `ipfs-provider.module.ts` has `provide: IPFS_PROVIDER` | covered |
+| 8   | `IpfsModule` / `VaultModule` / `PendingUnpinModule` import `IpfsProviderModule`             | grep: `ipfs.module.ts`, `vault.module.ts`, `pending-unpin.module.ts` all import `IpfsProviderModule`                  | covered |
+| 9   | IN-04 accepted-circular-dependency comments removed                                         | grep: no `forwardRef` / "circular dependency" comments remain in `ipfs/` or `vault/`                                  | covered |
+| 10  | `withCidLock` runs verbatim `pg_advisory_xact_lock(hashtext($1)::bigint)`, no `abs()`       | `unpin-helpers.spec.ts` — lock-SQL test asserts exact SQL + `[cid]`; source confirms no `abs()`                       | covered |
+| 11  | All 3 unpin sites route through shared helpers; `drainRow` uses `refcountAndMaybeUnpin`, vault.service post-commit does not | `unpin-helpers.spec.ts` (refs>0 skip, refs===0 unpin) + grep: `drainRow` = `withCidLock(... refcountAndMaybeUnpin)`; vault.service post-commit calls `ipfsProvider.unpinFile` directly | covered |
+| 12  | Post-commit `unpinFile` is OUTSIDE the inner transaction (D-03)                             | `vault.service.ts` inspection: transaction block (L260-309) closes before `unpinFile` at L314; comment + structure confirm | covered |
+
+### Notes
+
+- Requirements 1-3, 5, 7, 10, 11 are sampled by executed unit tests (part of the green 903/903 run).
+- Requirements 4, 8, 9 are structural invariants verified by source grep — no behavioral surface to assert beyond import wiring.
+- Requirement 6 is verified by a deterministic assertion against the committed `openapi.json` (located in `packages/api-client/openapi.json`, not `apps/api/`).
+- Requirement 12 is an ordering invariant verified by source inspection; the post-commit Kubo call provably sits outside the `dataSource.transaction` callback.
+
+_No Nyquist gaps. All must-have requirements have validating coverage._

--- a/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-VERIFICATION.md
+++ b/.planning/phases/57-api-cid-and-provider-hardening-and-module-dedup/57-VERIFICATION.md
@@ -1,0 +1,128 @@
+---
+phase: 57-api-cid-and-provider-hardening-and-module-dedup
+verified: 2026-06-22T02:10:00Z
+status: passed
+score: 12/12 must-haves verified
+overrides_applied: 0
+---
+
+# Phase 57: API CID and Provider Hardening + Module Dedup — Verification Report
+
+**Phase Goal:** Close CID-validation divergence (HARD-08), URL-encode CID in Kubo query strings, deduplicate the IPFS_PROVIDER factory and advisory-lock SQL across the module graph.
+**Verified:** 2026-06-22T02:10:00Z
+**Status:** PASSED
+**Re-verification:** No — initial verification
+
+---
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | RegisterCidDto rejects CIDv0 Qm... longer than 46 chars ({44,} overflow) | VERIFIED | register-cid.dto.spec.ts test 2 passes; `{44}` exact branch in cid.constants.ts; no `{44,}` in register-cid.dto.ts |
+| 2 | RegisterCidDto rejects any cid longer than 255 chars | VERIFIED | `@MaxLength(255)` on cid field in register-cid.dto.ts; test 3 in spec passes; 903/903 tests green |
+| 3 | RegisterCidDto accepts a valid CIDv1 bafk... string | VERIFIED | register-cid.dto.spec.ts test 1 passes; CIDv1 branch `b[a-z2-7]{58,}` kept in CID_REGEX |
+| 4 | RegisterCidDto and UnpinDto validate CID via the single shared CID_REGEX constant | VERIFIED | Both import `{ CID_REGEX } from './cid.constants'`; no inline regex in either DTO; no `const CID_REGEX` in unpin.dto.ts |
+| 5 | LocalProvider URL-encodes the CID in pin/rm and cat Kubo query strings | VERIFIED | `URLSearchParams` count=2; lines 87-88 (pin/rm) and 128+ (cat) confirmed; no raw `?arg=${cid}` interpolation |
+| 6 | openapi.json carries maxLength:255 on RegisterCidDto.cid and regenerated api-client is committed | VERIFIED | `node -e` assertion exits 0; `maxLength: 255` confirmed in openapi.json |
+| 7 | Single leaf IpfsProviderModule owns the IPFS_PROVIDER factory; three duplicated factories deleted | VERIFIED | `grep -rl "provide: IPFS_PROVIDER" apps/api/src --include="*.ts"` (non-spec) returns ONLY `ipfs-provider.module.ts` |
+| 8 | IpfsModule, VaultModule, PendingUnpinModule import IpfsProviderModule instead of self-providing | VERIFIED | Each module imports IpfsProviderModule; factory block deleted from all three |
+| 9 | Misleading IN-04 accepted-circular-dependency comments removed | VERIFIED | `grep -rn "IN-04 (accepted)" apps/api/src` returns nothing |
+| 10 | withCidLock runs verbatim pg_advisory_xact_lock(hashtext($1)::bigint) SQL with no abs() | VERIFIED | SQL string confirmed verbatim in unpin-helpers.ts; `grep -F "abs(" apps/api/src/ipfs/pending-unpin/unpin-helpers.ts` returns nothing (doc comment only, not in SQL) |
+| 11 | All three advisory-lock unpin sites route through shared helpers; drainRow uses refcountAndMaybeUnpin; vault.service post-commit does NOT | VERIFIED | processor.ts uses withCidLock+refcountAndMaybeUnpin; vault.service.ts has 0 uses of refcountAndMaybeUnpin; both use withCidLock |
+| 12 | Post-commit ipfsProvider.unpinFile(cid) stays OUTSIDE the inner transaction in guardedUnpin | VERIFIED | vault.service.ts lines 316-335: `unpinFile` call precedes the `dataSource.transaction` block for outbox delete; withCidLock only wraps the outbox delete |
+
+**Score:** 12/12 truths verified
+
+---
+
+### Required Artifacts
+
+| Artifact | Status | Evidence |
+|----------|--------|----------|
+| `apps/api/src/ipfs/dto/cid.constants.ts` | VERIFIED | Exists; exports `CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}\|b[a-z2-7]{58,})$/` with IN-02 comment |
+| `apps/api/src/ipfs/dto/register-cid.dto.spec.ts` | VERIFIED | Exists; 4 tests (CIDv1 accept, CIDv0 overflow reject, 255+ char reject, canonical CIDv0 accept); all pass |
+| `apps/api/src/ipfs/dto/register-cid.dto.ts` | VERIFIED | Contains `@MaxLength(255)`, imports CID_REGEX from cid.constants; no inline `{44,}` regex |
+| `apps/api/src/ipfs/providers/local.provider.ts` | VERIFIED | Contains `URLSearchParams` in 2 locations (pin/rm + cat); pin/add unchanged |
+| `apps/api/src/ipfs/providers/ipfs-provider.module.ts` | VERIFIED | Exists; leaf @Module importing only ConfigModule; exports `[IPFS_PROVIDER]`; exports `class IpfsProviderModule` |
+| `apps/api/src/ipfs/pending-unpin/unpin-helpers.ts` | VERIFIED | Exists; exports `withCidLock` and `refcountAndMaybeUnpin`; verbatim SQL; no abs() |
+| `apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts` | VERIFIED | Exists; contains `IpfsProviderModule` |
+| `apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts` | VERIFIED | Exists; contains `withCidLock`; 3 tests: lock SQL, refs>0 skip-unpin, refs===0 unpin |
+
+---
+
+### Key Link Verification
+
+| From | To | Via | Status | Evidence |
+|------|----|-----|--------|----------|
+| `register-cid.dto.ts` | `cid.constants.ts` | `import { CID_REGEX }` | WIRED | Line 3 confirmed |
+| `unpin.dto.ts` | `cid.constants.ts` | `import { CID_REGEX }` | WIRED | Line 3 confirmed |
+| `ipfs.module.ts` | `ipfs-provider.module.ts` | `imports: [..., IpfsProviderModule]` | WIRED | `exports: [IPFS_PROVIDER]` confirmed at line 16 |
+| `vault.service.ts` | `unpin-helpers.ts` | `import { withCidLock }` | WIRED | Line 17 confirmed; used at lines 267, 324 |
+| `pending-unpin.processor.ts` | `unpin-helpers.ts` | `import { withCidLock, refcountAndMaybeUnpin }` | WIRED | Line 10 confirmed; drainRow uses both at line 81 |
+
+---
+
+### Grep Gate Results
+
+| Gate | Command Result | Status |
+|------|---------------|--------|
+| Single `provide: IPFS_PROVIDER` source (non-spec) | 1 file: `ipfs-provider.module.ts` | PASS |
+| No `IN-04 (accepted)` comments | 0 matches | PASS |
+| No inline `pg_advisory_xact_lock` SQL at 3 sites | vault.service.ts + processor.ts: 0 executable SQL calls (comments only) | PASS |
+| No `abs(` in unpin-helpers.ts SQL | 0 matches in code (doc comment explains prohibition) | PASS |
+| No `{44,}` in register-cid.dto.ts | 0 matches | PASS |
+| No `const CID_REGEX` in unpin.dto.ts | 0 matches | PASS |
+| `URLSearchParams` count in local.provider.ts | 2 | PASS |
+| No raw `pin/rm?arg=${cid}` or `cat?arg=${cid}` | 0 matches | PASS |
+| `refcountAndMaybeUnpin` in vault.service.ts | 0 uses | PASS |
+| `refcountAndMaybeUnpin` in pending-unpin.processor.ts | 3 matches (import + usage) | PASS |
+| `exports: [IPFS_PROVIDER]` in ipfs.module.ts | Line 16 confirmed | PASS |
+| `providers/index.ts` re-exports IpfsProviderModule | `export * from './ipfs-provider.module'` | PASS |
+
+---
+
+### Test Suite Results
+
+| Suite | Command | Result |
+|-------|---------|--------|
+| Full apps/api jest | `npx jest` in apps/api | **903 tests, 47 suites — ALL PASSING** |
+| tsc --noEmit (phase-57-touched files) | `npx tsc --noEmit 2>&1 \| grep -E "ipfs/\|vault/"` | **0 errors** |
+| tsc --noEmit (known pre-existing) | 3 errors in `metrics/http-metrics.interceptor.spec.ts`, `shares/share-invite.service.spec.ts`, `shares/shares.controller.spec.ts` | Pre-existing at fork base; not introduced by phase 57 |
+
+---
+
+### D-03 Ordering Verification (Critical Safety Check)
+
+Post-commit `ipfsProvider.unpinFile(cid)` placement in `guardedUnpin` (vault.service.ts ~line 316):
+
+- `await this.ipfsProvider.unpinFile(cid)` is called FIRST, OUTSIDE any transaction
+- The `dataSource.transaction(async (manager) => { await withCidLock(...delete PendingUnpin...) })` runs AFTER
+- Kubo network call is never held inside the advisory-lock transaction — D-03 ordering maintained
+
+**Status: VERIFIED**
+
+---
+
+### Anti-Patterns Found
+
+None. No TBD/FIXME/XXX markers found in phase-57-touched files. No stub implementations. No hardcoded empty returns in functional paths.
+
+---
+
+### Human Verification Required
+
+None. All must-haves are verifiable programmatically. The openapi.json maxLength assertion was confirmed by direct `node -e` execution.
+
+---
+
+## Gaps Summary
+
+No gaps. All 12 must-have truths verified against actual source code and test execution.
+
+---
+
+_Verified: 2026-06-22T02:10:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/apps/api/src/ipfs/dto/cid.constants.ts
+++ b/apps/api/src/ipfs/dto/cid.constants.ts
@@ -1,0 +1,4 @@
+// IN-02: CID format regex covers CIDv0 (Qm... base58, 46 chars) and
+// CIDv1 (b... base32, 59+ chars). MaxLength(255) bounds the input to
+// prevent oversized-string DoS at the route boundary (T-50-12).
+export const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$/;

--- a/apps/api/src/ipfs/dto/register-cid.dto.spec.ts
+++ b/apps/api/src/ipfs/dto/register-cid.dto.spec.ts
@@ -1,0 +1,42 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { RegisterCidDto } from './register-cid.dto';
+
+describe('RegisterCidDto', () => {
+  async function validateDto(plain: Partial<RegisterCidDto>) {
+    const dto = plainToInstance(RegisterCidDto, plain);
+    return validate(dto);
+  }
+
+  it('accepts a valid CIDv1 (D-02 invariant — CIDv1 must be kept)', async () => {
+    const errors = await validateDto({
+      cid: 'bafkreigaknpexyvxt76zgkitavbwx6ejgfheup5oybpm77f3pxzrvwpfdi',
+      sizeBytes: 100,
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  // RED: the current loose {44,} regex wrongly accepts a CIDv0 with 47 base58 chars after Qm
+  it('rejects a CIDv0 with {44,} overflow — 47 chars after Qm (D-01)', async () => {
+    // 47 base58 chars after Qm = 49 total chars (one too many for a real CIDv0)
+    const overflowCidv0 = 'Qm' + '1'.repeat(47);
+    const errors = await validateDto({ cid: overflowCidv0, sizeBytes: 100 });
+    const cidErrors = errors.filter((e) => e.property === 'cid');
+    expect(cidErrors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // RED: current DTO has no @MaxLength(255) so a 256+ char string slips through
+  it('rejects a cid string longer than 255 chars (D-01 @MaxLength)', async () => {
+    const longCid = 'b' + 'a'.repeat(300);
+    const errors = await validateDto({ cid: longCid, sizeBytes: 100 });
+    const cidErrors = errors.filter((e) => e.property === 'cid');
+    expect(cidErrors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('accepts a canonical 46-char CIDv0 (D-01 sanity)', async () => {
+    // A real CIDv0: Qm + exactly 44 base58 chars = 46 total chars
+    const validCidv0 = 'QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB';
+    const errors = await validateDto({ cid: validCidv0, sizeBytes: 100 });
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/apps/api/src/ipfs/dto/register-cid.dto.ts
+++ b/apps/api/src/ipfs/dto/register-cid.dto.ts
@@ -8,7 +8,7 @@ const MAX_FILE_SIZE = 100 * 1024 * 1024;
 export class RegisterCidDto {
   @ApiProperty({
     description: 'IPFS CID pinned to external provider (CIDv0 or CIDv1)',
-    pattern: '^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$',
+    pattern: CID_REGEX.source,
     maxLength: 255,
   })
   @IsString()

--- a/apps/api/src/ipfs/dto/register-cid.dto.ts
+++ b/apps/api/src/ipfs/dto/register-cid.dto.ts
@@ -1,16 +1,20 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsInt, Min, Max, IsNotEmpty, Matches } from 'class-validator';
+import { IsString, IsInt, Min, Max, IsNotEmpty, Matches, MaxLength } from 'class-validator';
+import { CID_REGEX } from './cid.constants';
 
 // Max file size matches upload limit (100MB)
 const MAX_FILE_SIZE = 100 * 1024 * 1024;
 
 export class RegisterCidDto {
-  @ApiProperty({ description: 'IPFS CID pinned to external provider (CIDv0 or CIDv1)' })
+  @ApiProperty({
+    description: 'IPFS CID pinned to external provider (CIDv0 or CIDv1)',
+    pattern: '^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$',
+    maxLength: 255,
+  })
   @IsString()
   @IsNotEmpty()
-  @Matches(/^(Qm[1-9A-HJ-NP-Za-km-z]{44,}|b[a-z2-7]{58,})$/, {
-    message: 'cid must be a valid CIDv0 (Qm...) or CIDv1 (bafy...) string',
-  })
+  @MaxLength(255)
+  @Matches(CID_REGEX, { message: 'cid must be a valid CIDv0 (Qm...) or CIDv1 (b...) string' })
   cid!: string;
 
   @ApiProperty({ description: 'Size of the pinned content in bytes' })

--- a/apps/api/src/ipfs/dto/unpin.dto.ts
+++ b/apps/api/src/ipfs/dto/unpin.dto.ts
@@ -1,10 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsNotEmpty, MaxLength, Matches } from 'class-validator';
-
-// IN-02: CID format regex covers CIDv0 (Qm... base58, 46 chars) and
-// CIDv1 (b... base32, 59+ chars). MaxLength(255) bounds the input to
-// prevent oversized-string DoS at the route boundary (T-50-12).
-const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$/;
+import { CID_REGEX } from './cid.constants';
 
 export class UnpinDto {
   @ApiProperty({

--- a/apps/api/src/ipfs/ipfs.module.ts
+++ b/apps/api/src/ipfs/ipfs.module.ts
@@ -1,6 +1,7 @@
 import { Module, DynamicModule } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { IPFS_PROVIDER, LocalProvider } from './providers';
+import { ConfigModule } from '@nestjs/config';
+import { IPFS_PROVIDER } from './providers';
+import { IpfsProviderModule } from './providers';
 import { IpfsController } from './ipfs.controller';
 import { VaultModule } from '../vault/vault.module';
 
@@ -9,27 +10,9 @@ export class IpfsModule {
   static forRootAsync(): DynamicModule {
     return {
       module: IpfsModule,
-      imports: [ConfigModule, VaultModule],
+      imports: [ConfigModule, VaultModule, IpfsProviderModule],
       controllers: [IpfsController],
-      providers: [
-        {
-          // IN-04 (accepted): IPFS_PROVIDER useFactory is duplicated across IpfsModule,
-          // VaultModule, and PendingUnpinModule. Extraction into a shared IpfsProviderCoreModule
-          // is avoided because IpfsModule imports VaultModule and VaultModule imports
-          // IpfsModule's provider — a shared module would create a circular dependency.
-          // Each module self-provides to break the cycle. Accepted with this comment.
-          provide: IPFS_PROVIDER,
-          useFactory: (configService: ConfigService) => {
-            const apiUrl = configService.get<string>('IPFS_LOCAL_API_URL', 'http://localhost:5001');
-            const gatewayUrl = configService.get<string>(
-              'IPFS_LOCAL_GATEWAY_URL',
-              'http://localhost:8080'
-            );
-            return new LocalProvider(apiUrl, gatewayUrl);
-          },
-          inject: [ConfigService],
-        },
-      ],
+      providers: [],
       exports: [IPFS_PROVIDER],
     };
   }

--- a/apps/api/src/ipfs/ipfs.module.ts
+++ b/apps/api/src/ipfs/ipfs.module.ts
@@ -1,7 +1,6 @@
 import { Module, DynamicModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { IPFS_PROVIDER } from './providers';
-import { IpfsProviderModule } from './providers';
+import { IPFS_PROVIDER, IpfsProviderModule } from './providers';
 import { IpfsController } from './ipfs.controller';
 import { VaultModule } from '../vault/vault.module';
 

--- a/apps/api/src/ipfs/ipfs.module.ts
+++ b/apps/api/src/ipfs/ipfs.module.ts
@@ -1,6 +1,6 @@
 import { Module, DynamicModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { IPFS_PROVIDER, IpfsProviderModule } from './providers';
+import { IpfsProviderModule } from './providers';
 import { IpfsController } from './ipfs.controller';
 import { VaultModule } from '../vault/vault.module';
 
@@ -12,7 +12,11 @@ export class IpfsModule {
       imports: [ConfigModule, VaultModule, IpfsProviderModule],
       controllers: [IpfsController],
       providers: [],
-      exports: [IPFS_PROVIDER],
+      // Re-export the imported IpfsProviderModule (which exports IPFS_PROVIDER) so
+      // downstream importers like AuthModule can inject the token. A bare
+      // `exports: [IPFS_PROVIDER]` fails at boot because the token is not a local
+      // provider of IpfsModule — Nest only re-exports a token via its owning module.
+      exports: [IpfsProviderModule],
     };
   }
 }

--- a/apps/api/src/ipfs/pending-unpin/pending-unpin.module.ts
+++ b/apps/api/src/ipfs/pending-unpin/pending-unpin.module.ts
@@ -1,11 +1,11 @@
 import { Module, Logger, OnModuleInit } from '@nestjs/common';
 import { BullModule, InjectQueue } from '@nestjs/bullmq';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ConfigModule } from '@nestjs/config';
 import { Queue } from 'bullmq';
 import { PendingUnpin } from '../../vault/entities/pending-unpin.entity';
 import { PinnedCid } from '../../vault/entities/pinned-cid.entity';
-import { IPFS_PROVIDER, LocalProvider } from '../providers';
+import { IpfsProviderModule } from '../providers';
 import { PendingUnpinProcessor } from './pending-unpin.processor';
 
 @Module({
@@ -13,27 +13,9 @@ import { PendingUnpinProcessor } from './pending-unpin.processor';
     BullModule.registerQueue({ name: 'pending-unpins' }),
     TypeOrmModule.forFeature([PendingUnpin, PinnedCid]),
     ConfigModule,
+    IpfsProviderModule,
   ],
-  providers: [
-    PendingUnpinProcessor,
-    {
-      // IN-04 (accepted): IPFS_PROVIDER useFactory is duplicated across IpfsModule,
-      // VaultModule, and PendingUnpinModule. This instance exists to avoid importing
-      // IpfsModule (IpfsModule → VaultModule → circular). Each module self-provides
-      // to break the cycle. Extraction into a shared module would not eliminate the
-      // cycle without restructuring the import graph. Accepted with this comment.
-      provide: IPFS_PROVIDER,
-      useFactory: (configService: ConfigService) => {
-        const apiUrl = configService.get<string>('IPFS_LOCAL_API_URL', 'http://localhost:5001');
-        const gatewayUrl = configService.get<string>(
-          'IPFS_LOCAL_GATEWAY_URL',
-          'http://localhost:8080'
-        );
-        return new LocalProvider(apiUrl, gatewayUrl);
-      },
-      inject: [ConfigService],
-    },
-  ],
+  providers: [PendingUnpinProcessor],
 })
 export class PendingUnpinModule implements OnModuleInit {
   private readonly logger = new Logger(PendingUnpinModule.name);

--- a/apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts
+++ b/apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts
@@ -77,10 +77,17 @@ export class PendingUnpinProcessor extends WorkerHost {
    * The lock is the first transactional statement, mirroring guardedUnpin (D-04).
    */
   private async drainRow(cid: string): Promise<void> {
-    await this.dataSource.transaction(async (manager) => {
-      await withCidLock(manager, cid, () => refcountAndMaybeUnpin(manager, cid, this.ipfsProvider));
-    });
-    this.logger.log(`Drained cid=${cid}`);
+    const result = await this.dataSource.transaction((manager) =>
+      withCidLock(manager, cid, () => refcountAndMaybeUnpin(manager, cid, this.ipfsProvider))
+    );
+    if (result.outcome === 'skipped-repinned') {
+      // Preserve the distinct skip-path signal so re-pin races stay auditable in prod logs.
+      this.logger.log(
+        `Drain: skipped unpin for cid=${cid} — CID is re-pinned (refs=${result.refs}); stale outbox row discarded`
+      );
+    } else {
+      this.logger.log(`Drained cid=${cid}`);
+    }
   }
 
   private async runDriftReport(): Promise<void> {

--- a/apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts
+++ b/apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts
@@ -7,6 +7,7 @@ import { Job } from 'bullmq';
 import { PendingUnpin } from '../../vault/entities/pending-unpin.entity';
 import { PinnedCid } from '../../vault/entities/pinned-cid.entity';
 import { IPFS_PROVIDER, IpfsProvider } from '../providers';
+import { withCidLock, refcountAndMaybeUnpin } from './unpin-helpers';
 import { MetricsService } from '../../metrics/metrics.service';
 
 const BATCH_SIZE = 50;
@@ -88,32 +89,16 @@ export class PendingUnpinProcessor extends WorkerHost {
    * idempotent (LocalProvider swallows "not pinned"), so holding the lock across the
    * network call is acceptable for the drain's low-frequency, batched path.
    */
+  /**
+   * D-02 / WR-01: Run refcount recheck + conditional unpin + outbox delete under
+   * the per-CID advisory lock via shared helpers (withCidLock + refcountAndMaybeUnpin).
+   * The lock is the first transactional statement, mirroring guardedUnpin (D-04).
+   */
   private async drainRow(cid: string): Promise<void> {
     await this.dataSource.transaction(async (manager) => {
-      // Advisory xact lock — MUST be the first transactional statement, mirroring
-      // guardedUnpin (D-04). Released automatically when the transaction ends.
-      await manager.query(`SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`, [cid]);
-
-      // D-02 / WR-01: Re-check refcount UNDER the lock before unpinning. A concurrent
-      // re-upload or pin-migration may have re-pinned this CID while it sat in the
-      // outbox. Unpinning a live pin would cause Kubo GC → data loss. Skip the
-      // physical unpin but still delete the stale outbox row so it is not retried.
-      const refs = await manager.getRepository(PinnedCid).count({ where: { cid } });
-      if (refs > 0) {
-        await manager.getRepository(PendingUnpin).delete({ cid });
-        this.logger.log(
-          `Drain: skipped unpin for cid=${cid} — CID is re-pinned (refs=${refs}); stale outbox row discarded`
-        );
-        return;
-      }
-
-      // D-05: Call through provider so "not pinned" is treated as success
-      // (LocalProvider.unpinFile swallows "not pinned" at local.provider.ts:94).
-      // Inside the lock so a racing guardedUnpin cannot re-pin between recheck and unpin.
-      await this.ipfsProvider.unpinFile(cid);
-      await manager.getRepository(PendingUnpin).delete({ cid });
-      this.logger.log(`Drained cid=${cid}`);
+      await withCidLock(manager, cid, () => refcountAndMaybeUnpin(manager, cid, this.ipfsProvider));
     });
+    this.logger.log(`Drained cid=${cid}`);
   }
 
   private async runDriftReport(): Promise<void> {

--- a/apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts
+++ b/apps/api/src/ipfs/pending-unpin/pending-unpin.processor.ts
@@ -72,25 +72,7 @@ export class PendingUnpinProcessor extends WorkerHost {
    * guardedUnpin uses (vault.service.ts), serializing the refcount re-check +
    * physical unpin against concurrent recordPin/guardedUnpin for the same CID.
    *
-   * WR-01: Previously the count + unpinFile ran in autocommit with no lock, so the
-   * drain's refcount recheck and physical unpin were not serialized against a
-   * concurrent guardedUnpin for the same CID. Taking pg_advisory_xact_lock(hashtext(cid))
-   * as the first statement and holding it across the recheck + unpin serializes the
-   * drain against guardedUnpin (which takes the same lock), so the two unpin paths
-   * for one CID cannot interleave. The under-lock recheck also means we never unpin a
-   * CID whose re-pin has already committed (refs > 0 → skip).
-   *
-   * Precision (per review): recordPin does NOT take this lock, so a concurrent
-   * re-upload that re-pins the CID is not blocked by it. The residual drain↔recordPin
-   * window — a re-upload commits a fresh pinned_cids row in the gap between our recheck
-   * and the Kubo unpin — is therefore NOT closed by the lock; it is covered by D-13
-   * (colliding on the same CID requires re-uploading byte-identical ciphertext+IV,
-   * which is cryptographically negligible) and by the drift report. The unpin is
-   * idempotent (LocalProvider swallows "not pinned"), so holding the lock across the
-   * network call is acceptable for the drain's low-frequency, batched path.
-   */
-  /**
-   * D-02 / WR-01: Run refcount recheck + conditional unpin + outbox delete under
+   * WR-01: D-02 / WR-01: Run refcount recheck + conditional unpin + outbox delete under
    * the per-CID advisory lock via shared helpers (withCidLock + refcountAndMaybeUnpin).
    * The lock is the first transactional statement, mirroring guardedUnpin (D-04).
    */

--- a/apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts
+++ b/apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts
@@ -1,6 +1,7 @@
 import { withCidLock, refcountAndMaybeUnpin } from './unpin-helpers';
 import { PinnedCid } from '../../vault/entities/pinned-cid.entity';
 import { PendingUnpin } from '../../vault/entities/pending-unpin.entity';
+import { IpfsProvider } from '../providers/ipfs-provider.interface';
 
 describe('withCidLock', () => {
   it('executes the exact pg_advisory_xact_lock SQL with [cid] and returns fn result', async () => {
@@ -29,7 +30,8 @@ describe('refcountAndMaybeUnpin', () => {
       return {};
     }),
   } as any;
-  const mockIpfsProvider = { unpinFile: jest.fn() };
+  const mockIpfsProvider = { unpinFile: jest.fn<Promise<void>, [string]>() };
+  const ipfsProvider = mockIpfsProvider as unknown as IpfsProvider;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +46,7 @@ describe('refcountAndMaybeUnpin', () => {
     mockPinnedCidRepository.count.mockResolvedValue(2);
     mockPendingUnpinRepository.delete.mockResolvedValue({ affected: 1 });
 
-    const result = await refcountAndMaybeUnpin(mockManager, 'bafkcid', mockIpfsProvider as any);
+    const result = await refcountAndMaybeUnpin(mockManager, 'bafkcid', ipfsProvider);
 
     expect(mockIpfsProvider.unpinFile).not.toHaveBeenCalled();
     expect(mockPendingUnpinRepository.delete).toHaveBeenCalledWith({ cid: 'bafkcid' });
@@ -56,7 +58,7 @@ describe('refcountAndMaybeUnpin', () => {
     mockIpfsProvider.unpinFile.mockResolvedValue(undefined);
     mockPendingUnpinRepository.delete.mockResolvedValue({ affected: 1 });
 
-    const result = await refcountAndMaybeUnpin(mockManager, 'bafkcid', mockIpfsProvider as any);
+    const result = await refcountAndMaybeUnpin(mockManager, 'bafkcid', ipfsProvider);
 
     expect(mockIpfsProvider.unpinFile).toHaveBeenCalledWith('bafkcid');
     expect(mockPendingUnpinRepository.delete).toHaveBeenCalledWith({ cid: 'bafkcid' });

--- a/apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts
+++ b/apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts
@@ -44,10 +44,11 @@ describe('refcountAndMaybeUnpin', () => {
     mockPinnedCidRepository.count.mockResolvedValue(2);
     mockPendingUnpinRepository.delete.mockResolvedValue({ affected: 1 });
 
-    await refcountAndMaybeUnpin(mockManager, 'bafkcid', mockIpfsProvider as any);
+    const result = await refcountAndMaybeUnpin(mockManager, 'bafkcid', mockIpfsProvider as any);
 
     expect(mockIpfsProvider.unpinFile).not.toHaveBeenCalled();
     expect(mockPendingUnpinRepository.delete).toHaveBeenCalledWith({ cid: 'bafkcid' });
+    expect(result).toEqual({ outcome: 'skipped-repinned', refs: 2 });
   });
 
   it('calls unpinFile then deletes outbox row when refs === 0', async () => {
@@ -55,9 +56,10 @@ describe('refcountAndMaybeUnpin', () => {
     mockIpfsProvider.unpinFile.mockResolvedValue(undefined);
     mockPendingUnpinRepository.delete.mockResolvedValue({ affected: 1 });
 
-    await refcountAndMaybeUnpin(mockManager, 'bafkcid', mockIpfsProvider as any);
+    const result = await refcountAndMaybeUnpin(mockManager, 'bafkcid', mockIpfsProvider as any);
 
     expect(mockIpfsProvider.unpinFile).toHaveBeenCalledWith('bafkcid');
     expect(mockPendingUnpinRepository.delete).toHaveBeenCalledWith({ cid: 'bafkcid' });
+    expect(result).toEqual({ outcome: 'unpinned', refs: 0 });
   });
 });

--- a/apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts
+++ b/apps/api/src/ipfs/pending-unpin/unpin-helpers.spec.ts
@@ -1,0 +1,63 @@
+import { withCidLock, refcountAndMaybeUnpin } from './unpin-helpers';
+import { PinnedCid } from '../../vault/entities/pinned-cid.entity';
+import { PendingUnpin } from '../../vault/entities/pending-unpin.entity';
+
+describe('withCidLock', () => {
+  it('executes the exact pg_advisory_xact_lock SQL with [cid] and returns fn result', async () => {
+    const mockQuery = jest.fn().mockResolvedValue([]);
+    const mockManager = { query: mockQuery, getRepository: jest.fn() } as any;
+    const fn = jest.fn().mockResolvedValue('result');
+
+    const result = await withCidLock(mockManager, 'bafk...', fn);
+
+    expect(mockQuery).toHaveBeenCalledWith('SELECT pg_advisory_xact_lock(hashtext($1)::bigint)', [
+      'bafk...',
+    ]);
+    expect(fn).toHaveBeenCalled();
+    expect(result).toBe('result');
+  });
+});
+
+describe('refcountAndMaybeUnpin', () => {
+  const mockPinnedCidRepository = { count: jest.fn() };
+  const mockPendingUnpinRepository = { delete: jest.fn() };
+  const mockManager = {
+    query: jest.fn(),
+    getRepository: jest.fn((Entity: unknown) => {
+      if (Entity === PinnedCid) return mockPinnedCidRepository;
+      if (Entity === PendingUnpin) return mockPendingUnpinRepository;
+      return {};
+    }),
+  } as any;
+  const mockIpfsProvider = { unpinFile: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockManager.getRepository.mockImplementation((Entity: unknown) => {
+      if (Entity === PinnedCid) return mockPinnedCidRepository;
+      if (Entity === PendingUnpin) return mockPendingUnpinRepository;
+      return {};
+    });
+  });
+
+  it('skips unpin and deletes outbox row when refs > 0', async () => {
+    mockPinnedCidRepository.count.mockResolvedValue(2);
+    mockPendingUnpinRepository.delete.mockResolvedValue({ affected: 1 });
+
+    await refcountAndMaybeUnpin(mockManager, 'bafkcid', mockIpfsProvider as any);
+
+    expect(mockIpfsProvider.unpinFile).not.toHaveBeenCalled();
+    expect(mockPendingUnpinRepository.delete).toHaveBeenCalledWith({ cid: 'bafkcid' });
+  });
+
+  it('calls unpinFile then deletes outbox row when refs === 0', async () => {
+    mockPinnedCidRepository.count.mockResolvedValue(0);
+    mockIpfsProvider.unpinFile.mockResolvedValue(undefined);
+    mockPendingUnpinRepository.delete.mockResolvedValue({ affected: 1 });
+
+    await refcountAndMaybeUnpin(mockManager, 'bafkcid', mockIpfsProvider as any);
+
+    expect(mockIpfsProvider.unpinFile).toHaveBeenCalledWith('bafkcid');
+    expect(mockPendingUnpinRepository.delete).toHaveBeenCalledWith({ cid: 'bafkcid' });
+  });
+});

--- a/apps/api/src/ipfs/pending-unpin/unpin-helpers.ts
+++ b/apps/api/src/ipfs/pending-unpin/unpin-helpers.ts
@@ -21,8 +21,25 @@ export async function withCidLock<T>(
 }
 
 /**
+ * Outcome of refcountAndMaybeUnpin, so callers can log the two paths distinctly
+ * without the plain function needing access to a Logger:
+ * - 'unpinned': refs were zero, the CID was physically unpinned.
+ * - 'skipped-repinned': refs > 0, the physical unpin was skipped and only the
+ *   stale outbox row was discarded (re-pin race — useful to audit in prod logs).
+ *
+ * `refs` carries the refcount observed at re-check time so the caller can log
+ * the re-pin race detail (refs=N) for the skipped path.
+ */
+export interface RefcountUnpinResult {
+  outcome: 'unpinned' | 'skipped-repinned';
+  refs: number;
+}
+
+/**
  * Under an already-held CID advisory lock: recheck refcount, unpin when zero,
- * delete the outbox row.
+ * delete the outbox row. Returns which path was taken (and the observed
+ * refcount) so the caller can emit a distinct log message (the function itself
+ * has no Logger by design).
  *
  * Must be called within a transaction that has already called withCidLock for
  * the same CID. Use only for drainRow (Kubo inside lock). Do NOT use at the
@@ -32,12 +49,13 @@ export async function refcountAndMaybeUnpin(
   manager: EntityManager,
   cid: string,
   ipfsProvider: IpfsProvider
-): Promise<void> {
+): Promise<RefcountUnpinResult> {
   const refs = await manager.getRepository(PinnedCid).count({ where: { cid } });
   if (refs > 0) {
     await manager.getRepository(PendingUnpin).delete({ cid });
-    return; // stale outbox row — CID is re-pinned
+    return { outcome: 'skipped-repinned', refs }; // stale outbox row — CID is re-pinned
   }
   await ipfsProvider.unpinFile(cid);
   await manager.getRepository(PendingUnpin).delete({ cid });
+  return { outcome: 'unpinned', refs };
 }

--- a/apps/api/src/ipfs/pending-unpin/unpin-helpers.ts
+++ b/apps/api/src/ipfs/pending-unpin/unpin-helpers.ts
@@ -1,0 +1,43 @@
+import { EntityManager } from 'typeorm';
+import { PendingUnpin } from '../../vault/entities/pending-unpin.entity';
+import { PinnedCid } from '../../vault/entities/pinned-cid.entity';
+import { IpfsProvider } from '../providers/ipfs-provider.interface';
+
+/**
+ * Acquires pg_advisory_xact_lock(hashtext(cid)::bigint) as the first
+ * transactional statement and runs fn inside the lock.
+ *
+ * INT_MIN-safe: hashtext returns int4; casting directly to bigint sign-extends
+ * the value rather than overflowing abs() on INT_MIN (-2147483648). DO NOT
+ * add abs() before the cast — that was the bug fixed in Phase 42/50.
+ */
+export async function withCidLock<T>(
+  manager: EntityManager,
+  cid: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  await manager.query(`SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`, [cid]);
+  return fn();
+}
+
+/**
+ * Under an already-held CID advisory lock: recheck refcount, unpin when zero,
+ * delete the outbox row.
+ *
+ * Must be called within a transaction that has already called withCidLock for
+ * the same CID. Use only for drainRow (Kubo inside lock). Do NOT use at the
+ * guardedUnpin post-commit site where Kubo must remain outside the transaction.
+ */
+export async function refcountAndMaybeUnpin(
+  manager: EntityManager,
+  cid: string,
+  ipfsProvider: IpfsProvider
+): Promise<void> {
+  const refs = await manager.getRepository(PinnedCid).count({ where: { cid } });
+  if (refs > 0) {
+    await manager.getRepository(PendingUnpin).delete({ cid });
+    return; // stale outbox row — CID is re-pinned
+  }
+  await ipfsProvider.unpinFile(cid);
+  await manager.getRepository(PendingUnpin).delete({ cid });
+}

--- a/apps/api/src/ipfs/providers/index.ts
+++ b/apps/api/src/ipfs/providers/index.ts
@@ -1,2 +1,3 @@
 export * from './ipfs-provider.interface';
 export * from './local.provider';
+export * from './ipfs-provider.module';

--- a/apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts
+++ b/apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts
@@ -1,0 +1,17 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { IpfsProviderModule } from './ipfs-provider.module';
+import { IPFS_PROVIDER } from './ipfs-provider.interface';
+import { LocalProvider } from './local.provider';
+
+describe('IpfsProviderModule', () => {
+  it('provides and exports IPFS_PROVIDER token as a LocalProvider instance', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot({ isGlobal: false }), IpfsProviderModule],
+    }).compile();
+
+    const provider = module.get(IPFS_PROVIDER);
+    expect(provider).toBeDefined();
+    expect(provider).toBeInstanceOf(LocalProvider);
+  });
+});

--- a/apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts
+++ b/apps/api/src/ipfs/providers/ipfs-provider.module.spec.ts
@@ -1,7 +1,8 @@
+import { Injectable, Inject, Module } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
 import { IpfsProviderModule } from './ipfs-provider.module';
-import { IPFS_PROVIDER } from './ipfs-provider.interface';
+import { IPFS_PROVIDER, IpfsProvider } from './ipfs-provider.interface';
 import { LocalProvider } from './local.provider';
 
 describe('IpfsProviderModule', () => {
@@ -13,5 +14,39 @@ describe('IpfsProviderModule', () => {
     const provider = module.get(IPFS_PROVIDER);
     expect(provider).toBeDefined();
     expect(provider).toBeInstanceOf(LocalProvider);
+  });
+
+  // Regression for the boot-time UnknownExportException: a module that imports
+  // IpfsProviderModule cannot re-export IPFS_PROVIDER directly (the token is not
+  // its own local provider) — it must re-export the IpfsProviderModule itself for
+  // a downstream importer (e.g. AuthModule) to inject the token. This mirrors the
+  // IpfsModule.forRootAsync() -> AuthModule injection chain that failed at boot
+  // when exports was `[IPFS_PROVIDER]` instead of `[IpfsProviderModule]`.
+  it('re-exports IPFS_PROVIDER to a downstream importer via module re-export', async () => {
+    // Mirrors IpfsModule.forRootAsync(): imports the leaf, re-exports the module.
+    @Module({
+      imports: [IpfsProviderModule],
+      exports: [IpfsProviderModule],
+    })
+    class ReExportingModule {}
+
+    // Mirrors AuthService: a consumer in a separate module that injects the token.
+    @Injectable()
+    class ConsumerService {
+      constructor(@Inject(IPFS_PROVIDER) public readonly ipfs: IpfsProvider) {}
+    }
+
+    @Module({
+      imports: [ReExportingModule],
+      providers: [ConsumerService],
+    })
+    class ConsumerModule {}
+
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot({ isGlobal: false }), ConsumerModule],
+    }).compile();
+
+    const consumer = module.get(ConsumerService);
+    expect(consumer.ipfs).toBeInstanceOf(LocalProvider);
   });
 });

--- a/apps/api/src/ipfs/providers/ipfs-provider.module.ts
+++ b/apps/api/src/ipfs/providers/ipfs-provider.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { IPFS_PROVIDER } from './ipfs-provider.interface';
+import { LocalProvider } from './local.provider';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [
+    {
+      provide: IPFS_PROVIDER,
+      useFactory: (configService: ConfigService) => {
+        const apiUrl = configService.get<string>('IPFS_LOCAL_API_URL', 'http://localhost:5001');
+        const gatewayUrl = configService.get<string>(
+          'IPFS_LOCAL_GATEWAY_URL',
+          'http://localhost:8080'
+        );
+        return new LocalProvider(apiUrl, gatewayUrl);
+      },
+      inject: [ConfigService],
+    },
+  ],
+  exports: [IPFS_PROVIDER],
+})
+export class IpfsProviderModule {}

--- a/apps/api/src/ipfs/providers/local.provider.spec.ts
+++ b/apps/api/src/ipfs/providers/local.provider.spec.ts
@@ -140,9 +140,7 @@ describe('LocalProvider', () => {
     it('should percent-encode a CID with reserved chars in pin/rm URL (D-04)', async () => {
       mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
       const reservedCid = 'bafk&evil=1';
-      await provider.unpinFile(reservedCid).catch(() => {
-        // may throw due to the fake CID; we only care about the URL passed to fetch
-      });
+      await provider.unpinFile(reservedCid);
       const [url] = mockFetch.mock.calls[0];
       expect(url).not.toContain('&evil');
       expect(url).toContain('bafk%26evil%3D1');
@@ -218,9 +216,7 @@ describe('LocalProvider', () => {
         arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
       });
       const reservedCid = 'bafk&evil=1';
-      await provider.getFile(reservedCid).catch(() => {
-        // may throw due to the fake CID; we only care about the URL passed to fetch
-      });
+      await provider.getFile(reservedCid);
       const [url] = mockFetch.mock.calls[0];
       expect(url).not.toContain('&evil');
       expect(url).toContain('bafk%26evil%3D1');

--- a/apps/api/src/ipfs/providers/local.provider.spec.ts
+++ b/apps/api/src/ipfs/providers/local.provider.spec.ts
@@ -136,6 +136,18 @@ describe('LocalProvider', () => {
   describe('unpinFile', () => {
     const mockCid = 'bafkreigaknpexyvxt76zgkitavbwx6ejgfheup5oybpm77f3pxzrvwpfdi';
 
+    // RED: URL-encoding test — CID with reserved chars must be percent-encoded in the query string
+    it('should percent-encode a CID with reserved chars in pin/rm URL (D-04)', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
+      const reservedCid = 'bafk&evil=1';
+      await provider.unpinFile(reservedCid).catch(() => {
+        // may throw due to the fake CID; we only care about the URL passed to fetch
+      });
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).not.toContain('&evil');
+      expect(url).toContain('bafk%26evil%3D1');
+    });
+
     it('should return void on successful unpin', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -197,6 +209,22 @@ describe('LocalProvider', () => {
   describe('getFile', () => {
     const mockCid = 'bafkreigaknpexyvxt76zgkitavbwx6ejgfheup5oybpm77f3pxzrvwpfdi';
     const mockContent = Buffer.from('encrypted file content');
+
+    // RED: URL-encoding test — CID with reserved chars must be percent-encoded in the query string
+    it('should percent-encode a CID with reserved chars in cat URL (D-04)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      });
+      const reservedCid = 'bafk&evil=1';
+      await provider.getFile(reservedCid).catch(() => {
+        // may throw due to the fake CID; we only care about the URL passed to fetch
+      });
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).not.toContain('&evil');
+      expect(url).toContain('bafk%26evil%3D1');
+    });
 
     it('should return buffer on successful get', async () => {
       const contentArrayBuffer = new Uint8Array(mockContent).buffer;

--- a/apps/api/src/ipfs/providers/local.provider.ts
+++ b/apps/api/src/ipfs/providers/local.provider.ts
@@ -84,7 +84,8 @@ export class LocalProvider implements IpfsProvider {
 
     try {
       // Kubo API uses POST for all operations including unpin
-      const response = await fetch(`${this.apiUrl}/api/v0/pin/rm?arg=${cid}`, {
+      const params = new URLSearchParams({ arg: cid });
+      const response = await fetch(`${this.apiUrl}/api/v0/pin/rm?${params}`, {
         method: 'POST',
       });
 
@@ -124,7 +125,8 @@ export class LocalProvider implements IpfsProvider {
 
     try {
       // Kubo API uses POST for cat operation
-      const response = await fetch(`${this.apiUrl}/api/v0/cat?arg=${cid}`, {
+      const params = new URLSearchParams({ arg: cid });
+      const response = await fetch(`${this.apiUrl}/api/v0/cat?${params}`, {
         method: 'POST',
       });
 

--- a/apps/api/src/vault/vault.module.ts
+++ b/apps/api/src/vault/vault.module.ts
@@ -1,42 +1,23 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ConfigModule } from '@nestjs/config';
 import { VaultController } from './vault.controller';
 import { VaultService } from './vault.service';
 import { Vault, PinnedCid, PendingUnpin } from './entities';
 import { FolderIpns } from '../ipns/entities/folder-ipns.entity';
 import { User } from '../auth/entities/user.entity';
 import { TeeModule } from '../tee/tee.module';
-import { IPFS_PROVIDER, LocalProvider } from '../ipfs/providers';
+import { IpfsProviderModule } from '../ipfs/providers';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Vault, PinnedCid, FolderIpns, User, PendingUnpin]),
     ConfigModule,
     TeeModule,
+    IpfsProviderModule,
   ],
   controllers: [VaultController],
-  providers: [
-    VaultService,
-    // IN-04 (accepted): IPFS_PROVIDER useFactory is duplicated across VaultModule,
-    // IpfsModule, and PendingUnpinModule. This instance avoids a circular import:
-    // IpfsModule imports VaultModule, so re-importing IpfsModule here would create
-    // a cycle. Each module self-provides to break the cycle. Extraction into a shared
-    // IpfsProviderCoreModule is deferred — it would require restructuring the full
-    // import graph. Accepted with this comment.
-    {
-      provide: IPFS_PROVIDER,
-      useFactory: (configService: ConfigService) => {
-        const apiUrl = configService.get<string>('IPFS_LOCAL_API_URL', 'http://localhost:5001');
-        const gatewayUrl = configService.get<string>(
-          'IPFS_LOCAL_GATEWAY_URL',
-          'http://localhost:8080'
-        );
-        return new LocalProvider(apiUrl, gatewayUrl);
-      },
-      inject: [ConfigService],
-    },
-  ],
+  providers: [VaultService],
   exports: [VaultService],
 })
 export class VaultModule {}

--- a/apps/api/src/vault/vault.service.ts
+++ b/apps/api/src/vault/vault.service.ts
@@ -14,6 +14,7 @@ import { VaultConfigResponseDto } from './dto/vault-config.dto';
 import { TeeKeyStateService } from '../tee/tee-key-state.service';
 import { TeeKeysDto } from '../tee/dto/tee-keys.dto';
 import { IPFS_PROVIDER, IpfsProvider } from '../ipfs/providers';
+import { withCidLock } from '../ipfs/pending-unpin/unpin-helpers';
 import { MetricsService } from '../metrics/metrics.service';
 
 /**
@@ -260,52 +261,51 @@ export class VaultService {
       const pinnedCidRepo = manager.getRepository(PinnedCid);
       const pendingUnpinRepo = manager.getRepository(PendingUnpin);
 
-      // 1. Advisory xact lock — MUST be the first transactional statement (D-04)
-      // abs() was incorrectly applied to int4 before the bigint cast, overflowing for INT_MIN
-      // (-2147483648); pg_advisory_xact_lock accepts signed bigint so sign-extending
-      // hashtext int4→bigint is safe (D-01 / WR-01).
-      await manager.query(`SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`, [cid]);
-
-      // 2. Ownership check (D-01)
-      const row = await pinnedCidRepo.findOne({ where: { userId, cid } });
-      if (!row) {
-        const otherRow = await pinnedCidRepo.findOne({ where: { cid } });
-        if (otherRow && !options?.suppressCrossUserAudit) {
-          this.logger.warn(`Cross-user unpin attempt userId=${userId} cid=${cid}`);
-          this.metricsService.unpinCrossUserAttempts.inc();
+      // 1. Advisory xact lock — MUST be the first transactional statement (D-04).
+      // Lock is acquired via withCidLock (unpin-helpers.ts) which runs the verbatim
+      // INT_MIN-safe SQL: pg_advisory_xact_lock(hashtext($1)::bigint) with NO abs().
+      await withCidLock(manager, cid, async () => {
+        // 2. Ownership check (D-01)
+        const row = await pinnedCidRepo.findOne({ where: { userId, cid } });
+        if (!row) {
+          const otherRow = await pinnedCidRepo.findOne({ where: { cid } });
+          if (otherRow && !options?.suppressCrossUserAudit) {
+            this.logger.warn(`Cross-user unpin attempt userId=${userId} cid=${cid}`);
+            this.metricsService.unpinCrossUserAttempts.inc();
+          }
+          return; // silent 2XX (D-01: no oracle — same response for unknown vs cross-user)
         }
-        return; // silent 2XX (D-01: no oracle — same response for unknown vs cross-user)
-      }
 
-      // 3. Delete caller's row — this IS the quota decrement (D-03)
-      const deleteResult = await pinnedCidRepo.delete({ userId, cid });
-      rowDeleted = (deleteResult.affected ?? 0) > 0; // IN-01: only true on an actual row deletion
+        // 3. Delete caller's row — this IS the quota decrement (D-03)
+        const deleteResult = await pinnedCidRepo.delete({ userId, cid });
+        rowDeleted = (deleteResult.affected ?? 0) > 0; // IN-01: only true on an actual row deletion
 
-      // 4. Refcount across all users (D-05, D-07: no origin filtering)
-      // WR-07 disposition: BYO advisory rows intentionally count toward the hosted
-      // refcount — this is the D-07 design: a BYO advisory row blocks physical unpin
-      // of hosted content until that BYO row is removed. See docs/CAPACITY.md §7 for
-      // the retention consequence. (WR-07 accepted: filtering BYO rows would change
-      // refcount semantics and break the shared-owner-vs-BYO invariant from D-07.)
-      const result = await manager
-        .createQueryBuilder(PinnedCid, 'pc')
-        .select('COUNT(*)', 'count')
-        .where('pc.cid = :cid', { cid })
-        .getRawOne<{ count: string }>();
-      const refcount = parseInt(result?.count ?? '0', 10);
+        // 4. Refcount across all users (D-05, D-07: no origin filtering)
+        // WR-07 disposition: BYO advisory rows intentionally count toward the hosted
+        // refcount — this is the D-07 design: a BYO advisory row blocks physical unpin
+        // of hosted content until that BYO row is removed. See docs/CAPACITY.md §7 for
+        // the retention consequence. (WR-07 accepted: filtering BYO rows would change
+        // refcount semantics and break the shared-owner-vs-BYO invariant from D-07.)
+        const result = await manager
+          .createQueryBuilder(PinnedCid, 'pc')
+          .select('COUNT(*)', 'count')
+          .where('pc.cid = :cid', { cid })
+          .getRawOne<{ count: string }>();
+        const refcount = parseInt(result?.count ?? '0', 10);
 
-      if (refcount === 0) {
-        // 5. Queue physical unpin via outbox — orIgnore dedupes concurrent inserts (Pitfall 5)
-        await pendingUnpinRepo
-          .createQueryBuilder()
-          .insert()
-          .into(PendingUnpin)
-          .values({ cid })
-          .orIgnore()
-          .execute();
-        shouldAttemptPhysicalUnpin = true; // IN-06: flag gates the post-commit Kubo call
-      }
-      // Transaction commits; advisory lock released automatically at end of transaction
+        if (refcount === 0) {
+          // 5. Queue physical unpin via outbox — orIgnore dedupes concurrent inserts (Pitfall 5)
+          await pendingUnpinRepo
+            .createQueryBuilder()
+            .insert()
+            .into(PendingUnpin)
+            .values({ cid })
+            .orIgnore()
+            .execute();
+          shouldAttemptPhysicalUnpin = true; // IN-06: flag gates the post-commit Kubo call
+        }
+        // Transaction commits; advisory lock released automatically at end of transaction
+      });
     });
 
     // 6. Post-commit best-effort Kubo call (D-03 ordering: NEVER inside transaction, Pitfall 3)
@@ -319,8 +319,11 @@ export class VaultService {
         // Kubo call stays outside the lock/transaction (D-03 ordering, Pitfall 3); only
         // the row delete is serialized.
         await this.dataSource.transaction(async (manager) => {
-          await manager.query(`SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`, [cid]);
-          await manager.getRepository(PendingUnpin).delete({ cid });
+          // Post-commit: Kubo call already ran outside this transaction (D-03 ordering).
+          // Only the outbox-row delete is serialized under the advisory lock.
+          await withCidLock(manager, cid, async () => {
+            await manager.getRepository(PendingUnpin).delete({ cid });
+          });
         });
       } catch {
         // Leave outbox row for BullMQ retry worker — Kubo failure is not a request failure

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -2208,7 +2208,7 @@
   "info": {
     "title": "CipherBox API",
     "description": "Zero-knowledge encrypted cloud storage API",
-    "version": "0.41.0",
+    "version": "0.42.0",
     "contact": {}
   },
   "tags": [
@@ -2648,7 +2648,9 @@
         "properties": {
           "cid": {
             "type": "string",
-            "description": "IPFS CID pinned to external provider (CIDv0 or CIDv1)"
+            "description": "IPFS CID pinned to external provider (CIDv0 or CIDv1)",
+            "pattern": "^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$",
+            "maxLength": 255
           },
           "sizeBytes": {
             "type": "number",

--- a/packages/api-client/src/generated/auth/auth.ts
+++ b/packages/api-client/src/generated/auth/auth.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type {
   AuthMethodResponseDto,

--- a/packages/api-client/src/generated/device-approval/device-approval.ts
+++ b/packages/api-client/src/generated/device-approval/device-approval.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type {
   CreateApprovalDto,

--- a/packages/api-client/src/generated/health/health.ts
+++ b/packages/api-client/src/generated/health/health.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { HealthControllerCheck200 } from '../../models';
 

--- a/packages/api-client/src/generated/identity/identity.ts
+++ b/packages/api-client/src/generated/identity/identity.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type {
   GoogleLoginDto,

--- a/packages/api-client/src/generated/invites/invites.ts
+++ b/packages/api-client/src/generated/invites/invites.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type {
   ClaimInviteDto,

--- a/packages/api-client/src/generated/ipfs/ipfs.ts
+++ b/packages/api-client/src/generated/ipfs/ipfs.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type {
   IpfsControllerUploadBody,

--- a/packages/api-client/src/generated/ipns/ipns.ts
+++ b/packages/api-client/src/generated/ipns/ipns.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type {
   BatchPublishIpnsDto,

--- a/packages/api-client/src/generated/root/root.ts
+++ b/packages/api-client/src/generated/root/root.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import { customInstance } from '../../instance';
 

--- a/packages/api-client/src/generated/share-invites/share-invites.ts
+++ b/packages/api-client/src/generated/share-invites/share-invites.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type {
   CreateInviteDto,

--- a/packages/api-client/src/generated/shares/shares.ts
+++ b/packages/api-client/src/generated/shares/shares.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type {
   AddShareKeysDto,

--- a/packages/api-client/src/generated/tee/tee.ts
+++ b/packages/api-client/src/generated/tee/tee.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { ConnectionTestRequestDto, ConnectionTestResponseDto } from '../../models';
 

--- a/packages/api-client/src/generated/vault/vault.ts
+++ b/packages/api-client/src/generated/vault/vault.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type {
   InitVaultDto,

--- a/packages/api-client/src/models/addShareKeysDto.ts
+++ b/packages/api-client/src/models/addShareKeysDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { ShareKeyEntryDto } from './shareKeyEntryDto';
 

--- a/packages/api-client/src/models/authMethodResponseDto.ts
+++ b/packages/api-client/src/models/authMethodResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { AuthMethodResponseDtoType } from './authMethodResponseDtoType';
 

--- a/packages/api-client/src/models/authMethodResponseDtoType.ts
+++ b/packages/api-client/src/models/authMethodResponseDtoType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type AuthMethodResponseDtoType =

--- a/packages/api-client/src/models/batchPublishIpnsDto.ts
+++ b/packages/api-client/src/models/batchPublishIpnsDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { PublishIpnsEntryDto } from './publishIpnsEntryDto';
 

--- a/packages/api-client/src/models/batchPublishIpnsResponseDto.ts
+++ b/packages/api-client/src/models/batchPublishIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { PublishIpnsResponseDto } from './publishIpnsResponseDto';
 

--- a/packages/api-client/src/models/batchUnenrollIpnsDto.ts
+++ b/packages/api-client/src/models/batchUnenrollIpnsDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface BatchUnenrollIpnsDto {

--- a/packages/api-client/src/models/batchUnenrollIpnsResponseDto.ts
+++ b/packages/api-client/src/models/batchUnenrollIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface BatchUnenrollIpnsResponseDto {

--- a/packages/api-client/src/models/childKeyDto.ts
+++ b/packages/api-client/src/models/childKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { ChildKeyDtoKeyType } from './childKeyDtoKeyType';
 

--- a/packages/api-client/src/models/childKeyDtoKeyType.ts
+++ b/packages/api-client/src/models/childKeyDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/claimChildKeyDto.ts
+++ b/packages/api-client/src/models/claimChildKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { ClaimChildKeyDtoKeyType } from './claimChildKeyDtoKeyType';
 

--- a/packages/api-client/src/models/claimChildKeyDtoKeyType.ts
+++ b/packages/api-client/src/models/claimChildKeyDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/claimInviteDto.ts
+++ b/packages/api-client/src/models/claimInviteDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { ClaimChildKeyDto } from './claimChildKeyDto';
 

--- a/packages/api-client/src/models/claimInviteResponseDto.ts
+++ b/packages/api-client/src/models/claimInviteResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface ClaimInviteResponseDto {

--- a/packages/api-client/src/models/connectionTestRequestDto.ts
+++ b/packages/api-client/src/models/connectionTestRequestDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface ConnectionTestRequestDto {

--- a/packages/api-client/src/models/connectionTestResponseDto.ts
+++ b/packages/api-client/src/models/connectionTestResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { ConnectionTestResponseDtoProtocol } from './connectionTestResponseDtoProtocol';
 

--- a/packages/api-client/src/models/connectionTestResponseDtoProtocol.ts
+++ b/packages/api-client/src/models/connectionTestResponseDtoProtocol.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/createApprovalDto.ts
+++ b/packages/api-client/src/models/createApprovalDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface CreateApprovalDto {

--- a/packages/api-client/src/models/createInviteDto.ts
+++ b/packages/api-client/src/models/createInviteDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { CreateInviteDtoItemType } from './createInviteDtoItemType';
 import type { InviteChildKeyDto } from './inviteChildKeyDto';

--- a/packages/api-client/src/models/createInviteDtoItemType.ts
+++ b/packages/api-client/src/models/createInviteDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/createShareDto.ts
+++ b/packages/api-client/src/models/createShareDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { CreateShareDtoItemType } from './createShareDtoItemType';
 import type { CreateShareDtoPermission } from './createShareDtoPermission';

--- a/packages/api-client/src/models/createShareDtoItemType.ts
+++ b/packages/api-client/src/models/createShareDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/createShareDtoPermission.ts
+++ b/packages/api-client/src/models/createShareDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/createShareResponseDto.ts
+++ b/packages/api-client/src/models/createShareResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { CreateShareResponseDtoItemType } from './createShareResponseDtoItemType';
 import type { CreateShareResponseDtoPermission } from './createShareResponseDtoPermission';

--- a/packages/api-client/src/models/createShareResponseDtoItemType.ts
+++ b/packages/api-client/src/models/createShareResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type CreateShareResponseDtoItemType =

--- a/packages/api-client/src/models/createShareResponseDtoPermission.ts
+++ b/packages/api-client/src/models/createShareResponseDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/deleteAccountDto.ts
+++ b/packages/api-client/src/models/deleteAccountDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface DeleteAccountDto {

--- a/packages/api-client/src/models/deleteAccountResponseDto.ts
+++ b/packages/api-client/src/models/deleteAccountResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface DeleteAccountResponseDto {

--- a/packages/api-client/src/models/desktopRefreshDto.ts
+++ b/packages/api-client/src/models/desktopRefreshDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface DesktopRefreshDto {

--- a/packages/api-client/src/models/deviceApprovalControllerCreateRequest201.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerCreateRequest201.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type DeviceApprovalControllerCreateRequest201 = {

--- a/packages/api-client/src/models/deviceApprovalControllerGetPending200Item.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerGetPending200Item.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type DeviceApprovalControllerGetPending200Item = {

--- a/packages/api-client/src/models/deviceApprovalControllerGetStatus200.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerGetStatus200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { DeviceApprovalControllerGetStatus200Status } from './deviceApprovalControllerGetStatus200Status';
 

--- a/packages/api-client/src/models/deviceApprovalControllerGetStatus200Status.ts
+++ b/packages/api-client/src/models/deviceApprovalControllerGetStatus200Status.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type DeviceApprovalControllerGetStatus200Status =

--- a/packages/api-client/src/models/googleLoginDto.ts
+++ b/packages/api-client/src/models/googleLoginDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { GoogleLoginDtoIntent } from './googleLoginDtoIntent';
 

--- a/packages/api-client/src/models/googleLoginDtoIntent.ts
+++ b/packages/api-client/src/models/googleLoginDtoIntent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/healthControllerCheck200.ts
+++ b/packages/api-client/src/models/healthControllerCheck200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { HealthControllerCheck200Info } from './healthControllerCheck200Info';
 import type { HealthControllerCheck200Error } from './healthControllerCheck200Error';

--- a/packages/api-client/src/models/healthControllerCheck200Details.ts
+++ b/packages/api-client/src/models/healthControllerCheck200Details.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { HealthControllerCheck200DetailsDatabase } from './healthControllerCheck200DetailsDatabase';
 

--- a/packages/api-client/src/models/healthControllerCheck200DetailsDatabase.ts
+++ b/packages/api-client/src/models/healthControllerCheck200DetailsDatabase.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type HealthControllerCheck200DetailsDatabase = {

--- a/packages/api-client/src/models/healthControllerCheck200Error.ts
+++ b/packages/api-client/src/models/healthControllerCheck200Error.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type HealthControllerCheck200Error = { [key: string]: unknown };

--- a/packages/api-client/src/models/healthControllerCheck200Info.ts
+++ b/packages/api-client/src/models/healthControllerCheck200Info.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { HealthControllerCheck200InfoDatabase } from './healthControllerCheck200InfoDatabase';
 

--- a/packages/api-client/src/models/healthControllerCheck200InfoDatabase.ts
+++ b/packages/api-client/src/models/healthControllerCheck200InfoDatabase.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type HealthControllerCheck200InfoDatabase = {

--- a/packages/api-client/src/models/identityControllerGetJwks200.ts
+++ b/packages/api-client/src/models/identityControllerGetJwks200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { IdentityControllerGetJwks200KeysItem } from './identityControllerGetJwks200KeysItem';
 

--- a/packages/api-client/src/models/identityControllerGetJwks200KeysItem.ts
+++ b/packages/api-client/src/models/identityControllerGetJwks200KeysItem.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type IdentityControllerGetJwks200KeysItem = { [key: string]: unknown };

--- a/packages/api-client/src/models/identityControllerGetWalletNonce200.ts
+++ b/packages/api-client/src/models/identityControllerGetWalletNonce200.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type IdentityControllerGetWalletNonce200 = {

--- a/packages/api-client/src/models/identityTokenResponseDto.ts
+++ b/packages/api-client/src/models/identityTokenResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface IdentityTokenResponseDto {

--- a/packages/api-client/src/models/index.ts
+++ b/packages/api-client/src/models/index.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export * from './addShareKeysDto';

--- a/packages/api-client/src/models/initVaultDto.ts
+++ b/packages/api-client/src/models/initVaultDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface InitVaultDto {

--- a/packages/api-client/src/models/inviteChildKeyDto.ts
+++ b/packages/api-client/src/models/inviteChildKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { InviteChildKeyDtoKeyType } from './inviteChildKeyDtoKeyType';
 

--- a/packages/api-client/src/models/inviteChildKeyDtoKeyType.ts
+++ b/packages/api-client/src/models/inviteChildKeyDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/inviteDataResponseDto.ts
+++ b/packages/api-client/src/models/inviteDataResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { InviteDataResponseDtoStatus } from './inviteDataResponseDtoStatus';
 import type { InviteChildKeyDto } from './inviteChildKeyDto';

--- a/packages/api-client/src/models/inviteDataResponseDtoItemType.ts
+++ b/packages/api-client/src/models/inviteDataResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type InviteDataResponseDtoItemType =

--- a/packages/api-client/src/models/inviteDataResponseDtoStatus.ts
+++ b/packages/api-client/src/models/inviteDataResponseDtoStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/inviteResponseDto.ts
+++ b/packages/api-client/src/models/inviteResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { InviteResponseDtoItemType } from './inviteResponseDtoItemType';
 import type { InviteResponseDtoStatus } from './inviteResponseDtoStatus';

--- a/packages/api-client/src/models/inviteResponseDtoItemType.ts
+++ b/packages/api-client/src/models/inviteResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type InviteResponseDtoItemType =

--- a/packages/api-client/src/models/inviteResponseDtoStatus.ts
+++ b/packages/api-client/src/models/inviteResponseDtoStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type InviteResponseDtoStatus =

--- a/packages/api-client/src/models/inviteStatusResponseDto.ts
+++ b/packages/api-client/src/models/inviteStatusResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { InviteStatusResponseDtoStatus } from './inviteStatusResponseDtoStatus';
 

--- a/packages/api-client/src/models/inviteStatusResponseDtoStatus.ts
+++ b/packages/api-client/src/models/inviteStatusResponseDtoStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/ipfsControllerUploadBody.ts
+++ b/packages/api-client/src/models/ipfsControllerUploadBody.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type IpfsControllerUploadBody = {

--- a/packages/api-client/src/models/ipnsControllerResolveRecordParams.ts
+++ b/packages/api-client/src/models/ipnsControllerResolveRecordParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type IpnsControllerResolveRecordParams = {

--- a/packages/api-client/src/models/linkMethodDto.ts
+++ b/packages/api-client/src/models/linkMethodDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { LinkMethodDtoLoginType } from './linkMethodDtoLoginType';
 

--- a/packages/api-client/src/models/linkMethodDtoLoginType.ts
+++ b/packages/api-client/src/models/linkMethodDtoLoginType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/loginDto.ts
+++ b/packages/api-client/src/models/loginDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { LoginDtoLoginType } from './loginDtoLoginType';
 

--- a/packages/api-client/src/models/loginDtoLoginType.ts
+++ b/packages/api-client/src/models/loginDtoLoginType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/loginResponseDto.ts
+++ b/packages/api-client/src/models/loginResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface LoginResponseDto {

--- a/packages/api-client/src/models/logoutResponseDto.ts
+++ b/packages/api-client/src/models/logoutResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface LogoutResponseDto {

--- a/packages/api-client/src/models/lookupUserResponseDto.ts
+++ b/packages/api-client/src/models/lookupUserResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface LookupUserResponseDto {

--- a/packages/api-client/src/models/paginatedReceivedSharesDto.ts
+++ b/packages/api-client/src/models/paginatedReceivedSharesDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { ReceivedShareResponseDto } from './receivedShareResponseDto';
 

--- a/packages/api-client/src/models/paginatedSentSharesDto.ts
+++ b/packages/api-client/src/models/paginatedSentSharesDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { SentShareResponseDto } from './sentShareResponseDto';
 

--- a/packages/api-client/src/models/pendingRotationResponseDto.ts
+++ b/packages/api-client/src/models/pendingRotationResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { PendingRotationResponseDtoItemType } from './pendingRotationResponseDtoItemType';
 

--- a/packages/api-client/src/models/pendingRotationResponseDtoItemType.ts
+++ b/packages/api-client/src/models/pendingRotationResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type PendingRotationResponseDtoItemType =

--- a/packages/api-client/src/models/publishIpnsDto.ts
+++ b/packages/api-client/src/models/publishIpnsDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface PublishIpnsDto {

--- a/packages/api-client/src/models/publishIpnsEntryDto.ts
+++ b/packages/api-client/src/models/publishIpnsEntryDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { PublishIpnsEntryDtoRecordType } from './publishIpnsEntryDtoRecordType';
 

--- a/packages/api-client/src/models/publishIpnsEntryDtoRecordType.ts
+++ b/packages/api-client/src/models/publishIpnsEntryDtoRecordType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/publishIpnsResponseDto.ts
+++ b/packages/api-client/src/models/publishIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface PublishIpnsResponseDto {

--- a/packages/api-client/src/models/quotaResponseDto.ts
+++ b/packages/api-client/src/models/quotaResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface QuotaResponseDto {

--- a/packages/api-client/src/models/receivedShareResponseDto.ts
+++ b/packages/api-client/src/models/receivedShareResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { ReceivedShareResponseDtoItemType } from './receivedShareResponseDtoItemType';
 import type { ReceivedShareResponseDtoPermission } from './receivedShareResponseDtoPermission';

--- a/packages/api-client/src/models/receivedShareResponseDtoItemType.ts
+++ b/packages/api-client/src/models/receivedShareResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type ReceivedShareResponseDtoItemType =

--- a/packages/api-client/src/models/receivedShareResponseDtoPermission.ts
+++ b/packages/api-client/src/models/receivedShareResponseDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/registerCidDto.ts
+++ b/packages/api-client/src/models/registerCidDto.ts
@@ -3,11 +3,15 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface RegisterCidDto {
-  /** IPFS CID pinned to external provider (CIDv0 or CIDv1) */
+  /**
+   * IPFS CID pinned to external provider (CIDv0 or CIDv1)
+   * @maxLength 255
+   * @pattern ^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$
+   */
   cid: string;
   /** Size of the pinned content in bytes */
   sizeBytes: number;

--- a/packages/api-client/src/models/registerCidResponseDto.ts
+++ b/packages/api-client/src/models/registerCidResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface RegisterCidResponseDto {

--- a/packages/api-client/src/models/resolveIpnsResponseDto.ts
+++ b/packages/api-client/src/models/resolveIpnsResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface ResolveIpnsResponseDto {

--- a/packages/api-client/src/models/respondApprovalDto.ts
+++ b/packages/api-client/src/models/respondApprovalDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { RespondApprovalDtoAction } from './respondApprovalDtoAction';
 

--- a/packages/api-client/src/models/respondApprovalDtoAction.ts
+++ b/packages/api-client/src/models/respondApprovalDtoAction.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/sendOtpDto.ts
+++ b/packages/api-client/src/models/sendOtpDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface SendOtpDto {

--- a/packages/api-client/src/models/sendOtpResponseDto.ts
+++ b/packages/api-client/src/models/sendOtpResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface SendOtpResponseDto {

--- a/packages/api-client/src/models/sentShareResponseDto.ts
+++ b/packages/api-client/src/models/sentShareResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { SentShareResponseDtoItemType } from './sentShareResponseDtoItemType';
 import type { SentShareResponseDtoPermission } from './sentShareResponseDtoPermission';

--- a/packages/api-client/src/models/sentShareResponseDtoItemType.ts
+++ b/packages/api-client/src/models/sentShareResponseDtoItemType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type SentShareResponseDtoItemType =

--- a/packages/api-client/src/models/sentShareResponseDtoPermission.ts
+++ b/packages/api-client/src/models/sentShareResponseDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/setByoStatusDto.ts
+++ b/packages/api-client/src/models/setByoStatusDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface SetByoStatusDto {

--- a/packages/api-client/src/models/setByoStatusResponseDto.ts
+++ b/packages/api-client/src/models/setByoStatusResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface SetByoStatusResponseDto {

--- a/packages/api-client/src/models/shareInvitesControllerListInvitesParams.ts
+++ b/packages/api-client/src/models/shareInvitesControllerListInvitesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type ShareInvitesControllerListInvitesParams = {

--- a/packages/api-client/src/models/shareKeyEntryDto.ts
+++ b/packages/api-client/src/models/shareKeyEntryDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { ShareKeyEntryDtoKeyType } from './shareKeyEntryDtoKeyType';
 

--- a/packages/api-client/src/models/shareKeyEntryDtoKeyType.ts
+++ b/packages/api-client/src/models/shareKeyEntryDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/shareKeyResponseDto.ts
+++ b/packages/api-client/src/models/shareKeyResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { ShareKeyResponseDtoKeyType } from './shareKeyResponseDtoKeyType';
 

--- a/packages/api-client/src/models/shareKeyResponseDtoKeyType.ts
+++ b/packages/api-client/src/models/shareKeyResponseDtoKeyType.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type ShareKeyResponseDtoKeyType =

--- a/packages/api-client/src/models/sharesControllerGetReceivedSharesParams.ts
+++ b/packages/api-client/src/models/sharesControllerGetReceivedSharesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type SharesControllerGetReceivedSharesParams = {

--- a/packages/api-client/src/models/sharesControllerGetSentSharesParams.ts
+++ b/packages/api-client/src/models/sharesControllerGetSentSharesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type SharesControllerGetSentSharesParams = {

--- a/packages/api-client/src/models/sharesControllerLookupUserParams.ts
+++ b/packages/api-client/src/models/sharesControllerLookupUserParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export type SharesControllerLookupUserParams = {

--- a/packages/api-client/src/models/teeKeysDto.ts
+++ b/packages/api-client/src/models/teeKeysDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface TeeKeysDto {

--- a/packages/api-client/src/models/testLoginDto.ts
+++ b/packages/api-client/src/models/testLoginDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface TestLoginDto {

--- a/packages/api-client/src/models/testLoginResponseDto.ts
+++ b/packages/api-client/src/models/testLoginResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface TestLoginResponseDto {

--- a/packages/api-client/src/models/tokenResponseDto.ts
+++ b/packages/api-client/src/models/tokenResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface TokenResponseDto {

--- a/packages/api-client/src/models/unlinkMethodDto.ts
+++ b/packages/api-client/src/models/unlinkMethodDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface UnlinkMethodDto {

--- a/packages/api-client/src/models/unlinkMethodResponseDto.ts
+++ b/packages/api-client/src/models/unlinkMethodResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface UnlinkMethodResponseDto {

--- a/packages/api-client/src/models/unpinDto.ts
+++ b/packages/api-client/src/models/unpinDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface UnpinDto {

--- a/packages/api-client/src/models/unpinResponseDto.ts
+++ b/packages/api-client/src/models/unpinResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface UnpinResponseDto {

--- a/packages/api-client/src/models/updateEncryptedKeyDto.ts
+++ b/packages/api-client/src/models/updateEncryptedKeyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface UpdateEncryptedKeyDto {

--- a/packages/api-client/src/models/updateItemNameDto.ts
+++ b/packages/api-client/src/models/updateItemNameDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface UpdateItemNameDto {

--- a/packages/api-client/src/models/updatePermissionDto.ts
+++ b/packages/api-client/src/models/updatePermissionDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { UpdatePermissionDtoPermission } from './updatePermissionDtoPermission';
 

--- a/packages/api-client/src/models/updatePermissionDtoPermission.ts
+++ b/packages/api-client/src/models/updatePermissionDtoPermission.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/uploadResponseDto.ts
+++ b/packages/api-client/src/models/uploadResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface UploadResponseDto {

--- a/packages/api-client/src/models/vaultConfigResponseDto.ts
+++ b/packages/api-client/src/models/vaultConfigResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface VaultConfigResponseDto {

--- a/packages/api-client/src/models/vaultExportDto.ts
+++ b/packages/api-client/src/models/vaultExportDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 export interface VaultExportDto {

--- a/packages/api-client/src/models/vaultResponseDto.ts
+++ b/packages/api-client/src/models/vaultResponseDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { VaultResponseDtoTeeKeys } from './vaultResponseDtoTeeKeys';
 

--- a/packages/api-client/src/models/vaultResponseDtoTeeKeys.ts
+++ b/packages/api-client/src/models/vaultResponseDtoTeeKeys.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { TeeKeysDto } from './teeKeysDto';
 

--- a/packages/api-client/src/models/verifyOtpDto.ts
+++ b/packages/api-client/src/models/verifyOtpDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { VerifyOtpDtoIntent } from './verifyOtpDtoIntent';
 

--- a/packages/api-client/src/models/verifyOtpDtoIntent.ts
+++ b/packages/api-client/src/models/verifyOtpDtoIntent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/packages/api-client/src/models/walletVerifyDto.ts
+++ b/packages/api-client/src/models/walletVerifyDto.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 import type { WalletVerifyDtoIntent } from './walletVerifyDtoIntent';
 

--- a/packages/api-client/src/models/walletVerifyDtoIntent.ts
+++ b/packages/api-client/src/models/walletVerifyDtoIntent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * CipherBox API
  * Zero-knowledge encrypted cloud storage API
- * OpenAPI spec version: 0.41.0
+ * OpenAPI spec version: 0.42.0
  */
 
 /**

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -66,7 +66,7 @@
       "component": "@cipherbox/api",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.42.1"
+      "release-as": "0.43.0"
     },
     "apps/web": {
       "release-type": "node",
@@ -110,7 +110,7 @@
       "component": "@cipherbox/api-client",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.42.1"
+      "release-as": "0.43.0"
     },
     "packages/sdk-core": {
       "release-type": "node",


### PR DESCRIPTION
## Phase 57: API CID and Provider Hardening + Module Dedup

Closes the `RegisterCidDto` / `UnpinDto` CID-validation divergence (HARD-08), URL-encodes CIDs in Kubo query strings, and deduplicates the triplicated `IPFS_PROVIDER` factory and the advisory-lock SQL across the IPFS module graph. API-only; the IPNS publish/resolve round-trip is untouched.

### Plan 57-01 — CID validation + provider URL-encoding

- Single shared `CID_REGEX` in `apps/api/src/ipfs/dto/cid.constants.ts`; both `register-cid.dto.ts` and `unpin.dto.ts` import it — no inline regex remains.
- `RegisterCidDto.cid` now rejects CIDv0 overflow (tightened `{44,}` to exact `{44}`) and oversized strings (`@MaxLength(255)`), matching `UnpinDto`.
- `LocalProvider.unpinFile` / `getFile` build Kubo `pin/rm` and `cat` query strings via `URLSearchParams` (percent-encoding defense-in-depth); `pin/add` unchanged.
- `openapi.json` carries `maxLength: 255` on `RegisterCidDto.cid`; regenerated `@cipherbox/api-client` is built and committed.

### Plan 57-02 — module dedup + shared unpin primitives

- Single leaf `IpfsProviderModule` (imports only `ConfigModule`) owns the `IPFS_PROVIDER` factory; the three duplicated factory blocks and the misleading `IN-04 (accepted)` circular-dependency comments are removed. `IpfsModule` / `VaultModule` / `PendingUnpinModule` import the leaf; `IpfsModule` still explicitly exports `IPFS_PROVIDER`.
- New `withCidLock` (verbatim INT_MIN-safe `pg_advisory_xact_lock(hashtext($1)::bigint)`, no `abs()`) and `refcountAndMaybeUnpin` helpers in `apps/api/src/ipfs/pending-unpin/unpin-helpers.ts`.
- All three advisory-lock unpin sites route through the shared helpers. `drainRow` uses `refcountAndMaybeUnpin` (Kubo inside the lock); the `guardedUnpin` post-commit `unpinFile` call stays OUTSIDE the inner transaction (D-03 ordering) with only the outbox-row delete under `withCidLock`.

### Verification, security, validation

- Verify: PASSED — 12/12 observable truths verified against source + tests (`57-VERIFICATION.md`).
- Secure: SECURED — 9/9 threat mitigations verified, 0 new findings (`57-SECURITY.md`). T-57-05 (re-pin data-loss race) preserved via under-lock refcount recheck.
- Validate: compliant — 12/12 requirements have validating tests, 0 Nyquist gaps (`57-VALIDATION.md`).

### Tests

- Full `apps/api` jest suite: **903 tests, 47 suites — all passing**.
- New specs: `register-cid.dto.spec.ts` (CIDv1 accept, CIDv0 overflow reject, 255+ reject, canonical accept), `local.provider.spec.ts` (2 percent-encoding tests), `ipfs-provider.module.spec.ts` (leaf module provides token), `unpin-helpers.spec.ts` (lock SQL, refs>0 skip-unpin, refs===0 unpin).

### Notes

- SDK E2E gate intentionally skipped: this phase does not touch the IPNS publish/resolve round-trip that suite exercises. The relevant gates are the `apps/api` jest suite (903/903) and `api:generate` client consistency (both green).
- Pre-existing: 3 `tsc --noEmit` errors in `metrics/http-metrics.interceptor.spec.ts`, `shares/share-invite.service.spec.ts`, `shares/shares.controller.spec.ts` exist at the fork base, are untouched by this phase, and are not phase-57 blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tightened CID validation with shared rules and consistent `maxLength` constraints across API endpoints.
  * Improved IPFS Kubo request URL construction by properly encoding CID values to prevent malformed queries.

* **Bug Fixes**
  * More reliable per-CID unpin coordination to ensure correct behavior under concurrent updates and to preserve expected outbox cleanup.

* **Chores**
  * Completed Phase 57: API CID/Provider Hardening & Module Dedup.
  * Unified IPFS provider wiring across API components.
  * Version bumped to 0.43.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->