### PR TITLE
chore(ci): extract IPFS CID from ssh-action stdout in landing deploy

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -77,8 +77,17 @@ jobs:
             rm -rf /tmp/cipherbox-landing || true
 
       - name: Validate CID
+        env:
+          # appleboy/ssh-action's capture_stdout appends the drone-ssh banner
+          # ("✅ Successfully executed commands to all hosts") to the remote stdout,
+          # so outputs.stdout is MULTI-LINE even though the script echoes only the CID.
+          # Pass it via env (not inline ${{ }} interpolation) to avoid script injection.
+          RAW_STDOUT: ${{ steps.ipfs.outputs.stdout }}
         run: |
-          CID="${{ steps.ipfs.outputs.stdout }}"
+          # Extract just the IPFS CID (CIDv0 "Qm…" or CIDv1 "baf…") from the captured
+          # output. A bare multi-line value breaks `>> "$GITHUB_ENV"` with
+          # "Unable to process file command 'env' … Value cannot be null. (Parameter 'name')".
+          CID=$(printf '%s\n' "$RAW_STDOUT" | grep -oE -m1 'Qm[1-9A-HJ-NP-Za-km-z]{44}|baf[a-z2-7]{20,}')
           if [ -z "${CID}" ]; then
             echo "::error::No CID returned from IPFS pin step"
             exit 1


### PR DESCRIPTION
## Problem

`Deploy Landing Page to IPFS` fails on **every** push to `main` at the **Validate CID** step:

```
##[error]Unable to process file command 'env' successfully.
##[error]Value cannot be null. (Parameter 'name')
```

The IPFS pin itself always succeeds (the CID is produced and committed to Kubo on the staging host) — only the capture of the CID into `$GITHUB_ENV` fails, which then aborts the DNSLink update.

## Root cause

`appleboy/ssh-action`'s `capture_stdout` appends the drone-ssh banner to the remote stdout:

```
Qmf6j47AaQEtdH1ZHoxCa7Rzo6Wd1GgBh1D7FUNA5fSA34
===============================================
✅ Successfully executed commands to all hosts.
===============================================
```

So `steps.ipfs.outputs.stdout` is **multi-line** even though the remote script `echo`s only the CID (and redirects `docker cp` noise to stderr). `echo "CID=${multiline}" >> "$GITHUB_ENV"` writes a bare multi-line value, and `$GITHUB_ENV` rejects it — multi-line values require heredoc delimiter syntax.

## Fix

In the `Validate CID` step:

- Extract just the IPFS CID (CIDv0 `Qm…` / CIDv1 `baf…`) from the captured output with `grep -oE -m1` before writing to `$GITHUB_ENV`.
- Pass the raw stdout via `env:` instead of inline `${{ }}` interpolation in `run:` — avoids shell/script injection and clears the zizmor `template-injection` flag.

No change to the remote pin script or any other step.

## Testing

Locally validated the extraction against the real failing output:

- CIDv0 multi-line stdout → extracts `Qmf6j47…` ✓
- CIDv1 (`bafy…`) multi-line stdout → extracts the `baf…` CID ✓
- empty stdout → extraction empty, existing `No CID returned` guard fires ✓
- `actionlint .github/workflows/deploy-landing.yml` → clean ✓

The deploy only runs on `main` (or manual `workflow_dispatch`), so end-to-end verification happens on merge; the next push to `main` touching `landing/**` should deploy cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
