### PR TITLE
chore: upgrade Kubo to v0.42.0, raise ipfs CPU/memory, persist Provide.Strategy roots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       ipfs:
-        image: ipfs/kubo:v0.40.0
+        image: ipfs/kubo:v0.42.0
         ports:
           - 5001:5001
           - 8080:8080
@@ -301,7 +301,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       ipfs:
-        image: ipfs/kubo:v0.40.0
+        image: ipfs/kubo:v0.42.0
         ports:
           - 5001:5001
           - 8080:8080
@@ -406,7 +406,7 @@ jobs:
           --health-retries 5
 
       ipfs:
-        image: ipfs/kubo:v0.40.0
+        image: ipfs/kubo:v0.42.0
         ports:
           - 5001:5001
           - 8080:8080

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -53,12 +53,12 @@ jobs:
           script: |
             set -euo pipefail
             # Kubo runs as a Docker container on the staging host (compose service
-            # "ipfs", image ipfs/kubo:v0.40.0) — there is no host-level ipfs CLI, so a
+            # "ipfs", image ipfs/kubo:v0.42.0) — there is no host-level ipfs CLI, so a
             # bare `ipfs` here fails with "command not found". Run it inside the container.
             # Capture the container list first, THEN take the first line: piping
             # `docker ps` straight into `head` can SIGPIPE docker ps (exit 141) under
             # `pipefail` and abort before the empty-KUBO guard runs.
-            KUBO_IDS=$(docker ps -q --filter ancestor=ipfs/kubo:v0.40.0)
+            KUBO_IDS=$(docker ps -q --filter ancestor=ipfs/kubo:v0.42.0)
             KUBO=$(printf '%s\n' "${KUBO_IDS}" | head -n1)
             if [ -z "${KUBO}" ]; then
               echo "::error::No running ipfs/kubo container found on staging host"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -461,7 +461,7 @@ jobs:
           host: ${{ vars.STAGING_HOST }}
           username: ${{ vars.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
-          source: '.env.staging,docker/docker-compose.staging.yml,docker/Caddyfile,docker/alloy-config.river'
+          source: '.env.staging,docker/docker-compose.staging.yml,docker/Caddyfile,docker/alloy-config.river,docker/ipfs-init/001-provide-strategy.sh'
           target: /opt/cipherbox
           strip_components: 0
 

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -78,7 +78,7 @@ jobs:
           --health-retries 5
 
       ipfs:
-        image: ipfs/kubo:v0.40.0
+        image: ipfs/kubo:v0.42.0
         ports:
           - 5001:5001
           - 8080:8080

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -35,7 +35,7 @@ jobs:
           --health-retries 5
 
       ipfs:
-        image: ipfs/kubo:v0.40.0
+        image: ipfs/kubo:v0.42.0
         ports:
           - 5001:5001
           - 8080:8080
@@ -77,15 +77,15 @@ jobs:
       - name: Configure Kubo CORS for browser-based recovery test
         run: |
           # Allow browser cross-origin requests to Kubo gateway (needed by recovery.html)
-          docker exec $(docker ps -q --filter ancestor=ipfs/kubo:v0.40.0) ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
-          docker exec $(docker ps -q --filter ancestor=ipfs/kubo:v0.40.0) ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["GET","POST","OPTIONS"]'
-          docker exec $(docker ps -q --filter ancestor=ipfs/kubo:v0.40.0) ipfs config --json Gateway.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
-          docker exec $(docker ps -q --filter ancestor=ipfs/kubo:v0.40.0) ipfs config --json Gateway.HTTPHeaders.Access-Control-Allow-Methods '["GET","POST","OPTIONS"]'
+          docker exec $(docker ps -q --filter ancestor=ipfs/kubo:v0.42.0) ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
+          docker exec $(docker ps -q --filter ancestor=ipfs/kubo:v0.42.0) ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["GET","POST","OPTIONS"]'
+          docker exec $(docker ps -q --filter ancestor=ipfs/kubo:v0.42.0) ipfs config --json Gateway.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
+          docker exec $(docker ps -q --filter ancestor=ipfs/kubo:v0.42.0) ipfs config --json Gateway.HTTPHeaders.Access-Control-Allow-Methods '["GET","POST","OPTIONS"]'
           # Restart Kubo to apply config (kill + Docker auto-restarts)
-          docker restart $(docker ps -q --filter ancestor=ipfs/kubo:v0.40.0)
+          docker restart $(docker ps -q --filter ancestor=ipfs/kubo:v0.42.0)
           # Wait for Kubo to be healthy again
           for i in $(seq 1 30); do
-            if docker exec $(docker ps -q --filter ancestor=ipfs/kubo:v0.40.0) ipfs id > /dev/null 2>&1; then
+            if docker exec $(docker ps -q --filter ancestor=ipfs/kubo:v0.42.0) ipfs id > /dev/null 2>&1; then
               echo "Kubo ready with CORS configured"
               break
             fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "cipherbox-core"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "ciborium",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "cipherbox-fuse"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64 0.22.1",
  "ciborium",

--- a/docker/docker-compose.staging.yml
+++ b/docker/docker-compose.staging.yml
@@ -60,7 +60,7 @@ services:
       retries: 5
 
   ipfs:
-    image: ipfs/kubo:v0.40.0
+    image: ipfs/kubo:v0.42.0
     restart: unless-stopped
     environment:
       # pebbleds: LSM-tree datastore for faster concurrent write throughput (Phase 19.2)
@@ -74,6 +74,9 @@ services:
       - '127.0.0.1:8080:8080'
     volumes:
       - ipfs_staging:/data/ipfs
+      # Kubo runs /container-init.d/*.sh on every boot (sourced before the daemon);
+      # 001-provide-strategy.sh sets Provide.Strategy=roots idempotently.
+      - ./ipfs-init:/container-init.d:ro
     logging: *default-logging
     healthcheck:
       test: ['CMD-SHELL', 'ipfs id || exit 1']
@@ -84,8 +87,11 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
-          cpus: '1.0'
+          # Kubo is load-bearing and shares the 2-vCPU box with someguy. Load
+          # testing (2026-06) showed the 1.0 cap pegged under concurrent uploads;
+          # 1.5 is the measured throughput knee (+18%), 2.0 gave no further gain.
+          memory: 3G
+          cpus: '1.5'
 
   tee-worker:
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-OWNER}/cipherbox-tee-worker:${TAG:-latest}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 5
 
   ipfs:
-    image: ipfs/kubo:v0.40.0
+    image: ipfs/kubo:v0.42.0
     container_name: cipherbox-ipfs
     restart: unless-stopped
     environment:
@@ -30,6 +30,9 @@ services:
       - IPFS_PROFILE=server,pebbleds
     volumes:
       - ipfs_data:/data/ipfs
+      # Kubo runs /container-init.d/*.sh on every boot (sourced before the daemon);
+      # 001-provide-strategy.sh sets Provide.Strategy=roots idempotently.
+      - ./ipfs-init:/container-init.d:ro
     ports:
       # Swarm - P2P connections
       - '4001:4001/tcp'
@@ -50,8 +53,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
-          cpus: '1.0'
+          # Kubo is load-bearing; mirror the staging tuning (see docs/CAPACITY.md).
+          memory: 3G
+          cpus: '1.5'
 
   redis:
     image: redis:7-alpine

--- a/docker/ipfs-init/001-provide-strategy.sh
+++ b/docker/ipfs-init/001-provide-strategy.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# CipherBox Kubo init: announce only pin roots to the DHT, not every block.
+#
+# Reduces background provide/reprovide CPU on the shared Kubo node. With the
+# default "all" strategy the staging node scheduled ~76k CIDs for DHT
+# announcement, consuming a large share of Kubo's CPU at idle; "roots" cuts that
+# to the pin-root count (~18k) with no loss of retrievability (every pinned root
+# is still announced; only unpinned intermediate blocks are dropped).
+#
+# Kubo 0.40 renamed Reprovider.Strategy -> Provide.Strategy. This file is sourced
+# by the Kubo entrypoint on every boot (before the daemon starts), so the setting
+# is idempotent and survives container recreation and fresh repos.
+ipfs config Provide.Strategy roots || echo "ipfs-init: failed to set Provide.Strategy roots (continuing)"

--- a/docs/CAPACITY.md
+++ b/docs/CAPACITY.md
@@ -3,8 +3,8 @@
 > Observed performance limits, infrastructure bottlenecks, and scaling recommendations.
 > Based on baseline data captured during Phases 18, 19, 19.2, and 22.
 >
-> **Last updated:** 2026-03-25
-> **Environment:** Single API server + single Kubo node + PostgreSQL
+> **Last updated:** 2026-06-23
+> **Environment:** Single API server + single Kubo node + someguy routing sidecar + PostgreSQL
 
 ## Table of Contents
 
@@ -21,7 +21,7 @@
 
 ### 1.1 Single-User Performance (Phase 18)
 
-Client-side round-trip timings captured against staging (4 vCPU, 8GB RAM VPS) using `curl` with a 10KB test file:
+Client-side round-trip timings captured against staging (2 vCPU, 8GB RAM VPS) using `curl` with a 10KB test file:
 
 | Operation           | p50   | p95   | p99   |
 | ------------------- | ----- | ----- | ----- |
@@ -113,6 +113,28 @@ Kubo pin latency distribution captured from staging after 20,944 pin operations 
 
 **Mean pin latency:** 1.37s (down from 1.73s pre-optimization, -20.8%)
 
+### 1.5 Re-baseline (2026-06): provider CPU and someguy contention
+
+A 2026-06 staging re-baseline (upload-throughput @ 50 clients) measured ~10 ops/s versus the 15.10 ops/s recorded in Phase 19.2 (§1.2). Object count was ruled out as the cause: a garbage-collection from 294,811 to 20,038 datastore objects did not change throughput.
+
+CPU-limit sweep (all runs share the same datastore state, `Provide.Strategy=roots`, on the 2 vCPU staging host):
+
+| ipfs cpus | someguy cpus | uploadFile p50 | uploadFile p95 | Throughput  |
+| --------- | ------------ | -------------- | -------------- | ----------- |
+| 1.0       | 1.0          | 5,779ms        | 8,001ms        | 8.71 ops/s  |
+| 1.5       | 1.0          | 4,894ms        | 6,506ms        | 10.28 ops/s |
+| 2.0       | 1.0          | 5,105ms        | 7,385ms        | 9.80 ops/s  |
+| 2.0       | 0.4          | 5,855ms        | 7,501ms        | 8.66 ops/s  |
+
+Findings:
+
+- **Two cores are the wall.** During load, ipfs and someguy together saturate the host's two cores (combined CPU 160-176% of 200%). Raising ipfs past 1.5 gives nothing (2.0 ties 1.5) because the physical cores, shared with someguy, are the ceiling. 1.5 is the measured knee (+18% over 1.0).
+- **someguy is a per-upload participant, not a parasite.** Each upload publishes two IPNS records through the API's delegated-routing client (someguy): one per-file record and one parent-folder record. Throttling someguy to 0.4 made throughput _worse_ (8.66 ops/s) by bottlenecking the publish path - it is on the critical path and must not be starved.
+- **Object count is not the throughput driver** (GC test above). It affects background provide/DHT CPU, which `Provide.Strategy=roots` already bounds to the pin-root count (~18k roots vs ~76k blocks under the default `all`).
+- **Hardware note:** the host is a 2 vCPU / 8 GB / 100 GB NVMe plan (Hostinger KVM 2) and always has been - a 4 vCPU / 8 GB host is not an offered Hostinger plan, so the "4 vCPU" figure once in §1.1 was a documentation error (now corrected). The 15.10 ops/s Phase 19.2 figure is therefore same-hardware, making the drop to ~10 ops/s a software/contention regression on the same two cores, not a hardware change.
+
+Applied remediation (PR): Kubo upgraded v0.40.0 -> v0.42.0, ipfs limits raised to `cpus: 1.5` / `memory: 3G`, `Provide.Strategy=roots` made reproducible via a `/container-init.d` script. Recommended next: defer the per-file IPNS publish off the upload critical path (§3.2, a same-hardware win), and/or upgrade to the next Hostinger tier (4 vCPU / 16 GB) to lift the two-core ceiling.
+
 ---
 
 ## 2. Infrastructure Bottlenecks
@@ -134,6 +156,8 @@ Kubo's `pin add` operation is the **dominant bottleneck**, consuming ~95% of upl
 Concurrent pins from multiple clients cause contention on the Kubo datastore. At 50 clients, throughput plateaus at ~3.4-3.7 ops/s locally and ~15-19 ops/s on staging. At 75 clients with flatfs, errors begin appearing; pebbleds eliminates this failure mode entirely.
 
 **Memory and CPU:** Kubo uses Go's goroutine scheduler. Pin operations are I/O-bound on the datastore. The pebbleds LSM-tree datastore batches writes, reducing I/O contention under concurrent load.
+
+**CPU contention (2026-06):** On the 2 vCPU staging host, Kubo's container CPU cap is the binding constraint under concurrent uploads, not datastore I/O. At a 1.0 cap Kubo pegs at 100% during load; raising it to `cpus: 1.5` yields +18% throughput (§1.5). Kubo shares the two cores with the someguy sidecar, which is active on the upload path, so they contend at peak. Kubo runs `v0.42.0` with `Provide.Strategy=roots` (announces pin roots only; the 0.40 `Reprovider.*` keys were renamed to `Provide.*`).
 
 ### 2.2 PostgreSQL
 
@@ -174,6 +198,8 @@ IPNS publish DHT propagation happens asynchronously and does not block client re
 
 DHT propagation errors do not affect client-facing operations (fire-and-forget). Someguy's warm DHT is critical for IPNS resolution performance in non-API contexts (recovery tool, TEE republishing).
 
+**Per-upload load (2026-06):** someguy is also on the upload critical path - each `uploadFile` publishes two IPNS records through it (per-file + parent-folder), so its CPU tracks upload volume (spiking to 80-90% under 50-client load). Throttling it _reduces_ upload throughput (§1.5). Note someguy is a read/proxy delegated-routing _resolver_ and cannot accept provide writes, so Kubo's content announcing cannot be offloaded to it; reducing per-upload publishes (§3.2) is the lever, not delegating providing to someguy.
+
 ---
 
 ## 3. Scaling Recommendations
@@ -198,6 +224,8 @@ DHT propagation errors do not affect client-facing operations (fire-and-forget).
 - **Vertical:** Increase CPU/RAM/SSD. Pebbleds datastore benefits significantly from faster I/O. Move from HDD to NVMe SSD for pin operations.
 - **Horizontal:** Run multiple Kubo nodes behind the API. Each API instance pins to a designated Kubo node. Requires content routing coordination (IPFS Cluster or custom routing).
 - **Cluster mode:** [IPFS Cluster](https://cluster.ipfs.io/) adds pinning coordination but introduces operational complexity. Recommended only when single-node Kubo reaches sustained saturation.
+- **CPU sizing (2026-06):** The host is 2 vCPU; under 50-client load ipfs and the someguy sidecar saturate both cores (§1.5). Upgrading to the next Hostinger tier (4 vCPU / 16 GB) lets ipfs (`cpus: 1.5`) and someguy (`cpus: 1.0`) run without contending, or move someguy to its own host/cores.
+- **Reduce per-upload IPNS publishes:** Each upload issues two someguy publishes (per-file + parent-folder). The per-file record is published at sequence 1 on every upload but is only needed for later in-place version updates - deferring it off the upload critical path (publish lazily on first file mutation) would roughly halve someguy's per-upload load with no hardware change.
 
 **API Server (NestJS):**
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -103,7 +103,7 @@ Configuration: `docker/docker-compose.staging.yml`
 | `api`        | `ghcr.io/{owner}/cipherbox-api:{tag}`        | NestJS API, port 3000 (loopback only)                                                                                                    |
 | `postgres`   | `postgres:16-alpine`                         | PostgreSQL database, port 5432 (loopback only)                                                                                           |
 | `redis`      | `redis:7-alpine`                             | Redis (password-protected), port 6379 (loopback only)                                                                                    |
-| `ipfs`       | `ipfs/kubo:v0.40.0`                          | Kubo IPFS node (pebbleds profile), p2p port 4001 public, API/gateway loopback                                                            |
+| `ipfs`       | `ipfs/kubo:v0.42.0`                          | Kubo IPFS node (pebbleds profile), p2p port 4001 public, API/gateway loopback                                                            |
 | `tee-worker` | `ghcr.io/{owner}/cipherbox-tee-worker:{tag}` | TEE worker in `TEE_MODE=simulator` for staging                                                                                           |
 | `someguy`    | `ghcr.io/ipfs/someguy:v0.11.1`               | Delegated IPFS routing (accelerated DHT), p2p port 4004 public, routing API 8190 internal-only (unlike local dev, where it is published) |
 | `caddy`      | `caddy:2-alpine`                             | Reverse proxy / TLS termination / web app static serving                                                                                 |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -20,7 +20,7 @@ This starts the `cipherbox-infrastructure` compose project (containers are named
 | Service             | Image                                 | Host Port(s)                                     | Purpose                                  |
 | :------------------ | :------------------------------------ | :----------------------------------------------- | :--------------------------------------- |
 | `postgres`          | `postgres:16-alpine`                  | 5432 (`DB_PORT`)                                 | Database                                 |
-| `ipfs`              | `ipfs/kubo:v0.40.0`                   | 5001 (API), 8080 (gateway), 4001 tcp/udp (swarm) | Decentralized storage (Kubo)             |
+| `ipfs`              | `ipfs/kubo:v0.42.0`                   | 5001 (API), 8080 (gateway), 4001 tcp/udp (swarm) | Decentralized storage (Kubo)             |
 | `redis`             | `redis:7-alpine`                      | 6380 (`REDIS_PORT`) → container 6379             | BullMQ job queue                         |
 | `someguy`           | `ghcr.io/ipfs/someguy:v0.11.1`        | 8190 (routing API), 4004 tcp/udp (libp2p swarm)  | Delegated IPFS routing (accelerated DHT) |
 | `mock-ipns-routing` | built from `tools/mock-ipns-routing/` | 3001 (loopback only)                             | Local IPNS resolution for dev/E2E        |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -28,7 +28,7 @@ This starts the `cipherbox-infrastructure` compose project (containers are named
 Notes:
 
 - The IPFS node runs with the `server,pebbleds` datastore profile. If you have an `ipfs_data` volume created before the pebbleds switch, recreate it first: `docker compose -f docker/docker-compose.yml down -v --remove-orphans`.
-- The `ipfs` and `someguy` containers are each capped at 2 GB memory / 1 CPU.
+- The `ipfs` container is capped at 3 GB memory / 1.5 CPU; the `someguy` container is capped at 2 GB memory / 1 CPU.
 - The staging stack runs a different set of containers (adds `api`, `tee-worker`, `caddy`, `alloy`; drops `mock-ipns-routing`) — see [DEPLOYMENT.md](DEPLOYMENT.md).
 
 ## Environment

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -65,26 +65,20 @@
       "release-type": "node",
       "component": "@cipherbox/api",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true,
-      "release-as": "0.43.0"
+      "bump-minor-pre-major": true
     },
     "apps/web": {
       "release-type": "node",
       "component": "@cipherbox/web",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true,
-      "release-as": "0.46.0"
+      "bump-minor-pre-major": true
     },
     "apps/desktop": {
       "release-type": "node",
       "component": "cipherbox-desktop",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
-      "extra-files": [
-        "src-tauri/tauri.conf.json",
-        "src-tauri/Cargo.toml"
-      ],
-      "release-as": "0.44.0"
+      "extra-files": ["src-tauri/tauri.conf.json", "src-tauri/Cargo.toml"]
     },
     "apps/tee-worker": {
       "release-type": "node",
@@ -109,15 +103,13 @@
       "release-type": "node",
       "component": "@cipherbox/api-client",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true,
-      "release-as": "0.43.0"
+      "bump-minor-pre-major": true
     },
     "packages/sdk-core": {
       "release-type": "node",
       "component": "@cipherbox/sdk-core",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true,
-      "release-as": "0.38.0"
+      "bump-minor-pre-major": true
     },
     "packages/sdk": {
       "release-type": "node",
@@ -137,8 +129,7 @@
       "release-type": "rust",
       "component": "cipherbox-core",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true,
-      "release-as": "0.6.0"
+      "bump-minor-pre-major": true
     },
     "crates/api-client": {
       "release-type": "rust",
@@ -151,8 +142,7 @@
       "release-type": "rust",
       "component": "cipherbox-fuse",
       "include-component-in-tag": true,
-      "bump-minor-pre-major": true,
-      "release-as": "0.8.0"
+      "bump-minor-pre-major": true
     },
     "crates/sdk": {
       "release-type": "rust",


### PR DESCRIPTION
## What

Upgrade Kubo v0.40.0 → v0.42.0, raise the ipfs container limits to `cpus: 1.5` / `memory: 3G`, and make `Provide.Strategy=roots` reproducible via a Kubo `/container-init.d` script. Documents the 2026-06 staging load-test re-baseline in `CAPACITY.md`.

## Why

A 2026-06 staging re-baseline (`upload-throughput @ 50 clients`) measured ~10 ops/s vs the 15.10 ops/s Phase 19.2 figure. Investigation (all on the same 2-vCPU box):

- **Object count is not the driver** — a GC from 294,811 → 20,038 datastore objects did not move throughput.
- **The 2-vCPU box is the wall** — under load, ipfs + the someguy sidecar together saturate both cores. The measured CPU knee is ipfs `cpus: 1.5` (+18%); 2.0 gives no further gain.
- **someguy is a per-upload participant** (2 IPNS publishes per upload) on the critical path — throttling it makes throughput worse, not better.

CPU ladder (`Provide.Strategy=roots`, identical datastore state):

| ipfs cpus | someguy cpus | uploadFile p50 | uploadFile p95 | Throughput |
| --------- | ------------ | -------------- | -------------- | ---------- |
| 1.0 | 1.0 | 5779ms | 8001ms | 8.71 ops/s |
| 1.5 | 1.0 | 4894ms | 6506ms | 10.28 ops/s |
| 2.0 | 1.0 | 5105ms | 7385ms | 9.80 ops/s |
| 2.0 | 0.4 | 5855ms | 7501ms | 8.66 ops/s |

## Changes

- **Kubo 0.40.0 → 0.42.0** across both compose files, 6 CI workflows (incl. the `--filter ancestor=ipfs/kubo:...` refs in `web-e2e.yml` / `deploy-landing.yml`), and docs.
- **ipfs limits**: `cpus 1.0 → 1.5`, `memory 2G → 3G` (both compose files).
- **`docker/ipfs-init/001-provide-strategy.sh`** — Kubo `/container-init.d` script that sets `Provide.Strategy=roots` idempotently on every boot, replacing undocumented volume drift. Wired into the `deploy-staging.yml` scp source list so it reaches the VPS.
- **`docs/CAPACITY.md`** — re-baseline findings + scaling guidance; corrects a stale "4 vCPU" baseline note (no such Hostinger plan — the box is 2 vCPU / 8 GB).

## Validation

v0.42.0 was validated live on the staging box before opening this PR:

- Boots healthy in <31s; `Provide.Strategy=roots` and 17,880 pin roots intact; **no fs-repo migration** (`RepoVersion 18` unchanged in both versions); no FATAL/deprecation in logs.
- v0.42's pinner-lock fix stops the reprovide cycle from blocking `pin`/`add` under the `roots` strategy.
- Pre-upgrade volume snapshot saved on the VPS at `/opt/cipherbox/ipfs_staging.backup.pre042.tar`.

Note: staging is **already running** v0.42.0 at `cpus: 1.5` (applied manually during validation). This PR codifies that state; the next deploy re-applies it identically and adds the init mount.

## Follow-ups (not in this PR)

- Defer the per-file IPNS publish off the upload critical path (~halves someguy's per-upload load) — the highest-leverage same-hardware throughput fix.
- Optional: upgrade to the next Hostinger tier (4 vCPU / 16 GB) to lift the two-core ceiling.
- Recurring Kubo GC (see `#547`) and test-account cleanup (disk hygiene, not throughput).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded IPFS (Kubo) from v0.40.0 to v0.42.0 across CI/CD and deployment infrastructure
  * Increased IPFS container resource limits (memory and CPU) to improve performance under concurrent load

* **Documentation**
  * Updated capacity planning and performance baseline documentation with 2026-06 measurements and infrastructure scaling guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->