### PR TITLE
chore(ci): sync Cargo.lock on release PR branch not protected main

### DIFF
--- a/.github/workflows/cargo-lock-release-sync.yml
+++ b/.github/workflows/cargo-lock-release-sync.yml
@@ -1,0 +1,93 @@
+name: Cargo.lock Release Sync
+
+# release-please bumps each crate's Cargo.toml version but does NOT update the
+# workspace Cargo.lock (the native cargo-workspace plugin is deliberately not
+# enabled — googleapis/release-please#2517 skips Cargo.lock + manifest updates in
+# monorepo mode). main is a protected branch, so the synced lock cannot be pushed
+# there directly after the release PR merges. Instead we sync Cargo.lock ON the
+# release-please PR branch (which is NOT protected) so the synced lock lands
+# atomically with the version bumps when the release PR merges. The post-merge
+# fallback in release-please.yml only fires if this job races the merge.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cargo-lock-sync-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  sync-lock:
+    name: Sync Cargo.lock on release PR
+    runs-on: ubuntu-latest
+    # Only release-please's own PRs bump crate versions without the matching lock.
+    if: startsWith(github.head_ref, 'release-please--')
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          # Least privilege: this job only pushes the synced lock to the release
+          # PR branch, so scope the token to contents:write (not blanket install).
+          permission-contents: write
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        run: rustup default stable
+
+      - name: Sync Cargo.lock to released crate versions
+        run: |
+          set -euo pipefail
+
+          # First-party workspace crates whose versions release-please bumps in
+          # Cargo.toml. Pin each lock entry to its (now-bumped) manifest version.
+          # First-party crates ONLY — no transitive re-resolution.
+          PKGS=(
+            cipherbox-api-client
+            cipherbox-core
+            cipherbox-crypto
+            cipherbox-fuse
+            cipherbox-sdk
+            cipherbox-desktop
+          )
+
+          META=$(cargo metadata --no-deps --format-version 1)
+          for PKG in "${PKGS[@]}"; do
+            VER=$(echo "$META" | jq -r --arg p "$PKG" \
+              '.packages[] | select(.name == $p) | .version')
+            if [ -z "$VER" ] || [ "$VER" = "null" ]; then
+              echo "::warning::crate $PKG not found in workspace metadata — skipping"
+              continue
+            fi
+            echo "Pinning Cargo.lock: $PKG -> $VER"
+            cargo update -p "$PKG" --precise "$VER"
+          done
+
+      - name: Commit and push synced lock
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- Cargo.lock; then
+            echo "Cargo.lock already in sync — nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git commit -m "chore(ci): sync Cargo.lock for released crates"
+          # Soft push to the checked-out release branch's upstream. The branch can
+          # be force-pushed by release-please while this job runs; if our push is
+          # rejected, a later synchronize run re-syncs — do not red-fail the
+          # release PR over a lost race.
+          if ! git push; then
+            echo "::warning::push rejected (release branch moved) — a later synchronize run will re-sync."
+          fi

--- a/.github/workflows/cargo-lock-release-sync.yml
+++ b/.github/workflows/cargo-lock-release-sync.yml
@@ -13,8 +13,10 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+# The workflow's GITHUB_TOKEN is unused for writes — checkout and push both
+# authenticate via the scoped app token below — so read is sufficient here.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: cargo-lock-sync-${{ github.event.pull_request.number }}
@@ -40,7 +42,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}
-          fetch-depth: 0
+          # Only the branch tip is needed for cargo metadata/update + a one-commit
+          # push; no history required.
+          fetch-depth: 1
 
       - name: Install Rust toolchain
         run: rustup default stable

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -159,16 +159,36 @@ jobs:
           echo "::warning::Cargo.lock stale after release (pre-merge sync raced the merge) — opening a sync PR."
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Deterministic per-commit branch so a manual re-run of this workflow
+          # (same GITHUB_SHA) targets the same sync branch instead of spawning a
+          # new one. Each step below is made idempotent so a re-run after a prior
+          # fallback does not fail under `set -euo pipefail`.
           SYNC_BRANCH="chore/cargo-lock-sync-${GITHUB_SHA:0:7}"
-          git switch -c "$SYNC_BRANCH"
-          git add Cargo.lock
-          git commit -m "chore(ci): sync Cargo.lock for released crates"
-          git push origin "HEAD:${SYNC_BRANCH}"
-          gh pr create \
-            --repo "${{ github.repository }}" \
-            --base "${GITHUB_REF_NAME:-main}" \
-            --head "$SYNC_BRANCH" \
-            --title "chore(ci): sync Cargo.lock for released crates" \
-            --body "Automated Cargo.lock sync for released crate versions. The release PR merged before the pre-merge \`cargo-lock-release-sync\` job pushed the synced lock, so main's committed Cargo.lock is briefly out of sync with the bumped Cargo.toml versions. Merging this restores lock/manifest parity."
+
+          # Only create+push the branch if a prior run hasn't already. git push of
+          # an existing remote branch would be rejected and abort the step.
+          if git ls-remote --exit-code --heads origin "$SYNC_BRANCH" >/dev/null 2>&1; then
+            echo "Sync branch $SYNC_BRANCH already exists — a prior fallback run pushed it."
+          else
+            git switch -c "$SYNC_BRANCH"
+            git add Cargo.lock
+            git commit -m "chore(ci): sync Cargo.lock for released crates"
+            git push origin "HEAD:${SYNC_BRANCH}"
+          fi
+
+          # Open the PR only if one isn't already open for this branch — gh pr
+          # create exits non-zero when a PR already exists for the head branch.
+          EXISTING_PR=$(gh pr list --repo "${{ github.repository }}" \
+            --head "$SYNC_BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$EXISTING_PR" ]; then
+            gh pr create \
+              --repo "${{ github.repository }}" \
+              --base "${GITHUB_REF_NAME:-main}" \
+              --head "$SYNC_BRANCH" \
+              --title "chore(ci): sync Cargo.lock for released crates" \
+              --body "Automated Cargo.lock sync for released crate versions. The release PR merged before the pre-merge \`cargo-lock-release-sync\` job pushed the synced lock, so main's committed Cargo.lock is briefly out of sync with the bumped Cargo.toml versions. Merging this restores lock/manifest parity."
+          else
+            echo "PR #$EXISTING_PR already open for $SYNC_BRANCH — skipping create."
+          fi
           # Best-effort auto-merge; harmless (|| true) if auto-merge is disabled.
           gh pr merge "$SYNC_BRANCH" --repo "${{ github.repository }}" --squash --auto || true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -77,14 +77,18 @@ jobs:
             fi
           done
 
-      # Cargo.lock sync (D-05 fallback path). release-please bumps each crate's
+      # Cargo.lock sync (post-merge fallback). release-please bumps each crate's
       # Cargo.toml version but does NOT update the workspace Cargo.lock's
       # [[package]] version lines, leaving main stale-on-first-cargo after a
       # release. The native cargo-workspace plugin is deliberately NOT enabled
       # (open bug googleapis/release-please#2517 skips Cargo.lock and manifest
-      # updates in monorepo mode). Instead we cargo update --precise each bumped
-      # first-party crate, guard with git diff --exit-code, and push the synced
-      # lock. First-party crates ONLY — no transitive re-resolution.
+      # updates in monorepo mode). The PRIMARY sync runs pre-merge in
+      # cargo-lock-release-sync.yml (on the release PR branch, which is not
+      # protected) so the synced lock lands atomically with the merge. This step
+      # is only a fallback for the rare race where the PR merges before that job
+      # pushes: it detects a stale lock and opens a follow-up PR — main is a
+      # protected branch, so it never pushes there directly. First-party crates
+      # ONLY — no transitive re-resolution.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: steps.release.outputs.releases_created == 'true'
         with:
@@ -140,42 +144,31 @@ jobs:
             echo "No first-party crate versions released — Cargo.lock sync skipped."
           fi
 
-          # Stale-lock guard: fail loudly if cargo left the lock out of sync with
-          # itself (e.g. cargo update reported success but the lock did not change
-          # while a manifest version did). An empty diff is a no-op success;
-          # a non-empty diff is committed and pushed so main is never stale.
+          # Stale-lock guard. The pre-merge cargo-lock-release-sync.yml workflow
+          # normally syncs Cargo.lock on the release PR branch, so the merged lock
+          # is already in sync and this is a no-op. An empty diff is success.
           if git diff --quiet -- Cargo.lock; then
-            echo "Cargo.lock already in sync — nothing to commit."
+            echo "Cargo.lock already in sync — nothing to do."
             exit 0
           fi
 
-          echo "Cargo.lock changed — committing synced lock."
+          # A non-empty diff means the pre-merge sync raced the merge (the release
+          # PR was merged before that job pushed). main is a protected branch — we
+          # CANNOT push to it directly — so open a follow-up PR with the synced
+          # lock instead of failing the release. Never push to main here.
+          echo "::warning::Cargo.lock stale after release (pre-merge sync raced the merge) — opening a sync PR."
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          SYNC_BRANCH="chore/cargo-lock-sync-${GITHUB_SHA:0:7}"
+          git switch -c "$SYNC_BRANCH"
           git add Cargo.lock
           git commit -m "chore(ci): sync Cargo.lock for released crates"
-
-          # Push with a small retry/rebase loop: main can move while this job
-          # runs, so a single push may be rejected non-fast-forward and leave
-          # Cargo.lock unsynced despite a successful release. Rebase the lock
-          # commit onto the moved branch and retry before failing.
-          BRANCH="${GITHUB_REF_NAME:-main}"
-          PUSHED=0
-          for attempt in 1 2 3; do
-            if git push origin "HEAD:${BRANCH}"; then
-              PUSHED=1
-              break
-            fi
-            echo "Push attempt ${attempt} rejected — rebasing onto origin/${BRANCH} and retrying."
-            git fetch origin "${BRANCH}"
-            git rebase "origin/${BRANCH}"
-            sleep $((attempt * 3))
-          done
-          if [ "$PUSHED" -ne 1 ]; then
-            echo "::error::Failed to push Cargo.lock sync after 3 attempts"
-            exit 1
-          fi
-
-          # Post-commit guard: the working tree must now be clean against the
-          # committed lock. A residual diff means the sync is still stale.
-          git diff --exit-code Cargo.lock
+          git push origin "HEAD:${SYNC_BRANCH}"
+          gh pr create \
+            --repo "${{ github.repository }}" \
+            --base "${GITHUB_REF_NAME:-main}" \
+            --head "$SYNC_BRANCH" \
+            --title "chore(ci): sync Cargo.lock for released crates" \
+            --body "Automated Cargo.lock sync for released crate versions. The release PR merged before the pre-merge \`cargo-lock-release-sync\` job pushed the synced lock, so main's committed Cargo.lock is briefly out of sync with the bumped Cargo.toml versions. Merging this restores lock/manifest parity."
+          # Best-effort auto-merge; harmless (|| true) if auto-merge is disabled.
+          gh pr merge "$SYNC_BRANCH" --repo "${{ github.repository }}" --squash --auto || true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -12,6 +12,7 @@ rules:
   artipacked:
     # checkout persist-credentials hygiene — broad pre-existing finding (e.g. release-please.yml needs persist-credentials to push). Deferred: not in Phase 53 scope (supply-chain pinning + least-privilege only).
     ignore:
+      - cargo-lock-release-sync.yml
       - ci-e2e.yml
       - ci.yml
       - codecov-base.yml


### PR DESCRIPTION
## Problem

The post-merge `Cargo.lock` sync in `release-please.yml` pushes directly to `main`, which is protected (classic branch protection, `enforce_admins`, 13 required checks). Every push is rejected with `GH006: Protected branch update failed ... Changes must be made through a pull request`. The retry/rebase loop is futile — each attempt is rejected by the protected-branch hook, not a non-fast-forward race (the logs show `Current branch main is up to date` before every rejection), so the step fails 100% of the time a Rust crate is released (e.g. the release-please run for `#542`).

## Fix

1. **New `cargo-lock-release-sync.yml`** — syncs `Cargo.lock` on the release-please **PR branch pre-merge** (that branch is not protected), pinning each first-party crate's lock entry to its bumped `Cargo.toml` version. The synced lock then lands atomically when the release PR merges. Idempotent + soft-push, so a release-please force-push race never red-fails the PR.
2. **`release-please.yml` post-merge step** — replaces the impossible direct-push-to-`main` + retry loop with a fallback that opens a follow-up PR if it ever detects a stale lock (the rare merge-before-sync race), instead of pushing to `main`. It never fails the release workflow on a protected-branch push.
3. **`zizmor.yml`** — scopes the new job's app token to `permission-contents: write` (least privilege) and defers `artipacked` for it, consistent with the other push workflows.

## Verification

- `zizmor .github/workflows/` passes (the supply-chain security gate).
- `actionlint` clean on both workflows.
- Single root workspace, single `Cargo.lock` covering all 6 first-party crates incl. `cipherbox-desktop`; no CI job uses `--locked`.

Note: the `Lint` check on this PR will be red until the stale `release-as` pins that the `#542` release left on `main` are cleared (done on `#548`); rebase onto `main` after that lands and it goes green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to improve release automation and Cargo.lock synchronization
  * Enhanced CI/CD pipeline security audit configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->