### PR TITLE
docs: migrate periodic-GC and IPNS verify-caching todos from GitHub issues

### DIFF
--- a/.planning/todos/pending/2026-06-22-periodic-kubo-ipfs-gc-on-staging.md
+++ b/.planning/todos/pending/2026-06-22-periodic-kubo-ipfs-gc-on-staging.md
@@ -35,9 +35,12 @@ Pick one:
    for parity).
 2. Cron a `docker compose exec -T ipfs ipfs repo gc --silent` on the VPS.
 
+Already done (PR #548): Kubo's mem cap was raised 2 GB → 3 GB — both
+`docker/docker-compose.staging.yml` (ipfs service) and `docker/docker-compose.yml` set `memory: 3G`.
+No further mem-cap action needed unless the 3 GB store is again exceeded.
+
 Also consider:
 
-- Raising Kubo's mem cap 2 GB → 3-4 GB (host has headroom: ~2.8/7.8 GiB used).
 - Load-test hygiene: the load harness generates most of this garbage. GC before/after baseline runs,
   or have the harness clean up its test accounts' content (it deletes accounts but blocks linger
   until GC).

--- a/.planning/todos/pending/2026-06-22-periodic-kubo-ipfs-gc-on-staging.md
+++ b/.planning/todos/pending/2026-06-22-periodic-kubo-ipfs-gc-on-staging.md
@@ -1,0 +1,50 @@
+---
+created: 2026-06-22T22:01:24.000Z
+title: Enable periodic Kubo IPFS garbage collection on staging
+area: infra
+severity: medium
+source: GitHub issue #547 (migrated to file-todo) — 2026-06-22 staging load-test re-baseline regression
+files:
+  - docker/docker-compose.staging.yml
+  - docker/docker-compose.yml
+---
+
+## Problem
+
+A 2026-06-22 staging load-test re-baselining sweep (the `upload-throughput`, `mixed-workload`,
+and `sustained-load` scenarios from `tests/load/`, run via the `Load Tests` workflow against
+`api-staging.cipherbox.cc`) found upload throughput ~halved and p50/p95 ~doubled vs the Phase 19.2
+staging baseline.
+
+**Root cause:** Kubo IPFS datastore bloat. The repo had grown to 6.2 GB / 294,811 objects, but only
+~489 MB / 17,875 CIDs were actually pinned/live — ~93% was unpinned garbage accumulated from months
+of load-test churn (create then delete leaves orphaned blocks until GC). The oversized pebbleds store
+exceeded Kubo's 2 GB memory cap, pushing pins to disk: server-side pin mean latency 1.37s → 3.02s
+(+120%), which halved upload throughput.
+
+## Immediate remediation (already done)
+
+Ran `ipfs repo gc` on staging — 294,811 → 20,038 objects, on-disk 5.9 GB → 2.5 GB.
+
+## Action — make GC recurring so this can't silently recur
+
+Pick one:
+
+1. Kubo daemon auto-GC — set `Datastore.GCPeriod` (e.g. `1h`) and run the daemon with `--enable-gc`,
+   wired via the `ipfs` service in `docker/docker-compose.staging.yml` (and `docker/docker-compose.yml`
+   for parity).
+2. Cron a `docker compose exec -T ipfs ipfs repo gc --silent` on the VPS.
+
+Also consider:
+
+- Raising Kubo's mem cap 2 GB → 3-4 GB (host has headroom: ~2.8/7.8 GiB used).
+- Load-test hygiene: the load harness generates most of this garbage. GC before/after baseline runs,
+  or have the harness clean up its test accounts' content (it deletes accounts but blocks linger
+  until GC).
+- Minor: `cipherbox_drift_orphaned_pins_total` = 39 (Kubo pins not tracked in DB) — tighten the
+  unpin → GC reconciliation.
+
+## References
+
+- PR #548 — Kubo tuning + the staging-perf writeup
+- `docs/CAPACITY.md` §1.5 — re-baseline findings

--- a/.planning/todos/pending/2026-06-23-cache-redundant-ipns-signature-verification-hot-path.md
+++ b/.planning/todos/pending/2026-06-23-cache-redundant-ipns-signature-verification-hot-path.md
@@ -1,0 +1,59 @@
+---
+created: 2026-06-23T15:56:53.000Z
+title: Investigate caching/short-circuiting redundant IPNS signature verification on the publish/resolve hot path
+area: perf
+severity: low
+source: GitHub issue #549 (migrated to file-todo) — 2026-06-23 staging upload-throughput re-baseline
+files:
+  - apps/api/src/ipns/ipns.service.ts
+---
+
+## Context
+
+A 2026-06-23 staging load-test re-baseline (`upload-throughput @ 50 clients`) found upload throughput
+~10 ops/s vs the 15.10 ops/s Phase 19.2 baseline, on the same 2-vCPU staging box.
+
+Root cause was investigated (see `docs/CAPACITY.md` §1.5 and PR #548): the regression is **per-operation
+CPU cost, not op count or accumulated state**. Ruled out:
+
+- **Object/pin count** — a GC (294,811 → 20,038 objects) and an account cleanup (pin set 17,880 → 308)
+  both failed to move throughput.
+- **Op count** — constant (3 pins + 2 IPNS publishes per upload; the per-file IPNS model predates the
+  baseline).
+- **Kubo version / someguy** — 0.40 → 0.42 gave no gain; someguy has run `SOMEGUY_DHT=accelerated`
+  since before the baseline.
+
+The cause is **IPNS signature verification + durability hardening added after the baseline**: #448
+(IPNS signature storage + verification, 2026-04-04), #529 (signedRecord validation/verification
+hardening), #543 (write-path durability hardening), #544 (verify-coverage chokepoint + CAS gate).
+Every publish/resolve now performs Ed25519 verification + validation + durability fsync + CAS gating,
+so each operation costs more CPU on a 2-core box.
+
+## Opportunity
+
+The API frequently **signs** an IPNS record on publish and then **verifies** records on the resolve
+path — likely re-verifying records it just produced and persisted. Investigate caching or
+short-circuiting redundant verification of records the API itself just signed/wrote (the DB is
+authoritative), **without weakening the zero-knowledge integrity model**.
+
+## Scope / questions
+
+- Map where verification happens: the signed-record verify chokepoint from #544, `resolveRecord` in
+  `apps/api/src/ipns/ipns.service.ts`, and the publish path.
+- Profile the publish/resolve hot path to confirm the magnitude of the per-op verification cost.
+- Propose a safe short-circuit, e.g. skip re-verifying DB-authoritative records this server just
+  signed/persisted, while **still** verifying externally-sourced / DHT records (someguy resolves) and
+  anything not produced by this server. Must not reduce integrity guarantees for untrusted inputs.
+- Consider a short-TTL verified-record cache keyed by `(ipnsName, sequenceNumber, signature)`.
+
+## Acceptance
+
+A proposal (ideally with a measured per-op cost estimate and a prototype) that recovers verification
+CPU on the publish/resolve hot path without weakening IPNS integrity verification of untrusted /
+DHT-sourced records.
+
+## References
+
+- `docs/CAPACITY.md` §1.5 — re-baseline findings
+- PR #548 — Kubo tuning + the writeup
+- Hot-path PRs: #448, #529, #543, #544


### PR DESCRIPTION
## What

Migrates two staging-perf follow-ups from standalone GitHub issues into the GSD
file-todo backlog (`.planning/todos/pending/`), where the rest of the todos live and
where `/gsd:capture --list` can see them:

- **#547 → `2026-06-22-periodic-kubo-ipfs-gc-on-staging.md`** — enable periodic Kubo IPFS GC on staging (datastore bloat halved upload throughput; GC was a one-shot manual fix).
- **#549 → `2026-06-23-cache-redundant-ipns-signature-verification-hot-path.md`** — investigate caching/short-circuiting redundant IPNS signature verification on the publish/resolve hot path.

## Why

Both items were created as GitHub issues by mistake — the standing convention is to
capture todos via `/gsd:capture --todo` into `.planning/todos/pending/`. This restores
that, with the full issue writeups preserved verbatim.

## Follow-up

Issues #547 and #549 are closed, each pointing back to this PR / the file-todo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This pull request contains internal planning documentation only and includes no user-facing changes or feature updates. The changes document infrastructure maintenance considerations and performance optimization investigations for the platform's internal systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->