### PR TITLE
fix(fuse): re-resolve remote file edits during local publish window

### DIFF
--- a/.planning/todos/pending/2026-06-24-web-e2e-flaky-cascade-abort.md
+++ b/.planning/todos/pending/2026-06-24-web-e2e-flaky-cascade-abort.md
@@ -1,14 +1,17 @@
 ---
 created: 2026-06-24
-title: Stabilize flaky e2e suites (web cascade-abort + desktop macOS FUSE-T sync)
-area: tests/web-e2e, tests/desktop-e2e
+title: Stabilize flaky web-e2e suite (cascade-abort ordering)
+area: tests/web-e2e
 files:
   - tests/web-e2e/playwright.config.ts
   - tests/web-e2e/tests/invite-link-workflow.spec.ts
   - tests/web-e2e/tests/journey-timing.spec.ts
   - tests/web-e2e/tests/media-preview.spec.ts
-  - tests/desktop-e2e/scripts/test-cross-client-sync.sh
 ---
+
+> NOTE: The desktop-e2e macOS cross-client-**content**-sync leg of this todo
+> (Test 5) is RESOLVED in PR #558 — see the "DONE" section at the bottom. The
+> remaining actionable work here is the web-e2e cascade-abort below.
 
 ## Problem
 
@@ -50,7 +53,31 @@ TBD — options, smallest-first:
 Keep `retries: 0` philosophy in spirit (fix flakiness at the source) but stop a
 single flake from masking unrelated coverage.
 
-## Also: desktop-e2e macOS cross-client sync (FUSE-T timing)
+## DONE (PR #558): desktop-e2e macOS cross-client sync (FUSE-T timing)
+
+RESOLVED 2026-06-25. Root cause confirmed and fixed exactly as the analysis below
+predicted: `drain_refresh_completions` (`crates/fuse/src/fs.rs`) skipped
+`populate_folder` while the folder sat in `mutated_folders`/`publish_queue`,
+suppressing the remote-edit re-resolution spawn. Fix added
+`InodeTable::mark_remotely_edited_files_unresolved` — re-resolves genuine remote
+**file content** edits (same pointer identity, remote `modified_at` strictly newer
+than local mtime) without clobbering pending local mutations or folder structure;
+the gated branch now calls it then falls through to the existing resolution-spawn
+block. Verified: Test 5 synced in 35s across two independent all-platform-green
+`CI E2E Tests` runs (28172426013, 28172492917); 3 new unit tests + full
+`cipherbox-fuse` suite (92) green.
+
+NOT covered by #558 (left as an OPTIONAL follow-up, not blocking): **Test 7 folder
+RENAME** sync still falls through to the macOS `optional/warn` fallback — confirmed
+empirically in run 28172426013 (`WARN: FUSE mount did not detect folder rename after
+300s on macOS`). The fix is deliberately scoped to file content; rename detection
+needs full `populate_folder` (it rewrites the `name_to_ino` index), which is still
+gated. A real Test-7 fix is a riskier structural change (reconciling renames under a
+pending publish — see [[project-web-sdk-folder-state-desync]]) and may not clear
+FUSE-T's SMB *directory* cache regardless, so it could stay optional-on-macOS even if
+implemented. Open it as its own todo only if the rename gap becomes load-bearing.
+
+Original analysis (kept for history):
 
 `tests/desktop-e2e/scripts/test-cross-client-sync.sh:194` —
 `FUSE mount still shows original content after 120s` — flakes on **macOS only**

--- a/crates/fuse/src/fs.rs
+++ b/crates/fuse/src/fs.rs
@@ -390,21 +390,33 @@ impl CipherBoxFS {
             };
             self.refreshing_metadata.remove(&ipns_name);
             if self.mutated_folders.contains_key(&ino) || self.publish_queue.contains_key(&ino) {
+                // This folder has pending local mutations/publishes. Do NOT rebuild
+                // its structure from remote metadata -- that would clobber the local
+                // change with stale remote state before our own publish propagates
+                // (folder-state desync). But a *remote* file edit (newer modified_at)
+                // arriving in this same window must still surface, so mark only those
+                // genuine remote edits for re-resolution -- local mutations (local
+                // mtime >= remote) are left untouched -- then fall through to the
+                // shared resolution-spawn block below.
                 self.metadata_cache.set(&ipns_name, metadata.clone(), cid);
-                continue;
+                self.inodes
+                    .mark_remotely_edited_files_unresolved(ino, &metadata);
+            } else {
+                self.metadata_cache
+                    .set(&ipns_name, metadata.clone(), cid.clone());
+                if let Err(e) = self.inodes.populate_folder(
+                    ino,
+                    &metadata,
+                    &self.private_key,
+                    &self.public_key,
+                    true,
+                ) {
+                    log::warn!("Drain refresh apply failed for ino {}: {}", ino, e);
+                }
             }
-            self.metadata_cache
-                .set(&ipns_name, metadata.clone(), cid.clone());
-            if let Err(e) = self.inodes.populate_folder(
-                ino,
-                &metadata,
-                &self.private_key,
-                &self.public_key,
-                true,
-            ) {
-                log::warn!("Drain refresh apply failed for ino {}: {}", ino, e);
-            }
-            // Spawn async resolution for unresolved FilePointers in this folder
+            // Spawn async resolution for unresolved FilePointers in this folder.
+            // Covers both the freshly-populated path and the locally-mutating
+            // remote-edit path (marked just above).
             let unresolved = self.inodes.get_unresolved_file_pointers_for_parent(ino);
             if !unresolved.is_empty() {
                 let folder_key = self.inodes.get(ino).and_then(|i| match &i.kind {

--- a/crates/fuse/src/fs.rs
+++ b/crates/fuse/src/fs.rs
@@ -805,3 +805,196 @@ mod build_folder_metadata_tests {
         );
     }
 }
+
+/// Tests for `drain_refresh_completions` — the IPNS-refresh apply path and the
+/// cross-client re-resolution fix (PR #558).
+///
+/// These drive the synchronous bookkeeping directly: a `PendingRefresh` is pushed
+/// onto `refresh_tx`, `drain_refresh_completions()` is called, and the resulting
+/// inode/cache/queue state is asserted. The per-file resolution task the drain
+/// spawns is fire-and-forget and is never polled (the `#[tokio::test]` body does
+/// not await after the drain, and the API host is unroutable), so only the
+/// synchronous effects — which is exactly the patch under test — are observed.
+#[cfg(all(test, feature = "fuse"))]
+mod drain_refresh_completions_tests {
+    use crate::events::PendingRefresh;
+    use crate::inode::{FileAttrs, InodeData, InodeKind, ROOT_INO};
+    use crate::test_support::make_test_fs;
+    use std::time::{Duration, UNIX_EPOCH};
+    use zeroize::Zeroizing;
+
+    const FILE_IPNS: &str = "k51file-cross-client";
+    const ROOT_IPNS: &str = "k51test-root";
+
+    /// Insert a resolved `hello.txt` File child of root with mtime `mtime_ms`.
+    fn insert_resolved_file(fs: &mut crate::CipherBoxFS, mtime_ms: u64) -> u64 {
+        let ino = fs.inodes.allocate_ino();
+        let mtime = UNIX_EPOCH + Duration::from_millis(mtime_ms);
+        fs.inodes.insert(InodeData {
+            ino,
+            parent_ino: ROOT_INO,
+            name: "hello.txt".to_string(),
+            kind: InodeKind::File {
+                cid: "bafyOLDcid".to_string(),
+                encrypted_file_key: "deadbeef".to_string(),
+                iv: "aabbccdd".to_string(),
+                size: 42,
+                encryption_mode: "GCM".to_string(),
+                file_meta_ipns_name: Some(FILE_IPNS.to_string()),
+                file_meta_resolved: true,
+                file_ipns_private_key: Some(Zeroizing::new(vec![3u8; 32])),
+                file_ipns_key_encrypted_hex: Some("abcd".to_string()),
+                versions: None,
+            },
+            attr: FileAttrs {
+                ino,
+                size: 42,
+                blocks: 1,
+                atime: mtime,
+                mtime,
+                ctime: mtime,
+                crtime: mtime,
+                is_dir: false,
+                perm: 0o644,
+                nlink: 1,
+            },
+            children: None,
+            write_generation: 0,
+        });
+        if let Some(root) = fs.inodes.get_mut(ROOT_INO) {
+            root.children.get_or_insert_with(Vec::new).push(ino);
+        }
+        ino
+    }
+
+    /// Folder metadata listing `hello.txt` at the same IPNS identity with the
+    /// given `modified_at`.
+    fn refresh_metadata(file_mtime_ms: u64) -> cipherbox_core::FolderMetadata {
+        cipherbox_core::FolderMetadata {
+            version: "v2".to_string(),
+            children: vec![cipherbox_core::FolderChild::File(
+                cipherbox_core::FilePointer {
+                    id: "file-1".to_string(),
+                    name: "hello.txt".to_string(),
+                    file_meta_ipns_name: FILE_IPNS.to_string(),
+                    ipns_private_key_encrypted: None,
+                    created_at: 1700000000000,
+                    modified_at: file_mtime_ms,
+                },
+            )],
+        }
+    }
+
+    fn is_unresolved(fs: &crate::CipherBoxFS, ino: u64) -> bool {
+        matches!(
+            &fs.inodes.get(ino).unwrap().kind,
+            InodeKind::File {
+                file_meta_resolved: false,
+                cid,
+                ..
+            } if cid.is_empty()
+        )
+    }
+
+    fn send_refresh(fs: &crate::CipherBoxFS, metadata: cipherbox_core::FolderMetadata) {
+        fs.refresh_tx
+            .send(PendingRefresh::Success {
+                ino: ROOT_INO,
+                ipns_name: ROOT_IPNS.to_string(),
+                metadata,
+                cid: "bafyREFRESHcid".to_string(),
+            })
+            .unwrap();
+    }
+
+    /// Gated branch (folder mid local-publish): a strictly-newer remote edit is
+    /// flipped to unresolved WITHOUT a full populate_folder, and the fall-through
+    /// spawn block enqueues it for resolution. Remote metadata is still cached.
+    #[tokio::test]
+    async fn gated_marks_remote_edit_and_spawns_resolution() {
+        let mut fs = make_test_fs();
+        let file_ino = insert_resolved_file(&mut fs, 1700000000000);
+        fs.mutated_folders
+            .insert(ROOT_INO, std::time::Instant::now());
+
+        send_refresh(&fs, refresh_metadata(1700001000000));
+        fs.drain_refresh_completions();
+
+        assert!(is_unresolved(&fs, file_ino), "remote edit marked unresolved");
+        assert!(
+            fs.resolving_file_pointers.contains(&file_ino),
+            "fall-through spawn must enqueue the marked file for resolution"
+        );
+        assert!(
+            fs.metadata_cache.get(ROOT_IPNS).is_some(),
+            "remote metadata is cached even on the gated path"
+        );
+    }
+
+    /// Gated branch must NOT clobber a pending local mutation: the local inode is
+    /// newer than the (stale) remote refresh, so it stays resolved and is not
+    /// queued for re-resolution.
+    #[tokio::test]
+    async fn gated_preserves_pending_local_mutation() {
+        let mut fs = make_test_fs();
+        let file_ino = insert_resolved_file(&mut fs, 1700001000000); // local is newer
+        fs.mutated_folders
+            .insert(ROOT_INO, std::time::Instant::now());
+
+        send_refresh(&fs, refresh_metadata(1700000000000)); // older remote
+        fs.drain_refresh_completions();
+
+        assert!(
+            !is_unresolved(&fs, file_ino),
+            "local mutation must stay resolved (not clobbered by stale remote)"
+        );
+        assert!(
+            !fs.resolving_file_pointers.contains(&file_ino),
+            "older remote must not trigger re-resolution of a local mutation"
+        );
+    }
+
+    /// Non-gated branch (no pending local mutation): the full populate_folder path
+    /// runs, applying the remote modified_at change, then the shared spawn block
+    /// enqueues the file for resolution.
+    #[tokio::test]
+    async fn unmutated_populates_and_spawns_resolution() {
+        let mut fs = make_test_fs();
+        let file_ino = insert_resolved_file(&mut fs, 1700000000000);
+        // No mutated_folders / publish_queue entry -> non-gated populate_folder path.
+
+        send_refresh(&fs, refresh_metadata(1700001000000));
+        fs.drain_refresh_completions();
+
+        assert!(
+            is_unresolved(&fs, file_ino),
+            "populate_folder applies the remote edit and marks unresolved"
+        );
+        assert!(fs.resolving_file_pointers.contains(&file_ino));
+        assert!(fs.metadata_cache.get(ROOT_IPNS).is_some());
+    }
+
+    /// A `PendingRefresh::Failure` clears the in-flight `refreshing_metadata`
+    /// guard and applies no inode/cache changes.
+    #[tokio::test]
+    async fn failure_clears_refreshing_guard() {
+        let mut fs = make_test_fs();
+        fs.refreshing_metadata.insert(ROOT_IPNS.to_string());
+
+        fs.refresh_tx
+            .send(PendingRefresh::Failure {
+                ipns_name: ROOT_IPNS.to_string(),
+            })
+            .unwrap();
+        fs.drain_refresh_completions();
+
+        assert!(
+            !fs.refreshing_metadata.contains(ROOT_IPNS),
+            "Failure must clear the in-flight refresh guard"
+        );
+        assert!(
+            fs.metadata_cache.get(ROOT_IPNS).is_none(),
+            "Failure applies no cache write"
+        );
+    }
+}

--- a/crates/fuse/src/inode.rs
+++ b/crates/fuse/src/inode.rs
@@ -1076,6 +1076,12 @@ impl InodeTable {
                 file_ipns_key_encrypted_hex: prev_key_hex,
                 versions: None,
             };
+            // Clear the stale resolved size/blocks as well (mirrors populate_folder's
+            // unresolved rebuild, which derives attr from the size:0 kind) so
+            // GETATTR/READDIR do not expose the old size during the re-resolution
+            // window. resolve_file_pointer restores the real size on completion.
+            inode.attr.size = 0;
+            inode.attr.blocks = 0;
             // Adopt the remote timestamp so the next refresh cycle sees mtime ==
             // remote modified_at and does not re-mark (resolve_file_pointer leaves
             // mtime untouched, so this stays stable after resolution completes).
@@ -1602,6 +1608,8 @@ mod tests {
         let child = table.get(child_ino).unwrap();
         let expected_mtime = UNIX_EPOCH + Duration::from_millis(1700001000000);
         assert_eq!(child.attr.mtime, expected_mtime, "mtime adopts remote value");
+        assert_eq!(child.attr.size, 0, "stale resolved size cleared");
+        assert_eq!(child.attr.blocks, 0, "stale resolved blocks cleared");
         match &child.kind {
             InodeKind::File {
                 file_meta_resolved,

--- a/crates/fuse/src/inode.rs
+++ b/crates/fuse/src/inode.rs
@@ -978,6 +978,101 @@ impl InodeTable {
             })
             .collect()
     }
+
+    /// Mark *genuine remote file edits* in a folder for re-resolution WITHOUT
+    /// rebuilding folder structure or clobbering pending local mutations.
+    ///
+    /// `drain_refresh_completions` skips the full `populate_folder` apply while a
+    /// folder has pending local mutations/publishes (`mutated_folders` /
+    /// `publish_queue`) -- otherwise a refresh carrying stale remote metadata would
+    /// overwrite the local change before its own publish propagates (folder-state
+    /// desync). The side effect was that a *remote* edit (e.g. a file edited via the
+    /// web/SDK on another client) arriving in that same window was dropped entirely:
+    /// `populate_folder`'s `modified_at`-change detection -- the only thing that marks
+    /// an already-resolved file unresolved so its new CID is re-fetched -- never ran.
+    ///
+    /// This is the narrow, structure-free counterpart: for each remote File child
+    /// that maps to an *already-resolved* local inode under the SAME pointer identity
+    /// (same `file_meta_ipns_name`, same display name) AND whose remote `modified_at`
+    /// is **strictly newer** than the local inode's mtime, rebuild it as unresolved
+    /// (preserving IPNS keys) so the caller's resolution spawn re-fetches the new CID.
+    ///
+    /// Crucially it touches NOTHING else: folders, freshly-added remote files,
+    /// removed files, pointer swaps, and -- the whole point -- any file whose local
+    /// mtime is >= the remote timestamp (i.e. a pending local mutation) are left
+    /// untouched. The strict `>` comparison makes "local wins" the rule on ties or
+    /// behind-clock skew; once the local publish settles and the folder leaves
+    /// `mutated_folders`, the normal `populate_folder` path reconciles the rest.
+    ///
+    /// Returns `(ino, file_meta_ipns_name)` for each file marked, so the caller can
+    /// drive the existing per-folder resolution spawn.
+    #[cfg(any(feature = "fuse", feature = "winfsp"))]
+    pub fn mark_remotely_edited_files_unresolved(
+        &mut self,
+        parent_ino: u64,
+        metadata: &FolderMetadata,
+    ) -> Vec<(u64, String)> {
+        let mut marked = Vec::new();
+        for child in &metadata.children {
+            let file_pointer = match child {
+                FolderChild::File(f) => f,
+                FolderChild::Folder(_) => continue,
+            };
+            // Match strictly by current display name: a rename is a structural
+            // change we deliberately leave to the full populate_folder path.
+            let Some(existing_ino) = self.find_child(parent_ino, &file_pointer.name) else {
+                continue;
+            };
+            let modified = UNIX_EPOCH + Duration::from_millis(file_pointer.modified_at);
+            let Some(inode) = self.inodes.get_mut(&existing_ino) else {
+                continue;
+            };
+            // Only act on an already-resolved file under the SAME pointer identity
+            // whose remote timestamp is strictly newer than our local copy. Anything
+            // else (unresolved already, different pointer, local mtime >= remote) is
+            // skipped so pending local mutations are never overwritten.
+            let (prev_key, prev_key_hex) = match &inode.kind {
+                InodeKind::File {
+                    file_meta_resolved: true,
+                    file_meta_ipns_name: Some(name),
+                    file_ipns_private_key,
+                    file_ipns_key_encrypted_hex,
+                    ..
+                } if name == &file_pointer.file_meta_ipns_name && modified > inode.attr.mtime => {
+                    (
+                        file_ipns_private_key.clone(),
+                        file_ipns_key_encrypted_hex.clone(),
+                    )
+                }
+                _ => continue,
+            };
+            log::info!(
+                "File '{}': remote edit detected while folder ino {} is locally publishing -- marking for re-resolution without clobbering local state",
+                file_pointer.name,
+                parent_ino
+            );
+            inode.kind = InodeKind::File {
+                cid: String::new(),
+                encrypted_file_key: String::new(),
+                iv: String::new(),
+                size: 0,
+                encryption_mode: "GCM".to_string(),
+                file_meta_ipns_name: Some(file_pointer.file_meta_ipns_name.clone()),
+                file_meta_resolved: false,
+                file_ipns_private_key: prev_key,
+                file_ipns_key_encrypted_hex: prev_key_hex,
+                versions: None,
+            };
+            // Adopt the remote timestamp so the next refresh cycle sees mtime ==
+            // remote modified_at and does not re-mark (resolve_file_pointer leaves
+            // mtime untouched, so this stays stable after resolution completes).
+            inode.attr.atime = modified;
+            inode.attr.mtime = modified;
+            inode.attr.ctime = modified;
+            marked.push((existing_ino, file_pointer.file_meta_ipns_name.clone()));
+        }
+        marked
+    }
 }
 
 #[cfg(all(test, any(feature = "fuse", feature = "winfsp")))]
@@ -1424,6 +1519,198 @@ mod tests {
             "Old name should not exist"
         );
         assert_eq!(table.find_child(ROOT_INO, "Beta"), Some(original_ino));
+    }
+
+    /// Build a folder with one resolved file (cid="bafyOLDcid", keys set) at the
+    /// given `modified_at`, returning the table and the file's inode number.
+    #[cfg(test)]
+    fn table_with_resolved_file(ipns_name: &str, modified_at: u64) -> (InodeTable, u64) {
+        let mut table = InodeTable::new();
+        let metadata = FolderMetadata {
+            version: "v2".to_string(),
+            children: vec![FolderChild::File(cipherbox_core::folder::FilePointer {
+                id: "file-1".to_string(),
+                name: "hello.txt".to_string(),
+                file_meta_ipns_name: ipns_name.to_string(),
+                ipns_private_key_encrypted: None,
+                created_at: 1700000000000,
+                modified_at,
+            })],
+        };
+        let private_key = vec![0u8; 32];
+        let public_key = vec![0u8; 33];
+        table
+            .populate_folder(ROOT_INO, &metadata, &private_key, &public_key, false)
+            .unwrap();
+        let child_ino = table.get(ROOT_INO).unwrap().children.as_ref().unwrap()[0];
+        table.resolve_file_pointer(
+            child_ino,
+            "bafyOLDcid".to_string(),
+            "enckey".to_string(),
+            "iv123".to_string(),
+            42,
+            "GCM".to_string(),
+            None,
+        );
+        if let Some(inode) = table.inodes.get_mut(&child_ino) {
+            if let InodeKind::File {
+                ref mut file_ipns_private_key,
+                ref mut file_ipns_key_encrypted_hex,
+                ..
+            } = inode.kind
+            {
+                *file_ipns_private_key = Some(Zeroizing::new(vec![1u8; 32]));
+                *file_ipns_key_encrypted_hex = Some("abcdef1234".to_string());
+            }
+        }
+        (table, child_ino)
+    }
+
+    #[test]
+    fn test_mark_remotely_edited_marks_newer_same_pointer() {
+        let ipns_name = "k51qzi5uqu5dljtg5upm7x7ugan9lql3ewyknv4r4mhhkwzn8n7cnbd1unfwgx";
+        let (mut table, child_ino) = table_with_resolved_file(ipns_name, 1700000000000);
+
+        // Remote edit: same pointer + name, strictly newer modified_at.
+        let metadata = FolderMetadata {
+            version: "v2".to_string(),
+            children: vec![FolderChild::File(cipherbox_core::folder::FilePointer {
+                id: "file-1".to_string(),
+                name: "hello.txt".to_string(),
+                file_meta_ipns_name: ipns_name.to_string(),
+                ipns_private_key_encrypted: None,
+                created_at: 1700000000000,
+                modified_at: 1700001000000, // 1000s later
+            })],
+        };
+
+        let marked = table.mark_remotely_edited_files_unresolved(ROOT_INO, &metadata);
+        assert_eq!(
+            marked,
+            vec![(child_ino, ipns_name.to_string())],
+            "remote-newer same-pointer file should be marked for re-resolution"
+        );
+
+        let child = table.get(child_ino).unwrap();
+        let expected_mtime = UNIX_EPOCH + Duration::from_millis(1700001000000);
+        assert_eq!(child.attr.mtime, expected_mtime, "mtime adopts remote value");
+        match &child.kind {
+            InodeKind::File {
+                file_meta_resolved,
+                cid,
+                file_meta_ipns_name,
+                file_ipns_private_key,
+                file_ipns_key_encrypted_hex,
+                ..
+            } => {
+                assert!(!file_meta_resolved, "should be unresolved");
+                assert!(cid.is_empty(), "cid cleared for re-resolution");
+                assert_eq!(file_meta_ipns_name.as_deref(), Some(ipns_name));
+                assert!(
+                    file_ipns_private_key.is_some(),
+                    "IPNS key preserved (same pointer)"
+                );
+                assert_eq!(file_ipns_key_encrypted_hex.as_deref(), Some("abcdef1234"));
+            }
+            _ => panic!("Expected File"),
+        }
+
+        // Idempotent: now that it is unresolved, a second pass marks nothing (and
+        // get_unresolved... drives the actual re-spawn instead).
+        let again = table.mark_remotely_edited_files_unresolved(ROOT_INO, &metadata);
+        assert!(again.is_empty(), "already-unresolved file is not re-marked");
+    }
+
+    #[test]
+    fn test_mark_remotely_edited_preserves_local_mutations() {
+        let ipns_name = "k51qzi5uqu5dljtg5upm7x7ugan9lql3ewyknv4r4mhhkwzn8n7cnbd1unfwgx";
+
+        // Local inode sits at t=1700001000000 (a pending local mutation). Remote
+        // metadata is OLDER (1700000000000) -- it must NOT clobber local state.
+        let (mut table, child_ino) = table_with_resolved_file(ipns_name, 1700001000000);
+        let stale_remote = FolderMetadata {
+            version: "v2".to_string(),
+            children: vec![FolderChild::File(cipherbox_core::folder::FilePointer {
+                id: "file-1".to_string(),
+                name: "hello.txt".to_string(),
+                file_meta_ipns_name: ipns_name.to_string(),
+                ipns_private_key_encrypted: None,
+                created_at: 1700000000000,
+                modified_at: 1700000000000, // older than local
+            })],
+        };
+        let marked = table.mark_remotely_edited_files_unresolved(ROOT_INO, &stale_remote);
+        assert!(marked.is_empty(), "older remote must not mark local mutation");
+        match &table.get(child_ino).unwrap().kind {
+            InodeKind::File {
+                file_meta_resolved,
+                cid,
+                ..
+            } => {
+                assert!(file_meta_resolved, "local state stays resolved");
+                assert_eq!(cid, "bafyOLDcid", "local cid untouched");
+            }
+            _ => panic!("Expected File"),
+        }
+
+        // Equal modified_at is also a no-op (local wins on ties).
+        let equal_remote = FolderMetadata {
+            version: "v2".to_string(),
+            children: vec![FolderChild::File(cipherbox_core::folder::FilePointer {
+                id: "file-1".to_string(),
+                name: "hello.txt".to_string(),
+                file_meta_ipns_name: ipns_name.to_string(),
+                ipns_private_key_encrypted: None,
+                created_at: 1700000000000,
+                modified_at: 1700001000000,
+            })],
+        };
+        assert!(
+            table
+                .mark_remotely_edited_files_unresolved(ROOT_INO, &equal_remote)
+                .is_empty(),
+            "equal modified_at is a no-op"
+        );
+    }
+
+    #[test]
+    fn test_mark_remotely_edited_ignores_structural_changes() {
+        let ipns_name = "k51qzi5uqu5dljtg5upm7x7ugan9lql3ewyknv4r4mhhkwzn8n7cnbd1unfwgx";
+        let (mut table, _child_ino) = table_with_resolved_file(ipns_name, 1700000000000);
+        let inode_count_before = table.inodes.len();
+
+        // A brand-new remote file (no local inode) plus a folder child: neither is a
+        // content edit of an existing resolved file, so nothing is marked and -- the
+        // point of this path -- no structural inode is added while locally mutating.
+        let metadata = FolderMetadata {
+            version: "v2".to_string(),
+            children: vec![
+                FolderChild::File(cipherbox_core::folder::FilePointer {
+                    id: "file-2".to_string(),
+                    name: "brand-new.txt".to_string(),
+                    file_meta_ipns_name: "k51qzi5uqu5dNEWfileADDEDremotelyABC123".to_string(),
+                    ipns_private_key_encrypted: None,
+                    created_at: 1700002000000,
+                    modified_at: 1700002000000,
+                }),
+                FolderChild::Folder(cipherbox_core::folder::FolderEntry {
+                    id: "folder-1".to_string(),
+                    name: "subfolder".to_string(),
+                    ipns_name: "k51qzi5uqu5dSUBFOLDERref456".to_string(),
+                    folder_key_encrypted: "00".to_string(),
+                    ipns_private_key_encrypted: "00".to_string(),
+                    created_at: 1700002000000,
+                    modified_at: 1700002000000,
+                }),
+            ],
+        };
+        let marked = table.mark_remotely_edited_files_unresolved(ROOT_INO, &metadata);
+        assert!(marked.is_empty(), "structural changes are not marked here");
+        assert_eq!(
+            table.inodes.len(),
+            inode_count_before,
+            "no inodes added/removed by the content-only re-resolution path"
+        );
     }
 
     #[test]

--- a/crates/fuse/src/inode.rs
+++ b/crates/fuse/src/inode.rs
@@ -1004,15 +1004,19 @@ impl InodeTable {
     /// behind-clock skew; once the local publish settles and the folder leaves
     /// `mutated_folders`, the normal `populate_folder` path reconciles the rest.
     ///
-    /// Returns `(ino, file_meta_ipns_name)` for each file marked, so the caller can
-    /// drive the existing per-folder resolution spawn.
+    /// This only mutates matched inodes in place (flipping them to unresolved); it does
+    /// NOT spawn resolution itself and does NOT surface pre-existing unresolved files.
+    /// The caller MUST still call `get_unresolved_file_pointers_for_parent` afterwards --
+    /// that re-scans the whole folder (the files flipped here plus any already-unresolved
+    /// ones) and drives the actual resolution spawn. It returns `()` deliberately: the set
+    /// flipped here is intentionally not surfaced, so a future second call site can't be
+    /// tempted to drive the spawn from a return value and skip that re-scan.
     #[cfg(any(feature = "fuse", feature = "winfsp"))]
     pub fn mark_remotely_edited_files_unresolved(
         &mut self,
         parent_ino: u64,
         metadata: &FolderMetadata,
-    ) -> Vec<(u64, String)> {
-        let mut marked = Vec::new();
+    ) {
         for child in &metadata.children {
             let file_pointer = match child {
                 FolderChild::File(f) => f,
@@ -1031,6 +1035,15 @@ impl InodeTable {
             // whose remote timestamp is strictly newer than our local copy. Anything
             // else (unresolved already, different pointer, local mtime >= remote) is
             // skipped so pending local mutations are never overwritten.
+            //
+            // NOTE the deliberate `>` here vs `populate_folder`'s `!=`: populate_folder
+            // re-resolves on ANY mtime difference, so a behind-clock remote edit with a
+            // SMALLER modified_at than our local copy still re-resolves there. We are
+            // intentionally stricter inside the local-mutation window -- a behind-clock
+            // remote edit (remote mtime < local) is DEFERRED, not applied, so it cannot
+            // clobber a pending local mutation we haven't published yet. It is reconciled
+            // normally once the folder leaves `mutated_folders` and populate_folder runs
+            // (worst case ~30s, the retention window). "Local wins" is the intended rule.
             let (prev_key, prev_key_hex) = match &inode.kind {
                 InodeKind::File {
                     file_meta_resolved: true,
@@ -1069,9 +1082,7 @@ impl InodeTable {
             inode.attr.atime = modified;
             inode.attr.mtime = modified;
             inode.attr.ctime = modified;
-            marked.push((existing_ino, file_pointer.file_meta_ipns_name.clone()));
         }
-        marked
     }
 }
 
@@ -1584,12 +1595,9 @@ mod tests {
             })],
         };
 
-        let marked = table.mark_remotely_edited_files_unresolved(ROOT_INO, &metadata);
-        assert_eq!(
-            marked,
-            vec![(child_ino, ipns_name.to_string())],
-            "remote-newer same-pointer file should be marked for re-resolution"
-        );
+        // The remote-newer same-pointer file is flipped to unresolved in place (the
+        // function returns ()); the assertions below verify the flip.
+        table.mark_remotely_edited_files_unresolved(ROOT_INO, &metadata);
 
         let child = table.get(child_ino).unwrap();
         let expected_mtime = UNIX_EPOCH + Duration::from_millis(1700001000000);
@@ -1615,10 +1623,25 @@ mod tests {
             _ => panic!("Expected File"),
         }
 
-        // Idempotent: now that it is unresolved, a second pass marks nothing (and
-        // get_unresolved... drives the actual re-spawn instead).
-        let again = table.mark_remotely_edited_files_unresolved(ROOT_INO, &metadata);
-        assert!(again.is_empty(), "already-unresolved file is not re-marked");
+        // Idempotent: now that it is unresolved, a second pass is a no-op (the guard
+        // requires file_meta_resolved: true), leaving the inode untouched --
+        // get_unresolved... drives the actual re-spawn instead.
+        table.mark_remotely_edited_files_unresolved(ROOT_INO, &metadata);
+        let child = table.get(child_ino).unwrap();
+        assert_eq!(
+            child.attr.mtime, expected_mtime,
+            "second pass must not change the already-unresolved inode"
+        );
+        assert!(
+            matches!(
+                &child.kind,
+                InodeKind::File {
+                    file_meta_resolved: false,
+                    ..
+                }
+            ),
+            "still unresolved after second pass"
+        );
     }
 
     #[test]
@@ -1639,8 +1662,8 @@ mod tests {
                 modified_at: 1700000000000, // older than local
             })],
         };
-        let marked = table.mark_remotely_edited_files_unresolved(ROOT_INO, &stale_remote);
-        assert!(marked.is_empty(), "older remote must not mark local mutation");
+        // Older remote must NOT touch the local mutation -- the inode stays resolved.
+        table.mark_remotely_edited_files_unresolved(ROOT_INO, &stale_remote);
         match &table.get(child_ino).unwrap().kind {
             InodeKind::File {
                 file_meta_resolved,
@@ -1665,11 +1688,17 @@ mod tests {
                 modified_at: 1700001000000,
             })],
         };
+        // Equal modified_at is also a no-op (local wins on ties): inode stays resolved.
+        table.mark_remotely_edited_files_unresolved(ROOT_INO, &equal_remote);
         assert!(
-            table
-                .mark_remotely_edited_files_unresolved(ROOT_INO, &equal_remote)
-                .is_empty(),
-            "equal modified_at is a no-op"
+            matches!(
+                &table.get(child_ino).unwrap().kind,
+                InodeKind::File {
+                    file_meta_resolved: true,
+                    ..
+                }
+            ),
+            "equal modified_at is a no-op -- inode stays resolved"
         );
     }
 
@@ -1704,8 +1733,10 @@ mod tests {
                 }),
             ],
         };
-        let marked = table.mark_remotely_edited_files_unresolved(ROOT_INO, &metadata);
-        assert!(marked.is_empty(), "structural changes are not marked here");
+        // Structural changes (new file, folder) are not content edits of an existing
+        // resolved file, so nothing is flipped and -- the point of this path -- no
+        // structural inode is added while locally mutating.
+        table.mark_remotely_edited_files_unresolved(ROOT_INO, &metadata);
         assert_eq!(
             table.inodes.len(),
             inode_count_before,


### PR DESCRIPTION
## Problem

The macOS `Desktop E2E (macos)` job flakes on **Test 5** of cross-client sync
(`tests/desktop-e2e/scripts/test-cross-client-sync.sh`): after a file is edited
via the SDK, the FUSE mount keeps serving the original content past the 120s
budget. This was the only failing job blocking CI E2E on `main` (Linux + Windows
pass), which in turn blocks the Phase 60 staging wipe + redeploy.

## Root cause

In `drain_refresh_completions` (`crates/fuse/src/fs.rs`), when a folder has
pending local mutations/publishes (it sits in `mutated_folders` /
`publish_queue`), an incoming IPNS refresh was cached but `continue`d —
skipping `populate_folder` entirely to avoid clobbering the local change with
stale remote state (folder-state desync). The side effect: a genuine **remote**
file edit arriving in that same window was dropped, because `populate_folder`'s
`modified_at` detection is the only thing that marks an already-resolved file
unresolved so its new CID is re-fetched. The per-file re-resolution was never
spawned → original content for 120s → fail.

It is timing-dependent (the local publish window must overlap the remote-edit
refresh), hence the ~15% macOS flake, amplified by FUSE-T's SMB cache. **This is
pre-existing, not a Phase 60 regression** — the only Phase 60 change to `fs.rs`
was re-pointing the resolve call to the verified chokepoint.

## Fix

Add `InodeTable::mark_remotely_edited_files_unresolved` — a structure-free
counterpart to `populate_folder`. For each remote `File` child that maps to an
already-resolved local inode under the **same** pointer identity AND whose remote
`modified_at` is **strictly newer** than the local mtime, it rebuilds the inode
as unresolved (preserving IPNS keys, adopting the remote mtime) and returns it
for re-resolution. It touches nothing else:

- Folders, added/removed files, and pointer swaps → untouched (structural changes
  stay with the full `populate_folder` path once the local mutation settles).
- Any file whose local mtime `>=` remote (a pending local mutation) → untouched.
  The strict `>` makes "local wins" the rule on ties / behind-clock skew, so
  local changes are **never** clobbered.

The gated branch now calls this, then falls through to the existing shared
resolution-spawn block; the non-gated branch keeps full `populate_folder`. Adopting
the remote mtime makes it idempotent (no re-marking churn; `resolve_file_pointer`
leaves mtime intact). A timeout bump would *not* fix this — the failure is a
suppressed spawn, not slowness.

## Tests

- 3 new unit tests in `crates/fuse/src/inode.rs`: marks newer same-pointer edits
  (+ idempotency), preserves local mutations (older/equal remote is a no-op),
  ignores structural changes (no inodes added/removed).
- Full `cipherbox-fuse` suite green (92 passed); clippy clean on the change.
- Fix is feature-agnostic (shared `fuse`/`winfsp` cfg).

Addresses the desktop-macOS leg of the `2026-06-24-web-e2e-flaky-cascade-abort`
todo. The web-e2e cascade-abort half of that todo is unrelated and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed folder refresh behavior so remote file edits are now detected and reloaded correctly, even when local changes are pending.
  * Improved sync handling to avoid overwriting newer local changes during refresh.
  * Resolved an issue where refresh failures could leave sync state stuck, preventing the next update from continuing normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->