### PR TITLE
fix(web): embed sequence 1 on first BYO storage-config IPNS publish

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1075,12 +1075,12 @@ Verification gate: `cargo test` (fuse + winfsp feature sets), winfsp Windows CI,
 **Goal:** Extend verified IPNS resolution beyond the FUSE crate to the remaining desktop Tauri resolve sites, and recover the per-operation IPNS signature-verification CPU cost on the API publish/resolve hot path — without weakening the zero-knowledge integrity model (untrusted / DHT-sourced records must still be fully verified).
 **Requirements**: HARD-11
 **Depends on:** Phase 58 (resolve_ipns_verified chokepoint), Phase 59 (unified first-publish sequence convention)
-**Plans:** 7/8 plans executed
+**Plans:** 8/8 plans complete (completed 2026-06-26)
 
 Scope (captured todos):
 
-- [ ] Route `apps/desktop/src-tauri` `resolve_ipns` sites (`prepopulate.rs` ~43/110/177/236, `vault.rs` ~21/250) through a verified resolver with scoped fail-closed parity — `2026-06-22-desktop-resolve-ipns-verified-coverage.md`
-- [ ] Cache / short-circuit redundant IPNS signature verification on the API publish/resolve hot path (`apps/api/src/ipns/ipns.service.ts`): skip re-verifying DB-authoritative records this server just signed/persisted, and/or a short-TTL verified-record cache keyed by `(ipnsName, sequenceNumber, signature)`; MUST still verify externally-sourced / DHT records (someguy resolves) — `2026-06-23-cache-redundant-ipns-signature-verification-hot-path.md`
+- [x] Route `apps/desktop/src-tauri` `resolve_ipns` sites (`prepopulate.rs` ~43/110/177/236, `vault.rs` ~21/250) through a verified resolver with scoped fail-closed parity — `2026-06-22-desktop-resolve-ipns-verified-coverage.md`
+- [x] Cache / short-circuit redundant IPNS signature verification on the API publish/resolve hot path (`apps/api/src/ipns/ipns.service.ts`): skip re-verifying DB-authoritative records this server just signed/persisted, and/or a short-TTL verified-record cache keyed by `(ipnsName, sequenceNumber, signature)`; MUST still verify externally-sourced / DHT records (someguy resolves) — `2026-06-23-cache-redundant-ipns-signature-verification-hot-path.md`
 
 Plans:
 **Wave 1**
@@ -1101,7 +1101,7 @@ Plans:
 
 **Wave 4** *(blocked on Wave 3 completion)*
 
-- [ ] 60-08-PLAN.md — D-01/D-12 lockstep cutover: cross-layer gate confirmation + staging wipe + smoke (autonomous:false) [wave 4]
+- [x] 60-08-PLAN.md — D-01/D-12 lockstep cutover: cross-layer gate confirmation + staging wipe + smoke (autonomous:false) [wave 4]
 
 Verification gate: apps/api jest specs, full SDK E2E, desktop E2E (dispatch-gated); a measured per-op verification-cost recovery (benchmark/prototype) for the API short-circuit.
 
@@ -1157,6 +1157,8 @@ Phases execute in numeric order: 18 -> 19 -> 19.1 -> 19.2 -> 20 -> 21 -> 22 -> 2
 | 56. FUSE & IPNS Durability Hardening       | v1.1-hardening | 3/3 | Complete    | 2026-06-22 |
 | 57. API CID/Provider Hardening & Dedup     | v1.1-hardening | 2/2 | Complete    | 2026-06-22 |
 | 58. IPNS Signature-Verify Coverage         | v1.1-hardening | 4/4 | Complete    | 2026-06-22 |
+| 59. FUSE IPNS Verify/Publish Hardening     | v1.1-hardening | 4/4 | Complete    | 2026-06-23 |
+| 60. IPNS Verification Cross-Layer Closeout | v1.1-hardening | 8/8 | Complete    | 2026-06-26 |
 
 _Roadmap created: 2026-03-07_
 _Last updated: 2026-06-18 — added phase 49 (shared-folder intra-share move + useFolderNavigation unwrap consolidation; closes todos #8 + #7, builds on phase 48 shared-folder ownership)_
@@ -1165,3 +1167,4 @@ _Total M1.1 phases: 18 (18-35 complete) | Concern resolution: 5 phases | Post-mi
 _Last updated: 2026-06-21 — added deferred-findings hardening Phases 56–58 (HARD-07..09): FUSE/IPNS durability, API CID/provider hardening, IPNS signature-verify coverage; sourced from the Phase 50–55 / PR #529 + #538 review backlog. Filed resolved todos #5 (IPNS S1/S2/S3 → #529) and #10 (Tier-1/2 refactor → #538) to completed/._
 _Last updated: 2026-06-22 — Phase 58 planned: 4 plans (58-01 CBOR binding + resolve_ipns_verified chokepoint, 58-02 non-CAS D-09 sequence gate, 58-03 web/sdk-core resolve dedup, 58-04 shared cross-language verify vectors) in 2 waves (W1: 58-01/02; W2: 58-03/04 depends_on 58-01)._
 _Last updated: 2026-06-23 — added Phases 59–60 (HARD-10..11) from the 2026-06-23 pending-todo audit: 59 FUSE IPNS verify/publish hardening + cleanup (the Phase 56/58 long-tail, incl. 2 partial residuals), 60 IPNS verification cross-layer closeout (desktop verified-resolve + API hot-path verify caching). Not yet planned._
+_Last updated: 2026-06-26 — Phase 60 closed (60-08 D-01/D-12 lockstep cutover: cross-layer gates green, staging wiped + strict-verified smoke confirmed). Adversarial closeout verification caught a 10th first-publish producer (StorageTab BYO config embedded seq 0 → 400 under strict gate); fixed to embed sequence 1, completing D-02. Added Progress rows for Phases 59–60. NOTE: Progress table still shows stale 51–54 status (51 In Progress, 52–54 Planned) though disk shows their plans executed — defer reconciliation to /gsd:audit-milestone v1.1._

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v1.1
 milestone_name: IPFS Infrastructure
-status: Ready to execute
-last_updated: "2026-06-24T01:45:06Z"
-last_activity: 2026-06-24
+status: v1.1 complete on disk — milestone close pending verify + re-audit
+last_updated: "2026-06-26T21:50:33Z"
+last_activity: 2026-06-26
 progress:
   total_phases: 45
-  completed_phases: 44
-  total_plans: 198
-  completed_plans: 196
-  percent: 98
+  completed_phases: 45
+  total_plans: 199
+  completed_plans: 199
+  percent: 100
 ---
 
 # Project State
@@ -20,13 +20,22 @@ progress:
 See: .planning/PROJECT.md (updated 2026-03-07)
 
 **Core value:** Zero-knowledge privacy -- files encrypted client-side, server never sees plaintext
-**Current focus:** Phase 60 — ipns-verification-cross-layer-closeout-desktop-and-api
+**Current focus:** v1.1 milestone close — finish verification (Phases 59, 60) + re-audit hardening block, then /gsd:complete-milestone v1.1
 
 ## Current Position
 
-Phase: 60 (ipns-verification-cross-layer-closeout-desktop-and-api) — EXECUTING
-Plan: 8 of 8
-Milestone v1.1 hardening block extended 2026-06-21 with deferred-findings Phases 56–58 (HARD-07..09), sourced from the Phase 50–55 / PR #529 + #538 review backlog. Next: run /gsd:plan-phase 58 (recommended order was 56 FUSE/IPNS durability → 57 API CID/provider hardening → 58 IPNS signature-verify coverage; 58 last as it is the most regression-prone and full-SDK-E2E-gated). Note: STATE frontmatter progress counts are approximate and were periodically unreconciled (see todo `2026-06-18-gsd-phase-complete-regresses-state-final-phase.md`).
+Phase: 60 (ipns-verification-cross-layer-closeout-desktop-and-api) — COMPLETE (8/8 plans; 2026-06-26)
+Plan: 8 of 8 — COMPLETE
+Phase 60 closed 2026-06-26: 60-08 D-01/D-12 lockstep cutover done (cross-layer CI gates green, staging wiped + strict-verified smoke confirmed by maintainer). Adversarial closeout verification caught a 10th first-publish producer (StorageTab BYO storage-config embedded seq 0 → would 400 under the strict gate) that D-02/60-02 missed; fixed to embed sequence 1, completing D-02. 60-VERIFICATION flipped human_needed → passed (17/17). Every v1.1 phase (18–60) now has all plans executed on disk.
+
+**Next — resume the v1.1 milestone close (path chosen 2026-06-26):**
+
+1. `/gsd:verify-work 59` and `/gsd:verify-work 60` — clear the two human_needed verifications (59 still has 3 pending UAT scenarios; 60 now passed).
+2. `/gsd:health` — reconcile ROADMAP Progress-table drift (51 shows In Progress, 52–54 Planned, though their plans are executed on disk) and STATE counts.
+3. `/gsd:audit-milestone v1.1` — the existing audit only covers phases 18–35; the entire hardening block (50–60, HARD-01..11) is unaudited.
+4. `/gsd:complete-milestone v1.1` — once the re-audit passes.
+
+Note: STATE frontmatter progress counts are approximate and were periodically unreconciled (see todo `2026-06-18-gsd-phase-complete-regresses-state-final-phase.md`).
 
 ## Performance Metrics
 

--- a/.planning/phases/60-ipns-verification-cross-layer-closeout-desktop-and-api/60-08-SUMMARY.md
+++ b/.planning/phases/60-ipns-verification-cross-layer-closeout-desktop-and-api/60-08-SUMMARY.md
@@ -1,0 +1,113 @@
+---
+phase: 60-ipns-verification-cross-layer-closeout-desktop-and-api
+plan: "08"
+subsystem: infra/ipns
+tags: [cutover, ipns, strict-verify, staging, d11, hard-11, byo]
+dependency_graph:
+  requires: ["60-01", "60-02", "60-03", "60-04", "60-05", "60-06", "60-07"]
+  provides: ["strict-cutover-deployed", "staging-wiped-fresh-bootstrap", "d02-producer-completion"]
+  affects: ["apps/web/src/components/settings/StorageTab.tsx", "docs/DEVELOPMENT.md"]
+tech_stack:
+  added: []
+  patterns: ["lockstep cutover (deploy strict code -> wipe -> smoke)", "adversarial closeout verification before phase close"]
+key_files:
+  created:
+    - .planning/phases/60-ipns-verification-cross-layer-closeout-desktop-and-api/60-08-SUMMARY.md
+  modified:
+    - apps/web/src/components/settings/StorageTab.tsx
+    - docs/DEVELOPMENT.md
+decisions:
+  - "Gate confirmation read from main (where #555 + #566 + #568 merged + released), NOT the stale 56-commit-diverged feat branch — main is the integration source of truth post-squash-merge"
+  - "Adversarial closeout verification (4 parallel checks) run before close; it caught a 10th first-publish producer (StorageTab BYO config) that D-02/60-02 missed"
+  - "StorageTab BYO storage-config publish fixed to embed sequence 1 on first publish and existing+1 on update — completes D-02 and removes a live post-cutover 400 regression"
+  - "macOS Desktop-E2E failure on #555 is the known FUSE-T/SMB cross-client-sync flake (made optional by #560); #566/#568 macOS runs are green, so latest code is clean"
+metrics:
+  duration: "operator-gated"
+  completed: 2026-06-26
+requirements_completed: [HARD-11]
+---
+
+# Phase 60 Plan 08: D-01/D-12 Lockstep Cutover Summary
+
+**Strict fail-closed IPNS verification is live on staging via the deploy → wipe → smoke lockstep; adversarial closeout verification surfaced and fixed a missed first-publish producer (StorageTab BYO config) that the strict gate would otherwise 400.**
+
+## Performance
+
+- **Duration:** operator-gated (staging cutover performed by maintainer)
+- **Completed:** 2026-06-26
+- **Tasks:** 2 (Task 1 auto: gate confirmation + doc note; Task 2 human-action: staging cutover)
+- **Files modified:** 2 (StorageTab.tsx, DEVELOPMENT.md) + this SUMMARY
+
+## Task 1 — Cross-layer gate confirmation (D-12 pre-gate)
+
+The Phase 60 strict-cutover code (Waves 1–3) is **merged to main and released** via `#555` (strict
+fail-closed cutover), `#566` (FUSE publish + desktop vault-init hardening), and `#568` (FUSE share
+revoke). Release tags `cipher-box-v0.45.1` / `cipherbox-fuse-v0.10.1` / `@cipherbox/sdk-v0.37.2` /
+`@cipherbox/api-v0.44.1` were cut 2026-06-26 after `#568` merged. The five cross-layer gates were
+confirmed on the PR-head commits (CI runs on PR heads, not squash-merge commits):
+
+| Gate | Status | Evidence |
+| ---- | ------ | -------- |
+| Rust workspace (`cargo test`) | green | `Cargo Check, Test & Coverage (Linux)` + `Cargo Check & Test (macOS)` success on `#555`/`#566`/`#568` heads |
+| Windows winfsp | green | `Cargo Check & Test (Windows)` success on all three heads (distinct from `Desktop E2E (windows)`, also green) |
+| API jest | green | `Test` success on `#555`/`#566` heads; correctly path-skipped on `#568` (FUSE-only) |
+| SDK E2E round-trip | green | `SDK E2E Tests` named check success on `#555`/`#566` heads (directly observed, not inferred); path-skipped on `#568` |
+| Desktop E2E (dispatch-gated) | green | linux/macos/windows all success on `#566`/`#568` merge commits |
+
+The lone `#555` macOS Desktop-E2E failure is the known FUSE-T/macOS-SMB cross-client-sync flake
+(made macOS-optional by `#560`); the two later strict-cutover commits show macOS Desktop-E2E green,
+so the latest code is clean.
+
+**Local-dev-DB-wipe guidance** (D-01, RESEARCH Q5) documented as a one-paragraph note under
+`docs/DEVELOPMENT.md` → Testing → "Strict IPNS verification — wipe local DB first": developers with
+a pre-cutover local DB hold embedded-0 records that now fail strict-verify and must wipe per
+`DATABASE_EVOLUTION_PROTOCOL.md` §reset (non-destructive — IPNS keys derive deterministically from
+the Web3Auth key).
+
+## Adversarial closeout verification — D-02 gap found + fixed
+
+Before closing, a 4-check adversarial verification ran against current main. Results:
+
+- **Strict fail-closed cutover: confirmed** — no `VerifyError::Legacy`, no skew disjunct, no
+  `signatureVerified:false` soft path; `crates/fuse/src/verify.rs` deleted; all Rust/TS/desktop
+  resolve sites route through `resolve_ipns_verified`. (Minor: a few stale doc comments still
+  describe the removed legacy-allow path — documentation only, captured as a follow-up.)
+- **CI gate claims: confirmed** — all three commits merged + released; the five gates green as above.
+- **Milestone-unblock recheck: confirmed** — `60-08` was the ONLY incomplete plan across all 45
+  v1.1 phases; closing it leaves every phase complete on disk.
+- **Embedded-0 producer sweep: REFUTED** — found a **10th first-publish producer** that `60-02`/D-02
+  missed: `apps/web/src/components/settings/StorageTab.tsx:184` published the BYO storage-config IPNS
+  record with sequence **0** on first save (catch block literally "First publish -- sequence 0"),
+  passed verbatim through `createAndPublishIpnsRecord` to `/ipns/publish` → `upsertFolderIpns`'s
+  unconditional D-09 gate (`ipns.service.ts:295`, `if (embeddedSeq !== 1n) throw 400`). Post-cutover,
+  a BYO-IPFS user's first storage-config save would 400.
+
+**Fix:** `StorageTab.tsx` now embeds `1n` on first publish and `existing + 1n` on update (the latter
+also fixes a latent monotonicity bug — the prior code re-sent the stored sequence verbatim). This
+completes D-02 (all first-publish producers embed sequence 1) and removes the live regression. The
+phase's earlier "all 9 producers" count (60-VERIFICATION truth #6) was off by one; corrected here.
+
+## Task 2 — Staging cutover (D-01/D-12 blocking human checkpoint)
+
+Operator-confirmed ("cutover complete"). The D-12 lockstep order was followed: strict code deployed
+to staging → staging DB wiped per `DATABASE_EVOLUTION_PROTOCOL.md` §reset → services restarted →
+smoke test. Smoke-test conditions confirmed by the operator:
+
+- 4a — fresh login self-bootstraps a vault whose root folder resolves **strict-verified** (no
+  embedded-0 errors).
+- 4b — an embedded-0 publish is rejected with **400** (D-03).
+- 4c — a fresh post-wipe record passes strict verify; a tampered CID / expired record is rejected (D-07).
+
+## Verification
+
+- All 5 cross-layer gates green (recorded above).
+- Staging smoke-test operator-confirmed (4a/4b/4c).
+- Local-dev-DB-wipe guidance documented.
+- D-02 completed: StorageTab BYO first-publish producer corrected to embed sequence 1.
+
+## Follow-ups (captured, not blocking)
+
+- Clean up stale legacy-allow doc comments in `sdk-core/src/ipns/index.ts` (~207, ~302-303) and
+  `crates/api-client/src/ipns.rs` (~320, ~326) — they describe the removed path; code is correct.
+</content>
+</invoke>

--- a/.planning/phases/60-ipns-verification-cross-layer-closeout-desktop-and-api/60-VERIFICATION.md
+++ b/.planning/phases/60-ipns-verification-cross-layer-closeout-desktop-and-api/60-VERIFICATION.md
@@ -1,9 +1,10 @@
 ---
 phase: 60-ipns-verification-cross-layer-closeout-desktop-and-api
 verified: 2026-06-24T02:15:00Z
-status: human_needed
-score: 16/17 must-haves verified
+status: passed
+score: 17/17 must-haves verified
 overrides_applied: 0
+closed_out: '2026-06-26 — Plan 08 staging cutover operator-confirmed (D-12 lockstep deploy->wipe->smoke; 4a strict-verified self-bootstrap, 4b embedded-0 publish rejected 400, 4c tampered/expired rejected). Adversarial closeout verification found + fixed a 10th first-publish producer the original truth #6 missed (StorageTab BYO storage-config embedded seq 0 -> would 400 under the strict gate); fixed to embed sequence 1, completing D-02. The human_verification item below is now satisfied.'
 human_verification:
   - test: "Staging DB wipe + redeploy + strict-verify smoke test"
     expected: |

--- a/apps/web/src/components/settings/StorageTab.tsx
+++ b/apps/web/src/components/settings/StorageTab.tsx
@@ -193,7 +193,10 @@ export function StorageTab() {
             sequenceNumber = BigInt(existing.sequenceNumber) + 1n;
           }
         } catch {
-          // First publish -- sequence 1 (no existing record)
+          // First publish or resolve failure -- fall back to sequence 1.
+          // Note: if a record already exists (storedIpnsName set) and this
+          // catch fires due to a transient network error, publishing with
+          // sequence 1 will be rejected by the API's monotonicity gate.
         }
       }
 

--- a/apps/web/src/components/settings/StorageTab.tsx
+++ b/apps/web/src/components/settings/StorageTab.tsx
@@ -181,16 +181,19 @@ export function StorageTab() {
 
       const byoKeypair = await deriveByoConfigIpnsKeypair(vaultKeypair.privateKey);
 
-      let sequenceNumber = BigInt(0);
+      // Strict IPNS verification (Phase 60 / HARD-11) requires the first publish to
+      // embed sequence 1 and every subsequent publish to increment monotonically.
+      // Embedding 0 here would be rejected by the API's first-publish gate (400).
+      let sequenceNumber = BigInt(1);
       const storedIpnsName = localStorage.getItem(BYO_IPNS_NAME_KEY);
       if (storedIpnsName) {
         try {
           const existing = await resolveIpnsRecord(storedIpnsName);
           if (existing?.sequenceNumber) {
-            sequenceNumber = BigInt(existing.sequenceNumber);
+            sequenceNumber = BigInt(existing.sequenceNumber) + 1n;
           }
         } catch {
-          // First publish -- sequence 0
+          // First publish -- sequence 1 (no existing record)
         }
       }
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -122,6 +122,10 @@ pnpm --filter @cipherbox/crypto test
 
 > **Note:** `pnpm test` runs tests across all workspaces including E2E — use the filtered commands above for unit tests only.
 
+### Strict IPNS verification — wipe local DB first
+
+The strict fail-closed IPNS verification cutover (Phase 60 / HARD-11) rejects any IPNS record that embeds sequence `0`. A local dev database created before the cutover holds such "embedded-0" records, so a pre-existing vault or folder will fail strict verification and fail to resolve. Before running the strict build against an existing local DB, wipe it per [`DATABASE_EVOLUTION_PROTOCOL.md`](./DATABASE_EVOLUTION_PROTOCOL.md) (§reset) and log in again — the vault self-bootstraps fresh strict-verified records. Because all IPNS keys are deterministically derived from the Web3Auth key, the wipe is non-destructive to identity.
+
 ### E2E tests (Playwright)
 
 Playwright auto-starts API + web via `webServer` config (requires infra services: Postgres, IPFS, Redis):


### PR DESCRIPTION
## What

The strict fail-closed IPNS verification cutover (Phase 60 / HARD-11, shipped in `#555`) added an unconditional first-publish gate in the API: an IPNS record whose embedded sequence is not `1` is rejected with **400**. `StorageTab`'s BYO storage-config publish still seeded the first publish at **sequence 0** (catch block literally `// First publish -- sequence 0`), so a BYO-IPFS user's first config save would fail post-cutover.

Trace: `StorageTab.handleSave` → `createAndPublishIpnsRecord` (embeds the sequence verbatim) → `/ipns/publish` → `upsertFolderIpns`'s unconditional D-09 gate (`ipns.service.ts:295`, `if (embeddedSeq !== 1n) throw 400`).

## Fix

`apps/web/src/components/settings/StorageTab.tsx` now embeds:

- `1n` on first publish (no stored IPNS name / resolve miss)
- `existing + 1n` on update (also fixes a latent monotonicity bug — the prior code re-sent the stored sequence verbatim)

This completes **D-02** (unify all first-publish producers to embed sequence 1). It was the 10th producer the original Phase 60 sweep missed — surfaced by an adversarial closeout verification pass before closing the phase.

## Phase 60 closeout (included)

This PR also carries the Phase 60 plan-08 closeout (D-01/D-12 lockstep cutover):

- Cross-layer CI gates confirmed green on `#555` / `#566` / `#568` (Rust workspace, Windows winfsp, API jest, SDK E2E, Desktop E2E). The lone `#555` macOS Desktop-E2E failure is the known FUSE-T/SMB cross-client-sync flake (made optional by `#560`; later commits green).
- Staging DB wiped + redeployed; fresh-login strict-verified smoke test confirmed by maintainer (D-12 lockstep: deploy → wipe → smoke).
- Local-dev-DB-wipe guidance documented in `docs/DEVELOPMENT.md`.
- `60-VERIFICATION.md` flipped human_needed → passed (17/17); ROADMAP / STATE updated.

## Test

- `eslint` clean on the changed file.
- The API first-publish gate is covered by `apps/api/src/ipns/ipns.service.spec.ts` (embedded sequence must be 1).

## Follow-up (not blocking)

Stale legacy-allow doc comments in `sdk-core/src/ipns/index.ts` (~207, ~302-303) and `crates/api-client/src/ipns.rs` (~320, ~326) describe the removed degraded-acceptance path (code is correct) — captured for cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDNQVLoAw4DbPrPvtQPobh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where first-time saves could fail during IPNS publishing, improving reliability for storage settings updates.
  * Updated record versioning so new publishes advance correctly, preventing verification errors on existing data.

* **Documentation**
  * Added guidance for strict verification mode, including when to reset local development data before testing.
  
* **Chores**
  * Marked the IPNS verification rollout and milestone tracking as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->