### PR TITLE
chore: dedupe encryptedIpnsKey rename todo

### DIFF
--- a/.planning/todos/pending/2026-07-01-tee-republish-writepath-error-handling-hardening.md
+++ b/.planning/todos/pending/2026-07-01-tee-republish-writepath-error-handling-hardening.md
@@ -49,14 +49,3 @@ dereferences `entry.ipnsName` — throwing again and crashing the whole batch (5
 The relay is trusted and never sends null entries, so this is defense-in-depth: validate
 each `entry` is a non-null object at the top of the loop and skip/serialize invalid
 items safely in the failure path.
-
-### 4. Rename the `encryptedIpnsKey` wire field to `encryptedIpnsPrivateKey` (nitpick)
-
-CodeRabbit (PR #585, 2026-07-01): `RepublishEntry` sends the encrypted IPNS private key
-as `encryptedIpnsKey` (`republish.service.ts` ~135), but the repo terminology standard is
-`encryptedIpnsPrivateKey`. This is a **cross-package wire contract** — the same field name
-is read by the TEE worker (`apps/tee-worker/src/routes/republish.ts:58,121`) and referenced
-across ~15 worker test sites (`apps/tee-worker/src/__tests__/republish.test.ts`). Deferred
-because it's a trivial-importance rename that must change the API sender, the worker
-consumer, and all worker tests in one lockstep commit; not worth risking a wire-contract
-touch inside review resolution. Do it as its own scoped change with the worker tests.


### PR DESCRIPTION
Removes a duplicate todo entry. The `encryptedIpnsKey` → `encryptedIpnsPrivateKey` wire-contract rename is already tracked by the dedicated todo `2026-07-01-rename-encrypted-ipns-key-canonical-field.md` (which also covers `upgradedEncryptedKey`).

Finding #4 was added to `2026-07-01-tee-republish-writepath-error-handling-hardening.md` during PR #585 review resolution, before that dedicated todo was noticed — so the rename ended up tracked in two places. This removes the redundant entry.

Docs-only (`.planning/`), no code change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Removed a previously planned rename-related task from the roadmap, leaving current behavior unchanged.
* **Chores**
  * Updated internal planning notes to reflect the revised scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->