### PR TITLE
chore(ci): parallelize web-e2e across files for a reliable fast green

### DIFF
--- a/.planning/todos/pending/2026-07-03-port-recovery-tool-to-v3-vault-format.md
+++ b/.planning/todos/pending/2026-07-03-port-recovery-tool-to-v3-vault-format.md
@@ -4,7 +4,9 @@ title: Port standalone recovery tool to v3 vault format
 area: web
 files:
   - apps/web/public/recovery.html
-  - tests/web-e2e/tests/recovery.spec.ts
+  - tests/web-e2e/tests/recovery.spec.ts:68
+  - packages/core/src/vault/blob.ts:87
+  - packages/core/src/node/seal.ts
 source: 68.1-VERIFICATION.md (human-approved deferral, override 1 of 2)
 ---
 
@@ -24,3 +26,25 @@ tool to the v3 node format — unseal via the v3 envelope (readKey chain), under
 `WriteChildRef`/`SealedChildRef` split, and keep it a fully offline, standalone HTML
 artifact. Un-defer `recovery.spec.ts` once ported so the full web-e2e suite has zero
 expected failures.
+
+### Confirmed scope (from web-e2e parallelization investigation, 2026-07-06)
+
+Two distinct blockers — the tool is on the entire pre-#578 model, not just the blob header:
+
+1. **Blob parse (small):** `recovery.html:394,1160` hard-check `blob[0] === 0x02` and
+   halt with "not v2 format" on the current `0x03` blob. Replace with a v3 parser
+   mirroring `deserializeVaultBlobV3` (`packages/core/src/vault/blob.ts:87`): check
+   `0x03`, read `u16_BE(readLen)`, ECIES-decrypt the read-key segment (recovery only
+   needs the read chain; the write key can be ignored).
+2. **Folder/file traversal (large):** `recoverFolder` still expects the pre-#578
+   `{iv,data}` AES-GCM envelope with a `children[]` array. The runtime now publishes a
+   `node/v3` `PublishedNode` envelope sealed via `packages/core/src/node/seal.ts`
+   (AAD triad — roles `0x01` node / `0x02` child readKey / `0x03` content,
+   `buildNodeAad(id, kindByte, generation, role)`). Re-implement `unsealNode` /
+   `unsealChildReadKey` / `unsealContent` inline, since `recovery.html` is a
+   dependency-free standalone file (CDN `@noble`, no bundler).
+
+**Status:** as of the web-e2e parallelization branch, `recovery.spec.ts:68` is
+`test.fixme`'d (not just failing) with a `FIXME(recovery-v3)` pointer. Remove the
+`.fixme` once `recovery.html` speaks v3 so the full web-e2e suite has zero expected
+failures / skips.

--- a/tests/web-e2e/page-objects/file-browser/file-list.page.ts
+++ b/tests/web-e2e/page-objects/file-browser/file-list.page.ts
@@ -97,7 +97,10 @@ export class FileListPage {
    * Useful after file upload or folder creation.
    */
   async waitForItemToAppear(name: string, options?: { timeout?: number }): Promise<void> {
-    await this.getItem(name).waitFor({ state: 'visible', ...options });
+    // Default 60s: under parallel CI load the create/upload -> IPNS publish ->
+    // refresh round-trip can exceed Playwright's 30s default even though the item
+    // does eventually render. Callers may still override.
+    await this.getItem(name).waitFor({ state: 'visible', timeout: 60_000, ...options });
   }
 
   /**
@@ -105,7 +108,9 @@ export class FileListPage {
    * Useful after deletion or move.
    */
   async waitForItemToDisappear(name: string, options?: { timeout?: number }): Promise<void> {
-    await this.getItem(name).waitFor({ state: 'hidden', ...options });
+    // Default 60s: restore/delete/move round-trips are similarly slow under
+    // parallel CI load (see waitForItemToAppear).
+    await this.getItem(name).waitFor({ state: 'hidden', timeout: 60_000, ...options });
   }
 
   /**

--- a/tests/web-e2e/page-objects/file-browser/file-list.page.ts
+++ b/tests/web-e2e/page-objects/file-browser/file-list.page.ts
@@ -9,6 +9,9 @@ import { type Page, type Locator } from '@playwright/test';
  */
 function ciFloor(timeout?: number): number | undefined {
   if (!process.env.CI) return timeout;
+  // Preserve an explicit `timeout: 0` — in Playwright that means "no timeout,
+  // defer to the test/global budget", which the CI floor must not clamp to 60s.
+  if (timeout === 0) return 0;
   return Math.max(60_000, timeout ?? 0);
 }
 

--- a/tests/web-e2e/page-objects/file-browser/file-list.page.ts
+++ b/tests/web-e2e/page-objects/file-browser/file-list.page.ts
@@ -1,6 +1,18 @@
 import { type Page, type Locator } from '@playwright/test';
 
 /**
+ * Raise a per-call wait timeout to a 60s floor under CI, where the shared
+ * API/Kubo/Postgres stack under parallel-worker load makes write round-trips
+ * (create/upload/rename/delete -> IPNS publish -> refresh) slower than the
+ * serial-calibrated timeouts the specs pass. Longer explicit timeouts are
+ * honored; local runs keep the caller's value (undefined -> Playwright default).
+ */
+function ciFloor(timeout?: number): number | undefined {
+  if (!process.env.CI) return timeout;
+  return Math.max(60_000, timeout ?? 0);
+}
+
+/**
  * Page object for FileList component interactions.
  *
  * Encapsulates all file and folder list interactions in the main content area.
@@ -97,10 +109,12 @@ export class FileListPage {
    * Useful after file upload or folder creation.
    */
   async waitForItemToAppear(name: string, options?: { timeout?: number }): Promise<void> {
-    // Default 60s: under parallel CI load the create/upload -> IPNS publish ->
-    // refresh round-trip can exceed Playwright's 30s default even though the item
-    // does eventually render. Callers may still override.
-    await this.getItem(name).waitFor({ state: 'visible', timeout: 60_000, ...options });
+    // Under parallel CI load the create/upload -> IPNS publish -> refresh
+    // round-trip can exceed the serial-calibrated per-call timeouts sprinkled
+    // across the specs, even though the item does eventually render. Enforce a
+    // 60s floor on CI while still honoring longer explicit timeouts; locally,
+    // leave the caller's value untouched.
+    await this.getItem(name).waitFor({ state: 'visible', timeout: ciFloor(options?.timeout) });
   }
 
   /**
@@ -108,9 +122,9 @@ export class FileListPage {
    * Useful after deletion or move.
    */
   async waitForItemToDisappear(name: string, options?: { timeout?: number }): Promise<void> {
-    // Default 60s: restore/delete/move round-trips are similarly slow under
-    // parallel CI load (see waitForItemToAppear).
-    await this.getItem(name).waitFor({ state: 'hidden', timeout: 60_000, ...options });
+    // Restore/delete/move round-trips are similarly slow under parallel CI load
+    // (see waitForItemToAppear); apply the same CI floor.
+    await this.getItem(name).waitFor({ state: 'hidden', timeout: ciFloor(options?.timeout) });
   }
 
   /**

--- a/tests/web-e2e/playwright.config.ts
+++ b/tests/web-e2e/playwright.config.ts
@@ -27,12 +27,18 @@ export default defineConfig({
   // so different files never share user/IPNS/DB state. Keep fullyParallel:false so
   // tests WITHIN a file still run serially — the describe.serial suites depend on
   // ordered, stateful steps. Local stays single-worker; CI fans out across files.
-  // Ceiling is backend contention on the shared API/Kubo/Postgres stack, not
-  // Web3Auth: 4 workers starved the write path (folder-create / IPFS add / IPNS
-  // publish round-trips exceeded 30s on the 2-vCPU CI runner). 3 workers keeps
-  // wall-clock well under the 20-min job cap without starving writes.
+  // Parallelize across files (see fullyParallel note above). Worker count is not
+  // the flake lever here — 3 and 4 workers failed the identical set of write-heavy
+  // steps. Under concurrent load on the shared 2-vCPU CI stack, correct
+  // folder-create / restore / upload round-trips simply exceed Playwright's 30s
+  // default (the item does render — just late). The real lever is a longer test
+  // timeout on CI (and matching waiter timeouts in file-list.page.ts), not fewer
+  // workers. Local stays single-worker at the default timeout.
   fullyParallel: false,
-  workers: process.env.CI ? 3 : 1,
+  workers: process.env.CI ? 4 : 1,
+
+  // Give slow-but-correct write round-trips room under parallel CI load.
+  timeout: process.env.CI ? 60_000 : 30_000,
 
   // Fail build on CI if tests marked as test.only
   forbidOnly: !!process.env.CI,

--- a/tests/web-e2e/playwright.config.ts
+++ b/tests/web-e2e/playwright.config.ts
@@ -27,9 +27,12 @@ export default defineConfig({
   // so different files never share user/IPNS/DB state. Keep fullyParallel:false so
   // tests WITHIN a file still run serially — the describe.serial suites depend on
   // ordered, stateful steps. Local stays single-worker; CI fans out across files.
-  // Ceiling is Web3Auth Sapphire Devnet tolerance for concurrent DKG, not our infra.
+  // Ceiling is backend contention on the shared API/Kubo/Postgres stack, not
+  // Web3Auth: 4 workers starved the write path (folder-create / IPFS add / IPNS
+  // publish round-trips exceeded 30s on the 2-vCPU CI runner). 3 workers keeps
+  // wall-clock well under the 20-min job cap without starving writes.
   fullyParallel: false,
-  workers: process.env.CI ? 4 : 1,
+  workers: process.env.CI ? 3 : 1,
 
   // Fail build on CI if tests marked as test.only
   forbidOnly: !!process.env.CI,

--- a/tests/web-e2e/playwright.config.ts
+++ b/tests/web-e2e/playwright.config.ts
@@ -27,18 +27,20 @@ export default defineConfig({
   // so different files never share user/IPNS/DB state. Keep fullyParallel:false so
   // tests WITHIN a file still run serially — the describe.serial suites depend on
   // ordered, stateful steps. Local stays single-worker; CI fans out across files.
-  // Parallelize across files (see fullyParallel note above). Worker count is not
-  // the flake lever here — 3 and 4 workers failed the identical set of write-heavy
-  // steps. Under concurrent load on the shared 2-vCPU CI stack, correct
-  // folder-create / restore / upload round-trips simply exceed Playwright's 30s
-  // default (the item does render — just late). The real lever is a longer test
-  // timeout on CI (and matching waiter timeouts in file-list.page.ts), not fewer
-  // workers. Local stays single-worker at the default timeout.
+  //
+  // 3 workers, not 4: 4 workers cut wall-clock to ~12min but the extra concurrent
+  // load on the shared 2-vCPU CI stack pushed correct-but-slow paths over their
+  // budgets — notably sequential wallet-login DKG (the ~90s /files redirect) and
+  // multi-mutation deletes. 3 workers eases that contention across every path at
+  // once (login, write, per-test budget) for ~14min wall-clock, well under the
+  // 20-min job cap, and is far more reliable than inflating a dozen timeouts.
   fullyParallel: false,
-  workers: process.env.CI ? 4 : 1,
+  workers: process.env.CI ? 3 : 1,
 
-  // Give slow-but-correct write round-trips room under parallel CI load.
-  timeout: process.env.CI ? 60_000 : 30_000,
+  // Give slow-but-correct write round-trips room under parallel CI load. Waiters in
+  // file-list.page.ts floor to 60s each on CI, so a test chaining a few mutations
+  // needs more than one waiter's worth of budget.
+  timeout: process.env.CI ? 90_000 : 30_000,
 
   // Fail build on CI if tests marked as test.only
   forbidOnly: !!process.env.CI,

--- a/tests/web-e2e/playwright.config.ts
+++ b/tests/web-e2e/playwright.config.ts
@@ -22,9 +22,14 @@ export default defineConfig({
   // No global setup needed - tests handle their own authentication
   // (Removed globalSetup: './global-setup.ts')
 
-  // Run tests sequentially (single session approach)
+  // Parallelize at the file level, not the test level: each spec file provisions
+  // its own isolated wallet identity (unique privateKey -> unique backend userId),
+  // so different files never share user/IPNS/DB state. Keep fullyParallel:false so
+  // tests WITHIN a file still run serially — the describe.serial suites depend on
+  // ordered, stateful steps. Local stays single-worker; CI fans out across files.
+  // Ceiling is Web3Auth Sapphire Devnet tolerance for concurrent DKG, not our infra.
   fullyParallel: false,
-  workers: 1,
+  workers: process.env.CI ? 4 : 1,
 
   // Fail build on CI if tests marked as test.only
   forbidOnly: !!process.env.CI,

--- a/tests/web-e2e/tests/conflict-detection.spec.ts
+++ b/tests/web-e2e/tests/conflict-detection.spec.ts
@@ -13,7 +13,6 @@ import { FileListPage } from '../page-objects/file-browser/file-list.page';
 import { UploadZonePage } from '../page-objects/file-browser/upload-zone.page';
 import { CreateFolderDialogPage } from '../page-objects/dialogs/create-folder-dialog.page';
 import { ContextMenuPage } from '../page-objects/file-browser/context-menu.page';
-import { ConfirmDialogPage } from '../page-objects/dialogs/confirm-dialog.page';
 import { TextEditorDialogPage } from '../page-objects/dialogs/text-editor-dialog.page';
 
 /**
@@ -43,7 +42,6 @@ test.describe.serial('Conflict Detection', () => {
   let uploadZone: UploadZonePage;
   let createFolderDialog: CreateFolderDialogPage;
   let contextMenu: ContextMenuPage;
-  let confirmDialog: ConfirmDialogPage;
   let textEditorDialog: TextEditorDialogPage;
 
   let account: PrivateKeyAccount;
@@ -72,7 +70,6 @@ test.describe.serial('Conflict Detection', () => {
     uploadZone = new UploadZonePage(page);
     createFolderDialog = new CreateFolderDialogPage(page);
     contextMenu = new ContextMenuPage(page);
-    confirmDialog = new ConfirmDialogPage(page);
     textEditorDialog = new TextEditorDialogPage(page);
 
     // Login via wallet (mock wallet auto-approves connect + SIWE)
@@ -105,29 +102,16 @@ test.describe.serial('Conflict Detection', () => {
       await closeConflictDevice(deviceB);
     }
 
-    // Clean up remote items created during tests (runs even if earlier serial tests fail)
-    try {
-      const itemsToDelete = [...createdItems].reverse();
-      for (const item of itemsToDelete) {
-        const isVisible = await fileList.isItemVisible(item.name).catch(() => false);
-        if (!isVisible) continue;
-
-        await fileList.rightClickItem(item.name);
-        await contextMenu.waitForOpen();
-        await contextMenu.clickDelete();
-        await confirmDialog.waitForOpen();
-        await confirmDialog.clickConfirm();
-        await fileList.waitForItemToDisappear(item.name, { timeout: 30000 });
-      }
-    } catch (err) {
-      // Best-effort cleanup -- don't fail the suite if cleanup itself fails
-      console.warn('Cleanup of conflict test items failed:', err);
-    }
-
     cleanupTestFiles();
 
-    // Delete test account before closing context (page must still be navigable)
-    // Both primary and deviceB share the same wallet identity, so deleting once suffices.
+    // Delete the test account before closing the context (page must still be
+    // navigable). deleteAccount cascades server-side and removes every folder,
+    // file, and IPNS record for this identity, so there is no need to delete the
+    // created items through the UI first. That redundant per-item loop used to
+    // blow the 60s afterAll budget here: because this is the conflict suite,
+    // device A's local sequence is stale, so each UI delete triggered a
+    // 409 -> auto-resync -> retry cycle under 4-worker API rate-limiting.
+    // Both primary and deviceB share the same wallet identity, so one delete suffices.
     if (page) {
       await deleteAccountViaPage(page);
     }

--- a/tests/web-e2e/tests/full-workflow.spec.ts
+++ b/tests/web-e2e/tests/full-workflow.spec.ts
@@ -56,6 +56,20 @@ test.describe.serial('Full Workflow', () => {
   let detailsDialog: DetailsDialogPage;
   let textEditorDialog: TextEditorDialogPage;
 
+  // Assert an item's presence/absence, waiting for the list to settle first.
+  // Under parallel CI load the folder list re-renders only after a mutation's
+  // IPNS publish -> refresh round-trip, so an instant isItemVisible() check can
+  // race the mutation it is verifying. The waiters no-op when the state is
+  // already correct, so these are safe drop-in replacements everywhere.
+  const expectItemGone = async (name: string): Promise<void> => {
+    await fileList.waitForItemToDisappear(name);
+    expect(await fileList.isItemVisible(name)).toBe(false);
+  };
+  const expectItemPresent = async (name: string): Promise<void> => {
+    await fileList.waitForItemToAppear(name);
+    expect(await fileList.isItemVisible(name)).toBe(true);
+  };
+
   // Test data - unique names for this test run
   const timestamp = Date.now();
 
@@ -308,36 +322,36 @@ test.describe.serial('Full Workflow', () => {
 
   test('2.1 Create workspace folder at root', async () => {
     await createFolder(workspaceFolder);
-    expect(await fileList.isItemVisible(workspaceFolder)).toBe(true);
+    await expectItemPresent(workspaceFolder);
   });
 
   test('2.2 Create documents folder inside workspace', async () => {
     await navigateIntoFolder(workspaceFolder);
     await createFolder(documentsFolder);
-    expect(await fileList.isItemVisible(documentsFolder)).toBe(true);
+    await expectItemPresent(documentsFolder);
   });
 
   test('2.3 Create images folder inside workspace', async () => {
     // Still inside workspace
     await createFolder(imagesFolder);
-    expect(await fileList.isItemVisible(imagesFolder)).toBe(true);
+    await expectItemPresent(imagesFolder);
   });
 
   test('2.4 Create projects folder inside workspace', async () => {
     await createFolder(projectsFolder);
-    expect(await fileList.isItemVisible(projectsFolder)).toBe(true);
+    await expectItemPresent(projectsFolder);
   });
 
   test('2.5 Create active folder inside projects', async () => {
     await navigateIntoFolder(projectsFolder);
     await createFolder(activeFolder);
-    expect(await fileList.isItemVisible(activeFolder)).toBe(true);
+    await expectItemPresent(activeFolder);
   });
 
   test('2.6 Create archive folder inside projects', async () => {
     // Still inside projects
     await createFolder(archiveFolder);
-    expect(await fileList.isItemVisible(archiveFolder)).toBe(true);
+    await expectItemPresent(archiveFolder);
   });
 
   // ============================================
@@ -353,14 +367,14 @@ test.describe.serial('Full Workflow', () => {
 
     for (const file of rootFiles) {
       await uploadFile(file.name, file.content);
-      expect(await fileList.isItemVisible(file.name)).toBe(true);
+      await expectItemPresent(file.name);
     }
   });
 
   test('3.2 Upload editable file to root (for later edit test)', async () => {
     // This file will be edited later (deleted and re-uploaded with new content)
     await uploadFile(editableFileName, editableFileOriginalContent);
-    expect(await fileList.isItemVisible(editableFileName)).toBe(true);
+    await expectItemPresent(editableFileName);
   });
 
   test('3.3 Upload files to documents folder (3 files)', async () => {
@@ -369,7 +383,7 @@ test.describe.serial('Full Workflow', () => {
 
     for (const file of documentFiles) {
       await uploadFile(file.name, file.content);
-      expect(await fileList.isItemVisible(file.name)).toBe(true);
+      await expectItemPresent(file.name);
     }
   });
 
@@ -379,7 +393,7 @@ test.describe.serial('Full Workflow', () => {
 
     for (const file of imageFiles) {
       await uploadFile(file.name, file.content);
-      expect(await fileList.isItemVisible(file.name)).toBe(true);
+      await expectItemPresent(file.name);
     }
   });
 
@@ -390,7 +404,7 @@ test.describe.serial('Full Workflow', () => {
 
     for (const file of activeProjectFiles) {
       await uploadFile(file.name, file.content);
-      expect(await fileList.isItemVisible(file.name)).toBe(true);
+      await expectItemPresent(file.name);
     }
   });
 
@@ -400,7 +414,7 @@ test.describe.serial('Full Workflow', () => {
 
     for (const file of archiveProjectFiles) {
       await uploadFile(file.name, file.content);
-      expect(await fileList.isItemVisible(file.name)).toBe(true);
+      await expectItemPresent(file.name);
     }
   });
 
@@ -425,7 +439,7 @@ test.describe.serial('Full Workflow', () => {
     // Navigate to root where root files are visible
     await navigateToRoot();
     const fileName = rootFiles[1].name;
-    expect(await fileList.isItemVisible(fileName)).toBe(true);
+    await expectItemPresent(fileName);
 
     // Open context menu and click Details
     await fileList.rightClickItem(fileName);
@@ -470,7 +484,7 @@ test.describe.serial('Full Workflow', () => {
 
   test('3.66 View folder details via context menu', async () => {
     // We're at root, right-click on workspace folder
-    expect(await fileList.isItemVisible(workspaceFolder)).toBe(true);
+    await expectItemPresent(workspaceFolder);
 
     await fileList.rightClickItem(workspaceFolder);
     await contextMenu.waitForOpen();
@@ -569,9 +583,9 @@ test.describe.serial('Full Workflow', () => {
     // Verify other root-level items are also visible
     // rootFiles[0] was moved to workspace in 5.1 — but Phase 5 hasn't run yet at this point
     for (const file of rootFiles) {
-      expect(await fileList.isItemVisible(file.name)).toBe(true);
+      await expectItemPresent(file.name);
     }
-    expect(await fileList.isItemVisible(editableFileName)).toBe(true);
+    await expectItemPresent(editableFileName);
   });
 
   test('3.7.1 Storage quota persists after page reload', async () => {
@@ -596,9 +610,9 @@ test.describe.serial('Full Workflow', () => {
     await fileList.waitForItemToAppear(documentsFolder, { timeout: 60000 });
 
     // Verify workspace children are visible (documents, images, projects)
-    expect(await fileList.isItemVisible(documentsFolder)).toBe(true);
-    expect(await fileList.isItemVisible(imagesFolder)).toBe(true);
-    expect(await fileList.isItemVisible(projectsFolder)).toBe(true);
+    await expectItemPresent(documentsFolder);
+    await expectItemPresent(imagesFolder);
+    await expectItemPresent(projectsFolder);
 
     // Navigate deeper into documents — exercises nested IPNS resolve + key unwrap
     await navigateIntoFolder(documentsFolder);
@@ -608,7 +622,7 @@ test.describe.serial('Full Workflow', () => {
 
     // Verify uploaded document files are visible
     for (const file of documentFiles) {
-      expect(await fileList.isItemVisible(file.name)).toBe(true);
+      await expectItemPresent(file.name);
     }
   });
 
@@ -628,9 +642,9 @@ test.describe.serial('Full Workflow', () => {
     await fileList.waitForItemToAppear(documentsFolder, { timeout: 10000 });
 
     // Verify workspace children are all visible
-    expect(await fileList.isItemVisible(documentsFolder)).toBe(true);
-    expect(await fileList.isItemVisible(imagesFolder)).toBe(true);
-    expect(await fileList.isItemVisible(projectsFolder)).toBe(true);
+    await expectItemPresent(documentsFolder);
+    await expectItemPresent(imagesFolder);
+    await expectItemPresent(projectsFolder);
   });
 
   test('3.10 Upload file to subfolder after reload', async () => {
@@ -644,12 +658,12 @@ test.describe.serial('Full Workflow', () => {
 
     // Verify existing image files are present (from Phase 3.4)
     for (const file of imageFiles) {
-      expect(await fileList.isItemVisible(file.name)).toBe(true);
+      await expectItemPresent(file.name);
     }
 
     // Upload a new file — exercises the upload path after cold-load
     await uploadFile(postReloadFile.name, postReloadFile.content);
-    expect(await fileList.isItemVisible(postReloadFile.name)).toBe(true);
+    await expectItemPresent(postReloadFile.name);
 
     // Navigate away and back to verify persistence
     await navigateBack(); // Back to workspace
@@ -657,7 +671,7 @@ test.describe.serial('Full Workflow', () => {
 
     // File should still be there
     await fileList.waitForItemToAppear(postReloadFile.name, { timeout: 30000 });
-    expect(await fileList.isItemVisible(postReloadFile.name)).toBe(true);
+    await expectItemPresent(postReloadFile.name);
 
     // Navigate back to root for Phase 4
     await navigateToRoot();
@@ -683,7 +697,7 @@ test.describe.serial('Full Workflow', () => {
 
     // Create the multiselect folder at root
     await createFolder(multiselectFolder);
-    expect(await fileList.isItemVisible(multiselectFolder)).toBe(true);
+    await expectItemPresent(multiselectFolder);
 
     // Navigate into it
     await navigateIntoFolder(multiselectFolder);
@@ -691,12 +705,12 @@ test.describe.serial('Full Workflow', () => {
     // Upload 3 test files
     for (const file of msFiles) {
       await uploadFile(file.name, file.content);
-      expect(await fileList.isItemVisible(file.name)).toBe(true);
+      await expectItemPresent(file.name);
     }
 
     // Create a subfolder for move target
     await createFolder(batchDelFolder);
-    expect(await fileList.isItemVisible(batchDelFolder)).toBe(true);
+    await expectItemPresent(batchDelFolder);
   });
 
   test('4.1 Single click selects one item, clicking another deselects first', async () => {
@@ -876,7 +890,7 @@ test.describe.serial('Full Workflow', () => {
 
     // Both files should be gone
     await fileList.waitForItemToDisappear(delFile1.name, { timeout: 15000 });
-    expect(await fileList.isItemVisible(delFile2.name)).toBe(false);
+    await expectItemGone(delFile2.name);
   });
 
   test('4.11 Batch move via action bar', async () => {
@@ -906,12 +920,12 @@ test.describe.serial('Full Workflow', () => {
 
     // Files should be gone from current view
     await fileList.waitForItemToDisappear(msFiles[0].name, { timeout: 15000 });
-    expect(await fileList.isItemVisible(moveFile.name)).toBe(false);
+    await expectItemGone(moveFile.name);
 
     // Navigate into subfolder and verify
     await navigateIntoFolder(batchDelFolder);
-    expect(await fileList.isItemVisible(msFiles[0].name)).toBe(true);
-    expect(await fileList.isItemVisible(moveFile.name)).toBe(true);
+    await expectItemPresent(msFiles[0].name);
+    await expectItemPresent(moveFile.name);
 
     // Navigate back
     await navigateBack();
@@ -938,7 +952,7 @@ test.describe.serial('Full Workflow', () => {
 
     // Delete the multiselect folder
     await deleteItem(multiselectFolder);
-    expect(await fileList.isItemVisible(multiselectFolder)).toBe(false);
+    await expectItemGone(multiselectFolder);
   });
 
   // ============================================
@@ -955,7 +969,7 @@ test.describe.serial('Full Workflow', () => {
 
     // Get the first root file to move
     const fileToMove = rootFiles[0].name;
-    expect(await fileList.isItemVisible(fileToMove)).toBe(true);
+    await expectItemPresent(fileToMove);
 
     // Open context menu and click Move to...
     await fileList.rightClickItem(fileToMove);
@@ -973,16 +987,12 @@ test.describe.serial('Full Workflow', () => {
     await moveDialog.clickMove();
     await moveDialog.waitForClose({ timeout: 15000 });
 
-    // Verify file is no longer at root. Wait for the post-move refresh to
-    // settle first — under parallel CI load the instant visibility check can
-    // race the move's IPNS publish -> refresh round-trip.
-    await fileList.waitForItemToDisappear(fileToMove);
-    expect(await fileList.isItemVisible(fileToMove)).toBe(false);
+    // Verify file is no longer at root
+    await expectItemGone(fileToMove);
 
     // Navigate to workspace and verify file is there
     await navigateIntoFolder(workspaceFolder);
-    await fileList.waitForItemToAppear(fileToMove);
-    expect(await fileList.isItemVisible(fileToMove)).toBe(true);
+    await expectItemPresent(fileToMove);
   });
 
   test('5.2 Move file between sibling folders via context menu', async () => {
@@ -994,7 +1004,7 @@ test.describe.serial('Full Workflow', () => {
 
     // Get a document file to move (we have 3, take the first)
     const fileToMove = documentFiles[0].name;
-    expect(await fileList.isItemVisible(fileToMove)).toBe(true);
+    await expectItemPresent(fileToMove);
 
     // Navigate back to workspace where we can see both documents and images folders
     await navigateBack();
@@ -1010,7 +1020,7 @@ test.describe.serial('Full Workflow', () => {
     await navigateIntoFolder(documentsFolder);
 
     // File should be visible in documents
-    expect(await fileList.isItemVisible(fileToMove)).toBe(true);
+    await expectItemPresent(fileToMove);
 
     // Use context menu to move to images folder (sibling folder)
     await fileList.rightClickItem(fileToMove);
@@ -1024,12 +1034,12 @@ test.describe.serial('Full Workflow', () => {
     await moveDialog.waitForClose({ timeout: 15000 });
 
     // File should be gone from documents
-    expect(await fileList.isItemVisible(fileToMove)).toBe(false);
+    await expectItemGone(fileToMove);
 
     // Navigate to images and verify
     await navigateBack(); // Back to workspace
     await navigateIntoFolder(imagesFolder);
-    expect(await fileList.isItemVisible(fileToMove)).toBe(true);
+    await expectItemPresent(fileToMove);
   });
 
   test('5.3 Move file via drag-drop to breadcrumb', async () => {
@@ -1038,7 +1048,7 @@ test.describe.serial('Full Workflow', () => {
 
     // Get an image file to move
     const fileToMove = imageFiles[0].name;
-    expect(await fileList.isItemVisible(fileToMove)).toBe(true);
+    await expectItemPresent(fileToMove);
 
     // Drag to workspace breadcrumb
     const sourceItem = fileList.getItem(fileToMove);
@@ -1048,11 +1058,11 @@ test.describe.serial('Full Workflow', () => {
     await page.waitForTimeout(1000);
 
     // File should be gone from images
-    expect(await fileList.isItemVisible(fileToMove)).toBe(false);
+    await expectItemGone(fileToMove);
 
     // Navigate to workspace and verify file is there
     await navigateBack(); // Go up to workspace
-    expect(await fileList.isItemVisible(fileToMove)).toBe(true);
+    await expectItemPresent(fileToMove);
   });
 
   test('5.4 Navigate via breadcrumb click', async () => {
@@ -1072,7 +1082,7 @@ test.describe.serial('Full Workflow', () => {
     await fileList.waitForItemToAppear(projectsFolder, { timeout: 15000 });
 
     // Verify we're at workspace - should see projects folder
-    expect(await fileList.isItemVisible(projectsFolder)).toBe(true);
+    await expectItemPresent(projectsFolder);
   });
 
   // ============================================
@@ -1084,7 +1094,7 @@ test.describe.serial('Full Workflow', () => {
     await navigateToRoot();
 
     // Verify original file exists
-    expect(await fileList.isItemVisible(editableFileName)).toBe(true);
+    await expectItemPresent(editableFileName);
 
     // Download the file first to verify it's downloadable
     const downloadPromise = page.waitForEvent('download');
@@ -1099,13 +1109,13 @@ test.describe.serial('Full Workflow', () => {
     await deleteItem(editableFileName);
 
     // Verify file is gone
-    expect(await fileList.isItemVisible(editableFileName)).toBe(false);
+    await expectItemGone(editableFileName);
 
     // Upload new version with same name but different content
     await uploadFile(editableFileName, editableFileUpdatedContent);
 
     // Verify new file exists
-    expect(await fileList.isItemVisible(editableFileName)).toBe(true);
+    await expectItemPresent(editableFileName);
 
     // Download again to verify it's the new content (by checking download works)
     const downloadPromise2 = page.waitForEvent('download');
@@ -1127,7 +1137,7 @@ test.describe.serial('Full Workflow', () => {
     // We're at root from 5.1
 
     // Right-click the text file — "Edit" should be in context menu
-    expect(await fileList.isItemVisible(editableFileName)).toBe(true);
+    await expectItemPresent(editableFileName);
     await fileList.rightClickItem(editableFileName);
     await contextMenu.waitForOpen();
 
@@ -1136,7 +1146,7 @@ test.describe.serial('Full Workflow', () => {
     await contextMenu.closeWithEscape();
 
     // Right-click a folder — "Edit" should NOT be in context menu
-    expect(await fileList.isItemVisible(workspaceFolder)).toBe(true);
+    await expectItemPresent(workspaceFolder);
     await fileList.rightClickItem(workspaceFolder);
     await contextMenu.waitForOpen();
 
@@ -1219,7 +1229,7 @@ test.describe.serial('Full Workflow', () => {
     await textEditorDialog.waitForClose({ timeout: 30000 });
 
     // File should still be visible in the list
-    expect(await fileList.isItemVisible(editableFileName)).toBe(true);
+    await expectItemPresent(editableFileName);
   });
 
   test('6.5.4 Verify CID changed after edit (re-encryption confirmed)', async () => {
@@ -1393,7 +1403,7 @@ test.describe.serial('Full Workflow', () => {
     const fileToRename = rootFiles[1].name;
     const newFileName = `renamed-${timestamp}.txt`;
 
-    expect(await fileList.isItemVisible(fileToRename)).toBe(true);
+    await expectItemPresent(fileToRename);
 
     await fileList.rightClickItem(fileToRename);
     await contextMenu.waitForOpen();
@@ -1402,8 +1412,8 @@ test.describe.serial('Full Workflow', () => {
     await renameDialog.rename(newFileName);
 
     await fileList.waitForItemToAppear(newFileName, { timeout: 15000 });
-    expect(await fileList.isItemVisible(fileToRename)).toBe(false);
-    expect(await fileList.isItemVisible(newFileName)).toBe(true);
+    await expectItemGone(fileToRename);
+    await expectItemPresent(newFileName);
 
     // Update the array for cleanup
     rootFiles[1].name = newFileName;
@@ -1416,7 +1426,7 @@ test.describe.serial('Full Workflow', () => {
     const folderToRename = imagesFolder;
     const newFolderName = `media-${timestamp}`;
 
-    expect(await fileList.isItemVisible(folderToRename)).toBe(true);
+    await expectItemPresent(folderToRename);
 
     await fileList.rightClickItem(folderToRename);
     await contextMenu.waitForOpen();
@@ -1425,8 +1435,8 @@ test.describe.serial('Full Workflow', () => {
     await renameDialog.rename(newFolderName);
 
     await fileList.waitForItemToAppear(newFolderName, { timeout: 15000 });
-    expect(await fileList.isItemVisible(folderToRename)).toBe(false);
-    expect(await fileList.isItemVisible(newFolderName)).toBe(true);
+    await expectItemGone(folderToRename);
+    await expectItemPresent(newFolderName);
   });
 
   // ============================================
@@ -1441,7 +1451,7 @@ test.describe.serial('Full Workflow', () => {
     await deleteItem(workspaceFolder);
 
     // Verify folder is gone
-    expect(await fileList.isItemVisible(workspaceFolder)).toBe(false);
+    await expectItemGone(workspaceFolder);
   });
 
   test('8.2 Delete remaining root files', async () => {

--- a/tests/web-e2e/tests/full-workflow.spec.ts
+++ b/tests/web-e2e/tests/full-workflow.spec.ts
@@ -973,11 +973,15 @@ test.describe.serial('Full Workflow', () => {
     await moveDialog.clickMove();
     await moveDialog.waitForClose({ timeout: 15000 });
 
-    // Verify file is no longer at root
+    // Verify file is no longer at root. Wait for the post-move refresh to
+    // settle first — under parallel CI load the instant visibility check can
+    // race the move's IPNS publish -> refresh round-trip.
+    await fileList.waitForItemToDisappear(fileToMove);
     expect(await fileList.isItemVisible(fileToMove)).toBe(false);
 
     // Navigate to workspace and verify file is there
     await navigateIntoFolder(workspaceFolder);
+    await fileList.waitForItemToAppear(fileToMove);
     expect(await fileList.isItemVisible(fileToMove)).toBe(true);
   });
 

--- a/tests/web-e2e/tests/full-workflow.spec.ts
+++ b/tests/web-e2e/tests/full-workflow.spec.ts
@@ -61,12 +61,12 @@ test.describe.serial('Full Workflow', () => {
   // IPNS publish -> refresh round-trip, so an instant isItemVisible() check can
   // race the mutation it is verifying. The waiters no-op when the state is
   // already correct, so these are safe drop-in replacements everywhere.
-  const expectItemGone = async (name: string): Promise<void> => {
-    await fileList.waitForItemToDisappear(name);
+  const expectItemGone = async (name: string, options?: { timeout?: number }): Promise<void> => {
+    await fileList.waitForItemToDisappear(name, options);
     expect(await fileList.isItemVisible(name)).toBe(false);
   };
-  const expectItemPresent = async (name: string): Promise<void> => {
-    await fileList.waitForItemToAppear(name);
+  const expectItemPresent = async (name: string, options?: { timeout?: number }): Promise<void> => {
+    await fileList.waitForItemToAppear(name, options);
     expect(await fileList.isItemVisible(name)).toBe(true);
   };
 
@@ -670,8 +670,7 @@ test.describe.serial('Full Workflow', () => {
     await navigateIntoFolder(imagesFolder);
 
     // File should still be there
-    await fileList.waitForItemToAppear(postReloadFile.name, { timeout: 30000 });
-    await expectItemPresent(postReloadFile.name);
+    await expectItemPresent(postReloadFile.name, { timeout: 30000 });
 
     // Navigate back to root for Phase 4
     await navigateToRoot();

--- a/tests/web-e2e/tests/recovery.spec.ts
+++ b/tests/web-e2e/tests/recovery.spec.ts
@@ -65,7 +65,14 @@ test.describe('Vault Recovery Tool', () => {
     }
   });
 
-  test('recovers vault files via IPFS-direct v2 blob path', async ({ page }) => {
+  // FIXME(recovery-v3): the standalone recovery tool (apps/web/public/recovery.html)
+  // was never ported to the v3 two-key vault blob + node/v3 sealed codec introduced
+  // in #578. It still hard-checks `blob[0] === 0x02` (recovery.html:394,1160) and
+  // parses the pre-#578 `{iv,data}` folder envelope, so it halts with "not v2 format"
+  // on any current-format vault. This is a real recoverability gap (the shipped
+  // disaster-recovery tool cannot recover a current vault), not a test artifact —
+  // tracked separately for a product fix. Un-fixme once recovery.html speaks v3.
+  test.fixme('recovers vault files via IPFS-direct v2 blob path', async ({ page }) => {
     test.setTimeout(RECOVERY_TIMEOUT_MS);
     // Navigate to recovery tool
     await page.goto(`${WEB_URL}/recovery.html`);

--- a/tests/web-e2e/tests/rotation-durability.spec.ts
+++ b/tests/web-e2e/tests/rotation-durability.spec.ts
@@ -29,15 +29,16 @@ import { RenameDialogPage } from '../page-objects/dialogs/rename-dialog.page';
  * -> `enforceResolved`, gated exactly as any real user's rename action would
  * be -- no direct `page.evaluate` + dynamic-import invocation of
  * `resolveIpnsRecord`/`enforceResolved` is needed to trigger the gate any
- * more. `page.evaluate` is still used below, but ONLY for two narrowly-scoped,
- * non-mechanism-invoking purposes: (a) reading the real IndexedDB high-water
- * floor for assertions, and (b) reading `vaultStore.rootIpnsName` after a
- * real login to identify the account's own root IPNS name for the mock-relay
- * HTTP calls below -- neither reads/writes app rotation state, both are
- * read-only observation of state the UI mutations below already produced.
+ * more. `page.evaluate` is still used below for three narrowly-scoped
+ * purposes: (a) reading the real IndexedDB high-water floor for assertions,
+ * (b) reading `vaultStore.rootIpnsName` after a real login to identify the
+ * account's own root IPNS name, and (c) writing a durable seq high-water floor
+ * directly into IndexedDB to STAGE the ROT-07 anti-rollback condition. (a)/(b)
+ * are read-only observation; only (c) writes app rotation state -- it seeds the
+ * exact durable "this device already saw a higher sequence" memory the SC#4
+ * gate consumes, because the relay-replay path cannot reach the client through
+ * the real resolve (see the SC#4 test's own comment for the full rationale).
  */
-
-const MOCK_ROUTING_URL = process.env.DELEGATED_ROUTING_URL?.trim() || 'http://localhost:3001';
 
 /**
  * Reads the durable generation/seq high-water floors for `nodeId` directly
@@ -87,6 +88,46 @@ async function readDurableFloors(
       );
     },
     { nodeId }
+  );
+}
+
+/**
+ * Writes a durable seq high-water floor for `nodeId` directly into the real
+ * IndexedDB store `rotation-state.service.ts` owns. Used to STAGE the ROT-07
+ * anti-rollback condition test-only (a device that durably observed a higher
+ * sequence than the server now serves) -- see the SC#4 test comment for why
+ * the relay-replay path cannot reproduce this against the live API resolve.
+ *
+ * The stores are created WITHOUT a keyPath (out-of-line keys), matching
+ * `rotation-state.service.ts` -- so `put(value, key)` passes the value first
+ * and the nodeId key second.
+ */
+async function writeDurableSeqFloor(page: Page, nodeId: string, value: number): Promise<void> {
+  await page.evaluate(
+    ({ nodeId, value }) => {
+      return new Promise<void>((resolve, reject) => {
+        // No version argument: open at whatever version the service created so
+        // this write never races a future DB_VERSION bump.
+        const req = indexedDB.open('cipherbox-rotation-state');
+        req.onerror = () => reject(req.error);
+        req.onsuccess = () => {
+          const db = req.result;
+          if (!db.objectStoreNames.contains('seq-high-water')) {
+            reject(new Error('seq-high-water store missing -- durable floor not yet seeded'));
+            return;
+          }
+          try {
+            const tx = db.transaction('seq-high-water', 'readwrite');
+            tx.objectStore('seq-high-water').put(value, nodeId);
+            tx.oncomplete = () => resolve();
+            tx.onerror = () => reject(tx.error);
+          } catch (err) {
+            reject(err);
+          }
+        };
+      });
+    },
+    { nodeId, value }
   );
 }
 
@@ -192,40 +233,35 @@ test.describe
     expect(floors.seq).toBe(seededSeq);
   });
 
-  // 68.1-28 diagnostic note: this test currently FAILS (confirmed via a live
-  // repro) not because of a toast-classification gap, but because the replay
-  // below never reaches the client at all. `apps/api`'s IPNS resolve prefers
-  // its DB-cached record whenever it is at or ahead of the network record
-  // (ipns.service.ts::resolveRecord), and the DB row for rootIpnsName is
-  // written synchronously by THIS SAME test's own "bump" mutation below --
-  // so by the time the replay is PUT to the mock relay, the DB row is
-  // already strictly ahead of the replayed bytes and always wins the
-  // resolve. The rename mutation below therefore SUCCEEDS silently (renames
-  // to "-rejected") instead of throwing anything for useMutationFailureUx to
-  // classify. See 68.1-28-SUMMARY.md for the full trace; per that plan's
-  // explicit scope boundary this was surfaced, not fixed here -- assertions
-  // below are left intact ("never weaken an assertion") pending a dedicated
-  // follow-up plan.
-  test('rejects a relay-replayed stale record fail-closed via a genuine UI mutation, with the D-05 toast, and does not apply it (SC#4)', async ({
-    request,
-  }) => {
-    test.setTimeout(60_000);
-    const encodedName = encodeURIComponent(rootIpnsName);
-    const recordUrl = `${MOCK_ROUTING_URL}/routing/v1/ipns/${encodedName}`;
+  // SC#4 mechanism note (supersedes the 68.1-28 relay-replay approach): a
+  // colluding/lagging RELAY replaying old bytes CANNOT reach the client through
+  // the real resolve path. `apps/api`'s ipns.service.ts::resolveRecord prefers
+  // its DB-cached record whenever `dbSeq >= networkSeq` (ipns.service.ts:685),
+  // and the DB row for rootIpnsName is written synchronously by every publish
+  // -- so any bytes PUT back to the mock relay are shadowed by the fresher DB
+  // row and never served. Forging a HIGHER-sequence signed record (to win the
+  // network-ahead branch) is impossible without the root IPNS private key
+  // (client-held), and there is no HTTP surface to lower or clear the API DB
+  // row. Those are product-tier facts, not test-harness gaps, and the API's
+  // DB-cache-wins is itself an anti-rollback defense we must NOT weaken.
+  //
+  // The client-side durable floor (ROT-07) is the defense-in-depth layer this
+  // spec proves: even if the WHOLE server (relay + API) regressed to an older
+  // sequence, a device that has DURABLY recorded a higher sequence rejects the
+  // regressed resolve fail-closed. We reproduce exactly that condition
+  // test-only by raising this device's durable seq high-water floor above the
+  // server's current sequence (the same persisted memory :152/:180 prove is
+  // durable), then driving a real UI rename whose live reconcileFolderSequence
+  // resolves the (now below-floor) server record and is rejected by the live
+  // enforceResolved gate -- surfacing the D-05 toast and NOT applying the
+  // rename. No product code is touched.
+  test('rejects a below-durable-floor server record fail-closed via a genuine UI mutation, with the D-05 toast, and does not apply it (SC#4)', async () => {
+    test.setTimeout(240_000);
 
-    // 1. Capture the CURRENT record bytes directly from the delegated-routing
-    //    mock -- this is the "old" record a colluding/lagging relay (T-68-101)
-    //    could later replay once a newer sequence has been published.
-    const staleResponse = await request.get(recordUrl, {
-      headers: { Accept: 'application/vnd.ipfs.ipns-record' },
-    });
-    expect(staleResponse.ok()).toBe(true);
-    const staleBytes = await staleResponse.body();
-
-    // 2. Perform a REAL bump mutation (create + rename another throwaway
-    //    folder) so root republishes with a HIGHER sequence, and the live
+    // 1. Perform a REAL bump mutation (create + rename a throwaway folder) so
+    //    root republishes with a HIGHER sequence and the live
     //    reconcileFolderSequence -> enforceResolved gate advances the durable
-    //    floor past the bytes captured above -- entirely via real UI actions.
+    //    seq floor -- entirely via real UI actions.
     const folderName = `durability-bump-${runId}`;
     await page.locator('.file-browser-new-folder-button').click();
     await createFolderDialog.waitForOpen();
@@ -244,24 +280,26 @@ test.describe
     bumpedSeq = floorsAfterBump.seq as number;
     expect(bumpedSeq).toBeGreaterThan(seededSeq);
 
-    // 3. Replay the captured stale bytes back into the mock relay -- this is
-    //    the T-68-101 colluding/lagging relay scenario: a lower-sequence
-    //    record served after a higher sequence has already been observed.
-    const putResponse = await request.put(recordUrl, {
-      data: staleBytes,
-      headers: { 'Content-Type': 'application/vnd.ipfs.ipns-record' },
-    });
-    expect(putResponse.ok()).toBe(true);
+    // 2. STAGE the T-68-101 anti-rollback condition test-only: raise this
+    //    device's durable seq high-water floor ABOVE the server's current
+    //    sequence. This is the persisted "already saw a higher sequence"
+    //    memory a real device accumulates over its lifetime; here we set it
+    //    directly (see this test's mechanism note above for why a relay replay
+    //    cannot). The next real resolve of the server's (lower) record must be
+    //    rejected fail-closed by the live enforceResolved gate.
+    const injectedFloor = bumpedSeq + 1000;
+    await writeDurableSeqFloor(page, rootIpnsName, injectedFloor);
+    const floorsAfterInject = await readDurableFloors(page, rootIpnsName);
+    expect(floorsAfterInject.seq).toBe(injectedFloor);
 
-    // 4. Perform a REAL revocation-triggering mutation on a root child --
-    //    renaming the same item again. CipherBoxClient.renameItem calls
-    //    reconcileFolderSequence(rootIpnsName, ...), which resolves the
-    //    NOW-STALE record from the relay above and gates it through
-    //    enforceResolved (live, Gap 1 closure) -- the durable floor rejects
-    //    it fail-closed. The dialog does NOT close on failure
-    //    (handleRenameConfirm only calls closeRenameDialog() on success), so
-    //    we drive the form directly rather than using the `.rename()`
-    //    convenience helper (which awaits a close that will not happen).
+    // 3. Perform a REAL rename mutation on a root child. CipherBoxClient.renameItem
+    //    calls reconcileFolderSequence(rootIpnsName, ...), which resolves the
+    //    server's CURRENT (now below-floor) record and gates it through the live
+    //    enforceResolved -- the durable floor rejects it fail-closed with a
+    //    SequenceRegressionError. The dialog does NOT close on failure
+    //    (handleRenameConfirm only calls closeRenameDialog() on success), so we
+    //    drive the form directly rather than using the `.rename()` convenience
+    //    helper (which awaits a close that will not happen).
     await fileList.rightClickItem(renamedName);
     await contextMenu.waitForOpen();
     await contextMenu.clickRename();
@@ -269,25 +307,25 @@ test.describe
     await renameDialog.clearAndEnterName(`${renamedName}-rejected`);
     await renameDialog.clickSave();
 
-    // 5. D-05: the fail-closed toast is visible with the exact UI-SPEC copy,
-    //    surfaced by the SAME runWithFailureUx classifier real folder
-    //    mutations use (useFolderMutations.ts).
+    // 4. D-05: the fail-closed toast is visible with the exact UI-SPEC copy,
+    //    surfaced by the SAME runWithFailureUx classifier real folder mutations
+    //    use (useMutationFailureUx.ts -> dispatchRegressionRejected).
     await expect(
       page.locator('[role="alert"]', { hasText: 'Stale data from server rejected.' })
     ).toBeVisible({ timeout: 10000 });
 
-    // The rename dialog stays open (mutation threw) -- close it so it does
-    // not interfere with subsequent assertions or afterAll cleanup.
+    // The rename dialog stays open (mutation threw) -- close it so it does not
+    // interfere with subsequent assertions or afterAll cleanup.
     await renameDialog.clickCancel();
 
-    // 6. "Not applied": re-read the durable seq floor directly from real
-    //    IndexedDB -- it MUST still be the bumped value, never the replayed
-    //    stale sequence (the regression is rejected, not silently accepted).
+    // 5. "Not applied": re-read the durable seq floor directly from real
+    //    IndexedDB -- a rejected resolve never bumps the floor, so it MUST still
+    //    be the injected value (the regression is rejected, not accepted).
     const floorAfterRejection = await readDurableFloors(page, rootIpnsName);
-    expect(floorAfterRejection.seq).toBe(bumpedSeq);
+    expect(floorAfterRejection.seq).toBe(injectedFloor);
 
     // The item's display name must also be unchanged (the rename itself was
-    // rejected, not silently applied against the stale record).
+    // rejected, not silently applied).
     expect(await fileList.isItemVisible(renamedName)).toBe(true);
     expect(await fileList.isItemVisible(`${renamedName}-rejected`)).toBe(false);
   });

--- a/tests/web-e2e/utils/cleanup-helpers.ts
+++ b/tests/web-e2e/utils/cleanup-helpers.ts
@@ -29,12 +29,23 @@ export async function deleteAccountViaPage(page: Page): Promise<void> {
             ? window.location.origin.replace('app.', 'api.')
             : 'http://localhost:3000');
 
-      // Refresh to get access token (uses HTTP-only cookie)
-      const refreshRes = await fetch(`${apiUrl}/auth/refresh`, {
-        method: 'POST',
-        credentials: 'include',
-      });
-      if (!refreshRes.ok) return { ok: false, step: 'refresh', status: refreshRes.status };
+      // Refresh to get access token (uses HTTP-only cookie). Refresh tokens are
+      // single-use: at teardown the app page may still be polling IPNS and can
+      // fire its own /auth/refresh, rotating the cookie and making this raw call
+      // lose the race with a 401. Retry a few times -- the browser holds the
+      // freshly rotated cookie once the race settles.
+      let refreshRes: Response | undefined;
+      for (let attempt = 0; attempt < 4; attempt++) {
+        refreshRes = await fetch(`${apiUrl}/auth/refresh`, {
+          method: 'POST',
+          credentials: 'include',
+        });
+        if (refreshRes.ok) break;
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      if (!refreshRes || !refreshRes.ok) {
+        return { ok: false, step: 'refresh', status: refreshRes ? refreshRes.status : 0 };
+      }
       const { accessToken } = await refreshRes.json();
 
       const deleteRes = await fetch(`${apiUrl}/auth/account`, {


### PR DESCRIPTION
## Why

Web E2E has been effectively red on every substantive push to `main` since #578 (late June): the 213-test suite ran **fully serial** (`workers: 1`) doing real IPNS round-trips and consistently hit the **20-minute job timeout**, getting auto-cancelled with zero signal. Only trivial commits that skip the job via path-filter went green.

## What

Parallelize the suite across files and calibrate timeouts for parallel load. Each spec file already provisions its **own random wallet identity** (unique `privateKey` → unique backend `userId` → isolated context), so files never share user/IPNS/DB state — file-level parallelism is safe by construction. `fullyParallel: false` is kept so `describe.serial` ordering within a file is preserved.

**Result: cancelled@20min → green in ~14min (212 passed, 1 skipped).**

### Infra
- **3 workers** on CI (`workers: process.env.CI ? 3 : 1`), `fullyParallel: false`. 4 workers were ~2min faster but tipped correct-but-slow paths (sequential login DKG, multi-delete) over budget; 3 eases contention on every path at once.
- **`ciFloor(60s)`** on the `file-list` waiters + a **90s per-test budget** on CI — under load, correct create/upload/rename/delete → IPNS publish → refresh round-trips exceed Playwright's 30s default (the item does render, just late). Local runs are unchanged.

### Races the blind timeout had been hiding (surfaced once the suite ran to completion)
- **conflict-detection** cleanup: dropped a redundant per-item UI-delete loop that blew the 60s `afterAll` budget (account deletion cascades server-side); made `deleteAccountViaPage` tolerate the single-use refresh-token rotation race that was 401-ing and leaking accounts.
- **rotation-durability SC#4**: raised the test budget and staged the ROT-07 anti-rollback condition test-only via the durable IndexedDB seq floor, then drove a real rename rejected by the live `enforceResolved` gate (D-05 toast). **No product code touched** — deliberately did not weaken the API's DB-cache anti-rollback.
- **full-workflow** move/visibility asserts: routed all `isItemVisible` checks through wait-backed helpers so post-mutation assertions stop racing the refresh.

## Known follow-up (tracked, not fixed here)

`recovery.spec.ts:68` is **`test.fixme`'d**: the standalone `apps/web/public/recovery.html` disaster-recovery tool was never ported to the v3 two-key vault blob + `node/v3` sealed codec from #578, so it cannot recover any current-format vault. This is a **real recoverability gap** the e2e correctly caught — tracked in `.planning/todos/pending/2026-07-03-port-recovery-tool-to-v3-vault-format.md`. Un-`fixme` once ported.

## Verification

Full Web E2E green on this branch: **212 passed / 1 skipped** in 15m57s (13.8m test time), 3 workers, zero login flake across runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7XhtqxJ7pAYkZTmdmKerE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test reliability around file visibility, cleanup, and account deletion flows.
  * Adjusted recovery coverage to reflect the current vault format and avoid a known failing path.
  * Strengthened anti-rollback handling checks to better detect stale server data and preserve saved state.

* **Chores**
  * Updated CI settings to run web end-to-end tests with higher timeouts and more parallel workers.
  * Made test cleanup more resilient with retry handling for account refresh requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->