### PR TITLE
fix(fuse): resolve before per-file first-publish to avoid seq-1 equivocation

### DIFF
--- a/crates/fuse/src/content_ops.rs
+++ b/crates/fuse/src/content_ops.rs
@@ -269,7 +269,35 @@ pub async fn publish_file_node(
     )?;
     let value = format!("/ipfs/{}", node_cid);
 
-    if is_first_publish {
+    // `is_first_publish` is the caller's release-time HINT (the file inode had an
+    // empty CID; see read_ops.rs). A dropped UploadComplete (write_generation
+    // mismatch, fs.rs) or a duplicated/deferred FUSE-T release can leave that hint
+    // set AFTER the per-file record already exists at seq 1. Re-running the seq-1
+    // tail re-seals a FRESH node envelope (created_at/modified_at = now_ms changes
+    // each call → a new envelope CID), and the API anti-equivocation gate
+    // (Phase 71 D-05) rejects a same-sequence republish with a different CID (400).
+    // Confirm the record is genuinely absent before taking the first-publish
+    // (seq 1 + TEE enroll) tail; if it already resolves, the content still needs
+    // to be published, so fall through to the sequence-bumping CAS branch instead
+    // (cf. replay.rs::publish_child_node's resolve-first guard, which skips because
+    // replay has nothing new to publish — here we do).
+    let do_first_publish = if is_first_publish {
+        match crate::publish::resolve_ipns_for_replay(coordinator, api, file_ipns_name).await {
+            crate::error::IpnsResolveOutcome::NotFound => true,
+            crate::error::IpnsResolveOutcome::Found(_) => false,
+            crate::error::IpnsResolveOutcome::Error(e) => {
+                return Err(format!(
+                    "resolve before per-file first-publish for {}: {} \
+                     — refusing to risk a seq-1 equivocation",
+                    file_ipns_name, e
+                ));
+            }
+        }
+    } else {
+        false
+    };
+
+    if do_first_publish {
         // First publish: no prior record → seq 1, expected None, TEE enroll.
         let (enc_tee, epoch) = match (encrypted_ipns_for_tee, tee_key_epoch) {
             (Some(h), Some(e)) => (Some(h.to_string()), Some(e)),

--- a/crates/fuse/src/content_ops.rs
+++ b/crates/fuse/src/content_ops.rs
@@ -281,10 +281,12 @@ pub async fn publish_file_node(
     // to be published, so fall through to the sequence-bumping CAS branch instead
     // (cf. replay.rs::publish_child_node's resolve-first guard, which skips because
     // replay has nothing new to publish — here we do).
-    let do_first_publish = if is_first_publish {
+    // On the `Found` path we keep the resolved sequence so the CAS branch below can
+    // reuse it instead of resolving the same name a second time.
+    let (do_first_publish, resolved_seq) = if is_first_publish {
         match crate::publish::resolve_ipns_for_replay(coordinator, api, file_ipns_name).await {
-            crate::error::IpnsResolveOutcome::NotFound => true,
-            crate::error::IpnsResolveOutcome::Found(_) => false,
+            crate::error::IpnsResolveOutcome::NotFound => (true, None),
+            crate::error::IpnsResolveOutcome::Found(seq) => (false, Some(seq)),
             crate::error::IpnsResolveOutcome::Error(e) => {
                 return Err(format!(
                     "resolve before per-file first-publish for {}: {} \
@@ -294,7 +296,7 @@ pub async fn publish_file_node(
             }
         }
     } else {
-        false
+        (false, None)
     };
 
     if do_first_publish {
@@ -344,6 +346,7 @@ pub async fn publish_file_node(
             api,
             coordinator,
             file_ipns_name,
+            resolved_seq,
             |new_seq_for_record: u64| {
                 let value = format!("/ipfs/{}", node_cid_for_closure);
                 let record = cipherbox_core::ipns::create_ipns_record(

--- a/crates/fuse/src/metadata.rs
+++ b/crates/fuse/src/metadata.rs
@@ -33,11 +33,19 @@ use crate::publish::PublishCoordinator;
 /// The `old_cids_to_unpin` parameter carries CIDs to unpin only on success; on the
 /// retry path additional intermediate CIDs are also cleaned up. Pass `vec![]` when
 /// there is nothing to unpin.
+///
+/// `preresolved_seq`: when `Some(seq)`, the caller has already resolved the current
+/// sequence (e.g. `publish_file_node`'s pre-publish equivocation guard resolves the
+/// name via `resolve_ipns_for_replay`), so the first CAS attempt reuses it instead of
+/// issuing a second identical resolve round-trip. Pass `None` to resolve here as
+/// usual. The `Conflict` retry path always re-resolves regardless — a conflict means
+/// any pre-resolved sequence is already stale.
 #[cfg(any(feature = "fuse", feature = "winfsp"))]
 pub(crate) async fn publish_with_cas_retry<F>(
     api: &ApiClient,
     coordinator: &PublishCoordinator,
     ipns_name: &str,
+    preresolved_seq: Option<u64>,
     make_record: F,
     old_cids_to_unpin: &[String],
     journal_entry: Option<()>, // placeholder for future (queue, entry) — always None this phase
@@ -45,7 +53,10 @@ pub(crate) async fn publish_with_cas_retry<F>(
 where
     F: Fn(u64) -> Result<(String, String), String>, // make_record(new_seq) -> (record_b64, cid)
 {
-    let seq = coordinator.resolve_sequence(api, ipns_name).await?;
+    let seq = match preresolved_seq {
+        Some(s) => s,
+        None => coordinator.resolve_sequence(api, ipns_name).await?,
+    };
     let new_seq = seq
         .checked_add(1)
         .ok_or_else(|| "IPNS sequence number overflow".to_string())?;
@@ -538,6 +549,7 @@ pub fn spawn_bin_entry_publish(
                     &api,
                     &coordinator,
                     &bin_ipns_name,
+                    None, // no pre-resolved sequence on the bin-publish path
                     make_bin_record,
                     &old_cids,
                     None, // D-01a: no JournalOp::BinPublish variant; exhaustion → Err → EIO

--- a/tests/desktop-e2e/scripts/shared-scope-exit-rotation.mts
+++ b/tests/desktop-e2e/scripts/shared-scope-exit-rotation.mts
@@ -294,9 +294,9 @@ async function main(): Promise<void> {
     const wrappedForBob = await wrapKey(sharedFolderReadKey, bobPublicKey);
     const shareRes = await axiosInstance.post('/shares', {
       recipientPublicKey: '0x' + bytesToHex(bobPublicKey),
-      readDescriptorRef: bytesToHex(wrappedForBob),
+      encryptedReadKey: bytesToHex(wrappedForBob),
       rootNodeId: grantRootNodeId,
-      rootIpnsName: grantRootIpnsName,
+      shareRootIpnsName: grantRootIpnsName,
     });
     const shareId: string = shareRes.data.shareId;
     console.log(`Created share ${shareId} for ${bobEmail} rooted at ${grantRootIpnsName}`);
@@ -306,13 +306,13 @@ async function main(): Promise<void> {
     // isn't just "never worked").
     const receivedRes = await bobCtx.axiosInstance!.get('/shares/received');
     const receivedShare = (
-      receivedRes.data.shares as Array<{ shareId: string; readDescriptorRef: string }>
+      receivedRes.data.shares as Array<{ shareId: string; encryptedReadKey: string }>
     ).find((s) => s.shareId === shareId);
     if (!receivedShare) {
       throw new Error('Bob does not see the newly created share in /shares/received');
     }
     const bobFolderReadKey = await unwrapKey(
-      hexToBytes(receivedShare.readDescriptorRef),
+      hexToBytes(receivedShare.encryptedReadKey),
       bobPrivateKey
     );
     const bobCouldReadWhileActive = await canRead(grantRootIpnsName, bobFolderReadKey, bobCtx);


### PR DESCRIPTION
## Problem

The D-16 desktop-e2e leg `shared-scope-exit-rotation.mts` has been red on `main` since #599, failing identically on macOS and Linux:

```
Per-file node publish failed for ino N: API returned error 400:
IPNS publish failed: Same-sequence republish with a different CID rejected
(equivocation): stored=<cidA>, incoming=<cidB>, sequence=1
```

The 400 comes from Phase 71's anti-equivocation gate (`apps/api/src/ipns/ipns.service.ts`, #599) — which is **correct and stays intact**. The bug is on the FUSE side.

## Root cause

`publish_file_node` (`crates/fuse/src/content_ops.rs`) took its **seq-1 first-publish** tail purely on the caller's `is_first_publish` hint, which is `true` whenever the file inode's CID is empty (`read_ops.rs`). That inode CID is only filled by the `UploadComplete` drain, which is guarded by `write_generation` (`fs.rs`). A dropped completion (a superseding write bumps the generation) or a duplicated/deferred FUSE-T `release` leaves the inode CID empty, so a later release re-runs the seq-1 tail. Each run re-seals a **fresh** node envelope (`created_at`/`modified_at = now_ms` change → new envelope CID). Two seq-1 publishes with different CIDs is exactly the equivocation the Phase 71 gate rejects. The rotation window's extra mount activity makes this reliably observable in D-16.

## Fix (Rust-only)

Resolve the per-file IPNS name before the first-publish tail:

- `NotFound` → genuine first publish: seq 1 + TEE enrollment (unchanged).
- `Found` → the record already exists; the changed content still needs publishing, so fall through to the existing sequence-bumping CAS branch (`publish_with_cas_retry`) — no seq-1 equivocation.
- `Error` → fail the release closed rather than risk a seq-1 equivocation.

This mirrors the resolve-first guard already used by `replay.rs::publish_child_node` (which *skips* on `Found` because replay has nothing new to publish — here we do, so we route to CAS). `publish_file_node` is the single shared entry point for fuser (macOS/Linux) and WinFsp, so one edit fixes all three platforms. TEE enrollment stays on the genuine-first-publish path (crypto rule 7).

## Verification

- `cargo check -p cipherbox-fuse --features fuse` — clean; `rustfmt --check` on the file — clean.
- Runtime proof is this PR's desktop-e2e CI leg (the D-16 `shared-scope-exit-rotation` mount test). WinFsp is compile-checked on the Windows CI job. The full local mount e2e was not run in this session; CI desktop-e2e is the gating check.
