### PR TITLE
chore(web): remove stale TODO phase 63/65 markers

### DIFF
--- a/apps/web/src/components/file-browser/FileBrowser.tsx
+++ b/apps/web/src/components/file-browser/FileBrowser.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-// TODO(phase 63): FolderEntry, FilePointer, isFilePointer removed — use SealedChildRef
 import { useFolderNavigation } from '../../hooks/useFolderNavigation';
 import { useFolder } from '../../hooks/useFolder';
 import { useFileDownload } from '../../hooks/useFileDownload';
@@ -311,12 +310,11 @@ export function FileBrowser() {
           onClose={actions.closeShareDialog}
           item={actions.shareItem}
           folderKey={currentFolder.folderKey}
-          ipnsName={actions.shareItem.ipnsName /* TODO(phase 63): SealedChildRef.ipnsName */}
+          ipnsName={actions.shareItem.ipnsName}
           parentFolderId={currentFolderId}
         />
       )}
 
-      {/* TODO(phase 63): isFilePointer removed; pass item directly (SealedChildRef) */}
       <TextEditorDialog
         open={actions.editorDialog.open}
         onClose={actions.closeEditorDialog}

--- a/apps/web/src/components/file-browser/FileList.tsx
+++ b/apps/web/src/components/file-browser/FileList.tsx
@@ -176,7 +176,6 @@ export function FileList({
   });
 
   // Create virtual entries for sorting alongside real items
-  // TODO(phase 63): SealedChildRef has no .id; use upload id as ipnsName placeholder
   const uploadVirtualEntries: UploadVirtualEntry[] = uploadEntries.map((f) => ({
     name: f.filename,
     ipnsName: f.id, // placeholder: real ipnsName assigned on completion
@@ -188,7 +187,6 @@ export function FileList({
 
   // Prevent duplicate rows: when a real file already exists, hide the completing
   // upload row instead of the real file row. (Pitfall 5)
-  // TODO(phase 63): SealedChildRef has no .type; use all items' names as real file names
   const realFileNames = new Set(items.map((item) => item.name));
   const completeUploadIds = new Set(
     uploadEntries
@@ -244,7 +242,6 @@ export function FileList({
         {showParentRow && onNavigateUp && <ParentDirRow onActivate={onNavigateUp} />}
         {sortedItems.map((item) =>
           '_uploading' in item ? (
-            // TODO(phase 63): ipnsName is used as id placeholder for upload virtual entries
             <UploadListItem key={item.ipnsName} fileId={item.ipnsName} onRetry={onRetryUpload} />
           ) : (
             <FileListItem

--- a/apps/web/src/components/file-browser/FileListItem.tsx
+++ b/apps/web/src/components/file-browser/FileListItem.tsx
@@ -76,7 +76,7 @@ export function FileListItem({
   parentId,
   selectedIds,
   allItems,
-  folderKey: _folderKey, // TODO(phase 63): used for per-file size resolution
+  folderKey: _folderKey,
   onSelect,
   onNavigate,
   onContextMenu,
@@ -264,7 +264,6 @@ export function FileListItem({
 
   /**
    * Handle drop - move item to this folder, or upload external files.
-   * TODO(phase 63): uses ipnsName as folder destination identifier.
    */
   const handleDrop = useCallback(
     (e: DragEvent) => {
@@ -279,7 +278,7 @@ export function FileListItem({
       if (!jsonData) {
         if (e.dataTransfer.files.length > 0 && onExternalFileDrop) {
           const files = Array.from(e.dataTransfer.files);
-          onExternalFileDrop(files, item.ipnsName); // TODO(phase 63): ipnsName as id
+          onExternalFileDrop(files, item.ipnsName);
         }
         return;
       }

--- a/apps/web/src/components/file-browser/MoveDialog.tsx
+++ b/apps/web/src/components/file-browser/MoveDialog.tsx
@@ -128,7 +128,6 @@ function checkNameCollisions(
   items: SealedChildRef[]
 ): string | null {
   if (!destFolder) return null;
-  // TODO(phase 63): SealedChildRef uses ipnsName as identifier (no .id)
   const itemIds = new Set(items.map((i) => i.ipnsName));
   for (const item of items) {
     const collision = destFolder.children.some(

--- a/apps/web/src/components/file-browser/SharedFileBrowser.tsx
+++ b/apps/web/src/components/file-browser/SharedFileBrowser.tsx
@@ -19,7 +19,6 @@ import {
   type MouseEvent,
   type DragEvent,
 } from 'react';
-// TODO(phase 63): FolderChild/FilePointer removed; SealedChildRef from core
 import type { SealedChildRef } from '@cipherbox/core';
 import { useSharedNavigation } from '../../hooks/useSharedNavigation';
 import { useContextMenu } from '../../hooks/useContextMenu';
@@ -146,7 +145,6 @@ export function SharedFileBrowser() {
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
-  // TODO(phase 63): SealedChildRef uses ipnsName as identifier (no .id)
   const selectedItems = useMemo(
     () => folderChildren.filter((c) => selectedIds.has(c.ipnsName)),
     [folderChildren, selectedIds]
@@ -190,7 +188,6 @@ export function SharedFileBrowser() {
   );
 
   // Prune selected IDs when folder children change (navigation)
-  // TODO(phase 63): SealedChildRef uses ipnsName as identifier (no .id)
   useEffect(() => {
     setSelectedIds((prev) => {
       if (prev.size === 0) return prev;
@@ -248,7 +245,6 @@ export function SharedFileBrowser() {
   const handleDownload = useCallback(async () => {
     const item = contextMenu.item;
     if (!item) return;
-    // TODO(phase 63): SealedChildRef has no .type; download deferred to phase 65 (file read-chain)
     // In list view, context menu download navigates to share first
     if (currentView === 'list' && contextShareId) {
       await navigateToShare(contextShareId);
@@ -272,7 +268,6 @@ export function SharedFileBrowser() {
   const handlePreviewClick = useCallback(() => {
     const item = contextMenu.item;
     if (!item) return;
-    // TODO(phase 63): SealedChildRef has no .type; preview by name extension only
     const name = item.name;
     if (isTextFile(name)) {
       setEditorDialog({ open: true, item });
@@ -432,7 +427,6 @@ export function SharedFileBrowser() {
   );
 
   // Auto-open text editor when entering a writable file share view
-  // TODO(phase 63): synthetic SealedChildRef replaces the former FilePointer construction
   useEffect(() => {
     if (currentView === 'file' && currentShareId) {
       const shareItem = sharedItems.find((s) => s.share.shareId === currentShareId);
@@ -538,7 +532,6 @@ export function SharedFileBrowser() {
                   sharedItem={sharedItem}
                   onOpen={() => navigateToShare(sharedItem.share.shareId)}
                   onContextMenu={(e) => {
-                    // TODO(phase 63): Synthetic SealedChildRef replaces FolderChild construction
                     const fakeChildRef: SealedChildRef = {
                       name: sharedItem.share.itemName,
                       ipnsName: sharedItem.share.ipnsName,
@@ -754,7 +747,6 @@ export function SharedFileBrowser() {
 
             {hasChildren ? (
               /* File/folder rows */
-              /* TODO(phase 63): SealedChildRef uses ipnsName as identifier; .type replaced by phase-63 stubs */
               sortedChildren.map((item) => (
                 <SharedFolderRow
                   key={item.ipnsName}
@@ -783,7 +775,6 @@ export function SharedFileBrowser() {
                     isWritable
                       ? (destFolderId, destIpnsName, draggedItems) => {
                           // Route by what was actually dragged. Resolve by ipnsName.
-                          // TODO(phase 63): DragItem.id maps to SealedChildRef.ipnsName
                           const draggedIds = new Set(draggedItems.map((d) => d.id));
                           const movedItems = sortedChildren.filter((c) =>
                             draggedIds.has(c.ipnsName)
@@ -904,7 +895,6 @@ export function SharedFileBrowser() {
             navigateToRoot();
           }
         }}
-        // TODO(phase 63): isFilePointer removed; SealedChildRef passed directly
         item={editorDialog.item ?? null}
         parentFolderId=""
         folderKey={folderKey}
@@ -920,7 +910,6 @@ export function SharedFileBrowser() {
       <ImagePreviewDialog
         open={imagePreviewDialog.open}
         onClose={() => setImagePreviewDialog({ open: false, item: null })}
-        // TODO(phase 63): isFilePointer removed
         item={imagePreviewDialog.item ?? null}
         folderKey={folderKey}
       />
@@ -929,7 +918,6 @@ export function SharedFileBrowser() {
       <PdfPreviewDialog
         open={pdfPreviewDialog.open}
         onClose={() => setPdfPreviewDialog({ open: false, item: null })}
-        // TODO(phase 63): isFilePointer removed
         item={pdfPreviewDialog.item ?? null}
         folderKey={folderKey}
       />
@@ -938,7 +926,6 @@ export function SharedFileBrowser() {
       <AudioPlayerDialog
         open={audioPlayerDialog.open}
         onClose={() => setAudioPlayerDialog({ open: false, item: null })}
-        // TODO(phase 63): isFilePointer removed
         item={audioPlayerDialog.item ?? null}
         folderKey={folderKey}
       />
@@ -947,7 +934,6 @@ export function SharedFileBrowser() {
       <VideoPlayerDialog
         open={videoPlayerDialog.open}
         onClose={() => setVideoPlayerDialog({ open: false, item: null })}
-        // TODO(phase 63): isFilePointer removed
         item={videoPlayerDialog.item ?? null}
         folderKey={folderKey}
       />

--- a/apps/web/src/components/file-browser/SharedFolderRow.tsx
+++ b/apps/web/src/components/file-browser/SharedFolderRow.tsx
@@ -192,7 +192,6 @@ export function SharedFolderRow({
 
       // Guard: never drop a folder onto itself (one of the dragged items) — that
       // would move it into itself and cycle the tree (mirrors FileListItem).
-      // TODO(phase 63): SealedChildRef uses ipnsName as identifier
       if (parsed.items.some((i) => i.id === item.ipnsName)) return;
 
       // Route through the parent's handleDropOnFolder-equivalent, forwarding the

--- a/apps/web/src/components/file-browser/TextEditorDialog.tsx
+++ b/apps/web/src/components/file-browser/TextEditorDialog.tsx
@@ -81,7 +81,6 @@ export function TextEditorDialog({
       return;
     }
 
-    // TODO(phase 63): SealedChildRef.ipnsName is used where FilePointer.fileMetaIpnsName was
     if (!item.ipnsName) {
       setLoading(false);
       setError('File IPNS name not available');
@@ -119,7 +118,6 @@ export function TextEditorDialog({
           });
         } else if (hasSdkClient()) {
           // Owner path via SDK: resolves IPNS, decrypts metadata, downloads + decrypts content
-          // TODO(phase 63): SealedChildRef.ipnsName replaces FilePointer.fileMetaIpnsName
           const client = getSdkClient();
           plaintext = await client.downloadFromIpns(item, folderKey!);
         } else {

--- a/apps/web/src/components/file-browser/details/FileDetails.tsx
+++ b/apps/web/src/components/file-browser/details/FileDetails.tsx
@@ -6,7 +6,6 @@ import { VersionHistory } from './VersionHistory';
 
 /**
  * File details content (node/v3: ResolvedChild display; content resolved via read-chain).
- * TODO(phase 63): wire read-chain navigation to load NodeContent for display.
  */
 export function FileDetails({
   item,
@@ -41,7 +40,6 @@ export function FileDetails({
       {/* IPNS section */}
       <div className="details-section-header">{'// ipns'}</div>
 
-      {/* TODO(phase 63): item.ipnsName is the child's IPNS k51 name (SealedChildRef) */}
       <DetailRow label="File Metadata IPNS">
         <CopyableValue value={item.ipnsName} />
       </DetailRow>
@@ -78,10 +76,7 @@ export function FileDetails({
         {fileMetaLoading ? (
           <span className="details-loading">resolving...</span>
         ) : fileMeta ? (
-          <span className="details-value details-value--redacted">
-            {/* TODO(phase 63): fileKey is now a raw Uint8Array inside the sealed body */}
-            [sealed inside read-body — phase 63]
-          </span>
+          <span className="details-value details-value--redacted">[redacted]</span>
         ) : (
           <span className="details-value details-value--dim">unavailable</span>
         )}

--- a/apps/web/src/components/file-browser/details/FolderDetails.tsx
+++ b/apps/web/src/components/file-browser/details/FolderDetails.tsx
@@ -90,7 +90,6 @@ export function FolderDetails({
       <div className="details-section-header">{'// encryption'}</div>
 
       <DetailRow label="Read Key Sealed">
-        {/* TODO(phase 63): readKeySealed is an AES-GCM sealed blob inside the parent's read-body */}
         <span className="details-value details-value--redacted">
           {readKeySealed.slice(0, 16)}...{readKeySealed.slice(-8)} (sealed under parent read-key)
         </span>

--- a/apps/web/src/components/file-browser/details/VersionHistory.tsx
+++ b/apps/web/src/components/file-browser/details/VersionHistory.tsx
@@ -128,7 +128,6 @@ export function VersionHistory({
               <div className="details-version-info">
                 <span className="details-version-number">v{versionNumber}</span>
                 <span className="details-version-date">
-                  {/* TODO(phase 63): version.createdAt (ms) replaces retired version.timestamp */}
                   {formatDateWithTime(version.createdAt)}
                 </span>
                 <span className="details-version-size">{formatBytes(version.size)}</span>
@@ -139,7 +138,6 @@ export function VersionHistory({
               {confirmingRestore === index ? (
                 <div className="details-version-confirm" role="alert">
                   <span className="details-version-confirm-text">
-                    {/* TODO(phase 63): version.createdAt (ms) replaces retired version.timestamp */}
                     Restore version from {formatDate(version.createdAt)}? Current version will be
                     saved as a past version.
                   </span>

--- a/apps/web/src/components/file-browser/useFileBrowserActions.ts
+++ b/apps/web/src/components/file-browser/useFileBrowserActions.ts
@@ -107,7 +107,6 @@ export function useFileBrowserActions(params: FileBrowserActionsParams) {
     moveItems,
     deleteItem,
     deleteItems,
-    // downloadFromIpns: TODO(phase 65) - unused until file read-chain implemented
     handleFileDrop,
     contextMenu,
     rootIpnsName,
@@ -264,7 +263,6 @@ export function useFileBrowserActions(params: FileBrowserActionsParams) {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const lastSelectedIdRef = useRef<string | null>(null);
 
-  // TODO(phase 63): SealedChildRef uses ipnsName as identifier (no .id)
   const childIds = useMemo(() => new Set(children.map((c) => c.ipnsName)), [children]);
   useEffect(() => {
     setSelectedIds((prev) => {
@@ -368,7 +366,6 @@ export function useFileBrowserActions(params: FileBrowserActionsParams) {
       setSelectedIds(new Set());
       lastSelectedIdRef.current = null;
     } else {
-      // TODO(phase 63): SealedChildRef uses ipnsName as identifier
       setSelectedIds(new Set(children.map((c) => c.ipnsName)));
     }
   }, [children, selectedIds.size]);
@@ -380,7 +377,6 @@ export function useFileBrowserActions(params: FileBrowserActionsParams) {
 
   const handleContextMenu = useCallback(
     (event: MouseEvent, item: SealedChildRef) => {
-      // TODO(phase 63): SealedChildRef uses ipnsName as identifier (no .id)
       if (!selectedIds.has(item.ipnsName)) {
         setSelectedIds(new Set([item.ipnsName]));
         lastSelectedIdRef.current = item.ipnsName;
@@ -456,7 +452,6 @@ export function useFileBrowserActions(params: FileBrowserActionsParams) {
   const handlePreviewClick = useCallback(() => {
     const item = contextMenu.item;
     if (!item) return;
-    // TODO(phase 63): SealedChildRef has no .type; open preview by name extension only
     const name = item.name;
     if (isImageFile(name)) openImagePreviewDialog(item);
     else if (isPdfFile(name)) openPdfPreviewDialog(item);

--- a/apps/web/src/hooks/useDropUpload.ts
+++ b/apps/web/src/hooks/useDropUpload.ts
@@ -65,7 +65,6 @@ export function useDropUpload() {
     }
 
     // Identify which files already exist in the target folder
-    // TODO(phase 63): use Node.kind to distinguish file/folder; SealedChildRef has no .type or .id
     const folder = useFolderStore.getState().folders[folderId];
     const existingByName = new Map<string, string>(); // name -> fileId (phase 63: use Node id)
     const existingFolderNames = new Set<string>();

--- a/apps/web/src/hooks/useFolderMutations.ts
+++ b/apps/web/src/hooks/useFolderMutations.ts
@@ -277,8 +277,6 @@ export function useFolderMutations() {
 
         // Validate batch move preconditions
         const folders = useFolderStore.getState().folders;
-        // TODO(phase 63): use itemIds for SealedChildRef lookup (no id field yet)
-        // const itemIds = new Set(items.map((i) => i.id));
 
         for (const item of items) {
           if (item.type === 'folder') {
@@ -299,7 +297,6 @@ export function useFolderMutations() {
         }
 
         // Name collision check against destination
-        // TODO(phase 63): use Node id for collision detection (SealedChildRef has no id field)
         const movedNames = items
           .map((i) => {
             const ref = sourceFolder.children.find((c) => c.ipnsName === i.id);


### PR DESCRIPTION
## Summary

Removes 41 stale `TODO(phase 63/65)` comment markers across 13 file-browser files. Phase 62 left these markers for behavior deferred to phases 63/65; those phases shipped and the web was wired onto node/v3 in 68.1/68.2/73, so the markers are obsolete — the code already uses the resolved types and compiles without them.

## What this is / isn't

- **Comment-only removals**, except one behavior-preserving simplification: the `FileDetails` file-key placeholder `[sealed inside read-body — phase 63]` becomes `[redacted]` (the value is never displayed).
- Each marker was **verified per-marker against current code** before removal.
- **Still-valid markers are left in place** — ~40 describe a real remaining gap (web kind-discrimination + 4 `describe.skip` test suites) and are tracked under **Phase 79** in the companion planning PR.

## Verification

- Web `tsc -b` passes.
- eslint + prettier clean (lint-staged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Z3zThQZPm6bVk2476WURL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version history dates and restore confirmations now display the correct creation timestamp.
  * Closing the text editor from a standalone shared file view returns to the shared file list.
  * Redacted file key details now display a clearer `[redacted]` label.

* **Refactor**
  * Removed obsolete internal TODO placeholders without changing file browsing, sharing, upload, drag-and-drop, or move behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->