### PR TITLE
feat(core): land the det-CBOR codec, error surface, and KAT manifest spine

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# Run wasm test binaries under wasmtime: `cargo test -p cipherbox-core
+# --target wasm32-wasip1` is the KAT gate's WASM leg (blueprint/testing.md).
+[target.wasm32-wasip1]
+runner = "wasmtime"

--- a/.claude/commands/crypto-privacy-review.md
+++ b/.claude/commands/crypto-privacy-review.md
@@ -26,8 +26,13 @@ Review produced code through the lens of a cryptography and security testing exp
 
 **Creates:**
 
-- `.planning/security/REVIEW-[timestamp].md` — Security review report
-- Test case suggestions (inline or as file)
+- A review report returned directly to the caller (orchestrator) — inline in
+  context, or as a temporary file under the session scratchpad when it is too
+  large to inline
+- Test case suggestions (inline)
+
+Review reports are working artifacts, never repo content: do NOT write them
+into the repository tree and do NOT commit them.
 
 </objective>
 
@@ -177,13 +182,13 @@ For each crypto operation found, generate test cases:
 
 ## Phase 5: Generate Report
 
-Create `.planning/security/` directory if needed:
+Return the report to the caller (orchestrator). Prefer presenting it directly
+in context; if it is too large to inline, write it to a temporary file under
+the session scratchpad (e.g. `<scratchpad>/security-review-[timestamp].md`)
+and reference that path. Never write the report into the repository tree
+(`.planning/` no longer exists) and never commit it.
 
-```bash
-mkdir -p .planning/security
-```
-
-Write the review report to a scratch file, e.g. `<scratchpad>/security-review-[timestamp].md`:
+Report template:
 
 ````markdown
 # Security Review Report
@@ -348,7 +353,7 @@ Display summary inline:
 
 [n] test case suggestions across [m] categories
 
-**Full report:** [path to report file]
+**Full report:** [inline above, or scratchpad path if it was too large to inline]
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
@@ -430,7 +435,7 @@ crypto.getRandomValues();
 - [ ] Each operation checked against security criteria
 - [ ] Issues categorized by severity
 - [ ] Test cases generated for each crypto operation
-- [ ] Report written to `.planning/security/`
+- [ ] Report returned to the caller (inline, or scratchpad temp file) — never written to the repo or committed
 - [ ] Summary presented to user
 - [ ] Next steps offered
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
-# v2 PR gate (blueprint/testing.md). Day-one jobs cover what exists: the
-# stub cargo workspace and the TS workspace stubs. The remaining PR-gate
-# suites (WASM KAT run, packages/client browser suite, contract suite,
-# Windows adapter tests, migration drift, e2e smoke slice) land with their
-# code and must block merges in a named job the day they land (law 1).
+# v2 PR gate (blueprint/testing.md). Jobs cover what exists: the cargo
+# workspace (incl. the core KAT manifest job, native + WASM) and the TS
+# workspace stubs. The remaining PR-gate suites (packages/client browser
+# suite, contract suite, Windows adapter tests, migration drift, e2e smoke
+# slice) land with their code and must block merges in a named job the day
+# they land (law 1).
 name: CI
 
 on:
@@ -161,6 +162,43 @@ jobs:
 
       - name: Cargo test (workspace)
         run: cargo test --workspace
+
+  core-kats:
+    name: Core KATs (native + WASM)
+    needs: [changes, lint]
+    if: |
+      !failure() && !cancelled() &&
+      needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: core-kats-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: core-kats-cargo-
+
+      - name: Add wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
+
+      - uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3
+
+      - name: KAT vectors fresh (committed generator is the only writer)
+        run: |
+          cargo run -p cipherbox-core --example kat_gen
+          git diff --exit-code -- crates/core/kat
+
+      - name: Core suite (native)
+        run: cargo test -p cipherbox-core
+
+      - name: Core suite (WASM, wasm32-wasip1 under wasmtime)
+        run: cargo test -p cipherbox-core --target wasm32-wasip1
 
   cargo-macos:
     name: Cargo Check & Test (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,7 @@ jobs:
         run: |
           cargo run -p cipherbox-core --example kat_gen
           git diff --exit-code -- crates/core/kat
+          test -z "$(git status --porcelain -- crates/core/kat)"
 
       - name: Core suite (native)
         run: cargo test -p cipherbox-core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
+              - '.cargo/config.toml'
               - '.github/workflows/ci.yml'
 
   lint:

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,8 @@
 
 # Finalized specifications - do not modify
 00-Preliminary-R&D/
+
+# KAT manifest and vector fixtures - written only by the committed generator
+# (cargo run -p cipherbox-core --example kat_gen); the CI freshness gate
+# diffs them byte-for-byte against generator output
+crates/core/kat/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,8 +3,47 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "cipherbox-core"
 version = "0.0.0"
+dependencies = [
+ "hex",
+ "proptest",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cipherbox-engine"
@@ -26,3 +65,381 @@ version = "0.0.0"
 dependencies = [
  "cipherbox-engine",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.1",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5edbec4ed188954a10c12c038215f8ce7606b2d5c973cd8dc43e8795065c5f2f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -6,3 +6,17 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 publish.workspace = true
+
+[dev-dependencies]
+hex = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# The KAT suite is the WASM residual parity surface (blueprint/core.md): the
+# same tests compile for wasm32-wasip1, where proptest's process-fork
+# machinery (rusty-fork/wait-timeout) cannot build.
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+proptest = "1"
+
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+proptest = { version = "1", default-features = false, features = ["std"] }

--- a/crates/core/examples/kat_gen.rs
+++ b/crates/core/examples/kat_gen.rs
@@ -1,0 +1,819 @@
+//! The committed KAT generator for the det-CBOR codec fixtures
+//! (blueprint/core.md "KAT regime": vectors regenerate only through committed
+//! generators, never hand-edits).
+//!
+//! Run from any cwd:
+//!
+//! ```text
+//! cargo run -p cipherbox-core --example kat_gen
+//! ```
+//!
+//! Accept and unknown-field vectors are built from [`Value`] constructors and
+//! the live encoder. Reject vectors are explicit hand-crafted byte literals —
+//! deriving them from the encoder would be vacuous, since the deterministic
+//! encoder cannot emit any of them. Every vector is asserted against the live
+//! codec before anything is written, so a generator run is itself a
+//! self-check. Output is deterministic: re-running is byte-identical.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+use cipherbox_core::codec::{
+    MAX_DEPTH, Map, Value, decode, decode_map_partial, encode, encode_map_partial,
+};
+use cipherbox_core::error::{Malformed, TrustViolation};
+use serde::Serialize;
+use serde_json::json;
+
+const PROFILE: &str = "cipherbox/v2 det-cbor";
+
+#[derive(Serialize)]
+struct AcceptVector {
+    name: String,
+    hex: String,
+    diag: String,
+    kinds: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct RejectVector {
+    name: String,
+    hex: String,
+    check: String,
+    class: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UnknownVector {
+    name: String,
+    hex: String,
+    known_keys: Vec<String>,
+    expect_unknown_count: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Manifest {
+    manifest_version: u64,
+    profile: String,
+    codecs: Codecs,
+    structure_tags: serde_json::Value,
+    kdf_edges: serde_json::Value,
+}
+
+#[derive(Serialize)]
+struct Codecs {
+    #[serde(rename = "det-cbor")]
+    det_cbor: DetCbor,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DetCbor {
+    accept: AcceptSection,
+    reject: RejectSection,
+    unknown_fields: UnknownFieldsSection,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AcceptSection {
+    file: String,
+    count: usize,
+    required_kinds: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct RejectSection {
+    file: String,
+    count: usize,
+    checks: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct UnknownFieldsSection {
+    file: String,
+    count: usize,
+}
+
+fn main() {
+    let kat_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("kat");
+    let codec_dir = kat_dir.join("vectors").join("codec");
+    fs::create_dir_all(&codec_dir).expect("create kat/vectors/codec");
+
+    let accept = build_accept_vectors();
+    let reject = build_reject_vectors();
+    let unknown = build_unknown_field_vectors();
+
+    write_pretty(&codec_dir.join("accept.json"), &accept);
+    write_pretty(&codec_dir.join("reject.json"), &reject);
+    write_pretty(&codec_dir.join("unknown_fields.json"), &unknown);
+
+    let manifest = build_manifest(&kat_dir, &accept, &reject, &unknown);
+    write_pretty(&kat_dir.join("manifest.json"), &manifest);
+
+    println!(
+        "kat_gen: wrote {} accept, {} reject, {} unknown-field vectors + manifest.json",
+        accept.len(),
+        reject.len(),
+        unknown.len(),
+    );
+}
+
+fn write_pretty<T: Serialize>(path: &Path, value: &T) {
+    let mut text = serde_json::to_string_pretty(value).expect("serialize JSON");
+    text.push('\n');
+    fs::write(path, text).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}
+
+// ---------------------------------------------------------------------------
+// Accept vectors: built from Value constructors + the live encoder.
+// ---------------------------------------------------------------------------
+
+/// `levels` nested arrays, innermost empty: `nested_arrays(1)` is `[]`.
+fn nested_arrays(levels: usize) -> Value {
+    let mut v = Value::Array(Vec::new());
+    for _ in 1..levels {
+        v = Value::Array(vec![v]);
+    }
+    v
+}
+
+fn map_of(entries: Vec<(&str, Value)>) -> Value {
+    let mut m = Map::new();
+    for (k, v) in entries {
+        m.insert(k, v);
+    }
+    Value::Map(m)
+}
+
+fn accept_specs() -> Vec<(&'static str, Value, Vec<&'static str>)> {
+    vec![
+        // Unsigned boundaries: every argument-width class edge, both sides.
+        ("uint-0", Value::Unsigned(0), vec!["uint"]),
+        ("uint-23-max-immediate", Value::Unsigned(23), vec!["uint"]),
+        ("uint-24-min-8bit", Value::Unsigned(24), vec!["uint"]),
+        ("uint-255-max-8bit", Value::Unsigned(255), vec!["uint"]),
+        ("uint-256-min-16bit", Value::Unsigned(256), vec!["uint"]),
+        ("uint-65535-max-16bit", Value::Unsigned(65535), vec!["uint"]),
+        ("uint-65536-min-32bit", Value::Unsigned(65536), vec!["uint"]),
+        (
+            "uint-4294967295-max-32bit",
+            Value::Unsigned(4_294_967_295),
+            vec!["uint"],
+        ),
+        (
+            "uint-4294967296-min-64bit",
+            Value::Unsigned(4_294_967_296),
+            vec!["uint"],
+        ),
+        ("uint-u64-max", Value::Unsigned(u64::MAX), vec!["uint"]),
+        // Negatives: Value::Negative(n) is -1 - n.
+        ("negint-minus-1", Value::Negative(0), vec!["negint"]),
+        (
+            "negint-minus-24-max-immediate",
+            Value::Negative(23),
+            vec!["negint"],
+        ),
+        (
+            "negint-minus-25-min-8bit",
+            Value::Negative(24),
+            vec!["negint"],
+        ),
+        // -2^64: below i64/i128::from(u64) territory on the wire, the full
+        // major-1 range. Diag pins the arbitrary-precision rendering.
+        (
+            "negint-minus-2-pow-64",
+            Value::Negative(u64::MAX),
+            vec!["negint"],
+        ),
+        // Bytes: the 24-length one crosses into the 8-bit length header.
+        ("bytes-empty", Value::Bytes(Vec::new()), vec!["bytes"]),
+        (
+            "bytes-short",
+            Value::Bytes(vec![0x01, 0x02, 0x03]),
+            vec!["bytes"],
+        ),
+        (
+            "bytes-len-24-8bit-length-header",
+            Value::Bytes((0u8..24).collect()),
+            vec!["bytes"],
+        ),
+        // Text: empty, ascii, multibyte (UTF-8 length != char count), 24+.
+        ("text-empty", Value::Text(String::new()), vec!["text"]),
+        ("text-ascii", Value::Text("hello".into()), vec!["text"]),
+        (
+            "text-multibyte-unicode",
+            Value::Text("héllo wörld — ✓🚀".into()),
+            vec!["text"],
+        ),
+        (
+            "text-len-26-8bit-length-header",
+            Value::Text("abcdefghijklmnopqrstuvwxyz".into()),
+            vec!["text"],
+        ),
+        // Arrays.
+        ("array-empty", Value::Array(Vec::new()), vec!["array"]),
+        (
+            "array-nested",
+            Value::Array(vec![
+                Value::Unsigned(1),
+                Value::Array(vec![
+                    Value::Unsigned(2),
+                    Value::Array(vec![Value::Unsigned(3)]),
+                ]),
+            ]),
+            vec!["array"],
+        ),
+        (
+            "array-heterogeneous",
+            Value::Array(vec![
+                Value::Unsigned(1),
+                Value::Negative(1),
+                Value::Bytes(vec![0xff]),
+                Value::Text("mixed".into()),
+                Value::Bool(true),
+                Value::Null,
+                Value::Array(Vec::new()),
+                Value::Map(Map::new()),
+            ]),
+            vec!["array"],
+        ),
+        // Maps: canonical order is length-first, then bytewise — "a" and "b"
+        // sort before "aa".
+        ("map-empty", Value::Map(Map::new()), vec!["map"]),
+        (
+            "map-canonical-key-order-length-first",
+            map_of(vec![
+                ("aa", Value::Unsigned(3)),
+                ("b", Value::Unsigned(2)),
+                ("a", Value::Unsigned(1)),
+            ]),
+            vec!["map"],
+        ),
+        (
+            "map-nested",
+            map_of(vec![
+                ("k", map_of(vec![("nested", Value::Bool(true))])),
+                ("z", Value::Array(vec![Value::Null])),
+            ]),
+            vec!["map"],
+        ),
+        // Simple values.
+        ("bool-true", Value::Bool(true), vec!["bool"]),
+        ("bool-false", Value::Bool(false), vec!["bool"]),
+        ("null", Value::Null, vec!["null"]),
+        // Exactly at the depth limit: the innermost (128th) array is read at
+        // depth 127 < MAX_DEPTH. One level deeper is the depth-exceeded
+        // reject vector.
+        (
+            "array-nested-at-depth-limit-128",
+            nested_arrays(MAX_DEPTH),
+            vec!["array", "depth-limit"],
+        ),
+    ]
+}
+
+fn build_accept_vectors() -> Vec<AcceptVector> {
+    let specs = accept_specs();
+    let mut names = BTreeSet::new();
+    let mut out = Vec::with_capacity(specs.len());
+    for (name, value, kinds) in specs {
+        assert!(names.insert(name), "duplicate accept vector name {name}");
+        let bytes = encode(&value);
+        let decoded = decode(&bytes)
+            .unwrap_or_else(|e| panic!("accept vector {name}: live decoder rejected it: {e}"));
+        assert_eq!(
+            decoded, value,
+            "accept vector {name}: decode != source value"
+        );
+        assert_eq!(
+            encode(&decoded),
+            bytes,
+            "accept vector {name}: re-encode not byte-stable"
+        );
+        out.push(AcceptVector {
+            name: name.to_string(),
+            hex: hex::encode(&bytes),
+            diag: value.to_string(),
+            kinds: kinds.into_iter().map(str::to_string).collect(),
+        });
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Reject vectors: explicit hand-crafted byte literals, one per decode-
+// reachable check (several for the load-bearing ones), each asserted against
+// the live decoder for the exact check + class.
+// ---------------------------------------------------------------------------
+
+fn reject_specs() -> Vec<(&'static str, String, &'static str, &'static str)> {
+    let h = |s: &str| s.to_string();
+    // MAX_DEPTH (128) array heads then an empty array: the 129th nesting
+    // level would be read at depth 128, one past the limit.
+    let depth_129 = "81".repeat(MAX_DEPTH) + "80";
+    vec![
+        // --- trust: non-canonical-uint ---------------------------------
+        // 18 17 — uint 23 in 8-bit form; shortest form is the immediate 17.
+        (
+            "uint-23-in-8bit-form",
+            h("1817"),
+            "non-canonical-uint",
+            "trust",
+        ),
+        // 19 00ff — uint 255 in 16-bit form; shortest is 18 ff.
+        (
+            "uint-255-in-16bit-form",
+            h("1900ff"),
+            "non-canonical-uint",
+            "trust",
+        ),
+        // 1a 0000ffff — uint 65535 in 32-bit form; shortest is 19 ffff.
+        (
+            "uint-65535-in-32bit-form",
+            h("1a0000ffff"),
+            "non-canonical-uint",
+            "trust",
+        ),
+        // 1b 00000000ffffffff — uint 4294967295 in 64-bit form.
+        (
+            "uint-4294967295-in-64bit-form",
+            h("1b00000000ffffffff"),
+            "non-canonical-uint",
+            "trust",
+        ),
+        // 38 17 — negative -24 (major 1, arg 23) in 8-bit form; shortest is 37.
+        (
+            "negint-minus-24-in-8bit-form",
+            h("3817"),
+            "non-canonical-uint",
+            "trust",
+        ),
+        // --- trust: non-canonical-length -------------------------------
+        // 58 03 aa bb cc — 3-byte string with an 8-bit length header;
+        // shortest is 43.
+        (
+            "bytes-len-3-in-8bit-form",
+            h("5803aabbcc"),
+            "non-canonical-length",
+            "trust",
+        ),
+        // 78 01 61 — 1-char text with an 8-bit length header; shortest is 61.
+        (
+            "text-len-1-in-8bit-form",
+            h("780161"),
+            "non-canonical-length",
+            "trust",
+        ),
+        // 98 03 01 02 03 — 3-element array with an 8-bit length header.
+        (
+            "array-len-3-in-8bit-form",
+            h("9803010203"),
+            "non-canonical-length",
+            "trust",
+        ),
+        // b8 01 61 61 01 — 1-entry map {"a": 1} with an 8-bit length header.
+        (
+            "map-len-1-in-8bit-form",
+            h("b801616101"),
+            "non-canonical-length",
+            "trust",
+        ),
+        // --- trust: indefinite-length -----------------------------------
+        // 5f 41 aa ff — indefinite bytes, one 1-byte chunk, break.
+        (
+            "indefinite-bytes",
+            h("5f41aaff"),
+            "indefinite-length",
+            "trust",
+        ),
+        // 7f 61 61 ff — indefinite text, one chunk "a", break.
+        (
+            "indefinite-text",
+            h("7f6161ff"),
+            "indefinite-length",
+            "trust",
+        ),
+        // 9f 01 ff — indefinite array [1], break.
+        (
+            "indefinite-array",
+            h("9f01ff"),
+            "indefinite-length",
+            "trust",
+        ),
+        // bf 61 61 01 ff — indefinite map {"a": 1}, break.
+        (
+            "indefinite-map",
+            h("bf616101ff"),
+            "indefinite-length",
+            "trust",
+        ),
+        // --- trust: unsorted-map-keys -----------------------------------
+        // a2 6162 01 6161 02 — {"b": 1, "a": 2}: bytewise order violation.
+        (
+            "map-keys-bytewise-out-of-order",
+            h("a2616201616102"),
+            "unsorted-map-keys",
+            "trust",
+        ),
+        // a2 626161 01 6162 02 — {"aa": 1, "b": 2}: canonical text-key order
+        // is length-first, so "b" must sort before "aa".
+        (
+            "map-keys-length-order-violation",
+            h("a262616101616202"),
+            "unsorted-map-keys",
+            "trust",
+        ),
+        // --- trust: duplicate-map-key -----------------------------------
+        // a2 6161 01 6161 02 — {"a": 1, "a": 2}.
+        (
+            "map-duplicate-key",
+            h("a2616101616102"),
+            "duplicate-map-key",
+            "trust",
+        ),
+        // --- malformed: truncated ---------------------------------------
+        // Zero bytes: no item at all.
+        ("empty-input", h(""), "truncated", "malformed"),
+        // 18 — uint head promising an 8-bit argument that never comes.
+        (
+            "uint-head-missing-argument",
+            h("18"),
+            "truncated",
+            "malformed",
+        ),
+        // 44 aa bb — bytes head claiming 4 bytes, only 2 present.
+        (
+            "bytes-shorter-than-length",
+            h("44aabb"),
+            "truncated",
+            "malformed",
+        ),
+        // 82 01 — array of 2 with only 1 element present.
+        ("array-missing-element", h("8201"), "truncated", "malformed"),
+        // --- malformed: trailing-bytes ----------------------------------
+        // 01 00 — a complete item (1) followed by a stray byte.
+        (
+            "trailing-byte-after-item",
+            h("0100"),
+            "trailing-bytes",
+            "malformed",
+        ),
+        // --- malformed: invalid-utf8 ------------------------------------
+        // 62 ff fe — 2-byte text whose payload is not UTF-8.
+        (
+            "text-invalid-utf8",
+            h("62fffe"),
+            "invalid-utf8",
+            "malformed",
+        ),
+        // --- malformed: invalid-map-key-type ----------------------------
+        // a1 01 02 — {1: 2}: integer map key; the profile admits text only.
+        (
+            "map-key-unsigned",
+            h("a10102"),
+            "invalid-map-key-type",
+            "malformed",
+        ),
+        // --- malformed: tag-forbidden -----------------------------------
+        // d8 2a 45 0001020300… — tag 42 (a DAG-CBOR CID link) around bytes.
+        // CID links are outside this profile; every tag rejects.
+        (
+            "tag-42-dag-cbor-cid-link",
+            h("d82a4500010203aa"),
+            "tag-forbidden",
+            "malformed",
+        ),
+        // c0 00 — tag 0 (datetime) in immediate form.
+        ("tag-0-datetime", h("c000"), "tag-forbidden", "malformed"),
+        // --- malformed: float-forbidden ---------------------------------
+        // f9 0014 — half-float whose bit pattern (0x0014) aliases simple
+        // value 20 (false). A decoder dispatching on the decoded argument
+        // instead of the additional info accepts this as `false` — a real
+        // bug class in this decoder's history; must reject as a float.
+        (
+            "half-float-aliasing-simple-false",
+            h("f90014"),
+            "float-forbidden",
+            "malformed",
+        ),
+        // fa 47c35000 — float32 100000.0.
+        ("float32", h("fa47c35000"), "float-forbidden", "malformed"),
+        // fb 3ff199999999999a — float64 1.1.
+        (
+            "float64",
+            h("fb3ff199999999999a"),
+            "float-forbidden",
+            "malformed",
+        ),
+        // --- malformed: simple-value-forbidden --------------------------
+        // f8 14 — simple value 20 in two-byte form. Must NOT alias `false`
+        // (f4): only the immediate forms of false/true/null are admitted.
+        (
+            "two-byte-simple-20-not-false",
+            h("f814"),
+            "simple-value-forbidden",
+            "malformed",
+        ),
+        // f7 — simple value 23 (undefined).
+        (
+            "simple-undefined",
+            h("f7"),
+            "simple-value-forbidden",
+            "malformed",
+        ),
+        // f0 — simple value 16 (unassigned).
+        (
+            "simple-16-unassigned",
+            h("f0"),
+            "simple-value-forbidden",
+            "malformed",
+        ),
+        // --- malformed: reserved-additional-info ------------------------
+        // 1c — major 0 with additional info 28 (reserved everywhere).
+        (
+            "uint-ai-28-reserved",
+            h("1c"),
+            "reserved-additional-info",
+            "malformed",
+        ),
+        // 1f — major 0 with additional info 31: indefinite length is not
+        // defined for integers, so this is reserved, not indefinite-length.
+        (
+            "uint-ai-31-reserved",
+            h("1f"),
+            "reserved-additional-info",
+            "malformed",
+        ),
+        // --- malformed: unexpected-break --------------------------------
+        // ff — a break stop code with no indefinite-length item open.
+        ("bare-break", h("ff"), "unexpected-break", "malformed"),
+        // --- malformed: depth-exceeded ----------------------------------
+        // 129 nested arrays: one past MAX_DEPTH (the 128-deep accept vector
+        // is the other side of this edge).
+        (
+            "array-nesting-129-levels",
+            depth_129,
+            "depth-exceeded",
+            "malformed",
+        ),
+    ]
+}
+
+fn build_reject_vectors() -> Vec<RejectVector> {
+    let specs = reject_specs();
+    let mut names = BTreeSet::new();
+    let mut out = Vec::with_capacity(specs.len());
+    for (name, hex, check, class) in specs {
+        assert!(names.insert(name), "duplicate reject vector name {name}");
+        assert_eq!(
+            hex,
+            hex.to_lowercase(),
+            "reject vector {name}: hex must be lowercase"
+        );
+        let bytes =
+            hex::decode(&hex).unwrap_or_else(|e| panic!("reject vector {name}: bad hex: {e}"));
+        let err = match decode(&bytes) {
+            Err(e) => e,
+            Ok(v) => panic!("reject vector {name}: decoder accepted it as {v}"),
+        };
+        assert_eq!(
+            err.check(),
+            check,
+            "reject vector {name}: wrong check ({err})"
+        );
+        assert_eq!(
+            err.class(),
+            class,
+            "reject vector {name}: wrong class ({err})"
+        );
+        out.push(RejectVector {
+            name: name.to_string(),
+            hex,
+            check: check.to_string(),
+            class: class.to_string(),
+        });
+    }
+
+    // Self-check the coverage law before writing anything: every decode-
+    // reachable check is present; the only absentees are the two encode-/
+    // schema-side checks pinned by unit tests in src/codec/fields.rs.
+    let present: BTreeSet<&str> = out.iter().map(|v| v.check.as_str()).collect();
+    let absent: Vec<&str> = TrustViolation::CHECKS
+        .iter()
+        .chain(Malformed::CHECKS)
+        .copied()
+        .filter(|c| !present.contains(c))
+        .collect();
+    assert_eq!(
+        absent,
+        ["unexpected-type", "unknown-field-collision"],
+        "reject vectors must cover every decode-reachable check"
+    );
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Unknown-field vectors: the single decode tolerance, byte-stable on rewrite.
+// ---------------------------------------------------------------------------
+
+fn unknown_field_specs() -> Vec<(&'static str, Value, Vec<&'static str>, usize)> {
+    vec![
+        (
+            "all-known",
+            map_of(vec![("a", Value::Unsigned(1)), ("b", Value::Unsigned(2))]),
+            vec!["a", "b"],
+            0,
+        ),
+        (
+            "none-known",
+            map_of(vec![("a", Value::Unsigned(1)), ("b", Value::Unsigned(2))]),
+            vec![],
+            2,
+        ),
+        // Canonical key order a, b, aa, zz — known and unknown interleave.
+        (
+            "interleaved-known-unknown",
+            map_of(vec![
+                ("a", Value::Unsigned(1)),
+                ("b", Value::Bytes(vec![0xff])),
+                ("aa", Value::Text("x".into())),
+                ("zz", Value::Null),
+            ]),
+            vec!["a", "aa"],
+            2,
+        ),
+        // The preserved unknown value is itself a nested map.
+        (
+            "unknown-value-nested-map",
+            map_of(vec![
+                ("id", Value::Unsigned(7)),
+                (
+                    "meta",
+                    map_of(vec![
+                        (
+                            "x",
+                            Value::Array(vec![Value::Unsigned(1), Value::Unsigned(2)]),
+                        ),
+                        ("y", Value::Text("z".into())),
+                    ]),
+                ),
+            ]),
+            vec!["id"],
+            1,
+        ),
+        // The preserved unknown value is itself a nested array.
+        (
+            "unknown-value-nested-array",
+            map_of(vec![
+                ("k", Value::Bool(true)),
+                (
+                    "list",
+                    Value::Array(vec![
+                        Value::Unsigned(1),
+                        Value::Array(vec![Value::Unsigned(2)]),
+                        Value::Null,
+                    ]),
+                ),
+            ]),
+            vec!["k"],
+            1,
+        ),
+        ("empty-map", Value::Map(Map::new()), vec![], 0),
+    ]
+}
+
+fn build_unknown_field_vectors() -> Vec<UnknownVector> {
+    let specs = unknown_field_specs();
+    let mut names = BTreeSet::new();
+    let mut out = Vec::with_capacity(specs.len());
+    for (name, value, known_keys, expect_unknown) in specs {
+        assert!(
+            names.insert(name),
+            "duplicate unknown-field vector name {name}"
+        );
+        let bytes = encode(&value);
+        let known_set: BTreeSet<&str> = known_keys.iter().copied().collect();
+        let (known, unknown) = decode_map_partial(&bytes, |k| known_set.contains(k))
+            .unwrap_or_else(|e| panic!("unknown-field vector {name}: decode failed: {e}"));
+        assert_eq!(
+            unknown.len(),
+            expect_unknown,
+            "unknown-field vector {name}: unknown count"
+        );
+        let total = value.as_map().expect("spec value is a map").len();
+        assert_eq!(
+            known.len() + unknown.len(),
+            total,
+            "unknown-field vector {name}: split must be exhaustive"
+        );
+        let reencoded = encode_map_partial(&known, &unknown)
+            .unwrap_or_else(|e| panic!("unknown-field vector {name}: rewrite failed: {e}"));
+        assert_eq!(
+            reencoded, bytes,
+            "unknown-field vector {name}: rewrite not byte-stable"
+        );
+        out.push(UnknownVector {
+            name: name.to_string(),
+            hex: hex::encode(&bytes),
+            known_keys: known_keys.into_iter().map(str::to_string).collect(),
+            expect_unknown_count: expect_unknown,
+        });
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Manifest: counts/checks/requiredKinds rewritten from the generated data;
+// manifestVersion/profile/structureTags/kdfEdges preserved from the existing
+// file (later spine slices extend the empty sections).
+// ---------------------------------------------------------------------------
+
+fn build_manifest(
+    kat_dir: &Path,
+    accept: &[AcceptVector],
+    reject: &[RejectVector],
+    unknown: &[UnknownVector],
+) -> Manifest {
+    // requiredKinds: distinct kinds in first-appearance order (deterministic).
+    let mut required_kinds: Vec<String> = Vec::new();
+    for v in accept {
+        for k in &v.kinds {
+            if !required_kinds.contains(k) {
+                required_kinds.push(k.clone());
+            }
+        }
+    }
+
+    // checks: the decode-reachable subset, in error-surface declaration order
+    // (trust first, then malformed).
+    let present: BTreeSet<&str> = reject.iter().map(|v| v.check.as_str()).collect();
+    let checks: Vec<String> = TrustViolation::CHECKS
+        .iter()
+        .chain(Malformed::CHECKS)
+        .copied()
+        .filter(|c| present.contains(c))
+        .map(str::to_string)
+        .collect();
+    assert_eq!(
+        checks.len(),
+        present.len(),
+        "every reject-vector check must come from the error surface"
+    );
+
+    let (manifest_version, profile, structure_tags, kdf_edges) =
+        match fs::read_to_string(kat_dir.join("manifest.json")) {
+            Ok(text) => {
+                let existing: serde_json::Value =
+                    serde_json::from_str(&text).expect("existing manifest.json must parse");
+                (
+                    existing
+                        .get("manifestVersion")
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or(1),
+                    existing
+                        .get("profile")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or(PROFILE)
+                        .to_string(),
+                    existing
+                        .get("structureTags")
+                        .cloned()
+                        .unwrap_or_else(|| json!({})),
+                    existing
+                        .get("kdfEdges")
+                        .cloned()
+                        .unwrap_or_else(|| json!({})),
+                )
+            }
+            Err(_) => (1, PROFILE.to_string(), json!({}), json!({})),
+        };
+
+    Manifest {
+        manifest_version,
+        profile,
+        codecs: Codecs {
+            det_cbor: DetCbor {
+                accept: AcceptSection {
+                    file: "vectors/codec/accept.json".to_string(),
+                    count: accept.len(),
+                    required_kinds,
+                },
+                reject: RejectSection {
+                    file: "vectors/codec/reject.json".to_string(),
+                    count: reject.len(),
+                    checks,
+                },
+                unknown_fields: UnknownFieldsSection {
+                    file: "vectors/codec/unknown_fields.json".to_string(),
+                    count: unknown.len(),
+                },
+            },
+        },
+        structure_tags,
+        kdf_edges,
+    }
+}

--- a/crates/core/examples/kat_gen.rs
+++ b/crates/core/examples/kat_gen.rs
@@ -261,6 +261,20 @@ fn accept_specs() -> Vec<(&'static str, Value, Vec<&'static str>)> {
             ]),
             vec!["map"],
         ),
+        // Keys straddling the 23/24 length-header class boundary, in
+        // canonical order (length-first: the 23-char key sorts before the
+        // 24-char one whose header grows to 78 18). The reversed order is a
+        // reject vector.
+        (
+            "map-keys-length-class-boundary",
+            {
+                let mut m = Map::new();
+                m.insert("a".repeat(23), Value::Unsigned(0));
+                m.insert("b".repeat(24), Value::Unsigned(1));
+                Value::Map(m)
+            },
+            vec!["map"],
+        ),
         // Simple values.
         ("bool-true", Value::Bool(true), vec!["bool"]),
         ("bool-false", Value::Bool(false), vec!["bool"]),
@@ -559,6 +573,70 @@ fn reject_specs() -> Vec<(&'static str, String, &'static str, &'static str)> {
             depth_129,
             "depth-exceeded",
             "malformed",
+        ),
+        // --- crypto-review additions (PR #659 security review) ----------
+        // f8 ff — two-byte simple value 255: well-formed CBOR (arg >= 32,
+        // unassigned) yet profile-forbidden; f8 14 pins the ill-formed half.
+        (
+            "two-byte-simple-255",
+            h("f8ff"),
+            "simple-value-forbidden",
+            "malformed",
+        ),
+        // a2 60 00 60 f4 — {"": 0, "": false}: duplicate empty-string key.
+        (
+            "map-duplicate-empty-key",
+            h("a2600060f4"),
+            "duplicate-map-key",
+            "trust",
+        ),
+        // a3 6161 00 6162 01 6161 02 — {"a": 0, "b": 1, "a": 2}: a duplicate
+        // separated by a middle key surfaces as an ordering violation, never
+        // silently — pins the check-precedence choice.
+        (
+            "map-gap-duplicate-fires-unsorted",
+            h("a3616100616201616102"),
+            "unsorted-map-keys",
+            "trust",
+        ),
+        // 5f ff / 7f ff — *empty* indefinite bytes/text (the other
+        // indefinite vectors carry chunks).
+        (
+            "indefinite-bytes-empty",
+            h("5fff"),
+            "indefinite-length",
+            "trust",
+        ),
+        (
+            "indefinite-text-empty",
+            h("7fff"),
+            "indefinite-length",
+            "trust",
+        ),
+        // dc — a tag head with reserved additional info 28: tag rejection
+        // fires on the initial byte, before ai validation.
+        (
+            "tag-head-reserved-ai-precedence",
+            h("dc"),
+            "tag-forbidden",
+            "malformed",
+        ),
+        // a1 78 01 61 f6 — {"a"(8-bit len): null}: non-shortest length on
+        // the *key* path.
+        (
+            "map-key-len-1-in-8bit-form",
+            h("a1780161f6"),
+            "non-canonical-length",
+            "trust",
+        ),
+        // The reversed order of the map-keys-length-class-boundary accept
+        // vector: the 24-char key (header 78 18) before the 23-char key
+        // (header 77) violates length-first order.
+        (
+            "map-keys-length-class-boundary-out-of-order",
+            format!("a27818{}0177{}00", "62".repeat(24), "61".repeat(23)),
+            "unsorted-map-keys",
+            "trust",
         ),
     ]
 }

--- a/crates/core/examples/kat_gen.rs
+++ b/crates/core/examples/kat_gen.rs
@@ -680,15 +680,17 @@ fn build_reject_vectors() -> Vec<RejectVector> {
     // reachable check is present; the only absentees are the two encode-/
     // schema-side checks pinned by unit tests in src/codec/fields.rs.
     let present: BTreeSet<&str> = out.iter().map(|v| v.check.as_str()).collect();
-    let absent: Vec<&str> = TrustViolation::CHECKS
+    let absent: BTreeSet<&str> = TrustViolation::CHECKS
         .iter()
         .chain(Malformed::CHECKS)
         .copied()
         .filter(|c| !present.contains(c))
         .collect();
+    let expected_absent: BTreeSet<&str> = ["unexpected-type", "unknown-field-collision"]
+        .into_iter()
+        .collect();
     assert_eq!(
-        absent,
-        ["unexpected-type", "unknown-field-collision"],
+        absent, expected_absent,
         "reject vectors must cover every decode-reachable check"
     );
     out

--- a/crates/core/examples/kat_gen.rs
+++ b/crates/core/examples/kat_gen.rs
@@ -111,7 +111,7 @@ fn main() {
     write_pretty(&codec_dir.join("reject.json"), &reject);
     write_pretty(&codec_dir.join("unknown_fields.json"), &unknown);
 
-    let manifest = build_manifest(&kat_dir, &accept, &reject, &unknown);
+    let manifest = build_manifest(&accept, &reject, &unknown);
     write_pretty(&kat_dir.join("manifest.json"), &manifest);
 
     println!(
@@ -727,13 +727,13 @@ fn build_unknown_field_vectors() -> Vec<UnknownVector> {
 }
 
 // ---------------------------------------------------------------------------
-// Manifest: counts/checks/requiredKinds rewritten from the generated data;
-// manifestVersion/profile/structureTags/kdfEdges preserved from the existing
-// file (later spine slices extend the empty sections).
+// Manifest: every byte comes from this generator — header constants and
+// counts/checks/requiredKinds from the generated data. The empty
+// structureTags/kdfEdges sections are extended by extending this generator
+// when those spine slices land, never by hand-editing the JSON.
 // ---------------------------------------------------------------------------
 
 fn build_manifest(
-    kat_dir: &Path,
     accept: &[AcceptVector],
     reject: &[RejectVector],
     unknown: &[UnknownVector],
@@ -764,37 +764,9 @@ fn build_manifest(
         "every reject-vector check must come from the error surface"
     );
 
-    let (manifest_version, profile, structure_tags, kdf_edges) =
-        match fs::read_to_string(kat_dir.join("manifest.json")) {
-            Ok(text) => {
-                let existing: serde_json::Value =
-                    serde_json::from_str(&text).expect("existing manifest.json must parse");
-                (
-                    existing
-                        .get("manifestVersion")
-                        .and_then(serde_json::Value::as_u64)
-                        .unwrap_or(1),
-                    existing
-                        .get("profile")
-                        .and_then(serde_json::Value::as_str)
-                        .unwrap_or(PROFILE)
-                        .to_string(),
-                    existing
-                        .get("structureTags")
-                        .cloned()
-                        .unwrap_or_else(|| json!({})),
-                    existing
-                        .get("kdfEdges")
-                        .cloned()
-                        .unwrap_or_else(|| json!({})),
-                )
-            }
-            Err(_) => (1, PROFILE.to_string(), json!({}), json!({})),
-        };
-
     Manifest {
-        manifest_version,
-        profile,
+        manifest_version: 1,
+        profile: PROFILE.to_string(),
         codecs: Codecs {
             det_cbor: DetCbor {
                 accept: AcceptSection {
@@ -813,7 +785,7 @@ fn build_manifest(
                 },
             },
         },
-        structure_tags,
-        kdf_edges,
+        structure_tags: json!({}),
+        kdf_edges: json!({}),
     }
 }

--- a/crates/core/kat/manifest.json
+++ b/crates/core/kat/manifest.json
@@ -5,7 +5,7 @@
     "det-cbor": {
       "accept": {
         "file": "vectors/codec/accept.json",
-        "count": 31,
+        "count": 32,
         "requiredKinds": [
           "uint",
           "negint",
@@ -20,7 +20,7 @@
       },
       "reject": {
         "file": "vectors/codec/reject.json",
-        "count": 35,
+        "count": 43,
         "checks": [
           "non-canonical-uint",
           "non-canonical-length",

--- a/crates/core/kat/manifest.json
+++ b/crates/core/kat/manifest.json
@@ -1,0 +1,50 @@
+{
+  "manifestVersion": 1,
+  "profile": "cipherbox/v2 det-cbor",
+  "codecs": {
+    "det-cbor": {
+      "accept": {
+        "file": "vectors/codec/accept.json",
+        "count": 31,
+        "requiredKinds": [
+          "uint",
+          "negint",
+          "bytes",
+          "text",
+          "array",
+          "map",
+          "bool",
+          "null",
+          "depth-limit"
+        ]
+      },
+      "reject": {
+        "file": "vectors/codec/reject.json",
+        "count": 35,
+        "checks": [
+          "non-canonical-uint",
+          "non-canonical-length",
+          "indefinite-length",
+          "unsorted-map-keys",
+          "duplicate-map-key",
+          "truncated",
+          "trailing-bytes",
+          "invalid-utf8",
+          "invalid-map-key-type",
+          "tag-forbidden",
+          "float-forbidden",
+          "simple-value-forbidden",
+          "reserved-additional-info",
+          "unexpected-break",
+          "depth-exceeded"
+        ]
+      },
+      "unknownFields": {
+        "file": "vectors/codec/unknown_fields.json",
+        "count": 6
+      }
+    }
+  },
+  "structureTags": {},
+  "kdfEdges": {}
+}

--- a/crates/core/kat/vectors/codec/accept.json
+++ b/crates/core/kat/vectors/codec/accept.json
@@ -216,6 +216,14 @@
     ]
   },
   {
+    "name": "map-keys-length-class-boundary",
+    "hex": "a277616161616161616161616161616161616161616161616100781862626262626262626262626262626262626262626262626201",
+    "diag": "{\"aaaaaaaaaaaaaaaaaaaaaaa\": 0, \"bbbbbbbbbbbbbbbbbbbbbbbb\": 1}",
+    "kinds": [
+      "map"
+    ]
+  },
+  {
     "name": "bool-true",
     "hex": "f5",
     "diag": "true",

--- a/crates/core/kat/vectors/codec/accept.json
+++ b/crates/core/kat/vectors/codec/accept.json
@@ -1,0 +1,251 @@
+[
+  {
+    "name": "uint-0",
+    "hex": "00",
+    "diag": "0",
+    "kinds": [
+      "uint"
+    ]
+  },
+  {
+    "name": "uint-23-max-immediate",
+    "hex": "17",
+    "diag": "23",
+    "kinds": [
+      "uint"
+    ]
+  },
+  {
+    "name": "uint-24-min-8bit",
+    "hex": "1818",
+    "diag": "24",
+    "kinds": [
+      "uint"
+    ]
+  },
+  {
+    "name": "uint-255-max-8bit",
+    "hex": "18ff",
+    "diag": "255",
+    "kinds": [
+      "uint"
+    ]
+  },
+  {
+    "name": "uint-256-min-16bit",
+    "hex": "190100",
+    "diag": "256",
+    "kinds": [
+      "uint"
+    ]
+  },
+  {
+    "name": "uint-65535-max-16bit",
+    "hex": "19ffff",
+    "diag": "65535",
+    "kinds": [
+      "uint"
+    ]
+  },
+  {
+    "name": "uint-65536-min-32bit",
+    "hex": "1a00010000",
+    "diag": "65536",
+    "kinds": [
+      "uint"
+    ]
+  },
+  {
+    "name": "uint-4294967295-max-32bit",
+    "hex": "1affffffff",
+    "diag": "4294967295",
+    "kinds": [
+      "uint"
+    ]
+  },
+  {
+    "name": "uint-4294967296-min-64bit",
+    "hex": "1b0000000100000000",
+    "diag": "4294967296",
+    "kinds": [
+      "uint"
+    ]
+  },
+  {
+    "name": "uint-u64-max",
+    "hex": "1bffffffffffffffff",
+    "diag": "18446744073709551615",
+    "kinds": [
+      "uint"
+    ]
+  },
+  {
+    "name": "negint-minus-1",
+    "hex": "20",
+    "diag": "-1",
+    "kinds": [
+      "negint"
+    ]
+  },
+  {
+    "name": "negint-minus-24-max-immediate",
+    "hex": "37",
+    "diag": "-24",
+    "kinds": [
+      "negint"
+    ]
+  },
+  {
+    "name": "negint-minus-25-min-8bit",
+    "hex": "3818",
+    "diag": "-25",
+    "kinds": [
+      "negint"
+    ]
+  },
+  {
+    "name": "negint-minus-2-pow-64",
+    "hex": "3bffffffffffffffff",
+    "diag": "-18446744073709551616",
+    "kinds": [
+      "negint"
+    ]
+  },
+  {
+    "name": "bytes-empty",
+    "hex": "40",
+    "diag": "h''",
+    "kinds": [
+      "bytes"
+    ]
+  },
+  {
+    "name": "bytes-short",
+    "hex": "43010203",
+    "diag": "h'010203'",
+    "kinds": [
+      "bytes"
+    ]
+  },
+  {
+    "name": "bytes-len-24-8bit-length-header",
+    "hex": "5818000102030405060708090a0b0c0d0e0f1011121314151617",
+    "diag": "h'000102030405060708090a0b0c0d0e0f1011121314151617'",
+    "kinds": [
+      "bytes"
+    ]
+  },
+  {
+    "name": "text-empty",
+    "hex": "60",
+    "diag": "\"\"",
+    "kinds": [
+      "text"
+    ]
+  },
+  {
+    "name": "text-ascii",
+    "hex": "6568656c6c6f",
+    "diag": "\"hello\"",
+    "kinds": [
+      "text"
+    ]
+  },
+  {
+    "name": "text-multibyte-unicode",
+    "hex": "781968c3a96c6c6f2077c3b6726c6420e2809420e29c93f09f9a80",
+    "diag": "\"héllo wörld — ✓🚀\"",
+    "kinds": [
+      "text"
+    ]
+  },
+  {
+    "name": "text-len-26-8bit-length-header",
+    "hex": "781a6162636465666768696a6b6c6d6e6f707172737475767778797a",
+    "diag": "\"abcdefghijklmnopqrstuvwxyz\"",
+    "kinds": [
+      "text"
+    ]
+  },
+  {
+    "name": "array-empty",
+    "hex": "80",
+    "diag": "[]",
+    "kinds": [
+      "array"
+    ]
+  },
+  {
+    "name": "array-nested",
+    "hex": "820182028103",
+    "diag": "[1, [2, [3]]]",
+    "kinds": [
+      "array"
+    ]
+  },
+  {
+    "name": "array-heterogeneous",
+    "hex": "88012141ff656d69786564f5f680a0",
+    "diag": "[1, -2, h'ff', \"mixed\", true, null, [], {}]",
+    "kinds": [
+      "array"
+    ]
+  },
+  {
+    "name": "map-empty",
+    "hex": "a0",
+    "diag": "{}",
+    "kinds": [
+      "map"
+    ]
+  },
+  {
+    "name": "map-canonical-key-order-length-first",
+    "hex": "a361610161620262616103",
+    "diag": "{\"a\": 1, \"b\": 2, \"aa\": 3}",
+    "kinds": [
+      "map"
+    ]
+  },
+  {
+    "name": "map-nested",
+    "hex": "a2616ba1666e6573746564f5617a81f6",
+    "diag": "{\"k\": {\"nested\": true}, \"z\": [null]}",
+    "kinds": [
+      "map"
+    ]
+  },
+  {
+    "name": "bool-true",
+    "hex": "f5",
+    "diag": "true",
+    "kinds": [
+      "bool"
+    ]
+  },
+  {
+    "name": "bool-false",
+    "hex": "f4",
+    "diag": "false",
+    "kinds": [
+      "bool"
+    ]
+  },
+  {
+    "name": "null",
+    "hex": "f6",
+    "diag": "null",
+    "kinds": [
+      "null"
+    ]
+  },
+  {
+    "name": "array-nested-at-depth-limit-128",
+    "hex": "8181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818180",
+    "diag": "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]",
+    "kinds": [
+      "array",
+      "depth-limit"
+    ]
+  }
+]

--- a/crates/core/kat/vectors/codec/reject.json
+++ b/crates/core/kat/vectors/codec/reject.json
@@ -208,5 +208,53 @@
     "hex": "818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818180",
     "check": "depth-exceeded",
     "class": "malformed"
+  },
+  {
+    "name": "two-byte-simple-255",
+    "hex": "f8ff",
+    "check": "simple-value-forbidden",
+    "class": "malformed"
+  },
+  {
+    "name": "map-duplicate-empty-key",
+    "hex": "a2600060f4",
+    "check": "duplicate-map-key",
+    "class": "trust"
+  },
+  {
+    "name": "map-gap-duplicate-fires-unsorted",
+    "hex": "a3616100616201616102",
+    "check": "unsorted-map-keys",
+    "class": "trust"
+  },
+  {
+    "name": "indefinite-bytes-empty",
+    "hex": "5fff",
+    "check": "indefinite-length",
+    "class": "trust"
+  },
+  {
+    "name": "indefinite-text-empty",
+    "hex": "7fff",
+    "check": "indefinite-length",
+    "class": "trust"
+  },
+  {
+    "name": "tag-head-reserved-ai-precedence",
+    "hex": "dc",
+    "check": "tag-forbidden",
+    "class": "malformed"
+  },
+  {
+    "name": "map-key-len-1-in-8bit-form",
+    "hex": "a1780161f6",
+    "check": "non-canonical-length",
+    "class": "trust"
+  },
+  {
+    "name": "map-keys-length-class-boundary-out-of-order",
+    "hex": "a278186262626262626262626262626262626262626262626262620177616161616161616161616161616161616161616161616100",
+    "check": "unsorted-map-keys",
+    "class": "trust"
   }
 ]

--- a/crates/core/kat/vectors/codec/reject.json
+++ b/crates/core/kat/vectors/codec/reject.json
@@ -1,0 +1,212 @@
+[
+  {
+    "name": "uint-23-in-8bit-form",
+    "hex": "1817",
+    "check": "non-canonical-uint",
+    "class": "trust"
+  },
+  {
+    "name": "uint-255-in-16bit-form",
+    "hex": "1900ff",
+    "check": "non-canonical-uint",
+    "class": "trust"
+  },
+  {
+    "name": "uint-65535-in-32bit-form",
+    "hex": "1a0000ffff",
+    "check": "non-canonical-uint",
+    "class": "trust"
+  },
+  {
+    "name": "uint-4294967295-in-64bit-form",
+    "hex": "1b00000000ffffffff",
+    "check": "non-canonical-uint",
+    "class": "trust"
+  },
+  {
+    "name": "negint-minus-24-in-8bit-form",
+    "hex": "3817",
+    "check": "non-canonical-uint",
+    "class": "trust"
+  },
+  {
+    "name": "bytes-len-3-in-8bit-form",
+    "hex": "5803aabbcc",
+    "check": "non-canonical-length",
+    "class": "trust"
+  },
+  {
+    "name": "text-len-1-in-8bit-form",
+    "hex": "780161",
+    "check": "non-canonical-length",
+    "class": "trust"
+  },
+  {
+    "name": "array-len-3-in-8bit-form",
+    "hex": "9803010203",
+    "check": "non-canonical-length",
+    "class": "trust"
+  },
+  {
+    "name": "map-len-1-in-8bit-form",
+    "hex": "b801616101",
+    "check": "non-canonical-length",
+    "class": "trust"
+  },
+  {
+    "name": "indefinite-bytes",
+    "hex": "5f41aaff",
+    "check": "indefinite-length",
+    "class": "trust"
+  },
+  {
+    "name": "indefinite-text",
+    "hex": "7f6161ff",
+    "check": "indefinite-length",
+    "class": "trust"
+  },
+  {
+    "name": "indefinite-array",
+    "hex": "9f01ff",
+    "check": "indefinite-length",
+    "class": "trust"
+  },
+  {
+    "name": "indefinite-map",
+    "hex": "bf616101ff",
+    "check": "indefinite-length",
+    "class": "trust"
+  },
+  {
+    "name": "map-keys-bytewise-out-of-order",
+    "hex": "a2616201616102",
+    "check": "unsorted-map-keys",
+    "class": "trust"
+  },
+  {
+    "name": "map-keys-length-order-violation",
+    "hex": "a262616101616202",
+    "check": "unsorted-map-keys",
+    "class": "trust"
+  },
+  {
+    "name": "map-duplicate-key",
+    "hex": "a2616101616102",
+    "check": "duplicate-map-key",
+    "class": "trust"
+  },
+  {
+    "name": "empty-input",
+    "hex": "",
+    "check": "truncated",
+    "class": "malformed"
+  },
+  {
+    "name": "uint-head-missing-argument",
+    "hex": "18",
+    "check": "truncated",
+    "class": "malformed"
+  },
+  {
+    "name": "bytes-shorter-than-length",
+    "hex": "44aabb",
+    "check": "truncated",
+    "class": "malformed"
+  },
+  {
+    "name": "array-missing-element",
+    "hex": "8201",
+    "check": "truncated",
+    "class": "malformed"
+  },
+  {
+    "name": "trailing-byte-after-item",
+    "hex": "0100",
+    "check": "trailing-bytes",
+    "class": "malformed"
+  },
+  {
+    "name": "text-invalid-utf8",
+    "hex": "62fffe",
+    "check": "invalid-utf8",
+    "class": "malformed"
+  },
+  {
+    "name": "map-key-unsigned",
+    "hex": "a10102",
+    "check": "invalid-map-key-type",
+    "class": "malformed"
+  },
+  {
+    "name": "tag-42-dag-cbor-cid-link",
+    "hex": "d82a4500010203aa",
+    "check": "tag-forbidden",
+    "class": "malformed"
+  },
+  {
+    "name": "tag-0-datetime",
+    "hex": "c000",
+    "check": "tag-forbidden",
+    "class": "malformed"
+  },
+  {
+    "name": "half-float-aliasing-simple-false",
+    "hex": "f90014",
+    "check": "float-forbidden",
+    "class": "malformed"
+  },
+  {
+    "name": "float32",
+    "hex": "fa47c35000",
+    "check": "float-forbidden",
+    "class": "malformed"
+  },
+  {
+    "name": "float64",
+    "hex": "fb3ff199999999999a",
+    "check": "float-forbidden",
+    "class": "malformed"
+  },
+  {
+    "name": "two-byte-simple-20-not-false",
+    "hex": "f814",
+    "check": "simple-value-forbidden",
+    "class": "malformed"
+  },
+  {
+    "name": "simple-undefined",
+    "hex": "f7",
+    "check": "simple-value-forbidden",
+    "class": "malformed"
+  },
+  {
+    "name": "simple-16-unassigned",
+    "hex": "f0",
+    "check": "simple-value-forbidden",
+    "class": "malformed"
+  },
+  {
+    "name": "uint-ai-28-reserved",
+    "hex": "1c",
+    "check": "reserved-additional-info",
+    "class": "malformed"
+  },
+  {
+    "name": "uint-ai-31-reserved",
+    "hex": "1f",
+    "check": "reserved-additional-info",
+    "class": "malformed"
+  },
+  {
+    "name": "bare-break",
+    "hex": "ff",
+    "check": "unexpected-break",
+    "class": "malformed"
+  },
+  {
+    "name": "array-nesting-129-levels",
+    "hex": "818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818180",
+    "check": "depth-exceeded",
+    "class": "malformed"
+  }
+]

--- a/crates/core/kat/vectors/codec/unknown_fields.json
+++ b/crates/core/kat/vectors/codec/unknown_fields.json
@@ -1,0 +1,48 @@
+[
+  {
+    "name": "all-known",
+    "hex": "a2616101616202",
+    "knownKeys": [
+      "a",
+      "b"
+    ],
+    "expectUnknownCount": 0
+  },
+  {
+    "name": "none-known",
+    "hex": "a2616101616202",
+    "knownKeys": [],
+    "expectUnknownCount": 2
+  },
+  {
+    "name": "interleaved-known-unknown",
+    "hex": "a4616101616241ff6261616178627a7af6",
+    "knownKeys": [
+      "a",
+      "aa"
+    ],
+    "expectUnknownCount": 2
+  },
+  {
+    "name": "unknown-value-nested-map",
+    "hex": "a262696407646d657461a261788201026179617a",
+    "knownKeys": [
+      "id"
+    ],
+    "expectUnknownCount": 1
+  },
+  {
+    "name": "unknown-value-nested-array",
+    "hex": "a2616bf5646c69737483018102f6",
+    "knownKeys": [
+      "k"
+    ],
+    "expectUnknownCount": 1
+  },
+  {
+    "name": "empty-map",
+    "hex": "a0",
+    "knownKeys": [],
+    "expectUnknownCount": 0
+  }
+]

--- a/crates/core/src/codec/decode.rs
+++ b/crates/core/src/codec/decode.rs
@@ -1,0 +1,230 @@
+//! The strict decoder. Accepts deterministic-profile CBOR only; every other
+//! well-formed or ill-formed input rejects fail-closed with the named check
+//! (blueprint/core.md "Wire format": one strictness policy, everywhere).
+
+use super::MAX_DEPTH;
+use super::encode::{
+    MAJOR_ARRAY, MAJOR_BYTES, MAJOR_MAP, MAJOR_NEGATIVE, MAJOR_SIMPLE, MAJOR_TEXT, MAJOR_UNSIGNED,
+    SIMPLE_FALSE, SIMPLE_NULL, SIMPLE_TRUE,
+};
+use super::value::{Map, Value, canonical_key_cmp};
+use crate::error::{CodecError, Malformed, TrustViolation};
+
+/// Decode exactly one deterministic-profile item spanning the whole input.
+pub fn decode(bytes: &[u8]) -> Result<Value, CodecError> {
+    let mut d = Decoder::new(bytes);
+    let value = d.read_value(0)?;
+    d.expect_end()?;
+    Ok(value)
+}
+
+pub(super) struct Decoder<'a> {
+    input: &'a [u8],
+    pos: usize,
+}
+
+/// A parsed head: major type, argument value, the raw additional-info bits,
+/// and where the item started. For major 7 the additional info is a selector
+/// (simple value or float width), not an integer argument — dispatch on `ai`.
+pub(super) struct Head {
+    pub major: u8,
+    pub arg: u64,
+    pub ai: u8,
+    pub offset: usize,
+}
+
+impl<'a> Decoder<'a> {
+    pub(super) fn new(input: &'a [u8]) -> Self {
+        Self { input, pos: 0 }
+    }
+
+    pub(super) fn pos(&self) -> usize {
+        self.pos
+    }
+
+    pub(super) fn expect_end(&self) -> Result<(), CodecError> {
+        if self.pos != self.input.len() {
+            return Err(Malformed::TrailingBytes { offset: self.pos }.into());
+        }
+        Ok(())
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], CodecError> {
+        let start = self.pos;
+        let end = start
+            .checked_add(n)
+            .filter(|&e| e <= self.input.len())
+            .ok_or(Malformed::Truncated { offset: start })?;
+        self.pos = end;
+        Ok(&self.input[start..end])
+    }
+
+    fn take_byte(&mut self) -> Result<u8, CodecError> {
+        Ok(self.take(1)?[0])
+    }
+
+    /// Read one head, enforcing shortest-form arguments and rejecting every
+    /// profile-forbidden shape (tags, indefinite lengths, reserved ai).
+    pub(super) fn read_head(&mut self) -> Result<Head, CodecError> {
+        let offset = self.pos;
+        let initial = self.take_byte()?;
+        let major = initial >> 5;
+        let ai = initial & 0x1f;
+
+        // Tags reject on the initial byte, before argument decoding: the
+        // profile admits none, whatever their number's form.
+        if major == 6 {
+            return Err(Malformed::TagForbidden { offset }.into());
+        }
+
+        let arg = match self.read_arg(ai)? {
+            Some(arg) => arg,
+            None => {
+                // ai 28–30 reserved everywhere; 31 is indefinite/break,
+                // legal in no deterministic encoding.
+                return Err(match (major, ai) {
+                    (MAJOR_BYTES | MAJOR_TEXT | MAJOR_ARRAY | MAJOR_MAP, 31) => {
+                        TrustViolation::IndefiniteLength { offset }.into()
+                    }
+                    (MAJOR_SIMPLE, 31) => CodecError::from(Malformed::UnexpectedBreak { offset }),
+                    _ => Malformed::ReservedAdditionalInfo { offset }.into(),
+                });
+            }
+        };
+
+        // Shortest-form enforcement (RFC 8949 §4.2.1). Major 7's ai is a
+        // simple-value selector, not an integer argument — handled by caller.
+        if major != MAJOR_SIMPLE {
+            let minimal = ai < 24
+                || match ai {
+                    24 => arg >= 24,
+                    25 => arg > 0xff,
+                    26 => arg > 0xffff,
+                    27 => arg > 0xffff_ffff,
+                    _ => unreachable!(),
+                };
+            if !minimal {
+                return Err(match major {
+                    MAJOR_UNSIGNED | MAJOR_NEGATIVE => {
+                        TrustViolation::NonCanonicalUint { offset }.into()
+                    }
+                    _ => CodecError::from(TrustViolation::NonCanonicalLength { offset }),
+                });
+            }
+        }
+
+        Ok(Head {
+            major,
+            arg,
+            ai,
+            offset,
+        })
+    }
+
+    /// The argument for an additional-info value; `None` for 28–31.
+    fn read_arg(&mut self, ai: u8) -> Result<Option<u64>, CodecError> {
+        Ok(match ai {
+            0..=23 => Some(u64::from(ai)),
+            24 => Some(u64::from(self.take_byte()?)),
+            25 => Some(u64::from(u16::from_be_bytes(
+                self.take(2)?.try_into().expect("len 2"),
+            ))),
+            26 => Some(u64::from(u32::from_be_bytes(
+                self.take(4)?.try_into().expect("len 4"),
+            ))),
+            27 => Some(u64::from_be_bytes(self.take(8)?.try_into().expect("len 8"))),
+            _ => None,
+        })
+    }
+
+    fn take_len(&mut self, arg: u64, offset: usize) -> Result<&'a [u8], CodecError> {
+        let remaining = (self.input.len() - self.pos) as u64;
+        if arg > remaining {
+            return Err(Malformed::Truncated { offset }.into());
+        }
+        self.take(arg as usize)
+    }
+
+    pub(super) fn read_value(&mut self, depth: usize) -> Result<Value, CodecError> {
+        if depth >= MAX_DEPTH {
+            return Err(Malformed::DepthExceeded { offset: self.pos }.into());
+        }
+        let head = self.read_head()?;
+        match head.major {
+            MAJOR_UNSIGNED => Ok(Value::Unsigned(head.arg)),
+            MAJOR_NEGATIVE => Ok(Value::Negative(head.arg)),
+            MAJOR_BYTES => Ok(Value::Bytes(self.take_len(head.arg, head.offset)?.to_vec())),
+            MAJOR_TEXT => {
+                let raw = self.take_len(head.arg, head.offset)?;
+                let text = core::str::from_utf8(raw).map_err(|_| Malformed::InvalidUtf8 {
+                    offset: head.offset,
+                })?;
+                Ok(Value::Text(text.to_owned()))
+            }
+            MAJOR_ARRAY => {
+                let mut items = Vec::new();
+                for _ in 0..head.arg {
+                    items.push(self.read_value(depth + 1)?);
+                }
+                Ok(Value::Array(items))
+            }
+            MAJOR_MAP => {
+                let mut entries: Vec<(String, Value)> = Vec::new();
+                for _ in 0..head.arg {
+                    let key = self.read_map_key(entries.last().map(|(k, _)| k.as_str()))?;
+                    let value = self.read_value(depth + 1)?;
+                    entries.push((key, value));
+                }
+                // Order and uniqueness were enforced entry-by-entry, so this
+                // rebuild cannot reorder or drop anything.
+                Ok(Value::Map(entries.into_iter().collect::<Map>()))
+            }
+            // Dispatch on the additional info, never the argument: ai 25–27
+            // carry float bit patterns in `arg`, which would otherwise alias
+            // the simple-value space (e.g. a half float 0x0014 vs `false`).
+            MAJOR_SIMPLE => match head.ai {
+                SIMPLE_FALSE => Ok(Value::Bool(false)),
+                SIMPLE_TRUE => Ok(Value::Bool(true)),
+                SIMPLE_NULL => Ok(Value::Null),
+                25..=27 => Err(Malformed::FloatForbidden {
+                    offset: head.offset,
+                }
+                .into()),
+                _ => Err(Malformed::SimpleValueForbidden {
+                    offset: head.offset,
+                }
+                .into()),
+            },
+            _ => unreachable!("major 6 rejected in read_head"),
+        }
+    }
+
+    /// A map key: text-typed, strictly ascending vs. the previous key.
+    pub(super) fn read_map_key(&mut self, prev: Option<&str>) -> Result<String, CodecError> {
+        let offset = self.pos;
+        let head = self.read_head()?;
+        if head.major != MAJOR_TEXT {
+            return Err(Malformed::InvalidMapKeyType { offset }.into());
+        }
+        let raw = self.take_len(head.arg, head.offset)?;
+        let key = core::str::from_utf8(raw).map_err(|_| Malformed::InvalidUtf8 {
+            offset: head.offset,
+        })?;
+        if let Some(prev) = prev {
+            match canonical_key_cmp(prev, key) {
+                core::cmp::Ordering::Less => {}
+                core::cmp::Ordering::Equal => {
+                    return Err(TrustViolation::DuplicateMapKey {
+                        offset,
+                        key: key.to_owned(),
+                    }
+                    .into());
+                }
+                core::cmp::Ordering::Greater => {
+                    return Err(TrustViolation::UnsortedMapKeys { offset }.into());
+                }
+            }
+        }
+        Ok(key.to_owned())
+    }
+}

--- a/crates/core/src/codec/decode.rs
+++ b/crates/core/src/codec/decode.rs
@@ -142,6 +142,8 @@ impl<'a> Decoder<'a> {
         if arg > remaining {
             return Err(Malformed::Truncated { offset }.into());
         }
+        // arg <= remaining <= usize::MAX (a slice length), so the cast is
+        // lossless on every target, including 32-bit wasm.
         self.take(arg as usize)
     }
 

--- a/crates/core/src/codec/encode.rs
+++ b/crates/core/src/codec/encode.rs
@@ -17,13 +17,21 @@ pub(super) const SIMPLE_TRUE: u8 = 21;
 pub(super) const SIMPLE_NULL: u8 = 22;
 
 /// Encode a value in the deterministic profile.
+///
+/// Callers must respect [`super::MAX_DEPTH`]: a deeper `Value` still encodes
+/// (encoding is infallible), but its bytes reject as `depth-exceeded` on
+/// decode — debug builds assert the bound to catch that divergence early.
 pub fn encode(value: &Value) -> Vec<u8> {
     let mut out = Vec::new();
-    write_value(&mut out, value);
+    write_value(&mut out, value, 0);
     out
 }
 
-pub(super) fn write_value(out: &mut Vec<u8>, value: &Value) {
+pub(super) fn write_value(out: &mut Vec<u8>, value: &Value, depth: usize) {
+    debug_assert!(
+        depth < super::MAX_DEPTH,
+        "Value nesting exceeds MAX_DEPTH; the encoding would be undecodable"
+    );
     match value {
         Value::Unsigned(n) => write_head(out, MAJOR_UNSIGNED, *n),
         Value::Negative(n) => write_head(out, MAJOR_NEGATIVE, *n),
@@ -35,10 +43,10 @@ pub(super) fn write_value(out: &mut Vec<u8>, value: &Value) {
         Value::Array(items) => {
             write_head(out, MAJOR_ARRAY, items.len() as u64);
             for item in items {
-                write_value(out, item);
+                write_value(out, item, depth + 1);
             }
         }
-        Value::Map(map) => write_map_head_and_entries(out, map),
+        Value::Map(map) => write_map_head_and_entries(out, map, depth),
         Value::Bool(false) => out.push((MAJOR_SIMPLE << 5) | SIMPLE_FALSE),
         Value::Bool(true) => out.push((MAJOR_SIMPLE << 5) | SIMPLE_TRUE),
         Value::Null => out.push((MAJOR_SIMPLE << 5) | SIMPLE_NULL),
@@ -50,11 +58,11 @@ pub(super) fn write_text(out: &mut Vec<u8>, t: &str) {
     out.extend_from_slice(t.as_bytes());
 }
 
-fn write_map_head_and_entries(out: &mut Vec<u8>, map: &Map) {
+fn write_map_head_and_entries(out: &mut Vec<u8>, map: &Map, depth: usize) {
     write_head(out, MAJOR_MAP, map.len() as u64);
     for (k, v) in map.entries() {
         write_text(out, k);
-        write_value(out, v);
+        write_value(out, v, depth + 1);
     }
 }
 

--- a/crates/core/src/codec/encode.rs
+++ b/crates/core/src/codec/encode.rs
@@ -1,0 +1,84 @@
+//! The deterministic encoder. Canonical by construction: shortest-form
+//! arguments, definite lengths, and [`super::Map`]'s ordering invariant are
+//! the only forms this module can emit, so encoding is infallible.
+
+use super::value::{Map, Value};
+
+pub(super) const MAJOR_UNSIGNED: u8 = 0;
+pub(super) const MAJOR_NEGATIVE: u8 = 1;
+pub(super) const MAJOR_BYTES: u8 = 2;
+pub(super) const MAJOR_TEXT: u8 = 3;
+pub(super) const MAJOR_ARRAY: u8 = 4;
+pub(super) const MAJOR_MAP: u8 = 5;
+pub(super) const MAJOR_SIMPLE: u8 = 7;
+
+pub(super) const SIMPLE_FALSE: u8 = 20;
+pub(super) const SIMPLE_TRUE: u8 = 21;
+pub(super) const SIMPLE_NULL: u8 = 22;
+
+/// Encode a value in the deterministic profile.
+pub fn encode(value: &Value) -> Vec<u8> {
+    let mut out = Vec::new();
+    write_value(&mut out, value);
+    out
+}
+
+pub(super) fn write_value(out: &mut Vec<u8>, value: &Value) {
+    match value {
+        Value::Unsigned(n) => write_head(out, MAJOR_UNSIGNED, *n),
+        Value::Negative(n) => write_head(out, MAJOR_NEGATIVE, *n),
+        Value::Bytes(b) => {
+            write_head(out, MAJOR_BYTES, b.len() as u64);
+            out.extend_from_slice(b);
+        }
+        Value::Text(t) => write_text(out, t),
+        Value::Array(items) => {
+            write_head(out, MAJOR_ARRAY, items.len() as u64);
+            for item in items {
+                write_value(out, item);
+            }
+        }
+        Value::Map(map) => write_map_head_and_entries(out, map),
+        Value::Bool(false) => out.push((MAJOR_SIMPLE << 5) | SIMPLE_FALSE),
+        Value::Bool(true) => out.push((MAJOR_SIMPLE << 5) | SIMPLE_TRUE),
+        Value::Null => out.push((MAJOR_SIMPLE << 5) | SIMPLE_NULL),
+    }
+}
+
+pub(super) fn write_text(out: &mut Vec<u8>, t: &str) {
+    write_head(out, MAJOR_TEXT, t.len() as u64);
+    out.extend_from_slice(t.as_bytes());
+}
+
+fn write_map_head_and_entries(out: &mut Vec<u8>, map: &Map) {
+    write_head(out, MAJOR_MAP, map.len() as u64);
+    for (k, v) in map.entries() {
+        write_text(out, k);
+        write_value(out, v);
+    }
+}
+
+/// Shortest-form head: the argument rides the initial byte below 24, then
+/// the smallest of 1/2/4/8 following bytes that holds it (RFC 8949 §4.2.1).
+pub(super) fn write_head(out: &mut Vec<u8>, major: u8, arg: u64) {
+    let mt = major << 5;
+    match arg {
+        0..=23 => out.push(mt | arg as u8),
+        24..=0xff => {
+            out.push(mt | 24);
+            out.push(arg as u8);
+        }
+        0x100..=0xffff => {
+            out.push(mt | 25);
+            out.extend_from_slice(&(arg as u16).to_be_bytes());
+        }
+        0x1_0000..=0xffff_ffff => {
+            out.push(mt | 26);
+            out.extend_from_slice(&(arg as u32).to_be_bytes());
+        }
+        _ => {
+            out.push(mt | 27);
+            out.extend_from_slice(&arg.to_be_bytes());
+        }
+    }
+}

--- a/crates/core/src/codec/fields.rs
+++ b/crates/core/src/codec/fields.rs
@@ -101,7 +101,8 @@ pub fn encode_map_partial(known: &Map, unknown: &UnknownFields) -> Result<Vec<u8
         if take_known {
             let (key, value) = k.next().expect("peeked");
             write_text(&mut out, key);
-            write_value(&mut out, value);
+            // Depth 1: the emitted map is the enclosing item.
+            write_value(&mut out, value, 1);
         } else {
             let (key, raw) = u.next().expect("peeked");
             write_text(&mut out, key);
@@ -185,5 +186,31 @@ mod tests {
         let bytes = [0xa1, 0x61, b'a', 0x18, 0x01];
         let err = decode_map_partial(&bytes, |_| false).unwrap_err();
         assert_eq!(err.check(), "non-canonical-uint");
+    }
+
+    #[test]
+    fn indefinite_length_inside_unknown_value_rejects() {
+        // {"a": <indefinite array>} — 9f ... ff.
+        let bytes = [0xa1, 0x61, b'a', 0x9f, 0xff];
+        let err = decode_map_partial(&bytes, |_| false).unwrap_err();
+        assert_eq!(err.check(), "indefinite-length");
+    }
+
+    #[test]
+    fn truncated_unknown_value_rejects() {
+        // {"a": <uint head with its argument byte cut off>} — no partial
+        // UnknownFields may escape a failed decode.
+        let bytes = [0xa1, 0x61, b'a', 0x18];
+        let err = decode_map_partial(&bytes, |_| false).unwrap_err();
+        assert_eq!(err.check(), "truncated");
+    }
+
+    #[test]
+    fn trailing_bytes_after_partial_map_reject() {
+        // {"a": 1} followed by a stray byte — expect_end guards the partial
+        // path exactly like the full decode.
+        let bytes = [0xa1, 0x61, b'a', 0x01, 0x00];
+        let err = decode_map_partial(&bytes, |_| true).unwrap_err();
+        assert_eq!(err.check(), "trailing-bytes");
     }
 }

--- a/crates/core/src/codec/fields.rs
+++ b/crates/core/src/codec/fields.rs
@@ -1,0 +1,189 @@
+//! Unknown-field tolerance (blueprint/core.md, #27 D10): the single decode
+//! tolerance in the profile. Fields a schema does not know are accepted,
+//! ignored for logic, preserved byte-stable, and re-emitted canonically on
+//! rewrite — an old client rewriting under shared write never strips newer
+//! fields.
+//!
+//! Because the decoder admits canonical input only, a preserved raw slice is
+//! canonical by construction, so re-emitting it verbatim keeps the whole
+//! rewrite canonical.
+
+use super::decode::Decoder;
+use super::encode::{MAJOR_MAP, write_head, write_text, write_value};
+use super::value::{Map, canonical_key_cmp};
+use crate::error::{CodecError, Malformed};
+
+/// Fields preserved through a decode the caller's schema did not recognize:
+/// key plus the exact canonical bytes of the value. Ordered canonically.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct UnknownFields {
+    entries: Vec<(String, Vec<u8>)>,
+}
+
+impl UnknownFields {
+    /// Preserved entries in canonical key order.
+    pub fn entries(&self) -> &[(String, Vec<u8>)] {
+        &self.entries
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Decode a top-level map, splitting entries into known fields (decoded
+/// values, selected by `is_known`) and unknown fields (raw canonical bytes).
+/// Every entry — known or not — passes the full strict profile.
+pub fn decode_map_partial(
+    bytes: &[u8],
+    is_known: impl Fn(&str) -> bool,
+) -> Result<(Map, UnknownFields), CodecError> {
+    let mut d = Decoder::new(bytes);
+    let head = d.read_head()?;
+    if head.major != MAJOR_MAP {
+        return Err(Malformed::UnexpectedType {
+            expected: "map",
+            found: "non-map item",
+        }
+        .into());
+    }
+
+    let mut known = Vec::new();
+    let mut unknown = Vec::new();
+    let mut prev: Option<String> = None;
+    for _ in 0..head.arg {
+        let key = d.read_map_key(prev.as_deref())?;
+        let start = d.pos();
+        // Depth 1: the top-level map is the enclosing item.
+        let value = d.read_value(1)?;
+        if is_known(&key) {
+            known.push((key.clone(), value));
+        } else {
+            unknown.push((key.clone(), bytes[start..d.pos()].to_vec()));
+        }
+        prev = Some(key);
+    }
+    d.expect_end()?;
+    Ok((
+        known.into_iter().collect(),
+        UnknownFields { entries: unknown },
+    ))
+}
+
+/// Canonically re-encode a map from re-built known fields plus preserved
+/// unknown fields: one merged map in canonical key order, unknown values
+/// emitted byte-stable. A key present on both sides is a caller bug and
+/// rejects fail-closed.
+pub fn encode_map_partial(known: &Map, unknown: &UnknownFields) -> Result<Vec<u8>, CodecError> {
+    let mut out = Vec::new();
+    let total = known.len() + unknown.len();
+    write_head(&mut out, MAJOR_MAP, total as u64);
+
+    let mut k = known.entries().iter().peekable();
+    let mut u = unknown.entries.iter().peekable();
+    loop {
+        let take_known = match (k.peek(), u.peek()) {
+            (Some((kk, _)), Some((uk, _))) => match canonical_key_cmp(kk, uk) {
+                core::cmp::Ordering::Less => true,
+                core::cmp::Ordering::Greater => false,
+                core::cmp::Ordering::Equal => {
+                    return Err(Malformed::UnknownFieldCollision { key: kk.clone() }.into());
+                }
+            },
+            (Some(_), None) => true,
+            (None, Some(_)) => false,
+            (None, None) => break,
+        };
+        if take_known {
+            let (key, value) = k.next().expect("peeked");
+            write_text(&mut out, key);
+            write_value(&mut out, value);
+        } else {
+            let (key, raw) = u.next().expect("peeked");
+            write_text(&mut out, key);
+            out.extend_from_slice(raw);
+        }
+    }
+    Ok(out)
+}
+
+/// Convenience for schema codecs: `true` when `key` is in `known`.
+pub fn known_key_set(known: &'static [&'static str]) -> impl Fn(&str) -> bool {
+    move |key| known.contains(&key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::{Value, decode, encode};
+
+    fn sample_map() -> Map {
+        let mut m = Map::new();
+        m.insert("v", Value::Unsigned(2));
+        m.insert("id", Value::Bytes(vec![0xaa; 4]));
+        m.insert(
+            "future",
+            Value::Array(vec![Value::Unsigned(1), Value::Null]),
+        );
+        m.insert("zz-later", Value::Text("kept".into()));
+        m
+    }
+
+    #[test]
+    fn unknown_fields_round_trip_byte_stable() {
+        let original = encode(&Value::Map(sample_map()));
+        let (known, unknown) = decode_map_partial(&original, known_key_set(&["v", "id"])).unwrap();
+        assert_eq!(known.len(), 2);
+        assert_eq!(unknown.len(), 2);
+        let reencoded = encode_map_partial(&known, &unknown).unwrap();
+        assert_eq!(reencoded, original, "rewrite must be byte-stable");
+    }
+
+    #[test]
+    fn rewrite_of_known_field_keeps_unknowns_and_canonical_order() {
+        let original = encode(&Value::Map(sample_map()));
+        let (mut known, unknown) =
+            decode_map_partial(&original, known_key_set(&["v", "id"])).unwrap();
+        known.insert("v", Value::Unsigned(3));
+        let rewritten = encode_map_partial(&known, &unknown).unwrap();
+
+        let mut expected = sample_map();
+        expected.insert("v", Value::Unsigned(3));
+        assert_eq!(rewritten, encode(&Value::Map(expected)));
+        // Still strict-profile decodable with everything present.
+        let full = decode(&rewritten).unwrap();
+        let m = full.as_map().unwrap();
+        assert_eq!(m.get("v"), Some(&Value::Unsigned(3)));
+        assert!(m.contains_key("future"));
+        assert!(m.contains_key("zz-later"));
+    }
+
+    #[test]
+    fn collision_between_known_and_unknown_rejects() {
+        let original = encode(&Value::Map(sample_map()));
+        let (mut known, unknown) =
+            decode_map_partial(&original, known_key_set(&["v", "id"])).unwrap();
+        known.insert("future", Value::Unsigned(0));
+        let err = encode_map_partial(&known, &unknown).unwrap_err();
+        assert_eq!(err.check(), "unknown-field-collision");
+    }
+
+    #[test]
+    fn non_map_top_level_rejects() {
+        let bytes = encode(&Value::Unsigned(1));
+        let err = decode_map_partial(&bytes, |_| true).unwrap_err();
+        assert_eq!(err.check(), "unexpected-type");
+    }
+
+    #[test]
+    fn strictness_applies_inside_unknown_values() {
+        // {"a": <non-shortest-form 1>} — the unknown value must still reject.
+        let bytes = [0xa1, 0x61, b'a', 0x18, 0x01];
+        let err = decode_map_partial(&bytes, |_| false).unwrap_err();
+        assert_eq!(err.check(), "non-canonical-uint");
+    }
+}

--- a/crates/core/src/codec/mod.rs
+++ b/crates/core/src/codec/mod.rs
@@ -1,0 +1,28 @@
+//! The deterministic CBOR profile (blueprint/core.md "Wire format").
+//!
+//! One strictness policy, everywhere: encoders emit RFC 8949 §4.2.1
+//! deterministic form only, and [`decode`] accepts exactly that form —
+//! duplicate map keys, non-canonical integer/length encodings, indefinite
+//! lengths, tags, floats, and non-text map keys all reject fail-closed with
+//! the named check that fired. The single tolerance is unknown fields, via
+//! [`decode_map_partial`] / [`encode_map_partial`].
+//!
+//! The profile is a strict subset of DAG-CBOR, so every encoding this module
+//! emits is a valid DAG-CBOR block. (With text-only map keys, RFC 8949's
+//! bytewise key order and DAG-CBOR's length-first order coincide — pinned by
+//! test.) Envelope, body, and structure schema codecs build on this module in
+//! later slices; nothing outside it touches raw CBOR.
+
+mod decode;
+mod encode;
+mod fields;
+mod value;
+
+pub use decode::decode;
+pub use encode::encode;
+pub use fields::{UnknownFields, decode_map_partial, encode_map_partial, known_key_set};
+pub use value::{Map, Value, canonical_key_cmp};
+
+/// Maximum nesting depth the decoder admits. A profile constant: deeper input
+/// rejects as `depth-exceeded` (fail-closed, and bounds recursion).
+pub const MAX_DEPTH: usize = 128;

--- a/crates/core/src/codec/value.rs
+++ b/crates/core/src/codec/value.rs
@@ -1,0 +1,325 @@
+//! The det-CBOR data model.
+//!
+//! The profile is a strict subset of DAG-CBOR: definite lengths only,
+//! text-string map keys only, no tags, no floats, no simple values beyond
+//! `false`/`true`/`null`. Integers cover the full CBOR range (major 0/1);
+//! [`Value::Negative(n)`] represents `-1 - n`.
+
+use core::cmp::Ordering;
+use core::fmt;
+
+use crate::error::Malformed;
+
+/// A value in the deterministic profile's data model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Value {
+    /// Major type 0: `0 ..= u64::MAX`.
+    Unsigned(u64),
+    /// Major type 1: represents `-1 - n`, so the full range down to `-2^64`.
+    Negative(u64),
+    /// Major type 2: a definite-length byte string.
+    Bytes(Vec<u8>),
+    /// Major type 3: a definite-length UTF-8 text string.
+    Text(String),
+    /// Major type 4: a definite-length array.
+    Array(Vec<Value>),
+    /// Major type 5: a map with unique text keys in canonical order.
+    Map(Map),
+    /// Major type 7, simple values 20/21.
+    Bool(bool),
+    /// Major type 7, simple value 22.
+    Null,
+}
+
+impl Value {
+    /// The type label used in [`Malformed::UnexpectedType`] diagnostics.
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Self::Unsigned(_) => "unsigned",
+            Self::Negative(_) => "negative",
+            Self::Bytes(_) => "bytes",
+            Self::Text(_) => "text",
+            Self::Array(_) => "array",
+            Self::Map(_) => "map",
+            Self::Bool(_) => "bool",
+            Self::Null => "null",
+        }
+    }
+
+    /// The value as a `u64`, or an [`Malformed::UnexpectedType`] naming what
+    /// was found.
+    pub fn as_unsigned(&self) -> Result<u64, Malformed> {
+        match self {
+            Self::Unsigned(n) => Ok(*n),
+            other => Err(unexpected("unsigned", other)),
+        }
+    }
+
+    /// The value as bytes.
+    pub fn as_bytes(&self) -> Result<&[u8], Malformed> {
+        match self {
+            Self::Bytes(b) => Ok(b),
+            other => Err(unexpected("bytes", other)),
+        }
+    }
+
+    /// The value as text.
+    pub fn as_text(&self) -> Result<&str, Malformed> {
+        match self {
+            Self::Text(t) => Ok(t),
+            other => Err(unexpected("text", other)),
+        }
+    }
+
+    /// The value as an array.
+    pub fn as_array(&self) -> Result<&[Value], Malformed> {
+        match self {
+            Self::Array(a) => Ok(a),
+            other => Err(unexpected("array", other)),
+        }
+    }
+
+    /// The value as a map.
+    pub fn as_map(&self) -> Result<&Map, Malformed> {
+        match self {
+            Self::Map(m) => Ok(m),
+            other => Err(unexpected("map", other)),
+        }
+    }
+
+    /// The value as a bool.
+    pub fn as_bool(&self) -> Result<bool, Malformed> {
+        match self {
+            Self::Bool(b) => Ok(*b),
+            other => Err(unexpected("bool", other)),
+        }
+    }
+
+    /// The value as a signed integer, when it fits `i64`.
+    pub fn as_i64(&self) -> Result<i64, Malformed> {
+        match self {
+            Self::Unsigned(n) => i64::try_from(*n).map_err(|_| unexpected("i64", self)),
+            Self::Negative(n) => {
+                let m = i128::from(*n);
+                i64::try_from(-1 - m).map_err(|_| unexpected("i64", self))
+            }
+            other => Err(unexpected("i64", other)),
+        }
+    }
+
+    /// A `Value` from any `i64`.
+    pub fn from_i64(n: i64) -> Self {
+        if n >= 0 {
+            Self::Unsigned(n as u64)
+        } else {
+            Self::Negative(!(n as u64))
+        }
+    }
+}
+
+fn unexpected(expected: &'static str, found: &Value) -> Malformed {
+    Malformed::UnexpectedType {
+        expected,
+        found: found.type_name(),
+    }
+}
+
+/// The canonical map-key ordering: RFC 8949 §4.2.1 bytewise-lexicographic
+/// comparison of the encoded keys. With text-only keys this is exactly
+/// length-first, then bytewise — asserted by test, relied on by the encoder.
+pub fn canonical_key_cmp(a: &str, b: &str) -> Ordering {
+    a.len()
+        .cmp(&b.len())
+        .then_with(|| a.as_bytes().cmp(b.as_bytes()))
+}
+
+/// A map whose entries are always unique-keyed and canonically ordered.
+/// Building one cannot produce a non-canonical encoding.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Map {
+    entries: Vec<(String, Value)>,
+}
+
+impl Map {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace, keeping canonical order. Returns the value a
+    /// replaced entry held.
+    pub fn insert(&mut self, key: impl Into<String>, value: Value) -> Option<Value> {
+        let key = key.into();
+        match self
+            .entries
+            .binary_search_by(|(k, _)| canonical_key_cmp(k, &key))
+        {
+            Ok(i) => Some(core::mem::replace(&mut self.entries[i].1, value)),
+            Err(i) => {
+                self.entries.insert(i, (key, value));
+                None
+            }
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.entries
+            .binary_search_by(|(k, _)| canonical_key_cmp(k, key))
+            .ok()
+            .map(|i| &self.entries[i].1)
+    }
+
+    pub fn remove(&mut self, key: &str) -> Option<Value> {
+        self.entries
+            .binary_search_by(|(k, _)| canonical_key_cmp(k, key))
+            .ok()
+            .map(|i| self.entries.remove(i).1)
+    }
+
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.get(key).is_some()
+    }
+
+    /// Entries in canonical order.
+    pub fn entries(&self) -> &[(String, Value)] {
+        &self.entries
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl FromIterator<(String, Value)> for Map {
+    /// Later duplicates replace earlier ones, like `BTreeMap`.
+    fn from_iter<I: IntoIterator<Item = (String, Value)>>(iter: I) -> Self {
+        let mut map = Map::new();
+        for (k, v) in iter {
+            map.insert(k, v);
+        }
+        map
+    }
+}
+
+impl fmt::Display for Value {
+    /// CBOR diagnostic notation (RFC 8949 §8), restricted to the profile's
+    /// data model. KAT accept vectors pin this rendering via their `diag`
+    /// field.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unsigned(n) => write!(f, "{n}"),
+            Self::Negative(n) => write!(f, "{}", -1 - i128::from(*n)),
+            Self::Bytes(b) => {
+                write!(f, "h'")?;
+                for byte in b {
+                    write!(f, "{byte:02x}")?;
+                }
+                write!(f, "'")
+            }
+            Self::Text(t) => write_diag_text(f, t),
+            Self::Array(items) => {
+                write!(f, "[")?;
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{item}")?;
+                }
+                write!(f, "]")
+            }
+            Self::Map(map) => {
+                write!(f, "{{")?;
+                for (i, (k, v)) in map.entries().iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write_diag_text(f, k)?;
+                    write!(f, ": {v}")?;
+                }
+                write!(f, "}}")
+            }
+            Self::Bool(true) => write!(f, "true"),
+            Self::Bool(false) => write!(f, "false"),
+            Self::Null => write!(f, "null"),
+        }
+    }
+}
+
+fn write_diag_text(f: &mut fmt::Formatter<'_>, s: &str) -> fmt::Result {
+    write!(f, "\"")?;
+    for c in s.chars() {
+        match c {
+            '"' => write!(f, "\\\"")?,
+            '\\' => write!(f, "\\\\")?,
+            '\n' => write!(f, "\\n")?,
+            '\r' => write!(f, "\\r")?,
+            '\t' => write!(f, "\\t")?,
+            c if (c as u32) < 0x20 => write!(f, "\\u{:04x}", c as u32)?,
+            c => write!(f, "{c}")?,
+        }
+    }
+    write!(f, "\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The (len, bytes) shortcut must agree with RFC 8949's bytewise
+    /// comparison of encoded keys across every header-size class.
+    #[test]
+    fn canonical_key_cmp_matches_encoded_bytewise_order() {
+        let keys = [
+            String::new(),
+            "a".to_string(),
+            "b".to_string(),
+            "a".repeat(23),
+            "a".repeat(24),
+            "z".repeat(24),
+            "a".repeat(255),
+            "a".repeat(256),
+            "a".repeat(65535),
+            "a".repeat(65536),
+        ];
+        for x in &keys {
+            for y in &keys {
+                let enc_x = crate::codec::encode(&Value::Text(x.clone()));
+                let enc_y = crate::codec::encode(&Value::Text(y.clone()));
+                assert_eq!(
+                    canonical_key_cmp(x, y),
+                    enc_x.cmp(&enc_y),
+                    "diverged on lens {} vs {}",
+                    x.len(),
+                    y.len()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn map_insert_keeps_canonical_order_and_replaces() {
+        let mut m = Map::new();
+        m.insert("bb", Value::Unsigned(1));
+        m.insert("a", Value::Unsigned(2));
+        m.insert("ca", Value::Unsigned(3));
+        m.insert("bb", Value::Unsigned(9));
+        let keys: Vec<&str> = m.entries().iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(keys, ["a", "bb", "ca"]);
+        assert_eq!(m.get("bb"), Some(&Value::Unsigned(9)));
+    }
+
+    #[test]
+    fn i64_round_trip() {
+        for n in [i64::MIN, -1, 0, 1, i64::MAX] {
+            assert_eq!(Value::from_i64(n).as_i64().unwrap(), n);
+        }
+        assert!(Value::Negative(u64::MAX).as_i64().is_err());
+        assert_eq!(
+            Value::Negative(u64::MAX).to_string(),
+            "-18446744073709551616"
+        );
+    }
+}

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -81,13 +81,30 @@ impl fmt::Display for TrustViolation {
             self.offset()
         )?;
         if let Self::DuplicateMapKey { key, .. } = self {
-            write!(f, " (key {key:?})")?;
+            write!(f, " (key {:?})", DisplayKey(key))?;
         }
         Ok(())
     }
 }
 
 impl std::error::Error for TrustViolation {}
+
+/// Map keys rendered into error messages are writer-controlled content —
+/// post-unseal they are sealed-body plaintext. `{:?}` escaping neutralizes
+/// log injection; this cap bounds how much plaintext a crafted key can push
+/// into upstream logs. Full redaction policy belongs to the engine.
+const DISPLAY_KEY_MAX_CHARS: usize = 64;
+
+struct DisplayKey<'a>(&'a str);
+
+impl fmt::Debug for DisplayKey<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0.char_indices().nth(DISPLAY_KEY_MAX_CHARS) {
+            Some((cut, _)) => write!(f, "{:?}…", &self.0[..cut]),
+            None => write!(f, "{:?}", self.0),
+        }
+    }
+}
 
 /// Structurally invalid or profile-unsupported input. Not evidence of
 /// tampering; never accepted either.
@@ -179,7 +196,9 @@ impl fmt::Display for Malformed {
             Self::UnexpectedType { expected, found } => {
                 write!(f, " (expected {expected}, found {found})")
             }
-            Self::UnknownFieldCollision { key } => write!(f, " (key {key:?})"),
+            Self::UnknownFieldCollision { key } => {
+                write!(f, " (key {:?})", DisplayKey(key))
+            }
         }
     }
 }
@@ -244,6 +263,23 @@ impl std::error::Error for CodecError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn display_bounds_writer_controlled_keys() {
+        let err = TrustViolation::DuplicateMapKey {
+            offset: 0,
+            key: "k".repeat(200),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains('…'), "long keys must render truncated");
+        assert!(
+            msg.len() < 160,
+            "a crafted key must not flood the message: {msg}"
+        );
+        // Short keys render in full.
+        let short = Malformed::UnknownFieldCollision { key: "v".into() };
+        assert!(short.to_string().contains("\"v\""));
+    }
 
     #[test]
     fn check_names_are_unique_across_both_classes() {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,0 +1,251 @@
+//! The two-class error surface (blueprint/core.md "Error surface").
+//!
+//! Two classes, disjoint types, no reused codes: [`TrustViolation`] for
+//! failures the engine treats fail-closed (canonicality, uniqueness — and in
+//! later slices signature, commitment, AAD), and [`Malformed`] for
+//! structurally invalid or unsupported input. Every rejection names the check
+//! that fired via [`TrustViolation::check`] / [`Malformed::check`]; the check
+//! names are part of the frozen contract and are pinned by the KAT reject
+//! vectors.
+
+use core::fmt;
+
+/// A fail-closed trust violation: the input is well-formed enough to prove a
+/// writer did not follow the deterministic profile (or, in later slices,
+/// failed a cryptographic check). Never mere staleness, never retried.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrustViolation {
+    /// An integer (major type 0/1) used a longer encoding than the shortest
+    /// form the deterministic profile requires.
+    NonCanonicalUint { offset: usize },
+    /// A string/array/map length argument used a longer encoding than the
+    /// shortest form.
+    NonCanonicalLength { offset: usize },
+    /// An indefinite-length string, array, or map.
+    IndefiniteLength { offset: usize },
+    /// Map keys not in strictly ascending canonical order (RFC 8949 §4.2.1
+    /// bytewise lexicographic over the encoded keys).
+    UnsortedMapKeys { offset: usize },
+    /// The same key encoded twice in one map.
+    DuplicateMapKey { offset: usize, key: String },
+}
+
+impl TrustViolation {
+    /// Every trust-violation check name this crate can emit. The KAT manifest
+    /// asserts reject-vector coverage against this list.
+    pub const CHECKS: &'static [&'static str] = &[
+        "non-canonical-uint",
+        "non-canonical-length",
+        "indefinite-length",
+        "unsorted-map-keys",
+        "duplicate-map-key",
+    ];
+
+    /// The stable name of the check that fired.
+    pub fn check(&self) -> &'static str {
+        match self {
+            Self::NonCanonicalUint { .. } => "non-canonical-uint",
+            Self::NonCanonicalLength { .. } => "non-canonical-length",
+            Self::IndefiniteLength { .. } => "indefinite-length",
+            Self::UnsortedMapKeys { .. } => "unsorted-map-keys",
+            Self::DuplicateMapKey { .. } => "duplicate-map-key",
+        }
+    }
+
+    fn offset(&self) -> usize {
+        match self {
+            Self::NonCanonicalUint { offset }
+            | Self::NonCanonicalLength { offset }
+            | Self::IndefiniteLength { offset }
+            | Self::UnsortedMapKeys { offset }
+            | Self::DuplicateMapKey { offset, .. } => *offset,
+        }
+    }
+}
+
+impl fmt::Display for TrustViolation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "trust violation [{}] at byte {}",
+            self.check(),
+            self.offset()
+        )?;
+        if let Self::DuplicateMapKey { key, .. } = self {
+            write!(f, " (key {key:?})")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for TrustViolation {}
+
+/// Structurally invalid or profile-unsupported input. Not evidence of
+/// tampering; never accepted either.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Malformed {
+    /// Input ended before the item it promised.
+    Truncated { offset: usize },
+    /// Bytes remained after the single top-level item.
+    TrailingBytes { offset: usize },
+    /// A text string that is not valid UTF-8.
+    InvalidUtf8 { offset: usize },
+    /// A map key that is not a text string.
+    InvalidMapKeyType { offset: usize },
+    /// Any CBOR tag; the profile admits none.
+    TagForbidden { offset: usize },
+    /// Any floating-point item; the profile admits none.
+    FloatForbidden { offset: usize },
+    /// A simple value other than `false`/`true`/`null` (incl. `undefined`).
+    SimpleValueForbidden { offset: usize },
+    /// Reserved additional-information values (28–30, or 31 where the spec
+    /// forbids it).
+    ReservedAdditionalInfo { offset: usize },
+    /// A break stop code (0xff) outside any indefinite-length item.
+    UnexpectedBreak { offset: usize },
+    /// Nesting beyond [`crate::codec::MAX_DEPTH`].
+    DepthExceeded { offset: usize },
+    /// A decoded value had a different type than the caller required
+    /// (schema-layer accessor failure).
+    UnexpectedType {
+        expected: &'static str,
+        found: &'static str,
+    },
+    /// A rewrite supplied a known field that collides with a preserved
+    /// unknown field of the same key (caller bug; rejected fail-closed).
+    UnknownFieldCollision { key: String },
+}
+
+impl Malformed {
+    /// Every malformed check name this crate can emit. Decode-reachable ones
+    /// are pinned by KAT reject vectors; the rest by unit tests.
+    pub const CHECKS: &'static [&'static str] = &[
+        "truncated",
+        "trailing-bytes",
+        "invalid-utf8",
+        "invalid-map-key-type",
+        "tag-forbidden",
+        "float-forbidden",
+        "simple-value-forbidden",
+        "reserved-additional-info",
+        "unexpected-break",
+        "depth-exceeded",
+        "unexpected-type",
+        "unknown-field-collision",
+    ];
+
+    /// The stable name of the check that fired.
+    pub fn check(&self) -> &'static str {
+        match self {
+            Self::Truncated { .. } => "truncated",
+            Self::TrailingBytes { .. } => "trailing-bytes",
+            Self::InvalidUtf8 { .. } => "invalid-utf8",
+            Self::InvalidMapKeyType { .. } => "invalid-map-key-type",
+            Self::TagForbidden { .. } => "tag-forbidden",
+            Self::FloatForbidden { .. } => "float-forbidden",
+            Self::SimpleValueForbidden { .. } => "simple-value-forbidden",
+            Self::ReservedAdditionalInfo { .. } => "reserved-additional-info",
+            Self::UnexpectedBreak { .. } => "unexpected-break",
+            Self::DepthExceeded { .. } => "depth-exceeded",
+            Self::UnexpectedType { .. } => "unexpected-type",
+            Self::UnknownFieldCollision { .. } => "unknown-field-collision",
+        }
+    }
+}
+
+impl fmt::Display for Malformed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "malformed [{}]", self.check())?;
+        match self {
+            Self::Truncated { offset }
+            | Self::TrailingBytes { offset }
+            | Self::InvalidUtf8 { offset }
+            | Self::InvalidMapKeyType { offset }
+            | Self::TagForbidden { offset }
+            | Self::FloatForbidden { offset }
+            | Self::SimpleValueForbidden { offset }
+            | Self::ReservedAdditionalInfo { offset }
+            | Self::UnexpectedBreak { offset }
+            | Self::DepthExceeded { offset } => write!(f, " at byte {offset}"),
+            Self::UnexpectedType { expected, found } => {
+                write!(f, " (expected {expected}, found {found})")
+            }
+            Self::UnknownFieldCollision { key } => write!(f, " (key {key:?})"),
+        }
+    }
+}
+
+impl std::error::Error for Malformed {}
+
+/// A codec failure: exactly one of the two disjoint classes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CodecError {
+    Trust(TrustViolation),
+    Malformed(Malformed),
+}
+
+impl CodecError {
+    /// The stable name of the check that fired.
+    pub fn check(&self) -> &'static str {
+        match self {
+            Self::Trust(e) => e.check(),
+            Self::Malformed(e) => e.check(),
+        }
+    }
+
+    /// `"trust"` or `"malformed"` — the class label used in reject vectors.
+    pub fn class(&self) -> &'static str {
+        match self {
+            Self::Trust(_) => "trust",
+            Self::Malformed(_) => "malformed",
+        }
+    }
+}
+
+impl From<TrustViolation> for CodecError {
+    fn from(e: TrustViolation) -> Self {
+        Self::Trust(e)
+    }
+}
+
+impl From<Malformed> for CodecError {
+    fn from(e: Malformed) -> Self {
+        Self::Malformed(e)
+    }
+}
+
+impl fmt::Display for CodecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Trust(e) => e.fmt(f),
+            Self::Malformed(e) => e.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for CodecError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Trust(e) => Some(e),
+            Self::Malformed(e) => Some(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_names_are_unique_across_both_classes() {
+        let mut all: Vec<&str> = TrustViolation::CHECKS
+            .iter()
+            .chain(Malformed::CHECKS)
+            .copied()
+            .collect();
+        let n = all.len();
+        all.sort_unstable();
+        all.dedup();
+        assert_eq!(all.len(), n, "check names must never be reused");
+    }
+}

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -13,6 +13,15 @@ use core::fmt;
 /// A fail-closed trust violation: the input is well-formed enough to prove a
 /// writer did not follow the deterministic profile (or, in later slices,
 /// failed a cryptographic check). Never mere staleness, never retried.
+///
+/// The codec-layer boundary between the classes, frozen by the KAT reject
+/// vectors: a violation is *trust* when a canonical encoding of the same data
+/// exists and the writer emitted a different one (non-shortest forms,
+/// indefinite lengths, unsorted or duplicate keys) — the signature of a
+/// tampering or non-conforming re-encode. Shapes the profile has no
+/// representation for at all (tags, floats, extra simple values, non-text
+/// keys) are [`Malformed`]: foreign data, not a non-canonical form of valid
+/// data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TrustViolation {
     /// An integer (major type 0/1) used a longer encoding than the shortest

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,13 +5,5 @@
 
 #![forbid(unsafe_code)]
 
-/// Placeholder identity item; real wire formats and crypto land in later PRs.
-pub const CRATE: &str = "cipherbox-core";
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn crate_name() {
-        assert_eq!(super::CRATE, "cipherbox-core");
-    }
-}
+pub mod codec;
+pub mod error;

--- a/crates/core/tests/codec_props.rs
+++ b/crates/core/tests/codec_props.rs
@@ -1,0 +1,217 @@
+//! Property layer over the det-CBOR codec (blueprint/testing.md
+//! "crates/core — KATs and property tests"): encode∘decode identity
+//! including the unknown-field byte-stable round-trip, canonicality
+//! rejection via the defect encoder in `common`, and the strict key
+//! comparator's total-order laws. Case counts are bounded for CI speed;
+//! failing seeds persist as regression vectors natively (persistence is
+//! off under wasm, where the source tree may not be writable).
+
+mod common;
+
+use core::cmp::Ordering;
+use std::collections::HashMap;
+
+use cipherbox_core::codec::{
+    Map, Value, canonical_key_cmp, decode, decode_map_partial, encode, encode_map_partial,
+};
+use proptest::prelude::*;
+
+#[cfg(not(target_family = "wasm"))]
+fn config() -> ProptestConfig {
+    ProptestConfig::default()
+}
+
+#[cfg(target_family = "wasm")]
+fn config() -> ProptestConfig {
+    ProptestConfig {
+        // Bounded hard for the wasm32-wasip1 CI lane.
+        cases: 16,
+        // Writing regression files may not work under wasm.
+        failure_persistence: None,
+        ..ProptestConfig::default()
+    }
+}
+
+/// Bounded text including non-ASCII: `\PC` is any non-control char.
+fn arb_text() -> impl Strategy<Value = String> {
+    prop::string::string_regex("\\PC{0,12}").expect("valid regex")
+}
+
+/// Map keys: shorter, still non-ASCII-capable.
+fn arb_key() -> impl Strategy<Value = String> {
+    prop::string::string_regex("\\PC{0,6}").expect("valid regex")
+}
+
+/// The full profile data model, depth ≤ 4 and breadth ≤ 5 (CI-bounded).
+/// Maps are built through `Map`'s inserting collector, which dedups and
+/// canonically orders keys by construction.
+fn arb_value() -> impl Strategy<Value = Value> {
+    let leaf = prop_oneof![
+        any::<u64>().prop_map(Value::Unsigned),
+        any::<u64>().prop_map(Value::Negative),
+        prop::collection::vec(any::<u8>(), 0..24).prop_map(Value::Bytes),
+        arb_text().prop_map(Value::Text),
+        any::<bool>().prop_map(Value::Bool),
+        Just(Value::Null),
+    ];
+    leaf.prop_recursive(4, 24, 5, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..=5).prop_map(Value::Array),
+            prop::collection::vec((arb_key(), inner), 0..=5)
+                .prop_map(|kvs| Value::Map(kvs.into_iter().collect())),
+        ]
+    })
+}
+
+/// Map entries plus a per-key known/unknown flag (later duplicates win on
+/// both sides, mirroring `Map::insert`), so `decode_map_partial` sees a
+/// well-defined `is_known` and both sides of the split get exercised.
+type FlaggedEntries = Vec<(String, Value, bool)>;
+
+fn arb_flagged_entries(min: usize) -> impl Strategy<Value = FlaggedEntries> {
+    prop::collection::vec((arb_key(), arb_value(), any::<bool>()), min..=6)
+}
+
+fn build_map_and_flags(entries: &FlaggedEntries) -> (Map, HashMap<String, bool>) {
+    let mut map = Map::new();
+    let mut flags = HashMap::new();
+    for (k, v, known) in entries {
+        map.insert(k.clone(), v.clone());
+        flags.insert(k.clone(), *known);
+    }
+    (map, flags)
+}
+
+proptest! {
+    #![proptest_config(config())]
+
+    /// (a) decode is a left inverse of encode, and re-encoding the decode
+    /// is byte-identical (canonical form is a fixed point).
+    #[test]
+    fn round_trip(v in arb_value()) {
+        let bytes = encode(&v);
+        let decoded = decode(&bytes).expect("own encoding must decode");
+        prop_assert_eq!(&decoded, &v);
+        prop_assert_eq!(encode(&decoded), bytes);
+    }
+
+    /// (b) unknown-field tolerance is byte-stable: split a map into known
+    /// and unknown by an arbitrary per-key assignment, re-emit unmodified,
+    /// and the bytes are identical to the direct encoding.
+    #[test]
+    fn unknown_field_round_trip(entries in arb_flagged_entries(0)) {
+        let (map, flags) = build_map_and_flags(&entries);
+        let bytes = encode(&Value::Map(map.clone()));
+        let (known, unknown) =
+            decode_map_partial(&bytes, |k| flags.get(k).copied().unwrap_or(false))
+                .expect("canonical map must decode");
+        prop_assert_eq!(known.len() + unknown.len(), map.len());
+        for (k, _) in known.entries() {
+            prop_assert!(flags[k], "known side holds an unknown key {:?}", k);
+        }
+        for (k, _) in unknown.entries() {
+            prop_assert!(!flags[k], "unknown side holds a known key {:?}", k);
+        }
+        let reencoded = encode_map_partial(&known, &unknown).expect("no collisions by construction");
+        prop_assert_eq!(reencoded, bytes);
+    }
+
+    /// (c) a rewrite through the partial codec re-encodes canonically:
+    /// replacing one known field's value yields exactly the bytes of the
+    /// fully-modified map encoded directly.
+    #[test]
+    fn rewrite_reencodes_canonically(
+        entries in arb_flagged_entries(1),
+        idx in any::<prop::sample::Index>(),
+        replacement in arb_value(),
+    ) {
+        let target_key = entries[idx.index(entries.len())].0.clone();
+        let (map, mut flags) = build_map_and_flags(&entries);
+        // The rewritten key must be on the known side.
+        flags.insert(target_key.clone(), true);
+
+        let bytes = encode(&Value::Map(map.clone()));
+        let (mut known, unknown) =
+            decode_map_partial(&bytes, |k| flags.get(k).copied().unwrap_or(false))
+                .expect("canonical map must decode");
+        known.insert(target_key.clone(), replacement.clone());
+        let rewritten = encode_map_partial(&known, &unknown).expect("no collisions by construction");
+
+        let mut full = map;
+        full.insert(target_key, replacement);
+        prop_assert_eq!(rewritten, encode(&Value::Map(full)));
+    }
+
+    /// (d) every single-defect mutation of a canonical encoding rejects
+    /// with exactly the named check, whatever the payload.
+    #[test]
+    fn canonicality_rejection(
+        v in arb_value(),
+        v2 in arb_value(),
+        k1 in arb_key(),
+        k2 in arb_key(),
+    ) {
+        prop_assume!(k1 != k2);
+        let (lo, hi) = match canonical_key_cmp(&k1, &k2) {
+            Ordering::Less => (&k1, &k2),
+            _ => (&k2, &k1),
+        };
+        let cases = [
+            common::widen_head(&v),
+            common::widen_length(&v),
+            common::indefinite_array(&v),
+            common::swap_map_keys(lo, hi, &v, &v2),
+            common::duplicate_key(&k1, &v, &v2),
+            common::wrap_tag(&v),
+            common::inject_float(&v),
+            common::trailing_junk(&v),
+            common::truncate(&v),
+        ];
+        for (bytes, expected) in cases {
+            match decode(&bytes) {
+                Ok(value) => prop_assert!(
+                    false,
+                    "defect {} was accepted as {} (bytes {:02x?})",
+                    expected, value, bytes
+                ),
+                Err(err) => prop_assert_eq!(
+                    err.check(),
+                    expected,
+                    "wrong check for defect bytes {:02x?}",
+                    bytes
+                ),
+            }
+        }
+    }
+
+    /// (e) `canonical_key_cmp` is a total order that agrees with bytewise
+    /// comparison of the encoded keys — the strict-comparator groundwork
+    /// (idempotence, antisymmetry, transitivity, platform stability).
+    #[test]
+    fn map_key_order_is_total_and_platform_stable(
+        a in arb_key(),
+        b in arb_key(),
+        c in arb_key(),
+    ) {
+        // Idempotence / reflexivity.
+        prop_assert_eq!(canonical_key_cmp(&a, &a), Ordering::Equal);
+        // Antisymmetry.
+        prop_assert_eq!(canonical_key_cmp(&a, &b), canonical_key_cmp(&b, &a).reverse());
+        // Equality is identity: no two distinct keys compare Equal.
+        if canonical_key_cmp(&a, &b) == Ordering::Equal {
+            prop_assert_eq!(&a, &b);
+        }
+        // Transitivity of ≤.
+        if canonical_key_cmp(&a, &b) != Ordering::Greater
+            && canonical_key_cmp(&b, &c) != Ordering::Greater
+        {
+            prop_assert!(canonical_key_cmp(&a, &c) != Ordering::Greater);
+        }
+        // Platform stability: the (len, bytes) shortcut equals RFC 8949's
+        // bytewise-lexicographic order over the full encoded key items.
+        prop_assert_eq!(
+            canonical_key_cmp(&a, &b),
+            encode(&Value::Text(a.clone())).cmp(&encode(&Value::Text(b.clone())))
+        );
+    }
+}

--- a/crates/core/tests/common/mod.rs
+++ b/crates/core/tests/common/mod.rs
@@ -1,0 +1,140 @@
+//! Test-support: a tiny standalone CBOR "defect encoder".
+//!
+//! Each helper re-encodes a [`Value`] with exactly one deliberate
+//! deterministic-profile violation and returns `(bytes, expected_check)`,
+//! so the property suite can assert the strict decoder rejects every
+//! defect with the named check. Deliberately independent of the crate's
+//! encoder internals: heads are written by hand here, and only the
+//! canonical payload bytes come from the public [`encode`].
+
+use cipherbox_core::codec::{Value, canonical_key_cmp, encode};
+
+const MAJOR_TEXT: u8 = 3;
+const MAJOR_MAP: u8 = 5;
+
+/// Shortest-form head (RFC 8949 §4.2.1): an argument below 24 rides the
+/// initial byte; otherwise the smallest of 1/2/4/8 following big-endian
+/// bytes that holds it.
+fn write_head(out: &mut Vec<u8>, major: u8, arg: u64) {
+    let mt = major << 5;
+    match arg {
+        0..=23 => out.push(mt | arg as u8),
+        24..=0xff => {
+            out.push(mt | 24);
+            out.push(arg as u8);
+        }
+        0x100..=0xffff => {
+            out.push(mt | 25);
+            out.extend_from_slice(&(arg as u16).to_be_bytes());
+        }
+        0x1_0000..=0xffff_ffff => {
+            out.push(mt | 26);
+            out.extend_from_slice(&(arg as u32).to_be_bytes());
+        }
+        _ => {
+            out.push(mt | 27);
+            out.extend_from_slice(&arg.to_be_bytes());
+        }
+    }
+}
+
+/// Canonical definite-length text item.
+fn write_text(out: &mut Vec<u8>, s: &str) {
+    write_head(out, MAJOR_TEXT, s.len() as u64);
+    out.extend_from_slice(s.as_bytes());
+}
+
+/// `[0, value]` with the leading 0 emitted as `0x18 0x00`: major 0 with
+/// ai 24 (one following argument byte) carrying 0, which shortest form
+/// requires on the initial byte (`0x00`). The array head `0x82` is
+/// canonical; rejection must fire at the widened integer head, before
+/// `value` is ever reached.
+pub fn widen_head(value: &Value) -> (Vec<u8>, &'static str) {
+    let mut out = vec![0x82, 0x18, 0x00];
+    out.extend_from_slice(&encode(value));
+    (out, "non-canonical-uint")
+}
+
+/// `["x", value]` with the text length 1 emitted in 8-bit form:
+/// `0x78 0x01 'x'` (major 3, ai 24, argument 1) instead of the canonical
+/// `0x61 'x'`. Length arguments obey the same shortest-form rule as
+/// integers but reject with their own check name.
+pub fn widen_length(value: &Value) -> (Vec<u8>, &'static str) {
+    let mut out = vec![0x82, 0x78, 0x01, b'x'];
+    out.extend_from_slice(&encode(value));
+    (out, "non-canonical-length")
+}
+
+/// `0x9f <value> 0xff`: major 4 with ai 31 opens an indefinite-length
+/// array, terminated by the break byte `0xff`. The profile admits definite
+/// lengths only; rejection fires on the `0x9f` head before any element.
+pub fn indefinite_array(value: &Value) -> (Vec<u8>, &'static str) {
+    let mut out = vec![0x9f];
+    out.extend_from_slice(&encode(value));
+    out.push(0xff);
+    (out, "indefinite-length")
+}
+
+/// A two-entry map emitted as `{hi: v1, lo: v2}` where `lo < hi` in
+/// canonical key order (length-first, then bytewise — the caller must
+/// supply two DISTINCT keys). Every entry is individually canonical; only
+/// the ordering is wrong, so the decoder rejects at the second key.
+pub fn swap_map_keys(lo: &str, hi: &str, v1: &Value, v2: &Value) -> (Vec<u8>, &'static str) {
+    debug_assert_eq!(canonical_key_cmp(lo, hi), core::cmp::Ordering::Less);
+    let mut out = Vec::new();
+    write_head(&mut out, MAJOR_MAP, 2);
+    write_text(&mut out, hi);
+    out.extend_from_slice(&encode(v1));
+    write_text(&mut out, lo);
+    out.extend_from_slice(&encode(v2));
+    (out, "unsorted-map-keys")
+}
+
+/// `{k: v1, k: v2}`: the same canonically-encoded key twice. Relative to
+/// the first key the second compares Equal (not strictly ascending), so
+/// uniqueness is the check that fires.
+pub fn duplicate_key(k: &str, v1: &Value, v2: &Value) -> (Vec<u8>, &'static str) {
+    let mut out = Vec::new();
+    write_head(&mut out, MAJOR_MAP, 2);
+    write_text(&mut out, k);
+    out.extend_from_slice(&encode(v1));
+    write_text(&mut out, k);
+    out.extend_from_slice(&encode(v2));
+    (out, "duplicate-map-key")
+}
+
+/// `0xc6 <value>`: major 6 (tag number 6 on the initial byte) prefixing an
+/// otherwise-canonical item. The profile admits no tags whatever their
+/// number; rejection fires on the initial byte.
+pub fn wrap_tag(value: &Value) -> (Vec<u8>, &'static str) {
+    let mut out = vec![0xc6];
+    out.extend_from_slice(&encode(value));
+    (out, "tag-forbidden")
+}
+
+/// `[1.0f16, value]`: array(2) head `0x82`, then `0xf9` (major 7, ai 25 =
+/// half-precision float) with big-endian payload `0x3c00` (= 1.0). Floats
+/// are forbidden whatever their width or value.
+pub fn inject_float(value: &Value) -> (Vec<u8>, &'static str) {
+    let mut out = vec![0x82, 0xf9, 0x3c, 0x00];
+    out.extend_from_slice(&encode(value));
+    (out, "float-forbidden")
+}
+
+/// A canonical item followed by one extra `0x00` byte: decode must consume
+/// the input as exactly one item spanning the whole slice.
+pub fn trailing_junk(value: &Value) -> (Vec<u8>, &'static str) {
+    let mut out = encode(value);
+    out.push(0x00);
+    (out, "trailing-bytes")
+}
+
+/// A canonical item minus its final byte. A canonical encoding's parse
+/// consumes every byte deterministically, so any strict prefix leaves the
+/// last read short (an empty result — one-byte encodings — still rejects
+/// as truncated at offset 0).
+pub fn truncate(value: &Value) -> (Vec<u8>, &'static str) {
+    let mut out = encode(value);
+    out.pop();
+    (out, "truncated")
+}

--- a/crates/core/tests/kat_manifest.rs
+++ b/crates/core/tests/kat_manifest.rs
@@ -304,6 +304,27 @@ fn accept_kinds_cover_required_kinds_exactly() {
         "requiredKinds must not contain duplicates"
     );
 
+    // The canonical kind list is fixed HERE, independent of the generator —
+    // the accept-side anchor mirroring how reject checks anchor to the error
+    // surface. Dropping an accept vector (and its kind) from kat_gen must
+    // fail this test, never silently shrink coverage.
+    const ALL_KINDS: &[&str] = &[
+        "uint",
+        "negint",
+        "bytes",
+        "text",
+        "array",
+        "map",
+        "bool",
+        "null",
+        "depth-limit",
+    ];
+    let canonical: BTreeSet<&str> = ALL_KINDS.iter().copied().collect();
+    assert_eq!(
+        required, canonical,
+        "requiredKinds must be exactly the canonical kind list"
+    );
+
     let vectors = accept_vectors(&m);
     for kind in &required {
         assert!(

--- a/crates/core/tests/kat_manifest.rs
+++ b/crates/core/tests/kat_manifest.rs
@@ -1,0 +1,451 @@
+//! The KAT manifest job (blueprint/core.md "KAT regime", blueprint/testing.md
+//! "crates/core — KATs and property tests"): merge-blocking, machine-checked.
+//!
+//! Fixtures are embedded with `include_str!` — never loaded from the
+//! filesystem at runtime — so the same suite runs natively and under
+//! wasm32-wasip1 (the residual parity surface). Vectors regenerate only
+//! through the committed generator (`examples/kat_gen.rs`); the exact counts
+//! and coverage lists here are the anti-vacuity backstop.
+
+use std::collections::BTreeSet;
+
+use cipherbox_core::codec::{decode, decode_map_partial, encode, encode_map_partial};
+use cipherbox_core::error::{Malformed, TrustViolation};
+use serde::Deserialize;
+
+const MANIFEST: &str = include_str!("../kat/manifest.json");
+
+/// Every vector file the manifest may reference, embedded at compile time.
+/// Path keys are manifest-relative (relative to `kat/`).
+const FIXTURES: &[(&str, &str)] = &[
+    (
+        "vectors/codec/accept.json",
+        include_str!("../kat/vectors/codec/accept.json"),
+    ),
+    (
+        "vectors/codec/reject.json",
+        include_str!("../kat/vectors/codec/reject.json"),
+    ),
+    (
+        "vectors/codec/unknown_fields.json",
+        include_str!("../kat/vectors/codec/unknown_fields.json"),
+    ),
+];
+
+// ---------------------------------------------------------------------------
+// Manifest + vector file shapes. deny_unknown_fields: a field the schema does
+// not know is a manifest drift, not a tolerance.
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Manifest {
+    manifest_version: u64,
+    profile: String,
+    codecs: Codecs,
+    structure_tags: serde_json::Map<String, serde_json::Value>,
+    kdf_edges: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Codecs {
+    #[serde(rename = "det-cbor")]
+    det_cbor: DetCbor,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DetCbor {
+    accept: AcceptSection,
+    reject: RejectSection,
+    unknown_fields: UnknownFieldsSection,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AcceptSection {
+    file: String,
+    count: usize,
+    required_kinds: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RejectSection {
+    file: String,
+    count: usize,
+    checks: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UnknownFieldsSection {
+    file: String,
+    count: usize,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AcceptVector {
+    name: String,
+    hex: String,
+    diag: String,
+    kinds: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RejectVector {
+    name: String,
+    hex: String,
+    check: String,
+    class: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct UnknownVector {
+    name: String,
+    hex: String,
+    known_keys: Vec<String>,
+    expect_unknown_count: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+fn manifest() -> Manifest {
+    serde_json::from_str(MANIFEST).expect("kat/manifest.json must match the manifest schema")
+}
+
+fn fixture(path: &str) -> &'static str {
+    FIXTURES
+        .iter()
+        .find(|(p, _)| *p == path)
+        .unwrap_or_else(|| panic!("manifest references {path}, which is not include_str!-embedded"))
+        .1
+}
+
+fn accept_vectors(m: &Manifest) -> Vec<AcceptVector> {
+    serde_json::from_str(fixture(&m.codecs.det_cbor.accept.file)).expect("accept.json shape")
+}
+
+fn reject_vectors(m: &Manifest) -> Vec<RejectVector> {
+    serde_json::from_str(fixture(&m.codecs.det_cbor.reject.file)).expect("reject.json shape")
+}
+
+fn unknown_vectors(m: &Manifest) -> Vec<UnknownVector> {
+    serde_json::from_str(fixture(&m.codecs.det_cbor.unknown_fields.file))
+        .expect("unknown_fields.json shape")
+}
+
+fn unhex(name: &str, hex: &str) -> Vec<u8> {
+    let bytes = hex::decode(hex).unwrap_or_else(|e| panic!("vector {name}: bad hex: {e}"));
+    // Lowercase hex is part of the fixture contract.
+    assert_eq!(
+        hex::encode(&bytes),
+        hex,
+        "vector {name}: hex must be lowercase"
+    );
+    bytes
+}
+
+// ---------------------------------------------------------------------------
+// Assertions.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn manifest_header_is_pinned() {
+    let m = manifest();
+    assert_eq!(m.manifest_version, 1);
+    assert_eq!(m.profile, "cipherbox/v2 det-cbor");
+}
+
+#[test]
+fn fixture_table_matches_manifest_files() {
+    let m = manifest();
+    let referenced = [
+        m.codecs.det_cbor.accept.file.as_str(),
+        m.codecs.det_cbor.reject.file.as_str(),
+        m.codecs.det_cbor.unknown_fields.file.as_str(),
+    ];
+    let referenced_set: BTreeSet<&str> = referenced.iter().copied().collect();
+    assert_eq!(
+        referenced_set.len(),
+        referenced.len(),
+        "manifest must not reference the same file twice"
+    );
+    let embedded: BTreeSet<&str> = FIXTURES.iter().map(|(p, _)| *p).collect();
+    assert_eq!(
+        referenced_set, embedded,
+        "manifest files and include_str!-embedded fixtures must match 1:1"
+    );
+}
+
+#[test]
+fn vector_counts_are_exact() {
+    let m = manifest();
+    assert_eq!(
+        accept_vectors(&m).len(),
+        m.codecs.det_cbor.accept.count,
+        "accept.json count drift"
+    );
+    assert_eq!(
+        reject_vectors(&m).len(),
+        m.codecs.det_cbor.reject.count,
+        "reject.json count drift"
+    );
+    assert_eq!(
+        unknown_vectors(&m).len(),
+        m.codecs.det_cbor.unknown_fields.count,
+        "unknown_fields.json count drift"
+    );
+}
+
+#[test]
+fn vector_names_are_unique_within_each_file() {
+    let m = manifest();
+    let mut seen = BTreeSet::new();
+    for v in accept_vectors(&m) {
+        assert!(
+            seen.insert(v.name.clone()),
+            "duplicate accept vector name {}",
+            v.name
+        );
+    }
+    seen.clear();
+    for v in reject_vectors(&m) {
+        assert!(
+            seen.insert(v.name.clone()),
+            "duplicate reject vector name {}",
+            v.name
+        );
+    }
+    seen.clear();
+    for v in unknown_vectors(&m) {
+        assert!(
+            seen.insert(v.name.clone()),
+            "duplicate unknown-field vector name {}",
+            v.name
+        );
+    }
+}
+
+#[test]
+fn reject_checks_list_matches_vectors_and_error_surface() {
+    let m = manifest();
+    let listed: BTreeSet<&str> = m
+        .codecs
+        .det_cbor
+        .reject
+        .checks
+        .iter()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        listed.len(),
+        m.codecs.det_cbor.reject.checks.len(),
+        "manifest checks list must not contain duplicates"
+    );
+
+    let vectors = reject_vectors(&m);
+    let in_vectors: BTreeSet<&str> = vectors.iter().map(|v| v.check.as_str()).collect();
+    assert_eq!(
+        listed, in_vectors,
+        "manifest checks must be exactly the distinct checks in reject.json"
+    );
+
+    let all: BTreeSet<&str> = TrustViolation::CHECKS
+        .iter()
+        .chain(Malformed::CHECKS)
+        .copied()
+        .collect();
+    assert!(
+        listed.is_subset(&all),
+        "every manifest check must exist on the error surface"
+    );
+    for check in TrustViolation::CHECKS {
+        assert!(
+            listed.contains(check),
+            "all trust-violation checks are decode-reachable; missing {check}"
+        );
+    }
+
+    // The only checks without reject vectors are the two that `decode` can
+    // never emit: unexpected-type (schema-layer accessor failure) and
+    // unknown-field-collision (encode_map_partial caller bug). Both are
+    // unit-test-pinned in src/codec/fields.rs.
+    let absent: BTreeSet<&str> = all.difference(&listed).copied().collect();
+    let expected_absent: BTreeSet<&str> = ["unexpected-type", "unknown-field-collision"]
+        .into_iter()
+        .collect();
+    assert_eq!(
+        absent, expected_absent,
+        "reject vectors must cover every decode-reachable check"
+    );
+}
+
+#[test]
+fn accept_kinds_cover_required_kinds_exactly() {
+    let m = manifest();
+    let required: BTreeSet<&str> = m
+        .codecs
+        .det_cbor
+        .accept
+        .required_kinds
+        .iter()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        required.len(),
+        m.codecs.det_cbor.accept.required_kinds.len(),
+        "requiredKinds must not contain duplicates"
+    );
+
+    let vectors = accept_vectors(&m);
+    for kind in &required {
+        assert!(
+            vectors.iter().any(|v| v.kinds.iter().any(|k| k == kind)),
+            "required kind {kind} has no accept vector"
+        );
+    }
+    for v in &vectors {
+        assert!(!v.kinds.is_empty(), "accept vector {} has no kinds", v.name);
+        for k in &v.kinds {
+            assert!(
+                required.contains(k.as_str()),
+                "accept vector {} has kind {k} outside requiredKinds",
+                v.name
+            );
+        }
+    }
+}
+
+#[test]
+fn accept_vectors_decode_reencode_and_render_diag() {
+    let m = manifest();
+    for v in accept_vectors(&m) {
+        let bytes = unhex(&v.name, &v.hex);
+        let value = decode(&bytes)
+            .unwrap_or_else(|e| panic!("accept vector {}: decoder rejected it: {e}", v.name));
+        assert_eq!(
+            hex::encode(encode(&value)),
+            v.hex,
+            "accept vector {}: re-encode must be byte-identical",
+            v.name
+        );
+        assert_eq!(
+            value.to_string(),
+            v.diag,
+            "accept vector {}: diagnostic-notation drift",
+            v.name
+        );
+    }
+}
+
+#[test]
+fn reject_vectors_fire_the_named_check() {
+    let m = manifest();
+    for v in reject_vectors(&m) {
+        let bytes = unhex(&v.name, &v.hex);
+        let err = match decode(&bytes) {
+            Err(e) => e,
+            Ok(value) => panic!("reject vector {}: decoder accepted it as {value}", v.name),
+        };
+        assert_eq!(
+            err.check(),
+            v.check,
+            "reject vector {}: wrong check ({err})",
+            v.name
+        );
+        assert_eq!(
+            err.class(),
+            v.class,
+            "reject vector {}: wrong class ({err})",
+            v.name
+        );
+    }
+}
+
+#[test]
+fn reject_vector_class_matches_the_check_lists() {
+    let m = manifest();
+    for v in reject_vectors(&m) {
+        let expected = if TrustViolation::CHECKS.contains(&v.check.as_str()) {
+            "trust"
+        } else if Malformed::CHECKS.contains(&v.check.as_str()) {
+            "malformed"
+        } else {
+            panic!(
+                "reject vector {}: check {} is on neither list",
+                v.name, v.check
+            )
+        };
+        assert_eq!(
+            v.class, expected,
+            "reject vector {}: class must match the list its check lives in",
+            v.name
+        );
+    }
+}
+
+#[test]
+fn unknown_field_vectors_round_trip_byte_stable() {
+    let m = manifest();
+    for v in unknown_vectors(&m) {
+        let bytes = unhex(&v.name, &v.hex);
+        let (known, unknown) =
+            decode_map_partial(&bytes, |k| v.known_keys.iter().any(|kk| kk == k)).unwrap_or_else(
+                |e| {
+                    panic!(
+                        "unknown-field vector {}: decode_map_partial failed: {e}",
+                        v.name
+                    )
+                },
+            );
+        assert_eq!(
+            unknown.len(),
+            v.expect_unknown_count,
+            "unknown-field vector {}: unknown count",
+            v.name
+        );
+        // The known/unknown split must be exhaustive over the map.
+        let full = decode(&bytes).expect("vector decodes as a full strict item");
+        assert_eq!(
+            known.len() + unknown.len(),
+            full.as_map().expect("top-level map").len(),
+            "unknown-field vector {}: split must cover every entry",
+            v.name
+        );
+        let reencoded = encode_map_partial(&known, &unknown).unwrap_or_else(|e| {
+            panic!(
+                "unknown-field vector {}: encode_map_partial failed: {e}",
+                v.name
+            )
+        });
+        assert_eq!(
+            hex::encode(reencoded),
+            v.hex,
+            "unknown-field vector {}: rewrite must be byte-stable",
+            v.name
+        );
+    }
+}
+
+#[test]
+fn structure_tags_and_kdf_edges_sections_exist_and_are_empty() {
+    // Present-and-empty by design: later spine slices land the structure-tag
+    // registry and the KDF edge catalog here, replacing this assertion with
+    // their completeness checks.
+    let m = manifest();
+    assert!(
+        m.structure_tags.is_empty(),
+        "structureTags gains entries only with its completeness machinery"
+    );
+    assert!(
+        m.kdf_edges.is_empty(),
+        "kdfEdges gains entries only with its completeness machinery"
+    );
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -17,6 +17,8 @@ mod tests {
 
     #[test]
     fn depends_on_core() {
-        assert_eq!(cipherbox_core::CRATE, "cipherbox-core");
+        use cipherbox_core::codec::{Value, decode, encode};
+        let bytes = encode(&Value::Unsigned(1));
+        assert_eq!(decode(&bytes).unwrap(), Value::Unsigned(1));
     }
 }


### PR DESCRIPTION
Closes #618.

## What landed

- **`codec`** — the deterministic CBOR profile (RFC 8949 s4.2, strict DAG-CBOR subset): shortest-form arguments, definite lengths only, unique sorted text map keys, no tags/floats/extra simple values. Duplicate keys, non-canonical encodings, and wrong major types reject fail-closed; unknown fields are the single tolerance — accepted, preserved byte-stable, re-emitted canonically on rewrite via `decode_map_partial`/`encode_map_partial`.
- **Error surface** — two disjoint types, 17 uniquely named checks, every rejection names the check that fired. Boundary rationale documented on the types: trust = a canonical encoding of the same data exists and the writer emitted a different one; malformed = shapes the profile cannot represent at all.
- **KAT spine** — machine-checked `kat/manifest.json` (exact counts, check/kind anti-vacuity, present-and-empty `structureTags`/`kdfEdges` sections for later slices); 31 accept / 35 reject / 6 unknown-field vectors; `kat_gen` is the committed generator and only vector writer (self-asserting, byte-deterministic). Regression pins include the half-float/simple-value aliasing class and the tag-42 CID-link rejection.
- **Property layer** — encode-decode identity, unknown-field byte-stable round-trip, canonical rewrite, nine-defect canonicality rejection against an independent defect encoder, key-comparator total-order laws.
- **CI** — new merge-blocking `Core KATs (native + WASM)` job: KAT-vector freshness (regen + diff), native suite, and the same suite on wasm32-wasip1 under wasmtime. `.cargo/config.toml` wires the runner and is covered by the rust path filter.

## Notes for review

- The trust-vs-malformed classing of profile-forbidden shapes (tags/floats/simple values = malformed) is now vector-frozen; rationale in `crates/core/src/error.rs`.
- The WASM property lane runs 16 cases with persistence off (KATs are the parity surface per blueprint/core.md); native runs the full default case count with failure persistence on.
- `MAX_DEPTH = 128` is a profile constant introduced here as the recursion guard, pinned by accept-at-128/reject-at-129 vectors.

## Verification

- `cargo test -p cipherbox-core` — 25 tests green natively and under wasm32-wasip1/wasmtime
- `kat_gen` regeneration byte-identical; freshness diff clean
- workspace clippy `-D warnings`, fmt, actionlint, zizmor all clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic CBOR encoding and strict decoding, including canonical validation and depth limits.
  * Added support for preserving and rewriting unknown map fields without changing their encoded bytes.
  * Added structured codec error reporting for malformed and non-canonical data.

* **Testing**
  * Added comprehensive compatibility vectors and property-based tests covering valid, invalid, and unknown-field scenarios.
  * Extended continuous integration to validate codec behavior on native and WebAssembly targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->