### PR TITLE
feat(engine): scaffold seams, fakes, conformance kits, and the facade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,33 @@ jobs:
       - name: Cargo test (workspace)
         run: cargo test --workspace --exclude cipherbox-desktop
 
+  engine:
+    name: Engine Tests
+    needs: [changes, lint]
+    if: |
+      !failure() && !cancelled() &&
+      needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: linux-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: linux-cargo-
+
+      # Engine unit tests plus every seam conformance kit executed against
+      # its in-memory fake (the test-kit feature activates via the crate's
+      # self dev-dependency).
+      - name: Engine tests and seam conformance kits
+        run: cargo test -p cipherbox-engine
+
   core-kats:
     name: Core KATs (native + WASM)
     needs: [changes, lint]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,10 @@ name = "cipherbox-engine"
 version = "0.0.0"
 dependencies = [
  "cipherbox-core",
+ "cipherbox-engine",
+ "futures-channel",
+ "futures-core",
+ "zeroize",
 ]
 
 [[package]]
@@ -4579,6 +4583,12 @@ dependencies = [
  "syn 2.0.119",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ publish = false
 [workspace.dependencies]
 cipherbox-core = { path = "crates/core" }
 cipherbox-engine = { path = "crates/engine" }
+futures-channel = "0.3"
+futures-core = "0.3"
+zeroize = "1"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -7,5 +7,20 @@ repository.workspace = true
 rust-version.workspace = true
 publish.workspace = true
 
+[features]
+# Compiles the `testkit` module: in-memory seam fakes, seeded entropy, the
+# virtual-clock scheduler, and the per-seam conformance kits. Host crates
+# enable it from dev-dependencies to run the kits against their real seam
+# implementations; production builds never compile it.
+test-kit = []
+
 [dependencies]
 cipherbox-core.workspace = true
+futures-channel.workspace = true
+futures-core.workspace = true
+zeroize.workspace = true
+
+[dev-dependencies]
+# Self dev-dependency: enables `test-kit` for this crate's own tests (unit,
+# integration, doc) without leaking it into downstream production builds.
+cipherbox-engine = { workspace = true, features = ["test-kit"] }

--- a/crates/engine/src/entropy.rs
+++ b/crates/engine/src/entropy.rs
@@ -8,12 +8,47 @@
 //! the test kit's seeded source and every seed, jitter, and nonce becomes
 //! reproducible.
 
+use core::fmt;
+
+/// Entropy acquisition failed.
+///
+/// Fail closed: the engine surfaces this as a typed error — it never
+/// panics and never substitutes predictable bytes. The message is
+/// diagnostic only and must never carry key material.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntropyError {
+    message: String,
+}
+
+impl EntropyError {
+    /// Builds an entropy error from a diagnostic message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// The diagnostic message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for EntropyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "entropy error: {}", self.message)
+    }
+}
+
+impl std::error::Error for EntropyError {}
+
 /// A source of entropy for key seeds, nonces, and timer jitter.
 ///
 /// Production implementations must be cryptographically secure
-/// (per-target `getrandom`). The test kit's `SeededEntropy` is
-/// deterministic and test-only.
+/// (per-target `getrandom`, whose acquisition is fallible — hence the
+/// `Result`). The test kit's `SeededEntropy` is deterministic and
+/// test-only.
 pub trait Entropy {
-    /// Fills `dest` entirely with entropy bytes.
-    fn fill(&mut self, dest: &mut [u8]);
+    /// Fills `dest` entirely with entropy bytes, or fails closed.
+    fn fill(&mut self, dest: &mut [u8]) -> Result<(), EntropyError>;
 }

--- a/crates/engine/src/entropy.rs
+++ b/crates/engine/src/entropy.rs
@@ -1,0 +1,19 @@
+//! Injected entropy — the engine's only randomness source.
+//!
+//! Entropy is an engine input to core's pure functions (blueprint/engine.md
+//! "Host seams" notes; blueprint/core.md doctrine). It is deliberately *not*
+//! one of the nine host seams: production wiring is per-target `getrandom`,
+//! owned by the engine's construction site, not host logic. It is still
+//! injected — engine logic never calls an RNG directly — so tests substitute
+//! the test kit's seeded source and every seed, jitter, and nonce becomes
+//! reproducible.
+
+/// A source of entropy for key seeds, nonces, and timer jitter.
+///
+/// Production implementations must be cryptographically secure
+/// (per-target `getrandom`). The test kit's `SeededEntropy` is
+/// deterministic and test-only.
+pub trait Entropy {
+    /// Fills `dest` entirely with entropy bytes.
+    fn fill(&mut self, dest: &mut [u8]);
+}

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -1,0 +1,433 @@
+//! The facade — the engine's single async command-and-event surface
+//! (blueprint/engine.md "Facade").
+//!
+//! Designed to be wrapped, not extended: desktop calls it directly in the
+//! Tauri process; web wraps it via `crates/wasm` inside a dedicated worker,
+//! with the RPC layer and tab leadership owned by `packages/client`
+//! (#28 D3/D4). The engine's contract is only this: one live instance is
+//! the single writer, and every trust decision already happened below the
+//! facade — hosts render, they never decide.
+//!
+//! This is the skeleton slice: the surface shape (constructor over the
+//! whole seam set, `start(secret)`, the [`Command`] enum, the [`Event`]
+//! stream) is real and frozen; command execution is not — every command
+//! resolves to [`EngineError::Unimplemented`] until the pipeline slices
+//! land.
+
+use core::fmt;
+use core::pin::Pin;
+
+use futures_channel::mpsc;
+use futures_core::Stream;
+use zeroize::Zeroizing;
+
+use crate::entropy::Entropy;
+use crate::profile::SyncTimingProfile;
+use crate::seams::{OpId, SeamSet, SeamTypes};
+
+/// The stable 16-byte node identifier (`id16`, blueprint/core.md). Public,
+/// non-secret, and location-independent — routes and commands key on it,
+/// never on rotating `ipnsName`s.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NodeId(pub [u8; 16]);
+
+/// What a created node is. Kind is sealed inside the read-body on the wire;
+/// at the facade it is plain intent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeKind {
+    /// A file node.
+    File,
+    /// A folder node.
+    Folder,
+}
+
+/// Grant permission level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Permission {
+    /// Read grant: read seed only.
+    Read,
+    /// Write grant: read and write seeds.
+    Write,
+}
+
+/// The staleness ladder (#33 D4): fresh → reconciling → stale → offline.
+/// Availability staleness keeps cached views usable indefinitely; trust
+/// violations are never staleness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Staleness {
+    /// View is within the freshness window.
+    Fresh,
+    /// A background reconcile is in flight (quiet indicator).
+    Reconciling,
+    /// Past the profile threshold: stale badge, "last synced X ago".
+    Stale,
+    /// Offline banner.
+    Offline,
+}
+
+/// The login secret handed to [`Engine::start`], and nowhere else.
+///
+/// Zeroized on drop. The engine derives everything else in-crate via core's
+/// KDF catalog; the secret never leaves engine memory, is never logged, and
+/// has no `Clone`.
+pub struct LoginSecret(Zeroizing<Vec<u8>>);
+
+impl LoginSecret {
+    /// Wraps the raw login secret bytes. The caller should not retain a
+    /// copy (web transfers the buffer and zeroes its own).
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(Zeroizing::new(bytes))
+    }
+
+    /// Whether the secret is empty (always a caller bug).
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl fmt::Debug for LoginSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("LoginSecret(redacted)")
+    }
+}
+
+/// Every command a host can issue — the intent ops, grant/rotation/share
+/// actions, auth, and manual refresh (blueprint/engine.md "Facade").
+///
+/// Payload shapes are scaffold-minimal: opaque byte payloads harden into
+/// typed forms as the owning pipeline slices land, but the variant set is
+/// the surface hosts build against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Command {
+    // --- intent ops (#33 D6: every mutation rides the durable op queue) ---
+    /// Create a node under a parent.
+    Create {
+        /// Parent folder.
+        parent: NodeId,
+        /// Name as entered (uniqueness uses the strict comparator).
+        name: String,
+        /// File or folder.
+        kind: NodeKind,
+        /// Initial content for file creates.
+        content: Option<Vec<u8>>,
+    },
+    /// Delete a node (conditional delete semantics on rebase).
+    Delete {
+        /// Target node.
+        node: NodeId,
+    },
+    /// Rename a node in place.
+    Rename {
+        /// Target node.
+        node: NodeId,
+        /// New name as entered.
+        new_name: String,
+    },
+    /// Move a node to a new parent. Intra-scope this is a pure relink;
+    /// cross-scope it re-seals the subtree and may trigger a scope-exit
+    /// rotation for the source (#26 D1/D7).
+    Relink {
+        /// Node being moved.
+        node: NodeId,
+        /// Destination parent.
+        new_parent: NodeId,
+    },
+    /// Write new content to a file node (fresh per-version content key).
+    UpdateContent {
+        /// Target file node.
+        node: NodeId,
+        /// New content bytes.
+        content: Vec<u8>,
+    },
+
+    // --- focus and refresh ---
+    /// Set the open folder driving the focus window; `None` when no folder
+    /// is open.
+    SetFocus {
+        /// The open folder, if any.
+        node: Option<NodeId>,
+    },
+    /// Manual refresh with nocache semantics everywhere (#33 D4).
+    ManualRefresh,
+
+    // --- grants, shares, rotation (owner/grant actions per engine.md) ---
+    /// Import a contact code; binding-signature verification is mandatory
+    /// and fail-closed (#34 D6).
+    ImportContact {
+        /// The self-authenticating contact bundle bytes.
+        contact_code: Vec<u8>,
+    },
+    /// Grant a node to an imported contact (owner-only).
+    Grant {
+        /// Node to grant (folder or file — files are first-class targets).
+        node: NodeId,
+        /// Recipient's identity public key, as imported.
+        recipient_identity_public_key: Vec<u8>,
+        /// Read or write.
+        permission: Permission,
+    },
+    /// Revoke a grant (owner-only; read revoke = immediate cut).
+    Revoke {
+        /// Granted node.
+        node: NodeId,
+        /// Recipient's identity public key.
+        recipient_identity_public_key: Vec<u8>,
+    },
+    /// Downgrade a write grant to read (owner-only; triggers write
+    /// rotation).
+    Downgrade {
+        /// Granted node.
+        node: NodeId,
+        /// Recipient's identity public key.
+        recipient_identity_public_key: Vec<u8>,
+    },
+    /// Mint an invite link for a node (#25 D6). The returned URL fragment
+    /// carries the ephemeral secret; response payloads land with the grants
+    /// slice.
+    CreateInviteLink {
+        /// Node to invite to.
+        node: NodeId,
+        /// Read or write.
+        permission: Permission,
+    },
+    /// Accept a share from a polled mailbox pointer or claimed invite.
+    AcceptShare {
+        /// The sealed share pointer payload.
+        sealed_share_pointer: Vec<u8>,
+    },
+    /// Manual hygiene rotate-now for a scope (same primitives as every
+    /// rotation trigger).
+    RotateNow {
+        /// The scope root to rotate.
+        node: NodeId,
+    },
+
+    // --- auth ---
+    /// Exchange a host-collected SIWE wallet signature (secondary method;
+    /// the engine performs the exchange through its API client).
+    SiweLogin {
+        /// The signed SIWE message.
+        message: String,
+        /// The wallet signature bytes.
+        signature: Vec<u8>,
+    },
+    /// Log out: zeroize engine state; durable seams survive by design.
+    Logout,
+}
+
+impl Command {
+    /// Stable command name for diagnostics and typed unimplemented errors.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Command::Create { .. } => "create",
+            Command::Delete { .. } => "delete",
+            Command::Rename { .. } => "rename",
+            Command::Relink { .. } => "relink",
+            Command::UpdateContent { .. } => "updateContent",
+            Command::SetFocus { .. } => "setFocus",
+            Command::ManualRefresh => "manualRefresh",
+            Command::ImportContact { .. } => "importContact",
+            Command::Grant { .. } => "grant",
+            Command::Revoke { .. } => "revoke",
+            Command::Downgrade { .. } => "downgrade",
+            Command::CreateInviteLink { .. } => "createInviteLink",
+            Command::AcceptShare { .. } => "acceptShare",
+            Command::RotateNow { .. } => "rotateNow",
+            Command::SiweLogin { .. } => "siweLogin",
+            Command::Logout => "logout",
+        }
+    }
+}
+
+/// Events the engine emits on the one-way stream out
+/// (blueprint/engine.md "Facade"). Payloads are scaffold-minimal and harden
+/// with the pipeline slices; the variant set is the contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Event {
+    /// A new gate-passing snapshot (with pending-op overlay applied) is
+    /// available.
+    SnapshotUpdated,
+    /// Staleness-ladder transition.
+    StalenessChanged {
+        /// The new level.
+        level: Staleness,
+    },
+    /// Withheld-update escalation on a shared scope (#33 D7).
+    WithheldUpdateEscalation {
+        /// The pinned name, as opaque bytes.
+        ipns_name: Vec<u8>,
+    },
+    /// A queued op terminally failed rebase; staged bytes are preserved
+    /// (#33 D6).
+    DeadLetter {
+        /// The dead-lettered op.
+        op_id: OpId,
+    },
+    /// Attributable abuse: owner-blob / ascent-link / unseal cross-check
+    /// disagreement (#39 D6) — never a silent failure.
+    AttributableAbuse {
+        /// Human-readable classification (no key material).
+        description: String,
+    },
+}
+
+/// Errors returned by facade calls.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EngineError {
+    /// A command was issued before [`Engine::start`].
+    NotStarted,
+    /// [`Engine::start`] was called on an already-started engine (one live
+    /// instance is the single writer).
+    AlreadyStarted,
+    /// The login secret was empty.
+    InvalidSecret,
+    /// The command's pipeline slice has not landed yet (scaffold state).
+    Unimplemented {
+        /// [`Command::name`] of the rejected command.
+        command: &'static str,
+    },
+}
+
+impl fmt::Display for EngineError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            EngineError::NotStarted => f.write_str("engine not started"),
+            EngineError::AlreadyStarted => f.write_str("engine already started"),
+            EngineError::InvalidSecret => f.write_str("login secret must not be empty"),
+            EngineError::Unimplemented { command } => {
+                write!(f, "command not implemented yet: {command}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EngineError {}
+
+/// The receiving side of the engine's one-way event stream.
+///
+/// Runtime-agnostic: an unbounded in-process channel, awaitable on any
+/// executor, native or WASM. Ends (`None`) when the engine is dropped.
+pub struct EventStream {
+    receiver: mpsc::UnboundedReceiver<Event>,
+}
+
+impl EventStream {
+    /// Waits for the next event; `None` once the engine is gone.
+    pub async fn next(&mut self) -> Option<Event> {
+        core::future::poll_fn(|cx| Pin::new(&mut self.receiver).poll_next(cx)).await
+    }
+}
+
+/// The engine — the single stateful brain behind the facade.
+///
+/// Constructed over the whole seam set (missing seam = compile error), an
+/// injected entropy source, and an explicit sync timing profile. Generic
+/// over the host's [`SeamTypes`] family: fully statically dispatched, no
+/// `Send` requirement, so one implementation links natively on desktop and
+/// compiles to worker-hosted WASM on web.
+pub struct Engine<T: SeamTypes> {
+    /// Wired by the pipeline slices; injection is the contract this slice
+    /// freezes.
+    #[allow(dead_code)]
+    seams: SeamSet<T>,
+    /// Wired by the pipeline slices (seeds, nonces, jitter).
+    #[allow(dead_code)]
+    entropy: Box<dyn Entropy>,
+    profile: SyncTimingProfile,
+    /// Held by the engine; every emit site lands with its pipeline slice.
+    #[allow(dead_code)]
+    events: mpsc::UnboundedSender<Event>,
+    started: bool,
+}
+
+impl<T: SeamTypes> Engine<T> {
+    /// Builds an engine over the whole seam set and hands back the paired
+    /// event stream.
+    pub fn new(
+        seams: SeamSet<T>,
+        entropy: Box<dyn Entropy>,
+        profile: SyncTimingProfile,
+    ) -> (Self, EventStream) {
+        let (events, receiver) = mpsc::unbounded();
+        (
+            Self {
+                seams,
+                entropy,
+                profile,
+                events,
+                started: false,
+            },
+            EventStream { receiver },
+        )
+    }
+
+    /// Start of secret: consumes the login secret and brings the engine up.
+    ///
+    /// The full cold-start sequence (identity derivation, vault-pointer
+    /// resolve, floor cold-seed, root adoption, first snapshot event) lands
+    /// with the pipeline slices; the lifecycle contract — exactly one
+    /// successful `start` per instance, secret zeroized on consumption — is
+    /// in force now.
+    pub async fn start(&mut self, secret: LoginSecret) -> Result<(), EngineError> {
+        if self.started {
+            return Err(EngineError::AlreadyStarted);
+        }
+        if secret.is_empty() {
+            return Err(EngineError::InvalidSecret);
+        }
+        // Derivation lands with the pipeline slices; the secret zeroizes on
+        // drop here, at its terminal owner.
+        drop(secret);
+        self.started = true;
+        Ok(())
+    }
+
+    /// Executes one command. The single write entry point: every mutation,
+    /// share action, auth call, and manual refresh comes through here.
+    pub async fn command(&mut self, command: Command) -> Result<(), EngineError> {
+        if !self.started {
+            return Err(EngineError::NotStarted);
+        }
+        Err(EngineError::Unimplemented {
+            command: command.name(),
+        })
+    }
+
+    /// The sync timing profile this engine runs under.
+    pub fn profile(&self) -> &SyncTimingProfile {
+        &self.profile
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn login_secret_debug_is_redacted() {
+        let secret = LoginSecret::new(vec![0xAA; 32]);
+        assert_eq!(format!("{secret:?}"), "LoginSecret(redacted)");
+    }
+
+    #[test]
+    fn command_names_are_stable() {
+        assert_eq!(Command::ManualRefresh.name(), "manualRefresh");
+        assert_eq!(Command::Logout.name(), "logout");
+        assert_eq!(
+            Command::Delete {
+                node: NodeId([0; 16])
+            }
+            .name(),
+            "delete"
+        );
+    }
+
+    #[test]
+    fn engine_error_displays() {
+        assert_eq!(
+            EngineError::Unimplemented { command: "create" }.to_string(),
+            "command not implemented yet: create"
+        );
+        assert_eq!(EngineError::NotStarted.to_string(), "engine not started");
+    }
+}

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -111,7 +111,11 @@ impl fmt::Debug for LoginSecret {
 /// Payload shapes are scaffold-minimal: opaque byte payloads harden into
 /// typed forms as the owning pipeline slices land, but the variant set is
 /// the surface hosts build against.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `Debug` is hand-written and prints only the variant name: payloads
+/// carry private user data (plaintext content, names, contact bundles),
+/// and a derived `{:?}` at any diagnostic site would leak it into logs.
+#[derive(Clone, PartialEq, Eq)]
 pub enum Command {
     // --- intent ops (#33 D6: every mutation rides the durable op queue) ---
     /// Create a node under a parent.
@@ -250,6 +254,12 @@ impl Command {
             Command::SiweLogin { .. } => "siweLogin",
             Command::Logout => "logout",
         }
+    }
+}
+
+impl fmt::Debug for Command {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Command({})", self.name())
     }
 }
 
@@ -437,19 +447,21 @@ mod tests {
     }
 
     #[test]
-    fn command_debug_redacts_plaintext_content() {
+    fn command_debug_prints_only_the_variant_name() {
         let command = Command::Create {
             parent: NodeId([0; 16]),
-            name: "notes.txt".into(),
+            name: "vacation-plans.txt".into(),
             kind: NodeKind::File,
             content: Some(PlaintextContent(b"top-secret-plaintext".to_vec())),
         };
         let debug = format!("{command:?}");
-        assert!(
-            !debug.contains("top-secret-plaintext") && !debug.contains("116"),
-            "plaintext bytes must not leak through Debug: {debug}"
-        );
-        assert!(debug.contains("PlaintextContent(<20 bytes>)"));
+        assert_eq!(debug, "Command(create)", "payloads must never leak");
+    }
+
+    #[test]
+    fn plaintext_content_debug_is_redacted() {
+        let content = PlaintextContent(b"top-secret-plaintext".to_vec());
+        assert_eq!(format!("{content:?}"), "PlaintextContent(<20 bytes>)");
     }
 
     #[test]

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -31,6 +31,20 @@ use crate::seams::{OpId, SeamSet, SeamTypes};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct NodeId(pub [u8; 16]);
 
+/// Plaintext file content crossing the facade.
+///
+/// A newtype rather than bare `Vec<u8>` so `Debug` is structurally
+/// redacted: plaintext user bytes must never reach a log site (security
+/// rule 2), including through a derived `{:?}` on a containing [`Command`].
+#[derive(Clone, PartialEq, Eq)]
+pub struct PlaintextContent(pub Vec<u8>);
+
+impl fmt::Debug for PlaintextContent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PlaintextContent(<{} bytes>)", self.0.len())
+    }
+}
+
 /// What a created node is. Kind is sealed inside the read-body on the wire;
 /// at the facade it is plain intent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -109,7 +123,7 @@ pub enum Command {
         /// File or folder.
         kind: NodeKind,
         /// Initial content for file creates.
-        content: Option<Vec<u8>>,
+        content: Option<PlaintextContent>,
     },
     /// Delete a node (conditional delete semantics on rebase).
     Delete {
@@ -137,7 +151,7 @@ pub enum Command {
         /// Target file node.
         node: NodeId,
         /// New content bytes.
-        content: Vec<u8>,
+        content: PlaintextContent,
     },
 
     // --- focus and refresh ---
@@ -420,6 +434,22 @@ mod tests {
             .name(),
             "delete"
         );
+    }
+
+    #[test]
+    fn command_debug_redacts_plaintext_content() {
+        let command = Command::Create {
+            parent: NodeId([0; 16]),
+            name: "notes.txt".into(),
+            kind: NodeKind::File,
+            content: Some(PlaintextContent(b"top-secret-plaintext".to_vec())),
+        };
+        let debug = format!("{command:?}");
+        assert!(
+            !debug.contains("top-secret-plaintext") && !debug.contains("116"),
+            "plaintext bytes must not leak through Debug: {debug}"
+        );
+        assert!(debug.contains("PlaintextContent(<20 bytes>)"));
     }
 
     #[test]

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -33,7 +33,7 @@ pub mod testkit;
 pub use entropy::Entropy;
 pub use facade::{
     Command, Engine, EngineError, Event, EventStream, LoginSecret, NodeId, NodeKind, Permission,
-    Staleness,
+    PlaintextContent, Staleness,
 };
 pub use profile::SyncTimingProfile;
 pub use seams::{SeamError, SeamResult, SeamSet, SeamTypes};

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -2,10 +2,44 @@
 //! seam traits through which entropy, time, and policy are injected.
 //!
 //! Normative design: blueprint/engine.md
+//!
+//! This slice freezes the architecture surface: the nine host seam traits
+//! and the whole-set constructor bundle ([`seams`]), injected entropy
+//! ([`entropy`]), the environment-scoped sync timing profile ([`profile`]),
+//! and the facade skeleton ([`facade`]) — one async command-and-event
+//! surface with start of secret. Pipeline logic (gate, sync, rotation,
+//! grants, pointer, mailbox, net, content, api) lands in later slices
+//! behind this exact surface.
+//!
+//! The `test-kit` feature adds [`testkit`]: in-memory fakes for every seam,
+//! a virtual-clock scheduler, seeded entropy, and the reusable per-seam
+//! conformance kits that real host implementations must pass.
 
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
+// Deliberate: seam traits use native `async fn`. The engine is consumed as
+// a concrete generic (no `dyn` seams), runs single-writer pinned to one
+// execution context, and must compile for wasm32 where futures are !Send —
+// so no auto-trait bound flexibility is lost.
+#![allow(async_fn_in_trait)]
 
-/// Placeholder identity item; the real engine lands in later PRs.
+pub mod entropy;
+pub mod facade;
+pub mod profile;
+pub mod seams;
+#[cfg(feature = "test-kit")]
+pub mod testkit;
+
+pub use entropy::Entropy;
+pub use facade::{
+    Command, Engine, EngineError, Event, EventStream, LoginSecret, NodeId, NodeKind, Permission,
+    Staleness,
+};
+pub use profile::SyncTimingProfile;
+pub use seams::{SeamError, SeamResult, SeamSet, SeamTypes};
+
+/// Placeholder identity item; kept for the sibling crate stubs' dependency
+/// tests until real cross-crate surface replaces it.
 pub const CRATE: &str = "cipherbox-engine";
 
 #[cfg(test)]
@@ -13,12 +47,5 @@ mod tests {
     #[test]
     fn crate_name() {
         assert_eq!(super::CRATE, "cipherbox-engine");
-    }
-
-    #[test]
-    fn depends_on_core() {
-        use cipherbox_core::codec::{Value, decode, encode};
-        let bytes = encode(&Value::Unsigned(1));
-        assert_eq!(decode(&bytes).unwrap(), Value::Unsigned(1));
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -30,7 +30,7 @@ pub mod seams;
 #[cfg(feature = "test-kit")]
 pub mod testkit;
 
-pub use entropy::Entropy;
+pub use entropy::{Entropy, EntropyError};
 pub use facade::{
     Command, Engine, EngineError, Event, EventStream, LoginSecret, NodeId, NodeKind, Permission,
     PlaintextContent, Staleness,

--- a/crates/engine/src/profile.rs
+++ b/crates/engine/src/profile.rs
@@ -1,0 +1,134 @@
+//! The sync timing profile — environment-scoped timing policy
+//! (blueprint/engine.md "Sync core", blueprint/testing.md "The DX hook").
+
+use core::time::Duration;
+
+/// The environment-scoped bundle of sync timing policy (#33 D3).
+///
+/// Policy is injected: the engine never hardcodes a timing constant — every
+/// TTL, cadence, and threshold reads from the profile handed to the
+/// constructor. The profile is the CI-DX hook: the [`CI`] profile makes
+/// cross-client e2e flows run at speed, the [`PRODUCTION`] profile is the
+/// shipped policy.
+///
+/// There is deliberately **no `Default`**: v1 fell into a silent 5-minute
+/// library default through an unset TTL, so every construction site states
+/// its profile explicitly and [`record_ttl`] is always a real value — never
+/// zero, never unset.
+///
+/// [`CI`]: SyncTimingProfile::CI
+/// [`PRODUCTION`]: SyncTimingProfile::PRODUCTION
+/// [`record_ttl`]: SyncTimingProfile::record_ttl
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SyncTimingProfile {
+    /// TTL embedded in every published IPNS record. Always explicit;
+    /// independent of the 90-day EOL.
+    pub record_ttl: Duration,
+    /// Focus-window poll tick cadence (jitter is applied by the engine from
+    /// injected entropy).
+    pub poll_cadence: Duration,
+    /// Staleness-ladder threshold: a view unrefreshed this long shows the
+    /// stale badge (~3 missed poll cycles per #33 D4).
+    pub stale_after: Duration,
+    /// Withheld-update escalation window: a shared-scope name pinned this
+    /// long while other resolves succeed raises the stronger warning
+    /// (#33 D7).
+    pub escalation_window: Duration,
+    /// Scope-pointer consult interval — polled, not fallback (#38 D4);
+    /// bounds the read-only-survivor residual.
+    pub pointer_consult_interval: Duration,
+    /// Offline staging budget in bytes: past it, new uploads fail fast;
+    /// metadata ops queue unbounded (#33 D6).
+    pub staging_budget_bytes: u64,
+}
+
+impl SyncTimingProfile {
+    /// Shipped policy: TTL 1 minute, 30 s poll (#33 D3).
+    ///
+    /// `escalation_window`, `pointer_consult_interval`, and
+    /// `staging_budget_bytes` are placeholders pending the measurement
+    /// process fixed in blueprint/testing.md ("The profile is where
+    /// measured constants land"); each lands as a profile-constant change
+    /// with its measurement linked.
+    pub const PRODUCTION: Self = Self {
+        record_ttl: Duration::from_secs(60),
+        poll_cadence: Duration::from_secs(30),
+        stale_after: Duration::from_secs(90),
+        escalation_window: Duration::from_secs(600),
+        pointer_consult_interval: Duration::from_secs(30),
+        staging_budget_bytes: 1 << 30,
+    };
+
+    /// CI policy: record TTL 1–5 s (small but nonzero), compressed
+    /// cadences, and a small staging budget so budget-exhaustion paths are
+    /// reachable (blueprint/testing.md "The DX hook").
+    pub const CI: Self = Self {
+        record_ttl: Duration::from_secs(2),
+        poll_cadence: Duration::from_secs(1),
+        stale_after: Duration::from_secs(3),
+        escalation_window: Duration::from_secs(5),
+        pointer_consult_interval: Duration::from_secs(1),
+        staging_budget_bytes: 256 * 1024,
+    };
+}
+
+#[cfg(test)]
+// These tests deliberately assert on constants: they are the guard-rail
+// that a future edit to a profile value cannot drift silently past the
+// blueprint's ranges.
+#[allow(clippy::assertions_on_constants)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_matches_design_values() {
+        let p = SyncTimingProfile::PRODUCTION;
+        assert_eq!(
+            p.record_ttl,
+            Duration::from_secs(60),
+            "TTL 1 minute per #33 D3"
+        );
+        assert_eq!(
+            p.poll_cadence,
+            Duration::from_secs(30),
+            "30 s poll per #33 D3"
+        );
+        assert_eq!(
+            p.stale_after,
+            Duration::from_secs(90),
+            "stale badge after ~3 missed 30 s cycles"
+        );
+    }
+
+    #[test]
+    fn ci_ttl_is_small_but_nonzero() {
+        let ttl = SyncTimingProfile::CI.record_ttl;
+        assert!(
+            ttl >= Duration::from_secs(1) && ttl <= Duration::from_secs(5),
+            "CI record TTL must be 1-5 s per blueprint/testing.md"
+        );
+    }
+
+    #[test]
+    fn every_duration_is_nonzero_in_both_profiles() {
+        for profile in [SyncTimingProfile::PRODUCTION, SyncTimingProfile::CI] {
+            assert!(
+                !profile.record_ttl.is_zero(),
+                "TTL is always explicit, never zero"
+            );
+            assert!(!profile.poll_cadence.is_zero());
+            assert!(!profile.stale_after.is_zero());
+            assert!(!profile.escalation_window.is_zero());
+            assert!(!profile.pointer_consult_interval.is_zero());
+            assert!(profile.staging_budget_bytes > 0);
+        }
+    }
+
+    #[test]
+    fn ci_staging_budget_keeps_exhaustion_reachable() {
+        assert!(
+            SyncTimingProfile::CI.staging_budget_bytes <= 1024 * 1024,
+            "CI budget must be small enough to exhaust in a test"
+        );
+    }
+}

--- a/crates/engine/src/seams/credential_store.rs
+++ b/crates/engine/src/seams/credential_store.rs
@@ -1,0 +1,23 @@
+//! `CredentialStore` — refresh-token persistence (blueprint/engine.md).
+
+use super::SeamResult;
+
+/// Refresh-token persistence.
+///
+/// The rotating refresh token persists per platform: OS keychain on
+/// desktop; a **no-op** on web, where the HTTP-only cookie rides the
+/// [`super::Http`] seam instead. The no-op is contractual, so persistence
+/// is best-effort: `load` after `store` returns either the stored token or
+/// `None` — never a different token — and `clear` always results in `None`.
+/// The short-lived access JWT never touches this seam (engine memory only).
+pub trait CredentialStore {
+    /// Persists the refresh token, replacing any previous one. A no-op
+    /// implementation may discard it.
+    async fn store_refresh_token(&self, refresh_token: &[u8]) -> SeamResult<()>;
+
+    /// The persisted refresh token, if any.
+    async fn load_refresh_token(&self) -> SeamResult<Option<Vec<u8>>>;
+
+    /// Deletes any persisted refresh token. Idempotent.
+    async fn clear_refresh_token(&self) -> SeamResult<()>;
+}

--- a/crates/engine/src/seams/floor_store.rs
+++ b/crates/engine/src/seams/floor_store.rs
@@ -1,0 +1,37 @@
+//! `FloorStore` — durable monotonic-max floors (blueprint/engine.md).
+
+use super::SeamResult;
+
+/// Durable monotonic-max per-scope epoch floors and per-name sequence
+/// floors; regression rejects fail-closed.
+///
+/// The floor law (blueprint/engine.md, #39 D4) lives in the engine — this
+/// seam only stores. Its contract, enforced by the conformance kit
+/// (`testkit::conformance::floor_store` under the `test-kit` feature):
+///
+/// - **Monotonic-max**: a `raise_*` call never lowers a floor. Raising to a
+///   value at or below the stored floor is a no-op that reports the stored
+///   floor — the store is structurally incapable of regression.
+/// - **Durable**: raised floors survive reopening the store (new session,
+///   new handle over the same backing).
+/// - **Namespaced**: epoch floors and sequence floors are independent maps;
+///   identical key bytes in the two namespaces never collide.
+///
+/// Keys are opaque bytes chosen by the engine (scope identifiers for epoch
+/// floors, `ipnsName` bytes for sequence floors); the store never interprets
+/// them. Hosts: IndexedDB (web), local journal (desktop).
+pub trait FloorStore {
+    /// The durable epoch floor for a scope, if one was ever raised.
+    async fn epoch_floor(&self, scope_id: &[u8]) -> SeamResult<Option<u64>>;
+
+    /// Raises the scope's epoch floor to `max(stored, epoch)`, durably, and
+    /// returns the resulting stored floor.
+    async fn raise_epoch_floor(&self, scope_id: &[u8], epoch: u64) -> SeamResult<u64>;
+
+    /// The durable sequence floor for a name, if one was ever raised.
+    async fn sequence_floor(&self, ipns_name: &[u8]) -> SeamResult<Option<u64>>;
+
+    /// Raises the name's sequence floor to `max(stored, sequence)`, durably,
+    /// and returns the resulting stored floor.
+    async fn raise_sequence_floor(&self, ipns_name: &[u8], sequence: u64) -> SeamResult<u64>;
+}

--- a/crates/engine/src/seams/http.rs
+++ b/crates/engine/src/seams/http.rs
@@ -1,0 +1,62 @@
+//! `Http` — plain HTTP transport (blueprint/engine.md).
+
+use super::SeamResult;
+
+/// HTTP method of a [`HttpRequest`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HttpMethod {
+    /// GET
+    Get,
+    /// POST
+    Post,
+    /// PUT
+    Put,
+    /// PATCH
+    Patch,
+    /// DELETE
+    Delete,
+    /// HEAD
+    Head,
+}
+
+/// One HTTP request, fully described by the engine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpRequest {
+    /// Request method.
+    pub method: HttpMethod,
+    /// Absolute URL.
+    pub url: String,
+    /// Header name/value pairs, in send order.
+    pub headers: Vec<(String, String)>,
+    /// Request body bytes, if any.
+    pub body: Option<Vec<u8>>,
+}
+
+/// One HTTP response, returned verbatim to the engine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpResponse {
+    /// Status code.
+    pub status: u16,
+    /// Header name/value pairs as received.
+    pub headers: Vec<(String, String)>,
+    /// Response body bytes.
+    pub body: Vec<u8>,
+}
+
+/// Plain HTTP for the hand-written API client, the trustless gateway read
+/// path, and BYO pin providers.
+///
+/// A pure byte mover: the transport adds no headers the engine did not ask
+/// for, follows the host's cookie policy (web rides the HTTP-only refresh
+/// cookie here via `credentials: 'include'`, which is why web's
+/// [`super::CredentialStore`] is a no-op), and never interprets bodies.
+/// Non-2xx statuses are responses, not errors — a seam `Err` is reserved
+/// for transport-level failure (unreachable, aborted).
+///
+/// No conformance kit ships for this seam: it has no seam-local durable
+/// semantics; its behavior is exercised end-to-end by the live contract
+/// suite (blueprint/testing.md).
+pub trait Http {
+    /// Sends one request and resolves with the complete response.
+    async fn send(&self, request: HttpRequest) -> SeamResult<HttpResponse>;
+}

--- a/crates/engine/src/seams/http.rs
+++ b/crates/engine/src/seams/http.rs
@@ -1,6 +1,30 @@
 //! `Http` — plain HTTP transport (blueprint/engine.md).
 
+use core::fmt;
+
 use super::SeamResult;
+
+/// Formats headers as their names only. Header values ride this seam
+/// carrying live credentials (`Authorization` bearer JWTs, refresh
+/// cookies) and must never reach logs.
+struct HeaderNames<'a>(&'a [(String, String)]);
+
+impl fmt::Debug for HeaderNames<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list()
+            .entries(self.0.iter().map(|(name, _)| name))
+            .finish()
+    }
+}
+
+/// Formats a body as its byte length only.
+struct BodyLen(usize);
+
+impl fmt::Debug for BodyLen {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "<{} bytes>", self.0)
+    }
+}
 
 /// HTTP method of a [`HttpRequest`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -20,7 +44,11 @@ pub enum HttpMethod {
 }
 
 /// One HTTP request, fully described by the engine.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `Debug` is hand-written: header values and bodies carry credentials and
+/// are redacted to names and byte lengths (security rule 2 — never log
+/// sensitive material).
+#[derive(Clone, PartialEq, Eq)]
 pub struct HttpRequest {
     /// Request method.
     pub method: HttpMethod,
@@ -32,8 +60,22 @@ pub struct HttpRequest {
     pub body: Option<Vec<u8>>,
 }
 
+impl fmt::Debug for HttpRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HttpRequest")
+            .field("method", &self.method)
+            .field("url", &self.url)
+            .field("headers", &HeaderNames(&self.headers))
+            .field("body", &self.body.as_ref().map(|body| BodyLen(body.len())))
+            .finish()
+    }
+}
+
 /// One HTTP response, returned verbatim to the engine.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `Debug` is hand-written: header values (`Set-Cookie`) and bodies are
+/// redacted to names and byte lengths, like [`HttpRequest`].
+#[derive(Clone, PartialEq, Eq)]
 pub struct HttpResponse {
     /// Status code.
     pub status: u16,
@@ -41,6 +83,16 @@ pub struct HttpResponse {
     pub headers: Vec<(String, String)>,
     /// Response body bytes.
     pub body: Vec<u8>,
+}
+
+impl fmt::Debug for HttpResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HttpResponse")
+            .field("status", &self.status)
+            .field("headers", &HeaderNames(&self.headers))
+            .field("body", &BodyLen(self.body.len()))
+            .finish()
+    }
 }
 
 /// Plain HTTP for the hand-written API client, the trustless gateway read
@@ -59,4 +111,37 @@ pub struct HttpResponse {
 pub trait Http {
     /// Sends one request and resolves with the complete response.
     async fn send(&self, request: HttpRequest) -> SeamResult<HttpResponse>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_debug_redacts_header_values_and_body() {
+        let request = HttpRequest {
+            method: HttpMethod::Post,
+            url: "https://api.example/auth/refresh".into(),
+            headers: vec![("Authorization".into(), "Bearer secret-jwt".into())],
+            body: Some(b"refresh-token-bytes".to_vec()),
+        };
+        let debug = format!("{request:?}");
+        assert!(!debug.contains("secret-jwt"), "header values must not leak");
+        assert!(!debug.contains("refresh-token-bytes"), "body must not leak");
+        assert!(debug.contains("Authorization"), "header names stay visible");
+        assert!(debug.contains("<19 bytes>"), "body renders as a length");
+    }
+
+    #[test]
+    fn response_debug_redacts_header_values_and_body() {
+        let response = HttpResponse {
+            status: 200,
+            headers: vec![("Set-Cookie".into(), "refresh=secret-cookie".into())],
+            body: b"account-payload".to_vec(),
+        };
+        let debug = format!("{response:?}");
+        assert!(!debug.contains("secret-cookie"), "cookie must not leak");
+        assert!(!debug.contains("account-payload"), "body must not leak");
+        assert!(debug.contains("Set-Cookie") && debug.contains("200"));
+    }
 }

--- a/crates/engine/src/seams/mailbox.rs
+++ b/crates/engine/src/seams/mailbox.rs
@@ -1,0 +1,49 @@
+//! `Mailbox` — sealed-blob discovery transport (blueprint/engine.md).
+
+use super::SeamResult;
+
+/// One pending mailbox item, as delivered by [`Mailbox::poll`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MailboxItem {
+    /// Transport-assigned identifier, used to ack.
+    pub item_id: String,
+    /// The sealed payload, opaque to the transport. Sender authentication
+    /// lives inside the seal and is verified by the engine (#39 D9).
+    pub sealed_payload: Vec<u8>,
+}
+
+/// Post/poll/ack of sealed blobs to/from a recipient public key.
+///
+/// An integrity-untrusted transport for discovery and courtesy traffic only
+/// (share pointers, re-point accelerators, invite claims) — nothing on it is
+/// load-bearing for safety. One instance is bound to one account's inbox:
+/// [`Mailbox::poll`] reads the caller's own items. Contract, enforced by the
+/// conformance kit:
+///
+/// - **Until-acked retention**: an item stays visible to `poll` until acked;
+///   ack deletes, and acking is idempotent.
+/// - **Idempotent post**: re-posting with an already-seen idempotency key
+///   for the same recipient creates no second item.
+///
+/// v2.0 rides the API mailbox via the engine's own API client on both
+/// platforms; a decentralized inbox stays swappable behind this trait
+/// (#25 D2).
+pub trait Mailbox {
+    /// Posts a sealed payload to a recipient's inbox.
+    async fn post(
+        &self,
+        recipient_public_key: &[u8],
+        sealed_payload: &[u8],
+        idempotency_key: &str,
+    ) -> SeamResult<()>;
+
+    /// All items currently pending in the caller's own inbox.
+    async fn poll(&self) -> SeamResult<Vec<MailboxItem>>;
+
+    /// Acknowledges (deletes) one item. Idempotent: acking an already-acked
+    /// or unknown item succeeds.
+    ///
+    /// The engine acks only after the pointed-at fact is durably recorded
+    /// (blueprint/engine.md "Mailbox logic").
+    async fn ack(&self, item_id: &str) -> SeamResult<()>;
+}

--- a/crates/engine/src/seams/mod.rs
+++ b/crates/engine/src/seams/mod.rs
@@ -1,0 +1,126 @@
+//! Host seams — the nine constructor trait contracts (blueprint/engine.md
+//! "Host seams").
+//!
+//! Every capability the engine needs from a host enters through one of these
+//! traits, injected as a constructor argument via [`SeamSet`]. Traits move
+//! opaque bytes and events — no seam holds logic, no domain type leaks into a
+//! seam; the engine owns all interpretation. A missing seam is a compile
+//! error (a missing [`SeamSet`] field), never a runtime gap.
+//!
+//! Determinism is injected: wall clock and timers come only from
+//! [`Scheduler`], entropy only from [`crate::entropy::Entropy`]. Engine logic
+//! never calls a clock or RNG directly.
+
+mod credential_store;
+mod floor_store;
+mod http;
+mod mailbox;
+mod record_transport;
+mod refresh_hint;
+mod scheduler;
+mod snapshot_cache;
+mod staging_store;
+
+pub use credential_store::CredentialStore;
+pub use floor_store::FloorStore;
+pub use http::{Http, HttpMethod, HttpRequest, HttpResponse};
+pub use mailbox::{Mailbox, MailboxItem};
+pub use record_transport::{EndpointId, RecordTransport};
+pub use refresh_hint::{RefreshHint, RefreshHintSource};
+pub use scheduler::{BoxedTask, Scheduler, UnixMillis};
+pub use snapshot_cache::SnapshotCache;
+pub use staging_store::{OpId, StagingStore};
+
+use core::fmt;
+
+/// Error returned by a seam implementation.
+///
+/// Deliberately opaque at this layer: a seam failure is a host-side I/O or
+/// availability problem, never a trust decision — trust classification
+/// happens in the engine (adoption gate, floor law). The message exists for
+/// diagnostics only and must never carry key material.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SeamError {
+    message: String,
+}
+
+impl SeamError {
+    /// Builds a seam error from a diagnostic message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// The diagnostic message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for SeamError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "seam error: {}", self.message)
+    }
+}
+
+impl std::error::Error for SeamError {}
+
+/// Result alias used by every seam method.
+pub type SeamResult<T> = Result<T, SeamError>;
+
+/// The type family binding one host's nine concrete seam implementations.
+///
+/// A host (web worker realm, desktop process, the test kit) implements this
+/// trait once, naming its concrete type for every seam. Collapsing the nine
+/// generics into one type parameter keeps [`SeamSet`] and
+/// [`crate::facade::Engine`] signatures readable while preserving full
+/// static dispatch — no boxing, no `Send` assumptions, so the same engine
+/// compiles natively and to WASM.
+pub trait SeamTypes {
+    /// Durable floor storage ([`FloorStore`]).
+    type FloorStore: FloorStore;
+    /// Dumb `/routing/v1` byte mover ([`RecordTransport`]).
+    type RecordTransport: RecordTransport;
+    /// Plain HTTP ([`Http`]).
+    type Http: Http;
+    /// Sealed-blob mailbox transport ([`Mailbox`]).
+    type Mailbox: Mailbox;
+    /// Host refresh-hint event stream ([`RefreshHintSource`]).
+    type RefreshHintSource: RefreshHintSource;
+    /// Timers, background tasks, wall clock ([`Scheduler`]).
+    type Scheduler: Scheduler;
+    /// Durable op queue and staged bytes ([`StagingStore`]).
+    type StagingStore: StagingStore;
+    /// Durable last-known-good cache ([`SnapshotCache`]).
+    type SnapshotCache: SnapshotCache;
+    /// Refresh-token persistence ([`CredentialStore`]).
+    type CredentialStore: CredentialStore;
+}
+
+/// The whole seam set, taken by the engine constructor in one piece.
+///
+/// Field-struct construction is the compile-time completeness gate
+/// (blueprint/engine.md doctrine, #26 D8): omitting any seam is a missing
+/// struct field — a compile error, not a silent behavior gap. There are no
+/// optional seams and no defaults.
+pub struct SeamSet<T: SeamTypes> {
+    /// Durable monotonic-max floors; fail-closed regression rejection.
+    pub floor_store: T::FloorStore,
+    /// GET/PUT of opaque signed record bytes against the endpoint set.
+    pub record_transport: T::RecordTransport,
+    /// HTTP for the API client, trustless gateway, and BYO providers.
+    pub http: T::Http,
+    /// Post/poll/ack of sealed blobs to/from a recipient public key.
+    pub mailbox: T::Mailbox,
+    /// Host events that force an immediate sync tick.
+    pub refresh_hints: T::RefreshHintSource,
+    /// Jittered timers, background task execution, wall clock.
+    pub scheduler: T::Scheduler,
+    /// Durable op queue plus staged upload bytes.
+    pub staging_store: T::StagingStore,
+    /// Durable last-known-good record/metadata cache, ciphertext-only.
+    pub snapshot_cache: T::SnapshotCache,
+    /// Refresh-token persistence.
+    pub credential_store: T::CredentialStore,
+}

--- a/crates/engine/src/seams/record_transport.rs
+++ b/crates/engine/src/seams/record_transport.rs
@@ -1,0 +1,53 @@
+//! `RecordTransport` — dumb `/routing/v1` byte mover (blueprint/engine.md).
+
+use super::SeamResult;
+
+/// Identifies one configured `/routing/v1` endpoint.
+///
+/// Opaque to the engine: it enumerates endpoints for fan-out GET / parallel
+/// PUT bookkeeping and hands the token back to the transport, which alone
+/// knows how to reach it (URL, embedded DHT node, …).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct EndpointId(pub String);
+
+impl EndpointId {
+    /// Builds an endpoint identifier.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+/// Dumb `/routing/v1` byte mover: GET/PUT of opaque signed record bytes
+/// against a configured endpoint set.
+///
+/// The engine owns IPNS end-to-end (#28 D2): core signs and verifies,
+/// this seam only moves bytes. Fan-out across the endpoint set, CAS,
+/// re-resolve confirmation, and every trust decision live in the engine —
+/// a transport never inspects, caches, or reorders records.
+///
+/// The endpoint set is host configuration: CipherBox someguy plus at least
+/// one independent public endpoint (#23 D1); a desktop embedded rust-libp2p
+/// kad backend is designed-for behind this same trait (#23 D2).
+pub trait RecordTransport {
+    /// The configured endpoint set. Never empty; order is not significant.
+    fn endpoints(&self) -> Vec<EndpointId>;
+
+    /// GET the signed record bytes stored for `routing_key` at one endpoint;
+    /// `None` when the endpoint holds no record for that key.
+    ///
+    /// `routing_key` is the exact `/routing/v1` path segment (the textual
+    /// IPNS name); the transport must not interpret it beyond addressing.
+    async fn get_record(
+        &self,
+        endpoint: &EndpointId,
+        routing_key: &str,
+    ) -> SeamResult<Option<Vec<u8>>>;
+
+    /// PUT opaque signed record bytes for `routing_key` at one endpoint.
+    async fn put_record(
+        &self,
+        endpoint: &EndpointId,
+        routing_key: &str,
+        record: &[u8],
+    ) -> SeamResult<()>;
+}

--- a/crates/engine/src/seams/refresh_hint.rs
+++ b/crates/engine/src/seams/refresh_hint.rs
@@ -1,0 +1,26 @@
+//! `RefreshHintSource` — host events forcing an immediate tick
+//! (blueprint/engine.md).
+
+/// One refresh hint. Carries no payload in v2.0: a hint only ever means
+/// "run an immediate focus-window tick now".
+///
+/// The designed-for push overlay (#33 D1 — API WebSocket hints, desktop
+/// PubSub) extends this type behind the same seam when it lands; hosts and
+/// the engine already treat hints as events, so richer payloads are
+/// additive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RefreshHint;
+
+/// Host-event stream that forces an immediate sync tick.
+///
+/// Web: UI navigation, tab-visibility regain, `online` reconnect, cross-tab
+/// focus hints. Desktop: FUSE-op TTL checks, reconnect. Hints are
+/// best-effort accelerators — losing one costs staleness bounded by the
+/// poll cadence, never correctness — so no conformance kit ships for this
+/// seam: it has no durable semantics, and its events are host-driven.
+pub trait RefreshHintSource {
+    /// Waits for the next hint; `None` once the source is closed for good
+    /// (host shutdown). The engine treats `None` as end-of-stream and stops
+    /// listening.
+    async fn next_hint(&mut self) -> Option<RefreshHint>;
+}

--- a/crates/engine/src/seams/scheduler.rs
+++ b/crates/engine/src/seams/scheduler.rs
@@ -15,11 +15,6 @@ impl UnixMillis {
         let millis = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
         Self(self.0.saturating_add(millis))
     }
-
-    /// The duration elapsed since `earlier`; zero if `earlier` is later.
-    pub fn saturating_since(self, earlier: Self) -> Duration {
-        Duration::from_millis(self.0.saturating_sub(earlier.0))
-    }
 }
 
 /// A boxed background task handed to [`Scheduler::spawn`].

--- a/crates/engine/src/seams/scheduler.rs
+++ b/crates/engine/src/seams/scheduler.rs
@@ -1,0 +1,52 @@
+//! `Scheduler` — timers, background tasks, wall clock (blueprint/engine.md).
+
+use core::future::Future;
+use core::pin::Pin;
+use core::time::Duration;
+
+/// Milliseconds since the Unix epoch, as reported by the host wall clock
+/// (or the virtual clock in tests).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct UnixMillis(pub u64);
+
+impl UnixMillis {
+    /// This instant advanced by `duration`, saturating at the maximum.
+    pub fn saturating_add(self, duration: Duration) -> Self {
+        let millis = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
+        Self(self.0.saturating_add(millis))
+    }
+
+    /// The duration elapsed since `earlier`; zero if `earlier` is later.
+    pub fn saturating_since(self, earlier: Self) -> Duration {
+        Duration::from_millis(self.0.saturating_sub(earlier.0))
+    }
+}
+
+/// A boxed background task handed to [`Scheduler::spawn`].
+///
+/// Deliberately not `Send`: the engine is the single writer and runs pinned
+/// to one execution context on every host (the worker on web, a
+/// single-threaded task context on desktop), so seam futures never cross
+/// threads and the same code compiles to WASM unchanged.
+pub type BoxedTask = Pin<Box<dyn Future<Output = ()> + 'static>>;
+
+/// Jittered timers, background task execution, and the wall clock.
+///
+/// The only source of time in the engine (determinism law): timestamps for
+/// core's pure functions come from [`Scheduler::now`], delays from
+/// [`Scheduler::sleep`]. Jitter is computed by the engine from injected
+/// entropy — hosts sleep exactly the duration asked. Hosts: worker timers
+/// (web, coarse throttling tolerated), tokio (desktop); the test kit ships
+/// a virtual clock.
+pub trait Scheduler {
+    /// Current wall-clock time.
+    fn now(&self) -> UnixMillis;
+
+    /// Resolves after at least `duration` of host time has passed.
+    async fn sleep(&self, duration: Duration);
+
+    /// Runs a background task to completion on the engine's execution
+    /// context. Fire-and-forget: completion is observed only through the
+    /// task's own effects.
+    fn spawn(&self, task: BoxedTask);
+}

--- a/crates/engine/src/seams/scheduler.rs
+++ b/crates/engine/src/seams/scheduler.rs
@@ -11,8 +11,10 @@ pub struct UnixMillis(pub u64);
 
 impl UnixMillis {
     /// This instant advanced by `duration`, saturating at the maximum.
+    /// Sub-millisecond remainders round **up**, so a non-zero duration
+    /// always advances the instant (a deadline never truncates to "now").
     pub fn saturating_add(self, duration: Duration) -> Self {
-        let millis = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
+        let millis = u64::try_from(duration.as_nanos().div_ceil(1_000_000)).unwrap_or(u64::MAX);
         Self(self.0.saturating_add(millis))
     }
 }
@@ -44,4 +46,28 @@ pub trait Scheduler {
     /// context. Fire-and-forget: completion is observed only through the
     /// task's own effects.
     fn spawn(&self, task: BoxedTask);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn saturating_add_rounds_sub_millisecond_durations_up() {
+        let base = UnixMillis(10);
+        assert_eq!(base.saturating_add(Duration::ZERO), UnixMillis(10));
+        assert_eq!(
+            base.saturating_add(Duration::from_micros(1)),
+            UnixMillis(11),
+            "a non-zero duration must advance the instant"
+        );
+        assert_eq!(
+            base.saturating_add(Duration::from_micros(1_500)),
+            UnixMillis(12)
+        );
+        assert_eq!(
+            UnixMillis(u64::MAX).saturating_add(Duration::from_secs(1)),
+            UnixMillis(u64::MAX)
+        );
+    }
 }

--- a/crates/engine/src/seams/snapshot_cache.rs
+++ b/crates/engine/src/seams/snapshot_cache.rs
@@ -1,0 +1,30 @@
+//! `SnapshotCache` — durable last-known-good cache (blueprint/engine.md).
+
+use super::SeamResult;
+
+/// Durable last-known-good record/metadata cache backing cache-first reads.
+///
+/// **Ciphertext-only at rest**: the engine only ever hands this store sealed
+/// bytes and unseals on read — plaintext never lands in host storage
+/// (blueprint/web-client.md seam table). The store must treat values as
+/// opaque: arbitrary, non-decodable bytes round-trip verbatim; the
+/// conformance kit feeds it garbage to prove the store never requires
+/// parseable content. Only gate-passing records ever reach this cache — the
+/// adoption gate runs upstream, in the engine.
+///
+/// Keys are opaque bytes chosen by the engine. Contents survive logout by
+/// design (cache-first rendering after restart); an explicit
+/// "forget this device" clears them via [`SnapshotCache::clear`].
+pub trait SnapshotCache {
+    /// Stores ciphertext under a key, replacing any previous value.
+    async fn put(&self, cache_key: &[u8], ciphertext: &[u8]) -> SeamResult<()>;
+
+    /// The ciphertext at a key, verbatim; `None` if absent.
+    async fn get(&self, cache_key: &[u8]) -> SeamResult<Option<Vec<u8>>>;
+
+    /// Removes one entry. Idempotent.
+    async fn remove(&self, cache_key: &[u8]) -> SeamResult<()>;
+
+    /// Removes every entry ("forget this device").
+    async fn clear(&self) -> SeamResult<()>;
+}

--- a/crates/engine/src/seams/staging_store.rs
+++ b/crates/engine/src/seams/staging_store.rs
@@ -1,0 +1,51 @@
+//! `StagingStore` — durable op queue and staged bytes (blueprint/engine.md).
+
+use super::SeamResult;
+
+/// Store-assigned identifier of one queued op. Strictly increasing per
+/// store, never reused — enqueue order is FIFO order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OpId(pub u64);
+
+/// Durable op queue plus staged upload bytes, behind the sync-timing-profile
+/// staging budget.
+///
+/// Every mutation rides the durable op queue (#33 D6); ops are opaque
+/// encoded intent records — the engine owns their encoding, replay, rebase,
+/// and dead-lettering. Staged upload bytes are keyed by opaque staging keys;
+/// the engine knows which ops reference which keys, and drives orphan GC
+/// through [`StagingStore::staged_keys`] / `remove_staged_bytes`. Budget
+/// enforcement is engine policy fed by [`StagingStore::staged_bytes_total`].
+///
+/// Contract, enforced by the conformance kit: FIFO ordering with strictly
+/// increasing never-reused ids, durability of queue and staged bytes across
+/// reopen, and enumeration/removal exact enough that orphan GC is
+/// implementable. Hosts: IndexedDB + OPFS (web), local journal (desktop).
+pub trait StagingStore {
+    /// Appends an opaque op record to the durable FIFO queue and returns
+    /// its id.
+    async fn enqueue_op(&self, op: &[u8]) -> SeamResult<OpId>;
+
+    /// Every queued op in FIFO (ascending-id) order.
+    async fn queued_ops(&self) -> SeamResult<Vec<(OpId, Vec<u8>)>>;
+
+    /// Removes one op (completed, rebased away, or dead-lettered).
+    /// Idempotent: removing an unknown id succeeds.
+    async fn remove_op(&self, op_id: OpId) -> SeamResult<()>;
+
+    /// Stores staged bytes under an opaque staging key, replacing any
+    /// previous bytes at that key.
+    async fn put_staged_bytes(&self, staging_key: &[u8], bytes: &[u8]) -> SeamResult<()>;
+
+    /// The staged bytes at a key, verbatim; `None` if absent.
+    async fn staged_bytes(&self, staging_key: &[u8]) -> SeamResult<Option<Vec<u8>>>;
+
+    /// Removes the staged bytes at a key. Idempotent.
+    async fn remove_staged_bytes(&self, staging_key: &[u8]) -> SeamResult<()>;
+
+    /// Every staging key currently holding bytes (orphan-GC enumeration).
+    async fn staged_keys(&self) -> SeamResult<Vec<Vec<u8>>>;
+
+    /// Total staged payload bytes across all keys (budget input).
+    async fn staged_bytes_total(&self) -> SeamResult<u64>;
+}

--- a/crates/engine/src/testkit/conformance/credential_store.rs
+++ b/crates/engine/src/testkit/conformance/credential_store.rs
@@ -1,0 +1,70 @@
+//! Conformance kit: [`CredentialStore`] best-effort persistence.
+
+use crate::seams::CredentialStore;
+
+/// Runs the `CredentialStore` contract against an implementation.
+///
+/// `open` must return a handle over the same backing on every call; the
+/// backing must start empty. The contract is deliberately best-effort —
+/// web's no-op implementation is valid (blueprint/engine.md seam table) —
+/// so the kit asserts consistency, never mandatory persistence: `load`
+/// returns the last stored token or `None`, never anything else, and
+/// `clear` always results in `None`.
+///
+/// # Panics
+/// Panics on the first contract violation.
+pub async fn check<S, F>(mut open: F)
+where
+    S: CredentialStore,
+    F: AsyncFnMut() -> S,
+{
+    let store = open().await;
+
+    assert_eq!(
+        store.load_refresh_token().await.unwrap(),
+        None,
+        "a fresh backing must hold no token"
+    );
+
+    store.store_refresh_token(b"token-1").await.unwrap();
+    let loaded = store.load_refresh_token().await.unwrap();
+    assert!(
+        loaded.is_none() || loaded.as_deref() == Some(b"token-1".as_slice()),
+        "load must return the stored token or None, never a different token"
+    );
+    assert_eq!(
+        store.load_refresh_token().await.unwrap(),
+        loaded,
+        "repeated loads must agree"
+    );
+
+    // A persisting implementation must replace on store.
+    if loaded.is_some() {
+        store.store_refresh_token(b"token-2").await.unwrap();
+        assert_eq!(
+            store.load_refresh_token().await.unwrap().as_deref(),
+            Some(b"token-2".as_slice()),
+            "a persisting store must replace the token"
+        );
+
+        // ... and keep it across reopen.
+        let reopened = open().await;
+        assert_eq!(
+            reopened.load_refresh_token().await.unwrap().as_deref(),
+            Some(b"token-2".as_slice()),
+            "a persisting store must keep the token across reopen"
+        );
+    }
+
+    // Clear always lands on None, durably, and is idempotent.
+    let store = open().await;
+    store.clear_refresh_token().await.unwrap();
+    store.clear_refresh_token().await.unwrap();
+    assert_eq!(store.load_refresh_token().await.unwrap(), None);
+    let reopened = open().await;
+    assert_eq!(
+        reopened.load_refresh_token().await.unwrap(),
+        None,
+        "clear must be durable"
+    );
+}

--- a/crates/engine/src/testkit/conformance/floor_store.rs
+++ b/crates/engine/src/testkit/conformance/floor_store.rs
@@ -1,0 +1,90 @@
+//! Conformance kit: [`FloorStore`] monotonicity, durability, and
+//! namespacing.
+
+use crate::seams::FloorStore;
+
+/// Runs the `FloorStore` contract against an implementation.
+///
+/// `open` must return a handle over the same durable backing on every call
+/// (reopen semantics); the backing must start empty.
+///
+/// # Panics
+/// Panics on the first contract violation.
+pub async fn check<S, F>(mut open: F)
+where
+    S: FloorStore,
+    F: AsyncFnMut() -> S,
+{
+    let store = open().await;
+
+    let scope_a = b"scope-a".as_slice();
+    let scope_b = b"scope-b".as_slice();
+
+    // Fresh backing: no floors.
+    assert_eq!(
+        store.epoch_floor(scope_a).await.unwrap(),
+        None,
+        "a never-raised epoch floor must be None"
+    );
+    assert_eq!(
+        store.sequence_floor(scope_a).await.unwrap(),
+        None,
+        "a never-raised sequence floor must be None"
+    );
+
+    // Raise, then attempt a regression: monotonic-max must hold.
+    assert_eq!(store.raise_epoch_floor(scope_a, 5).await.unwrap(), 5);
+    assert_eq!(store.epoch_floor(scope_a).await.unwrap(), Some(5));
+    assert_eq!(
+        store.raise_epoch_floor(scope_a, 3).await.unwrap(),
+        5,
+        "raising below the stored floor must be a no-op reporting the stored floor"
+    );
+    assert_eq!(
+        store.epoch_floor(scope_a).await.unwrap(),
+        Some(5),
+        "a floor must never regress"
+    );
+    assert_eq!(store.raise_epoch_floor(scope_a, 7).await.unwrap(), 7);
+
+    // Idempotent raise to the same value.
+    assert_eq!(store.raise_epoch_floor(scope_a, 7).await.unwrap(), 7);
+
+    // Independent keys.
+    assert_eq!(
+        store.epoch_floor(scope_b).await.unwrap(),
+        None,
+        "epoch floors must be independent per key"
+    );
+    assert_eq!(store.raise_epoch_floor(scope_b, 2).await.unwrap(), 2);
+    assert_eq!(store.epoch_floor(scope_a).await.unwrap(), Some(7));
+
+    // Epoch and sequence namespaces must not collide on identical key
+    // bytes.
+    assert_eq!(
+        store.sequence_floor(scope_a).await.unwrap(),
+        None,
+        "sequence floors must be namespaced apart from epoch floors"
+    );
+    assert_eq!(store.raise_sequence_floor(scope_a, 41).await.unwrap(), 41);
+    assert_eq!(
+        store.raise_sequence_floor(scope_a, 40).await.unwrap(),
+        41,
+        "sequence floors are monotonic-max too"
+    );
+    assert_eq!(store.epoch_floor(scope_a).await.unwrap(), Some(7));
+
+    // Durability: a reopened handle sees every raised floor.
+    let reopened = open().await;
+    assert_eq!(
+        reopened.epoch_floor(scope_a).await.unwrap(),
+        Some(7),
+        "epoch floors must survive reopen"
+    );
+    assert_eq!(reopened.epoch_floor(scope_b).await.unwrap(), Some(2));
+    assert_eq!(
+        reopened.sequence_floor(scope_a).await.unwrap(),
+        Some(41),
+        "sequence floors must survive reopen"
+    );
+}

--- a/crates/engine/src/testkit/conformance/mailbox.rs
+++ b/crates/engine/src/testkit/conformance/mailbox.rs
@@ -1,0 +1,79 @@
+//! Conformance kit: [`Mailbox`] until-acked retention and idempotency.
+
+use crate::seams::Mailbox;
+
+/// Runs the `Mailbox` contract against an implementation.
+///
+/// `mailbox` must be bound to the inbox of `own_recipient_public_key` (the
+/// kit posts to itself) and that inbox must start empty.
+///
+/// # Panics
+/// Panics on the first contract violation.
+pub async fn check<M>(mailbox: &M, own_recipient_public_key: &[u8])
+where
+    M: Mailbox,
+{
+    assert!(
+        mailbox.poll().await.unwrap().is_empty(),
+        "the inbox must start empty"
+    );
+
+    // Post, then poll repeatedly: until-acked retention.
+    mailbox
+        .post(own_recipient_public_key, b"sealed-1", "idem-1")
+        .await
+        .unwrap();
+    let first_poll = mailbox.poll().await.unwrap();
+    assert_eq!(first_poll.len(), 1);
+    assert_eq!(
+        first_poll[0].sealed_payload, b"sealed-1",
+        "the sealed payload must arrive verbatim"
+    );
+    assert_eq!(
+        mailbox.poll().await.unwrap().len(),
+        1,
+        "an unacked item must survive repeated polls"
+    );
+
+    // Idempotent post: an already-seen idempotency key creates no second
+    // item.
+    mailbox
+        .post(own_recipient_public_key, b"sealed-1", "idem-1")
+        .await
+        .unwrap();
+    assert_eq!(
+        mailbox.poll().await.unwrap().len(),
+        1,
+        "re-posting an already-seen idempotency key must not duplicate"
+    );
+
+    // A distinct key is a distinct item.
+    mailbox
+        .post(own_recipient_public_key, b"sealed-2", "idem-2")
+        .await
+        .unwrap();
+    let items = mailbox.poll().await.unwrap();
+    assert_eq!(items.len(), 2);
+    let payloads: Vec<&[u8]> = items.iter().map(|i| i.sealed_payload.as_slice()).collect();
+    assert!(payloads.contains(&b"sealed-1".as_slice()));
+    assert!(payloads.contains(&b"sealed-2".as_slice()));
+
+    // Ack deletes exactly the acked item; acking is idempotent.
+    let first_id = items
+        .iter()
+        .find(|i| i.sealed_payload == b"sealed-1")
+        .expect("item present")
+        .item_id
+        .clone();
+    mailbox.ack(&first_id).await.unwrap();
+    mailbox.ack(&first_id).await.unwrap();
+    let remaining = mailbox.poll().await.unwrap();
+    assert_eq!(remaining.len(), 1, "ack must delete exactly one item");
+    assert_eq!(remaining[0].sealed_payload, b"sealed-2");
+
+    mailbox.ack(&remaining[0].item_id).await.unwrap();
+    assert!(
+        mailbox.poll().await.unwrap().is_empty(),
+        "an acked inbox must poll empty"
+    );
+}

--- a/crates/engine/src/testkit/conformance/mod.rs
+++ b/crates/engine/src/testkit/conformance/mod.rs
@@ -1,0 +1,30 @@
+//! Per-seam conformance kits (blueprint/testing.md "Seam conformance
+//! kits").
+//!
+//! One reusable behavioral suite per seam trait with seam-local semantics;
+//! every real implementation must pass its kit — browser seams inside the
+//! merge-blocking browser suite, desktop seams in cargo tests, the
+//! in-memory fakes in this crate's own tests (which is what proves the kits
+//! themselves). One contract, every platform: the v1 per-platform
+//! store-drift class has no home.
+//!
+//! Shape: each kit is one `check` async function that panics (via
+//! `assert!`) on the first contract violation, so it drops into any test
+//! harness — `#[test]` + `block_on` natively, `wasm_bindgen_test` in the
+//! browser. Kits for durable stores take an `AsyncFnMut() -> S` **factory**;
+//! calling it again must "reopen" the same logical backing (new handle,
+//! same durable state) — that is how durability is asserted without a
+//! process restart. Kits for transports take a live instance.
+//!
+//! Two seams ship no kit, deliberately: `Http` (pure passthrough — its
+//! behavior is the live contract suite's job) and `RefreshHintSource`
+//! (host-driven events, no seam-local semantics; losing hints costs only
+//! staleness).
+
+pub mod credential_store;
+pub mod floor_store;
+pub mod mailbox;
+pub mod record_transport;
+pub mod scheduler;
+pub mod snapshot_cache;
+pub mod staging_store;

--- a/crates/engine/src/testkit/conformance/record_transport.rs
+++ b/crates/engine/src/testkit/conformance/record_transport.rs
@@ -1,0 +1,54 @@
+//! Conformance kit: [`RecordTransport`] endpoint enumeration and byte
+//! fidelity.
+
+use crate::seams::RecordTransport;
+
+/// Runs the `RecordTransport` contract against an implementation.
+///
+/// The caller supplies the payload because real `/routing/v1` endpoints
+/// validate what they store: against a live endpoint, pass a genuinely
+/// signed record and its real routing key; the in-memory fake accepts any
+/// bytes. `routing_key` must be unpublished when the kit starts.
+///
+/// # Panics
+/// Panics on the first contract violation.
+pub async fn check<T>(transport: &T, routing_key: &str, record: &[u8])
+where
+    T: RecordTransport,
+{
+    let endpoints = transport.endpoints();
+    assert!(
+        !endpoints.is_empty(),
+        "the configured endpoint set must never be empty"
+    );
+
+    // An unpublished key resolves to nothing, everywhere — absence is
+    // `None`, not an error.
+    for endpoint in &endpoints {
+        assert_eq!(
+            transport.get_record(endpoint, routing_key).await.unwrap(),
+            None,
+            "an unpublished routing key must GET as None"
+        );
+    }
+
+    // PUT to every endpoint (the engine's parallel fan-out shape), then
+    // read the exact bytes back from each.
+    for endpoint in &endpoints {
+        transport
+            .put_record(endpoint, routing_key, record)
+            .await
+            .unwrap();
+    }
+    for endpoint in &endpoints {
+        assert_eq!(
+            transport
+                .get_record(endpoint, routing_key)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(record),
+            "record bytes must round-trip verbatim — transports never rewrite records"
+        );
+    }
+}

--- a/crates/engine/src/testkit/conformance/scheduler.rs
+++ b/crates/engine/src/testkit/conformance/scheduler.rs
@@ -1,0 +1,34 @@
+//! Conformance kit: [`Scheduler`] clock/timer coherence.
+
+use core::time::Duration;
+
+use crate::seams::Scheduler;
+
+/// Runs the `Scheduler` contract against an implementation.
+///
+/// Works for real schedulers and the virtual clock alike; run the virtual
+/// clock in auto-advance mode (nothing else drives time inside the kit).
+/// `spawn` is fire-and-forget by contract, so the kit only asserts it
+/// accepts a task — execution semantics are host-suite territory.
+///
+/// # Panics
+/// Panics on the first contract violation.
+pub async fn check<S>(scheduler: &S)
+where
+    S: Scheduler,
+{
+    let before = scheduler.now();
+
+    // A zero sleep resolves.
+    scheduler.sleep(Duration::ZERO).await;
+
+    // A real sleep resolves and the clock never runs backwards across it.
+    scheduler.sleep(Duration::from_millis(25)).await;
+    let after = scheduler.now();
+    assert!(
+        after >= before,
+        "the clock must not run backwards across a sleep"
+    );
+
+    scheduler.spawn(Box::pin(async {}));
+}

--- a/crates/engine/src/testkit/conformance/snapshot_cache.rs
+++ b/crates/engine/src/testkit/conformance/snapshot_cache.rs
@@ -1,0 +1,64 @@
+//! Conformance kit: [`SnapshotCache`] opacity, durability, and clearing.
+
+use crate::seams::SnapshotCache;
+
+/// Runs the `SnapshotCache` contract against an implementation.
+///
+/// `open` must return a handle over the same durable backing on every call
+/// (reopen semantics); the backing must start empty.
+///
+/// Ciphertext-only-at-rest is asserted as **opacity**: the kit stores
+/// deliberately non-decodable bytes and requires them back verbatim — a
+/// store that parses, normalizes, or requires plaintext structure cannot
+/// pass. (That the engine only ever hands this seam sealed bytes is the
+/// engine's own invariant, exercised by engine tests.)
+///
+/// # Panics
+/// Panics on the first contract violation.
+pub async fn check<S, F>(mut open: F)
+where
+    S: SnapshotCache,
+    F: AsyncFnMut() -> S,
+{
+    let store = open().await;
+
+    assert_eq!(store.get(b"missing").await.unwrap(), None);
+
+    // Garbage in, same garbage out: no plaintext structure required.
+    let opaque = [0xFFu8, 0x00, 0x9F, 0x92, 0x96, 0x00, 0xFF, 0x7F];
+    store.put(b"key-1", &opaque).await.unwrap();
+    assert_eq!(
+        store.get(b"key-1").await.unwrap(),
+        Some(opaque.to_vec()),
+        "arbitrary ciphertext must round-trip verbatim"
+    );
+
+    // Overwrite replaces.
+    store.put(b"key-1", b"v2").await.unwrap();
+    assert_eq!(store.get(b"key-1").await.unwrap(), Some(b"v2".to_vec()));
+
+    // Independent keys; idempotent remove.
+    store.put(b"key-2", b"other").await.unwrap();
+    store.remove(b"key-1").await.unwrap();
+    store.remove(b"key-1").await.unwrap();
+    assert_eq!(store.get(b"key-1").await.unwrap(), None);
+    assert_eq!(store.get(b"key-2").await.unwrap(), Some(b"other".to_vec()));
+
+    // Durability: entries survive reopen.
+    let reopened = open().await;
+    assert_eq!(
+        reopened.get(b"key-2").await.unwrap(),
+        Some(b"other".to_vec()),
+        "cache entries must survive reopen"
+    );
+
+    // Clear ("forget this device") empties the backing, durably.
+    reopened.clear().await.unwrap();
+    assert_eq!(reopened.get(b"key-2").await.unwrap(), None);
+    let after_clear = open().await;
+    assert_eq!(
+        after_clear.get(b"key-2").await.unwrap(),
+        None,
+        "clear must be durable"
+    );
+}

--- a/crates/engine/src/testkit/conformance/staging_store.rs
+++ b/crates/engine/src/testkit/conformance/staging_store.rs
@@ -1,0 +1,100 @@
+//! Conformance kit: [`StagingStore`] FIFO ordering, durability, and
+//! orphan-GC support.
+
+use crate::seams::StagingStore;
+
+/// Runs the `StagingStore` contract against an implementation.
+///
+/// `open` must return a handle over the same durable backing on every call
+/// (reopen semantics); the backing must start empty.
+///
+/// # Panics
+/// Panics on the first contract violation.
+pub async fn check<S, F>(mut open: F)
+where
+    S: StagingStore,
+    F: AsyncFnMut() -> S,
+{
+    let store = open().await;
+
+    // Fresh backing.
+    assert!(store.queued_ops().await.unwrap().is_empty());
+    assert!(store.staged_keys().await.unwrap().is_empty());
+    assert_eq!(store.staged_bytes_total().await.unwrap(), 0);
+
+    // FIFO with strictly increasing ids.
+    let id_a = store.enqueue_op(b"op-a").await.unwrap();
+    let id_b = store.enqueue_op(b"op-b").await.unwrap();
+    let id_c = store.enqueue_op(b"op-c").await.unwrap();
+    assert!(
+        id_a < id_b && id_b < id_c,
+        "op ids must be strictly increasing"
+    );
+
+    let ops = store.queued_ops().await.unwrap();
+    assert_eq!(
+        ops,
+        vec![
+            (id_a, b"op-a".to_vec()),
+            (id_b, b"op-b".to_vec()),
+            (id_c, b"op-c".to_vec()),
+        ],
+        "queued ops must come back FIFO with payloads verbatim"
+    );
+
+    // Removal preserves the order of survivors; removing again is
+    // idempotent.
+    store.remove_op(id_b).await.unwrap();
+    store.remove_op(id_b).await.unwrap();
+    assert_eq!(
+        store.queued_ops().await.unwrap(),
+        vec![(id_a, b"op-a".to_vec()), (id_c, b"op-c".to_vec())],
+        "removing one op must not disturb FIFO order"
+    );
+
+    // Staged bytes: verbatim round-trip, replacement, exact accounting.
+    store.put_staged_bytes(b"key-1", b"12345").await.unwrap();
+    store.put_staged_bytes(b"key-2", b"1234567").await.unwrap();
+    assert_eq!(
+        store.staged_bytes(b"key-1").await.unwrap(),
+        Some(b"12345".to_vec())
+    );
+    assert_eq!(store.staged_bytes_total().await.unwrap(), 12);
+
+    store.put_staged_bytes(b"key-1", b"123").await.unwrap();
+    assert_eq!(
+        store.staged_bytes_total().await.unwrap(),
+        10,
+        "replacing staged bytes must not double-count"
+    );
+
+    // Orphan-GC support: enumeration and removal are exact.
+    let mut keys = store.staged_keys().await.unwrap();
+    keys.sort();
+    assert_eq!(keys, vec![b"key-1".to_vec(), b"key-2".to_vec()]);
+
+    store.remove_staged_bytes(b"key-1").await.unwrap();
+    store.remove_staged_bytes(b"key-1").await.unwrap(); // idempotent
+    assert_eq!(store.staged_bytes(b"key-1").await.unwrap(), None);
+    assert_eq!(store.staged_keys().await.unwrap(), vec![b"key-2".to_vec()]);
+    assert_eq!(store.staged_bytes_total().await.unwrap(), 7);
+
+    // Durability: queue order, staged bytes, and id progression survive
+    // reopen.
+    let reopened = open().await;
+    assert_eq!(
+        reopened.queued_ops().await.unwrap(),
+        vec![(id_a, b"op-a".to_vec()), (id_c, b"op-c".to_vec())],
+        "the op queue must survive reopen in order"
+    );
+    assert_eq!(
+        reopened.staged_bytes(b"key-2").await.unwrap(),
+        Some(b"1234567".to_vec()),
+        "staged bytes must survive reopen"
+    );
+    let id_d = reopened.enqueue_op(b"op-d").await.unwrap();
+    assert!(
+        id_d > id_c,
+        "op ids must never be reused, even across reopen"
+    );
+}

--- a/crates/engine/src/testkit/entropy.rs
+++ b/crates/engine/src/testkit/entropy.rs
@@ -1,0 +1,70 @@
+//! Seeded, deterministic entropy for tests.
+
+use crate::entropy::Entropy;
+
+/// Deterministic entropy from a 64-bit seed (SplitMix64 stream).
+///
+/// **Test-only, not cryptographic.** Same seed, same byte stream — every
+/// engine-minted seed, nonce, and jitter value becomes reproducible, which
+/// is the point (determinism is injected, blueprint/testing.md law 3).
+pub struct SeededEntropy {
+    state: u64,
+}
+
+impl SeededEntropy {
+    /// A deterministic entropy stream for `seed`.
+    pub fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        // SplitMix64: tiny, well-distributed, dependency-free.
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+}
+
+impl Entropy for SeededEntropy {
+    fn fill(&mut self, dest: &mut [u8]) {
+        for chunk in dest.chunks_mut(8) {
+            let bytes = self.next_u64().to_le_bytes();
+            chunk.copy_from_slice(&bytes[..chunk.len()]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_seed_same_stream() {
+        let mut a = SeededEntropy::new(7);
+        let mut b = SeededEntropy::new(7);
+        let (mut buf_a, mut buf_b) = ([0u8; 33], [0u8; 33]);
+        a.fill(&mut buf_a);
+        b.fill(&mut buf_b);
+        assert_eq!(buf_a, buf_b);
+    }
+
+    #[test]
+    fn different_seeds_diverge() {
+        let mut a = SeededEntropy::new(1);
+        let mut b = SeededEntropy::new(2);
+        let (mut buf_a, mut buf_b) = ([0u8; 32], [0u8; 32]);
+        a.fill(&mut buf_a);
+        b.fill(&mut buf_b);
+        assert_ne!(buf_a, buf_b);
+    }
+
+    #[test]
+    fn fills_non_multiple_of_eight_lengths() {
+        let mut e = SeededEntropy::new(9);
+        let mut buf = [0u8; 5];
+        e.fill(&mut buf);
+        assert_ne!(buf, [0u8; 5], "five bytes should be written");
+    }
+}

--- a/crates/engine/src/testkit/entropy.rs
+++ b/crates/engine/src/testkit/entropy.rs
@@ -1,6 +1,6 @@
 //! Seeded, deterministic entropy for tests.
 
-use crate::entropy::Entropy;
+use crate::entropy::{Entropy, EntropyError};
 
 /// Deterministic entropy from a 64-bit seed (SplitMix64 stream).
 ///
@@ -28,11 +28,12 @@ impl SeededEntropy {
 }
 
 impl Entropy for SeededEntropy {
-    fn fill(&mut self, dest: &mut [u8]) {
+    fn fill(&mut self, dest: &mut [u8]) -> Result<(), EntropyError> {
         for chunk in dest.chunks_mut(8) {
             let bytes = self.next_u64().to_le_bytes();
             chunk.copy_from_slice(&bytes[..chunk.len()]);
         }
+        Ok(())
     }
 }
 
@@ -45,8 +46,8 @@ mod tests {
         let mut a = SeededEntropy::new(7);
         let mut b = SeededEntropy::new(7);
         let (mut buf_a, mut buf_b) = ([0u8; 33], [0u8; 33]);
-        a.fill(&mut buf_a);
-        b.fill(&mut buf_b);
+        a.fill(&mut buf_a).expect("seeded entropy never fails");
+        b.fill(&mut buf_b).expect("seeded entropy never fails");
         assert_eq!(buf_a, buf_b);
     }
 
@@ -55,8 +56,8 @@ mod tests {
         let mut a = SeededEntropy::new(1);
         let mut b = SeededEntropy::new(2);
         let (mut buf_a, mut buf_b) = ([0u8; 32], [0u8; 32]);
-        a.fill(&mut buf_a);
-        b.fill(&mut buf_b);
+        a.fill(&mut buf_a).expect("seeded entropy never fails");
+        b.fill(&mut buf_b).expect("seeded entropy never fails");
         assert_ne!(buf_a, buf_b);
     }
 
@@ -64,7 +65,7 @@ mod tests {
     fn fills_non_multiple_of_eight_lengths() {
         let mut e = SeededEntropy::new(9);
         let mut buf = [0u8; 5];
-        e.fill(&mut buf);
+        e.fill(&mut buf).expect("seeded entropy never fails");
         assert_ne!(buf, [0u8; 5], "five bytes should be written");
     }
 }

--- a/crates/engine/src/testkit/executor.rs
+++ b/crates/engine/src/testkit/executor.rs
@@ -1,0 +1,60 @@
+//! A minimal single-future executor for native test processes.
+
+use std::future::{Future, IntoFuture};
+use std::pin::pin;
+use std::sync::Arc;
+use std::task::{Context, Poll, Wake, Waker};
+use std::thread::{self, Thread};
+
+struct ThreadWaker(Thread);
+
+impl Wake for ThreadWaker {
+    fn wake(self: Arc<Self>) {
+        self.0.unpark();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.0.unpark();
+    }
+}
+
+/// Drives one future to completion on the current thread.
+///
+/// Enough executor for the whole test kit — fakes never touch real timers
+/// or I/O, so nothing needs a runtime. Native test processes only; WASM
+/// hosts (the browser suite) await kit futures on their own harness
+/// instead.
+pub fn block_on<F: IntoFuture>(future: F) -> F::Output {
+    let mut future = pin!(future.into_future());
+    let waker = Waker::from(Arc::new(ThreadWaker(thread::current())));
+    let mut cx = Context::from_waker(&waker);
+    loop {
+        match future.as_mut().poll(&mut cx) {
+            Poll::Ready(output) => return output,
+            Poll::Pending => thread::park(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::block_on;
+
+    #[test]
+    fn drives_a_ready_future() {
+        assert_eq!(block_on(async { 41 + 1 }), 42);
+    }
+
+    #[test]
+    fn survives_cross_thread_wakes() {
+        let out = block_on(async {
+            let (tx, rx) = futures_channel::oneshot::channel::<u32>();
+            std::thread::spawn(move || {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                tx.send(7).expect("receiver alive");
+            });
+            rx.await.expect("sender completed")
+        });
+        assert_eq!(out, 7);
+    }
+}

--- a/crates/engine/src/testkit/fakes/credential_store.rs
+++ b/crates/engine/src/testkit/fakes/credential_store.rs
@@ -1,0 +1,28 @@
+//! In-memory [`CredentialStore`] fake.
+
+use std::sync::{Arc, Mutex};
+
+use crate::seams::{CredentialStore, SeamResult};
+
+/// In-memory refresh-token store (models the desktop keychain shape).
+/// Clones share state ("reopen").
+#[derive(Clone, Default)]
+pub struct InMemoryCredentialStore {
+    inner: Arc<Mutex<Option<Vec<u8>>>>,
+}
+
+impl CredentialStore for InMemoryCredentialStore {
+    async fn store_refresh_token(&self, refresh_token: &[u8]) -> SeamResult<()> {
+        *self.inner.lock().expect("lock") = Some(refresh_token.to_vec());
+        Ok(())
+    }
+
+    async fn load_refresh_token(&self) -> SeamResult<Option<Vec<u8>>> {
+        Ok(self.inner.lock().expect("lock").clone())
+    }
+
+    async fn clear_refresh_token(&self) -> SeamResult<()> {
+        *self.inner.lock().expect("lock") = None;
+        Ok(())
+    }
+}

--- a/crates/engine/src/testkit/fakes/floor_store.rs
+++ b/crates/engine/src/testkit/fakes/floor_store.rs
@@ -1,0 +1,62 @@
+//! In-memory [`FloorStore`] fake.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::seams::{FloorStore, SeamResult};
+
+#[derive(Default)]
+struct Inner {
+    epoch: HashMap<Vec<u8>, u64>,
+    sequence: HashMap<Vec<u8>, u64>,
+}
+
+/// In-memory monotonic-max floor store. Clones share state ("reopen").
+#[derive(Clone, Default)]
+pub struct InMemoryFloorStore {
+    inner: Arc<Mutex<Inner>>,
+}
+
+fn raise(map: &mut HashMap<Vec<u8>, u64>, key: &[u8], value: u64) -> u64 {
+    let entry = map.entry(key.to_vec()).or_insert(value);
+    *entry = (*entry).max(value);
+    *entry
+}
+
+impl FloorStore for InMemoryFloorStore {
+    async fn epoch_floor(&self, scope_id: &[u8]) -> SeamResult<Option<u64>> {
+        Ok(self
+            .inner
+            .lock()
+            .expect("lock")
+            .epoch
+            .get(scope_id)
+            .copied())
+    }
+
+    async fn raise_epoch_floor(&self, scope_id: &[u8], epoch: u64) -> SeamResult<u64> {
+        Ok(raise(
+            &mut self.inner.lock().expect("lock").epoch,
+            scope_id,
+            epoch,
+        ))
+    }
+
+    async fn sequence_floor(&self, ipns_name: &[u8]) -> SeamResult<Option<u64>> {
+        Ok(self
+            .inner
+            .lock()
+            .expect("lock")
+            .sequence
+            .get(ipns_name)
+            .copied())
+    }
+
+    async fn raise_sequence_floor(&self, ipns_name: &[u8], sequence: u64) -> SeamResult<u64> {
+        Ok(raise(
+            &mut self.inner.lock().expect("lock").sequence,
+            ipns_name,
+            sequence,
+        ))
+    }
+}

--- a/crates/engine/src/testkit/fakes/http.rs
+++ b/crates/engine/src/testkit/fakes/http.rs
@@ -1,0 +1,97 @@
+//! Scripted [`Http`] fake.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use crate::seams::{Http, HttpRequest, HttpResponse, SeamError, SeamResult};
+
+#[derive(Default)]
+struct Inner {
+    responses: VecDeque<SeamResult<HttpResponse>>,
+    requests: Vec<HttpRequest>,
+}
+
+/// Scripted HTTP: responses are queued by the test and returned in order;
+/// every request is recorded for assertion. An unscripted request is a
+/// seam error — a test that hits the network unexpectedly should fail
+/// loudly.
+#[derive(Clone, Default)]
+pub struct ScriptedHttp {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl ScriptedHttp {
+    /// Queues a successful response.
+    pub fn enqueue_response(&self, response: HttpResponse) {
+        self.inner
+            .lock()
+            .expect("lock")
+            .responses
+            .push_back(Ok(response));
+    }
+
+    /// Queues a transport-level failure.
+    pub fn enqueue_error(&self, error: SeamError) {
+        self.inner
+            .lock()
+            .expect("lock")
+            .responses
+            .push_back(Err(error));
+    }
+
+    /// Every request sent so far, in order.
+    pub fn requests(&self) -> Vec<HttpRequest> {
+        self.inner.lock().expect("lock").requests.clone()
+    }
+}
+
+impl Http for ScriptedHttp {
+    async fn send(&self, request: HttpRequest) -> SeamResult<HttpResponse> {
+        let mut inner = self.inner.lock().expect("lock");
+        inner.requests.push(request);
+        inner
+            .responses
+            .pop_front()
+            .unwrap_or_else(|| Err(SeamError::new("ScriptedHttp: no scripted response left")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::seams::HttpMethod;
+    use crate::testkit::block_on;
+
+    fn request(url: &str) -> HttpRequest {
+        HttpRequest {
+            method: HttpMethod::Get,
+            url: url.to_owned(),
+            headers: Vec::new(),
+            body: None,
+        }
+    }
+
+    #[test]
+    fn returns_scripted_responses_in_order_and_records_requests() {
+        let http = ScriptedHttp::default();
+        http.enqueue_response(HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: b"first".to_vec(),
+        });
+
+        let response = block_on(http.send(request("https://api.test/a"))).unwrap();
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, b"first");
+
+        let requests = http.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].url, "https://api.test/a");
+    }
+
+    #[test]
+    fn unscripted_request_fails_loudly() {
+        let http = ScriptedHttp::default();
+        assert!(block_on(http.send(request("https://api.test/oops"))).is_err());
+    }
+}

--- a/crates/engine/src/testkit/fakes/mailbox.rs
+++ b/crates/engine/src/testkit/fakes/mailbox.rs
@@ -1,0 +1,110 @@
+//! In-memory mailbox hub and per-recipient [`Mailbox`] fake.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use crate::seams::{Mailbox, MailboxItem, SeamResult};
+
+#[derive(Default)]
+struct HubInner {
+    next_id: u64,
+    queues: HashMap<Vec<u8>, Vec<MailboxItem>>,
+    seen_idempotency_keys: HashSet<(Vec<u8>, String)>,
+}
+
+/// The shared mailbox "server": routes posts between recipients so N
+/// engines in a scenario exchange sealed blobs through one hub.
+#[derive(Clone, Default)]
+pub struct InMemoryMailboxHub {
+    inner: Arc<Mutex<HubInner>>,
+}
+
+impl InMemoryMailboxHub {
+    /// A [`Mailbox`] seam handle bound to one recipient's inbox.
+    pub fn mailbox_for(&self, recipient_public_key: &[u8]) -> InMemoryMailbox {
+        InMemoryMailbox {
+            hub: self.clone(),
+            recipient_public_key: recipient_public_key.to_vec(),
+        }
+    }
+}
+
+/// One account's view of the hub: posts route anywhere, polls and acks
+/// operate on the bound recipient's own queue.
+#[derive(Clone)]
+pub struct InMemoryMailbox {
+    hub: InMemoryMailboxHub,
+    recipient_public_key: Vec<u8>,
+}
+
+impl Mailbox for InMemoryMailbox {
+    async fn post(
+        &self,
+        recipient_public_key: &[u8],
+        sealed_payload: &[u8],
+        idempotency_key: &str,
+    ) -> SeamResult<()> {
+        let mut inner = self.hub.inner.lock().expect("lock");
+        let dedupe_key = (recipient_public_key.to_vec(), idempotency_key.to_owned());
+        if !inner.seen_idempotency_keys.insert(dedupe_key) {
+            return Ok(());
+        }
+        inner.next_id += 1;
+        let item = MailboxItem {
+            item_id: format!("item-{}", inner.next_id),
+            sealed_payload: sealed_payload.to_vec(),
+        };
+        inner
+            .queues
+            .entry(recipient_public_key.to_vec())
+            .or_default()
+            .push(item);
+        Ok(())
+    }
+
+    async fn poll(&self) -> SeamResult<Vec<MailboxItem>> {
+        Ok(self
+            .hub
+            .inner
+            .lock()
+            .expect("lock")
+            .queues
+            .get(&self.recipient_public_key)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    async fn ack(&self, item_id: &str) -> SeamResult<()> {
+        if let Some(queue) = self
+            .hub
+            .inner
+            .lock()
+            .expect("lock")
+            .queues
+            .get_mut(&self.recipient_public_key)
+        {
+            queue.retain(|item| item.item_id != item_id);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testkit::block_on;
+
+    #[test]
+    fn hub_routes_between_recipients_and_isolates_inboxes() {
+        let hub = InMemoryMailboxHub::default();
+        let alice = hub.mailbox_for(b"alice-pk");
+        let bob = hub.mailbox_for(b"bob-pk");
+
+        block_on(alice.post(b"bob-pk", b"sealed-for-bob", "k1")).unwrap();
+
+        let bob_items = block_on(bob.poll()).unwrap();
+        assert_eq!(bob_items.len(), 1);
+        assert_eq!(bob_items[0].sealed_payload, b"sealed-for-bob");
+        assert!(block_on(alice.poll()).unwrap().is_empty());
+    }
+}

--- a/crates/engine/src/testkit/fakes/mod.rs
+++ b/crates/engine/src/testkit/fakes/mod.rs
@@ -1,0 +1,26 @@
+//! In-memory fakes, one per seam trait.
+//!
+//! Every fake is a cheap `Clone` handle over shared state: cloning models
+//! "reopening" the same durable backing (the conformance kits' factory
+//! contract) and lets a test keep an inspection handle to state it moved
+//! into an engine.
+
+mod credential_store;
+mod floor_store;
+mod http;
+mod mailbox;
+mod record_store;
+mod refresh_hint;
+mod scheduler;
+mod snapshot_cache;
+mod staging_store;
+
+pub use credential_store::InMemoryCredentialStore;
+pub use floor_store::InMemoryFloorStore;
+pub use http::ScriptedHttp;
+pub use mailbox::{InMemoryMailbox, InMemoryMailboxHub};
+pub use record_store::InMemoryRecordStore;
+pub use refresh_hint::ManualHintSource;
+pub use scheduler::VirtualScheduler;
+pub use snapshot_cache::InMemorySnapshotCache;
+pub use staging_store::InMemoryStagingStore;

--- a/crates/engine/src/testkit/fakes/record_store.rs
+++ b/crates/engine/src/testkit/fakes/record_store.rs
@@ -1,0 +1,129 @@
+//! The fake `/routing/v1` record store — an in-memory [`RecordTransport`].
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::seams::{EndpointId, RecordTransport, SeamError, SeamResult};
+
+/// Records held by one endpoint, keyed by routing key.
+type EndpointRecords = HashMap<String, Vec<u8>>;
+
+/// In-memory fake of the `/routing/v1` endpoint set: one map of opaque
+/// record bytes per configured endpoint.
+///
+/// Shared by design — every engine in a scenario clones the same store, so
+/// N instances see one "network". Direct [`seed_record`] /
+/// [`record_at`] access lets tests stage adversarial records and observe
+/// publishes without a transport round-trip.
+///
+/// [`seed_record`]: InMemoryRecordStore::seed_record
+/// [`record_at`]: InMemoryRecordStore::record_at
+#[derive(Clone)]
+pub struct InMemoryRecordStore {
+    endpoints: Vec<EndpointId>,
+    inner: Arc<Mutex<HashMap<EndpointId, EndpointRecords>>>,
+}
+
+impl InMemoryRecordStore {
+    /// A store serving the given endpoint set.
+    ///
+    /// # Panics
+    /// Panics on an empty endpoint set — the transport contract requires at
+    /// least one endpoint.
+    pub fn new(endpoints: Vec<EndpointId>) -> Self {
+        assert!(!endpoints.is_empty(), "endpoint set must not be empty");
+        let inner = endpoints
+            .iter()
+            .cloned()
+            .map(|endpoint| (endpoint, HashMap::new()))
+            .collect();
+        Self {
+            endpoints,
+            inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+
+    /// Test-side write, bypassing the seam (adversarial staging).
+    pub fn seed_record(&self, endpoint: &EndpointId, routing_key: &str, record: Vec<u8>) {
+        self.inner
+            .lock()
+            .expect("lock")
+            .get_mut(endpoint)
+            .expect("known endpoint")
+            .insert(routing_key.to_owned(), record);
+    }
+
+    /// Test-side read, bypassing the seam (publish observation).
+    pub fn record_at(&self, endpoint: &EndpointId, routing_key: &str) -> Option<Vec<u8>> {
+        self.inner
+            .lock()
+            .expect("lock")
+            .get(endpoint)
+            .and_then(|records| records.get(routing_key).cloned())
+    }
+}
+
+impl RecordTransport for InMemoryRecordStore {
+    fn endpoints(&self) -> Vec<EndpointId> {
+        self.endpoints.clone()
+    }
+
+    async fn get_record(
+        &self,
+        endpoint: &EndpointId,
+        routing_key: &str,
+    ) -> SeamResult<Option<Vec<u8>>> {
+        self.inner
+            .lock()
+            .expect("lock")
+            .get(endpoint)
+            .map(|records| records.get(routing_key).cloned())
+            .ok_or_else(|| SeamError::new(format!("unknown endpoint: {}", endpoint.0)))
+    }
+
+    async fn put_record(
+        &self,
+        endpoint: &EndpointId,
+        routing_key: &str,
+        record: &[u8],
+    ) -> SeamResult<()> {
+        self.inner
+            .lock()
+            .expect("lock")
+            .get_mut(endpoint)
+            .map(|records| {
+                records.insert(routing_key.to_owned(), record.to_vec());
+            })
+            .ok_or_else(|| SeamError::new(format!("unknown endpoint: {}", endpoint.0)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testkit::block_on;
+
+    #[test]
+    fn unknown_endpoint_is_a_seam_error() {
+        let store = InMemoryRecordStore::new(vec![EndpointId::new("a")]);
+        let missing = EndpointId::new("nope");
+        assert!(block_on(store.get_record(&missing, "k")).is_err());
+        assert!(block_on(store.put_record(&missing, "k", b"r")).is_err());
+    }
+
+    #[test]
+    fn seed_and_inspect_bypass_the_seam() {
+        let endpoint = EndpointId::new("a");
+        let store = InMemoryRecordStore::new(vec![endpoint.clone()]);
+        store.seed_record(&endpoint, "name", b"forged".to_vec());
+        assert_eq!(
+            block_on(store.get_record(&endpoint, "name")).unwrap(),
+            Some(b"forged".to_vec())
+        );
+        block_on(store.put_record(&endpoint, "name", b"published")).unwrap();
+        assert_eq!(
+            store.record_at(&endpoint, "name"),
+            Some(b"published".to_vec())
+        );
+    }
+}

--- a/crates/engine/src/testkit/fakes/refresh_hint.rs
+++ b/crates/engine/src/testkit/fakes/refresh_hint.rs
@@ -1,0 +1,104 @@
+//! Manually driven [`RefreshHintSource`] fake.
+
+use core::task::{Poll, Waker};
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use crate::seams::{RefreshHint, RefreshHintSource};
+
+#[derive(Default)]
+struct Inner {
+    queue: VecDeque<RefreshHint>,
+    wakers: Vec<Waker>,
+    closed: bool,
+}
+
+/// A hint source the test drives by hand: [`push_hint`] delivers one hint,
+/// [`close`] ends the stream.
+///
+/// [`push_hint`]: ManualHintSource::push_hint
+/// [`close`]: ManualHintSource::close
+#[derive(Clone, Default)]
+pub struct ManualHintSource {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl ManualHintSource {
+    /// Delivers one refresh hint to the listener.
+    pub fn push_hint(&self) {
+        let woken: Vec<Waker> = {
+            let mut inner = self.inner.lock().expect("lock");
+            inner.queue.push_back(RefreshHint);
+            std::mem::take(&mut inner.wakers)
+        };
+        for waker in woken {
+            waker.wake();
+        }
+    }
+
+    /// Closes the stream: pending and future `next_hint` calls resolve to
+    /// `None` once the queue drains.
+    pub fn close(&self) {
+        let woken: Vec<Waker> = {
+            let mut inner = self.inner.lock().expect("lock");
+            inner.closed = true;
+            std::mem::take(&mut inner.wakers)
+        };
+        for waker in woken {
+            waker.wake();
+        }
+    }
+}
+
+impl RefreshHintSource for ManualHintSource {
+    async fn next_hint(&mut self) -> Option<RefreshHint> {
+        core::future::poll_fn(|cx| {
+            let mut inner = self.inner.lock().expect("lock");
+            if let Some(hint) = inner.queue.pop_front() {
+                return Poll::Ready(Some(hint));
+            }
+            if inner.closed {
+                return Poll::Ready(None);
+            }
+            inner.wakers.push(cx.waker().clone());
+            Poll::Pending
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testkit::block_on;
+
+    #[test]
+    fn queued_hints_are_delivered_then_close_ends_the_stream() {
+        let source = ManualHintSource::default();
+        source.push_hint();
+        source.push_hint();
+        source.close();
+
+        let mut listener = source.clone();
+        assert_eq!(block_on(listener.next_hint()), Some(RefreshHint));
+        assert_eq!(block_on(listener.next_hint()), Some(RefreshHint));
+        assert_eq!(block_on(listener.next_hint()), None);
+    }
+
+    #[test]
+    fn push_wakes_a_parked_listener() {
+        let source = ManualHintSource::default();
+        let mut listener = source.clone();
+
+        let pusher = {
+            let source = source.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                source.push_hint();
+            })
+        };
+
+        assert_eq!(block_on(listener.next_hint()), Some(RefreshHint));
+        pusher.join().expect("pusher thread");
+    }
+}

--- a/crates/engine/src/testkit/fakes/scheduler.rs
+++ b/crates/engine/src/testkit/fakes/scheduler.rs
@@ -1,0 +1,246 @@
+//! The virtual-clock [`Scheduler`] fake.
+
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker};
+use core::time::Duration;
+use std::sync::{Arc, Mutex};
+
+use crate::seams::{BoxedTask, Scheduler, UnixMillis};
+
+struct Inner {
+    now: UnixMillis,
+    auto_advance: bool,
+    sleepers: Vec<(UnixMillis, Waker)>,
+    tasks: Vec<BoxedTask>,
+}
+
+/// A deterministic virtual clock: time moves only when a test advances it.
+///
+/// Clones share the same clock, so every device in a [`super::super::FakeWorld`]
+/// steps on one timeline. Two modes:
+///
+/// - **Manual** (default): `sleep` parks until [`advance`] /
+///   [`advance_to`] moves virtual time past its deadline — the simulation
+///   harness's stepping lever.
+/// - **Auto-advance** ([`with_auto_advance`]): a polled sleep immediately
+///   jumps the clock to its own deadline and resolves — multi-day
+///   timelines execute in microseconds with no external driver.
+///
+/// [`advance`]: VirtualScheduler::advance
+/// [`advance_to`]: VirtualScheduler::advance_to
+/// [`with_auto_advance`]: VirtualScheduler::with_auto_advance
+#[derive(Clone)]
+pub struct VirtualScheduler {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl VirtualScheduler {
+    /// A manual-mode clock starting at `UnixMillis(0)`.
+    pub fn new() -> Self {
+        Self::starting_at(UnixMillis(0))
+    }
+
+    /// A manual-mode clock starting at an arbitrary instant.
+    // `BoxedTask` is deliberately `!Send` (the engine runs pinned to one
+    // execution context), which makes `Mutex<Inner>` `!Send + !Sync`; the
+    // `Arc` exists only for same-thread handle cloning, matching how every
+    // fake models "one shared backing".
+    #[allow(clippy::arc_with_non_send_sync)]
+    pub fn starting_at(now: UnixMillis) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                now,
+                auto_advance: false,
+                sleepers: Vec::new(),
+                tasks: Vec::new(),
+            })),
+        }
+    }
+
+    /// Switches this clock (and every clone of it) to auto-advance mode.
+    #[must_use]
+    pub fn with_auto_advance(self) -> Self {
+        self.inner.lock().expect("lock").auto_advance = true;
+        self
+    }
+
+    /// Moves virtual time forward by `duration`, waking every sleep whose
+    /// deadline is reached.
+    pub fn advance(&self, duration: Duration) {
+        let target = self.now().saturating_add(duration);
+        self.advance_to(target);
+    }
+
+    /// Moves virtual time to `instant` (never backwards), waking every
+    /// sleep whose deadline is reached.
+    pub fn advance_to(&self, instant: UnixMillis) {
+        let woken: Vec<Waker> = {
+            let mut inner = self.inner.lock().expect("lock");
+            inner.now = inner.now.max(instant);
+            let now = inner.now;
+            let (due, pending) = std::mem::take(&mut inner.sleepers)
+                .into_iter()
+                .partition(|(deadline, _)| *deadline <= now);
+            inner.sleepers = pending;
+            due.into_iter().map(|(_, waker)| waker).collect()
+        };
+        for waker in woken {
+            waker.wake();
+        }
+    }
+
+    /// Takes every task handed to [`Scheduler::spawn`] so far; the test
+    /// decides when (and whether) to drive them.
+    pub fn take_spawned_tasks(&self) -> Vec<BoxedTask> {
+        std::mem::take(&mut self.inner.lock().expect("lock").tasks)
+    }
+
+    /// How many sleeps are currently parked (manual mode introspection).
+    pub fn pending_sleepers(&self) -> usize {
+        self.inner.lock().expect("lock").sleepers.len()
+    }
+}
+
+impl Default for VirtualScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct SleepFuture {
+    scheduler: VirtualScheduler,
+    deadline: UnixMillis,
+}
+
+impl Future for SleepFuture {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        let woken: Vec<Waker>;
+        let result = {
+            let mut inner = self.scheduler.inner.lock().expect("lock");
+            if inner.now >= self.deadline {
+                woken = Vec::new();
+                Poll::Ready(())
+            } else if inner.auto_advance {
+                inner.now = self.deadline;
+                let now = inner.now;
+                let (due, pending) = std::mem::take(&mut inner.sleepers)
+                    .into_iter()
+                    .partition(|(deadline, _)| *deadline <= now);
+                inner.sleepers = pending;
+                woken = due.into_iter().map(|(_, waker)| waker).collect();
+                Poll::Ready(())
+            } else {
+                inner.sleepers.push((self.deadline, cx.waker().clone()));
+                woken = Vec::new();
+                Poll::Pending
+            }
+        };
+        for waker in woken {
+            waker.wake();
+        }
+        result
+    }
+}
+
+impl Scheduler for VirtualScheduler {
+    fn now(&self) -> UnixMillis {
+        self.inner.lock().expect("lock").now
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        let deadline = self.now().saturating_add(duration);
+        SleepFuture {
+            scheduler: self.clone(),
+            deadline,
+        }
+        .await;
+    }
+
+    fn spawn(&self, task: BoxedTask) {
+        self.inner.lock().expect("lock").tasks.push(task);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::pin::pin;
+
+    fn noop_context() -> Context<'static> {
+        Context::from_waker(Waker::noop())
+    }
+
+    #[test]
+    fn manual_sleep_parks_until_advanced() {
+        let scheduler = VirtualScheduler::new();
+        let mut sleep = pin!(scheduler.sleep(Duration::from_millis(100)));
+        let mut cx = noop_context();
+
+        assert!(sleep.as_mut().poll(&mut cx).is_pending());
+        scheduler.advance(Duration::from_millis(99));
+        assert!(sleep.as_mut().poll(&mut cx).is_pending());
+        scheduler.advance(Duration::from_millis(1));
+        assert!(sleep.as_mut().poll(&mut cx).is_ready());
+        assert_eq!(scheduler.now(), UnixMillis(100));
+    }
+
+    #[test]
+    fn advance_wakes_registered_sleepers() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::task::Wake;
+
+        struct FlagWaker(AtomicBool);
+        impl Wake for FlagWaker {
+            fn wake(self: Arc<Self>) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+            fn wake_by_ref(self: &Arc<Self>) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let scheduler = VirtualScheduler::new();
+        let flag = Arc::new(FlagWaker(AtomicBool::new(false)));
+        let waker = Waker::from(Arc::clone(&flag));
+        let mut cx = Context::from_waker(&waker);
+
+        let mut sleep = pin!(scheduler.sleep(Duration::from_millis(10)));
+        assert!(sleep.as_mut().poll(&mut cx).is_pending());
+        assert_eq!(scheduler.pending_sleepers(), 1);
+
+        scheduler.advance(Duration::from_millis(10));
+        assert!(
+            flag.0.load(Ordering::SeqCst),
+            "advance must wake the sleeper"
+        );
+        assert!(sleep.as_mut().poll(&mut cx).is_ready());
+        assert_eq!(scheduler.pending_sleepers(), 0);
+    }
+
+    #[test]
+    fn auto_advance_resolves_multi_day_sleeps_instantly() {
+        let scheduler = VirtualScheduler::new().with_auto_advance();
+        crate::testkit::block_on(scheduler.sleep(Duration::from_secs(90 * 24 * 3600)));
+        assert_eq!(scheduler.now(), UnixMillis(90 * 24 * 3600 * 1000));
+    }
+
+    #[test]
+    fn spawn_queues_tasks_for_the_test_to_drive() {
+        let scheduler = VirtualScheduler::new();
+        scheduler.spawn(Box::pin(async {}));
+        scheduler.spawn(Box::pin(async {}));
+        assert_eq!(scheduler.take_spawned_tasks().len(), 2);
+        assert!(scheduler.take_spawned_tasks().is_empty());
+    }
+
+    #[test]
+    fn clones_share_one_timeline() {
+        let a = VirtualScheduler::starting_at(UnixMillis(1_000));
+        let b = a.clone();
+        b.advance(Duration::from_millis(500));
+        assert_eq!(a.now(), UnixMillis(1_500));
+    }
+}

--- a/crates/engine/src/testkit/fakes/scheduler.rs
+++ b/crates/engine/src/testkit/fakes/scheduler.rs
@@ -15,6 +15,21 @@ struct Inner {
     tasks: Vec<BoxedTask>,
 }
 
+impl Inner {
+    /// Moves the clock to `target` (never backwards) and takes the wakers
+    /// of every sleep whose deadline has been reached. The caller wakes
+    /// them outside the lock.
+    fn advance_and_take_due(&mut self, target: UnixMillis) -> Vec<Waker> {
+        self.now = self.now.max(target);
+        let now = self.now;
+        let (due, pending): (Vec<_>, Vec<_>) = std::mem::take(&mut self.sleepers)
+            .into_iter()
+            .partition(|(deadline, _)| *deadline <= now);
+        self.sleepers = pending;
+        due.into_iter().map(|(_, waker)| waker).collect()
+    }
+}
+
 /// A deterministic virtual clock: time moves only when a test advances it.
 ///
 /// Clones share the same clock, so every device in a [`super::super::FakeWorld`]
@@ -75,16 +90,11 @@ impl VirtualScheduler {
     /// Moves virtual time to `instant` (never backwards), waking every
     /// sleep whose deadline is reached.
     pub fn advance_to(&self, instant: UnixMillis) {
-        let woken: Vec<Waker> = {
-            let mut inner = self.inner.lock().expect("lock");
-            inner.now = inner.now.max(instant);
-            let now = inner.now;
-            let (due, pending) = std::mem::take(&mut inner.sleepers)
-                .into_iter()
-                .partition(|(deadline, _)| *deadline <= now);
-            inner.sleepers = pending;
-            due.into_iter().map(|(_, waker)| waker).collect()
-        };
+        let woken = self
+            .inner
+            .lock()
+            .expect("lock")
+            .advance_and_take_due(instant);
         for waker in woken {
             waker.wake();
         }
@@ -124,13 +134,7 @@ impl Future for SleepFuture {
                 woken = Vec::new();
                 Poll::Ready(())
             } else if inner.auto_advance {
-                inner.now = self.deadline;
-                let now = inner.now;
-                let (due, pending) = std::mem::take(&mut inner.sleepers)
-                    .into_iter()
-                    .partition(|(deadline, _)| *deadline <= now);
-                inner.sleepers = pending;
-                woken = due.into_iter().map(|(_, waker)| waker).collect();
+                woken = inner.advance_and_take_due(self.deadline);
                 Poll::Ready(())
             } else {
                 inner.sleepers.push((self.deadline, cx.waker().clone()));

--- a/crates/engine/src/testkit/fakes/scheduler.rs
+++ b/crates/engine/src/testkit/fakes/scheduler.rs
@@ -8,10 +8,19 @@ use std::sync::{Arc, Mutex};
 
 use crate::seams::{BoxedTask, Scheduler, UnixMillis};
 
+/// One parked sleep: its deadline, the identity of the owning
+/// [`SleepFuture`], and the waker from its latest poll.
+struct Sleeper {
+    deadline: UnixMillis,
+    sleep_id: u64,
+    waker: Waker,
+}
+
 struct Inner {
     now: UnixMillis,
     auto_advance: bool,
-    sleepers: Vec<(UnixMillis, Waker)>,
+    next_sleep_id: u64,
+    sleepers: Vec<Sleeper>,
     tasks: Vec<BoxedTask>,
 }
 
@@ -24,9 +33,28 @@ impl Inner {
         let now = self.now;
         let (due, pending): (Vec<_>, Vec<_>) = std::mem::take(&mut self.sleepers)
             .into_iter()
-            .partition(|(deadline, _)| *deadline <= now);
+            .partition(|sleeper| sleeper.deadline <= now);
         self.sleepers = pending;
-        due.into_iter().map(|(_, waker)| waker).collect()
+        due.into_iter().map(|sleeper| sleeper.waker).collect()
+    }
+
+    /// Registers (or, on a re-poll of the same future, replaces) the parked
+    /// waker for one sleep — one entry per live [`SleepFuture`], so
+    /// re-polling never accumulates duplicates and only the latest waker
+    /// fires (the futures contract).
+    fn park(&mut self, sleep_id: u64, deadline: UnixMillis, waker: Waker) {
+        match self
+            .sleepers
+            .iter_mut()
+            .find(|sleeper| sleeper.sleep_id == sleep_id)
+        {
+            Some(sleeper) => sleeper.waker = waker,
+            None => self.sleepers.push(Sleeper {
+                deadline,
+                sleep_id,
+                waker,
+            }),
+        }
     }
 }
 
@@ -67,6 +95,7 @@ impl VirtualScheduler {
             inner: Arc::new(Mutex::new(Inner {
                 now,
                 auto_advance: false,
+                next_sleep_id: 0,
                 sleepers: Vec::new(),
                 tasks: Vec::new(),
             })),
@@ -121,23 +150,32 @@ impl Default for VirtualScheduler {
 struct SleepFuture {
     scheduler: VirtualScheduler,
     deadline: UnixMillis,
+    /// Identity in `Inner::sleepers`, assigned on first park so a re-poll
+    /// replaces this future's waker instead of accumulating duplicates.
+    sleep_id: Option<u64>,
 }
 
 impl Future for SleepFuture {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        let this = self.get_mut();
         let woken: Vec<Waker>;
         let result = {
-            let mut inner = self.scheduler.inner.lock().expect("lock");
-            if inner.now >= self.deadline {
+            let mut inner = this.scheduler.inner.lock().expect("lock");
+            if inner.now >= this.deadline {
                 woken = Vec::new();
                 Poll::Ready(())
             } else if inner.auto_advance {
-                woken = inner.advance_and_take_due(self.deadline);
+                woken = inner.advance_and_take_due(this.deadline);
                 Poll::Ready(())
             } else {
-                inner.sleepers.push((self.deadline, cx.waker().clone()));
+                let sleep_id = *this.sleep_id.get_or_insert_with(|| {
+                    let id = inner.next_sleep_id;
+                    inner.next_sleep_id += 1;
+                    id
+                });
+                inner.park(sleep_id, this.deadline, cx.waker().clone());
                 woken = Vec::new();
                 Poll::Pending
             }
@@ -159,6 +197,7 @@ impl Scheduler for VirtualScheduler {
         SleepFuture {
             scheduler: self.clone(),
             deadline,
+            sleep_id: None,
         }
         .await;
     }
@@ -221,6 +260,43 @@ mod tests {
             "advance must wake the sleeper"
         );
         assert!(sleep.as_mut().poll(&mut cx).is_ready());
+        assert_eq!(scheduler.pending_sleepers(), 0);
+    }
+
+    #[test]
+    fn repolling_one_sleep_registers_exactly_one_sleeper() {
+        let scheduler = VirtualScheduler::new();
+        let mut sleep = pin!(scheduler.sleep(Duration::from_millis(100)));
+        let mut cx = noop_context();
+
+        assert!(sleep.as_mut().poll(&mut cx).is_pending());
+        scheduler.advance(Duration::from_millis(50));
+        assert!(sleep.as_mut().poll(&mut cx).is_pending());
+        assert_eq!(
+            scheduler.pending_sleepers(),
+            1,
+            "a re-poll must replace the parked waker, not accumulate"
+        );
+    }
+
+    #[test]
+    fn two_sleeps_sharing_a_deadline_both_wake() {
+        let scheduler = VirtualScheduler::new();
+        let mut cx = noop_context();
+        let mut sleep_a = pin!(scheduler.sleep(Duration::from_millis(10)));
+        let mut sleep_b = pin!(scheduler.sleep(Duration::from_millis(10)));
+
+        assert!(sleep_a.as_mut().poll(&mut cx).is_pending());
+        assert!(sleep_b.as_mut().poll(&mut cx).is_pending());
+        assert_eq!(
+            scheduler.pending_sleepers(),
+            2,
+            "distinct futures park separately"
+        );
+
+        scheduler.advance(Duration::from_millis(10));
+        assert!(sleep_a.as_mut().poll(&mut cx).is_ready());
+        assert!(sleep_b.as_mut().poll(&mut cx).is_ready());
         assert_eq!(scheduler.pending_sleepers(), 0);
     }
 

--- a/crates/engine/src/testkit/fakes/snapshot_cache.rs
+++ b/crates/engine/src/testkit/fakes/snapshot_cache.rs
@@ -1,0 +1,37 @@
+//! In-memory [`SnapshotCache`] fake.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use crate::seams::{SeamResult, SnapshotCache};
+
+/// In-memory ciphertext cache. Clones share state ("reopen"). Stores bytes
+/// verbatim and never inspects them — the ciphertext-only-at-rest posture.
+#[derive(Clone, Default)]
+pub struct InMemorySnapshotCache {
+    inner: Arc<Mutex<BTreeMap<Vec<u8>, Vec<u8>>>>,
+}
+
+impl SnapshotCache for InMemorySnapshotCache {
+    async fn put(&self, cache_key: &[u8], ciphertext: &[u8]) -> SeamResult<()> {
+        self.inner
+            .lock()
+            .expect("lock")
+            .insert(cache_key.to_vec(), ciphertext.to_vec());
+        Ok(())
+    }
+
+    async fn get(&self, cache_key: &[u8]) -> SeamResult<Option<Vec<u8>>> {
+        Ok(self.inner.lock().expect("lock").get(cache_key).cloned())
+    }
+
+    async fn remove(&self, cache_key: &[u8]) -> SeamResult<()> {
+        self.inner.lock().expect("lock").remove(cache_key);
+        Ok(())
+    }
+
+    async fn clear(&self) -> SeamResult<()> {
+        self.inner.lock().expect("lock").clear();
+        Ok(())
+    }
+}

--- a/crates/engine/src/testkit/fakes/staging_store.rs
+++ b/crates/engine/src/testkit/fakes/staging_store.rs
@@ -1,0 +1,98 @@
+//! In-memory [`StagingStore`] fake.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use crate::seams::{OpId, SeamResult, StagingStore};
+
+struct Inner {
+    next_op_id: u64,
+    ops: Vec<(OpId, Vec<u8>)>,
+    staged: BTreeMap<Vec<u8>, Vec<u8>>,
+}
+
+impl Default for Inner {
+    fn default() -> Self {
+        Self {
+            next_op_id: 1,
+            ops: Vec::new(),
+            staged: BTreeMap::new(),
+        }
+    }
+}
+
+/// In-memory durable op queue + staged bytes. Clones share state
+/// ("reopen").
+#[derive(Clone, Default)]
+pub struct InMemoryStagingStore {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl StagingStore for InMemoryStagingStore {
+    async fn enqueue_op(&self, op: &[u8]) -> SeamResult<OpId> {
+        let mut inner = self.inner.lock().expect("lock");
+        let op_id = OpId(inner.next_op_id);
+        inner.next_op_id += 1;
+        inner.ops.push((op_id, op.to_vec()));
+        Ok(op_id)
+    }
+
+    async fn queued_ops(&self) -> SeamResult<Vec<(OpId, Vec<u8>)>> {
+        Ok(self.inner.lock().expect("lock").ops.clone())
+    }
+
+    async fn remove_op(&self, op_id: OpId) -> SeamResult<()> {
+        self.inner
+            .lock()
+            .expect("lock")
+            .ops
+            .retain(|(id, _)| *id != op_id);
+        Ok(())
+    }
+
+    async fn put_staged_bytes(&self, staging_key: &[u8], bytes: &[u8]) -> SeamResult<()> {
+        self.inner
+            .lock()
+            .expect("lock")
+            .staged
+            .insert(staging_key.to_vec(), bytes.to_vec());
+        Ok(())
+    }
+
+    async fn staged_bytes(&self, staging_key: &[u8]) -> SeamResult<Option<Vec<u8>>> {
+        Ok(self
+            .inner
+            .lock()
+            .expect("lock")
+            .staged
+            .get(staging_key)
+            .cloned())
+    }
+
+    async fn remove_staged_bytes(&self, staging_key: &[u8]) -> SeamResult<()> {
+        self.inner.lock().expect("lock").staged.remove(staging_key);
+        Ok(())
+    }
+
+    async fn staged_keys(&self) -> SeamResult<Vec<Vec<u8>>> {
+        Ok(self
+            .inner
+            .lock()
+            .expect("lock")
+            .staged
+            .keys()
+            .cloned()
+            .collect())
+    }
+
+    async fn staged_bytes_total(&self) -> SeamResult<u64> {
+        Ok(self
+            .inner
+            .lock()
+            .expect("lock")
+            .staged
+            .values()
+            .map(|bytes| bytes.len() as u64)
+            .sum())
+    }
+}

--- a/crates/engine/src/testkit/mod.rs
+++ b/crates/engine/src/testkit/mod.rs
@@ -1,0 +1,25 @@
+//! The engine test kit (`test-kit` feature): in-memory seam fakes, the
+//! virtual-clock scheduler, seeded entropy, and the per-seam conformance
+//! kits (blueprint/testing.md "crates/engine — seam fakes and the
+//! simulation harness", "Seam conformance kits").
+//!
+//! No network, no docker, no wall clock: engines built on [`FakeWorld`]
+//! devices run entirely in memory on virtual time, so CAS races and
+//! multi-day EOL timelines execute in milliseconds. Multiple devices share
+//! one fake record store, mailbox hub, and clock — the seed of the
+//! simulation harness.
+//!
+//! Host crates enable this feature from dev-dependencies and run each
+//! [`conformance`] kit against their real seam implementations: browser
+//! seams inside the merge-blocking browser suite, desktop seams in cargo
+//! tests. One contract, every platform.
+
+pub mod conformance;
+mod entropy;
+mod executor;
+pub mod fakes;
+mod world;
+
+pub use entropy::SeededEntropy;
+pub use executor::block_on;
+pub use world::{FakeDevice, FakeSeamTypes, FakeWorld};

--- a/crates/engine/src/testkit/world.rs
+++ b/crates/engine/src/testkit/world.rs
@@ -1,0 +1,118 @@
+//! The fake world — shared network state plus per-device seam sets, the
+//! seed of the simulation harness (blueprint/testing.md).
+
+use crate::seams::{EndpointId, SeamSet, SeamTypes};
+use crate::testkit::fakes::{
+    InMemoryCredentialStore, InMemoryFloorStore, InMemoryMailbox, InMemoryMailboxHub,
+    InMemoryRecordStore, InMemorySnapshotCache, InMemoryStagingStore, ManualHintSource,
+    ScriptedHttp, VirtualScheduler,
+};
+
+/// The [`SeamTypes`] family binding every fake — the test kit's host.
+pub struct FakeSeamTypes;
+
+impl SeamTypes for FakeSeamTypes {
+    type FloorStore = InMemoryFloorStore;
+    type RecordTransport = InMemoryRecordStore;
+    type Http = ScriptedHttp;
+    type Mailbox = InMemoryMailbox;
+    type RefreshHintSource = ManualHintSource;
+    type Scheduler = VirtualScheduler;
+    type StagingStore = InMemoryStagingStore;
+    type SnapshotCache = InMemorySnapshotCache;
+    type CredentialStore = InMemoryCredentialStore;
+}
+
+/// State shared by every device in a scenario: one virtual clock, one fake
+/// `/routing/v1` record store, one mailbox hub. N engine instances (owner,
+/// write-grantee, read-grantee, revokee, adversary) built over one world
+/// interact exactly the way real clients do — through published records
+/// and sealed mailbox traffic — stepped deterministically on virtual time.
+pub struct FakeWorld {
+    /// The shared virtual clock.
+    pub scheduler: VirtualScheduler,
+    /// The shared fake record store ("the network").
+    pub record_store: InMemoryRecordStore,
+    /// The shared mailbox hub ("the API mailbox").
+    pub mailbox_hub: InMemoryMailboxHub,
+}
+
+impl FakeWorld {
+    /// A fresh world with the default two-endpoint set (mirroring
+    /// production shape: someguy plus one independent endpoint).
+    pub fn new() -> Self {
+        Self {
+            scheduler: VirtualScheduler::new(),
+            record_store: InMemoryRecordStore::new(vec![
+                EndpointId::new("fake:someguy"),
+                EndpointId::new("fake:public-routing"),
+            ]),
+            mailbox_hub: InMemoryMailboxHub::default(),
+        }
+    }
+
+    /// A new device (one account session) on this world: fresh device-local
+    /// stores, shared network and clock. `recipient_public_key` binds the
+    /// device's mailbox inbox.
+    pub fn device(&self, recipient_public_key: &[u8]) -> FakeDevice {
+        FakeDevice {
+            floor_store: InMemoryFloorStore::default(),
+            staging_store: InMemoryStagingStore::default(),
+            snapshot_cache: InMemorySnapshotCache::default(),
+            credential_store: InMemoryCredentialStore::default(),
+            http: ScriptedHttp::default(),
+            hints: ManualHintSource::default(),
+            mailbox: self.mailbox_hub.mailbox_for(recipient_public_key),
+            scheduler: self.scheduler.clone(),
+            record_store: self.record_store.clone(),
+        }
+    }
+}
+
+impl Default for FakeWorld {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// One device's seam handles. Every field is a cheap `Clone` handle, so the
+/// test retains inspection/driving access to state it moves into an engine
+/// via [`FakeDevice::seam_set`].
+pub struct FakeDevice {
+    /// Device-local durable floors.
+    pub floor_store: InMemoryFloorStore,
+    /// Device-local op queue + staged bytes.
+    pub staging_store: InMemoryStagingStore,
+    /// Device-local ciphertext cache.
+    pub snapshot_cache: InMemorySnapshotCache,
+    /// Device-local refresh-token store.
+    pub credential_store: InMemoryCredentialStore,
+    /// Device-local scripted HTTP.
+    pub http: ScriptedHttp,
+    /// Device-local hint source, driven by the test.
+    pub hints: ManualHintSource,
+    /// This device's inbox on the shared hub.
+    pub mailbox: InMemoryMailbox,
+    /// The shared virtual clock.
+    pub scheduler: VirtualScheduler,
+    /// The shared record store.
+    pub record_store: InMemoryRecordStore,
+}
+
+impl FakeDevice {
+    /// The complete seam set for this device, ready for
+    /// [`crate::facade::Engine::new`].
+    pub fn seam_set(&self) -> SeamSet<FakeSeamTypes> {
+        SeamSet {
+            floor_store: self.floor_store.clone(),
+            record_transport: self.record_store.clone(),
+            http: self.http.clone(),
+            mailbox: self.mailbox.clone(),
+            refresh_hints: self.hints.clone(),
+            scheduler: self.scheduler.clone(),
+            staging_store: self.staging_store.clone(),
+            snapshot_cache: self.snapshot_cache.clone(),
+            credential_store: self.credential_store.clone(),
+        }
+    }
+}

--- a/crates/engine/tests/conformance_fakes.rs
+++ b/crates/engine/tests/conformance_fakes.rs
@@ -1,0 +1,60 @@
+//! Every seam conformance kit executed against its in-memory fake — the
+//! kits are proven by the fakes passing them (issue #623), and the fakes
+//! are proven honest by the kits.
+
+use cipherbox_engine::seams::EndpointId;
+use cipherbox_engine::testkit::fakes::{
+    InMemoryCredentialStore, InMemoryFloorStore, InMemoryMailboxHub, InMemoryRecordStore,
+    InMemorySnapshotCache, InMemoryStagingStore, VirtualScheduler,
+};
+use cipherbox_engine::testkit::{block_on, conformance};
+
+#[test]
+fn in_memory_floor_store_passes_the_floor_store_kit() {
+    let store = InMemoryFloorStore::default();
+    block_on(conformance::floor_store::check(async || store.clone()));
+}
+
+#[test]
+fn in_memory_staging_store_passes_the_staging_store_kit() {
+    let store = InMemoryStagingStore::default();
+    block_on(conformance::staging_store::check(async || store.clone()));
+}
+
+#[test]
+fn in_memory_snapshot_cache_passes_the_snapshot_cache_kit() {
+    let cache = InMemorySnapshotCache::default();
+    block_on(conformance::snapshot_cache::check(async || cache.clone()));
+}
+
+#[test]
+fn in_memory_credential_store_passes_the_credential_store_kit() {
+    let store = InMemoryCredentialStore::default();
+    block_on(conformance::credential_store::check(async || store.clone()));
+}
+
+#[test]
+fn in_memory_record_store_passes_the_record_transport_kit() {
+    let transport = InMemoryRecordStore::new(vec![
+        EndpointId::new("fake:someguy"),
+        EndpointId::new("fake:public-routing"),
+    ]);
+    block_on(conformance::record_transport::check(
+        &transport,
+        "k51-fresh-routing-key",
+        b"opaque-signed-record-bytes",
+    ));
+}
+
+#[test]
+fn in_memory_mailbox_passes_the_mailbox_kit() {
+    let hub = InMemoryMailboxHub::default();
+    let mailbox = hub.mailbox_for(b"self-pk");
+    block_on(conformance::mailbox::check(&mailbox, b"self-pk"));
+}
+
+#[test]
+fn virtual_scheduler_passes_the_scheduler_kit() {
+    let scheduler = VirtualScheduler::new().with_auto_advance();
+    block_on(conformance::scheduler::check(&scheduler));
+}

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -4,7 +4,7 @@
 use cipherbox_engine::testkit::{FakeDevice, FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
 use cipherbox_engine::{
     Command, Engine, EngineError, EventStream, LoginSecret, NodeId, NodeKind, Permission,
-    SyncTimingProfile,
+    PlaintextContent, SyncTimingProfile,
 };
 
 fn new_engine(device: &FakeDevice) -> (Engine<FakeSeamTypes>, EventStream) {
@@ -28,7 +28,7 @@ fn all_commands() -> Vec<(Command, &'static str)> {
                 parent,
                 name: "notes.txt".into(),
                 kind: NodeKind::File,
-                content: Some(b"hello".to_vec()),
+                content: Some(PlaintextContent(b"hello".to_vec())),
             },
             "create",
         ),
@@ -50,7 +50,7 @@ fn all_commands() -> Vec<(Command, &'static str)> {
         (
             Command::UpdateContent {
                 node,
-                content: b"v2".to_vec(),
+                content: PlaintextContent(b"v2".to_vec()),
             },
             "updateContent",
         ),

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -1,0 +1,211 @@
+//! Facade skeleton surface: lifecycle law, typed unimplemented commands,
+//! and event-stream plumbing over a fully faked seam set.
+
+use cipherbox_engine::testkit::{FakeDevice, FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
+use cipherbox_engine::{
+    Command, Engine, EngineError, EventStream, LoginSecret, NodeId, NodeKind, Permission,
+    SyncTimingProfile,
+};
+
+fn new_engine(device: &FakeDevice) -> (Engine<FakeSeamTypes>, EventStream) {
+    Engine::new(
+        device.seam_set(),
+        Box::new(SeededEntropy::new(42)),
+        SyncTimingProfile::CI,
+    )
+}
+
+fn secret() -> LoginSecret {
+    LoginSecret::new(vec![7u8; 32])
+}
+
+fn all_commands() -> Vec<(Command, &'static str)> {
+    let node = NodeId([1; 16]);
+    let parent = NodeId([2; 16]);
+    vec![
+        (
+            Command::Create {
+                parent,
+                name: "notes.txt".into(),
+                kind: NodeKind::File,
+                content: Some(b"hello".to_vec()),
+            },
+            "create",
+        ),
+        (Command::Delete { node }, "delete"),
+        (
+            Command::Rename {
+                node,
+                new_name: "renamed.txt".into(),
+            },
+            "rename",
+        ),
+        (
+            Command::Relink {
+                node,
+                new_parent: parent,
+            },
+            "relink",
+        ),
+        (
+            Command::UpdateContent {
+                node,
+                content: b"v2".to_vec(),
+            },
+            "updateContent",
+        ),
+        (Command::SetFocus { node: Some(node) }, "setFocus"),
+        (Command::ManualRefresh, "manualRefresh"),
+        (
+            Command::ImportContact {
+                contact_code: b"contact-bundle".to_vec(),
+            },
+            "importContact",
+        ),
+        (
+            Command::Grant {
+                node,
+                recipient_identity_public_key: b"bob-pk".to_vec(),
+                permission: Permission::Read,
+            },
+            "grant",
+        ),
+        (
+            Command::Revoke {
+                node,
+                recipient_identity_public_key: b"bob-pk".to_vec(),
+            },
+            "revoke",
+        ),
+        (
+            Command::Downgrade {
+                node,
+                recipient_identity_public_key: b"bob-pk".to_vec(),
+            },
+            "downgrade",
+        ),
+        (
+            Command::CreateInviteLink {
+                node,
+                permission: Permission::Write,
+            },
+            "createInviteLink",
+        ),
+        (
+            Command::AcceptShare {
+                sealed_share_pointer: b"sealed-pointer".to_vec(),
+            },
+            "acceptShare",
+        ),
+        (Command::RotateNow { node }, "rotateNow"),
+        (
+            Command::SiweLogin {
+                message: "siwe message".into(),
+                signature: b"wallet-sig".to_vec(),
+            },
+            "siweLogin",
+        ),
+        (Command::Logout, "logout"),
+    ]
+}
+
+#[test]
+fn commands_before_start_are_rejected_not_started() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (mut engine, _events) = new_engine(&device);
+
+    let result = block_on(engine.command(Command::ManualRefresh));
+    assert_eq!(result, Err(EngineError::NotStarted));
+}
+
+#[test]
+fn start_succeeds_once_and_only_once() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (mut engine, _events) = new_engine(&device);
+
+    assert_eq!(block_on(engine.start(secret())), Ok(()));
+    assert_eq!(
+        block_on(engine.start(secret())),
+        Err(EngineError::AlreadyStarted),
+        "one live instance is the single writer — no second start"
+    );
+}
+
+#[test]
+fn an_empty_secret_is_rejected() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (mut engine, _events) = new_engine(&device);
+
+    assert_eq!(
+        block_on(engine.start(LoginSecret::new(Vec::new()))),
+        Err(EngineError::InvalidSecret)
+    );
+    // A rejected start does not consume the lifecycle.
+    assert_eq!(block_on(engine.start(secret())), Ok(()));
+}
+
+#[test]
+fn every_command_returns_its_typed_unimplemented_error() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (mut engine, _events) = new_engine(&device);
+    block_on(engine.start(secret())).unwrap();
+
+    for (command, expected_name) in all_commands() {
+        let result = block_on(engine.command(command));
+        assert_eq!(
+            result,
+            Err(EngineError::Unimplemented {
+                command: expected_name
+            }),
+            "scaffold facade: `{expected_name}` must reject as typed-unimplemented"
+        );
+    }
+}
+
+#[test]
+fn the_event_stream_ends_when_the_engine_drops() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (engine, mut events) = new_engine(&device);
+
+    drop(engine);
+    assert_eq!(block_on(events.next()), None);
+}
+
+#[test]
+fn the_engine_runs_under_the_injected_profile() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (engine, _events) = new_engine(&device);
+
+    assert_eq!(engine.profile(), &SyncTimingProfile::CI);
+}
+
+#[test]
+fn two_devices_on_one_world_share_network_and_clock() {
+    let world = FakeWorld::new();
+    let alice = world.device(b"alice-pk");
+    let bob = world.device(b"bob-pk");
+
+    // Shared clock.
+    use cipherbox_engine::seams::Scheduler;
+    world
+        .scheduler
+        .advance(core::time::Duration::from_millis(250));
+    assert_eq!(alice.scheduler.now(), bob.scheduler.now());
+
+    // Shared record store, per-device floors.
+    use cipherbox_engine::seams::RecordTransport;
+    let endpoint = &world.record_store.endpoints()[0];
+    alice
+        .record_store
+        .seed_record(endpoint, "shared-name", b"record".to_vec());
+    assert_eq!(
+        bob.record_store.record_at(endpoint, "shared-name"),
+        Some(b"record".to_vec())
+    );
+}


### PR DESCRIPTION
Closes #623

## What lands

- **Nine seam traits** (`crates/engine/src/seams/`) — `FloorStore`, `RecordTransport`, `Http`, `Mailbox`, `RefreshHintSource`, `Scheduler`, `StagingStore`, `SnapshotCache`, `CredentialStore` — as opaque-byte/event contracts per blueprint/engine.md "Host seams". No seam holds logic; the engine owns all interpretation.
- **`SeamSet` + `SeamTypes`** — the constructor takes the seam set whole; omitting any seam is a missing struct field, a compile error (verified: E0063), never a runtime gap.
- **Test kit** (`test-kit` feature, self-dev-dependency pattern) — in-memory fakes for every seam: virtual-clock `VirtualScheduler`, fake `/routing/v1` `InMemoryRecordStore`, mailbox hub, plus `FakeWorld`/`FakeDevice` (shared network + clock, per-device stores) as the seed of the simulation harness. Seeded deterministic entropy (`SeededEntropy`, explicitly non-cryptographic, test-only).
- **Seven per-seam conformance kits** (`testkit::conformance`) — reusable against real host implementations; proven here by every fake passing its kit. The Http and RefreshHintSource kit omissions are documented with rationale.
- **`SyncTimingProfile`** with `PRODUCTION` and `CI` consts — policy injected, no `Default` (the v1 silent 5-minute-TTL lesson), guard-rail tests on the blueprint ranges.
- **Facade skeleton** — `Engine::new(seams, entropy, profile)` + start of secret (`LoginSecret`: zeroizing, no `Clone`, redacted `Debug`), the full `Command`/`Event` variant sets, and typed `EngineError::Unimplemented { command }` for every command until the pipeline slices land. Plaintext file bytes cross the facade as `PlaintextContent` (structurally redacted `Debug`); `Command`'s `Debug` prints only the variant name.
- **"Engine Tests" CI job** — merge-blocking `cargo test -p cipherbox-engine` (engine unit tests + all conformance kits) in ci.yml, per the issue's gate requirement and testing.md law 1 (named gate the day the suite lands).

## Two architecture-defining decisions — flagged for human review

1. **`!Send` async traits.** Seams use native `async fn` in traits (`#![allow(async_fn_in_trait)]`) with no `Send` bounds, and `BoxedTask` is deliberately `!Send`. This commits the desktop host to running the engine on a **single-threaded task** pinned to one execution context (the wasm32 build already forces `!Send` futures). One engine, statically dispatched, both targets — but desktop cannot later move the engine across threads without a facade-level redesign.
2. **Entropy is a constructor parameter, not a tenth seam.** `Engine::new` takes `Box<dyn Entropy>`; production wiring is per-target `getrandom` owned by the engine construction site, not host logic (blueprint/engine.md treats entropy as an engine input, distinct from the nine host seams). Still injected — engine logic never calls an RNG directly — so the determinism law holds and tests substitute the seeded source.

## Verification

- Facade driven end-to-end from an **external consumer crate** (path-dep with `features = ["test-kit"]`, the way real hosts consume it): command-before-start yields `NotStarted`; empty secret yields `InvalidSecret` without consuming the lifecycle; start once `Ok`, twice `AlreadyStarted`; every command yields its typed `Unimplemented`; event stream ends on engine drop; `LoginSecret` debug prints `LoginSecret(redacted)`.
- Missing-seam completeness gate verified negatively: omitting `credential_store` from a `SeamSet` initializer fails to compile with E0063.
- All 7 conformance kits pass against their fakes.

## Local gates

- `cargo test --workspace` — all green: engine 46 (32 unit + 7 conformance + 7 facade), core 29, fuse 2, wasm 2.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `actionlint .github/workflows/ci.yml` — clean.

## Security and crypto/privacy review

Crypto/privacy review scoped to the secret/entropy/credential surface (`facade.rs`, `entropy.rs`, `testkit/entropy.rs`, `seams/credential_store.rs`): clean. `LoginSecret` zeroizes at its terminal owner (consumed by `start`, dropped there); no clocks or RNG outside the `Scheduler`/`Entropy` injections anywhere in engine logic; the non-cryptographic `SeededEntropy` cannot reach production builds (`test-kit` compiles only via dev-dependencies); the access JWT contractually never touches `CredentialStore`.

General security sweep: no high or medium findings. Two low-severity latent `Debug`-leak surfaces (plaintext `content` on `Command`, headers/bodies on `HttpRequest`/`HttpResponse`) were fixed on this branch with behavior tests. Informational items dismissed: the unbounded event channel (documented; no emit sites exist yet — revisit when they land) and the `Entropy` trait being satisfiable by non-CSPRNG implementations (production wiring is pinned to per-target `getrandom` at the construction site; review-checklist item when that wiring lands).

## Review triage

- **Fixed (5):** `Debug` redaction for `Command` plaintext/payloads and `HttpRequest`/`HttpResponse` credentials; `Entropy::fill` made fallible with a typed `EntropyError` (a `getrandom` wrapper must fail closed, not panic); `UnixMillis::saturating_add` rounds sub-millisecond remainders up so a deadline never truncates to "now"; the virtual clock parks one waker per sleep future (Greptile finding — fixed with per-future identity rather than the suggested deadline-keyed replacement, which would drop a waker when two sleeps share a deadline).
- **Simplified (2):** virtual-clock advance/wake logic deduped into `Inner::advance_and_take_due`; unused `UnixMillis::saturating_since` removed until a slice needs it.
- **Discarded:** staging-store GC "atomicity" (the engine is the single writer; ordering is pipeline policy, and seam-level conditional logic would violate "no seam holds logic"); bounding the event stream now (no emit sites exist); a typed `CommandResult` return (response payloads are explicitly reserved to the grants slice); deleting the dedicated Engine Tests job as duplicate compute (the issue and testing.md law 1 require the named gate); swapping the 25-line `block_on` for a `futures-executor` dependency; assorted test-literal nits.
- **Issues filed:** none.
