### PR TITLE
feat(wasm): bind the engine facade surface and gate the browser-shaped WASM KATs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,15 @@
 # Run wasm test binaries under wasmtime: `cargo test -p cipherbox-core
-# --target wasm32-wasip1` is the KAT gate's WASM leg (blueprint/testing.md).
+# --target wasm32-wasip1` is one KAT gate WASM leg (blueprint/testing.md).
 [target.wasm32-wasip1]
 runner = "wasmtime"
+
+# The browser-shaped WASM leg: `cargo test --target wasm32-unknown-unknown`
+# runs the core KAT + property suite (and the crates/wasm boundary tests)
+# through wasm-bindgen-test-runner, which drives Node.js headlessly — the
+# residual u64/BigInt and getrandom parity surface (blueprint/web-client.md,
+# blueprint/core.md). `getrandom_backend="wasm_js"` selects getrandom's
+# `crypto.getRandomValues` backend for this target, matching the worker-scope
+# wiring; it is inert for crates that pull no getrandom.
+[target.wasm32-unknown-unknown]
+runner = "wasm-bindgen-test-runner"
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,13 +361,19 @@ jobs:
 
       # wasm-bindgen-test-runner drives the wasm32-unknown-unknown tests in
       # Node and must match the locked wasm-bindgen version exactly (a schema
-      # mismatch fails the run); derive the version from Cargo.lock. Cached in
-      # ~/.cargo/bin, so this is a no-op on a cache hit.
+      # mismatch fails the run); derive the version from Cargo.lock. The binary
+      # is cached in ~/.cargo/bin: skip the install when the cached binary
+      # already matches (a bare `cargo install` errors "already exists" on a
+      # cache hit), otherwise install with --force to overwrite a stale one.
       - name: Install wasm-bindgen-cli (matching Cargo.lock)
         run: |
           WB_VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
           echo "wasm-bindgen ${WB_VERSION}"
-          cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked
+          if wasm-bindgen --version 2>/dev/null | grep -qw "${WB_VERSION}"; then
+            echo "wasm-bindgen-cli ${WB_VERSION} already present (cache hit); skipping install"
+          else
+            cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked --force
+          fi
 
       - name: KAT vectors fresh (committed generator is the only writer)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,12 @@ jobs:
       - name: Engine tests and seam conformance kits
         run: cargo test -p cipherbox-engine
 
+  # The WASM parity gate. Runs the core KAT + property suite in three shapes —
+  # native, wasm32-wasip1 (libtest under wasmtime), and the browser-shaped
+  # wasm32-unknown-unknown (wasm-bindgen-test → Node) that exercises the
+  # residual u64/BigInt and getrandom-`crypto.getRandomValues` boundary risks
+  # (blueprint/core.md, blueprint/web-client.md) — plus the crates/wasm facade
+  # boundary tests and the single ES-module artifact build.
   core-kats:
     name: Core KATs (native + WASM)
     needs: [changes, lint]
@@ -339,14 +345,29 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            ~/.cargo/bin
             target
           key: core-kats-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: core-kats-cargo-
 
-      - name: Add wasm32-wasip1 target
-        run: rustup target add wasm32-wasip1
+      - name: Add wasm targets
+        run: rustup target add wasm32-wasip1 wasm32-unknown-unknown
 
       - uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: 'package.json'
+
+      # wasm-bindgen-test-runner drives the wasm32-unknown-unknown tests in
+      # Node and must match the locked wasm-bindgen version exactly (a schema
+      # mismatch fails the run); derive the version from Cargo.lock. Cached in
+      # ~/.cargo/bin, so this is a no-op on a cache hit.
+      - name: Install wasm-bindgen-cli (matching Cargo.lock)
+        run: |
+          WB_VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "wasm-bindgen ${WB_VERSION}"
+          cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked
 
       - name: KAT vectors fresh (committed generator is the only writer)
         run: |
@@ -359,6 +380,28 @@ jobs:
 
       - name: Core suite (WASM, wasm32-wasip1 under wasmtime)
         run: cargo test -p cipherbox-core --target wasm32-wasip1
+
+      # Browser-shaped leg: the KAT + property suite under Node via
+      # wasm-bindgen-test. Count parity with the native run is the anti-vacuity
+      # backstop (the test-file `#[test]` shadow routes both to this harness).
+      - name: Core KAT + property suite (WASM, wasm32-unknown-unknown)
+        run: cargo test -p cipherbox-core --target wasm32-unknown-unknown --test kat_manifest --test codec_props
+
+      # The crates/wasm facade boundary tests (u64/BigInt, getrandom wiring,
+      # command/event shapes) run under the same Node harness.
+      - name: WASM facade boundary tests (wasm32-unknown-unknown)
+        run: cargo test -p cipherbox-wasm --target wasm32-unknown-unknown
+
+      # The single wasm-bindgen ES module and its generated .d.ts contract must
+      # build (blueprint/web-client.md); packages/client hosts and fingerprints
+      # it later.
+      - name: Build the wasm-bindgen ES module and .d.ts
+        run: |
+          cargo build -p cipherbox-wasm --release --target wasm32-unknown-unknown
+          wasm-bindgen --target web --out-dir target/wasm-pkg --out-name cipherbox_wasm \
+            target/wasm32-unknown-unknown/release/cipherbox_wasm.wasm
+          test -f target/wasm-pkg/cipherbox_wasm.d.ts
+          test -f target/wasm-pkg/cipherbox_wasm.js
 
   cargo-macos:
     name: Cargo Check & Test (macOS)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.1",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,10 +348,12 @@ dependencies = [
 name = "cipherbox-core"
 version = "0.0.0"
 dependencies = [
+ "getrandom 0.3.4",
  "hex",
  "proptest",
  "serde",
  "serde_json",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -1064,9 +1083,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1711,6 +1732,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,6 +1804,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1861,6 +1898,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,6 +1919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2097,6 +2144,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "option-ext"
@@ -3942,6 +3995,45 @@ checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0d555ca874445df8d314f94f5c948a4e74e5418f332c89f660a3d8310a96f4"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
 
 [[package]]
 name = "wasm-streams"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,9 @@ name = "cipherbox-wasm"
 version = "0.0.0"
 dependencies = [
  "cipherbox-engine",
+ "getrandom 0.3.4",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,3 +20,13 @@ proptest = "1"
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 proptest = { version = "1", default-features = false, features = ["std"] }
+
+# The browser-shaped WASM leg (wasm32-unknown-unknown). Unlike wasm32-wasip1,
+# it lacks a native libtest harness, so the KAT + property tests run under
+# wasm-bindgen-test (see the `#[test]` shadow in the test files). getrandom's
+# `wasm_js` backend gives proptest's RNG `crypto.getRandomValues` — the
+# getrandom parity surface (blueprint/core.md); the backend is selected by the
+# `getrandom_backend="wasm_js"` cfg in `.cargo/config.toml`.
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+getrandom = { version = "0.3", features = ["wasm_js"] }

--- a/crates/core/tests/codec_props.rs
+++ b/crates/core/tests/codec_props.rs
@@ -8,6 +8,14 @@
 
 mod common;
 
+// The browser-shaped KAT leg (wasm32-unknown-unknown) has no libtest harness;
+// shadowing `test` routes the proptest-generated `#[test]` cases through
+// wasm-bindgen-test-runner, exercising getrandom's `crypto.getRandomValues`
+// backend (the getrandom parity surface). Native and wasm32-wasip1 are
+// untouched.
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
 use core::cmp::Ordering;
 use std::collections::HashMap;
 

--- a/crates/core/tests/kat_manifest.rs
+++ b/crates/core/tests/kat_manifest.rs
@@ -9,6 +9,13 @@
 
 use std::collections::BTreeSet;
 
+// On wasm32-unknown-unknown (the browser-shaped KAT leg) there is no libtest
+// harness; wasm-bindgen-test provides one. Shadowing `test` with its attribute
+// runs every `#[test]` below under wasm-bindgen-test-runner unchanged, while
+// native and wasm32-wasip1 keep the built-in `#[test]`.
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
 use cipherbox_core::codec::{decode, decode_map_partial, encode, encode_map_partial};
 use cipherbox_core::error::{Malformed, TrustViolation};
 use serde::Deserialize;

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -7,5 +7,22 @@ repository.workspace = true
 rust-version.workspace = true
 publish.workspace = true
 
+# cdylib is the wasm-bindgen artifact loaded in the engine worker; rlib lets
+# the crate link into native builds (workspace `cargo test`/`clippy`) and its
+# own integration tests.
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 cipherbox-engine.workspace = true
+wasm-bindgen = "0.2"
+
+# Browser-shaped test deps only (wasm32-unknown-unknown): the boundary tests
+# run under wasm-bindgen-test-runner, and getrandom's `wasm_js` backend proves
+# the `crypto.getRandomValues` worker-scope wiring. No production getrandom use
+# yet — the engine takes injected entropy; the entropy seam impl lands with the
+# worker-hosting slice. The `getrandom_backend="wasm_js"` cfg is in
+# `.cargo/config.toml`.
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+getrandom = { version = "0.3", features = ["wasm_js"] }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -382,9 +382,13 @@ impl Event {
 // Native-only conversion tests. The browser-shaped boundary behaviour lives in
 // `tests/boundary.rs` under wasm-bindgen-test; these host tests guard the
 // facade<->binding mapping (a new engine variant breaks an exhaustive match).
+//
+// Gated off wasm32-unknown-unknown (the exact complement of `boundary.rs`):
+// that target has no libtest harness, so a plain `#[test]` there compiles to a
+// silent no-op. Native and wasm32-wasip1 run these unchanged.
 // ---------------------------------------------------------------------------
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_family = "wasm", target_os = "unknown"))))]
 mod tests {
     use super::*;
     use cipherbox_engine::seams::OpId;

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -12,8 +12,9 @@
 //! `packages/client` re-exports — there is no hand-maintained TS mirror of
 //! engine structures. Boundary hygiene is structural: `u64`s (op ids, sizes,
 //! IPNS sequence numbers) cross as `bigint`, binary payloads as `Uint8Array`,
-//! and no key-shaped value crosses at all — the command surface exposes only
-//! intent, the event surface only key-free view state.
+//! and no secret key material crosses at all — the command surface exposes
+//! only intent (a grant carries the recipient's *public* identity key, never
+//! a secret), and the event surface only key-free view state.
 //!
 //! Scope of this slice: the facade's **command builders** and **event
 //! readers** plus their boundary value types. The live engine handle

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,20 +1,457 @@
-//! CipherBox wasm: wasm-bindgen bindings exposing the engine to the web
-//! client (`packages/client`), hosted in a worker.
+//! CipherBox wasm — wasm-bindgen bindings over the engine facade
+//! (`cipherbox-engine`, which links `cipherbox-core`), loaded as one ES module
+//! inside the engine worker by `packages/client`.
 //!
-//! Normative design: blueprint/web-client.md
+//! Normative design: blueprint/web-client.md ("WASM packaging and the type
+//! boundary"). This crate is bindings only — it holds no vault logic, no
+//! crypto, and no codec of its own; every trust decision already happened
+//! below the facade (blueprint/engine.md). Core is linked *inside*: nothing
+//! from `cipherbox-core` is exported directly to JS.
+//!
+//! The wasm-bindgen-generated `.d.ts` is the single boundary contract that
+//! `packages/client` re-exports — there is no hand-maintained TS mirror of
+//! engine structures. Boundary hygiene is structural: `u64`s (op ids, sizes,
+//! IPNS sequence numbers) cross as `bigint`, binary payloads as `Uint8Array`,
+//! and no key-shaped value crosses at all — the command surface exposes only
+//! intent, the event surface only key-free view state.
+//!
+//! Scope of this slice: the facade's **command builders** and **event
+//! readers** plus their boundary value types. The live engine handle
+//! (`start`, `command`, the event-stream reader) and the login-secret ingress
+//! bind once their host seams and worker transport land (blueprint/web-client.md
+//! "Engine hosting"); they are deliberately absent here — this crate lands no
+//! seams, no transports, and no worker hosting.
 
-/// Placeholder identity item; the real bindings land in later PRs.
-pub const CRATE: &str = "cipherbox-wasm";
+// wasm-bindgen's macro-generated glue is unsafe by nature and exempt; this
+// forbids only unsafe we would hand-write (there is none).
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+use cipherbox_engine::facade;
+use wasm_bindgen::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Boundary value types.
+// ---------------------------------------------------------------------------
+
+/// The stable 16-byte node identifier (`id16`). Routes and commands key on it,
+/// never on rotating `ipnsName`s.
+#[wasm_bindgen]
+pub struct NodeId {
+    inner: facade::NodeId,
+}
+
+#[wasm_bindgen]
+impl NodeId {
+    /// Builds a node id from its 16 raw bytes; throws if the length is wrong.
+    #[wasm_bindgen(js_name = fromBytes)]
+    pub fn from_bytes(bytes: &[u8]) -> Result<NodeId, JsError> {
+        let inner: [u8; 16] = bytes
+            .try_into()
+            .map_err(|_| JsError::new("nodeId must be exactly 16 bytes"))?;
+        Ok(Self {
+            inner: facade::NodeId(inner),
+        })
+    }
+
+    /// The 16 raw bytes of this node id.
+    #[wasm_bindgen(getter)]
+    pub fn bytes(&self) -> Vec<u8> {
+        self.inner.0.to_vec()
+    }
+}
+
+impl NodeId {
+    fn facade(&self) -> facade::NodeId {
+        self.inner
+    }
+}
+
+/// What a created node is (sealed inside the read-body on the wire; plain
+/// intent at the facade).
+#[wasm_bindgen]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeKind {
+    /// A file node.
+    File,
+    /// A folder node.
+    Folder,
+}
+
+impl From<NodeKind> for facade::NodeKind {
+    fn from(kind: NodeKind) -> Self {
+        match kind {
+            NodeKind::File => facade::NodeKind::File,
+            NodeKind::Folder => facade::NodeKind::Folder,
+        }
+    }
+}
+
+/// Grant permission level.
+#[wasm_bindgen]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Permission {
+    /// Read grant: read seed only.
+    Read,
+    /// Write grant: read and write seeds.
+    Write,
+}
+
+impl From<Permission> for facade::Permission {
+    fn from(permission: Permission) -> Self {
+        match permission {
+            Permission::Read => facade::Permission::Read,
+            Permission::Write => facade::Permission::Write,
+        }
+    }
+}
+
+/// The staleness ladder (#33 D4): a view is `Fresh`, quietly `Reconciling`,
+/// `Stale` past the profile threshold, or `Offline`. Availability staleness,
+/// never a trust violation.
+#[wasm_bindgen]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Staleness {
+    /// View is within the freshness window.
+    Fresh,
+    /// A background reconcile is in flight.
+    Reconciling,
+    /// Past the profile threshold: "last synced X ago".
+    Stale,
+    /// Offline banner.
+    Offline,
+}
+
+impl From<facade::Staleness> for Staleness {
+    fn from(level: facade::Staleness) -> Self {
+        match level {
+            facade::Staleness::Fresh => Staleness::Fresh,
+            facade::Staleness::Reconciling => Staleness::Reconciling,
+            facade::Staleness::Stale => Staleness::Stale,
+            facade::Staleness::Offline => Staleness::Offline,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Commands — the write-intent surface. Built by the host, consumed (later) by
+// the engine handle; payload readback is deliberately absent so no user data or
+// key material can be read back out through the boundary. Only the stable
+// variant `name` is exposed.
+// ---------------------------------------------------------------------------
+
+/// One command a host issues to the engine (blueprint/engine.md "Facade").
+/// Opaque to JS: constructed through the static builders, then handed to the
+/// engine — never destructured.
+#[wasm_bindgen]
+pub struct Command {
+    inner: facade::Command,
+}
+
+#[wasm_bindgen]
+impl Command {
+    /// Create a node under a parent (`content` only for file creates).
+    pub fn create(
+        parent: &NodeId,
+        name: String,
+        kind: NodeKind,
+        content: Option<Vec<u8>>,
+    ) -> Command {
+        Self::wrap(facade::Command::Create {
+            parent: parent.facade(),
+            name,
+            kind: kind.into(),
+            content: content.map(facade::PlaintextContent),
+        })
+    }
+
+    /// Delete a node (conditional-delete semantics on rebase).
+    pub fn delete(node: &NodeId) -> Command {
+        Self::wrap(facade::Command::Delete {
+            node: node.facade(),
+        })
+    }
+
+    /// Rename a node in place.
+    pub fn rename(node: &NodeId, new_name: String) -> Command {
+        Self::wrap(facade::Command::Rename {
+            node: node.facade(),
+            new_name,
+        })
+    }
+
+    /// Move a node to a new parent.
+    pub fn relink(node: &NodeId, new_parent: &NodeId) -> Command {
+        Self::wrap(facade::Command::Relink {
+            node: node.facade(),
+            new_parent: new_parent.facade(),
+        })
+    }
+
+    /// Write new content to a file node.
+    #[wasm_bindgen(js_name = updateContent)]
+    pub fn update_content(node: &NodeId, content: Vec<u8>) -> Command {
+        Self::wrap(facade::Command::UpdateContent {
+            node: node.facade(),
+            content: facade::PlaintextContent(content),
+        })
+    }
+
+    /// Set the open folder driving the focus window (`undefined` clears it).
+    #[wasm_bindgen(js_name = setFocus)]
+    pub fn set_focus(node: Option<NodeId>) -> Command {
+        Self::wrap(facade::Command::SetFocus {
+            node: node.map(|n| n.facade()),
+        })
+    }
+
+    /// Manual refresh with nocache semantics everywhere.
+    #[wasm_bindgen(js_name = manualRefresh)]
+    pub fn manual_refresh() -> Command {
+        Self::wrap(facade::Command::ManualRefresh)
+    }
+
+    /// Import a self-authenticating contact code (binding-signature verified
+    /// in the engine).
+    #[wasm_bindgen(js_name = importContact)]
+    pub fn import_contact(contact_code: Vec<u8>) -> Command {
+        Self::wrap(facade::Command::ImportContact { contact_code })
+    }
+
+    /// Grant a node to an imported contact (owner-only).
+    pub fn grant(
+        node: &NodeId,
+        recipient_identity_public_key: Vec<u8>,
+        permission: Permission,
+    ) -> Command {
+        Self::wrap(facade::Command::Grant {
+            node: node.facade(),
+            recipient_identity_public_key,
+            permission: permission.into(),
+        })
+    }
+
+    /// Revoke a grant (owner-only; read revoke = immediate cut).
+    pub fn revoke(node: &NodeId, recipient_identity_public_key: Vec<u8>) -> Command {
+        Self::wrap(facade::Command::Revoke {
+            node: node.facade(),
+            recipient_identity_public_key,
+        })
+    }
+
+    /// Downgrade a write grant to read (owner-only; triggers write rotation).
+    pub fn downgrade(node: &NodeId, recipient_identity_public_key: Vec<u8>) -> Command {
+        Self::wrap(facade::Command::Downgrade {
+            node: node.facade(),
+            recipient_identity_public_key,
+        })
+    }
+
+    /// Mint an invite link for a node.
+    #[wasm_bindgen(js_name = createInviteLink)]
+    pub fn create_invite_link(node: &NodeId, permission: Permission) -> Command {
+        Self::wrap(facade::Command::CreateInviteLink {
+            node: node.facade(),
+            permission: permission.into(),
+        })
+    }
+
+    /// Accept a share from a polled mailbox pointer or claimed invite.
+    #[wasm_bindgen(js_name = acceptShare)]
+    pub fn accept_share(sealed_share_pointer: Vec<u8>) -> Command {
+        Self::wrap(facade::Command::AcceptShare {
+            sealed_share_pointer,
+        })
+    }
+
+    /// Manual hygiene rotate-now for a scope.
+    #[wasm_bindgen(js_name = rotateNow)]
+    pub fn rotate_now(node: &NodeId) -> Command {
+        Self::wrap(facade::Command::RotateNow {
+            node: node.facade(),
+        })
+    }
+
+    /// Exchange a host-collected SIWE wallet signature (secondary method).
+    #[wasm_bindgen(js_name = siweLogin)]
+    pub fn siwe_login(message: String, signature: Vec<u8>) -> Command {
+        Self::wrap(facade::Command::SiweLogin { message, signature })
+    }
+
+    /// Log out: zeroize engine state; durable seams survive by design.
+    pub fn logout() -> Command {
+        Self::wrap(facade::Command::Logout)
+    }
+
+    /// The stable command name (matches the builder's JS name), for
+    /// diagnostics. Carries no payload.
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        self.inner.name().to_string()
+    }
+}
+
+impl Command {
+    fn wrap(inner: facade::Command) -> Self {
+        Self { inner }
+    }
+
+    /// Unwraps to the engine command. For the engine-handle slice and the
+    /// boundary tests; never exported to JS.
+    pub fn into_facade(self) -> facade::Command {
+        self.inner
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Events — the read surface of the one-way event stream. Every getter returns
+// key-free view state; a getter is `undefined` for a non-matching variant.
+// ---------------------------------------------------------------------------
+
+/// One event the engine emits on the outbound stream (blueprint/engine.md
+/// "Facade"). Read `kind`, then the matching payload getter.
+#[wasm_bindgen]
+pub struct Event {
+    inner: facade::Event,
+}
+
+#[wasm_bindgen]
+impl Event {
+    /// The event discriminant, as a stable string literal.
+    #[wasm_bindgen(getter)]
+    pub fn kind(&self) -> String {
+        match self.inner {
+            facade::Event::SnapshotUpdated => "snapshotUpdated",
+            facade::Event::StalenessChanged { .. } => "stalenessChanged",
+            facade::Event::WithheldUpdateEscalation { .. } => "withheldUpdateEscalation",
+            facade::Event::DeadLetter { .. } => "deadLetter",
+            facade::Event::AttributableAbuse { .. } => "attributableAbuse",
+        }
+        .to_string()
+    }
+
+    /// `stalenessChanged`: the new level; otherwise `undefined`.
+    #[wasm_bindgen(getter)]
+    pub fn staleness(&self) -> Option<Staleness> {
+        match self.inner {
+            facade::Event::StalenessChanged { level } => Some(level.into()),
+            _ => None,
+        }
+    }
+
+    /// `withheldUpdateEscalation`: the pinned IPNS name bytes; otherwise
+    /// `undefined`.
+    #[wasm_bindgen(getter, js_name = ipnsName)]
+    pub fn ipns_name(&self) -> Option<Vec<u8>> {
+        match &self.inner {
+            facade::Event::WithheldUpdateEscalation { ipns_name } => Some(ipns_name.clone()),
+            _ => None,
+        }
+    }
+
+    /// `deadLetter`: the op id (a `u64`, crossing as `bigint`); otherwise
+    /// `undefined`.
+    #[wasm_bindgen(getter, js_name = opId)]
+    pub fn op_id(&self) -> Option<u64> {
+        match self.inner {
+            facade::Event::DeadLetter { op_id } => Some(op_id.0),
+            _ => None,
+        }
+    }
+
+    /// `attributableAbuse`: the key-free classification; otherwise `undefined`.
+    #[wasm_bindgen(getter)]
+    pub fn description(&self) -> Option<String> {
+        match &self.inner {
+            facade::Event::AttributableAbuse { description } => Some(description.clone()),
+            _ => None,
+        }
+    }
+}
+
+impl Event {
+    /// Wraps an engine event for the boundary. For the event-stream reader
+    /// slice and the boundary tests; never exported to JS.
+    pub fn from_facade(inner: facade::Event) -> Self {
+        Self { inner }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Native-only conversion tests. The browser-shaped boundary behaviour lives in
+// `tests/boundary.rs` under wasm-bindgen-test; these host tests guard the
+// facade<->binding mapping (a new engine variant breaks an exhaustive match).
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use cipherbox_engine::seams::OpId;
+
+    // The wrong-length rejection path builds a `JsError`, which only runs on
+    // wasm; it is asserted in `tests/boundary.rs`. Here we cover the accepted
+    // path and the byte round-trip.
     #[test]
-    fn crate_name() {
-        assert_eq!(super::CRATE, "cipherbox-wasm");
+    fn node_id_accepts_16_bytes_and_round_trips() {
+        assert!(NodeId::from_bytes(&[0u8; 16]).is_ok());
+        assert_eq!(
+            NodeId::from_bytes(&[7u8; 16]).unwrap().bytes(),
+            vec![7u8; 16]
+        );
     }
 
     #[test]
-    fn depends_on_engine() {
-        assert_eq!(cipherbox_engine::CRATE, "cipherbox-engine");
+    fn command_builders_carry_the_stable_name() {
+        let node = NodeId::from_bytes(&[0u8; 16]).unwrap();
+        assert_eq!(Command::manual_refresh().name(), "manualRefresh");
+        assert_eq!(Command::logout().name(), "logout");
+        assert_eq!(
+            Command::update_content(&node, b"bytes".to_vec()).name(),
+            "updateContent"
+        );
+        assert_eq!(Command::set_focus(None).name(), "setFocus");
+        assert_eq!(
+            Command::create(&node, "f".into(), NodeKind::Folder, None).name(),
+            "create"
+        );
+    }
+
+    #[test]
+    fn command_unwraps_to_the_engine_variant() {
+        let node = NodeId::from_bytes(&[1u8; 16]).unwrap();
+        let cmd = Command::grant(&node, vec![9, 9, 9], Permission::Write);
+        match cmd.into_facade() {
+            facade::Command::Grant {
+                permission,
+                recipient_identity_public_key,
+                ..
+            } => {
+                assert_eq!(permission, facade::Permission::Write);
+                assert_eq!(recipient_identity_public_key, vec![9, 9, 9]);
+            }
+            other => panic!("expected Grant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn event_kind_and_payload_getters_map_variants() {
+        let snapshot = Event::from_facade(facade::Event::SnapshotUpdated);
+        assert_eq!(snapshot.kind(), "snapshotUpdated");
+        assert!(snapshot.op_id().is_none());
+
+        let dead = Event::from_facade(facade::Event::DeadLetter { op_id: OpId(42) });
+        assert_eq!(dead.kind(), "deadLetter");
+        assert_eq!(dead.op_id(), Some(42));
+
+        let stale = Event::from_facade(facade::Event::StalenessChanged {
+            level: facade::Staleness::Offline,
+        });
+        assert_eq!(stale.kind(), "stalenessChanged");
+        assert_eq!(stale.staleness(), Some(Staleness::Offline));
+
+        let withheld = Event::from_facade(facade::Event::WithheldUpdateEscalation {
+            ipns_name: vec![1, 2, 3],
+        });
+        assert_eq!(withheld.ipns_name(), Some(vec![1, 2, 3]));
     }
 }

--- a/crates/wasm/tests/boundary.rs
+++ b/crates/wasm/tests/boundary.rs
@@ -1,0 +1,87 @@
+//! Browser-shaped boundary tests (wasm32-unknown-unknown, under
+//! wasm-bindgen-test-runner → Node.js). They exercise the two boundary risks
+//! the WASM leg exists to cover (blueprint/web-client.md "Boundary hygiene"):
+//! `u64`→`bigint` marshalling and the getrandom → `crypto.getRandomValues`
+//! worker-scope wiring, plus the command/event surface shapes.
+//!
+//! The whole file is gated to the browser target; native `cargo test` for this
+//! crate runs the host conversion tests in `src/lib.rs` instead.
+#![cfg(all(target_family = "wasm", target_os = "unknown"))]
+
+use cipherbox_engine::facade;
+use cipherbox_engine::seams::OpId;
+use cipherbox_wasm::{Command, Event, NodeId, NodeKind, Permission, Staleness};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+/// getrandom's `wasm_js` backend must reach `crypto.getRandomValues` in the
+/// worker/JS scope — the getrandom parity surface. A dependency-level need:
+/// engine logic still takes injected entropy.
+#[wasm_bindgen_test]
+fn getrandom_wires_to_crypto_get_random_values() {
+    let mut buf = [0u8; 32];
+    getrandom::fill(&mut buf).expect("crypto.getRandomValues must be wired in the worker scope");
+    assert!(
+        buf.iter().any(|&b| b != 0),
+        "32 random bytes are all-zero with negligible probability"
+    );
+}
+
+/// A `u64` op id (> Number.MAX_SAFE_INTEGER) must survive the boundary as a
+/// `bigint` — the u64/BigInt parity surface.
+#[wasm_bindgen_test]
+fn op_id_u64_crosses_as_bigint() {
+    let event = Event::from_facade(facade::Event::DeadLetter {
+        op_id: OpId(u64::MAX),
+    });
+    assert_eq!(event.kind(), "deadLetter");
+    assert_eq!(event.op_id(), Some(u64::MAX));
+}
+
+/// Binary payloads cross as `Uint8Array` in both directions.
+#[wasm_bindgen_test]
+fn node_id_bytes_round_trip_and_reject_bad_length() {
+    let bytes: Vec<u8> = (0..16).collect();
+    let node = NodeId::from_bytes(&bytes).expect("16 bytes is a valid node id");
+    assert_eq!(node.bytes(), bytes);
+    assert!(
+        NodeId::from_bytes(&[0u8; 20]).is_err(),
+        "a wrong-length node id must throw at the boundary"
+    );
+}
+
+/// The command builders wrap engine intent and expose only the stable name.
+#[wasm_bindgen_test]
+fn command_builders_expose_stable_names() {
+    let node = NodeId::from_bytes(&[0u8; 16]).expect("valid node id");
+    assert_eq!(
+        Command::create(
+            &node,
+            "photo.jpg".into(),
+            NodeKind::File,
+            Some(vec![1, 2, 3])
+        )
+        .name(),
+        "create"
+    );
+    assert_eq!(
+        Command::grant(&node, vec![0xAB; 32], Permission::Write).name(),
+        "grant"
+    );
+    assert_eq!(Command::manual_refresh().name(), "manualRefresh");
+}
+
+/// Event getters return key-free view state, keyed off `kind`.
+#[wasm_bindgen_test]
+fn event_getters_map_variants() {
+    let staleness = Event::from_facade(facade::Event::StalenessChanged {
+        level: facade::Staleness::Stale,
+    });
+    assert_eq!(staleness.kind(), "stalenessChanged");
+    assert_eq!(staleness.staleness(), Some(Staleness::Stale));
+    assert!(staleness.op_id().is_none());
+
+    let withheld = Event::from_facade(facade::Event::WithheldUpdateEscalation {
+        ipns_name: vec![9, 8, 7],
+    });
+    assert_eq!(withheld.ipns_name(), Some(vec![9, 8, 7]));
+}


### PR DESCRIPTION
Closes #637.

## What this lands

A new crate `crates/wasm` (`cipherbox-wasm`): one `wasm-bindgen` ES module that binds the engine facade's command + event surface, plus the merge-blocking browser-shaped WASM KAT gate.

- **Opaque `Command`** with 16 static builders (one per facade variant), exposing only a stable `name` getter — no payload readback, so no user data or key material can be read back out through the boundary.
- **`Event`** with typed, key-free getters (`kind`, `staleness`, `ipnsName`, `opId`, `description`); a getter is `undefined` for a non-matching variant.
- **`NodeId`** length-checked (`fromBytes` throws on != 16 bytes), plus `NodeKind` / `Permission` / `Staleness` boundary enums.
- **Boundary hygiene is structural:** `u64` (op ids) crosses as `bigint`, binary payloads as `Uint8Array`; `getrandom` to `crypto.getRandomValues` is wired for the browser test target only.
- The **wasm-bindgen-generated `.d.ts` is the single contract** — there is no hand-written TS mirror. `packages/client` re-exports it later.

## Key deviation (scope)

This lands the facade **type surface only**, not a live engine handle. `start` / `command` / the event-stream reader and the `LoginSecret` ingress need the host seams + worker transport, which are out of scope here — they bind in the next slice, `#639` (host the engine worker and land the local facade transport). No secret ever crosses the boundary in this slice.

## CI gate

Extends the existing `core-kats` job (no new third-party action — `actions/setup-node` and `bytecodealliance/actions/wasmtime` were already allowlisted; `wasm-bindgen-cli` comes via `cargo install`, version pinned from `Cargo.lock`). Adds three legs on `wasm32-unknown-unknown` under `wasm-bindgen-test` to Node: the core KAT + property suite (count-parity with the native run is the anti-vacuity backstop), the `crates/wasm` boundary tests, and the single ES-module + `.d.ts` build.

## Crypto / privacy review

Ran a real boundary review against `blueprint/web-client.md` (WASM packaging + type boundary) and `CONTEXT.md`. Outcome: clean, nothing to fix beyond the doc sharpening below.

- The wasm crate imports **only** `cipherbox_engine::facade` — nothing from `cipherbox-core` is re-exported to JS; all crypto/codec stays behind the facade.
- Redaction discipline survives the boundary: `Command` exposes only its variant `name`, never payloads or keys (mirrors the facade's own hand-written redacting `Debug`).
- `getrandom` wiring is a browser-**test**-only dev-dependency; production engine logic still takes injected entropy, so no nondeterminism is smuggled into core/engine.
- No secret key material crosses. A grant carries the recipient's **public** identity key inward as intent — the module doc was sharpened to name that public-key exception explicitly rather than overclaim "no key crosses".

## Local gates (all green)

- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --exclude cipherbox-desktop --all-targets -- -D warnings` — clean; same for `-p cipherbox-wasm` and `-p cipherbox-core` on `--target wasm32-unknown-unknown`.
- `cargo test --workspace --exclude cipherbox-desktop` — all green (core 13 unit + engine 32 + conformance/facade + wasm host 4, etc.).
- **KAT parity:** native `kat_manifest` (11) + `codec_props` (5) = 16; `wasm32-unknown-unknown` under `wasm-bindgen-test` to Node = 11 + 5 = **16, exact match**. Plus the 5 `crates/wasm` boundary tests green on wasm.
- ES-module artifact builds with the exact CI command; `cipherbox_wasm.d.ts` + `cipherbox_wasm.js` generated.

## Review triage

- **General security sweep** of the diff: clean. `#![forbid(unsafe_code)]`; length-checked `NodeId`; the CI `cargo install` version is derived from committed `Cargo.lock` and `--locked`; no secrets, all action SHAs pinned.
- **CodeRabbit CLI:** 3 findings — 1 fixed (doc precision on the public-key crossing), 2 discarded: a request for JS-side ES-module integration tests (the `wasm-bindgen-test` leg already runs on the real wasm target under Node; JS-side module-loading integration belongs with the worker-hosting slice `#639`), and a camelCase-parameter naming nit (positional TS params, zero caller impact, would need `#[allow(non_snake_case)]` noise across 7 methods).
- **Issues filed:** none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a WebAssembly interface for creating commands, handling events, and working with node identifiers, permissions, and statuses.
  * Added JavaScript-compatible outputs for the WASM module, including module and type definition files.
  * Added browser-oriented WASM test coverage, including random number generation, byte validation, command naming, event data, and large operation IDs.

* **Bug Fixes**
  * Improved WASM test compatibility across supported runtimes and browser-like environments.

* **Tests**
  * Expanded continuous integration checks to validate WASM parity and generated artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->