### PR TITLE
feat(desktop): implement the desktop seam set against the conformance kits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2303,7 @@ dependencies = [
  "security-framework 2.11.1",
  "security-framework 3.7.0",
  "windows-sys 0.60.2",
+ "zbus",
  "zeroize",
 ]
 
@@ -5903,9 +5929,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
 dependencies = [
  "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
  "async-process",
  "async-recursion",
+ "async-task",
  "async-trait",
+ "blocking",
  "enumflags2",
  "event-listener",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +79,112 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -187,12 +304,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -332,6 +471,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +523,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,13 +540,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -450,6 +615,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipherbox-desktop-seams"
+version = "0.0.0"
+dependencies = [
+ "cipherbox-desktop-seams",
+ "cipherbox-engine",
+ "keyring",
+ "reqwest 0.12.28",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "cipherbox-engine"
 version = "0.0.0"
 dependencies = [
@@ -488,6 +665,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +693,16 @@ checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -532,7 +728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -545,7 +741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -722,6 +918,24 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -983,6 +1197,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1248,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1145,6 +1407,19 @@ name = "futures-io"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1302,8 +1577,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1327,8 +1604,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1515,6 +1795,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,6 +1891,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1824,6 +2126,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -1963,6 +2266,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,6 +2371,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -2178,6 +2503,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,10 +2525,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2444,6 +2845,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,6 +2878,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2557,6 +2974,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,6 +3027,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2714,8 +3156,8 @@ dependencies = [
  "bit-vec",
  "bitflags 2.13.1",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2745,6 +3187,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2767,12 +3265,44 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2790,6 +3320,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -2798,6 +3331,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2886,6 +3434,44 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -2929,6 +3515,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,6 +3557,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2973,6 +3608,12 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3051,6 +3692,61 @@ dependencies = [
  "generic-array",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.7",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3178,6 +3874,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3241,6 +3949,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3256,6 +3975,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "signature"
@@ -3354,6 +4083,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -3475,7 +4210,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -3555,7 +4290,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3866,7 +4601,29 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4054,7 +4811,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4105,6 +4874,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unarray"
@@ -4174,6 +4954,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -4411,6 +5197,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4464,6 +5260,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4698,11 +5503,29 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -4738,11 +5561,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4776,6 +5616,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4786,6 +5632,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4800,10 +5652,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4818,6 +5682,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4828,6 +5698,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4842,6 +5718,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4852,6 +5734,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -4976,6 +5864,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4996,6 +5894,62 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.7",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -5097,3 +6051,40 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/engine",
     "crates/wasm",
     "crates/fuse",
+    "crates/desktop-seams",
     "apps/desktop/src-tauri",
 ]
 

--- a/crates/desktop-seams/Cargo.toml
+++ b/crates/desktop-seams/Cargo.toml
@@ -1,0 +1,53 @@
+# CipherBox desktop seam set (blueprint/desktop.md, "Engine wiring").
+#
+# The concrete implementations of the engine's host seam traits for the
+# desktop native host: fsync-barriered file stores, the OS-keyring
+# credential store, reqwest transports, and the Tokio scheduler. Pure Rust,
+# no Tauri: this crate is a library the desktop shell (cipherbox-desktop)
+# links to construct the engine at login — a later slice owns that wiring.
+# Version-frozen at 0.0.0 like every workspace crate; never published.
+[package]
+name = "cipherbox-desktop-seams"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[features]
+# Compiles test-only seam doubles (the file-backed CredentialStore) used to
+# run the CredentialStore conformance kit on headless CI, where the OS
+# keyring is unavailable. Never enabled in production builds; activated only
+# by this crate's own self dev-dependency (below), exactly like the engine's
+# `test-kit` feature.
+test-support = []
+
+[dependencies]
+cipherbox-engine.workspace = true
+# reqwest with ring-backed rustls only — no OpenSSL, no native-tls, no
+# aws-lc-rs/cmake (hard constraint 6). Bundled webpki roots keep it
+# self-contained for the public /routing/v1 and gateway endpoints.
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls-webpki-roots",
+] }
+# OS keyring: Apple Keychain / Windows Credential Manager / Secret Service
+# (crypto-rust keeps the Linux transport encryption pure Rust — no OpenSSL).
+keyring = { version = "3", features = [
+    "apple-native",
+    "windows-native",
+    "sync-secret-service",
+    "crypto-rust",
+] }
+# Tokio backs the Scheduler seam (timers, background tasks, wall clock).
+tokio = { version = "1", features = ["rt", "time"] }
+
+[dev-dependencies]
+# Self dev-dependency enables `test-support` for this crate's own tests
+# without leaking it into downstream production builds (engine's pattern).
+cipherbox-desktop-seams = { path = ".", features = ["test-support"] }
+# The reusable per-seam conformance kits + the minimal single-future
+# executor live behind the engine's `test-kit` feature.
+cipherbox-engine = { workspace = true, features = ["test-kit"] }
+tokio = { version = "1", features = ["rt", "time", "macros"] }
+tempfile = "3"

--- a/crates/desktop-seams/Cargo.toml
+++ b/crates/desktop-seams/Cargo.toml
@@ -31,12 +31,18 @@ cipherbox-engine.workspace = true
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls-webpki-roots",
 ] }
-# OS keyring: Apple Keychain / Windows Credential Manager / Secret Service
-# (crypto-rust keeps the Linux transport encryption pure Rust — no OpenSSL).
+# OS keyring: Apple Keychain / Windows Credential Manager / Secret Service.
+# The Linux backend is the *async* Secret Service over zbus + async-io +
+# crypto-rust — pure Rust end to end (no OpenSSL, and crucially no libdbus C
+# dependency, which `sync-secret-service` would drag in via libdbus-sys and
+# break hard constraint 6 / the no-cmake, no-C-toolchain rule). async-io (not
+# the tokio runtime feature) does the internal block-on, so the sync keyring
+# API stays callable without nesting inside the engine's own Tokio runtime.
 keyring = { version = "3", features = [
     "apple-native",
     "windows-native",
-    "sync-secret-service",
+    "async-secret-service",
+    "async-io",
     "crypto-rust",
 ] }
 # Tokio backs the Scheduler seam (timers, background tasks, wall clock).

--- a/crates/desktop-seams/src/credential_store.rs
+++ b/crates/desktop-seams/src/credential_store.rs
@@ -1,0 +1,171 @@
+//! Desktop [`CredentialStore`]: the OS keyring, plus a feature-gated
+//! file-backed test double.
+
+use cipherbox_engine::seams::{CredentialStore, SeamError, SeamResult};
+
+/// Keyring account label for the rotating refresh token.
+const REFRESH_TOKEN_ACCOUNT: &str = "refresh-token";
+/// Keyring account label for the last-account id.
+const LAST_ACCOUNT_ID_ACCOUNT: &str = "last-account-id";
+
+/// Refresh-token persistence in the OS keyring (Apple Keychain, Windows
+/// Credential Manager, or the Secret Service on Linux) —
+/// blueprint/engine.md "CredentialStore", desktop column;
+/// blueprint/desktop.md "OS keychain".
+///
+/// Holds **only** the rotating refresh token and the last-account id, under
+/// one service name, two accounts — never key material, never a seed, never
+/// the short-lived access JWT (which lives in engine memory only). Both
+/// values are stored as opaque secret bytes.
+///
+/// `Debug` is derived and safe: the struct carries only the service name, a
+/// non-secret; no token is ever held in memory by this handle.
+#[derive(Debug, Clone)]
+pub struct KeyringCredentialStore {
+    service: String,
+}
+
+impl KeyringCredentialStore {
+    /// A credential store under one keyring service name (e.g.
+    /// `"com.cipherbox.desktop"`). One store per running app.
+    pub fn new(service: impl Into<String>) -> Self {
+        Self {
+            service: service.into(),
+        }
+    }
+
+    fn entry(&self, account: &str) -> SeamResult<keyring::Entry> {
+        keyring::Entry::new(&self.service, account)
+            .map_err(|err| SeamError::new(format!("keyring entry: {err}")))
+    }
+
+    /// Stores an opaque secret under one account, replacing any previous
+    /// value.
+    fn store_secret(&self, account: &str, secret: &[u8]) -> SeamResult<()> {
+        self.entry(account)?
+            .set_secret(secret)
+            .map_err(|err| SeamError::new(format!("keyring set: {err}")))
+    }
+
+    /// Loads an opaque secret, mapping a missing entry to `None`.
+    fn load_secret(&self, account: &str) -> SeamResult<Option<Vec<u8>>> {
+        match self.entry(account)?.get_secret() {
+            Ok(secret) => Ok(Some(secret)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(err) => Err(SeamError::new(format!("keyring get: {err}"))),
+        }
+    }
+
+    /// Deletes an account's secret. Idempotent (a missing entry is success).
+    fn clear_secret(&self, account: &str) -> SeamResult<()> {
+        match self.entry(account)?.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(err) => Err(SeamError::new(format!("keyring delete: {err}"))),
+        }
+    }
+
+    /// Persists the last-account id — the only extra datum this store holds
+    /// beyond the refresh token, used by the shell to pick the account
+    /// directory on next launch (blueprint/desktop.md "last-account id").
+    pub async fn store_last_account_id(&self, account_id: &[u8]) -> SeamResult<()> {
+        self.store_secret(LAST_ACCOUNT_ID_ACCOUNT, account_id)
+    }
+
+    /// The persisted last-account id, if any.
+    pub async fn load_last_account_id(&self) -> SeamResult<Option<Vec<u8>>> {
+        self.load_secret(LAST_ACCOUNT_ID_ACCOUNT)
+    }
+
+    /// Deletes the persisted last-account id. Idempotent.
+    pub async fn clear_last_account_id(&self) -> SeamResult<()> {
+        self.clear_secret(LAST_ACCOUNT_ID_ACCOUNT)
+    }
+}
+
+impl CredentialStore for KeyringCredentialStore {
+    async fn store_refresh_token(&self, refresh_token: &[u8]) -> SeamResult<()> {
+        self.store_secret(REFRESH_TOKEN_ACCOUNT, refresh_token)
+    }
+
+    async fn load_refresh_token(&self) -> SeamResult<Option<Vec<u8>>> {
+        self.load_secret(REFRESH_TOKEN_ACCOUNT)
+    }
+
+    async fn clear_refresh_token(&self) -> SeamResult<()> {
+        self.clear_secret(REFRESH_TOKEN_ACCOUNT)
+    }
+}
+
+/// A file-backed [`CredentialStore`] **test double** for headless CI, where
+/// no OS keyring is available (hard-constraint note in issue #646).
+///
+/// Gated behind the `test-support` feature and never compiled into a
+/// production build. It writes its values to plaintext files, so it must
+/// never hold a real token — only the conformance kit's fixture tokens. The
+/// real credential path is always [`KeyringCredentialStore`].
+#[cfg(feature = "test-support")]
+pub use file_double::FileCredentialStore;
+
+#[cfg(feature = "test-support")]
+mod file_double {
+    use std::path::{Path, PathBuf};
+
+    use cipherbox_engine::seams::{CredentialStore, SeamResult};
+
+    use crate::fs_util::{atomic_write, ensure_dir, read_file_opt, remove_file_durable, seam_err};
+
+    /// File-backed credential store — TEST DOUBLE ONLY. Values are written
+    /// in plaintext; never use it for a real token. See the module note.
+    pub struct FileCredentialStore {
+        refresh_token_path: PathBuf,
+        last_account_id_path: PathBuf,
+    }
+
+    impl FileCredentialStore {
+        /// Opens (creating if absent) a file-backed store rooted at `dir`.
+        pub fn open(dir: impl AsRef<Path>) -> SeamResult<Self> {
+            let dir = dir.as_ref();
+            ensure_dir(dir).map_err(|err| seam_err("file_credential_store open", &err))?;
+            Ok(Self {
+                refresh_token_path: dir.join("refresh_token"),
+                last_account_id_path: dir.join("last_account_id"),
+            })
+        }
+
+        /// Persists the last-account id (mirrors the keyring store's inherent
+        /// method so tests exercise the same surface).
+        pub async fn store_last_account_id(&self, account_id: &[u8]) -> SeamResult<()> {
+            atomic_write(&self.last_account_id_path, account_id)
+                .map_err(|err| seam_err("file_credential_store store_last_account_id", &err))
+        }
+
+        /// The persisted last-account id, if any.
+        pub async fn load_last_account_id(&self) -> SeamResult<Option<Vec<u8>>> {
+            read_file_opt(&self.last_account_id_path)
+                .map_err(|err| seam_err("file_credential_store load_last_account_id", &err))
+        }
+
+        /// Deletes the persisted last-account id. Idempotent.
+        pub async fn clear_last_account_id(&self) -> SeamResult<()> {
+            remove_file_durable(&self.last_account_id_path)
+                .map_err(|err| seam_err("file_credential_store clear_last_account_id", &err))
+        }
+    }
+
+    impl CredentialStore for FileCredentialStore {
+        async fn store_refresh_token(&self, refresh_token: &[u8]) -> SeamResult<()> {
+            atomic_write(&self.refresh_token_path, refresh_token)
+                .map_err(|err| seam_err("file_credential_store store_refresh_token", &err))
+        }
+
+        async fn load_refresh_token(&self) -> SeamResult<Option<Vec<u8>>> {
+            read_file_opt(&self.refresh_token_path)
+                .map_err(|err| seam_err("file_credential_store load_refresh_token", &err))
+        }
+
+        async fn clear_refresh_token(&self) -> SeamResult<()> {
+            remove_file_durable(&self.refresh_token_path)
+                .map_err(|err| seam_err("file_credential_store clear_refresh_token", &err))
+        }
+    }
+}

--- a/crates/desktop-seams/src/floor_store.rs
+++ b/crates/desktop-seams/src/floor_store.rs
@@ -1,0 +1,89 @@
+//! Desktop [`FloorStore`]: fsync-barriered per-key floor files.
+
+use std::path::{Path, PathBuf};
+
+use cipherbox_engine::seams::{FloorStore, SeamError, SeamResult};
+
+use crate::fs_util::{atomic_write, ensure_dir, read_file_opt, seam_err, to_hex};
+
+/// Durable monotonic-max floor store backed by one small file per key
+/// (blueprint/engine.md "FloorStore"; blueprint/desktop.md "Local journal").
+///
+/// Epoch floors live under `epoch/`, sequence floors under `seq/`, so the
+/// two namespaces cannot collide even on identical key bytes. Each floor is
+/// a single `u64` (8 bytes, little-endian) written through the
+/// [`atomic_write`] fsync barrier, so a floor is structurally incapable of
+/// regression or a torn value, and survives reopen. Keys are opaque engine
+/// bytes, hex-encoded into filenames; the store never interprets them.
+pub struct FileFloorStore {
+    epoch_dir: PathBuf,
+    seq_dir: PathBuf,
+}
+
+impl FileFloorStore {
+    /// Opens (creating if absent) a floor store rooted at `dir`. Reopening
+    /// the same `dir` yields the same durable floors.
+    pub fn open(dir: impl AsRef<Path>) -> SeamResult<Self> {
+        let dir = dir.as_ref();
+        let epoch_dir = dir.join("epoch");
+        let seq_dir = dir.join("seq");
+        ensure_dir(&epoch_dir).map_err(|err| seam_err("floor_store open epoch", &err))?;
+        ensure_dir(&seq_dir).map_err(|err| seam_err("floor_store open seq", &err))?;
+        Ok(Self { epoch_dir, seq_dir })
+    }
+
+    fn read_floor(&self, dir: &Path, key: &[u8], op: &str) -> SeamResult<Option<u64>> {
+        let path = dir.join(to_hex(key));
+        let bytes = read_file_opt(&path).map_err(|err| seam_err(op, &err))?;
+        match bytes {
+            None => Ok(None),
+            Some(bytes) => {
+                let array: [u8; 8] = bytes
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| SeamError::new(format!("{op}: corrupt floor value on disk")))?;
+                Ok(Some(u64::from_le_bytes(array)))
+            }
+        }
+    }
+
+    fn raise_floor(&self, dir: &Path, key: &[u8], value: u64, op: &str) -> SeamResult<u64> {
+        let current = self.read_floor(dir, key, op)?;
+        let raised = current.map_or(value, |stored| stored.max(value));
+        // Monotonic-max: only touch the platter when the floor actually
+        // advances, so a no-op raise is genuinely free.
+        if current != Some(raised) {
+            let path = dir.join(to_hex(key));
+            atomic_write(&path, &raised.to_le_bytes()).map_err(|err| seam_err(op, &err))?;
+        }
+        Ok(raised)
+    }
+}
+
+impl FloorStore for FileFloorStore {
+    async fn epoch_floor(&self, scope_id: &[u8]) -> SeamResult<Option<u64>> {
+        self.read_floor(&self.epoch_dir, scope_id, "floor_store epoch_floor")
+    }
+
+    async fn raise_epoch_floor(&self, scope_id: &[u8], epoch: u64) -> SeamResult<u64> {
+        self.raise_floor(
+            &self.epoch_dir,
+            scope_id,
+            epoch,
+            "floor_store raise_epoch_floor",
+        )
+    }
+
+    async fn sequence_floor(&self, ipns_name: &[u8]) -> SeamResult<Option<u64>> {
+        self.read_floor(&self.seq_dir, ipns_name, "floor_store sequence_floor")
+    }
+
+    async fn raise_sequence_floor(&self, ipns_name: &[u8], sequence: u64) -> SeamResult<u64> {
+        self.raise_floor(
+            &self.seq_dir,
+            ipns_name,
+            sequence,
+            "floor_store raise_sequence_floor",
+        )
+    }
+}

--- a/crates/desktop-seams/src/fs_util.rs
+++ b/crates/desktop-seams/src/fs_util.rs
@@ -1,0 +1,225 @@
+//! Fsync-barrier file primitives shared by the durable desktop stores.
+//!
+//! The v1 high-water-store / write-journal durability discipline
+//! (blueprint/desktop.md): a value is durable only after its bytes hit the
+//! platter (`sync_all`) **and** the directory entry that names them is
+//! itself fsynced. [`atomic_write`] and [`remove_file_durable`] are the two
+//! barriers every store builds on.
+
+use std::fs::{self, File};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use cipherbox_engine::seams::SeamError;
+
+/// Process-unique suffix source for in-flight temp files, so two atomic
+/// writes never collide on a temp name even across different keys.
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Prefix marking a store's in-flight temp file. Enumeration skips these,
+/// and [`ensure_dir`] sweeps any left behind by a crash mid-write.
+const TEMP_PREFIX: &str = ".cbtmp.";
+
+/// Wraps an I/O error as an opaque [`SeamError`] with an operation label.
+///
+/// Deliberately carries only the operation and the OS error — never a value
+/// or a token (security rule 2). Store keys are engine-chosen identifiers,
+/// not secrets, but they are still left out to keep messages minimal.
+pub(crate) fn seam_err(op: &str, err: &io::Error) -> SeamError {
+    SeamError::new(format!("{op}: {err}"))
+}
+
+/// Ensures a directory exists and sweeps any stale temp files from a
+/// previous crashed write. Idempotent.
+pub(crate) fn ensure_dir(dir: &Path) -> io::Result<()> {
+    fs::create_dir_all(dir)?;
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        if entry.file_name().to_string_lossy().starts_with(TEMP_PREFIX) {
+            // Best-effort: a racing writer is impossible (single-writer
+            // engine), so a lingering temp is always crash debris.
+            let _ = fs::remove_file(entry.path());
+        }
+    }
+    fsync_dir(dir)
+}
+
+/// Durably writes `bytes` to `path`, replacing any existing file atomically.
+///
+/// Barrier order: write a fresh temp file in the same directory, `sync_all`
+/// its contents, `rename` it over the target (atomic replace on Unix and on
+/// Windows — Rust's `fs::rename` maps to `MoveFileExW` with
+/// `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH`), then fsync the
+/// directory so the rename itself is durable. A crash can only ever leave
+/// the old value or the new value — never a torn one.
+pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let dir = path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no parent"))?;
+    let tmp = temp_path(dir);
+    // Scope the handle so it is closed before the rename.
+    {
+        let mut file = File::create(&tmp)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+    }
+    match fs::rename(&tmp, path) {
+        Ok(()) => {}
+        Err(err) => {
+            let _ = fs::remove_file(&tmp);
+            return Err(err);
+        }
+    }
+    fsync_dir(dir)
+}
+
+/// Durably removes a file. Idempotent: a missing file is success. The
+/// removal is barriered with a directory fsync so an ordered caller (e.g.
+/// the StagingStore's op-before-sidecar removal) can rely on it having hit
+/// the platter before the next removal begins.
+pub(crate) fn remove_file_durable(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err),
+    }
+    if let Some(dir) = path.parent() {
+        fsync_dir(dir)?;
+    }
+    Ok(())
+}
+
+/// Reads a file whole, mapping a missing file to `None`.
+pub(crate) fn read_file_opt(path: &Path) -> io::Result<Option<Vec<u8>>> {
+    match File::open(path) {
+        Ok(mut file) => {
+            let mut buf = Vec::new();
+            file.read_to_end(&mut buf)?;
+            Ok(Some(buf))
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+/// The names of the non-temp files directly in `dir` (no recursion). Temp
+/// files and subdirectories are skipped.
+pub(crate) fn list_file_names(dir: &Path) -> io::Result<Vec<String>> {
+    let mut names = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.starts_with(TEMP_PREFIX) {
+            continue;
+        }
+        names.push(name);
+    }
+    Ok(names)
+}
+
+/// Fsyncs a directory so a create/rename/unlink inside it is durable.
+///
+/// Unix opens the directory and `sync_all`s it. Windows has no directory
+/// fsync; `fs::rename`'s `MOVEFILE_WRITE_THROUGH` and NTFS metadata
+/// journaling cover the same guarantee, so this is a no-op there.
+#[cfg(unix)]
+fn fsync_dir(dir: &Path) -> io::Result<()> {
+    File::open(dir)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn fsync_dir(_dir: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+/// A process-unique temp path inside `dir`.
+fn temp_path(dir: &Path) -> PathBuf {
+    let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    dir.join(format!("{TEMP_PREFIX}{}.{seq}", std::process::id()))
+}
+
+/// Lowercase hex encoding of opaque key bytes for use as a filename.
+pub(crate) fn to_hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(DIGITS[(byte >> 4) as usize] as char);
+        out.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Decodes a lowercase-hex filename back to the original key bytes; `None`
+/// if the string is not valid hex (so enumeration can skip foreign files).
+pub(crate) fn from_hex(text: &str) -> Option<Vec<u8>> {
+    if !text.len().is_multiple_of(2) {
+        return None;
+    }
+    let bytes = text.as_bytes();
+    let mut out = Vec::with_capacity(text.len() / 2);
+    let mut i = 0;
+    while i < bytes.len() {
+        let hi = (bytes[i] as char).to_digit(16)?;
+        let lo = (bytes[i + 1] as char).to_digit(16)?;
+        out.push(((hi << 4) | lo) as u8);
+        i += 2;
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_round_trips_arbitrary_bytes() {
+        let bytes = [0x00u8, 0xff, 0x9f, 0x92, 0x10, 0xab];
+        assert_eq!(from_hex(&to_hex(&bytes)), Some(bytes.to_vec()));
+        assert_eq!(to_hex(&[]), "");
+        assert_eq!(from_hex(""), Some(Vec::new()));
+    }
+
+    #[test]
+    fn from_hex_rejects_non_hex() {
+        assert_eq!(from_hex("zz"), None);
+        assert_eq!(from_hex("abc"), None); // odd length
+    }
+
+    #[test]
+    fn atomic_write_replaces_and_reads_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("value");
+        atomic_write(&path, b"first").unwrap();
+        assert_eq!(read_file_opt(&path).unwrap(), Some(b"first".to_vec()));
+        atomic_write(&path, b"second").unwrap();
+        assert_eq!(read_file_opt(&path).unwrap(), Some(b"second".to_vec()));
+        // No temp debris survives a successful write.
+        assert_eq!(
+            list_file_names(dir.path()).unwrap(),
+            vec!["value".to_string()]
+        );
+    }
+
+    #[test]
+    fn remove_file_durable_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("value");
+        atomic_write(&path, b"x").unwrap();
+        remove_file_durable(&path).unwrap();
+        remove_file_durable(&path).unwrap();
+        assert_eq!(read_file_opt(&path).unwrap(), None);
+    }
+
+    #[test]
+    fn ensure_dir_sweeps_temp_debris() {
+        let dir = tempfile::tempdir().unwrap();
+        let debris = dir.path().join(format!("{TEMP_PREFIX}stale"));
+        std::fs::write(&debris, b"crash").unwrap();
+        ensure_dir(dir.path()).unwrap();
+        assert!(!debris.exists(), "a crashed temp file must be swept");
+    }
+}

--- a/crates/desktop-seams/src/http.rs
+++ b/crates/desktop-seams/src/http.rs
@@ -1,5 +1,7 @@
 //! Desktop [`Http`]: a `reqwest` byte mover.
 
+use core::time::Duration;
+
 use cipherbox_engine::seams::{Http, HttpMethod, HttpRequest, HttpResponse, SeamError, SeamResult};
 
 /// Plain HTTP for the hand-written API client, the trustless gateway read
@@ -18,8 +20,16 @@ pub struct ReqwestHttp {
 
 impl ReqwestHttp {
     /// Builds an HTTP seam over a fresh `reqwest` client.
+    ///
+    /// A connect timeout bounds the handshake, so a dead or black-hole host
+    /// fails fast instead of hanging the engine task forever. No total
+    /// request timeout is imposed here: the Http seam also carries
+    /// content-chunk bodies that can legitimately be large and slow, so a
+    /// host that needs a bounded whole-request timeout supplies its own
+    /// client via [`with_client`](Self::with_client).
     pub fn new() -> SeamResult<Self> {
         let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
             .build()
             .map_err(|err| SeamError::new(format!("http client build: {err}")))?;
         Ok(Self { client })

--- a/crates/desktop-seams/src/http.rs
+++ b/crates/desktop-seams/src/http.rs
@@ -1,0 +1,88 @@
+//! Desktop [`Http`]: a `reqwest` byte mover.
+
+use cipherbox_engine::seams::{Http, HttpMethod, HttpRequest, HttpResponse, SeamError, SeamResult};
+
+/// Plain HTTP for the hand-written API client, the trustless gateway read
+/// path, and BYO providers (blueprint/engine.md "Http", desktop column).
+///
+/// A pure byte mover over `reqwest` with rustls: it sends exactly the
+/// request the engine describes — no headers the engine did not ask for —
+/// and returns the response verbatim. Non-2xx statuses are responses, not
+/// errors; a seam `Err` is reserved for transport-level failure (unreachable,
+/// aborted). The rotating refresh token is injected by the engine as an
+/// `Authorization`/cookie header here; this seam never persists it.
+#[derive(Debug, Clone)]
+pub struct ReqwestHttp {
+    client: reqwest::Client,
+}
+
+impl ReqwestHttp {
+    /// Builds an HTTP seam over a fresh `reqwest` client.
+    pub fn new() -> SeamResult<Self> {
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|err| SeamError::new(format!("http client build: {err}")))?;
+        Ok(Self { client })
+    }
+
+    /// Builds an HTTP seam over a caller-supplied `reqwest` client (shared
+    /// connection pool, custom timeouts).
+    pub fn with_client(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+}
+
+impl Http for ReqwestHttp {
+    async fn send(&self, request: HttpRequest) -> SeamResult<HttpResponse> {
+        let mut builder = self
+            .client
+            .request(map_method(request.method), &request.url);
+        for (name, value) in &request.headers {
+            builder = builder.header(name, value);
+        }
+        if let Some(body) = request.body {
+            builder = builder.body(body);
+        }
+
+        let response = builder
+            .send()
+            .await
+            .map_err(|err| SeamError::new(format!("http send: {err}")))?;
+
+        let status = response.status().as_u16();
+        let headers = response
+            .headers()
+            .iter()
+            .map(|(name, value)| {
+                (
+                    name.as_str().to_owned(),
+                    // Header values can be non-UTF-8; keep them lossless-ish
+                    // without failing the whole response on an odd byte.
+                    String::from_utf8_lossy(value.as_bytes()).into_owned(),
+                )
+            })
+            .collect();
+        let body = response
+            .bytes()
+            .await
+            .map_err(|err| SeamError::new(format!("http body: {err}")))?
+            .to_vec();
+
+        Ok(HttpResponse {
+            status,
+            headers,
+            body,
+        })
+    }
+}
+
+fn map_method(method: HttpMethod) -> reqwest::Method {
+    match method {
+        HttpMethod::Get => reqwest::Method::GET,
+        HttpMethod::Post => reqwest::Method::POST,
+        HttpMethod::Put => reqwest::Method::PUT,
+        HttpMethod::Patch => reqwest::Method::PATCH,
+        HttpMethod::Delete => reqwest::Method::DELETE,
+        HttpMethod::Head => reqwest::Method::HEAD,
+    }
+}

--- a/crates/desktop-seams/src/lib.rs
+++ b/crates/desktop-seams/src/lib.rs
@@ -1,0 +1,56 @@
+//! CipherBox desktop seam set: the concrete host-seam implementations the
+//! desktop native host injects into the engine constructor
+//! (blueprint/engine.md "Host seams", desktop column; blueprint/desktop.md
+//! "Engine wiring").
+//!
+//! Every durable store here writes **ciphertext-only at rest** under
+//! `<data_local_dir>/cipherbox/<accountId>/` — the same law as web's
+//! IndexedDB stores; a stolen disk yields sealed bytes only. Plaintext and
+//! key material never touch these stores: [`FileSnapshotCache`] holds sealed
+//! record/metadata bytes the engine unseals on read, and
+//! [`KeyringCredentialStore`] keeps only the rotating refresh token and the
+//! last-account id in the OS keyring — never a seed or an unwrapped key.
+//!
+//! The nine seams split by concern:
+//!
+//! - [`FileFloorStore`], [`FileStagingStore`], [`FileSnapshotCache`] —
+//!   fsync-barriered files (the v1 high-water / write-journal discipline
+//!   generalized).
+//! - [`KeyringCredentialStore`] — the OS keyring.
+//! - [`ReqwestHttp`], [`ReqwestRecordTransport`] — `reqwest` over rustls.
+//! - [`TokioScheduler`] — timers, background tasks, wall clock on Tokio.
+//!
+//! `Mailbox` and `RefreshHintSource` are not implemented here: the mailbox
+//! is the engine's own API client over the [`ReqwestHttp`] seam (nothing
+//! desktop-specific), and refresh hints are produced by the `crates/fuse`
+//! operation core from FUSE-op TTL checks. This crate constructs no engine
+//! and touches no webview — the desktop shell wires those in a later slice.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+// The seam traits use native `async fn` (blueprint: single-writer engine
+// pinned to one execution context, `!Send` futures). Implementing them is
+// unremarkable; this mirrors the engine crate's own allowance.
+#![allow(async_fn_in_trait)]
+
+mod credential_store;
+mod floor_store;
+mod fs_util;
+mod http;
+mod paths;
+mod record_transport;
+mod scheduler;
+mod snapshot_cache;
+mod staging_store;
+
+pub use credential_store::KeyringCredentialStore;
+pub use floor_store::FileFloorStore;
+pub use http::ReqwestHttp;
+pub use paths::account_data_dir;
+pub use record_transport::ReqwestRecordTransport;
+pub use scheduler::TokioScheduler;
+pub use snapshot_cache::FileSnapshotCache;
+pub use staging_store::FileStagingStore;
+
+#[cfg(feature = "test-support")]
+pub use credential_store::FileCredentialStore;

--- a/crates/desktop-seams/src/paths.rs
+++ b/crates/desktop-seams/src/paths.rs
@@ -1,0 +1,24 @@
+//! The on-disk home of every desktop engine store.
+
+use std::path::{Path, PathBuf};
+
+/// The per-account engine data directory: `<data_local_dir>/cipherbox/<accountId>/`
+/// (blueprint/desktop.md "Engine wiring").
+///
+/// All desktop seam stores live under this root, ciphertext-only at rest.
+/// The host supplies `data_local_dir` (Tauri's `data_local_dir()`); this
+/// crate never resolves it, so it stays testable against a tempdir.
+pub fn account_data_dir(data_local_dir: &Path, account_id: &str) -> PathBuf {
+    data_local_dir.join("cipherbox").join(account_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn composes_the_cipherbox_account_root() {
+        let dir = account_data_dir(Path::new("/var/lib"), "acct-42");
+        assert_eq!(dir, PathBuf::from("/var/lib/cipherbox/acct-42"));
+    }
+}

--- a/crates/desktop-seams/src/paths.rs
+++ b/crates/desktop-seams/src/paths.rs
@@ -1,6 +1,8 @@
 //! The on-disk home of every desktop engine store.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
+
+use cipherbox_engine::seams::{SeamError, SeamResult};
 
 /// The per-account engine data directory: `<data_local_dir>/cipherbox/<accountId>/`
 /// (blueprint/desktop.md "Engine wiring").
@@ -8,8 +10,33 @@ use std::path::{Path, PathBuf};
 /// All desktop seam stores live under this root, ciphertext-only at rest.
 /// The host supplies `data_local_dir` (Tauri's `data_local_dir()`); this
 /// crate never resolves it, so it stays testable against a tempdir.
-pub fn account_data_dir(data_local_dir: &Path, account_id: &str) -> PathBuf {
-    data_local_dir.join("cipherbox").join(account_id)
+///
+/// `account_id` is joined onto the storage root verbatim, so it must be a
+/// single normal path component: a value carrying a separator, a `..`, or an
+/// absolute/prefixed path would escape `<data_local_dir>/cipherbox/`. Such an
+/// id is an identity-layer bug, rejected here fail-closed rather than silently
+/// sanitized (sanitizing could collide two distinct ids onto one dir).
+pub fn account_data_dir(data_local_dir: &Path, account_id: &str) -> SeamResult<PathBuf> {
+    if !is_single_normal_component(account_id) {
+        return Err(SeamError::new(
+            "account_data_dir: account_id must be a single path component",
+        ));
+    }
+    Ok(data_local_dir.join("cipherbox").join(account_id))
+}
+
+/// True only when `account_id` is exactly one `Normal` path component with no
+/// embedded separator on any platform — so `..`, `.`, `/tmp`, `a/b`, `C:\tmp`,
+/// and the empty string are all rejected.
+fn is_single_normal_component(account_id: &str) -> bool {
+    if account_id.is_empty() || account_id.contains(['/', '\\']) {
+        return false;
+    }
+    let mut components = Path::new(account_id).components();
+    matches!(
+        (components.next(), components.next()),
+        (Some(Component::Normal(_)), None)
+    )
 }
 
 #[cfg(test)]
@@ -18,7 +45,18 @@ mod tests {
 
     #[test]
     fn composes_the_cipherbox_account_root() {
-        let dir = account_data_dir(Path::new("/var/lib"), "acct-42");
+        let dir = account_data_dir(Path::new("/var/lib"), "acct-42").unwrap();
         assert_eq!(dir, PathBuf::from("/var/lib/cipherbox/acct-42"));
+    }
+
+    #[test]
+    fn rejects_ids_that_would_escape_the_root() {
+        let base = Path::new("/var/lib");
+        for bad in ["", "..", ".", "../other", "/tmp", "a/b", "C:\\tmp", "a\\b"] {
+            assert!(
+                account_data_dir(base, bad).is_err(),
+                "account_id {bad:?} must be rejected"
+            );
+        }
     }
 }

--- a/crates/desktop-seams/src/record_transport.rs
+++ b/crates/desktop-seams/src/record_transport.rs
@@ -1,0 +1,127 @@
+//! Desktop [`RecordTransport`]: a `reqwest` `/routing/v1` byte mover.
+
+use cipherbox_engine::seams::{EndpointId, RecordTransport, SeamError, SeamResult};
+
+/// IPFS delegated-routing content type for a signed IPNS record.
+const IPNS_RECORD_CONTENT_TYPE: &str = "application/vnd.ipfs.ipns-record";
+
+/// Dumb `/routing/v1` byte mover over `reqwest` (blueprint/engine.md
+/// "RecordTransport", desktop column).
+///
+/// GET/PUT of opaque signed record bytes against a configured endpoint set;
+/// it moves bytes and nothing else — the engine owns IPNS end-to-end (core
+/// signs and verifies, fan-out, CAS, and every trust decision live above
+/// this seam). Each [`EndpointId`] is the endpoint's base URL; a record for
+/// `routing_key` is addressed at `<base>/routing/v1/ipns/<routing_key>`. An
+/// absent record GETs as `None` (HTTP 404), never an error.
+#[derive(Debug, Clone)]
+pub struct ReqwestRecordTransport {
+    client: reqwest::Client,
+    endpoints: Vec<EndpointId>,
+}
+
+impl ReqwestRecordTransport {
+    /// Builds a transport over the given `/routing/v1` base URLs (CipherBox
+    /// someguy plus at least one independent public endpoint, #23 D1). The
+    /// [`EndpointId`] of each endpoint is its base URL.
+    ///
+    /// # Panics
+    /// Panics if `base_urls` is empty — the endpoint set must never be empty
+    /// (the seam contract), and an empty set is a host misconfiguration, not
+    /// a runtime condition.
+    pub fn new(base_urls: impl IntoIterator<Item = String>) -> SeamResult<Self> {
+        let endpoints: Vec<EndpointId> = base_urls.into_iter().map(EndpointId::new).collect();
+        assert!(
+            !endpoints.is_empty(),
+            "RecordTransport endpoint set must not be empty"
+        );
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|err| SeamError::new(format!("record_transport client build: {err}")))?;
+        Ok(Self { client, endpoints })
+    }
+
+    /// Builds a transport over a caller-supplied `reqwest` client.
+    ///
+    /// # Panics
+    /// Panics if `base_urls` is empty (see [`ReqwestRecordTransport::new`]).
+    pub fn with_client(
+        client: reqwest::Client,
+        base_urls: impl IntoIterator<Item = String>,
+    ) -> Self {
+        let endpoints: Vec<EndpointId> = base_urls.into_iter().map(EndpointId::new).collect();
+        assert!(
+            !endpoints.is_empty(),
+            "RecordTransport endpoint set must not be empty"
+        );
+        Self { client, endpoints }
+    }
+
+    fn record_url(endpoint: &EndpointId, routing_key: &str) -> String {
+        format!(
+            "{}/routing/v1/ipns/{routing_key}",
+            endpoint.0.trim_end_matches('/')
+        )
+    }
+}
+
+impl RecordTransport for ReqwestRecordTransport {
+    fn endpoints(&self) -> Vec<EndpointId> {
+        self.endpoints.clone()
+    }
+
+    async fn get_record(
+        &self,
+        endpoint: &EndpointId,
+        routing_key: &str,
+    ) -> SeamResult<Option<Vec<u8>>> {
+        let response = self
+            .client
+            .get(Self::record_url(endpoint, routing_key))
+            .header(reqwest::header::ACCEPT, IPNS_RECORD_CONTENT_TYPE)
+            .send()
+            .await
+            .map_err(|err| SeamError::new(format!("record_transport get: {err}")))?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !status.is_success() {
+            return Err(SeamError::new(format!(
+                "record_transport get: status {}",
+                status.as_u16()
+            )));
+        }
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|err| SeamError::new(format!("record_transport get body: {err}")))?;
+        Ok(Some(bytes.to_vec()))
+    }
+
+    async fn put_record(
+        &self,
+        endpoint: &EndpointId,
+        routing_key: &str,
+        record: &[u8],
+    ) -> SeamResult<()> {
+        let response = self
+            .client
+            .put(Self::record_url(endpoint, routing_key))
+            .header(reqwest::header::CONTENT_TYPE, IPNS_RECORD_CONTENT_TYPE)
+            .body(record.to_vec())
+            .send()
+            .await
+            .map_err(|err| SeamError::new(format!("record_transport put: {err}")))?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(SeamError::new(format!(
+                "record_transport put: status {}",
+                response.status().as_u16()
+            )))
+        }
+    }
+}

--- a/crates/desktop-seams/src/record_transport.rs
+++ b/crates/desktop-seams/src/record_transport.rs
@@ -1,5 +1,7 @@
 //! Desktop [`RecordTransport`]: a `reqwest` `/routing/v1` byte mover.
 
+use core::time::Duration;
+
 use cipherbox_engine::seams::{EndpointId, RecordTransport, SeamError, SeamResult};
 
 /// IPFS delegated-routing content type for a signed IPNS record.
@@ -35,7 +37,15 @@ impl ReqwestRecordTransport {
             !endpoints.is_empty(),
             "RecordTransport endpoint set must not be empty"
         );
+        // `/routing/v1` records are small and directly addressed: bound both
+        // the handshake and the whole request so a stalled public endpoint
+        // cannot hang fan-out, and follow no redirects — direct addressing
+        // needs none, and refusing them closes an SSRF-shaped vector from an
+        // untrusted public endpoint. `with_client` callers own their policy.
         let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .map_err(|err| SeamError::new(format!("record_transport client build: {err}")))?;
         Ok(Self { client, endpoints })

--- a/crates/desktop-seams/src/scheduler.rs
+++ b/crates/desktop-seams/src/scheduler.rs
@@ -1,0 +1,51 @@
+//! Desktop [`Scheduler`]: timers, background tasks, and the wall clock on
+//! Tokio.
+
+use core::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use cipherbox_engine::seams::{BoxedTask, Scheduler, UnixMillis};
+
+/// Jittered timers, background task execution, and the wall clock, backed by
+/// Tokio (blueprint/engine.md "Scheduler", desktop column).
+///
+/// The only source of time in the engine on desktop: [`now`](Self::now)
+/// reads the system wall clock, [`sleep`](Self::sleep) delegates to
+/// `tokio::time::sleep`. Jitter is the engine's business (computed from
+/// injected entropy); this seam sleeps exactly the duration asked.
+///
+/// Because [`BoxedTask`] is deliberately `!Send` (the single-writer engine
+/// is pinned to one execution context), [`spawn`](Self::spawn) uses
+/// `tokio::task::spawn_local` and therefore must run inside a Tokio
+/// `LocalSet` on a current-thread runtime — exactly the shape the desktop
+/// host runs the engine in.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TokioScheduler;
+
+impl TokioScheduler {
+    /// A new scheduler handle. Cheap and copyable; carries no state.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Scheduler for TokioScheduler {
+    fn now(&self) -> UnixMillis {
+        let millis = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_millis())
+            .unwrap_or(0);
+        UnixMillis(u64::try_from(millis).unwrap_or(u64::MAX))
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        tokio::time::sleep(duration).await;
+    }
+
+    fn spawn(&self, task: BoxedTask) {
+        // Fire-and-forget: dropping the JoinHandle detaches the task, which
+        // keeps running (the seam contract observes completion only through
+        // the task's own effects).
+        tokio::task::spawn_local(task);
+    }
+}

--- a/crates/desktop-seams/src/snapshot_cache.rs
+++ b/crates/desktop-seams/src/snapshot_cache.rs
@@ -1,0 +1,63 @@
+//! Desktop [`SnapshotCache`]: sealed record/metadata cache files.
+
+use std::path::{Path, PathBuf};
+
+use cipherbox_engine::seams::{SeamResult, SnapshotCache};
+
+use crate::fs_util::{
+    atomic_write, ensure_dir, list_file_names, read_file_opt, remove_file_durable, seam_err, to_hex,
+};
+
+/// Durable last-known-good cache backed by one sealed file per key
+/// (blueprint/engine.md "SnapshotCache"; blueprint/desktop.md "Sealed
+/// record/metadata cache files").
+///
+/// **Ciphertext-only at rest**: the engine hands this store already-sealed
+/// bytes and unseals them on read, so a file is opaque by construction — it
+/// round-trips arbitrary bytes verbatim, requiring no parseable structure.
+/// Keys are opaque engine bytes hex-encoded into filenames. Entries survive
+/// reopen (cache-first rendering after restart); [`clear`](Self::clear)
+/// ("forget this device") empties the backing durably.
+pub struct FileSnapshotCache {
+    dir: PathBuf,
+}
+
+impl FileSnapshotCache {
+    /// Opens (creating if absent) a snapshot cache rooted at `dir`.
+    pub fn open(dir: impl AsRef<Path>) -> SeamResult<Self> {
+        let dir = dir.as_ref().to_path_buf();
+        ensure_dir(&dir).map_err(|err| seam_err("snapshot_cache open", &err))?;
+        Ok(Self { dir })
+    }
+
+    fn entry_path(&self, key: &[u8]) -> PathBuf {
+        self.dir.join(to_hex(key))
+    }
+}
+
+impl SnapshotCache for FileSnapshotCache {
+    async fn put(&self, cache_key: &[u8], ciphertext: &[u8]) -> SeamResult<()> {
+        atomic_write(&self.entry_path(cache_key), ciphertext)
+            .map_err(|err| seam_err("snapshot_cache put", &err))
+    }
+
+    async fn get(&self, cache_key: &[u8]) -> SeamResult<Option<Vec<u8>>> {
+        read_file_opt(&self.entry_path(cache_key))
+            .map_err(|err| seam_err("snapshot_cache get", &err))
+    }
+
+    async fn remove(&self, cache_key: &[u8]) -> SeamResult<()> {
+        remove_file_durable(&self.entry_path(cache_key))
+            .map_err(|err| seam_err("snapshot_cache remove", &err))
+    }
+
+    async fn clear(&self) -> SeamResult<()> {
+        let names = list_file_names(&self.dir)
+            .map_err(|err| seam_err("snapshot_cache clear list", &err))?;
+        for name in names {
+            remove_file_durable(&self.dir.join(name))
+                .map_err(|err| seam_err("snapshot_cache clear", &err))?;
+        }
+        Ok(())
+    }
+}

--- a/crates/desktop-seams/src/staging_store.rs
+++ b/crates/desktop-seams/src/staging_store.rs
@@ -172,12 +172,26 @@ impl StagingStore for FileStagingStore {
             .map_err(|err| seam_err("staging_store staged_bytes_total", &err))?;
         let mut total = 0u64;
         for name in names {
-            if !name.ends_with(SIDECAR_SUFFIX) {
+            // Mirror `staged_keys`: only count sidecars whose stem is valid
+            // hex, so the budget total and the GC-reclaimable set (staged_keys
+            // + remove_staged_bytes) always agree on the same file set. A
+            // foreign `.bin` counted here but invisible to staged_keys could
+            // never be reclaimed and would inflate the budget permanently.
+            let is_sidecar = name
+                .strip_suffix(SIDECAR_SUFFIX)
+                .is_some_and(|stem| from_hex(stem).is_some());
+            if !is_sidecar {
                 continue;
             }
-            let meta = std::fs::metadata(self.staged_dir.join(&name))
-                .map_err(|err| seam_err("staging_store staged_bytes_total meta", &err))?;
-            total = total.saturating_add(meta.len());
+            match std::fs::metadata(self.staged_dir.join(&name)) {
+                Ok(meta) => total = total.saturating_add(meta.len()),
+                // A sidecar removed between listing and stat contributes zero,
+                // mirroring read_file_opt's NotFound handling.
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    return Err(seam_err("staging_store staged_bytes_total meta", &err));
+                }
+            }
         }
         Ok(total)
     }

--- a/crates/desktop-seams/src/staging_store.rs
+++ b/crates/desktop-seams/src/staging_store.rs
@@ -1,0 +1,194 @@
+//! Desktop [`StagingStore`]: the v1 write journal generalized to every op.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use cipherbox_engine::seams::{OpId, SeamResult, StagingStore};
+
+use crate::fs_util::{
+    atomic_write, ensure_dir, from_hex, list_file_names, read_file_opt, remove_file_durable,
+    seam_err, to_hex,
+};
+
+/// Suffix for op-record files (`ops/<id>.op`). The "json record" of the v1
+/// journal, generalized: it holds the engine's opaque encoded intent op
+/// verbatim — the store never parses it.
+const OP_SUFFIX: &str = ".op";
+/// Suffix for staged-ciphertext sidecar files (`staged/<hexkey>.bin`).
+const SIDECAR_SUFFIX: &str = ".bin";
+/// Filename of the durable monotonic op-id counter.
+const COUNTER_FILE: &str = "next_op_id";
+
+/// Durable op queue plus staged upload bytes, backed by the fsync-barriered
+/// write journal (blueprint/engine.md "StagingStore"; blueprint/desktop.md
+/// "the v1 write journal generalized").
+///
+/// Layout under the store root:
+///
+/// - `ops/<20-digit-id>.op` — one durable record per queued op, id in the
+///   filename; enqueue order is id order (FIFO). Each op is opaque engine
+///   bytes stored verbatim.
+/// - `staged/<hexkey>.bin` — one sidecar per staged-ciphertext key.
+/// - `next_op_id` — the monotonic id counter, so ids are strictly
+///   increasing and never reused, even after every op drains and the store
+///   reopens.
+///
+/// **Removal ordering is a correctness property** (hard constraint 5): every
+/// mutating method fsyncs before returning, so when the engine completes an
+/// op by removing the op record *before* its sidecar, that ordering actually
+/// reaches the platter in order. A crash can then only ever leave an orphan
+/// sidecar (harmless, reclaimed by orphan-sidecar GC via [`staged_keys`] +
+/// [`remove_staged_bytes`]) — never an op record pointing at a sidecar that
+/// is already gone.
+pub struct FileStagingStore {
+    ops_dir: PathBuf,
+    staged_dir: PathBuf,
+    counter_path: PathBuf,
+    /// Next op id to hand out; persisted to `next_op_id` on each allocation.
+    next_op_id: Mutex<u64>,
+}
+
+impl FileStagingStore {
+    /// Opens (creating if absent) a staging store rooted at `dir`. Reopening
+    /// the same `dir` recovers the queue, staged bytes, and id progression.
+    pub fn open(dir: impl AsRef<Path>) -> SeamResult<Self> {
+        let dir = dir.as_ref();
+        let ops_dir = dir.join("ops");
+        let staged_dir = dir.join("staged");
+        ensure_dir(&ops_dir).map_err(|err| seam_err("staging_store open ops", &err))?;
+        ensure_dir(&staged_dir).map_err(|err| seam_err("staging_store open staged", &err))?;
+        let counter_path = dir.join(COUNTER_FILE);
+
+        // Recover the id watermark from both the persisted counter and the
+        // highest surviving op file, then take the larger — so a crash
+        // between bumping the counter and writing the op file (or vice
+        // versa) still never reuses an id.
+        let persisted = read_file_opt(&counter_path)
+            .map_err(|err| seam_err("staging_store open counter", &err))?
+            .and_then(|bytes| <[u8; 8]>::try_from(bytes.as_slice()).ok())
+            .map(u64::from_le_bytes)
+            .unwrap_or(0);
+        let highest_op = highest_op_id(&ops_dir)
+            .map_err(|err| seam_err("staging_store open scan", &err))?
+            .map_or(0, |id| id.saturating_add(1));
+        let next = persisted.max(highest_op).max(1);
+
+        Ok(Self {
+            ops_dir,
+            staged_dir,
+            counter_path,
+            next_op_id: Mutex::new(next),
+        })
+    }
+
+    fn op_path(&self, id: u64) -> PathBuf {
+        self.ops_dir.join(format!("{id:020}{OP_SUFFIX}"))
+    }
+
+    fn sidecar_path(&self, key: &[u8]) -> PathBuf {
+        self.staged_dir
+            .join(format!("{}{SIDECAR_SUFFIX}", to_hex(key)))
+    }
+}
+
+impl StagingStore for FileStagingStore {
+    async fn enqueue_op(&self, op: &[u8]) -> SeamResult<OpId> {
+        // Reserve an id and durably advance the counter *before* writing the
+        // op file: a crash after the counter bump merely burns an id (ids
+        // need only be strictly increasing, not contiguous), never reuses
+        // one.
+        let id = {
+            let mut next = self.next_op_id.lock().expect("lock");
+            let id = *next;
+            let advanced = id + 1;
+            atomic_write(&self.counter_path, &advanced.to_le_bytes())
+                .map_err(|err| seam_err("staging_store enqueue_op counter", &err))?;
+            *next = advanced;
+            id
+        };
+        atomic_write(&self.op_path(id), op)
+            .map_err(|err| seam_err("staging_store enqueue_op", &err))?;
+        Ok(OpId(id))
+    }
+
+    async fn queued_ops(&self) -> SeamResult<Vec<(OpId, Vec<u8>)>> {
+        let names = list_file_names(&self.ops_dir)
+            .map_err(|err| seam_err("staging_store queued_ops", &err))?;
+        let mut ops = Vec::new();
+        for name in names {
+            let Some(id) = parse_op_id(&name) else {
+                continue;
+            };
+            if let Some(bytes) = read_file_opt(&self.op_path(id))
+                .map_err(|err| seam_err("staging_store queued_ops read", &err))?
+            {
+                ops.push((OpId(id), bytes));
+            }
+        }
+        ops.sort_by_key(|(id, _)| *id);
+        Ok(ops)
+    }
+
+    async fn remove_op(&self, op_id: OpId) -> SeamResult<()> {
+        remove_file_durable(&self.op_path(op_id.0))
+            .map_err(|err| seam_err("staging_store remove_op", &err))
+    }
+
+    async fn put_staged_bytes(&self, staging_key: &[u8], bytes: &[u8]) -> SeamResult<()> {
+        atomic_write(&self.sidecar_path(staging_key), bytes)
+            .map_err(|err| seam_err("staging_store put_staged_bytes", &err))
+    }
+
+    async fn staged_bytes(&self, staging_key: &[u8]) -> SeamResult<Option<Vec<u8>>> {
+        read_file_opt(&self.sidecar_path(staging_key))
+            .map_err(|err| seam_err("staging_store staged_bytes", &err))
+    }
+
+    async fn remove_staged_bytes(&self, staging_key: &[u8]) -> SeamResult<()> {
+        remove_file_durable(&self.sidecar_path(staging_key))
+            .map_err(|err| seam_err("staging_store remove_staged_bytes", &err))
+    }
+
+    async fn staged_keys(&self) -> SeamResult<Vec<Vec<u8>>> {
+        let names = list_file_names(&self.staged_dir)
+            .map_err(|err| seam_err("staging_store staged_keys", &err))?;
+        let mut keys = Vec::new();
+        for name in names {
+            if let Some(stem) = name.strip_suffix(SIDECAR_SUFFIX) {
+                if let Some(key) = from_hex(stem) {
+                    keys.push(key);
+                }
+            }
+        }
+        Ok(keys)
+    }
+
+    async fn staged_bytes_total(&self) -> SeamResult<u64> {
+        let names = list_file_names(&self.staged_dir)
+            .map_err(|err| seam_err("staging_store staged_bytes_total", &err))?;
+        let mut total = 0u64;
+        for name in names {
+            if !name.ends_with(SIDECAR_SUFFIX) {
+                continue;
+            }
+            let meta = std::fs::metadata(self.staged_dir.join(&name))
+                .map_err(|err| seam_err("staging_store staged_bytes_total meta", &err))?;
+            total = total.saturating_add(meta.len());
+        }
+        Ok(total)
+    }
+}
+
+/// Parses the op id out of an `ops/` filename, or `None` for anything that
+/// is not an op record (temp debris, foreign files).
+fn parse_op_id(name: &str) -> Option<u64> {
+    name.strip_suffix(OP_SUFFIX)?.parse::<u64>().ok()
+}
+
+/// The largest op id currently on disk in `ops_dir`, if any.
+fn highest_op_id(ops_dir: &Path) -> std::io::Result<Option<u64>> {
+    Ok(list_file_names(ops_dir)?
+        .iter()
+        .filter_map(|name| parse_op_id(name))
+        .max())
+}

--- a/crates/desktop-seams/src/staging_store.rs
+++ b/crates/desktop-seams/src/staging_store.rs
@@ -55,6 +55,10 @@ impl FileStagingStore {
         let dir = dir.as_ref();
         let ops_dir = dir.join("ops");
         let staged_dir = dir.join("staged");
+        // Sweep the root too: the `next_op_id` counter is atomic-written
+        // directly under `dir`, so a crash mid-counter-write can strand a
+        // temp file here — reclaim it on reopen like the ops/staged debris.
+        ensure_dir(dir).map_err(|err| seam_err("staging_store open root", &err))?;
         ensure_dir(&ops_dir).map_err(|err| seam_err("staging_store open ops", &err))?;
         ensure_dir(&staged_dir).map_err(|err| seam_err("staging_store open staged", &err))?;
         let counter_path = dir.join(COUNTER_FILE);

--- a/crates/desktop-seams/tests/conformance.rs
+++ b/crates/desktop-seams/tests/conformance.rs
@@ -170,6 +170,34 @@ fn staging_store_reopen_sweeps_stranded_root_temp_debris() {
     );
 }
 
+/// A foreign `.bin` file with a non-hex stem is ignored by both the budget
+/// total and the GC enumeration, so the two always agree on the reclaimable
+/// set — a file counted toward the budget but invisible to `staged_keys`
+/// could never be reclaimed.
+#[test]
+fn staging_store_budget_and_gc_set_agree_on_foreign_sidecars() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("staging");
+    block_on(async {
+        let store = FileStagingStore::open(&path).unwrap();
+        store.put_staged_bytes(b"real", b"12345").await.unwrap();
+
+        // Drop a foreign, non-hex-stemmed .bin into the staged dir.
+        std::fs::write(path.join("staged").join("not-hex.bin"), b"9999999999").unwrap();
+
+        assert_eq!(
+            store.staged_keys().await.unwrap(),
+            vec![b"real".to_vec()],
+            "staged_keys must skip the non-hex file"
+        );
+        assert_eq!(
+            store.staged_bytes_total().await.unwrap(),
+            5,
+            "staged_bytes_total must count only the real sidecar, not the foreign file"
+        );
+    });
+}
+
 // ---------------------------------------------------------------------------
 // Network seams — driven on a Tokio current-thread runtime (reqwest needs the
 // reactor). RecordTransport has a kit; Http does not (pure passthrough), so a

--- a/crates/desktop-seams/tests/conformance.rs
+++ b/crates/desktop-seams/tests/conformance.rs
@@ -1,0 +1,326 @@
+//! The desktop seam implementations run against the engine's reusable
+//! per-seam conformance kits (blueprint/testing.md "Seam conformance kits":
+//! "desktop implementations in cargo tests"), plus desktop-specific
+//! durability tests the kits do not cover (StagingStore crash-ordering and
+//! id-watermark durability).
+//!
+//! CredentialStore CI story: the OS keyring is unavailable on headless CI,
+//! so the automated gate runs the kit against the feature-gated
+//! [`FileCredentialStore`] test double; the real
+//! [`KeyringCredentialStore`](cipherbox_desktop_seams::KeyringCredentialStore)
+//! is exercised by the `#[ignore]`d `real_keyring_*` tests, run by hand on a
+//! machine with a keyring (see the report).
+
+use cipherbox_desktop_seams::{
+    FileCredentialStore, FileFloorStore, FileSnapshotCache, FileStagingStore, ReqwestHttp,
+    ReqwestRecordTransport, TokioScheduler,
+};
+use cipherbox_engine::seams::{CredentialStore, Http, HttpMethod, HttpRequest, StagingStore};
+use cipherbox_engine::testkit::{block_on, conformance};
+
+mod mock_http;
+use mock_http::MockServer;
+
+// ---------------------------------------------------------------------------
+// Fsync-barriered file stores — driven by the minimal single-future executor
+// (no runtime needed: the bodies are synchronous filesystem work).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn file_floor_store_passes_the_floor_store_kit() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("floors");
+    block_on(conformance::floor_store::check(async || {
+        FileFloorStore::open(&path).unwrap()
+    }));
+}
+
+#[test]
+fn file_staging_store_passes_the_staging_store_kit() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("staging");
+    block_on(conformance::staging_store::check(async || {
+        FileStagingStore::open(&path).unwrap()
+    }));
+}
+
+#[test]
+fn file_snapshot_cache_passes_the_snapshot_cache_kit() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snapshots");
+    block_on(conformance::snapshot_cache::check(async || {
+        FileSnapshotCache::open(&path).unwrap()
+    }));
+}
+
+/// The CI CredentialStore gate: the feature-gated file-backed double (the OS
+/// keyring is not present on headless runners).
+#[test]
+fn file_credential_store_passes_the_credential_store_kit() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("credentials");
+    block_on(conformance::credential_store::check(async || {
+        FileCredentialStore::open(&path).unwrap()
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// StagingStore desktop-specific durability — beyond what the kit asserts.
+// ---------------------------------------------------------------------------
+
+/// The json-record-before-bin-sidecar removal ordering (hard constraint 5).
+///
+/// Simulates a crash at the kill point *between* `remove_op` (the op record,
+/// the "json" of the v1 journal) and `remove_staged_bytes` (the sidecar):
+/// after reopen the op is durably gone while the sidecar survives as a
+/// harmless orphan — never the dangerous inverse (an op record referencing a
+/// sidecar that is already gone). Orphan-sidecar GC then reclaims it.
+#[test]
+fn staging_store_removal_ordering_leaves_only_a_reclaimable_orphan() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("staging");
+
+    block_on(async {
+        let store = FileStagingStore::open(&path).unwrap();
+        let op_id = store.enqueue_op(b"update-content-op").await.unwrap();
+        store
+            .put_staged_bytes(b"chunk-key", b"sealed-ciphertext")
+            .await
+            .unwrap();
+
+        // Engine completes the op: op record removed durably FIRST...
+        store.remove_op(op_id).await.unwrap();
+        // ...and the process dies here, before remove_staged_bytes.
+    });
+
+    // Reopen (post-"crash"): the op is gone, the sidecar is an orphan.
+    block_on(async {
+        let reopened = FileStagingStore::open(&path).unwrap();
+        assert!(
+            reopened.queued_ops().await.unwrap().is_empty(),
+            "the op record must be durably gone after remove_op"
+        );
+        assert_eq!(
+            reopened.staged_bytes(b"chunk-key").await.unwrap(),
+            Some(b"sealed-ciphertext".to_vec()),
+            "the sidecar must survive as a harmless orphan, never a dangling op"
+        );
+
+        // Orphan-sidecar GC reclaims it.
+        assert_eq!(
+            reopened.staged_keys().await.unwrap(),
+            vec![b"chunk-key".to_vec()]
+        );
+        reopened.remove_staged_bytes(b"chunk-key").await.unwrap();
+        assert!(reopened.staged_keys().await.unwrap().is_empty());
+        assert_eq!(reopened.staged_bytes_total().await.unwrap(), 0);
+    });
+}
+
+/// Op ids never repeat, even after every op drains and the store reopens —
+/// stronger than the kit, which keeps one surviving op across reopen.
+#[test]
+fn staging_store_op_ids_never_reuse_across_a_full_drain() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("staging");
+
+    let last = block_on(async {
+        let store = FileStagingStore::open(&path).unwrap();
+        let a = store.enqueue_op(b"a").await.unwrap();
+        let b = store.enqueue_op(b"b").await.unwrap();
+        // Drain the queue completely.
+        store.remove_op(a).await.unwrap();
+        store.remove_op(b).await.unwrap();
+        assert!(store.queued_ops().await.unwrap().is_empty());
+        b
+    });
+
+    block_on(async {
+        let reopened = FileStagingStore::open(&path).unwrap();
+        let next = reopened.enqueue_op(b"c").await.unwrap();
+        assert!(
+            next > last,
+            "an id after a full drain + reopen must still exceed every prior id"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Network seams — driven on a Tokio current-thread runtime (reqwest needs the
+// reactor). RecordTransport has a kit; Http does not (pure passthrough), so a
+// focused round-trip test stands in.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn reqwest_record_transport_passes_the_record_transport_kit() {
+    // Two independent endpoints, matching the engine's parallel fan-out
+    // shape — each is its own routing store.
+    let endpoint_a = MockServer::start();
+    let endpoint_b = MockServer::start();
+    let transport = ReqwestRecordTransport::new(vec![endpoint_a.base_url(), endpoint_b.base_url()])
+        .expect("client builds");
+
+    conformance::record_transport::check(
+        &transport,
+        "k51-fresh-desktop-routing-key",
+        b"opaque-signed-record-bytes",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn reqwest_http_round_trips_request_and_response() {
+    let server = MockServer::start();
+    let http = ReqwestHttp::new().expect("client builds");
+
+    // /echo returns the body verbatim plus an x-echo header, and records the
+    // request it received.
+    let response = http
+        .send(HttpRequest {
+            method: HttpMethod::Post,
+            url: format!("{}/echo", server.base_url()),
+            headers: vec![("x-cipherbox".into(), "seam".into())],
+            body: Some(b"request-payload".to_vec()),
+        })
+        .await
+        .expect("transport-level success");
+
+    assert_eq!(response.status, 200);
+    assert_eq!(response.body, b"request-payload");
+    assert!(
+        response
+            .headers
+            .iter()
+            .any(|(name, value)| name.eq_ignore_ascii_case("x-echo") && value == "yes"),
+        "response headers must round-trip"
+    );
+
+    // The engine's header actually reached the server.
+    let recorded = server.last_request().expect("a request was recorded");
+    assert!(
+        recorded
+            .headers
+            .iter()
+            .any(|(name, value)| name.eq_ignore_ascii_case("x-cipherbox") && value == "seam"),
+        "the request header the engine set must be sent verbatim"
+    );
+    assert_eq!(recorded.body, b"request-payload");
+}
+
+#[tokio::test]
+async fn reqwest_http_returns_non_2xx_as_a_response_not_an_error() {
+    let server = MockServer::start();
+    let http = ReqwestHttp::new().expect("client builds");
+
+    let response = http
+        .send(HttpRequest {
+            method: HttpMethod::Get,
+            url: format!("{}/teapot", server.base_url()),
+            headers: Vec::new(),
+            body: None,
+        })
+        .await
+        .expect("a non-2xx status is a response, never a seam Err");
+
+    assert_eq!(response.status, 418);
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler — the kit needs real timers + a LocalSet (spawn is spawn_local).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tokio_scheduler_passes_the_scheduler_kit() {
+    // spawn() delegates to spawn_local, which requires a LocalSet.
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let scheduler = TokioScheduler::new();
+            conformance::scheduler::check(&scheduler).await;
+        })
+        .await;
+}
+
+// ---------------------------------------------------------------------------
+// Last-account id — the one datum beyond the refresh token that the desktop
+// CredentialStore holds (blueprint/desktop.md). Exercised on the file double.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn credential_store_persists_last_account_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("credentials");
+    block_on(async {
+        let store = FileCredentialStore::open(&path).unwrap();
+        assert_eq!(store.load_last_account_id().await.unwrap(), None);
+        store.store_last_account_id(b"account-7").await.unwrap();
+        assert_eq!(
+            store.load_last_account_id().await.unwrap(),
+            Some(b"account-7".to_vec())
+        );
+
+        // Independent of the refresh token.
+        store.store_refresh_token(b"tok").await.unwrap();
+        assert_eq!(
+            store.load_last_account_id().await.unwrap(),
+            Some(b"account-7".to_vec())
+        );
+
+        store.clear_last_account_id().await.unwrap();
+        assert_eq!(store.load_last_account_id().await.unwrap(), None);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Real OS keyring — ignored by default (no keyring on headless CI). Run
+// locally: `cargo test -p cipherbox-desktop-seams --test conformance --
+// --ignored`.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires an unlocked OS keyring; run locally"]
+fn real_keyring_credential_store_passes_the_credential_store_kit() {
+    use cipherbox_desktop_seams::KeyringCredentialStore;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    // Unique service per run so the backing starts empty and never collides
+    // with a real CipherBox install.
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let service = format!("com.cipherbox.desktop.test.{}.{nonce}", std::process::id());
+
+    block_on(conformance::credential_store::check(async || {
+        KeyringCredentialStore::new(service.clone())
+    }));
+}
+
+#[test]
+#[ignore = "requires an unlocked OS keyring; run locally"]
+fn real_keyring_credential_store_persists_last_account_id() {
+    use cipherbox_desktop_seams::KeyringCredentialStore;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let service = format!(
+        "com.cipherbox.desktop.test.lastacct.{}.{nonce}",
+        std::process::id()
+    );
+
+    block_on(async {
+        let store = KeyringCredentialStore::new(service);
+        assert_eq!(store.load_last_account_id().await.unwrap(), None);
+        store.store_last_account_id(b"acct-xyz").await.unwrap();
+        assert_eq!(
+            store.load_last_account_id().await.unwrap(),
+            Some(b"acct-xyz".to_vec())
+        );
+        // Clean up the keyring entry.
+        store.clear_last_account_id().await.unwrap();
+        assert_eq!(store.load_last_account_id().await.unwrap(), None);
+    });
+}

--- a/crates/desktop-seams/tests/conformance.rs
+++ b/crates/desktop-seams/tests/conformance.rs
@@ -145,6 +145,31 @@ fn staging_store_op_ids_never_reuse_across_a_full_drain() {
     });
 }
 
+/// A temp file stranded in the store root by a crash mid-counter-write is
+/// reclaimed on reopen — the `next_op_id` counter lives directly under the
+/// root, so the root must be swept like the ops/staged subdirs.
+#[test]
+fn staging_store_reopen_sweeps_stranded_root_temp_debris() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("staging");
+    block_on(async {
+        FileStagingStore::open(&path).unwrap();
+    });
+
+    // Simulate crash debris from a counter write: a temp file in the root.
+    let debris = path.join(".cbtmp.stranded");
+    std::fs::write(&debris, b"partial-counter").unwrap();
+    assert!(debris.exists());
+
+    block_on(async {
+        FileStagingStore::open(&path).unwrap();
+    });
+    assert!(
+        !debris.exists(),
+        "reopen must sweep temp debris stranded in the store root"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Network seams — driven on a Tokio current-thread runtime (reqwest needs the
 // reactor). RecordTransport has a kit; Http does not (pure passthrough), so a

--- a/crates/desktop-seams/tests/mock_http/mod.rs
+++ b/crates/desktop-seams/tests/mock_http/mod.rs
@@ -1,0 +1,212 @@
+//! A tiny loopback HTTP/1.1 server for the transport/HTTP seam tests.
+//!
+//! Std-only (no extra deps): it speaks just enough HTTP to exercise the
+//! `reqwest` seams. Routes:
+//!
+//! - `PUT|GET /routing/v1/ipns/<key>` — an in-memory `/routing/v1` record
+//!   store (PUT stores the body, GET returns it or 404), matching the shape
+//!   the [`RecordTransport`] kit drives.
+//! - `POST /echo` — echoes the request body and adds an `x-echo: yes`
+//!   header; records the request for assertions.
+//! - `GET /teapot` — returns 418, to prove a non-2xx status is a response,
+//!   not a seam error.
+//!
+//! Every response carries `Connection: close`, so each request is one
+//! connection and the accept loop stays single-threaded.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+/// One request the server received, captured for test assertions.
+#[derive(Clone)]
+pub struct RecordedRequest {
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
+}
+
+/// A running loopback mock server. Dropping it stops the accept thread.
+pub struct MockServer {
+    addr: SocketAddr,
+    stop: Arc<AtomicBool>,
+    last: Arc<Mutex<Option<RecordedRequest>>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl MockServer {
+    /// Binds an ephemeral loopback port and starts serving.
+    pub fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        listener
+            .set_nonblocking(true)
+            .expect("nonblocking listener");
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let last = Arc::new(Mutex::new(None));
+        let store: Arc<Mutex<HashMap<String, Vec<u8>>>> = Arc::new(Mutex::new(HashMap::new()));
+
+        let thread_stop = Arc::clone(&stop);
+        let thread_last = Arc::clone(&last);
+        let handle = thread::spawn(move || {
+            while !thread_stop.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        let _ = handle_conn(stream, &store, &thread_last);
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(1));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Self {
+            addr,
+            stop,
+            last,
+            handle: Some(handle),
+        }
+    }
+
+    /// The `http://127.0.0.1:<port>` base URL of this server.
+    pub fn base_url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    /// The most recent request the server received, if any.
+    pub fn last_request(&self) -> Option<RecordedRequest> {
+        self.last.lock().expect("lock").clone()
+    }
+}
+
+impl Drop for MockServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn handle_conn(
+    mut stream: TcpStream,
+    store: &Mutex<HashMap<String, Vec<u8>>>,
+    last: &Mutex<Option<RecordedRequest>>,
+) -> std::io::Result<()> {
+    // Accepted streams can inherit the listener's non-blocking mode; force
+    // blocking reads with a safety timeout.
+    stream.set_nonblocking(false)?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 2048];
+    let header_end = loop {
+        if let Some(pos) = find_subslice(&buf, b"\r\n\r\n") {
+            break pos;
+        }
+        let read = stream.read(&mut chunk)?;
+        if read == 0 {
+            return Ok(());
+        }
+        buf.extend_from_slice(&chunk[..read]);
+        if buf.len() > 16 * 1024 * 1024 {
+            return Ok(());
+        }
+    };
+
+    let header_text = String::from_utf8_lossy(&buf[..header_end]).into_owned();
+    let mut lines = header_text.split("\r\n");
+    let request_line = lines.next().unwrap_or_default();
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts.next().unwrap_or_default().to_owned();
+    let path = request_parts.next().unwrap_or_default().to_owned();
+
+    let mut headers = Vec::new();
+    let mut content_length = 0usize;
+    for line in lines {
+        if let Some((name, value)) = line.split_once(':') {
+            let name = name.trim().to_owned();
+            let value = value.trim().to_owned();
+            if name.eq_ignore_ascii_case("content-length") {
+                content_length = value.parse().unwrap_or(0);
+            }
+            headers.push((name, value));
+        }
+    }
+
+    let mut body = buf[header_end + 4..].to_vec();
+    while body.len() < content_length {
+        let read = stream.read(&mut chunk)?;
+        if read == 0 {
+            break;
+        }
+        body.extend_from_slice(&chunk[..read]);
+    }
+    body.truncate(content_length);
+
+    *last.lock().expect("lock") = Some(RecordedRequest {
+        headers,
+        body: body.clone(),
+    });
+
+    let (status, reason, extra_headers, response_body): (u16, &str, Vec<(&str, &str)>, Vec<u8>) =
+        if let Some(_key) = path.strip_prefix("/routing/v1/ipns/") {
+            if method == "PUT" {
+                store.lock().expect("lock").insert(path.clone(), body);
+                (200, "OK", Vec::new(), Vec::new())
+            } else {
+                match store.lock().expect("lock").get(&path) {
+                    Some(bytes) => (
+                        200,
+                        "OK",
+                        vec![("content-type", "application/vnd.ipfs.ipns-record")],
+                        bytes.clone(),
+                    ),
+                    None => (404, "Not Found", Vec::new(), Vec::new()),
+                }
+            }
+        } else if path == "/echo" {
+            (200, "OK", vec![("x-echo", "yes")], body)
+        } else if path == "/teapot" {
+            (418, "I'm a teapot", Vec::new(), b"teapot".to_vec())
+        } else {
+            (404, "Not Found", Vec::new(), Vec::new())
+        };
+
+    write_response(&mut stream, status, reason, &extra_headers, &response_body)
+}
+
+fn write_response(
+    stream: &mut TcpStream,
+    status: u16,
+    reason: &str,
+    extra_headers: &[(&str, &str)],
+    body: &[u8],
+) -> std::io::Result<()> {
+    let mut head = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Length: {}\r\nConnection: close\r\n",
+        body.len()
+    );
+    for (name, value) in extra_headers {
+        head.push_str(name);
+        head.push_str(": ");
+        head.push_str(value);
+        head.push_str("\r\n");
+    }
+    head.push_str("\r\n");
+    stream.write_all(head.as_bytes())?;
+    stream.write_all(body)?;
+    stream.flush()
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}


### PR DESCRIPTION
Closes #646

## What this ships

A new pure-Rust crate `crates/desktop-seams` implementing the seven desktop host-seam traits the engine constructor injects on the native host, each verified against the engine's reusable per-seam conformance kits (`blueprint/desktop.md` "Engine wiring", `blueprint/engine.md` "Host seams"):

- **FileFloorStore** — fsync-barriered per-key floor files (`epoch/`, `seq/`), monotonic-max, the v1 high-water discipline.
- **FileStagingStore** — the v1 write journal generalized to every op: one durable op record per queued op (id in the filename, FIFO), staged-ciphertext sidecars, a durable monotonic id counter, and op-record-before-sidecar removal ordering so a crash can only ever orphan a sidecar.
- **FileSnapshotCache** — sealed record/metadata cache files, ciphertext-only at rest, unsealed in the engine on read.
- **KeyringCredentialStore** — OS keyring (Apple Keychain / Windows Credential Manager / Secret Service), one service name, holding only the rotating refresh token and last-account id.
- **ReqwestHttp** / **ReqwestRecordTransport** — `reqwest` over ring-backed rustls; a dumb byte mover and a dumb `/routing/v1` GET/PUT mover.
- **TokioScheduler** — timers, background tasks, and the wall clock on Tokio.

All durable stores share one fsync-barrier primitive layer (`fs_util`): `atomic_write` (temp + `sync_all` + rename + dir-fsync) and `remove_file_durable` (unlink + dir-fsync), with crash-debris sweeping on open. `Mailbox` and `RefreshHintSource` are intentionally not here (the mailbox is the engine's own API client over the Http seam; refresh hints come from the `crates/fuse` op core) — this crate constructs no engine and touches no webview; the shell wires those in a later slice.

## Deviations flagged

- **New `crates/desktop-seams` crate.** The kits must run inside the cargo gate, but `apps/desktop` (the Tauri crate) is excluded from the fast clippy/test gate, so it cannot host them. A dedicated pure-Rust library crate is the only home that satisfies both "kits run in the cargo gate" and "Tauri stays gated out". Version-frozen at `0.0.0`, never published.
- **reqwest 0.12 / ring, not 0.13.** reqwest 0.13 forces the `aws-lc-rs` rustls backend, which pulls a `cmake` C-toolchain build dependency. Pinning `reqwest = 0.12` with `rustls-tls-webpki-roots` keeps the crypto backend ring-only — no OpenSSL, no native-tls, no cmake (hard constraint 6). The Linux keyring transport likewise uses `crypto-rust` to stay pure-Rust.
- **File-double CI story for the keyring.** Headless CI has no OS keyring, so the automated CredentialStore gate runs the kit against a feature-gated `FileCredentialStore` test double (behind `test-support`, enabled only by this crate's own dev-dependency — it never compiles into a production build). The real `KeyringCredentialStore` is exercised by two `#[ignore]`d tests, run by hand on a machine with a keyring. Verified locally on macOS this ship (see below).

## Verification

Local gates, all green (`crates/*` touched):

- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --exclude cipherbox-desktop --all-targets -- -D warnings` — clean, no warnings.
- `cargo test --workspace --exclude cipherbox-desktop` — all base suites + the 6 conformance-kit tests + desktop-specific durability/integration tests, 0 failures. desktop-seams: 7 unit + 12 conformance passing, 2 keyring tests `#[ignore]`d.
- **Real macOS Keychain:** `cargo test -p cipherbox-desktop-seams --test conformance -- --ignored` -> `2 passed; 0 failed`. The real `KeyringCredentialStore` round-trips the refresh token and last-account id through the live Apple Keychain on this machine.
- **StagingStore kill-point:** the crash-ordering test drives the real `FileStagingStore` on a real tempdir — enqueue, stage, `remove_op`, "crash" before `remove_staged_bytes`, reopen — and asserts the op is durably gone while the sidecar survives as a reclaimable orphan (never the dangerous inverse). Passes. Honest scope: this proves the op-record-before-sidecar ordering + reopen recovery against the real fsync-barriered store; it is not a power-loss fault-injection test (that needs dm-flakey-class tooling and is out of scope).

## Security & crypto/privacy review

Step 2b applies (durability + credential storage are privacy/crypto-adjacent). Ran an adversarial sweep of `origin/main...HEAD` against `blueprint/desktop.md` and `CONTEXT.md`. All five required properties PASS:

- **Ciphertext-only at rest** — SnapshotCache/StagingStore sidecars hold engine-sealed bytes verbatim; FloorStore holds only public monotonic counters (epoch/sequence), never plaintext content or key material.
- **CredentialStore scope** — exactly the refresh token + last-account id in the keyring; no seed, no unwrapped key, and the access JWT stays in engine memory.
- **Debug redaction** — every derived `Debug` in the crate holds only non-secret fields (a service-name string, endpoint URLs, a reqwest client, a unit struct); no credential-bearing type can leak a secret.
- **Zeroize-at-terminal-owner** — this crate is a pass-through for the refresh token, correctly holds no lingering secret copy, and correctly does not zeroize caller-owned buffers.
- **Crash-ordering durability** — `remove_op` fsyncs before returning, so the op-record unlink is durable before the sidecar unlink is attempted; the dangerous inverse is structurally impossible on Unix.

## Triage

**Fixed (3):**

- `account_data_dir` now rejects an `account_id` that is not a single normal path component, so a stray separator or `..` can no longer escape `<data_local_dir>/cipherbox/` (fail-closed, with regression tests). Flagged independently by both reviewers.
- Default Http and RecordTransport reqwest clients gained a connect timeout so a dead/black-hole host fails fast instead of hanging the engine task; RecordTransport also caps the whole request and follows no redirects (direct addressing needs none, closing an SSRF-shaped vector from an untrusted public endpoint). `with_client` callers keep owning their own policy.
- FileStagingStore reopen now sweeps crash debris from the store root too (the `next_op_id` counter is atomic-written there); previously only `ops/` and `staged/` were swept.

**Filed (1):** #665 — harden StagingStore unlink-ordering durability on Windows (`fsync_dir` is a no-op there; NTFS journaling gives consistency but not the app-visible unlink ordering the Unix path fsyncs). Low severity today — Windows desktop is not a current shipping target — but a real durability gap in a correctness-critical path.

**Discarded (4, by-contract or speculative):** routing_key not percent-encoded (routing keys are restricted-alphabet IPNS CIDs, safe by contract); no redirect policy on the Http seam (the engine owns API-client semantics and may rely on redirects; reqwest strips standard sensitive headers cross-host); a CI guard that no production build enables `test-support` (containment is already sound — dev-deps don't propagate; the shell-wiring slice is the natural home); the kill-point test being logical-ordering rather than power-loss (infeasible portably; ordering is proven and the fsync barrier is code-reviewed).

CodeRabbit CLI surfaced 3 findings on the first pass (all three fixed above); the confirming re-run was rate-limited, so a full CodeRabbit web review is requested on this PR — the CLI under-reports on durability logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added desktop storage for credentials, snapshots, staged operations, and durable counters.
  * Added HTTP and record transport support with configurable endpoints and timeout handling.
  * Added Tokio-based scheduling and account-specific data directory management.
  * Added durable file operations with crash-safe writes, removals, and recovery.

* **Tests**
  * Added comprehensive conformance, durability, persistence, and HTTP integration coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->