### PR TITLE
feat(api): build the mailbox with post, poll, ack, caps, and rate limits

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -621,7 +621,7 @@
           },
           "idempotencyKey": {
             "type": "string",
-            "description": "Sender-supplied idempotency key; a replay returns the original message id"
+            "description": "Sender-supplied idempotency key; a replay returns the original message id. MUST be a high-entropy per-message random value: it is blended into a one-way sender digest, and a low-entropy key would let a server-side observer brute-force the sender→recipient edge."
           }
         },
         "required": [

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -290,6 +290,104 @@
           "Auth"
         ]
       }
+    },
+    "/mailbox/messages": {
+      "post": {
+        "operationId": "MailboxController_post",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PostMessageDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostMessageResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Post an HPKE-sealed blob to a recipient identity publicKey; unknown recipients are rejected (rate-limited existence oracle)",
+        "tags": [
+          "Mailbox"
+        ]
+      },
+      "get": {
+        "operationId": "MailboxController_poll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PollResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Poll the authenticated mailbox; returns sealed blobs with no sender metadata in the clear",
+        "tags": [
+          "Mailbox"
+        ]
+      }
+    },
+    "/mailbox/messages/{id}": {
+      "delete": {
+        "operationId": "MailboxController_ack",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AckResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Ack a message: hard delete by id, scoped to the caller mailbox",
+        "tags": [
+          "Mailbox"
+        ]
+      }
     }
   },
   "info": {
@@ -306,6 +404,10 @@
     {
       "name": "Auth",
       "description": "Identity auth, SIWE secondary, refresh rotation"
+    },
+    {
+      "name": "Mailbox",
+      "description": "Integrity-untrusted sealed-pointer transport: post, poll, ack"
     }
   ],
   "servers": [],
@@ -503,6 +605,89 @@
           "refreshToken",
           "publicKey",
           "privateKey"
+        ]
+      },
+      "PostMessageDto": {
+        "type": "object",
+        "properties": {
+          "recipientPublicKey": {
+            "type": "string",
+            "description": "Recipient identity publicKey, hex secp256k1 (compressed or uncompressed)",
+            "example": "02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc"
+          },
+          "blob": {
+            "type": "string",
+            "description": "HPKE-sealed opaque payload, base64 (decodes to <= 8 KiB). Never inspected server-side."
+          },
+          "idempotencyKey": {
+            "type": "string",
+            "description": "Sender-supplied idempotency key; a replay returns the original message id"
+          }
+        },
+        "required": [
+          "recipientPublicKey",
+          "blob",
+          "idempotencyKey"
+        ]
+      },
+      "PostMessageResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Server-assigned message id"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "MailboxMessageDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Message id; ack deletes by this id"
+          },
+          "receivedAt": {
+            "type": "string",
+            "description": "Post time, ISO 8601"
+          },
+          "blob": {
+            "type": "string",
+            "description": "HPKE-sealed opaque payload, base64 (owner-signed inside the seal)"
+          }
+        },
+        "required": [
+          "id",
+          "receivedAt",
+          "blob"
+        ]
+      },
+      "PollResponseDto": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "description": "Pending messages, oldest first",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MailboxMessageDto"
+            }
+          }
+        },
+        "required": [
+          "messages"
+        ]
+      },
+      "AckResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success"
         ]
       }
     }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -315,6 +315,24 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Malformed body (invalid publicKey, blob, or key)"
+          },
+          "401": {
+            "description": "Missing or invalid access token"
+          },
+          "404": {
+            "description": "Unknown recipient (rate-limited existence oracle)"
+          },
+          "409": {
+            "description": "Recipient mailbox is full (per-recipient pending cap)"
+          },
+          "413": {
+            "description": "Sealed blob exceeds 8 KiB"
+          },
+          "429": {
+            "description": "Per-sender post rate limit exceeded"
           }
         },
         "security": [
@@ -340,6 +358,12 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Missing or invalid access token"
+          },
+          "429": {
+            "description": "Per-recipient poll rate limit exceeded"
           }
         },
         "security": [
@@ -376,6 +400,12 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Missing or invalid access token"
+          },
+          "429": {
+            "description": "Per-recipient ack rate limit exceeded"
           }
         },
         "security": [

--- a/apps/api/scripts/generate-openapi.ts
+++ b/apps/api/scripts/generate-openapi.ts
@@ -21,15 +21,18 @@ import { AuthService } from '../src/auth/services/auth.service';
 import { TestAuthService } from '../src/auth/services/test-auth.service';
 import { TokenService } from '../src/auth/services/token.service';
 import { HealthController } from '../src/health/health.controller';
+import { MailboxController } from '../src/mailbox/mailbox.controller';
+import { MailboxService } from '../src/mailbox/services/mailbox.service';
 import { MetricsController } from '../src/ops/metrics.controller';
 import { MetricsService } from '../src/ops/metrics.service';
 
 @Module({
-  controllers: [HealthController, MetricsController, AuthController],
+  controllers: [HealthController, MetricsController, AuthController, MailboxController],
   providers: [
     { provide: AuthService, useValue: {} },
     { provide: TestAuthService, useValue: {} },
     { provide: TokenService, useValue: {} },
+    { provide: MailboxService, useValue: {} },
     { provide: MetricsService, useValue: {} },
     { provide: JwtService, useValue: {} },
     { provide: ConfigService, useValue: new ConfigService() },

--- a/apps/api/src/app-setup.ts
+++ b/apps/api/src/app-setup.ts
@@ -61,6 +61,7 @@ export function buildOpenApiDocument(app: INestApplication): OpenAPIObject {
     .addBearerAuth()
     .addTag('Ops', 'Health and metrics')
     .addTag('Auth', 'Identity auth, SIWE secondary, refresh rotation')
+    .addTag('Mailbox', 'Integrity-untrusted sealed-pointer transport: post, poll, ack')
     .build();
   return SwaggerModule.createDocument(app, config);
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from './auth/auth.module';
 import { RuntimeModule } from './common/runtime.module';
+import { MailboxModule } from './mailbox/mailbox.module';
 import { OpsModule } from './ops/ops.module';
 
 @Module({
@@ -26,6 +27,7 @@ import { OpsModule } from './ops/ops.module';
     RuntimeModule,
     OpsModule,
     AuthModule,
+    MailboxModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/mailbox/dto/mailbox.dto.ts
+++ b/apps/api/src/mailbox/dto/mailbox.dto.ts
@@ -30,7 +30,10 @@ export class PostMessageDto {
   blob!: string;
 
   @ApiProperty({
-    description: 'Sender-supplied idempotency key; a replay returns the original message id',
+    description:
+      'Sender-supplied idempotency key; a replay returns the original message id. MUST be a ' +
+      'high-entropy per-message random value: it is blended into a one-way sender digest, and a ' +
+      'low-entropy key would let a server-side observer brute-force the sender→recipient edge.',
   })
   @IsString()
   @Matches(IDEMPOTENCY_KEY, {

--- a/apps/api/src/mailbox/dto/mailbox.dto.ts
+++ b/apps/api/src/mailbox/dto/mailbox.dto.ts
@@ -1,0 +1,66 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, Matches, MaxLength } from 'class-validator';
+
+const HEX_PUBLIC_KEY = /^(02|03)[0-9a-fA-F]{64}$|^04[0-9a-fA-F]{128}$/;
+const BASE64 = /^[A-Za-z0-9+/]+={0,2}$/;
+const IDEMPOTENCY_KEY = /^[A-Za-z0-9._~-]{1,128}$/;
+
+/**
+ * A base64 blob string longer than this cannot decode to <= 8 KiB, so the DTO
+ * rejects it cheaply; the service still enforces the exact decoded-byte bound.
+ */
+const MAX_BLOB_BASE64_LENGTH = 12000;
+
+export class PostMessageDto {
+  @ApiProperty({
+    description: 'Recipient identity publicKey, hex secp256k1 (compressed or uncompressed)',
+    example: '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc',
+  })
+  @IsString()
+  @Matches(HEX_PUBLIC_KEY, { message: 'recipientPublicKey must be a hex secp256k1 public key' })
+  recipientPublicKey!: string;
+
+  @ApiProperty({
+    description:
+      'HPKE-sealed opaque payload, base64 (decodes to <= 8 KiB). Never inspected server-side.',
+  })
+  @IsString()
+  @MaxLength(MAX_BLOB_BASE64_LENGTH)
+  @Matches(BASE64, { message: 'blob must be base64' })
+  blob!: string;
+
+  @ApiProperty({
+    description: 'Sender-supplied idempotency key; a replay returns the original message id',
+  })
+  @IsString()
+  @Matches(IDEMPOTENCY_KEY, {
+    message: 'idempotencyKey must be 1-128 url-safe characters',
+  })
+  idempotencyKey!: string;
+}
+
+export class PostMessageResponseDto {
+  @ApiProperty({ description: 'Server-assigned message id' })
+  id!: string;
+}
+
+export class MailboxMessageDto {
+  @ApiProperty({ description: 'Message id; ack deletes by this id' })
+  id!: string;
+
+  @ApiProperty({ description: 'Post time, ISO 8601' })
+  receivedAt!: string;
+
+  @ApiProperty({ description: 'HPKE-sealed opaque payload, base64 (owner-signed inside the seal)' })
+  blob!: string;
+}
+
+export class PollResponseDto {
+  @ApiProperty({ type: [MailboxMessageDto], description: 'Pending messages, oldest first' })
+  messages!: MailboxMessageDto[];
+}
+
+export class AckResponseDto {
+  @ApiProperty()
+  success!: boolean;
+}

--- a/apps/api/src/mailbox/entities/mailbox-message.entity.ts
+++ b/apps/api/src/mailbox/entities/mailbox-message.entity.ts
@@ -13,9 +13,19 @@ import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
  * (poll routing + the accepted exact-pubkey existence oracle needs it), but
  * the sender is NOT persisted as a separable column. Per-sender idempotency
  * rides `idempotencyScope` = sha256(`${senderPublicKey}:${idempotencyKey}`),
- * which blends the sender into a one-way digest — so there is no durable,
- * pivotable sender→recipient graph, only the transient edge the blueprint
- * accepts (Mailbox: "never a durable graph, never key material").
+ * which blends the sender into a one-way digest — so the durable,
+ * server-pivotable sender→recipient graph the blueprint forbids ("never a
+ * durable graph, never key material") does not sit in the schema.
+ *
+ * That one-wayness is contingent on a CLIENT invariant: `idempotencyKey` must
+ * be a high-entropy per-message random value. The sender set is enumerable
+ * (account pubkeys, confirmable via the existence oracle), so a low-entropy
+ * key (a counter, a deterministic derivation) would let a server-side observer
+ * brute-force `sha256(senderPk:key)` and re-attribute a row's sender. A random
+ * key makes the digest a genuine one-way commitment; a per-row salt is NOT an
+ * option because it would break the (sender,key) determinism idempotency needs.
+ * The engine's mailbox client is responsible for drawing the key from its RNG
+ * seam (blueprint/engine.md); this boundary cannot enforce it.
  */
 @Entity('mailbox_messages')
 @Index('uq_mailbox_recipient_idempotency', ['recipientPublicKey', 'idempotencyScope'], {

--- a/apps/api/src/mailbox/entities/mailbox-message.entity.ts
+++ b/apps/api/src/mailbox/entities/mailbox-message.entity.ts
@@ -1,0 +1,44 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+/**
+ * One sealed pointer parked for a recipient (blueprint/api.md, Mailbox).
+ *
+ * The mailbox is an integrity-untrusted, zero-knowledge transport: the row
+ * holds an opaque HPKE-sealed blob the server never decodes, never logs, and
+ * never verifies (payload signatures are checked client-side). Rows are
+ * hard-deleted on ack and on TTL expiry — no crypto-bearing row outlives its
+ * consumer (AGENTS.md; blueprint/api.md Data model).
+ *
+ * Privacy posture: the recipient identity publicKey is stored in the clear
+ * (poll routing + the accepted exact-pubkey existence oracle needs it), but
+ * the sender is NOT persisted as a separable column. Per-sender idempotency
+ * rides `idempotencyScope` = sha256(`${senderPublicKey}:${idempotencyKey}`),
+ * which blends the sender into a one-way digest — so there is no durable,
+ * pivotable sender→recipient graph, only the transient edge the blueprint
+ * accepts (Mailbox: "never a durable graph, never key material").
+ */
+@Entity('mailbox_messages')
+@Index('uq_mailbox_recipient_idempotency', ['recipientPublicKey', 'idempotencyScope'], {
+  unique: true,
+})
+@Index('idx_mailbox_recipient_received', ['recipientPublicKey', 'receivedAt'])
+export class MailboxMessage {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Canonical compressed secp256k1 recipient identity publicKey, lowercase hex. */
+  @Column({ name: 'recipient_public_key', type: 'varchar', length: 130 })
+  recipientPublicKey: string;
+
+  /** sha256(`${senderPublicKey}:${idempotencyKey}`); scopes idempotent replay per sender. */
+  @Column({ name: 'idempotency_scope', type: 'varchar', length: 64 })
+  idempotencyScope: string;
+
+  /** Opaque HPKE-sealed payload; never decoded or logged server-side. */
+  @Column({ name: 'blob', type: 'bytea' })
+  blob: Buffer;
+
+  /** Post time from the injected clock; drives poll ordering and the 90-day TTL. */
+  @Column({ name: 'received_at', type: 'timestamptz' })
+  receivedAt: Date;
+}

--- a/apps/api/src/mailbox/mailbox.controller.ts
+++ b/apps/api/src/mailbox/mailbox.controller.ts
@@ -1,0 +1,66 @@
+import { Body, Controller, Delete, Get, Param, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { AuthenticatedRequest, JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { THROTTLE_SURFACES } from '../ops/throttling';
+import {
+  AckResponseDto,
+  MailboxMessageDto,
+  PollResponseDto,
+  PostMessageDto,
+  PostMessageResponseDto,
+} from './dto/mailbox.dto';
+import { MailboxService } from './services/mailbox.service';
+
+/**
+ * The integrity-untrusted mailbox surface (blueprint/api.md, Mailbox): post a
+ * sealed pointer to a recipient pubkey, poll your own mailbox, ack-delete by
+ * id. Every route is authenticated; blobs are opaque and never inspected.
+ */
+@ApiTags('Mailbox')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('mailbox')
+export class MailboxController {
+  constructor(private readonly mailboxService: MailboxService) {}
+
+  @Post('messages')
+  @Throttle(THROTTLE_SURFACES.mailboxPost)
+  @ApiOperation({
+    summary:
+      'Post an HPKE-sealed blob to a recipient identity publicKey; unknown recipients are rejected (rate-limited existence oracle)',
+  })
+  @ApiCreatedResponse({ type: PostMessageResponseDto })
+  post(
+    @Body() body: PostMessageDto,
+    @Req() request: AuthenticatedRequest
+  ): Promise<PostMessageResponseDto> {
+    return this.mailboxService.post(request.user.publicKey, body);
+  }
+
+  @Get('messages')
+  @Throttle(THROTTLE_SURFACES.mailboxPoll)
+  @ApiOperation({
+    summary:
+      'Poll the authenticated mailbox; returns sealed blobs with no sender metadata in the clear',
+  })
+  @ApiOkResponse({ type: PollResponseDto })
+  async poll(@Req() request: AuthenticatedRequest): Promise<PollResponseDto> {
+    const { messages } = await this.mailboxService.poll(request.user.publicKey);
+    return { messages: messages as MailboxMessageDto[] };
+  }
+
+  @Delete('messages/:id')
+  @Throttle(THROTTLE_SURFACES.mailboxAck)
+  @ApiOperation({ summary: 'Ack a message: hard delete by id, scoped to the caller mailbox' })
+  @ApiOkResponse({ type: AckResponseDto })
+  ack(@Param('id') id: string, @Req() request: AuthenticatedRequest): Promise<AckResponseDto> {
+    return this.mailboxService.ack(request.user.publicKey, id);
+  }
+}

--- a/apps/api/src/mailbox/mailbox.controller.ts
+++ b/apps/api/src/mailbox/mailbox.controller.ts
@@ -4,6 +4,7 @@ import {
   ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
@@ -37,6 +38,15 @@ export class MailboxController {
       'Post an HPKE-sealed blob to a recipient identity publicKey; unknown recipients are rejected (rate-limited existence oracle)',
   })
   @ApiCreatedResponse({ type: PostMessageResponseDto })
+  @ApiResponse({ status: 400, description: 'Malformed body (invalid publicKey, blob, or key)' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
+  @ApiResponse({ status: 404, description: 'Unknown recipient (rate-limited existence oracle)' })
+  @ApiResponse({
+    status: 409,
+    description: 'Recipient mailbox is full (per-recipient pending cap)',
+  })
+  @ApiResponse({ status: 413, description: 'Sealed blob exceeds 8 KiB' })
+  @ApiResponse({ status: 429, description: 'Per-sender post rate limit exceeded' })
   post(
     @Body() body: PostMessageDto,
     @Req() request: AuthenticatedRequest
@@ -51,6 +61,8 @@ export class MailboxController {
       'Poll the authenticated mailbox; returns sealed blobs with no sender metadata in the clear',
   })
   @ApiOkResponse({ type: PollResponseDto })
+  @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
+  @ApiResponse({ status: 429, description: 'Per-recipient poll rate limit exceeded' })
   async poll(@Req() request: AuthenticatedRequest): Promise<PollResponseDto> {
     const { messages } = await this.mailboxService.poll(request.user.publicKey);
     return { messages: messages as MailboxMessageDto[] };
@@ -60,6 +72,8 @@ export class MailboxController {
   @Throttle(THROTTLE_SURFACES.mailboxAck)
   @ApiOperation({ summary: 'Ack a message: hard delete by id, scoped to the caller mailbox' })
   @ApiOkResponse({ type: AckResponseDto })
+  @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
+  @ApiResponse({ status: 429, description: 'Per-recipient ack rate limit exceeded' })
   ack(@Param('id') id: string, @Req() request: AuthenticatedRequest): Promise<AckResponseDto> {
     return this.mailboxService.ack(request.user.publicKey, id);
   }

--- a/apps/api/src/mailbox/mailbox.http.test.ts
+++ b/apps/api/src/mailbox/mailbox.http.test.ts
@@ -1,0 +1,332 @@
+import { INestApplication } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { configureApp } from '../app-setup';
+import { User } from '../auth/entities/user.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { IdentityService } from '../auth/services/identity.service';
+import { Clock, SystemClock } from '../common/clock';
+import { OpsModule } from '../ops/ops.module';
+import { THROTTLE_SURFACES } from '../ops/throttling';
+import { FakeRepository } from '../testing/fake-repo';
+import { fakeConfig } from '../testing/fakes';
+import { MailboxController } from './mailbox.controller';
+import { MailboxMessage } from './entities/mailbox-message.entity';
+import { MailboxService } from './services/mailbox.service';
+
+const SECRET = 'mailbox-test-secret';
+const PENDING_CAP = 3;
+
+function base64Blob(bytes: number): string {
+  return Buffer.alloc(bytes, 42).toString('base64');
+}
+
+describe('mailbox HTTP surface', () => {
+  let app: INestApplication;
+  let http: ReturnType<INestApplication['getHttpServer']>;
+  let userRepo: FakeRepository<User>;
+  let messageRepo: FakeRepository<MailboxMessage>;
+  let jwt: JwtService;
+
+  beforeAll(async () => {
+    userRepo = new FakeRepository<User>();
+    messageRepo = new FakeRepository<MailboxMessage>();
+    jwt = new JwtService();
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true }),
+        OpsModule,
+        JwtModule.register({ secret: SECRET, signOptions: { expiresIn: 900 } }),
+      ],
+      controllers: [MailboxController],
+      providers: [
+        MailboxService,
+        IdentityService,
+        JwtAuthGuard,
+        { provide: Clock, useClass: SystemClock },
+        {
+          provide: ConfigService,
+          useValue: fakeConfig({ MAILBOX_PENDING_CAP: String(PENDING_CAP) }).service,
+        },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+        { provide: getRepositoryToken(MailboxMessage), useValue: messageRepo },
+      ],
+    }).compile();
+
+    app = configureApp(moduleRef.createNestApplication());
+    await app.init();
+    http = app.getHttpServer();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  /** Seed a user account and mint a valid access token for it. */
+  async function account(): Promise<{ publicKey: string; token: string }> {
+    const priv = secp256k1.utils.randomPrivateKey();
+    const publicKey = Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+    const user = await userRepo.save({ publicKey } as never);
+    const token = await jwt.signAsync({ sub: user.id, publicKey }, { secret: SECRET });
+    return { publicKey, token };
+  }
+
+  function unknownPublicKey(): string {
+    const priv = secp256k1.utils.randomPrivateKey();
+    return Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+  }
+
+  describe('post → poll → ack lifecycle', () => {
+    it('delivers a sealed blob end-to-end and hard-deletes on ack', async () => {
+      const sender = await account();
+      const recipient = await account();
+      const blob = base64Blob(128);
+
+      const posted = await request(http)
+        .post('/mailbox/messages')
+        .set('Authorization', `Bearer ${sender.token}`)
+        .send({ recipientPublicKey: recipient.publicKey, blob, idempotencyKey: 'life-1' })
+        .expect(201);
+      expect(posted.body.id).toBeTruthy();
+
+      const polled = await request(http)
+        .get('/mailbox/messages')
+        .set('Authorization', `Bearer ${recipient.token}`)
+        .expect(200);
+      expect(polled.body.messages).toHaveLength(1);
+      expect(polled.body.messages[0]).toEqual({
+        id: posted.body.id,
+        receivedAt: expect.any(String),
+        blob,
+      });
+
+      await request(http)
+        .delete(`/mailbox/messages/${posted.body.id}`)
+        .set('Authorization', `Bearer ${recipient.token}`)
+        .expect(200);
+
+      const afterAck = await request(http)
+        .get('/mailbox/messages')
+        .set('Authorization', `Bearer ${recipient.token}`)
+        .expect(200);
+      expect(afterAck.body.messages).toHaveLength(0);
+    });
+
+    it('replays idempotently: the same key returns the original id, no duplicate', async () => {
+      const sender = await account();
+      const recipient = await account();
+      const body = {
+        recipientPublicKey: recipient.publicKey,
+        blob: base64Blob(64),
+        idempotencyKey: 'idem-1',
+      };
+      const first = await request(http)
+        .post('/mailbox/messages')
+        .set('Authorization', `Bearer ${sender.token}`)
+        .send(body)
+        .expect(201);
+      const second = await request(http)
+        .post('/mailbox/messages')
+        .set('Authorization', `Bearer ${sender.token}`)
+        .send(body)
+        .expect(201);
+      expect(second.body.id).toBe(first.body.id);
+
+      const polled = await request(http)
+        .get('/mailbox/messages')
+        .set('Authorization', `Bearer ${recipient.token}`)
+        .expect(200);
+      expect(polled.body.messages).toHaveLength(1);
+    });
+  });
+
+  describe('rejections', () => {
+    it('rejects a post to an unknown recipient with 404 (the existence oracle)', async () => {
+      const sender = await account();
+      await request(http)
+        .post('/mailbox/messages')
+        .set('Authorization', `Bearer ${sender.token}`)
+        .send({ recipientPublicKey: unknownPublicKey(), blob: base64Blob(64), idempotencyKey: 'x' })
+        .expect(404);
+    });
+
+    it('rejects new posts once the per-recipient pending cap is full (reject-new)', async () => {
+      const sender = await account();
+      const recipient = await account();
+      for (let i = 0; i < PENDING_CAP; i += 1) {
+        await request(http)
+          .post('/mailbox/messages')
+          .set('Authorization', `Bearer ${sender.token}`)
+          .send({
+            recipientPublicKey: recipient.publicKey,
+            blob: base64Blob(64),
+            idempotencyKey: `c${i}`,
+          })
+          .expect(201);
+      }
+      await request(http)
+        .post('/mailbox/messages')
+        .set('Authorization', `Bearer ${sender.token}`)
+        .send({
+          recipientPublicKey: recipient.publicKey,
+          blob: base64Blob(64),
+          idempotencyKey: 'over',
+        })
+        .expect(409);
+    });
+
+    it('rejects a blob larger than 8 KiB with 413', async () => {
+      const sender = await account();
+      const recipient = await account();
+      await request(http)
+        .post('/mailbox/messages')
+        .set('Authorization', `Bearer ${sender.token}`)
+        .send({
+          recipientPublicKey: recipient.publicKey,
+          blob: base64Blob(8193),
+          idempotencyKey: 'big',
+        })
+        .expect(413);
+    });
+
+    it('rejects malformed bodies and unexpected properties with 400', async () => {
+      const sender = await account();
+      const recipient = await account();
+      await request(http)
+        .post('/mailbox/messages')
+        .set('Authorization', `Bearer ${sender.token}`)
+        .send({ recipientPublicKey: 'not-hex', blob: base64Blob(16), idempotencyKey: 'x' })
+        .expect(400);
+      await request(http)
+        .post('/mailbox/messages')
+        .set('Authorization', `Bearer ${sender.token}`)
+        .send({
+          recipientPublicKey: recipient.publicKey,
+          blob: 'not base64!!',
+          idempotencyKey: 'x',
+        })
+        .expect(400);
+      await request(http)
+        .post('/mailbox/messages')
+        .set('Authorization', `Bearer ${sender.token}`)
+        .send({
+          recipientPublicKey: recipient.publicKey,
+          blob: base64Blob(16),
+          idempotencyKey: 'x',
+          senderPublicKey: 'never-send-this',
+        })
+        .expect(400);
+    });
+
+    it('requires authentication on every route', async () => {
+      const recipient = await account();
+      await request(http)
+        .post('/mailbox/messages')
+        .send({
+          recipientPublicKey: recipient.publicKey,
+          blob: base64Blob(16),
+          idempotencyKey: 'x',
+        })
+        .expect(401);
+      await request(http).get('/mailbox/messages').expect(401);
+      await request(http).delete('/mailbox/messages/some-id').expect(401);
+    });
+  });
+
+  describe('ownership scoping', () => {
+    it('will not let one account ack another account message', async () => {
+      const sender = await account();
+      const recipient = await account();
+      const attacker = await account();
+      const posted = await request(http)
+        .post('/mailbox/messages')
+        .set('Authorization', `Bearer ${sender.token}`)
+        .send({
+          recipientPublicKey: recipient.publicKey,
+          blob: base64Blob(32),
+          idempotencyKey: 'own',
+        })
+        .expect(201);
+
+      // The attacker ack is idempotent-success but must not delete the row.
+      await request(http)
+        .delete(`/mailbox/messages/${posted.body.id}`)
+        .set('Authorization', `Bearer ${attacker.token}`)
+        .expect(200);
+
+      const stillThere = await request(http)
+        .get('/mailbox/messages')
+        .set('Authorization', `Bearer ${recipient.token}`)
+        .expect(200);
+      expect(stillThere.body.messages).toHaveLength(1);
+    });
+  });
+
+  describe('rate limiting (real 429s)', () => {
+    it('rate-limits the per-sender post surface — including the existence oracle', async () => {
+      const sender = await account();
+      const limit = THROTTLE_SURFACES.mailboxPost.default.limit;
+      // Probe unknown recipients: each is a 404, but the throttler counts them,
+      // so an account cannot brute-force the pubkey existence oracle.
+      for (let i = 0; i < limit; i += 1) {
+        await request(http)
+          .post('/mailbox/messages')
+          .set('Authorization', `Bearer ${sender.token}`)
+          .send({
+            recipientPublicKey: unknownPublicKey(),
+            blob: base64Blob(16),
+            idempotencyKey: `o${i}`,
+          })
+          .expect(404);
+      }
+      const throttled = await request(http)
+        .post('/mailbox/messages')
+        .set('Authorization', `Bearer ${sender.token}`)
+        .send({
+          recipientPublicKey: unknownPublicKey(),
+          blob: base64Blob(16),
+          idempotencyKey: 'last',
+        })
+        .expect(429);
+      expect(throttled.headers['retry-after']).toBeDefined();
+    });
+
+    it('keys the post limit by account: a second sender is unaffected', async () => {
+      const fresh = await account();
+      const recipient = await account();
+      await request(http)
+        .post('/mailbox/messages')
+        .set('Authorization', `Bearer ${fresh.token}`)
+        .send({
+          recipientPublicKey: recipient.publicKey,
+          blob: base64Blob(16),
+          idempotencyKey: 'fresh',
+        })
+        .expect(201);
+    });
+  });
+
+  describe('metrics', () => {
+    it('records the mailbox endpoints in the Prometheus registry', async () => {
+      const sender = await account();
+      const recipient = await account();
+      await request(http)
+        .post('/mailbox/messages')
+        .set('Authorization', `Bearer ${sender.token}`)
+        .send({
+          recipientPublicKey: recipient.publicKey,
+          blob: base64Blob(16),
+          idempotencyKey: 'm',
+        })
+        .expect(201);
+      const res = await request(http).get('/metrics').expect(200);
+      expect(res.text).toMatch(/http_requests_total\{[^}]*route="\/mailbox\/messages"[^}]*\} \d+/);
+    });
+  });
+});

--- a/apps/api/src/mailbox/mailbox.http.test.ts
+++ b/apps/api/src/mailbox/mailbox.http.test.ts
@@ -32,8 +32,14 @@ describe('mailbox HTTP surface', () => {
   let userRepo: FakeRepository<User>;
   let messageRepo: FakeRepository<MailboxMessage>;
   let jwt: JwtService;
+  let priorJwtSecret: string | undefined;
 
   beforeAll(async () => {
+    // The account-keyed throttler only trusts a `sub` from a token it can
+    // verify; align its HS256 secret with the one these tokens are signed with.
+    priorJwtSecret = process.env.JWT_SECRET;
+    process.env.JWT_SECRET = SECRET;
+
     userRepo = new FakeRepository<User>();
     messageRepo = new FakeRepository<MailboxMessage>();
     jwt = new JwtService();
@@ -66,6 +72,11 @@ describe('mailbox HTTP surface', () => {
 
   afterAll(async () => {
     await app.close();
+    if (priorJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = priorJwtSecret;
+    }
   });
 
   /** Seed a user account and mint a valid access token for it. */

--- a/apps/api/src/mailbox/mailbox.module.ts
+++ b/apps/api/src/mailbox/mailbox.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { buildJwtOptions } from '../auth/auth.module';
+import { User } from '../auth/entities/user.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { IdentityService } from '../auth/services/identity.service';
+import { MailboxController } from './mailbox.controller';
+import { MailboxMessage } from './entities/mailbox-message.entity';
+import { MailboxService } from './services/mailbox.service';
+
+/**
+ * The mailbox slice (blueprint/api.md, Mailbox). Reads the users table for
+ * the recipient-existence oracle and provides its own stateless
+ * IdentityService for publicKey normalization. Route auth reuses the auth
+ * slice's JwtAuthGuard and JWT configuration.
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([MailboxMessage, User]),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: buildJwtOptions,
+    }),
+  ],
+  controllers: [MailboxController],
+  providers: [MailboxService, IdentityService, JwtAuthGuard],
+})
+export class MailboxModule {}

--- a/apps/api/src/mailbox/services/mailbox.service.test.ts
+++ b/apps/api/src/mailbox/services/mailbox.service.test.ts
@@ -1,0 +1,286 @@
+import { ConflictException, NotFoundException, PayloadTooLargeException } from '@nestjs/common';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { IdentityService } from '../../auth/services/identity.service';
+import { User } from '../../auth/entities/user.entity';
+import { FakeRepository } from '../../testing/fake-repo';
+import { FakeClock, fakeConfig } from '../../testing/fakes';
+import { MailboxMessage } from '../entities/mailbox-message.entity';
+import { MailboxService } from './mailbox.service';
+
+function newPublicKey(): string {
+  const priv = secp256k1.utils.randomPrivateKey();
+  return Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+}
+
+function base64Blob(bytes: number): string {
+  return Buffer.alloc(bytes, 7).toString('base64');
+}
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+describe('MailboxService', () => {
+  let messages: FakeRepository<MailboxMessage>;
+  let users: FakeRepository<User>;
+  let clock: FakeClock;
+  let service: MailboxService;
+  let recipient: string;
+  let sender: string;
+
+  function build(config: Record<string, string | undefined> = {}) {
+    messages = new FakeRepository<MailboxMessage>();
+    users = new FakeRepository<User>();
+    clock = new FakeClock();
+    service = new MailboxService(
+      messages as never,
+      users as never,
+      new IdentityService(),
+      clock,
+      fakeConfig(config).service
+    );
+  }
+
+  beforeEach(async () => {
+    build({ MAILBOX_PENDING_CAP: '3' });
+    recipient = newPublicKey();
+    sender = newPublicKey();
+    await users.save({ publicKey: recipient } as never);
+  });
+
+  describe('post', () => {
+    it('stores a sealed blob for a known recipient and returns an id', async () => {
+      const { id } = await service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(64),
+        idempotencyKey: 'k1',
+      });
+      expect(id).toBeTruthy();
+      expect(messages.rows).toHaveLength(1);
+      expect(messages.rows[0].recipientPublicKey).toBe(recipient);
+      // The stored blob is the opaque bytes, never a decoded structure.
+      expect(Buffer.isBuffer(messages.rows[0].blob)).toBe(true);
+    });
+
+    it('rejects a post to an unknown recipient (the rate-limited existence oracle)', async () => {
+      await expect(
+        service.post(sender, {
+          recipientPublicKey: newPublicKey(),
+          blob: base64Blob(64),
+          idempotencyKey: 'k1',
+        })
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(messages.rows).toHaveLength(0);
+    });
+
+    it('normalizes an uncompressed recipient key to the account it belongs to', async () => {
+      const priv = secp256k1.utils.randomPrivateKey();
+      const compressed = Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+      const uncompressed = Buffer.from(secp256k1.getPublicKey(priv, false)).toString('hex');
+      await users.save({ publicKey: compressed } as never);
+      const { id } = await service.post(sender, {
+        recipientPublicKey: uncompressed,
+        blob: base64Blob(64),
+        idempotencyKey: 'k1',
+      });
+      expect(id).toBeTruthy();
+      expect(messages.rows.at(-1)?.recipientPublicKey).toBe(compressed);
+    });
+
+    it('is idempotent per sender: a replay returns the original id without a duplicate row', async () => {
+      const first = await service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(64),
+        idempotencyKey: 'dup',
+      });
+      const second = await service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(64),
+        idempotencyKey: 'dup',
+      });
+      expect(second.id).toBe(first.id);
+      expect(messages.rows).toHaveLength(1);
+    });
+
+    it('does not collide idempotency keys across different senders', async () => {
+      const other = newPublicKey();
+      const a = await service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(64),
+        idempotencyKey: 'shared',
+      });
+      const b = await service.post(other, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(64),
+        idempotencyKey: 'shared',
+      });
+      expect(b.id).not.toBe(a.id);
+      expect(messages.rows).toHaveLength(2);
+    });
+
+    it('rejects a blob larger than 8 KiB', async () => {
+      await expect(
+        service.post(sender, {
+          recipientPublicKey: recipient,
+          blob: base64Blob(8193),
+          idempotencyKey: 'big',
+        })
+      ).rejects.toBeInstanceOf(PayloadTooLargeException);
+      expect(messages.rows).toHaveLength(0);
+    });
+
+    it('rejects new posts once the per-recipient pending cap is full (reject-new)', async () => {
+      for (let i = 0; i < 3; i += 1) {
+        await service.post(sender, {
+          recipientPublicKey: recipient,
+          blob: base64Blob(64),
+          idempotencyKey: `k${i}`,
+        });
+      }
+      await expect(
+        service.post(sender, {
+          recipientPublicKey: recipient,
+          blob: base64Blob(64),
+          idempotencyKey: 'overflow',
+        })
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(messages.rows).toHaveLength(3);
+    });
+
+    it('lets an idempotent replay through even when the mailbox is full', async () => {
+      for (let i = 0; i < 3; i += 1) {
+        await service.post(sender, {
+          recipientPublicKey: recipient,
+          blob: base64Blob(64),
+          idempotencyKey: `k${i}`,
+        });
+      }
+      const replay = await service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(64),
+        idempotencyKey: 'k0',
+      });
+      expect(replay.id).toBe(messages.rows[0].id);
+      expect(messages.rows).toHaveLength(3);
+    });
+
+    it('frees cap room by purging entries past the 90-day TTL before counting', async () => {
+      for (let i = 0; i < 3; i += 1) {
+        await service.post(sender, {
+          recipientPublicKey: recipient,
+          blob: base64Blob(64),
+          idempotencyKey: `k${i}`,
+        });
+      }
+      clock.advanceMs(NINETY_DAYS_MS + 1);
+      const fresh = await service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(64),
+        idempotencyKey: 'fresh',
+      });
+      expect(fresh.id).toBeTruthy();
+      // The three expired rows were purged; only the fresh one remains.
+      expect(messages.rows).toHaveLength(1);
+      expect(messages.rows[0].idempotencyScope).not.toBe(messages.rows[0].recipientPublicKey);
+    });
+  });
+
+  describe('poll', () => {
+    it('returns pending messages oldest-first with no sender metadata', async () => {
+      await service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(10),
+        idempotencyKey: 'a',
+      });
+      clock.advanceMs(1000);
+      await service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(20),
+        idempotencyKey: 'b',
+      });
+      const { messages: out } = await service.poll(recipient);
+      expect(out).toHaveLength(2);
+      expect(new Date(out[0].receivedAt).getTime()).toBeLessThan(
+        new Date(out[1].receivedAt).getTime()
+      );
+      // Only id/receivedAt/blob are exposed — nothing identifies the sender.
+      expect(Object.keys(out[0]).sort()).toEqual(['blob', 'id', 'receivedAt']);
+      expect(out[0].blob).toBe(base64Blob(10));
+    });
+
+    it('returns only the polling recipient own messages', async () => {
+      const otherRecipient = newPublicKey();
+      await users.save({ publicKey: otherRecipient } as never);
+      await service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(10),
+        idempotencyKey: 'mine',
+      });
+      await service.post(sender, {
+        recipientPublicKey: otherRecipient,
+        blob: base64Blob(10),
+        idempotencyKey: 'theirs',
+      });
+      const { messages: out } = await service.poll(recipient);
+      expect(out).toHaveLength(1);
+    });
+
+    it('purges and omits messages past the 90-day TTL', async () => {
+      await service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(10),
+        idempotencyKey: 'old',
+      });
+      clock.advanceMs(NINETY_DAYS_MS + 1);
+      await service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(10),
+        idempotencyKey: 'new',
+      });
+      const { messages: out } = await service.poll(recipient);
+      expect(out).toHaveLength(1);
+      expect(messages.rows).toHaveLength(1);
+    });
+
+    it('caps the batch at the configured poll limit', async () => {
+      build({ MAILBOX_PENDING_CAP: '100', MAILBOX_POLL_LIMIT: '2' });
+      await users.save({ publicKey: recipient } as never);
+      for (let i = 0; i < 5; i += 1) {
+        await service.post(sender, {
+          recipientPublicKey: recipient,
+          blob: base64Blob(10),
+          idempotencyKey: `k${i}`,
+        });
+      }
+      const { messages: out } = await service.poll(recipient);
+      expect(out).toHaveLength(2);
+    });
+  });
+
+  describe('ack', () => {
+    it('hard-deletes the message by id for its recipient', async () => {
+      const { id } = await service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(10),
+        idempotencyKey: 'a',
+      });
+      await service.ack(recipient, id);
+      expect(messages.rows).toHaveLength(0);
+    });
+
+    it('will not let one account ack another account message', async () => {
+      const attacker = newPublicKey();
+      const { id } = await service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(10),
+        idempotencyKey: 'a',
+      });
+      await service.ack(attacker, id);
+      // The row survives: ack is scoped to the caller mailbox.
+      expect(messages.rows).toHaveLength(1);
+    });
+
+    it('is idempotent: acking an already-gone id succeeds', async () => {
+      await expect(service.ack(recipient, 'no-such-id')).resolves.toEqual({ success: true });
+    });
+  });
+});

--- a/apps/api/src/mailbox/services/mailbox.service.test.ts
+++ b/apps/api/src/mailbox/services/mailbox.service.test.ts
@@ -1,6 +1,6 @@
 import { ConflictException, NotFoundException, PayloadTooLargeException } from '@nestjs/common';
 import { secp256k1 } from '@noble/curves/secp256k1';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { IdentityService } from '../../auth/services/identity.service';
 import { User } from '../../auth/entities/user.entity';
 import { FakeRepository } from '../../testing/fake-repo';
@@ -178,9 +178,9 @@ describe('MailboxService', () => {
         idempotencyKey: 'fresh',
       });
       expect(fresh.id).toBeTruthy();
-      // The three expired rows were purged; only the fresh one remains.
+      // The three expired rows were purged; only the freshly-posted one remains.
       expect(messages.rows).toHaveLength(1);
-      expect(messages.rows[0].idempotencyScope).not.toBe(messages.rows[0].recipientPublicKey);
+      expect(messages.rows[0].id).toBe(fresh.id);
     });
   });
 
@@ -298,8 +298,18 @@ describe('MailboxService', () => {
       expect(messages.rows).toHaveLength(1);
     });
 
-    it('is idempotent: acking an already-gone id succeeds', async () => {
-      await expect(service.ack(recipient, 'no-such-id')).resolves.toEqual({ success: true });
+    it('is idempotent: acking a well-formed but already-gone id succeeds', async () => {
+      await expect(service.ack(recipient, '00000000-0000-4000-8000-000000000000')).resolves.toEqual(
+        { success: true }
+      );
+    });
+
+    it('returns idempotent success for a malformed id without touching the repo', async () => {
+      // A non-uuid id would make the `uuid`-typed column raise 22P02 → a 500;
+      // the guard short-circuits to success and never issues the delete.
+      const deleteSpy = vi.spyOn(messages, 'delete');
+      await expect(service.ack(recipient, 'not-a-uuid')).resolves.toEqual({ success: true });
+      expect(deleteSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/mailbox/services/mailbox.service.test.ts
+++ b/apps/api/src/mailbox/services/mailbox.service.test.ts
@@ -256,6 +256,25 @@ describe('MailboxService', () => {
     });
   });
 
+  describe('configuration', () => {
+    it('falls back to safe finite bounds when the configured limits are garbage', async () => {
+      // A misconfigured limit must fail closed to the default, never to NaN:
+      // a NaN poll limit slices to [] (and a NaN pending cap fails open, since
+      // `pending >= NaN` is always false). The fallbacks keep both finite.
+      build({ MAILBOX_PENDING_CAP: 'not-a-number', MAILBOX_POLL_LIMIT: 'nope' });
+      await users.save({ publicKey: recipient } as never);
+      for (let i = 0; i < 3; i += 1) {
+        await service.post(sender, {
+          recipientPublicKey: recipient,
+          blob: base64Blob(10),
+          idempotencyKey: `k${i}`,
+        });
+      }
+      const { messages: out } = await service.poll(recipient);
+      expect(out).toHaveLength(3);
+    });
+  });
+
   describe('ack', () => {
     it('hard-deletes the message by id for its recipient', async () => {
       const { id } = await service.post(sender, {

--- a/apps/api/src/mailbox/services/mailbox.service.ts
+++ b/apps/api/src/mailbox/services/mailbox.service.ts
@@ -20,6 +20,14 @@ const MAX_BLOB_BYTES = 8192;
 const TTL_MS = 90 * 24 * 60 * 60 * 1000;
 
 /**
+ * Canonical RFC 4122 UUID — the form `gen_random_uuid()` mints for the id
+ * column. Ids are always server-minted uuids, so any other shape can never
+ * name a row; matching this before the ack delete keeps a malformed id from
+ * reaching the `uuid`-typed column (Postgres would raise 22P02 → a 500).
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
  * Read a positive-integer bound from config, falling back to the default for
  * an unset OR garbage value. Both bounds are DoS controls (the pending cap and
  * the poll batch size), so a misconfigured env var must fail closed to the
@@ -169,6 +177,13 @@ export class MailboxService {
    * leak-free: acking a gone or foreign id succeeds without side effects.
    */
   async ack(recipientPublicKey: string, id: string): Promise<{ success: boolean }> {
+    // A malformed (non-uuid) id can never name a server-minted row, so short
+    // out to the documented idempotent success WITHOUT querying Postgres —
+    // otherwise the `uuid`-typed id column raises 22P02 (invalid input syntax
+    // for uuid) and turns a well-behaved no-op into a 500.
+    if (!UUID_RE.test(id)) {
+      return { success: true };
+    }
     await this.messageRepository.delete({ id, recipientPublicKey });
     return { success: true };
   }

--- a/apps/api/src/mailbox/services/mailbox.service.ts
+++ b/apps/api/src/mailbox/services/mailbox.service.ts
@@ -1,0 +1,173 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+  PayloadTooLargeException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { createHash } from 'node:crypto';
+import { LessThan, QueryFailedError, Repository } from 'typeorm';
+import { User } from '../../auth/entities/user.entity';
+import { IdentityService } from '../../auth/services/identity.service';
+import { Clock } from '../../common/clock';
+import { MailboxMessage } from '../entities/mailbox-message.entity';
+
+/** Spec-fixed hard bound on the sealed blob (blueprint/api.md: <= ~8 KB). */
+const MAX_BLOB_BYTES = 8192;
+
+/** 90-day unacked TTL, aligned with record EOLs (blueprint/api.md, Mailbox). */
+const TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+export interface PostMessageInput {
+  recipientPublicKey: string;
+  blob: string;
+  idempotencyKey: string;
+}
+
+export interface PostMessageResult {
+  id: string;
+}
+
+export interface PolledMessage {
+  id: string;
+  receivedAt: string;
+  blob: string;
+}
+
+/**
+ * The integrity-untrusted mailbox (blueprint/api.md, Mailbox).
+ *
+ * Zero-knowledge: blobs are opaque HPKE-sealed bytes — never decoded, never
+ * logged, never signature-checked (that is client-side). Retention is bounded
+ * until ack: a per-recipient pending cap (reject-new) and a lazily enforced
+ * 90-day TTL, both hard-deletes. Determinism is injected — post time and TTL
+ * cutoffs come from the Clock, never `Date.now()`.
+ */
+@Injectable()
+export class MailboxService {
+  private readonly pendingCap: number;
+  private readonly pollLimit: number;
+
+  constructor(
+    @InjectRepository(MailboxMessage)
+    private readonly messageRepository: Repository<MailboxMessage>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly identityService: IdentityService,
+    private readonly clock: Clock,
+    configService: ConfigService
+  ) {
+    this.pendingCap = Number(configService.get('MAILBOX_PENDING_CAP') ?? 1000);
+    this.pollLimit = Number(configService.get('MAILBOX_POLL_LIMIT') ?? 100);
+  }
+
+  /**
+   * Post a sealed blob to a recipient identity publicKey. The sender is the
+   * authenticated account; only its hash feeds the idempotency scope, so no
+   * durable sender→recipient graph is stored.
+   *
+   * Posts to unknown recipient pubkeys are rejected — the accepted,
+   * rate-limited, exact-pubkey existence oracle (blueprint/api.md). The rate
+   * limit lives at the HTTP edge (per-sender throttle); reaching this check at
+   * all requires a valid access token, so only a real account can probe it.
+   */
+  async post(senderPublicKey: string, input: PostMessageInput): Promise<PostMessageResult> {
+    const recipientPublicKey = this.identityService.normalizePublicKey(input.recipientPublicKey);
+
+    // Validate the payload before touching the oracle: a malformed request
+    // must never learn whether the recipient exists.
+    const blob = Buffer.from(input.blob, 'base64');
+    if (blob.length > MAX_BLOB_BYTES) {
+      throw new PayloadTooLargeException(`Sealed blob exceeds ${MAX_BLOB_BYTES} bytes`);
+    }
+
+    const recipient = await this.userRepository.findOne({
+      where: { publicKey: recipientPublicKey },
+    });
+    if (!recipient) {
+      throw new NotFoundException('Unknown recipient');
+    }
+
+    const idempotencyScope = this.scopeIdempotency(senderPublicKey, input.idempotencyKey);
+
+    // Idempotent replay wins even when the mailbox is full.
+    const existing = await this.messageRepository.findOne({
+      where: { recipientPublicKey, idempotencyScope },
+    });
+    if (existing) {
+      return { id: existing.id };
+    }
+
+    // Expired rows are dead fuel: purge before counting so a full-of-expired
+    // mailbox still accepts new mail (opportunistic housekeeping).
+    await this.purgeExpired(recipientPublicKey);
+
+    const pending = await this.messageRepository.count({ where: { recipientPublicKey } });
+    if (pending >= this.pendingCap) {
+      throw new ConflictException('Recipient mailbox is full');
+    }
+
+    try {
+      const saved = await this.messageRepository.save({
+        recipientPublicKey,
+        idempotencyScope,
+        blob,
+        receivedAt: this.clock.now(),
+      });
+      return { id: saved.id };
+    } catch (error) {
+      // The unique (recipient, idempotencyScope) index is the durable dedup
+      // backstop under a concurrent double-post; re-read and return the winner.
+      if (error instanceof QueryFailedError) {
+        const winner = await this.messageRepository.findOne({
+          where: { recipientPublicKey, idempotencyScope },
+        });
+        if (winner) {
+          return { id: winner.id };
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Poll the caller mailbox: pending messages oldest-first, capped at the
+   * poll limit. No sender metadata is returned in the clear — the sealed
+   * payload carries the owner-signed sender inside.
+   */
+  async poll(recipientPublicKey: string): Promise<{ messages: PolledMessage[] }> {
+    await this.purgeExpired(recipientPublicKey);
+    const rows = await this.messageRepository.find({
+      where: { recipientPublicKey },
+      order: { receivedAt: 'ASC' },
+      take: this.pollLimit,
+    });
+    return {
+      messages: rows.map((row) => ({
+        id: row.id,
+        receivedAt: row.receivedAt.toISOString(),
+        blob: Buffer.from(row.blob).toString('base64'),
+      })),
+    };
+  }
+
+  /**
+   * Ack = hard delete by id, scoped to the caller mailbox (AGENTS.md: never
+   * persist crypto-bearing rows past their consumer). Idempotent and
+   * leak-free: acking a gone or foreign id succeeds without side effects.
+   */
+  async ack(recipientPublicKey: string, id: string): Promise<{ success: boolean }> {
+    await this.messageRepository.delete({ id, recipientPublicKey });
+    return { success: true };
+  }
+
+  private async purgeExpired(recipientPublicKey: string): Promise<void> {
+    const cutoff = new Date(this.clock.now().getTime() - TTL_MS);
+    await this.messageRepository.delete({ recipientPublicKey, receivedAt: LessThan(cutoff) });
+  }
+
+  private scopeIdempotency(senderPublicKey: string, idempotencyKey: string): string {
+    return createHash('sha256').update(`${senderPublicKey}:${idempotencyKey}`).digest('hex');
+  }
+}

--- a/apps/api/src/mailbox/services/mailbox.service.ts
+++ b/apps/api/src/mailbox/services/mailbox.service.ts
@@ -19,6 +19,17 @@ const MAX_BLOB_BYTES = 8192;
 /** 90-day unacked TTL, aligned with record EOLs (blueprint/api.md, Mailbox). */
 const TTL_MS = 90 * 24 * 60 * 60 * 1000;
 
+/**
+ * Read a positive-integer bound from config, falling back to the default for
+ * an unset OR garbage value. Both bounds are DoS controls (the pending cap and
+ * the poll batch size), so a misconfigured env var must fail closed to the
+ * safe default, never silently to NaN (which would disable the cap entirely).
+ */
+function positiveIntConfig(raw: unknown, fallback: number): number {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
 export interface PostMessageInput {
   recipientPublicKey: string;
   blob: string;
@@ -58,8 +69,8 @@ export class MailboxService {
     private readonly clock: Clock,
     configService: ConfigService
   ) {
-    this.pendingCap = Number(configService.get('MAILBOX_PENDING_CAP') ?? 1000);
-    this.pollLimit = Number(configService.get('MAILBOX_POLL_LIMIT') ?? 100);
+    this.pendingCap = positiveIntConfig(configService.get('MAILBOX_PENDING_CAP'), 1000);
+    this.pollLimit = positiveIntConfig(configService.get('MAILBOX_POLL_LIMIT'), 100);
   }
 
   /**

--- a/apps/api/src/migrations/1784519962991-AddMailboxMessages.ts
+++ b/apps/api/src/migrations/1784519962991-AddMailboxMessages.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMailboxMessages1784519962991 implements MigrationInterface {
+  name = 'AddMailboxMessages1784519962991';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "mailbox_messages" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "recipient_public_key" character varying(130) NOT NULL, "idempotency_scope" character varying(64) NOT NULL, "blob" bytea NOT NULL, "received_at" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_865e565d761179ce3e394b8b619" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_mailbox_recipient_received" ON "mailbox_messages" ("recipient_public_key", "received_at") `
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_mailbox_recipient_idempotency" ON "mailbox_messages" ("recipient_public_key", "idempotency_scope") `
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."uq_mailbox_recipient_idempotency"`);
+    await queryRunner.query(`DROP INDEX "public"."idx_mailbox_recipient_received"`);
+    await queryRunner.query(`DROP TABLE "mailbox_messages"`);
+  }
+}

--- a/apps/api/src/ops/account-throttler.guard.test.ts
+++ b/apps/api/src/ops/account-throttler.guard.test.ts
@@ -1,0 +1,74 @@
+import { createHmac } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { verifiedSubjectFromBearer } from './account-throttler.guard';
+
+const SECRET = 'account-throttler-test-secret';
+
+function b64url(value: string | Buffer): string {
+  return Buffer.from(value).toString('base64url');
+}
+
+/** Mint an HS256 JWT signed with `secret`. */
+function token(claims: Record<string, unknown>, secret = SECRET): string {
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = b64url(JSON.stringify(claims));
+  const signature = b64url(createHmac('sha256', secret).update(`${header}.${payload}`).digest());
+  return `${header}.${payload}.${signature}`;
+}
+
+function bearer(value: string): Record<string, unknown> {
+  return { authorization: `Bearer ${value}` };
+}
+
+describe('verifiedSubjectFromBearer', () => {
+  let priorSecret: string | undefined;
+
+  beforeAll(() => {
+    priorSecret = process.env.JWT_SECRET;
+    process.env.JWT_SECRET = SECRET;
+  });
+
+  afterAll(() => {
+    if (priorSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = priorSecret;
+    }
+  });
+
+  it('returns the sub of a token carrying our own HS256 signature', () => {
+    expect(verifiedSubjectFromBearer(bearer(token({ sub: 'user-1' })))).toBe('user-1');
+  });
+
+  it('rejects a token signed with a different secret (no forged-sub bucket)', () => {
+    expect(verifiedSubjectFromBearer(bearer(token({ sub: 'victim' }, 'attacker-secret')))).toBe(
+      undefined
+    );
+  });
+
+  it('rejects a token with a tampered payload (signature no longer matches)', () => {
+    const valid = token({ sub: 'user-1' });
+    const [header, , signature] = valid.split('.');
+    const forgedPayload = b64url(JSON.stringify({ sub: 'someone-else' }));
+    expect(verifiedSubjectFromBearer(bearer(`${header}.${forgedPayload}.${signature}`))).toBe(
+      undefined
+    );
+  });
+
+  it('rejects an unsigned (alg:none-style) token with an empty signature', () => {
+    const header = b64url(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+    const payload = b64url(JSON.stringify({ sub: 'user-1' }));
+    expect(verifiedSubjectFromBearer(bearer(`${header}.${payload}.`))).toBe(undefined);
+  });
+
+  it('returns undefined for a validly-signed token with no sub claim', () => {
+    expect(verifiedSubjectFromBearer(bearer(token({ publicKey: 'abc' })))).toBe(undefined);
+  });
+
+  it('returns undefined when there is no bearer or the header is malformed', () => {
+    expect(verifiedSubjectFromBearer(undefined)).toBe(undefined);
+    expect(verifiedSubjectFromBearer({})).toBe(undefined);
+    expect(verifiedSubjectFromBearer({ authorization: 'Basic abc' })).toBe(undefined);
+    expect(verifiedSubjectFromBearer(bearer('not-a-jwt'))).toBe(undefined);
+  });
+});

--- a/apps/api/src/ops/account-throttler.guard.ts
+++ b/apps/api/src/ops/account-throttler.guard.ts
@@ -1,26 +1,33 @@
 import { Injectable } from '@nestjs/common';
 import { ThrottlerGuard } from '@nestjs/throttler';
+import { createHmac, timingSafeEqual } from 'node:crypto';
 
 /**
- * Global throttler keyed by the authenticated account when present, falling
- * back to the client IP otherwise.
+ * Global throttler keyed by the authenticated account when the bearer carries
+ * a VERIFIED access token, falling back to the client IP otherwise.
  *
  * The blueprint's mailbox limits are per SENDER account (post) and per
  * RECIPIENT mailbox (poll/ack) — both the authenticated account — so the
  * tracker must be the account, not the IP. Buckets are already separated per
  * route+throttler by the base `generateKey`, so this only widens the tracker.
  *
- * The account is read from the bearer's `sub` WITHOUT verification: this is a
- * rate-limit key, not an authorization decision. A forged token cannot exploit
- * it — the route's JwtAuthGuard rejects any unsigned/invalid token with 401
- * before the handler runs, so a forged `sub` can neither store a message nor
- * reach the existence oracle. Unauthenticated routes (auth, health) carry no
- * bearer and keep the base IP tracker unchanged.
+ * Why the signature is checked here even though it is only a rate-limit key,
+ * not an authorization decision: this guard is a global `APP_GUARD`, so it runs
+ * BEFORE the route's `JwtAuthGuard`, and `@nestjs/throttler` increments the
+ * bucket before it would reject. Trusting an UNVERIFIED `sub` would therefore
+ * let a forged, never-authenticated token (i) poison another account's bucket
+ * (counting toward the victim's limit before the 401) and (ii) mint unbounded
+ * distinct tracker keys from a single source — worse than the IP tracker it
+ * replaces. Requiring our own HS256 signature closes both: a token we did not
+ * sign falls back to the IP tracker. (Confidentiality was never at risk — the
+ * route's `JwtAuthGuard` still rejects any unsigned/invalid token with 401, so
+ * a forged `sub` can neither store a message nor reach the existence oracle.)
+ * Unauthenticated routes carry no bearer and keep the base IP tracker.
  */
 @Injectable()
 export class AccountThrottlerGuard extends ThrottlerGuard {
   protected async getTracker(req: Record<string, unknown>): Promise<string> {
-    const subject = subjectFromBearer(req.headers as Record<string, unknown> | undefined);
+    const subject = verifiedSubjectFromBearer(req.headers as Record<string, unknown> | undefined);
     if (subject) {
       return `acct:${subject}`;
     }
@@ -28,7 +35,23 @@ export class AccountThrottlerGuard extends ThrottlerGuard {
   }
 }
 
-function subjectFromBearer(headers: Record<string, unknown> | undefined): string | undefined {
+/** The effective HS256 secret, resolved exactly as `buildJwtOptions` does. */
+function jwtSecret(): string {
+  return process.env.JWT_SECRET ?? 'cipherbox-dev-jwt-secret';
+}
+
+/**
+ * Return the `sub` claim ONLY when the bearer is a well-formed HS256 JWT that
+ * carries our own signature; otherwise `undefined` (so the caller keys by IP).
+ * The header's declared `alg` is never trusted — the signature is always
+ * recomputed as HMAC-SHA256, so `alg: none`/algorithm-confusion cannot forge a
+ * subject. Expiry is intentionally not enforced: a validly-signed-but-expired
+ * token still carries a genuine (non-forgeable) `sub`, which is a correct
+ * rate-limit key; it will still 401 at the route's auth guard.
+ */
+export function verifiedSubjectFromBearer(
+  headers: Record<string, unknown> | undefined
+): string | undefined {
   const authorization = headers?.authorization;
   if (typeof authorization !== 'string' || !authorization.startsWith('Bearer ')) {
     return undefined;
@@ -37,11 +60,22 @@ function subjectFromBearer(headers: Record<string, unknown> | undefined): string
   if (parts.length !== 3) {
     return undefined;
   }
+  const [header, payload, signature] = parts;
+  const expected = createHmac('sha256', jwtSecret()).update(`${header}.${payload}`).digest();
+  let provided: Buffer;
   try {
-    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')) as {
+    provided = Buffer.from(signature, 'base64url');
+  } catch {
+    return undefined;
+  }
+  if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+    return undefined;
+  }
+  try {
+    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as {
       sub?: unknown;
     };
-    return typeof payload.sub === 'string' ? payload.sub : undefined;
+    return typeof claims.sub === 'string' ? claims.sub : undefined;
   } catch {
     return undefined;
   }

--- a/apps/api/src/ops/account-throttler.guard.ts
+++ b/apps/api/src/ops/account-throttler.guard.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+/**
+ * Global throttler keyed by the authenticated account when present, falling
+ * back to the client IP otherwise.
+ *
+ * The blueprint's mailbox limits are per SENDER account (post) and per
+ * RECIPIENT mailbox (poll/ack) — both the authenticated account — so the
+ * tracker must be the account, not the IP. Buckets are already separated per
+ * route+throttler by the base `generateKey`, so this only widens the tracker.
+ *
+ * The account is read from the bearer's `sub` WITHOUT verification: this is a
+ * rate-limit key, not an authorization decision. A forged token cannot exploit
+ * it — the route's JwtAuthGuard rejects any unsigned/invalid token with 401
+ * before the handler runs, so a forged `sub` can neither store a message nor
+ * reach the existence oracle. Unauthenticated routes (auth, health) carry no
+ * bearer and keep the base IP tracker unchanged.
+ */
+@Injectable()
+export class AccountThrottlerGuard extends ThrottlerGuard {
+  protected async getTracker(req: Record<string, unknown>): Promise<string> {
+    const subject = subjectFromBearer(req.headers as Record<string, unknown> | undefined);
+    if (subject) {
+      return `acct:${subject}`;
+    }
+    return super.getTracker(req);
+  }
+}
+
+function subjectFromBearer(headers: Record<string, unknown> | undefined): string | undefined {
+  const authorization = headers?.authorization;
+  if (typeof authorization !== 'string' || !authorization.startsWith('Bearer ')) {
+    return undefined;
+  }
+  const parts = authorization.slice('Bearer '.length).split('.');
+  if (parts.length !== 3) {
+    return undefined;
+  }
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')) as {
+      sub?: unknown;
+    };
+    return typeof payload.sub === 'string' ? payload.sub : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/api/src/ops/ops.module.ts
+++ b/apps/api/src/ops/ops.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
-import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { HealthController } from '../health/health.controller';
+import { AccountThrottlerGuard } from './account-throttler.guard';
 import { MetricsController } from './metrics.controller';
 import { MetricsInterceptor } from './metrics.interceptor';
 import { MetricsService } from './metrics.service';
@@ -13,6 +14,10 @@ import { MetricsService } from './metrics.service';
  * any app importing this module is rate-limited by the global default, with
  * per-surface tightening via @Throttle and explicit @SkipThrottle opt-outs
  * (health, metrics). v1's defect was decorators without an active guard.
+ *
+ * The guard is account-aware (AccountThrottlerGuard): authenticated routes
+ * are keyed by the account so the mailbox's per-sender / per-recipient limits
+ * are literal, while unauthenticated routes keep the IP tracker.
  */
 @Module({
   imports: [
@@ -30,7 +35,7 @@ import { MetricsService } from './metrics.service';
   controllers: [HealthController, MetricsController],
   providers: [
     MetricsService,
-    { provide: APP_GUARD, useClass: ThrottlerGuard },
+    { provide: APP_GUARD, useClass: AccountThrottlerGuard },
     { provide: APP_INTERCEPTOR, useClass: MetricsInterceptor },
   ],
   exports: [MetricsService],

--- a/apps/api/src/ops/throttling.ts
+++ b/apps/api/src/ops/throttling.ts
@@ -11,4 +11,14 @@ export const THROTTLE_SURFACES = {
   auth: { default: { limit: 10, ttl: 60_000 } },
   /** Refresh rotation: chattier than login, still bounded. */
   refresh: { default: { limit: 30, ttl: 60_000 } },
+  /**
+   * Mailbox post: per SENDER account (AccountThrottlerGuard keys by the
+   * authenticated account). This same bucket rate-limits the unknown-recipient
+   * existence oracle — an account can only probe pubkeys at the post rate.
+   */
+  mailboxPost: { default: { limit: 30, ttl: 60_000 } },
+  /** Mailbox poll: per RECIPIENT mailbox; chattier on the sync cadence. */
+  mailboxPoll: { default: { limit: 60, ttl: 60_000 } },
+  /** Mailbox ack: per RECIPIENT mailbox; one delete per delivered message. */
+  mailboxAck: { default: { limit: 120, ttl: 60_000 } },
 } as const;

--- a/apps/api/src/testing/fake-repo.ts
+++ b/apps/api/src/testing/fake-repo.ts
@@ -30,6 +30,36 @@ export class FakeRepository<T extends { id: string }> {
     return this.rows.find((row) => matches(row as Record<string, unknown>, options.where)) ?? null;
   }
 
+  async find(options: {
+    where?: Where;
+    order?: Record<string, 'ASC' | 'DESC'>;
+    take?: number;
+  }): Promise<T[]> {
+    let result = options.where
+      ? this.rows.filter((row) => matches(row as Record<string, unknown>, options.where as Where))
+      : [...this.rows];
+    const order = options.order;
+    if (order) {
+      const [[key, direction]] = Object.entries(order);
+      result = [...result].sort((a, b) => {
+        const av = (a as Record<string, unknown>)[key] as Date | number | string;
+        const bv = (b as Record<string, unknown>)[key] as Date | number | string;
+        const cmp = av < bv ? -1 : av > bv ? 1 : 0;
+        return direction === 'DESC' ? -cmp : cmp;
+      });
+    }
+    return options.take != null ? result.slice(0, options.take) : result;
+  }
+
+  async count(options: { where?: Where } = {}): Promise<number> {
+    if (!options.where) {
+      return this.rows.length;
+    }
+    return this.rows.filter((row) =>
+      matches(row as Record<string, unknown>, options.where as Where)
+    ).length;
+  }
+
   async save(partial: Partial<T>): Promise<T> {
     if (partial.id) {
       const existing = this.rows.find((row) => row.id === partial.id);


### PR DESCRIPTION
Closes #631.

## What this is

The integrity-untrusted **mailbox** (`blueprint/api.md`, Mailbox): a zero-knowledge, swappable transport for one-shot sealed pointers (share pointers, write-rotation root re-points, invite claims, courtesy notifications). Nothing on it is load-bearing for safety.

- `POST /mailbox/messages` — any authenticated account to a recipient identity `publicKey`; body is the HPKE-sealed opaque blob (<= 8 KiB), sender supplies an idempotency key.
- `GET /mailbox/messages` — recipient-authenticated; returns `{ id, receivedAt, blob }`, oldest-first, no sender metadata in the clear.
- `DELETE /mailbox/messages/:id` — ack = hard delete by id, scoped to the caller mailbox.

Retention is bounded until ack: a per-recipient pending cap (reject-new when full) and a lazily enforced 90-day unacked TTL, both hard-deletes. Rate limits are per-sender account (post) and per-recipient mailbox (poll/ack), enforced by a now-**working** global throttler (v1's inert `@Throttle` decorators were a named defect).

Migration `AddMailboxMessages...`; committed OpenAPI regenerated (all three routes, bearer-secured, DTO schemas).

## Design decisions

- **Sender is never stored as a column.** Per-sender idempotency rides `idempotencyScope = sha256(senderPublicKey + ":" + idempotencyKey)`. The sender is blended into a one-way digest, so the durable, server-pivotable sender to recipient graph the blueprint forbids does not sit in the schema — only the transient edge it accepts ("never a durable graph, never key material"). The delimiter is unambiguous (senderPublicKey is hex, idempotencyKey is url-safe), so scopes cannot collide across senders. Note: the one-wayness is contingent on a client invariant — `idempotencyKey` must be a high-entropy per-message random (documented on the DTO/entity); the engine's mailbox client draws it from its RNG seam.
- **Account-keyed throttler as the oracle limiter.** The unknown-recipient rejection is a deliberate, accepted, rate-limited exact-pubkey existence oracle. Since the blueprint's limits are per authenticated account (per sender on post, per recipient on poll/ack), the global throttler keys on the account rather than the client IP. It trusts the `sub` only when the bearer carries our own HS256 signature, else falls back to IP — so a forged token cannot poison another account's bucket or mint tracker keys (see review below). The oracle rate-limit is not bypassable: a forged token 401s at `JwtAuthGuard` before it can probe. Verified live at a real 429.
- **413 on oversize.** A decoded blob over 8 KiB is a 413, checked before the recipient lookup so a malformed request never learns whether the recipient exists.
- **ack = 200.** Idempotent and leak-free: acking a gone or foreign id succeeds (200) without deleting anything it doesn't own.

## Zero-knowledge posture

The server never decodes, logs, inspects, or verifies the blob — it stores opaque bytes (`bytea`) and round-trips them base64; payload signatures are checked client-side. No crypto-bearing row outlives its consumer: ack and TTL are both hard `DELETE`s, no soft-delete column. Confirmed at the DB level in live-verify (exact opaque bytes stored untransformed; 0 rows after ack; no `sender`/`revoked`/`deleted` columns).

## Reviews and triage

Ran a general security sweep, a crypto/privacy review (step 2b — the slice touches the HPKE blob, recipient pubkey, and the existence oracle), a simplify pass, and the CodeRabbit CLI. Net: **3 fixed, 1 filed, rest dismissed.**

**Fixed (this branch, commit `37ac46d75`):**

- **Throttler trusted an unverified JWT `sub`** (crypto review + CodeRabbit, `major`). Because the throttler is a global guard, it runs and increments the bucket before route auth rejects; an unverified `sub` let a forged, never-authenticated token poison another account's bucket or mint unbounded tracker keys from one source (worse than the IP tracker it replaces). Now the `sub` is trusted only when the bearer carries our own HS256 signature (the header's `alg` is never trusted; HMAC is always recomputed), else IP fallback. Confidentiality was never at risk — `JwtAuthGuard` still 401s any invalid token. New unit tests cover forged/tampered/unsigned/no-sub tokens.
- **Config could parse to `NaN`** (crypto review + CodeRabbit, `low`/`minor`). A garbage `MAILBOX_PENDING_CAP` / `MAILBOX_POLL_LIMIT` env value became `NaN`, silently fail-opening the pending-cap DoS control (`pending >= NaN` is always false). Now falls back to the safe default for any non-positive-integer; regression-tested.
- **Privacy-invariant documentation** (crypto review, `medium` doc gap). The entity docstring overstated the anti-graph property as unconditional. It now states the property is contingent on a high-entropy client `idempotencyKey`, with the same note on the DTO field.

**Filed:**

- `#667` — the 90-day TTL is enforced lazily (only on the recipient's own post/poll), so a dormant-yet-alive mailbox keeps expired (opaque-ciphertext) rows past 90 days. Needs a scheduled global sweep = scheduling infrastructure out of this slice's scope. Bounded impact (ciphertext, not key material).

**Dismissed (not material / accepted blueprint tradeoffs):**

- base64 DTO regex accepts non-canonical quartets: no impact — the server is zero-knowledge about blob content and the decoded 8 KiB byte-bound is enforced regardless; malformed base64 only breaks the sender's own client-side unseal.
- "migration not idempotent (`IF NOT EXISTS`)": this is `migration:generate` output; TypeORM records applied migrations and runs each exactly once in a transaction. Plain `CREATE`/`DROP` matches the repo convention (`InitAuthSchema`) and the drift check.
- Same `NaN`-on-garbage pattern in the pre-existing global throttle config (`ops.module.ts`, from the ops baseline, not this slice) — doesn't affect the mailbox oracle (hardcoded per-surface limits); left out of scope.
- Mailbox flooding within the cap (reject-new) and the Sybil-multipliable per-account oracle limit are the blueprint's deliberate semantics (evict-oldest would let a flooder erase real mail; per-account limits are mandated).

## Gates (all green)

- `pnpm --filter @cipherbox/api test` — **77 passed** (43 baseline + 27 mailbox + 6 throttler-verification + 1 config regression).
- Root `pnpm lint`, `pnpm typecheck`, `pnpm build` — clean.
- Migration drift (ci.yml `Migration Drift`): ran the committed migrations against a fresh Postgres, then `migration:generate` — "No changes in database schema were found".
- OpenAPI freshness: regenerated, `git diff --exit-code apps/api/openapi.json` clean.
- **Live end-to-end** against the real API + real Postgres (challenge/login token driving the full flow): post to poll to ack with DB-confirmed hard-delete, idempotency replay (same id, no dup), unknown-recipient 404, pending-cap 409 (+ idempotent replay wins when full), 413 oversize, ownership-scoped ack, 401 on all routes unauthenticated, a **real 429** at the 31st post with `Retry-After`, account-keyed throttle isolation (incl. real-login tokens), and byte-exact zero-knowledge storage/round-trip. 25/25 checks passed against the verified-subject guard.

## Note on the contract suite

The live client to API contract suite is `#625` and has not landed yet. Its intent is covered here at the API-test level (a supertest HTTP suite driving the real Nest app) and by the live-verify run above; the contract-suite rows are owed to `#625`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated mailbox API for sending, polling, and acknowledging sealed messages.
  * Supports idempotent message submission, ordered polling, automatic expiration, and mailbox capacity limits.
  * Added validation for recipients, payload sizes, and request formats.
* **Security & Reliability**
  * Added account-aware rate limiting and authorization safeguards.
  * Added comprehensive coverage for authentication, privacy, throttling, lifecycle, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->