### PR TITLE
chore(ci): add always-reporting desktop build gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,3 +522,26 @@ jobs:
 
       - name: Tauri build (unsigned, no bundle)
         run: pnpm --filter @cipherbox/desktop tauri build --no-bundle
+
+  # Single always-reporting gate for the path-filtered desktop matrix. Branch
+  # protection requires this stable context instead of the per-OS matrix legs:
+  # the matrix legs are only reported when `desktop-build` actually runs (its
+  # paths filter matched), so requiring them directly blocks every PR that does
+  # not touch the desktop paths. This job runs on every PR and passes when the
+  # matrix succeeded or was skipped, failing only on a real desktop-build break.
+  desktop-build-result:
+    name: Desktop Build Result
+    needs: desktop-build
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Require desktop build to pass or be skipped
+        run: |
+          result='${{ needs.desktop-build.result }}'
+          echo "desktop-build result: ${result}"
+          if [ "${result}" = 'failure' ] || [ "${result}" = 'cancelled' ]; then
+            echo "::error::desktop-build ${result}"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,10 +538,11 @@ jobs:
       contents: read
     steps:
       - name: Require desktop build to pass or be skipped
+        env:
+          DESKTOP_BUILD_RESULT: ${{ needs.desktop-build.result }}
         run: |
-          result='${{ needs.desktop-build.result }}'
-          echo "desktop-build result: ${result}"
-          if [ "${result}" = 'failure' ] || [ "${result}" = 'cancelled' ]; then
-            echo "::error::desktop-build ${result}"
+          echo "desktop-build result: ${DESKTOP_BUILD_RESULT}"
+          if [ "${DESKTOP_BUILD_RESULT}" = 'failure' ] || [ "${DESKTOP_BUILD_RESULT}" = 'cancelled' ]; then
+            echo "::error::desktop-build ${DESKTOP_BUILD_RESULT}"
             exit 1
           fi


### PR DESCRIPTION
## Problem

The `desktop-build` matrix in `ci.yml` is path-filtered (`apps/desktop/**`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, `.cargo/config.toml`, `ci.yml`). GitHub only reports the per-OS check contexts `Desktop Build (macos-latest)` / `(ubuntu-latest)` / `(windows-latest)` when that matrix actually runs. When a PR does not touch those paths — any pure-TS api/web slice — the matrix is skipped and those contexts are **never reported**.

Because branch protection required those three matrix-leg contexts, every such PR sat at `mergeStateStatus=BLOCKED` waiting on statuses that would never arrive. `#668` (api mailbox, `apps/api` only) hit this first; every future api/web-only slice would too.

## Fix

Add a `desktop-build-result` gate job that runs on **every** PR (`if: always()`, `needs: desktop-build`) and:

- passes when `desktop-build` **succeeded** or was **skipped**,
- fails only when it **failed** or was **cancelled**.

Branch protection now requires the single stable `Desktop Build Result` context instead of the three matrix legs — keeping the desktop build merge-blocking (`blueprint/testing.md` law 1) without the path-filter deadlock.

## Follow-up

The three `Desktop Build (os)` contexts were removed from branch protection to unblock `#668` immediately; `Desktop Build Result` is registered as required once this merges.
