### PR TITLE
feat: hand-written engine API client, token lifecycle, and contract suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 # v2 PR gate (blueprint/testing.md). Jobs cover what exists: the cargo
-# workspace (incl. the core KAT manifest job, native + WASM) and the TS
-# workspace stubs. The remaining PR-gate suites (packages/client browser
-# suite, contract suite, Windows adapter tests, migration drift, e2e smoke
-# slice) land with their code and must block merges in a named job the day
-# they land (law 1).
+# workspace (incl. the core KAT manifest job, native + WASM), the TS
+# workspace stubs, and the live contract suite against the CI stack. The
+# remaining PR-gate suites (packages/client browser suite, Windows adapter
+# tests, e2e smoke slice) land with their code and must block merges in a
+# named job the day they land (law 1).
 name: CI
 
 on:
@@ -288,12 +288,14 @@ jobs:
 
       # The desktop shell is excluded from the workspace-wide jobs: compiling
       # Tauri needs webkit2gtk system deps on Linux, and the desktop-build job
-      # owns its check/clippy/build on all three platforms.
+      # owns its check/clippy/build on all three platforms. The contract crate
+      # is excluded from the test run below (its tests need the live API stack)
+      # and owns its own lint in the contract-suite job.
       - name: Cargo clippy
-        run: cargo clippy --workspace --exclude cipherbox-desktop --all-targets -- -D warnings
+        run: cargo clippy --workspace --exclude cipherbox-desktop --exclude cipherbox-contract --all-targets -- -D warnings
 
       - name: Cargo test (workspace)
-        run: cargo test --workspace --exclude cipherbox-desktop
+        run: cargo test --workspace --exclude cipherbox-desktop --exclude cipherbox-contract
 
   engine:
     name: Engine Tests
@@ -431,10 +433,10 @@ jobs:
           restore-keys: macos-cargo-
 
       - name: Cargo check (workspace)
-        run: cargo check --workspace --exclude cipherbox-desktop --all-targets
+        run: cargo check --workspace --exclude cipherbox-desktop --exclude cipherbox-contract --all-targets
 
       - name: Cargo test (workspace)
-        run: cargo test --workspace --exclude cipherbox-desktop
+        run: cargo test --workspace --exclude cipherbox-desktop --exclude cipherbox-contract
 
   cargo-windows:
     name: Cargo Check & Test (Windows)
@@ -458,10 +460,145 @@ jobs:
           restore-keys: windows-cargo-
 
       - name: Cargo check (workspace)
-        run: cargo check --workspace --exclude cipherbox-desktop --all-targets
+        run: cargo check --workspace --exclude cipherbox-desktop --exclude cipherbox-contract --all-targets
 
       - name: Cargo test (workspace)
-        run: cargo test --workspace --exclude cipherbox-desktop
+        run: cargo test --workspace --exclude cipherbox-desktop --exclude cipherbox-contract
+
+  # The live contract suite (blueprint/testing.md "The contract suite"): the
+  # sdk-e2e descendant and the sole contract enforcement. It stands up the CI
+  # stack — Postgres, Kubo, the promoted mock-ipns-routing /routing/v1 store,
+  # and the real NestJS API (a second instance in production mode to assert
+  # test-login is hard-blocked) — then runs the engine's hand-written API
+  # client against it. Contract drift fails a test run, not a grep. Runs
+  # whenever Rust or TS changed (the client is Rust, the API is TS).
+  contract-suite:
+    name: Contract Suite
+    needs: [changes, lint]
+    if: |
+      !failure() && !cancelled() &&
+      (needs.changes.outputs.rust == 'true' || needs.changes.outputs.ts == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: cipherbox_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      ipfs:
+        image: ipfs/kubo:v0.42.0
+        ports:
+          - 5001:5001
+          - 8080:8080
+        options: >-
+          --health-cmd "ipfs id"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+          --health-start-period 30s
+    env:
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      DB_DATABASE: cipherbox_test
+      NODE_ENV: test
+      JWT_SECRET: contract-suite-jwt-secret
+      # The client-presented secret must equal the API's TEST_LOGIN_SECRET.
+      TEST_LOGIN_SECRET: contract-suite-secret
+      CONTRACT_API_URL: http://localhost:3000
+      CONTRACT_API_PROD_URL: http://localhost:3100
+      CONTRACT_TEST_LOGIN_SECRET: contract-suite-secret
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: linux-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: linux-cargo-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The contract crate is excluded from the general cargo jobs, so lint it
+      # here.
+      - name: Cargo fmt and clippy (contract crate)
+        run: |
+          cargo fmt -p cipherbox-contract --check
+          cargo clippy -p cipherbox-contract --all-targets -- -D warnings
+
+      # The promoted mock-ipns-routing tool is the hermetic /routing/v1 record
+      # store (blueprint/testing.md). It is not a pnpm workspace member, so it
+      # installs and builds with its own npm.
+      - name: Start the mock /routing/v1 record store
+        run: |
+          cd tools/mock-ipns-routing
+          npm ci
+          npm run build
+          node dist/index.js > /tmp/mock-ipns-routing.log 2>&1 &
+          curl -fsS --retry 30 --retry-connrefused --retry-delay 1 http://localhost:3001/health \
+            || { echo '--- mock-ipns-routing log ---'; cat /tmp/mock-ipns-routing.log; exit 1; }
+
+      - name: Apply migrations to a fresh database
+        run: pnpm --filter @cipherbox/api migration:run
+
+      - name: Build the API
+        run: pnpm --filter @cipherbox/api build
+
+      - name: Boot the API in test and production modes
+        run: |
+          node apps/api/dist/main.js > /tmp/api-test.log 2>&1 &
+          NODE_ENV=production PORT=3100 node apps/api/dist/main.js > /tmp/api-prod.log 2>&1 &
+          curl -fsS --retry 60 --retry-connrefused --retry-delay 1 http://localhost:3000/health \
+            || { echo '--- test-mode API log ---'; cat /tmp/api-test.log; exit 1; }
+          curl -fsS --retry 60 --retry-connrefused --retry-delay 1 http://localhost:3100/health \
+            || { echo '--- production-mode API log ---'; cat /tmp/api-prod.log; exit 1; }
+
+      - name: Run the live contract suite
+        run: cargo test -p cipherbox-contract
+
+  # Single always-reporting gate for the contract suite, mirroring
+  # desktop-build-result: branch protection requires this stable context so a
+  # PR that touches neither Rust nor TS (the suite is skipped) is not blocked
+  # forever, while a real contract-suite failure fails this gate.
+  contract-suite-result:
+    name: Contract Suite Result
+    needs: contract-suite
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Require the contract suite to pass or be skipped
+        env:
+          CONTRACT_SUITE_RESULT: ${{ needs.contract-suite.result }}
+        run: |
+          echo "contract-suite result: ${CONTRACT_SUITE_RESULT}"
+          if [ "${CONTRACT_SUITE_RESULT}" = 'failure' ] || [ "${CONTRACT_SUITE_RESULT}" = 'cancelled' ]; then
+            echo "::error::contract-suite ${CONTRACT_SUITE_RESULT}"
+            exit 1
+          fi
 
   desktop-build:
     name: Desktop Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipherbox-contract"
+version = "0.0.0"
+dependencies = [
+ "cipherbox-engine",
+ "getrandom 0.2.17",
+ "reqwest 0.13.4",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "cipherbox-core"
 version = "0.0.0"
 dependencies = [
@@ -655,10 +666,13 @@ dependencies = [
 name = "cipherbox-engine"
 version = "0.0.0"
 dependencies = [
+ "base64 0.22.1",
  "cipherbox-core",
  "cipherbox-engine",
  "futures-channel",
  "futures-core",
+ "serde",
+ "serde_json",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/wasm",
     "crates/fuse",
     "crates/desktop-seams",
+    "crates/contract",
     "apps/desktop/src-tauri",
 ]
 
@@ -24,6 +25,9 @@ publish = false
 [workspace.dependencies]
 cipherbox-core = { path = "crates/core" }
 cipherbox-engine = { path = "crates/engine" }
+base64 = "0.22"
 futures-channel = "0.3"
 futures-core = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 zeroize = "1"

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "cipherbox-contract"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+# The live contract-test suite (blueprint/testing.md "The contract suite"): the
+# sdk-e2e descendant. It builds the engine's real API client over a production-
+# shaped reqwest Http seam, points it at the CI stack (real NestJS API +
+# Postgres + Kubo + the mock /routing/v1 store), and asserts API-side effects.
+# It is excluded from the general workspace cargo jobs and run only by the
+# merge-blocking `contract-suite` CI job, which stands up that stack.
+
+[dependencies]
+cipherbox-engine.workspace = true
+# featureless reqwest (no TLS backend, matching the tauri resolution): the API
+# is reached over plain http on localhost in CI, so no TLS/OpenSSL is linked.
+reqwest = { version = "0.13", default-features = false }
+getrandom = "0.2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+serde_json.workspace = true

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1,0 +1,151 @@
+//! Production-shaped seam implementations and helpers for the live contract
+//! suite (blueprint/testing.md).
+//!
+//! The tests in `tests/contract.rs` build the engine's real [`ApiClient`] over
+//! [`ReqwestHttp`] (a real HTTP client, the desktop `Http` seam's shape) and
+//! [`MemoryCredentialStore`] (models the OS keychain), point it at the CI
+//! stack, and assert API-side effects. No mocks: contract drift between server
+//! behavior and the hand-written client fails a test run, not a grep.
+
+#![forbid(unsafe_code)]
+
+use std::sync::{Arc, Mutex};
+
+use cipherbox_engine::api::IdentityChallengeSigner;
+use cipherbox_engine::seams::{
+    CredentialStore, Http, HttpMethod, HttpRequest, HttpResponse, SeamError, SeamResult,
+};
+
+/// The desktop-shaped `Http` seam: a real reqwest client. Featureless reqwest
+/// (no TLS backend) is enough — the CI stack is reached over plain http.
+#[derive(Clone, Default)]
+pub struct ReqwestHttp {
+    client: reqwest::Client,
+}
+
+impl ReqwestHttp {
+    /// Builds a client with reqwest defaults.
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+impl Http for ReqwestHttp {
+    async fn send(&self, request: HttpRequest) -> SeamResult<HttpResponse> {
+        let method = match request.method {
+            HttpMethod::Get => reqwest::Method::GET,
+            HttpMethod::Post => reqwest::Method::POST,
+            HttpMethod::Put => reqwest::Method::PUT,
+            HttpMethod::Patch => reqwest::Method::PATCH,
+            HttpMethod::Delete => reqwest::Method::DELETE,
+            HttpMethod::Head => reqwest::Method::HEAD,
+        };
+        let mut builder = self.client.request(method, &request.url);
+        for (name, value) in &request.headers {
+            builder = builder.header(name, value);
+        }
+        if let Some(body) = request.body {
+            builder = builder.body(body);
+        }
+        let response = builder
+            .send()
+            .await
+            .map_err(|error| SeamError::new(format!("reqwest send: {error}")))?;
+        let status = response.status().as_u16();
+        let headers = response
+            .headers()
+            .iter()
+            .map(|(name, value)| {
+                (
+                    name.as_str().to_owned(),
+                    value.to_str().unwrap_or_default().to_owned(),
+                )
+            })
+            .collect();
+        let body = response
+            .bytes()
+            .await
+            .map_err(|error| SeamError::new(format!("reqwest body: {error}")))?
+            .to_vec();
+        Ok(HttpResponse {
+            status,
+            headers,
+            body,
+        })
+    }
+}
+
+/// An in-memory refresh-token store modelling the desktop OS keychain: a token
+/// stored here survives across `ApiClient` calls within one test.
+#[derive(Clone, Default)]
+pub struct MemoryCredentialStore {
+    inner: Arc<Mutex<Option<Vec<u8>>>>,
+}
+
+impl CredentialStore for MemoryCredentialStore {
+    async fn store_refresh_token(&self, refresh_token: &[u8]) -> SeamResult<()> {
+        *self.inner.lock().expect("lock") = Some(refresh_token.to_vec());
+        Ok(())
+    }
+
+    async fn load_refresh_token(&self) -> SeamResult<Option<Vec<u8>>> {
+        Ok(self.inner.lock().expect("lock").clone())
+    }
+
+    async fn clear_refresh_token(&self) -> SeamResult<()> {
+        *self.inner.lock().expect("lock") = None;
+        Ok(())
+    }
+}
+
+/// A fresh random secp256k1 identity signer (crypto lives in core; this loops
+/// over the OS RNG until it draws a valid scalar).
+pub fn random_identity_signer() -> IdentityChallengeSigner {
+    loop {
+        let mut scalar = [0u8; 32];
+        getrandom::getrandom(&mut scalar).expect("os rng");
+        if let Some(signer) = IdentityChallengeSigner::from_scalar(&scalar) {
+            return signer;
+        }
+    }
+}
+
+/// Decode a 64-char hex string into a 32-byte scalar. `None` on any malformed
+/// input.
+pub fn hex_to_scalar(hex: &str) -> Option<[u8; 32]> {
+    if hex.len() != 64 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    for (index, byte) in out.iter_mut().enumerate() {
+        let high = (hex.as_bytes()[index * 2] as char).to_digit(16)?;
+        let low = (hex.as_bytes()[index * 2 + 1] as char).to_digit(16)?;
+        *byte = ((high << 4) | low) as u8;
+    }
+    Some(out)
+}
+
+/// The API base URL for the live stack, from `CONTRACT_API_URL`. When unset the
+/// suite skips (there is no stack to hit); the merge-blocking CI job always
+/// sets it, so the assertions always run there.
+pub fn api_url() -> Option<String> {
+    non_empty("CONTRACT_API_URL")
+}
+
+/// The base URL of a second API instance booted in production mode, from
+/// `CONTRACT_API_PROD_URL`, used to assert test-login is hard-blocked in
+/// production. Optional locally; set by the CI job.
+pub fn prod_api_url() -> Option<String> {
+    non_empty("CONTRACT_API_PROD_URL")
+}
+
+/// The shared test-login secret; must equal the API's `TEST_LOGIN_SECRET`.
+pub fn test_login_secret() -> String {
+    std::env::var("CONTRACT_TEST_LOGIN_SECRET").unwrap_or_else(|_| "contract-suite-secret".into())
+}
+
+fn non_empty(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|value| !value.is_empty())
+}

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -10,6 +10,7 @@
 #![forbid(unsafe_code)]
 
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use cipherbox_engine::api::IdentityChallengeSigner;
 use cipherbox_engine::seams::{
@@ -24,10 +25,14 @@ pub struct ReqwestHttp {
 }
 
 impl ReqwestHttp {
-    /// Builds a client with reqwest defaults.
+    /// Builds a client with a finite total request timeout so a hung CI stack
+    /// fails the suite instead of blocking it forever.
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .expect("build reqwest client"),
         }
     }
 }

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -1,0 +1,258 @@
+//! The live contract suite — the engine's hand-written API client exercised
+//! against a real NestJS API on the CI stack (blueprint/testing.md).
+//!
+//! Coverage mirrors api.md surface for surface, over the auth/token surface
+//! that exists server-side today (#624): challenge-signature login and account
+//! identity, refresh rotation with reuse detection, test-login environment
+//! gating + deterministic keypair + cross-consistency with identity login,
+//! SIWE secondary surface, logout revocation, and a raw endpoint round-trip.
+//!
+//! Each test skips (loudly) when `CONTRACT_API_URL` is unset — there is no
+//! stack to hit locally. The merge-blocking `contract-suite` CI job always
+//! sets it (and boots the stack), so the assertions always run there.
+
+use cipherbox_contract::{
+    MemoryCredentialStore, ReqwestHttp, api_url, hex_to_scalar, prod_api_url,
+    random_identity_signer, test_login_secret,
+};
+use cipherbox_engine::api::{ApiClient, ApiError, IdentityChallengeSigner};
+use cipherbox_engine::seams::{CredentialStore, Http, HttpMethod, HttpRequest};
+
+type Client = ApiClient<ReqwestHttp, MemoryCredentialStore>;
+
+fn new_client(base: &str) -> Client {
+    ApiClient::new(ReqwestHttp::new(), MemoryCredentialStore::default(), base)
+}
+
+fn client_with_store(base: &str) -> (Client, MemoryCredentialStore) {
+    let store = MemoryCredentialStore::default();
+    let client = ApiClient::new(ReqwestHttp::new(), store.clone(), base);
+    (client, store)
+}
+
+async fn client_seeded_with(base: &str, refresh_token: &[u8]) -> Client {
+    let store = MemoryCredentialStore::default();
+    store
+        .store_refresh_token(refresh_token)
+        .await
+        .expect("seed the store");
+    ApiClient::new(ReqwestHttp::new(), store, base)
+}
+
+macro_rules! require_stack {
+    ($name:literal) => {
+        match api_url() {
+            Some(base) => base,
+            None => {
+                eprintln!(
+                    "SKIP {}: set CONTRACT_API_URL to run the contract suite against a live stack",
+                    $name
+                );
+                return;
+            }
+        }
+    };
+}
+
+#[tokio::test]
+async fn api_health_round_trips() {
+    let base = require_stack!("api_health_round_trips");
+    let http = ReqwestHttp::new();
+    let response = http
+        .send(HttpRequest {
+            method: HttpMethod::Get,
+            url: format!("{base}/health"),
+            headers: Vec::new(),
+            body: None,
+        })
+        .await
+        .expect("health request");
+    assert_eq!(response.status, 200);
+    let body: serde_json::Value = serde_json::from_slice(&response.body).expect("health json");
+    assert_eq!(body["status"], "ok");
+}
+
+#[tokio::test]
+async fn challenge_signature_login_creates_and_reuses_the_account() {
+    let base = require_stack!("challenge_signature_login_creates_and_reuses_the_account");
+    let signer = random_identity_signer();
+
+    let first = new_client(&base);
+    let outcome = first.login_identity(&signer).await.expect("identity login");
+    assert!(outcome.is_new_user, "a fresh random key creates an account");
+    assert!(first.is_authenticated());
+
+    // The same identity key is the same account on a second, independent client.
+    let second = new_client(&base);
+    let outcome = second
+        .login_identity(&signer)
+        .await
+        .expect("second identity login");
+    assert!(!outcome.is_new_user, "same identity key is one account");
+}
+
+#[tokio::test]
+async fn refresh_rotates_and_reuse_kills_the_family() {
+    let base = require_stack!("refresh_rotates_and_reuse_kills_the_family");
+    let (client, store) = client_with_store(&base);
+    client
+        .login_identity(&random_identity_signer())
+        .await
+        .expect("login");
+
+    let original = store
+        .load_refresh_token()
+        .await
+        .expect("load")
+        .expect("a token after login");
+    client.refresh().await.expect("refresh");
+    let rotated = store
+        .load_refresh_token()
+        .await
+        .expect("load")
+        .expect("a token after refresh");
+    assert_ne!(original, rotated, "refresh rotates the token");
+
+    // Replaying the already-used original triggers reuse detection: the whole
+    // family is revoked, so even the rotated token now fails.
+    let replay = client_seeded_with(&base, &original).await;
+    assert!(
+        matches!(replay.refresh().await, Err(ApiError::Unauthorized)),
+        "a reused refresh token is rejected"
+    );
+    assert!(
+        matches!(client.refresh().await, Err(ApiError::Unauthorized)),
+        "reuse detection revoked the whole family"
+    );
+}
+
+#[tokio::test]
+async fn test_login_gates_the_secret_and_derives_a_stable_keypair() {
+    let base = require_stack!("test_login_gates_the_secret_and_derives_a_stable_keypair");
+    let secret = test_login_secret();
+    let handle = "contract-suite-user";
+
+    // A wrong secret is rejected (the secret gate is live).
+    let wrong = new_client(&base);
+    assert!(
+        matches!(
+            wrong
+                .test_login(handle, "definitely-the-wrong-secret")
+                .await,
+            Err(ApiError::Unauthorized)
+        ),
+        "a wrong test-login secret is rejected"
+    );
+
+    // The right secret returns a deterministic keypair.
+    let client = new_client(&base);
+    let first = client
+        .test_login(handle, &secret)
+        .await
+        .expect("test login");
+    assert_eq!(
+        first.public_key.len(),
+        66,
+        "compressed secp256k1 public key"
+    );
+    assert!(client.is_authenticated());
+
+    let again = new_client(&base)
+        .test_login(handle, &secret)
+        .await
+        .expect("second test login");
+    assert_eq!(first.public_key, again.public_key, "same handle, same key");
+    assert_eq!(&*first.private_key, &*again.private_key);
+    assert!(!again.is_new_user, "the account already existed");
+
+    // The returned private key really is this account's identity key: a
+    // challenge-signature login with it lands on the same account.
+    let scalar = hex_to_scalar(&first.private_key).expect("valid private key hex");
+    let signer = IdentityChallengeSigner::from_scalar(&scalar).expect("valid scalar");
+    let identity = new_client(&base)
+        .login_identity(&signer)
+        .await
+        .expect("identity login with the test key");
+    assert!(
+        !identity.is_new_user,
+        "the test-login keypair is the same account as challenge-signature login"
+    );
+}
+
+#[tokio::test]
+async fn test_login_is_hard_blocked_in_production() {
+    let Some(prod) = prod_api_url() else {
+        eprintln!(
+            "SKIP test_login_is_hard_blocked_in_production: set CONTRACT_API_PROD_URL to a \
+             production-mode API instance"
+        );
+        return;
+    };
+    let client = new_client(&prod);
+    assert!(
+        matches!(
+            client
+                .test_login("contract-suite-user", &test_login_secret())
+                .await,
+            Err(ApiError::Forbidden)
+        ),
+        "production mode must refuse test-login regardless of the secret"
+    );
+}
+
+#[tokio::test]
+async fn siwe_secondary_surface_is_reachable_and_gated() {
+    let base = require_stack!("siwe_secondary_surface_is_reachable_and_gated");
+    let client = new_client(&base);
+
+    // The nonce endpoint issues a fresh nonce.
+    let nonce = client.siwe_challenge().await.expect("siwe nonce");
+    assert!(!nonce.nonce.is_empty(), "a nonce is issued");
+
+    // A well-formed-but-unlinked SIWE login is refused (the wallet is not
+    // linked to any account). The signature is shaped to pass DTO validation
+    // (65-byte 0x-hex) so the request reaches the SIWE service.
+    let message = format!(
+        "localhost:5173 wants you to sign in with your Ethereum account:\n\
+         0x0000000000000000000000000000000000000000\n\nNonce: {}\n",
+        nonce.nonce
+    );
+    let signature = format!("0x{}", "ab".repeat(65));
+    let error = client
+        .siwe_login(&message, &signature)
+        .await
+        .expect_err("an unlinked SIWE login must fail");
+    assert!(
+        matches!(error, ApiError::Unauthorized | ApiError::Status { .. }),
+        "unlinked/invalid SIWE is refused, got {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn logout_revokes_the_refresh_token_server_side() {
+    let base = require_stack!("logout_revokes_the_refresh_token_server_side");
+    let (client, store) = client_with_store(&base);
+    client
+        .login_identity(&random_identity_signer())
+        .await
+        .expect("login");
+    let token = store
+        .load_refresh_token()
+        .await
+        .expect("load")
+        .expect("a token after login");
+
+    client.logout().await.expect("logout");
+    assert!(!client.is_authenticated());
+    assert!(
+        store.load_refresh_token().await.expect("load").is_none(),
+        "logout clears the local refresh token"
+    );
+
+    // The server hard-deleted every refresh token: the old one no longer works.
+    let replay = client_seeded_with(&base, &token).await;
+    assert!(
+        matches!(replay.refresh().await, Err(ApiError::Unauthorized)),
+        "logout revoked the refresh token server-side"
+    );
+}

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -15,9 +15,12 @@ publish.workspace = true
 test-kit = []
 
 [dependencies]
+base64.workspace = true
 cipherbox-core.workspace = true
 futures-channel.workspace = true
 futures-core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]

--- a/crates/engine/src/api/client.rs
+++ b/crates/engine/src/api/client.rs
@@ -1,0 +1,981 @@
+//! The hand-written API client (blueprint/engine.md "API client").
+//!
+//! One client, shared by web and desktop, over the [`Http`] seam — no
+//! generated clients anywhere (#28 D5). It owns the token lifecycle: the
+//! short-lived access JWT lives in engine memory (never persisted), the
+//! rotating refresh token persists per platform through [`CredentialStore`]
+//! (HTTP-only cookie on web via the Http seam, OS keychain on desktop).
+//! Refresh is single-flight with one retry-then-fail on 401.
+
+use core::cell::RefCell;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use futures_channel::oneshot;
+use serde::Serialize;
+use zeroize::Zeroizing;
+
+use super::error::ApiError;
+use super::signer::ChallengeSigner;
+use super::types::{
+    ChallengeRequest, ChallengeResponse, ErrorBody, LoginOutcome, LoginRequest, MailboxItem,
+    MailboxItemWire, NameRegistration, Quota, RefreshRequest, SiweChallengeResponse,
+    SiweLoginRequest, SiweNonce, TestLoginOutcome, TestLoginRequest, TestLoginResponse,
+    TokenResponse, UploadResult,
+};
+use crate::seams::{CredentialStore, Http, HttpMethod, HttpRequest, HttpResponse};
+
+const CONTENT_TYPE: &str = "Content-Type";
+const AUTHORIZATION: &str = "Authorization";
+const APPLICATION_JSON: &str = "application/json";
+const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";
+
+/// Mutable client state, single-owner behind a [`RefCell`]: the engine is the
+/// single writer (blueprint/engine.md Facade), so interior mutability with no
+/// borrow held across an `await` is sufficient — no lock is needed.
+struct State {
+    /// The short-lived access JWT, in memory only. Zeroized on replacement/drop.
+    access_token: Option<Zeroizing<String>>,
+    /// Waiters coalesced behind the one in-flight refresh (single-flight).
+    /// `Some(vec)` means a refresh is in progress; the leader owns the vec and
+    /// notifies every waiter with a clone of the result when it finishes.
+    refresh_waiters: Option<Vec<oneshot::Sender<Result<(), ApiError>>>>,
+}
+
+/// The engine's single API client. Generic over the two seams it drives so the
+/// contract suite can point it at a real HTTP stack while unit tests drive it
+/// with the scripted fake.
+pub struct ApiClient<H: Http, C: CredentialStore> {
+    http: H,
+    credentials: C,
+    base_url: String,
+    state: RefCell<State>,
+}
+
+impl<H: Http, C: CredentialStore> ApiClient<H, C> {
+    /// Builds a client over the Http and CredentialStore seams against an API
+    /// base URL (any trailing slash is trimmed).
+    pub fn new(http: H, credentials: C, base_url: impl Into<String>) -> Self {
+        let mut base = base_url.into();
+        while base.ends_with('/') {
+            base.pop();
+        }
+        Self {
+            http,
+            credentials,
+            base_url: base,
+            state: RefCell::new(State {
+                access_token: None,
+                refresh_waiters: None,
+            }),
+        }
+    }
+
+    /// The API base URL, without a trailing slash.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Whether an access token is currently held in memory.
+    pub fn is_authenticated(&self) -> bool {
+        self.state.borrow().access_token.is_some()
+    }
+
+    // --- auth: identity, SIWE, test-login, refresh, logout ---
+
+    /// Engine-native challenge-signature login: request a challenge for the
+    /// signer's identity key, sign it, and exchange it for tokens. Creates the
+    /// account implicitly at first login (`is_new_user`).
+    pub async fn login_identity(
+        &self,
+        signer: &impl ChallengeSigner,
+    ) -> Result<LoginOutcome, ApiError> {
+        let public_key = signer.public_key_hex();
+        let challenge = {
+            let response = self
+                .post_json(
+                    "/auth/challenge",
+                    &ChallengeRequest {
+                        public_key: &public_key,
+                    },
+                )
+                .await?;
+            let response = ok_or_err(response)?;
+            let body: ChallengeResponse = decode(&response)?;
+            body.challenge
+        };
+        let signature = signer.sign_challenge(&challenge);
+        let response = self
+            .post_json(
+                "/auth/login",
+                &LoginRequest {
+                    public_key: &public_key,
+                    challenge: &challenge,
+                    signature: &signature,
+                },
+            )
+            .await?;
+        let response = ok_or_err(response)?;
+        let tokens: TokenResponse = decode(&response)?;
+        let is_new_user = tokens.is_new_user.unwrap_or(false);
+        self.store_tokens(tokens.access_token, tokens.refresh_token)
+            .await?;
+        Ok(LoginOutcome { is_new_user })
+    }
+
+    /// Issue a single-use SIWE nonce to embed in an EIP-4361 message.
+    pub async fn siwe_challenge(&self) -> Result<SiweNonce, ApiError> {
+        let request = HttpRequest {
+            method: HttpMethod::Post,
+            url: self.url("/auth/siwe/challenge"),
+            headers: Vec::new(),
+            body: None,
+        };
+        let response = ok_or_err(self.http.send(request).await?)?;
+        let body: SiweChallengeResponse = decode(&response)?;
+        Ok(SiweNonce {
+            nonce: body.nonce,
+            expires_at: body.expires_at,
+        })
+    }
+
+    /// SIWE wallet login (secondary method). The host collects the wallet
+    /// signature and the engine exchanges it here; the wallet must already be
+    /// linked to an account.
+    pub async fn siwe_login(
+        &self,
+        message: &str,
+        signature: &str,
+    ) -> Result<LoginOutcome, ApiError> {
+        let response = self
+            .post_json("/auth/siwe/login", &SiweLoginRequest { message, signature })
+            .await?;
+        let response = ok_or_err(response)?;
+        let tokens: TokenResponse = decode(&response)?;
+        let is_new_user = tokens.is_new_user.unwrap_or(false);
+        self.store_tokens(tokens.access_token, tokens.refresh_token)
+            .await?;
+        Ok(LoginOutcome { is_new_user })
+    }
+
+    /// Link a SIWE wallet to the authenticated account (owner-authenticated).
+    pub async fn siwe_link(&self, message: &str, signature: &str) -> Result<(), ApiError> {
+        let body = to_json(&SiweLoginRequest { message, signature });
+        let response = self
+            .request_authed(
+                HttpMethod::Post,
+                "/auth/siwe/link",
+                Some(APPLICATION_JSON),
+                Some(body),
+            )
+            .await?;
+        ok_or_err(response).map(drop)
+    }
+
+    /// Staging-gated deterministic login for e2e. The API hard-blocks this in
+    /// production and when `TEST_LOGIN_SECRET` is unset; those surface as
+    /// [`ApiError::Forbidden`], a wrong secret as [`ApiError::Unauthorized`].
+    pub async fn test_login(
+        &self,
+        handle: &str,
+        secret: &str,
+    ) -> Result<TestLoginOutcome, ApiError> {
+        let response = self
+            .post_json("/auth/test-login", &TestLoginRequest { handle, secret })
+            .await?;
+        let response = ok_or_err(response)?;
+        let body: TestLoginResponse = decode(&response)?;
+        let outcome = TestLoginOutcome {
+            is_new_user: body.is_new_user.unwrap_or(false),
+            public_key: body.public_key,
+            private_key: Zeroizing::new(body.private_key),
+        };
+        self.store_tokens(body.access_token, body.refresh_token)
+            .await?;
+        Ok(outcome)
+    }
+
+    /// Rotate the refresh token. Single-flight: a concurrent caller awaits the
+    /// in-flight rotation instead of spending its own (already-invalidated)
+    /// token. On failure the local session is torn down.
+    pub async fn refresh(&self) -> Result<(), ApiError> {
+        let receiver = {
+            let mut state = self.state.borrow_mut();
+            match state.refresh_waiters.as_mut() {
+                // A refresh is already running: enqueue and await its result.
+                Some(waiters) => {
+                    let (tx, rx) = oneshot::channel();
+                    waiters.push(tx);
+                    Some(rx)
+                }
+                // We are the leader: mark a refresh in progress and run it.
+                None => {
+                    state.refresh_waiters = Some(Vec::new());
+                    None
+                }
+            }
+        };
+
+        if let Some(rx) = receiver {
+            return match rx.await {
+                Ok(result) => result,
+                Err(oneshot::Canceled) => Err(ApiError::Unauthorized),
+            };
+        }
+
+        let result = self.do_refresh().await;
+        let waiters = self
+            .state
+            .borrow_mut()
+            .refresh_waiters
+            .take()
+            .unwrap_or_default();
+        for tx in waiters {
+            let _ = tx.send(result.clone());
+        }
+        result
+    }
+
+    /// Revoke every refresh token server-side and tear down the local session.
+    pub async fn logout(&self) -> Result<(), ApiError> {
+        let response = self
+            .request_authed(HttpMethod::Post, "/auth/logout", None, None)
+            .await?;
+        let result = ok_or_err(response).map(drop);
+        self.clear_session().await?;
+        result
+    }
+
+    // --- pin/name registry, quota, content, mailbox, recovery, account ---
+    // Provisional until the matching API slices land (see types.rs).
+
+    /// Batch register names (`[{ipnsName, headCid?, contentCids[]}]`).
+    /// Register-first ordering is the publish pipeline's concern, not the
+    /// caller's; this is the raw endpoint.
+    pub async fn register(&self, names: &[NameRegistration]) -> Result<(), ApiError> {
+        let body = to_json(names);
+        let response = self
+            .request_authed(
+                HttpMethod::Post,
+                "/registry/register",
+                Some(APPLICATION_JSON),
+                Some(body),
+            )
+            .await?;
+        ok_or_err(response).map(drop)
+    }
+
+    /// Batch retire names or CIDs (`[ipnsName | cid]`).
+    pub async fn retire(&self, targets: &[String]) -> Result<(), ApiError> {
+        let body = to_json(targets);
+        let response = self
+            .request_authed(
+                HttpMethod::Post,
+                "/registry/retire",
+                Some(APPLICATION_JSON),
+                Some(body),
+            )
+            .await?;
+        ok_or_err(response).map(drop)
+    }
+
+    /// The per-account quota (advisory for BYO accounts).
+    pub async fn quota(&self) -> Result<Quota, ApiError> {
+        let response = self
+            .request_authed(HttpMethod::Get, "/account/quota", None, None)
+            .await?;
+        let response = ok_or_err(response)?;
+        decode(&response)
+    }
+
+    /// Upload content bytes to the hosted pin store.
+    pub async fn upload(&self, content: &[u8]) -> Result<UploadResult, ApiError> {
+        let response = self
+            .request_authed(
+                HttpMethod::Post,
+                "/content/upload",
+                Some(APPLICATION_OCTET_STREAM),
+                Some(content.to_vec()),
+            )
+            .await?;
+        let response = ok_or_err(response)?;
+        decode(&response)
+    }
+
+    /// Post a sealed blob to a recipient's mailbox with an idempotency key.
+    pub async fn mailbox_post(
+        &self,
+        recipient_public_key: &str,
+        blob: &[u8],
+        idempotency_key: &str,
+    ) -> Result<(), ApiError> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Body<'a> {
+            recipient_public_key: &'a str,
+            blob: String,
+            idempotency_key: &'a str,
+        }
+        let body = to_json(&Body {
+            recipient_public_key,
+            blob: BASE64.encode(blob),
+            idempotency_key,
+        });
+        let response = self
+            .request_authed(
+                HttpMethod::Post,
+                "/mailbox",
+                Some(APPLICATION_JSON),
+                Some(body),
+            )
+            .await?;
+        ok_or_err(response).map(drop)
+    }
+
+    /// Poll pending mailbox items, decoding each sealed blob from base64.
+    pub async fn mailbox_poll(&self) -> Result<Vec<MailboxItem>, ApiError> {
+        let response = self
+            .request_authed(HttpMethod::Get, "/mailbox", None, None)
+            .await?;
+        let response = ok_or_err(response)?;
+        let wire: Vec<MailboxItemWire> = decode(&response)?;
+        wire.into_iter()
+            .map(|item| {
+                let blob = BASE64
+                    .decode(item.blob.as_bytes())
+                    .map_err(|error| ApiError::Decode(format!("mailbox blob base64: {error}")))?;
+                Ok(MailboxItem {
+                    id: item.id,
+                    received_at: item.received_at,
+                    blob,
+                })
+            })
+            .collect()
+    }
+
+    /// Ack (delete) a mailbox item by id.
+    pub async fn mailbox_ack(&self, id: &str) -> Result<(), ApiError> {
+        let response = self
+            .request_authed(HttpMethod::Delete, &format!("/mailbox/{id}"), None, None)
+            .await?;
+        ok_or_err(response).map(drop)
+    }
+
+    /// Fetch cached (possibly expired) record bytes for a name — the revival
+    /// aid after a >EOL lapse. Returns the raw record bytes.
+    pub async fn recovery_fetch(&self, ipns_name: &str) -> Result<Vec<u8>, ApiError> {
+        let response = self
+            .request_authed(
+                HttpMethod::Get,
+                &format!("/recovery/{ipns_name}"),
+                None,
+                None,
+            )
+            .await?;
+        let response = ok_or_err(response)?;
+        Ok(response.body)
+    }
+
+    /// Toggle the account's BYO (bring-your-own IPFS) flag.
+    pub async fn set_byo(&self, enabled: bool) -> Result<(), ApiError> {
+        #[derive(Serialize)]
+        struct Body {
+            byo: bool,
+        }
+        let body = to_json(&Body { byo: enabled });
+        let response = self
+            .request_authed(
+                HttpMethod::Patch,
+                "/account/byo",
+                Some(APPLICATION_JSON),
+                Some(body),
+            )
+            .await?;
+        ok_or_err(response).map(drop)
+    }
+
+    /// Immediate account hard-delete, then tear down the local session.
+    pub async fn delete_account(&self) -> Result<(), ApiError> {
+        let response = self
+            .request_authed(HttpMethod::Delete, "/account", None, None)
+            .await?;
+        let result = ok_or_err(response).map(drop);
+        self.clear_session().await?;
+        result
+    }
+
+    // --- internals ---
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+
+    /// POST a JSON body without authentication (the challenge/login/refresh
+    /// surface).
+    async fn post_json<B: Serialize>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<HttpResponse, ApiError> {
+        let request = HttpRequest {
+            method: HttpMethod::Post,
+            url: self.url(path),
+            headers: vec![(CONTENT_TYPE.to_owned(), APPLICATION_JSON.to_owned())],
+            body: Some(to_json(body)),
+        };
+        Ok(self.http.send(request).await?)
+    }
+
+    /// Send an authenticated request with one refresh-then-retry on 401.
+    async fn request_authed(
+        &self,
+        method: HttpMethod,
+        path: &str,
+        content_type: Option<&str>,
+        body: Option<Vec<u8>>,
+    ) -> Result<HttpResponse, ApiError> {
+        let first = self
+            .send_with_token(method, path, content_type, body.clone())
+            .await?;
+        if first.status != 401 {
+            return Ok(first);
+        }
+        // One refresh, then one retry; a second 401 is terminal (the caller
+        // maps it via `ok_or_err`).
+        self.refresh().await?;
+        self.send_with_token(method, path, content_type, body).await
+    }
+
+    /// Send a request, attaching the in-memory access token as a bearer when
+    /// one is held. When none is held the request goes out unauthenticated —
+    /// the server's 401 then drives the refresh path (which covers a web
+    /// reload where only the HTTP-only cookie survives).
+    async fn send_with_token(
+        &self,
+        method: HttpMethod,
+        path: &str,
+        content_type: Option<&str>,
+        body: Option<Vec<u8>>,
+    ) -> Result<HttpResponse, ApiError> {
+        let mut headers = Vec::new();
+        if let Some(content_type) = content_type {
+            headers.push((CONTENT_TYPE.to_owned(), content_type.to_owned()));
+        }
+        // Scope the borrow so it never crosses the await below.
+        if let Some(token) = self.state.borrow().access_token.as_ref() {
+            headers.push((
+                AUTHORIZATION.to_owned(),
+                format!("Bearer {}", token.as_str()),
+            ));
+        }
+        let request = HttpRequest {
+            method,
+            url: self.url(path),
+            headers,
+            body,
+        };
+        Ok(self.http.send(request).await?)
+    }
+
+    /// The refresh rotation itself (only the single-flight leader runs this).
+    async fn do_refresh(&self) -> Result<(), ApiError> {
+        let stored = self.credentials.load_refresh_token().await?;
+        let refresh_token = match stored {
+            Some(bytes) => Some(
+                String::from_utf8(bytes)
+                    .map_err(|_| ApiError::Decode("stored refresh token is not utf-8".into()))?,
+            ),
+            // Web: no stored token — the HTTP-only cookie rides the Http seam.
+            None => None,
+        };
+        let response = self
+            .post_json("/auth/refresh", &RefreshRequest { refresh_token })
+            .await?;
+        if !is_success(response.status) {
+            // Session is dead: drop the stale access + refresh material so it
+            // is never replayed.
+            self.clear_session().await?;
+            return Err(error_from_response(&response));
+        }
+        let tokens: TokenResponse = decode(&response)?;
+        self.store_tokens(tokens.access_token, tokens.refresh_token)
+            .await
+    }
+
+    /// Persist the refresh token and hold the access token in memory. The
+    /// refresh string is zeroized once handed to the store.
+    async fn store_tokens(
+        &self,
+        access_token: String,
+        refresh_token: String,
+    ) -> Result<(), ApiError> {
+        let refresh_token = Zeroizing::new(refresh_token);
+        self.credentials
+            .store_refresh_token(refresh_token.as_bytes())
+            .await?;
+        self.state.borrow_mut().access_token = Some(Zeroizing::new(access_token));
+        Ok(())
+    }
+
+    /// Drop the in-memory access token and any persisted refresh token.
+    async fn clear_session(&self) -> Result<(), ApiError> {
+        self.state.borrow_mut().access_token = None;
+        self.credentials.clear_refresh_token().await?;
+        Ok(())
+    }
+}
+
+fn is_success(status: u16) -> bool {
+    (200..300).contains(&status)
+}
+
+/// Serialize a request body. The client's own request types are always
+/// serializable, so a failure is a programmer error, not a runtime condition.
+fn to_json<B: Serialize + ?Sized>(body: &B) -> Vec<u8> {
+    serde_json::to_vec(body).expect("api request bodies always serialize")
+}
+
+fn ok_or_err(response: HttpResponse) -> Result<HttpResponse, ApiError> {
+    if is_success(response.status) {
+        Ok(response)
+    } else {
+        Err(error_from_response(&response))
+    }
+}
+
+fn error_from_response(response: &HttpResponse) -> ApiError {
+    match response.status {
+        401 => ApiError::Unauthorized,
+        403 => ApiError::Forbidden,
+        status => {
+            let message = serde_json::from_slice::<ErrorBody>(&response.body)
+                .ok()
+                .and_then(|body| body.message_string());
+            ApiError::Status { status, message }
+        }
+    }
+}
+
+fn decode<T: serde::de::DeserializeOwned>(response: &HttpResponse) -> Result<T, ApiError> {
+    serde_json::from_slice(&response.body).map_err(|error| ApiError::Decode(error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testkit::block_on;
+    use crate::testkit::fakes::{InMemoryCredentialStore, ScriptedHttp};
+    use serde_json::{Value, json};
+    use std::future::Future;
+    use std::pin::pin;
+    use std::sync::{Arc, Mutex};
+    use std::task::{Context, Poll, Waker};
+
+    struct StubSigner;
+
+    impl ChallengeSigner for StubSigner {
+        fn public_key_hex(&self) -> String {
+            "02".to_owned() + &"ab".repeat(32)
+        }
+        fn sign_challenge(&self, challenge: &str) -> String {
+            format!("sig-for-{challenge}")
+        }
+    }
+
+    fn json_response(status: u16, body: Value) -> HttpResponse {
+        HttpResponse {
+            status,
+            headers: vec![(CONTENT_TYPE.to_owned(), APPLICATION_JSON.to_owned())],
+            body: serde_json::to_vec(&body).unwrap(),
+        }
+    }
+
+    fn body_json(request: &HttpRequest) -> Value {
+        serde_json::from_slice(request.body.as_ref().expect("request has a body")).unwrap()
+    }
+
+    fn has_bearer(request: &HttpRequest) -> bool {
+        request
+            .headers
+            .iter()
+            .any(|(name, value)| name == AUTHORIZATION && value.starts_with("Bearer "))
+    }
+
+    type Fakes = (
+        ScriptedHttp,
+        InMemoryCredentialStore,
+        ApiClient<ScriptedHttp, InMemoryCredentialStore>,
+    );
+
+    fn fakes() -> Fakes {
+        let http = ScriptedHttp::default();
+        let creds = InMemoryCredentialStore::default();
+        let client = ApiClient::new(http.clone(), creds.clone(), "http://api.test/");
+        (http, creds, client)
+    }
+
+    /// Log in so the client holds an access token and a stored refresh token.
+    fn login(http: &ScriptedHttp, client: &ApiClient<ScriptedHttp, InMemoryCredentialStore>) {
+        http.enqueue_response(json_response(
+            200,
+            json!({ "challenge": "cipherbox-login:v2:abc", "expiresAt": "2026-01-01T00:00:00Z" }),
+        ));
+        http.enqueue_response(json_response(
+            200,
+            json!({ "accessToken": "jwt-1", "refreshToken": "a".repeat(64), "isNewUser": true }),
+        ));
+        block_on(client.login_identity(&StubSigner)).expect("login");
+    }
+
+    #[test]
+    fn base_url_trailing_slash_is_trimmed() {
+        let (_http, _creds, client) = fakes();
+        assert_eq!(client.base_url(), "http://api.test");
+    }
+
+    #[test]
+    fn identity_login_signs_the_challenge_and_persists_tokens() {
+        let (http, creds, client) = fakes();
+        login(&http, &client);
+
+        assert!(client.is_authenticated());
+        let requests = http.requests();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].method, HttpMethod::Post);
+        assert_eq!(requests[0].url, "http://api.test/auth/challenge");
+        assert_eq!(
+            body_json(&requests[0])["publicKey"],
+            StubSigner.public_key_hex()
+        );
+        assert_eq!(requests[1].url, "http://api.test/auth/login");
+        let login_body = body_json(&requests[1]);
+        assert_eq!(login_body["challenge"], "cipherbox-login:v2:abc");
+        assert_eq!(login_body["signature"], "sig-for-cipherbox-login:v2:abc");
+
+        let stored = block_on(creds.load_refresh_token()).unwrap().unwrap();
+        assert_eq!(stored, "a".repeat(64).as_bytes());
+    }
+
+    #[test]
+    fn identity_login_bad_signature_is_unauthorized() {
+        let (http, _creds, client) = fakes();
+        http.enqueue_response(json_response(
+            200,
+            json!({ "challenge": "c", "expiresAt": "2026-01-01T00:00:00Z" }),
+        ));
+        http.enqueue_response(json_response(
+            401,
+            json!({ "message": "Invalid challenge signature" }),
+        ));
+        assert_eq!(
+            block_on(client.login_identity(&StubSigner)).unwrap_err(),
+            ApiError::Unauthorized
+        );
+        assert!(!client.is_authenticated());
+    }
+
+    #[test]
+    fn refresh_sends_the_stored_token_and_rotates() {
+        let (http, creds, client) = fakes();
+        block_on(creds.store_refresh_token(b"seed-refresh-token")).unwrap();
+        http.enqueue_response(json_response(
+            200,
+            json!({ "accessToken": "jwt-2", "refreshToken": "b".repeat(64) }),
+        ));
+
+        block_on(client.refresh()).expect("refresh");
+
+        let requests = http.requests();
+        assert_eq!(requests[0].url, "http://api.test/auth/refresh");
+        assert_eq!(
+            body_json(&requests[0])["refreshToken"],
+            "seed-refresh-token"
+        );
+        assert!(client.is_authenticated());
+        let stored = block_on(creds.load_refresh_token()).unwrap().unwrap();
+        assert_eq!(stored, "b".repeat(64).as_bytes());
+    }
+
+    #[test]
+    fn refresh_without_a_stored_token_omits_the_field() {
+        // The web platform keeps no stored token: the HTTP-only cookie rides
+        // the Http seam, so the body must carry no refreshToken field.
+        let (http, _creds, client) = fakes();
+        http.enqueue_response(json_response(
+            200,
+            json!({ "accessToken": "jwt", "refreshToken": "c".repeat(64) }),
+        ));
+        block_on(client.refresh()).expect("refresh via cookie");
+        assert_eq!(body_json(&http.requests()[0]), json!({}));
+    }
+
+    #[test]
+    fn refresh_failure_clears_the_session() {
+        let (http, creds, client) = fakes();
+        login(&http, &client);
+        http.enqueue_response(json_response(
+            401,
+            json!({ "message": "Invalid refresh token" }),
+        ));
+
+        assert_eq!(
+            block_on(client.refresh()).unwrap_err(),
+            ApiError::Unauthorized
+        );
+        assert!(!client.is_authenticated());
+        assert!(block_on(creds.load_refresh_token()).unwrap().is_none());
+    }
+
+    #[test]
+    fn expired_access_triggers_one_refresh_then_retry() {
+        let (http, _creds, client) = fakes();
+        login(&http, &client);
+        // First logout attempt 401 → refresh 200 → retry 200.
+        http.enqueue_response(json_response(401, json!({ "message": "jwt expired" })));
+        http.enqueue_response(json_response(
+            200,
+            json!({ "accessToken": "jwt-2", "refreshToken": "d".repeat(64) }),
+        ));
+        http.enqueue_response(json_response(200, json!({ "success": true })));
+
+        block_on(client.logout()).expect("logout after refresh");
+
+        let urls: Vec<_> = http.requests().iter().map(|r| r.url.clone()).collect();
+        assert_eq!(
+            &urls[2..],
+            &[
+                "http://api.test/auth/logout",
+                "http://api.test/auth/refresh",
+                "http://api.test/auth/logout",
+            ]
+        );
+    }
+
+    #[test]
+    fn terminal_401_after_refresh_is_unauthorized() {
+        let (http, _creds, client) = fakes();
+        login(&http, &client);
+        http.enqueue_response(json_response(401, json!({ "message": "expired" }))); // quota attempt
+        http.enqueue_response(json_response(
+            200,
+            json!({ "accessToken": "jwt-2", "refreshToken": "d".repeat(64) }),
+        )); // refresh ok
+        http.enqueue_response(json_response(401, json!({ "message": "still bad" }))); // retry 401
+
+        assert_eq!(
+            block_on(client.quota()).unwrap_err(),
+            ApiError::Unauthorized
+        );
+    }
+
+    #[test]
+    fn test_login_returns_the_keypair_and_redacts_the_private_key() {
+        let (http, _creds, client) = fakes();
+        let private_key = "11".repeat(32);
+        http.enqueue_response(json_response(
+            200,
+            json!({
+                "accessToken": "jwt",
+                "refreshToken": "e".repeat(64),
+                "isNewUser": true,
+                "publicKey": "02cafe",
+                "privateKey": private_key,
+            }),
+        ));
+
+        let outcome = block_on(client.test_login("alice@test", "the-secret")).expect("test login");
+        assert!(outcome.is_new_user);
+        assert_eq!(outcome.public_key, "02cafe");
+        assert_eq!(&*outcome.private_key, &private_key);
+        assert!(client.is_authenticated());
+
+        let body = body_json(&http.requests()[0]);
+        assert_eq!(body["handle"], "alice@test");
+        assert_eq!(body["secret"], "the-secret");
+
+        let debug = format!("{outcome:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(
+            !debug.contains(&private_key),
+            "private key must never render"
+        );
+    }
+
+    #[test]
+    fn test_login_disabled_is_forbidden() {
+        let (http, _creds, client) = fakes();
+        http.enqueue_response(json_response(
+            403,
+            json!({ "message": "Test login is not enabled" }),
+        ));
+        assert_eq!(
+            block_on(client.test_login("h", "wrong")).unwrap_err(),
+            ApiError::Forbidden
+        );
+    }
+
+    #[test]
+    fn siwe_challenge_returns_a_nonce_with_no_request_body() {
+        let (http, _creds, client) = fakes();
+        http.enqueue_response(json_response(
+            200,
+            json!({ "nonce": "nonce-123", "expiresAt": "2026-01-01T00:00:00Z" }),
+        ));
+        let nonce = block_on(client.siwe_challenge()).expect("nonce");
+        assert_eq!(nonce.nonce, "nonce-123");
+        let request = &http.requests()[0];
+        assert_eq!(request.url, "http://api.test/auth/siwe/challenge");
+        assert!(request.body.is_none());
+    }
+
+    #[test]
+    fn siwe_login_unlinked_wallet_is_unauthorized() {
+        let (http, _creds, client) = fakes();
+        http.enqueue_response(json_response(
+            401,
+            json!({ "message": "Wallet is not linked to an account" }),
+        ));
+        assert_eq!(
+            block_on(client.siwe_login("message", "0xsig")).unwrap_err(),
+            ApiError::Unauthorized
+        );
+    }
+
+    #[test]
+    fn register_builds_the_batch_body_with_a_bearer() {
+        let (http, _creds, client) = fakes();
+        login(&http, &client);
+        http.enqueue_response(json_response(200, json!({})));
+
+        let names = vec![NameRegistration {
+            ipns_name: "k51abc".into(),
+            head_cid: Some("bafyhead".into()),
+            content_cids: vec!["bafyc1".into(), "bafyc2".into()],
+        }];
+        block_on(client.register(&names)).expect("register");
+
+        let request = http.requests().pop().unwrap();
+        assert_eq!(request.url, "http://api.test/registry/register");
+        assert!(has_bearer(&request));
+        let body = body_json(&request);
+        assert_eq!(body[0]["ipnsName"], "k51abc");
+        assert_eq!(body[0]["headCid"], "bafyhead");
+        assert_eq!(body[0]["contentCids"], json!(["bafyc1", "bafyc2"]));
+    }
+
+    #[test]
+    fn mailbox_poll_decodes_base64_blobs() {
+        let (http, _creds, client) = fakes();
+        login(&http, &client);
+        let blob = b"sealed-payload-bytes";
+        http.enqueue_response(json_response(
+            200,
+            json!([{ "id": "m1", "receivedAt": "2026-01-01T00:00:00Z", "blob": BASE64.encode(blob) }]),
+        ));
+
+        let items = block_on(client.mailbox_poll()).expect("poll");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "m1");
+        assert_eq!(items[0].blob, blob);
+    }
+
+    #[test]
+    fn status_error_carries_the_server_message() {
+        let (http, _creds, client) = fakes();
+        http.enqueue_response(json_response(
+            500,
+            json!({ "statusCode": 500, "message": "internal boom" }),
+        ));
+        assert_eq!(
+            block_on(client.siwe_challenge()).unwrap_err(),
+            ApiError::Status {
+                status: 500,
+                message: Some("internal boom".into())
+            }
+        );
+    }
+
+    // --- single-flight: two concurrent refreshes issue exactly one request ---
+
+    #[derive(Clone, Default)]
+    struct GatedHttp {
+        inner: Arc<Mutex<GateInner>>,
+    }
+
+    #[derive(Default)]
+    struct GateInner {
+        requests: usize,
+        response: Option<HttpResponse>,
+        wakers: Vec<Waker>,
+    }
+
+    impl GatedHttp {
+        fn request_count(&self) -> usize {
+            self.inner.lock().unwrap().requests
+        }
+        fn release(&self, response: HttpResponse) {
+            let mut inner = self.inner.lock().unwrap();
+            inner.response = Some(response);
+            for waker in inner.wakers.drain(..) {
+                waker.wake();
+            }
+        }
+    }
+
+    impl Http for GatedHttp {
+        async fn send(&self, _request: HttpRequest) -> crate::seams::SeamResult<HttpResponse> {
+            self.inner.lock().unwrap().requests += 1;
+            GateFuture {
+                inner: self.inner.clone(),
+            }
+            .await
+        }
+    }
+
+    struct GateFuture {
+        inner: Arc<Mutex<GateInner>>,
+    }
+
+    impl Future for GateFuture {
+        type Output = crate::seams::SeamResult<HttpResponse>;
+        fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let mut inner = self.inner.lock().unwrap();
+            match &inner.response {
+                Some(response) => Poll::Ready(Ok(response.clone())),
+                None => {
+                    inner.wakers.push(cx.waker().clone());
+                    Poll::Pending
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn concurrent_refreshes_are_single_flight() {
+        let http = GatedHttp::default();
+        let creds = InMemoryCredentialStore::default();
+        block_on(creds.store_refresh_token(b"seed-refresh-token")).unwrap();
+        let client = ApiClient::new(http.clone(), creds, "http://api.test");
+
+        let mut first = pin!(client.refresh());
+        let mut second = pin!(client.refresh());
+        let mut cx = Context::from_waker(Waker::noop());
+
+        // Leader polls first: one /auth/refresh goes out, then it parks.
+        assert!(first.as_mut().poll(&mut cx).is_pending());
+        assert_eq!(http.request_count(), 1);
+        // Waiter polls: it coalesces behind the leader — no second request.
+        assert!(second.as_mut().poll(&mut cx).is_pending());
+        assert_eq!(http.request_count(), 1);
+
+        http.release(json_response(
+            200,
+            json!({ "accessToken": "jwt", "refreshToken": "f".repeat(64) }),
+        ));
+
+        assert!(matches!(first.as_mut().poll(&mut cx), Poll::Ready(Ok(()))));
+        assert!(matches!(second.as_mut().poll(&mut cx), Poll::Ready(Ok(()))));
+        assert_eq!(http.request_count(), 1, "one refresh served both callers");
+        assert!(client.is_authenticated());
+    }
+}

--- a/crates/engine/src/api/client.rs
+++ b/crates/engine/src/api/client.rs
@@ -410,8 +410,8 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
         format!("{}{}", self.base_url, path)
     }
 
-    /// POST a JSON body without authentication (the challenge/login/refresh
-    /// surface).
+    /// POST a JSON body without authentication (the challenge/login surface;
+    /// refresh builds its request inline to zeroize the secret-bearing body).
     async fn post_json<B: Serialize>(
         &self,
         path: &str,
@@ -481,16 +481,34 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
     async fn do_refresh(&self) -> Result<(), ApiError> {
         let stored = self.credentials.load_refresh_token().await?;
         let refresh_token = match stored {
-            Some(bytes) => Some(
-                String::from_utf8(bytes)
-                    .map_err(|_| ApiError::Decode("stored refresh token is not utf-8".into()))?,
-            ),
+            // Wrap the decoded secret so its allocation is cleared at this
+            // terminal owner (mirrors `store_tokens`); `from_utf8` reuses the
+            // stored bytes' buffer, so this also clears them.
+            Some(bytes) => match String::from_utf8(bytes) {
+                Ok(token) => Some(Zeroizing::new(token)),
+                // Corrupted stored credential: self-heal by clearing the dead
+                // session, else every authed call loops 401 → refresh → Decode
+                // → 401. Mirrors the refresh-failure path below.
+                Err(_) => {
+                    self.clear_session().await?;
+                    return Err(ApiError::Decode("stored refresh token is not utf-8".into()));
+                }
+            },
             // Web: no stored token — the HTTP-only cookie rides the Http seam.
             None => None,
         };
-        let response = self
-            .post_json("/auth/refresh", &RefreshRequest { refresh_token })
-            .await?;
+        // Serialize once into a zeroizing buffer so the secret-bearing body is
+        // cleared on every exit path (success, error, network failure).
+        let body = Zeroizing::new(to_json(&RefreshRequest {
+            refresh_token: refresh_token.as_ref().map(|token| token.to_string()),
+        }));
+        let request = HttpRequest {
+            method: HttpMethod::Post,
+            url: self.url("/auth/refresh"),
+            headers: vec![(CONTENT_TYPE.to_owned(), APPLICATION_JSON.to_owned())],
+            body: Some(body.to_vec()),
+        };
+        let response = self.http.send(request).await?;
         if !is_success(response.status) {
             // Session is dead: drop the stale access + refresh material so it
             // is never replayed.

--- a/crates/engine/src/api/error.rs
+++ b/crates/engine/src/api/error.rs
@@ -1,0 +1,68 @@
+//! Errors surfaced by the [`super::ApiClient`].
+
+use core::fmt;
+
+use crate::seams::SeamError;
+
+/// A failure of an API call.
+///
+/// Diagnostic strings carried here are the API's own error messages, never key
+/// material: the client extracts only the server's `message` field and never
+/// echoes request bodies, tokens, or signatures (security rule 2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApiError {
+    /// Transport-level failure from the [`crate::seams::Http`] seam
+    /// (unreachable host, aborted request). Distinct from an HTTP error
+    /// status, which is a well-formed response.
+    Transport(SeamError),
+    /// The request needed authentication the client does not hold — no access
+    /// token in memory and no refresh token to mint one (e.g. a call before
+    /// any login).
+    NotAuthenticated,
+    /// The API answered 401 and a single refresh-then-retry did not recover
+    /// it: the session is dead and the caller must re-login.
+    Unauthorized,
+    /// The API answered 403 — e.g. the staging test-login endpoint is disabled
+    /// or hard-blocked in production.
+    Forbidden,
+    /// A non-2xx status the client does not special-case. `message` is the
+    /// server's diagnostic string when the body parsed as a Nest error
+    /// envelope.
+    Status {
+        /// The HTTP status code.
+        status: u16,
+        /// The server's `message` field, if the error body carried one.
+        message: Option<String>,
+    },
+    /// A 2xx body did not match the expected shape. Carries a short reason,
+    /// never the body bytes.
+    Decode(String),
+}
+
+impl From<SeamError> for ApiError {
+    fn from(error: SeamError) -> Self {
+        ApiError::Transport(error)
+    }
+}
+
+impl fmt::Display for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ApiError::Transport(error) => write!(f, "api transport error: {error}"),
+            ApiError::NotAuthenticated => f.write_str("api call requires authentication"),
+            ApiError::Unauthorized => f.write_str("api rejected the request as unauthorized"),
+            ApiError::Forbidden => f.write_str("api refused the request as forbidden"),
+            ApiError::Status {
+                status,
+                message: Some(message),
+            } => write!(f, "api returned status {status}: {message}"),
+            ApiError::Status {
+                status,
+                message: None,
+            } => write!(f, "api returned status {status}"),
+            ApiError::Decode(reason) => write!(f, "api response decode error: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for ApiError {}

--- a/crates/engine/src/api/mod.rs
+++ b/crates/engine/src/api/mod.rs
@@ -1,0 +1,23 @@
+//! The hand-written API client and token lifecycle (blueprint/engine.md
+//! "API client").
+//!
+//! One client for both hosts, over the [`crate::seams::Http`] and
+//! [`crate::seams::CredentialStore`] seams — no generated clients anywhere
+//! (#28 D5). The NestJS API keeps emitting its OpenAPI spec as a docs
+//! artifact; enforcement is the live contract-test suite (`crates/contract`),
+//! not codegen. Only the auth/token surface is implemented server-side today
+//! (#624); the registry/content/mailbox/recovery/account methods here follow
+//! blueprint/api.md and are provisional until those API slices land, when the
+//! contract suite binds them live.
+
+mod client;
+mod error;
+mod signer;
+mod types;
+
+pub use client::ApiClient;
+pub use error::ApiError;
+pub use signer::{ChallengeSigner, IdentityChallengeSigner};
+pub use types::{
+    LoginOutcome, MailboxItem, NameRegistration, Quota, SiweNonce, TestLoginOutcome, UploadResult,
+};

--- a/crates/engine/src/api/signer.rs
+++ b/crates/engine/src/api/signer.rs
@@ -1,0 +1,106 @@
+//! Challenge-signature signing for identity login.
+//!
+//! Login is engine-native (blueprint/engine.md "API client"): the engine holds
+//! the secp256k1 identity key and signs the server-issued challenge. All crypto
+//! lives in `crates/core` (security rule 4) — [`IdentityChallengeSigner`] is a
+//! thin adapter over [`cipherbox_core::suite::ecdsa`]; the engine only
+//! hex-encodes the public key and signature for the wire.
+
+use cipherbox_core::suite::ecdsa::EcdsaSigner;
+
+/// Produces the two hex fields the `/auth/challenge` + `/auth/login` flow
+/// needs: the identity public key and a signature over a challenge string.
+///
+/// An abstraction rather than a concrete type so the [`super::ApiClient`] stays
+/// crypto-free and testable with a stub, while the production implementation
+/// ([`IdentityChallengeSigner`]) routes through core.
+pub trait ChallengeSigner {
+    /// The identity public key as the API's `publicKey` field: compressed
+    /// SEC1, lowercase hex (66 chars, `02`/`03` prefix).
+    fn public_key_hex(&self) -> String;
+
+    /// A signature over `sha256(utf8(challenge))` as the API's `signature`
+    /// field: the compact `r || s` form, lowercase hex (128 chars).
+    fn sign_challenge(&self, challenge: &str) -> String;
+}
+
+/// The production [`ChallengeSigner`]: a secp256k1 identity key held in the
+/// engine, signing through core's RFC 6979 deterministic ECDSA.
+///
+/// `sign_detcbor` hashes its input with SHA-256 before signing, which is
+/// exactly the API's `sha256(utf8(challenge))` verification input, so signing
+/// the raw challenge bytes here matches the server verbatim.
+pub struct IdentityChallengeSigner {
+    signer: EcdsaSigner,
+}
+
+impl IdentityChallengeSigner {
+    /// Adopts a 32-byte scalar as the identity signing key. `None` when the
+    /// scalar is zero or not below the group order (core's validation).
+    pub fn from_scalar(scalar: &[u8; 32]) -> Option<Self> {
+        EcdsaSigner::from_scalar(scalar).map(|signer| Self { signer })
+    }
+}
+
+impl ChallengeSigner for IdentityChallengeSigner {
+    fn public_key_hex(&self) -> String {
+        hex_lower(&self.signer.verifying_key().to_sec1())
+    }
+
+    fn sign_challenge(&self, challenge: &str) -> String {
+        hex_lower(&self.signer.sign_detcbor(challenge.as_bytes()).to_compact())
+    }
+}
+
+/// Lowercase hex encoding. Not crypto — a wire encoding of already-public
+/// bytes (the SEC1 public key and the compact signature).
+pub(crate) fn hex_lower(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(char::from_digit((byte >> 4) as u32, 16).expect("high nibble is < 16"));
+        out.push(char::from_digit((byte & 0x0f) as u32, 16).expect("low nibble is < 16"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn signer() -> IdentityChallengeSigner {
+        IdentityChallengeSigner::from_scalar(&[0x11; 32]).expect("valid scalar")
+    }
+
+    #[test]
+    fn public_key_is_compressed_lowercase_hex() {
+        let pk = signer().public_key_hex();
+        assert_eq!(pk.len(), 66, "compressed SEC1 is 33 bytes");
+        assert!(
+            pk.starts_with("02") || pk.starts_with("03"),
+            "compressed prefix"
+        );
+        assert_eq!(pk, pk.to_lowercase(), "lowercase hex");
+    }
+
+    #[test]
+    fn signature_is_compact_lowercase_hex_and_deterministic() {
+        let s = signer();
+        let sig = s.sign_challenge("cipherbox-login:v2:deadbeef");
+        assert_eq!(sig.len(), 128, "compact r||s is 64 bytes");
+        assert_eq!(sig, sig.to_lowercase(), "lowercase hex");
+        // RFC 6979 determinism: same key + challenge => same signature.
+        assert_eq!(s.sign_challenge("cipherbox-login:v2:deadbeef"), sig);
+        // A different challenge produces a different signature.
+        assert_ne!(s.sign_challenge("cipherbox-login:v2:0000"), sig);
+    }
+
+    #[test]
+    fn zero_scalar_is_rejected() {
+        assert!(IdentityChallengeSigner::from_scalar(&[0u8; 32]).is_none());
+    }
+
+    #[test]
+    fn hex_lower_pads_each_byte() {
+        assert_eq!(hex_lower(&[0x00, 0x0f, 0xa0, 0xff]), "000fa0ff");
+    }
+}

--- a/crates/engine/src/api/types.rs
+++ b/crates/engine/src/api/types.rs
@@ -1,0 +1,223 @@
+//! Wire DTOs and the public outcome types for the [`super::ApiClient`].
+//!
+//! Field names mirror the NestJS API's camelCase JSON verbatim (AGENTS.md:
+//! camelCase for API fields). The token-bearing request/response structs are
+//! crate-internal and deliberately implement no `Debug` — tokens and
+//! signatures must never reach a log site (security rule 2). Public outcome
+//! types expose only non-secret data, except the test-login private key which
+//! is zeroized and redacted.
+
+use core::fmt;
+
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
+
+// --- auth requests (serialized to JSON bodies) ---
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ChallengeRequest<'a> {
+    pub public_key: &'a str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LoginRequest<'a> {
+    pub public_key: &'a str,
+    pub challenge: &'a str,
+    pub signature: &'a str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RefreshRequest {
+    /// Omitted entirely on web, where the HTTP-only refresh cookie rides the
+    /// Http seam instead of a body field (blueprint/engine.md CredentialStore).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SiweLoginRequest<'a> {
+    pub message: &'a str,
+    pub signature: &'a str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TestLoginRequest<'a> {
+    pub handle: &'a str,
+    pub secret: &'a str,
+}
+
+// --- auth responses (deserialized from JSON bodies) ---
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TokenResponse {
+    pub access_token: String,
+    pub refresh_token: String,
+    #[serde(default)]
+    pub is_new_user: Option<bool>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ChallengeResponse {
+    pub challenge: String,
+    #[allow(dead_code)]
+    pub expires_at: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SiweChallengeResponse {
+    pub nonce: String,
+    pub expires_at: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TestLoginResponse {
+    pub access_token: String,
+    pub refresh_token: String,
+    #[serde(default)]
+    pub is_new_user: Option<bool>,
+    pub public_key: String,
+    pub private_key: String,
+}
+
+/// A NestJS error envelope: `{ statusCode, message, error }`. `message` is a
+/// string or an array of strings (validation failures); both are accepted.
+#[derive(Deserialize)]
+pub(crate) struct ErrorBody {
+    #[serde(default)]
+    pub message: serde_json::Value,
+}
+
+impl ErrorBody {
+    /// The server's message as a flat string, or `None` when absent.
+    pub fn message_string(&self) -> Option<String> {
+        match &self.message {
+            serde_json::Value::String(s) => Some(s.clone()),
+            serde_json::Value::Array(items) => {
+                let joined = items
+                    .iter()
+                    .filter_map(|item| item.as_str())
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                (!joined.is_empty()).then_some(joined)
+            }
+            _ => None,
+        }
+    }
+}
+
+// --- public outcome types (returned across the client boundary) ---
+
+/// The result of a successful identity or SIWE login.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoginOutcome {
+    /// True when this login implicitly created the account (first login).
+    pub is_new_user: bool,
+}
+
+/// A freshly issued SIWE nonce to embed in an EIP-4361 message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SiweNonce {
+    /// The single-use nonce.
+    pub nonce: String,
+    /// Nonce expiry, ISO 8601.
+    pub expires_at: String,
+}
+
+/// The result of the staging-gated test-login: the deterministic keypair plus
+/// whether the account was created. `Debug` redacts the private key.
+#[derive(Clone)]
+pub struct TestLoginOutcome {
+    /// True when this login implicitly created the account.
+    pub is_new_user: bool,
+    /// The deterministic compressed secp256k1 public key, lowercase hex.
+    pub public_key: String,
+    /// The deterministic secp256k1 private key, hex — a test hook only.
+    /// Zeroized on drop and never logged.
+    pub private_key: Zeroizing<String>,
+}
+
+impl fmt::Debug for TestLoginOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TestLoginOutcome")
+            .field("is_new_user", &self.is_new_user)
+            .field("public_key", &self.public_key)
+            .field("private_key", &"<redacted>")
+            .finish()
+    }
+}
+
+// --- pin/name registry, quota, content, mailbox, recovery ---
+//
+// These endpoints are not yet implemented server-side (only the auth surface
+// exists in the API today, #624); the wire shapes below follow blueprint/api.md
+// and are provisional until the registry/content/mailbox API slices land, at
+// which point the live contract suite binds and enforces them. The client
+// methods are unit-tested for request construction against the scripted Http
+// fake.
+
+/// One entry of a batch name registration
+/// (`[{ipnsName, headCid?, contentCids[]}]`, blueprint/api.md).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NameRegistration {
+    /// The IPNS name being registered.
+    pub ipns_name: String,
+    /// The head (metadata) CID, when publishing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_cid: Option<String>,
+    /// The content CIDs to pin/count under this name.
+    pub content_cids: Vec<String>,
+}
+
+/// A per-account quota response. Hosted rows are authoritative; a BYO account's
+/// rows are advisory (`advisory: true`, quota always allows) — blueprint/api.md.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Quota {
+    /// Bytes currently counted against the account.
+    pub used_bytes: u64,
+    /// The account's limit (env default plus any override).
+    pub limit_bytes: u64,
+    /// True for BYO accounts, whose rows never gate uploads.
+    pub advisory: bool,
+}
+
+/// The result of a hosted upload.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UploadResult {
+    /// The content CID Kubo pinned.
+    pub cid: String,
+    /// The pinned size in bytes.
+    pub size: u64,
+}
+
+/// One polled mailbox item. The blob is the HPKE-sealed payload bytes; no
+/// sender metadata is exposed in the clear (blueprint/api.md Mailbox).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MailboxItem {
+    /// The item id (used to ack).
+    pub id: String,
+    /// When the item was received, ISO 8601.
+    pub received_at: String,
+    /// The sealed payload bytes.
+    pub blob: Vec<u8>,
+}
+
+/// The mailbox item as it rides the wire: the blob is base64.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MailboxItemWire {
+    pub id: String,
+    pub received_at: String,
+    pub blob: String,
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -7,9 +7,10 @@
 //! and the whole-set constructor bundle ([`seams`]), injected entropy
 //! ([`entropy`]), the environment-scoped sync timing profile ([`profile`]),
 //! and the facade skeleton ([`facade`]) — one async command-and-event
-//! surface with start of secret. Pipeline logic (gate, sync, rotation,
-//! grants, pointer, mailbox, net, content, api) lands in later slices
-//! behind this exact surface.
+//! surface with start of secret. The [`api`] module lands the single
+//! hand-written API client and token lifecycle. The rest of the pipeline
+//! (gate, sync, rotation, grants, pointer, mailbox, net, content) lands in
+//! later slices behind this exact surface.
 //!
 //! The `test-kit` feature adds [`testkit`]: in-memory fakes for every seam,
 //! a virtual-clock scheduler, seeded entropy, and the reusable per-seam
@@ -23,6 +24,7 @@
 // so no auto-trait bound flexibility is lost.
 #![allow(async_fn_in_trait)]
 
+pub mod api;
 pub mod entropy;
 pub mod facade;
 pub mod profile;
@@ -30,6 +32,10 @@ pub mod seams;
 #[cfg(feature = "test-kit")]
 pub mod testkit;
 
+pub use api::{
+    ApiClient, ApiError, ChallengeSigner, IdentityChallengeSigner, LoginOutcome, MailboxItem,
+    NameRegistration, Quota, SiweNonce, TestLoginOutcome, UploadResult,
+};
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{
     Command, Engine, EngineError, Event, EventStream, LoginSecret, NodeId, NodeKind, Permission,


### PR DESCRIPTION
## What

The single hand-written Rust API client inside the engine, over the `Http` and `CredentialStore` seams (blueprint/engine.md "API client") — no generated clients (FSM1/cipher-box-next#28 D5) — plus the live contract suite that enforces it.

### API client (`crates/engine/src/api`)

- **Token lifecycle**: engine-native challenge-signature login with the secp256k1 identity key (signing via `crates/core`, never in the client), SIWE secondary, staging-gated test-login. The access JWT lives in engine memory (zeroized); the rotating refresh token persists per platform via `CredentialStore` — web omits it and rides the HTTP-only cookie over the Http seam, desktop uses the keychain.
- **Single-flight refresh** with one retry-then-fail on 401: concurrent callers coalesce behind one in-flight rotation instead of spending an already-invalidated token.
- **Surface**: auth / refresh / test-login / SIWE are what the API implements today (#624). `register` / `retire` / `quota` / `upload` / mailbox / `recovery` / `set_byo` / `delete_account` follow blueprint/api.md and are provisional (marked in code) until those API slices land, when the contract suite binds them live.
- Crypto stays in core: the client depends on a `ChallengeSigner` trait; `IdentityChallengeSigner` adapts core's ECDSA. The client itself only does JSON + hex.

### Contract suite (`crates/contract`)

The sdk-e2e descendant and sole contract enforcement. It builds the real client over a production-shaped reqwest `Http` seam, points it at the CI stack, and asserts API-side effects: challenge-signature login + account identity, refresh rotation + reuse-detection family kill, test-login secret gating + deterministic keypair + cross-consistency with identity login, production-mode hard-block, the SIWE surface, logout revocation, and a raw health round-trip.

### CI gate

A new merge-blocking `Contract Suite` job stands up Postgres + Kubo + the promoted `mock-ipns-routing` `/routing/v1` store + the real NestJS API (a second instance in production mode for the test-login gating assertion), then runs the suite. An always-reporting `Contract Suite Result` gate (mirroring `desktop-build-result`) is the stable required context. The contract crate is excluded from the general cargo jobs, since its tests need the live stack.

## Testing

- `cargo test -p cipherbox-engine` — 52 unit tests incl. the client (single-flight, refresh, 401 retry, redaction, request construction).
- Live contract suite run locally against docker Postgres/Kubo + `mock-ipns-routing` + two API instances: 7/7 pass.
- `cargo clippy` / `fmt` clean; the WASM build (`cipherbox-wasm`, wasm32-unknown-unknown) is green with the new serde/base64 deps; actionlint + prettier clean on ci.yml.

## Does NOT land

Register-first ordering in the publish pipeline and mailbox engine logic (per the ticket) — later slices.

Closes #625


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified API client supporting identity login, SIWE authentication, token refresh, logout, account management, uploads, mailbox operations, recovery, and related services.
  * Added challenge-signing support and structured API errors.
  * Added live contract tests covering authentication, token rotation, logout, production safeguards, and key API flows.
* **CI Improvements**
  * Expanded workspace validation across platforms and added live contract-suite coverage.
  * Added service setup and merge-blocking reporting for contract test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->