### PR TITLE
feat: pin and name registry with register-first and quota in the api

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -429,6 +429,7 @@
             "application/json": {
               "schema": {
                 "type": "array",
+                "maxItems": 1000,
                 "items": {
                   "$ref": "#/components/schemas/RegisterEntryDto"
                 }
@@ -478,8 +479,10 @@
             "application/json": {
               "schema": {
                 "type": "array",
+                "maxItems": 1000,
                 "items": {
-                  "type": "string"
+                  "type": "string",
+                  "maxLength": 256
                 }
               }
             }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -430,7 +430,7 @@
               "schema": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/RegisterEntryDto"
                 }
               }
             }
@@ -897,6 +897,31 @@
         },
         "required": [
           "success"
+        ]
+      },
+      "RegisterEntryDto": {
+        "type": "object",
+        "properties": {
+          "ipnsName": {
+            "type": "string",
+            "description": "The IPNS name to register (libp2p-key CID). Register-first: this row precedes publish.",
+            "example": "k51qzi5uqu5dkuzo866rgfkt5nuqo53l6l3l6zk3l6zk3l6zk3l6zk3l6zk3"
+          },
+          "headCid": {
+            "type": "string",
+            "description": "Current head (metadata) CID this name publishes; omit to register the name only."
+          },
+          "contentCids": {
+            "description": "Content CIDs to pin/count under this account (idempotent upsert).",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "ipnsName",
+          "contentCids"
         ]
       },
       "RegisterResponseDto": {

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -418,6 +418,177 @@
           "Mailbox"
         ]
       }
+    },
+    "/registry/register": {
+      "post": {
+        "operationId": "RegistryController_register",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisterResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed batch (invalid entry, name, or CID)"
+          },
+          "401": {
+            "description": "Missing or invalid access token"
+          },
+          "429": {
+            "description": "Registry rate limit exceeded"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Batch register [{ipnsName, headCid?, contentCids[]}] under the caller account; register-first, idempotent upserts",
+        "tags": [
+          "Registry"
+        ]
+      }
+    },
+    "/registry/retire": {
+      "post": {
+        "operationId": "RegistryController_retire",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetireResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed batch"
+          },
+          "401": {
+            "description": "Missing or invalid access token"
+          },
+          "429": {
+            "description": "Registry rate limit exceeded"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Batch retire [ipnsName | cid] for the caller account; union liveness, refcounted physical unpin at global zero",
+        "tags": [
+          "Registry"
+        ]
+      }
+    },
+    "/account/quota": {
+      "get": {
+        "operationId": "AccountController_quota",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuotaResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid access token"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "The caller per-account quota: usedBytes (sum over pin rows), limitBytes (override or env default), advisory (BYO)",
+        "tags": [
+          "Account"
+        ]
+      }
+    },
+    "/account/byo": {
+      "patch": {
+        "operationId": "AccountController_setByo",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetByoDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ByoResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed body"
+          },
+          "401": {
+            "description": "Missing or invalid access token"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Toggle the caller BYO-IPFS flag; advisory pin rows follow it",
+        "tags": [
+          "Account"
+        ]
+      }
     }
   },
   "info": {
@@ -438,6 +609,14 @@
     {
       "name": "Mailbox",
       "description": "Integrity-untrusted sealed-pointer transport: post, poll, ack"
+    },
+    {
+      "name": "Registry",
+      "description": "Pin/name registry: batch register/retire, union liveness"
+    },
+    {
+      "name": "Account",
+      "description": "Per-account quota and the BYO-IPFS toggle"
     }
   ],
   "servers": [],
@@ -718,6 +897,86 @@
         },
         "required": [
           "success"
+        ]
+      },
+      "RegisterResponseDto": {
+        "type": "object",
+        "properties": {
+          "names": {
+            "type": "number",
+            "description": "Distinct names registered or refreshed in this batch"
+          },
+          "cids": {
+            "type": "number",
+            "description": "Distinct content CIDs pinned/counted in this batch"
+          }
+        },
+        "required": [
+          "names",
+          "cids"
+        ]
+      },
+      "RetireResponseDto": {
+        "type": "object",
+        "properties": {
+          "retired": {
+            "type": "number",
+            "description": "Inventory + pin rows removed for the caller account"
+          },
+          "unpinned": {
+            "type": "number",
+            "description": "CIDs physically unpinned because global refcount reached zero"
+          }
+        },
+        "required": [
+          "retired",
+          "unpinned"
+        ]
+      },
+      "QuotaResponseDto": {
+        "type": "object",
+        "properties": {
+          "usedBytes": {
+            "type": "number",
+            "description": "Bytes currently counted against the account (sum over pin rows)"
+          },
+          "limitBytes": {
+            "type": "number",
+            "description": "The account limit: per-account override, else the env default"
+          },
+          "advisory": {
+            "type": "boolean",
+            "description": "True for BYO accounts, whose rows never gate uploads (quota always allows)"
+          }
+        },
+        "required": [
+          "usedBytes",
+          "limitBytes",
+          "advisory"
+        ]
+      },
+      "SetByoDto": {
+        "type": "object",
+        "properties": {
+          "byo": {
+            "type": "boolean",
+            "description": "Enable BYO-IPFS: pin rows become advisory, never quota-enforced"
+          }
+        },
+        "required": [
+          "byo"
+        ]
+      },
+      "ByoResponseDto": {
+        "type": "object",
+        "properties": {
+          "byo": {
+            "type": "boolean",
+            "description": "The account BYO flag after the update"
+          }
+        },
+        "required": [
+          "byo"
         ]
       }
     }

--- a/apps/api/scripts/generate-openapi.ts
+++ b/apps/api/scripts/generate-openapi.ts
@@ -25,15 +25,26 @@ import { MailboxController } from '../src/mailbox/mailbox.controller';
 import { MailboxService } from '../src/mailbox/services/mailbox.service';
 import { MetricsController } from '../src/ops/metrics.controller';
 import { MetricsService } from '../src/ops/metrics.service';
+import { AccountController } from '../src/registry/account.controller';
+import { RegistryController } from '../src/registry/registry.controller';
+import { RegistryService } from '../src/registry/services/registry.service';
 
 @Module({
-  controllers: [HealthController, MetricsController, AuthController, MailboxController],
+  controllers: [
+    HealthController,
+    MetricsController,
+    AuthController,
+    MailboxController,
+    RegistryController,
+    AccountController,
+  ],
   providers: [
     { provide: AuthService, useValue: {} },
     { provide: TestAuthService, useValue: {} },
     { provide: TokenService, useValue: {} },
     { provide: MailboxService, useValue: {} },
     { provide: MetricsService, useValue: {} },
+    { provide: RegistryService, useValue: {} },
     { provide: JwtService, useValue: {} },
     { provide: ConfigService, useValue: new ConfigService() },
   ],

--- a/apps/api/src/app-setup.ts
+++ b/apps/api/src/app-setup.ts
@@ -62,6 +62,8 @@ export function buildOpenApiDocument(app: INestApplication): OpenAPIObject {
     .addTag('Ops', 'Health and metrics')
     .addTag('Auth', 'Identity auth, SIWE secondary, refresh rotation')
     .addTag('Mailbox', 'Integrity-untrusted sealed-pointer transport: post, poll, ack')
+    .addTag('Registry', 'Pin/name registry: batch register/retire, union liveness')
+    .addTag('Account', 'Per-account quota and the BYO-IPFS toggle')
     .build();
   return SwaggerModule.createDocument(app, config);
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { AuthModule } from './auth/auth.module';
 import { RuntimeModule } from './common/runtime.module';
 import { MailboxModule } from './mailbox/mailbox.module';
 import { OpsModule } from './ops/ops.module';
+import { RegistryModule } from './registry/registry.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { OpsModule } from './ops/ops.module';
     OpsModule,
     AuthModule,
     MailboxModule,
+    RegistryModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/migrations/1784566605863-AddNameInventoryAndPinnedCids.ts
+++ b/apps/api/src/migrations/1784566605863-AddNameInventoryAndPinnedCids.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNameInventoryAndPinnedCids1784566605863 implements MigrationInterface {
+  name = 'AddNameInventoryAndPinnedCids1784566605863';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "pinned_cids" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "account_id" uuid NOT NULL, "cid" character varying(256) NOT NULL, "size" bigint NOT NULL DEFAULT '0', "advisory" boolean NOT NULL DEFAULT false, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_851abdeec6202c4b68375a2db0d" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(`CREATE INDEX "idx_pinned_cids_cid" ON "pinned_cids" ("cid") `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_pinned_cids_account_cid" ON "pinned_cids" ("account_id", "cid") `
+    );
+    await queryRunner.query(
+      `CREATE TABLE "name_inventory" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "account_id" uuid NOT NULL, "ipns_name" character varying(128) NOT NULL, "head_cid" character varying(256), "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_dceb44e1d721492c6672d763bf7" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_name_inventory_ipns_name" ON "name_inventory" ("ipns_name") `
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_name_inventory_account_ipns" ON "name_inventory" ("account_id", "ipns_name") `
+    );
+    await queryRunner.query(
+      `ALTER TABLE "pinned_cids" ADD CONSTRAINT "FK_a87e230cafef1df3885777f1e81" FOREIGN KEY ("account_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "name_inventory" ADD CONSTRAINT "FK_a155da8994ed8c83c47a0cf876d" FOREIGN KEY ("account_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "name_inventory" DROP CONSTRAINT "FK_a155da8994ed8c83c47a0cf876d"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "pinned_cids" DROP CONSTRAINT "FK_a87e230cafef1df3885777f1e81"`
+    );
+    await queryRunner.query(`DROP INDEX "public"."uq_name_inventory_account_ipns"`);
+    await queryRunner.query(`DROP INDEX "public"."idx_name_inventory_ipns_name"`);
+    await queryRunner.query(`DROP TABLE "name_inventory"`);
+    await queryRunner.query(`DROP INDEX "public"."uq_pinned_cids_account_cid"`);
+    await queryRunner.query(`DROP INDEX "public"."idx_pinned_cids_cid"`);
+    await queryRunner.query(`DROP TABLE "pinned_cids"`);
+  }
+}

--- a/apps/api/src/ops/throttling.ts
+++ b/apps/api/src/ops/throttling.ts
@@ -21,4 +21,12 @@ export const THROTTLE_SURFACES = {
   mailboxPoll: { default: { limit: 60, ttl: 60_000 } },
   /** Mailbox ack: per RECIPIENT mailbox; one delete per delivered message. */
   mailboxAck: { default: { limit: 120, ttl: 60_000 } },
+  /**
+   * Registry register/retire: per account. Ordinary writes send single-item
+   * batches; name waves and sweeps send a few bulk batches — so the cap is on
+   * request count, not item count, and sits well above the sync cadence.
+   */
+  registry: { default: { limit: 120, ttl: 60_000 } },
+  /** Account quota/BYO: per account; quota is polled on the statfs path. */
+  account: { default: { limit: 120, ttl: 60_000 } },
 } as const;

--- a/apps/api/src/registry/account.controller.ts
+++ b/apps/api/src/registry/account.controller.ts
@@ -1,0 +1,43 @@
+import { Body, Controller, Get, Patch, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { AuthenticatedRequest, JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { THROTTLE_SURFACES } from '../ops/throttling';
+import { ByoResponseDto, QuotaResponseDto, SetByoDto } from './dto/registry.dto';
+import { RegistryService } from './services/registry.service';
+
+/**
+ * Account-scoped registry surface (blueprint/api.md): the per-account quota
+ * derived from the caller's pin rows, and the BYO-IPFS toggle that flips those
+ * rows between authoritative (hosted) and advisory. Both are authenticated and
+ * act on the caller's OWN account.
+ */
+@ApiTags('Account')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('account')
+export class AccountController {
+  constructor(private readonly registryService: RegistryService) {}
+
+  @Get('quota')
+  @Throttle(THROTTLE_SURFACES.account)
+  @ApiOperation({
+    summary:
+      'The caller per-account quota: usedBytes (sum over pin rows), limitBytes (override or env default), advisory (BYO)',
+  })
+  @ApiOkResponse({ type: QuotaResponseDto })
+  @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
+  quota(@Req() request: AuthenticatedRequest): Promise<QuotaResponseDto> {
+    return this.registryService.quota(request.user.userId);
+  }
+
+  @Patch('byo')
+  @Throttle(THROTTLE_SURFACES.account)
+  @ApiOperation({ summary: 'Toggle the caller BYO-IPFS flag; advisory pin rows follow it' })
+  @ApiOkResponse({ type: ByoResponseDto })
+  @ApiResponse({ status: 400, description: 'Malformed body' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
+  setByo(@Body() body: SetByoDto, @Req() request: AuthenticatedRequest): Promise<ByoResponseDto> {
+    return this.registryService.setByo(request.user.userId, body.byo);
+  }
+}

--- a/apps/api/src/registry/dto/registry.dto.ts
+++ b/apps/api/src/registry/dto/registry.dto.ts
@@ -1,0 +1,107 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsBoolean,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+} from 'class-validator';
+
+/**
+ * A CID or an IPNS name: url-safe base32/base36/base58 token. Kept
+ * deliberately loose — the API is zero-knowledge about the encoding and never
+ * parses the multiformat; it only guards the DB column width and rejects
+ * obvious junk (whitespace, control chars, oversize).
+ */
+const CID_OR_NAME = /^[A-Za-z0-9]{1,256}$/;
+
+/** Batch bounds: bulk name waves and sweeps are large but not unbounded. */
+export const MAX_BATCH = 1000;
+const MAX_CONTENT_CIDS = 1000;
+
+export class RegisterEntryDto {
+  @ApiProperty({
+    description:
+      'The IPNS name to register (libp2p-key CID). Register-first: this row precedes publish.',
+    example: 'k51qzi5uqu5dkuzo866rgfkt5nuqo53l6l3l6zk3l6zk3l6zk3l6zk3l6zk3',
+  })
+  @IsString()
+  @MaxLength(128)
+  @Matches(CID_OR_NAME, { message: 'ipnsName must be a bare CID/name token' })
+  ipnsName!: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Current head (metadata) CID this name publishes; omit to register the name only.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(256)
+  @Matches(CID_OR_NAME, { message: 'headCid must be a bare CID token' })
+  headCid?: string;
+
+  @ApiProperty({
+    type: [String],
+    description: 'Content CIDs to pin/count under this account (idempotent upsert).',
+  })
+  @IsArray()
+  @ArrayMaxSize(MAX_CONTENT_CIDS)
+  @IsString({ each: true })
+  @MaxLength(256, { each: true })
+  @Matches(CID_OR_NAME, { each: true, message: 'each contentCid must be a bare CID token' })
+  contentCids!: string[];
+}
+
+/** The register batch: a top-level JSON array `[{ipnsName, headCid?, contentCids[]}]`. */
+export const REGISTER_ARRAY_OPTIONS = {
+  items: RegisterEntryDto,
+  whitelist: true,
+  forbidNonWhitelisted: true,
+} as const;
+
+/** The retire batch: a top-level JSON array of `[ipnsName | cid]` strings. */
+export const RETIRE_ARRAY_OPTIONS = {
+  items: String,
+} as const;
+
+export class RegisterResponseDto {
+  @ApiProperty({ description: 'Distinct names registered or refreshed in this batch' })
+  names!: number;
+
+  @ApiProperty({ description: 'Distinct content CIDs pinned/counted in this batch' })
+  cids!: number;
+}
+
+export class RetireResponseDto {
+  @ApiProperty({ description: 'Inventory + pin rows removed for the caller account' })
+  retired!: number;
+
+  @ApiProperty({ description: 'CIDs physically unpinned because global refcount reached zero' })
+  unpinned!: number;
+}
+
+export class QuotaResponseDto {
+  @ApiProperty({ description: 'Bytes currently counted against the account (sum over pin rows)' })
+  usedBytes!: number;
+
+  @ApiProperty({ description: 'The account limit: per-account override, else the env default' })
+  limitBytes!: number;
+
+  @ApiProperty({
+    description: 'True for BYO accounts, whose rows never gate uploads (quota always allows)',
+  })
+  advisory!: boolean;
+}
+
+export class SetByoDto {
+  @ApiProperty({ description: 'Enable BYO-IPFS: pin rows become advisory, never quota-enforced' })
+  @IsBoolean()
+  byo!: boolean;
+}
+
+export class ByoResponseDto {
+  @ApiProperty({ description: 'The account BYO flag after the update' })
+  byo!: boolean;
+}

--- a/apps/api/src/registry/dto/registry.dto.ts
+++ b/apps/api/src/registry/dto/registry.dto.ts
@@ -66,6 +66,13 @@ export const RETIRE_ARRAY_OPTIONS = {
   items: String,
 } as const;
 
+/**
+ * Per-target length cap. `ParseArrayPipe`'s `maxLength` never reaches items, so
+ * the guard is enforced explicitly in the controller — 256 matches the widest
+ * target column (`pinned_cids.cid`).
+ */
+export const RETIRE_TARGET_MAX_LENGTH = 256;
+
 export class RegisterResponseDto {
   @ApiProperty({ description: 'Distinct names registered or refreshed in this batch' })
   names!: number;

--- a/apps/api/src/registry/entities/name-inventory.entity.ts
+++ b/apps/api/src/registry/entities/name-inventory.entity.ts
@@ -1,0 +1,55 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../../auth/entities/user.entity';
+
+/**
+ * One name-inventory row: the per-account `(account, ipnsName)` registration
+ * that feeds the republisher inventory (blueprint/api.md, Pin/name registry).
+ *
+ * Membership derives from pin registration on the publish path, never a side
+ * channel: register-first, fail-closed — a name's inventory row exists before
+ * its first publish, so a live-but-uninventoried name is structurally
+ * impossible. Whoever publishes registers under their OWN account; the server
+ * is zero-knowledge about the grant graph and authorizes nothing across
+ * accounts. Union liveness: a name stays in the republish inventory while any
+ * account holds a row for it and leaves when the last row retires — the
+ * republisher walks DISTINCT `ipnsName`s across all accounts.
+ *
+ * The row carries the current head (metadata) CID as a routing hint for the
+ * inventory; the head bytes themselves are pinned via a `pinned_cids` row
+ * (old + new metadata heads transiently double-count during a rotation —
+ * metadata-scale only, accepted).
+ */
+@Entity('name_inventory')
+@Index('uq_name_inventory_account_ipns', ['accountId', 'ipnsName'], { unique: true })
+export class NameInventory {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Owning account (users.id). Rows cascade-delete with the account. */
+  @Column({ name: 'account_id', type: 'uuid' })
+  accountId: string;
+
+  /** The registered IPNS name (libp2p-key CID). Distinct names drive the walk. */
+  @Index('idx_name_inventory_ipns_name')
+  @Column({ name: 'ipns_name', type: 'varchar', length: 128 })
+  ipnsName: string;
+
+  /** Current head (metadata) CID this name points to; null before first publish. */
+  @Column({ name: 'head_cid', type: 'varchar', length: 256, nullable: true })
+  headCid: string | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'account_id' })
+  account: User;
+}

--- a/apps/api/src/registry/entities/pinned-cid.entity.ts
+++ b/apps/api/src/registry/entities/pinned-cid.entity.ts
@@ -1,0 +1,60 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../../auth/entities/user.entity';
+
+/**
+ * One pin row: the per-account `(account, cid, size, advisory)` registration
+ * (blueprint/api.md, Pin/name registry). Content CID rows are the quota and
+ * union-liveness ledger, independent of any name — the same CID is referenced
+ * by many names and re-referenced unchanged across rotations (idempotent
+ * upserts).
+ *
+ * Refcounting is GLOBAL: physical unpin fires only when the LAST account
+ * holding a row for a CID retires it (refcount zero) — v1's `guardedUnpin`
+ * survives. A shared-scope CID stays pinned while any co-registering account
+ * still references it.
+ *
+ * Quota is a per-account sum over these rows' sizes. Hosted rows
+ * (`advisory = false`) are authoritative and gate uploads; a BYO account's
+ * rows are `advisory = true` — counted for union liveness and the inventory,
+ * never quota-enforced (the bytes live on the user's own provider). Size is
+ * established when the hosted upload path pins the bytes; a register that only
+ * records CID membership leaves it at 0.
+ */
+@Entity('pinned_cids')
+@Index('uq_pinned_cids_account_cid', ['accountId', 'cid'], { unique: true })
+export class PinnedCid {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Owning account (users.id). Rows cascade-delete with the account. */
+  @Column({ name: 'account_id', type: 'uuid' })
+  accountId: string;
+
+  /** The pinned content CID. Indexed for the global refcount. */
+  @Index('idx_pinned_cids_cid')
+  @Column({ name: 'cid', type: 'varchar', length: 256 })
+  cid: string;
+
+  /** Pinned size in bytes; 0 until the hosted upload path attaches a real size. */
+  @Column({ name: 'size', type: 'bigint', default: 0 })
+  size: string;
+
+  /** BYO-origin row: counted for liveness/inventory, never quota-enforced. */
+  @Column({ name: 'advisory', type: 'boolean', default: false })
+  advisory: boolean;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'account_id' })
+  account: User;
+}

--- a/apps/api/src/registry/pin-store.ts
+++ b/apps/api/src/registry/pin-store.ts
@@ -1,0 +1,52 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * The physical-unpin seam (blueprint/api.md: "physical unpin fires at global
+ * refcount zero" — v1's `guardedUnpin` survives). The registry owns the
+ * refcount DECISION; this port owns the side effect of releasing bytes from
+ * the hosted pin store.
+ *
+ * It is a best-effort liveness optimization, not a correctness dependency:
+ * the per-account row bookkeeping is the source of truth, so a failed or
+ * unconfigured unpin never fails a retire. The pinned CID simply lingers and
+ * decays from the pin store's own GC — never re-registered, so union liveness
+ * still reports it gone.
+ */
+@Injectable()
+export abstract class PinStore {
+  abstract unpin(cid: string): Promise<void>;
+}
+
+/**
+ * Default hosted implementation: releases a CID from CipherBox Kubo when
+ * `KUBO_API_URL` is configured. Absent that config (unit tests, BYO-only
+ * deployments), it no-ops — the hosted byte path is wired by the content-plane
+ * slice; this slice ships the refcount decision that drives it.
+ */
+@Injectable()
+export class KuboPinStore extends PinStore {
+  private readonly logger = new Logger(PinStore.name);
+  private readonly apiUrl: string | undefined;
+
+  constructor(configService: ConfigService) {
+    super();
+    const raw = configService.get<string>('KUBO_API_URL');
+    this.apiUrl = raw && raw.trim() ? raw.replace(/\/+$/, '') : undefined;
+  }
+
+  async unpin(cid: string): Promise<void> {
+    if (!this.apiUrl) {
+      return;
+    }
+    try {
+      await fetch(`${this.apiUrl}/api/v0/pin/rm?arg=${encodeURIComponent(cid)}&recursive=true`, {
+        method: 'POST',
+      });
+    } catch (error) {
+      // Best-effort: bookkeeping already dropped the row, so a Kubo hiccup
+      // must not fail the caller's retire. Log and move on.
+      this.logger.warn(`pin/rm failed for ${cid}: ${String(error)}`);
+    }
+  }
+}

--- a/apps/api/src/registry/pin-store.ts
+++ b/apps/api/src/registry/pin-store.ts
@@ -40,9 +40,13 @@ export class KuboPinStore extends PinStore {
       return;
     }
     try {
-      await fetch(`${this.apiUrl}/api/v0/pin/rm?arg=${encodeURIComponent(cid)}&recursive=true`, {
-        method: 'POST',
-      });
+      const response = await fetch(
+        `${this.apiUrl}/api/v0/pin/rm?arg=${encodeURIComponent(cid)}&recursive=true`,
+        { method: 'POST', signal: AbortSignal.timeout(5000) }
+      );
+      if (!response.ok) {
+        this.logger.warn(`pin/rm for ${cid} returned ${response.status}`);
+      }
     } catch (error) {
       // Best-effort: bookkeeping already dropped the row, so a Kubo hiccup
       // must not fail the caller's retire. Log and move on.

--- a/apps/api/src/registry/registry.controller.ts
+++ b/apps/api/src/registry/registry.controller.ts
@@ -1,0 +1,83 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  ParseArrayPipe,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { AuthenticatedRequest, JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { THROTTLE_SURFACES } from '../ops/throttling';
+import {
+  MAX_BATCH,
+  REGISTER_ARRAY_OPTIONS,
+  RegisterEntryDto,
+  RegisterResponseDto,
+  RETIRE_ARRAY_OPTIONS,
+  RetireResponseDto,
+} from './dto/registry.dto';
+import { RegistryService } from './services/registry.service';
+
+/**
+ * The pin/name registry surface (blueprint/api.md, Pin/name registry): the one
+ * surface every publish flow traverses, feeding both quota and the republisher
+ * inventory. Both routes are authenticated and act on the caller's OWN
+ * account; both take a top-level JSON array (single-item batches for ordinary
+ * writes, bulk for name waves and sweeps) and are idempotent.
+ */
+@ApiTags('Registry')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('registry')
+export class RegistryController {
+  constructor(private readonly registryService: RegistryService) {}
+
+  @Post('register')
+  @Throttle(THROTTLE_SURFACES.registry)
+  @ApiOperation({
+    summary:
+      'Batch register [{ipnsName, headCid?, contentCids[]}] under the caller account; register-first, idempotent upserts',
+  })
+  @ApiCreatedResponse({ type: RegisterResponseDto })
+  @ApiResponse({ status: 400, description: 'Malformed batch (invalid entry, name, or CID)' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
+  @ApiResponse({ status: 429, description: 'Registry rate limit exceeded' })
+  register(
+    @Body(new ParseArrayPipe(REGISTER_ARRAY_OPTIONS)) entries: RegisterEntryDto[],
+    @Req() request: AuthenticatedRequest
+  ): Promise<RegisterResponseDto> {
+    if (entries.length > MAX_BATCH) {
+      throw new BadRequestException(`Batch exceeds ${MAX_BATCH} entries`);
+    }
+    return this.registryService.register(request.user.userId, entries);
+  }
+
+  @Post('retire')
+  @Throttle(THROTTLE_SURFACES.registry)
+  @ApiOperation({
+    summary:
+      'Batch retire [ipnsName | cid] for the caller account; union liveness, refcounted physical unpin at global zero',
+  })
+  @ApiCreatedResponse({ type: RetireResponseDto })
+  @ApiResponse({ status: 400, description: 'Malformed batch' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
+  @ApiResponse({ status: 429, description: 'Registry rate limit exceeded' })
+  retire(
+    @Body(new ParseArrayPipe(RETIRE_ARRAY_OPTIONS)) targets: string[],
+    @Req() request: AuthenticatedRequest
+  ): Promise<RetireResponseDto> {
+    if (targets.length > MAX_BATCH) {
+      throw new BadRequestException(`Batch exceeds ${MAX_BATCH} targets`);
+    }
+    return this.registryService.retire(request.user.userId, targets);
+  }
+}

--- a/apps/api/src/registry/registry.controller.ts
+++ b/apps/api/src/registry/registry.controller.ts
@@ -3,14 +3,22 @@ import {
   ApiBearerAuth,
   ApiBody,
   ApiCreatedResponse,
+  ApiExtraModels,
   ApiOperation,
   ApiResponse,
   ApiTags,
+  getSchemaPath,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { AuthenticatedRequest, JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { THROTTLE_SURFACES } from '../ops/throttling';
-import { RegisterEntryDto, RegisterResponseDto, RetireResponseDto } from './dto/registry.dto';
+import {
+  MAX_BATCH,
+  RegisterEntryDto,
+  RegisterResponseDto,
+  RETIRE_TARGET_MAX_LENGTH,
+  RetireResponseDto,
+} from './dto/registry.dto';
 import { registerBodyPipes, retireBodyPipes } from './registry.pipes';
 import { RegistryService } from './services/registry.service';
 
@@ -23,6 +31,7 @@ import { RegistryService } from './services/registry.service';
  */
 @ApiTags('Registry')
 @ApiBearerAuth()
+@ApiExtraModels(RegisterEntryDto)
 @UseGuards(JwtAuthGuard)
 @Controller('registry')
 export class RegistryController {
@@ -34,7 +43,13 @@ export class RegistryController {
     summary:
       'Batch register [{ipnsName, headCid?, contentCids[]}] under the caller account; register-first, idempotent upserts',
   })
-  @ApiBody({ type: RegisterEntryDto, isArray: true })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      maxItems: MAX_BATCH,
+      items: { $ref: getSchemaPath(RegisterEntryDto) },
+    },
+  })
   @ApiCreatedResponse({ type: RegisterResponseDto })
   @ApiResponse({ status: 400, description: 'Malformed batch (invalid entry, name, or CID)' })
   @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
@@ -52,7 +67,13 @@ export class RegistryController {
     summary:
       'Batch retire [ipnsName | cid] for the caller account; union liveness, refcounted physical unpin at global zero',
   })
-  @ApiBody({ type: String, isArray: true })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      maxItems: MAX_BATCH,
+      items: { type: 'string', maxLength: RETIRE_TARGET_MAX_LENGTH },
+    },
+  })
   @ApiCreatedResponse({ type: RetireResponseDto })
   @ApiResponse({ status: 400, description: 'Malformed batch' })
   @ApiResponse({ status: 401, description: 'Missing or invalid access token' })

--- a/apps/api/src/registry/registry.controller.ts
+++ b/apps/api/src/registry/registry.controller.ts
@@ -1,14 +1,7 @@
-import {
-  BadRequestException,
-  Body,
-  Controller,
-  ParseArrayPipe,
-  Post,
-  Req,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiCreatedResponse,
   ApiOperation,
   ApiResponse,
@@ -17,14 +10,8 @@ import {
 import { Throttle } from '@nestjs/throttler';
 import { AuthenticatedRequest, JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { THROTTLE_SURFACES } from '../ops/throttling';
-import {
-  MAX_BATCH,
-  REGISTER_ARRAY_OPTIONS,
-  RegisterEntryDto,
-  RegisterResponseDto,
-  RETIRE_ARRAY_OPTIONS,
-  RetireResponseDto,
-} from './dto/registry.dto';
+import { RegisterEntryDto, RegisterResponseDto, RetireResponseDto } from './dto/registry.dto';
+import { registerBodyPipes, retireBodyPipes } from './registry.pipes';
 import { RegistryService } from './services/registry.service';
 
 /**
@@ -47,17 +34,15 @@ export class RegistryController {
     summary:
       'Batch register [{ipnsName, headCid?, contentCids[]}] under the caller account; register-first, idempotent upserts',
   })
+  @ApiBody({ type: RegisterEntryDto, isArray: true })
   @ApiCreatedResponse({ type: RegisterResponseDto })
   @ApiResponse({ status: 400, description: 'Malformed batch (invalid entry, name, or CID)' })
   @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
   @ApiResponse({ status: 429, description: 'Registry rate limit exceeded' })
   register(
-    @Body(new ParseArrayPipe(REGISTER_ARRAY_OPTIONS)) entries: RegisterEntryDto[],
+    @Body(...registerBodyPipes) entries: RegisterEntryDto[],
     @Req() request: AuthenticatedRequest
   ): Promise<RegisterResponseDto> {
-    if (entries.length > MAX_BATCH) {
-      throw new BadRequestException(`Batch exceeds ${MAX_BATCH} entries`);
-    }
     return this.registryService.register(request.user.userId, entries);
   }
 
@@ -67,17 +52,15 @@ export class RegistryController {
     summary:
       'Batch retire [ipnsName | cid] for the caller account; union liveness, refcounted physical unpin at global zero',
   })
+  @ApiBody({ type: String, isArray: true })
   @ApiCreatedResponse({ type: RetireResponseDto })
   @ApiResponse({ status: 400, description: 'Malformed batch' })
   @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
   @ApiResponse({ status: 429, description: 'Registry rate limit exceeded' })
   retire(
-    @Body(new ParseArrayPipe(RETIRE_ARRAY_OPTIONS)) targets: string[],
+    @Body(...retireBodyPipes) targets: string[],
     @Req() request: AuthenticatedRequest
   ): Promise<RetireResponseDto> {
-    if (targets.length > MAX_BATCH) {
-      throw new BadRequestException(`Batch exceeds ${MAX_BATCH} targets`);
-    }
     return this.registryService.retire(request.user.userId, targets);
   }
 }

--- a/apps/api/src/registry/registry.http.test.ts
+++ b/apps/api/src/registry/registry.http.test.ts
@@ -1,0 +1,234 @@
+import { INestApplication } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { configureApp } from '../app-setup';
+import { User } from '../auth/entities/user.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OpsModule } from '../ops/ops.module';
+import { FakeRepository } from '../testing/fake-repo';
+import { fakeConfig } from '../testing/fakes';
+import { AccountController } from './account.controller';
+import { NameInventory } from './entities/name-inventory.entity';
+import { PinnedCid } from './entities/pinned-cid.entity';
+import { PinStore } from './pin-store';
+import { RegistryController } from './registry.controller';
+import { RegistryService } from './services/registry.service';
+
+const SECRET = 'registry-test-secret';
+const GIB = 1024 * 1024 * 1024;
+
+/** Records physical unpins so the refcount-zero decision is observable in HTTP tests. */
+class FakePinStore extends PinStore {
+  readonly unpinned: string[] = [];
+  async unpin(cid: string): Promise<void> {
+    this.unpinned.push(cid);
+  }
+}
+
+describe('registry HTTP surface', () => {
+  let app: INestApplication;
+  let http: ReturnType<INestApplication['getHttpServer']>;
+  let userRepo: FakeRepository<User>;
+  let nameRepo: FakeRepository<NameInventory>;
+  let pinRepo: FakeRepository<PinnedCid>;
+  let pinStore: FakePinStore;
+  let jwt: JwtService;
+  let priorJwtSecret: string | undefined;
+
+  beforeAll(async () => {
+    priorJwtSecret = process.env.JWT_SECRET;
+    process.env.JWT_SECRET = SECRET;
+
+    userRepo = new FakeRepository<User>();
+    nameRepo = new FakeRepository<NameInventory>();
+    pinRepo = new FakeRepository<PinnedCid>();
+    pinStore = new FakePinStore();
+    jwt = new JwtService();
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true }),
+        OpsModule,
+        JwtModule.register({ secret: SECRET, signOptions: { expiresIn: 900 } }),
+      ],
+      controllers: [RegistryController, AccountController],
+      providers: [
+        RegistryService,
+        JwtAuthGuard,
+        { provide: PinStore, useValue: pinStore },
+        {
+          provide: ConfigService,
+          useValue: fakeConfig({ QUOTA_DEFAULT_BYTES: String(10 * GIB) }).service,
+        },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+        { provide: getRepositoryToken(NameInventory), useValue: nameRepo },
+        { provide: getRepositoryToken(PinnedCid), useValue: pinRepo },
+      ],
+    }).compile();
+
+    app = configureApp(moduleRef.createNestApplication());
+    await app.init();
+    http = app.getHttpServer();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    if (priorJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = priorJwtSecret;
+    }
+  });
+
+  /** Seed an account and mint a valid access token for it. */
+  async function account(overrides: Partial<User> = {}): Promise<{ id: string; token: string }> {
+    const priv = secp256k1.utils.randomPrivateKey();
+    const publicKey = Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+    const user = await userRepo.save({ publicKey, byo: false, ...overrides } as never);
+    const token = await jwt.signAsync({ sub: user.id, publicKey }, { secret: SECRET });
+    return { id: user.id, token };
+  }
+
+  describe('register — register-first, idempotency', () => {
+    it('registers a name with its head and content, reflected in the inventory', async () => {
+      const acct = await account();
+      const res = await request(http)
+        .post('/registry/register')
+        .set('Authorization', `Bearer ${acct.token}`)
+        .send([{ ipnsName: 'k51regA', headCid: 'bafyHeadA', contentCids: ['bafyC1', 'bafyC2'] }])
+        .expect(201);
+      expect(res.body).toEqual({ names: 1, cids: 3 });
+      expect(nameRepo.rows.filter((r) => r.accountId === acct.id)).toHaveLength(1);
+      expect(
+        pinRepo.rows
+          .filter((r) => r.accountId === acct.id)
+          .map((r) => r.cid)
+          .sort()
+      ).toEqual(['bafyC1', 'bafyC2', 'bafyHeadA']);
+    });
+
+    it('is idempotent: replaying a batch adds no duplicate rows', async () => {
+      const acct = await account();
+      const batch = [{ ipnsName: 'k51idem', headCid: 'bafyIdem', contentCids: ['bafyDup'] }];
+      await request(http)
+        .post('/registry/register')
+        .set('Authorization', `Bearer ${acct.token}`)
+        .send(batch)
+        .expect(201);
+      await request(http)
+        .post('/registry/register')
+        .set('Authorization', `Bearer ${acct.token}`)
+        .send(batch)
+        .expect(201);
+      expect(nameRepo.rows.filter((r) => r.ipnsName === 'k51idem')).toHaveLength(1);
+      expect(
+        pinRepo.rows.filter((r) => r.accountId === acct.id && r.cid === 'bafyDup')
+      ).toHaveLength(1);
+    });
+
+    it('fail-closed: a malformed entry is refused wholesale, writing no rows', async () => {
+      const acct = await account();
+      const before = nameRepo.rows.length;
+      // Invalid ipnsName (illegal chars) — the whole request 400s.
+      await request(http)
+        .post('/registry/register')
+        .set('Authorization', `Bearer ${acct.token}`)
+        .send([{ ipnsName: 'not a name!', contentCids: ['bafyX'] }])
+        .expect(400);
+      // Unknown property on an entry — forbidNonWhitelisted rejects it.
+      await request(http)
+        .post('/registry/register')
+        .set('Authorization', `Bearer ${acct.token}`)
+        .send([{ ipnsName: 'k51ok', contentCids: [], sneaky: 'no' }])
+        .expect(400);
+      expect(nameRepo.rows.length).toBe(before);
+      expect(pinRepo.rows.some((r) => r.cid === 'bafyX')).toBe(false);
+    });
+  });
+
+  describe('retire — union liveness, refcounted unpin', () => {
+    it('keeps a shared CID pinned until the last account retires, then unpins', async () => {
+      const alice = await account();
+      const bob = await account();
+      const shared = 'bafySharedHttp';
+      for (const who of [alice, bob]) {
+        await request(http)
+          .post('/registry/register')
+          .set('Authorization', `Bearer ${who.token}`)
+          .send([{ ipnsName: `k51${who.id.slice(0, 8)}`, contentCids: [shared] }])
+          .expect(201);
+      }
+
+      const first = await request(http)
+        .post('/registry/retire')
+        .set('Authorization', `Bearer ${alice.token}`)
+        .send([shared])
+        .expect(201);
+      expect(first.body).toEqual({ retired: 1, unpinned: 0 });
+      expect(pinStore.unpinned).not.toContain(shared);
+      expect(pinRepo.rows.filter((r) => r.cid === shared)).toHaveLength(1);
+
+      const second = await request(http)
+        .post('/registry/retire')
+        .set('Authorization', `Bearer ${bob.token}`)
+        .send([shared])
+        .expect(201);
+      expect(second.body).toEqual({ retired: 1, unpinned: 1 });
+      expect(pinStore.unpinned).toContain(shared);
+      expect(pinRepo.rows.filter((r) => r.cid === shared)).toHaveLength(0);
+    });
+  });
+
+  describe('quota — hosted authoritative vs BYO advisory', () => {
+    it('sums the account pin rows and reports the env-default limit for a hosted account', async () => {
+      const acct = await account();
+      await pinRepo.save({
+        accountId: acct.id,
+        cid: 'bafyQ',
+        size: '512',
+        advisory: false,
+      } as never);
+      const res = await request(http)
+        .get('/account/quota')
+        .set('Authorization', `Bearer ${acct.token}`)
+        .expect(200);
+      expect(res.body).toEqual({ usedBytes: 512, limitBytes: 10 * GIB, advisory: false });
+    });
+
+    it('flips advisory once the account enables BYO', async () => {
+      const acct = await account();
+      const before = await request(http)
+        .get('/account/quota')
+        .set('Authorization', `Bearer ${acct.token}`)
+        .expect(200);
+      expect(before.body.advisory).toBe(false);
+
+      const patched = await request(http)
+        .patch('/account/byo')
+        .set('Authorization', `Bearer ${acct.token}`)
+        .send({ byo: true })
+        .expect(200);
+      expect(patched.body).toEqual({ byo: true });
+
+      const after = await request(http)
+        .get('/account/quota')
+        .set('Authorization', `Bearer ${acct.token}`)
+        .expect(200);
+      expect(after.body.advisory).toBe(true);
+    });
+  });
+
+  describe('auth', () => {
+    it('requires authentication on every route', async () => {
+      await request(http).post('/registry/register').send([]).expect(401);
+      await request(http).post('/registry/retire').send([]).expect(401);
+      await request(http).get('/account/quota').expect(401);
+      await request(http).patch('/account/byo').send({ byo: true }).expect(401);
+    });
+  });
+});

--- a/apps/api/src/registry/registry.http.test.ts
+++ b/apps/api/src/registry/registry.http.test.ts
@@ -140,6 +140,7 @@ describe('registry HTTP surface', () => {
         {
           provide: DataSource,
           useValue: fakeDataSource([
+            [User, userRepo],
             [NameInventory, nameRepo],
             [PinnedCid, pinRepo],
           ]),

--- a/apps/api/src/registry/registry.http.test.ts
+++ b/apps/api/src/registry/registry.http.test.ts
@@ -5,6 +5,7 @@ import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import request from 'supertest';
+import { DataSource, FindOperator } from 'typeorm';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { configureApp } from '../app-setup';
 import { User } from '../auth/entities/user.entity';
@@ -30,12 +31,77 @@ class FakePinStore extends PinStore {
   }
 }
 
+/** Matches plain equality plus the `In([...])` operator the bulk paths use. */
+function inMatch(row: Record<string, unknown>, where: Record<string, unknown>): boolean {
+  return Object.entries(where).every(([key, expected]) => {
+    if (expected instanceof FindOperator) {
+      if (expected.type === 'in') {
+        return (expected.value as unknown[]).includes(row[key]);
+      }
+      throw new Error(`InAwareRepository: unsupported operator ${expected.type}`);
+    }
+    return row[key] === expected;
+  });
+}
+
+/** FakeRepository plus the `In`/array-save/`sum` surface the bulk paths need. */
+class InAwareRepository<T extends { id: string }> extends FakeRepository<T> {
+  override async find(options: { where?: Record<string, unknown> } = {}): Promise<T[]> {
+    const where = options.where;
+    if (!where) {
+      return [...this.rows];
+    }
+    return this.rows.filter((row) => inMatch(row as Record<string, unknown>, where));
+  }
+
+  override async delete(criteria: Record<string, unknown>): Promise<{ affected: number }> {
+    const before = this.rows.length;
+    this.rows = this.rows.filter((row) => !inMatch(row as Record<string, unknown>, criteria));
+    return { affected: before - this.rows.length };
+  }
+
+  override save(entity: Partial<T>): Promise<T>;
+  override save(entities: Partial<T>[]): Promise<T[]>;
+  override async save(entities: Partial<T> | Partial<T>[]): Promise<T | T[]> {
+    if (Array.isArray(entities)) {
+      const saved: T[] = [];
+      for (const entity of entities) {
+        saved.push(await super.save(entity));
+      }
+      return saved;
+    }
+    return super.save(entities);
+  }
+
+  async sum(column: string, where?: Record<string, unknown>): Promise<number | null> {
+    const rows = where
+      ? this.rows.filter((row) => inMatch(row as Record<string, unknown>, where))
+      : this.rows;
+    if (rows.length === 0) {
+      return null;
+    }
+    return rows.reduce(
+      (total, row) => total + Number((row as Record<string, unknown>)[column] ?? 0),
+      0
+    );
+  }
+}
+
+/** A DataSource whose transaction runs inline against the in-memory repos. */
+function fakeDataSource(repos: Array<[unknown, unknown]>): DataSource {
+  const byEntity = new Map(repos);
+  return {
+    transaction: (runInTransaction: (manager: unknown) => unknown) =>
+      runInTransaction({ getRepository: (entity: unknown) => byEntity.get(entity) }),
+  } as unknown as DataSource;
+}
+
 describe('registry HTTP surface', () => {
   let app: INestApplication;
   let http: ReturnType<INestApplication['getHttpServer']>;
   let userRepo: FakeRepository<User>;
-  let nameRepo: FakeRepository<NameInventory>;
-  let pinRepo: FakeRepository<PinnedCid>;
+  let nameRepo: InAwareRepository<NameInventory>;
+  let pinRepo: InAwareRepository<PinnedCid>;
   let pinStore: FakePinStore;
   let jwt: JwtService;
   let priorJwtSecret: string | undefined;
@@ -45,8 +111,8 @@ describe('registry HTTP surface', () => {
     process.env.JWT_SECRET = SECRET;
 
     userRepo = new FakeRepository<User>();
-    nameRepo = new FakeRepository<NameInventory>();
-    pinRepo = new FakeRepository<PinnedCid>();
+    nameRepo = new InAwareRepository<NameInventory>();
+    pinRepo = new InAwareRepository<PinnedCid>();
     pinStore = new FakePinStore();
     jwt = new JwtService();
 
@@ -68,6 +134,13 @@ describe('registry HTTP surface', () => {
         { provide: getRepositoryToken(User), useValue: userRepo },
         { provide: getRepositoryToken(NameInventory), useValue: nameRepo },
         { provide: getRepositoryToken(PinnedCid), useValue: pinRepo },
+        {
+          provide: DataSource,
+          useValue: fakeDataSource([
+            [NameInventory, nameRepo],
+            [PinnedCid, pinRepo],
+          ]),
+        },
       ],
     }).compile();
 
@@ -181,6 +254,15 @@ describe('registry HTTP surface', () => {
       expect(second.body).toEqual({ retired: 1, unpinned: 1 });
       expect(pinStore.unpinned).toContain(shared);
       expect(pinRepo.rows.filter((r) => r.cid === shared)).toHaveLength(0);
+    });
+
+    it('rejects an over-length target at the pipe (256-char cap)', async () => {
+      const acct = await account();
+      await request(http)
+        .post('/registry/retire')
+        .set('Authorization', `Bearer ${acct.token}`)
+        .send(['a'.repeat(257)])
+        .expect(400);
     });
   });
 

--- a/apps/api/src/registry/registry.http.test.ts
+++ b/apps/api/src/registry/registry.http.test.ts
@@ -92,7 +92,10 @@ function fakeDataSource(repos: Array<[unknown, unknown]>): DataSource {
   const byEntity = new Map(repos);
   return {
     transaction: (runInTransaction: (manager: unknown) => unknown) =>
-      runInTransaction({ getRepository: (entity: unknown) => byEntity.get(entity) }),
+      runInTransaction({
+        getRepository: (entity: unknown) => byEntity.get(entity),
+        query: async () => [],
+      }),
   } as unknown as DataSource;
 }
 
@@ -161,10 +164,14 @@ describe('registry HTTP surface', () => {
   /** Seed an account and mint a valid access token for it. */
   async function account(overrides: Partial<User> = {}): Promise<{ id: string; token: string }> {
     const priv = secp256k1.utils.randomPrivateKey();
-    const publicKey = Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
-    const user = await userRepo.save({ publicKey, byo: false, ...overrides } as never);
-    const token = await jwt.signAsync({ sub: user.id, publicKey }, { secret: SECRET });
-    return { id: user.id, token };
+    try {
+      const publicKey = Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+      const user = await userRepo.save({ publicKey, byo: false, ...overrides } as never);
+      const token = await jwt.signAsync({ sub: user.id, publicKey }, { secret: SECRET });
+      return { id: user.id, token };
+    } finally {
+      priv.fill(0);
+    }
   }
 
   describe('register — register-first, idempotency', () => {

--- a/apps/api/src/registry/registry.module.ts
+++ b/apps/api/src/registry/registry.module.ts
@@ -1,0 +1,34 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { buildJwtOptions } from '../auth/auth.module';
+import { User } from '../auth/entities/user.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AccountController } from './account.controller';
+import { NameInventory } from './entities/name-inventory.entity';
+import { PinnedCid } from './entities/pinned-cid.entity';
+import { KuboPinStore, PinStore } from './pin-store';
+import { RegistryController } from './registry.controller';
+import { RegistryService } from './services/registry.service';
+
+/**
+ * The pin/name registry slice (blueprint/api.md, Pin/name registry): the
+ * register/retire inventory, the per-account quota, and the BYO toggle. Reads
+ * the users table for the account BYO flag and quota override; route auth
+ * reuses the auth slice's JwtAuthGuard and JWT configuration. The physical
+ * unpin is the injectable [`PinStore`] seam (Kubo-backed in a hosted deploy).
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([NameInventory, PinnedCid, User]),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: buildJwtOptions,
+    }),
+  ],
+  controllers: [RegistryController, AccountController],
+  providers: [RegistryService, JwtAuthGuard, { provide: PinStore, useClass: KuboPinStore }],
+})
+export class RegistryModule {}

--- a/apps/api/src/registry/registry.pipes.ts
+++ b/apps/api/src/registry/registry.pipes.ts
@@ -1,0 +1,49 @@
+import { BadRequestException, ParseArrayPipe, PipeTransform } from '@nestjs/common';
+import {
+  MAX_BATCH,
+  REGISTER_ARRAY_OPTIONS,
+  RETIRE_ARRAY_OPTIONS,
+  RETIRE_TARGET_MAX_LENGTH,
+} from './dto/registry.dto';
+
+/** Reject an oversize batch up front, before per-item validation runs. */
+class BatchSizePipe implements PipeTransform {
+  constructor(
+    private readonly max: number,
+    private readonly noun: string
+  ) {}
+
+  transform(value: unknown): unknown {
+    if (Array.isArray(value) && value.length > this.max) {
+      throw new BadRequestException(`Batch exceeds ${this.max} ${this.noun}`);
+    }
+    return value;
+  }
+}
+
+/** Cap each retire target's length; ParseArrayPipe never reaches items. */
+class TargetLengthPipe implements PipeTransform {
+  constructor(private readonly max: number) {}
+
+  transform(value: string[]): string[] {
+    for (const target of value) {
+      if (target.length > this.max) {
+        throw new BadRequestException(`target exceeds ${this.max} characters`);
+      }
+    }
+    return value;
+  }
+}
+
+/** Size guard first, then the register DTO validation. */
+export const registerBodyPipes = [
+  new BatchSizePipe(MAX_BATCH, 'entries'),
+  new ParseArrayPipe(REGISTER_ARRAY_OPTIONS),
+];
+
+/** Size guard first, then array parse, then the per-target length cap. */
+export const retireBodyPipes = [
+  new BatchSizePipe(MAX_BATCH, 'targets'),
+  new ParseArrayPipe(RETIRE_ARRAY_OPTIONS),
+  new TargetLengthPipe(RETIRE_TARGET_MAX_LENGTH),
+];

--- a/apps/api/src/registry/services/registry.service.concurrency.test.ts
+++ b/apps/api/src/registry/services/registry.service.concurrency.test.ts
@@ -1,0 +1,274 @@
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { randomBytes } from 'node:crypto';
+import { DataSource, EntityManager, FindOneOptions, Repository } from 'typeorm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { AuthMethod } from '../../auth/entities/auth-method.entity';
+import { RefreshToken } from '../../auth/entities/refresh-token.entity';
+import { User } from '../../auth/entities/user.entity';
+import { fakeConfig } from '../../testing/fakes';
+import { NameInventory } from '../entities/name-inventory.entity';
+import { PinnedCid } from '../entities/pinned-cid.entity';
+import { PinStore } from '../pin-store';
+import { RegistryService } from './registry.service';
+
+/**
+ * The BYO-flag read serialized against a concurrent toggle, proven on a REAL
+ * Postgres. register reads `users.byo` under a `pessimistic_write` row lock
+ * inside its transaction; a concurrent setByo (a plain row UPDATE) must block
+ * on that lock until register commits, so a new pin row can never be stamped
+ * with a BYO flag that changed mid-transaction. Real row locks are genuine
+ * Postgres behavior — no in-memory fake can exercise the block — so this suite
+ * is opt-in: it runs only when `REGISTRY_DB_TEST=1` with a reachable Postgres
+ * (standard DB_* env, defaults matching docker/docker-compose.yml). Left unset
+ * — as in the fake-only `Run API unit suite` CI job — the whole suite skips.
+ */
+const RUN_DB_TEST = process.env.REGISTRY_DB_TEST === '1';
+
+const DB = {
+  host: process.env.DB_HOST ?? 'localhost',
+  port: Number(process.env.DB_PORT ?? 5432),
+  user: process.env.DB_USERNAME ?? 'postgres',
+  password: process.env.DB_PASSWORD ?? 'postgres',
+};
+
+// A throwaway database, created and dropped by this suite, so the shared dev
+// `cipherbox` database is never touched.
+const TEST_DB = 'cipherbox_registry_byo_test';
+
+/** Run one-off admin DDL (CREATE/DROP DATABASE) via a short-lived connection to
+ * the default `postgres` database. Kept off TypeORM's entity path so it needs no
+ * `pg` type declarations. */
+async function adminExec(sql: string): Promise<void> {
+  const admin = new DataSource({
+    type: 'postgres',
+    host: DB.host,
+    port: DB.port,
+    username: DB.user,
+    password: DB.password,
+    database: 'postgres',
+  });
+  await admin.initialize();
+  try {
+    await admin.query(sql);
+  } finally {
+    await admin.destroy();
+  }
+}
+
+function compressedPublicKey(): string {
+  const priv = secp256k1.utils.randomPrivateKey();
+  try {
+    return Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+  } finally {
+    priv.fill(0);
+  }
+}
+
+/** A random opaque token — stands in for an IPNS name or a content CID. */
+function token(): string {
+  return randomBytes(16).toString('hex');
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+class NoopPinStore extends PinStore {
+  async unpin(): Promise<void> {}
+}
+
+/** A barrier register trips the instant it has read (and locked) the users row. */
+interface ReadGate {
+  reached: Promise<void>;
+  release: () => void;
+  onRead: () => Promise<void>;
+}
+
+function makeGate(): ReadGate {
+  let signalReached!: () => void;
+  let release!: () => void;
+  const reached = new Promise<void>((resolve) => (signalReached = resolve));
+  const open = new Promise<void>((resolve) => (release = resolve));
+  return {
+    reached,
+    release,
+    onRead: async () => {
+      signalReached();
+      await open;
+    },
+  };
+}
+
+/**
+ * A DataSource that runs the real transaction but pauses register the instant
+ * its `User.findOne` returns — while the row lock is still held — so a racing
+ * setByo can be observed to block. `stripLock` drops the pessimistic lock to
+ * model the pre-fix read and reproduce the race.
+ */
+function gatedDataSource(
+  real: DataSource,
+  onRead: () => Promise<void>,
+  stripLock = false
+): DataSource {
+  const wrapUserRepo = (repo: Repository<User>): Repository<User> =>
+    new Proxy(repo, {
+      get(target, prop, receiver) {
+        if (prop === 'findOne') {
+          return async (options: FindOneOptions<User>) => {
+            const opts = stripLock ? { ...options, lock: undefined } : options;
+            const row = await target.findOne(opts);
+            await onRead();
+            return row;
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+
+  return {
+    transaction: (runInTransaction: (manager: EntityManager) => Promise<unknown>) =>
+      real.transaction((manager) => {
+        const proxied = new Proxy(manager, {
+          get(target, prop, receiver) {
+            if (prop === 'getRepository') {
+              return (entity: unknown) => {
+                const repo = target.getRepository(entity as never);
+                return entity === User ? wrapUserRepo(repo as Repository<User>) : repo;
+              };
+            }
+            const value = Reflect.get(target, prop, receiver);
+            return typeof value === 'function' ? value.bind(target) : value;
+          },
+        });
+        return runInTransaction(proxied);
+      }),
+  } as unknown as DataSource;
+}
+
+describe.skipIf(!RUN_DB_TEST)('RegistryService BYO-flag serialization (real Postgres)', () => {
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    await adminExec(`DROP DATABASE IF EXISTS ${TEST_DB} WITH (FORCE)`);
+    await adminExec(`CREATE DATABASE ${TEST_DB}`);
+
+    dataSource = new DataSource({
+      type: 'postgres',
+      host: DB.host,
+      port: DB.port,
+      username: DB.user,
+      password: DB.password,
+      database: TEST_DB,
+      entities: [User, AuthMethod, RefreshToken, NameInventory, PinnedCid],
+      synchronize: false,
+      uuidExtension: 'pgcrypto',
+      // Room for register's held transaction plus the racing setByo connection.
+      extra: { max: 10 },
+    });
+    await dataSource.initialize();
+    await dataSource.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+    await dataSource.synchronize();
+  }, 30_000);
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+    await adminExec(`DROP DATABASE IF EXISTS ${TEST_DB} WITH (FORCE)`);
+  });
+
+  beforeEach(async () => {
+    await dataSource.query('TRUNCATE TABLE users CASCADE');
+  });
+
+  // register takes the gated DataSource; setByo takes the real one (a plain
+  // row UPDATE). Both share the same underlying users table and connection pool.
+  function buildService(ds: DataSource): RegistryService {
+    return new RegistryService(
+      dataSource.getRepository(PinnedCid) as never,
+      dataSource.getRepository(User) as never,
+      ds as never,
+      new NoopPinStore(),
+      fakeConfig({}).service
+    );
+  }
+
+  async function seedAccount(byo: boolean): Promise<string> {
+    const user = await dataSource
+      .getRepository(User)
+      .save({ publicKey: compressedPublicKey(), byo });
+    return user.id;
+  }
+
+  async function pinsFor(accountId: string): Promise<PinnedCid[]> {
+    return dataSource.getRepository(PinnedCid).find({ where: { accountId } });
+  }
+
+  it('a concurrent setByo blocks while register holds the users-row lock; the new pin row keeps the value read under the lock', async () => {
+    const accountId = await seedAccount(false);
+    const gate = makeGate();
+    const register = buildService(gatedDataSource(dataSource, gate.onRead));
+
+    const registered = register.register(accountId, [
+      { ipnsName: token(), contentCids: [token()] },
+    ]);
+
+    // register has taken the row lock and read byo=false; it now waits, still
+    // holding the lock and uncommitted.
+    await gate.reached;
+
+    let setByoDone = false;
+    const toggled = buildService(dataSource)
+      .setByo(accountId, true)
+      .then((result) => {
+        setByoDone = true;
+        return result;
+      });
+
+    // The toggle is blocked on register's row lock — it cannot commit.
+    await delay(200);
+    expect(setByoDone).toBe(false);
+
+    gate.release();
+    const result = await registered;
+    const toggleResult = await toggled;
+
+    expect(setByoDone).toBe(true);
+    expect(result).toEqual({ names: 1, cids: 1 });
+    expect(toggleResult).toEqual({ byo: true });
+
+    // The pin row carries advisory=false — register's locked read — and the
+    // toggle applied strictly after register committed.
+    const pins = await pinsFor(accountId);
+    expect(pins).toHaveLength(1);
+    expect(pins[0].advisory).toBe(false);
+    const user = await dataSource.getRepository(User).findOne({ where: { id: accountId } });
+    expect(user?.byo).toBe(true);
+  });
+
+  it('negative control — without the row lock, setByo commits between the read and the insert, tearing the advisory stamp', async () => {
+    const accountId = await seedAccount(false);
+    const gate = makeGate();
+    // Same interleaving, but the users read drops the pessimistic lock (the
+    // pre-fix code path) — nothing serializes register against the toggle.
+    const register = buildService(gatedDataSource(dataSource, gate.onRead, true));
+
+    const registered = register.register(accountId, [
+      { ipnsName: token(), contentCids: [token()] },
+    ]);
+    await gate.reached;
+
+    // With no row lock, the toggle commits immediately, mid-register.
+    await buildService(dataSource).setByo(accountId, true);
+    const midUser = await dataSource.getRepository(User).findOne({ where: { id: accountId } });
+    expect(midUser?.byo).toBe(true);
+
+    gate.release();
+    await registered;
+
+    // The pin row is stamped advisory=false — the stale pre-toggle read — even
+    // though the account is now BYO. This is the race the row lock closes.
+    const pins = await pinsFor(accountId);
+    expect(pins).toHaveLength(1);
+    expect(pins[0].advisory).toBe(false);
+  });
+});

--- a/apps/api/src/registry/services/registry.service.test.ts
+++ b/apps/api/src/registry/services/registry.service.test.ts
@@ -1,0 +1,237 @@
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { UnauthorizedException } from '@nestjs/common';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { User } from '../../auth/entities/user.entity';
+import { FakeRepository } from '../../testing/fake-repo';
+import { fakeConfig } from '../../testing/fakes';
+import { NameInventory } from '../entities/name-inventory.entity';
+import { PinnedCid } from '../entities/pinned-cid.entity';
+import { PinStore } from '../pin-store';
+import { RegistryService } from './registry.service';
+
+function newPublicKey(): string {
+  const priv = secp256k1.utils.randomPrivateKey();
+  return Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+}
+
+/** Records every physical unpin so the refcount-zero decision is observable. */
+class FakePinStore extends PinStore {
+  readonly unpinned: string[] = [];
+  async unpin(cid: string): Promise<void> {
+    this.unpinned.push(cid);
+  }
+}
+
+const GIB = 1024 * 1024 * 1024;
+
+describe('RegistryService', () => {
+  let names: FakeRepository<NameInventory>;
+  let pins: FakeRepository<PinnedCid>;
+  let users: FakeRepository<User>;
+  let pinStore: FakePinStore;
+  let service: RegistryService;
+
+  function build(config: Record<string, string | undefined> = {}) {
+    names = new FakeRepository<NameInventory>();
+    pins = new FakeRepository<PinnedCid>();
+    users = new FakeRepository<User>();
+    pinStore = new FakePinStore();
+    service = new RegistryService(
+      names as never,
+      pins as never,
+      users as never,
+      pinStore,
+      fakeConfig(config).service
+    );
+  }
+
+  async function account(overrides: Partial<User> = {}): Promise<string> {
+    const user = await users.save({ publicKey: newPublicKey(), byo: false, ...overrides } as never);
+    return user.id;
+  }
+
+  beforeEach(() => build());
+
+  describe('register — register-first, idempotent upserts', () => {
+    it('creates the name row before any content pin, and pins head + content', async () => {
+      const acct = await account();
+      const result = await service.register(acct, [
+        { ipnsName: 'k51name', headCid: 'bafyHead', contentCids: ['bafyA', 'bafyB'] },
+      ]);
+
+      expect(result).toEqual({ names: 1, cids: 3 });
+      // The name is inventoried (register-first) with its head as a routing hint.
+      expect(names.rows).toHaveLength(1);
+      expect(names.rows[0]).toMatchObject({
+        accountId: acct,
+        ipnsName: 'k51name',
+        headCid: 'bafyHead',
+      });
+      // Head + content are all pinned under the account.
+      expect(pins.rows.map((r) => r.cid).sort()).toEqual(['bafyA', 'bafyB', 'bafyHead']);
+      expect(pins.rows.every((r) => r.accountId === acct)).toBe(true);
+    });
+
+    it('registers a bare name with no content when headCid and contentCids are absent', async () => {
+      const acct = await account();
+      const result = await service.register(acct, [{ ipnsName: 'k51bare', contentCids: [] }]);
+      expect(result).toEqual({ names: 1, cids: 0 });
+      expect(names.rows).toHaveLength(1);
+      expect(pins.rows).toHaveLength(0);
+    });
+
+    it('is idempotent: replaying the same batch adds no duplicate rows', async () => {
+      const acct = await account();
+      const batch = [{ ipnsName: 'k51name', headCid: 'bafyHead', contentCids: ['bafyA'] }];
+      await service.register(acct, batch);
+      await service.register(acct, batch);
+      expect(names.rows).toHaveLength(1);
+      expect(pins.rows).toHaveLength(2); // bafyHead + bafyA, once each
+    });
+
+    it('advances the head on re-publish without duplicating the name row', async () => {
+      const acct = await account();
+      await service.register(acct, [{ ipnsName: 'k51name', headCid: 'bafyOld', contentCids: [] }]);
+      await service.register(acct, [{ ipnsName: 'k51name', headCid: 'bafyNew', contentCids: [] }]);
+      expect(names.rows).toHaveLength(1);
+      expect(names.rows[0].headCid).toBe('bafyNew');
+    });
+
+    it('marks rows advisory for a BYO account', async () => {
+      const acct = await account({ byo: true });
+      await service.register(acct, [{ ipnsName: 'k51byo', contentCids: ['bafyC'] }]);
+      expect(pins.rows[0].advisory).toBe(true);
+    });
+
+    it('rejects registration for an unknown account (fail-closed)', async () => {
+      await expect(
+        service.register('00000000-0000-4000-8000-000000000000', [
+          { ipnsName: 'k51x', contentCids: [] },
+        ])
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+  });
+
+  describe('retire — union liveness, refcounted physical unpin', () => {
+    it('keeps a CID pinned while another account still holds a row, unpins at global zero', async () => {
+      const alice = await account();
+      const bob = await account();
+      // Both accounts register the same shared content CID.
+      await service.register(alice, [{ ipnsName: 'k51a', contentCids: ['bafyShared'] }]);
+      await service.register(bob, [{ ipnsName: 'k51b', contentCids: ['bafyShared'] }]);
+
+      // Alice retires her row: the CID survives (Bob still references it).
+      const first = await service.retire(alice, ['bafyShared']);
+      expect(first).toEqual({ retired: 1, unpinned: 0 });
+      expect(pinStore.unpinned).toEqual([]);
+      expect(pins.rows.filter((r) => r.cid === 'bafyShared')).toHaveLength(1);
+
+      // Bob retires the last row: global refcount hits zero → physical unpin.
+      const second = await service.retire(bob, ['bafyShared']);
+      expect(second).toEqual({ retired: 1, unpinned: 1 });
+      expect(pinStore.unpinned).toEqual(['bafyShared']);
+      expect(pins.rows.filter((r) => r.cid === 'bafyShared')).toHaveLength(0);
+    });
+
+    it('retires a name row without any unpin (names never carry bytes)', async () => {
+      const acct = await account();
+      await service.register(acct, [{ ipnsName: 'k51name', headCid: 'bafyHead', contentCids: [] }]);
+      const result = await service.retire(acct, ['k51name']);
+      // The name row is gone; the head CID pin is untouched (retire targeted the name only).
+      expect(result.retired).toBe(1);
+      expect(result.unpinned).toBe(0);
+      expect(names.rows).toHaveLength(0);
+      expect(pins.rows).toHaveLength(1);
+      expect(pinStore.unpinned).toEqual([]);
+    });
+
+    it('only the row-holding account can drop the refcount — a foreign retire is a no-op', async () => {
+      const owner = await account();
+      const stranger = await account();
+      await service.register(owner, [{ ipnsName: 'k51o', contentCids: ['bafyOwned'] }]);
+
+      const result = await service.retire(stranger, ['bafyOwned']);
+      expect(result).toEqual({ retired: 0, unpinned: 0 });
+      expect(pinStore.unpinned).toEqual([]);
+      expect(pins.rows.filter((r) => r.cid === 'bafyOwned')).toHaveLength(1);
+    });
+
+    it('is idempotent: retiring an already-gone target succeeds as a no-op', async () => {
+      const acct = await account();
+      const result = await service.retire(acct, ['never-registered']);
+      expect(result).toEqual({ retired: 0, unpinned: 0 });
+    });
+  });
+
+  describe('quota — arithmetic, override, hosted vs BYO advisory', () => {
+    async function seedPin(accountId: string, cid: string, size: number): Promise<void> {
+      await pins.save({ accountId, cid, size: String(size), advisory: false } as never);
+    }
+
+    it('sums the account own pin-row sizes and reports the env-default limit', async () => {
+      build({ QUOTA_DEFAULT_BYTES: String(2 * GIB) });
+      const acct = await account();
+      await seedPin(acct, 'bafy1', 100);
+      await seedPin(acct, 'bafy2', 250);
+
+      const quota = await service.quota(acct);
+      expect(quota).toEqual({ usedBytes: 350, limitBytes: 2 * GIB, advisory: false });
+    });
+
+    it('counts only the account own rows, never another account bytes', async () => {
+      const mine = await account();
+      const theirs = await account();
+      await seedPin(mine, 'bafyMine', 400);
+      await seedPin(theirs, 'bafyTheirs', 999);
+
+      const quota = await service.quota(mine);
+      expect(quota.usedBytes).toBe(400);
+    });
+
+    it('honors the per-account override over the env default', async () => {
+      build({ QUOTA_DEFAULT_BYTES: String(2 * GIB) });
+      const acct = await account({ quotaLimitOverride: String(5000) });
+      await seedPin(acct, 'bafy1', 100);
+
+      const quota = await service.quota(acct);
+      expect(quota.limitBytes).toBe(5000);
+      expect(quota.usedBytes).toBe(100);
+    });
+
+    it('falls back to the 10 GiB default when QUOTA_DEFAULT_BYTES is garbage', async () => {
+      build({ QUOTA_DEFAULT_BYTES: 'not-a-number' });
+      const acct = await account();
+      const quota = await service.quota(acct);
+      expect(quota.limitBytes).toBe(10 * GIB);
+    });
+
+    it('reports advisory:true for a BYO account, still summing its rows', async () => {
+      const acct = await account({ byo: true });
+      await seedPin(acct, 'bafyByo', 777);
+      const quota = await service.quota(acct);
+      expect(quota.advisory).toBe(true);
+      expect(quota.usedBytes).toBe(777);
+    });
+
+    it('rejects a quota query for an unknown account', async () => {
+      await expect(service.quota('00000000-0000-4000-8000-000000000000')).rejects.toBeInstanceOf(
+        UnauthorizedException
+      );
+    });
+  });
+
+  describe('setByo', () => {
+    it('flips the account BYO flag', async () => {
+      const acct = await account({ byo: false });
+      const result = await service.setByo(acct, true);
+      expect(result).toEqual({ byo: true });
+      expect(users.rows[0].byo).toBe(true);
+    });
+
+    it('rejects a BYO toggle for an unknown account', async () => {
+      await expect(
+        service.setByo('00000000-0000-4000-8000-000000000000', true)
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+  });
+});

--- a/apps/api/src/registry/services/registry.service.test.ts
+++ b/apps/api/src/registry/services/registry.service.test.ts
@@ -113,6 +113,7 @@ describe('RegistryService', () => {
       pins as never,
       users as never,
       fakeDataSource([
+        [User, users],
         [NameInventory, names],
         [PinnedCid, pins],
       ]),

--- a/apps/api/src/registry/services/registry.service.test.ts
+++ b/apps/api/src/registry/services/registry.service.test.ts
@@ -107,7 +107,6 @@ describe('RegistryService', () => {
     users = new FakeRepository<User>();
     pinStore = new FakePinStore();
     service = new RegistryService(
-      names as never,
       pins as never,
       users as never,
       fakeDataSource([

--- a/apps/api/src/registry/services/registry.service.test.ts
+++ b/apps/api/src/registry/services/registry.service.test.ts
@@ -80,7 +80,10 @@ function fakeDataSource(repos: Array<[unknown, unknown]>): DataSource {
   const byEntity = new Map(repos);
   return {
     transaction: (runInTransaction: (manager: unknown) => unknown) =>
-      runInTransaction({ getRepository: (entity: unknown) => byEntity.get(entity) }),
+      runInTransaction({
+        getRepository: (entity: unknown) => byEntity.get(entity),
+        query: async () => [],
+      }),
   } as unknown as DataSource;
 }
 
@@ -151,6 +154,18 @@ describe('RegistryService', () => {
       expect(result).toEqual({ names: 1, cids: 0 });
       expect(names.rows).toHaveLength(1);
       expect(pins.rows).toHaveLength(0);
+    });
+
+    it('reports the DISTINCT name count, not the raw batch length', async () => {
+      const acct = await account();
+      // The same name appears in two entries; the last-provided head wins.
+      const result = await service.register(acct, [
+        { ipnsName: 'dup', headCid: 'bafyH1', contentCids: ['bafyA'] },
+        { ipnsName: 'dup', headCid: 'bafyH2', contentCids: ['bafyB'] },
+      ]);
+      expect(result).toEqual({ names: 1, cids: 4 });
+      expect(names.rows).toHaveLength(1);
+      expect(names.rows[0].headCid).toBe('bafyH2');
     });
 
     it('is idempotent: replaying the same batch adds no duplicate rows', async () => {

--- a/apps/api/src/registry/services/registry.service.test.ts
+++ b/apps/api/src/registry/services/registry.service.test.ts
@@ -1,5 +1,6 @@
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { UnauthorizedException } from '@nestjs/common';
+import { DataSource, FindOperator } from 'typeorm';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { User } from '../../auth/entities/user.entity';
 import { FakeRepository } from '../../testing/fake-repo';
@@ -11,7 +12,76 @@ import { RegistryService } from './registry.service';
 
 function newPublicKey(): string {
   const priv = secp256k1.utils.randomPrivateKey();
-  return Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+  try {
+    return Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+  } finally {
+    priv.fill(0);
+  }
+}
+
+/** Matches plain equality plus the `In([...])` operator the bulk paths use. */
+function inMatch(row: Record<string, unknown>, where: Record<string, unknown>): boolean {
+  return Object.entries(where).every(([key, expected]) => {
+    if (expected instanceof FindOperator) {
+      if (expected.type === 'in') {
+        return (expected.value as unknown[]).includes(row[key]);
+      }
+      throw new Error(`InAwareRepository: unsupported operator ${expected.type}`);
+    }
+    return row[key] === expected;
+  });
+}
+
+/** FakeRepository plus the `In`/array-save/`sum` surface the bulk paths need. */
+class InAwareRepository<T extends { id: string }> extends FakeRepository<T> {
+  override async find(options: { where?: Record<string, unknown> } = {}): Promise<T[]> {
+    const where = options.where;
+    if (!where) {
+      return [...this.rows];
+    }
+    return this.rows.filter((row) => inMatch(row as Record<string, unknown>, where));
+  }
+
+  override async delete(criteria: Record<string, unknown>): Promise<{ affected: number }> {
+    const before = this.rows.length;
+    this.rows = this.rows.filter((row) => !inMatch(row as Record<string, unknown>, criteria));
+    return { affected: before - this.rows.length };
+  }
+
+  override save(entity: Partial<T>): Promise<T>;
+  override save(entities: Partial<T>[]): Promise<T[]>;
+  override async save(entities: Partial<T> | Partial<T>[]): Promise<T | T[]> {
+    if (Array.isArray(entities)) {
+      const saved: T[] = [];
+      for (const entity of entities) {
+        saved.push(await super.save(entity));
+      }
+      return saved;
+    }
+    return super.save(entities);
+  }
+
+  async sum(column: string, where?: Record<string, unknown>): Promise<number | null> {
+    const rows = where
+      ? this.rows.filter((row) => inMatch(row as Record<string, unknown>, where))
+      : this.rows;
+    if (rows.length === 0) {
+      return null;
+    }
+    return rows.reduce(
+      (total, row) => total + Number((row as Record<string, unknown>)[column] ?? 0),
+      0
+    );
+  }
+}
+
+/** A DataSource whose transaction runs inline against the in-memory repos. */
+function fakeDataSource(repos: Array<[unknown, unknown]>): DataSource {
+  const byEntity = new Map(repos);
+  return {
+    transaction: (runInTransaction: (manager: unknown) => unknown) =>
+      runInTransaction({ getRepository: (entity: unknown) => byEntity.get(entity) }),
+  } as unknown as DataSource;
 }
 
 /** Records every physical unpin so the refcount-zero decision is observable. */
@@ -25,21 +95,25 @@ class FakePinStore extends PinStore {
 const GIB = 1024 * 1024 * 1024;
 
 describe('RegistryService', () => {
-  let names: FakeRepository<NameInventory>;
-  let pins: FakeRepository<PinnedCid>;
+  let names: InAwareRepository<NameInventory>;
+  let pins: InAwareRepository<PinnedCid>;
   let users: FakeRepository<User>;
   let pinStore: FakePinStore;
   let service: RegistryService;
 
   function build(config: Record<string, string | undefined> = {}) {
-    names = new FakeRepository<NameInventory>();
-    pins = new FakeRepository<PinnedCid>();
+    names = new InAwareRepository<NameInventory>();
+    pins = new InAwareRepository<PinnedCid>();
     users = new FakeRepository<User>();
     pinStore = new FakePinStore();
     service = new RegistryService(
       names as never,
       pins as never,
       users as never,
+      fakeDataSource([
+        [NameInventory, names],
+        [PinnedCid, pins],
+      ]),
       pinStore,
       fakeConfig(config).service
     );

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -1,0 +1,204 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../../auth/entities/user.entity';
+import { NameInventory } from '../entities/name-inventory.entity';
+import { PinnedCid } from '../entities/pinned-cid.entity';
+import { PinStore } from '../pin-store';
+
+/** Default per-account quota when neither an override nor `QUOTA_DEFAULT_BYTES` is set: 10 GiB. */
+const DEFAULT_QUOTA_BYTES = 10 * 1024 * 1024 * 1024;
+
+export interface RegisterEntry {
+  ipnsName: string;
+  headCid?: string;
+  contentCids: string[];
+}
+
+export interface RegisterResult {
+  names: number;
+  cids: number;
+}
+
+export interface RetireResult {
+  retired: number;
+  unpinned: number;
+}
+
+export interface QuotaResult {
+  usedBytes: number;
+  limitBytes: number;
+  advisory: boolean;
+}
+
+/**
+ * Read a non-negative integer byte bound from config, falling back to the
+ * default for an unset OR garbage value (a misconfigured limit must fail
+ * closed to the safe default, never to NaN).
+ */
+function byteConfig(raw: unknown, fallback: number): number {
+  const value = Number(raw);
+  return Number.isInteger(value) && value >= 0 ? value : fallback;
+}
+
+/**
+ * The pin/name registry (blueprint/api.md, Pin/name registry) — the one
+ * surface every publish flow traverses. It is deliberately dumb bookkeeping:
+ * per-account rows, idempotent upserts, union liveness, and a per-account
+ * quota sum. It authorizes nothing across accounts and holds no state a
+ * client cannot rebuild from the network.
+ *
+ * Determinism/side-effects are injected: the physical unpin rides the
+ * [`PinStore`] seam, never a direct Kubo call in this logic.
+ */
+@Injectable()
+export class RegistryService {
+  private readonly defaultLimitBytes: number;
+
+  constructor(
+    @InjectRepository(NameInventory)
+    private readonly nameRepository: Repository<NameInventory>,
+    @InjectRepository(PinnedCid)
+    private readonly pinRepository: Repository<PinnedCid>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly pinStore: PinStore,
+    configService: ConfigService
+  ) {
+    this.defaultLimitBytes = byteConfig(
+      configService.get('QUOTA_DEFAULT_BYTES'),
+      DEFAULT_QUOTA_BYTES
+    );
+  }
+
+  /**
+   * Batch register `[{ipnsName, headCid?, contentCids[]}]` under the caller's
+   * account. Register-first, fail-closed: each entry upserts its name-inventory
+   * row BEFORE any content pin row, so content is never accepted without the
+   * name that anchors it. Every upsert is idempotent — a replayed batch (name
+   * waves re-reference the same CIDs) changes nothing.
+   */
+  async register(accountId: string, entries: RegisterEntry[]): Promise<RegisterResult> {
+    const advisory = await this.isByo(accountId);
+    const cids = new Set<string>();
+
+    for (const entry of entries) {
+      // Register-first: the name row exists before its content is accepted.
+      await this.upsertName(accountId, entry.ipnsName, entry.headCid);
+
+      const entryCids = [...(entry.headCid ? [entry.headCid] : []), ...entry.contentCids];
+      for (const cid of entryCids) {
+        await this.upsertPin(accountId, cid, advisory);
+        cids.add(cid);
+      }
+    }
+
+    return { names: entries.length, cids: cids.size };
+  }
+
+  /**
+   * Batch retire `[ipnsName | cid]` for the caller's account. A target may be
+   * either a name or a CID; the API is zero-knowledge about which, so it
+   * removes the caller's matching row from BOTH tables (their namespaces do
+   * not collide). Union liveness: a retired CID is physically unpinned only
+   * when the LAST account's row for it is gone (global refcount zero).
+   */
+  async retire(accountId: string, targets: string[]): Promise<RetireResult> {
+    let retired = 0;
+    let unpinned = 0;
+
+    for (const target of targets) {
+      const nameDeleted = await this.nameRepository.delete({ accountId, ipnsName: target });
+      retired += nameDeleted.affected ?? 0;
+
+      const pinDeleted = await this.pinRepository.delete({ accountId, cid: target });
+      const pinAffected = pinDeleted.affected ?? 0;
+      retired += pinAffected;
+
+      // Only the account that actually held this CID can drop the global
+      // refcount; check it exactly when a row was removed.
+      if (pinAffected > 0) {
+        const remaining = await this.pinRepository.count({ where: { cid: target } });
+        if (remaining === 0) {
+          await this.pinStore.unpin(target);
+          unpinned += 1;
+        }
+      }
+    }
+
+    return { retired, unpinned };
+  }
+
+  /**
+   * The per-account quota (blueprint/api.md). `usedBytes` is the sum over the
+   * account's pin rows; `limitBytes` is the per-account override, else the env
+   * default. Hosted accounts are authoritative (`advisory: false`, the sum
+   * gates uploads); a BYO account's rows are advisory (`advisory: true`, quota
+   * always allows) — the bytes live on the user's own provider.
+   */
+  async quota(accountId: string): Promise<QuotaResult> {
+    const user = await this.userRepository.findOne({ where: { id: accountId } });
+    if (!user) {
+      throw new UnauthorizedException('Unknown account');
+    }
+
+    const rows = await this.pinRepository.find({ where: { accountId } });
+    let used = 0n;
+    for (const row of rows) {
+      used += BigInt(row.size ?? '0');
+    }
+
+    const limitBytes =
+      user.quotaLimitOverride != null
+        ? Number(BigInt(user.quotaLimitOverride))
+        : this.defaultLimitBytes;
+
+    return {
+      usedBytes: Number(used),
+      limitBytes,
+      advisory: user.byo,
+    };
+  }
+
+  /** Toggle the account's BYO flag; new pin rows are advisory while set. */
+  async setByo(accountId: string, byo: boolean): Promise<{ byo: boolean }> {
+    const result = await this.userRepository.update({ id: accountId }, { byo });
+    if (!result.affected) {
+      throw new UnauthorizedException('Unknown account');
+    }
+    return { byo };
+  }
+
+  private async isByo(accountId: string): Promise<boolean> {
+    const user = await this.userRepository.findOne({ where: { id: accountId } });
+    if (!user) {
+      throw new UnauthorizedException('Unknown account');
+    }
+    return user.byo;
+  }
+
+  private async upsertName(accountId: string, ipnsName: string, headCid?: string): Promise<void> {
+    const existing = await this.nameRepository.findOne({ where: { accountId, ipnsName } });
+    if (existing) {
+      // Idempotent: a re-publish only advances the head; a bare re-register
+      // (no headCid) leaves the existing head untouched.
+      if (headCid !== undefined && existing.headCid !== headCid) {
+        existing.headCid = headCid;
+        await this.nameRepository.save(existing);
+      }
+      return;
+    }
+    await this.nameRepository.save({ accountId, ipnsName, headCid: headCid ?? null });
+  }
+
+  private async upsertPin(accountId: string, cid: string, advisory: boolean): Promise<void> {
+    const existing = await this.pinRepository.findOne({ where: { accountId, cid } });
+    if (existing) {
+      // Idempotent: the CID is already counted; its size (set by the hosted
+      // upload path) and advisory origin are preserved.
+      return;
+    }
+    await this.pinRepository.save({ accountId, cid, size: '0', advisory });
+  }
+}

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -100,8 +100,6 @@ export class RegistryService {
    * waves re-reference the same CIDs) changes nothing.
    */
   async register(accountId: string, entries: RegisterEntry[]): Promise<RegisterResult> {
-    const advisory = await this.isByo(accountId);
-
     // Collapse the batch to its distinct writes; the last-provided head wins
     // per name, matching the sequential upsert semantics.
     const heads = new Map<string, string | undefined>();
@@ -132,6 +130,18 @@ export class RegistryService {
         // contend on the same keys, closing the phantom-INSERT race and
         // concurrent-duplicate inserts.
         await lockTokens(manager, [...nameOrder, ...cidOrder]);
+
+        // Read BYO under a users-row lock: register and setByo contend on the
+        // same existing row, so a row lock (not the token advisory lock) keeps
+        // a concurrent toggle from stamping new pins with a stale advisory flag.
+        const user = await manager.getRepository(User).findOne({
+          where: { id: accountId },
+          lock: { mode: 'pessimistic_write' },
+        });
+        if (!user) {
+          throw new UnauthorizedException('Unknown account');
+        }
+        const advisory = user.byo;
 
         const nameRepo = manager.getRepository(NameInventory);
         const pinRepo = manager.getRepository(PinnedCid);
@@ -263,13 +273,5 @@ export class RegistryService {
       throw new UnauthorizedException('Unknown account');
     }
     return { byo };
-  }
-
-  private async isByo(accountId: string): Promise<boolean> {
-    const user = await this.userRepository.findOne({ where: { id: accountId } });
-    if (!user) {
-      throw new UnauthorizedException('Unknown account');
-    }
-    return user.byo;
   }
 }

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import { DataSource, In, Repository } from 'typeorm';
+import { createHash } from 'node:crypto';
+import { DataSource, EntityManager, In, Repository } from 'typeorm';
 import { User } from '../../auth/entities/user.entity';
 import { NameInventory } from '../entities/name-inventory.entity';
 import { PinnedCid } from '../entities/pinned-cid.entity';
@@ -9,6 +10,25 @@ import { PinStore } from '../pin-store';
 
 /** Default per-account quota when neither an override nor `QUOTA_DEFAULT_BYTES` is set: 10 GiB. */
 const DEFAULT_QUOTA_BYTES = 10 * 1024 * 1024 * 1024;
+
+/** Stable 64-bit advisory-lock key for a token: first 8 bytes of its sha256. */
+function lockKey(token: string): bigint {
+  return createHash('sha256').update(token).digest().readBigInt64BE(0);
+}
+
+/**
+ * Serialize every refcount/inventory mutation for each token by taking a
+ * transaction-scoped advisory lock. Row locks can't see an unborn INSERT, so
+ * only a per-token lock closes the register/retire phantom race and concurrent
+ * duplicate inserts. Keys are acquired in sorted order so overlapping batches
+ * cannot deadlock; the lock auto-releases at commit or rollback.
+ */
+async function lockTokens(manager: EntityManager, tokens: string[]): Promise<void> {
+  const keys = [...new Set(tokens.map(lockKey))].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  for (const key of keys) {
+    await manager.query('SELECT pg_advisory_xact_lock($1::bigint)', [key.toString()]);
+  }
+}
 
 export interface RegisterEntry {
   ipnsName: string;
@@ -108,6 +128,11 @@ export class RegistryService {
     // leave no partial state behind.
     if (nameOrder.length > 0 || cidOrder.length > 0) {
       await this.dataSource.transaction(async (manager) => {
+        // Serialize per token before any read/write: register and retire
+        // contend on the same keys, closing the phantom-INSERT race and
+        // concurrent-duplicate inserts.
+        await lockTokens(manager, [...nameOrder, ...cidOrder]);
+
         const nameRepo = manager.getRepository(NameInventory);
         const pinRepo = manager.getRepository(PinnedCid);
 
@@ -148,7 +173,9 @@ export class RegistryService {
       });
     }
 
-    return { names: entries.length, cids: cids.size };
+    // `names` is the distinct-name count (the DTO contract), not the raw batch
+    // length, which double-counts a name repeated across entries.
+    return { names: nameOrder.length, cids: cids.size };
   }
 
   /**
@@ -163,20 +190,17 @@ export class RegistryService {
       return { retired: 0, unpinned: 0 };
     }
 
-    // All-or-nothing, and serialized against concurrent same-CID retires: a
-    // pessimistic-write lock on every target row makes the delete → survivor
-    // check atomic so physical unpin fires exactly at global refcount zero.
+    // All-or-nothing, and serialized per CID against concurrent register and
+    // retire: the advisory lock (not a row lock, which can't see an unborn
+    // INSERT) makes the delete → survivor check the authority for unpinning.
     const { retired, unpinCids } = await this.dataSource.transaction(async (manager) => {
+      await lockTokens(manager, targets);
+
       const nameRepo = manager.getRepository(NameInventory);
       const pinRepo = manager.getRepository(PinnedCid);
 
-      const locked = await pinRepo.find({
-        where: { cid: In(targets) },
-        lock: { mode: 'pessimistic_write' },
-      });
-      const heldByCaller = new Set(
-        locked.filter((row) => row.accountId === accountId).map((row) => row.cid)
-      );
+      const held = await pinRepo.find({ where: { accountId, cid: In(targets) } });
+      const heldByCaller = new Set(held.map((row) => row.cid));
       const heldCids = targets.filter(
         (target, index) => targets.indexOf(target) === index && heldByCaller.has(target)
       );

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 import { User } from '../../auth/entities/user.entity';
 import { NameInventory } from '../entities/name-inventory.entity';
 import { PinnedCid } from '../entities/pinned-cid.entity';
@@ -63,6 +63,8 @@ export class RegistryService {
     private readonly pinRepository: Repository<PinnedCid>,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
     private readonly pinStore: PinStore,
     configService: ConfigService
   ) {
@@ -81,17 +83,71 @@ export class RegistryService {
    */
   async register(accountId: string, entries: RegisterEntry[]): Promise<RegisterResult> {
     const advisory = await this.isByo(accountId);
+
+    // Collapse the batch to its distinct writes; the last-provided head wins
+    // per name, matching the sequential upsert semantics.
+    const heads = new Map<string, string | undefined>();
+    const nameOrder: string[] = [];
+    const cidOrder: string[] = [];
     const cids = new Set<string>();
-
     for (const entry of entries) {
-      // Register-first: the name row exists before its content is accepted.
-      await this.upsertName(accountId, entry.ipnsName, entry.headCid);
-
-      const entryCids = [...(entry.headCid ? [entry.headCid] : []), ...entry.contentCids];
-      for (const cid of entryCids) {
-        await this.upsertPin(accountId, cid, advisory);
-        cids.add(cid);
+      if (!heads.has(entry.ipnsName)) {
+        nameOrder.push(entry.ipnsName);
+        heads.set(entry.ipnsName, undefined);
       }
+      if (entry.headCid !== undefined) {
+        heads.set(entry.ipnsName, entry.headCid);
+      }
+      for (const cid of [...(entry.headCid ? [entry.headCid] : []), ...entry.contentCids]) {
+        if (!cids.has(cid)) {
+          cids.add(cid);
+          cidOrder.push(cid);
+        }
+      }
+    }
+
+    // All-or-nothing: register-first, fail-closed means a mid-batch error must
+    // leave no partial state behind.
+    if (nameOrder.length > 0 || cidOrder.length > 0) {
+      await this.dataSource.transaction(async (manager) => {
+        const nameRepo = manager.getRepository(NameInventory);
+        const pinRepo = manager.getRepository(PinnedCid);
+
+        // Names first: content is never accepted without its anchoring name.
+        const existingNames = nameOrder.length
+          ? await nameRepo.find({ where: { accountId, ipnsName: In(nameOrder) } })
+          : [];
+        const nameByKey = new Map(existingNames.map((row) => [row.ipnsName, row]));
+        const nameWrites: Partial<NameInventory>[] = [];
+        for (const ipnsName of nameOrder) {
+          const head = heads.get(ipnsName);
+          const existing = nameByKey.get(ipnsName);
+          if (existing) {
+            // A bare re-register (no head) leaves the head untouched.
+            if (head !== undefined && existing.headCid !== head) {
+              existing.headCid = head;
+              nameWrites.push(existing);
+            }
+          } else {
+            nameWrites.push({ accountId, ipnsName, headCid: head ?? null });
+          }
+        }
+        if (nameWrites.length) {
+          await nameRepo.save(nameWrites);
+        }
+
+        const existingPins = cidOrder.length
+          ? await pinRepo.find({ where: { accountId, cid: In(cidOrder) } })
+          : [];
+        const knownCids = new Set(existingPins.map((row) => row.cid));
+        // Idempotent: a CID already counted keeps its size and advisory origin.
+        const pinWrites = cidOrder
+          .filter((cid) => !knownCids.has(cid))
+          .map((cid) => ({ accountId, cid, size: '0', advisory }));
+        if (pinWrites.length) {
+          await pinRepo.save(pinWrites);
+        }
+      });
     }
 
     return { names: entries.length, cids: cids.size };
@@ -105,23 +161,30 @@ export class RegistryService {
    * when the LAST account's row for it is gone (global refcount zero).
    */
   async retire(accountId: string, targets: string[]): Promise<RetireResult> {
-    let retired = 0;
+    if (targets.length === 0) {
+      return { retired: 0, unpinned: 0 };
+    }
+
+    // The CIDs the caller actually holds among the targets — read before the
+    // delete so the refcount check is scoped to rows we remove, never a scan.
+    const held = await this.pinRepository.find({ where: { accountId, cid: In(targets) } });
+    const heldCids = targets.filter(
+      (target, index) => targets.indexOf(target) === index && held.some((row) => row.cid === target)
+    );
+
+    const nameDeleted = await this.nameRepository.delete({ accountId, ipnsName: In(targets) });
+    const pinDeleted = await this.pinRepository.delete({ accountId, cid: In(targets) });
+    const retired = (nameDeleted.affected ?? 0) + (pinDeleted.affected ?? 0);
+
     let unpinned = 0;
-
-    for (const target of targets) {
-      const nameDeleted = await this.nameRepository.delete({ accountId, ipnsName: target });
-      retired += nameDeleted.affected ?? 0;
-
-      const pinDeleted = await this.pinRepository.delete({ accountId, cid: target });
-      const pinAffected = pinDeleted.affected ?? 0;
-      retired += pinAffected;
-
-      // Only the account that actually held this CID can drop the global
-      // refcount; check it exactly when a row was removed.
-      if (pinAffected > 0) {
-        const remaining = await this.pinRepository.count({ where: { cid: target } });
-        if (remaining === 0) {
-          await this.pinStore.unpin(target);
+    if (heldCids.length > 0) {
+      // Only the account that held a row can drop the global refcount; a CID
+      // with no survivor is physically unpinned.
+      const survivors = await this.pinRepository.find({ where: { cid: In(heldCids) } });
+      const surviving = new Set(survivors.map((row) => row.cid));
+      for (const cid of heldCids) {
+        if (!surviving.has(cid)) {
+          await this.pinStore.unpin(cid);
           unpinned += 1;
         }
       }
@@ -143,11 +206,8 @@ export class RegistryService {
       throw new UnauthorizedException('Unknown account');
     }
 
-    const rows = await this.pinRepository.find({ where: { accountId } });
-    let used = 0n;
-    for (const row of rows) {
-      used += BigInt(row.size ?? '0');
-    }
+    // Aggregate server-side; size is a bigint column typed as string.
+    const used = await this.pinRepository.sum('size' as never, { accountId });
 
     const limitBytes =
       user.quotaLimitOverride != null
@@ -155,7 +215,7 @@ export class RegistryService {
         : this.defaultLimitBytes;
 
     return {
-      usedBytes: Number(used),
+      usedBytes: used ?? 0,
       limitBytes,
       advisory: user.byo,
     };
@@ -176,29 +236,5 @@ export class RegistryService {
       throw new UnauthorizedException('Unknown account');
     }
     return user.byo;
-  }
-
-  private async upsertName(accountId: string, ipnsName: string, headCid?: string): Promise<void> {
-    const existing = await this.nameRepository.findOne({ where: { accountId, ipnsName } });
-    if (existing) {
-      // Idempotent: a re-publish only advances the head; a bare re-register
-      // (no headCid) leaves the existing head untouched.
-      if (headCid !== undefined && existing.headCid !== headCid) {
-        existing.headCid = headCid;
-        await this.nameRepository.save(existing);
-      }
-      return;
-    }
-    await this.nameRepository.save({ accountId, ipnsName, headCid: headCid ?? null });
-  }
-
-  private async upsertPin(accountId: string, cid: string, advisory: boolean): Promise<void> {
-    const existing = await this.pinRepository.findOne({ where: { accountId, cid } });
-    if (existing) {
-      // Idempotent: the CID is already counted; its size (set by the hosted
-      // upload path) and advisory origin are preserved.
-      return;
-    }
-    await this.pinRepository.save({ accountId, cid, size: '0', advisory });
   }
 }

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -57,8 +57,6 @@ export class RegistryService {
   private readonly defaultLimitBytes: number;
 
   constructor(
-    @InjectRepository(NameInventory)
-    private readonly nameRepository: Repository<NameInventory>,
     @InjectRepository(PinnedCid)
     private readonly pinRepository: Repository<PinnedCid>,
     @InjectRepository(User)
@@ -165,29 +163,42 @@ export class RegistryService {
       return { retired: 0, unpinned: 0 };
     }
 
-    // The CIDs the caller actually holds among the targets — read before the
-    // delete so the refcount check is scoped to rows we remove, never a scan.
-    const held = await this.pinRepository.find({ where: { accountId, cid: In(targets) } });
-    const heldCids = targets.filter(
-      (target, index) => targets.indexOf(target) === index && held.some((row) => row.cid === target)
-    );
+    // All-or-nothing, and serialized against concurrent same-CID retires: a
+    // pessimistic-write lock on every target row makes the delete → survivor
+    // check atomic so physical unpin fires exactly at global refcount zero.
+    const { retired, unpinCids } = await this.dataSource.transaction(async (manager) => {
+      const nameRepo = manager.getRepository(NameInventory);
+      const pinRepo = manager.getRepository(PinnedCid);
 
-    const nameDeleted = await this.nameRepository.delete({ accountId, ipnsName: In(targets) });
-    const pinDeleted = await this.pinRepository.delete({ accountId, cid: In(targets) });
-    const retired = (nameDeleted.affected ?? 0) + (pinDeleted.affected ?? 0);
+      const locked = await pinRepo.find({
+        where: { cid: In(targets) },
+        lock: { mode: 'pessimistic_write' },
+      });
+      const heldByCaller = new Set(
+        locked.filter((row) => row.accountId === accountId).map((row) => row.cid)
+      );
+      const heldCids = targets.filter(
+        (target, index) => targets.indexOf(target) === index && heldByCaller.has(target)
+      );
 
-    let unpinned = 0;
-    if (heldCids.length > 0) {
-      // Only the account that held a row can drop the global refcount; a CID
-      // with no survivor is physically unpinned.
-      const survivors = await this.pinRepository.find({ where: { cid: In(heldCids) } });
+      const nameDeleted = await nameRepo.delete({ accountId, ipnsName: In(targets) });
+      const pinDeleted = await pinRepo.delete({ accountId, cid: In(targets) });
+
+      // Under the lock, a held CID with no surviving row is at global zero.
+      const survivors = heldCids.length ? await pinRepo.find({ where: { cid: In(heldCids) } }) : [];
       const surviving = new Set(survivors.map((row) => row.cid));
-      for (const cid of heldCids) {
-        if (!surviving.has(cid)) {
-          await this.pinStore.unpin(cid);
-          unpinned += 1;
-        }
-      }
+
+      return {
+        retired: (nameDeleted.affected ?? 0) + (pinDeleted.affected ?? 0),
+        unpinCids: heldCids.filter((cid) => !surviving.has(cid)),
+      };
+    });
+
+    // Fire the external unpin after commit — never hold the txn across Kubo.
+    let unpinned = 0;
+    for (const cid of unpinCids) {
+      await this.pinStore.unpin(cid);
+      unpinned += 1;
     }
 
     return { retired, unpinned };

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -15,7 +15,7 @@ use cipherbox_contract::{
     MemoryCredentialStore, ReqwestHttp, api_url, hex_to_scalar, prod_api_url,
     random_identity_signer, test_login_secret,
 };
-use cipherbox_engine::api::{ApiClient, ApiError, IdentityChallengeSigner};
+use cipherbox_engine::api::{ApiClient, ApiError, IdentityChallengeSigner, NameRegistration};
 use cipherbox_engine::seams::{CredentialStore, Http, HttpMethod, HttpRequest};
 
 type Client = ApiClient<ReqwestHttp, MemoryCredentialStore>;
@@ -37,6 +37,20 @@ async fn client_seeded_with(base: &str, refresh_token: &[u8]) -> Client {
         .await
         .expect("seed the store");
     ApiClient::new(ReqwestHttp::new(), store, base)
+}
+
+/// A fresh account: a new client logged in with a random identity key, which
+/// implicitly creates the account (challenge-signature first login). Every
+/// contract run mints a brand-new account, so fixed name/CID strings below are
+/// always a fresh `(account, ...)` pair — no cross-run collision on the shared
+/// CI database.
+async fn fresh_account(base: &str) -> Client {
+    let client = new_client(base);
+    client
+        .login_identity(&random_identity_signer())
+        .await
+        .expect("identity login creates the account");
+    client
 }
 
 macro_rules! require_stack {
@@ -254,5 +268,161 @@ async fn logout_revokes_the_refresh_token_server_side() {
     assert!(
         matches!(replay.refresh().await, Err(ApiError::Unauthorized)),
         "logout revoked the refresh token server-side"
+    );
+}
+
+// --- pin/name registry and quota (blueprint/api.md; #627) -------------------
+
+/// Register-first, fail-closed (blueprint/api.md): the register call is the one
+/// mandatory gate — content enters the inventory only through a valid
+/// registration, and a malformed one is refused wholesale, never partially
+/// accepted. (End-to-end "publishing an unregistered name is refused" is the
+/// engine publish pipeline's ordering law; the API's half is that the gate
+/// exists and fails closed.)
+#[tokio::test]
+async fn register_first_gate_accepts_valid_and_refuses_malformed() {
+    let base = require_stack!("register_first_gate_accepts_valid_and_refuses_malformed");
+    let client = fresh_account(&base).await;
+
+    // A well-formed registration opens the gate.
+    let valid = vec![NameRegistration {
+        ipns_name: "k51contractRegisterFirst".into(),
+        head_cid: Some("bafyContractHead".into()),
+        content_cids: vec!["bafyContractC1".into(), "bafyContractC2".into()],
+    }];
+    client
+        .register(&valid)
+        .await
+        .expect("valid register accepted");
+
+    // A structurally invalid name is refused (the batch is rejected wholesale,
+    // so no content rides in behind an unregisterable name).
+    let malformed = vec![NameRegistration {
+        ipns_name: "not a valid ipns name!!".into(),
+        head_cid: None,
+        content_cids: vec!["bafyContractC3".into()],
+    }];
+    let error = client
+        .register(&malformed)
+        .await
+        .expect_err("a malformed registration must be refused");
+    assert!(
+        matches!(error, ApiError::Status { status: 400, .. }),
+        "register-first is fail-closed: a malformed batch is a 400, got {error:?}"
+    );
+}
+
+/// Batch register/retire idempotency (blueprint/api.md): every upsert is
+/// idempotent, so a replayed batch — the shape a resumed name wave or a retried
+/// write sends — changes nothing and never errors.
+#[tokio::test]
+async fn batch_register_and_retire_are_idempotent() {
+    let base = require_stack!("batch_register_and_retire_are_idempotent");
+    let client = fresh_account(&base).await;
+
+    let batch = vec![NameRegistration {
+        ipns_name: "k51contractIdem".into(),
+        head_cid: Some("bafyContractIdemHead".into()),
+        content_cids: vec!["bafyContractIdemC".into()],
+    }];
+
+    // Replaying the same register batch is accepted both times.
+    client.register(&batch).await.expect("first register");
+    client.register(&batch).await.expect("replayed register");
+
+    // Register carries no byte sizes (those come from the hosted upload path),
+    // so a register-only account still reports zero used bytes — a durable,
+    // idempotent invariant regardless of replay count.
+    let quota = client.quota().await.expect("quota");
+    assert_eq!(
+        quota.used_bytes, 0,
+        "register records membership, not bytes"
+    );
+
+    // Retiring the same targets twice is accepted both times (the second is a
+    // no-op removal).
+    let targets = vec!["k51contractIdem".to_owned(), "bafyContractIdemC".to_owned()];
+    client.retire(&targets).await.expect("first retire");
+    client
+        .retire(&targets)
+        .await
+        .expect("replayed retire is a no-op");
+}
+
+/// Union liveness (blueprint/api.md): inventory rows are per account and the
+/// server authorizes nothing across accounts, so two accounts independently
+/// hold rows for the same shared CID and each retires its own permissionlessly
+/// — the self-healing shared-scope path. (Physical unpin fires only at GLOBAL
+/// refcount zero; that decision is exercised by the api-unit refcounting suite
+/// via the PinStore seam, as it is not observable through the client surface.)
+#[tokio::test]
+async fn union_liveness_is_per_account_and_permissionless() {
+    let base = require_stack!("union_liveness_is_per_account_and_permissionless");
+    let alice = fresh_account(&base).await;
+    let bob = fresh_account(&base).await;
+
+    let shared = "bafyContractUnionShared".to_owned();
+    alice
+        .register(&[NameRegistration {
+            ipns_name: "k51contractUnionAlice".into(),
+            head_cid: None,
+            content_cids: vec![shared.clone()],
+        }])
+        .await
+        .expect("alice registers the shared CID under her account");
+    bob.register(&[NameRegistration {
+        ipns_name: "k51contractUnionBob".into(),
+        head_cid: None,
+        content_cids: vec![shared.clone()],
+    }])
+    .await
+    .expect("bob co-registers the same CID under his own account");
+
+    // Each account retires only its own row; neither call authorizes or touches
+    // the other account's inventory, and both succeed.
+    alice
+        .retire(&[shared.clone()])
+        .await
+        .expect("alice retires her row while bob still references the CID");
+    bob.retire(&[shared])
+        .await
+        .expect("bob retires the last row");
+}
+
+/// Quota (blueprint/api.md): hosted accounts are authoritative (`advisory:
+/// false`) with a positive limit; a BYO account's rows are advisory
+/// (`advisory: true`, quota always allows). The flag flips live with the BYO
+/// toggle.
+#[tokio::test]
+async fn quota_is_hosted_authoritative_and_byo_advisory() {
+    let base = require_stack!("quota_is_hosted_authoritative_and_byo_advisory");
+    let client = fresh_account(&base).await;
+
+    // A fresh account is hosted: quota is authoritative and carries a limit.
+    let hosted = client.quota().await.expect("hosted quota");
+    assert!(
+        !hosted.advisory,
+        "a hosted account's quota is authoritative"
+    );
+    assert!(
+        hosted.limit_bytes > 0,
+        "a hosted account has a positive limit"
+    );
+
+    // Enabling BYO makes the account's rows advisory: quota always allows.
+    client.set_byo(true).await.expect("enable BYO");
+    let byo = client.quota().await.expect("byo quota");
+    assert!(byo.advisory, "a BYO account's quota is advisory");
+    assert_eq!(
+        byo.limit_bytes, hosted.limit_bytes,
+        "the limit is unchanged"
+    );
+
+    // Toggling BYO back restores the authoritative posture.
+    client.set_byo(false).await.expect("disable BYO");
+    let restored = client.quota().await.expect("restored quota");
+    assert!(
+        !restored.advisory,
+        "clearing BYO restores authoritative quota"
     );
 }


### PR DESCRIPTION
## Summary

Implements the pin/name registry slice (`blueprint/api.md`, Pin/name registry) — the one API surface every publish flow traverses, feeding both quota and the republisher inventory. The API stays dumb bookkeeping: per-account rows, idempotent upserts, union liveness, and a per-account quota sum. It authorizes nothing across accounts.

## What landed

- **Schema.** `name_inventory (account, ipnsName, headCid?)` and `pinned_cids (account, cid, size, advisory)` entities, both cascade-deleting with the account, plus a plain-DDL migration generated the existing way (the migration-drift gate stays green).
- **Batch register** `POST /registry/register` — top-level JSON array `[{ipnsName, headCid?, contentCids[]}]`, idempotent upserts. **Register-first, fail-closed:** each entry writes its name-inventory row before any content pin, so content is never accepted without the name that anchors it; a malformed batch is refused wholesale.
- **Batch retire** `POST /registry/retire` — top-level array `[ipnsName | cid]`. **Union liveness:** a target's caller row is removed from both tables; a CID is **physically unpinned only at GLOBAL refcount zero** (the last account's row gone), via the injectable `PinStore` seam (Kubo-backed when `KUBO_API_URL` is set, no-op otherwise — the hosted byte path is the content-plane slice).
- **Quota** `GET /account/quota` — per-account sum over pin rows; hosted rows authoritative, BYO rows advisory (`advisory: true`, quota always allows); limit = env default plus the per-account override column. The BYO toggle `PATCH /account/byo` flips the account's posture.

## Route binding

Endpoints match the already-merged engine API client verbatim (`/registry/register`, `/registry/retire`, `/account/quota`, `/account/byo`) — **no client changes were needed**. Verified by running the live contract cases against a local API instance.

## Out of scope (not built)

Hosted upload bytes, the republisher walk, and root-linger/retire timing (client policy — the API stays dumb). The `PinStore` seam's Kubo wiring lands with the content-plane slice; the refcount decision that drives it ships here.

## Gates

- **api-unit** extended with quota arithmetic + refcounting tests (service + HTTP surface) — full suite green.
- **migration-drift** verified against a fresh Postgres: applying the committed migration leaves zero entity drift.
- **Contract suite** gains four cases (compiled here, run by CI's Contract Suite job; also verified green against a local API): register-first fail-closed, batch register/retire idempotency, union liveness per-account, quota hosted-authoritative vs BYO advisory.
- typecheck, build, OpenAPI freshness (regenerated artifact committed), `cargo fmt`/`clippy`/`test --no-run` for the contract crate — all green.

Closes #627


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated registry batch endpoints to register and retire IPNS names and content identifiers.
  * Added per-account quota reporting and a BYO-IPFS advisory toggle.
* **Bug Fixes**
  * Improved idempotency and isolation for register/retire; retiring now unpins only when no longer referenced.
* **Chores**
  * Added database migration for inventory and pinned-content tracking.
  * Updated OpenAPI/Swagger docs with new Registry and Account endpoints and schemas.
* **Tests**
  * Added comprehensive HTTP and contract tests covering authorization, batching limits, idempotency, quota, and BYO behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->