### PR TITLE
fix(core): zeroize content-key copies on the sealed-body encode path

### DIFF
--- a/crates/core/src/codec/value.rs
+++ b/crates/core/src/codec/value.rs
@@ -8,6 +8,8 @@
 use core::cmp::Ordering;
 use core::fmt;
 
+use zeroize::Zeroize;
+
 use crate::error::Malformed;
 
 /// A value in the deterministic profile's data model.
@@ -115,6 +117,39 @@ impl Value {
             Self::Negative(!(n as u64))
         }
     }
+
+    /// Scrub every owned byte buffer in this value tree in place: each
+    /// [`Value::Bytes`] has its contents wiped from memory and is cleared to
+    /// empty (`Vec::zeroize` semantics), while the tree's shape and every
+    /// non-byte value are left intact.
+    ///
+    /// The sealed-body encode path builds a transient `Value` tree that carries
+    /// verbatim copies of inline **content-key** material — one
+    /// [`Value::Bytes`] per file version ([`encode_read_body`]). That tree is
+    /// built and owned by the encoder, so the encoder is its terminal owner and
+    /// wipes it here before it drops, closing the window where a
+    /// freed-but-uncleared `Value::Bytes` copy of key material would linger on
+    /// the heap (blueprint/core.md "Crypto suite": key material lives only in
+    /// zeroizing owners). Non-secret byte buffers (ids, cids, ipnsNames) are
+    /// wiped too: they are all encoder-owned transient copies, so a whole-tree
+    /// wipe needs no per-field secret classification and stays correct as later
+    /// sealed bodies add secret byte fields (grant/owner/history seed material).
+    /// This only ever touches the encoder's own transient copies — the caller's
+    /// [`SecretBytes`](crate::suite::secret::SecretBytes) inputs are untouched.
+    ///
+    /// [`encode_read_body`]: crate::seal::encode_read_body
+    pub(crate) fn zeroize_bytes(&mut self) {
+        match self {
+            Self::Bytes(b) => b.zeroize(),
+            Self::Array(items) => {
+                for item in items {
+                    item.zeroize_bytes();
+                }
+            }
+            Self::Map(map) => map.zeroize_bytes(),
+            Self::Unsigned(_) | Self::Negative(_) | Self::Text(_) | Self::Bool(_) | Self::Null => {}
+        }
+    }
 }
 
 fn unexpected(expected: &'static str, found: &Value) -> Malformed {
@@ -190,6 +225,15 @@ impl Map {
 
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
+    }
+
+    /// Zeroize every entry value's owned byte buffers in place (keys are text,
+    /// never secret). See [`Value::zeroize_bytes`] for the terminal-owner
+    /// rationale — the caller owns this map and is its terminal owner.
+    pub(crate) fn zeroize_bytes(&mut self) {
+        for (_, v) in &mut self.entries {
+            v.zeroize_bytes();
+        }
     }
 }
 
@@ -310,6 +354,43 @@ mod tests {
         assert_eq!(keys, ["a", "bb", "ca"]);
         assert_eq!(m.get("bb"), Some(&Value::Unsigned(9)));
     }
+
+    #[test]
+    fn zeroize_bytes_wipes_every_nested_byte_buffer() {
+        // A tree shaped like the sealed-body encode tree: a map holding an
+        // array of maps, each with a secret-carrying `Bytes` value plus
+        // non-byte fields, and a top-level non-secret `Bytes`.
+        let mut version = Map::new();
+        version.insert("contentKey", Value::Bytes(vec![0xab; SECRET_LEN_TEST]));
+        version.insert("size", Value::Unsigned(4096));
+        version.insert("contentCid", Value::Bytes(vec![0xcd; 5]));
+
+        let mut root = Map::new();
+        root.insert("versions", Value::Array(vec![Value::Map(version)]));
+        root.insert("kind", Value::Text("file".into()));
+        root.insert("id", Value::Bytes(vec![0xef; 16]));
+        let mut tree = Value::Map(root);
+
+        tree.zeroize_bytes();
+
+        // `Vec::zeroize` wipes the whole buffer (contents scrubbed from memory)
+        // and clears it to empty; the tree keeps its shape and every non-byte
+        // value is untouched.
+        let root = tree.as_map().unwrap();
+        assert_eq!(root.get("id"), Some(&Value::Bytes(Vec::new())));
+        assert_eq!(root.get("kind"), Some(&Value::Text("file".into())));
+        let versions = root.get("versions").unwrap().as_array().unwrap();
+        let ver = versions[0].as_map().unwrap();
+        assert_eq!(
+            ver.get("contentKey"),
+            Some(&Value::Bytes(Vec::new())),
+            "content key buffer scrubbed and cleared"
+        );
+        assert_eq!(ver.get("contentCid"), Some(&Value::Bytes(Vec::new())));
+        assert_eq!(ver.get("size"), Some(&Value::Unsigned(4096)));
+    }
+
+    const SECRET_LEN_TEST: usize = 32;
 
     #[test]
     fn i64_round_trip() {

--- a/crates/core/src/seal/body.rs
+++ b/crates/core/src/seal/body.rs
@@ -376,7 +376,17 @@ pub fn encode_read_body(body: &ReadBody) -> Vec<u8> {
             merge_unknown(&mut m, unknown);
         }
     }
-    encode(&Value::Map(m))
+    // The transient `Value` tree just built carries a verbatim copy of every
+    // inline content key (one `Value::Bytes` per file version, produced by
+    // `Version::to_value`). We own that tree, so we are its terminal owner:
+    // encode it, then wipe its byte buffers before it drops, so no
+    // freed-but-uncleared copy of key material lingers on the heap. The
+    // returned plaintext buffer carries the same key bytes and is the seal
+    // path's ([`seal_read_body`](super::seal_read_body)) to zeroize — it does.
+    let mut value = Value::Map(m);
+    let out = encode(&value);
+    value.zeroize_bytes();
+    out
 }
 
 /// Fail-closed uniqueness over one folder's child listing (#39 D7).

--- a/crates/core/src/seal/body.rs
+++ b/crates/core/src/seal/body.rs
@@ -378,15 +378,31 @@ pub fn encode_read_body(body: &ReadBody) -> Vec<u8> {
     }
     // The transient `Value` tree just built carries a verbatim copy of every
     // inline content key (one `Value::Bytes` per file version, produced by
-    // `Version::to_value`). We own that tree, so we are its terminal owner:
-    // encode it, then wipe its byte buffers before it drops, so no
-    // freed-but-uncleared copy of key material lingers on the heap. The
-    // returned plaintext buffer carries the same key bytes and is the seal
-    // path's ([`seal_read_body`](super::seal_read_body)) to zeroize — it does.
+    // `Version::to_value`). We own that tree, so we are its terminal owner
+    // (blueprint/core.md "Crypto suite": key material lives only in zeroizing
+    // owners). Scrub it through a drop guard, not an explicit trailing call, so
+    // the wipe runs whether `encode` returns or unwinds: `write_value`'s
+    // `debug_assert!(depth < MAX_DEPTH)` can panic in debug/test builds, and a
+    // bare post-`encode` scrub would be skipped on that unwind, leaving a
+    // freed-but-uncleared key copy on the heap. The returned buffer carries the
+    // same key bytes and is the seal path's
+    // ([`seal_read_body`](super::seal_read_body)) to zeroize — it does.
     let mut value = Value::Map(m);
-    let out = encode(&value);
-    value.zeroize_bytes();
-    out
+    let guard = ScrubOnDrop(&mut value);
+    encode(guard.0)
+}
+
+/// Scrubs the encoder's transient `Value` tree on drop, so the inline
+/// content-key copies it carries are wiped on both normal return and
+/// panic-unwind out of `encode` (blueprint/core.md terminal-owner rule). It
+/// borrows the tree rather than owning it, leaving the wiped buffers observable
+/// to a caller/test after the guard falls.
+struct ScrubOnDrop<'a>(&'a mut Value);
+
+impl Drop for ScrubOnDrop<'_> {
+    fn drop(&mut self) {
+        self.0.zeroize_bytes();
+    }
 }
 
 /// Fail-closed uniqueness over one folder's child listing (#39 D7).
@@ -661,5 +677,53 @@ mod tests {
             unknown: Vec::new(),
         };
         assert!(file.validate().is_ok());
+    }
+
+    #[test]
+    fn scrub_on_drop_guard_wipes_tree() {
+        let mut value = Value::Array(vec![Value::Bytes(vec![0xab; 32])]);
+        {
+            let _guard = ScrubOnDrop(&mut value);
+        }
+        let items = value.as_array().unwrap();
+        assert_eq!(
+            items[0],
+            Value::Bytes(Vec::new()),
+            "guard's Drop scrubbed the tree"
+        );
+    }
+
+    // Unwinding is a native/desktop concern: wasm builds are `panic=abort`, so
+    // a `debug_assert` there aborts the instance rather than unwinding past the
+    // guard — there is no scrub-skipping window to defend on that leg.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn scrub_runs_when_encode_unwinds() {
+        // `write_value`'s `debug_assert!(depth < MAX_DEPTH)` fires in this
+        // (test) build for a tree nested past MAX_DEPTH; the guard's Drop must
+        // still scrub the content-key copy while the stack unwinds out of
+        // `encode`. The secret rides item 0 (written before the panic); the
+        // deep nest that trips the assert rides item 1.
+        let mut deep = Value::Null;
+        for _ in 0..=crate::codec::MAX_DEPTH {
+            deep = Value::Array(vec![deep]);
+        }
+        let mut value = Value::Array(vec![Value::Bytes(vec![0xab; 32]), deep]);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let guard = ScrubOnDrop(&mut value);
+            let _ = encode(guard.0);
+        }));
+        assert!(
+            result.is_err(),
+            "encode panics past MAX_DEPTH in test build"
+        );
+
+        let items = value.as_array().unwrap();
+        assert_eq!(
+            items[0],
+            Value::Bytes(Vec::new()),
+            "guard scrubbed the key copy on unwind"
+        );
     }
 }


### PR DESCRIPTION
## What

Closes the content-key hygiene gap on the sealed read-body encode path flagged by CodeRabbit (`major [Security & Privacy]`) on the seal slice.

`encode_read_body` builds a transient `Value`/`Map` tree in which `Version::to_value` copies each inline **content key** into a non-zeroizing `Value::Bytes`. The final encoded plaintext buffer is zeroized by its terminal owner (`seal_read_body`), but the intermediate `Value::Bytes` copy was left in freed-but-uncleared heap when the transient tree dropped — a stray copy of key material on the heap.

## Fix (least-invasive: option c — zeroize the transient tree)

- Add `Value::zeroize_bytes` (and `Map::zeroize_bytes`), a crate-internal recursive scrub of every owned byte buffer in a `Value` tree (`Vec::zeroize` semantics: contents wiped from memory, buffer cleared).
- Call it in `encode_read_body` right after `encode(...)`. The encoder builds and owns that transient tree, so it is its terminal owner and wipes the content-key copies before the tree drops.

Terminal-owner discipline is preserved: only the encoder's own transient copies are scrubbed; the caller's `SecretBytes`/`Version` inputs are never touched (they zeroize themselves on drop). A whole-tree scrub avoids per-field secret classification and stays correct as later sealed bodies add secret byte fields (grant/owner/history seed material).

No shared-codec enum variant, no new match-arm ripple beyond the one additive method; a single call site changes.

## No wire-format change

The scrub runs **after** `encode` has produced the output buffer, so the encoded bytes are identical. KAT byte-repro is clean: `cargo run -p cipherbox-core --example kat_gen` then `git diff --quiet crates/core/kat` produces no drift.

## Validation

- `cargo fmt -p cipherbox-core -- --check` — clean
- `cargo clippy -p cipherbox-core --all-targets -- -D warnings` — clean
- `cargo test -p cipherbox-core` — all pass (adds a behavioral test `zeroize_bytes_wipes_every_nested_byte_buffer`, asserting the scrub property, not source text)
- KAT byte-repro — clean (no wire change)

## Residual

`codec::encode` grows its output `Vec` from empty and may reallocate mid-encode, freeing intermediate backing stores uncleared. This is a pre-existing, codec-wide property shared by every encode call site and outside the defined gap (the issue treats the final encoded buffer as already handled by the terminal owner). Not addressed here to keep scope tight; worth a separate codec-wide pass if we want a fully zeroizing encode buffer.

Closes #672


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved protection of sensitive inline key material by securely wiping temporary byte buffers after use.
  * Sensitive data is now also cleared when encoding encounters an error or panic.

* **Tests**
  * Added coverage confirming secure cleanup for nested data and interrupted encoding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->