### PR TITLE
feat(engine): adoption gate and floor law with sim harness

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -27,3 +27,7 @@ zeroize.workspace = true
 # Self dev-dependency: enables `test-kit` for this crate's own tests (unit,
 # integration, doc) without leaking it into downstream production builds.
 cipherbox-engine = { workspace = true, features = ["test-kit"] }
+# Integration tests construct real signed/sealed records with core's crypto to
+# hand-feed the adoption-gate simulation harness (core is already a normal
+# dependency; this line makes it addressable from `tests/`).
+cipherbox-core.workspace = true

--- a/crates/engine/src/gate/adoption.rs
+++ b/crates/engine/src/gate/adoption.rs
@@ -43,8 +43,9 @@ use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
     AadContext, AscentLink, Envelope, GrantSetCommitment, Permission, ReadBody,
-    STRUCT_TAG_ASCENT_LINK, StructureSigInput, open_ascent_link, open_grant_blob, open_owner_blob,
-    open_read_body, verify_grant_set, verify_structure,
+    STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_GRANT_BLOB, STRUCT_TAG_OWNER_BLOB, StructureSigInput,
+    open_ascent_link, open_grant_blob, open_owner_blob, open_read_body, verify_grant_set,
+    verify_structure,
 };
 use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaVerifier};
 use cipherbox_core::suite::ed25519::{Ed25519Signature, Ed25519Verifier};
@@ -357,6 +358,16 @@ impl SeedBlob<'_> {
             SeedBlob::Owner { aad, .. } | SeedBlob::Grantee { aad, .. } => aad,
         }
     }
+
+    /// The domain-separation tag this blob variant must carry — the AAD's
+    /// `structTag` is pinned to it so an owner blob can never present as a grant
+    /// blob (or any other structure).
+    fn struct_tag(&self) -> u8 {
+        match self {
+            SeedBlob::Owner { .. } => STRUCT_TAG_OWNER_BLOB,
+            SeedBlob::Grantee { .. } => STRUCT_TAG_GRANT_BLOB,
+        }
+    }
 }
 
 /// Open the reader's HPKE seed source, returning the recovered scope seed so the
@@ -532,14 +543,28 @@ pub async fn adopt<F: FloorStore>(
     // Stage 6 — unseal success required (AAD-confirmed). The HPKE seed source
     // (if any) opens first, then the symmetric read-body; the read-body decode
     // enforces child id/ipnsName uniqueness fail-closed.
+    //
+    // Reader-scope precondition: the scope UUID is not in the read-key KDF, so a
+    // read body sealed under a foreign scope still opens under this reader's key.
+    // Bind the envelope's scope to the reader's own scope so it joins the same
+    // equivalence class as every AAD/structure scope — a foreign-scope envelope
+    // is a scope transplant, fail-closed (blueprint/engine.md cross-check).
+    if candidate.envelope.scope != reader.scope_id {
+        return Err(reject(
+            GateStage::Unseal,
+            RejectionReason::Trust(TrustViolation::SealOpenFailed.into()),
+        ));
+    }
     if let Some(blob) = &reader.seed_blob {
         // Bind the blob to THIS envelope: a seed blob sealed under a different
         // scope/epoch/version is a transplant, not this record's seed source.
         // Fail closed before opening (blueprint/engine.md cross-check discipline).
         let aad = blob.aad();
         if aad.scope != reader.scope_id
+            || aad.id != candidate.envelope.id
             || aad.epoch != candidate.envelope.epoch
             || aad.v != candidate.envelope.v
+            || aad.struct_tag != blob.struct_tag()
         {
             return Err(reject(
                 GateStage::Unseal,

--- a/crates/engine/src/gate/adoption.rs
+++ b/crates/engine/src/gate/adoption.rs
@@ -473,9 +473,27 @@ pub async fn adopt<F: FloorStore>(
                 RejectionReason::Trust(TrustViolation::AscentLinkMismatch.into()),
             ));
         }
-        open_ascent_link(&parent_node_seed, &ascent.aad, &ascent.link)
-            .map(drop)
+        // Cross-check the recovered override seed: the ascent public key is
+        // published, so anyone can seal a rogue payload to it. The seed the link
+        // carries is this scope root's current override seed (CONTEXT.md "Ascent
+        // link"/"Override seed"), so it must belong to this epoch and derive this
+        // node's read key — the ascent-link half of engine.md:406-408 (owner-blob
+        // seed vs ascent-link seed vs actual unseal; any disagreement is
+        // attributable abuse). The recovered `OverrideSeedPayload` and derived
+        // `SecretBytes` are gate-owned and zeroize on drop; `reader.read_key` is
+        // caller-owned and never zeroized.
+        let payload = open_ascent_link(&parent_node_seed, &ascent.aad, &ascent.link)
             .map_err(|e| reject(GateStage::GrantSection, RejectionReason::Trust(e)))?;
+        let node_seed = kdf::node_seed(payload.override_seed(), &candidate.envelope.id);
+        let derived_read_key = kdf::read_key(node_seed.as_bytes());
+        if payload.epoch != candidate.envelope.epoch
+            || !ct_eq_secret(derived_read_key.as_bytes(), reader.read_key)
+        {
+            return Err(reject(
+                GateStage::GrantSection,
+                RejectionReason::Trust(TrustViolation::AscentLinkMismatch.into()),
+            ));
+        }
     }
 
     // Stage 4 — strictly newer than the durable per-name sequence floor.

--- a/crates/engine/src/gate/adoption.rs
+++ b/crates/engine/src/gate/adoption.rs
@@ -40,6 +40,7 @@ use core::fmt;
 
 use cipherbox_core::error::{CodecError, TrustViolation};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::kdf;
 use cipherbox_core::seal::{
     AadContext, AscentLink, Envelope, GrantSetCommitment, Permission, ReadBody, StructureSigInput,
     open_ascent_link, open_grant_blob, open_owner_blob, open_read_body, verify_grant_set,
@@ -47,6 +48,7 @@ use cipherbox_core::seal::{
 };
 use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaVerifier};
 use cipherbox_core::suite::ed25519::{Ed25519Signature, Ed25519Verifier};
+use cipherbox_core::suite::secret::SecretBytes;
 use cipherbox_core::suite::x25519::X25519Secret;
 
 use crate::gate::floor;
@@ -212,16 +214,18 @@ pub struct SignedStructure {
     pub signature: Ed25519Signature,
 }
 
-/// An ascent link plus the parent node seed an ancestor reader derives-and-
-/// verifies it under (stage 3, `ascent-link-mismatch`). Present only when the
-/// reader descends through the link from an ancestor scope; a same-scope
-/// holder passes `None`.
+/// A network-supplied ascent link presented for the stage-3 derive-and-verify
+/// (`ascent-link-mismatch`). Present only when the reader descends through the
+/// link from an ancestor scope; a same-scope holder passes `None`. The seed the
+/// expected keypair re-derives from is **reader state**
+/// ([`ReaderContext::parent_node_seed`]), never carried here — the candidate
+/// producer must not supply its own verification key (blueprint/engine.md:
+/// "Ancestor readers derive the expected ascent keypair from the parent node
+/// seed").
 #[derive(Clone)]
 pub struct AscentCheck {
     /// The published ascent link (plaintext public half + HPKE-sealed seed).
     pub link: AscentLink,
-    /// The parent node seed the expected keypair re-derives from.
-    pub parent_node_seed: [u8; 32],
     /// The structured AAD the link was sealed under.
     pub aad: AadContext,
 }
@@ -289,6 +293,11 @@ pub struct ReaderContext<'a> {
     pub scope_id: [u8; 16],
     /// The reader's own derived scope read key for the read-body unseal.
     pub read_key: &'a [u8; 32],
+    /// The reader's cached ancestor node seed — the trusted secret the expected
+    /// ascent keypair re-derives from. Required whenever `candidate.ascent` is
+    /// `Some`; a `None` here against a present ascent link is fail-closed
+    /// (cannot verify).
+    pub parent_node_seed: Option<[u8; 32]>,
     /// The reader's HPKE seed source, opened at the unseal stage; `None` for a
     /// holder that already possesses the read key.
     pub seed_blob: Option<SeedBlob<'a>>,
@@ -340,24 +349,51 @@ fn authenticate_structure(
     Err(TrustViolation::StructureSignatureInvalid.into())
 }
 
-/// Open the reader's HPKE seed source to confirm the reader can obtain the
-/// scope seed. The opened payload is dropped immediately (zeroized by core's
-/// owning types); the gate only needs the unseal-success verdict here.
-fn open_seed_blob(blob: &SeedBlob<'_>) -> Result<(), CodecError> {
+impl SeedBlob<'_> {
+    /// The structured AAD the blob claims to be sealed under — cross-checked
+    /// against the envelope before it is trusted.
+    fn aad(&self) -> &AadContext {
+        match self {
+            SeedBlob::Owner { aad, .. } | SeedBlob::Grantee { aad, .. } => aad,
+        }
+    }
+}
+
+/// Open the reader's HPKE seed source, returning the recovered scope seed so the
+/// gate can cross-check it derives the reader's read key. The returned
+/// [`SecretBytes`] zeroizes on drop at the gate (the terminal owner).
+fn open_seed_blob(blob: &SeedBlob<'_>) -> Result<SecretBytes, CodecError> {
     match blob {
         SeedBlob::Owner {
             enc_secret,
             enc,
             ciphertext,
             aad,
-        } => open_owner_blob(enc_secret, enc, aad, ciphertext).map(drop),
+        } => {
+            let payload = open_owner_blob(enc_secret, enc, aad, ciphertext)?;
+            Ok(SecretBytes::new(*payload.override_seed()))
+        }
         SeedBlob::Grantee {
             enc_secret,
             enc,
             ciphertext,
             aad,
-        } => open_grant_blob(enc_secret, enc, aad, ciphertext).map(drop),
+        } => {
+            let payload = open_grant_blob(enc_secret, enc, aad, ciphertext)?;
+            Ok(SecretBytes::new(*payload.read_scope_seed()))
+        }
     }
+}
+
+/// Constant-time 32-byte equality: no data-dependent early exit, so a mismatch
+/// between a candidate-derived key and the caller-owned read key is never a
+/// timing oracle over the reader's secret.
+fn ct_eq_secret(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    core::hint::black_box(diff) == 0
 }
 
 /// Run the adoption gate over one hand-fed [`Candidate`] for one
@@ -394,11 +430,35 @@ pub async fn adopt<F: FloorStore>(
     // Stage 3 — grant-section authentication under committed write pseudonyms.
     let committed = committed_write_pseudonyms(&candidate.commitment);
     for structure in &candidate.structures {
+        // Bind every structure to THIS envelope: an authentically-signed
+        // structure from another scope/epoch is a cross-epoch replay, not
+        // adoption material, and any grant-section failure rejects the whole
+        // record (blueprint/engine.md §"Adoption gate and floors", #39 D3).
+        // TODO(grant-section): recompute ciphertext_hash from record bytes, don't trust structure.input
+        if structure.input.scope_id != candidate.envelope.scope
+            || structure.input.epoch != candidate.envelope.epoch
+        {
+            return Err(reject(
+                GateStage::GrantSection,
+                RejectionReason::Trust(TrustViolation::StructureSignatureInvalid.into()),
+            ));
+        }
         authenticate_structure(&committed, structure)
             .map_err(|e| reject(GateStage::GrantSection, RejectionReason::Trust(e)))?;
     }
     if let Some(ascent) = &candidate.ascent {
-        open_ascent_link(&ascent.parent_node_seed, &ascent.aad, &ascent.link)
+        // Ascent authority is reader-derived: the expected keypair comes from
+        // the reader's cached ancestor node seed, never the network-supplied
+        // candidate (blueprint/engine.md: "Ancestor readers derive the expected
+        // ascent keypair from the parent node seed"). No reader seed ⇒ cannot
+        // verify ⇒ fail closed.
+        let parent_node_seed = reader.parent_node_seed.ok_or_else(|| {
+            reject(
+                GateStage::GrantSection,
+                RejectionReason::Trust(TrustViolation::AscentLinkMismatch.into()),
+            )
+        })?;
+        open_ascent_link(&parent_node_seed, &ascent.aad, &ascent.link)
             .map(drop)
             .map_err(|e| reject(GateStage::GrantSection, RejectionReason::Trust(e)))?;
     }
@@ -440,7 +500,34 @@ pub async fn adopt<F: FloorStore>(
     // (if any) opens first, then the symmetric read-body; the read-body decode
     // enforces child id/ipnsName uniqueness fail-closed.
     if let Some(blob) = &reader.seed_blob {
-        open_seed_blob(blob).map_err(|e| reject(GateStage::Unseal, RejectionReason::Trust(e)))?;
+        // Bind the blob to THIS envelope: a seed blob sealed under a different
+        // scope/epoch/version is a transplant, not this record's seed source.
+        // Fail closed before opening (blueprint/engine.md cross-check discipline).
+        let aad = blob.aad();
+        if aad.scope != reader.scope_id
+            || aad.epoch != candidate.envelope.epoch
+            || aad.v != candidate.envelope.v
+        {
+            return Err(reject(
+                GateStage::Unseal,
+                RejectionReason::Trust(TrustViolation::HpkeOpenFailed.into()),
+            ));
+        }
+        // Cross-check: the recovered seed must derive the reader's read key, or
+        // the blob-seed and the actual-unseal key disagree — an attributable
+        // abuse event (blueprint/engine.md), never a silent staleness. The
+        // derived `SecretBytes` are gate-owned and zeroize on drop here;
+        // `reader.read_key` is caller-owned and never zeroized.
+        let seed = open_seed_blob(blob)
+            .map_err(|e| reject(GateStage::Unseal, RejectionReason::Trust(e)))?;
+        let node_seed = kdf::node_seed(seed.as_bytes(), &candidate.envelope.id);
+        let derived_read_key = kdf::read_key(node_seed.as_bytes());
+        if !ct_eq_secret(derived_read_key.as_bytes(), reader.read_key) {
+            return Err(reject(
+                GateStage::Unseal,
+                RejectionReason::Trust(TrustViolation::SealOpenFailed.into()),
+            ));
+        }
     }
     let read_body = open_read_body(&candidate.envelope, reader.read_key)
         .map_err(|e| reject(GateStage::Unseal, RejectionReason::Trust(e)))?;

--- a/crates/engine/src/gate/adoption.rs
+++ b/crates/engine/src/gate/adoption.rs
@@ -42,9 +42,9 @@ use cipherbox_core::error::{CodecError, TrustViolation};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
-    AadContext, AscentLink, Envelope, GrantSetCommitment, Permission, ReadBody, StructureSigInput,
-    open_ascent_link, open_grant_blob, open_owner_blob, open_read_body, verify_grant_set,
-    verify_structure,
+    AadContext, AscentLink, Envelope, GrantSetCommitment, Permission, ReadBody,
+    STRUCT_TAG_ASCENT_LINK, StructureSigInput, open_ascent_link, open_grant_blob, open_owner_blob,
+    open_read_body, verify_grant_set, verify_structure,
 };
 use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaVerifier};
 use cipherbox_core::suite::ed25519::{Ed25519Signature, Ed25519Verifier};
@@ -458,6 +458,21 @@ pub async fn adopt<F: FloorStore>(
                 RejectionReason::Trust(TrustViolation::AscentLinkMismatch.into()),
             )
         })?;
+        // Bind the link's AAD to THIS envelope: a link valid under the same
+        // parent seed for another node/scope/epoch/version is a replay, not this
+        // record's ascent (blueprint/engine.md:405-406 — derive-and-verify
+        // against the current node). Fail closed before opening.
+        if ascent.aad.scope != reader.scope_id
+            || ascent.aad.id != candidate.envelope.id
+            || ascent.aad.epoch != candidate.envelope.epoch
+            || ascent.aad.v != candidate.envelope.v
+            || ascent.aad.struct_tag != STRUCT_TAG_ASCENT_LINK
+        {
+            return Err(reject(
+                GateStage::GrantSection,
+                RejectionReason::Trust(TrustViolation::AscentLinkMismatch.into()),
+            ));
+        }
         open_ascent_link(&parent_node_seed, &ascent.aad, &ascent.link)
             .map(drop)
             .map_err(|e| reject(GateStage::GrantSection, RejectionReason::Trust(e)))?;

--- a/crates/engine/src/gate/adoption.rs
+++ b/crates/engine/src/gate/adoption.rs
@@ -1,0 +1,520 @@
+//! The adoption gate — the six-stage trust pipeline every resolved record
+//! passes before it touches the snapshot (blueprint/engine.md "Adoption gate
+//! and floors"; CONTEXT.md "Adoption gate").
+//!
+//! The gate is a **pure composition of `crates/core`'s verify/unseal
+//! functions** plus the engine's durable floors. It defines no crypto, no
+//! codec, and no cryptographic error code of its own: every cryptographic
+//! verdict is a core [`CodecError`] surfaced verbatim through
+//! [`RejectionReason::Trust`]. The only engine-domain verdicts are the two
+//! floor comparisons (stages 4 and 5), which are the [`FloorStore`] seam's
+//! territory by construction.
+//!
+//! Stage order (composes the #33 pipeline with the #39 D3 seal-auth stage and
+//! the D4 floor law):
+//!
+//! 1. **Record verify** — core's full IPNS chain: the Ed25519 key is taken from
+//!    the [`IpnsName`] itself, `signatureV2` verifies, and the signed
+//!    `data.Value` must equal the top-level value. Yields the authenticated
+//!    sequence/epoch/EOL.
+//! 2. **Commitment verify** — the owner-signed grant-set commitment against the
+//!    contact-code-anchored owner identity, and its binding to this record's
+//!    name.
+//! 3. **Grant-section authentication** — every seed-bearing structure verifies
+//!    under a *committed write-capable pseudonym*; an ancestor reader also
+//!    derives-and-verifies the ascent link. Any failure rejects the **whole
+//!    record**.
+//! 4. **Sequence** — strictly newer than the durable per-name sequence floor.
+//! 5. **Epoch** — the envelope epoch tag at or above the scope's durable
+//!    read-epoch floor.
+//! 6. **Unseal** — the reader's HPKE seed source (if any) and the symmetric
+//!    read-body must open; the read-body decode also enforces child
+//!    id/`ipnsName` uniqueness fail-closed.
+//!
+//! Every failure is fail-closed and whole-record: the caller pins last-known-
+//! good and never renders the rejected record. Floors advance (via
+//! [`floor::advance_on_unseal`]) **only** after stage 6 succeeds — the
+//! AAD-confirmed-unseal rule of the floor law.
+
+use core::fmt;
+
+use cipherbox_core::error::{CodecError, TrustViolation};
+use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::seal::{
+    AadContext, AscentLink, Envelope, GrantSetCommitment, Permission, ReadBody, StructureSigInput,
+    open_ascent_link, open_grant_blob, open_owner_blob, open_read_body, verify_grant_set,
+    verify_structure,
+};
+use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaVerifier};
+use cipherbox_core::suite::ed25519::{Ed25519Signature, Ed25519Verifier};
+use cipherbox_core::suite::x25519::X25519Secret;
+
+use crate::gate::floor;
+use crate::seams::{FloorStore, SeamError};
+
+/// The six ordered stages of the adoption gate. The stage a rejection names is
+/// the first stage that failed; earlier stages all passed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateStage {
+    /// Stage 1: core's IPNS record verify chain.
+    RecordVerify,
+    /// Stage 2: the owner-signed grant-set commitment.
+    CommitmentVerify,
+    /// Stage 3: seed-bearing structure signatures under committed pseudonyms.
+    GrantSection,
+    /// Stage 4: strictly-newer sequence vs the durable per-name floor.
+    Sequence,
+    /// Stage 5: epoch tag at or above the scope's durable read-epoch floor.
+    Epoch,
+    /// Stage 6: HPKE seed source and symmetric read-body unseal.
+    Unseal,
+}
+
+impl GateStage {
+    /// Every stage, in pipeline order — the anti-vacuity anchor for the
+    /// six-stage matrix.
+    pub const ALL: &'static [GateStage] = &[
+        GateStage::RecordVerify,
+        GateStage::CommitmentVerify,
+        GateStage::GrantSection,
+        GateStage::Sequence,
+        GateStage::Epoch,
+        GateStage::Unseal,
+    ];
+
+    /// The stable kebab-case name of the stage.
+    pub fn name(&self) -> &'static str {
+        match self {
+            GateStage::RecordVerify => "record-verify",
+            GateStage::CommitmentVerify => "commitment-verify",
+            GateStage::GrantSection => "grant-section",
+            GateStage::Sequence => "sequence",
+            GateStage::Epoch => "epoch",
+            GateStage::Unseal => "unseal",
+        }
+    }
+}
+
+/// The engine floor-law verdict names — the two adoption-gate rejections that
+/// are engine domain (a durable-floor comparison), not a composed core check.
+/// Every *other* gate rejection carries a core `TrustViolation`/`Malformed`
+/// check name verbatim.
+pub const FLOOR_VERDICTS: &[&str] = &["sequence-not-newer", "epoch-below-floor"];
+
+/// Why the gate rejected a record. Fail-closed in every arm: a rejection is a
+/// trust violation, never mere staleness.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RejectionReason {
+    /// A composed `crates/core` cryptographic/codec check fired — surfaced
+    /// verbatim, never reclassified. Covers stages 1–3 and 6.
+    Trust(CodecError),
+    /// Stage 4: the record's sequence is not strictly newer than the durable
+    /// per-name sequence floor — a replay/rollback, fail-closed.
+    SequenceNotNewer {
+        /// The durable per-name sequence floor.
+        floor: u64,
+        /// The rejected record's sequence.
+        sequence: u64,
+    },
+    /// Stage 5: the envelope epoch tag is below the scope's durable read-epoch
+    /// floor — an old-epoch record past a revocation boundary, fail-closed.
+    EpochBelowFloor {
+        /// The durable read-epoch floor.
+        floor: u64,
+        /// The rejected record's epoch tag.
+        epoch: u64,
+    },
+}
+
+/// A fail-closed adoption-gate rejection: the stage that fired and its reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GateRejection {
+    /// The first stage that failed.
+    pub stage: GateStage,
+    /// Why it failed.
+    pub reason: RejectionReason,
+}
+
+impl GateRejection {
+    /// The stable named error for this rejection: the composed core check name
+    /// for a cryptographic/codec stage, or the engine floor-law verdict name
+    /// for a floor stage. This is the string the six-stage matrix asserts 1:1
+    /// against the design tables.
+    pub fn check(&self) -> &'static str {
+        match &self.reason {
+            RejectionReason::Trust(e) => e.check(),
+            RejectionReason::SequenceNotNewer { .. } => "sequence-not-newer",
+            RejectionReason::EpochBelowFloor { .. } => "epoch-below-floor",
+        }
+    }
+}
+
+impl fmt::Display for GateRejection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "adoption gate rejected at stage [{}]: [{}]",
+            self.stage.name(),
+            self.check()
+        )
+    }
+}
+
+impl std::error::Error for GateRejection {}
+
+/// The result of running the gate: a fail-closed [`GateRejection`], or a host
+/// seam I/O failure — availability, never a trust decision. Only
+/// [`GateError::Rejected`] means the record was untrustworthy; a
+/// [`GateError::Seam`] is a retryable read of the durable floors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GateError {
+    /// A fail-closed gate rejection.
+    Rejected(GateRejection),
+    /// A [`FloorStore`] seam failure — host I/O, not a trust verdict.
+    Seam(SeamError),
+}
+
+impl fmt::Display for GateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GateError::Rejected(r) => write!(f, "{r}"),
+            GateError::Seam(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for GateError {}
+
+impl GateError {
+    /// The rejection, if this was a fail-closed trust verdict (not a seam I/O
+    /// failure). Convenience for tests and hosts that classify verdicts.
+    pub fn rejection(&self) -> Option<&GateRejection> {
+        match self {
+            GateError::Rejected(r) => Some(r),
+            GateError::Seam(_) => None,
+        }
+    }
+}
+
+/// One seed-bearing structure presented for stage-3 authentication: the exact
+/// [`StructureSigInput`] it was detached-signed over and the signature. It
+/// carries **no** trusted author — the gate authenticates it against the
+/// committed writer-pseudonym set, so a signature under a non-committed key is
+/// rejected.
+#[derive(Clone)]
+pub struct SignedStructure {
+    /// The signed input `{scope, epoch, structTag, recipientTag?, H(ciphertext)}`.
+    pub input: StructureSigInput,
+    /// The detached pseudonym signature over [`structure_sig_preimage`] of the
+    /// input.
+    ///
+    /// [`structure_sig_preimage`]: cipherbox_core::seal::structure_sig_preimage
+    pub signature: Ed25519Signature,
+}
+
+/// An ascent link plus the parent node seed an ancestor reader derives-and-
+/// verifies it under (stage 3, `ascent-link-mismatch`). Present only when the
+/// reader descends through the link from an ancestor scope; a same-scope
+/// holder passes `None`.
+#[derive(Clone)]
+pub struct AscentCheck {
+    /// The published ascent link (plaintext public half + HPKE-sealed seed).
+    pub link: AscentLink,
+    /// The parent node seed the expected keypair re-derives from.
+    pub parent_node_seed: [u8; 32],
+    /// The structured AAD the link was sealed under.
+    pub aad: AadContext,
+}
+
+/// The reader's HPKE seed source, opened at the unseal stage to prove the
+/// reader can obtain the scope seed (`hpke-open-failed` on tamper). The public
+/// `enc`/`ciphertext` are the envelope grant-section blob addressed to this
+/// reader; the secret is the reader's own. A holder that already possesses the
+/// scope read key passes no seed blob.
+pub enum SeedBlob<'a> {
+    /// The vault owner's own-scope owner blob (HPKE to the owner enc subkey).
+    Owner {
+        /// The owner's X25519 encryption secret.
+        enc_secret: &'a X25519Secret,
+        /// The HPKE encapsulated key.
+        enc: [u8; 32],
+        /// The HPKE ciphertext.
+        ciphertext: Vec<u8>,
+        /// The structured AAD the blob was sealed under.
+        aad: AadContext,
+    },
+    /// A grantee's grant blob (HPKE to the recipient enc subkey).
+    Grantee {
+        /// The grantee's X25519 encryption secret.
+        enc_secret: &'a X25519Secret,
+        /// The HPKE encapsulated key.
+        enc: [u8; 32],
+        /// The HPKE ciphertext.
+        ciphertext: Vec<u8>,
+        /// The structured AAD the blob was sealed under.
+        aad: AadContext,
+    },
+}
+
+/// The hand-fed resolved record the gate adopts — the public bytes a resolve
+/// would assemble off the record/content plane. This slice does not resolve;
+/// tests feed candidates directly (blueprint/engine.md: "records are
+/// hand-fed").
+pub struct Candidate {
+    /// The IPNS name the record was fetched under — the verify chain's sole
+    /// trust anchor.
+    pub name: IpnsName,
+    /// The raw IPNS record protobuf bytes.
+    pub record_bytes: Vec<u8>,
+    /// The scope root's grant-set commitment.
+    pub commitment: GrantSetCommitment,
+    /// The owner's identity signature over the commitment.
+    pub commitment_sig: EcdsaSignature,
+    /// The seed-bearing structures presented for stage-3 authentication.
+    pub structures: Vec<SignedStructure>,
+    /// The ascent link derive-and-verify, for an ancestor reader.
+    pub ascent: Option<AscentCheck>,
+    /// The scope root's envelope (carries the plaintext epoch tag and the
+    /// sealed read-body).
+    pub envelope: Envelope,
+}
+
+/// The reader's private context for adoption. The gate borrows every field and
+/// zeroizes none of it — the reader is the terminal owner of its own key
+/// material.
+pub struct ReaderContext<'a> {
+    /// The contact-code-anchored owner identity (stage-2 verification anchor).
+    pub owner_identity: &'a EcdsaVerifier,
+    /// The scope id (the read-epoch floor key and the AAD scope binding).
+    pub scope_id: [u8; 16],
+    /// The reader's own derived scope read key for the read-body unseal.
+    pub read_key: &'a [u8; 32],
+    /// The reader's HPKE seed source, opened at the unseal stage; `None` for a
+    /// holder that already possesses the read key.
+    pub seed_blob: Option<SeedBlob<'a>>,
+}
+
+/// A record that passed all six gate stages: the unsealed read-body and the
+/// authenticated sequence/epoch the floor law advanced to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Adopted {
+    /// The unsealed, uniqueness-checked read-body.
+    pub read_body: ReadBody,
+    /// The authenticated record sequence (the new per-name floor).
+    pub sequence: u64,
+    /// The authenticated epoch tag (the new read-epoch floor).
+    pub epoch: u64,
+}
+
+/// The committed write-capable pseudonyms of a scope root: the owner pseudonym
+/// plus every write-permission entry's pseudonym. Read-only entries never
+/// authorize a seed-bearing structure.
+fn committed_write_pseudonyms(commitment: &GrantSetCommitment) -> Vec<Ed25519Verifier> {
+    let mut set = Vec::new();
+    if let Some(owner) = Ed25519Verifier::from_bytes(commitment.owner_pseudonym_pk) {
+        set.push(owner);
+    }
+    for entry in &commitment.entries {
+        if entry.permission == Permission::Write {
+            if let Some(pk) = Ed25519Verifier::from_bytes(entry.pseudonym_pk) {
+                set.push(pk);
+            }
+        }
+    }
+    set
+}
+
+/// Authenticate one seed-bearing structure against the committed write-capable
+/// pseudonyms. The structure is trusted iff its signature verifies under at
+/// least one committed pseudonym; otherwise the whole record is a
+/// `structure-signature-invalid` trust violation.
+fn authenticate_structure(
+    committed: &[Ed25519Verifier],
+    structure: &SignedStructure,
+) -> Result<(), CodecError> {
+    for pseudonym in committed {
+        if verify_structure(pseudonym, &structure.input, &structure.signature).is_ok() {
+            return Ok(());
+        }
+    }
+    Err(TrustViolation::StructureSignatureInvalid.into())
+}
+
+/// Open the reader's HPKE seed source to confirm the reader can obtain the
+/// scope seed. The opened payload is dropped immediately (zeroized by core's
+/// owning types); the gate only needs the unseal-success verdict here.
+fn open_seed_blob(blob: &SeedBlob<'_>) -> Result<(), CodecError> {
+    match blob {
+        SeedBlob::Owner {
+            enc_secret,
+            enc,
+            ciphertext,
+            aad,
+        } => open_owner_blob(enc_secret, enc, aad, ciphertext).map(drop),
+        SeedBlob::Grantee {
+            enc_secret,
+            enc,
+            ciphertext,
+            aad,
+        } => open_grant_blob(enc_secret, enc, aad, ciphertext).map(drop),
+    }
+}
+
+/// Run the adoption gate over one hand-fed [`Candidate`] for one
+/// [`ReaderContext`]. On success the floor law has advanced (per the
+/// AAD-confirmed-unseal rule) and the unsealed read-body is returned; on
+/// failure nothing durable changed and the caller pins last-known-good.
+pub async fn adopt<F: FloorStore>(
+    floors: &F,
+    reader: &ReaderContext<'_>,
+    candidate: &Candidate,
+) -> Result<Adopted, GateError> {
+    // Stage 1 — record verify (Ed25519 key from the name itself).
+    let verified = IpnsRecord::unmarshal(&candidate.record_bytes)
+        .and_then(|record| record.verify(&candidate.name))
+        .map_err(|e| reject(GateStage::RecordVerify, RejectionReason::Trust(e)))?;
+
+    // Stage 2 — commitment verify against the contact-anchored owner identity,
+    // and its binding to this record's name (the name is inside the signed
+    // commitment preimage; a commitment for a different scope root is invalid
+    // here).
+    verify_grant_set(
+        reader.owner_identity,
+        &candidate.commitment,
+        &candidate.commitment_sig,
+    )
+    .map_err(|e| reject(GateStage::CommitmentVerify, RejectionReason::Trust(e)))?;
+    if candidate.commitment.ipns_name != candidate.name.as_str().as_bytes() {
+        return Err(reject(
+            GateStage::CommitmentVerify,
+            RejectionReason::Trust(TrustViolation::CommitmentInvalid.into()),
+        ));
+    }
+
+    // Stage 3 — grant-section authentication under committed write pseudonyms.
+    let committed = committed_write_pseudonyms(&candidate.commitment);
+    for structure in &candidate.structures {
+        authenticate_structure(&committed, structure)
+            .map_err(|e| reject(GateStage::GrantSection, RejectionReason::Trust(e)))?;
+    }
+    if let Some(ascent) = &candidate.ascent {
+        open_ascent_link(&ascent.parent_node_seed, &ascent.aad, &ascent.link)
+            .map(drop)
+            .map_err(|e| reject(GateStage::GrantSection, RejectionReason::Trust(e)))?;
+    }
+
+    // Stage 4 — strictly newer than the durable per-name sequence floor.
+    let name_bytes = candidate.name.as_str().as_bytes();
+    let sequence_floor = floors
+        .sequence_floor(name_bytes)
+        .await
+        .map_err(GateError::Seam)?
+        .unwrap_or(0);
+    if verified.sequence <= sequence_floor {
+        return Err(reject(
+            GateStage::Sequence,
+            RejectionReason::SequenceNotNewer {
+                floor: sequence_floor,
+                sequence: verified.sequence,
+            },
+        ));
+    }
+
+    // Stage 5 — epoch tag at or above the scope's durable read-epoch floor.
+    let epoch = candidate.envelope.epoch;
+    let epoch_floor = floor::read_epoch_floor(floors, &reader.scope_id)
+        .await
+        .map_err(GateError::Seam)?
+        .unwrap_or(0);
+    if epoch < epoch_floor {
+        return Err(reject(
+            GateStage::Epoch,
+            RejectionReason::EpochBelowFloor {
+                floor: epoch_floor,
+                epoch,
+            },
+        ));
+    }
+
+    // Stage 6 — unseal success required (AAD-confirmed). The HPKE seed source
+    // (if any) opens first, then the symmetric read-body; the read-body decode
+    // enforces child id/ipnsName uniqueness fail-closed.
+    if let Some(blob) = &reader.seed_blob {
+        open_seed_blob(blob).map_err(|e| reject(GateStage::Unseal, RejectionReason::Trust(e)))?;
+    }
+    let read_body = open_read_body(&candidate.envelope, reader.read_key)
+        .map_err(|e| reject(GateStage::Unseal, RejectionReason::Trust(e)))?;
+
+    // Floor law — advance ONLY now, after the AAD-confirmed unseal.
+    floor::advance_on_unseal(
+        floors,
+        &reader.scope_id,
+        name_bytes,
+        verified.sequence,
+        epoch,
+    )
+    .await
+    .map_err(GateError::Seam)?;
+
+    Ok(Adopted {
+        read_body,
+        sequence: verified.sequence,
+        epoch,
+    })
+}
+
+/// Build a `GateError::Rejected` from a stage and reason.
+fn reject(stage: GateStage, reason: RejectionReason) -> GateError {
+    GateError::Rejected(GateRejection { stage, reason })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stage_names_are_stable_and_complete() {
+        assert_eq!(GateStage::ALL.len(), 6, "the gate has exactly six stages");
+        let names: Vec<&str> = GateStage::ALL.iter().map(GateStage::name).collect();
+        assert_eq!(
+            names,
+            [
+                "record-verify",
+                "commitment-verify",
+                "grant-section",
+                "sequence",
+                "epoch",
+                "unseal"
+            ]
+        );
+    }
+
+    #[test]
+    fn rejection_check_names_the_error() {
+        let seq = GateRejection {
+            stage: GateStage::Sequence,
+            reason: RejectionReason::SequenceNotNewer {
+                floor: 5,
+                sequence: 3,
+            },
+        };
+        assert_eq!(seq.check(), "sequence-not-newer");
+
+        let epoch = GateRejection {
+            stage: GateStage::Epoch,
+            reason: RejectionReason::EpochBelowFloor { floor: 4, epoch: 2 },
+        };
+        assert_eq!(epoch.check(), "epoch-below-floor");
+
+        let trust = GateRejection {
+            stage: GateStage::RecordVerify,
+            reason: RejectionReason::Trust(TrustViolation::IpnsSignatureInvalid.into()),
+        };
+        assert_eq!(trust.check(), "ipns-signature-invalid");
+    }
+
+    #[test]
+    fn floor_verdicts_are_the_two_engine_domain_names() {
+        assert_eq!(FLOOR_VERDICTS, &["sequence-not-newer", "epoch-below-floor"]);
+    }
+}

--- a/crates/engine/src/gate/adoption.rs
+++ b/crates/engine/src/gate/adoption.rs
@@ -446,6 +446,13 @@ pub async fn adopt<F: FloorStore>(
         .map_err(|e| reject(GateStage::Unseal, RejectionReason::Trust(e)))?;
 
     // Floor law — advance ONLY now, after the AAD-confirmed unseal.
+    //
+    // The stage-4/5 reads above and this advance are not a CAS pair, and they
+    // do not need to be: the engine is the single writer (blueprint/engine.md
+    // "Facade" — one live instance), so no concurrent adopt races this device's
+    // floors between the read and the advance. Cross-writer contention is
+    // resolved on the publish/RecordTransport plane (CAS), never on the local
+    // floor read. `advance_on_unseal` itself orders its two raises fail-safe.
     floor::advance_on_unseal(
         floors,
         &reader.scope_id,

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -76,10 +76,23 @@ pub async fn sequence_floor<F: FloorStore>(
 }
 
 /// Advance floors after an AAD-confirmed unseal — the only record-sourced
-/// advancement. Raises the per-name sequence floor to `sequence` and the
-/// per-scope read-epoch floor to `epoch`, both monotonic-max. Callers invoke
-/// this exactly once, at the adoption gate's successful unseal stage, so a
-/// record whose body never unsealed can never move a floor.
+/// advancement. Raises the per-scope read-epoch floor to `epoch` and the
+/// per-name sequence floor to `sequence`, both monotonic-max. Callers invoke
+/// this exactly once, at the adoption gate's successful unseal stage
+/// ([`adopt`](crate::gate::adopt) is the sole caller), so a record whose body
+/// never unsealed can never move a floor — the provenance the plain scalar
+/// arguments cannot express is enforced at that single call site.
+///
+/// **Fail-safe ordering.** The [`FloorStore`] seam is per-key monotonic with no
+/// cross-key transaction, so the two raises are separate durable writes. The
+/// trust-critical **read-epoch (revocation) floor commits first**: if the
+/// second (sequence) write then fails with a seam error, the durable state is
+/// epoch-advanced (fail-closed — old-epoch records still reject) with only the
+/// sequence floor stale-low, whose sole effect is a harmless idempotent
+/// re-adoption of the identical record on the caller's retry. The reverse
+/// order could leave the revocation floor stale, so it is deliberately avoided.
+/// Because both raises are idempotent monotonic-max, a retried `adopt`
+/// re-converges the pair.
 pub async fn advance_on_unseal<F: FloorStore>(
     floors: &F,
     scope_id: &[u8; 16],
@@ -87,8 +100,9 @@ pub async fn advance_on_unseal<F: FloorStore>(
     sequence: u64,
     epoch: u64,
 ) -> SeamResult<()> {
-    floors.raise_sequence_floor(ipns_name, sequence).await?;
+    // Revocation floor first (see "Fail-safe ordering" above).
     floors.raise_epoch_floor(scope_id, epoch).await?;
+    floors.raise_sequence_floor(ipns_name, sequence).await?;
     Ok(())
 }
 
@@ -100,8 +114,11 @@ pub async fn advance_on_unseal<F: FloorStore>(
 /// [`open_pointer_payload`](cipherbox_core::payload::open_pointer_payload),
 /// which authenticates the owner identity signature and the seal — so a forged,
 /// tampered, or non-owner re-point never produces one, and this function never
-/// runs on unauthenticated input.
+/// runs on unauthenticated input. As with [`advance_on_unseal`], the
+/// trust-critical read-epoch (revocation) floor commits before the write-epoch
+/// floor, so a partial seam failure leaves the fail-closed state.
 pub async fn cold_seed<F: FloorStore>(floors: &F, repoint: &RepointObject) -> SeamResult<()> {
+    // Revocation floor first (fail-safe ordering).
     floors
         .raise_epoch_floor(&repoint.scope_id, repoint.min_read_epoch)
         .await?;

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -1,0 +1,170 @@
+//! The floor law — durable monotonic advancement of the per-scope epoch and
+//! per-name sequence floors (blueprint/engine.md "Adoption gate and floors",
+//! #39 D4 / #38 D4).
+//!
+//! Floors are engine state, held behind the [`FloorStore`] seam. This module
+//! is the *only* place that advances them, and it advances them only the four
+//! ways the law admits:
+//!
+//! 1. **Advance on AAD-confirmed unseal** ([`advance_on_unseal`]) — the sole
+//!    record-sourced path. A record's sequence/epoch move the floors only after
+//!    its body cryptographically unsealed (the adoption gate's stage 6), never
+//!    from a claimed-but-unconfirmed field.
+//! 2. **Cold-seed from a re-point object** ([`cold_seed`]) — the cold-start
+//!    anchor. The owner-vouched `minReadEpoch` seeds the read-epoch floor (the
+//!    revocation boundary) and `writeEpoch` the write-epoch floor. The caller
+//!    passes a [`RepointObject`] it already authenticated with
+//!    [`open_pointer_payload`](cipherbox_core::payload::open_pointer_payload):
+//!    the object type is only obtainable from that verified open, so an
+//!    unsigned or non-owner re-point never reaches this function and no floor
+//!    moves (fail-closed by construction).
+//! 3. **Pointer `writeEpoch` advances on sight** ([`advance_write_epoch_on_sight`])
+//!    — an owner-vouched write epoch above the durable floor raises it the
+//!    moment it is seen (#38 D4).
+//! 4. **Regression is fail-closed** — every advance is monotonic-max via the
+//!    store (raising below the stored floor is a no-op that keeps the max), so
+//!    a floor can never move backward.
+//!
+//! A grant blob's epoch field is an advisory routing hint and has **no**
+//! advancement path here — deliberately. Nothing reads it as authority.
+
+use cipherbox_core::payload::RepointObject;
+
+use crate::seams::{FloorStore, SeamResult};
+
+/// Suffix that distinguishes a scope's write-epoch floor key from its
+/// read-epoch floor key inside the [`FloorStore`] epoch namespace. The
+/// read-epoch floor (the revocation boundary the adoption gate's epoch stage
+/// enforces against the envelope epoch tag) is keyed by the bare 16-byte scope
+/// id; the write-epoch floor, an independent clock authored by owner-only write
+/// rotations, is keyed by the scope id plus this suffix so the two never
+/// collide.
+const WRITE_EPOCH_SUFFIX: &[u8] = b"/write-epoch";
+
+/// The [`FloorStore`] epoch-namespace key for a scope's write-epoch floor.
+fn write_epoch_key(scope_id: &[u8; 16]) -> Vec<u8> {
+    let mut key = Vec::with_capacity(scope_id.len() + WRITE_EPOCH_SUFFIX.len());
+    key.extend_from_slice(scope_id);
+    key.extend_from_slice(WRITE_EPOCH_SUFFIX);
+    key
+}
+
+/// The scope's durable read-epoch floor (the revocation boundary), if ever
+/// raised. This is the floor the adoption gate's epoch stage compares the
+/// envelope epoch tag against.
+pub async fn read_epoch_floor<F: FloorStore>(
+    floors: &F,
+    scope_id: &[u8; 16],
+) -> SeamResult<Option<u64>> {
+    floors.epoch_floor(scope_id).await
+}
+
+/// The scope's durable write-epoch floor, if ever raised.
+pub async fn write_epoch_floor<F: FloorStore>(
+    floors: &F,
+    scope_id: &[u8; 16],
+) -> SeamResult<Option<u64>> {
+    floors.epoch_floor(&write_epoch_key(scope_id)).await
+}
+
+/// The durable per-name sequence floor, if ever raised.
+pub async fn sequence_floor<F: FloorStore>(
+    floors: &F,
+    ipns_name: &[u8],
+) -> SeamResult<Option<u64>> {
+    floors.sequence_floor(ipns_name).await
+}
+
+/// Advance floors after an AAD-confirmed unseal — the only record-sourced
+/// advancement. Raises the per-name sequence floor to `sequence` and the
+/// per-scope read-epoch floor to `epoch`, both monotonic-max. Callers invoke
+/// this exactly once, at the adoption gate's successful unseal stage, so a
+/// record whose body never unsealed can never move a floor.
+pub async fn advance_on_unseal<F: FloorStore>(
+    floors: &F,
+    scope_id: &[u8; 16],
+    ipns_name: &[u8],
+    sequence: u64,
+    epoch: u64,
+) -> SeamResult<()> {
+    floors.raise_sequence_floor(ipns_name, sequence).await?;
+    floors.raise_epoch_floor(scope_id, epoch).await?;
+    Ok(())
+}
+
+/// Cold-seed a scope's floors from an owner-vouched re-point object. Raises the
+/// read-epoch floor to `minReadEpoch` (the revocation boundary) and the
+/// write-epoch floor to `writeEpoch`, both monotonic-max.
+///
+/// The [`RepointObject`] argument is only obtainable from a successful
+/// [`open_pointer_payload`](cipherbox_core::payload::open_pointer_payload),
+/// which authenticates the owner identity signature and the seal — so a forged,
+/// tampered, or non-owner re-point never produces one, and this function never
+/// runs on unauthenticated input.
+pub async fn cold_seed<F: FloorStore>(floors: &F, repoint: &RepointObject) -> SeamResult<()> {
+    floors
+        .raise_epoch_floor(&repoint.scope_id, repoint.min_read_epoch)
+        .await?;
+    floors
+        .raise_epoch_floor(&write_epoch_key(&repoint.scope_id), repoint.write_epoch)
+        .await?;
+    Ok(())
+}
+
+/// Advance the write-epoch floor on sight of an owner-vouched pointer
+/// `writeEpoch`. Monotonic-max: a value at or below the durable floor is a
+/// no-op that reports the stored floor. Returns the resulting floor.
+pub async fn advance_write_epoch_on_sight<F: FloorStore>(
+    floors: &F,
+    scope_id: &[u8; 16],
+    write_epoch: u64,
+) -> SeamResult<u64> {
+    floors
+        .raise_epoch_floor(&write_epoch_key(scope_id), write_epoch)
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testkit::block_on;
+    use crate::testkit::fakes::InMemoryFloorStore;
+
+    const SCOPE: [u8; 16] = [7u8; 16];
+    const NAME: &[u8] = b"k51-scope-root-name";
+
+    #[test]
+    fn advance_on_unseal_raises_both_floors_monotonically() {
+        let floors = InMemoryFloorStore::default();
+        block_on(async {
+            advance_on_unseal(&floors, &SCOPE, NAME, 5, 3)
+                .await
+                .unwrap();
+            assert_eq!(sequence_floor(&floors, NAME).await.unwrap(), Some(5));
+            assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(3));
+
+            // A regression attempt is a no-op: the store keeps the max.
+            advance_on_unseal(&floors, &SCOPE, NAME, 2, 1)
+                .await
+                .unwrap();
+            assert_eq!(sequence_floor(&floors, NAME).await.unwrap(), Some(5));
+            assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(3));
+        });
+    }
+
+    #[test]
+    fn read_and_write_epoch_floors_are_independent() {
+        let floors = InMemoryFloorStore::default();
+        block_on(async {
+            advance_on_unseal(&floors, &SCOPE, NAME, 1, 4)
+                .await
+                .unwrap();
+            advance_write_epoch_on_sight(&floors, &SCOPE, 9)
+                .await
+                .unwrap();
+            // The write-epoch floor moving does not disturb the read-epoch floor.
+            assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(4));
+            assert_eq!(write_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(9));
+        });
+    }
+}

--- a/crates/engine/src/gate/mod.rs
+++ b/crates/engine/src/gate/mod.rs
@@ -1,0 +1,23 @@
+//! The trust layer: the adoption gate and the durable floor law
+//! (blueprint/engine.md "Adoption gate and floors").
+//!
+//! [`adopt`] is the six-stage pipeline every resolved record passes before
+//! adoption — a pure composition of `crates/core`'s verify/unseal functions
+//! over the engine's [`FloorStore`](crate::seams::FloorStore) floors. [`floor`]
+//! is the floor law: the only place floors advance, and only the four ways the
+//! law admits (AAD-confirmed unseal, re-point cold-seed, `writeEpoch` on sight,
+//! all monotonic-max so regression is impossible).
+//!
+//! No crypto, no codec, and no cryptographic error code lives here: every
+//! cryptographic verdict is a core [`CodecError`](cipherbox_core::error::CodecError)
+//! surfaced verbatim; the only engine-domain verdicts are the two floor
+//! comparisons.
+
+pub mod floor;
+
+mod adoption;
+
+pub use adoption::{
+    Adopted, AscentCheck, Candidate, FLOOR_VERDICTS, GateError, GateRejection, GateStage,
+    ReaderContext, RejectionReason, SeedBlob, SignedStructure, adopt,
+};

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -27,6 +27,7 @@
 pub mod api;
 pub mod entropy;
 pub mod facade;
+pub mod gate;
 pub mod profile;
 pub mod seams;
 #[cfg(feature = "test-kit")]
@@ -40,6 +41,10 @@ pub use entropy::{Entropy, EntropyError};
 pub use facade::{
     Command, Engine, EngineError, Event, EventStream, LoginSecret, NodeId, NodeKind, Permission,
     PlaintextContent, Staleness,
+};
+pub use gate::{
+    Adopted, AscentCheck, Candidate, GateError, GateRejection, GateStage, ReaderContext,
+    RejectionReason, SeedBlob, SignedStructure, adopt,
 };
 pub use profile::SyncTimingProfile;
 pub use seams::{SeamError, SeamResult, SeamSet, SeamTypes};

--- a/crates/engine/tests/adoption_gate.rs
+++ b/crates/engine/tests/adoption_gate.rs
@@ -1,0 +1,928 @@
+//! The adoption-gate simulation harness: N engine instances on one fake record
+//! store, virtual time, and adversarial replay/transplant/re-sign, plus the
+//! six-stage matrix and the floor-law scenarios hard-asserted 1:1 against the
+//! design tables in blueprint/engine.md ("Adoption gate and floors").
+//!
+//! Every record is hand-fed (this slice lands no resolve/publish wiring): the
+//! IPNS record plane rides the shared fake record store; the metadata (grant
+//! commitment, seed-bearing structures, envelope) is constructed directly with
+//! `crates/core`'s crypto. The gate composes only core's verify/unseal
+//! functions — so the reject rows assert core's exact named `TrustViolation`
+//! error, never an engine reinvention.
+
+use std::collections::BTreeSet;
+
+use cipherbox_core::codec::{Map, Value, encode};
+use cipherbox_core::error::TrustViolation;
+use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::kdf;
+use cipherbox_core::payload::{RepointObject, open_pointer_payload, seal_pointer_payload};
+use cipherbox_core::seal::{
+    AadContext, Envelope, GrantBlobPayload, GrantSetCommitment, OverrideSeedPayload, ReadBody,
+    STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_GRANT_BLOB, STRUCT_TAG_HISTORY_LINK, STRUCT_TAG_OWNER_BLOB,
+    STRUCT_TAG_READ_BODY, STRUCT_TAG_WRITE_BODY, StructureSigInput, WriteBody, encode_write_body,
+    open_grant_blob, seal, seal_ascent_link, seal_grant_blob, seal_owner_blob, seal_read_body,
+    sign_grant_set, sign_structure,
+};
+use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
+use cipherbox_core::suite::ed25519::{Ed25519Signature, Ed25519Signer};
+use cipherbox_core::suite::x25519::X25519Secret;
+
+use cipherbox_engine::SyncTimingProfile;
+use cipherbox_engine::gate::floor::{
+    advance_write_epoch_on_sight, cold_seed, read_epoch_floor, sequence_floor, write_epoch_floor,
+};
+use cipherbox_engine::gate::{
+    Adopted, AscentCheck, Candidate, FLOOR_VERDICTS, GateError, GateStage, ReaderContext, SeedBlob,
+    SignedStructure, adopt,
+};
+use cipherbox_engine::seams::{FloorStore, RecordTransport, Scheduler};
+use cipherbox_engine::testkit::fakes::InMemoryFloorStore;
+use cipherbox_engine::testkit::{FakeWorld, block_on};
+
+// Format version, injected TTL/EOL, and the fixed nonces/ephemeral scalars the
+// fixture seals under (test crypto: deterministic, KAT-style injected entropy).
+const V: u64 = 1;
+const TTL_NANOS: u64 = 2_000_000_000;
+const EOL: &str = "2027-01-01T00:00:00Z";
+const RECORD_VALUE: &[u8] = b"/ipfs/AAAAAAAAAA";
+const NONCE_READ_BODY: [u8; 24] = [11u8; 24];
+const NONCE_WRITE_BODY: [u8; 24] = [22u8; 24];
+const NONCE_POINTER: [u8; 24] = [33u8; 24];
+const EPH_OWNER: [u8; 32] = [3u8; 32];
+const EPH_ASCENT: [u8; 32] = [4u8; 32];
+const EPH_GRANT: [u8; 32] = [5u8; 32];
+
+/// A fully valid scope-root fixture: every key/seed and the derived valid
+/// [`Candidate`] parts. Each test builds a fresh fixture and mutates one aspect
+/// to exercise exactly one gate stage.
+struct Fixture {
+    // Identities.
+    owner_identity: EcdsaSigner,
+    owner_identity_verifier: EcdsaVerifier,
+    owner_pseudonym: Ed25519Signer,
+    owner_enc: X25519Secret,
+    // Scope shape.
+    scope_id: [u8; 16],
+    root_id: [u8; 16],
+    scope_seed: [u8; 32],
+    epoch: u64,
+    // Derived record/metadata.
+    read_key: [u8; 32],
+    ipns_signer: Ed25519Signer,
+    name: IpnsName,
+    owner_blob_enc: [u8; 32],
+    owner_blob_ct: Vec<u8>,
+    owner_blob_aad: AadContext,
+    commitment: GrantSetCommitment,
+    commitment_sig: cipherbox_core::suite::ecdsa::EcdsaSignature,
+    structures: Vec<SignedStructure>,
+    valid_envelope: Envelope,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let owner_identity = EcdsaSigner::from_scalar(&[0x11; 32]).expect("valid scalar");
+        let owner_identity_verifier = owner_identity.verifying_key();
+        let owner_pseudonym = Ed25519Signer::from_seed([0x22; 32]);
+        let owner_enc = X25519Secret::from_scalar([0x33; 32]);
+
+        let scope_id = [0x44; 16];
+        let root_id = [0x55; 16];
+        let scope_seed = [0x66; 32];
+        let write_scope_seed = [0x77; 32];
+        let epoch = 1;
+
+        // Read plane: read key from the node seed.
+        let node_seed = kdf::node_seed(&scope_seed, &root_id);
+        let read_key = *kdf::read_key(node_seed.as_bytes()).as_bytes();
+
+        // Write plane: the IPNS keypair and the write-body key.
+        let write_seed = kdf::write_seed(&write_scope_seed, &root_id);
+        let ipns_signer = kdf::ipns_keypair(write_seed.as_bytes());
+        let name = IpnsName::from_public_key(&ipns_signer.verifying_key());
+        let write_key = kdf::write_key(write_seed.as_bytes());
+
+        // Owner blob (a seed-bearing structure AND the owner's seed source).
+        let override_payload = OverrideSeedPayload::new(scope_seed, epoch);
+        let owner_blob_aad = AadContext {
+            v: V,
+            id: root_id,
+            scope: scope_id,
+            epoch,
+            struct_tag: STRUCT_TAG_OWNER_BLOB,
+        };
+        let owner_blob = seal_owner_blob(
+            &owner_enc.public(),
+            &EPH_OWNER,
+            &owner_blob_aad,
+            &override_payload,
+        );
+        let owner_blob_ct = owner_blob.ciphertext.clone();
+        let owner_blob_enc = owner_blob.enc;
+        let owner_blob_input = StructureSigInput::over_ciphertext(
+            scope_id,
+            epoch,
+            STRUCT_TAG_OWNER_BLOB,
+            None,
+            &owner_blob_ct,
+        );
+        let owner_blob_structure = SignedStructure {
+            signature: sign_structure(&owner_pseudonym, &owner_blob_input),
+            input: owner_blob_input,
+        };
+
+        // Write-body (a second seed-bearing structure, to exercise the loop).
+        let write_body = WriteBody {
+            grant_ledger: Vec::new(),
+            write_history_link: Vec::new(),
+            direct_child_scope_index: Vec::new(),
+            unknown: Vec::new(),
+        };
+        let write_body_aad = AadContext {
+            v: V,
+            id: root_id,
+            scope: scope_id,
+            epoch,
+            struct_tag: STRUCT_TAG_WRITE_BODY,
+        };
+        let write_body_sealed = seal(
+            write_key.as_bytes(),
+            &NONCE_WRITE_BODY,
+            &write_body_aad,
+            &encode_write_body(&write_body),
+        );
+        let write_body_input = StructureSigInput::over_ciphertext(
+            scope_id,
+            epoch,
+            STRUCT_TAG_WRITE_BODY,
+            None,
+            &write_body_sealed,
+        );
+        let write_body_structure = SignedStructure {
+            signature: sign_structure(&owner_pseudonym, &write_body_input),
+            input: write_body_input,
+        };
+
+        // Grant-set commitment (grant-less scope: the owner pseudonym is the
+        // sole committed writer).
+        let commitment = GrantSetCommitment {
+            ipns_name: name.as_str().as_bytes().to_vec(),
+            owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
+            entries: Vec::new(),
+            unknown: Vec::new(),
+        };
+        let commitment_sig = sign_grant_set(&owner_identity, &commitment);
+
+        // Valid empty-folder read-body sealed into the envelope.
+        let folder = ReadBody::Folder {
+            created_at: 0,
+            modified_at: 0,
+            children: Vec::new(),
+            unknown: Vec::new(),
+        };
+        let valid_envelope = seal_read_body(
+            &read_key,
+            &NONCE_READ_BODY,
+            V,
+            root_id,
+            scope_id,
+            epoch,
+            &folder,
+        )
+        .expect("valid folder seals");
+
+        Self {
+            owner_identity,
+            owner_identity_verifier,
+            owner_pseudonym,
+            owner_enc,
+            scope_id,
+            root_id,
+            scope_seed,
+            epoch,
+            read_key,
+            ipns_signer,
+            name,
+            owner_blob_enc,
+            owner_blob_ct,
+            owner_blob_aad,
+            commitment,
+            commitment_sig,
+            structures: vec![owner_blob_structure, write_body_structure],
+            valid_envelope,
+        }
+    }
+
+    fn record_bytes(&self, sequence: u64) -> Vec<u8> {
+        IpnsRecord::create_v2(&self.ipns_signer, RECORD_VALUE, sequence, TTL_NANOS, EOL).marshal()
+    }
+
+    fn read_body_aad(&self) -> AadContext {
+        AadContext {
+            v: V,
+            id: self.root_id,
+            scope: self.scope_id,
+            epoch: self.epoch,
+            struct_tag: STRUCT_TAG_READ_BODY,
+        }
+    }
+
+    /// Seal an arbitrary read-body plaintext under the scope read key — used to
+    /// stage a duplicate-child body built at the codec level (bypassing
+    /// `encode_read_body`'s uniqueness guard, exactly as a hostile peer would).
+    fn seal_read_plaintext(&self, plaintext: &[u8]) -> Vec<u8> {
+        seal(
+            &self.read_key,
+            &NONCE_READ_BODY,
+            &self.read_body_aad(),
+            plaintext,
+        )
+    }
+
+    fn envelope_with_read_sealed(&self, read_sealed: Vec<u8>) -> Envelope {
+        Envelope {
+            v: V,
+            id: self.root_id,
+            scope: self.scope_id,
+            epoch: self.epoch,
+            read_sealed,
+            unknown: Vec::new(),
+            epoch_tag_unknown: Vec::new(),
+        }
+    }
+
+    fn candidate_with_record(&self, record_bytes: Vec<u8>) -> Candidate {
+        Candidate {
+            name: self.name.clone(),
+            record_bytes,
+            commitment: self.commitment.clone(),
+            commitment_sig: self.commitment_sig.clone(),
+            structures: self.structures.clone(),
+            ascent: None,
+            envelope: self.valid_envelope.clone(),
+        }
+    }
+
+    fn candidate(&self, sequence: u64) -> Candidate {
+        self.candidate_with_record(self.record_bytes(sequence))
+    }
+
+    fn owner_seed_blob(&self, tampered: bool) -> SeedBlob<'_> {
+        let mut ciphertext = self.owner_blob_ct.clone();
+        if tampered {
+            ciphertext[0] ^= 0xFF;
+        }
+        SeedBlob::Owner {
+            enc_secret: &self.owner_enc,
+            enc: self.owner_blob_enc,
+            ciphertext,
+            aad: self.owner_blob_aad,
+        }
+    }
+
+    fn reader(&self) -> ReaderContext<'_> {
+        ReaderContext {
+            owner_identity: &self.owner_identity_verifier,
+            scope_id: self.scope_id,
+            read_key: &self.read_key,
+            seed_blob: Some(self.owner_seed_blob(false)),
+        }
+    }
+
+    /// An ascent link whose plaintext public half is corrupted, so an ancestor
+    /// reader's derive-and-verify fails `ascent-link-mismatch`.
+    fn tampered_ascent(&self) -> AscentCheck {
+        let parent_node_seed = [0x99; 32];
+        let payload = OverrideSeedPayload::new(self.scope_seed, self.epoch);
+        let aad = AadContext {
+            v: V,
+            id: self.root_id,
+            scope: self.scope_id,
+            epoch: self.epoch,
+            struct_tag: STRUCT_TAG_ASCENT_LINK,
+        };
+        let mut link = seal_ascent_link(&parent_node_seed, &EPH_ASCENT, &aad, &payload);
+        link.ascent_public[0] ^= 0xFF;
+        AscentCheck {
+            link,
+            parent_node_seed,
+            aad,
+        }
+    }
+}
+
+/// One folder child as a raw det-CBOR map (so a duplicate listing can be built
+/// below the `encode_read_body` uniqueness guard).
+fn raw_child(id: [u8; 16], name: &str, ipns: &[u8]) -> Value {
+    let mut m = Map::new();
+    m.insert("id", Value::Bytes(id.to_vec()));
+    m.insert("name", Value::Text(name.to_string()));
+    m.insert("ipnsName", Value::Bytes(ipns.to_vec()));
+    m.insert("kind", Value::Text("file".to_string()));
+    m.insert("linkCounter", Value::Unsigned(0));
+    Value::Map(m)
+}
+
+/// A folder read-body plaintext built directly through the codec.
+fn raw_folder_plaintext(children: Vec<Value>) -> Vec<u8> {
+    let mut m = Map::new();
+    m.insert("kind", Value::Text("folder".to_string()));
+    m.insert("children", Value::Array(children));
+    m.insert("createdAt", Value::Unsigned(0));
+    m.insert("modifiedAt", Value::Unsigned(0));
+    encode(&Value::Map(m))
+}
+
+fn duplicate_id_plaintext() -> Vec<u8> {
+    raw_folder_plaintext(vec![
+        raw_child([1; 16], "a", b"ipns-a"),
+        raw_child([1; 16], "b", b"ipns-b"),
+    ])
+}
+
+fn duplicate_ipns_name_plaintext() -> Vec<u8> {
+    raw_folder_plaintext(vec![
+        raw_child([1; 16], "a", b"ipns-same"),
+        raw_child([2; 16], "b", b"ipns-same"),
+    ])
+}
+
+/// Overwrite the top-level `value` protobuf field (field 1, emitted first) with
+/// a same-length payload, leaving the signed `data` field untouched — so the
+/// signature still verifies but the data/value consistency check fires.
+fn tamper_top_value(mut bytes: Vec<u8>, new_value: &[u8]) -> Vec<u8> {
+    assert_eq!(bytes[0], 0x0A, "IPNS field-1 (value) length-delimited tag");
+    let len = bytes[1] as usize;
+    assert_eq!(
+        len,
+        new_value.len(),
+        "same-length overwrite keeps the signed data field intact"
+    );
+    bytes[2..2 + len].copy_from_slice(new_value);
+    bytes
+}
+
+// ---------------------------------------------------------------------------
+// The six-stage matrix — mirrored 1:1 from blueprint/engine.md.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+enum Expect {
+    Accept,
+    Reject(GateStage, &'static str),
+}
+
+/// The design table: the acceptance row plus every reject class, each pinned to
+/// the stage it fires at and its exact named error.
+const MATRIX: &[(&str, Expect)] = &[
+    ("accept", Expect::Accept),
+    (
+        "record-verify:ipns-signature-invalid",
+        Expect::Reject(GateStage::RecordVerify, "ipns-signature-invalid"),
+    ),
+    (
+        "record-verify:ipns-value-mismatch",
+        Expect::Reject(GateStage::RecordVerify, "ipns-value-mismatch"),
+    ),
+    (
+        "commitment-verify:commitment-invalid",
+        Expect::Reject(GateStage::CommitmentVerify, "commitment-invalid"),
+    ),
+    (
+        "grant-section:structure-signature-invalid",
+        Expect::Reject(GateStage::GrantSection, "structure-signature-invalid"),
+    ),
+    (
+        "grant-section:ascent-link-mismatch",
+        Expect::Reject(GateStage::GrantSection, "ascent-link-mismatch"),
+    ),
+    (
+        "sequence:sequence-not-newer",
+        Expect::Reject(GateStage::Sequence, "sequence-not-newer"),
+    ),
+    (
+        "epoch:epoch-below-floor",
+        Expect::Reject(GateStage::Epoch, "epoch-below-floor"),
+    ),
+    (
+        "unseal:seal-open-failed",
+        Expect::Reject(GateStage::Unseal, "seal-open-failed"),
+    ),
+    (
+        "unseal:hpke-open-failed",
+        Expect::Reject(GateStage::Unseal, "hpke-open-failed"),
+    ),
+    (
+        "unseal:duplicate-id",
+        Expect::Reject(GateStage::Unseal, "duplicate-id"),
+    ),
+    (
+        "unseal:duplicate-ipns-name",
+        Expect::Reject(GateStage::Unseal, "duplicate-ipns-name"),
+    ),
+];
+
+/// The exact reject surface the six-stage matrix must exercise: nine composed
+/// core `TrustViolation` checks plus the two engine floor-law verdicts.
+const MATRIX_REJECT_SURFACE: &[&str] = &[
+    "ipns-signature-invalid",
+    "ipns-value-mismatch",
+    "commitment-invalid",
+    "structure-signature-invalid",
+    "ascent-link-mismatch",
+    "sequence-not-newer",
+    "epoch-below-floor",
+    "seal-open-failed",
+    "hpke-open-failed",
+    "duplicate-id",
+    "duplicate-ipns-name",
+];
+
+/// Build a fresh fixture, apply the named mutation, and run the gate to a
+/// verdict. Each call owns its fixture/floors for the whole adopt.
+fn run_matrix_case(name: &str) -> Result<Adopted, GateError> {
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let mut candidate = fx.candidate(1);
+    let mut tamper_seed_blob = false;
+
+    match name {
+        "accept" => {}
+        "record-verify:ipns-signature-invalid" => {
+            let last = candidate.record_bytes.len() - 1;
+            candidate.record_bytes[last] ^= 0x01;
+        }
+        "record-verify:ipns-value-mismatch" => {
+            candidate.record_bytes = tamper_top_value(candidate.record_bytes, b"/ipfs/BBBBBBBBBB");
+        }
+        "commitment-verify:commitment-invalid" => {
+            let foreign = EcdsaSigner::from_scalar(&[0x5A; 32]).expect("valid scalar");
+            candidate.commitment_sig = sign_grant_set(&foreign, &candidate.commitment);
+        }
+        "grant-section:structure-signature-invalid" => {
+            let mut sig = candidate.structures[0].signature.to_bytes();
+            sig[0] ^= 0xFF;
+            candidate.structures[0].signature = Ed25519Signature::from_bytes(sig);
+        }
+        "grant-section:ascent-link-mismatch" => {
+            candidate.ascent = Some(fx.tampered_ascent());
+        }
+        "sequence:sequence-not-newer" => {
+            block_on(floors.raise_sequence_floor(fx.name.as_str().as_bytes(), 5)).unwrap();
+        }
+        "epoch:epoch-below-floor" => {
+            block_on(floors.raise_epoch_floor(&fx.scope_id, 5)).unwrap();
+        }
+        "unseal:seal-open-failed" => {
+            let last = candidate.envelope.read_sealed.len() - 1;
+            candidate.envelope.read_sealed[last] ^= 0x01;
+        }
+        "unseal:hpke-open-failed" => {
+            tamper_seed_blob = true;
+        }
+        "unseal:duplicate-id" => {
+            candidate.envelope =
+                fx.envelope_with_read_sealed(fx.seal_read_plaintext(&duplicate_id_plaintext()));
+        }
+        "unseal:duplicate-ipns-name" => {
+            candidate.envelope = fx.envelope_with_read_sealed(
+                fx.seal_read_plaintext(&duplicate_ipns_name_plaintext()),
+            );
+        }
+        other => panic!("unknown matrix row: {other}"),
+    }
+
+    let reader = ReaderContext {
+        owner_identity: &fx.owner_identity_verifier,
+        scope_id: fx.scope_id,
+        read_key: &fx.read_key,
+        seed_blob: Some(fx.owner_seed_blob(tamper_seed_blob)),
+    };
+    block_on(adopt(&floors, &reader, &candidate))
+}
+
+#[test]
+fn six_stage_matrix_matches_the_design_table() {
+    let mut observed: BTreeSet<String> = BTreeSet::new();
+    for (name, expect) in MATRIX {
+        let result = run_matrix_case(name);
+        match expect {
+            Expect::Accept => {
+                let adopted = result
+                    .unwrap_or_else(|e| panic!("row `{name}` must accept, got rejection: {e}"));
+                assert_eq!(adopted.sequence, 1, "row `{name}`");
+                assert_eq!(adopted.epoch, 1, "row `{name}`");
+            }
+            Expect::Reject(stage, check) => {
+                let err = result.expect_err(&format!("row `{name}` must reject"));
+                let rejection = err.rejection().unwrap_or_else(|| {
+                    panic!("row `{name}` must be a trust rejection, not a seam error")
+                });
+                assert_eq!(rejection.stage, *stage, "row `{name}` stage");
+                assert_eq!(rejection.check(), *check, "row `{name}` named error");
+                observed.insert(rejection.check().to_string());
+            }
+        }
+    }
+
+    // Anti-vacuity: the run exercised exactly the reject surface — every row
+    // ran (or the loop would have panicked) and no check is missing or extra.
+    let expected: BTreeSet<String> = MATRIX_REJECT_SURFACE
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert_eq!(
+        observed, expected,
+        "the matrix run must exercise exactly the design reject surface"
+    );
+}
+
+#[test]
+fn every_gate_stage_is_pinned_by_a_matrix_reject_row() {
+    let stages: BTreeSet<&str> = MATRIX
+        .iter()
+        .filter_map(|(_, e)| match e {
+            Expect::Reject(stage, _) => Some(stage.name()),
+            Expect::Accept => None,
+        })
+        .collect();
+    let all: BTreeSet<&str> = GateStage::ALL.iter().map(|s| s.name()).collect();
+    assert_eq!(
+        stages, all,
+        "each of the six stages must have at least one reject row"
+    );
+}
+
+#[test]
+fn matrix_table_and_reject_surface_mirror_one_to_one() {
+    let from_table: BTreeSet<&str> = MATRIX
+        .iter()
+        .filter_map(|(_, e)| match e {
+            Expect::Reject(_, check) => Some(*check),
+            Expect::Accept => None,
+        })
+        .collect();
+    let surface: BTreeSet<&str> = MATRIX_REJECT_SURFACE.iter().copied().collect();
+    assert_eq!(
+        from_table, surface,
+        "the matrix table's reject checks must mirror the reject surface 1:1"
+    );
+}
+
+#[test]
+fn no_reject_check_is_an_engine_invented_crypto_code() {
+    let core: BTreeSet<&str> = TrustViolation::CHECKS.iter().copied().collect();
+    let floor: BTreeSet<&str> = FLOOR_VERDICTS.iter().copied().collect();
+    for check in MATRIX_REJECT_SURFACE {
+        assert!(
+            core.contains(check) || floor.contains(check),
+            "`{check}` must be a core TrustViolation or an engine floor verdict — never an engine-invented crypto code"
+        );
+    }
+    // The only non-core checks are exactly the two floor verdicts.
+    let non_core: BTreeSet<&str> = MATRIX_REJECT_SURFACE
+        .iter()
+        .copied()
+        .filter(|c| !core.contains(c))
+        .collect();
+    assert_eq!(
+        non_core, floor,
+        "the only engine-domain reject checks are the two floor verdicts"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The floor-law scenarios — mirrored 1:1 from the floor law (#39 D4 / #38 D4).
+// ---------------------------------------------------------------------------
+
+/// The five floor-law rules, each exercised by [`run_floor_scenario`].
+const FLOOR_LAW_RULES: &[&str] = &[
+    "advance-only-on-aad-confirmed-unseal",
+    "cold-seed-from-repoint",
+    "pointer-write-epoch-advances-on-sight",
+    "grant-blob-epoch-advisory-only",
+    "floorstore-regression-fail-closed",
+];
+
+fn run_floor_scenario(rule: &str) {
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let name_bytes = fx.name.as_str().as_bytes();
+
+    match rule {
+        "advance-only-on-aad-confirmed-unseal" => {
+            // A confirmed adopt advances both floors.
+            block_on(adopt(&floors, &fx.reader(), &fx.candidate(1))).expect("adopts");
+            assert_eq!(
+                block_on(sequence_floor(&floors, name_bytes)).unwrap(),
+                Some(1)
+            );
+            assert_eq!(
+                block_on(read_epoch_floor(&floors, &fx.scope_id)).unwrap(),
+                Some(1)
+            );
+
+            // A newer record whose body does NOT unseal must move no floor.
+            let mut broken = fx.candidate(2);
+            let last = broken.envelope.read_sealed.len() - 1;
+            broken.envelope.read_sealed[last] ^= 0x01;
+            let err = block_on(adopt(&floors, &fx.reader(), &broken)).unwrap_err();
+            assert_eq!(err.rejection().unwrap().check(), "seal-open-failed");
+            assert_eq!(
+                block_on(sequence_floor(&floors, name_bytes)).unwrap(),
+                Some(1),
+                "a failed unseal must not advance the sequence floor despite a newer sequence"
+            );
+            assert_eq!(
+                block_on(read_epoch_floor(&floors, &fx.scope_id)).unwrap(),
+                Some(1)
+            );
+        }
+        "cold-seed-from-repoint" => {
+            let pointer_read_key = [0x8A; 32];
+            let repoint = RepointObject {
+                scope_id: fx.scope_id,
+                current_root: fx.name.clone(),
+                write_epoch: 7,
+                min_read_epoch: 3,
+                prev_root: None,
+            };
+            let sealed = seal_pointer_payload(
+                &pointer_read_key,
+                &NONCE_POINTER,
+                V,
+                &fx.owner_identity,
+                &repoint,
+            );
+
+            // Owner-vouched: opens under the owner identity, then seeds.
+            let opened = open_pointer_payload(
+                &pointer_read_key,
+                V,
+                &fx.scope_id,
+                &fx.owner_identity_verifier,
+                &sealed,
+            )
+            .expect("owner-signed re-point opens");
+            block_on(cold_seed(&floors, &opened)).unwrap();
+            assert_eq!(
+                block_on(read_epoch_floor(&floors, &fx.scope_id)).unwrap(),
+                Some(3),
+                "read-epoch floor cold-seeds from minReadEpoch"
+            );
+            assert_eq!(
+                block_on(write_epoch_floor(&floors, &fx.scope_id)).unwrap(),
+                Some(7),
+                "write-epoch floor cold-seeds from writeEpoch"
+            );
+
+            // Fail-closed: a non-owner re-point never authenticates, so nothing
+            // seeds (identity-signature-invalid, floors untouched).
+            let untouched = InMemoryFloorStore::default();
+            let foreign = EcdsaSigner::from_scalar(&[0x1D; 32]).unwrap();
+            let err = open_pointer_payload(
+                &pointer_read_key,
+                V,
+                &fx.scope_id,
+                &foreign.verifying_key(),
+                &sealed,
+            )
+            .expect_err("a non-owner re-point must fail closed");
+            assert_eq!(err.check(), "identity-signature-invalid");
+            assert_eq!(
+                block_on(read_epoch_floor(&untouched, &fx.scope_id)).unwrap(),
+                None,
+                "a rejected re-point moves no floor"
+            );
+        }
+        "pointer-write-epoch-advances-on-sight" => {
+            assert_eq!(
+                block_on(advance_write_epoch_on_sight(&floors, &fx.scope_id, 5)).unwrap(),
+                5
+            );
+            assert_eq!(
+                block_on(advance_write_epoch_on_sight(&floors, &fx.scope_id, 3)).unwrap(),
+                5,
+                "a writeEpoch at or below the durable floor is a monotonic no-op"
+            );
+            assert_eq!(
+                block_on(advance_write_epoch_on_sight(&floors, &fx.scope_id, 9)).unwrap(),
+                9
+            );
+        }
+        "grant-blob-epoch-advisory-only" => {
+            // A grant blob claims epoch 99, but the record's AAD-confirmed
+            // envelope epoch is 1 — the floor advances to 1, never to 99.
+            let recipient_tag = [0x7A; 32];
+            let grant_aad = AadContext {
+                v: V,
+                id: fx.root_id,
+                scope: fx.scope_id,
+                epoch: fx.epoch,
+                struct_tag: STRUCT_TAG_GRANT_BLOB,
+            };
+            let payload = GrantBlobPayload::new(fx.scope_seed, None, 99, [0x7B; 32]);
+            let blob = seal_grant_blob(&fx.owner_enc.public(), &EPH_GRANT, &grant_aad, &payload);
+            let input = StructureSigInput::over_ciphertext(
+                fx.scope_id,
+                fx.epoch,
+                STRUCT_TAG_GRANT_BLOB,
+                Some(recipient_tag),
+                &blob.ciphertext,
+            );
+            let signed = SignedStructure {
+                signature: sign_structure(&fx.owner_pseudonym, &input),
+                input,
+            };
+            let mut candidate = fx.candidate(1);
+            candidate.structures.push(signed);
+
+            block_on(adopt(&floors, &fx.reader(), &candidate)).expect("adopts");
+            assert_eq!(
+                block_on(read_epoch_floor(&floors, &fx.scope_id)).unwrap(),
+                Some(1),
+                "the floor advances to the AAD-confirmed envelope epoch, not the grant blob's claim"
+            );
+            let opened =
+                open_grant_blob(&fx.owner_enc, &blob.enc, &grant_aad, &blob.ciphertext).unwrap();
+            assert_eq!(
+                opened.epoch, 99,
+                "the grant blob really carried epoch 99 — advisory, and it moved no floor"
+            );
+        }
+        "floorstore-regression-fail-closed" => {
+            // Seed the read-epoch floor high, then prove a below-floor record is
+            // rejected AND the durable floor never regresses.
+            block_on(floors.raise_epoch_floor(&fx.scope_id, 5)).unwrap();
+            let err = block_on(adopt(&floors, &fx.reader(), &fx.candidate(1))).unwrap_err();
+            let rejection = err.rejection().unwrap();
+            assert_eq!(rejection.stage, GateStage::Epoch);
+            assert_eq!(rejection.check(), "epoch-below-floor");
+            assert_eq!(
+                block_on(floors.raise_epoch_floor(&fx.scope_id, 2)).unwrap(),
+                5,
+                "a raise below the stored floor is a fail-closed no-op keeping the max"
+            );
+            assert_eq!(
+                block_on(read_epoch_floor(&floors, &fx.scope_id)).unwrap(),
+                Some(5)
+            );
+        }
+        other => panic!("unknown floor-law rule: {other}"),
+    }
+}
+
+#[test]
+fn floor_law_scenarios_match_the_design_table() {
+    for rule in FLOOR_LAW_RULES {
+        run_floor_scenario(rule);
+    }
+}
+
+#[test]
+fn every_floor_law_rule_is_named_and_covered() {
+    // The scenario runner recognizes exactly the design's rule set — any rule
+    // added to the table without an arm panics, any arm without a table entry
+    // is never covered.
+    let rules: BTreeSet<&str> = FLOOR_LAW_RULES.iter().copied().collect();
+    assert_eq!(
+        rules.len(),
+        FLOOR_LAW_RULES.len(),
+        "no duplicate rule names"
+    );
+    assert_eq!(
+        FLOOR_LAW_RULES.len(),
+        5,
+        "the floor law has exactly five rules: advance-on-unseal, cold-seed, writeEpoch-on-sight, blob-epoch-advisory, regression-fail-closed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The simulation harness — N engines on one fake record store, virtual time,
+// adversarial replay / transplant / re-sign.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn simulation_n_engines_one_record_store_adversarial() {
+    let world = FakeWorld::new();
+    let owner_device = world.device(b"owner-pk");
+    let reader_device = world.device(b"reader-pk");
+    let fx = Fixture::new();
+    let endpoint = world.record_store.endpoints()[0].clone();
+    let routing_key = fx.name.as_str().to_string();
+
+    // A valid seq-1 record on the shared network adopts on every device.
+    world
+        .record_store
+        .seed_record(&endpoint, &routing_key, fx.record_bytes(1));
+    for device in [&owner_device, &reader_device] {
+        let bytes = block_on(device.record_store.get_record(&endpoint, &routing_key))
+            .unwrap()
+            .expect("record present on the shared store");
+        let candidate = fx.candidate_with_record(bytes);
+        let adopted = block_on(adopt(&device.floor_store, &fx.reader(), &candidate))
+            .expect("a shared valid record adopts on every device");
+        assert_eq!(adopted.sequence, 1);
+    }
+
+    // Virtual time is one shared timeline.
+    world.scheduler.advance(SyncTimingProfile::CI.poll_cadence);
+    assert_eq!(owner_device.scheduler.now(), reader_device.scheduler.now());
+
+    // Replay: adopt a newer record, then the adversary re-seeds the old one.
+    world
+        .record_store
+        .seed_record(&endpoint, &routing_key, fx.record_bytes(2));
+    let newer = block_on(
+        owner_device
+            .record_store
+            .get_record(&endpoint, &routing_key),
+    )
+    .unwrap()
+    .unwrap();
+    block_on(adopt(
+        &owner_device.floor_store,
+        &fx.reader(),
+        &fx.candidate_with_record(newer),
+    ))
+    .expect("the newer record adopts");
+
+    world
+        .record_store
+        .seed_record(&endpoint, &routing_key, fx.record_bytes(1));
+    let replayed = block_on(
+        owner_device
+            .record_store
+            .get_record(&endpoint, &routing_key),
+    )
+    .unwrap()
+    .unwrap();
+    let err = block_on(adopt(
+        &owner_device.floor_store,
+        &fx.reader(),
+        &fx.candidate_with_record(replayed),
+    ))
+    .unwrap_err();
+    assert_eq!(
+        err.rejection().unwrap().check(),
+        "sequence-not-newer",
+        "a replayed older record is a fail-closed rejection, never a silent no-op"
+    );
+
+    // Re-sign: a fresh device cold-seeds its read floor from an owner re-point
+    // at minReadEpoch 2; a revokee re-signs a valid old-epoch(1) record.
+    let victim = world.device(b"victim-pk");
+    let pointer_read_key = [0x8A; 32];
+    let repoint = RepointObject {
+        scope_id: fx.scope_id,
+        current_root: fx.name.clone(),
+        write_epoch: 2,
+        min_read_epoch: 2,
+        prev_root: None,
+    };
+    let sealed = seal_pointer_payload(
+        &pointer_read_key,
+        &NONCE_POINTER,
+        V,
+        &fx.owner_identity,
+        &repoint,
+    );
+    let opened = open_pointer_payload(
+        &pointer_read_key,
+        V,
+        &fx.scope_id,
+        &fx.owner_identity_verifier,
+        &sealed,
+    )
+    .unwrap();
+    block_on(cold_seed(&victim.floor_store, &opened)).unwrap();
+    let err = block_on(adopt(&victim.floor_store, &fx.reader(), &fx.candidate(3))).unwrap_err();
+    assert_eq!(
+        err.rejection().unwrap().check(),
+        "epoch-below-floor",
+        "a revokee's validly re-signed old-epoch record fails the advanced floor"
+    );
+
+    // Transplant: a structure signature moved to a different structure tag
+    // fails core's tag-bound preimage check.
+    let mut transplanted = fx.candidate(1);
+    transplanted.structures[0].input = StructureSigInput::over_ciphertext(
+        fx.scope_id,
+        fx.epoch,
+        STRUCT_TAG_HISTORY_LINK,
+        None,
+        &fx.owner_blob_ct,
+    );
+    let err = block_on(adopt(
+        &reader_device.floor_store,
+        &fx.reader(),
+        &transplanted,
+    ))
+    .unwrap_err();
+    assert_eq!(
+        err.rejection().unwrap().check(),
+        "structure-signature-invalid",
+        "a transplanted structure signature is rejected by core's tag-bound preimage"
+    );
+}

--- a/crates/engine/tests/adoption_gate.rs
+++ b/crates/engine/tests/adoption_gate.rs
@@ -296,7 +296,6 @@ impl Fixture {
     /// `parent_node_seed` re-derives this keypair — a mismatched reader seed is
     /// a natural `ascent-link-mismatch`, no hand-corruption needed.
     fn ascent_link_under(&self, parent_node_seed: &[u8; 32]) -> AscentCheck {
-        let payload = OverrideSeedPayload::new(self.scope_seed, self.epoch);
         let aad = AadContext {
             v: V,
             id: self.root_id,
@@ -304,6 +303,14 @@ impl Fixture {
             epoch: self.epoch,
             struct_tag: STRUCT_TAG_ASCENT_LINK,
         };
+        self.ascent_link_under_aad(parent_node_seed, aad)
+    }
+
+    /// An ascent link sealed under `parent_node_seed` with a caller-chosen AAD —
+    /// lets a test pass the seed-derive half yet present an AAD that does not
+    /// bind to the envelope.
+    fn ascent_link_under_aad(&self, parent_node_seed: &[u8; 32], aad: AadContext) -> AscentCheck {
+        let payload = OverrideSeedPayload::new(self.scope_seed, self.epoch);
         let link = seal_ascent_link(parent_node_seed, &EPH_ASCENT, &aad, &payload);
         AscentCheck { link, aad }
     }
@@ -1013,6 +1020,32 @@ fn ascent_adopts_when_reader_seed_matches_sealed_link() {
     reader.parent_node_seed = Some(parent_seed);
     let adopted = block_on(adopt(&floors, &reader, &candidate)).expect("valid ascent adopts");
     assert_eq!(adopted.sequence, 1);
+}
+
+#[test]
+fn ascent_link_aad_must_bind_to_the_envelope() {
+    // The link is correctly sealed under the reader's real parent seed (the
+    // seed-derive half passes), but its AAD names a different epoch than the
+    // envelope — a link minted under the same parent seed for another
+    // node/epoch/version. Fail closed on the AAD bind, before opening.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let parent_seed = [0xAB; 32];
+    let foreign_aad = AadContext {
+        v: V,
+        id: fx.root_id,
+        scope: fx.scope_id,
+        epoch: fx.epoch + 1,
+        struct_tag: STRUCT_TAG_ASCENT_LINK,
+    };
+    let mut candidate = fx.candidate(1);
+    candidate.ascent = Some(fx.ascent_link_under_aad(&parent_seed, foreign_aad));
+    let mut reader = fx.reader();
+    reader.parent_node_seed = Some(parent_seed);
+    let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();
+    let rej = err.rejection().unwrap();
+    assert_eq!(rej.stage, GateStage::GrantSection);
+    assert_eq!(rej.check(), "ascent-link-mismatch");
 }
 
 #[test]

--- a/crates/engine/tests/adoption_gate.rs
+++ b/crates/engine/tests/adoption_gate.rs
@@ -286,14 +286,16 @@ impl Fixture {
             owner_identity: &self.owner_identity_verifier,
             scope_id: self.scope_id,
             read_key: &self.read_key,
+            parent_node_seed: None,
             seed_blob: Some(self.owner_seed_blob(false)),
         }
     }
 
-    /// An ascent link whose plaintext public half is corrupted, so an ancestor
-    /// reader's derive-and-verify fails `ascent-link-mismatch`.
-    fn tampered_ascent(&self) -> AscentCheck {
-        let parent_node_seed = [0x99; 32];
+    /// A well-formed ascent link sealed under `parent_node_seed` (uncorrupted
+    /// public half). The stage-3 verdict now hinges on whether the *reader's*
+    /// `parent_node_seed` re-derives this keypair — a mismatched reader seed is
+    /// a natural `ascent-link-mismatch`, no hand-corruption needed.
+    fn ascent_link_under(&self, parent_node_seed: &[u8; 32]) -> AscentCheck {
         let payload = OverrideSeedPayload::new(self.scope_seed, self.epoch);
         let aad = AadContext {
             v: V,
@@ -302,12 +304,39 @@ impl Fixture {
             epoch: self.epoch,
             struct_tag: STRUCT_TAG_ASCENT_LINK,
         };
-        let mut link = seal_ascent_link(&parent_node_seed, &EPH_ASCENT, &aad, &payload);
-        link.ascent_public[0] ^= 0xFF;
-        AscentCheck {
-            link,
-            parent_node_seed,
+        let link = seal_ascent_link(parent_node_seed, &EPH_ASCENT, &aad, &payload);
+        AscentCheck { link, aad }
+    }
+
+    /// An owner seed blob whose sealed AAD is overridden (e.g. a foreign scope)
+    /// while still HPKE-wrapped to the reader's real enc subkey — a transplant
+    /// that opens but must fail the envelope cross-check.
+    fn owner_seed_blob_with_aad(&self, aad: AadContext) -> SeedBlob<'_> {
+        let payload = OverrideSeedPayload::new(self.scope_seed, self.epoch);
+        let blob = seal_owner_blob(&self.owner_enc.public(), &EPH_OWNER, &aad, &payload);
+        SeedBlob::Owner {
+            enc_secret: &self.owner_enc,
+            enc: blob.enc,
+            ciphertext: blob.ciphertext,
             aad,
+        }
+    }
+
+    /// An owner seed blob carrying a *wrong* scope seed: it opens cleanly (real
+    /// AAD, real enc subkey) yet cannot derive the reader's read key.
+    fn owner_seed_blob_wrong_seed(&self, wrong_seed: [u8; 32]) -> SeedBlob<'_> {
+        let payload = OverrideSeedPayload::new(wrong_seed, self.epoch);
+        let blob = seal_owner_blob(
+            &self.owner_enc.public(),
+            &EPH_OWNER,
+            &self.owner_blob_aad,
+            &payload,
+        );
+        SeedBlob::Owner {
+            enc_secret: &self.owner_enc,
+            enc: blob.enc,
+            ciphertext: blob.ciphertext,
+            aad: self.owner_blob_aad,
         }
     }
 }
@@ -446,6 +475,7 @@ fn run_matrix_case(name: &str) -> Result<Adopted, GateError> {
     let floors = InMemoryFloorStore::default();
     let mut candidate = fx.candidate(1);
     let mut tamper_seed_blob = false;
+    let mut reader_parent_seed: Option<[u8; 32]> = None;
 
     match name {
         "accept" => {}
@@ -466,7 +496,11 @@ fn run_matrix_case(name: &str) -> Result<Adopted, GateError> {
             candidate.structures[0].signature = Ed25519Signature::from_bytes(sig);
         }
         "grant-section:ascent-link-mismatch" => {
-            candidate.ascent = Some(fx.tampered_ascent());
+            // The link is sealed under one parent seed; the reader supplies a
+            // DIFFERENT real ancestor seed, so the reader-derived keypair
+            // mismatches the link's public half — a natural ascent-link-mismatch.
+            candidate.ascent = Some(fx.ascent_link_under(&[0xA1; 32]));
+            reader_parent_seed = Some([0xB2; 32]);
         }
         "sequence:sequence-not-newer" => {
             block_on(floors.raise_sequence_floor(fx.name.as_str().as_bytes(), 5)).unwrap();
@@ -497,6 +531,7 @@ fn run_matrix_case(name: &str) -> Result<Adopted, GateError> {
         owner_identity: &fx.owner_identity_verifier,
         scope_id: fx.scope_id,
         read_key: &fx.read_key,
+        parent_node_seed: reader_parent_seed,
         seed_blob: Some(fx.owner_seed_blob(tamper_seed_blob)),
     };
     block_on(adopt(&floors, &reader, &candidate))
@@ -925,4 +960,142 @@ fn simulation_n_engines_one_record_store_adversarial() {
         "structure-signature-invalid",
         "a transplanted structure signature is rejected by core's tag-bound preimage"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Trust-boundary hardening: ascent authority, cross-epoch structure replay, and
+// seed-blob envelope binding + read-key cross-check (blueprint/engine.md §405-408).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ascent_authority_is_reader_derived_not_candidate_supplied() {
+    // The attacker seals a well-formed ascent link from a seed IT chose; the
+    // reader's real ancestor seed is different. The gate re-derives the expected
+    // keypair from reader state (not the candidate), so the check mismatches —
+    // the vacuous "producer picks its own seed and passes" is closed.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let mut candidate = fx.candidate(1);
+    candidate.ascent = Some(fx.ascent_link_under(&[0xAB; 32]));
+    let mut reader = fx.reader();
+    reader.parent_node_seed = Some([0xCD; 32]);
+    let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();
+    let rej = err.rejection().unwrap();
+    assert_eq!(rej.stage, GateStage::GrantSection);
+    assert_eq!(rej.check(), "ascent-link-mismatch");
+}
+
+#[test]
+fn ascent_present_without_reader_seed_fails_closed() {
+    // An ascent link present with no reader ancestor seed cannot be verified —
+    // fail closed, never adopt on an unverifiable link.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let mut candidate = fx.candidate(1);
+    candidate.ascent = Some(fx.ascent_link_under(&[0xAB; 32]));
+    let reader = fx.reader();
+    let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();
+    let rej = err.rejection().unwrap();
+    assert_eq!(rej.stage, GateStage::GrantSection);
+    assert_eq!(rej.check(), "ascent-link-mismatch");
+}
+
+#[test]
+fn ascent_adopts_when_reader_seed_matches_sealed_link() {
+    // Positive: the reader's ancestor seed re-derives the sealed keypair, so the
+    // link verifies and the record adopts.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let parent_seed = [0xAB; 32];
+    let mut candidate = fx.candidate(1);
+    candidate.ascent = Some(fx.ascent_link_under(&parent_seed));
+    let mut reader = fx.reader();
+    reader.parent_node_seed = Some(parent_seed);
+    let adopted = block_on(adopt(&floors, &reader, &candidate)).expect("valid ascent adopts");
+    assert_eq!(adopted.sequence, 1);
+}
+
+#[test]
+fn cross_epoch_structure_replay_rejected_at_grant_section() {
+    // A new record at epoch 2 carrying an authentic owner-signed structure from
+    // the OLD epoch 1 (same scope, same pseudonym): the signature verifies, so
+    // only the envelope-binding cross-check rejects the cross-epoch replay.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let folder = ReadBody::Folder {
+        created_at: 0,
+        modified_at: 0,
+        children: Vec::new(),
+        unknown: Vec::new(),
+    };
+    let envelope_e2 = seal_read_body(
+        &fx.read_key,
+        &NONCE_READ_BODY,
+        V,
+        fx.root_id,
+        fx.scope_id,
+        2,
+        &folder,
+    )
+    .expect("epoch-2 folder seals");
+    let mut candidate = fx.candidate(1);
+    candidate.envelope = envelope_e2;
+    // The old-epoch owner-blob structure is validly signed (epoch 1 != 2).
+    candidate.structures = vec![fx.structures[0].clone()];
+    assert_eq!(candidate.structures[0].input.scope_id, fx.scope_id);
+    assert_eq!(candidate.structures[0].input.epoch, 1);
+    let err = block_on(adopt(&floors, &fx.reader(), &candidate)).unwrap_err();
+    let rej = err.rejection().unwrap();
+    assert_eq!(rej.stage, GateStage::GrantSection);
+    assert_eq!(rej.check(), "structure-signature-invalid");
+}
+
+#[test]
+fn seed_blob_foreign_scope_aad_rejected_at_unseal() {
+    // The seed blob is HPKE-wrapped to the reader's real enc subkey but sealed
+    // under a foreign scope AAD — it would open, yet it is not this envelope's
+    // seed source. Fail closed on the AAD cross-check.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let foreign_aad = AadContext {
+        v: V,
+        id: fx.root_id,
+        scope: [0xEE; 16],
+        epoch: fx.epoch,
+        struct_tag: STRUCT_TAG_OWNER_BLOB,
+    };
+    let mut reader = fx.reader();
+    reader.seed_blob = Some(fx.owner_seed_blob_with_aad(foreign_aad));
+    let candidate = fx.candidate(1);
+    let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();
+    let rej = err.rejection().unwrap();
+    assert_eq!(rej.stage, GateStage::Unseal);
+    assert_eq!(rej.check(), "hpke-open-failed");
+}
+
+#[test]
+fn seed_blob_wrong_seed_fails_read_key_cross_check() {
+    // The blob opens cleanly (real AAD, real enc subkey) but carries a wrong
+    // scope seed that does not derive the reader's read key — an attributable
+    // seed disagreement, not silent staleness.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let mut reader = fx.reader();
+    reader.seed_blob = Some(fx.owner_seed_blob_wrong_seed([0xAB; 32]));
+    let candidate = fx.candidate(1);
+    let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();
+    let rej = err.rejection().unwrap();
+    assert_eq!(rej.stage, GateStage::Unseal);
+    assert_eq!(rej.check(), "seal-open-failed");
+}
+
+#[test]
+fn seed_blob_correct_seed_derives_read_key_and_adopts() {
+    // Positive: the default owner blob carries the real scope seed under the real
+    // scope/epoch/v AAD — the cross-check passes and the record adopts.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let adopted = block_on(adopt(&floors, &fx.reader(), &fx.candidate(1))).expect("adopts");
+    assert_eq!(adopted.sequence, 1);
+    assert_eq!(adopted.epoch, 1);
 }

--- a/crates/engine/tests/adoption_gate.rs
+++ b/crates/engine/tests/adoption_gate.rs
@@ -296,23 +296,43 @@ impl Fixture {
     /// `parent_node_seed` re-derives this keypair — a mismatched reader seed is
     /// a natural `ascent-link-mismatch`, no hand-corruption needed.
     fn ascent_link_under(&self, parent_node_seed: &[u8; 32]) -> AscentCheck {
-        let aad = AadContext {
+        self.ascent_link_under_aad(parent_node_seed, self.ascent_aad())
+    }
+
+    /// An ascent link sealed under `parent_node_seed` with a caller-chosen AAD,
+    /// carrying this scope's real override seed — lets a test pass the seed-derive
+    /// half yet present an AAD that does not bind to the envelope.
+    fn ascent_link_under_aad(&self, parent_node_seed: &[u8; 32], aad: AadContext) -> AscentCheck {
+        self.ascent_link_full(
+            parent_node_seed,
+            aad,
+            OverrideSeedPayload::new(self.scope_seed, self.epoch),
+        )
+    }
+
+    /// An ascent link sealed under `parent_node_seed`/`aad` carrying a
+    /// caller-chosen `OverrideSeedPayload` — lets a test seal a rogue or
+    /// stale-epoch seed to the published ascent public key.
+    fn ascent_link_full(
+        &self,
+        parent_node_seed: &[u8; 32],
+        aad: AadContext,
+        payload: OverrideSeedPayload,
+    ) -> AscentCheck {
+        let link = seal_ascent_link(parent_node_seed, &EPH_ASCENT, &aad, &payload);
+        AscentCheck { link, aad }
+    }
+
+    /// The envelope-matching ascent AAD (the honest ascent context for the
+    /// fixture's scope root).
+    fn ascent_aad(&self) -> AadContext {
+        AadContext {
             v: V,
             id: self.root_id,
             scope: self.scope_id,
             epoch: self.epoch,
             struct_tag: STRUCT_TAG_ASCENT_LINK,
-        };
-        self.ascent_link_under_aad(parent_node_seed, aad)
-    }
-
-    /// An ascent link sealed under `parent_node_seed` with a caller-chosen AAD —
-    /// lets a test pass the seed-derive half yet present an AAD that does not
-    /// bind to the envelope.
-    fn ascent_link_under_aad(&self, parent_node_seed: &[u8; 32], aad: AadContext) -> AscentCheck {
-        let payload = OverrideSeedPayload::new(self.scope_seed, self.epoch);
-        let link = seal_ascent_link(parent_node_seed, &EPH_ASCENT, &aad, &payload);
-        AscentCheck { link, aad }
+        }
     }
 
     /// An owner seed blob whose sealed AAD is overridden (e.g. a foreign scope)
@@ -1040,6 +1060,44 @@ fn ascent_link_aad_must_bind_to_the_envelope() {
     };
     let mut candidate = fx.candidate(1);
     candidate.ascent = Some(fx.ascent_link_under_aad(&parent_seed, foreign_aad));
+    let mut reader = fx.reader();
+    reader.parent_node_seed = Some(parent_seed);
+    let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();
+    let rej = err.rejection().unwrap();
+    assert_eq!(rej.stage, GateStage::GrantSection);
+    assert_eq!(rej.check(), "ascent-link-mismatch");
+}
+
+#[test]
+fn ascent_link_rogue_seed_fails_read_key_cross_check() {
+    // The link opens cleanly (real parent seed, envelope-matching AAD) but a
+    // rogue override seed was sealed to the PUBLISHED ascent public key — it does
+    // not derive this scope root's read key. Attributable abuse, not adoption.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let parent_seed = [0xAB; 32];
+    let rogue = OverrideSeedPayload::new([0xEE; 32], fx.epoch);
+    let mut candidate = fx.candidate(1);
+    candidate.ascent = Some(fx.ascent_link_full(&parent_seed, fx.ascent_aad(), rogue));
+    let mut reader = fx.reader();
+    reader.parent_node_seed = Some(parent_seed);
+    let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();
+    let rej = err.rejection().unwrap();
+    assert_eq!(rej.stage, GateStage::GrantSection);
+    assert_eq!(rej.check(), "ascent-link-mismatch");
+}
+
+#[test]
+fn ascent_link_stale_epoch_payload_rejected() {
+    // The link opens and carries the real scope seed (so the read-key derive
+    // matches), but its payload epoch is stale vs the envelope — a cross-epoch
+    // ascent seed. The epoch bind rejects it.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let parent_seed = [0xAB; 32];
+    let stale = OverrideSeedPayload::new(fx.scope_seed, fx.epoch + 1);
+    let mut candidate = fx.candidate(1);
+    candidate.ascent = Some(fx.ascent_link_full(&parent_seed, fx.ascent_aad(), stale));
     let mut reader = fx.reader();
     reader.parent_node_seed = Some(parent_seed);
     let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();

--- a/crates/engine/tests/adoption_gate.rs
+++ b/crates/engine/tests/adoption_gate.rs
@@ -1190,3 +1190,82 @@ fn seed_blob_correct_seed_derives_read_key_and_adopts() {
     assert_eq!(adopted.sequence, 1);
     assert_eq!(adopted.epoch, 1);
 }
+
+#[test]
+fn envelope_scope_must_equal_reader_scope() {
+    // The read body is sealed under a FOREIGN scope with the reader's real read
+    // key (the scope UUID is not in the read-key KDF, so it still opens), and the
+    // envelope is labeled that foreign scope — while the reader is scope A. With
+    // structures/ascent absent, only the reader-scope precondition can reject.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let foreign_scope = [0xEE; 16];
+    let folder = ReadBody::Folder {
+        created_at: 0,
+        modified_at: 0,
+        children: Vec::new(),
+        unknown: Vec::new(),
+    };
+    let envelope_b = seal_read_body(
+        &fx.read_key,
+        &NONCE_READ_BODY,
+        V,
+        fx.root_id,
+        foreign_scope,
+        fx.epoch,
+        &folder,
+    )
+    .expect("foreign-scope folder seals under the reader's read key");
+    let mut candidate = fx.candidate(1);
+    candidate.envelope = envelope_b;
+    candidate.structures = Vec::new();
+    let err = block_on(adopt(&floors, &fx.reader(), &candidate)).unwrap_err();
+    let rej = err.rejection().unwrap();
+    assert_eq!(rej.stage, GateStage::Unseal);
+    assert_eq!(rej.check(), "seal-open-failed");
+}
+
+#[test]
+fn seed_blob_aad_id_must_equal_envelope_id() {
+    // The blob is wrapped to the reader's real enc subkey with the right
+    // scope/epoch/v, but names a different node id than the envelope — a
+    // wrong-node transplant, fail-closed.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let wrong_id_aad = AadContext {
+        v: V,
+        id: [0xDD; 16],
+        scope: fx.scope_id,
+        epoch: fx.epoch,
+        struct_tag: STRUCT_TAG_OWNER_BLOB,
+    };
+    let mut reader = fx.reader();
+    reader.seed_blob = Some(fx.owner_seed_blob_with_aad(wrong_id_aad));
+    let candidate = fx.candidate(1);
+    let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();
+    let rej = err.rejection().unwrap();
+    assert_eq!(rej.stage, GateStage::Unseal);
+    assert_eq!(rej.check(), "hpke-open-failed");
+}
+
+#[test]
+fn seed_blob_aad_struct_tag_must_match_blob_type() {
+    // An owner blob whose AAD carries the grant-blob tag: domain separation is
+    // broken, fail-closed even though it is wrapped to the reader's enc subkey.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let wrong_tag_aad = AadContext {
+        v: V,
+        id: fx.root_id,
+        scope: fx.scope_id,
+        epoch: fx.epoch,
+        struct_tag: STRUCT_TAG_GRANT_BLOB,
+    };
+    let mut reader = fx.reader();
+    reader.seed_blob = Some(fx.owner_seed_blob_with_aad(wrong_tag_aad));
+    let candidate = fx.candidate(1);
+    let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();
+    let rej = err.rejection().unwrap();
+    assert_eq!(rej.stage, GateStage::Unseal);
+    assert_eq!(rej.check(), "hpke-open-failed");
+}


### PR DESCRIPTION
## Summary

Implements slice #626 — the six-stage adoption gate and the floor law as a pure pipeline over `crates/core`'s verify/unseal functions, plus an N-engine simulation harness on the fake record store.

Scope is confined to `crates/engine/**`. No crypto, codec, or new cryptographic error code lives in the engine: every cryptographic verdict is a core `TrustViolation` surfaced verbatim; the only engine-domain verdicts are the two durable-floor comparisons (sequence, epoch). Time and entropy are never touched.

## What landed

- **`src/gate/adoption.rs`** — the six stages composed in order: (1) record verify (Ed25519 key from the name, `signatureV2`, data/value consistency), (2) commitment verify against the contact-anchored owner identity, (3) grant-section authentication of every seed-bearing structure under a committed write-capable pseudonym (plus ascent-link derive-and-verify), (4) strictly-newer sequence vs the durable per-name floor, (5) epoch tag at or above the scope's durable read-epoch floor, (6) unseal (HPKE seed source + symmetric read-body, with decode-time child uniqueness). Fail-closed, whole-record rejection.
- **`src/gate/floor.rs`** — the floor law: advance only on AAD-confirmed unseal; cold-seed from a re-point object's owner-vouched `writeEpoch`/`minReadEpoch`; pointer `writeEpoch` advances on sight; grant-blob epoch fields advisory only (no advancement path); monotonic-max so `FloorStore` regression is fail-closed by construction.
- **`tests/adoption_gate.rs`** — the six-stage matrix (acceptance + every reject class with its exact named error), the five floor-law scenarios, the N-engine adversarial sim (replay / transplant / re-sign on one shared record store, virtual time), and table-mirroring anti-vacuity meta-tests proving every stage and every reject/floor-law row is exercised.

## Validation

- `cargo fmt -p cipherbox-engine -- --check` — clean
- `cargo clippy -p cipherbox-engine --all-targets -- -D warnings` — clean
- `cargo test -p cipherbox-engine` — all pass (matrix, floor-law, sim, anti-vacuity)
- `cargo test -p cipherbox-core` — all pass (core untouched)
- No direct clock/RNG in non-test engine code

## CI gate

Covered by the existing **Engine Tests** job (`cargo test -p cipherbox-engine`); `.github/workflows/ci.yml` was not modified.

## Not landed (per scope)

Resolve/publish wiring and live pointer resolution — records are hand-fed into the gate. The write-epoch floor is maintained per the on-sight rule but its stage-level enforcement lands with the write-plane slices.

Closes #626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a secure adoption flow that verifies record authenticity, grants, signatures, encryption, and associated metadata before accepting content.
  - Added protection against replayed, outdated, or regressed records through durable sequence and epoch tracking.
  - Added structured rejection results with clear verification stages and stable error checks.
  - Added support for safely initializing and advancing security state during valid updates.

- **Tests**
  - Added comprehensive coverage for verification failures, replay protection, multi-device scenarios, and encrypted content handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->