### PR TITLE
fix(api): serialize mailbox pending-cap enforcement per recipient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,13 @@ jobs:
           echo "Fix: pnpm --filter @cipherbox/api migration:generate src/migrations/<Name> and commit the result."
           exit 1
 
+      # Folds the Postgres-backed mailbox pending-cap concurrency guard onto this
+      # job's database so it gates without registering a new required check (law 1).
+      - name: Prove the mailbox pending-cap concurrency guard against real Postgres
+        env:
+          MAILBOX_DB_TEST: '1'
+        run: pnpm --filter @cipherbox/api exec vitest run src/mailbox/services/mailbox.concurrency.test.ts
+
   openapi-freshness:
     name: OpenAPI Freshness
     needs: [changes, lint]

--- a/apps/api/src/mailbox/mailbox.http.test.ts
+++ b/apps/api/src/mailbox/mailbox.http.test.ts
@@ -2,7 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule, JwtService } from '@nestjs/jwt';
 import { Test } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -13,6 +13,7 @@ import { IdentityService } from '../auth/services/identity.service';
 import { Clock, SystemClock } from '../common/clock';
 import { OpsModule } from '../ops/ops.module';
 import { THROTTLE_SURFACES } from '../ops/throttling';
+import { FakeDataSource } from '../testing/fake-data-source';
 import { FakeRepository } from '../testing/fake-repo';
 import { fakeConfig } from '../testing/fakes';
 import { MailboxController } from './mailbox.controller';
@@ -62,6 +63,7 @@ describe('mailbox HTTP surface', () => {
         },
         { provide: getRepositoryToken(User), useValue: userRepo },
         { provide: getRepositoryToken(MailboxMessage), useValue: messageRepo },
+        { provide: getDataSourceToken(), useValue: new FakeDataSource(messageRepo as never) },
       ],
     }).compile();
 

--- a/apps/api/src/mailbox/services/mailbox.concurrency.test.ts
+++ b/apps/api/src/mailbox/services/mailbox.concurrency.test.ts
@@ -1,0 +1,207 @@
+import { ConflictException } from '@nestjs/common';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { randomBytes } from 'node:crypto';
+import { DataSource, Repository } from 'typeorm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { User } from '../../auth/entities/user.entity';
+import { IdentityService } from '../../auth/services/identity.service';
+import { FakeRepository } from '../../testing/fake-repo';
+import { FakeClock, fakeConfig } from '../../testing/fakes';
+import { MailboxMessage } from '../entities/mailbox-message.entity';
+import { MailboxService } from './mailbox.service';
+
+/**
+ * The pending-cap serialization guard proven against a REAL Postgres.
+ *
+ * The fix wraps purge → count → cap-check → insert in one transaction under a
+ * per-recipient `pg_advisory_xact_lock`. Advisory locks and the count→insert
+ * isolation they provide are genuine Postgres behavior — no sqlite or in-memory
+ * fake can exercise them — so this suite is opt-in: it runs only when
+ * `MAILBOX_DB_TEST=1` and a reachable Postgres is configured via the standard
+ * DB_* env (defaults match docker/docker-compose.yml). Left unset — as in the
+ * fake-only `Run API unit suite` CI job — the whole suite is skipped, never
+ * failing for want of a database.
+ */
+const RUN_DB_TEST = process.env.MAILBOX_DB_TEST === '1';
+
+const DB = {
+  host: process.env.DB_HOST ?? 'localhost',
+  port: Number(process.env.DB_PORT ?? 5432),
+  user: process.env.DB_USERNAME ?? 'postgres',
+  password: process.env.DB_PASSWORD ?? 'postgres',
+};
+
+// A throwaway database, created and dropped by this suite, so the shared dev
+// `cipherbox` database is never touched.
+const TEST_DB = 'cipherbox_mailbox_cap_test';
+
+/** Run one-off admin DDL (CREATE/DROP DATABASE) via a short-lived connection to
+ * the default `postgres` database. Kept off TypeORM's entity path so it needs no
+ * `pg` type declarations. */
+async function adminExec(sql: string): Promise<void> {
+  const admin = new DataSource({
+    type: 'postgres',
+    host: DB.host,
+    port: DB.port,
+    username: DB.user,
+    password: DB.password,
+    database: 'postgres',
+  });
+  await admin.initialize();
+  try {
+    await admin.query(sql);
+  } finally {
+    await admin.destroy();
+  }
+}
+
+function compressedPublicKey(): string {
+  const priv = secp256k1.utils.randomPrivateKey();
+  return Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+}
+
+function base64Blob(bytes: number): string {
+  return Buffer.alloc(bytes, 7).toString('base64');
+}
+
+describe.skipIf(!RUN_DB_TEST)('MailboxService pending-cap concurrency (real Postgres)', () => {
+  let dataSource: DataSource;
+  let repo: Repository<MailboxMessage>;
+
+  beforeAll(async () => {
+    await adminExec(`DROP DATABASE IF EXISTS ${TEST_DB} WITH (FORCE)`);
+    await adminExec(`CREATE DATABASE ${TEST_DB}`);
+
+    dataSource = new DataSource({
+      type: 'postgres',
+      host: DB.host,
+      port: DB.port,
+      username: DB.user,
+      password: DB.password,
+      database: TEST_DB,
+      entities: [MailboxMessage],
+      synchronize: false,
+      uuidExtension: 'pgcrypto',
+      // A pool comfortably wider than any batch below, so the racing posts hold
+      // real connections at once and genuinely contend on the advisory lock
+      // rather than queueing at the JS pool.
+      extra: { max: 30 },
+    });
+    await dataSource.initialize();
+    await dataSource.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+    await dataSource.synchronize();
+    repo = dataSource.getRepository(MailboxMessage);
+  }, 30_000);
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+    await adminExec(`DROP DATABASE IF EXISTS ${TEST_DB} WITH (FORCE)`);
+  });
+
+  beforeEach(async () => {
+    await dataSource.query('TRUNCATE TABLE mailbox_messages');
+  });
+
+  function buildService(cap: number): {
+    service: MailboxService;
+    recipient: string;
+    sender: string;
+  } {
+    const clock = new FakeClock();
+    const users = new FakeRepository<User>();
+    const recipient = compressedPublicKey();
+    const sender = compressedPublicKey();
+    // Recipient existence is checked outside the serialized window, so a fake
+    // user repo (seeded with the recipient) is faithful; the mailbox reads and
+    // writes go to the real Postgres via the real repo + DataSource.
+    void users.save({ publicKey: recipient } as never);
+    const service = new MailboxService(
+      repo,
+      users as never,
+      dataSource,
+      new IdentityService(),
+      clock,
+      fakeConfig({ MAILBOX_PENDING_CAP: String(cap) }).service
+    );
+    return { service, recipient, sender };
+  }
+
+  async function seedPending(recipient: string, count: number): Promise<void> {
+    const now = new Date();
+    const rows = Array.from({ length: count }, () => ({
+      recipientPublicKey: recipient,
+      idempotencyScope: randomBytes(32).toString('hex'),
+      blob: Buffer.alloc(16, 1),
+      receivedAt: now,
+    }));
+    await repo.save(rows);
+  }
+
+  it('at cap - 1, only ONE of N concurrent distinct-key posts wins; the rest 409, and the cap is never exceeded', async () => {
+    const CAP = 100;
+    const RACERS = 8;
+    const { service, recipient, sender } = buildService(CAP);
+    await seedPending(recipient, CAP - 1);
+
+    const outcomes = await Promise.allSettled(
+      Array.from({ length: RACERS }, (_, i) =>
+        service.post(sender, {
+          recipientPublicKey: recipient,
+          blob: base64Blob(64),
+          idempotencyKey: `race-${i}`,
+        })
+      )
+    );
+
+    const fulfilled = outcomes.filter((o) => o.status === 'fulfilled');
+    const conflicts = outcomes.filter(
+      (o): o is PromiseRejectedResult =>
+        o.status === 'rejected' && o.reason instanceof ConflictException
+    );
+    const otherErrors = outcomes.filter(
+      (o) => o.status === 'rejected' && !(o.reason instanceof ConflictException)
+    );
+
+    // Exactly one racer fills the last slot; every other loses with a 409 and
+    // nothing else fails. Without the lock, two+ readers see `cap - 1` and both
+    // insert.
+    expect(otherErrors).toHaveLength(0);
+    expect(fulfilled).toHaveLength(1);
+    expect(conflicts).toHaveLength(RACERS - 1);
+
+    const finalCount = await repo.count({ where: { recipientPublicKey: recipient } });
+    expect(finalCount).toBe(CAP);
+    expect(finalCount).toBeLessThanOrEqual(CAP);
+  });
+
+  it('under full saturation, exactly CAP of CAP+extra concurrent posts commit; the surplus 409', async () => {
+    const CAP = 10;
+    const EXTRA = 8;
+    const { service, recipient, sender } = buildService(CAP);
+
+    const outcomes = await Promise.allSettled(
+      Array.from({ length: CAP + EXTRA }, (_, i) =>
+        service.post(sender, {
+          recipientPublicKey: recipient,
+          blob: base64Blob(64),
+          idempotencyKey: `sat-${i}`,
+        })
+      )
+    );
+
+    const fulfilled = outcomes.filter((o) => o.status === 'fulfilled');
+    const conflicts = outcomes.filter(
+      (o): o is PromiseRejectedResult =>
+        o.status === 'rejected' && o.reason instanceof ConflictException
+    );
+
+    expect(fulfilled).toHaveLength(CAP);
+    expect(conflicts).toHaveLength(EXTRA);
+
+    const finalCount = await repo.count({ where: { recipientPublicKey: recipient } });
+    expect(finalCount).toBe(CAP);
+    expect(finalCount).toBeLessThanOrEqual(CAP);
+  });
+});

--- a/apps/api/src/mailbox/services/mailbox.service.test.ts
+++ b/apps/api/src/mailbox/services/mailbox.service.test.ts
@@ -3,6 +3,7 @@ import { secp256k1 } from '@noble/curves/secp256k1';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { IdentityService } from '../../auth/services/identity.service';
 import { User } from '../../auth/entities/user.entity';
+import { FakeDataSource } from '../../testing/fake-data-source';
 import { FakeRepository } from '../../testing/fake-repo';
 import { FakeClock, fakeConfig } from '../../testing/fakes';
 import { MailboxMessage } from '../entities/mailbox-message.entity';
@@ -34,6 +35,7 @@ describe('MailboxService', () => {
     service = new MailboxService(
       messages as never,
       users as never,
+      new FakeDataSource(messages as never) as never,
       new IdentityService(),
       clock,
       fakeConfig(config).service

--- a/apps/api/src/mailbox/services/mailbox.service.ts
+++ b/apps/api/src/mailbox/services/mailbox.service.ts
@@ -5,9 +5,9 @@ import {
   PayloadTooLargeException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { createHash } from 'node:crypto';
-import { LessThan, QueryFailedError, Repository } from 'typeorm';
+import { DataSource, LessThan, QueryFailedError, Repository } from 'typeorm';
 import { User } from '../../auth/entities/user.entity';
 import { IdentityService } from '../../auth/services/identity.service';
 import { Clock } from '../../common/clock';
@@ -73,6 +73,8 @@ export class MailboxService {
     private readonly messageRepository: Repository<MailboxMessage>,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
     private readonly identityService: IdentityService,
     private readonly clock: Clock,
     configService: ConfigService
@@ -110,7 +112,9 @@ export class MailboxService {
 
     const idempotencyScope = this.scopeIdempotency(senderPublicKey, input.idempotencyKey);
 
-    // Idempotent replay wins even when the mailbox is full.
+    // Fast path: an idempotent replay wins even when the mailbox is full, and
+    // takes no lock — the common repost case never contends on the per-recipient
+    // serialization below.
     const existing = await this.messageRepository.findOne({
       where: { recipientPublicKey, idempotencyScope },
     });
@@ -118,26 +122,13 @@ export class MailboxService {
       return { id: existing.id };
     }
 
-    // Expired rows are dead fuel: purge before counting so a full-of-expired
-    // mailbox still accepts new mail (opportunistic housekeeping).
-    await this.purgeExpired(recipientPublicKey);
-
-    const pending = await this.messageRepository.count({ where: { recipientPublicKey } });
-    if (pending >= this.pendingCap) {
-      throw new ConflictException('Recipient mailbox is full');
-    }
-
     try {
-      const saved = await this.messageRepository.save({
-        recipientPublicKey,
-        idempotencyScope,
-        blob,
-        receivedAt: this.clock.now(),
-      });
-      return { id: saved.id };
+      return await this.enforceCapAndInsert(recipientPublicKey, idempotencyScope, blob);
     } catch (error) {
       // The unique (recipient, idempotencyScope) index is the durable dedup
-      // backstop under a concurrent double-post; re-read and return the winner.
+      // backstop under a concurrent double-post: a same-scope insert that races
+      // past the in-transaction replay check aborts the transaction, so re-read
+      // the committed winner on a fresh statement (outside the rolled-back txn).
       if (error instanceof QueryFailedError) {
         const winner = await this.messageRepository.findOne({
           where: { recipientPublicKey, idempotencyScope },
@@ -151,12 +142,62 @@ export class MailboxService {
   }
 
   /**
+   * The pending-cap enforcement window — purge → count → cap-check → insert —
+   * run under a per-recipient transaction-scoped advisory lock so concurrent
+   * posts to the SAME recipient serialize. Without the lock the count read and
+   * the insert are separate statements: two writers arriving at `cap - 1` could
+   * both observe `cap - 1`, both pass the check, and both insert, overshooting
+   * the cap (a DoS control). Holding `pg_advisory_xact_lock` across the whole
+   * transaction means the second writer blocks until the first commits, then
+   * counts the first's committed row before its own check — the overshoot
+   * closes structurally, no schema change required. The lock is transaction
+   * scoped: Postgres releases it automatically on commit or rollback.
+   */
+  private async enforceCapAndInsert(
+    recipientPublicKey: string,
+    idempotencyScope: string,
+    blob: Buffer
+  ): Promise<PostMessageResult> {
+    return this.dataSource.transaction(async (manager) => {
+      await manager.query('SELECT pg_advisory_xact_lock($1::bigint)', [
+        this.recipientLockKey(recipientPublicKey),
+      ]);
+      const repo = manager.getRepository(MailboxMessage);
+
+      // Re-check idempotency now that we hold the lock: a same-scope writer that
+      // committed just ahead of us is visible here, so we return its row instead
+      // of racing it to a unique-index violation.
+      const replay = await repo.findOne({ where: { recipientPublicKey, idempotencyScope } });
+      if (replay) {
+        return { id: replay.id };
+      }
+
+      // Expired rows are dead fuel: purge before counting so a full-of-expired
+      // mailbox still accepts new mail (opportunistic housekeeping).
+      await this.purgeExpired(recipientPublicKey, repo);
+
+      const pending = await repo.count({ where: { recipientPublicKey } });
+      if (pending >= this.pendingCap) {
+        throw new ConflictException('Recipient mailbox is full');
+      }
+
+      const saved = await repo.save({
+        recipientPublicKey,
+        idempotencyScope,
+        blob,
+        receivedAt: this.clock.now(),
+      });
+      return { id: saved.id };
+    });
+  }
+
+  /**
    * Poll the caller mailbox: pending messages oldest-first, capped at the
    * poll limit. No sender metadata is returned in the clear — the sealed
    * payload carries the owner-signed sender inside.
    */
   async poll(recipientPublicKey: string): Promise<{ messages: PolledMessage[] }> {
-    await this.purgeExpired(recipientPublicKey);
+    await this.purgeExpired(recipientPublicKey, this.messageRepository);
     const rows = await this.messageRepository.find({
       where: { recipientPublicKey },
       order: { receivedAt: 'ASC' },
@@ -188,12 +229,31 @@ export class MailboxService {
     return { success: true };
   }
 
-  private async purgeExpired(recipientPublicKey: string): Promise<void> {
+  private async purgeExpired(
+    recipientPublicKey: string,
+    repo: Repository<MailboxMessage>
+  ): Promise<void> {
     const cutoff = new Date(this.clock.now().getTime() - TTL_MS);
-    await this.messageRepository.delete({ recipientPublicKey, receivedAt: LessThan(cutoff) });
+    await repo.delete({ recipientPublicKey, receivedAt: LessThan(cutoff) });
   }
 
   private scopeIdempotency(senderPublicKey: string, idempotencyKey: string): string {
     return createHash('sha256').update(`${senderPublicKey}:${idempotencyKey}`).digest('hex');
+  }
+
+  /**
+   * Map a recipientPublicKey to a stable signed 64-bit key for
+   * `pg_advisory_xact_lock`. sha256 — this file's existing hash of choice (see
+   * `scopeIdempotency`) — over the ALREADY-normalized recipient key, then the
+   * first 8 bytes read big-endian as a signed BigInt, which is exactly the
+   * Postgres `bigint` domain (−2^63 … 2^63−1). Deterministic and process-stable,
+   * so every API instance maps a given recipient to the same lock. Returned as a
+   * decimal string bound through `$1::bigint`, sidestepping driver-level BigInt
+   * parameter handling. The 8→64-bit truncation admits astronomically rare
+   * cross-recipient collisions; the only effect would be two distinct recipients
+   * briefly serializing, never a correctness or cap breach.
+   */
+  private recipientLockKey(recipientPublicKey: string): string {
+    return createHash('sha256').update(recipientPublicKey).digest().readBigInt64BE(0).toString();
   }
 }

--- a/apps/api/src/testing/fake-data-source.ts
+++ b/apps/api/src/testing/fake-data-source.ts
@@ -1,0 +1,41 @@
+import { FakeRepository } from './fake-repo';
+
+/**
+ * In-memory stand-in for the sliver of the TypeORM `EntityManager` surface the
+ * mailbox service touches inside a transaction: `query` (the advisory-lock
+ * acquire, a no-op here) and `getRepository` (routed to the same in-memory
+ * `FakeRepository` the test inspects). The fake runs single-threaded, so there
+ * is no race to serialize — the advisory lock's job is proven against a real
+ * Postgres in `mailbox.concurrency.test.ts`; these fakes only exercise the
+ * business logic (cap, TTL purge, idempotent replay) unchanged.
+ */
+class FakeEntityManager {
+  constructor(private readonly repo: FakeRepository<{ id: string }>) {}
+
+  async query(): Promise<unknown[]> {
+    return [];
+  }
+
+  getRepository(): FakeRepository<{ id: string }> {
+    return this.repo;
+  }
+}
+
+/**
+ * In-memory stand-in for the narrow `DataSource.transaction` surface the mailbox
+ * service uses. Runs the work function immediately against a manager backed by
+ * the supplied repository — no isolation, since the fake has no concurrency to
+ * isolate. A thrown work function (e.g. the cap `ConflictException`) propagates
+ * unchanged, mirroring a transaction rollback.
+ */
+export class FakeDataSource {
+  private readonly manager: FakeEntityManager;
+
+  constructor(repo: FakeRepository<{ id: string }>) {
+    this.manager = new FakeEntityManager(repo);
+  }
+
+  async transaction<T>(work: (manager: FakeEntityManager) => Promise<T>): Promise<T> {
+    return work(this.manager);
+  }
+}


### PR DESCRIPTION
## Problem

`MailboxService.post` enforced the per-recipient pending cap with a check-then-act sequence — `purgeExpired` -> `count` -> cap-check -> `insert` — with no transaction, row lock, or unique guard. Two concurrent posts to the **same** recipient with **distinct** idempotency keys, arriving at `pendingCap - 1`, could both observe `pendingCap - 1`, both pass the check, and both insert, overshooting the cap. The cap is a DoS control (default `MAILBOX_PENDING_CAP = 1000`).

The only existing safeguard — the unique index on `(recipientPublicKey, idempotencyScope)` — guards idempotent replay, but distinct-key concurrent posts have distinct scopes, so it never fires.

## Fix

Serialize enforcement per recipient inside a single transaction:

- Take a per-recipient, transaction-scoped advisory lock at the top: `SELECT pg_advisory_xact_lock($1::bigint)`, where the key is a stable signed 64-bit value derived from the already-normalized `recipientPublicKey` via `sha256` (this file's existing hash of choice) — first 8 bytes read big-endian as a signed BigInt, exactly the Postgres `bigint` domain. Deterministic and process-stable, so every API instance maps a recipient to the same lock.
- Run `purgeExpired` -> `count` -> cap-check -> `insert` under that lock. The second writer blocks until the first commits, then counts the first's committed row before its own check — the overshoot closes structurally. The lock auto-releases on commit or rollback.
- An in-transaction idempotency re-check under the lock returns a just-committed same-scope row instead of racing it to a unique-index violation; the `QueryFailedError` re-read stays as a defensive backstop.

No schema change (advisory-lock approach needs none). No public API contract change: same `413`/`404`/`409` responses, same idempotent-replay fast path (unlocked), same `Clock` seam.

## Tests

- `mailbox.concurrency.test.ts` (new): a real-Postgres suite, opt-in via `MAILBOX_DB_TEST=1`, that fires N concurrent distinct-key posts at `pendingCap - 1` and under full saturation, asserting the final row count never exceeds the cap and exactly the surplus get `409`. Skipped when the env is unset, so the fake-only unit gate stays green.
- Verified it **fails without the lock** (all 18 saturation racers committed, cap 10 overshot to 18) and **passes with it** — run locally against a docker Postgres.
- Unit/HTTP suites gain a small `FakeDataSource` stand-in so the existing fake-repo tests exercise the same code path unchanged (78 passed).

## Validation

- `pnpm --filter @cipherbox/api typecheck` — pass
- `pnpm --filter @cipherbox/api build` — pass
- `pnpm --filter @cipherbox/api test` — 78 passed, 2 skipped (concurrency suite)
- Concurrency suite against real Postgres — 2 passed

Closes #674


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mailbox capacity enforcement during concurrent message submissions.
  * Prevented pending messages from exceeding the configured recipient limit.
  * Preserved idempotent message submission behavior under concurrent requests.

* **Tests**
  * Added database-backed coverage for mailbox concurrency and capacity limits.
  * Improved mailbox service and HTTP test setup with transaction support.
  * Added validation for expired-message cleanup during capacity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->