### PR TITLE
fix(core): size the encode buffer up front so secret writes never realloc

### DIFF
--- a/crates/core/src/codec/encode.rs
+++ b/crates/core/src/codec/encode.rs
@@ -18,13 +18,59 @@ pub(super) const SIMPLE_NULL: u8 = 22;
 
 /// Encode a value in the deterministic profile.
 ///
+/// Two-pass: [`encoded_len`] sizes the buffer up front so the single allocation
+/// is exact and the write never reallocates. A grow-from-empty `Vec` frees each
+/// intermediate backing store un-zeroized, stranding secret bytes (content keys,
+/// scope/override/history seeds) in freed heap; with one right-sized buffer only
+/// the terminal owner's plaintext ever holds them, and that owner zeroizes it.
+///
 /// Callers must respect [`super::MAX_DEPTH`]: a deeper `Value` still encodes
 /// (encoding is infallible), but its bytes reject as `depth-exceeded` on
 /// decode — debug builds assert the bound to catch that divergence early.
 pub fn encode(value: &Value) -> Vec<u8> {
-    let mut out = Vec::new();
+    let mut out = Vec::with_capacity(encoded_len(value));
     write_value(&mut out, value, 0);
     out
+}
+
+/// The exact number of bytes [`encode`] emits for `value`. Mirrors
+/// [`write_value`] head-for-head; the codec property suite pins the two in
+/// lockstep (`encoded_len == encode().len()`), which is what makes [`encode`]'s
+/// single up-front reservation provably realloc-free.
+pub fn encoded_len(value: &Value) -> usize {
+    match value {
+        Value::Unsigned(n) | Value::Negative(n) => head_len(*n),
+        Value::Bytes(b) => head_len(b.len() as u64) + b.len(),
+        Value::Text(t) => text_len(t),
+        Value::Array(items) => {
+            head_len(items.len() as u64) + items.iter().map(encoded_len).sum::<usize>()
+        }
+        Value::Map(map) => {
+            head_len(map.len() as u64)
+                + map
+                    .entries()
+                    .iter()
+                    .map(|(k, v)| text_len(k) + encoded_len(v))
+                    .sum::<usize>()
+        }
+        Value::Bool(_) | Value::Null => 1,
+    }
+}
+
+/// The byte length of a text item: its head plus its UTF-8 bytes.
+fn text_len(t: &str) -> usize {
+    head_len(t.len() as u64) + t.len()
+}
+
+/// The byte length of a shortest-form head for `arg` (mirrors [`write_head`]).
+fn head_len(arg: u64) -> usize {
+    match arg {
+        0..=23 => 1,
+        24..=0xff => 2,
+        0x100..=0xffff => 3,
+        0x1_0000..=0xffff_ffff => 5,
+        _ => 9,
+    }
 }
 
 pub(super) fn write_value(out: &mut Vec<u8>, value: &Value, depth: usize) {
@@ -88,5 +134,87 @@ pub(super) fn write_head(out: &mut Vec<u8>, major: u8, arg: u64) {
             out.push(mt | 27);
             out.extend_from_slice(&arg.to_be_bytes());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A file-body-shaped value: a version list whose 32-byte `contentKey`
+    /// entries are the secret bytes the realloc-hygiene fix protects. Sized to
+    /// force many reallocations if encoded from an empty `Vec`.
+    fn secret_shaped_value(versions: usize) -> Value {
+        let mut items = Vec::new();
+        for i in 0..versions {
+            let mut m = Map::new();
+            m.insert("contentCid", Value::Bytes(vec![i as u8; 36]));
+            m.insert("contentKey", Value::Bytes(vec![0xAB; 32]));
+            m.insert("size", Value::Unsigned(4096));
+            m.insert("modifiedAt", Value::Unsigned(1_700_000_000));
+            items.push(Value::Map(m));
+        }
+        let mut body = Map::new();
+        body.insert("kind", Value::Text("file".into()));
+        body.insert("versions", Value::Array(items));
+        body.insert("createdAt", Value::Unsigned(1));
+        body.insert("modifiedAt", Value::Unsigned(2));
+        Value::Map(body)
+    }
+
+    /// `encoded_len` is exact across every head size class and nesting, so the
+    /// up-front reservation is neither short (would realloc) nor slack.
+    #[test]
+    fn encoded_len_is_exact() {
+        let cases = [
+            Value::Unsigned(0),
+            Value::Unsigned(23),
+            Value::Unsigned(24),
+            Value::Unsigned(0xff),
+            Value::Unsigned(0x100),
+            Value::Unsigned(0xffff),
+            Value::Unsigned(0x1_0000),
+            Value::Unsigned(0xffff_ffff),
+            Value::Unsigned(0x1_0000_0000),
+            Value::Negative(0),
+            Value::Negative(u64::MAX),
+            Value::Bytes(vec![0; 23]),
+            Value::Bytes(vec![0; 300]),
+            Value::Text("a".repeat(24)),
+            Value::Bool(true),
+            Value::Null,
+            Value::Array(vec![Value::Unsigned(1), Value::Null]),
+            secret_shaped_value(40),
+        ];
+        for v in &cases {
+            assert_eq!(encoded_len(v), encode(v).len(), "len oracle diverged");
+        }
+    }
+
+    /// The security invariant: encoding secret-bearing bytes performs a single
+    /// allocation and never reallocates, so no intermediate backing store is
+    /// freed un-zeroized. Capturing the pointer and capacity after the reserve
+    /// and asserting both are unchanged after the write proves the buffer never
+    /// moved (a realloc would move it and/or grow capacity), independent of any
+    /// allocator over-allocation.
+    #[test]
+    fn secret_bearing_encode_never_reallocates() {
+        let value = secret_shaped_value(64);
+        let mut out = Vec::with_capacity(encoded_len(&value));
+        let ptr = out.as_ptr();
+        let reserved_cap = out.capacity();
+        write_value(&mut out, &value, 0);
+        assert!(out.len() > 1024, "test payload must force multiple growths");
+        assert_eq!(
+            out.capacity(),
+            reserved_cap,
+            "capacity grew — a realloc ran"
+        );
+        assert_eq!(out.as_ptr(), ptr, "backing store moved — a realloc ran");
+        assert_eq!(
+            encode(&value),
+            out,
+            "public two-pass path is byte-identical"
+        );
     }
 }

--- a/crates/core/src/codec/mod.rs
+++ b/crates/core/src/codec/mod.rs
@@ -19,7 +19,7 @@ mod fields;
 mod value;
 
 pub use decode::decode;
-pub use encode::encode;
+pub use encode::{encode, encoded_len};
 pub use fields::{UnknownFields, decode_map_partial, encode_map_partial, known_key_set};
 pub use value::{Map, Value, canonical_key_cmp};
 

--- a/crates/core/tests/codec_props.rs
+++ b/crates/core/tests/codec_props.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 
 use cipherbox_core::codec::{
     Map, Value, canonical_key_cmp, decode, decode_map_partial, encode, encode_map_partial,
+    encoded_len,
 };
 use proptest::prelude::*;
 
@@ -190,6 +191,15 @@ proptest! {
                 ),
             }
         }
+    }
+
+    /// (f) the two-pass encoder's length oracle is exact for every value:
+    /// `encoded_len` equals the emitted byte count, so `encode`'s single
+    /// up-front reservation never reallocates mid-write — no intermediate
+    /// backing store is freed un-zeroized to strand secret bytes.
+    #[test]
+    fn encoded_len_matches_emitted_bytes(v in arb_value()) {
+        prop_assert_eq!(encoded_len(&v), encode(&v).len());
     }
 
     /// (e) `canonical_key_cmp` is a total order that agrees with bytewise


### PR DESCRIPTION
## What landed

`codec::encode` built its output `Vec<u8>` from empty and grew it by appending. On capacity overflow the `Vec` reallocates: it allocates a larger backing store, copies the bytes, and frees the old one **without zeroizing**. Any secret plaintext already serialized into that old buffer — inline `contentKey` bytes today, grant / override / history seed material as those structures land — was thus stranded in freed-but-uncleared heap.

This makes `encode` **two-pass**: a new `encoded_len(value)` computes the exact serialized byte count, `encode` reserves that once with `Vec::with_capacity`, then writes. With a single right-sized allocation the write never reallocates, so the one terminal buffer — which its owner already zeroizes (`seal_read_body`, the grant/override/history seal paths) — is the only allocation that ever holds key bytes.

Applied at the single `codec::encode` entry point, so it covers every secret-carrying encode path codec-wide (`encode_read_body`, `encode_grant_blob_payload`, `encode_override_seed_payload`, `encode_history_link_payload`) uniformly — no per-path variant.

## No wire-format impact (KAT byte-identity)

Only the buffer's initial capacity changed; the emitted bytes are unchanged. Verified by regenerating the full KAT corpus (`cargo run -p cipherbox-core --example kat_gen`) and confirming a **byte-identical** `git diff` on `crates/core/kat` (empty). The native + WASM KAT suites pass unchanged.

## Realloc-free proof (tests added)

- `secret_bearing_encode_never_reallocates` (inline unit, `src/codec/encode.rs`) — encodes a file-body-shaped value carrying 32-byte `contentKey` entries, sized to force multiple growths from empty. Captures the backing pointer and capacity after the reserve and asserts **both are unchanged** after the write: a reallocation would move the buffer and/or grow capacity, so this proves the single-allocation invariant independent of allocator over-allocation.
- `encoded_len_matches_emitted_bytes` (proptest, `tests/codec_props.rs`) — asserts `encoded_len(v) == encode(v).len()` for arbitrary values across the full profile data model. This is the lockstep invariant that keeps the length oracle exact (and thus the reservation short-proof-free) as the encoder evolves.
- `encoded_len_is_exact` (inline unit) — pins exactness across every head size class and nesting.

## CI gate wiring

No new required check. The tests land in the crate's existing gates:
- `encoded_len_matches_emitted_bytes` runs in **Core KATs (native + WASM)** on all three legs (native, `wasm32-wasip1`, and the browser-shaped `wasm32-unknown-unknown` leg, which explicitly names `codec_props`), and in **cargo-linux**'s workspace test.
- The inline unit tests run in the native `cargo test -p cipherbox-core` leg and the `wasm32-wasip1` leg.

`cargo fmt`, `cargo clippy -D warnings`, and the full native core suite are green; `wasm32-wasip1` compiles cleanly (pointer-width parity).

Closes #681


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public `encoded_len` helper to report the exact encoded size of values.
  * Improved encoding efficiency by preallocating the required output space.

* **Bug Fixes**
  * Ensured encoded length calculations consistently match the produced output.

* **Tests**
  * Expanded coverage across nested and varied value types.
  * Added checks preventing unnecessary buffer reallocation during encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->