### PR TITLE
feat(engine): add cross-key atomic floor commit to the FloorStore seam

### DIFF
--- a/crates/desktop-seams/src/floor_store.rs
+++ b/crates/desktop-seams/src/floor_store.rs
@@ -1,10 +1,13 @@
-//! Desktop [`FloorStore`]: fsync-barriered per-key floor files.
+//! Desktop [`FloorStore`]: fsync-barriered per-key floor files with a
+//! write-ahead intent record for cross-key atomic batch commits.
 
 use std::path::{Path, PathBuf};
 
-use cipherbox_engine::seams::{FloorStore, SeamError, SeamResult};
+use cipherbox_engine::seams::{FloorNamespace, FloorRaise, FloorStore, SeamError, SeamResult};
 
-use crate::fs_util::{atomic_write, ensure_dir, read_file_opt, seam_err, to_hex};
+use crate::fs_util::{
+    atomic_write, ensure_dir, read_file_opt, remove_file_durable, seam_err, to_hex,
+};
 
 /// Durable monotonic-max floor store backed by one small file per key
 /// (blueprint/engine.md "FloorStore"; blueprint/desktop.md "Local journal").
@@ -15,21 +18,43 @@ use crate::fs_util::{atomic_write, ensure_dir, read_file_opt, seam_err, to_hex};
 /// [`atomic_write`] fsync barrier, so a floor is structurally incapable of
 /// regression or a torn value, and survives reopen. Keys are opaque engine
 /// bytes, hex-encoded into filenames; the store never interprets them.
+///
+/// A batch [`commit_floors`](FloorStore::commit_floors) that raises several
+/// distinctly-keyed floors is made crash-atomic by a write-ahead intent record
+/// (`intent`): the whole batch is fsynced there before any per-key file moves,
+/// and [`open`](Self::open) replays a leftover intent on reopen. An advance
+/// interrupted between per-key writes therefore completes on the next open
+/// (idempotent monotonic-max), never lingering as a partial (#685).
 pub struct FileFloorStore {
     epoch_dir: PathBuf,
     seq_dir: PathBuf,
+    intent_path: PathBuf,
 }
+
+/// Intent-record tag for an epoch-namespace raise.
+const INTENT_TAG_EPOCH: u8 = 0;
+/// Intent-record tag for a sequence-namespace raise.
+const INTENT_TAG_SEQUENCE: u8 = 1;
 
 impl FileFloorStore {
     /// Opens (creating if absent) a floor store rooted at `dir`. Reopening
-    /// the same `dir` yields the same durable floors.
+    /// the same `dir` yields the same durable floors, replaying any intent
+    /// record a crashed batch commit left behind.
     pub fn open(dir: impl AsRef<Path>) -> SeamResult<Self> {
         let dir = dir.as_ref();
         let epoch_dir = dir.join("epoch");
         let seq_dir = dir.join("seq");
+        // The intent temp write lands in the root, so sweep it too.
+        ensure_dir(dir).map_err(|err| seam_err("floor_store open root", &err))?;
         ensure_dir(&epoch_dir).map_err(|err| seam_err("floor_store open epoch", &err))?;
         ensure_dir(&seq_dir).map_err(|err| seam_err("floor_store open seq", &err))?;
-        Ok(Self { epoch_dir, seq_dir })
+        let store = Self {
+            epoch_dir,
+            seq_dir,
+            intent_path: dir.join("intent"),
+        };
+        store.replay_intent()?;
+        Ok(store)
     }
 
     fn read_floor(&self, dir: &Path, key: &[u8], op: &str) -> SeamResult<Option<u64>> {
@@ -58,6 +83,37 @@ impl FileFloorStore {
         }
         Ok(raised)
     }
+
+    /// The namespace's floor directory.
+    fn dir_for(&self, namespace: FloorNamespace) -> &Path {
+        match namespace {
+            FloorNamespace::Epoch => &self.epoch_dir,
+            FloorNamespace::Sequence => &self.seq_dir,
+        }
+    }
+
+    /// Applies a batch of raises to the per-key files, returning each result.
+    fn apply_raises(&self, raises: &[FloorRaise], op: &str) -> SeamResult<Vec<u64>> {
+        raises
+            .iter()
+            .map(|r| self.raise_floor(self.dir_for(r.namespace), &r.key, r.value, op))
+            .collect()
+    }
+
+    /// Replays a leftover intent record left by a batch commit interrupted
+    /// mid-apply, then clears it. Monotonic-max makes replay idempotent, so a
+    /// batch that had partly applied before the crash simply completes.
+    fn replay_intent(&self) -> SeamResult<()> {
+        let bytes = read_file_opt(&self.intent_path)
+            .map_err(|err| seam_err("floor_store read intent", &err))?;
+        let Some(bytes) = bytes else {
+            return Ok(());
+        };
+        let raises = decode_intent(&bytes)?;
+        self.apply_raises(&raises, "floor_store replay intent")?;
+        remove_file_durable(&self.intent_path)
+            .map_err(|err| seam_err("floor_store clear intent", &err))
+    }
 }
 
 impl FloorStore for FileFloorStore {
@@ -85,5 +141,135 @@ impl FloorStore for FileFloorStore {
             sequence,
             "floor_store raise_sequence_floor",
         )
+    }
+
+    /// Crash-atomic across keys via a write-ahead intent record: the whole
+    /// batch is fsynced to `intent` first, so an advance interrupted between
+    /// per-key writes is completed by [`open`](Self::open)'s replay rather than
+    /// left partial (#685). A commit that returns `Ok` has cleared the intent.
+    async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<Vec<u64>> {
+        if raises.is_empty() {
+            return Ok(Vec::new());
+        }
+        atomic_write(&self.intent_path, &encode_intent(raises))
+            .map_err(|err| seam_err("floor_store write intent", &err))?;
+        let resulting = self.apply_raises(raises, "floor_store commit_floors")?;
+        remove_file_durable(&self.intent_path)
+            .map_err(|err| seam_err("floor_store clear intent", &err))?;
+        Ok(resulting)
+    }
+}
+
+/// Serializes a batch into the intent record: for each raise, a 1-byte
+/// namespace tag, a 4-byte little-endian key length, the key bytes, then the
+/// 8-byte little-endian value.
+fn encode_intent(raises: &[FloorRaise]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for raise in raises {
+        let tag = match raise.namespace {
+            FloorNamespace::Epoch => INTENT_TAG_EPOCH,
+            FloorNamespace::Sequence => INTENT_TAG_SEQUENCE,
+        };
+        out.push(tag);
+        out.extend_from_slice(&(raise.key.len() as u32).to_le_bytes());
+        out.extend_from_slice(&raise.key);
+        out.extend_from_slice(&raise.value.to_le_bytes());
+    }
+    out
+}
+
+/// The corruption error surfaced by [`decode_intent`].
+fn corrupt_intent() -> SeamError {
+    SeamError::new("floor_store: corrupt intent record on disk")
+}
+
+/// Reads a fixed slice at `start`, failing closed if it runs past the record.
+fn intent_slice(bytes: &[u8], start: usize, len: usize) -> SeamResult<&[u8]> {
+    bytes.get(start..start + len).ok_or_else(corrupt_intent)
+}
+
+/// Parses an intent record. The record is written whole through the
+/// [`atomic_write`] barrier, so a present file is never torn; a malformed one
+/// is genuine corruption and fails closed.
+fn decode_intent(bytes: &[u8]) -> SeamResult<Vec<FloorRaise>> {
+    let mut raises = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let namespace = match bytes[i] {
+            INTENT_TAG_EPOCH => FloorNamespace::Epoch,
+            INTENT_TAG_SEQUENCE => FloorNamespace::Sequence,
+            _ => return Err(corrupt_intent()),
+        };
+        i += 1;
+        let len_bytes: [u8; 4] = intent_slice(bytes, i, 4)?.try_into().unwrap();
+        let key_len = u32::from_le_bytes(len_bytes) as usize;
+        i += 4;
+        let key = intent_slice(bytes, i, key_len)?.to_vec();
+        i += key_len;
+        let val_bytes: [u8; 8] = intent_slice(bytes, i, 8)?.try_into().unwrap();
+        i += 8;
+        raises.push(FloorRaise {
+            namespace,
+            key,
+            value: u64::from_le_bytes(val_bytes),
+        });
+    }
+    Ok(raises)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cipherbox_engine::testkit::block_on;
+
+    #[test]
+    fn intent_round_trips() {
+        let raises = vec![
+            FloorRaise::epoch(b"scope".to_vec(), 7),
+            FloorRaise::sequence(b"k51-name".to_vec(), 42),
+            FloorRaise::epoch(Vec::new(), 1),
+        ];
+        assert_eq!(decode_intent(&encode_intent(&raises)).unwrap(), raises);
+    }
+
+    #[test]
+    fn decode_rejects_a_truncated_intent() {
+        let bytes = encode_intent(&[FloorRaise::epoch(b"scope".to_vec(), 7)]);
+        assert!(decode_intent(&bytes[..bytes.len() - 1]).is_err());
+    }
+
+    /// A batch commit interrupted mid-apply (intent fsynced, only the first of
+    /// two floors on the platter) is completed by reopen — the second floor
+    /// lands and the intent clears, so no partial advance survives (#685).
+    #[test]
+    fn open_replays_an_interrupted_batch_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("floors");
+
+        // Simulate the crashed state by hand: the revocation floor applied, its
+        // sequence partner not yet, and the intent record still present.
+        block_on(async {
+            let store = FileFloorStore::open(&path).unwrap();
+            store.raise_epoch_floor(b"scope", 9).await.unwrap();
+        });
+        let interrupted = vec![
+            FloorRaise::epoch(b"scope".to_vec(), 9),
+            FloorRaise::sequence(b"k51-name".to_vec(), 5),
+        ];
+        atomic_write(&path.join("intent"), &encode_intent(&interrupted)).unwrap();
+
+        block_on(async {
+            let reopened = FileFloorStore::open(&path).unwrap();
+            assert_eq!(
+                reopened.sequence_floor(b"k51-name").await.unwrap(),
+                Some(5),
+                "reopen must complete the interrupted sequence raise"
+            );
+            assert_eq!(reopened.epoch_floor(b"scope").await.unwrap(), Some(9));
+        });
+        assert!(
+            !path.join("intent").exists(),
+            "reopen must clear the intent record after replay"
+        );
     }
 }

--- a/crates/desktop-seams/src/floor_store.rs
+++ b/crates/desktop-seams/src/floor_store.rs
@@ -335,6 +335,31 @@ mod tests {
         );
     }
 
+    /// A corrupt leftover intent on disk fails the whole reopen closed: `open`
+    /// surfaces the decode error rather than panicking or silently skipping the
+    /// record, so a garbled recovery journal can never be quietly discarded
+    /// (#685). This is the crash-recovery fail-closed contract, exercised through
+    /// the public `open` surface (not just `decode_intent` in isolation).
+    #[test]
+    fn open_fails_closed_on_a_corrupt_intent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("floors");
+        FileFloorStore::open(&path).unwrap();
+
+        // A valid record truncated by one byte: structurally corrupt, not torn.
+        let good = encode_intent(&[FloorRaise::epoch(b"scope".to_vec(), 1)]);
+        atomic_write(
+            &path.join("intent").join("corrupt"),
+            &good[..good.len() - 1],
+        )
+        .unwrap();
+
+        assert!(
+            FileFloorStore::open(&path).is_err(),
+            "a corrupt intent must fail closed on reopen"
+        );
+    }
+
     /// Sequential commits over one handle each mint a distinct intent file and
     /// clean it up, so a successful commit leaves no intent debris behind for a
     /// later reopen to re-apply.

--- a/crates/desktop-seams/src/floor_store.rs
+++ b/crates/desktop-seams/src/floor_store.rs
@@ -6,7 +6,8 @@ use std::path::{Path, PathBuf};
 use cipherbox_engine::seams::{FloorNamespace, FloorRaise, FloorStore, SeamError, SeamResult};
 
 use crate::fs_util::{
-    atomic_write, ensure_dir, read_file_opt, remove_file_durable, seam_err, to_hex,
+    atomic_write, ensure_dir, list_file_names, read_file_opt, remove_file_durable, seam_err,
+    to_hex, unique_component,
 };
 
 /// Durable monotonic-max floor store backed by one small file per key
@@ -20,15 +21,19 @@ use crate::fs_util::{
 /// bytes, hex-encoded into filenames; the store never interprets them.
 ///
 /// A batch [`commit_floors`](FloorStore::commit_floors) that raises several
-/// distinctly-keyed floors is made crash-atomic by a write-ahead intent record
-/// (`intent`): the whole batch is fsynced there before any per-key file moves,
-/// and [`open`](Self::open) replays a leftover intent on reopen. An advance
-/// interrupted between per-key writes therefore completes on the next open
-/// (idempotent monotonic-max), never lingering as a partial (#685).
+/// distinctly-keyed floors is made crash-consistent by a write-ahead intent
+/// record: the whole batch is fsynced under `intent/` before any per-key file
+/// moves, and [`open`](Self::open) replays every leftover intent on reopen. The
+/// recovery is **roll-forward**, not rollback: an advance interrupted between
+/// per-key writes leaves the already-written floors in place and *completes* the
+/// rest on the next open (idempotent monotonic-max) — it never rewinds an
+/// applied floor. Each commit writes its own uniquely-named intent file, so
+/// overlapping commits neither clobber nor remove one another's recovery record
+/// (#685).
 pub struct FileFloorStore {
     epoch_dir: PathBuf,
     seq_dir: PathBuf,
-    intent_path: PathBuf,
+    intent_dir: PathBuf,
 }
 
 /// Intent-record tag for an epoch-namespace raise.
@@ -39,21 +44,22 @@ const INTENT_TAG_SEQUENCE: u8 = 1;
 impl FileFloorStore {
     /// Opens (creating if absent) a floor store rooted at `dir`. Reopening
     /// the same `dir` yields the same durable floors, replaying any intent
-    /// record a crashed batch commit left behind.
+    /// records a crashed batch commit left behind.
     pub fn open(dir: impl AsRef<Path>) -> SeamResult<Self> {
         let dir = dir.as_ref();
         let epoch_dir = dir.join("epoch");
         let seq_dir = dir.join("seq");
-        // The intent temp write lands in the root, so sweep it too.
+        let intent_dir = dir.join("intent");
         ensure_dir(dir).map_err(|err| seam_err("floor_store open root", &err))?;
         ensure_dir(&epoch_dir).map_err(|err| seam_err("floor_store open epoch", &err))?;
         ensure_dir(&seq_dir).map_err(|err| seam_err("floor_store open seq", &err))?;
+        ensure_dir(&intent_dir).map_err(|err| seam_err("floor_store open intent", &err))?;
         let store = Self {
             epoch_dir,
             seq_dir,
-            intent_path: dir.join("intent"),
+            intent_dir,
         };
-        store.replay_intent()?;
+        store.replay_intents()?;
         Ok(store)
     }
 
@@ -100,19 +106,26 @@ impl FileFloorStore {
             .collect()
     }
 
-    /// Replays a leftover intent record left by a batch commit interrupted
-    /// mid-apply, then clears it. Monotonic-max makes replay idempotent, so a
-    /// batch that had partly applied before the crash simply completes.
-    fn replay_intent(&self) -> SeamResult<()> {
-        let bytes = read_file_opt(&self.intent_path)
-            .map_err(|err| seam_err("floor_store read intent", &err))?;
-        let Some(bytes) = bytes else {
-            return Ok(());
-        };
-        let raises = decode_intent(&bytes)?;
-        self.apply_raises(&raises, "floor_store replay intent")?;
-        remove_file_durable(&self.intent_path)
-            .map_err(|err| seam_err("floor_store clear intent", &err))
+    /// Replays every leftover intent record left by batch commits interrupted
+    /// mid-apply, clearing each once reapplied. Monotonic-max makes replay
+    /// idempotent and order-independent, so a batch that had partly applied
+    /// before the crash simply completes, and multiple pending intents (from
+    /// overlapping commits) all heal forward.
+    fn replay_intents(&self) -> SeamResult<()> {
+        let names = list_file_names(&self.intent_dir)
+            .map_err(|err| seam_err("floor_store list intents", &err))?;
+        for name in names {
+            let path = self.intent_dir.join(&name);
+            let Some(bytes) =
+                read_file_opt(&path).map_err(|err| seam_err("floor_store read intent", &err))?
+            else {
+                continue;
+            };
+            let raises = decode_intent(&bytes)?;
+            self.apply_raises(&raises, "floor_store replay intent")?;
+            remove_file_durable(&path).map_err(|err| seam_err("floor_store clear intent", &err))?;
+        }
+        Ok(())
     }
 }
 
@@ -143,18 +156,21 @@ impl FloorStore for FileFloorStore {
         )
     }
 
-    /// Crash-atomic across keys via a write-ahead intent record: the whole
-    /// batch is fsynced to `intent` first, so an advance interrupted between
-    /// per-key writes is completed by [`open`](Self::open)'s replay rather than
-    /// left partial (#685). A commit that returns `Ok` has cleared the intent.
+    /// Crash-consistent across keys via a write-ahead intent record, roll-forward
+    /// (not rollback): the whole batch is fsynced to its own `intent/<unique>`
+    /// file first, so an advance interrupted between per-key writes is *completed*
+    /// by [`open`](Self::open)'s replay rather than left partial (#685). The
+    /// unique filename keeps overlapping commits from clobbering or removing each
+    /// other's record. A commit that returns `Ok` has cleared its intent.
     async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<Vec<u64>> {
         if raises.is_empty() {
             return Ok(Vec::new());
         }
-        atomic_write(&self.intent_path, &encode_intent(raises))
+        let intent_path = self.intent_dir.join(unique_component());
+        atomic_write(&intent_path, &encode_intent(raises))
             .map_err(|err| seam_err("floor_store write intent", &err))?;
         let resulting = self.apply_raises(raises, "floor_store commit_floors")?;
-        remove_file_durable(&self.intent_path)
+        remove_file_durable(&intent_path)
             .map_err(|err| seam_err("floor_store clear intent", &err))?;
         Ok(resulting)
     }
@@ -240,7 +256,9 @@ mod tests {
 
     /// A batch commit interrupted mid-apply (intent fsynced, only the first of
     /// two floors on the platter) is completed by reopen — the second floor
-    /// lands and the intent clears, so no partial advance survives (#685).
+    /// lands and the intent clears, so no partial advance survives (#685). This
+    /// is the roll-forward recovery contract: reopen *heals forward*, it never
+    /// rewinds the floor that already landed.
     #[test]
     fn open_replays_an_interrupted_batch_commit() {
         let dir = tempfile::tempdir().unwrap();
@@ -256,7 +274,11 @@ mod tests {
             FloorRaise::epoch(b"scope".to_vec(), 9),
             FloorRaise::sequence(b"k51-name".to_vec(), 5),
         ];
-        atomic_write(&path.join("intent"), &encode_intent(&interrupted)).unwrap();
+        atomic_write(
+            &path.join("intent").join("crashed-commit"),
+            &encode_intent(&interrupted),
+        )
+        .unwrap();
 
         block_on(async {
             let reopened = FileFloorStore::open(&path).unwrap();
@@ -268,8 +290,72 @@ mod tests {
             assert_eq!(reopened.epoch_floor(b"scope").await.unwrap(), Some(9));
         });
         assert!(
-            !path.join("intent").exists(),
+            list_file_names(&path.join("intent")).unwrap().is_empty(),
             "reopen must clear the intent record after replay"
+        );
+    }
+
+    /// Two overlapping commits each leave their own intent file — neither
+    /// clobbers nor removes the other's — and reopen replays BOTH, healing every
+    /// floor forward. This is the crash-consistency hole a single shared intent
+    /// path had: the second commit could overwrite or delete the first's
+    /// recovery record (#685).
+    #[test]
+    fn open_replays_multiple_overlapping_intents() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("floors");
+        block_on(async {
+            FileFloorStore::open(&path).unwrap();
+        });
+
+        // Two distinct commits crash with their intents still present and none
+        // of their floors yet on the platter (the worst case).
+        let first = vec![
+            FloorRaise::epoch(b"scope-a".to_vec(), 3),
+            FloorRaise::sequence(b"name-a".to_vec(), 7),
+        ];
+        let second = vec![
+            FloorRaise::epoch(b"scope-b".to_vec(), 4),
+            FloorRaise::sequence(b"name-b".to_vec(), 9),
+        ];
+        let intent_dir = path.join("intent");
+        atomic_write(&intent_dir.join("commit-1"), &encode_intent(&first)).unwrap();
+        atomic_write(&intent_dir.join("commit-2"), &encode_intent(&second)).unwrap();
+
+        block_on(async {
+            let reopened = FileFloorStore::open(&path).unwrap();
+            assert_eq!(reopened.epoch_floor(b"scope-a").await.unwrap(), Some(3));
+            assert_eq!(reopened.sequence_floor(b"name-a").await.unwrap(), Some(7));
+            assert_eq!(reopened.epoch_floor(b"scope-b").await.unwrap(), Some(4));
+            assert_eq!(reopened.sequence_floor(b"name-b").await.unwrap(), Some(9));
+        });
+        assert!(
+            list_file_names(&intent_dir).unwrap().is_empty(),
+            "reopen must clear every replayed intent record"
+        );
+    }
+
+    /// Sequential commits over one handle each mint a distinct intent file and
+    /// clean it up, so a successful commit leaves no intent debris behind for a
+    /// later reopen to re-apply.
+    #[test]
+    fn successful_commits_leave_no_intent_debris() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("floors");
+        block_on(async {
+            let store = FileFloorStore::open(&path).unwrap();
+            store
+                .commit_floors(&[FloorRaise::epoch(b"scope".to_vec(), 2)])
+                .await
+                .unwrap();
+            store
+                .commit_floors(&[FloorRaise::sequence(b"name".to_vec(), 5)])
+                .await
+                .unwrap();
+        });
+        assert!(
+            list_file_names(&path.join("intent")).unwrap().is_empty(),
+            "a returned commit must clear its own intent record"
         );
     }
 }

--- a/crates/desktop-seams/src/fs_util.rs
+++ b/crates/desktop-seams/src/fs_util.rs
@@ -136,10 +136,16 @@ fn fsync_dir(_dir: &Path) -> io::Result<()> {
     Ok(())
 }
 
+/// A process-unique filename component (`<pid>.<seq>`), so two in-flight
+/// records never collide on a name even across concurrent writers.
+pub(crate) fn unique_component() -> String {
+    let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    format!("{}.{seq}", std::process::id())
+}
+
 /// A process-unique temp path inside `dir`.
 fn temp_path(dir: &Path) -> PathBuf {
-    let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
-    dir.join(format!("{TEMP_PREFIX}{}.{seq}", std::process::id()))
+    dir.join(format!("{TEMP_PREFIX}{}", unique_component()))
 }
 
 /// Lowercase hex encoding of opaque key bytes for use as a filename.

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -30,7 +30,7 @@
 
 use cipherbox_core::payload::RepointObject;
 
-use crate::seams::{FloorStore, SeamResult};
+use crate::seams::{FloorRaise, FloorStore, SeamResult};
 
 /// Suffix that distinguishes a scope's write-epoch floor key from its
 /// read-epoch floor key inside the [`FloorStore`] epoch namespace. The
@@ -83,16 +83,15 @@ pub async fn sequence_floor<F: FloorStore>(
 /// never unsealed can never move a floor — the provenance the plain scalar
 /// arguments cannot express is enforced at that single call site.
 ///
-/// **Fail-safe ordering.** The [`FloorStore`] seam is per-key monotonic with no
-/// cross-key transaction, so the two raises are separate durable writes. The
-/// trust-critical **read-epoch (revocation) floor commits first**: if the
-/// second (sequence) write then fails with a seam error, the durable state is
-/// epoch-advanced (fail-closed — old-epoch records still reject) with only the
-/// sequence floor stale-low, whose sole effect is a harmless idempotent
-/// re-adoption of the identical record on the caller's retry. The reverse
-/// order could leave the revocation floor stale, so it is deliberately avoided.
-/// Because both raises are idempotent monotonic-max, a retried `adopt`
-/// re-converges the pair.
+/// **Fail-safe ordering.** The read-epoch (revocation) and sequence floors are
+/// distinctly keyed. The batch lists the trust-critical **read-epoch
+/// (revocation) floor first**, so on a backing without a cross-key transaction
+/// an interrupted commit is epoch-advanced (fail-closed — old-epoch records
+/// still reject) with only the sequence floor stale-low, whose sole effect is a
+/// harmless idempotent re-adoption of the identical record on retry. A backing
+/// that honors [`FloorStore::commit_floors`] atomically makes the pair
+/// all-or-nothing instead (#685); either way the monotonic-max, idempotent
+/// raises let a retried `adopt` re-converge.
 pub async fn advance_on_unseal<F: FloorStore>(
     floors: &F,
     scope_id: &[u8; 16],
@@ -101,8 +100,12 @@ pub async fn advance_on_unseal<F: FloorStore>(
     epoch: u64,
 ) -> SeamResult<()> {
     // Revocation floor first (see "Fail-safe ordering" above).
-    floors.raise_epoch_floor(scope_id, epoch).await?;
-    floors.raise_sequence_floor(ipns_name, sequence).await?;
+    floors
+        .commit_floors(&[
+            FloorRaise::epoch(scope_id.as_slice(), epoch),
+            FloorRaise::sequence(ipns_name, sequence),
+        ])
+        .await?;
     Ok(())
 }
 
@@ -116,14 +119,15 @@ pub async fn advance_on_unseal<F: FloorStore>(
 /// tampered, or non-owner re-point never produces one, and this function never
 /// runs on unauthenticated input. As with [`advance_on_unseal`], the
 /// trust-critical read-epoch (revocation) floor commits before the write-epoch
-/// floor, so a partial seam failure leaves the fail-closed state.
+/// floor, so a partial seam failure leaves the fail-closed state (or none at
+/// all, on a backing with an atomic [`FloorStore::commit_floors`]).
 pub async fn cold_seed<F: FloorStore>(floors: &F, repoint: &RepointObject) -> SeamResult<()> {
     // Revocation floor first (fail-safe ordering).
     floors
-        .raise_epoch_floor(&repoint.scope_id, repoint.min_read_epoch)
-        .await?;
-    floors
-        .raise_epoch_floor(&write_epoch_key(&repoint.scope_id), repoint.write_epoch)
+        .commit_floors(&[
+            FloorRaise::epoch(repoint.scope_id.as_slice(), repoint.min_read_epoch),
+            FloorRaise::epoch(write_epoch_key(&repoint.scope_id), repoint.write_epoch),
+        ])
         .await?;
     Ok(())
 }

--- a/crates/engine/src/seams/floor_store.rs
+++ b/crates/engine/src/seams/floor_store.rs
@@ -34,4 +34,73 @@ pub trait FloorStore {
     /// Raises the name's sequence floor to `max(stored, sequence)`, durably,
     /// and returns the resulting stored floor.
     async fn raise_sequence_floor(&self, ipns_name: &[u8], sequence: u64) -> SeamResult<u64>;
+
+    /// Commits a batch of monotonic-max floor raises across both namespaces,
+    /// returning the resulting stored floor for each entry in order.
+    ///
+    /// A single floor advance raises several distinctly-keyed floors at once
+    /// (read-epoch, write-epoch, per-name sequence). Where the backing offers a
+    /// cross-key transaction the commit is **all-or-nothing**: a seam error
+    /// leaves no entry durably changed, so a partial advance is never observable
+    /// (#685). The default fallback applies the raises one key at a time in the
+    /// given order — not atomic, but the caller passes the trust-critical
+    /// (revocation) floor first, so an interrupted fallback fails toward *more*
+    /// restriction and re-converges idempotently on retry, exactly the #682
+    /// mitigation this method subsumes. Callers MUST order entries
+    /// revocation-before-liveness for that guarantee to hold.
+    async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<Vec<u64>> {
+        let mut resulting = Vec::with_capacity(raises.len());
+        for raise in raises {
+            let floor = match raise.namespace {
+                FloorNamespace::Epoch => self.raise_epoch_floor(&raise.key, raise.value).await?,
+                FloorNamespace::Sequence => {
+                    self.raise_sequence_floor(&raise.key, raise.value).await?
+                }
+            };
+            resulting.push(floor);
+        }
+        Ok(resulting)
+    }
+}
+
+/// Which of the two independent floor maps a [`FloorRaise`] targets. Identical
+/// key bytes in the two namespaces never collide (the single-key methods keep
+/// the same separation).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FloorNamespace {
+    /// Per-scope epoch floors ([`FloorStore::raise_epoch_floor`]).
+    Epoch,
+    /// Per-name sequence floors ([`FloorStore::raise_sequence_floor`]).
+    Sequence,
+}
+
+/// One monotonic-max floor raise inside a [`FloorStore::commit_floors`] batch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FloorRaise {
+    /// The map this raise targets.
+    pub namespace: FloorNamespace,
+    /// Opaque engine-chosen key bytes (scope id or `ipnsName`).
+    pub key: Vec<u8>,
+    /// The floor value to raise to (`max(stored, value)`).
+    pub value: u64,
+}
+
+impl FloorRaise {
+    /// An epoch-namespace raise.
+    pub fn epoch(key: impl Into<Vec<u8>>, value: u64) -> Self {
+        Self {
+            namespace: FloorNamespace::Epoch,
+            key: key.into(),
+            value,
+        }
+    }
+
+    /// A sequence-namespace raise.
+    pub fn sequence(key: impl Into<Vec<u8>>, value: u64) -> Self {
+        Self {
+            namespace: FloorNamespace::Sequence,
+            key: key.into(),
+            value,
+        }
+    }
 }

--- a/crates/engine/src/seams/floor_store.rs
+++ b/crates/engine/src/seams/floor_store.rs
@@ -39,15 +39,30 @@ pub trait FloorStore {
     /// returning the resulting stored floor for each entry in order.
     ///
     /// A single floor advance raises several distinctly-keyed floors at once
-    /// (read-epoch, write-epoch, per-name sequence). Where the backing offers a
-    /// cross-key transaction the commit is **all-or-nothing**: a seam error
-    /// leaves no entry durably changed, so a partial advance is never observable
-    /// (#685). The default fallback applies the raises one key at a time in the
-    /// given order — not atomic, but the caller passes the trust-critical
-    /// (revocation) floor first, so an interrupted fallback fails toward *more*
-    /// restriction and re-converges idempotently on retry, exactly the #682
-    /// mitigation this method subsumes. Callers MUST order entries
-    /// revocation-before-liveness for that guarantee to hold.
+    /// (read-epoch, write-epoch, per-name sequence). Two backing shapes close
+    /// the partial-advance hazard (#685), differently:
+    ///
+    /// - **Transactional (all-or-nothing)** — a backing with a cross-key
+    ///   transaction (the in-memory fake's single lock guard) leaves *no* entry
+    ///   durably changed on a seam error, so a partial advance is never
+    ///   observable at all.
+    /// - **Roll-forward (write-ahead journal)** — the desktop file store fsyncs
+    ///   the batch to an intent record before any per-key write and replays it on
+    ///   reopen, so an interrupted advance *completes forward* on the next open
+    ///   rather than lingering as a partial. It heals forward; it never rewinds.
+    ///
+    /// The default fallback applies the raises one key at a time in the given
+    /// order — not atomic, but the caller passes the trust-critical (revocation)
+    /// floor first, so an interrupted fallback fails toward *more* restriction and
+    /// re-converges idempotently on retry, exactly the #682 mitigation this method
+    /// subsumes. Callers MUST order entries revocation-before-liveness for that
+    /// guarantee to hold.
+    ///
+    /// The web IndexedDB seam intentionally rides this fallback (its JS boundary
+    /// exposes only the per-key methods, no batch), which stays #682-safe.
+    /// Web-atomic commit is designed-for but deferred: #685 is a durability /
+    /// liveness concern, not a trust hole, and the ordered fallback already fails
+    /// closed on the revocation floor.
     async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<Vec<u64>> {
         let mut resulting = Vec::with_capacity(raises.len());
         for raise in raises {

--- a/crates/engine/src/seams/mod.rs
+++ b/crates/engine/src/seams/mod.rs
@@ -22,7 +22,7 @@ mod snapshot_cache;
 mod staging_store;
 
 pub use credential_store::CredentialStore;
-pub use floor_store::FloorStore;
+pub use floor_store::{FloorNamespace, FloorRaise, FloorStore};
 pub use http::{Http, HttpMethod, HttpRequest, HttpResponse};
 pub use mailbox::{Mailbox, MailboxItem};
 pub use record_transport::{EndpointId, RecordTransport};

--- a/crates/engine/src/testkit/conformance/floor_store.rs
+++ b/crates/engine/src/testkit/conformance/floor_store.rs
@@ -1,7 +1,7 @@
 //! Conformance kit: [`FloorStore`] monotonicity, durability, and
 //! namespacing.
 
-use crate::seams::FloorStore;
+use crate::seams::{FloorRaise, FloorStore};
 
 /// Runs the `FloorStore` contract against an implementation.
 ///
@@ -74,17 +74,49 @@ where
     );
     assert_eq!(store.epoch_floor(scope_a).await.unwrap(), Some(7));
 
-    // Durability: a reopened handle sees every raised floor.
+    // Cross-key batch commit: a mixed-namespace batch raises every entry
+    // monotonic-max and reports the resulting floors in order.
+    let batch = store
+        .commit_floors(&[
+            FloorRaise::epoch(scope_a.to_vec(), 6), // below stored 7 → no-op, reports 7
+            FloorRaise::epoch(scope_b.to_vec(), 8),
+            FloorRaise::sequence(scope_a.to_vec(), 50),
+        ])
+        .await
+        .unwrap();
+    assert_eq!(
+        batch,
+        vec![7, 8, 50],
+        "commit_floors must report each resulting floor in order, monotonic-max"
+    );
+    assert_eq!(
+        store.epoch_floor(scope_a).await.unwrap(),
+        Some(7),
+        "a below-floor batch entry must not lower the floor"
+    );
+    assert_eq!(store.epoch_floor(scope_b).await.unwrap(), Some(8));
+    assert_eq!(
+        store.sequence_floor(scope_a).await.unwrap(),
+        Some(50),
+        "a batch entry must not leak across namespaces"
+    );
+
+    // Durability: a reopened handle sees every raised floor, batch-committed
+    // ones included.
     let reopened = open().await;
     assert_eq!(
         reopened.epoch_floor(scope_a).await.unwrap(),
         Some(7),
         "epoch floors must survive reopen"
     );
-    assert_eq!(reopened.epoch_floor(scope_b).await.unwrap(), Some(2));
+    assert_eq!(
+        reopened.epoch_floor(scope_b).await.unwrap(),
+        Some(8),
+        "batch-committed epoch floors must survive reopen"
+    );
     assert_eq!(
         reopened.sequence_floor(scope_a).await.unwrap(),
-        Some(41),
-        "sequence floors must survive reopen"
+        Some(50),
+        "batch-committed sequence floors must survive reopen"
     );
 }

--- a/crates/engine/src/testkit/conformance/floor_store.rs
+++ b/crates/engine/src/testkit/conformance/floor_store.rs
@@ -119,4 +119,27 @@ where
         Some(50),
         "batch-committed sequence floors must survive reopen"
     );
+
+    // Retry convergence: re-committing the SAME batch (as a caller retry after
+    // an interrupted commit would) is idempotent — identical results, no floor
+    // regresses. This is the convergence property every impl's #685 contract
+    // rests on, whether it closes the hazard by all-or-nothing rollback, by
+    // roll-forward replay, or by the ordered fail-safe fallback: a partial or
+    // replayed commit always heals to the same floors on retry.
+    let retry = reopened
+        .commit_floors(&[
+            FloorRaise::epoch(scope_a.to_vec(), 6), // still below 7 → no-op
+            FloorRaise::epoch(scope_b.to_vec(), 8),
+            FloorRaise::sequence(scope_a.to_vec(), 50),
+        ])
+        .await
+        .unwrap();
+    assert_eq!(
+        retry,
+        vec![7, 8, 50],
+        "re-committing the same batch must converge to the identical floors"
+    );
+    assert_eq!(reopened.epoch_floor(scope_a).await.unwrap(), Some(7));
+    assert_eq!(reopened.epoch_floor(scope_b).await.unwrap(), Some(8));
+    assert_eq!(reopened.sequence_floor(scope_a).await.unwrap(), Some(50));
 }

--- a/crates/engine/src/testkit/fakes/floor_store.rs
+++ b/crates/engine/src/testkit/fakes/floor_store.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use crate::seams::{FloorStore, SeamResult};
+use crate::seams::{FloorNamespace, FloorRaise, FloorStore, SeamResult};
 
 #[derive(Default)]
 struct Inner {
@@ -58,5 +58,20 @@ impl FloorStore for InMemoryFloorStore {
             ipns_name,
             sequence,
         ))
+    }
+
+    /// Genuinely all-or-nothing: the whole batch applies under one lock guard,
+    /// so no observer sees a partial commit (the atomic contract #685 asks of a
+    /// transactional backing).
+    async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<Vec<u64>> {
+        let mut inner = self.inner.lock().expect("lock");
+        let resulting = raises
+            .iter()
+            .map(|r| match r.namespace {
+                FloorNamespace::Epoch => raise(&mut inner.epoch, &r.key, r.value),
+                FloorNamespace::Sequence => raise(&mut inner.sequence, &r.key, r.value),
+            })
+            .collect();
+        Ok(resulting)
     }
 }

--- a/crates/engine/tests/floor_atomic.rs
+++ b/crates/engine/tests/floor_atomic.rs
@@ -5,13 +5,18 @@
 //! ([`advance_on_unseal`]) through two fault-injecting [`FloorStore`] backings
 //! and contrasts them:
 //!
-//! - a backing whose [`FloorStore::commit_floors`] is atomic → a mid-advance
-//!   seam fault leaves **no** floor moved (all-or-nothing, the #685 fix);
+//! - a backing whose [`FloorStore::commit_floors`] is transactional → a
+//!   mid-advance seam fault leaves **no** floor moved (all-or-nothing, the #685
+//!   fix);
 //! - a backing on the seam's non-atomic default fallback → the same fault
 //!   leaves a *partial* advance. That negative control makes the atomic
 //!   assertion non-vacuous (it is what "the test fails with the atomic commit
 //!   disabled" means here) while confirming #682's fail-safe ordering and
 //!   idempotent re-convergence still hold.
+//!
+//! The desktop file store closes the same hazard by **roll-forward** replay
+//! (write-ahead intent, heal-on-reopen) rather than transactional rollback; that
+//! contract is exercised in `cipherbox-desktop-seams` (`floor_store` unit tests).
 
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 

--- a/crates/engine/tests/floor_atomic.rs
+++ b/crates/engine/tests/floor_atomic.rs
@@ -1,0 +1,224 @@
+//! Cross-key atomic floor-commit durability (#685).
+//!
+//! A floor advance raises several distinctly-keyed floors (read-epoch,
+//! per-name sequence) at once. This suite drives the engine's floor law
+//! ([`advance_on_unseal`]) through two fault-injecting [`FloorStore`] backings
+//! and contrasts them:
+//!
+//! - a backing whose [`FloorStore::commit_floors`] is atomic → a mid-advance
+//!   seam fault leaves **no** floor moved (all-or-nothing, the #685 fix);
+//! - a backing on the seam's non-atomic default fallback → the same fault
+//!   leaves a *partial* advance. That negative control makes the atomic
+//!   assertion non-vacuous (it is what "the test fails with the atomic commit
+//!   disabled" means here) while confirming #682's fail-safe ordering and
+//!   idempotent re-convergence still hold.
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use cipherbox_engine::gate::floor::{advance_on_unseal, read_epoch_floor, sequence_floor};
+use cipherbox_engine::seams::{FloorRaise, FloorStore, SeamError, SeamResult};
+use cipherbox_engine::testkit::block_on;
+use cipherbox_engine::testkit::fakes::InMemoryFloorStore;
+
+const SCOPE: [u8; 16] = [7u8; 16];
+const NAME: &[u8] = b"k51-scope-root-name";
+const EPOCH: u64 = 3;
+const SEQUENCE: u64 = 5;
+
+/// Never-fault sentinel for the injected raise budget.
+const DISARMED: usize = usize::MAX;
+
+// ---------------------------------------------------------------------------
+// A backing that faults the Nth single-key raise and does NOT override
+// commit_floors — so an advance runs the seam's non-atomic default fallback,
+// the pre-#685 split-write behaviour.
+// ---------------------------------------------------------------------------
+
+struct SplitFaultyStore {
+    inner: InMemoryFloorStore,
+    raises_until_fault: AtomicUsize,
+}
+
+impl SplitFaultyStore {
+    /// Allows `budget` raises to succeed, then faults every raise after.
+    fn allowing(budget: usize) -> Self {
+        Self {
+            inner: InMemoryFloorStore::default(),
+            raises_until_fault: AtomicUsize::new(budget),
+        }
+    }
+
+    fn disarm(&self) {
+        self.raises_until_fault.store(DISARMED, Ordering::Relaxed);
+    }
+
+    fn tick(&self) -> SeamResult<()> {
+        match self.raises_until_fault.load(Ordering::Relaxed) {
+            0 => Err(SeamError::new("injected seam I/O fault (split raise)")),
+            remaining => {
+                if remaining != DISARMED {
+                    self.raises_until_fault
+                        .store(remaining - 1, Ordering::Relaxed);
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl FloorStore for SplitFaultyStore {
+    async fn epoch_floor(&self, scope_id: &[u8]) -> SeamResult<Option<u64>> {
+        self.inner.epoch_floor(scope_id).await
+    }
+
+    async fn raise_epoch_floor(&self, scope_id: &[u8], epoch: u64) -> SeamResult<u64> {
+        self.tick()?;
+        self.inner.raise_epoch_floor(scope_id, epoch).await
+    }
+
+    async fn sequence_floor(&self, ipns_name: &[u8]) -> SeamResult<Option<u64>> {
+        self.inner.sequence_floor(ipns_name).await
+    }
+
+    async fn raise_sequence_floor(&self, ipns_name: &[u8], sequence: u64) -> SeamResult<u64> {
+        self.tick()?;
+        self.inner.raise_sequence_floor(ipns_name, sequence).await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A backing with a genuinely atomic commit_floors: an armed fault aborts the
+// whole batch before touching any key (a transactional store's all-or-nothing).
+// ---------------------------------------------------------------------------
+
+struct AtomicFaultyStore {
+    inner: InMemoryFloorStore,
+    fail_commit: AtomicBool,
+}
+
+impl AtomicFaultyStore {
+    fn armed() -> Self {
+        Self {
+            inner: InMemoryFloorStore::default(),
+            fail_commit: AtomicBool::new(true),
+        }
+    }
+
+    fn disarm(&self) {
+        self.fail_commit.store(false, Ordering::Relaxed);
+    }
+}
+
+impl FloorStore for AtomicFaultyStore {
+    async fn epoch_floor(&self, scope_id: &[u8]) -> SeamResult<Option<u64>> {
+        self.inner.epoch_floor(scope_id).await
+    }
+
+    async fn raise_epoch_floor(&self, scope_id: &[u8], epoch: u64) -> SeamResult<u64> {
+        self.inner.raise_epoch_floor(scope_id, epoch).await
+    }
+
+    async fn sequence_floor(&self, ipns_name: &[u8]) -> SeamResult<Option<u64>> {
+        self.inner.sequence_floor(ipns_name).await
+    }
+
+    async fn raise_sequence_floor(&self, ipns_name: &[u8], sequence: u64) -> SeamResult<u64> {
+        self.inner.raise_sequence_floor(ipns_name, sequence).await
+    }
+
+    async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<Vec<u64>> {
+        if self.fail_commit.load(Ordering::Relaxed) {
+            return Err(SeamError::new("injected seam I/O fault (atomic commit)"));
+        }
+        self.inner.commit_floors(raises).await
+    }
+}
+
+/// The fix: with an atomic commit, a mid-advance fault moves no floor at all,
+/// and a retry converges the whole advance.
+#[test]
+fn advance_on_unseal_is_all_or_nothing_when_the_backing_commits_atomically() {
+    let store = AtomicFaultyStore::armed();
+    block_on(async {
+        assert!(
+            advance_on_unseal(&store, &SCOPE, NAME, SEQUENCE, EPOCH)
+                .await
+                .is_err(),
+            "the injected commit fault must surface as a seam error"
+        );
+        assert_eq!(
+            read_epoch_floor(&store, &SCOPE).await.unwrap(),
+            None,
+            "an atomic commit must leave the read-epoch floor untouched on a fault"
+        );
+        assert_eq!(
+            sequence_floor(&store, NAME).await.unwrap(),
+            None,
+            "an atomic commit must leave NO partial floor state at all"
+        );
+
+        // Idempotent re-convergence once the fault clears.
+        store.disarm();
+        advance_on_unseal(&store, &SCOPE, NAME, SEQUENCE, EPOCH)
+            .await
+            .unwrap();
+        assert_eq!(read_epoch_floor(&store, &SCOPE).await.unwrap(), Some(EPOCH));
+        assert_eq!(sequence_floor(&store, NAME).await.unwrap(), Some(SEQUENCE));
+    });
+}
+
+/// The negative control (atomic commit disabled): the same fault leaves a
+/// PARTIAL advance — the hazard #685 closes. It also proves #682's fail-safe
+/// ordering (revocation floor commits first, so the partial fails closed) and
+/// idempotent re-convergence on retry.
+#[test]
+fn advance_on_unseal_leaves_a_fail_safe_partial_without_atomic_commit() {
+    // Budget 1: the first raise (revocation floor) succeeds, the second
+    // (sequence floor) faults.
+    let store = SplitFaultyStore::allowing(1);
+    block_on(async {
+        assert!(
+            advance_on_unseal(&store, &SCOPE, NAME, SEQUENCE, EPOCH)
+                .await
+                .is_err(),
+            "the second (sequence) raise must fault"
+        );
+        assert_eq!(
+            read_epoch_floor(&store, &SCOPE).await.unwrap(),
+            Some(EPOCH),
+            "fail-safe ordering: the revocation floor commits first, so a partial fails closed"
+        );
+        assert_eq!(
+            sequence_floor(&store, NAME).await.unwrap(),
+            None,
+            "without an atomic commit the sequence floor is left stale — the observable partial"
+        );
+
+        // Idempotent re-convergence: retry with the fault cleared completes it.
+        store.disarm();
+        advance_on_unseal(&store, &SCOPE, NAME, SEQUENCE, EPOCH)
+            .await
+            .unwrap();
+        assert_eq!(read_epoch_floor(&store, &SCOPE).await.unwrap(), Some(EPOCH));
+        assert_eq!(sequence_floor(&store, NAME).await.unwrap(), Some(SEQUENCE));
+    });
+}
+
+/// Monotonic-max holds through the atomic batch path: a lower retry never
+/// lowers a floor already raised.
+#[test]
+fn atomic_commit_preserves_monotonic_max() {
+    let store = AtomicFaultyStore::armed();
+    store.disarm();
+    block_on(async {
+        advance_on_unseal(&store, &SCOPE, NAME, SEQUENCE, EPOCH)
+            .await
+            .unwrap();
+        // A stale advance (lower epoch and sequence) is a no-op.
+        advance_on_unseal(&store, &SCOPE, NAME, SEQUENCE - 1, EPOCH - 1)
+            .await
+            .unwrap();
+        assert_eq!(read_epoch_floor(&store, &SCOPE).await.unwrap(), Some(EPOCH));
+        assert_eq!(sequence_floor(&store, NAME).await.unwrap(), Some(SEQUENCE));
+    });
+}

--- a/crates/wasm/src/conformance.rs
+++ b/crates/wasm/src/conformance.rs
@@ -119,6 +119,10 @@ extern "C" {
     ) -> Result<JsValue, JsValue>;
 }
 
+/// The JS `FloorStoreSeam` exposes only per-key methods, so this adapter does
+/// not override `commit_floors`: web batches ride the seam's ordered fail-safe
+/// fallback (#682-safe; web-atomic is deferred — see the trait doc). The
+/// conformance kit's batch assertions therefore exercise that default here.
 struct FloorStoreAdapter {
     js: JsFloorStoreSeam,
 }

--- a/packages/client/src/seams/types.ts
+++ b/packages/client/src/seams/types.ts
@@ -19,6 +19,13 @@
  * Durable monotonic-max per-scope epoch floors and per-name sequence floors.
  * The floor law lives in the engine; this seam only stores (fail-closed
  * regression is a property of `raise*` never lowering a floor).
+ *
+ * Per-key only, by design: there is deliberately no batch/commit method here.
+ * A cross-key floor advance (#685) rides the engine seam's ordered fail-safe
+ * fallback (`FloorStore::commit_floors` default), which commits the
+ * revocation floor first and re-converges idempotently on retry — the #682
+ * mitigation. Web-atomic commit is designed-for but deferred: #685 is a
+ * durability/liveness concern, not a trust hole.
  */
 export interface FloorStoreSeam {
   epochFloor(scopeId: Uint8Array): Promise<number | null>;


### PR DESCRIPTION
## What landed

A floor advance raises several distinctly-keyed floors (read-epoch, write-epoch, per-name sequence) through `FloorStore` as separate seam writes, so a seam I/O error partway through could leave a **partial** floor update. #682 mitigated this without a seam change (fail-safe ordering, monotonic-max, idempotent re-convergence) but could not close it. This slice adds the cross-key atomic commit the seam needs.

## Seam extension (additive)

Extends the (#623-frozen) `FloorStore` seam **additively** — every existing method signature is intact, so concurrent consumers (#628's resolve/publish usage) keep compiling:

- New `commit_floors(&[FloorRaise]) -> SeamResult<Vec<u64>>` batch method with a **default** implementation that applies the raises sequentially in caller order. The default preserves #682's revocation-first fail-safe ordering, so any impl that does not override it (the wasm JS-bridge `FloorStoreAdapter`) is unchanged and needs no TypeScript change.
- New `FloorRaise` + `FloorNamespace` (`Epoch`/`Sequence`) describe one batch entry.

Chosen shape: **batch multi-key set** at the seam, **plus a write-ahead intent record** in the desktop backing (the issue offered either; the desktop file-per-key store cannot transact across files without a journal, so it gets the WAL).

Two backing shapes close the partial-advance hazard, **differently** — the wording matters:

- **Transactional (all-or-nothing).** The `InMemoryFloorStore` fake commits the whole batch under one lock guard, so a seam error leaves no entry changed and no observer ever sees a partial.
- **Roll-forward (write-ahead journal), _not_ rollback.** Desktop `FileFloorStore` fsyncs a write-ahead intent record before any per-key file moves and replays leftover intents on `open`. An advance interrupted between per-key writes leaves the already-written floors in place and **completes forward** on the next open (idempotent monotonic-max) — it heals forward, it never rewinds. An in-process error mid-apply therefore leaves the earlier keys advanced with the intent lingering until reopen; that is the honest WAL semantics, not transactional all-or-nothing.

Each commit writes its own uniquely-named intent file under `intent/`, so overlapping commits neither clobber nor remove one another's recovery record (closes a Greptile P1 crash-consistency hole in the earlier single-shared-intent design).

The engine floor law (`advance_on_unseal`, `cold_seed`) now builds a revocation-first batch and calls `commit_floors`, which subsumes the old split-write ordering.

## Web scope (explicit)

Web is **intentionally** on the non-atomic default fallback: the IndexedDB `FloorStore` seam exposes only per-key methods (no batch on the JS boundary), so a batch degrades to the ordered per-key loop. That stays #682-safe (revocation floor first, monotonic-max, idempotent re-convergence). Web-atomic commit is designed-for but **deferred** — #685 is a durability/liveness concern, not a trust hole, so it is not built here.

## Fault-injection test evidence

`crates/engine/tests/floor_atomic.rs` drives the engine's `advance_on_unseal` through two fault-injecting backings:

- **transactional backing** — an armed fault mid-advance leaves **no** floor moved (all-or-nothing), and a retry converges the whole advance;
- **non-atomic default fallback (negative control)** — the same fault leaves a *partial* advance, proving the hazard is real (this is the "test fails with atomic commit disabled" evidence) while confirming #682's fail-safe ordering (revocation floor committed first) and idempotent re-convergence still hold;
- a third test asserts monotonic-max holds across the atomic batch path.

The desktop **roll-forward** contract is exercised separately in `cipherbox-desktop-seams` (`floor_store` unit tests): an interrupted single-batch commit heals on reopen, **and** two overlapping commits each leave their own intent file which reopen replays without either clobbering the other.

The `floor_store` conformance kit gains `commit_floors` coverage (mixed-namespace batch, monotonic-max within a batch, cross-namespace non-collision, durability across reopen) plus a **retry-convergence** assertion (re-committing the same batch is idempotent) so every real impl — desktop WAL, wasm default, in-memory fake — exercises the convergence property its #685 contract rests on.

## CI gate wiring

Folds into the existing engine job (`cargo test -p cipherbox-engine`) and the workspace `cargo test` job (which covers `cipherbox-desktop-seams`) — no brand-new required check that could deadlock older open PRs. `cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` are clean on the touched crates.

Closes #685


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch floor updates across epoch and sequence values.
  * Added crash recovery so interrupted updates complete automatically when reopened.
  * Ensured repeated updates remain monotonic and safe to retry.

* **Bug Fixes**
  * Prevented partial floor updates during atomic commits.
  * Improved durability and consistency across related floor changes.

* **Documentation**
  * Clarified fallback behavior and durability guarantees for supported adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->