### PR TITLE
feat(engine): build the gated resolve and publish pipeline and liveness jobs

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -28,6 +28,7 @@ pub mod api;
 pub mod entropy;
 pub mod facade;
 pub mod gate;
+pub mod net;
 pub mod profile;
 pub mod seams;
 #[cfg(feature = "test-kit")]
@@ -45,6 +46,10 @@ pub use facade::{
 pub use gate::{
     Adopted, AscentCheck, Candidate, GateError, GateRejection, GateStage, ReaderContext,
     RejectionReason, SeedBlob, SignedStructure, adopt,
+};
+pub use net::{
+    Adopter, HeldRecord, PublishError, PublishOutcome, PublishRequest, RePutResult, ResolveOutcome,
+    Resolved, ReviveError, ReviveRequest, publish, resolve, revive,
 };
 pub use profile::SyncTimingProfile;
 pub use seams::{SeamError, SeamResult, SeamSet, SeamTypes};

--- a/crates/engine/src/net/eol.rs
+++ b/crates/engine/src/net/eol.rs
@@ -1,0 +1,268 @@
+//! EOL policy and the RFC3339 timestamp codec (blueprint/engine.md
+//! "Resolve/publish pipeline: TTL/EOL", "Liveness", #24 D1).
+//!
+//! Every published record carries a 90-day client-signed EOL
+//! ([`cipherbox_core::ipns::DEFAULT_VALIDITY_DAYS`]) as an RFC3339 timestamp in
+//! the signed `data.Validity` field. Core treats the timestamp as opaque bytes
+//! and reads no clock (blueprint/core.md); the engine formats it from the
+//! injected [`Scheduler`](crate::seams::Scheduler) clock here and compares a
+//! resolved record's EOL against the same clock to drive the two liveness
+//! decisions: **renewal** (below the threshold, republish at seq+1) and
+//! **expiry** (a >EOL lapse, revive from the recovery endpoint).
+//!
+//! Determinism: this module reads no wall clock — every function takes the
+//! instant as a [`UnixMillis`] argument sourced from the scheduler seam.
+
+use core::time::Duration;
+
+use cipherbox_core::ipns::DEFAULT_VALIDITY_DAYS;
+
+use crate::seams::UnixMillis;
+
+/// Seconds in one day.
+const SECS_PER_DAY: u64 = 24 * 60 * 60;
+
+/// The sub-EOL renewal window: a name whose record has at or below this much
+/// EOL remaining is republished at seq+1 through the CAS path (blueprint:
+/// "below ~30 days remaining republishes the same CID at seq+1").
+///
+/// Designed-for cadence, not yet a frozen profile constant: like the sweep
+/// cadence (blueprint/engine.md "Open edges"), it joins the sync timing
+/// profile once the testing-strategy measurement process fixes it. The
+/// end-to-end timelines that exercise it run on virtual time, so a real 30-day
+/// value stays fast to test.
+pub const EOL_RENEW_THRESHOLD: Duration = Duration::from_secs(30 * SECS_PER_DAY);
+
+/// The full client-signed EOL window (90 days), as a [`Duration`]. Mirrors
+/// core's [`DEFAULT_VALIDITY_DAYS`] — the policy the engine applies when it
+/// stamps a fresh record.
+pub const EOL_WINDOW: Duration = Duration::from_secs(DEFAULT_VALIDITY_DAYS * SECS_PER_DAY);
+
+/// The RFC3339 EOL string for a record minted at `now`: `now + 90 days`,
+/// formatted UTC at second precision (`YYYY-MM-DDTHH:MM:SSZ`). This is the exact
+/// string handed to [`IpnsRecord::create_v2`](cipherbox_core::ipns::IpnsRecord::create_v2).
+pub fn eol_from(now: UnixMillis) -> String {
+    format_rfc3339(now.saturating_add(EOL_WINDOW))
+}
+
+/// Milliseconds of EOL remaining at `now` for a record whose signed
+/// `Validity` bytes are `validity`. Negative once past the EOL; `None` when the
+/// timestamp does not parse (a malformed record — the caller fails closed).
+pub fn remaining_millis(now: UnixMillis, validity: &[u8]) -> Option<i64> {
+    let eol = parse_rfc3339(validity)?;
+    Some(i64::try_from(eol).unwrap_or(i64::MAX) - i64::try_from(now.0).unwrap_or(i64::MAX))
+}
+
+/// Whether the record has lapsed past its EOL at `now` (a revival trigger). An
+/// unparseable EOL is treated as expired — fail-closed, the record cannot be
+/// trusted to be live.
+pub fn is_expired(now: UnixMillis, validity: &[u8]) -> bool {
+    remaining_millis(now, validity).is_none_or(|remaining| remaining <= 0)
+}
+
+/// Whether the record is still live but within the renewal window at `now`
+/// (a seq+1 republish trigger). A lapsed record is not a renewal case (that is
+/// revival); an unparseable EOL is not renewed here either.
+pub fn needs_renewal(now: UnixMillis, validity: &[u8], threshold: Duration) -> bool {
+    match remaining_millis(now, validity) {
+        Some(remaining) if remaining > 0 => {
+            remaining <= i64::try_from(threshold.as_millis()).unwrap_or(i64::MAX)
+        }
+        _ => false,
+    }
+}
+
+/// Format a UTC instant as `YYYY-MM-DDTHH:MM:SSZ` (second precision). Sub-second
+/// millis are truncated — the EOL policy is day-scale, so second precision
+/// round-trips exactly through [`parse_rfc3339`].
+fn format_rfc3339(instant: UnixMillis) -> String {
+    let total_secs = instant.0 / 1000;
+    let days = (total_secs / SECS_PER_DAY) as i64;
+    let sod = total_secs % SECS_PER_DAY;
+    let (year, month, day) = civil_from_days(days);
+    let (hour, minute, second) = (sod / 3600, (sod % 3600) / 60, sod % 60);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+/// Parse an RFC3339 UTC timestamp (`YYYY-MM-DDTHH:MM:SS[.frac]Z`) to Unix
+/// milliseconds. Accepts an optional fractional-second part (millisecond
+/// precision retained, finer digits truncated) and requires the trailing `Z`
+/// (records are always minted UTC). `None` on any structural defect.
+fn parse_rfc3339(bytes: &[u8]) -> Option<u64> {
+    let text = core::str::from_utf8(bytes).ok()?;
+    let (date, rest) = text.split_once('T')?;
+    let mut date_parts = date.split('-');
+    let year: i64 = date_parts.next()?.parse().ok()?;
+    let month: u32 = parse_2(date_parts.next()?)?;
+    let day: u32 = parse_2(date_parts.next()?)?;
+    if date_parts.next().is_some() || !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+
+    let time = rest.strip_suffix('Z')?;
+    // Split off an optional fractional-second part; keep at most 3 digits (ms).
+    let (clock, frac) = match time.split_once('.') {
+        Some((clock, frac)) => (clock, frac),
+        None => (time, ""),
+    };
+    let mut clock_parts = clock.split(':');
+    let hour: u64 = parse_2(clock_parts.next()?)?.into();
+    let minute: u64 = parse_2(clock_parts.next()?)?.into();
+    let second: u64 = parse_2(clock_parts.next()?)?.into();
+    if clock_parts.next().is_some() || hour > 23 || minute > 59 || second > 60 {
+        return None;
+    }
+    let millis_frac = fractional_millis(frac)?;
+
+    let days = days_from_civil(year, month, day);
+    let total_secs =
+        days.checked_mul(SECS_PER_DAY as i64)? + (hour * 3600 + minute * 60 + second) as i64;
+    let total_millis = total_secs.checked_mul(1000)? + millis_frac as i64;
+    u64::try_from(total_millis).ok()
+}
+
+/// Parse an exactly-two-ASCII-digit field.
+fn parse_2(field: &str) -> Option<u32> {
+    if field.len() != 2 {
+        return None;
+    }
+    field.parse().ok()
+}
+
+/// Millisecond value of a fractional-second string of ASCII digits (`""` → 0).
+/// Only the first three digits contribute; the rest are truncated.
+fn fractional_millis(frac: &str) -> Option<u32> {
+    if !frac.is_empty() && !frac.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let mut millis = 0u32;
+    for i in 0..3 {
+        millis = millis * 10 + frac.as_bytes().get(i).map_or(0, |b| u32::from(b - b'0'));
+    }
+    Some(millis)
+}
+
+// Civil-date conversions (Howard Hinnant's algorithms): days since the Unix
+// epoch ⇄ (year, month, day) in the proleptic Gregorian calendar, exact for the
+// full u64-millis range the record EOL ever spans.
+
+/// Days since 1970-01-01 for a civil date.
+fn days_from_civil(y: i64, m: u32, d: u32) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let m = i64::from(m);
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + i64::from(d) - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe - 719468
+}
+
+/// The civil date `z` days after 1970-01-01.
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_parse_round_trips_at_second_precision() {
+        // A handful of instants across days, months, years, leap years.
+        for millis in [
+            0u64,
+            1_000,
+            86_400_000,
+            1_700_000_000_000,
+            1_800_000_000_000,
+            4_102_444_800_000, // 2100-01-01
+        ] {
+            let s = format_rfc3339(UnixMillis(millis));
+            let back = parse_rfc3339(s.as_bytes()).expect("our own format parses");
+            assert_eq!(
+                back,
+                (millis / 1000) * 1000,
+                "round-trip at second precision: {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn epoch_is_the_expected_string() {
+        assert_eq!(format_rfc3339(UnixMillis(0)), "1970-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn known_timestamp_formats_correctly() {
+        // 2023-11-14T22:13:20Z
+        assert_eq!(
+            format_rfc3339(UnixMillis(1_700_000_000_000)),
+            "2023-11-14T22:13:20Z"
+        );
+    }
+
+    #[test]
+    fn parses_core_style_nanosecond_fraction() {
+        // The form core's own tests emit — fractional seconds must be accepted.
+        let millis = parse_rfc3339(b"2026-10-18T00:00:00.000000000Z").expect("parses");
+        assert_eq!(format_rfc3339(UnixMillis(millis)), "2026-10-18T00:00:00Z");
+    }
+
+    #[test]
+    fn eol_from_is_ninety_days_ahead() {
+        let now = UnixMillis(1_700_000_000_000);
+        let eol = eol_from(now);
+        let eol_millis = parse_rfc3339(eol.as_bytes()).unwrap();
+        assert_eq!(eol_millis - now.0, 90 * SECS_PER_DAY * 1000);
+    }
+
+    #[test]
+    fn remaining_expiry_and_renewal_transitions() {
+        let now = UnixMillis(1_700_000_000_000);
+        let eol = eol_from(now); // now + 90 days
+        let v = eol.as_bytes();
+
+        // At mint time: ~90 days remaining, live, no renewal.
+        assert!(remaining_millis(now, v).unwrap() > 0);
+        assert!(!is_expired(now, v));
+        assert!(!needs_renewal(now, v, EOL_RENEW_THRESHOLD));
+
+        // 65 days in (25 days remaining): live, renewal due.
+        let t65 = now.saturating_add(Duration::from_secs(65 * SECS_PER_DAY));
+        assert!(!is_expired(t65, v));
+        assert!(needs_renewal(t65, v, EOL_RENEW_THRESHOLD));
+
+        // 91 days in: lapsed — expiry, never renewal.
+        let t91 = now.saturating_add(Duration::from_secs(91 * SECS_PER_DAY));
+        assert!(is_expired(t91, v));
+        assert!(!needs_renewal(t91, v, EOL_RENEW_THRESHOLD));
+    }
+
+    #[test]
+    fn unparseable_validity_is_expired_and_not_renewable() {
+        let now = UnixMillis(1_700_000_000_000);
+        assert!(remaining_millis(now, b"not-a-timestamp").is_none());
+        assert!(is_expired(now, b"not-a-timestamp"));
+        assert!(!needs_renewal(now, b"not-a-timestamp", EOL_RENEW_THRESHOLD));
+    }
+
+    #[test]
+    fn parse_rejects_missing_zone_and_malformed_fields() {
+        assert!(parse_rfc3339(b"2026-10-18T00:00:00").is_none(), "no Z");
+        assert!(parse_rfc3339(b"2026-13-01T00:00:00Z").is_none(), "month 13");
+        assert!(parse_rfc3339(b"2026-10-18T24:00:00Z").is_none(), "hour 24");
+        assert!(
+            parse_rfc3339(b"2026-1-1T0:0:0Z").is_none(),
+            "unpadded fields"
+        );
+    }
+}

--- a/crates/engine/src/net/eol.rs
+++ b/crates/engine/src/net/eol.rs
@@ -95,7 +95,12 @@ fn parse_rfc3339(bytes: &[u8]) -> Option<u64> {
     let year: i64 = date_parts.next()?.parse().ok()?;
     let month: u32 = parse_2(date_parts.next()?)?;
     let day: u32 = parse_2(date_parts.next()?)?;
-    if date_parts.next().is_some() || !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+    // Reject out-of-range calendar dates outright — an invalid day (e.g. Feb 30)
+    // must fail closed, never silently normalize into the next month.
+    if date_parts.next().is_some()
+        || !(1..=12).contains(&month)
+        || !(1..=days_in_month(year, month)).contains(&day)
+    {
         return None;
     }
 
@@ -140,6 +145,22 @@ fn fractional_millis(frac: &str) -> Option<u32> {
         millis = millis * 10 + frac.as_bytes().get(i).map_or(0, |b| u32::from(b - b'0'));
     }
     Some(millis)
+}
+
+/// Proleptic-Gregorian leap year.
+fn is_leap_year(year: i64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+/// Days in a validated `month` (1-12) of `year` — 29 for a leap February.
+fn days_in_month(year: i64, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
 }
 
 // Civil-date conversions (Howard Hinnant's algorithms): days since the Unix
@@ -263,6 +284,33 @@ mod tests {
         assert!(
             parse_rfc3339(b"2026-1-1T0:0:0Z").is_none(),
             "unpadded fields"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_out_of_range_calendar_dates() {
+        // An invalid day for the month must fail closed, never normalize forward.
+        assert!(parse_rfc3339(b"2026-02-30T00:00:00Z").is_none(), "Feb 30");
+        assert!(
+            parse_rfc3339(b"2025-02-29T00:00:00Z").is_none(),
+            "Feb 29 in a non-leap year"
+        );
+        assert!(parse_rfc3339(b"2026-04-31T00:00:00Z").is_none(), "Apr 31");
+        assert!(parse_rfc3339(b"2026-01-32T00:00:00Z").is_none(), "Jan 32");
+        assert!(parse_rfc3339(b"2026-01-00T00:00:00Z").is_none(), "day 00");
+        // Genuine leap-day and month-length boundaries still parse.
+        assert!(
+            parse_rfc3339(b"2024-02-29T00:00:00Z").is_some(),
+            "Feb 29 in a leap year"
+        );
+        assert!(parse_rfc3339(b"2026-04-30T00:00:00Z").is_some(), "Apr 30");
+        assert!(
+            parse_rfc3339(b"2000-02-29T00:00:00Z").is_some(),
+            "Feb 29 2000"
+        );
+        assert!(
+            parse_rfc3339(b"1900-02-29T00:00:00Z").is_none(),
+            "1900 is not a leap year (century, not 400)"
         );
     }
 }

--- a/crates/engine/src/net/fanout.rs
+++ b/crates/engine/src/net/fanout.rs
@@ -1,0 +1,117 @@
+//! Endpoint-set fan-out primitives shared by the resolve, publish, and liveness
+//! paths (blueprint/engine.md "Resolve/publish pipeline").
+//!
+//! The engine owns IPNS end-to-end over dumb `/routing/v1` transports (#28 D2):
+//! core signs and verifies, the [`RecordTransport`] seam only moves bytes, and
+//! every decision — which endpoint's copy is freshest, when a PUT has succeeded,
+//! which endpoints still need a retry — lives here.
+
+use core::future::poll_fn;
+use core::task::Poll;
+
+use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+
+use crate::seams::{EndpointId, RecordTransport};
+
+/// The outcome of a parallel PUT across the endpoint set.
+pub struct Fanout {
+    /// Endpoints that acknowledged the PUT.
+    pub acked: Vec<EndpointId>,
+    /// Endpoints that failed or had not answered when the first ack returned —
+    /// the set a background retry re-PUTs (blueprint: "remaining PUTs retry in
+    /// the background").
+    pub not_acked: Vec<EndpointId>,
+}
+
+impl Fanout {
+    /// Whether any endpoint acknowledged: the publish success condition
+    /// (blueprint: "success = any ack").
+    pub fn any_acked(&self) -> bool {
+        !self.acked.is_empty()
+    }
+}
+
+/// PUT `bytes` for `key` to every endpoint concurrently, returning as soon as
+/// one endpoint acknowledges — the remaining endpoints (failed or still
+/// in-flight) come back in [`Fanout::not_acked`] for a background retry. When
+/// every endpoint settles with no ack, `acked` is empty and the caller fails
+/// closed.
+pub async fn fanout_put<T: RecordTransport>(transport: &T, key: &str, bytes: &[u8]) -> Fanout {
+    let endpoints = transport.endpoints();
+    let mut futs: Vec<_> = endpoints
+        .iter()
+        .map(|endpoint| Box::pin(transport.put_record(endpoint, key, bytes)))
+        .collect();
+    // Per-endpoint settle state: `Some(true)` acked, `Some(false)` failed,
+    // `None` still pending.
+    let mut status: Vec<Option<bool>> = vec![None; futs.len()];
+
+    poll_fn(|cx| {
+        let mut all_settled = true;
+        for (index, fut) in futs.iter_mut().enumerate() {
+            if status[index].is_some() {
+                continue;
+            }
+            match fut.as_mut().poll(cx) {
+                Poll::Ready(Ok(())) => status[index] = Some(true),
+                Poll::Ready(Err(_)) => status[index] = Some(false),
+                Poll::Pending => all_settled = false,
+            }
+        }
+        // Return the instant one endpoint acks, or once every endpoint settled.
+        if status.contains(&Some(true)) || all_settled {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    })
+    .await;
+
+    let mut acked = Vec::new();
+    let mut not_acked = Vec::new();
+    for (index, endpoint) in endpoints.iter().enumerate() {
+        if status[index] == Some(true) {
+            acked.push(endpoint.clone());
+        } else {
+            not_acked.push(endpoint.clone());
+        }
+    }
+    Fanout { acked, not_acked }
+}
+
+/// Fan-out GET across the endpoint set and core-verify each returned record
+/// against `name`, returning the freshest verified `(sequence, record_bytes)`
+/// or `None` when no endpoint serves a verifiable record. A malformed or
+/// signature-invalid copy at one endpoint is ignored (an accelerator can serve
+/// stale garbage); a per-endpoint transport error is tolerated as availability
+/// staleness — only genuine host failure is surfaced.
+///
+/// This is the record-plane verify step (core's Ed25519-from-the-name chain);
+/// the full adoption gate runs downstream on the chosen bytes.
+pub async fn fanout_get_verify<T: RecordTransport>(
+    transport: &T,
+    name: &IpnsName,
+) -> Option<(u64, Vec<u8>)> {
+    let key = name.as_str();
+    let mut best: Option<(u64, Vec<u8>)> = None;
+    for endpoint in transport.endpoints() {
+        // A per-endpoint transport error is availability staleness, not a trust
+        // decision: skip it and keep the freshest copy the other endpoints hold.
+        let Ok(Some(bytes)) = transport.get_record(&endpoint, key).await else {
+            continue;
+        };
+        let Ok(record) = IpnsRecord::unmarshal(&bytes) else {
+            continue;
+        };
+        let Ok(verified) = record.verify(name) else {
+            continue;
+        };
+        if best
+            .as_ref()
+            .is_none_or(|(seq, _)| verified.sequence > *seq)
+        {
+            best = Some((verified.sequence, bytes));
+        }
+    }
+    best
+}

--- a/crates/engine/src/net/liveness.rs
+++ b/crates/engine/src/net/liveness.rs
@@ -1,0 +1,128 @@
+//! The engine's half of the two re-PUT layers (blueprint/engine.md
+//! "Resolve/publish pipeline: Liveness", #24 D2/D5).
+//!
+//! Two jobs keep a session's records alive without depending on the API's
+//! background loop (no client resolve path ever touches the API's record cache,
+//! #24 D3):
+//!
+//! - **Keyless re-PUT** ([`keyless_re_put`]): an ~hourly Scheduler job that
+//!   re-PUTs every record the session holds, byte-for-byte with no key material
+//!   (core's keyless marshal, blueprint/core.md), so actively used vaults keep
+//!   themselves alive on endpoints that may have dropped the record.
+//! - **Sub-EOL renewal** ([`eol_republish`]): on session start and periodically,
+//!   a name with below-threshold EOL remaining is republished at seq+1 through
+//!   the normal CAS path with a fresh 90-day EOL.
+//!
+//! The API republisher (~12 h inventory walk) backstops dormant vaults only.
+
+use core::time::Duration;
+
+use cipherbox_core::ipns::IpnsRecord;
+
+use super::eol::{self, EOL_RENEW_THRESHOLD};
+use super::fanout::{fanout_get_verify, fanout_put};
+use super::publish::{PublishError, PublishOutcome, PublishRequest, publish};
+use crate::api::ApiClient;
+use crate::profile::SyncTimingProfile;
+use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
+
+/// The ~hourly cadence of the keyless re-PUT job (blueprint: "an ~hourly
+/// Scheduler job keyless-re-PUTs every record the session holds").
+///
+/// Designed-for cadence, not yet a frozen profile constant — like the sweep
+/// cadence (blueprint/engine.md "Open edges"), it joins the sync timing profile
+/// once measured. The facade slice wraps the job body below in a
+/// `Scheduler`-driven loop at this cadence.
+pub const RE_PUT_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+/// One held record to keep alive: its routing key (the `ipnsName`) and the exact
+/// signed record bytes the session last held for it.
+pub struct HeldRecord {
+    /// The routing key — the record's `ipnsName`.
+    pub routing_key: String,
+    /// The signed record bytes (re-PUT verbatim; keyless).
+    pub record_bytes: Vec<u8>,
+}
+
+/// The result of re-PUTting one held record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RePutResult {
+    /// The routing key re-PUT.
+    pub routing_key: String,
+    /// Whether at least one endpoint acknowledged (the record stays alive).
+    pub kept_alive: bool,
+}
+
+/// Run one pass of the keyless re-PUT job over the records the session holds:
+/// re-PUT each byte-for-byte to the endpoint set. Keyless — no signing key is
+/// touched; a malformed held record (which cannot round-trip core's byte-stable
+/// marshal) is skipped rather than re-PUT.
+///
+/// This is the job **body**; the ~hourly [`Scheduler`] loop that drives it at
+/// [`RE_PUT_INTERVAL`] is wired by the facade.
+pub async fn keyless_re_put<T: RecordTransport>(
+    transport: &T,
+    held: &[HeldRecord],
+) -> Vec<RePutResult> {
+    let mut results = Vec::with_capacity(held.len());
+    for record in held {
+        // Byte-stable keyless re-PUT (blueprint/core.md): a record that does not
+        // round-trip marshal is not a record we can keep alive — skip it.
+        let bytes = match IpnsRecord::unmarshal(&record.record_bytes) {
+            Ok(parsed) => parsed.marshal(),
+            Err(_) => {
+                results.push(RePutResult {
+                    routing_key: record.routing_key.clone(),
+                    kept_alive: false,
+                });
+                continue;
+            }
+        };
+        let fanout = fanout_put(transport, &record.routing_key, &bytes).await;
+        results.push(RePutResult {
+            routing_key: record.routing_key.clone(),
+            kept_alive: fanout.any_acked(),
+        });
+    }
+    results
+}
+
+/// Republish `request`'s name at seq+1 with a fresh 90-day EOL **iff** its
+/// current record is still live but within the renewal window
+/// ([`EOL_RENEW_THRESHOLD`]). Returns `Ok(None)` when the record's EOL is
+/// comfortably ahead (no renewal needed) or when no current record can be
+/// resolved to inspect. A lapsed record is out of scope here — that is revival.
+pub async fn eol_republish<T, H, C, F, Sch>(
+    transport: &T,
+    api: &ApiClient<H, C>,
+    floors: &F,
+    scheduler: &Sch,
+    profile: &SyncTimingProfile,
+    request: &PublishRequest<'_>,
+) -> Result<Option<PublishOutcome>, PublishError>
+where
+    T: RecordTransport + Clone + 'static,
+    H: Http,
+    C: CredentialStore,
+    F: FloorStore,
+    Sch: Scheduler + Clone + 'static,
+{
+    // Inspect the name's current record EOL against the injected clock.
+    let Some((_sequence, bytes)) = fanout_get_verify(transport, request.name).await else {
+        return Ok(None);
+    };
+    let Ok(record) = IpnsRecord::unmarshal(&bytes) else {
+        return Ok(None);
+    };
+    let Ok(verified) = record.verify(request.name) else {
+        return Ok(None);
+    };
+    if !eol::needs_renewal(scheduler.now(), &verified.validity, EOL_RENEW_THRESHOLD) {
+        return Ok(None);
+    }
+
+    // Republish the same content at seq+1 (floor + 1) with a fresh EOL.
+    publish(transport, api, floors, scheduler, profile, request)
+        .await
+        .map(Some)
+}

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -1,0 +1,43 @@
+//! The net plane: the gated resolve/publish pipeline, CAS, endpoint fan-out,
+//! and the liveness jobs (blueprint/engine.md "Resolve/publish pipeline").
+//!
+//! The engine owns IPNS end-to-end over dumb `/routing/v1` transports (#28 D2):
+//! core signs and verifies, the [`RecordTransport`](crate::seams::RecordTransport)
+//! seam only moves bytes, and every decision — cache-first rendering, which
+//! endpoint's copy is freshest, register-first ordering, CAS sequencing,
+//! confirm-by-re-resolve, when to re-PUT or renew or revive — lives here.
+//!
+//! - [`resolve`] — cache-first resolve: last-known-good renders immediately, a
+//!   fan-out GET + core verify picks the freshest record, and the adoption gate
+//!   runs on **every** resolve (through the [`resolve::Adopter`] seam); only a
+//!   gate-passing record touches the snapshot.
+//! - [`publish`] — register-first, fail-closed publish: core-signed with the
+//!   exact CAS sequence, parallel PUT with any-ack success + background retry,
+//!   and confirm-by-re-resolve with lost-race detection.
+//! - [`liveness`] — the ~hourly keyless re-PUT job and the sub-EOL seq+1
+//!   renewal.
+//! - [`revival`] — re-mint after a >EOL lapse via the recovery endpoint.
+//! - [`retire`] — registry-row retirement (root linger stubbed on the open-edge
+//!   migration-window constant).
+//! - [`eol`] — the 90-day EOL policy and RFC3339 codec, off the injected clock.
+//!
+//! What this slice deliberately does not land: rebase (a lost race is reported,
+//! not rebased) and the pointer planes (the re-point channels). The seams for
+//! both are left where the blueprint expects them — [`resolve::Adopter`] fronts
+//! the content/pointer/key assembly, and a lost race surfaces as
+//! [`publish::PublishOutcome::LostRace`] for the rebase slice.
+
+mod fanout;
+
+pub mod eol;
+pub mod liveness;
+pub mod publish;
+pub mod resolve;
+pub mod retire;
+pub mod revival;
+
+pub use liveness::{HeldRecord, RE_PUT_INTERVAL, RePutResult, eol_republish, keyless_re_put};
+pub use publish::{PublishError, PublishOutcome, PublishRequest, publish};
+pub use resolve::{Adopter, ResolveOutcome, Resolved, resolve};
+pub use retire::{retire, root_retire_ready};
+pub use revival::{ReviveError, ReviveRequest, revive};

--- a/crates/engine/src/net/publish.rs
+++ b/crates/engine/src/net/publish.rs
@@ -20,7 +20,9 @@ use super::eol;
 use super::fanout::{fanout_get_verify, fanout_put};
 use crate::api::{ApiClient, ApiError, NameRegistration};
 use crate::profile::SyncTimingProfile;
-use crate::seams::{CredentialStore, EndpointId, FloorStore, Http, RecordTransport, Scheduler};
+use crate::seams::{
+    CredentialStore, EndpointId, FloorStore, Http, RecordTransport, Scheduler, SeamError,
+};
 
 /// The `/ipfs/` path prefix a record's `Value` carries in front of the head CID.
 const IPFS_PREFIX: &str = "/ipfs/";
@@ -97,6 +99,10 @@ pub enum PublishError {
     /// No endpoint acknowledged the record PUT (the whole endpoint set is
     /// unreachable). Nothing durable happened; the caller retries later.
     AllEndpointsFailed,
+    /// The durable sequence floor could not be read. A floor-read failure is a
+    /// fail-closed trust event, never "no floor": publish stops rather than mint
+    /// a sequence from assumed-empty state (blueprint/engine.md floor law).
+    FloorRead(SeamError),
 }
 
 /// Run the publish pipeline for `request`. Register-first and fail-closed:
@@ -124,12 +130,14 @@ where
 
     // CAS expected sequence: floor + 1 (first publish → 1, the "no floor" 0
     // sentinel reserved). Revival raises the floor read to the recovered
-    // sequence so the re-mint is strictly newer than what lapsed.
+    // sequence so the re-mint is strictly newer than what lapsed. A floor-read
+    // failure is fail-closed — only a successful read with no floor defaults to
+    // 0 (blueprint/engine.md floor law).
     let name_bytes = request.name.as_str().as_bytes();
     let durable = floors
         .sequence_floor(name_bytes)
         .await
-        .map(|floor| floor.unwrap_or(0))
+        .map_err(PublishError::FloorRead)?
         .unwrap_or(0);
     let sequence = durable.max(request.min_current_sequence.unwrap_or(0)) + 1;
 

--- a/crates/engine/src/net/publish.rs
+++ b/crates/engine/src/net/publish.rs
@@ -1,0 +1,220 @@
+//! The publish pipeline: register-first, core-signed, parallel PUT with
+//! any-ack success + background retry, and confirm-by-re-resolve
+//! (blueprint/engine.md "Resolve/publish pipeline: Publish", #23 D3/D4,
+//! #34 D2, #24 D6).
+//!
+//! Register-first is built into the pipeline, not left to callers (#28 D5):
+//! the API registration precedes the record PUT and publish blocks on it, so
+//! an unregistered name never reaches the transport (fail-closed). Core signs
+//! (first publish embeds sequence 1; a CAS publish embeds the exact expected
+//! sequence = durable floor + 1), then a parallel PUT fans out to every
+//! endpoint — success is the first ack, the rest retry in the background — and
+//! a confirm-by-re-resolve detects a lost CAS race for the caller to rebase.
+
+use core::time::Duration;
+
+use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::suite::ed25519::Ed25519Signer;
+
+use super::eol;
+use super::fanout::{fanout_get_verify, fanout_put};
+use crate::api::{ApiClient, ApiError, NameRegistration};
+use crate::profile::SyncTimingProfile;
+use crate::seams::{CredentialStore, EndpointId, FloorStore, Http, RecordTransport, Scheduler};
+
+/// The `/ipfs/` path prefix a record's `Value` carries in front of the head CID.
+const IPFS_PREFIX: &str = "/ipfs/";
+
+/// Bounded background re-PUT attempts for endpoints that missed the first ack.
+/// Liveness is backstopped by the ~hourly keyless re-PUT job and the API
+/// republisher, so this loop stays short — it closes the common transient gap,
+/// not a durability guarantee.
+const MAX_REPUT_ATTEMPTS: u32 = 3;
+
+/// One publish request: the name and its node signing key, the head (metadata)
+/// CID to point at, and the content CIDs to register for pinning.
+pub struct PublishRequest<'a> {
+    /// The IPNS name being published (its Ed25519 key is [`Self::signer`]'s).
+    pub name: &'a IpnsName,
+    /// The node's Ed25519 signing key (derived in the key-lifecycle slice;
+    /// injected here so this slice owns no key derivation).
+    pub signer: &'a Ed25519Signer,
+    /// The head/metadata CID this record points at (`Value = /ipfs/<head_cid>`).
+    pub head_cid: String,
+    /// The content CIDs to register/pin under this name.
+    pub content_cids: Vec<String>,
+    /// Raises the CAS expected-current sequence to at least this value before
+    /// the +1. Normal writes pass `None` and derive it from the durable floor;
+    /// revival passes the sequence recovered from the last-known record so the
+    /// re-minted record is strictly newer than what lapsed.
+    pub min_current_sequence: Option<u64>,
+}
+
+impl PublishRequest<'_> {
+    /// The record `Value` bytes: `/ipfs/<head_cid>`.
+    fn value(&self) -> Vec<u8> {
+        format!("{IPFS_PREFIX}{}", self.head_cid).into_bytes()
+    }
+
+    /// The single-item registration batch for this publish (ordinary writes
+    /// register one name; name waves and sweeps batch — that is the caller's
+    /// concern, blueprint/engine.md).
+    fn registration(&self) -> NameRegistration {
+        NameRegistration {
+            ipns_name: self.name.as_str().to_owned(),
+            head_cid: Some(self.head_cid.clone()),
+            content_cids: self.content_cids.clone(),
+        }
+    }
+}
+
+/// The result of a completed publish.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PublishOutcome {
+    /// The record landed and confirm-by-re-resolve saw it as the freshest
+    /// record at the name.
+    Published {
+        /// The sequence embedded in the published record.
+        sequence: u64,
+    },
+    /// A concurrent writer's record at a strictly higher sequence was observed
+    /// on the confirm re-resolve: a lost CAS race. The caller re-resolves and
+    /// rebases (rebase is a later slice; this slice only reports the race).
+    LostRace {
+        /// The sequence this publish embedded.
+        published_sequence: u64,
+        /// The higher sequence a concurrent writer landed first.
+        observed_sequence: u64,
+    },
+}
+
+/// A fail-closed publish failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PublishError {
+    /// Register-first failed: the API rejected (or could not reach) the
+    /// registration, so no record was PUT — the fail-closed ordering law.
+    Register(ApiError),
+    /// No endpoint acknowledged the record PUT (the whole endpoint set is
+    /// unreachable). Nothing durable happened; the caller retries later.
+    AllEndpointsFailed,
+}
+
+/// Run the publish pipeline for `request`. Register-first and fail-closed:
+/// on a registration failure nothing is PUT.
+pub async fn publish<T, H, C, F, Sch>(
+    transport: &T,
+    api: &ApiClient<H, C>,
+    floors: &F,
+    scheduler: &Sch,
+    profile: &SyncTimingProfile,
+    request: &PublishRequest<'_>,
+) -> Result<PublishOutcome, PublishError>
+where
+    T: RecordTransport + Clone + 'static,
+    H: Http,
+    C: CredentialStore,
+    F: FloorStore,
+    Sch: Scheduler + Clone + 'static,
+{
+    // Register-first, fail-closed: the record never reaches the transport unless
+    // the registration succeeds (#24 D6 / #34 D2).
+    api.register(std::slice::from_ref(&request.registration()))
+        .await
+        .map_err(PublishError::Register)?;
+
+    // CAS expected sequence: floor + 1 (first publish → 1, the "no floor" 0
+    // sentinel reserved). Revival raises the floor read to the recovered
+    // sequence so the re-mint is strictly newer than what lapsed.
+    let name_bytes = request.name.as_str().as_bytes();
+    let durable = floors
+        .sequence_floor(name_bytes)
+        .await
+        .map(|floor| floor.unwrap_or(0))
+        .unwrap_or(0);
+    let sequence = durable.max(request.min_current_sequence.unwrap_or(0)) + 1;
+
+    // Core signs; the engine injects the explicit TTL (from the profile, never a
+    // library default) and the 90-day client-signed EOL (from the injected clock).
+    let ttl_nanos = u64::try_from(profile.record_ttl.as_nanos()).unwrap_or(u64::MAX);
+    let eol = eol::eol_from(scheduler.now());
+    let record_bytes =
+        IpnsRecord::create_v2(request.signer, &request.value(), sequence, ttl_nanos, &eol)
+            .marshal();
+
+    // Parallel PUT: success is the first ack; the rest retry in the background.
+    let key = request.name.as_str();
+    let fanout = fanout_put(transport, key, &record_bytes).await;
+    if !fanout.any_acked() {
+        return Err(PublishError::AllEndpointsFailed);
+    }
+    if !fanout.not_acked.is_empty() {
+        spawn_background_reput(
+            transport.clone(),
+            scheduler.clone(),
+            key.to_owned(),
+            record_bytes.clone(),
+            fanout.not_acked,
+            profile.poll_cadence,
+        );
+    }
+
+    // Confirm by re-resolve: a strictly higher record means a concurrent writer
+    // won the CAS race; anything else confirms our record landed.
+    let observed = fanout_get_verify(transport, request.name).await;
+    let outcome = match observed {
+        Some((observed_sequence, _)) if observed_sequence > sequence => PublishOutcome::LostRace {
+            published_sequence: sequence,
+            observed_sequence,
+        },
+        _ => PublishOutcome::Published { sequence },
+    };
+    Ok(outcome)
+}
+
+/// Spawn the background re-PUT for endpoints that missed the first ack: sleep a
+/// poll cadence, re-PUT the still-missing endpoints (idempotent), repeat up to
+/// [`MAX_REPUT_ATTEMPTS`]. Fire-and-forget on the [`Scheduler`] — the publish
+/// already succeeded on the first ack.
+fn spawn_background_reput<T, Sch>(
+    transport: T,
+    scheduler: Sch,
+    key: String,
+    record_bytes: Vec<u8>,
+    mut remaining: Vec<EndpointId>,
+    retry_delay: Duration,
+) where
+    T: RecordTransport + 'static,
+    Sch: Scheduler + Clone + 'static,
+{
+    let task_scheduler = scheduler.clone();
+    scheduler.spawn(Box::pin(async move {
+        for _ in 0..MAX_REPUT_ATTEMPTS {
+            if remaining.is_empty() {
+                return;
+            }
+            task_scheduler.sleep(retry_delay).await;
+            let mut still_missing = Vec::new();
+            for endpoint in remaining {
+                if transport
+                    .put_record(&endpoint, &key, &record_bytes)
+                    .await
+                    .is_err()
+                {
+                    still_missing.push(endpoint);
+                }
+            }
+            remaining = still_missing;
+        }
+    }));
+}
+
+/// Extract the head CID from a record `Value` (`/ipfs/<cid>`). `None` when the
+/// value is not an `/ipfs/` path — a malformed record, handled fail-closed by
+/// the caller.
+pub(super) fn head_cid_from_value(value: &[u8]) -> Option<String> {
+    core::str::from_utf8(value)
+        .ok()?
+        .strip_prefix(IPFS_PREFIX)
+        .filter(|cid| !cid.is_empty())
+        .map(str::to_owned)
+}

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -1,0 +1,111 @@
+//! The resolve pipeline: cache-first, fan-out GET, core verify, adoption gate
+//! on every resolve (blueprint/engine.md "Resolve/publish pipeline: Resolve",
+//! #23 D5, #33 D7).
+//!
+//! Cache-first — the UI never blocks on network resolution: last-known-good
+//! renders immediately and the network reconcile runs behind it. A fan-out GET
+//! collects the endpoint set's copies, core verifies each against the name, and
+//! the freshest verified record passes the adoption gate. Only a gate-passing
+//! record touches the snapshot; a gate failure is a fail-closed trust violation
+//! that pins last-known-good and never renders the rejected record.
+//!
+//! The gate itself is a composition over content-plane and reader state that
+//! lands with the content/pointer/grants and key-lifecycle slices, so this slice
+//! reaches it through the [`Adopter`] seam. The pipeline's contract is fixed
+//! now: **every** fetched record is routed through [`Adopter::adopt`] — there is
+//! no ungated path to the snapshot.
+
+use cipherbox_core::ipns::IpnsName;
+
+use super::fanout::fanout_get_verify;
+use crate::gate::{Adopted, GateError, GateRejection, RejectionReason};
+use crate::seams::{RecordTransport, SeamError, SnapshotCache};
+
+/// Runs the adoption gate over a fetched record. The concrete implementation
+/// assembles the content-plane candidate and the reader's private context and
+/// calls [`crate::gate::adopt`]; it lands with the content/pointer/grants and
+/// key-lifecycle slices. The resolve pipeline requires only this: every record
+/// it fetches is adopted through here before it can touch the snapshot
+/// (blueprint/engine.md: "only gate-passing records touch the snapshot").
+pub trait Adopter {
+    /// Assemble and gate the record fetched under `name`. `Ok` carries the
+    /// authenticated read-body and floors; `Err(GateError::Rejected)` is a
+    /// fail-closed trust violation; `Err(GateError::Seam)` is host I/O.
+    async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<Adopted, GateError>;
+}
+
+/// What a resolve produced for the freshest fetched record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveOutcome {
+    /// A newer record passed the adoption gate: its bytes are now the snapshot's
+    /// last-known-good and the read-body is authenticated.
+    Adopted(Adopted),
+    /// The freshest fetched record failed the gate — a fail-closed trust
+    /// violation. Last-known-good is pinned; the rejected record is never
+    /// rendered.
+    TrustViolation(GateRejection),
+    /// No newer record was fetched: either nothing resolvable (network
+    /// unreachable / cold) or only a copy at or below the current record. This
+    /// is availability staleness, not an error — the cached view stays usable.
+    NoUpdate,
+}
+
+/// The result of a resolve: the cache-first last-known-good plus the network
+/// reconcile outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Resolved {
+    /// Last-known-good record bytes from the snapshot cache, rendered
+    /// immediately (cache-first). `None` on a cold cache.
+    pub last_known_good: Option<Vec<u8>>,
+    /// The gate verdict on the freshest fetched record.
+    pub outcome: ResolveOutcome,
+}
+
+/// Resolve `name`: return last-known-good immediately, fan-out GET + core
+/// verify, then the adoption gate on the freshest verified record; only a
+/// gate-passing record is written back to the snapshot. A [`SeamError`] is a
+/// genuine host durable-store failure (the snapshot cache, or a floor read
+/// inside the gate); per-endpoint transport failures are tolerated upstream as
+/// availability staleness.
+pub async fn resolve<T, S, A>(
+    transport: &T,
+    snapshot_cache: &S,
+    adopter: &A,
+    name: &IpnsName,
+) -> Result<Resolved, SeamError>
+where
+    T: RecordTransport,
+    S: SnapshotCache,
+    A: Adopter,
+{
+    let cache_key = name.as_str().as_bytes();
+    // Cache-first: last-known-good renders immediately, reconcile runs behind it.
+    let last_known_good = snapshot_cache.get(cache_key).await?;
+
+    let outcome = match fanout_get_verify(transport, name).await {
+        None => ResolveOutcome::NoUpdate,
+        Some((_sequence, bytes)) => match adopter.adopt(name, &bytes).await {
+            Ok(adopted) => {
+                // Only gate-passing records touch the snapshot.
+                snapshot_cache.put(cache_key, &bytes).await?;
+                ResolveOutcome::Adopted(adopted)
+            }
+            // A record at exactly the durable sequence floor is our own current
+            // record re-fetched — no update, never a violation. A strictly older
+            // sequence is a replay/rollback and stays a fail-closed trust
+            // violation, as does every other gate rejection.
+            Err(GateError::Rejected(rejection)) => match &rejection.reason {
+                RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor => {
+                    ResolveOutcome::NoUpdate
+                }
+                _ => ResolveOutcome::TrustViolation(rejection),
+            },
+            Err(GateError::Seam(error)) => return Err(error),
+        },
+    };
+
+    Ok(Resolved {
+        last_known_good,
+        outcome,
+    })
+}

--- a/crates/engine/src/net/retire.rs
+++ b/crates/engine/src/net/retire.rs
@@ -1,0 +1,87 @@
+//! Retirement (blueprint/engine.md "Resolve/publish pipeline: Retirement",
+//! #34 D4).
+//!
+//! Retire = remove my registry rows; the timing is engine policy. Interior old
+//! names batch-retire at name-wave completion (immediate, [`retire`]); the old
+//! scope-root name lingers serving the tombstone until the migration window
+//! closes ([`root_retire_ready`], stubbed — see below).
+
+use crate::api::{ApiClient, ApiError};
+use crate::seams::{CredentialStore, Http};
+
+/// Batch-retire registry rows for `targets` (`ipnsName`s or CIDs). Idempotent
+/// server-side (blueprint/api.md), so a replayed batch — a resumed name wave —
+/// is a no-op, never an error. This is the interior-name path: it retires the
+/// moment the caller says a name is dead.
+pub async fn retire<H, C>(api: &ApiClient<H, C>, targets: &[String]) -> Result<(), ApiError>
+where
+    H: Http,
+    C: CredentialStore,
+{
+    if targets.is_empty() {
+        return Ok(());
+    }
+    api.retire(targets).await
+}
+
+/// Whether the old scope-root name may be retired yet. **Stubbed to `false`**:
+/// the migration-window constant that bounds how long the old root lingers
+/// serving the tombstone is an open edge (blueprint/engine.md "Open edges:
+/// Migration-window closure" — #38 fixed the channel architecture but not the
+/// window, proposed as a sync-timing-profile constant to settle with the
+/// testing-strategy blueprint). Until it lands the root never auto-retires, so
+/// a revokee or a lagging reader can always chase the tombstone to the new root.
+pub fn root_retire_ready() -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::seams::{HttpMethod, HttpResponse};
+    use crate::testkit::block_on;
+    use crate::testkit::fakes::{InMemoryCredentialStore, ScriptedHttp};
+
+    fn client() -> (
+        ScriptedHttp,
+        ApiClient<ScriptedHttp, InMemoryCredentialStore>,
+    ) {
+        let http = ScriptedHttp::default();
+        let client = ApiClient::new(
+            http.clone(),
+            InMemoryCredentialStore::default(),
+            "http://api.test",
+        );
+        (http, client)
+    }
+
+    #[test]
+    fn empty_retire_is_a_no_op_with_no_request() {
+        let (http, client) = client();
+        block_on(retire(&client, &[])).expect("empty retire");
+        assert!(http.requests().is_empty(), "no targets means no API call");
+    }
+
+    #[test]
+    fn retire_posts_the_batch_to_the_registry() {
+        let (http, client) = client();
+        http.enqueue_response(HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: Vec::new(),
+        });
+        block_on(retire(&client, &["k51interior".to_owned()])).expect("retire");
+        let requests = http.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, HttpMethod::Post);
+        assert!(requests[0].url.ends_with("/registry/retire"));
+    }
+
+    #[test]
+    fn root_never_auto_retires_pending_the_migration_window() {
+        assert!(
+            !root_retire_ready(),
+            "the old root lingers until the migration-window constant lands"
+        );
+    }
+}

--- a/crates/engine/src/net/revival.rs
+++ b/crates/engine/src/net/revival.rs
@@ -1,0 +1,87 @@
+//! Revival after a >EOL lapse (blueprint/engine.md "Resolve/publish pipeline:
+//! Revival", #24 lapse semantics).
+//!
+//! A lapse is an availability event, never loss. A key-holding session fetches
+//! the cached (possibly expired) record bytes from the authenticated recovery
+//! endpoint, extracts the last-known CID, and mints a fresh record with a fresh
+//! signature at a strictly-newer sequence through the normal publish path — the
+//! recovered sequence raises the CAS floor so the re-mint supersedes whatever
+//! lapsed. (The pin set's name→CID mapping is the designed-for alternate source
+//! behind the same recovery endpoint.)
+
+use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::suite::ed25519::Ed25519Signer;
+
+use super::publish::{PublishError, PublishOutcome, PublishRequest, head_cid_from_value, publish};
+use crate::api::{ApiClient, ApiError};
+use crate::profile::SyncTimingProfile;
+use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
+
+/// What to revive: the lapsed name, its node signing key, and the session's
+/// known content CIDs to re-register for pinning (empty is valid — a name-only
+/// re-mint). The CID to re-point at is recovered from the endpoint, not carried
+/// here.
+pub struct ReviveRequest<'a> {
+    /// The lapsed IPNS name.
+    pub name: &'a IpnsName,
+    /// The node's Ed25519 signing key (injected; this slice owns no derivation).
+    pub signer: &'a Ed25519Signer,
+    /// The session's content CIDs to re-register for pinning.
+    pub content_cids: Vec<String>,
+}
+
+/// A fail-closed revival failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReviveError {
+    /// The recovery fetch failed (auth, rate limit, or the name is unknown).
+    Recovery(ApiError),
+    /// The recovered bytes are not a valid record for this name, or its value is
+    /// not an `/ipfs/<cid>` path — nothing safe to revive from.
+    Unrecoverable,
+    /// The re-mint publish failed.
+    Publish(PublishError),
+}
+
+/// Revive after a >EOL lapse: fetch the last-known record from the recovery
+/// endpoint, extract its CID, and republish a fresh record at a strictly-newer
+/// sequence.
+pub async fn revive<T, H, C, F, Sch>(
+    transport: &T,
+    api: &ApiClient<H, C>,
+    floors: &F,
+    scheduler: &Sch,
+    profile: &SyncTimingProfile,
+    request: ReviveRequest<'_>,
+) -> Result<PublishOutcome, ReviveError>
+where
+    T: RecordTransport + Clone + 'static,
+    H: Http,
+    C: CredentialStore,
+    F: FloorStore,
+    Sch: Scheduler + Clone + 'static,
+{
+    let bytes = api
+        .recovery_fetch(request.name.as_str())
+        .await
+        .map_err(ReviveError::Recovery)?;
+
+    // The recovered record is authenticated against the name before we trust its
+    // CID/sequence — a recovery endpoint is an accelerator, never an authority.
+    let verified = IpnsRecord::unmarshal(&bytes)
+        .and_then(|record| record.verify(request.name))
+        .map_err(|_| ReviveError::Unrecoverable)?;
+    let head_cid = head_cid_from_value(&verified.value).ok_or(ReviveError::Unrecoverable)?;
+
+    let publish_request = PublishRequest {
+        name: request.name,
+        signer: request.signer,
+        head_cid,
+        content_cids: request.content_cids,
+        // Strictly newer than the lapsed record, even if this device's floor is
+        // stale after the lapse.
+        min_current_sequence: Some(verified.sequence),
+    };
+    publish(transport, api, floors, scheduler, profile, &publish_request)
+        .await
+        .map_err(ReviveError::Publish)
+}

--- a/crates/engine/src/testkit/fakes/record_store.rs
+++ b/crates/engine/src/testkit/fakes/record_store.rs
@@ -1,6 +1,6 @@
 //! The fake `/routing/v1` record store — an in-memory [`RecordTransport`].
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use crate::seams::{EndpointId, RecordTransport, SeamError, SeamResult};
@@ -14,14 +14,26 @@ type EndpointRecords = HashMap<String, Vec<u8>>;
 /// Shared by design — every engine in a scenario clones the same store, so
 /// N instances see one "network". Direct [`seed_record`] /
 /// [`record_at`] access lets tests stage adversarial records and observe
-/// publishes without a transport round-trip.
+/// publishes without a transport round-trip; [`fail_endpoint`] /
+/// [`heal_endpoint`] model an endpoint that is transiently unreachable, so the
+/// simulation harness can exercise any-ack success and the background re-PUT.
 ///
 /// [`seed_record`]: InMemoryRecordStore::seed_record
 /// [`record_at`]: InMemoryRecordStore::record_at
+/// [`fail_endpoint`]: InMemoryRecordStore::fail_endpoint
+/// [`heal_endpoint`]: InMemoryRecordStore::heal_endpoint
 #[derive(Clone)]
 pub struct InMemoryRecordStore {
     endpoints: Vec<EndpointId>,
     inner: Arc<Mutex<HashMap<EndpointId, EndpointRecords>>>,
+    /// Endpoints currently returning a transport error (unreachable). Empty by
+    /// default, so a store's behavior is unchanged until a test injects a fault.
+    failing: Arc<Mutex<HashSet<EndpointId>>>,
+    /// Endpoints that reject a PUT but still serve GET — models an endpoint that
+    /// already holds a strictly-newer record (IPNS higher-sequence-wins) and so
+    /// ignores our stale write while still serving the winner. Lets the harness
+    /// drive a lost CAS race.
+    put_failing: Arc<Mutex<HashSet<EndpointId>>>,
 }
 
 impl InMemoryRecordStore {
@@ -40,6 +52,8 @@ impl InMemoryRecordStore {
         Self {
             endpoints,
             inner: Arc::new(Mutex::new(inner)),
+            failing: Arc::new(Mutex::new(HashSet::new())),
+            put_failing: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -61,6 +75,42 @@ impl InMemoryRecordStore {
             .get(endpoint)
             .and_then(|records| records.get(routing_key).cloned())
     }
+
+    /// Make `endpoint` return a transport error on every GET/PUT until
+    /// [`heal_endpoint`](Self::heal_endpoint) clears it.
+    pub fn fail_endpoint(&self, endpoint: &EndpointId) {
+        self.failing.lock().expect("lock").insert(endpoint.clone());
+    }
+
+    /// Restore `endpoint` to normal operation.
+    pub fn heal_endpoint(&self, endpoint: &EndpointId) {
+        self.failing.lock().expect("lock").remove(endpoint);
+    }
+
+    /// Make `endpoint` reject PUTs while still serving GETs — an endpoint that
+    /// already holds a strictly-newer record and ignores our stale write.
+    pub fn fail_put_endpoint(&self, endpoint: &EndpointId) {
+        self.put_failing
+            .lock()
+            .expect("lock")
+            .insert(endpoint.clone());
+    }
+
+    /// Restore `endpoint`'s PUT path.
+    pub fn heal_put_endpoint(&self, endpoint: &EndpointId) {
+        self.put_failing.lock().expect("lock").remove(endpoint);
+    }
+
+    /// Whether `endpoint`'s GET path is currently injected to fail.
+    fn get_failing(&self, endpoint: &EndpointId) -> bool {
+        self.failing.lock().expect("lock").contains(endpoint)
+    }
+
+    /// Whether `endpoint`'s PUT path is currently injected to fail (a full fault
+    /// fails PUT too).
+    fn put_failing(&self, endpoint: &EndpointId) -> bool {
+        self.get_failing(endpoint) || self.put_failing.lock().expect("lock").contains(endpoint)
+    }
 }
 
 impl RecordTransport for InMemoryRecordStore {
@@ -73,6 +123,12 @@ impl RecordTransport for InMemoryRecordStore {
         endpoint: &EndpointId,
         routing_key: &str,
     ) -> SeamResult<Option<Vec<u8>>> {
+        if self.get_failing(endpoint) {
+            return Err(SeamError::new(format!(
+                "endpoint unreachable: {}",
+                endpoint.0
+            )));
+        }
         self.inner
             .lock()
             .expect("lock")
@@ -87,6 +143,12 @@ impl RecordTransport for InMemoryRecordStore {
         routing_key: &str,
         record: &[u8],
     ) -> SeamResult<()> {
+        if self.put_failing(endpoint) {
+            return Err(SeamError::new(format!(
+                "endpoint unreachable: {}",
+                endpoint.0
+            )));
+        }
         self.inner
             .lock()
             .expect("lock")

--- a/crates/engine/tests/net.rs
+++ b/crates/engine/tests/net.rs
@@ -1,0 +1,932 @@
+//! The net-plane simulation harness: the gated resolve/publish pipeline, CAS
+//! races, any-ack/retry fan-out, virtual-time multi-day EOL timelines, the
+//! keyless re-PUT Scheduler job, and revival — driven over the in-memory fake
+//! record store and virtual clock, no network and no docker
+//! (blueprint/engine.md "Resolve/publish pipeline"; blueprint/testing.md
+//! "the simulation harness").
+//!
+//! Records are real (core-signed via `IpnsRecord::create_v2`), so the fan-out
+//! verify step runs core's actual chain; the adoption gate — whose full
+//! candidate/reader assembly lands with the content/pointer/key slices — is
+//! reached through a scripted [`Adopter`] so this slice can prove the pipeline
+//! contract (every resolve is gated; only gate-passing records touch the
+//! snapshot) without re-deriving the whole crypto fixture the adoption-gate
+//! suite already owns.
+
+use core::time::Duration;
+use std::sync::{Arc, Mutex};
+
+use cipherbox_core::error::TrustViolation;
+use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::seal::ReadBody;
+use cipherbox_core::suite::ed25519::Ed25519Signer;
+
+use cipherbox_engine::SyncTimingProfile;
+use cipherbox_engine::api::ApiClient;
+use cipherbox_engine::gate::{Adopted, GateError, GateRejection, GateStage, RejectionReason};
+use cipherbox_engine::net::eol;
+use cipherbox_engine::net::{
+    Adopter, HeldRecord, PublishError, PublishOutcome, PublishRequest, RE_PUT_INTERVAL,
+    ResolveOutcome, ReviveError, ReviveRequest, eol_republish, keyless_re_put, publish, resolve,
+    revive,
+};
+use cipherbox_engine::seams::{
+    FloorStore, HttpResponse, RecordTransport, Scheduler, SnapshotCache, UnixMillis,
+};
+use cipherbox_engine::testkit::fakes::{
+    InMemoryCredentialStore, InMemoryRecordStore, ScriptedHttp,
+};
+use cipherbox_engine::testkit::{FakeDevice, FakeWorld, block_on};
+
+// Deterministic fixture constants (KAT-style injected values; core reads no clock).
+const TTL_NANOS: u64 = 2_000_000_000;
+const VALUE: &[u8] = b"/ipfs/bafyfixturehead";
+const DAY: u64 = 24 * 60 * 60;
+
+fn signer(seed: u8) -> Ed25519Signer {
+    Ed25519Signer::from_seed([seed; 32])
+}
+
+fn name_of(signer: &Ed25519Signer) -> IpnsName {
+    IpnsName::from_public_key(&signer.verifying_key())
+}
+
+/// A core-signed record for `signer` at `sequence`, minted with a 90-day EOL
+/// from `mint_millis`.
+fn record(signer: &Ed25519Signer, value: &[u8], sequence: u64, mint_millis: u64) -> Vec<u8> {
+    let validity = eol::eol_from(UnixMillis(mint_millis));
+    IpnsRecord::create_v2(signer, value, sequence, TTL_NANOS, &validity).marshal()
+}
+
+fn verify_seq(name: &IpnsName, bytes: &[u8]) -> u64 {
+    IpnsRecord::unmarshal(bytes)
+        .expect("record parses")
+        .verify(name)
+        .expect("record verifies")
+        .sequence
+}
+
+fn api_for(device: &FakeDevice) -> ApiClient<ScriptedHttp, InMemoryCredentialStore> {
+    ApiClient::new(
+        device.http.clone(),
+        device.credential_store.clone(),
+        "http://api.test",
+    )
+}
+
+/// A bare 2xx response (register/upload success — the client ignores the body).
+fn ok_200() -> HttpResponse {
+    HttpResponse {
+        status: 200,
+        headers: Vec::new(),
+        body: Vec::new(),
+    }
+}
+
+/// A 2xx response carrying `body` (recovery fetch returns the body verbatim).
+fn ok_200_body(body: Vec<u8>) -> HttpResponse {
+    HttpResponse {
+        status: 200,
+        headers: Vec::new(),
+        body,
+    }
+}
+
+/// Assert every configured endpoint holds a record for `name` at `sequence`.
+fn assert_all_endpoints_at(store: &InMemoryRecordStore, name: &IpnsName, sequence: u64) {
+    for endpoint in store.endpoints() {
+        let bytes = store
+            .record_at(&endpoint, name.as_str())
+            .unwrap_or_else(|| panic!("endpoint {} holds no record", endpoint.0));
+        assert_eq!(
+            verify_seq(name, &bytes),
+            sequence,
+            "endpoint {}",
+            endpoint.0
+        );
+    }
+}
+
+// --- the Adopter stub: a scripted gate verdict + the sequences it was fed ----
+
+#[derive(Clone, Copy)]
+enum Verdict {
+    /// The record passes the gate.
+    Accept,
+    /// A non-floor trust violation (fail-closed, pins last-known-good).
+    TrustViolation,
+    /// Our own current record re-fetched: `sequence == floor` (a no-update,
+    /// never a violation).
+    EqualSequence,
+}
+
+/// Fronts the adoption gate for the resolve pipeline. Records every sequence it
+/// is handed so a test can prove the gate ran on the freshest fetched record,
+/// and returns a scripted verdict.
+#[derive(Clone)]
+struct StubAdopter {
+    verdict: Verdict,
+    seen: Arc<Mutex<Vec<u64>>>,
+}
+
+impl StubAdopter {
+    fn new(verdict: Verdict) -> Self {
+        Self {
+            verdict,
+            seen: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn seen(&self) -> Vec<u64> {
+        self.seen.lock().unwrap().clone()
+    }
+}
+
+impl Adopter for StubAdopter {
+    async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<Adopted, GateError> {
+        let sequence = verify_seq(name, record_bytes);
+        self.seen.lock().unwrap().push(sequence);
+        match self.verdict {
+            Verdict::Accept => Ok(Adopted {
+                read_body: ReadBody::Folder {
+                    created_at: 0,
+                    modified_at: 0,
+                    children: Vec::new(),
+                    unknown: Vec::new(),
+                },
+                sequence,
+                epoch: 1,
+            }),
+            Verdict::TrustViolation => Err(GateError::Rejected(GateRejection {
+                stage: GateStage::RecordVerify,
+                reason: RejectionReason::Trust(TrustViolation::IpnsSignatureInvalid.into()),
+            })),
+            Verdict::EqualSequence => Err(GateError::Rejected(GateRejection {
+                stage: GateStage::Sequence,
+                reason: RejectionReason::SequenceNotNewer {
+                    floor: sequence,
+                    sequence,
+                },
+            })),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resolve — cache-first, fan-out verify, adoption gate on every resolve.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resolve_is_cache_first_and_renders_last_known_good_with_no_network_record() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let name = name_of(&signer(1));
+    let key = name.as_str().as_bytes();
+
+    block_on(device.snapshot_cache.put(key, b"cached-lkg")).unwrap();
+    let adopter = StubAdopter::new(Verdict::Accept);
+
+    let resolved = block_on(resolve(
+        &device.record_store,
+        &device.snapshot_cache,
+        &adopter,
+        &name,
+    ))
+    .expect("resolve");
+
+    assert_eq!(resolved.last_known_good, Some(b"cached-lkg".to_vec()));
+    assert_eq!(resolved.outcome, ResolveOutcome::NoUpdate);
+    assert!(
+        adopter.seen().is_empty(),
+        "with nothing fetched the gate is never invoked"
+    );
+}
+
+#[test]
+fn resolve_picks_freshest_verified_record_gates_it_and_writes_the_snapshot() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(2);
+    let name = name_of(&s);
+    let endpoints = world.record_store.endpoints();
+
+    // One endpoint serves garbage, one an older valid record, one the freshest.
+    world
+        .record_store
+        .seed_record(&endpoints[0], name.as_str(), b"not-a-record".to_vec());
+    world
+        .record_store
+        .seed_record(&endpoints[1], name.as_str(), record(&s, VALUE, 4, 0));
+    // Re-seed endpoint 0 with a valid older record to prove max-sequence wins.
+    world
+        .record_store
+        .seed_record(&endpoints[0], name.as_str(), record(&s, VALUE, 2, 0));
+
+    let adopter = StubAdopter::new(Verdict::Accept);
+    let resolved = block_on(resolve(
+        &device.record_store,
+        &device.snapshot_cache,
+        &adopter,
+        &name,
+    ))
+    .expect("resolve");
+
+    match resolved.outcome {
+        ResolveOutcome::Adopted(adopted) => assert_eq!(adopted.sequence, 4),
+        other => panic!("expected adoption, got {other:?}"),
+    }
+    assert_eq!(
+        adopter.seen(),
+        vec![4],
+        "the gate ran on the freshest record"
+    );
+
+    // Only the gate-passing record touched the snapshot.
+    let cached = block_on(device.snapshot_cache.get(name.as_str().as_bytes()))
+        .unwrap()
+        .expect("snapshot written");
+    assert_eq!(verify_seq(&name, &cached), 4);
+}
+
+#[test]
+fn resolve_gate_rejection_pins_last_known_good_and_never_overwrites_the_snapshot() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(3);
+    let name = name_of(&s);
+    let key = name.as_str().as_bytes();
+
+    block_on(device.snapshot_cache.put(key, b"trusted-lkg")).unwrap();
+    world.record_store.seed_record(
+        &world.record_store.endpoints()[0],
+        name.as_str(),
+        record(&s, VALUE, 9, 0),
+    );
+
+    let adopter = StubAdopter::new(Verdict::TrustViolation);
+    let resolved = block_on(resolve(
+        &device.record_store,
+        &device.snapshot_cache,
+        &adopter,
+        &name,
+    ))
+    .expect("resolve");
+
+    assert!(matches!(
+        resolved.outcome,
+        ResolveOutcome::TrustViolation(_)
+    ));
+    assert_eq!(resolved.last_known_good, Some(b"trusted-lkg".to_vec()));
+    assert_eq!(
+        block_on(device.snapshot_cache.get(key)).unwrap(),
+        Some(b"trusted-lkg".to_vec()),
+        "a fail-closed rejection never overwrites last-known-good"
+    );
+}
+
+#[test]
+fn resolve_equal_sequence_is_no_update_not_a_trust_violation() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(4);
+    let name = name_of(&s);
+    let key = name.as_str().as_bytes();
+
+    block_on(device.snapshot_cache.put(key, b"current")).unwrap();
+    world.record_store.seed_record(
+        &world.record_store.endpoints()[0],
+        name.as_str(),
+        record(&s, VALUE, 7, 0),
+    );
+
+    let adopter = StubAdopter::new(Verdict::EqualSequence);
+    let resolved = block_on(resolve(
+        &device.record_store,
+        &device.snapshot_cache,
+        &adopter,
+        &name,
+    ))
+    .expect("resolve");
+
+    assert_eq!(
+        resolved.outcome,
+        ResolveOutcome::NoUpdate,
+        "re-fetching our own current record is a no-update, never a violation"
+    );
+    assert_eq!(
+        block_on(device.snapshot_cache.get(key)).unwrap(),
+        Some(b"current".to_vec())
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Publish — register-first, sequence embedding, fan-out, confirm, CAS races.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn publish_registers_first_embeds_sequence_one_and_confirms() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(5);
+    let name = name_of(&s);
+    let api = api_for(&device);
+    device.http.enqueue_response(ok_200()); // register
+
+    let request = PublishRequest {
+        name: &name,
+        signer: &s,
+        head_cid: "bafyhead".into(),
+        content_cids: vec!["bafyc1".into()],
+        min_current_sequence: None,
+    };
+    let outcome = block_on(publish(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &device.scheduler,
+        &SyncTimingProfile::CI,
+        &request,
+    ))
+    .expect("publish");
+
+    assert_eq!(outcome, PublishOutcome::Published { sequence: 1 });
+    assert_all_endpoints_at(&world.record_store, &name, 1);
+
+    // The register call went out (register-first ordering), to the registry.
+    let requests = device.http.requests();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].url.ends_with("/registry/register"));
+}
+
+#[test]
+fn publish_cas_embeds_the_exact_expected_sequence_floor_plus_one() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(6);
+    let name = name_of(&s);
+    let api = api_for(&device);
+
+    // The last adopted record sat at sequence 3; the CAS publish embeds 4.
+    block_on(
+        device
+            .floor_store
+            .raise_sequence_floor(name.as_str().as_bytes(), 3),
+    )
+    .unwrap();
+    device.http.enqueue_response(ok_200());
+
+    let request = PublishRequest {
+        name: &name,
+        signer: &s,
+        head_cid: "bafyhead".into(),
+        content_cids: Vec::new(),
+        min_current_sequence: None,
+    };
+    let outcome = block_on(publish(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &device.scheduler,
+        &SyncTimingProfile::CI,
+        &request,
+    ))
+    .expect("publish");
+
+    assert_eq!(outcome, PublishOutcome::Published { sequence: 4 });
+    assert_all_endpoints_at(&world.record_store, &name, 4);
+}
+
+#[test]
+fn register_first_fail_closed_puts_no_record() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(7);
+    let name = name_of(&s);
+    let api = api_for(&device);
+
+    // The registration is refused: the record must never reach the transport.
+    device.http.enqueue_response(HttpResponse {
+        status: 500,
+        headers: Vec::new(),
+        body: Vec::new(),
+    });
+
+    let request = PublishRequest {
+        name: &name,
+        signer: &s,
+        head_cid: "bafyhead".into(),
+        content_cids: Vec::new(),
+        min_current_sequence: None,
+    };
+    let error = block_on(publish(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &device.scheduler,
+        &SyncTimingProfile::CI,
+        &request,
+    ))
+    .expect_err("register-first is fail-closed");
+
+    assert!(matches!(error, PublishError::Register(_)));
+    for endpoint in world.record_store.endpoints() {
+        assert!(
+            world
+                .record_store
+                .record_at(&endpoint, name.as_str())
+                .is_none(),
+            "no record is PUT when registration fails"
+        );
+    }
+}
+
+#[test]
+fn publish_succeeds_on_any_ack_and_the_background_retry_reaches_the_failed_endpoint() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(8);
+    let name = name_of(&s);
+    let api = api_for(&device);
+    let endpoints = world.record_store.endpoints();
+
+    // One endpoint is unreachable during the first attempt; the other acks.
+    world.record_store.fail_endpoint(&endpoints[0]);
+    device.http.enqueue_response(ok_200());
+    // Auto-advance so the spawned background retry's sleeps resolve when drained.
+    let scheduler = world.scheduler.clone().with_auto_advance();
+
+    let request = PublishRequest {
+        name: &name,
+        signer: &s,
+        head_cid: "bafyhead".into(),
+        content_cids: Vec::new(),
+        min_current_sequence: None,
+    };
+    let outcome = block_on(publish(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &scheduler,
+        &SyncTimingProfile::CI,
+        &request,
+    ))
+    .expect("publish");
+
+    assert_eq!(
+        outcome,
+        PublishOutcome::Published { sequence: 1 },
+        "any ack is success"
+    );
+    assert!(
+        world
+            .record_store
+            .record_at(&endpoints[0], name.as_str())
+            .is_none(),
+        "the failed endpoint has no record yet"
+    );
+    assert!(
+        world
+            .record_store
+            .record_at(&endpoints[1], name.as_str())
+            .is_some()
+    );
+
+    // Heal the endpoint and drain the background re-PUT: it now converges.
+    world.record_store.heal_endpoint(&endpoints[0]);
+    let tasks = scheduler.take_spawned_tasks();
+    assert_eq!(
+        tasks.len(),
+        1,
+        "publish spawned exactly one background re-PUT"
+    );
+    for task in tasks {
+        block_on(task);
+    }
+    assert_all_endpoints_at(&world.record_store, &name, 1);
+}
+
+#[test]
+fn publish_all_endpoints_failing_is_fail_closed() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(9);
+    let name = name_of(&s);
+    let api = api_for(&device);
+
+    for endpoint in world.record_store.endpoints() {
+        world.record_store.fail_endpoint(&endpoint);
+    }
+    device.http.enqueue_response(ok_200()); // registration succeeds; the PUT does not
+
+    let request = PublishRequest {
+        name: &name,
+        signer: &s,
+        head_cid: "bafyhead".into(),
+        content_cids: Vec::new(),
+        min_current_sequence: None,
+    };
+    let error = block_on(publish(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &device.scheduler,
+        &SyncTimingProfile::CI,
+        &request,
+    ))
+    .expect_err("no endpoint acked");
+
+    assert!(matches!(error, PublishError::AllEndpointsFailed));
+}
+
+#[test]
+fn publish_confirm_detects_a_lost_cas_race() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(10);
+    let name = name_of(&s);
+    let api = api_for(&device);
+    let endpoints = world.record_store.endpoints();
+
+    // A concurrent writer already landed sequence 3 on one endpoint; that
+    // endpoint rejects our stale (lower-sequence) PUT but still serves the
+    // winner (IPNS higher-sequence-wins), so confirm-by-re-resolve sees it.
+    world
+        .record_store
+        .seed_record(&endpoints[0], name.as_str(), record(&s, VALUE, 3, 0));
+    world.record_store.fail_put_endpoint(&endpoints[0]);
+    // Our floor is stale at 1, so we publish sequence 2 — behind the winner.
+    block_on(
+        device
+            .floor_store
+            .raise_sequence_floor(name.as_str().as_bytes(), 1),
+    )
+    .unwrap();
+    device.http.enqueue_response(ok_200());
+
+    let request = PublishRequest {
+        name: &name,
+        signer: &s,
+        head_cid: "bafyhead".into(),
+        content_cids: Vec::new(),
+        min_current_sequence: None,
+    };
+    let outcome = block_on(publish(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &device.scheduler,
+        &SyncTimingProfile::CI,
+        &request,
+    ))
+    .expect("publish");
+
+    assert_eq!(
+        outcome,
+        PublishOutcome::LostRace {
+            published_sequence: 2,
+            observed_sequence: 3,
+        },
+        "a strictly-higher record on confirm is a lost race for the caller to rebase"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Liveness — the keyless re-PUT Scheduler job and the sub-EOL seq+1 renewal.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn keyless_re_put_reposts_held_records_to_every_endpoint() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(11);
+    let name = name_of(&s);
+    let endpoints = world.record_store.endpoints();
+    let bytes = record(&s, VALUE, 1, 0);
+
+    // One endpoint dropped the record; the session still holds it.
+    world
+        .record_store
+        .seed_record(&endpoints[1], name.as_str(), bytes.clone());
+    let held = vec![HeldRecord {
+        routing_key: name.as_str().to_owned(),
+        record_bytes: bytes,
+    }];
+
+    let results = block_on(keyless_re_put(&device.record_store, &held));
+    assert_eq!(results.len(), 1);
+    assert!(results[0].kept_alive);
+    // The record is now alive on every endpoint again — keyless, byte-stable.
+    assert_all_endpoints_at(&world.record_store, &name, 1);
+}
+
+#[test]
+fn keyless_re_put_runs_as_an_hourly_scheduler_job_on_virtual_time() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(12);
+    let name = name_of(&s);
+    let held = vec![HeldRecord {
+        routing_key: name.as_str().to_owned(),
+        record_bytes: record(&s, VALUE, 1, 0),
+    }];
+
+    let scheduler = world.scheduler.clone().with_auto_advance();
+    let runs = Arc::new(Mutex::new(0u32));
+    {
+        let transport = device.record_store.clone();
+        let loop_scheduler = scheduler.clone();
+        let runs = runs.clone();
+        scheduler.spawn(Box::pin(async move {
+            for _ in 0..3 {
+                loop_scheduler.sleep(RE_PUT_INTERVAL).await;
+                keyless_re_put(&transport, &held).await;
+                *runs.lock().unwrap() += 1;
+            }
+        }));
+    }
+    for task in scheduler.take_spawned_tasks() {
+        block_on(task);
+    }
+
+    assert_eq!(
+        *runs.lock().unwrap(),
+        3,
+        "the job fired once per hourly tick"
+    );
+    assert_eq!(
+        scheduler.now(),
+        UnixMillis(3 * 60 * 60 * 1000),
+        "three hours elapsed on virtual time"
+    );
+    assert_all_endpoints_at(&world.record_store, &name, 1);
+}
+
+#[test]
+fn eol_republish_renews_at_seq_plus_one_only_inside_the_window() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(13);
+    let name = name_of(&s);
+    let api = api_for(&device);
+    let scheduler = world.scheduler.clone(); // manual clock, now = 0
+
+    // Publish the initial record at T0 (EOL = T0 + 90 days), then model its
+    // adoption by advancing the durable sequence floor to 1 (the gate's job).
+    device.http.enqueue_response(ok_200());
+    let request = PublishRequest {
+        name: &name,
+        signer: &s,
+        head_cid: "bafyhead".into(),
+        content_cids: Vec::new(),
+        min_current_sequence: None,
+    };
+    block_on(publish(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &scheduler,
+        &SyncTimingProfile::CI,
+        &request,
+    ))
+    .expect("initial publish");
+    block_on(
+        device
+            .floor_store
+            .raise_sequence_floor(name.as_str().as_bytes(), 1),
+    )
+    .unwrap();
+
+    // At T0 the EOL is ~90 days out: no renewal, no API call.
+    let none = block_on(eol_republish(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &scheduler,
+        &SyncTimingProfile::CI,
+        &request,
+    ))
+    .expect("eol_republish");
+    assert_eq!(none, None, "a record far from EOL is not renewed");
+
+    // 65 days on (25 days remaining, inside the 30-day window): republish at 2.
+    scheduler.advance(Duration::from_secs(65 * DAY));
+    device.http.enqueue_response(ok_200());
+    let outcome = block_on(eol_republish(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &scheduler,
+        &SyncTimingProfile::CI,
+        &request,
+    ))
+    .expect("eol_republish");
+    assert_eq!(outcome, Some(PublishOutcome::Published { sequence: 2 }));
+
+    // The renewed record carries a strictly-later EOL than the original.
+    let endpoint = world.record_store.endpoints()[0].clone();
+    let renewed = world
+        .record_store
+        .record_at(&endpoint, name.as_str())
+        .unwrap();
+    let renewed_validity = IpnsRecord::unmarshal(&renewed)
+        .unwrap()
+        .verify(&name)
+        .unwrap()
+        .validity;
+    let original_eol = eol::eol_from(UnixMillis(0));
+    assert_eq!(verify_seq(&name, &renewed), 2);
+    assert!(
+        renewed_validity > original_eol.into_bytes(),
+        "renewal stamps a fresh, later EOL"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Revival — re-mint after a >EOL lapse via the recovery endpoint.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn revive_re_mints_a_fresh_record_strictly_newer_than_the_lapsed_one() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(14);
+    let name = name_of(&s);
+    let api = api_for(&device);
+
+    // The recovery endpoint holds the last-known record (sequence 5) — the
+    // network copy has lapsed and been GC'd.
+    let lapsed = record(&s, b"/ipfs/bafyrecovered", 5, 0);
+    device.http.enqueue_response(ok_200_body(lapsed)); // recovery fetch
+    device.http.enqueue_response(ok_200()); // register for the re-mint
+
+    let request = ReviveRequest {
+        name: &name,
+        signer: &s,
+        content_cids: vec!["bafyrecovered".into()],
+    };
+    let outcome = block_on(revive(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &device.scheduler,
+        &SyncTimingProfile::CI,
+        request,
+    ))
+    .expect("revive");
+
+    // Strictly newer than the recovered sequence 5, even from a cold floor.
+    assert_eq!(outcome, PublishOutcome::Published { sequence: 6 });
+    for endpoint in world.record_store.endpoints() {
+        let bytes = world
+            .record_store
+            .record_at(&endpoint, name.as_str())
+            .unwrap();
+        let verified = IpnsRecord::unmarshal(&bytes)
+            .unwrap()
+            .verify(&name)
+            .unwrap();
+        assert_eq!(verified.sequence, 6);
+        assert_eq!(verified.value, b"/ipfs/bafyrecovered", "same CID re-minted");
+    }
+}
+
+#[test]
+fn revive_fails_closed_when_the_recovery_endpoint_is_unauthorized() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(15);
+    let name = name_of(&s);
+    let api = api_for(&device);
+
+    device.http.enqueue_response(HttpResponse {
+        status: 403,
+        headers: Vec::new(),
+        body: Vec::new(),
+    });
+
+    let request = ReviveRequest {
+        name: &name,
+        signer: &s,
+        content_cids: Vec::new(),
+    };
+    let error = block_on(revive(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &device.scheduler,
+        &SyncTimingProfile::CI,
+        request,
+    ))
+    .expect_err("a refused recovery fetch fails closed");
+    assert!(matches!(error, ReviveError::Recovery(_)));
+    // Nothing was published.
+    for endpoint in world.record_store.endpoints() {
+        assert!(
+            world
+                .record_store
+                .record_at(&endpoint, name.as_str())
+                .is_none()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// An end-to-end multi-day EOL timeline on virtual time: publish → live →
+// renewal → lapse → revival, one narrative over ~250 virtual days.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multi_day_eol_timeline_publish_renew_lapse_revive() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(16);
+    let name = name_of(&s);
+    let api = api_for(&device);
+    let scheduler = world.scheduler.clone(); // manual clock, now = 0
+    let endpoint = world.record_store.endpoints()[0].clone();
+
+    let request = PublishRequest {
+        name: &name,
+        signer: &s,
+        head_cid: "bafytimeline".into(),
+        content_cids: Vec::new(),
+        min_current_sequence: None,
+    };
+
+    // T0: first publish (seq 1, EOL T0+90d); model adoption (floor → 1).
+    device.http.enqueue_response(ok_200());
+    block_on(publish(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &scheduler,
+        &SyncTimingProfile::CI,
+        &request,
+    ))
+    .expect("publish seq 1");
+    block_on(
+        device
+            .floor_store
+            .raise_sequence_floor(name.as_str().as_bytes(), 1),
+    )
+    .unwrap();
+
+    // T0+65d: inside the renewal window → republish seq 2; model adoption.
+    scheduler.advance(Duration::from_secs(65 * DAY));
+    device.http.enqueue_response(ok_200());
+    assert_eq!(
+        block_on(eol_republish(
+            &device.record_store,
+            &api,
+            &device.floor_store,
+            &scheduler,
+            &SyncTimingProfile::CI,
+            &request,
+        ))
+        .expect("renew"),
+        Some(PublishOutcome::Published { sequence: 2 })
+    );
+    block_on(
+        device
+            .floor_store
+            .raise_sequence_floor(name.as_str().as_bytes(), 2),
+    )
+    .unwrap();
+
+    // Capture the live seq-2 bytes the recovery endpoint would return later.
+    let seq2_bytes = world
+        .record_store
+        .record_at(&endpoint, name.as_str())
+        .unwrap();
+    let seq2_validity = IpnsRecord::unmarshal(&seq2_bytes)
+        .unwrap()
+        .verify(&name)
+        .unwrap()
+        .validity;
+
+    // Advance well past the seq-2 EOL (T0+65d+90d = T0+155d): a >EOL lapse.
+    scheduler.advance(Duration::from_secs(120 * DAY)); // now ≈ T0+185d
+    assert!(
+        eol::is_expired(scheduler.now(), &seq2_validity),
+        "the record has lapsed past its EOL"
+    );
+
+    // Revival: recovery returns the last-known seq-2 record; re-mint at seq 3.
+    device.http.enqueue_response(ok_200_body(seq2_bytes));
+    device.http.enqueue_response(ok_200());
+    let outcome = block_on(revive(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &scheduler,
+        &SyncTimingProfile::CI,
+        ReviveRequest {
+            name: &name,
+            signer: &s,
+            content_cids: Vec::new(),
+        },
+    ))
+    .expect("revive after lapse");
+    assert_eq!(outcome, PublishOutcome::Published { sequence: 3 });
+    assert_all_endpoints_at(&world.record_store, &name, 3);
+}

--- a/crates/engine/tests/net.rs
+++ b/crates/engine/tests/net.rs
@@ -31,7 +31,8 @@ use cipherbox_engine::net::{
     revive,
 };
 use cipherbox_engine::seams::{
-    FloorStore, HttpResponse, RecordTransport, Scheduler, SnapshotCache, UnixMillis,
+    FloorStore, HttpResponse, RecordTransport, Scheduler, SeamError, SeamResult, SnapshotCache,
+    UnixMillis,
 };
 use cipherbox_engine::testkit::fakes::{
     InMemoryCredentialStore, InMemoryRecordStore, ScriptedHttp,
@@ -436,6 +437,68 @@ fn register_first_fail_closed_puts_no_record() {
                 .record_at(&endpoint, name.as_str())
                 .is_none(),
             "no record is PUT when registration fails"
+        );
+    }
+}
+
+/// A [`FloorStore`] whose sequence-floor read always fails — models a durable
+/// floor-store I/O error so publish must fail closed rather than assume "no
+/// floor" and mint a stale sequence.
+#[derive(Clone, Default)]
+struct FailingFloorStore;
+
+impl FloorStore for FailingFloorStore {
+    async fn epoch_floor(&self, _scope_id: &[u8]) -> SeamResult<Option<u64>> {
+        Ok(None)
+    }
+    async fn raise_epoch_floor(&self, _scope_id: &[u8], epoch: u64) -> SeamResult<u64> {
+        Ok(epoch)
+    }
+    async fn sequence_floor(&self, _ipns_name: &[u8]) -> SeamResult<Option<u64>> {
+        Err(SeamError::new("floor store unavailable"))
+    }
+    async fn raise_sequence_floor(&self, _ipns_name: &[u8], sequence: u64) -> SeamResult<u64> {
+        Ok(sequence)
+    }
+}
+
+#[test]
+fn publish_fails_closed_when_the_sequence_floor_cannot_be_read() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(9);
+    let name = name_of(&s);
+    let api = api_for(&device);
+    let floors = FailingFloorStore;
+    // Registration succeeds; the floor read then fails — the failure must stop
+    // publish before any record is minted or PUT (never collapse to "no floor").
+    device.http.enqueue_response(ok_200());
+
+    let request = PublishRequest {
+        name: &name,
+        signer: &s,
+        head_cid: "bafyhead".into(),
+        content_cids: Vec::new(),
+        min_current_sequence: None,
+    };
+    let error = block_on(publish(
+        &device.record_store,
+        &api,
+        &floors,
+        &device.scheduler,
+        &SyncTimingProfile::CI,
+        &request,
+    ))
+    .expect_err("a floor-read failure is fail-closed");
+
+    assert!(matches!(error, PublishError::FloorRead(_)));
+    for endpoint in world.record_store.endpoints() {
+        assert!(
+            world
+                .record_store
+                .record_at(&endpoint, name.as_str())
+                .is_none(),
+            "no record is PUT when the floor read fails"
         );
     }
 }


### PR DESCRIPTION
## What landed

The engine **net plane** (`crates/engine/src/net/`) — the gated resolve/publish pipeline, CAS, endpoint fan-out, and the liveness jobs — over the dumb `/routing/v1` `RecordTransport`. Core signs and verifies; the engine owns every decision.

- **resolve** (`net/resolve.rs`) — cache-first: last-known-good renders immediately, then fan-out GET + core verify picks the freshest record and the adoption gate runs on **every** resolve through the `Adopter` seam. Only a gate-passing record touches the snapshot; a rejection is fail-closed (pins last-known-good), and a re-fetch of our own current record (`sequence == floor`) is a no-update, never a violation.
- **publish** (`net/publish.rs`) — register-first, fail-closed (the record never reaches the transport unless the API registration succeeds); core-signed with **sequence 1 on first publish** and the **exact `floor+1` sequence on CAS**; parallel PUT with any-ack success + bounded background re-PUT of the missed endpoints; confirm-by-re-resolve with `LostRace` detection.
- **liveness** (`net/liveness.rs`) — the ~hourly keyless re-PUT job (byte-stable, no key material) and the sub-EOL `seq+1` renewal inside a ~30-day window.
- **revival** (`net/revival.rs`) — re-mint after a `>EOL` lapse via the authenticated recovery endpoint, strictly newer than the recovered sequence.
- **retire** (`net/retire.rs`) — interior-name batch retire; the old scope-root linger is stubbed (`root_retire_ready() == false`) on the open-edge migration-window constant.
- **eol** (`net/eol.rs`) — the 90-day EOL policy and an RFC3339 codec; TTL comes from the `SyncTimingProfile`, the EOL instant from the injected `Scheduler` clock (no wall-clock or RNG in net logic).

**Deliberately not landed** (per the issue): rebase (a lost race is reported, not rebased) and the pointer planes. The seams are left where the blueprint expects them — `resolve::Adopter` fronts the content/pointer/grants + key-lifecycle candidate assembly, and a lost race surfaces as `PublishOutcome::LostRace` for the rebase slice.

## Gate / CI wiring

New tests run in the existing **Engine Tests** gate (`cargo test -p cipherbox-engine`) and the `cargo-linux` / `cargo-macos` / `cargo-windows` workspace test jobs — integration tests under `crates/engine/tests/` are picked up automatically, so **no workflow change and no new required check** (avoids deadlocking older PRs). No branch-protection flip needed.

`crates/engine/tests/net.rs` — the net simulation harness (16 tests):

- **resolve**: cache-first LKG render; freshest-verified selection + gate + snapshot write; gate rejection pins LKG and never overwrites the snapshot; equal-sequence is a no-update.
- **publish**: register-first + sequence-1 + confirm; CAS embeds `floor+1`; **register-first fail-closed puts no record** (the engine-side ordering law); any-ack success + background retry converges the failed endpoint; all-endpoints-failing is fail-closed; confirm detects a lost CAS race.
- **liveness**: keyless re-PUT reposts to every endpoint; the re-PUT job runs as an ~hourly `Scheduler` job over virtual time; sub-EOL renewal republishes at `seq+1` only inside the window with a fresh, later EOL.
- **revival**: re-mint strictly newer than the lapsed record; fail-closed on a refused recovery fetch.
- **timeline**: an end-to-end multi-day virtual-time narrative — publish → live → renew → lapse → revive over ~185 virtual days.

Plus `net/eol.rs` unit tests (RFC3339 round-trip, expiry/renewal transitions, malformed rejection) and `net/retire.rs` unit tests.

**Contract-suite additions** named in the issue — `register-first fail-closed` (the API's gate half) and `batch register/retire idempotency` — already exist and gate in `crates/contract/tests/contract.rs` (landed with #627). The engine's contribution is the **ordering law** (register precedes PUT, fail-closed), added here as an engine simulation test; the live-API half is unchanged and executes in the `contract-suite` CI job.

## Test evidence

`cargo test -p cipherbox-engine`: 118 pass (68 lib + 20 adoption_gate + 7 conformance_fakes + 7 facade + 16 net). `cargo clippy --workspace --exclude cipherbox-desktop --exclude cipherbox-contract --all-targets` clean; `cargo fmt --check` clean. Local run was crate-scoped only (no docker / full stack).

## Deferrals / notes

- **Rebase and pointer planes** — out of scope; `LostRace` reports the race for the rebase slice, and `Adopter` fronts the pointer/content assembly.
- **Root-name retirement** — stubbed pending the migration-window constant (blueprint open edge).
- **`RE_PUT_INTERVAL` (~1h) and `EOL_RENEW_THRESHOLD` (~30d)** — designed-for cadences kept as documented module constants; like the sweep cadence (blueprint "Open edges"), they join the sync timing profile once measured. Virtual time keeps the real values fast to test.
- **Additive testkit change**: `InMemoryRecordStore` gained fault injection (`fail_endpoint` / `heal_endpoint`, and a put-only `fail_put_endpoint` for lost-race). Default behavior is unchanged; used only by the adversarial net scenarios.
- No `FloorStore` seam change (uses the existing frozen API only) — expect a merge-adjacency with #685 at floor call sites, resolved at merge time.

Closes #628


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable record publishing with endpoint confirmation and conflict detection.
  - Added cache-first record resolution with verification and trust safeguards.
  - Added automatic record keep-alive, expiration renewal, and revival after lapse.
  - Added concurrent endpoint synchronization with retry handling.
  - Added retirement support for registry records.
- **Bug Fixes**
  - Prevented rejected or unverifiable records from replacing trusted data.
  - Improved handling of unavailable endpoints and failed publishing attempts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->