### PR TITLE
fix(api): map user-row lock timeouts to 503 and parameterize the lock_timeout set

### DIFF
--- a/apps/api/src/common/advisory-lock.test.ts
+++ b/apps/api/src/common/advisory-lock.test.ts
@@ -1,6 +1,7 @@
+import { QueryFailedError } from 'typeorm';
 import { describe, expect, it } from 'vitest';
 import { fakeConfig } from '../testing/fakes';
-import { resolveAdvisoryLockTimeoutMs } from './advisory-lock';
+import { isLockNotAvailable, resolveAdvisoryLockTimeoutMs } from './advisory-lock';
 
 /** The safe fail-closed bound applied to an unset or garbage config value. */
 const DEFAULT = 3000;
@@ -19,5 +20,31 @@ describe('resolveAdvisoryLockTimeoutMs', () => {
     ['valid bound', '5000', 5000],
   ])('%s -> %d', (_label, value, expected) => {
     expect(resolve(value)).toBe(expected);
+  });
+});
+
+describe('isLockNotAvailable', () => {
+  it('is true for a QueryFailedError whose driverError.code is 55P03', () => {
+    const err = new QueryFailedError('SELECT 1', [], { code: '55P03' } as never);
+    expect(isLockNotAvailable(err)).toBe(true);
+  });
+
+  it('is true when the 55P03 code sits directly on the QueryFailedError', () => {
+    const err = new QueryFailedError('SELECT 1', [], {} as never);
+    (err as unknown as { code: string }).code = '55P03';
+    expect(isLockNotAvailable(err)).toBe(true);
+  });
+
+  it('is false for a QueryFailedError with a different code', () => {
+    const err = new QueryFailedError('SELECT 1', [], { code: '23505' } as never);
+    expect(isLockNotAvailable(err)).toBe(false);
+  });
+
+  it.each([
+    ['a plain Error', new Error('nope')],
+    ['a bare code-bearing object', { code: '55P03' } as unknown],
+    ['undefined', undefined],
+  ])('is false for %s (not a QueryFailedError)', (_label, value) => {
+    expect(isLockNotAvailable(value)).toBe(false);
   });
 });

--- a/apps/api/src/common/advisory-lock.ts
+++ b/apps/api/src/common/advisory-lock.ts
@@ -31,15 +31,19 @@ export function resolveAdvisoryLockTimeoutMs(configService: ConfigService): numb
 /**
  * Bound advisory-lock waits to `timeoutMs` for the current transaction. Call
  * once before acquiring any key; registry batches lock several keys under a
- * single bound. `SET LOCAL` is transaction-scoped and takes no bind parameters,
- * so the validated integer is inlined. `0` leaves the wait unbounded.
+ * single bound. `set_config('lock_timeout', …, true)` is the transaction-local
+ * (`is_local = true`) equivalent of `SET LOCAL`, taking the value as a bind
+ * parameter. `0` leaves the wait unbounded.
  */
 export async function setAdvisoryLockTimeout(
   manager: EntityManager,
   timeoutMs: number
 ): Promise<void> {
   if (timeoutMs > 0) {
-    await manager.query(`SET LOCAL lock_timeout = ${Math.trunc(timeoutMs)}`);
+    await manager.query('SELECT set_config($1, $2, true)', [
+      'lock_timeout',
+      Math.trunc(timeoutMs).toString(),
+    ]);
   }
 }
 
@@ -60,7 +64,13 @@ export async function acquireAdvisoryLock(manager: EntityManager, key: bigint): 
   }
 }
 
-function isLockNotAvailable(error: unknown): boolean {
+/**
+ * A Postgres `lock_not_available` (55P03) — a statement aborted by
+ * `lock_timeout`, whether the advisory-lock acquire or a row lock taken later
+ * under the same transaction-scoped bound. TypeORM wraps it as a
+ * `QueryFailedError` carrying the driver code.
+ */
+export function isLockNotAvailable(error: unknown): boolean {
   if (!(error instanceof QueryFailedError)) {
     return false;
   }

--- a/apps/api/src/registry/services/registry.service.integration.test.ts
+++ b/apps/api/src/registry/services/registry.service.integration.test.ts
@@ -1,3 +1,4 @@
+import { ServiceUnavailableException } from '@nestjs/common';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { randomBytes } from 'node:crypto';
 import { DataSource, EntityManager, FindManyOptions, FindOneOptions, Repository } from 'typeorm';
@@ -353,6 +354,37 @@ describe('RegistryService concurrency (real Postgres)', () => {
       expect(pinStore.unpinned).toEqual([cid]);
       const survivors = await db.dataSource.getRepository(PinnedCid).find({ where: { cid } });
       expect(survivors.map((r) => r.accountId)).toEqual([b]);
+    });
+  });
+
+  describe('user-row lock timeout maps to 503', () => {
+    it('a register whose users-row lock waits past lock_timeout surfaces a retryable 503, not a 500', async () => {
+      const accountId = await seedAccount(false);
+
+      // The transaction-scoped lock_timeout bounds the advisory acquire AND the
+      // users-row pessimistic_write taken later. Hold that row locked elsewhere
+      // so register's wait aborts with 55P03 — which must map to 503, not 500.
+      const holder = db.dataSource.createQueryRunner();
+      await holder.connect();
+      await holder.startTransaction();
+      await holder.query('SELECT id FROM users WHERE id = $1 FOR UPDATE', [accountId]);
+
+      const service = new RegistryService(
+        db.dataSource.getRepository(PinnedCid) as never,
+        db.dataSource.getRepository(User) as never,
+        db.dataSource as never,
+        new RecordingPinStore(),
+        fakeConfig({ DB_ADVISORY_LOCK_TIMEOUT_MS: '200' }).service
+      );
+
+      try {
+        await expect(
+          service.register(accountId, [{ ipnsName: token(), contentCids: [token()] }])
+        ).rejects.toBeInstanceOf(ServiceUnavailableException);
+      } finally {
+        await holder.rollbackTransaction();
+        await holder.release();
+      }
     });
   });
 

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, ServiceUnavailableException, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { createHash } from 'node:crypto';
@@ -6,6 +6,7 @@ import { DataSource, EntityManager, In, Repository } from 'typeorm';
 import { User } from '../../auth/entities/user.entity';
 import {
   acquireAdvisoryLock,
+  isLockNotAvailable,
   resolveAdvisoryLockTimeoutMs,
   setAdvisoryLockTimeout,
 } from '../../common/advisory-lock';
@@ -107,6 +108,27 @@ export class RegistryService {
   }
 
   /**
+   * Run `work` in a transaction, mapping any `lock_timeout` abort (55P03) to the
+   * retryable 503. The transaction-scoped `lock_timeout` bounds not just the
+   * advisory-lock acquire but every lock taken later in the same transaction
+   * (the users-row `pessimistic_write`, the delete row locks), so a contended
+   * wait anywhere must degrade the same way instead of escaping as a 500. A 503
+   * the advisory-lock helper already raised passes through unchanged.
+   */
+  private async lockGuardedTransaction<T>(
+    work: (manager: EntityManager) => Promise<T>
+  ): Promise<T> {
+    try {
+      return await this.dataSource.transaction(work);
+    } catch (error) {
+      if (isLockNotAvailable(error)) {
+        throw new ServiceUnavailableException('Contended resource; retry shortly');
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Batch register `[{ipnsName, headCid?, contentCids[]}]` under the caller's
    * account. Register-first, fail-closed: each entry upserts its name-inventory
    * row BEFORE any content pin row, so content is never accepted without the
@@ -139,7 +161,7 @@ export class RegistryService {
     // All-or-nothing: register-first, fail-closed means a mid-batch error must
     // leave no partial state behind.
     if (nameOrder.length > 0 || cidOrder.length > 0) {
-      await this.dataSource.transaction(async (manager) => {
+      await this.lockGuardedTransaction(async (manager) => {
         // Serialize per token before any read/write: register and retire
         // contend on the same keys, closing the phantom-INSERT race and
         // concurrent-duplicate inserts.
@@ -217,7 +239,7 @@ export class RegistryService {
     // All-or-nothing, and serialized per CID against concurrent register and
     // retire: the advisory lock (not a row lock, which can't see an unborn
     // INSERT) makes the delete → survivor check the authority for unpinning.
-    const { retired, unpinCids } = await this.dataSource.transaction(async (manager) => {
+    const { retired, unpinCids } = await this.lockGuardedTransaction(async (manager) => {
       await lockTokens(manager, targets, this.lockTimeoutMs);
 
       const nameRepo = manager.getRepository(NameInventory);


### PR DESCRIPTION
Follow-up to #686 / #688. #688 was merged while this fix was still in flight, so it landed on the PR branch (commit `e5f0c36a6`) rather than on `main`; this PR re-applies it.

Applies the two CodeRabbit review items that were **not** in #688's merge:

- **Major (outside-diff range): map the user-row lock timeout to 503.** `SET LOCAL lock_timeout` is transaction-local, so it also bounds the `users` `pessimistic_write` lock taken in the `register` transaction (added in #677). A contended wait raises `55P03`, which previously escaped the advisory-lock 503 mapper and surfaced as a **500**. Adds a `lockGuardedTransaction` wrapper that maps any `55P03` raised anywhere in the `register`/`retire` transaction to the retryable `ServiceUnavailableException` (503). A 503 already raised by `acquireAdvisoryLock` is not a `QueryFailedError`, so it passes through unchanged — no double-wrap, no downgrade.
- **Nitpick: parameterize the lock_timeout set.** Replaces the interpolated `SET LOCAL lock_timeout = N` with `SELECT set_config('lock_timeout', $2, true)` (`true` = transaction-local, semantically identical to `SET LOCAL`) — removes the SQL string-interpolation SAST smell.

Tests: exported `isLockNotAvailable` (+6 unit tests for the `55P03` detection); a real-Postgres integration test holds the `users` row `FOR UPDATE` in a second connection and asserts a contended `register` (lock_timeout 200ms) rejects with 503. API unit 118, integration 11 — all green (verified against the real Postgres integration gate landed by #688).

Cherry-picked from the #688 branch commit `e5f0c36a6`.
