### PR TITLE
feat(api): add the in-process republisher record cache and recovery

### DIFF
--- a/.github/workflows/scheduled-liveness.yml
+++ b/.github/workflows/scheduled-liveness.yml
@@ -1,0 +1,34 @@
+# Scheduled tier (blueprint/testing.md: Dispatch / scheduled). Long-horizon
+# liveness soaks that must NOT block a PR — the republisher walk against a
+# compressed-EOL profile over virtual time. Runs on a cron and on manual
+# dispatch; the per-PR CI gate never runs these.
+name: Scheduled Liveness
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  api-liveness:
+    name: API Long-Horizon Liveness
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run the compressed-EOL long-horizon suite
+        run: pnpm --filter @cipherbox/api test:scheduled

--- a/.github/workflows/scheduled-liveness.yml
+++ b/.github/workflows/scheduled-liveness.yml
@@ -19,6 +19,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 

--- a/.github/workflows/scheduled-liveness.yml
+++ b/.github/workflows/scheduled-liveness.yml
@@ -15,6 +15,9 @@ jobs:
   api-liveness:
     name: API Long-Horizon Liveness
     runs-on: ubuntu-latest
+    # The soak runs over virtual time, so wall-clock is short; cap it so a hung
+    # run fails fast instead of drifting to GitHub's 6h default.
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -602,6 +602,59 @@
         ]
       }
     },
+    "/content/upload": {
+      "post": {
+        "operationId": "ContentController_upload",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Empty or non-binary upload body"
+          },
+          "401": {
+            "description": "Missing or invalid access token"
+          },
+          "413": {
+            "description": "Upload exceeds the account storage quota or size cap"
+          },
+          "429": {
+            "description": "Upload rate limit exceeded"
+          },
+          "503": {
+            "description": "Pin store contended or unavailable; retry shortly"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Upload content bytes to the hosted pin store; quota-gated for hosted accounts, advisory for BYO",
+        "tags": [
+          "Content"
+        ]
+      }
+    },
     "/recovery/{ipnsName}": {
       "get": {
         "operationId": "RecoveryController_fetch",
@@ -676,6 +729,10 @@
     {
       "name": "Account",
       "description": "Per-account quota and the BYO-IPFS toggle"
+    },
+    {
+      "name": "Content",
+      "description": "Hosted ingress: quota-gated byte upload to CipherBox Kubo"
     },
     {
       "name": "Recovery",
@@ -1065,6 +1122,23 @@
         },
         "required": [
           "byo"
+        ]
+      },
+      "UploadResponseDto": {
+        "type": "object",
+        "properties": {
+          "cid": {
+            "type": "string",
+            "description": "The content CID Kubo pinned"
+          },
+          "size": {
+            "type": "number",
+            "description": "The pinned size in bytes"
+          }
+        },
+        "required": [
+          "cid",
+          "size"
         ]
       }
     }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -620,7 +620,12 @@
           "200": {
             "description": "Opaque signed record bytes",
             "content": {
-              "application/vnd.ipfs.ipns-record": {}
+              "application/vnd.ipfs.ipns-record": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
             }
           },
           "401": {

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -602,46 +602,35 @@
         ]
       }
     },
-    "/content/upload": {
-      "post": {
-        "operationId": "ContentController_upload",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/octet-stream": {
-              "schema": {
-                "type": "string",
-                "format": "binary"
-              }
+    "/recovery/{ipnsName}": {
+      "get": {
+        "operationId": "RecoveryController_fetch",
+        "parameters": [
+          {
+            "name": "ipnsName",
+            "required": true,
+            "in": "path",
+            "description": "The IPNS name (libp2p-key CID)",
+            "schema": {
+              "type": "string"
             }
           }
-        },
+        ],
         "responses": {
-          "201": {
-            "description": "",
+          "200": {
+            "description": "Opaque signed record bytes",
             "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UploadResponseDto"
-                }
-              }
+              "application/vnd.ipfs.ipns-record": {}
             }
-          },
-          "400": {
-            "description": "Empty or non-binary upload body"
           },
           "401": {
             "description": "Missing or invalid access token"
           },
-          "413": {
-            "description": "Upload exceeds the account storage quota or size cap"
+          "404": {
+            "description": "No cached record for this name"
           },
           "429": {
-            "description": "Upload rate limit exceeded"
-          },
-          "503": {
-            "description": "Pin store contended or unavailable; retry shortly"
+            "description": "Recovery rate limit exceeded"
           }
         },
         "security": [
@@ -649,9 +638,9 @@
             "bearer": []
           }
         ],
-        "summary": "Upload content bytes to the hosted pin store; quota-gated for hosted accounts, advisory for BYO",
+        "summary": "Fetch cached (possibly expired) record bytes for a name — the revival aid after a >EOL lapse. Non-canonical: verify against the network.",
         "tags": [
-          "Content"
+          "Recovery"
         ]
       }
     }
@@ -684,8 +673,8 @@
       "description": "Per-account quota and the BYO-IPFS toggle"
     },
     {
-      "name": "Content",
-      "description": "Hosted ingress: quota-gated byte upload to CipherBox Kubo"
+      "name": "Recovery",
+      "description": "Authenticated fetch of non-canonical cached record bytes by name"
     }
   ],
   "servers": [],
@@ -1071,23 +1060,6 @@
         },
         "required": [
           "byo"
-        ]
-      },
-      "UploadResponseDto": {
-        "type": "object",
-        "properties": {
-          "cid": {
-            "type": "string",
-            "description": "The content CID Kubo pinned"
-          },
-          "size": {
-            "type": "number",
-            "description": "The pinned size in bytes"
-          }
-        },
-        "required": [
-          "cid",
-          "size"
         ]
       }
     }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:scheduled": "vitest run --config vitest.scheduled.config.ts",
     "typeorm": "node -r ts-node/register ./node_modules/typeorm/cli.js",
     "migration:run": "pnpm typeorm migration:run -d src/data-source.ts",
     "migration:revert": "pnpm typeorm migration:revert -d src/data-source.ts",

--- a/apps/api/scripts/generate-openapi.ts
+++ b/apps/api/scripts/generate-openapi.ts
@@ -30,6 +30,8 @@ import { MetricsService } from '../src/ops/metrics.service';
 import { AccountController } from '../src/registry/account.controller';
 import { RegistryController } from '../src/registry/registry.controller';
 import { RegistryService } from '../src/registry/services/registry.service';
+import { RecoveryController } from '../src/republisher/recovery.controller';
+import { RecordCacheService } from '../src/republisher/services/record-cache.service';
 
 @Module({
   controllers: [
@@ -40,6 +42,7 @@ import { RegistryService } from '../src/registry/services/registry.service';
     RegistryController,
     AccountController,
     ContentController,
+    RecoveryController,
   ],
   providers: [
     { provide: AuthService, useValue: {} },
@@ -49,6 +52,7 @@ import { RegistryService } from '../src/registry/services/registry.service';
     { provide: MetricsService, useValue: {} },
     { provide: RegistryService, useValue: {} },
     { provide: ContentService, useValue: {} },
+    { provide: RecordCacheService, useValue: {} },
     { provide: JwtService, useValue: {} },
     { provide: ConfigService, useValue: new ConfigService() },
   ],

--- a/apps/api/src/app-setup.ts
+++ b/apps/api/src/app-setup.ts
@@ -134,6 +134,7 @@ export function buildOpenApiDocument(app: INestApplication): OpenAPIObject {
     .addTag('Registry', 'Pin/name registry: batch register/retire, union liveness')
     .addTag('Account', 'Per-account quota and the BYO-IPFS toggle')
     .addTag('Content', 'Hosted ingress: quota-gated byte upload to CipherBox Kubo')
+    .addTag('Recovery', 'Authenticated fetch of non-canonical cached record bytes by name')
     .build();
   return SwaggerModule.createDocument(app, config);
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { ContentModule } from './content/content.module';
 import { MailboxModule } from './mailbox/mailbox.module';
 import { OpsModule } from './ops/ops.module';
 import { RegistryModule } from './registry/registry.module';
+import { RepublisherModule } from './republisher/republisher.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { RegistryModule } from './registry/registry.module';
     MailboxModule,
     RegistryModule,
     ContentModule,
+    RepublisherModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/common/worker-scheduler.test.ts
+++ b/apps/api/src/common/worker-scheduler.test.ts
@@ -1,5 +1,19 @@
+import { Logger } from '@nestjs/common';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PeriodicTask, TimerWorkerScheduler } from './worker-scheduler';
+
+/** A task whose runOnce never settles — the hung-sweep case the run timeout bounds. */
+function hungTask(runTimeoutMs: number, onRun: () => void): PeriodicTask {
+  return {
+    taskName: 'hung',
+    intervalMs: 1000,
+    runTimeoutMs,
+    runOnce: () => {
+      onRun();
+      return new Promise<void>(() => {});
+    },
+  };
+}
 
 /** A task whose runOnce is fully controlled by the test. */
 class ControllableTask implements PeriodicTask {
@@ -128,5 +142,43 @@ describe('TimerWorkerScheduler', () => {
 
     await vi.advanceTimersByTimeAsync(5000);
     expect(task.runs).toBe(0);
+  });
+
+  it('times out a hung sweep, clears the in-flight flag, and resumes scheduling', async () => {
+    const errorSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    const scheduler = new TimerWorkerScheduler();
+    let runs = 0;
+    scheduler.register(hungTask(500, () => (runs += 1)));
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(1000); // tick 1 starts a sweep that never settles
+    expect(runs).toBe(1);
+
+    // The 500ms run timeout abandons the wedged sweep; without it `running` would
+    // stay true forever and every later tick would be dropped.
+    await vi.advanceTimersByTimeAsync(1000); // past the 1500ms timeout and the 2000ms tick
+    expect(runs).toBe(2);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('hung'));
+
+    await vi.advanceTimersByTimeAsync(500); // let the second wedged run time out too
+    await scheduler.stop();
+    errorSpy.mockRestore();
+  });
+
+  it('stop resolves despite a wedged sweep — bounded by the run timeout, never forever', async () => {
+    vi.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    const scheduler = new TimerWorkerScheduler();
+    scheduler.register(hungTask(500, () => undefined));
+    scheduler.start();
+    await vi.advanceTimersByTimeAsync(1000); // start the wedged run
+
+    let settled = false;
+    const stopping = scheduler.stop().then(() => {
+      settled = true;
+    });
+    // stop awaits the in-flight run; the run timeout releases it rather than hang.
+    await vi.advanceTimersByTimeAsync(500);
+    await stopping;
+    expect(settled).toBe(true);
   });
 });

--- a/apps/api/src/common/worker-scheduler.test.ts
+++ b/apps/api/src/common/worker-scheduler.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PeriodicTask, TimerWorkerScheduler } from './worker-scheduler';
+
+/** A task whose runOnce is fully controlled by the test. */
+class ControllableTask implements PeriodicTask {
+  runs = 0;
+  private resolvers: Array<() => void> = [];
+
+  constructor(
+    readonly taskName: string,
+    readonly intervalMs: number
+  ) {}
+
+  runOnce(): Promise<void> {
+    this.runs += 1;
+    return new Promise<void>((resolve) => this.resolvers.push(resolve));
+  }
+
+  /** Complete the oldest in-flight sweep. */
+  completeOldest(): void {
+    this.resolvers.shift()?.();
+  }
+
+  /** Complete every in-flight sweep so a graceful stop() can drain. */
+  completeAll(): void {
+    while (this.resolvers.length) {
+      this.resolvers.shift()?.();
+    }
+  }
+}
+
+describe('TimerWorkerScheduler', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('fires each task once per interval', async () => {
+    const scheduler = new TimerWorkerScheduler();
+    const task = new ControllableTask('walk', 1000);
+    scheduler.register(task);
+    scheduler.start();
+
+    expect(task.runs).toBe(0);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(task.runs).toBe(1);
+    task.completeOldest();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(task.runs).toBe(2);
+
+    task.completeAll();
+    await scheduler.stop();
+  });
+
+  it('drops overlapping ticks while a sweep is still in flight', async () => {
+    const scheduler = new TimerWorkerScheduler();
+    const task = new ControllableTask('walk', 1000);
+    scheduler.register(task);
+    scheduler.start();
+
+    // First tick starts a sweep that never completes; the next two ticks are
+    // dropped rather than stacked.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(task.runs).toBe(1);
+
+    // Once the sweep completes, the next tick runs.
+    task.completeOldest();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(task.runs).toBe(2);
+
+    task.completeAll();
+    await scheduler.stop();
+  });
+
+  it('keeps the loop alive after a sweep throws', async () => {
+    const scheduler = new TimerWorkerScheduler();
+    let calls = 0;
+    const task: PeriodicTask = {
+      taskName: 'flaky',
+      intervalMs: 1000,
+      runOnce: async () => {
+        calls += 1;
+        throw new Error('boom');
+      },
+    };
+    scheduler.register(task);
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(calls).toBe(2); // the first throw did not kill the timer
+
+    await scheduler.stop();
+  });
+
+  it('runs independent tasks on their own cadences', async () => {
+    const scheduler = new TimerWorkerScheduler();
+    const fast = new ControllableTask('fast', 500);
+    const slow = new ControllableTask('slow', 2000);
+    scheduler.register(fast);
+    scheduler.register(slow);
+    scheduler.start();
+
+    // Complete each fast sweep as it starts so the fast cadence keeps firing;
+    // the slow task fires exactly once over the same window.
+    for (let i = 0; i < 4; i += 1) {
+      await vi.advanceTimersByTimeAsync(500);
+      fast.completeOldest();
+    }
+    expect(fast.runs).toBe(4);
+    expect(slow.runs).toBe(1);
+
+    fast.completeAll();
+    slow.completeAll();
+    await scheduler.stop();
+  });
+
+  it('refuses registration after start', () => {
+    const scheduler = new TimerWorkerScheduler();
+    scheduler.start();
+    expect(() => scheduler.register(new ControllableTask('late', 1000))).toThrow();
+  });
+
+  it('stop clears timers so no further ticks fire', async () => {
+    const scheduler = new TimerWorkerScheduler();
+    const task = new ControllableTask('walk', 1000);
+    scheduler.register(task);
+    scheduler.start();
+    await scheduler.stop();
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(task.runs).toBe(0);
+  });
+});

--- a/apps/api/src/common/worker-scheduler.ts
+++ b/apps/api/src/common/worker-scheduler.ts
@@ -1,0 +1,102 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * A unit of periodic background work. The scheduler owns the cadence; the task
+ * owns one sweep. Deliberately capability-free so it is reusable: the
+ * republisher's inventory walk is the first implementer, and the dormant-mailbox
+ * scheduled sweep (#667) builds its scheduling on this same seam.
+ *
+ * `runOnce` MUST resolve/reject on its own — the scheduler never times it out —
+ * and MUST NOT assume it runs alone: the scheduler skips a tick while the
+ * previous sweep is still in flight, but a task should still be idempotent.
+ */
+export interface PeriodicTask {
+  /** Stable label for logs/metrics (bounded cardinality). */
+  readonly taskName: string;
+  /** Cadence between sweeps, in ms. Injected — never read from a clock here. */
+  readonly intervalMs: number;
+  runOnce(): Promise<void>;
+}
+
+/**
+ * Drives {@link PeriodicTask}s on their cadence. The one stateful loop shared by
+ * every in-process worker (blueprint/api.md: in-process, worker-shaped, cleanly
+ * extractable), so a future extraction moves this seam and its implementers
+ * together. Production uses real timers; tests substitute a manual scheduler and
+ * a fake clock so cadence and long-horizon timelines run in virtual time.
+ */
+@Injectable()
+export abstract class WorkerScheduler {
+  abstract register(task: PeriodicTask): void;
+  abstract start(): void;
+  abstract stop(): Promise<void>;
+}
+
+interface ScheduledEntry {
+  task: PeriodicTask;
+  handle?: ReturnType<typeof setInterval>;
+  running: boolean;
+}
+
+/**
+ * Real-timer scheduler. Each task fires on a `setInterval` at its own cadence;
+ * a per-task in-flight flag drops overlapping ticks (a slow sweep never stacks),
+ * and a thrown sweep is caught and logged so one failure never kills the loop.
+ * `stop` clears every timer and awaits in-flight sweeps.
+ */
+@Injectable()
+export class TimerWorkerScheduler extends WorkerScheduler {
+  private readonly logger = new Logger(WorkerScheduler.name);
+  private readonly entries: ScheduledEntry[] = [];
+  private readonly inFlight = new Set<Promise<void>>();
+  private started = false;
+
+  register(task: PeriodicTask): void {
+    if (this.started) {
+      throw new Error('WorkerScheduler.register must be called before start');
+    }
+    this.entries.push({ task, running: false });
+  }
+
+  start(): void {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+    for (const entry of this.entries) {
+      entry.handle = setInterval(() => this.tick(entry), entry.task.intervalMs);
+      // Don't keep the event loop alive solely for the sweep timer.
+      entry.handle.unref?.();
+    }
+  }
+
+  async stop(): Promise<void> {
+    for (const entry of this.entries) {
+      if (entry.handle) {
+        clearInterval(entry.handle);
+        entry.handle = undefined;
+      }
+    }
+    this.started = false;
+    await Promise.allSettled([...this.inFlight]);
+  }
+
+  private tick(entry: ScheduledEntry): void {
+    if (entry.running) {
+      // Previous sweep still in flight — drop this tick rather than stack.
+      return;
+    }
+    entry.running = true;
+    const run = entry.task
+      .runOnce()
+      .catch((error: unknown) => {
+        // A failed sweep is logged and swallowed: the loop must survive it.
+        this.logger.warn(`${entry.task.taskName} sweep failed: ${String(error)}`);
+      })
+      .finally(() => {
+        entry.running = false;
+        this.inFlight.delete(run);
+      });
+    this.inFlight.add(run);
+  }
+}

--- a/apps/api/src/common/worker-scheduler.ts
+++ b/apps/api/src/common/worker-scheduler.ts
@@ -6,15 +6,23 @@ import { Injectable, Logger } from '@nestjs/common';
  * republisher's inventory walk is the first implementer, and the dormant-mailbox
  * scheduled sweep (#667) builds its scheduling on this same seam.
  *
- * `runOnce` MUST resolve/reject on its own — the scheduler never times it out —
- * and MUST NOT assume it runs alone: the scheduler skips a tick while the
- * previous sweep is still in flight, but a task should still be idempotent.
+ * A sweep SHOULD settle on its own, but need not: the scheduler bounds every run
+ * with a per-run timeout, so a wedged sweep (a DB op that never returns) is
+ * abandoned rather than left to block scheduling forever. A task MUST NOT assume
+ * it runs alone either — the scheduler skips a tick while the previous sweep is
+ * still in flight, so a task should still be idempotent.
  */
 export interface PeriodicTask {
   /** Stable label for logs/metrics (bounded cardinality). */
   readonly taskName: string;
   /** Cadence between sweeps, in ms. Injected — never read from a clock here. */
   readonly intervalMs: number;
+  /**
+   * Hard per-run bound in ms; a sweep exceeding it is abandoned (in-flight flag
+   * cleared, logged) so a hung run can't wedge the loop or block shutdown.
+   * Omit to accept the scheduler default.
+   */
+  readonly runTimeoutMs?: number;
   runOnce(): Promise<void>;
 }
 
@@ -38,11 +46,17 @@ interface ScheduledEntry {
   running: boolean;
 }
 
+/** Fallback per-run bound when a task declares no `runTimeoutMs`. */
+const DEFAULT_RUN_TIMEOUT_MS = 60 * 60 * 1000;
+
 /**
  * Real-timer scheduler. Each task fires on a `setInterval` at its own cadence;
  * a per-task in-flight flag drops overlapping ticks (a slow sweep never stacks),
  * and a thrown sweep is caught and logged so one failure never kills the loop.
- * `stop` clears every timer and awaits in-flight sweeps.
+ * Every run is bounded by a per-run timeout: a wedged sweep is abandoned (its
+ * in-flight flag cleared, logged) so it can neither block later ticks forever nor
+ * hang `stop`. `stop` clears every timer and awaits in-flight sweeps — bounded by
+ * that same timeout, never indefinitely.
  */
 @Injectable()
 export class TimerWorkerScheduler extends WorkerScheduler {
@@ -87,13 +101,38 @@ export class TimerWorkerScheduler extends WorkerScheduler {
       return;
     }
     entry.running = true;
-    const run = entry.task
+    const timeoutMs = entry.task.runTimeoutMs ?? DEFAULT_RUN_TIMEOUT_MS;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<'timeout'>((resolve) => {
+      timer = setTimeout(() => resolve('timeout'), timeoutMs);
+      timer.unref?.();
+    });
+
+    const sweep = entry.task
       .runOnce()
+      .then(() => 'done' as const)
       .catch((error: unknown) => {
         // A failed sweep is logged and swallowed: the loop must survive it.
         this.logger.warn(`${entry.task.taskName} sweep failed: ${String(error)}`);
+        return 'done' as const;
+      });
+
+    // Whichever settles first releases the run. On timeout the sweep promise is
+    // abandoned (still caught, so a late rejection can't surface unhandled) so a
+    // wedged run never pins `running` or `stop`.
+    const run = Promise.race([sweep, timeout])
+      .then((outcome) => {
+        if (outcome === 'timeout') {
+          this.logger.error(
+            `${entry.task.taskName} sweep exceeded ${timeoutMs}ms; abandoned so scheduling continues`
+          );
+        }
       })
       .finally(() => {
+        if (timer) {
+          clearTimeout(timer);
+        }
         entry.running = false;
         this.inFlight.delete(run);
       });

--- a/apps/api/src/migrations/1784600557946-AddRecordCache.ts
+++ b/apps/api/src/migrations/1784600557946-AddRecordCache.ts
@@ -5,7 +5,7 @@ export class AddRecordCache1784600557946 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE "record_cache" ("ipns_name" character varying(128) NOT NULL, "record" bytea NOT NULL, "sequence" bigint NOT NULL, "last_republished_at" TIMESTAMP WITH TIME ZONE, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_49f183426ca65b21642fb75178c" PRIMARY KEY ("ipns_name"))`
+      `CREATE TABLE "record_cache" ("ipns_name" character varying(128) NOT NULL, "record" bytea NOT NULL, "sequence" numeric(20,0) NOT NULL, "last_republished_at" TIMESTAMP WITH TIME ZONE, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_49f183426ca65b21642fb75178c" PRIMARY KEY ("ipns_name"))`
     );
   }
 

--- a/apps/api/src/migrations/1784600557946-AddRecordCache.ts
+++ b/apps/api/src/migrations/1784600557946-AddRecordCache.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRecordCache1784600557946 implements MigrationInterface {
+  name = 'AddRecordCache1784600557946';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "record_cache" ("ipns_name" character varying(128) NOT NULL, "record" bytea NOT NULL, "sequence" bigint NOT NULL, "last_republished_at" TIMESTAMP WITH TIME ZONE, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_49f183426ca65b21642fb75178c" PRIMARY KEY ("ipns_name"))`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "record_cache"`);
+  }
+}

--- a/apps/api/src/ops/metrics.service.ts
+++ b/apps/api/src/ops/metrics.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Counter, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
+import { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
 
 /**
  * Prometheus metrics (blueprint/api.md Ops). Uses a per-instance registry
@@ -10,6 +10,10 @@ export class MetricsService {
   private readonly registry = new Registry();
   private readonly httpRequestsTotal: Counter<'method' | 'route' | 'status'>;
   private readonly httpRequestDurationSeconds: Histogram<'method' | 'route'>;
+  private readonly republisherResolveFailuresTotal: Counter;
+  private readonly republisherStaleNamesTotal: Counter;
+  private readonly republisherLastWalkNames: Gauge;
+  private readonly republisherLastWalkRepublished: Gauge;
 
   constructor() {
     collectDefaultMetrics({ register: this.registry });
@@ -25,11 +29,44 @@ export class MetricsService {
       labelNames: ['method', 'route'],
       registers: [this.registry],
     });
+    this.republisherResolveFailuresTotal = new Counter({
+      name: 'republisher_resolve_failures_total',
+      help: 'IPNS names the republisher could not resolve (orphans or unreachable)',
+      registers: [this.registry],
+    });
+    this.republisherStaleNamesTotal = new Counter({
+      name: 'republisher_stale_names_total',
+      help: 'IPNS names observed >24h without a successful re-PUT',
+      registers: [this.registry],
+    });
+    this.republisherLastWalkNames = new Gauge({
+      name: 'republisher_last_walk_names',
+      help: 'Distinct names walked in the most recent republisher sweep',
+      registers: [this.registry],
+    });
+    this.republisherLastWalkRepublished = new Gauge({
+      name: 'republisher_last_walk_republished',
+      help: 'Names successfully re-PUT in the most recent republisher sweep',
+      registers: [this.registry],
+    });
   }
 
   observeRequest(method: string, route: string, status: number, durationSeconds: number): void {
     this.httpRequestsTotal.inc({ method, route, status: String(status) });
     this.httpRequestDurationSeconds.observe({ method, route }, durationSeconds);
+  }
+
+  observeRepublisherResolveFailure(): void {
+    this.republisherResolveFailuresTotal.inc();
+  }
+
+  observeRepublisherStaleName(): void {
+    this.republisherStaleNamesTotal.inc();
+  }
+
+  observeRepublisherWalk(namesWalked: number, republished: number): void {
+    this.republisherLastWalkNames.set(namesWalked);
+    this.republisherLastWalkRepublished.set(republished);
   }
 
   get contentType(): string {

--- a/apps/api/src/ops/throttling.ts
+++ b/apps/api/src/ops/throttling.ts
@@ -31,4 +31,10 @@ export const THROTTLE_SURFACES = {
   account: { default: { limit: 120, ttl: 60_000 } },
   /** Content upload: per account; bounded above the write cadence, below abuse. */
   content: { default: { limit: 60, ttl: 60_000 } },
+  /**
+   * Recovery fetch: per account. The revival aid after a >EOL lapse is a rare,
+   * deliberate operation (extract the last CID, mint a fresh record), so the cap
+   * sits low — enough to sweep a handful of scope names, far below abuse rates.
+   */
+  recovery: { default: { limit: 30, ttl: 60_000 } },
 } as const;

--- a/apps/api/src/republisher/entities/record-cache.entity.ts
+++ b/apps/api/src/republisher/entities/record-cache.entity.ts
@@ -27,8 +27,12 @@ export class RecordCache {
   @Column({ name: 'record', type: 'bytea' })
   record: Buffer;
 
-  /** The record's public sequence number; the monotonic regression guard. */
-  @Column({ name: 'sequence', type: 'bigint' })
+  /**
+   * The record's public sequence number; the monotonic regression guard. IPNS
+   * sequences are uint64, so this is `numeric(20,0)` — a signed `bigint` would
+   * overflow (and abort the sweep) at 2^63, half the domain.
+   */
+  @Column({ name: 'sequence', type: 'numeric', precision: 20, scale: 0 })
   sequence: string;
 
   /** Last successful keyless re-PUT; null until the first succeeds. Drives the >24h liveness alert. */

--- a/apps/api/src/republisher/entities/record-cache.entity.ts
+++ b/apps/api/src/republisher/entities/record-cache.entity.ts
@@ -1,0 +1,41 @@
+import { Column, CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
+
+/**
+ * The non-canonical record cache (blueprint/api.md, Republisher module and
+ * recovery). One row per distinct IPNS name, holding the most recent record the
+ * republisher resolved from the network.
+ *
+ * It is a liveness aid, never a data plane: it is consulted by NO client resolve
+ * path (clients verify records from the network themselves), it is rebuildable
+ * from the network at any time, and it holds opaque signed record bytes the API
+ * never decodes or inspects (zero-knowledge). Its ONE integrity rule is
+ * monotonicity — a resolved record only replaces the cached one when its
+ * `sequence` is strictly greater, so a stale/replayed network answer can never
+ * regress the cache to older bytes (enforced race-safe in RecordCacheService via
+ * a conditional upsert, not a read-then-write).
+ *
+ * The name is the primary key (there is exactly one cached record per name), so
+ * the conditional upsert can target `ON CONFLICT (ipns_name)` directly.
+ */
+@Entity('record_cache')
+export class RecordCache {
+  /** The IPNS name (libp2p-key CID); one cached record per name. */
+  @PrimaryColumn({ name: 'ipns_name', type: 'varchar', length: 128 })
+  ipnsName: string;
+
+  /** Opaque signed IPNS record bytes; re-PUT verbatim, never decoded server-side. */
+  @Column({ name: 'record', type: 'bytea' })
+  record: Buffer;
+
+  /** The record's public sequence number; the monotonic regression guard. */
+  @Column({ name: 'sequence', type: 'bigint' })
+  sequence: string;
+
+  /** Last successful keyless re-PUT; null until the first succeeds. Drives the >24h liveness alert. */
+  @Column({ name: 'last_republished_at', type: 'timestamptz', nullable: true })
+  lastRepublishedAt: Date | null;
+
+  /** When this name first entered the cache; the staleness baseline before any re-PUT succeeds. */
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/apps/api/src/republisher/record-sequence-reader.test.ts
+++ b/apps/api/src/republisher/record-sequence-reader.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { MinimalIpnsSequenceReader } from './record-sequence-reader';
+
+/** Encode a uint64 as a protobuf varint. */
+function varint(value: bigint): Buffer {
+  const bytes: number[] = [];
+  let v = value;
+  do {
+    let byte = Number(v & 0x7fn);
+    v >>= 7n;
+    if (v > 0n) {
+      byte |= 0x80;
+    }
+    bytes.push(byte);
+  } while (v > 0n);
+  return Buffer.from(bytes);
+}
+
+/** A field with a varint payload (wire type 0). */
+function varintField(fieldNumber: number, value: bigint): Buffer {
+  return Buffer.concat([varint(BigInt((fieldNumber << 3) | 0)), varint(value)]);
+}
+
+/** A length-delimited field (wire type 2) — e.g. IPNS `value`/`signature`/`data`. */
+function bytesField(fieldNumber: number, payload: Buffer): Buffer {
+  return Buffer.concat([
+    varint(BigInt((fieldNumber << 3) | 2)),
+    varint(BigInt(payload.length)),
+    payload,
+  ]);
+}
+
+describe('MinimalIpnsSequenceReader', () => {
+  const reader = new MinimalIpnsSequenceReader();
+
+  it('reads the sequence (field 5) when it is the only field', () => {
+    expect(reader.read(varintField(5, 7n))).toBe(7n);
+  });
+
+  it('reads the sequence past length-delimited and varint fields', () => {
+    // A realistic IPNS entry shape: value(1), signatureV1(2), validityType(3),
+    // validity(4), then sequence(5), then ttl(6), pubKey(7), data(9).
+    const record = Buffer.concat([
+      bytesField(1, Buffer.from('value-cid-bytes')),
+      bytesField(2, Buffer.from('sigv1')),
+      varintField(3, 0n),
+      bytesField(4, Buffer.from('2099-01-01T00:00:00Z')),
+      varintField(5, 42n),
+      varintField(6, 3600n),
+      bytesField(7, Buffer.from('pubkey')),
+      bytesField(9, Buffer.from('cbor-data')),
+    ]);
+    expect(reader.read(record)).toBe(42n);
+  });
+
+  it('reads a multi-byte sequence varint', () => {
+    expect(reader.read(varintField(5, 300n))).toBe(300n);
+    expect(reader.read(varintField(5, 9_000_000_000n))).toBe(9_000_000_000n);
+  });
+
+  it('returns null when the sequence field is absent', () => {
+    const record = Buffer.concat([bytesField(1, Buffer.from('value')), varintField(6, 1n)]);
+    expect(reader.read(record)).toBeNull();
+  });
+
+  it('returns null for an empty record', () => {
+    expect(reader.read(Buffer.alloc(0))).toBeNull();
+  });
+
+  it('returns null for a truncated length-delimited field rather than throwing', () => {
+    // field 1 claims 50 bytes of payload but the buffer ends early.
+    const record = Buffer.concat([varint(BigInt((1 << 3) | 2)), varint(50n), Buffer.from('short')]);
+    expect(reader.read(record)).toBeNull();
+  });
+
+  it('returns null for a never-terminating varint rather than throwing', () => {
+    // Ten continuation bytes with no terminator.
+    const record = Buffer.concat([varint(BigInt((5 << 3) | 0)), Buffer.alloc(11, 0x80)]);
+    expect(reader.read(record)).toBeNull();
+  });
+});

--- a/apps/api/src/republisher/record-sequence-reader.ts
+++ b/apps/api/src/republisher/record-sequence-reader.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Reads the ordering value the record cache uses to refuse regressions.
+ *
+ * This is a seam, not the canonical IPNS codec — core owns that (AGENTS.md). It
+ * reads ONLY the public `sequence` field an IPNS record exposes for monotonic
+ * ordering; it never validates the signature, the EOL, or the sealed payload,
+ * and the record stays opaque bytes for the keyless re-PUT. The cache it feeds
+ * is non-canonical and on no client resolve path, so the worst case of a missing
+ * or misread sequence is a skipped cache update (returns `null`), never a trust
+ * decision. A core-backed reader can replace this behind the seam later.
+ */
+@Injectable()
+export abstract class RecordSequenceReader {
+  /** The record's sequence for cache ordering; null if it cannot be read. */
+  abstract read(record: Buffer): bigint | null;
+}
+
+/** Protobuf field 5 (`sequence`, uint64 varint) of the IPNS entry message. */
+const SEQUENCE_FIELD_TAG = (5 << 3) | 0;
+const MAX_VARINT_BYTES = 10;
+
+/**
+ * Minimal reader: scans the top-level protobuf fields for the `sequence` varint,
+ * skipping every other field by its wire type. Any structural surprise returns
+ * `null` — this must never throw into the walk, and a non-canonical cache
+ * tolerates a skipped update.
+ */
+@Injectable()
+export class MinimalIpnsSequenceReader extends RecordSequenceReader {
+  read(record: Buffer): bigint | null {
+    let offset = 0;
+    while (offset < record.length) {
+      const tag = this.readVarint(record, offset);
+      if (!tag) {
+        return null;
+      }
+      offset = tag.next;
+      const wireType = Number(tag.value & 0x7n);
+
+      if (Number(tag.value) === SEQUENCE_FIELD_TAG) {
+        const seq = this.readVarint(record, offset);
+        return seq ? seq.value : null;
+      }
+
+      const skipped = this.skipField(record, offset, wireType);
+      if (skipped === null) {
+        return null;
+      }
+      offset = skipped;
+    }
+    return null;
+  }
+
+  private skipField(record: Buffer, offset: number, wireType: number): number | null {
+    switch (wireType) {
+      case 0: {
+        const v = this.readVarint(record, offset);
+        return v ? v.next : null;
+      }
+      case 1:
+        return offset + 8 <= record.length ? offset + 8 : null;
+      case 2: {
+        const len = this.readVarint(record, offset);
+        if (!len) {
+          return null;
+        }
+        const end = len.next + Number(len.value);
+        return end <= record.length ? end : null;
+      }
+      case 5:
+        return offset + 4 <= record.length ? offset + 4 : null;
+      default:
+        return null;
+    }
+  }
+
+  private readVarint(record: Buffer, offset: number): { value: bigint; next: number } | null {
+    let value = 0n;
+    let shift = 0n;
+    let index = offset;
+    for (let count = 0; count < MAX_VARINT_BYTES && index < record.length; count += 1) {
+      const byte = record[index];
+      value |= BigInt(byte & 0x7f) << shift;
+      index += 1;
+      if ((byte & 0x80) === 0) {
+        return { value, next: index };
+      }
+      shift += 7n;
+    }
+    return null;
+  }
+}

--- a/apps/api/src/republisher/record-transport.ts
+++ b/apps/api/src/republisher/record-transport.ts
@@ -18,6 +18,16 @@ export abstract class RecordTransport {
   abstract resolve(ipnsName: string): Promise<Buffer | null>;
   /** Re-PUT opaque record bytes keyless (the records carry client-signed EOLs). */
   abstract republish(ipnsName: string, record: Buffer): Promise<void>;
+
+  /**
+   * Whether a routing endpoint is wired up. False in BYO-only deploys with no
+   * `ROUTING_V1_URL`, where the walk would resolve every name to null — the task
+   * checks this and skips the sweep rather than firing a resolve-failure alert
+   * for every name each cadence.
+   */
+  get configured(): boolean {
+    return true;
+  }
 }
 
 /**
@@ -39,6 +49,10 @@ export class RoutingV1RecordTransport extends RecordTransport {
     this.baseUrl = raw && raw.trim() ? raw.replace(/\/+$/, '') : undefined;
     const timeout = Number(configService.get('ROUTING_V1_TIMEOUT_MS'));
     this.timeoutMs = Number.isInteger(timeout) && timeout > 0 ? timeout : DEFAULT_TIMEOUT_MS;
+  }
+
+  override get configured(): boolean {
+    return this.baseUrl !== undefined;
   }
 
   async resolve(ipnsName: string): Promise<Buffer | null> {

--- a/apps/api/src/republisher/record-transport.ts
+++ b/apps/api/src/republisher/record-transport.ts
@@ -1,0 +1,81 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+const IPNS_RECORD_MEDIA_TYPE = 'application/vnd.ipfs.ipns-record';
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * The republisher's `/routing/v1` byte mover (blueprint/api.md: resolve from the
+ * network, re-PUT the same bytes keyless). A dumb transport, mirroring the
+ * client seam's doctrine: it never inspects, decodes, verifies, or reorders
+ * records — it only addresses a name and moves opaque signed bytes. Absence is
+ * `null`; a rejected promise is a transport-level failure the walk treats as a
+ * resolve failure. Injected so tests substitute an in-memory fake.
+ */
+@Injectable()
+export abstract class RecordTransport {
+  /** Resolve the latest record bytes for a name; null if the network has none. */
+  abstract resolve(ipnsName: string): Promise<Buffer | null>;
+  /** Re-PUT opaque record bytes keyless (the records carry client-signed EOLs). */
+  abstract republish(ipnsName: string, record: Buffer): Promise<void>;
+}
+
+/**
+ * Default HTTP transport against a `/routing/v1` endpoint (self-hosted someguy in
+ * production, the hermetic mock store in CI). The endpoint is an accelerator, so
+ * a failed resolve or re-PUT is never fatal — it surfaces as a resolve failure /
+ * liveness alert, never a correctness break. Absent `ROUTING_V1_URL` the resolve
+ * returns null and the re-PUT no-ops (unit deploys, BYO-only).
+ */
+@Injectable()
+export class RoutingV1RecordTransport extends RecordTransport {
+  private readonly logger = new Logger(RecordTransport.name);
+  private readonly baseUrl: string | undefined;
+  private readonly timeoutMs: number;
+
+  constructor(configService: ConfigService) {
+    super();
+    const raw = configService.get<string>('ROUTING_V1_URL');
+    this.baseUrl = raw && raw.trim() ? raw.replace(/\/+$/, '') : undefined;
+    const timeout = Number(configService.get('ROUTING_V1_TIMEOUT_MS'));
+    this.timeoutMs = Number.isInteger(timeout) && timeout > 0 ? timeout : DEFAULT_TIMEOUT_MS;
+  }
+
+  async resolve(ipnsName: string): Promise<Buffer | null> {
+    if (!this.baseUrl) {
+      return null;
+    }
+    const response = await fetch(this.recordUrl(ipnsName), {
+      method: 'GET',
+      headers: { Accept: IPNS_RECORD_MEDIA_TYPE },
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      throw new Error(`routing GET ${response.status} for ${ipnsName}`);
+    }
+    return Buffer.from(await response.arrayBuffer());
+  }
+
+  async republish(ipnsName: string, record: Buffer): Promise<void> {
+    if (!this.baseUrl) {
+      this.logger.debug?.(`ROUTING_V1_URL unset; skipping re-PUT for ${ipnsName}`);
+      return;
+    }
+    const response = await fetch(this.recordUrl(ipnsName), {
+      method: 'PUT',
+      headers: { 'Content-Type': IPNS_RECORD_MEDIA_TYPE },
+      body: new Uint8Array(record),
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+    if (!response.ok) {
+      throw new Error(`routing PUT ${response.status} for ${ipnsName}`);
+    }
+  }
+
+  private recordUrl(ipnsName: string): string {
+    return `${this.baseUrl}/routing/v1/ipns/${encodeURIComponent(ipnsName)}`;
+  }
+}

--- a/apps/api/src/republisher/recovery.controller.ts
+++ b/apps/api/src/republisher/recovery.controller.ts
@@ -43,7 +43,7 @@ export class RecoveryController {
   @ApiResponse({
     status: 200,
     description: 'Opaque signed record bytes',
-    content: { [IPNS_RECORD_MEDIA_TYPE]: {} },
+    content: { [IPNS_RECORD_MEDIA_TYPE]: { schema: { type: 'string', format: 'binary' } } },
   })
   @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
   @ApiResponse({ status: 404, description: 'No cached record for this name' })

--- a/apps/api/src/republisher/recovery.controller.ts
+++ b/apps/api/src/republisher/recovery.controller.ts
@@ -1,0 +1,63 @@
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  StreamableFile,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { THROTTLE_SURFACES } from '../ops/throttling';
+import { RecordCacheService } from './services/record-cache.service';
+
+const IPNS_RECORD_MEDIA_TYPE = 'application/vnd.ipfs.ipns-record';
+/** A bare CID/name token; matches the registry's zero-knowledge name shape. */
+const IPNS_NAME = /^[A-Za-z0-9]{1,128}$/;
+
+/**
+ * The recovery endpoint (blueprint/api.md, Republisher module and recovery):
+ * authenticated, rate-limited fetch of cached (possibly EOL-expired) record
+ * bytes by name — the revival aid after a >EOL liveness lapse, where a
+ * key-holder extracts the last CID and mints a fresh record.
+ *
+ * This is the ONLY path by which the API serves a record, and it is explicitly
+ * NOT a resolve path: the cache is non-canonical, so a caller still verifies the
+ * bytes against the network itself. The API never inspects the record.
+ */
+@ApiTags('Recovery')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('recovery')
+export class RecoveryController {
+  constructor(private readonly cache: RecordCacheService) {}
+
+  @Get(':ipnsName')
+  @Throttle(THROTTLE_SURFACES.recovery)
+  @ApiOperation({
+    summary:
+      'Fetch cached (possibly expired) record bytes for a name — the revival aid after a >EOL lapse. Non-canonical: verify against the network.',
+  })
+  @ApiParam({ name: 'ipnsName', description: 'The IPNS name (libp2p-key CID)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Opaque signed record bytes',
+    content: { [IPNS_RECORD_MEDIA_TYPE]: {} },
+  })
+  @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
+  @ApiResponse({ status: 404, description: 'No cached record for this name' })
+  @ApiResponse({ status: 429, description: 'Recovery rate limit exceeded' })
+  async fetch(@Param('ipnsName') ipnsName: string): Promise<StreamableFile> {
+    // A malformed name can never key a server-minted row; treat it as absent so
+    // the `varchar`-typed lookup never faults and the endpoint reveals nothing.
+    if (!IPNS_NAME.test(ipnsName)) {
+      throw new NotFoundException('No cached record for this name');
+    }
+    const record = await this.cache.fetch(ipnsName);
+    if (!record) {
+      throw new NotFoundException('No cached record for this name');
+    }
+    return new StreamableFile(record, { type: IPNS_RECORD_MEDIA_TYPE });
+  }
+}

--- a/apps/api/src/republisher/recovery.http.test.ts
+++ b/apps/api/src/republisher/recovery.http.test.ts
@@ -1,0 +1,121 @@
+import { INestApplication } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { Test } from '@nestjs/testing';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { randomUUID } from 'node:crypto';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { configureApp } from '../app-setup';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OpsModule } from '../ops/ops.module';
+import { THROTTLE_SURFACES } from '../ops/throttling';
+import { RecoveryController } from './recovery.controller';
+import { RecordCacheService } from './services/record-cache.service';
+
+const SECRET = 'recovery-test-secret';
+
+/** Collect a binary response body for byte-exact assertions. */
+function binaryParser(res: request.Response, callback: (err: Error | null, body: Buffer) => void) {
+  const chunks: Buffer[] = [];
+  res.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+  res.on('end', () => callback(null, Buffer.concat(chunks)));
+}
+
+describe('recovery HTTP surface', () => {
+  let app: INestApplication;
+  let http: ReturnType<INestApplication['getHttpServer']>;
+  let jwt: JwtService;
+  let priorJwtSecret: string | undefined;
+  const cache = new Map<string, Buffer>();
+
+  const cacheService: Pick<RecordCacheService, 'fetch'> = {
+    fetch: async (ipnsName: string) => cache.get(ipnsName) ?? null,
+  };
+
+  beforeAll(async () => {
+    priorJwtSecret = process.env.JWT_SECRET;
+    process.env.JWT_SECRET = SECRET;
+    jwt = new JwtService();
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true }),
+        OpsModule,
+        JwtModule.register({ secret: SECRET, signOptions: { expiresIn: 900 } }),
+      ],
+      controllers: [RecoveryController],
+      providers: [JwtAuthGuard, { provide: RecordCacheService, useValue: cacheService }],
+    }).compile();
+
+    app = configureApp(moduleRef.createNestApplication());
+    await app.init();
+    http = app.getHttpServer();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    if (priorJwtSecret === undefined) delete process.env.JWT_SECRET;
+    else process.env.JWT_SECRET = priorJwtSecret;
+  });
+
+  async function token(): Promise<string> {
+    const priv = secp256k1.utils.randomPrivateKey();
+    const publicKey = Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+    return jwt.signAsync({ sub: randomUUID(), publicKey }, { secret: SECRET });
+  }
+
+  it('serves cached record bytes to an authenticated caller', async () => {
+    const name = 'k51recoveryhappy';
+    const bytes = Buffer.from([1, 2, 3, 4, 5, 250, 200]);
+    cache.set(name, bytes);
+
+    const res = await request(http)
+      .get(`/recovery/${name}`)
+      .set('Authorization', `Bearer ${await token()}`)
+      .buffer(true)
+      .parse(binaryParser)
+      .expect(200);
+
+    expect(res.headers['content-type']).toContain('application/vnd.ipfs.ipns-record');
+    expect(Buffer.compare(res.body, bytes)).toBe(0);
+  });
+
+  it('returns 404 for a name that was never cached', async () => {
+    await request(http)
+      .get('/recovery/k51neverseen')
+      .set('Authorization', `Bearer ${await token()}`)
+      .expect(404);
+  });
+
+  it('returns 404 for a malformed name without faulting', async () => {
+    await request(http)
+      .get('/recovery/not%20a%20valid%20name')
+      .set('Authorization', `Bearer ${await token()}`)
+      .expect(404);
+  });
+
+  it('requires authentication', async () => {
+    await request(http).get('/recovery/k51recoveryhappy').expect(401);
+  });
+
+  it('rate-limits the recovery surface per account (real 429s)', async () => {
+    const authed = `Bearer ${await token()}`;
+    const limit = THROTTLE_SURFACES.recovery.default.limit;
+    for (let i = 0; i < limit; i += 1) {
+      await request(http).get('/recovery/k51burst').set('Authorization', authed).expect(404);
+    }
+    const throttled = await request(http)
+      .get('/recovery/k51burst')
+      .set('Authorization', authed)
+      .expect(429);
+    expect(throttled.headers['retry-after']).toBeDefined();
+  });
+
+  it('keys the recovery limit by account: a fresh account is unaffected', async () => {
+    await request(http)
+      .get('/recovery/k51fresh')
+      .set('Authorization', `Bearer ${await token()}`)
+      .expect(404);
+  });
+});

--- a/apps/api/src/republisher/republisher.alerter.ts
+++ b/apps/api/src/republisher/republisher.alerter.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { MetricsService } from '../ops/metrics.service';
+
+/**
+ * Where the republisher raises liveness alerts (blueprint/api.md). A seam so the
+ * walk stays deterministic and testable: tests inject a recording fake and
+ * assert exactly which names alerted, while production logs and increments
+ * Prometheus counters an operator can page on.
+ */
+@Injectable()
+export abstract class RepublisherAlerter {
+  /** A registered name the network could not resolve — an orphan or unreachable. */
+  abstract resolveFailure(ipnsName: string): void;
+  /** A name >24h without a successful re-PUT — the liveness backstop is slipping. */
+  abstract staleRepublish(ipnsName: string, ageMs: number): void;
+  /** End-of-sweep summary for dashboards. */
+  abstract walkComplete(namesWalked: number, republished: number): void;
+}
+
+@Injectable()
+export class LoggingRepublisherAlerter extends RepublisherAlerter {
+  private readonly logger = new Logger(RepublisherAlerter.name);
+
+  constructor(private readonly metrics: MetricsService) {
+    super();
+  }
+
+  resolveFailure(ipnsName: string): void {
+    this.metrics.observeRepublisherResolveFailure();
+    this.logger.warn(`republisher resolve failure for ${ipnsName}`);
+  }
+
+  staleRepublish(ipnsName: string, ageMs: number): void {
+    this.metrics.observeRepublisherStaleName();
+    this.logger.warn(
+      `republisher: ${ipnsName} has gone ${Math.round(ageMs / 3_600_000)}h without a successful re-PUT`
+    );
+  }
+
+  walkComplete(namesWalked: number, republished: number): void {
+    this.metrics.observeRepublisherWalk(namesWalked, republished);
+  }
+}

--- a/apps/api/src/republisher/republisher.module.test.ts
+++ b/apps/api/src/republisher/republisher.module.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { isDisabled } from './republisher.module';
+
+describe('isDisabled (republisher default-on opt-out parse)', () => {
+  it('treats every explicit falsey token as disabled, case-insensitively', () => {
+    for (const raw of ['false', 'False', 'FALSE', '0', 'no', 'NO', 'off', 'OFF', ' false ']) {
+      expect(isDisabled(raw)).toBe(true);
+    }
+  });
+
+  it('stays enabled for unset or any non-falsey value', () => {
+    for (const raw of [undefined, '', 'true', 'True', '1', 'yes', 'on', 'enabled', 'random']) {
+      expect(isDisabled(raw)).toBe(false);
+    }
+  });
+});

--- a/apps/api/src/republisher/republisher.module.ts
+++ b/apps/api/src/republisher/republisher.module.ts
@@ -1,0 +1,72 @@
+import { Module, OnApplicationBootstrap, OnModuleDestroy } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { buildJwtOptions } from '../auth/auth.module';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TimerWorkerScheduler, WorkerScheduler } from '../common/worker-scheduler';
+import { OpsModule } from '../ops/ops.module';
+import { NameInventory } from '../registry/entities/name-inventory.entity';
+import { RecordCache } from './entities/record-cache.entity';
+import { MinimalIpnsSequenceReader, RecordSequenceReader } from './record-sequence-reader';
+import { RecordTransport, RoutingV1RecordTransport } from './record-transport';
+import { RecoveryController } from './recovery.controller';
+import { LoggingRepublisherAlerter, RepublisherAlerter } from './republisher.alerter';
+import { RepublisherTask } from './republisher.task';
+import { RecordCacheService } from './services/record-cache.service';
+
+/**
+ * The republisher slice (blueprint/api.md, Republisher module and recovery): the
+ * in-process, worker-shaped, cleanly extractable liveness backstop and its
+ * recovery endpoint. It owns the non-canonical record cache, the inventory walk
+ * on a ~12h cadence, and the authenticated recovery fetch. The name inventory is
+ * read-only here (the registry slice owns writes). Every side effect — the
+ * network transport, the sequence read, alerting, and the scheduler — is a seam,
+ * so the walk is deterministic under test and the module extracts cleanly.
+ *
+ * The scheduler and its {@link RepublisherTask} are wired here but the loop is
+ * generic: the dormant-mailbox scheduled sweep (#667) registers its own
+ * PeriodicTask on the same WorkerScheduler.
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([RecordCache, NameInventory]),
+    OpsModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: buildJwtOptions,
+    }),
+  ],
+  controllers: [RecoveryController],
+  providers: [
+    RecordCacheService,
+    RepublisherTask,
+    JwtAuthGuard,
+    { provide: WorkerScheduler, useClass: TimerWorkerScheduler },
+    { provide: RecordTransport, useClass: RoutingV1RecordTransport },
+    { provide: RecordSequenceReader, useClass: MinimalIpnsSequenceReader },
+    { provide: RepublisherAlerter, useClass: LoggingRepublisherAlerter },
+  ],
+})
+export class RepublisherModule implements OnApplicationBootstrap, OnModuleDestroy {
+  constructor(
+    private readonly scheduler: WorkerScheduler,
+    private readonly task: RepublisherTask,
+    private readonly configService: ConfigService
+  ) {}
+
+  onApplicationBootstrap(): void {
+    // Opt-out for deployments that run the republisher out of process (or none),
+    // defaulting on. Absent, the loop is a no-op cost — an unref'd 12h timer.
+    if (this.configService.get('REPUBLISHER_ENABLED') === 'false') {
+      return;
+    }
+    this.scheduler.register(this.task);
+    this.scheduler.start();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.scheduler.stop();
+  }
+}

--- a/apps/api/src/republisher/republisher.module.ts
+++ b/apps/api/src/republisher/republisher.module.ts
@@ -15,6 +15,14 @@ import { LoggingRepublisherAlerter, RepublisherAlerter } from './republisher.ale
 import { RepublisherTask } from './republisher.task';
 import { RecordCacheService } from './services/record-cache.service';
 
+/** Disabled tokens for a default-on flag; case-insensitive so `False`/`0`/`OFF` all count. */
+const DISABLED_TOKENS = new Set(['false', '0', 'no', 'off']);
+
+/** A default-on env flag is disabled only by an explicit falsey token; unset stays on. */
+export function isDisabled(raw: unknown): boolean {
+  return DISABLED_TOKENS.has(String(raw).trim().toLowerCase());
+}
+
 /**
  * The republisher slice (blueprint/api.md, Republisher module and recovery): the
  * in-process, worker-shaped, cleanly extractable liveness backstop and its
@@ -59,7 +67,7 @@ export class RepublisherModule implements OnApplicationBootstrap, OnModuleDestro
   onApplicationBootstrap(): void {
     // Opt-out for deployments that run the republisher out of process (or none),
     // defaulting on. Absent, the loop is a no-op cost — an unref'd 12h timer.
-    if (this.configService.get('REPUBLISHER_ENABLED') === 'false') {
+    if (isDisabled(this.configService.get('REPUBLISHER_ENABLED'))) {
       return;
     }
     this.scheduler.register(this.task);

--- a/apps/api/src/republisher/republisher.module.ts
+++ b/apps/api/src/republisher/republisher.module.ts
@@ -32,9 +32,11 @@ export function isDisabled(raw: unknown): boolean {
  * network transport, the sequence read, alerting, and the scheduler — is a seam,
  * so the walk is deterministic under test and the module extracts cleanly.
  *
- * The scheduler and its {@link RepublisherTask} are wired here but the loop is
- * generic: the dormant-mailbox scheduled sweep (#667) registers its own
- * PeriodicTask on the same WorkerScheduler.
+ * The scheduler and its {@link RepublisherTask} are wired here, but the loop is
+ * generic. The {@link WorkerScheduler} provider is scoped to this module, not a
+ * shared instance — when the dormant-mailbox scheduled sweep (#667) lands, one
+ * shared loop means exporting this provider (or hoisting it into a shared
+ * module) and registering the mailbox PeriodicTask on it, not binding a second.
  */
 @Module({
   imports: [

--- a/apps/api/src/republisher/republisher.scheduled.test.ts
+++ b/apps/api/src/republisher/republisher.scheduled.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import { FakeClock, fakeConfig } from '../testing/fakes';
+import { MinimalIpnsSequenceReader } from './record-sequence-reader';
+import { RecordTransport } from './record-transport';
+import { RepublisherAlerter } from './republisher.alerter';
+import { RepublisherTask } from './republisher.task';
+import type { CacheUpsertResult } from './services/record-cache.service';
+
+/**
+ * The compressed-EOL long-horizon run (blueprint/testing.md scheduled tier). It
+ * drives the republisher walk over months of VIRTUAL time at a compressed
+ * cadence — no real clock, no network — to prove two liveness properties end to
+ * end: a walked name is re-PUT every cadence so it never decays past its EOL,
+ * and an abandoned name goes stale (alerts) yet its last record stays fetchable
+ * from the non-canonical cache as the post-EOL revival aid.
+ *
+ * Scheduled-only (excluded from the PR unit + integration configs): it is a
+ * long-horizon soak, not a per-PR blocking gate.
+ */
+
+const HOUR = 3_600_000;
+const DAY = 24 * HOUR;
+
+function record(sequence: bigint): Buffer {
+  const bytes: number[] = [(5 << 3) | 0];
+  let v = sequence;
+  do {
+    let byte = Number(v & 0x7fn);
+    v >>= 7n;
+    if (v > 0n) byte |= 0x80;
+    bytes.push(byte);
+  } while (v > 0n);
+  return Buffer.from(bytes);
+}
+
+interface CacheRow {
+  record: Buffer;
+  sequence: bigint;
+  lastRepublishedAt: Date | null;
+  createdAt: Date;
+}
+
+class FakeRecordCache {
+  readonly rows = new Map<string, CacheRow>();
+  async upsert(name: string, rec: Buffer, sequence: bigint, now: Date): Promise<CacheUpsertResult> {
+    const existing = this.rows.get(name);
+    if (!existing) {
+      this.rows.set(name, { record: rec, sequence, lastRepublishedAt: null, createdAt: now });
+      return { stored: true };
+    }
+    if (sequence > existing.sequence) {
+      existing.record = rec;
+      existing.sequence = sequence;
+      return { stored: true };
+    }
+    return { stored: false };
+  }
+  async markRepublished(name: string, now: Date): Promise<void> {
+    const row = this.rows.get(name);
+    if (row) row.lastRepublishedAt = now;
+  }
+  async staleNames(cutoff: Date): Promise<{ ipnsName: string; baseline: Date }[]> {
+    const out: { ipnsName: string; baseline: Date }[] = [];
+    for (const [ipnsName, row] of this.rows) {
+      const baseline = row.lastRepublishedAt ?? row.createdAt;
+      if (baseline < cutoff) out.push({ ipnsName, baseline });
+    }
+    return out;
+  }
+  async fetch(name: string): Promise<Buffer | null> {
+    return this.rows.get(name)?.record ?? null;
+  }
+}
+
+class HorizonTransport extends RecordTransport {
+  republishedCounts = new Map<string, number>();
+  constructor(private readonly canRepublish: (name: string) => boolean) {
+    super();
+  }
+  async resolve(_name: string): Promise<Buffer | null> {
+    return record(1n); // the record is EOL-stable; only re-PUT keeps it live
+  }
+  async republish(name: string, _record: Buffer): Promise<void> {
+    if (!this.canRepublish(name)) throw new Error('re-PUT failed');
+    this.republishedCounts.set(name, (this.republishedCounts.get(name) ?? 0) + 1);
+  }
+}
+
+class RecordingAlerter extends RepublisherAlerter {
+  staleAlerts: { name: string; ageMs: number }[] = [];
+  resolveFailure(): void {}
+  staleRepublish(name: string, ageMs: number): void {
+    this.staleAlerts.push({ name, ageMs });
+  }
+  walkComplete(): void {}
+}
+
+function fakeNameRepo(names: string[]): never {
+  return {
+    createQueryBuilder: () => ({
+      select: () => ({ getRawMany: async () => names.map((ipns_name) => ({ ipns_name })) }),
+    }),
+  } as never;
+}
+
+describe('republisher long-horizon liveness (compressed EOL)', () => {
+  it('keeps a walked name live across a horizon far past its EOL, and preserves an abandoned name for recovery', async () => {
+    const cadenceMs = 12 * HOUR;
+    const horizonDays = 60; // well past the 5-day compressed EOL below
+    const compressedEolMs = 5 * DAY;
+    const abandonAtDay = 10;
+
+    const clock = new FakeClock(new Date('2026-01-01T00:00:00Z'));
+    const cache = new FakeRecordCache();
+    const alerter = new RecordingAlerter();
+
+    // 'abandoned' stops being re-PUT once the clock passes day 10; 'kept' always
+    // succeeds. The predicate reads the live clock each step.
+    const abandonAt = new Date('2026-01-01T00:00:00Z').getTime() + abandonAtDay * DAY;
+    const liveTransport = new HorizonTransport(
+      (name) => name !== 'abandoned' || clock.now().getTime() < abandonAt
+    );
+
+    const task = new RepublisherTask(
+      fakeNameRepo(['kept', 'abandoned']),
+      cache as never,
+      liveTransport,
+      new MinimalIpnsSequenceReader(),
+      alerter,
+      clock,
+      fakeConfig({ REPUBLISHER_STALE_ALERT_MS: String(DAY) }).service
+    );
+
+    const steps = (horizonDays * DAY) / cadenceMs;
+    let lastKeptRepublishAt = 0;
+    for (let i = 0; i < steps; i += 1) {
+      clock.advanceMs(cadenceMs);
+      await task.runOnce();
+      lastKeptRepublishAt = clock.now().getTime();
+    }
+
+    // 'kept' was re-PUT every single cadence — it never decays past its EOL.
+    expect(liveTransport.republishedCounts.get('kept')).toBe(steps);
+    expect(cache.rows.get('kept')?.lastRepublishedAt?.getTime()).toBe(lastKeptRepublishAt);
+    // Its liveness never triggered a staleness alert.
+    expect(alerter.staleAlerts.filter((a) => a.name === 'kept')).toHaveLength(0);
+
+    // 'abandoned' stopped being re-PUT at day 10 and went stale within a day.
+    expect(alerter.staleAlerts.some((a) => a.name === 'abandoned')).toBe(true);
+    const firstStale = alerter.staleAlerts.find((a) => a.name === 'abandoned')!;
+    expect(firstStale.ageMs).toBeGreaterThanOrEqual(DAY);
+
+    // Even long past its EOL, its last record is still served from the cache —
+    // the revival aid a key-holder uses to mint a fresh record.
+    const survived = await cache.fetch('abandoned');
+    expect(survived).not.toBeNull();
+    expect(Buffer.compare(survived!, record(1n))).toBe(0);
+    expect(compressedEolMs).toBeLessThan(horizonDays * DAY); // the horizon truly exceeds EOL
+  });
+});

--- a/apps/api/src/republisher/republisher.task.test.ts
+++ b/apps/api/src/republisher/republisher.task.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FakeClock, fakeConfig } from '../testing/fakes';
 import { MinimalIpnsSequenceReader } from './record-sequence-reader';
 import { RecordTransport } from './record-transport';
@@ -20,6 +20,13 @@ function record(sequence: bigint): Buffer {
     bytes.push(byte);
   } while (v > 0n);
   return Buffer.from(bytes);
+}
+
+/** A well-formed record carrying NO sequence field — the reader returns null. */
+function recordWithoutSequence(): Buffer {
+  // A length-delimited field 1 (`value`) only; field 5 (`sequence`) is absent.
+  const payload = Buffer.from('value-cid-bytes');
+  return Buffer.concat([Buffer.from([(1 << 3) | 2, payload.length]), payload]);
 }
 
 interface CacheRow {
@@ -75,6 +82,11 @@ class FakeTransport extends RecordTransport {
   resolveAnswers = new Map<string, Buffer | null | 'throw'>();
   republishFailures = new Set<string>();
   republished: string[] = [];
+  isConfigured = true;
+
+  override get configured(): boolean {
+    return this.isConfigured;
+  }
 
   async resolve(name: string): Promise<Buffer | null> {
     const answer = this.resolveAnswers.get(name);
@@ -84,6 +96,29 @@ class FakeTransport extends RecordTransport {
 
   async republish(name: string, _record: Buffer): Promise<void> {
     if (this.republishFailures.has(name)) throw new Error('re-PUT failed');
+    this.republished.push(name);
+  }
+}
+
+/** Transport that delays each resolve so a sweep's live concurrency is observable. */
+class ConcurrencyTransport extends RecordTransport {
+  inFlight = 0;
+  maxInFlight = 0;
+  republished: string[] = [];
+
+  constructor(private readonly delayMs: number) {
+    super();
+  }
+
+  async resolve(_name: string): Promise<Buffer | null> {
+    this.inFlight += 1;
+    this.maxInFlight = Math.max(this.maxInFlight, this.inFlight);
+    await new Promise((resolve) => setTimeout(resolve, this.delayMs));
+    this.inFlight -= 1;
+    return record(1n);
+  }
+
+  async republish(name: string, _record: Buffer): Promise<void> {
     this.republished.push(name);
   }
 }
@@ -120,10 +155,11 @@ function fakeNameRepo(names: string[]): never {
 function buildTask(opts: {
   names: string[];
   cache: FakeRecordCache;
-  transport: FakeTransport;
+  transport: RecordTransport;
   alerter: RecordingAlerter;
   clock: FakeClock;
   staleAlertMs?: number;
+  concurrency?: number;
 }): RepublisherTask {
   return new RepublisherTask(
     fakeNameRepo(opts.names),
@@ -134,6 +170,7 @@ function buildTask(opts: {
     opts.clock,
     fakeConfig({
       REPUBLISHER_STALE_ALERT_MS: String(opts.staleAlertMs ?? 24 * HOUR),
+      REPUBLISHER_CONCURRENCY: opts.concurrency ? String(opts.concurrency) : undefined,
     }).service
   );
 }
@@ -265,5 +302,120 @@ describe('RepublisherTask walk', () => {
     await buildTask({ names: ['name'], cache, transport, alerter, clock }).runOnce();
 
     expect(alerter.staleAlerts).toEqual([]);
+  });
+
+  // G2: a re-PUT name whose sequence is unreadable must still be cached so
+  // recovery can serve it and staleness can cover it — never a silent 0-row
+  // markRepublished. It caches at the floor 0; a later real record wins.
+  it('caches a re-PUT record even when its sequence is unreadable', async () => {
+    const cache = new FakeRecordCache();
+    const transport = new FakeTransport();
+    const alerter = new RecordingAlerter();
+    const clock = new FakeClock();
+    transport.resolveAnswers.set('seqless', recordWithoutSequence());
+
+    await buildTask({ names: ['seqless'], cache, transport, alerter, clock }).runOnce();
+
+    // Cached (recovery can fetch it) and stamped re-PUT (not a 0-row no-op).
+    const row = cache.rows.get('seqless');
+    expect(row?.sequence).toBe(0n);
+    expect(row?.lastRepublishedAt).toEqual(clock.now());
+    expect(transport.republished).toEqual(['seqless']);
+  });
+
+  it('lets a later real record (seq ≥ 1) overwrite a floored placeholder', async () => {
+    const cache = new FakeRecordCache();
+    const transport = new FakeTransport();
+    const clock = new FakeClock();
+    transport.resolveAnswers.set('name', recordWithoutSequence());
+    await buildTask({
+      names: ['name'],
+      cache,
+      transport,
+      alerter: new RecordingAlerter(),
+      clock,
+    }).runOnce();
+    expect(cache.rows.get('name')?.sequence).toBe(0n);
+
+    transport.resolveAnswers.set('name', record(1n));
+    await buildTask({
+      names: ['name'],
+      cache,
+      transport,
+      alerter: new RecordingAlerter(),
+      clock,
+    }).runOnce();
+    expect(cache.rows.get('name')?.sequence).toBe(1n);
+  });
+
+  // G3: no routing endpoint (BYO-only deploy) → the walk is a no-op, never an
+  // every-name resolve-failure alert storm.
+  it('skips the walk without alerting when the transport is not configured', async () => {
+    const cache = new FakeRecordCache();
+    const transport = new FakeTransport();
+    transport.isConfigured = false;
+    const alerter = new RecordingAlerter();
+    transport.resolveAnswers.set('name-a', record(1n));
+
+    await buildTask({
+      names: ['name-a', 'name-b', 'name-c'],
+      cache,
+      transport,
+      alerter,
+      clock: new FakeClock(),
+    }).runOnce();
+
+    expect(alerter.resolveFailures).toEqual([]);
+    expect(alerter.walks).toEqual([]);
+    expect(transport.republished).toEqual([]);
+    expect(cache.rows.size).toBe(0);
+  });
+
+  // G5: names walk through a bounded pool so one slow name can't serialize the
+  // sweep; live concurrency never exceeds the cap and all names still process.
+  describe('bounded concurrency', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('caps in-flight names at the configured concurrency and processes all', async () => {
+      const cache = new FakeRecordCache();
+      const transport = new ConcurrencyTransport(10);
+      const names = ['a', 'b', 'c', 'd', 'e'];
+      const task = buildTask({
+        names,
+        cache,
+        transport,
+        alerter: new RecordingAlerter(),
+        clock: new FakeClock(),
+        concurrency: 2,
+      });
+
+      const done = task.runOnce();
+      await vi.advanceTimersByTimeAsync(100);
+      await done;
+
+      expect(transport.maxInFlight).toBe(2); // never more than the cap
+      expect(transport.republished.sort()).toEqual([...names].sort());
+    });
+
+    it('runs every name concurrently when the cap exceeds the name count', async () => {
+      const cache = new FakeRecordCache();
+      const transport = new ConcurrencyTransport(10);
+      const names = ['a', 'b', 'c'];
+      const task = buildTask({
+        names,
+        cache,
+        transport,
+        alerter: new RecordingAlerter(),
+        clock: new FakeClock(),
+        concurrency: 8,
+      });
+
+      const done = task.runOnce();
+      await vi.advanceTimersByTimeAsync(100);
+      await done;
+
+      expect(transport.maxInFlight).toBe(3); // bounded by name count, not the cap
+    });
   });
 });

--- a/apps/api/src/republisher/republisher.task.test.ts
+++ b/apps/api/src/republisher/republisher.task.test.ts
@@ -39,12 +39,15 @@ interface CacheRow {
 /** In-memory cache mirroring RecordCacheService's monotonic semantics. */
 class FakeRecordCache {
   readonly rows = new Map<string, CacheRow>();
+  /** Names whose `upsert` rejects — models a transient per-name DB failure. */
+  readonly upsertThrows = new Set<string>();
 
   seed(name: string, row: CacheRow): void {
     this.rows.set(name, row);
   }
 
   async upsert(name: string, rec: Buffer, sequence: bigint, now: Date): Promise<CacheUpsertResult> {
+    if (this.upsertThrows.has(name)) throw new Error('cache upsert failed');
     const existing = this.rows.get(name);
     if (!existing) {
       this.rows.set(name, { record: rec, sequence, lastRepublishedAt: null, createdAt: now });
@@ -211,6 +214,38 @@ describe('RepublisherTask walk', () => {
     expect(alerter.resolveFailures.sort()).toEqual(['orphan', 'unreachable']);
     expect(transport.republished).toEqual(['live']);
     expect(cache.rows.has('orphan')).toBe(false);
+  });
+
+  // Per-name isolation (Greptile P1): a cache op that rejects for one name must
+  // not reject the pool and abandon the rest — the remaining inventory is still
+  // re-PUT, and the failing name is counted through the resolve-failure path.
+  it('isolates a cache failure to one name and still processes the rest', async () => {
+    const cache = new FakeRecordCache();
+    const transport = new FakeTransport();
+    const alerter = new RecordingAlerter();
+    const clock = new FakeClock();
+    cache.upsertThrows.add('boom');
+    transport.resolveAnswers.set('boom', record(1n));
+    transport.resolveAnswers.set('name-a', record(1n));
+    transport.resolveAnswers.set('name-b', record(1n));
+
+    await buildTask({
+      names: ['boom', 'name-a', 'name-b'],
+      cache,
+      transport,
+      alerter,
+      clock,
+    }).runOnce();
+
+    // The failing name never re-PUTs and is counted as a failure...
+    expect(transport.republished).not.toContain('boom');
+    expect(alerter.resolveFailures).toEqual(['boom']);
+    // ...while the healthy names are still re-PUT and stamped.
+    expect(transport.republished.sort()).toEqual(['name-a', 'name-b']);
+    expect(cache.rows.get('name-a')?.lastRepublishedAt).toEqual(clock.now());
+    expect(cache.rows.get('name-b')?.lastRepublishedAt).toEqual(clock.now());
+    // The sweep completed cleanly and reported the two successes.
+    expect(alerter.walks).toEqual([{ names: 3, republished: 2 }]);
   });
 
   it('refuses a sequence-regressing resolve but keeps re-PUTting for liveness', async () => {

--- a/apps/api/src/republisher/republisher.task.test.ts
+++ b/apps/api/src/republisher/republisher.task.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from 'vitest';
+import { FakeClock, fakeConfig } from '../testing/fakes';
+import { MinimalIpnsSequenceReader } from './record-sequence-reader';
+import { RecordTransport } from './record-transport';
+import { RepublisherAlerter } from './republisher.alerter';
+import { RepublisherTask } from './republisher.task';
+import type { CacheUpsertResult } from './services/record-cache.service';
+
+const HOUR = 3_600_000;
+
+/** Build an IPNS-record-shaped byte string carrying only the sequence field (5). */
+function record(sequence: bigint): Buffer {
+  const tag = (5 << 3) | 0;
+  const bytes: number[] = [tag];
+  let v = sequence;
+  do {
+    let byte = Number(v & 0x7fn);
+    v >>= 7n;
+    if (v > 0n) byte |= 0x80;
+    bytes.push(byte);
+  } while (v > 0n);
+  return Buffer.from(bytes);
+}
+
+interface CacheRow {
+  record: Buffer;
+  sequence: bigint;
+  lastRepublishedAt: Date | null;
+  createdAt: Date;
+}
+
+/** In-memory cache mirroring RecordCacheService's monotonic semantics. */
+class FakeRecordCache {
+  readonly rows = new Map<string, CacheRow>();
+
+  seed(name: string, row: CacheRow): void {
+    this.rows.set(name, row);
+  }
+
+  async upsert(name: string, rec: Buffer, sequence: bigint, now: Date): Promise<CacheUpsertResult> {
+    const existing = this.rows.get(name);
+    if (!existing) {
+      this.rows.set(name, { record: rec, sequence, lastRepublishedAt: null, createdAt: now });
+      return { stored: true };
+    }
+    if (sequence > existing.sequence) {
+      existing.record = rec;
+      existing.sequence = sequence;
+      return { stored: true };
+    }
+    return { stored: false };
+  }
+
+  async markRepublished(name: string, now: Date): Promise<void> {
+    const row = this.rows.get(name);
+    if (row) row.lastRepublishedAt = now;
+  }
+
+  async staleNames(cutoff: Date): Promise<{ ipnsName: string; baseline: Date }[]> {
+    const out: { ipnsName: string; baseline: Date }[] = [];
+    for (const [ipnsName, row] of this.rows) {
+      const baseline = row.lastRepublishedAt ?? row.createdAt;
+      if (baseline < cutoff) out.push({ ipnsName, baseline });
+    }
+    return out;
+  }
+
+  async fetch(name: string): Promise<Buffer | null> {
+    return this.rows.get(name)?.record ?? null;
+  }
+}
+
+/** Fake transport with per-name resolve answers and re-PUT outcomes. */
+class FakeTransport extends RecordTransport {
+  resolveAnswers = new Map<string, Buffer | null | 'throw'>();
+  republishFailures = new Set<string>();
+  republished: string[] = [];
+
+  async resolve(name: string): Promise<Buffer | null> {
+    const answer = this.resolveAnswers.get(name);
+    if (answer === 'throw') throw new Error('transport down');
+    return answer ?? null;
+  }
+
+  async republish(name: string, _record: Buffer): Promise<void> {
+    if (this.republishFailures.has(name)) throw new Error('re-PUT failed');
+    this.republished.push(name);
+  }
+}
+
+/** Recording alerter capturing every alert for assertions. */
+class RecordingAlerter extends RepublisherAlerter {
+  resolveFailures: string[] = [];
+  staleAlerts: { name: string; ageMs: number }[] = [];
+  walks: { names: number; republished: number }[] = [];
+
+  resolveFailure(name: string): void {
+    this.resolveFailures.push(name);
+  }
+  staleRepublish(name: string, ageMs: number): void {
+    this.staleAlerts.push({ name, ageMs });
+  }
+  walkComplete(names: number, republished: number): void {
+    this.walks.push({ names, republished });
+  }
+}
+
+/** A name-inventory repo stub exposing only the distinct-name query the task uses. */
+function fakeNameRepo(names: string[]): never {
+  const distinct = [...new Set(names)];
+  return {
+    createQueryBuilder: () => ({
+      select: () => ({
+        getRawMany: async () => distinct.map((ipns_name) => ({ ipns_name })),
+      }),
+    }),
+  } as never;
+}
+
+function buildTask(opts: {
+  names: string[];
+  cache: FakeRecordCache;
+  transport: FakeTransport;
+  alerter: RecordingAlerter;
+  clock: FakeClock;
+  staleAlertMs?: number;
+}): RepublisherTask {
+  return new RepublisherTask(
+    fakeNameRepo(opts.names),
+    opts.cache as never,
+    opts.transport,
+    new MinimalIpnsSequenceReader(),
+    opts.alerter,
+    opts.clock,
+    fakeConfig({
+      REPUBLISHER_STALE_ALERT_MS: String(opts.staleAlertMs ?? 24 * HOUR),
+    }).service
+  );
+}
+
+describe('RepublisherTask walk', () => {
+  it('resolves, caches, and re-PUTs every distinct name', async () => {
+    const cache = new FakeRecordCache();
+    const transport = new FakeTransport();
+    const alerter = new RecordingAlerter();
+    const clock = new FakeClock();
+    transport.resolveAnswers.set('name-a', record(1n));
+    transport.resolveAnswers.set('name-b', record(1n));
+
+    await buildTask({ names: ['name-a', 'name-b'], cache, transport, alerter, clock }).runOnce();
+
+    expect(transport.republished.sort()).toEqual(['name-a', 'name-b']);
+    expect(cache.rows.get('name-a')?.lastRepublishedAt).toEqual(clock.now());
+    expect(alerter.resolveFailures).toEqual([]);
+    expect(alerter.walks).toEqual([{ names: 2, republished: 2 }]);
+  });
+
+  it('alerts a resolve failure for an unresolvable name and never re-PUTs it', async () => {
+    const cache = new FakeRecordCache();
+    const transport = new FakeTransport();
+    const alerter = new RecordingAlerter();
+    transport.resolveAnswers.set('orphan', null); // registered-never-published orphan
+    transport.resolveAnswers.set('unreachable', 'throw'); // transport-level failure
+    transport.resolveAnswers.set('live', record(1n));
+
+    await buildTask({
+      names: ['orphan', 'unreachable', 'live'],
+      cache,
+      transport,
+      alerter,
+      clock: new FakeClock(),
+    }).runOnce();
+
+    expect(alerter.resolveFailures.sort()).toEqual(['orphan', 'unreachable']);
+    expect(transport.republished).toEqual(['live']);
+    expect(cache.rows.has('orphan')).toBe(false);
+  });
+
+  it('refuses a sequence-regressing resolve but keeps re-PUTting for liveness', async () => {
+    const cache = new FakeRecordCache();
+    const clock = new FakeClock();
+    cache.seed('name', {
+      record: record(5n),
+      sequence: 5n,
+      lastRepublishedAt: clock.now(),
+      createdAt: clock.now(),
+    });
+    const transport = new FakeTransport();
+    transport.resolveAnswers.set('name', record(3n)); // older than cached seq 5
+
+    await buildTask({
+      names: ['name'],
+      cache,
+      transport,
+      alerter: new RecordingAlerter(),
+      clock,
+    }).runOnce();
+
+    // The cache kept seq 5; the stale network answer did not regress it, but the
+    // bytes were still re-PUT (liveness is independent of the cache decision).
+    expect(cache.rows.get('name')?.sequence).toBe(5n);
+    expect(transport.republished).toEqual(['name']);
+  });
+
+  it('stores a strictly-newer resolved record', async () => {
+    const cache = new FakeRecordCache();
+    const clock = new FakeClock();
+    cache.seed('name', {
+      record: record(5n),
+      sequence: 5n,
+      lastRepublishedAt: clock.now(),
+      createdAt: clock.now(),
+    });
+    const transport = new FakeTransport();
+    transport.resolveAnswers.set('name', record(7n));
+
+    await buildTask({
+      names: ['name'],
+      cache,
+      transport,
+      alerter: new RecordingAlerter(),
+      clock,
+    }).runOnce();
+
+    expect(cache.rows.get('name')?.sequence).toBe(7n);
+  });
+
+  it('alerts a name >24h without a successful re-PUT and resets on success', async () => {
+    const cache = new FakeRecordCache();
+    const transport = new FakeTransport();
+    const alerter = new RecordingAlerter();
+    const clock = new FakeClock();
+
+    // A name last re-PUT 25h ago whose re-PUT keeps failing this sweep.
+    const stalePast = new Date(clock.now().getTime() - 25 * HOUR);
+    cache.seed('stale', {
+      record: record(2n),
+      sequence: 2n,
+      lastRepublishedAt: stalePast,
+      createdAt: stalePast,
+    });
+    transport.resolveAnswers.set('stale', record(2n));
+    transport.republishFailures.add('stale');
+
+    // A healthy name that re-PUTs fine this sweep.
+    transport.resolveAnswers.set('fresh', record(1n));
+
+    await buildTask({ names: ['stale', 'fresh'], cache, transport, alerter, clock }).runOnce();
+
+    expect(alerter.staleAlerts).toHaveLength(1);
+    expect(alerter.staleAlerts[0].name).toBe('stale');
+    expect(alerter.staleAlerts[0].ageMs).toBe(25 * HOUR);
+
+    // The fresh name re-PUT successfully, so it is not stale.
+    expect(alerter.staleAlerts.map((a) => a.name)).not.toContain('fresh');
+  });
+
+  it('does not alert a name comfortably within the staleness window', async () => {
+    const cache = new FakeRecordCache();
+    const transport = new FakeTransport();
+    const alerter = new RecordingAlerter();
+    const clock = new FakeClock();
+    transport.resolveAnswers.set('name', record(1n));
+
+    await buildTask({ names: ['name'], cache, transport, alerter, clock }).runOnce();
+
+    expect(alerter.staleAlerts).toEqual([]);
+  });
+});

--- a/apps/api/src/republisher/republisher.task.ts
+++ b/apps/api/src/republisher/republisher.task.ts
@@ -14,9 +14,15 @@ import { RecordCacheService } from './services/record-cache.service';
 const DEFAULT_INTERVAL_MS = 12 * 60 * 60 * 1000;
 /** >24h without a successful re-PUT alerts (blueprint/api.md); via REPUBLISHER_STALE_ALERT_MS. */
 const DEFAULT_STALE_ALERT_MS = 24 * 60 * 60 * 1000;
+/** Hard bound on one sweep (below the cadence); via REPUBLISHER_RUN_TIMEOUT_MS. */
+const DEFAULT_RUN_TIMEOUT_MS = 60 * 60 * 1000;
+/** In-flight names per sweep so one slow name can't stall the walk; via REPUBLISHER_CONCURRENCY. */
+const DEFAULT_CONCURRENCY = 8;
+/** The monotonic floor a record with no readable sequence caches at (see walkName). */
+const SEQUENCE_FLOOR = 0n;
 
-/** Read a positive-integer ms bound, failing closed to `fallback` for unset/garbage. */
-function positiveMs(raw: unknown, fallback: number): number {
+/** Read a positive integer, failing closed to `fallback` for unset/garbage. */
+function positiveInt(raw: unknown, fallback: number): number {
   const value = Number(raw);
   return Number.isInteger(value) && value > 0 ? value : fallback;
 }
@@ -38,7 +44,9 @@ function positiveMs(raw: unknown, fallback: number): number {
 export class RepublisherTask implements PeriodicTask {
   readonly taskName = 'republisher-walk';
   readonly intervalMs: number;
+  readonly runTimeoutMs: number;
   private readonly staleAlertMs: number;
+  private readonly concurrency: number;
 
   constructor(
     @InjectRepository(NameInventory)
@@ -50,23 +58,34 @@ export class RepublisherTask implements PeriodicTask {
     private readonly clock: Clock,
     configService: ConfigService
   ) {
-    this.intervalMs = positiveMs(configService.get('REPUBLISHER_INTERVAL_MS'), DEFAULT_INTERVAL_MS);
-    this.staleAlertMs = positiveMs(
+    this.intervalMs = positiveInt(
+      configService.get('REPUBLISHER_INTERVAL_MS'),
+      DEFAULT_INTERVAL_MS
+    );
+    this.staleAlertMs = positiveInt(
       configService.get('REPUBLISHER_STALE_ALERT_MS'),
       DEFAULT_STALE_ALERT_MS
+    );
+    this.runTimeoutMs = positiveInt(
+      configService.get('REPUBLISHER_RUN_TIMEOUT_MS'),
+      DEFAULT_RUN_TIMEOUT_MS
+    );
+    this.concurrency = positiveInt(
+      configService.get('REPUBLISHER_CONCURRENCY'),
+      DEFAULT_CONCURRENCY
     );
   }
 
   async runOnce(): Promise<void> {
+    // No routing endpoint (BYO-only deploy) → the walk can neither resolve nor
+    // re-PUT; skip it rather than fire a resolve-failure alert for every name.
+    if (!this.transport.configured) {
+      return;
+    }
+
     const now = this.clock.now();
     const names = await this.distinctNames();
-
-    let republished = 0;
-    for (const ipnsName of names) {
-      if (await this.walkName(ipnsName, now)) {
-        republished += 1;
-      }
-    }
+    const republished = await this.walkAll(names, now);
 
     // One bulk pass for the >24h liveness alert — never per-name.
     const cutoff = new Date(now.getTime() - this.staleAlertMs);
@@ -75,6 +94,31 @@ export class RepublisherTask implements PeriodicTask {
     }
 
     this.alerter.walkComplete(names.length, republished);
+  }
+
+  /**
+   * Walk names through a bounded worker pool so one slow name (up to a 10s
+   * resolve + 10s re-PUT) can't serialize the whole inventory past the cadence.
+   * Single-threaded JS makes the cursor claim atomic between awaits.
+   */
+  private async walkAll(names: string[], now: Date): Promise<number> {
+    let cursor = 0;
+    let republished = 0;
+    const worker = async (): Promise<void> => {
+      while (true) {
+        const i = cursor;
+        cursor += 1;
+        if (i >= names.length) {
+          return;
+        }
+        if (await this.walkName(names[i], now)) {
+          republished += 1;
+        }
+      }
+    };
+    const workers = Math.min(this.concurrency, names.length);
+    await Promise.all(Array.from({ length: workers }, () => worker()));
+    return republished;
   }
 
   /** Resolve → cache → re-PUT one name; returns true iff the keyless re-PUT succeeded. */
@@ -93,12 +137,13 @@ export class RepublisherTask implements PeriodicTask {
       return false;
     }
 
-    // Cache the freshest record; a missing/misread sequence just skips the
-    // update (the cache is non-canonical, so a skipped update is harmless).
-    const sequence = this.sequenceReader.read(record);
-    if (sequence !== null) {
-      await this.cache.upsert(ipnsName, record, sequence, now);
-    }
+    // Cache every re-PUT name, floored at 0 when the sequence is unreadable, so a
+    // successful re-PUT is never left without a row (which would 404 recovery and
+    // drop the name from staleness alerts). CipherBox records carry sequence ≥ 1,
+    // so the floor only bites garbage/non-CipherBox bytes — and the monotonic
+    // guard means a later real record (≥ 1) always wins over a floored one.
+    const sequence = this.sequenceReader.read(record) ?? SEQUENCE_FLOOR;
+    await this.cache.upsert(ipnsName, record, sequence, now);
 
     try {
       await this.transport.republish(ipnsName, record);

--- a/apps/api/src/republisher/republisher.task.ts
+++ b/apps/api/src/republisher/republisher.task.ts
@@ -98,7 +98,8 @@ export class RepublisherTask implements PeriodicTask {
 
   /**
    * Walk names through a bounded worker pool so one slow name (up to a 10s
-   * resolve + 10s re-PUT) can't serialize the whole inventory past the cadence.
+   * resolve + 10s re-PUT) can't serialize the whole inventory past the cadence,
+   * and one failing name can't reject the pool and abandon the rest of the sweep.
    * Single-threaded JS makes the cursor claim atomic between awaits.
    */
   private async walkAll(names: string[], now: Date): Promise<number> {
@@ -111,8 +112,15 @@ export class RepublisherTask implements PeriodicTask {
         if (i >= names.length) {
           return;
         }
-        if (await this.walkName(names[i], now)) {
-          republished += 1;
+        // Isolate each name: a rejection (a cache write that fails, say) alerts and
+        // counts for that name alone — it must never reject the pool and abandon
+        // the names not yet claimed until the next 12h cadence.
+        try {
+          if (await this.walkName(names[i], now)) {
+            republished += 1;
+          }
+        } catch {
+          this.alerter.resolveFailure(names[i]);
         }
       }
     };

--- a/apps/api/src/republisher/republisher.task.ts
+++ b/apps/api/src/republisher/republisher.task.ts
@@ -1,0 +1,121 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Clock } from '../common/clock';
+import { PeriodicTask } from '../common/worker-scheduler';
+import { NameInventory } from '../registry/entities/name-inventory.entity';
+import { RecordSequenceReader } from './record-sequence-reader';
+import { RecordTransport } from './record-transport';
+import { RepublisherAlerter } from './republisher.alerter';
+import { RecordCacheService } from './services/record-cache.service';
+
+/** ~12h walk cadence (blueprint/api.md); overridable via REPUBLISHER_INTERVAL_MS. */
+const DEFAULT_INTERVAL_MS = 12 * 60 * 60 * 1000;
+/** >24h without a successful re-PUT alerts (blueprint/api.md); via REPUBLISHER_STALE_ALERT_MS. */
+const DEFAULT_STALE_ALERT_MS = 24 * 60 * 60 * 1000;
+
+/** Read a positive-integer ms bound, failing closed to `fallback` for unset/garbage. */
+function positiveMs(raw: unknown, fallback: number): number {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+/**
+ * The republisher inventory walk (blueprint/api.md, Republisher module and
+ * recovery), shaped as a reusable {@link PeriodicTask}. Once per cadence it
+ * walks the DISTINCT names in the inventory, resolves each from the network,
+ * re-PUTs the same bytes keyless, and caches the freshest record (regression
+ * refused). It is a liveness optimization, never a correctness dependency:
+ * records carry client-signed 90-day EOLs, so a failed resolve or re-PUT only
+ * raises an alert, never a hard error.
+ *
+ * Every capability is a seam and time is the injected Clock — no direct clock or
+ * network call — so the compressed-EOL long-horizon test drives the whole walk
+ * over virtual time.
+ */
+@Injectable()
+export class RepublisherTask implements PeriodicTask {
+  readonly taskName = 'republisher-walk';
+  readonly intervalMs: number;
+  private readonly staleAlertMs: number;
+
+  constructor(
+    @InjectRepository(NameInventory)
+    private readonly nameRepository: Repository<NameInventory>,
+    private readonly cache: RecordCacheService,
+    private readonly transport: RecordTransport,
+    private readonly sequenceReader: RecordSequenceReader,
+    private readonly alerter: RepublisherAlerter,
+    private readonly clock: Clock,
+    configService: ConfigService
+  ) {
+    this.intervalMs = positiveMs(configService.get('REPUBLISHER_INTERVAL_MS'), DEFAULT_INTERVAL_MS);
+    this.staleAlertMs = positiveMs(
+      configService.get('REPUBLISHER_STALE_ALERT_MS'),
+      DEFAULT_STALE_ALERT_MS
+    );
+  }
+
+  async runOnce(): Promise<void> {
+    const now = this.clock.now();
+    const names = await this.distinctNames();
+
+    let republished = 0;
+    for (const ipnsName of names) {
+      if (await this.walkName(ipnsName, now)) {
+        republished += 1;
+      }
+    }
+
+    // One bulk pass for the >24h liveness alert — never per-name.
+    const cutoff = new Date(now.getTime() - this.staleAlertMs);
+    for (const stale of await this.cache.staleNames(cutoff)) {
+      this.alerter.staleRepublish(stale.ipnsName, now.getTime() - stale.baseline.getTime());
+    }
+
+    this.alerter.walkComplete(names.length, republished);
+  }
+
+  /** Resolve → cache → re-PUT one name; returns true iff the keyless re-PUT succeeded. */
+  private async walkName(ipnsName: string, now: Date): Promise<boolean> {
+    let record: Buffer | null;
+    try {
+      record = await this.transport.resolve(ipnsName);
+    } catch {
+      // A transport failure is indistinguishable from absence for a liveness
+      // aid — both surface as a resolve-failure alert (orphan / unreachable).
+      this.alerter.resolveFailure(ipnsName);
+      return false;
+    }
+    if (record === null) {
+      this.alerter.resolveFailure(ipnsName);
+      return false;
+    }
+
+    // Cache the freshest record; a missing/misread sequence just skips the
+    // update (the cache is non-canonical, so a skipped update is harmless).
+    const sequence = this.sequenceReader.read(record);
+    if (sequence !== null) {
+      await this.cache.upsert(ipnsName, record, sequence, now);
+    }
+
+    try {
+      await this.transport.republish(ipnsName, record);
+    } catch {
+      // Re-PUT failed; the staleness backstop alerts if this persists past 24h.
+      return false;
+    }
+    await this.cache.markRepublished(ipnsName, now);
+    return true;
+  }
+
+  /** The DISTINCT names across all accounts — union liveness (blueprint/api.md). */
+  private async distinctNames(): Promise<string[]> {
+    const rows: { ipns_name: string }[] = await this.nameRepository
+      .createQueryBuilder('n')
+      .select('DISTINCT n.ipns_name', 'ipns_name')
+      .getRawMany();
+    return rows.map((row) => row.ipns_name);
+  }
+}

--- a/apps/api/src/republisher/services/record-cache.service.integration.test.ts
+++ b/apps/api/src/republisher/services/record-cache.service.integration.test.ts
@@ -110,6 +110,25 @@ describe('RecordCacheService monotonicity (real Postgres)', () => {
     }
   });
 
+  it('stores and orders sequences across the full uint64 domain, past signed bigint', async () => {
+    const n = name();
+    // 2^63 overflows a signed `bigint` column; the numeric(20,0) column holds it,
+    // so a hostile/garbage high sequence stores instead of faulting the upsert.
+    const beyondSigned = 2n ** 63n;
+    expect((await service.upsert(n, bytes(1), beyondSigned, AT)).stored).toBe(true);
+    expect(await storedSequence(n)).toBe(beyondSigned);
+
+    // A strictly-greater near-max uint64 still wins.
+    const nearMax = 2n ** 64n - 1n;
+    expect((await service.upsert(n, bytes(2), nearMax, AT)).stored).toBe(true);
+    expect(await storedSequence(n)).toBe(nearMax);
+
+    // And a regression just below 2^63 is refused — monotonicity holds past the boundary.
+    const belowSigned = 2n ** 63n - 1n;
+    expect((await service.upsert(n, bytes(3), belowSigned, AT)).stored).toBe(false);
+    expect(await storedSequence(n)).toBe(nearMax);
+  });
+
   it('negative control — without the guard, a regressing sequence overwrites the newer record', async () => {
     const n = name();
     await unsafeUpsert(n, bytes(5), 5n);

--- a/apps/api/src/republisher/services/record-cache.service.integration.test.ts
+++ b/apps/api/src/republisher/services/record-cache.service.integration.test.ts
@@ -1,0 +1,162 @@
+import { randomBytes } from 'node:crypto';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createIntegrationDatabase, IntegrationDatabase } from '../../testing/integration-db';
+import { RecordCache } from '../entities/record-cache.entity';
+import { RecordCacheService } from './record-cache.service';
+
+/**
+ * The record cache's monotonicity invariant proven on a REAL Postgres: the
+ * conditional upsert refuses every sequence regression, atomically, with no
+ * read-then-write window. Each guarantee is pinned by a negative control that
+ * reproduces the regression once the `WHERE excluded.sequence > ...` guard is
+ * stripped (the naive `DO UPDATE`) — exactly the race the guard closes.
+ */
+
+function name(): string {
+  return `k51${randomBytes(12).toString('hex')}`;
+}
+
+function bytes(marker: number): Buffer {
+  return Buffer.concat([Buffer.from([marker]), randomBytes(16)]);
+}
+
+const AT = new Date('2026-07-01T00:00:00Z');
+
+describe('RecordCacheService monotonicity (real Postgres)', () => {
+  let db: IntegrationDatabase;
+  let service: RecordCacheService;
+
+  beforeAll(async () => {
+    db = await createIntegrationDatabase({ poolMax: 10 });
+    service = new RecordCacheService(db.dataSource.getRepository(RecordCache) as never);
+  });
+
+  afterAll(async () => {
+    await db?.teardown();
+  });
+
+  beforeEach(async () => {
+    await db.dataSource.query('TRUNCATE TABLE record_cache');
+  });
+
+  /** The pre-guard code path: an unconditional upsert that admits any sequence. */
+  async function unsafeUpsert(ipnsName: string, record: Buffer, sequence: bigint): Promise<void> {
+    await db.dataSource.query(
+      `INSERT INTO record_cache (ipns_name, record, sequence, created_at)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (ipns_name) DO UPDATE
+         SET record = EXCLUDED.record, sequence = EXCLUDED.sequence`,
+      [ipnsName, record, sequence.toString(), AT]
+    );
+  }
+
+  async function storedSequence(ipnsName: string): Promise<bigint | null> {
+    const row = await db.dataSource.getRepository(RecordCache).findOne({ where: { ipnsName } });
+    return row ? BigInt(row.sequence) : null;
+  }
+
+  it('inserts a first record and reports it stored', async () => {
+    const n = name();
+    const rec = bytes(1);
+    const result = await service.upsert(n, rec, 1n, AT);
+    expect(result.stored).toBe(true);
+    expect(Buffer.compare((await service.fetch(n))!, rec)).toBe(0);
+    expect(await storedSequence(n)).toBe(1n);
+  });
+
+  it('refuses a sequence-regressing record; the newer one survives', async () => {
+    const n = name();
+    const newer = bytes(5);
+    await service.upsert(n, newer, 5n, AT);
+
+    const refused = await service.upsert(n, bytes(3), 3n, AT);
+    expect(refused.stored).toBe(false);
+
+    // The cache still holds the newer record — the stale sequence was refused.
+    expect(await storedSequence(n)).toBe(5n);
+    expect(Buffer.compare((await service.fetch(n))!, newer)).toBe(0);
+  });
+
+  it('treats an equal sequence as an idempotent no-op', async () => {
+    const n = name();
+    const original = bytes(4);
+    await service.upsert(n, original, 4n, AT);
+
+    const again = await service.upsert(n, bytes(4), 4n, AT);
+    expect(again.stored).toBe(false);
+    // Strictly-greater means the same sequence never overwrites the bytes.
+    expect(Buffer.compare((await service.fetch(n))!, original)).toBe(0);
+  });
+
+  it('accepts a strictly-newer record', async () => {
+    const n = name();
+    await service.upsert(n, bytes(5), 5n, AT);
+    const newer = bytes(9);
+    const result = await service.upsert(n, newer, 9n, AT);
+    expect(result.stored).toBe(true);
+    expect(await storedSequence(n)).toBe(9n);
+    expect(Buffer.compare((await service.fetch(n))!, newer)).toBe(0);
+  });
+
+  it('the newer sequence wins under concurrent writes regardless of arrival order', async () => {
+    for (let i = 0; i < 25; i += 1) {
+      const n = name();
+      const newer = bytes(5);
+      // Fire the newer and older writes concurrently; the atomic conditional
+      // upsert must always settle on the newer, whichever row lands first.
+      await Promise.all([service.upsert(n, newer, 5n, AT), service.upsert(n, bytes(3), 3n, AT)]);
+      expect(await storedSequence(n)).toBe(5n);
+      expect(Buffer.compare((await service.fetch(n))!, newer)).toBe(0);
+    }
+  });
+
+  it('negative control — without the guard, a regressing sequence overwrites the newer record', async () => {
+    const n = name();
+    await unsafeUpsert(n, bytes(5), 5n);
+    await unsafeUpsert(n, bytes(3), 3n);
+    // The unconditional upsert admitted the older sequence — the regression the
+    // production guard refuses.
+    expect(await storedSequence(n)).toBe(3n);
+  });
+
+  describe('staleNames + markRepublished', () => {
+    /** Seed a row with explicit timestamps to drive the staleness cutoff. */
+    async function seed(
+      ipnsName: string,
+      createdAt: Date,
+      lastRepublishedAt: Date | null
+    ): Promise<void> {
+      await db.dataSource.query(
+        `INSERT INTO record_cache (ipns_name, record, sequence, created_at, last_republished_at)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [ipnsName, bytes(1), '1', createdAt, lastRepublishedAt]
+      );
+    }
+
+    it('returns names whose last re-PUT (or first-seen) predates the cutoff', async () => {
+      const now = new Date('2026-07-10T00:00:00Z');
+      const cutoff = new Date(now.getTime() - 24 * 3_600_000);
+      const stale = name();
+      const neverRepublished = name();
+      const fresh = name();
+
+      await seed(stale, new Date('2026-07-01T00:00:00Z'), new Date('2026-07-08T00:00:00Z')); // 2d stale
+      await seed(neverRepublished, new Date('2026-07-01T00:00:00Z'), null); // ages from created_at
+      await seed(fresh, new Date('2026-07-01T00:00:00Z'), new Date('2026-07-09T23:00:00Z')); // 1h ago
+
+      const staleNames = (await service.staleNames(cutoff)).map((s) => s.ipnsName).sort();
+      expect(staleNames).toEqual([neverRepublished, stale].sort());
+    });
+
+    it('markRepublished resets a name out of the stale set', async () => {
+      const now = new Date('2026-07-10T00:00:00Z');
+      const cutoff = new Date(now.getTime() - 24 * 3_600_000);
+      const n = name();
+      await seed(n, new Date('2026-07-01T00:00:00Z'), null);
+      expect((await service.staleNames(cutoff)).map((s) => s.ipnsName)).toContain(n);
+
+      await service.markRepublished(n, now);
+      expect((await service.staleNames(cutoff)).map((s) => s.ipnsName)).not.toContain(n);
+    });
+  });
+});

--- a/apps/api/src/republisher/services/record-cache.service.ts
+++ b/apps/api/src/republisher/services/record-cache.service.ts
@@ -1,0 +1,84 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RecordCache } from '../entities/record-cache.entity';
+
+export interface CacheUpsertResult {
+  /** True if the record was stored (first insert or a strictly-newer update). */
+  stored: boolean;
+}
+
+/**
+ * The non-canonical record cache store (blueprint/api.md). It is written only by
+ * the republisher walk and read only by the recovery endpoint — never on any
+ * client resolve path. Records are opaque signed bytes; this service never
+ * decodes them.
+ */
+@Injectable()
+export class RecordCacheService {
+  constructor(
+    @InjectRepository(RecordCache)
+    private readonly repository: Repository<RecordCache>
+  ) {}
+
+  /**
+   * Store a resolved record for a name, refusing any sequence regression.
+   *
+   * The refusal is a single atomic statement — a conditional upsert whose
+   * `WHERE excluded.sequence > record_cache.sequence` runs under the row lock
+   * `ON CONFLICT` already takes — so two concurrent writers of different
+   * sequences can never let the older one win, and no read-then-write window
+   * exists to race (blueprint/api.md: refuses sequence-regressing records). A
+   * strictly-greater comparison also makes re-storing the same sequence an
+   * idempotent no-op. `RETURNING` yields a row only when the write took, so an
+   * empty result set means the guard refused a stale/equal sequence.
+   */
+  async upsert(
+    ipnsName: string,
+    record: Buffer,
+    sequence: bigint,
+    now: Date
+  ): Promise<CacheUpsertResult> {
+    const rows: unknown[] = await this.repository.query(
+      `INSERT INTO record_cache (ipns_name, record, sequence, created_at)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (ipns_name) DO UPDATE
+         SET record = EXCLUDED.record, sequence = EXCLUDED.sequence
+         WHERE EXCLUDED.sequence > record_cache.sequence
+       RETURNING ipns_name`,
+      [ipnsName, record, sequence.toString(), now]
+    );
+    return { stored: rows.length > 0 };
+  }
+
+  /** Stamp a successful keyless re-PUT so the >24h liveness alert resets. */
+  async markRepublished(ipnsName: string, now: Date): Promise<void> {
+    await this.repository.update({ ipnsName }, { lastRepublishedAt: now });
+  }
+
+  /**
+   * Names whose last successful re-PUT (or first-seen, if never re-PUT) predates
+   * `cutoff` — the >24h liveness alert set. One bulk query, never per-name: the
+   * baseline is `COALESCE(last_republished_at, created_at)` so a name that has
+   * never been re-PUT ages from when it entered the cache.
+   */
+  async staleNames(cutoff: Date): Promise<{ ipnsName: string; baseline: Date }[]> {
+    const rows: { ipns_name: string; baseline: Date }[] = await this.repository.query(
+      `SELECT ipns_name, COALESCE(last_republished_at, created_at) AS baseline
+       FROM record_cache
+       WHERE COALESCE(last_republished_at, created_at) < $1`,
+      [cutoff]
+    );
+    return rows.map((row) => ({ ipnsName: row.ipns_name, baseline: new Date(row.baseline) }));
+  }
+
+  /**
+   * Fetch cached record bytes by name for the recovery endpoint; null if the
+   * name was never cached. The bytes may be past their EOL — recovery is
+   * explicitly the revival aid after a liveness lapse.
+   */
+  async fetch(ipnsName: string): Promise<Buffer | null> {
+    const row = await this.repository.findOne({ where: { ipnsName } });
+    return row ? row.record : null;
+  }
+}

--- a/apps/api/src/testing/integration-db.ts
+++ b/apps/api/src/testing/integration-db.ts
@@ -6,9 +6,11 @@ import { User } from '../auth/entities/user.entity';
 import { MailboxMessage } from '../mailbox/entities/mailbox-message.entity';
 import { AddMailboxMessages1784519962991 } from '../migrations/1784519962991-AddMailboxMessages';
 import { AddNameInventoryAndPinnedCids1784566605863 } from '../migrations/1784566605863-AddNameInventoryAndPinnedCids';
+import { AddRecordCache1784600557946 } from '../migrations/1784600557946-AddRecordCache';
 import { InitAuthSchema1784513040045 } from '../migrations/1784513040045-InitAuthSchema';
 import { NameInventory } from '../registry/entities/name-inventory.entity';
 import { PinnedCid } from '../registry/entities/pinned-cid.entity';
+import { RecordCache } from '../republisher/entities/record-cache.entity';
 
 /**
  * Standard DB_* env, defaulting to docker/docker-compose.yml. Only the admin
@@ -24,11 +26,20 @@ const DB = {
 // The full application schema — every entity + every committed migration — so a
 // throwaway database is a faithful copy of production regardless of which tables
 // a given suite touches.
-const ENTITIES = [User, AuthMethod, RefreshToken, NameInventory, PinnedCid, MailboxMessage];
+const ENTITIES = [
+  User,
+  AuthMethod,
+  RefreshToken,
+  NameInventory,
+  PinnedCid,
+  MailboxMessage,
+  RecordCache,
+];
 const MIGRATIONS = [
   InitAuthSchema1784513040045,
   AddMailboxMessages1784519962991,
   AddNameInventoryAndPinnedCids1784566605863,
+  AddRecordCache1784600557946,
 ];
 
 export interface IntegrationDatabase {

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -2,12 +2,17 @@ import { configDefaults, defineConfig } from 'vitest/config';
 import { swcPlugin } from './vitest.swc';
 
 // The unit suite: fake-backed Nest specs, no real Postgres. `*.test.ts` would
-// otherwise also match `*.integration.test.ts`, so those are excluded here and
-// run only in the dedicated real-Postgres job (see vitest.integration.config.ts).
+// otherwise also match `*.integration.test.ts` and `*.scheduled.test.ts`, so
+// those are excluded here and run only in their own jobs (see
+// vitest.integration.config.ts and vitest.scheduled.config.ts).
 export default defineConfig({
   test: {
     include: ['src/**/*.test.ts'],
-    exclude: [...configDefaults.exclude, 'src/**/*.integration.test.ts'],
+    exclude: [
+      ...configDefaults.exclude,
+      'src/**/*.integration.test.ts',
+      'src/**/*.scheduled.test.ts',
+    ],
     environment: 'node',
   },
   plugins: [swcPlugin()],

--- a/apps/api/vitest.scheduled.config.ts
+++ b/apps/api/vitest.scheduled.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import { swcPlugin } from './vitest.swc';
+
+// The scheduled tier (blueprint/testing.md: Dispatch / scheduled). Long-horizon
+// liveness soaks — the republisher walk against a compressed-EOL profile — run
+// over virtual time here, NOT in the per-PR gate. Triggered by cron/dispatch
+// (`.github/workflows/scheduled-liveness.yml`); the unit config excludes these
+// `*.scheduled.test.ts` files.
+export default defineConfig({
+  test: {
+    include: ['src/**/*.scheduled.test.ts'],
+    environment: 'node',
+    testTimeout: 60_000,
+  },
+  plugins: [swcPlugin()],
+});


### PR DESCRIPTION
## What landed

The in-process, worker-shaped, cleanly extractable **republisher** (blueprint/api.md, "Republisher module and recovery") plus the non-canonical record cache and the recovery endpoint.

- **Reusable worker-loop seam** (`apps/api/src/common/worker-scheduler.ts`): a `PeriodicTask` interface + a `WorkerScheduler` seam with a `TimerWorkerScheduler` implementation (per-task cadence, in-flight overlap-guard, error-isolation so one failed sweep never kills the loop). The republisher is its first task; **#667 (dormant-mailbox scheduled sweep) registers its own `PeriodicTask` on the same `WorkerScheduler`** — no republisher coupling.
- **The walk** (`republisher.task.ts`, a `PeriodicTask`): once per ~12h cadence it walks the **DISTINCT** inventory names (union liveness), resolves each from `/routing/v1`, re-PUTs the same bytes **keyless**, and caches the freshest record. It is a liveness optimization, never a correctness dependency (records carry client-signed 90-day EOLs) — a failed resolve/re-PUT only alerts.
- **Non-canonical `record_cache`** (name-keyed, rebuildable, on **no** client resolve path): written only by the walk, read only by recovery.
- **Liveness alerts** behind a `RepublisherAlerter` seam: resolve-failure (surfaces registered-never-published orphans / unreachable names) and >24h without a successful re-PUT. Default impl → Prometheus counters/gauges (`republisher_*`) + warn logs.
- **Recovery endpoint** `GET /recovery/:ipnsName`: authenticated (JWT) + per-account rate-limited, streams cached record bytes (matches the engine client's `recovery_fetch` contract). Malformed/absent → 404; it is the only path the API serves a record on, and it is explicitly not a resolve path.
- **Determinism**: cadence + all time come from the injected `Clock` + config seams; network transport (`RecordTransport`) and the sequence read (`RecordSequenceReader`) are seams. No direct clock/RNG.

## record_cache race-safety

"Refuses sequence-regressing records" is a check-then-act, so it is a **single atomic statement**, never a read-then-write:

```sql
INSERT INTO record_cache (...) VALUES (...)
ON CONFLICT (ipns_name) DO UPDATE
  SET record = EXCLUDED.record, sequence = EXCLUDED.sequence
  WHERE EXCLUDED.sequence > record_cache.sequence
RETURNING ipns_name
```

The `WHERE` runs under the row lock `ON CONFLICT` already takes, so two concurrent writers of different sequences can never let the older win; strictly-greater makes a re-resolve of the same sequence an idempotent no-op. `RETURNING` yields a row only when the write took.

## Zero-knowledge / codec boundary

The transport moves opaque bytes only. The one place that reads record structure is `RecordSequenceReader` — a **minimal, non-canonical, single-field** read of the public `sequence` (protobuf field 5) for cache ordering; it never validates the signature/EOL/payload, the record stays opaque for re-PUT, and a missing/misread sequence just skips the cache update (the cache is non-canonical). It is a seam, so a core-backed reader can replace it. The canonical IPNS codec stays in core.

## Tests + gates

| Test | Coverage | Gate |
| --- | --- | --- |
| `common/worker-scheduler.test.ts` | scheduler cadence, overlap-guard, error-isolation (fake timers) | **api-unit** |
| `republisher/republisher.task.test.ts` | walk, resolve-failure alert, >24h stale alert, regression skip (virtual time) | **api-unit** |
| `republisher/record-sequence-reader.test.ts` | sequence read, absent/malformed → null | **api-unit** |
| `republisher/recovery.http.test.ts` | recovery **auth (401)** + **rate-limit (real 429s)** + 200/404, per-account keying | **api-unit** |
| `republisher/services/record-cache.service.integration.test.ts` | sequence-regression race-safety on **real Postgres**, with **negative controls** (guard stripped → regression admitted; concurrent newer-wins), staleNames/markRepublished | **api-integration (real Postgres)** |
| `republisher/republisher.scheduled.test.ts` | compressed-EOL long-horizon soak (60d virtual time) | **scheduled tier** — `scheduled-liveness.yml` (cron + dispatch), NOT the PR gate |

Negative controls included per the gate: the record_cache test reproduces the regression once the `WHERE` guard is stripped (the naive `DO UPDATE`), proving the guard is load-bearing; the recovery test drives real 429s.

- **Migration Drift**: `1784600557946-AddRecordCache` was generated from the entity; `migration:generate` reports "No changes" → drift green.
- **OpenAPI Freshness**: regenerated with the `/recovery/:ipnsName` path + `Recovery` tag.

Local verification (shared Postgres on :5432): api typecheck, eslint, full unit suite (143), full integration suite (19, incl. 8 new record_cache), scheduled suite (1) all green; full app boots and maps `/recovery` (401 unauth), `/metrics` exposes the `republisher_*` series.

## Scheduled-tier vs PR-CI vs CI-only

- **Scheduled tier** (not PR-blocking): the compressed-EOL long-horizon run → `scheduled-liveness.yml`.
- **PR-CI (merge-blocking)**: everything else above — worker/walk unit, recovery auth+rate-limit, record_cache real-Postgres race-safety, migration drift, openapi freshness.
- **CI-stack-only follow-up**: a live inventory-walk / resolve-failure test against the real `/routing/v1` store belongs in the Rust contract suite. The seams (`RecordTransport`, `RecordSequenceReader`) are in place and `RoutingV1RecordTransport` is wired; the walk behavior itself is covered deterministically in the TS unit + integration gates here (the recovery endpoint auth+rate-limit is genuinely stronger as the TS HTTP test).

## Notes / deferrals

- Not landed (out of scope): the re-signer seam (TEE dropped), serving records on any resolve path, tombstone semantics.
- `RepublisherModule` imports `OpsModule` for `MetricsService` (Nest dedupes the singleton). The scheduler auto-starts on bootstrap (`REPUBLISHER_ENABLED=false` opts out; `REPUBLISHER_INTERVAL_MS` / `REPUBLISHER_STALE_ALERT_MS` tune cadence/threshold).
- Low cross-slice overlap with #629 (hosted upload): only migration-ordering adjacency and read-only use of the name inventory.

Closes #634


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated republishing to maintain IPNS record liveness.
  * Added authenticated recovery access for cached IPNS record bytes, with rate limiting.
  * Added safeguards against record sequence regressions and stale records.
  * Added operational metrics and alerts for republishing outcomes.

* **Bug Fixes**
  * Improved scheduled worker reliability by handling failures, overlapping runs, and timeouts without stopping future work.

* **Tests**
  * Added coverage for recovery, caching, scheduling, concurrency, and long-horizon liveness behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->