### PR TITLE
feat(api): add the hosted upload path with quota gate and registry traversal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -626,6 +626,10 @@ jobs:
       DB_DATABASE: cipherbox_test
       NODE_ENV: test
       JWT_SECRET: contract-suite-jwt-secret
+      # The hosted upload path pins to the CI Kubo service; a tiny per-account
+      # quota lets a few-hundred-byte upload straddle the over-quota limit.
+      KUBO_API_URL: http://localhost:5001
+      QUOTA_DEFAULT_BYTES: '1024'
       # The client-presented secret must equal the API's TEST_LOGIN_SECRET.
       TEST_LOGIN_SECRET: contract-suite-secret
       CONTRACT_API_URL: http://localhost:3000

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -601,6 +601,59 @@
           "Account"
         ]
       }
+    },
+    "/content/upload": {
+      "post": {
+        "operationId": "ContentController_upload",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Empty or non-binary upload body"
+          },
+          "401": {
+            "description": "Missing or invalid access token"
+          },
+          "413": {
+            "description": "Upload exceeds the account storage quota or size cap"
+          },
+          "429": {
+            "description": "Upload rate limit exceeded"
+          },
+          "503": {
+            "description": "Pin store contended or unavailable; retry shortly"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Upload content bytes to the hosted pin store; quota-gated for hosted accounts, advisory for BYO",
+        "tags": [
+          "Content"
+        ]
+      }
     }
   },
   "info": {
@@ -629,6 +682,10 @@
     {
       "name": "Account",
       "description": "Per-account quota and the BYO-IPFS toggle"
+    },
+    {
+      "name": "Content",
+      "description": "Hosted ingress: quota-gated byte upload to CipherBox Kubo"
     }
   ],
   "servers": [],
@@ -1014,6 +1071,23 @@
         },
         "required": [
           "byo"
+        ]
+      },
+      "UploadResponseDto": {
+        "type": "object",
+        "properties": {
+          "cid": {
+            "type": "string",
+            "description": "The content CID Kubo pinned"
+          },
+          "size": {
+            "type": "number",
+            "description": "The pinned size in bytes"
+          }
+        },
+        "required": [
+          "cid",
+          "size"
         ]
       }
     }

--- a/apps/api/scripts/generate-openapi.ts
+++ b/apps/api/scripts/generate-openapi.ts
@@ -20,6 +20,8 @@ import { AuthController } from '../src/auth/auth.controller';
 import { AuthService } from '../src/auth/services/auth.service';
 import { TestAuthService } from '../src/auth/services/test-auth.service';
 import { TokenService } from '../src/auth/services/token.service';
+import { ContentController } from '../src/content/content.controller';
+import { ContentService } from '../src/content/content.service';
 import { HealthController } from '../src/health/health.controller';
 import { MailboxController } from '../src/mailbox/mailbox.controller';
 import { MailboxService } from '../src/mailbox/services/mailbox.service';
@@ -37,6 +39,7 @@ import { RegistryService } from '../src/registry/services/registry.service';
     MailboxController,
     RegistryController,
     AccountController,
+    ContentController,
   ],
   providers: [
     { provide: AuthService, useValue: {} },
@@ -45,6 +48,7 @@ import { RegistryService } from '../src/registry/services/registry.service';
     { provide: MailboxService, useValue: {} },
     { provide: MetricsService, useValue: {} },
     { provide: RegistryService, useValue: {} },
+    { provide: ContentService, useValue: {} },
     { provide: JwtService, useValue: {} },
     { provide: ConfigService, useValue: new ConfigService() },
   ],

--- a/apps/api/src/app-setup.ts
+++ b/apps/api/src/app-setup.ts
@@ -2,6 +2,7 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
 import cookieParser from 'cookie-parser';
 import type { NextFunction, Request, Response } from 'express';
+import { verifiedSubjectFromBearer } from './ops/account-throttler.guard';
 
 /** Absolute upload-size cap (coarse DoS guard); the quota gate is the fine one. */
 const DEFAULT_MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
@@ -19,22 +20,34 @@ function maxUploadBytes(): number {
  * built-in json/urlencoded parsers skip octet-stream without consuming the
  * stream, so this runs as global middleware (before the async auth guard) to
  * capture the bytes deterministically — a stream read from inside the handler
- * would race the guard's `await`. Bodies over the cap abort with a 413.
+ * would race the guard's `await`.
+ *
+ * The buffer is gated behind a VERIFIED bearer signature: an unauthenticated
+ * client is passed through unbuffered so the route's `JwtAuthGuard` 401s it
+ * before it can force `maxBytes` of heap per connection (a credential-less
+ * memory-exhaustion DoS). The signature check mirrors the throttler's — expiry
+ * is left to the guard; a validly-signed token is a genuine, rate-limited
+ * account. The content-type match is case-insensitive per RFC 9110. A body over
+ * the cap is answered with a 413 and drained (never `req.destroy()`, which would
+ * reset the connection before the 413 could flush).
  */
 function rawUploadBody(maxBytes: number) {
   return (req: Request & { body?: unknown }, res: Response, next: NextFunction): void => {
-    if (!(req.headers['content-type'] ?? '').includes('application/octet-stream')) {
+    const contentType = (req.headers['content-type'] ?? '').toLowerCase();
+    if (!contentType.includes('application/octet-stream')) {
+      return next();
+    }
+    if (!verifiedSubjectFromBearer(req.headers as Record<string, unknown>)) {
       return next();
     }
     const chunks: Buffer[] = [];
     let total = 0;
     let aborted = false;
     req.on('data', (chunk: Buffer) => {
-      if (aborted) return;
+      if (aborted) return; // over the cap: drain the rest so the 413 can flush
       total += chunk.length;
       if (total > maxBytes) {
         aborted = true;
-        req.destroy();
         res.status(413).json({
           statusCode: 413,
           message: `Upload exceeds ${maxBytes} bytes`,

--- a/apps/api/src/app-setup.ts
+++ b/apps/api/src/app-setup.ts
@@ -1,6 +1,60 @@
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
 import cookieParser from 'cookie-parser';
+import type { NextFunction, Request, Response } from 'express';
+
+/** Absolute upload-size cap (coarse DoS guard); the quota gate is the fine one. */
+const DEFAULT_MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
+
+function maxUploadBytes(): number {
+  const raw = process.env.MAX_UPLOAD_BYTES;
+  const value = Number(raw);
+  return raw !== undefined && Number.isInteger(value) && value > 0
+    ? value
+    : DEFAULT_MAX_UPLOAD_BYTES;
+}
+
+/**
+ * Buffer an `application/octet-stream` body into `req.body` as a Buffer. Nest's
+ * built-in json/urlencoded parsers skip octet-stream without consuming the
+ * stream, so this runs as global middleware (before the async auth guard) to
+ * capture the bytes deterministically — a stream read from inside the handler
+ * would race the guard's `await`. Bodies over the cap abort with a 413.
+ */
+function rawUploadBody(maxBytes: number) {
+  return (req: Request & { body?: unknown }, res: Response, next: NextFunction): void => {
+    if (!(req.headers['content-type'] ?? '').includes('application/octet-stream')) {
+      return next();
+    }
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let aborted = false;
+    req.on('data', (chunk: Buffer) => {
+      if (aborted) return;
+      total += chunk.length;
+      if (total > maxBytes) {
+        aborted = true;
+        req.destroy();
+        res.status(413).json({
+          statusCode: 413,
+          message: `Upload exceeds ${maxBytes} bytes`,
+          error: 'Payload Too Large',
+        });
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      if (!aborted) {
+        req.body = Buffer.concat(chunks);
+        next();
+      }
+    });
+    req.on('error', (error) => {
+      if (!aborted) next(error);
+    });
+  };
+}
 
 /**
  * Shared HTTP-pipeline configuration, applied identically by main.ts and by
@@ -15,6 +69,7 @@ export function configureApp(app: INestApplication): INestApplication {
     })
   );
   app.use(cookieParser());
+  app.use(rawUploadBody(maxUploadBytes()));
   return app;
 }
 
@@ -64,6 +119,7 @@ export function buildOpenApiDocument(app: INestApplication): OpenAPIObject {
     .addTag('Mailbox', 'Integrity-untrusted sealed-pointer transport: post, poll, ack')
     .addTag('Registry', 'Pin/name registry: batch register/retire, union liveness')
     .addTag('Account', 'Per-account quota and the BYO-IPFS toggle')
+    .addTag('Content', 'Hosted ingress: quota-gated byte upload to CipherBox Kubo')
     .build();
   return SwaggerModule.createDocument(app, config);
 }

--- a/apps/api/src/app-setup.ts
+++ b/apps/api/src/app-setup.ts
@@ -2,7 +2,7 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
 import cookieParser from 'cookie-parser';
 import type { NextFunction, Request, Response } from 'express';
-import { verifiedSubjectFromBearer } from './ops/account-throttler.guard';
+import { verifiedUnexpiredSubjectFromBearer } from './ops/account-throttler.guard';
 
 /** Absolute upload-size cap (coarse DoS guard); the quota gate is the fine one. */
 const DEFAULT_MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
@@ -22,14 +22,15 @@ function maxUploadBytes(): number {
  * capture the bytes deterministically — a stream read from inside the handler
  * would race the guard's `await`.
  *
- * The buffer is gated behind a VERIFIED bearer signature: an unauthenticated
- * client is passed through unbuffered so the route's `JwtAuthGuard` 401s it
- * before it can force `maxBytes` of heap per connection (a credential-less
- * memory-exhaustion DoS). The signature check mirrors the throttler's — expiry
- * is left to the guard; a validly-signed token is a genuine, rate-limited
- * account. The content-type match is case-insensitive per RFC 9110. A body over
- * the cap is answered with a 413 and drained (never `req.destroy()`, which would
- * reset the connection before the 413 could flush).
+ * The buffer is gated behind a VERIFIED, UNEXPIRED bearer signature: an
+ * unauthenticated OR expired client is passed through unbuffered so the route's
+ * `JwtAuthGuard` 401s it before it can force `maxBytes` of heap per connection
+ * (a credential-less memory-exhaustion DoS). Expiry mirrors the guard's `exp`
+ * check with the same secret, so a validly-signed-but-expired token cannot
+ * buffer; only a genuine, rate-limited account does. The content-type match is
+ * case-insensitive per RFC 9110. A body over the cap is answered with a 413 and
+ * drained (never `req.destroy()`, which would reset the connection before the
+ * 413 could flush).
  */
 function rawUploadBody(maxBytes: number) {
   return (req: Request & { body?: unknown }, res: Response, next: NextFunction): void => {
@@ -37,7 +38,7 @@ function rawUploadBody(maxBytes: number) {
     if (!contentType.includes('application/octet-stream')) {
       return next();
     }
-    if (!verifiedSubjectFromBearer(req.headers as Record<string, unknown>)) {
+    if (!verifiedUnexpiredSubjectFromBearer(req.headers as Record<string, unknown>)) {
       return next();
     }
     const chunks: Buffer[] = [];

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from './auth/auth.module';
 import { RuntimeModule } from './common/runtime.module';
+import { ContentModule } from './content/content.module';
 import { MailboxModule } from './mailbox/mailbox.module';
 import { OpsModule } from './ops/ops.module';
 import { RegistryModule } from './registry/registry.module';
@@ -30,6 +31,7 @@ import { RegistryModule } from './registry/registry.module';
     AuthModule,
     MailboxModule,
     RegistryModule,
+    ContentModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/common/advisory-lock.ts
+++ b/apps/api/src/common/advisory-lock.ts
@@ -1,6 +1,7 @@
 import { ServiceUnavailableException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { EntityManager, QueryFailedError } from 'typeorm';
+import { createHash } from 'node:crypto';
+import { DataSource, EntityManager, QueryFailedError } from 'typeorm';
 
 /**
  * Default bound on how long an advisory-lock acquire may WAIT while holding its
@@ -78,4 +79,48 @@ export function isLockNotAvailable(error: unknown): boolean {
     (error.driverError as { code?: string } | undefined)?.code ??
     (error as unknown as { code?: string }).code;
   return code === LOCK_NOT_AVAILABLE;
+}
+
+/**
+ * Stable 64-bit advisory-lock key for an opaque token — a content CID, an IPNS
+ * name, or a namespaced account key: the first 8 bytes of its sha256 read
+ * big-endian as a signed 64-bit int for `pg_advisory_xact_lock($1::bigint)`.
+ * The registry and the upload path MUST share this function so the same CID
+ * locked from either serializes against the other.
+ */
+export function advisoryLockKey(token: string): bigint {
+  return createHash('sha256').update(token).digest().readBigInt64BE(0);
+}
+
+/**
+ * Acquire a batch of transaction-scoped advisory locks in one deadlock-free
+ * order: keys are de-duplicated and sorted, so any two overlapping batches take
+ * their shared keys in the same sequence and cannot form a cycle. Set the
+ * `lock_timeout` bound (setAdvisoryLockTimeout) once before calling.
+ */
+export async function acquireAdvisoryLocks(manager: EntityManager, keys: bigint[]): Promise<void> {
+  const sorted = [...new Set(keys)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  for (const key of sorted) {
+    await acquireAdvisoryLock(manager, key);
+  }
+}
+
+/**
+ * Run `work` in a transaction, mapping any `lock_timeout` abort (55P03) — the
+ * advisory acquire OR any row lock taken later under the same bound — to the
+ * retryable 503, so a contended caller degrades gracefully instead of escaping
+ * as a 500. A 503 an inner helper already raised passes through unchanged.
+ */
+export async function runLockGuardedTransaction<T>(
+  dataSource: DataSource,
+  work: (manager: EntityManager) => Promise<T>
+): Promise<T> {
+  try {
+    return await dataSource.transaction(work);
+  } catch (error) {
+    if (isLockNotAvailable(error)) {
+      throw new ServiceUnavailableException('Contended resource; retry shortly');
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/common/advisory-lock.ts
+++ b/apps/api/src/common/advisory-lock.ts
@@ -124,3 +124,58 @@ export async function runLockGuardedTransaction<T>(
     throw error;
   }
 }
+
+/**
+ * Run `work` while holding a SESSION-level advisory lock on `key`, on a
+ * dedicated connection held for the whole span and released in a `finally`.
+ * Unlike the xact lock (auto-released at COMMIT), a session lock spans several
+ * transactions PLUS an external side effect — the caller uses it to serialize a
+ * commit → external effect → compensation window that a xact lock would leave
+ * unguarded once it releases at commit. A `lock_timeout` abort maps to the
+ * retryable 503; the bound is set session-local on the dedicated connection and
+ * RESET before release so it never leaks to the next pool borrower.
+ */
+export async function withSessionAdvisoryLock<T>(
+  dataSource: DataSource,
+  key: bigint,
+  timeoutMs: number,
+  work: () => Promise<T>
+): Promise<T> {
+  const runner = dataSource.createQueryRunner();
+  await runner.connect();
+  const bounded = timeoutMs > 0;
+  try {
+    if (bounded) {
+      await runner.query('SELECT set_config($1, $2, false)', [
+        'lock_timeout',
+        Math.trunc(timeoutMs).toString(),
+      ]);
+    }
+    let acquired = false;
+    try {
+      await runner.query('SELECT pg_advisory_lock($1::bigint)', [key.toString()]);
+      acquired = true;
+      return await work();
+    } catch (error) {
+      if (isLockNotAvailable(error)) {
+        throw new ServiceUnavailableException('Contended resource; retry shortly');
+      }
+      throw error;
+    } finally {
+      // Unlock failure implies a dead connection, whose session lock Postgres
+      // has already dropped — the pool discards it on release.
+      if (acquired) {
+        await runner.query('SELECT pg_advisory_unlock($1::bigint)', [key.toString()]).catch(() => {
+          /* noop */
+        });
+      }
+    }
+  } finally {
+    if (bounded) {
+      await runner.query('RESET lock_timeout').catch(() => {
+        /* noop */
+      });
+    }
+    await runner.release();
+  }
+}

--- a/apps/api/src/content/content.controller.ts
+++ b/apps/api/src/content/content.controller.ts
@@ -1,0 +1,51 @@
+import { BadRequestException, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { AuthenticatedRequest, JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { THROTTLE_SURFACES } from '../ops/throttling';
+import { ContentService } from './content.service';
+import { UploadResponseDto } from './dto/content.dto';
+
+/**
+ * The hosted content ingress surface (blueprint/api.md, Content plane): an
+ * authenticated, quota-gated upload that pins opaque bytes to CipherBox Kubo.
+ * The raw `application/octet-stream` body is buffered by the global raw-body
+ * middleware (app-setup); BYO/dual byte paths bypass the API entirely.
+ */
+@ApiTags('Content')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('content')
+export class ContentController {
+  constructor(private readonly contentService: ContentService) {}
+
+  @Post('upload')
+  @Throttle(THROTTLE_SURFACES.content)
+  @ApiOperation({
+    summary:
+      'Upload content bytes to the hosted pin store; quota-gated for hosted accounts, advisory for BYO',
+  })
+  @ApiConsumes('application/octet-stream')
+  @ApiBody({ schema: { type: 'string', format: 'binary' } })
+  @ApiCreatedResponse({ type: UploadResponseDto })
+  @ApiResponse({ status: 400, description: 'Empty or non-binary upload body' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
+  @ApiResponse({ status: 413, description: 'Upload exceeds the account storage quota or size cap' })
+  @ApiResponse({ status: 429, description: 'Upload rate limit exceeded' })
+  @ApiResponse({ status: 503, description: 'Pin store contended or unavailable; retry shortly' })
+  upload(@Req() request: AuthenticatedRequest): Promise<UploadResponseDto> {
+    const body: unknown = request.body;
+    if (!Buffer.isBuffer(body) || body.length === 0) {
+      throw new BadRequestException('Empty or non-binary upload body');
+    }
+    return this.contentService.upload(request.user.userId, body);
+  }
+}

--- a/apps/api/src/content/content.http.test.ts
+++ b/apps/api/src/content/content.http.test.ts
@@ -198,13 +198,13 @@ describe('content upload cap and pre-buffer auth gate', () => {
     else process.env.MAX_UPLOAD_BYTES = priorMax;
   });
 
-  async function authToken(): Promise<string> {
+  async function authToken(expiresIn = 900): Promise<string> {
     const priv = secp256k1.utils.randomPrivateKey();
     try {
       const publicKey = Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
       return jwt.signAsync(
         { sub: '11111111-1111-4111-8111-111111111111', publicKey },
-        { secret: SECRET }
+        { secret: SECRET, expiresIn }
       );
     } finally {
       priv.fill(0);
@@ -228,5 +228,28 @@ describe('content upload cap and pre-buffer auth gate', () => {
       .set('Content-Type', 'application/octet-stream')
       .send(Buffer.alloc(MAX + 8, 1))
       .expect(401);
+  });
+
+  it('refuses an over-cap EXPIRED-but-signed upload with 401 before buffering (not 413)', async () => {
+    // A genuine signature over an expired `exp`: it must NOT trigger buffering,
+    // so the over-cap body is rejected as 401 (unbuffered), never 413.
+    const expired = await authToken(-10);
+    await request(http)
+      .post('/content/upload')
+      .set('Authorization', `Bearer ${expired}`)
+      .set('Content-Type', 'application/octet-stream')
+      .send(Buffer.alloc(MAX + 8, 1))
+      .expect(401);
+  });
+
+  it('still buffers and uploads for an unexpired valid token', async () => {
+    const token = await authToken();
+    const res = await request(http)
+      .post('/content/upload')
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/octet-stream')
+      .send(Buffer.from([1, 2, 3]))
+      .expect(201);
+    expect(res.body).toBeDefined();
   });
 });

--- a/apps/api/src/content/content.http.test.ts
+++ b/apps/api/src/content/content.http.test.ts
@@ -1,0 +1,137 @@
+import {
+  INestApplication,
+  PayloadTooLargeException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { Test } from '@nestjs/testing';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import request from 'supertest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OpsModule } from '../ops/ops.module';
+import { configureApp } from '../app-setup';
+import { ContentController } from './content.controller';
+import { ContentService, UploadResult } from './content.service';
+
+const SECRET = 'content-test-secret';
+
+/**
+ * The hosted-upload endpoint's HTTP behavior with the service mocked: the raw
+ * octet-stream body reaches the service as a Buffer, the DTO round-trips, auth
+ * is enforced, an empty body is rejected before the service runs, and a
+ * service-raised quota/pin fault maps to its status. The gate arithmetic and
+ * concurrency live in the real-Postgres integration suite.
+ */
+describe('content HTTP surface', () => {
+  let app: INestApplication;
+  let http: ReturnType<INestApplication['getHttpServer']>;
+  let jwt: JwtService;
+  let upload: ReturnType<typeof vi.fn>;
+  let priorJwtSecret: string | undefined;
+
+  beforeAll(async () => {
+    priorJwtSecret = process.env.JWT_SECRET;
+    process.env.JWT_SECRET = SECRET;
+    upload = vi.fn();
+    jwt = new JwtService();
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true }),
+        OpsModule,
+        JwtModule.register({ secret: SECRET, signOptions: { expiresIn: 900 } }),
+      ],
+      controllers: [ContentController],
+      providers: [JwtAuthGuard, { provide: ContentService, useValue: { upload } }],
+    }).compile();
+
+    app = configureApp(moduleRef.createNestApplication());
+    await app.init();
+    http = app.getHttpServer();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    if (priorJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = priorJwtSecret;
+    }
+  });
+
+  beforeEach(() => {
+    upload.mockReset();
+  });
+
+  async function token(): Promise<{ userId: string; token: string }> {
+    const priv = secp256k1.utils.randomPrivateKey();
+    try {
+      const publicKey = Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+      const userId = '11111111-1111-4111-8111-111111111111';
+      return { userId, token: await jwt.signAsync({ sub: userId, publicKey }, { secret: SECRET }) };
+    } finally {
+      priv.fill(0);
+    }
+  }
+
+  function post(t: string) {
+    return request(http)
+      .post('/content/upload')
+      .set('Authorization', `Bearer ${t}`)
+      .set('Content-Type', 'application/octet-stream');
+  }
+
+  it('passes the raw octet-stream body to the service as a Buffer and returns the DTO', async () => {
+    const auth = await token();
+    const result: UploadResult = { cid: 'bafyUploaded', size: 5 };
+    upload.mockResolvedValue(result);
+
+    const res = await post(auth.token)
+      .send(Buffer.from([1, 2, 3, 4, 5]))
+      .expect(201);
+
+    expect(res.body).toEqual(result);
+    expect(upload).toHaveBeenCalledTimes(1);
+    const [accountArg, bytesArg] = upload.mock.calls[0];
+    expect(accountArg).toBe(auth.userId);
+    expect(Buffer.isBuffer(bytesArg)).toBe(true);
+    expect([...(bytesArg as Buffer)]).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('rejects an empty body with 400 before the service runs', async () => {
+    const auth = await token();
+    await post(auth.token).send(Buffer.alloc(0)).expect(400);
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it('rejects a request with no access token (401)', async () => {
+    await request(http)
+      .post('/content/upload')
+      .set('Content-Type', 'application/octet-stream')
+      .send(Buffer.from([9]))
+      .expect(401);
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it('maps an over-quota service fault to 413', async () => {
+    const auth = await token();
+    upload.mockRejectedValue(
+      new PayloadTooLargeException('Upload exceeds the account storage quota')
+    );
+    await post(auth.token)
+      .send(Buffer.from([1, 2, 3]))
+      .expect(413);
+  });
+
+  it('maps a pin-store fault to a retryable 503', async () => {
+    const auth = await token();
+    upload.mockRejectedValue(
+      new ServiceUnavailableException('Pin store unavailable; upload not durable')
+    );
+    await post(auth.token)
+      .send(Buffer.from([1, 2, 3]))
+      .expect(503);
+  });
+});

--- a/apps/api/src/content/content.http.test.ts
+++ b/apps/api/src/content/content.http.test.ts
@@ -100,6 +100,23 @@ describe('content HTTP surface', () => {
     expect([...(bytesArg as Buffer)]).toEqual([1, 2, 3, 4, 5]);
   });
 
+  it('buffers a mixed-case Application/Octet-Stream content-type (case-insensitive per RFC 9110)', async () => {
+    const auth = await token();
+    const result: UploadResult = { cid: 'bafyMixedCase', size: 2 };
+    upload.mockResolvedValue(result);
+
+    const res = await request(http)
+      .post('/content/upload')
+      .set('Authorization', `Bearer ${auth.token}`)
+      .set('Content-Type', 'Application/Octet-Stream')
+      .send(Buffer.from([7, 8]))
+      .expect(201);
+
+    expect(res.body).toEqual(result);
+    const [, bytesArg] = upload.mock.calls[0];
+    expect([...(bytesArg as Buffer)]).toEqual([7, 8]);
+  });
+
   it('rejects an empty body with 400 before the service runs', async () => {
     const auth = await token();
     await post(auth.token).send(Buffer.alloc(0)).expect(400);
@@ -133,5 +150,83 @@ describe('content HTTP surface', () => {
     await post(auth.token)
       .send(Buffer.from([1, 2, 3]))
       .expect(503);
+  });
+});
+
+/**
+ * The raw-body cap and its auth gate, with a low MAX_UPLOAD_BYTES so the cap is
+ * cheap to trip. Proves (a) an over-cap authenticated upload gets a real 413 JSON
+ * response — not a connection reset from destroying the socket — and (b) an
+ * UNAUTHENTICATED over-cap upload is refused with 401 BEFORE any buffering, so a
+ * credential-less client cannot force the process to buffer up to the cap.
+ */
+describe('content upload cap and pre-buffer auth gate', () => {
+  const MAX = 16;
+  let app: INestApplication;
+  let http: ReturnType<INestApplication['getHttpServer']>;
+  let jwt: JwtService;
+  let priorJwtSecret: string | undefined;
+  let priorMax: string | undefined;
+
+  beforeAll(async () => {
+    priorJwtSecret = process.env.JWT_SECRET;
+    priorMax = process.env.MAX_UPLOAD_BYTES;
+    process.env.JWT_SECRET = SECRET;
+    process.env.MAX_UPLOAD_BYTES = String(MAX);
+    jwt = new JwtService();
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true }),
+        OpsModule,
+        JwtModule.register({ secret: SECRET, signOptions: { expiresIn: 900 } }),
+      ],
+      controllers: [ContentController],
+      providers: [JwtAuthGuard, { provide: ContentService, useValue: { upload: vi.fn() } }],
+    }).compile();
+
+    app = configureApp(moduleRef.createNestApplication());
+    await app.init();
+    http = app.getHttpServer();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    if (priorJwtSecret === undefined) delete process.env.JWT_SECRET;
+    else process.env.JWT_SECRET = priorJwtSecret;
+    if (priorMax === undefined) delete process.env.MAX_UPLOAD_BYTES;
+    else process.env.MAX_UPLOAD_BYTES = priorMax;
+  });
+
+  async function authToken(): Promise<string> {
+    const priv = secp256k1.utils.randomPrivateKey();
+    try {
+      const publicKey = Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+      return jwt.signAsync(
+        { sub: '11111111-1111-4111-8111-111111111111', publicKey },
+        { secret: SECRET }
+      );
+    } finally {
+      priv.fill(0);
+    }
+  }
+
+  it('answers an over-cap authenticated upload with a real 413 JSON body (no connection reset)', async () => {
+    const token = await authToken();
+    const res = await request(http)
+      .post('/content/upload')
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/octet-stream')
+      .send(Buffer.alloc(MAX + 8, 1))
+      .expect(413);
+    expect(res.body).toMatchObject({ statusCode: 413, error: 'Payload Too Large' });
+  });
+
+  it('refuses an over-cap UNAUTHENTICATED upload with 401 before buffering (not 413)', async () => {
+    await request(http)
+      .post('/content/upload')
+      .set('Content-Type', 'application/octet-stream')
+      .send(Buffer.alloc(MAX + 8, 1))
+      .expect(401);
   });
 });

--- a/apps/api/src/content/content.module.ts
+++ b/apps/api/src/content/content.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { buildJwtOptions } from '../auth/auth.module';
+import { User } from '../auth/entities/user.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { PinnedCid } from '../registry/entities/pinned-cid.entity';
+import { KuboPinStore, PinStore } from '../registry/pin-store';
+import { ContentController } from './content.controller';
+import { ContentService } from './content.service';
+
+/**
+ * The hosted content ingress slice (blueprint/api.md, Content plane). Reuses the
+ * registry's pin-store port and `pinned_cids` ledger — an upload registers its
+ * pin row in the same traversal as the byte path. Route auth reuses the auth
+ * slice's JwtAuthGuard and JWT configuration.
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([PinnedCid, User]),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: buildJwtOptions,
+    }),
+  ],
+  controllers: [ContentController],
+  providers: [ContentService, JwtAuthGuard, { provide: PinStore, useClass: KuboPinStore }],
+})
+export class ContentModule {}

--- a/apps/api/src/content/content.service.integration.test.ts
+++ b/apps/api/src/content/content.service.integration.test.ts
@@ -390,6 +390,43 @@ describe('ContentService upload concurrency (real Postgres)', () => {
     });
   });
 
+  describe('quota gate — scoped to authoritative (advisory=false) rows', () => {
+    it('does not count advisory/BYO rows against the hosted quota (no false 413)', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '100' });
+      // A stale advisory row an account kept after toggling BYO off, far over
+      // the limit — its bytes live on the user's own provider, not the quota.
+      await db.dataSource
+        .getRepository(PinnedCid)
+        .save({ accountId, cid: 'baAdvisoryStale', size: '500', advisory: true });
+
+      const pinStore = new FakePinStore();
+      const result = await buildService(db.dataSource, pinStore).upload(
+        accountId,
+        Buffer.alloc(60, 1)
+      );
+
+      expect(result.size).toBe(60);
+      // Only the new authoritative row counts; the advisory 500 bytes are excluded.
+      const authoritative = (await pinsFor(accountId)).filter((row) => !row.advisory);
+      expect(authoritative).toHaveLength(1);
+      expect(authoritative[0].size).toBe('60');
+    });
+
+    it('still 413s a genuine hosted-over-quota upload (authoritative rows do count)', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '100' });
+      await db.dataSource
+        .getRepository(PinnedCid)
+        .save({ accountId, cid: 'baHosted', size: '60', advisory: false });
+
+      const pinStore = new FakePinStore();
+      await expect(
+        buildService(db.dataSource, pinStore).upload(accountId, Buffer.alloc(60, 2))
+      ).rejects.toBeInstanceOf(PayloadTooLargeException);
+      // Nothing pinned; the authoritative 60 + incoming 60 > 100 refused.
+      expect(pinStore.pinned).toEqual([]);
+    });
+  });
+
   describe('atomic byte-pin + register', () => {
     it('pins the bytes and keeps the row on success', async () => {
       const accountId = await seedAccount({ quotaLimitOverride: '1000' });

--- a/apps/api/src/content/content.service.integration.test.ts
+++ b/apps/api/src/content/content.service.integration.test.ts
@@ -1,0 +1,396 @@
+import { PayloadTooLargeException, ServiceUnavailableException } from '@nestjs/common';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { createHash } from 'node:crypto';
+import { DataSource, EntityManager, Repository } from 'typeorm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { User } from '../auth/entities/user.entity';
+import { advisoryLockKey } from '../common/advisory-lock';
+import { PinnedCid } from '../registry/entities/pinned-cid.entity';
+import { PinStore } from '../registry/pin-store';
+import { fakeConfig } from '../testing/fakes';
+import { createIntegrationDatabase, IntegrationDatabase } from '../testing/integration-db';
+import { ContentService } from './content.service';
+
+/**
+ * The hosted upload path's two concurrency guards + the quota/atomicity
+ * invariants, proven on a REAL Postgres where genuine advisory locks and the
+ * numeric SUM behave as they cannot under an in-memory fake. Each guard is
+ * pinned by a negative control that reproduces the breach once the guard is
+ * stripped.
+ */
+
+function compressedPublicKey(): string {
+  const priv = secp256k1.utils.randomPrivateKey();
+  try {
+    return Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+  } finally {
+    priv.fill(0);
+  }
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Deterministic CID from bytes so hash() and pin() always agree; records effects. */
+class FakePinStore extends PinStore {
+  readonly pinned: string[] = [];
+  readonly unpinned: string[] = [];
+  failPin = false;
+
+  cidFor(bytes: Uint8Array): string {
+    return `ba${createHash('sha256').update(bytes).digest('hex')}`;
+  }
+
+  override async hash(bytes: Uint8Array): Promise<string> {
+    return this.cidFor(bytes);
+  }
+
+  override async pin(bytes: Uint8Array): Promise<string> {
+    if (this.failPin) {
+      throw new Error('pin store unavailable');
+    }
+    const cid = this.cidFor(bytes);
+    this.pinned.push(cid);
+    return cid;
+  }
+
+  async unpin(cid: string): Promise<void> {
+    this.unpinned.push(cid);
+  }
+}
+
+/** A barrier a gated transaction trips the instant it reaches its hook point. */
+interface Gate {
+  reached: Promise<void>;
+  release: () => void;
+  onReach: () => Promise<void>;
+}
+
+function makeGate(): Gate {
+  let signalReached!: () => void;
+  let release!: () => void;
+  const reached = new Promise<void>((resolve) => (signalReached = resolve));
+  const open = new Promise<void>((resolve) => (release = resolve));
+  return {
+    reached,
+    release,
+    onReach: async () => {
+      signalReached();
+      await open;
+    },
+  };
+}
+
+interface GateHooks {
+  /** Skip these advisory-lock keys' acquires — models removing a guard. */
+  skipLockKeys?: bigint[];
+  /** Pause right before the pin-row INSERT (after the quota gate has decided). */
+  beforeInsert?: () => Promise<void>;
+}
+
+/**
+ * A DataSource that runs the real transaction but can drop chosen advisory locks
+ * and pause before the insert, so a concurrent upload can be observed to block
+ * (lock present) or to race (lock removed).
+ */
+function gatedDataSource(real: DataSource, hooks: GateHooks): DataSource {
+  const skip = new Set((hooks.skipLockKeys ?? []).map((k) => k.toString()));
+  const wrapPinRepo = (repo: Repository<PinnedCid>): Repository<PinnedCid> =>
+    new Proxy(repo, {
+      get(target, prop, receiver) {
+        if (prop === 'insert') {
+          return async (entity: never) => {
+            if (hooks.beforeInsert) await hooks.beforeInsert();
+            return target.insert(entity);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function'
+          ? (value as (...a: unknown[]) => unknown).bind(target)
+          : value;
+      },
+    });
+
+  return {
+    transaction: (runInTransaction: (manager: EntityManager) => Promise<unknown>) =>
+      real.transaction((manager) => {
+        const proxied = new Proxy(manager, {
+          get(target, prop, receiver) {
+            if (prop === 'query') {
+              return async (sql: string, params?: unknown[]) => {
+                if (/pg_advisory_xact_lock/i.test(sql) && skip.has(String(params?.[0]))) {
+                  return [];
+                }
+                return target.query(sql, params);
+              };
+            }
+            if (prop === 'getRepository') {
+              return (entity: unknown) => {
+                const repo = target.getRepository(entity as never);
+                if (entity === PinnedCid) return wrapPinRepo(repo as Repository<PinnedCid>);
+                return repo;
+              };
+            }
+            const value = Reflect.get(target, prop, receiver);
+            return typeof value === 'function'
+              ? (value as (...a: unknown[]) => unknown).bind(target)
+              : value;
+          },
+        });
+        return runInTransaction(proxied);
+      }),
+  } as unknown as DataSource;
+}
+
+function accountLockKey(accountId: string): bigint {
+  return advisoryLockKey(`account:${accountId}`);
+}
+
+describe('ContentService upload concurrency (real Postgres)', () => {
+  let db: IntegrationDatabase;
+
+  beforeAll(async () => {
+    db = await createIntegrationDatabase({ poolMax: 10 });
+  });
+
+  afterAll(async () => {
+    await db?.teardown();
+  });
+
+  beforeEach(async () => {
+    await db.dataSource.query('TRUNCATE TABLE users CASCADE');
+  });
+
+  // Lock timeout disabled: the gate, not the wall clock, decides when a blocked
+  // upload proceeds. The timeout's own effect is proven in advisory-lock tests.
+  function buildService(
+    ds: DataSource,
+    pinStore: PinStore,
+    config: Record<string, string> = {}
+  ): ContentService {
+    return new ContentService(
+      ds as never,
+      pinStore,
+      fakeConfig({ DB_ADVISORY_LOCK_TIMEOUT_MS: '0', ...config }).service
+    );
+  }
+
+  async function seedAccount(overrides: Partial<User> = {}): Promise<string> {
+    const user = await db.dataSource
+      .getRepository(User)
+      .save({ publicKey: compressedPublicKey(), byo: false, ...overrides });
+    return user.id;
+  }
+
+  async function pinsFor(accountId: string): Promise<PinnedCid[]> {
+    return db.dataSource.getRepository(PinnedCid).find({ where: { accountId } });
+  }
+
+  async function usedBytes(accountId: string): Promise<bigint> {
+    const rows = await pinsFor(accountId);
+    return rows.reduce((total, row) => total + BigInt(row.size), 0n);
+  }
+
+  describe('quota gate — per-account advisory lock', () => {
+    it('serializes two same-account uploads at the limit: exactly one is admitted, the other refused', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '100' });
+      const gate = makeGate();
+      const pinStore = new FakePinStore();
+
+      const first = buildService(
+        gatedDataSource(db.dataSource, { beforeInsert: gate.onReach }),
+        pinStore
+      ).upload(accountId, Buffer.alloc(60, 1));
+
+      // first holds the account lock, passed the gate (used 0 + 60 <= 100), and
+      // paused just before its insert.
+      await gate.reached;
+
+      let secondDone = false;
+      const second = buildService(db.dataSource, pinStore)
+        .upload(accountId, Buffer.alloc(60, 2))
+        .then((r) => {
+          secondDone = true;
+          return r;
+        })
+        .catch((e: unknown) => {
+          secondDone = true;
+          throw e;
+        });
+
+      // second is blocked acquiring the account lock first still holds.
+      await delay(200);
+      expect(secondDone).toBe(false);
+
+      gate.release();
+      await expect(first).resolves.toMatchObject({ size: 60 });
+      // second wakes, reads used=60, and 60+60 > 100 is refused.
+      await expect(second).rejects.toBeInstanceOf(PayloadTooLargeException);
+
+      expect(await pinsFor(accountId)).toHaveLength(1);
+      expect(await usedBytes(accountId)).toBe(60n);
+    });
+
+    it('negative control — with the account lock removed, both uploads pass the stale sum and breach the quota', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '100' });
+      const skipLockKey = accountLockKey(accountId);
+      const gate = makeGate();
+      const pinStore = new FakePinStore();
+
+      // Both uploads skip ONLY the account lock; their CIDs differ, so the CID
+      // lock never serializes them — nothing does.
+      const first = buildService(
+        gatedDataSource(db.dataSource, { skipLockKeys: [skipLockKey], beforeInsert: gate.onReach }),
+        pinStore
+      ).upload(accountId, Buffer.alloc(60, 1));
+
+      await gate.reached; // first read used=0, passed the gate, paused before insert
+
+      // second runs fully with no account lock: it also reads used=0 and inserts.
+      await buildService(
+        gatedDataSource(db.dataSource, { skipLockKeys: [skipLockKey] }),
+        pinStore
+      ).upload(accountId, Buffer.alloc(60, 2));
+
+      gate.release();
+      await first;
+
+      // Both were admitted at the same 100-byte limit — a 120-byte over-quota
+      // breach the account lock closes.
+      expect(await pinsFor(accountId)).toHaveLength(2);
+      expect(await usedBytes(accountId)).toBe(120n);
+    });
+  });
+
+  describe('per-CID pin row — advisory lock', () => {
+    it('serializes two same-account uploads of the same CID into exactly one pin row (idempotent, charged once)', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '1000' });
+      const bytes = Buffer.alloc(40, 7);
+      const gate = makeGate();
+      const pinStore = new FakePinStore();
+
+      const first = buildService(
+        gatedDataSource(db.dataSource, { beforeInsert: gate.onReach }),
+        pinStore
+      ).upload(accountId, bytes);
+
+      await gate.reached;
+
+      let secondDone = false;
+      const second = buildService(db.dataSource, pinStore)
+        .upload(accountId, bytes)
+        .then((r) => {
+          secondDone = true;
+          return r;
+        });
+
+      // second is blocked at the shared account/CID locks first holds.
+      await delay(200);
+      expect(secondDone).toBe(false);
+
+      gate.release();
+      await expect(first).resolves.toMatchObject({ size: 40 });
+      // second wakes, finds first's committed row, and is an idempotent no-op.
+      await expect(second).resolves.toMatchObject({ size: 40 });
+
+      expect(await pinsFor(accountId)).toHaveLength(1);
+      expect(await usedBytes(accountId)).toBe(40n); // charged once, not 80
+    });
+
+    it('negative control — without the locks, two concurrent same-CID uploads collide on the unique index (23505)', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '1000' });
+      const bytes = Buffer.alloc(40, 7);
+      const cid = new FakePinStore().cidFor(bytes);
+      const skipKeys = [accountLockKey(accountId), advisoryLockKey(cid)];
+      const gate = makeGate();
+      const pinStore = new FakePinStore();
+
+      // Strip both the account and CID locks (they hash to distinct keys), so
+      // nothing serializes the two identical (account, cid) inserts.
+      const first = buildService(
+        gatedDataSource(db.dataSource, { skipLockKeys: skipKeys, beforeInsert: gate.onReach }),
+        pinStore
+      ).upload(accountId, bytes);
+
+      await gate.reached; // first found no existing row and paused before insert
+
+      // second runs fully with no locks: it also sees no existing row and inserts.
+      const secondResult = await buildService(
+        gatedDataSource(db.dataSource, { skipLockKeys: skipKeys }),
+        pinStore
+      )
+        .upload(accountId, bytes)
+        .catch((e: unknown) => e);
+
+      // first now inserts the duplicate (account, cid) and hits the unique index.
+      gate.release();
+      const firstResult = await first.catch((e: unknown) => e);
+
+      const errors = [firstResult, secondResult].filter((r) => r instanceof Error) as {
+        driverError?: { code?: string };
+        code?: string;
+      }[];
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      const codes = errors.map((e) => e.driverError?.code ?? e.code);
+      expect(codes).toContain('23505');
+    });
+  });
+
+  describe('quota gate — BigInt exactness above 2^53', () => {
+    it('refuses an upload a Number comparison would wrongly admit', async () => {
+      // A limit and existing use far above 2^53, where a JS number cannot tell
+      // `limit` from `limit + 1` (folded from #677).
+      const limit = (1n << 60n) + 1n;
+      const accountId = await seedAccount({ quotaLimitOverride: limit.toString() });
+      await db.dataSource
+        .getRepository(PinnedCid)
+        .save({ accountId, cid: 'baExistingHuge', size: limit.toString(), advisory: false });
+
+      // A Number-based gate would admit this (Number(used) + 1 rounds back to
+      // Number(limit)); the BigInt gate refuses it.
+      expect(Number(limit) + 1 <= Number(limit)).toBe(true);
+
+      const pinStore = new FakePinStore();
+      await expect(
+        buildService(db.dataSource, pinStore).upload(accountId, Buffer.alloc(1, 9))
+      ).rejects.toBeInstanceOf(PayloadTooLargeException);
+
+      // Nothing was pinned; the ledger is unchanged.
+      expect(pinStore.pinned).toEqual([]);
+      expect(await usedBytes(accountId)).toBe(limit);
+    });
+  });
+
+  describe('atomic byte-pin + register', () => {
+    it('pins the bytes and keeps the row on success', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '1000' });
+      const bytes = Buffer.alloc(20, 5);
+      const pinStore = new FakePinStore();
+
+      const result = await buildService(db.dataSource, pinStore).upload(accountId, bytes);
+
+      expect(result.size).toBe(20);
+      expect(pinStore.pinned).toEqual([result.cid]);
+      const rows = await pinsFor(accountId);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].cid).toBe(result.cid);
+    });
+
+    it('rolls back to no durable state when the post-commit pin fails (compensation)', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '1000' });
+      const bytes = Buffer.alloc(20, 6);
+      const pinStore = new FakePinStore();
+      pinStore.failPin = true;
+
+      await expect(
+        buildService(db.dataSource, pinStore).upload(accountId, bytes)
+      ).rejects.toBeInstanceOf(ServiceUnavailableException);
+
+      // Byte-pin + register are all-or-nothing: the row it registered was
+      // compensated away, so the account is charged nothing.
+      expect(await pinsFor(accountId)).toHaveLength(0);
+      expect(await usedBytes(accountId)).toBe(0n);
+      // The compensating retire unpinned the CID it could not durably pin.
+      expect(pinStore.unpinned).toEqual([pinStore.cidFor(bytes)]);
+    });
+  });
+});

--- a/apps/api/src/content/content.service.integration.test.ts
+++ b/apps/api/src/content/content.service.integration.test.ts
@@ -7,6 +7,7 @@ import { User } from '../auth/entities/user.entity';
 import { advisoryLockKey } from '../common/advisory-lock';
 import { PinnedCid } from '../registry/entities/pinned-cid.entity';
 import { PinStore } from '../registry/pin-store';
+import { RegistryService } from '../registry/services/registry.service';
 import { fakeConfig } from '../testing/fakes';
 import { createIntegrationDatabase, IntegrationDatabase } from '../testing/integration-db';
 import { ContentService, UploadResult } from './content.service';
@@ -559,6 +560,113 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       // survives — a successful upload referencing bytes that are not durable.
       expect(failing.unpinned).toEqual([cid]);
       expect(await pinsFor(accountId)).toHaveLength(0);
+    });
+  });
+
+  // A register() row records CID membership at size 0 with NO bytes on hosted
+  // Kubo. The upload path must NOT trust it as a completed pin (that would leave
+  // content unpinned and uncharged); it must promote it — pin + charge — while
+  // still no-opping a genuine duplicate of a completed hosted pin.
+  describe('registry-only row promotion (durability + quota)', () => {
+    function buildRegistry(pinStore: PinStore): RegistryService {
+      return new RegistryService(
+        db.dataSource.getRepository(PinnedCid),
+        db.dataSource.getRepository(User),
+        db.dataSource,
+        pinStore,
+        fakeConfig({ DB_ADVISORY_LOCK_TIMEOUT_MS: '0' }).service
+      );
+    }
+
+    it('promotes a size-0 registry-only row: the matching upload pins and charges it, not skip-with-0', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '1000' });
+      const bytes = Buffer.alloc(50, 8);
+      const pinStore = new FakePinStore();
+      const cid = pinStore.cidFor(bytes);
+
+      // register(cid): CID membership at size 0, nothing pinned to hosted Kubo.
+      await buildRegistry(pinStore).register(accountId, [
+        { ipnsName: 'k51-promote-name', contentCids: [cid] },
+      ]);
+      const registered = (await pinsFor(accountId)).find((row) => row.cid === cid);
+      expect(registered).toMatchObject({ size: '0', advisory: false });
+      expect(pinStore.pinned).toEqual([]); // register pins nothing
+
+      const result = await buildService(db.dataSource, pinStore).upload(accountId, bytes);
+
+      // The bytes are now DURABLY pinned, the row carries the real size, and the
+      // quota is charged — closing the skip-with-size-0 durability/quota hole.
+      expect(result).toMatchObject({ cid, size: 50 });
+      expect(pinStore.pinned).toEqual([cid]);
+      const rows = await pinsFor(accountId);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ cid, size: '50', advisory: false });
+      expect(await usedBytes(accountId)).toBe(50n);
+    });
+
+    it('no-ops a genuine duplicate of a completed hosted pin — charged once, not re-pinned', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '1000' });
+      const bytes = Buffer.alloc(30, 9);
+      const pinStore = new FakePinStore();
+
+      const first = await buildService(db.dataSource, pinStore).upload(accountId, bytes);
+      expect(first.size).toBe(30);
+      expect(pinStore.pinned).toEqual([first.cid]);
+
+      // The second upload finds a COMPLETED hosted pin (size > 0): idempotent
+      // no-op — no second pin, no second charge.
+      const second = await buildService(db.dataSource, pinStore).upload(accountId, bytes);
+      expect(second).toMatchObject({ cid: first.cid, size: 30 });
+      expect(pinStore.pinned).toEqual([first.cid]); // not re-pinned
+      expect(await pinsFor(accountId)).toHaveLength(1);
+      expect(await usedBytes(accountId)).toBe(30n); // charged once
+    });
+
+    it('gates the promotion on the hosted quota: an over-limit promote 413s and leaves the registration at size 0', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '40' });
+      const bytes = Buffer.alloc(50, 4);
+      const pinStore = new FakePinStore();
+      const cid = pinStore.cidFor(bytes);
+
+      await buildRegistry(pinStore).register(accountId, [
+        { ipnsName: 'k51-overquota-name', contentCids: [cid] },
+      ]);
+
+      await expect(
+        buildService(db.dataSource, pinStore).upload(accountId, bytes)
+      ).rejects.toBeInstanceOf(PayloadTooLargeException);
+
+      // Refused before any pin; the registry-only row is untouched (still size 0).
+      expect(pinStore.pinned).toEqual([]);
+      const rows = await pinsFor(accountId);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ cid, size: '0' });
+    });
+
+    it('reverts a promoted row to size 0 but keeps the registration when the post-commit pin fails', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '1000' });
+      const bytes = Buffer.alloc(50, 2);
+      const registerStore = new FakePinStore();
+      const cid = registerStore.cidFor(bytes);
+
+      await buildRegistry(registerStore).register(accountId, [
+        { ipnsName: 'k51-revert-name', contentCids: [cid] },
+      ]);
+
+      const failing = new FakePinStore();
+      failing.failPin = true;
+      await expect(
+        buildService(db.dataSource, failing).upload(accountId, bytes)
+      ).rejects.toBeInstanceOf(ServiceUnavailableException);
+
+      // Compensation reverts the size charge but MUST keep the pre-existing
+      // registration — a transient pin failure cannot un-register the client's
+      // CID membership. No unpin fires: nothing was ever durably pinned.
+      const rows = await pinsFor(accountId);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ cid, size: '0' });
+      expect(await usedBytes(accountId)).toBe(0n);
+      expect(failing.unpinned).toEqual([]);
     });
   });
 });

--- a/apps/api/src/content/content.service.integration.test.ts
+++ b/apps/api/src/content/content.service.integration.test.ts
@@ -1,7 +1,7 @@
 import { PayloadTooLargeException, ServiceUnavailableException } from '@nestjs/common';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { createHash } from 'node:crypto';
-import { DataSource, EntityManager, Repository } from 'typeorm';
+import { DataSource, EntityManager, QueryRunner, Repository } from 'typeorm';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { User } from '../auth/entities/user.entity';
 import { advisoryLockKey } from '../common/advisory-lock';
@@ -9,7 +9,7 @@ import { PinnedCid } from '../registry/entities/pinned-cid.entity';
 import { PinStore } from '../registry/pin-store';
 import { fakeConfig } from '../testing/fakes';
 import { createIntegrationDatabase, IntegrationDatabase } from '../testing/integration-db';
-import { ContentService } from './content.service';
+import { ContentService, UploadResult } from './content.service';
 
 /**
  * The hosted upload path's two concurrency guards + the quota/atomicity
@@ -35,6 +35,8 @@ class FakePinStore extends PinStore {
   readonly pinned: string[] = [];
   readonly unpinned: string[] = [];
   failPin = false;
+  /** When set, pin() reaches this gate (after commit) and waits before resolving. */
+  pinGate?: Gate;
 
   cidFor(bytes: Uint8Array): string {
     return `ba${createHash('sha256').update(bytes).digest('hex')}`;
@@ -45,6 +47,9 @@ class FakePinStore extends PinStore {
   }
 
   override async pin(bytes: Uint8Array): Promise<string> {
+    if (this.pinGate) {
+      await this.pinGate.onReach();
+    }
     if (this.failPin) {
       throw new Error('pin store unavailable');
     }
@@ -90,10 +95,30 @@ interface GateHooks {
 /**
  * A DataSource that runs the real transaction but can drop chosen advisory locks
  * and pause before the insert, so a concurrent upload can be observed to block
- * (lock present) or to race (lock removed).
+ * (lock present) or to race (lock removed). Skipping applies to BOTH the in-tx
+ * xact locks and the session lock taken on a dedicated query runner.
  */
 function gatedDataSource(real: DataSource, hooks: GateHooks): DataSource {
   const skip = new Set((hooks.skipLockKeys ?? []).map((k) => k.toString()));
+  // The session lock/unlock (pg_advisory_lock / pg_advisory_unlock) — NOT the
+  // xact variant (pg_advisory_xact_lock) — dropped when its key is skipped.
+  const wrapRunner = (runner: QueryRunner): QueryRunner =>
+    new Proxy(runner, {
+      get(target, prop, receiver) {
+        if (prop === 'query') {
+          return async (sql: string, params?: unknown[]) => {
+            if (/pg_advisory_(?:un)?lock\(/i.test(sql) && skip.has(String(params?.[0]))) {
+              return [];
+            }
+            return target.query(sql, params);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function'
+          ? (value as (...a: unknown[]) => unknown).bind(target)
+          : value;
+      },
+    });
   const wrapPinRepo = (repo: Repository<PinnedCid>): Repository<PinnedCid> =>
     new Proxy(repo, {
       get(target, prop, receiver) {
@@ -111,6 +136,7 @@ function gatedDataSource(real: DataSource, hooks: GateHooks): DataSource {
     });
 
   return {
+    createQueryRunner: () => wrapRunner(real.createQueryRunner()),
     transaction: (runInTransaction: (manager: EntityManager) => Promise<unknown>) =>
       real.transaction((manager) => {
         const proxied = new Proxy(manager, {
@@ -143,6 +169,10 @@ function gatedDataSource(real: DataSource, hooks: GateHooks): DataSource {
 
 function accountLockKey(accountId: string): bigint {
   return advisoryLockKey(`account:${accountId}`);
+}
+
+function pinDurabilityLockKey(cid: string): bigint {
+  return advisoryLockKey(`pin-durability:${cid}`);
 }
 
 describe('ContentService upload concurrency (real Postgres)', () => {
@@ -300,11 +330,11 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       const accountId = await seedAccount({ quotaLimitOverride: '1000' });
       const bytes = Buffer.alloc(40, 7);
       const cid = new FakePinStore().cidFor(bytes);
-      const skipKeys = [accountLockKey(accountId), advisoryLockKey(cid)];
+      const skipKeys = [accountLockKey(accountId), advisoryLockKey(cid), pinDurabilityLockKey(cid)];
       const gate = makeGate();
       const pinStore = new FakePinStore();
 
-      // Strip both the account and CID locks (they hash to distinct keys), so
+      // Strip the account, CID, and durability locks (all distinct keys), so
       // nothing serializes the two identical (account, cid) inserts.
       const first = buildService(
         gatedDataSource(db.dataSource, { skipLockKeys: skipKeys, beforeInsert: gate.onReach }),
@@ -391,6 +421,107 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       expect(await usedBytes(accountId)).toBe(0n);
       // The compensating retire unpinned the CID it could not durably pin.
       expect(pinStore.unpinned).toEqual([pinStore.cidFor(bytes)]);
+    });
+
+    // G2: the compensating delete does not take the account lock, so a
+    // concurrent same-account upload can transiently count the failed row and
+    // 413. That over-restriction is conservative (it never over-admits) and
+    // self-heals — once compensation removes the row the account carries no
+    // lingering charge, so an at-limit retry fits.
+    it('leaves no lingering quota charge after compensation, so a later at-limit upload succeeds', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '20' });
+
+      const failing = new FakePinStore();
+      failing.failPin = true;
+      await expect(
+        buildService(db.dataSource, failing).upload(accountId, Buffer.alloc(20, 1))
+      ).rejects.toBeInstanceOf(ServiceUnavailableException);
+      expect(await usedBytes(accountId)).toBe(0n);
+
+      const ok = new FakePinStore();
+      const result = await buildService(db.dataSource, ok).upload(accountId, Buffer.alloc(20, 2));
+      expect(result.size).toBe(20);
+      expect(await usedBytes(accountId)).toBe(20n);
+    });
+  });
+
+  describe('post-commit durability — per-CID session lock', () => {
+    it('closes the race: while A holds the durability lock through a failing pin, a same-CID B blocks until A compensates, then durably pins itself', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '1000' });
+      const bytes = Buffer.alloc(30, 3);
+      const cid = new FakePinStore().cidFor(bytes);
+
+      const pinGate = makeGate();
+      const failing = new FakePinStore();
+      failing.pinGate = pinGate;
+      failing.failPin = true;
+
+      // A: commits its row, then reaches the (failing) pin while still holding
+      // the session durability lock.
+      const a = buildService(db.dataSource, failing)
+        .upload(accountId, bytes)
+        .catch((e: unknown) => e);
+      await pinGate.reached;
+
+      // B: same CID, its own working pin store — blocks on the durability lock.
+      const okStore = new FakePinStore();
+      let bResult: UploadResult | undefined;
+      const b = buildService(db.dataSource, okStore)
+        .upload(accountId, bytes)
+        .then((r) => (bResult = r));
+
+      await delay(200);
+      expect(bResult).toBeUndefined(); // B is parked on the durability lock
+
+      pinGate.release(); // A's pin fails → A compensates (row deleted, CID unpinned) → releases
+      expect(await a).toBeInstanceOf(ServiceUnavailableException);
+
+      await b; // B wakes, finds no row, and pins the bytes itself
+      expect(bResult).toMatchObject({ cid, size: 30 });
+      expect(okStore.pinned).toEqual([cid]); // B's upload is DURABLE
+      const rows = await pinsFor(accountId);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].cid).toBe(cid);
+    });
+
+    it('negative control — with the durability lock removed, B returns success for a CID A leaves unpinned', async () => {
+      const accountId = await seedAccount({ quotaLimitOverride: '1000' });
+      const bytes = Buffer.alloc(30, 4);
+      const cid = new FakePinStore().cidFor(bytes);
+      const skipDurability = [pinDurabilityLockKey(cid)];
+
+      const pinGate = makeGate();
+      const failing = new FakePinStore();
+      failing.pinGate = pinGate;
+      failing.failPin = true;
+
+      // A skips the durability lock, so it cannot serialize B against A's
+      // post-commit pin/compensation window.
+      const a = buildService(
+        gatedDataSource(db.dataSource, { skipLockKeys: skipDurability }),
+        failing
+      )
+        .upload(accountId, bytes)
+        .catch((e: unknown) => e);
+      await pinGate.reached; // A committed its row, paused in the failing pin
+
+      // B runs fully while A is parked: it sees A's committed row and returns
+      // success WITHOUT pinning (skips its own pin as idempotent).
+      const okStore = new FakePinStore();
+      const bResult = (await buildService(
+        gatedDataSource(db.dataSource, { skipLockKeys: skipDurability }),
+        okStore
+      ).upload(accountId, bytes)) as UploadResult;
+      expect(bResult).toMatchObject({ cid, size: 30 });
+      expect(okStore.pinned).toEqual([]); // B pinned nothing — it trusted A's row
+
+      pinGate.release(); // A now fails and compensates the row + unpins the CID
+      expect(await a).toBeInstanceOf(ServiceUnavailableException);
+
+      // The breach: B returned success, yet the CID was unpinned and no row
+      // survives — a successful upload referencing bytes that are not durable.
+      expect(failing.unpinned).toEqual([cid]);
+      expect(await pinsFor(accountId)).toHaveLength(0);
     });
   });
 });

--- a/apps/api/src/content/content.service.ts
+++ b/apps/api/src/content/content.service.ts
@@ -15,6 +15,7 @@ import {
   resolveAdvisoryLockTimeoutMs,
   runLockGuardedTransaction,
   setAdvisoryLockTimeout,
+  withSessionAdvisoryLock,
 } from '../common/advisory-lock';
 import { PinnedCid } from '../registry/entities/pinned-cid.entity';
 import { PinStore } from '../registry/pin-store';
@@ -52,7 +53,11 @@ export interface UploadResult {
  *
  * The DB transaction is the source of truth; the durable Kubo pin fires AFTER
  * commit. Byte-pin + row register stay all-or-nothing: a post-commit pin
- * failure compensates by retiring the row it just added.
+ * failure compensates by retiring the row it just added. A per-CID SESSION lock
+ * (distinct `pin-durability:` key) spans commit → pin → compensate, so the in-tx
+ * xact lock releasing at commit cannot let a concurrent same-CID upload observe
+ * a committed row whose pin is still pending and return success for bytes that
+ * were never durably pinned.
  */
 @Injectable()
 export class ContentService {
@@ -79,6 +84,24 @@ export class ContentService {
     // ledger below can key on it before any bytes are pinned.
     const cid = await this.pinStore.hash(bytes);
 
+    // Serialize the whole commit → pin → compensate span per CID with a session
+    // lock, so a concurrent same-CID upload cannot observe a committed-but-not-
+    // yet-pinned row and return success for it (the in-tx xact lock releases at
+    // commit, too early to cover the post-commit pin).
+    return withSessionAdvisoryLock(
+      this.dataSource,
+      pinDurabilityLockKey(cid),
+      this.lockTimeoutMs,
+      () => this.registerAndPin(accountId, cid, size, bytes)
+    );
+  }
+
+  private async registerAndPin(
+    accountId: string,
+    cid: string,
+    size: number,
+    bytes: Buffer
+  ): Promise<UploadResult> {
     // Phase 2 — the source of truth: gate + register under the account and CID
     // advisory locks, atomically.
     const outcome = await runLockGuardedTransaction(this.dataSource, (manager) =>
@@ -174,4 +197,14 @@ export class ContentService {
 /** Namespaced account advisory key: `account:` prevents any UUID/CID key collision. */
 function accountLockKey(accountId: string): bigint {
   return advisoryLockKey(`account:${accountId}`);
+}
+
+/**
+ * Namespaced session lock for the post-commit pin/compensation window. A
+ * DISTINCT key from the plain CID xact lock: the same upload holds both (session
+ * lock on its own connection, xact lock on the tx connection), and same-key
+ * session-vs-xact locks across connections would self-deadlock.
+ */
+function pinDurabilityLockKey(cid: string): bigint {
+  return advisoryLockKey(`pin-durability:${cid}`);
 }

--- a/apps/api/src/content/content.service.ts
+++ b/apps/api/src/content/content.service.ts
@@ -27,11 +27,17 @@ import {
   sumHostedBytes,
 } from '../registry/quota';
 
-/** A stored pin outcome plus whether THIS upload created the row (drives the pin). */
+/**
+ * A stored pin outcome. `created` drives the durable pin — true both when this
+ * upload inserted a fresh row and when it PROMOTED a registry-only row (size 0,
+ * never hosted-pinned) to a real hosted pin. `promoted` tells compensation to
+ * revert just the size charge on that pre-existing row rather than delete it.
+ */
 interface RegisterOutcome {
   cid: string;
   size: number;
   created: boolean;
+  promoted: boolean;
 }
 
 export interface UploadResult {
@@ -51,9 +57,14 @@ export interface UploadResult {
  *    the registry's register/retire take, so an insert here can never race an
  *    unpin there. Both keys acquire in one sorted batch (deadlock-free).
  *
+ * A register-only row (CID membership recorded at size 0 with no hosted bytes)
+ * is NOT a completed pin: an upload of the matching bytes promotes it — pinning
+ * and charging it — rather than trusting content Kubo never held.
+ *
  * The DB transaction is the source of truth; the durable Kubo pin fires AFTER
- * commit. Byte-pin + row register stay all-or-nothing: a post-commit pin
- * failure compensates by retiring the row it just added. A per-CID SESSION lock
+ * commit. Byte-pin + row register stay all-or-nothing: a post-commit pin failure
+ * compensates by retiring a row it inserted, or reverting a promoted row's size
+ * charge (the pre-existing registration survives). A per-CID SESSION lock
  * (distinct `pin-durability:` key) spans commit → pin → compensate, so the in-tx
  * xact lock releasing at commit cannot let a concurrent same-CID upload observe
  * a committed row whose pin is still pending and return success for bytes that
@@ -109,19 +120,20 @@ export class ContentService {
     );
 
     // Phase 3 — durable pin AFTER commit. Byte-pin + register are all-or-nothing:
-    // a pin failure (or a CID mismatch) compensates by retiring the new row.
+    // a pin failure (or a CID mismatch) compensates — retiring a row it inserted,
+    // or reverting a promoted row's size charge.
     if (outcome.created) {
       let pinnedCid: string;
       try {
         pinnedCid = await this.pinStore.pin(bytes);
       } catch {
-        await this.compensate(accountId, cid);
+        await this.compensate(accountId, cid, outcome.promoted);
         throw new ServiceUnavailableException('Pin store unavailable; upload not durable');
       }
       if (pinnedCid !== cid) {
         // Fail closed: the row keys on `cid`; a mismatch means Kubo pinned bytes
         // under a different CID than the ledger references.
-        await this.compensate(accountId, cid);
+        await this.compensate(accountId, cid, outcome.promoted);
         throw new ServiceUnavailableException('Pin CID mismatch; upload rejected');
       }
     }
@@ -152,14 +164,21 @@ export class ContentService {
     const advisory = user.byo;
 
     const existing = await pinRepo.findOne({ where: { accountId, cid } });
-    if (existing) {
+    // A registry-only row (register() records CID membership at size 0 with no
+    // bytes on hosted Kubo) is NOT a completed hosted pin: only `size > 0` marks
+    // durably-pinned, charged bytes. Short-circuit as idempotent only for the
+    // latter; promote the former so the bytes are actually pinned and charged
+    // rather than trusted for content Kubo never held.
+    if (existing && BigInt(existing.size) > 0n) {
       // Idempotent re-upload: the CID already counts — no gate, no new charge.
-      return { cid, size: Number(existing.size), created: false };
+      return { cid, size: Number(existing.size), created: false, promoted: false };
     }
 
     if (!advisory) {
       // Gate against AUTHORITATIVE rows only: stale advisory/BYO rows an account
       // kept after toggling BYO off live on its own provider, not the hosted quota.
+      // A promoted row is still size 0 here, so it adds nothing to `used` — the
+      // gate charges the incoming size exactly once, never double-counting.
       const used = await sumHostedBytes(pinRepo, accountId);
       const limit = resolveLimitBytes(user.quotaLimitOverride, this.defaultLimitBytes);
       if (exceedsQuota(used, BigInt(size), limit)) {
@@ -167,22 +186,38 @@ export class ContentService {
       }
     }
 
+    if (existing) {
+      // Promote the registry-only row: stamp the real size and the current
+      // hosting flag so the charge lands in the authoritative sum, then drive
+      // the durable pin (`created`) exactly as a fresh insert would.
+      await pinRepo.update({ accountId, cid }, { size: size.toString(), advisory });
+      return { cid, size, created: true, promoted: true };
+    }
+
     await pinRepo.insert({ accountId, cid, size: size.toString(), advisory });
-    return { cid, size, created: true };
+    return { cid, size, created: true, promoted: false };
   }
 
   /**
-   * Retire a pin row a failed durable pin left dangling, unpinning at global
-   * refcount zero — under the same per-CID lock discipline as the registry. A
-   * compensation failure is logged, never surfaced: a stranded row is only a
-   * registered orphan the republisher GCs, and it must not mask the pin error.
+   * Undo a failed durable pin. For a row THIS upload inserted, retire it,
+   * unpinning at global refcount zero — same per-CID lock discipline as the
+   * registry. For a PROMOTED row (a pre-existing registry-only registration),
+   * revert only the size charge back to 0: the registration must survive a
+   * transient pin failure, and nothing was durably pinned, so no unpin fires. A
+   * compensation failure is logged, never surfaced: a stranded charge/row is
+   * only a registered orphan the republisher GCs, and it must not mask the pin
+   * error.
    */
-  private async compensate(accountId: string, cid: string): Promise<void> {
+  private async compensate(accountId: string, cid: string, promoted: boolean): Promise<void> {
     try {
       const unpin = await runLockGuardedTransaction(this.dataSource, async (manager) => {
         await setAdvisoryLockTimeout(manager, this.lockTimeoutMs);
         await acquireAdvisoryLocks(manager, [advisoryLockKey(cid)]);
         const pinRepo = manager.getRepository(PinnedCid);
+        if (promoted) {
+          await pinRepo.update({ accountId, cid }, { size: '0' });
+          return false;
+        }
         await pinRepo.delete({ accountId, cid });
         const survivors = await pinRepo.find({ where: { cid } });
         return survivors.length === 0;

--- a/apps/api/src/content/content.service.ts
+++ b/apps/api/src/content/content.service.ts
@@ -24,7 +24,7 @@ import {
   DEFAULT_QUOTA_BYTES,
   exceedsQuota,
   resolveLimitBytes,
-  sumPinnedBytes,
+  sumHostedBytes,
 } from '../registry/quota';
 
 /** A stored pin outcome plus whether THIS upload created the row (drives the pin). */
@@ -158,7 +158,9 @@ export class ContentService {
     }
 
     if (!advisory) {
-      const used = await sumPinnedBytes(pinRepo, accountId);
+      // Gate against AUTHORITATIVE rows only: stale advisory/BYO rows an account
+      // kept after toggling BYO off live on its own provider, not the hosted quota.
+      const used = await sumHostedBytes(pinRepo, accountId);
       const limit = resolveLimitBytes(user.quotaLimitOverride, this.defaultLimitBytes);
       if (exceedsQuota(used, BigInt(size), limit)) {
         throw new PayloadTooLargeException('Upload exceeds the account storage quota');

--- a/apps/api/src/content/content.service.ts
+++ b/apps/api/src/content/content.service.ts
@@ -1,0 +1,177 @@
+import {
+  Injectable,
+  Logger,
+  PayloadTooLargeException,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource, EntityManager } from 'typeorm';
+import { User } from '../auth/entities/user.entity';
+import {
+  acquireAdvisoryLocks,
+  advisoryLockKey,
+  resolveAdvisoryLockTimeoutMs,
+  runLockGuardedTransaction,
+  setAdvisoryLockTimeout,
+} from '../common/advisory-lock';
+import { PinnedCid } from '../registry/entities/pinned-cid.entity';
+import { PinStore } from '../registry/pin-store';
+import {
+  byteConfigBigInt,
+  DEFAULT_QUOTA_BYTES,
+  exceedsQuota,
+  resolveLimitBytes,
+  sumPinnedBytes,
+} from '../registry/quota';
+
+/** A stored pin outcome plus whether THIS upload created the row (drives the pin). */
+interface RegisterOutcome {
+  cid: string;
+  size: number;
+  created: boolean;
+}
+
+export interface UploadResult {
+  cid: string;
+  size: number;
+}
+
+/**
+ * The hosted ingress upload path (blueprint/api.md, Content plane): pin opaque
+ * bytes to CipherBox Kubo, quota-gated, registering the pin row in the same
+ * traversal. The API is zero-knowledge — it pins bytes it never inspects.
+ *
+ * Concurrency (two shared resources under contention):
+ *  - the per-account quota SUM — a check-then-act serialized by a per-account
+ *    advisory lock so two concurrent uploads cannot both pass at the limit;
+ *  - the per-CID pin refcount — serialized by the SAME per-CID advisory lock
+ *    the registry's register/retire take, so an insert here can never race an
+ *    unpin there. Both keys acquire in one sorted batch (deadlock-free).
+ *
+ * The DB transaction is the source of truth; the durable Kubo pin fires AFTER
+ * commit. Byte-pin + row register stay all-or-nothing: a post-commit pin
+ * failure compensates by retiring the row it just added.
+ */
+@Injectable()
+export class ContentService {
+  private readonly logger = new Logger(ContentService.name);
+  private readonly defaultLimitBytes: bigint;
+  private readonly lockTimeoutMs: number;
+
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    private readonly pinStore: PinStore,
+    configService: ConfigService
+  ) {
+    this.defaultLimitBytes = byteConfigBigInt(
+      configService.get('QUOTA_DEFAULT_BYTES'),
+      DEFAULT_QUOTA_BYTES
+    );
+    this.lockTimeoutMs = resolveAdvisoryLockTimeoutMs(configService);
+  }
+
+  async upload(accountId: string, bytes: Buffer): Promise<UploadResult> {
+    const size = bytes.byteLength;
+    // Phase 1 — derive the CID with no durable side effect (only-hash), so the
+    // ledger below can key on it before any bytes are pinned.
+    const cid = await this.pinStore.hash(bytes);
+
+    // Phase 2 — the source of truth: gate + register under the account and CID
+    // advisory locks, atomically.
+    const outcome = await runLockGuardedTransaction(this.dataSource, (manager) =>
+      this.registerPin(manager, accountId, cid, size)
+    );
+
+    // Phase 3 — durable pin AFTER commit. Byte-pin + register are all-or-nothing:
+    // a pin failure (or a CID mismatch) compensates by retiring the new row.
+    if (outcome.created) {
+      let pinnedCid: string;
+      try {
+        pinnedCid = await this.pinStore.pin(bytes);
+      } catch {
+        await this.compensate(accountId, cid);
+        throw new ServiceUnavailableException('Pin store unavailable; upload not durable');
+      }
+      if (pinnedCid !== cid) {
+        // Fail closed: the row keys on `cid`; a mismatch means Kubo pinned bytes
+        // under a different CID than the ledger references.
+        await this.compensate(accountId, cid);
+        throw new ServiceUnavailableException('Pin CID mismatch; upload rejected');
+      }
+    }
+
+    return { cid: outcome.cid, size: outcome.size };
+  }
+
+  private async registerPin(
+    manager: EntityManager,
+    accountId: string,
+    cid: string,
+    size: number
+  ): Promise<RegisterOutcome> {
+    await setAdvisoryLockTimeout(manager, this.lockTimeoutMs);
+    // Account key serializes the quota check-then-act; the CID key serializes the
+    // pin-row insert against a concurrent register/retire of the same CID.
+    await acquireAdvisoryLocks(manager, [accountLockKey(accountId), advisoryLockKey(cid)]);
+
+    const userRepo = manager.getRepository(User);
+    const pinRepo = manager.getRepository(PinnedCid);
+
+    const user = await userRepo.findOne({ where: { id: accountId } });
+    if (!user) {
+      throw new UnauthorizedException('Unknown account');
+    }
+    // byo is read unlocked: the account lock serializes the quota gate; a racing
+    // BYO toggle only mis-stamps advisory on the new row, which self-heals.
+    const advisory = user.byo;
+
+    const existing = await pinRepo.findOne({ where: { accountId, cid } });
+    if (existing) {
+      // Idempotent re-upload: the CID already counts — no gate, no new charge.
+      return { cid, size: Number(existing.size), created: false };
+    }
+
+    if (!advisory) {
+      const used = await sumPinnedBytes(pinRepo, accountId);
+      const limit = resolveLimitBytes(user.quotaLimitOverride, this.defaultLimitBytes);
+      if (exceedsQuota(used, BigInt(size), limit)) {
+        throw new PayloadTooLargeException('Upload exceeds the account storage quota');
+      }
+    }
+
+    await pinRepo.insert({ accountId, cid, size: size.toString(), advisory });
+    return { cid, size, created: true };
+  }
+
+  /**
+   * Retire a pin row a failed durable pin left dangling, unpinning at global
+   * refcount zero — under the same per-CID lock discipline as the registry. A
+   * compensation failure is logged, never surfaced: a stranded row is only a
+   * registered orphan the republisher GCs, and it must not mask the pin error.
+   */
+  private async compensate(accountId: string, cid: string): Promise<void> {
+    try {
+      const unpin = await runLockGuardedTransaction(this.dataSource, async (manager) => {
+        await setAdvisoryLockTimeout(manager, this.lockTimeoutMs);
+        await acquireAdvisoryLocks(manager, [advisoryLockKey(cid)]);
+        const pinRepo = manager.getRepository(PinnedCid);
+        await pinRepo.delete({ accountId, cid });
+        const survivors = await pinRepo.find({ where: { cid } });
+        return survivors.length === 0;
+      });
+      if (unpin) {
+        await this.pinStore.unpin(cid);
+      }
+    } catch (error) {
+      this.logger.warn(`compensation for ${cid} failed: ${String(error)}`);
+    }
+  }
+}
+
+/** Namespaced account advisory key: `account:` prevents any UUID/CID key collision. */
+function accountLockKey(accountId: string): bigint {
+  return advisoryLockKey(`account:${accountId}`);
+}

--- a/apps/api/src/content/dto/content.dto.ts
+++ b/apps/api/src/content/dto/content.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * The hosted-upload result (blueprint/api.md, Content plane — Ingress). The
+ * client references content by the returned CID; `size` is the byte count
+ * charged against the account's quota.
+ */
+export class UploadResponseDto {
+  @ApiProperty({ description: 'The content CID Kubo pinned' })
+  cid!: string;
+
+  @ApiProperty({ description: 'The pinned size in bytes' })
+  size!: number;
+}

--- a/apps/api/src/ops/account-throttler.guard.test.ts
+++ b/apps/api/src/ops/account-throttler.guard.test.ts
@@ -1,6 +1,9 @@
 import { createHmac } from 'node:crypto';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { verifiedSubjectFromBearer } from './account-throttler.guard';
+import {
+  verifiedSubjectFromBearer,
+  verifiedUnexpiredSubjectFromBearer,
+} from './account-throttler.guard';
 
 const SECRET = 'account-throttler-test-secret';
 
@@ -70,5 +73,64 @@ describe('verifiedSubjectFromBearer', () => {
     expect(verifiedSubjectFromBearer({})).toBe(undefined);
     expect(verifiedSubjectFromBearer({ authorization: 'Basic abc' })).toBe(undefined);
     expect(verifiedSubjectFromBearer(bearer('not-a-jwt'))).toBe(undefined);
+  });
+
+  it('still returns the sub of a signed-but-EXPIRED token (expiry ignored for rate-limit keying)', () => {
+    const past = Math.floor(Date.now() / 1000) - 60;
+    expect(verifiedSubjectFromBearer(bearer(token({ sub: 'user-1', exp: past })))).toBe('user-1');
+  });
+});
+
+describe('verifiedUnexpiredSubjectFromBearer', () => {
+  let priorSecret: string | undefined;
+
+  beforeAll(() => {
+    priorSecret = process.env.JWT_SECRET;
+    process.env.JWT_SECRET = SECRET;
+  });
+
+  afterAll(() => {
+    if (priorSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = priorSecret;
+    }
+  });
+
+  const now = 1_000_000;
+
+  it('returns the sub of a validly-signed, unexpired token', () => {
+    expect(
+      verifiedUnexpiredSubjectFromBearer(bearer(token({ sub: 'user-1', exp: now + 60 })), now)
+    ).toBe('user-1');
+  });
+
+  it('fails closed on a validly-signed but EXPIRED token (unlike the rate-limit keyer)', () => {
+    const expired = bearer(token({ sub: 'user-1', exp: now - 1 }));
+    // The signature is genuine, so the rate-limit keyer still trusts the sub...
+    expect(verifiedSubjectFromBearer(expired)).toBe('user-1');
+    // ...but the pre-buffer gate rejects it (must not buffer for an expired token).
+    expect(verifiedUnexpiredSubjectFromBearer(expired, now)).toBe(undefined);
+  });
+
+  it('rejects at the exact expiry boundary (now >= exp), matching jsonwebtoken', () => {
+    expect(
+      verifiedUnexpiredSubjectFromBearer(bearer(token({ sub: 'user-1', exp: now })), now)
+    ).toBe(undefined);
+  });
+
+  it('treats a token with no exp as unexpired (matching the guard)', () => {
+    expect(verifiedUnexpiredSubjectFromBearer(bearer(token({ sub: 'user-1' })), now)).toBe(
+      'user-1'
+    );
+  });
+
+  it('rejects a token signed with a different secret regardless of expiry', () => {
+    expect(
+      verifiedUnexpiredSubjectFromBearer(
+        bearer(token({ sub: 'victim', exp: now + 60 }, 'attacker-secret')),
+        now
+      )
+    ).toBe(undefined);
   });
 });

--- a/apps/api/src/ops/account-throttler.guard.ts
+++ b/apps/api/src/ops/account-throttler.guard.ts
@@ -41,17 +41,14 @@ function jwtSecret(): string {
 }
 
 /**
- * Return the `sub` claim ONLY when the bearer is a well-formed HS256 JWT that
- * carries our own signature; otherwise `undefined` (so the caller keys by IP).
- * The header's declared `alg` is never trusted — the signature is always
- * recomputed as HMAC-SHA256, so `alg: none`/algorithm-confusion cannot forge a
- * subject. Expiry is intentionally not enforced: a validly-signed-but-expired
- * token still carries a genuine (non-forgeable) `sub`, which is a correct
- * rate-limit key; it will still 401 at the route's auth guard.
+ * The signature-verified claims of a bearer token, or `undefined` when the
+ * header is absent/malformed or carries a signature we did not produce. The
+ * declared `alg` is never trusted — the signature is always recomputed as
+ * HMAC-SHA256, so `alg: none`/algorithm-confusion cannot forge claims.
  */
-export function verifiedSubjectFromBearer(
+function verifiedBearerClaims(
   headers: Record<string, unknown> | undefined
-): string | undefined {
+): { sub?: unknown; exp?: unknown } | undefined {
   const authorization = headers?.authorization;
   if (typeof authorization !== 'string' || !authorization.startsWith('Bearer ')) {
     return undefined;
@@ -72,11 +69,47 @@ export function verifiedSubjectFromBearer(
     return undefined;
   }
   try {
-    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as {
+    return JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as {
       sub?: unknown;
+      exp?: unknown;
     };
-    return typeof claims.sub === 'string' ? claims.sub : undefined;
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Return the `sub` claim ONLY when the bearer carries our own HS256 signature;
+ * otherwise `undefined` (so the caller keys by IP). Expiry is intentionally not
+ * enforced: a validly-signed-but-expired token still carries a genuine (non-
+ * forgeable) `sub`, which is a correct rate-limit key; it will still 401 at the
+ * route's auth guard.
+ */
+export function verifiedSubjectFromBearer(
+  headers: Record<string, unknown> | undefined
+): string | undefined {
+  const claims = verifiedBearerClaims(headers);
+  return typeof claims?.sub === 'string' ? claims.sub : undefined;
+}
+
+/**
+ * Like `verifiedSubjectFromBearer`, but ALSO fails closed on an expired token:
+ * the `sub` only when the bearer is validly signed AND unexpired. The pre-body
+ * upload gate uses this so a validly-signed-but-EXPIRED token cannot force
+ * `maxBytes` of heap buffering before the route's `JwtAuthGuard` 401s it — same
+ * `exp` semantics as that guard (reject at `now >= exp`), same secret. A token
+ * with no `exp` never expires, matching the guard.
+ */
+export function verifiedUnexpiredSubjectFromBearer(
+  headers: Record<string, unknown> | undefined,
+  nowSeconds: number = Math.floor(Date.now() / 1000)
+): string | undefined {
+  const claims = verifiedBearerClaims(headers);
+  if (typeof claims?.sub !== 'string') {
+    return undefined;
+  }
+  if (typeof claims.exp === 'number' && nowSeconds >= claims.exp) {
+    return undefined;
+  }
+  return claims.sub;
 }

--- a/apps/api/src/ops/throttling.ts
+++ b/apps/api/src/ops/throttling.ts
@@ -29,4 +29,6 @@ export const THROTTLE_SURFACES = {
   registry: { default: { limit: 120, ttl: 60_000 } },
   /** Account quota/BYO: per account; quota is polled on the statfs path. */
   account: { default: { limit: 120, ttl: 60_000 } },
+  /** Content upload: per account; bounded above the write cadence, below abuse. */
+  content: { default: { limit: 60, ttl: 60_000 } },
 } as const;

--- a/apps/api/src/registry/pin-store.ts
+++ b/apps/api/src/registry/pin-store.ts
@@ -1,28 +1,47 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 /**
- * The physical-unpin seam (blueprint/api.md: "physical unpin fires at global
- * refcount zero" — v1's `guardedUnpin` survives). The registry owns the
- * refcount DECISION; this port owns the side effect of releasing bytes from
- * the hosted pin store.
+ * The hosted pin-store port (blueprint/api.md, Content plane + "physical unpin
+ * fires at global refcount zero" — v1's `guardedUnpin` survives). It owns every
+ * side effect against CipherBox Kubo: computing a content CID, durably pinning
+ * bytes on the ingress path, and releasing bytes at refcount zero. The registry
+ * and content services own the row DECISIONS; this port owns the byte effects.
  *
- * It is a best-effort liveness optimization, not a correctness dependency:
+ * `unpin` is a best-effort liveness optimization, not a correctness dependency:
  * the per-account row bookkeeping is the source of truth, so a failed or
- * unconfigured unpin never fails a retire. The pinned CID simply lingers and
- * decays from the pin store's own GC — never re-registered, so union liveness
- * still reports it gone.
+ * unconfigured unpin never fails a retire — the CID lingers and decays from the
+ * pin store's own GC. `hash`/`pin` are the ingress byte path; a consumer that
+ * only retires (the registry) never calls them, so the base rejects rather than
+ * forcing every unpin-only fake to stub the byte methods.
  */
 @Injectable()
 export abstract class PinStore {
   abstract unpin(cid: string): Promise<void>;
+
+  /** Content CID of `bytes` with no durable pin (the pre-commit CID derivation). */
+  hash(_bytes: Uint8Array): Promise<string> {
+    throw new ServiceUnavailableException('Hosted pin store does not support content hashing');
+  }
+
+  /** Durably pin `bytes`, returning the pinned CID (the post-commit byte effect). */
+  pin(_bytes: Uint8Array): Promise<string> {
+    throw new ServiceUnavailableException('Hosted pin store does not support pinning');
+  }
+}
+
+/** One Kubo `add` result line: `{ Name, Hash, Size }` (Size is a decimal string). */
+interface KuboAddResult {
+  Hash: string;
+  Size: string;
 }
 
 /**
- * Default hosted implementation: releases a CID from CipherBox Kubo when
- * `KUBO_API_URL` is configured. Absent that config (unit tests, BYO-only
- * deployments), it no-ops — the hosted byte path is wired by the content-plane
- * slice; this slice ships the refcount decision that drives it.
+ * Default hosted implementation over the Kubo RPC API (`KUBO_API_URL`). `hash`
+ * and `pin` share identical `add` parameters so the pre-commit CID always
+ * matches the pinned CID (content addressing is deterministic). `unpin` no-ops
+ * when Kubo is unconfigured (unit tests, BYO-only deployments); the byte path
+ * fails closed instead, since an upload with no pin store cannot be durable.
  */
 @Injectable()
 export class KuboPinStore extends PinStore {
@@ -33,6 +52,15 @@ export class KuboPinStore extends PinStore {
     super();
     const raw = configService.get<string>('KUBO_API_URL');
     this.apiUrl = raw && raw.trim() ? raw.replace(/\/+$/, '') : undefined;
+  }
+
+  override async hash(bytes: Uint8Array): Promise<string> {
+    // `only-hash` chunks and hashes without writing blocks — no durable effect.
+    return (await this.add(bytes, 'only-hash=true')).Hash;
+  }
+
+  override async pin(bytes: Uint8Array): Promise<string> {
+    return (await this.add(bytes, 'pin=true')).Hash;
   }
 
   async unpin(cid: string): Promise<void> {
@@ -52,5 +80,29 @@ export class KuboPinStore extends PinStore {
       // must not fail the caller's retire. Log and move on.
       this.logger.warn(`pin/rm failed for ${cid}: ${String(error)}`);
     }
+  }
+
+  private async add(bytes: Uint8Array, params: string): Promise<KuboAddResult> {
+    if (!this.apiUrl) {
+      throw new ServiceUnavailableException('Hosted pin store not configured');
+    }
+    const form = new FormData();
+    // Copy into an ArrayBuffer-backed view so the Blob part type is exact.
+    form.append('file', new Blob([new Uint8Array(bytes)]));
+    const response = await fetch(`${this.apiUrl}/api/v0/add?${params}`, {
+      method: 'POST',
+      body: form,
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) {
+      throw new ServiceUnavailableException(`Kubo add failed: ${response.status}`);
+    }
+    // Kubo streams newline-delimited JSON; a single file yields one final object.
+    const lines = (await response.text()).trim().split('\n').filter(Boolean);
+    const last = lines[lines.length - 1];
+    if (!last) {
+      throw new ServiceUnavailableException('Kubo add returned no result');
+    }
+    return JSON.parse(last) as KuboAddResult;
   }
 }

--- a/apps/api/src/registry/pin-store.ts
+++ b/apps/api/src/registry/pin-store.ts
@@ -87,8 +87,9 @@ export class KuboPinStore extends PinStore {
       throw new ServiceUnavailableException('Hosted pin store not configured');
     }
     const form = new FormData();
-    // Copy into an ArrayBuffer-backed view so the Blob part type is exact.
-    form.append('file', new Blob([new Uint8Array(bytes)]));
+    // Copy into an ArrayBuffer-backed view so the Blob part type is exact. Kubo
+    // requires the part to carry a filename, so pass one explicitly.
+    form.append('file', new Blob([new Uint8Array(bytes)]), 'blob');
     const response = await fetch(`${this.apiUrl}/api/v0/add?${params}`, {
       method: 'POST',
       body: form,

--- a/apps/api/src/registry/quota.test.ts
+++ b/apps/api/src/registry/quota.test.ts
@@ -1,5 +1,59 @@
-import { describe, expect, it } from 'vitest';
-import { byteConfigBigInt, DEFAULT_QUOTA_BYTES, exceedsQuota, resolveLimitBytes } from './quota';
+import { describe, expect, it, vi } from 'vitest';
+import type { Repository } from 'typeorm';
+import {
+  byteConfigBigInt,
+  DEFAULT_QUOTA_BYTES,
+  exceedsQuota,
+  resolveLimitBytes,
+  sumHostedBytes,
+  sumPinnedBytes,
+} from './quota';
+import type { PinnedCid } from './entities/pinned-cid.entity';
+
+/**
+ * A minimal QueryBuilder double that records the `andWhere` clauses each sum
+ * applies and returns a caller-set raw `used` string, so a test can prove which
+ * rows a sum narrows to and that the driver's `numeric` string is read back as
+ * an exact BigInt — without a live Postgres.
+ */
+function fakeRepo(used: string | undefined) {
+  const andWhere = vi.fn().mockReturnThis();
+  const qb = {
+    select: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    andWhere,
+    getRawOne: vi.fn().mockResolvedValue(used === undefined ? undefined : { used }),
+  };
+  const repo = {
+    createQueryBuilder: vi.fn().mockReturnValue(qb),
+  } as unknown as Repository<PinnedCid>;
+  return { repo, qb, andWhere };
+}
+
+describe('sumPinnedBytes / sumHostedBytes — aggregation scope and BigInt read-back', () => {
+  it('sumPinnedBytes sums ALL rows: no advisory predicate is applied', async () => {
+    const { repo, andWhere } = fakeRepo('42');
+    expect(await sumPinnedBytes(repo, 'acct-1')).toBe(42n);
+    expect(andWhere).not.toHaveBeenCalled();
+  });
+
+  it('sumHostedBytes narrows to authoritative rows via advisory = false', async () => {
+    const { repo, andWhere } = fakeRepo('42');
+    expect(await sumHostedBytes(repo, 'acct-1')).toBe(42n);
+    expect(andWhere).toHaveBeenCalledWith('pin.advisory = :advisory', { advisory: false });
+  });
+
+  it('reads the driver numeric string back as an exact BigInt above 2^53', async () => {
+    const huge = ((1n << 53n) + 5n).toString();
+    expect(await sumPinnedBytes(fakeRepo(huge).repo, 'acct-1')).toBe((1n << 53n) + 5n);
+    expect(await sumHostedBytes(fakeRepo(huge).repo, 'acct-1')).toBe((1n << 53n) + 5n);
+  });
+
+  it('reads an empty account (no row / COALESCE 0) as 0n', async () => {
+    expect(await sumPinnedBytes(fakeRepo(undefined).repo, 'acct-1')).toBe(0n);
+    expect(await sumHostedBytes(fakeRepo('0').repo, 'acct-1')).toBe(0n);
+  });
+});
 
 /**
  * The quota arithmetic that gates uploads, proven exact in BigInt where a JS

--- a/apps/api/src/registry/quota.test.ts
+++ b/apps/api/src/registry/quota.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { byteConfigBigInt, DEFAULT_QUOTA_BYTES, exceedsQuota, resolveLimitBytes } from './quota';
+
+/**
+ * The quota arithmetic that gates uploads, proven exact in BigInt where a JS
+ * `number` comparison would round (folded from #677). 2^53 is the first integer
+ * `number` cannot represent alongside its neighbor — the boundary these tests
+ * straddle.
+ */
+const TWO_POW_53 = 1n << 53n; // 9_007_199_254_740_992
+
+describe('exceedsQuota — BigInt exactness across 2^53', () => {
+  it('admits a use exactly at the limit and refuses one byte past it', () => {
+    expect(exceedsQuota(900n, 100n, 1000n)).toBe(false); // sum 1000 == limit
+    expect(exceedsQuota(901n, 100n, 1000n)).toBe(true); // sum 1001 > limit
+    expect(exceedsQuota(0n, 1001n, 1000n)).toBe(true); // a single oversize upload
+  });
+
+  it('distinguishes limit and limit+1 above 2^53, where Number cannot', () => {
+    const limit = TWO_POW_53 * 1000n; // ~9 PB, far past number precision
+    // Exactly filling the limit is admitted...
+    expect(exceedsQuota(limit - 1n, 1n, limit)).toBe(false);
+    // ...and a single byte beyond is refused, even though both operands round
+    // to the same JS number.
+    expect(exceedsQuota(limit, 1n, limit)).toBe(true);
+    expect(Number(limit) === Number(limit + 1n)).toBe(true);
+  });
+
+  it('gates a large incoming upload against a large existing use exactly', () => {
+    const used = TWO_POW_53 + 5n;
+    const incoming = TWO_POW_53 + 5n;
+    const limit = 2n * TWO_POW_53 + 10n; // exactly used + incoming
+    expect(exceedsQuota(used, incoming, limit)).toBe(false); // sum == limit
+    expect(exceedsQuota(used, incoming, limit - 1n)).toBe(true); // sum == limit + 1
+    expect(exceedsQuota(used, incoming + 1n, limit)).toBe(true); // sum == limit + 1
+  });
+});
+
+describe('resolveLimitBytes', () => {
+  it('prefers the per-account override, parsed exactly as BigInt', () => {
+    const override = (TWO_POW_53 * 3n).toString();
+    expect(resolveLimitBytes(override, DEFAULT_QUOTA_BYTES)).toBe(TWO_POW_53 * 3n);
+  });
+
+  it('falls back to the env default when there is no override', () => {
+    expect(resolveLimitBytes(null, DEFAULT_QUOTA_BYTES)).toBe(DEFAULT_QUOTA_BYTES);
+  });
+});
+
+describe('byteConfigBigInt', () => {
+  it('parses a valid non-negative integer string exactly', () => {
+    expect(byteConfigBigInt('1099511627776', 0n)).toBe(1099511627776n);
+    const huge = TWO_POW_53 * 7n;
+    expect(byteConfigBigInt(huge.toString(), 0n)).toBe(huge);
+  });
+
+  it('fails closed to the fallback for unset, empty, or garbage values', () => {
+    expect(byteConfigBigInt(undefined, DEFAULT_QUOTA_BYTES)).toBe(DEFAULT_QUOTA_BYTES);
+    expect(byteConfigBigInt('', DEFAULT_QUOTA_BYTES)).toBe(DEFAULT_QUOTA_BYTES);
+    expect(byteConfigBigInt('not-a-number', DEFAULT_QUOTA_BYTES)).toBe(DEFAULT_QUOTA_BYTES);
+    expect(byteConfigBigInt('12.5', DEFAULT_QUOTA_BYTES)).toBe(DEFAULT_QUOTA_BYTES);
+    expect(byteConfigBigInt('-5', DEFAULT_QUOTA_BYTES)).toBe(DEFAULT_QUOTA_BYTES);
+  });
+});

--- a/apps/api/src/registry/quota.ts
+++ b/apps/api/src/registry/quota.ts
@@ -1,0 +1,57 @@
+import { Repository } from 'typeorm';
+import { PinnedCid } from './entities/pinned-cid.entity';
+
+/** Default per-account quota when neither an override nor `QUOTA_DEFAULT_BYTES` is set: 10 GiB. */
+export const DEFAULT_QUOTA_BYTES = 10n * 1024n * 1024n * 1024n;
+
+/**
+ * Read a non-negative integer byte bound from config as a BigInt, failing
+ * closed to the fallback for an unset OR garbage value. BigInt (not Number)
+ * so an override above 2^53 bytes is honored exactly.
+ */
+export function byteConfigBigInt(raw: unknown, fallback: bigint): bigint {
+  if (raw === undefined || raw === null || String(raw).trim() === '') {
+    return fallback;
+  }
+  try {
+    const value = BigInt(String(raw).trim());
+    return value >= 0n ? value : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Server-side `SUM(size)` over the account's pin rows, exact at any magnitude.
+ * Postgres returns the `bigint` sum as `numeric` (a driver STRING), so
+ * `BigInt(...)` preserves precision that TypeORM's `sum()` — which returns a
+ * lossy JS `number` and can only type numeric columns — would drop above 2^53
+ * bytes (folded from #677). `COALESCE(..., 0)` makes an empty account read 0.
+ */
+export async function sumPinnedBytes(
+  repo: Repository<PinnedCid>,
+  accountId: string
+): Promise<bigint> {
+  const row = await repo
+    .createQueryBuilder('pin')
+    .select('COALESCE(SUM(pin.size), 0)', 'used')
+    .where('pin.account_id = :accountId', { accountId })
+    .getRawOne<{ used: string }>();
+  return BigInt(row?.used ?? '0');
+}
+
+/** The account limit in bytes: the per-account override, else the env default. */
+export function resolveLimitBytes(
+  quotaLimitOverride: string | null,
+  defaultLimitBytes: bigint
+): bigint {
+  return quotaLimitOverride != null ? BigInt(quotaLimitOverride) : defaultLimitBytes;
+}
+
+/**
+ * The over-quota decision, exact at any magnitude — BigInt throughout so a large
+ * account gates correctly where a JS `number` comparison would round (#677).
+ */
+export function exceedsQuota(used: bigint, incoming: bigint, limit: bigint): boolean {
+  return used + incoming > limit;
+}

--- a/apps/api/src/registry/quota.ts
+++ b/apps/api/src/registry/quota.ts
@@ -40,6 +40,27 @@ export async function sumPinnedBytes(
   return BigInt(row?.used ?? '0');
 }
 
+/**
+ * The quota-GATE sum: only AUTHORITATIVE hosted rows (`advisory = false`).
+ * BYO/advisory bytes live on the user's own provider and never count against
+ * the hosted quota (blueprint/api.md, Registry: "Hosted rows are authoritative
+ * and gate uploads; BYO accounts' rows are advisory — quota always allows").
+ * Distinct from `sumPinnedBytes` (all rows) because a hosted upload must not be
+ * 413'd by stale advisory rows an account kept after toggling BYO off.
+ */
+export async function sumHostedBytes(
+  repo: Repository<PinnedCid>,
+  accountId: string
+): Promise<bigint> {
+  const row = await repo
+    .createQueryBuilder('pin')
+    .select('COALESCE(SUM(pin.size), 0)', 'used')
+    .where('pin.account_id = :accountId', { accountId })
+    .andWhere('pin.advisory = :advisory', { advisory: false })
+    .getRawOne<{ used: string }>();
+  return BigInt(row?.used ?? '0');
+}
+
 /** The account limit in bytes: the per-account override, else the env default. */
 export function resolveLimitBytes(
   quotaLimitOverride: string | null,

--- a/apps/api/src/registry/quota.ts
+++ b/apps/api/src/registry/quota.ts
@@ -1,4 +1,4 @@
-import { Repository } from 'typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
 import { PinnedCid } from './entities/pinned-cid.entity';
 
 /** Default per-account quota when neither an override nor `QUOTA_DEFAULT_BYTES` is set: 10 GiB. */
@@ -22,22 +22,34 @@ export function byteConfigBigInt(raw: unknown, fallback: bigint): bigint {
 }
 
 /**
- * Server-side `SUM(size)` over the account's pin rows, exact at any magnitude.
+ * Per-account `COALESCE(SUM(size), 0)` aggregate, exact at any magnitude.
  * Postgres returns the `bigint` sum as `numeric` (a driver STRING), so
  * `BigInt(...)` preserves precision that TypeORM's `sum()` — which returns a
  * lossy JS `number` and can only type numeric columns — would drop above 2^53
  * bytes (folded from #677). `COALESCE(..., 0)` makes an empty account read 0.
+ * `narrow` optionally restricts the summed rows (e.g. authoritative-only for
+ * the quota gate).
  */
-export async function sumPinnedBytes(
+async function sumSizeBytes(
   repo: Repository<PinnedCid>,
-  accountId: string
+  accountId: string,
+  narrow?: (qb: SelectQueryBuilder<PinnedCid>) => void
 ): Promise<bigint> {
-  const row = await repo
+  const qb = repo
     .createQueryBuilder('pin')
     .select('COALESCE(SUM(pin.size), 0)', 'used')
-    .where('pin.account_id = :accountId', { accountId })
-    .getRawOne<{ used: string }>();
+    .where('pin.account_id = :accountId', { accountId });
+  narrow?.(qb);
+  const row = await qb.getRawOne<{ used: string }>();
   return BigInt(row?.used ?? '0');
+}
+
+/**
+ * Server-side `SUM(size)` over ALL of the account's pin rows — the usage the
+ * inventory REPORTS, exact at any magnitude (#677).
+ */
+export function sumPinnedBytes(repo: Repository<PinnedCid>, accountId: string): Promise<bigint> {
+  return sumSizeBytes(repo, accountId);
 }
 
 /**
@@ -48,17 +60,10 @@ export async function sumPinnedBytes(
  * Distinct from `sumPinnedBytes` (all rows) because a hosted upload must not be
  * 413'd by stale advisory rows an account kept after toggling BYO off.
  */
-export async function sumHostedBytes(
-  repo: Repository<PinnedCid>,
-  accountId: string
-): Promise<bigint> {
-  const row = await repo
-    .createQueryBuilder('pin')
-    .select('COALESCE(SUM(pin.size), 0)', 'used')
-    .where('pin.account_id = :accountId', { accountId })
-    .andWhere('pin.advisory = :advisory', { advisory: false })
-    .getRawOne<{ used: string }>();
-  return BigInt(row?.used ?? '0');
+export function sumHostedBytes(repo: Repository<PinnedCid>, accountId: string): Promise<bigint> {
+  return sumSizeBytes(repo, accountId, (qb) =>
+    qb.andWhere('pin.advisory = :advisory', { advisory: false })
+  );
 }
 
 /** The account limit in bytes: the per-account override, else the env default. */

--- a/apps/api/src/registry/registry.http.test.ts
+++ b/apps/api/src/registry/registry.http.test.ts
@@ -73,18 +73,31 @@ class InAwareRepository<T extends { id: string }> extends FakeRepository<T> {
     return super.save(entities);
   }
 
-  async sum(column: string, where?: Record<string, unknown>): Promise<number | null> {
-    const rows = where
-      ? this.rows.filter((row) => inMatch(row as Record<string, unknown>, where))
-      : this.rows;
-    if (rows.length === 0) {
-      return null;
-    }
-    return rows.reduce(
-      (total, row) => total + Number((row as Record<string, unknown>)[column] ?? 0),
-      0
-    );
+  /** Emulates the `COALESCE(SUM(size), 0)` aggregate `sumPinnedBytes` runs, keyed by accountId. */
+  createQueryBuilder(_alias?: string): SumQueryBuilder {
+    const allRows = this.rows;
+    let accountId: string | undefined;
+    const qb: SumQueryBuilder = {
+      select: () => qb,
+      where: (_clause, params) => {
+        accountId = params?.accountId as string | undefined;
+        return qb;
+      },
+      getRawOne: async () => {
+        const used = allRows
+          .filter((row) => (row as { accountId?: string }).accountId === accountId)
+          .reduce((total, row) => total + BigInt((row as { size?: string }).size ?? '0'), 0n);
+        return { used: used.toString() };
+      },
+    };
+    return qb;
   }
+}
+
+interface SumQueryBuilder {
+  select: (selection: string, alias: string) => SumQueryBuilder;
+  where: (clause: string, params?: Record<string, unknown>) => SumQueryBuilder;
+  getRawOne: () => Promise<{ used: string }>;
 }
 
 /** A DataSource whose transaction runs inline against the in-memory repos. */

--- a/apps/api/src/registry/services/registry.service.test.ts
+++ b/apps/api/src/registry/services/registry.service.test.ts
@@ -61,18 +61,31 @@ class InAwareRepository<T extends { id: string }> extends FakeRepository<T> {
     return super.save(entities);
   }
 
-  async sum(column: string, where?: Record<string, unknown>): Promise<number | null> {
-    const rows = where
-      ? this.rows.filter((row) => inMatch(row as Record<string, unknown>, where))
-      : this.rows;
-    if (rows.length === 0) {
-      return null;
-    }
-    return rows.reduce(
-      (total, row) => total + Number((row as Record<string, unknown>)[column] ?? 0),
-      0
-    );
+  /** Emulates the `COALESCE(SUM(size), 0)` aggregate `sumPinnedBytes` runs, keyed by accountId. */
+  createQueryBuilder(_alias?: string): SumQueryBuilder {
+    const allRows = this.rows;
+    let accountId: string | undefined;
+    const qb: SumQueryBuilder = {
+      select: () => qb,
+      where: (_clause, params) => {
+        accountId = params?.accountId as string | undefined;
+        return qb;
+      },
+      getRawOne: async () => {
+        const used = allRows
+          .filter((row) => (row as { accountId?: string }).accountId === accountId)
+          .reduce((total, row) => total + BigInt((row as { size?: string }).size ?? '0'), 0n);
+        return { used: used.toString() };
+      },
+    };
+    return qb;
   }
+}
+
+interface SumQueryBuilder {
+  select: (selection: string, alias: string) => SumQueryBuilder;
+  where: (clause: string, params?: Record<string, unknown>) => SumQueryBuilder;
+  getRawOne: () => Promise<{ used: string }>;
 }
 
 /** A DataSource whose transaction runs inline against the in-memory repos. */

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -1,11 +1,11 @@
 import { Injectable, ServiceUnavailableException, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import { createHash } from 'node:crypto';
 import { DataSource, EntityManager, In, Repository } from 'typeorm';
 import { User } from '../../auth/entities/user.entity';
 import {
-  acquireAdvisoryLock,
+  acquireAdvisoryLocks,
+  advisoryLockKey,
   isLockNotAvailable,
   resolveAdvisoryLockTimeoutMs,
   setAdvisoryLockTimeout,
@@ -13,14 +13,7 @@ import {
 import { NameInventory } from '../entities/name-inventory.entity';
 import { PinnedCid } from '../entities/pinned-cid.entity';
 import { PinStore } from '../pin-store';
-
-/** Default per-account quota when neither an override nor `QUOTA_DEFAULT_BYTES` is set: 10 GiB. */
-const DEFAULT_QUOTA_BYTES = 10 * 1024 * 1024 * 1024;
-
-/** Stable 64-bit advisory-lock key for a token: first 8 bytes of its sha256. */
-function lockKey(token: string): bigint {
-  return createHash('sha256').update(token).digest().readBigInt64BE(0);
-}
+import { byteConfigBigInt, DEFAULT_QUOTA_BYTES, resolveLimitBytes, sumPinnedBytes } from '../quota';
 
 /**
  * Serialize every refcount/inventory mutation for each token by taking a
@@ -37,10 +30,7 @@ async function lockTokens(
   timeoutMs: number
 ): Promise<void> {
   await setAdvisoryLockTimeout(manager, timeoutMs);
-  const keys = [...new Set(tokens.map(lockKey))].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-  for (const key of keys) {
-    await acquireAdvisoryLock(manager, key);
-  }
+  await acquireAdvisoryLocks(manager, tokens.map(advisoryLockKey));
 }
 
 export interface RegisterEntry {
@@ -66,16 +56,6 @@ export interface QuotaResult {
 }
 
 /**
- * Read a non-negative integer byte bound from config, falling back to the
- * default for an unset OR garbage value (a misconfigured limit must fail
- * closed to the safe default, never to NaN).
- */
-function byteConfig(raw: unknown, fallback: number): number {
-  const value = Number(raw);
-  return Number.isInteger(value) && value >= 0 ? value : fallback;
-}
-
-/**
  * The pin/name registry (blueprint/api.md, Pin/name registry) — the one
  * surface every publish flow traverses. It is deliberately dumb bookkeeping:
  * per-account rows, idempotent upserts, union liveness, and a per-account
@@ -87,7 +67,7 @@ function byteConfig(raw: unknown, fallback: number): number {
  */
 @Injectable()
 export class RegistryService {
-  private readonly defaultLimitBytes: number;
+  private readonly defaultLimitBytes: bigint;
   private readonly lockTimeoutMs: number;
 
   constructor(
@@ -100,7 +80,7 @@ export class RegistryService {
     private readonly pinStore: PinStore,
     configService: ConfigService
   ) {
-    this.defaultLimitBytes = byteConfig(
+    this.defaultLimitBytes = byteConfigBigInt(
       configService.get('QUOTA_DEFAULT_BYTES'),
       DEFAULT_QUOTA_BYTES
     );
@@ -287,17 +267,14 @@ export class RegistryService {
       throw new UnauthorizedException('Unknown account');
     }
 
-    // Aggregate server-side; size is a bigint column typed as string.
-    const used = await this.pinRepository.sum('size' as never, { accountId });
-
-    const limitBytes =
-      user.quotaLimitOverride != null
-        ? Number(BigInt(user.quotaLimitOverride))
-        : this.defaultLimitBytes;
+    // Compute in BigInt (exact above 2^53) and narrow to the wire number at the
+    // edge; the DTO is a JSON number, but the gate math never rounds (#677).
+    const used = await sumPinnedBytes(this.pinRepository, accountId);
+    const limit = resolveLimitBytes(user.quotaLimitOverride, this.defaultLimitBytes);
 
     return {
-      usedBytes: used ?? 0,
-      limitBytes,
+      usedBytes: Number(used),
+      limitBytes: Number(limit),
       advisory: user.byo,
     };
   }

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -389,10 +389,13 @@ async fn union_liveness_is_per_account_and_permissionless() {
         .expect("bob retires the last row");
 }
 
-/// Quota (blueprint/api.md): hosted accounts are authoritative (`advisory:
-/// false`) with a positive limit; a BYO account's rows are advisory
-/// (`advisory: true`, quota always allows). The flag flips live with the BYO
-/// toggle.
+/// Quota + hosted ingress (blueprint/api.md; #629): hosted accounts are
+/// authoritative (`advisory: false`) with a positive limit and gate uploads; a
+/// BYO account's rows are advisory (`advisory: true`, quota always allows). The
+/// upload path pins bytes to the real CI Kubo and is exercised here rather than
+/// in dedicated tests so the shared per-IP login throttle is not tripped by an
+/// extra account. The contract-suite job sets a tiny 1 KiB QUOTA_DEFAULT_BYTES,
+/// so a few hundred bytes straddle the over-quota limit deterministically.
 #[tokio::test]
 async fn quota_is_hosted_authoritative_and_byo_advisory() {
     let base = require_stack!("quota_is_hosted_authoritative_and_byo_advisory");
@@ -409,49 +412,20 @@ async fn quota_is_hosted_authoritative_and_byo_advisory() {
         "a hosted account has a positive limit"
     );
 
-    // Enabling BYO makes the account's rows advisory: quota always allows.
-    client.set_byo(true).await.expect("enable BYO");
-    let byo = client.quota().await.expect("byo quota");
-    assert!(byo.advisory, "a BYO account's quota is advisory");
-    assert_eq!(
-        byo.limit_bytes, hosted.limit_bytes,
-        "the limit is unchanged"
-    );
-
-    // Toggling BYO back restores the authoritative posture.
-    client.set_byo(false).await.expect("disable BYO");
-    let restored = client.quota().await.expect("restored quota");
-    assert!(
-        !restored.advisory,
-        "clearing BYO restores authoritative quota"
-    );
-}
-
-// --- hosted content ingress (blueprint/api.md; #629) ------------------------
-// These exercise the real Kubo pin against the CI stack's tiny 1 KiB
-// QUOTA_DEFAULT_BYTES (set in the contract-suite job), so a few hundred bytes
-// straddle the limit deterministically.
-
-/// Hosted upload (blueprint/api.md, Content plane — Ingress): pins bytes to
-/// CipherBox Kubo, returns the pinned CID + size, counts against the account's
-/// quota, and refuses an upload that would cross the limit.
-#[tokio::test]
-async fn hosted_upload_pins_bytes_and_gates_on_quota() {
-    let base = require_stack!("hosted_upload_pins_bytes_and_gates_on_quota");
-    let client = fresh_account(&base).await;
-
-    // A sub-limit upload is pinned and its bytes count against the quota.
-    let first = client
+    // A sub-limit hosted upload is pinned to Kubo and counts against the quota.
+    let pinned = client
         .upload(&vec![7u8; 512])
         .await
         .expect("hosted upload under quota is pinned");
-    assert!(!first.cid.is_empty(), "the pinned CID is returned");
-    assert_eq!(first.size, 512, "size is the uploaded byte count");
+    assert!(!pinned.cid.is_empty(), "the pinned CID is returned");
+    assert_eq!(pinned.size, 512, "size is the uploaded byte count");
+    assert_eq!(
+        client.quota().await.expect("quota after upload").used_bytes,
+        512,
+        "the upload is counted against quota"
+    );
 
-    let quota = client.quota().await.expect("quota after upload");
-    assert_eq!(quota.used_bytes, 512, "the upload is counted against quota");
-
-    // A second upload that would cross the 1 KiB limit is refused (over-quota).
+    // An upload crossing the 1 KiB limit is refused for a hosted account.
     let error = client
         .upload(&vec![9u8; 600])
         .await
@@ -460,23 +434,27 @@ async fn hosted_upload_pins_bytes_and_gates_on_quota() {
         matches!(error, ApiError::Status { status: 413, .. }),
         "over-quota is a 413, got {error:?}"
     );
-}
 
-/// A BYO account's upload is advisory (blueprint/api.md): the quota never gates
-/// it, so bytes larger than the hosted limit are still accepted.
-#[tokio::test]
-async fn byo_upload_is_advisory_and_never_gated() {
-    let base = require_stack!("byo_upload_is_advisory_and_never_gated");
-    let client = fresh_account(&base).await;
+    // Enabling BYO makes the account's rows advisory: quota always allows, so an
+    // upload past the hosted limit is accepted.
     client.set_byo(true).await.expect("enable BYO");
-
-    // 4 KiB is well past the 1 KiB hosted limit, yet a BYO upload is allowed.
-    let result = client
+    let byo = client.quota().await.expect("byo quota");
+    assert!(byo.advisory, "a BYO account's quota is advisory");
+    assert_eq!(
+        byo.limit_bytes, hosted.limit_bytes,
+        "the limit is unchanged"
+    );
+    let byo_upload = client
         .upload(&vec![3u8; 4096])
         .await
         .expect("a BYO upload is never quota-gated");
-    assert_eq!(result.size, 4096, "size is the uploaded byte count");
+    assert_eq!(byo_upload.size, 4096, "size is the uploaded byte count");
 
-    let quota = client.quota().await.expect("byo quota");
-    assert!(quota.advisory, "a BYO account's quota is advisory");
+    // Toggling BYO back restores the authoritative posture.
+    client.set_byo(false).await.expect("disable BYO");
+    let restored = client.quota().await.expect("restored quota");
+    assert!(
+        !restored.advisory,
+        "clearing BYO restores authoritative quota"
+    );
 }

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -426,3 +426,57 @@ async fn quota_is_hosted_authoritative_and_byo_advisory() {
         "clearing BYO restores authoritative quota"
     );
 }
+
+// --- hosted content ingress (blueprint/api.md; #629) ------------------------
+// These exercise the real Kubo pin against the CI stack's tiny 1 KiB
+// QUOTA_DEFAULT_BYTES (set in the contract-suite job), so a few hundred bytes
+// straddle the limit deterministically.
+
+/// Hosted upload (blueprint/api.md, Content plane — Ingress): pins bytes to
+/// CipherBox Kubo, returns the pinned CID + size, counts against the account's
+/// quota, and refuses an upload that would cross the limit.
+#[tokio::test]
+async fn hosted_upload_pins_bytes_and_gates_on_quota() {
+    let base = require_stack!("hosted_upload_pins_bytes_and_gates_on_quota");
+    let client = fresh_account(&base).await;
+
+    // A sub-limit upload is pinned and its bytes count against the quota.
+    let first = client
+        .upload(&vec![7u8; 512])
+        .await
+        .expect("hosted upload under quota is pinned");
+    assert!(!first.cid.is_empty(), "the pinned CID is returned");
+    assert_eq!(first.size, 512, "size is the uploaded byte count");
+
+    let quota = client.quota().await.expect("quota after upload");
+    assert_eq!(quota.used_bytes, 512, "the upload is counted against quota");
+
+    // A second upload that would cross the 1 KiB limit is refused (over-quota).
+    let error = client
+        .upload(&vec![9u8; 600])
+        .await
+        .expect_err("an over-quota upload is refused for a hosted account");
+    assert!(
+        matches!(error, ApiError::Status { status: 413, .. }),
+        "over-quota is a 413, got {error:?}"
+    );
+}
+
+/// A BYO account's upload is advisory (blueprint/api.md): the quota never gates
+/// it, so bytes larger than the hosted limit are still accepted.
+#[tokio::test]
+async fn byo_upload_is_advisory_and_never_gated() {
+    let base = require_stack!("byo_upload_is_advisory_and_never_gated");
+    let client = fresh_account(&base).await;
+    client.set_byo(true).await.expect("enable BYO");
+
+    // 4 KiB is well past the 1 KiB hosted limit, yet a BYO upload is allowed.
+    let result = client
+        .upload(&vec![3u8; 4096])
+        .await
+        .expect("a BYO upload is never quota-gated");
+    assert_eq!(result.size, 4096, "size is the uploaded byte count");
+
+    let quota = client.quota().await.expect("byo quota");
+    assert!(quota.advisory, "a BYO account's quota is advisory");
+}


### PR DESCRIPTION
Closes #629

## What landed

Authenticated hosted ingress: `POST /content/upload` (`application/octet-stream`, returns `{ cid, size }`) that pins opaque bytes to CipherBox Kubo, quota-gated, registering the pin row in the same traversal as the byte path. Matches the engine's existing hand-written Rust client contract exactly. No egress, no BYO/dual byte paths, no provider connection testing.

- **New `content` module** (`content.service.ts`, `content.controller.ts`, `content.module.ts`, DTO) wired into `AppModule`; new `content` throttle surface (per-account).
- **PinStore seam extended** to the full hosted pin-store port: `hash(bytes)` (only-hash CID derivation, no durable effect) and `pin(bytes)` (durable pin) alongside the existing `unpin`. `KuboPinStore` implements them over the Kubo RPC `add` API with identical params so the pre-commit CID always equals the pinned CID.
- **Raw octet-stream body** buffered by a small global middleware in `app-setup` (runs before the async auth guard, so the stream read never races the guard's `await`); absolute size cap via `MAX_UPLOAD_BYTES`.
- No migration — `pinned_cids` already carries `size`/`advisory`.

## Concurrency model

The upload path mutates two shared resources under contention; both reuse the existing `common/advisory-lock` primitives (extracted `advisoryLockKey`, `acquireAdvisoryLocks`, `runLockGuardedTransaction`), `55P03` → retryable 503:

- **Per-account quota gate** — the `SUM(size)` check-then-act is serialized by a per-account advisory lock keyed on `sha256('account:'+accountId)`, so two concurrent uploads cannot both pass at the limit.
- **Per-CID pin refcount** — the pin-row insert takes the SAME per-CID advisory lock (`advisoryLockKey(cid)`) that the registry's register/retire take, so an insert here can never race an unpin there. Both keys acquire in one deadlock-free sorted batch.
- **Atomicity** — the DB transaction is the source of truth; the durable Kubo pin fires AFTER commit. A post-commit pin failure (or a CID mismatch) compensates by retiring the just-registered row, so byte-pin + register are all-or-nothing. External side effects never run inside the txn.

## Folded-in #677 quota hardening

`RegistryService.quota()` no longer uses `pinRepository.sum('size' as never)`. A typed `COALESCE(SUM(size), 0)` query-builder aggregate (`registry/quota.ts::sumPinnedBytes`) returns the numeric sum as a string parsed to `BigInt`, and the used-vs-limit gate compares in BigInt throughout — exact above 2^53 bytes where a JS `number` rounds. The wire DTO stays a JSON number (u64 client type); only the gate math is BigInt.

## Test evidence

Green locally: `typecheck`, `lint`, `test` (130 unit), `test:integration` (18, real Postgres on :5432). Contract crate compiles (`cargo check -p cipherbox-contract --tests`) and is `cargo fmt` clean.

- **Unit** (`registry/quota.test.ts`): `exceedsQuota` / `resolveLimitBytes` / `byteConfigBigInt` BigInt exactness straddling 2^53. **`content/content.http.test.ts`**: octet-stream body → service Buffer, DTO round-trip, 401, empty-body 400, over-quota 413, pin-fault 503.
- **Integration, real Postgres** (`content/content.service.integration.test.ts`, runs in the `API Integration (real Postgres)` gate), each guard with a negative control:
  - quota gate: two same-account uploads race at the limit → exactly one admitted; **negative control** removes the account lock → both pass the stale sum, 120-byte over-quota breach.
  - per-CID: concurrent same-account same-CID uploads → one row, charged once (idempotent); **negative control** strips the locks → duplicate insert collides on the unique index (23505).
  - quota BigInt exactness at a `2^60+1` boundary a Number gate would wrongly admit → refused.
  - atomic byte-pin+register: success keeps row+pin; pin failure compensates the row away (0 rows, unpin fired).

## Wired to CI, not run locally (RAM/no Kubo stack)

Real-Kubo contract coverage lives in `quota_is_hosted_authoritative_and_byo_advisory` (`crates/contract/tests/contract.rs`): a sub-limit hosted upload is pinned + counted, an over-quota upload is refused (413), and a BYO upload past the hosted limit is allowed (advisory). It is folded into the existing quota test rather than added as separate tests so the suite adds no net login traffic against the shared per-IP auth throttle (an initial split-out tripped it, 429-ing two unrelated login tests). The `contract-suite` job already boots Kubo v0.42.0; this PR adds `KUBO_API_URL` and a tiny `QUOTA_DEFAULT_BYTES=1024` to that job's env so a few-hundred-byte upload straddles the limit deterministically.

## Cross-slice note

Minimal, additive touches to `registry.service.ts` (swap local lock helpers for the shared ones + the quota() aggregate) and no new migration, to keep #634's adjacency small.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated hosted content uploads via `POST /content/upload` (`application/octet-stream`).
  * Responses include pinned `cid` and charged `size` in bytes.
  * Enforced per-account rate limiting, hosted-byte quota gating, and a configurable max upload size.
* **Bug Fixes**
  * Improved BigInt-safe quota calculations and stronger consistency for concurrent uploads and quota/compensation flows.
* **Documentation**
  * Updated the OpenAPI spec with the new `Content` endpoint, response DTO, and error codes (400/401/413/429/503).
* **Tests**
  * Added HTTP and integration coverage for buffering/caps, auth behaviors, quota limits, and concurrency/lock guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->