### PR TITLE
fix(core): enforce single-byte content codec in release on the trusted compute_cid path

### DIFF
--- a/crates/core/src/content/cid.rs
+++ b/crates/core/src/content/cid.rs
@@ -65,10 +65,13 @@ pub const CONTENT_CID_LEN: usize = CID_PREFIX_LEN + DIGEST_LEN;
 /// `dag-cbor` (0x71) root (core.md:56) — like the name codec's libp2p-key 0x72
 /// ([`crate::ipns::name`]). A `codec >= 0x80` is a multi-byte unsigned varint,
 /// outside the frozen set and unrepresentable in this fixed layout, so callers
-/// must pass a single-byte multicodec; the guard fails closed (panics in debug)
-/// rather than silently emitting a malformed one-byte-truncated CID.
+/// must pass a single-byte multicodec; the guard fails closed (panics in every
+/// build) rather than silently emitting a malformed one-byte-truncated CID.
 pub fn compute_cid(codec: u8, bytes: &[u8]) -> Vec<u8> {
-    debug_assert!(
+    // A malformed content CID is a content-addressing hazard, so this holds in
+    // release too, not only debug (core.md:56). The frozen content-plane set is
+    // single-byte (raw 0x55, dag-cbor 0x71), so it never fires in correct use.
+    assert!(
         codec < 0x80,
         "content-plane multicodec must be single-byte (< 0x80, core.md:56)"
     );
@@ -188,9 +191,9 @@ mod tests {
         );
     }
 
-    // Native-only: the guard is an arch-independent `u8` comparison, and
-    // `#[should_panic]` is unsafe on the panic=abort wasm legs.
-    #[cfg(all(debug_assertions, not(target_family = "wasm")))]
+    // Native-only: the always-on assert holds in every build (debug and
+    // release), and `#[should_panic]` is unsafe on the panic=abort wasm legs.
+    #[cfg(not(target_family = "wasm"))]
     #[test]
     #[should_panic(expected = "single-byte")]
     fn compute_cid_guards_a_multibyte_codec_fail_closed() {


### PR DESCRIPTION
Follow-up hardening to #696 (merged). Closes a review finding that landed after #696 had merged, so it could not be folded into that PR.

## What

`compute_cid` guarded its `codec` parameter with `debug_assert!(codec < 0x80)`, which is stripped from release builds. A trusted/internal caller passing a multi-byte multicodec (`codec >= 0x80`) in a release build would therefore silently receive a malformed 36-byte CID — an incomplete multicodec varint that compliant CID readers reject — instead of failing.

This upgrades the guard to an always-on `assert!(codec < 0x80, ...)`, so the frozen single-byte content-plane codec contract (raw `0x55` leaf, dag-cbor `0x71` root — `blueprint/core.md:56`) is enforced in every build: a violation fails loud rather than emitting a malformed content address. `verify_cid`'s untrusted-input guard is unchanged — it still returns `TrustViolation::ContentCidMismatch` and never panics on hostile input. The `should_panic` guard test now runs in release as well as debug.

## Severity

Defense-in-depth, not a live bug: the content plane's codec set is single-byte, so nothing on `main` passes `codec >= 0x80`. This makes the invariant hold if that ever changes.

## Verification

`cargo clippy -p cipherbox-core --all-targets` clean; native suite 131 passed; wasm32-wasip1 and wasm32-unknown-unknown legs green; the guard test passes in both debug and release; KAT generator idempotent (no vector drift — `crates/core` is byte-identical to the merged #696 head aside from this guard).

Refs #691, #696.
