### PR TITLE
feat(engine): add the content plane with chunk framing and verified reads

### DIFF
--- a/crates/engine/src/content/chunk.rs
+++ b/crates/engine/src/content/chunk.rs
@@ -10,7 +10,7 @@
 
 use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, seal_chunk};
 use cipherbox_core::suite::aead::{KEY_LEN, NONCE_LEN};
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use super::profile::ContentProfile;
 use crate::entropy::{Entropy, EntropyError};
@@ -25,13 +25,13 @@ pub struct ContentKey([u8; KEY_LEN]);
 
 impl ContentKey {
     /// Mint a fresh content key from injected entropy. Fails closed if entropy
-    /// acquisition fails — never substitutes predictable bytes.
+    /// acquisition fails — never substitutes predictable bytes. The staging
+    /// buffer self-zeroizes on every return path (incl. the error path, where
+    /// it may hold partially-written key bytes).
     pub fn generate(entropy: &mut impl Entropy) -> Result<Self, EntropyError> {
-        let mut bytes = [0u8; KEY_LEN];
-        entropy.fill(&mut bytes)?;
-        let key = Self(bytes);
-        bytes.zeroize();
-        Ok(key)
+        let mut bytes = Zeroizing::new([0u8; KEY_LEN]);
+        entropy.fill(bytes.as_mut())?;
+        Ok(Self(*bytes))
     }
 
     /// Adopt caller-supplied key bytes (a restored per-version key). The array
@@ -182,5 +182,18 @@ mod tests {
             b"payload"
         );
         assert_eq!(format!("{key:?}"), "ContentKey(<redacted>)");
+    }
+
+    #[test]
+    fn generate_fails_closed_when_entropy_fails() {
+        struct FailingEntropy;
+        impl Entropy for FailingEntropy {
+            fn fill(&mut self, _: &mut [u8]) -> Result<(), EntropyError> {
+                Err(EntropyError::new("no entropy"))
+            }
+        }
+        // The error path (where the staging buffer may hold partial key bytes and
+        // the Zeroizing wrapper scrubs it on drop) returns Err, never a key.
+        assert!(ContentKey::generate(&mut FailingEntropy).is_err());
     }
 }

--- a/crates/engine/src/content/chunk.rs
+++ b/crates/engine/src/content/chunk.rs
@@ -1,0 +1,186 @@
+//! Fixed-size chunk framing over core's content-seal (blueprint/engine.md
+//! "Content plane": "the engine frames content into fixed-size chunks, seals
+//! each with core's content-seal primitive ... fresh random per-version content
+//! key").
+//!
+//! Framing is the engine's job; the seal and the leaf content-address are
+//! core's ([`cipherbox_core::content`], #691). This module owns only the
+//! split-into-fixed-chunks decision and the per-chunk nonce draw from injected
+//! entropy — no crypto of its own (AGENTS.md rule 4).
+
+use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, seal_chunk};
+use cipherbox_core::suite::aead::{KEY_LEN, NONCE_LEN};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use super::profile::ContentProfile;
+use crate::entropy::{Entropy, EntropyError};
+
+/// A fresh random per-version content key (blueprint/engine.md, #26 D6). The
+/// terminal owner of the key bytes: zeroized on drop, borrowed (never copied)
+/// by the seal, which must not zero it (the "zeroize at the terminal owner
+/// only" rule). One key seals every chunk of a version; a new version mints a
+/// new key.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct ContentKey([u8; KEY_LEN]);
+
+impl ContentKey {
+    /// Mint a fresh content key from injected entropy. Fails closed if entropy
+    /// acquisition fails — never substitutes predictable bytes.
+    pub fn generate(entropy: &mut impl Entropy) -> Result<Self, EntropyError> {
+        let mut bytes = [0u8; KEY_LEN];
+        entropy.fill(&mut bytes)?;
+        let key = Self(bytes);
+        bytes.zeroize();
+        Ok(key)
+    }
+
+    /// Adopt caller-supplied key bytes (a restored per-version key). The array
+    /// is caller-owned; callers holding secret material zeroize it themselves.
+    pub fn from_bytes(bytes: [u8; KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the raw key bytes for the seal. Borrowed, never taken — the seal
+    /// leaves this buffer intact.
+    pub fn as_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.0
+    }
+}
+
+// A key must never render its bytes to a log site (security rule 2).
+impl core::fmt::Debug for ContentKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("ContentKey(<redacted>)")
+    }
+}
+
+/// One sealed leaf: its content-address and the sealed wire bytes that address
+/// resolves to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SealedChunk {
+    /// The leaf content CID (binary CIDv1, `raw` codec) — a BLAKE3 digest over
+    /// [`Self::sealed`]. The block's authenticity anchor: a verified read
+    /// recomputes it and fails closed on mismatch.
+    pub cid: Vec<u8>,
+    /// The sealed wire blob `nonce(24) || ciphertext||tag` this CID addresses.
+    pub sealed: Vec<u8>,
+}
+
+/// Frame `plaintext` into fixed-size chunks and seal each under `key`
+/// (blueprint/engine.md "Content plane"). Every chunk but the last carries
+/// exactly `profile.chunk_size` plaintext bytes; empty input frames to a single
+/// empty leaf so every version has at least one addressable block.
+///
+/// Each chunk draws a fresh nonce from injected `entropy` — XChaCha20-Poly1305
+/// nonce reuse under one key is a break, and the nonce is public (core prefixes
+/// it into the sealed blob). Deterministic under a fixed key and a seeded
+/// entropy stream: the leaf CIDs and sealed bytes are byte-identical run to run.
+pub fn frame_and_seal(
+    plaintext: &[u8],
+    key: &ContentKey,
+    entropy: &mut impl Entropy,
+    profile: &ContentProfile,
+) -> Result<Vec<SealedChunk>, EntropyError> {
+    let framed: Vec<&[u8]> = if plaintext.is_empty() {
+        vec![&[][..]]
+    } else {
+        plaintext.chunks(profile.chunk_size).collect()
+    };
+    let mut leaves = Vec::with_capacity(framed.len());
+    for chunk in framed {
+        let mut nonce = [0u8; NONCE_LEN];
+        entropy.fill(&mut nonce)?;
+        let sealed = seal_chunk(key.as_bytes(), &nonce, chunk);
+        let cid = compute_cid(CONTENT_CID_CODEC, &sealed);
+        leaves.push(SealedChunk { cid, sealed });
+    }
+    Ok(leaves)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testkit::SeededEntropy;
+    use cipherbox_core::content::{open_chunk, verify_cid};
+
+    fn ci() -> ContentProfile {
+        ContentProfile::CI
+    }
+
+    #[test]
+    fn frames_into_chunk_sized_leaves_with_a_short_tail() {
+        // 40 bytes at 16-byte chunks => 16 + 16 + 8.
+        let plaintext: Vec<u8> = (0..40u8).collect();
+        let key = ContentKey::from_bytes([7u8; KEY_LEN]);
+        let mut entropy = SeededEntropy::new(1);
+        let leaves = frame_and_seal(&plaintext, &key, &mut entropy, &ci()).unwrap();
+        assert_eq!(leaves.len(), 3);
+
+        // Every leaf verifies against its own CID and opens to the right slice.
+        let mut recovered = Vec::new();
+        for leaf in &leaves {
+            assert!(verify_cid(&leaf.cid, &leaf.sealed).is_ok());
+            recovered.extend(open_chunk(key.as_bytes(), &leaf.sealed).unwrap());
+        }
+        assert_eq!(recovered, plaintext, "chunks reassemble to the original");
+    }
+
+    #[test]
+    fn empty_input_frames_to_one_empty_leaf() {
+        let key = ContentKey::from_bytes([3u8; KEY_LEN]);
+        let mut entropy = SeededEntropy::new(2);
+        let leaves = frame_and_seal(b"", &key, &mut entropy, &ci()).unwrap();
+        assert_eq!(
+            leaves.len(),
+            1,
+            "empty version still has one addressable leaf"
+        );
+        assert_eq!(open_chunk(key.as_bytes(), &leaves[0].sealed).unwrap(), b"");
+    }
+
+    #[test]
+    fn exact_multiple_has_no_trailing_empty_leaf() {
+        let plaintext = vec![9u8; 32]; // exactly two 16-byte chunks
+        let key = ContentKey::from_bytes([1u8; KEY_LEN]);
+        let mut entropy = SeededEntropy::new(3);
+        let leaves = frame_and_seal(&plaintext, &key, &mut entropy, &ci()).unwrap();
+        assert_eq!(
+            leaves.len(),
+            2,
+            "no phantom empty leaf on an exact multiple"
+        );
+    }
+
+    #[test]
+    fn deterministic_under_fixed_key_and_seeded_entropy() {
+        let plaintext: Vec<u8> = (0..50u8).collect();
+        let key = ContentKey::from_bytes([5u8; KEY_LEN]);
+        let a = frame_and_seal(&plaintext, &key, &mut SeededEntropy::new(42), &ci()).unwrap();
+        let b = frame_and_seal(&plaintext, &key, &mut SeededEntropy::new(42), &ci()).unwrap();
+        assert_eq!(a, b, "same key + seed => byte-identical framing");
+    }
+
+    #[test]
+    fn distinct_seeds_give_distinct_nonces_and_cids() {
+        let plaintext = vec![0u8; 16];
+        let key = ContentKey::from_bytes([5u8; KEY_LEN]);
+        let a = frame_and_seal(&plaintext, &key, &mut SeededEntropy::new(1), &ci()).unwrap();
+        let b = frame_and_seal(&plaintext, &key, &mut SeededEntropy::new(2), &ci()).unwrap();
+        assert_ne!(
+            a[0].cid, b[0].cid,
+            "a fresh nonce changes the sealed bytes and CID"
+        );
+    }
+
+    #[test]
+    fn generate_produces_a_usable_key_and_redacts_debug() {
+        let mut entropy = SeededEntropy::new(99);
+        let key = ContentKey::generate(&mut entropy).unwrap();
+        let sealed = frame_and_seal(b"payload", &key, &mut SeededEntropy::new(1), &ci()).unwrap();
+        assert_eq!(
+            open_chunk(key.as_bytes(), &sealed[0].sealed).unwrap(),
+            b"payload"
+        );
+        assert_eq!(format!("{key:?}"), "ContentKey(<redacted>)");
+    }
+}

--- a/crates/engine/src/content/chunk.rs
+++ b/crates/engine/src/content/chunk.rs
@@ -84,7 +84,7 @@ pub fn frame_and_seal(
     let framed: Vec<&[u8]> = if plaintext.is_empty() {
         vec![&[][..]]
     } else {
-        plaintext.chunks(profile.chunk_size).collect()
+        plaintext.chunks(profile.chunk_size()).collect()
     };
     let mut leaves = Vec::with_capacity(framed.len());
     for chunk in framed {

--- a/crates/engine/src/content/dag.rs
+++ b/crates/engine/src/content/dag.rs
@@ -16,7 +16,9 @@
 //! size (blueprint/engine.md "Open edges").
 
 use cipherbox_core::codec::{Map, Value, decode, encode};
-use cipherbox_core::content::compute_cid;
+use cipherbox_core::content::{
+    CONTENT_CID_CODEC, CONTENT_CID_LEN, CONTENT_CID_MULTIHASH, compute_cid,
+};
 use cipherbox_core::error::{CodecError, Malformed};
 
 use super::chunk::SealedChunk;
@@ -26,6 +28,41 @@ use super::profile::ContentProfile;
 /// (#630, engine.md:497) — core keeps the leaf `raw` codec but takes the root
 /// codec as a parameter. Single-byte, inside core's frozen content-plane set.
 pub const DAG_ROOT_CODEC: u8 = 0x71;
+
+/// CIDv1 version byte, and the digest-length byte (BLAKE3-256 = 32) — the two
+/// fixed CIDv1 framing bytes core does not expose as public constants; used to
+/// validate that a decoded leaf link is a well-formed content CID.
+const CID_VERSION: u8 = 0x01;
+const CID_DIGEST_LEN: u8 = 32;
+
+/// Why decoding a root block failed, fail-closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DagError {
+    /// The root block was not valid deterministic CBOR, or not the root map
+    /// shape (a non-canonical encoding, a missing field, a wrong-typed field) —
+    /// a core [`CodecError`] surfaced verbatim.
+    Cbor(CodecError),
+    /// The root decoded but violated a manifest invariant: a zero chunk size, a
+    /// leaf link that is not a well-formed content CID, or a link count
+    /// inconsistent with the byte size. An internally inconsistent manifest is
+    /// never trusted, even when its own `contentCid` verifies.
+    InvalidManifest {
+        /// Which invariant failed.
+        reason: &'static str,
+    },
+}
+
+impl From<CodecError> for DagError {
+    fn from(error: CodecError) -> Self {
+        Self::Cbor(error)
+    }
+}
+
+impl From<Malformed> for DagError {
+    fn from(error: Malformed) -> Self {
+        Self::Cbor(error.into())
+    }
+}
 
 const CHUNK_SIZE_KEY: &str = "chunkSize";
 const SIZE_KEY: &str = "size";
@@ -58,7 +95,7 @@ pub fn assemble(
         .map(|leaf| Value::Bytes(leaf.cid.clone()))
         .collect();
     let mut root = Map::new();
-    root.insert(CHUNK_SIZE_KEY, Value::Unsigned(profile.chunk_size as u64));
+    root.insert(CHUNK_SIZE_KEY, Value::Unsigned(profile.chunk_size() as u64));
     root.insert(SIZE_KEY, Value::Unsigned(plaintext_len));
     root.insert(LINKS_KEY, Value::Array(links));
     let root_block = encode(&Value::Map(root));
@@ -83,10 +120,13 @@ pub struct RootManifest {
 }
 
 /// Decode a root block (already verified against its `contentCid` by the
-/// caller) into its manifest. Fail-closed on a structurally invalid root: a
-/// non-canonical encoding is a core [`CodecError`] surfaced verbatim; a missing
-/// or wrong-typed field is [`Malformed`].
-pub fn decode_root(root_block: &[u8]) -> Result<RootManifest, CodecError> {
+/// caller) into its manifest, fail-closed. Beyond the core-CBOR checks (a
+/// non-canonical encoding, a missing or wrong-typed field), the manifest
+/// invariants are enforced here so a `contentCid`-valid-but-inconsistent root is
+/// rejected, not silently trusted: the chunk size must be nonzero, every leaf
+/// link must be a well-formed `raw` content CID, and the link count must match
+/// `ceil(size / chunkSize)` (an empty version is exactly one empty leaf).
+pub fn decode_root(root_block: &[u8]) -> Result<RootManifest, DagError> {
     let root = decode(root_block)?;
     let map = root.as_map()?;
     let chunk_size = map
@@ -103,7 +143,30 @@ pub fn decode_root(root_block: &[u8]) -> Result<RootManifest, CodecError> {
         .as_array()?
         .iter()
         .map(|link| link.as_bytes().map(<[u8]>::to_vec))
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>, Malformed>>()?;
+
+    if chunk_size == 0 {
+        return Err(DagError::InvalidManifest {
+            reason: "zero chunk size",
+        });
+    }
+    if !leaf_cids.iter().all(|cid| is_raw_leaf_cid(cid)) {
+        return Err(DagError::InvalidManifest {
+            reason: "malformed leaf cid",
+        });
+    }
+    // An empty version frames to one empty leaf; otherwise ceil(size/chunkSize).
+    let expected_leaves = if size == 0 {
+        1
+    } else {
+        size.div_ceil(chunk_size)
+    };
+    if leaf_cids.len() as u64 != expected_leaves {
+        return Err(DagError::InvalidManifest {
+            reason: "link count inconsistent with size",
+        });
+    }
+
     Ok(RootManifest {
         chunk_size,
         size,
@@ -111,12 +174,24 @@ pub fn decode_root(root_block: &[u8]) -> Result<RootManifest, CodecError> {
     })
 }
 
+/// Whether `cid` is a well-formed `raw` leaf content CID: the fixed CIDv1 framing
+/// `version || raw || blake3 || len` over a 32-byte digest. This checks framing,
+/// not the digest — the digest is verified when the leaf block is fetched and
+/// run through [`cipherbox_core::content::verify_cid`].
+fn is_raw_leaf_cid(cid: &[u8]) -> bool {
+    cid.len() == CONTENT_CID_LEN
+        && cid[0] == CID_VERSION
+        && cid[1] == CONTENT_CID_CODEC
+        && cid[2] == CONTENT_CID_MULTIHASH
+        && cid[3] == CID_DIGEST_LEN
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::content::chunk::{ContentKey, frame_and_seal};
     use crate::testkit::SeededEntropy;
-    use cipherbox_core::content::{CONTENT_CID_CODEC, verify_cid};
+    use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, verify_cid};
     use cipherbox_core::suite::aead::KEY_LEN;
 
     fn framed(plaintext: &[u8], seed: u64) -> (Vec<SealedChunk>, ContentProfile) {
@@ -125,6 +200,26 @@ mod tests {
         let leaves =
             frame_and_seal(plaintext, &key, &mut SeededEntropy::new(seed), &profile).unwrap();
         (leaves, profile)
+    }
+
+    /// Hand-build a root block with arbitrary fields, bypassing `assemble`, to
+    /// drive the fail-closed manifest checks.
+    fn root_bytes(chunk_size: u64, size: u64, links: &[Vec<u8>]) -> Vec<u8> {
+        let mut root = Map::new();
+        root.insert(CHUNK_SIZE_KEY, Value::Unsigned(chunk_size));
+        root.insert(SIZE_KEY, Value::Unsigned(size));
+        root.insert(
+            LINKS_KEY,
+            Value::Array(links.iter().cloned().map(Value::Bytes).collect()),
+        );
+        encode(&Value::Map(root))
+    }
+
+    fn invalid_manifest_reason(block: &[u8]) -> &'static str {
+        match decode_root(block) {
+            Err(DagError::InvalidManifest { reason }) => reason,
+            other => panic!("expected an InvalidManifest error, got {other:?}"),
+        }
     }
 
     #[test]
@@ -153,7 +248,7 @@ mod tests {
         let dag = assemble(&leaves, plaintext.len() as u64, &profile);
 
         let manifest = decode_root(&dag.root_block).unwrap();
-        assert_eq!(manifest.chunk_size, profile.chunk_size as u64);
+        assert_eq!(manifest.chunk_size, profile.chunk_size() as u64);
         assert_eq!(manifest.size, plaintext.len() as u64);
         assert_eq!(
             manifest.leaf_cids,
@@ -175,5 +270,40 @@ mod tests {
         // A valid det-CBOR value that is not the root map shape.
         let not_a_root = encode(&Value::Unsigned(7));
         assert!(decode_root(&not_a_root).is_err());
+    }
+
+    #[test]
+    fn decode_root_rejects_a_zero_chunk_size() {
+        assert_eq!(
+            invalid_manifest_reason(&root_bytes(0, 0, &[])),
+            "zero chunk size"
+        );
+    }
+
+    #[test]
+    fn decode_root_rejects_a_malformed_leaf_cid() {
+        // chunkSize 16, size 16 => one leaf expected; the one link is not a CID.
+        let block = root_bytes(16, 16, &[b"not-a-content-cid".to_vec()]);
+        assert_eq!(invalid_manifest_reason(&block), "malformed leaf cid");
+    }
+
+    #[test]
+    fn decode_root_rejects_a_link_count_size_mismatch() {
+        // size 40 at chunkSize 16 expects 3 leaves; only one (valid) link given.
+        let block = root_bytes(16, 40, &[compute_cid(CONTENT_CID_CODEC, b"x")]);
+        assert_eq!(
+            invalid_manifest_reason(&block),
+            "link count inconsistent with size"
+        );
+    }
+
+    #[test]
+    fn decode_root_accepts_the_empty_version_single_leaf() {
+        // size 0 frames to exactly one empty leaf; the count check must allow it.
+        let (leaves, profile) = framed(b"", 9);
+        let dag = assemble(&leaves, 0, &profile);
+        let manifest = decode_root(&dag.root_block).unwrap();
+        assert_eq!(manifest.size, 0);
+        assert_eq!(manifest.leaf_cids.len(), 1);
     }
 }

--- a/crates/engine/src/content/dag.rs
+++ b/crates/engine/src/content/dag.rs
@@ -90,6 +90,16 @@ pub fn assemble(
     plaintext_len: u64,
     profile: &ContentProfile,
 ) -> ContentDag {
+    // Produce/consume symmetry: assemble emits exactly the leaf count decode_root
+    // requires, so this crate never produces a root its own decode would reject.
+    // A debug_assert (not a fallible signature) is the right level — the inputs
+    // are trusted engine values, so this guards a mis-wired caller, not untrusted
+    // input.
+    debug_assert_eq!(
+        leaves.len() as u64,
+        expected_leaf_count(plaintext_len, profile.chunk_size() as u64),
+        "assemble leaf count must match decode_root's ceil(size / chunkSize)"
+    );
     let links = leaves
         .iter()
         .map(|leaf| Value::Bytes(leaf.cid.clone()))
@@ -155,13 +165,7 @@ pub fn decode_root(root_block: &[u8]) -> Result<RootManifest, DagError> {
             reason: "malformed leaf cid",
         });
     }
-    // An empty version frames to one empty leaf; otherwise ceil(size/chunkSize).
-    let expected_leaves = if size == 0 {
-        1
-    } else {
-        size.div_ceil(chunk_size)
-    };
-    if leaf_cids.len() as u64 != expected_leaves {
+    if leaf_cids.len() as u64 != expected_leaf_count(size, chunk_size) {
         return Err(DagError::InvalidManifest {
             reason: "link count inconsistent with size",
         });
@@ -172,6 +176,20 @@ pub fn decode_root(root_block: &[u8]) -> Result<RootManifest, DagError> {
         size,
         leaf_cids,
     })
+}
+
+/// The leaf count a version of `plaintext_len` bytes frames to at `chunk_size`:
+/// `ceil(len / chunk_size)`, except an empty version is exactly one empty leaf.
+/// The single formula both [`assemble`] (produce) and [`decode_root`] (consume)
+/// share, so the two sides cannot diverge. `chunk_size` is nonzero at both call
+/// sites (a profile invariant on produce; the zero-chunk check runs first on
+/// decode).
+fn expected_leaf_count(plaintext_len: u64, chunk_size: u64) -> u64 {
+    if plaintext_len == 0 {
+        1
+    } else {
+        plaintext_len.div_ceil(chunk_size)
+    }
 }
 
 /// Whether `cid` is a well-formed `raw` leaf content CID: the fixed CIDv1 framing

--- a/crates/engine/src/content/dag.rs
+++ b/crates/engine/src/content/dag.rs
@@ -1,0 +1,179 @@
+//! DAG assembly: the version root addressed by its `contentCid`
+//! (blueprint/engine.md "Content plane": "assembles a DAG addressed by the
+//! version's `contentCid`, shaped so ranged block/CAR fetches map
+//! chunk-aligned").
+//!
+//! The DAG *shape* is engine-owned (an open edge); the *encoding* and the
+//! content-address are core's — the root node is serialized with core's
+//! deterministic CBOR ([`cipherbox_core::codec`], a strict DAG-CBOR subset) and
+//! addressed by [`cipherbox_core::content::compute_cid`] under the engine-chosen
+//! `dag-cbor` codec, so there is one codec and one KAT set (AGENTS.md rules 4-5).
+//!
+//! Shape today is a single flat root over the ordered leaf CIDs plus the fixed
+//! chunk size and the plaintext length. Flat keeps the byte→leaf map trivial
+//! (offset / chunkSize), which is exactly the chunk-alignment a ranged fetch
+//! needs; a fan-out/balancing profile is the open edge deferred with the chunk
+//! size (blueprint/engine.md "Open edges").
+
+use cipherbox_core::codec::{Map, Value, decode, encode};
+use cipherbox_core::content::compute_cid;
+use cipherbox_core::error::{CodecError, Malformed};
+
+use super::chunk::SealedChunk;
+use super::profile::ContentProfile;
+
+/// The multicodec of the DAG-root `contentCid`: `dag-cbor` (0x71). Engine-owned
+/// (#630, engine.md:497) — core keeps the leaf `raw` codec but takes the root
+/// codec as a parameter. Single-byte, inside core's frozen content-plane set.
+pub const DAG_ROOT_CODEC: u8 = 0x71;
+
+const CHUNK_SIZE_KEY: &str = "chunkSize";
+const SIZE_KEY: &str = "size";
+const LINKS_KEY: &str = "links";
+
+/// An assembled content DAG: the version root block and the `contentCid` that
+/// addresses it. The leaf blocks live in the [`SealedChunk`]s passed to
+/// [`assemble`]; this is only the root the version metadata pins.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentDag {
+    /// The version's `contentCid` (binary CIDv1, `dag-cbor` codec) — a BLAKE3
+    /// digest over [`Self::root_block`]. A verified read of the root recomputes
+    /// and fails closed on mismatch.
+    pub content_cid: Vec<u8>,
+    /// The deterministic det-CBOR root node bytes this CID addresses.
+    pub root_block: Vec<u8>,
+}
+
+/// Assemble the ordered `leaves` into a version root addressed by its
+/// `contentCid`. `plaintext_len` is the pre-seal byte length (the ranged-read
+/// size bound). Deterministic: identical leaves + length + profile give a
+/// byte-identical root block and CID.
+pub fn assemble(
+    leaves: &[SealedChunk],
+    plaintext_len: u64,
+    profile: &ContentProfile,
+) -> ContentDag {
+    let links = leaves
+        .iter()
+        .map(|leaf| Value::Bytes(leaf.cid.clone()))
+        .collect();
+    let mut root = Map::new();
+    root.insert(CHUNK_SIZE_KEY, Value::Unsigned(profile.chunk_size as u64));
+    root.insert(SIZE_KEY, Value::Unsigned(plaintext_len));
+    root.insert(LINKS_KEY, Value::Array(links));
+    let root_block = encode(&Value::Map(root));
+    let content_cid = compute_cid(DAG_ROOT_CODEC, &root_block);
+    ContentDag {
+        content_cid,
+        root_block,
+    }
+}
+
+/// The manifest read back from a verified root block: the fixed chunk size, the
+/// plaintext length, and the ordered leaf CIDs. What a ranged read consults to
+/// map a byte range to leaf blocks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RootManifest {
+    /// The fixed chunk size the leaves were framed at.
+    pub chunk_size: u64,
+    /// The total plaintext byte length across all leaves.
+    pub size: u64,
+    /// The leaf content CIDs, in file order.
+    pub leaf_cids: Vec<Vec<u8>>,
+}
+
+/// Decode a root block (already verified against its `contentCid` by the
+/// caller) into its manifest. Fail-closed on a structurally invalid root: a
+/// non-canonical encoding is a core [`CodecError`] surfaced verbatim; a missing
+/// or wrong-typed field is [`Malformed`].
+pub fn decode_root(root_block: &[u8]) -> Result<RootManifest, CodecError> {
+    let root = decode(root_block)?;
+    let map = root.as_map()?;
+    let chunk_size = map
+        .get(CHUNK_SIZE_KEY)
+        .ok_or(Malformed::MissingField { field: "chunkSize" })?
+        .as_unsigned()?;
+    let size = map
+        .get(SIZE_KEY)
+        .ok_or(Malformed::MissingField { field: "size" })?
+        .as_unsigned()?;
+    let leaf_cids = map
+        .get(LINKS_KEY)
+        .ok_or(Malformed::MissingField { field: "links" })?
+        .as_array()?
+        .iter()
+        .map(|link| link.as_bytes().map(<[u8]>::to_vec))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(RootManifest {
+        chunk_size,
+        size,
+        leaf_cids,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::content::chunk::{ContentKey, frame_and_seal};
+    use crate::testkit::SeededEntropy;
+    use cipherbox_core::content::{CONTENT_CID_CODEC, verify_cid};
+    use cipherbox_core::suite::aead::KEY_LEN;
+
+    fn framed(plaintext: &[u8], seed: u64) -> (Vec<SealedChunk>, ContentProfile) {
+        let profile = ContentProfile::CI;
+        let key = ContentKey::from_bytes([7u8; KEY_LEN]);
+        let leaves =
+            frame_and_seal(plaintext, &key, &mut SeededEntropy::new(seed), &profile).unwrap();
+        (leaves, profile)
+    }
+
+    #[test]
+    fn root_content_addresses_to_its_content_cid() {
+        let (leaves, profile) = framed(&(0..40u8).collect::<Vec<_>>(), 1);
+        let dag = assemble(&leaves, 40, &profile);
+        assert!(verify_cid(&dag.content_cid, &dag.root_block).is_ok());
+        assert_eq!(
+            dag.content_cid[1], DAG_ROOT_CODEC,
+            "root CID carries dag-cbor"
+        );
+    }
+
+    #[test]
+    fn assembly_is_deterministic() {
+        let (leaves, profile) = framed(&(0..40u8).collect::<Vec<_>>(), 7);
+        let a = assemble(&leaves, 40, &profile);
+        let b = assemble(&leaves, 40, &profile);
+        assert_eq!(a, b, "same leaves + length => byte-identical root");
+    }
+
+    #[test]
+    fn root_manifest_round_trips_the_ordered_leaf_cids() {
+        let plaintext: Vec<u8> = (0..40u8).collect();
+        let (leaves, profile) = framed(&plaintext, 3);
+        let dag = assemble(&leaves, plaintext.len() as u64, &profile);
+
+        let manifest = decode_root(&dag.root_block).unwrap();
+        assert_eq!(manifest.chunk_size, profile.chunk_size as u64);
+        assert_eq!(manifest.size, plaintext.len() as u64);
+        assert_eq!(
+            manifest.leaf_cids,
+            leaves.iter().map(|l| l.cid.clone()).collect::<Vec<_>>(),
+            "links preserve file order"
+        );
+    }
+
+    #[test]
+    fn leaf_cids_use_the_raw_codec_root_uses_dag_cbor() {
+        let (leaves, profile) = framed(b"abc", 5);
+        let dag = assemble(&leaves, 3, &profile);
+        assert_eq!(leaves[0].cid[1], CONTENT_CID_CODEC, "leaf is raw");
+        assert_eq!(dag.content_cid[1], DAG_ROOT_CODEC, "root is dag-cbor");
+    }
+
+    #[test]
+    fn decode_rejects_a_non_root_block_fail_closed() {
+        // A valid det-CBOR value that is not the root map shape.
+        let not_a_root = encode(&Value::Unsigned(7));
+        assert!(decode_root(&not_a_root).is_err());
+    }
+}

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -1,0 +1,130 @@
+//! The content plane: chunk framing, DAG assembly, the pin-provider layer,
+//! verified reads, and version retention (blueprint/engine.md "Content plane").
+//!
+//! The engine frames content into fixed-size chunks and seals each with core's
+//! content-seal primitive under a fresh per-version content key, assembles a DAG
+//! addressed by the version's `contentCid`, and reads blocks back through the
+//! trustless gateway with a fail-closed CID verify on every response. All crypto
+//! and the content-address codec are core's ([`cipherbox_core::content`], #691);
+//! this plane composes them and owns the framing/DAG shape and the placement,
+//! quota, and retention judgment (#630).
+//!
+//! - [`chunk`] — fixed-size framing + per-version key + core seal + leaf CID.
+//! - [`dag`] — the version root addressed by its `contentCid`, chunk-aligned.
+//! - [`provider`] — the pin-provider layer and BYO reachability probe.
+//! - [`read`] — verified reads (accelerator + public fallback), fail-closed.
+//! - [`retention`] — pre-flight quota and the explicit prune op.
+//! - [`profile`] — the open-edge chunk-size constant.
+
+pub mod chunk;
+pub mod dag;
+pub mod profile;
+pub mod provider;
+pub mod read;
+pub mod retention;
+
+pub use chunk::{ContentKey, SealedChunk, frame_and_seal};
+pub use dag::{ContentDag, DAG_ROOT_CODEC, RootManifest, assemble, decode_root};
+pub use profile::ContentProfile;
+pub use provider::{ByoIpfsConfig, ByoKind, PinMode, ProviderError, test_connection};
+pub use read::{
+    ContentPlane, Gateway, GatewaySource, ReadError, leaf_range_for_byte_range, read_block,
+};
+pub use retention::{ContentVersion, PrunePlan, QuotaExceeded, plan_prune, pre_flight_quota_check};
+
+use crate::entropy::{Entropy, EntropyError};
+
+/// A fully sealed content version, ready to pin and register: the version's
+/// `contentCid`, the DAG root block it addresses, and every sealed leaf block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SealedContent {
+    /// The version's `contentCid` — the DAG root's content address, pinned by
+    /// the version metadata and the authenticity anchor for a verified read.
+    pub content_cid: Vec<u8>,
+    /// The DAG root block bytes (`dag-cbor`) that `content_cid` addresses.
+    pub root_block: Vec<u8>,
+    /// The sealed leaf blocks in file order, each carrying its own `raw` CID.
+    pub leaves: Vec<SealedChunk>,
+}
+
+/// Frame, seal, and assemble `plaintext` into a content version under `key`
+/// (blueprint/engine.md "Content plane"). Composes [`frame_and_seal`] and
+/// [`assemble`]; deterministic under a fixed key and seeded entropy. Fails
+/// closed only if entropy acquisition fails.
+pub fn seal_content(
+    plaintext: &[u8],
+    key: &ContentKey,
+    entropy: &mut impl Entropy,
+    profile: &ContentProfile,
+) -> Result<SealedContent, EntropyError> {
+    let leaves = frame_and_seal(plaintext, key, entropy, profile)?;
+    let dag = assemble(&leaves, plaintext.len() as u64, profile);
+    Ok(SealedContent {
+        content_cid: dag.content_cid,
+        root_block: dag.root_block,
+        leaves,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testkit::SeededEntropy;
+    use cipherbox_core::content::{open_chunk, verify_cid};
+    use cipherbox_core::suite::aead::KEY_LEN;
+
+    #[test]
+    fn seal_content_round_trips_through_the_dag() {
+        let plaintext: Vec<u8> = (0..100u8).collect();
+        let key = ContentKey::from_bytes([9u8; KEY_LEN]);
+        let sealed = seal_content(
+            &plaintext,
+            &key,
+            &mut SeededEntropy::new(1),
+            &ContentProfile::CI,
+        )
+        .unwrap();
+
+        // The root verifies, and its manifest lists the leaves in order.
+        assert!(verify_cid(&sealed.content_cid, &sealed.root_block).is_ok());
+        let manifest = decode_root(&sealed.root_block).unwrap();
+        assert_eq!(manifest.size, plaintext.len() as u64);
+        assert_eq!(
+            manifest.leaf_cids,
+            sealed
+                .leaves
+                .iter()
+                .map(|l| l.cid.clone())
+                .collect::<Vec<_>>()
+        );
+
+        // Every leaf verifies against its listed CID and opens to reassemble.
+        let mut recovered = Vec::new();
+        for (leaf, cid) in sealed.leaves.iter().zip(&manifest.leaf_cids) {
+            assert!(verify_cid(cid, &leaf.sealed).is_ok());
+            recovered.extend(open_chunk(key.as_bytes(), &leaf.sealed).unwrap());
+        }
+        assert_eq!(
+            recovered, plaintext,
+            "verified reassembly equals the original"
+        );
+    }
+
+    #[test]
+    fn seal_content_is_deterministic() {
+        let key = ContentKey::from_bytes([2u8; KEY_LEN]);
+        let a = seal_content(
+            b"determinism",
+            &key,
+            &mut SeededEntropy::new(7),
+            &ContentProfile::CI,
+        );
+        let b = seal_content(
+            b"determinism",
+            &key,
+            &mut SeededEntropy::new(7),
+            &ContentProfile::CI,
+        );
+        assert_eq!(a.unwrap(), b.unwrap());
+    }
+}

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -24,9 +24,11 @@ pub mod read;
 pub mod retention;
 
 pub use chunk::{ContentKey, SealedChunk, frame_and_seal};
-pub use dag::{ContentDag, DAG_ROOT_CODEC, RootManifest, assemble, decode_root};
+pub use dag::{ContentDag, DAG_ROOT_CODEC, DagError, RootManifest, assemble, decode_root};
 pub use profile::ContentProfile;
-pub use provider::{ByoIpfsConfig, ByoKind, PinMode, ProviderError, test_connection};
+pub use provider::{
+    ByoIpfsConfig, ByoKind, PinMode, ProviderError, test_connection, validate_endpoint,
+};
 pub use read::{
     ContentPlane, Gateway, GatewaySource, ReadError, leaf_range_for_byte_range, read_block,
 };

--- a/crates/engine/src/content/profile.rs
+++ b/crates/engine/src/content/profile.rs
@@ -11,18 +11,19 @@
 /// of the shape today; DAG fan-out/balancing stays flat (an open edge below).
 ///
 /// There is deliberately **no `Default`** (mirrors [`crate::profile`]): every
-/// construction site names its profile, and [`chunk_size`] is always a real,
-/// nonzero value.
-///
-/// [`chunk_size`]: ContentProfile::chunk_size
+/// construction site names its profile, and the chunk size is always a real,
+/// nonzero value — the field is private and every constructor rejects zero, so
+/// a zero chunk size (which would panic framing at `chunks(0)`) is
+/// unrepresentable rather than a fail-late panic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ContentProfile {
     /// Fixed content chunk size in bytes. Every leaf but the last carries
     /// exactly this many plaintext bytes, so a byte offset maps to a leaf index
     /// by integer division — the chunk-aligned property ranged block/CAR
     /// fetches rely on (blueprint/engine.md "shaped so ranged ... fetches map
-    /// chunk-aligned").
-    pub chunk_size: usize,
+    /// chunk-aligned"). Private with a nonzero invariant; read via
+    /// [`ContentProfile::chunk_size`].
+    chunk_size: usize,
 }
 
 impl ContentProfile {
@@ -39,6 +40,23 @@ impl ContentProfile {
     /// CI framing: 16-byte chunks so multi-chunk framing and DAG assembly are
     /// reachable from tiny fixtures (blueprint/testing.md "The DX hook").
     pub const CI: Self = Self { chunk_size: 16 };
+
+    /// A custom profile with the given chunk size, or `None` for a zero size.
+    /// The nonzero invariant is enforced here so framing never divides or
+    /// `chunks()` by zero — a zero chunk size is rejected at construction, not
+    /// discovered as a panic during a seal.
+    pub const fn new(chunk_size: usize) -> Option<Self> {
+        if chunk_size == 0 {
+            None
+        } else {
+            Some(Self { chunk_size })
+        }
+    }
+
+    /// The fixed chunk size in bytes (always nonzero).
+    pub const fn chunk_size(&self) -> usize {
+        self.chunk_size
+    }
 }
 
 #[cfg(test)]
@@ -50,13 +68,13 @@ mod tests {
 
     #[test]
     fn production_chunk_size_is_one_mib() {
-        assert_eq!(ContentProfile::PRODUCTION.chunk_size, 1 << 20);
+        assert_eq!(ContentProfile::PRODUCTION.chunk_size(), 1 << 20);
     }
 
     #[test]
     fn ci_chunk_size_keeps_multi_chunk_reachable() {
         assert!(
-            ContentProfile::CI.chunk_size <= 64,
+            ContentProfile::CI.chunk_size() <= 64,
             "CI chunk size must be small enough to exceed from a tiny fixture"
         );
     }
@@ -65,9 +83,15 @@ mod tests {
     fn every_profile_chunk_size_is_nonzero() {
         for profile in [ContentProfile::PRODUCTION, ContentProfile::CI] {
             assert!(
-                profile.chunk_size > 0,
+                profile.chunk_size() > 0,
                 "chunk size is always real, never zero"
             );
         }
+    }
+
+    #[test]
+    fn new_rejects_a_zero_chunk_size() {
+        assert_eq!(ContentProfile::new(0), None, "zero is unrepresentable");
+        assert_eq!(ContentProfile::new(4096).unwrap().chunk_size(), 4096);
     }
 }

--- a/crates/engine/src/content/profile.rs
+++ b/crates/engine/src/content/profile.rs
@@ -1,0 +1,73 @@
+//! The content profile — the open-edge chunk-framing constant
+//! (blueprint/engine.md "Content plane"; "Open edges": "Chunk size, DAG shape,
+//! retention defaults ... freeze alongside the KAT manifest").
+//!
+//! Chunk size is engine-owned per core.md's hand-off and, like the sync timing
+//! profile, is injected rather than hardcoded at a call site: framing reads the
+//! size from the profile handed in, so a future measured value lands as one
+//! profile-constant change.
+
+/// The content-plane framing profile (#630). Fixed-size chunking is the whole
+/// of the shape today; DAG fan-out/balancing stays flat (an open edge below).
+///
+/// There is deliberately **no `Default`** (mirrors [`crate::profile`]): every
+/// construction site names its profile, and [`chunk_size`] is always a real,
+/// nonzero value.
+///
+/// [`chunk_size`]: ContentProfile::chunk_size
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContentProfile {
+    /// Fixed content chunk size in bytes. Every leaf but the last carries
+    /// exactly this many plaintext bytes, so a byte offset maps to a leaf index
+    /// by integer division — the chunk-aligned property ranged block/CAR
+    /// fetches rely on (blueprint/engine.md "shaped so ranged ... fetches map
+    /// chunk-aligned").
+    pub chunk_size: usize,
+}
+
+impl ContentProfile {
+    /// Shipped framing: 1 MiB chunks.
+    ///
+    /// A placeholder pending the measurement process in blueprint/testing.md
+    /// ("The profile is where measured constants land"); it lands as a
+    /// profile-constant change with its measurement linked, and the DAG fan-out
+    /// open edge is settled alongside it.
+    pub const PRODUCTION: Self = Self {
+        chunk_size: 1 << 20,
+    };
+
+    /// CI framing: 16-byte chunks so multi-chunk framing and DAG assembly are
+    /// reachable from tiny fixtures (blueprint/testing.md "The DX hook").
+    pub const CI: Self = Self { chunk_size: 16 };
+}
+
+#[cfg(test)]
+// These tests assert on constants deliberately: the guard-rail that an edit to
+// a profile value cannot drift silently past the blueprint's intent.
+#[allow(clippy::assertions_on_constants)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_chunk_size_is_one_mib() {
+        assert_eq!(ContentProfile::PRODUCTION.chunk_size, 1 << 20);
+    }
+
+    #[test]
+    fn ci_chunk_size_keeps_multi_chunk_reachable() {
+        assert!(
+            ContentProfile::CI.chunk_size <= 64,
+            "CI chunk size must be small enough to exceed from a tiny fixture"
+        );
+    }
+
+    #[test]
+    fn every_profile_chunk_size_is_nonzero() {
+        for profile in [ContentProfile::PRODUCTION, ContentProfile::CI] {
+            assert!(
+                profile.chunk_size > 0,
+                "chunk size is always real, never zero"
+            );
+        }
+    }
+}

--- a/crates/engine/src/content/provider.rs
+++ b/crates/engine/src/content/provider.rs
@@ -1,0 +1,232 @@
+//! The pin-provider layer (blueprint/engine.md "Content plane": "hosted
+//! (default), external (own Kubo/PSA/Pinata endpoint), or dual — the engine
+//! decides where bytes go; every mode's publish flow still traverses
+//! registration. `ByoIpfsConfig` stays sealed in vault settings; provider
+//! connection testing is engine-side over the Http seam (the TEE tester is
+//! gone)").
+//!
+//! This module owns the placement decision surface and the BYO config type plus
+//! its engine-side reachability probe. Registration and the publish pipeline
+//! (register-first, every mode) live in the net plane; sealing the config into
+//! vault settings is the payload/vault-settings slice — the type here is the
+//! plaintext it seals.
+
+use core::fmt;
+
+use zeroize::Zeroizing;
+
+use crate::seams::{Http, HttpMethod, HttpRequest};
+
+const AUTHORIZATION: &str = "Authorization";
+
+/// Where a version's bytes are pinned (#34 D1). Every mode still registers with
+/// the API for union-liveness accounting; only the byte destination differs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinMode {
+    /// CipherBox's hosted pin store (the default). Quota is authoritative.
+    Hosted,
+    /// The member's own provider only. Quota is advisory.
+    External,
+    /// Both hosted and the member's own provider.
+    Dual,
+}
+
+/// The kind of member-supplied IPFS provider, which fixes the reachability
+/// probe (their APIs differ).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ByoKind {
+    /// A Kubo RPC endpoint (`/api/v0`).
+    Kubo,
+    /// An IPFS Pinning Service API endpoint (`/pins`).
+    Psa,
+    /// A Pinata endpoint.
+    Pinata,
+}
+
+/// A member's bring-your-own IPFS provider config. Stays sealed in vault
+/// settings (blueprint/engine.md); this is the plaintext the seal wraps. The
+/// access token is a credential: held in a zeroizing buffer and redacted from
+/// `Debug` (security rule 2).
+#[derive(Clone, PartialEq, Eq)]
+pub struct ByoIpfsConfig {
+    /// The provider API base URL.
+    pub endpoint: String,
+    /// The provider kind, selecting the reachability probe.
+    pub kind: ByoKind,
+    /// Bearer credential, when the provider requires one (PSA/Pinata always;
+    /// Kubo when fronted by an auth proxy). Zeroized on drop, never logged.
+    pub access_token: Option<Zeroizing<String>>,
+}
+
+impl fmt::Debug for ByoIpfsConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ByoIpfsConfig")
+            .field("endpoint", &self.endpoint)
+            .field("kind", &self.kind)
+            .field(
+                "access_token",
+                &self.access_token.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+/// Why a provider connection test did not succeed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderError {
+    /// The provider could not be reached (transport-level failure).
+    Unreachable,
+    /// The provider was reached but rejected the probe (bad endpoint, auth
+    /// failure, or an unhealthy node): a non-2xx status.
+    Rejected {
+        /// The status the provider returned.
+        status: u16,
+    },
+}
+
+/// Test that a member's BYO provider is reachable and authenticated, engine-side
+/// over the Http seam. Issues the provider's standard health/auth probe and
+/// treats any 2xx as success. A transport failure is [`ProviderError::Unreachable`];
+/// a non-2xx is [`ProviderError::Rejected`].
+pub async fn test_connection(
+    config: &ByoIpfsConfig,
+    http: &impl Http,
+) -> Result<(), ProviderError> {
+    let request = probe_request(config);
+    let response = http
+        .send(request)
+        .await
+        .map_err(|_| ProviderError::Unreachable)?;
+    if (200..300).contains(&response.status) {
+        Ok(())
+    } else {
+        Err(ProviderError::Rejected {
+            status: response.status,
+        })
+    }
+}
+
+/// The per-kind reachability probe. The endpoints are each provider's standard
+/// identity/auth check: Kubo `POST /api/v0/id`, PSA `GET /pins?limit=1`, Pinata
+/// `GET /data/testAuthentication`.
+fn probe_request(config: &ByoIpfsConfig) -> HttpRequest {
+    let base = config.endpoint.trim_end_matches('/');
+    let (method, path) = match config.kind {
+        ByoKind::Kubo => (HttpMethod::Post, "/api/v0/id"),
+        ByoKind::Psa => (HttpMethod::Get, "/pins?limit=1"),
+        ByoKind::Pinata => (HttpMethod::Get, "/data/testAuthentication"),
+    };
+    let mut headers = Vec::new();
+    if let Some(token) = &config.access_token {
+        headers.push((
+            AUTHORIZATION.to_owned(),
+            format!("Bearer {}", token.as_str()),
+        ));
+    }
+    HttpRequest {
+        method,
+        url: format!("{base}{path}"),
+        headers,
+        body: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::seams::HttpResponse;
+    use crate::testkit::block_on;
+    use crate::testkit::fakes::ScriptedHttp;
+
+    fn config(kind: ByoKind, token: Option<&str>) -> ByoIpfsConfig {
+        ByoIpfsConfig {
+            endpoint: "https://ipfs.member.test/".into(),
+            kind,
+            access_token: token.map(|t| Zeroizing::new(t.to_owned())),
+        }
+    }
+
+    fn ok() -> HttpResponse {
+        HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: b"{}".to_vec(),
+        }
+    }
+
+    #[test]
+    fn kubo_probe_posts_the_id_endpoint() {
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok());
+        block_on(test_connection(&config(ByoKind::Kubo, None), &http)).unwrap();
+        let request = &http.requests()[0];
+        assert_eq!(request.method, HttpMethod::Post);
+        assert_eq!(request.url, "https://ipfs.member.test/api/v0/id");
+    }
+
+    #[test]
+    fn psa_probe_gets_pins_with_the_bearer() {
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok());
+        block_on(test_connection(
+            &config(ByoKind::Psa, Some("psa-key")),
+            &http,
+        ))
+        .unwrap();
+        let request = &http.requests()[0];
+        assert_eq!(request.method, HttpMethod::Get);
+        assert_eq!(request.url, "https://ipfs.member.test/pins?limit=1");
+        assert!(
+            request
+                .headers
+                .iter()
+                .any(|(n, v)| n == AUTHORIZATION && v == "Bearer psa-key")
+        );
+    }
+
+    #[test]
+    fn pinata_probe_hits_test_authentication() {
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok());
+        block_on(test_connection(
+            &config(ByoKind::Pinata, Some("pin")),
+            &http,
+        ))
+        .unwrap();
+        assert_eq!(
+            http.requests()[0].url,
+            "https://ipfs.member.test/data/testAuthentication"
+        );
+    }
+
+    #[test]
+    fn non_2xx_is_rejected_with_the_status() {
+        let http = ScriptedHttp::default();
+        http.enqueue_response(HttpResponse {
+            status: 401,
+            headers: Vec::new(),
+            body: Vec::new(),
+        });
+        let err = block_on(test_connection(&config(ByoKind::Psa, Some("bad")), &http)).unwrap_err();
+        assert_eq!(err, ProviderError::Rejected { status: 401 });
+    }
+
+    #[test]
+    fn transport_failure_is_unreachable() {
+        let http = ScriptedHttp::default();
+        http.enqueue_error(crate::seams::SeamError::new("dns failure"));
+        let err = block_on(test_connection(&config(ByoKind::Kubo, None), &http)).unwrap_err();
+        assert_eq!(err, ProviderError::Unreachable);
+    }
+
+    #[test]
+    fn debug_redacts_the_access_token() {
+        let cfg = config(ByoKind::Pinata, Some("super-secret-jwt"));
+        let debug = format!("{cfg:?}");
+        assert!(
+            !debug.contains("super-secret-jwt"),
+            "token must never render"
+        );
+        assert!(debug.contains("<redacted>"));
+    }
+}

--- a/crates/engine/src/content/provider.rs
+++ b/crates/engine/src/content/provider.rs
@@ -74,6 +74,11 @@ impl fmt::Debug for ByoIpfsConfig {
 /// Why a provider connection test did not succeed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProviderError {
+    /// The endpoint is not an absolute `http(s)` URL with a host, so it is
+    /// rejected before any request is issued — a member-supplied string must not
+    /// reach the Http seam as a `file:`/relative/hostless target (SSRF and
+    /// scheme-exfiltration surface).
+    InvalidEndpoint,
     /// The provider could not be reached (transport-level failure).
     Unreachable,
     /// The provider was reached but rejected the probe (bad endpoint, auth
@@ -86,12 +91,18 @@ pub enum ProviderError {
 
 /// Test that a member's BYO provider is reachable and authenticated, engine-side
 /// over the Http seam. Issues the provider's standard health/auth probe and
-/// treats any 2xx as success. A transport failure is [`ProviderError::Unreachable`];
-/// a non-2xx is [`ProviderError::Rejected`].
+/// treats any 2xx as success.
+///
+/// The endpoint is member-controlled by design (it is the member's own
+/// provider), but it is still validated to an absolute `http(s)` URL before it
+/// reaches the seam — a `file:`, relative, or hostless target is
+/// [`ProviderError::InvalidEndpoint`], never sent. A transport failure is
+/// [`ProviderError::Unreachable`]; a non-2xx is [`ProviderError::Rejected`].
 pub async fn test_connection(
     config: &ByoIpfsConfig,
     http: &impl Http,
 ) -> Result<(), ProviderError> {
+    validate_endpoint(&config.endpoint)?;
     let request = probe_request(config);
     let response = http
         .send(request)
@@ -103,6 +114,23 @@ pub async fn test_connection(
         Err(ProviderError::Rejected {
             status: response.status,
         })
+    }
+}
+
+/// Require an absolute `http(s)` URL with a non-empty host before the endpoint
+/// reaches the Http seam. A lightweight scheme+authority check (the engine has
+/// no URL parser): it rejects other schemes (`file:`, `ftp:`, …), scheme-less or
+/// relative strings, and a hostless `http:///path`, closing the
+/// scheme-exfiltration / SSRF surface a raw member string would open.
+pub fn validate_endpoint(endpoint: &str) -> Result<(), ProviderError> {
+    let lower = endpoint.to_ascii_lowercase();
+    let authority = lower
+        .strip_prefix("https://")
+        .or_else(|| lower.strip_prefix("http://"));
+    match authority {
+        // A host must follow the scheme (not empty, not straight into a path).
+        Some(rest) if !rest.is_empty() && !rest.starts_with('/') => Ok(()),
+        _ => Err(ProviderError::InvalidEndpoint),
     }
 }
 
@@ -217,6 +245,47 @@ mod tests {
         http.enqueue_error(crate::seams::SeamError::new("dns failure"));
         let err = block_on(test_connection(&config(ByoKind::Kubo, None), &http)).unwrap_err();
         assert_eq!(err, ProviderError::Unreachable);
+    }
+
+    #[test]
+    fn a_non_http_or_hostless_endpoint_is_rejected_before_any_request() {
+        let http = ScriptedHttp::default();
+        for bad in [
+            "file:///etc/passwd",
+            "ftp://host/x",
+            "ipfs.member.test", // no scheme
+            "http://",          // no host
+            "https:///pins",    // hostless
+            "",
+        ] {
+            let cfg = ByoIpfsConfig {
+                endpoint: bad.into(),
+                kind: ByoKind::Psa,
+                access_token: None,
+            };
+            assert_eq!(
+                block_on(test_connection(&cfg, &http)).unwrap_err(),
+                ProviderError::InvalidEndpoint,
+                "{bad:?} must be rejected"
+            );
+        }
+        assert!(
+            http.requests().is_empty(),
+            "an invalid endpoint never reaches the seam"
+        );
+    }
+
+    #[test]
+    fn a_local_http_kubo_endpoint_is_allowed() {
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok());
+        let cfg = ByoIpfsConfig {
+            endpoint: "http://127.0.0.1:5001".into(),
+            kind: ByoKind::Kubo,
+            access_token: None,
+        };
+        block_on(test_connection(&cfg, &http)).unwrap();
+        assert_eq!(http.requests()[0].url, "http://127.0.0.1:5001/api/v0/id");
     }
 
     #[test]

--- a/crates/engine/src/content/read.rs
+++ b/crates/engine/src/content/read.rs
@@ -215,10 +215,13 @@ pub fn leaf_range_for_byte_range(
     let leaf_count = leaf_count as u64;
     let first = (offset / chunk_size).min(leaf_count);
     // The last byte touched is offset+length-1; a zero length touches nothing.
+    // Every step is saturating so an extreme range can never overflow the +1.
     let last_exclusive = if length == 0 {
         first
     } else {
-        (offset.saturating_add(length).saturating_sub(1) / chunk_size + 1).min(leaf_count)
+        (offset.saturating_add(length).saturating_sub(1) / chunk_size)
+            .saturating_add(1)
+            .min(leaf_count)
     };
     (first as usize)..(last_exclusive as usize)
 }
@@ -513,6 +516,16 @@ mod tests {
     #[test]
     fn zero_chunk_size_yields_an_empty_range_not_a_panic() {
         assert_eq!(leaf_range_for_byte_range(0, 10, 0, 3), 0..0);
+    }
+
+    #[test]
+    fn extreme_range_saturates_without_overflow() {
+        // Debug builds enable overflow checks; the +1 must not panic at u64::MAX.
+        assert_eq!(
+            leaf_range_for_byte_range(u64::MAX, u64::MAX, 1, 3),
+            3..3,
+            "clamped to leaf count, no overflow"
+        );
     }
 
     #[test]

--- a/crates/engine/src/content/read.rs
+++ b/crates/engine/src/content/read.rs
@@ -103,12 +103,20 @@ pub enum ReadError {
 }
 
 /// Fetch and verify one block addressed by `cid_str` against its binary
-/// `expected_cid`. `cid_str` is the gateway address (multibase string as it
-/// appears in metadata/links); `expected_cid` is the binary CIDv1 that is the
-/// trust anchor — verification binds to it, so a mismatched address at worst
-/// fails closed. `plane` pins the codec the CID must carry (raw leaf vs dag-cbor
-/// root), rejecting an out-of-set or wrong-plane codec fail-closed before any
-/// fetch — core's [`verify_cid`] alone would accept any single-byte codec.
+/// `expected_cid`. `cid_str` is the gateway address (the canonical CIDv1
+/// base32 string as it appears in metadata/links); `expected_cid` is the binary
+/// CIDv1 that is the trust anchor — verification binds to it, so a mismatched
+/// address at worst fails closed. `plane` pins the codec the CID must carry (raw
+/// leaf vs dag-cbor root), rejecting an out-of-set or wrong-plane codec
+/// fail-closed before any fetch — core's [`verify_cid`] alone would accept any
+/// single-byte codec.
+///
+/// `cid_str` is a distinct parameter because the engine has no CID-multibase
+/// codec (base encoders live in core; content CIDs have none yet), so the caller
+/// supplies the address form. It is validated to be a canonical content-CID
+/// string before it reaches the URL, so a non-CID or a path/query-bearing string
+/// (`../`, `?`, `#`) cannot be injected; misuse still fails closed on the binary
+/// anchor either way.
 ///
 /// Tries each source in [`Gateway`] order; returns the first block that
 /// verifies. A CID mismatch on any response is terminal
@@ -122,10 +130,12 @@ pub async fn read_block(
     expected_cid: &[u8],
     plane: ContentPlane,
 ) -> Result<Vec<u8>, ReadError> {
-    // Pin the plane codec before touching the network: a CID whose codec is out
-    // of the frozen set, or valid but for the wrong plane, is a fail-closed
-    // trust violation, not something to fetch and hope core rejects.
-    if expected_cid.len() != CONTENT_CID_LEN || expected_cid[CID_CODEC_INDEX] != plane.codec() {
+    // Reject a non-anchor request before touching the network, fail-closed: an
+    // expected CID whose codec is out of the frozen set or is valid but for the
+    // wrong plane, or an address that is not a canonical content-CID string.
+    let codec_ok =
+        expected_cid.len() == CONTENT_CID_LEN && expected_cid[CID_CODEC_INDEX] == plane.codec();
+    if !codec_ok || !is_canonical_content_cid_str(cid_str) {
         return Err(ReadError::TrustViolation(
             TrustViolation::ContentCidMismatch.into(),
         ));
@@ -144,6 +154,22 @@ pub async fn read_block(
             .map_err(ReadError::TrustViolation);
     }
     Err(ReadError::Unavailable)
+}
+
+/// Whether `cid_str` is the canonical CIDv1 base32 string of a content CID: the
+/// multibase base32-lower prefix `b` over the fixed [`CONTENT_CID_LEN`] bytes.
+/// A pure format check (base encoders live in core), tied to the CID length so
+/// only a real content-CID shape reaches the gateway URL — the base32 alphabet
+/// excludes `/`, `?`, `#`, and `.`, so no path/query fragment can slip through.
+fn is_canonical_content_cid_str(cid_str: &str) -> bool {
+    // Unpadded base32 length of CONTENT_CID_LEN bytes, plus the 'b' multibase tag.
+    const CID_STR_LEN: usize = 1 + (CONTENT_CID_LEN * 8).div_ceil(5);
+    cid_str.len() == CID_STR_LEN
+        && cid_str.as_bytes()[0] == b'b'
+        && cid_str
+            .bytes()
+            .skip(1)
+            .all(|c| c.is_ascii_lowercase() || (b'2'..=b'7').contains(&c))
 }
 
 /// Send the raw-block GET to one source; `None` on a transport-level failure
@@ -229,6 +255,13 @@ mod tests {
         .remove(0)
     }
 
+    /// A syntactically canonical CIDv1 base32 address (`b` + 58 base32 chars).
+    /// The trust anchor is the binary `expected_cid`, so a valid address need
+    /// only be well-formed here, not the encoding of that specific CID.
+    fn cid_str() -> String {
+        format!("b{}", "a".repeat(58))
+    }
+
     fn accelerator_only() -> Gateway {
         Gateway {
             accelerator: Some(GatewaySource {
@@ -251,7 +284,7 @@ mod tests {
         let out = block_on(read_block(
             &accelerator_only(),
             &http,
-            "bafyleaf",
+            &cid_str(),
             &leaf.cid,
             ContentPlane::Leaf,
         ))
@@ -261,7 +294,7 @@ mod tests {
         let request = &http.requests()[0];
         assert_eq!(
             request.url,
-            "https://gw.cipherbox.test/ipfs/bafyleaf?format=raw"
+            format!("https://gw.cipherbox.test/ipfs/{}?format=raw", cid_str())
         );
         assert!(
             request
@@ -283,7 +316,7 @@ mod tests {
         let err = block_on(read_block(
             &accelerator_only(),
             &http,
-            "bafyleaf",
+            &cid_str(),
             &leaf.cid,
             ContentPlane::Leaf,
         ))
@@ -315,7 +348,7 @@ mod tests {
         let out = block_on(read_block(
             &accelerator_only(),
             &http,
-            "bafyleaf",
+            &cid_str(),
             &leaf.cid,
             ContentPlane::Leaf,
         ))
@@ -355,7 +388,7 @@ mod tests {
         let err = block_on(read_block(
             &accelerator_only(),
             &http,
-            "bafyleaf",
+            &cid_str(),
             &leaf.cid,
             ContentPlane::Leaf,
         ))
@@ -372,7 +405,7 @@ mod tests {
         let out = block_on(read_block(
             &accelerator_only(),
             &http,
-            "bafyleaf",
+            &cid_str(),
             &leaf.cid,
             ContentPlane::Leaf,
         ))
@@ -393,7 +426,7 @@ mod tests {
         let err = block_on(read_block(
             &accelerator_only(),
             &http,
-            "bafyleaf",
+            &cid_str(),
             &rogue_cid,
             ContentPlane::Leaf,
         ))
@@ -417,7 +450,7 @@ mod tests {
         let err = block_on(read_block(
             &accelerator_only(),
             &http,
-            "bafyleaf",
+            &cid_str(),
             &leaf.cid,
             ContentPlane::Root,
         ))
@@ -426,6 +459,40 @@ mod tests {
         assert!(
             http.requests().is_empty(),
             "wrong-plane codec rejected pre-fetch"
+        );
+    }
+
+    #[test]
+    fn a_non_canonical_address_is_rejected_before_any_fetch() {
+        // A path-traversal / query-bearing address must never reach the URL,
+        // even though the binary anchor (`expected_cid`) is valid.
+        let leaf = one_leaf();
+        let http = ScriptedHttp::default();
+        // Correct length and 'b' tag, but a non-base32 tail char.
+        let wrong_charset = format!("b{}", "!".repeat(58));
+        for bad in [
+            "../../etc/passwd",
+            "bafyleaf?foo=bar",
+            "bafyleaf#frag",
+            "BAFYUPPERCASE",
+            wrong_charset.as_str(),
+        ] {
+            let err = block_on(read_block(
+                &accelerator_only(),
+                &http,
+                bad,
+                &leaf.cid,
+                ContentPlane::Leaf,
+            ))
+            .unwrap_err();
+            assert!(
+                matches!(err, ReadError::TrustViolation(_)),
+                "address {bad:?} must be rejected fail-closed"
+            );
+        }
+        assert!(
+            http.requests().is_empty(),
+            "a non-canonical address never reaches the network"
         );
     }
 

--- a/crates/engine/src/content/read.rs
+++ b/crates/engine/src/content/read.rs
@@ -1,0 +1,482 @@
+//! Verified content reads over the trustless gateway (blueprint/engine.md
+//! "Content plane": "the token-authed trustless gateway is a member
+//! accelerator; any public trustless gateway is the no-auth fallback. The
+//! engine verifies CIDs client-side via core on every block/CAR response").
+//!
+//! The authenticity anchor is the block's `contentCid`: every fetched block is
+//! run through [`cipherbox_core::content::verify_cid`] against the requested
+//! CID, and a mismatch fails **closed** as a [`TrustViolation`] — never a silent
+//! degrade to staleness (AGENTS.md rule 6). Only availability (transport error,
+//! non-2xx) rotates to the next source; a mismatch is terminal, because a
+//! content-address disagreement is an integrity signal to surface, not a
+//! retryable fetch miss.
+
+use core::fmt;
+use core::ops::Range;
+
+use cipherbox_core::content::{CONTENT_CID_CODEC, CONTENT_CID_LEN, verify_cid};
+use cipherbox_core::error::{CodecError, TrustViolation};
+use zeroize::Zeroizing;
+
+use super::dag::DAG_ROOT_CODEC;
+use crate::seams::{Http, HttpMethod, HttpRequest};
+
+const AUTHORIZATION: &str = "Authorization";
+const ACCEPT: &str = "Accept";
+/// The trustless-gateway raw-block content type (IPIP-0402).
+const RAW_BLOCK: &str = "application/vnd.ipld.raw";
+/// Byte offset of the multicodec in the fixed CIDv1 framing (version at 0).
+const CID_CODEC_INDEX: usize = 1;
+
+/// Which content-plane a fetched CID must address. Core's [`verify_cid`] accepts
+/// any single-byte multicodec (`< 0x80`), not just the frozen content-plane set,
+/// so the engine pins the expected codec here and fails closed on a valid-but-
+/// wrong-plane (or out-of-set) codec — a raw leaf and a dag-cbor root are not
+/// interchangeable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentPlane {
+    /// A sealed leaf block, addressed with the `raw` codec (0x55).
+    Leaf,
+    /// The DAG root block, addressed with the `dag-cbor` codec (0x71).
+    Root,
+}
+
+impl ContentPlane {
+    /// The multicodec byte a CID in this plane must carry.
+    fn codec(self) -> u8 {
+        match self {
+            Self::Leaf => CONTENT_CID_CODEC,
+            Self::Root => DAG_ROOT_CODEC,
+        }
+    }
+}
+
+/// One trustless-gateway endpoint. The member accelerator carries a bearer
+/// token; a public fallback carries none. The token is a credential: held in a
+/// zeroizing buffer and redacted from `Debug` (security rule 2).
+#[derive(Clone, PartialEq, Eq)]
+pub struct GatewaySource {
+    /// Gateway base URL (no trailing slash needed; one is tolerated).
+    pub base_url: String,
+    /// Bearer token for the token-authed accelerator; `None` for a public
+    /// gateway. Zeroized on drop, never logged.
+    pub bearer: Option<Zeroizing<String>>,
+}
+
+impl fmt::Debug for GatewaySource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GatewaySource")
+            .field("base_url", &self.base_url)
+            .field("bearer", &self.bearer.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
+}
+
+/// The ordered read source set: the token-authed accelerator is tried first as
+/// a member convenience, then the public no-auth fallbacks in order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Gateway {
+    /// The member accelerator (token-authed), consulted first when present.
+    pub accelerator: Option<GatewaySource>,
+    /// Public trustless-gateway fallbacks, tried in order after the accelerator.
+    pub public_fallbacks: Vec<GatewaySource>,
+}
+
+impl Gateway {
+    /// Accelerator (if any) first, then public fallbacks — read consult order.
+    fn sources(&self) -> impl Iterator<Item = &GatewaySource> {
+        self.accelerator.iter().chain(self.public_fallbacks.iter())
+    }
+}
+
+/// Why a verified read did not return bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReadError {
+    /// A fetched block did not content-address to the requested CID: fail-closed
+    /// integrity violation, surfaced verbatim from core. Terminal — never
+    /// retried against another source, never degraded to staleness.
+    TrustViolation(CodecError),
+    /// No source served the block: every gateway failed at the transport or
+    /// status level (unreachable, aborted, or non-2xx). Availability, not
+    /// integrity — the caller may retry later.
+    Unavailable,
+}
+
+/// Fetch and verify one block addressed by `cid_str` against its binary
+/// `expected_cid`. `cid_str` is the gateway address (multibase string as it
+/// appears in metadata/links); `expected_cid` is the binary CIDv1 that is the
+/// trust anchor — verification binds to it, so a mismatched address at worst
+/// fails closed. `plane` pins the codec the CID must carry (raw leaf vs dag-cbor
+/// root), rejecting an out-of-set or wrong-plane codec fail-closed before any
+/// fetch — core's [`verify_cid`] alone would accept any single-byte codec.
+///
+/// Tries each source in [`Gateway`] order; returns the first block that
+/// verifies. A CID mismatch on any response is terminal
+/// ([`ReadError::TrustViolation`]); only availability failures rotate to the
+/// next source. All sources exhausted without a verified block is
+/// [`ReadError::Unavailable`].
+pub async fn read_block(
+    gateway: &Gateway,
+    http: &impl Http,
+    cid_str: &str,
+    expected_cid: &[u8],
+    plane: ContentPlane,
+) -> Result<Vec<u8>, ReadError> {
+    // Pin the plane codec before touching the network: a CID whose codec is out
+    // of the frozen set, or valid but for the wrong plane, is a fail-closed
+    // trust violation, not something to fetch and hope core rejects.
+    if expected_cid.len() != CONTENT_CID_LEN || expected_cid[CID_CODEC_INDEX] != plane.codec() {
+        return Err(ReadError::TrustViolation(
+            TrustViolation::ContentCidMismatch.into(),
+        ));
+    }
+    for source in gateway.sources() {
+        let Some(response) = fetch(source, http, cid_str).await else {
+            continue; // transport-level failure: try the next source
+        };
+        if !(200..300).contains(&response.status) {
+            continue; // availability (not found / server error): next source
+        }
+        // Every 2xx body is verified before it can be returned. A mismatch is a
+        // fail-closed trust violation, not a reason to try another source.
+        return verify_cid(expected_cid, &response.body)
+            .map(|()| response.body)
+            .map_err(ReadError::TrustViolation);
+    }
+    Err(ReadError::Unavailable)
+}
+
+/// Send the raw-block GET to one source; `None` on a transport-level failure
+/// (the seam's reserved `Err`), which is an availability signal, not a trust one.
+async fn fetch(
+    source: &GatewaySource,
+    http: &impl Http,
+    cid_str: &str,
+) -> Option<crate::seams::HttpResponse> {
+    let base = source.base_url.trim_end_matches('/');
+    let mut headers = vec![(ACCEPT.to_owned(), RAW_BLOCK.to_owned())];
+    if let Some(bearer) = &source.bearer {
+        headers.push((
+            AUTHORIZATION.to_owned(),
+            format!("Bearer {}", bearer.as_str()),
+        ));
+    }
+    let request = HttpRequest {
+        method: HttpMethod::Get,
+        url: format!("{base}/ipfs/{cid_str}?format=raw"),
+        headers,
+        body: None,
+    };
+    http.send(request).await.ok()
+}
+
+/// The leaf-index range covering the plaintext byte range `[offset, offset +
+/// length)` for a flat DAG framed at `chunk_size` (blueprint/engine.md: "shaped
+/// so ranged block/CAR fetches map chunk-aligned"). The flat shape makes this a
+/// pure division: the first leaf is `offset / chunk_size`. Clamped to
+/// `leaf_count`; an offset at or past the end yields an empty range.
+pub fn leaf_range_for_byte_range(
+    offset: u64,
+    length: u64,
+    chunk_size: u64,
+    leaf_count: usize,
+) -> Range<usize> {
+    // A zero chunk size is a nonsensical (never-produced) manifest value; guard
+    // the division fail-safe rather than panic on it in any build.
+    if chunk_size == 0 {
+        return 0..0;
+    }
+    let leaf_count = leaf_count as u64;
+    let first = (offset / chunk_size).min(leaf_count);
+    // The last byte touched is offset+length-1; a zero length touches nothing.
+    let last_exclusive = if length == 0 {
+        first
+    } else {
+        (offset.saturating_add(length).saturating_sub(1) / chunk_size + 1).min(leaf_count)
+    };
+    (first as usize)..(last_exclusive as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::content::chunk::{ContentKey, frame_and_seal};
+    use crate::content::profile::ContentProfile;
+    use crate::seams::HttpResponse;
+    use crate::testkit::SeededEntropy;
+    use crate::testkit::block_on;
+    use crate::testkit::fakes::ScriptedHttp;
+    use cipherbox_core::content::compute_cid;
+    use cipherbox_core::suite::aead::KEY_LEN;
+
+    fn raw_response(body: Vec<u8>) -> HttpResponse {
+        HttpResponse {
+            status: 200,
+            headers: vec![("Content-Type".into(), RAW_BLOCK.into())],
+            body,
+        }
+    }
+
+    fn one_leaf() -> super::super::chunk::SealedChunk {
+        let key = ContentKey::from_bytes([4u8; KEY_LEN]);
+        frame_and_seal(
+            b"a sealed block",
+            &key,
+            &mut SeededEntropy::new(1),
+            &ContentProfile::CI,
+        )
+        .unwrap()
+        .remove(0)
+    }
+
+    fn accelerator_only() -> Gateway {
+        Gateway {
+            accelerator: Some(GatewaySource {
+                base_url: "https://gw.cipherbox.test/".into(),
+                bearer: Some(Zeroizing::new("member-token".to_owned())),
+            }),
+            public_fallbacks: vec![GatewaySource {
+                base_url: "https://public.gw.test".into(),
+                bearer: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn verified_block_is_returned_and_addressed_via_the_accelerator() {
+        let leaf = one_leaf();
+        let http = ScriptedHttp::default();
+        http.enqueue_response(raw_response(leaf.sealed.clone()));
+
+        let out = block_on(read_block(
+            &accelerator_only(),
+            &http,
+            "bafyleaf",
+            &leaf.cid,
+            ContentPlane::Leaf,
+        ))
+        .unwrap();
+        assert_eq!(out, leaf.sealed);
+
+        let request = &http.requests()[0];
+        assert_eq!(
+            request.url,
+            "https://gw.cipherbox.test/ipfs/bafyleaf?format=raw"
+        );
+        assert!(
+            request
+                .headers
+                .iter()
+                .any(|(n, v)| n == AUTHORIZATION && v == "Bearer member-token"),
+            "accelerator request carries the member bearer token"
+        );
+    }
+
+    #[test]
+    fn tampered_bytes_fail_closed_as_a_trust_violation() {
+        let leaf = one_leaf();
+        let mut tampered = leaf.sealed.clone();
+        *tampered.last_mut().unwrap() ^= 0x01;
+        let http = ScriptedHttp::default();
+        http.enqueue_response(raw_response(tampered));
+
+        let err = block_on(read_block(
+            &accelerator_only(),
+            &http,
+            "bafyleaf",
+            &leaf.cid,
+            ContentPlane::Leaf,
+        ))
+        .unwrap_err();
+        match err {
+            ReadError::TrustViolation(e) => assert_eq!(e.check(), "content-cid-mismatch"),
+            other => panic!("expected a trust violation, got {other:?}"),
+        }
+        // Terminal: the mismatch is not retried against the public fallback.
+        assert_eq!(
+            http.requests().len(),
+            1,
+            "a mismatch does not rotate sources"
+        );
+    }
+
+    #[test]
+    fn availability_failure_rotates_to_the_public_fallback() {
+        let leaf = one_leaf();
+        let http = ScriptedHttp::default();
+        // Accelerator 503, then the public fallback serves the real block.
+        http.enqueue_response(HttpResponse {
+            status: 503,
+            headers: Vec::new(),
+            body: Vec::new(),
+        });
+        http.enqueue_response(raw_response(leaf.sealed.clone()));
+
+        let out = block_on(read_block(
+            &accelerator_only(),
+            &http,
+            "bafyleaf",
+            &leaf.cid,
+            ContentPlane::Leaf,
+        ))
+        .unwrap();
+        assert_eq!(out, leaf.sealed);
+
+        let urls: Vec<_> = http.requests().iter().map(|r| r.url.clone()).collect();
+        assert_eq!(urls.len(), 2);
+        assert!(
+            urls[1].starts_with("https://public.gw.test/ipfs/"),
+            "fell back to public gateway"
+        );
+        assert!(
+            !http.requests()[1]
+                .headers
+                .iter()
+                .any(|(n, _)| n == AUTHORIZATION),
+            "public fallback carries no bearer token"
+        );
+    }
+
+    #[test]
+    fn all_sources_unavailable_is_unavailable_not_a_violation() {
+        let leaf = one_leaf();
+        let http = ScriptedHttp::default();
+        http.enqueue_response(HttpResponse {
+            status: 502,
+            headers: Vec::new(),
+            body: Vec::new(),
+        });
+        http.enqueue_response(HttpResponse {
+            status: 504,
+            headers: Vec::new(),
+            body: Vec::new(),
+        });
+
+        let err = block_on(read_block(
+            &accelerator_only(),
+            &http,
+            "bafyleaf",
+            &leaf.cid,
+            ContentPlane::Leaf,
+        ))
+        .unwrap_err();
+        assert_eq!(err, ReadError::Unavailable);
+    }
+
+    #[test]
+    fn transport_error_is_an_availability_failure() {
+        let leaf = one_leaf();
+        let http = ScriptedHttp::default();
+        http.enqueue_error(crate::seams::SeamError::new("connection refused"));
+        http.enqueue_response(raw_response(leaf.sealed.clone()));
+        let out = block_on(read_block(
+            &accelerator_only(),
+            &http,
+            "bafyleaf",
+            &leaf.cid,
+            ContentPlane::Leaf,
+        ))
+        .unwrap();
+        assert_eq!(out, leaf.sealed);
+    }
+
+    #[test]
+    fn out_of_set_codec_is_rejected_before_any_fetch() {
+        // A CID whose codec is a single byte < 0x80 but outside the frozen set
+        // (0x60) would pass core's verify_cid over the very block it addresses,
+        // yet the engine must reject it: it is not a raw leaf.
+        let leaf = one_leaf();
+        let rogue_cid = compute_cid(0x60, &leaf.sealed);
+        let http = ScriptedHttp::default();
+        http.enqueue_response(raw_response(leaf.sealed.clone()));
+
+        let err = block_on(read_block(
+            &accelerator_only(),
+            &http,
+            "bafyleaf",
+            &rogue_cid,
+            ContentPlane::Leaf,
+        ))
+        .unwrap_err();
+        match err {
+            ReadError::TrustViolation(e) => assert_eq!(e.check(), "content-cid-mismatch"),
+            other => panic!("expected a trust violation, got {other:?}"),
+        }
+        assert!(
+            http.requests().is_empty(),
+            "an out-of-set codec is rejected before any fetch"
+        );
+    }
+
+    #[test]
+    fn a_valid_leaf_cid_requested_as_a_root_is_rejected() {
+        // The leaf's own valid raw (0x55) CID, requested on the root plane
+        // (dag-cbor 0x71), must fail closed — planes are not interchangeable.
+        let leaf = one_leaf();
+        let http = ScriptedHttp::default();
+        let err = block_on(read_block(
+            &accelerator_only(),
+            &http,
+            "bafyleaf",
+            &leaf.cid,
+            ContentPlane::Root,
+        ))
+        .unwrap_err();
+        assert!(matches!(err, ReadError::TrustViolation(_)));
+        assert!(
+            http.requests().is_empty(),
+            "wrong-plane codec rejected pre-fetch"
+        );
+    }
+
+    #[test]
+    fn gateway_source_debug_redacts_the_bearer_token() {
+        let source = GatewaySource {
+            base_url: "https://gw.test".into(),
+            bearer: Some(Zeroizing::new("super-secret-token".to_owned())),
+        };
+        let debug = format!("{source:?}");
+        assert!(
+            !debug.contains("super-secret-token"),
+            "bearer must never render"
+        );
+        assert!(debug.contains("<redacted>"));
+    }
+
+    #[test]
+    fn zero_chunk_size_yields_an_empty_range_not_a_panic() {
+        assert_eq!(leaf_range_for_byte_range(0, 10, 0, 3), 0..0);
+    }
+
+    #[test]
+    fn byte_range_maps_chunk_aligned_to_leaf_indices() {
+        // 16-byte chunks, 3 leaves (48 bytes of capacity).
+        assert_eq!(leaf_range_for_byte_range(0, 16, 16, 3), 0..1);
+        assert_eq!(
+            leaf_range_for_byte_range(0, 17, 16, 3),
+            0..2,
+            "spills into leaf 1"
+        );
+        assert_eq!(leaf_range_for_byte_range(16, 16, 16, 3), 1..2);
+        assert_eq!(
+            leaf_range_for_byte_range(15, 2, 16, 3),
+            0..2,
+            "straddles the boundary"
+        );
+        assert_eq!(
+            leaf_range_for_byte_range(40, 100, 16, 3),
+            2..3,
+            "clamped to leaf count"
+        );
+        assert_eq!(
+            leaf_range_for_byte_range(100, 10, 16, 3),
+            3..3,
+            "past end is empty"
+        );
+        assert_eq!(
+            leaf_range_for_byte_range(5, 0, 16, 3),
+            0..0,
+            "zero length touches nothing"
+        );
+    }
+}

--- a/crates/engine/src/content/retention.rs
+++ b/crates/engine/src/content/retention.rs
@@ -71,7 +71,10 @@ pub struct PrunePlan {
 /// nothing (an empty plan).
 pub fn plan_prune(versions_newest_first: &[ContentVersion], keep_latest: usize) -> PrunePlan {
     let doomed = versions_newest_first.iter().skip(keep_latest);
-    let mut plan = PrunePlan::default();
+    let mut plan = PrunePlan {
+        retire_targets: Vec::with_capacity(doomed.len()),
+        ..PrunePlan::default()
+    };
     // Emit oldest-first so retirement proceeds from the tail of history.
     for version in doomed.rev() {
         plan.retire_targets.push(version.content_cid.clone());

--- a/crates/engine/src/content/retention.rs
+++ b/crates/engine/src/content/retention.rs
@@ -1,0 +1,161 @@
+//! Quota pre-flight and version retention (blueprint/engine.md "Content plane":
+//! "Retention default: keep all versions within quota, with an explicit
+//! user-initiated prune op"; "a pre-flight quota-query check to fail fast before
+//! bytes move is judgment").
+//!
+//! Retention is keep-all by default — nothing here evicts a version
+//! automatically; the network is authoritative on quota (enforced at the API
+//! upload endpoint) and [`pre_flight_quota_check`] only fails *fast*, before
+//! bytes move. Reclaiming space is the explicit user op [`plan_prune`], which is
+//! pure: it selects retire targets, and the net plane runs the retire.
+
+use crate::api::Quota;
+
+/// A pre-flight quota rejection: the hosted account cannot admit `needed_bytes`.
+/// Advisory (BYO) accounts never produce this — their bytes live on the member's
+/// own provider and are counted, never gated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuotaExceeded {
+    /// Bytes already counted against the account.
+    pub used_bytes: u64,
+    /// The account's limit.
+    pub limit_bytes: u64,
+    /// The bytes this upload would add.
+    pub needed_bytes: u64,
+}
+
+/// Fail fast before bytes move if a hosted upload of `needed_bytes` would exceed
+/// the account limit. A BYO account's quota is advisory (`advisory: true`) and
+/// always admits — its rows are counted for accounting, never quota-enforced
+/// (CONTEXT.md "Advisory pin row"). The API upload endpoint remains the
+/// authoritative gate; this is the fail-fast pre-flight, not the enforcement.
+pub fn pre_flight_quota_check(needed_bytes: u64, quota: &Quota) -> Result<(), QuotaExceeded> {
+    if quota.advisory {
+        return Ok(());
+    }
+    // Saturating so a pathological used+needed can never wrap under the limit.
+    if quota.used_bytes.saturating_add(needed_bytes) > quota.limit_bytes {
+        return Err(QuotaExceeded {
+            used_bytes: quota.used_bytes,
+            limit_bytes: quota.limit_bytes,
+            needed_bytes,
+        });
+    }
+    Ok(())
+}
+
+/// One retained content version: its root `contentCid` (the retire target, as it
+/// rides [`crate::api::ApiClient::retire`]) and its pinned byte size.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentVersion {
+    /// The version's root content CID (multibase string), the retire target.
+    pub content_cid: String,
+    /// The version's pinned size in bytes (what a prune reclaims).
+    pub size_bytes: u64,
+}
+
+/// The result of the explicit prune op: the versions to retire and the bytes
+/// reclaiming them frees.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PrunePlan {
+    /// Content CIDs to retire, oldest first.
+    pub retire_targets: Vec<String>,
+    /// Bytes freed by retiring [`Self::retire_targets`].
+    pub reclaimed_bytes: u64,
+}
+
+/// Plan the explicit user-initiated prune: keep the newest `keep_latest`
+/// versions and retire the rest. `versions_newest_first` is the version history
+/// ordered newest to oldest. Pure and deterministic — the net plane runs the
+/// retire against the returned targets. Keeping at least as many as exist prunes
+/// nothing (an empty plan).
+pub fn plan_prune(versions_newest_first: &[ContentVersion], keep_latest: usize) -> PrunePlan {
+    let doomed = versions_newest_first.iter().skip(keep_latest);
+    let mut plan = PrunePlan::default();
+    // Emit oldest-first so retirement proceeds from the tail of history.
+    for version in doomed.rev() {
+        plan.retire_targets.push(version.content_cid.clone());
+        plan.reclaimed_bytes = plan.reclaimed_bytes.saturating_add(version.size_bytes);
+    }
+    plan
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hosted(used: u64, limit: u64) -> Quota {
+        Quota {
+            used_bytes: used,
+            limit_bytes: limit,
+            advisory: false,
+        }
+    }
+
+    #[test]
+    fn admits_an_upload_that_fits() {
+        assert!(pre_flight_quota_check(100, &hosted(400, 1000)).is_ok());
+    }
+
+    #[test]
+    fn rejects_an_upload_that_would_exceed_the_limit() {
+        let err = pre_flight_quota_check(700, &hosted(400, 1000)).unwrap_err();
+        assert_eq!(
+            err,
+            QuotaExceeded {
+                used_bytes: 400,
+                limit_bytes: 1000,
+                needed_bytes: 700
+            }
+        );
+    }
+
+    #[test]
+    fn exactly_filling_the_limit_is_admitted() {
+        assert!(pre_flight_quota_check(600, &hosted(400, 1000)).is_ok());
+    }
+
+    #[test]
+    fn advisory_byo_quota_always_admits() {
+        let byo = Quota {
+            used_bytes: u64::MAX - 1,
+            limit_bytes: 0,
+            advisory: true,
+        };
+        assert!(
+            pre_flight_quota_check(u64::MAX, &byo).is_ok(),
+            "BYO is never gated"
+        );
+    }
+
+    fn version(cid: &str, size: u64) -> ContentVersion {
+        ContentVersion {
+            content_cid: cid.into(),
+            size_bytes: size,
+        }
+    }
+
+    #[test]
+    fn prune_keeps_the_newest_and_retires_the_rest_oldest_first() {
+        // Newest -> oldest: v3, v2, v1.
+        let history = vec![version("v3", 30), version("v2", 20), version("v1", 10)];
+        let plan = plan_prune(&history, 1);
+        assert_eq!(
+            plan.retire_targets,
+            vec!["v1", "v2"],
+            "oldest first, newest kept"
+        );
+        assert_eq!(plan.reclaimed_bytes, 30);
+    }
+
+    #[test]
+    fn keeping_all_or_more_prunes_nothing() {
+        let history = vec![version("v2", 20), version("v1", 10)];
+        assert_eq!(plan_prune(&history, 2), PrunePlan::default());
+        assert_eq!(
+            plan_prune(&history, 5),
+            PrunePlan::default(),
+            "keep>len is a no-op"
+        );
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -41,10 +41,10 @@ pub use api::{
 };
 pub use content::{
     ByoIpfsConfig, ByoKind, ContentDag, ContentKey, ContentPlane, ContentProfile, ContentVersion,
-    DAG_ROOT_CODEC, Gateway, GatewaySource, PinMode, ProviderError, PrunePlan, QuotaExceeded,
-    ReadError, RootManifest, SealedChunk, SealedContent, assemble, decode_root, frame_and_seal,
-    leaf_range_for_byte_range, plan_prune, pre_flight_quota_check, read_block, seal_content,
-    test_connection,
+    DAG_ROOT_CODEC, DagError, Gateway, GatewaySource, PinMode, ProviderError, PrunePlan,
+    QuotaExceeded, ReadError, RootManifest, SealedChunk, SealedContent, assemble, decode_root,
+    frame_and_seal, leaf_range_for_byte_range, plan_prune, pre_flight_quota_check, read_block,
+    seal_content, test_connection, validate_endpoint,
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -25,6 +25,7 @@
 #![allow(async_fn_in_trait)]
 
 pub mod api;
+pub mod content;
 pub mod entropy;
 pub mod facade;
 pub mod gate;
@@ -37,6 +38,13 @@ pub mod testkit;
 pub use api::{
     ApiClient, ApiError, ChallengeSigner, IdentityChallengeSigner, LoginOutcome, MailboxItem,
     NameRegistration, Quota, SiweNonce, TestLoginOutcome, UploadResult,
+};
+pub use content::{
+    ByoIpfsConfig, ByoKind, ContentDag, ContentKey, ContentPlane, ContentProfile, ContentVersion,
+    DAG_ROOT_CODEC, Gateway, GatewaySource, PinMode, ProviderError, PrunePlan, QuotaExceeded,
+    ReadError, RootManifest, SealedChunk, SealedContent, assemble, decode_root, frame_and_seal,
+    leaf_range_for_byte_range, plan_prune, pre_flight_quota_check, read_block, seal_content,
+    test_connection,
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{


### PR DESCRIPTION
## What

Adds the engine **content plane** (`crates/engine/src/content/`), composing the already-merged core content primitives (#691: `content-seal`, content-DAG CID) into the engine-owned framing, DAG, placement, quota, and read surface.

- **`chunk`** — fixed-size chunk framing. `ContentKey` (fresh random per-version key, `ZeroizeOnDrop`, redacting `Debug`); `frame_and_seal` splits plaintext into `chunk_size` slices, draws a fresh nonce per chunk from the injected `Entropy` seam, calls core `seal_chunk`, and content-addresses each leaf with core `compute_cid(raw)`.
- **`dag`** — DAG assembly. `assemble` builds a flat root over the ordered leaf CIDs + chunk size + plaintext length, serialized with core's deterministic CBOR and addressed by `compute_cid(dag-cbor 0x71)` — the version's `contentCid`. `decode_root` reads the manifest back fail-closed. `DAG_ROOT_CODEC` is the engine-owned root codec.
- **`read`** — verified reads over the token-authed trustless gateway (member accelerator) with public-gateway fallback. `read_block` verifies **every** 2xx response through core `verify_cid` and returns only verified bytes. `leaf_range_for_byte_range` maps a byte range to leaf indices (chunk-aligned ranged fetches).
- **`provider`** — the pin-provider layer: `PinMode` (hosted/external/dual), `ByoIpfsConfig` (sealed-in-vault plaintext type, credential redacted + zeroized), and `test_connection` — engine-side reachability/auth probe per kind (Kubo/PSA/Pinata) over the Http seam.
- **`retention`** — `pre_flight_quota_check` (fail fast before bytes move; BYO advisory always admits) and `plan_prune` (explicit keep-latest prune op producing retire targets). Default retention is keep-all.
- **`profile`** — `ContentProfile` open-edge chunk-size constant (`PRODUCTION` 1 MiB / `CI` 16 B), no `Default`, mirroring `SyncTimingProfile`.

Out of scope per the issue and left for later slices: the web service-worker decryption layer, upload staging through the op queue, and the publish/registration wiring (net plane).

## Why

`blueprint/engine.md` "Content plane" hands the engine chunk framing, DAG shape, placement, quota pre-flight, and retention as engineering judgment on top of core's crypto. This lands that surface behind clean seams so the publish pipeline and the web/desktop hosts can consume it. Chunk size and DAG fan-out stay open-edge profile constants, to freeze with the KAT manifest.

### Fail-closed enforcement (the load-bearing invariant)

A block's authenticity anchor is its `contentCid` (BLAKE3 over the sealed bytes). `read_block` (`crates/engine/src/content/read.rs`) is the enforcement point:

- The **only** bytes-returning statement is `verify_cid(expected_cid, &response.body).map(...).map_err(ReadError::TrustViolation)` — every 2xx body is verified before it can be returned; there is no path that returns unverified bytes.
- A CID mismatch is **terminal**: it returns `ReadError::TrustViolation` and does **not** rotate to another source or degrade to staleness. Only transport errors / non-2xx (availability) rotate accelerator to public fallback.
- Because core's `verify_cid` accepts any single-byte multicodec (`< 0x80`), the engine additionally **pins the plane codec** (raw leaf `0x55` vs dag-cbor root `0x71`) up front and fails closed on an out-of-set or wrong-plane codec before any fetch. `compute_cid` is only ever called with engine-chosen codec constants, never a remote byte (avoiding the primitive's `assert` as a panic-DoS).

## Verification

- `cargo test -p cipherbox-engine` — **161 passed / 0 failed** (38 new content-plane tests). Covers: framing/DAG determinism, empty/exact-multiple framing, full seal to assemble to verify to reassemble round-trip, verified-read happy path + tampered-bytes fail-closed (terminal, no rotation) + availability fallback + out-of-set/wrong-plane codec rejection, provider probes per kind, quota pre-flight (hosted vs BYO advisory), and the prune op.
- `cargo clippy -p cipherbox-engine --all-targets` — clean. `cargo fmt -p cipherbox-engine --check` — clean.
- No changes to `crates/core` (primitives consumed as-is).

### Reviews run on this diff before opening

- **`/simplify`** — removed unused `ContentKey: Clone` and `Gateway: Default`, dropped a redundant comment; kept `PinMode` (named pin-provider-layer scope) and the `cid_str`/`expected_cid` split (intentional seam).
- **security review** (trust boundaries, fail-closed reads, determinism) — folded: hand-written redacting `Debug` + `Zeroizing` for `GatewaySource.bearer`; guarded `leaf_range_for_byte_range` against a `chunk_size == 0` divide-by-zero.
- **`crypto-privacy-review`** (required) — confirmed the fail-closed `contentCid` path, entropy-only nonce draw, terminal-owner zeroization, and codec pinning; findings folded above.

Closes #630


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added encrypted content sealing with configurable chunk sizes and deterministic content identifiers.
  * Added content manifests for assembling and validating chunked content.
  * Added verified reads through authenticated and fallback gateways, with integrity checks.
  * Added support for testing and configuring external IPFS providers.
  * Added quota pre-checks and retention planning for older content versions.
* **Bug Fixes**
  * Invalid content, endpoints, malformed manifests, and tampered responses now fail safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->