### PR TITLE
feat(engine): implement the sync core with op queue, rebase, and pointers

### DIFF
--- a/crates/engine/src/content/dag.rs
+++ b/crates/engine/src/content/dag.rs
@@ -85,21 +85,22 @@ pub struct ContentDag {
 /// `contentCid`. `plaintext_len` is the pre-seal byte length (the ranged-read
 /// size bound). Deterministic: identical leaves + length + profile give a
 /// byte-identical root block and CID.
+///
+/// Fails closed when the leaf count does not match [`decode_root`]'s
+/// `ceil(size / chunkSize)`. Enforced in every build (not a release-compiled-out
+/// `debug_assert`): a mis-wired caller must never emit a root this crate's own
+/// [`decode_root`] would reject as `link count inconsistent with size`, which
+/// would leave the published version permanently unreadable.
 pub fn assemble(
     leaves: &[SealedChunk],
     plaintext_len: u64,
     profile: &ContentProfile,
-) -> ContentDag {
-    // Produce/consume symmetry: assemble emits exactly the leaf count decode_root
-    // requires, so this crate never produces a root its own decode would reject.
-    // A debug_assert (not a fallible signature) is the right level — the inputs
-    // are trusted engine values, so this guards a mis-wired caller, not untrusted
-    // input.
-    debug_assert_eq!(
-        leaves.len() as u64,
-        expected_leaf_count(plaintext_len, profile.chunk_size() as u64),
-        "assemble leaf count must match decode_root's ceil(size / chunkSize)"
-    );
+) -> Result<ContentDag, DagError> {
+    if leaves.len() as u64 != expected_leaf_count(plaintext_len, profile.chunk_size() as u64) {
+        return Err(DagError::InvalidManifest {
+            reason: "link count inconsistent with size",
+        });
+    }
     let links = leaves
         .iter()
         .map(|leaf| Value::Bytes(leaf.cid.clone()))
@@ -110,10 +111,10 @@ pub fn assemble(
     root.insert(LINKS_KEY, Value::Array(links));
     let root_block = encode(&Value::Map(root));
     let content_cid = compute_cid(DAG_ROOT_CODEC, &root_block);
-    ContentDag {
+    Ok(ContentDag {
         content_cid,
         root_block,
-    }
+    })
 }
 
 /// The manifest read back from a verified root block: the fixed chunk size, the
@@ -243,7 +244,7 @@ mod tests {
     #[test]
     fn root_content_addresses_to_its_content_cid() {
         let (leaves, profile) = framed(&(0..40u8).collect::<Vec<_>>(), 1);
-        let dag = assemble(&leaves, 40, &profile);
+        let dag = assemble(&leaves, 40, &profile).unwrap();
         assert!(verify_cid(&dag.content_cid, &dag.root_block).is_ok());
         assert_eq!(
             dag.content_cid[1], DAG_ROOT_CODEC,
@@ -254,8 +255,8 @@ mod tests {
     #[test]
     fn assembly_is_deterministic() {
         let (leaves, profile) = framed(&(0..40u8).collect::<Vec<_>>(), 7);
-        let a = assemble(&leaves, 40, &profile);
-        let b = assemble(&leaves, 40, &profile);
+        let a = assemble(&leaves, 40, &profile).unwrap();
+        let b = assemble(&leaves, 40, &profile).unwrap();
         assert_eq!(a, b, "same leaves + length => byte-identical root");
     }
 
@@ -263,7 +264,7 @@ mod tests {
     fn root_manifest_round_trips_the_ordered_leaf_cids() {
         let plaintext: Vec<u8> = (0..40u8).collect();
         let (leaves, profile) = framed(&plaintext, 3);
-        let dag = assemble(&leaves, plaintext.len() as u64, &profile);
+        let dag = assemble(&leaves, plaintext.len() as u64, &profile).unwrap();
 
         let manifest = decode_root(&dag.root_block).unwrap();
         assert_eq!(manifest.chunk_size, profile.chunk_size() as u64);
@@ -278,7 +279,7 @@ mod tests {
     #[test]
     fn leaf_cids_use_the_raw_codec_root_uses_dag_cbor() {
         let (leaves, profile) = framed(b"abc", 5);
-        let dag = assemble(&leaves, 3, &profile);
+        let dag = assemble(&leaves, 3, &profile).unwrap();
         assert_eq!(leaves[0].cid[1], CONTENT_CID_CODEC, "leaf is raw");
         assert_eq!(dag.content_cid[1], DAG_ROOT_CODEC, "root is dag-cbor");
     }
@@ -319,9 +320,24 @@ mod tests {
     fn decode_root_accepts_the_empty_version_single_leaf() {
         // size 0 frames to exactly one empty leaf; the count check must allow it.
         let (leaves, profile) = framed(b"", 9);
-        let dag = assemble(&leaves, 0, &profile);
+        let dag = assemble(&leaves, 0, &profile).unwrap();
         let manifest = decode_root(&dag.root_block).unwrap();
         assert_eq!(manifest.size, 0);
         assert_eq!(manifest.leaf_cids.len(), 1);
+    }
+
+    #[test]
+    fn assemble_rejects_a_leaf_count_size_mismatch_in_every_build() {
+        // `b"abc"` frames to one leaf at CI's 16-byte chunk, but a plaintext_len
+        // of 40 expects three — the invariant fails closed in a normal (non
+        // debug_assert) test build rather than emitting an unreadable root.
+        let (leaves, profile) = framed(b"abc", 11);
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(
+            assemble(&leaves, 40, &profile),
+            Err(DagError::InvalidManifest {
+                reason: "link count inconsistent with size",
+            })
+        );
     }
 }

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -49,18 +49,42 @@ pub struct SealedContent {
     pub leaves: Vec<SealedChunk>,
 }
 
+/// Why sealing a content version failed, fail-closed: entropy acquisition, or a
+/// leaf set that would assemble a root [`decode_root`] rejects. An `Ok` return is
+/// a version whose own DAG root this crate can decode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SealError {
+    /// Entropy acquisition for chunk sealing failed.
+    Entropy(EntropyError),
+    /// DAG assembly rejected the leaf set (see [`DagError`]).
+    Dag(DagError),
+}
+
+impl From<EntropyError> for SealError {
+    fn from(error: EntropyError) -> Self {
+        Self::Entropy(error)
+    }
+}
+
+impl From<DagError> for SealError {
+    fn from(error: DagError) -> Self {
+        Self::Dag(error)
+    }
+}
+
 /// Frame, seal, and assemble `plaintext` into a content version under `key`
 /// (blueprint/engine.md "Content plane"). Composes [`frame_and_seal`] and
 /// [`assemble`]; deterministic under a fixed key and seeded entropy. Fails
-/// closed only if entropy acquisition fails.
+/// closed if entropy acquisition fails or the assembled leaf count would not
+/// round-trip through [`decode_root`].
 pub fn seal_content(
     plaintext: &[u8],
     key: &ContentKey,
     entropy: &mut impl Entropy,
     profile: &ContentProfile,
-) -> Result<SealedContent, EntropyError> {
+) -> Result<SealedContent, SealError> {
     let leaves = frame_and_seal(plaintext, key, entropy, profile)?;
-    let dag = assemble(&leaves, plaintext.len() as u64, profile);
+    let dag = assemble(&leaves, plaintext.len() as u64, profile)?;
     Ok(SealedContent {
         content_cid: dag.content_cid,
         root_block: dag.root_block,

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -28,7 +28,13 @@ use crate::seams::{OpId, SeamSet, SeamTypes};
 /// The stable 16-byte node identifier (`id16`, blueprint/core.md). Public,
 /// non-secret, and location-independent — routes and commands key on it,
 /// never on rotating `ipnsName`s.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// `Ord` orders by the raw id bytes: a non-secret, location-independent total
+/// order that keeps the sync core's snapshot maps and dead-letter reporting
+/// deterministic across platforms.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub struct NodeId(pub [u8; 16]);
 
 /// Plaintext file content crossing the facade.
@@ -47,7 +53,7 @@ impl fmt::Debug for PlaintextContent {
 
 /// What a created node is. Kind is sealed inside the read-body on the wire;
 /// at the facade it is plain intent.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum NodeKind {
     /// A file node.
     File,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -43,9 +43,9 @@ pub use api::{
 pub use content::{
     ByoIpfsConfig, ByoKind, ContentDag, ContentKey, ContentPlane, ContentProfile, ContentVersion,
     DAG_ROOT_CODEC, DagError, Gateway, GatewaySource, PinMode, ProviderError, PrunePlan,
-    QuotaExceeded, ReadError, RootManifest, SealedChunk, SealedContent, assemble, decode_root,
-    frame_and_seal, leaf_range_for_byte_range, plan_prune, pre_flight_quota_check, read_block,
-    seal_content, test_connection, validate_endpoint,
+    QuotaExceeded, ReadError, RootManifest, SealError, SealedChunk, SealedContent, assemble,
+    decode_root, frame_and_seal, leaf_range_for_byte_range, plan_prune, pre_flight_quota_check,
+    read_block, seal_content, test_connection, validate_endpoint,
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -31,6 +31,7 @@ pub mod gate;
 pub mod net;
 pub mod profile;
 pub mod seams;
+pub mod sync;
 #[cfg(feature = "test-kit")]
 pub mod testkit;
 
@@ -53,6 +54,13 @@ pub use net::{
 };
 pub use profile::SyncTimingProfile;
 pub use seams::{SeamError, SeamResult, SeamSet, SeamTypes};
+pub use sync::{
+    AppliedOp, Connectivity, DeadLetterReason, DropReason, FocusTarget, FocusWindow, Link,
+    NodeMeta, Op, OpKind, OpResolution, PointerError, PointerFetch, Repair, ReplayReport,
+    SessionRole, Snapshot, StageOutcome, TickCause, TickControl, VaultPointerAdoption,
+    apply_overlay, apply_repairs, classify, cold_seed_floors, decode_queue, focus_set,
+    observed_repair, rebase_one, replay, resolve_vault_pointer, stage_op,
+};
 
 /// Placeholder identity item; kept for the sibling crate stubs' dependency
 /// tests until real cross-crate surface replaces it.

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -55,11 +55,12 @@ pub use net::{
 pub use profile::SyncTimingProfile;
 pub use seams::{SeamError, SeamResult, SeamSet, SeamTypes};
 pub use sync::{
-    AppliedOp, Connectivity, DeadLetterReason, DropReason, FocusTarget, FocusWindow, Link,
-    NodeMeta, Op, OpKind, OpResolution, PointerError, PointerFetch, Repair, ReplayReport,
-    SessionRole, Snapshot, StageOutcome, TickCause, TickControl, VaultPointerAdoption,
-    apply_overlay, apply_repairs, classify, cold_seed_floors, decode_queue, focus_set,
-    observed_repair, rebase_one, replay, resolve_vault_pointer, stage_op,
+    AppliedOp, Connectivity, DeadLetterReason, DropReason, FocusTarget, FocusWindow,
+    HeadReconciliation, Link, NodeMeta, Op, OpKind, OpResolution, PointerError, PointerFetch,
+    Repair, ReplayReport, SessionRole, Snapshot, StageOutcome, TickCause, TickControl,
+    VaultPointerAdoption, apply_overlay, apply_repairs, classify, cold_seed_floors, decode_queue,
+    focus_set, observed_repair, rebase_one, reconcile_head, replay, resolve_vault_pointer,
+    stage_op,
 };
 
 /// Placeholder identity item; kept for the sibling crate stubs' dependency

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -1,0 +1,60 @@
+//! The sync core — the state law, the durable op queue, FIFO rebase, budgeted
+//! offline staging, the focus-window tick, the staleness ladder, and the
+//! pointer planes (blueprint/engine.md "Sync core", "Pointer planes";
+//! CONTEXT.md).
+//!
+//! One model, single owner: rendered state = last-known-good gate-passing
+//! snapshot ⊕ pending-op overlay, and the op queue is the only local
+//! divergence (#33 D6). Every mutation rides the durable op queue as an intent
+//! op carrying its base sequence; offline replay and online CAS rebase re-apply
+//! ops through the **same** path — FIFO, onto gate-passing state only, through
+//! the five per-op race rules — and a terminally unrebasable op dead-letters
+//! with its staged bytes preserved rather than being silently dropped.
+//!
+//! Submodules:
+//!
+//! - [`model`] — the working tree (the state law's left operand) and the one
+//!   strict name comparator.
+//! - [`op`] — the intent-op model and its durable-queue codec.
+//! - [`overlay`] — the state law: snapshot ⊕ pending ops → rendered view.
+//! - [`rebase`] — FIFO replay, the five race rules, dead-lettering, and
+//!   dual-link observed repair.
+//! - [`staging`] — the budgeted offline staging policy over `StagingStore`.
+//! - [`staleness`] — the staleness ladder and the withheld-update escalation.
+//! - [`pointer`] — the scope/vault pointer planes, the re-point object, the
+//!   consult discipline, and the cold-start floor cold-seed.
+//! - [`tick`] — the jittered focus-window tick, immediate hint ticks, and
+//!   on-access refresh.
+//!
+//! Out of this slice, by design (CONTEXT.md #632): scope-exit rotation
+//! *triggering* — a cross-scope relink out of a granted scope **queues** the
+//! trigger event ([`rebase::ReplayReport::scope_exit_triggers`]); the rotation
+//! primitives themselves land with the rotation slice.
+
+pub mod model;
+pub mod op;
+pub mod overlay;
+pub mod pointer;
+pub mod rebase;
+pub mod staging;
+pub mod staleness;
+pub mod tick;
+
+pub use model::{Link, NodeMeta, Snapshot, collation_key, suffix_name};
+pub use op::{Op, OpDecodeError, OpKind};
+pub use overlay::apply_overlay;
+pub use pointer::{
+    ConsultReason, PointerError, PointerFetch, SessionRole, VaultPointerAdoption,
+    advance_write_epoch_on_sight, cold_seed_floors, open_repoint, resolve_vault_pointer,
+    scope_pointer_name, scope_pointer_signer, seal_repoint, should_consult, vault_pointer_name,
+};
+pub use rebase::{
+    AppliedOp, DeadLetterReason, DropReason, OpResolution, Repair, ReplayReport, apply_repairs,
+    decode_queue, observed_repair, rebase_one, replay,
+};
+pub use staging::{StageOutcome, orphan_staging_keys, stage_op};
+pub use staleness::{Connectivity, classify, withheld_escalation};
+pub use tick::{
+    FocusTarget, FocusWindow, ResolveMode, TickCause, TickControl, focus_set, jittered_cadence,
+    on_access_refresh_due, resolve_mode, run_tick_loop,
+};

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -44,13 +44,13 @@ pub use model::{Link, NodeMeta, Snapshot, collation_key, suffix_name};
 pub use op::{Op, OpDecodeError, OpKind};
 pub use overlay::apply_overlay;
 pub use pointer::{
-    ConsultReason, PointerError, PointerFetch, SessionRole, VaultPointerAdoption,
-    advance_write_epoch_on_sight, cold_seed_floors, open_repoint, resolve_vault_pointer,
-    scope_pointer_name, scope_pointer_signer, seal_repoint, should_consult, vault_pointer_name,
+    ConsultReason, PointerError, PointerFetch, SessionRole, VaultPointerAdoption, cold_seed_floors,
+    open_repoint, resolve_vault_pointer, scope_pointer_name, scope_pointer_signer, seal_repoint,
+    should_consult, vault_pointer_name,
 };
 pub use rebase::{
-    AppliedOp, DeadLetterReason, DropReason, OpResolution, Repair, ReplayReport, apply_repairs,
-    decode_queue, observed_repair, rebase_one, replay,
+    AppliedOp, DeadLetterReason, DropReason, HeadReconciliation, OpResolution, Repair,
+    ReplayReport, apply_repairs, decode_queue, observed_repair, rebase_one, reconcile_head, replay,
 };
 pub use staging::{StageOutcome, orphan_staging_keys, stage_op};
 pub use staleness::{Connectivity, classify, withheld_escalation};
@@ -58,3 +58,10 @@ pub use tick::{
     FocusTarget, FocusWindow, ResolveMode, TickCause, TickControl, focus_set, jittered_cadence,
     on_access_refresh_due, resolve_mode, run_tick_loop,
 };
+
+/// Whole milliseconds of `duration`, truncating and saturating — the engine's
+/// clock is the millisecond [`UnixMillis`](crate::seams::UnixMillis), so every
+/// timing threshold compares in the same unit.
+pub(crate) fn duration_millis(duration: core::time::Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}

--- a/crates/engine/src/sync/model.rs
+++ b/crates/engine/src/sync/model.rs
@@ -1,0 +1,342 @@
+//! The working tree model — the state law's left operand (blueprint/engine.md
+//! "Sync core", CONTEXT.md "Pending-op overlay").
+//!
+//! The [`Snapshot`] is the last-known-good **gate-passing** remote state, a
+//! single-owner projection of the resolved read-bodies (the content-plane
+//! assembly from `Adopted` read-bodies lands with a later slice; the sync core
+//! is written against this engine-domain projection). Rendered state is this
+//! snapshot with the pending-op overlay applied on top — the op queue is the
+//! only local divergence.
+//!
+//! A node's parent is expressed as a [`Link`] carrying the monotonic
+//! `link_counter` (mirrors core's `ChildRef.linkCounter`, #33 D5). A
+//! well-formed snapshot holds at most one link per child; a dual-link crash
+//! residue holds two, resolved by [`crate::sync::rebase::observed_repair`].
+
+use std::collections::BTreeMap;
+
+use crate::facade::{NodeId, NodeKind};
+
+/// One node's metadata in the working tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeMeta {
+    /// Location-independent node id.
+    pub id: NodeId,
+    /// The display name, stored **as entered** (uniqueness folds via
+    /// [`collation_key`]; the stored name is never mutated for comparison).
+    pub name: String,
+    /// File or folder.
+    pub kind: NodeKind,
+    /// The node's own IPNS record sequence — the conditional-delete snapshot
+    /// (a delete op drops on rebase if this advanced past the op's snapshot).
+    pub record_sequence: u64,
+    /// Bumped on every `updateContent` (a fresh per-version content key seals
+    /// each version, CONTEXT.md "Content key").
+    pub content_version: u64,
+}
+
+impl NodeMeta {
+    /// A node at record sequence 1, content version 0.
+    pub fn new(id: NodeId, name: impl Into<String>, kind: NodeKind) -> Self {
+        Self {
+            id,
+            name: name.into(),
+            kind,
+            record_sequence: 1,
+            content_version: 0,
+        }
+    }
+}
+
+/// A parent→child link with the monotonic dual-link tiebreak counter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Link {
+    /// The parent folder.
+    pub parent: NodeId,
+    /// The child node.
+    pub child: NodeId,
+    /// Monotonic counter; on a dual-link the higher counter is the winner
+    /// (ties broken by parent id for a total, cross-platform-stable order).
+    pub link_counter: u64,
+}
+
+/// The last-known-good remote snapshot: gate-passing state, single owner
+/// (the state law's left operand, #33 D6).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Snapshot {
+    /// The vault root node id.
+    pub root: NodeId,
+    nodes: BTreeMap<NodeId, NodeMeta>,
+    links: Vec<Link>,
+}
+
+impl Snapshot {
+    /// An empty snapshot anchored at `root` (the root node itself is present
+    /// as a folder with no parent link).
+    pub fn new(root: NodeId) -> Self {
+        let mut nodes = BTreeMap::new();
+        nodes.insert(root, NodeMeta::new(root, "", NodeKind::Folder));
+        Self {
+            root,
+            nodes,
+            links: Vec::new(),
+        }
+    }
+
+    /// Inserts or replaces a node's metadata.
+    pub fn upsert_node(&mut self, meta: NodeMeta) {
+        self.nodes.insert(meta.id, meta);
+    }
+
+    /// The node's metadata, if present.
+    pub fn node(&self, id: NodeId) -> Option<&NodeMeta> {
+        self.nodes.get(&id)
+    }
+
+    /// Mutable access to a node's metadata.
+    pub fn node_mut(&mut self, id: NodeId) -> Option<&mut NodeMeta> {
+        self.nodes.get_mut(&id)
+    }
+
+    /// Whether the node is present in gate-passing state.
+    pub fn contains(&self, id: NodeId) -> bool {
+        self.nodes.contains_key(&id)
+    }
+
+    /// The node's own record sequence, if present.
+    pub fn record_sequence(&self, id: NodeId) -> Option<u64> {
+        self.nodes.get(&id).map(|n| n.record_sequence)
+    }
+
+    /// Adds a parent→child link. Idempotent on `(parent, child)`: a repeat
+    /// keeps the higher `link_counter` (a re-link never lowers it).
+    pub fn link(&mut self, parent: NodeId, child: NodeId, link_counter: u64) {
+        if let Some(existing) = self
+            .links
+            .iter_mut()
+            .find(|l| l.parent == parent && l.child == child)
+        {
+            existing.link_counter = existing.link_counter.max(link_counter);
+            return;
+        }
+        self.links.push(Link {
+            parent,
+            child,
+            link_counter,
+        });
+    }
+
+    /// Removes the link between `parent` and `child`, if any.
+    pub fn unlink(&mut self, parent: NodeId, child: NodeId) {
+        self.links
+            .retain(|l| !(l.parent == parent && l.child == child));
+    }
+
+    /// Removes a node and every link that references it (as parent or child).
+    pub fn remove_node(&mut self, id: NodeId) {
+        self.nodes.remove(&id);
+        self.links.retain(|l| l.parent != id && l.child != id);
+    }
+
+    /// Every link naming `child` as the child. One entry in a well-formed
+    /// snapshot; two on a dual-link crash residue.
+    pub fn links_to(&self, child: NodeId) -> Vec<Link> {
+        self.links
+            .iter()
+            .copied()
+            .filter(|l| l.child == child)
+            .collect()
+    }
+
+    /// The child's effective parent: the winning link's parent on a dual-link
+    /// (highest counter, then lowest parent id). `None` for the root or an
+    /// unlinked node.
+    pub fn parent_of(&self, child: NodeId) -> Option<NodeId> {
+        self.winning_link(child).map(|l| l.parent)
+    }
+
+    /// The winning link for a child under the dual-link tiebreak.
+    pub fn winning_link(&self, child: NodeId) -> Option<Link> {
+        self.links
+            .iter()
+            .filter(|l| l.child == child)
+            .copied()
+            .max_by(|a, b| {
+                a.link_counter
+                    .cmp(&b.link_counter)
+                    .then(b.parent.cmp(&a.parent))
+            })
+    }
+
+    /// The children linked under `parent`, deterministically ordered by child
+    /// id. Dual-linked children appear under every parent that links them
+    /// (the residue [`observed_repair`](crate::sync::rebase::observed_repair)
+    /// heals).
+    pub fn children(&self, parent: NodeId) -> Vec<&NodeMeta> {
+        let mut ids: Vec<NodeId> = self
+            .links
+            .iter()
+            .filter(|l| l.parent == parent)
+            .map(|l| l.child)
+            .collect();
+        ids.sort_unstable();
+        ids.dedup();
+        ids.into_iter()
+            .filter_map(|id| self.nodes.get(&id))
+            .collect()
+    }
+
+    /// The ancestor chain from `node`'s parent up to and including the root,
+    /// nearest first. Empty for the root. Cycle-guarded (a malformed cycle
+    /// terminates rather than looping).
+    pub fn ancestors(&self, node: NodeId) -> Vec<NodeId> {
+        let mut chain = Vec::new();
+        let mut seen = vec![node];
+        let mut current = node;
+        while let Some(parent) = self.parent_of(current) {
+            if seen.contains(&parent) {
+                break;
+            }
+            chain.push(parent);
+            seen.push(parent);
+            current = parent;
+        }
+        chain
+    }
+
+    /// Whether `parent` already links a child (other than `exclude`) whose name
+    /// folds equal to `name` under the strict comparator — the add/add and
+    /// rename collision predicate.
+    pub fn name_taken(&self, parent: NodeId, name: &str, exclude: Option<NodeId>) -> bool {
+        let key = collation_key(name);
+        self.children(parent)
+            .into_iter()
+            .any(|child| Some(child.id) != exclude && collation_key(&child.name) == key)
+    }
+
+    /// The highest `link_counter` currently linking `child` anywhere, or 0.
+    pub fn max_link_counter(&self, child: NodeId) -> u64 {
+        self.links
+            .iter()
+            .filter(|l| l.child == child)
+            .map(|l| l.link_counter)
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Every link, for inspection (repair, tests).
+    pub fn links(&self) -> &[Link] {
+        &self.links
+    }
+}
+
+/// The single strict name comparator (blueprint/engine.md rebase table:
+/// "one strict comparator everywhere … identical at create and merge on all
+/// platforms, names stored as-entered"). Case-folded so `Report.txt` and
+/// `report.txt` collide; the stored name is never mutated.
+///
+/// Canonical Unicode NFC normalization is the cross-language KAT'd surface
+/// core owns (its `name_cmp` is the wire-order sibling); this engine-side key
+/// folds case with the platform-stable Unicode default mapping and is applied
+/// identically at create and at merge.
+pub fn collation_key(name: &str) -> String {
+    name.to_lowercase()
+}
+
+/// The auto-suffix for an add/add collision loser: ` (n)` inserted before the
+/// extension (`report.txt` → `report (2).txt`; `folder` → `folder (2)`;
+/// `.bashrc` → `.bashrc (2)`).
+pub fn suffix_name(name: &str, n: u32) -> String {
+    match split_extension(name) {
+        Some((stem, ext)) => format!("{stem} ({n}).{ext}"),
+        None => format!("{name} ({n})"),
+    }
+}
+
+/// Split a trailing extension: `("report", "txt")` for `report.txt`. `None`
+/// when there is no interior dot with a non-empty stem (a dotfile like
+/// `.bashrc` has no extension to preserve).
+fn split_extension(name: &str) -> Option<(&str, &str)> {
+    let dot = name.rfind('.')?;
+    let (stem, dot_ext) = name.split_at(dot);
+    let ext = &dot_ext[1..];
+    if stem.is_empty() || ext.is_empty() {
+        return None;
+    }
+    Some((stem, ext))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(b: u8) -> NodeId {
+        NodeId([b; 16])
+    }
+
+    #[test]
+    fn collation_key_folds_case() {
+        assert_eq!(collation_key("Report.TXT"), collation_key("report.txt"));
+        assert_ne!(collation_key("a"), collation_key("b"));
+    }
+
+    #[test]
+    fn suffix_preserves_extension() {
+        assert_eq!(suffix_name("report.txt", 2), "report (2).txt");
+        assert_eq!(suffix_name("folder", 2), "folder (2)");
+        assert_eq!(suffix_name(".bashrc", 2), ".bashrc (2)");
+        assert_eq!(suffix_name("a.b.c", 3), "a.b (3).c");
+    }
+
+    #[test]
+    fn parent_and_children_track_links() {
+        let mut snap = Snapshot::new(id(0));
+        snap.upsert_node(NodeMeta::new(id(1), "a", NodeKind::Folder));
+        snap.upsert_node(NodeMeta::new(id(2), "b", NodeKind::File));
+        snap.link(id(0), id(1), 1);
+        snap.link(id(1), id(2), 1);
+
+        assert_eq!(snap.parent_of(id(2)), Some(id(1)));
+        assert_eq!(snap.parent_of(id(1)), Some(id(0)));
+        assert_eq!(snap.parent_of(id(0)), None);
+        let names: Vec<&str> = snap
+            .children(id(1))
+            .iter()
+            .map(|n| n.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["b"]);
+    }
+
+    #[test]
+    fn ancestors_walk_to_root() {
+        let mut snap = Snapshot::new(id(0));
+        snap.upsert_node(NodeMeta::new(id(1), "a", NodeKind::Folder));
+        snap.upsert_node(NodeMeta::new(id(2), "b", NodeKind::Folder));
+        snap.link(id(0), id(1), 1);
+        snap.link(id(1), id(2), 1);
+        assert_eq!(snap.ancestors(id(2)), vec![id(1), id(0)]);
+        assert_eq!(snap.ancestors(id(0)), Vec::<NodeId>::new());
+    }
+
+    #[test]
+    fn dual_link_winner_is_highest_counter() {
+        let mut snap = Snapshot::new(id(0));
+        snap.upsert_node(NodeMeta::new(id(1), "p1", NodeKind::Folder));
+        snap.upsert_node(NodeMeta::new(id(2), "p2", NodeKind::Folder));
+        snap.upsert_node(NodeMeta::new(id(3), "c", NodeKind::File));
+        snap.link(id(1), id(3), 1);
+        snap.link(id(2), id(3), 2);
+        assert_eq!(snap.links_to(id(3)).len(), 2, "residue holds two links");
+        assert_eq!(snap.parent_of(id(3)), Some(id(2)), "higher counter wins");
+    }
+
+    #[test]
+    fn name_taken_folds_and_excludes_self() {
+        let mut snap = Snapshot::new(id(0));
+        snap.upsert_node(NodeMeta::new(id(1), "Report.txt", NodeKind::File));
+        snap.link(id(0), id(1), 1);
+        assert!(snap.name_taken(id(0), "report.txt", None));
+        assert!(!snap.name_taken(id(0), "report.txt", Some(id(1))));
+        assert!(!snap.name_taken(id(0), "other.txt", None));
+    }
+}

--- a/crates/engine/src/sync/model.rs
+++ b/crates/engine/src/sync/model.rs
@@ -126,6 +126,32 @@ impl Snapshot {
         });
     }
 
+    /// Links `child` under `parent` with a **fresh winning counter** — one
+    /// above every existing link to the child — in a single pass. The model
+    /// owns the "a newly-established link supersedes prior links" invariant so
+    /// callers (create, relink, resurrect) never hand-roll counter allocation.
+    pub fn link_next(&mut self, parent: NodeId, child: NodeId) {
+        let mut max_counter = 0u64;
+        let mut existing: Option<usize> = None;
+        for (i, l) in self.links.iter().enumerate() {
+            if l.child == child {
+                max_counter = max_counter.max(l.link_counter);
+                if l.parent == parent {
+                    existing = Some(i);
+                }
+            }
+        }
+        let next = max_counter + 1;
+        match existing {
+            Some(i) => self.links[i].link_counter = self.links[i].link_counter.max(next),
+            None => self.links.push(Link {
+                parent,
+                child,
+                link_counter: next,
+            }),
+        }
+    }
+
     /// Removes the link between `parent` and `child`, if any.
     pub fn unlink(&mut self, parent: NodeId, child: NodeId) {
         self.links

--- a/crates/engine/src/sync/op.rs
+++ b/crates/engine/src/sync/op.rs
@@ -1,0 +1,260 @@
+//! Intent ops — the durable FIFO journal every mutation rides (CONTEXT.md "Op
+//! queue"; blueprint/engine.md "Sync core: Ops").
+//!
+//! Every mutation is an intent op carrying its **base sequence** — the record
+//! sequence of the state it was formed against — journaled FIFO in the durable
+//! op queue on both platforms. Ops are the engine's own opaque encoded records
+//! (the [`StagingStore`](crate::seams::StagingStore) never interprets them);
+//! this module owns their encoding, and [`crate::sync::rebase`] owns their
+//! replay.
+//!
+//! Content bytes never live in an op: `create`/`updateContent` reference their
+//! staged upload by an opaque staging key, and the bytes sit in the staging
+//! store behind the profile budget ([`crate::sync::staging`]).
+
+use serde::{Deserialize, Serialize};
+
+use crate::facade::{NodeId, NodeKind};
+
+/// One intent op: the target node, the base sequence it was formed against,
+/// and the mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Op {
+    /// The node this op acts on. For [`OpKind::Create`] it is the id minted
+    /// for the new node.
+    pub target: NodeId,
+    /// The record sequence of the base state this op was formed against — the
+    /// rebase anchor (#33 D5).
+    pub base_sequence: u64,
+    /// The mutation.
+    pub kind: OpKind,
+}
+
+/// The five intent-op mutations (#33 D6).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OpKind {
+    /// Create a node under a parent.
+    Create {
+        /// The parent folder.
+        parent: NodeId,
+        /// The name as entered.
+        name: String,
+        /// File or folder.
+        kind: NodeKind,
+        /// Staging key of the initial file content, if any (folders and empty
+        /// files carry none).
+        content_staging_key: Option<Vec<u8>>,
+    },
+    /// Delete a node. `target_sequence` snapshots the target's own record
+    /// sequence for the conditional-delete rebase rule.
+    Delete {
+        /// The target's record sequence at the time the delete was formed.
+        target_sequence: u64,
+    },
+    /// Rename a node in place.
+    Rename {
+        /// The new name as entered.
+        new_name: String,
+    },
+    /// Move a node to a new parent. Intra-scope this is a pure relink;
+    /// cross-scope it re-seals the subtree at the destination epoch and, when
+    /// it leaves a granted source scope, **queues a scope-exit rotation
+    /// trigger** — this slice queues the trigger only, it does not rotate
+    /// (CONTEXT.md #632 scope: "does NOT land: scope-exit rotation
+    /// triggering").
+    Relink {
+        /// The source parent the move was formed against — the presence
+        /// condition for the source-remove and the move-race detector
+        /// (a concurrent move away from it makes this op the race loser).
+        from_parent: NodeId,
+        /// The destination parent.
+        new_parent: NodeId,
+        /// Whether the move crosses a scope boundary.
+        cross_scope: bool,
+        /// Whether the move leaves a granted source scope (a scope-exit
+        /// rotation trigger for the source).
+        exits_granted_source: bool,
+    },
+    /// Write a new file version (fresh per-version content key).
+    UpdateContent {
+        /// Staging key of the new content bytes.
+        content_staging_key: Vec<u8>,
+    },
+}
+
+impl Op {
+    /// A `create` op.
+    pub fn create(
+        new_node: NodeId,
+        parent: NodeId,
+        name: impl Into<String>,
+        kind: NodeKind,
+        base_sequence: u64,
+        content_staging_key: Option<Vec<u8>>,
+    ) -> Self {
+        Self {
+            target: new_node,
+            base_sequence,
+            kind: OpKind::Create {
+                parent,
+                name: name.into(),
+                kind,
+                content_staging_key,
+            },
+        }
+    }
+
+    /// A conditional-`delete` op snapshotting the target's own sequence.
+    pub fn delete(target: NodeId, base_sequence: u64, target_sequence: u64) -> Self {
+        Self {
+            target,
+            base_sequence,
+            kind: OpKind::Delete { target_sequence },
+        }
+    }
+
+    /// A `rename` op.
+    pub fn rename(target: NodeId, new_name: impl Into<String>, base_sequence: u64) -> Self {
+        Self {
+            target,
+            base_sequence,
+            kind: OpKind::Rename {
+                new_name: new_name.into(),
+            },
+        }
+    }
+
+    /// A `relink` (move) op from `from_parent` to `new_parent`.
+    pub fn relink(
+        target: NodeId,
+        from_parent: NodeId,
+        new_parent: NodeId,
+        base_sequence: u64,
+        cross_scope: bool,
+        exits_granted_source: bool,
+    ) -> Self {
+        Self {
+            target,
+            base_sequence,
+            kind: OpKind::Relink {
+                from_parent,
+                new_parent,
+                cross_scope,
+                exits_granted_source,
+            },
+        }
+    }
+
+    /// An `updateContent` op.
+    pub fn update_content(
+        target: NodeId,
+        content_staging_key: Vec<u8>,
+        base_sequence: u64,
+    ) -> Self {
+        Self {
+            target,
+            base_sequence,
+            kind: OpKind::UpdateContent {
+                content_staging_key,
+            },
+        }
+    }
+
+    /// The staging key this op references, if any (orphan-GC input).
+    pub fn staging_key(&self) -> Option<&[u8]> {
+        match &self.kind {
+            OpKind::Create {
+                content_staging_key: Some(key),
+                ..
+            }
+            | OpKind::UpdateContent {
+                content_staging_key: key,
+            } => Some(key),
+            _ => None,
+        }
+    }
+
+    /// Encode to the opaque bytes the durable op queue stores.
+    pub fn encode(&self) -> Vec<u8> {
+        // Infallible: `Op` has no non-serializable field (a map key type, a
+        // non-finite float); serde_json only errors on those.
+        serde_json::to_vec(self).expect("Op serializes")
+    }
+
+    /// Decode from the durable op queue's opaque bytes.
+    pub fn decode(bytes: &[u8]) -> Result<Self, OpDecodeError> {
+        serde_json::from_slice(bytes).map_err(|e| OpDecodeError(e.to_string()))
+    }
+}
+
+/// A durable op-queue record failed to decode — a corrupt or forward-version
+/// journal entry. The engine dead-letters it rather than crash the replay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpDecodeError(String);
+
+impl OpDecodeError {
+    /// The diagnostic message (no key material — ops carry no plaintext).
+    pub fn message(&self) -> &str {
+        &self.0
+    }
+}
+
+impl core::fmt::Display for OpDecodeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "op decode failed: {}", self.0)
+    }
+}
+
+impl std::error::Error for OpDecodeError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(b: u8) -> NodeId {
+        NodeId([b; 16])
+    }
+
+    #[test]
+    fn every_op_round_trips_through_the_durable_encoding() {
+        let ops = vec![
+            Op::create(
+                id(1),
+                id(0),
+                "a.txt",
+                NodeKind::File,
+                3,
+                Some(b"stage".to_vec()),
+            ),
+            Op::delete(id(2), 4, 7),
+            Op::rename(id(3), "b.txt", 5),
+            Op::relink(id(4), id(0), id(9), 6, true, true),
+            Op::update_content(id(5), b"stage2".to_vec(), 8),
+        ];
+        for op in ops {
+            assert_eq!(Op::decode(&op.encode()).unwrap(), op);
+        }
+    }
+
+    #[test]
+    fn staging_key_exposed_only_for_content_ops() {
+        assert_eq!(
+            Op::create(id(1), id(0), "a", NodeKind::File, 1, Some(b"k".to_vec())).staging_key(),
+            Some(&b"k"[..])
+        );
+        assert_eq!(
+            Op::update_content(id(1), b"k".to_vec(), 1).staging_key(),
+            Some(&b"k"[..])
+        );
+        assert_eq!(Op::rename(id(1), "b", 1).staging_key(), None);
+        assert_eq!(
+            Op::create(id(1), id(0), "d", NodeKind::Folder, 1, None).staging_key(),
+            None
+        );
+    }
+
+    #[test]
+    fn corrupt_bytes_decode_to_a_typed_error_not_a_panic() {
+        assert!(Op::decode(b"not json").is_err());
+    }
+}

--- a/crates/engine/src/sync/overlay.rs
+++ b/crates/engine/src/sync/overlay.rs
@@ -1,0 +1,123 @@
+//! The state law — rendered state = last-known-good snapshot ⊕ pending-op
+//! overlay, single owner (blueprint/engine.md "Sync core: State law",
+//! CONTEXT.md "Pending-op overlay").
+//!
+//! The overlay is the **optimistic local view**: the queued ops are applied on
+//! top of the gate-passing snapshot in FIFO order so the UI reflects the user's
+//! own pending mutations immediately, before the network confirms them. It is
+//! deliberately *not* the rebase ([`crate::sync::rebase`]): it never drops,
+//! suffixes, or dead-letters — it renders intent. The op queue is the only
+//! local divergence from the remote snapshot.
+
+use crate::sync::model::{NodeMeta, Snapshot};
+use crate::sync::op::{Op, OpKind};
+
+/// Apply the pending op queue onto `base` in FIFO order, returning the rendered
+/// view. Pure: `base` is untouched.
+pub fn apply_overlay(base: &Snapshot, ops: &[Op]) -> Snapshot {
+    let mut view = base.clone();
+    for op in ops {
+        apply_one(&mut view, op);
+    }
+    view
+}
+
+/// Apply one op to the working view optimistically (intent, not rebase).
+fn apply_one(view: &mut Snapshot, op: &Op) {
+    match &op.kind {
+        OpKind::Create {
+            parent, name, kind, ..
+        } => {
+            view.upsert_node(NodeMeta::new(op.target, name.clone(), *kind));
+            let counter = view.max_link_counter(op.target) + 1;
+            view.link(*parent, op.target, counter);
+        }
+        OpKind::Delete { .. } => {
+            view.remove_node(op.target);
+        }
+        OpKind::Rename { new_name } => {
+            if let Some(node) = view.node_mut(op.target) {
+                node.name = new_name.clone();
+            }
+        }
+        OpKind::Relink { new_parent, .. } => {
+            if let Some(old_parent) = view.parent_of(op.target) {
+                view.unlink(old_parent, op.target);
+            }
+            let counter = view.max_link_counter(op.target) + 1;
+            view.link(*new_parent, op.target, counter);
+        }
+        OpKind::UpdateContent { .. } => {
+            if let Some(node) = view.node_mut(op.target) {
+                node.content_version += 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::facade::{NodeId, NodeKind};
+
+    fn id(b: u8) -> NodeId {
+        NodeId([b; 16])
+    }
+
+    fn base() -> Snapshot {
+        Snapshot::new(id(0))
+    }
+
+    #[test]
+    fn overlay_renders_a_pending_create_over_the_snapshot() {
+        let base = base();
+        let ops = vec![Op::create(id(1), id(0), "a.txt", NodeKind::File, 1, None)];
+        let view = apply_overlay(&base, &ops);
+
+        assert!(view.contains(id(1)), "pending create is rendered");
+        assert_eq!(view.parent_of(id(1)), Some(id(0)));
+        assert!(!base.contains(id(1)), "the base snapshot is untouched");
+    }
+
+    #[test]
+    fn overlay_applies_ops_in_fifo_order() {
+        let mut base = base();
+        base.upsert_node(NodeMeta::new(id(1), "old.txt", NodeKind::File));
+        base.link(id(0), id(1), 1);
+
+        let ops = vec![
+            Op::rename(id(1), "mid.txt", 1),
+            Op::rename(id(1), "new.txt", 1),
+        ];
+        let view = apply_overlay(&base, &ops);
+        assert_eq!(
+            view.node(id(1)).unwrap().name,
+            "new.txt",
+            "last write in FIFO order wins"
+        );
+    }
+
+    #[test]
+    fn overlay_relink_moves_the_node_in_the_view() {
+        let mut base = base();
+        base.upsert_node(NodeMeta::new(id(1), "dir", NodeKind::Folder));
+        base.upsert_node(NodeMeta::new(id(2), "f", NodeKind::File));
+        base.link(id(0), id(1), 1);
+        base.link(id(0), id(2), 1);
+
+        let ops = vec![Op::relink(id(2), id(0), id(1), 1, false, false)];
+        let view = apply_overlay(&base, &ops);
+        assert_eq!(view.parent_of(id(2)), Some(id(1)));
+        assert_eq!(view.children(id(0)).len(), 1, "moved out of root");
+    }
+
+    #[test]
+    fn overlay_delete_removes_from_the_view_only() {
+        let mut base = base();
+        base.upsert_node(NodeMeta::new(id(1), "f", NodeKind::File));
+        base.link(id(0), id(1), 1);
+        let view = apply_overlay(&base, &[Op::delete(id(1), 1, 1)]);
+        assert!(!view.contains(id(1)));
+        assert!(base.contains(id(1)));
+    }
+}

--- a/crates/engine/src/sync/overlay.rs
+++ b/crates/engine/src/sync/overlay.rs
@@ -29,8 +29,7 @@ fn apply_one(view: &mut Snapshot, op: &Op) {
             parent, name, kind, ..
         } => {
             view.upsert_node(NodeMeta::new(op.target, name.clone(), *kind));
-            let counter = view.max_link_counter(op.target) + 1;
-            view.link(*parent, op.target, counter);
+            view.link_next(*parent, op.target);
         }
         OpKind::Delete { .. } => {
             view.remove_node(op.target);
@@ -44,8 +43,7 @@ fn apply_one(view: &mut Snapshot, op: &Op) {
             if let Some(old_parent) = view.parent_of(op.target) {
                 view.unlink(old_parent, op.target);
             }
-            let counter = view.max_link_counter(op.target) + 1;
-            view.link(*new_parent, op.target, counter);
+            view.link_next(*new_parent, op.target);
         }
         OpKind::UpdateContent { .. } => {
             if let Some(node) = view.node_mut(op.target) {
@@ -119,5 +117,23 @@ mod tests {
         let view = apply_overlay(&base, &[Op::delete(id(1), 1, 1)]);
         assert!(!view.contains(id(1)));
         assert!(base.contains(id(1)));
+    }
+
+    #[test]
+    fn overlay_update_content_bumps_the_content_version() {
+        let mut base = base();
+        base.upsert_node(NodeMeta::new(id(1), "f.txt", NodeKind::File));
+        base.link(id(0), id(1), 1);
+        let view = apply_overlay(&base, &[Op::update_content(id(1), b"k".to_vec(), 1)]);
+        assert_eq!(
+            view.node(id(1)).unwrap().content_version,
+            1,
+            "new version rendered"
+        );
+        assert_eq!(
+            base.node(id(1)).unwrap().content_version,
+            0,
+            "base untouched"
+        );
     }
 }

--- a/crates/engine/src/sync/pointer.rs
+++ b/crates/engine/src/sync/pointer.rs
@@ -1,0 +1,446 @@
+//! The pointer planes — scope pointer, vault pointer, re-point object, and the
+//! consult discipline (blueprint/engine.md "Pointer planes"; CONTEXT.md
+//! "Scope pointer", "Vault pointer", "Re-point object"; #38, #39 D5).
+//!
+//! Three planes (#38 D1): the owner plane (stable pointer names, owner-only
+//! keys), the write plane (rotating derived names), the read plane (seeds).
+//! The engine publishes to the owner plane **only in owner sessions**. Every
+//! re-point object is owner-identity-signed and sealed under the scope's stable
+//! `pointerReadKey`; core owns the codec, sign, and verify
+//! ([`seal_pointer_payload`]/[`open_pointer_payload`]) — this module owns name
+//! derivation, the vault-pointer index walk, the owner-plane write gate, the
+//! consult discipline, and the cold-start floor cold-seed.
+//!
+//! **Consult discipline: polled, not fallback** (#38 D4). A revokee's forged
+//! old-epoch record passes every *other* gate stage (valid old-key signature,
+//! fresh sequence, floor-level epoch, old-seed unseal), so staleness never
+//! fires and a fallback-only pointer would never be consulted. The pointer
+//! resolve therefore *joins the focus-window tick* for open shared scopes,
+//! runs on access for cached ones, and is the first act on cold start — it is
+//! never gated behind a staleness signal.
+
+use cipherbox_core::error::CodecError;
+use cipherbox_core::ipns::IpnsName;
+use cipherbox_core::kdf;
+use cipherbox_core::payload::{RepointObject, open_pointer_payload, seal_pointer_payload};
+use cipherbox_core::suite::aead::NONCE_LEN;
+use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
+
+use crate::entropy::{Entropy, EntropyError};
+use crate::gate::floor;
+use crate::seams::{FloorStore, SeamError, SeamResult};
+
+/// A safety bound on the vault-pointer index walk. The chain length is
+/// owner-authored (each index needs the owner's identity signature to open),
+/// so a valid chain is finite; this only guards against a misbehaving fetch
+/// never returning "unresolvable".
+const MAX_VAULT_POINTER_PROBE: u64 = 1 << 16;
+
+/// Who is driving this session — the owner-plane write gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionRole {
+    /// The vault owner: may publish the owner plane (scope/vault pointers).
+    Owner,
+    /// A grantee: reads pointers, never publishes the owner plane.
+    Grantee,
+}
+
+/// Why the pointer plane is being consulted — always polled, never a staleness
+/// fallback (#38 D4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsultReason {
+    /// The first act on cold start (before any record adoption).
+    ColdStart,
+    /// Riding the focus-window tick for an open shared scope.
+    FocusTick,
+    /// On access to a cached shared scope past its staleness threshold.
+    OnAccess,
+}
+
+/// A pointer-plane operation failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PointerError {
+    /// An owner-plane publish was attempted from a non-owner session.
+    NotOwnerSession,
+    /// Entropy acquisition for the seal nonce failed (fail-closed).
+    Entropy(EntropyError),
+    /// A fetched pointer block failed to open — tamper, wrong owner, scope
+    /// transplant, or version downgrade (surfaced from core verbatim).
+    Open(CodecError),
+    /// A host durable-store / transport seam failure.
+    Seam(SeamError),
+}
+
+/// Fetches the sealed re-point block published at a pointer name. `None` means
+/// the name is unresolvable (a gap in the vault-pointer chain, or a scope with
+/// no pointer yet). Abstracts the record resolve + content fetch the net/
+/// content slices own, so the pointer walk is testable in isolation.
+pub trait PointerFetch {
+    /// The sealed re-point block at `name`, or `None` if unresolvable.
+    async fn fetch(&self, name: &IpnsName) -> SeamResult<Option<Vec<u8>>>;
+}
+
+/// The vault-pointer IPNS name at `index` (`pointerKey_i = KDF(secret,
+/// "vault-pointer" ‖ i)`, CONTEXT.md).
+pub fn vault_pointer_name(login_secret: &[u8], index: u64) -> IpnsName {
+    IpnsName::from_public_key(&kdf::vault_pointer_index(login_secret, index).verifying_key())
+}
+
+/// The scope-pointer IPNS name for a shared scope (`pointerKey(scope) =
+/// KDF(ownerPointerSeed, scope.id)`, CONTEXT.md). The signer for that name is
+/// [`scope_pointer_signer`].
+pub fn scope_pointer_name(owner_pointer_seed: &[u8; 32], scope_id: &[u8; 16]) -> IpnsName {
+    IpnsName::from_public_key(&kdf::scope_pointer(owner_pointer_seed, scope_id).verifying_key())
+}
+
+/// The Ed25519 signer for a scope pointer's IPNS record (owner-only).
+pub fn scope_pointer_signer(
+    owner_pointer_seed: &[u8; 32],
+    scope_id: &[u8; 16],
+) -> cipherbox_core::suite::ed25519::Ed25519Signer {
+    kdf::scope_pointer(owner_pointer_seed, scope_id)
+}
+
+/// One adopted vault-pointer index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VaultPointerAdoption {
+    /// The highest valid index adopted.
+    pub index: u64,
+    /// Its owner-signed re-point object.
+    pub repoint: RepointObject,
+}
+
+/// Walk the indexed vault-pointer chain with probe-one-past semantics
+/// (CONTEXT.md "Vault pointer", #39 D5): from index 0 upward, adopt the highest
+/// index bearing a valid owner-signed payload, and stop at the first
+/// unresolvable index — which only the owner can extend. Probing continues one
+/// index past the highest resolvable one so an owner-side index bump (the
+/// pointer-key-compromise recovery) is discovered.
+///
+/// A resolvable-but-invalid payload (bad owner signature, tamper) stops the
+/// walk fail-closed at that index: it is never adopted and the walk never
+/// reaches beyond it, so a forged record cannot truncate the chain *below* an
+/// already-adopted valid index.
+pub async fn resolve_vault_pointer<F: PointerFetch>(
+    fetch: &F,
+    login_secret: &[u8],
+    owner_identity: &EcdsaVerifier,
+    root_scope_id: &[u8; 16],
+    payload_version: u64,
+) -> Result<Option<VaultPointerAdoption>, PointerError> {
+    let owner_seed = kdf::owner_pointer_seed(login_secret);
+    let read_key = kdf::pointer_read_key(owner_seed.as_bytes(), root_scope_id);
+
+    let mut best: Option<VaultPointerAdoption> = None;
+    let mut index = 0u64;
+    while index < MAX_VAULT_POINTER_PROBE {
+        let name = vault_pointer_name(login_secret, index);
+        match fetch.fetch(&name).await.map_err(PointerError::Seam)? {
+            // A gap: the chain ends here; the highest adopted below is the answer.
+            None => break,
+            Some(block) => match open_pointer_payload(
+                read_key.as_bytes(),
+                payload_version,
+                root_scope_id,
+                owner_identity,
+                &block,
+            ) {
+                Ok(repoint) => {
+                    best = Some(VaultPointerAdoption { index, repoint });
+                    index += 1;
+                }
+                // Fail-closed: an invalid payload is never adopted and stops the
+                // walk (a forged record cannot extend or masquerade the chain).
+                Err(e) => return Err(PointerError::Open(e)),
+            },
+        }
+    }
+    Ok(best)
+}
+
+/// Seal a re-point object for publication — **owner sessions only** (owner-
+/// plane write gate, #38 D1). The nonce is drawn from injected entropy
+/// (determinism law); the returned bytes are the sealed block to publish at the
+/// pointer name. A non-owner session is fail-closed with
+/// [`PointerError::NotOwnerSession`].
+pub fn seal_repoint(
+    session: SessionRole,
+    entropy: &mut dyn Entropy,
+    pointer_read_key: &[u8; 32],
+    payload_version: u64,
+    owner_signer: &EcdsaSigner,
+    object: &RepointObject,
+) -> Result<Vec<u8>, PointerError> {
+    if session != SessionRole::Owner {
+        return Err(PointerError::NotOwnerSession);
+    }
+    let mut nonce = [0u8; NONCE_LEN];
+    entropy.fill(&mut nonce).map_err(PointerError::Entropy)?;
+    Ok(seal_pointer_payload(
+        pointer_read_key,
+        &nonce,
+        payload_version,
+        owner_signer,
+        object,
+    ))
+}
+
+/// Open an authenticated re-point object from a fetched pointer block (the
+/// consult read path). A verify failure surfaces core's verdict verbatim —
+/// fail-closed, never reclassified as staleness.
+pub fn open_repoint(
+    pointer_read_key: &[u8; 32],
+    payload_version: u64,
+    scope_id: &[u8; 16],
+    owner_identity: &EcdsaVerifier,
+    block: &[u8],
+) -> Result<RepointObject, PointerError> {
+    open_pointer_payload(
+        pointer_read_key,
+        payload_version,
+        scope_id,
+        owner_identity,
+        block,
+    )
+    .map_err(PointerError::Open)
+}
+
+/// Cold-seed a scope's floors from an authenticated re-point object — the
+/// cold-start anchor. Delegates to the floor law's [`floor::cold_seed`]: the
+/// owner-vouched `minReadEpoch` seeds the read-epoch (revocation) floor and
+/// `writeEpoch` the write-epoch floor, both monotonic-max.
+///
+/// **Cold start adopts nothing** until this runs: before the floor store seeds
+/// from the owner-signed anchor, every scope's read-epoch floor is unseeded and
+/// the gate can be shown any old-epoch record. The non-circular sequence
+/// (#38 D3): own vault → vault/scope pointer (first act) → floors seeded →
+/// current root name → envelope grant blob → seeds → render.
+pub async fn cold_seed_floors<F: FloorStore>(
+    floors: &F,
+    repoint: &RepointObject,
+) -> Result<(), PointerError> {
+    floor::cold_seed(floors, repoint)
+        .await
+        .map_err(PointerError::Seam)
+}
+
+/// Advance the write-epoch floor on sight of an owner-vouched pointer
+/// `writeEpoch` (#38 D4). From that instant every old-epoch record at the old
+/// name fails the gate. Monotonic-max via the floor law.
+pub async fn advance_write_epoch_on_sight<F: FloorStore>(
+    floors: &F,
+    scope_id: &[u8; 16],
+    write_epoch: u64,
+) -> Result<u64, PointerError> {
+    floor::advance_write_epoch_on_sight(floors, scope_id, write_epoch)
+        .await
+        .map_err(PointerError::Seam)
+}
+
+/// Whether to consult the scope pointer now — the polled discipline, decided
+/// independently of any staleness signal. Consult on cold start, on the focus
+/// tick for an open shared scope, and on access to a cached shared scope past
+/// staleness. Never a staleness fallback (a forged old-epoch record that passes
+/// staleness must not suppress the consult, #38 D4).
+pub fn should_consult(
+    is_cold_start: bool,
+    is_open_shared_scope: bool,
+    accessed_past_staleness: bool,
+) -> Option<ConsultReason> {
+    if is_cold_start {
+        Some(ConsultReason::ColdStart)
+    } else if is_open_shared_scope {
+        Some(ConsultReason::FocusTick)
+    } else if accessed_past_staleness {
+        Some(ConsultReason::OnAccess)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use cipherbox_core::suite::ecdsa::EcdsaSigner;
+
+    use crate::testkit::{SeededEntropy, block_on};
+
+    // A deterministic owner identity for the fixtures.
+    fn owner_signer() -> EcdsaSigner {
+        EcdsaSigner::from_scalar(&[3u8; 32]).expect("valid scalar")
+    }
+
+    /// A scripted pointer network: names → sealed blocks; unknown names are
+    /// unresolvable (chain gaps).
+    #[derive(Clone, Default)]
+    struct ScriptedPointers {
+        blocks: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+    }
+
+    impl ScriptedPointers {
+        fn put(&self, name: &IpnsName, block: Vec<u8>) {
+            self.blocks
+                .lock()
+                .unwrap()
+                .insert(name.as_str().to_owned(), block);
+        }
+    }
+
+    impl PointerFetch for ScriptedPointers {
+        async fn fetch(&self, name: &IpnsName) -> SeamResult<Option<Vec<u8>>> {
+            Ok(self.blocks.lock().unwrap().get(name.as_str()).cloned())
+        }
+    }
+
+    fn repoint(scope_id: [u8; 16], min_read_epoch: u64, write_epoch: u64) -> RepointObject {
+        RepointObject {
+            scope_id,
+            current_root: vault_pointer_name(b"root-name-seed", 0),
+            write_epoch,
+            min_read_epoch,
+            prev_root: None,
+        }
+    }
+
+    const SECRET: &[u8] = b"login-secret-fixture-bytes";
+    const ROOT_SCOPE: [u8; 16] = [0u8; 16];
+
+    fn seal_index(
+        pointers: &ScriptedPointers,
+        owner: &EcdsaSigner,
+        index: u64,
+        object: &RepointObject,
+    ) {
+        let owner_seed = kdf::owner_pointer_seed(SECRET);
+        let read_key = kdf::pointer_read_key(owner_seed.as_bytes(), &ROOT_SCOPE);
+        let mut entropy = SeededEntropy::new(index);
+        let block = seal_repoint(
+            SessionRole::Owner,
+            &mut entropy,
+            read_key.as_bytes(),
+            1,
+            owner,
+            object,
+        )
+        .unwrap();
+        pointers.put(&vault_pointer_name(SECRET, index), block);
+    }
+
+    #[test]
+    fn owner_plane_seal_is_gated_to_owner_sessions() {
+        let mut entropy = SeededEntropy::new(9);
+        let owner_seed = kdf::owner_pointer_seed(SECRET);
+        let read_key = kdf::pointer_read_key(owner_seed.as_bytes(), &ROOT_SCOPE);
+        let err = seal_repoint(
+            SessionRole::Grantee,
+            &mut entropy,
+            read_key.as_bytes(),
+            1,
+            &owner_signer(),
+            &repoint(ROOT_SCOPE, 1, 1),
+        )
+        .expect_err("a grantee never writes the owner plane");
+        assert_eq!(err, PointerError::NotOwnerSession);
+    }
+
+    #[test]
+    fn vault_pointer_walk_adopts_the_highest_valid_index() {
+        let pointers = ScriptedPointers::default();
+        let owner = owner_signer();
+        // The owner authored indices 0, 1, 2; index 3 is a gap.
+        seal_index(&pointers, &owner, 0, &repoint(ROOT_SCOPE, 1, 1));
+        seal_index(&pointers, &owner, 1, &repoint(ROOT_SCOPE, 2, 1));
+        seal_index(&pointers, &owner, 2, &repoint(ROOT_SCOPE, 3, 2));
+
+        let adopted = block_on(resolve_vault_pointer(
+            &pointers,
+            SECRET,
+            &owner.verifying_key(),
+            &ROOT_SCOPE,
+            1,
+        ))
+        .unwrap()
+        .expect("a valid chain adopts");
+        assert_eq!(adopted.index, 2, "the highest valid index wins");
+        assert_eq!(adopted.repoint.min_read_epoch, 3);
+    }
+
+    #[test]
+    fn empty_chain_adopts_nothing() {
+        let pointers = ScriptedPointers::default();
+        let adopted = block_on(resolve_vault_pointer(
+            &pointers,
+            SECRET,
+            &owner_signer().verifying_key(),
+            &ROOT_SCOPE,
+            1,
+        ))
+        .unwrap();
+        assert_eq!(adopted, None, "cold start with no pointer adopts nothing");
+    }
+
+    #[test]
+    fn a_forged_index_stops_the_walk_fail_closed() {
+        let pointers = ScriptedPointers::default();
+        let owner = owner_signer();
+        seal_index(&pointers, &owner, 0, &repoint(ROOT_SCOPE, 1, 1));
+        // Index 1 is sealed by a DIFFERENT (rogue) identity: it must not open
+        // under the real owner and must fail the walk closed.
+        let rogue = EcdsaSigner::from_scalar(&[7u8; 32]).unwrap();
+        seal_index(&pointers, &rogue, 1, &repoint(ROOT_SCOPE, 99, 99));
+
+        let owner_identity = owner.verifying_key();
+        let result = resolve_vault_pointer(&pointers, SECRET, &owner_identity, &ROOT_SCOPE, 1);
+        let err = block_on(result).expect_err("a forged index is fail-closed");
+        assert!(matches!(err, PointerError::Open(_)));
+    }
+
+    #[test]
+    fn cold_seed_floors_then_old_epoch_records_are_below_floor() {
+        use crate::testkit::fakes::InMemoryFloorStore;
+        let floors = InMemoryFloorStore::default();
+        block_on(async {
+            // Before cold-seed the read-epoch floor is unseeded (adopts anything).
+            assert_eq!(
+                floor::read_epoch_floor(&floors, &ROOT_SCOPE).await.unwrap(),
+                None
+            );
+            cold_seed_floors(&floors, &repoint(ROOT_SCOPE, 5, 3))
+                .await
+                .unwrap();
+            assert_eq!(
+                floor::read_epoch_floor(&floors, &ROOT_SCOPE).await.unwrap(),
+                Some(5),
+                "minReadEpoch seeds the revocation floor"
+            );
+            assert_eq!(
+                floor::write_epoch_floor(&floors, &ROOT_SCOPE)
+                    .await
+                    .unwrap(),
+                Some(3)
+            );
+        });
+    }
+
+    #[test]
+    fn consult_is_polled_not_a_staleness_fallback() {
+        // Cold start and the focus tick consult regardless of any staleness.
+        assert_eq!(
+            should_consult(true, false, false),
+            Some(ConsultReason::ColdStart)
+        );
+        assert_eq!(
+            should_consult(false, true, false),
+            Some(ConsultReason::FocusTick)
+        );
+        assert_eq!(
+            should_consult(false, false, true),
+            Some(ConsultReason::OnAccess)
+        );
+        // A closed, fresh, cached scope is not consulted this tick.
+        assert_eq!(should_consult(false, false, false), None);
+    }
+}

--- a/crates/engine/src/sync/pointer.rs
+++ b/crates/engine/src/sync/pointer.rs
@@ -138,7 +138,7 @@ pub async fn resolve_vault_pointer<F: PointerFetch>(
         match fetch.fetch(&name).await.map_err(PointerError::Seam)? {
             // A gap: the chain ends here; the highest adopted below is the answer.
             None => break,
-            Some(block) => match open_pointer_payload(
+            Some(block) => match open_repoint(
                 read_key.as_bytes(),
                 payload_version,
                 root_scope_id,
@@ -151,7 +151,7 @@ pub async fn resolve_vault_pointer<F: PointerFetch>(
                 }
                 // Fail-closed: an invalid payload is never adopted and stops the
                 // walk (a forged record cannot extend or masquerade the chain).
-                Err(e) => return Err(PointerError::Open(e)),
+                Err(e) => return Err(e),
             },
         }
     }
@@ -220,19 +220,6 @@ pub async fn cold_seed_floors<F: FloorStore>(
     repoint: &RepointObject,
 ) -> Result<(), PointerError> {
     floor::cold_seed(floors, repoint)
-        .await
-        .map_err(PointerError::Seam)
-}
-
-/// Advance the write-epoch floor on sight of an owner-vouched pointer
-/// `writeEpoch` (#38 D4). From that instant every old-epoch record at the old
-/// name fails the gate. Monotonic-max via the floor law.
-pub async fn advance_write_epoch_on_sight<F: FloorStore>(
-    floors: &F,
-    scope_id: &[u8; 16],
-    write_epoch: u64,
-) -> Result<u64, PointerError> {
-    floor::advance_write_epoch_on_sight(floors, scope_id, write_epoch)
         .await
         .map_err(PointerError::Seam)
 }
@@ -442,5 +429,49 @@ mod tests {
         );
         // A closed, fresh, cached scope is not consulted this tick.
         assert_eq!(should_consult(false, false, false), None);
+    }
+
+    #[test]
+    fn scope_pointer_name_and_signer_agree_and_the_re_point_round_trips() {
+        let owner = owner_signer();
+        let scope: [u8; 16] = [9u8; 16];
+        let owner_seed = kdf::owner_pointer_seed(SECRET);
+
+        // The scope-pointer signer's public key IS the scope-pointer name — the
+        // signer is exactly the key that signs records published at that name.
+        let name = scope_pointer_name(owner_seed.as_bytes(), &scope);
+        let signer = scope_pointer_signer(owner_seed.as_bytes(), &scope);
+        assert_eq!(name, IpnsName::from_public_key(&signer.verifying_key()));
+
+        // A re-point sealed under the scope's stable pointer-read-key round-trips
+        // through the consult read path.
+        let read_key = kdf::pointer_read_key(owner_seed.as_bytes(), &scope);
+        let object = RepointObject {
+            scope_id: scope,
+            current_root: vault_pointer_name(b"some-root", 0),
+            write_epoch: 2,
+            min_read_epoch: 4,
+            prev_root: None,
+        };
+        let mut entropy = SeededEntropy::new(5);
+        let block = seal_repoint(
+            SessionRole::Owner,
+            &mut entropy,
+            read_key.as_bytes(),
+            1,
+            &owner,
+            &object,
+        )
+        .unwrap();
+        let opened = open_repoint(
+            read_key.as_bytes(),
+            1,
+            &scope,
+            &owner.verifying_key(),
+            &block,
+        )
+        .unwrap();
+        assert_eq!(opened.min_read_epoch, 4);
+        assert_eq!(opened.write_epoch, 2);
     }
 }

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -22,8 +22,10 @@
 //! Terminally unrebasable ops (access revoked while offline) **dead-letter**
 //! with their staged bytes preserved — nothing is silently dropped (#33 D6).
 
+use std::collections::HashSet;
+
 use crate::seams::OpId;
-use crate::sync::model::{NodeMeta, Snapshot, suffix_name};
+use crate::sync::model::{NodeMeta, Snapshot, collation_key, suffix_name};
 use crate::sync::op::{Op, OpKind};
 
 /// The highest auto-suffix a loser probes before dead-lettering — a folder
@@ -338,11 +340,23 @@ fn rebase_update_content(working: &mut Snapshot, local: &Snapshot, op: &Op) -> O
     // under a parent that still exists in gate-passing state.
     match (local.node(op.target), local.parent_of(op.target)) {
         (Some(meta), Some(parent)) if working.contains(parent) => {
+            // Re-link under the freed name only if it is still free: a concurrent
+            // sibling may have taken it, so route through the one collision
+            // resolver every other insert uses.
+            let (effective, suffixed) = match resolve_name(working, parent, &meta.name, op.target) {
+                Some(resolved) => resolved,
+                None => return OpResolution::DeadLetter(DeadLetterReason::SuffixExhausted),
+            };
             let mut resurrected = meta.clone();
+            resurrected.name = effective.clone();
             resurrected.content_version += 1;
             working.upsert_node(resurrected);
             working.link_next(parent, op.target);
-            OpResolution::applied(None)
+            OpResolution::Applied {
+                effective_name: Some(effective),
+                suffixed,
+                scope_exit_trigger: None,
+            }
         }
         _ => OpResolution::DeadLetter(DeadLetterReason::TargetGone),
     }
@@ -357,12 +371,20 @@ fn resolve_name(
     name: &str,
     exclude: crate::facade::NodeId,
 ) -> Option<(String, bool)> {
-    if !snap.name_taken(parent, name, Some(exclude)) {
+    // Fold the sibling collation keys once instead of rescanning the children on
+    // every probe — identical to `name_taken`, which folds the same set.
+    let taken: HashSet<String> = snap
+        .children(parent)
+        .into_iter()
+        .filter(|child| child.id != exclude)
+        .map(|child| collation_key(&child.name))
+        .collect();
+    if !taken.contains(&collation_key(name)) {
         return Some((name.to_owned(), false));
     }
     for n in 2..=MAX_SUFFIX_PROBE {
         let candidate = suffix_name(name, n);
-        if !snap.name_taken(parent, &candidate, Some(exclude)) {
+        if !taken.contains(&collation_key(&candidate)) {
             return Some((candidate, true));
         }
     }
@@ -389,19 +411,13 @@ pub fn observed_repair(snap: &Snapshot) -> Vec<Repair> {
     children.dedup();
 
     for child in children {
-        // One scan per child: pick the winner and the losers from the same set.
         let links = snap.links_to(child);
         if links.len() < 2 {
             continue;
         }
-        let winner = links
-            .iter()
-            .copied()
-            .max_by(|a, b| {
-                a.link_counter
-                    .cmp(&b.link_counter)
-                    .then(b.parent.cmp(&a.parent))
-            })
+        // The same dual-link tiebreak the model exposes — one comparator here too.
+        let winner = snap
+            .winning_link(child)
             .expect("a child with links has a winner");
         let remove: Vec<crate::facade::NodeId> = links
             .into_iter()
@@ -544,6 +560,90 @@ mod tests {
         assert!(matches!(res, OpResolution::Applied { .. }));
         assert!(working.contains(id(1)), "the edit resurrected the node");
         assert_eq!(working.parent_of(id(1)), Some(id(0)));
+    }
+
+    #[test]
+    fn resurrection_auto_suffixes_when_a_concurrent_create_took_the_freed_name() {
+        // Gate-passing state: the deleted node is gone, and a concurrent create
+        // already landed a sibling under the freed name.
+        let mut gate_passing = tree();
+        with_node(&mut gate_passing, id(0), id(2), "f.txt", NodeKind::File);
+        // Our overlay still holds the deleted node under its original name.
+        let mut local = tree();
+        with_node(&mut local, id(0), id(1), "f.txt", NodeKind::File);
+
+        let mut working = gate_passing.clone();
+        let res = rebase_one(
+            &mut working,
+            &local,
+            &Op::update_content(id(1), b"k".to_vec(), 1),
+        );
+        assert_eq!(
+            res,
+            OpResolution::Applied {
+                effective_name: Some("f (2).txt".to_owned()),
+                suffixed: true,
+                scope_exit_trigger: None,
+            },
+            "the resurrected node auto-suffixes off the taken name"
+        );
+        assert_eq!(working.node(id(1)).unwrap().name, "f (2).txt");
+        // Both siblings survive with distinct collation keys.
+        let keys: std::collections::HashSet<String> = working
+            .children(id(0))
+            .iter()
+            .map(|n| collation_key(&n.name))
+            .collect();
+        assert_eq!(
+            keys.len(),
+            2,
+            "distinct collation keys, no shadowed sibling"
+        );
+        assert!(
+            working.contains(id(1)) && working.contains(id(2)),
+            "both present"
+        );
+    }
+
+    #[test]
+    fn resurrection_dead_letters_under_a_saturated_parent() {
+        fn node_id(n: u32) -> NodeId {
+            let mut bytes = [0u8; 16];
+            bytes[..4].copy_from_slice(&n.to_le_bytes());
+            NodeId(bytes)
+        }
+        // Saturate the parent with every name the probe would try: "f.txt" plus
+        // "f (2).txt" .. "f (MAX).txt".
+        let mut gate_passing = tree();
+        with_node(
+            &mut gate_passing,
+            id(0),
+            node_id(1),
+            "f.txt",
+            NodeKind::File,
+        );
+        for n in 2..=MAX_SUFFIX_PROBE {
+            with_node(
+                &mut gate_passing,
+                id(0),
+                node_id(n),
+                &suffix_name("f.txt", n),
+                NodeKind::File,
+            );
+        }
+        // Our overlay still holds the concurrently-deleted node "f.txt".
+        let mut local = tree();
+        with_node(&mut local, id(0), id(1), "f.txt", NodeKind::File);
+
+        let res = rebase_one(
+            &mut gate_passing.clone(),
+            &local,
+            &Op::update_content(id(1), b"k".to_vec(), 1),
+        );
+        assert_eq!(
+            res,
+            OpResolution::DeadLetter(DeadLetterReason::SuffixExhausted)
+        );
     }
 
     #[test]

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -1,0 +1,675 @@
+//! The rebase engine — FIFO replay of the op queue onto gate-passing state,
+//! the five per-op race rules, dead-lettering, and dual-link observed repair
+//! (blueprint/engine.md "Sync core: Per-op rebase rules"; CONTEXT.md).
+//!
+//! Replay is FIFO in performed order through the standard rebase, and rebases
+//! **only onto gate-passing state** (#33 D5–D7): the caller resolves a fresh
+//! last-known-good snapshot (every record through the adoption gate) and hands
+//! it here as the base. Each op resolves to exactly one outcome — applied
+//! (possibly auto-suffixed), dropped, or dead-lettered — and an applied op
+//! advances the working base so later ops rebase onto the updated state.
+//!
+//! The five races, one rule each:
+//!
+//! | Race                | Rule                                                       |
+//! | ------------------- | ---------------------------------------------------------- |
+//! | Delete vs edit      | Conditional delete: drop if the target advanced (edit wins)|
+//! | Rename vs rename    | Parent-CAS serialized; the rebasing writer re-anchors, wins|
+//! | Add vs add          | Always visible; the loser auto-suffixes `name (2).ext`     |
+//! | Move                | Dest-first, presence-conditional source-remove; loser undoes|
+//! | Dual-link           | Observed repair; the link counter picks the loser          |
+//!
+//! Terminally unrebasable ops (access revoked while offline) **dead-letter**
+//! with their staged bytes preserved — nothing is silently dropped (#33 D6).
+
+use crate::seams::OpId;
+use crate::sync::model::{Link, NodeMeta, Snapshot, suffix_name};
+use crate::sync::op::{Op, OpDecodeError, OpKind};
+
+/// The highest auto-suffix a loser probes before dead-lettering — a folder
+/// jammed with this many colliding siblings is pathological, not a routine
+/// merge.
+const MAX_SUFFIX_PROBE: u32 = 10_000;
+
+/// How one op resolved against the working base.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpResolution {
+    /// The op applied onto the (possibly advanced) base.
+    Applied {
+        /// The name the op resolves to publish under — `Some` for create and
+        /// rename (auto-suffixed when `suffixed`), `None` otherwise.
+        effective_name: Option<String>,
+        /// The add/add auto-suffix fired.
+        suffixed: bool,
+        /// A cross-scope relink that left a granted source scope: the source
+        /// scope root whose scope-exit rotation is **queued** (this slice does
+        /// not rotate — CONTEXT.md #632 scope).
+        scope_exit_trigger: Option<crate::facade::NodeId>,
+    },
+    /// The op was dropped as a no-op or a lost race.
+    Dropped(DropReason),
+    /// The op is terminally unrebasable; the caller preserves its staged bytes.
+    DeadLetter(DeadLetterReason),
+}
+
+/// Why a rebasing op was dropped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DropReason {
+    /// Conditional delete: the target advanced past the op's snapshot by rebase
+    /// time — the concurrent edit wins in both directions.
+    TargetAdvanced,
+    /// The mutation is already reflected in gate-passing state (e.g. a delete
+    /// of an already-absent node, or a move already at its destination).
+    AlreadySatisfied,
+    /// A concurrent move won the child; this move undoes its own dest-add so
+    /// no orphan and no duplicate survives.
+    MoveRaceLost,
+}
+
+/// Why an op terminally dead-lettered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeadLetterReason {
+    /// The op's target/parent is absent from gate-passing state and cannot be
+    /// recreated — its scope was revoked (or the node hard-deleted) while the
+    /// op sat offline.
+    TargetGone,
+    /// A relink destination is absent from gate-passing state.
+    DestinationGone,
+    /// A folder is pathologically saturated with colliding names.
+    SuffixExhausted,
+    /// The durable op record failed to decode (corrupt or forward-version).
+    Undecodable,
+}
+
+/// One applied op, resolved for republish.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppliedOp {
+    /// The durable-queue id.
+    pub op_id: OpId,
+    /// The op as journaled.
+    pub op: Op,
+    /// The resolved name to publish under (create/rename; auto-suffixed on a
+    /// collision), `None` for ops that carry no name.
+    pub effective_name: Option<String>,
+    /// The add/add auto-suffix fired.
+    pub suffixed: bool,
+}
+
+/// The full replay result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplayReport {
+    /// Gate-passing base after every applied op — the state to publish from.
+    pub rebased: Snapshot,
+    /// Ops to (re)publish, in FIFO order.
+    pub applied: Vec<AppliedOp>,
+    /// Dropped ops (no-op or lost race) — silently discarded, never surfaced.
+    pub dropped: Vec<(OpId, DropReason)>,
+    /// Dead-lettered ops — surfaced to the host; staged bytes preserved.
+    pub dead_letters: Vec<(OpId, DeadLetterReason)>,
+    /// Scope-exit rotation triggers this replay queued (the source scope roots).
+    pub scope_exit_triggers: Vec<crate::facade::NodeId>,
+}
+
+/// Decoded op-queue entries, in FIFO order.
+pub type DecodedOps = Vec<(OpId, Op)>;
+
+/// Op-queue entries that failed to decode, tagged for dead-lettering.
+pub type UndecodableOps = Vec<(OpId, DeadLetterReason)>;
+
+/// Decode a raw durable op queue, dead-lettering any entry that fails to
+/// decode rather than aborting the whole replay.
+pub fn decode_queue(raw: &[(OpId, Vec<u8>)]) -> (DecodedOps, UndecodableOps) {
+    let mut ops = Vec::new();
+    let mut dead = Vec::new();
+    for (op_id, bytes) in raw {
+        match Op::decode(bytes) {
+            Ok(op) => ops.push((*op_id, op)),
+            Err(_e @ OpDecodeError { .. }) => dead.push((*op_id, DeadLetterReason::Undecodable)),
+        }
+    }
+    (ops, dead)
+}
+
+/// Replay `ops` FIFO onto the gate-passing base. `local` (the pre-rebase
+/// overlay view) supplies node metadata for the edit-resurrects-a-delete case
+/// — the only rule that must re-materialize a node the gate-passing base no
+/// longer carries.
+pub fn replay(gate_passing: &Snapshot, local: &Snapshot, ops: &[(OpId, Op)]) -> ReplayReport {
+    let mut working = gate_passing.clone();
+    let mut report = ReplayReport {
+        rebased: gate_passing.clone(),
+        applied: Vec::new(),
+        dropped: Vec::new(),
+        dead_letters: Vec::new(),
+        scope_exit_triggers: Vec::new(),
+    };
+
+    for (op_id, op) in ops {
+        match rebase_one(&mut working, local, op) {
+            OpResolution::Applied {
+                effective_name,
+                suffixed,
+                scope_exit_trigger,
+            } => {
+                if let Some(scope_root) = scope_exit_trigger {
+                    report.scope_exit_triggers.push(scope_root);
+                }
+                report.applied.push(AppliedOp {
+                    op_id: *op_id,
+                    op: op.clone(),
+                    effective_name,
+                    suffixed,
+                });
+            }
+            OpResolution::Dropped(reason) => report.dropped.push((*op_id, reason)),
+            OpResolution::DeadLetter(reason) => report.dead_letters.push((*op_id, reason)),
+        }
+    }
+
+    report.rebased = working;
+    report
+}
+
+/// Rebase one op onto the mutable working base and apply it. Returns the
+/// resolution and, on `Applied`, mutates `working` to reflect it.
+pub fn rebase_one(working: &mut Snapshot, local: &Snapshot, op: &Op) -> OpResolution {
+    match &op.kind {
+        OpKind::Create {
+            parent, name, kind, ..
+        } => rebase_create(working, op, *parent, name, *kind),
+        OpKind::Delete { target_sequence } => rebase_delete(working, op, *target_sequence),
+        OpKind::Rename { new_name } => rebase_rename(working, op, new_name),
+        OpKind::Relink {
+            from_parent,
+            new_parent,
+            exits_granted_source,
+            ..
+        } => rebase_relink(
+            working,
+            op,
+            *from_parent,
+            *new_parent,
+            *exits_granted_source,
+        ),
+        OpKind::UpdateContent { .. } => rebase_update_content(working, local, op),
+    }
+}
+
+/// Add vs add: always visible; the rebasing loser auto-suffixes.
+fn rebase_create(
+    working: &mut Snapshot,
+    op: &Op,
+    parent: crate::facade::NodeId,
+    name: &str,
+    kind: crate::facade::NodeKind,
+) -> OpResolution {
+    if working.contains(op.target) {
+        // Our own create already landed remotely (confirmed by a prior resolve).
+        return OpResolution::Dropped(DropReason::AlreadySatisfied);
+    }
+    if !working.contains(parent) {
+        return OpResolution::DeadLetter(DeadLetterReason::TargetGone);
+    }
+
+    let (effective, suffixed) = match resolve_name(working, parent, name, op.target) {
+        Some(resolved) => resolved,
+        None => return OpResolution::DeadLetter(DeadLetterReason::SuffixExhausted),
+    };
+
+    working.upsert_node(NodeMeta::new(op.target, effective.clone(), kind));
+    let counter = working.max_link_counter(op.target) + 1;
+    working.link(parent, op.target, counter);
+    OpResolution::Applied {
+        effective_name: Some(effective),
+        suffixed,
+        scope_exit_trigger: None,
+    }
+}
+
+/// Conditional delete: drop if the target advanced past the op's snapshot.
+fn rebase_delete(working: &mut Snapshot, op: &Op, target_sequence: u64) -> OpResolution {
+    match working.record_sequence(op.target) {
+        None => OpResolution::Dropped(DropReason::AlreadySatisfied),
+        Some(current) if current > target_sequence => {
+            // The target advanced by a concurrent edit — edit wins, delete drops.
+            OpResolution::Dropped(DropReason::TargetAdvanced)
+        }
+        Some(_) => {
+            working.remove_node(op.target);
+            OpResolution::Applied {
+                effective_name: None,
+                suffixed: false,
+                scope_exit_trigger: None,
+            }
+        }
+    }
+}
+
+/// Rename vs rename: serialized by the parent CAS; the rebasing writer
+/// re-anchors onto the fresh base and publishes at a higher sequence, so it
+/// wins. A rename into a name a concurrent add took auto-suffixes (one
+/// comparator everywhere).
+fn rebase_rename(working: &mut Snapshot, op: &Op, new_name: &str) -> OpResolution {
+    if !working.contains(op.target) {
+        return OpResolution::DeadLetter(DeadLetterReason::TargetGone);
+    }
+    let parent = working.parent_of(op.target);
+    let (effective, suffixed) = match parent {
+        Some(parent) => match resolve_name(working, parent, new_name, op.target) {
+            Some(resolved) => resolved,
+            None => return OpResolution::DeadLetter(DeadLetterReason::SuffixExhausted),
+        },
+        // The root has no parent scope to enforce sibling uniqueness against.
+        None => (new_name.to_owned(), false),
+    };
+    if let Some(node) = working.node_mut(op.target) {
+        node.name = effective.clone();
+    }
+    OpResolution::Applied {
+        effective_name: Some(effective),
+        suffixed,
+        scope_exit_trigger: None,
+    }
+}
+
+/// Move: dest-first publish, then a presence-conditional source-remove. A
+/// concurrent move that already relocated the child makes this op the race
+/// loser, which undoes its dest-add (no orphan, no duplicate).
+fn rebase_relink(
+    working: &mut Snapshot,
+    op: &Op,
+    from_parent: crate::facade::NodeId,
+    new_parent: crate::facade::NodeId,
+    exits_granted_source: bool,
+) -> OpResolution {
+    if !working.contains(op.target) {
+        return OpResolution::DeadLetter(DeadLetterReason::TargetGone);
+    }
+    if !working.contains(new_parent) {
+        return OpResolution::DeadLetter(DeadLetterReason::DestinationGone);
+    }
+
+    let scope_exit_trigger = exits_granted_source.then_some(from_parent);
+    match working.parent_of(op.target) {
+        // Already at the destination — our move (or an identical concurrent one)
+        // already landed.
+        Some(current) if current == new_parent => {
+            OpResolution::Dropped(DropReason::AlreadySatisfied)
+        }
+        // Still under the source we moved from: the normal dest-first + remove.
+        Some(current) if current == from_parent => {
+            let counter = working.max_link_counter(op.target) + 1;
+            working.link(new_parent, op.target, counter);
+            working.unlink(from_parent, op.target);
+            OpResolution::Applied {
+                effective_name: None,
+                suffixed: false,
+                scope_exit_trigger,
+            }
+        }
+        // A concurrent move relocated the child elsewhere: we are the race loser.
+        Some(_) => OpResolution::Dropped(DropReason::MoveRaceLost),
+        // No current parent (was at root / unlinked): dest-first still links it.
+        None => {
+            let counter = working.max_link_counter(op.target) + 1;
+            working.link(new_parent, op.target, counter);
+            OpResolution::Applied {
+                effective_name: None,
+                suffixed: false,
+                scope_exit_trigger,
+            }
+        }
+    }
+}
+
+/// Edit: applies onto a present target; onto a concurrently-deleted target the
+/// edit **resurrects** it from the local overlay view (edit wins in both
+/// directions). A target absent from both is a dead-letter.
+fn rebase_update_content(working: &mut Snapshot, local: &Snapshot, op: &Op) -> OpResolution {
+    if working.contains(op.target) {
+        if let Some(node) = working.node_mut(op.target) {
+            node.content_version += 1;
+        }
+        return OpResolution::Applied {
+            effective_name: None,
+            suffixed: false,
+            scope_exit_trigger: None,
+        };
+    }
+    // Resurrect a concurrently-deleted node from local knowledge, re-linking it
+    // under a parent that still exists in gate-passing state.
+    match (local.node(op.target), local.parent_of(op.target)) {
+        (Some(meta), Some(parent)) if working.contains(parent) => {
+            let mut resurrected = meta.clone();
+            resurrected.content_version += 1;
+            working.upsert_node(resurrected);
+            let counter = working.max_link_counter(op.target) + 1;
+            working.link(parent, op.target, counter);
+            OpResolution::Applied {
+                effective_name: None,
+                suffixed: false,
+                scope_exit_trigger: None,
+            }
+        }
+        _ => OpResolution::DeadLetter(DeadLetterReason::TargetGone),
+    }
+}
+
+/// Resolve a create/rename name against a parent's siblings: the entered name
+/// when free, else the lowest `name (n)` (n ≥ 2) that is free. `None` iff a
+/// pathological folder exhausts the probe.
+fn resolve_name(
+    snap: &Snapshot,
+    parent: crate::facade::NodeId,
+    name: &str,
+    exclude: crate::facade::NodeId,
+) -> Option<(String, bool)> {
+    if !snap.name_taken(parent, name, Some(exclude)) {
+        return Some((name.to_owned(), false));
+    }
+    for n in 2..=MAX_SUFFIX_PROBE {
+        let candidate = suffix_name(name, n);
+        if !snap.name_taken(parent, &candidate, Some(exclude)) {
+            return Some((candidate, true));
+        }
+    }
+    None
+}
+
+/// A dual-link observed repair: the losing links to remove for one child.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Repair {
+    /// The dual-linked child.
+    pub child: crate::facade::NodeId,
+    /// The losing links to remove (all but the winner).
+    pub remove: Vec<Link>,
+}
+
+/// Scan for dual-link crash residue: any child linked in more than one parent.
+/// The winner is the highest `link_counter` (ties by lowest parent id, a
+/// total cross-platform-stable order); every other link is a loser to remove.
+/// Any write-capable client that sees this publishes the fix (#33 D5).
+pub fn observed_repair(snap: &Snapshot) -> Vec<Repair> {
+    let mut repairs = Vec::new();
+    let mut children: Vec<crate::facade::NodeId> = snap.links().iter().map(|l| l.child).collect();
+    children.sort_unstable();
+    children.dedup();
+
+    for child in children {
+        let links = snap.links_to(child);
+        if links.len() < 2 {
+            continue;
+        }
+        let winner = snap
+            .winning_link(child)
+            .expect("a child with links has a winner");
+        let remove: Vec<Link> = links
+            .into_iter()
+            .filter(|l| l.parent != winner.parent)
+            .collect();
+        if !remove.is_empty() {
+            repairs.push(Repair { child, remove });
+        }
+    }
+    repairs
+}
+
+/// Apply observed repairs to a snapshot (removing losing links).
+pub fn apply_repairs(snap: &mut Snapshot, repairs: &[Repair]) {
+    for repair in repairs {
+        for link in &repair.remove {
+            snap.unlink(link.parent, repair.child);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::facade::{NodeId, NodeKind};
+
+    fn id(b: u8) -> NodeId {
+        NodeId([b; 16])
+    }
+
+    fn tree() -> Snapshot {
+        Snapshot::new(id(0))
+    }
+
+    fn with_node(snap: &mut Snapshot, parent: NodeId, node: NodeId, name: &str, kind: NodeKind) {
+        snap.upsert_node(NodeMeta::new(node, name, kind));
+        snap.link(parent, node, 1);
+    }
+
+    #[test]
+    fn conditional_delete_drops_when_the_target_advanced() {
+        let mut base = tree();
+        with_node(&mut base, id(0), id(1), "f", NodeKind::File);
+        base.node_mut(id(1)).unwrap().record_sequence = 5; // concurrent edit advanced it
+
+        // The delete snapshotted the target at sequence 3.
+        let local = base.clone();
+        let res = rebase_one(&mut base, &local, &Op::delete(id(1), 1, 3));
+        assert_eq!(res, OpResolution::Dropped(DropReason::TargetAdvanced));
+        assert!(base.contains(id(1)), "edit wins — the node survives");
+    }
+
+    #[test]
+    fn conditional_delete_applies_when_the_target_did_not_advance() {
+        let mut base = tree();
+        with_node(&mut base, id(0), id(1), "f", NodeKind::File);
+        base.node_mut(id(1)).unwrap().record_sequence = 3;
+
+        let local = base.clone();
+        let res = rebase_one(&mut base, &local, &Op::delete(id(1), 1, 3));
+        assert!(matches!(res, OpResolution::Applied { .. }));
+        assert!(!base.contains(id(1)));
+    }
+
+    #[test]
+    fn edit_resurrects_a_concurrently_deleted_node() {
+        let gate_passing = tree(); // the node was deleted remotely — absent here
+        let mut local = tree(); // our overlay still holds it
+        with_node(&mut local, id(0), id(1), "f", NodeKind::File);
+
+        let mut working = gate_passing.clone();
+        let res = rebase_one(
+            &mut working,
+            &local,
+            &Op::update_content(id(1), b"k".to_vec(), 1),
+        );
+        assert!(matches!(res, OpResolution::Applied { .. }));
+        assert!(working.contains(id(1)), "the edit resurrected the node");
+        assert_eq!(working.parent_of(id(1)), Some(id(0)));
+    }
+
+    #[test]
+    fn add_add_collision_auto_suffixes_the_loser() {
+        let mut base = tree();
+        // A concurrent add already took "a.txt" under the root.
+        with_node(&mut base, id(0), id(1), "a.txt", NodeKind::File);
+
+        let local = base.clone();
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::create(id(2), id(0), "a.txt", NodeKind::File, 1, None),
+        );
+        assert_eq!(
+            res,
+            OpResolution::Applied {
+                effective_name: Some("a (2).txt".to_owned()),
+                suffixed: true,
+                scope_exit_trigger: None,
+            }
+        );
+        assert_eq!(base.node(id(2)).unwrap().name, "a (2).txt");
+        // Both are visible.
+        assert_eq!(base.children(id(0)).len(), 2);
+    }
+
+    #[test]
+    fn rename_reanchors_onto_the_fresh_base_and_wins() {
+        let mut base = tree();
+        with_node(&mut base, id(0), id(1), "start.txt", NodeKind::File);
+        // A concurrent rename already moved it to "other.txt".
+        base.node_mut(id(1)).unwrap().name = "other.txt".into();
+
+        let local = base.clone();
+        let res = rebase_one(&mut base, &local, &Op::rename(id(1), "final.txt", 1));
+        assert!(matches!(
+            res,
+            OpResolution::Applied {
+                suffixed: false,
+                ..
+            }
+        ));
+        assert_eq!(
+            base.node(id(1)).unwrap().name,
+            "final.txt",
+            "the rebasing writer wins"
+        );
+    }
+
+    #[test]
+    fn move_dest_first_then_presence_conditional_source_remove() {
+        let mut base = tree();
+        with_node(&mut base, id(0), id(1), "dir", NodeKind::Folder);
+        with_node(&mut base, id(0), id(2), "f", NodeKind::File);
+
+        let local = base.clone();
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::relink(id(2), id(0), id(1), 1, false, false),
+        );
+        assert!(matches!(res, OpResolution::Applied { .. }));
+        assert_eq!(base.parent_of(id(2)), Some(id(1)), "dest-linked");
+        assert_eq!(base.children(id(0)).len(), 1, "source-removed, no orphan");
+    }
+
+    #[test]
+    fn move_race_loser_undoes_its_dest_add() {
+        let mut base = tree();
+        with_node(&mut base, id(0), id(1), "dirA", NodeKind::Folder);
+        with_node(&mut base, id(0), id(2), "dirB", NodeKind::Folder);
+        with_node(&mut base, id(0), id(3), "f", NodeKind::File);
+        // A concurrent move already relocated the child into dirB.
+        base.unlink(id(0), id(3));
+        base.link(id(2), id(3), 2);
+
+        // Our queued move was from root → dirA; the child is no longer at root.
+        let local = base.clone();
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::relink(id(3), id(0), id(1), 1, false, false),
+        );
+        assert_eq!(res, OpResolution::Dropped(DropReason::MoveRaceLost));
+        assert_eq!(
+            base.parent_of(id(3)),
+            Some(id(2)),
+            "the winning move stands"
+        );
+        assert!(base.children(id(1)).is_empty(), "no dest-add residue");
+    }
+
+    #[test]
+    fn cross_scope_move_out_of_a_granted_scope_queues_a_trigger_only() {
+        let mut base = tree();
+        with_node(&mut base, id(0), id(5), "granted", NodeKind::Folder);
+        with_node(&mut base, id(5), id(6), "dest", NodeKind::Folder);
+        with_node(&mut base, id(5), id(7), "moved", NodeKind::File);
+
+        let local = base.clone();
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::relink(id(7), id(5), id(6), 1, true, true),
+        );
+        assert_eq!(
+            res,
+            OpResolution::Applied {
+                effective_name: None,
+                suffixed: false,
+                scope_exit_trigger: Some(id(5)),
+            },
+            "the trigger is queued; no rotation happens in this slice"
+        );
+    }
+
+    #[test]
+    fn observed_repair_removes_the_lower_counter_link() {
+        let mut base = tree();
+        with_node(&mut base, id(0), id(1), "p1", NodeKind::Folder);
+        with_node(&mut base, id(0), id(2), "p2", NodeKind::Folder);
+        base.upsert_node(NodeMeta::new(id(3), "child", NodeKind::File));
+        base.link(id(1), id(3), 1);
+        base.link(id(2), id(3), 2); // the winner
+
+        let repairs = observed_repair(&base);
+        assert_eq!(repairs.len(), 1);
+        assert_eq!(repairs[0].child, id(3));
+        apply_repairs(&mut base, &repairs);
+        assert_eq!(base.links_to(id(3)).len(), 1);
+        assert_eq!(base.parent_of(id(3)), Some(id(2)), "higher counter kept");
+    }
+
+    #[test]
+    fn revoked_while_offline_op_dead_letters() {
+        // Gate-passing state no longer carries the granted parent (access revoked).
+        let gate_passing = tree();
+        let res = rebase_one(
+            &mut gate_passing.clone(),
+            &gate_passing,
+            &Op::create(
+                id(9),
+                id(8),
+                "x.txt",
+                NodeKind::File,
+                1,
+                Some(b"bytes".to_vec()),
+            ),
+        );
+        assert_eq!(res, OpResolution::DeadLetter(DeadLetterReason::TargetGone));
+    }
+
+    #[test]
+    fn replay_threads_the_base_and_buckets_every_outcome() {
+        let mut gate_passing = tree();
+        with_node(&mut gate_passing, id(0), id(1), "keep", NodeKind::Folder);
+
+        let ops = vec![
+            (
+                OpId(1),
+                Op::create(id(2), id(1), "a.txt", NodeKind::File, 1, None),
+            ),
+            (
+                OpId(2),
+                Op::create(id(3), id(1), "a.txt", NodeKind::File, 1, None),
+            ), // collides → suffix
+            (
+                OpId(3),
+                Op::create(id(4), id(99), "orphan", NodeKind::File, 1, None),
+            ), // dead-letter
+        ];
+        let report = replay(&gate_passing, &gate_passing, &ops);
+
+        assert_eq!(report.applied.len(), 2);
+        assert!(report.applied[1].suffixed);
+        assert_eq!(
+            report.dead_letters,
+            vec![(OpId(3), DeadLetterReason::TargetGone)]
+        );
+        assert_eq!(report.rebased.children(id(1)).len(), 2);
+    }
+
+    #[test]
+    fn decode_queue_dead_letters_corrupt_entries() {
+        let good = Op::rename(id(1), "n", 1).encode();
+        let raw = vec![(OpId(1), good), (OpId(2), b"garbage".to_vec())];
+        let (ops, dead) = decode_queue(&raw);
+        assert_eq!(ops.len(), 1);
+        assert_eq!(dead, vec![(OpId(2), DeadLetterReason::Undecodable)]);
+    }
+}

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -23,8 +23,8 @@
 //! with their staged bytes preserved — nothing is silently dropped (#33 D6).
 
 use crate::seams::OpId;
-use crate::sync::model::{Link, NodeMeta, Snapshot, suffix_name};
-use crate::sync::op::{Op, OpDecodeError, OpKind};
+use crate::sync::model::{NodeMeta, Snapshot, suffix_name};
+use crate::sync::op::{Op, OpKind};
 
 /// The highest auto-suffix a loser probes before dead-lettering — a folder
 /// jammed with this many colliding siblings is pathological, not a routine
@@ -124,7 +124,7 @@ pub fn decode_queue(raw: &[(OpId, Vec<u8>)]) -> (DecodedOps, UndecodableOps) {
     for (op_id, bytes) in raw {
         match Op::decode(bytes) {
             Ok(op) => ops.push((*op_id, op)),
-            Err(_e @ OpDecodeError { .. }) => dead.push((*op_id, DeadLetterReason::Undecodable)),
+            Err(_) => dead.push((*op_id, DeadLetterReason::Undecodable)),
         }
     }
     (ops, dead)
@@ -135,14 +135,13 @@ pub fn decode_queue(raw: &[(OpId, Vec<u8>)]) -> (DecodedOps, UndecodableOps) {
 /// — the only rule that must re-materialize a node the gate-passing base no
 /// longer carries.
 pub fn replay(gate_passing: &Snapshot, local: &Snapshot, ops: &[(OpId, Op)]) -> ReplayReport {
+    // The one necessary clone: rebase advances `working` but must never mutate
+    // the caller's gate-passing base.
     let mut working = gate_passing.clone();
-    let mut report = ReplayReport {
-        rebased: gate_passing.clone(),
-        applied: Vec::new(),
-        dropped: Vec::new(),
-        dead_letters: Vec::new(),
-        scope_exit_triggers: Vec::new(),
-    };
+    let mut applied = Vec::new();
+    let mut dropped = Vec::new();
+    let mut dead_letters = Vec::new();
+    let mut scope_exit_triggers = Vec::new();
 
     for (op_id, op) in ops {
         match rebase_one(&mut working, local, op) {
@@ -152,22 +151,40 @@ pub fn replay(gate_passing: &Snapshot, local: &Snapshot, ops: &[(OpId, Op)]) -> 
                 scope_exit_trigger,
             } => {
                 if let Some(scope_root) = scope_exit_trigger {
-                    report.scope_exit_triggers.push(scope_root);
+                    scope_exit_triggers.push(scope_root);
                 }
-                report.applied.push(AppliedOp {
+                applied.push(AppliedOp {
                     op_id: *op_id,
                     op: op.clone(),
                     effective_name,
                     suffixed,
                 });
             }
-            OpResolution::Dropped(reason) => report.dropped.push((*op_id, reason)),
-            OpResolution::DeadLetter(reason) => report.dead_letters.push((*op_id, reason)),
+            OpResolution::Dropped(reason) => dropped.push((*op_id, reason)),
+            OpResolution::DeadLetter(reason) => dead_letters.push((*op_id, reason)),
         }
     }
 
-    report.rebased = working;
-    report
+    ReplayReport {
+        rebased: working,
+        applied,
+        dropped,
+        dead_letters,
+        scope_exit_triggers,
+    }
+}
+
+impl OpResolution {
+    /// An applied op that carries no resolved name and no auto-suffix (delete,
+    /// move, content edit); `scope_exit_trigger` is the queued source scope
+    /// root, if any.
+    fn applied(scope_exit_trigger: Option<crate::facade::NodeId>) -> Self {
+        OpResolution::Applied {
+            effective_name: None,
+            suffixed: false,
+            scope_exit_trigger,
+        }
+    }
 }
 
 /// Rebase one op onto the mutable working base and apply it. Returns the
@@ -217,8 +234,7 @@ fn rebase_create(
     };
 
     working.upsert_node(NodeMeta::new(op.target, effective.clone(), kind));
-    let counter = working.max_link_counter(op.target) + 1;
-    working.link(parent, op.target, counter);
+    working.link_next(parent, op.target);
     OpResolution::Applied {
         effective_name: Some(effective),
         suffixed,
@@ -236,11 +252,7 @@ fn rebase_delete(working: &mut Snapshot, op: &Op, target_sequence: u64) -> OpRes
         }
         Some(_) => {
             working.remove_node(op.target);
-            OpResolution::Applied {
-                effective_name: None,
-                suffixed: false,
-                scope_exit_trigger: None,
-            }
+            OpResolution::applied(None)
         }
     }
 }
@@ -298,26 +310,16 @@ fn rebase_relink(
         }
         // Still under the source we moved from: the normal dest-first + remove.
         Some(current) if current == from_parent => {
-            let counter = working.max_link_counter(op.target) + 1;
-            working.link(new_parent, op.target, counter);
+            working.link_next(new_parent, op.target);
             working.unlink(from_parent, op.target);
-            OpResolution::Applied {
-                effective_name: None,
-                suffixed: false,
-                scope_exit_trigger,
-            }
+            OpResolution::applied(scope_exit_trigger)
         }
         // A concurrent move relocated the child elsewhere: we are the race loser.
         Some(_) => OpResolution::Dropped(DropReason::MoveRaceLost),
         // No current parent (was at root / unlinked): dest-first still links it.
         None => {
-            let counter = working.max_link_counter(op.target) + 1;
-            working.link(new_parent, op.target, counter);
-            OpResolution::Applied {
-                effective_name: None,
-                suffixed: false,
-                scope_exit_trigger,
-            }
+            working.link_next(new_parent, op.target);
+            OpResolution::applied(scope_exit_trigger)
         }
     }
 }
@@ -330,11 +332,7 @@ fn rebase_update_content(working: &mut Snapshot, local: &Snapshot, op: &Op) -> O
         if let Some(node) = working.node_mut(op.target) {
             node.content_version += 1;
         }
-        return OpResolution::Applied {
-            effective_name: None,
-            suffixed: false,
-            scope_exit_trigger: None,
-        };
+        return OpResolution::applied(None);
     }
     // Resurrect a concurrently-deleted node from local knowledge, re-linking it
     // under a parent that still exists in gate-passing state.
@@ -343,13 +341,8 @@ fn rebase_update_content(working: &mut Snapshot, local: &Snapshot, op: &Op) -> O
             let mut resurrected = meta.clone();
             resurrected.content_version += 1;
             working.upsert_node(resurrected);
-            let counter = working.max_link_counter(op.target) + 1;
-            working.link(parent, op.target, counter);
-            OpResolution::Applied {
-                effective_name: None,
-                suffixed: false,
-                scope_exit_trigger: None,
-            }
+            working.link_next(parent, op.target);
+            OpResolution::applied(None)
         }
         _ => OpResolution::DeadLetter(DeadLetterReason::TargetGone),
     }
@@ -376,13 +369,13 @@ fn resolve_name(
     None
 }
 
-/// A dual-link observed repair: the losing links to remove for one child.
+/// A dual-link observed repair: the losing parents to unlink from one child.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Repair {
     /// The dual-linked child.
     pub child: crate::facade::NodeId,
-    /// The losing links to remove (all but the winner).
-    pub remove: Vec<Link>,
+    /// The losing parents (every link but the winner's).
+    pub remove: Vec<crate::facade::NodeId>,
 }
 
 /// Scan for dual-link crash residue: any child linked in more than one parent.
@@ -396,16 +389,24 @@ pub fn observed_repair(snap: &Snapshot) -> Vec<Repair> {
     children.dedup();
 
     for child in children {
+        // One scan per child: pick the winner and the losers from the same set.
         let links = snap.links_to(child);
         if links.len() < 2 {
             continue;
         }
-        let winner = snap
-            .winning_link(child)
+        let winner = links
+            .iter()
+            .copied()
+            .max_by(|a, b| {
+                a.link_counter
+                    .cmp(&b.link_counter)
+                    .then(b.parent.cmp(&a.parent))
+            })
             .expect("a child with links has a winner");
-        let remove: Vec<Link> = links
+        let remove: Vec<crate::facade::NodeId> = links
             .into_iter()
             .filter(|l| l.parent != winner.parent)
+            .map(|l| l.parent)
             .collect();
         if !remove.is_empty() {
             repairs.push(Repair { child, remove });
@@ -414,12 +415,74 @@ pub fn observed_repair(snap: &Snapshot) -> Vec<Repair> {
     repairs
 }
 
-/// Apply observed repairs to a snapshot (removing losing links).
+/// Apply observed repairs to a snapshot (unlinking each losing parent).
 pub fn apply_repairs(snap: &mut Snapshot, repairs: &[Repair]) {
     for repair in repairs {
-        for link in &repair.remove {
-            snap.unlink(link.parent, repair.child);
+        for &parent in &repair.remove {
+            snap.unlink(parent, repair.child);
         }
+    }
+}
+
+/// How a confirm/resolve reconciles the local published head against the record
+/// the network now shows at the same name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HeadReconciliation {
+    /// The observed record is ours, or older/equal-and-identical: nothing
+    /// diverged.
+    Converged,
+    /// A concurrent writer landed a strictly-higher record — the classic lost
+    /// CAS race. Rebase local ops onto it and re-mint above `observed_sequence`.
+    LostRaceHigher {
+        /// The higher sequence a concurrent writer landed first.
+        observed_sequence: u64,
+    },
+    /// A **different** record at the **same** sequence — a same-sequence
+    /// split-brain. IPNS higher-sequence-wins cannot converge equal sequences,
+    /// so the deterministic tiebreak decides: the loser rebases its local ops
+    /// onto the winning sibling and re-mints at `sequence + 1`; the winner
+    /// holds, and the loser's strictly-higher re-mint then supersedes it
+    /// everywhere.
+    SameSequenceDivergence {
+        /// The contested sequence.
+        sequence: u64,
+        /// Whether our record won the deterministic tiebreak. When `false`, we
+        /// rebase local ops onto the observed sibling and re-mint above
+        /// `sequence`.
+        local_wins: bool,
+    },
+}
+
+/// Reconcile our published head (`local_record` at `local_sequence`) with a
+/// sibling record observed at the same name (`observed_record` at
+/// `observed_sequence`) — both already record-verified upstream by the gate.
+///
+/// This closes the same-sequence split-brain the publish confirm-by-re-resolve
+/// cannot resolve by sequence alone (deferred from the net publish slice, #692):
+/// two writers each mint a **different** record at `floor + 1`, both land, and
+/// higher-sequence-wins never picks between them. The tiebreak is a total order
+/// over the exact verified record bytes every client fetches, so all clients
+/// converge on the same canonical head with no shared state, and the loser's
+/// re-mint at `sequence + 1` makes the ordinary higher-sequence-wins machinery
+/// finish the job.
+pub fn reconcile_head(
+    local_record: &[u8],
+    local_sequence: u64,
+    observed_record: &[u8],
+    observed_sequence: u64,
+) -> HeadReconciliation {
+    use core::cmp::Ordering;
+    match observed_sequence.cmp(&local_sequence) {
+        Ordering::Greater => HeadReconciliation::LostRaceHigher { observed_sequence },
+        // Our head is strictly newer: the observed copy is stale, we are canonical.
+        Ordering::Less => HeadReconciliation::Converged,
+        // Same sequence: either an idempotent re-fetch of our own record, or a
+        // genuine split-brain broken by the byte-order tiebreak (smaller wins).
+        Ordering::Equal if observed_record == local_record => HeadReconciliation::Converged,
+        Ordering::Equal => HeadReconciliation::SameSequenceDivergence {
+            sequence: local_sequence,
+            local_wins: local_record < observed_record,
+        },
     }
 }
 
@@ -671,5 +734,55 @@ mod tests {
         let (ops, dead) = decode_queue(&raw);
         assert_eq!(ops.len(), 1);
         assert_eq!(dead, vec![(OpId(2), DeadLetterReason::Undecodable)]);
+    }
+
+    #[test]
+    fn reconcile_head_higher_sibling_is_a_lost_race() {
+        assert_eq!(
+            reconcile_head(b"local", 4, b"winner", 5),
+            HeadReconciliation::LostRaceHigher {
+                observed_sequence: 5
+            }
+        );
+    }
+
+    #[test]
+    fn reconcile_head_lower_or_identical_sibling_is_converged() {
+        // A strictly older observed copy — our head is canonical.
+        assert_eq!(
+            reconcile_head(b"local", 5, b"stale", 4),
+            HeadReconciliation::Converged
+        );
+        // The same record re-fetched (our own PUT / a byte-stable re-PUT).
+        assert_eq!(
+            reconcile_head(b"same", 5, b"same", 5),
+            HeadReconciliation::Converged
+        );
+    }
+
+    #[test]
+    fn reconcile_head_same_sequence_split_brain_is_broken_deterministically() {
+        // Two different records at the same sequence: exactly one side wins, and
+        // the two clients agree on which (the byte-order tiebreak is symmetric).
+        let a = b"aaa-record";
+        let b = b"bbb-record";
+        let from_a = reconcile_head(a, 7, b, 7);
+        let from_b = reconcile_head(b, 7, a, 7);
+        assert_eq!(
+            from_a,
+            HeadReconciliation::SameSequenceDivergence {
+                sequence: 7,
+                local_wins: true
+            },
+            "the lexicographically-smaller record is canonical"
+        );
+        assert_eq!(
+            from_b,
+            HeadReconciliation::SameSequenceDivergence {
+                sequence: 7,
+                local_wins: false
+            },
+            "the other client sees itself as the loser and re-mints above"
+        );
     }
 }

--- a/crates/engine/src/sync/staging.rs
+++ b/crates/engine/src/sync/staging.rs
@@ -37,6 +37,10 @@ pub enum StageOutcome {
 /// the budget, nothing is written; otherwise the bytes are staged under the
 /// op's staging key and the op is enqueued.
 ///
+/// `upload` is the **already-sealed** content payload (core's content-seal runs
+/// upstream in the content plane); no plaintext user content ever lands in the
+/// staging store at rest.
+///
 /// Fail-fast ordering: the budget is checked and the bytes staged **before**
 /// the op is enqueued, so a rejected upload leaves no dangling queue entry and
 /// an accepted one leaves no op referencing unstaged bytes.

--- a/crates/engine/src/sync/staging.rs
+++ b/crates/engine/src/sync/staging.rs
@@ -1,0 +1,217 @@
+//! Budgeted offline staging behind the [`StagingStore`] seam (blueprint/
+//! engine.md "Sync core: Ops"; #33 D6).
+//!
+//! Web reaches full offline parity: uploads stage into OPFS/IndexedDB behind
+//! the profile budget; **past the budget only new uploads fail fast, while
+//! metadata ops queue unbounded**. The op queue is the durable divergence and
+//! must never be capped — a delete or rename can always be journaled — but
+//! staged upload *bytes* are bounded so an offline device cannot exhaust host
+//! storage.
+
+use crate::profile::SyncTimingProfile;
+use crate::seams::{OpId, SeamResult, StagingStore};
+use crate::sync::op::Op;
+
+/// The outcome of staging one op.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StageOutcome {
+    /// The op was journaled; on a content op its bytes were staged too.
+    Queued {
+        /// The durable op-queue id.
+        op_id: OpId,
+    },
+    /// A content upload would exceed the profile staging budget: it fails fast
+    /// and **nothing** is journaled or staged (the mutation did not happen).
+    RejectedOverBudget {
+        /// Staged bytes already held.
+        staged: u64,
+        /// The upload's own byte length.
+        incoming: u64,
+        /// The profile budget.
+        budget: u64,
+    },
+}
+
+/// Stage one op. Metadata ops (no upload bytes) always enqueue, regardless of
+/// budget. A content op is fail-fast: if staged-total + its bytes would exceed
+/// the budget, nothing is written; otherwise the bytes are staged under the
+/// op's staging key and the op is enqueued.
+///
+/// Fail-fast ordering: the budget is checked and the bytes staged **before**
+/// the op is enqueued, so a rejected upload leaves no dangling queue entry and
+/// an accepted one leaves no op referencing unstaged bytes.
+pub async fn stage_op<S: StagingStore>(
+    store: &S,
+    profile: &SyncTimingProfile,
+    op: &Op,
+    upload: Option<&[u8]>,
+) -> SeamResult<StageOutcome> {
+    match (op.staging_key(), upload) {
+        (Some(key), Some(bytes)) => {
+            let staged = store.staged_bytes_total().await?;
+            let incoming = bytes.len() as u64;
+            // Saturating: an overflowing sum is unreachable under any real
+            // budget, and must still read as "over budget", never wrap to a
+            // spuriously-small total.
+            if staged.saturating_add(incoming) > profile.staging_budget_bytes {
+                return Ok(StageOutcome::RejectedOverBudget {
+                    staged,
+                    incoming,
+                    budget: profile.staging_budget_bytes,
+                });
+            }
+            store.put_staged_bytes(key, bytes).await?;
+            let op_id = store.enqueue_op(&op.encode()).await?;
+            Ok(StageOutcome::Queued { op_id })
+        }
+        // A content op with no bytes, or a metadata op: journal unbounded.
+        _ => {
+            let op_id = store.enqueue_op(&op.encode()).await?;
+            Ok(StageOutcome::Queued { op_id })
+        }
+    }
+}
+
+/// Staging keys held by the store that no queued op references — orphan
+/// residue from a rejected or superseded upload, safe to GC (#33 D6 staged-
+/// bytes hygiene).
+pub async fn orphan_staging_keys<S: StagingStore>(store: &S) -> SeamResult<Vec<Vec<u8>>> {
+    let queued = store.queued_ops().await?;
+    let referenced: Vec<Vec<u8>> = queued
+        .iter()
+        .filter_map(|(_, bytes)| Op::decode(bytes).ok())
+        .filter_map(|op| op.staging_key().map(<[u8]>::to_vec))
+        .collect();
+    let orphans = store
+        .staged_keys()
+        .await?
+        .into_iter()
+        .filter(|key| !referenced.contains(key))
+        .collect();
+    Ok(orphans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::facade::{NodeId, NodeKind};
+    use crate::testkit::block_on;
+    use crate::testkit::fakes::InMemoryStagingStore;
+
+    fn id(b: u8) -> NodeId {
+        NodeId([b; 16])
+    }
+
+    #[test]
+    fn metadata_ops_queue_unbounded_past_the_budget() {
+        let store = InMemoryStagingStore::default();
+        // A budget of zero: no upload byte fits, yet metadata must still queue.
+        let profile = SyncTimingProfile {
+            staging_budget_bytes: 0,
+            ..SyncTimingProfile::CI
+        };
+        block_on(async {
+            for i in 0..5 {
+                let out = stage_op(&store, &profile, &Op::rename(id(i), "n", 1), None)
+                    .await
+                    .unwrap();
+                assert!(matches!(out, StageOutcome::Queued { .. }));
+            }
+            assert_eq!(store.queued_ops().await.unwrap().len(), 5);
+        });
+    }
+
+    #[test]
+    fn upload_over_budget_fails_fast_and_stages_nothing() {
+        let store = InMemoryStagingStore::default();
+        let profile = SyncTimingProfile {
+            staging_budget_bytes: 8,
+            ..SyncTimingProfile::CI
+        };
+        block_on(async {
+            let op = Op::create(
+                id(1),
+                id(0),
+                "big",
+                NodeKind::File,
+                1,
+                Some(b"key".to_vec()),
+            );
+            let out = stage_op(&store, &profile, &op, Some(b"nine bytes"))
+                .await
+                .unwrap();
+            assert!(matches!(out, StageOutcome::RejectedOverBudget { .. }));
+            assert!(
+                store.queued_ops().await.unwrap().is_empty(),
+                "no dangling op"
+            );
+            assert_eq!(
+                store.staged_bytes_total().await.unwrap(),
+                0,
+                "no bytes staged"
+            );
+        });
+    }
+
+    #[test]
+    fn upload_within_budget_stages_bytes_and_queues_the_op() {
+        let store = InMemoryStagingStore::default();
+        let profile = SyncTimingProfile {
+            staging_budget_bytes: 1024,
+            ..SyncTimingProfile::CI
+        };
+        block_on(async {
+            let op = Op::create(id(1), id(0), "f", NodeKind::File, 1, Some(b"key".to_vec()));
+            let out = stage_op(&store, &profile, &op, Some(b"content"))
+                .await
+                .unwrap();
+            assert!(matches!(out, StageOutcome::Queued { .. }));
+            assert_eq!(
+                store.staged_bytes(b"key").await.unwrap(),
+                Some(b"content".to_vec())
+            );
+            assert_eq!(store.queued_ops().await.unwrap().len(), 1);
+        });
+    }
+
+    #[test]
+    fn budget_counts_cumulative_staged_bytes() {
+        let store = InMemoryStagingStore::default();
+        let profile = SyncTimingProfile {
+            staging_budget_bytes: 10,
+            ..SyncTimingProfile::CI
+        };
+        block_on(async {
+            let first = Op::create(id(1), id(0), "a", NodeKind::File, 1, Some(b"k1".to_vec()));
+            stage_op(&store, &profile, &first, Some(b"seven!!"))
+                .await
+                .unwrap(); // 7 bytes
+            // 7 + 5 = 12 > 10: the second upload fails fast.
+            let second = Op::create(id(2), id(0), "b", NodeKind::File, 1, Some(b"k2".to_vec()));
+            let out = stage_op(&store, &profile, &second, Some(b"fifty"))
+                .await
+                .unwrap();
+            assert!(matches!(out, StageOutcome::RejectedOverBudget { .. }));
+        });
+    }
+
+    #[test]
+    fn orphan_keys_are_the_unreferenced_staged_bytes() {
+        let store = InMemoryStagingStore::default();
+        let profile = SyncTimingProfile {
+            staging_budget_bytes: 1 << 20,
+            ..SyncTimingProfile::CI
+        };
+        block_on(async {
+            let op = Op::create(id(1), id(0), "f", NodeKind::File, 1, Some(b"live".to_vec()));
+            stage_op(&store, &profile, &op, Some(b"data"))
+                .await
+                .unwrap();
+            // A staged blob no op references (a rejected/superseded upload residue).
+            store.put_staged_bytes(b"orphan", b"stale").await.unwrap();
+
+            let orphans = orphan_staging_keys(&store).await.unwrap();
+            assert_eq!(orphans, vec![b"orphan".to_vec()]);
+        });
+    }
+}

--- a/crates/engine/src/sync/staging.rs
+++ b/crates/engine/src/sync/staging.rs
@@ -77,7 +77,7 @@ pub async fn stage_op<S: StagingStore>(
 /// bytes hygiene).
 pub async fn orphan_staging_keys<S: StagingStore>(store: &S) -> SeamResult<Vec<Vec<u8>>> {
     let queued = store.queued_ops().await?;
-    let referenced: Vec<Vec<u8>> = queued
+    let referenced: std::collections::HashSet<Vec<u8>> = queued
         .iter()
         .filter_map(|(_, bytes)| Op::decode(bytes).ok())
         .filter_map(|op| op.staging_key().map(<[u8]>::to_vec))

--- a/crates/engine/src/sync/staging.rs
+++ b/crates/engine/src/sync/staging.rs
@@ -9,7 +9,7 @@
 //! storage.
 
 use crate::profile::SyncTimingProfile;
-use crate::seams::{OpId, SeamResult, StagingStore};
+use crate::seams::{OpId, SeamError, SeamResult, StagingStore};
 use crate::sync::op::Op;
 
 /// The outcome of staging one op.
@@ -68,8 +68,14 @@ pub async fn stage_op<S: StagingStore>(
             let op_id = store.enqueue_op(&op.encode()).await?;
             Ok(StageOutcome::Queued { op_id })
         }
-        // A content op with no bytes, or a metadata op: journal unbounded.
-        _ => {
+        // A content op (staging key present) with no bytes is a broken caller
+        // contract: journaling it would leave a durable op referencing content
+        // that was never staged. Fail closed — enqueue nothing.
+        (Some(_), None) => Err(SeamError::new(
+            "stage_op: content op carries a staging key but no upload bytes",
+        )),
+        // A metadata op (no staging key): journal unbounded.
+        (None, _) => {
             let op_id = store.enqueue_op(&op.encode()).await?;
             Ok(StageOutcome::Queued { op_id })
         }
@@ -81,11 +87,20 @@ pub async fn stage_op<S: StagingStore>(
 /// bytes hygiene).
 pub async fn orphan_staging_keys<S: StagingStore>(store: &S) -> SeamResult<Vec<Vec<u8>>> {
     let queued = store.queued_ops().await?;
-    let referenced: std::collections::HashSet<Vec<u8>> = queued
-        .iter()
-        .filter_map(|(_, bytes)| Op::decode(bytes).ok())
-        .filter_map(|op| op.staging_key().map(<[u8]>::to_vec))
-        .collect();
+    let mut referenced = std::collections::HashSet::new();
+    for (_, bytes) in &queued {
+        match Op::decode(bytes) {
+            Ok(op) => {
+                if let Some(key) = op.staging_key() {
+                    referenced.insert(key.to_vec());
+                }
+            }
+            // An undecodable entry dead-letters with its staged bytes preserved
+            // (#33 D6); its staging key is unknowable, so nothing is safely an
+            // orphan this pass — fail closed.
+            Err(_) => return Ok(Vec::new()),
+        }
+    }
     let orphans = store
         .staged_keys()
         .await?
@@ -196,6 +211,47 @@ mod tests {
                 .await
                 .unwrap();
             assert!(matches!(out, StageOutcome::RejectedOverBudget { .. }));
+        });
+    }
+
+    #[test]
+    fn content_op_without_bytes_fails_closed_and_queues_nothing() {
+        let store = InMemoryStagingStore::default();
+        let profile = SyncTimingProfile {
+            staging_budget_bytes: 1024,
+            ..SyncTimingProfile::CI
+        };
+        block_on(async {
+            // A Create carrying a staging key but no upload bytes — a broken
+            // caller contract that must never journal a dangling content op.
+            let op = Op::create(id(1), id(0), "f", NodeKind::File, 1, Some(b"key".to_vec()));
+            let result = stage_op(&store, &profile, &op, None).await;
+            assert!(result.is_err(), "content op with no bytes fails closed");
+            assert!(
+                store.queued_ops().await.unwrap().is_empty(),
+                "nothing enqueued on the reject path"
+            );
+        });
+    }
+
+    #[test]
+    fn undecodable_queue_entry_makes_orphan_gc_conservative() {
+        let store = InMemoryStagingStore::default();
+        block_on(async {
+            // An undecodable/forward-version queue entry whose staging key is
+            // unknowable (its staged bytes are preserved by the dead-letter path).
+            store.enqueue_op(b"not a valid op").await.unwrap();
+            // A staged blob a naive scan would class as an orphan.
+            store
+                .put_staged_bytes(b"maybe-orphan", b"stale")
+                .await
+                .unwrap();
+
+            let orphans = orphan_staging_keys(&store).await.unwrap();
+            assert!(
+                orphans.is_empty(),
+                "an undecodable entry forbids classing anything an orphan"
+            );
         });
     }
 

--- a/crates/engine/src/sync/staleness.rs
+++ b/crates/engine/src/sync/staleness.rs
@@ -1,0 +1,193 @@
+//! The staleness ladder and the withheld-update escalation (blueprint/
+//! engine.md "Sync core: Staleness ladder"; #33 D4/D7, #38 D2).
+//!
+//! Availability staleness keeps cached views usable indefinitely — it is never
+//! an error. Errors are exactly two things: a trust violation (the adoption
+//! gate's job, never surfaced here) and an empty-cache cold start. The ladder
+//! is a pure function of the injected clock ([`Scheduler::now`]), the last
+//! successful reconcile, and connectivity — the engine never reads a clock
+//! directly.
+//!
+//! The withheld-update escalation is the sharper, shared-scope-only signal:
+//! one name pinned past the escalation window *while other resolves succeed*
+//! is not mere staleness — it is a targeted stale-view pin (it also covers the
+//! pointer-plane network-suppression residual, #38 D2).
+
+use crate::facade::Staleness;
+use crate::profile::SyncTimingProfile;
+use crate::seams::UnixMillis;
+
+/// Host connectivity as the engine observes it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Connectivity {
+    /// The network is reachable.
+    Online,
+    /// The network is unreachable (the offline banner rung).
+    Offline,
+}
+
+/// Classify the staleness rung. The ladder, top to bottom:
+///
+/// - `Offline` — connectivity is down.
+/// - `Reconciling` — a background reconcile is in flight (quiet indicator).
+/// - `Stale` — online and idle, but the last success is older than the
+///   profile threshold (`stale_after` ≈ 3 missed poll cycles).
+/// - `Fresh` — online and within the freshness window.
+///
+/// A cold cache (`last_success` is `None`) with no reconcile in flight while
+/// online is reported as `Reconciling`: the first tick is implied, and the
+/// empty-cache cold-start *error* is the caller's separate concern, not a
+/// staleness rung.
+pub fn classify(
+    now: UnixMillis,
+    last_success: Option<UnixMillis>,
+    reconcile_in_flight: bool,
+    connectivity: Connectivity,
+    profile: &SyncTimingProfile,
+) -> Staleness {
+    if connectivity == Connectivity::Offline {
+        return Staleness::Offline;
+    }
+    if reconcile_in_flight {
+        return Staleness::Reconciling;
+    }
+    match last_success {
+        None => Staleness::Reconciling,
+        Some(last) => {
+            let stale_after_ms = duration_ms(profile.stale_after);
+            if now.0.saturating_sub(last.0) >= stale_after_ms {
+                Staleness::Stale
+            } else {
+                Staleness::Fresh
+            }
+        }
+    }
+}
+
+/// Whether a shared-scope name pinned since `pinned_since` should raise the
+/// withheld-update escalation: shared scope, other resolves succeeding, and the
+/// pin older than the escalation window. A non-shared scope or a session where
+/// nothing else resolves never escalates (that is ordinary offline staleness).
+pub fn withheld_escalation(
+    now: UnixMillis,
+    pinned_since: UnixMillis,
+    is_shared_scope: bool,
+    other_resolves_succeeding: bool,
+    profile: &SyncTimingProfile,
+) -> bool {
+    is_shared_scope
+        && other_resolves_succeeding
+        && now.0.saturating_sub(pinned_since.0) >= duration_ms(profile.escalation_window)
+}
+
+/// A [`core::time::Duration`] as whole milliseconds, saturating (mirrors the
+/// scheduler's millisecond clock).
+fn duration_ms(duration: core::time::Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const P: SyncTimingProfile = SyncTimingProfile::PRODUCTION; // stale_after 90 s, escalation 600 s
+
+    #[test]
+    fn offline_beats_every_other_rung() {
+        assert_eq!(
+            classify(
+                UnixMillis(0),
+                Some(UnixMillis(0)),
+                true,
+                Connectivity::Offline,
+                &P
+            ),
+            Staleness::Offline
+        );
+    }
+
+    #[test]
+    fn reconcile_in_flight_shows_reconciling() {
+        assert_eq!(
+            classify(
+                UnixMillis(1_000),
+                Some(UnixMillis(0)),
+                true,
+                Connectivity::Online,
+                &P
+            ),
+            Staleness::Reconciling
+        );
+    }
+
+    #[test]
+    fn fresh_then_stale_across_the_threshold() {
+        let last = UnixMillis(0);
+        // 89 s < 90 s → fresh.
+        assert_eq!(
+            classify(
+                UnixMillis(89_000),
+                Some(last),
+                false,
+                Connectivity::Online,
+                &P
+            ),
+            Staleness::Fresh
+        );
+        // 90 s ≥ 90 s → stale.
+        assert_eq!(
+            classify(
+                UnixMillis(90_000),
+                Some(last),
+                false,
+                Connectivity::Online,
+                &P
+            ),
+            Staleness::Stale
+        );
+    }
+
+    #[test]
+    fn cold_cache_online_is_reconciling_not_an_error_rung() {
+        assert_eq!(
+            classify(UnixMillis(10_000), None, false, Connectivity::Online, &P),
+            Staleness::Reconciling
+        );
+    }
+
+    #[test]
+    fn escalation_needs_shared_scope_and_other_successes() {
+        // 600 s pinned, shared, others succeeding → escalate.
+        assert!(withheld_escalation(
+            UnixMillis(600_000),
+            UnixMillis(0),
+            true,
+            true,
+            &P
+        ));
+        // Not shared → never.
+        assert!(!withheld_escalation(
+            UnixMillis(600_000),
+            UnixMillis(0),
+            false,
+            true,
+            &P
+        ));
+        // Nothing else resolving → ordinary offline staleness, not a targeted pin.
+        assert!(!withheld_escalation(
+            UnixMillis(600_000),
+            UnixMillis(0),
+            true,
+            false,
+            &P
+        ));
+        // Within the window → not yet.
+        assert!(!withheld_escalation(
+            UnixMillis(599_000),
+            UnixMillis(0),
+            true,
+            true,
+            &P
+        ));
+    }
+}

--- a/crates/engine/src/sync/staleness.rs
+++ b/crates/engine/src/sync/staleness.rs
@@ -54,7 +54,7 @@ pub fn classify(
     match last_success {
         None => Staleness::Reconciling,
         Some(last) => {
-            let stale_after_ms = duration_ms(profile.stale_after);
+            let stale_after_ms = crate::sync::duration_millis(profile.stale_after);
             if now.0.saturating_sub(last.0) >= stale_after_ms {
                 Staleness::Stale
             } else {
@@ -77,13 +77,8 @@ pub fn withheld_escalation(
 ) -> bool {
     is_shared_scope
         && other_resolves_succeeding
-        && now.0.saturating_sub(pinned_since.0) >= duration_ms(profile.escalation_window)
-}
-
-/// A [`core::time::Duration`] as whole milliseconds, saturating (mirrors the
-/// scheduler's millisecond clock).
-fn duration_ms(duration: core::time::Duration) -> u64 {
-    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+        && now.0.saturating_sub(pinned_since.0)
+            >= crate::sync::duration_millis(profile.escalation_window)
 }
 
 #[cfg(test)]

--- a/crates/engine/src/sync/tick.rs
+++ b/crates/engine/src/sync/tick.rs
@@ -107,8 +107,7 @@ pub fn on_access_refresh_due(
     last_refreshed: UnixMillis,
     profile: &SyncTimingProfile,
 ) -> bool {
-    let stale_after = u64::try_from(profile.stale_after.as_millis()).unwrap_or(u64::MAX);
-    now.0.saturating_sub(last_refreshed.0) >= stale_after
+    now.0.saturating_sub(last_refreshed.0) >= crate::sync::duration_millis(profile.stale_after)
 }
 
 /// The poll cadence with jitter drawn from injected entropy:

--- a/crates/engine/src/sync/tick.rs
+++ b/crates/engine/src/sync/tick.rs
@@ -1,0 +1,350 @@
+//! The focus-window tick — the one sync model driven by two trigger sources
+//! (blueprint/engine.md "Sync core"; CONTEXT.md "Focus window"; #33 D2).
+//!
+//! One model, two triggers: web drives it from navigation and the poll timer,
+//! desktop from FUSE-op TTL checks — the loop is identical. A tick refreshes
+//! the **focus window**: the vault pointer, the open folder, its full ancestor
+//! chain to root, the scope pointers of open shared scopes, and the mailbox
+//! poll — everything else refreshes on access past the staleness threshold, so
+//! there is no background churn over the whole tree. Immediate ticks fire on a
+//! [`RefreshHintSource`] event; the poll cadence is jittered from injected
+//! entropy (the engine never sleeps a raw library default and never reads an
+//! RNG directly).
+
+use core::future::Future;
+use core::pin::pin;
+use core::task::Poll;
+use core::time::Duration;
+
+use crate::entropy::Entropy;
+use crate::facade::NodeId;
+use crate::profile::SyncTimingProfile;
+use crate::seams::{RefreshHintSource, Scheduler, UnixMillis};
+use crate::sync::model::Snapshot;
+
+/// The maximum jitter added to the poll cadence, as a fraction denominator: the
+/// tick sleeps `[cadence, cadence + cadence/JITTER_DIVISOR)` so concurrent
+/// clients spread their polls (thundering-herd avoidance) without ever
+/// polling *faster* than the cadence.
+const JITTER_DIVISOR: u32 = 2;
+
+/// The open focus of the UI: the folder in view and any open shared scopes.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FocusWindow {
+    /// The open folder driving the window; `None` when no folder is open.
+    pub open_folder: Option<NodeId>,
+    /// Scope roots of shared scopes currently open (their scope pointers ride
+    /// the tick, #38 D4).
+    pub open_shared_scopes: Vec<NodeId>,
+}
+
+/// One target a tick refreshes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FocusTarget {
+    /// The indexed vault pointer (the cold-boot entry point; every tick).
+    VaultPointer,
+    /// An open shared scope's scope pointer (polled, not fallback).
+    ScopePointer(NodeId),
+    /// The mailbox poll rides the same tick (#34 D5).
+    MailboxPoll,
+    /// A folder record (the open folder and each ancestor to root).
+    Folder(NodeId),
+}
+
+/// What woke a tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TickCause {
+    /// The jittered poll timer elapsed.
+    Poll,
+    /// A [`RefreshHintSource`] event forced an immediate tick.
+    Hint,
+    /// A host `ManualRefresh` — resolves with nocache semantics everywhere.
+    Manual,
+}
+
+/// How a tick resolves records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolveMode {
+    /// Cache-first: last-known-good renders immediately, reconcile behind it.
+    CacheFirst,
+    /// Nocache: bypass the cache and resolve fresh (manual refresh, #33 D4).
+    NoCache,
+}
+
+/// The resolve mode for a tick cause: manual refresh is nocache everywhere,
+/// every other cause is cache-first.
+pub fn resolve_mode(cause: TickCause) -> ResolveMode {
+    match cause {
+        TickCause::Manual => ResolveMode::NoCache,
+        TickCause::Poll | TickCause::Hint => ResolveMode::CacheFirst,
+    }
+}
+
+/// The focus set a tick refreshes, deterministically ordered: the vault pointer
+/// first (cold-boot anchor), then open shared-scope pointers (polled
+/// discipline), the mailbox poll, then the open folder and its ancestor chain
+/// to root. Everything else is out of the window (on-access refresh only).
+pub fn focus_set(snapshot: &Snapshot, focus: &FocusWindow) -> Vec<FocusTarget> {
+    let mut targets = vec![FocusTarget::VaultPointer];
+    for scope in &focus.open_shared_scopes {
+        targets.push(FocusTarget::ScopePointer(*scope));
+    }
+    targets.push(FocusTarget::MailboxPoll);
+    if let Some(open) = focus.open_folder {
+        targets.push(FocusTarget::Folder(open));
+        for ancestor in snapshot.ancestors(open) {
+            targets.push(FocusTarget::Folder(ancestor));
+        }
+    }
+    targets
+}
+
+/// Whether a cached folder outside the focus window is due for an on-access
+/// refresh: it was last refreshed longer ago than the staleness threshold. No
+/// background churn — this fires only when the folder is actually accessed.
+pub fn on_access_refresh_due(
+    now: UnixMillis,
+    last_refreshed: UnixMillis,
+    profile: &SyncTimingProfile,
+) -> bool {
+    let stale_after = u64::try_from(profile.stale_after.as_millis()).unwrap_or(u64::MAX);
+    now.0.saturating_sub(last_refreshed.0) >= stale_after
+}
+
+/// The poll cadence with jitter drawn from injected entropy:
+/// `[cadence, cadence + cadence/JITTER_DIVISOR)`. Deterministic for a given
+/// entropy stream (the determinism law); a zero cadence stays zero.
+pub fn jittered_cadence(cadence: Duration, entropy: &mut dyn Entropy) -> Duration {
+    let span = cadence / JITTER_DIVISOR;
+    if span.is_zero() {
+        return cadence;
+    }
+    let mut bytes = [0u8; 8];
+    // Entropy is fail-closed elsewhere; jitter is best-effort scheduling, so a
+    // (practically impossible) fill error degrades to the un-jittered cadence
+    // rather than propagating — losing jitter costs only herd spread, never
+    // correctness.
+    if entropy.fill(&mut bytes).is_err() {
+        return cadence;
+    }
+    let span_nanos = span.as_nanos().max(1);
+    let offset = (u128::from(u64::from_le_bytes(bytes)) % span_nanos) as u64;
+    cadence + Duration::from_nanos(offset)
+}
+
+/// A tick loop's control signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TickControl {
+    /// Keep polling.
+    Continue,
+    /// Stop the loop (logout / shutdown).
+    Stop,
+}
+
+/// What woke the tick-loop wait.
+enum TickWake {
+    /// The jittered timer elapsed.
+    Timer,
+    /// A hint arrived (`None` = the source closed for good).
+    Hint(bool),
+}
+
+/// Wait for the next tick: whichever of the jittered timer or the next refresh
+/// hint fires first. The hint is polled first, so an already-queued hint yields
+/// an immediate tick without waiting on the timer.
+async fn wait_for_tick<Sch, H>(scheduler: &Sch, hints: &mut H, delay: Duration) -> TickWake
+where
+    Sch: Scheduler,
+    H: RefreshHintSource,
+{
+    let mut sleep = pin!(scheduler.sleep(delay));
+    let mut hint = pin!(hints.next_hint());
+    core::future::poll_fn(|cx| {
+        if let Poll::Ready(h) = hint.as_mut().poll(cx) {
+            return Poll::Ready(TickWake::Hint(h.is_some()));
+        }
+        if sleep.as_mut().poll(cx).is_ready() {
+            return Poll::Ready(TickWake::Timer);
+        }
+        Poll::Pending
+    })
+    .await
+}
+
+/// Run the focus-window tick loop until `on_tick` returns [`TickControl::Stop`]
+/// or the hint source closes. Each iteration sleeps a freshly-jittered cadence
+/// but wakes immediately on a refresh hint; `on_tick` performs the actual focus
+/// resolve (the net/pointer wiring the caller composes) and decides whether to
+/// continue.
+pub async fn run_tick_loop<Sch, H, F, Fut>(
+    scheduler: &Sch,
+    hints: &mut H,
+    entropy: &mut dyn Entropy,
+    profile: &SyncTimingProfile,
+    mut on_tick: F,
+) where
+    Sch: Scheduler,
+    H: RefreshHintSource,
+    F: FnMut(TickCause) -> Fut,
+    Fut: Future<Output = TickControl>,
+{
+    loop {
+        let delay = jittered_cadence(profile.poll_cadence, entropy);
+        let cause = match wait_for_tick(scheduler, hints, delay).await {
+            TickWake::Timer => TickCause::Poll,
+            TickWake::Hint(true) => TickCause::Hint,
+            // The source closed for good: stop listening (host shutdown).
+            TickWake::Hint(false) => break,
+        };
+        if on_tick(cause).await == TickControl::Stop {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    use crate::facade::NodeKind;
+    use crate::sync::model::NodeMeta;
+    use crate::testkit::fakes::{ManualHintSource, VirtualScheduler};
+    use crate::testkit::{SeededEntropy, block_on};
+
+    fn id(b: u8) -> NodeId {
+        NodeId([b; 16])
+    }
+
+    #[test]
+    fn focus_set_is_vault_scopes_mailbox_then_the_folder_chain() {
+        let mut snap = Snapshot::new(id(0));
+        snap.upsert_node(NodeMeta::new(id(1), "a", NodeKind::Folder));
+        snap.upsert_node(NodeMeta::new(id(2), "b", NodeKind::Folder));
+        snap.link(id(0), id(1), 1);
+        snap.link(id(1), id(2), 1);
+
+        let focus = FocusWindow {
+            open_folder: Some(id(2)),
+            open_shared_scopes: vec![id(7)],
+        };
+        assert_eq!(
+            focus_set(&snap, &focus),
+            vec![
+                FocusTarget::VaultPointer,
+                FocusTarget::ScopePointer(id(7)),
+                FocusTarget::MailboxPoll,
+                FocusTarget::Folder(id(2)),
+                FocusTarget::Folder(id(1)),
+                FocusTarget::Folder(id(0)),
+            ]
+        );
+    }
+
+    #[test]
+    fn focus_set_with_no_open_folder_is_pointer_and_mailbox_only() {
+        let snap = Snapshot::new(id(0));
+        assert_eq!(
+            focus_set(&snap, &FocusWindow::default()),
+            vec![FocusTarget::VaultPointer, FocusTarget::MailboxPoll]
+        );
+    }
+
+    #[test]
+    fn manual_refresh_is_nocache_others_cache_first() {
+        assert_eq!(resolve_mode(TickCause::Manual), ResolveMode::NoCache);
+        assert_eq!(resolve_mode(TickCause::Poll), ResolveMode::CacheFirst);
+        assert_eq!(resolve_mode(TickCause::Hint), ResolveMode::CacheFirst);
+    }
+
+    #[test]
+    fn on_access_refresh_only_past_the_threshold() {
+        let p = SyncTimingProfile::PRODUCTION; // stale_after 90 s
+        assert!(!on_access_refresh_due(
+            UnixMillis(89_000),
+            UnixMillis(0),
+            &p
+        ));
+        assert!(on_access_refresh_due(UnixMillis(90_000), UnixMillis(0), &p));
+    }
+
+    #[test]
+    fn jitter_is_deterministic_and_bounded() {
+        let cadence = Duration::from_secs(30);
+        let a = jittered_cadence(cadence, &mut SeededEntropy::new(42));
+        let b = jittered_cadence(cadence, &mut SeededEntropy::new(42));
+        assert_eq!(a, b, "same entropy stream, same jitter");
+        assert!(a >= cadence, "jitter never polls faster than the cadence");
+        assert!(a < cadence + cadence / JITTER_DIVISOR, "jitter is bounded");
+    }
+
+    #[test]
+    fn jitter_zero_cadence_stays_zero() {
+        assert_eq!(
+            jittered_cadence(Duration::ZERO, &mut SeededEntropy::new(1)),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn a_queued_hint_forces_an_immediate_tick_without_advancing_time() {
+        let scheduler = VirtualScheduler::new(); // manual clock, never advanced here
+        let source = ManualHintSource::default();
+        let mut listener = source.clone();
+        let mut entropy = SeededEntropy::new(1);
+        let causes = RefCell::new(Vec::new());
+
+        source.push_hint();
+        source.push_hint();
+        source.close();
+
+        block_on(run_tick_loop(
+            &scheduler,
+            &mut listener,
+            &mut entropy,
+            &SyncTimingProfile::PRODUCTION,
+            |cause| {
+                causes.borrow_mut().push(cause);
+                async { TickControl::Continue }
+            },
+        ));
+
+        assert_eq!(
+            causes.into_inner(),
+            vec![TickCause::Hint, TickCause::Hint],
+            "both hints ticked immediately; the close stopped the loop"
+        );
+        assert_eq!(scheduler.now(), UnixMillis(0), "no timer ever elapsed");
+    }
+
+    #[test]
+    fn the_poll_timer_ticks_on_the_jittered_cadence() {
+        let scheduler = VirtualScheduler::new().with_auto_advance();
+        let source = ManualHintSource::default(); // no hints
+        let mut listener = source.clone();
+        let mut entropy = SeededEntropy::new(7);
+        let ticks = RefCell::new(0u32);
+
+        block_on(run_tick_loop(
+            &scheduler,
+            &mut listener,
+            &mut entropy,
+            &SyncTimingProfile::CI,
+            |cause| {
+                assert_eq!(cause, TickCause::Poll);
+                *ticks.borrow_mut() += 1;
+                let stop = *ticks.borrow() == 3;
+                async move {
+                    if stop {
+                        TickControl::Stop
+                    } else {
+                        TickControl::Continue
+                    }
+                }
+            },
+        ));
+
+        assert_eq!(ticks.into_inner(), 3, "the timer drove three poll ticks");
+        assert!(scheduler.now() > UnixMillis(0), "virtual time advanced");
+    }
+}

--- a/crates/engine/tests/sync.rs
+++ b/crates/engine/tests/sync.rs
@@ -1,0 +1,576 @@
+//! The sync-core simulation harness — the issue #632 gate mirrored 1:1
+//! (blueprint/engine.md "Sync core", "Pointer planes"; blueprint/testing.md
+//! "the simulation harness").
+//!
+//! No network, no docker, no wall clock: the whole sync core runs in memory on
+//! the test kit's fakes and virtual clock. The five-race table, offline queue
+//! replay, dead-letter on revoked-while-offline, the staging-budget fail-fast,
+//! the staleness ladder and escalation, the keyless-re-PUT adversary, and the
+//! cold-start-adopts-nothing sequence each get a narrative here, driven only
+//! through the engine's public sync surface.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use cipherbox_core::ipns::IpnsName;
+use cipherbox_core::kdf;
+use cipherbox_core::payload::RepointObject;
+use cipherbox_core::suite::ecdsa::EcdsaSigner;
+
+use cipherbox_engine::gate::floor;
+use cipherbox_engine::profile::SyncTimingProfile;
+use cipherbox_engine::seams::{SeamResult, StagingStore, UnixMillis};
+use cipherbox_engine::sync::model::NodeMeta;
+use cipherbox_engine::sync::pointer::{seal_repoint, vault_pointer_name};
+use cipherbox_engine::sync::{
+    self, Connectivity, DeadLetterReason, DropReason, Op, OpResolution, PointerFetch, SessionRole,
+    Snapshot, StageOutcome, apply_repairs, classify, cold_seed_floors, decode_queue,
+    observed_repair, rebase_one, replay, resolve_vault_pointer, stage_op, withheld_escalation,
+};
+use cipherbox_engine::testkit::fakes::{InMemoryFloorStore, InMemoryStagingStore};
+use cipherbox_engine::testkit::{SeededEntropy, block_on};
+use cipherbox_engine::{NodeId, NodeKind, Staleness};
+
+fn id(b: u8) -> NodeId {
+    NodeId([b; 16])
+}
+
+fn with_child(snap: &mut Snapshot, parent: NodeId, node: NodeId, name: &str, kind: NodeKind) {
+    snap.upsert_node(NodeMeta::new(node, name, kind));
+    snap.link(parent, node, 1);
+}
+
+// ---------------------------------------------------------------------------
+// The five-race table, mirrored 1:1 (blueprint/engine.md rebase rules).
+// Each is a two-client narrative: the "other" client's change is the fresh
+// gate-passing base our queued op rebases onto.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn race_1_delete_vs_concurrent_edit_edit_wins() {
+    // Other client edited the file (its record advanced 3 → 6). Our delete
+    // snapshotted it at 3.
+    let mut base = Snapshot::new(id(0));
+    with_child(&mut base, id(0), id(1), "f", NodeKind::File);
+    base.node_mut(id(1)).unwrap().record_sequence = 6;
+    let local = base.clone();
+
+    let res = rebase_one(&mut base, &local, &Op::delete(id(1), 1, 3));
+    assert_eq!(res, OpResolution::Dropped(DropReason::TargetAdvanced));
+    assert!(
+        base.contains(id(1)),
+        "the concurrent edit wins; the node survives"
+    );
+}
+
+#[test]
+fn race_1_reverse_edit_resurrects_a_concurrently_deleted_node() {
+    // Other client deleted the node (absent from gate-passing state); our edit
+    // resurrects it (edit wins in both directions).
+    let gate_passing = Snapshot::new(id(0));
+    let mut local = Snapshot::new(id(0));
+    with_child(&mut local, id(0), id(1), "f", NodeKind::File);
+
+    let mut working = gate_passing.clone();
+    let res = rebase_one(
+        &mut working,
+        &local,
+        &Op::update_content(id(1), b"v2".to_vec(), 1),
+    );
+    assert!(matches!(res, OpResolution::Applied { .. }));
+    assert!(
+        working.contains(id(1)),
+        "the edit resurrected the deleted node"
+    );
+}
+
+#[test]
+fn race_2_rename_vs_rename_serialized_by_parent_cas_higher_writer_wins() {
+    // Other client renamed the node first (base shows "other.txt"); our rebasing
+    // rename re-anchors and publishes at a higher parent sequence, so it wins.
+    let mut base = Snapshot::new(id(0));
+    with_child(&mut base, id(0), id(1), "start.txt", NodeKind::File);
+    base.node_mut(id(1)).unwrap().name = "other.txt".into();
+    let local = base.clone();
+
+    let res = rebase_one(&mut base, &local, &Op::rename(id(1), "mine.txt", 1));
+    assert!(matches!(
+        res,
+        OpResolution::Applied {
+            suffixed: false,
+            ..
+        }
+    ));
+    assert_eq!(base.node(id(1)).unwrap().name, "mine.txt");
+}
+
+#[test]
+fn race_3_add_vs_add_name_collision_auto_suffixes_the_loser() {
+    // Other client already created "a.txt" under root; our create collides and
+    // auto-suffixes — both stay visible.
+    let mut base = Snapshot::new(id(0));
+    with_child(&mut base, id(0), id(1), "a.txt", NodeKind::File);
+    let local = base.clone();
+
+    let res = rebase_one(
+        &mut base,
+        &local,
+        &Op::create(id(2), id(0), "a.txt", NodeKind::File, 1, None),
+    );
+    assert_eq!(
+        res,
+        OpResolution::Applied {
+            effective_name: Some("a (2).txt".to_owned()),
+            suffixed: true,
+            scope_exit_trigger: None,
+        }
+    );
+    assert_eq!(base.children(id(0)).len(), 2, "both adds are visible");
+}
+
+#[test]
+fn race_4_move_dest_first_then_presence_conditional_source_remove() {
+    let mut base = Snapshot::new(id(0));
+    with_child(&mut base, id(0), id(1), "dir", NodeKind::Folder);
+    with_child(&mut base, id(0), id(2), "f", NodeKind::File);
+    let local = base.clone();
+
+    let res = rebase_one(
+        &mut base,
+        &local,
+        &Op::relink(id(2), id(0), id(1), 1, false, false),
+    );
+    assert!(matches!(res, OpResolution::Applied { .. }));
+    assert_eq!(base.parent_of(id(2)), Some(id(1)), "dest-linked");
+    assert!(
+        base.children(id(0)).iter().all(|c| c.id != id(2)),
+        "source-removed — no orphan"
+    );
+}
+
+#[test]
+fn race_4_move_race_loser_undoes_its_dest_add() {
+    let mut base = Snapshot::new(id(0));
+    with_child(&mut base, id(0), id(1), "dirA", NodeKind::Folder);
+    with_child(&mut base, id(0), id(2), "dirB", NodeKind::Folder);
+    with_child(&mut base, id(0), id(3), "f", NodeKind::File);
+    // The other client's move already relocated the child into dirB.
+    base.unlink(id(0), id(3));
+    base.link(id(2), id(3), 2);
+    let local = base.clone();
+
+    // Our queued move (root → dirA) is the race loser: it undoes its dest-add.
+    let res = rebase_one(
+        &mut base,
+        &local,
+        &Op::relink(id(3), id(0), id(1), 1, false, false),
+    );
+    assert_eq!(res, OpResolution::Dropped(DropReason::MoveRaceLost));
+    assert_eq!(
+        base.parent_of(id(3)),
+        Some(id(2)),
+        "the winning move stands"
+    );
+    assert!(
+        base.children(id(1)).is_empty(),
+        "no dest-add residue under dirA"
+    );
+}
+
+#[test]
+fn race_5_dual_link_observed_repair_uses_the_link_counter() {
+    // Crash residue of a dest-first move: one child linked in two parents.
+    let mut base = Snapshot::new(id(0));
+    with_child(&mut base, id(0), id(1), "p1", NodeKind::Folder);
+    with_child(&mut base, id(0), id(2), "p2", NodeKind::Folder);
+    base.upsert_node(NodeMeta::new(id(3), "child", NodeKind::File));
+    base.link(id(1), id(3), 1);
+    base.link(id(2), id(3), 2); // the higher counter is the winner
+
+    let repairs = observed_repair(&base);
+    assert_eq!(repairs.len(), 1, "the dual link is detected");
+    apply_repairs(&mut base, &repairs);
+    assert_eq!(base.links_to(id(3)).len(), 1, "the losing link is removed");
+    assert_eq!(base.parent_of(id(3)), Some(id(2)));
+}
+
+// ---------------------------------------------------------------------------
+// Offline queue replay — stage ops offline, then replay FIFO onto a fresh
+// gate-passing base through the same rebase path.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn offline_queue_replays_fifo_onto_gate_passing_state() {
+    let store = InMemoryStagingStore::default();
+    let profile = SyncTimingProfile::CI;
+
+    block_on(async {
+        // Offline: journal a create, a rename, and a colliding create.
+        let ops = [
+            Op::create(id(1), id(0), "notes.txt", NodeKind::File, 1, None),
+            Op::rename(id(1), "notes-v2.txt", 1),
+            Op::create(id(2), id(0), "notes-v2.txt", NodeKind::File, 1, None), // will collide
+        ];
+        for op in &ops {
+            assert!(matches!(
+                stage_op(&store, &profile, op, None).await.unwrap(),
+                StageOutcome::Queued { .. }
+            ));
+        }
+
+        // Reconnect: decode the durable journal and replay onto fresh state.
+        let raw = store.queued_ops().await.unwrap();
+        let (decoded, undecodable) = decode_queue(&raw);
+        assert!(undecodable.is_empty());
+
+        let base = Snapshot::new(id(0));
+        let report = replay(&base, &base, &decoded);
+
+        assert_eq!(report.applied.len(), 3, "every op replayed in FIFO order");
+        assert_eq!(report.rebased.node(id(1)).unwrap().name, "notes-v2.txt");
+        // The colliding create auto-suffixed on merge.
+        assert!(report.applied[2].suffixed);
+        assert_eq!(report.rebased.node(id(2)).unwrap().name, "notes-v2 (2).txt");
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Dead-letter on revoked-while-offline — staged bytes preserved.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn revoked_while_offline_dead_letters_with_staged_bytes_preserved() {
+    let store = InMemoryStagingStore::default();
+    let profile = SyncTimingProfile {
+        staging_budget_bytes: 1 << 20,
+        ..SyncTimingProfile::CI
+    };
+
+    block_on(async {
+        // Offline: create a file inside a granted folder (id 5), staging its bytes.
+        let op = Op::create(
+            id(6),
+            id(5),
+            "secret.txt",
+            NodeKind::File,
+            1,
+            Some(b"stage-key".to_vec()),
+        );
+        assert!(matches!(
+            stage_op(&store, &profile, &op, Some(b"plaintext-bytes"))
+                .await
+                .unwrap(),
+            StageOutcome::Queued { .. }
+        ));
+
+        // While offline the grant is revoked: the granted folder is gone from
+        // gate-passing state entirely.
+        let gate_passing = Snapshot::new(id(0)); // no id(5)
+        let raw = store.queued_ops().await.unwrap();
+        let (decoded, _) = decode_queue(&raw);
+        let report = replay(&gate_passing, &gate_passing, &decoded);
+
+        // The op terminally dead-letters — nothing silently dropped.
+        assert_eq!(report.applied.len(), 0);
+        assert_eq!(report.dead_letters.len(), 1);
+        assert_eq!(report.dead_letters[0].1, DeadLetterReason::TargetGone);
+
+        // The staged bytes are preserved (the caller does NOT GC a dead-letter's
+        // bytes — the user can still recover them).
+        assert_eq!(
+            store.staged_bytes(b"stage-key").await.unwrap(),
+            Some(b"plaintext-bytes".to_vec()),
+            "staged bytes survive the dead-letter"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Staging-budget fail-fast — uploads bounded, metadata unbounded.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn staging_budget_fails_fast_on_uploads_but_metadata_queues_unbounded() {
+    let store = InMemoryStagingStore::default();
+    let profile = SyncTimingProfile {
+        staging_budget_bytes: 8,
+        ..SyncTimingProfile::CI
+    };
+    block_on(async {
+        // A 9-byte upload past the 8-byte budget fails fast — nothing staged.
+        let upload = Op::create(id(1), id(0), "big", NodeKind::File, 1, Some(b"k".to_vec()));
+        assert!(matches!(
+            stage_op(&store, &profile, &upload, Some(b"nine byte"))
+                .await
+                .unwrap(),
+            StageOutcome::RejectedOverBudget { .. }
+        ));
+        assert_eq!(store.staged_bytes_total().await.unwrap(), 0);
+
+        // Metadata ops still queue past the exhausted budget.
+        for i in 10..20 {
+            assert!(matches!(
+                stage_op(&store, &profile, &Op::rename(id(i), "n", 1), None)
+                    .await
+                    .unwrap(),
+                StageOutcome::Queued { .. }
+            ));
+        }
+        assert_eq!(
+            store.queued_ops().await.unwrap().len(),
+            10,
+            "metadata is unbounded"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// The staleness ladder and the withheld-update escalation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn staleness_ladder_climbs_fresh_reconciling_stale_offline() {
+    let p = SyncTimingProfile::PRODUCTION; // stale_after 90 s
+    let last = UnixMillis(0);
+
+    // Fresh within the window.
+    assert_eq!(
+        classify(
+            UnixMillis(10_000),
+            Some(last),
+            false,
+            Connectivity::Online,
+            &p
+        ),
+        Staleness::Fresh
+    );
+    // A reconcile in flight shows the quiet indicator.
+    assert_eq!(
+        classify(
+            UnixMillis(10_000),
+            Some(last),
+            true,
+            Connectivity::Online,
+            &p
+        ),
+        Staleness::Reconciling
+    );
+    // Past the threshold, idle: the stale badge.
+    assert_eq!(
+        classify(
+            UnixMillis(120_000),
+            Some(last),
+            false,
+            Connectivity::Online,
+            &p
+        ),
+        Staleness::Stale
+    );
+    // Offline outranks everything.
+    assert_eq!(
+        classify(
+            UnixMillis(120_000),
+            Some(last),
+            false,
+            Connectivity::Offline,
+            &p
+        ),
+        Staleness::Offline
+    );
+}
+
+#[test]
+fn withheld_update_escalation_is_shared_scope_only() {
+    let p = SyncTimingProfile::PRODUCTION; // escalation window 600 s
+    // Shared scope, others succeeding, pinned past the window: escalate.
+    assert!(withheld_escalation(
+        UnixMillis(600_000),
+        UnixMillis(0),
+        true,
+        true,
+        &p
+    ));
+    // A private-vault pin past the window is ordinary staleness, never escalated.
+    assert!(!withheld_escalation(
+        UnixMillis(600_000),
+        UnixMillis(0),
+        false,
+        true,
+        &p
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// The keyless re-PUT adversary — the floor law blocks a rollback.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn keyless_re_put_adversary_cannot_roll_the_floor_back() {
+    let floors = InMemoryFloorStore::default();
+    const SCOPE: [u8; 16] = [1u8; 16];
+    const NAME: &[u8] = b"scope-root-ipns-name";
+
+    block_on(async {
+        // The device adopted the record at sequence 5, epoch 3 (floors advanced).
+        floor::advance_on_unseal(&floors, &SCOPE, NAME, 5, 3)
+            .await
+            .unwrap();
+
+        // The adversary keyless-re-PUTs a captured OLDER record (seq 4, epoch 2)
+        // to try to roll the view back. It is byte-valid and validly signed, but
+        // both floors reject it — a re-PUT keeps a record alive, it can never
+        // regress the durable floors.
+        assert_eq!(floor::sequence_floor(&floors, NAME).await.unwrap(), Some(5));
+        assert_eq!(
+            floor::read_epoch_floor(&floors, &SCOPE).await.unwrap(),
+            Some(3)
+        );
+
+        // A monotonic-max re-raise at the lower values is a no-op: the floor holds.
+        floor::advance_on_unseal(&floors, &SCOPE, NAME, 4, 2)
+            .await
+            .unwrap();
+        assert_eq!(
+            floor::sequence_floor(&floors, NAME).await.unwrap(),
+            Some(5),
+            "no rollback"
+        );
+        assert_eq!(
+            floor::read_epoch_floor(&floors, &SCOPE).await.unwrap(),
+            Some(3),
+            "no rollback"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Cold-start adopts nothing before floor seeding — the non-circular sequence.
+// ---------------------------------------------------------------------------
+
+/// A scripted pointer network for the cold-start narrative.
+#[derive(Clone, Default)]
+struct ScriptedPointers {
+    blocks: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+}
+
+impl ScriptedPointers {
+    fn put(&self, name: &IpnsName, block: Vec<u8>) {
+        self.blocks
+            .lock()
+            .unwrap()
+            .insert(name.as_str().to_owned(), block);
+    }
+}
+
+impl PointerFetch for ScriptedPointers {
+    async fn fetch(&self, name: &IpnsName) -> SeamResult<Option<Vec<u8>>> {
+        Ok(self.blocks.lock().unwrap().get(name.as_str()).cloned())
+    }
+}
+
+const LOGIN_SECRET: &[u8] = b"cold-start-login-secret";
+const ROOT_SCOPE: [u8; 16] = [0u8; 16];
+
+fn repoint(min_read_epoch: u64, write_epoch: u64) -> RepointObject {
+    RepointObject {
+        scope_id: ROOT_SCOPE,
+        current_root: vault_pointer_name(LOGIN_SECRET, 0),
+        write_epoch,
+        min_read_epoch,
+        prev_root: None,
+    }
+}
+
+#[test]
+fn cold_start_adopts_nothing_until_the_floor_seeds_from_the_pointer() {
+    let pointers = ScriptedPointers::default();
+    let owner = EcdsaSigner::from_scalar(&[3u8; 32]).unwrap();
+    let floors = InMemoryFloorStore::default();
+
+    block_on(async {
+        // Step 1 — cold start with an empty vault-pointer chain: adopt nothing.
+        let cold = resolve_vault_pointer(
+            &pointers,
+            LOGIN_SECRET,
+            &owner.verifying_key(),
+            &ROOT_SCOPE,
+            1,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            cold, None,
+            "cold start adopts nothing before a pointer exists"
+        );
+        assert_eq!(
+            floor::read_epoch_floor(&floors, &ROOT_SCOPE).await.unwrap(),
+            None,
+            "no floor is seeded yet — the gate would have no revocation boundary"
+        );
+
+        // Step 2 — the owner publishes the vault pointer (re-point: minReadEpoch 5).
+        let owner_seed = kdf::owner_pointer_seed(LOGIN_SECRET);
+        let read_key = kdf::pointer_read_key(owner_seed.as_bytes(), &ROOT_SCOPE);
+        let mut entropy = SeededEntropy::new(1);
+        let block = seal_repoint(
+            SessionRole::Owner,
+            &mut entropy,
+            read_key.as_bytes(),
+            1,
+            &owner,
+            &repoint(5, 3),
+        )
+        .unwrap();
+        pointers.put(&vault_pointer_name(LOGIN_SECRET, 0), block);
+
+        // Step 3 — the pointer resolves first (the non-circular cold-start act),
+        // then the floors cold-seed from its owner-vouched epochs.
+        let adopted = resolve_vault_pointer(
+            &pointers,
+            LOGIN_SECRET,
+            &owner.verifying_key(),
+            &ROOT_SCOPE,
+            1,
+        )
+        .await
+        .unwrap()
+        .expect("the vault pointer now resolves");
+        assert_eq!(adopted.index, 0);
+        cold_seed_floors(&floors, &adopted.repoint).await.unwrap();
+
+        // Now the revocation floor is seeded: an old-epoch record (epoch 3 < 5)
+        // would fail the gate's epoch stage — cold start no longer adopts blindly.
+        assert_eq!(
+            floor::read_epoch_floor(&floors, &ROOT_SCOPE).await.unwrap(),
+            Some(5),
+            "the floor seeded from the owner-signed re-point anchor"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// The state law — rendered = gate-passing snapshot ⊕ pending-op overlay.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn state_law_renders_the_snapshot_plus_the_pending_overlay() {
+    let mut base = Snapshot::new(id(0));
+    with_child(&mut base, id(0), id(1), "confirmed.txt", NodeKind::File);
+
+    // Two pending ops not yet confirmed by the network.
+    let pending = [
+        Op::create(id(2), id(0), "pending.txt", NodeKind::File, 1, None),
+        Op::rename(id(1), "renamed.txt", 1),
+    ];
+    let view = sync::apply_overlay(&base, &pending);
+
+    assert!(view.contains(id(2)), "pending create shows immediately");
+    assert_eq!(
+        view.node(id(1)).unwrap().name,
+        "renamed.txt",
+        "pending rename shows"
+    );
+    // The gate-passing snapshot is the only source of truth and is untouched.
+    assert!(!base.contains(id(2)));
+    assert_eq!(base.node(id(1)).unwrap().name, "confirmed.txt");
+}


### PR DESCRIPTION
## What

Lands the keystone **sync core** for `crates/engine` behind the frozen facade — the one stateful sync model several downstream slices gate on. New `crates/engine/src/sync/` module with eight submodules:

- **`model`** — the working tree (the state law's left operand): a gate-passing `Snapshot` of nodes + parent links carrying the monotonic dual-link counter, plus the single strict name comparator (`collation_key`) and the `name (2).ext` auto-suffix.
- **`op`** — the five intent ops (`create`/`delete`/`rename`/`relink`/`updateContent`), each carrying its base sequence, and the durable-queue codec (engine-owned opaque bytes; content rides staging keys, never the op).
- **`overlay`** — the state law: rendered = last-known-good snapshot ⊕ pending-op overlay (optimistic, single owner).
- **`rebase`** — FIFO replay onto gate-passing state only, the five per-op race rules 1:1 (conditional delete, rename/rename via parent CAS, add/add auto-suffix, dest-first move with presence-conditional source-remove, dual-link observed repair), dead-lettering, and `decode_queue` (dead-letters corrupt entries).
- **`staging`** — the budgeted offline staging policy over `StagingStore`: uploads fail fast past the profile budget, metadata ops queue unbounded, orphan-key GC.
- **`staleness`** — the ladder (fresh → reconciling → stale → offline) and the shared-scope-only withheld-update escalation, off the injected clock.
- **`pointer`** — the scope/vault pointer planes: re-point object seal/open (over core's `RepointObject`), the indexed vault-pointer walk with probe-one-past, the owner-plane write gate (owner sessions only), the polled-not-fallback consult discipline, and the cold-start floor cold-seed (reusing `gate::floor`).
- **`tick`** — the jittered focus-window tick (jitter from injected entropy), immediate ticks on `RefreshHintSource`, the focus-set computation (vault pointer + open folder + ancestor chain + open shared-scope pointers + mailbox poll), on-access refresh, and manual-refresh nocache semantics.

Small additive edits: `NodeId` gains `Ord`/serde derives (deterministic maps + op codec), `NodeKind` gains serde; `sync` wired into `lib.rs` with re-exports.

## Why

Closes #632. Implements exactly the issue's scope against `blueprint/engine.md` ("Sync core", "Pointer planes", "Adoption gate and floors") and `CONTEXT.md`. Builds on #626 (adoption gate / floor law — reused via `gate::floor`) and #628 (net pipeline). Determinism is injected throughout: entropy only via `Entropy`, time only via `Scheduler`/`UnixMillis` — no direct clock or RNG in engine logic. All crypto stays in `crates/core` (the pointer plane calls core's `seal_pointer_payload`/`open_pointer_payload` and the pointer KDF edges; the engine implements no crypto). Every gate rejection is fail-closed.

**Explicitly deferred, per the issue scope** ("does NOT land: scope-exit rotation triggering"): a cross-scope relink out of a granted scope *queues* the scope-exit rotation trigger (`ReplayReport::scope_exit_triggers`) — it never rotates. The rotation primitives land with the rotation slice.

Scoping notes:
- The sync core operates on an engine-domain tree projection; later slices assemble it from gate-passing `Adopted` read-bodies. The tree mirrors core's `ChildRef` (id, name, kind, `link_counter`).
- `collation_key` folds case (Unicode default lowercase); canonical NFC normalization is the cross-language KAT'd surface core owns (its `name_cmp` is the wire-order sibling) and graduates there — the engine uses one comparator identically at create and merge.
- The tick loop's `on_tick` is a caller-supplied async closure so the net/pointer resolve wiring composes on top; the loop's timer-vs-hint race, jitter, and focus-set are fully covered here.

## Verification

- `cargo test -p cipherbox-engine`: **192 passed, 0 failed** (123 lib unit + 15 new sync integration + 54 existing across adoption-gate/net/facade/floor/conformance).
- `crates/engine/tests/sync.rs` is the simulation harness mirroring the issue's gate 1:1: the five-race table, offline queue replay, dead-letter on revoked-while-offline (staged bytes preserved), staging-budget fail-fast, the staleness ladder + escalation, the keyless-re-PUT adversary (floor law blocks the rollback), and cold-start-adopts-nothing-before-floor-seeding.
- `cargo clippy -p cipherbox-engine --all-targets`: clean. `cargo fmt -p cipherbox-engine --check`: clean.
- Ran `/simplify`, `/security-review`, and `/crypto-privacy-review` on the diff; findings folded in (see below).

### Review findings addressed

- **/simplify** (3 parallel reviewers): added `Snapshot::link_next` (single pass; folds the `max_link_counter+1; link` idiom out of 6 sites and pulls the fresh-link-wins invariant into the model); `replay` now constructs `ReplayReport` once (dropped a wasted init clone); single-scan `observed_repair` with `Repair.remove` narrowed to losing parent ids; `HashSet` in `orphan_staging_keys`; a shared `duration_millis` helper (was inlined in `staleness` + `tick`); an `OpResolution::applied()` constructor; deleted the dead `advance_write_epoch_on_sight` wrapper (the floor law is its home) and rewired `resolve_vault_pointer` through `open_repoint`; added coverage for the previously-uncalled `scope_pointer_name`/`scope_pointer_signer` and for `content_version`.
- **/crypto-privacy-review**: clean — no crypto in the engine (all via `crates/core`: pointer KDF edges + `seal/open_pointer_payload`), seal nonce and jitter from injected entropy, time only via `UnixMillis`, login-secret-derived `SecretBytes` zeroize on drop and caller-owned buffers are never zeroed, the vault-pointer walk and cold-seed are fail-closed. Tightened one doc: `stage_op`'s upload bytes are the already-sealed content payload (sealing runs upstream), so no plaintext lands at rest.
- **/security-review**: clean — every loop bounded (`MAX_VAULT_POINTER_PROBE`, `MAX_SUFFIX_PROBE`→`SuffixExhausted`, `ancestors` cycle guard), no unguarded panics on external input, corrupt op-queue bytes dead-letter rather than crash the replay.

### Coordinator-flagged addition (same-sequence split-brain)

Per timely guidance from the net publish slice (#692): two writers each minting a **different** record at `floor + 1` both land, and IPNS higher-sequence-wins cannot converge equal sequences. Added `reconcile_head` + `HeadReconciliation`: a deterministic byte-order tiebreak over the verified record bytes picks the canonical head with no shared state; the loser rebases its local ops onto the winning sibling and re-mints at `sequence + 1`, after which ordinary higher-sequence-wins finishes convergence. Covered by three unit tests (higher → lost race, lower/identical → converged, same-sequence divergence with symmetric winner/loser).

Closes #632
Closes #724 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new synchronization “sync core” surface with offline replay, pending-op overlays (base + queued intents), pointer resolution/sealing, focus refresh tick loop, and staleness classification.
  * Added budgeted staging (including queued/enqueued outcomes) plus orphan staging key discovery.
  * Node identifiers and created-node records now support deterministic ordering and serialization.
* **Bug Fixes**
  * Content sealing and DAG assembly are now fail-closed: invalid manifests/mismatches return errors even outside debug builds.
  * Updated sealing to surface DAG validation failures via a dedicated sealing error type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->