### PR TITLE
fix(api): serialize retire unpin against upload and cap record-transport body

### DIFF
--- a/apps/api/src/common/advisory-lock.ts
+++ b/apps/api/src/common/advisory-lock.ts
@@ -93,6 +93,19 @@ export function advisoryLockKey(token: string): bigint {
 }
 
 /**
+ * Namespaced per-CID key for the SESSION lock that guards a durability window:
+ * the upload path holds it across commit → pin, and retire holds it across
+ * commit → unpin. DISTINCT from the plain CID xact lock so the upload can hold
+ * both — session lock on its own connection, xact lock on the tx connection —
+ * without a same-key self-deadlock. Upload and retire MUST share this key so
+ * retire's post-commit unpin of a CID serializes against a concurrent upload
+ * re-pinning the same CID (#714).
+ */
+export function pinDurabilityLockKey(cid: string): bigint {
+  return advisoryLockKey(`pin-durability:${cid}`);
+}
+
+/**
  * Acquire a batch of transaction-scoped advisory locks in one deadlock-free
  * order: keys are de-duplicated and sorted, so any two overlapping batches take
  * their shared keys in the same sequence and cannot form a cycle. Set the

--- a/apps/api/src/content/content.service.ts
+++ b/apps/api/src/content/content.service.ts
@@ -12,6 +12,7 @@ import { User } from '../auth/entities/user.entity';
 import {
   acquireAdvisoryLocks,
   advisoryLockKey,
+  pinDurabilityLockKey,
   resolveAdvisoryLockTimeoutMs,
   runLockGuardedTransaction,
   setAdvisoryLockTimeout,
@@ -234,14 +235,4 @@ export class ContentService {
 /** Namespaced account advisory key: `account:` prevents any UUID/CID key collision. */
 function accountLockKey(accountId: string): bigint {
   return advisoryLockKey(`account:${accountId}`);
-}
-
-/**
- * Namespaced session lock for the post-commit pin/compensation window. A
- * DISTINCT key from the plain CID xact lock: the same upload holds both (session
- * lock on its own connection, xact lock on the tx connection), and same-key
- * session-vs-xact locks across connections would self-deadlock.
- */
-function pinDurabilityLockKey(cid: string): bigint {
-  return advisoryLockKey(`pin-durability:${cid}`);
 }

--- a/apps/api/src/registry/registry.http.test.ts
+++ b/apps/api/src/registry/registry.http.test.ts
@@ -100,7 +100,12 @@ interface SumQueryBuilder {
   getRawOne: () => Promise<{ used: string }>;
 }
 
-/** A DataSource whose transaction runs inline against the in-memory repos. */
+/**
+ * A DataSource whose transaction runs inline against the in-memory repos and
+ * whose query runner no-ops advisory-lock statements — the post-commit unpin
+ * guard's session lock is inert against a single-threaded fake, so its recount
+ * runs directly against the in-memory pins repo.
+ */
 function fakeDataSource(repos: Array<[unknown, unknown]>): DataSource {
   const byEntity = new Map(repos);
   return {
@@ -109,6 +114,11 @@ function fakeDataSource(repos: Array<[unknown, unknown]>): DataSource {
         getRepository: (entity: unknown) => byEntity.get(entity),
         query: async () => [],
       }),
+    createQueryRunner: () => ({
+      connect: async () => undefined,
+      query: async () => [],
+      release: async () => undefined,
+    }),
   } as unknown as DataSource;
 }
 

--- a/apps/api/src/registry/services/registry.service.integration.test.ts
+++ b/apps/api/src/registry/services/registry.service.integration.test.ts
@@ -4,6 +4,7 @@ import { randomBytes } from 'node:crypto';
 import { DataSource, EntityManager, FindManyOptions, FindOneOptions, Repository } from 'typeorm';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { User } from '../../auth/entities/user.entity';
+import { pinDurabilityLockKey, withSessionAdvisoryLock } from '../../common/advisory-lock';
 import { fakeConfig } from '../../testing/fakes';
 import { createIntegrationDatabase, IntegrationDatabase } from '../../testing/integration-db';
 import { PinnedCid } from '../entities/pinned-cid.entity';
@@ -48,6 +49,17 @@ class RecordingPinStore extends PinStore {
   }
 }
 
+/** Records the unpin, then pauses inside it so a test can commit a racing row. */
+class GatedUnpinStore extends RecordingPinStore {
+  constructor(private readonly gate: Gate) {
+    super();
+  }
+  override async unpin(cid: string): Promise<void> {
+    await super.unpin(cid);
+    await this.gate.onReach();
+  }
+}
+
 /** A barrier a gated transaction trips the instant it reaches its hook point. */
 interface Gate {
   reached: Promise<void>;
@@ -73,6 +85,8 @@ function makeGate(): Gate {
 interface GateHooks {
   /** No-op the advisory lock + lock_timeout, and drop the users-row lock — the pre-#677 path. */
   stripLock?: boolean;
+  /** No-op the post-commit SESSION advisory lock — the pre-#714 unguarded-unpin path. */
+  stripSessionLock?: boolean;
   afterUserRead?: () => Promise<void>;
   afterPinFind?: () => Promise<void>;
   afterPinSave?: () => Promise<void>;
@@ -122,7 +136,30 @@ function gatedDataSource(real: DataSource, hooks: GateHooks): DataSource {
       },
     });
 
+  // Strip the SESSION advisory (un)lock the post-commit unpin guard takes on a
+  // dedicated runner, so retire's recount races the concurrent upload instead of
+  // serializing behind it — the pre-#714 unguarded-unpin path.
+  const wrapQueryRunner = (runner: ReturnType<DataSource['createQueryRunner']>) =>
+    new Proxy(runner, {
+      get(target, prop, receiver) {
+        if (prop === 'query') {
+          return async (sql: string, params?: unknown[]) => {
+            if (/pg_advisory_lock|pg_advisory_unlock/i.test(sql)) {
+              return [];
+            }
+            return target.query(sql, params);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+
   return {
+    createQueryRunner: () => {
+      const runner = real.createQueryRunner();
+      return hooks.stripSessionLock ? wrapQueryRunner(runner) : runner;
+    },
     transaction: (runInTransaction: (manager: EntityManager) => Promise<unknown>) =>
       real.transaction((manager) => {
         const proxied = new Proxy(manager, {
@@ -456,6 +493,103 @@ describe('RegistryService concurrency (real Postgres)', () => {
         caught = error;
       }
       expect(pgErrorCode(caught)).toBe('23505');
+    });
+  });
+
+  describe('retire post-commit unpin guard (#714)', () => {
+    it('at true global-zero the guarded unpin fires exactly once', async () => {
+      const a = await seedAccount(false);
+      const cid = token();
+      await seedPin(a, cid);
+
+      const pinStore = new RecordingPinStore();
+      const result = await buildService(db.dataSource, pinStore).retire(a, [cid]);
+
+      expect(result.unpinned).toBe(1);
+      expect(pinStore.unpinned).toEqual([cid]);
+      expect(await db.dataSource.getRepository(PinnedCid).find({ where: { cid } })).toEqual([]);
+    });
+
+    it('skips the unpin when a concurrent upload re-pins the CID inside the commit→unpin window', async () => {
+      const a = await seedAccount(false);
+      const b = await seedAccount(false);
+      const cid = token();
+      await seedPin(a, cid); // A is the sole holder — retire will decide to unpin.
+
+      // A concurrent upload holds the SAME pin-durability session lock the guard
+      // takes and, while holding it, commits a fresh size>0 pin row for the CID —
+      // the re-pin retire's lagging unpin would otherwise destroy.
+      const gate = makeGate();
+      const uploadPromise = withSessionAdvisoryLock(
+        db.dataSource,
+        pinDurabilityLockKey(cid),
+        0,
+        async () => {
+          await gate.onReach();
+          await db.dataSource
+            .getRepository(PinnedCid)
+            .save({ accountId: b, cid, size: '100', advisory: false });
+        }
+      );
+      await gate.reached; // upload holds the session lock; B's row not yet inserted
+
+      // retire(A): its txn deletes A's only row, sees no survivor, commits, then
+      // BLOCKS acquiring the pin-durability lock the upload still holds.
+      const pinStore = new RecordingPinStore();
+      let retireDone = false;
+      const retired = buildService(db.dataSource, pinStore)
+        .retire(a, [cid])
+        .then((r) => {
+          retireDone = true;
+          return r;
+        });
+
+      await delay(200);
+      expect(retireDone).toBe(false);
+      expect(pinStore.unpinned).toEqual([]);
+
+      gate.release(); // upload commits B's row and releases the session lock
+      await uploadPromise;
+      const result = await retired;
+
+      // retire acquired the lock, recounted, saw B's survivor, and SKIPPED the
+      // unpin — the freshly-pinned bytes are preserved.
+      expect(result.unpinned).toBe(0);
+      expect(pinStore.unpinned).toEqual([]);
+      const survivors = await db.dataSource.getRepository(PinnedCid).find({ where: { cid } });
+      expect(survivors.map((r) => r.accountId)).toEqual([b]);
+    });
+
+    it('negative control — with the session lock stripped, retire prematurely unpins a CID a concurrent upload re-pins', async () => {
+      const a = await seedAccount(false);
+      const b = await seedAccount(false);
+      const cid = token();
+      await seedPin(a, cid);
+
+      // The unpin is gated so the racing upload can commit its row DURING it,
+      // after retire's now-unserialized recount has already passed.
+      const gate = makeGate();
+      const pinStore = new GatedUnpinStore(gate);
+      const retired = buildService(
+        gatedDataSource(db.dataSource, { stripSessionLock: true }),
+        pinStore
+      ).retire(a, [cid]);
+
+      // retire committed, recounted (no survivor), and is now paused inside unpin.
+      await gate.reached;
+      await db.dataSource
+        .getRepository(PinnedCid)
+        .save({ accountId: b, cid, size: '100', advisory: false });
+
+      gate.release();
+      const result = await retired;
+
+      // The CID was physically unpinned even though B now holds it — the
+      // data-loss window the session-lock guard closes.
+      expect(result.unpinned).toBe(1);
+      expect(pinStore.unpinned).toEqual([cid]);
+      const survivors = await db.dataSource.getRepository(PinnedCid).find({ where: { cid } });
+      expect(survivors.map((r) => r.accountId)).toEqual([b]);
     });
   });
 });

--- a/apps/api/src/registry/services/registry.service.integration.test.ts
+++ b/apps/api/src/registry/services/registry.service.integration.test.ts
@@ -560,6 +560,47 @@ describe('RegistryService concurrency (real Postgres)', () => {
       expect(survivors.map((r) => r.accountId)).toEqual([b]);
     });
 
+    it('a contended durability lock leaves the CID pinned for GC and still reports the committed retire, not a 503', async () => {
+      const a = await seedAccount(false);
+      const cid = token();
+      await seedPin(a, cid); // A is the sole holder — retire will decide to unpin.
+
+      // Hold the SAME pin-durability session lock so retire's post-commit acquire
+      // waits past lock_timeout and aborts (55P03) — the contention this test
+      // proves must degrade to a skip, not fail the already-committed retire.
+      const gate = makeGate();
+      const holder = withSessionAdvisoryLock(
+        db.dataSource,
+        pinDurabilityLockKey(cid),
+        0,
+        async () => {
+          await gate.onReach();
+        }
+      );
+      await gate.reached; // the durability lock is held
+
+      const pinStore = new RecordingPinStore();
+      const service = new RegistryService(
+        db.dataSource.getRepository(PinnedCid) as never,
+        db.dataSource.getRepository(User) as never,
+        db.dataSource as never,
+        pinStore,
+        fakeConfig({ DB_ADVISORY_LOCK_TIMEOUT_MS: '200' }).service
+      );
+
+      // retire's delete commits; the post-commit unpin can't acquire the held
+      // durability lock within 200ms, so it skips the unpin and returns.
+      const result = await service.retire(a, [cid]);
+
+      gate.release();
+      await holder;
+
+      expect(result).toEqual({ retired: 1, unpinned: 0 });
+      expect(pinStore.unpinned).toEqual([]);
+      // The row is gone (retire committed) but the CID is left pinned for GC.
+      expect(await db.dataSource.getRepository(PinnedCid).find({ where: { cid } })).toEqual([]);
+    });
+
     it('negative control — with the session lock stripped, retire prematurely unpins a CID a concurrent upload re-pins', async () => {
       const a = await seedAccount(false);
       const b = await seedAccount(false);

--- a/apps/api/src/registry/services/registry.service.test.ts
+++ b/apps/api/src/registry/services/registry.service.test.ts
@@ -88,7 +88,12 @@ interface SumQueryBuilder {
   getRawOne: () => Promise<{ used: string }>;
 }
 
-/** A DataSource whose transaction runs inline against the in-memory repos. */
+/**
+ * A DataSource whose transaction runs inline against the in-memory repos and
+ * whose query runner no-ops every advisory-lock statement — the post-commit
+ * unpin guard's session lock has no effect against a single-threaded fake, so
+ * its recount runs directly against the in-memory pins repo.
+ */
 function fakeDataSource(repos: Array<[unknown, unknown]>): DataSource {
   const byEntity = new Map(repos);
   return {
@@ -97,6 +102,11 @@ function fakeDataSource(repos: Array<[unknown, unknown]>): DataSource {
         getRepository: (entity: unknown) => byEntity.get(entity),
         query: async () => [],
       }),
+    createQueryRunner: () => ({
+      connect: async () => undefined,
+      query: async () => [],
+      release: async () => undefined,
+    }),
   } as unknown as DataSource;
 }
 

--- a/apps/api/src/registry/services/registry.service.test.ts
+++ b/apps/api/src/registry/services/registry.service.test.ts
@@ -1,6 +1,6 @@
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { UnauthorizedException } from '@nestjs/common';
-import { DataSource, FindOperator } from 'typeorm';
+import { DataSource, FindOperator, QueryFailedError } from 'typeorm';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { User } from '../../auth/entities/user.entity';
 import { FakeRepository } from '../../testing/fake-repo';
@@ -92,9 +92,15 @@ interface SumQueryBuilder {
  * A DataSource whose transaction runs inline against the in-memory repos and
  * whose query runner no-ops every advisory-lock statement — the post-commit
  * unpin guard's session lock has no effect against a single-threaded fake, so
- * its recount runs directly against the in-memory pins repo.
+ * its recount runs directly against the in-memory pins repo. With
+ * `sessionLockTimeout`, the post-commit `pg_advisory_lock` acquire instead
+ * aborts with a Postgres `lock_timeout` (55P03), simulating a contended
+ * durability window.
  */
-function fakeDataSource(repos: Array<[unknown, unknown]>): DataSource {
+function fakeDataSource(
+  repos: Array<[unknown, unknown]>,
+  opts: { sessionLockTimeout?: boolean } = {}
+): DataSource {
   const byEntity = new Map(repos);
   return {
     transaction: (runInTransaction: (manager: unknown) => unknown) =>
@@ -104,7 +110,16 @@ function fakeDataSource(repos: Array<[unknown, unknown]>): DataSource {
       }),
     createQueryRunner: () => ({
       connect: async () => undefined,
-      query: async () => [],
+      query: async (sql: string) => {
+        if (
+          opts.sessionLockTimeout &&
+          typeof sql === 'string' &&
+          sql.includes('pg_advisory_lock(')
+        ) {
+          throw new QueryFailedError(sql, [], { code: '55P03' } as never);
+        }
+        return [];
+      },
       release: async () => undefined,
     }),
   } as unknown as DataSource;
@@ -272,6 +287,36 @@ describe('RegistryService', () => {
       const acct = await account();
       const result = await service.retire(acct, ['never-registered']);
       expect(result).toEqual({ retired: 0, unpinned: 0 });
+    });
+
+    it('leaves a refcount-zero CID pinned for GC when the post-commit durability lock is contended, still reporting the committed retire', async () => {
+      const acct = await account();
+      await service.register(acct, [{ ipnsName: 'k51c', contentCids: ['bafyContended'] }]);
+
+      // Swap in a data source whose post-commit session-lock acquire aborts with
+      // a lock_timeout — the committed delete must stay observable, the unpin is
+      // skipped (left to GC), and the retire does NOT surface a 503.
+      service = new RegistryService(
+        pins as never,
+        users as never,
+        fakeDataSource(
+          [
+            [User, users],
+            [NameInventory, names],
+            [PinnedCid, pins],
+          ],
+          { sessionLockTimeout: true }
+        ),
+        pinStore,
+        fakeConfig({}).service
+      );
+
+      const result = await service.retire(acct, ['bafyContended']);
+
+      expect(result).toEqual({ retired: 1, unpinned: 0 });
+      expect(pinStore.unpinned).toEqual([]);
+      // The row is deleted (retire committed) but the physical pin is left intact.
+      expect(pins.rows.filter((r) => r.cid === 'bafyContended')).toHaveLength(0);
     });
   });
 

--- a/apps/api/src/registry/services/registry.service.test.ts
+++ b/apps/api/src/registry/services/registry.service.test.ts
@@ -318,6 +318,36 @@ describe('RegistryService', () => {
       // The row is deleted (retire committed) but the physical pin is left intact.
       expect(pins.rows.filter((r) => r.cid === 'bafyContended')).toHaveLength(0);
     });
+
+    it('does not surface a 500 when the post-commit unpin throws a non-contention error, still reporting the committed retire', async () => {
+      const acct = await account();
+      await service.register(acct, [{ ipnsName: 'k51e', contentCids: ['bafyUnpinFails'] }]);
+
+      // The physical unpin is best-effort after the row delete commits, so an
+      // arbitrary (non-lock-timeout) failure must be logged and skipped, never
+      // rethrown into a 500.
+      const throwing = new (class extends FakePinStore {
+        override async unpin(): Promise<void> {
+          throw new Error('kubo unreachable');
+        }
+      })();
+      service = new RegistryService(
+        pins as never,
+        users as never,
+        fakeDataSource([
+          [User, users],
+          [NameInventory, names],
+          [PinnedCid, pins],
+        ]),
+        throwing,
+        fakeConfig({}).service
+      );
+
+      const result = await service.retire(acct, ['bafyUnpinFails']);
+
+      expect(result).toEqual({ retired: 1, unpinned: 0 });
+      expect(pins.rows.filter((r) => r.cid === 'bafyUnpinFails')).toHaveLength(0);
+    });
   });
 
   describe('quota — arithmetic, override, hosted vs BYO advisory', () => {

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -286,11 +286,10 @@ export class RegistryService {
           unpinned += 1;
         }
       } catch (error) {
-        if (error instanceof ServiceUnavailableException) {
-          this.logger.warn(`retire left ${cid} pinned for GC: durability lock contended`);
-          continue;
-        }
-        throw error;
+        // The row deletes already committed and `retired` is authoritative; the
+        // post-commit unpin is best-effort (PinStore contract), so no failure
+        // here — lock contention or otherwise — may turn a retire into a 500.
+        this.logger.warn(`retire left ${cid} pinned for GC: ${String(error)}`);
       }
     }
 

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, ServiceUnavailableException, UnauthorizedException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { DataSource, EntityManager, In, Repository } from 'typeorm';
@@ -71,6 +76,7 @@ export interface QuotaResult {
 export class RegistryService {
   private readonly defaultLimitBytes: bigint;
   private readonly lockTimeoutMs: number;
+  private readonly logger = new Logger(RegistryService.name);
 
   constructor(
     @InjectRepository(PinnedCid)
@@ -253,23 +259,38 @@ export class RegistryService {
     // an unguarded unpin here would then delete freshly-pinned, durably-held
     // bytes (#714). Re-serialize on that SAME session key and recount under it:
     // if a survivor row now exists the bytes are legitimately held, so skip.
+    //
+    // The destructive work — the row deletes — is already committed, so `retired`
+    // is authoritative and must stay observable. unpin is best-effort (PinStore
+    // contract: a failed unpin never fails a retire; the CID decays via GC), so a
+    // per-CID durability lock that is contended here — almost always a concurrent
+    // upload re-pinning that same CID — leaves the CID pinned and moves on,
+    // rather than discarding the committed result behind a misleading 503 (#723).
     let unpinned = 0;
     for (const cid of unpinCids) {
-      const didUnpin = await withSessionAdvisoryLock(
-        this.dataSource,
-        pinDurabilityLockKey(cid),
-        this.lockTimeoutMs,
-        async () => {
-          const survivors = await this.pinRepository.find({ where: { cid } });
-          if (survivors.length > 0) {
-            return false;
+      try {
+        const didUnpin = await withSessionAdvisoryLock(
+          this.dataSource,
+          pinDurabilityLockKey(cid),
+          this.lockTimeoutMs,
+          async () => {
+            const survivors = await this.pinRepository.find({ where: { cid } });
+            if (survivors.length > 0) {
+              return false;
+            }
+            await this.pinStore.unpin(cid);
+            return true;
           }
-          await this.pinStore.unpin(cid);
-          return true;
+        );
+        if (didUnpin) {
+          unpinned += 1;
         }
-      );
-      if (didUnpin) {
-        unpinned += 1;
+      } catch (error) {
+        if (error instanceof ServiceUnavailableException) {
+          this.logger.warn(`retire left ${cid} pinned for GC: durability lock contended`);
+          continue;
+        }
+        throw error;
       }
     }
 

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -7,8 +7,10 @@ import {
   acquireAdvisoryLocks,
   advisoryLockKey,
   isLockNotAvailable,
+  pinDurabilityLockKey,
   resolveAdvisoryLockTimeoutMs,
   setAdvisoryLockTimeout,
+  withSessionAdvisoryLock,
 } from '../../common/advisory-lock';
 import { NameInventory } from '../entities/name-inventory.entity';
 import { PinnedCid } from '../entities/pinned-cid.entity';
@@ -245,10 +247,30 @@ export class RegistryService {
     });
 
     // Fire the external unpin after commit — never hold the txn across Kubo.
+    // The retire txn's per-token xact lock releases at commit, so between it and
+    // this unpin a concurrent upload can re-pin the same CID under the upload
+    // path's `pin-durability:` session lock, commit a row, and return success —
+    // an unguarded unpin here would then delete freshly-pinned, durably-held
+    // bytes (#714). Re-serialize on that SAME session key and recount under it:
+    // if a survivor row now exists the bytes are legitimately held, so skip.
     let unpinned = 0;
     for (const cid of unpinCids) {
-      await this.pinStore.unpin(cid);
-      unpinned += 1;
+      const didUnpin = await withSessionAdvisoryLock(
+        this.dataSource,
+        pinDurabilityLockKey(cid),
+        this.lockTimeoutMs,
+        async () => {
+          const survivors = await this.pinRepository.find({ where: { cid } });
+          if (survivors.length > 0) {
+            return false;
+          }
+          await this.pinStore.unpin(cid);
+          return true;
+        }
+      );
+      if (didUnpin) {
+        unpinned += 1;
+      }
     }
 
     return { retired, unpinned };

--- a/apps/api/src/republisher/record-transport.test.ts
+++ b/apps/api/src/republisher/record-transport.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fakeConfig } from '../testing/fakes';
+import { RoutingV1RecordTransport } from './record-transport';
+
+const MAX_RECORD_BYTES = 64 * 1024;
+
+/**
+ * Fake `/routing/v1` response letting each test set the body and the
+ * Content-Length header independently, so the absent/lying-header paths are
+ * exercised (the header cannot be trusted). `arrayBuffer` is a spy so a test can
+ * assert an honestly-declared oversized body is rejected BEFORE it is buffered.
+ */
+function fakeResponse(opts: { status?: number; body?: Buffer; contentLength?: string | null }): {
+  response: Response;
+  arrayBuffer: ReturnType<typeof vi.fn>;
+} {
+  const body = opts.body ?? Buffer.alloc(0);
+  const status = opts.status ?? 200;
+  const contentLength =
+    opts.contentLength === undefined ? String(body.byteLength) : opts.contentLength;
+  const arrayBuffer = vi.fn(async () =>
+    body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength)
+  );
+  const response = {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: (name: string) => (name.toLowerCase() === 'content-length' ? contentLength : null),
+    },
+    arrayBuffer,
+  } as unknown as Response;
+  return { response, arrayBuffer };
+}
+
+function transport(): RoutingV1RecordTransport {
+  return new RoutingV1RecordTransport(
+    fakeConfig({ ROUTING_V1_URL: 'https://routing.test' }).service
+  );
+}
+
+describe('RoutingV1RecordTransport response-size cap', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('returns an in-bounds body at exactly the ceiling', async () => {
+    const body = Buffer.alloc(MAX_RECORD_BYTES, 7);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => fakeResponse({ body }).response)
+    );
+
+    const result = await transport().resolve('k51-in-bounds');
+    expect(result?.byteLength).toBe(MAX_RECORD_BYTES);
+    expect(result?.equals(body)).toBe(true);
+  });
+
+  it('rejects an honestly-declared oversized body before buffering it', async () => {
+    const { response, arrayBuffer } = fakeResponse({
+      body: Buffer.alloc(8),
+      contentLength: String(MAX_RECORD_BYTES + 1),
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => response)
+    );
+
+    await expect(transport().resolve('k51-declared')).rejects.toThrow(/exceeds/);
+    expect(arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it('rejects an oversized body whose Content-Length is absent', async () => {
+    const body = Buffer.alloc(MAX_RECORD_BYTES + 1, 3);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => fakeResponse({ body, contentLength: null }).response)
+    );
+
+    await expect(transport().resolve('k51-absent')).rejects.toThrow(/exceeds/);
+  });
+
+  it('rejects an oversized body whose Content-Length lies small', async () => {
+    const body = Buffer.alloc(MAX_RECORD_BYTES + 1, 5);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => fakeResponse({ body, contentLength: '10' }).response)
+    );
+
+    await expect(transport().resolve('k51-lying')).rejects.toThrow(/exceeds/);
+  });
+});

--- a/apps/api/src/republisher/record-transport.ts
+++ b/apps/api/src/republisher/record-transport.ts
@@ -85,6 +85,8 @@ export class RoutingV1RecordTransport extends RecordTransport {
     // or lie.
     const declared = response.headers.get('content-length');
     if (declared !== null && Number(declared) > MAX_RECORD_BYTES) {
+      // Release the connection instead of leaking an unread body stream.
+      await response.body?.cancel();
       throw new Error(`routing GET body ${declared}B exceeds ${MAX_RECORD_BYTES}B for ${ipnsName}`);
     }
     const body = Buffer.from(await response.arrayBuffer());

--- a/apps/api/src/republisher/record-transport.ts
+++ b/apps/api/src/republisher/record-transport.ts
@@ -5,6 +5,16 @@ const IPNS_RECORD_MEDIA_TYPE = 'application/vnd.ipfs.ipns-record';
 const DEFAULT_TIMEOUT_MS = 10_000;
 
 /**
+ * Ceiling on a resolved `/routing/v1` body. An IPNS record
+ * (application/vnd.ipfs.ipns-record) is metadata-scale — a signed name→value
+ * record of ~10 KB by someguy/Kubo discipline — so 64 KiB is a generous cap.
+ * fetch is time-bounded (AbortSignal.timeout) but NOT size-bounded, so without
+ * this a misbehaving/compromised routing endpoint could stream a multi-GB body
+ * into API heap and into record_cache (defense-in-depth, #702).
+ */
+const MAX_RECORD_BYTES = 64 * 1024;
+
+/**
  * The republisher's `/routing/v1` byte mover (blueprint/api.md: resolve from the
  * network, re-PUT the same bytes keyless). A dumb transport, mirroring the
  * client seam's doctrine: it never inspects, decodes, verifies, or reorders
@@ -70,7 +80,20 @@ export class RoutingV1RecordTransport extends RecordTransport {
     if (!response.ok) {
       throw new Error(`routing GET ${response.status} for ${ipnsName}`);
     }
-    return Buffer.from(await response.arrayBuffer());
+    // Reject an honestly-declared oversized body before buffering it; the
+    // post-buffer assert is the real backstop since Content-Length may be absent
+    // or lie.
+    const declared = response.headers.get('content-length');
+    if (declared !== null && Number(declared) > MAX_RECORD_BYTES) {
+      throw new Error(`routing GET body ${declared}B exceeds ${MAX_RECORD_BYTES}B for ${ipnsName}`);
+    }
+    const body = Buffer.from(await response.arrayBuffer());
+    if (body.byteLength > MAX_RECORD_BYTES) {
+      throw new Error(
+        `routing GET body ${body.byteLength}B exceeds ${MAX_RECORD_BYTES}B for ${ipnsName}`
+      );
+    }
+    return body;
   }
 
   async republish(ipnsName: string, record: Buffer): Promise<void> {


### PR DESCRIPTION
## What

Two API durability hardening fixes.

### #714 — serialize retire's post-commit unpin against a concurrent upload

The retire post-commit unpin fired outside any lock. Between the retire transaction releasing its per-CID xact lock and the Kubo unpin, a concurrent upload could re-pin the same CID under the upload path's `pin-durability:` session lock, commit a fresh pin row, and return success — the lagging unpin then destroyed freshly-pinned, durably-held bytes (data loss).

Retire now takes that **same** session key per CID via `withSessionAdvisoryLock`, recounts survivor pin rows **under** the lock, and skips the unpin when a survivor exists. `pinDurabilityLockKey` is hoisted out of `content.service` into the shared `common/advisory-lock` module so the upload and retire paths provably share one key (`content.service` now imports it — the removal there is the intended counterpart of the hoist, not drift).

- retire↔upload is serialized by the `pin-durability:` **session** lock (upload holds it across commit→pin; retire recounts under it).
- retire↔retire is serialized by the per-CID **xact** lock inside the transaction (`lockTokens`), so only the last retire to reach true global-zero carries the CID to the post-commit unpin — exactly once, never twice.

Tests: an adversarial real-Postgres interleave (upload holds the session lock and commits a racing row inside retire's commit→unpin window → retire skips), a global-zero exactly-once case, and a stripped-session-lock **negative control** that reproduces the pre-fix data loss.

### #702 — cap the record-transport resolved body

`RoutingV1RecordTransport.resolve()` now bounds a resolved `/routing/v1` body to a 64 KiB `MAX_RECORD_BYTES` ceiling: a `Content-Length` pre-check rejects an honestly-declared oversized body before buffering, and a post-buffer `byteLength` assert backstops absent/lying headers so an oversized record can never be returned or enter `record_cache` (defense-in-depth). New unit test covers in-bounds-at-ceiling accept plus oversized reject via declared / absent / lying-small Content-Length.

## Verification

- `pnpm --filter api typecheck` — clean (exit 0)
- `pnpm --filter api test` — 20 files, 184 unit tests pass
- api integration suite (`registry.service.integration`) — 10 tests pass against local Postgres (incl. the 3 new #714 cases)
- eslint on the touched files — clean (fixed prettier formatting in the new test file)

## Self-review

`/security-review` + `/simplify` plus an independent reviewer pass (trust-critical, data-loss race):

- Data-loss race confirmed closed — the survivor recount runs strictly under the acquired session lock.
- retire↔retire unpins exactly once at global-zero (serialized by the txn xact lock).
- New failure mode noted and accepted: a lock-timeout 503 after the retire txn already committed leaves the row deleted but the pin not explicitly unpinned. This is fail-safe (bytes kept, not lost — strictly better than the data loss it replaces) and the pin store's own GC reclaims the lingering CID.
- No key/seed handling or sensitive logging introduced; determinism seams untouched.

## Known residual (tracked)

The #702 cap rejects post-buffer; for an absent/lying `Content-Length` the body is still fully buffered by `response.arrayBuffer()` before the assert, so heap is not stream-bounded. `ROUTING_V1_URL` is operator-configured CipherBox infra (someguy/Kubo), so this is defense-in-depth against compromised infra, not attacker-controlled input. Streaming-level heap bounding tracked in #722.

Closes #714
Closes #702


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retirement handling to prevent premature unpinning when content is re-pinned concurrently.
  - Retire operations now complete successfully during durability-lock contention, deferring cleanup for later garbage collection.
  - Added safeguards against oversized IPNS routing responses, rejecting payloads larger than 64 KiB before excessive buffering.

- **Tests**
  - Expanded coverage for concurrent retirement, lock contention, and response-size validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->