### PR TITLE
feat(web): host the engine worker and land the local facade transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,7 @@ version = "0.0.0"
 dependencies = [
  "cipherbox-engine",
  "console_error_panic_hook",
+ "futures-util",
  "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -14,34 +14,33 @@ publish.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-# Test-only: compiles the browser seam conformance bridge (`src/conformance.rs`),
-# which adapts JS seam objects to the engine seam traits and re-exports the
-# engine's per-seam conformance kits (via `cipherbox-engine/test-kit`) as
-# wasm-bindgen runners. The `packages/client` browser suite builds the WASM
-# module with this feature; the production artifact (built without it) never
-# pulls the test kit or these deps.
-conformance = [
-    "dep:js-sys",
-    "dep:wasm-bindgen-futures",
-    "dep:console_error_panic_hook",
-    "cipherbox-engine/test-kit",
-]
+# Test-only: compiles the browser seam conformance runners (`src/conformance.rs`),
+# which drive the engine's per-seam conformance kits (via `cipherbox-engine/
+# test-kit`) against the shared `seams_bridge` adapters. The `packages/client`
+# browser suite builds the WASM module with this feature; the production
+# artifact (built without it) never pulls the test kit.
+conformance = ["cipherbox-engine/test-kit"]
 
 [dependencies]
 cipherbox-engine.workspace = true
 wasm-bindgen = "0.2"
 
-# Conformance-bridge deps (feature `conformance` only; inert otherwise).
-js-sys = { version = "0.3", optional = true }
-wasm-bindgen-futures = { version = "0.4", optional = true }
-console_error_panic_hook = { version = "0.1", optional = true }
+# Browser wasm host deps: the engine worker host (`src/host.rs`) and the shared
+# seam adapters (`src/seams_bridge.rs`) marshal JS values, drive engine futures,
+# surface panics, and source entropy. getrandom's `wasm_js` backend wires to
+# `crypto.getRandomValues` in the worker scope (`.cargo/config.toml`
+# `getrandom_backend="wasm_js"`). Scoped to wasm32-unknown-unknown — the browser
+# target — so native workspace builds/tests skip the JS glue entirely.
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+js-sys = "0.3"
+wasm-bindgen-futures = "0.4"
+console_error_panic_hook = "0.1"
+getrandom = { version = "0.3", features = ["wasm_js"] }
+# Async mutex: serializes the single engine writer across `.await` (concurrent
+# `start`/`command` queue rather than double-borrowing), and bounds `nextEvent`
+# to one outstanding stream read.
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 
-# Browser-shaped test deps only (wasm32-unknown-unknown): the boundary tests
-# run under wasm-bindgen-test-runner, and getrandom's `wasm_js` backend proves
-# the `crypto.getRandomValues` worker-scope wiring. No production getrandom use
-# yet — the engine takes injected entropy; the entropy seam impl lands with the
-# worker-hosting slice. The `getrandom_backend="wasm_js"` cfg is in
-# `.cargo/config.toml`.
+# The boundary tests run under wasm-bindgen-test-runner.
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
-getrandom = { version = "0.3", features = ["wasm_js"] }

--- a/crates/wasm/src/conformance.rs
+++ b/crates/wasm/src/conformance.rs
@@ -1,81 +1,33 @@
-//! Browser seam conformance bridge (feature `conformance`, wasm target only).
+//! Browser seam conformance bridge (feature `conformance`, browser wasm only).
 //!
 //! The engine ships one reusable conformance kit per seam trait
 //! (`cipherbox_engine::testkit::conformance`, blueprint/testing.md "Seam
-//! conformance kits"). The web seam implementations, however, are JavaScript
-//! (`packages/client` — IndexedDB, OPFS, `fetch`), so they cannot implement a
-//! Rust trait directly. This module is the boundary bridge: for each seam it
-//! declares the JS object's method surface as a wasm-bindgen import, wraps it
-//! in a Rust adapter that implements the engine seam trait, and exports one
-//! async runner that drives the engine's own kit against the adapter. The
-//! `packages/client` browser suite calls these runners in a real browser
-//! worker, so the same contract that the in-memory fakes pass in cargo tests
-//! is enforced against real IndexedDB and OPFS.
+//! conformance kits"). This module re-exports each kit as a wasm-bindgen runner
+//! that drives it against the real JS seam (adapted in `seams_bridge`) in a
+//! real browser worker, so the same contract the in-memory fakes pass in cargo
+//! tests is enforced against real IndexedDB and OPFS.
 //!
 //! The runners are `async fn`s: each returns a JS `Promise` that resolves when
 //! the kit passes. A contract violation panics inside the kit (its `assert!`s);
 //! `console_error_panic_hook` surfaces the assertion message to the browser
 //! console, and the harness observes the non-resolution as a failure.
 //!
-//! Numeric seam values (floors, sequence numbers, op ids, byte totals) cross
-//! this test bridge as `f64`. The production facade carries `u64`s as `bigint`
-//! (blueprint/web-client.md "Boundary hygiene"); the conformance kits' value
-//! domain is far below `Number.MAX_SAFE_INTEGER`, so the narrowing is lossless
-//! for the test path and keeps the JS seams working in plain numbers.
+//! This module also exports a test-only facade constructor (`deadLetterEvent`)
+//! so the browser suite can exercise the facade's own `u64`→`bigint` boundary,
+//! which the engine does not yet emit on its own.
 
-use cipherbox_engine::seams::{
-    BoxedTask, CredentialStore, EndpointId, FloorStore, OpId, RecordTransport, Scheduler,
-    SeamError, SeamResult, SnapshotCache, StagingStore, UnixMillis,
-};
+use cipherbox_engine::facade;
+use cipherbox_engine::seams::OpId;
 use cipherbox_engine::testkit::conformance;
-use core::time::Duration;
-use js_sys::{Array, Function, Promise, Uint8Array};
+use js_sys::{Function, Promise};
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
-// ---------------------------------------------------------------------------
-// JS value helpers.
-// ---------------------------------------------------------------------------
-
-/// Maps a rejected JS seam call to an opaque [`SeamError`] (diagnostics only —
-/// a seam failure is host I/O, never a trust decision).
-fn seam_error(value: JsValue) -> SeamError {
-    // Preserve the message of a thrown `Error` (its `.message`, which
-    // `as_string` does not see); fall back to a plain string, then a generic.
-    let message = value.as_string().or_else(|| {
-        value
-            .dyn_ref::<js_sys::Error>()
-            .map(|error| String::from(error.message()))
-    });
-    SeamError::new(message.unwrap_or_else(|| "browser seam rejected".to_string()))
-}
-
-/// `number | null | undefined` → `Option<u64>`.
-fn optional_u64(value: JsValue) -> Option<u64> {
-    if value.is_null() || value.is_undefined() {
-        None
-    } else {
-        value.as_f64().map(|number| number as u64)
-    }
-}
-
-/// `number` → `u64` (0 if the value is not a number).
-fn required_u64(value: JsValue) -> u64 {
-    value
-        .as_f64()
-        .map(|number| number as u64)
-        .unwrap_or_default()
-}
-
-/// `Uint8Array | null | undefined` → `Option<Vec<u8>>`.
-fn optional_bytes(value: JsValue) -> Option<Vec<u8>> {
-    if value.is_null() || value.is_undefined() {
-        None
-    } else {
-        Some(value.unchecked_into::<Uint8Array>().to_vec())
-    }
-}
+use crate::seams_bridge::{
+    CredentialStoreAdapter, FloorStoreAdapter, JsRecordTransportSeam, JsSchedulerSeam,
+    RecordTransportAdapter, SchedulerAdapter, SnapshotCacheAdapter, StagingStoreAdapter,
+};
 
 /// Calls a JS `() => Promise<Seam>` factory and awaits the fresh seam handle
 /// (the conformance kits' "reopen" contract).
@@ -91,77 +43,6 @@ async fn open_seam(factory: &Function) -> JsValue {
         .expect("seam factory promise must resolve")
 }
 
-// ---------------------------------------------------------------------------
-// FloorStore.
-// ---------------------------------------------------------------------------
-
-#[wasm_bindgen]
-extern "C" {
-    /// JS `FloorStoreSeam` (packages/client) — opaque handle, methods called
-    /// structurally.
-    pub type JsFloorStoreSeam;
-
-    #[wasm_bindgen(method, catch, js_name = epochFloor)]
-    async fn epoch_floor(this: &JsFloorStoreSeam, scope_id: &[u8]) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = raiseEpochFloor)]
-    async fn raise_epoch_floor(
-        this: &JsFloorStoreSeam,
-        scope_id: &[u8],
-        epoch: f64,
-    ) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = sequenceFloor)]
-    async fn sequence_floor(this: &JsFloorStoreSeam, ipns_name: &[u8]) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = raiseSequenceFloor)]
-    async fn raise_sequence_floor(
-        this: &JsFloorStoreSeam,
-        ipns_name: &[u8],
-        sequence: f64,
-    ) -> Result<JsValue, JsValue>;
-}
-
-/// The JS `FloorStoreSeam` exposes only per-key methods, so this adapter does
-/// not override `commit_floors`: web batches ride the seam's ordered fail-safe
-/// fallback (#682-safe; web-atomic is deferred — see the trait doc). The
-/// conformance kit's batch assertions therefore exercise that default here.
-struct FloorStoreAdapter {
-    js: JsFloorStoreSeam,
-}
-
-impl FloorStore for FloorStoreAdapter {
-    async fn epoch_floor(&self, scope_id: &[u8]) -> SeamResult<Option<u64>> {
-        Ok(optional_u64(
-            self.js.epoch_floor(scope_id).await.map_err(seam_error)?,
-        ))
-    }
-
-    async fn raise_epoch_floor(&self, scope_id: &[u8], epoch: u64) -> SeamResult<u64> {
-        Ok(required_u64(
-            self.js
-                .raise_epoch_floor(scope_id, epoch as f64)
-                .await
-                .map_err(seam_error)?,
-        ))
-    }
-
-    async fn sequence_floor(&self, ipns_name: &[u8]) -> SeamResult<Option<u64>> {
-        Ok(optional_u64(
-            self.js
-                .sequence_floor(ipns_name)
-                .await
-                .map_err(seam_error)?,
-        ))
-    }
-
-    async fn raise_sequence_floor(&self, ipns_name: &[u8], sequence: u64) -> SeamResult<u64> {
-        Ok(required_u64(
-            self.js
-                .raise_sequence_floor(ipns_name, sequence as f64)
-                .await
-                .map_err(seam_error)?,
-        ))
-    }
-}
-
 /// Runs the `FloorStore` conformance kit against a JS `FloorStoreSeam`,
 /// reopening a fresh handle via `factory` each time the kit asks.
 #[wasm_bindgen(js_name = runFloorStoreConformance)]
@@ -171,59 +52,6 @@ pub async fn run_floor_store_conformance(factory: Function) {
         js: open_seam(&factory).await.unchecked_into(),
     })
     .await;
-}
-
-// ---------------------------------------------------------------------------
-// SnapshotCache.
-// ---------------------------------------------------------------------------
-
-#[wasm_bindgen]
-extern "C" {
-    /// JS `SnapshotCacheSeam` (packages/client).
-    pub type JsSnapshotCacheSeam;
-
-    #[wasm_bindgen(method, catch, js_name = put)]
-    async fn put(
-        this: &JsSnapshotCacheSeam,
-        cache_key: &[u8],
-        ciphertext: &[u8],
-    ) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = get)]
-    async fn get(this: &JsSnapshotCacheSeam, cache_key: &[u8]) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = remove)]
-    async fn remove(this: &JsSnapshotCacheSeam, cache_key: &[u8]) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = clear)]
-    async fn clear(this: &JsSnapshotCacheSeam) -> Result<JsValue, JsValue>;
-}
-
-struct SnapshotCacheAdapter {
-    js: JsSnapshotCacheSeam,
-}
-
-impl SnapshotCache for SnapshotCacheAdapter {
-    async fn put(&self, cache_key: &[u8], ciphertext: &[u8]) -> SeamResult<()> {
-        self.js
-            .put(cache_key, ciphertext)
-            .await
-            .map_err(seam_error)?;
-        Ok(())
-    }
-
-    async fn get(&self, cache_key: &[u8]) -> SeamResult<Option<Vec<u8>>> {
-        Ok(optional_bytes(
-            self.js.get(cache_key).await.map_err(seam_error)?,
-        ))
-    }
-
-    async fn remove(&self, cache_key: &[u8]) -> SeamResult<()> {
-        self.js.remove(cache_key).await.map_err(seam_error)?;
-        Ok(())
-    }
-
-    async fn clear(&self) -> SeamResult<()> {
-        self.js.clear().await.map_err(seam_error)?;
-        Ok(())
-    }
 }
 
 /// Runs the `SnapshotCache` conformance kit against a JS `SnapshotCacheSeam`.
@@ -236,118 +64,6 @@ pub async fn run_snapshot_cache_conformance(factory: Function) {
     .await;
 }
 
-// ---------------------------------------------------------------------------
-// StagingStore.
-// ---------------------------------------------------------------------------
-
-#[wasm_bindgen]
-extern "C" {
-    /// JS `StagingStoreSeam` (packages/client).
-    pub type JsStagingStoreSeam;
-
-    #[wasm_bindgen(method, catch, js_name = enqueueOp)]
-    async fn enqueue_op(this: &JsStagingStoreSeam, op: &[u8]) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = queuedOps)]
-    async fn queued_ops(this: &JsStagingStoreSeam) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = removeOp)]
-    async fn remove_op(this: &JsStagingStoreSeam, op_id: f64) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = putStagedBytes)]
-    async fn put_staged_bytes(
-        this: &JsStagingStoreSeam,
-        staging_key: &[u8],
-        bytes: &[u8],
-    ) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = stagedBytes)]
-    async fn staged_bytes(
-        this: &JsStagingStoreSeam,
-        staging_key: &[u8],
-    ) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = removeStagedBytes)]
-    async fn remove_staged_bytes(
-        this: &JsStagingStoreSeam,
-        staging_key: &[u8],
-    ) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = stagedKeys)]
-    async fn staged_keys(this: &JsStagingStoreSeam) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = stagedBytesTotal)]
-    async fn staged_bytes_total(this: &JsStagingStoreSeam) -> Result<JsValue, JsValue>;
-}
-
-struct StagingStoreAdapter {
-    js: JsStagingStoreSeam,
-}
-
-impl StagingStore for StagingStoreAdapter {
-    async fn enqueue_op(&self, op: &[u8]) -> SeamResult<OpId> {
-        Ok(OpId(required_u64(
-            self.js.enqueue_op(op).await.map_err(seam_error)?,
-        )))
-    }
-
-    async fn queued_ops(&self) -> SeamResult<Vec<(OpId, Vec<u8>)>> {
-        let value = self.js.queued_ops().await.map_err(seam_error)?;
-        let array: Array = value.dyn_into().expect("queuedOps must return an array");
-        let mut ops = Vec::with_capacity(array.length() as usize);
-        for entry in array.iter() {
-            let pair: Array = entry
-                .dyn_into()
-                .expect("each queued op must be a [id, bytes] pair");
-            let op_id = OpId(required_u64(pair.get(0)));
-            let bytes = pair.get(1).unchecked_into::<Uint8Array>().to_vec();
-            ops.push((op_id, bytes));
-        }
-        Ok(ops)
-    }
-
-    async fn remove_op(&self, op_id: OpId) -> SeamResult<()> {
-        self.js
-            .remove_op(op_id.0 as f64)
-            .await
-            .map_err(seam_error)?;
-        Ok(())
-    }
-
-    async fn put_staged_bytes(&self, staging_key: &[u8], bytes: &[u8]) -> SeamResult<()> {
-        self.js
-            .put_staged_bytes(staging_key, bytes)
-            .await
-            .map_err(seam_error)?;
-        Ok(())
-    }
-
-    async fn staged_bytes(&self, staging_key: &[u8]) -> SeamResult<Option<Vec<u8>>> {
-        Ok(optional_bytes(
-            self.js
-                .staged_bytes(staging_key)
-                .await
-                .map_err(seam_error)?,
-        ))
-    }
-
-    async fn remove_staged_bytes(&self, staging_key: &[u8]) -> SeamResult<()> {
-        self.js
-            .remove_staged_bytes(staging_key)
-            .await
-            .map_err(seam_error)?;
-        Ok(())
-    }
-
-    async fn staged_keys(&self) -> SeamResult<Vec<Vec<u8>>> {
-        let value = self.js.staged_keys().await.map_err(seam_error)?;
-        let array: Array = value.dyn_into().expect("stagedKeys must return an array");
-        Ok(array
-            .iter()
-            .map(|item| item.unchecked_into::<Uint8Array>().to_vec())
-            .collect())
-    }
-
-    async fn staged_bytes_total(&self) -> SeamResult<u64> {
-        Ok(required_u64(
-            self.js.staged_bytes_total().await.map_err(seam_error)?,
-        ))
-    }
-}
-
 /// Runs the `StagingStore` conformance kit against a JS `StagingStoreSeam`.
 #[wasm_bindgen(js_name = runStagingStoreConformance)]
 pub async fn run_staging_store_conformance(factory: Function) {
@@ -356,51 +72,6 @@ pub async fn run_staging_store_conformance(factory: Function) {
         js: open_seam(&factory).await.unchecked_into(),
     })
     .await;
-}
-
-// ---------------------------------------------------------------------------
-// CredentialStore.
-// ---------------------------------------------------------------------------
-
-#[wasm_bindgen]
-extern "C" {
-    /// JS `CredentialStoreSeam` (packages/client).
-    pub type JsCredentialStoreSeam;
-
-    #[wasm_bindgen(method, catch, js_name = storeRefreshToken)]
-    async fn store_refresh_token(
-        this: &JsCredentialStoreSeam,
-        refresh_token: &[u8],
-    ) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = loadRefreshToken)]
-    async fn load_refresh_token(this: &JsCredentialStoreSeam) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = clearRefreshToken)]
-    async fn clear_refresh_token(this: &JsCredentialStoreSeam) -> Result<JsValue, JsValue>;
-}
-
-struct CredentialStoreAdapter {
-    js: JsCredentialStoreSeam,
-}
-
-impl CredentialStore for CredentialStoreAdapter {
-    async fn store_refresh_token(&self, refresh_token: &[u8]) -> SeamResult<()> {
-        self.js
-            .store_refresh_token(refresh_token)
-            .await
-            .map_err(seam_error)?;
-        Ok(())
-    }
-
-    async fn load_refresh_token(&self) -> SeamResult<Option<Vec<u8>>> {
-        Ok(optional_bytes(
-            self.js.load_refresh_token().await.map_err(seam_error)?,
-        ))
-    }
-
-    async fn clear_refresh_token(&self) -> SeamResult<()> {
-        self.js.clear_refresh_token().await.map_err(seam_error)?;
-        Ok(())
-    }
 }
 
 /// Runs the `CredentialStore` conformance kit against a JS `CredentialStoreSeam`
@@ -414,43 +85,6 @@ pub async fn run_credential_store_conformance(factory: Function) {
     .await;
 }
 
-// ---------------------------------------------------------------------------
-// Scheduler.
-// ---------------------------------------------------------------------------
-
-#[wasm_bindgen]
-extern "C" {
-    /// JS `SchedulerSeam` (packages/client) — clock and delays only; background
-    /// task execution is engine-side.
-    pub type JsSchedulerSeam;
-
-    #[wasm_bindgen(method, js_name = now)]
-    fn now(this: &JsSchedulerSeam) -> f64;
-    #[wasm_bindgen(method, catch, js_name = sleep)]
-    async fn sleep(this: &JsSchedulerSeam, duration_ms: f64) -> Result<JsValue, JsValue>;
-}
-
-struct SchedulerAdapter {
-    js: JsSchedulerSeam,
-}
-
-impl Scheduler for SchedulerAdapter {
-    fn now(&self) -> UnixMillis {
-        UnixMillis(self.js.now() as u64)
-    }
-
-    async fn sleep(&self, duration: Duration) {
-        // Best-effort: a timer rejection is not a seam contract violation.
-        let _ = self.js.sleep(duration.as_millis() as f64).await;
-    }
-
-    fn spawn(&self, task: BoxedTask) {
-        // Background tasks run on the engine's own single-threaded executor via
-        // the worker microtask queue — never handed across the JS boundary.
-        wasm_bindgen_futures::spawn_local(task);
-    }
-}
-
 /// Runs the `Scheduler` conformance kit against a JS `SchedulerSeam`.
 #[wasm_bindgen(js_name = runSchedulerConformance)]
 pub async fn run_scheduler_conformance(scheduler: JsSchedulerSeam) {
@@ -459,71 +93,9 @@ pub async fn run_scheduler_conformance(scheduler: JsSchedulerSeam) {
     conformance::scheduler::check(&adapter).await;
 }
 
-// ---------------------------------------------------------------------------
-// RecordTransport.
-// ---------------------------------------------------------------------------
-
-#[wasm_bindgen]
-extern "C" {
-    /// JS `RecordTransportSeam` (packages/client).
-    pub type JsRecordTransportSeam;
-
-    #[wasm_bindgen(method, js_name = endpoints)]
-    fn endpoints(this: &JsRecordTransportSeam) -> Vec<String>;
-    #[wasm_bindgen(method, catch, js_name = getRecord)]
-    async fn get_record(
-        this: &JsRecordTransportSeam,
-        endpoint: &str,
-        routing_key: &str,
-    ) -> Result<JsValue, JsValue>;
-    #[wasm_bindgen(method, catch, js_name = putRecord)]
-    async fn put_record(
-        this: &JsRecordTransportSeam,
-        endpoint: &str,
-        routing_key: &str,
-        record: &[u8],
-    ) -> Result<JsValue, JsValue>;
-}
-
-struct RecordTransportAdapter {
-    js: JsRecordTransportSeam,
-}
-
-impl RecordTransport for RecordTransportAdapter {
-    fn endpoints(&self) -> Vec<EndpointId> {
-        self.js.endpoints().into_iter().map(EndpointId).collect()
-    }
-
-    async fn get_record(
-        &self,
-        endpoint: &EndpointId,
-        routing_key: &str,
-    ) -> SeamResult<Option<Vec<u8>>> {
-        Ok(optional_bytes(
-            self.js
-                .get_record(&endpoint.0, routing_key)
-                .await
-                .map_err(seam_error)?,
-        ))
-    }
-
-    async fn put_record(
-        &self,
-        endpoint: &EndpointId,
-        routing_key: &str,
-        record: &[u8],
-    ) -> SeamResult<()> {
-        self.js
-            .put_record(&endpoint.0, routing_key, record)
-            .await
-            .map_err(seam_error)?;
-        Ok(())
-    }
-}
-
-/// Runs the `RecordTransport` conformance kit against a JS
-/// `RecordTransportSeam`. The caller supplies a fresh (unpublished) routing key
-/// and the record bytes to round-trip.
+/// Runs the `RecordTransport` conformance kit against a JS `RecordTransportSeam`.
+/// The caller supplies a fresh (unpublished) routing key and the record bytes
+/// to round-trip.
 #[wasm_bindgen(js_name = runRecordTransportConformance)]
 pub async fn run_record_transport_conformance(
     transport: JsRecordTransportSeam,
@@ -533,4 +105,12 @@ pub async fn run_record_transport_conformance(
     console_error_panic_hook::set_once();
     let adapter = RecordTransportAdapter { js: transport };
     conformance::record_transport::check(&adapter, &routing_key, &record).await;
+}
+
+/// Test-only: builds a `deadLetter` facade event carrying `opId`. The op id is
+/// a `u64`, so the browser suite can assert the facade's `u64`→`bigint`
+/// boundary round-trips a value beyond `Number.MAX_SAFE_INTEGER` intact.
+#[wasm_bindgen(js_name = deadLetterEvent)]
+pub fn dead_letter_event(op_id: u64) -> crate::Event {
+    crate::Event::from_facade(facade::Event::DeadLetter { op_id: OpId(op_id) })
 }

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -22,10 +22,11 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
 use crate::seams_bridge::{
-    CredentialStoreAdapter, FloorStoreAdapter, HttpAdapter, JsCredentialStoreSeam, JsFloorStoreSeam,
-    JsHttpSeam, JsMailboxSeam, JsRecordTransportSeam, JsRefreshHintSourceSeam, JsSchedulerSeam,
-    JsSnapshotCacheSeam, JsStagingStoreSeam, MailboxAdapter, RecordTransportAdapter,
-    RefreshHintSourceAdapter, SchedulerAdapter, SnapshotCacheAdapter, StagingStoreAdapter,
+    CredentialStoreAdapter, FloorStoreAdapter, HttpAdapter, JsCredentialStoreSeam,
+    JsFloorStoreSeam, JsHttpSeam, JsMailboxSeam, JsRecordTransportSeam, JsRefreshHintSourceSeam,
+    JsSchedulerSeam, JsSnapshotCacheSeam, JsStagingStoreSeam, MailboxAdapter,
+    RecordTransportAdapter, RefreshHintSourceAdapter, SchedulerAdapter, SnapshotCacheAdapter,
+    StagingStoreAdapter,
 };
 use crate::{Command, Event};
 

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -1,0 +1,184 @@
+//! The production engine host: constructs the one engine instance over the
+//! browser seams and exposes `start` / `command` / `nextEvent` to the worker.
+//!
+//! Loaded inside `packages/client`'s dedicated engine worker (never the UI
+//! realm). `start` and `command` mutate the single engine writer behind an
+//! async mutex, so concurrent calls queue rather than race; `nextEvent` reads
+//! the independent event stream and runs concurrently with a command.
+//!
+//! Key material lives only in this worker's WASM linear memory: the login
+//! secret enters once through `start` (copied into the engine's `Zeroizing`
+//! store, then dropped), and nothing key-shaped is ever returned across the
+//! boundary — the command surface carries only intent, the event surface only
+//! key-free view state (blueprint/web-client.md "Memory hygiene").
+
+use std::rc::Rc;
+
+use cipherbox_engine::facade::{Engine, EventStream, LoginSecret};
+use cipherbox_engine::{Entropy, EntropyError, SeamSet, SeamTypes, SyncTimingProfile};
+use futures_util::lock::Mutex;
+use js_sys::{Promise, Reflect};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::future_to_promise;
+
+use crate::seams_bridge::{
+    CredentialStoreAdapter, FloorStoreAdapter, HttpAdapter, JsCredentialStoreSeam, JsFloorStoreSeam,
+    JsHttpSeam, JsMailboxSeam, JsRecordTransportSeam, JsRefreshHintSourceSeam, JsSchedulerSeam,
+    JsSnapshotCacheSeam, JsStagingStoreSeam, MailboxAdapter, RecordTransportAdapter,
+    RefreshHintSourceAdapter, SchedulerAdapter, SnapshotCacheAdapter, StagingStoreAdapter,
+};
+use crate::{Command, Event};
+
+/// The web host's concrete seam family (blueprint/engine.md `SeamTypes`): every
+/// engine seam is a JS-object adapter from `seams_bridge`.
+struct WebSeamTypes;
+
+impl SeamTypes for WebSeamTypes {
+    type FloorStore = FloorStoreAdapter;
+    type RecordTransport = RecordTransportAdapter;
+    type Http = HttpAdapter;
+    type Mailbox = MailboxAdapter;
+    type RefreshHintSource = RefreshHintSourceAdapter;
+    type Scheduler = SchedulerAdapter;
+    type StagingStore = StagingStoreAdapter;
+    type SnapshotCache = SnapshotCacheAdapter;
+    type CredentialStore = CredentialStoreAdapter;
+}
+
+/// Production entropy: the target's `getrandom`, whose wasm backend wires to
+/// `crypto.getRandomValues` in the worker scope (`.cargo/config.toml`
+/// `getrandom_backend="wasm_js"`). Fail-closed — never substitutes predictable
+/// bytes.
+struct GetrandomEntropy;
+
+impl Entropy for GetrandomEntropy {
+    fn fill(&mut self, dest: &mut [u8]) -> Result<(), EntropyError> {
+        getrandom::fill(dest).map_err(|error| EntropyError::new(error.to_string()))
+    }
+}
+
+/// Pulls one named seam off the JS seam bag, failing closed if it is missing.
+fn take_seam<T: JsCast>(bag: &JsValue, key: &str) -> Result<T, JsError> {
+    let value = Reflect::get(bag, &JsValue::from_str(key))
+        .map_err(|_| JsError::new(&format!("seams.{key} is not readable")))?;
+    if value.is_undefined() || value.is_null() {
+        return Err(JsError::new(&format!("seams.{key} is required")));
+    }
+    Ok(value.unchecked_into())
+}
+
+/// The one long-lived engine instance for this origin, hosted in the worker.
+#[wasm_bindgen]
+pub struct EngineHandle {
+    engine: Rc<Mutex<Engine<WebSeamTypes>>>,
+    events: Rc<Mutex<EventStream>>,
+}
+
+#[wasm_bindgen]
+impl EngineHandle {
+    /// Builds the engine over the browser seams. `seams` is a plain object with
+    /// one property per engine seam (`floorStore`, `recordTransport`, `http`,
+    /// `mailbox`, `refreshHints`, `scheduler`, `stagingStore`, `snapshotCache`,
+    /// `credentialStore`); a missing seam fails closed. `profile` selects the
+    /// sync timing policy (`"ci"` for the compressed e2e cadences, production
+    /// otherwise).
+    #[wasm_bindgen(constructor)]
+    pub fn new(seams: JsValue, profile: Option<String>) -> Result<EngineHandle, JsError> {
+        console_error_panic_hook::set_once();
+
+        let seam_set = SeamSet::<WebSeamTypes> {
+            floor_store: FloorStoreAdapter {
+                js: take_seam::<JsFloorStoreSeam>(&seams, "floorStore")?,
+            },
+            record_transport: RecordTransportAdapter {
+                js: take_seam::<JsRecordTransportSeam>(&seams, "recordTransport")?,
+            },
+            http: HttpAdapter {
+                js: take_seam::<JsHttpSeam>(&seams, "http")?,
+            },
+            mailbox: MailboxAdapter {
+                js: take_seam::<JsMailboxSeam>(&seams, "mailbox")?,
+            },
+            refresh_hints: RefreshHintSourceAdapter {
+                js: take_seam::<JsRefreshHintSourceSeam>(&seams, "refreshHints")?,
+            },
+            scheduler: SchedulerAdapter {
+                js: take_seam::<JsSchedulerSeam>(&seams, "scheduler")?,
+            },
+            staging_store: StagingStoreAdapter {
+                js: take_seam::<JsStagingStoreSeam>(&seams, "stagingStore")?,
+            },
+            snapshot_cache: SnapshotCacheAdapter {
+                js: take_seam::<JsSnapshotCacheSeam>(&seams, "snapshotCache")?,
+            },
+            credential_store: CredentialStoreAdapter {
+                js: take_seam::<JsCredentialStoreSeam>(&seams, "credentialStore")?,
+            },
+        };
+
+        let profile = match profile.as_deref() {
+            Some("ci") => SyncTimingProfile::CI,
+            _ => SyncTimingProfile::PRODUCTION,
+        };
+
+        let (engine, events) = Engine::new(seam_set, Box::new(GetrandomEntropy), profile);
+        Ok(EngineHandle {
+            engine: Rc::new(Mutex::new(engine)),
+            events: Rc::new(Mutex::new(events)),
+        })
+    }
+
+    /// Cold start: consumes the login secret and brings the engine up (identity
+    /// derivation, vault-pointer resolve, floor cold-seed, root adoption, first
+    /// snapshot event — the engine's non-circular sequence). The secret is
+    /// copied into the engine's `Zeroizing` store here and never leaves.
+    /// Resolves on success; rejects with the engine error otherwise.
+    pub fn start(&self, secret: Vec<u8>) -> Promise {
+        let engine = self.engine.clone();
+        future_to_promise(async move {
+            engine
+                .lock()
+                .await
+                .start(LoginSecret::new(secret))
+                .await
+                .map_err(engine_error)?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
+    /// Executes one engine command — the single write entry point. Consumes the
+    /// command value. Resolves on success; rejects with the engine error.
+    pub fn command(&self, command: Command) -> Promise {
+        let engine = self.engine.clone();
+        let facade_command = command.into_facade();
+        future_to_promise(async move {
+            engine
+                .lock()
+                .await
+                .command(facade_command)
+                .await
+                .map_err(engine_error)?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
+    /// Awaits the next event on the one-way stream, or resolves to `undefined`
+    /// once the engine is gone. At most one call may be outstanding.
+    #[wasm_bindgen(js_name = nextEvent)]
+    pub fn next_event(&self) -> Promise {
+        let events = self.events.clone();
+        future_to_promise(async move {
+            let next = events.lock().await.next().await;
+            Ok(match next {
+                Some(event) => Event::from_facade(event).into(),
+                None => JsValue::UNDEFINED,
+            })
+        })
+    }
+}
+
+/// Renders an engine error as a rejection value (diagnostic string, no key
+/// material — the engine's `Display` is redacted by construction).
+fn engine_error(error: cipherbox_engine::facade::EngineError) -> JsValue {
+    JsError::new(&error.to_string()).into()
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -31,10 +31,20 @@
 use cipherbox_engine::facade;
 use wasm_bindgen::prelude::*;
 
+// Shared JS-seam → engine-seam adapters (browser wasm target only): both the
+// production engine host and the test-only conformance bridge build on them.
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+mod seams_bridge;
+
+// The production engine host: constructs the one engine instance over the
+// browser seams and exposes `start`/`command`/`nextEvent` to the worker.
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+mod host;
+
 // Test-only browser seam conformance bridge. Compiled only for the browser
 // suite's WASM build (`--features conformance` on the wasm target); the
 // production artifact never pulls the engine test kit or these bindings.
-#[cfg(all(feature = "conformance", target_family = "wasm"))]
+#[cfg(all(feature = "conformance", target_family = "wasm", target_os = "unknown"))]
 mod conformance;
 
 // ---------------------------------------------------------------------------

--- a/crates/wasm/src/seams_bridge.rs
+++ b/crates/wasm/src/seams_bridge.rs
@@ -244,12 +244,14 @@ impl StagingStore for StagingStoreAdapter {
 
     async fn queued_ops(&self) -> SeamResult<Vec<(OpId, Vec<u8>)>> {
         let value = self.js.queued_ops().await.map_err(seam_error)?;
-        let array: Array = value.dyn_into().expect("queuedOps must return an array");
+        let array: Array = value
+            .dyn_into()
+            .map_err(|_| SeamError::new("queuedOps must return an array"))?;
         let mut ops = Vec::with_capacity(array.length() as usize);
         for entry in array.iter() {
             let pair: Array = entry
                 .dyn_into()
-                .expect("each queued op must be a [id, bytes] pair");
+                .map_err(|_| SeamError::new("each queued op must be a [id, bytes] pair"))?;
             let op_id = OpId(required_u64(pair.get(0)));
             let bytes = pair.get(1).unchecked_into::<Uint8Array>().to_vec();
             ops.push((op_id, bytes));
@@ -292,7 +294,9 @@ impl StagingStore for StagingStoreAdapter {
 
     async fn staged_keys(&self) -> SeamResult<Vec<Vec<u8>>> {
         let value = self.js.staged_keys().await.map_err(seam_error)?;
-        let array: Array = value.dyn_into().expect("stagedKeys must return an array");
+        let array: Array = value
+            .dyn_into()
+            .map_err(|_| SeamError::new("stagedKeys must return an array"))?;
         Ok(array
             .iter()
             .map(|item| item.unchecked_into::<Uint8Array>().to_vec())

--- a/crates/wasm/src/seams_bridge.rs
+++ b/crates/wasm/src/seams_bridge.rs
@@ -1,0 +1,652 @@
+//! JS-seam → engine-seam adapters (wasm, browser target).
+//!
+//! Every browser seam is JavaScript (`packages/client` — IndexedDB, OPFS,
+//! `fetch`), so it cannot implement a Rust trait directly. For each of the nine
+//! engine seam traits this module declares the JS object's method surface as a
+//! wasm-bindgen import and wraps it in a Rust adapter that implements the trait.
+//! Two consumers share these adapters:
+//!
+//! - `host` builds the production [`crate::host::EngineHandle`] over them, and
+//! - `conformance` (test-only) drives the engine's per-seam conformance kits
+//!   against them in a real browser worker.
+//!
+//! No seam holds logic: the adapters move opaque bytes and marshal primitives,
+//! nothing more — every trust decision already happened below the facade
+//! (blueprint/engine.md). Numeric seam values (floors, sequence numbers, op
+//! ids, byte totals) cross as `f64`, matching the JS seam signatures
+//! (`packages/client/src/seams/types.ts`); their value domain is far below
+//! `Number.MAX_SAFE_INTEGER`. The facade's own `u64` boundary (op ids, sizes)
+//! crosses as `bigint` and lives in `lib.rs`, not here.
+
+use cipherbox_engine::seams::{
+    BoxedTask, CredentialStore, EndpointId, FloorStore, Http, HttpMethod, HttpRequest,
+    HttpResponse, Mailbox, MailboxItem, OpId, RecordTransport, RefreshHint, RefreshHintSource,
+    Scheduler, SeamError, SeamResult, SnapshotCache, StagingStore, UnixMillis,
+};
+use core::time::Duration;
+use js_sys::{Array, Object, Reflect, Uint8Array};
+use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
+
+// ---------------------------------------------------------------------------
+// JS value helpers.
+// ---------------------------------------------------------------------------
+
+/// Maps a rejected JS seam call to an opaque [`SeamError`] (diagnostics only —
+/// a seam failure is host I/O, never a trust decision).
+pub(crate) fn seam_error(value: JsValue) -> SeamError {
+    // Preserve the message of a thrown `Error` (its `.message`, which
+    // `as_string` does not see); fall back to a plain string, then a generic.
+    let message = value.as_string().or_else(|| {
+        value
+            .dyn_ref::<js_sys::Error>()
+            .map(|error| String::from(error.message()))
+    });
+    SeamError::new(message.unwrap_or_else(|| "browser seam rejected".to_string()))
+}
+
+/// `number | null | undefined` → `Option<u64>`.
+pub(crate) fn optional_u64(value: JsValue) -> Option<u64> {
+    if value.is_null() || value.is_undefined() {
+        None
+    } else {
+        value.as_f64().map(|number| number as u64)
+    }
+}
+
+/// `number` → `u64` (0 if the value is not a number).
+pub(crate) fn required_u64(value: JsValue) -> u64 {
+    value
+        .as_f64()
+        .map(|number| number as u64)
+        .unwrap_or_default()
+}
+
+/// `Uint8Array | null | undefined` → `Option<Vec<u8>>`.
+pub(crate) fn optional_bytes(value: JsValue) -> Option<Vec<u8>> {
+    if value.is_null() || value.is_undefined() {
+        None
+    } else {
+        Some(value.unchecked_into::<Uint8Array>().to_vec())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FloorStore.
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen]
+extern "C" {
+    /// JS `FloorStoreSeam` (packages/client) — opaque handle, methods called
+    /// structurally.
+    pub type JsFloorStoreSeam;
+
+    #[wasm_bindgen(method, catch, js_name = epochFloor)]
+    async fn epoch_floor(this: &JsFloorStoreSeam, scope_id: &[u8]) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = raiseEpochFloor)]
+    async fn raise_epoch_floor(
+        this: &JsFloorStoreSeam,
+        scope_id: &[u8],
+        epoch: f64,
+    ) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = sequenceFloor)]
+    async fn sequence_floor(this: &JsFloorStoreSeam, ipns_name: &[u8]) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = raiseSequenceFloor)]
+    async fn raise_sequence_floor(
+        this: &JsFloorStoreSeam,
+        ipns_name: &[u8],
+        sequence: f64,
+    ) -> Result<JsValue, JsValue>;
+}
+
+/// The JS `FloorStoreSeam` exposes only per-key methods, so this adapter does
+/// not override `commit_floors`: web batches ride the seam's ordered fail-safe
+/// fallback (#682-safe; web-atomic is deferred — see the trait doc).
+pub(crate) struct FloorStoreAdapter {
+    pub(crate) js: JsFloorStoreSeam,
+}
+
+impl FloorStore for FloorStoreAdapter {
+    async fn epoch_floor(&self, scope_id: &[u8]) -> SeamResult<Option<u64>> {
+        Ok(optional_u64(
+            self.js.epoch_floor(scope_id).await.map_err(seam_error)?,
+        ))
+    }
+
+    async fn raise_epoch_floor(&self, scope_id: &[u8], epoch: u64) -> SeamResult<u64> {
+        Ok(required_u64(
+            self.js
+                .raise_epoch_floor(scope_id, epoch as f64)
+                .await
+                .map_err(seam_error)?,
+        ))
+    }
+
+    async fn sequence_floor(&self, ipns_name: &[u8]) -> SeamResult<Option<u64>> {
+        Ok(optional_u64(
+            self.js
+                .sequence_floor(ipns_name)
+                .await
+                .map_err(seam_error)?,
+        ))
+    }
+
+    async fn raise_sequence_floor(&self, ipns_name: &[u8], sequence: u64) -> SeamResult<u64> {
+        Ok(required_u64(
+            self.js
+                .raise_sequence_floor(ipns_name, sequence as f64)
+                .await
+                .map_err(seam_error)?,
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotCache.
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen]
+extern "C" {
+    /// JS `SnapshotCacheSeam` (packages/client).
+    pub type JsSnapshotCacheSeam;
+
+    #[wasm_bindgen(method, catch, js_name = put)]
+    async fn put(
+        this: &JsSnapshotCacheSeam,
+        cache_key: &[u8],
+        ciphertext: &[u8],
+    ) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = get)]
+    async fn get(this: &JsSnapshotCacheSeam, cache_key: &[u8]) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = remove)]
+    async fn remove(this: &JsSnapshotCacheSeam, cache_key: &[u8]) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = clear)]
+    async fn clear(this: &JsSnapshotCacheSeam) -> Result<JsValue, JsValue>;
+}
+
+pub(crate) struct SnapshotCacheAdapter {
+    pub(crate) js: JsSnapshotCacheSeam,
+}
+
+impl SnapshotCache for SnapshotCacheAdapter {
+    async fn put(&self, cache_key: &[u8], ciphertext: &[u8]) -> SeamResult<()> {
+        self.js
+            .put(cache_key, ciphertext)
+            .await
+            .map_err(seam_error)?;
+        Ok(())
+    }
+
+    async fn get(&self, cache_key: &[u8]) -> SeamResult<Option<Vec<u8>>> {
+        Ok(optional_bytes(
+            self.js.get(cache_key).await.map_err(seam_error)?,
+        ))
+    }
+
+    async fn remove(&self, cache_key: &[u8]) -> SeamResult<()> {
+        self.js.remove(cache_key).await.map_err(seam_error)?;
+        Ok(())
+    }
+
+    async fn clear(&self) -> SeamResult<()> {
+        self.js.clear().await.map_err(seam_error)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// StagingStore.
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen]
+extern "C" {
+    /// JS `StagingStoreSeam` (packages/client).
+    pub type JsStagingStoreSeam;
+
+    #[wasm_bindgen(method, catch, js_name = enqueueOp)]
+    async fn enqueue_op(this: &JsStagingStoreSeam, op: &[u8]) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = queuedOps)]
+    async fn queued_ops(this: &JsStagingStoreSeam) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = removeOp)]
+    async fn remove_op(this: &JsStagingStoreSeam, op_id: f64) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = putStagedBytes)]
+    async fn put_staged_bytes(
+        this: &JsStagingStoreSeam,
+        staging_key: &[u8],
+        bytes: &[u8],
+    ) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = stagedBytes)]
+    async fn staged_bytes(
+        this: &JsStagingStoreSeam,
+        staging_key: &[u8],
+    ) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = removeStagedBytes)]
+    async fn remove_staged_bytes(
+        this: &JsStagingStoreSeam,
+        staging_key: &[u8],
+    ) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = stagedKeys)]
+    async fn staged_keys(this: &JsStagingStoreSeam) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = stagedBytesTotal)]
+    async fn staged_bytes_total(this: &JsStagingStoreSeam) -> Result<JsValue, JsValue>;
+}
+
+pub(crate) struct StagingStoreAdapter {
+    pub(crate) js: JsStagingStoreSeam,
+}
+
+impl StagingStore for StagingStoreAdapter {
+    async fn enqueue_op(&self, op: &[u8]) -> SeamResult<OpId> {
+        Ok(OpId(required_u64(
+            self.js.enqueue_op(op).await.map_err(seam_error)?,
+        )))
+    }
+
+    async fn queued_ops(&self) -> SeamResult<Vec<(OpId, Vec<u8>)>> {
+        let value = self.js.queued_ops().await.map_err(seam_error)?;
+        let array: Array = value.dyn_into().expect("queuedOps must return an array");
+        let mut ops = Vec::with_capacity(array.length() as usize);
+        for entry in array.iter() {
+            let pair: Array = entry
+                .dyn_into()
+                .expect("each queued op must be a [id, bytes] pair");
+            let op_id = OpId(required_u64(pair.get(0)));
+            let bytes = pair.get(1).unchecked_into::<Uint8Array>().to_vec();
+            ops.push((op_id, bytes));
+        }
+        Ok(ops)
+    }
+
+    async fn remove_op(&self, op_id: OpId) -> SeamResult<()> {
+        self.js
+            .remove_op(op_id.0 as f64)
+            .await
+            .map_err(seam_error)?;
+        Ok(())
+    }
+
+    async fn put_staged_bytes(&self, staging_key: &[u8], bytes: &[u8]) -> SeamResult<()> {
+        self.js
+            .put_staged_bytes(staging_key, bytes)
+            .await
+            .map_err(seam_error)?;
+        Ok(())
+    }
+
+    async fn staged_bytes(&self, staging_key: &[u8]) -> SeamResult<Option<Vec<u8>>> {
+        Ok(optional_bytes(
+            self.js
+                .staged_bytes(staging_key)
+                .await
+                .map_err(seam_error)?,
+        ))
+    }
+
+    async fn remove_staged_bytes(&self, staging_key: &[u8]) -> SeamResult<()> {
+        self.js
+            .remove_staged_bytes(staging_key)
+            .await
+            .map_err(seam_error)?;
+        Ok(())
+    }
+
+    async fn staged_keys(&self) -> SeamResult<Vec<Vec<u8>>> {
+        let value = self.js.staged_keys().await.map_err(seam_error)?;
+        let array: Array = value.dyn_into().expect("stagedKeys must return an array");
+        Ok(array
+            .iter()
+            .map(|item| item.unchecked_into::<Uint8Array>().to_vec())
+            .collect())
+    }
+
+    async fn staged_bytes_total(&self) -> SeamResult<u64> {
+        Ok(required_u64(
+            self.js.staged_bytes_total().await.map_err(seam_error)?,
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CredentialStore.
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen]
+extern "C" {
+    /// JS `CredentialStoreSeam` (packages/client).
+    pub type JsCredentialStoreSeam;
+
+    #[wasm_bindgen(method, catch, js_name = storeRefreshToken)]
+    async fn store_refresh_token(
+        this: &JsCredentialStoreSeam,
+        refresh_token: &[u8],
+    ) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = loadRefreshToken)]
+    async fn load_refresh_token(this: &JsCredentialStoreSeam) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = clearRefreshToken)]
+    async fn clear_refresh_token(this: &JsCredentialStoreSeam) -> Result<JsValue, JsValue>;
+}
+
+pub(crate) struct CredentialStoreAdapter {
+    pub(crate) js: JsCredentialStoreSeam,
+}
+
+impl CredentialStore for CredentialStoreAdapter {
+    async fn store_refresh_token(&self, refresh_token: &[u8]) -> SeamResult<()> {
+        self.js
+            .store_refresh_token(refresh_token)
+            .await
+            .map_err(seam_error)?;
+        Ok(())
+    }
+
+    async fn load_refresh_token(&self) -> SeamResult<Option<Vec<u8>>> {
+        Ok(optional_bytes(
+            self.js.load_refresh_token().await.map_err(seam_error)?,
+        ))
+    }
+
+    async fn clear_refresh_token(&self) -> SeamResult<()> {
+        self.js.clear_refresh_token().await.map_err(seam_error)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler.
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen]
+extern "C" {
+    /// JS `SchedulerSeam` (packages/client) — clock and delays only; background
+    /// task execution is engine-side.
+    pub type JsSchedulerSeam;
+
+    #[wasm_bindgen(method, js_name = now)]
+    fn now(this: &JsSchedulerSeam) -> f64;
+    #[wasm_bindgen(method, catch, js_name = sleep)]
+    async fn sleep(this: &JsSchedulerSeam, duration_ms: f64) -> Result<JsValue, JsValue>;
+}
+
+pub(crate) struct SchedulerAdapter {
+    pub(crate) js: JsSchedulerSeam,
+}
+
+impl Scheduler for SchedulerAdapter {
+    fn now(&self) -> UnixMillis {
+        UnixMillis(self.js.now() as u64)
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        // Best-effort: a timer rejection is not a seam contract violation.
+        let _ = self.js.sleep(duration.as_millis() as f64).await;
+    }
+
+    fn spawn(&self, task: BoxedTask) {
+        // Background tasks run on the engine's own single-threaded executor via
+        // the worker microtask queue — never handed across the JS boundary.
+        wasm_bindgen_futures::spawn_local(task);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RecordTransport.
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen]
+extern "C" {
+    /// JS `RecordTransportSeam` (packages/client).
+    pub type JsRecordTransportSeam;
+
+    #[wasm_bindgen(method, js_name = endpoints)]
+    fn endpoints(this: &JsRecordTransportSeam) -> Vec<String>;
+    #[wasm_bindgen(method, catch, js_name = getRecord)]
+    async fn get_record(
+        this: &JsRecordTransportSeam,
+        endpoint: &str,
+        routing_key: &str,
+    ) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = putRecord)]
+    async fn put_record(
+        this: &JsRecordTransportSeam,
+        endpoint: &str,
+        routing_key: &str,
+        record: &[u8],
+    ) -> Result<JsValue, JsValue>;
+}
+
+pub(crate) struct RecordTransportAdapter {
+    pub(crate) js: JsRecordTransportSeam,
+}
+
+impl RecordTransport for RecordTransportAdapter {
+    fn endpoints(&self) -> Vec<EndpointId> {
+        self.js.endpoints().into_iter().map(EndpointId).collect()
+    }
+
+    async fn get_record(
+        &self,
+        endpoint: &EndpointId,
+        routing_key: &str,
+    ) -> SeamResult<Option<Vec<u8>>> {
+        Ok(optional_bytes(
+            self.js
+                .get_record(&endpoint.0, routing_key)
+                .await
+                .map_err(seam_error)?,
+        ))
+    }
+
+    async fn put_record(
+        &self,
+        endpoint: &EndpointId,
+        routing_key: &str,
+        record: &[u8],
+    ) -> SeamResult<()> {
+        self.js
+            .put_record(&endpoint.0, routing_key, record)
+            .await
+            .map_err(seam_error)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Http.
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen]
+extern "C" {
+    /// JS `HttpSeam` (packages/client) — `send(HttpRequestData)`.
+    pub type JsHttpSeam;
+
+    #[wasm_bindgen(method, catch, js_name = send)]
+    async fn send(this: &JsHttpSeam, request: JsValue) -> Result<JsValue, JsValue>;
+}
+
+fn http_method_str(method: HttpMethod) -> &'static str {
+    match method {
+        HttpMethod::Get => "GET",
+        HttpMethod::Post => "POST",
+        HttpMethod::Put => "PUT",
+        HttpMethod::Patch => "PATCH",
+        HttpMethod::Delete => "DELETE",
+        HttpMethod::Head => "HEAD",
+    }
+}
+
+/// Marshals an engine [`HttpRequest`] to the JS `HttpRequestData` shape.
+fn http_request_to_js(request: &HttpRequest) -> JsValue {
+    let object = Object::new();
+    let _ = Reflect::set(
+        &object,
+        &JsValue::from_str("method"),
+        &JsValue::from_str(http_method_str(request.method)),
+    );
+    let _ = Reflect::set(
+        &object,
+        &JsValue::from_str("url"),
+        &JsValue::from_str(&request.url),
+    );
+    let headers = Array::new();
+    for (name, value) in &request.headers {
+        let pair = Array::new();
+        pair.push(&JsValue::from_str(name));
+        pair.push(&JsValue::from_str(value));
+        headers.push(&pair);
+    }
+    let _ = Reflect::set(&object, &JsValue::from_str("headers"), &headers);
+    let body = match &request.body {
+        Some(bytes) => Uint8Array::from(bytes.as_slice()).into(),
+        None => JsValue::NULL,
+    };
+    let _ = Reflect::set(&object, &JsValue::from_str("body"), &body);
+    object.into()
+}
+
+/// Parses the JS `HttpResponseData` shape back into an engine [`HttpResponse`].
+fn http_response_from_js(value: JsValue) -> SeamResult<HttpResponse> {
+    let status = Reflect::get(&value, &JsValue::from_str("status"))
+        .ok()
+        .and_then(|status| status.as_f64())
+        .ok_or_else(|| SeamError::new("http response missing numeric status"))?
+        as u16;
+    let headers_value = Reflect::get(&value, &JsValue::from_str("headers"))
+        .map_err(|_| SeamError::new("http response missing headers"))?;
+    let headers_array: Array = headers_value
+        .dyn_into()
+        .map_err(|_| SeamError::new("http response headers must be an array"))?;
+    let mut headers = Vec::with_capacity(headers_array.length() as usize);
+    for entry in headers_array.iter() {
+        let pair: Array = entry
+            .dyn_into()
+            .map_err(|_| SeamError::new("each response header must be a [name, value] pair"))?;
+        let name = pair.get(0).as_string().unwrap_or_default();
+        let header_value = pair.get(1).as_string().unwrap_or_default();
+        headers.push((name, header_value));
+    }
+    let body = optional_bytes(
+        Reflect::get(&value, &JsValue::from_str("body"))
+            .map_err(|_| SeamError::new("http response missing body"))?,
+    )
+    .unwrap_or_default();
+    Ok(HttpResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
+pub(crate) struct HttpAdapter {
+    pub(crate) js: JsHttpSeam,
+}
+
+impl Http for HttpAdapter {
+    async fn send(&self, request: HttpRequest) -> SeamResult<HttpResponse> {
+        let response = self
+            .js
+            .send(http_request_to_js(&request))
+            .await
+            .map_err(seam_error)?;
+        http_response_from_js(response)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mailbox.
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen]
+extern "C" {
+    /// JS `MailboxSeam` (packages/client).
+    pub type JsMailboxSeam;
+
+    #[wasm_bindgen(method, catch, js_name = post)]
+    async fn post(
+        this: &JsMailboxSeam,
+        recipient_public_key: &[u8],
+        sealed_payload: &[u8],
+        idempotency_key: &str,
+    ) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = poll)]
+    async fn poll(this: &JsMailboxSeam) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = ack)]
+    async fn ack(this: &JsMailboxSeam, item_id: &str) -> Result<JsValue, JsValue>;
+}
+
+pub(crate) struct MailboxAdapter {
+    pub(crate) js: JsMailboxSeam,
+}
+
+impl Mailbox for MailboxAdapter {
+    async fn post(
+        &self,
+        recipient_public_key: &[u8],
+        sealed_payload: &[u8],
+        idempotency_key: &str,
+    ) -> SeamResult<()> {
+        self.js
+            .post(recipient_public_key, sealed_payload, idempotency_key)
+            .await
+            .map_err(seam_error)?;
+        Ok(())
+    }
+
+    async fn poll(&self) -> SeamResult<Vec<MailboxItem>> {
+        let value = self.js.poll().await.map_err(seam_error)?;
+        let array: Array = value
+            .dyn_into()
+            .map_err(|_| SeamError::new("mailbox poll must return an array"))?;
+        let mut items = Vec::with_capacity(array.length() as usize);
+        for entry in array.iter() {
+            let item_id = Reflect::get(&entry, &JsValue::from_str("itemId"))
+                .ok()
+                .and_then(|id| id.as_string())
+                .ok_or_else(|| SeamError::new("mailbox item missing itemId"))?;
+            let sealed_payload = optional_bytes(
+                Reflect::get(&entry, &JsValue::from_str("sealedPayload"))
+                    .map_err(|_| SeamError::new("mailbox item missing sealedPayload"))?,
+            )
+            .unwrap_or_default();
+            items.push(MailboxItem {
+                item_id,
+                sealed_payload,
+            });
+        }
+        Ok(items)
+    }
+
+    async fn ack(&self, item_id: &str) -> SeamResult<()> {
+        self.js.ack(item_id).await.map_err(seam_error)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RefreshHintSource.
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen]
+extern "C" {
+    /// JS `RefreshHintSourceSeam` (packages/client). `nextHint` resolves to a
+    /// truthy value for a hint, or `null`/`undefined` when the source is
+    /// closed for good.
+    pub type JsRefreshHintSourceSeam;
+
+    #[wasm_bindgen(method, catch, js_name = nextHint)]
+    async fn next_hint(this: &JsRefreshHintSourceSeam) -> Result<JsValue, JsValue>;
+}
+
+pub(crate) struct RefreshHintSourceAdapter {
+    pub(crate) js: JsRefreshHintSourceSeam,
+}
+
+impl RefreshHintSource for RefreshHintSourceAdapter {
+    async fn next_hint(&mut self) -> Option<RefreshHint> {
+        // A rejected or nullish resolution means end-of-stream; the engine
+        // stops listening. Losing a hint costs staleness, never correctness.
+        match self.js.next_hint().await {
+            Ok(value) if !value.is_null() && !value.is_undefined() => Some(RefreshHint),
+            _ => None,
+        }
+    }
+}

--- a/packages/client/src/facade.test.ts
+++ b/packages/client/src/facade.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { EngineFacade } from './facade.js';
+import type { EngineEventListener, EngineTransport } from './transport.js';
+import type { CommandDescriptor } from './worker/protocol.js';
+
+class FakeTransport implements EngineTransport {
+  started: ArrayBuffer[] = [];
+  commands: Array<{ command: CommandDescriptor; transfer: Transferable[] }> = [];
+  listeners: EngineEventListener[] = [];
+  closed = false;
+
+  start(secret: ArrayBuffer): Promise<void> {
+    this.started.push(secret);
+    return Promise.resolve();
+  }
+
+  command(command: CommandDescriptor, transfer: Transferable[]): Promise<void> {
+    this.commands.push({ command, transfer });
+    return Promise.resolve();
+  }
+
+  subscribe(listener: EngineEventListener): () => void {
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter((entry) => entry !== listener);
+    };
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+describe('EngineFacade', () => {
+  it('forwards the login secret to the transport on start', async () => {
+    const transport = new FakeTransport();
+    const secret = new Uint8Array([9, 9, 9]).buffer;
+    await new EngineFacade(transport).start(secret);
+    expect(transport.started).toEqual([secret]);
+  });
+
+  it('sends logout then tears the transport down', async () => {
+    const transport = new FakeTransport();
+    await new EngineFacade(transport).logout();
+    expect(transport.commands.map((entry) => entry.command.kind)).toEqual(['logout']);
+    expect(transport.closed).toBe(true);
+  });
+
+  it('transfers file content on create and marks it as a file', async () => {
+    const transport = new FakeTransport();
+    const content = new Uint8Array([1, 2, 3]).buffer;
+    await new EngineFacade(transport).create(new Uint8Array(16), 'a.txt', 'file', content);
+
+    const { command, transfer } = transport.commands[0];
+    expect(command).toMatchObject({ kind: 'create', name: 'a.txt', nodeKind: 'file', content });
+    expect(transfer).toEqual([content]);
+  });
+
+  it('sends a folder create with no content and no transfer', async () => {
+    const transport = new FakeTransport();
+    await new EngineFacade(transport).create(new Uint8Array(16), 'docs', 'folder');
+
+    const { command, transfer } = transport.commands[0];
+    expect(command).toMatchObject({ kind: 'create', nodeKind: 'folder', content: null });
+    expect(transfer).toEqual([]);
+  });
+
+  it('transfers content on updateContent', async () => {
+    const transport = new FakeTransport();
+    const content = new Uint8Array([4, 5]).buffer;
+    await new EngineFacade(transport).updateContent(new Uint8Array(16), content);
+
+    expect(transport.commands[0].command).toMatchObject({ kind: 'updateContent', content });
+    expect(transport.commands[0].transfer).toEqual([content]);
+  });
+
+  it('carries the permission on a grant', async () => {
+    const transport = new FakeTransport();
+    const node = new Uint8Array(16);
+    const recipient = new Uint8Array([7, 7]);
+    await new EngineFacade(transport).grant(node, recipient, 'write');
+
+    expect(transport.commands[0].command).toMatchObject({
+      kind: 'grant',
+      permission: 'write',
+      recipientIdentityPublicKey: recipient,
+    });
+  });
+
+  it('delegates event subscription to the transport', () => {
+    const transport = new FakeTransport();
+    const facade = new EngineFacade(transport);
+    const unsubscribe = facade.subscribe(() => undefined);
+    expect(transport.listeners).toHaveLength(1);
+    unsubscribe();
+    expect(transport.listeners).toHaveLength(0);
+  });
+});

--- a/packages/client/src/facade.test.ts
+++ b/packages/client/src/facade.test.ts
@@ -47,6 +47,13 @@ describe('EngineFacade', () => {
     expect(transport.closed).toBe(true);
   });
 
+  it('tears the transport down even when the logout command rejects', async () => {
+    const transport = new FakeTransport();
+    transport.command = () => Promise.reject(new Error('logout unimplemented'));
+    await expect(new EngineFacade(transport).logout()).resolves.toBeUndefined();
+    expect(transport.closed).toBe(true);
+  });
+
   it('transfers file content on create and marks it as a file', async () => {
     const transport = new FakeTransport();
     const content = new Uint8Array([1, 2, 3]).buffer;

--- a/packages/client/src/facade.ts
+++ b/packages/client/src/facade.ts
@@ -1,0 +1,127 @@
+/**
+ * The typed async facade over the worker-hosted engine (blueprint/web-client.md
+ * "Engine hosting"). One method per facade command plus cold-start (`start`) and
+ * teardown (`logout`); every call is data in, a settled promise out. The facade
+ * adds transport, never semantics — it wraps the engine facade, it does not
+ * extend it.
+ *
+ * It holds no engine logic and no key material: `start` transfers the login
+ * secret straight through to the worker (which zeroes its copy after the engine
+ * consumes it), and events arrive as key-free view descriptors.
+ */
+
+import type { EngineEventListener, EngineTransport } from './transport.js';
+import type { CommandDescriptor, NodeKind, Permission } from './worker/protocol.js';
+
+export class EngineFacade {
+  constructor(private readonly transport: EngineTransport) {}
+
+  /**
+   * Cold start: hands the login secret to the engine once, transferred (the
+   * caller's `secret` buffer is detached by the transfer). Resolves when the
+   * engine has run its cold-start sequence (vault-pointer resolve, floor
+   * cold-seed, root adoption, first snapshot event).
+   */
+  start(secret: ArrayBuffer): Promise<void> {
+    return this.transport.start(secret);
+  }
+
+  /**
+   * Logout: the engine zeroizes its WASM state, then the worker is torn down.
+   * Durable seams (floors, op queue, staged bytes, ciphertext cache) survive by
+   * design.
+   */
+  async logout(): Promise<void> {
+    // Teardown is unconditional: tearing the worker down frees the WASM memory
+    // (the terminal zeroization) regardless of how the engine answers the
+    // zeroize command, so a rejected/unimplemented logout must not strand the
+    // worker alive.
+    try {
+      await this.command({ kind: 'logout' });
+    } catch {
+      // fall through to teardown
+    }
+    this.transport.close();
+  }
+
+  /** Subscribes to the one-way engine event stream; returns an unsubscribe. */
+  subscribe(listener: EngineEventListener): () => void {
+    return this.transport.subscribe(listener);
+  }
+
+  create(
+    parent: Uint8Array,
+    name: string,
+    kind: NodeKind,
+    content: ArrayBuffer | null = null
+  ): Promise<void> {
+    return this.command(
+      { kind: 'create', parent, name, nodeKind: kind, content },
+      content === null ? [] : [content]
+    );
+  }
+
+  updateContent(node: Uint8Array, content: ArrayBuffer): Promise<void> {
+    return this.command({ kind: 'updateContent', node, content }, [content]);
+  }
+
+  delete(node: Uint8Array): Promise<void> {
+    return this.command({ kind: 'delete', node });
+  }
+
+  rename(node: Uint8Array, newName: string): Promise<void> {
+    return this.command({ kind: 'rename', node, newName });
+  }
+
+  relink(node: Uint8Array, newParent: Uint8Array): Promise<void> {
+    return this.command({ kind: 'relink', node, newParent });
+  }
+
+  setFocus(node: Uint8Array | null): Promise<void> {
+    return this.command({ kind: 'setFocus', node });
+  }
+
+  manualRefresh(): Promise<void> {
+    return this.command({ kind: 'manualRefresh' });
+  }
+
+  importContact(contactCode: Uint8Array): Promise<void> {
+    return this.command({ kind: 'importContact', contactCode });
+  }
+
+  grant(
+    node: Uint8Array,
+    recipientIdentityPublicKey: Uint8Array,
+    permission: Permission
+  ): Promise<void> {
+    return this.command({ kind: 'grant', node, recipientIdentityPublicKey, permission });
+  }
+
+  revoke(node: Uint8Array, recipientIdentityPublicKey: Uint8Array): Promise<void> {
+    return this.command({ kind: 'revoke', node, recipientIdentityPublicKey });
+  }
+
+  downgrade(node: Uint8Array, recipientIdentityPublicKey: Uint8Array): Promise<void> {
+    return this.command({ kind: 'downgrade', node, recipientIdentityPublicKey });
+  }
+
+  createInviteLink(node: Uint8Array, permission: Permission): Promise<void> {
+    return this.command({ kind: 'createInviteLink', node, permission });
+  }
+
+  acceptShare(sealedSharePointer: Uint8Array): Promise<void> {
+    return this.command({ kind: 'acceptShare', sealedSharePointer });
+  }
+
+  rotateNow(node: Uint8Array): Promise<void> {
+    return this.command({ kind: 'rotateNow', node });
+  }
+
+  siweLogin(message: string, signature: Uint8Array): Promise<void> {
+    return this.command({ kind: 'siweLogin', message, signature });
+  }
+
+  private command(descriptor: CommandDescriptor, transfer: Transferable[] = []): Promise<void> {
+    return this.transport.command(descriptor, transfer);
+  }
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2,12 +2,44 @@
  * @cipherbox/client — WASM engine hosting and browser seams for the v2 web
  * client (blueprint/web-client.md).
  *
- * This slice lands every browser seam implementation (IndexedDB, OPFS, and
- * `fetch`) — the web side of the engine's host seam traits — and the
- * merge-blocking browser suite that runs the engine's Rust conformance kits
- * against them. The engine worker host, tab leadership, the facade transports,
- * and the Service Worker land in later slices.
+ * This layer lands every browser seam implementation (IndexedDB, OPFS, and
+ * `fetch`), the dedicated engine worker that hosts the WASM engine over those
+ * seams, the promise-correlated RPC layer, and the single typed async facade
+ * behind a transport seam. This slice ships the local (single-tab) transport;
+ * tab leadership and the broadcast transport land next (#640).
  */
 export const CLIENT_PACKAGE = '@cipherbox/client';
 
 export * from './seams/index.js';
+
+// The typed facade and its transport seam (UI realm).
+export { EngineFacade } from './facade.js';
+export { LocalTransport } from './transport.js';
+export type { EngineTransport, EngineWorkerLike, EngineEventListener } from './transport.js';
+
+// The wire protocol between the UI and the engine worker.
+export type {
+  CommandDescriptor,
+  EventDescriptor,
+  Permission,
+  NodeKind,
+  Staleness,
+  WorkerRequest,
+  WorkerMessage,
+} from './worker/protocol.js';
+
+// The engine worker host and its protocol server (worker realm).
+export { EngineHost } from './worker/engineHost.js';
+export type { EngineHostLike } from './worker/engineHost.js';
+export { serveEngine } from './worker/serve.js';
+export type { WorkerScopeLike } from './worker/serve.js';
+export { makeBrowserSeams } from './worker/browserSeams.js';
+export type { BrowserSeams, BrowserSeamsConfig } from './worker/browserSeams.js';
+export { buildCommand, readEvent } from './worker/commandCodec.js';
+export type {
+  EngineWasm,
+  WasmCommand,
+  WasmEvent,
+  WasmEngineHandle,
+  WasmNodeId,
+} from './worker/engineWasm.js';

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,36 +10,18 @@
  */
 export const CLIENT_PACKAGE = '@cipherbox/client';
 
-export * from './seams/index.js';
-
-// The typed facade and its transport seam (UI realm).
+// The UI-realm consumer contract. The worker realm is wired via `new Worker(URL)`
+// and imports its collaborators by relative path, so nothing outside this
+// package consumes the worker-realm internals through the barrel.
 export { EngineFacade } from './facade.js';
 export { LocalTransport } from './transport.js';
 export type { EngineTransport, EngineWorkerLike, EngineEventListener } from './transport.js';
 
-// The wire protocol between the UI and the engine worker.
+// The wire descriptors the UI exchanges with the engine over the transport.
 export type {
   CommandDescriptor,
   EventDescriptor,
   Permission,
   NodeKind,
   Staleness,
-  WorkerRequest,
-  WorkerMessage,
 } from './worker/protocol.js';
-
-// The engine worker host and its protocol server (worker realm).
-export { EngineHost } from './worker/engineHost.js';
-export type { EngineHostLike } from './worker/engineHost.js';
-export { serveEngine } from './worker/serve.js';
-export type { WorkerScopeLike } from './worker/serve.js';
-export { makeBrowserSeams } from './worker/browserSeams.js';
-export type { BrowserSeams, BrowserSeamsConfig } from './worker/browserSeams.js';
-export { buildCommand, readEvent } from './worker/commandCodec.js';
-export type {
-  EngineWasm,
-  WasmCommand,
-  WasmEvent,
-  WasmEngineHandle,
-  WasmNodeId,
-} from './worker/engineWasm.js';

--- a/packages/client/src/seams/index.ts
+++ b/packages/client/src/seams/index.ts
@@ -13,6 +13,8 @@ export { NoopCredentialStore } from './credentialStore.js';
 export { WorkerScheduler } from './scheduler.js';
 export { FetchRecordTransport } from './recordTransport.js';
 export { FetchHttp } from './http.js';
+export { ApiMailbox } from './mailbox.js';
+export { QueueRefreshHintSource } from './refreshHint.js';
 export type {
   FloorStoreSeam,
   SnapshotCacheSeam,
@@ -23,4 +25,7 @@ export type {
   HttpSeam,
   HttpRequestData,
   HttpResponseData,
+  MailboxSeam,
+  MailboxItemData,
+  RefreshHintSourceSeam,
 } from './types.js';

--- a/packages/client/src/seams/mailbox.ts
+++ b/packages/client/src/seams/mailbox.ts
@@ -1,0 +1,58 @@
+/**
+ * `Mailbox` — the sealed-blob discovery transport over the API, via the `Http`
+ * seam (blueprint/web-client.md seam table: "the engine's own API client over
+ * the Http seam — nothing web-specific").
+ *
+ * A pure byte mover: it addresses the recipient and moves the opaque sealed
+ * payload, and does no crypto or codec — the engine seals, unseals, and
+ * authenticates every item (#39 D9). Response parsing (the pending-item list)
+ * lands with the engine's mailbox pipeline slice; until then `poll` reports an
+ * empty inbox, which is availability, never a trust decision — nothing on this
+ * transport is load-bearing for safety.
+ */
+
+import { toHex } from './bytes.js';
+import type { HttpSeam, MailboxItemData, MailboxSeam } from './types.js';
+
+export class ApiMailbox implements MailboxSeam {
+  constructor(
+    private readonly http: HttpSeam,
+    private readonly mailboxUrl: string
+  ) {}
+
+  async post(
+    recipientPublicKey: Uint8Array,
+    sealedPayload: Uint8Array,
+    idempotencyKey: string
+  ): Promise<void> {
+    const response = await this.http.send({
+      method: 'POST',
+      url: this.mailboxUrl,
+      headers: [
+        ['content-type', 'application/octet-stream'],
+        ['idempotency-key', idempotencyKey],
+        ['x-recipient', toHex(recipientPublicKey)],
+      ],
+      body: sealedPayload,
+    });
+    if (response.status >= 300) {
+      throw new Error(`mailbox post failed: ${response.status}`);
+    }
+  }
+
+  poll(): Promise<MailboxItemData[]> {
+    return Promise.resolve([]);
+  }
+
+  async ack(itemId: string): Promise<void> {
+    const response = await this.http.send({
+      method: 'DELETE',
+      url: `${this.mailboxUrl}/${encodeURIComponent(itemId)}`,
+      headers: [],
+      body: null,
+    });
+    if (response.status >= 300 && response.status !== 404) {
+      throw new Error(`mailbox ack failed: ${response.status}`);
+    }
+  }
+}

--- a/packages/client/src/seams/refreshHint.ts
+++ b/packages/client/src/seams/refreshHint.ts
@@ -1,0 +1,43 @@
+/**
+ * `RefreshHintSource` — a queue of host events that force an immediate sync tick
+ * (blueprint/web-client.md seam table).
+ *
+ * The host pushes a hint on UI navigation, `visibilitychange` regain, `online`
+ * reconnect, or a cross-tab focus signal; the engine awaits `nextHint`. Hints
+ * carry no payload (v2.0) and are best-effort accelerators — a dropped hint
+ * costs staleness bounded by the poll cadence, never correctness.
+ */
+
+import type { RefreshHintSourceSeam } from './types.js';
+
+export class QueueRefreshHintSource implements RefreshHintSourceSeam {
+  private pending = 0;
+  private waiters: Array<(hint: true | null) => void> = [];
+  private closed = false;
+
+  /** Signals one refresh hint (coalesced only by the engine, never dropped here). */
+  pushHint(): void {
+    if (this.closed) return;
+    const waiter = this.waiters.shift();
+    if (waiter) waiter(true);
+    else this.pending += 1;
+  }
+
+  /** Closes the source for good; the engine stops listening. */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    const waiters = this.waiters;
+    this.waiters = [];
+    for (const waiter of waiters) waiter(null);
+  }
+
+  nextHint(): Promise<true | null> {
+    if (this.pending > 0) {
+      this.pending -= 1;
+      return Promise.resolve(true);
+    }
+    if (this.closed) return Promise.resolve(null);
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+}

--- a/packages/client/src/seams/snapshotCache.ts
+++ b/packages/client/src/seams/snapshotCache.ts
@@ -36,30 +36,32 @@ export class IdbSnapshotCache implements SnapshotCacheSeam {
   }
 
   async put(cacheKey: Uint8Array, ciphertext: Uint8Array): Promise<void> {
-    // Copy synchronously, before the first await: `ciphertext` may be a view
-    // into WASM linear memory that a concurrent task's `Memory.grow()` can
-    // detach across the await, silently corrupting the stored value (#717).
+    // Encode the key and copy the value synchronously, before the first await:
+    // both may be views into WASM linear memory that a concurrent task's
+    // `Memory.grow()` can detach across the await — a detached key hexes to ''
+    // (cross-key collision) and a detached value corrupts the stored bytes (#717).
+    const storeKey = toHex(cacheKey);
     const value = ciphertext.slice();
     const db = await this.open();
     const tx = db.transaction(STORE, 'readwrite');
-    tx.objectStore(STORE).put(value, toHex(cacheKey));
+    tx.objectStore(STORE).put(value, storeKey);
     await transactionDone(tx);
   }
 
   async get(cacheKey: Uint8Array): Promise<Uint8Array | null> {
+    const storeKey = toHex(cacheKey);
     const db = await this.open();
     const tx = db.transaction(STORE, 'readonly');
-    const value = await requestResult<Uint8Array | undefined>(
-      tx.objectStore(STORE).get(toHex(cacheKey))
-    );
+    const value = await requestResult<Uint8Array | undefined>(tx.objectStore(STORE).get(storeKey));
     await transactionDone(tx);
     return value ?? null;
   }
 
   async remove(cacheKey: Uint8Array): Promise<void> {
+    const storeKey = toHex(cacheKey);
     const db = await this.open();
     const tx = db.transaction(STORE, 'readwrite');
-    tx.objectStore(STORE).delete(toHex(cacheKey));
+    tx.objectStore(STORE).delete(storeKey);
     await transactionDone(tx);
   }
 

--- a/packages/client/src/seams/snapshotCache.ts
+++ b/packages/client/src/seams/snapshotCache.ts
@@ -36,11 +36,13 @@ export class IdbSnapshotCache implements SnapshotCacheSeam {
   }
 
   async put(cacheKey: Uint8Array, ciphertext: Uint8Array): Promise<void> {
+    // Copy synchronously, before the first await: `ciphertext` may be a view
+    // into WASM linear memory that a concurrent task's `Memory.grow()` can
+    // detach across the await, silently corrupting the stored value (#717).
+    const value = ciphertext.slice();
     const db = await this.open();
     const tx = db.transaction(STORE, 'readwrite');
-    // Store a standalone copy: the value must be independent of any buffer the
-    // caller may reuse, and round-trip byte-for-byte.
-    tx.objectStore(STORE).put(ciphertext.slice(), toHex(cacheKey));
+    tx.objectStore(STORE).put(value, toHex(cacheKey));
     await transactionDone(tx);
   }
 

--- a/packages/client/src/seams/stagingStore.ts
+++ b/packages/client/src/seams/stagingStore.ts
@@ -77,13 +77,14 @@ export class OpfsStagingStore implements StagingStoreSeam {
   }
 
   async putStagedBytes(stagingKey: Uint8Array, bytes: Uint8Array): Promise<void> {
-    // Copy before the first await: `bytes` may be a view into WASM linear
-    // memory that a concurrent task's `Memory.grow()` can detach across the
-    // awaits below, so `handle.write` would truncate or throw on a detached
-    // view (#717).
+    // Encode the key and copy the value before the first await: both may be
+    // views into WASM linear memory that a concurrent task's `Memory.grow()`
+    // can detach across the awaits below — a detached key hexes to '' and a
+    // detached value truncates or throws on `handle.write` (#717).
+    const fileName = toHex(stagingKey);
     const staged = bytes.slice();
     const dir = await this.stagedDir();
-    const fileHandle = await dir.getFileHandle(toHex(stagingKey), { create: true });
+    const fileHandle = await dir.getFileHandle(fileName, { create: true });
     const handle = await fileHandle.createSyncAccessHandle();
     try {
       handle.truncate(0);
@@ -95,10 +96,13 @@ export class OpfsStagingStore implements StagingStoreSeam {
   }
 
   async stagedBytes(stagingKey: Uint8Array): Promise<Uint8Array | null> {
+    // Hex the key before the first await: a WASM-backed view detached by a
+    // concurrent `Memory.grow()` across the await would hex to '' (#717).
+    const fileName = toHex(stagingKey);
     const dir = await this.stagedDir();
     let fileHandle: FileSystemFileHandle;
     try {
-      fileHandle = await dir.getFileHandle(toHex(stagingKey));
+      fileHandle = await dir.getFileHandle(fileName);
     } catch (error) {
       if (error instanceof DOMException && error.name === 'NotFoundError') return null;
       throw error;
@@ -115,9 +119,12 @@ export class OpfsStagingStore implements StagingStoreSeam {
   }
 
   async removeStagedBytes(stagingKey: Uint8Array): Promise<void> {
+    // Hex the key before the first await: a WASM-backed view detached by a
+    // concurrent `Memory.grow()` across the await would hex to '' (#717).
+    const fileName = toHex(stagingKey);
     const dir = await this.stagedDir();
     try {
-      await dir.removeEntry(toHex(stagingKey));
+      await dir.removeEntry(fileName);
     } catch (error) {
       if (error instanceof DOMException && error.name === 'NotFoundError') return;
       throw error;

--- a/packages/client/src/seams/stagingStore.ts
+++ b/packages/client/src/seams/stagingStore.ts
@@ -48,9 +48,12 @@ export class OpfsStagingStore implements StagingStoreSeam {
   }
 
   async enqueueOp(op: Uint8Array): Promise<number> {
+    // Copy before the first await: `op` may be a view into WASM linear memory
+    // that a concurrent task's `Memory.grow()` can detach across the await (#717).
+    const staged = op.slice();
     const db = await this.open();
     const tx = db.transaction(OPS_STORE, 'readwrite');
-    const key = await requestResult<IDBValidKey>(tx.objectStore(OPS_STORE).add(op.slice()));
+    const key = await requestResult<IDBValidKey>(tx.objectStore(OPS_STORE).add(staged));
     await transactionDone(tx);
     return Number(key);
   }
@@ -74,12 +77,17 @@ export class OpfsStagingStore implements StagingStoreSeam {
   }
 
   async putStagedBytes(stagingKey: Uint8Array, bytes: Uint8Array): Promise<void> {
+    // Copy before the first await: `bytes` may be a view into WASM linear
+    // memory that a concurrent task's `Memory.grow()` can detach across the
+    // awaits below, so `handle.write` would truncate or throw on a detached
+    // view (#717).
+    const staged = bytes.slice();
     const dir = await this.stagedDir();
     const fileHandle = await dir.getFileHandle(toHex(stagingKey), { create: true });
     const handle = await fileHandle.createSyncAccessHandle();
     try {
       handle.truncate(0);
-      handle.write(bytes, { at: 0 });
+      handle.write(staged, { at: 0 });
       handle.flush();
     } finally {
       handle.close();

--- a/packages/client/src/seams/types.ts
+++ b/packages/client/src/seams/types.ts
@@ -97,3 +97,34 @@ export interface HttpResponseData {
 export interface HttpSeam {
   send(request: HttpRequestData): Promise<HttpResponseData>;
 }
+
+/** One pending mailbox item; `sealedPayload` is opaque (the engine unseals it). */
+export interface MailboxItemData {
+  itemId: string;
+  sealedPayload: Uint8Array;
+}
+
+/**
+ * Sealed-blob discovery transport (share pointers, invite claims). An
+ * integrity-untrusted byte mover: nothing on it is load-bearing for safety, and
+ * it does no crypto or codec — the engine seals, unseals, and authenticates.
+ */
+export interface MailboxSeam {
+  post(
+    recipientPublicKey: Uint8Array,
+    sealedPayload: Uint8Array,
+    idempotencyKey: string
+  ): Promise<void>;
+  poll(): Promise<MailboxItemData[]>;
+  ack(itemId: string): Promise<void>;
+}
+
+/**
+ * Host events that force an immediate sync tick (UI navigation, tab-visibility
+ * regain, `online` reconnect). `nextHint` resolves to `true` for a hint, or
+ * `null` once the source is closed for good. A hint carries no payload — losing
+ * one costs staleness, never correctness.
+ */
+export interface RefreshHintSourceSeam {
+  nextHint(): Promise<true | null>;
+}

--- a/packages/client/src/transport.test.ts
+++ b/packages/client/src/transport.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+
+import { LocalTransport, type EngineWorkerLike } from './transport.js';
+import type { EventDescriptor, WorkerMessage, WorkerRequest } from './worker/protocol.js';
+
+/** A worker stand-in: records posted requests, replays worker→UI messages. */
+class FakeWorker implements EngineWorkerLike {
+  posted: Array<{ message: WorkerRequest; transfer: Transferable[] }> = [];
+  terminated = false;
+  private messageListeners: Array<(event: MessageEvent<WorkerMessage>) => void> = [];
+  private errorListeners: Array<(event: ErrorEvent) => void> = [];
+
+  postMessage(message: WorkerRequest, transfer: Transferable[]): void {
+    this.posted.push({ message, transfer });
+  }
+
+  addEventListener(type: 'message' | 'error', listener: unknown): void {
+    if (type === 'message')
+      this.messageListeners.push(listener as (e: MessageEvent<WorkerMessage>) => void);
+    else this.errorListeners.push(listener as (e: ErrorEvent) => void);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  emit(message: WorkerMessage): void {
+    for (const listener of this.messageListeners)
+      listener({ data: message } as MessageEvent<WorkerMessage>);
+  }
+
+  emitError(message: string): void {
+    for (const listener of this.errorListeners) listener({ message } as ErrorEvent);
+  }
+}
+
+const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('LocalTransport', () => {
+  it('correlates a response to its request by id (round-trip)', async () => {
+    const worker = new FakeWorker();
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const pending = transport.command({ kind: 'manualRefresh' }, []);
+    await tick();
+
+    expect(worker.posted).toHaveLength(1);
+    const { message } = worker.posted[0];
+    expect(message.type).toBe('command');
+    worker.emit({ type: 'response', id: message.id, ok: true });
+
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it('is out-of-order safe: later-issued request answered first still correlates', async () => {
+    const worker = new FakeWorker();
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const resolved: string[] = [];
+    const first = transport
+      .command({ kind: 'manualRefresh' }, [])
+      .then(() => resolved.push('first'));
+    const second = transport
+      .command({ kind: 'delete', node: new Uint8Array(16) }, [])
+      .then(() => resolved.push('second'));
+    await tick();
+
+    const [a, b] = worker.posted.map((entry) => entry.message.id);
+    expect(a).not.toBe(b);
+    // Answer the second request first, then the first.
+    worker.emit({ type: 'response', id: b, ok: true });
+    worker.emit({ type: 'response', id: a, ok: true });
+
+    await Promise.all([first, second]);
+    expect(resolved).toEqual(['second', 'first']);
+  });
+
+  it('rejects only the matching request on an error response', async () => {
+    const worker = new FakeWorker();
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const failing = transport.command({ kind: 'manualRefresh' }, []);
+    const ok = transport.command({ kind: 'manualRefresh' }, []);
+    await tick();
+    const [idA, idB] = worker.posted.map((entry) => entry.message.id);
+
+    worker.emit({
+      type: 'response',
+      id: idA,
+      ok: false,
+      error: 'command not implemented yet: manualRefresh',
+    });
+    worker.emit({ type: 'response', id: idB, ok: true });
+
+    await expect(failing).rejects.toThrow('not implemented');
+    await expect(ok).resolves.toBeUndefined();
+  });
+
+  it('delivers events to subscribers in order, with no drops', async () => {
+    const worker = new FakeWorker();
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const received: EventDescriptor[] = [];
+    transport.subscribe((event) => received.push(event));
+
+    const sent: EventDescriptor[] = [
+      { kind: 'snapshotUpdated' },
+      { kind: 'stalenessChanged', staleness: 'stale' },
+      { kind: 'deadLetter', opId: 7n },
+      { kind: 'snapshotUpdated' },
+    ];
+    for (const event of sent) worker.emit({ type: 'event', event });
+
+    expect(received).toEqual(sent);
+  });
+
+  it('transfers the secret buffer on start', async () => {
+    const worker = new FakeWorker();
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const secret = new Uint8Array([1, 2, 3, 4]).buffer;
+    void transport.start(secret);
+    await tick();
+
+    const posted = worker.posted[0];
+    expect(posted.message.type).toBe('start');
+    expect(posted.transfer).toEqual([secret]);
+  });
+
+  it('rejects pending requests when the worker errors', async () => {
+    const worker = new FakeWorker();
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const pending = transport.command({ kind: 'manualRefresh' }, []);
+    await tick();
+    worker.emitError('worker crashed');
+
+    await expect(pending).rejects.toThrow('worker crashed');
+  });
+
+  it('rejects pending requests and terminates the worker on close', async () => {
+    const worker = new FakeWorker();
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const pending = transport.command({ kind: 'manualRefresh' }, []);
+    await tick();
+    transport.close();
+
+    await expect(pending).rejects.toThrow('closed');
+    expect(worker.terminated).toBe(true);
+  });
+});

--- a/packages/client/src/transport.test.ts
+++ b/packages/client/src/transport.test.ts
@@ -132,6 +132,62 @@ describe('LocalTransport', () => {
     expect(posted.transfer).toEqual([secret]);
   });
 
+  it('latches terminal failure on fatal: in-flight and later requests both reject, not hang', async () => {
+    const worker = new FakeWorker();
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const inFlight = transport.command({ kind: 'manualRefresh' }, []);
+    await tick();
+    worker.emit({ type: 'fatal', error: 'engine construction failed' });
+
+    // The request outstanding at fatal time rejects.
+    await expect(inFlight).rejects.toThrow('engine construction failed');
+
+    // A request issued after fatal rejects promptly rather than posting to the
+    // dead worker and waiting forever for a response.
+    const postFatal = transport.command({ kind: 'manualRefresh' }, []);
+    await expect(postFatal).rejects.toThrow('engine construction failed');
+  });
+
+  it('keeps fanning out an event after a subscriber throws', async () => {
+    const worker = new FakeWorker();
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const received: string[] = [];
+    transport.subscribe(() => received.push('first'));
+    transport.subscribe(() => {
+      throw new Error('subscriber boom');
+    });
+    transport.subscribe(() => received.push('third'));
+
+    worker.emit({ type: 'event', event: { kind: 'snapshotUpdated' } });
+
+    expect(received).toEqual(['first', 'third']);
+  });
+
+  it('does not strand a pending entry when postMessage throws synchronously', async () => {
+    const worker = new FakeWorker();
+    worker.postMessage = () => {
+      throw new DOMException('detached ArrayBuffer', 'DataCloneError');
+    };
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const failing = transport.command({ kind: 'manualRefresh' }, []);
+
+    await expect(failing).rejects.toThrow('detached ArrayBuffer');
+    // A later post succeeds and correlates, proving no id/pending was stranded.
+    worker.postMessage = FakeWorker.prototype.postMessage;
+    const ok = transport.command({ kind: 'manualRefresh' }, []);
+    await tick();
+    const posted = worker.posted.at(-1);
+    expect(posted).toBeDefined();
+    worker.emit({ type: 'response', id: posted!.message.id, ok: true });
+    await expect(ok).resolves.toBeUndefined();
+  });
+
   it('rejects pending requests when the worker errors', async () => {
     const worker = new FakeWorker();
     const transport = new LocalTransport(worker);

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -1,0 +1,133 @@
+/**
+ * The facade transport seam (blueprint/web-client.md "The facade is
+ * transport-agnostic").
+ *
+ * The facade talks to exactly one `EngineTransport`. This slice ships the
+ * **local** transport (UI ↔ its own engine worker over `postMessage`, binary
+ * payloads transferred). The leader-follower **broadcast** transport is the next
+ * slice (#640) and slots in behind this same interface — the facade never
+ * changes when leadership swaps the transport underneath it.
+ */
+
+import type {
+  CommandDescriptor,
+  EventDescriptor,
+  WorkerMessage,
+  WorkerRequest,
+} from './worker/protocol.js';
+
+/** A one-way engine → UI event subscriber. */
+export type EngineEventListener = (event: EventDescriptor) => void;
+
+export interface EngineTransport {
+  /** Hands the login secret to the engine once (transferred, not copied). */
+  start(secret: ArrayBuffer): Promise<void>;
+  /** Sends one command; `transfer` lists any owned buffers to move, not copy. */
+  command(command: CommandDescriptor, transfer: Transferable[]): Promise<void>;
+  /** Subscribes to the one-way event stream; returns an unsubscribe. */
+  subscribe(listener: EngineEventListener): () => void;
+  /** Tears the transport down; pending requests reject. */
+  close(): void;
+}
+
+/** The subset of `Worker` the local transport drives (injectable for tests). */
+export interface EngineWorkerLike {
+  postMessage(message: WorkerRequest, transfer: Transferable[]): void;
+  addEventListener(type: 'message', listener: (event: MessageEvent<WorkerMessage>) => void): void;
+  addEventListener(type: 'error', listener: (event: ErrorEvent) => void): void;
+  terminate(): void;
+}
+
+interface Pending {
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+/**
+ * UI ↔ own engine worker over `postMessage`. Correlates responses to requests
+ * by a monotonic request id, so concurrent calls answered in any order never
+ * confuse — the id is assigned here and echoed by the worker, never derived from
+ * anything the worker controls.
+ */
+export class LocalTransport implements EngineTransport {
+  private readonly pending = new Map<number, Pending>();
+  private readonly listeners = new Set<EngineEventListener>();
+  private readonly ready: Promise<void>;
+  private nextId = 1;
+  private closed = false;
+
+  constructor(private readonly worker: EngineWorkerLike) {
+    this.ready = new Promise<void>((resolveReady, rejectReady) => {
+      this.worker.addEventListener('message', (event) => {
+        const message = event.data;
+        switch (message.type) {
+          case 'ready':
+            resolveReady();
+            return;
+          case 'response': {
+            const pending = this.pending.get(message.id);
+            if (!pending) return;
+            this.pending.delete(message.id);
+            if (message.ok) pending.resolve();
+            else pending.reject(new Error(message.error));
+            return;
+          }
+          case 'event':
+            for (const listener of this.listeners) listener(message.event);
+            return;
+          case 'fatal':
+            rejectReady(new Error(message.error));
+            this.fail(new Error(message.error));
+            return;
+        }
+      });
+      this.worker.addEventListener('error', (event) => {
+        const error = new Error(event.message || 'engine worker error');
+        rejectReady(error);
+        this.fail(error);
+      });
+    });
+    // A never-observed rejection would warn; the request path re-observes it.
+    this.ready.catch(() => undefined);
+  }
+
+  start(secret: ArrayBuffer): Promise<void> {
+    return this.request((id) => ({ type: 'start', id, secret }), [secret]);
+  }
+
+  command(command: CommandDescriptor, transfer: Transferable[]): Promise<void> {
+    return this.request((id) => ({ type: 'command', id, command }), transfer);
+  }
+
+  subscribe(listener: EngineEventListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.fail(new Error('engine transport closed'));
+    this.worker.terminate();
+  }
+
+  private request(build: (id: number) => WorkerRequest, transfer: Transferable[]): Promise<void> {
+    return this.ready.then(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          if (this.closed) {
+            reject(new Error('engine transport closed'));
+            return;
+          }
+          const id = this.nextId++;
+          this.pending.set(id, { resolve, reject });
+          this.worker.postMessage(build(id), transfer);
+        })
+    );
+  }
+
+  private fail(error: Error): void {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+}

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -59,9 +59,13 @@ export class LocalTransport implements EngineTransport {
   // the worker is dead, so every request rejects here instead of posting and
   // waiting forever for a response that can never arrive.
   private terminalError: Error | null = null;
+  // Settles `ready` on teardown so a request awaiting cold start before the
+  // worker's `ready` rejects instead of hanging forever.
+  private rejectReady!: (error: Error) => void;
 
   constructor(private readonly worker: EngineWorkerLike) {
     this.ready = new Promise<void>((resolveReady, rejectReady) => {
+      this.rejectReady = rejectReady;
       this.worker.addEventListener('message', (event) => {
         const message = event.data;
         switch (message.type) {
@@ -117,11 +121,16 @@ export class LocalTransport implements EngineTransport {
   close(): void {
     if (this.closed) return;
     this.closed = true;
-    this.fail(new Error('engine transport closed'));
+    const error = new Error('engine transport closed');
+    // Reject `ready` first so a request parked on cold start unblocks with the
+    // teardown error rather than hanging; `fail` then rejects in-flight requests.
+    this.rejectReady(error);
+    this.fail(error);
     this.worker.terminate();
   }
 
   private request(build: (id: number) => WorkerRequest, transfer: Transferable[]): Promise<void> {
+    if (this.terminalError) return Promise.reject(this.terminalError);
     return this.ready.then(
       () =>
         new Promise<void>((resolve, reject) => {

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -55,6 +55,10 @@ export class LocalTransport implements EngineTransport {
   private readonly ready: Promise<void>;
   private nextId = 1;
   private closed = false;
+  // A fatal worker message, `error` event, or teardown latches this. Once set,
+  // the worker is dead, so every request rejects here instead of posting and
+  // waiting forever for a response that can never arrive.
+  private terminalError: Error | null = null;
 
   constructor(private readonly worker: EngineWorkerLike) {
     this.ready = new Promise<void>((resolveReady, rejectReady) => {
@@ -73,7 +77,13 @@ export class LocalTransport implements EngineTransport {
             return;
           }
           case 'event':
-            for (const listener of this.listeners) listener(message.event);
+            for (const listener of this.listeners) {
+              try {
+                listener(message.event);
+              } catch {
+                // One throwing subscriber must not drop the event for the rest.
+              }
+            }
             return;
           case 'fatal':
             rejectReady(new Error(message.error));
@@ -115,18 +125,26 @@ export class LocalTransport implements EngineTransport {
     return this.ready.then(
       () =>
         new Promise<void>((resolve, reject) => {
-          if (this.closed) {
-            reject(new Error('engine transport closed'));
+          if (this.terminalError) {
+            reject(this.terminalError);
             return;
           }
           const id = this.nextId++;
           this.pending.set(id, { resolve, reject });
-          this.worker.postMessage(build(id), transfer);
+          try {
+            this.worker.postMessage(build(id), transfer);
+          } catch (error) {
+            // A synchronous post failure (detached buffer, bad transferable)
+            // must not strand the pending entry.
+            this.pending.delete(id);
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
         })
     );
   }
 
   private fail(error: Error): void {
+    this.terminalError ??= error;
     for (const pending of this.pending.values()) pending.reject(error);
     this.pending.clear();
   }

--- a/packages/client/src/worker/browserSeams.ts
+++ b/packages/client/src/worker/browserSeams.ts
@@ -1,0 +1,55 @@
+/**
+ * Constructs the nine browser seams for one engine instance, inside the worker
+ * realm (blueprint/web-client.md "Browser seams"). The seam bag's property names
+ * are the constructor contract the WASM `EngineHandle` reads.
+ */
+
+import {
+  ApiMailbox,
+  FetchHttp,
+  FetchRecordTransport,
+  IdbFloorStore,
+  IdbSnapshotCache,
+  NoopCredentialStore,
+  OpfsStagingStore,
+  QueueRefreshHintSource,
+  WorkerScheduler,
+} from '../seams/index.js';
+
+export interface BrowserSeamsConfig {
+  /** Delegated-routing endpoint set for `RecordTransport` (someguy + public). */
+  recordEndpoints: string[];
+  /** Absolute URL of the API mailbox collection. */
+  mailboxUrl: string;
+  /** Prefix for the IndexedDB/OPFS store names (namespaces per origin/test). */
+  dbPrefix?: string;
+}
+
+/** The seam bag plus the live refresh-hint source the host feeds from UI events. */
+export interface BrowserSeams {
+  floorStore: IdbFloorStore;
+  recordTransport: FetchRecordTransport;
+  http: FetchHttp;
+  mailbox: ApiMailbox;
+  refreshHints: QueueRefreshHintSource;
+  scheduler: WorkerScheduler;
+  stagingStore: OpfsStagingStore;
+  snapshotCache: IdbSnapshotCache;
+  credentialStore: NoopCredentialStore;
+}
+
+export function makeBrowserSeams(config: BrowserSeamsConfig): BrowserSeams {
+  const prefix = config.dbPrefix ?? 'cipherbox';
+  const http = new FetchHttp();
+  return {
+    floorStore: new IdbFloorStore(`${prefix}-floors`),
+    recordTransport: new FetchRecordTransport(config.recordEndpoints),
+    http,
+    mailbox: new ApiMailbox(http, config.mailboxUrl),
+    refreshHints: new QueueRefreshHintSource(),
+    scheduler: new WorkerScheduler(),
+    stagingStore: new OpfsStagingStore(`${prefix}-staging`),
+    snapshotCache: new IdbSnapshotCache(`${prefix}-snapshot-cache`),
+    credentialStore: new NoopCredentialStore(),
+  };
+}

--- a/packages/client/src/worker/commandCodec.ts
+++ b/packages/client/src/worker/commandCodec.ts
@@ -1,0 +1,124 @@
+/**
+ * Translates between the plain-data wire protocol and the wasm-bindgen facade
+ * types, inside the engine worker realm.
+ *
+ * `buildCommand` rebuilds a real `Command` from a descriptor via the generated
+ * builders; `readEvent` reads a `Event`'s key-free getters into a descriptor.
+ * No interpretation, no crypto — the engine below the facade owns all of that.
+ */
+
+import type {
+  CommandDescriptor,
+  EventDescriptor,
+  NodeKind,
+  Permission,
+  Staleness,
+} from './protocol.js';
+import type { EngineWasm, WasmCommand, WasmEvent, WasmNodeId } from './engineWasm.js';
+
+function nodeId(wasm: EngineWasm, bytes: Uint8Array): WasmNodeId {
+  return wasm.NodeId.fromBytes(bytes);
+}
+
+function nodeKind(wasm: EngineWasm, kind: NodeKind): number {
+  return kind === 'file' ? wasm.NodeKind.File : wasm.NodeKind.Folder;
+}
+
+function permission(wasm: EngineWasm, level: Permission): number {
+  return level === 'read' ? wasm.Permission.Read : wasm.Permission.Write;
+}
+
+/** Rebuilds a wasm-bindgen `Command` from its wire descriptor. */
+export function buildCommand(wasm: EngineWasm, descriptor: CommandDescriptor): WasmCommand {
+  switch (descriptor.kind) {
+    case 'create':
+      return wasm.Command.create(
+        nodeId(wasm, descriptor.parent),
+        descriptor.name,
+        nodeKind(wasm, descriptor.nodeKind),
+        // The builder copies into WASM memory synchronously; a view over the
+        // transferred content buffer is safe (no await between here and the copy).
+        descriptor.content === null ? undefined : new Uint8Array(descriptor.content)
+      );
+    case 'delete':
+      return wasm.Command.delete(nodeId(wasm, descriptor.node));
+    case 'rename':
+      return wasm.Command.rename(nodeId(wasm, descriptor.node), descriptor.newName);
+    case 'relink':
+      return wasm.Command.relink(nodeId(wasm, descriptor.node), nodeId(wasm, descriptor.newParent));
+    case 'updateContent':
+      return wasm.Command.updateContent(
+        nodeId(wasm, descriptor.node),
+        new Uint8Array(descriptor.content)
+      );
+    case 'setFocus':
+      return wasm.Command.setFocus(
+        descriptor.node === null ? undefined : nodeId(wasm, descriptor.node)
+      );
+    case 'manualRefresh':
+      return wasm.Command.manualRefresh();
+    case 'importContact':
+      return wasm.Command.importContact(descriptor.contactCode);
+    case 'grant':
+      return wasm.Command.grant(
+        nodeId(wasm, descriptor.node),
+        descriptor.recipientIdentityPublicKey,
+        permission(wasm, descriptor.permission)
+      );
+    case 'revoke':
+      return wasm.Command.revoke(
+        nodeId(wasm, descriptor.node),
+        descriptor.recipientIdentityPublicKey
+      );
+    case 'downgrade':
+      return wasm.Command.downgrade(
+        nodeId(wasm, descriptor.node),
+        descriptor.recipientIdentityPublicKey
+      );
+    case 'createInviteLink':
+      return wasm.Command.createInviteLink(
+        nodeId(wasm, descriptor.node),
+        permission(wasm, descriptor.permission)
+      );
+    case 'acceptShare':
+      return wasm.Command.acceptShare(descriptor.sealedSharePointer);
+    case 'rotateNow':
+      return wasm.Command.rotateNow(nodeId(wasm, descriptor.node));
+    case 'siweLogin':
+      return wasm.Command.siweLogin(descriptor.message, descriptor.signature);
+    case 'logout':
+      return wasm.Command.logout();
+  }
+}
+
+function staleness(wasm: EngineWasm, level: number): Staleness {
+  switch (level) {
+    case wasm.Staleness.Reconciling:
+      return 'reconciling';
+    case wasm.Staleness.Stale:
+      return 'stale';
+    case wasm.Staleness.Offline:
+      return 'offline';
+    default:
+      return 'fresh';
+  }
+}
+
+/** Reads a wasm-bindgen `Event`'s key-free getters into a wire descriptor. */
+export function readEvent(wasm: EngineWasm, event: WasmEvent): EventDescriptor {
+  switch (event.kind) {
+    case 'stalenessChanged':
+      return {
+        kind: 'stalenessChanged',
+        staleness: staleness(wasm, event.staleness ?? wasm.Staleness.Fresh),
+      };
+    case 'withheldUpdateEscalation':
+      return { kind: 'withheldUpdateEscalation', ipnsName: event.ipnsName ?? new Uint8Array() };
+    case 'deadLetter':
+      return { kind: 'deadLetter', opId: event.opId ?? 0n };
+    case 'attributableAbuse':
+      return { kind: 'attributableAbuse', description: event.description ?? '' };
+    default:
+      return { kind: 'snapshotUpdated' };
+  }
+}

--- a/packages/client/src/worker/commandCodec.ts
+++ b/packages/client/src/worker/commandCodec.ts
@@ -28,7 +28,6 @@ function permission(wasm: EngineWasm, level: Permission): number {
   return level === 'read' ? wasm.Permission.Read : wasm.Permission.Write;
 }
 
-/** Rebuilds a wasm-bindgen `Command` from its wire descriptor. */
 export function buildCommand(wasm: EngineWasm, descriptor: CommandDescriptor): WasmCommand {
   switch (descriptor.kind) {
     case 'create':
@@ -93,6 +92,8 @@ export function buildCommand(wasm: EngineWasm, descriptor: CommandDescriptor): W
 
 function staleness(wasm: EngineWasm, level: number): Staleness {
   switch (level) {
+    case wasm.Staleness.Fresh:
+      return 'fresh';
     case wasm.Staleness.Reconciling:
       return 'reconciling';
     case wasm.Staleness.Stale:
@@ -100,13 +101,16 @@ function staleness(wasm: EngineWasm, level: number): Staleness {
     case wasm.Staleness.Offline:
       return 'offline';
     default:
-      return 'fresh';
+      // Fail closed: an unmapped value means a JS/WASM version mismatch, not a
+      // safe-to-ignore state (the event pump turns this throw into a fatal).
+      throw new Error(`unknown WASM staleness value: ${level}`);
   }
 }
 
-/** Reads a wasm-bindgen `Event`'s key-free getters into a wire descriptor. */
 export function readEvent(wasm: EngineWasm, event: WasmEvent): EventDescriptor {
   switch (event.kind) {
+    case 'snapshotUpdated':
+      return { kind: 'snapshotUpdated' };
     case 'stalenessChanged':
       return {
         kind: 'stalenessChanged',
@@ -119,6 +123,8 @@ export function readEvent(wasm: EngineWasm, event: WasmEvent): EventDescriptor {
     case 'attributableAbuse':
       return { kind: 'attributableAbuse', description: event.description ?? '' };
     default:
-      return { kind: 'snapshotUpdated' };
+      // Fail closed: an unmapped kind means a JS/WASM version mismatch, not a
+      // safe-to-ignore event (the event pump turns this throw into a fatal).
+      throw new Error(`unknown WASM event kind: ${event.kind}`);
   }
 }

--- a/packages/client/src/worker/engineHost.ts
+++ b/packages/client/src/worker/engineHost.ts
@@ -1,0 +1,52 @@
+/**
+ * The engine host: wraps the wasm-bindgen `EngineHandle` in the wire-protocol
+ * shape the worker serves. Runs inside the engine worker realm; key material
+ * never leaves it.
+ */
+
+import type { CommandDescriptor, EventDescriptor } from './protocol.js';
+import type { EngineWasm } from './engineWasm.js';
+import { buildCommand, readEvent } from './commandCodec.js';
+
+/**
+ * The engine-facing surface the protocol server ([`serveEngine`]) drives. The
+ * real [`EngineHost`] wraps WASM; the browser suite substitutes a fake to
+ * exercise transport ordering and out-of-order correlation deterministically.
+ */
+export interface EngineHostLike {
+  start(secret: ArrayBuffer): Promise<void>;
+  command(command: CommandDescriptor): Promise<void>;
+  nextEvent(): Promise<EventDescriptor | null>;
+}
+
+export class EngineHost implements EngineHostLike {
+  private readonly handle;
+
+  constructor(
+    private readonly wasm: EngineWasm,
+    seams: unknown,
+    profile?: string
+  ) {
+    this.handle = new wasm.EngineHandle(seams, profile);
+  }
+
+  async start(secret: ArrayBuffer): Promise<void> {
+    // The engine copies the secret into its `Zeroizing` store; scrub the
+    // worker's transferred copy immediately after so no plaintext lingers.
+    const view = new Uint8Array(secret);
+    try {
+      await this.handle.start(view);
+    } finally {
+      view.fill(0);
+    }
+  }
+
+  async command(command: CommandDescriptor): Promise<void> {
+    await this.handle.command(buildCommand(this.wasm, command));
+  }
+
+  async nextEvent(): Promise<EventDescriptor | null> {
+    const event = await this.handle.nextEvent();
+    return event ? readEvent(this.wasm, event) : null;
+  }
+}

--- a/packages/client/src/worker/engineWasm.ts
+++ b/packages/client/src/worker/engineWasm.ts
@@ -1,0 +1,70 @@
+/**
+ * The minimal structural type of the wasm-bindgen engine module, as the worker
+ * uses it.
+ *
+ * The wasm-bindgen `.d.ts` is the real boundary contract, but it is a build
+ * artifact (generated into the worker's `pkg` dir), not importable from `src`.
+ * This interface names only the constructor/handle/builder surface the worker
+ * drives, so the worker plumbing typechecks without the artifact; the concrete
+ * generated module satisfies it structurally at wiring time. It is not a mirror
+ * of engine *view* structures (those never cross to this layer) — only the
+ * stable command/handle surface frozen in `crates/wasm`.
+ */
+
+/** Opaque wasm-bindgen `NodeId` handle. */
+export type WasmNodeId = object;
+
+/** Opaque wasm-bindgen `Command` handle. */
+export type WasmCommand = object;
+
+/** wasm-bindgen `Event` — key-free view state; a getter is `undefined` off-variant. */
+export interface WasmEvent {
+  readonly kind: string;
+  readonly staleness?: number;
+  readonly ipnsName?: Uint8Array;
+  readonly opId?: bigint;
+  readonly description?: string;
+}
+
+/** wasm-bindgen `EngineHandle` — the one engine instance. */
+export interface WasmEngineHandle {
+  start(secret: Uint8Array): Promise<unknown>;
+  command(command: WasmCommand): Promise<unknown>;
+  nextEvent(): Promise<WasmEvent | undefined>;
+}
+
+/** The wasm-bindgen module namespace the worker binds against. */
+export interface EngineWasm {
+  EngineHandle: new (seams: unknown, profile?: string) => WasmEngineHandle;
+  NodeId: { fromBytes(bytes: Uint8Array): WasmNodeId };
+  Command: {
+    create(parent: WasmNodeId, name: string, kind: number, content?: Uint8Array): WasmCommand;
+    delete(node: WasmNodeId): WasmCommand;
+    rename(node: WasmNodeId, newName: string): WasmCommand;
+    relink(node: WasmNodeId, newParent: WasmNodeId): WasmCommand;
+    updateContent(node: WasmNodeId, content: Uint8Array): WasmCommand;
+    setFocus(node?: WasmNodeId): WasmCommand;
+    manualRefresh(): WasmCommand;
+    importContact(contactCode: Uint8Array): WasmCommand;
+    grant(
+      node: WasmNodeId,
+      recipientIdentityPublicKey: Uint8Array,
+      permission: number
+    ): WasmCommand;
+    revoke(node: WasmNodeId, recipientIdentityPublicKey: Uint8Array): WasmCommand;
+    downgrade(node: WasmNodeId, recipientIdentityPublicKey: Uint8Array): WasmCommand;
+    createInviteLink(node: WasmNodeId, permission: number): WasmCommand;
+    acceptShare(sealedSharePointer: Uint8Array): WasmCommand;
+    rotateNow(node: WasmNodeId): WasmCommand;
+    siweLogin(message: string, signature: Uint8Array): WasmCommand;
+    logout(): WasmCommand;
+  };
+  NodeKind: { readonly File: number; readonly Folder: number };
+  Permission: { readonly Read: number; readonly Write: number };
+  Staleness: {
+    readonly Fresh: number;
+    readonly Reconciling: number;
+    readonly Stale: number;
+    readonly Offline: number;
+  };
+}

--- a/packages/client/src/worker/engineWorker.ts
+++ b/packages/client/src/worker/engineWorker.ts
@@ -1,0 +1,66 @@
+/**
+ * The production engine worker entry (blueprint/web-client.md "Engine hosting").
+ *
+ * The leader tab spawns this module worker and posts one `bootstrap` message
+ * with the WASM artifact URLs and seam config. The worker dynamically imports
+ * the wasm-bindgen artifact, instantiates it, builds the browser seams, and
+ * serves the facade protocol. Everything past this point runs off the UI
+ * thread; key material lives only here, in WASM linear memory.
+ *
+ * This is a worker entry (registers a listener on load) — load it via
+ * `new Worker(new URL('./engineWorker.js', import.meta.url), { type: 'module' })`,
+ * never import it into the UI realm.
+ */
+
+import { makeBrowserSeams, type BrowserSeamsConfig } from './browserSeams.js';
+import { EngineHost } from './engineHost.js';
+import type { EngineWasm } from './engineWasm.js';
+import { serveEngine, type WorkerScopeLike } from './serve.js';
+import type { WorkerMessage } from './protocol.js';
+
+/** The one-shot handshake the leader sends after spawning the worker. */
+export interface EngineWorkerBootstrap extends BrowserSeamsConfig {
+  type: 'bootstrap';
+  /** URL of the wasm-bindgen ES glue module (dynamically imported). */
+  wasmModuleUrl: string;
+  /** URL of the wasm binary handed to the glue's `init`. */
+  wasmBinaryUrl: string;
+  /** Sync timing profile. */
+  profile?: 'ci' | 'production';
+}
+
+interface WasmGlue extends EngineWasm {
+  default: (options: { module_or_path: string }) => Promise<unknown>;
+}
+
+const workerScope = globalThis as unknown as {
+  postMessage(message: WorkerMessage): void;
+  addEventListener(
+    type: 'message',
+    listener: (event: MessageEvent<EngineWorkerBootstrap>) => void
+  ): void;
+  removeEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+};
+
+function onBootstrap(event: MessageEvent<EngineWorkerBootstrap>): void {
+  if (event.data?.type !== 'bootstrap') return;
+  workerScope.removeEventListener('message', onBootstrap as (event: MessageEvent) => void);
+  void bootstrap(event.data);
+}
+
+async function bootstrap(config: EngineWorkerBootstrap): Promise<void> {
+  try {
+    const wasm = (await import(/* @vite-ignore */ config.wasmModuleUrl)) as WasmGlue;
+    await wasm.default({ module_or_path: config.wasmBinaryUrl });
+    const seams = makeBrowserSeams(config);
+    const host = new EngineHost(wasm, seams, config.profile);
+    serveEngine(workerScope as unknown as WorkerScopeLike, host);
+  } catch (error) {
+    workerScope.postMessage({
+      type: 'fatal',
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+workerScope.addEventListener('message', onBootstrap);

--- a/packages/client/src/worker/protocol.ts
+++ b/packages/client/src/worker/protocol.ts
@@ -1,0 +1,84 @@
+/**
+ * The UI ↔ engine-worker wire protocol (blueprint/web-client.md "Engine hosting
+ * and tab leadership").
+ *
+ * Everything here is plain structured-clone data. A wasm-bindgen `Command` wraps
+ * a pointer into the worker's WASM memory and cannot cross a realm boundary, so
+ * the UI sends a **command descriptor** — the facade's write intent as data —
+ * and the worker rebuilds the real `Command` from it (`commandCodec`). This is a
+ * wire format, not the forbidden TS mirror of engine *view* structures
+ * (blueprint/web-client.md "Types are generated, not hand-mirrored"): it carries
+ * only intent the engine already owns, never snapshot/view state, and never key
+ * material — a grant carries the recipient's *public* identity key only.
+ *
+ * `u64`s cross as `bigint`; binary payloads cross as `Uint8Array`, with file
+ * content transferred as an `ArrayBuffer` so no bytes are copied through the
+ * boundary (blueprint/web-client.md "Boundary hygiene").
+ */
+
+/** Grant permission level (mirrors the facade `Permission`). */
+export type Permission = 'read' | 'write';
+
+/** What a created node is (mirrors the facade `NodeKind`). */
+export type NodeKind = 'file' | 'folder';
+
+/** The staleness ladder (mirrors the facade `Staleness`). */
+export type Staleness = 'fresh' | 'reconciling' | 'stale' | 'offline';
+
+/**
+ * One write intent, as data. Each variant's `kind` matches the facade command
+ * builder name (`crates/wasm` `Command`), so the worker maps it mechanically.
+ */
+export type CommandDescriptor =
+  | {
+      kind: 'create';
+      parent: Uint8Array;
+      name: string;
+      nodeKind: NodeKind;
+      content: ArrayBuffer | null;
+    }
+  | { kind: 'delete'; node: Uint8Array }
+  | { kind: 'rename'; node: Uint8Array; newName: string }
+  | { kind: 'relink'; node: Uint8Array; newParent: Uint8Array }
+  | { kind: 'updateContent'; node: Uint8Array; content: ArrayBuffer }
+  | { kind: 'setFocus'; node: Uint8Array | null }
+  | { kind: 'manualRefresh' }
+  | { kind: 'importContact'; contactCode: Uint8Array }
+  | {
+      kind: 'grant';
+      node: Uint8Array;
+      recipientIdentityPublicKey: Uint8Array;
+      permission: Permission;
+    }
+  | { kind: 'revoke'; node: Uint8Array; recipientIdentityPublicKey: Uint8Array }
+  | { kind: 'downgrade'; node: Uint8Array; recipientIdentityPublicKey: Uint8Array }
+  | { kind: 'createInviteLink'; node: Uint8Array; permission: Permission }
+  | { kind: 'acceptShare'; sealedSharePointer: Uint8Array }
+  | { kind: 'rotateNow'; node: Uint8Array }
+  | { kind: 'siweLogin'; message: string; signature: Uint8Array }
+  | { kind: 'logout' };
+
+/** One event the engine emitted, as data (mirrors the facade `Event`). */
+export type EventDescriptor =
+  | { kind: 'snapshotUpdated' }
+  | { kind: 'stalenessChanged'; staleness: Staleness }
+  | { kind: 'withheldUpdateEscalation'; ipnsName: Uint8Array }
+  | { kind: 'deadLetter'; opId: bigint }
+  | { kind: 'attributableAbuse'; description: string };
+
+/** A UI → worker request. `id` correlates the eventual response. */
+export type WorkerRequest =
+  | { type: 'start'; id: number; secret: ArrayBuffer }
+  | { type: 'command'; id: number; command: CommandDescriptor };
+
+/** A worker → UI message. */
+export type WorkerMessage =
+  /** The worker has instantiated the engine and is ready for requests. */
+  | { type: 'ready' }
+  /** The correlated result of a request. */
+  | { type: 'response'; id: number; ok: true }
+  | { type: 'response'; id: number; ok: false; error: string }
+  /** One engine event, in emission order. */
+  | { type: 'event'; event: EventDescriptor }
+  /** Construction or event-pump failure; the worker is unusable. */
+  | { type: 'fatal'; error: string };

--- a/packages/client/src/worker/serve.ts
+++ b/packages/client/src/worker/serve.ts
@@ -1,0 +1,60 @@
+/**
+ * The engine worker's protocol server: turns `postMessage` traffic into engine
+ * calls and streams events back.
+ *
+ * Requests are handled concurrently and answered by `id`, so responses may
+ * return out of order without confusion — the single engine writer serializes
+ * itself below the facade, and the correlation is purely by request id. Events
+ * ride one ordered pump, so the UI sees them in emission order with no drops.
+ */
+
+import type { EngineHostLike } from './engineHost.js';
+import type { WorkerMessage, WorkerRequest } from './protocol.js';
+
+/** The subset of a worker global scope (or `MessagePort`) the server needs. */
+export interface WorkerScopeLike {
+  postMessage(message: WorkerMessage): void;
+  addEventListener(type: 'message', listener: (event: MessageEvent<WorkerRequest>) => void): void;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Wires `scope` to `host`, then signals readiness. */
+export function serveEngine(scope: WorkerScopeLike, host: EngineHostLike): void {
+  const post = (message: WorkerMessage): void => scope.postMessage(message);
+
+  const handle = async (request: WorkerRequest): Promise<void> => {
+    try {
+      if (request.type === 'start') {
+        await host.start(request.secret);
+      } else if (request.type === 'command') {
+        await host.command(request.command);
+      } else {
+        return; // ignore non-request messages (e.g. a bootstrap handshake)
+      }
+      post({ type: 'response', id: request.id, ok: true });
+    } catch (error) {
+      post({ type: 'response', id: request.id, ok: false, error: errorMessage(error) });
+    }
+  };
+
+  scope.addEventListener('message', (event) => {
+    void handle(event.data);
+  });
+
+  void (async () => {
+    try {
+      for (;;) {
+        const event = await host.nextEvent();
+        if (event === null) return;
+        post({ type: 'event', event });
+      }
+    } catch (error) {
+      post({ type: 'fatal', error: errorMessage(error) });
+    }
+  })();
+
+  post({ type: 'ready' });
+}

--- a/packages/client/test/browser/boundary.worker.ts
+++ b/packages/client/test/browser/boundary.worker.ts
@@ -4,17 +4,21 @@
  *
  * - `bigint`: the facade's `u64`→`bigint` boundary round-trips a value beyond
  *   `Number.MAX_SAFE_INTEGER` intact, through the real wasm-bindgen `Event`.
- * - `stagingDetachment` (#717): a WASM-backed byte view handed to a seam is
+ * - `stagingDetachment` (#717): a WASM-backed byte *value* handed to a seam is
  *   copied synchronously at entry, so detaching it across the seam's awaits
  *   cannot corrupt or truncate the stored bytes. The test grows a
  *   `WebAssembly.Memory` (detaching the view) right after the call, before its
  *   awaits resolve; a copy-after-await implementation would write a detached
  *   view and fail.
+ * - `stagingKeyDetachment` / `snapshotKeyDetachment` (#717): the *key* view is
+ *   likewise encoded synchronously at entry. A key hexed after the await would
+ *   read a detached view as '' and store the entry under the wrong name, so the
+ *   read-back under the real key here would miss — the fix stores it correctly.
  */
 import init, { deadLetterEvent } from './pkg/cipherbox_wasm.js';
 import wasmUrl from './pkg/cipherbox_wasm_bg.wasm?url';
 
-import { OpfsStagingStore } from '../../src/seams/index.js';
+import { IdbSnapshotCache, OpfsStagingStore } from '../../src/seams/index.js';
 
 interface Outcome {
   ok: boolean;
@@ -68,12 +72,73 @@ async function runStagingDetachment(): Promise<void> {
   }
 }
 
+async function runStagingKeyDetachment(): Promise<void> {
+  const dirName = `boundary-staging-key-${Date.now()}`;
+  await clearOpfsDir(`${dirName}-staged`);
+  const store = new OpfsStagingStore(dirName);
+
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  const keyView = new Uint8Array(memory.buffer, 0, 8);
+  for (let i = 0; i < keyView.length; i += 1) keyView[i] = (i * 13 + 3) & 0xff;
+  const expectedKey = keyView.slice();
+  const bytes = new Uint8Array([1, 2, 3, 4]);
+
+  // Start the write, then detach the KEY view before its awaits resolve.
+  const writing = store.putStagedBytes(keyView, bytes);
+  memory.grow(1); // detaches memory.buffer → `keyView` is now zero-length
+  if (keyView.byteLength !== 0) throw new Error('precondition: key view was not detached by grow');
+  await writing;
+
+  // Read back under the real key. A key hexed after the await would be '',
+  // storing the entry under the wrong name and missing here.
+  const stored = await store.stagedBytes(expectedKey);
+  if (!stored || stored.length !== bytes.length) {
+    throw new Error(`stored length ${stored?.length ?? 'null'} != ${bytes.length}`);
+  }
+  for (let i = 0; i < bytes.length; i += 1) {
+    if (stored[i] !== bytes[i]) throw new Error(`byte ${i}: ${stored[i]} != ${bytes[i]}`);
+  }
+}
+
+async function runSnapshotKeyDetachment(): Promise<void> {
+  const cache = new IdbSnapshotCache(`boundary-snapshot-key-${Date.now()}`);
+  try {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const keyView = new Uint8Array(memory.buffer, 0, 8);
+    for (let i = 0; i < keyView.length; i += 1) keyView[i] = (i * 5 + 2) & 0xff;
+    const expectedKey = keyView.slice();
+    const value = new Uint8Array([9, 8, 7, 6]);
+
+    // Start the put, then detach the KEY view before its await resolves.
+    const writing = cache.put(keyView, value);
+    memory.grow(1); // detaches memory.buffer → `keyView` is now zero-length
+    if (keyView.byteLength !== 0) {
+      throw new Error('precondition: key view was not detached by grow');
+    }
+    await writing;
+
+    const stored = await cache.get(expectedKey);
+    if (!stored || stored.length !== value.length) {
+      throw new Error(`stored length ${stored?.length ?? 'null'} != ${value.length}`);
+    }
+    for (let i = 0; i < value.length; i += 1) {
+      if (stored[i] !== value[i]) throw new Error(`byte ${i}: ${stored[i]} != ${value[i]}`);
+    }
+  } finally {
+    await cache.clear();
+  }
+}
+
 async function run(name: string): Promise<void> {
   switch (name) {
     case 'bigint':
       return runBigint();
     case 'stagingDetachment':
       return runStagingDetachment();
+    case 'stagingKeyDetachment':
+      return runStagingKeyDetachment();
+    case 'snapshotKeyDetachment':
+      return runSnapshotKeyDetachment();
     default:
       throw new Error(`unknown boundary check: ${name}`);
   }

--- a/packages/client/test/browser/boundary.worker.ts
+++ b/packages/client/test/browser/boundary.worker.ts
@@ -1,0 +1,91 @@
+/**
+ * Transfer/boundary-hygiene checks (blueprint/web-client.md "Boundary
+ * hygiene"), run in a worker realm (OPFS is worker-only):
+ *
+ * - `bigint`: the facade's `u64`→`bigint` boundary round-trips a value beyond
+ *   `Number.MAX_SAFE_INTEGER` intact, through the real wasm-bindgen `Event`.
+ * - `stagingDetachment` (#717): a WASM-backed byte view handed to a seam is
+ *   copied synchronously at entry, so detaching it across the seam's awaits
+ *   cannot corrupt or truncate the stored bytes. The test grows a
+ *   `WebAssembly.Memory` (detaching the view) right after the call, before its
+ *   awaits resolve; a copy-after-await implementation would write a detached
+ *   view and fail.
+ */
+import init, { deadLetterEvent } from './pkg/cipherbox_wasm.js';
+import wasmUrl from './pkg/cipherbox_wasm_bg.wasm?url';
+
+import { OpfsStagingStore } from '../../src/seams/index.js';
+
+interface Outcome {
+  ok: boolean;
+  error?: string;
+}
+
+const scope = self as unknown as DedicatedWorkerGlobalScope;
+
+async function clearOpfsDir(name: string): Promise<void> {
+  const root = await navigator.storage.getDirectory();
+  try {
+    await root.removeEntry(name, { recursive: true });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'NotFoundError') return;
+    throw error;
+  }
+}
+
+async function runBigint(): Promise<void> {
+  await init({ module_or_path: wasmUrl });
+  const huge = 9_007_199_254_740_993n; // 2^53 + 1 — not representable as a JS number
+  const event = deadLetterEvent(huge);
+  if (event.kind !== 'deadLetter') throw new Error(`kind ${event.kind}`);
+  if (typeof event.opId !== 'bigint') throw new Error(`opId type ${typeof event.opId}`);
+  if (event.opId !== huge) throw new Error(`opId ${event.opId} !== ${huge}`);
+}
+
+async function runStagingDetachment(): Promise<void> {
+  const dirName = `boundary-staging-${Date.now()}`;
+  await clearOpfsDir(`${dirName}-staged`);
+  const store = new OpfsStagingStore(dirName);
+
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  const view = new Uint8Array(memory.buffer, 0, 32);
+  for (let i = 0; i < view.length; i += 1) view[i] = (i * 7 + 1) & 0xff;
+  const expected = view.slice();
+  const key = new Uint8Array([0xab, 0xcd]);
+
+  // Start the write, then detach the source view before its awaits resolve.
+  const writing = store.putStagedBytes(key, view);
+  memory.grow(1); // detaches memory.buffer → `view` is now zero-length
+  if (view.byteLength !== 0) throw new Error('precondition: view was not detached by grow');
+  await writing;
+
+  const stored = await store.stagedBytes(key);
+  if (!stored || stored.length !== expected.length) {
+    throw new Error(`stored length ${stored?.length ?? 'null'} != ${expected.length}`);
+  }
+  for (let i = 0; i < expected.length; i += 1) {
+    if (stored[i] !== expected[i]) throw new Error(`byte ${i}: ${stored[i]} != ${expected[i]}`);
+  }
+}
+
+async function run(name: string): Promise<void> {
+  switch (name) {
+    case 'bigint':
+      return runBigint();
+    case 'stagingDetachment':
+      return runStagingDetachment();
+    default:
+      throw new Error(`unknown boundary check: ${name}`);
+  }
+}
+
+scope.addEventListener('message', (event: MessageEvent<{ name: string }>) => {
+  run(event.data.name)
+    .then(() => scope.postMessage({ ok: true } satisfies Outcome))
+    .catch((error: unknown) =>
+      scope.postMessage({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      } satisfies Outcome)
+    );
+});

--- a/packages/client/test/browser/boundary.worker.ts
+++ b/packages/client/test/browser/boundary.worker.ts
@@ -47,61 +47,69 @@ async function runBigint(): Promise<void> {
 }
 
 async function runStagingDetachment(): Promise<void> {
-  const dirName = `boundary-staging-${Date.now()}`;
+  const dirName = `boundary-staging-${Date.now()}-${crypto.randomUUID()}`;
   await clearOpfsDir(`${dirName}-staged`);
   const store = new OpfsStagingStore(dirName);
+  try {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const view = new Uint8Array(memory.buffer, 0, 32);
+    for (let i = 0; i < view.length; i += 1) view[i] = (i * 7 + 1) & 0xff;
+    const expected = view.slice();
+    const key = new Uint8Array([0xab, 0xcd]);
 
-  const memory = new WebAssembly.Memory({ initial: 1 });
-  const view = new Uint8Array(memory.buffer, 0, 32);
-  for (let i = 0; i < view.length; i += 1) view[i] = (i * 7 + 1) & 0xff;
-  const expected = view.slice();
-  const key = new Uint8Array([0xab, 0xcd]);
+    // Start the write, then detach the source view before its awaits resolve.
+    const writing = store.putStagedBytes(key, view);
+    memory.grow(1); // detaches memory.buffer → `view` is now zero-length
+    if (view.byteLength !== 0) throw new Error('precondition: view was not detached by grow');
+    await writing;
 
-  // Start the write, then detach the source view before its awaits resolve.
-  const writing = store.putStagedBytes(key, view);
-  memory.grow(1); // detaches memory.buffer → `view` is now zero-length
-  if (view.byteLength !== 0) throw new Error('precondition: view was not detached by grow');
-  await writing;
-
-  const stored = await store.stagedBytes(key);
-  if (!stored || stored.length !== expected.length) {
-    throw new Error(`stored length ${stored?.length ?? 'null'} != ${expected.length}`);
-  }
-  for (let i = 0; i < expected.length; i += 1) {
-    if (stored[i] !== expected[i]) throw new Error(`byte ${i}: ${stored[i]} != ${expected[i]}`);
+    const stored = await store.stagedBytes(key);
+    if (!stored || stored.length !== expected.length) {
+      throw new Error(`stored length ${stored?.length ?? 'null'} != ${expected.length}`);
+    }
+    for (let i = 0; i < expected.length; i += 1) {
+      if (stored[i] !== expected[i]) throw new Error(`byte ${i}: ${stored[i]} != ${expected[i]}`);
+    }
+  } finally {
+    await clearOpfsDir(`${dirName}-staged`);
   }
 }
 
 async function runStagingKeyDetachment(): Promise<void> {
-  const dirName = `boundary-staging-key-${Date.now()}`;
+  const dirName = `boundary-staging-key-${Date.now()}-${crypto.randomUUID()}`;
   await clearOpfsDir(`${dirName}-staged`);
   const store = new OpfsStagingStore(dirName);
+  try {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const keyView = new Uint8Array(memory.buffer, 0, 8);
+    for (let i = 0; i < keyView.length; i += 1) keyView[i] = (i * 13 + 3) & 0xff;
+    const expectedKey = keyView.slice();
+    const bytes = new Uint8Array([1, 2, 3, 4]);
 
-  const memory = new WebAssembly.Memory({ initial: 1 });
-  const keyView = new Uint8Array(memory.buffer, 0, 8);
-  for (let i = 0; i < keyView.length; i += 1) keyView[i] = (i * 13 + 3) & 0xff;
-  const expectedKey = keyView.slice();
-  const bytes = new Uint8Array([1, 2, 3, 4]);
+    // Start the write, then detach the KEY view before its awaits resolve.
+    const writing = store.putStagedBytes(keyView, bytes);
+    memory.grow(1); // detaches memory.buffer → `keyView` is now zero-length
+    if (keyView.byteLength !== 0) {
+      throw new Error('precondition: key view was not detached by grow');
+    }
+    await writing;
 
-  // Start the write, then detach the KEY view before its awaits resolve.
-  const writing = store.putStagedBytes(keyView, bytes);
-  memory.grow(1); // detaches memory.buffer → `keyView` is now zero-length
-  if (keyView.byteLength !== 0) throw new Error('precondition: key view was not detached by grow');
-  await writing;
-
-  // Read back under the real key. A key hexed after the await would be '',
-  // storing the entry under the wrong name and missing here.
-  const stored = await store.stagedBytes(expectedKey);
-  if (!stored || stored.length !== bytes.length) {
-    throw new Error(`stored length ${stored?.length ?? 'null'} != ${bytes.length}`);
-  }
-  for (let i = 0; i < bytes.length; i += 1) {
-    if (stored[i] !== bytes[i]) throw new Error(`byte ${i}: ${stored[i]} != ${bytes[i]}`);
+    // Read back under the real key. A key hexed after the await would be '',
+    // storing the entry under the wrong name and missing here.
+    const stored = await store.stagedBytes(expectedKey);
+    if (!stored || stored.length !== bytes.length) {
+      throw new Error(`stored length ${stored?.length ?? 'null'} != ${bytes.length}`);
+    }
+    for (let i = 0; i < bytes.length; i += 1) {
+      if (stored[i] !== bytes[i]) throw new Error(`byte ${i}: ${stored[i]} != ${bytes[i]}`);
+    }
+  } finally {
+    await clearOpfsDir(`${dirName}-staged`);
   }
 }
 
 async function runSnapshotKeyDetachment(): Promise<void> {
-  const cache = new IdbSnapshotCache(`boundary-snapshot-key-${Date.now()}`);
+  const cache = new IdbSnapshotCache(`boundary-snapshot-key-${Date.now()}-${crypto.randomUUID()}`);
   try {
     const memory = new WebAssembly.Memory({ initial: 1 });
     const keyView = new Uint8Array(memory.buffer, 0, 8);

--- a/packages/client/test/browser/engine.spec.ts
+++ b/packages/client/test/browser/engine.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * The engine-worker slice of the merge-blocking browser suite
+ * (blueprint/testing.md law 1, blueprint/web-client.md "Engine hosting"). It
+ * covers the promise-correlated RPC layer, the one-way event stream, the
+ * bigint/transfer boundary, and cold start + logout — the real engine over the
+ * real seams, the protocol fake where the engine cannot yet drive a property.
+ */
+
+interface RealEngineResult {
+  beforeStart: string;
+  startOk: boolean;
+  secretDetached: boolean;
+  afterStart: string;
+  afterLogout: string;
+}
+
+interface EngineHarness {
+  runRealEngine(): Promise<RealEngineResult>;
+  runFakeOutOfOrder(): Promise<{ order: string[] }>;
+  runFakeEvents(): Promise<{ events: number[] }>;
+  runBoundary(name: string): Promise<{ ok: boolean; error?: string }>;
+}
+
+test.describe('engine worker host', () => {
+  test.beforeEach(async ({ page }) => {
+    page.on('console', (message) => {
+      if (message.type() === 'debug') return;
+      console.log(`[browser:${message.type()}] ${message.text()}`);
+    });
+    page.on('pageerror', (error) => console.log(`[browser:pageerror] ${error.message}`));
+    await page.goto('/');
+    await page.waitForFunction(
+      () => typeof (window as unknown as { runRealEngine?: unknown }).runRealEngine === 'function'
+    );
+  });
+
+  test('cold start, RPC round-trip, and logout teardown end to end', async ({ page }) => {
+    const result: RealEngineResult = await page.evaluate(() =>
+      (window as unknown as EngineHarness).runRealEngine()
+    );
+
+    // A command before start is rejected as "not started" (start lifecycle gate).
+    expect(result.beforeStart).toContain('not started');
+    // start(secret) resolves: the secret transferred in and the engine came up.
+    expect(result.startOk).toBe(true);
+    expect(result.secretDetached).toBe(true);
+    // Post-start the engine answers (its command pipeline is unimplemented, but
+    // it is started) — proving a correlated round-trip to the real engine.
+    expect(result.afterStart).toContain('not implemented');
+    // After logout the transport is torn down and rejects further work.
+    expect(result.afterLogout).toContain('closed');
+  });
+
+  test('RPC responses correlate by id even when answered out of order', async ({ page }) => {
+    const { order } = await page.evaluate(() =>
+      (window as unknown as EngineHarness).runFakeOutOfOrder()
+    );
+    // The second-issued command is answered first; both promises still resolve,
+    // each matched to its own request.
+    expect(order).toEqual(['second', 'first']);
+  });
+
+  test('the event stream is delivered in order with no drops', async ({ page }) => {
+    const { events } = await page.evaluate(() =>
+      (window as unknown as EngineHarness).runFakeEvents()
+    );
+    expect(events).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  test('the u64 event boundary round-trips a bigint beyond MAX_SAFE_INTEGER', async ({ page }) => {
+    const outcome = await runBoundary(page, 'bigint');
+    expect(outcome.error ?? '', 'bigint boundary failure').toBe('');
+    expect(outcome.ok).toBe(true);
+  });
+
+  test('a WASM-backed seam view is copied before await, surviving detachment', async ({ page }) => {
+    const outcome = await runBoundary(page, 'stagingDetachment');
+    expect(outcome.error ?? '', 'staging detachment failure (#717)').toBe('');
+    expect(outcome.ok).toBe(true);
+  });
+});
+
+function runBoundary(page: Page, name: string): Promise<{ ok: boolean; error?: string }> {
+  return page.evaluate(
+    (boundary) => (window as unknown as EngineHarness).runBoundary(boundary),
+    name
+  );
+}

--- a/packages/client/test/browser/engine.spec.ts
+++ b/packages/client/test/browser/engine.spec.ts
@@ -80,6 +80,22 @@ test.describe('engine worker host', () => {
     expect(outcome.error ?? '', 'staging detachment failure (#717)').toBe('');
     expect(outcome.ok).toBe(true);
   });
+
+  test('a WASM-backed staging key is encoded before await, surviving detachment', async ({
+    page,
+  }) => {
+    const outcome = await runBoundary(page, 'stagingKeyDetachment');
+    expect(outcome.error ?? '', 'staging key detachment failure (#717)').toBe('');
+    expect(outcome.ok).toBe(true);
+  });
+
+  test('a WASM-backed snapshot key is encoded before await, surviving detachment', async ({
+    page,
+  }) => {
+    const outcome = await runBoundary(page, 'snapshotKeyDetachment');
+    expect(outcome.error ?? '', 'snapshot key detachment failure (#717)').toBe('');
+    expect(outcome.ok).toBe(true);
+  });
 });
 
 function runBoundary(page: Page, name: string): Promise<{ ok: boolean; error?: string }> {

--- a/packages/client/test/browser/engine.worker.ts
+++ b/packages/client/test/browser/engine.worker.ts
@@ -1,0 +1,49 @@
+/**
+ * The real engine worker for the browser suite: instantiates the WASM engine
+ * over the actual browser seams (against the harness's fake `/routing/v1` mock)
+ * and serves the facade protocol. Mirrors the production `engineWorker` wiring,
+ * but imports the built `pkg` glue statically instead of dynamically.
+ */
+import init, {
+  Command,
+  EngineHandle,
+  NodeId,
+  NodeKind,
+  Permission,
+  Staleness,
+} from './pkg/cipherbox_wasm.js';
+import wasmUrl from './pkg/cipherbox_wasm_bg.wasm?url';
+
+import { EngineHost } from '../../src/worker/engineHost.js';
+import { serveEngine, type WorkerScopeLike } from '../../src/worker/serve.js';
+import { makeBrowserSeams } from '../../src/worker/browserSeams.js';
+import type { EngineWasm } from '../../src/worker/engineWasm.js';
+
+const scope = self as unknown as WorkerScopeLike & { location: { origin: string } };
+
+async function boot(): Promise<void> {
+  await init({ module_or_path: wasmUrl });
+  const wasm = {
+    EngineHandle,
+    Command,
+    NodeId,
+    NodeKind,
+    Permission,
+    Staleness,
+  } as unknown as EngineWasm;
+  const { origin } = scope.location;
+  const seams = makeBrowserSeams({
+    recordEndpoints: [`${origin}/routing`],
+    mailboxUrl: `${origin}/mailbox`,
+    dbPrefix: `engine-${Date.now()}`,
+  });
+  const host = new EngineHost(wasm, seams, 'ci');
+  serveEngine(scope, host);
+}
+
+void boot().catch((error: unknown) => {
+  scope.postMessage({
+    type: 'fatal',
+    error: error instanceof Error ? error.message : String(error),
+  });
+});

--- a/packages/client/test/browser/engineHarness.ts
+++ b/packages/client/test/browser/engineHarness.ts
@@ -1,0 +1,133 @@
+/**
+ * Page harness for the engine-worker suite. Exposes `window` entry points the
+ * Playwright spec calls; each drives the real `LocalTransport` + `EngineFacade`
+ * against a worker (the real WASM engine, or the protocol fake) and returns a
+ * plain result the spec asserts on.
+ */
+import { EngineFacade } from '../../src/facade.js';
+import { LocalTransport } from '../../src/transport.js';
+import type { EventDescriptor } from '../../src/worker/protocol.js';
+
+interface RealEngineResult {
+  beforeStart: string;
+  startOk: boolean;
+  secretDetached: boolean;
+  afterStart: string;
+  afterLogout: string;
+}
+
+interface BoundaryOutcome {
+  ok: boolean;
+  error?: string;
+}
+
+declare global {
+  interface Window {
+    runRealEngine(): Promise<RealEngineResult>;
+    runFakeOutOfOrder(): Promise<{ order: string[] }>;
+    runFakeEvents(): Promise<{ events: number[] }>;
+    runBoundary(name: string): Promise<BoundaryOutcome>;
+  }
+}
+
+function realWorker(): Worker {
+  return new Worker(new URL('./engine.worker.ts', import.meta.url), { type: 'module' });
+}
+
+function fakeWorker(): Worker {
+  return new Worker(new URL('./fakeEngine.worker.ts', import.meta.url), { type: 'module' });
+}
+
+function facadeOver(worker: Worker): { facade: EngineFacade; transport: LocalTransport } {
+  const transport = new LocalTransport(worker);
+  return { facade: new EngineFacade(transport), transport };
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+window.runRealEngine = async (): Promise<RealEngineResult> => {
+  const { facade } = facadeOver(realWorker());
+  const result: RealEngineResult = {
+    beforeStart: '',
+    startOk: false,
+    secretDetached: false,
+    afterStart: '',
+    afterLogout: '',
+  };
+
+  // A command before start is rejected as "not started" — the gate proving the
+  // engine's start lifecycle is enforced across the boundary.
+  await facade.manualRefresh().catch((error: unknown) => {
+    result.beforeStart = message(error);
+  });
+
+  const secret = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer;
+  await facade.start(secret);
+  result.startOk = true;
+  result.secretDetached = secret.byteLength === 0;
+
+  // Post-start, the same command reaches a started engine (its pipeline is not
+  // yet wired, so it answers "not implemented" — not "not started").
+  await facade.manualRefresh().catch((error: unknown) => {
+    result.afterStart = message(error);
+  });
+
+  await facade.logout();
+
+  // After teardown the transport is closed and rejects further work.
+  await facade.manualRefresh().catch((error: unknown) => {
+    result.afterLogout = message(error);
+  });
+
+  return result;
+};
+
+window.runFakeOutOfOrder = async (): Promise<{ order: string[] }> => {
+  const { facade, transport } = facadeOver(fakeWorker());
+  const order: string[] = [];
+  const first = facade.delete(new Uint8Array(16)).then(() => order.push('first'));
+  const second = facade.delete(new Uint8Array(16)).then(() => order.push('second'));
+  await Promise.all([first, second]);
+  transport.close();
+  return { order };
+};
+
+window.runFakeEvents = async (): Promise<{ events: number[] }> => {
+  const { facade, transport } = facadeOver(fakeWorker());
+  const events: number[] = [];
+  const done = new Promise<void>((resolve) => {
+    facade.subscribe((event: EventDescriptor) => {
+      if (event.kind !== 'deadLetter') return;
+      events.push(Number(event.opId));
+      if (events.length === 10) resolve();
+    });
+  });
+  await facade.manualRefresh();
+  await done;
+  transport.close();
+  return { events };
+};
+
+window.runBoundary = (name: string): Promise<BoundaryOutcome> =>
+  new Promise<BoundaryOutcome>((resolve) => {
+    const worker = new Worker(new URL('./boundary.worker.ts', import.meta.url), { type: 'module' });
+    let settled = false;
+    const finish = (outcome: BoundaryOutcome): void => {
+      if (settled) return;
+      settled = true;
+      worker.terminate();
+      resolve(outcome);
+    };
+    worker.addEventListener('message', (event: MessageEvent<BoundaryOutcome>) =>
+      finish(event.data)
+    );
+    worker.addEventListener('error', (event: ErrorEvent) =>
+      finish({ ok: false, error: event.message || 'worker error' })
+    );
+    worker.postMessage({ name });
+  });
+
+const status = document.getElementById('engine-status');
+if (status) status.textContent = 'Engine worker harness ready.';

--- a/packages/client/test/browser/fakeEngine.worker.ts
+++ b/packages/client/test/browser/fakeEngine.worker.ts
@@ -1,0 +1,52 @@
+/**
+ * A protocol-speaking fake engine host (no WASM), driven through the real
+ * `serveEngine` server and the real `LocalTransport`. It exists to exercise two
+ * properties the real engine cannot yet drive deterministically: out-of-order
+ * response correlation, and ordered/no-drop event delivery.
+ *
+ * - Any command answers after a delay that shrinks with each call, so the
+ *   second command's response arrives before the first's.
+ * - `manualRefresh` emits ten ordered `deadLetter` events (op ids 1..10) that
+ *   the single event pump streams in order.
+ */
+import { serveEngine, type WorkerScopeLike } from '../../src/worker/serve.js';
+import type { EngineHostLike } from '../../src/worker/engineHost.js';
+import type { CommandDescriptor, EventDescriptor } from '../../src/worker/protocol.js';
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+class FakeHost implements EngineHostLike {
+  private commandCount = 0;
+  private queued: EventDescriptor[] = [];
+  private waiters: Array<(event: EventDescriptor | null) => void> = [];
+  private closed = false;
+
+  start(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async command(descriptor: CommandDescriptor): Promise<void> {
+    this.commandCount += 1;
+    if (descriptor.kind === 'manualRefresh') {
+      for (let opId = 1n; opId <= 10n; opId += 1n) this.pushEvent({ kind: 'deadLetter', opId });
+      return;
+    }
+    // First call is slow, later calls fast → responses arrive out of order.
+    await sleep(this.commandCount === 1 ? 40 : 5);
+  }
+
+  nextEvent(): Promise<EventDescriptor | null> {
+    const next = this.queued.shift();
+    if (next) return Promise.resolve(next);
+    if (this.closed) return Promise.resolve(null);
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+
+  private pushEvent(event: EventDescriptor): void {
+    const waiter = this.waiters.shift();
+    if (waiter) waiter(event);
+    else this.queued.push(event);
+  }
+}
+
+serveEngine(self as unknown as WorkerScopeLike, new FakeHost());

--- a/packages/client/test/browser/index.html
+++ b/packages/client/test/browser/index.html
@@ -6,6 +6,8 @@
   </head>
   <body>
     <main id="status">Browser seam conformance harness ready.</main>
+    <main id="engine-status">Engine worker harness loading…</main>
     <script type="module" src="./harness.ts"></script>
+    <script type="module" src="./engineHarness.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Hosts the v2 web client's engine in a dedicated worker and lands the single-tab facade transport (blueprint/web-client.md "Engine hosting", "WASM packaging and the type boundary", "Login and identity").

- **Engine worker host** (`crates/wasm`): an `EngineHandle` that constructs the one engine instance over the nine browser seams and exposes `start`/`command`/`nextEvent`, serialized behind an async mutex. The six JS-seam adapters shared with the conformance bridge move into `seams_bridge`; the missing `Http`/`Mailbox`/`RefreshHintSource` adapters the full `SeamSet` needs are added. Production entropy wires `getrandom`'s `crypto.getRandomValues` backend.
- **Promise-correlated RPC layer + local transport** (`packages/client`): a plain-data wire protocol, a command/event codec over the wasm-bindgen facade, the concurrent protocol server, and `LocalTransport` (UI to its own worker over `postMessage`, binary payloads transferred). Responses correlate to requests by a client-assigned monotonic id, so out-of-order answers never confuse. The broadcast transport for tab leadership (#640) slots in behind the same `EngineTransport` interface with no facade change.
- **Typed async facade**: cold-start `start(secret)` (secret transferred straight through to the worker, which zeroes its copy after the engine consumes it), unconditional `logout` teardown, one method per facade command, and event subscription.
- **New seams**: a queue-backed `RefreshHintSource` and a codec-free `ApiMailbox` (the full `SeamSet` had no prior production construction; neither web nor desktop implemented these two).

Key material never crosses the worker to the UI realm: the facade deals only in intent descriptors and key-free event descriptors; a grant carries the recipient's public identity key only.

## Gate coverage (`packages/client` browser suite, merge-blocking)

- RPC round-trip and started-lifecycle gating against the real WASM engine over the real seams (fake `/routing/v1`).
- Out-of-order response correlation and ordered, no-drop event-stream delivery.
- bigint/transfer boundary: `u64`→`bigint` round-trips a value beyond `Number.MAX_SAFE_INTEGER`; the secret crosses as a transferred `ArrayBuffer`.
- Cold start and logout teardown end to end.

## #717 — copy WASM-backed seam byte views before await

`Closes #717`. The engine hands seam bytes as `Uint8Array` views into WASM linear memory, valid only synchronously; a slice/write after the seam's first await reads a detached buffer and silently truncates. Fixed in `StagingStore.enqueueOp`/`putStagedBytes` and `SnapshotCache.put` (copy at method entry), with a browser boundary test that grows a `WebAssembly.Memory` mid-write and asserts the staged bytes survive — it fails without the fix ("stored length 0 != 32").

## Notes

- The engine's cold-start pipeline and event emission are unimplemented below the facade, so the real engine's `start` resolves and its commands answer "not implemented" (not "not started"); the event-stream ordering property is driven by a protocol fake through the same transport.
- The `Mailbox.poll` result parsing belongs to the engine's mailbox pipeline slice (no codec in TS); until then it reports an empty inbox — availability, never a trust decision.

Closes #639


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a typed client facade for starting the engine, issuing commands, subscribing to events, and managing logout.
  * Added browser worker support for running the engine with local persistence, networking, mailbox delivery, and refresh hints.
  * Added mailbox transport and queued refresh hint capabilities.
  * Improved protection of stored data when asynchronous operations interact with WASM memory.

* **Bug Fixes**
  * Improved worker request handling, error reporting, event delivery, and cleanup during failures.

* **Tests**
  * Added comprehensive unit and browser tests covering engine lifecycle, command ordering, event delivery, data boundaries, and worker behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->