### PR TITLE
feat(client): add tab leadership, broadcast transport, and failover

### DIFF
--- a/packages/client/src/broadcast.ts
+++ b/packages/client/src/broadcast.ts
@@ -4,8 +4,10 @@
  * plus the one-way event stream back, all over a single `BroadcastChannel`.
  *
  * Security shape, structural not by discipline:
- * - The login **secret never crosses** — a follower scrubs it locally and lets
- *   the leader's already-started engine own key derivation.
+ * - The login **secret never crosses** — the keyless follower transport takes no
+ *   secret at all (its `start` has no secret parameter); `EngineClient`, the
+ *   secret's terminal owner, scrubs the buffer it chose not to use and lets the
+ *   leader's already-started engine own key derivation.
  * - Leader → follower carries only key-free, plaintext-free `EventDescriptor`s
  *   (the facade's event surface exposes no key bytes by construction).
  * - Follower → leader commands may carry the user's own upload bytes as a
@@ -44,15 +46,31 @@ export type FollowerMessage =
   /** A follower is leaving (tab close / transport teardown). */
   | { type: 'cb:bye'; clientId: string };
 
-/** Leader → follower messages. */
+/**
+ * Leader → follower messages. Every one carries the current leadership's
+ * `token` — an unguessable per-leadership capability minted at election. Same
+ * origin is the trust boundary, but any same-origin context can observe a
+ * follower's `clientId`/`requestId` and post a forged `cb:response`/`cb:event`;
+ * followers reject any leader message whose token isn't the active leader's, so
+ * a non-leader cannot forge an ack or inject an event.
+ */
 export type LeaderMessage =
   /** The current leader announces itself (on election and on demand). */
-  | { type: 'cb:leader' }
+  | { type: 'cb:leader'; token: string }
+  /** The current leader is stepping down (graceful teardown); re-arm the gate. */
+  | { type: 'cb:leaderGone'; token: string }
   /** The correlated result of a follower's command. */
-  | { type: 'cb:response'; clientId: string; requestId: number; ok: true }
-  | { type: 'cb:response'; clientId: string; requestId: number; ok: false; error: string }
+  | { type: 'cb:response'; token: string; clientId: string; requestId: number; ok: true }
+  | {
+      type: 'cb:response';
+      token: string;
+      clientId: string;
+      requestId: number;
+      ok: false;
+      error: string;
+    }
   /** One engine event, fanned out to every follower in emission order. */
-  | { type: 'cb:event'; event: EventDescriptor };
+  | { type: 'cb:event'; token: string; event: EventDescriptor };
 
 export type BroadcastMessage = FollowerMessage | LeaderMessage;
 

--- a/packages/client/src/broadcast.ts
+++ b/packages/client/src/broadcast.ts
@@ -1,0 +1,99 @@
+/**
+ * The cross-tab broadcast wire (blueprint/web-client.md "Followers are thin
+ * mirrors"). Followers send commands to the leader and receive view projections
+ * plus the one-way event stream back, all over a single `BroadcastChannel`.
+ *
+ * Security shape, structural not by discipline:
+ * - The login **secret never crosses** — a follower scrubs it locally and lets
+ *   the leader's already-started engine own key derivation.
+ * - Leader → follower carries only key-free, plaintext-free `EventDescriptor`s
+ *   (the facade's event surface exposes no key bytes by construction).
+ * - Follower → leader commands may carry the user's own upload bytes as a
+ *   `Blob` handle: structured clone shares the immutable backing store, so the
+ *   cross-tab hop copies no bytes (blueprint "no byte copies for uploads").
+ */
+
+import type { CommandDescriptor, EventDescriptor } from './worker/protocol.js';
+
+/** The subset of `BroadcastChannel` the transport/relay drive (injectable). */
+export interface BroadcastChannelLike {
+  postMessage(message: unknown): void;
+  addEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+  removeEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+  close(): void;
+}
+
+/**
+ * A command on the wire. Binary upload content is hoisted out of the descriptor
+ * into a `Blob` sibling so it rides as a shared handle, not a structured-clone
+ * byte copy; the descriptor's own `content` field is nulled for transit.
+ */
+export interface WireCommand {
+  command: CommandDescriptor;
+  content?: Blob;
+}
+
+/** Follower → leader messages. */
+export type FollowerMessage =
+  /** A follower announces itself so the leader replies with a `leader` beacon. */
+  | { type: 'cb:hello'; clientId: string }
+  /** A correlated command; the leader answers with a matching `response`. */
+  | { type: 'cb:command'; clientId: string; requestId: number; wire: WireCommand }
+  /** This tab's currently open folder (for the leader's focus-window union). */
+  | { type: 'cb:focus'; clientId: string; node: Uint8Array | null }
+  /** A follower is leaving (tab close / transport teardown). */
+  | { type: 'cb:bye'; clientId: string };
+
+/** Leader → follower messages. */
+export type LeaderMessage =
+  /** The current leader announces itself (on election and on demand). */
+  | { type: 'cb:leader' }
+  /** The correlated result of a follower's command. */
+  | { type: 'cb:response'; clientId: string; requestId: number; ok: true }
+  | { type: 'cb:response'; clientId: string; requestId: number; ok: false; error: string }
+  /** One engine event, fanned out to every follower in emission order. */
+  | { type: 'cb:event'; event: EventDescriptor };
+
+export type BroadcastMessage = FollowerMessage | LeaderMessage;
+
+/** The channel name pairing the broadcast wire with the `cipherbox-engine` lock. */
+export const BROADCAST_CHANNEL_NAME = 'cipherbox-engine';
+
+/** A per-tab identity for command correlation. Injectable for deterministic tests. */
+export function newClientId(): string {
+  return globalThis.crypto.randomUUID();
+}
+
+/**
+ * Hoists binary upload content out of a command descriptor into a shared `Blob`
+ * handle. `create`/`updateContent` carry an `ArrayBuffer` the UI transferred in;
+ * across the channel we wrap it once so followers copy no upload bytes.
+ */
+export function hoistContent(command: CommandDescriptor): WireCommand {
+  // A 0-byte placeholder satisfies `updateContent`'s non-nullable field on the
+  // wire; the real bytes ride the `Blob` and are re-attached by `lowerContent`.
+  if (command.kind === 'create' && command.content) {
+    return { command: { ...command, content: null }, content: new Blob([command.content]) };
+  }
+  if (command.kind === 'updateContent') {
+    return { command: { ...command, content: EMPTY }, content: new Blob([command.content]) };
+  }
+  return { command };
+}
+
+const EMPTY = new ArrayBuffer(0);
+
+/**
+ * Rebuilds a leader-side command descriptor from the wire, reading the hoisted
+ * `Blob` back into an `ArrayBuffer` that the leader transfers into its worker.
+ */
+export async function lowerContent(
+  wire: WireCommand
+): Promise<{ command: CommandDescriptor; transfer: Transferable[] }> {
+  const { command, content } = wire;
+  if (content && (command.kind === 'create' || command.kind === 'updateContent')) {
+    const buffer = await content.arrayBuffer();
+    return { command: { ...command, content: buffer }, transfer: [buffer] };
+  }
+  return { command, transfer: [] };
+}

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -22,7 +22,7 @@ describe('broadcast transport ↔ leader relay', () => {
     expect(engine.commands.map((c) => c.kind)).toEqual(['delete']);
   });
 
-  it('never transmits the login secret and scrubs the follower copy', async () => {
+  it('takes no secret: start just awaits a live leader, wire carries only a hello', async () => {
     const bus = new FakeBus();
     const posted: unknown[] = [];
     const leaderChannel = bus.channel();
@@ -31,13 +31,15 @@ describe('broadcast transport ↔ leader relay', () => {
     new LeaderRelay(leaderChannel, new FakeEngineTransport());
     const follower = new BroadcastTransport(bus.channel(), 'f');
 
-    const secret = new Uint8Array([1, 2, 3, 4, 5]).buffer;
-    await follower.start(secret);
+    // The keyless follower transport receives no secret at all — `start` has no
+    // secret parameter; it resolves once a leader beacon arrives.
+    await follower.start();
 
-    // The secret buffer was zeroed in place and no command carried its bytes.
-    expect([...new Uint8Array(secret)]).toEqual([0, 0, 0, 0, 0]);
-    const carriedSecret = posted.some((m) => JSON.stringify(m).includes('"1,2,3,4,5"'));
-    expect(carriedSecret).toBe(false);
+    // The only thing the follower put on the wire is its self-announcing hello.
+    const followerPosts = posted.filter(
+      (m) => (m as { clientId?: string }).clientId === 'f'
+    ) as Array<{ type: string }>;
+    expect(followerPosts.map((m) => m.type)).toEqual(['cb:hello']);
   });
 
   it('leaks no key-shaped sentinel on any leader→follower message (structural)', async () => {
@@ -52,10 +54,9 @@ describe('broadcast transport ↔ leader relay', () => {
 
     const follower = new BroadcastTransport(bus.channel(), 'f');
     // A key-shaped sentinel: distinctive 32-byte key material that must never
-    // appear on the keyless leader→follower wire. Plant it as this follower's
-    // secret (the follower scrubs it) so it genuinely exists in the test realm.
+    // appear on the keyless leader→follower wire.
     const sentinel = Uint8Array.from({ length: 32 }, (_, i) => (i * 7 + 3) & 0xff);
-    await follower.start(sentinel.slice().buffer);
+    await follower.start();
 
     // Drive the full leader→follower surface: a correlated response plus every
     // EventDescriptor variant, including the byte- and string-bearing ones.
@@ -130,5 +131,79 @@ describe('broadcast transport ↔ leader relay', () => {
 
     const hints = engine.commands.slice(before).filter((c) => c.kind === 'manualRefresh');
     expect(hints.length).toBe(1);
+  });
+
+  it('re-arms on leadership change: an in-flight command rejects retryably, later commands await the next leader (P1-3)', async () => {
+    const bus = new FakeBus();
+    const engineA = new FakeEngineTransport();
+    engineA.respond = () => new Promise(() => undefined); // leader A never answers
+    const relayA = new LeaderRelay(bus.channel(), engineA);
+    const follower = new BroadcastTransport(bus.channel(), 'f');
+    await follower.start(); // leader A present
+
+    const inFlight = follower.command({ kind: 'manualRefresh' }, []);
+    await tick();
+
+    // Leader A steps down: the in-flight command rejects retryably, never hangs.
+    relayA.close();
+    await expect(inFlight).rejects.toThrow(/retry/);
+
+    // A command issued while no leader is present parks on the re-armed gate.
+    const queued = follower.command({ kind: 'manualRefresh' }, []);
+    let settled = false;
+    void queued.then(
+      () => (settled = true),
+      () => (settled = true)
+    );
+    await tick();
+    expect(settled).toBe(false);
+
+    // A fresh leader is elected → the queued command resolves against it.
+    const engineB = new FakeEngineTransport();
+    new LeaderRelay(bus.channel(), engineB);
+    await queued;
+    expect(engineB.commands.map((c) => c.kind)).toEqual(['manualRefresh']);
+  });
+
+  it('rejects a forged response/event bearing a wrong or absent leader token (P1-4)', async () => {
+    const bus = new FakeBus();
+    const engine = new FakeEngineTransport();
+    engine.respond = () => new Promise(() => undefined); // the real leader never answers
+    new LeaderRelay(bus.channel(), engine);
+    const follower = new BroadcastTransport(bus.channel(), 'f');
+    await follower.start();
+
+    const pending = follower.command({ kind: 'manualRefresh' }, []);
+    let settled = false;
+    void pending.then(
+      () => (settled = true),
+      () => (settled = true)
+    );
+    await tick();
+
+    // A same-origin attacker forges an ok response for the follower's request —
+    // once with a wrong token, once with none. Neither may settle the command.
+    const attacker = bus.channel();
+    attacker.postMessage({
+      type: 'cb:response',
+      token: 'forged-token',
+      clientId: 'f',
+      requestId: 1,
+      ok: true,
+    });
+    attacker.postMessage({ type: 'cb:response', clientId: 'f', requestId: 1, ok: true });
+
+    // A forged event with a wrong token must not reach subscribers either.
+    const events: EventDescriptor[] = [];
+    follower.subscribe((event) => events.push(event));
+    attacker.postMessage({
+      type: 'cb:event',
+      token: 'forged-token',
+      event: { kind: 'snapshotUpdated' },
+    });
+    await tick();
+
+    expect(settled).toBe(false);
+    expect(events).toEqual([]);
   });
 });

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { BroadcastTransport } from './broadcastTransport.js';
+import { LeaderRelay } from './leaderRelay.js';
+import { FakeBus, FakeEngineTransport } from './testkit.js';
+import type { EventDescriptor } from './worker/protocol.js';
+
+const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+function wire(): { engine: FakeEngineTransport; relay: LeaderRelay; follower: BroadcastTransport } {
+  const bus = new FakeBus();
+  const engine = new FakeEngineTransport();
+  const relay = new LeaderRelay(bus.channel(), engine);
+  const follower = new BroadcastTransport(bus.channel(), 'follower-1');
+  return { engine, relay, follower };
+}
+
+describe('broadcast transport ↔ leader relay', () => {
+  it('routes a follower command to the leader engine and correlates the response', async () => {
+    const { engine, follower } = wire();
+    await follower.command({ kind: 'delete', node: new Uint8Array(16) }, []);
+    expect(engine.commands.map((c) => c.kind)).toEqual(['delete']);
+  });
+
+  it('never transmits the login secret and scrubs the follower copy', async () => {
+    const bus = new FakeBus();
+    const posted: unknown[] = [];
+    const leaderChannel = bus.channel();
+    leaderChannel.addEventListener('message', (event) => posted.push(event.data));
+    // A relay makes a leader "present" so start resolves.
+    new LeaderRelay(leaderChannel, new FakeEngineTransport());
+    const follower = new BroadcastTransport(bus.channel(), 'f');
+
+    const secret = new Uint8Array([1, 2, 3, 4, 5]).buffer;
+    await follower.start(secret);
+
+    // The secret buffer was zeroed in place and no command carried its bytes.
+    expect([...new Uint8Array(secret)]).toEqual([0, 0, 0, 0, 0]);
+    const carriedSecret = posted.some((m) => JSON.stringify(m).includes('"1,2,3,4,5"'));
+    expect(carriedSecret).toBe(false);
+  });
+
+  it('shares upload content as a Blob and rebuilds identical bytes on the leader', async () => {
+    const { engine, follower } = wire();
+    const bytes = new Uint8Array([9, 8, 7, 6]);
+    await follower.command(
+      { kind: 'updateContent', node: new Uint8Array(16), content: bytes.buffer },
+      [bytes.buffer]
+    );
+
+    const command = engine.commands[0];
+    expect(command.kind).toBe('updateContent');
+    if (command.kind !== 'updateContent') throw new Error('unreachable');
+    expect([...new Uint8Array(command.content)]).toEqual([9, 8, 7, 6]);
+  });
+
+  it('fans engine events out to the follower in emission order', async () => {
+    const { engine, follower } = wire();
+    const received: EventDescriptor[] = [];
+    follower.subscribe((event) => received.push(event));
+    await tick(); // let the follower register with the leader
+
+    const sent: EventDescriptor[] = [
+      { kind: 'snapshotUpdated' },
+      { kind: 'deadLetter', opId: 3n },
+      { kind: 'stalenessChanged', staleness: 'stale' },
+    ];
+    for (const event of sent) engine.emit(event);
+    await tick();
+
+    expect(received).toEqual(sent);
+  });
+
+  it('rejects in-flight and later commands once the follower transport closes', async () => {
+    const { engine, follower } = wire();
+    engine.respond = () => new Promise(() => undefined); // never settles
+    const inFlight = follower.command({ kind: 'manualRefresh' }, []);
+    await tick();
+    follower.close();
+
+    await expect(inFlight).rejects.toThrow('closed');
+    await expect(follower.command({ kind: 'manualRefresh' }, [])).rejects.toThrow('closed');
+  });
+
+  it('folds follower focus into the union and forwards a refresh hint', async () => {
+    const { engine, follower } = wire();
+    const before = engine.commands.length;
+    follower.reportFocus(new Uint8Array([0xaa, 0xbb]));
+    await tick();
+
+    const hints = engine.commands.slice(before).filter((c) => c.kind === 'manualRefresh');
+    expect(hints.length).toBe(1);
+  });
+});

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -40,6 +40,46 @@ describe('broadcast transport ↔ leader relay', () => {
     expect(carriedSecret).toBe(false);
   });
 
+  it('leaks no key-shaped sentinel on any leader→follower message (structural)', async () => {
+    const bus = new FakeBus();
+    const engine = new FakeEngineTransport();
+    new LeaderRelay(bus.channel(), engine);
+
+    // Capture everything the leader broadcasts to followers (events + responses).
+    const leaderPosts: unknown[] = [];
+    const spy = bus.channel();
+    spy.addEventListener('message', (event) => leaderPosts.push(event.data));
+
+    const follower = new BroadcastTransport(bus.channel(), 'f');
+    // A key-shaped sentinel: distinctive 32-byte key material that must never
+    // appear on the keyless leader→follower wire. Plant it as this follower's
+    // secret (the follower scrubs it) so it genuinely exists in the test realm.
+    const sentinel = Uint8Array.from({ length: 32 }, (_, i) => (i * 7 + 3) & 0xff);
+    await follower.start(sentinel.slice().buffer);
+
+    // Drive the full leader→follower surface: a correlated response plus every
+    // EventDescriptor variant, including the byte- and string-bearing ones.
+    await follower.command({ kind: 'manualRefresh' }, []);
+    engine.emit({ kind: 'snapshotUpdated' });
+    engine.emit({ kind: 'stalenessChanged', staleness: 'stale' });
+    engine.emit({ kind: 'withheldUpdateEscalation', ipnsName: new Uint8Array([1, 2, 3]) });
+    engine.emit({ kind: 'deadLetter', opId: 9n });
+    engine.emit({ kind: 'attributableAbuse', description: 'abuse' });
+    await tick();
+
+    // Serialize every leader post (bytes as csv, bigint as string) and assert the
+    // sentinel never rode along — a future variant echoing key bytes would fail.
+    const serialize = (value: unknown): string =>
+      JSON.stringify(value, (_key, v) =>
+        v instanceof Uint8Array ? [...v].join(',') : typeof v === 'bigint' ? v.toString() : v
+      );
+    const sentinelCsv = [...sentinel].join(',');
+    const leaked = leaderPosts.some((message) => serialize(message).includes(sentinelCsv));
+    expect(leaked).toBe(false);
+    // Sanity: the leader actually broadcast the events + response we drove.
+    expect(leaderPosts.length).toBeGreaterThanOrEqual(6);
+  });
+
   it('shares upload content as a Blob and rebuilds identical bytes on the leader', async () => {
     const { engine, follower } = wire();
     const bytes = new Uint8Array([9, 8, 7, 6]);

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -42,9 +42,16 @@ describe('broadcast transport ↔ leader relay', () => {
     expect(followerPosts.map((m) => m.type)).toEqual(['cb:hello']);
   });
 
-  it('leaks no key-shaped sentinel on any leader→follower message (structural)', async () => {
+  it('never echoes the leader secret onto any leader→follower message (structural)', async () => {
     const bus = new FakeBus();
     const engine = new FakeEngineTransport();
+
+    // The sentinel *is* the leader's key material: 32 distinctive secret bytes
+    // actually handed to the leader engine. It must never ride the keyless
+    // leader→follower wire — not on an event, not in a response error string.
+    const sentinel = Uint8Array.from({ length: 32 }, (_, i) => (i * 7 + 3) & 0xff);
+    await engine.start(sentinel.buffer.slice(0));
+
     new LeaderRelay(bus.channel(), engine);
 
     // Capture everything the leader broadcasts to followers (events + responses).
@@ -53,14 +60,17 @@ describe('broadcast transport ↔ leader relay', () => {
     spy.addEventListener('message', (event) => leaderPosts.push(event.data));
 
     const follower = new BroadcastTransport(bus.channel(), 'f');
-    // A key-shaped sentinel: distinctive 32-byte key material that must never
-    // appear on the keyless leader→follower wire.
-    const sentinel = Uint8Array.from({ length: 32 }, (_, i) => (i * 7 + 3) & 0xff);
     await follower.start();
 
-    // Drive the full leader→follower surface: a correlated response plus every
-    // EventDescriptor variant, including the byte- and string-bearing ones.
-    await follower.command({ kind: 'manualRefresh' }, []);
+    // A command whose engine handling rejects: the relay forwards the failure as
+    // a `cb:response` error string — a real leak vector for secret bytes bleeding
+    // into an error message. A hygienic engine rejects with a generic message.
+    engine.respond = () => Promise.reject(new Error('command failed'));
+    await follower.command({ kind: 'manualRefresh' }, []).catch(() => undefined);
+
+    // Plus every EventDescriptor variant, including the byte- and string-bearing
+    // ones the relay forwards verbatim.
+    engine.respond = () => Promise.resolve();
     engine.emit({ kind: 'snapshotUpdated' });
     engine.emit({ kind: 'stalenessChanged', staleness: 'stale' });
     engine.emit({ kind: 'withheldUpdateEscalation', ipnsName: new Uint8Array([1, 2, 3]) });
@@ -69,7 +79,8 @@ describe('broadcast transport ↔ leader relay', () => {
     await tick();
 
     // Serialize every leader post (bytes as csv, bigint as string) and assert the
-    // sentinel never rode along — a future variant echoing key bytes would fail.
+    // secret never rode along. A relay that echoed the leader's key material into
+    // an event or error string would surface the sentinel here and fail.
     const serialize = (value: unknown): string =>
       JSON.stringify(value, (_key, v) =>
         v instanceof Uint8Array ? [...v].join(',') : typeof v === 'bigint' ? v.toString() : v
@@ -77,7 +88,13 @@ describe('broadcast transport ↔ leader relay', () => {
     const sentinelCsv = [...sentinel].join(',');
     const leaked = leaderPosts.some((message) => serialize(message).includes(sentinelCsv));
     expect(leaked).toBe(false);
-    // Sanity: the leader actually broadcast the events + response we drove.
+    // Sanity: the leader actually broadcast the failure response + events we drove
+    // — the error-string wire field the sentinel could have leaked through is live.
+    const errorResponses = leaderPosts.filter(
+      (m) =>
+        (m as { type?: string; ok?: boolean }).type === 'cb:response' && !(m as { ok?: boolean }).ok
+    );
+    expect(errorResponses.length).toBe(1);
     expect(leaderPosts.length).toBeGreaterThanOrEqual(6);
   });
 

--- a/packages/client/src/broadcastTransport.ts
+++ b/packages/client/src/broadcastTransport.ts
@@ -1,0 +1,150 @@
+/**
+ * The follower-side `EngineTransport` (blueprint/web-client.md "Followers are
+ * thin mirrors"). A non-leader tab holds no worker and no keys: it sends
+ * commands as data to the leader over the `BroadcastChannel` and renders the
+ * projections and events the leader broadcasts back.
+ *
+ * It honors the same teardown contract as `LocalTransport`: a torn-down or
+ * leader-dead transport **rejects** every pending request, never hangs — so a
+ * command caught in flight at a leadership swap surfaces a retry to the UI
+ * rather than silently disappearing.
+ */
+
+import { hoistContent, type BroadcastChannelLike, type LeaderMessage } from './broadcast.js';
+import type { EngineEventListener, EngineTransport } from './transport.js';
+import type { CommandDescriptor } from './worker/protocol.js';
+
+interface Pending {
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+export class BroadcastTransport implements EngineTransport {
+  private readonly pending = new Map<number, Pending>();
+  private readonly listeners = new Set<EngineEventListener>();
+  private nextId = 1;
+  private closed = false;
+  private terminalError: Error | null = null;
+
+  private leaderPresent = false;
+  private readonly leaderReady: Promise<void>;
+  private resolveLeaderReady!: () => void;
+  private rejectLeaderReady!: (error: Error) => void;
+
+  private readonly onMessage = (event: MessageEvent): void => this.receive(event.data);
+
+  constructor(
+    private readonly channel: BroadcastChannelLike,
+    private readonly clientId: string
+  ) {
+    this.leaderReady = new Promise<void>((resolve, reject) => {
+      this.resolveLeaderReady = resolve;
+      this.rejectLeaderReady = reject;
+    });
+    this.leaderReady.catch(() => undefined);
+    this.channel.addEventListener('message', this.onMessage);
+    // Announce ourselves so a live leader replies with a `leader` beacon.
+    this.channel.postMessage({ type: 'cb:hello', clientId: this.clientId });
+  }
+
+  /**
+   * A follower never transmits the login secret — the leader's engine already
+   * owns key derivation. Scrub this tab's copy and resolve once a leader is
+   * confirmed present.
+   */
+  start(secret: ArrayBuffer): Promise<void> {
+    new Uint8Array(secret).fill(0);
+    if (this.terminalError) return Promise.reject(this.terminalError);
+    return this.leaderReady;
+  }
+
+  command(command: CommandDescriptor, _transfer: Transferable[]): Promise<void> {
+    if (this.terminalError) return Promise.reject(this.terminalError);
+    return this.leaderReady.then(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          if (this.terminalError) {
+            reject(this.terminalError);
+            return;
+          }
+          const requestId = this.nextId++;
+          this.pending.set(requestId, { resolve, reject });
+          try {
+            this.channel.postMessage({
+              type: 'cb:command',
+              clientId: this.clientId,
+              requestId,
+              wire: hoistContent(command),
+            });
+          } catch (error) {
+            this.pending.delete(requestId);
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
+        })
+    );
+  }
+
+  subscribe(listener: EngineEventListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Reports this tab's open folder to the leader's focus-window union. */
+  reportFocus(node: Uint8Array | null): void {
+    if (this.closed) return;
+    this.channel.postMessage({ type: 'cb:focus', clientId: this.clientId, node });
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    const error = new Error('engine transport closed');
+    // Unblock a request parked on `leaderReady`, then reject all in-flight work.
+    this.rejectLeaderReady(error);
+    this.fail(error);
+    try {
+      this.channel.postMessage({ type: 'cb:bye', clientId: this.clientId });
+    } catch {
+      // The channel may already be torn down; teardown proceeds regardless.
+    }
+    this.channel.removeEventListener('message', this.onMessage);
+  }
+
+  private receive(message: LeaderMessage | { type?: string }): void {
+    switch (message.type) {
+      case 'cb:leader':
+        if (!this.leaderPresent) {
+          this.leaderPresent = true;
+          this.resolveLeaderReady();
+        }
+        return;
+      case 'cb:response': {
+        const response = message as Extract<LeaderMessage, { type: 'cb:response' }>;
+        if (response.clientId !== this.clientId) return;
+        const pending = this.pending.get(response.requestId);
+        if (!pending) return;
+        this.pending.delete(response.requestId);
+        if (response.ok) pending.resolve();
+        else pending.reject(new Error(response.error));
+        return;
+      }
+      case 'cb:event': {
+        const { event } = message as Extract<LeaderMessage, { type: 'cb:event' }>;
+        for (const listener of this.listeners) {
+          try {
+            listener(event);
+          } catch {
+            // One throwing subscriber must not drop the event for the rest.
+          }
+        }
+        return;
+      }
+    }
+  }
+
+  private fail(error: Error): void {
+    this.terminalError ??= error;
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+}

--- a/packages/client/src/broadcastTransport.ts
+++ b/packages/client/src/broadcastTransport.ts
@@ -8,6 +8,11 @@
  * leader-dead transport **rejects** every pending request, never hangs — so a
  * command caught in flight at a leadership swap surfaces a retry to the UI
  * rather than silently disappearing.
+ *
+ * A follower authenticates the leader by an unguessable per-leadership `token`
+ * carried on the `cb:leader` beacon: it stamps every accepted response/event and
+ * lets the follower reject forged acks/events from a non-leader same-origin
+ * context.
  */
 
 import { hoistContent, type BroadcastChannelLike, type LeaderMessage } from './broadcast.js';
@@ -17,8 +22,13 @@ import type { CommandDescriptor } from './worker/protocol.js';
 export class BroadcastTransport extends CorrelatedTransport {
   private closed = false;
 
-  private leaderPresent = false;
-  private readonly leaderReady: Promise<void>;
+  // The active leadership's capability token; `null` when no leader is known
+  // (start, or after the leader stepped down). Only messages bearing this exact
+  // token are accepted.
+  private leaderToken: string | null = null;
+  // Re-armed on every leadership change so a command posted while no leader is
+  // present awaits the *next* leader instead of resolving against a dead one.
+  private leaderReady!: Promise<void>;
   private resolveLeaderReady!: () => void;
   private rejectLeaderReady!: (error: Error) => void;
 
@@ -29,25 +39,19 @@ export class BroadcastTransport extends CorrelatedTransport {
     private readonly clientId: string
   ) {
     super();
-    this.leaderReady = new Promise<void>((resolve, reject) => {
-      this.resolveLeaderReady = resolve;
-      this.rejectLeaderReady = reject;
-    });
-    this.leaderReady.catch(() => undefined);
+    this.armLeaderReady();
     this.channel.addEventListener('message', this.onMessage);
     // Announce ourselves so a live leader replies with a `leader` beacon.
     this.channel.postMessage({ type: 'cb:hello', clientId: this.clientId });
   }
 
   /**
-   * A follower never transmits the login secret — the leader's engine already
-   * owns key derivation. This **consumes and scrubs** the secret: it zeroes the
-   * caller's buffer so the plaintext never lingers in the keyless follower realm.
-   * A caller MUST re-derive a fresh buffer via `SecretSource` for any retry
-   * (e.g. failover cold-start) — never reuse this buffer, whose bytes are now 0.
+   * A follower holds no keys and never receives the login secret — the leader's
+   * engine already owns key derivation. Starting a follower is just awaiting a
+   * live leader; the secret is scrubbed by its terminal owner (`EngineClient`),
+   * never handed to this keyless transport.
    */
-  start(secret: ArrayBuffer): Promise<void> {
-    new Uint8Array(secret).fill(0);
+  start(): Promise<void> {
     if (this.terminalError) return Promise.reject(this.terminalError);
     return this.leaderReady;
   }
@@ -84,25 +88,67 @@ export class BroadcastTransport extends CorrelatedTransport {
     this.channel.removeEventListener('message', this.onMessage);
   }
 
+  private armLeaderReady(): void {
+    this.leaderReady = new Promise<void>((resolve, reject) => {
+      this.resolveLeaderReady = resolve;
+      this.rejectLeaderReady = reject;
+    });
+    // A request re-observes this rejection; swallow the unobserved-rejection warn.
+    this.leaderReady.catch(() => undefined);
+  }
+
   private receive(message: LeaderMessage | { type?: string }): void {
+    if (this.closed) return;
     switch (message.type) {
       case 'cb:leader':
-        if (!this.leaderPresent) {
-          this.leaderPresent = true;
-          this.resolveLeaderReady();
-        }
+        this.onLeader((message as Extract<LeaderMessage, { type: 'cb:leader' }>).token);
+        return;
+      case 'cb:leaderGone':
+        this.onLeaderGone((message as Extract<LeaderMessage, { type: 'cb:leaderGone' }>).token);
         return;
       case 'cb:response': {
         const response = message as Extract<LeaderMessage, { type: 'cb:response' }>;
         if (response.clientId !== this.clientId) return;
+        if (!this.fromActiveLeader(response.token)) return; // forged / stale ack
         this.settle(response.requestId, response.ok, response.ok ? undefined : response.error);
         return;
       }
       case 'cb:event': {
-        const { event } = message as Extract<LeaderMessage, { type: 'cb:event' }>;
-        this.emit(event);
+        const event = message as Extract<LeaderMessage, { type: 'cb:event' }>;
+        if (!this.fromActiveLeader(event.token)) return; // forged / stale event
+        this.emit(event.event);
         return;
       }
     }
   }
+
+  private fromActiveLeader(token: string): boolean {
+    return this.leaderToken !== null && token === this.leaderToken;
+  }
+
+  private onLeader(token: string): void {
+    if (this.leaderToken === token) return; // duplicate beacon from the same leadership
+    if (this.leaderToken !== null) {
+      // Leadership moved to a new tab without a graceful step-down (the old
+      // leader crashed): reject requests bound to it so the UI retries the new
+      // leader. New commands go to the new leader once the token is adopted.
+      this.rejectPending(retryError());
+    }
+    this.leaderToken = token;
+    this.resolveLeaderReady();
+  }
+
+  private onLeaderGone(token: string): void {
+    // Only the current leader may step us down; ignore a stale/forged farewell.
+    if (this.leaderToken === null || token !== this.leaderToken) return;
+    this.leaderToken = null;
+    this.rejectPending(retryError());
+    // Re-arm so subsequent commands await the next leader rather than resolving
+    // against the departed one.
+    this.armLeaderReady();
+  }
+}
+
+function retryError(): Error {
+  return new Error('leader changed; retry');
 }

--- a/packages/client/src/broadcastTransport.ts
+++ b/packages/client/src/broadcastTransport.ts
@@ -11,20 +11,11 @@
  */
 
 import { hoistContent, type BroadcastChannelLike, type LeaderMessage } from './broadcast.js';
-import type { EngineEventListener, EngineTransport } from './transport.js';
+import { CorrelatedTransport } from './correlatedTransport.js';
 import type { CommandDescriptor } from './worker/protocol.js';
 
-interface Pending {
-  resolve: () => void;
-  reject: (error: Error) => void;
-}
-
-export class BroadcastTransport implements EngineTransport {
-  private readonly pending = new Map<number, Pending>();
-  private readonly listeners = new Set<EngineEventListener>();
-  private nextId = 1;
+export class BroadcastTransport extends CorrelatedTransport {
   private closed = false;
-  private terminalError: Error | null = null;
 
   private leaderPresent = false;
   private readonly leaderReady: Promise<void>;
@@ -37,6 +28,7 @@ export class BroadcastTransport implements EngineTransport {
     private readonly channel: BroadcastChannelLike,
     private readonly clientId: string
   ) {
+    super();
     this.leaderReady = new Promise<void>((resolve, reject) => {
       this.resolveLeaderReady = resolve;
       this.rejectLeaderReady = reject;
@@ -49,8 +41,10 @@ export class BroadcastTransport implements EngineTransport {
 
   /**
    * A follower never transmits the login secret — the leader's engine already
-   * owns key derivation. Scrub this tab's copy and resolve once a leader is
-   * confirmed present.
+   * owns key derivation. This **consumes and scrubs** the secret: it zeroes the
+   * caller's buffer so the plaintext never lingers in the keyless follower realm.
+   * A caller MUST re-derive a fresh buffer via `SecretSource` for any retry
+   * (e.g. failover cold-start) — never reuse this buffer, whose bytes are now 0.
    */
   start(secret: ArrayBuffer): Promise<void> {
     new Uint8Array(secret).fill(0);
@@ -59,34 +53,14 @@ export class BroadcastTransport implements EngineTransport {
   }
 
   command(command: CommandDescriptor, _transfer: Transferable[]): Promise<void> {
-    if (this.terminalError) return Promise.reject(this.terminalError);
-    return this.leaderReady.then(
-      () =>
-        new Promise<void>((resolve, reject) => {
-          if (this.terminalError) {
-            reject(this.terminalError);
-            return;
-          }
-          const requestId = this.nextId++;
-          this.pending.set(requestId, { resolve, reject });
-          try {
-            this.channel.postMessage({
-              type: 'cb:command',
-              clientId: this.clientId,
-              requestId,
-              wire: hoistContent(command),
-            });
-          } catch (error) {
-            this.pending.delete(requestId);
-            reject(error instanceof Error ? error : new Error(String(error)));
-          }
-        })
+    return this.dispatch(this.leaderReady, (requestId) =>
+      this.channel.postMessage({
+        type: 'cb:command',
+        clientId: this.clientId,
+        requestId,
+        wire: hoistContent(command),
+      })
     );
-  }
-
-  subscribe(listener: EngineEventListener): () => void {
-    this.listeners.add(listener);
-    return () => this.listeners.delete(listener);
   }
 
   /** Reports this tab's open folder to the leader's focus-window union. */
@@ -121,30 +95,14 @@ export class BroadcastTransport implements EngineTransport {
       case 'cb:response': {
         const response = message as Extract<LeaderMessage, { type: 'cb:response' }>;
         if (response.clientId !== this.clientId) return;
-        const pending = this.pending.get(response.requestId);
-        if (!pending) return;
-        this.pending.delete(response.requestId);
-        if (response.ok) pending.resolve();
-        else pending.reject(new Error(response.error));
+        this.settle(response.requestId, response.ok, response.ok ? undefined : response.error);
         return;
       }
       case 'cb:event': {
         const { event } = message as Extract<LeaderMessage, { type: 'cb:event' }>;
-        for (const listener of this.listeners) {
-          try {
-            listener(event);
-          } catch {
-            // One throwing subscriber must not drop the event for the rest.
-          }
-        }
+        this.emit(event);
         return;
       }
     }
-  }
-
-  private fail(error: Error): void {
-    this.terminalError ??= error;
-    for (const pending of this.pending.values()) pending.reject(error);
-    this.pending.clear();
   }
 }

--- a/packages/client/src/correlatedTransport.ts
+++ b/packages/client/src/correlatedTransport.ts
@@ -91,10 +91,20 @@ export abstract class CorrelatedTransport implements EngineTransport {
     else pending.reject(new Error(error));
   }
 
+  /**
+   * Rejects every in-flight request without latching a terminal error, so the
+   * transport stays usable. Used when leadership moves under a follower: the
+   * requests bound to the departed leader reject retryably while the transport
+   * awaits the next leader.
+   */
+  protected rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+
   /** Latches terminal failure and rejects every in-flight request. */
   protected fail(error: Error): void {
     this.terminalError ??= error;
-    for (const pending of this.pending.values()) pending.reject(error);
-    this.pending.clear();
+    this.rejectPending(error);
   }
 }

--- a/packages/client/src/correlatedTransport.ts
+++ b/packages/client/src/correlatedTransport.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared request-correlation machinery for the two `EngineTransport`s
+ * (`LocalTransport` over a worker, `BroadcastTransport` over a channel). Both
+ * correlate responses to requests by a monotonic id and honor the same teardown
+ * contract hardened in #728: a torn-down or dead transport **rejects** every
+ * pending request instead of hanging.
+ *
+ * A subclass supplies only its readiness gate and its send primitive; this base
+ * owns the pending map, the no-hang request skeleton, response settlement, the
+ * terminal-failure latch, and the event fan-out.
+ */
+
+import type { EngineEventListener, EngineTransport } from './transport.js';
+import type { CommandDescriptor, EventDescriptor } from './worker/protocol.js';
+
+interface Pending {
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+/**
+ * Delivers one event to every listener, isolating a throwing subscriber so it
+ * cannot drop the event for the rest.
+ */
+export function fanOut(listeners: Iterable<EngineEventListener>, event: EventDescriptor): void {
+  for (const listener of listeners) {
+    try {
+      listener(event);
+    } catch {
+      // One throwing subscriber must not drop the event for the rest.
+    }
+  }
+}
+
+export abstract class CorrelatedTransport implements EngineTransport {
+  private readonly pending = new Map<number, Pending>();
+  private readonly listeners = new Set<EngineEventListener>();
+  private nextId = 1;
+  // A fatal message, transport error, or teardown latches this. Once set, every
+  // request rejects here instead of dispatching and waiting for a response that
+  // can never arrive.
+  protected terminalError: Error | null = null;
+
+  abstract start(secret: ArrayBuffer): Promise<void>;
+  abstract command(command: CommandDescriptor, transfer: Transferable[]): Promise<void>;
+  abstract close(): void;
+
+  subscribe(listener: EngineEventListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Fans one engine event out to this transport's subscribers. */
+  protected emit(event: EventDescriptor): void {
+    fanOut(this.listeners, event);
+  }
+
+  /**
+   * The no-hang request skeleton: short-circuit on `terminalError` before
+   * awaiting the readiness gate, register the pending entry, then `send`. A
+   * synchronous `send` failure deletes the pending entry before rejecting so it
+   * is never stranded.
+   */
+  protected dispatch(readyGate: Promise<void>, send: (id: number) => void): Promise<void> {
+    if (this.terminalError) return Promise.reject(this.terminalError);
+    return readyGate.then(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          if (this.terminalError) {
+            reject(this.terminalError);
+            return;
+          }
+          const id = this.nextId++;
+          this.pending.set(id, { resolve, reject });
+          try {
+            send(id);
+          } catch (error) {
+            this.pending.delete(id);
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
+        })
+    );
+  }
+
+  /** Correlates a response to its request id, resolving or rejecting it. */
+  protected settle(id: number, ok: boolean, error?: string): void {
+    const pending = this.pending.get(id);
+    if (!pending) return;
+    this.pending.delete(id);
+    if (ok) pending.resolve();
+    else pending.reject(new Error(error));
+  }
+
+  /** Latches terminal failure and rejects every in-flight request. */
+  protected fail(error: Error): void {
+    this.terminalError ??= error;
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+}

--- a/packages/client/src/engineClient.test.ts
+++ b/packages/client/src/engineClient.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+
+import { EngineClient, type EngineClientConfig } from './engineClient.js';
+import { FakeBus, FakeEngineWorker, FakeLockManager } from './testkit.js';
+import type { EventDescriptor } from './worker/protocol.js';
+
+const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+/** A shared origin: one lock manager, one broadcast bus, one worker registry. */
+function origin() {
+  const locks = new FakeLockManager();
+  const bus = new FakeBus();
+  const workers: FakeEngineWorker[] = [];
+  const spawnWorker = (): FakeEngineWorker => {
+    const worker = new FakeEngineWorker();
+    workers.push(worker);
+    setTimeout(() => worker.ready(), 0);
+    return worker;
+  };
+  const liveWorkers = (): number => workers.filter((w) => !w.terminated).length;
+
+  const tab = (overrides?: Partial<EngineClientConfig>): EngineClient =>
+    new EngineClient({
+      locks,
+      createChannel: () => bus.channel(),
+      spawnWorker,
+      ...overrides,
+    });
+
+  return { tab, workers, liveWorkers };
+}
+
+describe('EngineClient leadership + transport swap', () => {
+  it('elects the first tab leader and spawns exactly one worker', async () => {
+    const { tab, liveWorkers } = origin();
+    const a = tab();
+    const b = tab();
+    await tick();
+
+    expect(a.currentRole()).toBe('leader');
+    expect(b.currentRole()).toBe('follower');
+    expect(liveWorkers()).toBe(1); // the single writer per origin
+    await a.dispose();
+    await b.dispose();
+  });
+
+  it('routes a follower command through the broadcast wire to the leader worker', async () => {
+    const { tab, workers } = origin();
+    const leader = tab();
+    const follower = tab();
+    await tick();
+    await leader.facade.start(new Uint8Array([1, 2, 3]).buffer);
+
+    await follower.facade.delete(new Uint8Array(16));
+    // The command reached the leader's worker (a `command` request was posted).
+    const posted = workers[0].posted.filter((m) => (m as { type?: string }).type === 'command');
+    expect(posted.length).toBe(1);
+    await leader.dispose();
+    await follower.dispose();
+  });
+
+  it('never spawns a worker on a follower tab', async () => {
+    const { tab, workers } = origin();
+    const leader = tab();
+    const follower = tab();
+    await tick();
+
+    expect(workers.length).toBe(1); // only the leader spawned one
+    void leader;
+    await follower.dispose();
+    await leader.dispose();
+  });
+
+  it('fails a follower over to leader on lock release, spawning a fresh worker with a re-derived secret', async () => {
+    const { tab, liveWorkers, workers } = origin();
+    let secretCalls = 0;
+    const secretSource = {
+      provideSecret: (): Promise<ArrayBuffer> => {
+        secretCalls += 1;
+        return Promise.resolve(new Uint8Array([7, 7, 7, 7]).buffer);
+      },
+    };
+
+    const leader = tab();
+    const follower = tab({ secretSource });
+    await tick();
+    // The follower is an active session (logged in via the leader).
+    await follower.facade.start(new Uint8Array([9]).buffer);
+    expect(follower.currentRole()).toBe('follower');
+
+    // Kill the leader → the follower is promoted.
+    await leader.dispose();
+    await tick();
+    await tick();
+
+    expect(follower.currentRole()).toBe('leader');
+    expect(liveWorkers()).toBe(1); // still exactly one writer
+    expect(secretCalls).toBe(1); // failover re-derived the secret
+    // The fresh worker was cold-started with the re-derived secret.
+    const startPosted = workers[workers.length - 1].posted.some(
+      (m) => (m as { type?: string }).type === 'start'
+    );
+    expect(startPosted).toBe(true);
+    await follower.dispose();
+  });
+
+  it('keeps the UI event subscription alive across a leadership swap', async () => {
+    const { tab } = origin();
+    const secretSource = {
+      provideSecret: (): Promise<ArrayBuffer> => Promise.resolve(new Uint8Array([1]).buffer),
+    };
+    const leader = tab();
+    const follower = tab({ secretSource });
+    await tick();
+    await follower.facade.start(new Uint8Array([2]).buffer);
+
+    const received: EventDescriptor[] = [];
+    follower.facade.subscribe((event) => received.push(event));
+
+    await leader.dispose();
+    await tick();
+    await tick();
+    // After promotion the follower is the leader; its own worker's events reach
+    // the same UI subscription registered before the swap.
+    expect(follower.currentRole()).toBe('leader');
+    await follower.dispose();
+  });
+
+  it('rejects a command in flight at a leadership swap so the UI can retry', async () => {
+    const { tab } = origin();
+    const secretSource = {
+      provideSecret: (): Promise<ArrayBuffer> => Promise.resolve(new Uint8Array([1]).buffer),
+    };
+    const leader = tab();
+    const follower = tab({ secretSource });
+    await tick();
+    await follower.facade.start(new Uint8Array([2]).buffer);
+
+    // Issue a follower command, then kill the leader before it can respond.
+    const inFlight = follower.facade.manualRefresh();
+    await leader.dispose();
+
+    await expect(inFlight).rejects.toThrow(/closed/);
+    await follower.dispose();
+  });
+});

--- a/packages/client/src/engineClient.test.ts
+++ b/packages/client/src/engineClient.test.ts
@@ -105,7 +105,7 @@ describe('EngineClient leadership + transport swap', () => {
   });
 
   it('keeps the UI event subscription alive across a leadership swap', async () => {
-    const { tab } = origin();
+    const { tab, workers } = origin();
     const secretSource = {
       provideSecret: (): Promise<ArrayBuffer> => Promise.resolve(new Uint8Array([1]).buffer),
     };
@@ -120,9 +120,16 @@ describe('EngineClient leadership + transport swap', () => {
     await leader.dispose();
     await tick();
     await tick();
-    // After promotion the follower is the leader; its own worker's events reach
-    // the same UI subscription registered before the swap.
     expect(follower.currentRole()).toBe('leader');
+
+    // The subscription registered *before* the swap must still be live: an event
+    // emitted by the promoted tab's own worker reaches it. A swap that dropped
+    // the subscription would leave `received` empty and fail here.
+    const promoted = workers[workers.length - 1];
+    promoted.emit({ type: 'event', event: { kind: 'snapshotUpdated' } });
+    await tick();
+    expect(received).toContainEqual({ kind: 'snapshotUpdated' });
+
     await follower.dispose();
   });
 
@@ -179,6 +186,34 @@ describe('EngineClient leadership + transport swap', () => {
     expect(promoted.posted.some((m) => (m as { type?: string }).type === 'start')).toBe(true);
 
     await follower.dispose();
+  });
+
+  it('releases the election lock and surfaces onError when the worker spawn throws synchronously (P1-5)', async () => {
+    const { tab } = origin();
+    const errors: Error[] = [];
+    const spawnFailure = new Error('worker spawn failed');
+
+    // This tab wins the lock first but its worker spawn throws synchronously
+    // during promotion: it must not sit on a dead-leader lock. It releases the
+    // lock, falls back to a follower, and surfaces the fault via onError.
+    const doomed = tab({
+      spawnWorker: (): never => {
+        throw spawnFailure;
+      },
+      onError: (error) => errors.push(error),
+    });
+    const healthy = tab();
+    await tick();
+    await tick();
+
+    expect(doomed.currentRole()).not.toBe('leader');
+    expect(errors).toContain(spawnFailure);
+    // The released lock was handed to the healthy tab, proving it was never held
+    // by the doomed leader after the throw.
+    expect(healthy.currentRole()).toBe('leader');
+
+    await doomed.dispose();
+    await healthy.dispose();
   });
 
   it('rejects a command in flight at a leadership swap so the UI can retry', async () => {

--- a/packages/client/src/engineClient.test.ts
+++ b/packages/client/src/engineClient.test.ts
@@ -126,6 +126,61 @@ describe('EngineClient leadership + transport swap', () => {
     await follower.dispose();
   });
 
+  it('scrubs the secret at the client seam and hands none to the keyless follower transport (P1-1)', async () => {
+    const { tab } = origin();
+    const leader = tab();
+    const follower = tab();
+    await tick();
+    expect(follower.currentRole()).toBe('follower');
+
+    // The follower holds no keys: the EngineClient (the secret's terminal owner)
+    // scrubs the buffer it decided not to use, and the BroadcastTransport — a
+    // callee — never receives it (its `start` takes no secret argument).
+    const secret = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer;
+    await follower.facade.start(secret);
+    expect([...new Uint8Array(secret)]).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+
+    await leader.dispose();
+    await follower.dispose();
+  });
+
+  it('does not advertise leadership or start the worker until the cold-start secret resolves (P1-2)', async () => {
+    const { tab, workers } = origin();
+    let releaseSecret!: () => void;
+    const secretSource = {
+      provideSecret: (): Promise<ArrayBuffer> =>
+        new Promise<ArrayBuffer>((resolve) => {
+          releaseSecret = () => resolve(new Uint8Array([1]).buffer);
+        }),
+    };
+    const leader = tab();
+    const follower = tab({ secretSource });
+    await tick();
+    await follower.facade.start(new Uint8Array([2]).buffer);
+
+    // Promote the follower, but stall it on the pending re-derived secret.
+    await leader.dispose();
+    await tick();
+    await tick();
+
+    // Promotion has spawned the fresh worker but is stalled on the secret.
+    expect(workers.length).toBe(2);
+    const promoted = workers[workers.length - 1];
+    // Leadership is not yet advertised and the worker has not been cold-started:
+    // a command in this window cannot reach an uninitialized worker.
+    expect(follower.currentRole()).not.toBe('leader');
+    expect(promoted.posted.some((m) => (m as { type?: string }).type === 'start')).toBe(false);
+
+    // The secret resolves → the worker cold-starts → only now is leadership live.
+    releaseSecret();
+    await tick();
+    await tick();
+    expect(follower.currentRole()).toBe('leader');
+    expect(promoted.posted.some((m) => (m as { type?: string }).type === 'start')).toBe(true);
+
+    await follower.dispose();
+  });
+
   it('rejects a command in flight at a leadership swap so the UI can retry', async () => {
     const { tab } = origin();
     const secretSource = {
@@ -136,11 +191,13 @@ describe('EngineClient leadership + transport swap', () => {
     await tick();
     await follower.facade.start(new Uint8Array([2]).buffer);
 
-    // Issue a follower command, then kill the leader before it can respond.
+    // Issue a follower command, then kill the leader before it can respond. The
+    // command rejects retryably (the leader stepped down / the transport closed)
+    // so the UI retries against the new leader instead of hanging forever.
     const inFlight = follower.facade.manualRefresh();
     await leader.dispose();
 
-    await expect(inFlight).rejects.toThrow(/closed/);
+    await expect(inFlight).rejects.toThrow(/retry|closed/);
     await follower.dispose();
   });
 });

--- a/packages/client/src/engineClient.ts
+++ b/packages/client/src/engineClient.ts
@@ -154,7 +154,10 @@ export class EngineClient implements EngineTransport {
 
   private becomeLeader(): void {
     if (this.role === 'closed') return;
-    void this.promote();
+    // Defer off the election callback so `this.election` is fully assigned before
+    // promotion runs: a synchronous worker-spawn throw then reaches `abortPromotion`
+    // with a live election to release, never a half-constructed one.
+    queueMicrotask(() => void this.promote());
   }
 
   /**
@@ -176,31 +179,35 @@ export class EngineClient implements EngineTransport {
     this.innerUnsub();
     this.current.close();
 
-    const worker = this.config.spawnWorker();
-    const local = new LocalTransport(worker);
+    // Worker creation and cold start run inside the guard: a synchronous throw
+    // from `spawnWorker()` or the `LocalTransport` constructor must release the
+    // Web Lock exactly like an async startup failure, never leave it held with
+    // no live leader (a dead-leader lock).
+    let local: LocalTransport | null = null;
+    try {
+      const worker = this.config.spawnWorker();
+      local = new LocalTransport(worker);
 
-    if (wasActiveFollower) {
-      try {
+      if (wasActiveFollower) {
         const secret = await this.provideFailoverSecret();
         await local.start(secret);
-      } catch (error) {
-        this.abortPromotion(local, error);
-        return;
       }
       // `dispose()` may have latched `closed` during the awaited startup.
       if ((this.role as EngineClientRole) === 'closed') {
         local.close();
         return;
       }
-    }
 
-    // Startup resolved: only now install the transport as active, wire events,
-    // and announce the relay so followers route commands to a live worker.
-    this.role = 'leader';
-    this.current = local;
-    this.innerUnsub = local.subscribe((event) => this.fanOut(event));
-    this.relay = new LeaderRelay(this.channel, local);
-    if (this.ownFocus) this.relay.reportLocalFocus(this.clientId, this.ownFocus);
+      // Startup resolved: only now install the transport as active, wire events,
+      // and announce the relay so followers route commands to a live worker.
+      this.role = 'leader';
+      this.current = local;
+      this.innerUnsub = local.subscribe((event) => this.fanOut(event));
+      this.relay = new LeaderRelay(this.channel, local);
+      if (this.ownFocus) this.relay.reportLocalFocus(this.clientId, this.ownFocus);
+    } catch (error) {
+      this.abortPromotion(local, error);
+    }
   }
 
   private async provideFailoverSecret(): Promise<ArrayBuffer> {
@@ -209,11 +216,12 @@ export class EngineClient implements EngineTransport {
     return source.provideSecret();
   }
 
-  private abortPromotion(local: LocalTransport, error: unknown): void {
-    // Never advertise a dead leader: tear down the half-built worker, release
+  private abortPromotion(local: LocalTransport | null, error: unknown): void {
+    // Never advertise a dead leader: tear down any half-built worker, release
     // the lock so a healthy tab is elected, and fall back to a follower that
-    // mirrors the next leader.
-    local.close();
+    // mirrors the next leader. `local` is null when the throw beat transport
+    // construction — there is nothing to tear down, only the lock to release.
+    local?.close();
     if (this.role !== 'closed') {
       this.role = 'follower';
       this.installFollower();

--- a/packages/client/src/engineClient.ts
+++ b/packages/client/src/engineClient.ts
@@ -67,9 +67,9 @@ export class EngineClient implements EngineTransport {
   private readonly election: LeaderElection;
 
   private role: EngineClientRole = 'follower';
-  private current: EngineTransport;
+  private current!: EngineTransport;
   private relay: LeaderRelay | null = null;
-  private innerUnsub: () => void;
+  private innerUnsub!: () => void;
   private readonly listeners = new Set<EngineEventListener>();
 
   // The vault is active (user logged in). A follower promoted while active must
@@ -81,9 +81,7 @@ export class EngineClient implements EngineTransport {
     this.clientId = config.clientId ?? newClientId();
     this.channel = (config.createChannel ?? defaultChannel)();
 
-    const follower = new BroadcastTransport(this.channel, this.clientId);
-    this.current = follower;
-    this.innerUnsub = follower.subscribe((event) => this.fanOut(event));
+    this.installFollower();
 
     this.election = new LeaderElection(
       config.locks,
@@ -103,6 +101,12 @@ export class EngineClient implements EngineTransport {
 
   start(secret: ArrayBuffer): Promise<void> {
     if (this.role === 'closed') return Promise.reject(new Error('engine client closed'));
+    // This seam is the secret's terminal owner (security rule 7). On the leader
+    // path the worker becomes the terminal owner — `LocalTransport.start`
+    // transfers the buffer in (neutered), never copied. On the follower path the
+    // keyless transport gets no secret: we scrub the buffer we decided not to use
+    // right here, rather than in a callee that would be zeroing someone else's.
+    if (this.role !== 'leader') new Uint8Array(secret).fill(0);
     return this.current.start(secret).then(() => {
       this.started = true;
     });
@@ -141,40 +145,81 @@ export class EngineClient implements EngineTransport {
     this.channel.close();
   }
 
+  private installFollower(): BroadcastTransport {
+    const follower = new BroadcastTransport(this.channel, this.clientId);
+    this.current = follower;
+    this.innerUnsub = follower.subscribe((event) => this.fanOut(event));
+    return follower;
+  }
+
   private becomeLeader(): void {
     if (this.role === 'closed') return;
-    const wasActiveFollower = this.started;
-    this.role = 'leader';
+    void this.promote();
+  }
 
-    // Drop the follower transport: any command in flight rejects so the UI
-    // retries it against the new leader rather than losing it silently.
+  /**
+   * Win the lock → become the engine host. The worker is spawned and (on
+   * failover) cold-started with a re-derived secret **before** we advertise
+   * leadership: we do not install the local transport, route commands, or
+   * register the relay until the worker start resolves, so a command in the
+   * promotion window never reaches an uninitialized worker. If startup fails we
+   * release the lock (a healthy tab takes over) and surface via `onError` rather
+   * than holding a dead-leader lock.
+   */
+  private async promote(): Promise<void> {
+    if (this.role === 'closed') return;
+    const wasActiveFollower = this.started;
+
+    // Drop the follower transport now: a command in flight rejects so the UI
+    // retries it against the new leader, and a command issued during the
+    // promotion window hits this closed transport and rejects (never hangs).
     this.innerUnsub();
     this.current.close();
 
     const worker = this.config.spawnWorker();
     const local = new LocalTransport(worker);
+
+    if (wasActiveFollower) {
+      try {
+        const secret = await this.provideFailoverSecret();
+        await local.start(secret);
+      } catch (error) {
+        this.abortPromotion(local, error);
+        return;
+      }
+      // `dispose()` may have latched `closed` during the awaited startup.
+      if ((this.role as EngineClientRole) === 'closed') {
+        local.close();
+        return;
+      }
+    }
+
+    // Startup resolved: only now install the transport as active, wire events,
+    // and announce the relay so followers route commands to a live worker.
+    this.role = 'leader';
     this.current = local;
     this.innerUnsub = local.subscribe((event) => this.fanOut(event));
     this.relay = new LeaderRelay(this.channel, local);
     if (this.ownFocus) this.relay.reportLocalFocus(this.clientId, this.ownFocus);
-
-    // A promoted active follower must cold-start the fresh worker with a
-    // re-derived secret; a first-ever leader waits for the UI's explicit start.
-    if (wasActiveFollower) this.coldStartOnFailover(local);
   }
 
-  private coldStartOnFailover(local: LocalTransport): void {
+  private async provideFailoverSecret(): Promise<ArrayBuffer> {
     const source = this.config.secretSource;
-    if (!source) {
-      this.config.onError?.(new Error('failover leader has no SecretSource; engine cannot start'));
-      return;
+    if (!source) throw new Error('failover leader has no SecretSource; engine cannot start');
+    return source.provideSecret();
+  }
+
+  private abortPromotion(local: LocalTransport, error: unknown): void {
+    // Never advertise a dead leader: tear down the half-built worker, release
+    // the lock so a healthy tab is elected, and fall back to a follower that
+    // mirrors the next leader.
+    local.close();
+    if (this.role !== 'closed') {
+      this.role = 'follower';
+      this.installFollower();
+      void this.election.close();
     }
-    void source
-      .provideSecret()
-      .then((secret) => local.start(secret))
-      .catch((error: unknown) => {
-        this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
-      });
+    this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
   }
 
   private fanOut(event: Parameters<EngineEventListener>[0]): void {

--- a/packages/client/src/engineClient.ts
+++ b/packages/client/src/engineClient.ts
@@ -18,6 +18,7 @@
 
 import { BROADCAST_CHANNEL_NAME, newClientId, type BroadcastChannelLike } from './broadcast.js';
 import { BroadcastTransport } from './broadcastTransport.js';
+import { fanOut } from './correlatedTransport.js';
 import { EngineFacade } from './facade.js';
 import { LeaderRelay } from './leaderRelay.js';
 import { LeaderElection, type LockManagerLike } from './leadership.js';
@@ -177,13 +178,7 @@ export class EngineClient implements EngineTransport {
   }
 
   private fanOut(event: Parameters<EngineEventListener>[0]): void {
-    for (const listener of this.listeners) {
-      try {
-        listener(event);
-      } catch {
-        // One throwing subscriber must not drop the event for the rest.
-      }
-    }
+    fanOut(this.listeners, event);
   }
 }
 

--- a/packages/client/src/engineClient.ts
+++ b/packages/client/src/engineClient.ts
@@ -1,0 +1,192 @@
+/**
+ * The transport-swapping engine client (blueprint/web-client.md "The facade is
+ * transport-agnostic"). One typed async facade over the origin's single engine,
+ * regardless of whether *this* tab is the leader hosting the worker or a
+ * follower mirroring it. Leadership changes swap the transport underneath the
+ * facade without the UI noticing.
+ *
+ * - **Leader**: holds the `cipherbox-engine` Web Lock, spawns the engine worker,
+ *   drives it over `LocalTransport`, and relays for followers.
+ * - **Follower**: holds no worker and no keys; drives the leader over
+ *   `BroadcastTransport`.
+ * - **Failover**: the lock releases → this tab may win it, spawn a fresh worker,
+ *   re-derive its keys from the `SecretSource`, and rehydrate from the durable
+ *   origin-shared seams. Commands in flight at the swap reject (never hang), so
+ *   the UI retries them — and because the engine journals an op before acking
+ *   it, an accepted op survives the handoff.
+ */
+
+import { BROADCAST_CHANNEL_NAME, newClientId, type BroadcastChannelLike } from './broadcast.js';
+import { BroadcastTransport } from './broadcastTransport.js';
+import { EngineFacade } from './facade.js';
+import { LeaderRelay } from './leaderRelay.js';
+import { LeaderElection, type LockManagerLike } from './leadership.js';
+import type { EngineEventListener, EngineTransport, EngineWorkerLike } from './transport.js';
+import { LocalTransport } from './transport.js';
+import type { CommandDescriptor } from './worker/protocol.js';
+
+/**
+ * Re-derives the login secret when this tab is promoted to leader mid-session
+ * (failover). Keys never persist in JS (security rule 1); the UI re-exports the
+ * secret from its auth session (Web3Auth Core Kit restore) on demand. The
+ * returned buffer is transferred into the worker and zeroed — never retained.
+ */
+export interface SecretSource {
+  provideSecret(): Promise<ArrayBuffer>;
+}
+
+export interface EngineClientConfig {
+  /** `navigator.locks` (or a test double). */
+  locks: LockManagerLike;
+  /** Builds the broadcast channel; each tab keeps one for its lifetime. */
+  createChannel?: () => BroadcastChannelLike;
+  /** Spawns and bootstraps the engine worker (leader only). */
+  spawnWorker: () => EngineWorkerLike;
+  /** Re-derives the secret for a failover cold-start. */
+  secretSource?: SecretSource;
+  /** This tab's correlation id; defaults to a random UUID. */
+  clientId?: string;
+  /** Overrides the lock name (tests isolate origins by name). */
+  lockName?: string;
+  /** Surfaces election/failover faults (best-effort; the facade still works). */
+  onError?: (error: Error) => void;
+}
+
+export type EngineClientRole = 'follower' | 'leader' | 'closed';
+
+/**
+ * The object handed to `EngineFacade`: it *is* the transport, delegating to the
+ * live inner transport and re-homing the UI's event subscription across swaps.
+ */
+export class EngineClient implements EngineTransport {
+  readonly facade: EngineFacade;
+
+  private readonly channel: BroadcastChannelLike;
+  private readonly clientId: string;
+  private readonly election: LeaderElection;
+
+  private role: EngineClientRole = 'follower';
+  private current: EngineTransport;
+  private relay: LeaderRelay | null = null;
+  private innerUnsub: () => void;
+  private readonly listeners = new Set<EngineEventListener>();
+
+  // The vault is active (user logged in). A follower promoted while active must
+  // re-derive keys; a never-active tab elected first just awaits `start`.
+  private started = false;
+  private ownFocus: Uint8Array | null = null;
+
+  constructor(private readonly config: EngineClientConfig) {
+    this.clientId = config.clientId ?? newClientId();
+    this.channel = (config.createChannel ?? defaultChannel)();
+
+    const follower = new BroadcastTransport(this.channel, this.clientId);
+    this.current = follower;
+    this.innerUnsub = follower.subscribe((event) => this.fanOut(event));
+
+    this.election = new LeaderElection(
+      config.locks,
+      config.lockName ?? BROADCAST_CHANNEL_NAME,
+      () => this.becomeLeader(),
+      config.onError
+    );
+
+    this.facade = new EngineFacade(this);
+  }
+
+  currentRole(): EngineClientRole {
+    return this.role;
+  }
+
+  // --- EngineTransport ---
+
+  start(secret: ArrayBuffer): Promise<void> {
+    if (this.role === 'closed') return Promise.reject(new Error('engine client closed'));
+    return this.current.start(secret).then(() => {
+      this.started = true;
+    });
+  }
+
+  command(command: CommandDescriptor, transfer: Transferable[]): Promise<void> {
+    return this.current.command(command, transfer);
+  }
+
+  subscribe(listener: EngineEventListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  close(): void {
+    void this.dispose();
+  }
+
+  // --- leadership + swaps ---
+
+  /** Reports this tab's open folder into the origin-wide focus-window union. */
+  reportFocus(node: Uint8Array | null): void {
+    this.ownFocus = node;
+    if (this.role === 'leader') this.relay?.reportLocalFocus(this.clientId, node);
+    else if (this.role === 'follower') (this.current as BroadcastTransport).reportFocus(node);
+  }
+
+  /** Tears this tab out of the engine: closes the transport and releases the lock. */
+  async dispose(): Promise<void> {
+    if (this.role === 'closed') return;
+    this.role = 'closed';
+    this.innerUnsub();
+    this.relay?.close();
+    this.current.close();
+    await this.election.close();
+    this.channel.close();
+  }
+
+  private becomeLeader(): void {
+    if (this.role === 'closed') return;
+    const wasActiveFollower = this.started;
+    this.role = 'leader';
+
+    // Drop the follower transport: any command in flight rejects so the UI
+    // retries it against the new leader rather than losing it silently.
+    this.innerUnsub();
+    this.current.close();
+
+    const worker = this.config.spawnWorker();
+    const local = new LocalTransport(worker);
+    this.current = local;
+    this.innerUnsub = local.subscribe((event) => this.fanOut(event));
+    this.relay = new LeaderRelay(this.channel, local);
+    if (this.ownFocus) this.relay.reportLocalFocus(this.clientId, this.ownFocus);
+
+    // A promoted active follower must cold-start the fresh worker with a
+    // re-derived secret; a first-ever leader waits for the UI's explicit start.
+    if (wasActiveFollower) this.coldStartOnFailover(local);
+  }
+
+  private coldStartOnFailover(local: LocalTransport): void {
+    const source = this.config.secretSource;
+    if (!source) {
+      this.config.onError?.(new Error('failover leader has no SecretSource; engine cannot start'));
+      return;
+    }
+    void source
+      .provideSecret()
+      .then((secret) => local.start(secret))
+      .catch((error: unknown) => {
+        this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
+      });
+  }
+
+  private fanOut(event: Parameters<EngineEventListener>[0]): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch {
+        // One throwing subscriber must not drop the event for the rest.
+      }
+    }
+  }
+}
+
+function defaultChannel(): BroadcastChannelLike {
+  return new BroadcastChannel(BROADCAST_CHANNEL_NAME);
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4,9 +4,9 @@
  *
  * This layer lands every browser seam implementation (IndexedDB, OPFS, and
  * `fetch`), the dedicated engine worker that hosts the WASM engine over those
- * seams, the promise-correlated RPC layer, and the single typed async facade
- * behind a transport seam. This slice ships the local (single-tab) transport;
- * tab leadership and the broadcast transport land next (#640).
+ * seams, the promise-correlated RPC layer, the single typed async facade behind
+ * a transport seam, and tab leadership with the leader/follower broadcast
+ * transports and failover (#640).
  */
 export const CLIENT_PACKAGE = '@cipherbox/client';
 
@@ -16,6 +16,17 @@ export const CLIENT_PACKAGE = '@cipherbox/client';
 export { EngineFacade } from './facade.js';
 export { LocalTransport } from './transport.js';
 export type { EngineTransport, EngineWorkerLike, EngineEventListener } from './transport.js';
+
+// Tab leadership, the broadcast transport, and the transport-swapping client:
+// one facade per tab, leader or follower, over the origin's single engine.
+export { EngineClient } from './engineClient.js';
+export type { EngineClientConfig, EngineClientRole, SecretSource } from './engineClient.js';
+export { LeaderElection } from './leadership.js';
+export type { LockManagerLike, LockGrant, ElectionRole } from './leadership.js';
+export { BroadcastTransport } from './broadcastTransport.js';
+export { LeaderRelay, FocusRegistry } from './leaderRelay.js';
+export { BROADCAST_CHANNEL_NAME, newClientId } from './broadcast.js';
+export type { BroadcastChannelLike } from './broadcast.js';
 
 // The wire descriptors the UI exchanges with the engine over the transport.
 export type {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -24,7 +24,7 @@ export type { EngineClientConfig, EngineClientRole, SecretSource } from './engin
 export { LeaderElection } from './leadership.js';
 export type { LockManagerLike, LockGrant, ElectionRole } from './leadership.js';
 export { BroadcastTransport } from './broadcastTransport.js';
-export { LeaderRelay, FocusRegistry } from './leaderRelay.js';
+export { LeaderRelay } from './leaderRelay.js';
 export { BROADCAST_CHANNEL_NAME, newClientId } from './broadcast.js';
 export type { BroadcastChannelLike } from './broadcast.js';
 

--- a/packages/client/src/leaderRelay.ts
+++ b/packages/client/src/leaderRelay.ts
@@ -65,6 +65,10 @@ export class LeaderRelay {
   private readonly focus = new FocusRegistry();
   private readonly unsubscribe: () => void;
   private closed = false;
+  // An unguessable per-leadership capability. It stamps every leader→follower
+  // message so followers reject forged acks/events from a non-leader same-origin
+  // context (integrity defense-in-depth; same-origin is the trust boundary).
+  private readonly token = globalThis.crypto.randomUUID();
   private readonly onMessage = (event: MessageEvent): void => this.receive(event.data);
 
   constructor(
@@ -73,10 +77,10 @@ export class LeaderRelay {
   ) {
     this.channel.addEventListener('message', this.onMessage);
     this.unsubscribe = this.transport.subscribe((event) => {
-      this.post({ type: 'cb:event', event });
+      this.post({ type: 'cb:event', token: this.token, event });
     });
     // Announce leadership so followers (existing or newly-elected-away) reconnect.
-    this.post({ type: 'cb:leader' });
+    this.post({ type: 'cb:leader', token: this.token });
   }
 
   /** Folds the leader tab's own open folder into the focus-window union. */
@@ -87,6 +91,11 @@ export class LeaderRelay {
 
   close(): void {
     if (this.closed) return;
+    // Announce the graceful step-down before latching closed so followers re-arm
+    // their readiness gate and reject in-flight work instead of hanging on a
+    // leader that is gone. A crashed leader can't send this; the next leader's
+    // fresh token covers that path.
+    this.post({ type: 'cb:leaderGone', token: this.token });
     this.closed = true;
     this.unsubscribe();
     this.channel.removeEventListener('message', this.onMessage);
@@ -96,7 +105,7 @@ export class LeaderRelay {
     if (this.closed) return;
     switch (message.type) {
       case 'cb:hello':
-        this.post({ type: 'cb:leader' });
+        this.post({ type: 'cb:leader', token: this.token });
         return;
       case 'cb:command':
         void this.forward(message as Extract<FollowerMessage, { type: 'cb:command' }>);
@@ -119,10 +128,11 @@ export class LeaderRelay {
     try {
       const { command, transfer } = await lowerContent(wire);
       await this.transport.command(command, transfer);
-      this.post({ type: 'cb:response', clientId, requestId, ok: true });
+      this.post({ type: 'cb:response', token: this.token, clientId, requestId, ok: true });
     } catch (error) {
       this.post({
         type: 'cb:response',
+        token: this.token,
         clientId,
         requestId,
         ok: false,

--- a/packages/client/src/leaderRelay.ts
+++ b/packages/client/src/leaderRelay.ts
@@ -25,7 +25,7 @@ import type { EngineTransport } from './transport.js';
  * Tracks each tab's open folder and derives the union — the set of distinct
  * folders any tab has open. Nodes are compared by their bytes (hex-keyed).
  */
-export class FocusRegistry {
+class FocusRegistry {
   private readonly perClient = new Map<string, string | null>();
   private union = new Set<string>();
 

--- a/packages/client/src/leaderRelay.ts
+++ b/packages/client/src/leaderRelay.ts
@@ -1,0 +1,147 @@
+/**
+ * The leader-side broadcast relay (blueprint/web-client.md "Engine hosting and
+ * tab leadership"). The leader owns the single engine worker over its
+ * `LocalTransport`; this relay bridges that worker to follower tabs over the
+ * `BroadcastChannel`:
+ *
+ * - follower command → the leader's worker → correlated response back;
+ * - every engine event → fanned out to all followers in emission order;
+ * - each tab's open folder → the leader's **focus-window union**, so freshness
+ *   follows whichever tab is focused (the RefreshHintSource seam, cross-tab).
+ *
+ * No keys and no plaintext leave the worker: only key-free `EventDescriptor`s
+ * ride the outbound wire, exactly the facade's event surface.
+ */
+
+import {
+  lowerContent,
+  type BroadcastChannelLike,
+  type FollowerMessage,
+  type LeaderMessage,
+} from './broadcast.js';
+import type { EngineTransport } from './transport.js';
+
+/**
+ * Tracks each tab's open folder and derives the union — the set of distinct
+ * folders any tab has open. Nodes are compared by their bytes (hex-keyed).
+ */
+export class FocusRegistry {
+  private readonly perClient = new Map<string, string | null>();
+  private union = new Set<string>();
+
+  /** Records a client's focus; returns whether the union changed. */
+  set(clientId: string, node: Uint8Array | null): boolean {
+    this.perClient.set(clientId, node ? hex(node) : null);
+    return this.recomputeUnion();
+  }
+
+  /** Drops a departed client; returns whether the union changed. */
+  remove(clientId: string): boolean {
+    if (!this.perClient.delete(clientId)) return false;
+    return this.recomputeUnion();
+  }
+
+  /** The current union as a stable, sorted list of hex node ids. */
+  snapshot(): string[] {
+    return [...this.union].sort();
+  }
+
+  private recomputeUnion(): boolean {
+    const next = new Set<string>();
+    for (const node of this.perClient.values()) if (node) next.add(node);
+    if (next.size === this.union.size && [...next].every((n) => this.union.has(n))) return false;
+    this.union = next;
+    return true;
+  }
+}
+
+function hex(bytes: Uint8Array): string {
+  let out = '';
+  for (const byte of bytes) out += byte.toString(16).padStart(2, '0');
+  return out;
+}
+
+export class LeaderRelay {
+  private readonly focus = new FocusRegistry();
+  private readonly unsubscribe: () => void;
+  private closed = false;
+  private readonly onMessage = (event: MessageEvent): void => this.receive(event.data);
+
+  constructor(
+    private readonly channel: BroadcastChannelLike,
+    private readonly transport: EngineTransport
+  ) {
+    this.channel.addEventListener('message', this.onMessage);
+    this.unsubscribe = this.transport.subscribe((event) => {
+      this.post({ type: 'cb:event', event });
+    });
+    // Announce leadership so followers (existing or newly-elected-away) reconnect.
+    this.post({ type: 'cb:leader' });
+  }
+
+  /** Folds the leader tab's own open folder into the focus-window union. */
+  reportLocalFocus(clientId: string, node: Uint8Array | null): void {
+    if (this.closed) return;
+    if (this.focus.set(clientId, node)) this.refreshHint();
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.unsubscribe();
+    this.channel.removeEventListener('message', this.onMessage);
+  }
+
+  private receive(message: FollowerMessage | { type?: string }): void {
+    if (this.closed) return;
+    switch (message.type) {
+      case 'cb:hello':
+        this.post({ type: 'cb:leader' });
+        return;
+      case 'cb:command':
+        void this.forward(message as Extract<FollowerMessage, { type: 'cb:command' }>);
+        return;
+      case 'cb:focus': {
+        const { clientId, node } = message as Extract<FollowerMessage, { type: 'cb:focus' }>;
+        if (this.focus.set(clientId, node)) this.refreshHint();
+        return;
+      }
+      case 'cb:bye': {
+        const { clientId } = message as Extract<FollowerMessage, { type: 'cb:bye' }>;
+        if (this.focus.remove(clientId)) this.refreshHint();
+        return;
+      }
+    }
+  }
+
+  private async forward(message: Extract<FollowerMessage, { type: 'cb:command' }>): Promise<void> {
+    const { clientId, requestId, wire } = message;
+    try {
+      const { command, transfer } = await lowerContent(wire);
+      await this.transport.command(command, transfer);
+      this.post({ type: 'cb:response', clientId, requestId, ok: true });
+    } catch (error) {
+      this.post({
+        type: 'cb:response',
+        clientId,
+        requestId,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * A tab's focus changed the union: forward a manual-refresh hint to the
+   * engine. This is the RefreshHintSource seam (a best-effort accelerator), not
+   * a new command semantic — a dropped hint costs staleness, never correctness.
+   */
+  private refreshHint(): void {
+    void this.transport.command({ kind: 'manualRefresh' }, []).catch(() => undefined);
+  }
+
+  private post(message: LeaderMessage): void {
+    if (this.closed) return;
+    this.channel.postMessage(message);
+  }
+}

--- a/packages/client/src/leadership.test.ts
+++ b/packages/client/src/leadership.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { LeaderElection } from './leadership.js';
+import { FakeLockManager } from './testkit.js';
+
+const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('LeaderElection', () => {
+  it('elects the first requester as leader and queues the rest as followers', async () => {
+    const locks = new FakeLockManager();
+    const acquired: string[] = [];
+    const a = new LeaderElection(locks, 'engine', () => acquired.push('a'));
+    const b = new LeaderElection(locks, 'engine', () => acquired.push('b'));
+    await tick();
+
+    expect(acquired).toEqual(['a']);
+    expect(a.role).toBe('leader');
+    expect(b.role).toBe('follower');
+  });
+
+  it('hands leadership to a queued follower when the leader releases', async () => {
+    const locks = new FakeLockManager();
+    const acquired: string[] = [];
+    const a = new LeaderElection(locks, 'engine', () => acquired.push('a'));
+    const b = new LeaderElection(locks, 'engine', () => acquired.push('b'));
+    await tick();
+    expect(acquired).toEqual(['a']);
+
+    // The leader dies (lock releases) → the follower is elected.
+    await a.close();
+    await tick();
+
+    expect(acquired).toEqual(['a', 'b']);
+    expect(b.role).toBe('leader');
+  });
+
+  it('never runs the acquire callback for a follower cancelled before election', async () => {
+    const locks = new FakeLockManager();
+    const acquired: string[] = [];
+    const a = new LeaderElection(locks, 'engine', () => acquired.push('a'));
+    const b = new LeaderElection(locks, 'engine', () => acquired.push('b'));
+    await tick();
+
+    // Cancel the queued follower, then the leader releases: b must not be elected.
+    await b.close();
+    await a.close();
+    await tick();
+
+    expect(acquired).toEqual(['a']);
+    expect(b.role).toBe('closed');
+  });
+
+  it('enforces a single leader across many tabs at once', async () => {
+    const locks = new FakeLockManager();
+    let liveLeaders = 0;
+    let maxConcurrent = 0;
+    const tabs = Array.from(
+      { length: 5 },
+      () =>
+        new LeaderElection(locks, 'engine', () => {
+          liveLeaders += 1;
+          maxConcurrent = Math.max(maxConcurrent, liveLeaders);
+        })
+    );
+    await tick();
+
+    // Roll leadership down the queue; at no point are two leaders live.
+    for (const tab of tabs) {
+      const leader = tabs.find((t) => t.role === 'leader');
+      if (!leader) break;
+      liveLeaders -= 1;
+      await leader.close();
+      await tick();
+      void tab;
+    }
+
+    expect(maxConcurrent).toBe(1);
+  });
+});

--- a/packages/client/src/leadership.ts
+++ b/packages/client/src/leadership.ts
@@ -1,0 +1,99 @@
+/**
+ * Tab-leadership election over the Web Locks API (blueprint/web-client.md
+ * "Engine hosting and tab leadership"). The invariant is #28 D4: **one engine
+ * writer per origin**. Every tab requests the same exclusive lock
+ * (`cipherbox-engine`); the browser grants it to exactly one holder — the
+ * leader. The rest queue as followers.
+ *
+ * Web Locks auto-release on tab close, crash, or discard, so the release itself
+ * is the failover primitive — no heartbeat, no liveness poll. When the leader's
+ * lock releases (for any reason), the browser hands it to the next queued tab,
+ * which becomes the new leader.
+ */
+
+/** A granted lock handle (the fields we read of a real `Lock`). */
+export interface LockGrant {
+  readonly name: string;
+}
+
+/** The callback a lock request runs while it holds the lock. */
+export type LockRequestCallback = (lock: LockGrant | null) => Promise<unknown>;
+
+/** The subset of `navigator.locks` the election drives (injectable for tests). */
+export interface LockManagerLike {
+  request(
+    name: string,
+    options: { signal?: AbortSignal; mode?: 'exclusive' | 'shared' },
+    callback: LockRequestCallback
+  ): Promise<unknown>;
+}
+
+/** Election lifecycle: a tab is a follower until it acquires the lock. */
+export type ElectionRole = 'follower' | 'leader' | 'closed';
+
+/**
+ * Requests the engine lock once and holds it for the tab's lifetime. `onAcquire`
+ * fires when this tab becomes the leader; the lock is then held until `close()`
+ * relinquishes it (logout) or the tab dies (the browser releases it), at which
+ * point some other tab's queued request wins.
+ */
+export class LeaderElection {
+  private state: ElectionRole = 'follower';
+  private releaseHeld: (() => void) | null = null;
+  private readonly controller = new AbortController();
+  private readonly settled: Promise<unknown>;
+
+  constructor(
+    private readonly locks: LockManagerLike,
+    private readonly lockName: string,
+    private readonly onAcquire: () => void,
+    private readonly onError?: (error: Error) => void
+  ) {
+    this.settled = this.elect();
+  }
+
+  get role(): ElectionRole {
+    return this.state;
+  }
+
+  private elect(): Promise<unknown> {
+    return this.locks
+      .request(this.lockName, { signal: this.controller.signal, mode: 'exclusive' }, () => {
+        // Acquired. If close() already ran while we were queued, drop it
+        // immediately so a live follower can take the lock instead.
+        if (this.state === 'closed') return Promise.resolve();
+        this.state = 'leader';
+        this.onAcquire();
+        // Hold the lock until close() resolves this. Returning a pending promise
+        // keeps the Web Lock held; resolving it releases the lock cleanly.
+        return new Promise<void>((resolve) => {
+          this.releaseHeld = resolve;
+        });
+      })
+      .catch((error: unknown) => {
+        // Aborting a still-queued follower request is the normal close path, not
+        // a failure to report.
+        if (this.controller.signal.aborted) return;
+        this.onError?.(error instanceof Error ? error : new Error(String(error)));
+      });
+  }
+
+  /**
+   * Relinquishes leadership (or cancels a queued follower request). Returns when
+   * the underlying lock request has fully settled, so the caller can sequence a
+   * clean handoff.
+   */
+  async close(): Promise<void> {
+    if (this.state === 'closed') return;
+    this.state = 'closed';
+    if (this.releaseHeld) {
+      // We hold the lock: release it so the next queued tab is elected.
+      this.releaseHeld();
+      this.releaseHeld = null;
+    } else {
+      // Still queued: abort the pending request.
+      this.controller.abort();
+    }
+    await this.settled.catch(() => undefined);
+  }
+}

--- a/packages/client/src/leadership.ts
+++ b/packages/client/src/leadership.ts
@@ -23,7 +23,7 @@ export type LockRequestCallback = (lock: LockGrant | null) => Promise<unknown>;
 export interface LockManagerLike {
   request(
     name: string,
-    options: { signal?: AbortSignal; mode?: 'exclusive' | 'shared' },
+    options: { signal?: AbortSignal; mode?: 'exclusive' },
     callback: LockRequestCallback
   ): Promise<unknown>;
 }

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -1,0 +1,190 @@
+/**
+ * Test doubles for the leadership/broadcast unit suite. Excluded from the build
+ * (tsconfig.build.json). These model the *behaviors* the real browser APIs give
+ * us — an origin-exclusive lock and a same-origin broadcast bus that never
+ * echoes to the sender — so unit tests can drive election, relaying, and
+ * failover deterministically. The real-API coverage lives in the browser suite.
+ */
+
+import type { BroadcastChannelLike } from './broadcast.js';
+import type { LockManagerLike, LockRequestCallback } from './leadership.js';
+import type { EngineEventListener, EngineTransport, EngineWorkerLike } from './transport.js';
+import type { CommandDescriptor, EventDescriptor, WorkerMessage } from './worker/protocol.js';
+
+/** A same-origin broadcast bus: a posted message reaches every *other* channel. */
+export class FakeBus {
+  private readonly channels = new Set<FakeChannel>();
+
+  channel(): FakeChannel {
+    const channel = new FakeChannel(this, (c) => this.channels.delete(c));
+    this.channels.add(channel);
+    return channel;
+  }
+
+  deliver(from: FakeChannel, message: unknown): void {
+    // Structured-clone semantics: the sender never receives its own post.
+    for (const channel of this.channels) if (channel !== from) channel.receive(message);
+  }
+}
+
+export class FakeChannel implements BroadcastChannelLike {
+  private readonly listeners = new Set<(event: MessageEvent) => void>();
+  private closed = false;
+
+  constructor(
+    private readonly bus: FakeBus,
+    private readonly onClose: (channel: FakeChannel) => void
+  ) {}
+
+  postMessage(message: unknown): void {
+    if (this.closed) return;
+    // Deliver asynchronously, like a real BroadcastChannel.
+    queueMicrotask(() => this.bus.deliver(this, structuredClone(message)));
+  }
+
+  addEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
+    this.listeners.add(listener);
+  }
+
+  removeEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
+    this.listeners.delete(listener);
+  }
+
+  receive(message: unknown): void {
+    if (this.closed) return;
+    for (const listener of this.listeners) listener({ data: message } as MessageEvent);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.onClose(this);
+  }
+}
+
+interface Held {
+  release: () => void;
+  done: Promise<unknown>;
+}
+
+/** An origin-exclusive lock: at most one holder at a time, FIFO queue behind it. */
+export class FakeLockManager implements LockManagerLike {
+  private held: Held | null = null;
+  private readonly queue: Array<() => void> = [];
+
+  request(
+    name: string,
+    options: { signal?: AbortSignal; mode?: 'exclusive' | 'shared' },
+    callback: LockRequestCallback
+  ): Promise<unknown> {
+    return new Promise<unknown>((resolveRequest, rejectRequest) => {
+      const signal = options.signal;
+      const grant = (): void => {
+        if (signal?.aborted) {
+          rejectRequest(new DOMException('aborted', 'AbortError'));
+          this.next();
+          return;
+        }
+        const done = Promise.resolve(callback({ name }));
+        this.held = { release: () => undefined, done };
+        void done.then(
+          (value) => {
+            this.held = null;
+            resolveRequest(value);
+            this.next();
+          },
+          (error) => {
+            this.held = null;
+            rejectRequest(error);
+            this.next();
+          }
+        );
+      };
+
+      const enqueue = (): void => {
+        this.queue.push(grant);
+        if (!this.held) this.next();
+      };
+
+      if (signal) {
+        signal.addEventListener('abort', () => {
+          const index = this.queue.indexOf(grant);
+          if (index >= 0) {
+            this.queue.splice(index, 1);
+            rejectRequest(new DOMException('aborted', 'AbortError'));
+          }
+        });
+      }
+      enqueue();
+    });
+  }
+
+  private next(): void {
+    if (this.held || this.queue.length === 0) return;
+    const grant = this.queue.shift();
+    grant?.();
+  }
+}
+
+/** A minimal in-process EngineTransport for relay/orchestrator tests. */
+export class FakeEngineTransport implements EngineTransport {
+  readonly commands: CommandDescriptor[] = [];
+  started: ArrayBuffer[] = [];
+  closed = false;
+  respond: (command: CommandDescriptor) => Promise<void> = () => Promise.resolve();
+  private readonly listeners = new Set<EngineEventListener>();
+
+  start(secret: ArrayBuffer): Promise<void> {
+    this.started.push(secret);
+    return Promise.resolve();
+  }
+
+  command(command: CommandDescriptor): Promise<void> {
+    this.commands.push(command);
+    return this.respond(command);
+  }
+
+  subscribe(listener: EngineEventListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  emit(event: EventDescriptor): void {
+    for (const listener of this.listeners) listener(event);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+/** A worker double that immediately reports `ready` and echoes responses. */
+export class FakeEngineWorker implements EngineWorkerLike {
+  readonly posted: unknown[] = [];
+  terminated = false;
+  private messageListeners: Array<(event: MessageEvent<WorkerMessage>) => void> = [];
+
+  postMessage(message: { id?: number }): void {
+    this.posted.push(message);
+    if (typeof message.id === 'number') {
+      queueMicrotask(() => this.emit({ type: 'response', id: message.id!, ok: true }));
+    }
+  }
+
+  addEventListener(type: 'message' | 'error', listener: unknown): void {
+    if (type === 'message')
+      this.messageListeners.push(listener as (e: MessageEvent<WorkerMessage>) => void);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  emit(message: WorkerMessage): void {
+    for (const listener of this.messageListeners)
+      listener({ data: message } as MessageEvent<WorkerMessage>);
+  }
+
+  ready(): void {
+    this.emit({ type: 'ready' });
+  }
+}

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -73,7 +73,7 @@ export class FakeLockManager implements LockManagerLike {
 
   request(
     name: string,
-    options: { signal?: AbortSignal; mode?: 'exclusive' | 'shared' },
+    options: { signal?: AbortSignal; mode?: 'exclusive' },
     callback: LockRequestCallback
   ): Promise<unknown> {
     return new Promise<unknown>((resolveRequest, rejectRequest) => {

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -9,6 +9,7 @@
  * changes when leadership swaps the transport underneath it.
  */
 
+import { CorrelatedTransport } from './correlatedTransport.js';
 import type {
   CommandDescriptor,
   EventDescriptor,
@@ -38,32 +39,21 @@ export interface EngineWorkerLike {
   terminate(): void;
 }
 
-interface Pending {
-  resolve: () => void;
-  reject: (error: Error) => void;
-}
-
 /**
  * UI ↔ own engine worker over `postMessage`. Correlates responses to requests
  * by a monotonic request id, so concurrent calls answered in any order never
  * confuse — the id is assigned here and echoed by the worker, never derived from
  * anything the worker controls.
  */
-export class LocalTransport implements EngineTransport {
-  private readonly pending = new Map<number, Pending>();
-  private readonly listeners = new Set<EngineEventListener>();
+export class LocalTransport extends CorrelatedTransport {
   private readonly ready: Promise<void>;
-  private nextId = 1;
   private closed = false;
-  // A fatal worker message, `error` event, or teardown latches this. Once set,
-  // the worker is dead, so every request rejects here instead of posting and
-  // waiting forever for a response that can never arrive.
-  private terminalError: Error | null = null;
   // Settles `ready` on teardown so a request awaiting cold start before the
   // worker's `ready` rejects instead of hanging forever.
   private rejectReady!: (error: Error) => void;
 
   constructor(private readonly worker: EngineWorkerLike) {
+    super();
     this.ready = new Promise<void>((resolveReady, rejectReady) => {
       this.rejectReady = rejectReady;
       this.worker.addEventListener('message', (event) => {
@@ -72,22 +62,11 @@ export class LocalTransport implements EngineTransport {
           case 'ready':
             resolveReady();
             return;
-          case 'response': {
-            const pending = this.pending.get(message.id);
-            if (!pending) return;
-            this.pending.delete(message.id);
-            if (message.ok) pending.resolve();
-            else pending.reject(new Error(message.error));
+          case 'response':
+            this.settle(message.id, message.ok, message.ok ? undefined : message.error);
             return;
-          }
           case 'event':
-            for (const listener of this.listeners) {
-              try {
-                listener(message.event);
-              } catch {
-                // One throwing subscriber must not drop the event for the rest.
-              }
-            }
+            this.emit(message.event);
             return;
           case 'fatal':
             rejectReady(new Error(message.error));
@@ -106,16 +85,15 @@ export class LocalTransport implements EngineTransport {
   }
 
   start(secret: ArrayBuffer): Promise<void> {
-    return this.request((id) => ({ type: 'start', id, secret }), [secret]);
+    return this.dispatch(this.ready, (id) =>
+      this.worker.postMessage({ type: 'start', id, secret }, [secret])
+    );
   }
 
   command(command: CommandDescriptor, transfer: Transferable[]): Promise<void> {
-    return this.request((id) => ({ type: 'command', id, command }), transfer);
-  }
-
-  subscribe(listener: EngineEventListener): () => void {
-    this.listeners.add(listener);
-    return () => this.listeners.delete(listener);
+    return this.dispatch(this.ready, (id) =>
+      this.worker.postMessage({ type: 'command', id, command }, transfer)
+    );
   }
 
   close(): void {
@@ -127,34 +105,5 @@ export class LocalTransport implements EngineTransport {
     this.rejectReady(error);
     this.fail(error);
     this.worker.terminate();
-  }
-
-  private request(build: (id: number) => WorkerRequest, transfer: Transferable[]): Promise<void> {
-    if (this.terminalError) return Promise.reject(this.terminalError);
-    return this.ready.then(
-      () =>
-        new Promise<void>((resolve, reject) => {
-          if (this.terminalError) {
-            reject(this.terminalError);
-            return;
-          }
-          const id = this.nextId++;
-          this.pending.set(id, { resolve, reject });
-          try {
-            this.worker.postMessage(build(id), transfer);
-          } catch (error) {
-            // A synchronous post failure (detached buffer, bad transferable)
-            // must not strand the pending entry.
-            this.pending.delete(id);
-            reject(error instanceof Error ? error : new Error(String(error)));
-          }
-        })
-    );
-  }
-
-  private fail(error: Error): void {
-    this.terminalError ??= error;
-    for (const pending of this.pending.values()) pending.reject(error);
-    this.pending.clear();
   }
 }

--- a/packages/client/test/browser/index.html
+++ b/packages/client/test/browser/index.html
@@ -7,7 +7,9 @@
   <body>
     <main id="status">Browser seam conformance harness ready.</main>
     <main id="engine-status">Engine worker harness loading…</main>
+    <main id="leadership-status">Tab leadership harness loading…</main>
     <script type="module" src="./harness.ts"></script>
     <script type="module" src="./engineHarness.ts"></script>
+    <script type="module" src="./leadership.ts"></script>
   </body>
 </html>

--- a/packages/client/test/browser/journalEngine.worker.ts
+++ b/packages/client/test/browser/journalEngine.worker.ts
@@ -1,0 +1,63 @@
+/**
+ * A protocol-speaking engine worker (no WASM) for the leadership browser suite.
+ * It stands in for the real engine to exercise leadership, the broadcast relay,
+ * and failover against real Web Locks and a real BroadcastChannel.
+ *
+ * The one behavior that matters for the failover gate: every write command is
+ * **journaled durably to IndexedDB before it is acked** (the doctrine's
+ * ack-after-journal ordering, blueprint/web-client.md "Failover"). Because the
+ * journal is origin-shared, a fresh worker spawned by a promoted follower sees
+ * every op the dead leader had already accepted — no accepted work is lost.
+ */
+import { serveEngine, type WorkerScopeLike } from '../../src/worker/serve.js';
+import type { EngineHostLike } from '../../src/worker/engineHost.js';
+import type { CommandDescriptor, EventDescriptor } from '../../src/worker/protocol.js';
+
+const DB_NAME = 'cb-leadership-journal';
+const STORE = 'ops';
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE, { autoIncrement: true });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error('idb open failed'));
+  });
+}
+
+async function journal(command: CommandDescriptor): Promise<void> {
+  const db = await openDb();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite');
+      tx.objectStore(STORE).add({ kind: command.kind, at: Date.now() });
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error('journal write failed'));
+    });
+  } finally {
+    db.close();
+  }
+}
+
+class JournalHost implements EngineHostLike {
+  start(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async command(command: CommandDescriptor): Promise<void> {
+    // Durable journal BEFORE the ack: the resolved promise is the UI-visible
+    // ack, and it only settles once the op is on disk.
+    if (command.kind !== 'manualRefresh' && command.kind !== 'setFocus') {
+      await journal(command);
+    }
+  }
+
+  nextEvent(): Promise<EventDescriptor | null> {
+    // No engine events in this fake; park the pump forever.
+    return new Promise<EventDescriptor | null>(() => undefined);
+  }
+}
+
+serveEngine(self as unknown as WorkerScopeLike, new JournalHost());

--- a/packages/client/test/browser/leadership.spec.ts
+++ b/packages/client/test/browser/leadership.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+
+/**
+ * The tab-leadership slice of the merge-blocking browser suite
+ * (blueprint/testing.md law 1, blueprint/web-client.md "Engine hosting and tab
+ * leadership"). Two real tabs in one browser context share the origin's real
+ * `navigator.locks` and `BroadcastChannel`. It asserts the D4 invariant — one
+ * engine writer per origin — leader election, kill-the-leader failover with no
+ * accepted-op loss, and that both facade transports (leader-local and
+ * follower-broadcast) reach the single engine worker.
+ */
+
+interface LeadershipHarness {
+  cbCreate(options: { lockName: string; channelName: string }): Promise<void>;
+  cbRole(): string;
+  cbStart(): Promise<string>;
+  cbCreateFile(name: string): Promise<string>;
+  cbDispose(): Promise<void>;
+  cbJournalCount(): Promise<number>;
+  cbHeldLocks(lockName: string): Promise<number>;
+  cbResetJournal(): Promise<void>;
+}
+
+let testSeq = 0;
+
+async function openTab(context: BrowserContext): Promise<Page> {
+  const page = await context.newPage();
+  page.on('pageerror', (error) => console.log(`[browser:pageerror] ${error.message}`));
+  await page.goto('/');
+  await page.waitForFunction(
+    () => typeof (window as unknown as { cbCreate?: unknown }).cbCreate === 'function'
+  );
+  return page;
+}
+
+function harness(page: Page): {
+  create(lockName: string, channelName: string): Promise<void>;
+  role(): Promise<string>;
+  start(): Promise<string>;
+  createFile(name: string): Promise<string>;
+  dispose(): Promise<void>;
+  journalCount(): Promise<number>;
+  heldLocks(lockName: string): Promise<number>;
+  resetJournal(): Promise<void>;
+  waitForRole(role: string): Promise<void>;
+} {
+  return {
+    create: (lockName, channelName) =>
+      page.evaluate((opts) => (window as unknown as LeadershipHarness).cbCreate(opts), {
+        lockName,
+        channelName,
+      }),
+    role: () => page.evaluate(() => (window as unknown as LeadershipHarness).cbRole()),
+    start: () => page.evaluate(() => (window as unknown as LeadershipHarness).cbStart()),
+    createFile: (name) =>
+      page.evaluate((n) => (window as unknown as LeadershipHarness).cbCreateFile(n), name),
+    dispose: () => page.evaluate(() => (window as unknown as LeadershipHarness).cbDispose()),
+    journalCount: () =>
+      page.evaluate(() => (window as unknown as LeadershipHarness).cbJournalCount()),
+    heldLocks: (lockName) =>
+      page.evaluate((n) => (window as unknown as LeadershipHarness).cbHeldLocks(n), lockName),
+    resetJournal: () =>
+      page.evaluate(() => (window as unknown as LeadershipHarness).cbResetJournal()),
+    waitForRole: (role) =>
+      page.waitForFunction(
+        (want) => (window as unknown as LeadershipHarness).cbRole() === want,
+        role,
+        { timeout: 10_000 }
+      ) as unknown as Promise<void>,
+  };
+}
+
+function names(): { lockName: string; channelName: string } {
+  testSeq += 1;
+  return { lockName: `cb-lock-${testSeq}`, channelName: `cb-chan-${testSeq}` };
+}
+
+test.describe('tab leadership over real Web Locks + BroadcastChannel', () => {
+  test('elects exactly one leader; the other tab is a follower (single writer per origin)', async ({
+    context,
+  }) => {
+    const { lockName, channelName } = names();
+    const a = harness(await openTab(context));
+    const b = harness(await openTab(context));
+
+    await a.create(lockName, channelName);
+    await b.create(lockName, channelName);
+
+    const roles = [await a.role(), await b.role()].sort();
+    expect(roles).toEqual(['follower', 'leader']);
+    // The single exclusive lock is held exactly once — one engine writer.
+    expect(await a.heldLocks(lockName)).toBe(1);
+
+    await a.dispose();
+    await b.dispose();
+  });
+
+  test('a follower command reaches the single leader worker (both transports live)', async ({
+    context,
+  }) => {
+    const { lockName, channelName } = names();
+    const a = harness(await openTab(context));
+    const b = harness(await openTab(context));
+    await a.resetJournal();
+
+    await a.create(lockName, channelName);
+    await b.create(lockName, channelName);
+    const leader = (await a.role()) === 'leader' ? a : b;
+    const follower = leader === a ? b : a;
+
+    await leader.start();
+    expect(await follower.start()).toBe('ok');
+
+    // Leader-local transport journals one op.
+    expect(await leader.createFile('from-leader.txt')).toBe('ok');
+    // Follower-broadcast transport routes to the same worker: a second op.
+    expect(await follower.createFile('from-follower.txt')).toBe('ok');
+
+    expect(await leader.journalCount()).toBe(2);
+
+    await a.dispose();
+    await b.dispose();
+  });
+
+  test('kill the leader: a follower is promoted and no accepted op is lost', async ({
+    context,
+  }) => {
+    const { lockName, channelName } = names();
+    const a = harness(await openTab(context));
+    const b = harness(await openTab(context));
+    await a.resetJournal();
+
+    await a.create(lockName, channelName);
+    await b.create(lockName, channelName);
+    const leader = (await a.role()) === 'leader' ? a : b;
+    const follower = leader === a ? b : a;
+
+    await leader.start();
+    await follower.start();
+
+    // The follower issues a command; it is journaled durably before the ack.
+    expect(await follower.createFile('accepted.txt')).toBe('ok');
+    const acceptedCount = await follower.journalCount();
+    expect(acceptedCount).toBeGreaterThanOrEqual(1);
+
+    // Kill the leader — its Web Lock releases and the follower is elected.
+    await leader.dispose();
+    await follower.waitForRole('leader');
+
+    // The accepted op survived the handoff in the origin-shared journal.
+    expect(await follower.journalCount()).toBe(acceptedCount);
+
+    // The new leader now writes through its own fresh worker.
+    expect(await follower.createFile('after-failover.txt')).toBe('ok');
+    expect(await follower.journalCount()).toBe(acceptedCount + 1);
+
+    await follower.dispose();
+  });
+});

--- a/packages/client/test/browser/leadership.spec.ts
+++ b/packages/client/test/browser/leadership.spec.ts
@@ -17,6 +17,7 @@ interface LeadershipHarness {
   cbCreateFile(name: string): Promise<string>;
   cbDispose(): Promise<void>;
   cbJournalCount(): Promise<number>;
+  cbJournalRecords(): Promise<unknown[]>;
   cbHeldLocks(lockName: string): Promise<number>;
   cbResetJournal(): Promise<void>;
 }
@@ -40,6 +41,7 @@ function harness(page: Page): {
   createFile(name: string): Promise<string>;
   dispose(): Promise<void>;
   journalCount(): Promise<number>;
+  journalRecords(): Promise<unknown[]>;
   heldLocks(lockName: string): Promise<number>;
   resetJournal(): Promise<void>;
   waitForRole(role: string): Promise<void>;
@@ -57,6 +59,8 @@ function harness(page: Page): {
     dispose: () => page.evaluate(() => (window as unknown as LeadershipHarness).cbDispose()),
     journalCount: () =>
       page.evaluate(() => (window as unknown as LeadershipHarness).cbJournalCount()),
+    journalRecords: () =>
+      page.evaluate(() => (window as unknown as LeadershipHarness).cbJournalRecords()),
     heldLocks: (lockName) =>
       page.evaluate((n) => (window as unknown as LeadershipHarness).cbHeldLocks(n), lockName),
     resetJournal: () =>
@@ -117,6 +121,18 @@ test.describe('tab leadership over real Web Locks + BroadcastChannel', () => {
     expect(await follower.createFile('from-follower.txt')).toBe('ok');
 
     expect(await leader.journalCount()).toBe(2);
+
+    // No plaintext at rest: the durable journal records only {kind, at} — never
+    // the upload content or any byte-array field the write command carried.
+    const records = await leader.journalRecords();
+    for (const record of records) {
+      const row = record as Record<string, unknown>;
+      expect(Object.keys(row).sort()).toEqual(['at', 'kind']);
+      expect('content' in row).toBe(false);
+      expect(
+        Object.values(row).some((v) => v instanceof Uint8Array || v instanceof ArrayBuffer)
+      ).toBe(false);
+    }
 
     await a.dispose();
     await b.dispose();

--- a/packages/client/test/browser/leadership.ts
+++ b/packages/client/test/browser/leadership.ts
@@ -25,6 +25,7 @@ declare global {
     cbCreateFile(name: string): Promise<string>;
     cbDispose(): Promise<void>;
     cbJournalCount(): Promise<number>;
+    cbJournalRecords(): Promise<unknown[]>;
     cbHeldLocks(lockName: string): Promise<number>;
     cbResetJournal(): Promise<void>;
   }
@@ -102,6 +103,20 @@ window.cbJournalCount = async (): Promise<number> => {
       const count = tx.objectStore(JOURNAL_STORE).count();
       count.onsuccess = () => resolve(count.result);
       count.onerror = () => reject(count.error ?? new Error('journal count failed'));
+    });
+  } finally {
+    db.close();
+  }
+};
+
+window.cbJournalRecords = async (): Promise<unknown[]> => {
+  const db = await openJournal();
+  try {
+    return await new Promise<unknown[]>((resolve, reject) => {
+      const tx = db.transaction(JOURNAL_STORE, 'readonly');
+      const all = tx.objectStore(JOURNAL_STORE).getAll();
+      all.onsuccess = () => resolve(all.result);
+      all.onerror = () => reject(all.error ?? new Error('journal read failed'));
     });
   } finally {
     db.close();

--- a/packages/client/test/browser/leadership.ts
+++ b/packages/client/test/browser/leadership.ts
@@ -1,0 +1,120 @@
+/**
+ * Page harness for the tab-leadership browser suite. Each Playwright page is a
+ * real tab in a shared browser context, so `navigator.locks` and
+ * `BroadcastChannel` are the real origin-wide primitives — no mocks, no jsdom.
+ *
+ * The spec opens two pages, drives one `EngineClient` per page through these
+ * entry points, and asserts election, the single-writer invariant, and
+ * kill-the-leader failover with no accepted-op loss.
+ */
+import { EngineClient } from '../../src/engineClient.js';
+
+const JOURNAL_DB = 'cb-leadership-journal';
+const JOURNAL_STORE = 'ops';
+
+interface HarnessOptions {
+  lockName: string;
+  channelName: string;
+}
+
+declare global {
+  interface Window {
+    cbCreate(options: HarnessOptions): Promise<void>;
+    cbRole(): string;
+    cbStart(): Promise<string>;
+    cbCreateFile(name: string): Promise<string>;
+    cbDispose(): Promise<void>;
+    cbJournalCount(): Promise<number>;
+    cbHeldLocks(lockName: string): Promise<number>;
+    cbResetJournal(): Promise<void>;
+  }
+}
+
+let client: EngineClient | null = null;
+
+const rootNode = new Uint8Array(16);
+
+function settle(error: unknown): string {
+  if (error === undefined) return 'ok';
+  return error instanceof Error ? error.message : String(error);
+}
+
+window.cbCreate = ({ lockName, channelName }: HarnessOptions): Promise<void> => {
+  client = new EngineClient({
+    locks: navigator.locks,
+    lockName,
+    createChannel: () => new BroadcastChannel(channelName),
+    spawnWorker: () =>
+      new Worker(new URL('./journalEngine.worker.ts', import.meta.url), { type: 'module' }),
+    // Failover re-derivation: a real login re-exports this from Core Kit; the
+    // suite only needs a non-key placeholder to drive the cold-start path.
+    secretSource: { provideSecret: () => Promise.resolve(new ArrayBuffer(8)) },
+  });
+  // Let the lock election settle so role() is meaningful to the caller.
+  return new Promise<void>((resolve) => setTimeout(resolve, 50));
+};
+
+window.cbRole = (): string => client?.currentRole() ?? 'none';
+
+window.cbStart = async (): Promise<string> => {
+  try {
+    await client!.facade.start(new ArrayBuffer(8));
+    return 'ok';
+  } catch (error) {
+    return settle(error);
+  }
+};
+
+window.cbCreateFile = async (name: string): Promise<string> => {
+  try {
+    await client!.facade.create(rootNode, name, 'file', new Uint8Array([1, 2, 3]).buffer);
+    return 'ok';
+  } catch (error) {
+    return settle(error);
+  }
+};
+
+window.cbDispose = async (): Promise<void> => {
+  await client?.dispose();
+  client = null;
+};
+
+window.cbHeldLocks = async (lockName: string): Promise<number> => {
+  const state = await navigator.locks.query();
+  return (state.held ?? []).filter((lock) => lock.name === lockName).length;
+};
+
+function openJournal(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(JOURNAL_DB, 1);
+    request.onupgradeneeded = () =>
+      request.result.createObjectStore(JOURNAL_STORE, { autoIncrement: true });
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error('idb open failed'));
+  });
+}
+
+window.cbJournalCount = async (): Promise<number> => {
+  const db = await openJournal();
+  try {
+    return await new Promise<number>((resolve, reject) => {
+      const tx = db.transaction(JOURNAL_STORE, 'readonly');
+      const count = tx.objectStore(JOURNAL_STORE).count();
+      count.onsuccess = () => resolve(count.result);
+      count.onerror = () => reject(count.error ?? new Error('journal count failed'));
+    });
+  } finally {
+    db.close();
+  }
+};
+
+window.cbResetJournal = (): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(JOURNAL_DB);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error ?? new Error('journal delete failed'));
+    request.onblocked = () => resolve();
+  });
+
+const status = document.getElementById('leadership-status');
+if (status) status.textContent = 'Tab leadership harness ready.';

--- a/packages/client/tsconfig.build.json
+++ b/packages/client/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts", "src/testkit.ts"]
 }


### PR DESCRIPTION
## What

Adds **tab leadership, the leader/follower broadcast transport, and leader failover** to `packages/client`, enforcing the D4 invariant: **one engine writer per origin**. Builds on the #639/#728 facade + `LocalTransport` foundation.

## Deliverables

1. **Web Locks election** (`src/leadership.ts`) — every tab requests the exclusive `cipherbox-engine` lock; the holder is the leader and spawns the engine worker. Web Lock auto-release on tab close/crash/discard is the failover primitive (no heartbeat).
2. **BroadcastChannel transport** (`src/broadcastTransport.ts`, `src/leaderRelay.ts`, `src/broadcast.ts`) — followers hold no worker and no keys; they send commands as data and receive projections + the one-way event stream. Upload bytes ride as shared `Blob` handles (no byte copies). The login secret never crosses; only key-free `EventDescriptor`s return.
3. **Transport-swapping facade** (`src/engineClient.ts`) — one facade selects `LocalTransport` on the leader and the broadcast transport on followers, swapping transparently on leadership change. A command in flight at a swap **rejects so the UI retries** (honors the hardened `transport.ts` no-hang contract), never silently dropped.
4. **Failover** — a promoted follower re-derives its secret via the injected `SecretSource`, cold-starts a fresh worker, and rehydrates from the origin-shared durable seams. Ack-after-journal ordering (engine-owned; preserved at the client layer by never synthesizing an ack) means no accepted op is lost.
5. **Cross-tab focus hints** — followers broadcast focus hints (RefreshHintSource seam); the leader unions all tabs' open folders (`FocusRegistry`).

## The gate

Lands the merge-blocking `packages/client` browser suite (`test/browser/leadership.spec.ts`) against **real Web Locks + real BroadcastChannel + real IndexedDB** across two real tabs: (a) election + single-writer invariant, (b) kill-the-leader failover with no accepted-op loss, (c) both facade transports reaching the single worker. Auto-included by the existing `Client Browser Suite` CI job (`testMatch **/*.spec.ts`). Vitest unit suites cover the same behaviors with deterministic doubles (`src/testkit.ts`, excluded from the build).

## Verification

- `pnpm typecheck` clean, `pnpm build` clean (test doubles excluded from `dist`)
- `pnpm test` — 35 vitest tests pass
- `pnpm exec eslint` clean
- `pnpm exec playwright test leadership.spec.ts` — 3/3 pass locally

Closes #640


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-tab engine coordination with automatic leader election and follower command routing.
  * Added seamless failover when the active tab closes, allowing another tab to take over.
  * Preserved engine events and focus updates across connected tabs.
  * Added secure binary content transfer between tabs.
  * Exposed new client, leadership, and broadcast APIs.

* **Bug Fixes**
  * Improved handling of pending commands during leadership changes and transport shutdowns.
  * Added safeguards against stale or forged cross-tab responses and events.

* **Tests**
  * Added comprehensive unit, integration, and browser coverage for leadership, failover, routing, security, and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->