### PR TITLE
fix(api): report retire unpin count from PinStore.unpin result

### DIFF
--- a/apps/api/src/registry/services/registry.service.test.ts
+++ b/apps/api/src/registry/services/registry.service.test.ts
@@ -307,6 +307,36 @@ describe('RegistryService', () => {
       expect(result).toEqual({ retired: 1, unpinned: 0 });
       expect(pins.rows.filter((r) => r.cid === 'bafyUnpinFails')).toHaveLength(0);
     });
+
+    it('does not count a CID whose physical unpin the seam reports as a no-op (returns false)', async () => {
+      const acct = await account();
+      await service.register(acct, [{ ipnsName: 'k51f', contentCids: ['bafyUnpinNoop'] }]);
+
+      // A refcount-zero CID whose unpin is swallowed (Kubo hiccup / unconfigured
+      // store) returns false — the row delete still commits, but the count must
+      // reflect the seam, not assume a release happened (#729).
+      const noopStore = new (class extends FakePinStore {
+        override async unpin(): Promise<boolean> {
+          return false;
+        }
+      })();
+      service = new RegistryService(
+        pins as never,
+        users as never,
+        fakeDataSource([
+          [User, users],
+          [NameInventory, names],
+          [PinnedCid, pins],
+        ]),
+        noopStore,
+        fakeConfig({}).service
+      );
+
+      const result = await service.retire(acct, ['bafyUnpinNoop']);
+
+      expect(result).toEqual({ retired: 1, unpinned: 0 });
+      expect(pins.rows.filter((r) => r.cid === 'bafyUnpinNoop')).toHaveLength(0);
+    });
   });
 
   describe('quota — arithmetic, override, hosted vs BYO advisory', () => {

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -257,8 +257,9 @@ export class RegistryService {
             if (survivors.length > 0) {
               return false;
             }
-            await this.pinStore.unpin(cid);
-            return true;
+            // Count only seam-confirmed releases; a no-op/swallowed unpin (Kubo
+            // hiccup, unconfigured store) returns false and must not be counted.
+            return this.pinStore.unpin(cid);
           }
         );
         if (didUnpin) {


### PR DESCRIPTION
## What

`RegistryService.retire`'s post-commit unpin loop ignored the boolean returned by `PinStore.unpin` (introduced in #707) — it did `await this.pinStore.unpin(cid); return true;`, counting a swallowed/no-op unpin as a successful physical release. A Kubo hiccup or an unconfigured pin store returns `false`, yet `RetireResult.unpinned` was still incremented, so callers/metrics saw a release count higher than what physically happened. This diverged from `AccountService.unpinAfterCommit`, which already respects the boolean.

## Fix

Return the seam boolean directly from the durability-lock recount so `unpinned` counts only seam-confirmed releases — matching `AccountService`. Minimal option from the issue; the DRY extraction was deliberately not taken to avoid over-coupling the account cascade to retire, per the issue's guidance.

## Test

Added a `retire` unit test where `PinStore.unpin` returns `false` for a refcount-zero CID, asserting `RetireResult.unpinned` does not count it (the row delete still commits). The existing throw-path test already covered the throw case.

## Validation

- `pnpm typecheck` (apps/api) — clean
- `pnpm test` (apps/api) — 146 passed
- `eslint` on changed files — clean
- Self-review: /simplify + /security-review manual pass, no findings folded. No crypto surface touched, so /crypto-privacy-review N/A.

Closes #729


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected retirement reporting so no-op unpin operations are not counted as successful unpins.
  * Retired records are still committed and removed correctly when no physical unpin occurs.
* **Tests**
  * Added coverage for retirement behavior when an unpin operation reports no changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->