### PR TITLE
fix(api): stream-bound record-transport body to cap heap

### DIFF
--- a/apps/api/src/republisher/record-transport.test.ts
+++ b/apps/api/src/republisher/record-transport.test.ts
@@ -5,31 +5,54 @@ import { RoutingV1RecordTransport } from './record-transport';
 const MAX_RECORD_BYTES = 64 * 1024;
 
 /**
- * Fake `/routing/v1` response letting each test set the body and the
- * Content-Length header independently, so the absent/lying-header paths are
- * exercised (the header cannot be trusted). `arrayBuffer` is a spy so a test can
- * assert an honestly-declared oversized body is rejected BEFORE it is buffered.
+ * Fake `/routing/v1` response backed by a chunked ReadableStream reader, letting
+ * each test set the body, chunk size, and Content-Length header independently.
+ * The reader is a spy so a test can assert an honestly-declared oversized body is
+ * rejected BEFORE any byte is read, and that an over-cap stream is cancelled
+ * mid-flight rather than buffered whole (the header cannot be trusted).
  */
-function fakeResponse(opts: { status?: number; body?: Buffer; contentLength?: string | null }): {
+function fakeResponse(opts: {
+  status?: number;
+  body?: Buffer;
+  contentLength?: string | null;
+  chunkSize?: number;
+}): {
   response: Response;
-  arrayBuffer: ReturnType<typeof vi.fn>;
+  read: ReturnType<typeof vi.fn>;
+  readerCancel: ReturnType<typeof vi.fn>;
+  bodyCancel: ReturnType<typeof vi.fn>;
 } {
   const body = opts.body ?? Buffer.alloc(0);
   const status = opts.status ?? 200;
+  const chunkSize = opts.chunkSize ?? 16 * 1024;
   const contentLength =
     opts.contentLength === undefined ? String(body.byteLength) : opts.contentLength;
-  const arrayBuffer = vi.fn(async () =>
-    body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength)
-  );
+
+  let offset = 0;
+  const read = vi.fn(async () => {
+    if (offset >= body.byteLength) {
+      return { done: true, value: undefined };
+    }
+    const end = Math.min(offset + chunkSize, body.byteLength);
+    const value = new Uint8Array(body.subarray(offset, end));
+    offset = end;
+    return { done: false, value };
+  });
+  const readerCancel = vi.fn(async () => {});
+  const bodyCancel = vi.fn(async () => {});
+
   const response = {
     status,
     ok: status >= 200 && status < 300,
     headers: {
       get: (name: string) => (name.toLowerCase() === 'content-length' ? contentLength : null),
     },
-    arrayBuffer,
+    body: {
+      getReader: () => ({ read, cancel: readerCancel }),
+      cancel: bodyCancel,
+    },
   } as unknown as Response;
-  return { response, arrayBuffer };
+  return { response, read, readerCancel, bodyCancel };
 }
 
 function transport(): RoutingV1RecordTransport {
@@ -53,8 +76,19 @@ describe('RoutingV1RecordTransport response-size cap', () => {
     expect(result?.equals(body)).toBe(true);
   });
 
-  it('rejects an honestly-declared oversized body before buffering it', async () => {
-    const { response, arrayBuffer } = fakeResponse({
+  it('returns a small chunked body reassembled from multiple reads', async () => {
+    const body = Buffer.from('signed-ipns-record-bytes');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => fakeResponse({ body, contentLength: null, chunkSize: 4 }).response)
+    );
+
+    const result = await transport().resolve('k51-chunked');
+    expect(result?.equals(body)).toBe(true);
+  });
+
+  it('rejects an honestly-declared oversized body before reading it', async () => {
+    const { response, read, bodyCancel } = fakeResponse({
       body: Buffer.alloc(8),
       contentLength: String(MAX_RECORD_BYTES + 1),
     });
@@ -64,26 +98,70 @@ describe('RoutingV1RecordTransport response-size cap', () => {
     );
 
     await expect(transport().resolve('k51-declared')).rejects.toThrow(/exceeds/);
-    expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(read).not.toHaveBeenCalled();
+    expect(bodyCancel).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects an oversized body whose Content-Length is absent', async () => {
+  it('rejects and cancels an oversized stream whose Content-Length is absent', async () => {
     const body = Buffer.alloc(MAX_RECORD_BYTES + 1, 3);
+    const { response, readerCancel } = fakeResponse({
+      body,
+      contentLength: null,
+      chunkSize: 16 * 1024,
+    });
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => fakeResponse({ body, contentLength: null }).response)
+      vi.fn(async () => response)
     );
 
     await expect(transport().resolve('k51-absent')).rejects.toThrow(/exceeds/);
+    expect(readerCancel).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects an oversized body whose Content-Length lies small', async () => {
+  it('rejects and cancels an oversized stream whose Content-Length lies small', async () => {
     const body = Buffer.alloc(MAX_RECORD_BYTES + 1, 5);
+    const { response, readerCancel } = fakeResponse({
+      body,
+      contentLength: '10',
+      chunkSize: 16 * 1024,
+    });
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => fakeResponse({ body, contentLength: '10' }).response)
+      vi.fn(async () => response)
     );
 
     await expect(transport().resolve('k51-lying')).rejects.toThrow(/exceeds/);
+    expect(readerCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds heap by cancelling mid-stream instead of draining the whole body', async () => {
+    // A GB-scale stream in tiny chunks: the cap must trip ~one chunk past the
+    // ceiling and cancel, never draining every chunk (post-facto buffering would).
+    const oneGiB = 1024 * 1024 * 1024;
+    const chunkSize = 16 * 1024;
+    let served = 0;
+    const read = vi.fn(async () => {
+      if (served >= oneGiB) {
+        return { done: true, value: undefined };
+      }
+      served += chunkSize;
+      return { done: false, value: new Uint8Array(chunkSize) };
+    });
+    const readerCancel = vi.fn(async () => {});
+    const response = {
+      status: 200,
+      ok: true,
+      headers: { get: () => null },
+      body: { getReader: () => ({ read, cancel: readerCancel }), cancel: vi.fn() },
+    } as unknown as Response;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => response)
+    );
+
+    await expect(transport().resolve('k51-flood')).rejects.toThrow(/exceeds/);
+    expect(readerCancel).toHaveBeenCalledTimes(1);
+    // Cap is 64 KiB; one chunk past = 5 reads. Assert we stopped far below the GB.
+    expect(read.mock.calls.length).toBeLessThan(16);
   });
 });

--- a/apps/api/src/republisher/record-transport.ts
+++ b/apps/api/src/republisher/record-transport.ts
@@ -80,22 +80,45 @@ export class RoutingV1RecordTransport extends RecordTransport {
     if (!response.ok) {
       throw new Error(`routing GET ${response.status} for ${ipnsName}`);
     }
-    // Reject an honestly-declared oversized body before buffering it; the
-    // post-buffer assert is the real backstop since Content-Length may be absent
-    // or lie.
+    // Reject an honestly-declared oversized body before reading any of it.
     const declared = response.headers.get('content-length');
     if (declared !== null && Number(declared) > MAX_RECORD_BYTES) {
       // Release the connection instead of leaking an unread body stream.
       await response.body?.cancel();
       throw new Error(`routing GET body ${declared}B exceeds ${MAX_RECORD_BYTES}B for ${ipnsName}`);
     }
-    const body = Buffer.from(await response.arrayBuffer());
-    if (body.byteLength > MAX_RECORD_BYTES) {
-      throw new Error(
-        `routing GET body ${body.byteLength}B exceeds ${MAX_RECORD_BYTES}B for ${ipnsName}`
-      );
+    return this.readCapped(response, ipnsName);
+  }
+
+  /**
+   * Read the body enforcing the cap as bytes arrive, so heap stays bounded to
+   * ~the cap plus one chunk even when Content-Length is absent or lies (#722).
+   * Buffering the whole body first would let a misbehaving routing endpoint spike
+   * heap to GBs before any post-facto assert could reject it.
+   */
+  private async readCapped(response: Response, ipnsName: string): Promise<Buffer> {
+    const reader = response.body?.getReader();
+    if (!reader) {
+      return Buffer.alloc(0);
     }
-    return body;
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value) {
+        continue;
+      }
+      total += value.byteLength;
+      if (total > MAX_RECORD_BYTES) {
+        await reader.cancel();
+        throw new Error(`routing GET body exceeds ${MAX_RECORD_BYTES}B for ${ipnsName}`);
+      }
+      chunks.push(Buffer.from(value));
+    }
+    return Buffer.concat(chunks);
   }
 
   async republish(ipnsName: string, record: Buffer): Promise<void> {


### PR DESCRIPTION
## Summary

Follow-up to the #702 body-size cap on `RoutingV1RecordTransport.resolve()`. The prior cap buffered the entire body with `await response.arrayBuffer()` before a post-buffer `byteLength` assert, so the two bypass paths the code itself named were not heap-bounded:

- chunked / absent `Content-Length` -> pre-check skipped -> full body buffered before rejection
- lying-small `Content-Length` -> pre-check passes -> full body buffered before rejection

The body is now STREAM-bound: `response.body.getReader()` accumulates `byteLength` and, once cumulative size exceeds `MAX_RECORD_BYTES` (64 KiB), cancels the reader and throws (fail-closed). Heap stays bounded to roughly the cap plus one chunk regardless of what `Content-Length` claims. The honestly-declared-oversized pre-check is retained to reject before reading a byte.

## Tests

Rewrote `record-transport.test.ts` to drive a chunked `ReadableStream` reader (the old fake mocked `arrayBuffer`, exercising only post-facto rejection):

- returns an in-bounds body at exactly the ceiling
- returns a small chunked body reassembled from multiple reads
- rejects an honestly-declared oversized body before reading it (reader untouched, connection cancelled)
- rejects and cancels an oversized stream whose `Content-Length` is absent
- rejects and cancels an oversized stream whose `Content-Length` lies small
- bounds heap by cancelling mid-stream on a GB-scale flood instead of draining every chunk

## Validation

- `apps/api` typecheck, eslint (changed files), and full unit suite (147 tests) green.
- Integration/scheduled suites need a live Postgres and are not run in the worktree; no integration test touches record-transport streaming (human-verification note).

## Review

Self-review trio: /simplify (folded: copy chunks via `Buffer.from(value)` to avoid pooled-buffer aliasing) and /security-review (clean; the heap-bounding property is the review's own excluded DoS category, no other findings) run. /crypto-privacy-review N/A - no crypto surface touched.

Closes #722