### PR TITLE
test(wasm): assert boundary ABI and restore getrandom production tripwire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,6 +452,22 @@ jobs:
       - name: WASM facade boundary tests (wasm32-unknown-unknown)
         run: cargo test -p cipherbox-wasm --target wasm32-unknown-unknown
 
+      # getrandom tripwire (#718): core is pure — entropy is injected, never
+      # sourced in-tree (blueprint/core.md "Doctrine"). The global
+      # getrandom_backend cfg in .cargo/config.toml defeats getrandom-0.3's
+      # no-backend compile error, so a getrandom that sneaked into core's
+      # production graph would silently link a live crypto.getRandomValues
+      # backend. Fail closed: core's normal-edge wasm graph must pull no
+      # getrandom (its dev-only proptest RNG is fine). Capture first so a
+      # cargo-tree failure fails the step rather than skipping the check.
+      - name: getrandom stays out of core's production graph (wasm)
+        run: |
+          graph=$(cargo tree -p cipherbox-core --target wasm32-unknown-unknown --edges normal)
+          if echo "$graph" | grep -qi getrandom; then
+            echo "::error::getrandom entered cipherbox-core's production graph — core must source no entropy (blueprint/core.md)."
+            exit 1
+          fi
+
       # The single wasm-bindgen ES module and its generated .d.ts contract must
       # build (blueprint/web-client.md); packages/client hosts and fingerprints
       # it later.

--- a/crates/wasm/tests/boundary.rs
+++ b/crates/wasm/tests/boundary.rs
@@ -11,6 +11,8 @@
 use cipherbox_engine::facade;
 use cipherbox_engine::seams::OpId;
 use cipherbox_wasm::{Command, Event, NodeId, NodeKind, Permission, Staleness};
+use js_sys::{BigInt, Reflect, Uint8Array};
+use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_test::wasm_bindgen_test;
 
 /// getrandom's `wasm_js` backend must reach `crypto.getRandomValues` in the
@@ -27,22 +29,51 @@ fn getrandom_wires_to_crypto_get_random_values() {
 }
 
 /// A `u64` op id (> Number.MAX_SAFE_INTEGER) must survive the boundary as a
-/// `bigint` — the u64/BigInt parity surface.
+/// JS `bigint` — the u64/BigInt parity surface. Read through the generated
+/// `#[wasm_bindgen(getter)]` glue (not the Rust field) so a wasm-bindgen ABI
+/// regression that marshalled it as an f64 `number` — truncating at 2^53 — is
+/// observed, not hidden.
 #[wasm_bindgen_test]
 fn op_id_u64_crosses_as_bigint() {
-    let event = Event::from_facade(facade::Event::DeadLetter {
+    let event: JsValue = Event::from_facade(facade::Event::DeadLetter {
         op_id: OpId(u64::MAX),
-    });
-    assert_eq!(event.kind(), "deadLetter");
-    assert_eq!(event.op_id(), Some(u64::MAX));
+    })
+    .into();
+    let op_id = Reflect::get(&event, &JsValue::from_str("opId")).expect("opId getter is readable");
+
+    assert_eq!(
+        op_id.js_typeof(),
+        JsValue::from_str("bigint"),
+        "opId must cross as a JS bigint, never a number"
+    );
+    // A number (f64) marshalling would round u64::MAX to 2^64; assert the exact
+    // value survived, in JS's own decimal rendering.
+    let decimal = String::from(
+        op_id
+            .unchecked_into::<BigInt>()
+            .to_string(10)
+            .expect("bigint renders in base 10"),
+    );
+    assert_eq!(decimal, u64::MAX.to_string());
 }
 
-/// Binary payloads cross as `Uint8Array` in both directions.
+/// Binary payloads cross as a JS `Uint8Array`. Read the `bytes` getter through
+/// the wasm-bindgen glue and assert the JS-observed type and contents; a
+/// wrong-length constructor returns a `JsError` (surfaced as a JS throw at the
+/// call site).
 #[wasm_bindgen_test]
-fn node_id_bytes_round_trip_and_reject_bad_length() {
+fn node_id_bytes_cross_as_uint8array_and_reject_bad_length() {
     let bytes: Vec<u8> = (0..16).collect();
-    let node = NodeId::from_bytes(&bytes).expect("16 bytes is a valid node id");
-    assert_eq!(node.bytes(), bytes);
+    let node: JsValue = NodeId::from_bytes(&bytes)
+        .expect("16 bytes is a valid node id")
+        .into();
+    let out = Reflect::get(&node, &JsValue::from_str("bytes")).expect("bytes getter is readable");
+
+    assert!(
+        out.is_instance_of::<Uint8Array>(),
+        "node id bytes must cross as a Uint8Array"
+    );
+    assert_eq!(out.unchecked_into::<Uint8Array>().to_vec(), bytes);
     assert!(
         NodeId::from_bytes(&[0u8; 20]).is_err(),
         "a wrong-length node id must throw at the boundary"


### PR DESCRIPTION
Closes #718.

Two hardening items from the #663 retro review.

## 1. Boundary tests assert JS-observed marshalling, not Rust internals

`crates/wasm/tests/boundary.rs` — the `opId` and node-`bytes` tests compared `Option<u64>` / `Vec<u8>` inside Rust and never invoked the `#[wasm_bindgen(getter)]` JS glue, so a wasm-bindgen ABI regression (e.g. `u64` marshalled as an f64 `number`, truncating at 2^53) would still pass green. The docstrings overclaimed.

Both now read the getter through `Reflect::get`, exercising the real ABI:

- `op_id_u64_crosses_as_bigint`: asserts `typeof === "bigint"` and that the full `u64::MAX` value survives (base-10 BigInt string), catching a 2^53 truncation.
- `node_id_bytes_cross_as_uint8array_and_reject_bad_length`: asserts `instanceof Uint8Array` plus contents.

The `getrandom` → `crypto.getRandomValues` wiring test was already genuine and is unchanged.

## 2. Production getrandom tripwire restored (fail-closed CI assertion)

The global `getrandom_backend="wasm_js"` cfg in `.cargo/config.toml` defeats getrandom-0.3's no-backend compile error for production builds, so a getrandom that sneaks into the pure core's production graph would silently link a live RNG instead of failing — defeating core's "entropy is injected, never sourced in-tree" doctrine (blueprint/core.md).

Restored as a fail-closed step in the `core-kats` job: `cipherbox-core`'s normal-edge `wasm32-unknown-unknown` dependency graph must contain no getrandom (its dev-only proptest RNG is unaffected). The graph output is captured first so a `cargo tree` failure fails the step rather than skipping the check.

### Scope note

The issue's literal framing ("getrandom is dev-only; assert the wasm artifact has no getrandom symbol") is overtaken by events: `crates/wasm/src/host.rs` `GetrandomEntropy` now legitimately links getrandom in production (the worker entropy source wiring to `crypto.getRandomValues`), landing after #718 was filed. The enforceable invariant that remains is **core's purity**, so the tripwire is scoped there. An optional extension to the native target was considered and deferred — the acute risk is specific to the wasm cfg.

## Validation

- `cargo fmt --all` clean; `cargo clippy -p cipherbox-wasm --all-targets` (native + wasm target) `-D warnings` clean.
- `cargo test -p cipherbox-wasm --target wasm32-unknown-unknown` — 5 passed. Mutation-checked the bigint value assertion (wrong expected value fails).
- Tripwire query verified both directions locally: passes for core (no getrandom), detects getrandom for wasm (proving fail-closed).
- No TS surface touched (the `.d.ts` boundary contract is unchanged), so packages/client is outside the diff.
- Self-review trio: manual /simplify + /security-review, plus an independent crypto-privacy-reviewer pass (getrandom/RNG tripwire). No critical/high findings. Folded: hardened the CI step against a `cargo tree` failure (fail-open hole) and tightened an overclaiming docstring.