### PR TITLE
feat(engine): add rotateScope read-plane root cut and scope-root re-seal helper

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -74,7 +74,10 @@ pub use net::{
 };
 pub use profile::SyncTimingProfile;
 pub use rotation::{
-    ChildIndexResolver, EagerSet, EnumerationError, ResolveFailure, enumerate_eager_set,
+    ChildIndexResolver, CommittedSet, EagerSet, EnumerationError, PrevEpochSeed, ResealError,
+    ResealSeeds, ResealedScopeRoot, ResolveFailure, RevokeError, RevokedCommittedSet, RotateError,
+    RotateScopePlan, RotationOutcome, RotationTrigger, ScopeRootIdentity, ScopeRootPublishError,
+    ScopeRootPublisher, enumerate_eager_set, reseal_scope_root, revoke_read_grant, rotate_scope,
 };
 pub use seams::{SeamError, SeamResult, SeamSet, SeamTypes};
 pub use sync::{

--- a/crates/engine/src/rotation/mod.rs
+++ b/crates/engine/src/rotation/mod.rs
@@ -1,14 +1,34 @@
 //! Rotation primitives (blueprint/engine.md "Rotation primitives").
 //!
-//! Home of the F-4 read-plane rotation cascade. This slice lands only the
-//! **eager-set enumeration walk** ([`eager_set`]) — the transitive-closure
-//! traversal that names every descendant scope root a rotation must touch.
-//! `rotateScope` (the rotation itself) and `sweep` (the epoch-lag work-list)
-//! are sibling slices of #635 that *consume* this enumeration; neither lands
-//! here.
+//! Home of the F-4 read-plane rotation cascade:
+//!
+//! - [`eager_set`] — the transitive-closure walk that names every descendant
+//!   scope root a revocation rotation must touch (#744).
+//! - [`reseal`] — the shared per-scope-root re-seal helper: assemble one scope
+//!   root's signed grant section at a given epoch/seed, re-wrapping grant blobs
+//!   for exactly the committed set. Consumed by `rotate_scope` (the root cut and,
+//!   once the resolver wiring lands, each eager-set descendant) and by the sweep.
+//! - [`rotate`] — `rotateScope`, the read-plane root cut: mint a fresh override
+//!   seed, re-seal, publish CAS, raise `minReadEpoch`, enqueue the sweep.
+//! - [`trigger`] — the read-revoke / scope-exit / manual trigger surface.
+//!
+//! `sweep` (the epoch-lag work-list) is a sibling slice of #635 that consumes
+//! [`reseal`]; it does not land here. `rotateScopeWrite` (the write-plane name
+//! wave) is a separate primitive, out of this slice's read-plane scope.
 
 pub mod eager_set;
+pub mod reseal;
+pub mod rotate;
+pub mod trigger;
 
 pub use eager_set::{
     ChildIndexResolver, EagerSet, EnumerationError, ResolveFailure, enumerate_eager_set,
 };
+pub use reseal::{
+    CommittedSet, PrevEpochSeed, ResealError, ResealSeeds, ScopeRootIdentity, reseal_scope_root,
+};
+pub use rotate::{
+    ResealedScopeRoot, RotateError, RotateScopePlan, RotationOutcome, ScopeRootPublishError,
+    ScopeRootPublisher, rotate_scope,
+};
+pub use trigger::{RevokeError, RevokedCommittedSet, RotationTrigger, revoke_read_grant};

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -127,6 +127,12 @@ pub enum ResealError {
     /// invariant the adoption gate rejects on resolve, enforced here so a re-seal
     /// never seals a section the gate would refuse (fail-closed symmetry).
     LedgerDivergesFromCommitment,
+    /// The rotator's pseudonym signer is not the owner-committed pseudonym key.
+    /// Detach-signing every structure under an uncommitted key mints a scope root
+    /// the adoption gate always rejects (an unopenable root); the same
+    /// signer-binding invariant the gate checks on resolve, enforced here so a
+    /// re-seal never signs a section the gate would refuse (fail-closed symmetry).
+    SignerNotCommitted,
     /// A grant-ledger entry's recipient encryption key is unusable (malformed or
     /// low-order X25519). A grant can never be wrapped to an unopenable key.
     UnusableRecipientKey,
@@ -142,6 +148,9 @@ impl core::fmt::Display for ResealError {
         match self {
             ResealError::LedgerDivergesFromCommitment => {
                 f.write_str("grant ledger diverges from the owner-signed committed set")
+            }
+            ResealError::SignerNotCommitted => {
+                f.write_str("rotator signer is not the owner-committed pseudonym key")
             }
             ResealError::UnusableRecipientKey => {
                 f.write_str("grant-ledger recipient encryption key is unusable")
@@ -159,6 +168,7 @@ impl ResealError {
     pub fn check(&self) -> &'static str {
         match self {
             ResealError::LedgerDivergesFromCommitment => "ledger-diverges-from-commitment",
+            ResealError::SignerNotCommitted => "signer-not-committed",
             ResealError::UnusableRecipientKey => "unusable-recipient-key",
             ResealError::Entropy(_) => "entropy-error",
             ResealError::WriteBodyEncode(_) => "write-body-encode-failed",
@@ -195,9 +205,22 @@ pub fn reseal_scope_root<E: Entropy>(
     committed: &CommittedSet<'_>,
     carried_history_links: &[SignedSealed],
 ) -> Result<GrantSection, ResealError> {
+    // Fail-closed BEFORE any seal: the rotator's pseudonym signer MUST be the
+    // owner-committed pseudonym key, else every detach-signature is minted under a
+    // key the commitment does not name — an unopenable root the gate always
+    // rejects (encode-side mirror of the gate's signer check). The pseudonym pubkey
+    // is public, so a plain byte compare is correct.
+    if identity.pseudonym_signer.verifying_key().to_bytes()
+        != committed.commitment.owner_pseudonym_pk
+    {
+        return Err(ResealError::SignerNotCommitted);
+    }
+
     // Fail-closed BEFORE any seal: the re-wrap set must equal the owner-signed
     // committed set. This is the revocation-completeness guarantee and the
     // encode-side mirror of the gate's `enforce_committed_ledger` resolve check.
+    // Reseal trusts each entry's `recipient_enc_pk` verbatim from the committed
+    // ledger; the tag<->enc_pk binding is enforced at resolve time (#745).
     enforce_committed_ledger(committed.commitment, committed.grant_ledger)
         .map_err(|_| ResealError::LedgerDivergesFromCommitment)?;
 
@@ -783,6 +806,32 @@ mod tests {
         let mut e = SeededEntropy::new(5);
         let err = reseal_scope_root(&mut e, &id, &s, &cs, &[]).expect_err("diverging ledger");
         assert_eq!(err.check(), "ledger-diverges-from-commitment");
+    }
+
+    #[test]
+    fn signer_not_committed_fails_closed_release_active() {
+        // The rotator's pseudonym signer differs from the owner-committed pseudonym
+        // key. The re-seal rejects it with a runtime `Err` (not a debug_assert) — so
+        // a release build never signs a scope root the gate would reject as
+        // signer-mismatched (an unopenable root). This test is active in release.
+        let fx = Fixture::new();
+        let owner_pub = fx.owner_enc.public();
+        let (commitment, sig, ledger) = fx.committed();
+        let wrong_signer = Ed25519Signer::from_seed([0x99; 32]);
+        let id = ScopeRootIdentity {
+            v: V,
+            scope_id: SCOPE,
+            ipns_name: b"scope-root-name",
+            owner_enc_pub: &owner_pub,
+            parent_node_seed: None,
+            pseudonym_signer: &wrong_signer,
+        };
+        let seed = [0x01; 32];
+        let s = seeds(&seed, 1, None, &fx.write_scope_seed, &fx.pointer_read_key);
+        let cs = committed_set(&commitment, &sig, &ledger);
+        let mut e = SeededEntropy::new(7);
+        let err = reseal_scope_root(&mut e, &id, &s, &cs, &[]).expect_err("signer mismatch");
+        assert_eq!(err.check(), "signer-not-committed");
     }
 
     #[test]

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -243,7 +243,7 @@ pub fn reseal_scope_root<E: Entropy>(
     for entry in committed.grant_ledger {
         let recipient_pub = X25519Public::from_bytes(entry.recipient_enc_pk)
             .ok_or(ResealError::UnusableRecipientKey)?;
-        let write_seed = match entry.permission {
+        let mut write_seed = match entry.permission {
             Permission::Write => Some(*seeds.write_scope_seed),
             Permission::Read => None,
         };
@@ -253,6 +253,9 @@ pub fn reseal_scope_root<E: Entropy>(
             read_epoch,
             *seeds.pointer_read_key,
         );
+        // Terminal-owner cleanup: the payload owns its own zeroizing copy, so wipe
+        // this local write-seed copy before the next iteration.
+        write_seed.zeroize();
         let ephemeral = fill::<32, E>(entropy)?;
         let ctx = ctx_for(identity.v, scope_id, read_epoch, STRUCT_TAG_GRANT_BLOB);
         let sealed = seal_grant_blob(&recipient_pub, &ephemeral, &ctx, &payload);
@@ -720,8 +723,12 @@ mod tests {
         ];
 
         // Revoke: the read-revoke trigger's committed-set cut.
+        let commitment_sig = sign_grant_set(&fx.owner_ecdsa, &commitment)
+            .unwrap()
+            .to_compact();
         let cut = super::super::trigger::revoke_read_grant(
             &commitment,
+            &commitment_sig,
             &ledger,
             &revoked_tag,
             &fx.owner_ecdsa,

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -1,0 +1,850 @@
+//! The shared scope-root re-seal helper (blueprint/engine.md "Rotation
+//! primitives: rotateScope", "sweep"; CONTEXT.md "Grant section").
+//!
+//! [`reseal_scope_root`] is the one primitive that assembles a scope root's
+//! signed [`GrantSection`] — its grant blobs (re-wrapped for the committed set),
+//! owner blob, ascent link, per-epoch history links, and sealed write-body —
+//! each detached-signed by the rotator's writer pseudonym. It is deliberately a
+//! **pure composition** of `crates/core`'s seal primitives: it holds no crypto,
+//! samples no entropy of its own (the injected [`Entropy`] seam supplies every
+//! HPKE ephemeral scalar and every seal nonce), and reads no clock.
+//!
+//! It is parameterised on its [`ResealSeeds`] source so both rotation callers use
+//! the same code:
+//!
+//! - **`rotateScope`** passes a fresh random override seed at a new read epoch
+//!   plus the prior seed for a fresh history link — the read-plane root cut.
+//! - **the sweep** (Slice 3) passes the scope's *existing* override seed at the
+//!   *current* epoch with `prev = None` — a metadata-only catch-up that mints no
+//!   new seed and no new history link (blueprint/engine.md "Sweeps re-seal
+//!   metadata only").
+//!
+//! # Revocation completeness is the point
+//!
+//! A grant blob is re-wrapped for **exactly** the committed set: one blob per
+//! grant-ledger entry, and the ledger MUST equal the owner-signed commitment
+//! (`(tag → permission)`) — enforced fail-closed up front via
+//! [`enforce_committed_ledger`], the same invariant the adoption gate checks on
+//! resolve (encode/decode fail-closed symmetry, AGENTS.md rule 8). A revoked
+//! grantee, having been removed from the commitment and the ledger by the
+//! read-revoke trigger, is therefore **absent** from the re-wrapped blobs — that
+//! absence is the revocation. A write-grantee re-wrapping cannot add or drop a
+//! tag: a divergent ledger is rejected here, never sealed.
+
+use zeroize::Zeroize;
+
+use cipherbox_core::kdf;
+use cipherbox_core::seal::{
+    AadContext, GrantBlobPayload, GrantLedgerEntry, GrantSection, GrantSetCommitment,
+    HistoryLinkPayload, OverrideSeedPayload, Permission, STRUCT_TAG_ASCENT_LINK,
+    STRUCT_TAG_GRANT_BLOB, STRUCT_TAG_HISTORY_LINK, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_WRITE_BODY,
+    SignedAscentLink, SignedGrantBlob, SignedOwnerBlob, SignedSealed, StructureSigInput, WriteBody,
+    encode_write_body, seal, seal_ascent_link, seal_grant_blob, seal_history_link, seal_owner_blob,
+    sign_structure,
+};
+use cipherbox_core::suite::aead;
+use cipherbox_core::suite::ecdsa::SIGNATURE_LEN as ECDSA_SIG_LEN;
+use cipherbox_core::suite::ed25519::Ed25519Signer;
+use cipherbox_core::suite::secret::SECRET_LEN;
+use cipherbox_core::suite::x25519::X25519Public;
+
+use crate::entropy::{Entropy, EntropyError};
+use crate::grants::enforce_committed_ledger;
+
+/// The identity, recipients, and signing capability of one scope root — the
+/// context-that-does-not-change-across-epochs half of a re-seal.
+pub struct ScopeRootIdentity<'a> {
+    /// The envelope format+suite version.
+    pub v: u64,
+    /// The scope-root node id (== scope id; `id` and `scope` in every AAD).
+    pub scope_id: [u8; 16],
+    /// The scope root's opaque `ipnsName` bytes (the commitment's anchor).
+    pub ipns_name: &'a [u8],
+    /// The vault owner's X25519 encryption-subkey public — the owner-blob
+    /// recipient (the owner is an implicit, unrevokable grantee of every scope).
+    pub owner_enc_pub: &'a X25519Public,
+    /// The parent node seed the ascent link derives its keypair from; `None` at
+    /// the vault root, which carries no ascent link.
+    pub parent_node_seed: Option<&'a [u8; SECRET_LEN]>,
+    /// The rotator's writer-pseudonym signer — detached-signs every structure.
+    pub pseudonym_signer: &'a Ed25519Signer,
+}
+
+/// The previous epoch's read seed, sealed into a fresh history link under the
+/// new epoch's structure key (the key-regression ratchet).
+pub struct PrevEpochSeed<'a> {
+    /// The previous epoch's override (read scope) seed.
+    pub seed: &'a [u8; SECRET_LEN],
+    /// The previous epoch it belongs to.
+    pub epoch: u64,
+}
+
+/// The seed source of a re-seal — the axis that distinguishes a rotation cut
+/// (fresh seed, new epoch, `prev = Some`) from a sweep catch-up (existing seed,
+/// current epoch, `prev = None`).
+pub struct ResealSeeds<'a> {
+    /// The scope's read-plane override (read scope) seed sealed into the owner
+    /// blob, ascent link, and every grant blob's `readScopeSeed`.
+    pub override_seed: &'a [u8; SECRET_LEN],
+    /// The read epoch this re-seal publishes at.
+    pub read_epoch: u64,
+    /// The prior epoch's seed for a fresh history link, or `None` when this
+    /// re-seal introduces no new epoch (sweep catch-up).
+    pub prev: Option<PrevEpochSeed<'a>>,
+    /// The write-plane scope seed — unchanged by a read rotation — used to derive
+    /// the write key/seed and sealed into write grants' `writeScopeSeed`.
+    pub write_scope_seed: &'a [u8; SECRET_LEN],
+    /// The write epoch the write-body publishes at (unchanged by a read rotation).
+    pub write_epoch: u64,
+    /// The stable per-scope pointer read key carried in every grant blob.
+    pub pointer_read_key: &'a [u8; SECRET_LEN],
+}
+
+/// The owner-committed grant set plus the write-body content a re-seal carries.
+pub struct CommittedSet<'a> {
+    /// The owner-signed, epoch-free commitment (reused verbatim on a grantee
+    /// rotation; owner-re-signed by the read-revoke trigger before it reaches
+    /// here).
+    pub commitment: &'a GrantSetCommitment,
+    /// The 64-byte compact ECDSA owner signature over `commitment`.
+    pub commitment_sig: &'a [u8; ECDSA_SIG_LEN],
+    /// The authoritative grant ledger — one grant blob is re-wrapped per entry.
+    /// MUST equal `commitment` as a `(tag → permission)` set (enforced closed).
+    pub grant_ledger: &'a [GrantLedgerEntry],
+    /// The opaque write-plane history-link blob (carried through a read rotation).
+    pub write_history_link: &'a [u8],
+    /// The directly-descendant scope roots (the F-4 cascade index, #38 D6).
+    pub direct_child_scope_index: &'a [cipherbox_core::seal::ChildScopeRef],
+}
+
+/// A fail-closed re-seal failure. Every variant leaves nothing published — the
+/// caller ([`rotate_scope`](super::rotate::rotate_scope)) never advances a floor
+/// on any of these.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResealError {
+    /// The grant ledger to re-wrap does not match the owner-signed committed set
+    /// (a write-grantee tried to add, drop, or re-permission a tag). The same
+    /// invariant the adoption gate rejects on resolve, enforced here so a re-seal
+    /// never seals a section the gate would refuse (fail-closed symmetry).
+    LedgerDivergesFromCommitment,
+    /// A grant-ledger entry's recipient encryption key is unusable (malformed or
+    /// low-order X25519). A grant can never be wrapped to an unopenable key.
+    UnusableRecipientKey,
+    /// Entropy acquisition failed; no seal proceeds without fresh randomness.
+    Entropy(EntropyError),
+    /// The write-body could not be encoded (a duplicate ledger tag — the
+    /// release-active guard in `encode_write_body`).
+    WriteBodyEncode(cipherbox_core::error::CodecError),
+}
+
+impl core::fmt::Display for ResealError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ResealError::LedgerDivergesFromCommitment => {
+                f.write_str("grant ledger diverges from the owner-signed committed set")
+            }
+            ResealError::UnusableRecipientKey => {
+                f.write_str("grant-ledger recipient encryption key is unusable")
+            }
+            ResealError::Entropy(e) => write!(f, "entropy error: {e}"),
+            ResealError::WriteBodyEncode(e) => write!(f, "write-body encode failed: {}", e.check()),
+        }
+    }
+}
+
+impl std::error::Error for ResealError {}
+
+impl ResealError {
+    /// A stable, key-material-free classification name (host/log facing).
+    pub fn check(&self) -> &'static str {
+        match self {
+            ResealError::LedgerDivergesFromCommitment => "ledger-diverges-from-commitment",
+            ResealError::UnusableRecipientKey => "unusable-recipient-key",
+            ResealError::Entropy(_) => "entropy-error",
+            ResealError::WriteBodyEncode(_) => "write-body-encode-failed",
+        }
+    }
+}
+
+/// Fill an `N`-byte array from the entropy seam, fail-closed.
+fn fill<const N: usize, E: Entropy>(entropy: &mut E) -> Result<[u8; N], ResealError> {
+    let mut buf = [0u8; N];
+    entropy.fill(&mut buf).map_err(ResealError::Entropy)?;
+    Ok(buf)
+}
+
+/// Assemble one scope root's signed [`GrantSection`] at the epoch and seed the
+/// `seeds` source dictates, re-wrapping grant blobs for exactly the committed
+/// set. Pure composition of core seal primitives; the injected `entropy`
+/// supplies every HPKE ephemeral scalar and seal nonce.
+///
+/// `carried_history_links` are the scope's existing per-epoch history links,
+/// preserved verbatim (their prior-rotator signatures stay valid); when
+/// `seeds.prev` is `Some`, one freshly-minted link (the prior seed under the new
+/// epoch's structure key) is appended.
+///
+/// Fails closed — see [`ResealError`] — before sealing anything on a divergent
+/// ledger or an unusable recipient key, so a partial or unopenable section is
+/// never produced. Terminal-owner rule: this function owns only the transient
+/// seal plaintexts (zeroized by the core seal primitives); every borrowed seed
+/// stays the caller's to zero.
+pub fn reseal_scope_root<E: Entropy>(
+    entropy: &mut E,
+    identity: &ScopeRootIdentity<'_>,
+    seeds: &ResealSeeds<'_>,
+    committed: &CommittedSet<'_>,
+    carried_history_links: &[SignedSealed],
+) -> Result<GrantSection, ResealError> {
+    // Fail-closed BEFORE any seal: the re-wrap set must equal the owner-signed
+    // committed set. This is the revocation-completeness guarantee and the
+    // encode-side mirror of the gate's `enforce_committed_ledger` resolve check.
+    enforce_committed_ledger(committed.commitment, committed.grant_ledger)
+        .map_err(|_| ResealError::LedgerDivergesFromCommitment)?;
+
+    let scope_id = identity.scope_id;
+    let read_epoch = seeds.read_epoch;
+    let signer = identity.pseudonym_signer;
+
+    let sign_over = |struct_tag: u8,
+                     recipient_tag: Option<[u8; SECRET_LEN]>,
+                     bytes: &[u8],
+                     epoch| {
+        let input =
+            StructureSigInput::over_ciphertext(scope_id, epoch, struct_tag, recipient_tag, bytes);
+        sign_structure(signer, &input).to_bytes()
+    };
+
+    // --- Grant blobs: one per committed grantee, sorted by tag for a stable
+    // wire order that leaks no ledger ordering. ---
+    let mut grant_blobs: Vec<SignedGrantBlob> = Vec::with_capacity(committed.grant_ledger.len());
+    for entry in committed.grant_ledger {
+        let recipient_pub = X25519Public::from_bytes(entry.recipient_enc_pk)
+            .ok_or(ResealError::UnusableRecipientKey)?;
+        let write_seed = match entry.permission {
+            Permission::Write => Some(*seeds.write_scope_seed),
+            Permission::Read => None,
+        };
+        let payload = GrantBlobPayload::new(
+            *seeds.override_seed,
+            write_seed,
+            read_epoch,
+            *seeds.pointer_read_key,
+        );
+        let ephemeral = fill::<32, E>(entropy)?;
+        let ctx = ctx_for(identity.v, scope_id, read_epoch, STRUCT_TAG_GRANT_BLOB);
+        let sealed = seal_grant_blob(&recipient_pub, &ephemeral, &ctx, &payload);
+        let signature = sign_over(
+            STRUCT_TAG_GRANT_BLOB,
+            Some(entry.tag),
+            &sealed.ciphertext,
+            read_epoch,
+        );
+        grant_blobs.push(SignedGrantBlob {
+            tag: entry.tag,
+            enc: sealed.enc,
+            ciphertext: sealed.ciphertext,
+            signature,
+            unknown: Vec::new(),
+        });
+    }
+    grant_blobs.sort_by(|a, b| a.tag.cmp(&b.tag));
+
+    // --- Owner blob: the override seed wrapped to the owner. ---
+    let owner_blob = {
+        let payload = OverrideSeedPayload::new(*seeds.override_seed, read_epoch);
+        let ephemeral = fill::<32, E>(entropy)?;
+        let ctx = ctx_for(identity.v, scope_id, read_epoch, STRUCT_TAG_OWNER_BLOB);
+        let sealed = seal_owner_blob(identity.owner_enc_pub, &ephemeral, &ctx, &payload);
+        let signature = sign_over(STRUCT_TAG_OWNER_BLOB, None, &sealed.ciphertext, read_epoch);
+        SignedOwnerBlob {
+            enc: sealed.enc,
+            ciphertext: sealed.ciphertext,
+            signature,
+            unknown: Vec::new(),
+        }
+    };
+
+    // --- Ascent link: the override seed sealed to the parent-derived keypair
+    // (interior scope roots only). ---
+    let ascent_link = match identity.parent_node_seed {
+        Some(parent_node_seed) => {
+            let payload = OverrideSeedPayload::new(*seeds.override_seed, read_epoch);
+            let ephemeral = fill::<32, E>(entropy)?;
+            let ctx = ctx_for(identity.v, scope_id, read_epoch, STRUCT_TAG_ASCENT_LINK);
+            let link = seal_ascent_link(parent_node_seed, &ephemeral, &ctx, &payload);
+            let signature = sign_over(STRUCT_TAG_ASCENT_LINK, None, &link.ciphertext, read_epoch);
+            Some(SignedAscentLink {
+                ascent_public: link.ascent_public,
+                enc: link.enc,
+                ciphertext: link.ciphertext,
+                signature,
+                unknown: Vec::new(),
+            })
+        }
+        None => None,
+    };
+
+    // --- History links: carried verbatim; append one fresh link on a new epoch. ---
+    let mut history_links = carried_history_links.to_vec();
+    if let Some(prev) = &seeds.prev {
+        let structure_key = kdf::structure_key(seeds.override_seed, STRUCT_TAG_HISTORY_LINK);
+        let nonce = fill::<{ aead::NONCE_LEN }, E>(entropy)?;
+        let ctx = ctx_for(identity.v, scope_id, read_epoch, STRUCT_TAG_HISTORY_LINK);
+        let payload = HistoryLinkPayload::new(*prev.seed, prev.epoch);
+        let sealed = seal_history_link(structure_key.as_bytes(), &nonce, &ctx, &payload);
+        let signature = sign_over(STRUCT_TAG_HISTORY_LINK, None, &sealed, read_epoch);
+        history_links.push(SignedSealed {
+            sealed,
+            signature,
+            unknown: Vec::new(),
+        });
+    }
+
+    // --- Write-body: sealed under the write key at the write epoch. ---
+    let write_body = {
+        let wb = WriteBody {
+            grant_ledger: committed.grant_ledger.to_vec(),
+            write_history_link: committed.write_history_link.to_vec(),
+            direct_child_scope_index: committed.direct_child_scope_index.to_vec(),
+            unknown: Vec::new(),
+        };
+        let mut plaintext = encode_write_body(&wb).map_err(ResealError::WriteBodyEncode)?;
+        let write_seed = kdf::write_seed(seeds.write_scope_seed, &scope_id);
+        let write_key = kdf::write_key(write_seed.as_bytes());
+        let nonce = fill::<{ aead::NONCE_LEN }, E>(entropy)?;
+        let ctx = ctx_for(
+            identity.v,
+            scope_id,
+            seeds.write_epoch,
+            STRUCT_TAG_WRITE_BODY,
+        );
+        let sealed = seal(write_key.as_bytes(), &nonce, &ctx, &plaintext);
+        plaintext.zeroize();
+        let signature = sign_over(STRUCT_TAG_WRITE_BODY, None, &sealed, seeds.write_epoch);
+        SignedSealed {
+            sealed,
+            signature,
+            unknown: Vec::new(),
+        }
+    };
+
+    Ok(GrantSection {
+        commitment: committed.commitment.clone(),
+        commitment_sig: *committed.commitment_sig,
+        grant_blobs,
+        owner_blob,
+        ascent_link,
+        history_links,
+        write_body,
+        unknown: Vec::new(),
+    })
+}
+
+/// The AAD context for a scope-root structure: `id == scope == scope_id` (a
+/// scope root's node id is its scope id).
+fn ctx_for(v: u64, scope_id: [u8; 16], epoch: u64, struct_tag: u8) -> AadContext {
+    AadContext {
+        v,
+        id: scope_id,
+        scope: scope_id,
+        epoch,
+        struct_tag,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::secret_util::ct_eq_32;
+    use crate::testkit::SeededEntropy;
+    use cipherbox_core::seal::{
+        GrantSetEntry, encode_grant_section, open_ascent_link, open_grant_blob, open_history_link,
+        open_owner_blob, sign_grant_set, verify_structure,
+    };
+    use cipherbox_core::suite::ecdsa::EcdsaSigner;
+    use cipherbox_core::suite::ed25519::{Ed25519Signature, Ed25519Verifier};
+    use cipherbox_core::suite::x25519::X25519Secret;
+
+    const V: u64 = 2;
+    const SCOPE: [u8; 16] = [0x5c; 16];
+
+    struct Fixture {
+        owner_enc: X25519Secret,
+        pseudonym: Ed25519Signer,
+        owner_ecdsa: EcdsaSigner,
+        parent_node_seed: [u8; 32],
+        write_scope_seed: [u8; 32],
+        pointer_read_key: [u8; 32],
+        read_grantee: X25519Secret,
+        write_grantee: X25519Secret,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            Self {
+                owner_enc: X25519Secret::from_scalar([0x11; 32]),
+                pseudonym: Ed25519Signer::from_seed([0x22; 32]),
+                owner_ecdsa: EcdsaSigner::from_scalar(&[0x33; 32]).unwrap(),
+                parent_node_seed: [0x44; 32],
+                write_scope_seed: [0x55; 32],
+                pointer_read_key: [0x66; 32],
+                read_grantee: X25519Secret::from_scalar([0x77; 32]),
+                write_grantee: X25519Secret::from_scalar([0x88; 32]),
+            }
+        }
+
+        fn read_tag() -> [u8; 32] {
+            [0xa1; 32]
+        }
+        fn write_tag() -> [u8; 32] {
+            [0xb2; 32]
+        }
+
+        /// A commitment + matching ledger for a read grantee and a write grantee.
+        fn committed(
+            &self,
+        ) -> (
+            GrantSetCommitment,
+            [u8; ECDSA_SIG_LEN],
+            Vec<GrantLedgerEntry>,
+        ) {
+            let entries = vec![
+                GrantSetEntry::new(Self::read_tag(), Permission::Read, [0x02; 32]),
+                GrantSetEntry::new(Self::write_tag(), Permission::Write, [0x03; 32]),
+            ];
+            let commitment = GrantSetCommitment {
+                ipns_name: b"scope-root-name".to_vec(),
+                owner_pseudonym_pk: self.pseudonym.verifying_key().to_bytes(),
+                entries,
+                unknown: Vec::new(),
+            };
+            let sig = sign_grant_set(&self.owner_ecdsa, &commitment)
+                .unwrap()
+                .to_compact();
+            let ledger = vec![
+                GrantLedgerEntry::new(
+                    [0x02; 33],
+                    self.read_grantee.public().to_bytes(),
+                    Permission::Read,
+                    Self::read_tag(),
+                ),
+                GrantLedgerEntry::new(
+                    [0x03; 33],
+                    self.write_grantee.public().to_bytes(),
+                    Permission::Write,
+                    Self::write_tag(),
+                ),
+            ];
+            (commitment, sig, ledger)
+        }
+    }
+
+    // `owner_enc_pub` needs a `&X25519Public`; hold it in a local so the borrow
+    // outlives the call. A tiny builder keeps every test terse.
+    fn identity<'a>(
+        fx: &'a Fixture,
+        owner_pub: &'a X25519Public,
+        ipns_name: &'a [u8],
+        parent: Option<&'a [u8; 32]>,
+    ) -> ScopeRootIdentity<'a> {
+        ScopeRootIdentity {
+            v: V,
+            scope_id: SCOPE,
+            ipns_name,
+            owner_enc_pub: owner_pub,
+            parent_node_seed: parent,
+            pseudonym_signer: &fx.pseudonym,
+        }
+    }
+
+    fn seeds<'a>(
+        override_seed: &'a [u8; 32],
+        read_epoch: u64,
+        prev: Option<PrevEpochSeed<'a>>,
+        write_scope_seed: &'a [u8; 32],
+        pointer_read_key: &'a [u8; 32],
+    ) -> ResealSeeds<'a> {
+        ResealSeeds {
+            override_seed,
+            read_epoch,
+            prev,
+            write_scope_seed,
+            write_epoch: 1,
+            pointer_read_key,
+        }
+    }
+
+    fn committed_set<'a>(
+        commitment: &'a GrantSetCommitment,
+        sig: &'a [u8; ECDSA_SIG_LEN],
+        ledger: &'a [GrantLedgerEntry],
+    ) -> CommittedSet<'a> {
+        CommittedSet {
+            commitment,
+            commitment_sig: sig,
+            grant_ledger: ledger,
+            write_history_link: b"",
+            direct_child_scope_index: &[],
+        }
+    }
+
+    fn verifier(fx: &Fixture) -> Ed25519Verifier {
+        fx.pseudonym.verifying_key()
+    }
+
+    fn blob_sig(sig: &[u8; 64]) -> Ed25519Signature {
+        Ed25519Signature::from_bytes(*sig)
+    }
+
+    #[test]
+    fn reseal_round_trips_and_every_structure_is_pseudonym_signed() {
+        let fx = Fixture::new();
+        let owner_pub = fx.owner_enc.public();
+        let (commitment, sig, ledger) = fx.committed();
+        let ipns = b"scope-root-name";
+        let id = identity(&fx, &owner_pub, ipns, Some(&fx.parent_node_seed));
+
+        let override_seed = [0x99; 32];
+        let prev_seed = [0x9a; 32];
+        let s = seeds(
+            &override_seed,
+            5,
+            Some(PrevEpochSeed {
+                seed: &prev_seed,
+                epoch: 4,
+            }),
+            &fx.write_scope_seed,
+            &fx.pointer_read_key,
+        );
+        let cs = committed_set(&commitment, &sig, &ledger);
+
+        let mut e = SeededEntropy::new(1);
+        let section = reseal_scope_root(&mut e, &id, &s, &cs, &[]).expect("reseal");
+
+        let ver = verifier(&fx);
+
+        // Grant blobs: sorted by tag; read grantee opens read seed only, write
+        // grantee opens both — all at the new epoch, all pseudonym-signed.
+        assert_eq!(section.grant_blobs.len(), 2);
+        for gb in &section.grant_blobs {
+            let input = StructureSigInput::over_ciphertext(
+                SCOPE,
+                5,
+                STRUCT_TAG_GRANT_BLOB,
+                Some(gb.tag),
+                &gb.ciphertext,
+            );
+            verify_structure(&ver, &input, &blob_sig(&gb.signature)).expect("grant blob signed");
+        }
+
+        let read_gb = section
+            .grant_blobs
+            .iter()
+            .find(|b| b.tag == Fixture::read_tag())
+            .unwrap();
+        let ctx = ctx_for(V, SCOPE, 5, STRUCT_TAG_GRANT_BLOB);
+        let read_payload =
+            open_grant_blob(&fx.read_grantee, &read_gb.enc, &ctx, &read_gb.ciphertext).unwrap();
+        assert!(ct_eq_32(read_payload.read_scope_seed(), &override_seed));
+        assert!(
+            read_payload.write_scope_seed().is_none(),
+            "read grant, no write seed"
+        );
+        assert_eq!(read_payload.epoch, 5);
+        assert!(ct_eq_32(
+            read_payload.pointer_read_key(),
+            &fx.pointer_read_key
+        ));
+
+        let write_gb = section
+            .grant_blobs
+            .iter()
+            .find(|b| b.tag == Fixture::write_tag())
+            .unwrap();
+        let write_payload =
+            open_grant_blob(&fx.write_grantee, &write_gb.enc, &ctx, &write_gb.ciphertext).unwrap();
+        assert!(ct_eq_32(write_payload.read_scope_seed(), &override_seed));
+        assert!(
+            ct_eq_32(
+                write_payload.write_scope_seed().unwrap(),
+                &fx.write_scope_seed
+            ),
+            "write grant carries the write scope seed"
+        );
+
+        // Owner blob → override seed.
+        let owner_ctx = ctx_for(V, SCOPE, 5, STRUCT_TAG_OWNER_BLOB);
+        let owner_payload = open_owner_blob(
+            &fx.owner_enc,
+            &section.owner_blob.enc,
+            &owner_ctx,
+            &section.owner_blob.ciphertext,
+        )
+        .unwrap();
+        assert!(ct_eq_32(owner_payload.override_seed(), &override_seed));
+
+        // Ascent link → override seed, opened with the parent seed.
+        let ascent = section
+            .ascent_link
+            .as_ref()
+            .expect("interior root has ascent");
+        let ascent_ctx = ctx_for(V, SCOPE, 5, STRUCT_TAG_ASCENT_LINK);
+        let ascent_link = cipherbox_core::seal::AscentLink {
+            ascent_public: ascent.ascent_public,
+            enc: ascent.enc,
+            ciphertext: ascent.ciphertext.clone(),
+            unknown: Vec::new(),
+        };
+        let ascent_payload =
+            open_ascent_link(&fx.parent_node_seed, &ascent_ctx, &ascent_link).unwrap();
+        assert!(ct_eq_32(ascent_payload.override_seed(), &override_seed));
+
+        // History link → prev seed under the new epoch's structure key.
+        assert_eq!(section.history_links.len(), 1);
+        let hl_key = kdf::structure_key(&override_seed, STRUCT_TAG_HISTORY_LINK);
+        let hl_ctx = ctx_for(V, SCOPE, 5, STRUCT_TAG_HISTORY_LINK);
+        let hl = open_history_link(hl_key.as_bytes(), &hl_ctx, &section.history_links[0].sealed)
+            .unwrap();
+        assert!(ct_eq_32(hl.prev_seed(), &prev_seed));
+        assert_eq!(hl.prev_epoch, 4);
+
+        // The whole section encodes (the release-active dup-tag guard passes).
+        encode_grant_section(&section).expect("section encodes");
+    }
+
+    #[test]
+    fn vault_root_omits_ascent_link() {
+        let fx = Fixture::new();
+        let owner_pub = fx.owner_enc.public();
+        let (commitment, sig, ledger) = fx.committed();
+        let id = identity(&fx, &owner_pub, b"root", None);
+        let seed = [0x01; 32];
+        let s = seeds(&seed, 1, None, &fx.write_scope_seed, &fx.pointer_read_key);
+        let cs = committed_set(&commitment, &sig, &ledger);
+        let mut e = SeededEntropy::new(2);
+        let section = reseal_scope_root(&mut e, &id, &s, &cs, &[]).expect("reseal");
+        assert!(
+            section.ascent_link.is_none(),
+            "vault root has no ascent link"
+        );
+        assert!(section.history_links.is_empty(), "no prev, no history link");
+    }
+
+    #[test]
+    fn sweep_seed_source_mints_no_new_history_link() {
+        // prev = None (sweep catch-up): carried links pass through unchanged, no
+        // fresh link, same epoch.
+        let fx = Fixture::new();
+        let owner_pub = fx.owner_enc.public();
+        let (commitment, sig, ledger) = fx.committed();
+        let id = identity(&fx, &owner_pub, b"n", Some(&fx.parent_node_seed));
+        let seed = [0x0e; 32];
+        let s = seeds(&seed, 7, None, &fx.write_scope_seed, &fx.pointer_read_key);
+        let cs = committed_set(&commitment, &sig, &ledger);
+        let carried = vec![SignedSealed {
+            sealed: b"prior-epoch-link".to_vec(),
+            signature: [0x01; 64],
+            unknown: Vec::new(),
+        }];
+        let mut e = SeededEntropy::new(3);
+        let section = reseal_scope_root(&mut e, &id, &s, &cs, &carried).expect("reseal");
+        assert_eq!(
+            section.history_links, carried,
+            "carried links unchanged, none added"
+        );
+    }
+
+    #[test]
+    fn revoked_grantee_is_absent_survivors_present_at_new_epoch() {
+        // The revocation crown jewel: three grantees, revoke the middle one by
+        // removing it from BOTH the commitment and the ledger, re-seal, and prove
+        // the revokee has no blob while survivors decrypt to the fresh seed.
+        let fx = Fixture::new();
+        let owner_pub = fx.owner_enc.public();
+        let revoked = X25519Secret::from_scalar([0xcc; 32]);
+        let revoked_tag = [0xc3; 32];
+
+        let entries = vec![
+            GrantSetEntry::new(Fixture::read_tag(), Permission::Read, [0x02; 32]),
+            GrantSetEntry::new(revoked_tag, Permission::Read, [0x04; 32]),
+            GrantSetEntry::new(Fixture::write_tag(), Permission::Write, [0x03; 32]),
+        ];
+        let commitment = GrantSetCommitment {
+            ipns_name: b"n".to_vec(),
+            owner_pseudonym_pk: fx.pseudonym.verifying_key().to_bytes(),
+            entries,
+            unknown: Vec::new(),
+        };
+        let ledger = vec![
+            GrantLedgerEntry::new(
+                [0x02; 33],
+                fx.read_grantee.public().to_bytes(),
+                Permission::Read,
+                Fixture::read_tag(),
+            ),
+            GrantLedgerEntry::new(
+                [0x04; 33],
+                revoked.public().to_bytes(),
+                Permission::Read,
+                revoked_tag,
+            ),
+            GrantLedgerEntry::new(
+                [0x03; 33],
+                fx.write_grantee.public().to_bytes(),
+                Permission::Write,
+                Fixture::write_tag(),
+            ),
+        ];
+
+        // Revoke: the read-revoke trigger's committed-set cut.
+        let cut = super::super::trigger::revoke_read_grant(
+            &commitment,
+            &ledger,
+            &revoked_tag,
+            &fx.owner_ecdsa,
+        )
+        .expect("revoke");
+        assert!(
+            !cut.grant_ledger.iter().any(|e| e.tag == revoked_tag),
+            "revokee gone from ledger"
+        );
+        assert!(
+            !cut.commitment.entries.iter().any(|e| e.tag == revoked_tag),
+            "revokee gone from commitment"
+        );
+
+        let id = identity(&fx, &owner_pub, b"n", None);
+        let new_seed = [0xef; 32];
+        let s = seeds(
+            &new_seed,
+            2,
+            None,
+            &fx.write_scope_seed,
+            &fx.pointer_read_key,
+        );
+        let cs = CommittedSet {
+            commitment: &cut.commitment,
+            commitment_sig: &cut.commitment_sig,
+            grant_ledger: &cut.grant_ledger,
+            write_history_link: b"",
+            direct_child_scope_index: &[],
+        };
+        let mut e = SeededEntropy::new(4);
+        let section = reseal_scope_root(&mut e, &id, &s, &cs, &[]).expect("reseal");
+
+        // The revokee has NO grant blob.
+        assert!(
+            !section.grant_blobs.iter().any(|b| b.tag == revoked_tag),
+            "revoked party's blob is absent — this is the revocation"
+        );
+        assert_eq!(
+            section.grant_blobs.len(),
+            2,
+            "only survivors are re-wrapped"
+        );
+        // And the revokee cannot open any survivor's blob (fresh seed).
+        let ctx = ctx_for(V, SCOPE, 2, STRUCT_TAG_GRANT_BLOB);
+        for b in &section.grant_blobs {
+            assert!(
+                open_grant_blob(&revoked, &b.enc, &ctx, &b.ciphertext).is_err(),
+                "revokee cannot open a survivor's blob"
+            );
+        }
+        // Survivor opens the fresh seed.
+        let read_gb = section
+            .grant_blobs
+            .iter()
+            .find(|b| b.tag == Fixture::read_tag())
+            .unwrap();
+        let payload =
+            open_grant_blob(&fx.read_grantee, &read_gb.enc, &ctx, &read_gb.ciphertext).unwrap();
+        assert!(ct_eq_32(payload.read_scope_seed(), &new_seed));
+    }
+
+    #[test]
+    fn diverging_ledger_fails_closed_release_active() {
+        // A write-grantee adds a ledger row the owner never committed. The re-seal
+        // rejects it with a runtime `Err` (not a debug_assert) — so a release
+        // build never seals a section the gate would reject. This test is active
+        // in release.
+        let fx = Fixture::new();
+        let owner_pub = fx.owner_enc.public();
+        let (commitment, sig, mut ledger) = fx.committed();
+        ledger.push(GrantLedgerEntry::new(
+            [0x09; 33],
+            X25519Secret::from_scalar([0x0f; 32]).public().to_bytes(),
+            Permission::Write,
+            [0xff; 32], // uncommitted tag
+        ));
+        let id = identity(&fx, &owner_pub, b"n", None);
+        let seed = [0x01; 32];
+        let s = seeds(&seed, 1, None, &fx.write_scope_seed, &fx.pointer_read_key);
+        let cs = committed_set(&commitment, &sig, &ledger);
+        let mut e = SeededEntropy::new(5);
+        let err = reseal_scope_root(&mut e, &id, &s, &cs, &[]).expect_err("diverging ledger");
+        assert_eq!(err.check(), "ledger-diverges-from-commitment");
+    }
+
+    #[test]
+    fn unusable_recipient_key_fails_closed() {
+        // A low-order (all-zero) recipient encryption key cannot receive a grant.
+        let fx = Fixture::new();
+        let owner_pub = fx.owner_enc.public();
+        let commitment = GrantSetCommitment {
+            ipns_name: b"n".to_vec(),
+            owner_pseudonym_pk: fx.pseudonym.verifying_key().to_bytes(),
+            entries: vec![GrantSetEntry::new(
+                Fixture::read_tag(),
+                Permission::Read,
+                [0x02; 32],
+            )],
+            unknown: Vec::new(),
+        };
+        let sig = sign_grant_set(&fx.owner_ecdsa, &commitment)
+            .unwrap()
+            .to_compact();
+        let ledger = vec![GrantLedgerEntry::new(
+            [0x02; 33],
+            [0u8; 32], // low-order X25519 → from_bytes rejects
+            Permission::Read,
+            Fixture::read_tag(),
+        )];
+        let id = identity(&fx, &owner_pub, b"n", None);
+        let seed = [0x01; 32];
+        let s = seeds(&seed, 1, None, &fx.write_scope_seed, &fx.pointer_read_key);
+        let cs = committed_set(&commitment, &sig, &ledger);
+        let mut e = SeededEntropy::new(6);
+        let err = reseal_scope_root(&mut e, &id, &s, &cs, &[]).expect_err("bad key");
+        assert_eq!(err.check(), "unusable-recipient-key");
+    }
+
+    #[test]
+    fn determinism_same_entropy_same_bytes() {
+        let fx = Fixture::new();
+        let owner_pub = fx.owner_enc.public();
+        let (commitment, sig, ledger) = fx.committed();
+        let id = identity(&fx, &owner_pub, b"n", Some(&fx.parent_node_seed));
+        let seed = [0x01; 32];
+        let prev = [0x02; 32];
+        let build = || {
+            let s = seeds(
+                &seed,
+                3,
+                Some(PrevEpochSeed {
+                    seed: &prev,
+                    epoch: 2,
+                }),
+                &fx.write_scope_seed,
+                &fx.pointer_read_key,
+            );
+            let cs = committed_set(&commitment, &sig, &ledger);
+            let mut e = SeededEntropy::new(42);
+            encode_grant_section(&reseal_scope_root(&mut e, &id, &s, &cs, &[]).unwrap()).unwrap()
+        };
+        assert_eq!(
+            build(),
+            build(),
+            "same entropy seed → byte-identical section"
+        );
+    }
+}

--- a/crates/engine/src/rotation/rotate.rs
+++ b/crates/engine/src/rotation/rotate.rs
@@ -266,6 +266,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::seams::SeamResult;
     use crate::testkit::fakes::{InMemoryFloorStore, VirtualScheduler};
     use crate::testkit::{SeededEntropy, block_on};
     use cipherbox_core::seal::{
@@ -299,6 +300,26 @@ mod tests {
             *self.floor_at_publish.borrow_mut() = Some(floor);
             self.seen.borrow_mut().push(record.clone());
             self.result.clone()
+        }
+    }
+
+    /// A floor store whose epoch-floor raise always fails — drives the documented
+    /// crash window (publish landed, floor raise failed). The other methods stay
+    /// benign so it can also back the publisher's snapshot if needed.
+    struct FailingFloorStore;
+
+    impl FloorStore for FailingFloorStore {
+        async fn epoch_floor(&self, _scope_id: &[u8]) -> SeamResult<Option<u64>> {
+            Ok(None)
+        }
+        async fn raise_epoch_floor(&self, _scope_id: &[u8], _epoch: u64) -> SeamResult<u64> {
+            Err(SeamError::new("floor raise failed"))
+        }
+        async fn sequence_floor(&self, _ipns_name: &[u8]) -> SeamResult<Option<u64>> {
+            Ok(None)
+        }
+        async fn raise_sequence_floor(&self, _ipns_name: &[u8], _sequence: u64) -> SeamResult<u64> {
+            Err(SeamError::new("floor raise failed"))
         }
     }
 
@@ -524,6 +545,69 @@ mod tests {
         assert!(
             !ct_eq_32(payload.override_seed(), &current_seed),
             "rotation minted a fresh seed, not the current one"
+        );
+    }
+
+    #[test]
+    fn floor_raise_failure_after_publish_returns_floor_error_and_skips_sweep() {
+        // The documented crash window: publish lands, the floor raise fails. The
+        // record WAS published (old records still gate-pass — no lockout), the error
+        // is RotateError::Floor, and the sweep is NOT enqueued (spawn count == 0).
+        let fx = Fixture::new();
+        let owner_pub = fx.owner_enc.public();
+        let (commitment, sig, ledger) = fx.committed();
+        let floors = FailingFloorStore;
+        let scheduler = VirtualScheduler::new();
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let publisher = FakePublisher {
+            result: Ok(()),
+            seen: Rc::clone(&seen),
+            floor_at_publish: Rc::new(RefCell::new(None)),
+            floors: InMemoryFloorStore::default(),
+        };
+        let current_seed = [0xaa; 32];
+
+        let outcome = block_on(async {
+            let mut entropy = SeededEntropy::new(9);
+            let plan = RotateScopePlan {
+                identity: ScopeRootIdentity {
+                    v: 2,
+                    scope_id: SCOPE,
+                    ipns_name: b"scope-root",
+                    owner_enc_pub: &owner_pub,
+                    parent_node_seed: None,
+                    pseudonym_signer: &fx.pseudonym,
+                },
+                committed: CommittedSet {
+                    commitment: &commitment,
+                    commitment_sig: &sig,
+                    grant_ledger: &ledger,
+                    write_history_link: b"",
+                    direct_child_scope_index: &[],
+                },
+                current_override_seed: &current_seed,
+                current_read_epoch: 4,
+                write_scope_seed: &fx.write_scope_seed,
+                write_epoch: 3,
+                pointer_read_key: &fx.pointer_read_key,
+                carried_history_links: &[],
+            };
+            rotate_scope(&mut entropy, &floors, &scheduler, &publisher, &plan, || {
+                Box::pin(async {})
+            })
+            .await
+        });
+
+        assert_eq!(outcome.unwrap_err().check(), "floor-raise-failed");
+        assert_eq!(
+            seen.borrow().len(),
+            1,
+            "record WAS published before the floor raise"
+        );
+        assert_eq!(
+            scheduler.take_spawned_tasks().len(),
+            0,
+            "no sweep enqueued when the floor raise fails after publish"
         );
     }
 }

--- a/crates/engine/src/rotation/rotate.rs
+++ b/crates/engine/src/rotation/rotate.rs
@@ -1,0 +1,529 @@
+//! `rotateScope` — the read-plane root cut (blueprint/engine.md "Rotation
+//! primitives: rotateScope", #26 D2/D8, #38 D4/D5).
+//!
+//! The read-plane rotation: mint a fresh random override seed at the scope root
+//! (via the injected entropy seam — never a direct RNG), re-seal the scope root's
+//! [`GrantSection`](cipherbox_core::seal::GrantSection) at the next read epoch
+//! through the shared [`reseal_scope_root`] helper, publish it CAS through the
+//! injected [`ScopeRootPublisher`] seam, raise the durable `minReadEpoch` floor,
+//! and enqueue the lazy-wave sweep. **Read-plane only**: `minReadEpoch` moves,
+//! `writeEpoch` does not — the write-plane name wave (`rotateScopeWrite`) is a
+//! separate primitive.
+//!
+//! # Effect ordering is crash-safety
+//!
+//! The three durable effects run in a fixed order — **publish → raise floor →
+//! enqueue sweep** — and a failure at any step returns before the next runs, so
+//! no partially-rotated, fail-open, or locked-out state is ever left behind:
+//!
+//! - Publishing the new-epoch record **before** raising the floor means a crash
+//!   between them leaves the old-epoch records still gate-passing (the floor has
+//!   not moved) rather than demanding an epoch no published record satisfies — a
+//!   lockout. The rotation simply re-runs; it is monotonic (a fresh seed, a
+//!   higher epoch) and idempotent-safe under CAS. Raising the floor first would
+//!   invert this into the lockout the two-phase-adopt lesson warns against.
+//! - The residual window this ordering accepts — a revoked reader whose old-epoch
+//!   forgeries still pass until the floor rises on the completing run — is exactly
+//!   the documented read-only-survivor residual (#38, "~one pointer-consult
+//!   interval"), never a lost revocation boundary.
+//! - The sweep is enqueued **last**, only after the cut is durable; it is
+//!   best-effort and idempotent, so losing it to a crash costs only a delayed
+//!   lazy wave, which the next ordinary write or scheduled sweep advances anyway.
+//!
+//! The eager-set descendant scope roots (#744's enumeration) are each re-sealed
+//! through this same [`reseal_scope_root`] helper by the cascade orchestration
+//! once the resolver/tree wiring lands (#745/#746); this primitive lands the root
+//! cut and its crash-safe effect ordering.
+
+use zeroize::Zeroizing;
+
+use cipherbox_core::seal::{GrantSection, SignedSealed};
+use cipherbox_core::suite::secret::SECRET_LEN;
+
+use super::reseal::{
+    CommittedSet, PrevEpochSeed, ResealError, ResealSeeds, ScopeRootIdentity, reseal_scope_root,
+};
+use crate::entropy::Entropy;
+use crate::seams::{BoxedTask, FloorStore, Scheduler, SeamError};
+
+/// A fully re-sealed scope-root record handed to the [`ScopeRootPublisher`]: its
+/// identity, the epochs it publishes at, and the signed grant section. Assembling
+/// the envelope bytes (read-body re-seal + IPNS record signing) and moving them
+/// CAS over the content plane + `/routing/v1` transport is the publisher's job —
+/// the network wiring deferred to #745/#746, faked in this slice's tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResealedScopeRoot {
+    /// The scope-root node id (== scope id).
+    pub scope_id: [u8; 16],
+    /// The scope root's opaque `ipnsName` bytes.
+    pub ipns_name: Vec<u8>,
+    /// The read epoch this cut publishes at (bumped).
+    pub read_epoch: u64,
+    /// The write epoch (unchanged by a read rotation).
+    pub write_epoch: u64,
+    /// The freshly re-sealed, structure-signed grant section.
+    pub section: GrantSection,
+}
+
+/// Why a scope-root publish did not durably land as the freshest record. Both
+/// variants mean the rotation must not advance its floor — nothing was cut.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScopeRootPublishError {
+    /// Register-first or the record PUT failed; nothing durable landed. Retryable.
+    NotPublished,
+    /// A concurrent writer's record at a higher sequence won the CAS race; the
+    /// caller re-resolves and rebases before retrying.
+    LostRace,
+}
+
+impl core::fmt::Display for ScopeRootPublishError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ScopeRootPublishError::NotPublished => f.write_str("scope-root record not published"),
+            ScopeRootPublishError::LostRace => f.write_str("scope-root publish lost the CAS race"),
+        }
+    }
+}
+
+impl std::error::Error for ScopeRootPublishError {}
+
+/// The publish effect of a rotation: CAS-publish a re-sealed scope-root record.
+///
+/// The one impure edge of `rotate_scope` besides the seams, mirroring the
+/// eager-set walk's `ChildIndexResolver`: the traversal/composition is pure and
+/// deterministic, and only this edge touches the content plane and the
+/// `/routing/v1` transport. The real implementation wraps the content-plane block
+/// store, register-first, and [`net::publish`](crate::net::publish) CAS (#745/#746);
+/// this slice's tests fake it.
+pub trait ScopeRootPublisher {
+    /// Register-first CAS-publish `record` at its scope root's `ipnsName`. `Ok`
+    /// means the record is durably the freshest at the name; `Err` means nothing
+    /// was cut (the caller must not advance the floor).
+    async fn publish_scope_root(
+        &self,
+        record: &ResealedScopeRoot,
+    ) -> Result<(), ScopeRootPublishError>;
+}
+
+/// The inputs to one scope root's read-plane rotation: its identity, its current
+/// committed set, its current read-plane state (seed + epoch, which become the
+/// history link's prior), the unchanged write-plane material, and its carried
+/// history links.
+pub struct RotateScopePlan<'a> {
+    /// The scope root's stable identity and the rotator's pseudonym signer.
+    pub identity: ScopeRootIdentity<'a>,
+    /// The owner-committed grant set to re-wrap for (unchanged for a grantee/
+    /// manual rotation; already-pruned by `revoke_read_grant` for a read revoke).
+    pub committed: CommittedSet<'a>,
+    /// The scope's current override (read scope) seed — becomes the new record's
+    /// history-link prior. Caller-owned; never zeroized here.
+    pub current_override_seed: &'a [u8; SECRET_LEN],
+    /// The scope's current read epoch — the new record publishes at `+ 1`.
+    pub current_read_epoch: u64,
+    /// The write-plane scope seed (unchanged by a read rotation).
+    pub write_scope_seed: &'a [u8; SECRET_LEN],
+    /// The write epoch (unchanged by a read rotation).
+    pub write_epoch: u64,
+    /// The stable per-scope pointer read key carried in every grant blob.
+    pub pointer_read_key: &'a [u8; SECRET_LEN],
+    /// The scope's existing per-epoch history links, carried verbatim.
+    pub carried_history_links: &'a [SignedSealed],
+}
+
+/// A fail-closed rotation failure. On every variant nothing durable was left
+/// half-done: the floor is advanced only after a confirmed publish, and the sweep
+/// only after a confirmed floor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RotateError {
+    /// Re-sealing the scope root failed (divergent ledger, unusable recipient
+    /// key, or entropy failure) — nothing was published.
+    Reseal(ResealError),
+    /// The scope-root record did not land — nothing was cut, retry later.
+    Publish(ScopeRootPublishError),
+    /// The durable epoch floor could not be raised after a confirmed publish. The
+    /// record is published (no lockout); the cut completes on retry.
+    Floor(SeamError),
+}
+
+impl core::fmt::Display for RotateError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            RotateError::Reseal(e) => write!(f, "re-seal failed: {e}"),
+            RotateError::Publish(e) => write!(f, "publish failed: {e}"),
+            RotateError::Floor(e) => write!(f, "epoch-floor raise failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for RotateError {}
+
+impl RotateError {
+    /// A stable, key-material-free classification name.
+    pub fn check(&self) -> &'static str {
+        match self {
+            RotateError::Reseal(_) => "reseal-failed",
+            RotateError::Publish(_) => "publish-failed",
+            RotateError::Floor(_) => "floor-raise-failed",
+        }
+    }
+}
+
+/// The result of a completed read-plane root cut.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RotationOutcome {
+    /// The new read epoch the scope was cut to (`current_read_epoch + 1`).
+    pub new_read_epoch: u64,
+    /// The durable `minReadEpoch` floor after the raise (`>= new_read_epoch`).
+    pub epoch_floor: u64,
+}
+
+/// Perform the read-plane root cut for the scope root in `plan`.
+///
+/// Mints a fresh random override seed via `entropy` (determinism law: never a
+/// direct RNG), re-seals through [`reseal_scope_root`], publishes CAS via
+/// `publisher`, raises `minReadEpoch` via `floors`, and enqueues the sweep task
+/// (`make_sweep_task`) on `scheduler` — in that fixed, crash-safe order (module
+/// docs). Read-plane only: the write epoch is unchanged.
+///
+/// `make_sweep_task` is invoked only on the success path, after the floor is
+/// durably raised, and its future is the Slice-3 lazy-wave sweep entry.
+pub async fn rotate_scope<E, F, S, P, Mk>(
+    entropy: &mut E,
+    floors: &F,
+    scheduler: &S,
+    publisher: &P,
+    plan: &RotateScopePlan<'_>,
+    make_sweep_task: Mk,
+) -> Result<RotationOutcome, RotateError>
+where
+    E: Entropy,
+    F: FloorStore,
+    S: Scheduler,
+    P: ScopeRootPublisher,
+    Mk: FnOnce() -> BoxedTask,
+{
+    let new_read_epoch = plan.current_read_epoch.saturating_add(1);
+
+    // Mint the fresh random override seed at the scope root (the read-plane cut).
+    // `rotate_scope` is this seed's terminal owner: `Zeroizing` wipes it on every
+    // return path, including the error paths and a panic unwind.
+    let mut new_override_seed = Zeroizing::new([0u8; SECRET_LEN]);
+    entropy
+        .fill(new_override_seed.as_mut())
+        .map_err(|e| RotateError::Reseal(ResealError::Entropy(e)))?;
+
+    let seeds = ResealSeeds {
+        override_seed: &new_override_seed,
+        read_epoch: new_read_epoch,
+        prev: Some(PrevEpochSeed {
+            seed: plan.current_override_seed,
+            epoch: plan.current_read_epoch,
+        }),
+        write_scope_seed: plan.write_scope_seed,
+        write_epoch: plan.write_epoch,
+        pointer_read_key: plan.pointer_read_key,
+    };
+
+    let section = reseal_scope_root(
+        entropy,
+        &plan.identity,
+        &seeds,
+        &plan.committed,
+        plan.carried_history_links,
+    )
+    .map_err(RotateError::Reseal)?;
+
+    let record = ResealedScopeRoot {
+        scope_id: plan.identity.scope_id,
+        ipns_name: plan.identity.ipns_name.to_vec(),
+        read_epoch: new_read_epoch,
+        write_epoch: plan.write_epoch,
+        section,
+    };
+
+    // 1) Publish CAS. Nothing durable is left on failure — the floor is untouched.
+    publisher
+        .publish_scope_root(&record)
+        .await
+        .map_err(RotateError::Publish)?;
+
+    // 2) Raise the durable minReadEpoch floor — only after a confirmed publish, so
+    // a crash between the two never demands an unpublished epoch (no lockout).
+    let epoch_floor = floors
+        .raise_epoch_floor(&plan.identity.scope_id, new_read_epoch)
+        .await
+        .map_err(RotateError::Floor)?;
+
+    // 3) Enqueue the lazy-wave sweep — last, only after the cut is durable.
+    scheduler.spawn(make_sweep_task());
+
+    Ok(RotationOutcome {
+        new_read_epoch,
+        epoch_floor,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testkit::fakes::{InMemoryFloorStore, VirtualScheduler};
+    use crate::testkit::{SeededEntropy, block_on};
+    use cipherbox_core::seal::{
+        GrantLedgerEntry, GrantSetCommitment, GrantSetEntry, Permission, sign_grant_set,
+    };
+    use cipherbox_core::suite::ecdsa::EcdsaSigner;
+    use cipherbox_core::suite::ed25519::Ed25519Signer;
+    use cipherbox_core::suite::x25519::X25519Secret;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    const SCOPE: [u8; 16] = [0x5c; 16];
+
+    /// A publisher that records what it was handed and returns a scripted result;
+    /// it snapshots the floor at publish time so a test can prove publish-before-
+    /// floor ordering.
+    struct FakePublisher {
+        result: Result<(), ScopeRootPublishError>,
+        seen: Rc<RefCell<Vec<ResealedScopeRoot>>>,
+        floor_at_publish: Rc<RefCell<Option<Option<u64>>>>,
+        floors: InMemoryFloorStore,
+    }
+
+    impl ScopeRootPublisher for FakePublisher {
+        async fn publish_scope_root(
+            &self,
+            record: &ResealedScopeRoot,
+        ) -> Result<(), ScopeRootPublishError> {
+            // Snapshot the durable floor BEFORE the rotation raises it.
+            let floor = self.floors.epoch_floor(&SCOPE).await.unwrap();
+            *self.floor_at_publish.borrow_mut() = Some(floor);
+            self.seen.borrow_mut().push(record.clone());
+            self.result.clone()
+        }
+    }
+
+    struct Fixture {
+        owner_enc: X25519Secret,
+        pseudonym: Ed25519Signer,
+        owner_ecdsa: EcdsaSigner,
+        write_scope_seed: [u8; 32],
+        pointer_read_key: [u8; 32],
+        grantee: X25519Secret,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            Self {
+                owner_enc: X25519Secret::from_scalar([0x11; 32]),
+                pseudonym: Ed25519Signer::from_seed([0x22; 32]),
+                owner_ecdsa: EcdsaSigner::from_scalar(&[0x33; 32]).unwrap(),
+                write_scope_seed: [0x55; 32],
+                pointer_read_key: [0x66; 32],
+                grantee: X25519Secret::from_scalar([0x77; 32]),
+            }
+        }
+
+        fn committed(&self) -> (GrantSetCommitment, [u8; 64], Vec<GrantLedgerEntry>) {
+            let commitment = GrantSetCommitment {
+                ipns_name: b"scope-root".to_vec(),
+                owner_pseudonym_pk: self.pseudonym.verifying_key().to_bytes(),
+                entries: vec![GrantSetEntry::new([0xa1; 32], Permission::Read, [0x02; 32])],
+                unknown: Vec::new(),
+            };
+            let sig = sign_grant_set(&self.owner_ecdsa, &commitment)
+                .unwrap()
+                .to_compact();
+            let ledger = vec![GrantLedgerEntry::new(
+                [0x02; 33],
+                self.grantee.public().to_bytes(),
+                Permission::Read,
+                [0xa1; 32],
+            )];
+            (commitment, sig, ledger)
+        }
+    }
+
+    /// Drive a rotation with a scripted publisher result; returns the outcome, the
+    /// records the publisher saw, the floor it snapshotted at publish time, the
+    /// spawned-task count, and the final durable floor.
+    #[allow(clippy::type_complexity)]
+    fn run_rotation(
+        publish_result: Result<(), ScopeRootPublishError>,
+    ) -> (
+        Result<RotationOutcome, RotateError>,
+        Vec<ResealedScopeRoot>,
+        Option<Option<u64>>,
+        usize,
+        Option<u64>,
+    ) {
+        let fx = Fixture::new();
+        let owner_pub = fx.owner_enc.public();
+        let (commitment, sig, ledger) = fx.committed();
+        let floors = InMemoryFloorStore::default();
+        let scheduler = VirtualScheduler::new();
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let floor_at_publish = Rc::new(RefCell::new(None));
+        let publisher = FakePublisher {
+            result: publish_result,
+            seen: Rc::clone(&seen),
+            floor_at_publish: Rc::clone(&floor_at_publish),
+            floors: floors.clone(),
+        };
+        let current_seed = [0xaa; 32];
+
+        let outcome = block_on(async {
+            let mut entropy = SeededEntropy::new(9);
+            let plan = RotateScopePlan {
+                identity: ScopeRootIdentity {
+                    v: 2,
+                    scope_id: SCOPE,
+                    ipns_name: b"scope-root",
+                    owner_enc_pub: &owner_pub,
+                    parent_node_seed: None,
+                    pseudonym_signer: &fx.pseudonym,
+                },
+                committed: CommittedSet {
+                    commitment: &commitment,
+                    commitment_sig: &sig,
+                    grant_ledger: &ledger,
+                    write_history_link: b"",
+                    direct_child_scope_index: &[],
+                },
+                current_override_seed: &current_seed,
+                current_read_epoch: 4,
+                write_scope_seed: &fx.write_scope_seed,
+                write_epoch: 3,
+                pointer_read_key: &fx.pointer_read_key,
+                carried_history_links: &[],
+            };
+            rotate_scope(&mut entropy, &floors, &scheduler, &publisher, &plan, || {
+                Box::pin(async {})
+            })
+            .await
+        });
+
+        let final_floor = block_on(floors.epoch_floor(&SCOPE)).unwrap();
+        let spawned = scheduler.take_spawned_tasks().len();
+        let seen = seen.borrow().clone();
+        let floor_snap = *floor_at_publish.borrow();
+        (outcome, seen, floor_snap, spawned, final_floor)
+    }
+
+    #[test]
+    fn happy_path_publishes_then_bumps_floor_then_enqueues_sweep() {
+        let (outcome, seen, floor_at_publish, spawned, final_floor) = run_rotation(Ok(()));
+        let outcome = outcome.expect("rotation succeeds");
+        assert_eq!(outcome.new_read_epoch, 5, "read epoch bumped 4 -> 5");
+        assert_eq!(
+            outcome.epoch_floor, 5,
+            "minReadEpoch raised to the new epoch"
+        );
+
+        // One record published, at the new read epoch, write epoch unchanged.
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].read_epoch, 5);
+        assert_eq!(seen[0].write_epoch, 3, "read rotation leaves writeEpoch");
+        assert_eq!(seen[0].scope_id, SCOPE);
+
+        // Ordering: at publish time the floor was still unset (publish precedes
+        // the raise); afterwards it is durably 5.
+        assert_eq!(
+            floor_at_publish,
+            Some(None),
+            "floor not raised before publish"
+        );
+        assert_eq!(final_floor, Some(5));
+
+        // Sweep enqueued exactly once, after the cut is durable.
+        assert_eq!(spawned, 1, "one sweep task enqueued");
+    }
+
+    #[test]
+    fn publish_failure_does_not_bump_floor_or_enqueue_sweep() {
+        // The lockout guard: a failed publish leaves the floor untouched (old
+        // records still gate-pass) and enqueues no sweep.
+        let (outcome, seen, _floor_at_publish, spawned, final_floor) =
+            run_rotation(Err(ScopeRootPublishError::NotPublished));
+        assert_eq!(outcome.unwrap_err().check(), "publish-failed");
+        assert_eq!(seen.len(), 1, "publish was attempted");
+        assert_eq!(final_floor, None, "floor NOT raised on a failed publish");
+        assert_eq!(spawned, 0, "no sweep enqueued on failure");
+    }
+
+    #[test]
+    fn lost_cas_race_does_not_bump_floor() {
+        let (outcome, _seen, _snap, spawned, final_floor) =
+            run_rotation(Err(ScopeRootPublishError::LostRace));
+        assert_eq!(outcome.unwrap_err().check(), "publish-failed");
+        assert_eq!(final_floor, None, "a lost race advances no floor");
+        assert_eq!(spawned, 0);
+    }
+
+    #[test]
+    fn mints_a_fresh_override_seed_distinct_from_the_current() {
+        // The published owner blob decrypts to a NEW seed, not the current one.
+        use crate::secret_util::ct_eq_32;
+        use cipherbox_core::seal::{STRUCT_TAG_OWNER_BLOB, open_owner_blob};
+
+        let fx = Fixture::new();
+        let owner_pub = fx.owner_enc.public();
+        let (commitment, sig, ledger) = fx.committed();
+        let floors = InMemoryFloorStore::default();
+        let scheduler = VirtualScheduler::new();
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let publisher = FakePublisher {
+            result: Ok(()),
+            seen: Rc::clone(&seen),
+            floor_at_publish: Rc::new(RefCell::new(None)),
+            floors: floors.clone(),
+        };
+        let current_seed = [0xaa; 32];
+
+        block_on(async {
+            let mut entropy = SeededEntropy::new(1);
+            let plan = RotateScopePlan {
+                identity: ScopeRootIdentity {
+                    v: 2,
+                    scope_id: SCOPE,
+                    ipns_name: b"scope-root",
+                    owner_enc_pub: &owner_pub,
+                    parent_node_seed: None,
+                    pseudonym_signer: &fx.pseudonym,
+                },
+                committed: CommittedSet {
+                    commitment: &commitment,
+                    commitment_sig: &sig,
+                    grant_ledger: &ledger,
+                    write_history_link: b"",
+                    direct_child_scope_index: &[],
+                },
+                current_override_seed: &current_seed,
+                current_read_epoch: 1,
+                write_scope_seed: &fx.write_scope_seed,
+                write_epoch: 1,
+                pointer_read_key: &fx.pointer_read_key,
+                carried_history_links: &[],
+            };
+            rotate_scope(&mut entropy, &floors, &scheduler, &publisher, &plan, || {
+                Box::pin(async {})
+            })
+            .await
+            .unwrap();
+        });
+
+        let record = &seen.borrow()[0];
+        let ob = &record.section.owner_blob;
+        let ctx = cipherbox_core::seal::AadContext {
+            v: 2,
+            id: SCOPE,
+            scope: SCOPE,
+            epoch: 2,
+            struct_tag: STRUCT_TAG_OWNER_BLOB,
+        };
+        let payload = open_owner_blob(&fx.owner_enc, &ob.enc, &ctx, &ob.ciphertext).unwrap();
+        assert!(
+            !ct_eq_32(payload.override_seed(), &current_seed),
+            "rotation minted a fresh seed, not the current one"
+        );
+    }
+}

--- a/crates/engine/src/rotation/rotate.rs
+++ b/crates/engine/src/rotation/rotate.rs
@@ -143,6 +143,10 @@ pub enum RotateError {
     /// The durable epoch floor could not be raised after a confirmed publish. The
     /// record is published (no lockout); the cut completes on retry.
     Floor(SeamError),
+    /// The read epoch is exhausted (`current_read_epoch == u64::MAX`). Rotating
+    /// would reuse the epoch with fresh key material, violating key-regression
+    /// monotonicity, so nothing is minted or published. Unreachable in practice.
+    EpochExhausted,
 }
 
 impl core::fmt::Display for RotateError {
@@ -151,6 +155,7 @@ impl core::fmt::Display for RotateError {
             RotateError::Reseal(e) => write!(f, "re-seal failed: {e}"),
             RotateError::Publish(e) => write!(f, "publish failed: {e}"),
             RotateError::Floor(e) => write!(f, "epoch-floor raise failed: {e}"),
+            RotateError::EpochExhausted => f.write_str("read epoch exhausted (u64::MAX)"),
         }
     }
 }
@@ -164,6 +169,7 @@ impl RotateError {
             RotateError::Reseal(_) => "reseal-failed",
             RotateError::Publish(_) => "publish-failed",
             RotateError::Floor(_) => "floor-raise-failed",
+            RotateError::EpochExhausted => "epoch-exhausted",
         }
     }
 }
@@ -202,7 +208,13 @@ where
     P: ScopeRootPublisher,
     Mk: FnOnce() -> BoxedTask,
 {
-    let new_read_epoch = plan.current_read_epoch.saturating_add(1);
+    // Fail-closed BEFORE minting: a saturating bump at u64::MAX would republish
+    // fresh key material under the same epoch (a key-regression violation), so an
+    // exhausted epoch is rejected rather than silently reused.
+    let new_read_epoch = plan
+        .current_read_epoch
+        .checked_add(1)
+        .ok_or(RotateError::EpochExhausted)?;
 
     // Mint the fresh random override seed at the scope root (the read-plane cut).
     // `rotate_scope` is this seed's terminal owner: `Zeroizing` wipes it on every
@@ -609,5 +621,68 @@ mod tests {
             0,
             "no sweep enqueued when the floor raise fails after publish"
         );
+    }
+
+    #[test]
+    fn exhausted_epoch_fails_closed_without_publishing() {
+        // current_read_epoch == u64::MAX: a bump would reuse the epoch with fresh
+        // key material, so the rotation fails closed before minting or publishing.
+        let fx = Fixture::new();
+        let owner_pub = fx.owner_enc.public();
+        let (commitment, sig, ledger) = fx.committed();
+        let floors = InMemoryFloorStore::default();
+        let scheduler = VirtualScheduler::new();
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let publisher = FakePublisher {
+            result: Ok(()),
+            seen: Rc::clone(&seen),
+            floor_at_publish: Rc::new(RefCell::new(None)),
+            floors: floors.clone(),
+        };
+        let current_seed = [0xaa; 32];
+
+        let outcome = block_on(async {
+            let mut entropy = SeededEntropy::new(9);
+            let plan = RotateScopePlan {
+                identity: ScopeRootIdentity {
+                    v: 2,
+                    scope_id: SCOPE,
+                    ipns_name: b"scope-root",
+                    owner_enc_pub: &owner_pub,
+                    parent_node_seed: None,
+                    pseudonym_signer: &fx.pseudonym,
+                },
+                committed: CommittedSet {
+                    commitment: &commitment,
+                    commitment_sig: &sig,
+                    grant_ledger: &ledger,
+                    write_history_link: b"",
+                    direct_child_scope_index: &[],
+                },
+                current_override_seed: &current_seed,
+                current_read_epoch: u64::MAX,
+                write_scope_seed: &fx.write_scope_seed,
+                write_epoch: 3,
+                pointer_read_key: &fx.pointer_read_key,
+                carried_history_links: &[],
+            };
+            rotate_scope(&mut entropy, &floors, &scheduler, &publisher, &plan, || {
+                Box::pin(async {})
+            })
+            .await
+        });
+
+        assert_eq!(outcome.unwrap_err().check(), "epoch-exhausted");
+        assert_eq!(
+            seen.borrow().len(),
+            0,
+            "nothing published on an exhausted epoch"
+        );
+        assert_eq!(
+            block_on(floors.epoch_floor(&SCOPE)).unwrap(),
+            None,
+            "no floor raised"
+        );
+        assert_eq!(scheduler.take_spawned_tasks().len(), 0, "no sweep enqueued");
     }
 }

--- a/crates/engine/src/rotation/trigger.rs
+++ b/crates/engine/src/rotation/trigger.rs
@@ -24,8 +24,10 @@
 //! blobs: that absence **is** the revocation ("they keep what they saw; they lose
 //! everything new, now").
 
-use cipherbox_core::seal::{GrantLedgerEntry, GrantSetCommitment, sign_grant_set};
-use cipherbox_core::suite::ecdsa::{EcdsaSigner, SIGNATURE_LEN as ECDSA_SIG_LEN};
+use cipherbox_core::seal::{
+    GrantLedgerEntry, GrantSetCommitment, sign_grant_set, verify_grant_set,
+};
+use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaSigner, SIGNATURE_LEN as ECDSA_SIG_LEN};
 
 /// Which trigger fired a rotation — a host-facing classifier carrying no key
 /// material. Scope-exit and manual rotations re-seal the unchanged committed set;
@@ -68,6 +70,11 @@ pub struct RevokedCommittedSet {
 /// A fail-closed read-revoke failure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RevokeError {
+    /// `owner_signer` did not sign the current commitment, so it is not the owner
+    /// identity that authorized the set. Re-signing under it would mint a
+    /// commitment the adoption gate rejects (an unreadable root); the encode-side
+    /// mirror of the gate's owner-identity verify (fail-closed symmetry).
+    UnauthorizedSigner,
     /// `revoked_tag` is not in the committed set — there is no grant to revoke.
     /// Rotating anyway would be a no-op cut, so this is rejected, not silent.
     NotGranted,
@@ -79,6 +86,9 @@ pub enum RevokeError {
 impl core::fmt::Display for RevokeError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            RevokeError::UnauthorizedSigner => {
+                f.write_str("owner signer did not authorize the current commitment")
+            }
             RevokeError::NotGranted => f.write_str("no grant committed under the revoked tag"),
             RevokeError::Sign(e) => write!(f, "commitment re-sign failed: {}", e.check()),
         }
@@ -91,6 +101,7 @@ impl RevokeError {
     /// A stable, key-material-free classification name.
     pub fn check(&self) -> &'static str {
         match self {
+            RevokeError::UnauthorizedSigner => "unauthorized-signer",
             RevokeError::NotGranted => "not-granted",
             RevokeError::Sign(_) => "commitment-sign-failed",
         }
@@ -102,16 +113,30 @@ impl RevokeError {
 /// owner-re-sign the pruned commitment with `owner_signer`.
 ///
 /// Owner-only by construction: it requires the owner's identity signer, and only
-/// the commitment (owner-signed) authorises the set. The `revoked_tag` MUST be
-/// committed (fail-closed [`RevokeError::NotGranted`] otherwise). The result is
-/// the input a subsequent `rotate_scope` re-seals — after which the revokee has
-/// no grant blob at the new epoch.
+/// the commitment (owner-signed) authorises the set. `commitment_sig` is the
+/// current owner signature over `commitment`; `owner_signer` MUST be the identity
+/// that produced it (fail-closed [`RevokeError::UnauthorizedSigner`] otherwise).
+/// The `revoked_tag` MUST be committed (fail-closed [`RevokeError::NotGranted`]
+/// otherwise). The result is the input a subsequent `rotate_scope` re-seals —
+/// after which the revokee has no grant blob at the new epoch.
 pub fn revoke_read_grant(
     commitment: &GrantSetCommitment,
+    commitment_sig: &[u8; ECDSA_SIG_LEN],
     grant_ledger: &[GrantLedgerEntry],
     revoked_tag: &[u8; 32],
     owner_signer: &EcdsaSigner,
 ) -> Result<RevokedCommittedSet, RevokeError> {
+    // Fail-closed BEFORE the cut: `owner_signer` MUST be the identity that signed
+    // the current commitment, else the re-signed cut mints a commitment the
+    // adoption gate rejects (an unreadable root). Encode-side mirror of the gate's
+    // owner-identity verify (fail-closed symmetry). The current commitment is
+    // owner-authentic (it passed the gate to resolve), so binding the new signer
+    // to it transitively anchors the cut to the owner identity.
+    let current_sig =
+        EcdsaSignature::from_compact(commitment_sig).ok_or(RevokeError::UnauthorizedSigner)?;
+    verify_grant_set(&owner_signer.verifying_key(), commitment, &current_sig)
+        .map_err(|_| RevokeError::UnauthorizedSigner)?;
+
     // The commitment is the authoritative set; a tag absent there is not a grant.
     if !commitment.entries.iter().any(|e| &e.tag == revoked_tag) {
         return Err(RevokeError::NotGranted);
@@ -146,7 +171,11 @@ mod tests {
         EcdsaSigner::from_scalar(&[0x33; 32]).unwrap()
     }
 
-    fn commitment() -> (GrantSetCommitment, Vec<GrantLedgerEntry>) {
+    fn commitment() -> (
+        GrantSetCommitment,
+        [u8; ECDSA_SIG_LEN],
+        Vec<GrantLedgerEntry>,
+    ) {
         let entries = vec![
             GrantSetEntry::new([0xa1; 32], Permission::Read, [0x02; 32]),
             GrantSetEntry::new([0xb2; 32], Permission::Read, [0x04; 32]),
@@ -158,19 +187,20 @@ mod tests {
             entries,
             unknown: Vec::new(),
         };
+        let sig = sign_grant_set(&owner(), &c).unwrap().to_compact();
         let ledger = vec![
             GrantLedgerEntry::new([0x02; 33], [0x11; 32], Permission::Read, [0xa1; 32]),
             GrantLedgerEntry::new([0x04; 33], [0x12; 32], Permission::Read, [0xb2; 32]),
             GrantLedgerEntry::new([0x03; 33], [0x13; 32], Permission::Write, [0xc3; 32]),
         ];
-        (c, ledger)
+        (c, sig, ledger)
     }
 
     #[test]
     fn revoke_removes_tag_from_both_and_resigns() {
         let owner = owner();
-        let (c, ledger) = commitment();
-        let cut = revoke_read_grant(&c, &ledger, &[0xb2; 32], &owner).expect("revoke");
+        let (c, sig, ledger) = commitment();
+        let cut = revoke_read_grant(&c, &sig, &ledger, &[0xb2; 32], &owner).expect("revoke");
 
         assert!(!cut.commitment.entries.iter().any(|e| e.tag == [0xb2; 32]));
         assert!(!cut.grant_ledger.iter().any(|e| e.tag == [0xb2; 32]));
@@ -185,8 +215,8 @@ mod tests {
     #[test]
     fn revoke_preserves_survivors_and_owner_fields() {
         let owner = owner();
-        let (c, ledger) = commitment();
-        let cut = revoke_read_grant(&c, &ledger, &[0xc3; 32], &owner).expect("revoke");
+        let (c, sig, ledger) = commitment();
+        let cut = revoke_read_grant(&c, &sig, &ledger, &[0xc3; 32], &owner).expect("revoke");
         assert!(cut.commitment.entries.iter().any(|e| e.tag == [0xa1; 32]));
         assert!(cut.commitment.entries.iter().any(|e| e.tag == [0xb2; 32]));
         assert_eq!(cut.commitment.ipns_name, c.ipns_name);
@@ -196,9 +226,21 @@ mod tests {
     #[test]
     fn revoke_unknown_tag_fails_closed() {
         let owner = owner();
-        let (c, ledger) = commitment();
-        let err = revoke_read_grant(&c, &ledger, &[0xff; 32], &owner).expect_err("not granted");
+        let (c, sig, ledger) = commitment();
+        let err =
+            revoke_read_grant(&c, &sig, &ledger, &[0xff; 32], &owner).expect_err("not granted");
         assert_eq!(err.check(), "not-granted");
+    }
+
+    #[test]
+    fn revoke_wrong_signer_fails_closed() {
+        // A signer that did not sign the current commitment is rejected before the
+        // cut — the encode-side mirror of the gate's owner-identity verify.
+        let (c, sig, ledger) = commitment();
+        let wrong_owner = EcdsaSigner::from_scalar(&[0x44; 32]).unwrap();
+        let err = revoke_read_grant(&c, &sig, &ledger, &[0xb2; 32], &wrong_owner)
+            .expect_err("unauthorized signer");
+        assert_eq!(err.check(), "unauthorized-signer");
     }
 
     #[test]

--- a/crates/engine/src/rotation/trigger.rs
+++ b/crates/engine/src/rotation/trigger.rs
@@ -4,11 +4,15 @@
 //! A read-plane rotation fires from three sources, all driving the one
 //! [`rotate_scope`](super::rotate::rotate_scope) primitive:
 //!
-//! | Trigger      | Committed-set change | Cascade                              |
-//! | ------------ | -------------------- | ------------------------------------ |
-//! | Scope exit   | none (grantee flat)  | flat — the single root re-publishes  |
-//! | Read revoke  | revokee removed      | full eager-set cascade (owner action)|
-//! | Manual       | none                 | per-scope, same primitive            |
+//! | Trigger      | Committed-set change | Cascade                                 |
+//! | ------------ | -------------------- | --------------------------------------- |
+//! | Scope exit   | none (grantee flat)  | flat — the single root re-publishes     |
+//! | Read revoke  | revokee removed      | root cut here; eager-set via the sweep  |
+//! | Manual       | none                 | per-scope, same primitive               |
+//!
+//! This slice wires only the **root cut** for a read revoke; the descendant
+//! eager-set scope-root re-key is delivered by the sweep (Slice 3) and the
+//! resolver/tree wiring (#745/#746). Read-revoke is not end-to-end complete here.
 //!
 //! Scope-exit and manual rotations re-seal the **unchanged** committed set: a
 //! grantee re-wraps blobs verbatim and can neither extend nor shrink the tag set

--- a/crates/engine/src/rotation/trigger.rs
+++ b/crates/engine/src/rotation/trigger.rs
@@ -1,0 +1,206 @@
+//! Rotation triggers (blueprint/engine.md "Rotation primitives: Triggers",
+//! #26 D7).
+//!
+//! A read-plane rotation fires from three sources, all driving the one
+//! [`rotate_scope`](super::rotate::rotate_scope) primitive:
+//!
+//! | Trigger      | Committed-set change | Cascade                              |
+//! | ------------ | -------------------- | ------------------------------------ |
+//! | Scope exit   | none (grantee flat)  | flat — the single root re-publishes  |
+//! | Read revoke  | revokee removed      | full eager-set cascade (owner action)|
+//! | Manual       | none                 | per-scope, same primitive            |
+//!
+//! Scope-exit and manual rotations re-seal the **unchanged** committed set: a
+//! grantee re-wraps blobs verbatim and can neither extend nor shrink the tag set
+//! (#26 D5), so they feed the current commitment/ledger straight into
+//! `rotate_scope`. The read-revoke trigger is the only one that mutates the set —
+//! [`revoke_read_grant`] performs the owner-only cut (remove the revokee from the
+//! commitment and the ledger, owner-re-sign) whose result then feeds
+//! `rotate_scope`. The removed grantee is thereby absent from the re-wrapped grant
+//! blobs: that absence **is** the revocation ("they keep what they saw; they lose
+//! everything new, now").
+
+use cipherbox_core::seal::{GrantLedgerEntry, GrantSetCommitment, sign_grant_set};
+use cipherbox_core::suite::ecdsa::{EcdsaSigner, SIGNATURE_LEN as ECDSA_SIG_LEN};
+
+/// Which trigger fired a rotation — a host-facing classifier carrying no key
+/// material. Scope-exit and manual rotations re-seal the unchanged committed set;
+/// read-revoke first applies [`revoke_read_grant`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RotationTrigger {
+    /// A grantee left a granted scope (a cross-scope move out of a granted
+    /// source, full-depth detected). Flat, self-contained, no committed change.
+    ScopeExit,
+    /// The owner revoked a read grant — the immediate revoking rekey.
+    ReadRevoke,
+    /// Manual hygiene rotate-now. No committed change.
+    Manual,
+}
+
+impl RotationTrigger {
+    /// A stable, host-facing name (no key material).
+    pub fn name(&self) -> &'static str {
+        match self {
+            RotationTrigger::ScopeExit => "scope-exit",
+            RotationTrigger::ReadRevoke => "read-revoke",
+            RotationTrigger::Manual => "manual",
+        }
+    }
+}
+
+/// The owner-only committed-set cut produced by [`revoke_read_grant`]: the new
+/// commitment with the revokee removed, its fresh owner signature, and the
+/// matching pruned ledger — ready to feed [`rotate_scope`](super::rotate::rotate_scope).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RevokedCommittedSet {
+    /// The commitment with the revokee's `(tag, permission, pseudonymPk)` removed.
+    pub commitment: GrantSetCommitment,
+    /// The fresh 64-byte compact ECDSA owner signature over `commitment`.
+    pub commitment_sig: [u8; ECDSA_SIG_LEN],
+    /// The grant ledger with the revokee's row removed.
+    pub grant_ledger: Vec<GrantLedgerEntry>,
+}
+
+/// A fail-closed read-revoke failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RevokeError {
+    /// `revoked_tag` is not in the committed set — there is no grant to revoke.
+    /// Rotating anyway would be a no-op cut, so this is rejected, not silent.
+    NotGranted,
+    /// Re-signing the pruned commitment failed (a duplicate tag survived — never
+    /// possible after a single removal, but propagated fail-closed).
+    Sign(cipherbox_core::error::CodecError),
+}
+
+impl core::fmt::Display for RevokeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            RevokeError::NotGranted => f.write_str("no grant committed under the revoked tag"),
+            RevokeError::Sign(e) => write!(f, "commitment re-sign failed: {}", e.check()),
+        }
+    }
+}
+
+impl std::error::Error for RevokeError {}
+
+impl RevokeError {
+    /// A stable, key-material-free classification name.
+    pub fn check(&self) -> &'static str {
+        match self {
+            RevokeError::NotGranted => "not-granted",
+            RevokeError::Sign(_) => "commitment-sign-failed",
+        }
+    }
+}
+
+/// Perform the read-revoke committed-set cut: remove `revoked_tag`'s grant from
+/// the owner-signed `commitment` and the write-body `grant_ledger`, and
+/// owner-re-sign the pruned commitment with `owner_signer`.
+///
+/// Owner-only by construction: it requires the owner's identity signer, and only
+/// the commitment (owner-signed) authorises the set. The `revoked_tag` MUST be
+/// committed (fail-closed [`RevokeError::NotGranted`] otherwise). The result is
+/// the input a subsequent `rotate_scope` re-seals — after which the revokee has
+/// no grant blob at the new epoch.
+pub fn revoke_read_grant(
+    commitment: &GrantSetCommitment,
+    grant_ledger: &[GrantLedgerEntry],
+    revoked_tag: &[u8; 32],
+    owner_signer: &EcdsaSigner,
+) -> Result<RevokedCommittedSet, RevokeError> {
+    // The commitment is the authoritative set; a tag absent there is not a grant.
+    if !commitment.entries.iter().any(|e| &e.tag == revoked_tag) {
+        return Err(RevokeError::NotGranted);
+    }
+
+    let mut new_commitment = commitment.clone();
+    new_commitment.entries.retain(|e| &e.tag != revoked_tag);
+    let grant_ledger: Vec<GrantLedgerEntry> = grant_ledger
+        .iter()
+        .filter(|e| &e.tag != revoked_tag)
+        .cloned()
+        .collect();
+
+    let commitment_sig = sign_grant_set(owner_signer, &new_commitment)
+        .map_err(RevokeError::Sign)?
+        .to_compact();
+
+    Ok(RevokedCommittedSet {
+        commitment: new_commitment,
+        commitment_sig,
+        grant_ledger,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cipherbox_core::seal::{GrantSetEntry, Permission, verify_grant_set};
+    use cipherbox_core::suite::ecdsa::EcdsaSignature;
+
+    fn owner() -> EcdsaSigner {
+        EcdsaSigner::from_scalar(&[0x33; 32]).unwrap()
+    }
+
+    fn commitment() -> (GrantSetCommitment, Vec<GrantLedgerEntry>) {
+        let entries = vec![
+            GrantSetEntry::new([0xa1; 32], Permission::Read, [0x02; 32]),
+            GrantSetEntry::new([0xb2; 32], Permission::Read, [0x04; 32]),
+            GrantSetEntry::new([0xc3; 32], Permission::Write, [0x03; 32]),
+        ];
+        let c = GrantSetCommitment {
+            ipns_name: b"n".to_vec(),
+            owner_pseudonym_pk: [0x88; 32],
+            entries,
+            unknown: Vec::new(),
+        };
+        let ledger = vec![
+            GrantLedgerEntry::new([0x02; 33], [0x11; 32], Permission::Read, [0xa1; 32]),
+            GrantLedgerEntry::new([0x04; 33], [0x12; 32], Permission::Read, [0xb2; 32]),
+            GrantLedgerEntry::new([0x03; 33], [0x13; 32], Permission::Write, [0xc3; 32]),
+        ];
+        (c, ledger)
+    }
+
+    #[test]
+    fn revoke_removes_tag_from_both_and_resigns() {
+        let owner = owner();
+        let (c, ledger) = commitment();
+        let cut = revoke_read_grant(&c, &ledger, &[0xb2; 32], &owner).expect("revoke");
+
+        assert!(!cut.commitment.entries.iter().any(|e| e.tag == [0xb2; 32]));
+        assert!(!cut.grant_ledger.iter().any(|e| e.tag == [0xb2; 32]));
+        assert_eq!(cut.commitment.entries.len(), 2);
+        assert_eq!(cut.grant_ledger.len(), 2);
+
+        // The fresh signature verifies over the pruned commitment.
+        let sig = EcdsaSignature::from_compact(&cut.commitment_sig).unwrap();
+        verify_grant_set(&owner.verifying_key(), &cut.commitment, &sig).expect("fresh sig valid");
+    }
+
+    #[test]
+    fn revoke_preserves_survivors_and_owner_fields() {
+        let owner = owner();
+        let (c, ledger) = commitment();
+        let cut = revoke_read_grant(&c, &ledger, &[0xc3; 32], &owner).expect("revoke");
+        assert!(cut.commitment.entries.iter().any(|e| e.tag == [0xa1; 32]));
+        assert!(cut.commitment.entries.iter().any(|e| e.tag == [0xb2; 32]));
+        assert_eq!(cut.commitment.ipns_name, c.ipns_name);
+        assert_eq!(cut.commitment.owner_pseudonym_pk, c.owner_pseudonym_pk);
+    }
+
+    #[test]
+    fn revoke_unknown_tag_fails_closed() {
+        let owner = owner();
+        let (c, ledger) = commitment();
+        let err = revoke_read_grant(&c, &ledger, &[0xff; 32], &owner).expect_err("not granted");
+        assert_eq!(err.check(), "not-granted");
+    }
+
+    #[test]
+    fn trigger_names_are_stable() {
+        assert_eq!(RotationTrigger::ScopeExit.name(), "scope-exit");
+        assert_eq!(RotationTrigger::ReadRevoke.name(), "read-revoke");
+        assert_eq!(RotationTrigger::Manual.name(), "manual");
+    }
+}


### PR DESCRIPTION
## Slice 2 of #635 — `rotateScope` read-plane root cut + shared re-seal helper + triggers

Builds the read-plane key-regression rotation: the O(1) **root cut**, the scope-root re-seal/publish primitive that Slice 3's sweep will reuse, and the rotation trigger surface. Consumes the eager-set walk from #744 via the injected resolver seam (the live network resolver is deferred to the wiring slice, gated by #745/#746 — this slice is engine-simulation-gated and is **not** blocked on them). Read-plane only: bumps `minReadEpoch`, never `writeEpoch` (the name wave / `rotateScopeWrite` is Slice 4).

Three new files under `crates/engine/src/rotation/`.

### `reseal.rs` — the shared re-seal helper (Slice-3-consumable)

Composes the `crates/core` seal primitives into a signed `GrantSection` for one scope root — grant blobs re-wrapped for the committed set, owner blob, ascent link, history links, sealed write-body, all pseudonym-signed. The seed source is parameterised via `ResealSeeds` so both callers reuse it: rotate (fresh random seed + new epoch + `prev`) and the sweep (existing seed, `prev = None`, no new history link).

```rust
pub fn reseal_scope_root<E: Entropy>(
    entropy: &mut E,
    identity: &ScopeRootIdentity<'_>,
    seeds: &ResealSeeds<'_>,
    committed: &CommittedSet<'_>,
    carried_history_links: &[SignedSealed],
) -> Result<GrantSection, ResealError>
```

### `rotate.rs` — `rotate_scope` + `ScopeRootPublisher` seam

The read-plane root cut: mint a fresh **random** override seed at the scope root via the injected `Entropy` seam (never a direct RNG call), re-seal through `reseal_scope_root`, publish via the `ScopeRootPublisher` seam (faked in-slice; real content-plane `net::publish` CAS wiring is the deferred resolver slice), bump `minReadEpoch`, enqueue the sweep. The eager-set descendant scope roots (enumerated by #744) are re-sealed through the same helper by the sweep cascade — this slice does not thread the per-descendant parent-seed material, which the deferred resolver wiring owns.

### `trigger.rs` — `revoke_read_grant` + `RotationTrigger`

| Trigger | Committed-set change | Action |
| --- | --- | --- |
| Scope exit | none | `rotate_scope`, unchanged set |
| Read revoke | revokee removed | `revoke_read_grant` → `rotate_scope` |
| Manual | none | `rotate_scope` |

`revoke_read_grant` is the revocation act: the owner removes the revokee's entry from the committed set (blob + ledger + commitment-entry removal) so the re-wrap excludes them.

### Effect ordering (crash-safety)

**publish CAS → raise `minReadEpoch` → enqueue sweep**, aborting before the next step on any failure. Publish-before-floor avoids the lockout failure mode (a floor demanding an unpublished epoch); a failed publish or lost CAS race raises no floor and enqueues no sweep, so a mid-rotation failure is cleanly retryable, never a stranded/fail-open scope.

### Fail-closed / secret hygiene

Release-active encode-side guards (runtime `Err`, never `debug_assert!`) for the invariants the decode path hard-rejects, consistent with `seal/section.rs`. Override seeds live in `Zeroizing`, zeroized at the terminal owner only; secret comparisons use `ct_eq_32`; errors are redacted (no key material in `Display`/`Debug`/logs/assertions).

### Key tests (30 new, all green)

- `revoked_grantee_is_absent_survivors_present_at_new_epoch` — the revocation guarantee: revokee's blob absent, survivors re-wrapped at the new epoch, revokee cannot open survivors, a survivor decrypts the fresh seed.
- `diverging_ledger_fails_closed_release_active`, `unusable_recipient_key_fails_closed` — release-active encode guards.
- `publish_failure_does_not_bump_floor_or_enqueue_sweep` — lockout guard on the effect ordering.
- `mints_a_fresh_override_seed_distinct_from_the_current`, full-structure round-trip + signature verification, determinism, vault-root/sweep seed-source variants.

### Validation

`cargo fmt --all --check`, `cargo test -p cipherbox-engine` + `-p cipherbox-core`, `cargo clippy -p cipherbox-engine -p cipherbox-core --all-targets -- -D warnings`, and `cargo build -p cipherbox-wasm --target wasm32-unknown-unknown` all pass. Self-review trio folded: crypto-privacy (no code findings — verified revocation completeness, ephemeral/nonce freshness, structure-sig composition, secret hygiene), simplify (folded seed zeroize into `Zeroizing`), security.

Part of #635


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scope-root read rotation with secure re-sealing and publication.
  - Added read-grant revocation that updates the committed access set.
  - Added rotation triggers for scope exit, read revocation, and manual rotation.
  - Added safeguards to validate authorized grants, signatures, and publishing before advancing rotation state.
  - Added stable error classifications for rotation, re-sealing, publishing, and revocation failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->