### PR TITLE
feat(engine): derive the cold-start session identity at start

### DIFF
--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -27,6 +27,7 @@ use crate::entropy::Entropy;
 use crate::net::{HeldRecord, LivenessControl, RE_PUT_INTERVAL, keyless_re_put, run_liveness_loop};
 use crate::profile::SyncTimingProfile;
 use crate::seams::{OpId, Scheduler, SeamSet, SeamTypes};
+use crate::session::SessionIdentity;
 
 /// The stable 16-byte node identifier (`id16`, blueprint/core.md). Public,
 /// non-secret, and location-independent — routes and commands key on it,
@@ -105,6 +106,13 @@ impl LoginSecret {
     /// Whether the secret is empty (always a caller bug).
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    /// Borrow the raw secret bytes for in-crate cold-start derivation only.
+    /// `pub(crate)` so the secret never leaves engine memory; the only caller
+    /// is [`SessionIdentity::derive`](crate::session::SessionIdentity::derive).
+    pub(crate) fn expose(&self) -> &[u8] {
+        &self.0
     }
 }
 
@@ -376,6 +384,11 @@ pub struct Engine<T: SeamTypes> {
     /// Session-alive latch: cleared on drop so the spawned liveness loop
     /// stops at its next wake instead of re-PUTting after the engine is gone.
     alive: Rc<Cell<bool>>,
+    /// The cold-start session identity, derived from the login secret at
+    /// [`start`](Self::start). `None` until then; the single place derived key
+    /// material lives once the engine is live. The resolve/publish/rotation
+    /// slices and the liveness loop read every signer from here.
+    session: Option<SessionIdentity>,
     started: bool,
 }
 
@@ -396,6 +409,7 @@ impl<T: SeamTypes> Engine<T> {
                 events,
                 held_records: Rc::new(RefCell::new(Vec::new())),
                 alive: Rc::new(Cell::new(true)),
+                session: None,
                 started: false,
             },
             EventStream { receiver },
@@ -404,11 +418,18 @@ impl<T: SeamTypes> Engine<T> {
 
     /// Start of secret: consumes the login secret and brings the engine up.
     ///
-    /// The full cold-start sequence (identity derivation, vault-pointer
-    /// resolve, floor cold-seed, root adoption, first snapshot event) lands
-    /// with the pipeline slices; the lifecycle contract — exactly one
-    /// successful `start` per instance, secret zeroized on consumption — is
-    /// in force now.
+    /// Derives the cold-start [`SessionIdentity`] from the secret — the
+    /// owner-plane identity that needs no network (enc subkey, owner pointer
+    /// seed, vault-pointer signer chain), plus the per-scope/per-name signer
+    /// factories the pipeline layers scope material onto. The remaining
+    /// cold-start steps (vault-pointer resolve, floor cold-seed, root
+    /// adoption, first snapshot event) land with the resolve/gate slices,
+    /// which read their key material from the session assembled here.
+    ///
+    /// The lifecycle contract holds: exactly one successful `start` per
+    /// instance, and the secret is zeroized on consumption — derivation is the
+    /// only reader, and the secret is dropped at its terminal owner the moment
+    /// the identity is built.
     pub async fn start(&mut self, secret: LoginSecret) -> Result<(), EngineError>
     where
         T::Scheduler: Clone + 'static,
@@ -420,12 +441,24 @@ impl<T: SeamTypes> Engine<T> {
         if secret.is_empty() {
             return Err(EngineError::InvalidSecret);
         }
-        // Derivation lands with the pipeline slices; the secret zeroizes on
-        // drop here, at its terminal owner.
+        // Pure derivation from the injected secret — no clock, no RNG — then
+        // the secret zeroizes on drop here, at its terminal owner.
+        self.session = Some(SessionIdentity::derive(&secret));
         drop(secret);
         self.spawn_liveness_loop();
         self.started = true;
         Ok(())
+    }
+
+    /// The live session identity, once [`start`](Self::start) has derived it.
+    /// `pub(crate)`: the in-crate pipeline (resolve, publish, rotation, the
+    /// liveness loop) reads its signers here; hosts wrap the facade and never
+    /// hold key material.
+    // Read by the pipeline slices that consume the session (resolve #745/#746,
+    // liveness composition #750/#751); the hook is live now, its callers land next.
+    #[allow(dead_code)]
+    pub(crate) fn session(&self) -> Option<&SessionIdentity> {
+        self.session.as_ref()
     }
 
     /// Spawn the ~hourly keyless re-PUT loop (blueprint/engine.md "Liveness"):
@@ -485,10 +518,74 @@ impl<T: SeamTypes> Drop for Engine<T> {
 mod tests {
     use super::*;
 
+    use crate::testkit::{FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
+
+    fn new_engine() -> (Engine<FakeSeamTypes>, EventStream) {
+        let device = FakeWorld::new().device(b"alice-pk");
+        Engine::new(
+            device.seam_set(),
+            Box::new(SeededEntropy::new(42)),
+            SyncTimingProfile::CI,
+        )
+    }
+
+    fn started_engine(secret_byte: u8) -> Engine<FakeSeamTypes> {
+        let (mut engine, _events) = new_engine();
+        block_on(engine.start(LoginSecret::new(vec![secret_byte; 32]))).unwrap();
+        engine
+    }
+
     #[test]
     fn login_secret_debug_is_redacted() {
         let secret = LoginSecret::new(vec![0xAA; 32]);
         assert_eq!(format!("{secret:?}"), "LoginSecret(redacted)");
+    }
+
+    #[test]
+    fn cold_start_derives_and_wires_the_session_identity() {
+        let (mut engine, _events) = new_engine();
+        assert!(engine.session().is_none(), "no identity before start");
+
+        block_on(engine.start(LoginSecret::new(vec![7u8; 32]))).unwrap();
+        let session = engine
+            .session()
+            .expect("start derives the session identity");
+
+        // The per-name signers #750/#751 need are reachable and match the pure
+        // derivation from the same secret — start invents no key material.
+        let expected = SessionIdentity::derive(&LoginSecret::new(vec![7u8; 32]));
+        assert_eq!(
+            session.vault_pointer_signer(0).verifying_key().to_bytes(),
+            expected.vault_pointer_signer(0).verifying_key().to_bytes(),
+        );
+        assert_eq!(
+            session
+                .write_name_signer(&[5u8; 32], &[4u8; 16])
+                .verifying_key()
+                .to_bytes(),
+            expected
+                .write_name_signer(&[5u8; 32], &[4u8; 16])
+                .verifying_key()
+                .to_bytes(),
+        );
+    }
+
+    #[test]
+    fn cold_start_derivation_is_deterministic_and_clock_independent() {
+        // Two engines over independent virtual clocks derive the same identity
+        // from the same secret: `start` reads no clock or RNG, only the seed.
+        let a = started_engine(7);
+        let b = started_engine(7);
+        assert_eq!(
+            a.session().unwrap().enc_subkey_public().to_bytes(),
+            b.session().unwrap().enc_subkey_public().to_bytes(),
+        );
+        let c = started_engine(8);
+        assert_ne!(
+            a.session().unwrap().enc_subkey_public().to_bytes(),
+            c.session().unwrap().enc_subkey_public().to_bytes(),
+            "a different secret is a different identity",
+        );
     }
 
     #[test]

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -518,6 +518,7 @@ impl<T: SeamTypes> Drop for Engine<T> {
 mod tests {
     use super::*;
 
+    use crate::seams::UnixMillis;
     use crate::testkit::{FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
 
     fn new_engine() -> (Engine<FakeSeamTypes>, EventStream) {
@@ -529,8 +530,17 @@ mod tests {
         )
     }
 
-    fn started_engine(secret_byte: u8) -> Engine<FakeSeamTypes> {
-        let (mut engine, _events) = new_engine();
+    /// Starts an engine whose virtual clock sits at `clock` before `start`, so
+    /// tests can prove derivation is independent of the wall time at boot.
+    fn started_engine_at(secret_byte: u8, clock: UnixMillis) -> Engine<FakeSeamTypes> {
+        let world = FakeWorld::new();
+        world.scheduler.advance_to(clock);
+        let device = world.device(b"alice-pk");
+        let (mut engine, _events) = Engine::new(
+            device.seam_set(),
+            Box::new(SeededEntropy::new(42)),
+            SyncTimingProfile::CI,
+        );
         block_on(engine.start(LoginSecret::new(vec![secret_byte; 32]))).unwrap();
         engine
     }
@@ -572,15 +582,16 @@ mod tests {
 
     #[test]
     fn cold_start_derivation_is_deterministic_and_clock_independent() {
-        // Two engines over independent virtual clocks derive the same identity
-        // from the same secret: `start` reads no clock or RNG, only the seed.
-        let a = started_engine(7);
-        let b = started_engine(7);
+        // Two engines whose virtual clocks sit at different instants derive the
+        // same identity from the same secret: `start` reads no clock or RNG,
+        // only the seed.
+        let a = started_engine_at(7, UnixMillis(0));
+        let b = started_engine_at(7, UnixMillis(1_000_000));
         assert_eq!(
             a.session().unwrap().enc_subkey_public().to_bytes(),
             b.session().unwrap().enc_subkey_public().to_bytes(),
         );
-        let c = started_engine(8);
+        let c = started_engine_at(8, UnixMillis(2_000_000));
         assert_ne!(
             a.session().unwrap().enc_subkey_public().to_bytes(),
             c.session().unwrap().enc_subkey_public().to_bytes(),

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -37,6 +37,7 @@ pub mod profile;
 pub mod rotation;
 pub mod seams;
 pub mod secret_util;
+mod session;
 pub mod sync;
 #[cfg(feature = "test-kit")]
 pub mod testkit;

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -1,0 +1,246 @@
+//! Cold-start session identity — the seed-derived signing and sealing identity
+//! assembled once at [`Engine::start`](crate::facade::Engine::start).
+//!
+//! The cold-start sequence begins by deriving, as a pure function of the login
+//! secret, the owner-plane identity that needs no network: the encryption
+//! subkey, the owner pointer seed, and the vault-pointer signer chain
+//! (blueprint/engine.md "Pointer planes"; CONTEXT.md "Vault pointer", "Scope
+//! pointer", "Encryption subkey"). Per-scope read/write material and the
+//! per-name write-plane signers layer on top through the factory methods here,
+//! fed the scope seeds the resolve/gate path unseals later — this module owns
+//! the derivation edges, the resolve slices (#745/#746) and the liveness
+//! composition (#750/#751) own the inputs.
+//!
+//! Every derivation composes `crates/core`'s frozen KDF edge catalog
+//! ([`cipherbox_core::kdf`]); nothing here derives a key of its own. The whole
+//! type is a pure function of the injected secret — no clock, no RNG — so the
+//! same secret always yields the same identity (the determinism a cold-start
+//! test pins). Secret material lives in zeroizing owners and is redacted from
+//! `Debug`; the login secret is retained in engine memory only, because the
+//! vault-pointer chain is index-probed at runtime (cold start and per tick,
+//! CONTEXT.md "Vault pointer") and cannot be fully pre-derived.
+
+use core::fmt;
+
+use cipherbox_core::kdf;
+use cipherbox_core::suite::ed25519::Ed25519Signer;
+use cipherbox_core::suite::secret::SecretBytes;
+use cipherbox_core::suite::x25519::{X25519Public, X25519Secret};
+use zeroize::Zeroizing;
+
+use crate::facade::LoginSecret;
+
+/// The session's seed-derived identity — the single place derived key material
+/// lives once the engine is live.
+///
+/// Constructed by [`SessionIdentity::derive`] at cold start and held by the
+/// engine for the session's lifetime. Public-key accessors are `pub`; the
+/// signer/seal factories that return secret-bearing material are `pub(crate)`,
+/// reachable only by the in-crate pipeline (resolve, publish, rotation, the
+/// liveness loop) — hosts wrap the facade and never hold signers.
+// The factory surface is the hook the deferred slices consume (resolve
+// #745/#746, liveness composition #750/#751, rotation); `derive` is live at
+// cold start now, the readers of each factory land with those slices.
+#[allow(dead_code)]
+pub(crate) struct SessionIdentity {
+    /// The login secret, retained for the runtime vault-pointer index probe.
+    /// Engine memory only: never persisted, never logged, zeroized on drop.
+    login_secret: Zeroizing<Vec<u8>>,
+    /// The user's X25519 encryption subkey (`enc-subkey` edge). Seals only;
+    /// the identity key signs. Zeroizes on drop.
+    enc_subkey: X25519Secret,
+    /// The owner pointer seed (`owner-pointer-seed` edge). Per-scope pointer
+    /// signers and pointer read keys derive from it lazily. Zeroizes on drop.
+    owner_pointer_seed: SecretBytes,
+}
+
+#[allow(dead_code)]
+impl SessionIdentity {
+    /// Derive the cold-start identity from the login secret — a pure function
+    /// of the secret bytes (no clock, no RNG), composing only frozen catalog
+    /// edges. Same secret in, same identity out.
+    pub(crate) fn derive(secret: &LoginSecret) -> Self {
+        let bytes = secret.expose();
+        Self {
+            login_secret: Zeroizing::new(bytes.to_vec()),
+            enc_subkey: kdf::enc_subkey(bytes),
+            owner_pointer_seed: kdf::owner_pointer_seed(bytes),
+        }
+    }
+
+    /// The public half of the encryption subkey — the sealing identity peers
+    /// address. Non-secret; safe to publish and to compare in tests.
+    pub fn enc_subkey_public(&self) -> X25519Public {
+        self.enc_subkey.public()
+    }
+
+    /// The encryption subkey itself — the sealing key the grant/mailbox paths
+    /// use. Secret-bearing, so in-crate only.
+    pub(crate) fn enc_subkey(&self) -> &X25519Secret {
+        &self.enc_subkey
+    }
+
+    /// The `i`-th vault-pointer signer (`vault-pointer-index` edge): the
+    /// per-name Ed25519 signer for the indexed owner re-point chain, index 0
+    /// the default. Probed one past the highest known on cold start and per
+    /// tick (CONTEXT.md "Vault pointer"), so it derives on demand.
+    pub(crate) fn vault_pointer_signer(&self, index: u64) -> Ed25519Signer {
+        kdf::vault_pointer_index(&self.login_secret, index)
+    }
+
+    /// The per-scope pointer signer (`scope-pointer` edge): the owner-keyed
+    /// stable IPNS name a shared scope carries, from the owner pointer seed
+    /// and the scope id.
+    pub(crate) fn scope_pointer_signer(&self, scope_id: &[u8; 16]) -> Ed25519Signer {
+        kdf::scope_pointer(self.owner_pointer_seed.as_bytes(), scope_id)
+    }
+
+    /// The stable per-scope pointer read key (`pointer-read-key` edge) that
+    /// seals a scope's re-point object.
+    pub(crate) fn pointer_read_key(&self, scope_id: &[u8; 16]) -> SecretBytes {
+        kdf::pointer_read_key(self.owner_pointer_seed.as_bytes(), scope_id)
+    }
+
+    /// The per-name write-plane IPNS signer for a node: `writeSeed(node) =
+    /// KDF(writeScopeSeed, node.id)` then the `ipns-keypair` edge. This is the
+    /// per-name `Ed25519Signer` the liveness loop's sub-EOL `seq+1` renewal
+    /// (#750) and the held-set republish (#751) sign with — the resolve/gate
+    /// path supplies the unsealed `write_scope_seed`.
+    pub(crate) fn write_name_signer(
+        &self,
+        write_scope_seed: &[u8; 32],
+        node_id: &[u8; 16],
+    ) -> Ed25519Signer {
+        let write_seed = kdf::write_seed(write_scope_seed, node_id);
+        kdf::ipns_keypair(write_seed.as_bytes())
+    }
+
+    /// The writer-pseudonym signer (`pseudonym-sign` edge): the per-(scope,
+    /// writer) signing keypair the rotator detached-signs re-sealed structures
+    /// with, from the pairwise material (owner root secret or grant ECDH) and
+    /// the scope id.
+    pub(crate) fn writer_pseudonym_signer(
+        &self,
+        pairwise_material: &[u8; 32],
+        scope_id: &[u8; 16],
+    ) -> Ed25519Signer {
+        kdf::pseudonym_sign(pairwise_material, scope_id)
+    }
+}
+
+impl fmt::Debug for SessionIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SessionIdentity(redacted)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity(secret: &[u8]) -> SessionIdentity {
+        SessionIdentity::derive(&LoginSecret::new(secret.to_vec()))
+    }
+
+    #[test]
+    fn derivation_is_a_pure_function_of_the_secret() {
+        let a = identity(&[7u8; 32]);
+        let b = identity(&[7u8; 32]);
+        let scope = [3u8; 16];
+        let node = [4u8; 16];
+        let write_scope_seed = [5u8; 32];
+
+        assert_eq!(
+            a.enc_subkey_public().to_bytes(),
+            b.enc_subkey_public().to_bytes(),
+            "same secret must yield the same enc subkey"
+        );
+        assert_eq!(
+            a.vault_pointer_signer(0).verifying_key().to_bytes(),
+            b.vault_pointer_signer(0).verifying_key().to_bytes(),
+            "same secret must yield the same vault-pointer signer"
+        );
+        assert_eq!(
+            a.scope_pointer_signer(&scope).verifying_key().to_bytes(),
+            b.scope_pointer_signer(&scope).verifying_key().to_bytes(),
+        );
+        assert_eq!(
+            a.pointer_read_key(&scope).as_bytes(),
+            b.pointer_read_key(&scope).as_bytes(),
+        );
+        assert_eq!(
+            a.write_name_signer(&write_scope_seed, &node)
+                .verifying_key()
+                .to_bytes(),
+            b.write_name_signer(&write_scope_seed, &node)
+                .verifying_key()
+                .to_bytes(),
+            "same secret must yield the same per-name write signer",
+        );
+    }
+
+    #[test]
+    fn a_different_secret_yields_a_different_identity() {
+        let a = identity(&[7u8; 32]);
+        let b = identity(&[8u8; 32]);
+
+        assert_ne!(
+            a.enc_subkey_public().to_bytes(),
+            b.enc_subkey_public().to_bytes(),
+        );
+        assert_ne!(
+            a.vault_pointer_signer(0).verifying_key().to_bytes(),
+            b.vault_pointer_signer(0).verifying_key().to_bytes(),
+        );
+        assert_ne!(
+            a.scope_pointer_signer(&[3u8; 16])
+                .verifying_key()
+                .to_bytes(),
+            b.scope_pointer_signer(&[3u8; 16])
+                .verifying_key()
+                .to_bytes(),
+            "the owner-plane scope pointer is keyed off the login secret",
+        );
+    }
+
+    #[test]
+    fn the_vault_pointer_chain_is_indexed() {
+        let id = identity(&[7u8; 32]);
+        assert_ne!(
+            id.vault_pointer_signer(0).verifying_key().to_bytes(),
+            id.vault_pointer_signer(1).verifying_key().to_bytes(),
+            "each index is a distinct name in the chain",
+        );
+    }
+
+    #[test]
+    fn per_name_write_signers_bind_scope_seed_and_node_id() {
+        let id = identity(&[7u8; 32]);
+        let base = id
+            .write_name_signer(&[5u8; 32], &[4u8; 16])
+            .verifying_key()
+            .to_bytes();
+        assert_ne!(
+            base,
+            id.write_name_signer(&[6u8; 32], &[4u8; 16])
+                .verifying_key()
+                .to_bytes(),
+            "a different write scope seed is a different name",
+        );
+        assert_ne!(
+            base,
+            id.write_name_signer(&[5u8; 32], &[9u8; 16])
+                .verifying_key()
+                .to_bytes(),
+            "a different node id is a different name",
+        );
+    }
+
+    #[test]
+    fn debug_is_redacted() {
+        assert_eq!(
+            format!("{:?}", identity(&[7u8; 32])),
+            "SessionIdentity(redacted)"
+        );
+    }
+}

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -137,6 +137,7 @@ impl fmt::Debug for SessionIdentity {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::secret_util::ct_eq_32;
 
     fn identity(secret: &[u8]) -> SessionIdentity {
         SessionIdentity::derive(&LoginSecret::new(secret.to_vec()))
@@ -164,9 +165,12 @@ mod tests {
             a.scope_pointer_signer(&scope).verifying_key().to_bytes(),
             b.scope_pointer_signer(&scope).verifying_key().to_bytes(),
         );
-        assert_eq!(
-            a.pointer_read_key(&scope).as_bytes(),
-            b.pointer_read_key(&scope).as_bytes(),
+        assert!(
+            ct_eq_32(
+                a.pointer_read_key(&scope).as_bytes(),
+                b.pointer_read_key(&scope).as_bytes(),
+            ),
+            "same secret must yield the same pointer read key",
         );
         assert_eq!(
             a.write_name_signer(&write_scope_seed, &node)

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -118,7 +118,10 @@ impl SessionIdentity {
     /// The writer-pseudonym signer (`pseudonym-sign` edge): the per-(scope,
     /// writer) signing keypair the rotator detached-signs re-sealed structures
     /// with, from the pairwise material (owner root secret or grant ECDH) and
-    /// the scope id.
+    /// the scope id. The pairwise material already fully encodes the
+    /// owner/writer identity, so — unlike every sibling factory — this one
+    /// consults no stored session field; its output is keyed solely by its
+    /// arguments.
     pub(crate) fn writer_pseudonym_signer(
         &self,
         pairwise_material: &[u8; 32],
@@ -237,6 +240,38 @@ mod tests {
                 .verifying_key()
                 .to_bytes(),
             "a different node id is a different name",
+        );
+    }
+
+    #[test]
+    fn writer_pseudonym_signer_binds_pairwise_material_and_scope() {
+        let id = identity(&[7u8; 32]);
+        let pairwise = [2u8; 32];
+        let scope = [3u8; 16];
+        let base = id
+            .writer_pseudonym_signer(&pairwise, &scope)
+            .verifying_key()
+            .to_bytes();
+        assert_eq!(
+            base,
+            id.writer_pseudonym_signer(&pairwise, &scope)
+                .verifying_key()
+                .to_bytes(),
+            "same pairwise material and scope must yield the same pseudonym signer",
+        );
+        assert_ne!(
+            base,
+            id.writer_pseudonym_signer(&[9u8; 32], &scope)
+                .verifying_key()
+                .to_bytes(),
+            "different pairwise material is a different pseudonym",
+        );
+        assert_ne!(
+            base,
+            id.writer_pseudonym_signer(&pairwise, &[4u8; 16])
+                .verifying_key()
+                .to_bytes(),
+            "a different scope is a different pseudonym",
         );
     }
 


### PR DESCRIPTION
## What

The foundational slice of the facade cold-start umbrella: `Engine::start` now derives the **session identity** from the injected login secret and holds it as the one place derived key material lives once the engine is live.

Before this, `start` authenticated and spawned the liveness loop but derived nothing — the cold-start sequence was the frozen skeleton. This lands the seed-derived identity the deferred pipeline slices need.

## Cold-start derivation

New crate-private `crates/engine/src/session.rs` — `SessionIdentity`, a **pure function of the login secret** (no clock, no RNG), composing only `crates/core`'s frozen KDF edge catalog:

- `enc_subkey` — the X25519 encryption subkey (seals; the identity key signs).
- `owner_pointer_seed` — the owner-plane pointer seed.
- Signer/key factories over the catalog edges:
  - `vault_pointer_signer(index)` — the per-name Ed25519 signer for the indexed owner re-point chain (probed at runtime per `CONTEXT.md` "Vault pointer").
  - `scope_pointer_signer(scope_id)` / `pointer_read_key(scope_id)` — the owner-keyed pointer plane per scope.
  - `write_name_signer(write_scope_seed, node_id)` — the per-name write-plane IPNS signer (`writeSeed` then the `ipns-keypair` edge); the resolve/gate path feeds it the unsealed scope seed.
  - `writer_pseudonym_signer(pairwise_material, scope_id)` — the rotator's writer pseudonym.

`Engine::start` derives it into `self.session` and drops the secret at its terminal owner immediately after. Secret material lives in zeroizing owners, is redacted from `Debug`, and never leaves engine memory or reaches a log site. The login secret is retained inside the identity (zeroized on drop) only because the vault-pointer chain is index-probed at runtime and cannot be fully pre-derived.

## Session seam / hook boundary

A `pub(crate) Engine::session()` accessor surfaces the identity to the in-crate pipeline. The signer factories are the hook points the deferred dependents consume; hosts wrap the facade and never hold key material.

## Unblocks / defers

- **Unblocks** the per-name `Ed25519Signer`s that #750 (sub-EOL `seq+1` renewal) and #751 (held-set population) need, and the pointer/write signers that #745/#746 (resolver wiring) and the production wiring of #749's cascade layer on.
- **Deferred** (stays tracked, not built here): the rest of the live-session cold-start data path — vault-pointer resolve, floor cold-seed, root adoption, first snapshot event, rehydrate-on-boot — filed as a follow-up blocked-by this umbrella; plus #750 / #751 / #745 / #746 / #749-prod.

## Tests

- `session.rs`: derivation is a pure function of the secret (same seed to same identity across every factory; different seed to a different owner-plane identity), the vault-pointer chain is indexed, per-name write signers bind the scope seed and node id, `Debug` is redacted.
- `facade.rs`: cold start derives and wires the identity (reachable, matches the standalone derivation — `start` invents no key material); derivation is deterministic and clock-independent across two engines on independent virtual clocks (proving `start` reads no clock/RNG).

No wire encoding is introduced, so the encode/decode fail-closed symmetry rule has no new surface here.

Part of #752. Tracked in #655.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added deterministic session identity generation during engine startup.
- Added a publicly accessible encryption key for session-based operations.
- Session-derived signing and read keys now support secure, scoped engine workflows.

## Security
- Sensitive session material is cleared from memory when no longer needed.
- Session identity debug output is fully redacted.

## Tests
- Added coverage for deterministic derivation, secret separation, scoped key binding, and secure debug behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->