### PR TITLE
feat(engine): compose the cold-start live-session data path

### DIFF
--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -500,16 +500,21 @@ impl<T: SeamTypes> Engine<T> {
         Pf: PointerFetch,
         Ad: Adopter,
     {
+        // Precondition guard fails fast before any seam I/O, so an unstarted
+        // engine returns `NotStarted` rather than misclassifying a staging-store
+        // failure as retryable `Seam`.
+        let session = self.session.as_ref().ok_or(ColdStartError::NotStarted)?;
         let raw = self
             .seams
             .staging_store
             .queued_ops()
             .await
             .map_err(ColdStartError::Seam)?;
+        // `_undecodable` dead-letters are dropped here; surfacing them (and
+        // replay dead-letters) as `Event::DeadLetter` on boot is deferred to #768.
         let (decoded, _undecodable) = decode_queue(&raw);
         let pending: Vec<_> = decoded.into_iter().map(|(_id, op)| op).collect();
 
-        let session = self.session.as_ref().ok_or(ColdStartError::NotStarted)?;
         let params = ColdStartParams {
             login_secret: session.login_secret(),
             owner_identity,
@@ -902,6 +907,31 @@ mod tests {
         #[test]
         fn before_start_returns_not_started_not_panic() {
             let (mut engine, _events) = new_engine();
+            assert!(engine.session().is_none(), "no identity before start");
+            let out = block_on(engine.cold_start_data_path(
+                &ScriptedPointers::default(),
+                &AdoptingAdopter,
+                &owner().verifying_key(),
+                ROOT_SCOPE,
+                VERSION,
+                NodeId([0xAB; 16]),
+            ));
+            assert_eq!(out, Err(ColdStartError::NotStarted));
+        }
+
+        #[test]
+        fn unstarted_engine_reports_not_started_even_when_staging_store_fails() {
+            // Precondition guard must run before the staging read, so a failing
+            // seam on an unstarted engine still classifies as `NotStarted`, not
+            // a retryable `Seam`.
+            let world = FakeWorld::new();
+            let device = world.device(b"alice-pk");
+            device.staging_store.fail_queued_ops();
+            let (mut engine, _events) = Engine::new(
+                device.seam_set(),
+                Box::new(SeededEntropy::new(42)),
+                SyncTimingProfile::CI,
+            );
             assert!(engine.session().is_none(), "no identity before start");
             let out = block_on(engine.cold_start_data_path(
                 &ScriptedPointers::default(),

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -19,15 +19,21 @@ use core::fmt;
 use core::pin::Pin;
 use std::rc::Rc;
 
+use cipherbox_core::suite::ecdsa::EcdsaVerifier;
 use futures_channel::mpsc;
 use futures_core::Stream;
 use zeroize::Zeroizing;
 
 use crate::entropy::Entropy;
-use crate::net::{HeldRecord, LivenessControl, RE_PUT_INTERVAL, keyless_re_put, run_liveness_loop};
+use crate::net::{
+    Adopter, HeldRecord, LivenessControl, RE_PUT_INTERVAL, keyless_re_put, run_liveness_loop,
+};
 use crate::profile::SyncTimingProfile;
-use crate::seams::{OpId, Scheduler, SeamSet, SeamTypes};
+use crate::seams::{OpId, Scheduler, SeamSet, SeamTypes, StagingStore};
 use crate::session::SessionIdentity;
+use crate::sync::boot::{ColdStartError, ColdStartOutcome, ColdStartParams, cold_start};
+use crate::sync::pointer::PointerFetch;
+use crate::sync::rebase::decode_queue;
 
 /// The stable 16-byte node identifier (`id16`, blueprint/core.md). Public,
 /// non-secret, and location-independent — routes and commands key on it,
@@ -461,6 +467,76 @@ impl<T: SeamTypes> Engine<T> {
         self.session.as_ref()
     }
 
+    /// Run the cold-start live-session data path — the ordered chain composed on
+    /// top of the derived [`SessionIdentity`] (blueprint/engine.md cold-start
+    /// sequence): vault-pointer resolve → floor cold-seed (fail-closed on
+    /// regression) → current root name adoption through the gate → first
+    /// [`Event::SnapshotUpdated`] with the pending-op overlay, cache-first from
+    /// the snapshot cache.
+    ///
+    /// Reads every seam from the engine, the login secret from
+    /// [`session`](Self::session), and the pending ops from the durable staging
+    /// store; emits no clock/RNG-derived value, so the whole chain is
+    /// deterministic off the injected seams. The record-plane fetchers enter as
+    /// the two seam traits the resolver slices (#745/#746) implement:
+    /// [`PointerFetch`] for the pointer block and [`Adopter`] for the root record.
+    ///
+    /// `owner_identity` is the auth-provided contact-code-anchored identity that
+    /// signs the re-point object — the vault-pointer walk's fail-closed anchor.
+    // Live composition consumed by the facade cold-start test; the resolver slice
+    // (#745/#746) supplies the concrete `PointerFetch`/`Adopter` at the `start`
+    // call site.
+    #[allow(dead_code)]
+    pub(crate) async fn cold_start_data_path<Pf, Ad>(
+        &mut self,
+        pointer_fetch: &Pf,
+        adopter: &Ad,
+        owner_identity: &EcdsaVerifier,
+        root_scope_id: [u8; 16],
+        payload_version: u64,
+        root: NodeId,
+    ) -> Result<ColdStartOutcome, ColdStartError>
+    where
+        Pf: PointerFetch,
+        Ad: Adopter,
+    {
+        let raw = self
+            .seams
+            .staging_store
+            .queued_ops()
+            .await
+            .map_err(ColdStartError::Seam)?;
+        let (decoded, _undecodable) = decode_queue(&raw);
+        let pending: Vec<_> = decoded.into_iter().map(|(_id, op)| op).collect();
+
+        let session = self
+            .session
+            .as_ref()
+            .expect("cold start runs after start derives the session");
+        let params = ColdStartParams {
+            login_secret: session.login_secret(),
+            owner_identity,
+            root_scope_id,
+            payload_version,
+            root,
+            pending_ops: &pending,
+        };
+        let events = self.events.clone();
+        let mut emit = |event: Event| {
+            let _ = events.unbounded_send(event);
+        };
+        cold_start(
+            pointer_fetch,
+            adopter,
+            &self.seams.floor_store,
+            &self.seams.record_transport,
+            &self.seams.snapshot_cache,
+            &params,
+            &mut emit,
+        )
+        .await
+    }
+
     /// Spawn the ~hourly keyless re-PUT loop (blueprint/engine.md "Liveness"):
     /// actively-used vaults keep their own records alive off the injected
     /// scheduler, so no client depends on the API republisher. The task holds
@@ -637,5 +713,193 @@ mod tests {
             "command not implemented yet: create"
         );
         assert_eq!(EngineError::NotStarted.to_string(), "engine not started");
+    }
+
+    // --- cold-start data path composition ---
+
+    mod cold_start {
+        use super::*;
+
+        use std::sync::{Arc, Mutex};
+
+        use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+        use cipherbox_core::kdf;
+        use cipherbox_core::payload::RepointObject;
+        use cipherbox_core::seal::ReadBody;
+        use cipherbox_core::suite::ecdsa::EcdsaSigner;
+        use cipherbox_core::suite::ed25519::Ed25519Signer;
+
+        use crate::gate::Adopted;
+        use crate::seams::{EndpointId, SeamResult};
+        use crate::sync::boot::RootResolve;
+        use crate::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
+        use crate::testkit::FakeDevice;
+
+        const SECRET: &[u8] = b"facade-cold-start-secret-fixture";
+        const ROOT_SCOPE: [u8; 16] = [0u8; 16];
+        const VERSION: u64 = 1;
+
+        fn owner() -> EcdsaSigner {
+            EcdsaSigner::from_scalar(&[3u8; 32]).expect("valid scalar")
+        }
+
+        fn root_signer() -> Ed25519Signer {
+            kdf::ipns_keypair(&[9u8; 32])
+        }
+
+        fn root_name() -> IpnsName {
+            IpnsName::from_public_key(&root_signer().verifying_key())
+        }
+
+        /// A scripted vault-pointer network keyed by the login secret's indexed
+        /// names.
+        #[derive(Clone, Default)]
+        struct ScriptedPointers {
+            blocks: Arc<Mutex<std::collections::HashMap<String, Vec<u8>>>>,
+        }
+
+        impl ScriptedPointers {
+            fn seal_index(&self, index: u64, min_read_epoch: u64, write_epoch: u64) {
+                let read_key =
+                    kdf::pointer_read_key(kdf::owner_pointer_seed(SECRET).as_bytes(), &ROOT_SCOPE);
+                let object = RepointObject {
+                    scope_id: ROOT_SCOPE,
+                    current_root: root_name(),
+                    write_epoch,
+                    min_read_epoch,
+                    prev_root: None,
+                };
+                let mut entropy = SeededEntropy::new(index);
+                let block = seal_repoint(
+                    SessionRole::Owner,
+                    &mut entropy,
+                    read_key.as_bytes(),
+                    VERSION,
+                    &owner(),
+                    &object,
+                )
+                .unwrap();
+                self.blocks
+                    .lock()
+                    .unwrap()
+                    .insert(vault_pointer_name(SECRET, index).as_str().to_owned(), block);
+            }
+        }
+
+        impl PointerFetch for ScriptedPointers {
+            async fn fetch(&self, name: &IpnsName) -> SeamResult<Option<Vec<u8>>> {
+                Ok(self.blocks.lock().unwrap().get(name.as_str()).cloned())
+            }
+        }
+
+        #[derive(Clone)]
+        struct AdoptingAdopter;
+
+        impl Adopter for AdoptingAdopter {
+            async fn adopt(
+                &self,
+                _name: &IpnsName,
+                _record_bytes: &[u8],
+            ) -> Result<Adopted, crate::gate::GateError> {
+                Ok(Adopted {
+                    read_body: ReadBody::Folder {
+                        created_at: 0,
+                        modified_at: 0,
+                        children: Vec::new(),
+                        unknown: Vec::new(),
+                    },
+                    sequence: 1,
+                    epoch: 1,
+                })
+            }
+        }
+
+        /// Seed a valid signed IPNS record at the root name across the device's
+        /// endpoints so the gated resolve fetches a record to adopt.
+        fn seed_root_record(device: &FakeDevice) {
+            let record = IpnsRecord::create_v2(
+                &root_signer(),
+                b"/ipfs/bafyrootmeta",
+                1,
+                0,
+                "2099-01-01T00:00:00Z",
+            )
+            .marshal();
+            for endpoint in [
+                EndpointId::new("fake:someguy"),
+                EndpointId::new("fake:public-routing"),
+            ] {
+                device
+                    .record_store
+                    .seed_record(&endpoint, root_name().as_str(), record.clone());
+            }
+        }
+
+        /// A started engine on a world whose clock sits at `clock`, with a valid
+        /// vault pointer and root record already published.
+        fn started_at(clock: UnixMillis) -> (Engine<FakeSeamTypes>, EventStream, ScriptedPointers) {
+            let world = FakeWorld::new();
+            world.scheduler.advance_to(clock);
+            let device = world.device(b"alice-pk");
+            seed_root_record(&device);
+            let (mut engine, events) = Engine::new(
+                device.seam_set(),
+                Box::new(SeededEntropy::new(42)),
+                SyncTimingProfile::CI,
+            );
+            block_on(engine.start(LoginSecret::new(SECRET.to_vec()))).unwrap();
+            let pointers = ScriptedPointers::default();
+            pointers.seal_index(0, 1, 1);
+            pointers.seal_index(1, 3, 2);
+            (engine, events, pointers)
+        }
+
+        fn drive(
+            engine: &mut Engine<FakeSeamTypes>,
+            pointers: &ScriptedPointers,
+        ) -> ColdStartOutcome {
+            block_on(engine.cold_start_data_path(
+                pointers,
+                &AdoptingAdopter,
+                &owner().verifying_key(),
+                ROOT_SCOPE,
+                VERSION,
+                NodeId([0xAB; 16]),
+            ))
+            .unwrap()
+        }
+
+        #[test]
+        fn runs_the_full_sequence_and_emits_on_the_event_stream() {
+            let (mut engine, mut events, pointers) = started_at(UnixMillis(123_456));
+            let outcome = drive(&mut engine, &pointers);
+
+            assert_eq!(
+                outcome.vault_pointer.unwrap().index,
+                1,
+                "highest valid index"
+            );
+            assert_eq!(outcome.root_resolve, Some(RootResolve::Adopted));
+            // Floors seeded from the owner-vouched re-point.
+            assert_eq!(
+                block_on(crate::gate::floor::read_epoch_floor(
+                    &engine.seams.floor_store,
+                    &ROOT_SCOPE
+                ))
+                .unwrap(),
+                Some(3)
+            );
+            // The first snapshot event reached the host's stream.
+            assert_eq!(block_on(events.next()), Some(Event::SnapshotUpdated));
+        }
+
+        #[test]
+        fn reads_no_clock_two_engines_on_independent_clocks_agree() {
+            let (mut a, _ea, pa) = started_at(UnixMillis(0));
+            let (mut b, _eb, pb) = started_at(UnixMillis(5_000_000));
+            // The data path is a pure function of the seams + session: the two
+            // outcomes match despite the engines' clocks sitting far apart.
+            assert_eq!(drive(&mut a, &pa), drive(&mut b, &pb));
+        }
     }
 }

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -509,10 +509,7 @@ impl<T: SeamTypes> Engine<T> {
         let (decoded, _undecodable) = decode_queue(&raw);
         let pending: Vec<_> = decoded.into_iter().map(|(_id, op)| op).collect();
 
-        let session = self
-            .session
-            .as_ref()
-            .expect("cold start runs after start derives the session");
+        let session = self.session.as_ref().ok_or(ColdStartError::NotStarted)?;
         let params = ColdStartParams {
             login_secret: session.login_secret(),
             owner_identity,
@@ -900,6 +897,21 @@ mod tests {
             // The data path is a pure function of the seams + session: the two
             // outcomes match despite the engines' clocks sitting far apart.
             assert_eq!(drive(&mut a, &pa), drive(&mut b, &pb));
+        }
+
+        #[test]
+        fn before_start_returns_not_started_not_panic() {
+            let (mut engine, _events) = new_engine();
+            assert!(engine.session().is_none(), "no identity before start");
+            let out = block_on(engine.cold_start_data_path(
+                &ScriptedPointers::default(),
+                &AdoptingAdopter,
+                &owner().verifying_key(),
+                ROOT_SCOPE,
+                VERSION,
+                NodeId([0xAB; 16]),
+            ));
+            assert_eq!(out, Err(ColdStartError::NotStarted));
         }
     }
 }

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -30,7 +30,74 @@
 
 use cipherbox_core::payload::RepointObject;
 
-use crate::seams::{FloorRaise, FloorStore, SeamResult};
+use crate::seams::{FloorRaise, FloorStore, SeamError, SeamResult};
+
+/// An owner-vouched epoch that regressed below a durable floor at cold-seed — a
+/// rolled-back re-point object, a fail-closed trust violation and never mere
+/// staleness (the floor law: revocation boundaries cannot be rolled back).
+///
+/// The comparison is sound at the vault/root anchor: the root scope's read
+/// epoch is authored only by the owner (no grantee rotation advances the
+/// envelope read epoch past `minReadEpoch` there), so `min_read_epoch` and the
+/// durable read-epoch floor share the owner's authorship, and `write_epoch` is
+/// owner-vouched and never unseal-advanced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FloorRegression {
+    /// The re-point's `minReadEpoch` is strictly below the durable read-epoch
+    /// (revocation) floor — an attempt to roll back a revocation boundary.
+    ReadEpoch {
+        /// The durable read-epoch floor.
+        floor: u64,
+        /// The re-point's owner-vouched `minReadEpoch`.
+        vouched: u64,
+    },
+    /// The re-point's `writeEpoch` is strictly below the durable write-epoch
+    /// floor — a rolled-back owner-vouched write clock.
+    WriteEpoch {
+        /// The durable write-epoch floor.
+        floor: u64,
+        /// The re-point's owner-vouched `writeEpoch`.
+        vouched: u64,
+    },
+}
+
+impl core::fmt::Display for FloorRegression {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            FloorRegression::ReadEpoch { floor, vouched } => write!(
+                f,
+                "read-epoch floor regression: vouched {vouched} below durable floor {floor}"
+            ),
+            FloorRegression::WriteEpoch { floor, vouched } => write!(
+                f,
+                "write-epoch floor regression: vouched {vouched} below durable floor {floor}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FloorRegression {}
+
+/// A cold-seed failure: a host floor-store I/O error (availability), or a
+/// fail-closed [`FloorRegression`] (a trust violation).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ColdSeedError {
+    /// A [`FloorStore`] seam failure — host I/O, retryable, never a trust verdict.
+    Seam(SeamError),
+    /// A fail-closed floor regression.
+    Regression(FloorRegression),
+}
+
+impl core::fmt::Display for ColdSeedError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ColdSeedError::Seam(e) => write!(f, "{e}"),
+            ColdSeedError::Regression(r) => write!(f, "{r}"),
+        }
+    }
+}
+
+impl std::error::Error for ColdSeedError {}
 
 /// Suffix that distinguishes a scope's write-epoch floor key from its
 /// read-epoch floor key inside the [`FloorStore`] epoch namespace. The
@@ -134,6 +201,50 @@ pub async fn cold_seed<F: FloorStore>(floors: &F, repoint: &RepointObject) -> Se
     Ok(())
 }
 
+/// Cold-seed a scope's floors **fail-closed on regression** (the floor law).
+///
+/// Reads the durable read- and write-epoch floors and rejects before any write
+/// if the owner-vouched re-point would move either backward: a re-point whose
+/// `minReadEpoch` or `writeEpoch` is strictly below the durable floor is a
+/// rolled-back pointer (a replay past a revocation boundary), a trust violation
+/// never mere staleness. Only when neither regresses does it advance the floors
+/// via the monotonic-max [`cold_seed`].
+///
+/// The single-writer engine reads the floors and advances them with no
+/// concurrent adopt in between (blueprint/engine.md "Facade" — one live
+/// instance), so the check-then-advance is not a CAS pair; the monotonic-max
+/// store is the backstop either way.
+pub async fn cold_seed_checked<F: FloorStore>(
+    floors: &F,
+    repoint: &RepointObject,
+) -> Result<(), ColdSeedError> {
+    if let Some(floor) = read_epoch_floor(floors, &repoint.scope_id)
+        .await
+        .map_err(ColdSeedError::Seam)?
+    {
+        if repoint.min_read_epoch < floor {
+            return Err(ColdSeedError::Regression(FloorRegression::ReadEpoch {
+                floor,
+                vouched: repoint.min_read_epoch,
+            }));
+        }
+    }
+    if let Some(floor) = write_epoch_floor(floors, &repoint.scope_id)
+        .await
+        .map_err(ColdSeedError::Seam)?
+    {
+        if repoint.write_epoch < floor {
+            return Err(ColdSeedError::Regression(FloorRegression::WriteEpoch {
+                floor,
+                vouched: repoint.write_epoch,
+            }));
+        }
+    }
+    cold_seed(floors, repoint)
+        .await
+        .map_err(ColdSeedError::Seam)
+}
+
 /// Advance the write-epoch floor on sight of an owner-vouched pointer
 /// `writeEpoch`. Monotonic-max: a value at or below the durable floor is a
 /// no-op that reports the stored floor. Returns the resulting floor.
@@ -172,6 +283,82 @@ mod tests {
                 .unwrap();
             assert_eq!(sequence_floor(&floors, NAME).await.unwrap(), Some(5));
             assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(3));
+        });
+    }
+
+    fn repoint(scope_id: [u8; 16], min_read_epoch: u64, write_epoch: u64) -> RepointObject {
+        use cipherbox_core::ipns::IpnsName;
+        use cipherbox_core::kdf;
+        RepointObject {
+            scope_id,
+            current_root: IpnsName::from_public_key(
+                &kdf::vault_pointer_index(b"root", 0).verifying_key(),
+            ),
+            write_epoch,
+            min_read_epoch,
+            prev_root: None,
+        }
+    }
+
+    #[test]
+    fn cold_seed_checked_seeds_a_fresh_scope_then_is_monotonic() {
+        let floors = InMemoryFloorStore::default();
+        block_on(async {
+            // A fresh (unseeded) scope adopts the owner-vouched anchor.
+            cold_seed_checked(&floors, &repoint(SCOPE, 5, 3))
+                .await
+                .unwrap();
+            assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(5));
+            assert_eq!(write_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(3));
+            // Re-seeding at or above the floor advances monotonically.
+            cold_seed_checked(&floors, &repoint(SCOPE, 7, 3))
+                .await
+                .unwrap();
+            assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(7));
+        });
+    }
+
+    #[test]
+    fn cold_seed_checked_rejects_a_read_epoch_regression_fail_closed() {
+        let floors = InMemoryFloorStore::default();
+        block_on(async {
+            cold_seed_checked(&floors, &repoint(SCOPE, 5, 3))
+                .await
+                .unwrap();
+            // A rolled-back re-point vouching a lower minReadEpoch is fail-closed.
+            let err = cold_seed_checked(&floors, &repoint(SCOPE, 4, 3))
+                .await
+                .expect_err("read-epoch regression is a trust violation");
+            assert_eq!(
+                err,
+                ColdSeedError::Regression(FloorRegression::ReadEpoch {
+                    floor: 5,
+                    vouched: 4
+                })
+            );
+            // The durable floor is untouched by the rejected seed.
+            assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(5));
+        });
+    }
+
+    #[test]
+    fn cold_seed_checked_rejects_a_write_epoch_regression_fail_closed() {
+        let floors = InMemoryFloorStore::default();
+        block_on(async {
+            cold_seed_checked(&floors, &repoint(SCOPE, 5, 6))
+                .await
+                .unwrap();
+            let err = cold_seed_checked(&floors, &repoint(SCOPE, 5, 4))
+                .await
+                .expect_err("write-epoch regression is a trust violation");
+            assert_eq!(
+                err,
+                ColdSeedError::Regression(FloorRegression::WriteEpoch {
+                    floor: 6,
+                    vouched: 4
+                })
+            );
+            assert_eq!(write_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(6));
         });
     }
 

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -74,6 +74,14 @@ impl SessionIdentity {
         self.enc_subkey.public()
     }
 
+    /// The retained login secret, for the runtime vault-pointer index probe
+    /// (cold start and per tick). Owner-plane name/read-key derivation happens
+    /// inside the pointer walk, which needs the raw secret; secret-bearing, so
+    /// in-crate only.
+    pub(crate) fn login_secret(&self) -> &[u8] {
+        &self.login_secret
+    }
+
     /// The encryption subkey itself — the sealing key the grant/mailbox paths
     /// use. Secret-bearing, so in-crate only.
     pub(crate) fn enc_subkey(&self) -> &X25519Secret {

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -55,9 +55,10 @@ pub struct ColdStartParams<'a> {
     pub pending_ops: &'a [Op],
 }
 
-/// A fail-closed cold-start failure. Only [`ColdStartError::Seam`] is
-/// availability (retryable host I/O); every other arm is a trust violation the
-/// engine never renders past.
+/// A fail-closed cold-start failure. [`ColdStartError::Seam`] is availability
+/// (retryable host I/O) and [`ColdStartError::NotStarted`] is a caller-ordering
+/// precondition; every other arm is a trust violation the engine never renders
+/// past.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ColdStartError {
     /// The vault-pointer walk hit a forged/tampered index — fail-closed.
@@ -70,6 +71,10 @@ pub enum ColdStartError {
     /// A host seam failure (floor store, snapshot cache, transport) — not a
     /// trust decision.
     Seam(SeamError),
+    /// Cold start was invoked before `start` derived the session identity — a
+    /// caller-ordering precondition, mirroring `EngineError::NotStarted` rather
+    /// than panicking.
+    NotStarted,
 }
 
 impl core::fmt::Display for ColdStartError {
@@ -79,6 +84,7 @@ impl core::fmt::Display for ColdStartError {
             ColdStartError::FloorRegression(r) => write!(f, "{r}"),
             ColdStartError::RootAdoption(r) => write!(f, "{r}"),
             ColdStartError::Seam(e) => write!(f, "{e}"),
+            ColdStartError::NotStarted => f.write_str("engine not started"),
         }
     }
 }

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -1,0 +1,572 @@
+//! The cold-start live-session data path — the ordered chain composed on top of
+//! the seed-derived session identity (blueprint/engine.md "Adoption gate and
+//! floors", "Pointer planes"; CONTEXT.md "Vault pointer", "Floor law",
+//! "Re-point object").
+//!
+//! The non-circular cold-start sequence (#38 D3): own vault → scope/vault
+//! pointer (first act) → floors seeded → current root name → envelope grant
+//! blob → seeds → render. This module composes that chain as a **pure
+//! orchestration over the seam traits** — it derives no key material and defines
+//! no crypto: the vault-pointer walk ([`resolve_vault_pointer`]), the floor law
+//! ([`floor::cold_seed_checked`]), and the gated resolve ([`net::resolve`]) are
+//! the machinery it sequences. Determinism is preserved: no clock and no RNG are
+//! read here — the entire chain is a function of the injected seams plus the
+//! session inputs, so two engines on independent virtual clocks agree.
+//!
+//! The record-plane fetchers are the two seam traits the resolver slices
+//! (#745/#746) implement against the content plane:
+//! [`PointerFetch`](crate::sync::PointerFetch) fronts the vault-pointer block
+//! resolve, and [`Adopter`](crate::net::Adopter) fronts the root-record
+//! candidate assembly and the adoption gate. This slice owns the sequencing and
+//! the fail-closed points; the concrete fetchers plug in behind these traits.
+
+use cipherbox_core::suite::ecdsa::EcdsaVerifier;
+
+use crate::facade::{Event, NodeId};
+use crate::gate::GateRejection;
+use crate::gate::floor::{self, ColdSeedError, FloorRegression};
+use crate::net::{Adopter, ResolveOutcome, resolve};
+use crate::seams::{FloorStore, RecordTransport, SeamError, SnapshotCache};
+use crate::sync::model::Snapshot;
+use crate::sync::op::Op;
+use crate::sync::overlay::apply_overlay;
+use crate::sync::pointer::{
+    PointerError, PointerFetch, VaultPointerAdoption, resolve_vault_pointer,
+};
+
+/// The session inputs the cold-start chain needs, all read from the derived
+/// [`SessionIdentity`](crate::session::SessionIdentity) and the auth-provided
+/// owner identity — never re-derived here.
+pub struct ColdStartParams<'a> {
+    /// The login secret, for the runtime vault-pointer index probe (owner-plane
+    /// name derivation happens inside the pointer walk).
+    pub login_secret: &'a [u8],
+    /// The contact-code-anchored owner identity that signs the re-point object
+    /// (from auth; the vault-pointer walk's fail-closed verify anchor).
+    pub owner_identity: &'a EcdsaVerifier,
+    /// The root scope id (the vault's own scope) — the floor key and the
+    /// pointer-read-key binding.
+    pub root_scope_id: [u8; 16],
+    /// The re-point payload wire version the walk verifies against.
+    pub payload_version: u64,
+    /// The vault root node id, anchoring the rendered snapshot.
+    pub root: NodeId,
+    /// The durable pending-op queue, applied as the overlay on first paint.
+    pub pending_ops: &'a [Op],
+}
+
+/// A fail-closed cold-start failure. Only [`ColdStartError::Seam`] is
+/// availability (retryable host I/O); every other arm is a trust violation the
+/// engine never renders past.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ColdStartError {
+    /// The vault-pointer walk hit a forged/tampered index — fail-closed.
+    VaultPointer(PointerError),
+    /// The owner-vouched re-point regressed a durable floor — a rolled-back
+    /// pointer, fail-closed (the floor law).
+    FloorRegression(FloorRegression),
+    /// The current root record failed the adoption gate — fail-closed.
+    RootAdoption(GateRejection),
+    /// A host seam failure (floor store, snapshot cache, transport) — not a
+    /// trust decision.
+    Seam(SeamError),
+}
+
+impl core::fmt::Display for ColdStartError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ColdStartError::VaultPointer(e) => write!(f, "vault-pointer resolve failed: {e:?}"),
+            ColdStartError::FloorRegression(r) => write!(f, "{r}"),
+            ColdStartError::RootAdoption(r) => write!(f, "{r}"),
+            ColdStartError::Seam(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for ColdStartError {}
+
+/// The gate verdict on the current root record, once a vault pointer was adopted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RootResolve {
+    /// A gate-passing record was adopted (its bytes are the new last-known-good).
+    Adopted,
+    /// No newer record than the cached last-known-good (availability staleness).
+    NoUpdate,
+}
+
+/// What the cold-start data path produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColdStartOutcome {
+    /// The adopted vault pointer, or `None` on an empty chain (a first-run vault
+    /// with no pointer yet — cold start adopts nothing).
+    pub vault_pointer: Option<VaultPointerAdoption>,
+    /// The current-root gate verdict, or `None` when no pointer was adopted.
+    pub root_resolve: Option<RootResolve>,
+    /// Whether cache-first rehydrate found last-known-good for the current root.
+    pub rehydrated: bool,
+    /// The rendered view emitted on the first snapshot event: the gate-passing
+    /// base snapshot with the pending-op overlay applied. The read-body →
+    /// snapshot projection lands with a later slice, so the base is the anchored
+    /// root; the overlay renders the user's pending ops immediately.
+    pub rendered: Snapshot,
+}
+
+/// Run the cold-start live-session data path off the injected seams, emitting
+/// the first [`Event::SnapshotUpdated`]. Fail-closed at every trust boundary:
+/// a forged vault-pointer index, an owner-vouched floor regression, and an
+/// adoption-gate rejection all return `Err` — never silent staleness.
+///
+/// Reads no clock and no RNG: the sequence is a pure function of the injected
+/// seams and the [`ColdStartParams`], so a deterministic virtual-time test pins
+/// it and two engines on independent clocks produce the identical outcome.
+pub async fn cold_start<Pf, Ad, Fl, T, Sc>(
+    pointer_fetch: &Pf,
+    adopter: &Ad,
+    floors: &Fl,
+    transport: &T,
+    snapshot_cache: &Sc,
+    params: &ColdStartParams<'_>,
+    emit: &mut dyn FnMut(Event),
+) -> Result<ColdStartOutcome, ColdStartError>
+where
+    Pf: PointerFetch,
+    Ad: Adopter,
+    Fl: FloorStore,
+    T: RecordTransport,
+    Sc: SnapshotCache,
+{
+    // Step 1 — vault-pointer resolve (the first act): probe one past the highest
+    // known index and adopt the highest valid owner-signed payload. A forged
+    // index is fail-closed inside the walk.
+    let adoption = resolve_vault_pointer(
+        pointer_fetch,
+        params.login_secret,
+        params.owner_identity,
+        &params.root_scope_id,
+        params.payload_version,
+    )
+    .await
+    .map_err(ColdStartError::VaultPointer)?;
+
+    let base = Snapshot::new(params.root);
+    let Some(adoption) = adoption else {
+        // Empty chain: a first-run vault with no pointer yet. Cold start adopts
+        // nothing (no floor seeds, no root), but the empty base ⊕ overlay still
+        // paints so pending ops render.
+        let rendered = apply_overlay(&base, params.pending_ops);
+        emit(Event::SnapshotUpdated);
+        return Ok(ColdStartOutcome {
+            vault_pointer: None,
+            root_resolve: None,
+            rehydrated: false,
+            rendered,
+        });
+    };
+
+    // Step 2 — floor cold-seed, fail-closed on regression. The owner-vouched
+    // epochs seed the durable floors; a re-point that would move either floor
+    // backward is a rolled-back pointer, a trust violation.
+    floor::cold_seed_checked(floors, &adoption.repoint)
+        .await
+        .map_err(|e| match e {
+            ColdSeedError::Seam(seam) => ColdStartError::Seam(seam),
+            ColdSeedError::Regression(reg) => ColdStartError::FloorRegression(reg),
+        })?;
+
+    // Step 3 + 5 — current root name adoption through the gated, cache-first
+    // resolve: last-known-good rehydrates the first paint (step 5) while the
+    // fan-out GET + adoption gate reconcile behind it (step 3). Every resolved
+    // record passes the gate; a rejection is fail-closed.
+    let resolved = resolve(
+        transport,
+        snapshot_cache,
+        adopter,
+        &adoption.repoint.current_root,
+    )
+    .await
+    .map_err(ColdStartError::Seam)?;
+    let root_resolve = match resolved.outcome {
+        ResolveOutcome::Adopted(_) => RootResolve::Adopted,
+        ResolveOutcome::NoUpdate => RootResolve::NoUpdate,
+        ResolveOutcome::TrustViolation(rejection) => {
+            return Err(ColdStartError::RootAdoption(rejection));
+        }
+    };
+
+    // Step 4 — first snapshot event with the pending-op overlay applied.
+    let rendered = apply_overlay(&base, params.pending_ops);
+    emit(Event::SnapshotUpdated);
+
+    Ok(ColdStartOutcome {
+        vault_pointer: Some(adoption),
+        root_resolve: Some(root_resolve),
+        rehydrated: resolved.last_known_good.is_some(),
+        rendered,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+    use cipherbox_core::kdf;
+    use cipherbox_core::payload::RepointObject;
+    use cipherbox_core::seal::ReadBody;
+    use cipherbox_core::suite::ecdsa::EcdsaSigner;
+    use cipherbox_core::suite::ed25519::Ed25519Signer;
+
+    use crate::facade::{NodeId, NodeKind};
+    use crate::gate::{Adopted, GateError, GateRejection, GateStage, RejectionReason};
+    use crate::seams::{EndpointId, FloorStore, SeamResult, SnapshotCache};
+    use crate::sync::op::Op;
+    use crate::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
+    use crate::testkit::fakes::{InMemoryFloorStore, InMemoryRecordStore, InMemorySnapshotCache};
+    use crate::testkit::{SeededEntropy, block_on};
+
+    const SECRET: &[u8] = b"cold-start-login-secret-fixture";
+    const ROOT_SCOPE: [u8; 16] = [0u8; 16];
+    const VERSION: u64 = 1;
+
+    fn owner() -> EcdsaSigner {
+        EcdsaSigner::from_scalar(&[3u8; 32]).expect("valid scalar")
+    }
+
+    fn root_id() -> NodeId {
+        NodeId([0xAB; 16])
+    }
+
+    /// A scripted vault-pointer network: names → sealed re-point blocks; unknown
+    /// names are unresolvable (chain gaps).
+    #[derive(Clone, Default)]
+    struct ScriptedPointers {
+        blocks: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+    }
+
+    impl ScriptedPointers {
+        fn seal_index(&self, owner: &EcdsaSigner, index: u64, object: &RepointObject) {
+            let read_key =
+                kdf::pointer_read_key(kdf::owner_pointer_seed(SECRET).as_bytes(), &ROOT_SCOPE);
+            let mut entropy = SeededEntropy::new(index);
+            let block = seal_repoint(
+                SessionRole::Owner,
+                &mut entropy,
+                read_key.as_bytes(),
+                VERSION,
+                owner,
+                object,
+            )
+            .unwrap();
+            self.blocks
+                .lock()
+                .unwrap()
+                .insert(vault_pointer_name(SECRET, index).as_str().to_owned(), block);
+        }
+    }
+
+    impl PointerFetch for ScriptedPointers {
+        async fn fetch(&self, name: &IpnsName) -> SeamResult<Option<Vec<u8>>> {
+            Ok(self.blocks.lock().unwrap().get(name.as_str()).cloned())
+        }
+    }
+
+    /// A scripted adopter: returns the configured gate verdict for any record.
+    #[derive(Clone)]
+    struct ScriptedAdopter {
+        verdict: Arc<Mutex<Result<Adopted, GateError>>>,
+    }
+
+    impl ScriptedAdopter {
+        fn adopting() -> Self {
+            Self {
+                verdict: Arc::new(Mutex::new(Ok(Adopted {
+                    read_body: ReadBody::Folder {
+                        created_at: 0,
+                        modified_at: 0,
+                        children: Vec::new(),
+                        unknown: Vec::new(),
+                    },
+                    sequence: 1,
+                    epoch: 1,
+                }))),
+            }
+        }
+
+        fn rejecting() -> Self {
+            Self {
+                verdict: Arc::new(Mutex::new(Err(GateError::Rejected(GateRejection {
+                    stage: GateStage::Unseal,
+                    reason: RejectionReason::EpochBelowFloor { floor: 9, epoch: 1 },
+                })))),
+            }
+        }
+    }
+
+    impl Adopter for ScriptedAdopter {
+        async fn adopt(
+            &self,
+            _name: &IpnsName,
+            _record_bytes: &[u8],
+        ) -> Result<Adopted, GateError> {
+            self.verdict.lock().unwrap().clone()
+        }
+    }
+
+    fn root_signer() -> Ed25519Signer {
+        kdf::ipns_keypair(&[9u8; 32])
+    }
+
+    fn repoint(current_root: IpnsName, min_read_epoch: u64, write_epoch: u64) -> RepointObject {
+        RepointObject {
+            scope_id: ROOT_SCOPE,
+            current_root,
+            write_epoch,
+            min_read_epoch,
+            prev_root: None,
+        }
+    }
+
+    /// Two endpoints with a valid signed IPNS record at the root name.
+    fn transport_with_root_record(name: &IpnsName) -> InMemoryRecordStore {
+        let store = InMemoryRecordStore::new(vec![EndpointId::new("e1"), EndpointId::new("e2")]);
+        let record = IpnsRecord::create_v2(
+            &root_signer(),
+            b"/ipfs/bafyrootmetadatacid",
+            1,
+            0,
+            "2099-01-01T00:00:00Z",
+        )
+        .marshal();
+        store.seed_record(&EndpointId::new("e1"), name.as_str(), record);
+        store
+    }
+
+    fn empty_transport() -> InMemoryRecordStore {
+        InMemoryRecordStore::new(vec![EndpointId::new("e1"), EndpointId::new("e2")])
+    }
+
+    fn pending_create() -> Vec<Op> {
+        vec![Op::create(
+            NodeId([1u8; 16]),
+            root_id(),
+            "pending.txt",
+            NodeKind::File,
+            1,
+            None,
+        )]
+    }
+
+    /// Drive `cold_start`, collecting emitted events.
+    async fn run<Pf: PointerFetch, Ad: Adopter, Fl: FloorStore, Sc: SnapshotCache>(
+        pointers: &Pf,
+        adopter: &Ad,
+        floors: &Fl,
+        transport: &InMemoryRecordStore,
+        cache: &Sc,
+        pending: &[Op],
+    ) -> (Result<ColdStartOutcome, ColdStartError>, Vec<Event>) {
+        let events = RefCell::new(Vec::new());
+        let params = ColdStartParams {
+            login_secret: SECRET,
+            owner_identity: &owner().verifying_key(),
+            root_scope_id: ROOT_SCOPE,
+            payload_version: VERSION,
+            root: root_id(),
+            pending_ops: pending,
+        };
+        let out = {
+            let mut emit = |e: Event| events.borrow_mut().push(e);
+            cold_start(
+                pointers, adopter, floors, transport, cache, &params, &mut emit,
+            )
+            .await
+        };
+        (out, events.into_inner())
+    }
+
+    #[test]
+    fn empty_chain_paints_an_overlay_only_snapshot() {
+        block_on(async {
+            let (out, events) = run(
+                &ScriptedPointers::default(),
+                &ScriptedAdopter::adopting(),
+                &InMemoryFloorStore::default(),
+                &empty_transport(),
+                &InMemorySnapshotCache::default(),
+                &pending_create(),
+            )
+            .await;
+            let out = out.unwrap();
+            assert_eq!(out.vault_pointer, None, "no pointer on a first-run vault");
+            assert_eq!(out.root_resolve, None);
+            assert!(!out.rehydrated);
+            assert!(
+                out.rendered.contains(NodeId([1u8; 16])),
+                "the pending create renders over the empty base"
+            );
+            assert_eq!(
+                events,
+                vec![Event::SnapshotUpdated],
+                "first paint still emits"
+            );
+        });
+    }
+
+    #[test]
+    fn adopts_highest_valid_pointer_seeds_floors_and_emits() {
+        block_on(async {
+            let pointers = ScriptedPointers::default();
+            let root_name = IpnsName::from_public_key(&root_signer().verifying_key());
+            // Owner authored indices 0 and 1; the highest valid wins.
+            pointers.seal_index(&owner(), 0, &repoint(root_name.clone(), 1, 1));
+            pointers.seal_index(&owner(), 1, &repoint(root_name.clone(), 3, 2));
+
+            let floors = InMemoryFloorStore::default();
+            let (out, events) = run(
+                &pointers,
+                &ScriptedAdopter::adopting(),
+                &floors,
+                &transport_with_root_record(&root_name),
+                &InMemorySnapshotCache::default(),
+                &pending_create(),
+            )
+            .await;
+            let out = out.unwrap();
+            assert_eq!(out.vault_pointer.unwrap().index, 1, "highest valid index");
+            assert_eq!(out.root_resolve, Some(RootResolve::Adopted));
+            assert_eq!(events, vec![Event::SnapshotUpdated]);
+            // The re-point's owner-vouched epochs seeded the durable floors.
+            assert_eq!(
+                floor::read_epoch_floor(&floors, &ROOT_SCOPE).await.unwrap(),
+                Some(3)
+            );
+            assert_eq!(
+                floor::write_epoch_floor(&floors, &ROOT_SCOPE)
+                    .await
+                    .unwrap(),
+                Some(2)
+            );
+        });
+    }
+
+    #[test]
+    fn rehydrate_on_boot_renders_from_the_snapshot_cache() {
+        block_on(async {
+            let pointers = ScriptedPointers::default();
+            let root_name = IpnsName::from_public_key(&root_signer().verifying_key());
+            pointers.seal_index(&owner(), 0, &repoint(root_name.clone(), 1, 1));
+
+            // Pre-seed last-known-good for the root name: cache-first first paint.
+            let cache = InMemorySnapshotCache::default();
+            cache
+                .put(root_name.as_str().as_bytes(), b"cached-last-known-good")
+                .await
+                .unwrap();
+
+            let (out, events) = run(
+                &pointers,
+                &ScriptedAdopter::adopting(),
+                &InMemoryFloorStore::default(),
+                // No network record: NoUpdate, but the cache still rehydrates.
+                &empty_transport(),
+                &cache,
+                &pending_create(),
+            )
+            .await;
+            let out = out.unwrap();
+            assert!(
+                out.rehydrated,
+                "cache-first rehydrate found last-known-good"
+            );
+            assert_eq!(out.root_resolve, Some(RootResolve::NoUpdate));
+            assert_eq!(events, vec![Event::SnapshotUpdated]);
+        });
+    }
+
+    #[test]
+    fn floor_regression_is_fail_closed_and_emits_nothing() {
+        block_on(async {
+            let pointers = ScriptedPointers::default();
+            let root_name = IpnsName::from_public_key(&root_signer().verifying_key());
+            // The re-point vouches a lower minReadEpoch than the durable floor.
+            pointers.seal_index(&owner(), 0, &repoint(root_name.clone(), 2, 1));
+
+            let floors = InMemoryFloorStore::default();
+            floors.raise_epoch_floor(&ROOT_SCOPE, 5).await.unwrap();
+
+            let (out, events) = run(
+                &pointers,
+                &ScriptedAdopter::adopting(),
+                &floors,
+                &transport_with_root_record(&root_name),
+                &InMemorySnapshotCache::default(),
+                &pending_create(),
+            )
+            .await;
+            assert_eq!(
+                out,
+                Err(ColdStartError::FloorRegression(
+                    FloorRegression::ReadEpoch {
+                        floor: 5,
+                        vouched: 2,
+                    }
+                ))
+            );
+            assert!(events.is_empty(), "a trust violation never paints");
+        });
+    }
+
+    #[test]
+    fn adoption_gate_failure_is_fail_closed_and_emits_nothing() {
+        block_on(async {
+            let pointers = ScriptedPointers::default();
+            let root_name = IpnsName::from_public_key(&root_signer().verifying_key());
+            pointers.seal_index(&owner(), 0, &repoint(root_name.clone(), 1, 1));
+
+            let (out, events) = run(
+                &pointers,
+                &ScriptedAdopter::rejecting(),
+                &InMemoryFloorStore::default(),
+                &transport_with_root_record(&root_name),
+                &InMemorySnapshotCache::default(),
+                &pending_create(),
+            )
+            .await;
+            assert!(
+                matches!(out, Err(ColdStartError::RootAdoption(_))),
+                "a gate rejection is fail-closed, got {out:?}"
+            );
+            assert!(events.is_empty());
+        });
+    }
+
+    #[test]
+    fn a_forged_pointer_index_is_fail_closed() {
+        block_on(async {
+            let pointers = ScriptedPointers::default();
+            let root_name = IpnsName::from_public_key(&root_signer().verifying_key());
+            pointers.seal_index(&owner(), 0, &repoint(root_name.clone(), 1, 1));
+            // Index 1 sealed by a rogue identity: it must not open under the owner.
+            let rogue = EcdsaSigner::from_scalar(&[7u8; 32]).unwrap();
+            pointers.seal_index(&rogue, 1, &repoint(root_name, 9, 9));
+
+            let (out, events) = run(
+                &pointers,
+                &ScriptedAdopter::adopting(),
+                &InMemoryFloorStore::default(),
+                &empty_transport(),
+                &InMemorySnapshotCache::default(),
+                &pending_create(),
+            )
+            .await;
+            assert!(
+                matches!(out, Err(ColdStartError::VaultPointer(_))),
+                "a forged index stops the walk fail-closed, got {out:?}"
+            );
+            assert!(events.is_empty());
+        });
+    }
+}

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -31,6 +31,7 @@
 //! trigger event ([`rebase::ReplayReport::scope_exit_triggers`]); the rotation
 //! primitives themselves land with the rotation slice.
 
+pub mod boot;
 pub mod model;
 pub mod op;
 pub mod overlay;
@@ -40,6 +41,7 @@ pub mod staging;
 pub mod staleness;
 pub mod tick;
 
+pub use boot::{ColdStartError, ColdStartOutcome, ColdStartParams, RootResolve, cold_start};
 pub use model::{Link, NodeMeta, Snapshot, collation_key, suffix_name};
 pub use op::{Op, OpDecodeError, OpKind};
 pub use overlay::apply_overlay;

--- a/crates/engine/src/testkit/fakes/staging_store.rs
+++ b/crates/engine/src/testkit/fakes/staging_store.rs
@@ -3,12 +3,13 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
-use crate::seams::{OpId, SeamResult, StagingStore};
+use crate::seams::{OpId, SeamError, SeamResult, StagingStore};
 
 struct Inner {
     next_op_id: u64,
     ops: Vec<(OpId, Vec<u8>)>,
     staged: BTreeMap<Vec<u8>, Vec<u8>>,
+    fail_queued_ops: bool,
 }
 
 impl Default for Inner {
@@ -17,6 +18,7 @@ impl Default for Inner {
             next_op_id: 1,
             ops: Vec::new(),
             staged: BTreeMap::new(),
+            fail_queued_ops: false,
         }
     }
 }
@@ -26,6 +28,14 @@ impl Default for Inner {
 #[derive(Clone, Default)]
 pub struct InMemoryStagingStore {
     inner: Arc<Mutex<Inner>>,
+}
+
+impl InMemoryStagingStore {
+    /// Makes `queued_ops` return a seam error, so tests can prove a caller's
+    /// precondition guard runs before the staging read.
+    pub fn fail_queued_ops(&self) {
+        self.inner.lock().expect("lock").fail_queued_ops = true;
+    }
 }
 
 impl StagingStore for InMemoryStagingStore {
@@ -38,7 +48,11 @@ impl StagingStore for InMemoryStagingStore {
     }
 
     async fn queued_ops(&self) -> SeamResult<Vec<(OpId, Vec<u8>)>> {
-        Ok(self.inner.lock().expect("lock").ops.clone())
+        let inner = self.inner.lock().expect("lock");
+        if inner.fail_queued_ops {
+            return Err(SeamError::new("queued_ops unavailable"));
+        }
+        Ok(inner.ops.clone())
     }
 
     async fn remove_op(&self, op_id: OpId) -> SeamResult<()> {


### PR DESCRIPTION
## What

Composes the cold-start live-session **data path** into the engine, on top of the seed-derived `SessionIdentity` that #758 landed. Implements the normative ordered chain (`blueprint/engine.md`): own vault → vault pointer (first act) → floors seeded → current root name → first snapshot render, cache-first.

Closes #759. Part of the facade cold-start umbrella #752, tracked in #655. Unblocks the liveness held-set population (#751) and the facade command/read-accessor surface (#748); the concrete record-plane fetchers land with the resolver wiring (#745 / #746).

## The composed sequence

`sync/boot.rs::cold_start` sequences existing machinery — it derives no key material and defines no crypto:

1. **Vault-pointer resolve** — reuses `resolve_vault_pointer` (probe-one-past, adopt the highest valid owner-signed index, forged index fail-closed).
2. **Floor cold-seed, fail-closed on regression** — new `gate::floor::cold_seed_checked` rejects an owner-vouched epoch that would move a durable floor backward (a rolled-back re-point), then advances monotonic-max.
3. **Current root name adoption** — through the gated, cache-first `net::resolve` (fan-out GET + adoption gate); a gate rejection is fail-closed.
4. **First snapshot event** — `Event::SnapshotUpdated` with the pending-op overlay (`apply_overlay`) applied.
5. **Rehydrate-on-boot** — the cache-first last-known-good from `SnapshotCache` feeds the first paint.

`Engine::cold_start_data_path` drives the chain from the engine seams, reading the login secret from `Engine::session()` and the pending ops from the staging store, emitting on the event stream. The two record-plane fetchers enter as the `PointerFetch` and `Adopter` seam traits the resolver slices implement — this slice owns the sequencing and every fail-closed point.

## Fail-closed / determinism

- Forged vault-pointer index, owner-vouched floor regression, and adoption-gate rejection all return `Err` and emit nothing — never silent staleness.
- Reads no clock and no RNG: the whole chain is a pure function of the injected seams. A determinism test drives two engines on independent virtual clocks to the identical outcome.

No codec/decode hard-reject was added (the floor-regression check is a runtime trust comparison, not a wire decode), so the encode/decode symmetry rule adds no encode guard here; no `debug_assert!` is used at any trust boundary.

## Cut point

The read-body → `Snapshot` projection and the concrete network `PointerFetch`/`Adopter` are separate slices (#745 / #746); this PR composes the ordered chain over their seam traits and is fully driven by fakes on virtual time. The emitted first-paint snapshot is the anchored root with the pending-op overlay; per-stage first-paint-vs-reconcile emission lands with the projection slice.

## Tests

Deterministic virtual-time coverage in `sync/boot.rs` and `facade.rs`: highest-valid pointer adoption + floor seeding, floor regression fail-closed, adoption-gate failure fail-closed, forged-index fail-closed, overlay-applied `SnapshotUpdated` emission, cache-first rehydrate, empty-chain first-run paint, and clock independence. Floor-law regression unit tests in `gate/floor.rs`.

Gates: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p cipherbox-engine -p cipherbox-core`, and `cargo build -p cipherbox-wasm --target wasm32-unknown-unknown` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cold-start support to restore the initial session snapshot from queued operations and available state.
  * Added cache-aware startup behavior, including recovery from the latest valid saved state.
  * Added clear startup outcomes for restored, updated, or empty sessions.

* **Bug Fixes**
  * Prevented startup when durable read or write progress would move backward.
  * Added fail-closed handling for invalid or untrusted startup data.
  * Ensured failed startup attempts do not emit partial updates or modify stored progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->