### PR TITLE
docs: retire the v1 staging-tag redeploy note after v1 tag cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,7 @@ The v2 release scheme (normative: `blueprint/deploy.md` in [FSM1/cipher-box-next
 - `release-please.yml` is **dormant during the v2 build** (dispatch-only). Re-engage by restoring its `push: main` trigger when the first v2.0.0 release candidate is ready.
 - The release path writes nothing to PR branches. The v1 preview-bot (`pr-release-preview.yml`), `release-gate.yml`, and `cargo-lock-release-sync.yml` are deleted — do not resurrect the pattern of bot commits on PR branches.
 - Staging deploys are triggered by `staging-*` tags via `tag-staging.yml` (manual dispatch → release-tag assertion → e2e gates → `staging-approval` → tag → `deploy-staging.yml`). Pre-v2.0.0 staging deploys of WIP v2 go via `workflow_dispatch` of `deploy-staging.yml` at a `main` SHA.
-- v1 is frozen: branch `v1` / tag `v1-freeze` at the last released state (`07376d0b`, cipher-box-v0.45.1). No new v1 releases; existing `staging-*` tags remain self-contained v1 redeploys.
+- v1 is frozen: branch `v1` / tag `v1-freeze` at `07376d0b` (cipher-box-v0.45.1). No new v1 releases. Only the final v1 product release `cipher-box-v0.45.2` is retained (until the first v2.0.0 release is cut); all other v1 tags, per-package release tags, and `staging-*` tags have been pruned — v1 will not be redeployed to staging before the v2 cutover.
 
 ## Developer Profile
 


### PR DESCRIPTION
Updates the v1-frozen bullet in AGENTS.md to reflect the v1 tag/release cleanup: all stale v1 tags, per-package release tags, and `staging-*` tags have been pruned; only `cipher-box-v0.45.2`, `v1-freeze`, and the `v1` branch are retained, and v1 will not be redeployed to staging before the v2 cutover. Refs #655