### PR TITLE
feat(engine): surface cold-start undecodable dead-letters

### DIFF
--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -520,18 +520,24 @@ impl<T: SeamTypes> Engine<T> {
         // entry is not re-decoded and re-emitted on every boot (#768). Staged
         // upload bytes live in a separate plane keyed by staging keys — never
         // touched here, so they are retained per the dead-letter contract
-        // (blueprint/engine.md #33 D6). `replay()` does not run on the
-        // cold-start happy path (it composes `apply_overlay`), so `decode_queue`
-        // is the only dead-letter source on boot at this stage.
+        // (blueprint/engine.md #33 D6).
+        //
+        // `DeadLetter` delivery is best-effort over a non-durable in-process
+        // channel, so hosts MUST dedup by `op_id`. Gate the durable removal on a
+        // successful send: a receiver dropped mid-teardown must not silently
+        // purge an unsurfaced entry — preserved, the next boot re-surfaces it.
         for (op_id, _reason) in &undecodable {
-            let _ = self
+            if self
                 .events
-                .unbounded_send(Event::DeadLetter { op_id: *op_id });
-            self.seams
-                .staging_store
-                .remove_op(*op_id)
-                .await
-                .map_err(ColdStartError::Seam)?;
+                .unbounded_send(Event::DeadLetter { op_id: *op_id })
+                .is_ok()
+            {
+                self.seams
+                    .staging_store
+                    .remove_op(*op_id)
+                    .await
+                    .map_err(ColdStartError::Seam)?;
+            }
         }
 
         let params = ColdStartParams {
@@ -1005,6 +1011,25 @@ mod tests {
             // so only the paint event fires — no re-emitted dead-letter.
             drive(&mut engine, &pointers);
             assert_eq!(block_on(events.next()), Some(Event::SnapshotUpdated));
+        }
+
+        #[test]
+        fn dropped_receiver_preserves_unsurfaced_dead_letter_across_a_boot() {
+            let (mut engine, events, pointers) = started_at(UnixMillis(123_456));
+            block_on(engine.seams.staging_store.enqueue_op(b"not-a-valid-op")).expect("enqueue");
+            // Receiver gone mid-teardown: the `DeadLetter` send fails, so the
+            // durable removal is gated off and the entry survives for next boot.
+            drop(events);
+
+            drive(&mut engine, &pointers);
+
+            assert_eq!(
+                block_on(engine.seams.staging_store.queued_ops())
+                    .unwrap()
+                    .len(),
+                1,
+                "an unsurfaced dead-letter is retained when the send fails"
+            );
         }
     }
 }

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -1031,5 +1031,55 @@ mod tests {
                 "an unsurfaced dead-letter is retained when the send fails"
             );
         }
+
+        #[test]
+        fn remove_op_failure_after_send_re_surfaces_the_dead_letter_next_boot() {
+            let (mut engine, mut events, pointers) = started_at(UnixMillis(123_456));
+            block_on(engine.seams.staging_store.enqueue_op(b"not-a-valid-op")).expect("enqueue");
+            // Send lands in the buffer but the durable removal fails: the gated
+            // `?` aborts cold-start with `Seam` before the paint, leaving the op
+            // queued. The receiver stays alive, so the `DeadLetter` is observable.
+            engine.seams.staging_store.fail_remove_op();
+
+            let first = block_on(engine.cold_start_data_path(
+                &pointers,
+                &AdoptingAdopter,
+                &owner().verifying_key(),
+                ROOT_SCOPE,
+                VERSION,
+                NodeId([0xAB; 16]),
+            ));
+            assert!(
+                matches!(first, Err(ColdStartError::Seam(_))),
+                "a failed durable removal aborts cold-start as a retryable Seam error"
+            );
+            assert_eq!(
+                block_on(events.next()),
+                Some(Event::DeadLetter { op_id: OpId(1) })
+            );
+            assert_eq!(
+                block_on(engine.seams.staging_store.queued_ops())
+                    .unwrap()
+                    .len(),
+                1,
+                "a removal failure after a successful send retains the op"
+            );
+
+            // Next boot re-surfaces the same op_id — hosts dedup by it — proving
+            // the best-effort contract holds under a partial seam failure.
+            let second = block_on(engine.cold_start_data_path(
+                &pointers,
+                &AdoptingAdopter,
+                &owner().verifying_key(),
+                ROOT_SCOPE,
+                VERSION,
+                NodeId([0xAB; 16]),
+            ));
+            assert!(matches!(second, Err(ColdStartError::Seam(_))));
+            assert_eq!(
+                block_on(events.next()),
+                Some(Event::DeadLetter { op_id: OpId(1) })
+            );
+        }
     }
 }

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -472,7 +472,9 @@ impl<T: SeamTypes> Engine<T> {
     /// sequence): vault-pointer resolve → floor cold-seed (fail-closed on
     /// regression) → current root name adoption through the gate → first
     /// [`Event::SnapshotUpdated`] with the pending-op overlay, cache-first from
-    /// the snapshot cache.
+    /// the snapshot cache. Any queue entry that fails to decode is surfaced as
+    /// an [`Event::DeadLetter`] and dropped from the durable queue before the
+    /// chain runs, so a corrupt entry is not re-emitted on the next boot.
     ///
     /// Reads every seam from the engine, the login secret from
     /// [`session`](Self::session), and the pending ops from the durable staging
@@ -510,10 +512,27 @@ impl<T: SeamTypes> Engine<T> {
             .queued_ops()
             .await
             .map_err(ColdStartError::Seam)?;
-        // `_undecodable` dead-letters are dropped here; surfacing them (and
-        // replay dead-letters) as `Event::DeadLetter` on boot is deferred to #768.
-        let (decoded, _undecodable) = decode_queue(&raw);
+        let (decoded, undecodable) = decode_queue(&raw);
         let pending: Vec<_> = decoded.into_iter().map(|(_id, op)| op).collect();
+
+        // Surface every undecodable queue entry as `Event::DeadLetter` and drop
+        // its op record from the durable queue so a corrupt/forward-version
+        // entry is not re-decoded and re-emitted on every boot (#768). Staged
+        // upload bytes live in a separate plane keyed by staging keys — never
+        // touched here, so they are retained per the dead-letter contract
+        // (blueprint/engine.md #33 D6). `replay()` does not run on the
+        // cold-start happy path (it composes `apply_overlay`), so `decode_queue`
+        // is the only dead-letter source on boot at this stage.
+        for (op_id, _reason) in &undecodable {
+            let _ = self
+                .events
+                .unbounded_send(Event::DeadLetter { op_id: *op_id });
+            self.seams
+                .staging_store
+                .remove_op(*op_id)
+                .await
+                .map_err(ColdStartError::Seam)?;
+        }
 
         let params = ColdStartParams {
             login_secret: session.login_secret(),
@@ -732,7 +751,7 @@ mod tests {
         use cipherbox_core::suite::ed25519::Ed25519Signer;
 
         use crate::gate::Adopted;
-        use crate::seams::{EndpointId, SeamResult};
+        use crate::seams::{EndpointId, OpId, SeamResult, StagingStore};
         use crate::sync::boot::RootResolve;
         use crate::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
         use crate::testkit::FakeDevice;
@@ -942,6 +961,50 @@ mod tests {
                 NodeId([0xAB; 16]),
             ));
             assert_eq!(out, Err(ColdStartError::NotStarted));
+        }
+
+        #[test]
+        fn undecodable_queue_entry_surfaces_as_dead_letter_on_cold_start() {
+            let (mut engine, mut events, pointers) = started_at(UnixMillis(123_456));
+            // A corrupt op record that `Op::decode` rejects.
+            let op_id = block_on(engine.seams.staging_store.enqueue_op(b"not-a-valid-op"))
+                .expect("enqueue");
+            assert_eq!(op_id, OpId(1));
+
+            drive(&mut engine, &pointers);
+
+            // The dead-letter surfaces on the host stream ahead of the first paint.
+            assert_eq!(
+                block_on(events.next()),
+                Some(Event::DeadLetter { op_id: OpId(1) })
+            );
+            assert_eq!(block_on(events.next()), Some(Event::SnapshotUpdated));
+            // The op record was dropped from the durable queue.
+            assert!(
+                block_on(engine.seams.staging_store.queued_ops())
+                    .unwrap()
+                    .is_empty(),
+                "the dead-lettered op is removed from the durable queue"
+            );
+        }
+
+        #[test]
+        fn dead_lettered_entry_is_not_re_emitted_on_a_second_boot() {
+            let (mut engine, mut events, pointers) = started_at(UnixMillis(123_456));
+            block_on(engine.seams.staging_store.enqueue_op(b"not-a-valid-op")).expect("enqueue");
+
+            // First boot: surfaces the dead-letter, then paints.
+            drive(&mut engine, &pointers);
+            assert_eq!(
+                block_on(events.next()),
+                Some(Event::DeadLetter { op_id: OpId(1) })
+            );
+            assert_eq!(block_on(events.next()), Some(Event::SnapshotUpdated));
+
+            // Second boot over the same durable store: the corrupt entry is gone,
+            // so only the paint event fires — no re-emitted dead-letter.
+            drive(&mut engine, &pointers);
+            assert_eq!(block_on(events.next()), Some(Event::SnapshotUpdated));
         }
     }
 }

--- a/crates/engine/src/testkit/fakes/staging_store.rs
+++ b/crates/engine/src/testkit/fakes/staging_store.rs
@@ -10,6 +10,7 @@ struct Inner {
     ops: Vec<(OpId, Vec<u8>)>,
     staged: BTreeMap<Vec<u8>, Vec<u8>>,
     fail_queued_ops: bool,
+    fail_remove_op: bool,
 }
 
 impl Default for Inner {
@@ -19,6 +20,7 @@ impl Default for Inner {
             ops: Vec::new(),
             staged: BTreeMap::new(),
             fail_queued_ops: false,
+            fail_remove_op: false,
         }
     }
 }
@@ -35,6 +37,13 @@ impl InMemoryStagingStore {
     /// precondition guard runs before the staging read.
     pub fn fail_queued_ops(&self) {
         self.inner.lock().expect("lock").fail_queued_ops = true;
+    }
+
+    /// Makes `remove_op` return a seam error without dropping the record, so
+    /// tests can prove a durable removal that fails after a successful
+    /// dead-letter send leaves the op queued for the next boot.
+    pub fn fail_remove_op(&self) {
+        self.inner.lock().expect("lock").fail_remove_op = true;
     }
 }
 
@@ -56,11 +65,11 @@ impl StagingStore for InMemoryStagingStore {
     }
 
     async fn remove_op(&self, op_id: OpId) -> SeamResult<()> {
-        self.inner
-            .lock()
-            .expect("lock")
-            .ops
-            .retain(|(id, _)| *id != op_id);
+        let mut inner = self.inner.lock().expect("lock");
+        if inner.fail_remove_op {
+            return Err(SeamError::new("remove_op unavailable"));
+        }
+        inner.ops.retain(|(id, _)| *id != op_id);
         Ok(())
     }
 


### PR DESCRIPTION
## What

Surfaces cold-start dead-letters, split off from PR #762 review.

- `cold_start_data_path` (facade.rs) now emits `Event::DeadLetter { op_id }` for every `decode_queue` undecodable entry, replacing the previously-dropped `_undecodable` tuple and its deferral comment.
- Each dead-lettered op record is removed from the durable queue via `StagingStore::remove_op` (the seam's sanctioned dead-letter removal path), so a corrupt / forward-version entry is not re-decoded and re-emitted on every boot.
- Staged upload bytes live in a separate plane (`put/remove_staged_bytes`, keyed by staging keys) and are never touched, so they are retained per the `#33 D6` dead-letter contract.

## `replay()` dead-letters (issue item 2)

Confirmed against `sync/boot.rs` and `sync/rebase.rs`: `cold_start` composes `apply_overlay` on the happy path and **never invokes `replay()`** — `replay` is referenced only from the `sync` re-exports and its own module. So on the cold-start boot path `decode_queue` is the only genuine dead-letter source at this stage; no replay call was invented.

## Removal / retention decision (issue item 3)

Minimal sound policy, no schema redesign: `remove_op(op_id)` after surfacing. The `StagingStore` trait already documents `remove_op` as the removal path for a "dead-lettered" op, it stops re-emission on the next boot, and it leaves the separate staged-bytes plane intact (staged bytes retained). No new seam methods, no dead-letter partition, no durable "already-dead-lettered" flag needed.

## Tests

- `undecodable_queue_entry_surfaces_as_dead_letter_on_cold_start` — a corrupt op surfaces as `Event::DeadLetter { op_id }` ahead of the first paint and is dropped from the durable queue.
- `dead_lettered_entry_is_not_re_emitted_on_a_second_boot` — a second cold start over the same store emits only the paint event.

Gates (local): `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p cipherbox-engine -p cipherbox-core`, plus a `--release` pass of the cold_start tests — all green.

Closes #768
