### PR TITLE
refactor(engine): collapse the cold-seed seam and role-gate the read-epoch check

### DIFF
--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -99,6 +99,33 @@ impl core::fmt::Display for ColdSeedError {
 
 impl std::error::Error for ColdSeedError {}
 
+/// The scope role a cold-seed runs against — the gate on the read-epoch
+/// (revocation) regression check, which is sound **only at the root/vault
+/// anchor**.
+///
+/// At the root scope the read epoch is owner-authored, so
+/// [`advance_on_unseal`] raises the read-epoch floor in lockstep with the owner
+/// clock and a vouched `minReadEpoch` below the durable floor is an unambiguous
+/// owner rollback (correct fail-closed). At a **shared** scope a grantee's
+/// legitimate lazy-rotation unseal-advances that same floor *past* the
+/// owner-authored `minReadEpoch`, so the identical comparison would
+/// false-positive into a self-inflicted fail-closed **DoS** (a bricked boot) —
+/// never a security hole, since no rollback is accepted and the write-epoch
+/// check stays unconditionally sound. `Shared` therefore never runs the
+/// read-epoch check; only `Root` does (#763). Making the role explicit means no
+/// caller can express "read-epoch check on a shared scope": the check lives
+/// behind the `Root` arm alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnchorRole {
+    /// The vault/root anchor: the read epoch is owner-authored, so the
+    /// read-epoch regression check is sound and runs (alongside write-epoch).
+    Root,
+    /// A shared scope: the read-epoch floor is unseal-advanced by legitimate
+    /// grantee rotation, so only the unconditionally-sound write-epoch check
+    /// runs — the read-epoch check is skipped by construction.
+    Shared,
+}
+
 /// Suffix that distinguishes a scope's write-epoch floor key from its
 /// read-epoch floor key inside the [`FloorStore`] epoch namespace. The
 /// read-epoch floor (the revocation boundary the adoption gate's epoch stage
@@ -201,14 +228,22 @@ pub async fn cold_seed<F: FloorStore>(floors: &F, repoint: &RepointObject) -> Se
     Ok(())
 }
 
-/// Cold-seed a scope's floors **fail-closed on regression** (the floor law).
+/// Cold-seed a scope's floors **fail-closed on regression** (the floor law) —
+/// the single checked cold-seed seam production uses.
 ///
-/// Reads the durable read- and write-epoch floors and rejects before any write
-/// if the owner-vouched re-point would move either backward: a re-point whose
-/// `minReadEpoch` or `writeEpoch` is strictly below the durable floor is a
-/// rolled-back pointer (a replay past a revocation boundary), a trust violation
-/// never mere staleness. Only when neither regresses does it advance the floors
-/// via the monotonic-max [`cold_seed`].
+/// Reads the durable floors and rejects before any write if the owner-vouched
+/// re-point would move one backward: a re-point whose `writeEpoch` (any role),
+/// or whose `minReadEpoch` (root anchor only, see below), is strictly below the
+/// durable floor is a rolled-back pointer (a replay past a revocation
+/// boundary), a trust violation never mere staleness. Only when nothing
+/// regresses does it advance the floors via the monotonic-max [`cold_seed`].
+///
+/// The **write-epoch** check is unconditionally sound and runs for every
+/// [`AnchorRole`]. The **read-epoch** (revocation) check is sound only at the
+/// root/vault anchor and runs only under [`AnchorRole::Root`] — see
+/// [`AnchorRole`] for why a shared scope's read-epoch floor legitimately
+/// advances past `minReadEpoch`, making the check a self-inflicted DoS there
+/// (#763). The role gate makes the unsound combination unrepresentable.
 ///
 /// The single-writer engine reads the floors and advances them with no
 /// concurrent adopt in between (blueprint/engine.md "Facade" — one live
@@ -217,16 +252,19 @@ pub async fn cold_seed<F: FloorStore>(floors: &F, repoint: &RepointObject) -> Se
 pub async fn cold_seed_checked<F: FloorStore>(
     floors: &F,
     repoint: &RepointObject,
+    role: AnchorRole,
 ) -> Result<(), ColdSeedError> {
-    if let Some(floor) = read_epoch_floor(floors, &repoint.scope_id)
-        .await
-        .map_err(ColdSeedError::Seam)?
-    {
-        if repoint.min_read_epoch < floor {
-            return Err(ColdSeedError::Regression(FloorRegression::ReadEpoch {
-                floor,
-                vouched: repoint.min_read_epoch,
-            }));
+    if role == AnchorRole::Root {
+        if let Some(floor) = read_epoch_floor(floors, &repoint.scope_id)
+            .await
+            .map_err(ColdSeedError::Seam)?
+        {
+            if repoint.min_read_epoch < floor {
+                return Err(ColdSeedError::Regression(FloorRegression::ReadEpoch {
+                    floor,
+                    vouched: repoint.min_read_epoch,
+                }));
+            }
         }
     }
     if let Some(floor) = write_epoch_floor(floors, &repoint.scope_id)
@@ -305,13 +343,13 @@ mod tests {
         let floors = InMemoryFloorStore::default();
         block_on(async {
             // A fresh (unseeded) scope adopts the owner-vouched anchor.
-            cold_seed_checked(&floors, &repoint(SCOPE, 5, 3))
+            cold_seed_checked(&floors, &repoint(SCOPE, 5, 3), AnchorRole::Root)
                 .await
                 .unwrap();
             assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(5));
             assert_eq!(write_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(3));
             // Re-seeding at or above the floor advances monotonically.
-            cold_seed_checked(&floors, &repoint(SCOPE, 7, 3))
+            cold_seed_checked(&floors, &repoint(SCOPE, 7, 3), AnchorRole::Root)
                 .await
                 .unwrap();
             assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(7));
@@ -322,11 +360,11 @@ mod tests {
     fn cold_seed_checked_rejects_a_read_epoch_regression_fail_closed() {
         let floors = InMemoryFloorStore::default();
         block_on(async {
-            cold_seed_checked(&floors, &repoint(SCOPE, 5, 3))
+            cold_seed_checked(&floors, &repoint(SCOPE, 5, 3), AnchorRole::Root)
                 .await
                 .unwrap();
             // A rolled-back re-point vouching a lower minReadEpoch is fail-closed.
-            let err = cold_seed_checked(&floors, &repoint(SCOPE, 4, 3))
+            let err = cold_seed_checked(&floors, &repoint(SCOPE, 4, 3), AnchorRole::Root)
                 .await
                 .expect_err("read-epoch regression is a trust violation");
             assert_eq!(
@@ -345,10 +383,10 @@ mod tests {
     fn cold_seed_checked_rejects_a_write_epoch_regression_fail_closed() {
         let floors = InMemoryFloorStore::default();
         block_on(async {
-            cold_seed_checked(&floors, &repoint(SCOPE, 5, 6))
+            cold_seed_checked(&floors, &repoint(SCOPE, 5, 6), AnchorRole::Root)
                 .await
                 .unwrap();
-            let err = cold_seed_checked(&floors, &repoint(SCOPE, 5, 4))
+            let err = cold_seed_checked(&floors, &repoint(SCOPE, 5, 4), AnchorRole::Root)
                 .await
                 .expect_err("write-epoch regression is a trust violation");
             assert_eq!(
@@ -359,6 +397,66 @@ mod tests {
                 })
             );
             assert_eq!(write_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(6));
+        });
+    }
+
+    /// The read-epoch regression check is unrepresentable for a shared scope:
+    /// under [`AnchorRole::Shared`] a `minReadEpoch` far below the durable
+    /// read-epoch floor (the legitimate steady state once grantee lazy rotation
+    /// has unseal-advanced that floor) seeds cleanly instead of false-positiving
+    /// into a fail-closed DoS (#763). The same input under `Root` is fail-closed.
+    #[test]
+    fn cold_seed_checked_shared_scope_skips_the_read_epoch_check() {
+        let floors = InMemoryFloorStore::default();
+        block_on(async {
+            // Grantee lazy rotation has driven the read-epoch floor to 9.
+            advance_on_unseal(&floors, &SCOPE, NAME, 1, 9)
+                .await
+                .unwrap();
+
+            // A shared-scope cold-seed vouching minReadEpoch 4 (< floor 9) is the
+            // normal steady state — it must NOT fire the read-epoch check.
+            cold_seed_checked(&floors, &repoint(SCOPE, 4, 2), AnchorRole::Shared)
+                .await
+                .expect("shared-scope cold-seed never runs the read-epoch check");
+            // The monotonic-max floor is unmoved by the lower vouched read epoch;
+            // the write-epoch floor still seeds.
+            assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(9));
+            assert_eq!(write_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(2));
+
+            // The identical input at the root anchor IS a fail-closed rollback.
+            let err = cold_seed_checked(&floors, &repoint(SCOPE, 4, 2), AnchorRole::Root)
+                .await
+                .expect_err("the read-epoch check is sound and active at the root anchor");
+            assert_eq!(
+                err,
+                ColdSeedError::Regression(FloorRegression::ReadEpoch {
+                    floor: 9,
+                    vouched: 4
+                })
+            );
+        });
+    }
+
+    /// The write-epoch check stays unconditionally active — a shared-scope
+    /// cold-seed still fails closed on a write-epoch rollback.
+    #[test]
+    fn cold_seed_checked_shared_scope_still_rejects_a_write_epoch_regression() {
+        let floors = InMemoryFloorStore::default();
+        block_on(async {
+            cold_seed_checked(&floors, &repoint(SCOPE, 5, 6), AnchorRole::Shared)
+                .await
+                .unwrap();
+            let err = cold_seed_checked(&floors, &repoint(SCOPE, 5, 4), AnchorRole::Shared)
+                .await
+                .expect_err("write-epoch regression is fail-closed for every role");
+            assert_eq!(
+                err,
+                ColdSeedError::Regression(FloorRegression::WriteEpoch {
+                    floor: 6,
+                    vouched: 4
+                })
+            );
         });
     }
 

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -117,12 +117,12 @@ impl std::error::Error for ColdSeedError {}
 /// behind the `Root` arm alone.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AnchorRole {
-    /// The vault/root anchor: the read epoch is owner-authored, so the
-    /// read-epoch regression check is sound and runs (alongside write-epoch).
+    /// The vault/root anchor: read-epoch check runs (alongside write-epoch).
     Root,
-    /// A shared scope: the read-epoch floor is unseal-advanced by legitimate
-    /// grantee rotation, so only the unconditionally-sound write-epoch check
-    /// runs — the read-epoch check is skipped by construction.
+    /// A shared scope: read-epoch check skipped; only write-epoch runs.
+    ///
+    /// A production `Shared` caller MUST select this role from authenticated
+    /// scope identity, never a network/`RepointObject` field (#775).
     Shared,
 }
 
@@ -238,12 +238,8 @@ pub async fn cold_seed<F: FloorStore>(floors: &F, repoint: &RepointObject) -> Se
 /// boundary), a trust violation never mere staleness. Only when nothing
 /// regresses does it advance the floors via the monotonic-max [`cold_seed`].
 ///
-/// The **write-epoch** check is unconditionally sound and runs for every
-/// [`AnchorRole`]. The **read-epoch** (revocation) check is sound only at the
-/// root/vault anchor and runs only under [`AnchorRole::Root`] — see
-/// [`AnchorRole`] for why a shared scope's read-epoch floor legitimately
-/// advances past `minReadEpoch`, making the check a self-inflicted DoS there
-/// (#763). The role gate makes the unsound combination unrepresentable.
+/// The read-epoch check runs under [`AnchorRole::Root`] only; the write-epoch
+/// check is unconditional — see [`AnchorRole`] for why.
 ///
 /// The single-writer engine reads the floors and advances them with no
 /// concurrent adopt in between (blueprint/engine.md "Facade" — one live

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -434,6 +434,23 @@ mod tests {
         });
     }
 
+    /// Skipping the read-epoch *check* for a shared scope must not skip the
+    /// unconditional `cold_seed`: a fresh (None) shared scope still seeds its
+    /// read-epoch floor to `minReadEpoch` via the monotonic-max raise, exactly
+    /// as `Root` does. Guards a future refactor from dropping the seed for
+    /// `Shared`.
+    #[test]
+    fn cold_seed_checked_shared_scope_seeds_a_fresh_read_epoch_floor() {
+        let floors = InMemoryFloorStore::default();
+        block_on(async {
+            cold_seed_checked(&floors, &repoint(SCOPE, 5, 3), AnchorRole::Shared)
+                .await
+                .expect("a fresh shared scope seeds without running the read-epoch check");
+            assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(5));
+            assert_eq!(write_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(3));
+        });
+    }
+
     /// The write-epoch check stays unconditionally active — a shared-scope
     /// cold-seed still fails closed on a write-epoch rollback.
     #[test]

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -85,9 +85,8 @@ pub use sync::{
     AppliedOp, Connectivity, DeadLetterReason, DropReason, FocusTarget, FocusWindow,
     HeadReconciliation, Link, NodeMeta, Op, OpKind, OpResolution, PointerError, PointerFetch,
     Repair, ReplayReport, SessionRole, Snapshot, StageOutcome, TickCause, TickControl,
-    VaultPointerAdoption, apply_overlay, apply_repairs, classify, cold_seed_floors, decode_queue,
-    focus_set, observed_repair, rebase_one, reconcile_head, replay, resolve_vault_pointer,
-    stage_op,
+    VaultPointerAdoption, apply_overlay, apply_repairs, classify, decode_queue, focus_set,
+    observed_repair, rebase_one, reconcile_head, replay, resolve_vault_pointer, stage_op,
 };
 
 /// Placeholder identity item; kept for the sibling crate stubs' dependency

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -172,7 +172,10 @@ where
     // Step 2 — floor cold-seed, fail-closed on regression. The owner-vouched
     // epochs seed the durable floors; a re-point that would move either floor
     // backward is a rolled-back pointer, a trust violation.
-    floor::cold_seed_checked(floors, &adoption.repoint)
+    // The vault pointer is the root/vault anchor, so the read-epoch check is
+    // sound here (`AnchorRole::Root`); a shared-scope cold-seed would pass
+    // `Shared` (#763).
+    floor::cold_seed_checked(floors, &adoption.repoint, floor::AnchorRole::Root)
         .await
         .map_err(|e| match e {
             ColdSeedError::Seam(seam) => ColdStartError::Seam(seam),

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -46,9 +46,9 @@ pub use model::{Link, NodeMeta, Snapshot, collation_key, suffix_name};
 pub use op::{Op, OpDecodeError, OpKind};
 pub use overlay::apply_overlay;
 pub use pointer::{
-    ConsultReason, PointerError, PointerFetch, SessionRole, VaultPointerAdoption, cold_seed_floors,
-    open_repoint, resolve_vault_pointer, scope_pointer_name, scope_pointer_signer, seal_repoint,
-    should_consult, vault_pointer_name,
+    ConsultReason, PointerError, PointerFetch, SessionRole, VaultPointerAdoption, open_repoint,
+    resolve_vault_pointer, scope_pointer_name, scope_pointer_signer, seal_repoint, should_consult,
+    vault_pointer_name,
 };
 pub use rebase::{
     AppliedOp, DeadLetterReason, DropReason, HeadReconciliation, OpResolution, Repair,

--- a/crates/engine/src/sync/pointer.rs
+++ b/crates/engine/src/sync/pointer.rs
@@ -8,8 +8,10 @@
 //! re-point object is owner-identity-signed and sealed under the scope's stable
 //! `pointerReadKey`; core owns the codec, sign, and verify
 //! ([`seal_pointer_payload`]/[`open_pointer_payload`]) — this module owns name
-//! derivation, the vault-pointer index walk, the owner-plane write gate, the
-//! consult discipline, and the cold-start floor cold-seed.
+//! derivation, the vault-pointer index walk, the owner-plane write gate, and
+//! the consult discipline. The floor cold-seed itself is the floor law's
+//! ([`floor::cold_seed_checked`](crate::gate::floor::cold_seed_checked)) — cold
+//! start feeds it the re-point this walk authenticated.
 //!
 //! **Consult discipline: polled, not fallback** (#38 D4). A revokee's forged
 //! old-epoch record passes every *other* gate stage (valid old-key signature,
@@ -27,8 +29,7 @@ use cipherbox_core::suite::aead::NONCE_LEN;
 use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
 
 use crate::entropy::{Entropy, EntropyError};
-use crate::gate::floor;
-use crate::seams::{FloorStore, SeamError, SeamResult};
+use crate::seams::{SeamError, SeamResult};
 
 /// A safety bound on the vault-pointer index walk. The chain length is
 /// owner-authored (each index needs the owner's identity signature to open),
@@ -121,6 +122,14 @@ pub struct VaultPointerAdoption {
 /// walk fail-closed at that index: it is never adopted and the walk never
 /// reaches beyond it, so a forged record cannot truncate the chain *below* an
 /// already-adopted valid index.
+///
+/// The `login_secret` stays a raw read-only borrow rather than a pre-derived
+/// probe capability: the walk needs two *distinct* frozen KDF edges keyed on
+/// the secret itself — `owner-pointer-seed` (for the read key) and the
+/// per-index `vault-pointer-index` signer, unbounded across the probe — with no
+/// shared intermediate seed to hand off instead. The secret is already
+/// `Zeroizing` at its terminal owner (the session identity); this borrow is
+/// read-only, never logged, and this is its sole consumer.
 pub async fn resolve_vault_pointer<F: PointerFetch>(
     fetch: &F,
     login_secret: &[u8],
@@ -203,25 +212,6 @@ pub fn open_repoint(
         block,
     )
     .map_err(PointerError::Open)
-}
-
-/// Cold-seed a scope's floors from an authenticated re-point object — the
-/// cold-start anchor. Delegates to the floor law's [`floor::cold_seed`]: the
-/// owner-vouched `minReadEpoch` seeds the read-epoch (revocation) floor and
-/// `writeEpoch` the write-epoch floor, both monotonic-max.
-///
-/// **Cold start adopts nothing** until this runs: before the floor store seeds
-/// from the owner-signed anchor, every scope's read-epoch floor is unseeded and
-/// the gate can be shown any old-epoch record. The non-circular sequence
-/// (#38 D3): own vault → vault/scope pointer (first act) → floors seeded →
-/// current root name → envelope grant blob → seeds → render.
-pub async fn cold_seed_floors<F: FloorStore>(
-    floors: &F,
-    repoint: &RepointObject,
-) -> Result<(), PointerError> {
-    floor::cold_seed(floors, repoint)
-        .await
-        .map_err(PointerError::Seam)
 }
 
 /// Whether to consult the scope pointer now — the polled discipline, decided
@@ -383,33 +373,6 @@ mod tests {
         let result = resolve_vault_pointer(&pointers, SECRET, &owner_identity, &ROOT_SCOPE, 1);
         let err = block_on(result).expect_err("a forged index is fail-closed");
         assert!(matches!(err, PointerError::Open(_)));
-    }
-
-    #[test]
-    fn cold_seed_floors_then_old_epoch_records_are_below_floor() {
-        use crate::testkit::fakes::InMemoryFloorStore;
-        let floors = InMemoryFloorStore::default();
-        block_on(async {
-            // Before cold-seed the read-epoch floor is unseeded (adopts anything).
-            assert_eq!(
-                floor::read_epoch_floor(&floors, &ROOT_SCOPE).await.unwrap(),
-                None
-            );
-            cold_seed_floors(&floors, &repoint(ROOT_SCOPE, 5, 3))
-                .await
-                .unwrap();
-            assert_eq!(
-                floor::read_epoch_floor(&floors, &ROOT_SCOPE).await.unwrap(),
-                Some(5),
-                "minReadEpoch seeds the revocation floor"
-            );
-            assert_eq!(
-                floor::write_epoch_floor(&floors, &ROOT_SCOPE)
-                    .await
-                    .unwrap(),
-                Some(3)
-            );
-        });
     }
 
     #[test]

--- a/crates/engine/src/sync/pointer.rs
+++ b/crates/engine/src/sync/pointer.rs
@@ -123,13 +123,7 @@ pub struct VaultPointerAdoption {
 /// reaches beyond it, so a forged record cannot truncate the chain *below* an
 /// already-adopted valid index.
 ///
-/// The `login_secret` stays a raw read-only borrow rather than a pre-derived
-/// probe capability: the walk needs two *distinct* frozen KDF edges keyed on
-/// the secret itself — `owner-pointer-seed` (for the read key) and the
-/// per-index `vault-pointer-index` signer, unbounded across the probe — with no
-/// shared intermediate seed to hand off instead. The secret is already
-/// `Zeroizing` at its terminal owner (the session identity); this borrow is
-/// read-only, never logged, and this is its sole consumer.
+/// `login_secret` is a read-only borrow; sole consumer; zeroized at the session owner.
 pub async fn resolve_vault_pointer<F: PointerFetch>(
     fetch: &F,
     login_secret: &[u8],

--- a/crates/engine/tests/sync.rs
+++ b/crates/engine/tests/sync.rs
@@ -24,8 +24,8 @@ use cipherbox_engine::sync::model::NodeMeta;
 use cipherbox_engine::sync::pointer::{seal_repoint, vault_pointer_name};
 use cipherbox_engine::sync::{
     self, Connectivity, DeadLetterReason, DropReason, Op, OpResolution, PointerFetch, SessionRole,
-    Snapshot, StageOutcome, apply_repairs, classify, cold_seed_floors, decode_queue,
-    observed_repair, rebase_one, replay, resolve_vault_pointer, stage_op, withheld_escalation,
+    Snapshot, StageOutcome, apply_repairs, classify, decode_queue, observed_repair, rebase_one,
+    replay, resolve_vault_pointer, stage_op, withheld_escalation,
 };
 use cipherbox_engine::testkit::fakes::{InMemoryFloorStore, InMemoryStagingStore};
 use cipherbox_engine::testkit::{SeededEntropy, block_on};
@@ -536,7 +536,11 @@ fn cold_start_adopts_nothing_until_the_floor_seeds_from_the_pointer() {
         .unwrap()
         .expect("the vault pointer now resolves");
         assert_eq!(adopted.index, 0);
-        cold_seed_floors(&floors, &adopted.repoint).await.unwrap();
+        // The vault pointer is the root anchor: cold-seed through the same
+        // checked, fail-closed seam production's `cold_start` uses.
+        floor::cold_seed_checked(&floors, &adopted.repoint, floor::AnchorRole::Root)
+            .await
+            .unwrap();
 
         // Now the revocation floor is seeded: an old-epoch record (epoch 3 < 5)
         // would fail the gate's epoch stage — cold start no longer adopts blindly.


### PR DESCRIPTION
Closes #763
Closes #765

Rationalizes the cold-seed seam surfaced by the #762 crypto-privacy, security, and /simplify reviews of the cold-start data path (#759). Engine-only Rust; no crypto changes (all crypto stays in `crates/core`).

## Part 1 — one obvious cold-seed seam (#765.1)

There were three layers: `floor::cold_seed` (primitive) -> `pointer::cold_seed_floors` (unchecked exported wrapper) -> `floor::cold_seed_checked` (checked, fail-closed). Production `cold_start` used the checked one while the integration test drove the unchecked wrapper.

- Removed `pointer::cold_seed_floors` and its `lib.rs` / `sync/mod.rs` re-exports.
- Left the natural two layers: the monotonic-max primitive `floor::cold_seed` and the single fail-closed seam `floor::cold_seed_checked`.
- The cold-start integration test (`tests/sync.rs`) now drives the same checked seam production uses.

## Part 2 — root-anchor precondition unrepresentable (#763)

The read-epoch regression check is sound only at the root/vault anchor (read epoch is owner-authored). At a shared scope a grantee's legitimate lazy rotation unseal-advances the read-epoch floor past `minReadEpoch`, so the same check would false-positive into a self-inflicted fail-closed DoS (bricked boot) -- not a security hole (no rollback accepted; the write-epoch check stays unconditionally sound).

- Added an `AnchorRole { Root, Shared }` marker to `cold_seed_checked`.
- `Root` runs the read-epoch check + write-epoch check; `Shared` runs only the unconditionally-sound write-epoch check. The read-epoch check lives behind the `Root` arm alone, so "read-epoch check on a shared scope" is unrepresentable.
- No behavior change to the root-anchor path: `cold_start` passes `AnchorRole::Root`.
- New role-gated tests: a shared-scope cold-seed with `minReadEpoch` far below the durable read-epoch floor seeds cleanly (no false positive), while the identical input at `Root` stays fail-closed; and the write-epoch check still fails closed for a shared scope.

## Part 3 — login_secret probe shape (#765.2)

Evaluated reshaping `resolve_vault_pointer` to take a derived probe capability instead of the raw `login_secret`. The walk needs two distinct frozen KDF edges keyed on the secret itself -- `owner-pointer-seed` and the per-index `vault-pointer-index` signer (unbounded across the probe) -- with no shared intermediate seed to hand off. A capability wrapper would still hold the raw secret (pure indirection), and a new intermediate edge would ripple into the core KDF catalog and KAT regime. Kept the raw read-only borrow and added a short doc note: the secret is already `Zeroizing` at its terminal owner, the borrow is read-only and never logged, and this is its sole consumer.

## Gates (local, from the worktree)

- `cargo fmt --all` clean.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test -p cipherbox-engine -p cipherbox-core` green.
- `--release` pass of the floor + cold-start tests green -- the fail-closed regression checks are release-active `Err` returns (no `debug_assert`), confirmed firing in release.

Root-anchor cold-start behavior is unchanged; floor-law and cold-start tests stay green.
