### PR TITLE
docs(agents): flag absence-justifying and unchanged-code comment smells

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ Two recurring shapes of this smell go beyond excusing a hack — avoid both:
 
 State genuine non-obvious domain rationale **once**, at its home (the type or definition), not restated on every caller. These cost real review cycles — `/simplify`, CodeRabbit, and Greptile all flag them.
 
+Length discipline for the permitted domain-rationale exception: state each invariant **once** and prefer a one-line cross-reference to the blueprint / `CONTEXT.md` over re-deriving it in prose. Do not narrate the happy path — the code is the narrative, and a comment restating what the next lines plainly do rots out of sync and misleads. A module header past ~25 lines is almost always restating the spec: keep only the rationale that is non-obvious _from the code itself_ and cite the blueprint for the rest.
+
 ## Architecture Pillars
 
 - **Auth:** Web3Auth key derivation; challenge-signature login; short-lived JWT + rotating refresh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,13 @@ There are **no generated API clients** and no codegen loop. The engine contains 
 
 Comments explain _why_, not _what_, and stay short. **If you need a paragraph-long comment to justify why a workaround is OK, the code is wrong — fix the code.** A long apologia for a hack is a smell: rework the code so it no longer needs defending, rather than documenting the shortcut. Reserve multi-line comments for genuinely non-obvious domain rationale — a spec citation, a cryptographic invariant, a wire-format or fail-closed constraint — not for excusing a shortcut.
 
+Two recurring shapes of this smell go beyond excusing a hack — avoid both:
+
+- **Absence-justifying comments** — prose explaining why a path that is _not_ in the code does not happen (e.g. "`replay()` does not run here, so `decode_queue` is the only source at this stage"). It bloats the diff and rots into a falsehood the moment that path is wired — a stale in-code claim that actively misleads. Describe what the present code does; a bare cross-reference suffices if a reader must know a related path lives elsewhere.
+- **Unchanged-code apologia** — a doc block defending code this change does not modify (e.g. why a parameter stays a raw borrow, on a function the diff leaves untouched). It is scope creep into untouched code and reads as pre-emptive defensiveness. Leave that rationale where it already lives.
+
+State genuine non-obvious domain rationale **once**, at its home (the type or definition), not restated on every caller. These cost real review cycles — `/simplify`, CodeRabbit, and Greptile all flag them.
+
 ## Architecture Pillars
 
 - **Auth:** Web3Auth key derivation; challenge-signature login; short-lived JWT + rotating refresh

--- a/crates/core/src/content/cid.rs
+++ b/crates/core/src/content/cid.rs
@@ -68,9 +68,8 @@ pub const CONTENT_CID_LEN: usize = CID_PREFIX_LEN + DIGEST_LEN;
 /// must pass a single-byte multicodec; the guard fails closed (panics in every
 /// build) rather than silently emitting a malformed one-byte-truncated CID.
 pub fn compute_cid(codec: u8, bytes: &[u8]) -> Vec<u8> {
-    // A malformed content CID is a content-addressing hazard, so this holds in
-    // release too, not only debug (core.md:56). The frozen content-plane set is
-    // single-byte (raw 0x55, dag-cbor 0x71), so it never fires in correct use.
+    // `assert!` (not `debug_assert!`): a one-byte-truncated CID from a
+    // multi-byte codec must fail closed in release too (core.md:56).
     assert!(
         codec < 0x80,
         "content-plane multicodec must be single-byte (< 0x80, core.md:56)"

--- a/crates/core/src/payload/mailbox.rs
+++ b/crates/core/src/payload/mailbox.rs
@@ -135,8 +135,6 @@ fn verify_inner(inner: &[u8], v: u64, recipient_pk: &[u8]) -> Result<MailboxItem
     let sender_pk = req(map, "senderIdentityPk")?.as_bytes()?;
     let sig_bytes = req(map, "senderSig")?.as_bytes()?;
 
-    // A bad key encoding, a non-canonical signature, or a mismatch are all the
-    // one trust check: the claimed sender did not author this item.
     let sender_identity =
         EcdsaVerifier::from_sec1(sender_pk).ok_or(TrustViolation::IdentitySignatureInvalid)?;
     let sig =

--- a/crates/core/src/seal/aad.rs
+++ b/crates/core/src/seal/aad.rs
@@ -36,9 +36,9 @@ pub const AAD_DOMAIN: &str = "cipherbox/v2/aad";
 // ---------------------------------------------------------------------------
 // Structure-tag registry: the domain-separation byte-space, frozen here and in
 // the KAT manifest. Every sealed/signed structure has exactly one tag; the tag
-// is bound into the AAD (and, in later slices, the structure-signature
-// preimage). Bytes are assigned once and never reused — a fresh v2 space (the
-// v1 content self-seal role `0x03` has no v2 analog and is not carried).
+// is bound into the AAD and the structure-signature preimage. Bytes are assigned
+// once and never reused — a fresh v2 space (the v1 content self-seal role `0x03`
+// has no v2 analog and is not carried).
 // ---------------------------------------------------------------------------
 
 /// `read-body` — the sealed node body (folder children / file versions). The
@@ -124,9 +124,7 @@ pub struct AadContext {
 
 /// Build the AAD bytes for a seal: the det-CBOR encoding of
 /// `[AAD_DOMAIN, v, id, scope, epoch, structTag]`. Deterministic and
-/// unambiguous; the array positions are frozen by the KAT, so this is never
-/// decoded back — it is only handed to the AEAD as additional authenticated
-/// data.
+/// unambiguous; the array positions are frozen by the KAT.
 pub fn build_aad(ctx: &AadContext) -> Vec<u8> {
     encode(&Value::Array(vec![
         Value::Text(AAD_DOMAIN.to_string()),

--- a/crates/core/src/seal/body.rs
+++ b/crates/core/src/seal/body.rs
@@ -384,17 +384,11 @@ pub fn encode_read_body(body: &ReadBody) -> Vec<u8> {
             merge_unknown(&mut m, unknown);
         }
     }
-    // The transient `Value` tree just built carries a verbatim copy of every
-    // inline content key (one `Value::Bytes` per file version, produced by
-    // `Version::to_value`). We own that tree, so we are its terminal owner
-    // (blueprint/core.md "Crypto suite": key material lives only in zeroizing
-    // owners). Scrub it through a drop guard, not an explicit trailing call, so
-    // the wipe runs whether `encode` returns or unwinds: `write_value`'s
-    // `debug_assert!(depth < MAX_DEPTH)` can panic in debug/test builds, and a
-    // bare post-`encode` scrub would be skipped on that unwind, leaving a
-    // freed-but-uncleared key copy on the heap. The returned buffer carries the
-    // same key bytes and is the seal path's
-    // ([`seal_read_body`](super::seal_read_body)) to zeroize — it does.
+    // The transient tree carries a verbatim copy of every inline content key
+    // (one `Value::Bytes` per version). Scrub it through the drop guard so the
+    // wipe runs on both return and panic-unwind (terminal-owner rule; see
+    // [`ScrubOnDrop`]). The returned buffer stays the seal path's
+    // ([`seal_read_body`](super::seal_read_body)) to zeroize.
     let mut value = Value::Map(m);
     let guard = ScrubOnDrop(&mut value);
     encode(guard.0)

--- a/crates/core/src/seal/envelope.rs
+++ b/crates/core/src/seal/envelope.rs
@@ -7,11 +7,10 @@
 //! the read-body, so observers cannot distinguish them. The scope id is the
 //! scope root's node UUID; `epochTag` is the plaintext, AAD-bound membership.
 //!
-//! This slice lands `{v, id, epochTag, readSealed}`. The write-body and grant
-//! section are later slices — but an envelope that carries them (written by a
-//! newer client) must round-trip byte-stable through this decoder, so they ride
-//! the unknown-field tolerance (#27 D10): `writeSealed`/`grantSection` are
-//! preserved in [`Envelope::unknown`], never stripped on rewrite.
+//! This codec models only `{v, id, epochTag, readSealed}` as typed fields;
+//! `writeSealed`/`grantSection` are carried through the unknown-field tolerance
+//! (#27 D10), preserved in [`Envelope::unknown`] and never stripped on rewrite,
+//! so an envelope written by a newer client round-trips byte-stable here.
 
 use zeroize::Zeroize;
 
@@ -92,8 +91,8 @@ pub fn encode_envelope(env: &Envelope) -> Vec<u8> {
 /// Seal a read-body into a fresh envelope under the read key + injected nonce.
 ///
 /// The struct tag is fixed to `read-body`; the AAD binds `(v, id, scope, epoch,
-/// read-body)`. `nonce` must be unique per `key` (XChaCha20-Poly1305 nonce
-/// reuse under one key is a break) and is caller-injected entropy the KATs pin.
+/// read-body)`. `nonce` must be unique per `key` (see [`super::seal`]) and is
+/// caller-injected entropy the KATs pin.
 ///
 /// The body is [`ReadBody::validate`]d first, so this never persists a folder
 /// with duplicate child ids/ipnsNames that decode would refuse to reopen —

--- a/crates/core/src/seal/mod.rs
+++ b/crates/core/src/seal/mod.rs
@@ -2,11 +2,9 @@
 //! structures").
 //!
 //! AAD construction, symmetric seal/unseal, the kind-uniform envelope codec,
-//! and the read-body tagged union. Pure and deterministic: the sealing key and
-//! the nonce are injected (KATs pin them); core samples no entropy and reads no
-//! clock. Structure signatures, the write-body, the grant section, and the
-//! pointer/mailbox payloads are later slices — this slice lands the symmetric
-//! read-plane path end to end.
+//! the read-body tagged union, the grant section, and the structure signatures.
+//! Pure and deterministic: the sealing key and the nonce are injected (KATs pin
+//! them); core samples no entropy and reads no clock.
 //!
 //! The wire framing of a sealed body is `nonce(24) || ciphertext||tag`: the
 //! XChaCha20-Poly1305 24-byte nonce is prefixed so [`unseal`] can recover it,

--- a/crates/core/src/seal/structure.rs
+++ b/crates/core/src/seal/structure.rs
@@ -67,8 +67,7 @@ impl StructureSigInput {
 }
 
 /// Build the det-CBOR structure-signature preimage. The `recipientTag` key is
-/// present iff `recipient_tag` is `Some`; the array positions are frozen by the
-/// KAT, so this is never decoded — only signed and verified.
+/// present iff `recipient_tag` is `Some`.
 pub fn structure_sig_preimage(input: &StructureSigInput) -> Vec<u8> {
     let mut m = Map::new();
     m.insert(

--- a/crates/core/src/seal/write_body.rs
+++ b/crates/core/src/seal/write_body.rs
@@ -183,8 +183,7 @@ const WRITE_BODY_KNOWN: &[&str] = &["directChildScopeIndex", "grantLedger", "wri
 ///
 /// The write-body is a scope-root-only structure; this codec does not (and
 /// cannot) enforce that — whether a node is a scope root is the engine's
-/// decision. Interior nodes simply never carry a `writeSealed` for this to
-/// decode.
+/// decision.
 pub fn decode_write_body(bytes: &[u8]) -> Result<WriteBody, CodecError> {
     let value = decode(bytes)?;
     let map = value.as_map()?;

--- a/crates/core/src/suite/contact.rs
+++ b/crates/core/src/suite/contact.rs
@@ -141,7 +141,6 @@ pub fn import_contact_code(bytes: &[u8]) -> Result<ContactCode, CodecError> {
     let binding_sig =
         EcdsaSignature::from_compact(sig_bytes).ok_or(Malformed::InvalidBindingSigEncoding)?;
 
-    // Mandatory, fail-closed: never construct a ContactCode past a failed verify.
     if !verify_subkey_binding(&identity_pk, &enc_subkey, &binding_sig) {
         return Err(TrustViolation::SubkeyBindingInvalid.into());
     }

--- a/crates/engine/src/content/read.rs
+++ b/crates/engine/src/content/read.rs
@@ -130,9 +130,8 @@ pub async fn read_block(
     expected_cid: &[u8],
     plane: ContentPlane,
 ) -> Result<Vec<u8>, ReadError> {
-    // Reject a non-anchor request before touching the network, fail-closed: an
-    // expected CID whose codec is out of the frozen set or is valid but for the
-    // wrong plane, or an address that is not a canonical content-CID string.
+    // Reject a non-anchor request before any fetch, fail-closed (codec
+    // out-of-set/wrong-plane, or a non-canonical address).
     let codec_ok =
         expected_cid.len() == CONTENT_CID_LEN && expected_cid[CID_CODEC_INDEX] == plane.codec();
     if !codec_ok || !is_canonical_content_cid_str(cid_str) {

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -131,9 +131,8 @@ impl fmt::Debug for LoginSecret {
 /// Every command a host can issue — the intent ops, grant/rotation/share
 /// actions, auth, and manual refresh (blueprint/engine.md "Facade").
 ///
-/// Payload shapes are scaffold-minimal: opaque byte payloads harden into
-/// typed forms as the owning pipeline slices land, but the variant set is
-/// the surface hosts build against.
+/// Payloads are scaffold-minimal and harden with the pipeline slices; the
+/// variant set is the surface hosts build against.
 ///
 /// `Debug` is hand-written and prints only the variant name: payloads
 /// carry private user data (plaintext content, names, contact bundles),
@@ -373,14 +372,11 @@ impl EventStream {
 /// `Send` requirement, so one implementation links natively on desktop and
 /// compiles to worker-hosted WASM on web.
 pub struct Engine<T: SeamTypes> {
-    /// Injection is the contract this slice freezes; the cold-start liveness
-    /// loop is the first live use (the rest wire with the pipeline slices).
     seams: SeamSet<T>,
     /// Wired by the pipeline slices (seeds, nonces, jitter).
     #[allow(dead_code)]
     entropy: Box<dyn Entropy>,
     profile: SyncTimingProfile,
-    /// Held by the engine; every emit site lands with its pipeline slice.
     #[allow(dead_code)]
     events: mpsc::UnboundedSender<Event>,
     /// The session's live held-record set: the resolve slice pushes each

--- a/crates/engine/src/gate/adoption.rs
+++ b/crates/engine/src/gate/adoption.rs
@@ -1,35 +1,15 @@
 //! The adoption gate — the six-stage trust pipeline every resolved record
 //! passes before it touches the snapshot (blueprint/engine.md "Adoption gate
-//! and floors"; CONTEXT.md "Adoption gate").
+//! and floors"; CONTEXT.md "Adoption gate"). It composes the #33 pipeline with
+//! the #39 D3 seal-auth stage and the D4 floor law. The six stages are
+//! enumerated on [`GateStage`] and documented at each stage below.
 //!
 //! The gate is a **pure composition of `crates/core`'s verify/unseal
-//! functions** plus the engine's durable floors. It defines no crypto, no
-//! codec, and no cryptographic error code of its own: every cryptographic
-//! verdict is a core [`CodecError`] surfaced verbatim through
-//! [`RejectionReason::Trust`]. The only engine-domain verdicts are the two
-//! floor comparisons (stages 4 and 5), which are the [`FloorStore`] seam's
-//! territory by construction.
-//!
-//! Stage order (composes the #33 pipeline with the #39 D3 seal-auth stage and
-//! the D4 floor law):
-//!
-//! 1. **Record verify** — core's full IPNS chain: the Ed25519 key is taken from
-//!    the [`IpnsName`] itself, `signatureV2` verifies, and the signed
-//!    `data.Value` must equal the top-level value. Yields the authenticated
-//!    sequence/epoch/EOL.
-//! 2. **Commitment verify** — the owner-signed grant-set commitment against the
-//!    contact-code-anchored owner identity, and its binding to this record's
-//!    name.
-//! 3. **Grant-section authentication** — every seed-bearing structure verifies
-//!    under a *committed write-capable pseudonym*; an ancestor reader also
-//!    derives-and-verifies the ascent link. Any failure rejects the **whole
-//!    record**.
-//! 4. **Sequence** — strictly newer than the durable per-name sequence floor.
-//! 5. **Epoch** — the envelope epoch tag at or above the scope's durable
-//!    read-epoch floor.
-//! 6. **Unseal** — the reader's HPKE seed source (if any) and the symmetric
-//!    read-body must open; the read-body decode also enforces child
-//!    id/`ipnsName` uniqueness fail-closed.
+//! functions** plus the engine's durable floors: no crypto, no codec, and no
+//! cryptographic error code of its own. Every cryptographic verdict is a core
+//! [`CodecError`] surfaced verbatim through [`RejectionReason::Trust`]; the only
+//! engine-domain verdicts are the two floor comparisons (stages 4 and 5), the
+//! [`FloorStore`] seam's territory.
 //!
 //! Every failure is fail-closed and whole-record: the caller pins last-known-
 //! good and never renders the rejected record. Floors advance (via
@@ -439,7 +419,7 @@ pub async fn adopt_deferred<F: FloorStore>(
     // Stage 2 — commitment verify against the contact-anchored owner identity,
     // and its binding to this record's name (the name is inside the signed
     // commitment preimage; a commitment for a different scope root is invalid
-    // here). The commitment and its signature live in the record's grant section.
+    // here).
     let section = &candidate.grant_section;
     let commitment_sig =
         EcdsaSignature::from_compact(&section.commitment_sig).ok_or_else(|| {
@@ -533,9 +513,7 @@ pub async fn adopt_deferred<F: FloorStore>(
         // published, so anyone can seal a rogue payload to it. The seed the link
         // carries is this scope root's current override seed (CONTEXT.md "Ascent
         // link"/"Override seed"), so it must belong to this epoch and derive this
-        // node's read key — the ascent-link half of engine.md:406-408. The
-        // recovered `OverrideSeedPayload` and derived `SecretBytes` are gate-owned
-        // and zeroize on drop; `reader.read_key` is caller-owned and never zeroized.
+        // node's read key — the ascent-link half of engine.md:406-408.
         let payload = open_ascent_link(&parent_node_seed, &aad, &link)
             .map_err(|e| reject(GateStage::GrantSection, RejectionReason::Trust(e)))?;
         let node_seed = kdf::node_seed(payload.override_seed(), &candidate.envelope.id);
@@ -616,9 +594,7 @@ pub async fn adopt_deferred<F: FloorStore>(
         }
         // Cross-check: the recovered seed must derive the reader's read key, or
         // the blob-seed and the actual-unseal key disagree — an attributable
-        // abuse event (blueprint/engine.md), never a silent staleness. The
-        // derived `SecretBytes` are gate-owned and zeroize on drop here;
-        // `reader.read_key` is caller-owned and never zeroized.
+        // abuse event (blueprint/engine.md), never a silent staleness.
         let seed = open_seed_blob(blob)
             .map_err(|e| reject(GateStage::Unseal, RejectionReason::Trust(e)))?;
         let node_seed = kdf::node_seed(seed.as_bytes(), &candidate.envelope.id);
@@ -633,9 +609,8 @@ pub async fn adopt_deferred<F: FloorStore>(
     let read_body = open_read_body(&candidate.envelope, reader.read_key)
         .map_err(|e| reject(GateStage::Unseal, RejectionReason::Trust(e)))?;
 
-    // The read-body unsealed (stage 6). The floor-law advance is DEFERRED to
-    // [`PendingAdoption::commit`] so a caller that must persist accepted state
-    // first advances the floors only after that state is durable.
+    // All six stages passed; the floor-law advance is DEFERRED to
+    // [`PendingAdoption::commit`] (see that type's contract).
     Ok(PendingAdoption {
         adopted: Adopted {
             read_body,

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -12,12 +12,9 @@
 //!    from a claimed-but-unconfirmed field.
 //! 2. **Cold-seed from a re-point object** ([`cold_seed`]) — the cold-start
 //!    anchor. The owner-vouched `minReadEpoch` seeds the read-epoch floor (the
-//!    revocation boundary) and `writeEpoch` the write-epoch floor. The caller
-//!    passes a [`RepointObject`] it already authenticated with
-//!    [`open_pointer_payload`](cipherbox_core::payload::open_pointer_payload):
-//!    the object type is only obtainable from that verified open, so an
-//!    unsigned or non-owner re-point never reaches this function and no floor
-//!    moves (fail-closed by construction).
+//!    revocation boundary) and `writeEpoch` the write-epoch floor. The
+//!    [`RepointObject`] is authenticated by construction, so no floor moves on
+//!    an unsigned or non-owner re-point (see [`cold_seed`]).
 //! 3. **Pointer `writeEpoch` advances on sight** ([`advance_write_epoch_on_sight`])
 //!    — an owner-vouched write epoch above the durable floor raises it the
 //!    moment it is seen (#38 D4).

--- a/crates/engine/src/grants/accept.rs
+++ b/crates/engine/src/grants/accept.rs
@@ -1,21 +1,16 @@
 //! The share-accept flow and the self-healing share bookmarks (blueprint/
 //! engine.md "Grants and ledger — Accept flow", #25 D3).
 //!
-//! Accepting a share is: a sender-verified mailbox pointer → resolve the name →
-//! the adoption gate (commitment verified against the contact-anchored owner) →
-//! self-locate the grant blob by blinded tag → unseal the seeds → reconcile
-//! `{name, sharerPub, displayName, permission, pointerReadKey}` into the
-//! recipient's received-shares list → **durably persist that list** → **only
-//! then** ack. The owner keeps a denormalized sent-index. Both lists are
-//! self-healing bookmarks keyed by scope-root name: the published metadata is
-//! the authority, so a re-accept heals a drifted permission or rotated pointer
-//! read key in place, and only a byte-identical re-accept is a true no-op.
+//! Trust flows from the resolved record and the verified [`Contact`], never the
+//! untrusted pointer: the pointer only says *which name to resolve*, and the gate
+//! re-verifies everything against the contact-anchored owner. The blinded-tag
+//! ECDH peer is the verified contact's encryption subkey, not the pointer's
+//! claimed `sharerPub`.
 //!
-//! Trust flows from the resolved record and the verified [`Contact`], never from
-//! the untrusted pointer: the pointer only says *which name to resolve*, and the
-//! gate re-verifies everything against the contact-anchored owner identity. The
-//! blinded-tag ECDH peer is taken from the verified contact's encryption subkey,
-//! not the pointer's claimed `sharerPub`.
+//! Both share lists are self-healing bookmarks keyed by scope-root name: the
+//! published metadata is authority, so a re-accept heals a drifted permission or
+//! rotated pointer read key in place; only a byte-identical re-accept is a true
+//! no-op. Persist durably before ack (the flow order lives on [`accept_share`]).
 
 use core::fmt;
 
@@ -159,13 +154,10 @@ impl ReceivedSharesList {
     }
 
     /// Reconcile a freshly-verified share into the self-healing bookmark: append
-    /// if the scope is absent, heal the stored entry in place if its authority
-    /// or pointer key drifted, or no-op if it is byte-identical. The published
-    /// metadata is always the authority, so a re-accept that carries a changed
-    /// committed permission or a rotated pointer read key must overwrite the
-    /// stale entry — never keep it (blueprint/engine.md "self-healing
-    /// bookmarks"). The returned [`Reconciled`] carries the pre-image needed to
-    /// [`revert`](Self::revert) if the durable persist then fails.
+    /// if absent, heal in place if the committed permission or pointer read key
+    /// drifted, no-op if byte-identical (blueprint/engine.md "self-healing
+    /// bookmarks"). The returned [`Reconciled`] carries the pre-image
+    /// [`revert`](Self::revert) needs if the durable persist then fails.
     fn reconcile(&mut self, share: ReceivedShare) -> Reconciled {
         match self
             .entries
@@ -246,16 +238,13 @@ impl Reconciled {
 /// Durable persistence for the recipient's received-shares bookmark — the seam
 /// the accept flow writes through before it acks the mailbox item.
 ///
-/// The engine acks **only** after this returns `Ok` (blueprint/engine.md
-/// "Mailbox logic — ack after durable"), and the durable sequence floor is
-/// advanced only after this returns `Ok` too: were the floor to advance first, a
-/// persist failure would strand the share for good, because the redelivered
-/// record is now below the floor and rejected. Persisting the whole list first,
-/// then advancing the floor and acking, keeps redelivery safe — a persist failure
-/// returns un-acked with the floor untouched and the item re-accepts idempotently
-/// (the bookmark self-heals). Injected as a grants-layer seam, not one of the
-/// nine host seams; the facade wires a concrete store when the accept flow is
-/// mounted (#635).
+/// Both the ack and the durable sequence-floor advance happen **only** after this
+/// returns `Ok` (blueprint/engine.md "Mailbox logic — ack after durable"): a floor
+/// that advanced ahead of a failed persist would strand the share below it forever.
+/// Persist-fail returns un-acked with the floor untouched, so the item redelivers
+/// and re-accepts idempotently (the bookmark self-heals). Injected as a grants-layer
+/// seam, not one of the nine host seams; the facade wires a concrete store when the
+/// accept flow is mounted (#635).
 pub trait ReceivedShareStore {
     /// Durably persist the whole received-shares list. A failure returns a
     /// [`SeamError`] and the accept flow does not ack.

--- a/crates/engine/src/grants/child_index.rs
+++ b/crates/engine/src/grants/child_index.rs
@@ -1,48 +1,32 @@
 //! Direct-child-scope index maintenance (blueprint/engine.md "Enumeration walks
 //! the write-body's direct-child-scope index", #38 D6).
 //!
-//! The direct-child-scope index enumerates a scope root's directly-descendant
-//! scope roots. Later slices (rotate/sweep) walk it as the enumeration
-//! substrate for the F-4 cascade; this module builds only the index and its
-//! maintenance semantics, not any rotation or sweep.
-//!
-//! # Persistence
-//!
-//! The index's durable substrate is the write-body's `direct_child_scope_index`
-//! field ([`ChildScopeRef`]), already sealed under the root's `writeKey`,
-//! published, gate-authenticated, and snapshot-cached via the normal envelope
-//! path. This module introduces **no** new seam and **no** separate store — it
-//! is the pure maintenance/ordering logic over `Vec<ChildScopeRef>`; durability
-//! rides the existing sealed write-body. (A separate SnapshotCache/StagingStore
-//! entry is wrong: SnapshotCache is ciphertext-only by contract, and the
-//! write-body already *is* the canonical index.)
+//! The index enumerates a scope root's directly-descendant scope roots; later
+//! rotate/sweep slices walk it for the F-4 cascade. This module is the pure
+//! maintenance/ordering logic over `Vec<ChildScopeRef>` — no new seam, no separate
+//! store: durability rides the write-body's `direct_child_scope_index` field
+//! ([`ChildScopeRef`]), already sealed under the root's `writeKey`, published, and
+//! gate-authenticated.
 //!
 //! # Maintenance semantics
 //!
-//! The ops that change scope parentage — grant, scope dissolution, cross-scope
-//! moves of a scope root — maintain the index under **dest-first +
-//! observed-repair** move semantics (#38 D6):
+//! Parentage-changing ops (grant, scope dissolution, cross-scope move) maintain
+//! the index under **dest-first + observed-repair** (#38 D6):
 //!
-//! - **Dest-first**: publish the add into the destination parent's index before
-//!   the presence-conditional remove from the source — so no window leaves the
-//!   child absent from both, and orphans are structurally impossible. A race
-//!   loser compensates by undoing its dest-add ([`undo_dest_add`]).
-//! - **Observed repair**: any write-capable client that sees a child missing
-//!   from its parent's index repairs it ([`repair_observed`]) — the sweep
-//!   self-heal for "a scope root encountered but missing from its parent's index
-//!   is repaired and flagged".
+//! - **Dest-first**: add into the destination parent's index before the
+//!   presence-conditional remove from the source, so no window leaves the child
+//!   absent from both — orphans are structurally impossible. A race loser undoes
+//!   its dest-add ([`undo_dest_add`]).
+//! - **Observed repair**: any write-capable client that sees a child missing from
+//!   its parent's index repairs it ([`repair_observed`]).
 //!
 //! # Deterministic convergence
 //!
-//! Entries are ordered by `scope_id` ([u8; 16]) using Rust's byte-slice `Ord`
-//! (the documented cross-platform total order) so replayed / multi-writer runs
-//! converge to identical bytes. A `scope_id` names exactly one child, so
-//! permutation-independence holds over any set of **distinct** ids, and the
-//! index is deduplicated on `scope_id`. Two entries sharing an id but differing
-//! in `ipns_name`/unknown fields is an invariant violation the maintenance ops
-//! never emit; the **first-seen** dedup is the deliberate replace-wins operation
-//! policy ([`insert_child`] prepends the authoritative entry so it wins), not a
-//! content-level convergence tie-break (see [`canonicalize`]).
+//! Entries are ordered and deduped by `scope_id` byte `Ord` so replayed /
+//! multi-writer runs converge to identical bytes. A `scope_id` names exactly one
+//! child, so **first-seen** dedup is the deliberate replace-wins operation policy
+//! (ops prepend the authoritative entry), not a content tie-break — see
+//! [`canonicalize`].
 
 use cipherbox_core::seal::ChildScopeRef;
 
@@ -51,13 +35,12 @@ use cipherbox_core::seal::ChildScopeRef;
 /// primitive: any permutation of a set of **distinct** `scope_id`s yields
 /// byte-identical output.
 ///
-/// First-seen (not last) is the dedup rule because the maintenance ops
-/// ([`insert_child`], [`repair_observed`]) prepend the authoritative entry
-/// before canonicalizing, so a fresh add wins over a stale duplicate. Because a
-/// `scope_id` names exactly one child, differing-content duplicates are an
-/// invariant violation the ops never produce; first-seen is the replace-wins
-/// operation policy, not a content tie-break, so a permutation-blind full-entry
-/// order would wrongly override that policy.
+/// First-seen (not last) is the rule because the maintenance ops
+/// ([`insert_child`], [`repair_observed`]) prepend the authoritative entry, so a
+/// fresh add wins over a stale duplicate. A `scope_id` names exactly one child, so
+/// differing-content duplicates are an invariant violation the ops never produce;
+/// first-seen is the replace-wins operation policy, not a content tie-break a
+/// permutation-blind full-entry order could wrongly override.
 pub fn canonicalize(entries: &[ChildScopeRef]) -> Vec<ChildScopeRef> {
     let mut sorted: Vec<ChildScopeRef> = entries.to_vec();
     // Stable sort keeps first-seen order among equal ids, so the retain below

--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -1,43 +1,25 @@
 //! Owner-side read-grant creation (blueprint/engine.md "Grants and ledger:
 //! Grant creation"; #635).
 //!
-//! Minting the owner-only sharing path for a **read** grant, as the exact
-//! sequence the blueprint fixes:
-//!
-//! 1. **Converge** the subtree — run the [`sweep_pass`] over the granted
-//!    folder's descendant scope roots. A grant over a subtree that cannot be
-//!    proven epoch-converged is rejected **fail-closed** ([`CreateGrantError::
-//!    SubtreeNotConverged`] / [`CreateGrantError::Converge`]); a new grantee must
-//!    never be able to regress through an ancestor scope's history (CONTEXT.md
-//!    "Epoch-converged"). This is the load-bearing correctness rule.
-//! 2. **Mint the scope at read epoch 1** — a fresh **random** override seed (via
-//!    the injected [`Entropy`] seam, never KDF-derived), assembled into the
-//!    grantee scope root by [`reseal_scope_root`] with `prev = None` (the new
-//!    grantee needs no history).
-//! 3. **Parent index update** — move the folder's descendant scope roots into the
-//!    new scope's direct-child-scope index and insert the new scope root into the
-//!    parent's, under the dest-first / never-orphan discipline of
-//!    [`child_index`](super::child_index).
-//! 4. **Publish** — the grantee scope root first (register-first: it exists
-//!    before anything references it), then the reparented parent.
-//! 5. **Mailbox share pointer** — the sealed [`SharePointer`] posted to the
-//!    recipient's mailbox (sender signature inside the seal), with a fresh
-//!    HPKE ephemeral scalar drawn from entropy.
+//! Mints the owner-only **read** sharing path in the sequence the blueprint
+//! fixes: converge the subtree, mint the grantee scope at read epoch 1, reparent
+//! the descendant scope roots, publish grantee-first, then post the sealed share
+//! pointer. Convergence is the load-bearing correctness rule — a grant over a
+//! subtree that cannot be proven epoch-converged is refused **fail-closed**, so a
+//! new grantee can never regress through an ancestor scope's history (CONTEXT.md
+//! "Epoch-converged"). Each step carries its rationale inline.
 //!
 //! # Simulation boundary
 //!
-//! This is a deterministic-simulation slice: entropy is the injected
-//! [`Entropy`] seam and the read/floor/publish/mailbox effects are the faked
-//! seams (`SweepResolver`, `FloorStore`, `ScopeRootPublisher`, `Mailbox`). No
-//! clock or RNG is read. Production resolver/publisher wiring is deferred to
-//! #745/#746, mirroring the rotation primitives (#744/#747/#749/#760).
+//! Deterministic-simulation slice: entropy is the injected [`Entropy`] seam and
+//! the read/floor/publish/mailbox effects are faked. Production resolver/
+//! publisher wiring is deferred to #745/#746 (mirroring #744/#747/#749/#760).
 //!
 //! # Deferred (follow-on slices of #635)
 //!
 //! - **Write grants**: the write-scope cut via [`rotate_scope_write`](super::
-//!   super::rotation::rotate_scope_write) plus the both-seeds grant blob. Read
-//!   grant creation is the clean cut point; write grants layer the write-scope
-//!   cut on top of this identical skeleton.
+//!   super::rotation::rotate_scope_write) plus the both-seeds grant blob, layered
+//!   on this identical skeleton.
 //! - **Invites**: ephemeral-key blobs, bearer write-link flagging, claim
 //!   conversion.
 //!
@@ -385,8 +367,7 @@ where
         .await
         .map_err(CreateGrantError::Publish)?;
 
-    // 6) Parent index update: remove the reparented descendants, insert the new
-    // scope root, then re-seal + publish the parent (metadata-only, same epoch).
+    // 6) Parent index update — a metadata-only re-seal at the same epoch.
     let mut parent_index = parent.current_child_index.to_vec();
     for descendant in grantee.subtree_child_index {
         parent_index = remove_child(&parent_index, &descendant.scope_id);

--- a/crates/engine/src/grants/ledger.rs
+++ b/crates/engine/src/grants/ledger.rs
@@ -2,23 +2,20 @@
 //! (blueprint/engine.md "Grants and ledger", #25 D1/D7, #26 D5, #39 D1).
 //!
 //! Grants live in the published scope root: grant blobs keyed by blinded tags,
-//! the authoritative ledger `(recipientIdentityPk, recipientEncPk, permission,
-//! tag)` in the write-body, and the epoch-free owner-signed grant-set
-//! commitment. This module composes core's codecs/KDF over those three; it
-//! mints nothing (grant creation needs the rotation primitives of #635) and
-//! holds no crypto.
+//! the authoritative write-body ledger, and the epoch-free owner-signed grant-set
+//! commitment. This module composes core's codecs/KDF over those three; it mints
+//! nothing (grant creation rides the #635 rotation primitives) and holds no crypto.
 //!
 //! Two boundary rules it enforces:
 //!
 //! - **Self-location** — a recipient re-derives its own blinded tag from the
 //!   pairwise ECDH of its encryption subkey with the sharer's, plus the scope
-//!   root's `ipnsName`, then locates its grant blob by that public tag. Tags are
-//!   public, so the lookup needs no constant-time guarantee.
-//! - **Owner-only authority** — sharing, revoking, and every commitment change
-//!   are owner-only; a write-grantee re-wraps blobs for the committed set during
-//!   a re-seal but can neither add nor drop a tag. [`enforce_committed_ledger`]
-//!   is the resolve-side check that a re-sealed write-body's ledger still
-//!   matches the owner-signed committed set exactly.
+//!   root's `ipnsName`, then locates its blob by that public tag. Tags are public,
+//!   so the lookup needs no constant-time guarantee.
+//! - **Owner-only authority** — sharing, revoking, and every commitment change are
+//!   owner-only; a write-grantee re-wraps blobs for the committed set but can
+//!   neither add nor drop a tag. [`enforce_committed_ledger`] is the resolve-side
+//!   check that a re-sealed ledger still matches the owner-signed committed set.
 
 use std::collections::BTreeMap;
 

--- a/crates/engine/src/grants/mod.rs
+++ b/crates/engine/src/grants/mod.rs
@@ -1,16 +1,12 @@
-//! Grants — the ledger, commitment, pseudonyms, contact import, share lists,
-//! and the accept flow (blueprint/engine.md "Grants and ledger").
+//! Grants — the ledger, commitment, contact import, share lists, and the accept
+//! flow (blueprint/engine.md "Grants and ledger", grants-in-metadata #25 D1).
 //!
-//! Grants live in the published scope root (grants-in-metadata, #25 D1): grant
-//! blobs keyed by blinded tags, the authoritative ledger in the write-body, and
-//! the epoch-free owner-signed grant-set commitment. This module is the engine
-//! layer that *composes* `crates/core`'s grant/contact/mailbox codecs and KDF
-//! edges into the stateful behaviour — self-location, owner-only authority,
-//! contact import, the accept flow, revocation classification, and the owner
-//! seed cross-check. It mints no grants: grant *creation*, invites, and revoke
-//! *actions* ride the rotation primitives of a sibling slice (#635). Every trust
-//! decision here is a composed core verdict or the adoption gate's; this layer
-//! holds no crypto.
+//! The engine layer that *composes* `crates/core`'s grant/contact/mailbox codecs
+//! and KDF edges into stateful behaviour — self-location, owner-only authority,
+//! contact import, the accept flow, revocation classification, and the owner seed
+//! cross-check. It mints no grants: creation, invites, and revoke actions ride the
+//! #635 rotation primitives. Every trust decision is a composed core verdict or
+//! the adoption gate's; this layer holds no crypto.
 
 pub mod accept;
 pub mod child_index;

--- a/crates/engine/src/net/eol.rs
+++ b/crates/engine/src/net/eol.rs
@@ -28,9 +28,7 @@ const SECS_PER_DAY: u64 = 24 * 60 * 60;
 ///
 /// Designed-for cadence, not yet a frozen profile constant: like the sweep
 /// cadence (blueprint/engine.md "Open edges"), it joins the sync timing
-/// profile once the testing-strategy measurement process fixes it. The
-/// end-to-end timelines that exercise it run on virtual time, so a real 30-day
-/// value stays fast to test.
+/// profile once the testing-strategy measurement process fixes it.
 pub const EOL_RENEW_THRESHOLD: Duration = Duration::from_secs(30 * SECS_PER_DAY);
 
 /// The full client-signed EOL window (90 days), as a [`Duration`]. Mirrors

--- a/crates/engine/src/net/liveness.rs
+++ b/crates/engine/src/net/liveness.rs
@@ -32,8 +32,7 @@ use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler
 ///
 /// Designed-for cadence, not yet a frozen profile constant — like the sweep
 /// cadence (blueprint/engine.md "Open edges"), it joins the sync timing profile
-/// once measured. The facade slice wraps the job body below in a
-/// `Scheduler`-driven loop at this cadence.
+/// once measured.
 pub const RE_PUT_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
 /// One held record to keep alive: its routing key (the `ipnsName`) and the exact

--- a/crates/engine/src/rotation/cascade.rs
+++ b/crates/engine/src/rotation/cascade.rs
@@ -4,71 +4,51 @@
 //!
 //! # What the cascade is
 //!
-//! On an **owner read-revocation**, `rotateScope` must fully re-key the rotated
+//! On an owner read-revocation, [`cascade_rotate_scope`] re-keys the rotated
 //! scope root **plus every transitively-reachable descendant scope root**, each
-//! with a **fresh random override seed** — grant blobs re-sealed for the
-//! committed set, owner blob, history-link ratchet, and ascent link under the
-//! **parent's new derivation**. Cost is O(descendant scope count), never tree
-//! size. This module is that whole rotation: [`cascade_rotate_scope`] re-keys the
-//! root (the thread head) and then walks the descendant tree top-down, re-keying
-//! every descendant through the shared [`reseal_scope_root`] helper with
-//! `prev = Some(fresh seed)`.
+//! with a **fresh random override seed**, re-sealing through [`reseal_scope_root`]
+//! with `prev = Some(fresh seed)`. Cost is O(descendant scope count), never tree
+//! size.
 //!
-//! # Why the fresh-seed cascade — and only it — completes a revoke
+//! # Why only the fresh-seed cascade completes a revoke
 //!
-//! A party who cached a *descendant* scope root's override seed can open that
-//! descendant's records at **any** epoch: the descendant's structure keys derive
-//! from its own override seed, and the epoch lives only in the AAD. Raising the
-//! epoch floor and letting the **sweep** converge each descendant does **not**
-//! lock that party out — the sweep re-seals metadata reusing each descendant's
-//! **existing** seed (`prev = None`), so a floor-raise + sweep merely walks the
-//! revoked reader's cached seed forward to the new epoch. Only minting a
-//! **fresh** seed per descendant — this cascade — actually revokes the cached
-//! access. This is the cross-slice invariant: **revocation re-keys descendants
-//! via the fresh-seed cascade, never via floor-raise + sweep** (the seed changes;
-//! it is not an epoch bump over the same seed).
+//! A party who cached a *descendant* scope root's override seed opens that
+//! descendant at **any** epoch — its structure keys derive from the seed and the
+//! epoch is only AAD. A floor-raise + **sweep** reuses each descendant's existing
+//! seed (`prev = None`), merely walking the revoked reader's cached seed forward;
+//! only minting a **fresh** seed per descendant revokes the cached access. This
+//! is the cross-slice invariant: revocation re-keys descendants via the
+//! fresh-seed cascade, never via floor-raise + sweep.
 //!
 //! # Top-down seed threading
 //!
-//! A descendant's ascent link is sealed to a keypair derived from its **parent
-//! node seed** = `node_seed(parent_override_seed, child_scope_id)`
-//! (`crates/engine/src/gate/adoption.rs`, the ascent-authority derive-and-verify).
-//! When the parent is re-keyed to a fresh override seed, that parent node seed
-//! changes, so the child's ascent link **must** be re-sealed under the parent's
-//! **new** derivation — else an ancestor descending with the parent's new seed
-//! could not reach the child, and (worse) the child's ascent link would still
-//! open under the parent's *stale* seed, leaving a revoked ancestor a path in.
-//! The cascade therefore walks **top-down**, minting the root's fresh seed first
-//! and threading each parent's freshly-minted seed to its children. The
-//! [`CascadeTarget`] a descendant resolves to deliberately carries **no**
-//! `parent_node_seed`: it is always threaded, never taken from the descendant's
-//! own (stale) published record.
+//! A descendant's ascent link is sealed to a keypair derived from its parent node
+//! seed `node_seed(parent_override_seed, child_scope_id)`
+//! (`crates/engine/src/gate/adoption.rs`). Re-keying the parent changes that
+//! derivation, so the walk runs **top-down**, threading each parent's
+//! freshly-minted seed so the child's ascent link re-seals under the parent's
+//! **new** seed — else the link still opens under the stale seed, leaving a
+//! revoked ancestor a path in. [`CascadeTarget`] carries **no** `parent_node_seed`:
+//! it is always threaded, never taken from the descendant's own stale record.
 //!
 //! # Fail-closed completeness
 //!
-//! An owner-revocation rotation that skips any reachable descendant is a **silent
-//! revocation hole**, not staleness. The walk mirrors [`enumerate_eager_set`]'s
-//! discipline — canonicalized frontiers, a `scope_id`-keyed visited set for
-//! diamond/cycle termination, and a **hard abort** naming the first descendant it
-//! cannot resolve, re-seal, publish, or floor-raise. It never returns a partial
-//! [`CascadeOutcome`] a caller could mistake for a complete revoke. Some durable
-//! re-keys may already have landed before an abort (there is no distributed
-//! transaction); that is safe and retryable — every re-key is monotonic (a fresh
-//! seed at a higher epoch) — and the `Err` tells the caller the revoke is
-//! incomplete and must be retried, so success is never *claimed* on a partial
-//! cascade. A retry re-resolves current network state and rebuilds the plan; it
-//! must not replay a plan whose root/descendants already advanced, or the stale
-//! epoch transition loses CAS.
+//! Skipping any reachable descendant is a silent revocation hole, not staleness.
+//! The walk mirrors [`enumerate_eager_set`] — canonicalized frontiers, a
+//! `scope_id`-keyed visited set for diamond/cycle termination, and a hard abort
+//! naming the first descendant it cannot resolve, re-seal, publish, or
+//! floor-raise, never a partial [`CascadeOutcome`] mistakable for a complete
+//! revoke. Some re-keys may land before an abort (no distributed transaction) —
+//! safe and retryable, since every re-key is monotonic (a fresh seed at a higher
+//! epoch); the retry re-resolves current state and rebuilds the plan rather than
+//! replaying one whose nodes already advanced (which would lose CAS).
 //!
 //! # Determinism
 //!
-//! Entropy enters only through the [`Entropy`] seam (every fresh seed) and time
-//! only through the [`Scheduler`] seam (the enqueued sweep); the walk itself reads
-//! no clock and samples no randomness of its own. The sole impure edges are the
-//! injected [`CascadeResealResolver`] (resolve + gate + unseal a descendant's
-//! re-seal material) and [`ScopeRootPublisher`] (CAS-publish) — the same two
-//! edges `rotate_scope` and the sweep carry. The real network/gate wiring of the
-//! resolver is #745/#746; this slice fakes it and proves the cascade in
+//! Entropy enters only through [`Entropy`] and time only through [`Scheduler`];
+//! the sole impure edges are the injected [`CascadeResealResolver`] and
+//! [`ScopeRootPublisher`] (as `rotate_scope` and the sweep also carry). Real
+//! resolver wiring is #745/#746; this slice fakes it and proves the cascade in
 //! simulation.
 //!
 //! [`enumerate_eager_set`]: super::eager_set::enumerate_eager_set

--- a/crates/engine/src/rotation/eager_set.rs
+++ b/crates/engine/src/rotation/eager_set.rs
@@ -5,61 +5,46 @@
 //! # What it computes
 //!
 //! Given a scope root, the eager set is **every transitively-reachable
-//! descendant scope root** — the F-4 cascade set. The root's level-1 adjacency
-//! is its own write-body `direct_child_scope_index` (already in the rotator's
-//! hand); every deeper level is read from *each descendant's own* write-body
-//! index (blueprint/engine.md: "Enumeration walks the write-body's
-//! direct-child-scope index", #38 D6). Cost is O(descendant scope count), never
-//! tree size — a scope-less subtree contributes nothing to walk.
-//!
-//! The returned [`EagerSet`] holds the **descendants only**: the rotator already
-//! holds the root and rotates it directly, so re-emitting it here would be
-//! redundant. The root is still tracked internally so a back-edge to it
-//! terminates.
+//! descendant scope root** — the F-4 cascade set. The root's level-1 adjacency is
+//! its own write-body `direct_child_scope_index` (caller-held); each deeper level
+//! is read from *each descendant's own* write-body index (#38 D6). Cost is
+//! O(descendant scope count), never tree size. The returned [`EagerSet`] holds
+//! the **descendants only** — the rotator holds and rotates the root directly —
+//! though the root is tracked internally so a back-edge to it terminates.
 //!
 //! # Why completeness is a security property
 //!
-//! Read-plane rotation is how a revocation takes effect: an owner-revocation
-//! rotation must re-seal *every* reachable descendant so no cached descendant
-//! seed survives (blueprint/engine.md: "Cached descendant seeds are why
-//! ascent-re-seal alone is insufficient"). A descendant silently missing from
-//! the eager set is a **silent revocation hole**, not staleness — the revoked
-//! party keeps a live seed. Completeness is therefore enforced fail-closed:
-//!
-//! - The walk resolves *every* discovered descendant. If any reachable
-//!   descendant's index cannot be authoritatively obtained (its record fails the
-//!   adoption gate, or is unavailable), the walk returns [`EnumerationError`]
-//!   naming that scope — it **never** returns a partial set a caller could
-//!   mistake for complete. `EagerSet` has no public constructor other than a
-//!   successful walk, so "an incomplete eager set" is unrepresentable.
-//! - This mirrors the adoption gate's own split (`GateError::Rejected` vs
-//!   `Seam`): a trust rejection and a host-I/O failure are distinct
-//!   ([`ResolveFailure`]) but *both* block a claim of completeness. A resolve
-//!   failure is a fail-closed trust boundary, never mere staleness
-//!   (AGENTS.md critical security rule 6).
+//! A revocation rotation must re-seal *every* reachable descendant so no cached
+//! descendant seed survives; a descendant silently missing from the eager set is
+//! a **silent revocation hole**, not staleness — the revoked party keeps a live
+//! seed. Completeness is therefore fail-closed: the walk resolves every
+//! discovered descendant, and any that cannot be authoritatively obtained (its
+//! record fails the adoption gate, or is unavailable) returns [`EnumerationError`]
+//! naming that scope, never a partial set. `EagerSet` has no public constructor
+//! other than a successful walk, so an incomplete set is unrepresentable.
+//! [`ResolveFailure`] mirrors the adoption gate's `Rejected` vs `Seam` split — a
+//! trust rejection and a host-I/O failure are distinct but *both* block a
+//! completeness claim; a resolve failure is a fail-closed trust boundary, never
+//! staleness (AGENTS.md critical security rule 6).
 //!
 //! # Termination and bounding
 //!
-//! The graph is walked with a visited set keyed by `scope_id`: a scope root is
-//! resolved at most once, so a cycle (a corrupt or adversarial index claiming a
-//! back-edge) is skipped, not followed — the walk always terminates. No depth or
-//! count cap is imposed: the eager set of a legitimately large owner tree must
-//! not be rejected. A compromised descendant index that injects fake children
-//! cannot amplify unboundedly either — each frontier is canonicalized and the
-//! walk aborts at the first resolve that fails the gate, so at most the scopes
-//! ordered before the first forgery's canonical position are resolved (bounded
-//! by the genuinely gate-passing scopes the attacker controls), never an
-//! unbounded injected fan-out.
+//! A `scope_id`-keyed visited set resolves each scope root at most once, so a
+//! cycle (a corrupt/adversarial back-edge) is skipped, not followed — the walk
+//! always terminates. No depth or count cap is imposed (a legitimately large
+//! owner tree must not be rejected); an injected fake fan-out cannot amplify
+//! unboundedly either, since each frontier is canonicalized and the walk aborts
+//! at the first gate-failing resolve, bounding resolves to the gate-passing
+//! scopes ordered before the first forgery.
 //!
 //! # Determinism
 //!
-//! The walk is pure: no clock, RNG, or I/O of its own — the sole impure edge is
-//! the injected [`ChildIndexResolver`]. Output is ordered by `scope_id` byte
-//! `Ord` (a [`BTreeMap`] keyed by `scope_id`, matching Slice 1's
-//! [`canonicalize`](crate::grants::child_index::canonicalize) convention), and
-//! each level is canonicalized before descent, so the first-seen entry for any
-//! shared descendant is fixed regardless of input permutation. Replayed or
-//! multi-writer runs converge to byte-identical output.
+//! The walk is pure — the sole impure edge is the injected [`ChildIndexResolver`].
+//! Output is ordered by `scope_id` (a [`BTreeMap`], matching Slice 1's
+//! [`canonicalize`](crate::grants::child_index::canonicalize) convention) and each
+//! level is canonicalized before descent, so the first-seen entry for any shared
+//! descendant is permutation-independent. Replayed or multi-writer runs converge
+//! to byte-identical output.
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/crates/engine/src/rotation/mod.rs
+++ b/crates/engine/src/rotation/mod.rs
@@ -17,11 +17,10 @@
 //!   seeds — that fresh-seed eager-set republish is the [`cascade`]'s job.
 //! - [`cascade`] — the owner-revocation eager cascade (`rotateScope` on a read
 //!   revoke): re-key the root **and every transitively-reachable descendant scope
-//!   root** with a **fresh** override seed (`prev = Some`), threaded top-down so
-//!   each descendant's ascent link re-seals under its parent's new derivation.
+//!   root** with a **fresh** override seed (`prev = Some`), threaded top-down.
 //!   This — not the sweep — completes a read revoke by locking out cached
-//!   descendant seeds. Proven in simulation against faked seams; the production
-//!   resolver wiring is #745/#746.
+//!   descendant seeds. Proven in simulation; production resolver wiring is
+//!   #745/#746.
 //!
 //! - [`rotate_write`] — `rotateScopeWrite`, the owner-only write-plane rotation:
 //!   a fresh write override seed, a bumped `writeEpoch`, and a child-first name

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -1,35 +1,30 @@
 //! The shared scope-root re-seal helper (blueprint/engine.md "Rotation
 //! primitives: rotateScope", "sweep"; CONTEXT.md "Grant section").
 //!
-//! [`reseal_scope_root`] is the one primitive that assembles a scope root's
-//! signed [`GrantSection`] — its grant blobs (re-wrapped for the committed set),
-//! owner blob, ascent link, per-epoch history links, and sealed write-body —
-//! each detached-signed by the rotator's writer pseudonym. It is deliberately a
-//! **pure composition** of `crates/core`'s seal primitives: it holds no crypto,
-//! samples no entropy of its own (the injected [`Entropy`] seam supplies every
-//! HPKE ephemeral scalar and every seal nonce), and reads no clock.
-//!
-//! It is parameterised on its [`ResealSeeds`] source so both rotation callers use
-//! the same code:
+//! [`reseal_scope_root`] assembles a scope root's signed [`GrantSection`] — its
+//! grant blobs (re-wrapped for the committed set), owner blob, ascent link,
+//! per-epoch history links, and sealed write-body — each detached-signed by the
+//! rotator's writer pseudonym. It is a **pure composition** of `crates/core`'s
+//! seal primitives: no crypto of its own, it samples no entropy (the injected
+//! [`Entropy`] seam supplies every HPKE ephemeral scalar and seal nonce), and
+//! reads no clock. Its [`ResealSeeds`] source is the axis both callers share:
 //!
 //! - **`rotateScope`** passes a fresh random override seed at a new read epoch
 //!   plus the prior seed for a fresh history link — the read-plane root cut.
-//! - **the sweep** (Slice 3) passes the scope's *existing* override seed at the
-//!   *current* epoch with `prev = None` — a metadata-only catch-up that mints no
-//!   new seed and no new history link (blueprint/engine.md "Sweeps re-seal
-//!   metadata only").
+//! - **the sweep** passes the scope's *existing* seed at the *current* epoch with
+//!   `prev = None` — a metadata-only catch-up minting no new seed or history link
+//!   (blueprint/engine.md "Sweeps re-seal metadata only").
 //!
 //! # Revocation completeness is the point
 //!
 //! A grant blob is re-wrapped for **exactly** the committed set: one blob per
 //! grant-ledger entry, and the ledger MUST equal the owner-signed commitment
-//! (`(tag → permission)`) — enforced fail-closed up front via
-//! [`enforce_committed_ledger`], the same invariant the adoption gate checks on
-//! resolve (encode/decode fail-closed symmetry, AGENTS.md rule 8). A revoked
-//! grantee, having been removed from the commitment and the ledger by the
-//! read-revoke trigger, is therefore **absent** from the re-wrapped blobs — that
-//! absence is the revocation. A write-grantee re-wrapping cannot add or drop a
-//! tag: a divergent ledger is rejected here, never sealed.
+//! (`(tag → permission)`), enforced fail-closed up front via
+//! [`enforce_committed_ledger`] — the encode-side mirror of the adoption gate's
+//! resolve check (AGENTS.md rule 8). A grantee removed from the commitment and
+//! ledger by the read-revoke trigger is therefore **absent** from the re-wrapped
+//! blobs — that absence is the revocation; a divergent ledger is rejected here,
+//! never sealed.
 
 use zeroize::Zeroize;
 

--- a/crates/engine/src/rotation/rotate.rs
+++ b/crates/engine/src/rotation/rotate.rs
@@ -13,27 +13,27 @@
 //! # Effect ordering is crash-safety
 //!
 //! The three durable effects run in a fixed order — **publish → raise floor →
-//! enqueue sweep** — and a failure at any step returns before the next runs, so
-//! no partially-rotated, fail-open, or locked-out state is ever left behind:
+//! enqueue sweep** — each returning before the next on failure, so no
+//! partially-rotated, fail-open, or locked-out state is left behind:
 //!
 //! - Publishing the new-epoch record **before** raising the floor means a crash
 //!   between them leaves the old-epoch records still gate-passing (the floor has
 //!   not moved) rather than demanding an epoch no published record satisfies — a
 //!   lockout. The rotation simply re-runs; it is monotonic (a fresh seed, a
 //!   higher epoch) and idempotent-safe under CAS. Raising the floor first would
-//!   invert this into the lockout the two-phase-adopt lesson warns against.
-//! - The residual window this ordering accepts — a revoked reader whose old-epoch
-//!   forgeries still pass until the floor rises on the completing run — is exactly
-//!   the documented read-only-survivor residual (#38, "~one pointer-consult
+//!   invert this into that lockout.
+//! - The residual window this accepts — a revoked reader whose old-epoch
+//!   forgeries still pass until the floor rises on the completing run — is the
+//!   documented read-only-survivor residual (#38, "~one pointer-consult
 //!   interval"), never a lost revocation boundary.
 //! - The sweep is enqueued **last**, only after the cut is durable; it is
 //!   best-effort and idempotent, so losing it to a crash costs only a delayed
-//!   lazy wave, which the next ordinary write or scheduled sweep advances anyway.
+//!   lazy wave the next ordinary write or scheduled sweep advances.
 //!
-//! The eager-set descendant scope roots (#744's enumeration) are each re-sealed
-//! through this same [`reseal_scope_root`] helper by the cascade orchestration
-//! once the resolver/tree wiring lands (#745/#746); this primitive lands the root
-//! cut and its crash-safe effect ordering.
+//! The eager-set descendant scope roots (#744's enumeration) are re-sealed
+//! through this same [`reseal_scope_root`] helper by the cascade once the
+//! resolver/tree wiring lands (#745/#746); this primitive lands the root cut and
+//! its crash-safe effect ordering.
 
 use zeroize::Zeroizing;
 

--- a/crates/engine/src/rotation/rotate_write.rs
+++ b/crates/engine/src/rotation/rotate_write.rs
@@ -1,89 +1,63 @@
 //! `rotateScopeWrite` — the owner-only write-plane rotation (blueprint/engine.md
 //! "Rotation primitives: rotateScopeWrite", #26 D3, #38 D3, #34 D4).
 //!
-//! The third rotation primitive. Where [`rotate_scope`](super::rotate::rotate_scope)
-//! cuts the **read** plane (a fresh override seed, `minReadEpoch` moves) and the
-//! [`cascade`](super::cascade) re-keys descendant read scopes, this cuts the
-//! **write** plane: a fresh **write override seed**, a bumped `writeEpoch`, and a
-//! background **child-first name wave** that republishes the write scope's subtree
-//! under freshly derived names — the **root re-pointed last**, so a resolver
-//! following the stable scope pointer always reaches a live chain mid-wave.
+//! The third rotation primitive: where [`rotate_scope`](super::rotate::rotate_scope)
+//! cuts the read plane and [`cascade`](super::cascade) re-keys descendant read
+//! scopes, this cuts the **write** plane — a fresh write override seed, a bumped
+//! `writeEpoch`, and a background child-first name wave.
 //!
-//! # What changes on a write rotation (and what does not)
+//! # What changes (and what does not)
 //!
-//! A node's `ipnsName`, its IPNS signing keypair, and its `writeKey` all derive
-//! from its write seed `writeSeed(node) = KDF(writeScopeSeed, node.id)`
-//! (CONTEXT.md "Write seed"). Minting a fresh **write scope seed** therefore moves
-//! every node to a fresh name under a fresh signing key. The **read plane is
-//! untouched**: override seeds, read keys, and `minReadEpoch` are carried verbatim
-//! (content bytes are never re-encrypted by any rotation path, #26 D6). Surviving
-//! write-grantees derive every new name locally (zero re-discovery); read-only
-//! survivors follow the owner-signed re-point object.
+//! `ipnsName`, the IPNS signing keypair, and `writeKey` all derive from
+//! `writeSeed(node) = KDF(writeScopeSeed, node.id)` (CONTEXT.md "Write seed"), so a
+//! fresh write scope seed moves every node to a fresh name under a fresh signing
+//! key. The read plane is untouched — override seeds, read keys, and `minReadEpoch`
+//! carry verbatim, and no rotation path re-encrypts content bytes (#26 D6).
+//! Write-grantees derive the new names locally; read-only survivors follow the
+//! owner-signed re-point object.
 //!
-//! # Ordering is the safety property (child-first, root-last, linger)
+//! # Ordering is the safety property (#34 D4)
 //!
-//! The wave republishes **descendants first** at their new names, then the root
-//! **last**, and only then re-points the stable scope pointer at the new root.
-//! Old names **linger** — interior old names batch-retire at completion, the old
-//! root name lingers past the migration window (#34 D4). Composed:
-//!
-//! - A new name is **registered before** its predecessor is retired (register-
-//!   first, never orphan a name — the same pin/name-registry quota discipline the
-//!   API enforces). Interior retirement happens only **after** the root re-point.
-//! - Because old names stay live until the switch and the pointer flips last, at
-//!   every instant a resolver reaches every node by **at least one** live name:
-//!   via the old root → old names before the flip, via the new root → new names
-//!   after it. There is never a window with no live pointer to a descendant.
+//! Republish descendants first at their new names, the root last, then flip the
+//! stable scope pointer. A new name is **registered before** its predecessor is
+//! retired (register-first, never orphan a live name — the API's pin/name-registry
+//! quota discipline); interior old names batch-retire only **after** the root
+//! re-point, and the old root name lingers past the migration window. Old names
+//! stay live until the flip and the pointer flips last, so at every instant a
+//! resolver reaches every node by at least one live name.
 //!
 //! # Three-channel re-point (#38 D3)
 //!
 //! The owner-identity-signed re-point object `{scopeId, currentRootName,
-//! writeEpoch, minReadEpoch, prevRootName}` publishes to three channels: the
-//! scope pointer record (canonical), the mailbox (accelerator, verifiable), and
-//! the old root name's tombstone (accelerator, feeding the depth-guarded
-//! `movedTo` chase). `writeEpoch` advances here; `minReadEpoch` is carried
-//! unchanged (only owner read rotations move it), so each plane's clock is
-//! authored by the authority that owns it (#38 D1).
+//! writeEpoch, minReadEpoch, prevRootName}` publishes to the scope pointer record
+//! (canonical), the mailbox, and the old root name's tombstone (feeding the
+//! depth-guarded `movedTo` chase). `writeEpoch` advances here; `minReadEpoch` is
+//! carried unchanged, so each plane's clock is authored by its owning authority
+//! (#38 D1).
 //!
 //! # Crash recovery from published records only (#26 D8)
 //!
-//! No job records, no checkpoints: this orchestrator holds no state across a
-//! crash. A pre-publish crash changed nothing durable; a resumed wave re-derives
-//! every node's deterministic new name and **skips** any already-republished node
-//! by querying published state ([`WriteWavePublisher::is_republished`]) — never an
-//! in-memory work-list. The fresh write scope seed a resumed wave re-uses is
-//! recovered from the published root (the write-plane history link); that recovery
-//! is the deferred #745/#746 resolver wiring, so callers thread it back in via
-//! [`RotateScopeWritePlan::resume_write_scope_seed`] and this slice's tests fake
-//! the recovery. register/republish/retire/re-point are all idempotent, so a
-//! resumed wave converges to the same terminal state.
+//! No cross-crash state: a resumed wave re-derives each node's deterministic new
+//! name and skips already-republished nodes via
+//! [`WriteWavePublisher::is_republished`]; register/republish/retire/re-point are
+//! idempotent, so it converges to the same terminal state. The fresh write scope
+//! seed is recovered from the published root (the write-plane history link) — the
+//! deferred #745/#746 resolver wiring, faked here and threaded via
+//! [`RotateScopeWritePlan::resume_write_scope_seed`]. Accepted limitation: a crash
+//! after the pointer flip but before interior retirement orphans the prior run's
+//! interior old names — the fail-safe direction (leaking a registration beats
+//! retiring a live name); reclaim is tracked in #764.
 //!
-//! One accepted limitation: a crash **after** the pointer flips but **before**
-//! interior retirement orphans the prior run's interior old names. Post-flip the
-//! resolver reports every node's new name as current, so the never-orphan-a-live-
-//! name guard finds nothing to retire and no durable read can rediscover the
-//! superseded names. This is the fail-safe direction (leaking a name registration
-//! beats retiring a live one); reclaiming the orphans is tracked in #764.
+//! # Owner-only, fail-closed, deterministic
 //!
-//! # Owner-only, fail-closed
-//!
-//! `rotateScopeWrite` is owner-only: the caller must present the owner identity
-//! signer that authored the current grant-set commitment, verified up front
-//! ([`WriteRotateError::NotOwner`]) — the same owner-identity binding
-//! [`revoke_read_grant`](super::trigger::revoke_read_grant) enforces, and the
-//! encode-side mirror of the pointer read path's owner-signature verify. A
+//! The caller must present the owner identity signer that authored the current
+//! grant-set commitment, verified up front ([`WriteRotateError::NotOwner`]). A
 //! non-advancing `writeEpoch` or an identity re-point is rejected release-active
 //! ([`build_repoint_object`]), never a `debug_assert!` — the encode-side mirror of
-//! the floor law's monotonic write-epoch reject (AGENTS.md rule 8).
-//!
-//! # Determinism
-//!
-//! Entropy enters only through the [`Entropy`] seam (the fresh write scope seed
-//! and the re-point nonce); the wave reads no clock and samples no randomness of
-//! its own. The impure edges are the injected [`WriteSubtreeResolver`] (resolve
-//! the subtree from published records) and [`WriteWavePublisher`] (register /
-//! republish / retire / re-point) — the network wiring behind them is #745/#746;
-//! this slice fakes them and proves the primitive in simulation.
+//! the floor law's monotonic write-epoch reject (AGENTS.md rule 8). Entropy enters
+//! only through the [`Entropy`] seam (fresh seed + re-point nonce); the impure edges
+//! are the injected [`WriteSubtreeResolver`] and [`WriteWavePublisher`] (network
+//! wiring is #745/#746, faked in this slice).
 
 use std::collections::{BTreeSet, VecDeque};
 

--- a/crates/engine/src/rotation/sweep.rs
+++ b/crates/engine/src/rotation/sweep.rs
@@ -8,54 +8,43 @@
 //! eager set from a rotated root and, for every descendant scope root whose
 //! published record epoch lags its scope's durable epoch floor, re-seals that
 //! scope root's **metadata** up to the floor epoch — reusing the scope's
-//! **existing** override seed, `prev = None`, minting no new seed, no new epoch,
-//! and no new history link. Content bytes are never re-encrypted (#26 D6).
+//! **existing** override seed, `prev = None`, minting no new seed, epoch, or
+//! history link. Content bytes are never re-encrypted (#26 D6).
 //!
-//! It deliberately does **not** mint fresh descendant seeds. Fresh-seed
-//! descendant re-keying — the part that defeats a revokee's *cached descendant
-//! seeds* — is `rotateScope`'s **eager-set republish** on an owner-revocation
-//! rotation (blueprint/engine.md "rotateScope", L243-252: "mint a random override
-//! seed at the scope root, republish the eager set, enqueue the sweep"; each
-//! descendant "fully rotated — fresh override seed"). That eager cascade is a
-//! separate piece, currently deferred pending the resolver/tree wiring
-//! (#745/#746). The sweep completes only the **epoch-lag convergence** and the
-//! direct-child-scope index self-heal; it does not, on its own, complete a read
-//! revoke, and re-sealing a descendant with its existing seed does not revoke a
-//! cached descendant seed.
+//! It deliberately does **not** mint fresh descendant seeds — that fresh-seed
+//! eager-set republish, the part that defeats a revokee's cached descendant
+//! seeds, is the [`cascade`](super::cascade)'s job (blueprint/engine.md
+//! "rotateScope", L243-252). The sweep completes only epoch-lag convergence and
+//! the direct-child-scope index self-heal, so re-sealing a descendant with its
+//! existing seed does not on its own complete a read revoke.
 //!
 //! # Completeness is fail-closed
 //!
-//! The work-list is computed purely from **published records** (the epoch-lag
-//! predicate: record epoch `<` the scope's durable epoch floor). There is no
-//! pending-rotation store, no job record, and no checkpoint — published records
-//! are the sole source of truth, so a re-run reconstructs the identical
+//! The work-list is computed purely from **published records** (epoch-lag
+//! predicate: record epoch `<` the scope's durable floor) — no pending-rotation
+//! store, job record, or checkpoint — so a re-run reconstructs the identical
 //! work-list and the pass is idempotent.
 //!
 //! A lagging descendant that cannot be enumerated, resolved, re-sealed, or
-//! published is **never silently skipped** — under-enumeration is a silent hole,
-//! not staleness. Mirroring the eager-set walk's hard-abort posture
-//! ([`enumerate_eager_set`]), a pass aborts with a [`SweepError`] naming the
-//! offending scope rather than returning a partial "converged" claim. The one
-//! spec-mandated per-node exception is a **lost CAS race**: a concurrent write
-//! won the sequence CAS for that node, so the loser drops it and re-resolves
-//! (blueprint/engine.md L276-278). The winner is not necessarily a *sweeper* —
-//! an ordinary metadata write bumps the sequence without advancing the read
-//! epoch — so a dropped node is **not** proven converged by the drop alone. The
-//! idle-cadence driver ([`run_sweep`]) therefore re-runs the idempotent pass
-//! until a pass drops nothing (or the attempt cap is hit), which is what
-//! actually confirms convergence. Availability failures (unavailable resolve,
-//! transport `NotPublished`, floor-read error) abort the pass but are likewise
-//! **retryable**. Trust failures (a rejected record, a divergent ledger, an
+//! published is **never silently skipped** — mirroring the eager-set walk's
+//! hard-abort posture ([`enumerate_eager_set`]), a pass aborts with a
+//! [`SweepError`] naming the offending scope rather than a partial "converged"
+//! claim. The one spec-mandated per-node exception is a **lost CAS race**: a
+//! concurrent write won the sequence CAS, so the loser drops it and re-resolves
+//! (blueprint/engine.md L276-278). The winner may be an ordinary metadata write
+//! (bumps the sequence without advancing the read epoch), so a dropped node is
+//! **not** proven converged by the drop alone — the idle-cadence driver
+//! ([`run_sweep`]) re-runs the idempotent pass until one drops nothing (or the
+//! cap is hit), which is what confirms convergence. Availability failures
+//! (unavailable resolve, transport `NotPublished`, floor-read) abort but are
+//! **retryable**; trust failures (a rejected record, a divergent ledger, an
 //! uncommitted signer) are fatal.
 //!
 //! # Determinism
 //!
-//! Time (the idle cadence) enters only through the [`Scheduler`] seam and entropy
-//! only through the [`Entropy`] seam; the pass itself reads no clock and samples
-//! no randomness of its own beyond what `reseal_scope_root` draws from the
-//! injected entropy. The sole impure edges are the injected [`SweepResolver`]
-//! (resolve + gate + unseal a scope root's re-seal material) and
-//! [`ScopeRootPublisher`] (CAS-publish), mirroring `rotate_scope`; the real
+//! Time (the idle cadence) enters only through [`Scheduler`] and entropy only
+//! through [`Entropy`]; the sole impure edges are the injected [`SweepResolver`]
+//! and [`ScopeRootPublisher`] (CAS-publish), mirroring `rotate_scope`. The real
 //! network wiring is #745/#746 and tests fake both.
 
 use core::time::Duration;

--- a/crates/engine/src/rotation/trigger.rs
+++ b/crates/engine/src/rotation/trigger.rs
@@ -15,25 +15,20 @@
 //! root **and every transitively-reachable descendant scope root** are re-keyed
 //! with a fresh override seed (blueprint/engine.md "rotateScope", L243-252).
 //! **That cascade — not the sweep — completes a read revoke**: a revokee who
-//! cached a descendant scope root's override seed can open that descendant at any
-//! epoch, so only minting a fresh seed per descendant locks them out. The sweep
-//! ([`super::sweep`]) does only metadata-only epoch-lag convergence and the index
-//! self-heal — it reuses the existing seed and never re-keys, so a floor-raise +
-//! sweep would merely walk the revokee's cached seed forward to the new epoch.
-//! [`revoke_read_grant`] performs the owner-only committed-set cut that feeds the
-//! cascade for the root; the cascade re-seals each descendant's own unchanged
-//! committed set. The cascade is proven in simulation against faked seams; the
-//! production resolver/tree wiring of its per-descendant resolve edge is #745/#746.
+//! cached a descendant's override seed can open it at any epoch, so only a fresh
+//! seed per descendant locks them out; a floor-raise + sweep ([`super::sweep`])
+//! would merely walk the cached seed forward. The cascade is proven in simulation
+//! against faked seams; the production per-descendant resolver wiring is #745/#746.
 //!
 //! Scope-exit and manual rotations re-seal the **unchanged** committed set: a
 //! grantee re-wraps blobs verbatim and can neither extend nor shrink the tag set
 //! (#26 D5), so they feed the current commitment/ledger straight into
-//! `rotate_scope`. The read-revoke trigger is the only one that mutates the set —
+//! `rotate_scope`. Read-revoke is the only trigger that mutates the set —
 //! [`revoke_read_grant`] performs the owner-only cut (remove the revokee from the
-//! commitment and the ledger, owner-re-sign) whose result then feeds
-//! `rotate_scope`. The removed grantee is thereby absent from the re-wrapped grant
-//! blobs: that absence **is** the revocation ("they keep what they saw; they lose
-//! everything new, now").
+//! commitment and ledger, owner-re-sign) that then feeds the cascade; each
+//! descendant re-seals its own unchanged set. The removed grantee is thereby
+//! absent from the re-wrapped grant blobs: that absence **is** the revocation
+//! ("they keep what they saw; they lose everything new, now").
 
 use cipherbox_core::seal::{
     GrantLedgerEntry, GrantSetCommitment, sign_grant_set, verify_grant_set,

--- a/crates/engine/src/seams/mod.rs
+++ b/crates/engine/src/seams/mod.rs
@@ -4,8 +4,7 @@
 //! Every capability the engine needs from a host enters through one of these
 //! traits, injected as a constructor argument via [`SeamSet`]. Traits move
 //! opaque bytes and events — no seam holds logic, no domain type leaks into a
-//! seam; the engine owns all interpretation. A missing seam is a compile
-//! error (a missing [`SeamSet`] field), never a runtime gap.
+//! seam; the engine owns all interpretation.
 //!
 //! Determinism is injected: wall clock and timers come only from
 //! [`Scheduler`], entropy only from [`crate::entropy::Entropy`]. Engine logic

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -118,13 +118,11 @@ pub struct ColdStartOutcome {
 }
 
 /// Run the cold-start live-session data path off the injected seams, emitting
-/// the first [`Event::SnapshotUpdated`]. Fail-closed at every trust boundary:
-/// a forged vault-pointer index, an owner-vouched floor regression, and an
-/// adoption-gate rejection all return `Err` — never silent staleness.
-///
-/// Reads no clock and no RNG: the sequence is a pure function of the injected
-/// seams and the [`ColdStartParams`], so a deterministic virtual-time test pins
-/// it and two engines on independent clocks produce the identical outcome.
+/// the first [`Event::SnapshotUpdated`]. Fail-closed at every trust boundary
+/// (see [`ColdStartError`]): a trust violation returns `Err`, never silent
+/// staleness. Reads no clock and no RNG — the sequence is a pure function of the
+/// injected seams and [`ColdStartParams`], so two engines on independent clocks
+/// produce the identical outcome.
 pub async fn cold_start<Pf, Ad, Fl, T, Sc>(
     pointer_fetch: &Pf,
     adopter: &Ad,
@@ -141,9 +139,8 @@ where
     T: RecordTransport,
     Sc: SnapshotCache,
 {
-    // Step 1 — vault-pointer resolve (the first act): probe one past the highest
-    // known index and adopt the highest valid owner-signed payload. A forged
-    // index is fail-closed inside the walk.
+    // Step 1 — vault-pointer resolve (the first act). A forged index is
+    // fail-closed inside the walk.
     let adoption = resolve_vault_pointer(
         pointer_fetch,
         params.login_secret,
@@ -169,9 +166,8 @@ where
         });
     };
 
-    // Step 2 — floor cold-seed, fail-closed on regression. The owner-vouched
-    // epochs seed the durable floors; a re-point that would move either floor
-    // backward is a rolled-back pointer, a trust violation.
+    // Step 2 — floor cold-seed, fail-closed on regression: a re-point that would
+    // move either floor backward is a rolled-back pointer, a trust violation.
     floor::cold_seed_checked(floors, &adoption.repoint)
         .await
         .map_err(|e| match e {

--- a/crates/engine/src/sync/pointer.rs
+++ b/crates/engine/src/sync/pointer.rs
@@ -212,9 +212,8 @@ pub fn open_repoint(
 ///
 /// **Cold start adopts nothing** until this runs: before the floor store seeds
 /// from the owner-signed anchor, every scope's read-epoch floor is unseeded and
-/// the gate can be shown any old-epoch record. The non-circular sequence
-/// (#38 D3): own vault → vault/scope pointer (first act) → floors seeded →
-/// current root name → envelope grant blob → seeds → render.
+/// the gate can be shown any old-epoch record (the non-circular sequence,
+/// #38 D3).
 pub async fn cold_seed_floors<F: FloorStore>(
     floors: &F,
     repoint: &RepointObject,

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -2,12 +2,11 @@
 //! the five per-op race rules, dead-lettering, and dual-link observed repair
 //! (blueprint/engine.md "Sync core: Per-op rebase rules"; CONTEXT.md).
 //!
-//! Replay is FIFO in performed order through the standard rebase, and rebases
-//! **only onto gate-passing state** (#33 D5–D7): the caller resolves a fresh
-//! last-known-good snapshot (every record through the adoption gate) and hands
-//! it here as the base. Each op resolves to exactly one outcome — applied
-//! (possibly auto-suffixed), dropped, or dead-lettered — and an applied op
-//! advances the working base so later ops rebase onto the updated state.
+//! Replay is FIFO in performed order and rebases **only onto gate-passing
+//! state** (#33 D5–D7): the caller resolves a fresh last-known-good snapshot
+//! (every record through the adoption gate) and hands it here as the base. An
+//! applied op advances the working base so later ops rebase onto the updated
+//! state.
 //!
 //! The five races, one rule each:
 //!
@@ -473,14 +472,11 @@ pub enum HeadReconciliation {
 /// sibling record observed at the same name (`observed_record` at
 /// `observed_sequence`) — both already record-verified upstream by the gate.
 ///
-/// This closes the same-sequence split-brain the publish confirm-by-re-resolve
+/// Closes the same-sequence split-brain the publish confirm-by-re-resolve
 /// cannot resolve by sequence alone (deferred from the net publish slice, #692):
-/// two writers each mint a **different** record at `floor + 1`, both land, and
-/// higher-sequence-wins never picks between them. The tiebreak is a total order
-/// over the exact verified record bytes every client fetches, so all clients
-/// converge on the same canonical head with no shared state, and the loser's
-/// re-mint at `sequence + 1` makes the ordinary higher-sequence-wins machinery
-/// finish the job.
+/// the tiebreak is a total order over the exact verified record bytes every
+/// client fetches, so all clients converge on the same canonical head with no
+/// shared state (see [`HeadReconciliation::SameSequenceDivergence`]).
 pub fn reconcile_head(
     local_record: &[u8],
     local_sequence: u64,

--- a/crates/engine/tests/grants_mailbox.rs
+++ b/crates/engine/tests/grants_mailbox.rs
@@ -360,7 +360,6 @@ fn two_instance_share_accept_end_to_end() {
     let owner_device = world.device(b"owner-inbox");
     let recipient_device = world.device(&recipient_address);
 
-    // Owner posts the sealed share pointer to the recipient's mailbox.
     block_on(post_sealed(
         &owner_device.mailbox,
         &fx.recipient_enc.public(),
@@ -383,7 +382,6 @@ fn two_instance_share_accept_end_to_end() {
     });
     assert_eq!(sent.len(), 1);
 
-    // Owner publishes the scope root record to the shared network.
     let endpoint = world.record_store.endpoints()[0].clone();
     world
         .record_store
@@ -404,7 +402,6 @@ fn two_instance_share_accept_end_to_end() {
     );
     assert_eq!(items[0].sender_identity, fx.owner_identity_pub);
 
-    // Recipient resolves the name off the shared store and runs accept.
     let bytes = block_on(
         recipient_device
             .record_store


### PR DESCRIPTION
Extends the existing `### Comments` workaround-apologia rule under `## Code Style` by naming two recurring comment smells that reviews kept flagging: absence-justifying comments (prose defending why a not-present code path does not happen, which rots into a stale in-code falsehood once that path is wired) and unchanged-code apologia (a doc block defending code the change does not modify, which is scope creep into untouched code). Both go beyond merely excusing a hack, and `/simplify`, CodeRabbit, and Greptile all flag them, so the guidance now calls them out explicitly.
