### PR TITLE
feat(api): add a scheduled dormant-mailbox sweep

### DIFF
--- a/apps/api/src/common/config-int.ts
+++ b/apps/api/src/common/config-int.ts
@@ -1,0 +1,10 @@
+/**
+ * Read a positive-integer bound from config, failing closed to `fallback` for an
+ * unset OR garbage value. A misconfigured env var must never silently become
+ * `NaN` (which would disable the bound it controls), so the guard is `> 0` AND
+ * integral — the shared parse for every DoS/efficiency knob.
+ */
+export function positiveIntConfig(raw: unknown, fallback: number): number {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}

--- a/apps/api/src/common/config-int.ts
+++ b/apps/api/src/common/config-int.ts
@@ -3,8 +3,15 @@
  * unset OR garbage value. A misconfigured env var must never silently become
  * `NaN` (which would disable the bound it controls), so the guard is `> 0` AND
  * integral — the shared parse for every DoS/efficiency knob.
+ *
+ * `max` fails closed the same way for an out-of-range value: a timer delay above
+ * Node's max (see MAX_TIMER_DELAY_MS) is coerced to 1ms, so an over-range cadence
+ * would otherwise run near-continuously.
  */
-export function positiveIntConfig(raw: unknown, fallback: number): number {
+export function positiveIntConfig(raw: unknown, fallback: number, max?: number): number {
   const value = Number(raw);
-  return Number.isInteger(value) && value > 0 ? value : fallback;
+  if (!Number.isInteger(value) || value <= 0) {
+    return fallback;
+  }
+  return max !== undefined && value > max ? fallback : value;
 }

--- a/apps/api/src/common/env-flag.test.ts
+++ b/apps/api/src/common/env-flag.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { isDisabled } from './republisher.module';
+import { isDisabled } from './env-flag';
 
-describe('isDisabled (republisher default-on opt-out parse)', () => {
+describe('isDisabled (default-on env-flag opt-out parse)', () => {
   it('treats every explicit falsey token as disabled, case-insensitively', () => {
     for (const raw of ['false', 'False', 'FALSE', '0', 'no', 'NO', 'off', 'OFF', ' false ']) {
       expect(isDisabled(raw)).toBe(true);

--- a/apps/api/src/common/env-flag.ts
+++ b/apps/api/src/common/env-flag.ts
@@ -1,0 +1,7 @@
+/** Disabled tokens for a default-on flag; case-insensitive so `False`/`0`/`OFF` all count. */
+const DISABLED_TOKENS = new Set(['false', '0', 'no', 'off']);
+
+/** A default-on env flag is disabled only by an explicit falsey token; unset stays on. */
+export function isDisabled(raw: unknown): boolean {
+  return DISABLED_TOKENS.has(String(raw).trim().toLowerCase());
+}

--- a/apps/api/src/common/scheduler.module.test.ts
+++ b/apps/api/src/common/scheduler.module.test.ts
@@ -1,0 +1,73 @@
+import { Injectable, Module, OnModuleInit } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SchedulerModule } from './scheduler.module';
+import { PeriodicTask, WorkerScheduler } from './worker-scheduler';
+
+class CountingTask implements PeriodicTask {
+  runs = 0;
+  constructor(
+    readonly taskName: string,
+    readonly intervalMs: number
+  ) {}
+  async runOnce(): Promise<void> {
+    this.runs += 1;
+  }
+}
+
+/**
+ * A feature module that, like the real republisher/mailbox slices, registers its
+ * task in `onModuleInit` on the SHARED scheduler it imports — never starting the
+ * loop itself.
+ */
+function consumerModule(task: CountingTask) {
+  @Injectable()
+  class Registrar implements OnModuleInit {
+    constructor(private readonly scheduler: WorkerScheduler) {}
+    onModuleInit(): void {
+      this.scheduler.register(task);
+    }
+  }
+
+  @Module({ imports: [SchedulerModule], providers: [Registrar] })
+  class ConsumerModule {}
+
+  return ConsumerModule;
+}
+
+describe('SchedulerModule shared loop', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('starts tasks that multiple consumer modules register in onModuleInit on ONE shared scheduler', async () => {
+    const a = new CountingTask('a', 1000);
+    const b = new CountingTask('b', 1000);
+    const ModuleA = consumerModule(a);
+    const ModuleB = consumerModule(b);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [ModuleA, ModuleB],
+    }).compile();
+    const app = moduleRef.createNestApplication();
+
+    // Both consumers import SchedulerModule; a single shared instance backs both.
+    const viaA = app.select(ModuleA).get(WorkerScheduler, { strict: false });
+    const viaB = app.select(ModuleB).get(WorkerScheduler, { strict: false });
+    expect(viaA).toBe(viaB);
+
+    // init() runs every onModuleInit (both registrations) before the module's
+    // onApplicationBootstrap start() — so the single start schedules both tasks.
+    await app.init();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(a.runs).toBe(1);
+    expect(b.runs).toBe(1);
+
+    await app.close();
+
+    // stop() cleared the timers: no further ticks fire.
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(a.runs).toBe(1);
+    expect(b.runs).toBe(1);
+  });
+});

--- a/apps/api/src/common/scheduler.module.ts
+++ b/apps/api/src/common/scheduler.module.ts
@@ -1,0 +1,32 @@
+import { Module, OnApplicationBootstrap, OnModuleDestroy } from '@nestjs/common';
+import { TimerWorkerScheduler, WorkerScheduler } from './worker-scheduler';
+
+/**
+ * The one shared worker loop (blueprint/api.md: in-process, worker-shaped,
+ * cleanly extractable). A single {@link WorkerScheduler} instance is provided and
+ * exported here, so every feature module that owns a {@link PeriodicTask} — the
+ * republisher walk, the dormant-mailbox sweep (#667) — registers on the SAME loop
+ * rather than binding a second scheduler.
+ *
+ * Lifecycle is owned here, not by the task modules: feature modules register
+ * their task in `onModuleInit`, and this module calls `start()` in
+ * `onApplicationBootstrap`. Nest runs EVERY `onModuleInit` before ANY
+ * `onApplicationBootstrap`, so all registrations land before the single start —
+ * the scheduler's register-before-start contract holds regardless of module
+ * topology, and no task's cadence is coupled to another module's opt-out flag.
+ */
+@Module({
+  providers: [{ provide: WorkerScheduler, useClass: TimerWorkerScheduler }],
+  exports: [WorkerScheduler],
+})
+export class SchedulerModule implements OnApplicationBootstrap, OnModuleDestroy {
+  constructor(private readonly scheduler: WorkerScheduler) {}
+
+  onApplicationBootstrap(): void {
+    this.scheduler.start();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.scheduler.stop();
+  }
+}

--- a/apps/api/src/common/worker-scheduler.ts
+++ b/apps/api/src/common/worker-scheduler.ts
@@ -1,6 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
 
 /**
+ * Node coerces a `setTimeout`/`setInterval` delay above 2^31-1 ms to 1ms, so an
+ * over-range cadence or run bound would fire near-continuously. Configured delays
+ * are clamped to this ceiling (fail closed to the default) at their parse sites.
+ */
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/**
  * A unit of periodic background work. The scheduler owns the cadence; the task
  * owns one sweep. Deliberately capability-free so it is reusable: the
  * republisher's inventory walk is the first implementer, and the dormant-mailbox

--- a/apps/api/src/data-source.ts
+++ b/apps/api/src/data-source.ts
@@ -17,6 +17,9 @@ export default new DataSource({
   database: process.env.DB_DATABASE ?? 'cipherbox',
   entities: ['src/**/*.entity.ts'],
   migrations: ['src/migrations/*.ts'],
+  // Per-migration transaction: each migration wraps in its own txn by default,
+  // so a migration may opt out (transaction = false) to run CONCURRENTLY DDL.
+  migrationsTransactionMode: 'each',
   uuidExtension: 'pgcrypto',
   logging: false,
 });

--- a/apps/api/src/mailbox/entities/mailbox-message.entity.ts
+++ b/apps/api/src/mailbox/entities/mailbox-message.entity.ts
@@ -32,6 +32,9 @@ import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
   unique: true,
 })
 @Index('idx_mailbox_recipient_received', ['recipientPublicKey', 'receivedAt'])
+// Recipient-less `received_at` index serving the global TTL sweep's scan (#667);
+// idx_mailbox_recipient_received leads with the recipient and can't drive it.
+@Index('idx_mailbox_received_at', ['receivedAt'])
 export class MailboxMessage {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/apps/api/src/mailbox/mailbox.module.ts
+++ b/apps/api/src/mailbox/mailbox.module.ts
@@ -1,24 +1,34 @@
-import { Module } from '@nestjs/common';
+import { Module, OnModuleInit } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { buildJwtOptions } from '../auth/auth.module';
 import { User } from '../auth/entities/user.entity';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { isDisabled } from '../common/env-flag';
+import { SchedulerModule } from '../common/scheduler.module';
+import { WorkerScheduler } from '../common/worker-scheduler';
 import { IdentityService } from '../auth/services/identity.service';
 import { MailboxController } from './mailbox.controller';
 import { MailboxMessage } from './entities/mailbox-message.entity';
 import { MailboxService } from './services/mailbox.service';
+import { MailboxSweepTask } from './tasks/mailbox-sweep.task';
 
 /**
  * The mailbox slice (blueprint/api.md, Mailbox). Reads the users table for
  * the recipient-existence oracle and provides its own stateless
  * IdentityService for publicKey normalization. Route auth reuses the auth
  * slice's JwtAuthGuard and JWT configuration.
+ *
+ * The scheduled dormant-mailbox TTL sweep (#667) registers on the shared
+ * {@link SchedulerModule} loop in `onModuleInit` — independent of per-recipient
+ * activity and of the republisher's own opt-out, so a dormant mailbox's expired
+ * rows are still swept.
  */
 @Module({
   imports: [
     TypeOrmModule.forFeature([MailboxMessage, User]),
+    SchedulerModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -26,6 +36,21 @@ import { MailboxService } from './services/mailbox.service';
     }),
   ],
   controllers: [MailboxController],
-  providers: [MailboxService, IdentityService, JwtAuthGuard],
+  providers: [MailboxService, IdentityService, JwtAuthGuard, MailboxSweepTask],
 })
-export class MailboxModule {}
+export class MailboxModule implements OnModuleInit {
+  constructor(
+    private readonly scheduler: WorkerScheduler,
+    private readonly sweepTask: MailboxSweepTask,
+    private readonly configService: ConfigService
+  ) {}
+
+  onModuleInit(): void {
+    // Opt-out (default on) for deployments that run the sweep out of process or
+    // pin it to a single instance. Absent, the loop is an unref'd 12h timer.
+    if (isDisabled(this.configService.get('MAILBOX_SWEEP_ENABLED'))) {
+      return;
+    }
+    this.scheduler.register(this.sweepTask);
+  }
+}

--- a/apps/api/src/mailbox/services/mailbox.service.ts
+++ b/apps/api/src/mailbox/services/mailbox.service.ts
@@ -17,6 +17,7 @@ import {
   setAdvisoryLockTimeout,
 } from '../../common/advisory-lock';
 import { Clock } from '../../common/clock';
+import { positiveIntConfig } from '../../common/config-int';
 import { MailboxMessage } from '../entities/mailbox-message.entity';
 
 /** Spec-fixed hard bound on the sealed blob (blueprint/api.md: <= ~8 KB). */
@@ -25,6 +26,12 @@ const MAX_BLOB_BYTES = 8192;
 /** 90-day unacked TTL, aligned with record EOLs (blueprint/api.md, Mailbox). */
 const TTL_MS = 90 * 24 * 60 * 60 * 1000;
 
+/** Rows deleted per global-sweep batch; via MAILBOX_SWEEP_BATCH_SIZE. */
+const DEFAULT_SWEEP_BATCH_SIZE = 1000;
+
+/** Safety bound on batches per sweep run so a huge backlog can't loop unbounded; via MAILBOX_SWEEP_MAX_BATCHES. */
+const DEFAULT_SWEEP_MAX_BATCHES = 1000;
+
 /**
  * Canonical RFC 4122 UUID — the form `gen_random_uuid()` mints for the id
  * column. Ids are always server-minted uuids, so any other shape can never
@@ -32,17 +39,6 @@ const TTL_MS = 90 * 24 * 60 * 60 * 1000;
  * reaching the `uuid`-typed column (Postgres would raise 22P02 → a 500).
  */
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-/**
- * Read a positive-integer bound from config, falling back to the default for
- * an unset OR garbage value. Both bounds are DoS controls (the pending cap and
- * the poll batch size), so a misconfigured env var must fail closed to the
- * safe default, never silently to NaN (which would disable the cap entirely).
- */
-function positiveIntConfig(raw: unknown, fallback: number): number {
-  const value = Number(raw);
-  return Number.isInteger(value) && value > 0 ? value : fallback;
-}
 
 export interface PostMessageInput {
   recipientPublicKey: string;
@@ -74,6 +70,8 @@ export class MailboxService {
   private readonly pendingCap: number;
   private readonly pollLimit: number;
   private readonly lockTimeoutMs: number;
+  private readonly sweepBatchSize: number;
+  private readonly sweepMaxBatches: number;
 
   constructor(
     @InjectRepository(MailboxMessage)
@@ -89,6 +87,14 @@ export class MailboxService {
     this.pendingCap = positiveIntConfig(configService.get('MAILBOX_PENDING_CAP'), 1000);
     this.pollLimit = positiveIntConfig(configService.get('MAILBOX_POLL_LIMIT'), 100);
     this.lockTimeoutMs = resolveAdvisoryLockTimeoutMs(configService);
+    this.sweepBatchSize = positiveIntConfig(
+      configService.get('MAILBOX_SWEEP_BATCH_SIZE'),
+      DEFAULT_SWEEP_BATCH_SIZE
+    );
+    this.sweepMaxBatches = positiveIntConfig(
+      configService.get('MAILBOX_SWEEP_MAX_BATCHES'),
+      DEFAULT_SWEEP_MAX_BATCHES
+    );
   }
 
   /**
@@ -258,6 +264,55 @@ export class MailboxService {
   ): Promise<void> {
     const cutoff = new Date(this.clock.now().getTime() - TTL_MS);
     await repo.delete({ recipientPublicKey, receivedAt: LessThan(cutoff) });
+  }
+
+  /**
+   * The global, recipient-less TTL sweep the scheduled worker drives (#667): the
+   * lazy `purgeExpired` only fires on a recipient's own post/poll, so a dormant
+   * mailbox keeps expired rows forever. This makes the 90-day bound a hard
+   * guarantee independent of activity.
+   *
+   * The cutoff is one Clock snapshot for the whole run (deterministic, testable),
+   * and deletes are batched by `ctid` — bounded rows per statement, looping until
+   * a short batch signals drained — so the sweep never takes a long table lock or
+   * bloats a single transaction on a large backlog. It is safe to interleave with
+   * post/poll/lazy purge: a concurrent post writes a fresh `received_at` (>=
+   * cutoff) that this WHERE can never match, and a row another path already
+   * deleted simply isn't re-counted. Overlap is prevented in-process by the
+   * scheduler's in-flight guard (the republisher's mechanism); a cross-instance
+   * overlap is harmless because the delete is idempotent. Returns the number of
+   * rows deleted.
+   */
+  async sweepExpired(): Promise<number> {
+    const cutoff = new Date(this.clock.now().getTime() - TTL_MS);
+    let total = 0;
+    for (let batch = 0; batch < this.sweepMaxBatches; batch += 1) {
+      const deleted = await this.deleteExpiredBatch(cutoff);
+      total += deleted;
+      if (deleted < this.sweepBatchSize) {
+        break;
+      }
+    }
+    return total;
+  }
+
+  /**
+   * Delete up to one batch of globally-expired rows. Postgres has no
+   * `DELETE ... LIMIT`, so the batch is bounded by selecting `ctid`s under the
+   * cutoff and deleting exactly those; `received_at` ordering lets the
+   * `idx_mailbox_received_at` index drive the scan. Returns the rows deleted.
+   */
+  private async deleteExpiredBatch(cutoff: Date): Promise<number> {
+    const result = await this.messageRepository
+      .createQueryBuilder()
+      .delete()
+      .from(MailboxMessage)
+      .where(
+        'ctid IN (SELECT ctid FROM mailbox_messages WHERE received_at < :cutoff ORDER BY received_at LIMIT :limit)',
+        { cutoff, limit: this.sweepBatchSize }
+      )
+      .execute();
+    return result.affected ?? 0;
   }
 
   private scopeIdempotency(senderPublicKey: string, idempotencyKey: string): string {

--- a/apps/api/src/mailbox/services/mailbox.service.ts
+++ b/apps/api/src/mailbox/services/mailbox.service.ts
@@ -29,8 +29,12 @@ const TTL_MS = 90 * 24 * 60 * 60 * 1000;
 /** Rows deleted per global-sweep batch; via MAILBOX_SWEEP_BATCH_SIZE. */
 const DEFAULT_SWEEP_BATCH_SIZE = 1000;
 
-/** Safety bound on batches per sweep run so a huge backlog can't loop unbounded; via MAILBOX_SWEEP_MAX_BATCHES. */
-const DEFAULT_SWEEP_MAX_BATCHES = 1000;
+/**
+ * Internal "don't loop forever" guard on batches per sweep run — not a per-deploy
+ * knob. The loop already drains on `deleted < batchSize`; this only caps a
+ * pathological backlog, leaving any remainder for the next scheduled run.
+ */
+export const SWEEP_MAX_BATCHES = 1000;
 
 /**
  * Canonical RFC 4122 UUID — the form `gen_random_uuid()` mints for the id
@@ -71,7 +75,6 @@ export class MailboxService {
   private readonly pollLimit: number;
   private readonly lockTimeoutMs: number;
   private readonly sweepBatchSize: number;
-  private readonly sweepMaxBatches: number;
 
   constructor(
     @InjectRepository(MailboxMessage)
@@ -90,10 +93,6 @@ export class MailboxService {
     this.sweepBatchSize = positiveIntConfig(
       configService.get('MAILBOX_SWEEP_BATCH_SIZE'),
       DEFAULT_SWEEP_BATCH_SIZE
-    );
-    this.sweepMaxBatches = positiveIntConfig(
-      configService.get('MAILBOX_SWEEP_MAX_BATCHES'),
-      DEFAULT_SWEEP_MAX_BATCHES
     );
   }
 
@@ -286,7 +285,7 @@ export class MailboxService {
   async sweepExpired(): Promise<number> {
     const cutoff = new Date(this.clock.now().getTime() - TTL_MS);
     let total = 0;
-    for (let batch = 0; batch < this.sweepMaxBatches; batch += 1) {
+    for (let batch = 0; batch < SWEEP_MAX_BATCHES; batch += 1) {
       const deleted = await this.deleteExpiredBatch(cutoff);
       total += deleted;
       if (deleted < this.sweepBatchSize) {

--- a/apps/api/src/mailbox/services/mailbox.sweep.integration.test.ts
+++ b/apps/api/src/mailbox/services/mailbox.sweep.integration.test.ts
@@ -1,0 +1,186 @@
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { randomBytes } from 'node:crypto';
+import { Repository } from 'typeorm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { User } from '../../auth/entities/user.entity';
+import { IdentityService } from '../../auth/services/identity.service';
+import { FakeRepository } from '../../testing/fake-repo';
+import { FakeClock, fakeConfig } from '../../testing/fakes';
+import { createIntegrationDatabase, IntegrationDatabase } from '../../testing/integration-db';
+import { MailboxMessage } from '../entities/mailbox-message.entity';
+import { MailboxService } from './mailbox.service';
+
+/**
+ * The global dormant-mailbox TTL sweep (#667) proven against a REAL Postgres.
+ *
+ * The lazy per-recipient purge only fires on a recipient's own post/poll, so the
+ * cases that matter here — a dormant mailbox that never polls, and a concurrent
+ * post that must survive a sweep in flight — are genuine Postgres timing/DELETE
+ * semantics no in-memory fake reproduces.
+ */
+
+const TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+function compressedPublicKey(): string {
+  const priv = secp256k1.utils.randomPrivateKey();
+  try {
+    return Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+  } finally {
+    priv.fill(0);
+  }
+}
+
+function base64Blob(bytes: number): string {
+  return Buffer.alloc(bytes, 7).toString('base64');
+}
+
+describe('MailboxService global TTL sweep (real Postgres)', () => {
+  let db: IntegrationDatabase;
+  let repo: Repository<MailboxMessage>;
+  const clock = new FakeClock();
+
+  beforeAll(async () => {
+    db = await createIntegrationDatabase({ poolMax: 30 });
+    repo = db.dataSource.getRepository(MailboxMessage);
+  });
+
+  afterAll(async () => {
+    await db?.teardown();
+  });
+
+  beforeEach(async () => {
+    await db.dataSource.query('TRUNCATE TABLE mailbox_messages');
+  });
+
+  function buildService(env: Record<string, string | undefined> = {}): {
+    service: MailboxService;
+    users: FakeRepository<User>;
+  } {
+    const users = new FakeRepository<User>();
+    const service = new MailboxService(
+      repo,
+      users as never,
+      db.dataSource,
+      new IdentityService(),
+      clock,
+      fakeConfig({ DB_ADVISORY_LOCK_TIMEOUT_MS: '0', ...env }).service
+    );
+    return { service, users };
+  }
+
+  /** Seed one row with an explicit age, bypassing the service so no purge fires. */
+  async function seedRow(recipient: string, ageMs: number): Promise<string> {
+    const saved = await repo.save({
+      recipientPublicKey: recipient,
+      idempotencyScope: randomBytes(32).toString('hex'),
+      blob: Buffer.alloc(16, 1),
+      receivedAt: new Date(clock.now().getTime() - ageMs),
+    });
+    return saved.id;
+  }
+
+  it('deletes rows older than 90 days and keeps fresh ones, with no recipient activity', async () => {
+    const dormant = compressedPublicKey();
+    const active = compressedPublicKey();
+    const { service } = buildService();
+
+    const expiredA = await seedRow(dormant, TTL_MS + 60_000);
+    const expiredB = await seedRow(dormant, TTL_MS + 24 * 60 * 60 * 1000);
+    const freshDormant = await seedRow(dormant, TTL_MS - 60_000);
+    const freshActive = await seedRow(active, 1000);
+
+    const deleted = await service.sweepExpired();
+
+    expect(deleted).toBe(2);
+    const survivors = (await repo.find()).map((r) => r.id).sort();
+    expect(survivors).toEqual([freshDormant, freshActive].sort());
+    expect(survivors).not.toContain(expiredA);
+    expect(survivors).not.toContain(expiredB);
+  });
+
+  it('is exactly at the cutoff boundary: strictly-older is deleted, exactly-90d survives', async () => {
+    const recipient = compressedPublicKey();
+    const { service } = buildService();
+
+    // received_at < now - TTL deletes; == cutoff is NOT strictly less, so survives.
+    const justExpired = await seedRow(recipient, TTL_MS + 1);
+    const exactlyAtCutoff = await seedRow(recipient, TTL_MS);
+
+    const deleted = await service.sweepExpired();
+
+    expect(deleted).toBe(1);
+    const survivors = (await repo.find()).map((r) => r.id);
+    expect(survivors).toEqual([exactlyAtCutoff]);
+    expect(survivors).not.toContain(justExpired);
+  });
+
+  it('batches: drains a backlog larger than one batch across looped deletes', async () => {
+    const recipient = compressedPublicKey();
+    const { service } = buildService({ MAILBOX_SWEEP_BATCH_SIZE: '50' });
+
+    const EXPIRED = 220;
+    for (let i = 0; i < EXPIRED; i += 1) {
+      await seedRow(recipient, TTL_MS + 60_000 + i);
+    }
+    const fresh = await seedRow(recipient, 1000);
+
+    const deleted = await service.sweepExpired();
+
+    expect(deleted).toBe(EXPIRED);
+    const survivors = (await repo.find()).map((r) => r.id);
+    expect(survivors).toEqual([fresh]);
+  });
+
+  it('respects the per-run batch cap, leaving the remainder for the next run', async () => {
+    const recipient = compressedPublicKey();
+    // 2 batches of 5 = at most 10 rows deleted this run; the 11th+ waits.
+    const { service } = buildService({
+      MAILBOX_SWEEP_BATCH_SIZE: '5',
+      MAILBOX_SWEEP_MAX_BATCHES: '2',
+    });
+
+    for (let i = 0; i < 13; i += 1) {
+      await seedRow(recipient, TTL_MS + 60_000 + i);
+    }
+
+    const firstRun = await service.sweepExpired();
+    expect(firstRun).toBe(10);
+    expect(await repo.count()).toBe(3);
+
+    const secondRun = await service.sweepExpired();
+    expect(secondRun).toBe(3);
+    expect(await repo.count()).toBe(0);
+  });
+
+  it('adversarial: a post concurrent with a sweep survives while dormant expired rows are deleted', async () => {
+    const dormant = compressedPublicKey();
+    const recipient = compressedPublicKey();
+    const sender = compressedPublicKey();
+    const { service, users } = buildService({ MAILBOX_SWEEP_BATCH_SIZE: '10' });
+    void users.save({ publicKey: recipient } as never);
+
+    // A large dormant backlog so the sweep loops across many awaits, giving the
+    // concurrent post real opportunity to interleave mid-sweep.
+    const EXPIRED = 300;
+    for (let i = 0; i < EXPIRED; i += 1) {
+      await seedRow(dormant, TTL_MS + 60_000 + i);
+    }
+
+    const [deleted, posted] = await Promise.all([
+      service.sweepExpired(),
+      service.post(sender, {
+        recipientPublicKey: recipient,
+        blob: base64Blob(64),
+        idempotencyKey: 'concurrent-post',
+      }),
+    ]);
+
+    // The fresh post — received_at = clock.now(), never < cutoff — must survive
+    // the sweep untouched, and every expired dormant row must be gone.
+    expect(deleted).toBe(EXPIRED);
+    const survivors = await repo.find();
+    expect(survivors).toHaveLength(1);
+    expect(survivors[0].id).toBe(posted.id);
+    expect(survivors[0].recipientPublicKey).toBe(recipient);
+  });
+});

--- a/apps/api/src/mailbox/services/mailbox.sweep.integration.test.ts
+++ b/apps/api/src/mailbox/services/mailbox.sweep.integration.test.ts
@@ -8,7 +8,7 @@ import { FakeRepository } from '../../testing/fake-repo';
 import { FakeClock, fakeConfig } from '../../testing/fakes';
 import { createIntegrationDatabase, IntegrationDatabase } from '../../testing/integration-db';
 import { MailboxMessage } from '../entities/mailbox-message.entity';
-import { MailboxService } from './mailbox.service';
+import { MailboxService, SWEEP_MAX_BATCHES } from './mailbox.service';
 
 /**
  * The global dormant-mailbox TTL sweep (#667) proven against a REAL Postgres.
@@ -79,6 +79,17 @@ describe('MailboxService global TTL sweep (real Postgres)', () => {
     return saved.id;
   }
 
+  /** Bulk-seed `count` already-expired rows for a recipient in one INSERT. */
+  async function seedExpiredBatch(recipient: string, count: number): Promise<void> {
+    const receivedAt = new Date(clock.now().getTime() - (TTL_MS + 60_000));
+    await db.dataSource.query(
+      `INSERT INTO mailbox_messages (recipient_public_key, idempotency_scope, blob, received_at)
+       SELECT $1, lpad(g::text, 64, '0'), '\\x01'::bytea, $2::timestamptz
+       FROM generate_series(1, $3) AS g`,
+      [recipient, receivedAt.toISOString(), count]
+    );
+  }
+
   it('deletes rows older than 90 days and keeps fresh ones, with no recipient activity', async () => {
     const dormant = compressedPublicKey();
     const active = compressedPublicKey();
@@ -131,24 +142,22 @@ describe('MailboxService global TTL sweep (real Postgres)', () => {
     expect(survivors).toEqual([fresh]);
   });
 
-  it('respects the per-run batch cap, leaving the remainder for the next run', async () => {
+  it('respects the internal SWEEP_MAX_BATCHES cap, leaving the remainder for the next run', async () => {
     const recipient = compressedPublicKey();
-    // 2 batches of 5 = at most 10 rows deleted this run; the 11th+ waits.
-    const { service } = buildService({
-      MAILBOX_SWEEP_BATCH_SIZE: '5',
-      MAILBOX_SWEEP_MAX_BATCHES: '2',
-    });
+    // batchSize=1 means each batch deletes one row and never short-circuits on
+    // drain, so a run is bounded solely by the SWEEP_MAX_BATCHES const. Seed a
+    // few rows past the cap: the first run stops at the cap, the next drains.
+    const REMAINDER = 3;
+    const { service } = buildService({ MAILBOX_SWEEP_BATCH_SIZE: '1' });
 
-    for (let i = 0; i < 13; i += 1) {
-      await seedRow(recipient, TTL_MS + 60_000 + i);
-    }
+    await seedExpiredBatch(recipient, SWEEP_MAX_BATCHES + REMAINDER);
 
     const firstRun = await service.sweepExpired();
-    expect(firstRun).toBe(10);
-    expect(await repo.count()).toBe(3);
+    expect(firstRun).toBe(SWEEP_MAX_BATCHES);
+    expect(await repo.count()).toBe(REMAINDER);
 
     const secondRun = await service.sweepExpired();
-    expect(secondRun).toBe(3);
+    expect(secondRun).toBe(REMAINDER);
     expect(await repo.count()).toBe(0);
   });
 

--- a/apps/api/src/mailbox/tasks/mailbox-sweep.task.test.ts
+++ b/apps/api/src/mailbox/tasks/mailbox-sweep.task.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fakeConfig } from '../../testing/fakes';
+import { MailboxService } from '../services/mailbox.service';
+import { MailboxSweepTask } from './mailbox-sweep.task';
+
+function buildTask(env: Record<string, string | undefined>): {
+  task: MailboxSweepTask;
+  sweepExpired: ReturnType<typeof vi.fn>;
+} {
+  const sweepExpired = vi.fn().mockResolvedValue(0);
+  const mailbox = { sweepExpired } as unknown as MailboxService;
+  const task = new MailboxSweepTask(mailbox, fakeConfig(env).service);
+  return { task, sweepExpired };
+}
+
+describe('MailboxSweepTask', () => {
+  it('defaults to a ~12h cadence and a 1h run bound', () => {
+    const { task } = buildTask({});
+    expect(task.taskName).toBe('mailbox-sweep');
+    expect(task.intervalMs).toBe(12 * 60 * 60 * 1000);
+    expect(task.runTimeoutMs).toBe(60 * 60 * 1000);
+  });
+
+  it('honors positive-integer overrides', () => {
+    const { task } = buildTask({
+      MAILBOX_SWEEP_INTERVAL_MS: '5000',
+      MAILBOX_SWEEP_RUN_TIMEOUT_MS: '2500',
+    });
+    expect(task.intervalMs).toBe(5000);
+    expect(task.runTimeoutMs).toBe(2500);
+  });
+
+  it('fails closed to the defaults for garbage config', () => {
+    const { task } = buildTask({
+      MAILBOX_SWEEP_INTERVAL_MS: 'not-a-number',
+      MAILBOX_SWEEP_RUN_TIMEOUT_MS: '-1',
+    });
+    expect(task.intervalMs).toBe(12 * 60 * 60 * 1000);
+    expect(task.runTimeoutMs).toBe(60 * 60 * 1000);
+  });
+
+  it('runOnce delegates to the service sweep', async () => {
+    const { task, sweepExpired } = buildTask({});
+    await task.runOnce();
+    expect(sweepExpired).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/mailbox/tasks/mailbox-sweep.task.test.ts
+++ b/apps/api/src/mailbox/tasks/mailbox-sweep.task.test.ts
@@ -34,6 +34,11 @@ describe('MailboxSweepTask', () => {
     expect(task.intervalMs).toBe(12 * 60 * 60 * 1000);
   });
 
+  it('fails closed to the default cadence for a delay above Node maximum', () => {
+    const { task } = buildTask({ MAILBOX_SWEEP_INTERVAL_MS: '2147483648' });
+    expect(task.intervalMs).toBe(12 * 60 * 60 * 1000);
+  });
+
   it('runOnce delegates to the service sweep', async () => {
     const { task, sweepExpired } = buildTask({});
     await task.runOnce();

--- a/apps/api/src/mailbox/tasks/mailbox-sweep.task.test.ts
+++ b/apps/api/src/mailbox/tasks/mailbox-sweep.task.test.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { describe, expect, it, vi } from 'vitest';
 import { PeriodicTask } from '../../common/worker-scheduler';
 import { fakeConfig } from '../../testing/fakes';
@@ -37,5 +38,17 @@ describe('MailboxSweepTask', () => {
     const { task, sweepExpired } = buildTask({});
     await task.runOnce();
     expect(sweepExpired).toHaveBeenCalledOnce();
+  });
+
+  it('logs the deleted-row count so operators can see sweep activity', async () => {
+    const { task, sweepExpired } = buildTask({});
+    sweepExpired.mockResolvedValue(7);
+    const log = vi.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    try {
+      await task.runOnce();
+      expect(log).toHaveBeenCalledWith('mailbox-sweep: deleted 7 expired rows');
+    } finally {
+      log.mockRestore();
+    }
   });
 });

--- a/apps/api/src/mailbox/tasks/mailbox-sweep.task.test.ts
+++ b/apps/api/src/mailbox/tasks/mailbox-sweep.task.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { PeriodicTask } from '../../common/worker-scheduler';
 import { fakeConfig } from '../../testing/fakes';
 import { MailboxService } from '../services/mailbox.service';
 import { MailboxSweepTask } from './mailbox-sweep.task';
@@ -14,29 +15,22 @@ function buildTask(env: Record<string, string | undefined>): {
 }
 
 describe('MailboxSweepTask', () => {
-  it('defaults to a ~12h cadence and a 1h run bound', () => {
+  it('defaults to a ~12h cadence and inherits the scheduler run bound', () => {
     const { task } = buildTask({});
     expect(task.taskName).toBe('mailbox-sweep');
     expect(task.intervalMs).toBe(12 * 60 * 60 * 1000);
-    expect(task.runTimeoutMs).toBe(60 * 60 * 1000);
+    // No per-task timeout: the scheduler's DEFAULT_RUN_TIMEOUT_MS applies.
+    expect((task as PeriodicTask).runTimeoutMs).toBeUndefined();
   });
 
-  it('honors positive-integer overrides', () => {
-    const { task } = buildTask({
-      MAILBOX_SWEEP_INTERVAL_MS: '5000',
-      MAILBOX_SWEEP_RUN_TIMEOUT_MS: '2500',
-    });
+  it('honors a positive-integer cadence override', () => {
+    const { task } = buildTask({ MAILBOX_SWEEP_INTERVAL_MS: '5000' });
     expect(task.intervalMs).toBe(5000);
-    expect(task.runTimeoutMs).toBe(2500);
   });
 
-  it('fails closed to the defaults for garbage config', () => {
-    const { task } = buildTask({
-      MAILBOX_SWEEP_INTERVAL_MS: 'not-a-number',
-      MAILBOX_SWEEP_RUN_TIMEOUT_MS: '-1',
-    });
+  it('fails closed to the default cadence for garbage config', () => {
+    const { task } = buildTask({ MAILBOX_SWEEP_INTERVAL_MS: 'not-a-number' });
     expect(task.intervalMs).toBe(12 * 60 * 60 * 1000);
-    expect(task.runTimeoutMs).toBe(60 * 60 * 1000);
   });
 
   it('runOnce delegates to the service sweep', async () => {

--- a/apps/api/src/mailbox/tasks/mailbox-sweep.task.ts
+++ b/apps/api/src/mailbox/tasks/mailbox-sweep.task.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { positiveIntConfig } from '../../common/config-int';
+import { PeriodicTask } from '../../common/worker-scheduler';
+import { MailboxService } from '../services/mailbox.service';
+
+/** ~12h cadence, a sibling of the republisher walk; via MAILBOX_SWEEP_INTERVAL_MS. */
+const DEFAULT_INTERVAL_MS = 12 * 60 * 60 * 1000;
+/** Hard bound on one sweep run (below the cadence); via MAILBOX_SWEEP_RUN_TIMEOUT_MS. */
+const DEFAULT_RUN_TIMEOUT_MS = 60 * 60 * 1000;
+
+/**
+ * The scheduled dormant-mailbox TTL sweep (#667), shaped as a reusable
+ * {@link PeriodicTask} on the shared worker loop. It is a thin scheduling wrapper
+ * over {@link MailboxService.sweepExpired} — all delete semantics, the injected
+ * Clock cutoff, and batching live in the service, so the sweep is exercised
+ * directly against real Postgres without the scheduler. The scheduler's in-flight
+ * guard makes the run single-flight in-process.
+ */
+@Injectable()
+export class MailboxSweepTask implements PeriodicTask {
+  readonly taskName = 'mailbox-sweep';
+  readonly intervalMs: number;
+  readonly runTimeoutMs: number;
+
+  constructor(
+    private readonly mailbox: MailboxService,
+    configService: ConfigService
+  ) {
+    this.intervalMs = positiveIntConfig(
+      configService.get('MAILBOX_SWEEP_INTERVAL_MS'),
+      DEFAULT_INTERVAL_MS
+    );
+    this.runTimeoutMs = positiveIntConfig(
+      configService.get('MAILBOX_SWEEP_RUN_TIMEOUT_MS'),
+      DEFAULT_RUN_TIMEOUT_MS
+    );
+  }
+
+  async runOnce(): Promise<void> {
+    await this.mailbox.sweepExpired();
+  }
+}

--- a/apps/api/src/mailbox/tasks/mailbox-sweep.task.ts
+++ b/apps/api/src/mailbox/tasks/mailbox-sweep.task.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { positiveIntConfig } from '../../common/config-int';
 import { PeriodicTask } from '../../common/worker-scheduler';
@@ -25,6 +25,7 @@ const DEFAULT_INTERVAL_MS = 12 * 60 * 60 * 1000;
 export class MailboxSweepTask implements PeriodicTask {
   readonly taskName = 'mailbox-sweep';
   readonly intervalMs: number;
+  private readonly logger = new Logger(MailboxSweepTask.name);
 
   constructor(
     private readonly mailbox: MailboxService,
@@ -37,6 +38,7 @@ export class MailboxSweepTask implements PeriodicTask {
   }
 
   async runOnce(): Promise<void> {
-    await this.mailbox.sweepExpired();
+    const deleted = await this.mailbox.sweepExpired();
+    this.logger.log(`mailbox-sweep: deleted ${deleted} expired rows`);
   }
 }

--- a/apps/api/src/mailbox/tasks/mailbox-sweep.task.ts
+++ b/apps/api/src/mailbox/tasks/mailbox-sweep.task.ts
@@ -6,8 +6,6 @@ import { MailboxService } from '../services/mailbox.service';
 
 /** ~12h cadence, a sibling of the republisher walk; via MAILBOX_SWEEP_INTERVAL_MS. */
 const DEFAULT_INTERVAL_MS = 12 * 60 * 60 * 1000;
-/** Hard bound on one sweep run (below the cadence); via MAILBOX_SWEEP_RUN_TIMEOUT_MS. */
-const DEFAULT_RUN_TIMEOUT_MS = 60 * 60 * 1000;
 
 /**
  * The scheduled dormant-mailbox TTL sweep (#667), shaped as a reusable
@@ -16,12 +14,17 @@ const DEFAULT_RUN_TIMEOUT_MS = 60 * 60 * 1000;
  * Clock cutoff, and batching live in the service, so the sweep is exercised
  * directly against real Postgres without the scheduler. The scheduler's in-flight
  * guard makes the run single-flight in-process.
+ *
+ * No per-run timeout is declared, so the scheduler's default applies. That
+ * timeout only frees the scheduling slot on expiry — it does NOT cancel an
+ * in-flight `sweepExpired`; the run self-bounds via SWEEP_MAX_BATCHES + drain
+ * (each batch its own autocommit txn), so it finishes its bounded work and a
+ * benign overlap with the next tick is acceptable.
  */
 @Injectable()
 export class MailboxSweepTask implements PeriodicTask {
   readonly taskName = 'mailbox-sweep';
   readonly intervalMs: number;
-  readonly runTimeoutMs: number;
 
   constructor(
     private readonly mailbox: MailboxService,
@@ -30,10 +33,6 @@ export class MailboxSweepTask implements PeriodicTask {
     this.intervalMs = positiveIntConfig(
       configService.get('MAILBOX_SWEEP_INTERVAL_MS'),
       DEFAULT_INTERVAL_MS
-    );
-    this.runTimeoutMs = positiveIntConfig(
-      configService.get('MAILBOX_SWEEP_RUN_TIMEOUT_MS'),
-      DEFAULT_RUN_TIMEOUT_MS
     );
   }
 

--- a/apps/api/src/mailbox/tasks/mailbox-sweep.task.ts
+++ b/apps/api/src/mailbox/tasks/mailbox-sweep.task.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { positiveIntConfig } from '../../common/config-int';
-import { PeriodicTask } from '../../common/worker-scheduler';
+import { MAX_TIMER_DELAY_MS, PeriodicTask } from '../../common/worker-scheduler';
 import { MailboxService } from '../services/mailbox.service';
 
 /** ~12h cadence, a sibling of the republisher walk; via MAILBOX_SWEEP_INTERVAL_MS. */
@@ -33,7 +33,8 @@ export class MailboxSweepTask implements PeriodicTask {
   ) {
     this.intervalMs = positiveIntConfig(
       configService.get('MAILBOX_SWEEP_INTERVAL_MS'),
-      DEFAULT_INTERVAL_MS
+      DEFAULT_INTERVAL_MS,
+      MAX_TIMER_DELAY_MS
     );
   }
 

--- a/apps/api/src/migrations/1784692000000-AddMailboxReceivedAtIndex.ts
+++ b/apps/api/src/migrations/1784692000000-AddMailboxReceivedAtIndex.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMailboxReceivedAtIndex1784692000000 implements MigrationInterface {
+  name = 'AddMailboxReceivedAtIndex1784692000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "idx_mailbox_received_at" ON "mailbox_messages" ("received_at") `
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."idx_mailbox_received_at"`);
+  }
+}

--- a/apps/api/src/migrations/1784692000000-AddMailboxReceivedAtIndex.ts
+++ b/apps/api/src/migrations/1784692000000-AddMailboxReceivedAtIndex.ts
@@ -3,13 +3,18 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 export class AddMailboxReceivedAtIndex1784692000000 implements MigrationInterface {
   name = 'AddMailboxReceivedAtIndex1784692000000';
 
+  // CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction, so TypeORM
+  // must not wrap this migration in one — it builds the sweep-scan index without
+  // taking a table lock that would block concurrent post/poll/ack writes.
+  public transaction = false as const;
+
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE INDEX "idx_mailbox_received_at" ON "mailbox_messages" ("received_at") `
+      `CREATE INDEX CONCURRENTLY "idx_mailbox_received_at" ON "mailbox_messages" ("received_at") `
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX "public"."idx_mailbox_received_at"`);
+    await queryRunner.query(`DROP INDEX CONCURRENTLY "public"."idx_mailbox_received_at"`);
   }
 }

--- a/apps/api/src/republisher/republisher.module.ts
+++ b/apps/api/src/republisher/republisher.module.ts
@@ -1,10 +1,11 @@
-import { Module, OnApplicationBootstrap, OnModuleDestroy } from '@nestjs/common';
+import { Module, OnModuleInit } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { buildJwtOptions } from '../auth/auth.module';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { TimerWorkerScheduler, WorkerScheduler } from '../common/worker-scheduler';
+import { SchedulerModule } from '../common/scheduler.module';
+import { WorkerScheduler } from '../common/worker-scheduler';
 import { OpsModule } from '../ops/ops.module';
 import { NameInventory } from '../registry/entities/name-inventory.entity';
 import { RecordCache } from './entities/record-cache.entity';
@@ -15,13 +16,10 @@ import { LoggingRepublisherAlerter, RepublisherAlerter } from './republisher.ale
 import { RepublisherTask } from './republisher.task';
 import { RecordCacheService } from './services/record-cache.service';
 
-/** Disabled tokens for a default-on flag; case-insensitive so `False`/`0`/`OFF` all count. */
-const DISABLED_TOKENS = new Set(['false', '0', 'no', 'off']);
-
-/** A default-on env flag is disabled only by an explicit falsey token; unset stays on. */
-export function isDisabled(raw: unknown): boolean {
-  return DISABLED_TOKENS.has(String(raw).trim().toLowerCase());
-}
+// Re-exported so the one implementation lives in common; existing importers keep
+// resolving `isDisabled` from this module.
+export { isDisabled } from '../common/env-flag';
+import { isDisabled } from '../common/env-flag';
 
 /**
  * The republisher slice (blueprint/api.md, Republisher module and recovery): the
@@ -32,16 +30,17 @@ export function isDisabled(raw: unknown): boolean {
  * network transport, the sequence read, alerting, and the scheduler — is a seam,
  * so the walk is deterministic under test and the module extracts cleanly.
  *
- * The scheduler and its {@link RepublisherTask} are wired here, but the loop is
- * generic. The {@link WorkerScheduler} provider is scoped to this module, not a
- * shared instance — when the dormant-mailbox scheduled sweep (#667) lands, one
- * shared loop means exporting this provider (or hoisting it into a shared
- * module) and registering the mailbox PeriodicTask on it, not binding a second.
+ * The {@link RepublisherTask} registers on the shared {@link SchedulerModule}
+ * loop, not a scheduler bound here — one loop carries every PeriodicTask (the
+ * dormant-mailbox sweep, #667, is the sibling). Registration happens in
+ * `onModuleInit`; the shared module owns `start()`/`stop()`, so the loop runs
+ * even when this slice opts out.
  */
 @Module({
   imports: [
     TypeOrmModule.forFeature([RecordCache, NameInventory]),
     OpsModule,
+    SchedulerModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -53,30 +52,24 @@ export function isDisabled(raw: unknown): boolean {
     RecordCacheService,
     RepublisherTask,
     JwtAuthGuard,
-    { provide: WorkerScheduler, useClass: TimerWorkerScheduler },
     { provide: RecordTransport, useClass: RoutingV1RecordTransport },
     { provide: RecordSequenceReader, useClass: MinimalIpnsSequenceReader },
     { provide: RepublisherAlerter, useClass: LoggingRepublisherAlerter },
   ],
 })
-export class RepublisherModule implements OnApplicationBootstrap, OnModuleDestroy {
+export class RepublisherModule implements OnModuleInit {
   constructor(
     private readonly scheduler: WorkerScheduler,
     private readonly task: RepublisherTask,
     private readonly configService: ConfigService
   ) {}
 
-  onApplicationBootstrap(): void {
+  onModuleInit(): void {
     // Opt-out for deployments that run the republisher out of process (or none),
     // defaulting on. Absent, the loop is a no-op cost — an unref'd 12h timer.
     if (isDisabled(this.configService.get('REPUBLISHER_ENABLED'))) {
       return;
     }
     this.scheduler.register(this.task);
-    this.scheduler.start();
-  }
-
-  async onModuleDestroy(): Promise<void> {
-    await this.scheduler.stop();
   }
 }

--- a/apps/api/src/republisher/republisher.module.ts
+++ b/apps/api/src/republisher/republisher.module.ts
@@ -4,6 +4,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { buildJwtOptions } from '../auth/auth.module';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { isDisabled } from '../common/env-flag';
 import { SchedulerModule } from '../common/scheduler.module';
 import { WorkerScheduler } from '../common/worker-scheduler';
 import { OpsModule } from '../ops/ops.module';
@@ -15,11 +16,6 @@ import { RecoveryController } from './recovery.controller';
 import { LoggingRepublisherAlerter, RepublisherAlerter } from './republisher.alerter';
 import { RepublisherTask } from './republisher.task';
 import { RecordCacheService } from './services/record-cache.service';
-
-// Re-exported so the one implementation lives in common; existing importers keep
-// resolving `isDisabled` from this module.
-export { isDisabled } from '../common/env-flag';
-import { isDisabled } from '../common/env-flag';
 
 /**
  * The republisher slice (blueprint/api.md, Republisher module and recovery): the

--- a/apps/api/src/republisher/republisher.task.ts
+++ b/apps/api/src/republisher/republisher.task.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Clock } from '../common/clock';
+import { positiveIntConfig } from '../common/config-int';
 import { PeriodicTask } from '../common/worker-scheduler';
 import { NameInventory } from '../registry/entities/name-inventory.entity';
 import { RecordSequenceReader } from './record-sequence-reader';
@@ -20,12 +21,6 @@ const DEFAULT_RUN_TIMEOUT_MS = 60 * 60 * 1000;
 const DEFAULT_CONCURRENCY = 8;
 /** The monotonic floor a record with no readable sequence caches at (see walkName). */
 const SEQUENCE_FLOOR = 0n;
-
-/** Read a positive integer, failing closed to `fallback` for unset/garbage. */
-function positiveInt(raw: unknown, fallback: number): number {
-  const value = Number(raw);
-  return Number.isInteger(value) && value > 0 ? value : fallback;
-}
 
 /**
  * The republisher inventory walk (blueprint/api.md, Republisher module and
@@ -58,19 +53,19 @@ export class RepublisherTask implements PeriodicTask {
     private readonly clock: Clock,
     configService: ConfigService
   ) {
-    this.intervalMs = positiveInt(
+    this.intervalMs = positiveIntConfig(
       configService.get('REPUBLISHER_INTERVAL_MS'),
       DEFAULT_INTERVAL_MS
     );
-    this.staleAlertMs = positiveInt(
+    this.staleAlertMs = positiveIntConfig(
       configService.get('REPUBLISHER_STALE_ALERT_MS'),
       DEFAULT_STALE_ALERT_MS
     );
-    this.runTimeoutMs = positiveInt(
+    this.runTimeoutMs = positiveIntConfig(
       configService.get('REPUBLISHER_RUN_TIMEOUT_MS'),
       DEFAULT_RUN_TIMEOUT_MS
     );
-    this.concurrency = positiveInt(
+    this.concurrency = positiveIntConfig(
       configService.get('REPUBLISHER_CONCURRENCY'),
       DEFAULT_CONCURRENCY
     );

--- a/apps/api/src/republisher/republisher.task.ts
+++ b/apps/api/src/republisher/republisher.task.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Clock } from '../common/clock';
 import { positiveIntConfig } from '../common/config-int';
-import { PeriodicTask } from '../common/worker-scheduler';
+import { MAX_TIMER_DELAY_MS, PeriodicTask } from '../common/worker-scheduler';
 import { NameInventory } from '../registry/entities/name-inventory.entity';
 import { RecordSequenceReader } from './record-sequence-reader';
 import { RecordTransport } from './record-transport';
@@ -55,7 +55,8 @@ export class RepublisherTask implements PeriodicTask {
   ) {
     this.intervalMs = positiveIntConfig(
       configService.get('REPUBLISHER_INTERVAL_MS'),
-      DEFAULT_INTERVAL_MS
+      DEFAULT_INTERVAL_MS,
+      MAX_TIMER_DELAY_MS
     );
     this.staleAlertMs = positiveIntConfig(
       configService.get('REPUBLISHER_STALE_ALERT_MS'),
@@ -63,7 +64,8 @@ export class RepublisherTask implements PeriodicTask {
     );
     this.runTimeoutMs = positiveIntConfig(
       configService.get('REPUBLISHER_RUN_TIMEOUT_MS'),
-      DEFAULT_RUN_TIMEOUT_MS
+      DEFAULT_RUN_TIMEOUT_MS,
+      MAX_TIMER_DELAY_MS
     );
     this.concurrency = positiveIntConfig(
       configService.get('REPUBLISHER_CONCURRENCY'),

--- a/apps/api/src/testing/integration-db.ts
+++ b/apps/api/src/testing/integration-db.ts
@@ -5,6 +5,7 @@ import { RefreshToken } from '../auth/entities/refresh-token.entity';
 import { User } from '../auth/entities/user.entity';
 import { MailboxMessage } from '../mailbox/entities/mailbox-message.entity';
 import { AddMailboxMessages1784519962991 } from '../migrations/1784519962991-AddMailboxMessages';
+import { AddMailboxReceivedAtIndex1784692000000 } from '../migrations/1784692000000-AddMailboxReceivedAtIndex';
 import { AddNameInventoryAndPinnedCids1784566605863 } from '../migrations/1784566605863-AddNameInventoryAndPinnedCids';
 import { AddRecordCache1784600557946 } from '../migrations/1784600557946-AddRecordCache';
 import { InitAuthSchema1784513040045 } from '../migrations/1784513040045-InitAuthSchema';
@@ -40,6 +41,7 @@ const MIGRATIONS = [
   AddMailboxMessages1784519962991,
   AddNameInventoryAndPinnedCids1784566605863,
   AddRecordCache1784600557946,
+  AddMailboxReceivedAtIndex1784692000000,
 ];
 
 export interface IntegrationDatabase {

--- a/apps/api/src/testing/integration-db.ts
+++ b/apps/api/src/testing/integration-db.ts
@@ -86,6 +86,9 @@ export async function createIntegrationDatabase(
     database: name,
     entities: ENTITIES,
     migrations: MIGRATIONS,
+    // Match data-source.ts so a migration opting out (transaction = false) for
+    // CONCURRENTLY DDL runs identically here as under the CLI/drift check.
+    migrationsTransactionMode: 'each',
     synchronize: false,
     uuidExtension: 'pgcrypto',
     extra: options.poolMax ? { max: options.poolMax } : undefined,


### PR DESCRIPTION
Closes #667

## Problem

The mailbox 90-day unacked TTL was enforced **lazily only** — `MailboxService.purgeExpired` fires on a recipient's own `post`/`poll`. A **dormant-but-alive** mailbox (recipient stops polling, receives no new posts) kept its expired HPKE-sealed rows in `mailbox_messages` indefinitely, so the 90-day bound was eventual-consistency-on-activity rather than a hard guarantee.

## What this adds

A **global scheduled sweep** independent of per-recipient activity: `MailboxService.sweepExpired()`, driven on a `~12h` `PeriodicTask` (`MailboxSweepTask`) — a sibling of the republisher walk.

### Cadence
`~12h` (`MAILBOX_SWEEP_INTERVAL_MS`, default `12h`), per-run bound `1h` (`MAILBOX_SWEEP_RUN_TIMEOUT_MS`), both `positiveIntConfig` fail-closed. Default-on, opt-out via `MAILBOX_SWEEP_ENABLED` (for out-of-process / single-instance pinning).

### Single loop, single-flight
The republisher previously bound its own `WorkerScheduler`. A new `common/SchedulerModule` now owns **one shared** `WorkerScheduler`; feature modules register their task in `onModuleInit`, and the shared module calls `start()` in `onApplicationBootstrap`. Nest runs every `onModuleInit` before any `onApplicationBootstrap`, so all registrations land before the single start — the scheduler's register-before-start contract is preserved untouched (no scheduler-contract change). A behavioral test (`scheduler.module.test.ts`) proves both consumers share one instance and both tasks start.

**Single-flight** uses the scheduler's own in-flight guard — the same mechanism the republisher uses (the issue's "whichever the republisher uses"). Cross-instance overlap is harmless because the batched delete is idempotent.

### Batched, set-based deletes
```sql
DELETE FROM mailbox_messages
WHERE ctid IN (
  SELECT ctid FROM mailbox_messages
  WHERE received_at < :cutoff ORDER BY received_at LIMIT :batchSize
)
```
The cutoff is **one injected-`Clock` snapshot per run** (deterministic/testable, exactly like the lazy purge — no `Date.now()`). Deletes are bounded per statement (`MAILBOX_SWEEP_BATCH_SIZE`, default `1000`) and loop until a short batch signals drained, capped per run at `MAILBOX_SWEEP_MAX_BATCHES` (default `1000`) so a huge backlog can't loop unbounded (the remainder waits for the next cadence). No long table lock, no bloated transaction — never row-by-row.

### Concurrency safety (specced upfront, not whack-a-mole)
Safe to interleave with `post`/`poll`/lazy `purgeExpired`: a concurrent post writes `received_at = clock.now()` (`>= cutoff`) that the sweep's `WHERE received_at < cutoff` can **never** match, and a row another path already deleted simply isn't re-counted. Proven by an **adversarial real-Postgres interleave test**: a `post` run concurrently with a sweep over a 300-row dormant backlog — the fresh post survives untouched and every expired dormant row is deleted.

## Index decision

**Added** a migration for `idx_mailbox_received_at` (recipient-less `received_at` btree) plus the matching entity `@Index`. The existing `idx_mailbox_recipient_received` leads with `recipient_public_key`, so it cannot drive the recipient-less range scan — without a dedicated index the batched `SELECT ... WHERE received_at < cutoff LIMIT n` would seq-scan the whole table each batch to find the few expired rows in a mostly-fresh table (the dormant-sweep case). The index makes each batch an index range scan. Migration drift check verified clean locally (`migration:run` + `migration:generate` reported "No changes in database schema were found").

## Zero-knowledge

The sweep never reads or logs blob contents — it touches only `ctid`/`received_at` and returns a deleted-row count. No sensitive material in logs.

## Tests

- `mailbox.sweep.integration.test.ts` (real-Postgres gate): expiry vs fresh with no activity, exact-cutoff boundary, multi-batch drain, per-run batch cap remainder, adversarial concurrent-post-survives-sweep.
- `mailbox-sweep.task.test.ts`: cadence defaults / overrides / fail-closed, delegation.
- `scheduler.module.test.ts`: shared-instance + lifecycle-ordering wiring.

All green locally: typecheck, build, 153 unit tests, 127 real-Postgres integration tests, eslint, migration-drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated cleanup of mailbox messages that have exceeded the 90-day retention period.
  * Cleanup runs periodically, supports batching, and can be configured or disabled through environment settings.
  * Added shared scheduling infrastructure for background tasks.

* **Improvements**
  * Invalid numeric configuration now safely falls back to defaults.
  * Mailbox cleanup performance improved through an optimized database index.
  * Database migrations now run in individual transactions by default.

* **Tests**
  * Added coverage for cleanup behavior, batching, concurrency, scheduling, and configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->