### PR TITLE
feat(engine): bind resolved scope-root records to the enumerated scope_id

### DIFF
--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -548,7 +548,6 @@ mod tests {
                 .to_compact();
             Ok(SweepTarget {
                 v: V,
-                ipns_name: DESCENDANT_NAME.to_vec(),
                 current_read_epoch: 1,
                 owner_enc_pub: owner_enc().public(),
                 parent_node_seed: None,

--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -548,7 +548,6 @@ mod tests {
                 .to_compact();
             Ok(SweepTarget {
                 v: V,
-                scope_id: DESCENDANT_SCOPE,
                 ipns_name: DESCENDANT_NAME.to_vec(),
                 current_read_epoch: 1,
                 owner_enc_pub: owner_enc().public(),

--- a/crates/engine/src/rotation/cascade.rs
+++ b/crates/engine/src/rotation/cascade.rs
@@ -78,20 +78,21 @@ use crate::seams::{BoxedTask, FloorStore, Scheduler, SeamError};
 
 /// One descendant scope root's current re-seal material, as resolved from its
 /// published record — everything [`reseal_scope_root`] needs **except** the
-/// parent node seed and any self-identifying scope id.
+/// parent node seed and any self-identifying `scope_id`/`ipns_name`.
 ///
-/// Both omissions are deliberate and load-bearing. The cascade re-seals each
+/// Those omissions are deliberate and load-bearing. The cascade re-seals each
 /// descendant's ascent link under its **parent's freshly-minted** derivation
 /// (`node_seed(parent_fresh_seed, child_scope_id)`), threaded top-down — never
 /// under the descendant's own stale published parent seed; carrying a
 /// `parent_node_seed` here would invite re-sealing under the wrong (stale)
 /// derivation (contrast [`SweepTarget`](super::sweep::SweepTarget), which *does*
 /// carry it because the sweep reuses the published derivation). A resolved
-/// scope-root record likewise carries no cryptographically self-identifying
-/// `scope_id` — the id lives only in the sealed-structure AAD — so a returned
-/// `scope_id` would be unbound trust: the re-seal, publish, and floor-raise run
-/// under the **enumerated** `child.scope_id` alone (see
-/// [`CascadeResealResolver::resolve`]), making the #756 divergence unrepresentable.
+/// record carries no self-identifying `scope_id` or `ipns_name` either: the
+/// re-seal identity, CAS-publish destination, parent-seed derivation, and
+/// floor-raise all run under the **enumerated** [`ChildScopeRef`]
+/// (`child.scope_id` / `child.ipns_name`) alone — there is no second copy for a
+/// network hint to diverge from, so the #756 divergence class is
+/// unrepresentable.
 ///
 /// Owns its secrets so the cascade is their terminal owner: the seed fields are
 /// [`Zeroizing`] and the pseudonym signer zeroizes on drop. Seeds are handed to
@@ -100,8 +101,6 @@ use crate::seams::{BoxedTask, FloorStore, Scheduler, SeamError};
 pub struct CascadeTarget {
     /// The envelope format+suite version.
     pub v: u64,
-    /// The scope root's opaque `ipnsName` bytes.
-    pub ipns_name: Vec<u8>,
     /// The published record's current read epoch — the new record publishes at
     /// `+ 1`, and this seed+epoch become the fresh history link's prior.
     pub current_read_epoch: u64,
@@ -148,17 +147,14 @@ pub trait CascadeResealResolver {
     /// # Binding contract (obligation on the real resolver, #745/#746)
     ///
     /// The resolver MUST gate `scope`'s record under the enumerated
-    /// `scope.scope_id`, take `ipns_name` solely from `scope.ipns_name`, and return
-    /// **no** independent `scope_id`. The enumerated `scope.scope_id` is the sole
-    /// authority for parent-node-seed derivation
-    /// (`node_seed(parent_fresh_seed, scope.scope_id)`), the visited/dedup key, and
-    /// the re-seal identity, CAS publish, and epoch-floor raise — there is no
-    /// second `scope_id` for the engine to trust ([`CascadeTarget`] carries none),
-    /// so #756's divergence is unrepresentable. `scope.ipns_name` is the **sole
-    /// gated identity edge** (the adoption gate binds `ipns_name -> record` via the
-    /// Ed25519 key derived from the name); the returned `ipns_name` — the CAS
-    /// publish destination — MUST equal it and `commitment.ipns_name`, never swayed
-    /// by a network-supplied hint. In this slice the resolver is faked.
+    /// `scope.scope_id` and `scope.ipns_name` — the adoption gate binds
+    /// `ipns_name -> record` via the Ed25519 key derived from the name, and the
+    /// gated record's `commitment.ipns_name` MUST equal `scope.ipns_name`. It
+    /// returns **no** self-identifying `scope_id` or `ipns_name`: the engine
+    /// re-seals, derives the parent node seed, CAS-publishes, and floor-raises
+    /// under the enumerated [`ChildScopeRef`] alone (see [`CascadeTarget`], which
+    /// carries neither, making the #756 divergence unrepresentable). In this
+    /// slice the resolver is faked.
     async fn resolve(&self, scope: &ChildScopeRef) -> Result<CascadeTarget, ResolveFailure>;
 }
 
@@ -517,9 +513,7 @@ where
                     reason,
                 })?;
 
-            // Bind this one parent's index (canonicalized: its own duplicate
-            // self-heals) into the cross-parent label map — a same-`scope_id`
-            // disagreement with an earlier parent is the C2 conflict.
+            // Bind per-parent (see bind_child_labels).
             bind_child_labels(
                 &mut labels,
                 canonicalize(&target.direct_child_scope_index).iter(),
@@ -536,11 +530,12 @@ where
             let plan = RotateScopePlan {
                 identity: ScopeRootIdentity {
                     v: target.v,
-                    // The enumerated id is the sole authority: re-seal, publish, and
-                    // floor-raise all run under `child.scope_id`, never a
-                    // resolver-returned one (#756).
+                    // The enumerated ChildScopeRef is the sole identity authority:
+                    // re-seal, publish, and floor-raise all run under
+                    // `child.scope_id`/`child.ipns_name`, never a resolver-returned
+                    // copy (#756; see CascadeTarget).
                     scope_id: child.scope_id,
-                    ipns_name: &target.ipns_name,
+                    ipns_name: &child.ipns_name,
                     owner_enc_pub: &target.owner_enc_pub,
                     parent_node_seed: Some(&child_parent_node_seed),
                     pseudonym_signer: &target.pseudonym_signer,
@@ -856,7 +851,6 @@ mod tests {
             }
             Ok(CascadeTarget {
                 v: V,
-                ipns_name: scope.ipns_name.clone(),
                 current_read_epoch: s.current_epoch,
                 owner_enc_pub: self.owner.enc.public(),
                 pseudonym_signer: self.owner.pseudonym.clone(),

--- a/crates/engine/src/rotation/cascade.rs
+++ b/crates/engine/src/rotation/cascade.rs
@@ -53,7 +53,7 @@
 //!
 //! [`enumerate_eager_set`]: super::eager_set::enumerate_eager_set
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use zeroize::Zeroizing;
 
@@ -64,7 +64,7 @@ use cipherbox_core::suite::ed25519::Ed25519Signer;
 use cipherbox_core::suite::secret::SECRET_LEN;
 use cipherbox_core::suite::x25519::X25519Public;
 
-use super::eager_set::ResolveFailure;
+use super::eager_set::{ResolveFailure, bind_child_labels};
 use super::reseal::{
     CommittedSet, PrevEpochSeed, ResealError, ResealSeeds, ScopeRootIdentity, reseal_scope_root,
 };
@@ -72,21 +72,26 @@ use super::rotate::{
     ResealedScopeRoot, RotateScopePlan, ScopeRootPublishError, ScopeRootPublisher,
 };
 use crate::entropy::Entropy;
+use crate::grants::child_index::canonicalize;
 use crate::hex::hex_lower;
 use crate::seams::{BoxedTask, FloorStore, Scheduler, SeamError};
 
 /// One descendant scope root's current re-seal material, as resolved from its
 /// published record — everything [`reseal_scope_root`] needs **except** the
-/// parent node seed.
+/// parent node seed and any self-identifying scope id.
 ///
-/// The omission is deliberate and load-bearing: the cascade re-seals each
+/// Both omissions are deliberate and load-bearing. The cascade re-seals each
 /// descendant's ascent link under its **parent's freshly-minted** derivation
 /// (`node_seed(parent_fresh_seed, child_scope_id)`), threaded top-down — never
-/// under the descendant's own stale published parent seed. Carrying a
+/// under the descendant's own stale published parent seed; carrying a
 /// `parent_node_seed` here would invite re-sealing under the wrong (stale)
-/// derivation, the exact bug the cascade exists to avoid (contrast
-/// [`SweepTarget`](super::sweep::SweepTarget), which *does* carry it because the
-/// sweep reuses the published derivation rather than threading a new one).
+/// derivation (contrast [`SweepTarget`](super::sweep::SweepTarget), which *does*
+/// carry it because the sweep reuses the published derivation). A resolved
+/// scope-root record likewise carries no cryptographically self-identifying
+/// `scope_id` — the id lives only in the sealed-structure AAD — so a returned
+/// `scope_id` would be unbound trust: the re-seal, publish, and floor-raise run
+/// under the **enumerated** `child.scope_id` alone (see
+/// [`CascadeResealResolver::resolve`]), making the #756 divergence unrepresentable.
 ///
 /// Owns its secrets so the cascade is their terminal owner: the seed fields are
 /// [`Zeroizing`] and the pseudonym signer zeroizes on drop. Seeds are handed to
@@ -95,10 +100,6 @@ use crate::seams::{BoxedTask, FloorStore, Scheduler, SeamError};
 pub struct CascadeTarget {
     /// The envelope format+suite version.
     pub v: u64,
-    /// The scope-root node id (== scope id). This is the id the re-seal, publish,
-    /// and floor-raise run under; the production resolver MUST return it equal to
-    /// the enumerated `child.scope_id` (see [`CascadeResealResolver::resolve`]).
-    pub scope_id: [u8; 16],
     /// The scope root's opaque `ipnsName` bytes.
     pub ipns_name: Vec<u8>,
     /// The published record's current read epoch — the new record publishes at
@@ -146,21 +147,18 @@ pub trait CascadeResealResolver {
     ///
     /// # Binding contract (obligation on the real resolver, #745/#746)
     ///
-    /// `scope`'s `ipns_name` is the **sole gated identity edge** (the adoption
-    /// gate binds `ipns_name -> record` via the Ed25519 key derived from the
-    /// name). The returned material's `ipns_name` — the CAS **publish**
-    /// destination — MUST be that gated name, equal to `commitment.ipns_name`, and
-    /// MUST NOT be swayed by any network-supplied hint.
-    ///
-    /// The enumerated `child.scope_id` drives the parent-node-seed derivation
-    /// (`node_seed(parent_fresh_seed, child.scope_id)`) and the visited/dedup key,
-    /// but the re-seal identity, CAS publish, and epoch-floor raise all run under
-    /// the resolver-returned `target.scope_id`. The production resolver therefore
-    /// MUST guarantee `target.scope_id == child.scope_id` — the same equality that
-    /// keeps `ipns_name`/`commitment.ipns_name` gate-consistent — so the enumerated
-    /// id it was asked to resolve is the id it re-keys and publishes under. This
-    /// binding obligation is on the #745/#746 resolver wiring (tracked by #756); in
-    /// this slice the resolver is faked and always returns the equal id.
+    /// The resolver MUST gate `scope`'s record under the enumerated
+    /// `scope.scope_id`, take `ipns_name` solely from `scope.ipns_name`, and return
+    /// **no** independent `scope_id`. The enumerated `scope.scope_id` is the sole
+    /// authority for parent-node-seed derivation
+    /// (`node_seed(parent_fresh_seed, scope.scope_id)`), the visited/dedup key, and
+    /// the re-seal identity, CAS publish, and epoch-floor raise — there is no
+    /// second `scope_id` for the engine to trust ([`CascadeTarget`] carries none),
+    /// so #756's divergence is unrepresentable. `scope.ipns_name` is the **sole
+    /// gated identity edge** (the adoption gate binds `ipns_name -> record` via the
+    /// Ed25519 key derived from the name); the returned `ipns_name` — the CAS
+    /// publish destination — MUST equal it and `commitment.ipns_name`, never swayed
+    /// by a network-supplied hint. In this slice the resolver is faked.
     async fn resolve(&self, scope: &ChildScopeRef) -> Result<CascadeTarget, ResolveFailure>;
 }
 
@@ -199,9 +197,10 @@ impl CascadeOutcome {
 /// trust violation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CascadeError {
-    /// A reachable descendant's re-seal material could not be authoritatively
-    /// resolved (gate rejection or host unavailability), so the cascade is not
-    /// provably complete.
+    /// A reachable descendant could not be authoritatively resolved — a gate
+    /// rejection, host unavailability, or a C2 label conflict (the same
+    /// `scope_id` reached via two parents with different `ipns_name`, #746) — so
+    /// the cascade is not provably complete.
     Resolve {
         /// The descendant scope root that could not be resolved.
         scope_id: [u8; 16],
@@ -304,12 +303,15 @@ impl CascadeError {
 
     /// Whether re-running the cascade could clear this failure — an availability
     /// stall (unavailable resolve, publish not-landed/lost-race, floor-read I/O,
-    /// or an entropy hiccup) — versus a trust violation (a gate-rejected record,
-    /// a divergent ledger / uncommitted signer, an exhausted epoch), which no
-    /// retry can fix.
+    /// or an entropy hiccup), or a C2 label conflict the re-point wave repairs —
+    /// versus a trust violation (a gate-rejected record, a divergent ledger /
+    /// uncommitted signer, an exhausted epoch), which no retry can fix.
     pub fn is_retryable(&self) -> bool {
         match self {
-            CascadeError::Resolve { reason, .. } => *reason == ResolveFailure::Unavailable,
+            CascadeError::Resolve { reason, .. } => matches!(
+                reason,
+                ResolveFailure::Unavailable | ResolveFailure::ConflictingChildLabel
+            ),
             CascadeError::Reseal { error, .. } => matches!(error, ResealError::Entropy(_)),
             CascadeError::Publish { .. } => true,
             CascadeError::Floor { .. } => true,
@@ -465,12 +467,25 @@ where
     // 2) Top-down threaded walk over the descendant tree. Each frontier entry
     //    carries its parent's freshly-minted override seed so the child's ascent
     //    link re-seals under the parent's NEW derivation. Mirrors
-    //    `enumerate_eager_set`: canonicalized frontiers (permutation-independent,
-    //    first-seen parent wins a diamond) and a `scope_id`-keyed visited set that
-    //    terminates diamonds and cycles. The re-key needs these ordered edges,
-    //    which the flat `EagerSet` does not carry.
+    //    `enumerate_eager_set`: canonicalized frontiers, a `scope_id`-keyed visited
+    //    set that terminates diamonds and cycles, and a `scope_id -> ipns_name`
+    //    label map that aborts a same-`scope_id`/different-`ipns_name` conflict
+    //    (C2, #746) rather than picking a coin-flip first-seen name. The re-key
+    //    needs these ordered edges, which the flat `EagerSet` does not carry.
     let mut visited: BTreeSet<[u8; 16]> = BTreeSet::new();
     visited.insert(root_scope_id);
+
+    let mut labels: BTreeMap<[u8; 16], Vec<u8>> = BTreeMap::new();
+    let conflict = |scope_id| CascadeError::Resolve {
+        scope_id,
+        reason: ResolveFailure::ConflictingChildLabel,
+    };
+    bind_child_labels(
+        &mut labels,
+        canonicalize(root_plan.committed.direct_child_scope_index).iter(),
+        root_scope_id,
+    )
+    .map_err(conflict)?;
 
     let mut frontier = canonicalize_frontier(
         root_plan
@@ -502,6 +517,16 @@ where
                     reason,
                 })?;
 
+            // Bind this one parent's index (canonicalized: its own duplicate
+            // self-heals) into the cross-parent label map — a same-`scope_id`
+            // disagreement with an earlier parent is the C2 conflict.
+            bind_child_labels(
+                &mut labels,
+                canonicalize(&target.direct_child_scope_index).iter(),
+                root_scope_id,
+            )
+            .map_err(conflict)?;
+
             // Thread: the child's ascent link re-seals under the parent's NEW
             // derivation, `node_seed(parent_fresh_seed, child_scope_id)`.
             let parent_seed_ref: &[u8; SECRET_LEN] = parent_seed;
@@ -511,7 +536,10 @@ where
             let plan = RotateScopePlan {
                 identity: ScopeRootIdentity {
                     v: target.v,
-                    scope_id: target.scope_id,
+                    // The enumerated id is the sole authority: re-seal, publish, and
+                    // floor-raise all run under `child.scope_id`, never a
+                    // resolver-returned one (#756).
+                    scope_id: child.scope_id,
                     ipns_name: &target.ipns_name,
                     owner_enc_pub: &target.owner_enc_pub,
                     parent_node_seed: Some(&child_parent_node_seed),
@@ -598,6 +626,13 @@ mod tests {
 
     fn childref(byte: u8) -> ChildScopeRef {
         ChildScopeRef::new(sid(byte), format!("ipns-{byte:02x}").into_bytes())
+    }
+
+    /// A child ref for scope `byte` carrying a caller-chosen `ipns_name` — to build
+    /// a diamond where one `scope_id` is reached with differing labels (C2), or an
+    /// attacker-chosen label the resolver's gate rejects.
+    fn childref_named(byte: u8, ipns_name: &str) -> ChildScopeRef {
+        ChildScopeRef::new(sid(byte), ipns_name.as_bytes().to_vec())
     }
 
     /// The single vault owner/pseudonym identity every scope commits to, so
@@ -694,6 +729,14 @@ mod tests {
         /// as its direct-child index, published at `current_epoch`, pre-cascade
         /// override seed `[byte; 32]`.
         fn scope(self, byte: u8, current_epoch: u64, children: &[u8]) -> Self {
+            let refs: Vec<ChildScopeRef> = children.iter().map(|b| childref(*b)).collect();
+            self.scope_refs(byte, current_epoch, refs)
+        }
+
+        /// Like [`Self::scope`] but with caller-chosen child refs, so a parent can
+        /// list a descendant under a specific (possibly conflicting or attacker)
+        /// `ipns_name`.
+        fn scope_refs(self, byte: u8, current_epoch: u64, children: Vec<ChildScopeRef>) -> Self {
             let (commitment, commitment_sig, grant_ledger) = self.owner.committed(byte);
             self.scopes.borrow_mut().insert(
                 sid(byte),
@@ -704,7 +747,7 @@ mod tests {
                     commitment,
                     commitment_sig,
                     grant_ledger,
-                    children: children.iter().map(|b| childref(*b)).collect(),
+                    children,
                     current_epoch,
                 },
             );
@@ -804,9 +847,15 @@ mod tests {
             let s = scopes
                 .get(&scope.scope_id)
                 .ok_or(ResolveFailure::Unavailable)?;
+            // Fidelity to the gate contract: the record's owner-signed commitment
+            // binds its ipns_name (adoption gate stage 2). A child ref whose
+            // ipns_name is not the committed name has no commitment binding it —
+            // the gate rejects, so an attacker-chosen label cannot resolve.
+            if scope.ipns_name != s.commitment.ipns_name {
+                return Err(ResolveFailure::Rejected);
+            }
             Ok(CascadeTarget {
                 v: V,
-                scope_id: scope.scope_id,
                 ipns_name: scope.ipns_name.clone(),
                 current_read_epoch: s.current_epoch,
                 owner_enc_pub: self.owner.enc.public(),
@@ -910,10 +959,24 @@ mod tests {
         InMemoryFloorStore,
         usize,
     ) {
+        let root_index: Vec<ChildScopeRef> = root_children.iter().map(|b| childref(*b)).collect();
+        run_with_index(net, root_index)
+    }
+
+    /// [`run`] with a caller-chosen root child index (custom `ipns_name` labels).
+    #[allow(clippy::type_complexity)]
+    fn run_with_index(
+        net: FakeNet,
+        root_index: Vec<ChildScopeRef>,
+    ) -> (
+        Result<CascadeOutcome, CascadeError>,
+        FakeNet,
+        InMemoryFloorStore,
+        usize,
+    ) {
         let fx = RootFx::new(net.clone());
         let floors = InMemoryFloorStore::default();
         let scheduler = VirtualScheduler::new();
-        let root_index: Vec<ChildScopeRef> = root_children.iter().map(|b| childref(*b)).collect();
         let outcome = block_on(async {
             let mut entropy = SeededEntropy::new(0xCA5CADE);
             let plan = fx.plan(&root_index);
@@ -1051,8 +1114,9 @@ mod tests {
 
     #[test]
     fn diamond_descendant_rekeyed_once_under_first_seen_parent() {
-        // root -> A(0x0a), B(0x0b); both A and B list D(0x0d). D is re-keyed exactly
-        // once, threaded from the canonically-first parent A (0x0a < 0x0b).
+        // Test E (regression): root -> A(0x0a), B(0x0b); both A and B list D(0x0d)
+        // with the SAME ipns_name (childref). D is re-keyed exactly once, threaded
+        // from the canonically-first parent A (0x0a < 0x0b) — no C2 abort.
         let net = FakeNet::new()
             .scope(0x0a, 4, &[0x0d])
             .scope(0x0b, 4, &[0x0d])
@@ -1080,6 +1144,91 @@ mod tests {
                 .is_none(),
             "D does not thread from the later parent B"
         );
+    }
+
+    #[test]
+    fn c2_conflicting_ipns_name_aborts_fail_closed_permutation_independent() {
+        // Test B (C2, #746): root -> A(0x0a), B(0x0b); both list D(0x0d) but under
+        // DIFFERENT ipns_name labels. First-seen would be a coin-flip that could
+        // re-key a dead name and leave the real D unrotated — a revocation hole —
+        // so the walk aborts fail-closed naming D, identically under either parent
+        // order (the frontier is canonicalized, so A is always seen before B).
+        let build = || {
+            FakeNet::new()
+                .scope_refs(0x0a, 4, vec![childref_named(0x0d, "ipns-0d")])
+                .scope_refs(0x0b, 4, vec![childref_named(0x0d, "ipns-old")])
+                .scope(0x0d, 4, &[])
+        };
+        let forward = run_with_index(build(), vec![childref(0x0a), childref(0x0b)]).0;
+        let reversed = run_with_index(build(), vec![childref(0x0b), childref(0x0a)]).0;
+
+        let fwd = forward.expect_err("conflict aborts");
+        let rev = reversed.expect_err("conflict aborts");
+        assert_eq!(fwd, rev, "abort is permutation-independent");
+        assert_eq!(fwd.check(), "resolve-failed");
+        assert_eq!(fwd.scope_id(), sid(0x0d), "the conflict names scope D");
+        assert!(
+            fwd.is_retryable(),
+            "a label conflict is retryable (re-point wave)"
+        );
+    }
+
+    #[test]
+    fn c2_conflict_is_retryable_and_succeeds_after_repoint_wave() {
+        // Test C (legitimate mid-wave): parent A points D at its new name while B is
+        // not-yet-repaired (still the stale name) -> C2 abort, retryable. Once the
+        // re-point wave repairs B to the same name, a retried walk resolves D once.
+        let mid_wave = FakeNet::new()
+            .scope_refs(0x0a, 4, vec![childref_named(0x0d, "ipns-0d")])
+            .scope_refs(0x0b, 4, vec![childref_named(0x0d, "ipns-old")])
+            .scope(0x0d, 4, &[]);
+        let (out, _net, _f, spawned) =
+            run_with_index(mid_wave, vec![childref(0x0a), childref(0x0b)]);
+        let err = out.expect_err("mid-wave conflict aborts");
+        assert_eq!(err.scope_id(), sid(0x0d));
+        assert!(
+            err.is_retryable(),
+            "converges once the re-point wave repairs B"
+        );
+        assert_eq!(spawned, 0, "no sweep enqueued on a fail-closed abort");
+
+        // After the wave: both parents agree on D's current committed name.
+        let repaired = FakeNet::new()
+            .scope_refs(0x0a, 4, vec![childref_named(0x0d, "ipns-0d")])
+            .scope_refs(0x0b, 4, vec![childref_named(0x0d, "ipns-0d")])
+            .scope(0x0d, 4, &[]);
+        let (out, net, _f, spawned) =
+            run_with_index(repaired, vec![childref(0x0a), childref(0x0b)]);
+        let outcome = out.expect("repaired walk completes");
+        let d_rekeys = outcome
+            .rekeyed
+            .iter()
+            .filter(|r| r.scope_id == sid(0x0d))
+            .count();
+        assert_eq!(d_rekeys, 1, "D re-keyed exactly once at the agreed name");
+        assert!(
+            !ct_eq_32(&net.published_seed(0x0d), &[0x0d; 32]),
+            "D got a fresh seed"
+        );
+        assert_eq!(spawned, 1, "the repaired cascade enqueues the sweep");
+    }
+
+    #[test]
+    fn attacker_label_without_commitment_binding_is_fatal() {
+        // Test D: A lists D(0x0d) under an attacker-chosen ipns_name that no
+        // owner-signed commitment binds. There is no conflict (a single label), so
+        // the record resolves — and the gate rejects it because the commitment does
+        // not bind that name. Trust rests on the owner-signed commitment, not the
+        // parent label: the reject is FATAL, not a retryable stall.
+        let net = FakeNet::new()
+            .scope_refs(0x0a, 4, vec![childref_named(0x0d, "ipns-attacker")])
+            .scope(0x0d, 4, &[]);
+        let (out, _net, _f, spawned) = run_with_index(net, vec![childref(0x0a)]);
+        let err = out.expect_err("attacker label is rejected");
+        assert_eq!(err.check(), "resolve-failed");
+        assert_eq!(err.scope_id(), sid(0x0d));
+        assert!(!err.is_retryable(), "a commitment-gate rejection is fatal");
+        assert_eq!(spawned, 0);
     }
 
     #[test]

--- a/crates/engine/src/rotation/eager_set.rs
+++ b/crates/engine/src/rotation/eager_set.rs
@@ -42,9 +42,11 @@
 //! The walk is pure — the sole impure edge is the injected [`ChildIndexResolver`].
 //! Output is ordered by `scope_id` (a [`BTreeMap`], matching Slice 1's
 //! [`canonicalize`](crate::grants::child_index::canonicalize) convention) and each
-//! level is canonicalized before descent, so the first-seen entry for any shared
-//! descendant is permutation-independent. Replayed or multi-writer runs converge
-//! to byte-identical output.
+//! level is canonicalized before descent, so a shared descendant reached via
+//! multiple parents is recorded once, permutation-independently — or, if those
+//! parents disagree on its `ipns_name`, the walk aborts fail-closed (C2, #746;
+//! [`ResolveFailure::ConflictingChildLabel`]). Replayed or multi-writer runs
+//! converge to byte-identical output.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -66,6 +68,15 @@ pub enum ResolveFailure {
     /// The descendant's record could not be fetched or read — host I/O or
     /// availability. Retryable; not a trust verdict.
     Unavailable,
+    /// The same `scope_id` was reached via two parents carrying **different**
+    /// `ipns_name` labels (C2, #746). A [`ChildScopeRef`] carries no ordering
+    /// signal, so first-seen-wins would be a coin-flip; picking the stale name in a
+    /// revocation cascade re-keys a dead name and leaves the real descendant
+    /// unrotated — a silent revocation hole. The walk aborts fail-closed instead.
+    /// Retryable: converges once the write-rotation re-point wave repairs both
+    /// parent indexes (engine.md #38 D6). The accept-freshest alternative needs a
+    /// core schema change and is deferred to #778.
+    ConflictingChildLabel,
 }
 
 impl core::fmt::Display for ResolveFailure {
@@ -73,6 +84,9 @@ impl core::fmt::Display for ResolveFailure {
         match self {
             ResolveFailure::Rejected => f.write_str("descendant record rejected by adoption gate"),
             ResolveFailure::Unavailable => f.write_str("descendant record unavailable"),
+            ResolveFailure::ConflictingChildLabel => {
+                f.write_str("descendant scope_id reached with conflicting ipns_name labels")
+            }
         }
     }
 }
@@ -164,6 +178,38 @@ pub trait ChildIndexResolver {
     ) -> Result<Vec<ChildScopeRef>, ResolveFailure>;
 }
 
+/// Bind each ref's `scope_id -> ipns_name` label into `labels`, aborting
+/// fail-closed on the C2 conflict: a `scope_id` already bound to a **different**
+/// `ipns_name` (#746). Returns the conflicting `scope_id` on abort. The root is
+/// skipped — a back-edge to it is ignored by the walk, never a labeled
+/// descendant. Rationale for the hard abort lives on
+/// [`ResolveFailure::ConflictingChildLabel`].
+///
+/// Call once **per parent index** (each already canonicalized), never over a
+/// merged frontier. A single parent's own duplicate `scope_id` is crash residue
+/// the [`canonicalize`] self-heal repairs first-seen (#38 D6) — only a
+/// **cross-parent** disagreement, where neither parent is authoritative over the
+/// other's label, is the revocation-hole conflict this abort exists to catch.
+pub(super) fn bind_child_labels<'a>(
+    labels: &mut BTreeMap<[u8; 16], Vec<u8>>,
+    refs: impl Iterator<Item = &'a ChildScopeRef>,
+    root_scope_id: [u8; 16],
+) -> Result<(), [u8; 16]> {
+    for child in refs {
+        if child.scope_id == root_scope_id {
+            continue;
+        }
+        match labels.get(&child.scope_id) {
+            Some(name) if name != &child.ipns_name => return Err(child.scope_id),
+            Some(_) => {}
+            None => {
+                labels.insert(child.scope_id, child.ipns_name.clone());
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Enumerate the eager set: the transitive closure of descendant scope roots
 /// reachable from `root_scope_id`, whose level-1 adjacency is `root_child_index`
 /// (the root's own, caller-held write-body index) and whose deeper levels the
@@ -171,8 +217,10 @@ pub trait ChildIndexResolver {
 ///
 /// Fail-closed and complete: returns [`EagerSet`] only if *every* reachable
 /// descendant resolved; otherwise [`EnumerationError`] names the first
-/// unresolved scope. Deterministic: output is ascending by `scope_id`,
-/// permutation-independent, and terminates on any cyclic input.
+/// unresolved scope, or the first C2 label conflict
+/// ([`ResolveFailure::ConflictingChildLabel`]). Deterministic: output is
+/// ascending by `scope_id`, permutation-independent, and terminates on any cyclic
+/// input.
 pub async fn enumerate_eager_set<R: ChildIndexResolver>(
     root_scope_id: [u8; 16],
     root_child_index: &[ChildScopeRef],
@@ -188,10 +236,21 @@ pub async fn enumerate_eager_set<R: ChildIndexResolver>(
     // ascending-scope_id order for free.
     let mut discovered: BTreeMap<[u8; 16], ChildScopeRef> = BTreeMap::new();
 
+    // The single authoritative `scope_id -> ipns_name` binding. Registered once
+    // per parent index (each canonicalized), so two parents that disagree on a
+    // descendant's `ipns_name` conflict (C2), while one parent's own duplicate
+    // self-heals.
+    let mut labels: BTreeMap<[u8; 16], Vec<u8>> = BTreeMap::new();
+    let conflict = |scope_id| EnumerationError {
+        scope_id,
+        reason: ResolveFailure::ConflictingChildLabel,
+    };
+
     // Canonicalize each level (sort + dedup by scope_id) before descending so
     // traversal order — and thus the first-seen entry for any shared descendant
     // reachable via multiple parents — is fixed independent of input order.
     let mut frontier = canonicalize(root_child_index);
+    bind_child_labels(&mut labels, frontier.iter(), root_scope_id).map_err(conflict)?;
 
     while !frontier.is_empty() {
         let mut next: Vec<ChildScopeRef> = Vec::new();
@@ -214,6 +273,11 @@ pub async fn enumerate_eager_set<R: ChildIndexResolver>(
                         scope_id: child.scope_id,
                         reason,
                     })?;
+            // Bind this one parent's index (canonicalized: its own duplicate
+            // self-heals) into the cross-parent label map — a same-`scope_id`
+            // disagreement with an earlier parent is the C2 conflict.
+            let canon = canonicalize(&grandchildren);
+            bind_child_labels(&mut labels, canon.iter(), root_scope_id).map_err(conflict)?;
             next.extend(grandchildren);
         }
         frontier = canonicalize(&next);
@@ -412,40 +476,52 @@ mod tests {
     }
 
     #[test]
-    fn determinism_diamond_records_first_seen_ipns_name() {
-        // root -> A(0x01), B(0x02); both parents list the same descendant scope
-        // D(0x04) but carry DIFFERING ipns_name values. D is recorded exactly
-        // once, and the recorded ChildScopeRef is the canonically-first
-        // (lowest-scope_id, thus earliest-visited) parent A's ipns_name —
-        // deterministically and independent of the root-index permutation.
+    fn c2_conflicting_ipns_name_aborts_fail_closed_permutation_independent() {
+        // C2 (#746): root -> A(0x01), B(0x02); both parents list the same
+        // descendant scope D(0x04) but carry DIFFERING ipns_name values. A
+        // ChildScopeRef has no ordering signal, so first-seen would be a coin-flip
+        // and picking the stale name is a silent revocation hole — the walk aborts
+        // fail-closed naming D, identically under forward and reversed parent order.
         let build = |root_index: Vec<ChildScopeRef>| {
             let resolver = FakeResolver::new()
                 .with_refs(0x01, vec![child_named(0x04, "via-a")])
                 .with_refs(0x02, vec![child_named(0x04, "via-b")]);
+            block_on(enumerate_eager_set(sid(0x00), &root_index, &resolver))
+        };
+
+        let forward = build(vec![child(0x01), child(0x02)]).expect_err("conflict aborts");
+        let reversed = build(vec![child(0x02), child(0x01)]).expect_err("conflict aborts");
+
+        assert_eq!(forward, reversed, "abort is permutation-independent");
+        assert_eq!(forward.scope_id, sid(0x04), "the conflict names scope D");
+        assert_eq!(forward.reason, ResolveFailure::ConflictingChildLabel);
+    }
+
+    #[test]
+    fn diamond_same_scope_and_ipns_name_resolves_once_no_abort() {
+        // Regression (test E): a legitimate diamond — both parents list D(0x04) with
+        // the SAME ipns_name — resolves D exactly once with no conflict abort.
+        let build = |root_index: Vec<ChildScopeRef>| {
+            let resolver = FakeResolver::new()
+                .with_refs(0x01, vec![child_named(0x04, "via-shared")])
+                .with_refs(0x02, vec![child_named(0x04, "via-shared")]);
             block_on(enumerate_eager_set(sid(0x00), &root_index, &resolver)).expect("enumerates")
         };
-        let d_name = |set: &EagerSet| {
-            set.descendants()
-                .iter()
-                .find(|c| c.scope_id == sid(0x04))
-                .expect("D present")
-                .ipns_name
-                .clone()
-        };
-
         let forward = build(vec![child(0x01), child(0x02)]);
         let reversed = build(vec![child(0x02), child(0x01)]);
-
         assert_eq!(
             forward, reversed,
-            "first-seen content is permutation-independent"
-        );
-        assert_eq!(
-            d_name(&forward),
-            b"via-a",
-            "canonically-first parent's ipns_name wins the first-seen record"
+            "shared-name diamond is order-independent"
         );
         assert_eq!(ids(&forward), vec![sid(0x01), sid(0x02), sid(0x04)]);
+        let d_name = forward
+            .descendants()
+            .iter()
+            .find(|c| c.scope_id == sid(0x04))
+            .expect("D present")
+            .ipns_name
+            .clone();
+        assert_eq!(d_name, b"via-shared");
     }
 
     #[test]

--- a/crates/engine/src/rotation/eager_set.rs
+++ b/crates/engine/src/rotation/eager_set.rs
@@ -236,10 +236,8 @@ pub async fn enumerate_eager_set<R: ChildIndexResolver>(
     // ascending-scope_id order for free.
     let mut discovered: BTreeMap<[u8; 16], ChildScopeRef> = BTreeMap::new();
 
-    // The single authoritative `scope_id -> ipns_name` binding. Registered once
-    // per parent index (each canonicalized), so two parents that disagree on a
-    // descendant's `ipns_name` conflict (C2), while one parent's own duplicate
-    // self-heals.
+    // The single authoritative `scope_id -> ipns_name` binding, bound per parent
+    // index (see bind_child_labels).
     let mut labels: BTreeMap<[u8; 16], Vec<u8>> = BTreeMap::new();
     let conflict = |scope_id| EnumerationError {
         scope_id,
@@ -273,9 +271,7 @@ pub async fn enumerate_eager_set<R: ChildIndexResolver>(
                         scope_id: child.scope_id,
                         reason,
                     })?;
-            // Bind this one parent's index (canonicalized: its own duplicate
-            // self-heals) into the cross-parent label map — a same-`scope_id`
-            // disagreement with an earlier parent is the C2 conflict.
+            // Bind per-parent (see bind_child_labels).
             let canon = canonicalize(&grandchildren);
             bind_child_labels(&mut labels, canon.iter(), root_scope_id).map_err(conflict)?;
             next.extend(grandchildren);

--- a/crates/engine/src/rotation/sweep.rs
+++ b/crates/engine/src/rotation/sweep.rs
@@ -68,8 +68,11 @@ use crate::hex::hex_lower;
 use crate::seams::{FloorStore, Scheduler, SeamError};
 
 /// One scope root's current re-seal material, as resolved from its published
-/// record: everything [`reseal_scope_root`] needs plus the record epoch the
-/// epoch-lag predicate compares against the floor.
+/// record: everything [`reseal_scope_root`] needs **except** a self-identifying
+/// `scope_id`/`ipns_name`, plus the record epoch the epoch-lag predicate compares
+/// against the floor. The re-seal identity and CAS-publish destination run under
+/// the **enumerated** [`ChildScopeRef`] (`scope_id`/`ipns_name`) alone — the
+/// target carries no second copy for a network hint to diverge from (#756).
 ///
 /// Owns its secrets so the sweep is their terminal owner: the seed fields are
 /// [`Zeroizing`] and the pseudonym signer zeroizes on drop, so a resolved target
@@ -79,8 +82,6 @@ use crate::seams::{FloorStore, Scheduler, SeamError};
 pub struct SweepTarget {
     /// The envelope format+suite version.
     pub v: u64,
-    /// The scope root's opaque `ipnsName` bytes.
-    pub ipns_name: Vec<u8>,
     /// The published record's current read epoch — the epoch-lag operand.
     pub current_read_epoch: u64,
     /// The vault owner's X25519 encryption-subkey public (owner-blob recipient).
@@ -138,14 +139,13 @@ pub trait SweepResolver {
     /// # Binding contract (obligation on the real resolver, #745/#746)
     ///
     /// The same edge discipline [`ChildIndexResolver`] carries applies. The
-    /// resolver MUST gate `scope`'s record under the enumerated `scope.scope_id`,
-    /// take `ipns_name` solely from `scope.ipns_name`, and return **no** independent
-    /// `scope_id` — the sweep re-seals and CAS-publishes under the enumerated
-    /// `scope.scope_id` alone ([`SweepTarget`] carries none). `scope.ipns_name` is
-    /// the **sole gated identity edge** (the adoption gate binds `ipns_name ->
-    /// record` via the Ed25519 key derived from the name); the returned
-    /// `SweepTarget.ipns_name` — the CAS publish destination — MUST equal it and
-    /// `commitment.ipns_name`, never swayed by a network-supplied hint.
+    /// resolver MUST gate `scope`'s record under the enumerated `scope.scope_id`
+    /// and `scope.ipns_name` — the adoption gate binds `ipns_name -> record` via
+    /// the Ed25519 key derived from the name, and the gated record's
+    /// `commitment.ipns_name` MUST equal `scope.ipns_name`. It returns **no**
+    /// self-identifying `scope_id` or `ipns_name`: the sweep re-seals and
+    /// CAS-publishes under the enumerated [`ChildScopeRef`] alone (see
+    /// [`SweepTarget`]).
     async fn resolve(&self, scope: &ChildScopeRef) -> Result<SweepTarget, ResolveFailure>;
 }
 
@@ -357,7 +357,9 @@ where
         let identity = ScopeRootIdentity {
             v: target.v,
             scope_id,
-            ipns_name: &target.ipns_name,
+            // The enumerated ChildScopeRef is the sole identity authority (#756;
+            // see SweepTarget).
+            ipns_name: &descendant.ipns_name,
             owner_enc_pub: &target.owner_enc_pub,
             parent_node_seed: target.parent_node_seed.as_deref(),
             pseudonym_signer: &target.pseudonym_signer,
@@ -390,9 +392,7 @@ where
 
         let record = ResealedScopeRoot {
             scope_id,
-            // `target`'s borrows (identity/seeds/committed) all end at the
-            // `reseal_scope_root` return above, so the name moves out here.
-            ipns_name: target.ipns_name,
+            ipns_name: descendant.ipns_name.clone(),
             read_epoch: floor_epoch,
             write_epoch: target.write_epoch,
             section,
@@ -722,7 +722,6 @@ mod tests {
                 .ok_or(ResolveFailure::Unavailable)?;
             Ok(SweepTarget {
                 v: V,
-                ipns_name: scope.ipns_name.clone(),
                 current_read_epoch: s.current_epoch,
                 owner_enc_pub: self.owner.enc.public(),
                 parent_node_seed: s.parent_node_seed.map(Zeroizing::new),

--- a/crates/engine/src/rotation/sweep.rs
+++ b/crates/engine/src/rotation/sweep.rs
@@ -79,8 +79,6 @@ use crate::seams::{FloorStore, Scheduler, SeamError};
 pub struct SweepTarget {
     /// The envelope format+suite version.
     pub v: u64,
-    /// The scope-root node id (== scope id).
-    pub scope_id: [u8; 16],
     /// The scope root's opaque `ipnsName` bytes.
     pub ipns_name: Vec<u8>,
     /// The published record's current read epoch — the epoch-lag operand.
@@ -139,16 +137,15 @@ pub trait SweepResolver {
     ///
     /// # Binding contract (obligation on the real resolver, #745/#746)
     ///
-    /// The same edge discipline [`ChildIndexResolver`] carries applies: `scope`'s
-    /// `ipns_name` is the **sole gated identity edge** (the adoption gate binds
-    /// `ipns_name -> record` via the Ed25519 key derived from the name), and the
-    /// returned `SweepTarget.ipns_name` — the CAS **publish** destination — MUST be
-    /// that gated name, equal to `commitment.ipns_name`, and MUST NOT be swayed by
-    /// any network-supplied hint. The sweep re-seals and CAS-publishes under the
-    /// enumerated parent-index `scope_id` (never a resolver-returned `scope_id`),
-    /// so a resolver that returned a mismatched name/commitment could only mint a
-    /// record its own resolve-time gate rejects — but binding the two here keeps
-    /// that fail-closed at the source.
+    /// The same edge discipline [`ChildIndexResolver`] carries applies. The
+    /// resolver MUST gate `scope`'s record under the enumerated `scope.scope_id`,
+    /// take `ipns_name` solely from `scope.ipns_name`, and return **no** independent
+    /// `scope_id` — the sweep re-seals and CAS-publishes under the enumerated
+    /// `scope.scope_id` alone ([`SweepTarget`] carries none). `scope.ipns_name` is
+    /// the **sole gated identity edge** (the adoption gate binds `ipns_name ->
+    /// record` via the Ed25519 key derived from the name); the returned
+    /// `SweepTarget.ipns_name` — the CAS publish destination — MUST equal it and
+    /// `commitment.ipns_name`, never swayed by a network-supplied hint.
     async fn resolve(&self, scope: &ChildScopeRef) -> Result<SweepTarget, ResolveFailure>;
 }
 
@@ -237,11 +234,15 @@ impl SweepError {
 
     /// Whether re-running the idempotent pass could clear this failure — an
     /// availability stall (unavailable resolve, floor-read I/O, transport
-    /// not-published) — versus a trust violation (a gate-rejected record, a
-    /// divergent ledger / uncommitted signer), which no retry can fix.
+    /// not-published) or a C2 label conflict that the re-point wave repairs —
+    /// versus a trust violation (a gate-rejected record, a divergent ledger /
+    /// uncommitted signer), which no retry can fix.
     pub fn is_retryable(&self) -> bool {
         match self {
-            SweepError::Enumeration(e) => e.reason == ResolveFailure::Unavailable,
+            SweepError::Enumeration(e) => matches!(
+                e.reason,
+                ResolveFailure::Unavailable | ResolveFailure::ConflictingChildLabel
+            ),
             SweepError::Floor(_) => true,
             SweepError::Publish { .. } => true,
             SweepError::Reseal { .. } => false,
@@ -721,7 +722,6 @@ mod tests {
                 .ok_or(ResolveFailure::Unavailable)?;
             Ok(SweepTarget {
                 v: V,
-                scope_id: scope.scope_id,
                 ipns_name: scope.ipns_name.clone(),
                 current_read_epoch: s.current_epoch,
                 owner_enc_pub: self.owner.enc.public(),

--- a/crates/engine/tests/adoption_gate.rs
+++ b/crates/engine/tests/adoption_gate.rs
@@ -658,6 +658,39 @@ fn matrix_table_and_reject_surface_mirror_one_to_one() {
 }
 
 #[test]
+fn foreign_scope_label_rejected_at_stage_six_binding() {
+    // Test A (resolver binding, #745/#756): the record is a fully valid scope root
+    // sealed for its own scope, and the reader's read_key opens it (the scope UUID
+    // is not in the read-key KDF). Only the reader's `scope_id` — the trusted
+    // parent-index label — is foreign. Adopting under it would dedup/rotate the
+    // WRONG scope key, a silent revocation hole. Stage 6 binds `envelope.scope` to
+    // `reader.scope_id` and rejects fail-closed. With the returned `scope_id`
+    // dropped from the rotation targets, a divergent label can no longer even reach
+    // a re-key: this gate check is the sole surviving edge, and it fails closed.
+    let fx = Fixture::new();
+    let floors = InMemoryFloorStore::default();
+    let candidate = fx.candidate(1);
+
+    let foreign_scope = [0xEE; 16];
+    assert_ne!(foreign_scope, fx.scope_id, "the label must actually differ");
+    let reader = ReaderContext {
+        owner_identity: &fx.owner_identity_verifier,
+        scope_id: foreign_scope,
+        read_key: &fx.read_key,
+        parent_node_seed: None,
+        seed_blob: Some(fx.owner_seed_blob(false)),
+    };
+
+    let err = block_on(adopt(&floors, &reader, &candidate))
+        .expect_err("a foreign scope label must be rejected");
+    let rejection = err
+        .rejection()
+        .expect("a trust rejection, not a seam error");
+    assert_eq!(rejection.stage, GateStage::Unseal, "stage-6 binding");
+    assert_eq!(rejection.check(), "seal-open-failed");
+}
+
+#[test]
 fn no_reject_check_is_an_engine_invented_crypto_code() {
     let core: BTreeSet<&str> = TrustViolation::CHECKS.iter().copied().collect();
     let floor: BTreeSet<&str> = FLOOR_VERDICTS.iter().copied().collect();


### PR DESCRIPTION
## What

Closes the resolver-binding gap in the rotation walk, ahead of the production resolve/gate/unseal wiring. A resolved scope-root record carries no self-identifying `scope_id` (it lives only in the sealed-structure AAD), so the `scope_id -> record` binding rests entirely on which `scope_id` the caller feeds the adoption gate. This slice makes the correct binding structural, not a trusted resolver promise.

Closes #745
Closes #746
Closes #756
Part of #635

## Deliverable 1 — drop the returned scope_id (#756 / #745)

Option 1 (structural, mirrors the existing `parent_node_seed` omission precedent): **remove the `scope_id` field from `CascadeTarget` and `SweepTarget`.** The enumerated `child.scope_id` is now the sole authority for parent-node-seed derivation, the visited/dedup key, the re-seal `ScopeRootIdentity.scope_id`, the CAS publish destination, and the epoch floor.

- `cascade.rs`: the plan identity now uses `child.scope_id`, never `target.scope_id`. The doc/code mismatch #756 flagged (walk keyed on the enumerated id, but published/floored under the resolver-returned id) can no longer recur — there is no second `scope_id` to diverge.
- The sweep already used the enumerated `descendant.scope_id`; only the now-dead field was removed.
- Resolver-trait docs (`CascadeResealResolver`, `SweepResolver`, `ChildIndexResolver`) now state the binding as a contract: gate the record under the enumerated `child.scope_id`, take `ipns_name` solely from `child.ipns_name`, return no independent `scope_id`. True by construction; no runtime guard needed.

## Deliverable 2 — hard-abort the C2 conflict (#746)

A same-`scope_id`/different-`ipns_name` conflict (the same scope reached via two parents carrying different names) now **aborts fail-closed** with a new retryable `ResolveFailure::ConflictingChildLabel`, replacing the old first-seen-wins in `enumerate_eager_set` and the cascade frontier. `ChildScopeRef` carries no ordering signal, so first-seen is a coin-flip; picking the stale name in a revocation cascade re-keys a dead name and leaves the real descendant unrotated — a silent revocation hole.

It is **retryable**: the walk converges once the write-rotation re-point wave repairs both parent indexes (engine.md `#38 D6`), wired into `CascadeError::is_retryable` and the eager-set/sweep classification.

Labels are bound **per parent index** (each canonicalized first), so a single parent's own duplicate index still self-heals via canonicalize (#38 D6), while only genuine cross-parent disagreement fails closed.

## Deliverable 3 — tests

- **A (binding, gate-level):** a fully valid record whose reader `scope_id` label is foreign is rejected at stage 6 (`seal-open-failed`). With the returned `scope_id` gone from the targets, this gate check is the sole surviving edge.
- **B (C2):** diamond with two parents disagreeing on a descendant's name aborts fail-closed naming the scope, permutation-independently (forward + reversed) — eager-set and cascade.
- **C (legitimate mid-wave):** conflict during a re-point wave aborts with `is_retryable() == true`; after both indexes converge, a retried walk succeeds and re-keys the descendant once.
- **D (attacker name):** a child listed under an attacker `ipns_name` with no owner-signed commitment binding it is gate-rejected → fatal (not retryable). Trust rests on the commitment, not the label.
- **E (regression):** a same-`scope_id` + same-`ipns_name` diamond resolves once, no abort.

All debug + `--release` runs green (`cargo test -p cipherbox-engine -p cipherbox-core`, plus a `--release` pass of the rotation + gate tests to confirm fail-closed `Err`s fire in release); `cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` clean.

## Preserved deferrals (kept faked / tracked)

- Real `resolve -> adoption-gate -> unseal` transport (content-plane fetch, `PointerFetch`, register-first CAS publisher) stays faked — #745 defines the contract both the fake and the future real impl satisfy.
- `tag <-> recipient_enc_pk` validation at resolve, the gate-verified `(commitment, commitment_sig)` caller contract, and `PointerFetch` unreachable -> `Err(Seam)` remain tracked-defers on #745 / #747 / #762.
- The accept-freshest alternative to the C2 hard-abort needs a `ChildScopeRef` core schema change and is deferred to #778.

`crates/core` is untouched — Option 1 needs no wire-format change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened descendant identity validation during rotation and sweeping operations.
  - Conflicting labels for the same descendant now fail closed instead of being accepted inconsistently.
  - Retry handling improved for temporary descendant-label conflicts.
  - Rejected adoption of records containing foreign scope labels.

- **Tests**
  - Added coverage for conflicting and matching labels across shared descendant paths.
  - Added regression checks confirming order-independent behavior and stricter identity validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->