### PR TITLE
fix(engine): bind the owner-gate commitment to the rotated scope in rotate_scope_write

### DIFF
--- a/crates/engine/src/rotation/rotate_write.rs
+++ b/crates/engine/src/rotation/rotate_write.rs
@@ -51,7 +51,10 @@
 //! # Owner-only, fail-closed, deterministic
 //!
 //! The caller must present the owner identity signer that authored the current
-//! grant-set commitment, verified up front ([`WriteRotateError::NotOwner`]). A
+//! grant-set commitment, verified up front ([`WriteRotateError::NotOwner`]), and
+//! that commitment must name this scope's current root
+//! ([`WriteRotateError::CommitmentScopeMismatch`]) — binding the owner-auth token
+//! to the exact rotated scope, the same binding the adoption gate enforces. A
 //! non-advancing `writeEpoch` or an identity re-point is rejected release-active
 //! ([`build_repoint_object`]), never a `debug_assert!` — the encode-side mirror of
 //! the floor law's monotonic write-epoch reject (AGENTS.md rule 8). Entropy enters
@@ -255,6 +258,12 @@ pub enum WriteRotateError {
     /// The presented owner signer did not author the current commitment — not the
     /// owner. Owner-only, fail-closed before anything is minted or published.
     NotOwner,
+    /// The owner-authentic commitment names a different scope than the one under
+    /// rotation (`commitment.ipns_name != current_root_name`). Binds the owner-auth
+    /// token to the exact rotated scope, the same binding the adoption gate enforces
+    /// (`gate/adoption.rs`) — so a valid owner signature over another scope's
+    /// commitment cannot authorize this rotation. Fail-closed before any mint.
+    CommitmentScopeMismatch,
     /// The write epoch is exhausted (`current_write_epoch == u64::MAX`). Rotating
     /// would reuse the epoch with fresh key material (a key-regression violation),
     /// so nothing is minted. Unreachable in practice; release-active.
@@ -300,6 +309,9 @@ impl core::fmt::Display for WriteRotateError {
             WriteRotateError::NotOwner => {
                 f.write_str("presented signer did not author the current commitment (not owner)")
             }
+            WriteRotateError::CommitmentScopeMismatch => {
+                f.write_str("commitment names a different scope than the one under rotation")
+            }
             WriteRotateError::EpochExhausted => f.write_str("write epoch exhausted (u64::MAX)"),
             WriteRotateError::WriteEpochNotAdvancing => {
                 f.write_str("re-point write epoch does not advance past its predecessor")
@@ -334,6 +346,7 @@ impl WriteRotateError {
     pub fn check(&self) -> &'static str {
         match self {
             WriteRotateError::NotOwner => "not-owner",
+            WriteRotateError::CommitmentScopeMismatch => "commitment-scope-mismatch",
             WriteRotateError::EpochExhausted => "epoch-exhausted",
             WriteRotateError::WriteEpochNotAdvancing => "write-epoch-not-advancing",
             WriteRotateError::IdentityRepoint => "identity-repoint",
@@ -349,6 +362,7 @@ impl WriteRotateError {
     pub fn is_retryable(&self) -> bool {
         match self {
             WriteRotateError::NotOwner
+            | WriteRotateError::CommitmentScopeMismatch
             | WriteRotateError::EpochExhausted
             | WriteRotateError::WriteEpochNotAdvancing
             | WriteRotateError::IdentityRepoint => false,
@@ -431,6 +445,16 @@ where
         &current_sig,
     )
     .map_err(|_| WriteRotateError::NotOwner)?;
+
+    // 1a) Bind the owner-auth token to the exact scope under rotation: the
+    //     owner-authentic commitment MUST name this scope's current root. Same
+    //     binding the adoption gate enforces (`gate/adoption.rs`,
+    //     `commitment.ipns_name == candidate name`), so a valid owner signature over
+    //     a DIFFERENT scope's commitment cannot authorize this rotation. Fail-closed
+    //     before anything is minted or published.
+    if plan.commitment.ipns_name != plan.current_root_name.as_str().as_bytes() {
+        return Err(WriteRotateError::CommitmentScopeMismatch);
+    }
 
     // 2) Fail-closed BEFORE minting: a saturating bump at u64::MAX would republish
     //    fresh key material under the same write epoch (a key-regression violation),
@@ -654,17 +678,26 @@ mod tests {
         EcdsaSigner::from_scalar(&[0x33; 32]).unwrap()
     }
 
-    /// An owner-signed commitment naming `owner`'s identity — the owner-only
-    /// anchor. The write rotation only verifies the owner identity against it.
-    fn commitment(owner: &EcdsaSigner) -> (GrantSetCommitment, [u8; ECDSA_SIG_LEN]) {
+    /// An owner-signed commitment naming `name` as the scope root — matching the
+    /// scope's `current_root_name`, so the owner-gate scope-binding check passes.
+    fn commitment_for(
+        owner: &EcdsaSigner,
+        name: &IpnsName,
+    ) -> (GrantSetCommitment, [u8; ECDSA_SIG_LEN]) {
         let c = GrantSetCommitment {
-            ipns_name: b"scope-root".to_vec(),
+            ipns_name: name.as_str().as_bytes().to_vec(),
             owner_pseudonym_pk: [0x22; 32],
             entries: Vec::new(),
             unknown: Vec::new(),
         };
         let sig = sign_grant_set(owner, &c).unwrap().to_compact();
         (c, sig)
+    }
+
+    /// The default commitment: bound to the scope root every test rotates
+    /// (`old_name_of(SCOPE)`, each test's `current_root`).
+    fn commitment(owner: &EcdsaSigner) -> (GrantSetCommitment, [u8; ECDSA_SIG_LEN]) {
+        commitment_for(owner, &old_name_of(&SCOPE))
     }
 
     /// A node's old (pre-rotation) name — derived from the OLD write scope seed, so
@@ -1181,6 +1214,43 @@ mod tests {
         assert!(
             state.published.borrow().is_empty(),
             "nothing published on an owner-only rejection"
+        );
+    }
+
+    #[test]
+    fn commitment_naming_a_different_scope_is_rejected_fail_closed() {
+        // The owner correctly signs the commitment, but it names a DIFFERENT scope
+        // root than the one under rotation. The owner-gate binds the auth token to
+        // the exact rotated scope (the adoption gate's `commitment.ipns_name`
+        // binding), so a valid-but-wrong-scope commitment fails closed before any
+        // mint or publish — an owner cannot rotate scope B with scope A's token.
+        let owner = owner();
+        let other_root = old_name_of(&nid(0xaa));
+        let (c, sig) = commitment_for(&owner, &other_root);
+        let resolver = tree();
+        let state = WaveState::default();
+        let publisher = FakePublisher::new(state.clone());
+        let current_root = old_name_of(&SCOPE);
+
+        let err = block_on(async {
+            let mut e = SeededEntropy::new(7);
+            rotate_scope_write(
+                &mut e,
+                &resolver,
+                &publisher,
+                &plan(&owner, &c, &sig, &current_root, None),
+            )
+            .await
+        })
+        .expect_err("a commitment naming another scope is rejected");
+        assert_eq!(err.check(), "commitment-scope-mismatch");
+        assert!(
+            !err.is_retryable(),
+            "a scope-binding violation is not an availability stall"
+        );
+        assert!(
+            state.published.borrow().is_empty(),
+            "nothing published on a scope-mismatch rejection"
         );
     }
 

--- a/crates/engine/src/rotation/rotate_write.rs
+++ b/crates/engine/src/rotation/rotate_write.rs
@@ -53,8 +53,7 @@
 //! The caller must present the owner identity signer that authored the current
 //! grant-set commitment, verified up front ([`WriteRotateError::NotOwner`]), and
 //! that commitment must name this scope's current root
-//! ([`WriteRotateError::CommitmentScopeMismatch`]) — binding the owner-auth token
-//! to the exact rotated scope, the same binding the adoption gate enforces. A
+//! ([`WriteRotateError::CommitmentScopeMismatch`]). A
 //! non-advancing `writeEpoch` or an identity re-point is rejected release-active
 //! ([`build_repoint_object`]), never a `debug_assert!` — the encode-side mirror of
 //! the floor law's monotonic write-epoch reject (AGENTS.md rule 8). Entropy enters

--- a/crates/engine/src/rotation/rotate_write.rs
+++ b/crates/engine/src/rotation/rotate_write.rs
@@ -672,8 +672,8 @@ mod tests {
         EcdsaSigner::from_scalar(&[0x33; 32]).unwrap()
     }
 
-    /// An owner-signed commitment naming `name` as the scope root — matching the
-    /// scope's `current_root_name`, so the owner-gate scope-binding check passes.
+    /// An owner-signed commitment naming `name` as the scope root. The signature
+    /// binds `name` only; callers pass a mismatched name to exercise the reject path.
     fn commitment_for(
         owner: &EcdsaSigner,
         name: &IpnsName,

--- a/crates/engine/src/rotation/rotate_write.rs
+++ b/crates/engine/src/rotation/rotate_write.rs
@@ -446,12 +446,7 @@ where
     )
     .map_err(|_| WriteRotateError::NotOwner)?;
 
-    // 1a) Bind the owner-auth token to the exact scope under rotation: the
-    //     owner-authentic commitment MUST name this scope's current root. Same
-    //     binding the adoption gate enforces (`gate/adoption.rs`,
-    //     `commitment.ipns_name == candidate name`), so a valid owner signature over
-    //     a DIFFERENT scope's commitment cannot authorize this rotation. Fail-closed
-    //     before anything is minted or published.
+    // 1a) bind commitment to the rotated scope — see CommitmentScopeMismatch
     if plan.commitment.ipns_name != plan.current_root_name.as_str().as_bytes() {
         return Err(WriteRotateError::CommitmentScopeMismatch);
     }


### PR DESCRIPTION
Defense-in-depth follow-up from the #760 crypto-privacy review.

## Problem

`rotate_scope_write` authenticated the owner-only gate by verifying `commitment_sig` over `plan.commitment` under the owner identity, proving the signer authored the commitment — but never checked that the commitment actually **names the scope under rotation**. `commitment.ipns_name` was never compared to `plan.current_root_name`, so an owner could present a valid commitment for scope A while rotating scope B. Not exploitable by a non-owner (the ECDSA key is still required), but the owner-auth token was decoupled from the exact rotated scope.

## Fix

After verifying the signature, add a release-active fail-closed check that `commitment.ipns_name == current_root_name.as_str().as_bytes()` before anything is minted or published. This mirrors the binding the adoption gate already enforces (`gate/adoption.rs`, `commitment.ipns_name == candidate name`). Rejection surfaces via a new `WriteRotateError::CommitmentScopeMismatch` variant (check name `commitment-scope-mismatch`, non-retryable — a trust violation, not an availability stall).

`ipns_name` is the only scope-identifying field the commitment carries (`owner_pseudonym_pk` is owner identity, not scope; `entries` are grants), so it is the sole field to bind.

## Tests

- New `commitment_naming_a_different_scope_is_rejected_fail_closed`: an owner-signed commitment naming a different scope root is rejected pre-publish; verified to FAIL without the guard.
- Existing `commitment` test helper now binds `ipns_name` to the rotated scope root so the happy-path (matching-scope) cases still pass.
- `cargo test -p cipherbox-engine` (all green), `cargo clippy --all-targets -D warnings` (clean), `cargo fmt --all` (clean).

Scope confined to `crates/engine/src/rotation/rotate_write.rs`.

Closes #761
Part of #635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure write rotations use a commitment for the current scope root.
  * Invalid commitments are now rejected without publishing changes.
  * Added clearer error classification for scope-mismatch failures, which are treated as non-retryable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->