### PR TITLE
fix(engine): use versioned compare-and-remove for dest-add compensation

### DIFF
--- a/crates/engine/src/grants/child_index.rs
+++ b/crates/engine/src/grants/child_index.rs
@@ -16,7 +16,10 @@
 //! - **Dest-first**: add into the destination parent's index before the
 //!   presence-conditional remove from the source, so no window leaves the child
 //!   absent from both — orphans are structurally impossible. A race loser undoes
-//!   its dest-add ([`undo_dest_add`]).
+//!   its dest-add. At a distributed publish boundary that undo is a **versioned
+//!   compare-and-remove** ([`undo_dest_add_versioned`]): it removes only when the
+//!   dest index is still at the seq-CAS base the add read, so it never clobbers a
+//!   concurrent authoritative write (#743, deferred from #741).
 //! - **Observed repair**: any write-capable client that sees a child missing from
 //!   its parent's index repairs it ([`repair_observed`]).
 //!
@@ -105,9 +108,46 @@ pub fn repair_observed(index: &[ChildScopeRef], child: ChildScopeRef) -> Vec<Chi
 
 /// Race-loser compensation for the dest-first path: undo a dest-add by removing
 /// `scope_id`. Semantically identical to [`remove_child`]; named for the
-/// compensation call site.
+/// compensation call site. This is the **unversioned** local primitive — a
+/// distributed publish boundary must gate it with [`undo_dest_add_versioned`],
+/// which fails closed on a concurrent write.
 pub fn undo_dest_add(dest: &[ChildScopeRef], scope_id: &[u8; 16]) -> Vec<ChildScopeRef> {
     remove_child(dest, scope_id)
+}
+
+/// The read-version a dest-add was derived against: the dest parent scope root's
+/// published record sequence — the same monotonic seq-CAS key the net publish
+/// path mints against (`net::publish`, blueprint/engine.md "CAS sequencing").
+pub type DestIndexVersion = u64;
+
+/// Outcome of a versioned dest-add compensation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UndoDestAdd {
+    /// The dest index was still at the CAS base the add read: the dest-add was
+    /// removed cleanly. Carries the recomputed index to publish.
+    Removed(Vec<ChildScopeRef>),
+    /// A concurrent authoritative writer advanced the dest index past the CAS
+    /// base: a blind remove would clobber the winner. Fail-closed — the caller
+    /// re-reads the current dest index at its new version and re-derives.
+    Conflict,
+}
+
+/// Versioned compare-and-remove race-loser compensation for the dest-first path:
+/// undo the dest-add **only** when the dest index is unchanged since the add read
+/// (`observed == cas_base`). Any version divergence fails closed with
+/// [`UndoDestAdd::Conflict`] rather than blind-removing, so a concurrent
+/// authoritative write always wins and the caller re-reads + re-derives instead
+/// of clobbering it (#743, deferred from #741; blueprint/engine.md).
+pub fn undo_dest_add_versioned(
+    dest: &[ChildScopeRef],
+    scope_id: &[u8; 16],
+    cas_base: DestIndexVersion,
+    observed: DestIndexVersion,
+) -> UndoDestAdd {
+    if observed != cas_base {
+        return UndoDestAdd::Conflict;
+    }
+    UndoDestAdd::Removed(undo_dest_add(dest, scope_id))
 }
 
 #[cfg(test)]
@@ -280,5 +320,26 @@ mod tests {
         let added = insert_child(&dest, moving.clone());
         let undone = undo_dest_add(&added, &[0x44; 16]);
         assert_eq!(undone, canonicalize(&dest));
+    }
+
+    #[test]
+    fn versioned_compensation_removes_only_when_the_version_is_unchanged() {
+        // The loser added itself to the dest index it read at CAS base seq 7.
+        let moving = child(0x44, "x");
+        let base = vec![child(0x10, "d1")];
+        let added = insert_child(&base, moving.clone());
+        let cas_base: DestIndexVersion = 7;
+
+        // Dest index still at seq 7: the compensation removes its own add.
+        let unchanged = undo_dest_add_versioned(&added, &[0x44; 16], cas_base, 7);
+        assert_eq!(unchanged, UndoDestAdd::Removed(canonicalize(&base)));
+
+        // A concurrent authoritative writer bumped the dest to seq 8: fail closed,
+        // never remove — the winner's newer state stands untouched.
+        let raced = undo_dest_add_versioned(&added, &[0x44; 16], cas_base, 8);
+        assert_eq!(raced, UndoDestAdd::Conflict);
+        // A stale/lower observed version is a divergence too — also fail-closed.
+        let stale = undo_dest_add_versioned(&added, &[0x44; 16], cas_base, 6);
+        assert_eq!(stale, UndoDestAdd::Conflict);
     }
 }

--- a/crates/engine/src/grants/child_index.rs
+++ b/crates/engine/src/grants/child_index.rs
@@ -16,10 +16,8 @@
 //! - **Dest-first**: add into the destination parent's index before the
 //!   presence-conditional remove from the source, so no window leaves the child
 //!   absent from both — orphans are structurally impossible. A race loser undoes
-//!   its dest-add. At a distributed publish boundary that undo is a **versioned
-//!   compare-and-remove** ([`undo_dest_add_versioned`]): it removes only when the
-//!   dest index is still at the seq-CAS base the add read, so it never clobbers a
-//!   concurrent authoritative write (#743, deferred from #741).
+//!   its dest-add at a distributed publish boundary via the versioned
+//!   compare-and-remove ([`undo_dest_add_versioned`]).
 //! - **Observed repair**: any write-capable client that sees a child missing from
 //!   its parent's index repairs it ([`repair_observed`]).
 //!
@@ -106,12 +104,9 @@ pub fn repair_observed(index: &[ChildScopeRef], child: ChildScopeRef) -> Vec<Chi
     insert_child(index, child)
 }
 
-/// Race-loser compensation for the dest-first path: undo a dest-add by removing
-/// `scope_id`. Semantically identical to [`remove_child`]; named for the
-/// compensation call site. This is the **unversioned** local primitive — a
-/// distributed publish boundary must gate it with [`undo_dest_add_versioned`],
-/// which fails closed on a concurrent write.
-pub fn undo_dest_add(dest: &[ChildScopeRef], scope_id: &[u8; 16]) -> Vec<ChildScopeRef> {
+/// Unversioned local dest-add compensation; a distributed publish boundary must
+/// use the fail-closed [`undo_dest_add_versioned`] instead.
+pub(crate) fn undo_dest_add(dest: &[ChildScopeRef], scope_id: &[u8; 16]) -> Vec<ChildScopeRef> {
     remove_child(dest, scope_id)
 }
 
@@ -127,8 +122,7 @@ pub enum UndoDestAdd {
     /// removed cleanly. Carries the recomputed index to publish.
     Removed(Vec<ChildScopeRef>),
     /// A concurrent authoritative writer advanced the dest index past the CAS
-    /// base: a blind remove would clobber the winner. Fail-closed — the caller
-    /// re-reads the current dest index at its new version and re-derives.
+    /// base: a blind remove would clobber the winner. Fail-closed.
     Conflict,
 }
 

--- a/crates/engine/src/grants/mod.rs
+++ b/crates/engine/src/grants/mod.rs
@@ -23,7 +23,7 @@ pub use accept::{
 };
 pub use child_index::{
     DestIndexVersion, UndoDestAdd, canonicalize, insert_child, move_child, remove_child,
-    repair_observed, undo_dest_add, undo_dest_add_versioned,
+    repair_observed, undo_dest_add_versioned,
 };
 pub use contact::{Contact, import_contact};
 pub use create::{

--- a/crates/engine/src/grants/mod.rs
+++ b/crates/engine/src/grants/mod.rs
@@ -22,7 +22,8 @@ pub use accept::{
     SentShare, SharePointer, accept_share,
 };
 pub use child_index::{
-    canonicalize, insert_child, move_child, remove_child, repair_observed, undo_dest_add,
+    DestIndexVersion, UndoDestAdd, canonicalize, insert_child, move_child, remove_child,
+    repair_observed, undo_dest_add, undo_dest_add_versioned,
 };
 pub use contact::{Contact, import_contact};
 pub use create::{


### PR DESCRIPTION
## Summary

The dest-first race-loser compensation (`undo_dest_add`) did an unversioned compare-and-remove of the child-scope index. At a distributed publish boundary that could clobber a concurrent authoritative write to the same dest parent's index (CodeRabbit Major on #741).

## Change

- Add `undo_dest_add_versioned`: a fail-closed compare-and-remove gated on the dest parent scope root's published record sequence (`DestIndexVersion` = the same monotonic u64 seq-CAS key `net::publish` mints against).
- It removes the dest-add **only** when the dest index is unchanged since the add read (`observed == cas_base`); any divergence returns `UndoDestAdd::Conflict` so the caller re-reads at the new version and re-derives rather than blind-removing.
- The version check is release-active (`return Conflict`), never `debug_assert!`/`assert!`.
- The unversioned `undo_dest_add` stays as the pure local primitive; its doc now points distributed callers at the versioned variant.

## Test

`versioned_compensation_removes_only_when_the_version_is_unchanged` exercises the concurrent-writer race: removes its own add when the version is unchanged, and returns `Conflict` (no removal) when a concurrent writer bumped the version (and on a stale/lower version too).

Closes #743
Part of #635


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed child-scope index updates to prevent outdated changes from overwriting newer data.
  * Added conflict detection when undoing destination index additions with mismatched versions.
* **API Improvements**
  * Exposed version tracking and undo-result types for grant index operations.
* **Tests**
  * Added coverage for successful removal with matching versions and conflict handling for mismatched versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->