### PR TITLE
feat(engine): cap resolved-record envelope size at the fetch boundary

### DIFF
--- a/crates/desktop-seams/src/http.rs
+++ b/crates/desktop-seams/src/http.rs
@@ -2,7 +2,9 @@
 
 use core::time::Duration;
 
-use cipherbox_engine::seams::{Http, HttpMethod, HttpRequest, HttpResponse, SeamError, SeamResult};
+use cipherbox_engine::seams::{
+    CappedFetchError, Http, HttpMethod, HttpRequest, HttpResponse, SeamError, SeamResult,
+};
 
 /// Plain HTTP for the hand-written API client, the trustless gateway read
 /// path, and BYO providers (blueprint/engine.md "Http", desktop column).
@@ -42,8 +44,13 @@ impl ReqwestHttp {
     }
 }
 
-impl Http for ReqwestHttp {
-    async fn send(&self, request: HttpRequest) -> SeamResult<HttpResponse> {
+impl ReqwestHttp {
+    /// Send the request and return the status, headers, and the not-yet-read
+    /// `reqwest` response — the shared prelude for buffered and capped reads.
+    async fn dispatch(
+        &self,
+        request: HttpRequest,
+    ) -> SeamResult<(u16, Vec<(String, String)>, reqwest::Response)> {
         let mut builder = self
             .client
             .request(map_method(request.method), &request.url);
@@ -72,11 +79,59 @@ impl Http for ReqwestHttp {
                 )
             })
             .collect();
+        Ok((status, headers, response))
+    }
+}
+
+impl Http for ReqwestHttp {
+    async fn send(&self, request: HttpRequest) -> SeamResult<HttpResponse> {
+        let (status, headers, response) = self.dispatch(request).await?;
         let body = response
             .bytes()
             .await
             .map_err(|err| SeamError::new(format!("http body: {err}")))?
             .to_vec();
+        Ok(HttpResponse {
+            status,
+            headers,
+            body,
+        })
+    }
+
+    async fn send_capped(
+        &self,
+        request: HttpRequest,
+        max_bytes: usize,
+    ) -> Result<HttpResponse, CappedFetchError> {
+        let (status, headers, mut response) = self
+            .dispatch(request)
+            .await
+            .map_err(CappedFetchError::Transport)?;
+
+        // Reject a body that declares itself over the cap before reading a byte;
+        // a missing or lying Content-Length is still bounded by the streaming
+        // cap below, which is the true peak-memory bound (#787).
+        if let Some(declared) = response.content_length() {
+            if declared > max_bytes as u64 {
+                return Err(CappedFetchError::BodyTooLarge {
+                    observed: usize::try_from(declared).unwrap_or(usize::MAX),
+                    limit: max_bytes,
+                });
+            }
+        }
+
+        let mut body = Vec::new();
+        while let Some(chunk) = response.chunk().await.map_err(|err| {
+            CappedFetchError::Transport(SeamError::new(format!("http body: {err}")))
+        })? {
+            if body.len() + chunk.len() > max_bytes {
+                return Err(CappedFetchError::BodyTooLarge {
+                    observed: body.len() + chunk.len(),
+                    limit: max_bytes,
+                });
+            }
+            body.extend_from_slice(&chunk);
+        }
 
         Ok(HttpResponse {
             status,

--- a/crates/engine/src/content/dag.rs
+++ b/crates/engine/src/content/dag.rs
@@ -22,6 +22,7 @@ use cipherbox_core::content::{
 use cipherbox_core::error::{CodecError, Malformed};
 
 use super::chunk::SealedChunk;
+use super::limits::MAX_RESOLVED_RECORD_BYTES;
 use super::profile::ContentProfile;
 
 /// The multicodec of the DAG-root `contentCid`: `dag-cbor` (0x71). Engine-owned
@@ -49,6 +50,17 @@ pub enum DagError {
     InvalidManifest {
         /// Which invariant failed.
         reason: &'static str,
+    },
+    /// The assembled root manifest exceeded [`MAX_RESOLVED_RECORD_BYTES`]: the
+    /// flat root inlines every leaf CID, so a file past the flat-DAG ceiling
+    /// (~108 GiB) produces a root [`read_block`](super::read::read_block) would
+    /// reject on fetch. Fails closed here so the encoder never emits an
+    /// unreadable root (AGENTS.md rule 8; #788).
+    RootTooLarge {
+        /// The encoded root size.
+        size: usize,
+        /// The enforced ceiling ([`MAX_RESOLVED_RECORD_BYTES`]).
+        limit: usize,
     },
 }
 
@@ -110,6 +122,15 @@ pub fn assemble(
     root.insert(SIZE_KEY, Value::Unsigned(plaintext_len));
     root.insert(LINKS_KEY, Value::Array(links));
     let root_block = encode(&Value::Map(root));
+    // Fail closed rather than emit a root `read_block` would reject on fetch:
+    // the flat root inlines every leaf CID, so past the flat-DAG ceiling it
+    // exceeds the block cap (AGENTS.md rule 8 — encode/decode symmetry; #788).
+    if root_block.len() > MAX_RESOLVED_RECORD_BYTES {
+        return Err(DagError::RootTooLarge {
+            size: root_block.len(),
+            limit: MAX_RESOLVED_RECORD_BYTES,
+        });
+    }
     let content_cid = compute_cid(DAG_ROOT_CODEC, &root_block);
     Ok(ContentDag {
         content_cid,
@@ -324,6 +345,52 @@ mod tests {
         let manifest = decode_root(&dag.root_block).unwrap();
         assert_eq!(manifest.size, 0);
         assert_eq!(manifest.leaf_cids.len(), 1);
+    }
+
+    /// `count` dummy leaves with 36-byte (`CONTENT_CID_LEN`) CIDs and empty
+    /// sealed bytes, framed to match a `chunk_size`-16 profile — enough to size
+    /// the root manifest without materializing any file bytes. `assemble` only
+    /// reads `leaf.cid`, so the sealed payload can stay empty.
+    fn dummy_leaves(count: usize) -> Vec<SealedChunk> {
+        (0..count)
+            .map(|_| SealedChunk {
+                cid: vec![0u8; CONTENT_CID_LEN],
+                sealed: Vec::new(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn assemble_fails_closed_when_the_root_exceeds_the_block_cap() {
+        // Each inlined 36-byte CID costs ~38 CBOR bytes, so ~120k links push the
+        // flat root over the 4 MiB cap; `assemble` must fail closed in every
+        // build (not a release-stripped assert) rather than emit an unreadable
+        // root (AGENTS.md rule 8). `plaintext_len = count * chunkSize` keeps the
+        // leaf-count invariant satisfied so the size guard is what fires.
+        let profile = ContentProfile::CI;
+        let chunk_size = profile.chunk_size() as u64;
+        let count = 120_000;
+        let leaves = dummy_leaves(count);
+        match assemble(&leaves, count as u64 * chunk_size, &profile) {
+            Err(DagError::RootTooLarge { size, limit }) => {
+                assert!(size > limit, "reported size exceeds the cap");
+                assert_eq!(limit, 4 * 1024 * 1024);
+            }
+            other => panic!("expected RootTooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assemble_accepts_a_root_just_under_the_block_cap() {
+        // ~100k links keep the root comfortably under 4 MiB; it assembles Ok and
+        // content-addresses, proving the guard rejects only over-cap roots.
+        let profile = ContentProfile::CI;
+        let chunk_size = profile.chunk_size() as u64;
+        let count = 100_000;
+        let leaves = dummy_leaves(count);
+        let dag = assemble(&leaves, count as u64 * chunk_size, &profile).unwrap();
+        assert!(dag.root_block.len() <= 4 * 1024 * 1024);
+        assert!(verify_cid(&dag.content_cid, &dag.root_block).is_ok());
     }
 
     #[test]

--- a/crates/engine/src/content/dag.rs
+++ b/crates/engine/src/content/dag.rs
@@ -122,9 +122,7 @@ pub fn assemble(
     root.insert(SIZE_KEY, Value::Unsigned(plaintext_len));
     root.insert(LINKS_KEY, Value::Array(links));
     let root_block = encode(&Value::Map(root));
-    // Fail closed rather than emit a root `read_block` would reject on fetch:
-    // the flat root inlines every leaf CID, so past the flat-DAG ceiling it
-    // exceeds the block cap (AGENTS.md rule 8 — encode/decode symmetry; #788).
+    // fail closed: an over-cap root would be unreadable — see DagError::RootTooLarge.
     if root_block.len() > MAX_RESOLVED_RECORD_BYTES {
         return Err(DagError::RootTooLarge {
             size: root_block.len(),

--- a/crates/engine/src/content/limits.rs
+++ b/crates/engine/src/content/limits.rs
@@ -1,0 +1,17 @@
+//! Shared content-plane size limits.
+
+/// Hard ceiling on a resolved content block, the single source of truth for both
+/// the decode side ([`super::read::read_block`], which rejects any fetched block
+/// over this before it is hashed, decoded, or gated — gate work is linear in the
+/// fetched byte count) and the encode side ([`super::dag::assemble`], which fails
+/// closed rather than emit a root manifest over this cap). A resolved record's
+/// envelope-content rides in an IPFS block fetched by CID; capping it here bounds
+/// gate work to a fixed budget and fails closed on anything larger (#742;
+/// blueprint/engine.md "Content plane").
+///
+/// Must exceed the 1 MiB content chunk size. A legitimate flat-DAG root inlines
+/// every leaf CID, so it fits only up to the flat-DAG ceiling (~108 GiB at a
+/// 1 MiB chunk size); `assemble` enforces that ceiling as a release-active
+/// `Err`, so this crate never publishes a root its own `read_block` rejects
+/// (#788 — the encode/decode fail-closed symmetry of AGENTS.md rule 8).
+pub(crate) const MAX_RESOLVED_RECORD_BYTES: usize = 4 * 1024 * 1024;

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -18,6 +18,7 @@
 
 pub mod chunk;
 pub mod dag;
+mod limits;
 pub mod profile;
 pub mod provider;
 pub mod read;

--- a/crates/engine/src/content/read.rs
+++ b/crates/engine/src/content/read.rs
@@ -19,7 +19,8 @@ use cipherbox_core::error::{CodecError, TrustViolation};
 use zeroize::Zeroizing;
 
 use super::dag::DAG_ROOT_CODEC;
-use crate::seams::{Http, HttpMethod, HttpRequest};
+use super::limits::MAX_RESOLVED_RECORD_BYTES;
+use crate::seams::{CappedFetchError, Http, HttpMethod, HttpRequest};
 
 const AUTHORIZATION: &str = "Authorization";
 const ACCEPT: &str = "Accept";
@@ -27,17 +28,6 @@ const ACCEPT: &str = "Accept";
 const RAW_BLOCK: &str = "application/vnd.ipld.raw";
 /// Byte offset of the multicodec in the fixed CIDv1 framing (version at 0).
 const CID_CODEC_INDEX: usize = 1;
-
-/// Hard ceiling on a fetched content block, enforced at this fetch boundary
-/// before the block is hashed, decoded, or gated. A resolved record's
-/// envelope-content (grant blobs, history links) rides in an IPFS block fetched
-/// by CID, and the adoption gate then hashes and verifies every structure it
-/// carries — gate work is linear in the fetched byte count. Capping the block
-/// here bounds that work to a fixed budget and fails closed on anything larger,
-/// before any per-structure cost is paid (#742; blueprint/engine.md "Content
-/// plane"). Must exceed the 1 MiB content chunk size; a legitimate leaf or
-/// flat-DAG root fits only up to the flat-DAG ceiling (~108 GiB); see #788.
-const MAX_RESOLVED_RECORD_BYTES: usize = 4 * 1024 * 1024;
 
 /// Which content-plane a fetched CID must address. Core's [`verify_cid`] accepts
 /// any single-byte multicodec (`< 0x80`), not just the frozen content-plane set,
@@ -161,16 +151,26 @@ pub async fn read_block(
         ));
     }
     for source in gateway.sources() {
-        let Some(response) = fetch(source, http, cid_str).await else {
-            continue; // transport-level failure: try the next source
+        let response = match fetch(source, http, cid_str).await {
+            Ok(response) => response,
+            // Transport-level failure is availability: rotate to the next source.
+            Err(CappedFetchError::Transport(_)) => continue,
+            // An over-cap body is terminal and fail-closed — the transport bounds
+            // peak memory before buffering the whole body (#787), and the same
+            // block is over-cap from any source, so it is never retried.
+            Err(CappedFetchError::BodyTooLarge { observed, limit }) => {
+                return Err(ReadError::TooLarge {
+                    size: observed,
+                    limit,
+                });
+            }
         };
         if !(200..300).contains(&response.status) {
             continue; // availability (not found / server error): next source
         }
-        // Fail closed on an oversized block before it is hashed or decoded: gate
-        // work is linear in these bytes, so this cap bounds it at the fetch
-        // boundary (#742), ahead of the verify hash below and all downstream
-        // decode/gate work.
+        // Defense-in-depth backstop behind the transport cap: a seam using the
+        // buffering default (or one that mis-sizes) still cannot slip an over-cap
+        // body past this before it is hashed, decoded, or gated (#742).
         if response.body.len() > MAX_RESOLVED_RECORD_BYTES {
             return Err(ReadError::TooLarge {
                 size: response.body.len(),
@@ -202,13 +202,17 @@ fn is_canonical_content_cid_str(cid_str: &str) -> bool {
             .all(|c| c.is_ascii_lowercase() || (b'2'..=b'7').contains(&c))
 }
 
-/// Send the raw-block GET to one source; `None` on a transport-level failure
-/// (the seam's reserved `Err`), which is an availability signal, not a trust one.
+/// Send the raw-block GET to one source under the block-size cap. The transport
+/// bounds peak memory while reading the body (#787): a `Content-Length`
+/// pre-check plus a capped streaming read, so an over-cap body fails closed
+/// ([`CappedFetchError::BodyTooLarge`]) before it is fully allocated. A
+/// transport-level failure ([`CappedFetchError::Transport`]) is an availability
+/// signal, not a trust one.
 async fn fetch(
     source: &GatewaySource,
     http: &impl Http,
     cid_str: &str,
-) -> Option<crate::seams::HttpResponse> {
+) -> Result<crate::seams::HttpResponse, CappedFetchError> {
     let base = source.base_url.trim_end_matches('/');
     let mut headers = vec![(ACCEPT.to_owned(), RAW_BLOCK.to_owned())];
     if let Some(bearer) = &source.bearer {
@@ -223,7 +227,7 @@ async fn fetch(
         headers,
         body: None,
     };
-    http.send(request).await.ok()
+    http.send_capped(request, MAX_RESOLVED_RECORD_BYTES).await
 }
 
 /// The leaf-index range covering the plaintext byte range `[offset, offset +

--- a/crates/engine/src/content/read.rs
+++ b/crates/engine/src/content/read.rs
@@ -35,8 +35,8 @@ const CID_CODEC_INDEX: usize = 1;
 /// carries — gate work is linear in the fetched byte count. Capping the block
 /// here bounds that work to a fixed budget and fails closed on anything larger,
 /// before any per-structure cost is paid (#742; blueprint/engine.md "Content
-/// plane"). Must stay above the production content chunk size (1 MiB) so a
-/// legitimate leaf or root block always fits.
+/// plane"). Must exceed the 1 MiB content chunk size; a legitimate leaf or
+/// flat-DAG root fits only up to the flat-DAG ceiling (~108 GiB); see #788.
 const MAX_RESOLVED_RECORD_BYTES: usize = 4 * 1024 * 1024;
 
 /// Which content-plane a fetched CID must address. Core's [`verify_cid`] accepts

--- a/crates/engine/src/content/read.rs
+++ b/crates/engine/src/content/read.rs
@@ -7,9 +7,9 @@
 //! run through [`cipherbox_core::content::verify_cid`] against the requested
 //! CID, and a mismatch fails **closed** as a [`TrustViolation`] — never a silent
 //! degrade to staleness (AGENTS.md rule 6). Only availability (transport error,
-//! non-2xx) rotates to the next source; a mismatch is terminal, because a
-//! content-address disagreement is an integrity signal to surface, not a
-//! retryable fetch miss.
+//! non-2xx, or an over-cap body) rotates to the next source; a mismatch is
+//! terminal, because a content-address disagreement is an integrity signal to
+//! surface, not a retryable fetch miss.
 
 use core::fmt;
 use core::ops::Range;
@@ -97,10 +97,12 @@ pub enum ReadError {
     /// integrity violation, surfaced verbatim from core. Terminal — never
     /// retried against another source, never degraded to staleness.
     TrustViolation(CodecError),
-    /// The fetched block exceeded [`MAX_RESOLVED_RECORD_BYTES`]: rejected at the
-    /// fetch boundary before any hash/decode/gate work. Terminal and fail-closed
-    /// — a record over the size bound is never adoptable, so it is not retried
-    /// against another source (#742).
+    /// Every source that responded served an over-cap body (rejected at the
+    /// fetch boundary before any hash/decode/gate work), and the source set was
+    /// exhausted with no correctly-sized block. An oversized body is an
+    /// availability failure that rotates to the next source (a non-authoritative
+    /// source can serve an arbitrary huge body for any CID); this surfaces only
+    /// once every source is exhausted having hit that (#742).
     TooLarge {
         /// The oversized response body length.
         size: usize,
@@ -131,9 +133,11 @@ pub enum ReadError {
 ///
 /// Tries each source in [`Gateway`] order; returns the first block that
 /// verifies. A CID mismatch on any response is terminal
-/// ([`ReadError::TrustViolation`]); only availability failures rotate to the
-/// next source. All sources exhausted without a verified block is
-/// [`ReadError::Unavailable`].
+/// ([`ReadError::TrustViolation`]); every availability failure — transport
+/// error, non-2xx, or an over-cap body — rotates to the next source. All
+/// sources exhausted without a verified block is [`ReadError::Unavailable`],
+/// unless at least one source served an over-cap body, which surfaces as
+/// [`ReadError::TooLarge`].
 pub async fn read_block(
     gateway: &Gateway,
     http: &impl Http,
@@ -150,19 +154,23 @@ pub async fn read_block(
             TrustViolation::ContentCidMismatch.into(),
         ));
     }
+    // An over-cap body at any source is an availability failure that rotates;
+    // remembered so an exhausted source set surfaces TooLarge rather than a plain
+    // no-source Unavailable.
+    let mut over_cap: Option<(usize, usize)> = None;
     for source in gateway.sources() {
         let response = match fetch(source, http, cid_str).await {
             Ok(response) => response,
             // Transport-level failure is availability: rotate to the next source.
             Err(CappedFetchError::Transport(_)) => continue,
-            // An over-cap body is terminal and fail-closed — the transport bounds
-            // peak memory before buffering the whole body (#787), and the same
-            // block is over-cap from any source, so it is never retried.
+            // Rotate: a non-authoritative source's oversized body does not prove
+            // the block is over-cap (a malicious source can serve an arbitrary
+            // huge body — e.g. a non-2xx error page — for any CID), so a healthy
+            // source may still serve the correctly-sized block. Terminal only
+            // once every source is exhausted (#742).
             Err(CappedFetchError::BodyTooLarge { observed, limit }) => {
-                return Err(ReadError::TooLarge {
-                    size: observed,
-                    limit,
-                });
+                over_cap = Some((observed, limit));
+                continue;
             }
         };
         if !(200..300).contains(&response.status) {
@@ -170,12 +178,11 @@ pub async fn read_block(
         }
         // Defense-in-depth backstop behind the transport cap: a seam using the
         // buffering default (or one that mis-sizes) still cannot slip an over-cap
-        // body past this before it is hashed, decoded, or gated (#742).
+        // body past this before it is hashed, decoded, or gated (#742). Same
+        // rotation as the transport cap — an oversized body is not authoritative.
         if response.body.len() > MAX_RESOLVED_RECORD_BYTES {
-            return Err(ReadError::TooLarge {
-                size: response.body.len(),
-                limit: MAX_RESOLVED_RECORD_BYTES,
-            });
+            over_cap = Some((response.body.len(), MAX_RESOLVED_RECORD_BYTES));
+            continue;
         }
         // Every 2xx body is verified before it can be returned. A mismatch is a
         // fail-closed trust violation, not a reason to try another source.
@@ -183,7 +190,10 @@ pub async fn read_block(
             .map(|()| response.body)
             .map_err(ReadError::TrustViolation);
     }
-    Err(ReadError::Unavailable)
+    match over_cap {
+        Some((size, limit)) => Err(ReadError::TooLarge { size, limit }),
+        None => Err(ReadError::Unavailable),
+    }
 }
 
 /// Whether `cid_str` is the canonical CIDv1 base32 string of a content CID: the
@@ -371,15 +381,15 @@ mod tests {
     }
 
     #[test]
-    fn an_over_cap_block_is_rejected_before_any_hash_or_rotation() {
+    fn all_sources_over_cap_is_terminal_too_large_once_exhausted() {
         let leaf = one_leaf();
         let http = ScriptedHttp::default();
-        // An over-cap body that would NOT content-address to `leaf.cid`: getting
-        // TooLarge (not a content-cid-mismatch) proves the size gate fired
-        // before verify_cid hashed the body, and before any decode/gate work.
+        // Both sources serve an over-cap body that would NOT content-address to
+        // `leaf.cid`: getting TooLarge (not a content-cid-mismatch) proves the
+        // size gate fired before verify_cid hashed the body, before any
+        // decode/gate work. Terminal only once the source set is exhausted.
         http.enqueue_response(raw_response(vec![0u8; MAX_RESOLVED_RECORD_BYTES + 1]));
-        // A good block is queued behind it; a terminal rejection must not consume it.
-        http.enqueue_response(raw_response(leaf.sealed.clone()));
+        http.enqueue_response(raw_response(vec![0u8; MAX_RESOLVED_RECORD_BYTES + 1]));
 
         let err = block_on(read_block(
             &accelerator_only(),
@@ -398,8 +408,38 @@ mod tests {
         );
         assert_eq!(
             http.requests().len(),
-            1,
-            "an over-cap block is terminal — it does not rotate to another source"
+            2,
+            "an over-cap body rotates through every source before failing closed"
+        );
+    }
+
+    #[test]
+    fn an_over_cap_body_rotates_to_a_healthy_source() {
+        let leaf = one_leaf();
+        let http = ScriptedHttp::default();
+        // The accelerator serves an over-cap body (which would NOT content-address
+        // to `leaf.cid`); the public fallback serves the real block. The read
+        // succeeds via rotation, and the over-cap body is never hashed/verified —
+        // returning `leaf.sealed` (not a trust violation) proves it was rejected
+        // at the size gate before verify_cid ran.
+        http.enqueue_response(raw_response(vec![0u8; MAX_RESOLVED_RECORD_BYTES + 1]));
+        http.enqueue_response(raw_response(leaf.sealed.clone()));
+
+        let out = block_on(read_block(
+            &accelerator_only(),
+            &http,
+            &cid_str(),
+            &leaf.cid,
+            ContentPlane::Leaf,
+        ))
+        .unwrap();
+        assert_eq!(out, leaf.sealed);
+
+        let urls: Vec<_> = http.requests().iter().map(|r| r.url.clone()).collect();
+        assert_eq!(urls.len(), 2);
+        assert!(
+            urls[1].starts_with("https://public.gw.test/ipfs/"),
+            "rotated to the public fallback after the over-cap body"
         );
     }
 

--- a/crates/engine/src/content/read.rs
+++ b/crates/engine/src/content/read.rs
@@ -28,6 +28,17 @@ const RAW_BLOCK: &str = "application/vnd.ipld.raw";
 /// Byte offset of the multicodec in the fixed CIDv1 framing (version at 0).
 const CID_CODEC_INDEX: usize = 1;
 
+/// Hard ceiling on a fetched content block, enforced at this fetch boundary
+/// before the block is hashed, decoded, or gated. A resolved record's
+/// envelope-content (grant blobs, history links) rides in an IPFS block fetched
+/// by CID, and the adoption gate then hashes and verifies every structure it
+/// carries — gate work is linear in the fetched byte count. Capping the block
+/// here bounds that work to a fixed budget and fails closed on anything larger,
+/// before any per-structure cost is paid (#742; blueprint/engine.md "Content
+/// plane"). Must stay above the production content chunk size (1 MiB) so a
+/// legitimate leaf or root block always fits.
+const MAX_RESOLVED_RECORD_BYTES: usize = 4 * 1024 * 1024;
+
 /// Which content-plane a fetched CID must address. Core's [`verify_cid`] accepts
 /// any single-byte multicodec (`< 0x80`), not just the frozen content-plane set,
 /// so the engine pins the expected codec here and fails closed on a valid-but-
@@ -96,6 +107,16 @@ pub enum ReadError {
     /// integrity violation, surfaced verbatim from core. Terminal — never
     /// retried against another source, never degraded to staleness.
     TrustViolation(CodecError),
+    /// The fetched block exceeded [`MAX_RESOLVED_RECORD_BYTES`]: rejected at the
+    /// fetch boundary before any hash/decode/gate work. Terminal and fail-closed
+    /// — a record over the size bound is never adoptable, so it is not retried
+    /// against another source (#742).
+    TooLarge {
+        /// The oversized response body length.
+        size: usize,
+        /// The enforced ceiling ([`MAX_RESOLVED_RECORD_BYTES`]).
+        limit: usize,
+    },
     /// No source served the block: every gateway failed at the transport or
     /// status level (unreachable, aborted, or non-2xx). Availability, not
     /// integrity — the caller may retry later.
@@ -145,6 +166,16 @@ pub async fn read_block(
         };
         if !(200..300).contains(&response.status) {
             continue; // availability (not found / server error): next source
+        }
+        // Fail closed on an oversized block before it is hashed or decoded: gate
+        // work is linear in these bytes, so this cap bounds it at the fetch
+        // boundary (#742), ahead of the verify hash below and all downstream
+        // decode/gate work.
+        if response.body.len() > MAX_RESOLVED_RECORD_BYTES {
+            return Err(ReadError::TooLarge {
+                size: response.body.len(),
+                limit: MAX_RESOLVED_RECORD_BYTES,
+            });
         }
         // Every 2xx body is verified before it can be returned. A mismatch is a
         // fail-closed trust violation, not a reason to try another source.
@@ -333,6 +364,62 @@ mod tests {
             1,
             "a mismatch does not rotate sources"
         );
+    }
+
+    #[test]
+    fn an_over_cap_block_is_rejected_before_any_hash_or_rotation() {
+        let leaf = one_leaf();
+        let http = ScriptedHttp::default();
+        // An over-cap body that would NOT content-address to `leaf.cid`: getting
+        // TooLarge (not a content-cid-mismatch) proves the size gate fired
+        // before verify_cid hashed the body, and before any decode/gate work.
+        http.enqueue_response(raw_response(vec![0u8; MAX_RESOLVED_RECORD_BYTES + 1]));
+        // A good block is queued behind it; a terminal rejection must not consume it.
+        http.enqueue_response(raw_response(leaf.sealed.clone()));
+
+        let err = block_on(read_block(
+            &accelerator_only(),
+            &http,
+            &cid_str(),
+            &leaf.cid,
+            ContentPlane::Leaf,
+        ))
+        .unwrap_err();
+        assert_eq!(
+            err,
+            ReadError::TooLarge {
+                size: MAX_RESOLVED_RECORD_BYTES + 1,
+                limit: MAX_RESOLVED_RECORD_BYTES,
+            }
+        );
+        assert_eq!(
+            http.requests().len(),
+            1,
+            "an over-cap block is terminal — it does not rotate to another source"
+        );
+    }
+
+    #[test]
+    fn a_block_at_the_cap_passes_the_size_gate_and_reaches_verify() {
+        let leaf = one_leaf();
+        let http = ScriptedHttp::default();
+        // Exactly at the cap: the boundary is exclusive (`>`), so this passes the
+        // size gate and reaches verify_cid, which then rejects the garbage bytes
+        // as a content-cid-mismatch — proving at-cap content proceeds.
+        http.enqueue_response(raw_response(vec![0u8; MAX_RESOLVED_RECORD_BYTES]));
+
+        let err = block_on(read_block(
+            &accelerator_only(),
+            &http,
+            &cid_str(),
+            &leaf.cid,
+            ContentPlane::Leaf,
+        ))
+        .unwrap_err();
+        match err {
+            ReadError::TrustViolation(e) => assert_eq!(e.check(), "content-cid-mismatch"),
+            other => panic!("expected a content-cid-mismatch, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -1202,4 +1202,34 @@ mod tests {
             "ascent link yields the descendant override seed under the grantee derivation"
         );
     }
+
+    #[test]
+    fn descendant_scope_root_publishes_under_the_enumerated_ref_name() {
+        // The re-key step 5b must publish/reseal the reparented descendant under
+        // the name from the enumerated `ChildScopeRef` (`descendant.ipns_name`),
+        // not the resolved target's — the scope-root publication binding #779
+        // fixed in sweep.rs. A regression to any other name (e.g. the parent's)
+        // is caught here.
+        let subtree = vec![ChildScopeRef::new(
+            DESCENDANT_SCOPE,
+            DESCENDANT_NAME.to_vec(),
+        )];
+        let (outcome, published, _hub) = run(7, &subtree, None, FakeNet::new(Ok(())));
+        outcome.expect("grant creation succeeds over a converged subtree");
+
+        let descendant_record = published
+            .iter()
+            .find(|r| r.scope_id == DESCENDANT_SCOPE)
+            .expect("descendant re-keyed and published");
+        assert_eq!(
+            descendant_record.ipns_name,
+            DESCENDANT_NAME.to_vec(),
+            "published under the enumerated ChildScopeRef name"
+        );
+        assert_ne!(
+            descendant_record.ipns_name,
+            PARENT_NAME.to_vec(),
+            "never republished under the parent scope-root name"
+        );
+    }
 }

--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -416,7 +416,7 @@ where
         let identity = ScopeRootIdentity {
             v: target.v,
             scope_id: descendant.scope_id,
-            ipns_name: &target.ipns_name,
+            ipns_name: &descendant.ipns_name,
             owner_enc_pub: &target.owner_enc_pub,
             parent_node_seed: Some(&parent_node_seed),
             pseudonym_signer: &target.pseudonym_signer,
@@ -450,7 +450,7 @@ where
         })?;
         let record = ResealedScopeRoot {
             scope_id: descendant.scope_id,
-            ipns_name: target.ipns_name.clone(),
+            ipns_name: descendant.ipns_name.clone(),
             read_epoch: target.current_read_epoch,
             write_epoch: target.write_epoch,
             section,

--- a/crates/engine/src/seams/http.rs
+++ b/crates/engine/src/seams/http.rs
@@ -137,17 +137,22 @@ pub trait Http {
     async fn send(&self, request: HttpRequest) -> SeamResult<HttpResponse>;
 
     /// Like [`send`](Self::send), but fails closed if the response body would
-    /// exceed `max_bytes`. A conforming transport enforces the bound *while*
-    /// reading the body (a `Content-Length` pre-check plus a capped streaming
-    /// read), so a malicious gateway cannot force an allocation larger than the
-    /// cap — the true peak-memory bound at the content fetch boundary (#787).
+    /// exceed `max_bytes`, so a lying/huge gateway cannot force an over-cap
+    /// adoption. The strength of the bound differs by transport:
+    ///
+    /// - Desktop (`reqwest`) enforces it *while* reading the body — a
+    ///   `Content-Length` pre-check plus a capped streaming read that aborts
+    ///   past the cap — the true peak-memory bound at the content fetch
+    ///   boundary (#787).
+    /// - WASM (the JS fetch bridge) applies a `Content-Length` pre-check plus a
+    ///   post-buffer size check: it fails closed on size but is *not* a
+    ///   peak-memory bound, because the JS seam buffers the whole body before it
+    ///   reaches Rust. The streaming bound is tracked in #641.
     ///
     /// The default implementation only backstops: it buffers the whole body via
-    /// [`send`](Self::send) and then checks the length, which bounds nothing.
-    /// The real content-read transports (desktop `reqwest`, the WASM fetch
-    /// bridge) override this with a streaming bound; the default is for seams
-    /// that never carry untrusted content bodies (the fakes, the API-only
-    /// contract transport).
+    /// [`send`](Self::send) and then checks the length, which bounds nothing. It
+    /// is for seams that never carry untrusted content bodies (the fakes, the
+    /// API-only contract transport).
     async fn send_capped(
         &self,
         request: HttpRequest,

--- a/crates/engine/src/seams/http.rs
+++ b/crates/engine/src/seams/http.rs
@@ -2,7 +2,31 @@
 
 use core::fmt;
 
-use super::SeamResult;
+use super::{SeamError, SeamResult};
+
+/// The `Content-Length` response header, consulted by [`Http::send_capped`] for
+/// an up-front reject before any body bytes are read.
+pub const CONTENT_LENGTH: &str = "content-length";
+
+/// Why a size-capped fetch ([`Http::send_capped`]) did not return a body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CappedFetchError {
+    /// Transport-level failure (unreachable, aborted) — the seam's reserved
+    /// `Err`, an availability signal, not a trust or size decision.
+    Transport(SeamError),
+    /// The response body would exceed `max_bytes`, rejected at the transport
+    /// before the whole body is buffered so a lying/huge gateway cannot force an
+    /// unbounded allocation (the peak-memory bound of #787). Fail-closed and
+    /// terminal: an over-cap block is never adoptable from any source.
+    BodyTooLarge {
+        /// The observed lower bound on the body size — the declared
+        /// `Content-Length` if that alone exceeded the cap, else the bytes
+        /// accumulated when the streaming read passed the cap.
+        observed: usize,
+        /// The enforced ceiling (`max_bytes`).
+        limit: usize,
+    },
+}
 
 /// Formats headers as their names only. Header values ride this seam
 /// carrying live credentials (`Authorization` bearer JWTs, refresh
@@ -111,6 +135,36 @@ impl fmt::Debug for HttpResponse {
 pub trait Http {
     /// Sends one request and resolves with the complete response.
     async fn send(&self, request: HttpRequest) -> SeamResult<HttpResponse>;
+
+    /// Like [`send`](Self::send), but fails closed if the response body would
+    /// exceed `max_bytes`. A conforming transport enforces the bound *while*
+    /// reading the body (a `Content-Length` pre-check plus a capped streaming
+    /// read), so a malicious gateway cannot force an allocation larger than the
+    /// cap — the true peak-memory bound at the content fetch boundary (#787).
+    ///
+    /// The default implementation only backstops: it buffers the whole body via
+    /// [`send`](Self::send) and then checks the length, which bounds nothing.
+    /// The real content-read transports (desktop `reqwest`, the WASM fetch
+    /// bridge) override this with a streaming bound; the default is for seams
+    /// that never carry untrusted content bodies (the fakes, the API-only
+    /// contract transport).
+    async fn send_capped(
+        &self,
+        request: HttpRequest,
+        max_bytes: usize,
+    ) -> Result<HttpResponse, CappedFetchError> {
+        let response = self
+            .send(request)
+            .await
+            .map_err(CappedFetchError::Transport)?;
+        if response.body.len() > max_bytes {
+            return Err(CappedFetchError::BodyTooLarge {
+                observed: response.body.len(),
+                limit: max_bytes,
+            });
+        }
+        Ok(response)
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/src/seams/mod.rs
+++ b/crates/engine/src/seams/mod.rs
@@ -22,7 +22,7 @@ mod staging_store;
 
 pub use credential_store::CredentialStore;
 pub use floor_store::{FloorNamespace, FloorRaise, FloorStore};
-pub use http::{Http, HttpMethod, HttpRequest, HttpResponse};
+pub use http::{CONTENT_LENGTH, CappedFetchError, Http, HttpMethod, HttpRequest, HttpResponse};
 pub use mailbox::{Mailbox, MailboxItem};
 pub use record_transport::{EndpointId, RecordTransport};
 pub use refresh_hint::{RefreshHint, RefreshHintSource};

--- a/crates/engine/src/testkit/fakes/http.rs
+++ b/crates/engine/src/testkit/fakes/http.rs
@@ -94,4 +94,29 @@ mod tests {
         let http = ScriptedHttp::default();
         assert!(block_on(http.send(request("https://api.test/oops"))).is_err());
     }
+
+    #[test]
+    fn send_capped_rejects_an_over_cap_body_and_admits_one_at_the_cap() {
+        use crate::seams::CappedFetchError;
+
+        let body = |len: usize| HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: vec![0u8; len],
+        };
+        let http = ScriptedHttp::default();
+        http.enqueue_response(body(9)); // over the cap
+        http.enqueue_response(body(8)); // exactly at the cap
+
+        let err = block_on(http.send_capped(request("https://api.test/big"), 8)).unwrap_err();
+        assert_eq!(
+            err,
+            CappedFetchError::BodyTooLarge {
+                observed: 9,
+                limit: 8
+            }
+        );
+        let ok = block_on(http.send_capped(request("https://api.test/ok"), 8)).unwrap();
+        assert_eq!(ok.body.len(), 8, "a body exactly at the cap is admitted");
+    }
 }

--- a/crates/wasm/src/seams_bridge.rs
+++ b/crates/wasm/src/seams_bridge.rs
@@ -19,9 +19,10 @@
 //! crosses as `bigint` and lives in `lib.rs`, not here.
 
 use cipherbox_engine::seams::{
-    BoxedTask, CredentialStore, EndpointId, FloorStore, Http, HttpMethod, HttpRequest,
-    HttpResponse, Mailbox, MailboxItem, OpId, RecordTransport, RefreshHint, RefreshHintSource,
-    Scheduler, SeamError, SeamResult, SnapshotCache, StagingStore, UnixMillis,
+    BoxedTask, CONTENT_LENGTH, CappedFetchError, CredentialStore, EndpointId, FloorStore, Http,
+    HttpMethod, HttpRequest, HttpResponse, Mailbox, MailboxItem, OpId, RecordTransport,
+    RefreshHint, RefreshHintSource, Scheduler, SeamError, SeamResult, SnapshotCache, StagingStore,
+    UnixMillis,
 };
 use core::time::Duration;
 use js_sys::{Array, Object, Reflect, Uint8Array};
@@ -556,6 +557,45 @@ impl Http for HttpAdapter {
             .await
             .map_err(seam_error)?;
         http_response_from_js(response)
+    }
+
+    async fn send_capped(
+        &self,
+        request: HttpRequest,
+        max_bytes: usize,
+    ) -> Result<HttpResponse, CappedFetchError> {
+        // Residual (#787): the JS `HttpSeam.send` materializes the whole body
+        // before it returns here, so this bounds one already-buffered response,
+        // not peak memory. The Content-Length reject and the body-length check
+        // both fail closed on an over-cap block; the true streaming bound must
+        // live in the JS seam (enforce `maxBytes` while reading `Response.body`).
+        let response = self
+            .js
+            .send(http_request_to_js(&request))
+            .await
+            .map_err(|err| CappedFetchError::Transport(seam_error(err)))?;
+        let response = http_response_from_js(response).map_err(CappedFetchError::Transport)?;
+
+        let declared = response
+            .headers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(CONTENT_LENGTH))
+            .and_then(|(_, value)| value.parse::<u64>().ok());
+        if let Some(declared) = declared {
+            if declared > max_bytes as u64 {
+                return Err(CappedFetchError::BodyTooLarge {
+                    observed: usize::try_from(declared).unwrap_or(usize::MAX),
+                    limit: max_bytes,
+                });
+            }
+        }
+        if response.body.len() > max_bytes {
+            return Err(CappedFetchError::BodyTooLarge {
+                observed: response.body.len(),
+                limit: max_bytes,
+            });
+        }
+        Ok(response)
     }
 }
 

--- a/crates/wasm/src/seams_bridge.rs
+++ b/crates/wasm/src/seams_bridge.rs
@@ -564,7 +564,7 @@ impl Http for HttpAdapter {
         request: HttpRequest,
         max_bytes: usize,
     ) -> Result<HttpResponse, CappedFetchError> {
-        // Residual (#787): the JS `HttpSeam.send` materializes the whole body
+        // Residual (#641): the JS `HttpSeam.send` materializes the whole body
         // before it returns here, so this bounds one already-buffered response,
         // not peak memory. The Content-Length reject and the body-length check
         // both fail closed on an over-cap block; the true streaming bound must


### PR DESCRIPTION
## What

Cap the size of a resolved-record envelope-content block at the engine's content fetch boundary, bounding adoption-gate work before it starts.

## Why

Surfaced by the Greptile P2 on #741: a resolved record can carry arbitrarily large `grantBlobs`/`historyLinks`, and the adoption gate hashes+verifies every structure, so an oversized record consumes CPU before rejection. The det-CBOR decoder itself is not vulnerable to a small-record -> huge-allocation amplification (`take_len` rejects over-long length claims), so this is a genuine-bytes DoS bound at the fetch boundary, not a codec fix — and not a per-array cardinality cap on the frozen KAT'd wire format.

The envelope-content rides in the IPFS block fetched by CID (`content::read::read_block`), a different path from the IPNS record transport that #722/#738 capped at 64 KiB. `read_block` is the sole content-by-CID fetch boundary, and `verify_cid` (BLAKE3 over the whole body) is the first O(bytes) work; the record-envelope candidate assembly (#745/#746) plugs in behind the `Adopter` seam using it.

## Change

- New `MAX_RESOLVED_RECORD_BYTES = 4 MiB` constant in `crates/engine/src/content/read.rs`, the single source of truth. Sized to bound gate work while clearing the production 1 MiB content chunk and any realistic grant-section record (4x leaf headroom).
- New `ReadError::TooLarge { size, limit }` — fail-closed, terminal (a record over the bound is never adoptable, so no source rotation).
- `read_block` rejects an over-cap body before `verify_cid` hashes/decodes it, so no per-structure hash/decode/gate work is ever paid on oversized input.
- Tests: an over-cap block is rejected with `TooLarge` before any hash and does not rotate to a good source queued behind it; an at-cap block passes the (exclusive `>`) size gate and reaches `verify_cid`.

## Deferral

The cap is enforced on every `read_block` response (plane-agnostic), so it also bounds the file-content DAG root manifest — practically capping max file size at ~114 GiB (4 MiB / ~36-byte leaf CID x 1 MiB chunk). When #745/#746 wire a distinct record-envelope fetch, the record cap can be tightened independently of the file-manifest bound. Flagging rather than expanding scope here.

Closes #742
Closes #787
Closes #788
Part of #635

## Merge-conflict fix (create.rs)

Merging main restored the descendant re-key's compile after #779 dropped `SweepTarget.ipns_name` while #782's descendant re-key still sourced the publish/reseal name from it. The reparented descendant scope root now publishes and reseals under the enumerated `descendant.ipns_name` (the `ChildScopeRef` name), matching #779's sweep.rs binding. A focused test (`descendant_scope_root_publishes_under_the_enumerated_ref_name`) pins that the published descendant record's `ipns_name` equals the enumerated ref, so a regression to any other name is caught.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safeguards that limit resolved content records to 4 MiB.
  - Added capped downloads that reject responses exceeding the configured size limit.
  - Added clear errors for oversized content and transport failures.

- **Bug Fixes**
  - Oversized content is now rejected before processing or publishing.
  - Content retrieval can continue with another source when one returns an oversized response.
  - Corrected descendant access permissions when reparenting scopes.

- **Tests**
  - Added coverage for size limits, boundary-sized responses, and source fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
