### PR TITLE
feat(engine): wire the facade cold-start pipeline and live resolve-tick driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "zeroize",
 ]
 
 [[package]]

--- a/blueprint/core.md
+++ b/blueprint/core.md
@@ -215,6 +215,12 @@ byte movers injected by the engine.
 - **Name codec**: `ipnsName` = base36 CIDv1 libp2p-key of the Ed25519 public
   key. Encode + strict decode are core exports; everything downstream treats
   names as opaque.
+- **Content-CID string codec**: a scope's IPNS record value `/ipfs/<head_cid>`
+  carries the head block's binary CIDv1 in base32-lowercase multibase (`b…`).
+  Encode + strict decode are core exports; decode fail-closes on a wrong/missing
+  `b` prefix, a non-base32 or non-canonical body, or any bytes that are not the
+  frozen content-plane CIDv1 framing — the Adopter recovers the trust anchor from
+  the record string before `read_block` verifies the fetched head.
 - **Keyless re-PUT** is a first-class shape: marshal/unmarshal round-trips a
   foreign signed record byte-stable without key material (the republisher and
   every accelerator depend on this).

--- a/crates/core/examples/kat_gen.rs
+++ b/crates/core/examples/kat_gen.rs
@@ -23,8 +23,8 @@ use cipherbox_core::codec::{
     MAX_DEPTH, Map, Value, decode, decode_map_partial, encode, encode_map_partial,
 };
 use cipherbox_core::content::{
-    CONTENT_CID_CODEC, CONTENT_CID_LEN, CONTENT_CID_MULTIHASH, compute_cid, open_chunk, seal_chunk,
-    verify_cid,
+    CONTENT_CID_CODEC, CONTENT_CID_LEN, CONTENT_CID_MULTIHASH, compute_cid, decode_content_cid_str,
+    encode_content_cid_str, open_chunk, seal_chunk, verify_cid,
 };
 use cipherbox_core::error::{CodecError, Malformed, TrustViolation};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
@@ -228,6 +228,18 @@ struct ContentSection {
     seal_reject: RejectSection,
     cid: FileCount,
     cid_reject: RejectSection,
+    cid_str_accept: FileCount,
+    cid_str_reject: RejectSection,
+}
+
+/// A content-CID string accept vector: a binary CIDv1 and its canonical
+/// base32-lowercase multibase (`b…`) rendering, round-tripping byte-for-byte.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ContentCidStrAcceptVector {
+    name: String,
+    cid: String,
+    cid_str: String,
 }
 
 /// A content-seal accept vector: a fixed content key + nonce seal of
@@ -890,11 +902,21 @@ fn main() {
     let content_seal_reject = build_content_seal_reject();
     let content_cid = build_content_cid();
     let content_cid_reject = build_content_cid_reject();
+    let content_cid_str_accept = build_content_cid_str_accept();
+    let content_cid_str_reject = build_content_cid_str_reject();
 
     write_pretty(&content_dir.join("seal.json"), &content_seal);
     write_pretty(&content_dir.join("seal_reject.json"), &content_seal_reject);
     write_pretty(&content_dir.join("cid.json"), &content_cid);
     write_pretty(&content_dir.join("cid_reject.json"), &content_cid_reject);
+    write_pretty(
+        &content_dir.join("cid_str_accept.json"),
+        &content_cid_str_accept,
+    );
+    write_pretty(
+        &content_dir.join("cid_str_reject.json"),
+        &content_cid_str_reject,
+    );
 
     let manifest = build_manifest(ManifestInputs {
         accept: &accept,
@@ -925,6 +947,8 @@ fn main() {
         content_seal_reject: &content_seal_reject,
         content_cid: &content_cid,
         content_cid_reject: &content_cid_reject,
+        content_cid_str_accept: &content_cid_str_accept,
+        content_cid_str_reject: &content_cid_str_reject,
     });
     write_pretty(&kat_dir.join("manifest.json"), &manifest);
 
@@ -935,7 +959,8 @@ fn main() {
          {} name-accept, {} name-reject, {} record-accept, {} record-reject, {} record-reput, \
          {} pointer-accept, {} pointer-reject, {} mailbox-accept, {} mailbox-reject, \
          {} grant-family, {} content-seal, {} content-seal-reject, {} content-cid, \
-         {} content-cid-reject vectors + manifest.json",
+         {} content-cid-reject, {} content-cid-str-accept, {} content-cid-str-reject \
+         vectors + manifest.json",
         accept.len(),
         reject.len(),
         unknown.len(),
@@ -964,6 +989,8 @@ fn main() {
         content_seal_reject.len(),
         content_cid.len(),
         content_cid_reject.len(),
+        content_cid_str_accept.len(),
+        content_cid_str_reject.len(),
     );
 }
 
@@ -1718,6 +1745,8 @@ struct ManifestInputs<'a> {
     content_seal_reject: &'a [ContentSealRejectVector],
     content_cid: &'a [ContentCidVector],
     content_cid_reject: &'a [ContentCidRejectVector],
+    content_cid_str_accept: &'a [ContentCidStrAcceptVector],
+    content_cid_str_reject: &'a [TextRejectVector],
 }
 
 fn build_manifest(m: ManifestInputs) -> Manifest {
@@ -1929,6 +1958,17 @@ fn build_content_section(m: &ManifestInputs) -> ContentSection {
             count: m.content_cid_reject.len(),
             checks: checks_surface_ordered(
                 &m.content_cid_reject
+                    .iter()
+                    .map(|v| v.check.as_str())
+                    .collect(),
+            ),
+        },
+        cid_str_accept: file("cid_str_accept", m.content_cid_str_accept.len()),
+        cid_str_reject: RejectSection {
+            file: "vectors/content/cid_str_reject.json".to_string(),
+            count: m.content_cid_str_reject.len(),
+            checks: checks_surface_ordered(
+                &m.content_cid_str_reject
                     .iter()
                     .map(|v| v.check.as_str())
                     .collect(),
@@ -2297,6 +2337,126 @@ fn build_content_cid_reject() -> Vec<ContentCidRejectVector> {
         });
     }
     out
+}
+
+fn build_content_cid_str_accept() -> Vec<ContentCidStrAcceptVector> {
+    let key = content_key();
+    const DAG_CBOR_CODEC: u8 = 0x71;
+    // (name, codec, bytes) → binary CIDv1 → canonical base32-lower `b…` string.
+    // A raw leaf, the empty-input leaf, and the dag-cbor DAG root (the head-block
+    // codec a scope's `/ipfs/<head_cid>` record actually carries).
+    let cases: Vec<(&str, u8, Vec<u8>)> = vec![
+        (
+            "cid-str-sealed-chunk",
+            CONTENT_CID_CODEC,
+            seal_chunk(&key, &content_nonce(0x11), b"caller-framed chunk bytes"),
+        ),
+        ("cid-str-empty-input", CONTENT_CID_CODEC, Vec::new()),
+        (
+            "cid-str-dag-root-nonraw-codec",
+            DAG_CBOR_CODEC,
+            b"assembled dag-root node bytes".to_vec(),
+        ),
+    ];
+
+    let mut names = BTreeSet::new();
+    let mut out = Vec::with_capacity(cases.len());
+    for (name, codec, sealed) in cases {
+        assert!(
+            names.insert(name),
+            "duplicate content cid-str vector {name}"
+        );
+        let cid = compute_cid(codec, &sealed);
+        let cid_str = encode_content_cid_str(&cid);
+        // Self-checks: canonical `b` prefix and a byte-stable strict round-trip.
+        assert!(
+            cid_str.starts_with('b'),
+            "content cid-str {name}: base32 multibase prefix"
+        );
+        assert_eq!(
+            decode_content_cid_str(&cid_str).expect("own string decodes"),
+            cid,
+            "content cid-str {name}: decode recovers the binary CID"
+        );
+        out.push(ContentCidStrAcceptVector {
+            name: name.to_string(),
+            cid: hexstr(&cid),
+            cid_str,
+        });
+    }
+    out
+}
+
+fn build_content_cid_str_reject() -> Vec<TextRejectVector> {
+    let good = encode_content_cid_str(&compute_cid(CONTENT_CID_CODEC, b"anchor bytes"));
+    let body = &good[1..];
+
+    // A canonical base32 body over a 36-byte string whose multihash code is
+    // corrupted: valid base32, wrong CIDv1 framing → must fail closed.
+    let mut wrong_framing = compute_cid(CONTENT_CID_CODEC, b"anchor bytes");
+    wrong_framing[2] ^= 0xff;
+    let mut wrong_framing_str = String::from("b");
+    base32_encode_into_ref(&wrong_framing, &mut wrong_framing_str);
+
+    // (name, string). Every string is not the one canonical `b…` CIDv1.
+    let cases: Vec<(&str, String)> = vec![
+        ("empty", String::new()),
+        ("prefix-only", "b".to_string()),
+        ("wrong-multibase-base36-k", format!("k{body}")),
+        ("wrong-multibase-base58-z", format!("z{body}")),
+        ("uppercase-base32-upper", good.to_uppercase()),
+        ("non-base32-char-1", format!("b1{body}")),
+        ("truncated", good[..good.len() - 1].to_string()),
+        ("trailing-extra-char", format!("{good}a")),
+        ("wrong-cid-framing", wrong_framing_str),
+    ];
+
+    let mut names = BTreeSet::new();
+    let mut out = Vec::with_capacity(cases.len());
+    for (name, text) in cases {
+        assert!(
+            names.insert(name),
+            "duplicate content cid-str-reject {name}"
+        );
+        let err = decode_content_cid_str(&text).expect_err("cid-str-reject must fail closed");
+        assert_eq!(
+            err.check(),
+            "content-cid-str-malformed",
+            "content cid-str-reject {name}: check ({err})"
+        );
+        assert_eq!(
+            err.class(),
+            "malformed",
+            "content cid-str-reject {name}: class ({err})"
+        );
+        out.push(TextRejectVector {
+            name: name.to_string(),
+            text,
+            check: err.check().to_string(),
+            class: err.class().to_string(),
+        });
+    }
+    out
+}
+
+/// Canonical base32-lowercase (no-padding) of `input` appended to `out` — the
+/// same transform the codec applies, used only to hand-craft the wrong-framing
+/// reject vector's body from arbitrary (non-CID) bytes.
+fn base32_encode_into_ref(input: &[u8], out: &mut String) {
+    const ALPHABET: &[u8; 32] = b"abcdefghijklmnopqrstuvwxyz234567";
+    let mut acc: u32 = 0;
+    let mut bits: u32 = 0;
+    for &b in input {
+        acc = (acc << 8) | u32::from(b);
+        bits += 8;
+        while bits >= 5 {
+            bits -= 5;
+            out.push(ALPHABET[((acc >> bits) & 0x1f) as usize] as char);
+        }
+    }
+    if bits > 0 {
+        out.push(ALPHABET[((acc << (5 - bits)) & 0x1f) as usize] as char);
+    }
 }
 
 /// A frozen sample folder read-body, used as the read-body-tag plaintext.

--- a/crates/core/kat/manifest.json
+++ b/crates/core/kat/manifest.json
@@ -417,6 +417,17 @@
       "checks": [
         "content-cid-mismatch"
       ]
+    },
+    "cidStrAccept": {
+      "file": "vectors/content/cid_str_accept.json",
+      "count": 3
+    },
+    "cidStrReject": {
+      "file": "vectors/content/cid_str_reject.json",
+      "count": 9,
+      "checks": [
+        "content-cid-str-malformed"
+      ]
     }
   }
 }

--- a/crates/core/kat/vectors/content/cid_str_accept.json
+++ b/crates/core/kat/vectors/content/cid_str_accept.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "cid-str-sealed-chunk",
+    "cid": "01551e2013ae00f54c9c89553f94e187896df002878d65519d7edebb3b2b60f9b140bf64",
+    "cidStr": "bafkr4iatvyapkte4rfkt7fhbq6ew34acq6gwkum5p3plwozlmd43cqf7mq"
+  },
+  {
+    "name": "cid-str-empty-input",
+    "cid": "01551e20af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+    "cidStr": "bafkr4ifpcne3t5pzugtkaqcn5i3nzskjtpfslsnnyejlpte2spfoihzsmi"
+  },
+  {
+    "name": "cid-str-dag-root-nonraw-codec",
+    "cid": "01711e20469f95275785ff4265858b4963283402fbcfb0c73b90d085f6ed61e4b741fdb7",
+    "cidStr": "bafyr4icgt6ksov4f75bglbmljfrsqnac7ph3brz3sdiil5xnmhsloqp5w4"
+  }
+]

--- a/crates/core/kat/vectors/content/cid_str_reject.json
+++ b/crates/core/kat/vectors/content/cid_str_reject.json
@@ -1,0 +1,56 @@
+[
+  {
+    "name": "empty",
+    "text": "",
+    "check": "content-cid-str-malformed",
+    "class": "malformed"
+  },
+  {
+    "name": "prefix-only",
+    "text": "b",
+    "check": "content-cid-str-malformed",
+    "class": "malformed"
+  },
+  {
+    "name": "wrong-multibase-base36-k",
+    "text": "kafkr4ihrcmbmwxxzhi2wtw2ej4h4sy3kbr5tbf4q6ciabphxzkug7dfvfe",
+    "check": "content-cid-str-malformed",
+    "class": "malformed"
+  },
+  {
+    "name": "wrong-multibase-base58-z",
+    "text": "zafkr4ihrcmbmwxxzhi2wtw2ej4h4sy3kbr5tbf4q6ciabphxzkug7dfvfe",
+    "check": "content-cid-str-malformed",
+    "class": "malformed"
+  },
+  {
+    "name": "uppercase-base32-upper",
+    "text": "BAFKR4IHRCMBMWXXZHI2WTW2EJ4H4SY3KBR5TBF4Q6CIABPHXZKUG7DFVFE",
+    "check": "content-cid-str-malformed",
+    "class": "malformed"
+  },
+  {
+    "name": "non-base32-char-1",
+    "text": "b1afkr4ihrcmbmwxxzhi2wtw2ej4h4sy3kbr5tbf4q6ciabphxzkug7dfvfe",
+    "check": "content-cid-str-malformed",
+    "class": "malformed"
+  },
+  {
+    "name": "truncated",
+    "text": "bafkr4ihrcmbmwxxzhi2wtw2ej4h4sy3kbr5tbf4q6ciabphxzkug7dfvf",
+    "check": "content-cid-str-malformed",
+    "class": "malformed"
+  },
+  {
+    "name": "trailing-extra-char",
+    "text": "bafkr4ihrcmbmwxxzhi2wtw2ej4h4sy3kbr5tbf4q6ciabphxzkug7dfvfea",
+    "check": "content-cid-str-malformed",
+    "class": "malformed"
+  },
+  {
+    "name": "wrong-cid-framing",
+    "text": "bafk6cihrcmbmwxxzhi2wtw2ej4h4sy3kbr5tbf4q6ciabphxzkug7dfvfe",
+    "check": "content-cid-str-malformed",
+    "class": "malformed"
+  }
+]

--- a/crates/core/src/content/cid.rs
+++ b/crates/core/src/content/cid.rs
@@ -26,7 +26,7 @@
 //! the claimed CID's *own* codec byte, validating both a raw leaf and a DAG root
 //! while the version, multihash, and length framing stay fixed and fail-closed.
 
-use crate::error::{CodecError, TrustViolation};
+use crate::error::{CodecError, Malformed, TrustViolation};
 use crate::suite::hash::hash;
 use crate::suite::secret::SECRET_LEN;
 
@@ -102,6 +102,133 @@ pub fn verify_cid(claimed_cid: &[u8], bytes: &[u8]) -> Result<(), CodecError> {
         Ok(())
     } else {
         Err(TrustViolation::ContentCidMismatch.into())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Content-CID string codec (blueprint/core.md "Content-CID string codec"). A
+// scope's metadata IPNS record carries `/ipfs/<head_cid>` where `<head_cid>` is
+// the binary CIDv1 above rendered in base32-lowercase multibase (leading `b`),
+// the form IPFS emits. The Adopter must recover the binary anchor from that
+// string before `read_block` can trust-check the fetched head, so encode + strict
+// decode are core exports — mirroring the base36 name codec ([`crate::ipns::name`]).
+// ---------------------------------------------------------------------------
+
+/// The multibase prefix for lowercase base32 (RFC 4648 `base32`, no padding).
+const MULTIBASE_BASE32: char = 'b';
+
+/// The RFC 4648 base32 lowercase alphabet (`a`=0 … `z`=25, `2`=26 … `7`=31).
+const BASE32_ALPHABET: &[u8; 32] = b"abcdefghijklmnopqrstuvwxyz234567";
+
+/// Whether `cid` is the frozen content-plane CIDv1 framing: 36 bytes,
+/// `version=1`, a single-byte multicodec (`< 0x80`, engine-owned #630), the
+/// BLAKE3 multihash code, and the 32-byte digest length. The invariant both the
+/// encoder guards (release-active) and the decoder rejects on, kept symmetric.
+fn is_wellformed_content_cid(cid: &[u8]) -> bool {
+    cid.len() == CONTENT_CID_LEN
+        && cid[0] == CID_VERSION
+        && cid[CID_CODEC_INDEX] < 0x80
+        && cid[2] == CONTENT_CID_MULTIHASH
+        && cid[3] == DIGEST_LEN as u8
+}
+
+/// Encode a binary content CIDv1 as its canonical base32-lowercase multibase
+/// string (leading `b`). Every valid content CID has exactly one such string.
+///
+/// `assert!` (release-active, like [`compute_cid`]): emitting a `b…` string over
+/// bytes the decoder rejects would publish an unresolvable scope head (AGENTS.md
+/// rule 8 encode/decode symmetry), so a malformed CID fails closed in every build.
+pub fn encode_content_cid_str(cid: &[u8]) -> String {
+    assert!(
+        is_wellformed_content_cid(cid),
+        "content CID must be the frozen CIDv1 framing (core.md)"
+    );
+    let mut out = String::with_capacity(1 + base32_len(cid.len()));
+    out.push(MULTIBASE_BASE32);
+    base32_encode_into(cid, &mut out);
+    out
+}
+
+/// Strictly decode a base32-lowercase multibase content-CID string into its
+/// binary CIDv1 bytes, fail-closed ([`Malformed::ContentCidStrMalformed`]).
+/// Rejects a wrong/missing `b` prefix, a non-base32 or non-canonical body, and
+/// anything that is not the frozen content-plane CIDv1 framing — the recovered
+/// anchor must be trustworthy before a fetch trusts it (AGENTS.md rule 6).
+pub fn decode_content_cid_str(s: &str) -> Result<Vec<u8>, CodecError> {
+    // Fixed-width anchor: reject an over-long string up front (cheap, never
+    // rejects a real 36-byte CID — the base32 bound always exceeds its width).
+    if s.len() > 1 + base32_len(CONTENT_CID_LEN) {
+        return Err(malformed_cid_str());
+    }
+    let mut chars = s.chars();
+    if chars.next() != Some(MULTIBASE_BASE32) {
+        return Err(malformed_cid_str());
+    }
+    let cid = base32_decode(chars.as_str()).ok_or_else(malformed_cid_str)?;
+    if !is_wellformed_content_cid(&cid) {
+        return Err(malformed_cid_str());
+    }
+    // Re-derive the canonical string and byte-compare: a body that decoded but
+    // is not the byte-exact canonical rendering (e.g. a dangling zero-bit char)
+    // never survives as a distinct string (mirrors ipns/name.rs).
+    if encode_content_cid_str(&cid) != s {
+        return Err(malformed_cid_str());
+    }
+    Ok(cid)
+}
+
+fn malformed_cid_str() -> CodecError {
+    Malformed::ContentCidStrMalformed.into()
+}
+
+/// A loose upper bound on the base32 length of `n` bytes: 8 bits/byte over
+/// 5 bits/char is 1.6, so `2*n` always suffices (for capacity and the cap).
+fn base32_len(n: usize) -> usize {
+    2 * n
+}
+
+/// Append the canonical base32-lowercase (no-padding) rendering of `input`.
+fn base32_encode_into(input: &[u8], out: &mut String) {
+    let mut acc: u32 = 0;
+    let mut bits: u32 = 0;
+    for &b in input {
+        acc = (acc << 8) | u32::from(b);
+        bits += 8;
+        while bits >= 5 {
+            bits -= 5;
+            out.push(BASE32_ALPHABET[((acc >> bits) & 0x1f) as usize] as char);
+        }
+    }
+    if bits > 0 {
+        out.push(BASE32_ALPHABET[((acc << (5 - bits)) & 0x1f) as usize] as char);
+    }
+}
+
+/// Decode a canonical base32-lowercase (no-padding) body. Returns `None` on any
+/// non-alphabet char or a non-zero trailing-bit remainder (a non-canonical tail).
+fn base32_decode(text: &str) -> Option<Vec<u8>> {
+    let mut acc: u32 = 0;
+    let mut bits: u32 = 0;
+    let mut out = Vec::with_capacity(text.len() * 5 / 8);
+    for c in text.chars() {
+        acc = (acc << 5) | u32::from(base32_digit(c)?);
+        bits += 5;
+        if bits >= 8 {
+            bits -= 8;
+            out.push(((acc >> bits) & 0xff) as u8);
+        }
+    }
+    if bits > 0 && (acc & ((1 << bits) - 1)) != 0 {
+        return None;
+    }
+    Some(out)
+}
+
+fn base32_digit(c: char) -> Option<u8> {
+    match c {
+        'a'..='z' => Some(c as u8 - b'a'),
+        '2'..='7' => Some(c as u8 - b'2' + 26),
+        _ => None,
     }
 }
 
@@ -254,5 +381,70 @@ mod tests {
             verify_cid(b"not a cid", bytes).unwrap_err().check(),
             "content-cid-mismatch"
         );
+    }
+
+    #[test]
+    fn content_cid_str_round_trips_and_is_lowercase_b_prefixed() {
+        for codec in [CONTENT_CID_CODEC, 0x71u8] {
+            let cid = compute_cid(codec, b"head block bytes");
+            let s = encode_content_cid_str(&cid);
+            assert!(s.starts_with('b'), "base32-lower multibase prefix");
+            assert!(
+                s.bytes()
+                    .skip(1)
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()),
+                "base32-lower body: {s}"
+            );
+            assert_eq!(
+                decode_content_cid_str(&s).expect("own string decodes"),
+                cid,
+                "string codec round-trips byte-for-byte"
+            );
+        }
+    }
+
+    #[test]
+    fn decode_rejects_foreign_and_non_canonical_strings() {
+        let cid = compute_cid(CONTENT_CID_CODEC, b"anchor");
+        let s = encode_content_cid_str(&cid);
+        for bad in [
+            String::new(),                // empty
+            "b".to_string(),              // prefix only
+            format!("k{}", &s[1..]),      // wrong multibase (base36 k)
+            format!("z{}", &s[1..]),      // wrong multibase (base58 z)
+            s.to_uppercase(),             // uppercase (base32 upper 'B…')
+            format!("{s}a"),              // trailing extra char
+            s[..s.len() - 1].to_string(), // truncated
+            format!("b1{}", &s[1..]),     // '1' not in base32 alphabet
+        ] {
+            assert_eq!(
+                decode_content_cid_str(&bad).unwrap_err().check(),
+                "content-cid-str-malformed",
+                "must reject {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn decode_rejects_wrong_framing_even_when_base32_canonical() {
+        // A canonical base32 body over 36 bytes with a corrupted multihash code:
+        // valid base32, wrong CIDv1 framing → fail closed.
+        let mut cid = compute_cid(CONTENT_CID_CODEC, b"anchor");
+        cid[2] ^= 0xff;
+        let mut s = String::from("b");
+        super::base32_encode_into(&cid, &mut s);
+        assert_eq!(
+            decode_content_cid_str(&s).unwrap_err().check(),
+            "content-cid-str-malformed"
+        );
+    }
+
+    // Native-only: the always-on encode guard fires in every build; `#[should_panic]`
+    // is unsafe on the panic=abort wasm legs (mirrors compute_cid's guard test).
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    #[should_panic(expected = "frozen CIDv1 framing")]
+    fn encode_guards_malformed_cid_fail_closed() {
+        let _ = encode_content_cid_str(b"not a well-framed content cid");
     }
 }

--- a/crates/core/src/content/mod.rs
+++ b/crates/core/src/content/mod.rs
@@ -11,10 +11,16 @@
 //!   zeroizes it.
 //! - **content-DAG CID** ([`cid::compute_cid`]/[`cid::verify_cid`]): the
 //!   deterministic CIDv1 content address over the sealed bytes and a fail-closed
-//!   verify. One implementation, one KAT set, byte-identical native + wasm32.
+//!   verify. One implementation, one KAT set, byte-identical native + wasm32. The
+//!   string codec ([`cid::encode_content_cid_str`]/[`cid::decode_content_cid_str`])
+//!   renders that CID as its base32-lowercase multibase `b…` form and strictly
+//!   recovers the binary anchor from a scope's `/ipfs/<head_cid>` record value.
 
 pub mod cid;
 pub mod seal;
 
-pub use cid::{CONTENT_CID_CODEC, CONTENT_CID_LEN, CONTENT_CID_MULTIHASH, compute_cid, verify_cid};
+pub use cid::{
+    CONTENT_CID_CODEC, CONTENT_CID_LEN, CONTENT_CID_MULTIHASH, compute_cid, decode_content_cid_str,
+    encode_content_cid_str, verify_cid,
+};
 pub use seal::{open_chunk, seal_chunk};

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -325,6 +325,14 @@ pub enum Malformed {
     /// slot, not a non-canonical encoding of a real name (the strict decode keeps
     /// the Rust side fail-closed).
     IpnsNameMalformed,
+    /// A content-CID string was not the one canonical base32-lowercase multibase
+    /// (`b`-prefixed) CIDv1 with the frozen content-plane framing (version 1, a
+    /// single-byte multicodec, the BLAKE3 multihash code, 32-byte digest length):
+    /// wrong/missing multibase prefix, a non-base32 or non-canonical body, a wrong
+    /// length, or wrong framing bytes. *Malformed*: foreign bytes in a content-CID
+    /// slot, not a non-canonical encoding of a real CID — the strict decode keeps
+    /// the recovered head anchor fail-closed before a fetch trusts it.
+    ContentCidStrMalformed,
     /// An IPNS record's protobuf could not be parsed, or it was missing a field
     /// the V2 verify chain requires (`value`, `signatureV2`, or `data`), or its
     /// `data` field was not the frozen det-CBOR shape. *Malformed*: structurally
@@ -358,6 +366,7 @@ impl Malformed {
         "invalid-permission",
         "invalid-field-length",
         "ipns-name-malformed",
+        "content-cid-str-malformed",
         "ipns-record-malformed",
     ];
 
@@ -384,6 +393,7 @@ impl Malformed {
             Self::InvalidPermission => "invalid-permission",
             Self::InvalidFieldLength { .. } => "invalid-field-length",
             Self::IpnsNameMalformed => "ipns-name-malformed",
+            Self::ContentCidStrMalformed => "content-cid-str-malformed",
             Self::IpnsRecordMalformed => "ipns-record-malformed",
         }
     }
@@ -421,6 +431,7 @@ impl fmt::Display for Malformed {
             | Self::InvalidNodeKind
             | Self::InvalidPermission
             | Self::IpnsNameMalformed
+            | Self::ContentCidStrMalformed
             | Self::IpnsRecordMalformed => Ok(()),
         }
     }

--- a/crates/core/src/seal/envelope.rs
+++ b/crates/core/src/seal/envelope.rs
@@ -72,6 +72,19 @@ pub fn decode_envelope(bytes: &[u8]) -> Result<Envelope, CodecError> {
     })
 }
 
+/// The `grantSection` bytes carried in the envelope's preserved unknown
+/// top-level fields (#27 D10 — `grantSection` rides `unknown`, never a typed
+/// field, so an envelope stays kind-uniform and byte-stable on rewrite). A
+/// non-crypto accessor: it hands the raw section bytes to the caller (see
+/// [`super::decode_grant_section`]) so the engine never matches raw `Value`s.
+/// `None` when the field is absent or not a byte string.
+pub fn grant_section_bytes(env: &Envelope) -> Option<&[u8]> {
+    env.unknown
+        .iter()
+        .find(|(key, _)| key == "grantSection")
+        .and_then(|(_, value)| value.as_bytes().ok())
+}
+
 /// Encode an envelope to its canonical det-CBOR plaintext.
 pub fn encode_envelope(env: &Envelope) -> Vec<u8> {
     let mut epoch_tag = Map::new();
@@ -243,6 +256,38 @@ mod tests {
         assert_eq!(encode_envelope(&decoded), bytes, "unknown field preserved");
         // The read-body still opens despite the extra field.
         assert!(open_read_body(&decoded, &key).is_ok());
+    }
+
+    #[test]
+    fn grant_section_bytes_pulls_the_unknown_field() {
+        let key = [3u8; KEY_LEN];
+        let nonce = [4u8; NONCE_LEN];
+        let mut env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &folder()).unwrap();
+        assert_eq!(grant_section_bytes(&env), None, "absent without the field");
+
+        env.unknown.push((
+            "grantSection".to_string(),
+            Value::Bytes(b"section-bytes".to_vec()),
+        ));
+        assert_eq!(
+            grant_section_bytes(&env),
+            Some(b"section-bytes".as_slice()),
+            "pulls the grantSection bytes out of unknown"
+        );
+    }
+
+    #[test]
+    fn grant_section_bytes_none_when_not_a_byte_string() {
+        let key = [3u8; KEY_LEN];
+        let nonce = [4u8; NONCE_LEN];
+        let mut env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &folder()).unwrap();
+        env.unknown
+            .push(("grantSection".to_string(), Value::Unsigned(7)));
+        assert_eq!(
+            grant_section_bytes(&env),
+            None,
+            "a non-bytes grantSection is not returned"
+        );
     }
 
     #[test]

--- a/crates/core/src/seal/mod.rs
+++ b/crates/core/src/seal/mod.rs
@@ -29,7 +29,9 @@ pub use aad::{
 pub use body::{
     ChildRef, NodeKind, ReadBody, Version, decode_read_body, encode_read_body, name_cmp,
 };
-pub use envelope::{Envelope, decode_envelope, encode_envelope, open_read_body, seal_read_body};
+pub use envelope::{
+    Envelope, decode_envelope, encode_envelope, grant_section_bytes, open_read_body, seal_read_body,
+};
 pub use grant::{
     AscentLink, GrantBlobPayload, GrantSetCommitment, GrantSetEntry, HistoryLinkPayload,
     OverrideSeedPayload, OwnerWriteBlobPayload, Permission, decode_ascent_link,

--- a/crates/core/tests/kat_manifest.rs
+++ b/crates/core/tests/kat_manifest.rs
@@ -18,8 +18,8 @@ use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use cipherbox_core::codec::{decode, decode_map_partial, encode, encode_map_partial};
 use cipherbox_core::content::{
-    CONTENT_CID_CODEC, CONTENT_CID_LEN, CONTENT_CID_MULTIHASH, compute_cid, open_chunk, seal_chunk,
-    verify_cid,
+    CONTENT_CID_CODEC, CONTENT_CID_LEN, CONTENT_CID_MULTIHASH, compute_cid, decode_content_cid_str,
+    encode_content_cid_str, open_chunk, seal_chunk, verify_cid,
 };
 use cipherbox_core::error::{Malformed, TrustViolation};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
@@ -232,6 +232,14 @@ const FIXTURES: &[(&str, &str)] = &[
         "vectors/content/cid_reject.json",
         include_str!("../kat/vectors/content/cid_reject.json"),
     ),
+    (
+        "vectors/content/cid_str_accept.json",
+        include_str!("../kat/vectors/content/cid_str_accept.json"),
+    ),
+    (
+        "vectors/content/cid_str_reject.json",
+        include_str!("../kat/vectors/content/cid_str_reject.json"),
+    ),
 ];
 
 // ---------------------------------------------------------------------------
@@ -265,6 +273,16 @@ struct ContentManifest {
     seal_reject: RejectSection,
     cid: FileCount,
     cid_reject: RejectSection,
+    cid_str_accept: FileCount,
+    cid_str_reject: RejectSection,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ContentCidStrAcceptVector {
+    name: String,
+    cid: String,
+    cid_str: String,
 }
 
 #[derive(Deserialize)]
@@ -953,6 +971,16 @@ fn content_cid_reject_vectors(m: &Manifest) -> Vec<ContentCidRejectVector> {
         .expect("content cid_reject.json shape")
 }
 
+fn content_cid_str_accept_vectors(m: &Manifest) -> Vec<ContentCidStrAcceptVector> {
+    serde_json::from_str(fixture(&m.content.cid_str_accept.file))
+        .expect("content cid_str_accept.json shape")
+}
+
+fn content_cid_str_reject_vectors(m: &Manifest) -> Vec<TextRejectVector> {
+    serde_json::from_str(fixture(&m.content.cid_str_reject.file))
+        .expect("content cid_str_reject.json shape")
+}
+
 fn read_body_accept_vectors(m: &Manifest) -> Vec<ReadBodyAcceptVector> {
     serde_json::from_str(fixture(&m.seal.read_body_accept.file))
         .expect("read_body_accept.json shape")
@@ -1143,6 +1171,8 @@ fn fixture_table_matches_manifest_files() {
         m.content.seal_reject.file.as_str(),
         m.content.cid.file.as_str(),
         m.content.cid_reject.file.as_str(),
+        m.content.cid_str_accept.file.as_str(),
+        m.content.cid_str_reject.file.as_str(),
     ];
     let referenced_set: BTreeSet<&str> = referenced.iter().copied().collect();
     assert_eq!(
@@ -1329,6 +1359,12 @@ fn every_crate_check_is_pinned_by_a_vector_family() {
     // families pin `seal-open-failed`/`truncated` and `content-cid-mismatch`.
     covered.extend(content_seal_reject_vectors(&m).into_iter().map(|v| v.check));
     covered.extend(content_cid_reject_vectors(&m).into_iter().map(|v| v.check));
+    // The content-CID string codec's strict decode pins `content-cid-str-malformed`.
+    covered.extend(
+        content_cid_str_reject_vectors(&m)
+            .into_iter()
+            .map(|v| v.check),
+    );
 
     let surface: BTreeSet<String> = TrustViolation::CHECKS
         .iter()
@@ -3899,5 +3935,100 @@ fn content_cid_reject_vectors_fail_closed() {
             v.name
         );
         assert_eq!(err.class(), v.class, "content cid-reject {}: class", v.name);
+    }
+}
+
+#[test]
+fn content_cid_str_accept_vectors_round_trip() {
+    let m = manifest();
+    let vectors = content_cid_str_accept_vectors(&m);
+    assert_eq!(
+        vectors.len(),
+        m.content.cid_str_accept.count,
+        "content cid-str-accept count drift"
+    );
+    assert!(
+        !vectors.is_empty(),
+        "content cid-str-accept family must not be empty"
+    );
+
+    let mut names = BTreeSet::new();
+    for v in &vectors {
+        assert!(
+            names.insert(v.name.clone()),
+            "duplicate content cid-str {}",
+            v.name
+        );
+        let cid = unhex(&v.name, &v.cid);
+        // Encode: the binary CID renders to its one canonical base32-lower string.
+        assert_eq!(
+            encode_content_cid_str(&cid),
+            v.cid_str,
+            "content cid-str {}: encode drift",
+            v.name
+        );
+        assert!(
+            v.cid_str.starts_with('b'),
+            "content cid-str {}: base32 multibase prefix",
+            v.name
+        );
+        // Strict decode recovers the binary anchor byte-for-byte.
+        let decoded = decode_content_cid_str(&v.cid_str)
+            .unwrap_or_else(|e| panic!("content cid-str {}: decode rejected: {e}", v.name));
+        assert_eq!(decoded, cid, "content cid-str {}: decode drift", v.name);
+    }
+}
+
+#[test]
+fn content_cid_str_reject_vectors_fail_closed() {
+    let m = manifest();
+    let vectors = content_cid_str_reject_vectors(&m);
+    assert_eq!(
+        vectors.len(),
+        m.content.cid_str_reject.count,
+        "content cid-str-reject count drift"
+    );
+    assert!(
+        !vectors.is_empty(),
+        "content cid-str-reject family must not be empty"
+    );
+
+    let listed: BTreeSet<&str> = m
+        .content
+        .cid_str_reject
+        .checks
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let in_vectors: BTreeSet<&str> = vectors.iter().map(|v| v.check.as_str()).collect();
+    assert_eq!(
+        listed, in_vectors,
+        "manifest checks vs content cid_str_reject.json"
+    );
+    assert!(
+        listed.contains("content-cid-str-malformed"),
+        "content cid-str-reject covers content-cid-str-malformed"
+    );
+
+    let mut names = BTreeSet::new();
+    for v in &vectors {
+        assert!(
+            names.insert(v.name.clone()),
+            "duplicate content cid-str-reject {}",
+            v.name
+        );
+        let err = decode_content_cid_str(&v.text).expect_err("cid-str-reject must fail closed");
+        assert_eq!(
+            err.check(),
+            v.check,
+            "content cid-str-reject {}: check ({err})",
+            v.name
+        );
+        assert_eq!(
+            err.class(),
+            v.class,
+            "content cid-str-reject {}: class",
+            v.name
+        );
     }
 }

--- a/crates/engine/src/api/signer.rs
+++ b/crates/engine/src/api/signer.rs
@@ -42,6 +42,12 @@ impl IdentityChallengeSigner {
     pub fn from_scalar(scalar: &[u8; 32]) -> Option<Self> {
         EcdsaSigner::from_scalar(scalar).map(|signer| Self { signer })
     }
+
+    /// Adopts the session's already-derived identity signer, so cold-start
+    /// login reuses the derived key instead of re-reading the raw login secret.
+    pub fn from_signer(signer: EcdsaSigner) -> Self {
+        Self { signer }
+    }
 }
 
 impl ChallengeSigner for IdentityChallengeSigner {

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -31,7 +31,8 @@ pub use provider::{
     ByoIpfsConfig, ByoKind, PinMode, ProviderError, test_connection, validate_endpoint,
 };
 pub use read::{
-    ContentPlane, Gateway, GatewaySource, ReadError, leaf_range_for_byte_range, read_block,
+    ContentPlane, Gateway, GatewayConfig, GatewaySource, ReadError, leaf_range_for_byte_range,
+    read_block,
 };
 pub use retention::{ContentVersion, PrunePlan, QuotaExceeded, plan_prune, pre_flight_quota_check};
 

--- a/crates/engine/src/content/read.rs
+++ b/crates/engine/src/content/read.rs
@@ -90,6 +90,40 @@ impl Gateway {
     }
 }
 
+/// The content-gateway configuration handed to [`Engine::new`](crate::Engine),
+/// resolved into a [`Gateway`] once at construction. [`disabled`](Self::disabled)
+/// yields an empty source set whose reads fail closed as
+/// [`ReadError::Unavailable`] (retryable availability, never a trust violation) —
+/// the dormant default until the host supplies real endpoints.
+///
+/// `Debug` derives the redaction from [`GatewaySource`]: the bearer never renders.
+#[derive(Clone, Debug)]
+pub struct GatewayConfig {
+    /// The member accelerator (token-authed), consulted first when present.
+    pub accelerator: Option<GatewaySource>,
+    /// Public trustless-gateway fallbacks, tried in order after the accelerator.
+    pub public_fallbacks: Vec<GatewaySource>,
+}
+
+impl GatewayConfig {
+    /// The dormant default: no accelerator, no fallbacks. Reads over the
+    /// resulting [`Gateway`] fail closed as [`ReadError::Unavailable`].
+    pub fn disabled() -> Self {
+        Self {
+            accelerator: None,
+            public_fallbacks: Vec::new(),
+        }
+    }
+
+    /// Resolve into the read-plane [`Gateway`], preserving accelerator-first order.
+    pub fn into_gateway(self) -> Gateway {
+        Gateway {
+            accelerator: self.accelerator,
+            public_fallbacks: self.public_fallbacks,
+        }
+    }
+}
+
 /// Why a verified read did not return bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReadError {
@@ -639,6 +673,63 @@ mod tests {
         assert!(
             !debug.contains("super-secret-token"),
             "bearer must never render"
+        );
+        assert!(debug.contains("<redacted>"));
+    }
+
+    fn a_config() -> GatewayConfig {
+        GatewayConfig {
+            accelerator: Some(GatewaySource {
+                base_url: "https://gw.cipherbox.test/".into(),
+                bearer: Some(Zeroizing::new("member-token".to_owned())),
+            }),
+            public_fallbacks: vec![GatewaySource {
+                base_url: "https://public.gw.test".into(),
+                bearer: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn disabled_gateway_config_yields_an_empty_gateway() {
+        // No source: reads fail closed as availability, never a trust violation.
+        let gateway = GatewayConfig::disabled().into_gateway();
+        let leaf = one_leaf();
+        let http = ScriptedHttp::default();
+        let err = block_on(read_block(
+            &gateway,
+            &http,
+            &cid_str(),
+            &leaf.cid,
+            ContentPlane::Leaf,
+        ))
+        .unwrap_err();
+        assert_eq!(err, ReadError::Unavailable);
+        assert!(
+            http.requests().is_empty(),
+            "an empty gateway consults no source"
+        );
+    }
+
+    #[test]
+    fn gateway_config_round_trips_source_ordering() {
+        let gateway = a_config().into_gateway();
+        let urls: Vec<_> = gateway.sources().map(|s| s.base_url.as_str()).collect();
+        assert_eq!(
+            urls,
+            vec!["https://gw.cipherbox.test/", "https://public.gw.test"],
+            "accelerator-first ordering is preserved"
+        );
+    }
+
+    #[test]
+    fn gateway_config_debug_never_renders_the_bearer() {
+        // Release-active behavioral assert (not a debug_assert): the derived
+        // `Debug` inherits `GatewaySource`'s redaction.
+        let debug = format!("{:?}", a_config());
+        assert!(
+            !debug.contains("member-token"),
+            "bearer must never render in GatewayConfig Debug"
         );
         assert!(debug.contains("<redacted>"));
     }

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -22,6 +22,7 @@ use core::fmt;
 use core::pin::Pin;
 use std::rc::Rc;
 
+use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
 use futures_channel::mpsc;
 use futures_core::Stream;
@@ -32,8 +33,9 @@ use crate::content::{Gateway, GatewayConfig};
 use crate::entropy::Entropy;
 use crate::hex::hex_lower;
 use crate::net::{
-    Adopter, EolRenewResult, HeldRecord, HeldRecords, LivenessControl, PublishError,
-    PublishOutcome, RE_PUT_INTERVAL, eol_renew_pass, keyless_re_put, run_liveness_loop,
+    Adopter, EolRenewResult, HeldMaterial, HeldRecord, HeldRecords, LivenessControl, PublishError,
+    PublishOutcome, RE_PUT_INTERVAL, RecordPointerFetch, RootAdopter, eol_renew_pass,
+    keyless_re_put, resolve_and_hold, run_liveness_loop,
 };
 use crate::profile::SyncTimingProfile;
 use crate::seams::{OpId, Scheduler, SeamError, SeamSet, SeamTypes, StagingStore};
@@ -396,6 +398,16 @@ pub enum EngineError {
         /// Diagnostic message; never carries key material.
         message: String,
     },
+    /// The cold-start data path hit a fail-closed trust violation — a forged
+    /// vault pointer, a regressed floor, or a root record the adoption gate
+    /// rejected. `start` returns before spawning any background loop; the engine
+    /// renders nothing past an unadopted root (rules 4/6). Distinct from
+    /// [`Seam`](EngineError::Seam): never retryable availability. The message
+    /// carries the verdict classification, never key material.
+    ColdStart {
+        /// Diagnostic message; never carries key material.
+        message: String,
+    },
 }
 
 impl EngineError {
@@ -408,6 +420,21 @@ impl EngineError {
     fn from_api(err: ApiError) -> Self {
         EngineError::Auth {
             message: err.to_string(),
+        }
+    }
+
+    /// Map a cold-start failure onto the facade error. A host seam stays
+    /// availability; the caller-ordering precondition maps verbatim; every trust
+    /// arm (forged pointer, regressed floor, rejected root) surfaces as the
+    /// fail-closed [`ColdStart`](EngineError::ColdStart) — never retryable
+    /// availability.
+    fn from_cold_start(err: ColdStartError) -> Self {
+        match err {
+            ColdStartError::Seam(seam) => EngineError::from_seam(seam),
+            ColdStartError::NotStarted => EngineError::NotStarted,
+            trust => EngineError::ColdStart {
+                message: trust.to_string(),
+            },
         }
     }
 }
@@ -426,6 +453,7 @@ impl fmt::Display for EngineError {
             EngineError::Seam { message } => write!(f, "seam error: {message}"),
             EngineError::Entropy { message } => write!(f, "entropy error: {message}"),
             EngineError::Auth { message } => write!(f, "auth error: {message}"),
+            EngineError::ColdStart { message } => write!(f, "cold-start failed: {message}"),
         }
     }
 }
@@ -550,6 +578,13 @@ fn count_nodes(snapshot: &Snapshot) -> u64 {
     seen.len() as u64
 }
 
+/// The re-point pointer-payload wire version the owner's own vault seals under
+/// and the cold-start walk verifies against (`crates/core` pointer payload) — the
+/// sole v2 version. The vault's own root scope and root node are the anchored
+/// all-zero `id16`: the bootstrap anchor a cold start knows from the login secret
+/// alone, before any record resolves (CONTEXT.md "Vault pointer").
+const POINTER_PAYLOAD_VERSION: u64 = 1;
+
 /// The engine — the single stateful brain behind the facade.
 ///
 /// Constructed over the whole seam set (missing seam = compile error), an
@@ -569,8 +604,8 @@ pub struct Engine<T: SeamTypes> {
     /// The resolved content read-source set, built once from the injected
     /// [`GatewayConfig`] at construction. Empty (dormant) until the host supplies
     /// endpoints; reads then fail closed as [`ReadError`](crate::ReadError)`::Unavailable`.
-    // Consumed by start()/RootAdopter (E4).
-    #[allow(dead_code)]
+    /// Read by the cold-start [`RootAdopter`] and the resolve-tick driver's
+    /// per-pass adopter.
     gateway: Gateway,
     events: mpsc::UnboundedSender<Event>,
     /// The last-known-good gate-passing base snapshot (state law's left
@@ -653,6 +688,7 @@ impl<T: SeamTypes> Engine<T> {
         T::Http: Clone + 'static,
         T::CredentialStore: Clone + 'static,
         T::FloorStore: Clone + 'static,
+        T::SnapshotCache: Clone + 'static,
     {
         if self.started {
             return Err(EngineError::AlreadyStarted);
@@ -684,7 +720,54 @@ impl<T: SeamTypes> Engine<T> {
         }
 
         self.session = Some(session);
+
+        // Cold-start data path (E4/E7): resolve the owner vault pointer, cold-seed
+        // the floors, adopt the current root through the gate, and project its base
+        // snapshot — all off the production `RecordPointerFetch`/`RootAdopter` over
+        // the engine's own gateway/seams. Fail-closed: a trust violation returns
+        // here, before either background loop spawns, so nothing runs past an
+        // unadopted root (rules 4/6). An empty chain (a first-run vault with no
+        // pointer yet) degrades to the anchored root with no error. The adopter and
+        // pointer fetch borrow `&self`, so they live only inside this block and
+        // release before the base snapshot is assigned.
+        let outcome = {
+            let session = self.session.as_ref().expect("session set above");
+            let owner_identity = session.owner_identity();
+            let root = self.snapshot.root;
+            let root_scope_id = root.0;
+            let pointer_fetch = RecordPointerFetch::new(&self.seams.record_transport);
+            let adopter = RootAdopter::new(
+                &self.gateway,
+                &self.seams.http,
+                &self.seams.floor_store,
+                session.enc_subkey(),
+                &owner_identity,
+                root_scope_id,
+            );
+            self.cold_start_data_path(
+                &pointer_fetch,
+                &adopter,
+                &owner_identity,
+                root_scope_id,
+                POINTER_PAYLOAD_VERSION,
+                root,
+            )
+            .await
+            .map_err(EngineError::from_cold_start)?
+        };
+
+        // The gate-passing base becomes the state law's left operand (reads render
+        // this ⊕ the pending-op overlay). The resolved root name — the vault
+        // pointer's `currentRoot` — drives the resolve-tick loop; `None` on an
+        // empty chain, where the tick loop stays a dormant no-op.
+        let root_name = outcome
+            .vault_pointer
+            .as_ref()
+            .map(|vp| vp.repoint.current_root.clone());
+        self.snapshot = outcome.base;
+
         self.spawn_liveness_loop(api.clone());
+        self.spawn_resolve_tick_loop(root_name);
         self.api = Some(api);
         self.started = true;
         Ok(())
@@ -719,12 +802,11 @@ impl<T: SeamTypes> Engine<T> {
     ///
     /// `owner_identity` is the auth-provided contact-code-anchored identity that
     /// signs the re-point object — the vault-pointer walk's fail-closed anchor.
-    // Live composition consumed by the facade cold-start test; the resolver slice
-    // (#745/#746) supplies the concrete `PointerFetch`/`Adopter` at the `start`
-    // call site.
-    #[allow(dead_code)]
+    // Takes `&self`: `start` runs the production `RootAdopter`/`RecordPointerFetch`
+    // through it while they borrow the engine's own gateway/seams — a `&mut self`
+    // receiver would alias those shared borrows.
     pub(crate) async fn cold_start_data_path<Pf, Ad>(
-        &mut self,
+        &self,
         pointer_fetch: &Pf,
         adopter: &Ad,
         owner_identity: &EcdsaVerifier,
@@ -838,6 +920,85 @@ impl<T: SeamTypes> Engine<T> {
                 let renewals =
                     eol_renew_pass(&transport, &api, &floors, &scheduler, &profile, &records).await;
                 emit_renewal_failures(&events, &renewals);
+                LivenessControl::Continue
+            })
+            .await;
+        }));
+    }
+
+    /// Spawn the fixed-cadence resolve-tick driver (blueprint/engine.md
+    /// "Resolve/publish pipeline", "Liveness"): each pass re-resolves the owner
+    /// root through the adoption gate and inserts the gate-passing record into the
+    /// held set the liveness loop keeps alive. Fixed cadence off the injected
+    /// scheduler's focus-window `poll_cadence` — the determinism law's only time
+    /// source is `scheduler.sleep`, so it holds under virtual time. The task holds
+    /// only `Rc`/seam-handle clones and the alive latch, so it stops once the
+    /// engine drops.
+    ///
+    /// `root_name` is the vault pointer's resolved `currentRoot`; `None` (an empty
+    /// chain) spawns nothing — there is no root to poll until a later start
+    /// rediscovers one.
+    fn spawn_resolve_tick_loop(&self, root_name: Option<IpnsName>)
+    where
+        T::Scheduler: Clone + 'static,
+        T::RecordTransport: Clone + 'static,
+        T::Http: Clone + 'static,
+        T::FloorStore: Clone + 'static,
+        T::SnapshotCache: Clone + 'static,
+    {
+        let (Some(root_name), Some(session)) = (root_name, self.session.clone()) else {
+            return;
+        };
+        let scheduler = self.seams.scheduler.clone();
+        let transport = self.seams.record_transport.clone();
+        let snapshot_cache = self.seams.snapshot_cache.clone();
+        let floors = self.seams.floor_store.clone();
+        let http = self.seams.http.clone();
+        let gateway = self.gateway.clone();
+        let held = self.held_records.clone();
+        let alive = self.alive.clone();
+        let interval = self.profile.poll_cadence;
+        let owner_identity = session.owner_identity();
+        // The vault's own root scope and root node are the anchored all-zero id16
+        // (the cold-start bootstrap anchor): the adopter's scope binding and the
+        // held-set fallback key.
+        let root_id = self.snapshot.root.0;
+
+        self.seams.scheduler.spawn(Box::pin(async move {
+            run_liveness_loop(&scheduler, interval, || async {
+                if !alive.get() {
+                    return LivenessControl::Stop;
+                }
+                // Rebuild the owner-root adopter from the Rc'd session + task-owned
+                // seams each pass (the adopter borrows; the task owns the clones).
+                let adopter = RootAdopter::new(
+                    &gateway,
+                    &http,
+                    &floors,
+                    session.enc_subkey(),
+                    &owner_identity,
+                    root_id,
+                );
+                // Own-root material: the write-scope seed the owner cannot
+                // re-derive rides the adopt (recovered from the owner-write-blob),
+                // so the caller-side seed is `None` and the gate's authenticated
+                // node id keys the hold. A resolve/gate failure is availability —
+                // it never stops the loop (blueprint/engine.md "Liveness").
+                let material = HeldMaterial {
+                    node_id: root_id,
+                    write_scope_seed: None,
+                    head_cid: String::new(),
+                    content_cids: Vec::new(),
+                };
+                let _ = resolve_and_hold(
+                    &transport,
+                    &snapshot_cache,
+                    &adopter,
+                    &root_name,
+                    &held,
+                    &material,
+                )
+                .await;
                 LivenessControl::Continue
             })
             .await;
@@ -1600,7 +1761,7 @@ mod tests {
             world.scheduler.advance_to(clock);
             let device = world.device(b"alice-pk");
             seed_root_record(&device);
-            let (mut engine, events) = Engine::new(
+            let (mut engine, mut events) = Engine::new(
                 device.seam_set(),
                 Box::new(SeededEntropy::new(42)),
                 SyncTimingProfile::CI,
@@ -1608,6 +1769,11 @@ mod tests {
                 GatewayConfig::disabled(),
             );
             block_on(engine.start(LoginSecret::new(SECRET.to_vec()))).unwrap();
+            // `start` runs its own cold start over the (unseeded) record store: an
+            // empty vault-pointer chain paints once. These tests then drive
+            // `cold_start_data_path` directly against the scripted pointers, so
+            // drain that incidental first paint to isolate the driven stream.
+            assert_eq!(block_on(events.next()), Some(Event::SnapshotUpdated));
             let pointers = ScriptedPointers::default();
             pointers.seal_index(0, 1, 1);
             pointers.seal_index(1, 3, 2);
@@ -1664,7 +1830,7 @@ mod tests {
 
         #[test]
         fn before_start_returns_not_started_not_panic() {
-            let (mut engine, _events) = new_engine();
+            let (engine, _events) = new_engine();
             assert!(engine.session().is_none(), "no identity before start");
             let out = block_on(engine.cold_start_data_path(
                 &ScriptedPointers::default(),
@@ -1685,7 +1851,7 @@ mod tests {
             let world = FakeWorld::new();
             let device = world.device(b"alice-pk");
             device.staging_store.fail_queued_ops();
-            let (mut engine, _events) = Engine::new(
+            let (engine, _events) = Engine::new(
                 device.seam_set(),
                 Box::new(SeededEntropy::new(42)),
                 SyncTimingProfile::CI,
@@ -1769,7 +1935,7 @@ mod tests {
 
         #[test]
         fn remove_op_failure_after_send_re_surfaces_the_dead_letter_next_boot() {
-            let (mut engine, mut events, pointers) = started_at(UnixMillis(123_456));
+            let (engine, mut events, pointers) = started_at(UnixMillis(123_456));
             block_on(engine.seams.staging_store.enqueue_op(b"not-a-valid-op")).expect("enqueue");
             // Send lands in the buffer but the durable removal fails: the gated
             // `?` aborts cold-start with `Seam` before the paint, leaving the op
@@ -1814,6 +1980,437 @@ mod tests {
             assert_eq!(
                 block_on(events.next()),
                 Some(Event::DeadLetter { op_id: OpId(1) })
+            );
+        }
+    }
+
+    // --- capstone: start() cold-start orchestration + resolve-tick driver ---
+
+    mod capstone {
+        use super::*;
+
+        use core::task::{Context, Poll, Waker};
+
+        use cipherbox_core::codec::Value;
+        use cipherbox_core::content::{compute_cid, encode_content_cid_str};
+        use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+        use cipherbox_core::kdf;
+        use cipherbox_core::payload::RepointObject;
+        use cipherbox_core::seal::{
+            AadContext, ChildRef, GrantSection, GrantSetCommitment, NodeKind as CoreNodeKind,
+            OverrideSeedPayload, OwnerWriteBlobPayload, ReadBody, STRUCT_TAG_OWNER_BLOB,
+            STRUCT_TAG_OWNER_WRITE_BLOB, STRUCT_TAG_WRITE_BODY, SignedOwnerBlob,
+            SignedOwnerWriteBlob, SignedSealed, StructureSigInput, WriteBody, encode_envelope,
+            encode_grant_section, encode_write_body, seal, seal_owner_blob, seal_owner_write_blob,
+            seal_read_body, sign_grant_set, sign_structure,
+        };
+        use cipherbox_core::suite::ecdsa::EcdsaSigner;
+        use cipherbox_core::suite::ed25519::Ed25519Signer;
+
+        use crate::content::{DAG_ROOT_CODEC, GatewaySource};
+        use crate::net::RE_PUT_INTERVAL;
+        use crate::seams::{BoxedTask, EndpointId, RecordTransport};
+        use crate::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
+        use crate::testkit::FakeDevice;
+
+        const CAP_SECRET: [u8; 32] = [7u8; 32];
+        const SCOPE: [u8; 16] = [0u8; 16];
+        const ROOT: NodeId = NodeId([0u8; 16]);
+        const CHILD_ID: [u8; 16] = [0x2C; 16];
+        const CHILD_NAME: &str = "hello.txt";
+        const SCOPE_SEED: [u8; 32] = [0x66; 32];
+        const WRITE_SCOPE_SEED: [u8; 32] = [0x77; 32];
+        const EPOCH: u64 = 1;
+        const TTL_NANOS: u64 = 2_000_000_000;
+        const EOL: &str = "2099-01-01T00:00:00Z";
+
+        fn owner_identity() -> EcdsaSigner {
+            EcdsaSigner::from_scalar(&CAP_SECRET).expect("valid scalar")
+        }
+
+        /// The owner-root head block (one child) and its content-CID string, plus
+        /// the root record's write-plane IPNS name. Keyed off `CAP_SECRET` so the
+        /// engine's session-derived owner identity + enc subkey open it, and scoped
+        /// to the all-zero bootstrap anchor (`SCOPE`/`ROOT`) so `start`'s cold-start
+        /// scope binding matches. Mirrors the E2 `RootAdopter` head-block fixture.
+        fn owner_root() -> (Vec<u8>, String, IpnsName) {
+            let owner_identity = owner_identity();
+            let owner_pseudonym = Ed25519Signer::from_seed([0x22; 32]);
+            let owner_enc = kdf::enc_subkey(&CAP_SECRET);
+
+            let node_seed = kdf::node_seed(&SCOPE_SEED, &ROOT.0);
+            let read_key = *kdf::read_key(node_seed.as_bytes()).as_bytes();
+            let write_seed = kdf::write_seed(&WRITE_SCOPE_SEED, &ROOT.0);
+            let name = IpnsName::from_public_key(
+                &kdf::ipns_keypair(write_seed.as_bytes()).verifying_key(),
+            );
+            let write_key = kdf::write_key(write_seed.as_bytes());
+
+            let sign = |tag: u8, ct: &[u8]| -> [u8; 64] {
+                let input = StructureSigInput::over_ciphertext(SCOPE, EPOCH, tag, None, ct);
+                sign_structure(&owner_pseudonym, &input).to_bytes()
+            };
+
+            let owner_blob_aad = AadContext {
+                v: 1,
+                id: ROOT.0,
+                scope: SCOPE,
+                epoch: EPOCH,
+                struct_tag: STRUCT_TAG_OWNER_BLOB,
+            };
+            let sealed_owner = seal_owner_blob(
+                &owner_enc.public(),
+                &[3u8; 32],
+                &owner_blob_aad,
+                &OverrideSeedPayload::new(SCOPE_SEED, EPOCH),
+            );
+            let owner_blob = SignedOwnerBlob {
+                signature: sign(STRUCT_TAG_OWNER_BLOB, &sealed_owner.ciphertext),
+                enc: sealed_owner.enc,
+                ciphertext: sealed_owner.ciphertext.clone(),
+                unknown: Vec::new(),
+            };
+
+            let write_body_aad = AadContext {
+                v: 1,
+                id: ROOT.0,
+                scope: SCOPE,
+                epoch: EPOCH,
+                struct_tag: STRUCT_TAG_WRITE_BODY,
+            };
+            let write_body_sealed = seal(
+                write_key.as_bytes(),
+                &[22u8; 24],
+                &write_body_aad,
+                &encode_write_body(&WriteBody {
+                    grant_ledger: Vec::new(),
+                    write_history_link: Vec::new(),
+                    direct_child_scope_index: Vec::new(),
+                    unknown: Vec::new(),
+                })
+                .unwrap(),
+            );
+            let write_body = SignedSealed {
+                signature: sign(STRUCT_TAG_WRITE_BODY, &write_body_sealed),
+                sealed: write_body_sealed,
+                unknown: Vec::new(),
+            };
+
+            // Owner-write-blob at the read epoch (write plane == read plane here), so
+            // the cold-seeded write floor opens it and the owner recovers its
+            // write-scope seed for the held-set renewal signer.
+            let owb_aad = AadContext {
+                v: 1,
+                id: ROOT.0,
+                scope: SCOPE,
+                epoch: EPOCH,
+                struct_tag: STRUCT_TAG_OWNER_WRITE_BLOB,
+            };
+            let sealed_owb = seal_owner_write_blob(
+                &owner_enc.public(),
+                &[4u8; 32],
+                &owb_aad,
+                &OwnerWriteBlobPayload::new(WRITE_SCOPE_SEED, EPOCH),
+            );
+            let owner_write_blob = Some(SignedOwnerWriteBlob {
+                signature: sign(STRUCT_TAG_OWNER_WRITE_BLOB, &sealed_owb.ciphertext),
+                enc: sealed_owb.enc,
+                ciphertext: sealed_owb.ciphertext,
+                unknown: Vec::new(),
+            });
+
+            let commitment = GrantSetCommitment {
+                ipns_name: name.as_str().as_bytes().to_vec(),
+                owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
+                entries: Vec::new(),
+                unknown: Vec::new(),
+            };
+            let commitment_sig = sign_grant_set(&owner_identity, &commitment)
+                .unwrap()
+                .to_compact();
+            let grant_section = GrantSection {
+                commitment,
+                commitment_sig,
+                grant_blobs: Vec::new(),
+                owner_blob,
+                owner_write_blob,
+                ascent_link: None,
+                history_links: Vec::new(),
+                write_body,
+                unknown: Vec::new(),
+            };
+
+            let folder = ReadBody::Folder {
+                created_at: 0,
+                modified_at: 0,
+                children: vec![ChildRef {
+                    id: CHILD_ID,
+                    name: CHILD_NAME.into(),
+                    ipns_name: vec![0x2C],
+                    kind: CoreNodeKind::File,
+                    link_counter: 1,
+                    unknown: Vec::new(),
+                }],
+                unknown: Vec::new(),
+            };
+            let mut envelope =
+                seal_read_body(&read_key, &[11u8; 24], 1, ROOT.0, SCOPE, EPOCH, &folder).unwrap();
+            envelope.unknown.push((
+                "grantSection".to_string(),
+                Value::Bytes(encode_grant_section(&grant_section).unwrap()),
+            ));
+
+            let head_block = encode_envelope(&envelope);
+            let head_cid_str = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head_block));
+            (head_block, head_cid_str, name)
+        }
+
+        fn root_record(head_cid_str: &str, sequence: u64) -> Vec<u8> {
+            let write_seed = kdf::write_seed(&WRITE_SCOPE_SEED, &ROOT.0);
+            let signer = kdf::ipns_keypair(write_seed.as_bytes());
+            let value = format!("/ipfs/{head_cid_str}");
+            IpnsRecord::create_v2(&signer, value.as_bytes(), sequence, TTL_NANOS, EOL).marshal()
+        }
+
+        /// Seal + publish the owner vault pointer at index 0, its re-point naming
+        /// `root_name` and vouching the read/write floors the cold-seed adopts.
+        fn seed_vault_pointer(device: &FakeDevice, root_name: &IpnsName) {
+            let read_key =
+                kdf::pointer_read_key(kdf::owner_pointer_seed(&CAP_SECRET).as_bytes(), &SCOPE);
+            let mut entropy = SeededEntropy::new(0);
+            let block = seal_repoint(
+                SessionRole::Owner,
+                &mut entropy,
+                read_key.as_bytes(),
+                POINTER_PAYLOAD_VERSION,
+                &owner_identity(),
+                &RepointObject {
+                    scope_id: SCOPE,
+                    current_root: root_name.clone(),
+                    write_epoch: EPOCH,
+                    min_read_epoch: EPOCH,
+                    prev_root: None,
+                },
+            )
+            .unwrap();
+            let record = IpnsRecord::create_v2(
+                &kdf::vault_pointer_index(&CAP_SECRET, 0),
+                &block,
+                1,
+                TTL_NANOS,
+                EOL,
+            )
+            .marshal();
+            let pointer_name = vault_pointer_name(&CAP_SECRET, 0);
+            for endpoint in device.record_store.endpoints() {
+                device
+                    .record_store
+                    .seed_record(&endpoint, pointer_name.as_str(), record.clone());
+            }
+        }
+
+        fn seed_root_record_at(
+            device: &FakeDevice,
+            endpoint: &EndpointId,
+            name: &IpnsName,
+            head_cid_str: &str,
+        ) {
+            device
+                .record_store
+                .seed_record(endpoint, name.as_str(), root_record(head_cid_str, 1));
+        }
+
+        fn gateway_config() -> GatewayConfig {
+            GatewayConfig {
+                accelerator: Some(GatewaySource {
+                    base_url: "https://gw.test".into(),
+                    bearer: None,
+                }),
+                public_fallbacks: Vec::new(),
+            }
+        }
+
+        fn head_response(head_block: &[u8]) -> HttpResponse {
+            HttpResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: head_block.to_vec(),
+            }
+        }
+
+        fn engine_on(device: &FakeDevice) -> (Engine<FakeSeamTypes>, EventStream) {
+            Engine::new(
+                device.seam_set(),
+                Box::new(SeededEntropy::new(42)),
+                SyncTimingProfile::CI,
+                String::new(),
+                gateway_config(),
+            )
+        }
+
+        /// Poll every spawned loop task once with a no-op waker. Manual re-polls
+        /// drive the virtual clock's parked sleeps (the loops never yield inside a
+        /// pass over the synchronous fakes), so this is the sound driver for the
+        /// fire-and-forget loops — auto-advance would spin an infinite pass loop.
+        fn poll_each(tasks: &mut [BoxedTask]) -> Vec<Poll<()>> {
+            let mut cx = Context::from_waker(Waker::noop());
+            tasks.iter_mut().map(|t| t.as_mut().poll(&mut cx)).collect()
+        }
+
+        #[test]
+        fn start_with_empty_seams_is_a_graceful_noop() {
+            // The regression guard: empty seams (no vault pointer, no record) leave
+            // cold start an anchored-root no-op — start succeeds, no error, and the
+            // base is the all-zero root with no children.
+            let world = FakeWorld::new();
+            let device = world.device(b"alice-pk");
+            let (mut engine, _events) = engine_on(&device);
+            block_on(engine.start(LoginSecret::new(CAP_SECRET.to_vec())))
+                .expect("empty seams start cleanly");
+            assert_eq!(engine.root(), ROOT);
+            assert!(
+                block_on(engine.view()).unwrap().children(ROOT).is_empty(),
+                "an empty chain projects no children"
+            );
+        }
+
+        #[test]
+        fn start_assigns_the_projected_base_snapshot() {
+            let world = FakeWorld::new();
+            let device = world.device(b"alice-pk");
+            let (head_block, head_cid, root_name) = owner_root();
+            seed_vault_pointer(&device, &root_name);
+            for endpoint in device.record_store.endpoints() {
+                seed_root_record_at(&device, &endpoint, &root_name, &head_cid);
+            }
+            // The cold-start adopt fetches the head block once over the gateway.
+            device.http.enqueue_response(head_response(&head_block));
+
+            let (mut engine, _events) = engine_on(&device);
+            block_on(engine.start(LoginSecret::new(CAP_SECRET.to_vec())))
+                .expect("cold start adopts the owner root");
+
+            let view = block_on(engine.view()).unwrap();
+            let children = view.children(ROOT);
+            assert_eq!(
+                children.len(),
+                1,
+                "the projected base carries the root's child"
+            );
+            assert_eq!(children[0].id, NodeId(CHILD_ID));
+            assert_eq!(children[0].name, CHILD_NAME);
+            assert_eq!(children[0].kind, NodeKind::File);
+        }
+
+        #[test]
+        fn start_is_clock_independent() {
+            fn base_children(clock: UnixMillis) -> Vec<NodeAttrs> {
+                let world = FakeWorld::new();
+                world.scheduler.advance_to(clock);
+                let device = world.device(b"alice-pk");
+                let (head_block, head_cid, root_name) = owner_root();
+                seed_vault_pointer(&device, &root_name);
+                for endpoint in device.record_store.endpoints() {
+                    seed_root_record_at(&device, &endpoint, &root_name, &head_cid);
+                }
+                device.http.enqueue_response(head_response(&head_block));
+                let (mut engine, _events) = engine_on(&device);
+                block_on(engine.start(LoginSecret::new(CAP_SECRET.to_vec()))).unwrap();
+                block_on(engine.view()).unwrap().children(ROOT)
+            }
+            // Two engines whose virtual clocks sit far apart reach the identical
+            // projected base: cold start reads no clock.
+            assert_eq!(
+                base_children(UnixMillis(0)),
+                base_children(UnixMillis(5_000_000))
+            );
+        }
+
+        #[test]
+        fn resolve_tick_loop_populates_the_held_set() {
+            let world = FakeWorld::new();
+            let device = world.device(b"alice-pk");
+            let (head_block, head_cid, root_name) = owner_root();
+            // Vault pointer present (the root name is known and floors cold-seed),
+            // but no root record at boot: cold start resolves NoUpdate, so the
+            // sequence floor stays unset and the tick's later resolve is a fresh,
+            // gate-passing Adopt that surfaces the owner write seed.
+            seed_vault_pointer(&device, &root_name);
+            let (mut engine, _events) = engine_on(&device);
+            block_on(engine.start(LoginSecret::new(CAP_SECRET.to_vec()))).unwrap();
+            assert!(
+                engine.held_records.borrow().is_empty(),
+                "nothing held until the record appears"
+            );
+
+            // The record appears; drive one resolve-tick interval.
+            for endpoint in device.record_store.endpoints() {
+                seed_root_record_at(&device, &endpoint, &root_name, &head_cid);
+            }
+            device.http.enqueue_response(head_response(&head_block));
+
+            let mut tasks = world.scheduler.take_spawned_tasks();
+            poll_each(&mut tasks); // park each loop at its first sleep
+            world.scheduler.advance(engine.profile().poll_cadence);
+            poll_each(&mut tasks); // the resolve tick runs one pass
+
+            let held = engine.held_records.borrow();
+            assert_eq!(held.len(), 1, "the resolve tick held the owner root");
+            let record = held.get(&ROOT.0).expect("held under the root node id");
+            assert_eq!(record.routing_key, root_name.as_str());
+        }
+
+        #[test]
+        fn two_loops_coexist_and_stop_on_drop() {
+            let world = FakeWorld::new();
+            let device = world.device(b"alice-pk");
+            let (head_block, head_cid, root_name) = owner_root();
+            seed_vault_pointer(&device, &root_name);
+            let (mut engine, _events) = engine_on(&device);
+            block_on(engine.start(LoginSecret::new(CAP_SECRET.to_vec()))).unwrap();
+
+            let mut tasks = world.scheduler.take_spawned_tasks();
+            assert_eq!(
+                tasks.len(),
+                2,
+                "start spawns the liveness loop and the resolve-tick loop"
+            );
+
+            // Seed the record at only the first endpoint so the keyless re-PUT is
+            // observable when it propagates to the second.
+            let endpoints = device.record_store.endpoints();
+            seed_root_record_at(&device, &endpoints[0], &root_name, &head_cid);
+            device.http.enqueue_response(head_response(&head_block));
+
+            let mut cx = Context::from_waker(Waker::noop());
+            for task in &mut tasks {
+                let _ = task.as_mut().poll(&mut cx); // park both at their first sleep
+            }
+            // One hourly interval wakes both the 1 s tick and the 1 h re-PUT. Drive
+            // the tick first (it holds the root), then the keyless re-PUT.
+            world.scheduler.advance(RE_PUT_INTERVAL);
+            let _ = tasks[1].as_mut().poll(&mut cx); // resolve tick
+            let _ = tasks[0].as_mut().poll(&mut cx); // keyless re-PUT
+
+            assert!(
+                !engine.held_records.borrow().is_empty(),
+                "the resolve tick populated the held set"
+            );
+            assert!(
+                device
+                    .record_store
+                    .record_at(&endpoints[1], root_name.as_str())
+                    .is_some(),
+                "the keyless re-PUT propagated the held record to the second endpoint"
+            );
+
+            // Drop clears the alive latch; both loops stop at their next wake.
+            drop(engine);
+            world.scheduler.advance(RE_PUT_INTERVAL);
+            let after = poll_each(&mut tasks);
+            assert!(
+                after.iter().all(Poll::is_ready),
+                "both loops stop after the engine drops"
             );
         }
     }

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -28,6 +28,7 @@ use futures_core::Stream;
 use zeroize::Zeroizing;
 
 use crate::api::{ApiClient, ApiError, IdentityChallengeSigner};
+use crate::content::{Gateway, GatewayConfig};
 use crate::entropy::Entropy;
 use crate::hex::hex_lower;
 use crate::net::{
@@ -565,6 +566,12 @@ pub struct Engine<T: SeamTypes> {
     /// against. Empty until the auth/config slice supplies it; the register-first
     /// renewal is a no-op against an empty base until then.
     api_base_url: String,
+    /// The resolved content read-source set, built once from the injected
+    /// [`GatewayConfig`] at construction. Empty (dormant) until the host supplies
+    /// endpoints; reads then fail closed as [`ReadError`](crate::ReadError)`::Unavailable`.
+    // Consumed by start()/RootAdopter (E4).
+    #[allow(dead_code)]
+    gateway: Gateway,
     events: mpsc::UnboundedSender<Event>,
     /// The last-known-good gate-passing base snapshot (state law's left
     /// operand). Seeded at the anchored root; cold-start/resolve replace it
@@ -601,6 +608,7 @@ impl<T: SeamTypes> Engine<T> {
         entropy: Box<dyn Entropy>,
         profile: SyncTimingProfile,
         api_base_url: String,
+        gateway: GatewayConfig,
     ) -> (Self, EventStream) {
         let (events, receiver) = mpsc::unbounded();
         (
@@ -609,6 +617,7 @@ impl<T: SeamTypes> Engine<T> {
                 entropy,
                 profile,
                 api_base_url,
+                gateway: gateway.into_gateway(),
                 events,
                 // The anchored all-zero root until cold-start/resolve replaces
                 // the base snapshot; children come from the pending-op overlay.
@@ -1019,6 +1028,7 @@ mod tests {
             Box::new(SeededEntropy::new(42)),
             SyncTimingProfile::CI,
             base_url.to_owned(),
+            GatewayConfig::disabled(),
         );
         (engine, events, device)
     }
@@ -1030,6 +1040,7 @@ mod tests {
             Box::new(SeededEntropy::new(42)),
             SyncTimingProfile::CI,
             String::new(),
+            GatewayConfig::disabled(),
         )
     }
 
@@ -1044,6 +1055,7 @@ mod tests {
             Box::new(SeededEntropy::new(42)),
             SyncTimingProfile::CI,
             String::new(),
+            GatewayConfig::disabled(),
         );
         block_on(engine.start(LoginSecret::new(vec![secret_byte; 32]))).unwrap();
         engine
@@ -1593,6 +1605,7 @@ mod tests {
                 Box::new(SeededEntropy::new(42)),
                 SyncTimingProfile::CI,
                 String::new(),
+                GatewayConfig::disabled(),
             );
             block_on(engine.start(LoginSecret::new(SECRET.to_vec()))).unwrap();
             let pointers = ScriptedPointers::default();
@@ -1677,6 +1690,7 @@ mod tests {
                 Box::new(SeededEntropy::new(42)),
                 SyncTimingProfile::CI,
                 String::new(),
+                GatewayConfig::disabled(),
             );
             assert!(engine.session().is_none(), "no identity before start");
             let out = block_on(engine.cold_start_data_path(

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -734,6 +734,7 @@ impl<T: SeamTypes> Engine<T> {
         if !self.started {
             return Err(EngineError::NotStarted);
         }
+        let command_name = command.name();
         match command {
             Command::Create {
                 parent,
@@ -745,7 +746,9 @@ impl<T: SeamTypes> Engine<T> {
                 // staged bytes), a later slice; only metadata creates (folders
                 // and empty files) stage here.
                 if content.is_some() {
-                    return Err(EngineError::Unimplemented { command: "create" });
+                    return Err(EngineError::Unimplemented {
+                        command: command_name,
+                    });
                 }
                 let target = self.mint_node_id()?;
                 let base_sequence = self.base_sequence_for(parent).await?;
@@ -765,10 +768,9 @@ impl<T: SeamTypes> Engine<T> {
             }
             Command::Relink { node, new_parent } => {
                 let rendered = self.render().await?;
-                // Intra-scope pure relink: cross-scope detection and scope-exit
-                // rotation triggering are later slices.
                 let from_parent = rendered.parent_of(node).unwrap_or(self.snapshot.root);
                 let base_sequence = rendered.record_sequence(node).unwrap_or(1);
+                // trailing bools: cross_scope=false, exits_granted_source=false — intra-scope pure relink
                 let op = Op::relink(node, from_parent, new_parent, base_sequence, false, false);
                 self.stage_and_notify(&op).await
             }
@@ -838,10 +840,7 @@ impl<T: SeamTypes> Engine<T> {
 
     /// Stage a metadata op and emit [`Event::SnapshotUpdated`] on success.
     async fn stage_and_notify(&mut self, op: &Op) -> Result<(), EngineError> {
-        // Metadata ops carry no upload, so `stage_op` journals them unbounded
-        // and never budget-rejects — `Queued` is the only success. A rejection
-        // here would mean a content op reached this metadata-only path; fail
-        // closed rather than silently swallow it.
+        // metadata ops never budget-reject; a rejection means a content op reached this path — fail closed
         match stage_op(&self.seams.staging_store, &self.profile, op, None)
             .await
             .map_err(EngineError::from_seam)?

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -30,8 +30,8 @@ use zeroize::Zeroizing;
 use crate::api::ApiClient;
 use crate::entropy::Entropy;
 use crate::net::{
-    Adopter, HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, eol_renew_pass,
-    keyless_re_put, run_liveness_loop,
+    Adopter, EolRenewResult, HeldRecord, HeldRecords, LivenessControl, PublishError,
+    PublishOutcome, RE_PUT_INTERVAL, eol_renew_pass, keyless_re_put, run_liveness_loop,
 };
 use crate::profile::SyncTimingProfile;
 use crate::seams::{OpId, Scheduler, SeamError, SeamSet, SeamTypes, StagingStore};
@@ -348,6 +348,15 @@ pub enum Event {
         /// Human-readable classification (no key material).
         description: String,
     },
+    /// A held record's sub-EOL renewal did not land — a lost CAS race or a
+    /// fail-closed publish failure. Surfaced, never silent (blueprint/engine.md
+    /// "never a silent failure"); a later rebase/retry slice acts on it.
+    RenewalFailed {
+        /// The record's routing key (`ipnsName`); non-secret.
+        routing_key: String,
+        /// Human-readable classification (no key material).
+        detail: String,
+    },
 }
 
 /// Errors returned by facade calls.
@@ -474,6 +483,35 @@ fn node_attrs(meta: &NodeMeta) -> NodeAttrs {
         name: meta.name.clone(),
         kind: meta.kind,
         content_version: meta.content_version,
+    }
+}
+
+/// Emit an [`Event::RenewalFailed`] for every sub-EOL renewal that did not land
+/// (a lost CAS race or a fail-closed publish failure). A comfortably-ahead or
+/// republished record emits nothing. Best-effort over the in-process channel: a
+/// dropped receiver (host torn down) is fine.
+fn emit_renewal_failures(events: &mpsc::UnboundedSender<Event>, results: &[EolRenewResult]) {
+    for result in results {
+        let detail = match &result.outcome {
+            Ok(Some(PublishOutcome::LostRace {
+                published_sequence,
+                observed_sequence,
+            })) => {
+                format!(
+                    "lost CAS race: published {published_sequence}, observed {observed_sequence}"
+                )
+            }
+            Err(PublishError::Register(_)) => "register-first publish failed".to_owned(),
+            Err(PublishError::AllEndpointsFailed) => "all record endpoints failed".to_owned(),
+            Err(PublishError::FloorRead(_)) => "sequence floor read failed".to_owned(),
+            // A no-renewal (comfortably ahead) or a clean republish is not a
+            // failure — nothing to surface.
+            Ok(Some(PublishOutcome::Published { .. })) | Ok(None) => continue,
+        };
+        let _ = events.unbounded_send(Event::RenewalFailed {
+            routing_key: result.routing_key.clone(),
+            detail,
+        });
     }
 }
 
@@ -728,6 +766,7 @@ impl<T: SeamTypes> Engine<T> {
         let profile = self.profile;
         let held = self.held_records.clone();
         let alive = self.alive.clone();
+        let events = self.events.clone();
         // One API client for the whole task: register-first renewal needs the
         // API, and the refresh token lives in the credential store, so the client
         // self-heals its access token on a 401 across the session's lifetime. The
@@ -745,11 +784,12 @@ impl<T: SeamTypes> Engine<T> {
                 }
                 let records: Vec<HeldRecord> = held.borrow().values().cloned().collect();
                 keyless_re_put(&transport, &records).await;
-                // The renewal outcomes (LostRace/PublishError) are dropped until
-                // the resolve-tick driver surfaces them via Event/dead-letter
-                // (#752); the held set is empty until that slice populates it.
-                let _ =
+                // Surface every renewal that did not land (LostRace/PublishError)
+                // as an Event — never a silent failure (blueprint/engine.md). The
+                // held set is empty until the resolve-tick driver populates it.
+                let renewals =
                     eol_renew_pass(&transport, &api, &floors, &scheduler, &profile, &records).await;
+                emit_renewal_failures(&events, &renewals);
                 LivenessControl::Continue
             })
             .await;
@@ -980,6 +1020,61 @@ mod tests {
             a.session().unwrap().enc_subkey_public().to_bytes(),
             c.session().unwrap().enc_subkey_public().to_bytes(),
             "a different secret is a different identity",
+        );
+    }
+
+    #[test]
+    fn renewal_lost_race_surfaces_an_event_not_silence() {
+        use crate::net::EolRenewResult;
+
+        let (events, mut receiver) = mpsc::unbounded();
+        let results = vec![
+            // A lost CAS race: surfaced.
+            EolRenewResult {
+                routing_key: "k12D-lost".to_owned(),
+                outcome: Ok(Some(PublishOutcome::LostRace {
+                    published_sequence: 2,
+                    observed_sequence: 3,
+                })),
+            },
+            // A fail-closed publish failure: surfaced.
+            EolRenewResult {
+                routing_key: "k12D-failed".to_owned(),
+                outcome: Err(PublishError::AllEndpointsFailed),
+            },
+            // A clean republish and a comfortably-ahead no-renewal: silent.
+            EolRenewResult {
+                routing_key: "k12D-ok".to_owned(),
+                outcome: Ok(Some(PublishOutcome::Published { sequence: 2 })),
+            },
+            EolRenewResult {
+                routing_key: "k12D-ahead".to_owned(),
+                outcome: Ok(None),
+            },
+        ];
+
+        emit_renewal_failures(&events, &results);
+        drop(events);
+
+        let mut emitted = Vec::new();
+        while let Some(event) = block_on(async {
+            core::future::poll_fn(|cx| Pin::new(&mut receiver).poll_next(cx)).await
+        }) {
+            emitted.push(event);
+        }
+        assert_eq!(
+            emitted,
+            vec![
+                Event::RenewalFailed {
+                    routing_key: "k12D-lost".to_owned(),
+                    detail: "lost CAS race: published 2, observed 3".to_owned(),
+                },
+                Event::RenewalFailed {
+                    routing_key: "k12D-failed".to_owned(),
+                    detail: "all record endpoints failed".to_owned(),
+                },
+            ],
+            "only the lost race and the publish failure surface; success is silent",
         );
     }
 

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -27,10 +27,11 @@ use futures_channel::mpsc;
 use futures_core::Stream;
 use zeroize::Zeroizing;
 
+use crate::api::ApiClient;
 use crate::entropy::Entropy;
 use crate::net::{
-    Adopter, HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, keyless_re_put,
-    run_liveness_loop,
+    Adopter, HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, eol_renew_pass,
+    keyless_re_put, run_liveness_loop,
 };
 use crate::profile::SyncTimingProfile;
 use crate::seams::{OpId, Scheduler, SeamError, SeamSet, SeamTypes, StagingStore};
@@ -522,8 +523,9 @@ pub struct Engine<T: SeamTypes> {
     /// The cold-start session identity, derived from the login secret at
     /// [`start`](Self::start). `None` until then; the single place derived key
     /// material lives once the engine is live. The resolve/publish/rotation
-    /// slices and the liveness loop read every signer from here.
-    session: Option<SessionIdentity>,
+    /// slices read every signer from here. Behind an [`Rc`] so the spawned
+    /// liveness loop shares it for the sub-EOL renewal's per-name signers.
+    session: Option<Rc<SessionIdentity>>,
     started: bool,
 }
 
@@ -572,6 +574,9 @@ impl<T: SeamTypes> Engine<T> {
     where
         T::Scheduler: Clone + 'static,
         T::RecordTransport: Clone + 'static,
+        T::Http: Clone + 'static,
+        T::CredentialStore: Clone + 'static,
+        T::FloorStore: Clone + 'static,
     {
         if self.started {
             return Err(EngineError::AlreadyStarted);
@@ -581,7 +586,7 @@ impl<T: SeamTypes> Engine<T> {
         }
         // Pure derivation from the injected secret — no clock, no RNG — then
         // the secret zeroizes on drop here, at its terminal owner.
-        self.session = Some(SessionIdentity::derive(&secret));
+        self.session = Some(Rc::new(SessionIdentity::derive(&secret)));
         drop(secret);
         self.spawn_liveness_loop();
         self.started = true;
@@ -592,11 +597,11 @@ impl<T: SeamTypes> Engine<T> {
     /// `pub(crate)`: the in-crate pipeline (resolve, publish, rotation, the
     /// liveness loop) reads its signers here; hosts wrap the facade and never
     /// hold key material.
-    // Read by the pipeline slices that consume the session (resolve #745/#746,
-    // liveness composition #750/#751); the hook is live now, its callers land next.
+    // Read by the pipeline slices that consume the session (resolve #745/#746);
+    // the liveness loop (#750) shares the `Rc` directly.
     #[allow(dead_code)]
     pub(crate) fn session(&self) -> Option<&SessionIdentity> {
-        self.session.as_ref()
+        self.session.as_deref()
     }
 
     /// Run the cold-start live-session data path — the ordered chain composed on
@@ -696,21 +701,38 @@ impl<T: SeamTypes> Engine<T> {
         .await
     }
 
-    /// Spawn the ~hourly keyless re-PUT loop (blueprint/engine.md "Liveness"):
+    /// Spawn the ~hourly liveness loop (blueprint/engine.md "Liveness"):
     /// actively-used vaults keep their own records alive off the injected
-    /// scheduler, so no client depends on the API republisher. The task holds
-    /// only `Rc`/seam-handle clones, so the engine may drop while it is parked;
-    /// the alive latch then stops it. The sub-EOL seq+1 renewal joins this same
-    /// loop once cold-start derives the per-name signers it needs.
+    /// scheduler, so no client depends on the API republisher. Each pass runs
+    /// the keyless re-PUT (every held record, byte-for-byte) and then the
+    /// sub-EOL seq+1 renewal (any name inside the 30-day EOL window). The task
+    /// holds only `Rc`/seam-handle clones, so the engine may drop while it is
+    /// parked; the alive latch then stops it.
     fn spawn_liveness_loop(&self)
     where
         T::Scheduler: Clone + 'static,
         T::RecordTransport: Clone + 'static,
+        T::Http: Clone + 'static,
+        T::CredentialStore: Clone + 'static,
+        T::FloorStore: Clone + 'static,
     {
         let scheduler = self.seams.scheduler.clone();
         let transport = self.seams.record_transport.clone();
+        let floors = self.seams.floor_store.clone();
+        let profile = self.profile;
         let held = self.held_records.clone();
         let alive = self.alive.clone();
+        let session = self.session.clone();
+        // One API client for the whole task: register-first renewal needs the
+        // API, and the refresh token lives in the credential store, so the client
+        // self-heals its access token on a 401 across the session's lifetime.
+        // The base URL is supplied by the facade auth/config slice; the renewal
+        // pass only fires once the resolve-tick driver populates the held set.
+        let api = ApiClient::new(
+            self.seams.http.clone(),
+            self.seams.credential_store.clone(),
+            String::new(),
+        );
         self.seams.scheduler.spawn(Box::pin(async move {
             run_liveness_loop(&scheduler, RE_PUT_INTERVAL, || async {
                 if !alive.get() {
@@ -718,6 +740,12 @@ impl<T: SeamTypes> Engine<T> {
                 }
                 let records: Vec<HeldRecord> = held.borrow().values().cloned().collect();
                 keyless_re_put(&transport, &records).await;
+                if let Some(session) = session.as_deref() {
+                    eol_renew_pass(
+                        &transport, &api, &floors, &scheduler, &profile, session, &records,
+                    )
+                    .await;
+                }
                 LivenessControl::Continue
             })
             .await;

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -8,11 +8,14 @@
 //! the single writer, and every trust decision already happened below the
 //! facade — hosts render, they never decide.
 //!
-//! This is the skeleton slice: the surface shape (constructor over the
-//! whole seam set, `start(secret)`, the [`Command`] enum, the [`Event`]
-//! stream) is real and frozen; command execution is not — every command
-//! resolves to [`EngineError::Unimplemented`] until the pipeline slices
-//! land.
+//! The surface shape (constructor over the whole seam set, `start(secret)`,
+//! the [`Command`] enum, the [`Event`] stream) is frozen. This slice wires the
+//! facade onto the sync core: the metadata intent ops (create/delete/rename/
+//! relink) stage through the durable op queue, reads render the gate-passing
+//! base snapshot ⊕ pending-op overlay (blueprint/engine.md "Sync core: State
+//! law"), and every successful stage emits [`Event::SnapshotUpdated`]. The
+//! non-metadata commands (grants, rotation, auth, content seal) stay
+//! [`EngineError::Unimplemented`] until their slices land.
 
 use core::cell::{Cell, RefCell};
 use core::fmt;
@@ -29,11 +32,15 @@ use crate::net::{
     Adopter, HeldRecord, LivenessControl, RE_PUT_INTERVAL, keyless_re_put, run_liveness_loop,
 };
 use crate::profile::SyncTimingProfile;
-use crate::seams::{OpId, Scheduler, SeamSet, SeamTypes, StagingStore};
+use crate::seams::{OpId, Scheduler, SeamError, SeamSet, SeamTypes, StagingStore};
 use crate::session::SessionIdentity;
 use crate::sync::boot::{ColdStartError, ColdStartOutcome, ColdStartParams, cold_start};
+use crate::sync::model::{NodeMeta, Snapshot, collation_key};
+use crate::sync::op::Op;
+use crate::sync::overlay::apply_overlay;
 use crate::sync::pointer::PointerFetch;
 use crate::sync::rebase::decode_queue;
+use crate::sync::staging::{StageOutcome, stage_op};
 
 /// The stable 16-byte node identifier (`id16`, blueprint/core.md). Public,
 /// non-secret, and location-independent — routes and commands key on it,
@@ -69,6 +76,30 @@ pub enum NodeKind {
     File,
     /// A folder node.
     Folder,
+}
+
+/// A node's host-facing attributes, projected from the rendered view for a
+/// FUSE getattr/readdir. Kind-uniform metadata only — content size and
+/// timestamps land with the content-plane slice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeAttrs {
+    /// Stable node id.
+    pub id: NodeId,
+    /// Display name, as entered.
+    pub name: String,
+    /// File or folder.
+    pub kind: NodeKind,
+    /// Current content version (bumped per `updateContent`).
+    pub content_version: u64,
+}
+
+/// Minimal filesystem-level counters for a FUSE statfs. Node count only:
+/// quota and byte accounting live on the API client and are not wired at the
+/// facade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StatFs {
+    /// Nodes reachable from the root in the rendered view.
+    pub nodes: u64,
 }
 
 /// Grant permission level.
@@ -332,6 +363,26 @@ pub enum EngineError {
         /// [`Command::name`] of the rejected command.
         command: &'static str,
     },
+    /// A host seam failed (durable op-queue I/O). Availability, never a trust
+    /// decision — trust classification happens below the facade.
+    Seam {
+        /// Diagnostic message; never carries key material.
+        message: String,
+    },
+    /// Entropy acquisition failed while minting a node id (fail closed — never
+    /// a predictable id).
+    Entropy {
+        /// Diagnostic message; never carries key material.
+        message: String,
+    },
+}
+
+impl EngineError {
+    fn from_seam(err: SeamError) -> Self {
+        EngineError::Seam {
+            message: err.message().to_owned(),
+        }
+    }
 }
 
 impl fmt::Display for EngineError {
@@ -343,6 +394,8 @@ impl fmt::Display for EngineError {
             EngineError::Unimplemented { command } => {
                 write!(f, "command not implemented yet: {command}")
             }
+            EngineError::Seam { message } => write!(f, "seam error: {message}"),
+            EngineError::Entropy { message } => write!(f, "entropy error: {message}"),
         }
     }
 }
@@ -364,6 +417,80 @@ impl EventStream {
     }
 }
 
+/// A rendered read of the engine's state: the gate-passing base snapshot with
+/// the pending-op overlay applied (state law, blueprint/engine.md "Sync core:
+/// State law"). Reads project off this — never off raw or ungated records.
+/// One render backs a whole FUSE readdir+getattr batch, so the view is
+/// internally consistent.
+pub struct EngineView {
+    rendered: Snapshot,
+}
+
+impl EngineView {
+    /// The rendered root node id — the FUSE mount anchor.
+    pub fn root(&self) -> NodeId {
+        self.rendered.root
+    }
+
+    /// The children under `parent`, deterministically ordered by node id.
+    pub fn children(&self, parent: NodeId) -> Vec<NodeAttrs> {
+        self.rendered
+            .children(parent)
+            .into_iter()
+            .map(node_attrs)
+            .collect()
+    }
+
+    /// The child of `parent` whose name folds equal to `name` under the strict
+    /// comparator, if any (FUSE lookup).
+    pub fn lookup(&self, parent: NodeId, name: &str) -> Option<NodeAttrs> {
+        let key = collation_key(name);
+        self.rendered
+            .children(parent)
+            .into_iter()
+            .find(|child| collation_key(&child.name) == key)
+            .map(node_attrs)
+    }
+
+    /// The node's attributes, if present in the rendered view (FUSE getattr).
+    pub fn attrs(&self, node: NodeId) -> Option<NodeAttrs> {
+        self.rendered.node(node).map(node_attrs)
+    }
+
+    /// Minimal statfs: the node count reachable from the root. Byte/quota
+    /// accounting is API-client-side and not wired here.
+    pub fn statfs(&self) -> StatFs {
+        StatFs {
+            nodes: count_nodes(&self.rendered),
+        }
+    }
+}
+
+fn node_attrs(meta: &NodeMeta) -> NodeAttrs {
+    NodeAttrs {
+        id: meta.id,
+        name: meta.name.clone(),
+        kind: meta.kind,
+        content_version: meta.content_version,
+    }
+}
+
+/// Count nodes reachable from the root via the link graph, cycle-guarded (a
+/// malformed link cycle terminates rather than looping).
+fn count_nodes(snapshot: &Snapshot) -> u64 {
+    let mut seen = std::collections::HashSet::new();
+    let mut stack = vec![snapshot.root];
+    seen.insert(snapshot.root);
+    while let Some(id) = stack.pop() {
+        for child in snapshot.children(id) {
+            if seen.insert(child.id) {
+                stack.push(child.id);
+            }
+        }
+    }
+    seen.len() as u64
+}
+
 /// The engine — the single stateful brain behind the facade.
 ///
 /// Constructed over the whole seam set (missing seam = compile error), an
@@ -373,12 +500,15 @@ impl EventStream {
 /// compiles to worker-hosted WASM on web.
 pub struct Engine<T: SeamTypes> {
     seams: SeamSet<T>,
-    /// Wired by the pipeline slices (seeds, nonces, jitter).
-    #[allow(dead_code)]
+    /// Seeds, nonces, jitter, and command-path node-id minting.
     entropy: Box<dyn Entropy>,
     profile: SyncTimingProfile,
-    #[allow(dead_code)]
     events: mpsc::UnboundedSender<Event>,
+    /// The last-known-good gate-passing base snapshot (state law's left
+    /// operand). Seeded at the anchored root; cold-start/resolve replace it
+    /// with the resolved remote state. Reads render this ⊕ the pending-op
+    /// overlay; commands never mutate it — only the op queue diverges locally.
+    snapshot: Snapshot,
     /// The session's live held-record set: the resolve slice pushes each
     /// gate-passing record here, and the cold-start liveness loop keyless
     /// re-PUTs the set on the hourly cadence. Empty until resolve lands.
@@ -409,6 +539,9 @@ impl<T: SeamTypes> Engine<T> {
                 entropy,
                 profile,
                 events,
+                // The anchored all-zero root until cold-start/resolve replaces
+                // the base snapshot; children come from the pending-op overlay.
+                snapshot: Snapshot::new(NodeId([0u8; 16])),
                 held_records: Rc::new(RefCell::new(Vec::new())),
                 alive: Rc::new(Cell::new(true)),
                 session: None,
@@ -590,13 +723,139 @@ impl<T: SeamTypes> Engine<T> {
 
     /// Executes one command. The single write entry point: every mutation,
     /// share action, auth call, and manual refresh comes through here.
+    ///
+    /// The metadata intent ops (create/delete/rename/relink) stage onto the
+    /// durable op queue via [`stage_op`] and emit [`Event::SnapshotUpdated`];
+    /// the base sequence each op carries is read from the rendered view (state
+    /// law), so an op rebases against the state the host saw. Content sealing,
+    /// grants, rotation, and auth land with their own slices and stay
+    /// [`EngineError::Unimplemented`].
     pub async fn command(&mut self, command: Command) -> Result<(), EngineError> {
         if !self.started {
             return Err(EngineError::NotStarted);
         }
-        Err(EngineError::Unimplemented {
-            command: command.name(),
+        match command {
+            Command::Create {
+                parent,
+                name,
+                kind,
+                content,
+            } => {
+                // A content-bearing create needs the content plane (sealing +
+                // staged bytes), a later slice; only metadata creates (folders
+                // and empty files) stage here.
+                if content.is_some() {
+                    return Err(EngineError::Unimplemented { command: "create" });
+                }
+                let target = self.mint_node_id()?;
+                let base_sequence = self.base_sequence_for(parent).await?;
+                let op = Op::create(target, parent, name, kind, base_sequence, None);
+                self.stage_and_notify(&op).await
+            }
+            Command::Delete { node } => {
+                // Both anchors snapshot the target's own sequence for the
+                // conditional-delete rebase rule.
+                let seq = self.base_sequence_for(node).await?;
+                self.stage_and_notify(&Op::delete(node, seq, seq)).await
+            }
+            Command::Rename { node, new_name } => {
+                let seq = self.base_sequence_for(node).await?;
+                self.stage_and_notify(&Op::rename(node, new_name, seq))
+                    .await
+            }
+            Command::Relink { node, new_parent } => {
+                let rendered = self.render().await?;
+                // Intra-scope pure relink: cross-scope detection and scope-exit
+                // rotation triggering are later slices.
+                let from_parent = rendered.parent_of(node).unwrap_or(self.snapshot.root);
+                let base_sequence = rendered.record_sequence(node).unwrap_or(1);
+                let op = Op::relink(node, from_parent, new_parent, base_sequence, false, false);
+                self.stage_and_notify(&op).await
+            }
+            other => Err(EngineError::Unimplemented {
+                command: other.name(),
+            }),
+        }
+    }
+
+    /// A rendered read of the current state — the gate-passing base snapshot ⊕
+    /// the pending-op overlay — for FUSE-shaped reads (children/lookup/attrs/
+    /// statfs). Fails `NotStarted` before [`start`](Self::start).
+    pub async fn view(&self) -> Result<EngineView, EngineError> {
+        if !self.started {
+            return Err(EngineError::NotStarted);
+        }
+        Ok(EngineView {
+            rendered: self.render().await?,
         })
+    }
+
+    /// The current base snapshot's root node id — the FUSE mount anchor. The
+    /// seeded all-zero root until cold-start/resolve replaces the base snapshot.
+    pub fn root(&self) -> NodeId {
+        self.snapshot.root
+    }
+
+    /// Render the base snapshot with the pending-op overlay applied.
+    async fn render(&self) -> Result<Snapshot, EngineError> {
+        let ops = self.pending_ops().await?;
+        Ok(apply_overlay(&self.snapshot, &ops))
+    }
+
+    /// The pending ops from the durable staging store, decoded FIFO. Undecodable
+    /// entries are dropped from the render here; the cold-start path dead-letters
+    /// and removes them from the durable queue.
+    async fn pending_ops(&self) -> Result<Vec<Op>, EngineError> {
+        let raw = self
+            .seams
+            .staging_store
+            .queued_ops()
+            .await
+            .map_err(EngineError::from_seam)?;
+        let (decoded, _undecodable) = decode_queue(&raw);
+        Ok(decoded.into_iter().map(|(_id, op)| op).collect())
+    }
+
+    /// The base sequence to anchor an op at: the target's own record sequence in
+    /// the rendered view, defaulting to 1 for a node not yet in gate-passing
+    /// state (a pending create).
+    async fn base_sequence_for(&self, node: NodeId) -> Result<u64, EngineError> {
+        Ok(self.render().await?.record_sequence(node).unwrap_or(1))
+    }
+
+    /// Mint a fresh random 16-byte node id from the injected entropy seam
+    /// (id16, non-secret; blueprint/core.md). Fails closed on entropy failure —
+    /// never a predictable id.
+    fn mint_node_id(&mut self) -> Result<NodeId, EngineError> {
+        let mut id = [0u8; 16];
+        self.entropy
+            .fill(&mut id)
+            .map_err(|e| EngineError::Entropy {
+                message: e.message().to_owned(),
+            })?;
+        Ok(NodeId(id))
+    }
+
+    /// Stage a metadata op and emit [`Event::SnapshotUpdated`] on success.
+    async fn stage_and_notify(&mut self, op: &Op) -> Result<(), EngineError> {
+        // Metadata ops carry no upload, so `stage_op` journals them unbounded
+        // and never budget-rejects — `Queued` is the only success. A rejection
+        // here would mean a content op reached this metadata-only path; fail
+        // closed rather than silently swallow it.
+        match stage_op(&self.seams.staging_store, &self.profile, op, None)
+            .await
+            .map_err(EngineError::from_seam)?
+        {
+            StageOutcome::Queued { .. } => {
+                // Best-effort push-invalidation trigger; a dropped receiver
+                // (host torn down) is fine.
+                let _ = self.events.unbounded_send(Event::SnapshotUpdated);
+                Ok(())
+            }
+            StageOutcome::RejectedOverBudget { .. } => Err(EngineError::Seam {
+                message: "metadata op unexpectedly rejected over budget".to_owned(),
+            }),
+        }
     }
 
     /// The sync timing profile this engine runs under.
@@ -736,6 +995,172 @@ mod tests {
             "command not implemented yet: create"
         );
         assert_eq!(EngineError::NotStarted.to_string(), "engine not started");
+    }
+
+    // --- facade wiring: reads, command execution, event emission ---
+
+    fn started() -> (Engine<FakeSeamTypes>, EventStream) {
+        let (mut engine, events) = new_engine();
+        block_on(engine.start(LoginSecret::new(vec![7u8; 32]))).unwrap();
+        (engine, events)
+    }
+
+    fn create(engine: &mut Engine<FakeSeamTypes>, parent: NodeId, name: &str, kind: NodeKind) {
+        block_on(engine.command(Command::Create {
+            parent,
+            name: name.into(),
+            kind,
+            content: None,
+        }))
+        .unwrap();
+    }
+
+    #[test]
+    fn command_before_start_returns_not_started() {
+        let (mut engine, _events) = new_engine();
+        let out = block_on(engine.command(Command::Delete {
+            node: NodeId([1; 16]),
+        }));
+        assert_eq!(out, Err(EngineError::NotStarted));
+    }
+
+    #[test]
+    fn view_before_start_returns_not_started() {
+        let (engine, _events) = new_engine();
+        assert!(matches!(
+            block_on(engine.view()),
+            Err(EngineError::NotStarted)
+        ));
+    }
+
+    #[test]
+    fn create_is_visible_through_the_read_surface_and_emits() {
+        let (mut engine, mut events) = started();
+        let root = engine.root();
+        create(&mut engine, root, "notes.txt", NodeKind::File);
+
+        let view = block_on(engine.view()).unwrap();
+        let children = view.children(root);
+        assert_eq!(children.len(), 1, "the pending create renders");
+        assert_eq!(children[0].name, "notes.txt");
+        assert_eq!(children[0].kind, NodeKind::File);
+
+        let found = view.lookup(root, "notes.txt").expect("lookup finds it");
+        assert_eq!(found.id, children[0].id);
+        assert_eq!(view.attrs(found.id).unwrap().name, "notes.txt");
+
+        assert_eq!(
+            block_on(events.next()),
+            Some(Event::SnapshotUpdated),
+            "a successful stage emits SnapshotUpdated"
+        );
+    }
+
+    #[test]
+    fn content_bearing_create_is_unimplemented_pending_the_content_plane() {
+        let (mut engine, _events) = started();
+        let root = engine.root();
+        let out = block_on(engine.command(Command::Create {
+            parent: root,
+            name: "f".into(),
+            kind: NodeKind::File,
+            content: Some(PlaintextContent(b"x".to_vec())),
+        }));
+        assert_eq!(out, Err(EngineError::Unimplemented { command: "create" }));
+        // Nothing staged: the read surface stays empty.
+        assert!(block_on(engine.view()).unwrap().children(root).is_empty());
+    }
+
+    #[test]
+    fn delete_removes_the_node_from_the_view() {
+        let (mut engine, _events) = started();
+        let root = engine.root();
+        create(&mut engine, root, "f", NodeKind::File);
+        let id = block_on(engine.view()).unwrap().children(root)[0].id;
+
+        block_on(engine.command(Command::Delete { node: id })).unwrap();
+        assert!(
+            block_on(engine.view()).unwrap().children(root).is_empty(),
+            "the pending delete renders"
+        );
+    }
+
+    #[test]
+    fn rename_updates_the_name_in_the_view() {
+        let (mut engine, _events) = started();
+        let root = engine.root();
+        create(&mut engine, root, "old.txt", NodeKind::File);
+        let id = block_on(engine.view()).unwrap().children(root)[0].id;
+
+        block_on(engine.command(Command::Rename {
+            node: id,
+            new_name: "new.txt".into(),
+        }))
+        .unwrap();
+
+        let view = block_on(engine.view()).unwrap();
+        assert!(view.lookup(root, "old.txt").is_none());
+        assert_eq!(view.lookup(root, "new.txt").unwrap().id, id);
+    }
+
+    #[test]
+    fn relink_moves_the_node_between_folders_in_the_view() {
+        let (mut engine, _events) = started();
+        let root = engine.root();
+        create(&mut engine, root, "dir", NodeKind::Folder);
+        let dir = block_on(engine.view())
+            .unwrap()
+            .lookup(root, "dir")
+            .unwrap()
+            .id;
+        create(&mut engine, dir, "f", NodeKind::File);
+        let file = block_on(engine.view())
+            .unwrap()
+            .lookup(dir, "f")
+            .unwrap()
+            .id;
+
+        block_on(engine.command(Command::Relink {
+            node: file,
+            new_parent: root,
+        }))
+        .unwrap();
+
+        let view = block_on(engine.view()).unwrap();
+        assert!(view.children(dir).is_empty(), "moved out of dir");
+        assert_eq!(
+            view.lookup(root, "f").unwrap().id,
+            file,
+            "now linked under root"
+        );
+    }
+
+    #[test]
+    fn statfs_counts_reachable_nodes() {
+        let (mut engine, _events) = started();
+        let root = engine.root();
+        assert_eq!(
+            block_on(engine.view()).unwrap().statfs().nodes,
+            1,
+            "root only"
+        );
+        create(&mut engine, root, "a", NodeKind::Folder);
+        create(&mut engine, root, "b", NodeKind::File);
+        assert_eq!(block_on(engine.view()).unwrap().statfs().nodes, 3);
+    }
+
+    #[test]
+    fn non_metadata_commands_stay_unimplemented() {
+        let (mut engine, _events) = started();
+        let out = block_on(engine.command(Command::RotateNow {
+            node: NodeId([1; 16]),
+        }));
+        assert_eq!(
+            out,
+            Err(EngineError::Unimplemented {
+                command: "rotateNow"
+            })
+        );
     }
 
     // --- cold-start data path composition ---

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -367,7 +367,7 @@ pub enum EngineError {
     /// [`Engine::start`] was called on an already-started engine (one live
     /// instance is the single writer).
     AlreadyStarted,
-    /// The login secret was empty.
+    /// The login secret was empty or not a valid 32-byte identity scalar.
     InvalidSecret,
     /// The command's pipeline slice has not landed yet (scaffold state).
     Unimplemented {
@@ -401,7 +401,9 @@ impl fmt::Display for EngineError {
         match self {
             EngineError::NotStarted => f.write_str("engine not started"),
             EngineError::AlreadyStarted => f.write_str("engine already started"),
-            EngineError::InvalidSecret => f.write_str("login secret must not be empty"),
+            EngineError::InvalidSecret => {
+                f.write_str("login secret is not a valid identity scalar")
+            }
             EngineError::Unimplemented { command } => {
                 write!(f, "command not implemented yet: {command}")
             }
@@ -630,7 +632,7 @@ impl<T: SeamTypes> Engine<T> {
         }
         // Pure derivation from the injected secret — no clock, no RNG — then
         // the secret zeroizes on drop here, at its terminal owner.
-        self.session = Some(Rc::new(SessionIdentity::derive(&secret)));
+        self.session = Some(Rc::new(SessionIdentity::derive(&secret)?));
         drop(secret);
         self.spawn_liveness_loop();
         self.started = true;
@@ -997,7 +999,8 @@ mod tests {
 
         // Start derives the same identity as the pure derivation from the same
         // secret — it invents no key material.
-        let expected = SessionIdentity::derive(&LoginSecret::new(vec![7u8; 32]));
+        let expected =
+            SessionIdentity::derive(&LoginSecret::new(vec![7u8; 32])).expect("valid identity");
         assert_eq!(
             session.vault_pointer_signer(0).verifying_key().to_bytes(),
             expected.vault_pointer_signer(0).verifying_key().to_bytes(),

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -995,13 +995,9 @@ impl<T: SeamTypes> Engine<T> {
                     write_scope_seed: None,
                     content_cids: Vec::new(),
                 };
-                // A gate-passing resolve repaints the shared base cell and emits
-                // `SnapshotUpdated`; a steady-state `TrustViolation`/`Current`/
-                // `NoUpdate` leaves last-known-good intact (fail-closed for data:
-                // a forged record is never held or rendered). Surfacing the
-                // violation as a staleness-ladder / `AttributableAbuse` event, and
-                // a resolve `SeamError` as availability, are later slices — the
-                // error stays swallowed here.
+                // A gate-passing `Adopted` repaints the shared base cell and emits
+                // `SnapshotUpdated`; `Current`/`NoUpdate`/`TrustViolation` leave
+                // last-known-good intact (fail-closed for data). (surfacing: #796)
                 if let Ok(resolved) = resolve_and_hold(
                     &transport,
                     &snapshot_cache,

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -35,7 +35,7 @@ use crate::hex::hex_lower;
 use crate::net::{
     Adopter, EolRenewResult, HeldMaterial, HeldRecord, HeldRecords, LivenessControl, PublishError,
     PublishOutcome, RE_PUT_INTERVAL, RecordPointerFetch, RootAdopter, eol_renew_pass,
-    keyless_re_put, resolve_and_hold, run_liveness_loop,
+    keyless_re_put, refresh_base_from_outcome, resolve_and_hold, run_liveness_loop,
 };
 use crate::profile::SyncTimingProfile;
 use crate::seams::{OpId, Scheduler, SeamError, SeamSet, SeamTypes, StagingStore};
@@ -610,7 +610,9 @@ pub struct Engine<T: SeamTypes> {
     /// operand). Seeded at the anchored root; cold-start/resolve replace it
     /// with the resolved remote state. Reads render this ⊕ the pending-op
     /// overlay; commands never mutate it — only the op queue diverges locally.
-    snapshot: Snapshot,
+    /// Behind an [`Rc`]`<`[`RefCell`]`>` so the resolve-tick loop shares the one
+    /// cell and repaints it in place from a gate-passing live resolve.
+    snapshot: Rc<RefCell<Snapshot>>,
     /// The session's live held-record set, keyed by node id: the resolve path
     /// ([`resolve_and_hold`](crate::net::resolve_and_hold)) inserts each
     /// gate-passing record here, and the cold-start liveness loop keyless
@@ -654,7 +656,7 @@ impl<T: SeamTypes> Engine<T> {
                 events,
                 // The anchored all-zero root until cold-start/resolve replaces
                 // the base snapshot; children come from the pending-op overlay.
-                snapshot: Snapshot::new(NodeId([0u8; 16])),
+                snapshot: Rc::new(RefCell::new(Snapshot::new(NodeId([0u8; 16])))),
                 held_records: Rc::new(RefCell::new(HeldRecords::new())),
                 alive: Rc::new(Cell::new(true)),
                 session: None,
@@ -729,7 +731,7 @@ impl<T: SeamTypes> Engine<T> {
         let cold_start = {
             let session = self.session.as_ref().expect("session set above");
             let owner_identity = session.owner_identity();
-            let root = self.snapshot.root;
+            let root = self.snapshot.borrow().root;
             let root_scope_id = root.0;
             let pointer_fetch = RecordPointerFetch::new(&self.seams.record_transport);
             let adopter = RootAdopter::new(
@@ -769,7 +771,7 @@ impl<T: SeamTypes> Engine<T> {
             .vault_pointer
             .as_ref()
             .map(|vp| vp.repoint.current_root.clone());
-        self.snapshot = outcome.base;
+        *self.snapshot.borrow_mut() = outcome.base;
 
         self.spawn_liveness_loop(api.clone());
         self.spawn_resolve_tick_loop(root_name);
@@ -958,13 +960,15 @@ impl<T: SeamTypes> Engine<T> {
         let http = self.seams.http.clone();
         let gateway = self.gateway.clone();
         let held = self.held_records.clone();
+        let base = self.snapshot.clone();
+        let events = self.events.clone();
         let alive = self.alive.clone();
         let interval = self.profile.poll_cadence;
         let owner_identity = session.owner_identity();
         // The vault's own root scope and root node are the anchored all-zero id16
         // (the cold-start bootstrap anchor): the adopter's scope binding and the
         // held-set fallback key.
-        let root_id = self.snapshot.root.0;
+        let root_id = self.snapshot.borrow().root.0;
 
         self.seams.scheduler.spawn(Box::pin(async move {
             run_liveness_loop(&scheduler, interval, || async {
@@ -991,11 +995,14 @@ impl<T: SeamTypes> Engine<T> {
                     write_scope_seed: None,
                     content_cids: Vec::new(),
                 };
-                // The resolve outcome (incl. a steady-state `TrustViolation`) is
-                // dropped: fail-closed for data (a forged record is never held or
-                // rendered), but surfacing it as a staleness-ladder /
-                // `AttributableAbuse` event is a later slice.
-                let _ = resolve_and_hold(
+                // A gate-passing resolve repaints the shared base cell and emits
+                // `SnapshotUpdated`; a steady-state `TrustViolation`/`Current`/
+                // `NoUpdate` leaves last-known-good intact (fail-closed for data:
+                // a forged record is never held or rendered). Surfacing the
+                // violation as a staleness-ladder / `AttributableAbuse` event, and
+                // a resolve `SeamError` as availability, are later slices — the
+                // error stays swallowed here.
+                if let Ok(resolved) = resolve_and_hold(
                     &transport,
                     &snapshot_cache,
                     &adopter,
@@ -1003,7 +1010,12 @@ impl<T: SeamTypes> Engine<T> {
                     &held,
                     &material,
                 )
-                .await;
+                .await
+                {
+                    if refresh_base_from_outcome(&base, NodeId(root_id), &resolved.outcome) {
+                        let _ = events.unbounded_send(Event::SnapshotUpdated);
+                    }
+                }
                 LivenessControl::Continue
             })
             .await;
@@ -1057,7 +1069,9 @@ impl<T: SeamTypes> Engine<T> {
             }
             Command::Relink { node, new_parent } => {
                 let rendered = self.render().await?;
-                let from_parent = rendered.parent_of(node).unwrap_or(self.snapshot.root);
+                let from_parent = rendered
+                    .parent_of(node)
+                    .unwrap_or(self.snapshot.borrow().root);
                 let base_sequence = rendered.record_sequence(node).unwrap_or(1);
                 // trailing bools: cross_scope=false, exits_granted_source=false — intra-scope pure relink
                 let op = Op::relink(node, from_parent, new_parent, base_sequence, false, false);
@@ -1091,13 +1105,16 @@ impl<T: SeamTypes> Engine<T> {
     /// The current base snapshot's root node id — the FUSE mount anchor. The
     /// seeded all-zero root until cold-start/resolve replaces the base snapshot.
     pub fn root(&self) -> NodeId {
-        self.snapshot.root
+        self.snapshot.borrow().root
     }
 
     /// Render the base snapshot with the pending-op overlay applied.
     async fn render(&self) -> Result<Snapshot, EngineError> {
+        // Take the base borrow only after the await, and drop it at the end of
+        // this sync call — a `RefCell` borrow must never span an `.await`.
         let ops = self.pending_ops().await?;
-        Ok(apply_overlay(&self.snapshot, &ops))
+        let base = self.snapshot.borrow();
+        Ok(apply_overlay(&base, &ops))
     }
 
     /// The pending ops from the durable staging store, decoded FIFO. Undecodable
@@ -1831,6 +1848,83 @@ mod tests {
             // The data path is a pure function of the seams + session: the two
             // outcomes match despite the engines' clocks sitting far apart.
             assert_eq!(drive(&mut a, &pa), drive(&mut b, &pb));
+        }
+
+        /// A gate-passing `Adopted` folder carrying one child — the projected
+        /// material a newer live resolve folds into the shared base cell.
+        fn adopted_with_child(child_id: [u8; 16], name: &str) -> Adopted {
+            use cipherbox_core::seal::{ChildRef, NodeKind as CoreNodeKind};
+            Adopted {
+                read_body: ReadBody::Folder {
+                    created_at: 0,
+                    modified_at: 0,
+                    children: vec![ChildRef {
+                        id: child_id,
+                        name: name.to_string(),
+                        ipns_name: vec![1],
+                        kind: CoreNodeKind::File,
+                        link_counter: 1,
+                        unknown: Vec::new(),
+                    }],
+                    unknown: Vec::new(),
+                },
+                sequence: 2,
+                epoch: 1,
+            }
+        }
+
+        #[test]
+        fn a_newer_adopted_tick_repaints_the_view_and_emits() {
+            use crate::net::{ResolveOutcome, refresh_base_from_outcome};
+
+            let (engine, mut events, _pointers) = started_at(UnixMillis(123_456));
+            let root = engine.root();
+
+            // One resolve-tick pass over a gate-passing newer `Adopted`: fold it
+            // into the shared base cell and emit, exactly as the tick loop does.
+            assert!(refresh_base_from_outcome(
+                &engine.snapshot,
+                root,
+                &ResolveOutcome::Adopted(adopted_with_child([0xC1; 16], "live.txt")),
+            ));
+            let _ = engine.events.unbounded_send(Event::SnapshotUpdated);
+
+            let view = block_on(engine.view()).unwrap();
+            assert!(
+                view.lookup(root, "live.txt").is_some(),
+                "the view reflects the newly adopted child"
+            );
+            assert_eq!(view.children(root).len(), 1);
+            assert_eq!(block_on(events.next()), Some(Event::SnapshotUpdated));
+        }
+
+        #[test]
+        fn tick_repaint_is_clock_independent() {
+            use crate::net::{ResolveOutcome, refresh_base_from_outcome};
+
+            let (a, _ea, _pa) = started_at(UnixMillis(0));
+            let (b, _eb, _pb) = started_at(UnixMillis(5_000_000));
+            let root = a.root();
+            assert_eq!(root, b.root());
+
+            refresh_base_from_outcome(
+                &a.snapshot,
+                root,
+                &ResolveOutcome::Adopted(adopted_with_child([0xD2; 16], "clk.txt")),
+            );
+            refresh_base_from_outcome(
+                &b.snapshot,
+                root,
+                &ResolveOutcome::Adopted(adopted_with_child([0xD2; 16], "clk.txt")),
+            );
+
+            // Clock-independent: the two repainted bases are byte-identical, and
+            // both render the same post-pass view.
+            assert_eq!(*a.snapshot.borrow(), *b.snapshot.borrow());
+            let va = block_on(a.view()).unwrap();
+            let vb = block_on(b.view()).unwrap();
+            assert!(va.lookup(root, "clk.txt").is_some());
+            assert_eq!(va.children(root).len(), vb.children(root).len());
         }
 
         #[test]

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -505,6 +505,10 @@ pub struct Engine<T: SeamTypes> {
     /// Seeds, nonces, jitter, and command-path node-id minting.
     entropy: Box<dyn Entropy>,
     profile: SyncTimingProfile,
+    /// The API base URL the liveness loop's [`ApiClient`] registers renewals
+    /// against. Empty until the auth/config slice supplies it; the register-first
+    /// renewal is a no-op against an empty base until then.
+    api_base_url: String,
     events: mpsc::UnboundedSender<Event>,
     /// The last-known-good gate-passing base snapshot (state law's left
     /// operand). Seeded at the anchored root; cold-start/resolve replace it
@@ -536,6 +540,7 @@ impl<T: SeamTypes> Engine<T> {
         seams: SeamSet<T>,
         entropy: Box<dyn Entropy>,
         profile: SyncTimingProfile,
+        api_base_url: String,
     ) -> (Self, EventStream) {
         let (events, receiver) = mpsc::unbounded();
         (
@@ -543,6 +548,7 @@ impl<T: SeamTypes> Engine<T> {
                 seams,
                 entropy,
                 profile,
+                api_base_url,
                 events,
                 // The anchored all-zero root until cold-start/resolve replaces
                 // the base snapshot; children come from the pending-op overlay.
@@ -724,13 +730,13 @@ impl<T: SeamTypes> Engine<T> {
         let alive = self.alive.clone();
         // One API client for the whole task: register-first renewal needs the
         // API, and the refresh token lives in the credential store, so the client
-        // self-heals its access token on a 401 across the session's lifetime.
-        // The base URL is supplied by the facade auth/config slice; the renewal
-        // pass only fires once the resolve-tick driver populates the held set.
+        // self-heals its access token on a 401 across the session's lifetime. The
+        // renewal pass only fires once the resolve-tick driver populates the held
+        // set.
         let api = ApiClient::new(
             self.seams.http.clone(),
             self.seams.credential_store.clone(),
-            String::new(),
+            self.api_base_url.clone(),
         );
         self.seams.scheduler.spawn(Box::pin(async move {
             run_liveness_loop(&scheduler, RE_PUT_INTERVAL, || async {
@@ -913,6 +919,7 @@ mod tests {
             device.seam_set(),
             Box::new(SeededEntropy::new(42)),
             SyncTimingProfile::CI,
+            String::new(),
         )
     }
 
@@ -926,6 +933,7 @@ mod tests {
             device.seam_set(),
             Box::new(SeededEntropy::new(42)),
             SyncTimingProfile::CI,
+            String::new(),
         );
         block_on(engine.start(LoginSecret::new(vec![secret_byte; 32]))).unwrap();
         engine
@@ -1316,6 +1324,7 @@ mod tests {
                 device.seam_set(),
                 Box::new(SeededEntropy::new(42)),
                 SyncTimingProfile::CI,
+                String::new(),
             );
             block_on(engine.start(LoginSecret::new(SECRET.to_vec()))).unwrap();
             let pointers = ScriptedPointers::default();
@@ -1399,6 +1408,7 @@ mod tests {
                 device.seam_set(),
                 Box::new(SeededEntropy::new(42)),
                 SyncTimingProfile::CI,
+                String::new(),
             );
             assert!(engine.session().is_none(), "no identity before start");
             let out = block_on(engine.cold_start_data_path(

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -29,7 +29,8 @@ use zeroize::Zeroizing;
 
 use crate::entropy::Entropy;
 use crate::net::{
-    Adopter, HeldRecord, LivenessControl, RE_PUT_INTERVAL, keyless_re_put, run_liveness_loop,
+    Adopter, HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, keyless_re_put,
+    run_liveness_loop,
 };
 use crate::profile::SyncTimingProfile;
 use crate::seams::{OpId, Scheduler, SeamError, SeamSet, SeamTypes, StagingStore};
@@ -509,10 +510,12 @@ pub struct Engine<T: SeamTypes> {
     /// with the resolved remote state. Reads render this ⊕ the pending-op
     /// overlay; commands never mutate it — only the op queue diverges locally.
     snapshot: Snapshot,
-    /// The session's live held-record set: the resolve slice pushes each
+    /// The session's live held-record set, keyed by node id: the resolve path
+    /// ([`resolve_and_hold`](crate::net::resolve_and_hold)) inserts each
     /// gate-passing record here, and the cold-start liveness loop keyless
-    /// re-PUTs the set on the hourly cadence. Empty until resolve lands.
-    held_records: Rc<RefCell<Vec<HeldRecord>>>,
+    /// re-PUTs the map's values on the hourly cadence. Empty until the resolve
+    /// tick driver (next slice) wires it in.
+    held_records: Rc<RefCell<HeldRecords>>,
     /// Session-alive latch: cleared on drop so the spawned liveness loop
     /// stops at its next wake instead of re-PUTting after the engine is gone.
     alive: Rc<Cell<bool>>,
@@ -542,7 +545,7 @@ impl<T: SeamTypes> Engine<T> {
                 // The anchored all-zero root until cold-start/resolve replaces
                 // the base snapshot; children come from the pending-op overlay.
                 snapshot: Snapshot::new(NodeId([0u8; 16])),
-                held_records: Rc::new(RefCell::new(Vec::new())),
+                held_records: Rc::new(RefCell::new(HeldRecords::new())),
                 alive: Rc::new(Cell::new(true)),
                 session: None,
                 started: false,
@@ -713,7 +716,7 @@ impl<T: SeamTypes> Engine<T> {
                 if !alive.get() {
                     return LivenessControl::Stop;
                 }
-                let records = held.borrow().clone();
+                let records: Vec<HeldRecord> = held.borrow().values().cloned().collect();
                 keyless_re_put(&transport, &records).await;
                 LivenessControl::Continue
             })

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -551,6 +551,7 @@ fn emit_renewal_failures(events: &mpsc::UnboundedSender<Event>, results: &[EolRe
             Err(PublishError::Register(_)) => "register-first publish failed".to_owned(),
             Err(PublishError::AllEndpointsFailed) => "all record endpoints failed".to_owned(),
             Err(PublishError::FloorRead(_)) => "sequence floor read failed".to_owned(),
+            Err(PublishError::EmptyHeadCid) => "empty head CID (never published)".to_owned(),
             // A no-renewal (comfortably ahead) or a clean republish is not a
             // failure — nothing to surface.
             Ok(Some(PublishOutcome::Published { .. })) | Ok(None) => continue,
@@ -987,9 +988,12 @@ impl<T: SeamTypes> Engine<T> {
                 let material = HeldMaterial {
                     node_id: root_id,
                     write_scope_seed: None,
-                    head_cid: String::new(),
                     content_cids: Vec::new(),
                 };
+                // The resolve outcome (incl. a steady-state `TrustViolation`) is
+                // dropped: fail-closed for data (a forged record is never held or
+                // rendered), but surfacing it as a staleness-ladder /
+                // `AttributableAbuse` event is a later slice.
                 let _ = resolve_and_hold(
                     &transport,
                     &snapshot_cache,

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -722,7 +722,6 @@ impl<T: SeamTypes> Engine<T> {
         let profile = self.profile;
         let held = self.held_records.clone();
         let alive = self.alive.clone();
-        let session = self.session.clone();
         // One API client for the whole task: register-first renewal needs the
         // API, and the refresh token lives in the credential store, so the client
         // self-heals its access token on a 401 across the session's lifetime.
@@ -740,12 +739,11 @@ impl<T: SeamTypes> Engine<T> {
                 }
                 let records: Vec<HeldRecord> = held.borrow().values().cloned().collect();
                 keyless_re_put(&transport, &records).await;
-                if let Some(session) = session.as_deref() {
-                    eol_renew_pass(
-                        &transport, &api, &floors, &scheduler, &profile, session, &records,
-                    )
-                    .await;
-                }
+                // The renewal outcomes (LostRace/PublishError) are dropped until
+                // the resolve-tick driver surfaces them via Event/dead-letter
+                // (#752); the held set is empty until that slice populates it.
+                let _ =
+                    eol_renew_pass(&transport, &api, &floors, &scheduler, &profile, &records).await;
                 LivenessControl::Continue
             })
             .await;
@@ -949,22 +947,12 @@ mod tests {
             .session()
             .expect("start derives the session identity");
 
-        // The per-name signers #750/#751 need are reachable and match the pure
-        // derivation from the same secret — start invents no key material.
+        // Start derives the same identity as the pure derivation from the same
+        // secret — it invents no key material.
         let expected = SessionIdentity::derive(&LoginSecret::new(vec![7u8; 32]));
         assert_eq!(
             session.vault_pointer_signer(0).verifying_key().to_bytes(),
             expected.vault_pointer_signer(0).verifying_key().to_bytes(),
-        );
-        assert_eq!(
-            session
-                .write_name_signer(&[5u8; 32], &[4u8; 16])
-                .verifying_key()
-                .to_bytes(),
-            expected
-                .write_name_signer(&[5u8; 32], &[4u8; 16])
-                .verifying_key()
-                .to_bytes(),
         );
     }
 

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -1266,16 +1266,20 @@ mod tests {
                 &self,
                 _name: &IpnsName,
                 _record_bytes: &[u8],
-            ) -> Result<Adopted, crate::gate::GateError> {
-                Ok(Adopted {
-                    read_body: ReadBody::Folder {
-                        created_at: 0,
-                        modified_at: 0,
-                        children: Vec::new(),
-                        unknown: Vec::new(),
+            ) -> Result<crate::net::AdoptOutcome, crate::gate::GateError> {
+                Ok(crate::net::AdoptOutcome {
+                    adopted: Adopted {
+                        read_body: ReadBody::Folder {
+                            created_at: 0,
+                            modified_at: 0,
+                            children: Vec::new(),
+                            unknown: Vec::new(),
+                        },
+                        sequence: 1,
+                        epoch: 1,
                     },
-                    sequence: 1,
-                    epoch: 1,
+                    write_scope_seed: None,
+                    node_id: [0u8; 16],
                 })
             }
         }

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -423,9 +423,8 @@ impl EngineError {
         }
     }
 
-    /// Map a cold-start failure onto the facade error. A host seam stays
-    /// availability; the caller-ordering precondition maps verbatim; every trust
-    /// arm (forged pointer, regressed floor, rejected root) surfaces as the
+    /// Map a cold-start failure onto the facade error: every trust arm (forged
+    /// pointer, regressed floor, rejected root) collapses to the single
     /// fail-closed [`ColdStart`](EngineError::ColdStart) — never retryable
     /// availability.
     fn from_cold_start(err: ColdStartError) -> Self {
@@ -581,9 +580,7 @@ fn count_nodes(snapshot: &Snapshot) -> u64 {
 
 /// The re-point pointer-payload wire version the owner's own vault seals under
 /// and the cold-start walk verifies against (`crates/core` pointer payload) — the
-/// sole v2 version. The vault's own root scope and root node are the anchored
-/// all-zero `id16`: the bootstrap anchor a cold start knows from the login secret
-/// alone, before any record resolves (CONTEXT.md "Vault pointer").
+/// sole v2 version (CONTEXT.md "Vault pointer").
 const POINTER_PAYLOAD_VERSION: u64 = 1;
 
 /// The engine — the single stateful brain behind the facade.
@@ -703,10 +700,9 @@ impl<T: SeamTypes> Engine<T> {
         drop(secret);
 
         // The one shared client for login, publish, and renewal. Login is
-        // fail-closed: on any error `start` returns before it commits the
-        // session or spawns the liveness loop, so no half-initialized state
-        // survives and the loop never runs unauthenticated (rules 3/6). An
-        // empty base URL is the pre-integration dormant state (field doc) — no
+        // fail-closed: a rejected login returns before the session is committed
+        // or any loop spawns, so the loop never runs unauthenticated (rules 3/6).
+        // An empty base URL is the pre-integration dormant state (field doc) — no
         // API to authenticate against, so login is skipped.
         let api = Rc::new(ApiClient::new(
             self.seams.http.clone(),
@@ -725,13 +721,12 @@ impl<T: SeamTypes> Engine<T> {
         // Cold-start data path (E4/E7): resolve the owner vault pointer, cold-seed
         // the floors, adopt the current root through the gate, and project its base
         // snapshot — all off the production `RecordPointerFetch`/`RootAdopter` over
-        // the engine's own gateway/seams. Fail-closed: a trust violation returns
-        // here, before either background loop spawns, so nothing runs past an
-        // unadopted root (rules 4/6). An empty chain (a first-run vault with no
-        // pointer yet) degrades to the anchored root with no error. The adopter and
-        // pointer fetch borrow `&self`, so they live only inside this block and
-        // release before the base snapshot is assigned.
-        let outcome = {
+        // the engine's own gateway/seams. Fail-closed: a trust violation clears the
+        // just-derived session and returns before either background loop spawns, so
+        // no derived key material stays resident and nothing runs past an unadopted
+        // root (rules 4/6). An empty chain (a first-run vault with no pointer yet)
+        // degrades to the anchored root with no error.
+        let cold_start = {
             let session = self.session.as_ref().expect("session set above");
             let owner_identity = session.owner_identity();
             let root = self.snapshot.root;
@@ -754,7 +749,16 @@ impl<T: SeamTypes> Engine<T> {
                 root,
             )
             .await
-            .map_err(EngineError::from_cold_start)?
+        };
+        let outcome = match cold_start {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                // Fail-closed symmetry with the login path: clear the derived
+                // session so no key material stays resident and the engine reports
+                // unstarted.
+                self.session = None;
+                return Err(EngineError::from_cold_start(err));
+            }
         };
 
         // The gate-passing base becomes the state law's left operand (reads render
@@ -903,11 +907,8 @@ impl<T: SeamTypes> Engine<T> {
         let held = self.held_records.clone();
         let alive = self.alive.clone();
         let events = self.events.clone();
-        // The shared client from `start`: its access JWT is already live from the
-        // cold-start login, so the renewal pass reuses it (no redundant
-        // 401→refresh) and self-heals on expiry via the credential store. The
-        // renewal pass only fires once the resolve-tick driver populates the held
-        // set.
+        // The shared client from `start` (see the `api` field): the renewal pass
+        // only fires once the resolve-tick driver populates the held set.
         self.seams.scheduler.spawn(Box::pin(async move {
             run_liveness_loop(&scheduler, RE_PUT_INTERVAL, || async {
                 if !alive.get() {
@@ -2304,6 +2305,43 @@ mod tests {
             assert_eq!(children[0].id, NodeId(CHILD_ID));
             assert_eq!(children[0].name, CHILD_NAME);
             assert_eq!(children[0].kind, NodeKind::File);
+        }
+
+        #[test]
+        fn start_cold_start_trust_failure_is_fail_closed() {
+            let world = FakeWorld::new();
+            let device = world.device(b"alice-pk");
+            let (_head_block, head_cid, root_name) = owner_root();
+            seed_vault_pointer(&device, &root_name);
+            for endpoint in device.record_store.endpoints() {
+                seed_root_record_at(&device, &endpoint, &root_name, &head_cid);
+            }
+            // The adopt fetches the head block over the gateway, but the returned
+            // bytes do not hash to the record's head CID: a fail-closed trust
+            // violation surfaces as `ColdStart`.
+            device
+                .http
+                .enqueue_response(head_response(b"forged head block"));
+
+            let (mut engine, _events) = engine_on(&device);
+            let out = block_on(engine.start(LoginSecret::new(CAP_SECRET.to_vec())));
+
+            assert!(
+                matches!(out, Err(EngineError::ColdStart { .. })),
+                "a forged cold-start root is a hard trust failure, not a start: {out:?}"
+            );
+            // Mirrors `start_login_failure_is_fail_closed`: the derived session is
+            // cleared, so no key material stays resident and the engine reports
+            // unstarted.
+            assert!(
+                engine.session().is_none(),
+                "a fail-closed cold start leaves no derived session resident"
+            );
+            assert_eq!(
+                block_on(engine.command(Command::ManualRefresh)),
+                Err(EngineError::NotStarted),
+                "the engine stays unstarted after a cold-start trust failure"
+            );
         }
 
         #[test]

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -27,8 +27,9 @@ use futures_channel::mpsc;
 use futures_core::Stream;
 use zeroize::Zeroizing;
 
-use crate::api::ApiClient;
+use crate::api::{ApiClient, ApiError, IdentityChallengeSigner};
 use crate::entropy::Entropy;
+use crate::hex::hex_lower;
 use crate::net::{
     Adopter, EolRenewResult, HeldRecord, HeldRecords, LivenessControl, PublishError,
     PublishOutcome, RE_PUT_INTERVAL, eol_renew_pass, keyless_re_put, run_liveness_loop,
@@ -386,12 +387,26 @@ pub enum EngineError {
         /// Diagnostic message; never carries key material.
         message: String,
     },
+    /// An authenticated API call failed (cold-start login or SIWE): a rejected
+    /// credential or an unreachable API. Fail-closed — `start` propagates it
+    /// rather than running unauthenticated. The message is the API's own
+    /// diagnostic, never key material.
+    Auth {
+        /// Diagnostic message; never carries key material.
+        message: String,
+    },
 }
 
 impl EngineError {
     fn from_seam(err: SeamError) -> Self {
         EngineError::Seam {
             message: err.message().to_owned(),
+        }
+    }
+
+    fn from_api(err: ApiError) -> Self {
+        EngineError::Auth {
+            message: err.to_string(),
         }
     }
 }
@@ -409,6 +424,7 @@ impl fmt::Display for EngineError {
             }
             EngineError::Seam { message } => write!(f, "seam error: {message}"),
             EngineError::Entropy { message } => write!(f, "entropy error: {message}"),
+            EngineError::Auth { message } => write!(f, "auth error: {message}"),
         }
     }
 }
@@ -570,6 +586,10 @@ pub struct Engine<T: SeamTypes> {
     /// slices read every signer from here. Behind an [`Rc`] so the spawned
     /// liveness loop shares it for the sub-EOL renewal's per-name signers.
     session: Option<Rc<SessionIdentity>>,
+    /// The one shared API client, built and logged in at [`start`](Self::start)
+    /// and handed to the liveness loop so the access JWT is shared across
+    /// publish/renew (no redundant 401→refresh). `None` until then.
+    api: Option<Rc<ApiClient<T::Http, T::CredentialStore>>>,
     started: bool,
 }
 
@@ -596,6 +616,7 @@ impl<T: SeamTypes> Engine<T> {
                 held_records: Rc::new(RefCell::new(HeldRecords::new())),
                 alive: Rc::new(Cell::new(true)),
                 session: None,
+                api: None,
                 started: false,
             },
             EventStream { receiver },
@@ -632,9 +653,30 @@ impl<T: SeamTypes> Engine<T> {
         }
         // Pure derivation from the injected secret — no clock, no RNG — then
         // the secret zeroizes on drop here, at its terminal owner.
-        self.session = Some(Rc::new(SessionIdentity::derive(&secret)?));
+        let session = Rc::new(SessionIdentity::derive(&secret)?);
         drop(secret);
-        self.spawn_liveness_loop();
+
+        // The one shared client for login, publish, and renewal. Login is
+        // fail-closed: on any error `start` returns before it commits the
+        // session or spawns the liveness loop, so no half-initialized state
+        // survives and the loop never runs unauthenticated (rules 3/6). An
+        // empty base URL is the pre-integration dormant state (field doc) — no
+        // API to authenticate against, so login is skipped.
+        let api = Rc::new(ApiClient::new(
+            self.seams.http.clone(),
+            self.seams.credential_store.clone(),
+            self.api_base_url.clone(),
+        ));
+        if !self.api_base_url.is_empty() {
+            let signer = IdentityChallengeSigner::from_signer(session.identity().clone());
+            api.login_identity(&signer)
+                .await
+                .map_err(EngineError::from_api)?;
+        }
+
+        self.session = Some(session);
+        self.spawn_liveness_loop(api.clone());
+        self.api = Some(api);
         self.started = true;
         Ok(())
     }
@@ -754,7 +796,7 @@ impl<T: SeamTypes> Engine<T> {
     /// sub-EOL seq+1 renewal (any name inside the 30-day EOL window). The task
     /// holds only `Rc`/seam-handle clones, so the engine may drop while it is
     /// parked; the alive latch then stops it.
-    fn spawn_liveness_loop(&self)
+    fn spawn_liveness_loop(&self, api: Rc<ApiClient<T::Http, T::CredentialStore>>)
     where
         T::Scheduler: Clone + 'static,
         T::RecordTransport: Clone + 'static,
@@ -769,16 +811,11 @@ impl<T: SeamTypes> Engine<T> {
         let held = self.held_records.clone();
         let alive = self.alive.clone();
         let events = self.events.clone();
-        // One API client for the whole task: register-first renewal needs the
-        // API, and the refresh token lives in the credential store, so the client
-        // self-heals its access token on a 401 across the session's lifetime. The
+        // The shared client from `start`: its access JWT is already live from the
+        // cold-start login, so the renewal pass reuses it (no redundant
+        // 401→refresh) and self-heals on expiry via the credential store. The
         // renewal pass only fires once the resolve-tick driver populates the held
         // set.
-        let api = ApiClient::new(
-            self.seams.http.clone(),
-            self.seams.credential_store.clone(),
-            self.api_base_url.clone(),
-        );
         self.seams.scheduler.spawn(Box::pin(async move {
             run_liveness_loop(&scheduler, RE_PUT_INTERVAL, || async {
                 if !alive.get() {
@@ -850,6 +887,13 @@ impl<T: SeamTypes> Engine<T> {
                 // trailing bools: cross_scope=false, exits_granted_source=false — intra-scope pure relink
                 let op = Op::relink(node, from_parent, new_parent, base_sequence, false, false);
                 self.stage_and_notify(&op).await
+            }
+            Command::SiweLogin { message, signature } => {
+                let api = self.api.as_ref().ok_or(EngineError::NotStarted)?;
+                api.siwe_login(&message, &hex_lower(&signature))
+                    .await
+                    .map_err(EngineError::from_api)?;
+                Ok(())
             }
             other => Err(EngineError::Unimplemented {
                 command: other.name(),
@@ -952,8 +996,32 @@ impl<T: SeamTypes> Drop for Engine<T> {
 mod tests {
     use super::*;
 
-    use crate::seams::UnixMillis;
-    use crate::testkit::{FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
+    use serde_json::{Value, json};
+
+    use crate::seams::{CredentialStore, HttpResponse, UnixMillis};
+    use crate::testkit::{FakeDevice, FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
+
+    /// A JSON HTTP response the scripted client decodes as a Nest body.
+    fn json_response(status: u16, body: Value) -> HttpResponse {
+        HttpResponse {
+            status,
+            headers: vec![("Content-Type".to_owned(), "application/json".to_owned())],
+            body: serde_json::to_vec(&body).unwrap(),
+        }
+    }
+
+    /// An engine over a retained device (so the test scripts HTTP and inspects
+    /// the credential store), against `base_url`.
+    fn engine_over(base_url: &str) -> (Engine<FakeSeamTypes>, EventStream, FakeDevice) {
+        let device = FakeWorld::new().device(b"alice-pk");
+        let (engine, events) = Engine::new(
+            device.seam_set(),
+            Box::new(SeededEntropy::new(42)),
+            SyncTimingProfile::CI,
+            base_url.to_owned(),
+        );
+        (engine, events, device)
+    }
 
     fn new_engine() -> (Engine<FakeSeamTypes>, EventStream) {
         let device = FakeWorld::new().device(b"alice-pk");
@@ -1023,6 +1091,108 @@ mod tests {
             a.session().unwrap().enc_subkey_public().to_bytes(),
             c.session().unwrap().enc_subkey_public().to_bytes(),
             "a different secret is a different identity",
+        );
+    }
+
+    #[test]
+    fn start_performs_identity_login_and_persists_a_refresh_token() {
+        let (mut engine, _events, device) = engine_over("http://api.test");
+        device.http.enqueue_response(json_response(
+            200,
+            json!({ "challenge": "cipherbox-login:v2:abc", "expiresAt": "2099-01-01T00:00:00Z" }),
+        ));
+        device.http.enqueue_response(json_response(
+            200,
+            json!({ "accessToken": "jwt-1", "refreshToken": "a".repeat(64), "isNewUser": true }),
+        ));
+
+        block_on(engine.start(LoginSecret::new(vec![7u8; 32]))).expect("start logs in");
+
+        // The refresh token from the token response persisted via CredentialStore.
+        let stored = block_on(device.credential_store.load_refresh_token())
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored, "a".repeat(64).as_bytes());
+
+        // The login signed the server challenge with the session identity signer:
+        // the wire signature equals the identity's own deterministic signature.
+        let requests = device.http.requests();
+        assert_eq!(requests[1].url, "http://api.test/auth/login");
+        let login_body: Value = serde_json::from_slice(requests[1].body.as_ref().unwrap()).unwrap();
+        let identity = engine.session().unwrap().identity();
+        let expected = hex_lower(
+            &identity
+                .sign_detcbor(b"cipherbox-login:v2:abc")
+                .to_compact(),
+        );
+        assert_eq!(login_body["signature"], expected);
+    }
+
+    #[test]
+    fn start_login_failure_is_fail_closed() {
+        let (mut engine, _events, device) = engine_over("http://api.test");
+        device.http.enqueue_response(json_response(
+            200,
+            json!({ "challenge": "c", "expiresAt": "2099-01-01T00:00:00Z" }),
+        ));
+        device.http.enqueue_response(json_response(
+            401,
+            json!({ "message": "Invalid challenge signature" }),
+        ));
+        // Clear any pre-start bookkeeping so the spawn assertion is unambiguous.
+        let _ = device.scheduler.take_spawned_tasks();
+
+        let out = block_on(engine.start(LoginSecret::new(vec![7u8; 32])));
+
+        assert!(
+            matches!(out, Err(EngineError::Auth { .. })),
+            "a rejected login is a hard error, not a start"
+        );
+        assert!(
+            engine.session().is_none(),
+            "session not left half-initialized on login failure"
+        );
+        assert!(
+            device.scheduler.take_spawned_tasks().is_empty(),
+            "no liveness loop spawned before authentication succeeds"
+        );
+        assert_eq!(
+            block_on(engine.command(Command::ManualRefresh)),
+            Err(EngineError::NotStarted),
+            "the engine stays unstarted after a failed login"
+        );
+    }
+
+    #[test]
+    fn siwe_login_command_forwards_message_and_hex_signature() {
+        // Empty base: `start` skips cold-start login, so only the SIWE exchange
+        // is scripted here.
+        let (mut engine, _events, device) = engine_over("");
+        block_on(engine.start(LoginSecret::new(vec![7u8; 32]))).unwrap();
+        device.http.enqueue_response(json_response(
+            200,
+            json!({ "accessToken": "jwt-siwe", "refreshToken": "b".repeat(64) }),
+        ));
+
+        let signature = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        block_on(engine.command(Command::SiweLogin {
+            message: "siwe-message".to_owned(),
+            signature: signature.clone(),
+        }))
+        .expect("siwe login");
+
+        let request = device
+            .http
+            .requests()
+            .pop()
+            .expect("a SIWE request was sent");
+        assert_eq!(request.url, "/auth/siwe/login");
+        let body: Value = serde_json::from_slice(request.body.as_ref().unwrap()).unwrap();
+        assert_eq!(body["message"], "siwe-message");
+        assert_eq!(
+            body["signature"],
+            hex_lower(&signature),
+            "the wallet signature crosses the wire hex-encoded"
         );
     }
 

--- a/crates/engine/src/gate/adoption.rs
+++ b/crates/engine/src/gate/adoption.rs
@@ -31,6 +31,7 @@ use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaVerifier};
 use cipherbox_core::suite::ed25519::{Ed25519Signature, Ed25519Verifier};
 use cipherbox_core::suite::secret::SecretBytes;
 use cipherbox_core::suite::x25519::X25519Secret;
+use zeroize::Zeroizing;
 
 use crate::gate::floor;
 use crate::seams::{FloorStore, SeamError};
@@ -373,10 +374,17 @@ impl SeedBlob<'_> {
     }
 }
 
-/// Open the reader's HPKE seed source, returning the recovered scope seed so the
-/// gate can cross-check it derives the reader's read key. The returned
-/// [`SecretBytes`] zeroizes on drop at the gate (the terminal owner).
-fn open_seed_blob(blob: &SeedBlob<'_>) -> Result<SecretBytes, CodecError> {
+/// The two seeds a seed blob yields: the recovered read scope seed (always) and,
+/// for a write-grantee, the scope write seed the held set derives its renewal
+/// signer from (`None` for a read-only grant and the owner arm). Both zeroize on
+/// drop.
+type UnsealedSeeds = (SecretBytes, Option<Zeroizing<[u8; 32]>>);
+
+/// Open the reader's HPKE seed source, returning the recovered read scope seed
+/// (for the gate's read-key cross-check) and, for a write-grantee, the write
+/// scope seed. The write seed is consumed by the resolve/gate driver that keeps
+/// a write-capable scope alive (blueprint/engine.md "Liveness").
+fn open_seed_blob(blob: &SeedBlob<'_>) -> Result<UnsealedSeeds, CodecError> {
     match blob {
         SeedBlob::Owner {
             enc_secret,
@@ -385,7 +393,7 @@ fn open_seed_blob(blob: &SeedBlob<'_>) -> Result<SecretBytes, CodecError> {
             aad,
         } => {
             let payload = open_owner_blob(enc_secret, enc, aad, ciphertext)?;
-            Ok(SecretBytes::new(*payload.override_seed()))
+            Ok((SecretBytes::new(*payload.override_seed()), None))
         }
         SeedBlob::Grantee {
             enc_secret,
@@ -394,7 +402,11 @@ fn open_seed_blob(blob: &SeedBlob<'_>) -> Result<SecretBytes, CodecError> {
             aad,
         } => {
             let payload = open_grant_blob(enc_secret, enc, aad, ciphertext)?;
-            Ok(SecretBytes::new(*payload.read_scope_seed()))
+            let write_scope_seed = payload.write_scope_seed().copied().map(Zeroizing::new);
+            Ok((
+                SecretBytes::new(*payload.read_scope_seed()),
+                write_scope_seed,
+            ))
         }
     }
 }
@@ -410,7 +422,7 @@ pub async fn adopt_deferred<F: FloorStore>(
     floors: &F,
     reader: &ReaderContext<'_>,
     candidate: &Candidate,
-) -> Result<PendingAdoption, GateError> {
+) -> Result<(PendingAdoption, Option<Zeroizing<[u8; 32]>>), GateError> {
     // Stage 1 — record verify (Ed25519 key from the name itself).
     let verified = IpnsRecord::unmarshal(&candidate.record_bytes)
         .and_then(|record| record.verify(&candidate.name))
@@ -588,6 +600,10 @@ pub async fn adopt_deferred<F: FloorStore>(
             RejectionReason::Trust(TrustViolation::SealOpenFailed.into()),
         ));
     }
+    // A write-grantee's blob also carries the scope write seed the held set
+    // derives its per-name renewal signer from; `None` for a read-only grant,
+    // the owner arm, or a holder that passes no seed blob.
+    let mut write_scope_seed = None;
     if let Some(blob) = &reader.seed_blob {
         // Bind the blob to THIS envelope: a seed blob sealed under a different
         // scope/epoch/version is a transplant, not this record's seed source.
@@ -607,7 +623,7 @@ pub async fn adopt_deferred<F: FloorStore>(
         // Cross-check: the recovered seed must derive the reader's read key, or
         // the blob-seed and the actual-unseal key disagree — an attributable
         // abuse event (blueprint/engine.md), never a silent staleness.
-        let seed = open_seed_blob(blob)
+        let (seed, ws) = open_seed_blob(blob)
             .map_err(|e| reject(GateStage::Unseal, RejectionReason::Trust(e)))?;
         let node_seed = kdf::node_seed(seed.as_bytes(), &candidate.envelope.id);
         let derived_read_key = kdf::read_key(node_seed.as_bytes());
@@ -617,37 +633,42 @@ pub async fn adopt_deferred<F: FloorStore>(
                 RejectionReason::Trust(TrustViolation::SealOpenFailed.into()),
             ));
         }
+        write_scope_seed = ws;
     }
     let read_body = open_read_body(&candidate.envelope, reader.read_key)
         .map_err(|e| reject(GateStage::Unseal, RejectionReason::Trust(e)))?;
 
     // All six stages passed; the floor-law advance is DEFERRED to
     // [`PendingAdoption::commit`] (see that type's contract).
-    Ok(PendingAdoption {
-        adopted: Adopted {
-            read_body,
-            sequence: verified.sequence,
-            epoch,
+    Ok((
+        PendingAdoption {
+            adopted: Adopted {
+                read_body,
+                sequence: verified.sequence,
+                epoch,
+            },
+            scope_id: reader.scope_id,
+            ipns_name: name_bytes.to_vec(),
         },
-        scope_id: reader.scope_id,
-        ipns_name: name_bytes.to_vec(),
-    })
+        write_scope_seed,
+    ))
 }
 
 /// Run the adoption gate and, on success, immediately advance the floor law
 /// (the AAD-confirmed-unseal rule). The eager path for callers that hold no
 /// accepted state to persist first (e.g. a plain resolve); a caller that must
 /// make the floor advance atomic with a durable write uses [`adopt_deferred`]
-/// plus [`PendingAdoption::commit`].
+/// plus [`PendingAdoption::commit`]. Returns the adopted state and, for a
+/// write-grantee, the transient scope write seed the held set derives its
+/// renewal signer from (`None` for a read-only holder and the owner arm).
 pub async fn adopt<F: FloorStore>(
     floors: &F,
     reader: &ReaderContext<'_>,
     candidate: &Candidate,
-) -> Result<Adopted, GateError> {
-    adopt_deferred(floors, reader, candidate)
-        .await?
-        .commit(floors)
-        .await
+) -> Result<(Adopted, Option<Zeroizing<[u8; 32]>>), GateError> {
+    let (pending, write_scope_seed) = adopt_deferred(floors, reader, candidate).await?;
+    let adopted = pending.commit(floors).await?;
+    Ok((adopted, write_scope_seed))
 }
 
 /// Build a `GateError::Rejected` from a stage and reason.

--- a/crates/engine/src/grants/accept.rs
+++ b/crates/engine/src/grants/accept.rs
@@ -479,8 +479,10 @@ pub async fn accept_share<F: FloorStore, M: Mailbox, S: ReceivedShareStore>(
     // floor must not move ahead of the bookmark it accepts. If the persist below
     // fails the floor stays put, so redelivery re-adopts cleanly instead of being
     // stranded below an already-advanced floor (a permanently-lost share).
+    // The share-accept flow does not hold the scope for liveness here, so the
+    // write-grantee seed the gate surfaces is dropped (the `_`).
     let pending = match adopt_deferred(floors, &reader, candidate).await {
-        Ok(pending) => pending,
+        Ok((pending, _)) => pending,
         Err(e) => {
             // Idempotent ack-only short-circuit. A strict-sequence anti-replay
             // reject for a scope we ALREADY durably hold is a redelivery whose

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -70,8 +70,9 @@ pub use grants::{
 };
 pub use mailbox::{VerifiedMailboxItem, poll_verified, post_sealed};
 pub use net::{
-    Adopter, HeldRecord, PublishError, PublishOutcome, PublishRequest, RePutResult, ResolveOutcome,
-    Resolved, ReviveError, ReviveRequest, publish, resolve, revive,
+    Adopter, HeldMaterial, HeldRecord, HeldRecords, PublishError, PublishOutcome, PublishRequest,
+    RePutResult, ResolveOutcome, Resolved, ReviveError, ReviveRequest, publish, resolve,
+    resolve_and_hold, revive,
 };
 pub use profile::SyncTimingProfile;
 pub use rotation::{

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -70,8 +70,8 @@ pub use grants::{
 };
 pub use mailbox::{VerifiedMailboxItem, poll_verified, post_sealed};
 pub use net::{
-    Adopter, HeldRecord, HeldRecords, PublishError, PublishOutcome, PublishRequest, RePutResult,
-    ResolveOutcome, Resolved, ReviveError, ReviveRequest, publish, resolve, revive,
+    AdoptOutcome, Adopter, HeldRecord, HeldRecords, PublishError, PublishOutcome, PublishRequest,
+    RePutResult, ResolveOutcome, Resolved, ReviveError, ReviveRequest, publish, resolve, revive,
 };
 pub use profile::SyncTimingProfile;
 pub use rotation::{

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -48,10 +48,10 @@ pub use api::{
 };
 pub use content::{
     ByoIpfsConfig, ByoKind, ContentDag, ContentKey, ContentPlane, ContentProfile, ContentVersion,
-    DAG_ROOT_CODEC, DagError, Gateway, GatewaySource, PinMode, ProviderError, PrunePlan,
-    QuotaExceeded, ReadError, RootManifest, SealError, SealedChunk, SealedContent, assemble,
-    decode_root, frame_and_seal, leaf_range_for_byte_range, plan_prune, pre_flight_quota_check,
-    read_block, seal_content, test_connection, validate_endpoint,
+    DAG_ROOT_CODEC, DagError, Gateway, GatewayConfig, GatewaySource, PinMode, ProviderError,
+    PrunePlan, QuotaExceeded, ReadError, RootManifest, SealError, SealedChunk, SealedContent,
+    assemble, decode_root, frame_and_seal, leaf_range_for_byte_range, plan_prune,
+    pre_flight_quota_check, read_block, seal_content, test_connection, validate_endpoint,
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -70,9 +70,8 @@ pub use grants::{
 };
 pub use mailbox::{VerifiedMailboxItem, poll_verified, post_sealed};
 pub use net::{
-    Adopter, HeldMaterial, HeldRecord, HeldRecords, PublishError, PublishOutcome, PublishRequest,
-    RePutResult, ResolveOutcome, Resolved, ReviveError, ReviveRequest, publish, resolve,
-    resolve_and_hold, revive,
+    Adopter, HeldRecord, HeldRecords, PublishError, PublishOutcome, PublishRequest, RePutResult,
+    ResolveOutcome, Resolved, ReviveError, ReviveRequest, publish, resolve, revive,
 };
 pub use profile::SyncTimingProfile;
 pub use rotation::{

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -71,7 +71,8 @@ pub use grants::{
 pub use mailbox::{VerifiedMailboxItem, poll_verified, post_sealed};
 pub use net::{
     AdoptOutcome, Adopter, HeldRecord, HeldRecords, PublishError, PublishOutcome, PublishRequest,
-    RePutResult, ResolveOutcome, Resolved, ReviveError, ReviveRequest, publish, resolve, revive,
+    RePutResult, ResolveOutcome, Resolved, ReviveError, ReviveRequest, RootAdopter, publish,
+    resolve, revive,
 };
 pub use profile::SyncTimingProfile;
 pub use rotation::{

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -71,8 +71,8 @@ pub use grants::{
 pub use mailbox::{VerifiedMailboxItem, poll_verified, post_sealed};
 pub use net::{
     AdoptOutcome, Adopter, HeldRecord, HeldRecords, PublishError, PublishOutcome, PublishRequest,
-    RePutResult, ResolveOutcome, Resolved, ReviveError, ReviveRequest, RootAdopter, publish,
-    resolve, revive,
+    RePutResult, RecordPointerFetch, ResolveOutcome, Resolved, ReviveError, ReviveRequest,
+    RootAdopter, publish, resolve, revive,
 };
 pub use profile::SyncTimingProfile;
 pub use rotation::{

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -1,0 +1,519 @@
+//! The production [`Adopter`]: cold-start content-plane assembly (blueprint/
+//! engine.md "Resolve/publish pipeline", "Adoption gate and floors").
+//!
+//! The resolve pipeline routes every fetched record through [`Adopter::adopt`];
+//! this is the concrete owner-arm implementation for the vault's own root. It
+//! assembles the content-plane [`Candidate`] — recover the head CID anchor from
+//! the signed record, fetch the head block fail-closed on a CID mismatch, decode
+//! the envelope and its grant section — then builds the owner's [`ReaderContext`]
+//! and calls [`gate::adopt`](crate::gate::adopt). The adopter adds **no** trust
+//! logic: it only assembles inputs; every trust decision (commitment, structure
+//! signatures, seed cross-checks, read-body unseal, floor law) stays in the gate.
+//!
+//! Minimal cold-start scope (#789): read-only. The write-plane owner-write-blob
+//! recovery (owner self-renewal) and the owner-seed-cache tri-way abuse
+//! cross-check are later slices; a tampered owner blob still fails closed here at
+//! the grant-section structure signature and the read-body unseal.
+
+use cipherbox_core::content::decode_content_cid_str;
+use cipherbox_core::error::{CodecError, Malformed};
+use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::kdf;
+use cipherbox_core::seal::{
+    AadContext, STRUCT_TAG_OWNER_BLOB, decode_envelope, decode_grant_section, grant_section_bytes,
+    open_owner_blob,
+};
+use cipherbox_core::suite::ecdsa::EcdsaVerifier;
+use cipherbox_core::suite::x25519::X25519Secret;
+use zeroize::Zeroizing;
+
+use super::publish::head_cid_from_value;
+use super::resolve::{AdoptOutcome, Adopter};
+use crate::content::{ContentPlane, Gateway, ReadError, read_block};
+use crate::gate::{
+    Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason, SeedBlob, adopt,
+};
+use crate::seams::{FloorStore, Http, SeamError};
+
+/// The cold-start owner-root [`Adopter`]. Borrows the content-plane seams and
+/// the owner's identity/sealing material from the live session; the vault owner
+/// is the terminal owner of its own key material, so nothing is zeroized here.
+pub struct RootAdopter<'a, H, F> {
+    /// Content read sources (accelerator + public fallbacks).
+    gateway: &'a Gateway,
+    /// The HTTP seam the content fetch rides.
+    http: &'a H,
+    /// The durable floor store the gate reads and advances.
+    floors: &'a F,
+    /// The owner's X25519 encryption secret — opens the root owner blob to
+    /// recover the scope seed.
+    owner_enc_secret: &'a X25519Secret,
+    /// The contact-anchored owner identity verifier (the gate's stage-2 anchor).
+    owner_identity: &'a EcdsaVerifier,
+    /// The vault root scope id (the AAD scope binding and the read-epoch floor
+    /// key). A resolved root whose envelope scope disagrees is a scope transplant
+    /// the gate rejects fail-closed.
+    root_scope_id: [u8; 16],
+}
+
+impl<'a, H, F> RootAdopter<'a, H, F> {
+    /// Assemble the cold-start owner-root adopter over the borrowed seams and the
+    /// session's owner material.
+    pub fn new(
+        gateway: &'a Gateway,
+        http: &'a H,
+        floors: &'a F,
+        owner_enc_secret: &'a X25519Secret,
+        owner_identity: &'a EcdsaVerifier,
+        root_scope_id: [u8; 16],
+    ) -> Self {
+        Self {
+            gateway,
+            http,
+            floors,
+            owner_enc_secret,
+            owner_identity,
+            root_scope_id,
+        }
+    }
+}
+
+impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
+    /// Steps 1-5: turn a fetched record into a content-plane [`Candidate`].
+    /// Verifies the record only to read its signed head anchor (the gate
+    /// re-verifies from scratch); fetches the head block fail-closed on a CID
+    /// mismatch; decodes the envelope and its grant section.
+    async fn assemble_candidate(
+        &self,
+        name: &IpnsName,
+        record_bytes: &[u8],
+    ) -> Result<Candidate, GateError> {
+        // Step 1 — verify to read the signed `/ipfs/<cid>` value (the head
+        // anchor). Trust is the gate's; this only extracts the anchor.
+        let verified = IpnsRecord::unmarshal(record_bytes)
+            .and_then(|record| record.verify(name))
+            .map_err(assembly_reject)?;
+
+        // Step 2/3 — recover the head CID string and the binary CIDv1 anchor.
+        let cid_str = head_cid_from_value(&verified.value)
+            .ok_or_else(|| assembly_reject(Malformed::ContentCidStrMalformed.into()))?;
+        let expected_cid = decode_content_cid_str(&cid_str).map_err(assembly_reject)?;
+
+        // Step 4 — fetch the head block (dag-cbor root), fail-closed on mismatch.
+        let block = read_block(
+            self.gateway,
+            self.http,
+            &cid_str,
+            &expected_cid,
+            ContentPlane::Root,
+        )
+        .await
+        .map_err(map_read_error)?;
+
+        // Step 5 — decode the envelope and its grant section.
+        let envelope = decode_envelope(&block).map_err(assembly_reject)?;
+        let section_bytes = grant_section_bytes(&envelope).ok_or_else(|| {
+            assembly_reject(
+                Malformed::MissingField {
+                    field: "grantSection",
+                }
+                .into(),
+            )
+        })?;
+        let grant_section = decode_grant_section(section_bytes).map_err(assembly_reject)?;
+
+        Ok(Candidate {
+            name: name.clone(),
+            record_bytes: record_bytes.to_vec(),
+            grant_section,
+            envelope,
+        })
+    }
+}
+
+impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
+    async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<AdoptOutcome, GateError> {
+        let candidate = self.assemble_candidate(name, record_bytes).await?;
+
+        // Step 6 — owner-blob ReaderContext. The vault owner recovers its own root
+        // scope seed from the record's owner blob (the read-plane seed source) and
+        // derives the read key; the gate re-opens the same blob, cross-checks the
+        // seed derives this key, and unseals the read-body.
+        let env = &candidate.envelope;
+        let owner_blob = &candidate.grant_section.owner_blob;
+        let owner_blob_aad = AadContext {
+            v: env.v,
+            id: env.id,
+            scope: env.scope,
+            epoch: env.epoch,
+            struct_tag: STRUCT_TAG_OWNER_BLOB,
+        };
+        let payload = open_owner_blob(
+            self.owner_enc_secret,
+            &owner_blob.enc,
+            &owner_blob_aad,
+            &owner_blob.ciphertext,
+        )
+        .map_err(|e| reject(GateStage::Unseal, e))?;
+
+        // The derived read key is secret; this fn is its terminal owner, so it
+        // zeroizes on drop (the gate borrows it and never zeroizes a caller buffer).
+        let node_seed = kdf::node_seed(payload.override_seed(), &env.id);
+        let read_key = Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes());
+
+        let reader = ReaderContext {
+            owner_identity: self.owner_identity,
+            scope_id: self.root_scope_id,
+            read_key: &read_key,
+            parent_node_seed: None,
+            seed_blob: Some(SeedBlob::Owner {
+                enc_secret: self.owner_enc_secret,
+                enc: owner_blob.enc,
+                ciphertext: owner_blob.ciphertext.clone(),
+                aad: owner_blob_aad,
+            }),
+        };
+
+        // Step 7 — the gate owns all trust. The owner arm surfaces no write seed
+        // (owner self-renewal is a later slice), so the record is held keyless and
+        // `node_id` rides only as the scope-root id.
+        let (adopted, write_scope_seed) = adopt(self.floors, &reader, &candidate).await?;
+        Ok(AdoptOutcome {
+            adopted,
+            write_scope_seed,
+            node_id: env.id,
+        })
+    }
+}
+
+/// A fail-closed content-plane assembly failure: the head the signed record
+/// anchors is malformed or tampered, so the record's content anchor is
+/// untrustworthy. Assembly runs before the gate's six stages, so it surfaces as
+/// a `RecordVerify` rejection carrying the verbatim core check (the check name
+/// carries the real detail).
+fn assembly_reject(e: CodecError) -> GateError {
+    reject(GateStage::RecordVerify, e)
+}
+
+fn reject(stage: GateStage, e: CodecError) -> GateError {
+    GateError::Rejected(GateRejection {
+        stage,
+        reason: RejectionReason::Trust(e),
+    })
+}
+
+/// Map a content-read failure: a CID mismatch/tamper is a fail-closed trust
+/// violation surfaced verbatim; no source or an over-cap body is availability (a
+/// retryable seam), never a trust verdict (`content/read.rs`).
+fn map_read_error(e: ReadError) -> GateError {
+    match e {
+        ReadError::TrustViolation(codec) => assembly_reject(codec),
+        ReadError::Unavailable => GateError::Seam(SeamError::new("head block unavailable")),
+        ReadError::TooLarge { size, limit } => GateError::Seam(SeamError::new(format!(
+            "head block exceeds the content cap ({size} > {limit})"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use cipherbox_core::codec::Value;
+    use cipherbox_core::content::{compute_cid, encode_content_cid_str};
+    use cipherbox_core::seal::{
+        Envelope, GrantSection, GrantSetCommitment, OverrideSeedPayload, ReadBody,
+        STRUCT_TAG_WRITE_BODY, SignedOwnerBlob, SignedSealed, StructureSigInput, WriteBody,
+        encode_envelope, encode_grant_section, encode_write_body, seal, seal_owner_blob,
+        seal_read_body, sign_grant_set, sign_structure,
+    };
+    use cipherbox_core::suite::ecdsa::EcdsaSigner;
+    use cipherbox_core::suite::ed25519::Ed25519Signer;
+
+    use crate::content::{DAG_ROOT_CODEC, GatewaySource};
+    use crate::seams::HttpResponse;
+    use crate::testkit::block_on;
+    use crate::testkit::fakes::{InMemoryFloorStore, ScriptedHttp};
+
+    const V: u64 = 1;
+    const TTL_NANOS: u64 = 2_000_000_000;
+    const EOL: &str = "2099-01-01T00:00:00Z";
+    const NONCE_READ_BODY: [u8; 24] = [11u8; 24];
+    const NONCE_WRITE_BODY: [u8; 24] = [22u8; 24];
+    const EPH_OWNER: [u8; 32] = [3u8; 32];
+
+    /// A valid owner-root scope fixture: the owner keys plus the head block (an
+    /// envelope carrying its grant section) the record anchors.
+    struct Fixture {
+        owner_identity_verifier: EcdsaVerifier,
+        owner_enc: X25519Secret,
+        scope_id: [u8; 16],
+        root_id: [u8; 16],
+        name: IpnsName,
+        grant_section: GrantSection,
+        envelope: Envelope,
+        head_block: Vec<u8>,
+        head_cid_str: String,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let owner_identity = EcdsaSigner::from_scalar(&[0x11; 32]).unwrap();
+            let owner_identity_verifier = owner_identity.verifying_key();
+            let owner_pseudonym = Ed25519Signer::from_seed([0x22; 32]);
+            let owner_enc = X25519Secret::from_scalar([0x33; 32]);
+
+            let scope_id = [0x44; 16];
+            let root_id = [0x55; 16];
+            let scope_seed = [0x66; 32];
+            let write_scope_seed = [0x77; 32];
+            let epoch = 1;
+
+            let node_seed = kdf::node_seed(&scope_seed, &root_id);
+            let read_key = *kdf::read_key(node_seed.as_bytes()).as_bytes();
+            let write_seed = kdf::write_seed(&write_scope_seed, &root_id);
+            let ipns_signer = kdf::ipns_keypair(write_seed.as_bytes());
+            let name = IpnsName::from_public_key(&ipns_signer.verifying_key());
+            let write_key = kdf::write_key(write_seed.as_bytes());
+
+            let sign = |tag: u8, ct: &[u8]| -> [u8; 64] {
+                let input = StructureSigInput::over_ciphertext(scope_id, epoch, tag, None, ct);
+                sign_structure(&owner_pseudonym, &input).to_bytes()
+            };
+
+            // Owner blob — the seed-bearing structure AND the owner's seed source.
+            let override_payload = OverrideSeedPayload::new(scope_seed, epoch);
+            let owner_blob_aad = AadContext {
+                v: V,
+                id: root_id,
+                scope: scope_id,
+                epoch,
+                struct_tag: STRUCT_TAG_OWNER_BLOB,
+            };
+            let sealed_owner = seal_owner_blob(
+                &owner_enc.public(),
+                &EPH_OWNER,
+                &owner_blob_aad,
+                &override_payload,
+            );
+            let owner_blob = SignedOwnerBlob {
+                signature: sign(STRUCT_TAG_OWNER_BLOB, &sealed_owner.ciphertext),
+                enc: sealed_owner.enc,
+                ciphertext: sealed_owner.ciphertext.clone(),
+                unknown: Vec::new(),
+            };
+
+            // Write body — a second seed-bearing structure the gate authenticates.
+            let write_body_aad = AadContext {
+                v: V,
+                id: root_id,
+                scope: scope_id,
+                epoch,
+                struct_tag: STRUCT_TAG_WRITE_BODY,
+            };
+            let write_body_sealed = seal(
+                write_key.as_bytes(),
+                &NONCE_WRITE_BODY,
+                &write_body_aad,
+                &encode_write_body(&WriteBody {
+                    grant_ledger: Vec::new(),
+                    write_history_link: Vec::new(),
+                    direct_child_scope_index: Vec::new(),
+                    unknown: Vec::new(),
+                })
+                .unwrap(),
+            );
+            let write_body = SignedSealed {
+                signature: sign(STRUCT_TAG_WRITE_BODY, &write_body_sealed),
+                sealed: write_body_sealed,
+                unknown: Vec::new(),
+            };
+
+            let commitment = GrantSetCommitment {
+                ipns_name: name.as_str().as_bytes().to_vec(),
+                owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
+                entries: Vec::new(),
+                unknown: Vec::new(),
+            };
+            let commitment_sig = sign_grant_set(&owner_identity, &commitment)
+                .unwrap()
+                .to_compact();
+            let grant_section = GrantSection {
+                commitment,
+                commitment_sig,
+                grant_blobs: Vec::new(),
+                owner_blob,
+                owner_write_blob: None,
+                ascent_link: None,
+                history_links: Vec::new(),
+                write_body,
+                unknown: Vec::new(),
+            };
+
+            let folder = ReadBody::Folder {
+                created_at: 0,
+                modified_at: 0,
+                children: Vec::new(),
+                unknown: Vec::new(),
+            };
+            let mut envelope = seal_read_body(
+                &read_key,
+                &NONCE_READ_BODY,
+                V,
+                root_id,
+                scope_id,
+                epoch,
+                &folder,
+            )
+            .unwrap();
+            envelope.unknown.push((
+                "grantSection".to_string(),
+                Value::Bytes(encode_grant_section(&grant_section).unwrap()),
+            ));
+
+            let head_block = encode_envelope(&envelope);
+            let head_cid_str = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head_block));
+
+            Self {
+                owner_identity_verifier,
+                owner_enc,
+                scope_id,
+                root_id,
+                name,
+                grant_section,
+                envelope,
+                head_block,
+                head_cid_str,
+            }
+        }
+
+        fn record(&self, sequence: u64) -> Vec<u8> {
+            let value = format!("/ipfs/{}", self.head_cid_str);
+            let signer = {
+                let write_seed = kdf::write_seed(&[0x77; 32], &self.root_id);
+                kdf::ipns_keypair(write_seed.as_bytes())
+            };
+            IpnsRecord::create_v2(&signer, value.as_bytes(), sequence, TTL_NANOS, EOL).marshal()
+        }
+
+        fn adopter<'a>(
+            &'a self,
+            http: &'a ScriptedHttp,
+            floors: &'a InMemoryFloorStore,
+            owner_identity: &'a EcdsaVerifier,
+            gateway: &'a Gateway,
+        ) -> RootAdopter<'a, ScriptedHttp, InMemoryFloorStore> {
+            RootAdopter::new(
+                gateway,
+                http,
+                floors,
+                &self.owner_enc,
+                owner_identity,
+                self.scope_id,
+            )
+        }
+    }
+
+    fn gateway() -> Gateway {
+        Gateway {
+            accelerator: Some(GatewaySource {
+                base_url: "https://gw.test".into(),
+                bearer: None,
+            }),
+            public_fallbacks: Vec::new(),
+        }
+    }
+
+    fn ok_response(body: Vec<u8>) -> HttpResponse {
+        HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body,
+        }
+    }
+
+    #[test]
+    fn assembles_the_expected_candidate_from_a_fixture_head_block() {
+        let fx = Fixture::new();
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+
+        let candidate = block_on(adopter.assemble_candidate(&fx.name, &fx.record(1)))
+            .expect("assembles a candidate");
+        assert_eq!(candidate.name, fx.name);
+        assert_eq!(candidate.envelope, fx.envelope);
+        assert_eq!(candidate.grant_section, fx.grant_section);
+        // The head block was fetched at its canonical content-CID address.
+        assert!(http.requests()[0].url.contains(&fx.head_cid_str));
+    }
+
+    #[test]
+    fn a_tampered_head_block_fails_closed_at_assembly() {
+        let fx = Fixture::new();
+        let http = ScriptedHttp::default();
+        // A block that does not content-address to the record's head CID: the
+        // fetch verify fails closed before any decode.
+        let mut tampered = fx.head_block.clone();
+        *tampered.last_mut().unwrap() ^= 0x01;
+        http.enqueue_response(ok_response(tampered));
+        let floors = InMemoryFloorStore::default();
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+
+        match block_on(adopter.assemble_candidate(&fx.name, &fx.record(1))) {
+            Ok(_) => panic!("a tampered head block must fail closed"),
+            Err(GateError::Rejected(r)) => assert_eq!(r.check(), "content-cid-mismatch"),
+            Err(GateError::Seam(e)) => panic!("expected a rejection, got seam {e}"),
+        }
+    }
+
+    #[test]
+    fn a_gate_passing_owner_root_adopts_through_the_production_adopter() {
+        let fx = Fixture::new();
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+
+        let outcome =
+            block_on(adopter.adopt(&fx.name, &fx.record(1))).expect("the owner root adopts");
+        assert_eq!(outcome.adopted.sequence, 1);
+        assert_eq!(outcome.adopted.epoch, 1);
+        assert_eq!(
+            outcome.node_id, fx.root_id,
+            "the scope-root id rides the outcome"
+        );
+        assert!(
+            outcome.write_scope_seed.is_none(),
+            "the owner arm surfaces no write seed (held keyless)"
+        );
+    }
+
+    #[test]
+    fn a_wrong_owner_identity_is_rejected_by_the_gate() {
+        let fx = Fixture::new();
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        let gw = gateway();
+        // A different owner identity than the one that signed the commitment: the
+        // gate rejects fail-closed at commitment-verify.
+        let rogue = EcdsaSigner::from_scalar(&[0x99; 32])
+            .unwrap()
+            .verifying_key();
+        let adopter = fx.adopter(&http, &floors, &rogue, &gw);
+
+        match block_on(adopter.adopt(&fx.name, &fx.record(1))) {
+            Ok(_) => panic!("a wrong owner identity must be rejected"),
+            Err(GateError::Rejected(r)) => {
+                assert_eq!(r.stage, GateStage::CommitmentVerify);
+                assert_eq!(r.check(), "commitment-invalid");
+            }
+            Err(GateError::Seam(e)) => panic!("expected a gate rejection, got seam {e}"),
+        }
+    }
+}

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -193,6 +193,34 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
             node_id: env.id,
         })
     }
+
+    async fn recover_own_write_seed(
+        &self,
+        name: &IpnsName,
+        record_bytes: &[u8],
+    ) -> Result<Option<([u8; 16], Zeroizing<[u8; 32]>)>, SeamError> {
+        // The record already assembled during `adopt` on this same Current path
+        // (content-addressed, deterministic); a re-assembly failure is fail-open —
+        // held keyless, never a trust verdict (#752 F3: a Current never hardens).
+        let candidate = match self.assemble_candidate(name, record_bytes).await {
+            Ok(candidate) => candidate,
+            Err(GateError::Seam(seam)) => return Err(seam),
+            Err(GateError::Rejected(_)) => return Ok(None),
+        };
+        let Some(owb) = &candidate.grant_section.owner_write_blob else {
+            return Ok(None);
+        };
+        // The E8 recovery only ever yields Ok/Seam; map its seam to availability.
+        let seed = match self
+            .recover_write_scope_seed(&candidate.envelope, owb)
+            .await
+        {
+            Ok(seed) => seed,
+            Err(GateError::Seam(seam)) => return Err(seam),
+            Err(GateError::Rejected(_)) => return Ok(None),
+        };
+        Ok(seed.map(|seed| (candidate.envelope.id, seed)))
+    }
 }
 
 impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
@@ -694,6 +722,75 @@ mod tests {
         assert!(
             outcome.write_scope_seed.is_none(),
             "a transplanted owner-write-blob yields no seed"
+        );
+    }
+
+    #[test]
+    fn recover_own_write_seed_returns_the_seed_for_our_own_current_root() {
+        let fx = Fixture::build(Some(OWB_WRITE_EPOCH));
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+
+        let (node_id, seed) = block_on(adopter.recover_own_write_seed(&fx.name, &fx.record(1)))
+            .expect("recovery is fail-open, never an error")
+            .expect("the owner recovers its own write seed on the Current path");
+        assert_eq!(node_id, fx.root_id, "keyed by the envelope id");
+        assert_eq!(*seed, WRITE_SCOPE_SEED);
+        // The recovered seed reproduces the record's IPNS routing name.
+        let signer = SessionIdentity::write_name_signer(&seed, &fx.root_id);
+        assert_eq!(IpnsName::from_public_key(&signer.verifying_key()), fx.name);
+    }
+
+    #[test]
+    fn recover_own_write_seed_is_none_when_the_blob_is_absent_stale_or_transplanted() {
+        // Missing owner-write-blob → held keyless, never a seed.
+        let fx = Fixture::new();
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+        assert!(
+            block_on(adopter.recover_own_write_seed(&fx.name, &fx.record(1)))
+                .expect("fail-open")
+                .is_none(),
+            "no owner-write-blob ⇒ no recovered seed"
+        );
+
+        // Stale blob one write epoch below the floor → won't open → None.
+        let fx = Fixture::build(Some(OWB_WRITE_EPOCH - 1));
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+        assert!(
+            block_on(adopter.recover_own_write_seed(&fx.name, &fx.record(1)))
+                .expect("fail-open")
+                .is_none(),
+            "a stale owner-write-blob below the floor recovers no seed"
+        );
+
+        // Transplanted: the floor names a different write epoch than the blob was
+        // sealed under → the recomputed AAD never opens it → None.
+        let fx = Fixture::build(Some(OWB_WRITE_EPOCH));
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH + 1);
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+        assert!(
+            block_on(adopter.recover_own_write_seed(&fx.name, &fx.record(1)))
+                .expect("fail-open")
+                .is_none(),
+            "a transplanted owner-write-blob recovers no seed"
         );
     }
 }

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -199,9 +199,8 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
         name: &IpnsName,
         record_bytes: &[u8],
     ) -> Result<Option<([u8; 16], Zeroizing<[u8; 32]>)>, SeamError> {
-        // The record already assembled during `adopt` on this same Current path
-        // (content-addressed, deterministic); a re-assembly failure is fail-open —
-        // held keyless, never a trust verdict (#752 F3: a Current never hardens).
+        // Recovery is fail-open, never a trust verdict: an unopenable/absent blob
+        // yields `Ok(None)`, held keyless (#752 F3: a Current never hardens).
         let candidate = match self.assemble_candidate(name, record_bytes).await {
             Ok(candidate) => candidate,
             Err(GateError::Seam(seam)) => return Err(seam),
@@ -210,7 +209,7 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
         let Some(owb) = &candidate.grant_section.owner_write_blob else {
             return Ok(None);
         };
-        // The E8 recovery only ever yields Ok/Seam; map its seam to availability.
+        // Map a recovery seam to availability, never a trust verdict.
         let seed = match self
             .recover_write_scope_seed(&candidate.envelope, owb)
             .await

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -16,6 +16,8 @@
 //! cross-check is a later slice; a tampered owner blob still fails closed here at
 //! the grant-section structure signature and the read-body unseal.
 
+use core::cell::RefCell;
+
 use cipherbox_core::content::decode_content_cid_str;
 use cipherbox_core::error::{CodecError, Malformed};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
@@ -57,6 +59,10 @@ pub struct RootAdopter<'a, H, F> {
     /// key). A resolved root whose envelope scope disagrees is a scope transplant
     /// the gate rejects fail-closed.
     root_scope_id: [u8; 16],
+    /// The candidate a rejected [`Adopter::adopt`] assembled, kept so the
+    /// equal-floor `Current` recovery ([`Adopter::recover_own_write_seed`])
+    /// reuses it instead of re-fetching the same head block per resolve tick.
+    assembled: RefCell<Option<Candidate>>,
 }
 
 impl<'a, H, F> RootAdopter<'a, H, F> {
@@ -77,6 +83,7 @@ impl<'a, H, F> RootAdopter<'a, H, F> {
             owner_enc_secret,
             owner_identity,
             root_scope_id,
+            assembled: RefCell::new(None),
         }
     }
 }
@@ -180,7 +187,15 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
         // Step 7 — the gate owns all trust; the owner reader surfaces no gate write
         // seed (that arm is the write-grantee's). The owner's own write-scope seed
         // is recovered from the owner-write-blob below for cold-start self-renewal.
-        let (adopted, _) = adopt(self.floors, &reader, &candidate).await?;
+        let (adopted, _) = match adopt(self.floors, &reader, &candidate).await {
+            Ok(pass) => pass,
+            Err(err) => {
+                // Keep the candidate for the equal-floor recovery path — it
+                // re-resolves the same head CID otherwise.
+                *self.assembled.borrow_mut() = Some(candidate);
+                return Err(err);
+            }
+        };
 
         let write_scope_seed = match &candidate.grant_section.owner_write_blob {
             // Re-authorable, NOT a trust failure — held keyless.
@@ -201,10 +216,20 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
     ) -> Result<Option<([u8; 16], Zeroizing<[u8; 32]>)>, SeamError> {
         // Recovery is fail-open, never a trust verdict: an unopenable/absent blob
         // yields `Ok(None)`, held keyless (#752 F3: a Current never hardens).
-        let candidate = match self.assemble_candidate(name, record_bytes).await {
-            Ok(candidate) => candidate,
-            Err(GateError::Seam(seam)) => return Err(seam),
-            Err(GateError::Rejected(_)) => return Ok(None),
+        // Reuse the candidate the rejected `adopt` assembled for these same
+        // bytes; assembling again re-fetches the head block.
+        let cached = self
+            .assembled
+            .borrow_mut()
+            .take()
+            .filter(|c| c.name == *name && c.record_bytes == record_bytes);
+        let candidate = match cached {
+            Some(candidate) => candidate,
+            None => match self.assemble_candidate(name, record_bytes).await {
+                Ok(candidate) => candidate,
+                Err(GateError::Seam(seam)) => return Err(seam),
+                Err(GateError::Rejected(_)) => return Ok(None),
+            },
         };
         let Some(owb) = &candidate.grant_section.owner_write_blob else {
             return Ok(None);
@@ -742,6 +767,36 @@ mod tests {
         // The recovered seed reproduces the record's IPNS routing name.
         let signer = SessionIdentity::write_name_signer(&seed, &fx.root_id);
         assert_eq!(IpnsName::from_public_key(&signer.verifying_key()), fx.name);
+    }
+
+    #[test]
+    fn equal_floor_recovery_reuses_the_candidate_adopt_assembled() {
+        let fx = Fixture::build(Some(OWB_WRITE_EPOCH));
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        // Steady state: the durable sequence floor already sits at the record's
+        // sequence, so adopt rejects equal-floor and recovery runs next.
+        block_on(floors.raise_sequence_floor(fx.name.as_str().as_bytes(), 1)).unwrap();
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+
+        let record = fx.record(1);
+        match block_on(adopter.adopt(&fx.name, &record)) {
+            Err(GateError::Rejected(r)) => assert_eq!(r.check(), "sequence-not-newer"),
+            Ok(_) => panic!("an equal-floor record must reject at the sequence stage"),
+            Err(GateError::Seam(e)) => panic!("expected a rejection, got seam {e}"),
+        }
+        let (_, seed) = block_on(adopter.recover_own_write_seed(&fx.name, &record))
+            .expect("recovery is fail-open, never an error")
+            .expect("the owner recovers its write seed from the reused candidate");
+        assert_eq!(*seed, WRITE_SCOPE_SEED);
+        assert_eq!(
+            http.requests().len(),
+            1,
+            "the head block is fetched once; recovery reuses adopt's candidate"
+        );
     }
 
     #[test]

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -10,9 +10,10 @@
 //! logic: it only assembles inputs; every trust decision (commitment, structure
 //! signatures, seed cross-checks, read-body unseal, floor law) stays in the gate.
 //!
-//! Minimal cold-start scope (#789): read-only. The write-plane owner-write-blob
-//! recovery (owner self-renewal) and the owner-seed-cache tri-way abuse
-//! cross-check are later slices; a tampered owner blob still fails closed here at
+//! Cold-start scope (#789): read-plane assembly plus owner cold-start
+//! write-plane recovery (E8) — the owner-write-blob hands the owner the
+//! write-scope seed it cannot re-derive. The owner-seed-cache tri-way abuse
+//! cross-check is a later slice; a tampered owner blob still fails closed here at
 //! the grant-section structure signature and the read-body unseal.
 
 use cipherbox_core::content::decode_content_cid_str;
@@ -20,8 +21,9 @@ use cipherbox_core::error::{CodecError, Malformed};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
-    AadContext, STRUCT_TAG_OWNER_BLOB, decode_envelope, decode_grant_section, grant_section_bytes,
-    open_owner_blob,
+    AadContext, Envelope, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB, SignedOwnerWriteBlob,
+    decode_envelope, decode_grant_section, grant_section_bytes, open_owner_blob,
+    open_owner_write_blob,
 };
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
 use cipherbox_core::suite::x25519::X25519Secret;
@@ -31,7 +33,8 @@ use super::publish::head_cid_from_value;
 use super::resolve::{AdoptOutcome, Adopter};
 use crate::content::{ContentPlane, Gateway, ReadError, read_block};
 use crate::gate::{
-    Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason, SeedBlob, adopt,
+    Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason, SeedBlob,
+    adopt, floor,
 };
 use crate::seams::{FloorStore, Http, SeamError};
 
@@ -174,15 +177,67 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
             }),
         };
 
-        // Step 7 — the gate owns all trust. The owner arm surfaces no write seed
-        // (owner self-renewal is a later slice), so the record is held keyless and
-        // `node_id` rides only as the scope-root id.
-        let (adopted, write_scope_seed) = adopt(self.floors, &reader, &candidate).await?;
+        // Step 7 — the gate owns all trust; the owner reader surfaces no gate write
+        // seed (that arm is the write-grantee's). The owner's own write-scope seed
+        // is recovered from the owner-write-blob below for cold-start self-renewal.
+        let (adopted, _) = adopt(self.floors, &reader, &candidate).await?;
+
+        let write_scope_seed = match &candidate.grant_section.owner_write_blob {
+            // Re-authorable, NOT a trust failure — held keyless.
+            None => None,
+            Some(owb) => self.recover_write_scope_seed(env, owb).await?,
+        };
         Ok(AdoptOutcome {
             adopted,
             write_scope_seed,
             node_id: env.id,
         })
+    }
+}
+
+impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
+    /// Recover the owner's write-scope seed (a KDF non-edge the owner cannot
+    /// re-derive) from the record's owner-write-blob for cold-start write-plane
+    /// self-renewal (blueprint/core.md "Grant section").
+    ///
+    /// The AAD binds the durable, monotonic write-epoch floor — cold-seeded from
+    /// the owner-vouched pointer before `resolve` runs (`sync/boot.rs`). A stale
+    /// owner-write-blob authored below the floor cannot open under the newer
+    /// floor's AAD, so an older write epoch can never be replayed (#752 rollback
+    /// defense). No known write floor, an open failure, or an epoch mismatch ⇒
+    /// re-authorable, held keyless — never a `Rejected` verdict, no abuse event.
+    /// The gate independently authenticates this blob's structure signature at the
+    /// read epoch (`gate/adoption.rs`); this only reads the seed it wraps.
+    async fn recover_write_scope_seed(
+        &self,
+        env: &Envelope,
+        owb: &SignedOwnerWriteBlob,
+    ) -> Result<Option<Zeroizing<[u8; 32]>>, GateError> {
+        let Some(wf) = floor::write_epoch_floor(self.floors, &self.root_scope_id)
+            .await
+            .map_err(GateError::Seam)?
+        else {
+            return Ok(None);
+        };
+        let aad = AadContext {
+            v: env.v,
+            id: env.id,
+            scope: env.scope,
+            epoch: wf,
+            struct_tag: STRUCT_TAG_OWNER_WRITE_BLOB,
+        };
+        let Ok(payload) =
+            open_owner_write_blob(self.owner_enc_secret, &owb.enc, &aad, &owb.ciphertext)
+        else {
+            return Ok(None);
+        };
+        // Belt-and-suspenders: the HPKE AAD already binds `epoch == wf`, so a
+        // successful open implies equality; a mismatch means something is off —
+        // treat as re-authorable, never adopt the seed.
+        if payload.write_epoch != wf {
+            return Ok(None);
+        }
+        Ok(Some(Zeroizing::new(*payload.write_scope_seed())))
     }
 }
 
@@ -222,16 +277,17 @@ mod tests {
     use cipherbox_core::codec::Value;
     use cipherbox_core::content::{compute_cid, encode_content_cid_str};
     use cipherbox_core::seal::{
-        Envelope, GrantSection, GrantSetCommitment, OverrideSeedPayload, ReadBody,
-        STRUCT_TAG_WRITE_BODY, SignedOwnerBlob, SignedSealed, StructureSigInput, WriteBody,
-        encode_envelope, encode_grant_section, encode_write_body, seal, seal_owner_blob,
-        seal_read_body, sign_grant_set, sign_structure,
+        Envelope, GrantSection, GrantSetCommitment, OverrideSeedPayload, OwnerWriteBlobPayload,
+        ReadBody, STRUCT_TAG_WRITE_BODY, SignedOwnerBlob, SignedSealed, StructureSigInput,
+        WriteBody, encode_envelope, encode_grant_section, encode_write_body, seal, seal_owner_blob,
+        seal_owner_write_blob, seal_read_body, sign_grant_set, sign_structure,
     };
     use cipherbox_core::suite::ecdsa::EcdsaSigner;
     use cipherbox_core::suite::ed25519::Ed25519Signer;
 
     use crate::content::{DAG_ROOT_CODEC, GatewaySource};
     use crate::seams::HttpResponse;
+    use crate::session::SessionIdentity;
     use crate::testkit::block_on;
     use crate::testkit::fakes::{InMemoryFloorStore, ScriptedHttp};
 
@@ -241,6 +297,12 @@ mod tests {
     const NONCE_READ_BODY: [u8; 24] = [11u8; 24];
     const NONCE_WRITE_BODY: [u8; 24] = [22u8; 24];
     const EPH_OWNER: [u8; 32] = [3u8; 32];
+    const EPH_OWNER_WRITE: [u8; 32] = [4u8; 32];
+    /// The write-scope seed the fixture's owner-write-blob wraps (matches the seed
+    /// that derives the record's IPNS name).
+    const WRITE_SCOPE_SEED: [u8; 32] = [0x77; 32];
+    /// The write epoch the fixture authors its owner-write-blob at.
+    const OWB_WRITE_EPOCH: u64 = 3;
 
     /// A valid owner-root scope fixture: the owner keys plus the head block (an
     /// envelope carrying its grant section) the record anchors.
@@ -258,6 +320,13 @@ mod tests {
 
     impl Fixture {
         fn new() -> Self {
+            Self::build(None)
+        }
+
+        /// Build the fixture, optionally authoring a real owner-write-blob at
+        /// `owb_write_epoch` (the write plane's own clock; its AAD binds that
+        /// epoch, its structure signature the read epoch — mirrors reseal).
+        fn build(owb_write_epoch: Option<u64>) -> Self {
             let owner_identity = EcdsaSigner::from_scalar(&[0x11; 32]).unwrap();
             let owner_identity_verifier = owner_identity.verifying_key();
             let owner_pseudonym = Ed25519Signer::from_seed([0x22; 32]);
@@ -329,6 +398,31 @@ mod tests {
                 unknown: Vec::new(),
             };
 
+            // Owner-write-blob — the write-scope seed sealed to the owner. AAD
+            // binds the WRITE epoch; the structure signature binds the read epoch.
+            let owner_write_blob = owb_write_epoch.map(|we| {
+                let payload = OwnerWriteBlobPayload::new(write_scope_seed, we);
+                let owb_aad = AadContext {
+                    v: V,
+                    id: root_id,
+                    scope: scope_id,
+                    epoch: we,
+                    struct_tag: STRUCT_TAG_OWNER_WRITE_BLOB,
+                };
+                let sealed = seal_owner_write_blob(
+                    &owner_enc.public(),
+                    &EPH_OWNER_WRITE,
+                    &owb_aad,
+                    &payload,
+                );
+                SignedOwnerWriteBlob {
+                    signature: sign(STRUCT_TAG_OWNER_WRITE_BLOB, &sealed.ciphertext),
+                    enc: sealed.enc,
+                    ciphertext: sealed.ciphertext,
+                    unknown: Vec::new(),
+                }
+            });
+
             let commitment = GrantSetCommitment {
                 ipns_name: name.as_str().as_bytes().to_vec(),
                 owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
@@ -343,7 +437,7 @@ mod tests {
                 commitment_sig,
                 grant_blobs: Vec::new(),
                 owner_blob,
-                owner_write_blob: None,
+                owner_write_blob,
                 ascent_link: None,
                 history_links: Vec::new(),
                 write_body,
@@ -515,5 +609,91 @@ mod tests {
             }
             Err(GateError::Seam(e)) => panic!("expected a gate rejection, got seam {e}"),
         }
+    }
+
+    /// Seed the write-epoch floor to `epoch` (the cold-start seeding `sync/boot`
+    /// does from the owner-vouched pointer before `resolve`).
+    fn seed_write_floor(floors: &InMemoryFloorStore, scope_id: &[u8; 16], epoch: u64) {
+        block_on(floor::advance_write_epoch_on_sight(floors, scope_id, epoch)).unwrap();
+    }
+
+    #[test]
+    fn owner_root_with_owner_write_blob_recovers_the_write_scope_seed() {
+        let fx = Fixture::build(Some(OWB_WRITE_EPOCH));
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+
+        let outcome = block_on(adopter.adopt(&fx.name, &fx.record(1))).expect("adopts");
+        let seed = outcome
+            .write_scope_seed
+            .expect("the owner recovers its write-scope seed from the owner-write-blob");
+        assert_eq!(*seed, WRITE_SCOPE_SEED);
+        // The recovered seed reproduces the record's IPNS routing name.
+        let signer = SessionIdentity::write_name_signer(&seed, &fx.root_id);
+        assert_eq!(IpnsName::from_public_key(&signer.verifying_key()), fx.name);
+    }
+
+    #[test]
+    fn missing_owner_write_blob_is_held_keyless_not_a_trust_failure() {
+        let fx = Fixture::new(); // owner_write_blob: None
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+
+        let outcome = block_on(adopter.adopt(&fx.name, &fx.record(1)))
+            .expect("a record without an owner-write-blob still adopts");
+        assert!(
+            outcome.write_scope_seed.is_none(),
+            "no owner-write-blob ⇒ held keyless, never a trust failure"
+        );
+    }
+
+    #[test]
+    fn stale_owner_write_blob_below_the_write_floor_is_ignored() {
+        // Blob authored one write epoch below the durable floor: its AAD under the
+        // newer floor cannot open it (#752 rollback defense) — a stale owner-write
+        // -blob is re-authorable, not a rejection. This invariant holds in release.
+        let fx = Fixture::build(Some(OWB_WRITE_EPOCH - 1));
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+
+        let outcome = block_on(adopter.adopt(&fx.name, &fx.record(1)))
+            .expect("a stale owner-write-blob is re-authorable, never a rejection");
+        assert!(
+            outcome.write_scope_seed.is_none(),
+            "a stale owner-write-blob below the floor yields no seed"
+        );
+    }
+
+    #[test]
+    fn owner_write_blob_transplanted_across_write_epoch_fails_open() {
+        // The floor names a different write epoch than the blob was sealed under:
+        // the recomputed AAD never opens it (adopter-layer mirror of the core
+        // transplant test) ⇒ Ok(None), no rejection, no abuse event.
+        let fx = Fixture::build(Some(OWB_WRITE_EPOCH));
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH + 1);
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+
+        let outcome = block_on(adopter.adopt(&fx.name, &fx.record(1)))
+            .expect("a write-epoch-transplanted owner-write-blob fails open, not closed");
+        assert!(
+            outcome.write_scope_seed.is_none(),
+            "a transplanted owner-write-blob yields no seed"
+        );
     }
 }

--- a/crates/engine/src/net/liveness.rs
+++ b/crates/engine/src/net/liveness.rs
@@ -247,6 +247,13 @@ where
         let Ok(name) = IpnsName::parse(&hr.routing_key) else {
             continue;
         };
+        // Belt-and-suspenders (security rule 8): a held record with an empty head
+        // CID would encode `/ipfs/` and clobber the tip. The insert-time
+        // derivation makes this unreachable; the guard keeps the invariant
+        // explicit.
+        if hr.head_cid.is_empty() {
+            continue;
+        }
         // The held signer signs for this name by the insert-time bind (#751:
         // resolve_and_hold rejects a signer whose derived name is not the
         // routing key), so no signing key is derived in the loop.
@@ -278,7 +285,7 @@ mod tests {
     use cipherbox_core::suite::ed25519::Ed25519Signer;
 
     use super::super::eol;
-    use super::super::publish::PublishOutcome;
+    use super::super::publish::{PublishError, PublishOutcome, PublishRequest, publish};
     use crate::api::ApiClient;
     use crate::profile::SyncTimingProfile;
     use crate::seams::{FloorStore, HttpResponse, RecordTransport, UnixMillis};
@@ -338,6 +345,43 @@ mod tests {
             .iter()
             .find(|r| r.routing_key == name.as_str())
             .expect("held name has a result")
+    }
+
+    #[test]
+    fn publish_fails_closed_on_an_empty_head_cid() {
+        let world = FakeWorld::new();
+        let device = world.device(b"me");
+        let scheduler = world.scheduler.clone();
+        let api = ApiClient::new(
+            device.http.clone(),
+            device.credential_store.clone(),
+            "http://api.test",
+        );
+        let signer = Ed25519Signer::from_seed([9u8; 32]);
+        let name = IpnsName::from_public_key(&signer.verifying_key());
+        let request = PublishRequest {
+            name: &name,
+            signer: &signer,
+            head_cid: String::new(),
+            content_cids: Vec::new(),
+            min_current_sequence: None,
+        };
+        // Encode/decode fail-closed symmetry (security rule 8): an empty head CID
+        // would sign `/ipfs/`, which head_cid_from_value always rejects — so
+        // publish refuses release-active, before any registration or PUT.
+        let out = block_on(publish(
+            &device.record_store,
+            &api,
+            &device.floor_store,
+            &scheduler,
+            &SyncTimingProfile::CI,
+            &request,
+        ));
+        assert_eq!(out, Err(PublishError::EmptyHeadCid));
+        assert!(
+            device.http.requests().is_empty(),
+            "an empty head CID never reaches the API",
+        );
     }
 
     fn seq_at(device: &FakeDevice, name: &IpnsName) -> u64 {

--- a/crates/engine/src/net/liveness.rs
+++ b/crates/engine/src/net/liveness.rs
@@ -15,10 +15,13 @@
 //!
 //! The API republisher (~12 h inventory walk) backstops dormant vaults only.
 
+use core::fmt;
 use core::future::Future;
 use core::time::Duration;
+use std::collections::BTreeMap;
 
 use cipherbox_core::ipns::IpnsRecord;
+use zeroize::Zeroizing;
 
 use super::eol::{self, EOL_RENEW_THRESHOLD};
 use super::fanout::{fanout_get_verify, fanout_put};
@@ -35,15 +38,59 @@ use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler
 /// once measured.
 pub const RE_PUT_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
-/// One held record to keep alive: its routing key (the `ipnsName`) and the exact
-/// signed record bytes the session last held for it.
+/// One held record to keep alive across both re-PUT layers.
+///
+/// [`keyless_re_put`] needs only [`routing_key`](Self::routing_key) +
+/// [`record_bytes`](Self::record_bytes); the sub-EOL seq+1 renewal (#750)
+/// rebuilds a [`PublishRequest`] from the rest. It stores the derivation
+/// **inputs**, never a live signer: the per-name signer is re-derived on demand
+/// via `SessionIdentity::write_name_signer(write_scope_seed, node_id)` at
+/// renewal, so no session key material lingers in the held set
+/// (blueprint/engine.md "Liveness").
 #[derive(Clone)]
 pub struct HeldRecord {
     /// The routing key — the record's `ipnsName`.
     pub routing_key: String,
     /// The signed record bytes (re-PUT verbatim; keyless).
     pub record_bytes: Vec<u8>,
+    /// The node id (`id16`) — the held-set key and the write-seed input the
+    /// renewal signer re-derives from.
+    pub node_id: [u8; 16],
+    /// The scope's unsealed write seed — a derivation input, not a signer.
+    /// Zeroized on drop and redacted from [`Debug`]; never printed or logged
+    /// (security rule 2).
+    pub write_scope_seed: Zeroizing<[u8; 32]>,
+    /// The head/metadata CID the renewal record points at.
+    pub head_cid: String,
+    /// The content CIDs to re-register/pin at renewal.
+    pub content_cids: Vec<String>,
 }
+
+impl fmt::Debug for HeldRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The write seed is secret: redact it, and print record bytes by length
+        // only (they are large, not secret).
+        f.debug_struct("HeldRecord")
+            .field("routing_key", &self.routing_key)
+            .field(
+                "record_bytes",
+                &format_args!("<{} bytes>", self.record_bytes.len()),
+            )
+            .field("node_id", &self.node_id)
+            .field("write_scope_seed", &"<redacted>")
+            .field("head_cid", &self.head_cid)
+            .field("content_cids", &self.content_cids)
+            .finish()
+    }
+}
+
+/// The session's live held-record set, keyed by node id (`id16`): the resolve
+/// path inserts each gate-passing record and the liveness loop re-PUTs the
+/// map's values. Keyed by node id so a re-resolve replaces in place and an
+/// eviction removes in O(1) — the loop never re-PUTs a stale record
+/// (blueprint/engine.md "Liveness"). `BTreeMap` for a deterministic iteration
+/// order across platforms.
+pub type HeldRecords = BTreeMap<[u8; 16], HeldRecord>;
 
 /// The result of re-PUTting one held record.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/engine/src/net/liveness.rs
+++ b/crates/engine/src/net/liveness.rs
@@ -20,7 +20,7 @@ use core::future::Future;
 use core::time::Duration;
 use std::collections::BTreeMap;
 
-use cipherbox_core::ipns::IpnsRecord;
+use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use zeroize::Zeroizing;
 
 use super::eol::{self, EOL_RENEW_THRESHOLD};
@@ -29,6 +29,7 @@ use super::publish::{PublishError, PublishOutcome, PublishRequest, publish};
 use crate::api::ApiClient;
 use crate::profile::SyncTimingProfile;
 use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
+use crate::session::SessionIdentity;
 
 /// The ~hourly cadence of the keyless re-PUT job (blueprint: "an ~hourly
 /// Scheduler job keyless-re-PUTs every record the session holds").
@@ -203,4 +204,261 @@ where
     publish(transport, api, floors, scheduler, profile, request)
         .await
         .map(Some)
+}
+
+/// One held record's sub-EOL renewal outcome.
+#[derive(Debug)]
+pub struct EolRenewResult {
+    /// The routing key considered for renewal.
+    pub routing_key: String,
+    /// `Ok(None)` when the record was comfortably ahead of the threshold (no
+    /// renewal), `Ok(Some(_))` on a seq+1 republish (including a reported lost
+    /// CAS race), `Err` on a fail-closed publish failure.
+    pub outcome: Result<Option<PublishOutcome>, PublishError>,
+}
+
+/// Run one sub-EOL renewal pass over the held set: for each record still live
+/// but within [`EOL_RENEW_THRESHOLD`], republish the same CID at seq+1 through
+/// the CAS path with a fresh 90-day EOL (blueprint/engine.md "Liveness"). A
+/// record comfortably ahead of the threshold no-ops in [`eol_republish`]; a
+/// lost CAS race is reported (never silently overwritten) for a later rebase
+/// slice.
+///
+/// This is the renewal-pass **body**; the ~hourly [`Scheduler`] loop that drives
+/// it alongside [`keyless_re_put`] is wired by the facade.
+pub(crate) async fn eol_renew_pass<T, H, C, F, Sch>(
+    transport: &T,
+    api: &ApiClient<H, C>,
+    floors: &F,
+    scheduler: &Sch,
+    profile: &SyncTimingProfile,
+    session: &SessionIdentity,
+    held: &[HeldRecord],
+) -> Vec<EolRenewResult>
+where
+    T: RecordTransport + Clone + 'static,
+    H: Http,
+    C: CredentialStore,
+    F: FloorStore,
+    Sch: Scheduler + Clone + 'static,
+{
+    let mut results = Vec::with_capacity(held.len());
+    for hr in held {
+        // A routing key that no longer parses to its IPNS name is not renewable
+        // — skip fail-closed rather than publish under a malformed name.
+        let Ok(name) = IpnsName::parse(&hr.routing_key) else {
+            continue;
+        };
+        // Re-derive the per-name signer into a short-lived local: `PublishRequest`
+        // borrows it, and it zeroizes at the end of this iteration, so no signing
+        // key ever lingers in the held set. The name and signer are the same
+        // Ed25519 key by the held-set invariant (#751 built the record from the
+        // same write-scope seed + node id).
+        let signer = session.write_name_signer(&hr.write_scope_seed, &hr.node_id);
+        let request = PublishRequest {
+            name: &name,
+            signer: &signer,
+            head_cid: hr.head_cid.clone(),
+            content_cids: hr.content_cids.clone(),
+            // Renewal is a normal CAS write: the sequence comes from the durable
+            // floor + 1, not a recovered revival sequence.
+            min_current_sequence: None,
+        };
+        let outcome = eol_republish(transport, api, floors, scheduler, profile, &request).await;
+        results.push(EolRenewResult {
+            routing_key: hr.routing_key.clone(),
+            outcome,
+        });
+    }
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EolRenewResult, HeldRecord, eol_renew_pass, keyless_re_put};
+
+    use core::time::Duration;
+
+    use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+    use cipherbox_core::suite::ed25519::Ed25519Signer;
+    use zeroize::Zeroizing;
+
+    use super::super::eol;
+    use super::super::publish::PublishOutcome;
+    use crate::api::ApiClient;
+    use crate::facade::LoginSecret;
+    use crate::profile::SyncTimingProfile;
+    use crate::seams::{FloorStore, HttpResponse, RecordTransport, UnixMillis};
+    use crate::session::SessionIdentity;
+    use crate::testkit::{FakeDevice, FakeWorld, block_on};
+
+    const DAY: u64 = 24 * 60 * 60;
+    const TTL_NANOS: u64 = 2_000_000_000;
+
+    /// A held record for a per-name signer the pass re-derives from
+    /// `(write_scope_seed, node_id)`, carrying a record minted at `mint_millis`
+    /// with a 90-day EOL.
+    fn seeded_held(
+        device: &FakeDevice,
+        session: &SessionIdentity,
+        write_scope_seed: [u8; 32],
+        node_id: [u8; 16],
+        head_cid: &str,
+        mint_millis: u64,
+    ) -> (IpnsName, HeldRecord) {
+        let signer: Ed25519Signer = session.write_name_signer(&write_scope_seed, &node_id);
+        let name = IpnsName::from_public_key(&signer.verifying_key());
+        let value = format!("/ipfs/{head_cid}").into_bytes();
+        let validity = eol::eol_from(UnixMillis(mint_millis));
+        let bytes = IpnsRecord::create_v2(&signer, &value, 1, TTL_NANOS, &validity).marshal();
+        for endpoint in device.record_store.endpoints() {
+            device
+                .record_store
+                .seed_record(&endpoint, name.as_str(), bytes.clone());
+        }
+        // Model the gate's job: the durable floor sits at the adopted sequence.
+        block_on(
+            device
+                .floor_store
+                .raise_sequence_floor(name.as_str().as_bytes(), 1),
+        )
+        .unwrap();
+        let held = HeldRecord {
+            routing_key: name.as_str().to_owned(),
+            record_bytes: bytes,
+            node_id,
+            write_scope_seed: Zeroizing::new(write_scope_seed),
+            head_cid: head_cid.to_owned(),
+            content_cids: Vec::new(),
+        };
+        (name, held)
+    }
+
+    fn ok_200() -> HttpResponse {
+        HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: Vec::new(),
+        }
+    }
+
+    fn outcome_of<'a>(results: &'a [EolRenewResult], name: &IpnsName) -> &'a EolRenewResult {
+        results
+            .iter()
+            .find(|r| r.routing_key == name.as_str())
+            .expect("held name has a result")
+    }
+
+    fn seq_at(device: &FakeDevice, name: &IpnsName) -> u64 {
+        let endpoint = device.record_store.endpoints()[0].clone();
+        let bytes = device
+            .record_store
+            .record_at(&endpoint, name.as_str())
+            .expect("record present");
+        IpnsRecord::unmarshal(&bytes)
+            .unwrap()
+            .verify(name)
+            .unwrap()
+            .sequence
+    }
+
+    #[test]
+    fn renews_only_the_below_threshold_name_and_runs_beside_keyless() {
+        let world = FakeWorld::new();
+        let device = world.device(b"me");
+        let scheduler = world.scheduler.clone(); // virtual clock, now = 0
+        let session = SessionIdentity::derive(&LoginSecret::new(vec![7u8; 32]));
+        let api = ApiClient::new(
+            device.http.clone(),
+            device.credential_store.clone(),
+            "http://api.test",
+        );
+        let profile = SyncTimingProfile::CI;
+
+        // Two held names, both at seq 1 with a 90-day EOL: one minted at T0
+        // (25 days left at T+65d — inside the renewal window) and one minted at
+        // T+60d (85 days left at T+65d — comfortably ahead).
+        let (below, below_held) =
+            seeded_held(&device, &session, [1u8; 32], [2u8; 16], "bafybelow", 0);
+        let (ahead, ahead_held) = seeded_held(
+            &device,
+            &session,
+            [3u8; 32],
+            [4u8; 16],
+            "bafyahead",
+            60 * DAY * 1000,
+        );
+        let held = vec![below_held, ahead_held];
+
+        // At T0 both records are far from EOL: the pass no-ops for both, proving
+        // the renewal decision is driven purely off the injected scheduler clock.
+        let at_zero = block_on(eol_renew_pass(
+            &device.record_store,
+            &api,
+            &device.floor_store,
+            &scheduler,
+            &profile,
+            &session,
+            &held,
+        ));
+        assert_eq!(
+            outcome_of(&at_zero, &below).outcome.as_ref().unwrap(),
+            &None
+        );
+        assert_eq!(
+            outcome_of(&at_zero, &ahead).outcome.as_ref().unwrap(),
+            &None
+        );
+
+        // Advance the injected clock into the below name's renewal window.
+        scheduler.advance(Duration::from_secs(65 * DAY));
+
+        // Keyless re-PUT runs in the same pass and keeps every held record alive.
+        let keyless = block_on(keyless_re_put(&device.record_store, &held));
+        assert!(
+            keyless.iter().all(|r| r.kept_alive),
+            "keyless keeps both names alive"
+        );
+
+        // The renewal pass then republishes only the near-expiry name at seq+1.
+        device.http.enqueue_response(ok_200()); // register-first for the one renewal
+        let results = block_on(eol_renew_pass(
+            &device.record_store,
+            &api,
+            &device.floor_store,
+            &scheduler,
+            &profile,
+            &session,
+            &held,
+        ));
+        assert_eq!(
+            outcome_of(&results, &below).outcome.as_ref().unwrap(),
+            &Some(PublishOutcome::Published { sequence: 2 }),
+            "the near-expiry name is republished at seq+1",
+        );
+        assert_eq!(
+            outcome_of(&results, &ahead).outcome.as_ref().unwrap(),
+            &None,
+            "the comfortably-ahead name is not renewed",
+        );
+
+        // The renewed record is live at seq 2 with a fresh, strictly-later EOL;
+        // the ahead name is untouched at seq 1.
+        assert_eq!(seq_at(&device, &below), 2);
+        let endpoint = device.record_store.endpoints()[0].clone();
+        let renewed = device
+            .record_store
+            .record_at(&endpoint, below.as_str())
+            .unwrap();
+        let renewed_validity = IpnsRecord::unmarshal(&renewed)
+            .unwrap()
+            .verify(&below)
+            .unwrap()
+            .validity;
+        assert!(
+            renewed_validity > eol::eol_from(UnixMillis(0)).into_bytes(),
+            "renewal stamps a fresh, later EOL",
+        );
+        assert_eq!(seq_at(&device, &ahead), 1);
+    }
 }

--- a/crates/engine/src/net/liveness.rs
+++ b/crates/engine/src/net/liveness.rs
@@ -21,7 +21,7 @@ use core::time::Duration;
 use std::collections::BTreeMap;
 
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
-use zeroize::Zeroizing;
+use cipherbox_core::suite::ed25519::Ed25519Signer;
 
 use super::eol::{self, EOL_RENEW_THRESHOLD};
 use super::fanout::{fanout_get_verify, fanout_put};
@@ -29,7 +29,6 @@ use super::publish::{PublishError, PublishOutcome, PublishRequest, publish};
 use crate::api::ApiClient;
 use crate::profile::SyncTimingProfile;
 use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
-use crate::session::SessionIdentity;
 
 /// The ~hourly cadence of the keyless re-PUT job (blueprint: "an ~hourly
 /// Scheduler job keyless-re-PUTs every record the session holds").
@@ -43,24 +42,23 @@ pub const RE_PUT_INTERVAL: Duration = Duration::from_secs(60 * 60);
 ///
 /// [`keyless_re_put`] needs only [`routing_key`](Self::routing_key) +
 /// [`record_bytes`](Self::record_bytes); the sub-EOL seq+1 renewal (#750)
-/// rebuilds a [`PublishRequest`] from the rest. It stores the derivation
-/// **inputs**, never a live signer: the per-name signer is re-derived on demand
-/// via `SessionIdentity::write_name_signer(write_scope_seed, node_id)` at
-/// renewal, so no session key material lingers in the held set
-/// (blueprint/engine.md "Liveness").
+/// rebuilds a [`PublishRequest`] from the rest. It stores the **narrow per-name
+/// signer** the renewal signs with — not the scope's write seed, which would
+/// derive the full write plane (content + IPNS) for every node in the scope
+/// (least privilege; security rules 2 and 5). The signer is derived once at
+/// insert from the scope seed + node id (see `HeldMaterial`) and the seed is
+/// dropped there — it never lingers in the held set (blueprint/engine.md
+/// "Liveness").
 #[derive(Clone)]
 pub struct HeldRecord {
     /// The routing key — the record's `ipnsName`.
     pub routing_key: String,
     /// The signed record bytes (re-PUT verbatim; keyless).
     pub record_bytes: Vec<u8>,
-    /// The node id (`id16`) — the held-set key and the write-seed input the
-    /// renewal signer re-derives from.
-    pub node_id: [u8; 16],
-    /// The scope's unsealed write seed — a derivation input, not a signer.
-    /// Zeroized on drop and redacted from [`Debug`]; never printed or logged
-    /// (security rule 2).
-    pub write_scope_seed: Zeroizing<[u8; 32]>,
+    /// The per-name IPNS signer the sub-EOL seq+1 renewal signs with. Zeroizes
+    /// on drop and its `Debug` is redacted; never printed or logged (security
+    /// rule 2).
+    pub signer: Ed25519Signer,
     /// The head/metadata CID the renewal record points at.
     pub head_cid: String,
     /// The content CIDs to re-register/pin at renewal.
@@ -69,16 +67,15 @@ pub struct HeldRecord {
 
 impl fmt::Debug for HeldRecord {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // The write seed is secret: redact it, and print record bytes by length
-        // only (they are large, not secret).
+        // The signer redacts itself in Debug; print record bytes by length only
+        // (they are large, not secret).
         f.debug_struct("HeldRecord")
             .field("routing_key", &self.routing_key)
             .field(
                 "record_bytes",
                 &format_args!("<{} bytes>", self.record_bytes.len()),
             )
-            .field("node_id", &self.node_id)
-            .field("write_scope_seed", &"<redacted>")
+            .field("signer", &self.signer)
             .field("head_cid", &self.head_cid)
             .field("content_cids", &self.content_cids)
             .finish()
@@ -208,6 +205,7 @@ where
 
 /// One held record's sub-EOL renewal outcome.
 #[derive(Debug)]
+#[must_use = "renewal outcomes carry LostRace/PublishError; surface them when the held set is live"]
 pub struct EolRenewResult {
     /// The routing key considered for renewal.
     pub routing_key: String,
@@ -226,13 +224,13 @@ pub struct EolRenewResult {
 ///
 /// This is the renewal-pass **body**; the ~hourly [`Scheduler`] loop that drives
 /// it alongside [`keyless_re_put`] is wired by the facade.
+#[must_use = "renewal outcomes carry LostRace/PublishError; surface them when the held set is live"]
 pub(crate) async fn eol_renew_pass<T, H, C, F, Sch>(
     transport: &T,
     api: &ApiClient<H, C>,
     floors: &F,
     scheduler: &Sch,
     profile: &SyncTimingProfile,
-    session: &SessionIdentity,
     held: &[HeldRecord],
 ) -> Vec<EolRenewResult>
 where
@@ -249,15 +247,12 @@ where
         let Ok(name) = IpnsName::parse(&hr.routing_key) else {
             continue;
         };
-        // Re-derive the per-name signer into a short-lived local: `PublishRequest`
-        // borrows it, and it zeroizes at the end of this iteration, so no signing
-        // key ever lingers in the held set. The name and signer are the same
-        // Ed25519 key by the held-set invariant (#751 built the record from the
-        // same write-scope seed + node id).
-        let signer = session.write_name_signer(&hr.write_scope_seed, &hr.node_id);
+        // The held signer signs for this name by the insert-time bind (#751:
+        // resolve_and_hold rejects a signer whose derived name is not the
+        // routing key), so no signing key is derived in the loop.
         let request = PublishRequest {
             name: &name,
-            signer: &signer,
+            signer: &hr.signer,
             head_cid: hr.head_cid.clone(),
             content_cids: hr.content_cids.clone(),
             // Renewal is a normal CAS write: the sequence comes from the durable
@@ -281,12 +276,10 @@ mod tests {
 
     use cipherbox_core::ipns::{IpnsName, IpnsRecord};
     use cipherbox_core::suite::ed25519::Ed25519Signer;
-    use zeroize::Zeroizing;
 
     use super::super::eol;
     use super::super::publish::PublishOutcome;
     use crate::api::ApiClient;
-    use crate::facade::LoginSecret;
     use crate::profile::SyncTimingProfile;
     use crate::seams::{FloorStore, HttpResponse, RecordTransport, UnixMillis};
     use crate::session::SessionIdentity;
@@ -295,18 +288,17 @@ mod tests {
     const DAY: u64 = 24 * 60 * 60;
     const TTL_NANOS: u64 = 2_000_000_000;
 
-    /// A held record for a per-name signer the pass re-derives from
-    /// `(write_scope_seed, node_id)`, carrying a record minted at `mint_millis`
-    /// with a 90-day EOL.
+    /// A held record carrying the per-name signer derived from
+    /// `(write_scope_seed, node_id)` and a record minted at `mint_millis` with a
+    /// 90-day EOL.
     fn seeded_held(
         device: &FakeDevice,
-        session: &SessionIdentity,
         write_scope_seed: [u8; 32],
         node_id: [u8; 16],
         head_cid: &str,
         mint_millis: u64,
     ) -> (IpnsName, HeldRecord) {
-        let signer: Ed25519Signer = session.write_name_signer(&write_scope_seed, &node_id);
+        let signer: Ed25519Signer = SessionIdentity::write_name_signer(&write_scope_seed, &node_id);
         let name = IpnsName::from_public_key(&signer.verifying_key());
         let value = format!("/ipfs/{head_cid}").into_bytes();
         let validity = eol::eol_from(UnixMillis(mint_millis));
@@ -326,8 +318,7 @@ mod tests {
         let held = HeldRecord {
             routing_key: name.as_str().to_owned(),
             record_bytes: bytes,
-            node_id,
-            write_scope_seed: Zeroizing::new(write_scope_seed),
+            signer,
             head_cid: head_cid.to_owned(),
             content_cids: Vec::new(),
         };
@@ -367,7 +358,6 @@ mod tests {
         let world = FakeWorld::new();
         let device = world.device(b"me");
         let scheduler = world.scheduler.clone(); // virtual clock, now = 0
-        let session = SessionIdentity::derive(&LoginSecret::new(vec![7u8; 32]));
         let api = ApiClient::new(
             device.http.clone(),
             device.credential_store.clone(),
@@ -378,16 +368,9 @@ mod tests {
         // Two held names, both at seq 1 with a 90-day EOL: one minted at T0
         // (25 days left at T+65d — inside the renewal window) and one minted at
         // T+60d (85 days left at T+65d — comfortably ahead).
-        let (below, below_held) =
-            seeded_held(&device, &session, [1u8; 32], [2u8; 16], "bafybelow", 0);
-        let (ahead, ahead_held) = seeded_held(
-            &device,
-            &session,
-            [3u8; 32],
-            [4u8; 16],
-            "bafyahead",
-            60 * DAY * 1000,
-        );
+        let (below, below_held) = seeded_held(&device, [1u8; 32], [2u8; 16], "bafybelow", 0);
+        let (ahead, ahead_held) =
+            seeded_held(&device, [3u8; 32], [4u8; 16], "bafyahead", 60 * DAY * 1000);
         let held = vec![below_held, ahead_held];
 
         // At T0 both records are far from EOL: the pass no-ops for both, proving
@@ -398,7 +381,6 @@ mod tests {
             &device.floor_store,
             &scheduler,
             &profile,
-            &session,
             &held,
         ));
         assert_eq!(
@@ -428,7 +410,6 @@ mod tests {
             &device.floor_store,
             &scheduler,
             &profile,
-            &session,
             &held,
         ));
         assert_eq!(

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -29,6 +29,7 @@
 
 mod adopter;
 mod fanout;
+mod pointer_fetch;
 
 pub mod eol;
 pub mod liveness;
@@ -43,6 +44,7 @@ pub use liveness::{
     EolRenewResult, HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, RePutResult,
     eol_republish, keyless_re_put, run_liveness_loop,
 };
+pub use pointer_fetch::RecordPointerFetch;
 pub use publish::{PublishError, PublishOutcome, PublishRequest, publish};
 pub use resolve::{AdoptOutcome, Adopter, ResolveOutcome, Resolved, resolve};
 pub use retire::{retire, root_retire_ready};

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -27,6 +27,7 @@
 //! the content/pointer/key assembly, and a lost race surfaces as
 //! [`publish::PublishOutcome::LostRace`] for the rebase slice.
 
+mod adopter;
 mod fanout;
 
 pub mod eol;
@@ -36,6 +37,7 @@ pub mod resolve;
 pub mod retire;
 pub mod revival;
 
+pub use adopter::RootAdopter;
 pub(crate) use liveness::eol_renew_pass;
 pub use liveness::{
     EolRenewResult, HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, RePutResult,

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -36,9 +36,10 @@ pub mod resolve;
 pub mod retire;
 pub mod revival;
 
+pub(crate) use liveness::eol_renew_pass;
 pub use liveness::{
-    HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, RePutResult, eol_republish,
-    keyless_re_put, run_liveness_loop,
+    EolRenewResult, HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, RePutResult,
+    eol_republish, keyless_re_put, run_liveness_loop,
 };
 pub use publish::{PublishError, PublishOutcome, PublishRequest, publish};
 pub use resolve::{Adopter, HeldMaterial, ResolveOutcome, Resolved, resolve, resolve_and_hold};

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -42,6 +42,6 @@ pub use liveness::{
     eol_republish, keyless_re_put, run_liveness_loop,
 };
 pub use publish::{PublishError, PublishOutcome, PublishRequest, publish};
-pub use resolve::{Adopter, HeldMaterial, ResolveOutcome, Resolved, resolve, resolve_and_hold};
+pub use resolve::{Adopter, ResolveOutcome, Resolved, resolve};
 pub use retire::{retire, root_retire_ready};
 pub use revival::{ReviveError, ReviveRequest, revive};

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -37,10 +37,10 @@ pub mod retire;
 pub mod revival;
 
 pub use liveness::{
-    HeldRecord, LivenessControl, RE_PUT_INTERVAL, RePutResult, eol_republish, keyless_re_put,
-    run_liveness_loop,
+    HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, RePutResult, eol_republish,
+    keyless_re_put, run_liveness_loop,
 };
 pub use publish::{PublishError, PublishOutcome, PublishRequest, publish};
-pub use resolve::{Adopter, ResolveOutcome, Resolved, resolve};
+pub use resolve::{Adopter, HeldMaterial, ResolveOutcome, Resolved, resolve, resolve_and_hold};
 pub use retire::{retire, root_retire_ready};
 pub use revival::{ReviveError, ReviveRequest, revive};

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -42,6 +42,6 @@ pub use liveness::{
     eol_republish, keyless_re_put, run_liveness_loop,
 };
 pub use publish::{PublishError, PublishOutcome, PublishRequest, publish};
-pub use resolve::{Adopter, ResolveOutcome, Resolved, resolve};
+pub use resolve::{AdoptOutcome, Adopter, ResolveOutcome, Resolved, resolve};
 pub use retire::{retire, root_retire_ready};
 pub use revival::{ReviveError, ReviveRequest, revive};

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -47,6 +47,6 @@ pub use liveness::{
 pub use pointer_fetch::RecordPointerFetch;
 pub use publish::{PublishError, PublishOutcome, PublishRequest, publish};
 pub use resolve::{AdoptOutcome, Adopter, ResolveOutcome, Resolved, resolve};
-pub(crate) use resolve::{HeldMaterial, resolve_and_hold};
+pub(crate) use resolve::{HeldMaterial, refresh_base_from_outcome, resolve_and_hold};
 pub use retire::{retire, root_retire_ready};
 pub use revival::{ReviveError, ReviveRequest, revive};

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -47,5 +47,6 @@ pub use liveness::{
 pub use pointer_fetch::RecordPointerFetch;
 pub use publish::{PublishError, PublishOutcome, PublishRequest, publish};
 pub use resolve::{AdoptOutcome, Adopter, ResolveOutcome, Resolved, resolve};
+pub(crate) use resolve::{HeldMaterial, resolve_and_hold};
 pub use retire::{retire, root_retire_ready};
 pub use revival::{ReviveError, ReviveRequest, revive};

--- a/crates/engine/src/net/pointer_fetch.rs
+++ b/crates/engine/src/net/pointer_fetch.rs
@@ -1,0 +1,211 @@
+//! The production [`PointerFetch`]: resolve the sealed re-point block a pointer
+//! name carries (blueprint/engine.md "Pointer planes").
+//!
+//! The re-point object is inlined as the IPNS record value at the pointer name
+//! (CONTEXT.md "Re-point object"; `crates/core/src/payload/pointer.rs`), so this
+//! touches no gateway — a fan-out GET + core verify yields the freshest
+//! owner-signed record and its authenticated value is the block. The inner
+//! unseal + owner-ECDSA verify is the walk's ([`open_repoint`]), fail-closed;
+//! this returns raw authenticated bytes and re-classifies no trust.
+//!
+//! [`open_repoint`]: crate::sync::pointer::open_repoint
+
+use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+
+use super::fanout::fanout_get_verify;
+use crate::seams::{RecordTransport, SeamError, SeamResult};
+use crate::sync::pointer::PointerFetch;
+
+/// The record-plane [`PointerFetch`]: resolves pointer names over the borrowed
+/// [`RecordTransport`] seam. Holds no key material — a pure function of the
+/// transport bytes.
+pub struct RecordPointerFetch<'a, T> {
+    transport: &'a T,
+}
+
+impl<'a, T> RecordPointerFetch<'a, T> {
+    /// Wrap the borrowed `/routing/v1` transport as a pointer fetch.
+    pub fn new(transport: &'a T) -> Self {
+        Self { transport }
+    }
+}
+
+impl<T: RecordTransport> PointerFetch for RecordPointerFetch<'_, T> {
+    async fn fetch(&self, name: &IpnsName) -> SeamResult<Option<Vec<u8>>> {
+        let Some((_sequence, record_bytes)) = fanout_get_verify(self.transport, name).await else {
+            return Ok(None);
+        };
+        // Fan-out returns the marshaled record (already Ed25519-from-name
+        // verified); re-extract the authenticated value — the inlined re-point
+        // block. The same bytes just verified, so a failure here is an internal
+        // inconsistency, surfaced as a seam error, never a trust reclassification.
+        let value = IpnsRecord::unmarshal(&record_bytes)
+            .and_then(|record| record.verify(name))
+            .map_err(|e| SeamError::new(format!("verified record re-extract failed: {e}")))?
+            .value;
+        Ok(Some(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use cipherbox_core::kdf;
+    use cipherbox_core::payload::RepointObject;
+    use cipherbox_core::suite::ecdsa::EcdsaSigner;
+
+    use crate::seams::EndpointId;
+    use crate::sync::pointer::{
+        PointerError, SessionRole, resolve_vault_pointer, seal_repoint, vault_pointer_name,
+    };
+    use crate::testkit::fakes::InMemoryRecordStore;
+    use crate::testkit::{SeededEntropy, block_on};
+
+    const SECRET: &[u8] = b"login-secret-fixture-bytes";
+    const ROOT_SCOPE: [u8; 16] = [0u8; 16];
+    const PAYLOAD_VERSION: u64 = 1;
+    const TTL_NANOS: u64 = 2_000_000_000;
+    const EOL: &str = "2099-01-01T00:00:00Z";
+
+    fn owner_signer() -> EcdsaSigner {
+        EcdsaSigner::from_scalar(&[3u8; 32]).expect("valid scalar")
+    }
+
+    fn repoint(min_read_epoch: u64, write_epoch: u64) -> RepointObject {
+        RepointObject {
+            scope_id: ROOT_SCOPE,
+            current_root: vault_pointer_name(b"root-name-seed", 0),
+            write_epoch,
+            min_read_epoch,
+            prev_root: None,
+        }
+    }
+
+    /// Seal a re-point block under the root scope's stable pointer-read-key,
+    /// owner-signed by `owner` (reuses the production `seal_repoint`).
+    fn seal_block(owner: &EcdsaSigner, entropy_seed: u64, object: &RepointObject) -> Vec<u8> {
+        let owner_seed = kdf::owner_pointer_seed(SECRET);
+        let read_key = kdf::pointer_read_key(owner_seed.as_bytes(), &ROOT_SCOPE);
+        let mut entropy = SeededEntropy::new(entropy_seed);
+        seal_repoint(
+            SessionRole::Owner,
+            &mut entropy,
+            read_key.as_bytes(),
+            PAYLOAD_VERSION,
+            owner,
+            object,
+        )
+        .expect("owner session seals")
+    }
+
+    /// A valid IPNS record carrying `block` as its inlined value, signed by the
+    /// vault-pointer key for `index` (so `verify(vault_pointer_name(index))`
+    /// passes).
+    fn record_for(index: u64, block: &[u8], sequence: u64) -> Vec<u8> {
+        let signer = kdf::vault_pointer_index(SECRET, index);
+        IpnsRecord::create_v2(&signer, block, sequence, TTL_NANOS, EOL).marshal()
+    }
+
+    fn endpoints(n: usize) -> Vec<EndpointId> {
+        (0..n).map(|i| EndpointId::new(format!("e{i}"))).collect()
+    }
+
+    #[test]
+    fn fetch_returns_the_inlined_repoint_value() {
+        let eps = endpoints(1);
+        let store = InMemoryRecordStore::new(eps.clone());
+        let block = seal_block(&owner_signer(), 0, &repoint(1, 1));
+        let name = vault_pointer_name(SECRET, 0);
+        store.seed_record(&eps[0], name.as_str(), record_for(0, &block, 1));
+
+        let fetch = RecordPointerFetch::new(&store);
+        let got = block_on(fetch.fetch(&name)).expect("fetch succeeds");
+        assert_eq!(
+            got,
+            Some(block),
+            "the authenticated value is the inlined re-point block"
+        );
+    }
+
+    #[test]
+    fn fetch_unknown_name_is_none() {
+        let eps = endpoints(2);
+        let store = InMemoryRecordStore::new(eps);
+        let fetch = RecordPointerFetch::new(&store);
+        let unseeded = vault_pointer_name(SECRET, 7);
+        assert_eq!(
+            block_on(fetch.fetch(&unseeded)).expect("fetch succeeds"),
+            None,
+            "an unresolvable name yields None"
+        );
+    }
+
+    #[test]
+    fn fetch_prefers_the_freshest_valid_record() {
+        let eps = endpoints(3);
+        let store = InMemoryRecordStore::new(eps.clone());
+        let name = vault_pointer_name(SECRET, 0);
+
+        // Endpoint 0: an outer-signature-invalid copy (signed by the WRONG key) —
+        // fan-out drops it as availability, never a trust verdict here.
+        let stale_block = seal_block(&owner_signer(), 1, &repoint(2, 1));
+        let wrong = kdf::vault_pointer_index(SECRET, 99);
+        let forged_outer = IpnsRecord::create_v2(&wrong, &stale_block, 9, TTL_NANOS, EOL).marshal();
+        store.seed_record(&eps[0], name.as_str(), forged_outer);
+
+        // Endpoint 1: a valid, older-sequence copy.
+        let older_block = seal_block(&owner_signer(), 2, &repoint(3, 1));
+        store.seed_record(&eps[1], name.as_str(), record_for(0, &older_block, 2));
+
+        // Endpoint 2: a valid, freshest copy — its value must win.
+        let freshest_block = seal_block(&owner_signer(), 3, &repoint(5, 2));
+        store.seed_record(&eps[2], name.as_str(), record_for(0, &freshest_block, 5));
+
+        let fetch = RecordPointerFetch::new(&store);
+        assert_eq!(
+            block_on(fetch.fetch(&name)).expect("fetch succeeds"),
+            Some(freshest_block),
+            "the freshest valid record's value wins over an older one and a forged outer sig"
+        );
+    }
+
+    #[test]
+    fn production_fetch_walk_fails_closed_on_a_forged_inner_repoint() {
+        let eps = endpoints(1);
+        let store = InMemoryRecordStore::new(eps.clone());
+        let owner = owner_signer();
+
+        // Index 0: a valid owner-signed re-point.
+        let good = seal_block(&owner, 0, &repoint(1, 1));
+        store.seed_record(
+            &eps[0],
+            vault_pointer_name(SECRET, 0).as_str(),
+            record_for(0, &good, 1),
+        );
+        // Index 1: a valid OUTER IPNS record whose INNER re-point is sealed by a
+        // rogue owner identity — the outer passes fan-out verify, the inner
+        // fails closed at the walk's `open_repoint`.
+        let rogue = EcdsaSigner::from_scalar(&[7u8; 32]).unwrap();
+        let forged_inner = seal_block(&rogue, 1, &repoint(99, 99));
+        store.seed_record(
+            &eps[0],
+            vault_pointer_name(SECRET, 1).as_str(),
+            record_for(1, &forged_inner, 1),
+        );
+
+        let fetch = RecordPointerFetch::new(&store);
+        let err = block_on(resolve_vault_pointer(
+            &fetch,
+            SECRET,
+            &owner.verifying_key(),
+            &ROOT_SCOPE,
+            PAYLOAD_VERSION,
+        ))
+        .expect_err("a forged inner re-point fails the walk closed");
+        assert!(
+            matches!(err, PointerError::Open(_)),
+            "the inner-forge is surfaced verbatim as PointerError::Open, not swallowed"
+        );
+    }
+}

--- a/crates/engine/src/net/publish.rs
+++ b/crates/engine/src/net/publish.rs
@@ -103,6 +103,11 @@ pub enum PublishError {
     /// fail-closed trust event, never "no floor": publish stops rather than mint
     /// a sequence from assumed-empty state (blueprint/engine.md floor law).
     FloorRead(SeamError),
+    /// The request carried an empty head CID, which would sign `/ipfs/` — a
+    /// value the decode side ([`head_cid_from_value`]) always rejects. Refused
+    /// release-active so no path can ever PUT an unopenable pointer (security
+    /// rule 8; encode/decode fail-closed symmetry).
+    EmptyHeadCid,
 }
 
 /// Run the publish pipeline for `request`. Register-first and fail-closed:
@@ -122,6 +127,13 @@ where
     F: FloorStore,
     Sch: Scheduler + Clone + 'static,
 {
+    // Encode/decode fail-closed symmetry (security rule 8): head_cid_from_value
+    // rejects an empty CID, so refuse to sign+PUT `/ipfs/` here — release-active,
+    // never a debug_assert stripped in release.
+    if request.head_cid.is_empty() {
+        return Err(PublishError::EmptyHeadCid);
+    }
+
     // Register-first, fail-closed: the record never reaches the transport unless
     // the registration succeeds (#24 D6 / #34 D2).
     api.register(std::slice::from_ref(&request.registration()))

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -23,9 +23,12 @@ use zeroize::Zeroizing;
 use super::fanout::fanout_get_verify;
 use super::liveness::{HeldRecord, HeldRecords};
 use super::publish::head_cid_from_value;
+use crate::facade::NodeId;
 use crate::gate::{Adopted, GateError, GateRejection, RejectionReason};
 use crate::seams::{RecordTransport, SeamError, SnapshotCache};
 use crate::session::SessionIdentity;
+use crate::sync::model::Snapshot;
+use crate::sync::project::project_root;
 
 /// Runs the adoption gate over a fetched record. The concrete implementation
 /// assembles the content-plane candidate and the reader's private context and
@@ -273,6 +276,26 @@ where
         );
     }
     Ok(resolved)
+}
+
+/// Fold a completed resolve's verdict into the shared base cell. A gate-passing
+/// `Adopted` re-projects (`project_root`) and replaces the base, returning true
+/// (the caller emits `SnapshotUpdated`); `Current`/`NoUpdate`/`TrustViolation`
+/// leave last-known-good intact and return false. Non-await by construction — the
+/// short `borrow_mut` never spans an `.await` (facade single-threaded executor
+/// rule).
+pub(crate) fn refresh_base_from_outcome(
+    base: &RefCell<Snapshot>,
+    root: NodeId,
+    outcome: &ResolveOutcome,
+) -> bool {
+    match outcome {
+        ResolveOutcome::Adopted(adopted) => {
+            *base.borrow_mut() = project_root(root, adopted);
+            true
+        }
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -728,5 +751,87 @@ mod tests {
             "renewal preserves the head CID; never /ipfs/",
         );
         assert!(!expected_head.is_empty());
+    }
+
+    mod refresh_base {
+        use super::super::refresh_base_from_outcome;
+        use super::{GateRejection, GateStage, RejectionReason, ResolveOutcome};
+
+        use core::cell::RefCell;
+
+        use cipherbox_core::error::TrustViolation;
+        use cipherbox_core::seal::{ChildRef, NodeKind, ReadBody};
+
+        use crate::facade::NodeId;
+        use crate::gate::Adopted;
+        use crate::sync::model::Snapshot;
+        use crate::sync::overlay::apply_overlay;
+
+        fn adopted_with_one_child(child_id: [u8; 16]) -> Adopted {
+            Adopted {
+                read_body: ReadBody::Folder {
+                    created_at: 0,
+                    modified_at: 0,
+                    children: vec![ChildRef {
+                        id: child_id,
+                        name: "hello.txt".to_string(),
+                        ipns_name: vec![1],
+                        kind: NodeKind::File,
+                        link_counter: 1,
+                        unknown: Vec::new(),
+                    }],
+                    unknown: Vec::new(),
+                },
+                sequence: 2,
+                epoch: 1,
+            }
+        }
+
+        #[test]
+        fn refresh_base_from_a_newer_adopted_updates_the_cell() {
+            let root = NodeId([0u8; 16]);
+            let cell = RefCell::new(Snapshot::new(root));
+            let child_id = [7u8; 16];
+
+            assert!(refresh_base_from_outcome(
+                &cell,
+                root,
+                &ResolveOutcome::Adopted(adopted_with_one_child(child_id)),
+            ));
+
+            let base = cell.borrow();
+            let rendered = apply_overlay(&base, &[]);
+            let children = rendered.children(root);
+            assert_eq!(children.len(), 1, "the newer child is projected under root");
+            assert_eq!(children[0].id, NodeId(child_id));
+        }
+
+        #[test]
+        fn non_adopting_outcomes_leave_the_base_untouched() {
+            let root = NodeId([9u8; 16]);
+            let before = Snapshot::new(root);
+            let rejection = GateRejection {
+                stage: GateStage::RecordVerify,
+                reason: RejectionReason::Trust(TrustViolation::IpnsSignatureInvalid.into()),
+            };
+            for outcome in [
+                ResolveOutcome::NoUpdate,
+                ResolveOutcome::Current {
+                    record_bytes: vec![1, 2, 3],
+                },
+                ResolveOutcome::TrustViolation(rejection),
+            ] {
+                let cell = RefCell::new(before.clone());
+                assert!(
+                    !refresh_base_from_outcome(&cell, root, &outcome),
+                    "{outcome:?} must not repaint the base"
+                );
+                assert_eq!(
+                    *cell.borrow(),
+                    before,
+                    "{outcome:?} leaves last-known-good byte-identical"
+                );
+            }
+        }
     }
 }

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -15,9 +15,13 @@
 //! now: **every** fetched record is routed through [`Adopter::adopt`] — there is
 //! no ungated path to the snapshot.
 
+use core::cell::RefCell;
+
 use cipherbox_core::ipns::IpnsName;
+use zeroize::Zeroizing;
 
 use super::fanout::fanout_get_verify;
+use super::liveness::{HeldRecord, HeldRecords};
 use crate::gate::{Adopted, GateError, GateRejection, RejectionReason};
 use crate::seams::{RecordTransport, SeamError, SnapshotCache};
 
@@ -108,4 +112,62 @@ where
         last_known_good,
         outcome,
     })
+}
+
+/// The per-name material the held set carries beyond the fetched record: the
+/// derivation **inputs** #750's seq+1 renewal rebuilds a `PublishRequest` from
+/// (never a live signer — see [`HeldRecord`]). Supplied by the resolve/gate
+/// path, which already unsealed the scope's write seed for this node.
+pub struct HeldMaterial {
+    /// The node id (`id16`) — the held-set key and a signer-derivation input.
+    pub node_id: [u8; 16],
+    /// The scope's unsealed write seed — a derivation input, not a signer.
+    pub write_scope_seed: Zeroizing<[u8; 32]>,
+    /// The head/metadata CID the renewal record points at.
+    pub head_cid: String,
+    /// The content CIDs to re-register/pin at renewal.
+    pub content_cids: Vec<String>,
+}
+
+/// [`resolve`] a name, then hold it for liveness **iff** it passed the gate:
+/// on [`ResolveOutcome::Adopted`], insert (replacing any prior entry for the
+/// same node) a [`HeldRecord`] so the keyless re-PUT loop keeps it alive. Only a
+/// gate-passing record enters the set — a `TrustViolation`/`NoUpdate` never
+/// does (blueprint/engine.md "Liveness": never re-PUT a stale record).
+pub async fn resolve_and_hold<T, S, A>(
+    transport: &T,
+    snapshot_cache: &S,
+    adopter: &A,
+    name: &IpnsName,
+    held: &RefCell<HeldRecords>,
+    material: &HeldMaterial,
+) -> Result<Resolved, SeamError>
+where
+    T: RecordTransport,
+    S: SnapshotCache,
+    A: Adopter,
+{
+    let resolved = resolve(transport, snapshot_cache, adopter, name).await?;
+    if matches!(resolved.outcome, ResolveOutcome::Adopted(_)) {
+        // The adopted record is now the snapshot cache's last-known-good; hold
+        // exactly those bytes for a byte-stable keyless re-PUT. A cache that
+        // dropped what it just adopted is a broken durable seam — fail closed.
+        let cache_key = name.as_str().as_bytes();
+        let record_bytes = snapshot_cache
+            .get(cache_key)
+            .await?
+            .ok_or_else(|| SeamError::new("snapshot cache dropped the adopted record"))?;
+        held.borrow_mut().insert(
+            material.node_id,
+            HeldRecord {
+                routing_key: name.as_str().to_owned(),
+                record_bytes,
+                node_id: material.node_id,
+                write_scope_seed: material.write_scope_seed.clone(),
+                head_cid: material.head_cid.clone(),
+                content_cids: material.content_cids.clone(),
+            },
+        );
+    }
+    Ok(resolved)
 }

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -34,9 +34,27 @@ use crate::session::SessionIdentity;
 /// (blueprint/engine.md: "only gate-passing records touch the snapshot").
 pub trait Adopter {
     /// Assemble and gate the record fetched under `name`. `Ok` carries the
-    /// authenticated read-body and floors; `Err(GateError::Rejected)` is a
-    /// fail-closed trust violation; `Err(GateError::Seam)` is host I/O.
-    async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<Adopted, GateError>;
+    /// authenticated read-body and floors plus, for a write-capable holder, the
+    /// transient write material the held set derives its renewal signer from;
+    /// `Err(GateError::Rejected)` is a fail-closed trust violation;
+    /// `Err(GateError::Seam)` is host I/O.
+    async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<AdoptOutcome, GateError>;
+}
+
+/// A gate pass plus the transient write material a write-capable holder needs to
+/// keep its scope alive (blueprint/engine.md "Liveness").
+pub struct AdoptOutcome {
+    /// The authenticated read-body and floors.
+    pub adopted: Adopted,
+    /// The scope write seed, `Some` only for a write-capable holder (a write
+    /// grant). `None` for a read-only holder and the owner arm → the record is
+    /// held keyless. Transient: [`resolve_and_hold`] derives the narrow per-name
+    /// signer and drops it; never persisted (least privilege; security rules
+    /// 2/5).
+    pub write_scope_seed: Option<Zeroizing<[u8; 32]>>,
+    /// The scope-root node id (`id16`, the envelope id) — the held-set key and
+    /// signer-derivation input for a gate-surfaced write grant.
+    pub node_id: [u8; 16],
 }
 
 /// What a resolve produced for the freshest fetched record.
@@ -91,17 +109,47 @@ where
     S: SnapshotCache,
     A: Adopter,
 {
+    // The public resolve drops the transient hold material — only the liveness
+    // driver ([`resolve_and_hold`]) consumes it.
+    Ok(resolve_gated(transport, snapshot_cache, adopter, name)
+        .await?
+        .0)
+}
+
+/// The (node id, write scope seed) a gate-surfaced write grant contributes to
+/// the held set. `Some` only on a gate pass that carried a write seed.
+type AdoptHold = ([u8; 16], Zeroizing<[u8; 32]>);
+
+/// The gated resolve, returning the outcome plus, on a gate pass that surfaced a
+/// write seed, the transient hold material the held set consumes. Kept internal
+/// so the write seed never rides the public [`Resolved`].
+async fn resolve_gated<T, S, A>(
+    transport: &T,
+    snapshot_cache: &S,
+    adopter: &A,
+    name: &IpnsName,
+) -> Result<(Resolved, Option<AdoptHold>), SeamError>
+where
+    T: RecordTransport,
+    S: SnapshotCache,
+    A: Adopter,
+{
     let cache_key = name.as_str().as_bytes();
     // Cache-first: last-known-good renders immediately, reconcile runs behind it.
     let last_known_good = snapshot_cache.get(cache_key).await?;
 
-    let outcome = match fanout_get_verify(transport, name).await {
-        None => ResolveOutcome::NoUpdate,
+    let (outcome, hold) = match fanout_get_verify(transport, name).await {
+        None => (ResolveOutcome::NoUpdate, None),
         Some((_sequence, bytes)) => match adopter.adopt(name, &bytes).await {
-            Ok(adopted) => {
+            Ok(AdoptOutcome {
+                adopted,
+                write_scope_seed,
+                node_id,
+            }) => {
                 // Only gate-passing records touch the snapshot.
                 snapshot_cache.put(cache_key, &bytes).await?;
-                ResolveOutcome::Adopted(adopted)
+                let hold = write_scope_seed.map(|seed| (node_id, seed));
+                (ResolveOutcome::Adopted(adopted), hold)
             }
             // A record at exactly the durable sequence floor is our own current
             // record re-fetched — no update, never a violation; its verified
@@ -109,21 +157,25 @@ where
             // re-fetch. A strictly older sequence is a replay/rollback and stays
             // a fail-closed trust violation, as does every other gate rejection.
             Err(GateError::Rejected(rejection)) => match &rejection.reason {
-                RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor => {
+                RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor => (
                     ResolveOutcome::Current {
                         record_bytes: bytes,
-                    }
-                }
-                _ => ResolveOutcome::TrustViolation(rejection),
+                    },
+                    None,
+                ),
+                _ => (ResolveOutcome::TrustViolation(rejection), None),
             },
             Err(GateError::Seam(error)) => return Err(error),
         },
     };
 
-    Ok(Resolved {
-        last_known_good,
-        outcome,
-    })
+    Ok((
+        Resolved {
+            last_known_good,
+            outcome,
+        },
+        hold,
+    ))
 }
 
 /// The transient insert-time input for a held record: the resolve/gate path has
@@ -133,11 +185,15 @@ where
 /// (only the #752 resolve-tick driver constructs it), hence crate-internal.
 #[allow(dead_code)] // wired by the #752 resolve-tick driver
 pub(crate) struct HeldMaterial {
-    /// The node id (`id16`) — the held-set key and a signer-derivation input.
+    /// The node id (`id16`) — the held-set key and a signer-derivation input for
+    /// an own-scope record. A gate-surfaced write grant overrides it with the
+    /// authenticated envelope id.
     pub node_id: [u8; 16],
-    /// The scope's unsealed write seed — an insert-time derivation input, never
+    /// Our own scope's write seed for an own-scope record (`Current`, or an
+    /// adopt with no gate-surfaced seed). `None` when the seed rides the adopt
+    /// instead (a write grantee). An insert-time derivation input, never
     /// persisted in the held set.
-    pub write_scope_seed: Zeroizing<[u8; 32]>,
+    pub write_scope_seed: Option<Zeroizing<[u8; 32]>>,
     /// The head/metadata CID the renewal record points at.
     pub head_cid: String,
     /// The content CIDs to re-register/pin at renewal.
@@ -163,7 +219,7 @@ where
     S: SnapshotCache,
     A: Adopter,
 {
-    let resolved = resolve(transport, snapshot_cache, adopter, name).await?;
+    let (resolved, adopt_hold) = resolve_gated(transport, snapshot_cache, adopter, name).await?;
     // A gate-passing adopt (`Adopted`) and our own current record (`Current`)
     // are both alive-worthy; a `TrustViolation`/`NoUpdate` is never held. For
     // `Adopted` the bytes are the cache's fresh last-known-good; for `Current`
@@ -185,18 +241,29 @@ where
         ResolveOutcome::TrustViolation(_) | ResolveOutcome::NoUpdate => None,
     };
     if let Some(record_bytes) = record_bytes {
-        // Derive the narrow per-name signer once from the transient seed and
-        // hold only it — the scope seed is dropped with `material`. Fail-closed
-        // encode-side bind (security rule 8): the derived signer must sign for
-        // exactly this name, or the held record could never renew under its
-        // routing key — skip the hold rather than store a mismatched signer.
-        let signer =
-            SessionIdentity::write_name_signer(&material.write_scope_seed, &material.node_id);
+        // The renewal (node id, write seed) comes from the gate for a write
+        // grantee, else from the caller for an own-scope record. No seed on
+        // either side ⇒ nothing to renew with ⇒ held keyless is a later slice, so
+        // skip the hold rather than store a signerless record.
+        let Some((node_id, write_scope_seed)) = adopt_hold.or_else(|| {
+            material
+                .write_scope_seed
+                .as_ref()
+                .map(|seed| (material.node_id, seed.clone()))
+        }) else {
+            return Ok(resolved);
+        };
+        // Derive the narrow per-name signer once from the transient seed and hold
+        // only it — the seed drops at this scope's end. Fail-closed encode-side
+        // bind (security rule 8): the derived signer must sign for exactly this
+        // name, or the held record could never renew under its routing key — skip
+        // the hold rather than store a mismatched signer.
+        let signer = SessionIdentity::write_name_signer(&write_scope_seed, &node_id);
         if IpnsName::from_public_key(&signer.verifying_key()) != *name {
             return Ok(resolved);
         }
         held.borrow_mut().insert(
-            material.node_id,
+            node_id,
             HeldRecord {
                 routing_key: name.as_str().to_owned(),
                 record_bytes,
@@ -240,25 +307,52 @@ mod tests {
 
     struct StubAdopter {
         verdict: Verdict,
+        /// The (write scope seed, node id) a gate-surfaced write grant contributes
+        /// on an `Accept` — `None` models a read-only/own-scope adopt.
+        grant: Option<([u8; 32], [u8; 16])>,
+    }
+
+    impl StubAdopter {
+        fn new(verdict: Verdict) -> Self {
+            Self {
+                verdict,
+                grant: None,
+            }
+        }
+
+        fn write_grant(seed: [u8; 32], node_id: [u8; 16]) -> Self {
+            Self {
+                verdict: Verdict::Accept,
+                grant: Some((seed, node_id)),
+            }
+        }
     }
 
     impl super::Adopter for StubAdopter {
-        async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<Adopted, GateError> {
+        async fn adopt(
+            &self,
+            name: &IpnsName,
+            record_bytes: &[u8],
+        ) -> Result<super::AdoptOutcome, GateError> {
             let sequence = IpnsRecord::unmarshal(record_bytes)
                 .unwrap()
                 .verify(name)
                 .unwrap()
                 .sequence;
             match self.verdict {
-                Verdict::Accept => Ok(Adopted {
-                    read_body: ReadBody::Folder {
-                        created_at: 0,
-                        modified_at: 0,
-                        children: Vec::new(),
-                        unknown: Vec::new(),
+                Verdict::Accept => Ok(super::AdoptOutcome {
+                    adopted: Adopted {
+                        read_body: ReadBody::Folder {
+                            created_at: 0,
+                            modified_at: 0,
+                            children: Vec::new(),
+                            unknown: Vec::new(),
+                        },
+                        sequence,
+                        epoch: 1,
                     },
-                    sequence,
-                    epoch: 1,
+                    write_scope_seed: self.grant.map(|(seed, _)| Zeroizing::new(seed)),
+                    node_id: self.grant.map(|(_, id)| id).unwrap_or([0u8; 16]),
                 }),
                 Verdict::TrustViolation => Err(GateError::Rejected(GateRejection {
                     stage: GateStage::RecordVerify,
@@ -298,16 +392,14 @@ mod tests {
         let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
         let material = HeldMaterial {
             node_id,
-            write_scope_seed: Zeroizing::new(write_scope_seed),
+            write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
             head_cid: "bafyhead".into(),
             content_cids: vec!["bafycontent".into()],
         };
         let resolved = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
-            &StubAdopter {
-                verdict: Verdict::Accept,
-            },
+            &StubAdopter::new(Verdict::Accept),
             &name,
             &held,
             &material,
@@ -340,7 +432,7 @@ mod tests {
             .seed_record(&endpoints[0], name.as_str(), record(&signer, 5));
         let material = HeldMaterial {
             node_id: [1u8; 16],
-            write_scope_seed: Zeroizing::new([0u8; 32]),
+            write_scope_seed: Some(Zeroizing::new([0u8; 32])),
             head_cid: "h".into(),
             content_cids: Vec::new(),
         };
@@ -350,9 +442,7 @@ mod tests {
         let out = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
-            &StubAdopter {
-                verdict: Verdict::TrustViolation,
-            },
+            &StubAdopter::new(Verdict::TrustViolation),
             &name,
             &held,
             &material,
@@ -381,16 +471,14 @@ mod tests {
         let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
         let material = HeldMaterial {
             node_id,
-            write_scope_seed: Zeroizing::new(write_scope_seed),
+            write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
             head_cid: "bafyhead".into(),
             content_cids: Vec::new(),
         };
         let resolved = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
-            &StubAdopter {
-                verdict: Verdict::EqualSequence,
-            },
+            &StubAdopter::new(Verdict::EqualSequence),
             &name,
             &held,
             &material,
@@ -413,5 +501,97 @@ mod tests {
             "held bytes are the in-hand Current bytes"
         );
         assert_eq!(hr.routing_key, name.as_str());
+    }
+
+    #[test]
+    fn grantee_write_holder_derives_a_renewal_signer() {
+        use core::time::Duration;
+
+        use crate::api::ApiClient;
+        use crate::net::eol_renew_pass;
+        use crate::net::publish::PublishOutcome;
+        use crate::profile::SyncTimingProfile;
+        use crate::seams::FloorStore;
+
+        let world = FakeWorld::new();
+        let device = world.device(b"me");
+        let scheduler = world.scheduler.clone(); // manual clock, now = 0
+
+        // A write-grant adopt: the gate surfaces the scope write seed, so the
+        // caller's material carries no seed of its own (a grantee does not know
+        // it a priori). The held name is the one the gate-surfaced (seed, node id)
+        // derives.
+        let write_scope_seed = [5u8; 32];
+        let node_id = [6u8; 16];
+        let signer = SessionIdentity::write_name_signer(&write_scope_seed, &node_id);
+        let name = IpnsName::from_public_key(&signer.verifying_key());
+        for endpoint in device.record_store.endpoints() {
+            device
+                .record_store
+                .seed_record(&endpoint, name.as_str(), record(&signer, 1));
+        }
+
+        let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+        let material = HeldMaterial {
+            node_id: [0u8; 16],
+            write_scope_seed: None,
+            head_cid: "bafyfixturehead".into(),
+            content_cids: Vec::new(),
+        };
+        block_on(resolve_and_hold(
+            &device.record_store,
+            &device.snapshot_cache,
+            &StubAdopter::write_grant(write_scope_seed, node_id),
+            &name,
+            &held,
+            &material,
+        ))
+        .expect("resolve_and_hold");
+
+        // The gate-surfaced write seed derived the renewal signer, keyed by the
+        // gate's node id, and it signs for exactly the held name.
+        let hr = held
+            .borrow()
+            .get(&node_id)
+            .cloned()
+            .expect("write grantee is held by the gate node id");
+        assert_eq!(
+            IpnsName::from_public_key(&hr.signer.verifying_key()),
+            name,
+            "the derived signer signs for the held routing key"
+        );
+
+        // The held record renews: model adoption (floor → 1), advance into the
+        // EOL window, and prove the derived signer republishes at seq+1.
+        block_on(
+            device
+                .floor_store
+                .raise_sequence_floor(name.as_str().as_bytes(), 1),
+        )
+        .unwrap();
+        scheduler.advance(Duration::from_secs(65 * 24 * 60 * 60));
+        let api = ApiClient::new(
+            device.http.clone(),
+            device.credential_store.clone(),
+            "http://api.test",
+        );
+        device.http.enqueue_response(crate::seams::HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: Vec::new(),
+        });
+        let results = block_on(eol_renew_pass(
+            &device.record_store,
+            &api,
+            &device.floor_store,
+            &scheduler,
+            &SyncTimingProfile::CI,
+            &[hr],
+        ));
+        assert_eq!(
+            results[0].outcome.as_ref().unwrap(),
+            &Some(PublishOutcome::Published { sequence: 2 }),
+            "the held write grantee renews at seq+1 under its derived signer",
+        );
     }
 }

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -17,11 +17,12 @@
 
 use core::cell::RefCell;
 
-use cipherbox_core::ipns::IpnsName;
+use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use zeroize::Zeroizing;
 
 use super::fanout::fanout_get_verify;
 use super::liveness::{HeldRecord, HeldRecords};
+use super::publish::head_cid_from_value;
 use crate::gate::{Adopted, GateError, GateRejection, RejectionReason};
 use crate::seams::{RecordTransport, SeamError, SnapshotCache};
 use crate::session::SessionIdentity;
@@ -128,7 +129,7 @@ async fn resolve_gated<T, S, A>(
     snapshot_cache: &S,
     adopter: &A,
     name: &IpnsName,
-) -> Result<(Resolved, Option<AdoptHold>), SeamError>
+) -> Result<(Resolved, Option<AdoptHold>, Option<Vec<u8>>), SeamError>
 where
     T: RecordTransport,
     S: SnapshotCache,
@@ -138,32 +139,34 @@ where
     // Cache-first: last-known-good renders immediately, reconcile runs behind it.
     let last_known_good = snapshot_cache.get(cache_key).await?;
 
-    let (outcome, hold) = match fanout_get_verify(transport, name).await {
-        None => (ResolveOutcome::NoUpdate, None),
+    let (outcome, hold, held_bytes) = match fanout_get_verify(transport, name).await {
+        None => (ResolveOutcome::NoUpdate, None, None),
         Some((_sequence, bytes)) => match adopter.adopt(name, &bytes).await {
             Ok(AdoptOutcome {
                 adopted,
                 write_scope_seed,
                 node_id,
             }) => {
-                // Only gate-passing records touch the snapshot.
+                // Only gate-passing records touch the snapshot; the same verified
+                // bytes ride out to the liveness hold, so no re-fetch/re-get.
                 snapshot_cache.put(cache_key, &bytes).await?;
                 let hold = write_scope_seed.map(|seed| (node_id, seed));
-                (ResolveOutcome::Adopted(adopted), hold)
+                (ResolveOutcome::Adopted(adopted), hold, Some(bytes))
             }
             // A record at exactly the durable sequence floor is our own current
             // record re-fetched — no update, never a violation; its verified
-            // bytes are handed back so the liveness loop holds them without a
-            // re-fetch. A strictly older sequence is a replay/rollback and stays
-            // a fail-closed trust violation, as does every other gate rejection.
+            // bytes ride out so the liveness loop holds them without a re-fetch.
+            // A strictly older sequence is a replay/rollback and stays a
+            // fail-closed trust violation, as does every other gate rejection.
             Err(GateError::Rejected(rejection)) => match &rejection.reason {
                 RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor => (
                     ResolveOutcome::Current {
-                        record_bytes: bytes,
+                        record_bytes: bytes.clone(),
                     },
                     None,
+                    Some(bytes),
                 ),
-                _ => (ResolveOutcome::TrustViolation(rejection), None),
+                _ => (ResolveOutcome::TrustViolation(rejection), None, None),
             },
             Err(GateError::Seam(error)) => return Err(error),
         },
@@ -175,6 +178,7 @@ where
             outcome,
         },
         hold,
+        held_bytes,
     ))
 }
 
@@ -194,8 +198,6 @@ pub(crate) struct HeldMaterial {
     /// instead (a write grantee). An insert-time derivation input, never
     /// persisted in the held set.
     pub write_scope_seed: Option<Zeroizing<[u8; 32]>>,
-    /// The head/metadata CID the renewal record points at.
-    pub head_cid: String,
     /// The content CIDs to re-register/pin at renewal.
     pub content_cids: Vec<String>,
 }
@@ -218,28 +220,24 @@ where
     S: SnapshotCache,
     A: Adopter,
 {
-    let (resolved, adopt_hold) = resolve_gated(transport, snapshot_cache, adopter, name).await?;
+    let (resolved, adopt_hold, held_bytes) =
+        resolve_gated(transport, snapshot_cache, adopter, name).await?;
     // A gate-passing adopt (`Adopted`) and our own current record (`Current`)
-    // are both alive-worthy; a `TrustViolation`/`NoUpdate` is never held. For
-    // `Adopted` the bytes are the cache's fresh last-known-good; for `Current`
-    // the verified bytes are already in hand, so no re-fetch (blueprint/engine.md
-    // "Liveness").
-    let record_bytes = match &resolved.outcome {
-        ResolveOutcome::Adopted(_) => {
-            // A cache that dropped what it just adopted is a broken durable seam
-            // — fail closed rather than hold nothing.
-            let cache_key = name.as_str().as_bytes();
-            Some(
-                snapshot_cache
-                    .get(cache_key)
-                    .await?
-                    .ok_or_else(|| SeamError::new("snapshot cache dropped the adopted record"))?,
-            )
-        }
-        ResolveOutcome::Current { record_bytes } => Some(record_bytes.clone()),
-        ResolveOutcome::TrustViolation(_) | ResolveOutcome::NoUpdate => None,
-    };
-    if let Some(record_bytes) = record_bytes {
+    // are both alive-worthy and ride their verified bytes back here; a
+    // `TrustViolation`/`NoUpdate` holds nothing (blueprint/engine.md "Liveness").
+    if let Some(record_bytes) = held_bytes {
+        // Renew under the record's own adopted head CID, not a caller-supplied
+        // one: parse it from the signed `/ipfs/<cid>` value. A gate-passing
+        // record always carries a valid value; if it does not, skip the hold
+        // rather than renew under `/ipfs/` — an empty head CID would clobber the
+        // tip (security rule 8, fail-closed).
+        let Some(head_cid) = IpnsRecord::unmarshal(&record_bytes)
+            .and_then(|record| record.verify(name))
+            .ok()
+            .and_then(|verified| head_cid_from_value(&verified.value))
+        else {
+            return Ok(resolved);
+        };
         // The renewal (node id, write seed) comes from the gate for a write
         // grantee, else from the caller for an own-scope record. No seed on
         // either side ⇒ nothing to renew with ⇒ held keyless is a later slice, so
@@ -261,13 +259,15 @@ where
         if IpnsName::from_public_key(&signer.verifying_key()) != *name {
             return Ok(resolved);
         }
+        // Content re-pin on renewal is a deferred slice; the record still
+        // republishes validly under its head CID (only re-pinning is deferred).
         held.borrow_mut().insert(
             node_id,
             HeldRecord {
                 routing_key: name.as_str().to_owned(),
                 record_bytes,
                 signer,
-                head_cid: material.head_cid.clone(),
+                head_cid,
                 content_cids: material.content_cids.clone(),
             },
         );
@@ -277,7 +277,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{HeldMaterial, ResolveOutcome, resolve_and_hold};
+    use super::{HeldMaterial, ResolveOutcome, head_cid_from_value, resolve_and_hold};
 
     use core::cell::RefCell;
 
@@ -392,7 +392,6 @@ mod tests {
         let material = HeldMaterial {
             node_id,
             write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
-            head_cid: "bafyhead".into(),
             content_cids: vec!["bafycontent".into()],
         };
         let resolved = block_on(resolve_and_hold(
@@ -410,7 +409,6 @@ mod tests {
         assert_eq!(map.len(), 1, "the adopted record is held, keyed by node id");
         let record = map.get(&node_id).expect("held under its node id");
         assert_eq!(record.routing_key, name.as_str());
-        assert_eq!(record.head_cid, "bafyhead");
         assert_eq!(record.content_cids, vec!["bafycontent".to_owned()]);
         // The held signer signs for the routing key (the insert-time bind).
         assert_eq!(
@@ -432,7 +430,6 @@ mod tests {
         let material = HeldMaterial {
             node_id: [1u8; 16],
             write_scope_seed: Some(Zeroizing::new([0u8; 32])),
-            head_cid: "h".into(),
             content_cids: Vec::new(),
         };
 
@@ -471,7 +468,6 @@ mod tests {
         let material = HeldMaterial {
             node_id,
             write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
-            head_cid: "bafyhead".into(),
             content_cids: Vec::new(),
         };
         let resolved = block_on(resolve_and_hold(
@@ -534,7 +530,6 @@ mod tests {
         let material = HeldMaterial {
             node_id: [0u8; 16],
             write_scope_seed: None,
-            head_cid: "bafyfixturehead".into(),
             content_cids: Vec::new(),
         };
         block_on(resolve_and_hold(
@@ -592,5 +587,146 @@ mod tests {
             &Some(PublishOutcome::Published { sequence: 2 }),
             "the held write grantee renews at seq+1 under its derived signer",
         );
+    }
+
+    #[test]
+    fn resolve_and_hold_takes_the_head_cid_from_the_adopted_record() {
+        let world = FakeWorld::new();
+        let device = world.device(b"me");
+        let write_scope_seed = [11u8; 32];
+        let node_id = [12u8; 16];
+        let signer = SessionIdentity::write_name_signer(&write_scope_seed, &node_id);
+        let name = IpnsName::from_public_key(&signer.verifying_key());
+        for endpoint in device.record_store.endpoints() {
+            device
+                .record_store
+                .seed_record(&endpoint, name.as_str(), record(&signer, 1));
+        }
+
+        // The caller supplies no head CID (HeldMaterial has none): the held
+        // record must take it from the adopted record's own signed value.
+        let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+        let material = HeldMaterial {
+            node_id,
+            write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
+            content_cids: Vec::new(),
+        };
+        block_on(resolve_and_hold(
+            &device.record_store,
+            &device.snapshot_cache,
+            &StubAdopter::new(Verdict::Accept),
+            &name,
+            &held,
+            &material,
+        ))
+        .expect("resolve_and_hold");
+
+        let expected = head_cid_from_value(VALUE).expect("fixture value has a head cid");
+        assert!(!expected.is_empty());
+        let map = held.borrow();
+        let record = map.get(&node_id).expect("held under its node id");
+        assert_eq!(
+            record.head_cid, expected,
+            "the held head CID is derived from the adopted record, never empty",
+        );
+    }
+
+    #[test]
+    fn renewal_republishes_under_the_real_head_cid() {
+        use core::time::Duration;
+
+        use crate::api::ApiClient;
+        use crate::net::eol_renew_pass;
+        use crate::net::publish::PublishOutcome;
+        use crate::profile::SyncTimingProfile;
+        use crate::seams::FloorStore;
+
+        let world = FakeWorld::new();
+        let device = world.device(b"me");
+        let scheduler = world.scheduler.clone(); // manual clock, now = 0
+
+        let write_scope_seed = [2u8; 32];
+        let node_id = [3u8; 16];
+        let signer = SessionIdentity::write_name_signer(&write_scope_seed, &node_id);
+        let name = IpnsName::from_public_key(&signer.verifying_key());
+        for endpoint in device.record_store.endpoints() {
+            device
+                .record_store
+                .seed_record(&endpoint, name.as_str(), record(&signer, 1));
+        }
+
+        let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+        let material = HeldMaterial {
+            node_id,
+            write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
+            content_cids: Vec::new(),
+        };
+        block_on(resolve_and_hold(
+            &device.record_store,
+            &device.snapshot_cache,
+            &StubAdopter::new(Verdict::Accept),
+            &name,
+            &held,
+            &material,
+        ))
+        .expect("resolve_and_hold");
+        let hr = held
+            .borrow()
+            .get(&node_id)
+            .cloned()
+            .expect("held under its node id");
+        let expected_head = head_cid_from_value(VALUE).expect("fixture value has a head cid");
+        assert_eq!(hr.head_cid, expected_head);
+
+        // Advance into the EOL window and renew, then prove the republished
+        // record's value round-trips to the SAME non-empty head CID (never
+        // `/ipfs/`).
+        block_on(
+            device
+                .floor_store
+                .raise_sequence_floor(name.as_str().as_bytes(), 1),
+        )
+        .unwrap();
+        scheduler.advance(Duration::from_secs(65 * 24 * 60 * 60));
+        let api = ApiClient::new(
+            device.http.clone(),
+            device.credential_store.clone(),
+            "http://api.test",
+        );
+        device.http.enqueue_response(crate::seams::HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: Vec::new(),
+        });
+        let results = block_on(eol_renew_pass(
+            &device.record_store,
+            &api,
+            &device.floor_store,
+            &scheduler,
+            &SyncTimingProfile::CI,
+            &[hr],
+        ));
+        assert_eq!(
+            results[0].outcome.as_ref().unwrap(),
+            &Some(PublishOutcome::Published { sequence: 2 }),
+            "renewal republishes at seq+1",
+        );
+
+        let endpoint = device.record_store.endpoints()[0].clone();
+        let republished = device
+            .record_store
+            .record_at(&endpoint, name.as_str())
+            .expect("republished record present");
+        let value = IpnsRecord::unmarshal(&republished)
+            .unwrap()
+            .verify(&name)
+            .unwrap()
+            .value;
+        assert_eq!(
+            head_cid_from_value(&value).as_deref(),
+            Some(expected_head.as_str()),
+            "renewal preserves the head CID; never /ipfs/",
+        );
+        assert!(!expected_head.is_empty());
     }
 }

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -24,6 +24,7 @@ use super::fanout::fanout_get_verify;
 use super::liveness::{HeldRecord, HeldRecords};
 use crate::gate::{Adopted, GateError, GateRejection, RejectionReason};
 use crate::seams::{RecordTransport, SeamError, SnapshotCache};
+use crate::session::SessionIdentity;
 
 /// Runs the adoption gate over a fetched record. The concrete implementation
 /// assembles the content-plane candidate and the reader's private context and
@@ -114,14 +115,17 @@ where
     })
 }
 
-/// The per-name material the held set carries beyond the fetched record: the
-/// derivation **inputs** #750's seq+1 renewal rebuilds a `PublishRequest` from
-/// (never a live signer — see [`HeldRecord`]). Supplied by the resolve/gate
-/// path, which already unsealed the scope's write seed for this node.
-pub struct HeldMaterial {
+/// The transient insert-time input for a held record: the resolve/gate path has
+/// already unsealed the scope's write seed for this node, so the held set
+/// derives the narrow per-name signer from it once at insert and drops the seed
+/// (never persisting it — see [`HeldRecord`]). Not yet wired in production
+/// (only the #752 resolve-tick driver constructs it), hence crate-internal.
+#[allow(dead_code)] // wired by the #752 resolve-tick driver
+pub(crate) struct HeldMaterial {
     /// The node id (`id16`) — the held-set key and a signer-derivation input.
     pub node_id: [u8; 16],
-    /// The scope's unsealed write seed — a derivation input, not a signer.
+    /// The scope's unsealed write seed — an insert-time derivation input, never
+    /// persisted in the held set.
     pub write_scope_seed: Zeroizing<[u8; 32]>,
     /// The head/metadata CID the renewal record points at.
     pub head_cid: String,
@@ -134,7 +138,8 @@ pub struct HeldMaterial {
 /// same node) a [`HeldRecord`] so the keyless re-PUT loop keeps it alive. Only a
 /// gate-passing record enters the set — a `TrustViolation`/`NoUpdate` never
 /// does (blueprint/engine.md "Liveness": never re-PUT a stale record).
-pub async fn resolve_and_hold<T, S, A>(
+#[allow(dead_code)] // wired by the #752 resolve-tick driver
+pub(crate) async fn resolve_and_hold<T, S, A>(
     transport: &T,
     snapshot_cache: &S,
     adopter: &A,
@@ -149,6 +154,16 @@ where
 {
     let resolved = resolve(transport, snapshot_cache, adopter, name).await?;
     if matches!(resolved.outcome, ResolveOutcome::Adopted(_)) {
+        // Derive the narrow per-name signer once from the transient seed and
+        // hold only it — the scope seed is dropped with `material`. Fail-closed
+        // encode-side bind (security rule 8): the derived signer must sign for
+        // exactly the adopted name, or the held record could never renew under
+        // its routing key — skip the hold rather than store a mismatched signer.
+        let signer =
+            SessionIdentity::write_name_signer(&material.write_scope_seed, &material.node_id);
+        if IpnsName::from_public_key(&signer.verifying_key()) != *name {
+            return Ok(resolved);
+        }
         // The adopted record is now the snapshot cache's last-known-good; hold
         // exactly those bytes for a byte-stable keyless re-PUT. A cache that
         // dropped what it just adopted is a broken durable seam — fail closed.
@@ -162,12 +177,181 @@ where
             HeldRecord {
                 routing_key: name.as_str().to_owned(),
                 record_bytes,
-                node_id: material.node_id,
-                write_scope_seed: material.write_scope_seed.clone(),
+                signer,
                 head_cid: material.head_cid.clone(),
                 content_cids: material.content_cids.clone(),
             },
         );
     }
     Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HeldMaterial, ResolveOutcome, resolve_and_hold};
+
+    use core::cell::RefCell;
+
+    use cipherbox_core::error::TrustViolation;
+    use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+    use cipherbox_core::seal::ReadBody;
+    use cipherbox_core::suite::ed25519::Ed25519Signer;
+    use zeroize::Zeroizing;
+
+    use super::super::eol;
+    use crate::gate::{Adopted, GateError, GateRejection, GateStage, RejectionReason};
+    use crate::net::HeldRecords;
+    use crate::seams::{RecordTransport, UnixMillis};
+    use crate::session::SessionIdentity;
+    use crate::testkit::{FakeWorld, block_on};
+
+    const TTL_NANOS: u64 = 2_000_000_000;
+    const VALUE: &[u8] = b"/ipfs/bafyfixturehead";
+
+    #[derive(Clone, Copy)]
+    enum Verdict {
+        Accept,
+        TrustViolation,
+        EqualSequence,
+    }
+
+    struct StubAdopter {
+        verdict: Verdict,
+    }
+
+    impl super::Adopter for StubAdopter {
+        async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<Adopted, GateError> {
+            let sequence = IpnsRecord::unmarshal(record_bytes)
+                .unwrap()
+                .verify(name)
+                .unwrap()
+                .sequence;
+            match self.verdict {
+                Verdict::Accept => Ok(Adopted {
+                    read_body: ReadBody::Folder {
+                        created_at: 0,
+                        modified_at: 0,
+                        children: Vec::new(),
+                        unknown: Vec::new(),
+                    },
+                    sequence,
+                    epoch: 1,
+                }),
+                Verdict::TrustViolation => Err(GateError::Rejected(GateRejection {
+                    stage: GateStage::RecordVerify,
+                    reason: RejectionReason::Trust(TrustViolation::IpnsSignatureInvalid.into()),
+                })),
+                Verdict::EqualSequence => Err(GateError::Rejected(GateRejection {
+                    stage: GateStage::Sequence,
+                    reason: RejectionReason::SequenceNotNewer {
+                        floor: sequence,
+                        sequence,
+                    },
+                })),
+            }
+        }
+    }
+
+    fn record(signer: &Ed25519Signer, sequence: u64) -> Vec<u8> {
+        let validity = eol::eol_from(UnixMillis(0));
+        IpnsRecord::create_v2(signer, VALUE, sequence, TTL_NANOS, &validity).marshal()
+    }
+
+    #[test]
+    fn resolve_and_hold_holds_a_gate_passing_record() {
+        let world = FakeWorld::new();
+        let device = world.device(b"me");
+        // The held name is the one the material's (seed, node id) derives, so the
+        // insert-time signer<->name bind passes.
+        let write_scope_seed = [9u8; 32];
+        let node_id = [7u8; 16];
+        let signer = SessionIdentity::write_name_signer(&write_scope_seed, &node_id);
+        let name = IpnsName::from_public_key(&signer.verifying_key());
+        let endpoints = world.record_store.endpoints();
+        world
+            .record_store
+            .seed_record(&endpoints[0], name.as_str(), record(&signer, 1));
+
+        let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+        let material = HeldMaterial {
+            node_id,
+            write_scope_seed: Zeroizing::new(write_scope_seed),
+            head_cid: "bafyhead".into(),
+            content_cids: vec!["bafycontent".into()],
+        };
+        let resolved = block_on(resolve_and_hold(
+            &device.record_store,
+            &device.snapshot_cache,
+            &StubAdopter {
+                verdict: Verdict::Accept,
+            },
+            &name,
+            &held,
+            &material,
+        ))
+        .expect("resolve_and_hold");
+
+        assert!(matches!(resolved.outcome, ResolveOutcome::Adopted(_)));
+        let map = held.borrow();
+        assert_eq!(map.len(), 1, "the adopted record is held, keyed by node id");
+        let record = map.get(&node_id).expect("held under its node id");
+        assert_eq!(record.routing_key, name.as_str());
+        assert_eq!(record.head_cid, "bafyhead");
+        assert_eq!(record.content_cids, vec!["bafycontent".to_owned()]);
+        // The held signer signs for the routing key (the insert-time bind).
+        assert_eq!(
+            IpnsName::from_public_key(&record.signer.verifying_key()),
+            name
+        );
+    }
+
+    #[test]
+    fn resolve_and_hold_does_not_hold_a_non_gate_passing_record() {
+        let world = FakeWorld::new();
+        let device = world.device(b"me");
+        let signer = Ed25519Signer::from_seed([32u8; 32]);
+        let name = IpnsName::from_public_key(&signer.verifying_key());
+        let endpoints = world.record_store.endpoints();
+        world
+            .record_store
+            .seed_record(&endpoints[0], name.as_str(), record(&signer, 5));
+        let material = HeldMaterial {
+            node_id: [1u8; 16],
+            write_scope_seed: Zeroizing::new([0u8; 32]),
+            head_cid: "h".into(),
+            content_cids: Vec::new(),
+        };
+
+        // A fail-closed trust violation is never held.
+        let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+        let out = block_on(resolve_and_hold(
+            &device.record_store,
+            &device.snapshot_cache,
+            &StubAdopter {
+                verdict: Verdict::TrustViolation,
+            },
+            &name,
+            &held,
+            &material,
+        ))
+        .unwrap();
+        assert!(matches!(out.outcome, ResolveOutcome::TrustViolation(_)));
+        assert!(held.borrow().is_empty(), "a trust violation is never held");
+
+        // A no-update (nothing newer than our current record) is never held.
+        let held2: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+        let out2 = block_on(resolve_and_hold(
+            &device.record_store,
+            &device.snapshot_cache,
+            &StubAdopter {
+                verdict: Verdict::EqualSequence,
+            },
+            &name,
+            &held2,
+            &material,
+        ))
+        .unwrap();
+        assert_eq!(out2.outcome, ResolveOutcome::NoUpdate);
+        assert!(held2.borrow().is_empty(), "a no-update is never held");
+    }
 }

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -45,13 +45,21 @@ pub enum ResolveOutcome {
     /// A newer record passed the adoption gate: its bytes are now the snapshot's
     /// last-known-good and the read-body is authenticated.
     Adopted(Adopted),
+    /// Our own current record re-fetched at exactly the durable sequence floor:
+    /// no update, but the (already-verified, public/signed) bytes are in hand so
+    /// the liveness loop can keep them alive without re-fetching. Carries no
+    /// secret.
+    Current {
+        /// The verified record bytes, byte-stable for a keyless re-PUT.
+        record_bytes: Vec<u8>,
+    },
     /// The freshest fetched record failed the gate — a fail-closed trust
     /// violation. Last-known-good is pinned; the rejected record is never
     /// rendered.
     TrustViolation(GateRejection),
-    /// No newer record was fetched: either nothing resolvable (network
-    /// unreachable / cold) or only a copy at or below the current record. This
-    /// is availability staleness, not an error — the cached view stays usable.
+    /// No newer record was fetched: nothing resolvable (network unreachable /
+    /// cold). This is availability staleness, not an error — the cached view
+    /// stays usable.
     NoUpdate,
 }
 
@@ -96,12 +104,15 @@ where
                 ResolveOutcome::Adopted(adopted)
             }
             // A record at exactly the durable sequence floor is our own current
-            // record re-fetched — no update, never a violation. A strictly older
-            // sequence is a replay/rollback and stays a fail-closed trust
-            // violation, as does every other gate rejection.
+            // record re-fetched — no update, never a violation; its verified
+            // bytes are handed back so the liveness loop holds them without a
+            // re-fetch. A strictly older sequence is a replay/rollback and stays
+            // a fail-closed trust violation, as does every other gate rejection.
             Err(GateError::Rejected(rejection)) => match &rejection.reason {
                 RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor => {
-                    ResolveOutcome::NoUpdate
+                    ResolveOutcome::Current {
+                        record_bytes: bytes,
+                    }
                 }
                 _ => ResolveOutcome::TrustViolation(rejection),
             },
@@ -153,25 +164,37 @@ where
     A: Adopter,
 {
     let resolved = resolve(transport, snapshot_cache, adopter, name).await?;
-    if matches!(resolved.outcome, ResolveOutcome::Adopted(_)) {
+    // A gate-passing adopt (`Adopted`) and our own current record (`Current`)
+    // are both alive-worthy; a `TrustViolation`/`NoUpdate` is never held. For
+    // `Adopted` the bytes are the cache's fresh last-known-good; for `Current`
+    // the verified bytes are already in hand, so no re-fetch (blueprint/engine.md
+    // "Liveness").
+    let record_bytes = match &resolved.outcome {
+        ResolveOutcome::Adopted(_) => {
+            // A cache that dropped what it just adopted is a broken durable seam
+            // — fail closed rather than hold nothing.
+            let cache_key = name.as_str().as_bytes();
+            Some(
+                snapshot_cache
+                    .get(cache_key)
+                    .await?
+                    .ok_or_else(|| SeamError::new("snapshot cache dropped the adopted record"))?,
+            )
+        }
+        ResolveOutcome::Current { record_bytes } => Some(record_bytes.clone()),
+        ResolveOutcome::TrustViolation(_) | ResolveOutcome::NoUpdate => None,
+    };
+    if let Some(record_bytes) = record_bytes {
         // Derive the narrow per-name signer once from the transient seed and
         // hold only it — the scope seed is dropped with `material`. Fail-closed
         // encode-side bind (security rule 8): the derived signer must sign for
-        // exactly the adopted name, or the held record could never renew under
-        // its routing key — skip the hold rather than store a mismatched signer.
+        // exactly this name, or the held record could never renew under its
+        // routing key — skip the hold rather than store a mismatched signer.
         let signer =
             SessionIdentity::write_name_signer(&material.write_scope_seed, &material.node_id);
         if IpnsName::from_public_key(&signer.verifying_key()) != *name {
             return Ok(resolved);
         }
-        // The adopted record is now the snapshot cache's last-known-good; hold
-        // exactly those bytes for a byte-stable keyless re-PUT. A cache that
-        // dropped what it just adopted is a broken durable seam — fail closed.
-        let cache_key = name.as_str().as_bytes();
-        let record_bytes = snapshot_cache
-            .get(cache_key)
-            .await?
-            .ok_or_else(|| SeamError::new("snapshot cache dropped the adopted record"))?;
         held.borrow_mut().insert(
             material.node_id,
             HeldRecord {
@@ -337,21 +360,58 @@ mod tests {
         .unwrap();
         assert!(matches!(out.outcome, ResolveOutcome::TrustViolation(_)));
         assert!(held.borrow().is_empty(), "a trust violation is never held");
+    }
 
-        // A no-update (nothing newer than our current record) is never held.
-        let held2: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
-        let out2 = block_on(resolve_and_hold(
+    #[test]
+    fn resolve_of_our_own_current_record_yields_current_and_is_held() {
+        let world = FakeWorld::new();
+        let device = world.device(b"me");
+        // The held name is the one the material's (seed, node id) derives, so the
+        // insert-time signer<->name bind passes for our own record.
+        let write_scope_seed = [4u8; 32];
+        let node_id = [8u8; 16];
+        let signer = SessionIdentity::write_name_signer(&write_scope_seed, &node_id);
+        let name = IpnsName::from_public_key(&signer.verifying_key());
+        let endpoints = world.record_store.endpoints();
+        let bytes = record(&signer, 3);
+        world
+            .record_store
+            .seed_record(&endpoints[0], name.as_str(), bytes.clone());
+
+        let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+        let material = HeldMaterial {
+            node_id,
+            write_scope_seed: Zeroizing::new(write_scope_seed),
+            head_cid: "bafyhead".into(),
+            content_cids: Vec::new(),
+        };
+        let resolved = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
             &StubAdopter {
                 verdict: Verdict::EqualSequence,
             },
             &name,
-            &held2,
+            &held,
             &material,
         ))
-        .unwrap();
-        assert_eq!(out2.outcome, ResolveOutcome::NoUpdate);
-        assert!(held2.borrow().is_empty(), "a no-update is never held");
+        .expect("resolve_and_hold");
+
+        // Our own current record at the floor is `Current`, carrying the verified
+        // bytes verbatim (no re-fetch), and is held for the keyless re-PUT.
+        match &resolved.outcome {
+            ResolveOutcome::Current { record_bytes } => {
+                assert_eq!(record_bytes, &bytes, "Current carries the fetched bytes")
+            }
+            other => panic!("expected Current, got {other:?}"),
+        }
+        let map = held.borrow();
+        assert_eq!(map.len(), 1, "our own current record is held by node id");
+        let hr = map.get(&node_id).expect("held under its node id");
+        assert_eq!(
+            hr.record_bytes, bytes,
+            "held bytes are the in-hand Current bytes"
+        );
+        assert_eq!(hr.routing_key, name.as_str());
     }
 }

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -43,6 +43,20 @@ pub trait Adopter {
     /// `Err(GateError::Rejected)` is a fail-closed trust violation;
     /// `Err(GateError::Seam)` is host I/O.
     async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<AdoptOutcome, GateError>;
+
+    /// Recover the OWNER's own write-scope seed for an equal-floor `Current` own
+    /// record so the liveness loop can hold+renew it (#752 F3). `Ok(None)` when
+    /// not our own / no owner-write-blob / the blob won't open under the durable
+    /// write floor — held keyless, never force-held. Fail-OPEN: returns a
+    /// [`SeamError`], never a `Rejected` verdict (a `Current` must never harden
+    /// into a trust error). The default suits every non-owner adopter stub.
+    async fn recover_own_write_seed(
+        &self,
+        _name: &IpnsName,
+        _record_bytes: &[u8],
+    ) -> Result<Option<([u8; 16], Zeroizing<[u8; 32]>)>, SeamError> {
+        Ok(None)
+    }
 }
 
 /// A gate pass plus the transient write material a write-capable holder needs to
@@ -162,13 +176,20 @@ where
             // A strictly older sequence is a replay/rollback and stays a
             // fail-closed trust violation, as does every other gate rejection.
             Err(GateError::Rejected(rejection)) => match &rejection.reason {
-                RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor => (
-                    ResolveOutcome::Current {
-                        record_bytes: bytes.clone(),
-                    },
-                    None,
-                    Some(bytes),
-                ),
+                RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor => {
+                    // Our own current root at exactly the floor: recover the
+                    // owner's write seed (fail-open) so the liveness loop can
+                    // hold+renew it before its EOL lapses (#752 F3). A non-owner
+                    // record or an unopenable owner-write-blob yields no hold.
+                    let hold = adopter.recover_own_write_seed(name, &bytes).await?;
+                    (
+                        ResolveOutcome::Current {
+                            record_bytes: bytes.clone(),
+                        },
+                        hold,
+                        Some(bytes),
+                    )
+                }
                 _ => (ResolveOutcome::TrustViolation(rejection), None, None),
             },
             Err(GateError::Seam(error)) => return Err(error),
@@ -332,6 +353,10 @@ mod tests {
         /// The (write scope seed, node id) a gate-surfaced write grant contributes
         /// on an `Accept` — `None` models a read-only/own-scope adopt.
         grant: Option<([u8; 32], [u8; 16])>,
+        /// The (node id, write scope seed) the owner recovers for its own
+        /// equal-floor `Current` record (#752 F3) — `None` models a non-owner
+        /// record with no recoverable seed (held keyless).
+        own_seed: Option<([u8; 16], [u8; 32])>,
     }
 
     impl StubAdopter {
@@ -339,6 +364,7 @@ mod tests {
             Self {
                 verdict,
                 grant: None,
+                own_seed: None,
             }
         }
 
@@ -346,6 +372,16 @@ mod tests {
             Self {
                 verdict: Verdict::Accept,
                 grant: Some((seed, node_id)),
+                own_seed: None,
+            }
+        }
+
+        /// An own equal-floor `Current` record whose write seed the owner recovers.
+        fn own_current(seed: [u8; 32], node_id: [u8; 16]) -> Self {
+            Self {
+                verdict: Verdict::EqualSequence,
+                grant: None,
+                own_seed: Some((node_id, seed)),
             }
         }
     }
@@ -388,6 +424,16 @@ mod tests {
                     },
                 })),
             }
+        }
+
+        async fn recover_own_write_seed(
+            &self,
+            _name: &IpnsName,
+            _record_bytes: &[u8],
+        ) -> Result<Option<([u8; 16], Zeroizing<[u8; 32]>)>, crate::seams::SeamError> {
+            Ok(self
+                .own_seed
+                .map(|(node_id, seed)| (node_id, Zeroizing::new(seed))))
         }
     }
 
@@ -519,6 +565,138 @@ mod tests {
             "held bytes are the in-hand Current bytes"
         );
         assert_eq!(hr.routing_key, name.as_str());
+    }
+
+    #[test]
+    fn own_current_root_is_held_with_a_valid_signer_and_real_head_cid() {
+        use core::time::Duration;
+
+        use crate::api::ApiClient;
+        use crate::net::eol_renew_pass;
+        use crate::net::publish::PublishOutcome;
+        use crate::profile::SyncTimingProfile;
+        use crate::seams::FloorStore;
+
+        let world = FakeWorld::new();
+        let device = world.device(b"me");
+        let scheduler = world.scheduler.clone(); // manual clock, now = 0
+
+        // Our own current root: the seed the owner recovers derives the routing
+        // name (the insert-time signer<->name bind passes for our own record).
+        let write_scope_seed = [5u8; 32];
+        let node_id = [6u8; 16];
+        let signer = SessionIdentity::write_name_signer(&write_scope_seed, &node_id);
+        let name = IpnsName::from_public_key(&signer.verifying_key());
+        let bytes = record(&signer, 1);
+        for endpoint in device.record_store.endpoints() {
+            device
+                .record_store
+                .seed_record(&endpoint, name.as_str(), bytes.clone());
+        }
+
+        // The gate rejects on sequence (equal-floor Current); the adopter recovers
+        // the owner's write seed, so the caller carries none of its own.
+        let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+        let material = HeldMaterial {
+            node_id: [0u8; 16],
+            write_scope_seed: None,
+            content_cids: Vec::new(),
+        };
+        let resolved = block_on(resolve_and_hold(
+            &device.record_store,
+            &device.snapshot_cache,
+            &StubAdopter::own_current(write_scope_seed, node_id),
+            &name,
+            &held,
+            &material,
+        ))
+        .expect("resolve_and_hold");
+        assert!(matches!(resolved.outcome, ResolveOutcome::Current { .. }));
+
+        let hr = held
+            .borrow()
+            .get(&node_id)
+            .cloned()
+            .expect("own current root is held by its recovered node id");
+        // Held under a valid signer that signs for exactly the routing key.
+        assert_eq!(IpnsName::from_public_key(&hr.signer.verifying_key()), name);
+        // A real, non-empty head CID from the signed record value (never /ipfs/).
+        let value = IpnsRecord::unmarshal(&bytes)
+            .unwrap()
+            .verify(&name)
+            .unwrap()
+            .value;
+        assert_eq!(Some(hr.head_cid.clone()), head_cid_from_value(&value));
+        assert!(!hr.head_cid.is_empty());
+
+        // The held record renews: model adoption (floor → 1), advance into the EOL
+        // window, and prove the recovered signer republishes at seq+1.
+        block_on(
+            device
+                .floor_store
+                .raise_sequence_floor(name.as_str().as_bytes(), 1),
+        )
+        .unwrap();
+        scheduler.advance(Duration::from_secs(65 * 24 * 60 * 60));
+        let api = ApiClient::new(
+            device.http.clone(),
+            device.credential_store.clone(),
+            "http://api.test",
+        );
+        device.http.enqueue_response(crate::seams::HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: Vec::new(),
+        });
+        let results = block_on(eol_renew_pass(
+            &device.record_store,
+            &api,
+            &device.floor_store,
+            &scheduler,
+            &SyncTimingProfile::CI,
+            &[hr],
+        ));
+        assert_eq!(
+            results[0].outcome.as_ref().unwrap(),
+            &Some(PublishOutcome::Published { sequence: 2 }),
+            "the held own current root renews at seq+1 under its recovered signer",
+        );
+    }
+
+    #[test]
+    fn non_owner_current_is_not_force_held() {
+        let world = FakeWorld::new();
+        let device = world.device(b"me");
+        let signer = Ed25519Signer::from_seed([21u8; 32]);
+        let name = IpnsName::from_public_key(&signer.verifying_key());
+        for endpoint in device.record_store.endpoints() {
+            device
+                .record_store
+                .seed_record(&endpoint, name.as_str(), record(&signer, 4));
+        }
+
+        // Equal-floor Current, but no recoverable owner write seed and no caller
+        // material seed: the record is never force-held (#752 F3 least-privilege).
+        let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+        let material = HeldMaterial {
+            node_id: [0u8; 16],
+            write_scope_seed: None,
+            content_cids: Vec::new(),
+        };
+        let resolved = block_on(resolve_and_hold(
+            &device.record_store,
+            &device.snapshot_cache,
+            &StubAdopter::new(Verdict::EqualSequence),
+            &name,
+            &held,
+            &material,
+        ))
+        .expect("resolve_and_hold");
+        assert!(matches!(resolved.outcome, ResolveOutcome::Current { .. }));
+        assert!(
+            held.borrow().is_empty(),
+            "a non-owner current record is never force-held"
+        );
     }
 
     #[test]

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -181,9 +181,9 @@ where
 /// The transient insert-time input for a held record: the resolve/gate path has
 /// already unsealed the scope's write seed for this node, so the held set
 /// derives the narrow per-name signer from it once at insert and drops the seed
-/// (never persisting it — see [`HeldRecord`]). Not yet wired in production
-/// (only the #752 resolve-tick driver constructs it), hence crate-internal.
-#[allow(dead_code)] // wired by the #752 resolve-tick driver
+/// (never persisting it — see [`HeldRecord`]). Constructed by the resolve-tick
+/// driver ([`Engine::spawn_resolve_tick_loop`](crate::facade)), hence
+/// crate-internal.
 pub(crate) struct HeldMaterial {
     /// The node id (`id16`) — the held-set key and a signer-derivation input for
     /// an own-scope record. A gate-surfaced write grant overrides it with the
@@ -205,7 +205,6 @@ pub(crate) struct HeldMaterial {
 /// same node) a [`HeldRecord`] so the keyless re-PUT loop keeps it alive. Only a
 /// gate-passing record enters the set — a `TrustViolation`/`NoUpdate` never
 /// does (blueprint/engine.md "Liveness": never re-PUT a stale record).
-#[allow(dead_code)] // wired by the #752 resolve-tick driver
 pub(crate) async fn resolve_and_hold<T, S, A>(
     transport: &T,
     snapshot_cache: &S,

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -23,12 +23,13 @@
 use core::fmt;
 
 use cipherbox_core::kdf;
+use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
 use cipherbox_core::suite::ed25519::Ed25519Signer;
-use cipherbox_core::suite::secret::SecretBytes;
+use cipherbox_core::suite::secret::{SECRET_LEN, SecretBytes};
 use cipherbox_core::suite::x25519::{X25519Public, X25519Secret};
 use zeroize::Zeroizing;
 
-use crate::facade::LoginSecret;
+use crate::facade::{EngineError, LoginSecret};
 
 /// The session's seed-derived identity — the single place derived key material
 /// lives once the engine is live.
@@ -52,6 +53,11 @@ pub(crate) struct SessionIdentity {
     /// The owner pointer seed (`owner-pointer-seed` edge). Per-scope pointer
     /// signers and pointer read keys derive from it lazily. Zeroizes on drop.
     owner_pointer_seed: SecretBytes,
+    /// The owner ECDSA identity: the login-secret scalar adopted directly (v1
+    /// Web3Auth TSS export is the secp256k1 identity key), not a catalog edge.
+    /// Signs the login challenge and structure commitments; its verifier is the
+    /// owner-trust anchor the adoption gate checks. Zeroizes on drop.
+    identity: EcdsaSigner,
 }
 
 #[allow(dead_code)]
@@ -59,19 +65,42 @@ impl SessionIdentity {
     /// Derive the cold-start identity from the login secret — a pure function
     /// of the secret bytes (no clock, no RNG), composing only frozen catalog
     /// edges. Same secret in, same identity out.
-    pub(crate) fn derive(secret: &LoginSecret) -> Self {
+    ///
+    /// Fails closed ([`EngineError::InvalidSecret`]) when the secret is not a
+    /// 32-byte scalar in range: the owner identity is the scalar adopted
+    /// directly, so a wrong-length or out-of-range secret has no valid identity
+    /// and must never derive a silent default (a real Web3Auth key is always
+    /// valid, so this is a guard, not a live path).
+    pub(crate) fn derive(secret: &LoginSecret) -> Result<Self, EngineError> {
         let bytes = secret.expose();
-        Self {
+        let scalar: Zeroizing<[u8; SECRET_LEN]> =
+            Zeroizing::new(bytes.try_into().map_err(|_| EngineError::InvalidSecret)?);
+        let identity = EcdsaSigner::from_scalar(&scalar).ok_or(EngineError::InvalidSecret)?;
+        Ok(Self {
             login_secret: Zeroizing::new(bytes.to_vec()),
             enc_subkey: kdf::enc_subkey(bytes),
             owner_pointer_seed: kdf::owner_pointer_seed(bytes),
-        }
+            identity,
+        })
     }
 
     /// The public half of the encryption subkey — the sealing identity peers
     /// address. Non-secret; safe to publish and to compare in tests.
     pub fn enc_subkey_public(&self) -> X25519Public {
         self.enc_subkey.public()
+    }
+
+    /// The owner ECDSA identity signer — the login-challenge and structure
+    /// commitment signer. Secret-bearing, so in-crate only.
+    pub(crate) fn identity(&self) -> &EcdsaSigner {
+        &self.identity
+    }
+
+    /// The owner identity verifier — the owner-trust anchor a resolved record
+    /// is gated against (later slices pass this to `cold_start_data_path`).
+    /// Public material.
+    pub fn owner_identity(&self) -> EcdsaVerifier {
+        self.identity.verifying_key()
     }
 
     /// The retained login secret, for the runtime vault-pointer index probe
@@ -151,7 +180,7 @@ mod tests {
     use crate::secret_util::ct_eq_32;
 
     fn identity(secret: &[u8]) -> SessionIdentity {
-        SessionIdentity::derive(&LoginSecret::new(secret.to_vec()))
+        SessionIdentity::derive(&LoginSecret::new(secret.to_vec())).expect("valid identity")
     }
 
     #[test]
@@ -278,6 +307,45 @@ mod tests {
                 .verifying_key()
                 .to_bytes(),
             "a different scope is a different pseudonym",
+        );
+    }
+
+    #[test]
+    fn the_owner_verifier_is_the_identity_signers_public_key() {
+        let id = identity(&[7u8; 32]);
+        assert_eq!(
+            id.identity().verifying_key().to_sec1(),
+            id.owner_identity().to_sec1(),
+            "owner_identity() exposes the identity signer's verifier",
+        );
+    }
+
+    #[test]
+    fn a_signature_by_identity_verifies_under_the_owner_verifier() {
+        let id = identity(&[7u8; 32]);
+        let msg = b"cipherbox-login:v2:deadbeef";
+        let sig = id.identity().sign_detcbor(msg);
+        assert!(
+            id.owner_identity().verify_detcbor(msg, &sig),
+            "the owner verifier accepts the identity signer's signature",
+        );
+    }
+
+    #[test]
+    fn derive_fails_closed_on_a_wrong_length_secret() {
+        assert_eq!(
+            SessionIdentity::derive(&LoginSecret::new(vec![7u8; 31])).unwrap_err(),
+            EngineError::InvalidSecret,
+            "a non-32-byte secret has no valid identity scalar",
+        );
+    }
+
+    #[test]
+    fn derive_fails_closed_on_a_zero_scalar() {
+        assert_eq!(
+            SessionIdentity::derive(&LoginSecret::new(vec![0u8; 32])).unwrap_err(),
+            EngineError::InvalidSecret,
+            "the zero scalar is not a valid secp256k1 key",
         );
     }
 

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -111,11 +111,11 @@ impl SessionIdentity {
 
     /// The per-name write-plane IPNS signer for a node: `writeSeed(node) =
     /// KDF(writeScopeSeed, node.id)` then the `ipns-keypair` edge. This is the
-    /// per-name `Ed25519Signer` the liveness loop's sub-EOL `seq+1` renewal
-    /// (#750) and the held-set republish (#751) sign with — the resolve/gate
-    /// path supplies the unsealed `write_scope_seed`.
+    /// per-name `Ed25519Signer` the held set stores for its sub-EOL `seq+1`
+    /// renewal (#750/#751) — the resolve/gate path supplies the unsealed
+    /// `write_scope_seed`. Keyed solely by its arguments (no session field), so
+    /// it is an associated function the held-set insert can call directly.
     pub(crate) fn write_name_signer(
-        &self,
         write_scope_seed: &[u8; 32],
         node_id: &[u8; 16],
     ) -> Ed25519Signer {
@@ -184,13 +184,13 @@ mod tests {
             "same secret must yield the same pointer read key",
         );
         assert_eq!(
-            a.write_name_signer(&write_scope_seed, &node)
+            SessionIdentity::write_name_signer(&write_scope_seed, &node)
                 .verifying_key()
                 .to_bytes(),
-            b.write_name_signer(&write_scope_seed, &node)
+            SessionIdentity::write_name_signer(&write_scope_seed, &node)
                 .verifying_key()
                 .to_bytes(),
-            "same secret must yield the same per-name write signer",
+            "the per-name write signer is a pure function of seed + node id",
         );
     }
 
@@ -230,21 +230,19 @@ mod tests {
 
     #[test]
     fn per_name_write_signers_bind_scope_seed_and_node_id() {
-        let id = identity(&[7u8; 32]);
-        let base = id
-            .write_name_signer(&[5u8; 32], &[4u8; 16])
+        let base = SessionIdentity::write_name_signer(&[5u8; 32], &[4u8; 16])
             .verifying_key()
             .to_bytes();
         assert_ne!(
             base,
-            id.write_name_signer(&[6u8; 32], &[4u8; 16])
+            SessionIdentity::write_name_signer(&[6u8; 32], &[4u8; 16])
                 .verifying_key()
                 .to_bytes(),
             "a different write scope seed is a different name",
         );
         assert_ne!(
             base,
-            id.write_name_signer(&[5u8; 32], &[9u8; 16])
+            SessionIdentity::write_name_signer(&[5u8; 32], &[9u8; 16])
                 .verifying_key()
                 .to_bytes(),
             "a different node id is a different name",

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -33,6 +33,7 @@ use crate::sync::overlay::apply_overlay;
 use crate::sync::pointer::{
     PointerError, PointerFetch, VaultPointerAdoption, resolve_vault_pointer,
 };
+use crate::sync::project::project_root;
 
 /// The session inputs the cold-start chain needs, all read from the derived
 /// [`SessionIdentity`](crate::session::SessionIdentity) and the auth-provided
@@ -110,10 +111,13 @@ pub struct ColdStartOutcome {
     pub root_resolve: Option<RootResolve>,
     /// Whether cache-first rehydrate found last-known-good for the current root.
     pub rehydrated: bool,
-    /// The rendered view emitted on the first snapshot event: the gate-passing
-    /// base snapshot with the pending-op overlay applied. The read-body →
-    /// snapshot projection lands with a later slice, so the base is the anchored
-    /// root; the overlay renders the user's pending ops immediately.
+    /// The gate-passing base snapshot the engine adopts as the state law's left
+    /// operand: the adopted root read-body projected to its direct children
+    /// ([`project_root`], E7) when a pointer resolved to a gate-passing record,
+    /// else the anchored root ([`Snapshot::new`]) on an empty/degenerate chain.
+    pub base: Snapshot,
+    /// The rendered view emitted on the first snapshot event: `base` ⊕ the
+    /// pending-op overlay.
     pub rendered: Snapshot,
 }
 
@@ -162,6 +166,7 @@ where
             vault_pointer: None,
             root_resolve: None,
             rehydrated: false,
+            base,
             rendered,
         });
     };
@@ -190,11 +195,17 @@ where
     )
     .await
     .map_err(ColdStartError::Seam)?;
-    let root_resolve = match resolved.outcome {
-        ResolveOutcome::Adopted(_) => RootResolve::Adopted,
+    // Project the gate-passing root read-body to its direct children (E7); an
+    // availability-stale current record leaves the base at the anchored root.
+    let (root_resolve, base) = match resolved.outcome {
+        ResolveOutcome::Adopted(adopted) => {
+            (RootResolve::Adopted, project_root(params.root, &adopted))
+        }
         // Cold start paints, it does not hold: our own current record at the
         // floor is availability staleness here, same as nothing newer fetched.
-        ResolveOutcome::NoUpdate | ResolveOutcome::Current { .. } => RootResolve::NoUpdate,
+        ResolveOutcome::NoUpdate | ResolveOutcome::Current { .. } => {
+            (RootResolve::NoUpdate, Snapshot::new(params.root))
+        }
         ResolveOutcome::TrustViolation(rejection) => {
             return Err(ColdStartError::RootAdoption(rejection));
         }
@@ -208,6 +219,7 @@ where
         vault_pointer: Some(adoption),
         root_resolve: Some(root_resolve),
         rehydrated: resolved.last_known_good.is_some(),
+        base,
         rendered,
     })
 }

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -317,8 +317,16 @@ mod tests {
             &self,
             _name: &IpnsName,
             _record_bytes: &[u8],
-        ) -> Result<Adopted, GateError> {
-            self.verdict.lock().unwrap().clone()
+        ) -> Result<crate::net::AdoptOutcome, GateError> {
+            self.verdict
+                .lock()
+                .unwrap()
+                .clone()
+                .map(|adopted| crate::net::AdoptOutcome {
+                    adopted,
+                    write_scope_seed: None,
+                    node_id: [0u8; 16],
+                })
         }
     }
 

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -192,7 +192,9 @@ where
     .map_err(ColdStartError::Seam)?;
     let root_resolve = match resolved.outcome {
         ResolveOutcome::Adopted(_) => RootResolve::Adopted,
-        ResolveOutcome::NoUpdate => RootResolve::NoUpdate,
+        // Cold start paints, it does not hold: our own current record at the
+        // floor is availability staleness here, same as nothing newer fetched.
+        ResolveOutcome::NoUpdate | ResolveOutcome::Current { .. } => RootResolve::NoUpdate,
         ResolveOutcome::TrustViolation(rejection) => {
             return Err(ColdStartError::RootAdoption(rejection));
         }

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -36,6 +36,7 @@ pub mod model;
 pub mod op;
 pub mod overlay;
 pub mod pointer;
+pub(crate) mod project;
 pub mod rebase;
 pub mod staging;
 pub mod staleness;

--- a/crates/engine/src/sync/project.rs
+++ b/crates/engine/src/sync/project.rs
@@ -1,0 +1,134 @@
+//! Projection of a gate-passing adopted root read-body into a facade
+//! [`Snapshot`] — direct children only, no recursion, no network, no seams
+//! (blueprint/engine.md "Sync core"; the deeper content-plane assembly is a
+//! later slice).
+
+use cipherbox_core::seal::{NodeKind as CoreNodeKind, ReadBody};
+
+use crate::facade::{NodeId, NodeKind};
+use crate::gate::Adopted;
+use crate::sync::model::{NodeMeta, Snapshot};
+
+/// Project a gate-passing adopted root read-body into a [`Snapshot`] holding
+/// the root and its **direct** children. Pure: the child read-bodies (and thus
+/// the deeper tree) are not fetched here.
+///
+/// Only a gate-passing [`Adopted`] reaches this fn — the gate already enforced
+/// child id/ipnsName uniqueness at unseal — so child uniqueness is trusted and
+/// not re-validated. `link_counter` is carried verbatim (feeds the dual-link
+/// tiebreak in [`Snapshot::winning_link`]).
+#[allow(dead_code)] // wired in start() (E4)
+pub(crate) fn project_root(root: NodeId, adopted: &Adopted) -> Snapshot {
+    let mut snapshot = Snapshot::new(root);
+    if let Some(node) = snapshot.node_mut(root) {
+        node.record_sequence = adopted.sequence;
+    }
+
+    if let ReadBody::Folder { children, .. } = &adopted.read_body {
+        for child in children {
+            let id = NodeId(child.id);
+            snapshot.upsert_node(NodeMeta::new(id, child.name.clone(), map_kind(child.kind)));
+            snapshot.link(root, id, child.link_counter);
+        }
+    }
+
+    snapshot
+}
+
+/// Map the core wire node kind onto the structurally-identical facade kind.
+fn map_kind(kind: CoreNodeKind) -> NodeKind {
+    match kind {
+        CoreNodeKind::Folder => NodeKind::Folder,
+        CoreNodeKind::File => NodeKind::File,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cipherbox_core::seal::ChildRef;
+
+    fn node_id(b: u8) -> NodeId {
+        NodeId([b; 16])
+    }
+
+    fn child(id: u8, name: &str, kind: CoreNodeKind, link_counter: u64) -> ChildRef {
+        ChildRef {
+            id: [id; 16],
+            name: name.to_string(),
+            ipns_name: vec![id],
+            kind,
+            link_counter,
+            unknown: Vec::new(),
+        }
+    }
+
+    fn adopted_folder(children: Vec<ChildRef>, sequence: u64) -> Adopted {
+        Adopted {
+            read_body: ReadBody::Folder {
+                created_at: 0,
+                modified_at: 0,
+                children,
+                unknown: Vec::new(),
+            },
+            sequence,
+            epoch: 0,
+        }
+    }
+
+    #[test]
+    fn project_root_lifts_direct_children_only() {
+        let root = node_id(0);
+        let adopted = adopted_folder(
+            vec![
+                child(1, "a", CoreNodeKind::Folder, 1),
+                child(2, "b.txt", CoreNodeKind::File, 1),
+            ],
+            5,
+        );
+
+        let snap = project_root(root, &adopted);
+
+        let kids = snap.children(root);
+        let by: Vec<(NodeId, &str, NodeKind)> = kids
+            .iter()
+            .map(|n| (n.id, n.name.as_str(), n.kind))
+            .collect();
+        assert_eq!(
+            by,
+            vec![
+                (node_id(1), "a", NodeKind::Folder),
+                (node_id(2), "b.txt", NodeKind::File),
+            ]
+        );
+        assert_eq!(snap.parent_of(node_id(1)), Some(root));
+        assert_eq!(snap.parent_of(node_id(2)), Some(root));
+    }
+
+    #[test]
+    fn project_root_carries_link_counter_for_dual_link_tiebreak() {
+        let root = node_id(0);
+        let adopted = adopted_folder(
+            vec![
+                child(1, "a", CoreNodeKind::Folder, 7),
+                child(2, "b", CoreNodeKind::File, 3),
+            ],
+            1,
+        );
+
+        let snap = project_root(root, &adopted);
+
+        assert_eq!(snap.max_link_counter(node_id(1)), 7);
+        assert_eq!(snap.max_link_counter(node_id(2)), 3);
+    }
+
+    #[test]
+    fn project_root_sets_root_sequence() {
+        let root = node_id(0);
+        let adopted = adopted_folder(vec![], 42);
+
+        let snap = project_root(root, &adopted);
+
+        assert_eq!(snap.record_sequence(root), Some(42));
+    }
+}

--- a/crates/engine/src/sync/project.rs
+++ b/crates/engine/src/sync/project.rs
@@ -17,7 +17,6 @@ use crate::sync::model::{NodeMeta, Snapshot};
 /// child id/ipnsName uniqueness at unseal — so child uniqueness is trusted and
 /// not re-validated. `link_counter` is carried verbatim (feeds the dual-link
 /// tiebreak in [`Snapshot::winning_link`]).
-#[allow(dead_code)] // wired in start() (E4)
 pub(crate) fn project_root(root: NodeId, adopted: &Adopted) -> Snapshot {
     let mut snapshot = Snapshot::new(root);
     if let Some(node) = snapshot.node_mut(root) {

--- a/crates/engine/tests/adoption_gate.rs
+++ b/crates/engine/tests/adoption_gate.rs
@@ -612,7 +612,9 @@ fn run_matrix_case(name: &str) -> Result<Adopted, GateError> {
         parent_node_seed: reader_parent_seed,
         seed_blob: Some(fx.owner_seed_blob(tamper_seed_blob)),
     };
-    block_on(adopt(&floors, &reader, &candidate))
+    // Drop the transient write-grantee seed the gate now surfaces; the matrix
+    // asserts only the adoption verdict.
+    block_on(adopt(&floors, &reader, &candidate)).map(|(adopted, _)| adopted)
 }
 
 #[test]
@@ -970,7 +972,7 @@ fn simulation_n_engines_one_record_store_adversarial() {
             .unwrap()
             .expect("record present on the shared store");
         let candidate = fx.candidate_with_record(bytes);
-        let adopted = block_on(adopt(&device.floor_store, &fx.reader(), &candidate))
+        let (adopted, _) = block_on(adopt(&device.floor_store, &fx.reader(), &candidate))
             .expect("a shared valid record adopts on every device");
         assert_eq!(adopted.sequence, 1);
     }
@@ -1207,7 +1209,7 @@ fn ascent_adopts_when_reader_seed_matches_sealed_link() {
     candidate.grant_section.ascent_link = Some(fx.ascent_link_under(&parent_seed));
     let mut reader = fx.reader();
     reader.parent_node_seed = Some(parent_seed);
-    let adopted = block_on(adopt(&floors, &reader, &candidate)).expect("valid ascent adopts");
+    let (adopted, _) = block_on(adopt(&floors, &reader, &candidate)).expect("valid ascent adopts");
     assert_eq!(adopted.sequence, 1);
 }
 
@@ -1363,7 +1365,8 @@ fn absent_owner_write_blob_still_adopts() {
     let floors = InMemoryFloorStore::default();
     let mut candidate = fx.candidate(1);
     candidate.grant_section.owner_write_blob = None;
-    let adopted = block_on(adopt(&floors, &fx.reader(), &candidate)).expect("adopts without it");
+    let (adopted, _) =
+        block_on(adopt(&floors, &fx.reader(), &candidate)).expect("adopts without it");
     assert_eq!(adopted.sequence, 1);
 }
 
@@ -1412,7 +1415,7 @@ fn seed_blob_correct_seed_derives_read_key_and_adopts() {
     // scope/epoch/v AAD — the cross-check passes and the record adopts.
     let fx = Fixture::new();
     let floors = InMemoryFloorStore::default();
-    let adopted = block_on(adopt(&floors, &fx.reader(), &fx.candidate(1))).expect("adopts");
+    let (adopted, _) = block_on(adopt(&floors, &fx.reader(), &fx.candidate(1))).expect("adopts");
     assert_eq!(adopted.sequence, 1);
     assert_eq!(adopted.epoch, 1);
 }

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -21,7 +21,12 @@ fn secret() -> LoginSecret {
     LoginSecret::new(vec![7u8; 32])
 }
 
-fn all_commands() -> Vec<(Command, &'static str)> {
+/// Commands whose pipeline slice has not landed: the still-unimplemented
+/// surface. The metadata intent ops (delete/rename/relink and metadata-only
+/// create) are wired and covered by the inline facade tests; a *content*-
+/// bearing create and `updateContent` still need the content plane, so they
+/// remain unimplemented here.
+fn unimplemented_commands() -> Vec<(Command, &'static str)> {
     let node = NodeId([1; 16]);
     let parent = NodeId([2; 16]);
     vec![
@@ -33,21 +38,6 @@ fn all_commands() -> Vec<(Command, &'static str)> {
                 content: Some(PlaintextContent(b"hello".to_vec())),
             },
             "create",
-        ),
-        (Command::Delete { node }, "delete"),
-        (
-            Command::Rename {
-                node,
-                new_name: "renamed.txt".into(),
-            },
-            "rename",
-        ),
-        (
-            Command::Relink {
-                node,
-                new_parent: parent,
-            },
-            "relink",
         ),
         (
             Command::UpdateContent {
@@ -150,20 +140,20 @@ fn an_empty_secret_is_rejected() {
 }
 
 #[test]
-fn every_command_returns_its_typed_unimplemented_error() {
+fn unimplemented_commands_return_their_typed_error() {
     let world = FakeWorld::new();
     let device = world.device(b"alice-pk");
     let (mut engine, _events) = new_engine(&device);
     block_on(engine.start(secret())).unwrap();
 
-    for (command, expected_name) in all_commands() {
+    for (command, expected_name) in unimplemented_commands() {
         let result = block_on(engine.command(command));
         assert_eq!(
             result,
             Err(EngineError::Unimplemented {
                 command: expected_name
             }),
-            "scaffold facade: `{expected_name}` must reject as typed-unimplemented"
+            "`{expected_name}` must reject as typed-unimplemented until its slice lands"
         );
     }
 }

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -91,13 +91,6 @@ fn unimplemented_commands() -> Vec<(Command, &'static str)> {
             "acceptShare",
         ),
         (Command::RotateNow { node }, "rotateNow"),
-        (
-            Command::SiweLogin {
-                message: "siwe message".into(),
-                signature: b"wallet-sig".to_vec(),
-            },
-            "siweLogin",
-        ),
         (Command::Logout, "logout"),
     ]
 }

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -14,6 +14,7 @@ fn new_engine(device: &FakeDevice) -> (Engine<FakeSeamTypes>, EventStream) {
         device.seam_set(),
         Box::new(SeededEntropy::new(42)),
         SyncTimingProfile::CI,
+        String::new(),
     )
 }
 

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -5,8 +5,8 @@ use cipherbox_engine::net::RE_PUT_INTERVAL;
 use cipherbox_engine::seams::{Scheduler, UnixMillis};
 use cipherbox_engine::testkit::{FakeDevice, FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
 use cipherbox_engine::{
-    Command, Engine, EngineError, EventStream, LoginSecret, NodeId, NodeKind, Permission,
-    PlaintextContent, SyncTimingProfile,
+    Command, Engine, EngineError, EventStream, GatewayConfig, LoginSecret, NodeId, NodeKind,
+    Permission, PlaintextContent, SyncTimingProfile,
 };
 
 fn new_engine(device: &FakeDevice) -> (Engine<FakeSeamTypes>, EventStream) {
@@ -15,6 +15,7 @@ fn new_engine(device: &FakeDevice) -> (Engine<FakeSeamTypes>, EventStream) {
         Box::new(SeededEntropy::new(42)),
         SyncTimingProfile::CI,
         String::new(),
+        GatewayConfig::disabled(),
     )
 }
 

--- a/crates/engine/tests/net.rs
+++ b/crates/engine/tests/net.rs
@@ -300,7 +300,7 @@ fn resolve_gate_rejection_pins_last_known_good_and_never_overwrites_the_snapshot
 }
 
 #[test]
-fn resolve_equal_sequence_is_no_update_not_a_trust_violation() {
+fn resolve_equal_sequence_is_current_not_a_trust_violation() {
     let world = FakeWorld::new();
     let device = world.device(b"me");
     let s = signer(4);
@@ -308,10 +308,11 @@ fn resolve_equal_sequence_is_no_update_not_a_trust_violation() {
     let key = name.as_str().as_bytes();
 
     block_on(device.snapshot_cache.put(key, b"current")).unwrap();
+    let bytes = record(&s, VALUE, 7, 0);
     world.record_store.seed_record(
         &world.record_store.endpoints()[0],
         name.as_str(),
-        record(&s, VALUE, 7, 0),
+        bytes.clone(),
     );
 
     let adopter = StubAdopter::new(Verdict::EqualSequence);
@@ -323,11 +324,16 @@ fn resolve_equal_sequence_is_no_update_not_a_trust_violation() {
     ))
     .expect("resolve");
 
-    assert_eq!(
-        resolved.outcome,
-        ResolveOutcome::NoUpdate,
-        "re-fetching our own current record is a no-update, never a violation"
-    );
+    // Re-fetching our own current record at the floor is a `Current` no-update
+    // (never a violation), and it carries the verified bytes verbatim so the
+    // liveness loop can hold them without a re-fetch.
+    match &resolved.outcome {
+        ResolveOutcome::Current { record_bytes } => {
+            assert_eq!(record_bytes, &bytes, "Current carries the fetched bytes")
+        }
+        other => panic!("expected Current, got {other:?}"),
+    }
+    // A `Current` never overwrites last-known-good.
     assert_eq!(
         block_on(device.snapshot_cache.get(key)).unwrap(),
         Some(b"current".to_vec())

--- a/crates/engine/tests/net.rs
+++ b/crates/engine/tests/net.rs
@@ -27,7 +27,7 @@ use cipherbox_engine::api::ApiClient;
 use cipherbox_engine::gate::{Adopted, GateError, GateRejection, GateStage, RejectionReason};
 use cipherbox_engine::net::eol;
 use cipherbox_engine::net::{
-    Adopter, HeldRecord, HeldRecords, LivenessControl, PublishError, PublishOutcome,
+    AdoptOutcome, Adopter, HeldRecord, HeldRecords, LivenessControl, PublishError, PublishOutcome,
     PublishRequest, RE_PUT_INTERVAL, ResolveOutcome, ReviveError, ReviveRequest, eol_republish,
     keyless_re_put, publish, resolve, revive, run_liveness_loop,
 };
@@ -158,19 +158,23 @@ impl StubAdopter {
 }
 
 impl Adopter for StubAdopter {
-    async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<Adopted, GateError> {
+    async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<AdoptOutcome, GateError> {
         let sequence = verify_seq(name, record_bytes);
         self.seen.lock().unwrap().push(sequence);
         match self.verdict {
-            Verdict::Accept => Ok(Adopted {
-                read_body: ReadBody::Folder {
-                    created_at: 0,
-                    modified_at: 0,
-                    children: Vec::new(),
-                    unknown: Vec::new(),
+            Verdict::Accept => Ok(AdoptOutcome {
+                adopted: Adopted {
+                    read_body: ReadBody::Folder {
+                        created_at: 0,
+                        modified_at: 0,
+                        children: Vec::new(),
+                        unknown: Vec::new(),
+                    },
+                    sequence,
+                    epoch: 1,
                 },
-                sequence,
-                epoch: 1,
+                write_scope_seed: None,
+                node_id: [0u8; 16],
             }),
             Verdict::TrustViolation => Err(GateError::Rejected(GateRejection {
                 stage: GateStage::RecordVerify,

--- a/crates/engine/tests/net.rs
+++ b/crates/engine/tests/net.rs
@@ -13,6 +13,7 @@
 //! snapshot) without re-deriving the whole crypto fixture the adoption-gate
 //! suite already owns.
 
+use core::cell::RefCell;
 use core::time::Duration;
 use std::sync::{Arc, Mutex};
 
@@ -20,15 +21,16 @@ use cipherbox_core::error::TrustViolation;
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::seal::ReadBody;
 use cipherbox_core::suite::ed25519::Ed25519Signer;
+use zeroize::Zeroizing;
 
 use cipherbox_engine::SyncTimingProfile;
 use cipherbox_engine::api::ApiClient;
 use cipherbox_engine::gate::{Adopted, GateError, GateRejection, GateStage, RejectionReason};
 use cipherbox_engine::net::eol;
 use cipherbox_engine::net::{
-    Adopter, HeldRecord, LivenessControl, PublishError, PublishOutcome, PublishRequest,
-    RE_PUT_INTERVAL, ResolveOutcome, ReviveError, ReviveRequest, eol_republish, keyless_re_put,
-    publish, resolve, revive, run_liveness_loop,
+    Adopter, HeldMaterial, HeldRecord, HeldRecords, LivenessControl, PublishError, PublishOutcome,
+    PublishRequest, RE_PUT_INTERVAL, ResolveOutcome, ReviveError, ReviveRequest, eol_republish,
+    keyless_re_put, publish, resolve, resolve_and_hold, revive, run_liveness_loop,
 };
 use cipherbox_engine::seams::{
     FloorStore, HttpResponse, RecordTransport, Scheduler, SeamError, SeamResult, SnapshotCache,
@@ -57,6 +59,20 @@ fn name_of(signer: &Ed25519Signer) -> IpnsName {
 fn record(signer: &Ed25519Signer, value: &[u8], sequence: u64, mint_millis: u64) -> Vec<u8> {
     let validity = eol::eol_from(UnixMillis(mint_millis));
     IpnsRecord::create_v2(signer, value, sequence, TTL_NANOS, &validity).marshal()
+}
+
+/// A held record for `name` carrying `bytes` plus placeholder renewal inputs
+/// (#750 exercises the seed/node-id/CID fields; the keyless re-PUT layer reads
+/// only routing key + bytes).
+fn held_record(name: &IpnsName, bytes: Vec<u8>) -> HeldRecord {
+    HeldRecord {
+        routing_key: name.as_str().to_owned(),
+        record_bytes: bytes,
+        node_id: [0u8; 16],
+        write_scope_seed: Zeroizing::new([0u8; 32]),
+        head_cid: "bafyhead".into(),
+        content_cids: Vec::new(),
+    }
 }
 
 fn verify_seq(name: &IpnsName, bytes: &[u8]) -> u64 {
@@ -670,10 +686,7 @@ fn keyless_re_put_reposts_held_records_to_every_endpoint() {
     world
         .record_store
         .seed_record(&endpoints[1], name.as_str(), bytes.clone());
-    let held = vec![HeldRecord {
-        routing_key: name.as_str().to_owned(),
-        record_bytes: bytes,
-    }];
+    let held = vec![held_record(&name, bytes)];
 
     let results = block_on(keyless_re_put(&device.record_store, &held));
     assert_eq!(results.len(), 1);
@@ -688,10 +701,7 @@ fn keyless_re_put_runs_as_an_hourly_scheduler_job_on_virtual_time() {
     let device = world.device(b"me");
     let s = signer(12);
     let name = name_of(&s);
-    let held = vec![HeldRecord {
-        routing_key: name.as_str().to_owned(),
-        record_bytes: record(&s, VALUE, 1, 0),
-    }];
+    let held = vec![held_record(&name, record(&s, VALUE, 1, 0))];
 
     let scheduler = world.scheduler.clone().with_auto_advance();
     let runs = Arc::new(Mutex::new(0u32));
@@ -722,6 +732,179 @@ fn keyless_re_put_runs_as_an_hourly_scheduler_job_on_virtual_time() {
         "three hours elapsed on virtual time"
     );
     assert_all_endpoints_at(&world.record_store, &name, 1);
+}
+
+#[test]
+fn resolve_and_hold_holds_a_gate_passing_record() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(31);
+    let name = name_of(&s);
+    let endpoints = world.record_store.endpoints();
+    world
+        .record_store
+        .seed_record(&endpoints[0], name.as_str(), record(&s, VALUE, 1, 0));
+
+    let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+    let material = HeldMaterial {
+        node_id: [7u8; 16],
+        write_scope_seed: Zeroizing::new([9u8; 32]),
+        head_cid: "bafyhead".into(),
+        content_cids: vec!["bafycontent".into()],
+    };
+    let resolved = block_on(resolve_and_hold(
+        &device.record_store,
+        &device.snapshot_cache,
+        &StubAdopter::new(Verdict::Accept),
+        &name,
+        &held,
+        &material,
+    ))
+    .expect("resolve_and_hold");
+
+    assert!(matches!(resolved.outcome, ResolveOutcome::Adopted(_)));
+    let map = held.borrow();
+    assert_eq!(map.len(), 1, "the adopted record is held, keyed by node id");
+    let record = map.get(&[7u8; 16]).expect("held under its node id");
+    assert_eq!(record.routing_key, name.as_str());
+    assert_eq!(record.head_cid, "bafyhead");
+    assert_eq!(record.content_cids, vec!["bafycontent".to_owned()]);
+    // The held bytes are exactly the record the gate adopted.
+    assert_eq!(verify_seq(&name, &record.record_bytes), 1);
+}
+
+#[test]
+fn resolve_and_hold_does_not_hold_a_non_gate_passing_record() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(32);
+    let name = name_of(&s);
+    let endpoints = world.record_store.endpoints();
+    world
+        .record_store
+        .seed_record(&endpoints[0], name.as_str(), record(&s, VALUE, 5, 0));
+    let material = HeldMaterial {
+        node_id: [1u8; 16],
+        write_scope_seed: Zeroizing::new([0u8; 32]),
+        head_cid: "h".into(),
+        content_cids: Vec::new(),
+    };
+
+    // A fail-closed trust violation is never held.
+    let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+    let out = block_on(resolve_and_hold(
+        &device.record_store,
+        &device.snapshot_cache,
+        &StubAdopter::new(Verdict::TrustViolation),
+        &name,
+        &held,
+        &material,
+    ))
+    .unwrap();
+    assert!(matches!(out.outcome, ResolveOutcome::TrustViolation(_)));
+    assert!(held.borrow().is_empty(), "a trust violation is never held");
+
+    // A no-update (nothing newer than our current record) is never held.
+    let held2: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+    let out2 = block_on(resolve_and_hold(
+        &device.record_store,
+        &device.snapshot_cache,
+        &StubAdopter::new(Verdict::EqualSequence),
+        &name,
+        &held2,
+        &material,
+    ))
+    .unwrap();
+    assert_eq!(out2.outcome, ResolveOutcome::NoUpdate);
+    assert!(held2.borrow().is_empty(), "a no-update is never held");
+}
+
+#[test]
+fn a_held_record_dropped_from_an_endpoint_is_alive_again_after_one_interval() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(33);
+    let name = name_of(&s);
+    let endpoints = world.record_store.endpoints();
+    // Only one endpoint still holds the record; the rest dropped it.
+    world
+        .record_store
+        .seed_record(&endpoints[1], name.as_str(), record(&s, VALUE, 1, 0));
+
+    let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+    held.borrow_mut()
+        .insert([1u8; 16], held_record(&name, record(&s, VALUE, 1, 0)));
+
+    // Drive exactly one interval over the populated set, then stop.
+    let scheduler = world.scheduler.clone().with_auto_advance();
+    block_on(run_liveness_loop(&scheduler, RE_PUT_INTERVAL, || async {
+        let records: Vec<HeldRecord> = held.borrow().values().cloned().collect();
+        keyless_re_put(&device.record_store, &records).await;
+        LivenessControl::Stop
+    }));
+
+    assert_all_endpoints_at(&world.record_store, &name, 1);
+    assert_eq!(
+        scheduler.now(),
+        UnixMillis(60 * 60 * 1000),
+        "one interval elapsed"
+    );
+}
+
+#[test]
+fn an_evicted_record_is_not_re_put() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let s = signer(34);
+    let name = name_of(&s);
+
+    let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+    held.borrow_mut()
+        .insert([1u8; 16], held_record(&name, record(&s, VALUE, 1, 0)));
+    // Eviction leaves the set before the loop runs.
+    held.borrow_mut().remove(&[1u8; 16]);
+    assert!(held.borrow().is_empty(), "eviction removes the record");
+
+    let scheduler = world.scheduler.clone().with_auto_advance();
+    block_on(run_liveness_loop(&scheduler, RE_PUT_INTERVAL, || async {
+        let records: Vec<HeldRecord> = held.borrow().values().cloned().collect();
+        keyless_re_put(&device.record_store, &records).await;
+        LivenessControl::Stop
+    }));
+
+    // No endpoint ever received the evicted record — the loop never re-PUTs it.
+    for endpoint in world.record_store.endpoints() {
+        assert!(
+            world
+                .record_store
+                .record_at(&endpoint, name.as_str())
+                .is_none(),
+            "endpoint {} must hold no record for an evicted name",
+            endpoint.0
+        );
+    }
+}
+
+#[test]
+fn held_record_debug_redacts_the_write_seed() {
+    let s = signer(35);
+    let name = name_of(&s);
+    let mut hr = held_record(&name, record(&s, VALUE, 1, 0));
+    hr.write_scope_seed = Zeroizing::new([0xAB; 32]);
+
+    let debug = format!("{hr:?}");
+    let seed_debug = format!("{:?}", [0xABu8; 32]);
+    assert!(
+        !debug.contains(&seed_debug),
+        "the raw write-seed bytes must never appear in Debug"
+    );
+    assert!(
+        debug.contains("<redacted>"),
+        "the write seed field must be redacted"
+    );
+    // Non-secret routing metadata is still visible for diagnostics.
+    assert!(debug.contains(name.as_str()));
+    assert!(debug.contains("bafyhead"));
 }
 
 #[test]
@@ -1037,10 +1220,7 @@ fn run_liveness_loop_keyless_re_puts_the_held_set_each_pass() {
     world
         .record_store
         .seed_record(&endpoints[1], name.as_str(), bytes.clone());
-    let held = vec![HeldRecord {
-        routing_key: name.as_str().to_owned(),
-        record_bytes: bytes,
-    }];
+    let held = vec![held_record(&name, bytes)];
 
     let scheduler = world.scheduler.clone().with_auto_advance();
     let transport = device.record_store.clone();

--- a/crates/engine/tests/net.rs
+++ b/crates/engine/tests/net.rs
@@ -21,16 +21,15 @@ use cipherbox_core::error::TrustViolation;
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::seal::ReadBody;
 use cipherbox_core::suite::ed25519::Ed25519Signer;
-use zeroize::Zeroizing;
 
 use cipherbox_engine::SyncTimingProfile;
 use cipherbox_engine::api::ApiClient;
 use cipherbox_engine::gate::{Adopted, GateError, GateRejection, GateStage, RejectionReason};
 use cipherbox_engine::net::eol;
 use cipherbox_engine::net::{
-    Adopter, HeldMaterial, HeldRecord, HeldRecords, LivenessControl, PublishError, PublishOutcome,
+    Adopter, HeldRecord, HeldRecords, LivenessControl, PublishError, PublishOutcome,
     PublishRequest, RE_PUT_INTERVAL, ResolveOutcome, ReviveError, ReviveRequest, eol_republish,
-    keyless_re_put, publish, resolve, resolve_and_hold, revive, run_liveness_loop,
+    keyless_re_put, publish, resolve, revive, run_liveness_loop,
 };
 use cipherbox_engine::seams::{
     FloorStore, HttpResponse, RecordTransport, Scheduler, SeamError, SeamResult, SnapshotCache,
@@ -61,15 +60,14 @@ fn record(signer: &Ed25519Signer, value: &[u8], sequence: u64, mint_millis: u64)
     IpnsRecord::create_v2(signer, value, sequence, TTL_NANOS, &validity).marshal()
 }
 
-/// A held record for `name` carrying `bytes` plus placeholder renewal inputs
-/// (#750 exercises the seed/node-id/CID fields; the keyless re-PUT layer reads
-/// only routing key + bytes).
+/// A held record for `name` carrying `bytes` plus a placeholder renewal signer
+/// (#750 exercises the signer/CID fields; the keyless re-PUT layer reads only
+/// routing key + bytes).
 fn held_record(name: &IpnsName, bytes: Vec<u8>) -> HeldRecord {
     HeldRecord {
         routing_key: name.as_str().to_owned(),
         record_bytes: bytes,
-        node_id: [0u8; 16],
-        write_scope_seed: Zeroizing::new([0u8; 32]),
+        signer: Ed25519Signer::from_seed([0u8; 32]),
         head_cid: "bafyhead".into(),
         content_cids: Vec::new(),
     }
@@ -735,91 +733,6 @@ fn keyless_re_put_runs_as_an_hourly_scheduler_job_on_virtual_time() {
 }
 
 #[test]
-fn resolve_and_hold_holds_a_gate_passing_record() {
-    let world = FakeWorld::new();
-    let device = world.device(b"me");
-    let s = signer(31);
-    let name = name_of(&s);
-    let endpoints = world.record_store.endpoints();
-    world
-        .record_store
-        .seed_record(&endpoints[0], name.as_str(), record(&s, VALUE, 1, 0));
-
-    let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
-    let material = HeldMaterial {
-        node_id: [7u8; 16],
-        write_scope_seed: Zeroizing::new([9u8; 32]),
-        head_cid: "bafyhead".into(),
-        content_cids: vec!["bafycontent".into()],
-    };
-    let resolved = block_on(resolve_and_hold(
-        &device.record_store,
-        &device.snapshot_cache,
-        &StubAdopter::new(Verdict::Accept),
-        &name,
-        &held,
-        &material,
-    ))
-    .expect("resolve_and_hold");
-
-    assert!(matches!(resolved.outcome, ResolveOutcome::Adopted(_)));
-    let map = held.borrow();
-    assert_eq!(map.len(), 1, "the adopted record is held, keyed by node id");
-    let record = map.get(&[7u8; 16]).expect("held under its node id");
-    assert_eq!(record.routing_key, name.as_str());
-    assert_eq!(record.head_cid, "bafyhead");
-    assert_eq!(record.content_cids, vec!["bafycontent".to_owned()]);
-    // The held bytes are exactly the record the gate adopted.
-    assert_eq!(verify_seq(&name, &record.record_bytes), 1);
-}
-
-#[test]
-fn resolve_and_hold_does_not_hold_a_non_gate_passing_record() {
-    let world = FakeWorld::new();
-    let device = world.device(b"me");
-    let s = signer(32);
-    let name = name_of(&s);
-    let endpoints = world.record_store.endpoints();
-    world
-        .record_store
-        .seed_record(&endpoints[0], name.as_str(), record(&s, VALUE, 5, 0));
-    let material = HeldMaterial {
-        node_id: [1u8; 16],
-        write_scope_seed: Zeroizing::new([0u8; 32]),
-        head_cid: "h".into(),
-        content_cids: Vec::new(),
-    };
-
-    // A fail-closed trust violation is never held.
-    let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
-    let out = block_on(resolve_and_hold(
-        &device.record_store,
-        &device.snapshot_cache,
-        &StubAdopter::new(Verdict::TrustViolation),
-        &name,
-        &held,
-        &material,
-    ))
-    .unwrap();
-    assert!(matches!(out.outcome, ResolveOutcome::TrustViolation(_)));
-    assert!(held.borrow().is_empty(), "a trust violation is never held");
-
-    // A no-update (nothing newer than our current record) is never held.
-    let held2: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
-    let out2 = block_on(resolve_and_hold(
-        &device.record_store,
-        &device.snapshot_cache,
-        &StubAdopter::new(Verdict::EqualSequence),
-        &name,
-        &held2,
-        &material,
-    ))
-    .unwrap();
-    assert_eq!(out2.outcome, ResolveOutcome::NoUpdate);
-    assert!(held2.borrow().is_empty(), "a no-update is never held");
-}
-
-#[test]
 fn a_held_record_dropped_from_an_endpoint_is_alive_again_after_one_interval() {
     let world = FakeWorld::new();
     let device = world.device(b"me");
@@ -886,21 +799,21 @@ fn an_evicted_record_is_not_re_put() {
 }
 
 #[test]
-fn held_record_debug_redacts_the_write_seed() {
+fn held_record_debug_redacts_the_signer() {
     let s = signer(35);
     let name = name_of(&s);
     let mut hr = held_record(&name, record(&s, VALUE, 1, 0));
-    hr.write_scope_seed = Zeroizing::new([0xAB; 32]);
+    hr.signer = Ed25519Signer::from_seed([0xAB; 32]);
 
     let debug = format!("{hr:?}");
     let seed_debug = format!("{:?}", [0xABu8; 32]);
     assert!(
         !debug.contains(&seed_debug),
-        "the raw write-seed bytes must never appear in Debug"
+        "the raw signing-key bytes must never appear in Debug"
     );
     assert!(
-        debug.contains("<redacted>"),
-        "the write seed field must be redacted"
+        debug.contains("Ed25519Signer(redacted)"),
+        "the held signer must be redacted"
     );
     // Non-secret routing metadata is still visible for diagnostics.
     assert!(debug.contains(name.as_str()));

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -40,6 +40,9 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 # `start`/`command` queue rather than double-borrowing), and bounds `nextEvent`
 # to one outstanding stream read.
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
+# Wraps the accelerator bearer token in a zeroizing buffer before it reaches the
+# engine's `GatewaySource` — the credential never sits in a plain `String`.
+zeroize.workspace = true
 
 # The boundary tests run under wasm-bindgen-test-runner.
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -15,11 +15,14 @@
 use std::rc::Rc;
 
 use cipherbox_engine::facade::{Engine, EventStream, LoginSecret};
-use cipherbox_engine::{Entropy, EntropyError, SeamSet, SeamTypes, SyncTimingProfile};
+use cipherbox_engine::{
+    Entropy, EntropyError, GatewayConfig, GatewaySource, SeamSet, SeamTypes, SyncTimingProfile,
+};
 use futures_util::lock::Mutex;
 use js_sys::{Promise, Reflect};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
+use zeroize::Zeroizing;
 
 use crate::seams_bridge::{
     CredentialStoreAdapter, FloorStoreAdapter, HttpAdapter, JsCredentialStoreSeam,
@@ -82,12 +85,18 @@ impl EngineHandle {
     /// `mailbox`, `refreshHints`, `scheduler`, `stagingStore`, `snapshotCache`,
     /// `credentialStore`); a missing seam fails closed. `profile` selects the
     /// sync timing policy (`"ci"` for the compressed e2e cadences, production
-    /// otherwise).
+    /// otherwise). The content gateway is configured from `acceleratorBaseUrl`
+    /// (+ optional `acceleratorBearer`) and `publicGateways`; all absent leaves
+    /// it dormant (reads fail closed as `Unavailable`) until E4 wires real
+    /// endpoints.
     #[wasm_bindgen(constructor)]
     pub fn new(
         seams: JsValue,
         profile: Option<String>,
         api_base_url: Option<String>,
+        accelerator_base_url: Option<String>,
+        accelerator_bearer: Option<String>,
+        public_gateways: Option<Vec<String>>,
     ) -> Result<EngineHandle, JsError> {
         console_error_panic_hook::set_once();
 
@@ -126,6 +135,24 @@ impl EngineHandle {
             _ => SyncTimingProfile::PRODUCTION,
         };
 
+        // Dormant until the config slice (E4) supplies real endpoints: with no
+        // accelerator base URL and no fallbacks the gateway is empty, and reads
+        // fail closed as `Unavailable` (availability, never a trust violation).
+        let gateway = GatewayConfig {
+            accelerator: accelerator_base_url.map(|base_url| GatewaySource {
+                base_url,
+                bearer: accelerator_bearer.map(Zeroizing::new),
+            }),
+            public_fallbacks: public_gateways
+                .unwrap_or_default()
+                .into_iter()
+                .map(|base_url| GatewaySource {
+                    base_url,
+                    bearer: None,
+                })
+                .collect(),
+        };
+
         // Empty until the auth/config slice supplies the real API base URL; the
         // register-first renewal is inert against an empty base until then.
         let (engine, events) = Engine::new(
@@ -133,6 +160,7 @@ impl EngineHandle {
             Box::new(GetrandomEntropy),
             profile,
             api_base_url.unwrap_or_default(),
+            gateway,
         );
         Ok(EngineHandle {
             engine: Rc::new(Mutex::new(engine)),

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -138,10 +138,14 @@ impl EngineHandle {
         // Dormant until the config slice (E4) supplies real endpoints: with no
         // accelerator base URL and no fallbacks the gateway is empty, and reads
         // fail closed as `Unavailable` (availability, never a trust violation).
+        // Zeroize the bearer before branching on the base URL: if no accelerator
+        // base URL is supplied the source closure never runs, so wrapping inside
+        // it would drop the Rust-owned bearer String unzeroized (security rule 7).
+        let accelerator_bearer = accelerator_bearer.map(Zeroizing::new);
         let gateway = GatewayConfig {
             accelerator: accelerator_base_url.map(|base_url| GatewaySource {
                 base_url,
-                bearer: accelerator_bearer.map(Zeroizing::new),
+                bearer: accelerator_bearer,
             }),
             public_fallbacks: public_gateways
                 .unwrap_or_default()

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -84,7 +84,11 @@ impl EngineHandle {
     /// sync timing policy (`"ci"` for the compressed e2e cadences, production
     /// otherwise).
     #[wasm_bindgen(constructor)]
-    pub fn new(seams: JsValue, profile: Option<String>) -> Result<EngineHandle, JsError> {
+    pub fn new(
+        seams: JsValue,
+        profile: Option<String>,
+        api_base_url: Option<String>,
+    ) -> Result<EngineHandle, JsError> {
         console_error_panic_hook::set_once();
 
         let seam_set = SeamSet::<WebSeamTypes> {
@@ -122,7 +126,14 @@ impl EngineHandle {
             _ => SyncTimingProfile::PRODUCTION,
         };
 
-        let (engine, events) = Engine::new(seam_set, Box::new(GetrandomEntropy), profile);
+        // Empty until the auth/config slice supplies the real API base URL; the
+        // register-first renewal is inert against an empty base until then.
+        let (engine, events) = Engine::new(
+            seam_set,
+            Box::new(GetrandomEntropy),
+            profile,
+            api_base_url.unwrap_or_default(),
+        );
         Ok(EngineHandle {
             engine: Rc::new(Mutex::new(engine)),
             events: Rc::new(Mutex::new(events)),

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -343,6 +343,7 @@ impl Event {
             facade::Event::WithheldUpdateEscalation { .. } => "withheldUpdateEscalation",
             facade::Event::DeadLetter { .. } => "deadLetter",
             facade::Event::AttributableAbuse { .. } => "attributableAbuse",
+            facade::Event::RenewalFailed { .. } => "renewalFailed",
         }
         .to_string()
     }
@@ -381,6 +382,26 @@ impl Event {
     pub fn description(&self) -> Option<String> {
         match &self.inner {
             facade::Event::AttributableAbuse { description } => Some(description.clone()),
+            _ => None,
+        }
+    }
+
+    /// `renewalFailed`: the failed record's routing key (`ipnsName`); otherwise
+    /// `undefined`.
+    #[wasm_bindgen(getter, js_name = routingKey)]
+    pub fn routing_key(&self) -> Option<String> {
+        match &self.inner {
+            facade::Event::RenewalFailed { routing_key, .. } => Some(routing_key.clone()),
+            _ => None,
+        }
+    }
+
+    /// `renewalFailed`: the key-free failure classification; otherwise
+    /// `undefined`.
+    #[wasm_bindgen(getter)]
+    pub fn detail(&self) -> Option<String> {
+        match &self.inner {
+            facade::Event::RenewalFailed { detail, .. } => Some(detail.clone()),
             _ => None,
         }
     }

--- a/crates/wasm/src/seams_bridge.rs
+++ b/crates/wasm/src/seams_bridge.rs
@@ -80,6 +80,7 @@ pub(crate) fn optional_bytes(value: JsValue) -> Option<Vec<u8>> {
 extern "C" {
     /// JS `FloorStoreSeam` (packages/client) — opaque handle, methods called
     /// structurally.
+    #[derive(Clone)]
     pub type JsFloorStoreSeam;
 
     #[wasm_bindgen(method, catch, js_name = epochFloor)]
@@ -319,6 +320,7 @@ impl StagingStore for StagingStoreAdapter {
 #[wasm_bindgen]
 extern "C" {
     /// JS `CredentialStoreSeam` (packages/client).
+    #[derive(Clone)]
     pub type JsCredentialStoreSeam;
 
     #[wasm_bindgen(method, catch, js_name = storeRefreshToken)]
@@ -468,6 +470,7 @@ impl RecordTransport for RecordTransportAdapter {
 #[wasm_bindgen]
 extern "C" {
     /// JS `HttpSeam` (packages/client) — `send(HttpRequestData)`.
+    #[derive(Clone)]
     pub type JsHttpSeam;
 
     #[wasm_bindgen(method, catch, js_name = send)]

--- a/crates/wasm/src/seams_bridge.rs
+++ b/crates/wasm/src/seams_bridge.rs
@@ -151,6 +151,7 @@ impl FloorStore for FloorStoreAdapter {
 #[wasm_bindgen]
 extern "C" {
     /// JS `SnapshotCacheSeam` (packages/client).
+    #[derive(Clone)]
     pub type JsSnapshotCacheSeam;
 
     #[wasm_bindgen(method, catch, js_name = put)]
@@ -167,6 +168,7 @@ extern "C" {
     async fn clear(this: &JsSnapshotCacheSeam) -> Result<JsValue, JsValue>;
 }
 
+#[derive(Clone)]
 pub(crate) struct SnapshotCacheAdapter {
     pub(crate) js: JsSnapshotCacheSeam,
 }

--- a/crates/wasm/src/seams_bridge.rs
+++ b/crates/wasm/src/seams_bridge.rs
@@ -103,6 +103,7 @@ extern "C" {
 /// The JS `FloorStoreSeam` exposes only per-key methods, so this adapter does
 /// not override `commit_floors`: web batches ride the seam's ordered fail-safe
 /// fallback (#682-safe; web-atomic is deferred — see the trait doc).
+#[derive(Clone)]
 pub(crate) struct FloorStoreAdapter {
     pub(crate) js: JsFloorStoreSeam,
 }
@@ -331,6 +332,7 @@ extern "C" {
     async fn clear_refresh_token(this: &JsCredentialStoreSeam) -> Result<JsValue, JsValue>;
 }
 
+#[derive(Clone)]
 pub(crate) struct CredentialStoreAdapter {
     pub(crate) js: JsCredentialStoreSeam,
 }
@@ -545,6 +547,7 @@ fn http_response_from_js(value: JsValue) -> SeamResult<HttpResponse> {
     })
 }
 
+#[derive(Clone)]
 pub(crate) struct HttpAdapter {
     pub(crate) js: JsHttpSeam,
 }

--- a/packages/client/test/browser/engineHarness.ts
+++ b/packages/client/test/browser/engineHarness.ts
@@ -63,7 +63,8 @@ window.runRealEngine = async (): Promise<RealEngineResult> => {
     result.beforeStart = message(error);
   });
 
-  const secret = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer;
+  // A valid secp256k1 identity scalar: 32 bytes, non-zero, well below the curve order n.
+  const secret = new Uint8Array(32).fill(1).buffer;
   await facade.start(secret);
   result.startOk = true;
   result.secretDetached = secret.byteLength === 0;


### PR DESCRIPTION
## Summary

Stands up the full engine cold-start pipeline behind the facade: a fresh device logs in, resolves its own vault from the network, projects a snapshot, and keeps its records alive — all fail-closed and deterministic. This began as the facade read/command/event spine and grew (by design) to cover the remaining #752 cold-start scope so the whole chain lands as one reviewed unit.

## What it does

- **Identity (E1):** `SessionIdentity` derives the owner secp256k1 identity directly from the reconstructed key (`EcdsaSigner::from_scalar`, an identity function — no KDF edge); `derive` is fail-closed on a non-scalar/zero/wrong-length secret.
- **Login (E5):** `start()` signs an API challenge with the identity (RFC-6979 deterministic ECDSA) for a short-lived JWT; login failure is fail-closed before any session commit or loop spawn. `SiweLogin` wired.
- **Content-CID codec (C2):** a base32 multibase content-CID string codec in `crates/core` (the record's signed value names the head block via this string) — triple-guarded, canonicality-enforced, release-active encode/decode symmetry.
- **Pointer + adopter (PointerFetch, E2):** a production `RecordPointerFetch` (the vault re-point rides inline in the owner-signed IPNS record value) and a production `RootAdopter` that assembles a gate `Candidate` over the content plane (`decode_content_cid_str` then `read_block` then `decode_envelope` then grant section then `gate::adopt`).
- **Owner write-seed recovery (E8):** on the owner's own root, the adopter opens the owner-write-blob (merged core, #792) under the durable, monotonic `write_epoch_floor` to recover `write_scope_seed`, derives the narrow per-name `Ed25519Signer`, and drops the seed. Open-failure / epoch-mismatch are re-authorable (held keyless, no abuse event) — the rollback defense from #752.
- **Snapshot projection (E7):** the adopted root read-body projects to the base `Snapshot` (direct children only; deeper descent deferred).
- **Gateway config:** `Engine::new` takes an explicit `GatewayConfig` (the accelerator is a distinct service; its bearer is `Zeroizing`, redacted); an unconfigured gateway is dormant.
- **Driver (E4 + E6):** `start()` runs the cold-start resolve, assigns the base snapshot, and spawns a fixed-cadence resolve-tick loop that populates the held set (alongside the liveness re-PUT loop). An unresolvable pointer degrades to an anchored-root snapshot — no error.
- **Liveness folds (#799 + #752 F3):** the resolve-tick now repaints the base snapshot from each adopted outcome (`refresh_base_from_outcome`, `Adopted`-only, emitting `SnapshotUpdated`; `Snapshot` moved to `Rc<RefCell<_>>` with no borrow held across an `.await`), and the owner's own current root is now held at the equal-floor `Current` path via `Adopter::recover_own_write_seed` (fail-open, never `Rejected`) so it stays renewable, not just on first adoption.

## Review

The mandatory trio ran on `git diff main...HEAD`:

- **crypto-privacy:** no HIGH/MEDIUM — sound across the trust-anchor codec, the E8 AAD (scope/floor-consistent, rollback closed), PointerFetch verification, signing, gateway redaction, and determinism seams.
- **security:** one HIGH — the resolve-tick held the owner root with an empty head CID, so sub-EOL renewal would republish an empty content path and clobber the valid tip (owner lockout). **Fixed:** the held head CID is now derived authoritatively from the adopted record's signed value (`HeldMaterial.head_cid` removed), with a release-active `EmptyHeadCid` encode guard (encode/decode fail-closed symmetry). Plus the fail-closed session-residual and cache-roundtrip folds.
- **simplify:** minor tightenings folded; the ~130-LOC fixture dedup deferred (#798).

Deferred follow-ups (all `Part of #752`): #795 (least-privilege loop capture), #796 (resolve-tick outcome surfacing), #797 (content re-pin on renewal), #798 (fixture dedup). Related core follow-ups: #793, #794.

Closes #748
Closes #751
Closes #750
Closes #799
Part of #752


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata operations for creating, deleting, renaming, and relinking items.
  * Added a live engine view with browsing, lookup, attributes, and filesystem statistics.
  * Added SIWE login support and configurable API/gateway connectivity.
  * Added automatic record renewal with surfaced renewal-failure events.
  * Added strict canonical content-CID string encoding and decoding.
  * Added WASM event details for renewal failures.

* **Bug Fixes**
  * Invalid secrets, malformed content CIDs, empty content references, and unavailable read sources now fail closed with clearer errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->