### PR TITLE
fix(engine): restore main compile after the SweepTarget ipns_name field drop

### DIFF
--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -416,7 +416,7 @@ where
         let identity = ScopeRootIdentity {
             v: target.v,
             scope_id: descendant.scope_id,
-            ipns_name: &target.ipns_name,
+            ipns_name: &descendant.ipns_name,
             owner_enc_pub: &target.owner_enc_pub,
             parent_node_seed: Some(&parent_node_seed),
             pseudonym_signer: &target.pseudonym_signer,
@@ -450,7 +450,7 @@ where
         })?;
         let record = ResealedScopeRoot {
             scope_id: descendant.scope_id,
-            ipns_name: target.ipns_name.clone(),
+            ipns_name: descendant.ipns_name.clone(),
             read_epoch: target.current_read_epoch,
             write_epoch: target.write_epoch,
             section,


### PR DESCRIPTION
## P0 — main does not compile

`main` (2c509d72c) fails to build: `error[E0609]: no field `ipns_name` on type `SweepTarget`` at `grants/create.rs:419` and `:453`.

**Cause — a semantic merge conflict between two already-merged PRs:**
- #779 dropped the `ipns_name` field from `SweepTarget` (the enumerated `ChildScopeRef` is the sole name authority).
- #782's read-grant descendant re-key still read `target.ipns_name`.

Both merged cleanly textually and were individually green, so nothing flagged it until both landed.

**Fix:** source the publish/reseal name from the enumerated `descendant.ipns_name` at both sites, exactly matching #779's own `sweep.rs` fix. 2-line change; no behavior change beyond restoring the correct (enumerated) name binding.

Verified locally: `cargo check`/`clippy`/`fmt` clean, full `cargo test -p cipherbox-engine` green (335+ tests).

Kept as draft to avoid consuming a CodeRabbit slot on a trivial compile fix — merge to unblock main (all open PR CI is currently red against broken main).