### PR TITLE
refactor(api): map mailbox cap-insert contention to 503 and consolidate lock helpers

### DIFF
--- a/apps/api/src/common/advisory-lock.ts
+++ b/apps/api/src/common/advisory-lock.ts
@@ -146,6 +146,19 @@ export async function acquireAdvisoryLocks(manager: EntityManager, keys: bigint[
 }
 
 /**
+ * Set the transaction-local wait bound and acquire a batch of advisory locks in
+ * one call — the pairing every lock-guarded transaction opens with.
+ */
+export async function boundedAcquire(
+  manager: EntityManager,
+  keys: bigint[],
+  timeoutMs: number
+): Promise<void> {
+  await setAdvisoryLockTimeout(manager, timeoutMs);
+  await acquireAdvisoryLocks(manager, keys);
+}
+
+/**
  * Run `work` in a transaction, mapping any `lock_timeout` abort (55P03) — the
  * advisory acquire OR any row lock taken later under the same bound — to the
  * retryable 503, so a contended caller degrades gracefully instead of escaping

--- a/apps/api/src/common/advisory-lock.ts
+++ b/apps/api/src/common/advisory-lock.ts
@@ -49,23 +49,6 @@ export async function setAdvisoryLockTimeout(
 }
 
 /**
- * Acquire one transaction-scoped advisory lock, mapping a `lock_timeout` abort
- * to a retryable 503 so a contended caller degrades gracefully instead of
- * holding its connection until the pool starves. The lock auto-releases at
- * commit or rollback.
- */
-export async function acquireAdvisoryLock(manager: EntityManager, key: bigint): Promise<void> {
-  try {
-    await manager.query('SELECT pg_advisory_xact_lock($1::bigint)', [key.toString()]);
-  } catch (error) {
-    if (isLockNotAvailable(error)) {
-      throw new ServiceUnavailableException('Contended resource; retry shortly');
-    }
-    throw error;
-  }
-}
-
-/**
  * A Postgres `lock_not_available` (55P03) — a statement aborted by
  * `lock_timeout`, whether the advisory-lock acquire or a row lock taken later
  * under the same transaction-scoped bound. TypeORM wraps it as a

--- a/apps/api/src/content/content.service.ts
+++ b/apps/api/src/content/content.service.ts
@@ -12,12 +12,11 @@ import { DataSource, EntityManager } from 'typeorm';
 import { User } from '../auth/entities/user.entity';
 import {
   accountLockKey,
-  acquireAdvisoryLocks,
   advisoryLockKey,
+  boundedAcquire,
   pinDurabilityLockKey,
   resolveAdvisoryLockTimeoutMs,
   runLockGuardedTransaction,
-  setAdvisoryLockTimeout,
   withSessionAdvisoryLock,
 } from '../common/advisory-lock';
 import { resolveDbPoolSize } from '../common/db-pool';
@@ -77,7 +76,6 @@ export function resolvePinConcurrency(configService: ConfigService): ResolvedPin
  * revert just the size charge on that pre-existing row rather than delete it.
  */
 interface RegisterOutcome {
-  cid: string;
   size: number;
   created: boolean;
   promoted: boolean;
@@ -168,10 +166,7 @@ export class ContentService {
     // so an unbounded burst would otherwise exhaust the DB pool; the ceiling
     // reserves connections for every other route while the pin is in flight.
     return this.pinSlots.run(() =>
-      // Serialize the whole commit → pin → compensate span per CID with a
-      // session lock, so a concurrent same-CID upload cannot observe a
-      // committed-but-not-yet-pinned row and return success for it (the in-tx
-      // xact lock releases at commit, too early to cover the post-commit pin).
+      // Per-CID session lock spans commit → pin → compensate (see class doc).
       withSessionAdvisoryLock(this.dataSource, pinDurabilityLockKey(cid), this.lockTimeoutMs, () =>
         this.registerAndPin(accountId, cid, size, bytes)
       )
@@ -209,7 +204,7 @@ export class ContentService {
       }
     }
 
-    return { cid: outcome.cid, size: outcome.size };
+    return { cid, size: outcome.size };
   }
 
   private async registerPin(
@@ -218,10 +213,13 @@ export class ContentService {
     cid: string,
     size: number
   ): Promise<RegisterOutcome> {
-    await setAdvisoryLockTimeout(manager, this.lockTimeoutMs);
     // Account key serializes the quota check-then-act; the CID key serializes the
     // pin-row insert against a concurrent register/retire of the same CID.
-    await acquireAdvisoryLocks(manager, [accountLockKey(accountId), advisoryLockKey(cid)]);
+    await boundedAcquire(
+      manager,
+      [accountLockKey(accountId), advisoryLockKey(cid)],
+      this.lockTimeoutMs
+    );
 
     const userRepo = manager.getRepository(User);
     const pinRepo = manager.getRepository(PinnedCid);
@@ -257,7 +255,7 @@ export class ContentService {
     // rather than trusted for content Kubo never held.
     if (existing && BigInt(existing.size) > 0n) {
       // Idempotent re-upload: the CID already counts — no gate, no new charge.
-      return { cid, size: Number(existing.size), created: false, promoted: false };
+      return { size: Number(existing.size), created: false, promoted: false };
     }
 
     // Gate against AUTHORITATIVE rows only: stale advisory rows an account kept
@@ -275,11 +273,11 @@ export class ContentService {
       // authoritative so the charge lands in the hosted sum, then drive the
       // durable pin (`created`) exactly as a fresh insert would.
       await pinRepo.update({ accountId, cid }, { size: size.toString(), advisory: false });
-      return { cid, size, created: true, promoted: true };
+      return { size, created: true, promoted: true };
     }
 
     await pinRepo.insert({ accountId, cid, size: size.toString(), advisory: false });
-    return { cid, size, created: true, promoted: false };
+    return { size, created: true, promoted: false };
   }
 
   /**
@@ -295,8 +293,7 @@ export class ContentService {
   private async compensate(accountId: string, cid: string, promoted: boolean): Promise<void> {
     try {
       const unpin = await runLockGuardedTransaction(this.dataSource, async (manager) => {
-        await setAdvisoryLockTimeout(manager, this.lockTimeoutMs);
-        await acquireAdvisoryLocks(manager, [advisoryLockKey(cid)]);
+        await boundedAcquire(manager, [advisoryLockKey(cid)], this.lockTimeoutMs);
         const pinRepo = manager.getRepository(PinnedCid);
         if (promoted) {
           await pinRepo.update({ accountId, cid }, { size: '0' });

--- a/apps/api/src/mailbox/services/mailbox.service.integration.test.ts
+++ b/apps/api/src/mailbox/services/mailbox.service.integration.test.ts
@@ -1,4 +1,4 @@
-import { ConflictException } from '@nestjs/common';
+import { ConflictException, ServiceUnavailableException } from '@nestjs/common';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { randomBytes } from 'node:crypto';
 import { Repository } from 'typeorm';
@@ -154,5 +154,52 @@ describe('MailboxService pending-cap concurrency (real Postgres)', () => {
     const finalCount = await repo.count({ where: { recipientPublicKey: recipient } });
     expect(finalCount).toBe(CAP);
     expect(finalCount).toBeLessThanOrEqual(CAP);
+  });
+
+  it('a row-lock wait past lock_timeout inside the cap window surfaces a retryable 503, not a 500', async () => {
+    const clock = new FakeClock();
+    const users = new FakeRepository<User>();
+    const recipient = compressedPublicKey();
+    const sender = compressedPublicKey();
+    void users.save({ publicKey: recipient } as never);
+    const service = new MailboxService(
+      repo,
+      users as never,
+      db.dataSource,
+      new IdentityService(),
+      clock,
+      fakeConfig({ DB_ADVISORY_LOCK_TIMEOUT_MS: '200' }).service
+    );
+
+    // An expired row (past the 90-day TTL relative to the FakeClock) that the
+    // cap window's purge DELETE must touch.
+    const expired = await repo.save({
+      recipientPublicKey: recipient,
+      idempotencyScope: randomBytes(32).toString('hex'),
+      blob: Buffer.alloc(16, 1),
+      receivedAt: new Date('2025-09-01T00:00:00Z'),
+    });
+
+    // Hold that row locked elsewhere: the advisory acquire succeeds (no
+    // contention on the recipient key), then the purge DELETE waits past the
+    // transaction-scoped lock_timeout and aborts with 55P03 — which must map
+    // to the retryable 503, not escape post()'s dedup catch as a 500.
+    const holder = db.dataSource.createQueryRunner();
+    await holder.connect();
+    await holder.startTransaction();
+    await holder.query('SELECT id FROM mailbox_messages WHERE id = $1 FOR UPDATE', [expired.id]);
+
+    try {
+      await expect(
+        service.post(sender, {
+          recipientPublicKey: recipient,
+          blob: base64Blob(64),
+          idempotencyKey: 'row-lock-timeout',
+        })
+      ).rejects.toBeInstanceOf(ServiceUnavailableException);
+    } finally {
+      await holder.rollbackTransaction();
+      await holder.release();
+    }
   });
 });

--- a/apps/api/src/mailbox/services/mailbox.service.ts
+++ b/apps/api/src/mailbox/services/mailbox.service.ts
@@ -11,11 +11,10 @@ import { DataSource, LessThan, QueryFailedError, Repository } from 'typeorm';
 import { User } from '../../auth/entities/user.entity';
 import { IdentityService } from '../../auth/services/identity.service';
 import {
-  acquireAdvisoryLock,
   advisoryLockKey,
+  boundedAcquire,
   resolveAdvisoryLockTimeoutMs,
   runLockGuardedTransaction,
-  setAdvisoryLockTimeout,
 } from '../../common/advisory-lock';
 import { Clock } from '../../common/clock';
 import { positiveIntConfig } from '../../common/config-int';
@@ -168,8 +167,7 @@ export class MailboxService {
    * scoped: Postgres releases it automatically on commit or rollback. The wait
    * is bounded by `lock_timeout` so sustained same-recipient contention cannot
    * fill the pool with blocked waiters (a timed-out waiter surfaces as a 503).
-   * The count-sees-committed-writer reasoning assumes READ COMMITTED (the
-   * Postgres default; not pinned here).
+   * The count-sees-committed-writer reasoning assumes READ COMMITTED.
    */
   private async enforceCapAndInsert(
     recipientPublicKey: string,
@@ -177,8 +175,11 @@ export class MailboxService {
     blob: Buffer
   ): Promise<PostMessageResult> {
     return runLockGuardedTransaction(this.dataSource, async (manager) => {
-      await setAdvisoryLockTimeout(manager, this.lockTimeoutMs);
-      await acquireAdvisoryLock(manager, this.recipientLockKey(recipientPublicKey));
+      await boundedAcquire(
+        manager,
+        [this.recipientLockKey(recipientPublicKey)],
+        this.lockTimeoutMs
+      );
       const repo = manager.getRepository(MailboxMessage);
 
       // Re-check idempotency now that we hold the lock: a same-scope writer that

--- a/apps/api/src/mailbox/services/mailbox.service.ts
+++ b/apps/api/src/mailbox/services/mailbox.service.ts
@@ -14,6 +14,7 @@ import {
   acquireAdvisoryLock,
   advisoryLockKey,
   resolveAdvisoryLockTimeoutMs,
+  runLockGuardedTransaction,
   setAdvisoryLockTimeout,
 } from '../../common/advisory-lock';
 import { Clock } from '../../common/clock';
@@ -167,13 +168,15 @@ export class MailboxService {
    * scoped: Postgres releases it automatically on commit or rollback. The wait
    * is bounded by `lock_timeout` so sustained same-recipient contention cannot
    * fill the pool with blocked waiters (a timed-out waiter surfaces as a 503).
+   * The count-sees-committed-writer reasoning assumes READ COMMITTED (the
+   * Postgres default; not pinned here).
    */
   private async enforceCapAndInsert(
     recipientPublicKey: string,
     idempotencyScope: string,
     blob: Buffer
   ): Promise<PostMessageResult> {
-    return this.dataSource.transaction(async (manager) => {
+    return runLockGuardedTransaction(this.dataSource, async (manager) => {
       await setAdvisoryLockTimeout(manager, this.lockTimeoutMs);
       await acquireAdvisoryLock(manager, this.recipientLockKey(recipientPublicKey));
       const repo = manager.getRepository(MailboxMessage);

--- a/apps/api/src/registry/pin-store.ts
+++ b/apps/api/src/registry/pin-store.ts
@@ -32,10 +32,9 @@ export abstract class PinStore {
   }
 }
 
-/** One Kubo `add` result line: `{ Name, Hash, Size }` (Size is a decimal string). */
+/** One Kubo `add` result line; only `Hash` is consumed. */
 interface KuboAddResult {
   Hash: string;
-  Size: string;
 }
 
 /**

--- a/apps/api/src/registry/services/account.service.integration.test.ts
+++ b/apps/api/src/registry/services/account.service.integration.test.ts
@@ -102,7 +102,7 @@ interface GateHooks {
    * unserialized pre-fix path. */
   stripLock?: boolean;
   /** Pause the register path after it inserts its pin row (still holding the lock). */
-  afterPinSave?: () => Promise<void>;
+  afterPinInsert?: () => Promise<void>;
   /** No-op the post-commit session advisory lock so the cascade's unpin does not
    * serialize on `pinDurabilityLockKey` — the pre-fix post-commit path. */
   stripDurabilityLock?: boolean;
@@ -129,11 +129,11 @@ function gatedDataSource(real: DataSource, hooks: GateHooks): DataSource {
   const wrapPinRepo = (repo: Repository<PinnedCid>): Repository<PinnedCid> =>
     new Proxy(repo, {
       get(target, prop, receiver) {
-        if (prop === 'save') {
-          return async (entities: never, options?: never) => {
-            const saved = await target.save(entities, options);
-            if (hooks.afterPinSave) await hooks.afterPinSave();
-            return saved;
+        if (prop === 'insert') {
+          return async (entities: never) => {
+            const result = await target.insert(entities);
+            if (hooks.afterPinInsert) await hooks.afterPinInsert();
+            return result;
           };
         }
         const value = Reflect.get(target, prop, receiver);
@@ -295,7 +295,7 @@ describe('AccountService cascade (real Postgres)', () => {
       const gate = makeGate();
       const pinStore = new RecordingPinStore();
       const registerB = registerService(
-        gatedDataSource(db.dataSource, { afterPinSave: gate.onReach }),
+        gatedDataSource(db.dataSource, { afterPinInsert: gate.onReach }),
         pinStore
       ).register(b.id, [{ ipnsName: token(), contentCids: [cid] }]);
 
@@ -335,7 +335,7 @@ describe('AccountService cascade (real Postgres)', () => {
       const gate = makeGate();
       const pinStore = new RecordingPinStore();
       const registerB = registerService(
-        gatedDataSource(db.dataSource, { stripLock: true, afterPinSave: gate.onReach }),
+        gatedDataSource(db.dataSource, { stripLock: true, afterPinInsert: gate.onReach }),
         pinStore
       ).register(b.id, [{ ipnsName: token(), contentCids: [cid] }]);
 

--- a/apps/api/src/registry/services/account.service.ts
+++ b/apps/api/src/registry/services/account.service.ts
@@ -5,12 +5,11 @@ import { DataSource, In, Repository } from 'typeorm';
 import { User } from '../../auth/entities/user.entity';
 import {
   accountLockKey,
-  acquireAdvisoryLocks,
   advisoryLockKey,
+  boundedAcquire,
   pinDurabilityLockKey,
   resolveAdvisoryLockTimeoutMs,
   runLockGuardedTransaction,
-  setAdvisoryLockTimeout,
   withSessionAdvisoryLock,
 } from '../../common/advisory-lock';
 import { MailboxMessage } from '../../mailbox/entities/mailbox-message.entity';
@@ -189,17 +188,20 @@ export class AccountService {
     chunkCids: string[]
   ): Promise<ChunkOutcome> {
     return runLockGuardedTransaction(this.dataSource, async (manager) => {
-      await setAdvisoryLockTimeout(manager, this.lockTimeoutMs);
       // The residue step (empty chunk) also takes `advisoryLockKey(publicKey)` —
       // the recipient key a mailbox POST holds across its existence re-check and
       // insert — so a post racing the mailbox purge + user delete observes the
       // committed deletion and fails closed rather than resurrecting an orphan
       // row (mailbox rows have no FK to cascade them).
-      await acquireAdvisoryLocks(manager, [
-        accountLockKey(accountId),
-        ...(chunkCids.length === 0 ? [advisoryLockKey(publicKey)] : []),
-        ...chunkCids.map(advisoryLockKey),
-      ]);
+      await boundedAcquire(
+        manager,
+        [
+          accountLockKey(accountId),
+          ...(chunkCids.length === 0 ? [advisoryLockKey(publicKey)] : []),
+          ...chunkCids.map(advisoryLockKey),
+        ],
+        this.lockTimeoutMs
+      );
 
       const locked = await manager
         .getRepository(User)

--- a/apps/api/src/registry/services/registry.service.integration.test.ts
+++ b/apps/api/src/registry/services/registry.service.integration.test.ts
@@ -91,7 +91,7 @@ interface GateHooks {
   stripSessionLock?: boolean;
   afterUserRead?: () => Promise<void>;
   afterPinFind?: () => Promise<void>;
-  afterPinSave?: () => Promise<void>;
+  afterPinInsert?: () => Promise<void>;
 }
 
 /**
@@ -126,11 +126,11 @@ function gatedDataSource(real: DataSource, hooks: GateHooks): DataSource {
             return rows;
           };
         }
-        if (prop === 'save') {
-          return async (entities: never, options?: never) => {
-            const saved = await target.save(entities, options);
-            if (hooks.afterPinSave) await hooks.afterPinSave();
-            return saved;
+        if (prop === 'insert') {
+          return async (entities: never) => {
+            const result = await target.insert(entities);
+            if (hooks.afterPinInsert) await hooks.afterPinInsert();
+            return result;
           };
         }
         const value = Reflect.get(target, prop, receiver);
@@ -326,7 +326,7 @@ describe('RegistryService concurrency (real Postgres)', () => {
       const gate = makeGate();
       const pinStore = new RecordingPinStore();
       const registerB = buildService(
-        gatedDataSource(db.dataSource, { afterPinSave: gate.onReach }),
+        gatedDataSource(db.dataSource, { afterPinInsert: gate.onReach }),
         pinStore
       ).register(b, [{ ipnsName: token(), contentCids: [cid] }]);
 
@@ -371,7 +371,7 @@ describe('RegistryService concurrency (real Postgres)', () => {
       const pinStore = new RecordingPinStore();
       // Both paths skip the advisory lock (the pre-#677 code path).
       const registerB = buildService(
-        gatedDataSource(db.dataSource, { stripLock: true, afterPinSave: gate.onReach }),
+        gatedDataSource(db.dataSource, { stripLock: true, afterPinInsert: gate.onReach }),
         pinStore
       ).register(b, [{ ipnsName: token(), contentCids: [cid] }]);
 

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -4,12 +4,11 @@ import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { DataSource, EntityManager, In, Repository } from 'typeorm';
 import { User } from '../../auth/entities/user.entity';
 import {
-  acquireAdvisoryLocks,
   advisoryLockKey,
+  boundedAcquire,
   pinDurabilityLockKey,
   resolveAdvisoryLockTimeoutMs,
   runLockGuardedTransaction,
-  setAdvisoryLockTimeout,
   withSessionAdvisoryLock,
 } from '../../common/advisory-lock';
 import { NameInventory } from '../entities/name-inventory.entity';
@@ -31,8 +30,7 @@ async function lockTokens(
   tokens: string[],
   timeoutMs: number
 ): Promise<void> {
-  await setAdvisoryLockTimeout(manager, timeoutMs);
-  await acquireAdvisoryLocks(manager, tokens.map(advisoryLockKey));
+  await boundedAcquire(manager, tokens.map(advisoryLockKey), timeoutMs);
 }
 
 export interface RegisterEntry {
@@ -172,11 +170,12 @@ export class RegistryService {
           : [];
         const knownCids = new Set(existingPins.map((row) => row.cid));
         // Idempotent: a CID already counted keeps its size and advisory origin.
+        // All-new rows, so one multi-row INSERT instead of per-row saves.
         const pinWrites = cidOrder
           .filter((cid) => !knownCids.has(cid))
           .map((cid) => ({ accountId, cid, size: '0', advisory }));
         if (pinWrites.length) {
-          await pinRepo.save(pinWrites);
+          await pinRepo.insert(pinWrites);
         }
       });
     }
@@ -211,9 +210,7 @@ export class RegistryService {
 
         const held = await pinRepo.find({ where: { accountId, cid: In(targets) } });
         const heldByCaller = new Set(held.map((row) => row.cid));
-        const heldCids = targets.filter(
-          (target, index) => targets.indexOf(target) === index && heldByCaller.has(target)
-        );
+        const heldCids = [...new Set(targets)].filter((target) => heldByCaller.has(target));
 
         const nameDeleted = await nameRepo.delete({ accountId, ipnsName: In(targets) });
         const pinDeleted = await pinRepo.delete({ accountId, cid: In(targets) });

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -169,8 +169,8 @@ export class RegistryService {
           ? await pinRepo.find({ where: { accountId, cid: In(cidOrder) } })
           : [];
         const knownCids = new Set(existingPins.map((row) => row.cid));
-        // Idempotent: a CID already counted keeps its size and advisory origin.
-        // All-new rows, so one multi-row INSERT instead of per-row saves.
+        // Idempotent: a CID already counted keeps its size and advisory origin;
+        // the rest are all-new, so one multi-row insert.
         const pinWrites = cidOrder
           .filter((cid) => !knownCids.has(cid))
           .map((cid) => ({ accountId, cid, size: '0', advisory }));

--- a/apps/api/src/testing/fake-repo.ts
+++ b/apps/api/src/testing/fake-repo.ts
@@ -77,6 +77,16 @@ export class FakeRepository<T extends { id: string }> {
     return row;
   }
 
+  async insert(partials: Partial<T> | Partial<T>[]): Promise<void> {
+    for (const partial of Array.isArray(partials) ? partials : [partials]) {
+      this.rows.push({
+        createdAt: new Date(),
+        ...partial,
+        id: partial.id ?? randomUUID(),
+      } as unknown as T);
+    }
+  }
+
   async update(criteria: Where, patch: Partial<T>): Promise<{ affected: number }> {
     let affected = 0;
     for (const row of this.rows) {

--- a/apps/api/src/testing/fake-repo.ts
+++ b/apps/api/src/testing/fake-repo.ts
@@ -20,11 +20,19 @@ function matches(row: Record<string, unknown>, where: Where): boolean {
 }
 
 /**
- * In-memory stand-in for the narrow TypeORM Repository surface the auth
- * services use (findOne/save/update/delete with plain equality + IsNull).
+ * In-memory stand-in for the narrow TypeORM Repository surface the API
+ * services use (findOne/save/insert/update/delete with plain equality + IsNull).
  */
 export class FakeRepository<T extends { id: string }> {
   rows: T[] = [];
+
+  private makeRow(partial: Partial<T>): T {
+    return {
+      createdAt: new Date(),
+      ...partial,
+      id: partial.id ?? randomUUID(),
+    } as unknown as T;
+  }
 
   async findOne(options: { where: Where }): Promise<T | null> {
     return this.rows.find((row) => matches(row as Record<string, unknown>, options.where)) ?? null;
@@ -68,22 +76,14 @@ export class FakeRepository<T extends { id: string }> {
         return existing;
       }
     }
-    const row = {
-      createdAt: new Date(),
-      ...partial,
-      id: partial.id ?? randomUUID(),
-    } as unknown as T;
+    const row = this.makeRow(partial);
     this.rows.push(row);
     return row;
   }
 
   async insert(partials: Partial<T> | Partial<T>[]): Promise<void> {
     for (const partial of Array.isArray(partials) ? partials : [partials]) {
-      this.rows.push({
-        createdAt: new Date(),
-        ...partial,
-        id: partial.id ?? randomUUID(),
-      } as unknown as T);
+      this.rows.push(this.makeRow(partial));
     }
   }
 


### PR DESCRIPTION
Implements the still-live API items of the retro-audit backlog — items 3–5 of the "API — concurrency helpers" section. Items 1 (registry lock dedup) is already done on `main`; item 2 (namespacing the mailbox recipient lock key) is deliberately **not** done: the key must stay the bare `advisoryLockKey(publicKey)` so the account hard-delete cascade's resurrection guard (#707) keeps serializing against concurrent mailbox posts on the same key.

## Changes

- **Mailbox cap-insert contention → 503, not 500.** `enforceCapAndInsert` now runs under `runLockGuardedTransaction`: a row-lock `lock_timeout` abort (55P03) inside the purge → count → cap-check → insert window (e.g. its purge DELETE vs a concurrent poll) previously escaped `post()`'s dedup catch as a raw `QueryFailedError` → 500. The unique-index 23505 dedup path is unchanged. Added a real-Postgres regression test (verified it fails on the pre-fix code) and a one-line note of the READ COMMITTED dependency.
- **Registry write efficiency.** `register` inserts its all-new pin rows with one multi-row `pinRepo.insert` instead of per-row saves under held locks; `retire` replaces the O(n²) `indexOf` dedup with a `Set`. `nameRepo.save` stays (mixed insert+update upsert).
- **Shared `boundedAcquire` helper.** The `setAdvisoryLockTimeout` + `acquireAdvisoryLocks` pairing is hoisted into `common/advisory-lock.ts` and used at its three call sites (registry `lockTokens`, content `registerPin`/`compensate`).
- **Dead surface dropped.** `RegisterOutcome.cid` (always the input CID) and `KuboAddResult.Size` (unread) removed — both file-local, no external consumers. Trimmed the session-lock invariant restatement in `upload()` to a class-doc cross-reference.
- Test support: `FakeRepository.insert`, and the two register-pause gate harnesses now hook `insert` instead of `save`.

Part of #719

## Testing

- `apps/api` unit suite: 155 passed.
- Integration suite (real Postgres): 128 passed, including the new 55P03→503 mailbox regression test with a negative control (fails when the fix is reverted).
