### PR TITLE
feat: project a facade snapshot and download read surface for the web client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,9 +687,9 @@ dependencies = [
 name = "cipherbox-wasm"
 version = "0.0.0"
 dependencies = [
+ "async-lock",
  "cipherbox-engine",
  "console_error_panic_hook",
- "futures-util",
  "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",

--- a/crates/core/src/seal/envelope.rs
+++ b/crates/core/src/seal/envelope.rs
@@ -85,6 +85,13 @@ pub fn grant_section_bytes(env: &Envelope) -> Option<&[u8]> {
         .and_then(|(_, value)| value.as_bytes().ok())
 }
 
+/// Whether the envelope carries a `grantSection` key at all, regardless of its
+/// value — the scope-root marker (a child envelope must carry none). Stricter
+/// than [`grant_section_bytes`], which also requires a byte-string value.
+pub fn has_grant_section(env: &Envelope) -> bool {
+    env.unknown.iter().any(|(key, _)| key == "grantSection")
+}
+
 /// Encode an envelope to its canonical det-CBOR plaintext.
 pub fn encode_envelope(env: &Envelope) -> Vec<u8> {
     let mut epoch_tag = Map::new();
@@ -288,6 +295,26 @@ mod tests {
             None,
             "a non-bytes grantSection is not returned"
         );
+    }
+
+    #[test]
+    fn has_grant_section_detects_the_raw_key_regardless_of_value() {
+        let key = [3u8; KEY_LEN];
+        let nonce = [4u8; NONCE_LEN];
+        let mut env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &folder()).unwrap();
+        assert!(!has_grant_section(&env), "absent without the field");
+
+        // A non-bytes value still marks the key present (stricter than
+        // grant_section_bytes, which requires a byte string).
+        env.unknown
+            .push(("grantSection".to_string(), Value::Unsigned(7)));
+        assert!(has_grant_section(&env));
+        assert_eq!(grant_section_bytes(&env), None);
+
+        let mut env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &folder()).unwrap();
+        env.unknown
+            .push(("grantSection".to_string(), Value::Bytes(b"s".to_vec())));
+        assert!(has_grant_section(&env));
     }
 
     #[test]

--- a/crates/core/src/seal/mod.rs
+++ b/crates/core/src/seal/mod.rs
@@ -30,7 +30,8 @@ pub use body::{
     ChildRef, NodeKind, ReadBody, Version, decode_read_body, encode_read_body, name_cmp,
 };
 pub use envelope::{
-    Envelope, decode_envelope, encode_envelope, grant_section_bytes, open_read_body, seal_read_body,
+    Envelope, decode_envelope, encode_envelope, grant_section_bytes, has_grant_section,
+    open_read_body, seal_read_body,
 };
 pub use grant::{
     AscentLink, GrantBlobPayload, GrantSetCommitment, GrantSetEntry, HistoryLinkPayload,

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -36,7 +36,11 @@ pub use read::{
 };
 pub use retention::{ContentVersion, PrunePlan, QuotaExceeded, plan_prune, pre_flight_quota_check};
 
+use cipherbox_core::content::{encode_content_cid_str, open_chunk};
+use cipherbox_core::seal::Version;
+
 use crate::entropy::{Entropy, EntropyError};
+use crate::seams::Http;
 
 /// A fully sealed content version, ready to pin and register: the version's
 /// `contentCid`, the DAG root block it addresses, and every sealed leaf block.
@@ -94,11 +98,86 @@ pub fn seal_content(
     })
 }
 
+/// Why a verified content read failed — the read dual of [`SealError`]. The
+/// classification is fail-closed: a CID, manifest, or unseal disagreement is
+/// trust; no reachable source or an over-cap block is availability.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpenError {
+    /// A fail-closed trust violation; the message names the check, never key
+    /// material.
+    Trust(String),
+    /// Availability — retryable, never a trust verdict.
+    Unavailable(String),
+}
+
+/// Map a content-block read failure onto the [`OpenError`] classification.
+fn open_read_error(e: ReadError) -> OpenError {
+    match e {
+        ReadError::TrustViolation(e) => {
+            OpenError::Trust(format!("content block rejected: [{}]", e.check()))
+        }
+        ReadError::Unavailable => OpenError::Unavailable("content block unavailable".to_owned()),
+        ReadError::TooLarge { size, limit } => {
+            OpenError::Unavailable(format!("content block exceeds the cap ({size} > {limit})"))
+        }
+    }
+}
+
+/// Fetch, verify, and reassemble one content version's plaintext — the read
+/// dual of [`seal_content`]: DAG root fetch (CID-verified fail-closed) →
+/// manifest-vs-version size cross-check → per-leaf CID-verified fetch + unseal
+/// under the version content key → reassembled-length cross-check.
+pub async fn open_content<H: Http>(
+    gateway: &Gateway,
+    http: &H,
+    version: &Version,
+) -> Result<Vec<u8>, OpenError> {
+    let root_cid_str = encode_content_cid_str(&version.content_cid);
+    let root_block = read_block(
+        gateway,
+        http,
+        &root_cid_str,
+        &version.content_cid,
+        ContentPlane::Root,
+    )
+    .await
+    .map_err(open_read_error)?;
+    let manifest = decode_root(&root_block)
+        .map_err(|e| OpenError::Trust(format!("content DAG root rejected: {e:?}")))?;
+    if manifest.size != version.size {
+        return Err(OpenError::Trust(format!(
+            "manifest size {} disagrees with version size {}",
+            manifest.size, version.size
+        )));
+    }
+
+    // The capacity is safe to trust: the manifest size was just cross-checked
+    // against the sealed version's.
+    let mut plaintext = Vec::with_capacity(manifest.size as usize);
+    for leaf_cid in &manifest.leaf_cids {
+        let leaf_cid_str = encode_content_cid_str(leaf_cid);
+        let sealed = read_block(gateway, http, &leaf_cid_str, leaf_cid, ContentPlane::Leaf)
+            .await
+            .map_err(open_read_error)?;
+        let chunk = open_chunk(version.content_key(), &sealed)
+            .map_err(|e| OpenError::Trust(format!("leaf unseal rejected: [{}]", e.check())))?;
+        plaintext.extend_from_slice(&chunk);
+    }
+    if plaintext.len() as u64 != manifest.size {
+        return Err(OpenError::Trust(format!(
+            "reassembled length {} disagrees with manifest size {}",
+            plaintext.len(),
+            manifest.size
+        )));
+    }
+    Ok(plaintext)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::testkit::SeededEntropy;
-    use cipherbox_core::content::{open_chunk, verify_cid};
+    use cipherbox_core::content::verify_cid;
     use cipherbox_core::suite::aead::KEY_LEN;
 
     #[test]

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -151,9 +151,12 @@ pub async fn open_content<H: Http>(
         )));
     }
 
-    // The capacity is safe to trust: the manifest size was just cross-checked
-    // against the sealed version's.
-    let mut plaintext = Vec::with_capacity(manifest.size as usize);
+    // Preallocate up to a fixed budget, then grow as leaves arrive: the size is
+    // authenticated but unproven until every leaf is fetched, so a large size
+    // field must not commit an outsized allocation upfront (on wasm32 it would
+    // also truncate). The reassembled-length cross-check below is the gate.
+    let prealloc = manifest.size.min(limits::MAX_RESOLVED_RECORD_BYTES as u64) as usize;
+    let mut plaintext = Vec::with_capacity(prealloc);
     for leaf_cid in &manifest.leaf_cids {
         let leaf_cid_str = encode_content_cid_str(leaf_cid);
         let sealed = read_block(gateway, http, &leaf_cid_str, leaf_cid, ContentPlane::Leaf)

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -1443,12 +1443,14 @@ impl<T: SeamTypes> Engine<T> {
         // slice). A clone of the seed keeps the cell borrow from spanning the
         // awaits below; the clone zeroizes when the adopter drops.
         let scope_id = self.snapshot.borrow().root.0;
+        // No untrusted input was judged here — a missing seed is missing held
+        // material (availability), never a trust verdict.
         let scope_read_seed = self
             .scope_read_seeds
             .borrow()
             .get(&scope_id)
             .cloned()
-            .ok_or_else(|| EngineError::TrustViolation {
+            .ok_or_else(|| EngineError::ContentUnavailable {
                 message: "no read seed held for the node's scope".to_owned(),
             })?;
         let adopter = ChildAdopter::new(
@@ -3257,6 +3259,8 @@ mod tests {
             use crate::content::{
                 ContentDag, ContentKey, ContentProfile, SealedChunk, assemble, frame_and_seal,
             };
+            use crate::gate::floor;
+            use crate::seams::SnapshotCache;
 
             const CONTENT_KEY: [u8; 32] = [0x99; 32];
             const CHILD_MTIME: u64 = 777;
@@ -3281,25 +3285,30 @@ mod tests {
                 Version::new(dag.content_cid.clone(), CONTENT_KEY, size, CHILD_MTIME)
             }
 
-            /// A child file head block sealed under the node's derived read key.
-            /// The knobs drive the fail-closed tests: the envelope id
-            /// (transplant), the version list (empty / size-lying), and a
-            /// bolted-on grant section.
-            fn child_head(
-                envelope_id: [u8; 16],
-                versions: Vec<Version>,
-                with_grant_section: bool,
-            ) -> (Vec<u8>, String) {
-                let node_seed = kdf::node_seed(&SCOPE_SEED, &envelope_id);
-                let read_key = *kdf::read_key(node_seed.as_bytes()).as_bytes();
-                let body = ReadBody::File {
+            fn file_body(versions: Vec<Version>) -> ReadBody {
+                ReadBody::File {
                     created_at: 0,
                     modified_at: CHILD_MTIME,
                     versions,
                     unknown: Vec::new(),
-                };
+                }
+            }
+
+            /// A child head block sealed under the node's derived read key. The
+            /// knobs drive the fail-closed tests: the envelope id/scope/epoch
+            /// (transplants, epoch inflation), the body (kind transplant, empty
+            /// / size-lying version list), and a bolted-on grant section.
+            fn sealed_child_head(
+                envelope_id: [u8; 16],
+                scope: [u8; 16],
+                epoch: u64,
+                body: &ReadBody,
+                with_grant_section: bool,
+            ) -> (Vec<u8>, String) {
+                let node_seed = kdf::node_seed(&SCOPE_SEED, &envelope_id);
+                let read_key = *kdf::read_key(node_seed.as_bytes()).as_bytes();
                 let mut envelope =
-                    seal_read_body(&read_key, &[13u8; 24], 1, envelope_id, SCOPE, EPOCH, &body)
+                    seal_read_body(&read_key, &[13u8; 24], 1, envelope_id, scope, epoch, body)
                         .unwrap();
                 if with_grant_section {
                     envelope
@@ -3311,15 +3320,32 @@ mod tests {
                 (head_block, cid)
             }
 
-            /// Seed the child record (signed by the child's own write-plane
-            /// signer) at every endpoint.
-            fn seed_child_record(device: &FakeDevice, head_cid_str: &str, sequence: u64) {
+            /// A child file head block at the fixture scope/epoch.
+            fn child_head(
+                envelope_id: [u8; 16],
+                versions: Vec<Version>,
+                with_grant_section: bool,
+            ) -> (Vec<u8>, String) {
+                sealed_child_head(
+                    envelope_id,
+                    SCOPE,
+                    EPOCH,
+                    &file_body(versions),
+                    with_grant_section,
+                )
+            }
+
+            /// The child record, signed by the child's own write-plane signer.
+            fn child_record(head_cid_str: &str, sequence: u64) -> Vec<u8> {
                 let write_seed = kdf::write_seed(&WRITE_SCOPE_SEED, &CHILD_ID);
                 let signer = kdf::ipns_keypair(write_seed.as_bytes());
                 let value = format!("/ipfs/{head_cid_str}");
-                let record =
-                    IpnsRecord::create_v2(&signer, value.as_bytes(), sequence, TTL_NANOS, EOL)
-                        .marshal();
+                IpnsRecord::create_v2(&signer, value.as_bytes(), sequence, TTL_NANOS, EOL).marshal()
+            }
+
+            /// Seed the child record at every endpoint.
+            fn seed_child_record(device: &FakeDevice, head_cid_str: &str, sequence: u64) {
+                let record = child_record(head_cid_str, sequence);
                 for endpoint in device.record_store.endpoints() {
                     device.record_store.seed_record(
                         &endpoint,
@@ -3647,6 +3673,212 @@ mod tests {
                 assert!(
                     matches!(err, EngineError::ContentUnavailable { .. }),
                     "an unreachable gateway is availability: {err:?}"
+                );
+            }
+
+            #[test]
+            fn an_inflated_child_epoch_cannot_poison_the_scope_epoch_floor() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (engine, _events) = started(&device);
+
+                // A write-capable party seals the child claiming a far-future
+                // epoch (the read key does not bind epoch, so it unseals fine).
+                let (leaves, dag) = content_dag(PLAINTEXT);
+                let (head_block, head_cid) = sealed_child_head(
+                    CHILD_ID,
+                    SCOPE,
+                    EPOCH + 1000,
+                    &file_body(vec![head_version(&dag, PLAINTEXT.len() as u64)]),
+                    false,
+                );
+                seed_child_record(&device, &head_cid, 1);
+                enqueue_download(&device, &head_block, &dag, &leaves);
+                assert_eq!(
+                    block_on(engine.read_content(NodeId(CHILD_ID))).unwrap(),
+                    PLAINTEXT,
+                    "the inflated-epoch child still reads"
+                );
+
+                // The child's sequence floor advanced...
+                assert_eq!(
+                    block_on(floor::sequence_floor(
+                        &device.floor_store,
+                        child_name().as_str().as_bytes(),
+                    ))
+                    .unwrap(),
+                    Some(1),
+                );
+                // ...but the scope read-epoch floor did not move: it advances
+                // only from gate-adopted roots.
+                assert_eq!(
+                    block_on(floor::read_epoch_floor(&device.floor_store, &SCOPE)).unwrap(),
+                    Some(EPOCH),
+                    "a child unseal must not raise the scope read-epoch floor"
+                );
+
+                // A subsequent honest root at the real epoch still adopts — the
+                // child could not poison the root path into EpochBelowFloor.
+                let (root_head_block, root_head_cid, root_name) = owner_root();
+                for endpoint in device.record_store.endpoints() {
+                    device.record_store.seed_record(
+                        &endpoint,
+                        root_name.as_str(),
+                        root_record(&root_head_cid, 2),
+                    );
+                }
+                device
+                    .http
+                    .enqueue_response(head_response(&root_head_block));
+                let mut tasks = world.scheduler.take_spawned_tasks();
+                poll_each(&mut tasks); // park each loop at its first sleep
+                world.scheduler.advance(engine.profile().poll_cadence);
+                poll_each(&mut tasks); // the resolve tick runs one pass
+                assert_eq!(
+                    block_on(floor::sequence_floor(
+                        &device.floor_store,
+                        root_name.as_str().as_bytes(),
+                    ))
+                    .unwrap(),
+                    Some(2),
+                    "the honest root adopted at the real epoch"
+                );
+            }
+
+            #[test]
+            fn at_floor_reopen_rejects_a_cached_record_above_the_floor() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (engine, _events) = started(&device);
+
+                // A cached child record at sequence 2 while this device's
+                // per-name floor never advanced (no prior adopt): the at-floor
+                // re-open admits only the exact floor.
+                let (_leaves, dag) = content_dag(PLAINTEXT);
+                let (head_block, head_cid) = child_head(
+                    CHILD_ID,
+                    vec![head_version(&dag, PLAINTEXT.len() as u64)],
+                    false,
+                );
+                block_on(device.snapshot_cache.put(
+                    child_name().as_str().as_bytes(),
+                    &child_record(&head_cid, 2),
+                ))
+                .unwrap();
+                for endpoint in device.record_store.endpoints() {
+                    device.record_store.fail_endpoint(&endpoint);
+                }
+                device.http.enqueue_response(head_response(&head_block));
+
+                let err = block_on(engine.read_content(NodeId(CHILD_ID))).unwrap_err();
+                match &err {
+                    EngineError::TrustViolation { message } => assert!(
+                        message.contains("sequence-not-newer"),
+                        "an above-floor re-open is a sequence rejection: {message}"
+                    ),
+                    other => panic!("an above-floor re-open must reject fail-closed: {other:?}"),
+                }
+            }
+
+            #[test]
+            fn a_scope_transplanted_child_envelope_rejects_fail_closed() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (engine, _events) = started(&device);
+
+                // The envelope carries the expected node id but a FOREIGN scope,
+                // sealed consistently (AAD scope == envelope scope, and the read
+                // key binds no scope) — only the explicit scope check can fire.
+                let (_leaves, dag) = content_dag(PLAINTEXT);
+                let (head_block, head_cid) = sealed_child_head(
+                    CHILD_ID,
+                    [0xAB; 16],
+                    EPOCH,
+                    &file_body(vec![head_version(&dag, PLAINTEXT.len() as u64)]),
+                    false,
+                );
+                seed_child_record(&device, &head_cid, 1);
+                device.http.enqueue_response(head_response(&head_block));
+
+                let err = block_on(engine.read_content(NodeId(CHILD_ID))).unwrap_err();
+                assert!(
+                    matches!(err, EngineError::TrustViolation { .. }),
+                    "a scope transplant rejects fail-closed: {err:?}"
+                );
+            }
+
+            #[test]
+            fn a_kind_transplanted_child_body_rejects_fail_closed() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (engine, _events) = started(&device);
+
+                // A sealed FOLDER body at a node the parent lists as a file.
+                let folder_body = ReadBody::Folder {
+                    created_at: 0,
+                    modified_at: 0,
+                    children: Vec::new(),
+                    unknown: Vec::new(),
+                };
+                let (head_block, head_cid) =
+                    sealed_child_head(CHILD_ID, SCOPE, EPOCH, &folder_body, false);
+                seed_child_record(&device, &head_cid, 1);
+                device.http.enqueue_response(head_response(&head_block));
+
+                let err = block_on(engine.read_content(NodeId(CHILD_ID))).unwrap_err();
+                match &err {
+                    EngineError::TrustViolation { message } => assert!(
+                        message.contains("kind disagrees"),
+                        "the rejection names the kind transplant: {message}"
+                    ),
+                    other => panic!("a kind transplant must reject fail-closed: {other:?}"),
+                }
+            }
+
+            #[test]
+            fn no_update_serves_the_cached_record_without_moving_floors() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (engine, _events) = started(&device);
+
+                let (leaves, dag) = content_dag(PLAINTEXT);
+                let (head_block, head_cid) = child_head(
+                    CHILD_ID,
+                    vec![head_version(&dag, PLAINTEXT.len() as u64)],
+                    false,
+                );
+                seed_child_record(&device, &head_cid, 1);
+                enqueue_download(&device, &head_block, &dag, &leaves);
+                assert_eq!(
+                    block_on(engine.read_content(NodeId(CHILD_ID))).unwrap(),
+                    PLAINTEXT,
+                    "the adopt seeds the cache and floors"
+                );
+
+                // Every record source unreachable: NoUpdate falls back to the
+                // cached last-known-good, re-opened at the floor.
+                for endpoint in device.record_store.endpoints() {
+                    device.record_store.fail_endpoint(&endpoint);
+                }
+                enqueue_download(&device, &head_block, &dag, &leaves);
+                assert_eq!(
+                    block_on(engine.read_content(NodeId(CHILD_ID))).unwrap(),
+                    PLAINTEXT,
+                    "the cached record serves the exact plaintext"
+                );
+                assert_eq!(
+                    block_on(floor::sequence_floor(
+                        &device.floor_store,
+                        child_name().as_str().as_bytes(),
+                    ))
+                    .unwrap(),
+                    Some(1),
+                    "the at-floor re-open advanced no sequence floor"
+                );
+                assert_eq!(
+                    block_on(floor::read_epoch_floor(&device.floor_store, &SCOPE)).unwrap(),
+                    Some(EPOCH),
+                    "the at-floor re-open advanced no epoch floor"
                 );
             }
         }

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -23,25 +23,31 @@ use core::pin::Pin;
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
+use cipherbox_core::content::{encode_content_cid_str, open_chunk};
 use cipherbox_core::ipns::IpnsName;
+use cipherbox_core::seal::ReadBody;
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
 use futures_channel::mpsc;
 use futures_core::Stream;
 use zeroize::Zeroizing;
 
 use crate::api::{ApiClient, ApiError, IdentityChallengeSigner};
-use crate::content::{Gateway, GatewayConfig};
+use crate::content::{ContentPlane, Gateway, GatewayConfig, ReadError, decode_root, read_block};
 use crate::entropy::Entropy;
+use crate::gate::GateError;
 use crate::hex::hex_lower;
 use crate::net::{
-    Adopter, EolRenewResult, HeldMaterial, HeldRecord, HeldRecords, LivenessControl, PublishError,
-    PublishOutcome, RE_PUT_INTERVAL, RecordPointerFetch, ResolveOutcome, RootAdopter,
-    eol_renew_pass, keyless_re_put, refresh_base_from_outcome, resolve_and_hold, run_liveness_loop,
+    Adopter, ChildAdopter, EolRenewResult, HeldMaterial, HeldRecord, HeldRecords, LivenessControl,
+    PublishError, PublishOutcome, RE_PUT_INTERVAL, RecordPointerFetch, ResolveOutcome, RootAdopter,
+    eol_renew_pass, keyless_re_put, refresh_base_from_outcome, resolve, resolve_and_hold,
+    run_liveness_loop,
 };
 use crate::profile::SyncTimingProfile;
 use crate::seams::{OpId, Scheduler, SeamError, SeamSet, SeamTypes, StagingStore, UnixMillis};
 use crate::session::SessionIdentity;
-use crate::sync::boot::{ColdStartError, ColdStartOutcome, ColdStartParams, cold_start};
+use crate::sync::boot::{
+    ColdStartError, ColdStartOutcome, ColdStartParams, ColdStartSinks, cold_start,
+};
 use crate::sync::model::{NodeMeta, Snapshot, collation_key};
 use crate::sync::op::Op;
 use crate::sync::overlay::apply_overlay;
@@ -453,6 +459,22 @@ pub enum EngineError {
     UnknownNode,
     /// A folder read named a file node.
     NotAFolder,
+    /// A content read named a folder node.
+    NotAFile,
+    /// The content plane could not serve the read — an unpublished pending
+    /// node, no reachable source, or an over-cap block. Availability,
+    /// retryable; never a trust verdict.
+    ContentUnavailable {
+        /// Diagnostic message; never carries key material.
+        message: String,
+    },
+    /// A fail-closed trust violation on the read path — a rejected child
+    /// record, or a CID/manifest/unseal disagreement. Never retried, never
+    /// rendered (rule 6).
+    TrustViolation {
+        /// The verdict classification; never carries key material.
+        message: String,
+    },
     /// The command's pipeline slice has not landed yet (scaffold state).
     Unimplemented {
         /// [`Command::name`] of the rejected command.
@@ -503,6 +525,35 @@ impl EngineError {
         }
     }
 
+    /// Map a child-pipeline gate error: a rejection is a fail-closed trust
+    /// verdict; a seam failure is availability.
+    fn from_gate(err: GateError) -> Self {
+        match err {
+            GateError::Rejected(rejection) => EngineError::TrustViolation {
+                message: rejection.to_string(),
+            },
+            GateError::Seam(seam) => EngineError::ContentUnavailable {
+                message: seam.message().to_owned(),
+            },
+        }
+    }
+
+    /// Map a content-block read failure: a CID mismatch is a fail-closed trust
+    /// verdict; no source or an over-cap body is availability.
+    fn from_read(err: ReadError) -> Self {
+        match err {
+            ReadError::TrustViolation(e) => EngineError::TrustViolation {
+                message: format!("content block rejected: [{}]", e.check()),
+            },
+            ReadError::Unavailable => EngineError::ContentUnavailable {
+                message: "content block unavailable".to_owned(),
+            },
+            ReadError::TooLarge { size, limit } => EngineError::ContentUnavailable {
+                message: format!("content block exceeds the cap ({size} > {limit})"),
+            },
+        }
+    }
+
     /// Map a cold-start failure onto the facade error: every trust arm (forged
     /// pointer, regressed floor, rejected root) collapses to the single
     /// fail-closed [`ColdStart`](EngineError::ColdStart) — never retryable
@@ -528,6 +579,11 @@ impl fmt::Display for EngineError {
             }
             EngineError::UnknownNode => f.write_str("unknown node"),
             EngineError::NotAFolder => f.write_str("not a folder"),
+            EngineError::NotAFile => f.write_str("not a file"),
+            EngineError::ContentUnavailable { message } => {
+                write!(f, "content unavailable: {message}")
+            }
+            EngineError::TrustViolation { message } => write!(f, "trust violation: {message}"),
             EngineError::Unimplemented { command } => {
                 write!(f, "command not implemented yet: {command}")
             }
@@ -670,6 +726,10 @@ struct SyncStatus {
     reported: Option<Staleness>,
 }
 
+/// The engine's in-memory per-scope read-seed cell: scope id → the recovered
+/// scope read seed (zeroized on removal/drop).
+type ScopeReadSeeds = BTreeMap<[u8; 16], Zeroizing<[u8; 32]>>;
+
 /// The re-point pointer-payload wire version the owner's own vault seals under
 /// and the cold-start walk verifies against (`crates/core` pointer payload) — the
 /// sole v2 version (CONTEXT.md "Vault pointer").
@@ -715,6 +775,11 @@ pub struct Engine<T: SeamTypes> {
     /// successes and reports rung changes; [`snapshot`](Self::snapshot)
     /// classifies at read time off the same cell.
     sync_status: Rc<RefCell<SyncStatus>>,
+    /// Per-scope read seeds recovered by gate-passing adopts (the owner-blob
+    /// override seed), keyed by scope id. In-memory only — never persisted,
+    /// never crossing the facade (security rules 1/3); the child read pipeline
+    /// derives per-node read keys from them (`node-seed` → `read-key`).
+    scope_read_seeds: Rc<RefCell<ScopeReadSeeds>>,
     /// Retained dead-lettered ops, mapped to the target node when known
     /// (`None` for an undecodable queue entry). Feeds [`SnapshotView`]'s
     /// dead-letter surface (#33 D6: dead letters are retained, never silent).
@@ -759,6 +824,7 @@ impl<T: SeamTypes> Engine<T> {
                 snapshot: Rc::new(RefCell::new(Snapshot::new(NodeId([0u8; 16])))),
                 held_records: Rc::new(RefCell::new(HeldRecords::new())),
                 sync_status: Rc::new(RefCell::new(SyncStatus::default())),
+                scope_read_seeds: Rc::new(RefCell::new(BTreeMap::new())),
                 dead_letters: Rc::new(RefCell::new(BTreeMap::new())),
                 alive: Rc::new(Cell::new(true)),
                 session: None,
@@ -983,6 +1049,16 @@ impl<T: SeamTypes> Engine<T> {
         let mut emit = |event: Event| {
             let _ = events.unbounded_send(event);
         };
+        // A gate-passing root adopt surfaces the scope read seed; deposit it in
+        // the in-memory per-scope cell the child read pipeline derives from.
+        let seeds = self.scope_read_seeds.clone();
+        let mut deposit_read_seed = |seed: Zeroizing<[u8; 32]>| {
+            seeds.borrow_mut().insert(root_scope_id, seed);
+        };
+        let mut sinks = ColdStartSinks {
+            emit: &mut emit,
+            deposit_read_seed: &mut deposit_read_seed,
+        };
         cold_start(
             pointer_fetch,
             adopter,
@@ -990,7 +1066,7 @@ impl<T: SeamTypes> Engine<T> {
             &self.seams.record_transport,
             &self.seams.snapshot_cache,
             &params,
-            &mut emit,
+            &mut sinks,
         )
         .await
     }
@@ -1072,6 +1148,7 @@ impl<T: SeamTypes> Engine<T> {
         let events = self.events.clone();
         let alive = self.alive.clone();
         let sync_status = self.sync_status.clone();
+        let scope_read_seeds = self.scope_read_seeds.clone();
         let profile = self.profile;
         let interval = self.profile.poll_cadence;
         let owner_identity = session.owner_identity();
@@ -1117,7 +1194,15 @@ impl<T: SeamTypes> Engine<T> {
                     &held,
                     &material,
                 )
-                .await;
+                .await
+                .map(|(resolved, read_scope_seed)| {
+                    // A gate-passing adopt re-surfaces the scope read seed:
+                    // refresh the in-memory per-scope cell.
+                    if let Some(seed) = read_scope_seed {
+                        scope_read_seeds.borrow_mut().insert(root_id, seed);
+                    }
+                    resolved
+                });
                 if let Ok(resolved) = &resolved {
                     if refresh_base_from_outcome(&base, NodeId(root_id), &resolved.outcome) {
                         let _ = events.unbounded_send(Event::SnapshotUpdated);
@@ -1298,6 +1383,197 @@ impl<T: SeamTypes> Engine<T> {
             dead_letters,
             staleness,
         })
+    }
+
+    /// Read one file node's full plaintext content (blueprint/engine.md
+    /// "Content plane": verified reads). Resolves the child record cache-first
+    /// through the [`ChildAdopter`] pipeline, fetches the head version's DAG
+    /// (root manifest + leaves) CID-verified fail-closed, unseals each leaf
+    /// under the version content key, and reassembles the plaintext with
+    /// length cross-checks. Emits [`Event::OpProgress`] on entry, success, and
+    /// failure; on success folds the head version's size/mtime into the base
+    /// snapshot and emits [`Event::SnapshotUpdated`].
+    pub async fn read_content(&self, node: NodeId) -> Result<Vec<u8>, EngineError> {
+        if !self.started {
+            return Err(EngineError::NotStarted);
+        }
+        self.emit_op_progress(node, OpPhase::DownloadStarted, None);
+        match self.read_content_inner(node).await {
+            Ok((plaintext, size, modified_at)) => {
+                // The verified head version is gate-passing state, so it may
+                // legally touch the base node's projected size/mtime.
+                if let Some(meta) = self.snapshot.borrow_mut().node_mut(node) {
+                    meta.size = Some(size);
+                    meta.mtime = Some(modified_at);
+                }
+                let _ = self.events.unbounded_send(Event::SnapshotUpdated);
+                self.emit_op_progress(node, OpPhase::DownloadCompleted, None);
+                Ok(plaintext)
+            }
+            Err(err) => {
+                self.emit_op_progress(node, OpPhase::DownloadFailed, Some(err.to_string()));
+                Err(err)
+            }
+        }
+    }
+
+    /// The verified read pipeline behind [`read_content`](Self::read_content):
+    /// rendered-view lookup → gated child resolve → version-DAG fetch and
+    /// per-leaf unseal → length cross-checks. Returns the plaintext plus the
+    /// head version's `(size, modifiedAt)`.
+    async fn read_content_inner(&self, node: NodeId) -> Result<(Vec<u8>, u64, u64), EngineError> {
+        let name = {
+            let rendered = self.render().await?;
+            let meta = rendered.node(node).ok_or(EngineError::UnknownNode)?;
+            if meta.kind == NodeKind::Folder {
+                return Err(EngineError::NotAFile);
+            }
+            let name_bytes =
+                meta.ipns_name
+                    .as_ref()
+                    .ok_or_else(|| EngineError::ContentUnavailable {
+                        message: "content not yet published".to_owned(),
+                    })?;
+            // The bytes are the UTF-8 of the canonical base36 name; anything
+            // else is a malformed child ref, fail-closed.
+            core::str::from_utf8(name_bytes)
+                .ok()
+                .and_then(|s| IpnsName::parse(s).ok())
+                .ok_or_else(|| EngineError::TrustViolation {
+                    message: "child ipnsName is not a canonical IPNS name".to_owned(),
+                })?
+        };
+        // The node's scope is the vault root scope (subscope reads are a later
+        // slice). A clone of the seed keeps the cell borrow from spanning the
+        // awaits below; the clone zeroizes when the adopter drops.
+        let scope_id = self.snapshot.borrow().root.0;
+        let scope_read_seed = self
+            .scope_read_seeds
+            .borrow()
+            .get(&scope_id)
+            .cloned()
+            .ok_or_else(|| EngineError::TrustViolation {
+                message: "no read seed held for the node's scope".to_owned(),
+            })?;
+        let adopter = ChildAdopter::new(
+            &self.gateway,
+            &self.seams.http,
+            &self.seams.floor_store,
+            scope_id,
+            scope_read_seed,
+            node.0,
+        );
+        let resolved = resolve(
+            &self.seams.record_transport,
+            &self.seams.snapshot_cache,
+            &adopter,
+            &name,
+        )
+        .await
+        .map_err(|e| EngineError::ContentUnavailable {
+            message: e.message().to_owned(),
+        })?;
+        let adopted = match resolved.outcome {
+            ResolveOutcome::Adopted(adopted) => adopted,
+            // Our own current record at the floor: re-open without a floor
+            // advance (cache-first steady state, not an update).
+            ResolveOutcome::Current { record_bytes } => adopter
+                .open_at_floor(&name, &record_bytes)
+                .await
+                .map_err(EngineError::from_gate)?,
+            ResolveOutcome::NoUpdate => match &resolved.last_known_good {
+                Some(bytes) => adopter
+                    .open_at_floor(&name, bytes)
+                    .await
+                    .map_err(EngineError::from_gate)?,
+                None => {
+                    return Err(EngineError::ContentUnavailable {
+                        message: "no record source reachable and no cached record".to_owned(),
+                    });
+                }
+            },
+            ResolveOutcome::TrustViolation(rejection) => {
+                return Err(EngineError::TrustViolation {
+                    message: rejection.to_string(),
+                });
+            }
+        };
+
+        let ReadBody::File { versions, .. } = adopted.read_body else {
+            // The parent's child ref said file: a sealed folder body is a kind
+            // transplant, fail-closed.
+            return Err(EngineError::TrustViolation {
+                message: "sealed body kind disagrees with the child ref".to_owned(),
+            });
+        };
+        // Newest-first; head is current (crates/core/src/seal/body.rs).
+        let Some(version) = versions.first() else {
+            return Err(EngineError::ContentUnavailable {
+                message: "file has no published content version".to_owned(),
+            });
+        };
+
+        let root_cid_str = encode_content_cid_str(&version.content_cid);
+        let root_block = read_block(
+            &self.gateway,
+            &self.seams.http,
+            &root_cid_str,
+            &version.content_cid,
+            ContentPlane::Root,
+        )
+        .await
+        .map_err(EngineError::from_read)?;
+        let manifest = decode_root(&root_block).map_err(|e| EngineError::TrustViolation {
+            message: format!("content DAG root rejected: {e:?}"),
+        })?;
+        if manifest.size != version.size {
+            return Err(EngineError::TrustViolation {
+                message: format!(
+                    "manifest size {} disagrees with version size {}",
+                    manifest.size, version.size
+                ),
+            });
+        }
+
+        let mut plaintext = Vec::new();
+        for leaf_cid in &manifest.leaf_cids {
+            let leaf_cid_str = encode_content_cid_str(leaf_cid);
+            let sealed = read_block(
+                &self.gateway,
+                &self.seams.http,
+                &leaf_cid_str,
+                leaf_cid,
+                ContentPlane::Leaf,
+            )
+            .await
+            .map_err(EngineError::from_read)?;
+            let chunk = open_chunk(version.content_key(), &sealed).map_err(|e| {
+                EngineError::TrustViolation {
+                    message: format!("leaf unseal rejected: [{}]", e.check()),
+                }
+            })?;
+            plaintext.extend_from_slice(&chunk);
+        }
+        if plaintext.len() as u64 != manifest.size {
+            return Err(EngineError::TrustViolation {
+                message: format!(
+                    "reassembled length {} disagrees with manifest size {}",
+                    plaintext.len(),
+                    manifest.size
+                ),
+            });
+        }
+        Ok((plaintext, version.size, version.modified_at))
+    }
+
+    /// Best-effort [`Event::OpProgress`] emission (a dropped receiver is fine).
+    fn emit_op_progress(&self, node: NodeId, phase: OpPhase, error: Option<String>) {
+        let _ = self.events.unbounded_send(Event::OpProgress {
+            op_id: None,
+            node,
+            phase,
+            error,
+        });
     }
 
     /// The current base snapshot's root node id — the FUSE mount anchor. The
@@ -2113,6 +2389,7 @@ mod tests {
                     },
                     write_scope_seed: None,
                     node_id: [0u8; 16],
+                    read_scope_seed: None,
                 })
             }
         }
@@ -2509,6 +2786,12 @@ mod tests {
             EcdsaSigner::from_scalar(&CAP_SECRET).expect("valid scalar")
         }
 
+        /// The child's write-plane IPNS name (`write-seed` → `ipns-keypair`).
+        fn child_name() -> IpnsName {
+            let write_seed = kdf::write_seed(&WRITE_SCOPE_SEED, &CHILD_ID);
+            IpnsName::from_public_key(&kdf::ipns_keypair(write_seed.as_bytes()).verifying_key())
+        }
+
         /// The owner-root head block (one child) and its content-CID string, plus
         /// the root record's write-plane IPNS name. Keyed off `CAP_SECRET` so the
         /// engine's session-derived owner identity + enc subkey open it, and scoped
@@ -2627,7 +2910,7 @@ mod tests {
                 children: vec![ChildRef {
                     id: CHILD_ID,
                     name: CHILD_NAME.into(),
-                    ipns_name: vec![0x2C],
+                    ipns_name: child_name().as_str().as_bytes().to_vec(),
                     kind: CoreNodeKind::File,
                     link_counter: 1,
                     unknown: Vec::new(),
@@ -2876,6 +3159,11 @@ mod tests {
             assert_eq!(held.len(), 1, "the resolve tick held the owner root");
             let record = held.get(&ROOT.0).expect("held under the root node id");
             assert_eq!(record.routing_key, root_name.as_str());
+            assert_eq!(
+                engine.scope_read_seeds.borrow().get(&SCOPE).map(|s| **s),
+                Some(SCOPE_SEED),
+                "the tick adopt deposited the recovered scope read seed"
+            );
         }
 
         #[test]
@@ -3007,6 +3295,401 @@ mod tests {
                 after.iter().all(Poll::is_ready),
                 "both loops stop after the engine drops"
             );
+        }
+
+        // --- Engine::read_content over the ChildAdopter pipeline ---
+
+        mod read_content {
+            use super::*;
+
+            use cipherbox_core::seal::Version;
+
+            use crate::content::{
+                ContentDag, ContentKey, ContentProfile, SealedChunk, assemble, frame_and_seal,
+            };
+
+            const CONTENT_KEY: [u8; 32] = [0x99; 32];
+            const CHILD_MTIME: u64 = 777;
+            /// 24 bytes → two leaves at the CI profile's 16-byte chunk size.
+            const PLAINTEXT: &[u8] = b"two-leaf plaintext bytes";
+
+            /// The child's sealed content DAG: leaves + root manifest block.
+            fn content_dag(plaintext: &[u8]) -> (Vec<SealedChunk>, ContentDag) {
+                let key = ContentKey::from_bytes(CONTENT_KEY);
+                let leaves = frame_and_seal(
+                    plaintext,
+                    &key,
+                    &mut SeededEntropy::new(5),
+                    &ContentProfile::CI,
+                )
+                .unwrap();
+                let dag = assemble(&leaves, plaintext.len() as u64, &ContentProfile::CI).unwrap();
+                (leaves, dag)
+            }
+
+            fn head_version(dag: &ContentDag, size: u64) -> Version {
+                Version::new(dag.content_cid.clone(), CONTENT_KEY, size, CHILD_MTIME)
+            }
+
+            /// A child file head block sealed under the node's derived read key.
+            /// The knobs drive the fail-closed tests: the envelope id
+            /// (transplant), the version list (empty / size-lying), and a
+            /// bolted-on grant section.
+            fn child_head(
+                envelope_id: [u8; 16],
+                versions: Vec<Version>,
+                with_grant_section: bool,
+            ) -> (Vec<u8>, String) {
+                let node_seed = kdf::node_seed(&SCOPE_SEED, &envelope_id);
+                let read_key = *kdf::read_key(node_seed.as_bytes()).as_bytes();
+                let body = ReadBody::File {
+                    created_at: 0,
+                    modified_at: CHILD_MTIME,
+                    versions,
+                    unknown: Vec::new(),
+                };
+                let mut envelope =
+                    seal_read_body(&read_key, &[13u8; 24], 1, envelope_id, SCOPE, EPOCH, &body)
+                        .unwrap();
+                if with_grant_section {
+                    envelope
+                        .unknown
+                        .push(("grantSection".to_string(), Value::Bytes(vec![1, 2, 3])));
+                }
+                let head_block = encode_envelope(&envelope);
+                let cid = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head_block));
+                (head_block, cid)
+            }
+
+            /// Seed the child record (signed by the child's own write-plane
+            /// signer) at every endpoint.
+            fn seed_child_record(device: &FakeDevice, head_cid_str: &str, sequence: u64) {
+                let write_seed = kdf::write_seed(&WRITE_SCOPE_SEED, &CHILD_ID);
+                let signer = kdf::ipns_keypair(write_seed.as_bytes());
+                let value = format!("/ipfs/{head_cid_str}");
+                let record =
+                    IpnsRecord::create_v2(&signer, value.as_bytes(), sequence, TTL_NANOS, EOL)
+                        .marshal();
+                for endpoint in device.record_store.endpoints() {
+                    device.record_store.seed_record(
+                        &endpoint,
+                        child_name().as_str(),
+                        record.clone(),
+                    );
+                }
+            }
+
+            /// A started engine over the full cold-start fixture (pointer +
+            /// root record + root head block), drained past the first paint.
+            fn started(device: &FakeDevice) -> (Engine<FakeSeamTypes>, EventStream) {
+                let (head_block, head_cid, root_name) = owner_root();
+                seed_vault_pointer(device, &root_name);
+                for endpoint in device.record_store.endpoints() {
+                    seed_root_record_at(device, &endpoint, &root_name, &head_cid);
+                }
+                device.http.enqueue_response(head_response(&head_block));
+                let (mut engine, mut events) = engine_on(device);
+                block_on(engine.start(LoginSecret::new(CAP_SECRET.to_vec()))).unwrap();
+                assert_eq!(drain(&mut events), vec![Event::SnapshotUpdated]);
+                (engine, events)
+            }
+
+            fn progress(node: NodeId, phase: OpPhase) -> Event {
+                Event::OpProgress {
+                    op_id: None,
+                    node,
+                    phase,
+                    error: None,
+                }
+            }
+
+            /// Script the full download fetch order: child head, DAG root, then
+            /// each leaf.
+            fn enqueue_download(
+                device: &FakeDevice,
+                head_block: &[u8],
+                dag: &ContentDag,
+                leaves: &[SealedChunk],
+            ) {
+                device.http.enqueue_response(head_response(head_block));
+                device.http.enqueue_response(head_response(&dag.root_block));
+                for leaf in leaves {
+                    device.http.enqueue_response(head_response(&leaf.sealed));
+                }
+            }
+
+            #[test]
+            fn happy_path_reads_the_exact_plaintext_and_folds_metadata() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (engine, mut events) = started(&device);
+
+                let (leaves, dag) = content_dag(PLAINTEXT);
+                assert_eq!(leaves.len(), 2, "the fixture spans two leaves");
+                let (head_block, head_cid) = child_head(
+                    CHILD_ID,
+                    vec![head_version(&dag, PLAINTEXT.len() as u64)],
+                    false,
+                );
+                seed_child_record(&device, &head_cid, 1);
+                enqueue_download(&device, &head_block, &dag, &leaves);
+
+                let node = NodeId(CHILD_ID);
+                let bytes = block_on(engine.read_content(node)).expect("read succeeds");
+                assert_eq!(bytes, PLAINTEXT, "the exact plaintext round-trips");
+                assert_eq!(
+                    drain(&mut events),
+                    vec![
+                        progress(node, OpPhase::DownloadStarted),
+                        Event::SnapshotUpdated,
+                        progress(node, OpPhase::DownloadCompleted),
+                    ],
+                );
+                let view = block_on(engine.snapshot(ROOT)).unwrap();
+                let child = view
+                    .children
+                    .iter()
+                    .find(|c| c.id == node)
+                    .expect("child listed");
+                assert_eq!(child.size, Some(PLAINTEXT.len() as u64));
+                assert_eq!(child.mtime, Some(CHILD_MTIME));
+
+                // A second read re-serves the same record, now at the durable
+                // floor: the at-floor re-open yields the identical plaintext.
+                enqueue_download(&device, &head_block, &dag, &leaves);
+                assert_eq!(block_on(engine.read_content(node)).unwrap(), PLAINTEXT);
+            }
+
+            #[test]
+            fn a_tampered_leaf_fails_closed_with_no_partial_bytes() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (engine, mut events) = started(&device);
+
+                let (leaves, dag) = content_dag(PLAINTEXT);
+                let (head_block, head_cid) = child_head(
+                    CHILD_ID,
+                    vec![head_version(&dag, PLAINTEXT.len() as u64)],
+                    false,
+                );
+                seed_child_record(&device, &head_cid, 1);
+                device.http.enqueue_response(head_response(&head_block));
+                device.http.enqueue_response(head_response(&dag.root_block));
+                // The first leaf does not content-address to its CID.
+                let mut tampered = leaves[0].sealed.clone();
+                *tampered.last_mut().unwrap() ^= 0x01;
+                device.http.enqueue_response(head_response(&tampered));
+
+                let node = NodeId(CHILD_ID);
+                let err = block_on(engine.read_content(node)).unwrap_err();
+                assert!(
+                    matches!(err, EngineError::TrustViolation { .. }),
+                    "a leaf CID mismatch is a fail-closed trust violation: {err:?}"
+                );
+                assert_eq!(
+                    drain(&mut events),
+                    vec![
+                        progress(node, OpPhase::DownloadStarted),
+                        Event::OpProgress {
+                            op_id: None,
+                            node,
+                            phase: OpPhase::DownloadFailed,
+                            error: Some(err.to_string()),
+                        },
+                    ],
+                    "started then failed; no snapshot fold"
+                );
+                let view = block_on(engine.snapshot(ROOT)).unwrap();
+                let child = view.children.iter().find(|c| c.id == node).unwrap();
+                assert_eq!(child.size, None, "no partial state reaches the view");
+            }
+
+            #[test]
+            fn a_transplanted_child_envelope_rejects_fail_closed() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (engine, _events) = started(&device);
+
+                // The envelope names a DIFFERENT node id, served under the
+                // child's name: an id transplant.
+                let (_leaves, dag) = content_dag(PLAINTEXT);
+                let (head_block, head_cid) = child_head(
+                    [0xEE; 16],
+                    vec![head_version(&dag, PLAINTEXT.len() as u64)],
+                    false,
+                );
+                seed_child_record(&device, &head_cid, 1);
+                device.http.enqueue_response(head_response(&head_block));
+
+                let err = block_on(engine.read_content(NodeId(CHILD_ID))).unwrap_err();
+                assert!(
+                    matches!(err, EngineError::TrustViolation { .. }),
+                    "an id transplant rejects fail-closed: {err:?}"
+                );
+            }
+
+            #[test]
+            fn a_child_envelope_bearing_a_grant_section_rejects() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (engine, _events) = started(&device);
+
+                let (_leaves, dag) = content_dag(PLAINTEXT);
+                let (head_block, head_cid) = child_head(
+                    CHILD_ID,
+                    vec![head_version(&dag, PLAINTEXT.len() as u64)],
+                    true,
+                );
+                seed_child_record(&device, &head_cid, 1);
+                device.http.enqueue_response(head_response(&head_block));
+
+                let err = block_on(engine.read_content(NodeId(CHILD_ID))).unwrap_err();
+                assert!(
+                    matches!(err, EngineError::TrustViolation { .. }),
+                    "a grant-section-bearing child rejects fail-closed: {err:?}"
+                );
+            }
+
+            #[test]
+            fn folder_unknown_and_pending_nodes_map_to_their_errors() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (mut engine, _events) = started(&device);
+
+                assert_eq!(
+                    block_on(engine.read_content(ROOT)),
+                    Err(EngineError::NotAFile),
+                    "a folder node is not readable content"
+                );
+                assert_eq!(
+                    block_on(engine.read_content(NodeId([0x5A; 16]))),
+                    Err(EngineError::UnknownNode)
+                );
+
+                // A staged (pending-only) create has no ipnsName yet:
+                // availability, not trust — content is simply not published.
+                block_on(engine.command(Command::Create {
+                    parent: ROOT,
+                    name: "pending.txt".into(),
+                    kind: NodeKind::File,
+                    content: None,
+                }))
+                .unwrap();
+                let pending = block_on(engine.view())
+                    .unwrap()
+                    .lookup(ROOT, "pending.txt")
+                    .unwrap()
+                    .id;
+                assert!(
+                    matches!(
+                        block_on(engine.read_content(pending)),
+                        Err(EngineError::ContentUnavailable { .. })
+                    ),
+                    "a pending-only node is availability, not trust"
+                );
+            }
+
+            #[test]
+            fn an_empty_version_list_is_an_error() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (engine, _events) = started(&device);
+
+                let (head_block, head_cid) = child_head(CHILD_ID, Vec::new(), false);
+                seed_child_record(&device, &head_cid, 1);
+                device.http.enqueue_response(head_response(&head_block));
+
+                assert!(
+                    matches!(
+                        block_on(engine.read_content(NodeId(CHILD_ID))),
+                        Err(EngineError::ContentUnavailable { .. })
+                    ),
+                    "no published version yields no content"
+                );
+            }
+
+            #[test]
+            fn a_manifest_size_disagreement_fails_closed() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (engine, _events) = started(&device);
+
+                // The version lies about its size relative to the manifest.
+                let (_leaves, dag) = content_dag(PLAINTEXT);
+                let (head_block, head_cid) = child_head(
+                    CHILD_ID,
+                    vec![head_version(&dag, PLAINTEXT.len() as u64 + 1)],
+                    false,
+                );
+                seed_child_record(&device, &head_cid, 1);
+                device.http.enqueue_response(head_response(&head_block));
+                device.http.enqueue_response(head_response(&dag.root_block));
+
+                let err = block_on(engine.read_content(NodeId(CHILD_ID))).unwrap_err();
+                assert!(
+                    matches!(err, EngineError::TrustViolation { .. }),
+                    "a size disagreement is fail-closed: {err:?}"
+                );
+            }
+
+            #[test]
+            fn a_replayed_lower_sequence_rejects_after_adoption() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (engine, _events) = started(&device);
+
+                let (leaves, dag) = content_dag(PLAINTEXT);
+                let (head_block, head_cid) = child_head(
+                    CHILD_ID,
+                    vec![head_version(&dag, PLAINTEXT.len() as u64)],
+                    false,
+                );
+                seed_child_record(&device, &head_cid, 2);
+                enqueue_download(&device, &head_block, &dag, &leaves);
+                block_on(engine.read_content(NodeId(CHILD_ID))).expect("adopts at sequence 2");
+
+                // Replay: re-serve sequence 1 for the same child. The per-name
+                // floor advanced to 2, so the replay rejects fail-closed.
+                seed_child_record(&device, &head_cid, 1);
+                device.http.enqueue_response(head_response(&head_block));
+                let err = block_on(engine.read_content(NodeId(CHILD_ID))).unwrap_err();
+                match &err {
+                    EngineError::TrustViolation { message } => assert!(
+                        message.contains("sequence-not-newer"),
+                        "the replay names the sequence floor: {message}"
+                    ),
+                    other => panic!("a replay must reject fail-closed, got {other:?}"),
+                }
+            }
+
+            #[test]
+            fn an_unreachable_content_plane_is_availability_not_trust() {
+                let world = FakeWorld::new();
+                let device = world.device(b"alice-pk");
+                let (engine, _events) = started(&device);
+
+                // No child record anywhere and a cold cache: nothing resolvable.
+                let err = block_on(engine.read_content(NodeId(CHILD_ID))).unwrap_err();
+                assert!(
+                    matches!(err, EngineError::ContentUnavailable { .. }),
+                    "an unpublished child is availability: {err:?}"
+                );
+
+                // The record appears but no gateway response is scripted: every
+                // source transport-fails, which stays availability, never trust.
+                let (_leaves, dag) = content_dag(PLAINTEXT);
+                let (_head_block, head_cid) = child_head(
+                    CHILD_ID,
+                    vec![head_version(&dag, PLAINTEXT.len() as u64)],
+                    false,
+                );
+                seed_child_record(&device, &head_cid, 1);
+                let err = block_on(engine.read_content(NodeId(CHILD_ID))).unwrap_err();
+                assert!(
+                    matches!(err, EngineError::ContentUnavailable { .. }),
+                    "an unreachable gateway is availability: {err:?}"
+                );
+            }
         }
     }
 }

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -20,6 +20,7 @@
 use core::cell::{Cell, RefCell};
 use core::fmt;
 use core::pin::Pin;
+use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
 use cipherbox_core::ipns::IpnsName;
@@ -34,11 +35,11 @@ use crate::entropy::Entropy;
 use crate::hex::hex_lower;
 use crate::net::{
     Adopter, EolRenewResult, HeldMaterial, HeldRecord, HeldRecords, LivenessControl, PublishError,
-    PublishOutcome, RE_PUT_INTERVAL, RecordPointerFetch, RootAdopter, eol_renew_pass,
-    keyless_re_put, refresh_base_from_outcome, resolve_and_hold, run_liveness_loop,
+    PublishOutcome, RE_PUT_INTERVAL, RecordPointerFetch, ResolveOutcome, RootAdopter,
+    eol_renew_pass, keyless_re_put, refresh_base_from_outcome, resolve_and_hold, run_liveness_loop,
 };
 use crate::profile::SyncTimingProfile;
-use crate::seams::{OpId, Scheduler, SeamError, SeamSet, SeamTypes, StagingStore};
+use crate::seams::{OpId, Scheduler, SeamError, SeamSet, SeamTypes, StagingStore, UnixMillis};
 use crate::session::SessionIdentity;
 use crate::sync::boot::{ColdStartError, ColdStartOutcome, ColdStartParams, cold_start};
 use crate::sync::model::{NodeMeta, Snapshot, collation_key};
@@ -47,6 +48,7 @@ use crate::sync::overlay::apply_overlay;
 use crate::sync::pointer::PointerFetch;
 use crate::sync::rebase::decode_queue;
 use crate::sync::staging::{StageOutcome, stage_op};
+use crate::sync::staleness::{Connectivity, classify};
 
 /// The stable 16-byte node identifier (`id16`, blueprint/core.md). Public,
 /// non-secret, and location-independent — routes and commands key on it,
@@ -106,6 +108,57 @@ pub struct NodeAttrs {
 pub struct StatFs {
     /// Nodes reachable from the root in the rendered view.
     pub nodes: u64,
+}
+
+/// One ancestor step in a [`SnapshotView`]'s breadcrumb trail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Breadcrumb {
+    /// Stable node id.
+    pub id: NodeId,
+    /// Display name, as entered (empty for the root).
+    pub name: String,
+}
+
+/// One direct child in a [`SnapshotView`], projected key-free from the
+/// rendered view plus the op-queue/dead-letter bookkeeping.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotChild {
+    /// Stable node id.
+    pub id: NodeId,
+    /// Display name, as entered.
+    pub name: String,
+    /// File or folder.
+    pub kind: NodeKind,
+    /// Plaintext content size in bytes, once the content plane projects it.
+    pub size: Option<u64>,
+    /// Modification time (Unix millis), once projected.
+    pub mtime: Option<u64>,
+    /// Whether a queued pending op targets this node.
+    pub pending: bool,
+    /// Whether a retained dead-lettered op maps to this node.
+    pub dead_letter: bool,
+    /// Current content version (bumped per `updateContent`).
+    pub content_version: u64,
+}
+
+/// A key-free snapshot of one folder for a host UI paint: its children, its
+/// breadcrumb trail, the retained dead letters, and the staleness rung — one
+/// internally-consistent read of the rendered view (state law).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotView {
+    /// The rendered root node id.
+    pub root: NodeId,
+    /// The folder this view lists.
+    pub folder: NodeId,
+    /// Direct children, deterministically ordered by node id.
+    pub children: Vec<SnapshotChild>,
+    /// Ancestor trail from the folder's parent up to and including the root,
+    /// nearest first.
+    pub ancestors: Vec<Breadcrumb>,
+    /// Every retained dead-lettered op id.
+    pub dead_letters: Vec<OpId>,
+    /// The staleness rung at read time.
+    pub staleness: Staleness,
 }
 
 /// Grant permission level.
@@ -361,6 +414,29 @@ pub enum Event {
         /// Human-readable classification (no key material).
         detail: String,
     },
+    /// Progress of a content-plane transfer for one node. Emitters land with
+    /// the content pipeline slice; the variant is the contract.
+    OpProgress {
+        /// The queued op driving the transfer, if any.
+        op_id: Option<OpId>,
+        /// The node the transfer is for.
+        node: NodeId,
+        /// The phase reached.
+        phase: OpPhase,
+        /// Failure classification for a failed phase (no key material).
+        error: Option<String>,
+    },
+}
+
+/// The phase an [`Event::OpProgress`] reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpPhase {
+    /// A content download started.
+    DownloadStarted,
+    /// A content download completed.
+    DownloadCompleted,
+    /// A content download failed.
+    DownloadFailed,
 }
 
 /// Errors returned by facade calls.
@@ -373,6 +449,10 @@ pub enum EngineError {
     AlreadyStarted,
     /// The login secret was empty or not a valid 32-byte identity scalar.
     InvalidSecret,
+    /// A read named a node absent from the rendered view.
+    UnknownNode,
+    /// A folder read named a file node.
+    NotAFolder,
     /// The command's pipeline slice has not landed yet (scaffold state).
     Unimplemented {
         /// [`Command::name`] of the rejected command.
@@ -446,6 +526,8 @@ impl fmt::Display for EngineError {
             EngineError::InvalidSecret => {
                 f.write_str("login secret is not a valid identity scalar")
             }
+            EngineError::UnknownNode => f.write_str("unknown node"),
+            EngineError::NotAFolder => f.write_str("not a folder"),
             EngineError::Unimplemented { command } => {
                 write!(f, "command not implemented yet: {command}")
             }
@@ -578,6 +660,16 @@ fn count_nodes(snapshot: &Snapshot) -> u64 {
     seen.len() as u64
 }
 
+/// Staleness-ladder inputs (#33 D4): the last successful reconcile, whether one
+/// is in flight, and the last rung reported — [`Event::StalenessChanged`] fires
+/// only on a rung change.
+#[derive(Default)]
+struct SyncStatus {
+    last_success: Option<UnixMillis>,
+    reconcile_in_flight: bool,
+    reported: Option<Staleness>,
+}
+
 /// The re-point pointer-payload wire version the owner's own vault seals under
 /// and the cold-start walk verifies against (`crates/core` pointer payload) — the
 /// sole v2 version (CONTEXT.md "Vault pointer").
@@ -619,6 +711,14 @@ pub struct Engine<T: SeamTypes> {
     /// re-PUTs the map's values on the hourly cadence. Empty until the resolve
     /// tick driver (next slice) wires it in.
     held_records: Rc<RefCell<HeldRecords>>,
+    /// Staleness bookkeeping shared with the resolve-tick loop: it stamps
+    /// successes and reports rung changes; [`snapshot`](Self::snapshot)
+    /// classifies at read time off the same cell.
+    sync_status: Rc<RefCell<SyncStatus>>,
+    /// Retained dead-lettered ops, mapped to the target node when known
+    /// (`None` for an undecodable queue entry). Feeds [`SnapshotView`]'s
+    /// dead-letter surface (#33 D6: dead letters are retained, never silent).
+    dead_letters: Rc<RefCell<BTreeMap<OpId, Option<NodeId>>>>,
     /// Session-alive latch: cleared on drop so the spawned liveness loop
     /// stops at its next wake instead of re-PUTting after the engine is gone.
     alive: Rc<Cell<bool>>,
@@ -658,6 +758,8 @@ impl<T: SeamTypes> Engine<T> {
                 // the base snapshot; children come from the pending-op overlay.
                 snapshot: Rc::new(RefCell::new(Snapshot::new(NodeId([0u8; 16])))),
                 held_records: Rc::new(RefCell::new(HeldRecords::new())),
+                sync_status: Rc::new(RefCell::new(SyncStatus::default())),
+                dead_letters: Rc::new(RefCell::new(BTreeMap::new())),
                 alive: Rc::new(Cell::new(true)),
                 session: None,
                 api: None,
@@ -772,6 +874,9 @@ impl<T: SeamTypes> Engine<T> {
             .as_ref()
             .map(|vp| vp.repoint.current_root.clone());
         *self.snapshot.borrow_mut() = outcome.base;
+        // A successful cold start is a successful reconcile: stamp it so the
+        // ladder starts Fresh rather than Reconciling.
+        self.sync_status.borrow_mut().last_success = Some(self.seams.scheduler.now());
 
         self.spawn_liveness_loop(api.clone());
         self.spawn_resolve_tick_loop(root_name);
@@ -850,6 +955,9 @@ impl<T: SeamTypes> Engine<T> {
         // successful send: a receiver dropped mid-teardown must not silently
         // purge an unsurfaced entry — preserved, the next boot re-surfaces it.
         for (op_id, _reason) in &undecodable {
+            // Retain the dead letter (target unknown for an undecodable entry)
+            // so the read surface keeps reporting it.
+            self.dead_letters.borrow_mut().insert(*op_id, None);
             if self
                 .events
                 .unbounded_send(Event::DeadLetter { op_id: *op_id })
@@ -963,6 +1071,8 @@ impl<T: SeamTypes> Engine<T> {
         let base = self.snapshot.clone();
         let events = self.events.clone();
         let alive = self.alive.clone();
+        let sync_status = self.sync_status.clone();
+        let profile = self.profile;
         let interval = self.profile.poll_cadence;
         let owner_identity = session.owner_identity();
         // The vault's own root scope and root node are the anchored all-zero id16
@@ -998,7 +1108,8 @@ impl<T: SeamTypes> Engine<T> {
                 // A gate-passing `Adopted` repaints the shared base cell and emits
                 // `SnapshotUpdated`; `Current`/`NoUpdate`/`TrustViolation` leave
                 // last-known-good intact (fail-closed for data). (surfacing: #796)
-                if let Ok(resolved) = resolve_and_hold(
+                sync_status.borrow_mut().reconcile_in_flight = true;
+                let resolved = resolve_and_hold(
                     &transport,
                     &snapshot_cache,
                     &adopter,
@@ -1006,12 +1117,39 @@ impl<T: SeamTypes> Engine<T> {
                     &held,
                     &material,
                 )
-                .await
-                {
+                .await;
+                if let Ok(resolved) = &resolved {
                     if refresh_base_from_outcome(&base, NodeId(root_id), &resolved.outcome) {
                         let _ = events.unbounded_send(Event::SnapshotUpdated);
                     }
                 }
+                // `Adopted`/`Current` are the reconciled outcomes: both prove the
+                // record plane answered with gate-passing state, so both stamp
+                // the ladder's `last_success` (#33 D4).
+                let reconciled = matches!(
+                    &resolved,
+                    Ok(r) if matches!(
+                        r.outcome,
+                        ResolveOutcome::Adopted(_) | ResolveOutcome::Current { .. }
+                    )
+                );
+                let mut status = sync_status.borrow_mut();
+                status.reconcile_in_flight = false;
+                if reconciled {
+                    status.last_success = Some(scheduler.now());
+                }
+                let rung = classify(
+                    scheduler.now(),
+                    status.last_success,
+                    status.reconcile_in_flight,
+                    Connectivity::Online,
+                    &profile,
+                );
+                if status.reported != Some(rung) {
+                    status.reported = Some(rung);
+                    let _ = events.unbounded_send(Event::StalenessChanged { level: rung });
+                }
+                drop(status);
                 LivenessControl::Continue
             })
             .await;
@@ -1095,6 +1233,70 @@ impl<T: SeamTypes> Engine<T> {
         }
         Ok(EngineView {
             rendered: self.render().await?,
+        })
+    }
+
+    /// A key-free [`SnapshotView`] of `folder` — its children (with pending/
+    /// dead-letter flags), breadcrumb trail, retained dead letters, and the
+    /// staleness rung. A pure read over the same rendered view [`view`](Self::view)
+    /// serves (state law): one pending-ops read feeds both the overlay and the
+    /// pending flags, so the flags and the rendered children never disagree.
+    pub async fn snapshot(&self, folder: NodeId) -> Result<SnapshotView, EngineError> {
+        if !self.started {
+            return Err(EngineError::NotStarted);
+        }
+        let ops = self.pending_ops().await?;
+        let rendered = {
+            let base = self.snapshot.borrow();
+            apply_overlay(&base, &ops)
+        };
+        let meta = rendered.node(folder).ok_or(EngineError::UnknownNode)?;
+        if meta.kind != NodeKind::Folder {
+            return Err(EngineError::NotAFolder);
+        }
+        let pending: BTreeSet<NodeId> = ops.iter().map(|op| op.target).collect();
+        let dead = self.dead_letters.borrow();
+        let children = rendered
+            .children(folder)
+            .into_iter()
+            .map(|child| SnapshotChild {
+                id: child.id,
+                name: child.name.clone(),
+                kind: child.kind,
+                size: child.size,
+                mtime: child.mtime,
+                pending: pending.contains(&child.id),
+                dead_letter: dead.values().any(|node| *node == Some(child.id)),
+                content_version: child.content_version,
+            })
+            .collect();
+        let ancestors = rendered
+            .ancestors(folder)
+            .into_iter()
+            .map(|id| Breadcrumb {
+                id,
+                name: rendered
+                    .node(id)
+                    .map(|meta| meta.name.clone())
+                    .unwrap_or_default(),
+            })
+            .collect();
+        let dead_letters = dead.keys().copied().collect();
+        let status = self.sync_status.borrow();
+        let staleness = classify(
+            self.seams.scheduler.now(),
+            status.last_success,
+            status.reconcile_in_flight,
+            Connectivity::Online,
+            &self.profile,
+        );
+        Ok(SnapshotView {
+            root: rendered.root,
+            folder,
+            children,
+            ancestors,
+            dead_letters,
+            staleness,
         })
     }
 
@@ -1490,6 +1692,15 @@ mod tests {
         (engine, events)
     }
 
+    /// Every event currently buffered on the stream, without blocking.
+    fn drain(events: &mut EventStream) -> Vec<Event> {
+        let mut out = Vec::new();
+        while let Ok(event) = events.receiver.try_recv() {
+            out.push(event);
+        }
+        out
+    }
+
     fn create(engine: &mut Engine<FakeSeamTypes>, parent: NodeId, name: &str, kind: NodeKind) {
         block_on(engine.command(Command::Create {
             parent,
@@ -1646,6 +1857,161 @@ mod tests {
                 command: "rotateNow"
             })
         );
+    }
+
+    // --- snapshot read surface ---
+
+    mod snapshot_read {
+        use super::*;
+
+        use cipherbox_core::seal::{ChildRef, NodeKind as CoreNodeKind, ReadBody};
+
+        use crate::gate::Adopted;
+        use crate::net::{ResolveOutcome, refresh_base_from_outcome};
+
+        /// A gate-passing adopted root folder with the given children, mirroring
+        /// what a live resolve repaints the base with.
+        fn adopted_folder(children: Vec<ChildRef>) -> Adopted {
+            Adopted {
+                read_body: ReadBody::Folder {
+                    created_at: 0,
+                    modified_at: 456,
+                    children,
+                    unknown: Vec::new(),
+                },
+                sequence: 2,
+                epoch: 1,
+            }
+        }
+
+        fn child_ref(id: u8, name: &str, kind: CoreNodeKind) -> ChildRef {
+            ChildRef {
+                id: [id; 16],
+                name: name.to_string(),
+                ipns_name: vec![id],
+                kind,
+                link_counter: 1,
+                unknown: Vec::new(),
+            }
+        }
+
+        #[test]
+        fn snapshot_lists_base_children_with_no_pending_flags() {
+            let (engine, _events) = started();
+            let root = engine.root();
+            refresh_base_from_outcome(
+                &engine.snapshot,
+                root,
+                &ResolveOutcome::Adopted(adopted_folder(vec![
+                    child_ref(1, "a", CoreNodeKind::Folder),
+                    child_ref(2, "b.txt", CoreNodeKind::File),
+                ])),
+            );
+
+            let view = block_on(engine.snapshot(root)).unwrap();
+            assert_eq!(view.root, root);
+            assert_eq!(view.folder, root);
+            let by: Vec<(NodeId, &str, NodeKind, bool, u64)> = view
+                .children
+                .iter()
+                .map(|c| (c.id, c.name.as_str(), c.kind, c.pending, c.content_version))
+                .collect();
+            assert_eq!(
+                by,
+                vec![
+                    (NodeId([1; 16]), "a", NodeKind::Folder, false, 0),
+                    (NodeId([2; 16]), "b.txt", NodeKind::File, false, 0),
+                ],
+                "base children render id-sorted, none pending"
+            );
+            assert!(view.children.iter().all(|c| !c.dead_letter));
+            assert!(view.dead_letters.is_empty());
+            assert!(view.ancestors.is_empty(), "the root has no ancestors");
+        }
+
+        #[test]
+        fn staged_create_appears_with_pending_true() {
+            let (mut engine, _events) = started();
+            let root = engine.root();
+            create(&mut engine, root, "notes.txt", NodeKind::File);
+
+            let view = block_on(engine.snapshot(root)).unwrap();
+            assert_eq!(view.children.len(), 1);
+            assert_eq!(view.children[0].name, "notes.txt");
+            assert!(
+                view.children[0].pending,
+                "a queued op targeting the node flags it pending"
+            );
+            assert!(!view.children[0].dead_letter);
+        }
+
+        #[test]
+        fn breadcrumbs_walk_nearest_first_to_the_root() {
+            let (mut engine, _events) = started();
+            let root = engine.root();
+            create(&mut engine, root, "dir", NodeKind::Folder);
+            let dir = block_on(engine.view())
+                .unwrap()
+                .lookup(root, "dir")
+                .unwrap()
+                .id;
+            create(&mut engine, dir, "sub", NodeKind::Folder);
+            let sub = block_on(engine.view())
+                .unwrap()
+                .lookup(dir, "sub")
+                .unwrap()
+                .id;
+
+            let view = block_on(engine.snapshot(sub)).unwrap();
+            assert_eq!(
+                view.ancestors,
+                vec![
+                    Breadcrumb {
+                        id: dir,
+                        name: "dir".to_owned(),
+                    },
+                    Breadcrumb {
+                        id: root,
+                        name: String::new(),
+                    },
+                ],
+                "nearest first, ending at the root"
+            );
+        }
+
+        #[test]
+        fn unknown_folder_is_unknown_node() {
+            let (engine, _events) = started();
+            assert_eq!(
+                block_on(engine.snapshot(NodeId([9; 16]))),
+                Err(EngineError::UnknownNode)
+            );
+        }
+
+        #[test]
+        fn file_node_is_not_a_folder() {
+            let (mut engine, _events) = started();
+            let root = engine.root();
+            create(&mut engine, root, "f.txt", NodeKind::File);
+            let file = block_on(engine.view())
+                .unwrap()
+                .lookup(root, "f.txt")
+                .unwrap()
+                .id;
+            assert_eq!(
+                block_on(engine.snapshot(file)),
+                Err(EngineError::NotAFolder)
+            );
+        }
+
+        #[test]
+        fn snapshot_before_start_returns_not_started() {
+            let (engine, _events) = new_engine();
+            assert_eq!(
+                block_on(engine.snapshot(NodeId([0; 16]))),
+                Err(EngineError::NotStarted)
+            );
+        }
     }
 
     // --- cold-start data path composition ---
@@ -1987,6 +2353,26 @@ mod tests {
                     .unwrap()
                     .is_empty(),
                 "the dead-lettered op is removed from the durable queue"
+            );
+        }
+
+        #[test]
+        fn retained_dead_letter_surfaces_in_the_snapshot_view() {
+            let (mut engine, _events, pointers) = started_at(UnixMillis(123_456));
+            block_on(engine.seams.staging_store.enqueue_op(b"not-a-valid-op")).expect("enqueue");
+
+            drive(&mut engine, &pointers);
+
+            let view = block_on(engine.snapshot(engine.root())).unwrap();
+            assert_eq!(
+                view.dead_letters,
+                vec![OpId(1)],
+                "the retained dead letter stays on the read surface after removal \
+                 from the durable queue"
+            );
+            assert!(
+                view.children.iter().all(|c| !c.dead_letter),
+                "an undecodable entry maps to no node"
             );
         }
 
@@ -2490,6 +2876,83 @@ mod tests {
             assert_eq!(held.len(), 1, "the resolve tick held the owner root");
             let record = held.get(&ROOT.0).expect("held under the root node id");
             assert_eq!(record.routing_key, root_name.as_str());
+        }
+
+        #[test]
+        fn staleness_rungs_transition_and_emit_once_per_change() {
+            use core::time::Duration;
+
+            let world = FakeWorld::new();
+            let device = world.device(b"alice-pk");
+            let (head_block, head_cid, root_name) = owner_root();
+            seed_vault_pointer(&device, &root_name);
+            for endpoint in device.record_store.endpoints() {
+                seed_root_record_at(&device, &endpoint, &root_name, &head_cid);
+            }
+            device.http.enqueue_response(head_response(&head_block));
+            let (mut engine, mut events) = engine_on(&device);
+            block_on(engine.start(LoginSecret::new(CAP_SECRET.to_vec()))).unwrap();
+            assert_eq!(
+                drain(&mut events),
+                vec![Event::SnapshotUpdated],
+                "cold start paints once and stamps last_success"
+            );
+
+            let mut tasks = world.scheduler.take_spawned_tasks();
+            poll_each(&mut tasks); // park each loop at its first sleep
+
+            // CI profile: 1 s poll, 3 s stale_after. With no reachable head
+            // block, each tick fails to reconcile and last_success stays at 0.
+            world.scheduler.advance(Duration::from_secs(1));
+            poll_each(&mut tasks);
+            assert_eq!(
+                drain(&mut events),
+                vec![Event::StalenessChanged {
+                    level: Staleness::Fresh
+                }],
+                "the first classified rung is reported"
+            );
+            world.scheduler.advance(Duration::from_secs(1));
+            poll_each(&mut tasks);
+            assert_eq!(drain(&mut events), vec![], "no re-emit within a rung");
+            world.scheduler.advance(Duration::from_secs(1)); // t=3 s ≥ stale_after
+            poll_each(&mut tasks);
+            assert_eq!(
+                drain(&mut events),
+                vec![Event::StalenessChanged {
+                    level: Staleness::Stale
+                }]
+            );
+            world.scheduler.advance(Duration::from_secs(1));
+            poll_each(&mut tasks);
+            assert_eq!(drain(&mut events), vec![], "stale reported exactly once");
+
+            // The record plane recovers with a newer root: the adopt stamps
+            // last_success and the rung steps back to Fresh.
+            for endpoint in device.record_store.endpoints() {
+                device.record_store.seed_record(
+                    &endpoint,
+                    root_name.as_str(),
+                    root_record(&head_cid, 2),
+                );
+            }
+            device.http.enqueue_response(head_response(&head_block));
+            world.scheduler.advance(Duration::from_secs(1));
+            poll_each(&mut tasks);
+            assert_eq!(
+                drain(&mut events),
+                vec![
+                    Event::SnapshotUpdated,
+                    Event::StalenessChanged {
+                        level: Staleness::Fresh
+                    },
+                ],
+                "a reconciled tick repaints and steps the ladder back to Fresh"
+            );
+
+            // The read surface classifies off the same state.
+            let view = block_on(engine.snapshot(ROOT)).unwrap();
+            assert_eq!(view.staleness, Staleness::Fresh);
         }
 
         #[test]

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -23,7 +23,6 @@ use core::pin::Pin;
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
-use cipherbox_core::content::{encode_content_cid_str, open_chunk};
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::seal::ReadBody;
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
@@ -32,7 +31,7 @@ use futures_core::Stream;
 use zeroize::Zeroizing;
 
 use crate::api::{ApiClient, ApiError, IdentityChallengeSigner};
-use crate::content::{ContentPlane, Gateway, GatewayConfig, ReadError, decode_root, read_block};
+use crate::content::{Gateway, GatewayConfig, OpenError, open_content};
 use crate::entropy::Entropy;
 use crate::gate::GateError;
 use crate::hex::hex_lower;
@@ -45,13 +44,12 @@ use crate::net::{
 use crate::profile::SyncTimingProfile;
 use crate::seams::{OpId, Scheduler, SeamError, SeamSet, SeamTypes, StagingStore, UnixMillis};
 use crate::session::SessionIdentity;
-use crate::sync::boot::{
-    ColdStartError, ColdStartOutcome, ColdStartParams, ColdStartSinks, cold_start,
-};
+use crate::sync::boot::{ColdStartError, ColdStartOutcome, ColdStartParams, cold_start};
 use crate::sync::model::{NodeMeta, Snapshot, collation_key};
 use crate::sync::op::Op;
 use crate::sync::overlay::apply_overlay;
 use crate::sync::pointer::PointerFetch;
+use crate::sync::project::project_child_version;
 use crate::sync::rebase::decode_queue;
 use crate::sync::staging::{StageOutcome, stage_op};
 use crate::sync::staleness::{Connectivity, classify};
@@ -420,8 +418,9 @@ pub enum Event {
         /// Human-readable classification (no key material).
         detail: String,
     },
-    /// Progress of a content-plane transfer for one node. Emitters land with
-    /// the content pipeline slice; the variant is the contract.
+    /// Progress of a content-plane transfer for one node: the driving op (if
+    /// any), the phase reached, and the failure classification on a failed
+    /// phase.
     OpProgress {
         /// The queued op driving the transfer, if any.
         op_id: Option<OpId>,
@@ -534,22 +533,6 @@ impl EngineError {
             },
             GateError::Seam(seam) => EngineError::ContentUnavailable {
                 message: seam.message().to_owned(),
-            },
-        }
-    }
-
-    /// Map a content-block read failure: a CID mismatch is a fail-closed trust
-    /// verdict; no source or an over-cap body is availability.
-    fn from_read(err: ReadError) -> Self {
-        match err {
-            ReadError::TrustViolation(e) => EngineError::TrustViolation {
-                message: format!("content block rejected: [{}]", e.check()),
-            },
-            ReadError::Unavailable => EngineError::ContentUnavailable {
-                message: "content block unavailable".to_owned(),
-            },
-            ReadError::TooLarge { size, limit } => EngineError::ContentUnavailable {
-                message: format!("content block exceeds the cap ({size} > {limit})"),
             },
         }
     }
@@ -896,11 +879,11 @@ impl<T: SeamTypes> Engine<T> {
         // no derived key material stays resident and nothing runs past an unadopted
         // root (rules 4/6). An empty chain (a first-run vault with no pointer yet)
         // degrades to the anchored root with no error.
+        let root = self.snapshot.borrow().root;
+        let root_scope_id = root.0;
         let cold_start = {
             let session = self.session.as_ref().expect("session set above");
             let owner_identity = session.owner_identity();
-            let root = self.snapshot.borrow().root;
-            let root_scope_id = root.0;
             let pointer_fetch = RecordPointerFetch::new(&self.seams.record_transport);
             let adopter = RootAdopter::new(
                 &self.gateway,
@@ -920,7 +903,7 @@ impl<T: SeamTypes> Engine<T> {
             )
             .await
         };
-        let outcome = match cold_start {
+        let mut outcome = match cold_start {
             Ok(outcome) => outcome,
             Err(err) => {
                 // Fail-closed symmetry with the login path: clear the derived
@@ -930,6 +913,13 @@ impl<T: SeamTypes> Engine<T> {
                 return Err(EngineError::from_cold_start(err));
             }
         };
+        // A gate-passing root adopt surfaced the scope read seed: deposit it in
+        // the in-memory per-scope cell the child read pipeline derives from.
+        if let Some(seed) = outcome.read_scope_seed.take() {
+            self.scope_read_seeds
+                .borrow_mut()
+                .insert(root_scope_id, seed);
+        }
 
         // The gate-passing base becomes the state law's left operand (reads render
         // this ⊕ the pending-op overlay). The resolved root name — the vault
@@ -1046,19 +1036,6 @@ impl<T: SeamTypes> Engine<T> {
             pending_ops: &pending,
         };
         let events = self.events.clone();
-        let mut emit = |event: Event| {
-            let _ = events.unbounded_send(event);
-        };
-        // A gate-passing root adopt surfaces the scope read seed; deposit it in
-        // the in-memory per-scope cell the child read pipeline derives from.
-        let seeds = self.scope_read_seeds.clone();
-        let mut deposit_read_seed = |seed: Zeroizing<[u8; 32]>| {
-            seeds.borrow_mut().insert(root_scope_id, seed);
-        };
-        let mut sinks = ColdStartSinks {
-            emit: &mut emit,
-            deposit_read_seed: &mut deposit_read_seed,
-        };
         cold_start(
             pointer_fetch,
             adopter,
@@ -1066,7 +1043,9 @@ impl<T: SeamTypes> Engine<T> {
             &self.seams.record_transport,
             &self.seams.snapshot_cache,
             &params,
-            &mut sinks,
+            &mut |event: Event| {
+                let _ = events.unbounded_send(event);
+            },
         )
         .await
     }
@@ -1341,6 +1320,7 @@ impl<T: SeamTypes> Engine<T> {
         }
         let pending: BTreeSet<NodeId> = ops.iter().map(|op| op.target).collect();
         let dead = self.dead_letters.borrow();
+        let dead_nodes: BTreeSet<NodeId> = dead.values().flatten().copied().collect();
         let children = rendered
             .children(folder)
             .into_iter()
@@ -1351,7 +1331,7 @@ impl<T: SeamTypes> Engine<T> {
                 size: child.size,
                 mtime: child.mtime,
                 pending: pending.contains(&child.id),
-                dead_letter: dead.values().any(|node| *node == Some(child.id)),
+                dead_letter: dead_nodes.contains(&child.id),
                 content_version: child.content_version,
             })
             .collect();
@@ -1392,7 +1372,7 @@ impl<T: SeamTypes> Engine<T> {
     /// under the version content key, and reassembles the plaintext with
     /// length cross-checks. Emits [`Event::OpProgress`] on entry, success, and
     /// failure; on success folds the head version's size/mtime into the base
-    /// snapshot and emits [`Event::SnapshotUpdated`].
+    /// snapshot, emitting [`Event::SnapshotUpdated`] only when they changed.
     pub async fn read_content(&self, node: NodeId) -> Result<Vec<u8>, EngineError> {
         if !self.started {
             return Err(EngineError::NotStarted);
@@ -1401,12 +1381,11 @@ impl<T: SeamTypes> Engine<T> {
         match self.read_content_inner(node).await {
             Ok((plaintext, size, modified_at)) => {
                 // The verified head version is gate-passing state, so it may
-                // legally touch the base node's projected size/mtime.
-                if let Some(meta) = self.snapshot.borrow_mut().node_mut(node) {
-                    meta.size = Some(size);
-                    meta.mtime = Some(modified_at);
+                // legally touch the base node's projected size/mtime. Repaint
+                // only on a real change — a repeat read must not cascade.
+                if project_child_version(&mut self.snapshot.borrow_mut(), node, size, modified_at) {
+                    let _ = self.events.unbounded_send(Event::SnapshotUpdated);
                 }
-                let _ = self.events.unbounded_send(Event::SnapshotUpdated);
                 self.emit_op_progress(node, OpPhase::DownloadCompleted, None);
                 Ok(plaintext)
             }
@@ -1418,31 +1397,48 @@ impl<T: SeamTypes> Engine<T> {
     }
 
     /// The verified read pipeline behind [`read_content`](Self::read_content):
-    /// rendered-view lookup → gated child resolve → version-DAG fetch and
-    /// per-leaf unseal → length cross-checks. Returns the plaintext plus the
-    /// head version's `(size, modifiedAt)`.
+    /// base-snapshot lookup → gated child resolve →
+    /// [`open_content`] (version-DAG fetch, per-leaf unseal, length
+    /// cross-checks). Returns the plaintext plus the head version's
+    /// `(size, modifiedAt)`.
     async fn read_content_inner(&self, node: NodeId) -> Result<(Vec<u8>, u64, u64), EngineError> {
-        let name = {
-            let rendered = self.render().await?;
-            let meta = rendered.node(node).ok_or(EngineError::UnknownNode)?;
-            if meta.kind == NodeKind::Folder {
-                return Err(EngineError::NotAFile);
-            }
-            let name_bytes =
-                meta.ipns_name
-                    .as_ref()
-                    .ok_or_else(|| EngineError::ContentUnavailable {
-                        message: "content not yet published".to_owned(),
-                    })?;
-            // The bytes are the UTF-8 of the canonical base36 name; anything
-            // else is a malformed child ref, fail-closed.
-            core::str::from_utf8(name_bytes)
-                .ok()
-                .and_then(|s| IpnsName::parse(s).ok())
-                .ok_or_else(|| EngineError::TrustViolation {
-                    message: "child ipnsName is not a canonical IPNS name".to_owned(),
-                })?
+        // The base snapshot alone answers the lookup (kind and ipnsName never
+        // come from the overlay) — no full render for a single node. The borrow
+        // never spans an await.
+        let base_meta = {
+            let base = self.snapshot.borrow();
+            base.node(node)
+                .map(|meta| (meta.kind, meta.ipns_name.clone()))
         };
+        let (kind, ipns_name) = match base_meta {
+            Some(meta) => meta,
+            None => {
+                // Absent from gate-passing state: a queued op targeting the node
+                // means a pending (unpublished) create; anything else is unknown.
+                let pending = self.pending_ops().await?;
+                return Err(if pending.iter().any(|op| op.target == node) {
+                    EngineError::ContentUnavailable {
+                        message: "content not yet published".to_owned(),
+                    }
+                } else {
+                    EngineError::UnknownNode
+                });
+            }
+        };
+        if kind == NodeKind::Folder {
+            return Err(EngineError::NotAFile);
+        }
+        let name_bytes = ipns_name.ok_or_else(|| EngineError::ContentUnavailable {
+            message: "content not yet published".to_owned(),
+        })?;
+        // The bytes are the UTF-8 of the canonical base36 name; anything
+        // else is a malformed child ref, fail-closed.
+        let name = core::str::from_utf8(&name_bytes)
+            .ok()
+            .and_then(|s| IpnsName::parse(s).ok())
+            .ok_or_else(|| EngineError::TrustViolation {
+                message: "child ipnsName is not a canonical IPNS name".to_owned(),
+            })?;
         // The node's scope is the vault root scope (subscope reads are a later
         // slice). A clone of the seed keeps the cell borrow from spanning the
         // awaits below; the clone zeroizes when the adopter drops.
@@ -1473,30 +1469,28 @@ impl<T: SeamTypes> Engine<T> {
         .map_err(|e| EngineError::ContentUnavailable {
             message: e.message().to_owned(),
         })?;
-        let adopted = match resolved.outcome {
-            ResolveOutcome::Adopted(adopted) => adopted,
-            // Our own current record at the floor: re-open without a floor
-            // advance (cache-first steady state, not an update).
-            ResolveOutcome::Current { record_bytes } => adopter
+        // One at-floor re-open serves both non-adopt outcomes: `Current` carries
+        // the re-fetched bytes, `NoUpdate` falls back to the cached
+        // last-known-good; neither advances a floor.
+        let adopted = 'adopted: {
+            let record_bytes = match resolved.outcome {
+                ResolveOutcome::Adopted(adopted) => break 'adopted adopted,
+                ResolveOutcome::TrustViolation(rejection) => {
+                    return Err(EngineError::from_gate(GateError::Rejected(rejection)));
+                }
+                ResolveOutcome::Current { record_bytes } => record_bytes,
+                ResolveOutcome::NoUpdate => {
+                    resolved
+                        .last_known_good
+                        .ok_or_else(|| EngineError::ContentUnavailable {
+                            message: "no record source reachable and no cached record".to_owned(),
+                        })?
+                }
+            };
+            adopter
                 .open_at_floor(&name, &record_bytes)
                 .await
-                .map_err(EngineError::from_gate)?,
-            ResolveOutcome::NoUpdate => match &resolved.last_known_good {
-                Some(bytes) => adopter
-                    .open_at_floor(&name, bytes)
-                    .await
-                    .map_err(EngineError::from_gate)?,
-                None => {
-                    return Err(EngineError::ContentUnavailable {
-                        message: "no record source reachable and no cached record".to_owned(),
-                    });
-                }
-            },
-            ResolveOutcome::TrustViolation(rejection) => {
-                return Err(EngineError::TrustViolation {
-                    message: rejection.to_string(),
-                });
-            }
+                .map_err(EngineError::from_gate)?
         };
 
         let ReadBody::File { versions, .. } = adopted.read_body else {
@@ -1513,56 +1507,12 @@ impl<T: SeamTypes> Engine<T> {
             });
         };
 
-        let root_cid_str = encode_content_cid_str(&version.content_cid);
-        let root_block = read_block(
-            &self.gateway,
-            &self.seams.http,
-            &root_cid_str,
-            &version.content_cid,
-            ContentPlane::Root,
-        )
-        .await
-        .map_err(EngineError::from_read)?;
-        let manifest = decode_root(&root_block).map_err(|e| EngineError::TrustViolation {
-            message: format!("content DAG root rejected: {e:?}"),
-        })?;
-        if manifest.size != version.size {
-            return Err(EngineError::TrustViolation {
-                message: format!(
-                    "manifest size {} disagrees with version size {}",
-                    manifest.size, version.size
-                ),
-            });
-        }
-
-        let mut plaintext = Vec::new();
-        for leaf_cid in &manifest.leaf_cids {
-            let leaf_cid_str = encode_content_cid_str(leaf_cid);
-            let sealed = read_block(
-                &self.gateway,
-                &self.seams.http,
-                &leaf_cid_str,
-                leaf_cid,
-                ContentPlane::Leaf,
-            )
+        let plaintext = open_content(&self.gateway, &self.seams.http, version)
             .await
-            .map_err(EngineError::from_read)?;
-            let chunk = open_chunk(version.content_key(), &sealed).map_err(|e| {
-                EngineError::TrustViolation {
-                    message: format!("leaf unseal rejected: [{}]", e.check()),
-                }
+            .map_err(|e| match e {
+                OpenError::Trust(message) => EngineError::TrustViolation { message },
+                OpenError::Unavailable(message) => EngineError::ContentUnavailable { message },
             })?;
-            plaintext.extend_from_slice(&chunk);
-        }
-        if plaintext.len() as u64 != manifest.size {
-            return Err(EngineError::TrustViolation {
-                message: format!(
-                    "reassembled length {} disagrees with manifest size {}",
-                    plaintext.len(),
-                    manifest.size
-                ),
-            });
-        }
         Ok((plaintext, version.size, version.modified_at))
     }
 
@@ -3455,9 +3405,18 @@ mod tests {
                 assert_eq!(child.mtime, Some(CHILD_MTIME));
 
                 // A second read re-serves the same record, now at the durable
-                // floor: the at-floor re-open yields the identical plaintext.
+                // floor: the at-floor re-open yields the identical plaintext,
+                // and the unchanged size/mtime fold repaints nothing.
                 enqueue_download(&device, &head_block, &dag, &leaves);
                 assert_eq!(block_on(engine.read_content(node)).unwrap(), PLAINTEXT);
+                assert_eq!(
+                    drain(&mut events),
+                    vec![
+                        progress(node, OpPhase::DownloadStarted),
+                        progress(node, OpPhase::DownloadCompleted),
+                    ],
+                    "an identical second read emits no SnapshotUpdated"
+                );
             }
 
             #[test]

--- a/crates/engine/src/gate/adoption.rs
+++ b/crates/engine/src/gate/adoption.rs
@@ -552,38 +552,19 @@ pub async fn adopt_deferred<F: FloorStore>(
         }
     }
 
-    // Stage 4 — strictly newer than the durable per-name sequence floor.
+    // Stages 4/5 — the durable floor law ([`floor::check`]): strictly-newer
+    // sequence vs the per-name floor, epoch tag at or above the scope's
+    // read-epoch floor.
     let name_bytes = candidate.name.as_str().as_bytes();
-    let sequence_floor = floors
-        .sequence_floor(name_bytes)
-        .await
-        .map_err(GateError::Seam)?
-        .unwrap_or(0);
-    if verified.sequence <= sequence_floor {
-        return Err(reject(
-            GateStage::Sequence,
-            RejectionReason::SequenceNotNewer {
-                floor: sequence_floor,
-                sequence: verified.sequence,
-            },
-        ));
-    }
-
-    // Stage 5 — epoch tag at or above the scope's durable read-epoch floor.
-    let epoch = candidate.envelope.epoch;
-    let epoch_floor = floor::read_epoch_floor(floors, &reader.scope_id)
-        .await
-        .map_err(GateError::Seam)?
-        .unwrap_or(0);
-    if epoch < epoch_floor {
-        return Err(reject(
-            GateStage::Epoch,
-            RejectionReason::EpochBelowFloor {
-                floor: epoch_floor,
-                epoch,
-            },
-        ));
-    }
+    floor::check(
+        floors,
+        name_bytes,
+        &reader.scope_id,
+        verified.sequence,
+        epoch,
+        floor::Strictness::StrictlyNewer,
+    )
+    .await?;
 
     // Stage 6 — unseal success required (AAD-confirmed). The HPKE seed source
     // (if any) opens first, then the symmetric read-body; the read-body decode

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -169,12 +169,12 @@ pub async fn sequence_floor<F: FloorStore>(
 /// Advance floors after an AAD-confirmed unseal — the only record-sourced
 /// advancement. Raises the per-scope read-epoch floor to `epoch` and the
 /// per-name sequence floor to `sequence`, both monotonic-max. Callers invoke
-/// this exactly once, at the adoption gate's successful unseal stage (the gate
-/// commits it — eagerly via [`adopt`](crate::gate::adopt), or deferred via
-/// [`PendingAdoption::commit`](crate::gate::PendingAdoption::commit) — after a
-/// confirmed unseal), so a record whose body never unsealed can never move a
-/// floor — the provenance the plain scalar arguments cannot express is enforced
-/// at that single call site.
+/// this only after a successful unseal: the adoption gate (eagerly via
+/// [`adopt`](crate::gate::adopt), or deferred via
+/// [`PendingAdoption::commit`](crate::gate::PendingAdoption::commit)) and the
+/// child pipeline ([`ChildAdopter`](crate::net::ChildAdopter)) — so a record
+/// whose body never unsealed can never move a floor; the provenance the plain
+/// scalar arguments cannot express is enforced at those call sites.
 ///
 /// **Fail-safe ordering.** The read-epoch (revocation) and sequence floors are
 /// distinctly keyed. The batch lists the trust-critical **read-epoch

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -6,10 +6,11 @@
 //! is the *only* place that advances them, and it advances them only the four
 //! ways the law admits:
 //!
-//! 1. **Advance on AAD-confirmed unseal** ([`advance_on_unseal`]) — the sole
-//!    record-sourced path. A record's sequence/epoch move the floors only after
-//!    its body cryptographically unsealed (the adoption gate's stage 6), never
-//!    from a claimed-but-unconfirmed field.
+//! 1. **Advance on AAD-confirmed unseal** ([`advance_on_unseal`] for
+//!    gate-adopted roots, [`advance_sequence_on_unseal`] for child records) —
+//!    the sole record-sourced paths. A record's sequence/epoch move the floors
+//!    only after its body cryptographically unsealed (the adoption gate's
+//!    stage 6), never from a claimed-but-unconfirmed field.
 //! 2. **Cold-seed from a re-point object** ([`cold_seed`]) — the cold-start
 //!    anchor. The owner-vouched `minReadEpoch` seeds the read-epoch floor (the
 //!    revocation boundary) and `writeEpoch` the write-epoch floor. The
@@ -175,8 +176,8 @@ pub enum Strictness {
     /// at the floor is our own current record, not an update).
     StrictlyNewer,
     /// The at-floor re-open path (our own current record / cached
-    /// last-known-good): equality is admitted; a strictly lower sequence stays
-    /// a fail-closed replay.
+    /// last-known-good): only exact equality is admitted — lower is a
+    /// fail-closed replay, higher is a record that never passed an adopt.
     AtFloor,
 }
 
@@ -197,7 +198,7 @@ pub async fn check<F: FloorStore>(
         .unwrap_or(0);
     let replayed = match strictness {
         Strictness::StrictlyNewer => sequence <= floor,
-        Strictness::AtFloor => sequence < floor,
+        Strictness::AtFloor => sequence != floor,
     };
     if replayed {
         return Err(GateError::Rejected(GateRejection {
@@ -221,15 +222,14 @@ pub async fn check<F: FloorStore>(
     Ok(())
 }
 
-/// Advance floors after an AAD-confirmed unseal — the only record-sourced
-/// advancement. Raises the per-scope read-epoch floor to `epoch` and the
-/// per-name sequence floor to `sequence`, both monotonic-max. Callers invoke
-/// this only after a successful unseal: the adoption gate (eagerly via
-/// [`adopt`](crate::gate::adopt), or deferred via
-/// [`PendingAdoption::commit`](crate::gate::PendingAdoption::commit)) and the
-/// child pipeline ([`ChildAdopter`](crate::net::ChildAdopter)) — so a record
-/// whose body never unsealed can never move a floor; the provenance the plain
-/// scalar arguments cannot express is enforced at those call sites.
+/// Advance floors after an AAD-confirmed **root** unseal. Raises the per-scope
+/// read-epoch floor to `epoch` and the per-name sequence floor to `sequence`,
+/// both monotonic-max. Callers invoke this only after a successful unseal
+/// behind the six-stage root gate: eagerly via [`adopt`](crate::gate::adopt),
+/// or deferred via [`PendingAdoption::commit`](crate::gate::PendingAdoption::commit)
+/// — so a record whose body never unsealed can never move a floor; the
+/// provenance the plain scalar arguments cannot express is enforced at those
+/// call sites. Child unseals go through [`advance_sequence_on_unseal`] instead.
 ///
 /// **Fail-safe ordering.** The read-epoch (revocation) and sequence floors are
 /// distinctly keyed. The batch lists the trust-critical **read-epoch
@@ -254,6 +254,20 @@ pub async fn advance_on_unseal<F: FloorStore>(
             FloorRaise::sequence(ipns_name, sequence),
         ])
         .await?;
+    Ok(())
+}
+
+/// Advance only the per-name sequence floor after an AAD-confirmed **child**
+/// unseal. The scope read-epoch floor advances only from gate-adopted roots
+/// ([`advance_on_unseal`]): a child's epoch is attested only by the
+/// epoch-independent read key, so it must never move the revocation boundary
+/// (blueprint/engine.md floor law).
+pub async fn advance_sequence_on_unseal<F: FloorStore>(
+    floors: &F,
+    ipns_name: &[u8],
+    sequence: u64,
+) -> SeamResult<()> {
+    floors.raise_sequence_floor(ipns_name, sequence).await?;
     Ok(())
 }
 
@@ -369,6 +383,52 @@ mod tests {
                 .unwrap();
             assert_eq!(sequence_floor(&floors, NAME).await.unwrap(), Some(5));
             assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(3));
+        });
+    }
+
+    #[test]
+    fn advance_sequence_on_unseal_never_touches_the_epoch_floor() {
+        let floors = InMemoryFloorStore::default();
+        block_on(async {
+            advance_sequence_on_unseal(&floors, NAME, 7).await.unwrap();
+            assert_eq!(sequence_floor(&floors, NAME).await.unwrap(), Some(7));
+            assert_eq!(
+                read_epoch_floor(&floors, &SCOPE).await.unwrap(),
+                None,
+                "a child unseal must not move the scope read-epoch floor"
+            );
+        });
+    }
+
+    #[test]
+    fn at_floor_admits_only_the_exact_floor() {
+        let floors = InMemoryFloorStore::default();
+        block_on(async {
+            advance_on_unseal(&floors, &SCOPE, NAME, 5, 1)
+                .await
+                .unwrap();
+            check(&floors, NAME, &SCOPE, 5, 1, Strictness::AtFloor)
+                .await
+                .expect("the exact floor re-opens");
+            for above_or_below in [4, 6] {
+                let err = check(
+                    &floors,
+                    NAME,
+                    &SCOPE,
+                    above_or_below,
+                    1,
+                    Strictness::AtFloor,
+                )
+                .await
+                .expect_err("anything but the exact floor is fail-closed");
+                assert!(matches!(
+                    err,
+                    GateError::Rejected(GateRejection {
+                        stage: GateStage::Sequence,
+                        reason: RejectionReason::SequenceNotNewer { floor: 5, .. },
+                    })
+                ));
+            }
         });
     }
 

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -27,6 +27,7 @@
 
 use cipherbox_core::payload::RepointObject;
 
+use crate::gate::{GateError, GateRejection, GateStage, RejectionReason};
 use crate::seams::{FloorRaise, FloorStore, SeamError, SeamResult};
 
 /// An owner-vouched epoch that regressed below a durable floor at cold-seed — a
@@ -164,6 +165,60 @@ pub async fn sequence_floor<F: FloorStore>(
     ipns_name: &[u8],
 ) -> SeamResult<Option<u64>> {
     floors.sequence_floor(ipns_name).await
+}
+
+/// How [`check`]'s sequence comparison treats a record at exactly the durable
+/// floor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Strictness {
+    /// The adopt path: the sequence must be strictly above the floor (a record
+    /// at the floor is our own current record, not an update).
+    StrictlyNewer,
+    /// The at-floor re-open path (our own current record / cached
+    /// last-known-good): equality is admitted; a strictly lower sequence stays
+    /// a fail-closed replay.
+    AtFloor,
+}
+
+/// The durable floor checks — gate stages 4/5: the per-name sequence floor
+/// (per `strictness`) and the scope's read-epoch floor (the revocation
+/// boundary, always `>=`). Shared by the root gate and the child pipeline.
+pub async fn check<F: FloorStore>(
+    floors: &F,
+    ipns_name: &[u8],
+    scope_id: &[u8; 16],
+    sequence: u64,
+    epoch: u64,
+    strictness: Strictness,
+) -> Result<(), GateError> {
+    let floor = sequence_floor(floors, ipns_name)
+        .await
+        .map_err(GateError::Seam)?
+        .unwrap_or(0);
+    let replayed = match strictness {
+        Strictness::StrictlyNewer => sequence <= floor,
+        Strictness::AtFloor => sequence < floor,
+    };
+    if replayed {
+        return Err(GateError::Rejected(GateRejection {
+            stage: GateStage::Sequence,
+            reason: RejectionReason::SequenceNotNewer { floor, sequence },
+        }));
+    }
+    let epoch_floor = read_epoch_floor(floors, scope_id)
+        .await
+        .map_err(GateError::Seam)?
+        .unwrap_or(0);
+    if epoch < epoch_floor {
+        return Err(GateError::Rejected(GateRejection {
+            stage: GateStage::Epoch,
+            reason: RejectionReason::EpochBelowFloor {
+                floor: epoch_floor,
+                epoch,
+            },
+        }));
+    }
+    Ok(())
 }
 
 /// Advance floors after an AAD-confirmed unseal — the only record-sourced

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -55,8 +55,8 @@ pub use content::{
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{
-    Command, Engine, EngineError, Event, EventStream, LoginSecret, NodeId, NodeKind, Permission,
-    PlaintextContent, Staleness,
+    Breadcrumb, Command, Engine, EngineError, Event, EventStream, LoginSecret, NodeId, NodeKind,
+    OpPhase, Permission, PlaintextContent, SnapshotChild, SnapshotView, Staleness,
 };
 pub use gate::{
     Adopted, Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason,

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -98,30 +98,12 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
         name: &IpnsName,
         record_bytes: &[u8],
     ) -> Result<Candidate, GateError> {
-        // Step 1 — verify to read the signed `/ipfs/<cid>` value (the head
-        // anchor). Trust is the gate's; this only extracts the anchor.
-        let verified = IpnsRecord::unmarshal(record_bytes)
-            .and_then(|record| record.verify(name))
-            .map_err(assembly_reject)?;
+        // Steps 1-4 are the shared head-envelope assembly; the sequence is
+        // discarded — the gate re-verifies the record from scratch.
+        let (_sequence, envelope) =
+            assemble_head_envelope(self.gateway, self.http, name, record_bytes).await?;
 
-        // Step 2/3 — recover the head CID string and the binary CIDv1 anchor.
-        let cid_str = head_cid_from_value(&verified.value)
-            .ok_or_else(|| assembly_reject(Malformed::ContentCidStrMalformed.into()))?;
-        let expected_cid = decode_content_cid_str(&cid_str).map_err(assembly_reject)?;
-
-        // Step 4 — fetch the head block (dag-cbor root), fail-closed on mismatch.
-        let block = read_block(
-            self.gateway,
-            self.http,
-            &cid_str,
-            &expected_cid,
-            ContentPlane::Root,
-        )
-        .await
-        .map_err(map_read_error)?;
-
-        // Step 5 — decode the envelope and its grant section.
-        let envelope = decode_envelope(&block).map_err(assembly_reject)?;
+        // Step 5 — decode the grant section.
         let section_bytes = grant_section_bytes(&envelope).ok_or_else(|| {
             assembly_reject(
                 Malformed::MissingField {
@@ -295,6 +277,32 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
         }
         Ok(Some(Zeroizing::new(*payload.write_scope_seed())))
     }
+}
+
+/// The head-envelope assembly shared by both adopters: verify the record to
+/// read its signed `/ipfs/<cid>` head anchor (trust is the gate's — this only
+/// extracts the anchor), fetch the head block fail-closed on a CID mismatch,
+/// and decode the envelope. Returns the verified record sequence alongside it.
+pub(super) async fn assemble_head_envelope<H: Http>(
+    gateway: &Gateway,
+    http: &H,
+    name: &IpnsName,
+    record_bytes: &[u8],
+) -> Result<(u64, Envelope), GateError> {
+    let verified = IpnsRecord::unmarshal(record_bytes)
+        .and_then(|record| record.verify(name))
+        .map_err(assembly_reject)?;
+
+    let cid_str = head_cid_from_value(&verified.value)
+        .ok_or_else(|| assembly_reject(Malformed::ContentCidStrMalformed.into()))?;
+    let expected_cid = decode_content_cid_str(&cid_str).map_err(assembly_reject)?;
+
+    let block = read_block(gateway, http, &cid_str, &expected_cid, ContentPlane::Root)
+        .await
+        .map_err(map_read_error)?;
+
+    let envelope = decode_envelope(&block).map_err(assembly_reject)?;
+    Ok((verified.sequence, envelope))
 }
 
 /// A fail-closed content-plane assembly failure: the head the signed record

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -168,7 +168,10 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
 
         // The derived read key is secret; this fn is its terminal owner, so it
         // zeroizes on drop (the gate borrows it and never zeroizes a caller buffer).
-        let node_seed = kdf::node_seed(payload.override_seed(), &env.id);
+        // The recovered scope read seed rides the outcome on a gate pass — the
+        // engine's per-scope seed cell feeds the child read pipeline from it.
+        let read_scope_seed = Zeroizing::new(*payload.override_seed());
+        let node_seed = kdf::node_seed(&read_scope_seed, &env.id);
         let read_key = Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes());
 
         let reader = ReaderContext {
@@ -206,6 +209,7 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
             adopted,
             write_scope_seed,
             node_id: env.id,
+            read_scope_seed: Some(read_scope_seed),
         })
     }
 
@@ -298,11 +302,11 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
 /// untrustworthy. Assembly runs before the gate's six stages, so it surfaces as
 /// a `RecordVerify` rejection carrying the verbatim core check (the check name
 /// carries the real detail).
-fn assembly_reject(e: CodecError) -> GateError {
+pub(super) fn assembly_reject(e: CodecError) -> GateError {
     reject(GateStage::RecordVerify, e)
 }
 
-fn reject(stage: GateStage, e: CodecError) -> GateError {
+pub(super) fn reject(stage: GateStage, e: CodecError) -> GateError {
     GateError::Rejected(GateRejection {
         stage,
         reason: RejectionReason::Trust(e),
@@ -312,7 +316,7 @@ fn reject(stage: GateStage, e: CodecError) -> GateError {
 /// Map a content-read failure: a CID mismatch/tamper is a fail-closed trust
 /// violation surfaced verbatim; no source or an over-cap body is availability (a
 /// retryable seam), never a trust verdict (`content/read.rs`).
-fn map_read_error(e: ReadError) -> GateError {
+pub(super) fn map_read_error(e: ReadError) -> GateError {
     match e {
         ReadError::TrustViolation(codec) => assembly_reject(codec),
         ReadError::Unavailable => GateError::Seam(SeamError::new("head block unavailable")),
@@ -636,6 +640,11 @@ mod tests {
         assert!(
             outcome.write_scope_seed.is_none(),
             "the owner arm surfaces no write seed (held keyless)"
+        );
+        assert_eq!(
+            outcome.read_scope_seed.as_deref(),
+            Some(&[0x66u8; 32]),
+            "a gate pass surfaces the owner-blob scope read seed"
         );
     }
 

--- a/crates/engine/src/net/child.rs
+++ b/crates/engine/src/net/child.rs
@@ -1,0 +1,263 @@
+//! The child-record [`Adopter`]: verified content-plane reads one level below
+//! the scope root (blueprint/engine.md "Content plane").
+//!
+//! A non-scope-root record carries no grant section, so the six-stage root gate
+//! cannot apply. The child pipeline instead composes: record verify → head
+//! fetch fail-closed on a CID mismatch → envelope binding (id + scope; a
+//! transplant rejects) → the per-name sequence and scope read-epoch floors →
+//! the AAD-bound read-body unseal under `read-key(node-seed(scopeReadSeed,
+//! id))` — the same KDF edges the root walks, one level down. Floors advance
+//! only after a successful unseal (the floor law). No new crypto: pure
+//! composition of core verify/unseal plus the frozen KDF catalog.
+
+use core::cell::RefCell;
+
+use cipherbox_core::content::decode_content_cid_str;
+use cipherbox_core::error::{Malformed, TrustViolation};
+use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::kdf;
+use cipherbox_core::seal::{Envelope, ReadBody, decode_envelope, open_read_body};
+use zeroize::Zeroizing;
+
+use super::adopter::{assembly_reject, map_read_error, reject};
+use super::publish::head_cid_from_value;
+use super::resolve::{AdoptOutcome, Adopter};
+use crate::content::{ContentPlane, Gateway, read_block};
+use crate::gate::{Adopted, GateError, GateRejection, GateStage, RejectionReason, floor};
+use crate::seams::{FloorStore, Http};
+
+/// The child-record [`Adopter`] for one non-root node of an owned scope.
+/// Borrows the content seams from the live session; terminally owns a
+/// zeroizing clone of the scope read seed (zeroized when the adopter drops).
+pub struct ChildAdopter<'a, H, F> {
+    /// Content read sources (accelerator + public fallbacks).
+    gateway: &'a Gateway,
+    /// The HTTP seam the head-block fetch rides.
+    http: &'a H,
+    /// The durable floor store the child floors read and advance.
+    floors: &'a F,
+    /// The scope the child must be sealed under (the AAD scope binding and the
+    /// read-epoch floor key). A foreign scope is a transplant, fail-closed.
+    scope_id: [u8; 16],
+    /// The scope read seed the per-node read key derives from.
+    scope_read_seed: Zeroizing<[u8; 32]>,
+    /// The node id the resolved envelope must carry — the rendered-view child
+    /// this read was issued for. A different id is a transplant, fail-closed.
+    expected_node: [u8; 16],
+    /// The envelope a floor-rejected [`Adopter::adopt`] assembled, kept so the
+    /// equal-floor re-open ([`Self::open_at_floor`]) reuses it instead of
+    /// re-fetching the same head block (mirrors
+    /// [`RootAdopter`](super::RootAdopter)).
+    assembled: RefCell<Option<AssembledChild>>,
+}
+
+/// One assembled child head, keyed by the record it came from.
+struct AssembledChild {
+    name: IpnsName,
+    record_bytes: Vec<u8>,
+    sequence: u64,
+    envelope: Envelope,
+}
+
+impl<'a, H, F> ChildAdopter<'a, H, F> {
+    /// Assemble a child adopter over the borrowed seams and the scope's read
+    /// material.
+    pub fn new(
+        gateway: &'a Gateway,
+        http: &'a H,
+        floors: &'a F,
+        scope_id: [u8; 16],
+        scope_read_seed: Zeroizing<[u8; 32]>,
+        expected_node: [u8; 16],
+    ) -> Self {
+        Self {
+            gateway,
+            http,
+            floors,
+            scope_id,
+            scope_read_seed,
+            expected_node,
+            assembled: RefCell::new(None),
+        }
+    }
+}
+
+impl<H: Http, F: FloorStore> ChildAdopter<'_, H, F> {
+    /// Record verify, CID-verified head fetch, envelope decode, and the child
+    /// bindings — every step fail-closed as a trust violation; a missing source
+    /// stays availability ([`map_read_error`]).
+    async fn assemble_envelope(
+        &self,
+        name: &IpnsName,
+        record_bytes: &[u8],
+    ) -> Result<(u64, Envelope), GateError> {
+        let verified = IpnsRecord::unmarshal(record_bytes)
+            .and_then(|record| record.verify(name))
+            .map_err(assembly_reject)?;
+
+        let cid_str = head_cid_from_value(&verified.value)
+            .ok_or_else(|| assembly_reject(Malformed::ContentCidStrMalformed.into()))?;
+        let expected_cid = decode_content_cid_str(&cid_str).map_err(assembly_reject)?;
+        let block = read_block(
+            self.gateway,
+            self.http,
+            &cid_str,
+            &expected_cid,
+            ContentPlane::Root,
+        )
+        .await
+        .map_err(map_read_error)?;
+
+        let envelope = decode_envelope(&block).map_err(assembly_reject)?;
+        // A grant section marks a scope root; granted-subscope reads are a
+        // later slice — fail closed, no partial support.
+        if envelope
+            .unknown
+            .iter()
+            .any(|(key, _)| key == "grantSection")
+        {
+            return Err(reject(
+                GateStage::GrantSection,
+                Malformed::UnexpectedType {
+                    expected: "child envelope",
+                    found: "grantSection",
+                }
+                .into(),
+            ));
+        }
+        // Transplant binding: the envelope must be exactly the expected node in
+        // this scope (the read-key KDF does not bind the scope UUID, so the
+        // scope check joins the same equivalence class as the root gate's).
+        if envelope.id != self.expected_node || envelope.scope != self.scope_id {
+            return Err(reject(
+                GateStage::Unseal,
+                TrustViolation::SealOpenFailed.into(),
+            ));
+        }
+        Ok((verified.sequence, envelope))
+    }
+
+    /// The child floor checks (root-gate stages 4/5). `strict` requires a
+    /// strictly newer sequence (the adopt path); the at-floor path admits
+    /// equality (our own current record) while a strictly lower sequence stays
+    /// a fail-closed replay.
+    async fn check_floors(
+        &self,
+        name: &IpnsName,
+        sequence: u64,
+        epoch: u64,
+        strict: bool,
+    ) -> Result<(), GateError> {
+        let sequence_floor = floor::sequence_floor(self.floors, name.as_str().as_bytes())
+            .await
+            .map_err(GateError::Seam)?
+            .unwrap_or(0);
+        let replayed = if strict {
+            sequence <= sequence_floor
+        } else {
+            sequence < sequence_floor
+        };
+        if replayed {
+            return Err(GateError::Rejected(GateRejection {
+                stage: GateStage::Sequence,
+                reason: RejectionReason::SequenceNotNewer {
+                    floor: sequence_floor,
+                    sequence,
+                },
+            }));
+        }
+        let epoch_floor = floor::read_epoch_floor(self.floors, &self.scope_id)
+            .await
+            .map_err(GateError::Seam)?
+            .unwrap_or(0);
+        if epoch < epoch_floor {
+            return Err(GateError::Rejected(GateRejection {
+                stage: GateStage::Epoch,
+                reason: RejectionReason::EpochBelowFloor {
+                    floor: epoch_floor,
+                    epoch,
+                },
+            }));
+        }
+        Ok(())
+    }
+
+    /// Unseal the read-body under the per-node read key derived from the scope
+    /// read seed (`node-seed` → `read-key`, the frozen KDF edges).
+    fn unseal(&self, envelope: &Envelope) -> Result<ReadBody, GateError> {
+        let node_seed = kdf::node_seed(&self.scope_read_seed, &envelope.id);
+        let read_key = kdf::read_key(node_seed.as_bytes());
+        open_read_body(envelope, read_key.as_bytes()).map_err(|e| reject(GateStage::Unseal, e))
+    }
+
+    /// Re-open a record already at the durable floor — our own current record
+    /// or the cached last-known-good. The full child pipeline minus the
+    /// strictly-newer requirement, with **no** floor advance (only a
+    /// gate-passing adopt moves floors).
+    pub(crate) async fn open_at_floor(
+        &self,
+        name: &IpnsName,
+        record_bytes: &[u8],
+    ) -> Result<Adopted, GateError> {
+        // Reuse the envelope the floor-rejected adopt assembled for these same
+        // bytes; assembling again re-fetches the head block.
+        let cached = self
+            .assembled
+            .borrow_mut()
+            .take()
+            .filter(|c| c.name == *name && c.record_bytes == record_bytes);
+        let (sequence, envelope) = match cached {
+            Some(cached) => (cached.sequence, cached.envelope),
+            None => self.assemble_envelope(name, record_bytes).await?,
+        };
+        self.check_floors(name, sequence, envelope.epoch, false)
+            .await?;
+        let read_body = self.unseal(&envelope)?;
+        Ok(Adopted {
+            read_body,
+            sequence,
+            epoch: envelope.epoch,
+        })
+    }
+}
+
+impl<H: Http, F: FloorStore> Adopter for ChildAdopter<'_, H, F> {
+    async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<AdoptOutcome, GateError> {
+        let (sequence, envelope) = self.assemble_envelope(name, record_bytes).await?;
+        if let Err(err) = self
+            .check_floors(name, sequence, envelope.epoch, true)
+            .await
+        {
+            // Keep the assembled head for the equal-floor re-open path — it
+            // re-fetches the same head block otherwise.
+            *self.assembled.borrow_mut() = Some(AssembledChild {
+                name: name.clone(),
+                record_bytes: record_bytes.to_vec(),
+                sequence,
+                envelope,
+            });
+            return Err(err);
+        }
+        let read_body = self.unseal(&envelope)?;
+        // Floors advance only after the AAD-confirmed unseal (the floor law).
+        floor::advance_on_unseal(
+            self.floors,
+            &self.scope_id,
+            name.as_str().as_bytes(),
+            sequence,
+            envelope.epoch,
+        )
+        .await
+        .map_err(GateError::Seam)?;
+        Ok(AdoptOutcome {
+            adopted: Adopted {
+                read_body,
+                sequence,
+                epoch: envelope.epoch,
+            },
+            write_scope_seed: None,
+            node_id: envelope.id,
+            read_scope_seed: None,
+        })
+    }
+}

--- a/crates/engine/src/net/child.rs
+++ b/crates/engine/src/net/child.rs
@@ -6,9 +6,11 @@
 //! fetch fail-closed on a CID mismatch → envelope binding (id + scope; a
 //! transplant rejects) → the per-name sequence and scope read-epoch floors →
 //! the AAD-bound read-body unseal under `read-key(node-seed(scopeReadSeed,
-//! id))` — the same KDF edges the root walks, one level down. Floors advance
-//! only after a successful unseal (the floor law). No new crypto: pure
-//! composition of core verify/unseal plus the frozen KDF catalog.
+//! id))` — the same KDF edges the root walks, one level down. The sequence
+//! floor advances only after a successful unseal (the floor law); the scope
+//! epoch floor never moves from a child
+//! ([`floor::advance_sequence_on_unseal`]). No new crypto: pure composition of
+//! core verify/unseal plus the frozen KDF catalog.
 
 use core::cell::RefCell;
 
@@ -185,16 +187,10 @@ impl<H: Http, F: FloorStore> Adopter for ChildAdopter<'_, H, F> {
             return Err(err);
         }
         let read_body = self.unseal(&envelope)?;
-        // Floors advance only after the AAD-confirmed unseal (the floor law).
-        floor::advance_on_unseal(
-            self.floors,
-            &self.scope_id,
-            name.as_str().as_bytes(),
-            sequence,
-            envelope.epoch,
-        )
-        .await
-        .map_err(GateError::Seam)?;
+        // Sequence floor only, after the AAD-confirmed unseal (the floor law).
+        floor::advance_sequence_on_unseal(self.floors, name.as_str().as_bytes(), sequence)
+            .await
+            .map_err(GateError::Seam)?;
         Ok(AdoptOutcome {
             adopted: Adopted {
                 read_body,

--- a/crates/engine/src/net/child.rs
+++ b/crates/engine/src/net/child.rs
@@ -12,18 +12,16 @@
 
 use core::cell::RefCell;
 
-use cipherbox_core::content::decode_content_cid_str;
 use cipherbox_core::error::{Malformed, TrustViolation};
-use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
-use cipherbox_core::seal::{Envelope, ReadBody, decode_envelope, open_read_body};
+use cipherbox_core::seal::{Envelope, ReadBody, has_grant_section, open_read_body};
 use zeroize::Zeroizing;
 
-use super::adopter::{assembly_reject, map_read_error, reject};
-use super::publish::head_cid_from_value;
+use super::adopter::{assemble_head_envelope, reject};
 use super::resolve::{AdoptOutcome, Adopter};
-use crate::content::{ContentPlane, Gateway, read_block};
-use crate::gate::{Adopted, GateError, GateRejection, GateStage, RejectionReason, floor};
+use crate::content::Gateway;
+use crate::gate::{Adopted, GateError, GateStage, floor};
 use crate::seams::{FloorStore, Http};
 
 /// The child-record [`Adopter`] for one non-root node of an owned scope.
@@ -83,39 +81,19 @@ impl<'a, H, F> ChildAdopter<'a, H, F> {
 }
 
 impl<H: Http, F: FloorStore> ChildAdopter<'_, H, F> {
-    /// Record verify, CID-verified head fetch, envelope decode, and the child
-    /// bindings — every step fail-closed as a trust violation; a missing source
-    /// stays availability ([`map_read_error`]).
+    /// The shared head-envelope assembly ([`assemble_head_envelope`]) plus the
+    /// child bindings — every step fail-closed as a trust violation; a missing
+    /// source stays availability.
     async fn assemble_envelope(
         &self,
         name: &IpnsName,
         record_bytes: &[u8],
     ) -> Result<(u64, Envelope), GateError> {
-        let verified = IpnsRecord::unmarshal(record_bytes)
-            .and_then(|record| record.verify(name))
-            .map_err(assembly_reject)?;
-
-        let cid_str = head_cid_from_value(&verified.value)
-            .ok_or_else(|| assembly_reject(Malformed::ContentCidStrMalformed.into()))?;
-        let expected_cid = decode_content_cid_str(&cid_str).map_err(assembly_reject)?;
-        let block = read_block(
-            self.gateway,
-            self.http,
-            &cid_str,
-            &expected_cid,
-            ContentPlane::Root,
-        )
-        .await
-        .map_err(map_read_error)?;
-
-        let envelope = decode_envelope(&block).map_err(assembly_reject)?;
+        let (sequence, envelope) =
+            assemble_head_envelope(self.gateway, self.http, name, record_bytes).await?;
         // A grant section marks a scope root; granted-subscope reads are a
         // later slice — fail closed, no partial support.
-        if envelope
-            .unknown
-            .iter()
-            .any(|(key, _)| key == "grantSection")
-        {
+        if has_grant_section(&envelope) {
             return Err(reject(
                 GateStage::GrantSection,
                 Malformed::UnexpectedType {
@@ -134,52 +112,7 @@ impl<H: Http, F: FloorStore> ChildAdopter<'_, H, F> {
                 TrustViolation::SealOpenFailed.into(),
             ));
         }
-        Ok((verified.sequence, envelope))
-    }
-
-    /// The child floor checks (root-gate stages 4/5). `strict` requires a
-    /// strictly newer sequence (the adopt path); the at-floor path admits
-    /// equality (our own current record) while a strictly lower sequence stays
-    /// a fail-closed replay.
-    async fn check_floors(
-        &self,
-        name: &IpnsName,
-        sequence: u64,
-        epoch: u64,
-        strict: bool,
-    ) -> Result<(), GateError> {
-        let sequence_floor = floor::sequence_floor(self.floors, name.as_str().as_bytes())
-            .await
-            .map_err(GateError::Seam)?
-            .unwrap_or(0);
-        let replayed = if strict {
-            sequence <= sequence_floor
-        } else {
-            sequence < sequence_floor
-        };
-        if replayed {
-            return Err(GateError::Rejected(GateRejection {
-                stage: GateStage::Sequence,
-                reason: RejectionReason::SequenceNotNewer {
-                    floor: sequence_floor,
-                    sequence,
-                },
-            }));
-        }
-        let epoch_floor = floor::read_epoch_floor(self.floors, &self.scope_id)
-            .await
-            .map_err(GateError::Seam)?
-            .unwrap_or(0);
-        if epoch < epoch_floor {
-            return Err(GateError::Rejected(GateRejection {
-                stage: GateStage::Epoch,
-                reason: RejectionReason::EpochBelowFloor {
-                    floor: epoch_floor,
-                    epoch,
-                },
-            }));
-        }
-        Ok(())
+        Ok((sequence, envelope))
     }
 
     /// Unseal the read-body under the per-node read key derived from the scope
@@ -210,8 +143,15 @@ impl<H: Http, F: FloorStore> ChildAdopter<'_, H, F> {
             Some(cached) => (cached.sequence, cached.envelope),
             None => self.assemble_envelope(name, record_bytes).await?,
         };
-        self.check_floors(name, sequence, envelope.epoch, false)
-            .await?;
+        floor::check(
+            self.floors,
+            name.as_str().as_bytes(),
+            &self.scope_id,
+            sequence,
+            envelope.epoch,
+            floor::Strictness::AtFloor,
+        )
+        .await?;
         let read_body = self.unseal(&envelope)?;
         Ok(Adopted {
             read_body,
@@ -224,9 +164,15 @@ impl<H: Http, F: FloorStore> ChildAdopter<'_, H, F> {
 impl<H: Http, F: FloorStore> Adopter for ChildAdopter<'_, H, F> {
     async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<AdoptOutcome, GateError> {
         let (sequence, envelope) = self.assemble_envelope(name, record_bytes).await?;
-        if let Err(err) = self
-            .check_floors(name, sequence, envelope.epoch, true)
-            .await
+        if let Err(err) = floor::check(
+            self.floors,
+            name.as_str().as_bytes(),
+            &self.scope_id,
+            sequence,
+            envelope.epoch,
+            floor::Strictness::StrictlyNewer,
+        )
+        .await
         {
             // Keep the assembled head for the equal-floor re-open path — it
             // re-fetches the same head block otherwise.

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -50,7 +50,7 @@ pub use pointer_fetch::RecordPointerFetch;
 pub use publish::{PublishError, PublishOutcome, PublishRequest, publish};
 pub use resolve::{AdoptOutcome, Adopter, ResolveOutcome, Resolved, resolve};
 pub(crate) use resolve::{
-    HeldMaterial, refresh_base_from_outcome, resolve_and_hold, resolve_with_read_seed,
+    GatedResolve, HeldMaterial, refresh_base_from_outcome, resolve_and_hold, resolve_gated,
 };
 pub use retire::{retire, root_retire_ready};
 pub use revival::{ReviveError, ReviveRequest, revive};

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -28,6 +28,7 @@
 //! [`publish::PublishOutcome::LostRace`] for the rebase slice.
 
 mod adopter;
+mod child;
 mod fanout;
 mod pointer_fetch;
 
@@ -39,6 +40,7 @@ pub mod retire;
 pub mod revival;
 
 pub use adopter::RootAdopter;
+pub use child::ChildAdopter;
 pub(crate) use liveness::eol_renew_pass;
 pub use liveness::{
     EolRenewResult, HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, RePutResult,
@@ -47,6 +49,8 @@ pub use liveness::{
 pub use pointer_fetch::RecordPointerFetch;
 pub use publish::{PublishError, PublishOutcome, PublishRequest, publish};
 pub use resolve::{AdoptOutcome, Adopter, ResolveOutcome, Resolved, resolve};
-pub(crate) use resolve::{HeldMaterial, refresh_base_from_outcome, resolve_and_hold};
+pub(crate) use resolve::{
+    HeldMaterial, refresh_base_from_outcome, resolve_and_hold, resolve_with_read_seed,
+};
 pub use retire::{retire, root_retire_ready};
 pub use revival::{ReviveError, ReviveRequest, revive};

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -73,6 +73,12 @@ pub struct AdoptOutcome {
     /// The scope-root node id (`id16`, the envelope id) — the held-set key and
     /// signer-derivation input for a gate-surfaced write grant.
     pub node_id: [u8; 16],
+    /// The scope read seed a gate-passing owner adopt recovered from the owner
+    /// blob. Transient like [`write_scope_seed`](Self::write_scope_seed): the
+    /// engine deposits it in its in-memory per-scope seed map (never persisted,
+    /// never on the public [`Resolved`]); the child read pipeline derives
+    /// per-node read keys from it. `None` for a non-owner adopter.
+    pub read_scope_seed: Option<Zeroizing<[u8; 32]>>,
 }
 
 /// What a resolve produced for the freshest fetched record.
@@ -127,26 +133,57 @@ where
     S: SnapshotCache,
     A: Adopter,
 {
-    // The public resolve drops the transient hold material — only the liveness
-    // driver ([`resolve_and_hold`]) consumes it.
+    // The public resolve drops the transient hold/seed material — only the
+    // engine drivers ([`resolve_and_hold`], [`resolve_with_read_seed`]) consume
+    // it.
     Ok(resolve_gated(transport, snapshot_cache, adopter, name)
         .await?
-        .0)
+        .resolved)
+}
+
+/// [`resolve`], additionally surfacing the scope read seed a gate-passing owner
+/// adopt recovered (see [`AdoptOutcome::read_scope_seed`]). Crate-internal so
+/// the seed never rides the public surface; the cold-start driver deposits it.
+pub(crate) async fn resolve_with_read_seed<T, S, A>(
+    transport: &T,
+    snapshot_cache: &S,
+    adopter: &A,
+    name: &IpnsName,
+) -> Result<(Resolved, Option<Zeroizing<[u8; 32]>>), SeamError>
+where
+    T: RecordTransport,
+    S: SnapshotCache,
+    A: Adopter,
+{
+    let gated = resolve_gated(transport, snapshot_cache, adopter, name).await?;
+    Ok((gated.resolved, gated.read_scope_seed))
 }
 
 /// The (node id, write scope seed) a gate-surfaced write grant contributes to
 /// the held set. `Some` only on a gate pass that carried a write seed.
 type AdoptHold = ([u8; 16], Zeroizing<[u8; 32]>);
 
-/// The gated resolve, returning the outcome plus, on a gate pass that surfaced a
-/// write seed, the transient hold material the held set consumes. Kept internal
-/// so the write seed never rides the public [`Resolved`].
+/// The internal gated-resolve product: the public outcome plus the transient
+/// material the engine drivers consume — kept off the public [`Resolved`] so no
+/// seed ever rides the facade-visible surface.
+struct GatedResolve {
+    /// The public resolve result.
+    resolved: Resolved,
+    /// The held-set (node id, write scope seed) from a gate-surfaced write grant.
+    hold: Option<AdoptHold>,
+    /// The verified record bytes an alive-worthy outcome rides to the hold.
+    held_bytes: Option<Vec<u8>>,
+    /// The scope read seed a gate-passing owner adopt recovered.
+    read_scope_seed: Option<Zeroizing<[u8; 32]>>,
+}
+
+/// The gated resolve behind [`resolve`]/[`resolve_and_hold`].
 async fn resolve_gated<T, S, A>(
     transport: &T,
     snapshot_cache: &S,
     adopter: &A,
     name: &IpnsName,
-) -> Result<(Resolved, Option<AdoptHold>, Option<Vec<u8>>), SeamError>
+) -> Result<GatedResolve, SeamError>
 where
     T: RecordTransport,
     S: SnapshotCache,
@@ -156,54 +193,63 @@ where
     // Cache-first: last-known-good renders immediately, reconcile runs behind it.
     let last_known_good = snapshot_cache.get(cache_key).await?;
 
-    let (outcome, hold, held_bytes) = match fanout_get_verify(transport, name).await {
-        None => (ResolveOutcome::NoUpdate, None, None),
-        Some((_sequence, bytes)) => match adopter.adopt(name, &bytes).await {
-            Ok(AdoptOutcome {
-                adopted,
-                write_scope_seed,
-                node_id,
-            }) => {
-                // Only gate-passing records touch the snapshot; the same verified
-                // bytes ride out to the liveness hold, so no re-fetch/re-get.
-                snapshot_cache.put(cache_key, &bytes).await?;
-                let hold = write_scope_seed.map(|seed| (node_id, seed));
-                (ResolveOutcome::Adopted(adopted), hold, Some(bytes))
-            }
-            // A record at exactly the durable sequence floor is our own current
-            // record re-fetched — no update, never a violation; its verified
-            // bytes ride out so the liveness loop holds them without a re-fetch.
-            // A strictly older sequence is a replay/rollback and stays a
-            // fail-closed trust violation, as does every other gate rejection.
-            Err(GateError::Rejected(rejection)) => match &rejection.reason {
-                RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor => {
-                    // Our own current root at exactly the floor: recover the
-                    // owner's write seed (fail-open) so the liveness loop can
-                    // hold+renew it before its EOL lapses (#752 F3). A non-owner
-                    // record or an unopenable owner-write-blob yields no hold.
-                    let hold = adopter.recover_own_write_seed(name, &bytes).await?;
+    let (outcome, hold, held_bytes, read_scope_seed) =
+        match fanout_get_verify(transport, name).await {
+            None => (ResolveOutcome::NoUpdate, None, None, None),
+            Some((_sequence, bytes)) => match adopter.adopt(name, &bytes).await {
+                Ok(AdoptOutcome {
+                    adopted,
+                    write_scope_seed,
+                    node_id,
+                    read_scope_seed,
+                }) => {
+                    // Only gate-passing records touch the snapshot; the same verified
+                    // bytes ride out to the liveness hold, so no re-fetch/re-get.
+                    snapshot_cache.put(cache_key, &bytes).await?;
+                    let hold = write_scope_seed.map(|seed| (node_id, seed));
                     (
-                        ResolveOutcome::Current {
-                            record_bytes: bytes.clone(),
-                        },
+                        ResolveOutcome::Adopted(adopted),
                         hold,
                         Some(bytes),
+                        read_scope_seed,
                     )
                 }
-                _ => (ResolveOutcome::TrustViolation(rejection), None, None),
+                // A record at exactly the durable sequence floor is our own current
+                // record re-fetched — no update, never a violation; its verified
+                // bytes ride out so the liveness loop holds them without a re-fetch.
+                // A strictly older sequence is a replay/rollback and stays a
+                // fail-closed trust violation, as does every other gate rejection.
+                Err(GateError::Rejected(rejection)) => match &rejection.reason {
+                    RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor => {
+                        // Our own current root at exactly the floor: recover the
+                        // owner's write seed (fail-open) so the liveness loop can
+                        // hold+renew it before its EOL lapses (#752 F3). A non-owner
+                        // record or an unopenable owner-write-blob yields no hold.
+                        let hold = adopter.recover_own_write_seed(name, &bytes).await?;
+                        (
+                            ResolveOutcome::Current {
+                                record_bytes: bytes.clone(),
+                            },
+                            hold,
+                            Some(bytes),
+                            None,
+                        )
+                    }
+                    _ => (ResolveOutcome::TrustViolation(rejection), None, None, None),
+                },
+                Err(GateError::Seam(error)) => return Err(error),
             },
-            Err(GateError::Seam(error)) => return Err(error),
-        },
-    };
+        };
 
-    Ok((
-        Resolved {
+    Ok(GatedResolve {
+        resolved: Resolved {
             last_known_good,
             outcome,
         },
         hold,
         held_bytes,
-    ))
+        read_scope_seed,
+    })
 }
 
 /// The transient insert-time input for a held record: the resolve/gate path has
@@ -231,6 +277,8 @@ pub(crate) struct HeldMaterial {
 /// same node) a [`HeldRecord`] so the keyless re-PUT loop keeps it alive. Only a
 /// gate-passing record enters the set — a `TrustViolation`/`NoUpdate` never
 /// does (blueprint/engine.md "Liveness": never re-PUT a stale record).
+/// Additionally surfaces the recovered scope read seed (see
+/// [`AdoptOutcome::read_scope_seed`]) for the tick driver's deposit.
 pub(crate) async fn resolve_and_hold<T, S, A>(
     transport: &T,
     snapshot_cache: &S,
@@ -238,14 +286,18 @@ pub(crate) async fn resolve_and_hold<T, S, A>(
     name: &IpnsName,
     held: &RefCell<HeldRecords>,
     material: &HeldMaterial,
-) -> Result<Resolved, SeamError>
+) -> Result<(Resolved, Option<Zeroizing<[u8; 32]>>), SeamError>
 where
     T: RecordTransport,
     S: SnapshotCache,
     A: Adopter,
 {
-    let (resolved, adopt_hold, held_bytes) =
-        resolve_gated(transport, snapshot_cache, adopter, name).await?;
+    let GatedResolve {
+        resolved,
+        hold: adopt_hold,
+        held_bytes,
+        read_scope_seed,
+    } = resolve_gated(transport, snapshot_cache, adopter, name).await?;
     // A gate-passing adopt (`Adopted`) and our own current record (`Current`)
     // are both alive-worthy and ride their verified bytes back here; a
     // `TrustViolation`/`NoUpdate` holds nothing (blueprint/engine.md "Liveness").
@@ -260,7 +312,7 @@ where
             .ok()
             .and_then(|verified| head_cid_from_value(&verified.value))
         else {
-            return Ok(resolved);
+            return Ok((resolved, read_scope_seed));
         };
         // The renewal (node id, write seed) comes from the gate for a write
         // grantee, else from the caller for an own-scope record. No seed on
@@ -272,7 +324,7 @@ where
                 .as_ref()
                 .map(|seed| (material.node_id, seed.clone()))
         }) else {
-            return Ok(resolved);
+            return Ok((resolved, read_scope_seed));
         };
         // Derive the narrow per-name signer once from the transient seed and hold
         // only it — the seed drops at this scope's end. Fail-closed encode-side
@@ -281,7 +333,7 @@ where
         // the hold rather than store a mismatched signer.
         let signer = SessionIdentity::write_name_signer(&write_scope_seed, &node_id);
         if IpnsName::from_public_key(&signer.verifying_key()) != *name {
-            return Ok(resolved);
+            return Ok((resolved, read_scope_seed));
         }
         // Content re-pin on renewal is a deferred slice; the record still
         // republishes validly under its head CID (only re-pinning is deferred).
@@ -296,7 +348,7 @@ where
             },
         );
     }
-    Ok(resolved)
+    Ok((resolved, read_scope_seed))
 }
 
 /// Fold a completed resolve's verdict into the shared base cell. A gate-passing
@@ -411,6 +463,7 @@ mod tests {
                     },
                     write_scope_seed: self.grant.map(|(seed, _)| Zeroizing::new(seed)),
                     node_id: self.grant.map(|(_, id)| id).unwrap_or([0u8; 16]),
+                    read_scope_seed: None,
                 }),
                 Verdict::TrustViolation => Err(GateError::Rejected(GateRejection {
                     stage: GateStage::RecordVerify,
@@ -463,7 +516,7 @@ mod tests {
             write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
             content_cids: vec!["bafycontent".into()],
         };
-        let resolved = block_on(resolve_and_hold(
+        let (resolved, _) = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
             &StubAdopter::new(Verdict::Accept),
@@ -504,7 +557,7 @@ mod tests {
 
         // A fail-closed trust violation is never held.
         let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
-        let out = block_on(resolve_and_hold(
+        let (out, _) = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
             &StubAdopter::new(Verdict::TrustViolation),
@@ -539,7 +592,7 @@ mod tests {
             write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
             content_cids: Vec::new(),
         };
-        let resolved = block_on(resolve_and_hold(
+        let (resolved, _) = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
             &StubAdopter::new(Verdict::EqualSequence),
@@ -602,7 +655,7 @@ mod tests {
             write_scope_seed: None,
             content_cids: Vec::new(),
         };
-        let resolved = block_on(resolve_and_hold(
+        let (resolved, _) = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
             &StubAdopter::own_current(write_scope_seed, node_id),
@@ -683,7 +736,7 @@ mod tests {
             write_scope_seed: None,
             content_cids: Vec::new(),
         };
-        let resolved = block_on(resolve_and_hold(
+        let (resolved, _) = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
             &StubAdopter::new(Verdict::EqualSequence),

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -134,51 +134,33 @@ where
     A: Adopter,
 {
     // The public resolve drops the transient hold/seed material — only the
-    // engine drivers ([`resolve_and_hold`], [`resolve_with_read_seed`]) consume
-    // it.
+    // engine drivers ([`resolve_gated`], [`resolve_and_hold`]) consume it.
     Ok(resolve_gated(transport, snapshot_cache, adopter, name)
         .await?
         .resolved)
 }
 
-/// [`resolve`], additionally surfacing the scope read seed a gate-passing owner
-/// adopt recovered (see [`AdoptOutcome::read_scope_seed`]). Crate-internal so
-/// the seed never rides the public surface; the cold-start driver deposits it.
-pub(crate) async fn resolve_with_read_seed<T, S, A>(
-    transport: &T,
-    snapshot_cache: &S,
-    adopter: &A,
-    name: &IpnsName,
-) -> Result<(Resolved, Option<Zeroizing<[u8; 32]>>), SeamError>
-where
-    T: RecordTransport,
-    S: SnapshotCache,
-    A: Adopter,
-{
-    let gated = resolve_gated(transport, snapshot_cache, adopter, name).await?;
-    Ok((gated.resolved, gated.read_scope_seed))
-}
-
 /// The (node id, write scope seed) a gate-surfaced write grant contributes to
 /// the held set. `Some` only on a gate pass that carried a write seed.
-type AdoptHold = ([u8; 16], Zeroizing<[u8; 32]>);
+pub(crate) type AdoptHold = ([u8; 16], Zeroizing<[u8; 32]>);
 
 /// The internal gated-resolve product: the public outcome plus the transient
 /// material the engine drivers consume — kept off the public [`Resolved`] so no
 /// seed ever rides the facade-visible surface.
-struct GatedResolve {
+pub(crate) struct GatedResolve {
     /// The public resolve result.
-    resolved: Resolved,
+    pub(crate) resolved: Resolved,
     /// The held-set (node id, write scope seed) from a gate-surfaced write grant.
-    hold: Option<AdoptHold>,
+    pub(crate) hold: Option<AdoptHold>,
     /// The verified record bytes an alive-worthy outcome rides to the hold.
-    held_bytes: Option<Vec<u8>>,
+    pub(crate) held_bytes: Option<Vec<u8>>,
     /// The scope read seed a gate-passing owner adopt recovered.
-    read_scope_seed: Option<Zeroizing<[u8; 32]>>,
+    pub(crate) read_scope_seed: Option<Zeroizing<[u8; 32]>>,
 }
 
-/// The gated resolve behind [`resolve`]/[`resolve_and_hold`].
-async fn resolve_gated<T, S, A>(
+/// The gated resolve behind [`resolve`]/[`resolve_and_hold`] and the cold-start
+/// driver.
+pub(crate) async fn resolve_gated<T, S, A>(
     transport: &T,
     snapshot_cache: &S,
     adopter: &A,

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -21,11 +21,12 @@
 //! the fail-closed points; the concrete fetchers plug in behind these traits.
 
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
+use zeroize::Zeroizing;
 
 use crate::facade::{Event, NodeId};
 use crate::gate::GateRejection;
 use crate::gate::floor::{self, ColdSeedError, FloorRegression};
-use crate::net::{Adopter, ResolveOutcome, resolve};
+use crate::net::{Adopter, ResolveOutcome, resolve_with_read_seed};
 use crate::seams::{FloorStore, RecordTransport, SeamError, SnapshotCache};
 use crate::sync::model::Snapshot;
 use crate::sync::op::Op;
@@ -54,6 +55,16 @@ pub struct ColdStartParams<'a> {
     pub root: NodeId,
     /// The durable pending-op queue, applied as the overlay on first paint.
     pub pending_ops: &'a [Op],
+}
+
+/// The out-channels the cold-start chain writes besides its return value: host
+/// events, and the in-memory deposit for the root-scope read seed a
+/// gate-passing adopt recovered (never persisted, never on the outcome).
+pub struct ColdStartSinks<'a> {
+    /// Event emitter (the first [`Event::SnapshotUpdated`] rides here).
+    pub emit: &'a mut dyn FnMut(Event),
+    /// Deposit for the recovered root-scope read seed.
+    pub deposit_read_seed: &'a mut dyn FnMut(Zeroizing<[u8; 32]>),
 }
 
 /// A fail-closed cold-start failure. [`ColdStartError::Seam`] is availability
@@ -134,7 +145,7 @@ pub async fn cold_start<Pf, Ad, Fl, T, Sc>(
     transport: &T,
     snapshot_cache: &Sc,
     params: &ColdStartParams<'_>,
-    emit: &mut dyn FnMut(Event),
+    sinks: &mut ColdStartSinks<'_>,
 ) -> Result<ColdStartOutcome, ColdStartError>
 where
     Pf: PointerFetch,
@@ -161,7 +172,7 @@ where
         // nothing (no floor seeds, no root), but the empty base ⊕ overlay still
         // paints so pending ops render.
         let rendered = apply_overlay(&base, params.pending_ops);
-        emit(Event::SnapshotUpdated);
+        (sinks.emit)(Event::SnapshotUpdated);
         return Ok(ColdStartOutcome {
             vault_pointer: None,
             root_resolve: None,
@@ -187,7 +198,7 @@ where
     // resolve: last-known-good rehydrates the first paint (step 5) while the
     // fan-out GET + adoption gate reconcile behind it (step 3). Every resolved
     // record passes the gate; a rejection is fail-closed.
-    let resolved = resolve(
+    let (resolved, read_scope_seed) = resolve_with_read_seed(
         transport,
         snapshot_cache,
         adopter,
@@ -195,6 +206,11 @@ where
     )
     .await
     .map_err(ColdStartError::Seam)?;
+    // A gate-passing adopt recovered the root-scope read seed: deposit it so
+    // the child read pipeline can derive per-node read keys this session.
+    if let Some(seed) = read_scope_seed {
+        (sinks.deposit_read_seed)(seed);
+    }
     // Project the gate-passing root read-body to its direct children (E7); an
     // availability-stale current record leaves the base at the anchored root.
     let (root_resolve, base) = match resolved.outcome {
@@ -213,7 +229,7 @@ where
 
     // Step 4 — first snapshot event with the pending-op overlay applied.
     let rendered = apply_overlay(&base, params.pending_ops);
-    emit(Event::SnapshotUpdated);
+    (sinks.emit)(Event::SnapshotUpdated);
 
     Ok(ColdStartOutcome {
         vault_pointer: Some(adoption),
@@ -338,6 +354,7 @@ mod tests {
                     adopted,
                     write_scope_seed: None,
                     node_id: [0u8; 16],
+                    read_scope_seed: None,
                 })
         }
     }
@@ -406,8 +423,13 @@ mod tests {
         };
         let out = {
             let mut emit = |e: Event| events.borrow_mut().push(e);
+            let mut deposit = |_seed: Zeroizing<[u8; 32]>| {};
+            let mut sinks = ColdStartSinks {
+                emit: &mut emit,
+                deposit_read_seed: &mut deposit,
+            };
             cold_start(
-                pointers, adopter, floors, transport, cache, &params, &mut emit,
+                pointers, adopter, floors, transport, cache, &params, &mut sinks,
             )
             .await
         };

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -26,7 +26,7 @@ use zeroize::Zeroizing;
 use crate::facade::{Event, NodeId};
 use crate::gate::GateRejection;
 use crate::gate::floor::{self, ColdSeedError, FloorRegression};
-use crate::net::{Adopter, ResolveOutcome, resolve_with_read_seed};
+use crate::net::{Adopter, GatedResolve, ResolveOutcome, resolve_gated};
 use crate::seams::{FloorStore, RecordTransport, SeamError, SnapshotCache};
 use crate::sync::model::Snapshot;
 use crate::sync::op::Op;
@@ -55,16 +55,6 @@ pub struct ColdStartParams<'a> {
     pub root: NodeId,
     /// The durable pending-op queue, applied as the overlay on first paint.
     pub pending_ops: &'a [Op],
-}
-
-/// The out-channels the cold-start chain writes besides its return value: host
-/// events, and the in-memory deposit for the root-scope read seed a
-/// gate-passing adopt recovered (never persisted, never on the outcome).
-pub struct ColdStartSinks<'a> {
-    /// Event emitter (the first [`Event::SnapshotUpdated`] rides here).
-    pub emit: &'a mut dyn FnMut(Event),
-    /// Deposit for the recovered root-scope read seed.
-    pub deposit_read_seed: &'a mut dyn FnMut(Zeroizing<[u8; 32]>),
 }
 
 /// A fail-closed cold-start failure. [`ColdStartError::Seam`] is availability
@@ -113,7 +103,11 @@ pub enum RootResolve {
 }
 
 /// What the cold-start data path produced.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `Debug` is hand-written: [`read_scope_seed`](Self::read_scope_seed) is key
+/// material and must never reach a log site (security rule 2), including a
+/// test-assertion `{:?}`.
+#[derive(Clone, PartialEq, Eq)]
 pub struct ColdStartOutcome {
     /// The adopted vault pointer, or `None` on an empty chain (a first-run vault
     /// with no pointer yet — cold start adopts nothing).
@@ -130,6 +124,26 @@ pub struct ColdStartOutcome {
     /// The rendered view emitted on the first snapshot event: `base` ⊕ the
     /// pending-op overlay.
     pub rendered: Snapshot,
+    /// The root-scope read seed a gate-passing adopt recovered from the owner
+    /// blob; `None` when nothing adopted. The engine deposits it in its
+    /// in-memory per-scope seed cell (never persisted).
+    pub read_scope_seed: Option<Zeroizing<[u8; 32]>>,
+}
+
+impl core::fmt::Debug for ColdStartOutcome {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ColdStartOutcome")
+            .field("vault_pointer", &self.vault_pointer)
+            .field("root_resolve", &self.root_resolve)
+            .field("rehydrated", &self.rehydrated)
+            .field("base", &self.base)
+            .field("rendered", &self.rendered)
+            .field(
+                "read_scope_seed",
+                &self.read_scope_seed.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 /// Run the cold-start live-session data path off the injected seams, emitting
@@ -145,7 +159,7 @@ pub async fn cold_start<Pf, Ad, Fl, T, Sc>(
     transport: &T,
     snapshot_cache: &Sc,
     params: &ColdStartParams<'_>,
-    sinks: &mut ColdStartSinks<'_>,
+    emit: &mut dyn FnMut(Event),
 ) -> Result<ColdStartOutcome, ColdStartError>
 where
     Pf: PointerFetch,
@@ -172,13 +186,14 @@ where
         // nothing (no floor seeds, no root), but the empty base ⊕ overlay still
         // paints so pending ops render.
         let rendered = apply_overlay(&base, params.pending_ops);
-        (sinks.emit)(Event::SnapshotUpdated);
+        emit(Event::SnapshotUpdated);
         return Ok(ColdStartOutcome {
             vault_pointer: None,
             root_resolve: None,
             rehydrated: false,
             base,
             rendered,
+            read_scope_seed: None,
         });
     };
 
@@ -198,7 +213,11 @@ where
     // resolve: last-known-good rehydrates the first paint (step 5) while the
     // fan-out GET + adoption gate reconcile behind it (step 3). Every resolved
     // record passes the gate; a rejection is fail-closed.
-    let (resolved, read_scope_seed) = resolve_with_read_seed(
+    let GatedResolve {
+        resolved,
+        read_scope_seed,
+        ..
+    } = resolve_gated(
         transport,
         snapshot_cache,
         adopter,
@@ -206,11 +225,6 @@ where
     )
     .await
     .map_err(ColdStartError::Seam)?;
-    // A gate-passing adopt recovered the root-scope read seed: deposit it so
-    // the child read pipeline can derive per-node read keys this session.
-    if let Some(seed) = read_scope_seed {
-        (sinks.deposit_read_seed)(seed);
-    }
     // Project the gate-passing root read-body to its direct children (E7); an
     // availability-stale current record leaves the base at the anchored root.
     let (root_resolve, base) = match resolved.outcome {
@@ -229,7 +243,7 @@ where
 
     // Step 4 — first snapshot event with the pending-op overlay applied.
     let rendered = apply_overlay(&base, params.pending_ops);
-    (sinks.emit)(Event::SnapshotUpdated);
+    emit(Event::SnapshotUpdated);
 
     Ok(ColdStartOutcome {
         vault_pointer: Some(adoption),
@@ -237,6 +251,7 @@ where
         rehydrated: resolved.last_known_good.is_some(),
         base,
         rendered,
+        read_scope_seed,
     })
 }
 
@@ -421,18 +436,16 @@ mod tests {
             root: root_id(),
             pending_ops: pending,
         };
-        let out = {
-            let mut emit = |e: Event| events.borrow_mut().push(e);
-            let mut deposit = |_seed: Zeroizing<[u8; 32]>| {};
-            let mut sinks = ColdStartSinks {
-                emit: &mut emit,
-                deposit_read_seed: &mut deposit,
-            };
-            cold_start(
-                pointers, adopter, floors, transport, cache, &params, &mut sinks,
-            )
-            .await
-        };
+        let out = cold_start(
+            pointers,
+            adopter,
+            floors,
+            transport,
+            cache,
+            &params,
+            &mut |e: Event| events.borrow_mut().push(e),
+        )
+        .await;
         (out, events.into_inner())
     }
 

--- a/crates/engine/src/sync/model.rs
+++ b/crates/engine/src/sync/model.rs
@@ -33,10 +33,20 @@ pub struct NodeMeta {
     /// Bumped on every `updateContent` (a fresh per-version content key seals
     /// each version, CONTEXT.md "Content key").
     pub content_version: u64,
+    /// Plaintext content size in bytes; `None` until the content plane
+    /// projects it.
+    pub size: Option<u64>,
+    /// Modification time (Unix millis) from the sealed read-body; `None`
+    /// until projected.
+    pub mtime: Option<u64>,
+    /// The node's opaque `ipnsName` bytes as carried by its parent's
+    /// `ChildRef`; `None` for nodes not yet in gate-passing state.
+    pub ipns_name: Option<Vec<u8>>,
 }
 
 impl NodeMeta {
-    /// A node at record sequence 1, content version 0.
+    /// A node at record sequence 1, content version 0, no projected
+    /// size/mtime/ipnsName.
     pub fn new(id: NodeId, name: impl Into<String>, kind: NodeKind) -> Self {
         Self {
             id,
@@ -44,6 +54,9 @@ impl NodeMeta {
             kind,
             record_sequence: 1,
             content_version: 0,
+            size: None,
+            mtime: None,
+            ipns_name: None,
         }
     }
 }

--- a/crates/engine/src/sync/project.rs
+++ b/crates/engine/src/sync/project.rs
@@ -44,6 +44,24 @@ pub(crate) fn project_root(root: NodeId, adopted: &Adopted) -> Snapshot {
     snapshot
 }
 
+/// Fold a verified head version's plaintext `(size, mtime)` into the base
+/// node. Returns whether either value actually changed, so the caller repaints
+/// only on a real change (a repeat read of the same version is a no-op).
+pub(crate) fn project_child_version(
+    snapshot: &mut Snapshot,
+    node: NodeId,
+    size: u64,
+    mtime: u64,
+) -> bool {
+    let Some(meta) = snapshot.node_mut(node) else {
+        return false;
+    };
+    let changed = meta.size != Some(size) || meta.mtime != Some(mtime);
+    meta.size = Some(size);
+    meta.mtime = Some(mtime);
+    changed
+}
+
 /// Map the core wire node kind onto the structurally-identical facade kind.
 fn map_kind(kind: CoreNodeKind) -> NodeKind {
     match kind {
@@ -153,6 +171,22 @@ mod tests {
             Some(vec![1]),
             "the ChildRef ipnsName rides into the projected meta"
         );
+    }
+
+    #[test]
+    fn project_child_version_reports_change_once() {
+        let root = node_id(0);
+        let adopted = adopted_folder(vec![child(1, "a", CoreNodeKind::File, 1)], 1);
+        let mut snap = project_root(root, &adopted);
+
+        assert!(project_child_version(&mut snap, node_id(1), 10, 99));
+        assert_eq!(snap.node(node_id(1)).unwrap().size, Some(10));
+        assert_eq!(snap.node(node_id(1)).unwrap().mtime, Some(99));
+        // The identical fold changes nothing; a differing one does.
+        assert!(!project_child_version(&mut snap, node_id(1), 10, 99));
+        assert!(project_child_version(&mut snap, node_id(1), 11, 99));
+        // An absent node folds nothing.
+        assert!(!project_child_version(&mut snap, node_id(7), 1, 1));
     }
 
     #[test]

--- a/crates/engine/src/sync/project.rs
+++ b/crates/engine/src/sync/project.rs
@@ -23,10 +23,20 @@ pub(crate) fn project_root(root: NodeId, adopted: &Adopted) -> Snapshot {
         node.record_sequence = adopted.sequence;
     }
 
-    if let ReadBody::Folder { children, .. } = &adopted.read_body {
+    if let ReadBody::Folder {
+        modified_at,
+        children,
+        ..
+    } = &adopted.read_body
+    {
+        if let Some(node) = snapshot.node_mut(root) {
+            node.mtime = Some(*modified_at);
+        }
         for child in children {
             let id = NodeId(child.id);
-            snapshot.upsert_node(NodeMeta::new(id, child.name.clone(), map_kind(child.kind)));
+            let mut meta = NodeMeta::new(id, child.name.clone(), map_kind(child.kind));
+            meta.ipns_name = Some(child.ipns_name.clone());
+            snapshot.upsert_node(meta);
             snapshot.link(root, id, child.link_counter);
         }
     }
@@ -129,5 +139,39 @@ mod tests {
         let snap = project_root(root, &adopted);
 
         assert_eq!(snap.record_sequence(root), Some(42));
+    }
+
+    #[test]
+    fn project_root_carries_child_ipns_name_verbatim() {
+        let root = node_id(0);
+        let adopted = adopted_folder(vec![child(1, "a", CoreNodeKind::File, 1)], 1);
+
+        let snap = project_root(root, &adopted);
+
+        assert_eq!(
+            snap.node(node_id(1)).unwrap().ipns_name,
+            Some(vec![1]),
+            "the ChildRef ipnsName rides into the projected meta"
+        );
+    }
+
+    #[test]
+    fn project_root_sets_root_mtime_from_modified_at() {
+        let root = node_id(0);
+        let adopted = Adopted {
+            read_body: ReadBody::Folder {
+                created_at: 5,
+                modified_at: 777,
+                children: Vec::new(),
+                unknown: Vec::new(),
+            },
+            sequence: 1,
+            epoch: 0,
+        };
+
+        let snap = project_root(root, &adopted);
+
+        assert_eq!(snap.node(root).unwrap().mtime, Some(777));
+        assert_eq!(snap.node(root).unwrap().size, None);
     }
 }

--- a/crates/engine/tests/net.rs
+++ b/crates/engine/tests/net.rs
@@ -175,6 +175,7 @@ impl Adopter for StubAdopter {
                 },
                 write_scope_seed: None,
                 node_id: [0u8; 16],
+                read_scope_seed: None,
             }),
             Verdict::TrustViolation => Err(GateError::Rejected(GateRejection {
                 stage: GateStage::RecordVerify,

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -36,10 +36,10 @@ js-sys = "0.3"
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1"
 getrandom = { version = "0.3", features = ["wasm_js"] }
-# Async mutex: serializes the single engine writer across `.await` (concurrent
-# `start`/`command` queue rather than double-borrowing), and bounds `nextEvent`
-# to one outstanding stream read.
-futures-util = { version = "0.3", default-features = false, features = ["std"] }
+# Async locks: an RwLock lets reads (`snapshot`/`download`) share the engine
+# while `start`/`command` serialize as the single writer; a Mutex bounds
+# `nextEvent` to one outstanding stream read.
+async-lock = "3"
 # Wraps the accelerator bearer token in a zeroizing buffer before it reaches the
 # engine's `GatewaySource` — the credential never sits in a plain `String`.
 zeroize.workspace = true

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -1,10 +1,12 @@
 //! The production engine host: constructs the one engine instance over the
-//! browser seams and exposes `start` / `command` / `nextEvent` to the worker.
+//! browser seams and exposes `start` / `command` / `snapshot` / `download` /
+//! `nextEvent` to the worker.
 //!
 //! Loaded inside `packages/client`'s dedicated engine worker (never the UI
-//! realm). `start` and `command` mutate the single engine writer behind an
-//! async mutex, so concurrent calls queue rather than race; `nextEvent` reads
-//! the independent event stream and runs concurrently with a command.
+//! realm). `start`, `command`, and the reads (`snapshot`, `download`) share
+//! the single engine behind an async mutex, so concurrent calls queue rather
+//! than race; `nextEvent` reads the independent event stream and runs
+//! concurrently with a command.
 //!
 //! Key material lives only in this worker's WASM linear memory: the login
 //! secret enters once through `start` (copied into the engine's `Zeroizing`
@@ -19,7 +21,7 @@ use cipherbox_engine::{
     Entropy, EntropyError, GatewayConfig, GatewaySource, SeamSet, SeamTypes, SyncTimingProfile,
 };
 use futures_util::lock::Mutex;
-use js_sys::{Promise, Reflect};
+use js_sys::{Promise, Reflect, Uint8Array};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 use zeroize::Zeroizing;
@@ -31,7 +33,7 @@ use crate::seams_bridge::{
     RecordTransportAdapter, RefreshHintSourceAdapter, SchedulerAdapter, SnapshotCacheAdapter,
     StagingStoreAdapter,
 };
-use crate::{Command, Event};
+use crate::{Command, Event, NodeId, SnapshotView};
 
 /// The web host's concrete seam family (blueprint/engine.md `SeamTypes`): every
 /// engine seam is a JS-object adapter from `seams_bridge`.
@@ -203,6 +205,39 @@ impl EngineHandle {
                 .await
                 .map_err(engine_error)?;
             Ok(JsValue::UNDEFINED)
+        })
+    }
+
+    /// Reads a key-free [`SnapshotView`] of `folder` for a UI paint. Resolves
+    /// with the view; rejects with the engine error.
+    pub fn snapshot(&self, folder: &NodeId) -> Promise {
+        let engine = self.engine.clone();
+        let folder = folder.facade();
+        future_to_promise(async move {
+            let view = engine
+                .lock()
+                .await
+                .snapshot(folder)
+                .await
+                .map_err(engine_error)?;
+            Ok(SnapshotView::from_facade(view).into())
+        })
+    }
+
+    /// Downloads and decrypts one file node's content through the verified
+    /// read pipeline. Resolves with the plaintext bytes as a `Uint8Array`;
+    /// rejects with the engine error.
+    pub fn download(&self, node: &NodeId) -> Promise {
+        let engine = self.engine.clone();
+        let node = node.facade();
+        future_to_promise(async move {
+            let bytes = engine
+                .lock()
+                .await
+                .read_content(node)
+                .await
+                .map_err(engine_error)?;
+            Ok(Uint8Array::from(bytes.as_slice()).into())
         })
     }
 

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -3,10 +3,10 @@
 //! `nextEvent` to the worker.
 //!
 //! Loaded inside `packages/client`'s dedicated engine worker (never the UI
-//! realm). `start`, `command`, and the reads (`snapshot`, `download`) share
-//! the single engine behind an async mutex, so concurrent calls queue rather
-//! than race; `nextEvent` reads the independent event stream and runs
-//! concurrently with a command.
+//! realm). The single engine sits behind an async RwLock: `start`/`command`
+//! take the write lock and serialize, while the reads (`snapshot`, `download`)
+//! share the read lock — a long download never blocks a snapshot. `nextEvent`
+//! reads the independent event stream and runs concurrently with a command.
 //!
 //! Key material lives only in this worker's WASM linear memory: the login
 //! secret enters once through `start` (copied into the engine's `Zeroizing`
@@ -16,11 +16,11 @@
 
 use std::rc::Rc;
 
-use cipherbox_engine::facade::{Engine, EventStream, LoginSecret};
+use async_lock::{Mutex, RwLock};
+use cipherbox_engine::facade::{Engine, EngineError, EventStream, LoginSecret};
 use cipherbox_engine::{
     Entropy, EntropyError, GatewayConfig, GatewaySource, SeamSet, SeamTypes, SyncTimingProfile,
 };
-use futures_util::lock::Mutex;
 use js_sys::{Promise, Reflect, Uint8Array};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
@@ -76,7 +76,7 @@ fn take_seam<T: JsCast>(bag: &JsValue, key: &str) -> Result<T, JsError> {
 /// The one long-lived engine instance for this origin, hosted in the worker.
 #[wasm_bindgen]
 pub struct EngineHandle {
-    engine: Rc<Mutex<Engine<WebSeamTypes>>>,
+    engine: Rc<RwLock<Engine<WebSeamTypes>>>,
     events: Rc<Mutex<EventStream>>,
 }
 
@@ -169,7 +169,7 @@ impl EngineHandle {
             gateway,
         );
         Ok(EngineHandle {
-            engine: Rc::new(Mutex::new(engine)),
+            engine: Rc::new(RwLock::new(engine)),
             events: Rc::new(Mutex::new(events)),
         })
     }
@@ -183,7 +183,7 @@ impl EngineHandle {
         let engine = self.engine.clone();
         future_to_promise(async move {
             engine
-                .lock()
+                .write()
                 .await
                 .start(LoginSecret::new(secret))
                 .await
@@ -199,7 +199,7 @@ impl EngineHandle {
         let facade_command = command.into_facade();
         future_to_promise(async move {
             engine
-                .lock()
+                .write()
                 .await
                 .command(facade_command)
                 .await
@@ -215,7 +215,7 @@ impl EngineHandle {
         let folder = folder.facade();
         future_to_promise(async move {
             let view = engine
-                .lock()
+                .read()
                 .await
                 .snapshot(folder)
                 .await
@@ -232,7 +232,7 @@ impl EngineHandle {
         let node = node.facade();
         future_to_promise(async move {
             let bytes = engine
-                .lock()
+                .read()
                 .await
                 .read_content(node)
                 .await
@@ -256,8 +256,28 @@ impl EngineHandle {
     }
 }
 
-/// Renders an engine error as a rejection value (diagnostic string, no key
-/// material — the engine's `Display` is redacted by construction).
-fn engine_error(error: cipherbox_engine::facade::EngineError) -> JsValue {
-    JsError::new(&error.to_string()).into()
+/// Renders an engine error as a rejection value: a `js_sys::Error` whose
+/// message is the diagnostic `Display` string (no key material — redacted by
+/// construction) and whose `code` property is the stable camelCase variant
+/// name the client matches on instead of the prose.
+fn engine_error(error: EngineError) -> JsValue {
+    let code = match &error {
+        EngineError::NotStarted => "notStarted",
+        EngineError::AlreadyStarted => "alreadyStarted",
+        EngineError::InvalidSecret => "invalidSecret",
+        EngineError::UnknownNode => "unknownNode",
+        EngineError::NotAFolder => "notAFolder",
+        EngineError::NotAFile => "notAFile",
+        EngineError::ContentUnavailable { .. } => "contentUnavailable",
+        EngineError::TrustViolation { .. } => "trustViolation",
+        EngineError::Unimplemented { .. } => "unimplemented",
+        EngineError::Seam { .. } => "seam",
+        EngineError::Entropy { .. } => "entropy",
+        EngineError::Auth { .. } => "auth",
+        EngineError::ColdStart { .. } => "coldStart",
+    };
+    let js = js_sys::Error::new(&error.to_string());
+    // Setting a plain property on a fresh `Error` cannot fail.
+    let _ = Reflect::set(&js, &JsValue::from_str("code"), &JsValue::from_str(code));
+    js.into()
 }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -344,6 +344,7 @@ impl Event {
             facade::Event::DeadLetter { .. } => "deadLetter",
             facade::Event::AttributableAbuse { .. } => "attributableAbuse",
             facade::Event::RenewalFailed { .. } => "renewalFailed",
+            facade::Event::OpProgress { .. } => "opProgress",
         }
         .to_string()
     }
@@ -495,5 +496,13 @@ mod tests {
             ipns_name: vec![1, 2, 3],
         });
         assert_eq!(withheld.ipns_name(), Some(vec![1, 2, 3]));
+
+        let progress = Event::from_facade(facade::Event::OpProgress {
+            op_id: None,
+            node: facade::NodeId([0u8; 16]),
+            phase: facade::OpPhase::DownloadStarted,
+            error: None,
+        });
+        assert_eq!(progress.kind(), "opProgress");
     }
 }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -14,14 +14,8 @@
 //! IPNS sequence numbers) cross as `bigint`, binary payloads as `Uint8Array`,
 //! and no secret key material crosses at all — the command surface exposes
 //! only intent (a grant carries the recipient's *public* identity key, never
-//! a secret), and the event surface only key-free view state.
-//!
-//! Scope of this slice: the facade's **command builders** and **event
-//! readers** plus their boundary value types. The live engine handle
-//! (`start`, `command`, the event-stream reader) and the login-secret ingress
-//! bind once their host seams and worker transport land (blueprint/web-client.md
-//! "Engine hosting"); they are deliberately absent here — this crate lands no
-//! seams, no transports, and no worker hosting.
+//! a secret), and the event and read surfaces only key-free view state and
+//! decrypted user content (snapshot views, downloaded plaintext bytes).
 
 // wasm-bindgen's macro-generated glue is unsafe by nature and exempt; this
 // forbids only unsafe we would hand-write (there is none).
@@ -37,7 +31,8 @@ use wasm_bindgen::prelude::*;
 mod seams_bridge;
 
 // The production engine host: constructs the one engine instance over the
-// browser seams and exposes `start`/`command`/`nextEvent` to the worker.
+// browser seams and exposes `start`/`command`/`snapshot`/`download`/`nextEvent`
+// to the worker.
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 mod host;
 
@@ -104,6 +99,15 @@ impl From<NodeKind> for facade::NodeKind {
     }
 }
 
+impl From<facade::NodeKind> for NodeKind {
+    fn from(kind: facade::NodeKind) -> Self {
+        match kind {
+            facade::NodeKind::File => NodeKind::File,
+            facade::NodeKind::Folder => NodeKind::Folder,
+        }
+    }
+}
+
 /// Grant permission level.
 #[wasm_bindgen]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -147,6 +151,193 @@ impl From<facade::Staleness> for Staleness {
             facade::Staleness::Stale => Staleness::Stale,
             facade::Staleness::Offline => Staleness::Offline,
         }
+    }
+}
+
+/// The phase an `opProgress` event reports.
+#[wasm_bindgen]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpPhase {
+    /// A content download started.
+    DownloadStarted,
+    /// A content download completed.
+    DownloadCompleted,
+    /// A content download failed.
+    DownloadFailed,
+}
+
+impl From<facade::OpPhase> for OpPhase {
+    fn from(phase: facade::OpPhase) -> Self {
+        match phase {
+            facade::OpPhase::DownloadStarted => OpPhase::DownloadStarted,
+            facade::OpPhase::DownloadCompleted => OpPhase::DownloadCompleted,
+            facade::OpPhase::DownloadFailed => OpPhase::DownloadFailed,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot read surface — key-free view state projected by the engine. Ids
+// cross as raw 16-byte `Uint8Array`s (the `NodeId.bytes` shape), `u64`s as
+// `bigint`, absent projections as `undefined`.
+// ---------------------------------------------------------------------------
+
+/// One ancestor step in a [`SnapshotView`]'s breadcrumb trail.
+#[wasm_bindgen]
+pub struct Breadcrumb {
+    inner: facade::Breadcrumb,
+}
+
+#[wasm_bindgen]
+impl Breadcrumb {
+    /// The 16 raw bytes of the ancestor's node id.
+    #[wasm_bindgen(getter)]
+    pub fn id(&self) -> Vec<u8> {
+        self.inner.id.0.to_vec()
+    }
+
+    /// Display name, as entered (empty for the root).
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        self.inner.name.clone()
+    }
+}
+
+impl Breadcrumb {
+    /// Wraps an engine breadcrumb. Never exported to JS.
+    pub fn from_facade(inner: facade::Breadcrumb) -> Self {
+        Self { inner }
+    }
+}
+
+/// One direct child in a [`SnapshotView`].
+#[wasm_bindgen]
+pub struct SnapshotChild {
+    inner: facade::SnapshotChild,
+}
+
+#[wasm_bindgen]
+impl SnapshotChild {
+    /// The 16 raw bytes of the child's node id.
+    #[wasm_bindgen(getter)]
+    pub fn id(&self) -> Vec<u8> {
+        self.inner.id.0.to_vec()
+    }
+
+    /// Display name, as entered.
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        self.inner.name.clone()
+    }
+
+    /// File or folder.
+    #[wasm_bindgen(getter)]
+    pub fn kind(&self) -> NodeKind {
+        self.inner.kind.into()
+    }
+
+    /// Plaintext content size in bytes (a `bigint`), or `undefined` until the
+    /// content plane projects it.
+    #[wasm_bindgen(getter)]
+    pub fn size(&self) -> Option<u64> {
+        self.inner.size
+    }
+
+    /// Modification time in Unix millis (a `bigint`), or `undefined` until
+    /// projected.
+    #[wasm_bindgen(getter)]
+    pub fn mtime(&self) -> Option<u64> {
+        self.inner.mtime
+    }
+
+    /// Whether a queued pending op targets this node.
+    #[wasm_bindgen(getter)]
+    pub fn pending(&self) -> bool {
+        self.inner.pending
+    }
+
+    /// Whether a retained dead-lettered op maps to this node.
+    #[wasm_bindgen(getter, js_name = deadLetter)]
+    pub fn dead_letter(&self) -> bool {
+        self.inner.dead_letter
+    }
+
+    /// Current content version (a `bigint`, bumped per `updateContent`).
+    #[wasm_bindgen(getter, js_name = contentVersion)]
+    pub fn content_version(&self) -> u64 {
+        self.inner.content_version
+    }
+}
+
+impl SnapshotChild {
+    /// Wraps an engine snapshot child. Never exported to JS.
+    pub fn from_facade(inner: facade::SnapshotChild) -> Self {
+        Self { inner }
+    }
+}
+
+/// A key-free snapshot of one folder for a host UI paint: children, breadcrumb
+/// trail, retained dead letters, and the staleness rung.
+#[wasm_bindgen]
+pub struct SnapshotView {
+    inner: facade::SnapshotView,
+}
+
+#[wasm_bindgen]
+impl SnapshotView {
+    /// The 16 raw bytes of the rendered root node id.
+    #[wasm_bindgen(getter)]
+    pub fn root(&self) -> Vec<u8> {
+        self.inner.root.0.to_vec()
+    }
+
+    /// The 16 raw bytes of the folder this view lists.
+    #[wasm_bindgen(getter)]
+    pub fn folder(&self) -> Vec<u8> {
+        self.inner.folder.0.to_vec()
+    }
+
+    /// Direct children, deterministically ordered by node id.
+    #[wasm_bindgen(getter)]
+    pub fn children(&self) -> Vec<SnapshotChild> {
+        self.inner
+            .children
+            .iter()
+            .cloned()
+            .map(SnapshotChild::from_facade)
+            .collect()
+    }
+
+    /// Ancestor trail from the folder's parent up to and including the root,
+    /// nearest first.
+    #[wasm_bindgen(getter)]
+    pub fn ancestors(&self) -> Vec<Breadcrumb> {
+        self.inner
+            .ancestors
+            .iter()
+            .cloned()
+            .map(Breadcrumb::from_facade)
+            .collect()
+    }
+
+    /// Every retained dead-lettered op id (`u64`s, crossing as `bigint`s).
+    #[wasm_bindgen(getter, js_name = deadLetters)]
+    pub fn dead_letters(&self) -> Vec<u64> {
+        self.inner.dead_letters.iter().map(|op| op.0).collect()
+    }
+
+    /// The staleness rung at read time.
+    #[wasm_bindgen(getter)]
+    pub fn staleness(&self) -> Staleness {
+        self.inner.staleness.into()
+    }
+}
+
+impl SnapshotView {
+    /// Wraps an engine snapshot view for the boundary. For the engine handle
+    /// and the boundary tests; never exported to JS.
+    pub fn from_facade(inner: facade::SnapshotView) -> Self {
+        Self { inner }
     }
 }
 
@@ -368,12 +559,42 @@ impl Event {
         }
     }
 
-    /// `deadLetter`: the op id (a `u64`, crossing as `bigint`); otherwise
-    /// `undefined`.
+    /// `deadLetter` or `opProgress`: the op id (a `u64`, crossing as
+    /// `bigint`); otherwise (or for an op-less transfer) `undefined`.
     #[wasm_bindgen(getter, js_name = opId)]
     pub fn op_id(&self) -> Option<u64> {
         match self.inner {
             facade::Event::DeadLetter { op_id } => Some(op_id.0),
+            facade::Event::OpProgress { op_id, .. } => op_id.map(|op| op.0),
+            _ => None,
+        }
+    }
+
+    /// `opProgress`: the 16 raw bytes of the transferring node's id; otherwise
+    /// `undefined`.
+    #[wasm_bindgen(getter)]
+    pub fn node(&self) -> Option<Vec<u8>> {
+        match self.inner {
+            facade::Event::OpProgress { node, .. } => Some(node.0.to_vec()),
+            _ => None,
+        }
+    }
+
+    /// `opProgress`: the phase reached; otherwise `undefined`.
+    #[wasm_bindgen(getter)]
+    pub fn phase(&self) -> Option<OpPhase> {
+        match self.inner {
+            facade::Event::OpProgress { phase, .. } => Some(phase.into()),
+            _ => None,
+        }
+    }
+
+    /// `opProgress`: the key-free failure classification for a failed phase;
+    /// otherwise `undefined`.
+    #[wasm_bindgen(getter)]
+    pub fn error(&self) -> Option<String> {
+        match &self.inner {
+            facade::Event::OpProgress { error, .. } => error.clone(),
             _ => None,
         }
     }
@@ -504,5 +725,97 @@ mod tests {
             error: None,
         });
         assert_eq!(progress.kind(), "opProgress");
+    }
+
+    #[test]
+    fn op_progress_getters_map_the_payload_and_stay_undefined_off_variant() {
+        let progress = Event::from_facade(facade::Event::OpProgress {
+            op_id: Some(OpId(7)),
+            node: facade::NodeId([3u8; 16]),
+            phase: facade::OpPhase::DownloadFailed,
+            error: Some("unavailable".into()),
+        });
+        assert_eq!(progress.op_id(), Some(7));
+        assert_eq!(progress.node(), Some(vec![3u8; 16]));
+        assert_eq!(progress.phase(), Some(OpPhase::DownloadFailed));
+        assert_eq!(progress.error(), Some("unavailable".into()));
+
+        let op_less = Event::from_facade(facade::Event::OpProgress {
+            op_id: None,
+            node: facade::NodeId([0u8; 16]),
+            phase: facade::OpPhase::DownloadStarted,
+            error: None,
+        });
+        assert!(op_less.op_id().is_none());
+        assert_eq!(op_less.phase(), Some(OpPhase::DownloadStarted));
+        assert!(op_less.error().is_none());
+
+        let other = Event::from_facade(facade::Event::SnapshotUpdated);
+        assert!(other.node().is_none());
+        assert!(other.phase().is_none());
+        assert!(other.error().is_none());
+    }
+
+    // Constructs the facade structs literally so a new engine field breaks this
+    // test at compile time, mirroring the exhaustive-match guard for enums.
+    #[test]
+    fn snapshot_view_getters_map_every_field() {
+        let view = SnapshotView::from_facade(facade::SnapshotView {
+            root: facade::NodeId([1u8; 16]),
+            folder: facade::NodeId([2u8; 16]),
+            children: vec![
+                facade::SnapshotChild {
+                    id: facade::NodeId([3u8; 16]),
+                    name: "photo.jpg".into(),
+                    kind: facade::NodeKind::File,
+                    size: Some(1024),
+                    mtime: Some(1_700_000_000_000),
+                    pending: true,
+                    dead_letter: false,
+                    content_version: 2,
+                },
+                facade::SnapshotChild {
+                    id: facade::NodeId([4u8; 16]),
+                    name: "docs".into(),
+                    kind: facade::NodeKind::Folder,
+                    size: None,
+                    mtime: None,
+                    pending: false,
+                    dead_letter: true,
+                    content_version: 0,
+                },
+            ],
+            ancestors: vec![facade::Breadcrumb {
+                id: facade::NodeId([1u8; 16]),
+                name: String::new(),
+            }],
+            dead_letters: vec![OpId(9), OpId(11)],
+            staleness: facade::Staleness::Reconciling,
+        });
+
+        assert_eq!(view.root(), vec![1u8; 16]);
+        assert_eq!(view.folder(), vec![2u8; 16]);
+        assert_eq!(view.dead_letters(), vec![9, 11]);
+        assert_eq!(view.staleness(), Staleness::Reconciling);
+
+        let children = view.children();
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].id(), vec![3u8; 16]);
+        assert_eq!(children[0].name(), "photo.jpg");
+        assert_eq!(children[0].kind(), NodeKind::File);
+        assert_eq!(children[0].size(), Some(1024));
+        assert_eq!(children[0].mtime(), Some(1_700_000_000_000));
+        assert!(children[0].pending());
+        assert!(!children[0].dead_letter());
+        assert_eq!(children[0].content_version(), 2);
+        assert_eq!(children[1].kind(), NodeKind::Folder);
+        assert!(children[1].size().is_none());
+        assert!(children[1].mtime().is_none());
+        assert!(children[1].dead_letter());
+
+        let ancestors = view.ancestors();
+        assert_eq!(ancestors.len(), 1);
+        assert_eq!(ancestors[0].id(), vec![1u8; 16]);
+        assert_eq!(ancestors[0].name(), "");
     }
 }

--- a/crates/wasm/tests/boundary.rs
+++ b/crates/wasm/tests/boundary.rs
@@ -10,8 +10,10 @@
 
 use cipherbox_engine::facade;
 use cipherbox_engine::seams::OpId;
-use cipherbox_wasm::{Command, Event, NodeId, NodeKind, Permission, Staleness};
-use js_sys::{BigInt, Reflect, Uint8Array};
+use cipherbox_wasm::{
+    Command, Event, NodeId, NodeKind, OpPhase, Permission, SnapshotView, Staleness,
+};
+use js_sys::{Array, BigInt, Reflect, Uint8Array};
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -115,4 +117,166 @@ fn event_getters_map_variants() {
         ipns_name: vec![9, 8, 7],
     });
     assert_eq!(withheld.ipns_name(), Some(vec![9, 8, 7]));
+}
+
+/// `opProgress` payload getters cross with boundary-correct JS shapes — op id
+/// as `bigint`, node id as `Uint8Array` — and every getter is `undefined` both
+/// off-variant and for an absent optional field.
+#[wasm_bindgen_test]
+fn op_progress_getters_cross_and_stay_undefined_off_variant() {
+    let progress = Event::from_facade(facade::Event::OpProgress {
+        op_id: Some(OpId(u64::MAX)),
+        node: facade::NodeId([5u8; 16]),
+        phase: facade::OpPhase::DownloadFailed,
+        error: Some("unavailable".into()),
+    });
+    assert_eq!(progress.kind(), "opProgress");
+    assert_eq!(progress.phase(), Some(OpPhase::DownloadFailed));
+    assert_eq!(progress.error(), Some("unavailable".into()));
+
+    let js: JsValue = progress.into();
+    let op_id = Reflect::get(&js, &JsValue::from_str("opId")).expect("opId getter is readable");
+    assert_eq!(op_id.js_typeof(), JsValue::from_str("bigint"));
+    let node = Reflect::get(&js, &JsValue::from_str("node")).expect("node getter is readable");
+    assert!(node.is_instance_of::<Uint8Array>());
+    assert_eq!(node.unchecked_into::<Uint8Array>().to_vec(), vec![5u8; 16]);
+
+    let op_less = Event::from_facade(facade::Event::OpProgress {
+        op_id: None,
+        node: facade::NodeId([0u8; 16]),
+        phase: facade::OpPhase::DownloadStarted,
+        error: None,
+    });
+    assert!(op_less.op_id().is_none());
+    assert!(op_less.error().is_none());
+    let js: JsValue = op_less.into();
+    assert!(
+        Reflect::get(&js, &JsValue::from_str("opId"))
+            .expect("opId getter is readable")
+            .is_undefined()
+    );
+    assert!(
+        Reflect::get(&js, &JsValue::from_str("error"))
+            .expect("error getter is readable")
+            .is_undefined()
+    );
+
+    let other: JsValue = Event::from_facade(facade::Event::SnapshotUpdated).into();
+    for key in ["node", "phase", "error", "opId"] {
+        assert!(
+            Reflect::get(&other, &JsValue::from_str(key))
+                .expect("getter is readable")
+                .is_undefined(),
+            "{key} must be undefined off-variant"
+        );
+    }
+}
+
+/// The snapshot read surface crosses with boundary-correct JS shapes: node ids
+/// as `Uint8Array`, `u64`s as `bigint`, absent projections as `undefined`, and
+/// children/ancestors as JS arrays of the wrapped types.
+#[wasm_bindgen_test]
+fn snapshot_view_getters_cross_with_boundary_shapes() {
+    let view: JsValue = SnapshotView::from_facade(facade::SnapshotView {
+        root: facade::NodeId([1u8; 16]),
+        folder: facade::NodeId([2u8; 16]),
+        children: vec![
+            facade::SnapshotChild {
+                id: facade::NodeId([3u8; 16]),
+                name: "photo.jpg".into(),
+                kind: facade::NodeKind::File,
+                size: Some(u64::MAX),
+                mtime: Some(1_700_000_000_000),
+                pending: true,
+                dead_letter: false,
+                content_version: 2,
+            },
+            facade::SnapshotChild {
+                id: facade::NodeId([4u8; 16]),
+                name: "docs".into(),
+                kind: facade::NodeKind::Folder,
+                size: None,
+                mtime: None,
+                pending: false,
+                dead_letter: true,
+                content_version: 0,
+            },
+        ],
+        ancestors: vec![facade::Breadcrumb {
+            id: facade::NodeId([1u8; 16]),
+            name: String::new(),
+        }],
+        dead_letters: vec![OpId(9)],
+        staleness: facade::Staleness::Fresh,
+    })
+    .into();
+
+    let get = |target: &JsValue, key: &str| {
+        Reflect::get(target, &JsValue::from_str(key)).expect("getter is readable")
+    };
+
+    let root = get(&view, "root");
+    assert!(root.is_instance_of::<Uint8Array>());
+    assert_eq!(root.unchecked_into::<Uint8Array>().to_vec(), vec![1u8; 16]);
+    let folder = get(&view, "folder");
+    assert_eq!(
+        folder.unchecked_into::<Uint8Array>().to_vec(),
+        vec![2u8; 16]
+    );
+
+    // Dead-letter op ids are u64s and must cross as bigints.
+    let dead_letters = get(&view, "deadLetters");
+    assert!(dead_letters.is_instance_of::<js_sys::BigUint64Array>());
+    assert_eq!(
+        dead_letters
+            .unchecked_into::<js_sys::BigUint64Array>()
+            .to_vec(),
+        vec![9u64]
+    );
+
+    let children = get(&view, "children");
+    assert!(children.is_instance_of::<Array>());
+    let children = children.unchecked_into::<Array>();
+    assert_eq!(children.length(), 2);
+
+    let file = children.get(0);
+    assert_eq!(get(&file, "name"), JsValue::from_str("photo.jpg"));
+    let id = get(&file, "id");
+    assert!(id.is_instance_of::<Uint8Array>());
+    assert_eq!(id.unchecked_into::<Uint8Array>().to_vec(), vec![3u8; 16]);
+    let size = get(&file, "size");
+    assert_eq!(
+        size.js_typeof(),
+        JsValue::from_str("bigint"),
+        "size must cross as a JS bigint, never a number"
+    );
+    let decimal = String::from(
+        size.unchecked_into::<BigInt>()
+            .to_string(10)
+            .expect("bigint renders in base 10"),
+    );
+    assert_eq!(decimal, u64::MAX.to_string());
+    assert_eq!(
+        get(&file, "contentVersion").js_typeof(),
+        JsValue::from_str("bigint")
+    );
+    assert_eq!(get(&file, "pending"), JsValue::TRUE);
+    assert_eq!(get(&file, "deadLetter"), JsValue::FALSE);
+
+    let folder_child = children.get(1);
+    assert!(
+        get(&folder_child, "size").is_undefined(),
+        "an unprojected size must cross as undefined"
+    );
+    assert!(get(&folder_child, "mtime").is_undefined());
+    assert_eq!(get(&folder_child, "deadLetter"), JsValue::TRUE);
+
+    let ancestors = get(&view, "ancestors").unchecked_into::<Array>();
+    assert_eq!(ancestors.length(), 1);
+    let crumb = ancestors.get(0);
+    assert_eq!(get(&crumb, "name"), JsValue::from_str(""));
+    assert_eq!(
+        get(&crumb, "id").unchecked_into::<Uint8Array>().to_vec(),
+        vec![1u8; 16]
+    );
 }

--- a/packages/client/src/broadcast.ts
+++ b/packages/client/src/broadcast.ts
@@ -68,9 +68,9 @@ export type LeaderMessage =
   | { type: 'cb:leaderGone'; token: string }
   /**
    * The correlated result of a follower's command or read. A snapshot read's
-   * ok carries `result`; a download's carries `content` as a `Blob` — the
-   * structured clone per receiver shares the immutable backing store, so the
-   * cross-tab hop copies no bytes (same rationale as `hoistContent`).
+   * ok carries the descriptor in `result`; a download's carries a `Blob` there
+   * — the structured clone per receiver shares the immutable backing store, so
+   * the cross-tab hop copies no bytes (same rationale as `hoistContent`).
    */
   | {
       type: 'cb:response';
@@ -78,9 +78,13 @@ export type LeaderMessage =
       clientId: string;
       requestId: number;
       ok: true;
-      result?: SnapshotDescriptor;
-      content?: Blob;
+      result?: SnapshotDescriptor | Blob;
     }
+  /**
+   * A failed command/read. `error` is the human-readable diagnostic; `code` is
+   * the engine's stable machine-readable error code when the failure came from
+   * the engine.
+   */
   | {
       type: 'cb:response';
       token: string;
@@ -88,6 +92,7 @@ export type LeaderMessage =
       requestId: number;
       ok: false;
       error: string;
+      code?: string;
     }
   /** One engine event, fanned out to every follower in emission order. */
   | { type: 'cb:event'; token: string; event: EventDescriptor };

--- a/packages/client/src/broadcast.ts
+++ b/packages/client/src/broadcast.ts
@@ -15,7 +15,7 @@
  *   cross-tab hop copies no bytes (blueprint "no byte copies for uploads").
  */
 
-import type { CommandDescriptor, EventDescriptor } from './worker/protocol.js';
+import type { CommandDescriptor, EventDescriptor, SnapshotDescriptor } from './worker/protocol.js';
 
 /** The subset of `BroadcastChannel` the transport/relay drive (injectable). */
 export interface BroadcastChannelLike {
@@ -35,12 +35,19 @@ export interface WireCommand {
   content?: Blob;
 }
 
+/** A follower read intent: served by the leader's engine, answered by value. */
+export type WireRead =
+  | { kind: 'snapshot'; folder: Uint8Array }
+  | { kind: 'download'; node: Uint8Array };
+
 /** Follower → leader messages. */
 export type FollowerMessage =
   /** A follower announces itself so the leader replies with a `leader` beacon. */
   | { type: 'cb:hello'; clientId: string }
   /** A correlated command; the leader answers with a matching `response`. */
   | { type: 'cb:command'; clientId: string; requestId: number; wire: WireCommand }
+  /** A correlated read; the leader answers with a value-bearing `response`. */
+  | { type: 'cb:read'; clientId: string; requestId: number; read: WireRead }
   /** This tab's currently open folder (for the leader's focus-window union). */
   | { type: 'cb:focus'; clientId: string; node: Uint8Array | null }
   /** A follower is leaving (tab close / transport teardown). */
@@ -59,8 +66,21 @@ export type LeaderMessage =
   | { type: 'cb:leader'; token: string }
   /** The current leader is stepping down (graceful teardown); re-arm the gate. */
   | { type: 'cb:leaderGone'; token: string }
-  /** The correlated result of a follower's command. */
-  | { type: 'cb:response'; token: string; clientId: string; requestId: number; ok: true }
+  /**
+   * The correlated result of a follower's command or read. A snapshot read's
+   * ok carries `result`; a download's carries `content` as a `Blob` — the
+   * structured clone per receiver shares the immutable backing store, so the
+   * cross-tab hop copies no bytes (same rationale as `hoistContent`).
+   */
+  | {
+      type: 'cb:response';
+      token: string;
+      clientId: string;
+      requestId: number;
+      ok: true;
+      result?: SnapshotDescriptor;
+      content?: Blob;
+    }
   | {
       type: 'cb:response';
       token: string;

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { BroadcastTransport } from './broadcastTransport.js';
 import { LeaderRelay } from './leaderRelay.js';
 import { FakeBus, FakeEngineTransport } from './testkit.js';
-import type { EventDescriptor } from './worker/protocol.js';
+import type { EventDescriptor, SnapshotDescriptor } from './worker/protocol.js';
 
 const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -148,6 +148,121 @@ describe('broadcast transport ↔ leader relay', () => {
 
     const hints = engine.commands.slice(before).filter((c) => c.kind === 'manualRefresh');
     expect(hints.length).toBe(1);
+  });
+
+  it('round-trips a follower snapshot through the leader engine', async () => {
+    const { engine, follower } = wire();
+    const view: SnapshotDescriptor = {
+      root: new Uint8Array(16).fill(1),
+      folder: new Uint8Array(16).fill(2),
+      children: [
+        {
+          id: new Uint8Array(16).fill(3),
+          name: 'photo.jpg',
+          kind: 'file',
+          size: 1024n,
+          mtime: null,
+          pending: true,
+          deadLetter: false,
+          contentVersion: 9_007_199_254_740_993n,
+        },
+      ],
+      ancestors: [{ id: new Uint8Array(16).fill(1), name: '' }],
+      deadLetters: [7n],
+      staleness: 'reconciling',
+    };
+    engine.respondSnapshot = () => Promise.resolve(view);
+
+    const folder = new Uint8Array(16).fill(2);
+    // Structured clone across the bus must preserve bytes and bigints intact.
+    await expect(follower.snapshot(folder)).resolves.toEqual(view);
+    expect(engine.snapshots).toEqual([folder]);
+  });
+
+  it('serves a follower download as a Blob and rebuilds identical bytes', async () => {
+    const { engine, follower } = wire();
+    const plaintext = Uint8Array.from({ length: 64 }, (_, i) => (i * 11 + 5) & 0xff);
+    engine.respondDownload = () => Promise.resolve(plaintext.buffer.slice(0));
+
+    const node = new Uint8Array(16).fill(6);
+    const content = await follower.download(node);
+    expect([...new Uint8Array(content)]).toEqual([...plaintext]);
+    expect(engine.downloads).toEqual([node]);
+  });
+
+  it('propagates a read rejection back to the follower', async () => {
+    const { engine, follower } = wire();
+    engine.respondSnapshot = () => Promise.reject(new Error('unknown node'));
+    engine.respondDownload = () => Promise.reject(new Error('content unavailable: pending'));
+
+    await expect(follower.snapshot(new Uint8Array(16))).rejects.toThrow('unknown node');
+    await expect(follower.download(new Uint8Array(16))).rejects.toThrow('content unavailable');
+  });
+
+  it('rejects a forged read response bearing a wrong or absent leader token', async () => {
+    const bus = new FakeBus();
+    const engine = new FakeEngineTransport();
+    engine.respondSnapshot = () => new Promise(() => undefined); // the real leader never answers
+    new LeaderRelay(bus.channel(), engine);
+    const follower = new BroadcastTransport(bus.channel(), 'f');
+    await follower.start();
+
+    const pending = follower.snapshot(new Uint8Array(16));
+    let settled = false;
+    void pending.then(
+      () => (settled = true),
+      () => (settled = true)
+    );
+    await tick();
+
+    const forgedView: SnapshotDescriptor = {
+      root: new Uint8Array(16),
+      folder: new Uint8Array(16),
+      children: [],
+      ancestors: [],
+      deadLetters: [],
+      staleness: 'fresh',
+    };
+    const attacker = bus.channel();
+    attacker.postMessage({
+      type: 'cb:response',
+      token: 'forged-token',
+      clientId: 'f',
+      requestId: 1,
+      ok: true,
+      result: forgedView,
+    });
+    attacker.postMessage({
+      type: 'cb:response',
+      clientId: 'f',
+      requestId: 1,
+      ok: true,
+      result: forgedView,
+    });
+    await tick();
+
+    expect(settled).toBe(false);
+  });
+
+  it('rejects an in-flight read retryably when the leader steps down', async () => {
+    const bus = new FakeBus();
+    const engineA = new FakeEngineTransport();
+    engineA.respondSnapshot = () => new Promise(() => undefined); // leader A never answers
+    const relayA = new LeaderRelay(bus.channel(), engineA);
+    const follower = new BroadcastTransport(bus.channel(), 'f');
+    await follower.start();
+
+    const inFlight = follower.snapshot(new Uint8Array(16));
+    await tick();
+    relayA.close();
+    await expect(inFlight).rejects.toThrow(/retry/);
+
+    // A read issued with no leader parks, then resolves against the next leader.
+    const queued = follower.snapshot(new Uint8Array(16).fill(4));
+    const engineB = new FakeEngineTransport();
+    new LeaderRelay(bus.channel(), engineB);
+    await expect(queued).resolves.toMatchObject({ staleness: 'fresh' });
+    expect(engineB.snapshots).toHaveLength(1);
   });
 
   it('re-arms on leadership change: an in-flight command rejects retryably, later commands await the next leader (P1-3)', async () => {

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import { BroadcastTransport } from './broadcastTransport.js';
+import { EngineRequestError } from './correlatedTransport.js';
 import { LeaderRelay } from './leaderRelay.js';
-import { FakeBus, FakeEngineTransport } from './testkit.js';
+import { emptySnapshot, FakeBus, FakeEngineTransport } from './testkit.js';
 import type { EventDescriptor, SnapshotDescriptor } from './worker/protocol.js';
 
 const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
@@ -190,13 +191,21 @@ describe('broadcast transport ↔ leader relay', () => {
     expect(engine.downloads).toEqual([node]);
   });
 
-  it('propagates a read rejection back to the follower', async () => {
+  it('propagates a read rejection back to the follower with the stable code', async () => {
     const { engine, follower } = wire();
-    engine.respondSnapshot = () => Promise.reject(new Error('unknown node'));
-    engine.respondDownload = () => Promise.reject(new Error('content unavailable: pending'));
+    engine.respondSnapshot = () =>
+      Promise.reject(new EngineRequestError('unknown node', 'unknownNode'));
+    engine.respondDownload = () =>
+      Promise.reject(new EngineRequestError('content unavailable: pending', 'contentUnavailable'));
 
-    await expect(follower.snapshot(new Uint8Array(16))).rejects.toThrow('unknown node');
-    await expect(follower.download(new Uint8Array(16))).rejects.toThrow('content unavailable');
+    // The code crosses the broadcast wire alongside the human-readable message.
+    await expect(follower.snapshot(new Uint8Array(16))).rejects.toMatchObject({
+      code: 'unknownNode',
+      message: 'unknown node',
+    });
+    await expect(follower.download(new Uint8Array(16))).rejects.toMatchObject({
+      code: 'contentUnavailable',
+    });
   });
 
   it('rejects a forged read response bearing a wrong or absent leader token', async () => {
@@ -215,14 +224,7 @@ describe('broadcast transport ↔ leader relay', () => {
     );
     await tick();
 
-    const forgedView: SnapshotDescriptor = {
-      root: new Uint8Array(16),
-      folder: new Uint8Array(16),
-      children: [],
-      ancestors: [],
-      deadLetters: [],
-      staleness: 'fresh',
-    };
+    const forgedView: SnapshotDescriptor = emptySnapshot();
     const attacker = bus.channel();
     attacker.postMessage({
       type: 'cb:response',

--- a/packages/client/src/broadcastTransport.ts
+++ b/packages/client/src/broadcastTransport.ts
@@ -133,9 +133,9 @@ export class BroadcastTransport extends CorrelatedTransport {
         if (response.clientId !== this.clientId) return;
         if (!this.fromActiveLeader(response.token)) return; // forged / stale ack
         if (response.ok) {
-          this.settle(response.requestId, true, undefined, response.content ?? response.result);
+          this.settle(response.requestId, true, undefined, response.result);
         } else {
-          this.settle(response.requestId, false, response.error);
+          this.settle(response.requestId, false, response.error, undefined, response.code);
         }
         return;
       }

--- a/packages/client/src/broadcastTransport.ts
+++ b/packages/client/src/broadcastTransport.ts
@@ -15,9 +15,14 @@
  * context.
  */
 
-import { hoistContent, type BroadcastChannelLike, type LeaderMessage } from './broadcast.js';
+import {
+  hoistContent,
+  type BroadcastChannelLike,
+  type LeaderMessage,
+  type WireRead,
+} from './broadcast.js';
 import { CorrelatedTransport } from './correlatedTransport.js';
-import type { CommandDescriptor } from './worker/protocol.js';
+import type { CommandDescriptor, SnapshotDescriptor } from './worker/protocol.js';
 
 export class BroadcastTransport extends CorrelatedTransport {
   private closed = false;
@@ -67,6 +72,23 @@ export class BroadcastTransport extends CorrelatedTransport {
     );
   }
 
+  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
+    return this.read<SnapshotDescriptor>({ kind: 'snapshot', folder });
+  }
+
+  async download(node: Uint8Array): Promise<ArrayBuffer> {
+    // The leader answers with a `Blob` handle (shared backing, no byte copy);
+    // materialize the bytes only here, in the requesting follower.
+    const content = await this.read<Blob>({ kind: 'download', node });
+    return content.arrayBuffer();
+  }
+
+  private read<T>(read: WireRead): Promise<T> {
+    return this.request<T>(this.leaderReady, (requestId) =>
+      this.channel.postMessage({ type: 'cb:read', clientId: this.clientId, requestId, read })
+    );
+  }
+
   /** Reports this tab's open folder to the leader's focus-window union. */
   reportFocus(node: Uint8Array | null): void {
     if (this.closed) return;
@@ -110,7 +132,11 @@ export class BroadcastTransport extends CorrelatedTransport {
         const response = message as Extract<LeaderMessage, { type: 'cb:response' }>;
         if (response.clientId !== this.clientId) return;
         if (!this.fromActiveLeader(response.token)) return; // forged / stale ack
-        this.settle(response.requestId, response.ok, response.ok ? undefined : response.error);
+        if (response.ok) {
+          this.settle(response.requestId, true, undefined, response.content ?? response.result);
+        } else {
+          this.settle(response.requestId, false, response.error);
+        }
         return;
       }
       case 'cb:event': {

--- a/packages/client/src/correlatedTransport.ts
+++ b/packages/client/src/correlatedTransport.ts
@@ -11,10 +11,10 @@
  */
 
 import type { EngineEventListener, EngineTransport } from './transport.js';
-import type { CommandDescriptor, EventDescriptor } from './worker/protocol.js';
+import type { CommandDescriptor, EventDescriptor, SnapshotDescriptor } from './worker/protocol.js';
 
 interface Pending {
-  resolve: () => void;
+  resolve: (result: unknown) => void;
   reject: (error: Error) => void;
 }
 
@@ -43,6 +43,8 @@ export abstract class CorrelatedTransport implements EngineTransport {
 
   abstract start(secret: ArrayBuffer): Promise<void>;
   abstract command(command: CommandDescriptor, transfer: Transferable[]): Promise<void>;
+  abstract snapshot(folder: Uint8Array): Promise<SnapshotDescriptor>;
+  abstract download(node: Uint8Array): Promise<ArrayBuffer>;
   abstract close(): void;
 
   subscribe(listener: EngineEventListener): () => void {
@@ -59,19 +61,20 @@ export abstract class CorrelatedTransport implements EngineTransport {
    * The no-hang request skeleton: short-circuit on `terminalError` before
    * awaiting the readiness gate, register the pending entry, then `send`. A
    * synchronous `send` failure deletes the pending entry before rejecting so it
-   * is never stranded.
+   * is never stranded. Resolves with the response's result value (`undefined`
+   * for a plain ack).
    */
-  protected dispatch(readyGate: Promise<void>, send: (id: number) => void): Promise<void> {
+  protected request<T>(readyGate: Promise<void>, send: (id: number) => void): Promise<T> {
     if (this.terminalError) return Promise.reject(this.terminalError);
     return readyGate.then(
       () =>
-        new Promise<void>((resolve, reject) => {
+        new Promise<T>((resolve, reject) => {
           if (this.terminalError) {
             reject(this.terminalError);
             return;
           }
           const id = this.nextId++;
-          this.pending.set(id, { resolve, reject });
+          this.pending.set(id, { resolve: resolve as (result: unknown) => void, reject });
           try {
             send(id);
           } catch (error) {
@@ -82,12 +85,17 @@ export abstract class CorrelatedTransport implements EngineTransport {
     );
   }
 
+  /** The void-ack variant of [`request`](CorrelatedTransport.request). */
+  protected dispatch(readyGate: Promise<void>, send: (id: number) => void): Promise<void> {
+    return this.request<void>(readyGate, send);
+  }
+
   /** Correlates a response to its request id, resolving or rejecting it. */
-  protected settle(id: number, ok: boolean, error?: string): void {
+  protected settle(id: number, ok: boolean, error?: string, result?: unknown): void {
     const pending = this.pending.get(id);
     if (!pending) return;
     this.pending.delete(id);
-    if (ok) pending.resolve();
+    if (ok) pending.resolve(result);
     else pending.reject(new Error(error));
   }
 

--- a/packages/client/src/correlatedTransport.ts
+++ b/packages/client/src/correlatedTransport.ts
@@ -19,6 +19,22 @@ interface Pending {
 }
 
 /**
+ * A rejected engine request. `code` is the engine's stable machine-readable
+ * error code (the wasm host's camelCase `EngineError` variant name, e.g.
+ * `'unknownNode'`, `'contentUnavailable'`) when the failure crossed from the
+ * engine; absent for transport-level failures.
+ */
+export class EngineRequestError extends Error {
+  readonly code?: string;
+
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = 'EngineRequestError';
+    this.code = code;
+  }
+}
+
+/**
  * Delivers one event to every listener, isolating a throwing subscriber so it
  * cannot drop the event for the rest.
  */
@@ -91,12 +107,12 @@ export abstract class CorrelatedTransport implements EngineTransport {
   }
 
   /** Correlates a response to its request id, resolving or rejecting it. */
-  protected settle(id: number, ok: boolean, error?: string, result?: unknown): void {
+  protected settle(id: number, ok: boolean, error?: string, result?: unknown, code?: string): void {
     const pending = this.pending.get(id);
     if (!pending) return;
     this.pending.delete(id);
     if (ok) pending.resolve(result);
-    else pending.reject(new Error(error));
+    else pending.reject(new EngineRequestError(error ?? 'engine request failed', code));
   }
 
   /**

--- a/packages/client/src/engineClient.ts
+++ b/packages/client/src/engineClient.ts
@@ -24,7 +24,7 @@ import { LeaderRelay } from './leaderRelay.js';
 import { LeaderElection, type LockManagerLike } from './leadership.js';
 import type { EngineEventListener, EngineTransport, EngineWorkerLike } from './transport.js';
 import { LocalTransport } from './transport.js';
-import type { CommandDescriptor } from './worker/protocol.js';
+import type { CommandDescriptor, SnapshotDescriptor } from './worker/protocol.js';
 
 /**
  * Re-derives the login secret when this tab is promoted to leader mid-session
@@ -114,6 +114,14 @@ export class EngineClient implements EngineTransport {
 
   command(command: CommandDescriptor, transfer: Transferable[]): Promise<void> {
     return this.current.command(command, transfer);
+  }
+
+  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
+    return this.current.snapshot(folder);
+  }
+
+  download(node: Uint8Array): Promise<ArrayBuffer> {
+    return this.current.download(node);
   }
 
   subscribe(listener: EngineEventListener): () => void {

--- a/packages/client/src/facade.test.ts
+++ b/packages/client/src/facade.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import { EngineFacade } from './facade.js';
+import { emptySnapshot } from './testkit.js';
 import type { EngineEventListener, EngineTransport } from './transport.js';
-import type { CommandDescriptor } from './worker/protocol.js';
+import type { CommandDescriptor, SnapshotDescriptor } from './worker/protocol.js';
 
 class FakeTransport implements EngineTransport {
   started: ArrayBuffer[] = [];
   commands: Array<{ command: CommandDescriptor; transfer: Transferable[] }> = [];
+  snapshots: Uint8Array[] = [];
+  downloads: Uint8Array[] = [];
   listeners: EngineEventListener[] = [];
   closed = false;
 
@@ -18,6 +21,16 @@ class FakeTransport implements EngineTransport {
   command(command: CommandDescriptor, transfer: Transferable[]): Promise<void> {
     this.commands.push({ command, transfer });
     return Promise.resolve();
+  }
+
+  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
+    this.snapshots.push(folder);
+    return Promise.resolve(emptySnapshot(folder));
+  }
+
+  download(node: Uint8Array): Promise<ArrayBuffer> {
+    this.downloads.push(node);
+    return Promise.resolve(new Uint8Array([1, 2, 3]).buffer);
   }
 
   subscribe(listener: EngineEventListener): () => void {
@@ -93,6 +106,21 @@ describe('EngineFacade', () => {
       permission: 'write',
       recipientIdentityPublicKey: recipient,
     });
+  });
+
+  it('delegates snapshot and download reads to the transport', async () => {
+    const transport = new FakeTransport();
+    const facade = new EngineFacade(transport);
+    const folder = new Uint8Array(16).fill(2);
+    const node = new Uint8Array(16).fill(3);
+
+    const view = await facade.snapshot(folder);
+    expect(view.folder).toBe(folder);
+    expect(transport.snapshots).toEqual([folder]);
+
+    const content = await facade.download(node);
+    expect([...new Uint8Array(content)]).toEqual([1, 2, 3]);
+    expect(transport.downloads).toEqual([node]);
   });
 
   it('delegates event subscription to the transport', () => {

--- a/packages/client/src/facade.ts
+++ b/packages/client/src/facade.ts
@@ -11,7 +11,12 @@
  */
 
 import type { EngineEventListener, EngineTransport } from './transport.js';
-import type { CommandDescriptor, NodeKind, Permission } from './worker/protocol.js';
+import type {
+  CommandDescriptor,
+  NodeKind,
+  Permission,
+  SnapshotDescriptor,
+} from './worker/protocol.js';
 
 export class EngineFacade {
   constructor(private readonly transport: EngineTransport) {}
@@ -47,6 +52,16 @@ export class EngineFacade {
   /** Subscribes to the one-way engine event stream; returns an unsubscribe. */
   subscribe(listener: EngineEventListener): () => void {
     return this.transport.subscribe(listener);
+  }
+
+  /** Reads a key-free snapshot of `folder` for a UI paint. */
+  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
+    return this.transport.snapshot(folder);
+  }
+
+  /** Downloads one file node's plaintext through the verified read pipeline. */
+  download(node: Uint8Array): Promise<ArrayBuffer> {
+    return this.transport.download(node);
   }
 
   create(

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -14,6 +14,7 @@ export const CLIENT_PACKAGE = '@cipherbox/client';
 // and imports its collaborators by relative path, so nothing outside this
 // package consumes the worker-realm internals through the barrel.
 export { EngineFacade } from './facade.js';
+export { EngineRequestError } from './correlatedTransport.js';
 export { LocalTransport } from './transport.js';
 export type { EngineTransport, EngineWorkerLike, EngineEventListener } from './transport.js';
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -35,4 +35,8 @@ export type {
   Permission,
   NodeKind,
   Staleness,
+  OpProgressPhase,
+  SnapshotDescriptor,
+  SnapshotChildDescriptor,
+  BreadcrumbDescriptor,
 } from './worker/protocol.js';

--- a/packages/client/src/leaderRelay.ts
+++ b/packages/client/src/leaderRelay.ts
@@ -110,6 +110,9 @@ export class LeaderRelay {
       case 'cb:command':
         void this.forward(message as Extract<FollowerMessage, { type: 'cb:command' }>);
         return;
+      case 'cb:read':
+        void this.serveRead(message as Extract<FollowerMessage, { type: 'cb:read' }>);
+        return;
       case 'cb:focus': {
         const { clientId, node } = message as Extract<FollowerMessage, { type: 'cb:focus' }>;
         if (this.focus.set(clientId, node)) this.refreshHint();
@@ -135,6 +138,28 @@ export class LeaderRelay {
         token: this.token,
         clientId,
         requestId,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async serveRead(message: Extract<FollowerMessage, { type: 'cb:read' }>): Promise<void> {
+    const { clientId, requestId, read } = message;
+    const ack = { type: 'cb:response', token: this.token, clientId, requestId } as const;
+    try {
+      if (read.kind === 'snapshot') {
+        const result = await this.transport.snapshot(read.folder);
+        this.post({ ...ack, ok: true, result });
+      } else {
+        // Wrap the plaintext in a `Blob` so the per-receiver structured clone
+        // shares the immutable backing store instead of copying the bytes.
+        const bytes = await this.transport.download(read.node);
+        this.post({ ...ack, ok: true, content: new Blob([bytes]) });
+      }
+    } catch (error) {
+      this.post({
+        ...ack,
         ok: false,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/packages/client/src/leaderRelay.ts
+++ b/packages/client/src/leaderRelay.ts
@@ -19,7 +19,16 @@ import {
   type FollowerMessage,
   type LeaderMessage,
 } from './broadcast.js';
+import { EngineRequestError } from './correlatedTransport.js';
 import type { EngineTransport } from './transport.js';
+
+/** Projects a caught failure onto the wire's `error`/`code` fields. */
+function wireError(error: unknown): { error: string; code?: string } {
+  return {
+    error: error instanceof Error ? error.message : String(error),
+    code: error instanceof EngineRequestError ? error.code : undefined,
+  };
+}
 
 /**
  * Tracks each tab's open folder and derives the union — the set of distinct
@@ -139,7 +148,7 @@ export class LeaderRelay {
         clientId,
         requestId,
         ok: false,
-        error: error instanceof Error ? error.message : String(error),
+        ...wireError(error),
       });
     }
   }
@@ -155,14 +164,10 @@ export class LeaderRelay {
         // Wrap the plaintext in a `Blob` so the per-receiver structured clone
         // shares the immutable backing store instead of copying the bytes.
         const bytes = await this.transport.download(read.node);
-        this.post({ ...ack, ok: true, content: new Blob([bytes]) });
+        this.post({ ...ack, ok: true, result: new Blob([bytes]) });
       }
     } catch (error) {
-      this.post({
-        ...ack,
-        ok: false,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      this.post({ ...ack, ok: false, ...wireError(error) });
     }
   }
 

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -16,6 +16,17 @@ import type {
   WorkerMessage,
 } from './worker/protocol.js';
 
+/**
+ * The wasm-bindgen mirror-enum value tables (as `crates/wasm` exports them),
+ * shared by the codec and worker test stubs.
+ */
+export const fakeWasmEnums = {
+  NodeKind: { File: 0, Folder: 1 },
+  Permission: { Read: 0, Write: 1 },
+  Staleness: { Fresh: 0, Reconciling: 1, Stale: 2, Offline: 3 },
+  OpPhase: { DownloadStarted: 0, DownloadCompleted: 1, DownloadFailed: 2 },
+} as const;
+
 /** A minimal empty snapshot descriptor for transport-plumbing assertions. */
 export function emptySnapshot(folder: Uint8Array = new Uint8Array(16)): SnapshotDescriptor {
   return {

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -9,7 +9,24 @@
 import type { BroadcastChannelLike } from './broadcast.js';
 import type { LockManagerLike, LockRequestCallback } from './leadership.js';
 import type { EngineEventListener, EngineTransport, EngineWorkerLike } from './transport.js';
-import type { CommandDescriptor, EventDescriptor, WorkerMessage } from './worker/protocol.js';
+import type {
+  CommandDescriptor,
+  EventDescriptor,
+  SnapshotDescriptor,
+  WorkerMessage,
+} from './worker/protocol.js';
+
+/** A minimal empty snapshot descriptor for transport-plumbing assertions. */
+export function emptySnapshot(folder: Uint8Array = new Uint8Array(16)): SnapshotDescriptor {
+  return {
+    root: new Uint8Array(16),
+    folder,
+    children: [],
+    ancestors: [],
+    deadLetters: [],
+    staleness: 'fresh',
+  };
+}
 
 /** A same-origin broadcast bus: a posted message reaches every *other* channel. */
 export class FakeBus {
@@ -128,9 +145,15 @@ export class FakeLockManager implements LockManagerLike {
 /** A minimal in-process EngineTransport for relay/orchestrator tests. */
 export class FakeEngineTransport implements EngineTransport {
   readonly commands: CommandDescriptor[] = [];
+  readonly snapshots: Uint8Array[] = [];
+  readonly downloads: Uint8Array[] = [];
   started: ArrayBuffer[] = [];
   closed = false;
   respond: (command: CommandDescriptor) => Promise<void> = () => Promise.resolve();
+  respondSnapshot: (folder: Uint8Array) => Promise<SnapshotDescriptor> = (folder) =>
+    Promise.resolve(emptySnapshot(folder));
+  respondDownload: (node: Uint8Array) => Promise<ArrayBuffer> = () =>
+    Promise.resolve(new ArrayBuffer(0));
   private readonly listeners = new Set<EngineEventListener>();
 
   start(secret: ArrayBuffer): Promise<void> {
@@ -141,6 +164,16 @@ export class FakeEngineTransport implements EngineTransport {
   command(command: CommandDescriptor): Promise<void> {
     this.commands.push(command);
     return this.respond(command);
+  }
+
+  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
+    this.snapshots.push(folder);
+    return this.respondSnapshot(folder);
+  }
+
+  download(node: Uint8Array): Promise<ArrayBuffer> {
+    this.downloads.push(node);
+    return this.respondDownload(node);
   }
 
   subscribe(listener: EngineEventListener): () => void {

--- a/packages/client/src/transport.test.ts
+++ b/packages/client/src/transport.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { emptySnapshot } from './testkit.js';
 import { LocalTransport, type EngineWorkerLike } from './transport.js';
 import type {
   EventDescriptor,
@@ -97,10 +98,15 @@ describe('LocalTransport', () => {
       id: idA,
       ok: false,
       error: 'command not implemented yet: manualRefresh',
+      code: 'unimplemented',
     });
     worker.emit({ type: 'response', id: idB, ok: true });
 
-    await expect(failing).rejects.toThrow('not implemented');
+    // The stable code crosses alongside the human-readable message.
+    await expect(failing).rejects.toMatchObject({
+      code: 'unimplemented',
+      message: 'command not implemented yet: manualRefresh',
+    });
     await expect(ok).resolves.toBeUndefined();
   });
 
@@ -135,10 +141,7 @@ describe('LocalTransport', () => {
     const { message } = worker.posted[0];
     expect(message).toMatchObject({ type: 'snapshot', folder });
     const result: SnapshotDescriptor = {
-      root: new Uint8Array(16),
-      folder,
-      children: [],
-      ancestors: [],
+      ...emptySnapshot(folder),
       deadLetters: [1n],
       staleness: 'stale',
     };
@@ -152,14 +155,7 @@ describe('LocalTransport', () => {
     const transport = new LocalTransport(worker);
     worker.emit({ type: 'ready' });
 
-    const snapshotResult: SnapshotDescriptor = {
-      root: new Uint8Array(16),
-      folder: new Uint8Array(16),
-      children: [],
-      ancestors: [],
-      deadLetters: [],
-      staleness: 'fresh',
-    };
+    const snapshotResult = emptySnapshot();
     const downloadResult = new Uint8Array([4, 5, 6]).buffer;
 
     const command = transport.command({ kind: 'manualRefresh' }, []);
@@ -188,22 +184,16 @@ describe('LocalTransport', () => {
     await tick();
     const [idA, idB] = worker.posted.map((entry) => entry.message.id);
 
-    worker.emit({ type: 'response', id: idA, ok: false, error: 'content unavailable: pending' });
     worker.emit({
       type: 'response',
-      id: idB,
-      ok: true,
-      result: {
-        root: new Uint8Array(16),
-        folder: new Uint8Array(16),
-        children: [],
-        ancestors: [],
-        deadLetters: [],
-        staleness: 'fresh',
-      },
+      id: idA,
+      ok: false,
+      error: 'content unavailable: pending',
+      code: 'contentUnavailable',
     });
+    worker.emit({ type: 'response', id: idB, ok: true, result: emptySnapshot() });
 
-    await expect(failing).rejects.toThrow('content unavailable');
+    await expect(failing).rejects.toMatchObject({ code: 'contentUnavailable' });
     await expect(ok).resolves.toMatchObject({ staleness: 'fresh' });
   });
 

--- a/packages/client/src/transport.test.ts
+++ b/packages/client/src/transport.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import { LocalTransport, type EngineWorkerLike } from './transport.js';
-import type { EventDescriptor, WorkerMessage, WorkerRequest } from './worker/protocol.js';
+import type {
+  EventDescriptor,
+  SnapshotDescriptor,
+  WorkerMessage,
+  WorkerRequest,
+} from './worker/protocol.js';
 
 /** A worker stand-in: records posted requests, replays worker→UI messages. */
 class FakeWorker implements EngineWorkerLike {
@@ -112,6 +117,113 @@ describe('LocalTransport', () => {
       { kind: 'stalenessChanged', staleness: 'stale' },
       { kind: 'deadLetter', opId: 7n },
       { kind: 'snapshotUpdated' },
+    ];
+    for (const event of sent) worker.emit({ type: 'event', event });
+
+    expect(received).toEqual(sent);
+  });
+
+  it('resolves a snapshot request with its result payload', async () => {
+    const worker = new FakeWorker();
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const folder = new Uint8Array(16).fill(5);
+    const pending = transport.snapshot(folder);
+    await tick();
+
+    const { message } = worker.posted[0];
+    expect(message).toMatchObject({ type: 'snapshot', folder });
+    const result: SnapshotDescriptor = {
+      root: new Uint8Array(16),
+      folder,
+      children: [],
+      ancestors: [],
+      deadLetters: [1n],
+      staleness: 'stale',
+    };
+    worker.emit({ type: 'response', id: message.id, ok: true, result });
+
+    await expect(pending).resolves.toEqual(result);
+  });
+
+  it('correlates interleaved command, snapshot, and download answered out of order', async () => {
+    const worker = new FakeWorker();
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const snapshotResult: SnapshotDescriptor = {
+      root: new Uint8Array(16),
+      folder: new Uint8Array(16),
+      children: [],
+      ancestors: [],
+      deadLetters: [],
+      staleness: 'fresh',
+    };
+    const downloadResult = new Uint8Array([4, 5, 6]).buffer;
+
+    const command = transport.command({ kind: 'manualRefresh' }, []);
+    const snapshot = transport.snapshot(new Uint8Array(16));
+    const download = transport.download(new Uint8Array(16));
+    await tick();
+
+    const [commandId, snapshotId, downloadId] = worker.posted.map((entry) => entry.message.id);
+    // Answer in reverse issue order; each promise must get its own value.
+    worker.emit({ type: 'response', id: downloadId, ok: true, result: downloadResult });
+    worker.emit({ type: 'response', id: snapshotId, ok: true, result: snapshotResult });
+    worker.emit({ type: 'response', id: commandId, ok: true });
+
+    await expect(command).resolves.toBeUndefined();
+    await expect(snapshot).resolves.toEqual(snapshotResult);
+    expect([...new Uint8Array(await download)]).toEqual([4, 5, 6]);
+  });
+
+  it('rejects only the matching read on an error response', async () => {
+    const worker = new FakeWorker();
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const failing = transport.download(new Uint8Array(16));
+    const ok = transport.snapshot(new Uint8Array(16));
+    await tick();
+    const [idA, idB] = worker.posted.map((entry) => entry.message.id);
+
+    worker.emit({ type: 'response', id: idA, ok: false, error: 'content unavailable: pending' });
+    worker.emit({
+      type: 'response',
+      id: idB,
+      ok: true,
+      result: {
+        root: new Uint8Array(16),
+        folder: new Uint8Array(16),
+        children: [],
+        ancestors: [],
+        deadLetters: [],
+        staleness: 'fresh',
+      },
+    });
+
+    await expect(failing).rejects.toThrow('content unavailable');
+    await expect(ok).resolves.toMatchObject({ staleness: 'fresh' });
+  });
+
+  it('delivers renewalFailed and opProgress events to subscribers', async () => {
+    const worker = new FakeWorker();
+    const transport = new LocalTransport(worker);
+    worker.emit({ type: 'ready' });
+
+    const received: EventDescriptor[] = [];
+    transport.subscribe((event) => received.push(event));
+
+    const sent: EventDescriptor[] = [
+      { kind: 'renewalFailed', routingKey: 'k51abc', detail: 'republish rejected' },
+      {
+        kind: 'opProgress',
+        opId: null,
+        node: new Uint8Array(16),
+        phase: 'downloadStarted',
+        error: null,
+      },
     ];
     for (const event of sent) worker.emit({ type: 'event', event });
 

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -69,7 +69,7 @@ export class LocalTransport extends CorrelatedTransport {
             return;
           case 'response':
             if (message.ok) this.settle(message.id, true, undefined, message.result);
-            else this.settle(message.id, false, message.error);
+            else this.settle(message.id, false, message.error, undefined, message.code);
             return;
           case 'event':
             this.emit(message.event);

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -13,6 +13,7 @@ import { CorrelatedTransport } from './correlatedTransport.js';
 import type {
   CommandDescriptor,
   EventDescriptor,
+  SnapshotDescriptor,
   WorkerMessage,
   WorkerRequest,
 } from './worker/protocol.js';
@@ -25,6 +26,10 @@ export interface EngineTransport {
   start(secret: ArrayBuffer): Promise<void>;
   /** Sends one command; `transfer` lists any owned buffers to move, not copy. */
   command(command: CommandDescriptor, transfer: Transferable[]): Promise<void>;
+  /** Reads a key-free snapshot of `folder` for a UI paint. */
+  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor>;
+  /** Downloads one file node's plaintext through the verified read pipeline. */
+  download(node: Uint8Array): Promise<ArrayBuffer>;
   /** Subscribes to the one-way event stream; returns an unsubscribe. */
   subscribe(listener: EngineEventListener): () => void;
   /** Tears the transport down; pending requests reject. */
@@ -63,7 +68,8 @@ export class LocalTransport extends CorrelatedTransport {
             resolveReady();
             return;
           case 'response':
-            this.settle(message.id, message.ok, message.ok ? undefined : message.error);
+            if (message.ok) this.settle(message.id, true, undefined, message.result);
+            else this.settle(message.id, false, message.error);
             return;
           case 'event':
             this.emit(message.event);
@@ -93,6 +99,18 @@ export class LocalTransport extends CorrelatedTransport {
   command(command: CommandDescriptor, transfer: Transferable[]): Promise<void> {
     return this.dispatch(this.ready, (id) =>
       this.worker.postMessage({ type: 'command', id, command }, transfer)
+    );
+  }
+
+  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
+    return this.request<SnapshotDescriptor>(this.ready, (id) =>
+      this.worker.postMessage({ type: 'snapshot', id, folder }, [])
+    );
+  }
+
+  download(node: Uint8Array): Promise<ArrayBuffer> {
+    return this.request<ArrayBuffer>(this.ready, (id) =>
+      this.worker.postMessage({ type: 'download', id, node }, [])
     );
   }
 

--- a/packages/client/src/worker/commandCodec.test.ts
+++ b/packages/client/src/worker/commandCodec.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+
+import { readEvent, readSnapshot } from './commandCodec.js';
+import type { EngineWasm, WasmEvent, WasmSnapshotView } from './engineWasm.js';
+
+/**
+ * A structural stand-in for the wasm-bindgen namespace: only the mirror-enum
+ * value tables the codec's read paths consult.
+ */
+const fakeWasm = {
+  NodeKind: { File: 0, Folder: 1 },
+  Permission: { Read: 0, Write: 1 },
+  Staleness: { Fresh: 0, Reconciling: 1, Stale: 2, Offline: 3 },
+  OpPhase: { DownloadStarted: 0, DownloadCompleted: 1, DownloadFailed: 2 },
+} as unknown as EngineWasm;
+
+describe('readEvent', () => {
+  it('maps renewalFailed instead of throwing (the transport-bricking bug)', () => {
+    const event: WasmEvent = {
+      kind: 'renewalFailed',
+      routingKey: 'k51qzi5uqu5dr',
+      detail: 'record rejected',
+    };
+    expect(readEvent(fakeWasm, event)).toEqual({
+      kind: 'renewalFailed',
+      routingKey: 'k51qzi5uqu5dr',
+      detail: 'record rejected',
+    });
+  });
+
+  it('maps a full opProgress payload to string-literal phase', () => {
+    const node = new Uint8Array(16).fill(3);
+    const event: WasmEvent = {
+      kind: 'opProgress',
+      opId: 7n,
+      node,
+      phase: 2,
+      error: 'unavailable',
+    };
+    expect(readEvent(fakeWasm, event)).toEqual({
+      kind: 'opProgress',
+      opId: 7n,
+      node,
+      phase: 'downloadFailed',
+      error: 'unavailable',
+    });
+  });
+
+  it('maps an op-less, error-less opProgress to nulls', () => {
+    const event: WasmEvent = { kind: 'opProgress', node: new Uint8Array(16), phase: 0 };
+    expect(readEvent(fakeWasm, event)).toEqual({
+      kind: 'opProgress',
+      opId: null,
+      node: new Uint8Array(16),
+      phase: 'downloadStarted',
+      error: null,
+    });
+  });
+
+  it('fails closed on an unknown opProgress phase', () => {
+    const event: WasmEvent = { kind: 'opProgress', node: new Uint8Array(16), phase: 99 };
+    expect(() => readEvent(fakeWasm, event)).toThrow('unknown WASM op phase value: 99');
+    expect(() => readEvent(fakeWasm, { kind: 'opProgress', node: new Uint8Array(16) })).toThrow(
+      'unknown WASM op phase value'
+    );
+  });
+});
+
+describe('readSnapshot', () => {
+  it('maps every field, including bigint dead letters and null size/mtime', () => {
+    const view: WasmSnapshotView = {
+      root: new Uint8Array(16).fill(1),
+      folder: new Uint8Array(16).fill(2),
+      children: [
+        {
+          id: new Uint8Array(16).fill(3),
+          name: 'photo.jpg',
+          kind: 0,
+          size: 1024n,
+          mtime: 1_700_000_000_000n,
+          pending: true,
+          deadLetter: false,
+          contentVersion: 2n,
+        },
+        {
+          id: new Uint8Array(16).fill(4),
+          name: 'docs',
+          kind: 1,
+          pending: false,
+          deadLetter: true,
+          contentVersion: 0n,
+        },
+      ],
+      ancestors: [{ id: new Uint8Array(16).fill(1), name: '' }],
+      deadLetters: new BigUint64Array([9n, 9_007_199_254_740_993n]),
+      staleness: 1,
+    };
+
+    expect(readSnapshot(fakeWasm, view)).toEqual({
+      root: new Uint8Array(16).fill(1),
+      folder: new Uint8Array(16).fill(2),
+      children: [
+        {
+          id: new Uint8Array(16).fill(3),
+          name: 'photo.jpg',
+          kind: 'file',
+          size: 1024n,
+          mtime: 1_700_000_000_000n,
+          pending: true,
+          deadLetter: false,
+          contentVersion: 2n,
+        },
+        {
+          id: new Uint8Array(16).fill(4),
+          name: 'docs',
+          kind: 'folder',
+          size: null,
+          mtime: null,
+          pending: false,
+          deadLetter: true,
+          contentVersion: 0n,
+        },
+      ],
+      ancestors: [{ id: new Uint8Array(16).fill(1), name: '' }],
+      deadLetters: [9n, 9_007_199_254_740_993n],
+      staleness: 'reconciling',
+    });
+  });
+
+  it('fails closed on an unknown child kind or staleness value', () => {
+    const base: WasmSnapshotView = {
+      root: new Uint8Array(16),
+      folder: new Uint8Array(16),
+      children: [],
+      ancestors: [],
+      deadLetters: new BigUint64Array(0),
+      staleness: 0,
+    };
+    expect(() => readSnapshot(fakeWasm, { ...base, staleness: 42 })).toThrow(
+      'unknown WASM staleness value: 42'
+    );
+    expect(() =>
+      readSnapshot(fakeWasm, {
+        ...base,
+        children: [
+          {
+            id: new Uint8Array(16),
+            name: 'x',
+            kind: 42,
+            pending: false,
+            deadLetter: false,
+            contentVersion: 0n,
+          },
+        ],
+      })
+    ).toThrow('unknown WASM node kind value: 42');
+  });
+});

--- a/packages/client/src/worker/commandCodec.test.ts
+++ b/packages/client/src/worker/commandCodec.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { fakeWasmEnums } from '../testkit.js';
 import { readEvent, readSnapshot } from './commandCodec.js';
 import type { EngineWasm, WasmEvent, WasmSnapshotView } from './engineWasm.js';
 
@@ -7,12 +8,7 @@ import type { EngineWasm, WasmEvent, WasmSnapshotView } from './engineWasm.js';
  * A structural stand-in for the wasm-bindgen namespace: only the mirror-enum
  * value tables the codec's read paths consult.
  */
-const fakeWasm = {
-  NodeKind: { File: 0, Folder: 1 },
-  Permission: { Read: 0, Write: 1 },
-  Staleness: { Fresh: 0, Reconciling: 1, Stale: 2, Offline: 3 },
-  OpPhase: { DownloadStarted: 0, DownloadCompleted: 1, DownloadFailed: 2 },
-} as unknown as EngineWasm;
+const fakeWasm = fakeWasmEnums as unknown as EngineWasm;
 
 describe('readEvent', () => {
   it('maps renewalFailed instead of throwing (the transport-bricking bug)', () => {

--- a/packages/client/src/worker/commandCodec.ts
+++ b/packages/client/src/worker/commandCodec.ts
@@ -11,10 +11,18 @@ import type {
   CommandDescriptor,
   EventDescriptor,
   NodeKind,
+  OpProgressPhase,
   Permission,
+  SnapshotDescriptor,
   Staleness,
 } from './protocol.js';
-import type { EngineWasm, WasmCommand, WasmEvent, WasmNodeId } from './engineWasm.js';
+import type {
+  EngineWasm,
+  WasmCommand,
+  WasmEvent,
+  WasmNodeId,
+  WasmSnapshotView,
+} from './engineWasm.js';
 
 function nodeId(wasm: EngineWasm, bytes: Uint8Array): WasmNodeId {
   return wasm.NodeId.fromBytes(bytes);
@@ -107,6 +115,33 @@ function staleness(wasm: EngineWasm, level: number): Staleness {
   }
 }
 
+function opPhase(wasm: EngineWasm, phase: number | undefined): OpProgressPhase {
+  switch (phase) {
+    case wasm.OpPhase.DownloadStarted:
+      return 'downloadStarted';
+    case wasm.OpPhase.DownloadCompleted:
+      return 'downloadCompleted';
+    case wasm.OpPhase.DownloadFailed:
+      return 'downloadFailed';
+    default:
+      // Fail closed: an unmapped value means a JS/WASM version mismatch, not a
+      // safe-to-ignore state (the event pump turns this throw into a fatal).
+      throw new Error(`unknown WASM op phase value: ${phase}`);
+  }
+}
+
+function nodeKindFrom(wasm: EngineWasm, kind: number): NodeKind {
+  switch (kind) {
+    case wasm.NodeKind.File:
+      return 'file';
+    case wasm.NodeKind.Folder:
+      return 'folder';
+    default:
+      // Fail closed: an unmapped value means a JS/WASM version mismatch.
+      throw new Error(`unknown WASM node kind value: ${kind}`);
+  }
+}
+
 export function readEvent(wasm: EngineWasm, event: WasmEvent): EventDescriptor {
   switch (event.kind) {
     case 'snapshotUpdated':
@@ -122,9 +157,44 @@ export function readEvent(wasm: EngineWasm, event: WasmEvent): EventDescriptor {
       return { kind: 'deadLetter', opId: event.opId ?? 0n };
     case 'attributableAbuse':
       return { kind: 'attributableAbuse', description: event.description ?? '' };
+    case 'renewalFailed':
+      return {
+        kind: 'renewalFailed',
+        routingKey: event.routingKey ?? '',
+        detail: event.detail ?? '',
+      };
+    case 'opProgress':
+      return {
+        kind: 'opProgress',
+        opId: event.opId ?? null,
+        node: event.node ?? new Uint8Array(),
+        phase: opPhase(wasm, event.phase),
+        error: event.error ?? null,
+      };
     default:
       // Fail closed: an unmapped kind means a JS/WASM version mismatch, not a
       // safe-to-ignore event (the event pump turns this throw into a fatal).
       throw new Error(`unknown WASM event kind: ${event.kind}`);
   }
+}
+
+/** Reads a wasm-bindgen `SnapshotView`'s key-free getters into a descriptor. */
+export function readSnapshot(wasm: EngineWasm, view: WasmSnapshotView): SnapshotDescriptor {
+  return {
+    root: view.root,
+    folder: view.folder,
+    children: view.children.map((child) => ({
+      id: child.id,
+      name: child.name,
+      kind: nodeKindFrom(wasm, child.kind),
+      size: child.size ?? null,
+      mtime: child.mtime ?? null,
+      pending: child.pending,
+      deadLetter: child.deadLetter,
+      contentVersion: child.contentVersion,
+    })),
+    ancestors: view.ancestors.map((ancestor) => ({ id: ancestor.id, name: ancestor.name })),
+    deadLetters: [...view.deadLetters],
+    staleness: staleness(wasm, view.staleness),
+  };
 }

--- a/packages/client/src/worker/engineHost.ts
+++ b/packages/client/src/worker/engineHost.ts
@@ -4,9 +4,9 @@
  * never leaves it.
  */
 
-import type { CommandDescriptor, EventDescriptor } from './protocol.js';
+import type { CommandDescriptor, EventDescriptor, SnapshotDescriptor } from './protocol.js';
 import type { EngineWasm } from './engineWasm.js';
-import { buildCommand, readEvent } from './commandCodec.js';
+import { buildCommand, readEvent, readSnapshot } from './commandCodec.js';
 
 /**
  * The engine-facing surface the protocol server ([`serveEngine`]) drives. The
@@ -16,6 +16,8 @@ import { buildCommand, readEvent } from './commandCodec.js';
 export interface EngineHostLike {
   start(secret: ArrayBuffer): Promise<void>;
   command(command: CommandDescriptor): Promise<void>;
+  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor>;
+  download(node: Uint8Array): Promise<ArrayBuffer>;
   nextEvent(): Promise<EventDescriptor | null>;
 }
 
@@ -43,6 +45,20 @@ export class EngineHost implements EngineHostLike {
 
   async command(command: CommandDescriptor): Promise<void> {
     await this.handle.command(buildCommand(this.wasm, command));
+  }
+
+  async snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
+    const view = await this.handle.snapshot(this.wasm.NodeId.fromBytes(folder));
+    return readSnapshot(this.wasm, view);
+  }
+
+  async download(node: Uint8Array): Promise<ArrayBuffer> {
+    const bytes = await this.handle.download(this.wasm.NodeId.fromBytes(node));
+    // The handle returns a JS-owned copy (never a WASM-memory view); reuse its
+    // exact backing buffer for the transfer, re-slicing only a partial view.
+    return bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
+      ? (bytes.buffer as ArrayBuffer)
+      : (bytes.slice().buffer as ArrayBuffer);
   }
 
   async nextEvent(): Promise<EventDescriptor | null> {

--- a/packages/client/src/worker/engineWasm.ts
+++ b/packages/client/src/worker/engineWasm.ts
@@ -24,12 +24,47 @@ export interface WasmEvent {
   readonly ipnsName?: Uint8Array;
   readonly opId?: bigint;
   readonly description?: string;
+  readonly node?: Uint8Array;
+  readonly phase?: number;
+  readonly error?: string;
+  readonly routingKey?: string;
+  readonly detail?: string;
+}
+
+/** wasm-bindgen `Breadcrumb` — one ancestor step in a snapshot view. */
+export interface WasmBreadcrumb {
+  readonly id: Uint8Array;
+  readonly name: string;
+}
+
+/** wasm-bindgen `SnapshotChild` — one direct child in a snapshot view. */
+export interface WasmSnapshotChild {
+  readonly id: Uint8Array;
+  readonly name: string;
+  readonly kind: number;
+  readonly size?: bigint;
+  readonly mtime?: bigint;
+  readonly pending: boolean;
+  readonly deadLetter: boolean;
+  readonly contentVersion: bigint;
+}
+
+/** wasm-bindgen `SnapshotView` — a key-free folder snapshot for a UI paint. */
+export interface WasmSnapshotView {
+  readonly root: Uint8Array;
+  readonly folder: Uint8Array;
+  readonly children: WasmSnapshotChild[];
+  readonly ancestors: WasmBreadcrumb[];
+  readonly deadLetters: BigUint64Array;
+  readonly staleness: number;
 }
 
 /** wasm-bindgen `EngineHandle` — the one engine instance. */
 export interface WasmEngineHandle {
   start(secret: Uint8Array): Promise<unknown>;
   command(command: WasmCommand): Promise<unknown>;
+  snapshot(folder: WasmNodeId): Promise<WasmSnapshotView>;
+  download(node: WasmNodeId): Promise<Uint8Array>;
   nextEvent(): Promise<WasmEvent | undefined>;
 }
 
@@ -61,6 +96,11 @@ export interface EngineWasm {
   };
   NodeKind: { readonly File: number; readonly Folder: number };
   Permission: { readonly Read: number; readonly Write: number };
+  OpPhase: {
+    readonly DownloadStarted: number;
+    readonly DownloadCompleted: number;
+    readonly DownloadFailed: number;
+  };
   Staleness: {
     readonly Fresh: number;
     readonly Reconciling: number;

--- a/packages/client/src/worker/protocol.ts
+++ b/packages/client/src/worker/protocol.ts
@@ -126,7 +126,12 @@ export type WorkerMessage =
    * `ArrayBuffer` (transferred, not copied) for `download`.
    */
   | { type: 'response'; id: number; ok: true; result?: SnapshotDescriptor | ArrayBuffer }
-  | { type: 'response'; id: number; ok: false; error: string }
+  /**
+   * A failed request. `error` is the human-readable diagnostic; `code` is the
+   * engine's stable machine-readable error code (the wasm host's camelCase
+   * `EngineError` variant name) when the failure came from the engine.
+   */
+  | { type: 'response'; id: number; ok: false; error: string; code?: string }
   /** One engine event, in emission order. */
   | { type: 'event'; event: EventDescriptor }
   /** Construction or event-pump failure; the worker is unusable. */

--- a/packages/client/src/worker/protocol.ts
+++ b/packages/client/src/worker/protocol.ts
@@ -25,6 +25,41 @@ export type NodeKind = 'file' | 'folder';
 /** The staleness ladder (mirrors the facade `Staleness`). */
 export type Staleness = 'fresh' | 'reconciling' | 'stale' | 'offline';
 
+/** The phase an `opProgress` event reports (mirrors the facade `OpPhase`). */
+export type OpProgressPhase = 'downloadStarted' | 'downloadCompleted' | 'downloadFailed';
+
+/** One ancestor step in a snapshot's breadcrumb trail, as data. */
+export interface BreadcrumbDescriptor {
+  id: Uint8Array;
+  name: string;
+}
+
+/** One direct child in a snapshot, as data. `size`/`mtime` are `null` until projected. */
+export interface SnapshotChildDescriptor {
+  id: Uint8Array;
+  name: string;
+  kind: NodeKind;
+  size: bigint | null;
+  mtime: bigint | null;
+  pending: boolean;
+  deadLetter: boolean;
+  contentVersion: bigint;
+}
+
+/**
+ * A key-free folder snapshot, as data (mirrors the facade `SnapshotView`).
+ * A wire projection of view state the engine owns, not the forbidden
+ * hand-mirrored type surface — the wasm-bindgen `.d.ts` stays the contract.
+ */
+export interface SnapshotDescriptor {
+  root: Uint8Array;
+  folder: Uint8Array;
+  children: SnapshotChildDescriptor[];
+  ancestors: BreadcrumbDescriptor[];
+  deadLetters: bigint[];
+  staleness: Staleness;
+}
+
 /**
  * One write intent, as data. Each variant's `kind` matches the facade command
  * builder name (`crates/wasm` `Command`), so the worker maps it mechanically.
@@ -64,19 +99,33 @@ export type EventDescriptor =
   | { kind: 'stalenessChanged'; staleness: Staleness }
   | { kind: 'withheldUpdateEscalation'; ipnsName: Uint8Array }
   | { kind: 'deadLetter'; opId: bigint }
-  | { kind: 'attributableAbuse'; description: string };
+  | { kind: 'attributableAbuse'; description: string }
+  | { kind: 'renewalFailed'; routingKey: string; detail: string }
+  | {
+      kind: 'opProgress';
+      opId: bigint | null;
+      node: Uint8Array;
+      phase: OpProgressPhase;
+      error: string | null;
+    };
 
 /** A UI → worker request. `id` correlates the eventual response. */
 export type WorkerRequest =
   | { type: 'start'; id: number; secret: ArrayBuffer }
-  | { type: 'command'; id: number; command: CommandDescriptor };
+  | { type: 'command'; id: number; command: CommandDescriptor }
+  | { type: 'snapshot'; id: number; folder: Uint8Array }
+  | { type: 'download'; id: number; node: Uint8Array };
 
 /** A worker → UI message. */
 export type WorkerMessage =
   /** The worker has instantiated the engine and is ready for requests. */
   | { type: 'ready' }
-  /** The correlated result of a request. */
-  | { type: 'response'; id: number; ok: true }
+  /**
+   * The correlated result of a request. A read request's ok response carries
+   * its value: a `SnapshotDescriptor` for `snapshot`, the plaintext
+   * `ArrayBuffer` (transferred, not copied) for `download`.
+   */
+  | { type: 'response'; id: number; ok: true; result?: SnapshotDescriptor | ArrayBuffer }
   | { type: 'response'; id: number; ok: false; error: string }
   /** One engine event, in emission order. */
   | { type: 'event'; event: EventDescriptor }

--- a/packages/client/src/worker/serve.test.ts
+++ b/packages/client/src/worker/serve.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+
+import { LocalTransport, type EngineWorkerLike } from '../transport.js';
+import { EngineHost, type EngineHostLike } from './engineHost.js';
+import type { EngineWasm, WasmEngineHandle, WasmEvent } from './engineWasm.js';
+import type {
+  EventDescriptor,
+  SnapshotDescriptor,
+  WorkerMessage,
+  WorkerRequest,
+} from './protocol.js';
+import { serveEngine, type WorkerScopeLike } from './serve.js';
+
+const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+/** An in-memory scope↔worker pair wiring `serveEngine` to a `LocalTransport`. */
+function loopback(): {
+  scope: WorkerScopeLike;
+  worker: EngineWorkerLike;
+  toUi: Array<{ message: WorkerMessage; transfer?: Transferable[] }>;
+} {
+  const workerListeners: Array<(event: MessageEvent<WorkerRequest>) => void> = [];
+  const uiListeners: Array<(event: MessageEvent<WorkerMessage>) => void> = [];
+  const toUi: Array<{ message: WorkerMessage; transfer?: Transferable[] }> = [];
+
+  const scope: WorkerScopeLike = {
+    postMessage: (message, transfer) => {
+      toUi.push({ message, transfer });
+      queueMicrotask(() => {
+        for (const listener of uiListeners)
+          listener({ data: message } as MessageEvent<WorkerMessage>);
+      });
+    },
+    addEventListener: (_type, listener) => workerListeners.push(listener),
+  };
+  const worker: EngineWorkerLike = {
+    postMessage: (message) => {
+      queueMicrotask(() => {
+        for (const listener of workerListeners)
+          listener({ data: message } as MessageEvent<WorkerRequest>);
+      });
+    },
+    addEventListener: (type, listener) => {
+      if (type === 'message')
+        uiListeners.push(listener as (event: MessageEvent<WorkerMessage>) => void);
+    },
+    terminate: () => undefined,
+  };
+  return { scope, worker, toUi };
+}
+
+const SNAPSHOT: SnapshotDescriptor = {
+  root: new Uint8Array(16).fill(1),
+  folder: new Uint8Array(16).fill(2),
+  children: [],
+  ancestors: [],
+  deadLetters: [3n],
+  staleness: 'fresh',
+};
+
+class ReadHost implements EngineHostLike {
+  readonly snapshots: Uint8Array[] = [];
+  readonly downloads: Uint8Array[] = [];
+  respondSnapshot: () => Promise<SnapshotDescriptor> = () => Promise.resolve(SNAPSHOT);
+  respondDownload: () => Promise<ArrayBuffer> = () =>
+    Promise.resolve(new Uint8Array([9, 8, 7]).buffer);
+
+  start(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  command(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
+    this.snapshots.push(folder);
+    return this.respondSnapshot();
+  }
+
+  download(node: Uint8Array): Promise<ArrayBuffer> {
+    this.downloads.push(node);
+    return this.respondDownload();
+  }
+
+  nextEvent(): Promise<EventDescriptor | null> {
+    return new Promise<EventDescriptor | null>(() => undefined);
+  }
+}
+
+describe('serveEngine read requests', () => {
+  it('serves a snapshot read end to end over the transport', async () => {
+    const { scope, worker } = loopback();
+    const host = new ReadHost();
+    serveEngine(scope, host);
+    const transport = new LocalTransport(worker);
+
+    const folder = new Uint8Array(16).fill(2);
+    const view = await transport.snapshot(folder);
+    expect(view).toEqual(SNAPSHOT);
+    expect(host.snapshots).toEqual([folder]);
+  });
+
+  it('serves a download with the plaintext buffer in the transfer list', async () => {
+    const { scope, worker, toUi } = loopback();
+    serveEngine(scope, new ReadHost());
+    const transport = new LocalTransport(worker);
+
+    const content = await transport.download(new Uint8Array(16).fill(4));
+    expect([...new Uint8Array(content)]).toEqual([9, 8, 7]);
+
+    const response = toUi.find(
+      (entry) => entry.message.type === 'response' && 'result' in entry.message
+    );
+    expect(response).toBeDefined();
+    expect(response!.transfer).toEqual([content]);
+  });
+
+  it('maps a rejected read to a correlated error response', async () => {
+    const { scope, worker } = loopback();
+    const host = new ReadHost();
+    host.respondSnapshot = () => Promise.reject(new Error('unknown node'));
+    host.respondDownload = () => Promise.reject(new Error('content unavailable: not published'));
+    serveEngine(scope, host);
+    const transport = new LocalTransport(worker);
+
+    await expect(transport.snapshot(new Uint8Array(16))).rejects.toThrow('unknown node');
+    await expect(transport.download(new Uint8Array(16))).rejects.toThrow('content unavailable');
+    // The failures were per-request, never fatal: the next read still answers.
+    await expect(transport.command({ kind: 'manualRefresh' }, [])).resolves.toBeUndefined();
+  });
+
+  it('correlates concurrent command, snapshot, and download answered out of order', async () => {
+    const { scope, worker } = loopback();
+    const host = new ReadHost();
+    let releaseSnapshot!: () => void;
+    host.respondSnapshot = () =>
+      new Promise<SnapshotDescriptor>((resolve) => {
+        releaseSnapshot = () => resolve(SNAPSHOT);
+      });
+    serveEngine(scope, host);
+    const transport = new LocalTransport(worker);
+
+    const settled: string[] = [];
+    const snapshot = transport.snapshot(new Uint8Array(16)).then((view) => {
+      settled.push('snapshot');
+      return view;
+    });
+    const download = transport.download(new Uint8Array(16)).then((bytes) => {
+      settled.push('download');
+      return bytes;
+    });
+    const command = transport.command({ kind: 'manualRefresh' }, []).then(() => {
+      settled.push('command');
+    });
+
+    // The download and command answer while the snapshot is still parked.
+    await download;
+    await command;
+    expect(settled).toEqual(expect.arrayContaining(['download', 'command']));
+    expect(settled).not.toContain('snapshot');
+
+    releaseSnapshot();
+    expect(await snapshot).toEqual(SNAPSHOT);
+    expect([...new Uint8Array(await download)]).toEqual([9, 8, 7]);
+  });
+});
+
+describe('serveEngine event pump over the real EngineHost', () => {
+  it('streams renewalFailed and opProgress without turning the pump fatal', async () => {
+    // The regression this guards: a renewalFailed engine event used to be an
+    // unknown kind in `readEvent`, whose throw the pump escalated to `fatal`,
+    // bricking the transport.
+    const pumped: WasmEvent[] = [
+      { kind: 'renewalFailed', routingKey: 'k51abc', detail: 'republish rejected' },
+      {
+        kind: 'opProgress',
+        opId: 5n,
+        node: new Uint8Array(16).fill(7),
+        phase: 1,
+        error: undefined,
+      },
+      { kind: 'snapshotUpdated' },
+    ];
+    const handle: WasmEngineHandle = {
+      start: () => Promise.resolve(undefined),
+      command: () => Promise.resolve(undefined),
+      snapshot: () => Promise.reject(new Error('unused')),
+      download: () => Promise.reject(new Error('unused')),
+      nextEvent: () =>
+        pumped.length > 0
+          ? Promise.resolve(pumped.shift())
+          : new Promise<WasmEvent | undefined>(() => undefined),
+    };
+    const wasm = {
+      EngineHandle: function EngineHandle() {
+        return handle;
+      },
+      NodeId: { fromBytes: (bytes: Uint8Array) => ({ bytes }) },
+      Command: { manualRefresh: () => ({}) },
+      NodeKind: { File: 0, Folder: 1 },
+      Permission: { Read: 0, Write: 1 },
+      Staleness: { Fresh: 0, Reconciling: 1, Stale: 2, Offline: 3 },
+      OpPhase: { DownloadStarted: 0, DownloadCompleted: 1, DownloadFailed: 2 },
+    } as unknown as EngineWasm;
+
+    const { scope, worker, toUi } = loopback();
+    serveEngine(scope, new EngineHost(wasm, {}));
+    const transport = new LocalTransport(worker);
+    const received: EventDescriptor[] = [];
+    transport.subscribe((event) => received.push(event));
+
+    await tick();
+    expect(received).toEqual([
+      { kind: 'renewalFailed', routingKey: 'k51abc', detail: 'republish rejected' },
+      {
+        kind: 'opProgress',
+        opId: 5n,
+        node: new Uint8Array(16).fill(7),
+        phase: 'downloadCompleted',
+        error: null,
+      },
+      { kind: 'snapshotUpdated' },
+    ]);
+    expect(toUi.some((entry) => entry.message.type === 'fatal')).toBe(false);
+    // The transport is alive: a post-event command still round-trips.
+    await expect(transport.command({ kind: 'manualRefresh' }, [])).resolves.toBeUndefined();
+  });
+});

--- a/packages/client/src/worker/serve.test.ts
+++ b/packages/client/src/worker/serve.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { emptySnapshot, fakeWasmEnums } from '../testkit.js';
 import { LocalTransport, type EngineWorkerLike } from '../transport.js';
 import { EngineHost, type EngineHostLike } from './engineHost.js';
 import type { EngineWasm, WasmEngineHandle, WasmEvent } from './engineWasm.js';
@@ -50,12 +51,9 @@ function loopback(): {
 }
 
 const SNAPSHOT: SnapshotDescriptor = {
+  ...emptySnapshot(new Uint8Array(16).fill(2)),
   root: new Uint8Array(16).fill(1),
-  folder: new Uint8Array(16).fill(2),
-  children: [],
-  ancestors: [],
   deadLetters: [3n],
-  staleness: 'fresh',
 };
 
 class ReadHost implements EngineHostLike {
@@ -116,16 +114,29 @@ describe('serveEngine read requests', () => {
     expect(response!.transfer).toEqual([content]);
   });
 
-  it('maps a rejected read to a correlated error response', async () => {
+  it('maps a rejected read to a correlated error response with the stable code', async () => {
     const { scope, worker } = loopback();
     const host = new ReadHost();
-    host.respondSnapshot = () => Promise.reject(new Error('unknown node'));
-    host.respondDownload = () => Promise.reject(new Error('content unavailable: not published'));
+    // The wasm host rejects with an Error carrying the stable `code` property.
+    host.respondSnapshot = () =>
+      Promise.reject(Object.assign(new Error('unknown node'), { code: 'unknownNode' }));
+    host.respondDownload = () =>
+      Promise.reject(
+        Object.assign(new Error('content unavailable: not published'), {
+          code: 'contentUnavailable',
+        })
+      );
     serveEngine(scope, host);
     const transport = new LocalTransport(worker);
 
-    await expect(transport.snapshot(new Uint8Array(16))).rejects.toThrow('unknown node');
-    await expect(transport.download(new Uint8Array(16))).rejects.toThrow('content unavailable');
+    // The code crosses intact alongside the human-readable message.
+    await expect(transport.snapshot(new Uint8Array(16))).rejects.toMatchObject({
+      code: 'unknownNode',
+      message: 'unknown node',
+    });
+    await expect(transport.download(new Uint8Array(16))).rejects.toMatchObject({
+      code: 'contentUnavailable',
+    });
     // The failures were per-request, never fatal: the next read still answers.
     await expect(transport.command({ kind: 'manualRefresh' }, [])).resolves.toBeUndefined();
   });
@@ -198,10 +209,7 @@ describe('serveEngine event pump over the real EngineHost', () => {
       },
       NodeId: { fromBytes: (bytes: Uint8Array) => ({ bytes }) },
       Command: { manualRefresh: () => ({}) },
-      NodeKind: { File: 0, Folder: 1 },
-      Permission: { Read: 0, Write: 1 },
-      Staleness: { Fresh: 0, Reconciling: 1, Stale: 2, Offline: 3 },
-      OpPhase: { DownloadStarted: 0, DownloadCompleted: 1, DownloadFailed: 2 },
+      ...fakeWasmEnums,
     } as unknown as EngineWasm;
 
     const { scope, worker, toUi } = loopback();

--- a/packages/client/src/worker/serve.ts
+++ b/packages/client/src/worker/serve.ts
@@ -21,6 +21,12 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+/** The engine's stable error code, when the thrown value carries one. */
+function errorCode(error: unknown): string | undefined {
+  const code = (error as { code?: unknown } | null)?.code;
+  return typeof code === 'string' ? code : undefined;
+}
+
 /** Wires `scope` to `host`, then signals readiness. */
 export function serveEngine(scope: WorkerScopeLike, host: EngineHostLike): void {
   const post = (message: WorkerMessage): void => scope.postMessage(message);
@@ -50,7 +56,13 @@ export function serveEngine(scope: WorkerScopeLike, host: EngineHostLike): void 
       }
       post({ type: 'response', id: request.id, ok: true });
     } catch (error) {
-      post({ type: 'response', id: request.id, ok: false, error: errorMessage(error) });
+      post({
+        type: 'response',
+        id: request.id,
+        ok: false,
+        error: errorMessage(error),
+        code: errorCode(error),
+      });
     }
   };
 

--- a/packages/client/src/worker/serve.ts
+++ b/packages/client/src/worker/serve.ts
@@ -13,7 +13,7 @@ import type { WorkerMessage, WorkerRequest } from './protocol.js';
 
 /** The subset of a worker global scope (or `MessagePort`) the server needs. */
 export interface WorkerScopeLike {
-  postMessage(message: WorkerMessage): void;
+  postMessage(message: WorkerMessage, transfer?: Transferable[]): void;
   addEventListener(type: 'message', listener: (event: MessageEvent<WorkerRequest>) => void): void;
 }
 
@@ -27,12 +27,26 @@ export function serveEngine(scope: WorkerScopeLike, host: EngineHostLike): void 
 
   const handle = async (request: WorkerRequest): Promise<void> => {
     try {
-      if (request.type === 'start') {
-        await host.start(request.secret);
-      } else if (request.type === 'command') {
-        await host.command(request.command);
-      } else {
-        return; // ignore non-request messages (e.g. a bootstrap handshake)
+      switch (request.type) {
+        case 'start':
+          await host.start(request.secret);
+          break;
+        case 'command':
+          await host.command(request.command);
+          break;
+        case 'snapshot': {
+          const result = await host.snapshot(request.folder);
+          post({ type: 'response', id: request.id, ok: true, result });
+          return;
+        }
+        case 'download': {
+          const result = await host.download(request.node);
+          // Transfer the plaintext buffer: no byte copy through the boundary.
+          scope.postMessage({ type: 'response', id: request.id, ok: true, result }, [result]);
+          return;
+        }
+        default:
+          return; // ignore non-request messages (e.g. a bootstrap handshake)
       }
       post({ type: 'response', id: request.id, ok: true });
     } catch (error) {

--- a/packages/client/test/browser/engine.spec.ts
+++ b/packages/client/test/browser/engine.spec.ts
@@ -16,8 +16,25 @@ interface RealEngineResult {
   afterLogout: string;
 }
 
+interface SnapshotSuiteResult {
+  rootEchoed: boolean;
+  children: Array<{
+    name: string;
+    kind: string;
+    pending: boolean;
+    deadLetter: boolean;
+    sizeNull: boolean;
+    mtimeNull: boolean;
+  }>;
+  nestedAncestors: Array<{ idHex: string; name: string }>;
+  rootHex: string;
+  unknownError: string;
+  downloadError: string;
+}
+
 interface EngineHarness {
   runRealEngine(): Promise<RealEngineResult>;
+  runSnapshotSuite(): Promise<SnapshotSuiteResult>;
   runFakeOutOfOrder(): Promise<{ order: string[] }>;
   runFakeEvents(): Promise<{ events: number[] }>;
   runBoundary(name: string): Promise<{ ok: boolean; error?: string }>;
@@ -51,6 +68,37 @@ test.describe('engine worker host', () => {
     expect(result.afterStart).toContain('not implemented');
     // After logout the transport is torn down and rejects further work.
     expect(result.afterLogout).toContain('closed');
+  });
+
+  test('snapshot and download reads over the real engine', async ({ page }) => {
+    const result: SnapshotSuiteResult = await page.evaluate(() =>
+      (window as unknown as EngineHarness).runSnapshotSuite()
+    );
+
+    // The snapshot echoes the anchored all-zero root as both root and folder.
+    expect(result.rootEchoed).toBe(true);
+
+    // Both metadata creates project as pending children with no content plane.
+    expect(result.children).toHaveLength(2);
+    const docs = result.children.find((child) => child.name === 'docs');
+    const file = result.children.find((child) => child.name === 'pending.txt');
+    expect(docs).toMatchObject({ kind: 'folder', pending: true, deadLetter: false });
+    expect(file).toMatchObject({
+      kind: 'file',
+      pending: true,
+      deadLetter: false,
+      sizeNull: true,
+      mtimeNull: true,
+    });
+
+    // The nested folder's breadcrumb trail ends at the root.
+    expect(result.nestedAncestors.length).toBeGreaterThanOrEqual(1);
+    expect(result.nestedAncestors.at(-1)!.idHex).toBe(result.rootHex);
+
+    // An unknown node fails with the engine's stable error, crossed intact.
+    expect(result.unknownError).toContain('unknown node');
+    // A pending-only file has no published content: availability, not trust.
+    expect(result.downloadError).toContain('content unavailable');
   });
 
   test('RPC responses correlate by id even when answered out of order', async ({ page }) => {

--- a/packages/client/test/browser/engine.spec.ts
+++ b/packages/client/test/browser/engine.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
+import type { BoundaryOutcome, RealEngineResult, SnapshotSuiteResult } from './engineHarness.js';
+
 /**
  * The engine-worker slice of the merge-blocking browser suite
  * (blueprint/testing.md law 1, blueprint/web-client.md "Engine hosting"). It
@@ -8,36 +10,12 @@ import { expect, test, type Page } from '@playwright/test';
  * real seams, the protocol fake where the engine cannot yet drive a property.
  */
 
-interface RealEngineResult {
-  beforeStart: string;
-  startOk: boolean;
-  secretDetached: boolean;
-  afterStart: string;
-  afterLogout: string;
-}
-
-interface SnapshotSuiteResult {
-  rootEchoed: boolean;
-  children: Array<{
-    name: string;
-    kind: string;
-    pending: boolean;
-    deadLetter: boolean;
-    sizeNull: boolean;
-    mtimeNull: boolean;
-  }>;
-  nestedAncestors: Array<{ idHex: string; name: string }>;
-  rootHex: string;
-  unknownError: string;
-  downloadError: string;
-}
-
 interface EngineHarness {
   runRealEngine(): Promise<RealEngineResult>;
   runSnapshotSuite(): Promise<SnapshotSuiteResult>;
   runFakeOutOfOrder(): Promise<{ order: string[] }>;
   runFakeEvents(): Promise<{ events: number[] }>;
-  runBoundary(name: string): Promise<{ ok: boolean; error?: string }>;
+  runBoundary(name: string): Promise<BoundaryOutcome>;
 }
 
 test.describe('engine worker host', () => {
@@ -95,10 +73,12 @@ test.describe('engine worker host', () => {
     expect(result.nestedAncestors.length).toBeGreaterThanOrEqual(1);
     expect(result.nestedAncestors.at(-1)!.idHex).toBe(result.rootHex);
 
-    // An unknown node fails with the engine's stable error, crossed intact.
+    // An unknown node fails with the engine's stable code, crossed intact —
+    // plus the human-readable message alongside it.
+    expect(result.unknownCode).toBe('unknownNode');
     expect(result.unknownError).toContain('unknown node');
     // A pending-only file has no published content: availability, not trust.
-    expect(result.downloadError).toContain('content unavailable');
+    expect(result.downloadCode).toBe('contentUnavailable');
   });
 
   test('RPC responses correlate by id even when answered out of order', async ({ page }) => {
@@ -146,7 +126,7 @@ test.describe('engine worker host', () => {
   });
 });
 
-function runBoundary(page: Page, name: string): Promise<{ ok: boolean; error?: string }> {
+function runBoundary(page: Page, name: string): Promise<BoundaryOutcome> {
   return page.evaluate(
     (boundary) => (window as unknown as EngineHarness).runBoundary(boundary),
     name

--- a/packages/client/test/browser/engine.worker.ts
+++ b/packages/client/test/browser/engine.worker.ts
@@ -9,6 +9,7 @@ import init, {
   EngineHandle,
   NodeId,
   NodeKind,
+  OpPhase,
   Permission,
   Staleness,
 } from './pkg/cipherbox_wasm.js';
@@ -28,6 +29,7 @@ async function boot(): Promise<void> {
     Command,
     NodeId,
     NodeKind,
+    OpPhase,
     Permission,
     Staleness,
   } as unknown as EngineWasm;

--- a/packages/client/test/browser/engineHarness.ts
+++ b/packages/client/test/browser/engineHarness.ts
@@ -21,9 +21,27 @@ interface BoundaryOutcome {
   error?: string;
 }
 
+/** A page.evaluate-safe projection of the snapshot read surface. */
+interface SnapshotSuiteResult {
+  rootEchoed: boolean;
+  children: Array<{
+    name: string;
+    kind: string;
+    pending: boolean;
+    deadLetter: boolean;
+    sizeNull: boolean;
+    mtimeNull: boolean;
+  }>;
+  nestedAncestors: Array<{ idHex: string; name: string }>;
+  rootHex: string;
+  unknownError: string;
+  downloadError: string;
+}
+
 declare global {
   interface Window {
     runRealEngine(): Promise<RealEngineResult>;
+    runSnapshotSuite(): Promise<SnapshotSuiteResult>;
     runFakeOutOfOrder(): Promise<{ order: string[] }>;
     runFakeEvents(): Promise<{ events: number[] }>;
     runBoundary(name: string): Promise<BoundaryOutcome>;
@@ -83,6 +101,62 @@ window.runRealEngine = async (): Promise<RealEngineResult> => {
   });
 
   return result;
+};
+
+function hex(bytes: Uint8Array): string {
+  let out = '';
+  for (const byte of bytes) out += byte.toString(16).padStart(2, '0');
+  return out;
+}
+
+window.runSnapshotSuite = async (): Promise<SnapshotSuiteResult> => {
+  const { facade, transport } = facadeOver(realWorker());
+  try {
+    await facade.start(new Uint8Array(32).fill(1).buffer);
+
+    // Metadata-only creates: pending overlay entries with no content plane.
+    const root = new Uint8Array(16);
+    await facade.create(root, 'docs', 'folder');
+    await facade.create(root, 'pending.txt', 'file', null);
+
+    const view = await facade.snapshot(root);
+    const docs = view.children.find((child) => child.name === 'docs');
+    const file = view.children.find((child) => child.name === 'pending.txt');
+    if (!docs || !file) throw new Error('created children missing from the root snapshot');
+
+    const nested = await facade.snapshot(docs.id);
+
+    let unknownError = '';
+    await facade.snapshot(new Uint8Array(16).fill(0x5a)).catch((error: unknown) => {
+      unknownError = message(error);
+    });
+
+    let downloadError = '';
+    await facade.download(file.id).catch((error: unknown) => {
+      downloadError = message(error);
+    });
+
+    return {
+      rootEchoed: hex(view.folder) === hex(view.root) && hex(view.root) === hex(root),
+      children: view.children.map((child) => ({
+        name: child.name,
+        kind: child.kind,
+        pending: child.pending,
+        deadLetter: child.deadLetter,
+        sizeNull: child.size === null,
+        mtimeNull: child.mtime === null,
+      })),
+      nestedAncestors: nested.ancestors.map((ancestor) => ({
+        idHex: hex(ancestor.id),
+        name: ancestor.name,
+      })),
+      rootHex: hex(view.root),
+      unknownError,
+      downloadError,
+    };
+  } finally {
+    transport.close();
+  }
 };
 
 window.runFakeOutOfOrder = async (): Promise<{ order: string[] }> => {

--- a/packages/client/test/browser/engineHarness.ts
+++ b/packages/client/test/browser/engineHarness.ts
@@ -7,8 +7,9 @@
 import { EngineFacade } from '../../src/facade.js';
 import { LocalTransport } from '../../src/transport.js';
 import type { EventDescriptor } from '../../src/worker/protocol.js';
+import { hex } from './hexUtil.js';
 
-interface RealEngineResult {
+export interface RealEngineResult {
   beforeStart: string;
   startOk: boolean;
   secretDetached: boolean;
@@ -16,13 +17,13 @@ interface RealEngineResult {
   afterLogout: string;
 }
 
-interface BoundaryOutcome {
+export interface BoundaryOutcome {
   ok: boolean;
   error?: string;
 }
 
 /** A page.evaluate-safe projection of the snapshot read surface. */
-interface SnapshotSuiteResult {
+export interface SnapshotSuiteResult {
   rootEchoed: boolean;
   children: Array<{
     name: string;
@@ -35,7 +36,9 @@ interface SnapshotSuiteResult {
   nestedAncestors: Array<{ idHex: string; name: string }>;
   rootHex: string;
   unknownError: string;
+  unknownCode: string;
   downloadError: string;
+  downloadCode: string;
 }
 
 declare global {
@@ -63,6 +66,12 @@ function facadeOver(worker: Worker): { facade: EngineFacade; transport: LocalTra
 
 function message(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/** The engine's stable error code as crossed on the rejection, '' if absent. */
+function code(error: unknown): string {
+  const value = (error as { code?: unknown } | null)?.code;
+  return typeof value === 'string' ? value : '';
 }
 
 window.runRealEngine = async (): Promise<RealEngineResult> => {
@@ -103,12 +112,6 @@ window.runRealEngine = async (): Promise<RealEngineResult> => {
   return result;
 };
 
-function hex(bytes: Uint8Array): string {
-  let out = '';
-  for (const byte of bytes) out += byte.toString(16).padStart(2, '0');
-  return out;
-}
-
 window.runSnapshotSuite = async (): Promise<SnapshotSuiteResult> => {
   const { facade, transport } = facadeOver(realWorker());
   try {
@@ -127,13 +130,17 @@ window.runSnapshotSuite = async (): Promise<SnapshotSuiteResult> => {
     const nested = await facade.snapshot(docs.id);
 
     let unknownError = '';
+    let unknownCode = '';
     await facade.snapshot(new Uint8Array(16).fill(0x5a)).catch((error: unknown) => {
       unknownError = message(error);
+      unknownCode = code(error);
     });
 
     let downloadError = '';
+    let downloadCode = '';
     await facade.download(file.id).catch((error: unknown) => {
       downloadError = message(error);
+      downloadCode = code(error);
     });
 
     return {
@@ -152,7 +159,9 @@ window.runSnapshotSuite = async (): Promise<SnapshotSuiteResult> => {
       })),
       rootHex: hex(view.root),
       unknownError,
+      unknownCode,
       downloadError,
+      downloadCode,
     };
   } finally {
     transport.close();

--- a/packages/client/test/browser/fakeEngine.worker.ts
+++ b/packages/client/test/browser/fakeEngine.worker.ts
@@ -11,7 +11,11 @@
  */
 import { serveEngine, type WorkerScopeLike } from '../../src/worker/serve.js';
 import type { EngineHostLike } from '../../src/worker/engineHost.js';
-import type { CommandDescriptor, EventDescriptor } from '../../src/worker/protocol.js';
+import type {
+  CommandDescriptor,
+  EventDescriptor,
+  SnapshotDescriptor,
+} from '../../src/worker/protocol.js';
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -33,6 +37,14 @@ class FakeHost implements EngineHostLike {
     }
     // First call is slow, later calls fast → responses arrive out of order.
     await sleep(this.commandCount === 1 ? 40 : 5);
+  }
+
+  snapshot(): Promise<SnapshotDescriptor> {
+    return Promise.reject(new Error('fake host serves no snapshots'));
+  }
+
+  download(): Promise<ArrayBuffer> {
+    return Promise.reject(new Error('fake host serves no downloads'));
   }
 
   nextEvent(): Promise<EventDescriptor | null> {

--- a/packages/client/test/browser/hexUtil.ts
+++ b/packages/client/test/browser/hexUtil.ts
@@ -1,0 +1,13 @@
+/** Hex helpers shared by the browser-suite page harnesses. */
+
+export function hex(bytes: Uint8Array): string {
+  let out = '';
+  for (const byte of bytes) out += byte.toString(16).padStart(2, '0');
+  return out;
+}
+
+export function unhex(text: string): Uint8Array {
+  const bytes = new Uint8Array(text.length / 2);
+  for (let i = 0; i < bytes.length; i += 1) bytes[i] = parseInt(text.slice(i * 2, i * 2 + 2), 16);
+  return bytes;
+}

--- a/packages/client/test/browser/journalEngine.worker.ts
+++ b/packages/client/test/browser/journalEngine.worker.ts
@@ -11,7 +11,11 @@
  */
 import { serveEngine, type WorkerScopeLike } from '../../src/worker/serve.js';
 import type { EngineHostLike } from '../../src/worker/engineHost.js';
-import type { CommandDescriptor, EventDescriptor } from '../../src/worker/protocol.js';
+import type {
+  CommandDescriptor,
+  EventDescriptor,
+  SnapshotDescriptor,
+} from '../../src/worker/protocol.js';
 
 const DB_NAME = 'cb-leadership-journal';
 const STORE = 'ops';
@@ -52,6 +56,14 @@ class JournalHost implements EngineHostLike {
     if (command.kind !== 'manualRefresh' && command.kind !== 'setFocus') {
       await journal(command);
     }
+  }
+
+  snapshot(): Promise<SnapshotDescriptor> {
+    return Promise.reject(new Error('journal host serves no snapshots'));
+  }
+
+  download(): Promise<ArrayBuffer> {
+    return Promise.reject(new Error('journal host serves no downloads'));
   }
 
   nextEvent(): Promise<EventDescriptor | null> {

--- a/packages/client/test/browser/leadership.spec.ts
+++ b/packages/client/test/browser/leadership.spec.ts
@@ -10,11 +10,33 @@ import { expect, test, type BrowserContext, type Page } from '@playwright/test';
  * follower-broadcast) reach the single engine worker.
  */
 
+interface SnapshotResult {
+  error?: string;
+  rootHex?: string;
+  folderHex?: string;
+  children?: Array<{
+    idHex: string;
+    name: string;
+    kind: string;
+    pending: boolean;
+    sizeNull: boolean;
+    mtimeNull: boolean;
+  }>;
+  ancestors?: Array<{ idHex: string; name: string }>;
+}
+
 interface LeadershipHarness {
-  cbCreate(options: { lockName: string; channelName: string }): Promise<void>;
+  cbCreate(options: {
+    lockName: string;
+    channelName: string;
+    worker?: 'journal' | 'engine';
+  }): Promise<void>;
   cbRole(): string;
   cbStart(): Promise<string>;
   cbCreateFile(name: string): Promise<string>;
+  cbCreateNode(name: string, kind: 'file' | 'folder'): Promise<string>;
+  cbSnapshot(folderHex: string): Promise<SnapshotResult>;
+  cbDownload(nodeHex: string): Promise<{ bytes?: number[]; error?: string }>;
   cbDispose(): Promise<void>;
   cbJournalCount(): Promise<number>;
   cbJournalRecords(): Promise<unknown[]>;
@@ -35,10 +57,13 @@ async function openTab(context: BrowserContext): Promise<Page> {
 }
 
 function harness(page: Page): {
-  create(lockName: string, channelName: string): Promise<void>;
+  create(lockName: string, channelName: string, worker?: 'journal' | 'engine'): Promise<void>;
   role(): Promise<string>;
   start(): Promise<string>;
   createFile(name: string): Promise<string>;
+  createNode(name: string, kind: 'file' | 'folder'): Promise<string>;
+  snapshot(folderHex: string): Promise<SnapshotResult>;
+  download(nodeHex: string): Promise<{ bytes?: number[]; error?: string }>;
   dispose(): Promise<void>;
   journalCount(): Promise<number>;
   journalRecords(): Promise<unknown[]>;
@@ -47,15 +72,25 @@ function harness(page: Page): {
   waitForRole(role: string): Promise<void>;
 } {
   return {
-    create: (lockName, channelName) =>
+    create: (lockName, channelName, worker) =>
       page.evaluate((opts) => (window as unknown as LeadershipHarness).cbCreate(opts), {
         lockName,
         channelName,
+        worker,
       }),
     role: () => page.evaluate(() => (window as unknown as LeadershipHarness).cbRole()),
     start: () => page.evaluate(() => (window as unknown as LeadershipHarness).cbStart()),
     createFile: (name) =>
       page.evaluate((n) => (window as unknown as LeadershipHarness).cbCreateFile(n), name),
+    createNode: (name, kind) =>
+      page.evaluate(
+        (args) => (window as unknown as LeadershipHarness).cbCreateNode(args.name, args.kind),
+        { name, kind }
+      ),
+    snapshot: (folderHex) =>
+      page.evaluate((f) => (window as unknown as LeadershipHarness).cbSnapshot(f), folderHex),
+    download: (nodeHex) =>
+      page.evaluate((n) => (window as unknown as LeadershipHarness).cbDownload(n), nodeHex),
     dispose: () => page.evaluate(() => (window as unknown as LeadershipHarness).cbDispose()),
     journalCount: () =>
       page.evaluate(() => (window as unknown as LeadershipHarness).cbJournalCount()),
@@ -133,6 +168,50 @@ test.describe('tab leadership over real Web Locks + BroadcastChannel', () => {
         Object.values(row).some((v) => v instanceof Uint8Array || v instanceof ArrayBuffer)
       ).toBe(false);
     }
+
+    await a.dispose();
+    await b.dispose();
+  });
+
+  test('a follower reads snapshot and download through the real leader engine', async ({
+    context,
+  }) => {
+    const { lockName, channelName } = names();
+    const a = harness(await openTab(context));
+    const b = harness(await openTab(context));
+
+    await a.create(lockName, channelName, 'engine');
+    await b.create(lockName, channelName, 'engine');
+    const leader = (await a.role()) === 'leader' ? a : b;
+    const follower = leader === a ? b : a;
+
+    expect(await leader.start()).toBe('ok');
+    expect(await follower.start()).toBe('ok');
+
+    // Metadata-only creates via the leader's real engine.
+    expect(await leader.createNode('docs', 'folder')).toBe('ok');
+    expect(await leader.createNode('pending.txt', 'file')).toBe('ok');
+
+    // The follower's snapshot rides the broadcast wire to the leader engine.
+    const rootHex = '00'.repeat(16);
+    const view = await follower.snapshot(rootHex);
+    expect(view.error).toBeUndefined();
+    expect(view.rootHex).toBe(rootHex);
+    expect(view.folderHex).toBe(rootHex);
+    const docs = view.children!.find((child) => child.name === 'docs');
+    const file = view.children!.find((child) => child.name === 'pending.txt');
+    expect(docs).toMatchObject({ kind: 'folder', pending: true });
+    expect(file).toMatchObject({ kind: 'file', pending: true, sizeNull: true, mtimeNull: true });
+
+    // The nested snapshot's breadcrumb trail ends at the root.
+    const nested = await follower.snapshot(docs!.idHex);
+    expect(nested.error).toBeUndefined();
+    expect(nested.ancestors!.at(-1)!.idHex).toBe(rootHex);
+
+    // A pending-only file's download rejection propagates to the follower.
+    const download = await follower.download(file!.idHex);
+    expect(download.bytes).toBeUndefined();
+    expect(download.error).toContain('content unavailable');
 
     await a.dispose();
     await b.dispose();

--- a/packages/client/test/browser/leadership.spec.ts
+++ b/packages/client/test/browser/leadership.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type BrowserContext, type Page } from '@playwright/test';
 
+import type { DownloadResult, SnapshotResult } from './leadership.js';
+
 /**
  * The tab-leadership slice of the merge-blocking browser suite
  * (blueprint/testing.md law 1, blueprint/web-client.md "Engine hosting and tab
@@ -9,21 +11,6 @@ import { expect, test, type BrowserContext, type Page } from '@playwright/test';
  * accepted-op loss, and that both facade transports (leader-local and
  * follower-broadcast) reach the single engine worker.
  */
-
-interface SnapshotResult {
-  error?: string;
-  rootHex?: string;
-  folderHex?: string;
-  children?: Array<{
-    idHex: string;
-    name: string;
-    kind: string;
-    pending: boolean;
-    sizeNull: boolean;
-    mtimeNull: boolean;
-  }>;
-  ancestors?: Array<{ idHex: string; name: string }>;
-}
 
 interface LeadershipHarness {
   cbCreate(options: {
@@ -36,7 +23,7 @@ interface LeadershipHarness {
   cbCreateFile(name: string): Promise<string>;
   cbCreateNode(name: string, kind: 'file' | 'folder'): Promise<string>;
   cbSnapshot(folderHex: string): Promise<SnapshotResult>;
-  cbDownload(nodeHex: string): Promise<{ bytes?: number[]; error?: string }>;
+  cbDownload(nodeHex: string): Promise<DownloadResult>;
   cbDispose(): Promise<void>;
   cbJournalCount(): Promise<number>;
   cbJournalRecords(): Promise<unknown[]>;
@@ -63,7 +50,7 @@ function harness(page: Page): {
   createFile(name: string): Promise<string>;
   createNode(name: string, kind: 'file' | 'folder'): Promise<string>;
   snapshot(folderHex: string): Promise<SnapshotResult>;
-  download(nodeHex: string): Promise<{ bytes?: number[]; error?: string }>;
+  download(nodeHex: string): Promise<DownloadResult>;
   dispose(): Promise<void>;
   journalCount(): Promise<number>;
   journalRecords(): Promise<unknown[]>;
@@ -208,10 +195,11 @@ test.describe('tab leadership over real Web Locks + BroadcastChannel', () => {
     expect(nested.error).toBeUndefined();
     expect(nested.ancestors!.at(-1)!.idHex).toBe(rootHex);
 
-    // A pending-only file's download rejection propagates to the follower.
+    // A pending-only file's download rejection propagates to the follower with
+    // the engine's stable code intact across both wire hops.
     const download = await follower.download(file!.idHex);
     expect(download.bytes).toBeUndefined();
-    expect(download.error).toContain('content unavailable');
+    expect(download.code).toBe('contentUnavailable');
 
     await a.dispose();
     await b.dispose();

--- a/packages/client/test/browser/leadership.ts
+++ b/packages/client/test/browser/leadership.ts
@@ -8,19 +8,27 @@
  * kill-the-leader failover with no accepted-op loss.
  */
 import { EngineClient } from '../../src/engineClient.js';
+import { hex, unhex } from './hexUtil.js';
 
 const JOURNAL_DB = 'cb-leadership-journal';
 const JOURNAL_STORE = 'ops';
 
-interface HarnessOptions {
+export interface HarnessOptions {
   lockName: string;
   channelName: string;
   /** Which engine worker the leader spawns: the journal fake (default) or the real WASM engine. */
   worker?: 'journal' | 'engine';
 }
 
+/** A page.evaluate-safe download projection; `code` is the engine's stable error code. */
+export interface DownloadResult {
+  bytes?: number[];
+  error?: string;
+  code?: string;
+}
+
 /** A page.evaluate-safe snapshot projection (bytes as hex, bigints dropped). */
-interface SnapshotResult {
+export interface SnapshotResult {
   error?: string;
   rootHex?: string;
   folderHex?: string;
@@ -43,7 +51,7 @@ declare global {
     cbCreateFile(name: string): Promise<string>;
     cbCreateNode(name: string, kind: 'file' | 'folder'): Promise<string>;
     cbSnapshot(folderHex: string): Promise<SnapshotResult>;
-    cbDownload(nodeHex: string): Promise<{ bytes?: number[]; error?: string }>;
+    cbDownload(nodeHex: string): Promise<DownloadResult>;
     cbDispose(): Promise<void>;
     cbJournalCount(): Promise<number>;
     cbJournalRecords(): Promise<unknown[]>;
@@ -63,18 +71,6 @@ function settle(error: unknown): string {
 
 // A valid secp256k1 identity scalar placeholder (the journal fake ignores it).
 const secret = (): ArrayBuffer => new Uint8Array(32).fill(1).buffer;
-
-function hex(bytes: Uint8Array): string {
-  let out = '';
-  for (const byte of bytes) out += byte.toString(16).padStart(2, '0');
-  return out;
-}
-
-function unhex(text: string): Uint8Array {
-  const bytes = new Uint8Array(text.length / 2);
-  for (let i = 0; i < bytes.length; i += 1) bytes[i] = parseInt(text.slice(i * 2, i * 2 + 2), 16);
-  return bytes;
-}
 
 window.cbCreate = ({ lockName, channelName, worker }: HarnessOptions): Promise<void> => {
   const workerUrl =
@@ -146,12 +142,13 @@ window.cbSnapshot = async (folderHex: string): Promise<SnapshotResult> => {
   }
 };
 
-window.cbDownload = async (nodeHex: string): Promise<{ bytes?: number[]; error?: string }> => {
+window.cbDownload = async (nodeHex: string): Promise<DownloadResult> => {
   try {
     const content = await client!.facade.download(unhex(nodeHex));
     return { bytes: [...new Uint8Array(content)] };
   } catch (error) {
-    return { error: settle(error) };
+    const code = (error as { code?: unknown } | null)?.code;
+    return { error: settle(error), code: typeof code === 'string' ? code : undefined };
   }
 };
 

--- a/packages/client/test/browser/leadership.ts
+++ b/packages/client/test/browser/leadership.ts
@@ -15,6 +15,24 @@ const JOURNAL_STORE = 'ops';
 interface HarnessOptions {
   lockName: string;
   channelName: string;
+  /** Which engine worker the leader spawns: the journal fake (default) or the real WASM engine. */
+  worker?: 'journal' | 'engine';
+}
+
+/** A page.evaluate-safe snapshot projection (bytes as hex, bigints dropped). */
+interface SnapshotResult {
+  error?: string;
+  rootHex?: string;
+  folderHex?: string;
+  children?: Array<{
+    idHex: string;
+    name: string;
+    kind: string;
+    pending: boolean;
+    sizeNull: boolean;
+    mtimeNull: boolean;
+  }>;
+  ancestors?: Array<{ idHex: string; name: string }>;
 }
 
 declare global {
@@ -23,6 +41,9 @@ declare global {
     cbRole(): string;
     cbStart(): Promise<string>;
     cbCreateFile(name: string): Promise<string>;
+    cbCreateNode(name: string, kind: 'file' | 'folder'): Promise<string>;
+    cbSnapshot(folderHex: string): Promise<SnapshotResult>;
+    cbDownload(nodeHex: string): Promise<{ bytes?: number[]; error?: string }>;
     cbDispose(): Promise<void>;
     cbJournalCount(): Promise<number>;
     cbJournalRecords(): Promise<unknown[]>;
@@ -40,16 +61,33 @@ function settle(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-window.cbCreate = ({ lockName, channelName }: HarnessOptions): Promise<void> => {
+// A valid secp256k1 identity scalar placeholder (the journal fake ignores it).
+const secret = (): ArrayBuffer => new Uint8Array(32).fill(1).buffer;
+
+function hex(bytes: Uint8Array): string {
+  let out = '';
+  for (const byte of bytes) out += byte.toString(16).padStart(2, '0');
+  return out;
+}
+
+function unhex(text: string): Uint8Array {
+  const bytes = new Uint8Array(text.length / 2);
+  for (let i = 0; i < bytes.length; i += 1) bytes[i] = parseInt(text.slice(i * 2, i * 2 + 2), 16);
+  return bytes;
+}
+
+window.cbCreate = ({ lockName, channelName, worker }: HarnessOptions): Promise<void> => {
+  const workerUrl =
+    worker === 'engine'
+      ? new URL('./engine.worker.ts', import.meta.url)
+      : new URL('./journalEngine.worker.ts', import.meta.url);
   client = new EngineClient({
     locks: navigator.locks,
     lockName,
     createChannel: () => new BroadcastChannel(channelName),
-    spawnWorker: () =>
-      new Worker(new URL('./journalEngine.worker.ts', import.meta.url), { type: 'module' }),
-    // Failover re-derivation: a real login re-exports this from Core Kit; the
-    // suite only needs a non-key placeholder to drive the cold-start path.
-    secretSource: { provideSecret: () => Promise.resolve(new ArrayBuffer(8)) },
+    spawnWorker: () => new Worker(workerUrl, { type: 'module' }),
+    // Failover re-derivation: a real login re-exports this from Core Kit.
+    secretSource: { provideSecret: () => Promise.resolve(secret()) },
   });
   // Let the lock election settle so role() is meaningful to the caller.
   return new Promise<void>((resolve) => setTimeout(resolve, 50));
@@ -59,7 +97,7 @@ window.cbRole = (): string => client?.currentRole() ?? 'none';
 
 window.cbStart = async (): Promise<string> => {
   try {
-    await client!.facade.start(new ArrayBuffer(8));
+    await client!.facade.start(secret());
     return 'ok';
   } catch (error) {
     return settle(error);
@@ -72,6 +110,48 @@ window.cbCreateFile = async (name: string): Promise<string> => {
     return 'ok';
   } catch (error) {
     return settle(error);
+  }
+};
+
+window.cbCreateNode = async (name: string, kind: 'file' | 'folder'): Promise<string> => {
+  try {
+    await client!.facade.create(rootNode, name, kind, null);
+    return 'ok';
+  } catch (error) {
+    return settle(error);
+  }
+};
+
+window.cbSnapshot = async (folderHex: string): Promise<SnapshotResult> => {
+  try {
+    const view = await client!.facade.snapshot(unhex(folderHex));
+    return {
+      rootHex: hex(view.root),
+      folderHex: hex(view.folder),
+      children: view.children.map((child) => ({
+        idHex: hex(child.id),
+        name: child.name,
+        kind: child.kind,
+        pending: child.pending,
+        sizeNull: child.size === null,
+        mtimeNull: child.mtime === null,
+      })),
+      ancestors: view.ancestors.map((ancestor) => ({
+        idHex: hex(ancestor.id),
+        name: ancestor.name,
+      })),
+    };
+  } catch (error) {
+    return { error: settle(error) };
+  }
+};
+
+window.cbDownload = async (nodeHex: string): Promise<{ bytes?: number[]; error?: string }> => {
+  try {
+    const content = await client!.facade.download(unhex(nodeHex));
+    return { bytes: [...new Uint8Array(content)] };
+  } catch (error) {
+    return { error: settle(error) };
   }
 };
 


### PR DESCRIPTION
## Summary

Closes the facade read-surface gap that blocks the web browser UI: the engine was command-in / event-out only, with a payload-free `SnapshotUpdated`. This lands the key-free read surface end to end — engine projection, WASM boundary, and both client transports.

### Engine (`crates/engine`)

- `Engine::snapshot(folder) -> SnapshotView` — key-free projection over the rendered view (base ⊕ pending-op overlay): root id, focused-folder direct children `{id, name, kind, size?, mtime?, pending, deadLetter, contentVersion}`, breadcrumb ancestor chain, retained dead letters, and the current `Staleness` rung. Fail-closed on unknown nodes and non-folders.
- `Engine::read_content(node) -> Bytes` — resolves the file's own record via a new `ChildAdopter` (record verify → CID-verified head fetch → envelope decode → transplant checks → sequence/read-epoch floors → AAD-bound unseal under the node-derived read key; grant-bearing child envelopes fail closed), then fetches the content DAG through the gateway set with per-block CID verification, cross-checks manifest vs version size, opens each chunk, and returns plaintext. The owner scope read seed recovered at root adopts is now retained in memory (never persisted, never crosses the facade).
- Staleness tracking is now live: the resolve tick stamps successes via the scheduler seam, classifies the rung, and emits `StalenessChanged` on transitions (previously the classifier had no callers and the event no emitter).
- Dead letters are retained for the session and surfaced in `SnapshotView`; per-child attribution stays false until the rebase slice can name targets.
- `Event::OpProgress { opId?, node, phase, error? }` with download phases; upload phases join the content-plane slice.
- Successful downloads fold head-version `size`/`mtime` into the base snapshot and emit `SnapshotUpdated` (progressive hydration).

### WASM boundary (`crates/wasm`)

`EngineHandle.snapshot` / `EngineHandle.download`, plus `SnapshotView` / `SnapshotChild` / `Breadcrumb` / `OpPhase` boundary types with key-free getters following the existing conventions (u64 → bigint, ids → Uint8Array, Option → undefined).

### Client (`packages/client`)

- Worker protocol/codec/serve gain `snapshot` and `download` requests; download bytes transfer worker → UI and ride a shared-backing `Blob` leader → follower over the broadcast channel.
- `EngineTransport`, `LocalTransport`, `BroadcastTransport`, leader relay, `EngineClient`, and `EngineFacade` all gain the read paths; followers round-trip reads through the leader under the existing token gating.
- **Bug fix:** `renewalFailed` was emitted by the engine but missing from `EventDescriptor` — the fail-closed codec throw turned the event pump fatal, bricking every tab's transport on the first real renewal failure. It is now mirrored and reaches subscribers.

## Tests

- Engine: snapshot projection, staleness transitions under the virtual scheduler, dead-letter retention, and a full `read_content` capstone (happy path, tampered leaf, transplant, grant-bearing child, replay of an older sequence, size mismatches, availability vs trust classification) — all seam-driven, no clocks/RNG.
- WASM: native exhaustive-match guards plus wasm32 boundary tests (bigint/Uint8Array/undefined shapes).
- Client: 62 vitest cases including read/command correlation, renewalFailed pump survival, broadcast round-trips with forged-token rejection and Blob byte-equality; 19 Playwright browser tests including the new read-path conformance over both transports against the real WASM engine.

## Deferred (with rationale)

- `Staleness::Offline` rung — no connectivity seam exists yet; classifier input stays `Online`.
- Node-attributed dead letters — undecodable ops cannot name a target; attribution lands with the live-rebase slice.
- Upload `OpProgress` phases — content-bearing commands are still unimplemented.
- Focused-subfolder child hydration via the focus-window tick — `ChildAdopter` is the reusable piece.
- Granted-subscope child reads — fail closed now, grants slice later.

Closes #802
Part of #642

## Review gates

- `/simplify` — applied: shared `floor::check` + head-envelope assembly between root and child adopters, core-owned `has_grant_section`, `content::open_content` as the read dual of `seal_content`, wasm host RwLock so downloads stop serializing commands, stable error codes across the worker/broadcast wires, fold-only-on-change `SnapshotUpdated`, fixture dedup.
- `/security-review` — no findings at the reporting bar.
- `/crypto-privacy-review` — fixed the MEDIUM: child unseals no longer advance the durable scope read-epoch floor (a self-attested inflated child epoch could otherwise permanently brick honest root adoption on a device); tightened at-floor re-opens to the exact floor sequence; reclassified a missing scope read seed as availability. Added pins: epoch inflation, scope + kind transplants, cached no-update reads leaving floors unmoved. Encode-side symmetry debts for the new decode rejects are tracked in #812 (edge to #807).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added folder snapshots with child listings, breadcrumbs, pending operations, dead letters, metadata, and staleness status.
  * Added verified file downloads with progress events and clear availability or trust errors.
  * Added snapshot and download support across local, worker, and cross-tab workflows.
  * Added stable machine-readable error codes for client applications.
* **Bug Fixes**
  * Improved fail-closed validation for downloaded content and preserved unavailable-operation details.
* **Tests**
  * Expanded coverage for snapshots, downloads, progress events, error handling, and cross-tab coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->