### PR TITLE
fix: correct the engine mailbox client routes and gate them live

### DIFF
--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -5,7 +5,8 @@
 //! that exists server-side today (#624): challenge-signature login and account
 //! identity, refresh rotation with reuse detection, test-login environment
 //! gating + deterministic keypair + cross-consistency with identity login,
-//! SIWE secondary surface, logout revocation, and a raw endpoint round-trip.
+//! SIWE secondary surface, logout revocation, the pin/name registry and quota,
+//! the mailbox lifecycle, and a raw endpoint round-trip.
 //!
 //! Each test skips (loudly) when `CONTRACT_API_URL` is unset — there is no
 //! stack to hit locally. The merge-blocking `contract-suite` CI job always
@@ -15,7 +16,9 @@ use cipherbox_contract::{
     MemoryCredentialStore, ReqwestHttp, api_url, hex_to_scalar, prod_api_url,
     random_identity_signer, test_login_secret,
 };
-use cipherbox_engine::api::{ApiClient, ApiError, IdentityChallengeSigner, NameRegistration};
+use cipherbox_engine::api::{
+    ApiClient, ApiError, ChallengeSigner, IdentityChallengeSigner, NameRegistration,
+};
 use cipherbox_engine::seams::{CredentialStore, Http, HttpMethod, HttpRequest};
 
 type Client = ApiClient<ReqwestHttp, MemoryCredentialStore>;
@@ -463,5 +466,107 @@ async fn quota_is_hosted_authoritative_and_byo_advisory() {
     assert!(
         !restored.advisory,
         "clearing BYO restores authoritative quota"
+    );
+}
+
+// --- mailbox (blueprint/api.md, Mailbox; #827) ------------------------------
+
+/// An account addressable as a mailbox recipient: the client plus its identity
+/// publicKey. Minted through test-login rather than a fresh identity login so
+/// the mailbox tests add no traffic to the per-IP `/auth/login` bucket.
+async fn addressable_account(base: &str, handle: &str) -> (Client, String) {
+    let client = new_client(base);
+    let outcome = client
+        .test_login(handle, &test_login_secret())
+        .await
+        .expect("test login");
+    (client, outcome.public_key)
+}
+
+/// The mailbox lifecycle (blueprint/api.md, Mailbox): post → poll → ack over
+/// the real routes.
+#[tokio::test]
+async fn mailbox_post_poll_ack_round_trips() {
+    let base = require_stack!("mailbox_post_poll_ack_round_trips");
+    let (sender, _) = addressable_account(&base, "contract-mailbox-sender").await;
+    let (recipient, recipient_key) = addressable_account(&base, "contract-mailbox-recipient").await;
+
+    let blob = b"contract-suite-sealed-blob".to_vec();
+    let posted = sender
+        .mailbox_post(&recipient_key, &blob, "contract-mailbox-idem")
+        .await
+        .expect("post to a known recipient");
+
+    let items = recipient.mailbox_poll().await.expect("poll");
+    assert_eq!(items.len(), 1, "one pending item");
+    assert_eq!(items[0].id, posted, "the polled id is the posted id");
+    assert_eq!(items[0].blob, blob, "the sealed blob round-trips opaquely");
+    assert!(!items[0].received_at.is_empty(), "receivedAt is populated");
+    assert!(
+        sender.mailbox_poll().await.expect("sender poll").is_empty(),
+        "a post lands only in the recipient's mailbox"
+    );
+
+    let replay = sender
+        .mailbox_post(&recipient_key, &blob, "contract-mailbox-idem")
+        .await
+        .expect("replayed post");
+    assert_eq!(replay, posted, "a replay returns the original message id");
+    assert_eq!(
+        recipient
+            .mailbox_poll()
+            .await
+            .expect("poll after replay")
+            .len(),
+        1,
+        "the replay delivered no second copy"
+    );
+
+    recipient.mailbox_ack(&posted).await.expect("ack");
+    assert!(
+        recipient
+            .mailbox_poll()
+            .await
+            .expect("poll after ack")
+            .is_empty(),
+        "ack removes the item"
+    );
+    recipient
+        .mailbox_ack(&posted)
+        .await
+        .expect("acking a gone id is a no-op");
+}
+
+/// The mailbox's two fail-closed post bounds (blueprint/api.md, Mailbox): the
+/// rate-limited existence oracle, and the 8 KiB sealed-blob cap.
+#[tokio::test]
+async fn mailbox_post_is_bounded_by_recipient_existence_and_blob_size() {
+    let base = require_stack!("mailbox_post_is_bounded_by_recipient_existence_and_blob_size");
+    let (sender, recipient_key) = addressable_account(&base, "contract-mailbox-bounds").await;
+
+    // A well-formed publicKey that has never logged in, so no account backs it.
+    let stranger = random_identity_signer().public_key_hex();
+    let error = sender
+        .mailbox_post(&stranger, b"blob", "contract-mailbox-unknown")
+        .await
+        .expect_err("an unknown recipient must be refused");
+    assert!(
+        matches!(error, ApiError::Status { status: 404, .. }),
+        "an unknown recipient is a 404, got {error:?}"
+    );
+
+    // One byte over the 8 KiB bound, and far short of the DTO's base64 length
+    // cap, so the refusal is the spec bound and not DTO validation.
+    let error = sender
+        .mailbox_post(
+            &recipient_key,
+            &vec![1u8; 8193],
+            "contract-mailbox-oversize",
+        )
+        .await
+        .expect_err("an oversized blob must be refused");
+    assert!(
+        matches!(error, ApiError::Status { status: 413, .. }),
+        "an oversized sealed blob is a 413, got {error:?}"
     );
 }

--- a/crates/engine/src/api/client.rs
+++ b/crates/engine/src/api/client.rs
@@ -19,9 +19,9 @@ use super::error::ApiError;
 use super::signer::ChallengeSigner;
 use super::types::{
     ChallengeRequest, ChallengeResponse, ErrorBody, LoginOutcome, LoginRequest, MailboxItem,
-    MailboxItemWire, NameRegistration, Quota, RefreshRequest, SiweChallengeResponse,
-    SiweLoginRequest, SiweNonce, TestLoginOutcome, TestLoginRequest, TestLoginResponse,
-    TokenResponse, UploadResult,
+    MailboxPollWire, MailboxPostWire, NameRegistration, Quota, RefreshRequest,
+    SiweChallengeResponse, SiweLoginRequest, SiweNonce, TestLoginOutcome, TestLoginRequest,
+    TestLoginResponse, TokenResponse, UploadResult,
 };
 use crate::seams::{CredentialStore, Http, HttpMethod, HttpRequest, HttpResponse};
 
@@ -247,7 +247,6 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
     }
 
     // --- pin/name registry, quota, content, mailbox, recovery, account ---
-    // Provisional until the matching API slices land (see types.rs).
 
     /// Batch register names (`[{ipnsName, headCid?, contentCids[]}]`).
     /// Register-first ordering is the publish pipeline's concern, not the
@@ -302,13 +301,15 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
         decode(&response)
     }
 
-    /// Post a sealed blob to a recipient's mailbox with an idempotency key.
+    /// Post a sealed blob to a recipient's mailbox with an idempotency key,
+    /// returning the server-assigned message id (a replay of the same key
+    /// returns the original id).
     pub async fn mailbox_post(
         &self,
         recipient_public_key: &str,
         blob: &[u8],
         idempotency_key: &str,
-    ) -> Result<(), ApiError> {
+    ) -> Result<String, ApiError> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
         struct Body<'a> {
@@ -324,22 +325,25 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
         let response = self
             .request_authed(
                 HttpMethod::Post,
-                "/mailbox",
+                "/mailbox/messages",
                 Some(APPLICATION_JSON),
                 Some(body),
             )
             .await?;
-        ok_or_err(response).map(drop)
+        let response = ok_or_err(response)?;
+        let wire: MailboxPostWire = decode(&response)?;
+        Ok(wire.id)
     }
 
     /// Poll pending mailbox items, decoding each sealed blob from base64.
     pub async fn mailbox_poll(&self) -> Result<Vec<MailboxItem>, ApiError> {
         let response = self
-            .request_authed(HttpMethod::Get, "/mailbox", None, None)
+            .request_authed(HttpMethod::Get, "/mailbox/messages", None, None)
             .await?;
         let response = ok_or_err(response)?;
-        let wire: Vec<MailboxItemWire> = decode(&response)?;
-        wire.into_iter()
+        let wire: MailboxPollWire = decode(&response)?;
+        wire.messages
+            .into_iter()
             .map(|item| {
                 let blob = BASE64
                     .decode(item.blob.as_bytes())
@@ -356,7 +360,12 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
     /// Ack (delete) a mailbox item by id.
     pub async fn mailbox_ack(&self, id: &str) -> Result<(), ApiError> {
         let response = self
-            .request_authed(HttpMethod::Delete, &format!("/mailbox/{id}"), None, None)
+            .request_authed(
+                HttpMethod::Delete,
+                &format!("/mailbox/messages/{id}"),
+                None,
+                None,
+            )
             .await?;
         ok_or_err(response).map(drop)
     }
@@ -888,7 +897,9 @@ mod tests {
         let blob = b"sealed-payload-bytes";
         http.enqueue_response(json_response(
             200,
-            json!([{ "id": "m1", "receivedAt": "2026-01-01T00:00:00Z", "blob": BASE64.encode(blob) }]),
+            json!({ "messages": [
+                { "id": "m1", "receivedAt": "2026-01-01T00:00:00Z", "blob": BASE64.encode(blob) },
+            ] }),
         ));
 
         let items = block_on(client.mailbox_poll()).expect("poll");

--- a/crates/engine/src/api/mod.rs
+++ b/crates/engine/src/api/mod.rs
@@ -5,10 +5,7 @@
 //! [`crate::seams::CredentialStore`] seams — no generated clients anywhere
 //! (#28 D5). The NestJS API keeps emitting its OpenAPI spec as a docs
 //! artifact; enforcement is the live contract-test suite (`crates/contract`),
-//! not codegen. Only the auth/token surface is implemented server-side today
-//! (#624); the registry/content/mailbox/recovery/account methods here follow
-//! blueprint/api.md and are provisional until those API slices land, when the
-//! contract suite binds them live.
+//! not codegen.
 
 mod client;
 mod error;

--- a/crates/engine/src/api/types.rs
+++ b/crates/engine/src/api/types.rs
@@ -157,12 +157,9 @@ impl fmt::Debug for TestLoginOutcome {
 
 // --- pin/name registry, quota, content, mailbox, recovery ---
 //
-// These endpoints are not yet implemented server-side (only the auth surface
-// exists in the API today, #624); the wire shapes below follow blueprint/api.md
-// and are provisional until the registry/content/mailbox API slices land, at
-// which point the live contract suite binds and enforces them. The client
-// methods are unit-tested for request construction against the scripted Http
-// fake.
+// The wire shapes below follow blueprint/api.md and are bound to the live API
+// by the contract suite (`crates/contract`); the client methods are also
+// unit-tested for request construction against the scripted Http fake.
 
 /// One entry of a batch name registration
 /// (`[{ipnsName, headCid?, contentCids[]}]`, blueprint/api.md).
@@ -220,4 +217,16 @@ pub(crate) struct MailboxItemWire {
     pub id: String,
     pub received_at: String,
     pub blob: String,
+}
+
+/// The poll response envelope.
+#[derive(Deserialize)]
+pub(crate) struct MailboxPollWire {
+    pub messages: Vec<MailboxItemWire>,
+}
+
+/// The post response: the server-assigned message id.
+#[derive(Deserialize)]
+pub(crate) struct MailboxPostWire {
+    pub id: String,
 }

--- a/crates/engine/tests/grants_mailbox.rs
+++ b/crates/engine/tests/grants_mailbox.rs
@@ -1456,14 +1456,15 @@ fn mailbox_lifecycle_through_the_api_client() {
     let client = ApiClient::new(http.clone(), creds, "http://api.test");
 
     // post → poll → ack, the mailbox surface the contract suite exercises.
-    http.enqueue_response(json_ok(b"{}"));
+    http.enqueue_response(json_ok(br#"{"id":"m1"}"#));
     // "hi" base64 is "aGk=" — hard-coded so the test needs no base64 dep.
     http.enqueue_response(json_ok(
-        br#"[{"id":"m1","receivedAt":"2026-01-01T00:00:00Z","blob":"aGk="}]"#,
+        br#"{"messages":[{"id":"m1","receivedAt":"2026-01-01T00:00:00Z","blob":"aGk="}]}"#,
     ));
-    http.enqueue_response(json_ok(b"{}"));
+    http.enqueue_response(json_ok(br#"{"success":true}"#));
 
-    block_on(client.mailbox_post("02abc-recipient", b"hi", "idem-1")).expect("post");
+    let posted = block_on(client.mailbox_post("02abc-recipient", b"hi", "idem-1")).expect("post");
+    assert_eq!(posted, "m1", "post returns the server-assigned id");
     let items = block_on(client.mailbox_poll()).expect("poll");
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].id, "m1");
@@ -1474,7 +1475,7 @@ fn mailbox_lifecycle_through_the_api_client() {
     assert_eq!(requests.len(), 3);
 
     // post: JSON body carries the base64 blob and the idempotency key.
-    assert_eq!(requests[0].url, "http://api.test/mailbox");
+    assert_eq!(requests[0].url, "http://api.test/mailbox/messages");
     assert_eq!(requests[0].method, HttpMethod::Post);
     let post_body = String::from_utf8(requests[0].body.clone().unwrap()).unwrap();
     assert!(
@@ -1488,10 +1489,10 @@ fn mailbox_lifecycle_through_the_api_client() {
     );
 
     // poll: a GET on the mailbox collection.
-    assert_eq!(requests[1].url, "http://api.test/mailbox");
+    assert_eq!(requests[1].url, "http://api.test/mailbox/messages");
     assert_eq!(requests[1].method, HttpMethod::Get);
 
     // ack: a DELETE on the item.
-    assert_eq!(requests[2].url, "http://api.test/mailbox/m1");
+    assert_eq!(requests[2].url, "http://api.test/mailbox/messages/m1");
     assert_eq!(requests[2].method, HttpMethod::Delete);
 }


### PR DESCRIPTION
## What

All three mailbox methods on the engine's hand-written API client targeted routes the API does not serve, so every one would have 404'd on first use.

| Client method | Was | Now |
| --- | --- | --- |
| `mailbox_post` | `POST /mailbox` | `POST /mailbox/messages` |
| `mailbox_poll` | `GET /mailbox` | `GET /mailbox/messages` |
| `mailbox_ack` | `DELETE /mailbox/{id}` | `DELETE /mailbox/messages/{id}` |

Verified against `apps/api/src/mailbox/mailbox.controller.ts` (`@Controller('mailbox')` plus `@Post('messages')` / `@Get('messages')` / `@Delete('messages/:id')`) and `apps/api/openapi.json`, which declares only `/mailbox/messages` and `/mailbox/messages/{id}`.

Two wire-shape mismatches sat behind the same untested surface and are fixed with them:

- `mailbox_poll` decoded a bare array; the API returns a `PollResponseDto` envelope, `{ "messages": [...] }`.
- `mailbox_post` discarded the response; the API returns `{ "id": ... }`, and that id is the contract for idempotent replay — the same key returns the original message id. `mailbox_post` now returns it. No production caller exists yet, so the signature change breaks nothing.

## Why it survived

Per AGENTS.md there are no generated API clients, so the live contract suite is the enforcement mechanism for the API contract — and it had no mailbox coverage at all.

This adds it:

- `mailbox_post_poll_ack_round_trips` — post then poll then ack against a real API, asserting the sealed blob round-trips byte-identical, mail is recipient-scoped, a replayed idempotency key returns the original id and delivers no second copy, and ack hard-deletes and is idempotent.
- `mailbox_post_is_bounded_by_recipient_existence_and_blob_size` — the existence oracle's 404 and the 8 KiB blob cap's 413.

Both new tests were confirmed to FAIL against the old paths and pass against the corrected ones.

The mailbox accounts are minted through test-login rather than `fresh_account`. That is load-bearing, not stylistic: the per-IP `POST /auth/challenge` and `POST /auth/login` buckets are already at exactly 10/10 of the `auth` throttle surface, so one more identity login anywhere in the suite would 429 it. The `/auth/test-login` bucket goes from 3/10 to 6/10.

Also drops three now-false comments claiming the registry/content/mailbox/recovery endpoints are "not yet implemented server-side" and the wire shapes "provisional" — every path the client calls is served today, and the contract suite now binds them.

## Verification

Against a real local stack — Postgres, Kubo, the `tools/mock-ipns-routing` `/routing/v1` store, and a freshly migrated API booted from `apps/api/dist/main.js`:

- `cargo test -p cipherbox-contract` — **13 passed, 0 failed**, including the two new mailbox tests. Run three times consecutively against the same database to confirm rerun-safety of the deterministic accounts.
- `cargo test --workspace --exclude cipherbox-desktop --exclude cipherbox-contract` — **799 passed, 0 failed, 2 ignored**.
- `cargo fmt --all --check` clean; `cargo clippy --workspace --exclude cipherbox-desktop --exclude cipherbox-contract --all-targets -- -D warnings` and `cargo clippy -p cipherbox-contract --all-targets -- -D warnings` both clean.

The WASM legs of the Core KATs job were not run locally; the diff touches neither `crates/core` nor the WASM boundary, and CI covers them.

## Review gates

- `/simplify` — 5 findings folded in: trimmed comment duplication across the two new tests and the new wire types, dropped a redundant assertion, and moved the oversize-blob fixture off the DTO's base64 cap (9000 bytes encoded to exactly the 12000-char `@MaxLength`, so a tightening of that constant would have silently flipped the test from a 413 to a 400) to 8193 bytes, one byte over the 8 KiB spec bound. One finding rejected: the claim that the deterministic test-login accounts break on re-run — refuted empirically by three consecutive green runs against one database, since ack hard-deletes the row and an un-acked leftover collapses onto the same idempotency scope.
- `/security-review` — no findings. The blob stays an opaque caller-supplied passthrough, all three methods still route through `request_authed`, the server-side `JwtAuthGuard` is class-scoped so the sub-path change stays inside it, and `mailbox_post` is now strictly *more* fail-closed than before: it decodes the response instead of dropping it.
- `/crypto-privacy-review` — skipped; no crypto/privacy-adjacent changes. The diff is routing plus tests, and touches no key or seal material.
- CodeRabbit CLI — `findings: 0` across all five reviewed files.
- CodeRabbit PR review — 1 actionable comment, discarded and answered in-thread: it proposed a run-scoped idempotency key, on the premise that the stack retains idempotency records. It does not. Idempotency rides the message row as `idempotency_scope` = sha256(`sender:key`) under the unique `uq_mailbox_recipient_idempotency` index, and ack is a hard delete of that row, so nothing survives a completed run. An interrupted run is self-healing, not sticky: a leftover un-acked row collapses onto the same scope and the poll assertions still hold on the identical constant blob, then the test acks it away. Empirically confirmed by three consecutive green suite runs against one database. Thread resolved, 1/1.
- Greptile — no review this cycle; the bot reported it has exhausted its free open-source review credits for the billing period.

## Follow-ups filed

`#836` — the browser mailbox seam, `packages/client/src/seams/mailbox.ts`, has the same class of defect and worse: it posts `application/octet-stream` with `x-recipient` / `idempotency-key` headers to `POST /mailbox`, where the API serves a JSON DTO on `POST /mailbox/messages`, and its `ack` treats the resulting 404 as success. Deliberately out of scope here: the Rust fix is gated by the contract suite, while a TypeScript fix has no gate until the browser conformance switch runs the mailbox kit.

`#837` — the contract suite now sits at 6/10 on the per-IP `auth` throttle bucket with no headroom, so the next slice that adds a login will 429 it. Out of scope here: fixing it means changing the suite's throttle posture, not the mailbox routes.

Closes #827


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated mailbox messaging to use consistent REST-style endpoints.
  * Mailbox posts now return a server-assigned message ID.
  * Mailbox polling supports structured message responses.
  * Added mailbox delivery and acknowledgement behavior, including replay prevention and idempotent acknowledgements.

* **Bug Fixes**
  * Unknown recipients are rejected with a not-found error.
  * Oversized sealed messages are rejected with a payload-too-large error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
