### PR TITLE
test(engine): extract the shared owner-root head-block fixture to testkit

### DIFF
--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -2707,30 +2707,24 @@ mod tests {
         use cipherbox_core::kdf;
         use cipherbox_core::payload::RepointObject;
         use cipherbox_core::seal::{
-            AadContext, ChildRef, GrantSection, GrantSetCommitment, NodeKind as CoreNodeKind,
-            OverrideSeedPayload, OwnerWriteBlobPayload, ReadBody, STRUCT_TAG_OWNER_BLOB,
-            STRUCT_TAG_OWNER_WRITE_BLOB, STRUCT_TAG_WRITE_BODY, SignedOwnerBlob,
-            SignedOwnerWriteBlob, SignedSealed, StructureSigInput, WriteBody, encode_envelope,
-            encode_grant_section, encode_write_body, seal, seal_owner_blob, seal_owner_write_blob,
-            seal_read_body, sign_grant_set, sign_structure,
+            ChildRef, NodeKind as CoreNodeKind, ReadBody, encode_envelope, seal_read_body,
         };
         use cipherbox_core::suite::ecdsa::EcdsaSigner;
-        use cipherbox_core::suite::ed25519::Ed25519Signer;
 
         use crate::content::{DAG_ROOT_CODEC, GatewaySource};
         use crate::net::RE_PUT_INTERVAL;
         use crate::seams::{BoxedTask, EndpointId, RecordTransport};
         use crate::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
-        use crate::testkit::FakeDevice;
+        use crate::testkit::{
+            FakeDevice, OWNER_ROOT_EPOCH as EPOCH, OWNER_ROOT_SCOPE_SEED as SCOPE_SEED,
+            OWNER_ROOT_WRITE_SCOPE_SEED as WRITE_SCOPE_SEED, OwnerRootSpec, owner_root_fixture,
+        };
 
         const CAP_SECRET: [u8; 32] = [7u8; 32];
         const SCOPE: [u8; 16] = [0u8; 16];
         const ROOT: NodeId = NodeId([0u8; 16]);
         const CHILD_ID: [u8; 16] = [0x2C; 16];
         const CHILD_NAME: &str = "hello.txt";
-        const SCOPE_SEED: [u8; 32] = [0x66; 32];
-        const WRITE_SCOPE_SEED: [u8; 32] = [0x77; 32];
-        const EPOCH: u64 = 1;
         const TTL_NANOS: u64 = 2_000_000_000;
         const EOL: &str = "2099-01-01T00:00:00Z";
 
@@ -2748,117 +2742,13 @@ mod tests {
         /// the root record's write-plane IPNS name. Keyed off `CAP_SECRET` so the
         /// engine's session-derived owner identity + enc subkey open it, and scoped
         /// to the all-zero bootstrap anchor (`SCOPE`/`ROOT`) so `start`'s cold-start
-        /// scope binding matches. Mirrors the E2 `RootAdopter` head-block fixture.
+        /// scope binding matches.
         fn owner_root() -> (Vec<u8>, String, IpnsName) {
-            let owner_identity = owner_identity();
-            let owner_pseudonym = Ed25519Signer::from_seed([0x22; 32]);
-            let owner_enc = kdf::enc_subkey(&CAP_SECRET);
-
-            let node_seed = kdf::node_seed(&SCOPE_SEED, &ROOT.0);
-            let read_key = *kdf::read_key(node_seed.as_bytes()).as_bytes();
-            let write_seed = kdf::write_seed(&WRITE_SCOPE_SEED, &ROOT.0);
-            let name = IpnsName::from_public_key(
-                &kdf::ipns_keypair(write_seed.as_bytes()).verifying_key(),
-            );
-            let write_key = kdf::write_key(write_seed.as_bytes());
-
-            let sign = |tag: u8, ct: &[u8]| -> [u8; 64] {
-                let input = StructureSigInput::over_ciphertext(SCOPE, EPOCH, tag, None, ct);
-                sign_structure(&owner_pseudonym, &input).to_bytes()
-            };
-
-            let owner_blob_aad = AadContext {
-                v: 1,
-                id: ROOT.0,
-                scope: SCOPE,
-                epoch: EPOCH,
-                struct_tag: STRUCT_TAG_OWNER_BLOB,
-            };
-            let sealed_owner = seal_owner_blob(
-                &owner_enc.public(),
-                &[3u8; 32],
-                &owner_blob_aad,
-                &OverrideSeedPayload::new(SCOPE_SEED, EPOCH),
-            );
-            let owner_blob = SignedOwnerBlob {
-                signature: sign(STRUCT_TAG_OWNER_BLOB, &sealed_owner.ciphertext),
-                enc: sealed_owner.enc,
-                ciphertext: sealed_owner.ciphertext.clone(),
-                unknown: Vec::new(),
-            };
-
-            let write_body_aad = AadContext {
-                v: 1,
-                id: ROOT.0,
-                scope: SCOPE,
-                epoch: EPOCH,
-                struct_tag: STRUCT_TAG_WRITE_BODY,
-            };
-            let write_body_sealed = seal(
-                write_key.as_bytes(),
-                &[22u8; 24],
-                &write_body_aad,
-                &encode_write_body(&WriteBody {
-                    grant_ledger: Vec::new(),
-                    write_history_link: Vec::new(),
-                    direct_child_scope_index: Vec::new(),
-                    unknown: Vec::new(),
-                })
-                .unwrap(),
-            );
-            let write_body = SignedSealed {
-                signature: sign(STRUCT_TAG_WRITE_BODY, &write_body_sealed),
-                sealed: write_body_sealed,
-                unknown: Vec::new(),
-            };
-
-            // Owner-write-blob at the read epoch (write plane == read plane here), so
-            // the cold-seeded write floor opens it and the owner recovers its
-            // write-scope seed for the held-set renewal signer.
-            let owb_aad = AadContext {
-                v: 1,
-                id: ROOT.0,
-                scope: SCOPE,
-                epoch: EPOCH,
-                struct_tag: STRUCT_TAG_OWNER_WRITE_BLOB,
-            };
-            let sealed_owb = seal_owner_write_blob(
-                &owner_enc.public(),
-                &[4u8; 32],
-                &owb_aad,
-                &OwnerWriteBlobPayload::new(WRITE_SCOPE_SEED, EPOCH),
-            );
-            let owner_write_blob = Some(SignedOwnerWriteBlob {
-                signature: sign(STRUCT_TAG_OWNER_WRITE_BLOB, &sealed_owb.ciphertext),
-                enc: sealed_owb.enc,
-                ciphertext: sealed_owb.ciphertext,
-                unknown: Vec::new(),
-            });
-
-            let commitment = GrantSetCommitment {
-                ipns_name: name.as_str().as_bytes().to_vec(),
-                owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
-                entries: Vec::new(),
-                unknown: Vec::new(),
-            };
-            let commitment_sig = sign_grant_set(&owner_identity, &commitment)
-                .unwrap()
-                .to_compact();
-            let grant_section = GrantSection {
-                commitment,
-                commitment_sig,
-                grant_blobs: Vec::new(),
-                owner_blob,
-                owner_write_blob,
-                ascent_link: None,
-                history_links: Vec::new(),
-                write_body,
-                unknown: Vec::new(),
-            };
-
-            let folder = ReadBody::Folder {
-                created_at: 0,
-                modified_at: 0,
+            let fx = owner_root_fixture(OwnerRootSpec {
+                owner_identity: &owner_identity(),
+                owner_enc: &kdf::enc_subkey(&CAP_SECRET).public(),
+                scope_id: SCOPE,
+                root_id: ROOT.0,
                 children: vec![ChildRef {
                     id: CHILD_ID,
                     name: CHILD_NAME.into(),
@@ -2867,18 +2757,12 @@ mod tests {
                     link_counter: 1,
                     unknown: Vec::new(),
                 }],
-                unknown: Vec::new(),
-            };
-            let mut envelope =
-                seal_read_body(&read_key, &[11u8; 24], 1, ROOT.0, SCOPE, EPOCH, &folder).unwrap();
-            envelope.unknown.push((
-                "grantSection".to_string(),
-                Value::Bytes(encode_grant_section(&grant_section).unwrap()),
-            ));
-
-            let head_block = encode_envelope(&envelope);
-            let head_cid_str = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head_block));
-            (head_block, head_cid_str, name)
+                // At the read epoch (write plane == read plane here), so the
+                // cold-seeded write floor opens it and the owner recovers its
+                // write-scope seed for the held-set renewal signer.
+                owner_write_blob_epoch: Some(EPOCH),
+            });
+            (fx.head_block, fx.head_cid_str, fx.name)
         }
 
         fn root_record(head_cid_str: &str, sequence: u64) -> Vec<u8> {

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -338,38 +338,24 @@ pub(super) fn map_read_error(e: ReadError) -> GateError {
 mod tests {
     use super::*;
 
-    use cipherbox_core::codec::Value;
-    use cipherbox_core::content::{compute_cid, encode_content_cid_str};
-    use cipherbox_core::seal::{
-        Envelope, GrantSection, GrantSetCommitment, OverrideSeedPayload, OwnerWriteBlobPayload,
-        ReadBody, STRUCT_TAG_WRITE_BODY, SignedOwnerBlob, SignedSealed, StructureSigInput,
-        WriteBody, encode_envelope, encode_grant_section, encode_write_body, seal, seal_owner_blob,
-        seal_owner_write_blob, seal_read_body, sign_grant_set, sign_structure,
-    };
+    use cipherbox_core::seal::{Envelope, GrantSection};
     use cipherbox_core::suite::ecdsa::EcdsaSigner;
-    use cipherbox_core::suite::ed25519::Ed25519Signer;
 
-    use crate::content::{DAG_ROOT_CODEC, GatewaySource};
+    use crate::content::GatewaySource;
     use crate::seams::HttpResponse;
     use crate::session::SessionIdentity;
-    use crate::testkit::block_on;
     use crate::testkit::fakes::{InMemoryFloorStore, ScriptedHttp};
+    use crate::testkit::{
+        OWNER_ROOT_WRITE_SCOPE_SEED, OwnerRootFixture, OwnerRootSpec, block_on, owner_root_fixture,
+    };
 
-    const V: u64 = 1;
     const TTL_NANOS: u64 = 2_000_000_000;
     const EOL: &str = "2099-01-01T00:00:00Z";
-    const NONCE_READ_BODY: [u8; 24] = [11u8; 24];
-    const NONCE_WRITE_BODY: [u8; 24] = [22u8; 24];
-    const EPH_OWNER: [u8; 32] = [3u8; 32];
-    const EPH_OWNER_WRITE: [u8; 32] = [4u8; 32];
-    /// The write-scope seed the fixture's owner-write-blob wraps (matches the seed
-    /// that derives the record's IPNS name).
-    const WRITE_SCOPE_SEED: [u8; 32] = [0x77; 32];
     /// The write epoch the fixture authors its owner-write-blob at.
     const OWB_WRITE_EPOCH: u64 = 3;
 
-    /// A valid owner-root scope fixture: the owner keys plus the head block (an
-    /// envelope carrying its grant section) the record anchors.
+    /// A valid owner-root scope fixture: standalone owner keys (no session
+    /// derives them) plus the head block the record anchors.
     struct Fixture {
         owner_identity_verifier: EcdsaVerifier,
         owner_enc: X25519Secret,
@@ -388,152 +374,30 @@ mod tests {
         }
 
         /// Build the fixture, optionally authoring a real owner-write-blob at
-        /// `owb_write_epoch` (the write plane's own clock; its AAD binds that
-        /// epoch, its structure signature the read epoch — mirrors reseal).
+        /// `owb_write_epoch` (the write plane's own clock).
         fn build(owb_write_epoch: Option<u64>) -> Self {
             let owner_identity = EcdsaSigner::from_scalar(&[0x11; 32]).unwrap();
-            let owner_identity_verifier = owner_identity.verifying_key();
-            let owner_pseudonym = Ed25519Signer::from_seed([0x22; 32]);
             let owner_enc = X25519Secret::from_scalar([0x33; 32]);
-
             let scope_id = [0x44; 16];
             let root_id = [0x55; 16];
-            let scope_seed = [0x66; 32];
-            let write_scope_seed = [0x77; 32];
-            let epoch = 1;
 
-            let node_seed = kdf::node_seed(&scope_seed, &root_id);
-            let read_key = *kdf::read_key(node_seed.as_bytes()).as_bytes();
-            let write_seed = kdf::write_seed(&write_scope_seed, &root_id);
-            let ipns_signer = kdf::ipns_keypair(write_seed.as_bytes());
-            let name = IpnsName::from_public_key(&ipns_signer.verifying_key());
-            let write_key = kdf::write_key(write_seed.as_bytes());
-
-            let sign = |tag: u8, ct: &[u8]| -> [u8; 64] {
-                let input = StructureSigInput::over_ciphertext(scope_id, epoch, tag, None, ct);
-                sign_structure(&owner_pseudonym, &input).to_bytes()
-            };
-
-            // Owner blob — the seed-bearing structure AND the owner's seed source.
-            let override_payload = OverrideSeedPayload::new(scope_seed, epoch);
-            let owner_blob_aad = AadContext {
-                v: V,
-                id: root_id,
-                scope: scope_id,
-                epoch,
-                struct_tag: STRUCT_TAG_OWNER_BLOB,
-            };
-            let sealed_owner = seal_owner_blob(
-                &owner_enc.public(),
-                &EPH_OWNER,
-                &owner_blob_aad,
-                &override_payload,
-            );
-            let owner_blob = SignedOwnerBlob {
-                signature: sign(STRUCT_TAG_OWNER_BLOB, &sealed_owner.ciphertext),
-                enc: sealed_owner.enc,
-                ciphertext: sealed_owner.ciphertext.clone(),
-                unknown: Vec::new(),
-            };
-
-            // Write body — a second seed-bearing structure the gate authenticates.
-            let write_body_aad = AadContext {
-                v: V,
-                id: root_id,
-                scope: scope_id,
-                epoch,
-                struct_tag: STRUCT_TAG_WRITE_BODY,
-            };
-            let write_body_sealed = seal(
-                write_key.as_bytes(),
-                &NONCE_WRITE_BODY,
-                &write_body_aad,
-                &encode_write_body(&WriteBody {
-                    grant_ledger: Vec::new(),
-                    write_history_link: Vec::new(),
-                    direct_child_scope_index: Vec::new(),
-                    unknown: Vec::new(),
-                })
-                .unwrap(),
-            );
-            let write_body = SignedSealed {
-                signature: sign(STRUCT_TAG_WRITE_BODY, &write_body_sealed),
-                sealed: write_body_sealed,
-                unknown: Vec::new(),
-            };
-
-            // Owner-write-blob — the write-scope seed sealed to the owner. AAD
-            // binds the WRITE epoch; the structure signature binds the read epoch.
-            let owner_write_blob = owb_write_epoch.map(|we| {
-                let payload = OwnerWriteBlobPayload::new(write_scope_seed, we);
-                let owb_aad = AadContext {
-                    v: V,
-                    id: root_id,
-                    scope: scope_id,
-                    epoch: we,
-                    struct_tag: STRUCT_TAG_OWNER_WRITE_BLOB,
-                };
-                let sealed = seal_owner_write_blob(
-                    &owner_enc.public(),
-                    &EPH_OWNER_WRITE,
-                    &owb_aad,
-                    &payload,
-                );
-                SignedOwnerWriteBlob {
-                    signature: sign(STRUCT_TAG_OWNER_WRITE_BLOB, &sealed.ciphertext),
-                    enc: sealed.enc,
-                    ciphertext: sealed.ciphertext,
-                    unknown: Vec::new(),
-                }
+            let OwnerRootFixture {
+                name,
+                grant_section,
+                envelope,
+                head_block,
+                head_cid_str,
+            } = owner_root_fixture(OwnerRootSpec {
+                owner_identity: &owner_identity,
+                owner_enc: &owner_enc.public(),
+                scope_id,
+                root_id,
+                children: Vec::new(),
+                owner_write_blob_epoch: owb_write_epoch,
             });
 
-            let commitment = GrantSetCommitment {
-                ipns_name: name.as_str().as_bytes().to_vec(),
-                owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
-                entries: Vec::new(),
-                unknown: Vec::new(),
-            };
-            let commitment_sig = sign_grant_set(&owner_identity, &commitment)
-                .unwrap()
-                .to_compact();
-            let grant_section = GrantSection {
-                commitment,
-                commitment_sig,
-                grant_blobs: Vec::new(),
-                owner_blob,
-                owner_write_blob,
-                ascent_link: None,
-                history_links: Vec::new(),
-                write_body,
-                unknown: Vec::new(),
-            };
-
-            let folder = ReadBody::Folder {
-                created_at: 0,
-                modified_at: 0,
-                children: Vec::new(),
-                unknown: Vec::new(),
-            };
-            let mut envelope = seal_read_body(
-                &read_key,
-                &NONCE_READ_BODY,
-                V,
-                root_id,
-                scope_id,
-                epoch,
-                &folder,
-            )
-            .unwrap();
-            envelope.unknown.push((
-                "grantSection".to_string(),
-                Value::Bytes(encode_grant_section(&grant_section).unwrap()),
-            ));
-
-            let head_block = encode_envelope(&envelope);
-            let head_cid_str = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head_block));
-
             Self {
-                owner_identity_verifier,
+                owner_identity_verifier: owner_identity.verifying_key(),
                 owner_enc,
                 scope_id,
                 root_id,
@@ -547,10 +411,8 @@ mod tests {
 
         fn record(&self, sequence: u64) -> Vec<u8> {
             let value = format!("/ipfs/{}", self.head_cid_str);
-            let signer = {
-                let write_seed = kdf::write_seed(&[0x77; 32], &self.root_id);
-                kdf::ipns_keypair(write_seed.as_bytes())
-            };
+            let write_seed = kdf::write_seed(&OWNER_ROOT_WRITE_SCOPE_SEED, &self.root_id);
+            let signer = kdf::ipns_keypair(write_seed.as_bytes());
             IpnsRecord::create_v2(&signer, value.as_bytes(), sequence, TTL_NANOS, EOL).marshal()
         }
 
@@ -700,7 +562,7 @@ mod tests {
         let seed = outcome
             .write_scope_seed
             .expect("the owner recovers its write-scope seed from the owner-write-blob");
-        assert_eq!(*seed, WRITE_SCOPE_SEED);
+        assert_eq!(*seed, OWNER_ROOT_WRITE_SCOPE_SEED);
         // The recovered seed reproduces the record's IPNS routing name.
         let signer = SessionIdentity::write_name_signer(&seed, &fx.root_id);
         assert_eq!(IpnsName::from_public_key(&signer.verifying_key()), fx.name);
@@ -780,7 +642,7 @@ mod tests {
             .expect("recovery is fail-open, never an error")
             .expect("the owner recovers its own write seed on the Current path");
         assert_eq!(node_id, fx.root_id, "keyed by the envelope id");
-        assert_eq!(*seed, WRITE_SCOPE_SEED);
+        assert_eq!(*seed, OWNER_ROOT_WRITE_SCOPE_SEED);
         // The recovered seed reproduces the record's IPNS routing name.
         let signer = SessionIdentity::write_name_signer(&seed, &fx.root_id);
         assert_eq!(IpnsName::from_public_key(&signer.verifying_key()), fx.name);
@@ -808,7 +670,7 @@ mod tests {
         let (_, seed) = block_on(adopter.recover_own_write_seed(&fx.name, &record))
             .expect("recovery is fail-open, never an error")
             .expect("the owner recovers its write seed from the reused candidate");
-        assert_eq!(*seed, WRITE_SCOPE_SEED);
+        assert_eq!(*seed, OWNER_ROOT_WRITE_SCOPE_SEED);
         assert_eq!(
             http.requests().len(),
             1,

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -377,7 +377,13 @@ mod tests {
         /// `owb_write_epoch` (the write plane's own clock).
         fn build(owb_write_epoch: Option<u64>) -> Self {
             let owner_identity = EcdsaSigner::from_scalar(&[0x11; 32]).unwrap();
-            let owner_enc = X25519Secret::from_scalar([0x33; 32]);
+            // Distinct recipient key per authored write epoch — the owner-write-blob's
+            // HPKE key derives from `owner_enc` alone under a fixed ephemeral
+            // ([`OwnerRootSpec`]), so one key across epochs reuses the keystream.
+            let mut enc_scalar = [0x33u8; 32];
+            enc_scalar[0] = enc_scalar[0]
+                .wrapping_add(u8::try_from(owb_write_epoch.unwrap_or(0)).unwrap_or(u8::MAX));
+            let owner_enc = X25519Secret::from_scalar(enc_scalar);
             let scope_id = [0x44; 16];
             let root_id = [0x55; 16];
 

--- a/crates/engine/src/testkit/mod.rs
+++ b/crates/engine/src/testkit/mod.rs
@@ -18,8 +18,13 @@ pub mod conformance;
 mod entropy;
 mod executor;
 pub mod fakes;
+mod owner_root;
 mod world;
 
 pub use entropy::SeededEntropy;
 pub use executor::block_on;
+pub use owner_root::{
+    OWNER_ROOT_EPOCH, OWNER_ROOT_SCOPE_SEED, OWNER_ROOT_WRITE_SCOPE_SEED, OwnerRootFixture,
+    OwnerRootSpec, owner_root_fixture,
+};
 pub use world::{FakeDevice, FakeSeamTypes, FakeWorld};

--- a/crates/engine/src/testkit/owner_root.rs
+++ b/crates/engine/src/testkit/owner_root.rs
@@ -1,0 +1,209 @@
+//! The owner-root head-block fixture: an envelope carrying a grant section
+//! whose owner blob, write body, and optional owner-write-blob are all
+//! authored the way a real owner root is, so it passes the adoption gate.
+//!
+//! Sealing inputs (nonces, HPKE ephemerals, the pseudonym seed) are fixed
+//! constants, keeping the head block byte-for-byte reproducible across runs.
+
+use cipherbox_core::codec::Value;
+use cipherbox_core::content::{compute_cid, encode_content_cid_str};
+use cipherbox_core::ipns::IpnsName;
+use cipherbox_core::kdf;
+use cipherbox_core::seal::{
+    AadContext, ChildRef, Envelope, GrantSection, GrantSetCommitment, OverrideSeedPayload,
+    OwnerWriteBlobPayload, ReadBody, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB,
+    STRUCT_TAG_WRITE_BODY, SignedOwnerBlob, SignedOwnerWriteBlob, SignedSealed, StructureSigInput,
+    WriteBody, encode_envelope, encode_grant_section, encode_write_body, seal, seal_owner_blob,
+    seal_owner_write_blob, seal_read_body, sign_grant_set, sign_structure,
+};
+use cipherbox_core::suite::ecdsa::EcdsaSigner;
+use cipherbox_core::suite::ed25519::Ed25519Signer;
+use cipherbox_core::suite::x25519::X25519Public;
+
+use crate::content::DAG_ROOT_CODEC;
+
+/// The read-scope seed the fixture's owner blob overrides to.
+pub const OWNER_ROOT_SCOPE_SEED: [u8; 32] = [0x66; 32];
+/// The write-scope seed the fixture's IPNS name derives from, and that its
+/// owner-write-blob wraps.
+pub const OWNER_ROOT_WRITE_SCOPE_SEED: [u8; 32] = [0x77; 32];
+/// The read epoch every structure in the fixture is authored at.
+pub const OWNER_ROOT_EPOCH: u64 = 1;
+
+const V: u64 = 1;
+const PSEUDONYM_SEED: [u8; 32] = [0x22; 32];
+const NONCE_READ_BODY: [u8; 24] = [11u8; 24];
+const NONCE_WRITE_BODY: [u8; 24] = [22u8; 24];
+const EPH_OWNER: [u8; 32] = [3u8; 32];
+const EPH_OWNER_WRITE: [u8; 32] = [4u8; 32];
+
+/// The inputs that diverge between owner-root fixtures.
+///
+/// Nonces and HPKE ephemerals are fixed, so the two varying plaintexts must be
+/// kept apart on independent axes: the read body's key comes from `root_id`
+/// alone, so specs with differing `children` need differing `root_id`; the
+/// owner-write-blob's HPKE key comes from `owner_enc` alone, so specs with
+/// differing `owner_write_blob_epoch` need differing `owner_enc`.
+pub struct OwnerRootSpec<'a> {
+    /// Signs the grant-set commitment; its verifying key is the owner identity
+    /// the adoption gate checks against.
+    pub owner_identity: &'a EcdsaSigner,
+    /// Recipient of the owner blob and owner-write-blob HPKE seals.
+    pub owner_enc: &'a X25519Public,
+    /// The scope every structure's AAD and structure signature binds.
+    pub scope_id: [u8; 16],
+    /// The scope-root node id; also the seed-tree edge the read/write keys hang off.
+    pub root_id: [u8; 16],
+    /// The root folder's children.
+    pub children: Vec<ChildRef>,
+    /// `Some(epoch)` authors an owner-write-blob whose AAD binds that **write**
+    /// epoch (its structure signature still binds the read epoch — mirrors
+    /// reseal); `None` leaves the root held keyless.
+    pub owner_write_blob_epoch: Option<u64>,
+}
+
+/// The authored owner root: the head block plus the pieces a caller asserts on.
+pub struct OwnerRootFixture {
+    /// The record's write-plane IPNS name.
+    pub name: IpnsName,
+    /// The grant section the envelope carries under its `grantSection` key.
+    pub grant_section: GrantSection,
+    /// The sealed read body, grant section attached.
+    pub envelope: Envelope,
+    /// The encoded envelope — the block the record's value addresses.
+    pub head_block: Vec<u8>,
+    /// `head_block`'s content CID, as the record value spells it.
+    pub head_cid_str: String,
+}
+
+/// Author an owner-root head block from `spec`.
+pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
+    let OwnerRootSpec {
+        owner_identity,
+        owner_enc,
+        scope_id,
+        root_id,
+        children,
+        owner_write_blob_epoch,
+    } = spec;
+    let owner_pseudonym = Ed25519Signer::from_seed(PSEUDONYM_SEED);
+
+    let node_seed = kdf::node_seed(&OWNER_ROOT_SCOPE_SEED, &root_id);
+    let read_key = *kdf::read_key(node_seed.as_bytes()).as_bytes();
+    let write_seed = kdf::write_seed(&OWNER_ROOT_WRITE_SCOPE_SEED, &root_id);
+    let name = IpnsName::from_public_key(&kdf::ipns_keypair(write_seed.as_bytes()).verifying_key());
+    let write_key = kdf::write_key(write_seed.as_bytes());
+
+    let sign = |tag: u8, ct: &[u8]| -> [u8; 64] {
+        let input = StructureSigInput::over_ciphertext(scope_id, OWNER_ROOT_EPOCH, tag, None, ct);
+        sign_structure(&owner_pseudonym, &input).to_bytes()
+    };
+    let aad = |epoch: u64, struct_tag: u8| AadContext {
+        v: V,
+        id: root_id,
+        scope: scope_id,
+        epoch,
+        struct_tag,
+    };
+
+    // Owner blob — the seed-bearing structure, and the owner's seed source.
+    let sealed_owner = seal_owner_blob(
+        owner_enc,
+        &EPH_OWNER,
+        &aad(OWNER_ROOT_EPOCH, STRUCT_TAG_OWNER_BLOB),
+        &OverrideSeedPayload::new(OWNER_ROOT_SCOPE_SEED, OWNER_ROOT_EPOCH),
+    );
+    let owner_blob = SignedOwnerBlob {
+        signature: sign(STRUCT_TAG_OWNER_BLOB, &sealed_owner.ciphertext),
+        enc: sealed_owner.enc,
+        ciphertext: sealed_owner.ciphertext,
+        unknown: Vec::new(),
+    };
+
+    // Write body — a second seed-bearing structure the gate authenticates.
+    let write_body_sealed = seal(
+        write_key.as_bytes(),
+        &NONCE_WRITE_BODY,
+        &aad(OWNER_ROOT_EPOCH, STRUCT_TAG_WRITE_BODY),
+        &encode_write_body(&WriteBody {
+            grant_ledger: Vec::new(),
+            write_history_link: Vec::new(),
+            direct_child_scope_index: Vec::new(),
+            unknown: Vec::new(),
+        })
+        .unwrap(),
+    );
+    let write_body = SignedSealed {
+        signature: sign(STRUCT_TAG_WRITE_BODY, &write_body_sealed),
+        sealed: write_body_sealed,
+        unknown: Vec::new(),
+    };
+
+    let owner_write_blob = owner_write_blob_epoch.map(|write_epoch| {
+        let sealed = seal_owner_write_blob(
+            owner_enc,
+            &EPH_OWNER_WRITE,
+            &aad(write_epoch, STRUCT_TAG_OWNER_WRITE_BLOB),
+            &OwnerWriteBlobPayload::new(OWNER_ROOT_WRITE_SCOPE_SEED, write_epoch),
+        );
+        SignedOwnerWriteBlob {
+            signature: sign(STRUCT_TAG_OWNER_WRITE_BLOB, &sealed.ciphertext),
+            enc: sealed.enc,
+            ciphertext: sealed.ciphertext,
+            unknown: Vec::new(),
+        }
+    });
+
+    let commitment = GrantSetCommitment {
+        ipns_name: name.as_str().as_bytes().to_vec(),
+        owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
+        entries: Vec::new(),
+        unknown: Vec::new(),
+    };
+    let commitment_sig = sign_grant_set(owner_identity, &commitment)
+        .unwrap()
+        .to_compact();
+    let grant_section = GrantSection {
+        commitment,
+        commitment_sig,
+        grant_blobs: Vec::new(),
+        owner_blob,
+        owner_write_blob,
+        ascent_link: None,
+        history_links: Vec::new(),
+        write_body,
+        unknown: Vec::new(),
+    };
+
+    let folder = ReadBody::Folder {
+        created_at: 0,
+        modified_at: 0,
+        children,
+        unknown: Vec::new(),
+    };
+    let mut envelope = seal_read_body(
+        &read_key,
+        &NONCE_READ_BODY,
+        V,
+        root_id,
+        scope_id,
+        OWNER_ROOT_EPOCH,
+        &folder,
+    )
+    .unwrap();
+    envelope.unknown.push((
+        "grantSection".to_string(),
+        Value::Bytes(encode_grant_section(&grant_section).unwrap()),
+    ));
+
+    let head_block = encode_envelope(&envelope);
+    let head_cid_str = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head_block));
+
+    OwnerRootFixture {
+        name,
+        grant_section,
+        envelope,
+        head_block,
+        head_cid_str,
+    }
+}


### PR DESCRIPTION
Closes #798

## What

The owner-root head-block builder — owner blob → write body → owner-write-blob → grant section → `seal_read_body` → envelope → head CID — was copy-pasted across two test sites. Both now call one parameterized builder in `crates/engine/src/testkit/owner_root.rs`:

```rust
pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture

pub struct OwnerRootSpec<'a> {
    pub owner_identity: &'a EcdsaSigner,
    pub owner_enc: &'a X25519Public,
    pub scope_id: [u8; 16],
    pub root_id: [u8; 16],
    pub children: Vec<ChildRef>,
    pub owner_write_blob_epoch: Option<u64>,
}

pub struct OwnerRootFixture {
    pub name: IpnsName,
    pub grant_section: GrantSection,
    pub envelope: Envelope,
    pub head_block: Vec<u8>,
    pub head_cid_str: String,
}
```

Net `-298 / +256`. `net/adopter.rs` sheds 158 lines, `facade.rs` 128.

`OwnerRootSpec` carries only what the two real call sites actually diverge on — nothing speculative. Every field is varied by at least one site, and every `OwnerRootFixture` field is consumed by at least one.

## The divergence is preserved, not collapsed

The two sites source owner keys differently on purpose, and still do:

| | owner identity | owner enc |
| --- | --- | --- |
| `net/adopter.rs` | standalone `EcdsaSigner::from_scalar` | standalone `X25519Secret` |
| `facade.rs` | derived from `CAP_SECRET` | `kdf::enc_subkey(&CAP_SECRET)` |

The facade fixture must stay openable by the engine's own session; the adopter fixture must stay session-independent. Both hold. Only genuinely shared values were hoisted to module constants: the `0x66` scope seed, the `0x77` write-scope seed, epoch 1, and the fixed nonces / HPKE ephemerals / pseudonym seed.

The builder takes the X25519 **public** key rather than the secret — it only seals *to* the owner, so no secret crosses the new boundary and there is no caller-owned buffer for the callee to zeroize.

## Test-only

Every hunk in `facade.rs` and `net/adopter.rs` falls inside `#[cfg(test)] mod tests`. The new module sits behind the existing `test-kit` feature, which is off by default and enabled only from dev-dependencies and the non-default `conformance` feature of `crates/wasm`. No production path changed.

## Verification

Beyond the suites, the equivalence was proven directly: a throwaway test reproduced both pre-refactor inline builders verbatim from `origin/main` and asserted the extracted builder emits **byte-identical** head blocks, head CIDs, and IPNS names — across all four owner-write-blob variants the two sites use. Both passed; the scratch test was then deleted.

No test was dropped or weakened. Mechanically confirmed against `origin/main`: `#[test]` function sets identical, 11 in `adopter.rs` and 58 in `facade.rs`; assertion-macro counts identical; and all 148 `facade.rs` assertion lines byte-identical. The only assertion text change is three renames of a constant to the identically-valued `OWNER_ROOT_WRITE_SCOPE_SEED`.

Local gates, all green:

```text
cargo fmt --all --check                                             PASS
cargo clippy --workspace --exclude cipherbox-desktop \
  --exclude cipherbox-contract --all-targets -- -D warnings         PASS
cargo test --workspace --exclude cipherbox-desktop \
  --exclude cipherbox-contract                                      PASS
cargo test -p cipherbox-engine
  427 + 25 + 7 + 9 + 3 + 17 + 22 + 15 passed, 0 failed
cargo check -p cipherbox-wasm --features conformance \
  --target wasm32-unknown-unknown                                   PASS
```

The browser and contract suites are not gated by this diff — it touches no WASM boundary, seam, or API surface.

## Reviews

`/simplify`, `/security-review`, and `/crypto-privacy-review` all run.

Folded in: the `OwnerRootSpec` doc now records the keystream constraint the extraction newly exposes — nonces and HPKE ephemerals are fixed and no key schedule takes `scope_id`, `children`, or the owner-write-blob epoch, so two specs sharing `owner_enc` and `root_id` would reuse a keystream. Neither call site does; the note keeps a third caller from walking into it. Also dropped the alias constants in `facade.rs` in favour of `use ... as`, and removed rationale restated at a caller that already lives at the definition.

Discarded: 5 nits, mostly comment-shape preferences plus a suggestion to also fold in the IPNS record builders — out of this issue's scope, which is the head-block builder. No issues filed.

CodeRabbit CLI raised one major finding, also folded in: the first draft of that same `OwnerRootSpec` note treated `owner_enc` and `root_id` as interchangeable ways to separate keystreams. They are independent axes — the read body's key comes from `root_id` alone, the owner-write-blob's HPKE key from `owner_enc` alone — and the doc now says so. The confirming re-run hit the CodeRabbit org rate limit, so the clean-pass re-review is still outstanding.

## Rebase note

This touches `crates/engine/src/net/adopter.rs` and `crates/engine/src/facade.rs`, so it may need a rebase if concurrent work lands in either.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture consistency for owner-root read/write scenarios.
  * Added reusable deterministic fixtures for validating sealed root data, grants, and write-scope recovery.
  * Expanded coverage for owner-write-blob and cached-candidate recovery paths.
  * Included owner-write-blob epoch data in root read fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->