### PR TITLE
fix: make the encode-path recursion depth bound release-active

### DIFF
--- a/crates/core/examples/kat_gen.rs
+++ b/crates/core/examples/kat_gen.rs
@@ -1168,7 +1168,7 @@ fn build_accept_vectors() -> Vec<AcceptVector> {
     let mut out = Vec::with_capacity(specs.len());
     for (name, value, kinds) in specs {
         assert!(names.insert(name), "duplicate accept vector name {name}");
-        let bytes = encode(&value);
+        let bytes = encode(&value).unwrap();
         let decoded = decode(&bytes)
             .unwrap_or_else(|e| panic!("accept vector {name}: live decoder rejected it: {e}"));
         assert_eq!(
@@ -1176,7 +1176,7 @@ fn build_accept_vectors() -> Vec<AcceptVector> {
             "accept vector {name}: decode != source value"
         );
         assert_eq!(
-            encode(&decoded),
+            encode(&decoded).unwrap(),
             bytes,
             "accept vector {name}: re-encode not byte-stable"
         );
@@ -1676,7 +1676,7 @@ fn build_unknown_field_vectors() -> Vec<UnknownVector> {
             names.insert(name),
             "duplicate unknown-field vector name {name}"
         );
-        let bytes = encode(&value);
+        let bytes = encode(&value).unwrap();
         let known_set: BTreeSet<&str> = known_keys.iter().copied().collect();
         let (known, unknown) = decode_map_partial(&bytes, |k| known_set.contains(k))
             .unwrap_or_else(|e| panic!("unknown-field vector {name}: decode failed: {e}"));
@@ -2501,7 +2501,7 @@ fn sample_file() -> ReadBody {
 
 fn build_seal_vectors() -> Vec<SealVector> {
     let p = seal_probe();
-    let read_body_pt = encode_read_body(&sample_folder());
+    let read_body_pt = encode_read_body(&sample_folder()).unwrap();
 
     // (name, structTag, plaintext). read-body carries a real read-body; the
     // write-body tag reuses the primitive to prove per-tag AAD separation (its
@@ -2692,12 +2692,12 @@ fn build_read_body_accept() -> Vec<ReadBodyAcceptVector> {
             names.insert(name),
             "duplicate read-body accept vector {name}"
         );
-        let bytes = encode_read_body(&body);
+        let bytes = encode_read_body(&body).unwrap();
         let decoded = decode_read_body(&bytes)
             .unwrap_or_else(|e| panic!("read-body accept {name}: live decoder rejected it: {e}"));
         assert_eq!(decoded, body, "read-body accept {name}: decode != source");
         assert_eq!(
-            encode_read_body(&decoded),
+            encode_read_body(&decoded).unwrap(),
             bytes,
             "read-body accept {name}: re-encode not byte-stable"
         );
@@ -2836,7 +2836,7 @@ fn build_envelope_accept() -> Vec<EnvelopeAcceptVector> {
             name: name.to_string(),
             key: hexstr(&p.key),
             envelope: envelope_hex,
-            read_body: hexstr(&encode_read_body(&body)),
+            read_body: hexstr(&encode_read_body(&body).unwrap()),
         });
     }
 
@@ -2845,16 +2845,16 @@ fn build_envelope_accept() -> Vec<EnvelopeAcceptVector> {
     let body = sample_folder();
     let env = seal_read_body(&p.key, &p.nonce, p.v, p.id, p.scope, p.epoch, &body)
         .expect("sample folder is valid");
-    let mut m = decode(&encode_envelope(&env))
+    let mut m = decode(&encode_envelope(&env).unwrap())
         .unwrap()
         .as_map()
         .unwrap()
         .clone();
     m.insert("writeSealed", Value::Bytes(b"future-write-body".to_vec()));
-    let bytes = encode(&Value::Map(m));
+    let bytes = encode(&Value::Map(m)).unwrap();
     let decoded = decode_envelope(&bytes).expect("tolerant envelope decode");
     assert_eq!(
-        encode_envelope(&decoded),
+        encode_envelope(&decoded).unwrap(),
         bytes,
         "envelope accept with-unknown-field: not byte-stable"
     );
@@ -2876,7 +2876,7 @@ fn build_envelope_accept() -> Vec<EnvelopeAcceptVector> {
         name: "with-unknown-field".to_string(),
         key: hexstr(&p.key),
         envelope: hexstr(&bytes),
-        read_body: hexstr(&encode_read_body(&body)),
+        read_body: hexstr(&encode_read_body(&body).unwrap()),
     });
 
     out
@@ -2890,12 +2890,12 @@ fn envelope_accept_self_check(
     body: &ReadBody,
     key: &[u8; KEY_LEN],
 ) -> String {
-    let bytes = encode_envelope(env);
+    let bytes = encode_envelope(env).unwrap();
     let decoded = decode_envelope(&bytes)
         .unwrap_or_else(|e| panic!("envelope accept {name}: decode rejected it: {e}"));
     assert_eq!(&decoded, env, "envelope accept {name}: decode != source");
     assert_eq!(
-        encode_envelope(&decoded),
+        encode_envelope(&decoded).unwrap(),
         bytes,
         "envelope accept {name}: re-encode not byte-stable"
     );
@@ -2920,7 +2920,7 @@ fn build_envelope_reject() -> Vec<RejectVector> {
         &sample_folder(),
     )
     .expect("sample folder is valid");
-    let base = decode(&encode_envelope(&env))
+    let base = decode(&encode_envelope(&env).unwrap())
         .unwrap()
         .as_map()
         .unwrap()
@@ -2987,7 +2987,7 @@ where
             names.insert(name),
             "duplicate {family} reject vector {name}"
         );
-        let bytes = encode(&value);
+        let bytes = encode(&value).unwrap();
         let err = match decode_fn(&bytes) {
             Err(e) => e,
             Ok(_) => panic!("{family} reject {name}: decoder accepted it"),
@@ -3289,7 +3289,7 @@ fn build_contact_reject() -> Vec<RejectVector> {
         if let Some(v) = identity {
             m.insert("identityPk", v);
         }
-        encode(&Value::Map(m))
+        encode(&Value::Map(m)).unwrap()
     };
     let b = |v: &[u8]| Value::Bytes(v.to_vec());
 
@@ -3580,7 +3580,7 @@ fn ipns_data_cbor(
     m.insert("Sequence", Value::Unsigned(sequence));
     m.insert("Validity", Value::Bytes(validity.to_vec()));
     m.insert("ValidityType", Value::Unsigned(validity_type));
-    encode(&Value::Map(m))
+    encode(&Value::Map(m)).unwrap()
 }
 
 fn ipns_sign(signer: &Ed25519Signer, data: &[u8]) -> [u8; 64] {
@@ -3997,7 +3997,7 @@ fn build_mailbox_reject() -> Vec<MailboxRejectVector> {
     let mut ct = m.get("ct").unwrap().as_bytes().unwrap().to_vec();
     ct[0] ^= 0x01;
     m.insert("ct", Value::Bytes(ct));
-    let tampered_block = encode(&Value::Map(m));
+    let tampered_block = encode(&Value::Map(m)).unwrap();
 
     // A block that opens (anyone can HPKE-seal) but whose sender signature does
     // not verify: build the inner with a wrong signature and seal it.
@@ -4014,7 +4014,7 @@ fn build_mailbox_reject() -> Vec<MailboxRejectVector> {
                 .to_vec(),
         ),
     );
-    let inner_bytes = encode(&Value::Map(inner));
+    let inner_bytes = encode(&Value::Map(inner)).unwrap();
     let info = build_aad(&AadContext {
         v,
         id: [0; 16],
@@ -4026,7 +4026,7 @@ fn build_mailbox_reject() -> Vec<MailboxRejectVector> {
     let mut forged = Map::new();
     forged.insert("ct", Value::Bytes(sealed.ciphertext));
     forged.insert("enc", Value::Bytes(sealed.enc.to_vec()));
-    let forged_block = encode(&Value::Map(forged));
+    let forged_block = encode(&Value::Map(forged)).unwrap();
 
     // A block that opens but whose senderIdentityPk is the 65-byte uncompressed
     // re-encoding of the sender key: the frozen 33-byte identity width rejects it
@@ -4044,7 +4044,7 @@ fn build_mailbox_reject() -> Vec<MailboxRejectVector> {
         "senderSig",
         Value::Bytes(sender.sign_detcbor(b"any").to_compact().to_vec()),
     );
-    let uncompressed_inner_bytes = encode(&Value::Map(uncompressed_inner));
+    let uncompressed_inner_bytes = encode(&Value::Map(uncompressed_inner)).unwrap();
     let sealed_uncompressed = hpke_seal(
         &recipient.public(),
         &uncompressed_eph,
@@ -4055,7 +4055,7 @@ fn build_mailbox_reject() -> Vec<MailboxRejectVector> {
     let mut uncompressed_block_map = Map::new();
     uncompressed_block_map.insert("ct", Value::Bytes(sealed_uncompressed.ciphertext));
     uncompressed_block_map.insert("enc", Value::Bytes(sealed_uncompressed.enc.to_vec()));
-    let uncompressed_block = encode(&Value::Map(uncompressed_block_map));
+    let uncompressed_block = encode(&Value::Map(uncompressed_block_map)).unwrap();
 
     // Cross-recipient relay lift (#712): R1 opens an item sealed to it and
     // re-seals the untouched inner — sender signature included — to R2. Recipient
@@ -4080,7 +4080,7 @@ fn build_mailbox_reject() -> Vec<MailboxRejectVector> {
     let mut relay_block_map = Map::new();
     relay_block_map.insert("ct", Value::Bytes(sealed_to_r2.ciphertext));
     relay_block_map.insert("enc", Value::Bytes(sealed_to_r2.enc.to_vec()));
-    let relay_block = encode(&Value::Map(relay_block_map));
+    let relay_block = encode(&Value::Map(relay_block_map)).unwrap();
 
     // (name, recipient_secret, v, block, check).
     let wrong_recipient = [0x41u8; 32];
@@ -4624,10 +4624,12 @@ fn build_grant_blob_accept() -> Vec<HpkeStructureVector> {
     let mut out = Vec::with_capacity(cases.len());
     for (name, eph, payload) in cases {
         assert!(names.insert(name), "duplicate grant-blob accept {name}");
-        let plaintext = encode_grant_blob_payload(&payload);
-        let sealed = seal_grant_blob(&recipient.public(), &eph, &ctx, &payload);
+        let plaintext = encode_grant_blob_payload(&payload).unwrap();
+        let sealed = seal_grant_blob(&recipient.public(), &eph, &ctx, &payload).unwrap();
         assert_eq!(
-            seal_grant_blob(&recipient.public(), &eph, &ctx, &payload).ciphertext,
+            seal_grant_blob(&recipient.public(), &eph, &ctx, &payload)
+                .unwrap()
+                .ciphertext,
             sealed.ciphertext,
             "grant-blob {name}: not deterministic"
         );
@@ -4691,7 +4693,7 @@ fn build_grant_blob_reject() -> Vec<BlobRejectVector> {
     let recipient = X25519Secret::from_scalar(recipient_scalar);
     let ctx = grant_ctx(STRUCT_TAG_GRANT_BLOB);
     let payload = GrantBlobPayload::new([0x11; 32], Some([0x44; 32]), GRANT_EPOCH, [0x22; 32]);
-    let sealed = seal_grant_blob(&recipient.public(), &[0x68; 32], &ctx, &payload);
+    let sealed = seal_grant_blob(&recipient.public(), &[0x68; 32], &ctx, &payload).unwrap();
     out.extend(hpke_blob_reject_pair(
         recipient_scalar,
         &recipient,
@@ -4791,10 +4793,12 @@ fn build_owner_blob_accept() -> Vec<HpkeStructureVector> {
     let eph: [u8; 32] = std::array::from_fn(|i| (0x60 + i) as u8);
     let payload = OverrideSeedPayload::new([0x77; 32], GRANT_EPOCH);
 
-    let plaintext = encode_override_seed_payload(&payload);
-    let sealed = seal_owner_blob(&owner.public(), &eph, &ctx, &payload);
+    let plaintext = encode_override_seed_payload(&payload).unwrap();
+    let sealed = seal_owner_blob(&owner.public(), &eph, &ctx, &payload).unwrap();
     assert_eq!(
-        seal_owner_blob(&owner.public(), &eph, &ctx, &payload).ciphertext,
+        seal_owner_blob(&owner.public(), &eph, &ctx, &payload)
+            .unwrap()
+            .ciphertext,
         sealed.ciphertext,
         "owner-blob: not deterministic"
     );
@@ -4842,7 +4846,7 @@ fn build_owner_blob_reject() -> Vec<BlobRejectVector> {
     let owner = X25519Secret::from_scalar(owner_scalar);
     let ctx = grant_ctx(STRUCT_TAG_OWNER_BLOB);
     let payload = OverrideSeedPayload::new([0x77; 32], GRANT_EPOCH);
-    let sealed = seal_owner_blob(&owner.public(), &[0x69; 32], &ctx, &payload);
+    let sealed = seal_owner_blob(&owner.public(), &[0x69; 32], &ctx, &payload).unwrap();
     out.extend(hpke_blob_reject_pair(
         owner_scalar,
         &owner,
@@ -4909,10 +4913,12 @@ fn build_owner_write_blob_accept() -> Vec<HpkeStructureVector> {
     let eph: [u8; 32] = std::array::from_fn(|i| (0x62 + i) as u8);
     let payload = OwnerWriteBlobPayload::new([0x66; 32], GRANT_WRITE_EPOCH);
 
-    let plaintext = encode_owner_write_blob_payload(&payload);
-    let sealed = seal_owner_write_blob(&owner.public(), &eph, &ctx, &payload);
+    let plaintext = encode_owner_write_blob_payload(&payload).unwrap();
+    let sealed = seal_owner_write_blob(&owner.public(), &eph, &ctx, &payload).unwrap();
     assert_eq!(
-        seal_owner_write_blob(&owner.public(), &eph, &ctx, &payload).ciphertext,
+        seal_owner_write_blob(&owner.public(), &eph, &ctx, &payload)
+            .unwrap()
+            .ciphertext,
         sealed.ciphertext,
         "owner-write-blob: not deterministic"
     );
@@ -4961,7 +4967,7 @@ fn build_owner_write_blob_reject() -> Vec<BlobRejectVector> {
     let owner = X25519Secret::from_scalar(owner_scalar);
     let ctx = owner_write_blob_ctx();
     let payload = OwnerWriteBlobPayload::new([0x66; 32], GRANT_WRITE_EPOCH);
-    let sealed = seal_owner_write_blob(&owner.public(), &[0x6a; 32], &ctx, &payload);
+    let sealed = seal_owner_write_blob(&owner.public(), &[0x6a; 32], &ctx, &payload).unwrap();
 
     let mut tampered_ct = sealed.ciphertext.clone();
     tampered_ct[0] ^= 0x01;
@@ -5018,17 +5024,17 @@ fn build_ascent_link_accept() -> Vec<AscentLinkAcceptVector> {
     let eph: [u8; 32] = std::array::from_fn(|i| (0x70 + i) as u8);
     let ctx = grant_ctx(STRUCT_TAG_ASCENT_LINK);
     let payload = OverrideSeedPayload::new([0x88; 32], GRANT_EPOCH);
-    let plaintext = encode_override_seed_payload(&payload);
+    let plaintext = encode_override_seed_payload(&payload).unwrap();
 
-    let link = seal_ascent_link(&parent_node_seed, &eph, &ctx, &payload);
+    let link = seal_ascent_link(&parent_node_seed, &eph, &ctx, &payload).unwrap();
     // The ancestor re-derives the keypair, matches the public half, and opens.
     let opened = open_ascent_link(&parent_node_seed, &ctx, &link).expect("ascent open");
     assert_eq!(opened, payload, "ascent-link: round-trip");
-    let container = encode_ascent_link(&link);
+    let container = encode_ascent_link(&link).unwrap();
     let decoded = decode_ascent_link(&container).expect("ascent container decodes");
     assert_eq!(decoded, link, "ascent-link: container decode != source");
     assert_eq!(
-        encode_ascent_link(&decoded),
+        encode_ascent_link(&decoded).unwrap(),
         container,
         "ascent-link: container not byte-stable"
     );
@@ -5054,7 +5060,7 @@ fn build_ascent_link_reject() -> Vec<AscentLinkRejectVector> {
     let eph: [u8; 32] = std::array::from_fn(|i| (0x78 + i) as u8);
     let ctx = grant_ctx(STRUCT_TAG_ASCENT_LINK);
     let payload = OverrideSeedPayload::new([0x88; 32], GRANT_EPOCH);
-    let good = seal_ascent_link(&parent_node_seed, &eph, &ctx, &payload);
+    let good = seal_ascent_link(&parent_node_seed, &eph, &ctx, &payload).unwrap();
 
     // Mismatched public half: derive-and-verify rejects before the HPKE open.
     let mut mismatched = good.clone();
@@ -5078,7 +5084,7 @@ fn build_ascent_link_reject() -> Vec<AscentLinkRejectVector> {
     let mut out = Vec::with_capacity(cases.len());
     for (name, link, check, class) in cases {
         assert!(names.insert(name), "duplicate ascent-link reject {name}");
-        let container = encode_ascent_link(&link);
+        let container = encode_ascent_link(&link).unwrap();
         let err = open_ascent_link(&parent_node_seed, &ctx, &link)
             .expect_err("ascent-link reject must fail closed");
         assert_eq!(
@@ -5114,11 +5120,11 @@ fn build_history_link_accept() -> Vec<HistoryLinkAcceptVector> {
     let nonce: [u8; NONCE_LEN] = std::array::from_fn(|i| (0x10 + i) as u8);
     let ctx = grant_ctx(STRUCT_TAG_HISTORY_LINK);
     let payload = HistoryLinkPayload::new([0x99; 32], GRANT_EPOCH - 1);
-    let plaintext = encode_history_link_payload(&payload);
+    let plaintext = encode_history_link_payload(&payload).unwrap();
 
-    let sealed = seal_history_link(&key, &nonce, &ctx, &payload);
+    let sealed = seal_history_link(&key, &nonce, &ctx, &payload).unwrap();
     assert_eq!(
-        seal_history_link(&key, &nonce, &ctx, &payload),
+        seal_history_link(&key, &nonce, &ctx, &payload).unwrap(),
         sealed,
         "history-link: not deterministic"
     );
@@ -5361,7 +5367,7 @@ fn build_grant_set_reject() -> Vec<GrantSetRejectVector> {
         if !omit_entries {
             kv.push(("entries", Value::Array(entries)));
         }
-        encode(&map_of(kv))
+        encode(&map_of(kv)).unwrap()
     };
     let codec_cases: Vec<(&str, Vec<u8>, &str)> = vec![
         (

--- a/crates/core/src/codec/encode.rs
+++ b/crates/core/src/codec/encode.rs
@@ -1,8 +1,10 @@
 //! The deterministic encoder. Canonical by construction: shortest-form
 //! arguments, definite lengths, and [`super::Map`]'s ordering invariant are
-//! the only forms this module can emit, so encoding is infallible.
+//! the only forms this module can emit, so the one way encoding fails is a tree
+//! nested past [`super::MAX_DEPTH`].
 
 use super::value::{Map, Value};
+use crate::error::{CodecError, Malformed};
 
 pub(super) const MAJOR_UNSIGNED: u8 = 0;
 pub(super) const MAJOR_NEGATIVE: u8 = 1;
@@ -24,37 +26,69 @@ pub(super) const SIMPLE_NULL: u8 = 22;
 /// scope/override/history seeds) in freed heap; with one right-sized buffer only
 /// the terminal owner's plaintext ever holds them, and that owner zeroizes it.
 ///
-/// Callers must respect [`super::MAX_DEPTH`]: a deeper `Value` still encodes
-/// (encoding is infallible), but its bytes reject as `depth-exceeded` on
-/// decode — debug builds assert the bound to catch that divergence early.
-pub fn encode(value: &Value) -> Vec<u8> {
-    let mut out = Vec::with_capacity(encoded_len(value));
-    write_value(&mut out, value, 0);
-    out
+/// A tree nested past [`super::MAX_DEPTH`] rejects as `depth-exceeded` rather
+/// than emitting bytes the decoder always refuses.
+pub fn encode(value: &Value) -> Result<Vec<u8>, CodecError> {
+    let mut out = Vec::with_capacity(encoded_len(value)?);
+    write_value(&mut out, value, 0)?;
+    Ok(out)
+}
+
+/// [`encode`] for a tree whose nesting is fixed by its construction site — an
+/// AAD or signature preimage, a schema map of scalars — so the bound is
+/// unreachable and the surrounding seal/sign surface stays infallible.
+///
+/// # Panics
+///
+/// If `value` nests to [`super::MAX_DEPTH`]. Use [`encode`] for any tree whose
+/// depth comes from input rather than from the schema.
+pub fn encode_fixed_depth(value: &Value) -> Vec<u8> {
+    encode(value).expect("fixed-shape tree is within MAX_DEPTH")
 }
 
 /// The exact number of bytes [`encode`] emits for `value`. Mirrors
-/// [`write_value`] head-for-head; the codec property suite pins the two in
-/// lockstep (`encoded_len == encode().len()`), which is what makes [`encode`]'s
-/// single up-front reservation provably realloc-free.
-pub fn encoded_len(value: &Value) -> usize {
+/// [`write_value`] head-for-head — including the depth bound and the byte offset
+/// it reports; the codec property suite pins the two in lockstep
+/// (`encoded_len == encode().len()`), which is what makes [`encode`]'s single
+/// up-front reservation provably realloc-free.
+pub fn encoded_len(value: &Value) -> Result<usize, CodecError> {
+    let mut len = 0;
+    count_value(&mut len, value, 0)?;
+    Ok(len)
+}
+
+fn count_value(len: &mut usize, value: &Value, depth: usize) -> Result<(), CodecError> {
+    check_depth(depth, *len)?;
     match value {
-        Value::Unsigned(n) | Value::Negative(n) => head_len(*n),
-        Value::Bytes(b) => head_len(b.len() as u64) + b.len(),
-        Value::Text(t) => text_len(t),
+        Value::Unsigned(n) | Value::Negative(n) => *len += head_len(*n),
+        Value::Bytes(b) => *len += head_len(b.len() as u64) + b.len(),
+        Value::Text(t) => *len += text_len(t),
         Value::Array(items) => {
-            head_len(items.len() as u64) + items.iter().map(encoded_len).sum::<usize>()
+            *len += head_len(items.len() as u64);
+            for item in items {
+                count_value(len, item, depth + 1)?;
+            }
         }
         Value::Map(map) => {
-            head_len(map.len() as u64)
-                + map
-                    .entries()
-                    .iter()
-                    .map(|(k, v)| text_len(k) + encoded_len(v))
-                    .sum::<usize>()
+            *len += head_len(map.len() as u64);
+            for (k, v) in map.entries() {
+                *len += text_len(k);
+                count_value(len, v, depth + 1)?;
+            }
         }
-        Value::Bool(_) | Value::Null => 1,
+        Value::Bool(_) | Value::Null => *len += 1,
     }
+    Ok(())
+}
+
+/// The produce-side half of the decoder's `depth-exceeded` reject: bytes nested
+/// past [`super::MAX_DEPTH`] are unopenable, so encoding fails closed instead of
+/// emitting them, and the bound doubles as the recursion guard on both passes.
+fn check_depth(depth: usize, offset: usize) -> Result<(), CodecError> {
+    if depth >= super::MAX_DEPTH {
+        return Err(Malformed::DepthExceeded { offset }.into());
+    }
+    Ok(())
 }
 
 /// The byte length of a text item: its head plus its UTF-8 bytes.
@@ -73,11 +107,12 @@ fn head_len(arg: u64) -> usize {
     }
 }
 
-pub(super) fn write_value(out: &mut Vec<u8>, value: &Value, depth: usize) {
-    debug_assert!(
-        depth < super::MAX_DEPTH,
-        "Value nesting exceeds MAX_DEPTH; the encoding would be undecodable"
-    );
+pub(super) fn write_value(
+    out: &mut Vec<u8>,
+    value: &Value,
+    depth: usize,
+) -> Result<(), CodecError> {
+    check_depth(depth, out.len())?;
     match value {
         Value::Unsigned(n) => write_head(out, MAJOR_UNSIGNED, *n),
         Value::Negative(n) => write_head(out, MAJOR_NEGATIVE, *n),
@@ -89,14 +124,15 @@ pub(super) fn write_value(out: &mut Vec<u8>, value: &Value, depth: usize) {
         Value::Array(items) => {
             write_head(out, MAJOR_ARRAY, items.len() as u64);
             for item in items {
-                write_value(out, item, depth + 1);
+                write_value(out, item, depth + 1)?;
             }
         }
-        Value::Map(map) => write_map_head_and_entries(out, map, depth),
+        Value::Map(map) => write_map_head_and_entries(out, map, depth)?,
         Value::Bool(false) => out.push((MAJOR_SIMPLE << 5) | SIMPLE_FALSE),
         Value::Bool(true) => out.push((MAJOR_SIMPLE << 5) | SIMPLE_TRUE),
         Value::Null => out.push((MAJOR_SIMPLE << 5) | SIMPLE_NULL),
     }
+    Ok(())
 }
 
 pub(super) fn write_text(out: &mut Vec<u8>, t: &str) {
@@ -104,12 +140,17 @@ pub(super) fn write_text(out: &mut Vec<u8>, t: &str) {
     out.extend_from_slice(t.as_bytes());
 }
 
-fn write_map_head_and_entries(out: &mut Vec<u8>, map: &Map, depth: usize) {
+fn write_map_head_and_entries(
+    out: &mut Vec<u8>,
+    map: &Map,
+    depth: usize,
+) -> Result<(), CodecError> {
     write_head(out, MAJOR_MAP, map.len() as u64);
     for (k, v) in map.entries() {
         write_text(out, k);
-        write_value(out, v, depth + 1);
+        write_value(out, v, depth + 1)?;
     }
+    Ok(())
 }
 
 /// Shortest-form head: the argument rides the initial byte below 24, then
@@ -187,8 +228,35 @@ mod tests {
             secret_shaped_value(40),
         ];
         for v in &cases {
-            assert_eq!(encoded_len(v), encode(v).len(), "len oracle diverged");
+            assert_eq!(
+                encoded_len(v).unwrap(),
+                encode(v).unwrap().len(),
+                "len oracle diverged"
+            );
         }
+    }
+
+    /// Nesting arrays `n` deep around a scalar puts that scalar at depth `n`.
+    fn nested(n: usize) -> Value {
+        let mut v = Value::Null;
+        for _ in 0..n {
+            v = Value::Array(vec![v]);
+        }
+        v
+    }
+
+    /// The bound is release-active on both passes, at the same boundary the
+    /// decoder rejects: past `MAX_DEPTH` the encoder fails closed rather than
+    /// emit bytes decode always refuses.
+    #[test]
+    fn encode_rejects_past_max_depth() {
+        let deep = nested(crate::codec::MAX_DEPTH);
+        assert_eq!(encoded_len(&deep).unwrap_err().check(), "depth-exceeded");
+        assert_eq!(encode(&deep).unwrap_err().check(), "depth-exceeded");
+        assert!(
+            encode(&nested(crate::codec::MAX_DEPTH - 1)).is_ok(),
+            "the deepest admissible tree still encodes"
+        );
     }
 
     /// The security invariant: encoding secret-bearing bytes performs a single
@@ -200,10 +268,10 @@ mod tests {
     #[test]
     fn secret_bearing_encode_never_reallocates() {
         let value = secret_shaped_value(64);
-        let mut out = Vec::with_capacity(encoded_len(&value));
+        let mut out = Vec::with_capacity(encoded_len(&value).unwrap());
         let ptr = out.as_ptr();
         let reserved_cap = out.capacity();
-        write_value(&mut out, &value, 0);
+        write_value(&mut out, &value, 0).unwrap();
         assert!(out.len() > 1024, "test payload must force multiple growths");
         assert_eq!(
             out.capacity(),
@@ -212,7 +280,7 @@ mod tests {
         );
         assert_eq!(out.as_ptr(), ptr, "backing store moved — a realloc ran");
         assert_eq!(
-            encode(&value),
+            encode(&value).unwrap(),
             out,
             "public two-pass path is byte-identical"
         );

--- a/crates/core/src/codec/encode.rs
+++ b/crates/core/src/codec/encode.rs
@@ -1,7 +1,7 @@
 //! The deterministic encoder. Canonical by construction: shortest-form
 //! arguments, definite lengths, and [`super::Map`]'s ordering invariant are
-//! the only forms this module can emit, so the one way encoding fails is a tree
-//! nested past [`super::MAX_DEPTH`].
+//! the only forms this module can emit, so [`check_depth`] is the one way
+//! encoding fails.
 
 use super::value::{Map, Value};
 use crate::error::{CodecError, Malformed};
@@ -25,9 +25,8 @@ pub(super) const SIMPLE_NULL: u8 = 22;
 /// intermediate backing store un-zeroized, stranding secret bytes (content keys,
 /// scope/override/history seeds) in freed heap; with one right-sized buffer only
 /// the terminal owner's plaintext ever holds them, and that owner zeroizes it.
-///
-/// A tree nested past [`super::MAX_DEPTH`] rejects as `depth-exceeded` rather
-/// than emitting bytes the decoder always refuses.
+/// Sizing first is also what makes [`check_depth`] fail closed instead of
+/// overflowing the stack: the deeper pass runs before anything is allocated.
 pub fn encode(value: &Value) -> Result<Vec<u8>, CodecError> {
     let mut out = Vec::with_capacity(encoded_len(value)?);
     write_value(&mut out, value, 0)?;
@@ -47,10 +46,9 @@ pub fn encode_fixed_depth(value: &Value) -> Vec<u8> {
 }
 
 /// The exact number of bytes [`encode`] emits for `value`. Mirrors
-/// [`write_value`] head-for-head — including the depth bound and the byte offset
-/// it reports; the codec property suite pins the two in lockstep
-/// (`encoded_len == encode().len()`), which is what makes [`encode`]'s single
-/// up-front reservation provably realloc-free.
+/// [`write_value`] head-for-head; the codec property suite pins the two in
+/// lockstep (`encoded_len == encode().len()`), which is what makes [`encode`]'s
+/// single up-front reservation provably realloc-free.
 pub fn encoded_len(value: &Value) -> Result<usize, CodecError> {
     let mut len = 0;
     count_value(&mut len, value, 0)?;
@@ -81,9 +79,9 @@ fn count_value(len: &mut usize, value: &Value, depth: usize) -> Result<(), Codec
     Ok(())
 }
 
-/// The produce-side half of the decoder's `depth-exceeded` reject: bytes nested
-/// past [`super::MAX_DEPTH`] are unopenable, so encoding fails closed instead of
-/// emitting them, and the bound doubles as the recursion guard on both passes.
+/// The produce-side half of the decoder's `depth-exceeded` reject (AGENTS.md
+/// encode/decode fail-closed symmetry), and the recursion guard on both passes.
+/// `offset` is the emitted-byte position the bound fired at.
 fn check_depth(depth: usize, offset: usize) -> Result<(), CodecError> {
     if depth >= super::MAX_DEPTH {
         return Err(Malformed::DepthExceeded { offset }.into());
@@ -236,7 +234,6 @@ mod tests {
         }
     }
 
-    /// Nesting arrays `n` deep around a scalar puts that scalar at depth `n`.
     fn nested(n: usize) -> Value {
         let mut v = Value::Null;
         for _ in 0..n {
@@ -246,17 +243,19 @@ mod tests {
     }
 
     /// The bound is release-active on both passes, at the same boundary the
-    /// decoder rejects: past `MAX_DEPTH` the encoder fails closed rather than
-    /// emit bytes decode always refuses.
+    /// decoder rejects.
     #[test]
     fn encode_rejects_past_max_depth() {
         let deep = nested(crate::codec::MAX_DEPTH);
         assert_eq!(encoded_len(&deep).unwrap_err().check(), "depth-exceeded");
         assert_eq!(encode(&deep).unwrap_err().check(), "depth-exceeded");
-        assert!(
-            encode(&nested(crate::codec::MAX_DEPTH - 1)).is_ok(),
-            "the deepest admissible tree still encodes"
-        );
+
+        // The other half of the boundary: what the encoder admits, the decoder
+        // reopens — an off-by-one either way would break one of these.
+        let deepest = nested(crate::codec::MAX_DEPTH - 1);
+        let bytes = encode(&deepest).expect("the deepest admissible tree encodes");
+        assert_eq!(encoded_len(&deepest).unwrap(), bytes.len());
+        assert_eq!(super::super::decode(&bytes).unwrap(), deepest);
     }
 
     /// The security invariant: encoding secret-bearing bytes performs a single

--- a/crates/core/src/codec/fields.rs
+++ b/crates/core/src/codec/fields.rs
@@ -102,7 +102,7 @@ pub fn encode_map_partial(known: &Map, unknown: &UnknownFields) -> Result<Vec<u8
             let (key, value) = k.next().expect("peeked");
             write_text(&mut out, key);
             // Depth 1: the emitted map is the enclosing item.
-            write_value(&mut out, value, 1);
+            write_value(&mut out, value, 1)?;
         } else {
             let (key, raw) = u.next().expect("peeked");
             write_text(&mut out, key);
@@ -136,7 +136,7 @@ mod tests {
 
     #[test]
     fn unknown_fields_round_trip_byte_stable() {
-        let original = encode(&Value::Map(sample_map()));
+        let original = encode(&Value::Map(sample_map())).unwrap();
         let (known, unknown) = decode_map_partial(&original, known_key_set(&["v", "id"])).unwrap();
         assert_eq!(known.len(), 2);
         assert_eq!(unknown.len(), 2);
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     fn rewrite_of_known_field_keeps_unknowns_and_canonical_order() {
-        let original = encode(&Value::Map(sample_map()));
+        let original = encode(&Value::Map(sample_map())).unwrap();
         let (mut known, unknown) =
             decode_map_partial(&original, known_key_set(&["v", "id"])).unwrap();
         known.insert("v", Value::Unsigned(3));
@@ -154,7 +154,7 @@ mod tests {
 
         let mut expected = sample_map();
         expected.insert("v", Value::Unsigned(3));
-        assert_eq!(rewritten, encode(&Value::Map(expected)));
+        assert_eq!(rewritten, encode(&Value::Map(expected)).unwrap());
         // Still strict-profile decodable with everything present.
         let full = decode(&rewritten).unwrap();
         let m = full.as_map().unwrap();
@@ -165,7 +165,7 @@ mod tests {
 
     #[test]
     fn collision_between_known_and_unknown_rejects() {
-        let original = encode(&Value::Map(sample_map()));
+        let original = encode(&Value::Map(sample_map())).unwrap();
         let (mut known, unknown) =
             decode_map_partial(&original, known_key_set(&["v", "id"])).unwrap();
         known.insert("future", Value::Unsigned(0));
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn non_map_top_level_rejects() {
-        let bytes = encode(&Value::Unsigned(1));
+        let bytes = encode(&Value::Unsigned(1)).unwrap();
         let err = decode_map_partial(&bytes, |_| true).unwrap_err();
         assert_eq!(err.check(), "unexpected-type");
     }

--- a/crates/core/src/codec/mod.rs
+++ b/crates/core/src/codec/mod.rs
@@ -19,7 +19,7 @@ mod fields;
 mod value;
 
 pub use decode::decode;
-pub use encode::{encode, encoded_len};
+pub use encode::{encode, encode_fixed_depth, encoded_len};
 pub use fields::{UnknownFields, decode_map_partial, encode_map_partial, known_key_set};
 pub use value::{Map, Value, canonical_key_cmp};
 

--- a/crates/core/src/codec/value.rs
+++ b/crates/core/src/codec/value.rs
@@ -333,8 +333,8 @@ mod tests {
         ];
         for x in &keys {
             for y in &keys {
-                let enc_x = crate::codec::encode(&Value::Text(x.clone()));
-                let enc_y = crate::codec::encode(&Value::Text(y.clone()));
+                let enc_x = crate::codec::encode(&Value::Text(x.clone())).unwrap();
+                let enc_y = crate::codec::encode(&Value::Text(y.clone())).unwrap();
                 assert_eq!(
                     canonical_key_cmp(x, y),
                     enc_x.cmp(&enc_y),

--- a/crates/core/src/ipns/record.rs
+++ b/crates/core/src/ipns/record.rs
@@ -26,7 +26,7 @@
 
 use zeroize::Zeroize;
 
-use crate::codec::{Map, Value, decode, encode};
+use crate::codec::{Map, Value, decode, encode_fixed_depth};
 use crate::error::{CodecError, Malformed, TrustViolation};
 use crate::suite::ed25519::{Ed25519Signature, Ed25519Signer, SIGNATURE_LEN};
 
@@ -233,7 +233,7 @@ fn encode_data(
     m.insert("Sequence", Value::Unsigned(sequence));
     m.insert("Validity", Value::Bytes(validity.to_vec()));
     m.insert("ValidityType", Value::Unsigned(validity_type));
-    encode(&Value::Map(m))
+    encode_fixed_depth(&Value::Map(m))
 }
 
 /// Decode + shape-check the signed `data`. Any structural defect (non-canonical

--- a/crates/core/src/payload/mailbox.rs
+++ b/crates/core/src/payload/mailbox.rs
@@ -23,7 +23,7 @@
 
 use zeroize::Zeroize;
 
-use crate::codec::{Map, Value, decode, encode};
+use crate::codec::{Map, Value, decode, encode_fixed_depth};
 use crate::error::{CodecError, TrustViolation};
 use crate::seal::{AadContext, STRUCT_TAG_MAILBOX_PAYLOAD, build_aad};
 use crate::suite::ecdsa::{EcdsaSignature, EcdsaSigner, EcdsaVerifier};
@@ -62,7 +62,7 @@ fn mailbox_ctx(v: u64) -> AadContext {
 /// cross-recipient relay lift: an opened item cannot be re-sealed to a second
 /// recipient and still verify.
 fn sig_preimage(v: u64, recipient_pk: &[u8], sender_pk: &[u8], payload: &[u8]) -> Vec<u8> {
-    encode(&Value::Array(vec![
+    encode_fixed_depth(&Value::Array(vec![
         Value::Text(MAILBOX_SIG_DOMAIN.to_string()),
         Value::Unsigned(v),
         Value::Bytes(recipient_pk.to_vec()),
@@ -92,7 +92,7 @@ pub fn seal_mailbox_payload(
     inner_map.insert("payload", Value::Bytes(payload.to_vec()));
     inner_map.insert("senderIdentityPk", Value::Bytes(sender_pk.to_vec()));
     inner_map.insert("senderSig", Value::Bytes(sender_sig.to_compact().to_vec()));
-    let mut inner = encode(&Value::Map(inner_map));
+    let mut inner = encode_fixed_depth(&Value::Map(inner_map));
 
     let info = build_aad(&mailbox_ctx(v));
     let sealed = hpke_seal(recipient_enc_pub, ephemeral_scalar, &info, &[], &inner);
@@ -101,7 +101,7 @@ pub fn seal_mailbox_payload(
     let mut block = Map::new();
     block.insert("ct", Value::Bytes(sealed.ciphertext));
     block.insert("enc", Value::Bytes(sealed.enc.to_vec()));
-    encode(&Value::Map(block))
+    encode_fixed_depth(&Value::Map(block))
 }
 
 /// Open + verify a mailbox payload. HPKE-open under `recipient_secret` and the
@@ -154,6 +154,7 @@ fn verify_inner(inner: &[u8], v: u64, recipient_pk: &[u8]) -> Result<MailboxItem
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codec::encode;
 
     fn recipient() -> X25519Secret {
         X25519Secret::from_scalar([0x40; 32])
@@ -182,7 +183,7 @@ mod tests {
         let mut ct = m.get("ct").unwrap().as_bytes().unwrap().to_vec();
         ct[0] ^= 0x01;
         m.insert("ct", Value::Bytes(ct));
-        let tampered = encode(&Value::Map(m));
+        let tampered = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             open_mailbox_payload(&recipient(), 2, &tampered)
                 .unwrap_err()
@@ -227,13 +228,13 @@ mod tests {
         // A valid-encoding but wrong signature (sign a different message).
         let wrong = sender().sign_detcbor(b"not the preimage");
         inner.insert("senderSig", Value::Bytes(wrong.to_compact().to_vec()));
-        let inner_bytes = encode(&Value::Map(inner));
+        let inner_bytes = encode(&Value::Map(inner)).unwrap();
         let info = build_aad(&mailbox_ctx(2));
         let sealed = hpke_seal(&recipient().public(), &eph, &info, &[], &inner_bytes);
         let mut block = Map::new();
         block.insert("ct", Value::Bytes(sealed.ciphertext));
         block.insert("enc", Value::Bytes(sealed.enc.to_vec()));
-        let block_bytes = encode(&Value::Map(block));
+        let block_bytes = encode(&Value::Map(block)).unwrap();
         assert_eq!(
             open_mailbox_payload(&recipient(), 2, &block_bytes)
                 .unwrap_err()
@@ -261,7 +262,7 @@ mod tests {
         let mut relay = Map::new();
         relay.insert("ct", Value::Bytes(sealed.ciphertext));
         relay.insert("enc", Value::Bytes(sealed.enc.to_vec()));
-        let relay_block = encode(&Value::Map(relay));
+        let relay_block = encode(&Value::Map(relay)).unwrap();
 
         assert_eq!(
             open_mailbox_payload(&r2, 2, &relay_block)
@@ -308,7 +309,7 @@ mod tests {
         let mut block2 = Map::new();
         block2.insert("ct", Value::Bytes(resealed.ciphertext));
         block2.insert("enc", Value::Bytes(resealed.enc.to_vec()));
-        let block2_bytes = encode(&Value::Map(block2));
+        let block2_bytes = encode(&Value::Map(block2)).unwrap();
 
         let item = open_mailbox_payload(&r1, 2, &block2_bytes).unwrap();
         assert_eq!(item.payload, b"relayed");

--- a/crates/core/src/payload/pointer.rs
+++ b/crates/core/src/payload/pointer.rs
@@ -21,7 +21,7 @@
 
 use zeroize::Zeroize;
 
-use crate::codec::{Map, Value, decode, encode};
+use crate::codec::{Map, Value, decode, encode, encode_fixed_depth};
 use crate::error::{CodecError, Malformed, TrustViolation};
 use crate::ipns::IpnsName;
 use crate::seal::{AadContext, STRUCT_TAG_POINTER_PAYLOAD};
@@ -106,14 +106,14 @@ pub fn seal_pointer_payload(
     object: &RepointObject,
 ) -> Vec<u8> {
     let object_value = object.to_value();
-    let mut object_bytes = encode(&object_value);
+    let mut object_bytes = encode_fixed_depth(&object_value);
     let owner_sig = owner_signer.sign_detcbor(&object_bytes);
     object_bytes.zeroize();
 
     let mut m = Map::new();
     m.insert("object", object_value);
     m.insert("ownerSig", Value::Bytes(owner_sig.to_compact().to_vec()));
-    let mut plaintext = encode(&Value::Map(m));
+    let mut plaintext = encode_fixed_depth(&Value::Map(m));
 
     let sealed = crate::seal::seal(
         pointer_read_key,
@@ -168,7 +168,7 @@ fn decode_and_verify(
 
     // The object bytes the owner signed are the verbatim canonical re-encoding
     // of the decoded (canonical) `object` value.
-    let mut object_bytes = encode(object_value);
+    let mut object_bytes = encode(object_value)?;
     let verified = owner_identity.verify_detcbor(&object_bytes, &sig);
     object_bytes.zeroize();
     if !verified {

--- a/crates/core/src/seal/aad.rs
+++ b/crates/core/src/seal/aad.rs
@@ -25,7 +25,7 @@
 //! wave. Name transplant is closed by duplicate-`ipnsName` rejection at decode
 //! ([`super::body`]) instead of by the tag.
 
-use crate::codec::{Value, encode};
+use crate::codec::{Value, encode_fixed_depth};
 
 /// The fresh `cipherbox/v2` AAD domain separator. Its presence as the first
 /// AAD element keeps CipherBox v2 seals from ever colliding with another
@@ -134,7 +134,7 @@ pub struct AadContext {
 /// `[AAD_DOMAIN, v, id, scope, epoch, structTag]`. Deterministic and
 /// unambiguous; the array positions are frozen by the KAT.
 pub fn build_aad(ctx: &AadContext) -> Vec<u8> {
-    encode(&Value::Array(vec![
+    encode_fixed_depth(&Value::Array(vec![
         Value::Text(AAD_DOMAIN.to_string()),
         Value::Unsigned(ctx.v),
         Value::Bytes(ctx.id.to_vec()),

--- a/crates/core/src/seal/body.rs
+++ b/crates/core/src/seal/body.rs
@@ -340,13 +340,12 @@ pub fn decode_read_body(bytes: &[u8]) -> Result<ReadBody, CodecError> {
 /// its caller is the terminal owner and must zeroize it after use (the seal
 /// path, [`seal_read_body`](super::seal_read_body), does exactly this).
 ///
-/// Encoding is infallible and does *not* re-check uniqueness — mirroring the
-/// codec's `encode`/`MAX_DEPTH` contract, a caller-built folder with duplicate
+/// Encoding does *not* re-check uniqueness: a caller-built folder with duplicate
 /// child ids/ipnsNames still encodes but its bytes reject on decode. Callers
 /// that *persist* a body must go through [`seal_read_body`](super::seal_read_body)
 /// (or call [`ReadBody::validate`] first), which refuses to seal a body that
 /// would not reopen; a `debug_assert` catches the divergence early in tests.
-pub fn encode_read_body(body: &ReadBody) -> Vec<u8> {
+pub fn encode_read_body(body: &ReadBody) -> Result<Vec<u8>, CodecError> {
     debug_assert!(
         body.validate().is_ok(),
         "encoding a read-body that violates child uniqueness; its bytes would reject on decode"
@@ -553,7 +552,7 @@ mod tests {
         );
         m.insert("createdAt", Value::Unsigned(100));
         m.insert("modifiedAt", Value::Unsigned(200));
-        encode(&Value::Map(m))
+        encode(&Value::Map(m)).unwrap()
     }
 
     #[test]
@@ -562,10 +561,14 @@ mod tests {
             child(1, "a.txt", b"name-1"),
             child(2, "b.txt", b"name-2"),
         ]);
-        let bytes = encode_read_body(&body);
+        let bytes = encode_read_body(&body).unwrap();
         let decoded = decode_read_body(&bytes).expect("decodes");
         assert_eq!(decoded, body);
-        assert_eq!(encode_read_body(&decoded), bytes, "re-encode byte-stable");
+        assert_eq!(
+            encode_read_body(&decoded).unwrap(),
+            bytes,
+            "re-encode byte-stable"
+        );
         assert_eq!(decoded.kind(), NodeKind::Folder);
     }
 
@@ -580,7 +583,7 @@ mod tests {
             ],
             unknown: Vec::new(),
         };
-        let bytes = encode_read_body(&body);
+        let bytes = encode_read_body(&body).unwrap();
         let decoded = decode_read_body(&bytes).expect("decodes");
         assert_eq!(decoded, body);
         if let ReadBody::File { versions, .. } = &decoded {
@@ -618,9 +621,13 @@ mod tests {
         m.insert("createdAt", Value::Unsigned(1));
         m.insert("modifiedAt", Value::Unsigned(2));
         m.insert("futureField", Value::Text("keep me".into()));
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         let decoded = decode_read_body(&bytes).expect("tolerant decode");
-        assert_eq!(encode_read_body(&decoded), bytes, "unknown field preserved");
+        assert_eq!(
+            encode_read_body(&decoded).unwrap(),
+            bytes,
+            "unknown field preserved"
+        );
         if let ReadBody::Folder { unknown, .. } = &decoded {
             assert_eq!(unknown.len(), 1);
             assert_eq!(unknown[0].0, "futureField");
@@ -636,7 +643,7 @@ mod tests {
         m.insert("children", Value::Array(vec![]));
         m.insert("createdAt", Value::Unsigned(1));
         m.insert("modifiedAt", Value::Unsigned(2));
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             decode_read_body(&bytes).unwrap_err().check(),
             "invalid-node-kind"
@@ -656,7 +663,7 @@ mod tests {
         m.insert("children", Value::Array(vec![Value::Map(cm)]));
         m.insert("createdAt", Value::Unsigned(1));
         m.insert("modifiedAt", Value::Unsigned(2));
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             decode_read_body(&bytes).unwrap_err().check(),
             "invalid-field-length"
@@ -669,7 +676,7 @@ mod tests {
         m.insert("children", Value::Array(vec![]));
         m.insert("createdAt", Value::Unsigned(1));
         m.insert("modifiedAt", Value::Unsigned(2));
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             decode_read_body(&bytes).unwrap_err().check(),
             "missing-field"
@@ -696,7 +703,7 @@ mod tests {
             children: Vec::new(),
             unknown: vec![("kind".to_string(), Value::Text("file".into()))],
         };
-        let bytes = encode_read_body(&body);
+        let bytes = encode_read_body(&body).unwrap();
         let decoded = decode_read_body(&bytes).expect("decodes");
         assert_eq!(
             decoded.kind(),
@@ -733,37 +740,28 @@ mod tests {
         );
     }
 
-    // Unwinding is a native/desktop concern: wasm builds are `panic=abort`, so
-    // a `debug_assert` there aborts the instance rather than unwinding past the
-    // guard — there is no scrub-skipping window to defend on that leg.
-    #[cfg(not(target_arch = "wasm32"))]
     #[test]
-    fn scrub_runs_when_encode_unwinds() {
-        // `write_value`'s `debug_assert!(depth < MAX_DEPTH)` fires in this
-        // (test) build for a tree nested past MAX_DEPTH; the guard's Drop must
-        // still scrub the content-key copy while the stack unwinds out of
-        // `encode`. The secret rides item 0 (written before the panic); the
-        // deep nest that trips the assert rides item 1.
+    fn scrub_runs_when_encode_fails_closed() {
+        // The guard's Drop must wipe the content-key copy on the error return
+        // too, not just the Ok one. The secret rides item 0; the nest that trips
+        // the release-active `MAX_DEPTH` bound rides item 1.
         let mut deep = Value::Null;
-        for _ in 0..=crate::codec::MAX_DEPTH {
+        for _ in 0..crate::codec::MAX_DEPTH {
             deep = Value::Array(vec![deep]);
         }
         let mut value = Value::Array(vec![Value::Bytes(vec![0xab; 32]), deep]);
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let err = {
             let guard = ScrubOnDrop(&mut value);
-            let _ = encode(guard.0);
-        }));
-        assert!(
-            result.is_err(),
-            "encode panics past MAX_DEPTH in test build"
-        );
+            encode(guard.0).unwrap_err()
+        };
+        assert_eq!(err.check(), "depth-exceeded");
 
         let items = value.as_array().unwrap();
         assert_eq!(
             items[0],
             Value::Bytes(Vec::new()),
-            "guard scrubbed the key copy on unwind"
+            "guard scrubbed the key copy on the error return"
         );
     }
 }

--- a/crates/core/src/seal/envelope.rs
+++ b/crates/core/src/seal/envelope.rs
@@ -93,7 +93,7 @@ pub fn has_grant_section(env: &Envelope) -> bool {
 }
 
 /// Encode an envelope to its canonical det-CBOR plaintext.
-pub fn encode_envelope(env: &Envelope) -> Vec<u8> {
+pub fn encode_envelope(env: &Envelope) -> Result<Vec<u8>, CodecError> {
     let mut epoch_tag = Map::new();
     epoch_tag.insert("epoch", Value::Unsigned(env.epoch));
     epoch_tag.insert("scope", Value::Bytes(env.scope.to_vec()));
@@ -129,7 +129,7 @@ pub fn seal_read_body(
     body: &ReadBody,
 ) -> Result<Envelope, CodecError> {
     body.validate()?;
-    let mut plaintext = encode_read_body(body);
+    let mut plaintext = encode_read_body(body)?;
     let ctx = AadContext {
         v,
         id,
@@ -199,7 +199,7 @@ mod tests {
         let env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &body).unwrap();
         assert_eq!(
             env.read_sealed.len(),
-            NONCE_LEN + encode_read_body(&body).len() + 16
+            NONCE_LEN + encode_read_body(&body).unwrap().len() + 16
         );
         let opened = open_read_body(&env, &key).expect("opens");
         assert_eq!(opened, body);
@@ -210,10 +210,10 @@ mod tests {
         let key = [3u8; KEY_LEN];
         let nonce = [4u8; NONCE_LEN];
         let env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &folder()).unwrap();
-        let bytes = encode_envelope(&env);
+        let bytes = encode_envelope(&env).unwrap();
         let decoded = decode_envelope(&bytes).expect("decodes");
         assert_eq!(decoded, env);
-        assert_eq!(encode_envelope(&decoded), bytes, "byte-stable");
+        assert_eq!(encode_envelope(&decoded).unwrap(), bytes, "byte-stable");
     }
 
     #[test]
@@ -249,18 +249,22 @@ mod tests {
         let key = [3u8; KEY_LEN];
         let nonce = [4u8; NONCE_LEN];
         let env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &folder()).unwrap();
-        let mut m = decode(&encode_envelope(&env))
+        let mut m = decode(&encode_envelope(&env).unwrap())
             .unwrap()
             .as_map()
             .unwrap()
             .clone();
         m.insert("writeSealed", Value::Bytes(b"future-write-body".to_vec()));
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
 
         let decoded = decode_envelope(&bytes).expect("tolerant decode");
         assert_eq!(decoded.unknown.len(), 1);
         assert_eq!(decoded.unknown[0].0, "writeSealed");
-        assert_eq!(encode_envelope(&decoded), bytes, "unknown field preserved");
+        assert_eq!(
+            encode_envelope(&decoded).unwrap(),
+            bytes,
+            "unknown field preserved"
+        );
         // The read-body still opens despite the extra field.
         assert!(open_read_body(&decoded, &key).is_ok());
     }
@@ -322,13 +326,13 @@ mod tests {
         let key = [3u8; KEY_LEN];
         let nonce = [4u8; NONCE_LEN];
         let env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &folder()).unwrap();
-        let mut m = decode(&encode_envelope(&env))
+        let mut m = decode(&encode_envelope(&env).unwrap())
             .unwrap()
             .as_map()
             .unwrap()
             .clone();
         m.remove("v");
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             decode_envelope(&bytes).unwrap_err().check(),
             "missing-field"

--- a/crates/core/src/seal/grant.rs
+++ b/crates/core/src/seal/grant.rs
@@ -205,7 +205,7 @@ pub fn decode_grant_blob_payload(bytes: &[u8]) -> Result<GrantBlobPayload, Codec
 ///
 /// The buffer carries seed material verbatim, so its caller is the terminal
 /// owner and must zeroize it after use ([`seal_grant_blob`] does exactly this).
-pub fn encode_grant_blob_payload(payload: &GrantBlobPayload) -> Vec<u8> {
+pub fn encode_grant_blob_payload(payload: &GrantBlobPayload) -> Result<Vec<u8>, CodecError> {
     let mut m = Map::new();
     m.insert("epoch", Value::Unsigned(payload.epoch));
     m.insert(
@@ -237,8 +237,8 @@ pub fn seal_grant_blob(
     ephemeral_scalar: &[u8; 32],
     ctx: &AadContext,
     payload: &GrantBlobPayload,
-) -> HpkeCiphertext {
-    let mut plaintext = encode_grant_blob_payload(payload);
+) -> Result<HpkeCiphertext, CodecError> {
+    let mut plaintext = encode_grant_blob_payload(payload)?;
     let sealed = hpke::hpke_seal(
         recipient_pub,
         ephemeral_scalar,
@@ -247,7 +247,7 @@ pub fn seal_grant_blob(
         &plaintext,
     );
     plaintext.zeroize();
-    sealed
+    Ok(sealed)
 }
 
 /// Open a grant blob with the recipient's encryption subkey secret. Fails closed
@@ -346,7 +346,7 @@ pub fn decode_override_seed_payload(bytes: &[u8]) -> Result<OverrideSeedPayload,
 /// Encode an override-seed payload to its canonical det-CBOR plaintext. The
 /// buffer carries the seed verbatim; its caller is the terminal owner and must
 /// zeroize it (the seal paths do).
-pub fn encode_override_seed_payload(payload: &OverrideSeedPayload) -> Vec<u8> {
+pub fn encode_override_seed_payload(payload: &OverrideSeedPayload) -> Result<Vec<u8>, CodecError> {
     let mut m = Map::new();
     m.insert("epoch", Value::Unsigned(payload.epoch));
     m.insert(
@@ -369,8 +369,8 @@ pub fn seal_owner_blob(
     ephemeral_scalar: &[u8; 32],
     ctx: &AadContext,
     payload: &OverrideSeedPayload,
-) -> HpkeCiphertext {
-    let mut plaintext = encode_override_seed_payload(payload);
+) -> Result<HpkeCiphertext, CodecError> {
+    let mut plaintext = encode_override_seed_payload(payload)?;
     let sealed = hpke::hpke_seal(
         owner_enc_pub,
         ephemeral_scalar,
@@ -379,7 +379,7 @@ pub fn seal_owner_blob(
         &plaintext,
     );
     plaintext.zeroize();
-    sealed
+    Ok(sealed)
 }
 
 /// Open an owner blob with the owner's encryption subkey secret. Fails closed
@@ -485,7 +485,9 @@ pub fn decode_owner_write_blob_payload(bytes: &[u8]) -> Result<OwnerWriteBlobPay
 /// Encode an owner-write-blob payload to its canonical det-CBOR plaintext. The
 /// buffer carries the seed verbatim; its caller is the terminal owner and must
 /// zeroize it ([`seal_owner_write_blob`] does).
-pub fn encode_owner_write_blob_payload(payload: &OwnerWriteBlobPayload) -> Vec<u8> {
+pub fn encode_owner_write_blob_payload(
+    payload: &OwnerWriteBlobPayload,
+) -> Result<Vec<u8>, CodecError> {
     let mut m = Map::new();
     m.insert("writeEpoch", Value::Unsigned(payload.write_epoch));
     m.insert(
@@ -509,8 +511,8 @@ pub fn seal_owner_write_blob(
     ephemeral_scalar: &[u8; 32],
     ctx: &AadContext,
     payload: &OwnerWriteBlobPayload,
-) -> HpkeCiphertext {
-    let mut plaintext = encode_owner_write_blob_payload(payload);
+) -> Result<HpkeCiphertext, CodecError> {
+    let mut plaintext = encode_owner_write_blob_payload(payload)?;
     let sealed = hpke::hpke_seal(
         owner_enc_pub,
         ephemeral_scalar,
@@ -519,7 +521,7 @@ pub fn seal_owner_write_blob(
         &plaintext,
     );
     plaintext.zeroize();
-    sealed
+    Ok(sealed)
 }
 
 /// Open an owner-write-blob with the owner's encryption subkey secret. Fails
@@ -581,7 +583,7 @@ pub fn decode_ascent_link(bytes: &[u8]) -> Result<AscentLink, CodecError> {
 }
 
 /// Encode an ascent-link container to its canonical det-CBOR form.
-pub fn encode_ascent_link(link: &AscentLink) -> Vec<u8> {
+pub fn encode_ascent_link(link: &AscentLink) -> Result<Vec<u8>, CodecError> {
     let mut m = Map::new();
     m.insert("enc", Value::Bytes(link.enc.to_vec()));
     m.insert("ciphertext", Value::Bytes(link.ciphertext.clone()));
@@ -599,10 +601,10 @@ pub fn seal_ascent_link(
     ephemeral_scalar: &[u8; 32],
     ctx: &AadContext,
     payload: &OverrideSeedPayload,
-) -> AscentLink {
+) -> Result<AscentLink, CodecError> {
     let ascent_secret = kdf::ascent_keypair(parent_node_seed);
     let ascent_public = ascent_secret.public();
-    let mut plaintext = encode_override_seed_payload(payload);
+    let mut plaintext = encode_override_seed_payload(payload)?;
     let sealed = hpke::hpke_seal(
         &ascent_public,
         ephemeral_scalar,
@@ -611,12 +613,12 @@ pub fn seal_ascent_link(
         &plaintext,
     );
     plaintext.zeroize();
-    AscentLink {
+    Ok(AscentLink {
         ascent_public: ascent_public.to_bytes(),
         enc: sealed.enc,
         ciphertext: sealed.ciphertext,
         unknown: Vec::new(),
-    }
+    })
 }
 
 /// Open an ascent link as an ancestor reader: re-derive the ascent keypair from
@@ -723,7 +725,7 @@ pub fn decode_history_link_payload(bytes: &[u8]) -> Result<HistoryLinkPayload, C
 /// Encode a history-link payload to its canonical det-CBOR plaintext. The buffer
 /// carries the seed verbatim; its caller is the terminal owner and must zeroize
 /// it ([`seal_history_link`] does).
-pub fn encode_history_link_payload(payload: &HistoryLinkPayload) -> Vec<u8> {
+pub fn encode_history_link_payload(payload: &HistoryLinkPayload) -> Result<Vec<u8>, CodecError> {
     let mut m = Map::new();
     m.insert("prevEpoch", Value::Unsigned(payload.prev_epoch));
     m.insert(
@@ -747,11 +749,11 @@ pub fn seal_history_link(
     nonce: &[u8; crate::suite::aead::NONCE_LEN],
     ctx: &AadContext,
     payload: &HistoryLinkPayload,
-) -> Vec<u8> {
-    let mut plaintext = encode_history_link_payload(payload);
+) -> Result<Vec<u8>, CodecError> {
+    let mut plaintext = encode_history_link_payload(payload)?;
     let sealed = super::seal(key, nonce, ctx, &plaintext);
     plaintext.zeroize();
-    sealed
+    Ok(sealed)
 }
 
 /// Open a history link under the current epoch's structure `key`. Fails closed
@@ -886,7 +888,7 @@ pub fn encode_grant_set_commitment(c: &GrantSetCommitment) -> Result<Vec<u8>, Co
         Value::Bytes(c.owner_pseudonym_pk.to_vec()),
     );
     merge_unknown(&mut m, &c.unknown);
-    Ok(encode(&Value::Map(m)))
+    encode(&Value::Map(m))
 }
 
 /// Owner-sign a grant-set commitment: RFC 6979 ECDSA over the det-CBOR preimage.
@@ -943,10 +945,14 @@ mod tests {
     fn grant_blob_payload_round_trips_read_and_write() {
         for write in [None, Some([0x44; 32])] {
             let payload = GrantBlobPayload::new([0x11; 32], write, 7, [0x22; 32]);
-            let bytes = encode_grant_blob_payload(&payload);
+            let bytes = encode_grant_blob_payload(&payload).unwrap();
             let decoded = decode_grant_blob_payload(&bytes).expect("decodes");
             assert_eq!(decoded, payload);
-            assert_eq!(encode_grant_blob_payload(&decoded), bytes, "byte-stable");
+            assert_eq!(
+                encode_grant_blob_payload(&decoded).unwrap(),
+                bytes,
+                "byte-stable"
+            );
             assert_eq!(decoded.write_scope_seed().is_some(), write.is_some());
         }
     }
@@ -956,7 +962,7 @@ mod tests {
         let recipient = X25519Secret::from_scalar([0x30; 32]);
         let ctx = grant_ctx(super::super::STRUCT_TAG_GRANT_BLOB);
         let payload = GrantBlobPayload::new([0x11; 32], Some([0x44; 32]), 7, [0x22; 32]);
-        let sealed = seal_grant_blob(&recipient.public(), &[0x55; 32], &ctx, &payload);
+        let sealed = seal_grant_blob(&recipient.public(), &[0x55; 32], &ctx, &payload).unwrap();
         let opened = open_grant_blob(&recipient, &sealed.enc, &ctx, &sealed.ciphertext).unwrap();
         assert_eq!(opened, payload);
         // A struct-tag transplant recomputes a different AAD → the tag fails.
@@ -977,7 +983,7 @@ mod tests {
         // must survive intact (terminal-owner rule: never zero a caller's
         // buffer). Ok path: decode returns the exact seeds it read.
         let payload = GrantBlobPayload::new([0x11; 32], Some([0x44; 32]), 7, [0x22; 32]);
-        let bytes = encode_grant_blob_payload(&payload);
+        let bytes = encode_grant_blob_payload(&payload).unwrap();
         let decoded = decode_grant_blob_payload(&bytes).expect("decodes");
         assert_eq!(decoded.read_scope_seed(), &[0x11; 32]);
         assert_eq!(decoded.write_scope_seed(), Some(&[0x44; 32]));
@@ -989,7 +995,7 @@ mod tests {
         let owner = X25519Secret::from_scalar([0x31; 32]);
         let ctx = grant_ctx(super::super::STRUCT_TAG_OWNER_BLOB);
         let payload = OverrideSeedPayload::new([0x77; 32], 4);
-        let sealed = seal_owner_blob(&owner.public(), &[0x56; 32], &ctx, &payload);
+        let sealed = seal_owner_blob(&owner.public(), &[0x56; 32], &ctx, &payload).unwrap();
         let opened = open_owner_blob(&owner, &sealed.enc, &ctx, &sealed.ciphertext).unwrap();
         assert_eq!(opened, payload);
     }
@@ -997,11 +1003,11 @@ mod tests {
     #[test]
     fn owner_write_blob_payload_round_trips_byte_stable() {
         let payload = OwnerWriteBlobPayload::new([0x66; 32], 9);
-        let bytes = encode_owner_write_blob_payload(&payload);
+        let bytes = encode_owner_write_blob_payload(&payload).unwrap();
         let decoded = decode_owner_write_blob_payload(&bytes).expect("decodes");
         assert_eq!(decoded, payload);
         assert_eq!(
-            encode_owner_write_blob_payload(&decoded),
+            encode_owner_write_blob_payload(&decoded).unwrap(),
             bytes,
             "byte-stable"
         );
@@ -1014,7 +1020,7 @@ mod tests {
         // The AAD binds the WRITE epoch (the write plane's own clock).
         let ctx = grant_ctx(super::super::STRUCT_TAG_OWNER_WRITE_BLOB);
         let payload = OwnerWriteBlobPayload::new([0x66; 32], 9);
-        let sealed = seal_owner_write_blob(&owner.public(), &[0x58; 32], &ctx, &payload);
+        let sealed = seal_owner_write_blob(&owner.public(), &[0x58; 32], &ctx, &payload).unwrap();
         let opened = open_owner_write_blob(&owner, &sealed.enc, &ctx, &sealed.ciphertext).unwrap();
         assert_eq!(opened, payload);
         // A struct-tag transplant recomputes a different AAD → the tag fails.
@@ -1042,7 +1048,7 @@ mod tests {
         let parent_seed = [0x12; 32];
         let ctx = grant_ctx(super::super::STRUCT_TAG_ASCENT_LINK);
         let payload = OverrideSeedPayload::new([0x77; 32], 4);
-        let link = seal_ascent_link(&parent_seed, &[0x57; 32], &ctx, &payload);
+        let link = seal_ascent_link(&parent_seed, &[0x57; 32], &ctx, &payload).unwrap();
         // The plaintext public half is exactly the derived ascent public key.
         assert_eq!(
             link.ascent_public,
@@ -1051,10 +1057,10 @@ mod tests {
         let opened = open_ascent_link(&parent_seed, &ctx, &link).unwrap();
         assert_eq!(opened, payload);
         // Container codec is byte-stable.
-        let bytes = encode_ascent_link(&link);
+        let bytes = encode_ascent_link(&link).unwrap();
         assert_eq!(decode_ascent_link(&bytes).unwrap(), link);
         assert_eq!(
-            encode_ascent_link(&decode_ascent_link(&bytes).unwrap()),
+            encode_ascent_link(&decode_ascent_link(&bytes).unwrap()).unwrap(),
             bytes
         );
     }
@@ -1064,7 +1070,7 @@ mod tests {
         let parent_seed = [0x12; 32];
         let ctx = grant_ctx(super::super::STRUCT_TAG_ASCENT_LINK);
         let payload = OverrideSeedPayload::new([0x77; 32], 4);
-        let mut link = seal_ascent_link(&parent_seed, &[0x57; 32], &ctx, &payload);
+        let mut link = seal_ascent_link(&parent_seed, &[0x57; 32], &ctx, &payload).unwrap();
         // Flip the plaintext public half: derive-and-verify rejects it as a
         // mismatch, never reaching the HPKE open.
         link.ascent_public[0] ^= 0x01;
@@ -1075,7 +1081,7 @@ mod tests {
             "ascent-link-mismatch"
         );
         // A different parent seed derives a different keypair → also a mismatch.
-        let link2 = seal_ascent_link(&parent_seed, &[0x57; 32], &ctx, &payload);
+        let link2 = seal_ascent_link(&parent_seed, &[0x57; 32], &ctx, &payload).unwrap();
         assert_eq!(
             open_ascent_link(&[0x13; 32], &ctx, &link2)
                 .unwrap_err()
@@ -1090,7 +1096,7 @@ mod tests {
         let nonce = [0x10; NONCE_LEN];
         let ctx = grant_ctx(super::super::STRUCT_TAG_HISTORY_LINK);
         let payload = HistoryLinkPayload::new([0x99; 32], 3);
-        let sealed = seal_history_link(&key, &nonce, &ctx, &payload);
+        let sealed = seal_history_link(&key, &nonce, &ctx, &payload).unwrap();
         assert_eq!(open_history_link(&key, &ctx, &sealed).unwrap(), payload);
         let mut wrong = ctx;
         wrong.epoch += 1;
@@ -1151,7 +1157,7 @@ mod tests {
         m.insert("entries", Value::Array(vec![Value::Map(a), Value::Map(b)]));
         m.insert("ipnsName", Value::Bytes(b"n".to_vec()));
         m.insert("ownerPseudonymPk", Value::Bytes(vec![0x88; 32]));
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             decode_grant_set_commitment(&bytes).unwrap_err().check(),
             "duplicate-grant-tag"
@@ -1193,7 +1199,7 @@ mod tests {
         m.insert("entries", Value::Array(vec![Value::Map(entry)]));
         m.insert("ipnsName", Value::Bytes(b"n".to_vec()));
         m.insert("ownerPseudonymPk", Value::Bytes(vec![0x88; 32]));
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             decode_grant_set_commitment(&bytes).unwrap_err().check(),
             "invalid-permission"

--- a/crates/core/src/seal/section.rs
+++ b/crates/core/src/seal/section.rs
@@ -373,7 +373,7 @@ pub fn encode_grant_section(section: &GrantSection) -> Result<Vec<u8>, CodecErro
     }
     m.insert("writeBody", section.write_body.to_value());
     merge_unknown(&mut m, &section.unknown);
-    Ok(encode(&Value::Map(m)))
+    encode(&Value::Map(m))
 }
 
 #[cfg(test)]
@@ -509,7 +509,7 @@ mod tests {
         m.insert("historyLinks", Value::Array(Vec::new()));
         m.insert("ownerBlob", section.owner_blob.to_value());
         m.insert("writeBody", section.write_body.to_value());
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             decode_grant_section(&bytes).unwrap_err().check(),
             "duplicate-grant-tag"
@@ -531,7 +531,7 @@ mod tests {
         m.insert("grantBlobs", Value::Array(Vec::new()));
         m.insert("historyLinks", Value::Array(Vec::new()));
         m.insert("writeBody", section.write_body.to_value());
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             decode_grant_section(&bytes).unwrap_err().check(),
             "missing-field"
@@ -556,7 +556,7 @@ mod tests {
         m.insert("historyLinks", Value::Array(Vec::new()));
         m.insert("ownerBlob", Value::Map(owner));
         m.insert("writeBody", section.write_body.to_value());
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             decode_grant_section(&bytes).unwrap_err().check(),
             "invalid-field-length"
@@ -569,7 +569,7 @@ mod tests {
         let bytes = encode_grant_section(&section).unwrap();
         let mut m = decode(&bytes).unwrap().as_map().unwrap().clone();
         m.insert("futureField", Value::Text("keep".into()));
-        let extended = encode(&Value::Map(m));
+        let extended = encode(&Value::Map(m)).unwrap();
         let decoded = decode_grant_section(&extended).expect("tolerant decode");
         assert_eq!(decoded.unknown.len(), 1);
         assert_eq!(

--- a/crates/core/src/seal/structure.rs
+++ b/crates/core/src/seal/structure.rs
@@ -22,7 +22,7 @@
 //! verdicts (a missing or invalid signature is a whole-record trust violation)
 //! is the engine's adoption gate, which composes [`verify_structure`].
 
-use crate::codec::{Map, Value, encode};
+use crate::codec::{Map, Value, encode_fixed_depth};
 use crate::error::{CodecError, TrustViolation};
 use crate::suite::ed25519::{Ed25519Signature, Ed25519Signer, Ed25519Verifier};
 use crate::suite::hash::hash;
@@ -80,7 +80,7 @@ pub fn structure_sig_preimage(input: &StructureSigInput) -> Vec<u8> {
     }
     m.insert("scopeId", Value::Bytes(input.scope_id.to_vec()));
     m.insert("structTag", Value::Unsigned(u64::from(input.struct_tag)));
-    encode(&Value::Map(m))
+    encode_fixed_depth(&Value::Map(m))
 }
 
 /// Sign a structure with the rotator's writer-pseudonym Ed25519 key.

--- a/crates/core/src/seal/write_body.rs
+++ b/crates/core/src/seal/write_body.rs
@@ -243,7 +243,7 @@ pub fn encode_write_body(body: &WriteBody) -> Result<Vec<u8>, CodecError> {
         Value::Bytes(body.write_history_link.clone()),
     );
     merge_unknown(&mut m, &body.unknown);
-    Ok(encode(&Value::Map(m)))
+    encode(&Value::Map(m))
 }
 
 #[cfg(test)]
@@ -297,7 +297,7 @@ mod tests {
         m.insert("directChildScopeIndex", Value::Array(vec![]));
         m.insert("grantLedger", Value::Array(vec![Value::Map(entry)]));
         m.insert("writeHistoryLink", Value::Bytes(vec![]));
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             decode_write_body(&bytes).unwrap_err().check(),
             "invalid-permission"
@@ -315,7 +315,7 @@ mod tests {
         m.insert("directChildScopeIndex", Value::Array(vec![]));
         m.insert("grantLedger", Value::Array(vec![Value::Map(entry)]));
         m.insert("writeHistoryLink", Value::Bytes(vec![]));
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             decode_write_body(&bytes).unwrap_err().check(),
             "invalid-field-length"
@@ -346,7 +346,7 @@ mod tests {
             Value::Array(vec![Value::Map(a), Value::Map(b)]),
         );
         m.insert("writeHistoryLink", Value::Bytes(vec![]));
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             decode_write_body(&bytes).unwrap_err().check(),
             "duplicate-grant-tag"
@@ -358,7 +358,7 @@ mod tests {
         let mut m = Map::new();
         m.insert("directChildScopeIndex", Value::Array(vec![]));
         m.insert("writeHistoryLink", Value::Bytes(vec![]));
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             decode_write_body(&bytes).unwrap_err().check(),
             "missing-field"
@@ -372,7 +372,7 @@ mod tests {
         m.insert("grantLedger", Value::Array(vec![]));
         m.insert("writeHistoryLink", Value::Bytes(vec![]));
         m.insert("futureField", Value::Text("keep".into()));
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         let decoded = decode_write_body(&bytes).expect("tolerant decode");
         assert_eq!(decoded.unknown.len(), 1);
         assert_eq!(

--- a/crates/core/src/suite/contact.rs
+++ b/crates/core/src/suite/contact.rs
@@ -9,7 +9,7 @@
 //! a code whose binding does not verify is rejected as a trust violation, never
 //! imported and never treated as stale.
 
-use crate::codec::{Map, Value, decode, encode};
+use crate::codec::{Map, Value, decode, encode_fixed_depth};
 use crate::error::{CodecError, Malformed, TrustViolation};
 
 use super::ecdsa::{EcdsaSignature, EcdsaSigner, EcdsaVerifier};
@@ -35,7 +35,7 @@ pub fn subkey_binding_preimage(identity_pk: &EcdsaVerifier, enc_subkey: &X25519P
         FIELD_IDENTITY_PK,
         Value::Bytes(identity_pk.to_sec1().to_vec()),
     );
-    encode(&Value::Map(m))
+    encode_fixed_depth(&Value::Map(m))
 }
 
 /// Sign the subkey binding: the identity attests that `enc_subkey` is its
@@ -110,7 +110,7 @@ impl ContactCode {
             FIELD_IDENTITY_PK,
             Value::Bytes(self.identity_pk.to_sec1().to_vec()),
         );
-        encode(&Value::Map(m))
+        encode_fixed_depth(&Value::Map(m))
     }
 }
 

--- a/crates/core/tests/codec_props.rs
+++ b/crates/core/tests/codec_props.rs
@@ -98,10 +98,10 @@ proptest! {
     /// is byte-identical (canonical form is a fixed point).
     #[test]
     fn round_trip(v in arb_value()) {
-        let bytes = encode(&v);
+        let bytes = encode(&v).unwrap();
         let decoded = decode(&bytes).expect("own encoding must decode");
         prop_assert_eq!(&decoded, &v);
-        prop_assert_eq!(encode(&decoded), bytes);
+        prop_assert_eq!(encode(&decoded).unwrap(), bytes);
     }
 
     /// (b) unknown-field tolerance is byte-stable: split a map into known
@@ -110,7 +110,7 @@ proptest! {
     #[test]
     fn unknown_field_round_trip(entries in arb_flagged_entries(0)) {
         let (map, flags) = build_map_and_flags(&entries);
-        let bytes = encode(&Value::Map(map.clone()));
+        let bytes = encode(&Value::Map(map.clone())).unwrap();
         let (known, unknown) =
             decode_map_partial(&bytes, |k| flags.get(k).copied().unwrap_or(false))
                 .expect("canonical map must decode");
@@ -139,7 +139,7 @@ proptest! {
         // The rewritten key must be on the known side.
         flags.insert(target_key.clone(), true);
 
-        let bytes = encode(&Value::Map(map.clone()));
+        let bytes = encode(&Value::Map(map.clone())).unwrap();
         let (mut known, unknown) =
             decode_map_partial(&bytes, |k| flags.get(k).copied().unwrap_or(false))
                 .expect("canonical map must decode");
@@ -148,7 +148,7 @@ proptest! {
 
         let mut full = map;
         full.insert(target_key, replacement);
-        prop_assert_eq!(rewritten, encode(&Value::Map(full)));
+        prop_assert_eq!(rewritten, encode(&Value::Map(full)).unwrap());
     }
 
     /// (d) every single-defect mutation of a canonical encoding rejects
@@ -199,7 +199,7 @@ proptest! {
     /// backing store is freed un-zeroized to strand secret bytes.
     #[test]
     fn encoded_len_matches_emitted_bytes(v in arb_value()) {
-        prop_assert_eq!(encoded_len(&v), encode(&v).len());
+        prop_assert_eq!(encoded_len(&v).unwrap(), encode(&v).unwrap().len());
     }
 
     /// (e) `canonical_key_cmp` is a total order that agrees with bytewise
@@ -229,7 +229,7 @@ proptest! {
         // bytewise-lexicographic order over the full encoded key items.
         prop_assert_eq!(
             canonical_key_cmp(&a, &b),
-            encode(&Value::Text(a.clone())).cmp(&encode(&Value::Text(b.clone())))
+            encode(&Value::Text(a.clone())).unwrap().cmp(&encode(&Value::Text(b.clone())).unwrap())
         );
     }
 }

--- a/crates/core/tests/common/mod.rs
+++ b/crates/core/tests/common/mod.rs
@@ -51,7 +51,7 @@ fn write_text(out: &mut Vec<u8>, s: &str) {
 /// `value` is ever reached.
 pub fn widen_head(value: &Value) -> (Vec<u8>, &'static str) {
     let mut out = vec![0x82, 0x18, 0x00];
-    out.extend_from_slice(&encode(value));
+    out.extend_from_slice(&encode(value).unwrap());
     (out, "non-canonical-uint")
 }
 
@@ -61,7 +61,7 @@ pub fn widen_head(value: &Value) -> (Vec<u8>, &'static str) {
 /// integers but reject with their own check name.
 pub fn widen_length(value: &Value) -> (Vec<u8>, &'static str) {
     let mut out = vec![0x82, 0x78, 0x01, b'x'];
-    out.extend_from_slice(&encode(value));
+    out.extend_from_slice(&encode(value).unwrap());
     (out, "non-canonical-length")
 }
 
@@ -70,7 +70,7 @@ pub fn widen_length(value: &Value) -> (Vec<u8>, &'static str) {
 /// lengths only; rejection fires on the `0x9f` head before any element.
 pub fn indefinite_array(value: &Value) -> (Vec<u8>, &'static str) {
     let mut out = vec![0x9f];
-    out.extend_from_slice(&encode(value));
+    out.extend_from_slice(&encode(value).unwrap());
     out.push(0xff);
     (out, "indefinite-length")
 }
@@ -84,9 +84,9 @@ pub fn swap_map_keys(lo: &str, hi: &str, v1: &Value, v2: &Value) -> (Vec<u8>, &'
     let mut out = Vec::new();
     write_head(&mut out, MAJOR_MAP, 2);
     write_text(&mut out, hi);
-    out.extend_from_slice(&encode(v1));
+    out.extend_from_slice(&encode(v1).unwrap());
     write_text(&mut out, lo);
-    out.extend_from_slice(&encode(v2));
+    out.extend_from_slice(&encode(v2).unwrap());
     (out, "unsorted-map-keys")
 }
 
@@ -97,9 +97,9 @@ pub fn duplicate_key(k: &str, v1: &Value, v2: &Value) -> (Vec<u8>, &'static str)
     let mut out = Vec::new();
     write_head(&mut out, MAJOR_MAP, 2);
     write_text(&mut out, k);
-    out.extend_from_slice(&encode(v1));
+    out.extend_from_slice(&encode(v1).unwrap());
     write_text(&mut out, k);
-    out.extend_from_slice(&encode(v2));
+    out.extend_from_slice(&encode(v2).unwrap());
     (out, "duplicate-map-key")
 }
 
@@ -108,7 +108,7 @@ pub fn duplicate_key(k: &str, v1: &Value, v2: &Value) -> (Vec<u8>, &'static str)
 /// number; rejection fires on the initial byte.
 pub fn wrap_tag(value: &Value) -> (Vec<u8>, &'static str) {
     let mut out = vec![0xc6];
-    out.extend_from_slice(&encode(value));
+    out.extend_from_slice(&encode(value).unwrap());
     (out, "tag-forbidden")
 }
 
@@ -117,14 +117,14 @@ pub fn wrap_tag(value: &Value) -> (Vec<u8>, &'static str) {
 /// are forbidden whatever their width or value.
 pub fn inject_float(value: &Value) -> (Vec<u8>, &'static str) {
     let mut out = vec![0x82, 0xf9, 0x3c, 0x00];
-    out.extend_from_slice(&encode(value));
+    out.extend_from_slice(&encode(value).unwrap());
     (out, "float-forbidden")
 }
 
 /// A canonical item followed by one extra `0x00` byte: decode must consume
 /// the input as exactly one item spanning the whole slice.
 pub fn trailing_junk(value: &Value) -> (Vec<u8>, &'static str) {
-    let mut out = encode(value);
+    let mut out = encode(value).unwrap();
     out.push(0x00);
     (out, "trailing-bytes")
 }
@@ -134,7 +134,7 @@ pub fn trailing_junk(value: &Value) -> (Vec<u8>, &'static str) {
 /// last read short (an empty result — one-byte encodings — still rejects
 /// as truncated at offset 0).
 pub fn truncate(value: &Value) -> (Vec<u8>, &'static str) {
-    let mut out = encode(value);
+    let mut out = encode(value).unwrap();
     out.pop();
     (out, "truncated")
 }

--- a/crates/core/tests/kat_manifest.rs
+++ b/crates/core/tests/kat_manifest.rs
@@ -1449,7 +1449,7 @@ fn accept_vectors_decode_reencode_and_render_diag() {
         let value = decode(&bytes)
             .unwrap_or_else(|e| panic!("accept vector {}: decoder rejected it: {e}", v.name));
         assert_eq!(
-            hex::encode(encode(&value)),
+            hex::encode(encode(&value).unwrap()),
             v.hex,
             "accept vector {}: re-encode must be byte-identical",
             v.name
@@ -1674,7 +1674,7 @@ fn seal_vectors_are_frozen_and_round_trip() {
             let body = decode_read_body(&plaintext)
                 .unwrap_or_else(|e| panic!("seal {}: read-body must decode: {e}", v.name));
             assert_eq!(
-                encode_read_body(&body),
+                encode_read_body(&body).unwrap(),
                 plaintext,
                 "seal {}: read-body stable",
                 v.name
@@ -1775,7 +1775,7 @@ fn read_body_accept_vectors_decode_and_round_trip() {
         let body = decode_read_body(&bytes)
             .unwrap_or_else(|e| panic!("read-body accept {}: rejected: {e}", v.name));
         assert_eq!(
-            hex::encode(encode_read_body(&body)),
+            hex::encode(encode_read_body(&body).unwrap()),
             v.hex,
             "read-body accept {}: re-encode must be byte-identical",
             v.name
@@ -1878,7 +1878,7 @@ fn envelope_accept_vectors_decode_open_and_round_trip() {
         let env = decode_envelope(&bytes)
             .unwrap_or_else(|e| panic!("envelope accept {}: rejected: {e}", v.name));
         assert_eq!(
-            hex::encode(encode_envelope(&env)),
+            hex::encode(encode_envelope(&env).unwrap()),
             v.envelope,
             "envelope accept {}: re-encode must be byte-identical",
             v.name
@@ -1888,7 +1888,7 @@ fn envelope_accept_vectors_decode_open_and_round_trip() {
         let body = open_read_body(&env, &key)
             .unwrap_or_else(|e| panic!("envelope accept {}: open: {e}", v.name));
         assert_eq!(
-            hex::encode(encode_read_body(&body)),
+            hex::encode(encode_read_body(&body).unwrap()),
             v.read_body,
             "envelope accept {}: opened read-body drift",
             v.name
@@ -3324,7 +3324,7 @@ fn ascent_link_accept_vectors_derive_verify_and_open() {
         let link = decode_ascent_link(&container)
             .unwrap_or_else(|e| panic!("ascent accept {}: container decode: {e}", v.name));
         assert_eq!(
-            hex::encode(encode_ascent_link(&link)),
+            hex::encode(encode_ascent_link(&link).unwrap()),
             v.container,
             "ascent accept {}: container re-encode",
             v.name
@@ -3362,7 +3362,7 @@ fn ascent_link_accept_vectors_derive_verify_and_open() {
         let payload = open_ascent_link(&parent_seed, &ctx, &link)
             .unwrap_or_else(|e| panic!("ascent accept {}: open: {e}", v.name));
         assert_eq!(
-            hex::encode(encode_override_seed_payload(&payload)),
+            hex::encode(encode_override_seed_payload(&payload).unwrap()),
             v.plaintext,
             "ascent accept {}: opened plaintext drift",
             v.name

--- a/crates/core/tests/seal_props.rs
+++ b/crates/core/tests/seal_props.rs
@@ -131,10 +131,10 @@ proptest! {
     /// inverse of encode, and re-encoding the decode is byte-identical.
     #[test]
     fn read_body_round_trip(body in arb_read_body()) {
-        let bytes = encode_read_body(&body);
+        let bytes = encode_read_body(&body).unwrap();
         let decoded = decode_read_body(&bytes).expect("own encoding must decode");
         prop_assert_eq!(&decoded, &body);
-        prop_assert_eq!(encode_read_body(&decoded), bytes);
+        prop_assert_eq!(encode_read_body(&decoded).unwrap(), bytes);
     }
 
     /// (b) the envelope codec round-trips byte-stable, and the sealed read-body
@@ -155,10 +155,10 @@ proptest! {
         let env = seal_read_body(&key, &nonce, v, id, scope, epoch, &body)
             .expect("a valid read-body must seal");
         // Envelope codec identity + byte stability.
-        let bytes = encode_envelope(&env);
+        let bytes = encode_envelope(&env).unwrap();
         let decoded = decode_envelope(&bytes).expect("own envelope must decode");
         prop_assert_eq!(&decoded, &env);
-        prop_assert_eq!(encode_envelope(&decoded), bytes);
+        prop_assert_eq!(encode_envelope(&decoded).unwrap(), bytes);
         // The read-body opens back to the original.
         let opened = open_read_body(&decoded, &key).expect("must open under the sealing key");
         prop_assert_eq!(opened, body);

--- a/crates/engine/src/content/dag.rs
+++ b/crates/engine/src/content/dag.rs
@@ -15,7 +15,7 @@
 //! needs; a fan-out/balancing profile is the open edge deferred with the chunk
 //! size (blueprint/engine.md "Open edges").
 
-use cipherbox_core::codec::{Map, Value, decode, encode};
+use cipherbox_core::codec::{Map, Value, decode, encode_fixed_depth};
 use cipherbox_core::content::{
     CONTENT_CID_CODEC, CONTENT_CID_LEN, CONTENT_CID_MULTIHASH, compute_cid,
 };
@@ -121,7 +121,7 @@ pub fn assemble(
     root.insert(CHUNK_SIZE_KEY, Value::Unsigned(profile.chunk_size() as u64));
     root.insert(SIZE_KEY, Value::Unsigned(plaintext_len));
     root.insert(LINKS_KEY, Value::Array(links));
-    let root_block = encode(&Value::Map(root));
+    let root_block = encode_fixed_depth(&Value::Map(root));
     // fail closed: an over-cap root would be unreadable — see DagError::RootTooLarge.
     if root_block.len() > MAX_RESOLVED_RECORD_BYTES {
         return Err(DagError::RootTooLarge {
@@ -229,6 +229,7 @@ mod tests {
     use super::*;
     use crate::content::chunk::{ContentKey, frame_and_seal};
     use crate::testkit::SeededEntropy;
+    use cipherbox_core::codec::encode;
     use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, verify_cid};
     use cipherbox_core::suite::aead::KEY_LEN;
 
@@ -250,7 +251,7 @@ mod tests {
             LINKS_KEY,
             Value::Array(links.iter().cloned().map(Value::Bytes).collect()),
         );
-        encode(&Value::Map(root))
+        encode(&Value::Map(root)).unwrap()
     }
 
     fn invalid_manifest_reason(block: &[u8]) -> &'static str {
@@ -306,7 +307,7 @@ mod tests {
     #[test]
     fn decode_rejects_a_non_root_block_fail_closed() {
         // A valid det-CBOR value that is not the root map shape.
-        let not_a_root = encode(&Value::Unsigned(7));
+        let not_a_root = encode(&Value::Unsigned(7)).unwrap();
         assert!(decode_root(&not_a_root).is_err());
     }
 

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -3199,7 +3199,7 @@ mod tests {
                         .unknown
                         .push(("grantSection".to_string(), Value::Bytes(vec![1, 2, 3])));
                 }
-                let head_block = encode_envelope(&envelope);
+                let head_block = encode_envelope(&envelope).unwrap();
                 let cid = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head_block));
                 (head_block, cid)
             }

--- a/crates/engine/src/grants/accept.rs
+++ b/crates/engine/src/grants/accept.rs
@@ -14,7 +14,7 @@
 
 use core::fmt;
 
-use cipherbox_core::codec::{Map, Value, decode, encode};
+use cipherbox_core::codec::{Map, Value, decode, encode_fixed_depth};
 use cipherbox_core::error::{CodecError, Malformed};
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{AadContext, Permission, STRUCT_TAG_GRANT_BLOB, open_grant_blob};
@@ -62,7 +62,7 @@ impl SharePointer {
             "sharerIdentityPk",
             Value::Bytes(self.sharer_identity_pk.to_vec()),
         );
-        encode(&Value::Map(m))
+        encode_fixed_depth(&Value::Map(m))
     }
 
     /// Decode a share pointer (strict det-CBOR). A missing/mistyped field or an
@@ -568,6 +568,7 @@ fn fixed<const N: usize>(v: &Value, field: &'static str) -> Result<[u8; N], Code
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cipherbox_core::codec::encode;
 
     fn pointer() -> SharePointer {
         SharePointer {
@@ -595,7 +596,7 @@ mod tests {
             .unwrap()
             .clone();
         m.insert("permission", Value::Text("admin".into()));
-        let bytes = encode(&Value::Map(m));
+        let bytes = encode(&Value::Map(m)).unwrap();
         assert_eq!(
             SharePointer::decode(&bytes).unwrap_err().check(),
             "invalid-permission"

--- a/crates/engine/src/grants/contact.rs
+++ b/crates/engine/src/grants/contact.rs
@@ -89,7 +89,7 @@ mod tests {
         let mut map = decode(&good).unwrap().as_map().unwrap().clone();
         let bad_sig = sign_subkey_binding(&forger, &enc());
         map.insert("bindingSig", Value::Bytes(bad_sig.to_compact().to_vec()));
-        let tampered = encode(&Value::Map(map));
+        let tampered = encode(&Value::Map(map)).unwrap();
 
         let err = import_contact(&tampered).unwrap_err();
         assert_eq!(err.check(), "subkey-binding-invalid");

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -135,9 +135,8 @@ pub enum ResealError {
     UnusableRecipientKey,
     /// Entropy acquisition failed; no seal proceeds without fresh randomness.
     Entropy(EntropyError),
-    /// A grant-section structure could not be encoded — a duplicate ledger tag,
-    /// or nesting past the codec's `MAX_DEPTH`. Both are release-active encode
-    /// guards, so a re-seal never emits bytes the decoder refuses.
+    /// A re-sealed structure could not be encoded — a duplicate ledger tag, or
+    /// nesting past the codec's `MAX_DEPTH`.
     Encode(cipherbox_core::error::CodecError),
 }
 
@@ -256,9 +255,9 @@ pub fn reseal_scope_root<E: Entropy>(
         write_seed.zeroize();
         let mut ephemeral = fill::<32, E>(entropy)?;
         let ctx = ctx_for(identity.v, scope_id, read_epoch, STRUCT_TAG_GRANT_BLOB);
-        let sealed = seal_grant_blob(&recipient_pub, &ephemeral, &ctx, &payload)
-            .map_err(ResealError::Encode)?;
+        let sealed = seal_grant_blob(&recipient_pub, &ephemeral, &ctx, &payload);
         ephemeral.zeroize();
+        let sealed = sealed.map_err(ResealError::Encode)?;
         let signature = sign_over(
             STRUCT_TAG_GRANT_BLOB,
             Some(entry.tag),
@@ -280,9 +279,9 @@ pub fn reseal_scope_root<E: Entropy>(
         let payload = OverrideSeedPayload::new(*seeds.override_seed, read_epoch);
         let mut ephemeral = fill::<32, E>(entropy)?;
         let ctx = ctx_for(identity.v, scope_id, read_epoch, STRUCT_TAG_OWNER_BLOB);
-        let sealed = seal_owner_blob(identity.owner_enc_pub, &ephemeral, &ctx, &payload)
-            .map_err(ResealError::Encode)?;
+        let sealed = seal_owner_blob(identity.owner_enc_pub, &ephemeral, &ctx, &payload);
         ephemeral.zeroize();
+        let sealed = sealed.map_err(ResealError::Encode)?;
         let signature = sign_over(STRUCT_TAG_OWNER_BLOB, None, &sealed.ciphertext, read_epoch);
         SignedOwnerBlob {
             enc: sealed.enc,
@@ -306,9 +305,9 @@ pub fn reseal_scope_root<E: Entropy>(
             seeds.write_epoch,
             STRUCT_TAG_OWNER_WRITE_BLOB,
         );
-        let sealed = seal_owner_write_blob(identity.owner_enc_pub, &ephemeral, &ctx, &payload)
-            .map_err(ResealError::Encode)?;
+        let sealed = seal_owner_write_blob(identity.owner_enc_pub, &ephemeral, &ctx, &payload);
         ephemeral.zeroize();
+        let sealed = sealed.map_err(ResealError::Encode)?;
         let signature = sign_over(
             STRUCT_TAG_OWNER_WRITE_BLOB,
             None,
@@ -330,9 +329,9 @@ pub fn reseal_scope_root<E: Entropy>(
             let payload = OverrideSeedPayload::new(*seeds.override_seed, read_epoch);
             let mut ephemeral = fill::<32, E>(entropy)?;
             let ctx = ctx_for(identity.v, scope_id, read_epoch, STRUCT_TAG_ASCENT_LINK);
-            let link = seal_ascent_link(parent_node_seed, &ephemeral, &ctx, &payload)
-                .map_err(ResealError::Encode)?;
+            let link = seal_ascent_link(parent_node_seed, &ephemeral, &ctx, &payload);
             ephemeral.zeroize();
+            let link = link.map_err(ResealError::Encode)?;
             let signature = sign_over(STRUCT_TAG_ASCENT_LINK, None, &link.ciphertext, read_epoch);
             Some(SignedAscentLink {
                 ascent_public: link.ascent_public,

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -135,9 +135,10 @@ pub enum ResealError {
     UnusableRecipientKey,
     /// Entropy acquisition failed; no seal proceeds without fresh randomness.
     Entropy(EntropyError),
-    /// The write-body could not be encoded (a duplicate ledger tag — the
-    /// release-active guard in `encode_write_body`).
-    WriteBodyEncode(cipherbox_core::error::CodecError),
+    /// A grant-section structure could not be encoded — a duplicate ledger tag,
+    /// or nesting past the codec's `MAX_DEPTH`. Both are release-active encode
+    /// guards, so a re-seal never emits bytes the decoder refuses.
+    Encode(cipherbox_core::error::CodecError),
 }
 
 impl core::fmt::Display for ResealError {
@@ -153,7 +154,7 @@ impl core::fmt::Display for ResealError {
                 f.write_str("grant-ledger recipient encryption key is unusable")
             }
             ResealError::Entropy(e) => write!(f, "entropy error: {e}"),
-            ResealError::WriteBodyEncode(e) => write!(f, "write-body encode failed: {}", e.check()),
+            ResealError::Encode(e) => write!(f, "structure encode failed: {}", e.check()),
         }
     }
 }
@@ -168,7 +169,7 @@ impl ResealError {
             ResealError::SignerNotCommitted => "signer-not-committed",
             ResealError::UnusableRecipientKey => "unusable-recipient-key",
             ResealError::Entropy(_) => "entropy-error",
-            ResealError::WriteBodyEncode(_) => "write-body-encode-failed",
+            ResealError::Encode(_) => "structure-encode-failed",
         }
     }
 }
@@ -255,7 +256,8 @@ pub fn reseal_scope_root<E: Entropy>(
         write_seed.zeroize();
         let mut ephemeral = fill::<32, E>(entropy)?;
         let ctx = ctx_for(identity.v, scope_id, read_epoch, STRUCT_TAG_GRANT_BLOB);
-        let sealed = seal_grant_blob(&recipient_pub, &ephemeral, &ctx, &payload);
+        let sealed = seal_grant_blob(&recipient_pub, &ephemeral, &ctx, &payload)
+            .map_err(ResealError::Encode)?;
         ephemeral.zeroize();
         let signature = sign_over(
             STRUCT_TAG_GRANT_BLOB,
@@ -278,7 +280,8 @@ pub fn reseal_scope_root<E: Entropy>(
         let payload = OverrideSeedPayload::new(*seeds.override_seed, read_epoch);
         let mut ephemeral = fill::<32, E>(entropy)?;
         let ctx = ctx_for(identity.v, scope_id, read_epoch, STRUCT_TAG_OWNER_BLOB);
-        let sealed = seal_owner_blob(identity.owner_enc_pub, &ephemeral, &ctx, &payload);
+        let sealed = seal_owner_blob(identity.owner_enc_pub, &ephemeral, &ctx, &payload)
+            .map_err(ResealError::Encode)?;
         ephemeral.zeroize();
         let signature = sign_over(STRUCT_TAG_OWNER_BLOB, None, &sealed.ciphertext, read_epoch);
         SignedOwnerBlob {
@@ -303,7 +306,8 @@ pub fn reseal_scope_root<E: Entropy>(
             seeds.write_epoch,
             STRUCT_TAG_OWNER_WRITE_BLOB,
         );
-        let sealed = seal_owner_write_blob(identity.owner_enc_pub, &ephemeral, &ctx, &payload);
+        let sealed = seal_owner_write_blob(identity.owner_enc_pub, &ephemeral, &ctx, &payload)
+            .map_err(ResealError::Encode)?;
         ephemeral.zeroize();
         let signature = sign_over(
             STRUCT_TAG_OWNER_WRITE_BLOB,
@@ -326,7 +330,8 @@ pub fn reseal_scope_root<E: Entropy>(
             let payload = OverrideSeedPayload::new(*seeds.override_seed, read_epoch);
             let mut ephemeral = fill::<32, E>(entropy)?;
             let ctx = ctx_for(identity.v, scope_id, read_epoch, STRUCT_TAG_ASCENT_LINK);
-            let link = seal_ascent_link(parent_node_seed, &ephemeral, &ctx, &payload);
+            let link = seal_ascent_link(parent_node_seed, &ephemeral, &ctx, &payload)
+                .map_err(ResealError::Encode)?;
             ephemeral.zeroize();
             let signature = sign_over(STRUCT_TAG_ASCENT_LINK, None, &link.ciphertext, read_epoch);
             Some(SignedAscentLink {
@@ -347,7 +352,8 @@ pub fn reseal_scope_root<E: Entropy>(
         let nonce = fill::<{ aead::NONCE_LEN }, E>(entropy)?;
         let ctx = ctx_for(identity.v, scope_id, read_epoch, STRUCT_TAG_HISTORY_LINK);
         let payload = HistoryLinkPayload::new(*prev.seed, prev.epoch);
-        let sealed = seal_history_link(structure_key.as_bytes(), &nonce, &ctx, &payload);
+        let sealed = seal_history_link(structure_key.as_bytes(), &nonce, &ctx, &payload)
+            .map_err(ResealError::Encode)?;
         let signature = sign_over(STRUCT_TAG_HISTORY_LINK, None, &sealed, read_epoch);
         history_links.push(SignedSealed {
             sealed,
@@ -364,7 +370,7 @@ pub fn reseal_scope_root<E: Entropy>(
             direct_child_scope_index: committed.direct_child_scope_index.to_vec(),
             unknown: Vec::new(),
         };
-        let mut plaintext = encode_write_body(&wb).map_err(ResealError::WriteBodyEncode)?;
+        let mut plaintext = encode_write_body(&wb).map_err(ResealError::Encode)?;
         let write_seed = kdf::write_seed(seeds.write_scope_seed, &scope_id);
         let write_key = kdf::write_key(write_seed.as_bytes());
         let nonce = fill::<{ aead::NONCE_LEN }, E>(entropy)?;

--- a/crates/engine/src/testkit/owner_root.rs
+++ b/crates/engine/src/testkit/owner_root.rs
@@ -112,7 +112,8 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         &EPH_OWNER,
         &aad(OWNER_ROOT_EPOCH, STRUCT_TAG_OWNER_BLOB),
         &OverrideSeedPayload::new(OWNER_ROOT_SCOPE_SEED, OWNER_ROOT_EPOCH),
-    );
+    )
+    .unwrap();
     let owner_blob = SignedOwnerBlob {
         signature: sign(STRUCT_TAG_OWNER_BLOB, &sealed_owner.ciphertext),
         enc: sealed_owner.enc,
@@ -145,7 +146,8 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
             &EPH_OWNER_WRITE,
             &aad(write_epoch, STRUCT_TAG_OWNER_WRITE_BLOB),
             &OwnerWriteBlobPayload::new(OWNER_ROOT_WRITE_SCOPE_SEED, write_epoch),
-        );
+        )
+        .unwrap();
         SignedOwnerWriteBlob {
             signature: sign(STRUCT_TAG_OWNER_WRITE_BLOB, &sealed.ciphertext),
             enc: sealed.enc,
@@ -196,7 +198,7 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         Value::Bytes(encode_grant_section(&grant_section).unwrap()),
     ));
 
-    let head_block = encode_envelope(&envelope);
+    let head_block = encode_envelope(&envelope).unwrap();
     let head_cid_str = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head_block));
 
     OwnerRootFixture {

--- a/crates/engine/tests/adoption_gate.rs
+++ b/crates/engine/tests/adoption_gate.rs
@@ -119,7 +119,8 @@ impl Fixture {
             &EPH_OWNER,
             &owner_blob_aad,
             &override_payload,
-        );
+        )
+        .unwrap();
         let owner_blob_ct = owner_blob.ciphertext.clone();
         let owner_blob_enc = owner_blob.enc;
         // Sign a seed-bearing structure's ciphertext with the owner pseudonym —
@@ -177,7 +178,8 @@ impl Fixture {
             &EPH_OWNER,
             &owner_write_aad,
             &owner_write_payload,
-        );
+        )
+        .unwrap();
         let signed_owner_write_blob = SignedOwnerWriteBlob {
             signature: sign(STRUCT_TAG_OWNER_WRITE_BLOB, None, &owner_write.ciphertext),
             enc: owner_write.enc,
@@ -356,7 +358,7 @@ impl Fixture {
         aad: AadContext,
         payload: OverrideSeedPayload,
     ) -> SignedAscentLink {
-        let link = seal_ascent_link(parent_node_seed, &EPH_ASCENT, &aad, &payload);
+        let link = seal_ascent_link(parent_node_seed, &EPH_ASCENT, &aad, &payload).unwrap();
         let input = StructureSigInput::over_ciphertext(
             self.scope_id,
             self.epoch,
@@ -390,7 +392,7 @@ impl Fixture {
     /// that opens but must fail the envelope cross-check.
     fn owner_seed_blob_with_aad(&self, aad: AadContext) -> SeedBlob<'_> {
         let payload = OverrideSeedPayload::new(self.scope_seed, self.epoch);
-        let blob = seal_owner_blob(&self.owner_enc.public(), &EPH_OWNER, &aad, &payload);
+        let blob = seal_owner_blob(&self.owner_enc.public(), &EPH_OWNER, &aad, &payload).unwrap();
         SeedBlob::Owner {
             enc_secret: &self.owner_enc,
             enc: blob.enc,
@@ -408,7 +410,8 @@ impl Fixture {
             &EPH_OWNER,
             &self.owner_blob_aad,
             &payload,
-        );
+        )
+        .unwrap();
         SeedBlob::Owner {
             enc_secret: &self.owner_enc,
             enc: blob.enc,
@@ -437,7 +440,7 @@ fn raw_folder_plaintext(children: Vec<Value>) -> Vec<u8> {
     m.insert("children", Value::Array(children));
     m.insert("createdAt", Value::Unsigned(0));
     m.insert("modifiedAt", Value::Unsigned(0));
-    encode(&Value::Map(m))
+    encode(&Value::Map(m)).unwrap()
 }
 
 fn duplicate_id_plaintext() -> Vec<u8> {
@@ -871,7 +874,8 @@ fn run_floor_scenario(rule: &str) {
                 struct_tag: STRUCT_TAG_GRANT_BLOB,
             };
             let payload = GrantBlobPayload::new(fx.scope_seed, None, 99, [0x7B; 32]);
-            let blob = seal_grant_blob(&fx.owner_enc.public(), &EPH_GRANT, &grant_aad, &payload);
+            let blob =
+                seal_grant_blob(&fx.owner_enc.public(), &EPH_GRANT, &grant_aad, &payload).unwrap();
             let input = StructureSigInput::over_ciphertext(
                 fx.scope_id,
                 fx.epoch,

--- a/crates/engine/tests/grants_mailbox.rs
+++ b/crates/engine/tests/grants_mailbox.rs
@@ -120,7 +120,8 @@ impl GrantFixture {
             &EPH_GRANT,
             &grant_aad,
             &grant_payload,
-        );
+        )
+        .unwrap();
         // Sign a seed-bearing structure's ciphertext with the owner pseudonym.
         let sign = |tag: u8, recipient: Option<[u8; 32]>, ct: &[u8]| -> [u8; 64] {
             let input = StructureSigInput::over_ciphertext(scope_id, epoch, tag, recipient, ct);
@@ -148,7 +149,8 @@ impl GrantFixture {
             &EPH_OWNER,
             &owner_blob_aad,
             &OverrideSeedPayload::new(scope_seed, epoch),
-        );
+        )
+        .unwrap();
         let owner_blob_signed = SignedOwnerBlob {
             enc: owner_blob.enc,
             ciphertext: owner_blob.ciphertext.clone(),
@@ -305,7 +307,8 @@ impl GrantFixture {
             &EPH_GRANT_2,
             &grant_aad,
             &grant_payload,
-        );
+        )
+        .unwrap();
         let grant_blob_signed = SignedGrantBlob {
             tag: self.tag,
             enc: grant_blob.enc,


### PR DESCRIPTION
## What

`write_value`'s recursion limit was `debug_assert!(depth < MAX_DEPTH)` — stripped in release. Two consequences, both named in the issue:

1. A release build had **no** recursion bound on the encode path: a pathologically deep tree stack-overflows instead of failing closed, and a tree past `MAX_DEPTH` encodes to bytes the decoder always rejects. That is exactly the AGENTS.md rule 8 shape.
2. `seal::body::tests::scrub_runs_when_encode_unwinds` depended on that `debug_assert` firing, so `cargo test --release -p cipherbox-core` **failed** on `main`.

Reproduced at `origin/main` before the fix:

```text
test seal::body::tests::scrub_runs_when_encode_unwinds ... FAILED
thread '...' panicked at crates/core/src/seal/body.rs:757:9:
encode panics past MAX_DEPTH in test build
test result: FAILED. 0 passed; 1 failed; 162 filtered out
```

Closes #794

## How

- `check_depth` is release-active and returns `Malformed::DepthExceeded` — the **same** check name the decoder fires, at the **same** boundary (`depth >= MAX_DEPTH`, entered at 0). Neither side counts map keys, so both admit max node depth 127 and reject 128.
- Both encode passes are bounded. `encoded_len` became an accumulator (`count_value`) so it mirrors `write_value` head-for-head including the reported byte offset. This is load-bearing, not redundant: `encoded_len` runs **first** inside `encode`, so bounding only `write_value` would still let a very deep tree overflow the stack in the sizing pass before the write pass could return `Err`. It also means a failing tree never reaches `Vec::with_capacity`, so no secret-bearing buffer is ever allocated on the error path.
- `encode` / `encoded_len` now return `Result`. Encoders that carry caller-supplied `unknown` fields (read-body, envelope, grant blob, override seed, owner-write blob, ascent link, history link) propagate it, as do the `seal_*` wrappers over them.
- Fixed-shape builders use a new `encode_fixed_depth` — AAD and signature preimages, flat block maps, IPNS signed `data`, contact code, DAG root, share pointer. Their nesting is set by the schema (depth ≤ 2), never by input, so `seal`, `build_aad`, `sign_structure`, `sign_subkey_binding`, and the mailbox/pointer/IPNS/contact surfaces stay infallible.
- `write_value`'s own bound stays: it is the only guard on `encode_map_partial`, which calls it directly with no sizing pre-pass.

**No wire change.** `cargo run -p cipherbox-core --example kat_gen` regenerates every vector byte-identically; `git status -- crates/core/kat` is clean. AAD layout, all signature preimages, the structure-tag registry, and the KDF edge catalog are untouched.

The test is now `scrub_runs_when_encode_fails_closed`: it asserts the `ScrubOnDrop` guard wipes the content-key copy on the **error** return. It no longer needs `catch_unwind` or the `#[cfg(not(target_arch = "wasm32"))]` carve-out, so the guard's error-path behavior is now covered on the wasm leg too, which `panic=abort` previously excluded.

## Gates

| Gate | Result |
| --- | --- |
| `cargo test -p cipherbox-core` | 164 + 6 + 2 + 62 + 2 + 5 passed, 0 failed |
| `cargo test --release -p cipherbox-core` | 164 + 6 + 2 + 62 + 2 + 5 passed, 0 failed — the run that was red on `main` |
| `cargo test --workspace --exclude cipherbox-desktop --exclude cipherbox-contract` | all green, 0 failed |
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --exclude cipherbox-desktop --exclude cipherbox-contract --all-targets -- -D warnings` | clean |
| KAT freshness | vectors regenerate byte-identically |
| `cargo test -p cipherbox-core --target wasm32-wasip1` | 162 + 6 + 2 + 62 + 2 + 5 passed |
| `cargo test -p cipherbox-core --target wasm32-unknown-unknown` KAT + property legs | 6 + 2 + 62 + 5 passed |
| `cargo test -p cipherbox-wasm --target wasm32-unknown-unknown` | 7 passed |

End-to-end app verification is not applicable: the slice has no runtime, API, or UI surface — it is codec-internal. The equivalent evidence is the byte-identical KAT regeneration plus the wasm-target legs.

## Review

`/security-review`, `/crypto-privacy-review`, and `/simplify` were run on `origin/main...HEAD`.

Fixed:

- **Zeroization (MEDIUM, crypto review).** The new `?` in `reseal.rs` returned past `ephemeral.zeroize()` at four seal sites, stranding a live HPKE X25519 ephemeral scalar. `fill` returns a bare `[u8; 32]` with no `Drop` wipe, so the wipe is now unconditional: bind, zeroize, then propagate. Structurally unreachable today, and encode fails before `hpke_seal` so the scalar was never used — but it is a rule 7 terminal-owner violation regardless.
- **Comment duplication (simplify).** The symmetry invariant was restated in five doc blocks; it now lives once, at `check_depth`.
- **Doc altitude.** `ResealError::Encode`'s doc said "grant-section structure" but the variant also wraps `encode_write_body`.
- **Test coverage.** The boundary test now also asserts the deepest admissible tree round-trips through `decode`, pinning both halves of the boundary rather than only the reject side.

Rejected, with reasons:

- **"Delete `count_value`, keep `encoded_len` infallible"** (simplify, filed as must-fix). This reintroduces the exact stack overflow the issue is about. `encoded_len` runs to completion before `write_value` starts, so an unbounded sizing pass overflows first on a deep tree and `write_value`'s bound never gets to fire. The two checks guard two different entry points and both are load-bearing.
- **`fill` returning `Zeroizing<[u8; N]>`.** A better structural fix, but it is a pre-existing pattern across the engine and out of this slice's domain.
- **Promoting `encode_read_body`'s uniqueness `debug_assert!` to a release-active `Err`.** Called out deliberately rather than by silence: rule 8 is already satisfied for that invariant because the persist boundary `seal_read_body` calls `body.validate()?` release-actively. It is a different invariant from the depth bound and out of scope here.

Discarded as non-material: `offset` field-semantics nit on the encode side, absence-justifying doc notes on `encode_map_partial` and `RepointObject` (AGENTS.md forbids that comment shape), an untested `check()` string on a variant that was equally untested before the rename, and an off-by-one naming convention difference between two test helpers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codec operations now report encoding failures instead of silently succeeding.
  * Added a fixed-depth encoding option for deterministic serialization of signed and sealed data.
  * Unknown top-level fields are preserved during decode and re-encoding when valid.

* **Bug Fixes**
  * Excessively deep data is now rejected consistently.
  * Improved error propagation across envelope, payload, grant, and sealing operations.
  * Strengthened byte-stability and cryptographic self-checks for encoded data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->