### PR TITLE
test(contract): give the contract suite headroom on the per-IP auth throttle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,6 +648,11 @@ jobs:
       QUOTA_DEFAULT_BYTES: '1024'
       # The client-presented secret must equal the API's TEST_LOGIN_SECRET.
       TEST_LOGIN_SECRET: contract-suite-secret
+      # The whole suite logs in from one IP, so the per-IP auth bucket would
+      # otherwise cap how many tests can exist (#837). Only the test-mode
+      # instance honors it; the production-mode one on 3100 refuses it, which
+      # the suite asserts.
+      THROTTLE_AUTH_LIMIT: '200'
       CONTRACT_API_URL: http://localhost:3000
       CONTRACT_API_PROD_URL: http://localhost:3100
       CONTRACT_TEST_LOGIN_SECRET: contract-suite-secret

--- a/apps/api/src/ops/ops.http.integration.test.ts
+++ b/apps/api/src/ops/ops.http.integration.test.ts
@@ -17,7 +17,7 @@ import { Entropy, SystemEntropy } from '../common/entropy';
 import { fakeConfig } from '../testing/fakes';
 import { createHttpIntegrationApp, HttpIntegrationApp } from '../testing/http-integration-app';
 import { createIntegrationDatabase, IntegrationDatabase } from '../testing/integration-db';
-import { THROTTLE_SURFACES } from './throttling';
+import { resolveAuthLimit } from './throttling';
 
 /**
  * The Ops HTTP surface on a booted app against a throwaway Postgres (#725): the
@@ -62,7 +62,7 @@ describe('ops HTTP surface (real Postgres)', () => {
 
   describe('global throttler with per-surface limits', () => {
     it('returns real 429s on the auth surface once its limit is exhausted', async () => {
-      const limit = THROTTLE_SURFACES.auth.default.limit;
+      const limit = resolveAuthLimit();
       // Invalid bodies on purpose: the guard runs before validation, so within
       // the limit we see 400s, and past it the guard's 429.
       for (let i = 0; i < limit; i += 1) {
@@ -79,7 +79,7 @@ describe('ops HTTP surface (real Postgres)', () => {
     });
 
     it('exempts health and metrics via SkipThrottle', async () => {
-      const beyondLimit = THROTTLE_SURFACES.auth.default.limit + 5;
+      const beyondLimit = resolveAuthLimit() + 5;
       for (let i = 0; i < beyondLimit; i += 1) {
         await request(http()).get('/health').expect(200);
       }

--- a/apps/api/src/ops/throttling.test.ts
+++ b/apps/api/src/ops/throttling.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveAuthLimit } from './throttling';
+
+/**
+ * The per-IP auth limit's test-profile override (#837). The deployed-profile
+ * refusal is the security-relevant half: it is what keeps the knob from being a
+ * way to turn a live rate limit off.
+ */
+describe('resolveAuthLimit', () => {
+  const original = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  it('defaults to the catalog limit', () => {
+    delete process.env.THROTTLE_AUTH_LIMIT;
+    expect(resolveAuthLimit()).toBe(10);
+  });
+
+  it.each(['test', 'development'])('honors THROTTLE_AUTH_LIMIT on the %s profile', (nodeEnv) => {
+    process.env.NODE_ENV = nodeEnv;
+    process.env.THROTTLE_AUTH_LIMIT = '500';
+    expect(resolveAuthLimit()).toBe(500);
+  });
+
+  it.each(['production', 'staging', undefined])(
+    'refuses THROTTLE_AUTH_LIMIT on the deployed profile %s',
+    (nodeEnv) => {
+      if (nodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = nodeEnv;
+      }
+      process.env.THROTTLE_AUTH_LIMIT = '500';
+      expect(resolveAuthLimit()).toBe(10);
+    }
+  );
+
+  it('falls back to the catalog limit on an unusable value', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.THROTTLE_AUTH_LIMIT = 'lots';
+    expect(resolveAuthLimit()).toBe(10);
+  });
+});

--- a/apps/api/src/ops/throttling.ts
+++ b/apps/api/src/ops/throttling.ts
@@ -1,3 +1,34 @@
+import { positiveIntConfig } from '../common/config-int';
+
+/**
+ * The auth surface's per-IP limit; mirrored by the contract suite's
+ * `PRODUCTION_AUTH_LIMIT` (crates/contract/tests/contract.rs).
+ */
+const AUTH_LIMIT = 10;
+
+/**
+ * The undeployed profiles, where the API only ever answers a test harness — the
+ * same pair `AuthController` treats as not needing secure cookies.
+ */
+const TEST_PROFILES = ['test', 'development'];
+
+/**
+ * The effective per-IP auth limit, resolved per request by the throttler guard.
+ *
+ * A whole test suite logs in from ONE IP, so this bucket silently caps how many
+ * tests can exist (#837); `THROTTLE_AUTH_LIMIT` raises it, but ONLY on an
+ * undeployed profile — an allowlist rather than a production denylist, so no
+ * internet-facing deployment can be configured out of a live rate limit. The
+ * env is read directly because the guard resolves this outside Nest's DI graph,
+ * as `account-throttler.guard.ts` already does for the JWT secret.
+ */
+export function resolveAuthLimit(): number {
+  if (!TEST_PROFILES.includes(process.env.NODE_ENV ?? '')) {
+    return AUTH_LIMIT;
+  }
+  return positiveIntConfig(process.env.THROTTLE_AUTH_LIMIT, AUTH_LIMIT);
+}
+
 /**
  * Per-surface rate limits (blueprint/api.md Ops: a working global throttler
  * with per-surface limits — v1's inert decorators are a named defect, so
@@ -8,7 +39,7 @@
  */
 export const THROTTLE_SURFACES = {
   /** Login-shaped endpoints: challenge issuance and credential presentation. */
-  auth: { default: { limit: 10, ttl: 60_000 } },
+  auth: { default: { limit: resolveAuthLimit, ttl: 60_000 } },
   /** Refresh rotation: chattier than login, still bounded. */
   refresh: { default: { limit: 30, ttl: 60_000 } },
   /**

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -4,7 +4,8 @@
 //! Coverage mirrors api.md surface for surface, over the auth/token surface
 //! that exists server-side today (#624): challenge-signature login and account
 //! identity, refresh rotation with reuse detection, test-login environment
-//! gating + deterministic keypair + cross-consistency with identity login,
+//! gating + deterministic keypair + cross-consistency with identity login, the
+//! production block on the test-profile auth-limit override,
 //! SIWE secondary surface, logout revocation, the pin/name registry and quota,
 //! the mailbox lifecycle, and a raw endpoint round-trip.
 //!
@@ -42,6 +43,21 @@ async fn client_seeded_with(base: &str, refresh_token: &[u8]) -> Client {
     ApiClient::new(ReqwestHttp::new(), store, base)
 }
 
+/// Unwrap an auth-surface call, naming the per-IP throttle explicitly on a 429.
+/// One bucket is shared by every login-shaped route, so exhausting it fails
+/// whichever test happens to log in next — which reads as an unrelated auth
+/// failure unless the diagnostic says otherwise (#837).
+fn expect_auth<T>(what: &str, result: Result<T, ApiError>) -> T {
+    match result {
+        Ok(value) => value,
+        Err(ApiError::Status { status: 429, .. }) => panic!(
+            "{what}: the API rate-limited the suite (429) on the per-IP auth bucket. Raise \
+             THROTTLE_AUTH_LIMIT on the API under test."
+        ),
+        Err(error) => panic!("{what}: {error}"),
+    }
+}
+
 /// A fresh account: a new client logged in with a random identity key, which
 /// implicitly creates the account (challenge-signature first login). Every
 /// contract run mints a brand-new account, so fixed name/CID strings below are
@@ -49,10 +65,10 @@ async fn client_seeded_with(base: &str, refresh_token: &[u8]) -> Client {
 /// CI database.
 async fn fresh_account(base: &str) -> Client {
     let client = new_client(base);
-    client
-        .login_identity(&random_identity_signer())
-        .await
-        .expect("identity login creates the account");
+    expect_auth(
+        "identity login creates the account",
+        client.login_identity(&random_identity_signer()).await,
+    );
     client
 }
 
@@ -95,16 +111,16 @@ async fn challenge_signature_login_creates_and_reuses_the_account() {
     let signer = random_identity_signer();
 
     let first = new_client(&base);
-    let outcome = first.login_identity(&signer).await.expect("identity login");
+    let outcome = expect_auth("identity login", first.login_identity(&signer).await);
     assert!(outcome.is_new_user, "a fresh random key creates an account");
     assert!(first.is_authenticated());
 
     // The same identity key is the same account on a second, independent client.
     let second = new_client(&base);
-    let outcome = second
-        .login_identity(&signer)
-        .await
-        .expect("second identity login");
+    let outcome = expect_auth(
+        "second identity login",
+        second.login_identity(&signer).await,
+    );
     assert!(!outcome.is_new_user, "same identity key is one account");
 }
 
@@ -112,10 +128,10 @@ async fn challenge_signature_login_creates_and_reuses_the_account() {
 async fn refresh_rotates_and_reuse_kills_the_family() {
     let base = require_stack!("refresh_rotates_and_reuse_kills_the_family");
     let (client, store) = client_with_store(&base);
-    client
-        .login_identity(&random_identity_signer())
-        .await
-        .expect("login");
+    expect_auth(
+        "login",
+        client.login_identity(&random_identity_signer()).await,
+    );
 
     let original = store
         .load_refresh_token()
@@ -163,10 +179,7 @@ async fn test_login_gates_the_secret_and_derives_a_stable_keypair() {
 
     // The right secret returns a deterministic keypair.
     let client = new_client(&base);
-    let first = client
-        .test_login(handle, &secret)
-        .await
-        .expect("test login");
+    let first = expect_auth("test login", client.test_login(handle, &secret).await);
     assert_eq!(
         first.public_key.len(),
         66,
@@ -174,10 +187,10 @@ async fn test_login_gates_the_secret_and_derives_a_stable_keypair() {
     );
     assert!(client.is_authenticated());
 
-    let again = new_client(&base)
-        .test_login(handle, &secret)
-        .await
-        .expect("second test login");
+    let again = expect_auth(
+        "second test login",
+        new_client(&base).test_login(handle, &secret).await,
+    );
     assert_eq!(first.public_key, again.public_key, "same handle, same key");
     assert_eq!(&*first.private_key, &*again.private_key);
     assert!(!again.is_new_user, "the account already existed");
@@ -186,10 +199,10 @@ async fn test_login_gates_the_secret_and_derives_a_stable_keypair() {
     // challenge-signature login with it lands on the same account.
     let scalar = hex_to_scalar(&first.private_key).expect("valid private key hex");
     let signer = IdentityChallengeSigner::from_scalar(&scalar).expect("valid scalar");
-    let identity = new_client(&base)
-        .login_identity(&signer)
-        .await
-        .expect("identity login with the test key");
+    let identity = expect_auth(
+        "identity login with the test key",
+        new_client(&base).login_identity(&signer).await,
+    );
     assert!(
         !identity.is_new_user,
         "the test-login keypair is the same account as challenge-signature login"
@@ -217,13 +230,57 @@ async fn test_login_is_hard_blocked_in_production() {
     );
 }
 
+/// The catalog's per-IP auth limit — what production gets whatever
+/// `THROTTLE_AUTH_LIMIT` says (`apps/api/src/ops/throttling.ts`).
+const PRODUCTION_AUTH_LIMIT: usize = 10;
+
+/// The test-profile auth-limit override is hard-blocked in production (#837):
+/// the CI job sets `THROTTLE_AUTH_LIMIT` far above the catalog limit for BOTH
+/// instances, so the production-mode one still throttling inside a catalog
+/// window is the live evidence that no configuration widens a real rate limit.
+/// Malformed bodies on purpose: the throttler runs ahead of validation, so the
+/// bucket fills without touching the auth path.
+#[tokio::test]
+async fn production_ignores_the_test_profile_auth_limit_override() {
+    let Some(prod) = prod_api_url() else {
+        eprintln!(
+            "SKIP production_ignores_the_test_profile_auth_limit_override: set \
+             CONTRACT_API_PROD_URL to a production-mode API instance"
+        );
+        return;
+    };
+    let http = ReqwestHttp::new();
+    let mut statuses = Vec::new();
+    for _ in 0..=PRODUCTION_AUTH_LIMIT {
+        let response = http
+            .send(HttpRequest {
+                method: HttpMethod::Post,
+                url: format!("{prod}/auth/challenge"),
+                headers: vec![("content-type".to_owned(), "application/json".to_owned())],
+                body: Some(b"{}".to_vec()),
+            })
+            .await
+            .expect("challenge request");
+        statuses.push(response.status);
+        if response.status == 429 {
+            break;
+        }
+    }
+
+    assert!(
+        statuses.contains(&429),
+        "production throttled none of {} auth requests, so it honored THROTTLE_AUTH_LIMIT: {statuses:?}",
+        PRODUCTION_AUTH_LIMIT + 1
+    );
+}
+
 #[tokio::test]
 async fn siwe_secondary_surface_is_reachable_and_gated() {
     let base = require_stack!("siwe_secondary_surface_is_reachable_and_gated");
     let client = new_client(&base);
 
     // The nonce endpoint issues a fresh nonce.
-    let nonce = client.siwe_challenge().await.expect("siwe nonce");
+    let nonce = expect_auth("siwe nonce", client.siwe_challenge().await);
     assert!(!nonce.nonce.is_empty(), "a nonce is issued");
 
     // A well-formed-but-unlinked SIWE login is refused (the wallet is not
@@ -249,10 +306,10 @@ async fn siwe_secondary_surface_is_reachable_and_gated() {
 async fn logout_revokes_the_refresh_token_server_side() {
     let base = require_stack!("logout_revokes_the_refresh_token_server_side");
     let (client, store) = client_with_store(&base);
-    client
-        .login_identity(&random_identity_signer())
-        .await
-        .expect("login");
+    expect_auth(
+        "login",
+        client.login_identity(&random_identity_signer()).await,
+    );
     let token = store
         .load_refresh_token()
         .await
@@ -396,11 +453,9 @@ async fn union_liveness_is_per_account_and_permissionless() {
 /// authoritative (`advisory: false`) with a positive limit and gate uploads; a
 /// BYO account's quota is advisory (`advisory: true`, quota always allows) and
 /// its bytes bypass the API entirely — so hosted ingress is REFUSED for a BYO
-/// account rather than pinned off an uncounted row. The upload path pins bytes
-/// to the real CI Kubo and is exercised here rather than in dedicated tests so
-/// the shared per-IP login throttle is not tripped by an extra account. The
-/// contract-suite job sets a tiny 1 KiB QUOTA_DEFAULT_BYTES, so a few hundred
-/// bytes straddle the over-quota limit deterministically.
+/// account rather than pinned off an uncounted row. The contract-suite job sets
+/// a tiny 1 KiB QUOTA_DEFAULT_BYTES, so a few hundred bytes straddle the
+/// over-quota limit deterministically.
 #[tokio::test]
 async fn quota_is_hosted_authoritative_and_byo_advisory() {
     let base = require_stack!("quota_is_hosted_authoritative_and_byo_advisory");
@@ -472,14 +527,14 @@ async fn quota_is_hosted_authoritative_and_byo_advisory() {
 // --- mailbox (blueprint/api.md, Mailbox; #827) ------------------------------
 
 /// An account addressable as a mailbox recipient: the client plus its identity
-/// publicKey. Minted through test-login rather than a fresh identity login so
-/// the mailbox tests add no traffic to the per-IP `/auth/login` bucket.
+/// publicKey. Minted through test-login, whose deterministic per-handle keypair
+/// gives each role a stable recipient address.
 async fn addressable_account(base: &str, handle: &str) -> (Client, String) {
     let client = new_client(base);
-    let outcome = client
-        .test_login(handle, &test_login_secret())
-        .await
-        .expect("test login");
+    let outcome = expect_auth(
+        "test login",
+        client.test_login(handle, &test_login_secret()).await,
+    );
     (client, outcome.public_key)
 }
 

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -251,6 +251,7 @@ async fn production_ignores_the_test_profile_auth_limit_override() {
     };
     let http = ReqwestHttp::new();
     let mut statuses = Vec::new();
+    let mut advertised = None;
     for _ in 0..=PRODUCTION_AUTH_LIMIT {
         let response = http
             .send(HttpRequest {
@@ -261,6 +262,13 @@ async fn production_ignores_the_test_profile_auth_limit_override() {
             })
             .await
             .expect("challenge request");
+        if advertised.is_none() {
+            advertised = response
+                .headers
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case("x-ratelimit-limit"))
+                .map(|(_, value)| value.clone());
+        }
         statuses.push(response.status);
         if response.status == 429 {
             break;
@@ -272,6 +280,16 @@ async fn production_ignores_the_test_profile_auth_limit_override() {
         "production throttled none of {} auth requests, so it honored THROTTLE_AUTH_LIMIT: {statuses:?}",
         PRODUCTION_AUTH_LIMIT + 1
     );
+    // Pins the exact boundary, which the 429 alone does not: a production limit
+    // accidentally cut to 1 would still throttle. The throttler emits the header
+    // only on a request it admits, so an already-drained bucket yields none.
+    if let Some(limit) = advertised {
+        assert_eq!(
+            limit,
+            PRODUCTION_AUTH_LIMIT.to_string(),
+            "production advertised a per-IP auth limit other than the catalog's {PRODUCTION_AUTH_LIMIT}"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #837

## Problem

`THROTTLE_SURFACES.auth` is `{ limit: 10, ttl: 60_000 }` per IP, and the contract suite sat at exactly 10/10 on it. One more account-minting test would 429 the whole run, and the failure surfaced as a generic auth error rather than a rate limit. That is a gate that silently caps how many tests can be added to it.

## Fix

The issue's option 1: raise the limit under the test profile only, production limits intact.

- `resolveAuthLimit()` in `apps/api/src/ops/throttling.ts` is now the auth surface's `limit`. `@nestjs/throttler` accepts a `Resolvable<number>`, so the guard calls it per request — which also means a `.env`-supplied value is honored, unlike a decorator-time constant.
- `THROTTLE_AUTH_LIMIT` raises it **only** on an undeployed `NODE_ENV` profile, `test` or `development` — an allowlist, not a production denylist, so neither production nor staging can be configured out of a live rate limit. Parsing goes through the existing `positiveIntConfig` helper, so a garbage, zero, or negative value falls back to the catalog limit of 10.
- Every other surface keeps its plain numeric catalog limit. No production limit changed.

## Test side

- The contract-suite CI job sets `THROTTLE_AUTH_LIMIT=200`. The job env reaches **both** API instances, and the new `production_ignores_the_test_profile_auth_limit_override` test asserts the production-mode instance on 3100 still throttles inside a catalog window — the live regression guard on the security property. It breaks on the first 429, so it is safe to re-run within one throttle window.
- Auth-surface calls in `crates/contract/tests/contract.rs` go through `expect_auth`, which names the bucket explicitly on a 429 instead of panicking with a bare status.
- `apps/api/src/ops/throttling.test.ts` covers the profile allowlist, including `staging` and unset `NODE_ENV`.
- Two now-stale rationale comments that justified working around the bucket were dropped.

## Verification

Local stack: Postgres and Kubo from `docker/docker-compose.yml`, a test-mode API and a production-mode API off the same build.

Baseline, catalog limit 10, no override:

```text
BASELINE limit=10 RUN 1 - test result: ok.     14 passed; 0 failed
BASELINE limit=10 RUN 2 - test result: FAILED.  5 passed; 9 failed
                          throttle-diagnostic panics: 9
```

Run 2 inside the same 60s window fails 9/14 — the zero-headroom cliff — and every failure now reads `... the API rate-limited the suite (429) on the per-IP auth bucket. Raise THROTTLE_AUTH_LIMIT on the API under test.`

With `THROTTLE_AUTH_LIMIT=200`, six consecutive runs inside one throttle window:

```text
RUN 1 @ 13:16:08 - test result: ok. 14 passed; 0 failed
RUN 2 @ 13:16:09 - test result: ok. 14 passed; 0 failed
RUN 3 @ 13:16:09 - test result: ok. 14 passed; 0 failed
RUN 4 @ 13:16:10 - test result: ok. 14 passed; 0 failed
RUN 5 @ 13:16:10 - test result: ok. 14 passed; 0 failed
RUN 6 @ 13:16:10 - test result: ok. 14 passed; 0 failed
```

Effective `X-RateLimit-Limit` on `POST /auth/challenge`, three instances booted from the same build with `THROTTLE_AUTH_LIMIT=200` in env:

```text
NODE_ENV=test        200
NODE_ENV=production   10
NODE_ENV=staging      10
```

Also green: `apps/api` unit suite 162/162, `ops.http.integration.test.ts` 5/5 against real Postgres, `cargo fmt --all --check`, `cargo clippy -p cipherbox-contract --all-targets -- -D warnings`, `eslint`, API typecheck.

## Review gates

`/simplify` and `/security-review` both run against this diff.

Simplify findings folded in: reuse `positiveIntConfig` instead of a hand-rolled parse; restore the module doc block to `THROTTLE_SURFACES`, which the new code had orphaned; drop the parse cases already covered generically by `config-int.test.ts`; soften a comment that overclaimed shared identity with the test-login gate.

The security review returned no HIGH or MEDIUM findings. Its one design note — that a production denylist leaves `staging` inside the permissive branch — is what motivated switching to the undeployed-profile allowlist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication rate limits can be configured for test and development environments.
  * Production environments continue enforcing the standard authentication limit.
* **Bug Fixes**
  * Improved handling and diagnostics when authentication requests are throttled.
  * Health and metrics endpoints remain accessible even when authentication limits are reached.
* **Tests**
  * Expanded coverage for configurable limits, invalid settings, environment behavior, and production throttling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->