### PR TITLE
fix(api): discriminate the two upload 413s and report the gated quota sum

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -553,7 +553,7 @@
             "bearer": []
           }
         ],
-        "summary": "The caller per-account quota: usedBytes (sum over pin rows), limitBytes (override or env default), advisory (BYO)",
+        "summary": "The caller per-account quota: usedBytes is the gated sum the upload gate enforces, pinnedBytes the all-rows sum, limitBytes the override or env default, advisory the BYO flag",
         "tags": [
           "Account"
         ]
@@ -671,7 +671,14 @@
             "description": "Hosted ingress is unavailable for BYO accounts; pin to your own provider"
           },
           "413": {
-            "description": "Upload exceeds the account storage quota or size cap"
+            "description": "Two unrelated causes share this status; discriminate on the body `code`, never on `message`. `UPLOAD_TOO_LARGE`: the body exceeded the transport cap MAX_UPLOAD_BYTES — permanent, so retrying the same body always fails. `QUOTA_EXCEEDED`: the account storage quota gate refused it — transient, so the same body succeeds once space is freed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadTooLargeDto"
+                }
+              }
+            }
           },
           "429": {
             "description": "Upload rate limit exceeded"
@@ -1119,7 +1126,11 @@
         "properties": {
           "usedBytes": {
             "type": "number",
-            "description": "Bytes currently counted against the account (sum over pin rows)"
+            "description": "Bytes gated against the limit: the sum over AUTHORITATIVE (non-advisory) pin rows — the same sum the upload gate enforces, so a client pre-flight and the server refusal agree by construction"
+          },
+          "pinnedBytes": {
+            "type": "number",
+            "description": "Bytes across ALL pin rows, advisory ones included. Reported for BYO usage display only; never gated. Equals usedBytes for an account with no advisory bytes"
           },
           "limitBytes": {
             "type": "number",
@@ -1132,6 +1143,7 @@
         },
         "required": [
           "usedBytes",
+          "pinnedBytes",
           "limitBytes",
           "advisory"
         ]
@@ -1202,6 +1214,39 @@
         "required": [
           "cid",
           "size"
+        ]
+      },
+      "UploadTooLargeDto": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "UPLOAD_TOO_LARGE",
+              "QUOTA_EXCEEDED"
+            ],
+            "description": "The refusal cause"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic; never parse it"
+          },
+          "statusCode": {
+            "type": "number",
+            "description": "The HTTP status code",
+            "example": 413
+          },
+          "error": {
+            "type": "string",
+            "description": "The HTTP status reason phrase",
+            "example": "Payload Too Large"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "statusCode",
+          "error"
         ]
       }
     }

--- a/apps/api/src/app-setup.ts
+++ b/apps/api/src/app-setup.ts
@@ -2,6 +2,7 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
 import cookieParser from 'cookie-parser';
 import type { NextFunction, Request, Response } from 'express';
+import { UPLOAD_TOO_LARGE, uploadTooLargeBody } from './content/upload-error-codes';
 import { verifiedUnexpiredSubjectFromBearer } from './ops/account-throttler.guard';
 
 /** Absolute upload-size cap (coarse DoS guard); the quota gate is the fine one. */
@@ -49,11 +50,9 @@ function rawUploadBody(maxBytes: number) {
       total += chunk.length;
       if (total > maxBytes) {
         aborted = true;
-        res.status(413).json({
-          statusCode: 413,
-          message: `Upload exceeds ${maxBytes} bytes`,
-          error: 'Payload Too Large',
-        });
+        res
+          .status(413)
+          .json(uploadTooLargeBody(UPLOAD_TOO_LARGE, `Upload exceeds ${maxBytes} bytes`));
         return;
       }
       chunks.push(chunk);

--- a/apps/api/src/content/content.controller.ts
+++ b/apps/api/src/content/content.controller.ts
@@ -12,7 +12,8 @@ import { Throttle } from '@nestjs/throttler';
 import { AuthenticatedRequest, JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { THROTTLE_SURFACES } from '../ops/throttling';
 import { ContentService } from './content.service';
-import { UploadResponseDto } from './dto/content.dto';
+import { UploadResponseDto, UploadTooLargeDto } from './dto/content.dto';
+import { QUOTA_EXCEEDED, UPLOAD_TOO_LARGE } from './upload-error-codes';
 
 /**
  * The hosted content ingress surface (blueprint/api.md, Content plane): an
@@ -42,7 +43,14 @@ export class ContentController {
     status: 409,
     description: 'Hosted ingress is unavailable for BYO accounts; pin to your own provider',
   })
-  @ApiResponse({ status: 413, description: 'Upload exceeds the account storage quota or size cap' })
+  @ApiResponse({
+    status: 413,
+    type: UploadTooLargeDto,
+    description:
+      'Two unrelated causes share this status; discriminate on the body `code`, never on `message`. ' +
+      `\`${UPLOAD_TOO_LARGE}\`: the body exceeded the transport cap MAX_UPLOAD_BYTES — permanent, so retrying the same body always fails. ` +
+      `\`${QUOTA_EXCEEDED}\`: the account storage quota gate refused it — transient, so the same body succeeds once space is freed.`,
+  })
   @ApiResponse({ status: 429, description: 'Upload rate limit exceeded' })
   @ApiResponse({ status: 503, description: 'Pin store contended or unavailable; retry shortly' })
   upload(@Req() request: AuthenticatedRequest): Promise<UploadResponseDto> {

--- a/apps/api/src/content/content.http.integration.test.ts
+++ b/apps/api/src/content/content.http.integration.test.ts
@@ -17,6 +17,7 @@ import {
 import { createIntegrationDatabase, IntegrationDatabase } from '../testing/integration-db';
 import { ContentController } from './content.controller';
 import { ContentService } from './content.service';
+import { QUOTA_EXCEEDED, UPLOAD_TOO_LARGE } from './upload-error-codes';
 
 /**
  * The hosted-upload HTTP surface re-homed onto a REAL Postgres (#725): the raw
@@ -159,13 +160,18 @@ describe('content HTTP (real Postgres)', () => {
       expect(pinStore.pinned).toEqual([]);
     });
 
-    it('maps an over-quota upload to 413', async () => {
+    it('maps an over-quota upload to 413 discriminated by code QUOTA_EXCEEDED', async () => {
       const acct = await account({ quotaLimitOverride: '100' });
       await db.dataSource
         .getRepository(PinnedCid)
         .save({ accountId: acct.id, cid: 'baExisting', size: '60', advisory: false });
       // 60 already used + 60 incoming > 100.
-      await post(acct.token).send(Buffer.alloc(60, 1)).expect(413);
+      const res = await post(acct.token).send(Buffer.alloc(60, 1)).expect(413);
+      expect(res.body).toMatchObject({
+        statusCode: 413,
+        error: 'Payload Too Large',
+        code: QUOTA_EXCEEDED,
+      });
       expect(pinStore.pinned).toEqual([]);
     });
 
@@ -227,7 +233,7 @@ describe('content HTTP (real Postgres)', () => {
       return jwt.signAsync({ sub: user.id, publicKey }, { expiresIn });
     }
 
-    it('answers an over-cap authenticated upload with a real 413 JSON body (no connection reset)', async () => {
+    it('answers an over-cap authenticated upload with a real 413 JSON body discriminated by code UPLOAD_TOO_LARGE', async () => {
       const token = await authToken();
       const res = await request(ctx.http)
         .post('/content/upload')
@@ -235,7 +241,11 @@ describe('content HTTP (real Postgres)', () => {
         .set('Content-Type', 'application/octet-stream')
         .send(Buffer.alloc(MAX + 8, 1))
         .expect(413);
-      expect(res.body).toMatchObject({ statusCode: 413, error: 'Payload Too Large' });
+      expect(res.body).toMatchObject({
+        statusCode: 413,
+        error: 'Payload Too Large',
+        code: UPLOAD_TOO_LARGE,
+      });
     });
 
     it('refuses an over-cap UNAUTHENTICATED upload with 401 before buffering (not 413)', async () => {

--- a/apps/api/src/content/content.service.ts
+++ b/apps/api/src/content/content.service.ts
@@ -30,6 +30,7 @@ import {
   resolveLimitBytes,
   sumHostedBytes,
 } from '../registry/quota';
+import { QUOTA_EXCEEDED, uploadTooLargeBody } from './upload-error-codes';
 
 /**
  * Max uploads admitted concurrently to the pin path (`CONTENT_PIN_CONCURRENCY`).
@@ -265,7 +266,9 @@ export class ContentService {
     const used = await sumHostedBytes(pinRepo, accountId);
     const limit = resolveLimitBytes(user.quotaLimitOverride, this.defaultLimitBytes);
     if (exceedsQuota(used, BigInt(size), limit)) {
-      throw new PayloadTooLargeException('Upload exceeds the account storage quota');
+      throw new PayloadTooLargeException(
+        uploadTooLargeBody(QUOTA_EXCEEDED, 'Upload exceeds the account storage quota')
+      );
     }
 
     if (existing) {

--- a/apps/api/src/content/dto/content.dto.ts
+++ b/apps/api/src/content/dto/content.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { QUOTA_EXCEEDED, UPLOAD_TOO_LARGE, UploadTooLargeCode } from '../upload-error-codes';
 
 /**
  * The hosted-upload result (blueprint/api.md, Content plane — Ingress). The
@@ -11,4 +12,19 @@ export class UploadResponseDto {
 
   @ApiProperty({ description: 'The pinned size in bytes' })
   size!: number;
+}
+
+/** The 413 error body; see `upload-error-codes` for what `code` discriminates. */
+export class UploadTooLargeDto {
+  @ApiProperty({ enum: [UPLOAD_TOO_LARGE, QUOTA_EXCEEDED], description: 'The refusal cause' })
+  code!: UploadTooLargeCode;
+
+  @ApiProperty({ description: 'Human-readable diagnostic; never parse it' })
+  message!: string;
+
+  @ApiProperty({ description: 'The HTTP status code', example: 413 })
+  statusCode!: number;
+
+  @ApiProperty({ description: 'The HTTP status reason phrase', example: 'Payload Too Large' })
+  error!: string;
 }

--- a/apps/api/src/content/upload-error-codes.ts
+++ b/apps/api/src/content/upload-error-codes.ts
@@ -1,0 +1,19 @@
+/**
+ * `POST /content/upload` answers 413 for two unrelated causes, so the body
+ * carries a stable `code` a client classifies on instead of parsing `message`
+ * (#842): the transport cap is permanent for the request, the quota gate clears
+ * once the account frees space.
+ */
+export const UPLOAD_TOO_LARGE = 'UPLOAD_TOO_LARGE';
+export const QUOTA_EXCEEDED = 'QUOTA_EXCEEDED';
+
+export type UploadTooLargeCode = typeof UPLOAD_TOO_LARGE | typeof QUOTA_EXCEEDED;
+
+/**
+ * The 413 body both producers emit. Nest stops synthesizing `statusCode`/
+ * `error` as soon as an exception is given an object, so the full envelope is
+ * built here once rather than re-typed at each throw site.
+ */
+export function uploadTooLargeBody(code: UploadTooLargeCode, message: string) {
+  return { statusCode: 413, message, error: 'Payload Too Large', code };
+}

--- a/apps/api/src/registry/account.controller.ts
+++ b/apps/api/src/registry/account.controller.ts
@@ -32,7 +32,7 @@ export class AccountController {
   @Throttle(THROTTLE_SURFACES.account)
   @ApiOperation({
     summary:
-      'The caller per-account quota: usedBytes (sum over pin rows), limitBytes (override or env default), advisory (BYO)',
+      'The caller per-account quota: usedBytes is the gated sum the upload gate enforces, pinnedBytes the all-rows sum, limitBytes the override or env default, advisory the BYO flag',
   })
   @ApiOkResponse({ type: QuotaResponseDto })
   @ApiResponse({ status: 401, description: 'Missing or invalid access token' })

--- a/apps/api/src/registry/dto/registry.dto.ts
+++ b/apps/api/src/registry/dto/registry.dto.ts
@@ -90,8 +90,17 @@ export class RetireResponseDto {
 }
 
 export class QuotaResponseDto {
-  @ApiProperty({ description: 'Bytes currently counted against the account (sum over pin rows)' })
+  @ApiProperty({
+    description:
+      'Bytes gated against the limit: the sum over AUTHORITATIVE (non-advisory) pin rows — the same sum the upload gate enforces, so a client pre-flight and the server refusal agree by construction',
+  })
   usedBytes!: number;
+
+  @ApiProperty({
+    description:
+      'Bytes across ALL pin rows, advisory ones included. Reported for BYO usage display only; never gated. Equals usedBytes for an account with no advisory bytes',
+  })
+  pinnedBytes!: number;
 
   @ApiProperty({ description: 'The account limit: per-account override, else the env default' })
   limitBytes!: number;

--- a/apps/api/src/registry/quota.test.ts
+++ b/apps/api/src/registry/quota.test.ts
@@ -4,54 +4,68 @@ import {
   byteConfigBigInt,
   DEFAULT_QUOTA_BYTES,
   exceedsQuota,
+  quotaSums,
   resolveLimitBytes,
   sumHostedBytes,
-  sumPinnedBytes,
 } from './quota';
 import type { PinnedCid } from './entities/pinned-cid.entity';
 
 /**
- * A minimal QueryBuilder double that records the `andWhere` clauses each sum
- * applies and returns a caller-set raw `used` string, so a test can prove which
- * rows a sum narrows to and that the driver's `numeric` string is read back as
- * an exact BigInt — without a live Postgres.
+ * A minimal QueryBuilder double that records the clauses each sum applies and
+ * returns a caller-set raw row, so a test can prove which rows a sum narrows to
+ * and that the driver's `numeric` string is read back as an exact BigInt —
+ * without a live Postgres.
  */
-function fakeRepo(used: string | undefined) {
+function fakeRepo(row: Record<string, string> | undefined) {
+  const select = vi.fn().mockReturnThis();
   const andWhere = vi.fn().mockReturnThis();
   const qb = {
-    select: vi.fn().mockReturnThis(),
+    select,
+    addSelect: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnThis(),
     andWhere,
-    getRawOne: vi.fn().mockResolvedValue(used === undefined ? undefined : { used }),
+    getRawOne: vi.fn().mockResolvedValue(row),
   };
   const repo = {
     createQueryBuilder: vi.fn().mockReturnValue(qb),
   } as unknown as Repository<PinnedCid>;
-  return { repo, qb, andWhere };
+  return { repo, select, andWhere };
 }
 
-describe('sumPinnedBytes / sumHostedBytes — aggregation scope and BigInt read-back', () => {
-  it('sumPinnedBytes sums ALL rows: no advisory predicate is applied', async () => {
-    const { repo, andWhere } = fakeRepo('42');
-    expect(await sumPinnedBytes(repo, 'acct-1')).toBe(42n);
-    expect(andWhere).not.toHaveBeenCalled();
+describe('quota sums — aggregation scope and BigInt read-back', () => {
+  it('sumHostedBytes narrows to authoritative rows via advisory = false', async () => {
+    const { repo, andWhere } = fakeRepo({ used: '42' });
+    expect(await sumHostedBytes(repo, 'acct-1')).toBe(42n);
+    expect(andWhere).toHaveBeenCalledWith('pin.advisory = false');
   });
 
-  it('sumHostedBytes narrows to authoritative rows via advisory = false', async () => {
-    const { repo, andWhere } = fakeRepo('42');
-    expect(await sumHostedBytes(repo, 'acct-1')).toBe(42n);
-    expect(andWhere).toHaveBeenCalledWith('pin.advisory = :advisory', { advisory: false });
+  it('quotaSums gates on the SAME predicate as sumHostedBytes, in ONE aggregate', async () => {
+    const { repo, select, andWhere } = fakeRepo({ hosted: '42', pinned: '99' });
+    expect(await quotaSums(repo, 'acct-1')).toEqual({ hosted: 42n, pinned: 99n });
+    // The gate predicate rides a FILTER rather than a second query, so the
+    // reported and enforced sums cannot drift apart (#843).
+    expect(select).toHaveBeenCalledWith(
+      'COALESCE(SUM(pin.size) FILTER (WHERE pin.advisory = false), 0)',
+      'hosted'
+    );
+    expect(andWhere).not.toHaveBeenCalled();
   });
 
   it('reads the driver numeric string back as an exact BigInt above 2^53', async () => {
     const huge = ((1n << 53n) + 5n).toString();
-    expect(await sumPinnedBytes(fakeRepo(huge).repo, 'acct-1')).toBe((1n << 53n) + 5n);
-    expect(await sumHostedBytes(fakeRepo(huge).repo, 'acct-1')).toBe((1n << 53n) + 5n);
+    expect(await sumHostedBytes(fakeRepo({ used: huge }).repo, 'acct-1')).toBe((1n << 53n) + 5n);
+    expect(await quotaSums(fakeRepo({ hosted: huge, pinned: huge }).repo, 'acct-1')).toEqual({
+      hosted: (1n << 53n) + 5n,
+      pinned: (1n << 53n) + 5n,
+    });
   });
 
   it('reads an empty account (no row / COALESCE 0) as 0n', async () => {
-    expect(await sumPinnedBytes(fakeRepo(undefined).repo, 'acct-1')).toBe(0n);
-    expect(await sumHostedBytes(fakeRepo('0').repo, 'acct-1')).toBe(0n);
+    expect(await sumHostedBytes(fakeRepo(undefined).repo, 'acct-1')).toBe(0n);
+    expect(await quotaSums(fakeRepo(undefined).repo, 'acct-1')).toEqual({
+      hosted: 0n,
+      pinned: 0n,
+    });
   });
 });
 

--- a/apps/api/src/registry/quota.ts
+++ b/apps/api/src/registry/quota.ts
@@ -27,8 +27,7 @@ export function byteConfigBigInt(raw: unknown, fallback: bigint): bigint {
  * `BigInt(...)` preserves precision that TypeORM's `sum()` — which returns a
  * lossy JS `number` and can only type numeric columns — would drop above 2^53
  * bytes (folded from #677). `COALESCE(..., 0)` makes an empty account read 0.
- * `narrow` optionally restricts the summed rows (e.g. authoritative-only for
- * the quota gate).
+ * `narrow` optionally restricts the summed rows.
  */
 async function sumSizeBytes(
   repo: Repository<PinnedCid>,
@@ -45,25 +44,48 @@ async function sumSizeBytes(
 }
 
 /**
- * Server-side `SUM(size)` over ALL of the account's pin rows — the usage the
- * inventory REPORTS, exact at any magnitude (#677).
+ * The rows the hosted quota counts. Written ONCE and shared by the gate sum and
+ * the reported sum: #843 was two callers disagreeing about which rows count, so
+ * the predicate must not be re-typed per query.
  */
-export function sumPinnedBytes(repo: Repository<PinnedCid>, accountId: string): Promise<bigint> {
-  return sumSizeBytes(repo, accountId);
+const HOSTED_ROWS = 'pin.advisory = false';
+
+/**
+ * The quota-GATE sum: only AUTHORITATIVE hosted rows. BYO/advisory bytes live
+ * on the user's own provider and never count against the hosted quota
+ * (blueprint/api.md, Registry: "Hosted rows are authoritative and gate uploads;
+ * BYO accounts' rows are advisory — quota always allows"), so a hosted upload
+ * must not be 413'd by stale advisory rows an account kept after toggling BYO
+ * off.
+ */
+export function sumHostedBytes(repo: Repository<PinnedCid>, accountId: string): Promise<bigint> {
+  return sumSizeBytes(repo, accountId, (qb) => qb.andWhere(HOSTED_ROWS));
+}
+
+/** The pair `GET /account/quota` reports: the gated sum and the all-rows sum. */
+export interface QuotaSums {
+  /** The GATED sum — the same rows `sumHostedBytes` gives the upload gate. */
+  hosted: bigint;
+  /** Every pin row, advisory included. Informational; never gated. */
+  pinned: bigint;
 }
 
 /**
- * The quota-GATE sum: only AUTHORITATIVE hosted rows (`advisory = false`).
- * BYO/advisory bytes live on the user's own provider and never count against
- * the hosted quota (blueprint/api.md, Registry: "Hosted rows are authoritative
- * and gate uploads; BYO accounts' rows are advisory — quota always allows").
- * Distinct from `sumPinnedBytes` (all rows) because a hosted upload must not be
- * 413'd by stale advisory rows an account kept after toggling BYO off.
+ * Both sums in ONE aggregate: one round trip on a polled endpoint, and one MVCC
+ * snapshot, so `pinned >= hosted` holds by construction rather than by luck of
+ * two interleaved reads.
  */
-export function sumHostedBytes(repo: Repository<PinnedCid>, accountId: string): Promise<bigint> {
-  return sumSizeBytes(repo, accountId, (qb) =>
-    qb.andWhere('pin.advisory = :advisory', { advisory: false })
-  );
+export async function quotaSums(
+  repo: Repository<PinnedCid>,
+  accountId: string
+): Promise<QuotaSums> {
+  const row = await repo
+    .createQueryBuilder('pin')
+    .select(`COALESCE(SUM(pin.size) FILTER (WHERE ${HOSTED_ROWS}), 0)`, 'hosted')
+    .addSelect('COALESCE(SUM(pin.size), 0)', 'pinned')
+    .where('pin.account_id = :accountId', { accountId })
+    .getRawOne<{ hosted: string; pinned: string }>();
+  return { hosted: BigInt(row?.hosted ?? '0'), pinned: BigInt(row?.pinned ?? '0') };
 }
 
 /** The account limit in bytes: the per-account override, else the env default. */

--- a/apps/api/src/registry/registry.http.integration.test.ts
+++ b/apps/api/src/registry/registry.http.integration.test.ts
@@ -205,7 +205,28 @@ describe('registry HTTP surface (real Postgres)', () => {
         .get('/account/quota')
         .set('Authorization', `Bearer ${acct.token}`)
         .expect(200);
-      expect(res.body).toEqual({ usedBytes: 512, limitBytes: 10 * GIB, advisory: false });
+      expect(res.body).toEqual({
+        usedBytes: 512,
+        pinnedBytes: 512,
+        limitBytes: 10 * GIB,
+        advisory: false,
+      });
+    });
+
+    it('reports usedBytes as the GATED sum when advisory rows are present, pinnedBytes as all rows', async () => {
+      const acct = await account();
+      const pins = db.dataSource.getRepository(PinnedCid);
+      await pins.save({ accountId: acct.id, cid: 'bafyHostedQ', size: '512', advisory: false });
+      await pins.save({ accountId: acct.id, cid: 'bafyAdvisoryQ', size: '9000', advisory: true });
+
+      const res = await request(http())
+        .get('/account/quota')
+        .set('Authorization', `Bearer ${acct.token}`)
+        .expect(200);
+
+      // 512 is what the upload gate would enforce; the advisory 9000 is not.
+      expect(res.body.usedBytes).toBe(512);
+      expect(res.body.pinnedBytes).toBe(9512);
     });
 
     it('flips advisory once the account enables BYO', async () => {

--- a/apps/api/src/registry/services/registry.service.test.ts
+++ b/apps/api/src/registry/services/registry.service.test.ts
@@ -61,21 +61,32 @@ class InAwareRepository<T extends { id: string }> extends FakeRepository<T> {
     return super.save(entities);
   }
 
-  /** Emulates the `COALESCE(SUM(size), 0)` aggregate `sumPinnedBytes` runs, keyed by accountId. */
+  /**
+   * Emulates the account-scoped `COALESCE(SUM(size), 0)` aggregates in
+   * `quota.ts`, serving every alias they select: `used`/`hosted` narrow to
+   * authoritative rows, `pinned` counts all of them.
+   */
   createQueryBuilder(_alias?: string): SumQueryBuilder {
     const allRows = this.rows;
     let accountId: string | undefined;
     const qb: SumQueryBuilder = {
       select: () => qb,
+      addSelect: () => qb,
       where: (_clause, params) => {
         accountId = params?.accountId as string | undefined;
         return qb;
       },
+      andWhere: () => qb,
       getRawOne: async () => {
-        const used = allRows
-          .filter((row) => (row as { accountId?: string }).accountId === accountId)
-          .reduce((total, row) => total + BigInt((row as { size?: string }).size ?? '0'), 0n);
-        return { used: used.toString() };
+        const sum = (rows: T[]): string =>
+          rows
+            .reduce((total, row) => total + BigInt((row as { size?: string }).size ?? '0'), 0n)
+            .toString();
+        const mine = allRows.filter(
+          (row) => (row as { accountId?: string }).accountId === accountId
+        );
+        const hosted = sum(mine.filter((row) => !(row as { advisory?: boolean }).advisory));
+        return { used: hosted, hosted, pinned: sum(mine) };
       },
     };
     return qb;
@@ -84,8 +95,10 @@ class InAwareRepository<T extends { id: string }> extends FakeRepository<T> {
 
 interface SumQueryBuilder {
   select: (selection: string, alias: string) => SumQueryBuilder;
+  addSelect: (selection: string, alias: string) => SumQueryBuilder;
   where: (clause: string, params?: Record<string, unknown>) => SumQueryBuilder;
-  getRawOne: () => Promise<{ used: string }>;
+  andWhere: (clause: string, params?: Record<string, unknown>) => SumQueryBuilder;
+  getRawOne: () => Promise<{ used: string; hosted: string; pinned: string }>;
 }
 
 /**
@@ -351,7 +364,27 @@ describe('RegistryService', () => {
       await seedPin(acct, 'bafy2', 250);
 
       const quota = await service.quota(acct);
-      expect(quota).toEqual({ usedBytes: 350, limitBytes: 2 * GIB, advisory: false });
+      expect(quota).toEqual({
+        usedBytes: 350,
+        pinnedBytes: 350,
+        limitBytes: 2 * GIB,
+        advisory: false,
+      });
+    });
+
+    it('reports usedBytes as the GATED sum, excluding advisory rows pinnedBytes still counts', async () => {
+      const acct = await account();
+      await seedPin(acct, 'bafyHosted', 100);
+      await pins.save({
+        accountId: acct,
+        cid: 'bafyAdvisory',
+        size: '900',
+        advisory: true,
+      } as never);
+
+      const quota = await service.quota(acct);
+      expect(quota.usedBytes).toBe(100);
+      expect(quota.pinnedBytes).toBe(1000);
     });
 
     it('counts only the account own rows, never another account bytes', async () => {

--- a/apps/api/src/registry/services/registry.service.ts
+++ b/apps/api/src/registry/services/registry.service.ts
@@ -14,7 +14,7 @@ import {
 import { NameInventory } from '../entities/name-inventory.entity';
 import { PinnedCid } from '../entities/pinned-cid.entity';
 import { PinStore } from '../pin-store';
-import { byteConfigBigInt, DEFAULT_QUOTA_BYTES, resolveLimitBytes, sumPinnedBytes } from '../quota';
+import { byteConfigBigInt, DEFAULT_QUOTA_BYTES, quotaSums, resolveLimitBytes } from '../quota';
 
 /**
  * Serialize every refcount/inventory mutation for each token by taking a
@@ -51,6 +51,7 @@ export interface RetireResult {
 
 export interface QuotaResult {
   usedBytes: number;
+  pinnedBytes: number;
   limitBytes: number;
   advisory: boolean;
 }
@@ -274,11 +275,12 @@ export class RegistryService {
   }
 
   /**
-   * The per-account quota (blueprint/api.md). `usedBytes` is the sum over the
-   * account's pin rows; `limitBytes` is the per-account override, else the env
-   * default. Hosted accounts are authoritative (`advisory: false`, the sum
-   * gates uploads); a BYO account's rows are advisory (`advisory: true`, quota
-   * always allows) — the bytes live on the user's own provider.
+   * The per-account quota (blueprint/api.md). `usedBytes` is the GATED sum the
+   * upload gate itself enforces, so a client pre-flight and a server refusal
+   * read one number by construction (#843); `pinnedBytes` is the all-rows sum,
+   * informational only. `limitBytes` is the per-account override, else the env
+   * default. A BYO account's rows are advisory (`advisory: true`, quota always
+   * allows) — the bytes live on the user's own provider.
    */
   async quota(accountId: string): Promise<QuotaResult> {
     const user = await this.userRepository.findOne({ where: { id: accountId } });
@@ -288,11 +290,12 @@ export class RegistryService {
 
     // Compute in BigInt (exact above 2^53) and narrow to the wire number at the
     // edge; the DTO is a JSON number, but the gate math never rounds (#677).
-    const used = await sumPinnedBytes(this.pinRepository, accountId);
+    const sums = await quotaSums(this.pinRepository, accountId);
     const limit = resolveLimitBytes(user.quotaLimitOverride, this.defaultLimitBytes);
 
     return {
-      usedBytes: Number(used),
+      usedBytes: Number(sums.hosted),
+      pinnedBytes: Number(sums.pinned),
       limitBytes: Number(limit),
       advisory: user.byo,
     };


### PR DESCRIPTION
Closes #842
Closes #843

Two adjacent API-side quota/error-reporting defects, shipped together because they touch the same `apps/api` surface.

## #842 — the two upload 413s are now distinguishable

`POST /content/upload` refuses with 413 for two unrelated reasons and a client had nothing but prose to tell them apart:

- the transport cap `MAX_UPLOAD_BYTES` (`apps/api/src/app-setup.ts`) — permanent for the request
- the quota gate (`apps/api/src/content/content.service.ts`) — transient, clears when the account frees space

Both bodies now carry a stable `code`: `UPLOAD_TOO_LARGE` and `QUOTA_EXCEEDED`. The envelope is built once by `uploadTooLargeBody` in the new `apps/api/src/content/upload-error-codes.ts`, so the two producers cannot drift — Nest stops synthesizing `statusCode`/`error` the moment an exception is given an object, which is the trap that made the middleware and the service body diverge in the first place.

The OpenAPI 413 now documents each cause and its retry semantics separately, and types the body as `UploadTooLargeDto` with `code` as an enum.

## #843 — the quota endpoint reports the number the gate enforces

`GET /account/quota` reported `sumPinnedBytes` (all pin rows) while the upload gate enforced `sumHostedBytes` (`advisory = false` rows only). The endpoint now reports the gated sum as `usedBytes`, and exposes the all-rows sum as a new `pinnedBytes` field for BYO usage display.

Both sums come from one `quotaSums` aggregate with a shared `HOSTED_ROWS` predicate constant:

- one round trip on an endpoint the desktop statfs path polls, where the old code would have needed two
- one MVCC snapshot, so `pinnedBytes >= usedBytes` holds by construction
- the gate predicate is written once and used by both `sumHostedBytes` and the reported sum, so a future edit cannot reintroduce the divergence

`sumPinnedBytes` had no other caller and is retired.

## Coverage

- `content.http.integration.test.ts` — the quota 413 asserts `code: QUOTA_EXCEEDED`, the transport-cap 413 asserts `code: UPLOAD_TOO_LARGE`; both against the real app on real Postgres
- `registry.http.integration.test.ts` — an account with an advisory row present reports the gated `usedBytes` and the all-rows `pinnedBytes`
- `quota.test.ts` — `quotaSums` gates on the same predicate as `sumHostedBytes`, in one statement
- `registry.service.test.ts` — `usedBytes` excludes advisory rows that `pinnedBytes` still counts

## Test results

- `pnpm --filter @cipherbox/api test` — 21 files, 156 passed
- `pnpm --filter @cipherbox/api test:integration` — 13 files, 129 passed
- `cargo test -p cipherbox-contract` against a live local stack — 13 passed, 0 failed
- `pnpm exec eslint apps/api/src` — clean; `tsc --noEmit` — clean
- `apps/api/openapi.json` regenerated

## Review gates

`/simplify` and `/security-review` both run against this diff. Simplify findings folded in: the single-aggregate quota query, the shared 413 body builder, a self-referential test assertion removed, and duplicated rationale prose cut back to one home per invariant. Security review returned no CRITICAL/HIGH/MEDIUM findings; its two INFO notes were the shared-predicate hardening, which is applied, and the observation that `pinnedBytes` cannot diverge from `usedBytes` under today's writers — which is exactly the latent-not-live framing in #843.

## Deliberately out of scope

No Rust changed. `crates/engine`'s `ApiError::Status` still carries only `status` and `message`, so the Rust client cannot yet read `code` — threading it through and acting on the classification is the drain-valve work tracked in #841, not this PR. `Quota` has no `deny_unknown_fields`, so the added `pinnedBytes` deserializes harmlessly today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quota responses now include separate `usedBytes` and `pinnedBytes` values, clearly distinguishing enforced usage from informational totals.
  * Upload refusals now return structured JSON with a code identifying whether the file exceeded the upload limit or account quota.
* **Documentation**
  * API documentation now describes quota calculations and both upload refusal causes.
* **Bug Fixes**
  * Quota calculations consistently exclude advisory entries from enforced usage while retaining them in informational totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->