### PR TITLE
fix: merge the root re-projection and project the version count

### DIFF
--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -90,6 +90,21 @@ pub enum NodeKind {
     Folder,
 }
 
+/// What the op queue holds for a node, strongest class first: a queued content
+/// write outranks a queued metadata mutation. The variant order **is** the rank
+/// (a node with both queued reports `Content`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum PendingClass {
+    /// No queued op targets the node.
+    #[default]
+    None,
+    /// A queued op mutates only the node's metadata (create without content,
+    /// rename, relink, delete).
+    Metadata,
+    /// A queued op writes new content bytes for the node.
+    Content,
+}
+
 /// A node's host-facing attributes, projected from the rendered view for a
 /// FUSE getattr/readdir. Kind-uniform metadata only — content size and
 /// timestamps land with the content-plane slice.
@@ -101,8 +116,8 @@ pub struct NodeAttrs {
     pub name: String,
     /// File or folder.
     pub kind: NodeKind,
-    /// Current content version (bumped per `updateContent`).
-    pub content_version: u64,
+    /// Retained version count, `None` until projected.
+    pub content_version: Option<u64>,
 }
 
 /// Minimal filesystem-level counters for a FUSE statfs. Node count only:
@@ -137,12 +152,12 @@ pub struct SnapshotChild {
     pub size: Option<u64>,
     /// Modification time (Unix millis), once projected.
     pub mtime: Option<u64>,
-    /// Whether a queued pending op targets this node.
-    pub pending: bool,
+    /// What the op queue holds for this node.
+    pub pending: PendingClass,
     /// Whether a retained dead-lettered op maps to this node.
     pub dead_letter: bool,
-    /// Current content version (bumped per `updateContent`).
-    pub content_version: u64,
+    /// Retained version count, `None` until projected.
+    pub content_version: Option<u64>,
 }
 
 /// A key-free snapshot of one folder for a host UI paint: its children, its
@@ -1318,7 +1333,11 @@ impl<T: SeamTypes> Engine<T> {
         if meta.kind != NodeKind::Folder {
             return Err(EngineError::NotAFolder);
         }
-        let pending: BTreeSet<NodeId> = ops.iter().map(|op| op.target).collect();
+        let mut pending: BTreeMap<NodeId, PendingClass> = BTreeMap::new();
+        for op in &ops {
+            let slot = pending.entry(op.target).or_default();
+            *slot = (*slot).max(op.pending_class());
+        }
         let dead = self.dead_letters.borrow();
         let dead_nodes: BTreeSet<NodeId> = dead.values().flatten().copied().collect();
         let children = rendered
@@ -1330,7 +1349,7 @@ impl<T: SeamTypes> Engine<T> {
                 kind: child.kind,
                 size: child.size,
                 mtime: child.mtime,
-                pending: pending.contains(&child.id),
+                pending: pending.get(&child.id).copied().unwrap_or_default(),
                 dead_letter: dead_nodes.contains(&child.id),
                 content_version: child.content_version,
             })
@@ -1379,11 +1398,17 @@ impl<T: SeamTypes> Engine<T> {
         }
         self.emit_op_progress(node, OpPhase::DownloadStarted, None);
         match self.read_content_inner(node).await {
-            Ok((plaintext, size, modified_at)) => {
+            Ok((plaintext, size, modified_at, version_count)) => {
                 // The verified head version is gate-passing state, so it may
                 // legally touch the base node's projected size/mtime. Repaint
                 // only on a real change — a repeat read must not cascade.
-                if project_child_version(&mut self.snapshot.borrow_mut(), node, size, modified_at) {
+                if project_child_version(
+                    &mut self.snapshot.borrow_mut(),
+                    node,
+                    size,
+                    modified_at,
+                    version_count,
+                ) {
                     let _ = self.events.unbounded_send(Event::SnapshotUpdated);
                 }
                 self.emit_op_progress(node, OpPhase::DownloadCompleted, None);
@@ -1400,8 +1425,11 @@ impl<T: SeamTypes> Engine<T> {
     /// base-snapshot lookup → gated child resolve →
     /// [`open_content`] (version-DAG fetch, per-leaf unseal, length
     /// cross-checks). Returns the plaintext plus the head version's
-    /// `(size, modifiedAt)`.
-    async fn read_content_inner(&self, node: NodeId) -> Result<(Vec<u8>, u64, u64), EngineError> {
+    /// `(size, modifiedAt)` and the body's version count.
+    async fn read_content_inner(
+        &self,
+        node: NodeId,
+    ) -> Result<(Vec<u8>, u64, u64, u64), EngineError> {
         // The base snapshot alone answers the lookup (kind and ipnsName never
         // come from the overlay) — no full render for a single node. The borrow
         // never spans an await.
@@ -1515,7 +1543,12 @@ impl<T: SeamTypes> Engine<T> {
                 OpenError::Trust(message) => EngineError::TrustViolation { message },
                 OpenError::Unavailable(message) => EngineError::ContentUnavailable { message },
             })?;
-        Ok((plaintext, version.size, version.modified_at))
+        Ok((
+            plaintext,
+            version.size,
+            version.modified_at,
+            versions.len() as u64,
+        ))
     }
 
     /// Best-effort [`Event::OpProgress`] emission (a dropped receiver is fine).
@@ -2139,7 +2172,7 @@ mod tests {
             let view = block_on(engine.snapshot(root)).unwrap();
             assert_eq!(view.root, root);
             assert_eq!(view.folder, root);
-            let by: Vec<(NodeId, &str, NodeKind, bool, u64)> = view
+            let by: Vec<(NodeId, &str, NodeKind, PendingClass, Option<u64>)> = view
                 .children
                 .iter()
                 .map(|c| (c.id, c.name.as_str(), c.kind, c.pending, c.content_version))
@@ -2147,10 +2180,22 @@ mod tests {
             assert_eq!(
                 by,
                 vec![
-                    (NodeId([1; 16]), "a", NodeKind::Folder, false, 0),
-                    (NodeId([2; 16]), "b.txt", NodeKind::File, false, 0),
+                    (
+                        NodeId([1; 16]),
+                        "a",
+                        NodeKind::Folder,
+                        PendingClass::None,
+                        None
+                    ),
+                    (
+                        NodeId([2; 16]),
+                        "b.txt",
+                        NodeKind::File,
+                        PendingClass::None,
+                        None
+                    ),
                 ],
-                "base children render id-sorted, none pending"
+                "base children render id-sorted, none pending, no version count"
             );
             assert!(view.children.iter().all(|c| !c.dead_letter));
             assert!(view.dead_letters.is_empty());
@@ -2158,7 +2203,7 @@ mod tests {
         }
 
         #[test]
-        fn staged_create_appears_with_pending_true() {
+        fn staged_create_appears_pending_as_a_metadata_op() {
             let (mut engine, _events) = started();
             let root = engine.root();
             create(&mut engine, root, "notes.txt", NodeKind::File);
@@ -2166,11 +2211,31 @@ mod tests {
             let view = block_on(engine.snapshot(root)).unwrap();
             assert_eq!(view.children.len(), 1);
             assert_eq!(view.children[0].name, "notes.txt");
-            assert!(
+            assert_eq!(
                 view.children[0].pending,
-                "a queued op targeting the node flags it pending"
+                PendingClass::Metadata,
+                "a contentless create queues a metadata mutation"
             );
             assert!(!view.children[0].dead_letter);
+        }
+
+        #[test]
+        fn a_queued_content_write_outranks_a_queued_metadata_op() {
+            let (mut engine, _events) = started();
+            let root = engine.root();
+            create(&mut engine, root, "notes.txt", NodeKind::File);
+            let node = block_on(engine.snapshot(root)).unwrap().children[0].id;
+
+            block_on(stage_op(
+                &engine.seams.staging_store,
+                &engine.profile,
+                &Op::update_content(node, b"staged".to_vec(), 1),
+                Some(b"bytes"),
+            ))
+            .unwrap();
+
+            let view = block_on(engine.snapshot(root)).unwrap();
+            assert_eq!(view.children[0].pending, PendingClass::Content);
         }
 
         #[test]

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -334,11 +334,11 @@ where
 }
 
 /// Fold a completed resolve's verdict into the shared base cell. A gate-passing
-/// `Adopted` re-projects (`project_root`) and replaces the base, returning true
-/// (the caller emits `SnapshotUpdated`); `Current`/`NoUpdate`/`TrustViolation`
-/// leave last-known-good intact and return false. Non-await by construction — the
-/// short `borrow_mut` never spans an `.await` (facade single-threaded executor
-/// rule).
+/// `Adopted` re-projects ([`project_root`], merging over the current base) and
+/// installs the result, returning true (the caller emits `SnapshotUpdated`);
+/// `Current`/`NoUpdate`/`TrustViolation` leave last-known-good intact and return
+/// false. Non-await by construction — the short borrows never span an `.await`
+/// (facade single-threaded executor rule).
 pub(crate) fn refresh_base_from_outcome(
     base: &RefCell<Snapshot>,
     root: NodeId,
@@ -346,7 +346,8 @@ pub(crate) fn refresh_base_from_outcome(
 ) -> bool {
     match outcome {
         ResolveOutcome::Adopted(adopted) => {
-            *base.borrow_mut() = project_root(root, adopted);
+            let projected = project_root(root, adopted, &base.borrow());
+            *base.borrow_mut() = projected;
             true
         }
         _ => false,
@@ -979,6 +980,7 @@ mod tests {
         use crate::gate::Adopted;
         use crate::sync::model::Snapshot;
         use crate::sync::overlay::apply_overlay;
+        use crate::sync::project::project_child_version;
 
         fn adopted_with_one_child(child_id: [u8; 16]) -> Adopted {
             Adopted {
@@ -1017,6 +1019,43 @@ mod tests {
             let children = rendered.children(root);
             assert_eq!(children.len(), 1, "the newer child is projected under root");
             assert_eq!(children[0].id, NodeId(child_id));
+        }
+
+        #[test]
+        fn a_root_advance_keeps_the_values_the_root_body_cannot_express() {
+            let root = NodeId([0u8; 16]);
+            let child_id = [7u8; 16];
+            let cell = RefCell::new(Snapshot::new(root));
+
+            assert!(refresh_base_from_outcome(
+                &cell,
+                root,
+                &ResolveOutcome::Adopted(adopted_with_one_child(child_id)),
+            ));
+            // A verified head-version read folds the child's plaintext facts in.
+            assert!(project_child_version(
+                &mut cell.borrow_mut(),
+                NodeId(child_id),
+                4_096,
+                1_700,
+                2,
+            ));
+
+            assert!(refresh_base_from_outcome(
+                &cell,
+                root,
+                &ResolveOutcome::Adopted(adopted_with_one_child(child_id)),
+            ));
+
+            let base = cell.borrow();
+            let child = base.node(NodeId(child_id)).expect("child still projected");
+            assert_eq!(child.size, Some(4_096), "size survives the re-projection");
+            assert_eq!(child.mtime, Some(1_700), "mtime survives the re-projection");
+            assert_eq!(
+                child.content_version,
+                Some(2),
+                "the version count survives the re-projection"
+            );
         }
 
         #[test]

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -228,14 +228,13 @@ where
     // Project the gate-passing root read-body to its direct children (E7); an
     // availability-stale current record leaves the base at the anchored root.
     let (root_resolve, base) = match resolved.outcome {
-        ResolveOutcome::Adopted(adopted) => {
-            (RootResolve::Adopted, project_root(params.root, &adopted))
-        }
+        ResolveOutcome::Adopted(adopted) => (
+            RootResolve::Adopted,
+            project_root(params.root, &adopted, &base),
+        ),
         // Cold start paints, it does not hold: our own current record at the
         // floor is availability staleness here, same as nothing newer fetched.
-        ResolveOutcome::NoUpdate | ResolveOutcome::Current { .. } => {
-            (RootResolve::NoUpdate, Snapshot::new(params.root))
-        }
+        ResolveOutcome::NoUpdate | ResolveOutcome::Current { .. } => (RootResolve::NoUpdate, base),
         ResolveOutcome::TrustViolation(rejection) => {
             return Err(ColdStartError::RootAdoption(rejection));
         }

--- a/crates/engine/src/sync/model.rs
+++ b/crates/engine/src/sync/model.rs
@@ -30,9 +30,11 @@ pub struct NodeMeta {
     /// The node's own IPNS record sequence — the conditional-delete snapshot
     /// (a delete op drops on rebase if this advanced past the op's snapshot).
     pub record_sequence: u64,
-    /// Bumped on every `updateContent` (a fresh per-version content key seals
-    /// each version, CONTEXT.md "Content key").
-    pub content_version: u64,
+    /// The node's retained version count, projected from the file read-body's
+    /// `versions` list and bumped on every queued `updateContent` (a fresh
+    /// per-version content key seals each version, CONTEXT.md "Content key").
+    /// `None` until projected — unprojected is not zero.
+    pub content_version: Option<u64>,
     /// Plaintext content size in bytes; `None` until the content plane
     /// projects it.
     pub size: Option<u64>,
@@ -45,15 +47,15 @@ pub struct NodeMeta {
 }
 
 impl NodeMeta {
-    /// A node at record sequence 1, content version 0, no projected
-    /// size/mtime/ipnsName.
+    /// A node at record sequence 1, with no projected content
+    /// version/size/mtime/ipnsName.
     pub fn new(id: NodeId, name: impl Into<String>, kind: NodeKind) -> Self {
         Self {
             id,
             name: name.into(),
             kind,
             record_sequence: 1,
-            content_version: 0,
+            content_version: None,
             size: None,
             mtime: None,
             ipns_name: None,

--- a/crates/engine/src/sync/op.rs
+++ b/crates/engine/src/sync/op.rs
@@ -14,7 +14,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::facade::{NodeId, NodeKind};
+use crate::facade::{NodeId, NodeKind, PendingClass};
 
 /// One intent op: the target node, the base sequence it was formed against,
 /// and the mutation.
@@ -160,6 +160,15 @@ impl Op {
         }
     }
 
+    /// The pending class this op puts its target in — a staged content write
+    /// outranks a metadata-only mutation.
+    pub fn pending_class(&self) -> PendingClass {
+        match self.staging_key() {
+            Some(_) => PendingClass::Content,
+            None => PendingClass::Metadata,
+        }
+    }
+
     /// The staging key this op references, if any (orphan-GC input).
     pub fn staging_key(&self) -> Option<&[u8]> {
         match &self.kind {
@@ -251,6 +260,33 @@ mod tests {
             Op::create(id(1), id(0), "d", NodeKind::Folder, 1, None).staging_key(),
             None
         );
+    }
+
+    #[test]
+    fn pending_class_is_content_for_exactly_the_content_bearing_kinds() {
+        let classes = [
+            Op::create(id(1), id(0), "a", NodeKind::File, 1, Some(b"k".to_vec())).pending_class(),
+            Op::create(id(1), id(0), "a", NodeKind::File, 1, None).pending_class(),
+            Op::create(id(1), id(0), "d", NodeKind::Folder, 1, None).pending_class(),
+            Op::delete(id(2), 1, 1).pending_class(),
+            Op::rename(id(3), "b", 1).pending_class(),
+            Op::relink(id(4), id(0), id(9), 1, false, false).pending_class(),
+            Op::update_content(id(5), b"k".to_vec(), 1).pending_class(),
+        ];
+        assert_eq!(
+            classes,
+            [
+                PendingClass::Content,
+                PendingClass::Metadata,
+                PendingClass::Metadata,
+                PendingClass::Metadata,
+                PendingClass::Metadata,
+                PendingClass::Metadata,
+                PendingClass::Content,
+            ]
+        );
+        assert!(PendingClass::Content > PendingClass::Metadata);
+        assert!(PendingClass::Metadata > PendingClass::None);
     }
 
     #[test]

--- a/crates/engine/src/sync/overlay.rs
+++ b/crates/engine/src/sync/overlay.rs
@@ -26,9 +26,17 @@ pub fn apply_overlay(base: &Snapshot, ops: &[Op]) -> Snapshot {
 fn apply_one(view: &mut Snapshot, op: &Op) {
     match &op.kind {
         OpKind::Create {
-            parent, name, kind, ..
+            parent,
+            name,
+            kind,
+            content_staging_key,
         } => {
-            view.upsert_node(NodeMeta::new(op.target, name.clone(), *kind));
+            let mut meta = NodeMeta::new(op.target, name.clone(), *kind);
+            // A create carrying content authors exactly one version.
+            if content_staging_key.is_some() {
+                meta.content_version = Some(1);
+            }
+            view.upsert_node(meta);
             view.link_next(*parent, op.target);
         }
         OpKind::Delete { .. } => {
@@ -47,7 +55,7 @@ fn apply_one(view: &mut Snapshot, op: &Op) {
         }
         OpKind::UpdateContent { .. } => {
             if let Some(node) = view.node_mut(op.target) {
-                node.content_version += 1;
+                node.content_version = node.content_version.map(|count| count + 1);
             }
         }
     }
@@ -120,20 +128,54 @@ mod tests {
     }
 
     #[test]
-    fn overlay_update_content_bumps_the_content_version() {
+    fn overlay_update_content_bumps_a_projected_content_version() {
+        let mut base = base();
+        let mut meta = NodeMeta::new(id(1), "f.txt", NodeKind::File);
+        meta.content_version = Some(4);
+        base.upsert_node(meta);
+        base.link(id(0), id(1), 1);
+        let view = apply_overlay(&base, &[Op::update_content(id(1), b"k".to_vec(), 1)]);
+        assert_eq!(
+            view.node(id(1)).unwrap().content_version,
+            Some(5),
+            "new version rendered"
+        );
+        assert_eq!(
+            base.node(id(1)).unwrap().content_version,
+            Some(4),
+            "base untouched"
+        );
+    }
+
+    #[test]
+    fn overlay_update_content_leaves_an_unprojected_count_unknown() {
         let mut base = base();
         base.upsert_node(NodeMeta::new(id(1), "f.txt", NodeKind::File));
         base.link(id(0), id(1), 1);
         let view = apply_overlay(&base, &[Op::update_content(id(1), b"k".to_vec(), 1)]);
         assert_eq!(
             view.node(id(1)).unwrap().content_version,
+            None,
+            "one more than unknown is still unknown"
+        );
+    }
+
+    #[test]
+    fn overlay_renders_the_one_version_a_content_bearing_create_authors() {
+        let base = base();
+        let with_content = Op::create(
+            id(1),
+            id(0),
+            "a.txt",
+            NodeKind::File,
             1,
-            "new version rendered"
+            Some(b"k".to_vec()),
         );
-        assert_eq!(
-            base.node(id(1)).unwrap().content_version,
-            0,
-            "base untouched"
-        );
+        let bare = Op::create(id(2), id(0), "dir", NodeKind::Folder, 1, None);
+
+        let view = apply_overlay(&base, &[with_content, bare]);
+
+        assert_eq!(view.node(id(1)).unwrap().content_version, Some(1));
+        assert_eq!(view.node(id(2)).unwrap().content_version, None);
     }
 }

--- a/crates/engine/src/sync/project.rs
+++ b/crates/engine/src/sync/project.rs
@@ -10,14 +10,18 @@ use crate::gate::Adopted;
 use crate::sync::model::{NodeMeta, Snapshot};
 
 /// Project a gate-passing adopted root read-body into a [`Snapshot`] holding
-/// the root and its **direct** children. Pure: the child read-bodies (and thus
-/// the deeper tree) are not fetched here.
+/// the root and its **direct** children, merged over `previous`. Pure: the
+/// child read-bodies (and thus the deeper tree) are not fetched here.
 ///
 /// Only a gate-passing [`Adopted`] reaches this fn — the gate already enforced
 /// child id/ipnsName uniqueness at unseal — so child uniqueness is trusted and
 /// not re-validated. `link_counter` is carried verbatim (feeds the dual-link
 /// tiebreak in [`Snapshot::winning_link`]).
-pub(crate) fn project_root(root: NodeId, adopted: &Adopted) -> Snapshot {
+///
+/// `size`, `mtime` and the content-version count have no `ChildRef` to come
+/// from (`crates/core/src/seal/body.rs`: no size/mtime mirrors), so they carry
+/// forward from `previous`; every other field is rebuilt from the adopted body.
+pub(crate) fn project_root(root: NodeId, adopted: &Adopted, previous: &Snapshot) -> Snapshot {
     let mut snapshot = Snapshot::new(root);
     if let Some(node) = snapshot.node_mut(root) {
         node.record_sequence = adopted.sequence;
@@ -36,6 +40,11 @@ pub(crate) fn project_root(root: NodeId, adopted: &Adopted) -> Snapshot {
             let id = NodeId(child.id);
             let mut meta = NodeMeta::new(id, child.name.clone(), map_kind(child.kind));
             meta.ipns_name = Some(child.ipns_name.clone());
+            if let Some(prior) = previous.node(id) {
+                meta.size = prior.size;
+                meta.mtime = prior.mtime;
+                meta.content_version = prior.content_version;
+            }
             snapshot.upsert_node(meta);
             snapshot.link(root, id, child.link_counter);
         }
@@ -44,21 +53,25 @@ pub(crate) fn project_root(root: NodeId, adopted: &Adopted) -> Snapshot {
     snapshot
 }
 
-/// Fold a verified head version's plaintext `(size, mtime)` into the base
-/// node. Returns whether either value actually changed, so the caller repaints
-/// only on a real change (a repeat read of the same version is a no-op).
+/// Fold a verified file read-body's plaintext `(size, mtime)` and version count
+/// into the base node. Returns whether any value actually changed, so the caller
+/// repaints only on a real change (a repeat read of the same version is a no-op).
 pub(crate) fn project_child_version(
     snapshot: &mut Snapshot,
     node: NodeId,
     size: u64,
     mtime: u64,
+    version_count: u64,
 ) -> bool {
     let Some(meta) = snapshot.node_mut(node) else {
         return false;
     };
-    let changed = meta.size != Some(size) || meta.mtime != Some(mtime);
+    let changed = meta.size != Some(size)
+        || meta.mtime != Some(mtime)
+        || meta.content_version != Some(version_count);
     meta.size = Some(size);
     meta.mtime = Some(mtime);
+    meta.content_version = Some(version_count);
     changed
 }
 
@@ -90,6 +103,11 @@ mod tests {
         }
     }
 
+    /// Project with nothing to merge over — the cold-start shape.
+    fn project_fresh(root: NodeId, adopted: &Adopted) -> Snapshot {
+        project_root(root, adopted, &Snapshot::new(root))
+    }
+
     fn adopted_folder(children: Vec<ChildRef>, sequence: u64) -> Adopted {
         Adopted {
             read_body: ReadBody::Folder {
@@ -114,7 +132,7 @@ mod tests {
             5,
         );
 
-        let snap = project_root(root, &adopted);
+        let snap = project_fresh(root, &adopted);
 
         let kids = snap.children(root);
         let by: Vec<(NodeId, &str, NodeKind)> = kids
@@ -143,7 +161,7 @@ mod tests {
             1,
         );
 
-        let snap = project_root(root, &adopted);
+        let snap = project_fresh(root, &adopted);
 
         assert_eq!(snap.max_link_counter(node_id(1)), 7);
         assert_eq!(snap.max_link_counter(node_id(2)), 3);
@@ -154,7 +172,7 @@ mod tests {
         let root = node_id(0);
         let adopted = adopted_folder(vec![], 42);
 
-        let snap = project_root(root, &adopted);
+        let snap = project_fresh(root, &adopted);
 
         assert_eq!(snap.record_sequence(root), Some(42));
     }
@@ -164,7 +182,7 @@ mod tests {
         let root = node_id(0);
         let adopted = adopted_folder(vec![child(1, "a", CoreNodeKind::File, 1)], 1);
 
-        let snap = project_root(root, &adopted);
+        let snap = project_fresh(root, &adopted);
 
         assert_eq!(
             snap.node(node_id(1)).unwrap().ipns_name,
@@ -177,16 +195,77 @@ mod tests {
     fn project_child_version_reports_change_once() {
         let root = node_id(0);
         let adopted = adopted_folder(vec![child(1, "a", CoreNodeKind::File, 1)], 1);
-        let mut snap = project_root(root, &adopted);
+        let mut snap = project_fresh(root, &adopted);
 
-        assert!(project_child_version(&mut snap, node_id(1), 10, 99));
+        assert!(project_child_version(&mut snap, node_id(1), 10, 99, 3));
         assert_eq!(snap.node(node_id(1)).unwrap().size, Some(10));
         assert_eq!(snap.node(node_id(1)).unwrap().mtime, Some(99));
+        assert_eq!(snap.node(node_id(1)).unwrap().content_version, Some(3));
         // The identical fold changes nothing; a differing one does.
-        assert!(!project_child_version(&mut snap, node_id(1), 10, 99));
-        assert!(project_child_version(&mut snap, node_id(1), 11, 99));
+        assert!(!project_child_version(&mut snap, node_id(1), 10, 99, 3));
+        assert!(project_child_version(&mut snap, node_id(1), 11, 99, 3));
+        // A new version alone is a change.
+        assert!(project_child_version(&mut snap, node_id(1), 11, 99, 4));
         // An absent node folds nothing.
-        assert!(!project_child_version(&mut snap, node_id(7), 1, 1));
+        assert!(!project_child_version(&mut snap, node_id(7), 1, 1, 1));
+    }
+
+    #[test]
+    fn re_projection_carries_forward_only_what_the_root_body_cannot_express() {
+        let root = node_id(0);
+        let first = adopted_folder(vec![child(1, "a.txt", CoreNodeKind::File, 1)], 1);
+        let mut previous = project_fresh(root, &first);
+        assert!(project_child_version(
+            &mut previous,
+            node_id(1),
+            2_048,
+            500,
+            2
+        ));
+
+        // The same child renamed, re-linked and re-kinded by the newer body.
+        let next = adopted_folder(vec![child(1, "renamed.txt", CoreNodeKind::Folder, 9)], 2);
+        let snap = project_root(root, &next, &previous);
+
+        let meta = snap.node(node_id(1)).unwrap();
+        assert_eq!(meta.size, Some(2_048), "size has no ChildRef to come from");
+        assert_eq!(meta.mtime, Some(500), "mtime has no ChildRef to come from");
+        assert_eq!(meta.content_version, Some(2), "the version count carries");
+        assert_eq!(meta.name, "renamed.txt", "the body owns the name");
+        assert_eq!(meta.kind, NodeKind::Folder, "the body owns the kind");
+        assert_eq!(snap.max_link_counter(node_id(1)), 9, "the body owns links");
+        assert_eq!(
+            snap.record_sequence(root),
+            Some(2),
+            "the body owns sequence"
+        );
+    }
+
+    #[test]
+    fn re_projection_drops_the_carried_values_of_a_departed_node() {
+        let root = node_id(0);
+        let first = adopted_folder(vec![child(1, "a.txt", CoreNodeKind::File, 1)], 1);
+        let mut previous = project_fresh(root, &first);
+        assert!(project_child_version(
+            &mut previous,
+            node_id(1),
+            2_048,
+            500,
+            2
+        ));
+
+        // The child left the root body; it takes its projected values with it.
+        let snap = project_root(root, &adopted_folder(vec![], 2), &previous);
+
+        assert!(!snap.contains(node_id(1)));
+
+        // And a re-appearance is a fresh projection, not a resurrection.
+        let back = adopted_folder(vec![child(1, "a.txt", CoreNodeKind::File, 1)], 3);
+        let snap = project_root(root, &back, &snap);
+        let meta = snap.node(node_id(1)).unwrap();
+        assert_eq!(meta.size, None);
+        assert_eq!(meta.mtime, None);
+        assert_eq!(meta.content_version, None);
     }
 
     #[test]
@@ -203,7 +282,7 @@ mod tests {
             epoch: 0,
         };
 
-        let snap = project_root(root, &adopted);
+        let snap = project_fresh(root, &adopted);
 
         assert_eq!(snap.node(root).unwrap().mtime, Some(777));
         assert_eq!(snap.node(root).unwrap().size, None);

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -331,7 +331,7 @@ fn rebase_relink(
 fn rebase_update_content(working: &mut Snapshot, local: &Snapshot, op: &Op) -> OpResolution {
     if working.contains(op.target) {
         if let Some(node) = working.node_mut(op.target) {
-            node.content_version += 1;
+            node.content_version = node.content_version.map(|count| count + 1);
         }
         return OpResolution::applied(None);
     }
@@ -348,7 +348,7 @@ fn rebase_update_content(working: &mut Snapshot, local: &Snapshot, op: &Op) -> O
             };
             let mut resurrected = meta.clone();
             resurrected.name = effective.clone();
-            resurrected.content_version += 1;
+            resurrected.content_version = resurrected.content_version.map(|count| count + 1);
             working.upsert_node(resurrected);
             working.link_next(parent, op.target);
             OpResolution::Applied {

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -108,6 +108,29 @@ impl From<facade::NodeKind> for NodeKind {
     }
 }
 
+/// What the op queue holds for a node (a queued content write outranks a queued
+/// metadata mutation).
+#[wasm_bindgen]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingClass {
+    /// No queued op targets the node.
+    None,
+    /// A queued op mutates only the node's metadata.
+    Metadata,
+    /// A queued op writes new content bytes for the node.
+    Content,
+}
+
+impl From<facade::PendingClass> for PendingClass {
+    fn from(class: facade::PendingClass) -> Self {
+        match class {
+            facade::PendingClass::None => PendingClass::None,
+            facade::PendingClass::Metadata => PendingClass::Metadata,
+            facade::PendingClass::Content => PendingClass::Content,
+        }
+    }
+}
+
 /// Grant permission level.
 #[wasm_bindgen]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -250,10 +273,10 @@ impl SnapshotChild {
         self.inner.mtime
     }
 
-    /// Whether a queued pending op targets this node.
+    /// What the op queue holds for this node.
     #[wasm_bindgen(getter)]
-    pub fn pending(&self) -> bool {
-        self.inner.pending
+    pub fn pending(&self) -> PendingClass {
+        self.inner.pending.into()
     }
 
     /// Whether a retained dead-lettered op maps to this node.
@@ -262,9 +285,9 @@ impl SnapshotChild {
         self.inner.dead_letter
     }
 
-    /// Current content version (a `bigint`, bumped per `updateContent`).
+    /// Retained version count (a `bigint`), or `undefined` until projected.
     #[wasm_bindgen(getter, js_name = contentVersion)]
-    pub fn content_version(&self) -> u64 {
+    pub fn content_version(&self) -> Option<u64> {
         self.inner.content_version
     }
 }
@@ -770,9 +793,9 @@ mod tests {
                     kind: facade::NodeKind::File,
                     size: Some(1024),
                     mtime: Some(1_700_000_000_000),
-                    pending: true,
+                    pending: facade::PendingClass::Content,
                     dead_letter: false,
-                    content_version: 2,
+                    content_version: Some(2),
                 },
                 facade::SnapshotChild {
                     id: facade::NodeId([4u8; 16]),
@@ -780,9 +803,9 @@ mod tests {
                     kind: facade::NodeKind::Folder,
                     size: None,
                     mtime: None,
-                    pending: false,
+                    pending: facade::PendingClass::None,
                     dead_letter: true,
-                    content_version: 0,
+                    content_version: None,
                 },
             ],
             ancestors: vec![facade::Breadcrumb {
@@ -805,10 +828,12 @@ mod tests {
         assert_eq!(children[0].kind(), NodeKind::File);
         assert_eq!(children[0].size(), Some(1024));
         assert_eq!(children[0].mtime(), Some(1_700_000_000_000));
-        assert!(children[0].pending());
+        assert_eq!(children[0].pending(), PendingClass::Content);
         assert!(!children[0].dead_letter());
-        assert_eq!(children[0].content_version(), 2);
+        assert_eq!(children[0].content_version(), Some(2));
         assert_eq!(children[1].kind(), NodeKind::Folder);
+        assert_eq!(children[1].pending(), PendingClass::None);
+        assert!(children[1].content_version().is_none());
         assert!(children[1].size().is_none());
         assert!(children[1].mtime().is_none());
         assert!(children[1].dead_letter());

--- a/crates/wasm/tests/boundary.rs
+++ b/crates/wasm/tests/boundary.rs
@@ -11,7 +11,7 @@
 use cipherbox_engine::facade;
 use cipherbox_engine::seams::OpId;
 use cipherbox_wasm::{
-    Command, Event, NodeId, NodeKind, OpPhase, Permission, SnapshotView, Staleness,
+    Command, Event, NodeId, NodeKind, OpPhase, PendingClass, Permission, SnapshotView, Staleness,
 };
 use js_sys::{Array, BigInt, Reflect, Uint8Array};
 use wasm_bindgen::{JsCast, JsValue};
@@ -187,9 +187,9 @@ fn snapshot_view_getters_cross_with_boundary_shapes() {
                 kind: facade::NodeKind::File,
                 size: Some(u64::MAX),
                 mtime: Some(1_700_000_000_000),
-                pending: true,
+                pending: facade::PendingClass::Content,
                 dead_letter: false,
-                content_version: 2,
+                content_version: Some(2),
             },
             facade::SnapshotChild {
                 id: facade::NodeId([4u8; 16]),
@@ -197,9 +197,9 @@ fn snapshot_view_getters_cross_with_boundary_shapes() {
                 kind: facade::NodeKind::Folder,
                 size: None,
                 mtime: None,
-                pending: false,
+                pending: facade::PendingClass::None,
                 dead_letter: true,
-                content_version: 0,
+                content_version: None,
             },
         ],
         ancestors: vec![facade::Breadcrumb {
@@ -256,11 +256,26 @@ fn snapshot_view_getters_cross_with_boundary_shapes() {
             .expect("bigint renders in base 10"),
     );
     assert_eq!(decimal, u64::MAX.to_string());
+    let version = get(&file, "contentVersion");
     assert_eq!(
-        get(&file, "contentVersion").js_typeof(),
-        JsValue::from_str("bigint")
+        version.js_typeof(),
+        JsValue::from_str("bigint"),
+        "the version count must cross as a JS bigint, never a number"
     );
-    assert_eq!(get(&file, "pending"), JsValue::TRUE);
+    assert_eq!(
+        String::from(
+            version
+                .unchecked_into::<BigInt>()
+                .to_string(10)
+                .expect("bigint renders in base 10")
+        ),
+        "2"
+    );
+    assert_eq!(
+        get(&file, "pending").as_f64(),
+        Some(PendingClass::Content as u32 as f64),
+        "the pending class crosses as its enum value"
+    );
     assert_eq!(get(&file, "deadLetter"), JsValue::FALSE);
 
     let folder_child = children.get(1);
@@ -269,6 +284,10 @@ fn snapshot_view_getters_cross_with_boundary_shapes() {
         "an unprojected size must cross as undefined"
     );
     assert!(get(&folder_child, "mtime").is_undefined());
+    assert!(
+        get(&folder_child, "contentVersion").is_undefined(),
+        "an unprojected version count must cross as undefined"
+    );
     assert_eq!(get(&folder_child, "deadLetter"), JsValue::TRUE);
 
     let ancestors = get(&view, "ancestors").unchecked_into::<Array>();

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -163,7 +163,7 @@ describe('broadcast transport ↔ leader relay', () => {
           kind: 'file',
           size: 1024n,
           mtime: null,
-          pending: true,
+          pending: 'content',
           deadLetter: false,
           contentVersion: 9_007_199_254_740_993n,
         },

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -35,6 +35,7 @@ export type {
   EventDescriptor,
   Permission,
   NodeKind,
+  PendingClass,
   Staleness,
   OpProgressPhase,
   SnapshotDescriptor,

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -22,6 +22,7 @@ import type {
  */
 export const fakeWasmEnums = {
   NodeKind: { File: 0, Folder: 1 },
+  PendingClass: { None: 0, Metadata: 1, Content: 2 },
   Permission: { Read: 0, Write: 1 },
   Staleness: { Fresh: 0, Reconciling: 1, Stale: 2, Offline: 3 },
   OpPhase: { DownloadStarted: 0, DownloadCompleted: 1, DownloadFailed: 2 },

--- a/packages/client/src/worker/commandCodec.test.ts
+++ b/packages/client/src/worker/commandCodec.test.ts
@@ -74,7 +74,7 @@ describe('readSnapshot', () => {
           kind: 0,
           size: 1024n,
           mtime: 1_700_000_000_000n,
-          pending: true,
+          pending: 2,
           deadLetter: false,
           contentVersion: 2n,
         },
@@ -82,9 +82,15 @@ describe('readSnapshot', () => {
           id: new Uint8Array(16).fill(4),
           name: 'docs',
           kind: 1,
-          pending: false,
+          pending: 0,
           deadLetter: true,
-          contentVersion: 0n,
+        },
+        {
+          id: new Uint8Array(16).fill(5),
+          name: 'renamed.txt',
+          kind: 0,
+          pending: 1,
+          deadLetter: false,
         },
       ],
       ancestors: [{ id: new Uint8Array(16).fill(1), name: '' }],
@@ -102,7 +108,7 @@ describe('readSnapshot', () => {
           kind: 'file',
           size: 1024n,
           mtime: 1_700_000_000_000n,
-          pending: true,
+          pending: 'content',
           deadLetter: false,
           contentVersion: 2n,
         },
@@ -112,9 +118,19 @@ describe('readSnapshot', () => {
           kind: 'folder',
           size: null,
           mtime: null,
-          pending: false,
+          pending: 'none',
           deadLetter: true,
-          contentVersion: 0n,
+          contentVersion: null,
+        },
+        {
+          id: new Uint8Array(16).fill(5),
+          name: 'renamed.txt',
+          kind: 'file',
+          size: null,
+          mtime: null,
+          pending: 'metadata',
+          deadLetter: false,
+          contentVersion: null,
         },
       ],
       ancestors: [{ id: new Uint8Array(16).fill(1), name: '' }],
@@ -123,7 +139,7 @@ describe('readSnapshot', () => {
     });
   });
 
-  it('fails closed on an unknown child kind or staleness value', () => {
+  it('fails closed on an unknown child kind, pending class or staleness value', () => {
     const base: WasmSnapshotView = {
       root: new Uint8Array(16),
       folder: new Uint8Array(16),
@@ -143,12 +159,25 @@ describe('readSnapshot', () => {
             id: new Uint8Array(16),
             name: 'x',
             kind: 42,
-            pending: false,
+            pending: 0,
             deadLetter: false,
-            contentVersion: 0n,
           },
         ],
       })
     ).toThrow('unknown WASM node kind value: 42');
+    expect(() =>
+      readSnapshot(fakeWasm, {
+        ...base,
+        children: [
+          {
+            id: new Uint8Array(16),
+            name: 'x',
+            kind: 0,
+            pending: 42,
+            deadLetter: false,
+          },
+        ],
+      })
+    ).toThrow('unknown WASM pending class value: 42');
   });
 });

--- a/packages/client/src/worker/commandCodec.ts
+++ b/packages/client/src/worker/commandCodec.ts
@@ -12,6 +12,7 @@ import type {
   EventDescriptor,
   NodeKind,
   OpProgressPhase,
+  PendingClass,
   Permission,
   SnapshotDescriptor,
   Staleness,
@@ -130,6 +131,20 @@ function opPhase(wasm: EngineWasm, phase: number | undefined): OpProgressPhase {
   }
 }
 
+function pendingClass(wasm: EngineWasm, pending: number): PendingClass {
+  switch (pending) {
+    case wasm.PendingClass.None:
+      return 'none';
+    case wasm.PendingClass.Metadata:
+      return 'metadata';
+    case wasm.PendingClass.Content:
+      return 'content';
+    default:
+      // Fail closed: an unmapped value means a JS/WASM version mismatch.
+      throw new Error(`unknown WASM pending class value: ${pending}`);
+  }
+}
+
 function nodeKindFrom(wasm: EngineWasm, kind: number): NodeKind {
   switch (kind) {
     case wasm.NodeKind.File:
@@ -189,9 +204,9 @@ export function readSnapshot(wasm: EngineWasm, view: WasmSnapshotView): Snapshot
       kind: nodeKindFrom(wasm, child.kind),
       size: child.size ?? null,
       mtime: child.mtime ?? null,
-      pending: child.pending,
+      pending: pendingClass(wasm, child.pending),
       deadLetter: child.deadLetter,
-      contentVersion: child.contentVersion,
+      contentVersion: child.contentVersion ?? null,
     })),
     ancestors: view.ancestors.map((ancestor) => ({ id: ancestor.id, name: ancestor.name })),
     deadLetters: [...view.deadLetters],

--- a/packages/client/src/worker/engineWasm.ts
+++ b/packages/client/src/worker/engineWasm.ts
@@ -44,9 +44,9 @@ export interface WasmSnapshotChild {
   readonly kind: number;
   readonly size?: bigint;
   readonly mtime?: bigint;
-  readonly pending: boolean;
+  readonly pending: number;
   readonly deadLetter: boolean;
-  readonly contentVersion: bigint;
+  readonly contentVersion?: bigint;
 }
 
 /** wasm-bindgen `SnapshotView` — a key-free folder snapshot for a UI paint. */
@@ -95,6 +95,11 @@ export interface EngineWasm {
     logout(): WasmCommand;
   };
   NodeKind: { readonly File: number; readonly Folder: number };
+  PendingClass: {
+    readonly None: number;
+    readonly Metadata: number;
+    readonly Content: number;
+  };
   Permission: { readonly Read: number; readonly Write: number };
   OpPhase: {
     readonly DownloadStarted: number;

--- a/packages/client/src/worker/protocol.ts
+++ b/packages/client/src/worker/protocol.ts
@@ -34,16 +34,22 @@ export interface BreadcrumbDescriptor {
   name: string;
 }
 
-/** One direct child in a snapshot, as data. `size`/`mtime` are `null` until projected. */
+/** What the op queue holds for a node (mirrors the facade `PendingClass`). */
+export type PendingClass = 'none' | 'metadata' | 'content';
+
+/**
+ * One direct child in a snapshot, as data. `size`/`mtime`/`contentVersion` are
+ * `null` until projected.
+ */
 export interface SnapshotChildDescriptor {
   id: Uint8Array;
   name: string;
   kind: NodeKind;
   size: bigint | null;
   mtime: bigint | null;
-  pending: boolean;
+  pending: PendingClass;
   deadLetter: boolean;
-  contentVersion: bigint;
+  contentVersion: bigint | null;
 }
 
 /**

--- a/packages/client/test/browser/engine.spec.ts
+++ b/packages/client/test/browser/engine.spec.ts
@@ -60,10 +60,10 @@ test.describe('engine worker host', () => {
     expect(result.children).toHaveLength(2);
     const docs = result.children.find((child) => child.name === 'docs');
     const file = result.children.find((child) => child.name === 'pending.txt');
-    expect(docs).toMatchObject({ kind: 'folder', pending: true, deadLetter: false });
+    expect(docs).toMatchObject({ kind: 'folder', pending: 'metadata', deadLetter: false });
     expect(file).toMatchObject({
       kind: 'file',
-      pending: true,
+      pending: 'metadata',
       deadLetter: false,
       sizeNull: true,
       mtimeNull: true,

--- a/packages/client/test/browser/engine.worker.ts
+++ b/packages/client/test/browser/engine.worker.ts
@@ -4,15 +4,9 @@
  * and serves the facade protocol. Mirrors the production `engineWorker` wiring,
  * but imports the built `pkg` glue statically instead of dynamically.
  */
-import init, {
-  Command,
-  EngineHandle,
-  NodeId,
-  NodeKind,
-  OpPhase,
-  Permission,
-  Staleness,
-} from './pkg/cipherbox_wasm.js';
+// Namespace import, not named bindings: the host needs every binding `EngineWasm`
+// declares, and a hand-listed set silently goes stale when one is added.
+import init, * as glue from './pkg/cipherbox_wasm.js';
 import wasmUrl from './pkg/cipherbox_wasm_bg.wasm?url';
 
 import { EngineHost } from '../../src/worker/engineHost.js';
@@ -24,15 +18,7 @@ const scope = self as unknown as WorkerScopeLike & { location: { origin: string 
 
 async function boot(): Promise<void> {
   await init({ module_or_path: wasmUrl });
-  const wasm = {
-    EngineHandle,
-    Command,
-    NodeId,
-    NodeKind,
-    OpPhase,
-    Permission,
-    Staleness,
-  } as unknown as EngineWasm;
+  const wasm = glue as unknown as EngineWasm;
   const { origin } = scope.location;
   const seams = makeBrowserSeams({
     recordEndpoints: [`${origin}/routing`],

--- a/packages/client/test/browser/engineHarness.ts
+++ b/packages/client/test/browser/engineHarness.ts
@@ -6,7 +6,7 @@
  */
 import { EngineFacade } from '../../src/facade.js';
 import { LocalTransport } from '../../src/transport.js';
-import type { EventDescriptor } from '../../src/worker/protocol.js';
+import type { EventDescriptor, PendingClass } from '../../src/worker/protocol.js';
 import { hex } from './hexUtil.js';
 
 export interface RealEngineResult {
@@ -28,7 +28,7 @@ export interface SnapshotSuiteResult {
   children: Array<{
     name: string;
     kind: string;
-    pending: boolean;
+    pending: PendingClass;
     deadLetter: boolean;
     sizeNull: boolean;
     mtimeNull: boolean;

--- a/packages/client/test/browser/leadership.spec.ts
+++ b/packages/client/test/browser/leadership.spec.ts
@@ -187,8 +187,13 @@ test.describe('tab leadership over real Web Locks + BroadcastChannel', () => {
     expect(view.folderHex).toBe(rootHex);
     const docs = view.children!.find((child) => child.name === 'docs');
     const file = view.children!.find((child) => child.name === 'pending.txt');
-    expect(docs).toMatchObject({ kind: 'folder', pending: true });
-    expect(file).toMatchObject({ kind: 'file', pending: true, sizeNull: true, mtimeNull: true });
+    expect(docs).toMatchObject({ kind: 'folder', pending: 'metadata' });
+    expect(file).toMatchObject({
+      kind: 'file',
+      pending: 'metadata',
+      sizeNull: true,
+      mtimeNull: true,
+    });
 
     // The nested snapshot's breadcrumb trail ends at the root.
     const nested = await follower.snapshot(docs!.idHex);

--- a/packages/client/test/browser/leadership.ts
+++ b/packages/client/test/browser/leadership.ts
@@ -8,6 +8,7 @@
  * kill-the-leader failover with no accepted-op loss.
  */
 import { EngineClient } from '../../src/engineClient.js';
+import type { PendingClass } from '../../src/worker/protocol.js';
 import { hex, unhex } from './hexUtil.js';
 
 const JOURNAL_DB = 'cb-leadership-journal';
@@ -36,7 +37,7 @@ export interface SnapshotResult {
     idHex: string;
     name: string;
     kind: string;
-    pending: boolean;
+    pending: PendingClass;
     sizeNull: boolean;
     mtimeNull: boolean;
   }>;


### PR DESCRIPTION
Closes #863
Closes #854
Part of #655

## The ruling

`project_root` **merges** instead of replacing. The carry-forward test is "can the root folder body express this field?" — structure is rebuilt from the adopted body as authoritative, and only the per-node values a `ChildRef` has no room for survive.

| Carried forward from the previous snapshot | Rebuilt from the adopted body |
| --- | --- |
| `size` | `name` |
| `mtime` | `kind` |
| `content_version` (the version count) | `ipnsName` |
| &nbsp; | `link_counter` |
| &nbsp; | the root's `record_sequence` |

Carried values survive for nodes still in the body and drop with nodes that left it. A departed node that re-appears is a fresh projection, not a resurrection — `size`/`mtime`/`content_version` come back `None`.

Deliberately **not** carried: a child's own `record_sequence`. See the review-gates section.

## The #854 bug this fixes

`refresh_base_from_outcome` replaced the base wholesale on a gate-passing verdict, so every value `project_child_version` had folded in was blanked by the next root advance — including the client's own self-adopt when it creates a sibling. Download file A, upload file B, and A's size was gone.

The regression test was written first and failed on the pre-fix tree. Re-confirmed on this branch by deleting only the carry-forward block:

```text
thread 'net::resolve::tests::refresh_base::a_root_advance_keeps_the_values_the_root_body_cannot_express'
  panicked at crates/engine/src/net/resolve.rs:1052:13:
assertion `left == right` failed: size survives the re-projection
  left: None
 right: Some(4096)

thread 'sync::project::tests::re_projection_carries_forward_only_what_the_root_body_cannot_express'
  panicked at crates/engine/src/sync/project.rs:227:9:
assertion `left == right` failed: size has no ChildRef to come from
  left: None
 right: Some(2048)

test result: FAILED. 432 passed; 2 failed
```

## The other two scope bullets

**`content_version` becomes `Option<u64>`**, projected from the file read-body's `versions.len()`. It was permanently `0`. `None` means *unprojected* and is distinct from zero — an unprojected count crosses the wasm boundary as `undefined` and lands in TS as `null`, never as `0`. The overlay renders `Some(1)` for a content-bearing create and leaves an unprojected count unknown under `updateContent`; one more than unknown is still unknown.

**`pending` widens** from `bool` to a ranked `PendingClass { None < Metadata < Content }`, so a queued content write is distinguishable from a queued metadata op — the durable queue fact #824's lossy-event reconcile needs. A node with both queued reports `Content`. It crosses the wasm boundary as a `#[wasm_bindgen]` enum, the same pattern `NodeKind`/`Permission`/`Staleness` already use, and surfaces in `packages/client` as the string-literal union `'none' | 'metadata' | 'content'`. The mapper fails closed: an unmapped value throws `unknown WASM pending class value: N`, covered by a test.

## What is not in this PR

The fourth scope bullet of #863 — the overlay writing `mtime = authored_at` on every node the op authors, through one function shared with the drain's publish plan — is **not here**. It requires `Op.authored_at`, which #864 owns. It has already been folded into #864 as an explicit deliverable with the #863 to #864 edge recorded, so nothing was dropped and nothing new needs filing.

## Merge ordering

This PR adds `Op::pending_class()` in `crates/engine/src/sync/op.rs`. #864 rewrites the op record in that same file. **Merge this one first**, then rebase #864 onto it.

## Review gates

All three mandatory gates ran against `git diff origin/main...HEAD`.

- `/security-review` — clean, no findings. Verified: the split `RefCell` borrow in `refresh_base_from_outcome` is sound, since the `Ref` is a `let`-initializer temporary that drops before the `borrow_mut` and the path is non-await by construction; departed-node handling never resurrects; the TS mapper fails closed on unknown values, on `undefined`, and on a wasm module missing the enum; `versions.len() as u64` is lossless on every target; the merge retains nothing unbounded.
- `/crypto-privacy-review` — required because the diff touches `crates/engine/src/net/resolve.rs`, the gated resolve path. Clean, no findings. Verified: the merge source is the **base** cell, never the rendered view, so every carried value was itself produced by a prior gate pass and the merge cannot smuggle overlay or unverified state across a verdict; non-adopting verdicts still return `false` and leave last-known-good whole; none of the three carried fields is an input to any gate, floor, or key decision; keying the merge on `NodeId` while letting `ipnsName` change underneath is *required*, since a write-scope rotation and a cross-scope move both change `ipnsName` for a stable `id16`; no path renders `None` as `0` (there is no host consumer of `NodeAttrs.content_version` yet, and the arithmetic is `.map(|count| count + 1)`); `versions` is AEAD-unsealed and AAD-bound behind the child's own gated resolve; no zeroization surface is touched; and the one decode-side hard reject added (the TS `pendingClass` mapper) has a producer that is type-constrained to the three variants, so encode/decode symmetry holds structurally with no `assert!`/`debug_assert!` anywhere in the non-test diff.
- CodeRabbit CLI (`--agent --base main --type committed`) — 0 findings across all 21 changed files.
- CodeRabbit web review — a real review pass ("Actionable comments posted: 2"), both findings valid and fixed, both threads replied to and resolved (2/2, 0 unresolved), plus its one nitpick fixed. See the disposition comment below.
- `/simplify` — 3 comment findings, all fixed: an absence-justifying comment in `sync/boot.rs`, a restatement in `sync/overlay.rs` of rationale that already lives on `NodeMeta::content_version`, and a happy-path narration in the `project_root` doc block.

### The `record_sequence` question

Investigated and closed as **not a defect in this slice**. No production path ever writes a non-root child's `record_sequence` — `project_root` rebuilds every child through `NodeMeta::new`, which hard-codes `1`, and every other reference is a read (`facade.rs:1288`, `facade.rs:1597`, `rebase.rs:248`). So conditional delete is already inert for children on `main`, this slice changes nothing about it, and carrying the field today would carry a constant.

That gap is real and material, and it belongs to #866, which owns `Delete` conditional on `target_sequence`. Filed there as a comment rather than a new issue, with the requirement that whichever slice starts projecting child sequences must add the field to this carry set at the same time, or #854 recurs for a fourth field.

Also considered and rejected: gating the carry on `prior.ipns_name == child.ipns_name`. A node's `ipnsName` derives from its write seed, per `CONTEXT.md` "Write seed", so a write rotation legitimately changes it while the node stays the same node. That gate would drop `size`/`mtime` on every rotation and reintroduce the exact symptom this PR fixes.

## Tests

New coverage:

- `net/resolve.rs` — a root advance keeps the values the root body cannot express (the #854 regression test, through the real `refresh_base_from_outcome` path)
- `sync/project.rs` — re-projection carries forward only what the root body cannot express, and drops a departed node's carried values without resurrecting them on re-appearance
- `sync/overlay.rs` — a projected count bumps, an unprojected one stays unknown, a content-bearing create renders exactly one version
- `sync/op.rs` — `pending_class` is `Content` for exactly the content-bearing kinds, and the rank orders
- `facade.rs` — a queued content write outranks a queued metadata op
- `crates/wasm/tests/boundary.rs` — the pending class crosses as its enum value; an unprojected version count crosses as `undefined`
- `packages/client` — `readSnapshot` fails closed on an unknown pending class

Results:

- `cargo test -p cipherbox-engine` — 532 passed, 0 failed
- `cargo test --workspace --exclude cipherbox-desktop --exclude cipherbox-contract` — green
- `cargo clippy --all-targets -- -D warnings` — 0 warnings
- `cargo fmt --all --check` — clean
- `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --tests` — clean
- `pnpm test` (client 77, api 163), `pnpm -w typecheck`, eslint, prettier — clean
- `Client Browser Suite` (Playwright against the real wasm build) — 19 passed

### The browser suite caught a real runtime bug

Worth calling out, because it is the whole argument for that gate. The first CI run failed two specs with:

```text
EngineRequestError: Cannot read properties of undefined (reading 'None')
```

`packages/client/test/browser/engine.worker.ts` hand-assembled the `EngineWasm` object from a fixed list of named imports — `NodeKind`, `OpPhase`, `Permission`, `Staleness` — and then cast it with `as unknown as EngineWasm`. The cast erased the compile-time check, so adding a required `PendingClass` to `EngineWasm` did **not** fail `pnpm -w typecheck`; it only exploded at runtime inside the worker, where `wasm.PendingClass.None` read a property of `undefined`.

Production was never affected: `src/worker/engineWorker.ts` dynamically imports the whole glue namespace, so it picks up new bindings automatically. Only the test worker's hand-maintained list was stale.

Fixed by making the test worker do what production does — a namespace import (`import init, * as glue`) instead of named bindings, which removes the hand-maintained list and the failure mode with it. Verified locally by installing the worktree's deps and running the real suite: **19/19 pass**, including both specs that failed in CI.

## Gate

`Engine Tests`, plus the `Test`, `Client Browser Suite` and wasm build gates the boundary and `packages/client` changes fall under.

## Triage

**10 fixed:**

1. the stale hand-built `EngineWasm` in the browser suite's test worker, described above — the only one that was a live runtime break rather than a polish item
2. absence-justifying comment in `sync/boot.rs` — deleted
3. `sync/overlay.rs` restated rationale that already lives on `NodeMeta::content_version` — trimmed
4. `project_root`'s doc block narrated the happy path — cut to the non-obvious why
5. `sync/boot.rs` re-constructed `Snapshot::new(params.root)` twice when the empty `base` was already bound in scope — now reused, which also makes "cold start has nothing to merge over" self-evident from the code rather than from a comment
6. the version count was documented as the *published* count, but `blueprint/core.md` defers version-retention policy, so it is the *retained* count — corrected in `sync/model.rs`, `facade.rs` and `crates/wasm/src/lib.rs`
7. `PendingClass` was missing from the `packages/client` barrel, so a consumer could hold a `SnapshotChildDescriptor` but not name its `pending` type — exported alongside `NodeKind`/`Staleness`/`Permission`
8. `crates/wasm/tests/boundary.rs` asserted only that `contentVersion` crossed as a `bigint`, so any value passed — including the `0n` this PR exists to stop being. Now converts and asserts `"2"`, mirroring the `u64::MAX` pattern used for `size`.
9. `readSnapshot`'s fixture covered `pending` 2/`content` and 0/`none` but not 1/`metadata` — the most reachable of the three, since every contentless create, rename, relink and delete lands there. Third fixture added.
10. `pending` was `boolean` in the two browser-harness result types before this PR and the diff widened it to `string`. Restored to the `PendingClass` union in both `engineHarness.ts` and `leadership.ts`, so the specs' `'metadata'` expectations are type-checked.

**1 filed:** a comment on #866 (not a new issue — #866 already owns `Delete` conditional on `target_sequence`), covering the inert conditional delete and the requirement to add `record_sequence` to this carry set when child sequences start being projected.

**14 dismissed** as nits or non-material: child-id-reuse carrying a stale display value (no gate/floor/key consumer, and the write-capable party already controls the child ref outright), the deliberate staleness trade-off of a confidently-stale value over a flapping `None`, a `content_version` overflow needing 2^64 queued ops, a pre-existing self-referential `ChildRef` edge (both traversals are cycle-guarded and it is unchanged by this diff), a pre-existing read/resolve interleave on the base, root re-projection not reaching deeper than direct children (out of scope), `pending_class()` piggybacking on the `staging_key()` accessor, and 7 style/shape preferences (the `project_fresh` test helper, the `BTreeMap` fold in `facade.rs`, the three-way `PendingClass` mirror, and `project_child_version`'s positional-argument count).
