### PR TITLE
feat(engine): freeze the content format and land the engine-side KAT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,9 +370,15 @@ jobs:
           key: linux-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: linux-cargo-
 
-      # Engine unit tests plus every seam conformance kit executed against
-      # its in-memory fake (the test-kit feature activates via the crate's
-      # self dev-dependency).
+      - name: Engine KAT vectors fresh (committed generator is the only writer)
+        run: |
+          cargo run -p cipherbox-engine --example kat_gen
+          git diff --exit-code -- crates/engine/kat
+          test -z "$(git status --porcelain -- crates/engine/kat)"
+
+      # Engine unit tests, the content-DAG KAT suite, plus every seam
+      # conformance kit executed against its in-memory fake (the test-kit
+      # feature activates via the crate's self dev-dependency).
       - name: Engine tests and seam conformance kits
         run: cargo test -p cipherbox-engine
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,7 @@ dependencies = [
  "cipherbox-engine",
  "futures-channel",
  "futures-core",
+ "hex",
  "serde",
  "serde_json",
  "zeroize",

--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -486,8 +486,11 @@ contract-test suite owned by the testing-strategy blueprint (#28 D6).
   content key, #26 D6), and assembles a DAG addressed by the version's
   `contentCid`, shaped so ranged block/CAR fetches map chunk-aligned.
   Retention default: keep all versions within quota, with an explicit
-  user-initiated prune op. Exact chunk size and retention knobs are open edges
-  below.
+  user-initiated prune op. The framing is frozen (#820) and pinned by the
+  engine KAT manifest: the 1 MiB budget belongs to the **block**, so a
+  1,048,536-byte plaintext chunk seals to a 1 MiB leaf; the DAG is a flat root
+  carrying an explicit format version, whose inlined link list caps a single
+  file at ~107.78 GiB.
 
 ## Facade
 
@@ -507,8 +510,6 @@ already happened below the facade — hosts render, they never decide.
   serving the tombstone before retire. #38 fixed the channel architecture but
   not the window; proposed as a sync-timing-profile constant, to settle with
   the testing-strategy blueprint's e2e work.
-- **Chunk size, DAG shape, retention defaults** — the judgment above needs
-  numbers; freeze alongside the KAT manifest and testing strategy.
 - **Sweep cadence** — the idle-cadence value joins the sync timing profile.
 - **Designed-for seams, deliberately unbuilt in v2.0**: push overlay (API
   WebSocket hints or desktop PubSub) behind `RefreshHintSource` (#33 D1);

--- a/crates/core/src/suite/aead.rs
+++ b/crates/core/src/suite/aead.rs
@@ -98,10 +98,11 @@ mod tests {
 
     #[test]
     fn content_chunk_size_is_far_below_the_plaintext_ceiling() {
-        // The engine frames content into 1 MiB chunks (crates/engine content
-        // profile); that is orders of magnitude below the AEAD ceiling, so the
-        // infallible `encrypt` contract holds for every framed chunk.
-        let engine_chunk_size: u64 = 1 << 20;
+        // The engine frames content so the *sealed* leaf is 1 MiB (crates/engine
+        // content profile), so the plaintext it hands `encrypt` is that budget
+        // less this suite's own framing overhead. Derived rather than restated:
+        // core cannot depend on the engine to name the constant.
+        let engine_chunk_size: u64 = (1 << 20) - NONCE_LEN as u64 - TAG_LEN as u64;
         let ceiling = MAX_PLAINTEXT_LEN;
         assert!(engine_chunk_size.saturating_mul(1000) < ceiling);
         // Sanity-pin the ceiling itself: 64 * (2^32 - 1) bytes.

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -27,6 +27,8 @@ zeroize.workspace = true
 # Self dev-dependency: enables `test-kit` for this crate's own tests (unit,
 # integration, doc) without leaking it into downstream production builds.
 cipherbox-engine = { workspace = true, features = ["test-kit"] }
+# The KAT generator and suite encode vector bytes as lowercase hex.
+hex = "0.4"
 # Integration tests construct real signed/sealed records with core's crypto to
 # hand-feed the adoption-gate simulation harness (core is already a normal
 # dependency; this line makes it addressable from `tests/`).

--- a/crates/engine/examples/kat_gen.rs
+++ b/crates/engine/examples/kat_gen.rs
@@ -1,0 +1,400 @@
+//! The committed KAT generator for the engine's content-DAG fixtures
+//! (blueprint/core.md "KAT regime": vectors regenerate only through committed
+//! generators, never hand-edits). Sibling to core's generator; see
+//! `crates/engine/tests/kat_content.rs` for why the engine needs its own.
+//!
+//! Run from any cwd:
+//!
+//! ```text
+//! cargo run -p cipherbox-engine --example kat_gen
+//! ```
+//!
+//! Accept vectors run the live [`assemble`] over leaves the live framing
+//! produced. Reject vectors are hand-built root maps, since a valid encoder run
+//! cannot emit any of them. Every vector is asserted against the live decoder
+//! before anything is written, so a generator run is itself a self-check.
+//! Output is deterministic: re-running is byte-identical.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+use cipherbox_core::codec::{Map, Value, encode};
+use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, encode_content_cid_str, verify_cid};
+use cipherbox_core::suite::aead::KEY_LEN;
+use cipherbox_engine::content::{
+    ContentKey, ContentProfile, DAG_ROOT_CODEC, DagError, ROOT_FORMAT_VERSION, SealedChunk,
+    assemble, decode_root, frame_and_seal,
+};
+use cipherbox_engine::entropy::{Entropy, EntropyError};
+use serde::Serialize;
+
+const PROFILE: &str = "cipherbox/v2 engine content-dag";
+
+/// A pinned entropy stream: KAT vectors must be byte-reproducible, so the
+/// generator injects a fixed nonce sequence instead of sampling one.
+struct PinnedEntropy(u8);
+
+impl Entropy for PinnedEntropy {
+    fn fill(&mut self, out: &mut [u8]) -> Result<(), EntropyError> {
+        for byte in out.iter_mut() {
+            *byte = self.0;
+            self.0 = self.0.wrapping_add(1);
+        }
+        Ok(())
+    }
+}
+
+/// A DAG root the live encoder produced, frozen byte-for-byte.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DagRootAcceptVector {
+    name: String,
+    chunk_size: u64,
+    size: u64,
+    leaf_cids: Vec<String>,
+    root_block: String,
+    content_cid: String,
+    content_cid_str: String,
+}
+
+/// A root block the decoder must refuse, and the verdict it must return.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DagRootRejectVector {
+    name: String,
+    root_block: String,
+    check: String,
+    class: String,
+}
+
+/// The flat-DAG capacity boundary. At this link count the root is megabytes, so
+/// the leaf list is synthesized by [`capacity_leaves`] rather than committed and
+/// the frozen outputs are the root's size and its CID.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DagCapacityAcceptVector {
+    name: String,
+    chunk_size: u64,
+    leaf_count: u64,
+    size: u64,
+    root_block_len: usize,
+    content_cid: String,
+}
+
+/// One link past the capacity boundary: the encoder must refuse rather than
+/// emit a root its own reader would reject as over-cap.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DagCapacityRejectVector {
+    name: String,
+    chunk_size: u64,
+    leaf_count: u64,
+    size: u64,
+    check: String,
+    class: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FileCount {
+    file: String,
+    count: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RejectSection {
+    file: String,
+    count: usize,
+    checks: Vec<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ContentSection {
+    root_format_version: u64,
+    root_cid_codec: u8,
+    production_chunk_size: u64,
+    dag_root_accept: FileCount,
+    dag_root_reject: RejectSection,
+    dag_capacity_accept: FileCount,
+    dag_capacity_reject: RejectSection,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Manifest {
+    manifest_version: u64,
+    profile: String,
+    content: ContentSection,
+}
+
+fn main() {
+    let kat_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("kat");
+    let content_dir = kat_dir.join("vectors").join("content");
+    fs::create_dir_all(&content_dir)
+        .unwrap_or_else(|e| panic!("create {}: {e}", content_dir.display()));
+
+    let root_accept = build_dag_root_accept();
+    let root_reject = build_dag_root_reject();
+    // One leaf pool serves the ceiling search and both capacity vectors. The
+    // bound only has to sit above the ceiling for the search to bracket it.
+    let pool = capacity_leaves(1 << 17);
+    let capacity_accept = build_dag_capacity_accept(&pool);
+    let capacity_reject = build_dag_capacity_reject(&pool, capacity_accept.leaf_count + 1);
+
+    write_pretty(&content_dir.join("dag_root_accept.json"), &root_accept);
+    write_pretty(&content_dir.join("dag_root_reject.json"), &root_reject);
+    write_pretty(
+        &content_dir.join("dag_capacity_accept.json"),
+        &[&capacity_accept],
+    );
+    write_pretty(
+        &content_dir.join("dag_capacity_reject.json"),
+        &[&capacity_reject],
+    );
+
+    let manifest = Manifest {
+        manifest_version: 1,
+        profile: PROFILE.to_string(),
+        content: ContentSection {
+            root_format_version: ROOT_FORMAT_VERSION,
+            root_cid_codec: DAG_ROOT_CODEC,
+            production_chunk_size: ContentProfile::PRODUCTION.chunk_size() as u64,
+            dag_root_accept: FileCount {
+                file: "vectors/content/dag_root_accept.json".to_string(),
+                count: root_accept.len(),
+            },
+            dag_root_reject: RejectSection {
+                file: "vectors/content/dag_root_reject.json".to_string(),
+                count: root_reject.len(),
+                checks: checks_in_surface_order(root_reject.iter().map(|v| v.check.as_str())),
+            },
+            dag_capacity_accept: FileCount {
+                file: "vectors/content/dag_capacity_accept.json".to_string(),
+                count: 1,
+            },
+            dag_capacity_reject: RejectSection {
+                file: "vectors/content/dag_capacity_reject.json".to_string(),
+                count: 1,
+                checks: checks_in_surface_order([capacity_reject.check.as_str()]),
+            },
+        },
+    };
+    write_pretty(&kat_dir.join("manifest.json"), &manifest);
+
+    println!(
+        "kat_gen: wrote {} accept, {} reject, 2 capacity vectors + manifest.json",
+        root_accept.len(),
+        root_reject.len()
+    );
+}
+
+fn write_pretty<T: Serialize>(path: &Path, value: &T) {
+    let mut text = serde_json::to_string_pretty(value).expect("serialize JSON");
+    text.push('\n');
+    fs::write(path, text).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}
+
+/// The distinct checks in declaration order, asserting each comes from
+/// [`DagError::CHECKS`] (a reject vector can never name an off-surface check).
+fn checks_in_surface_order<'a>(present: impl IntoIterator<Item = &'a str>) -> Vec<String> {
+    let present: BTreeSet<&str> = present.into_iter().collect();
+    let checks: Vec<String> = DagError::CHECKS
+        .iter()
+        .filter(|c| present.contains(*c))
+        .map(|c| (*c).to_string())
+        .collect();
+    assert_eq!(
+        checks.len(),
+        present.len(),
+        "every reject-vector check must come from the DAG error surface"
+    );
+    checks
+}
+
+/// Deterministic plaintext of `len` bytes.
+fn plaintext(len: usize) -> Vec<u8> {
+    (0..len).map(|i| (i % 251) as u8).collect()
+}
+
+/// Production-framed accept vectors: the shape freeze made real. Every case
+/// runs the live framing and the live [`assemble`], then re-decodes the result.
+fn build_dag_root_accept() -> Vec<DagRootAcceptVector> {
+    let profile = ContentProfile::PRODUCTION;
+    let chunk = profile.chunk_size();
+    let cases: Vec<(&str, usize)> = vec![
+        ("production-multi-chunk-short-tail", 2 * chunk + 12_345),
+        ("production-single-chunk", 1_000),
+        ("production-empty-version", 0),
+        ("production-exact-multiple", 2 * chunk),
+    ];
+
+    let mut names = BTreeSet::new();
+    let mut out = Vec::with_capacity(cases.len());
+    for (name, size) in cases {
+        assert!(names.insert(name), "duplicate accept vector {name}");
+        let key = ContentKey::from_bytes([0x5au8; KEY_LEN]);
+        let leaves = frame_and_seal(&plaintext(size), &key, &mut PinnedEntropy(0x10), &profile)
+            .expect("pinned entropy never fails");
+        let dag = assemble(&leaves, size as u64, &profile).expect("production framing assembles");
+
+        verify_cid(&dag.content_cid, &dag.root_block).expect("root addresses its own bytes");
+        let manifest = decode_root(&dag.root_block).expect("own root decodes");
+        assert_eq!(manifest.chunk_size, chunk as u64, "{name}: chunk size");
+        assert_eq!(manifest.size, size as u64, "{name}: size");
+        assert_eq!(
+            manifest.leaf_cids,
+            leaves.iter().map(|l| l.cid.clone()).collect::<Vec<_>>(),
+            "{name}: links preserve file order"
+        );
+
+        out.push(DagRootAcceptVector {
+            name: name.to_string(),
+            chunk_size: chunk as u64,
+            size: size as u64,
+            leaf_cids: leaves.iter().map(|l| hex::encode(&l.cid)).collect(),
+            root_block: hex::encode(&dag.root_block),
+            content_cid: hex::encode(&dag.content_cid),
+            content_cid_str: encode_content_cid_str(&dag.content_cid),
+        });
+    }
+    out
+}
+
+/// Hand-build a root map, bypassing `assemble`, to drive a fail-closed check.
+fn root_bytes(version: u64, chunk_size: u64, size: u64, links: &[Vec<u8>]) -> Vec<u8> {
+    let mut root = Map::new();
+    root.insert("v", Value::Unsigned(version));
+    root.insert("chunkSize", Value::Unsigned(chunk_size));
+    root.insert("size", Value::Unsigned(size));
+    root.insert(
+        "links",
+        Value::Array(links.iter().cloned().map(Value::Bytes).collect()),
+    );
+    encode(&Value::Map(root)).expect("hand-built root encodes")
+}
+
+fn build_dag_root_reject() -> Vec<DagRootRejectVector> {
+    let chunk = ContentProfile::PRODUCTION.chunk_size() as u64;
+    let leaf = compute_cid(CONTENT_CID_CODEC, b"one sealed leaf");
+    let cases: Vec<(&str, Vec<u8>)> = vec![
+        (
+            "unsupported-format-version",
+            // Deliberately invariant-invalid too (a bad leaf link and a link
+            // count that disagrees with the size): the vector alone then proves
+            // the version check outranks every trust invariant, so the verdict
+            // is "upgrade", not "forged".
+            root_bytes(
+                ROOT_FORMAT_VERSION + 1,
+                chunk,
+                3 * chunk,
+                &[b"not-a-content-cid".to_vec()],
+            ),
+        ),
+        (
+            "zero-chunk-size",
+            root_bytes(ROOT_FORMAT_VERSION, 0, 0, &[]),
+        ),
+        (
+            "malformed-leaf-cid",
+            root_bytes(
+                ROOT_FORMAT_VERSION,
+                chunk,
+                chunk,
+                &[b"not-a-content-cid".to_vec()],
+            ),
+        ),
+        (
+            "link-count-inconsistent-with-size",
+            // Three leaves' worth of bytes, one link.
+            root_bytes(ROOT_FORMAT_VERSION, chunk, 3 * chunk, &[leaf.clone()]),
+        ),
+    ];
+
+    let mut names = BTreeSet::new();
+    let mut out = Vec::with_capacity(cases.len());
+    for (name, block) in cases {
+        assert!(names.insert(name), "duplicate reject vector {name}");
+        let error = decode_root(&block).expect_err("reject vector must fail closed");
+        out.push(DagRootRejectVector {
+            name: name.to_string(),
+            root_block: hex::encode(&block),
+            check: error.check().to_string(),
+            class: error.class().to_string(),
+        });
+    }
+    out
+}
+
+/// `count` synthetic leaf links: the `raw` content CID of the big-endian link
+/// index. The KAT suite rebuilds them by the same rule; a divergence surfaces as
+/// a mismatch against the frozen root CID.
+fn capacity_leaves(count: u64) -> Vec<SealedChunk> {
+    (0..count)
+        .map(|i| SealedChunk {
+            cid: compute_cid(CONTENT_CID_CODEC, &i.to_be_bytes()),
+            sealed: Vec::new(),
+        })
+        .collect()
+}
+
+/// The largest link count that still assembles at the production chunk size —
+/// the flat-DAG ceiling #820 committed to knowingly. Every probe subslices one
+/// leaf vector, so the search costs the bound rather than the sum of its probes.
+fn max_leaf_count(leaves: &[SealedChunk]) -> u64 {
+    let profile = ContentProfile::PRODUCTION;
+    let chunk = profile.chunk_size() as u64;
+    // Only the cap may move the boundary; any other verdict is a generator bug.
+    let assembles = |count: u64| match assemble(&leaves[..count as usize], count * chunk, &profile)
+    {
+        Ok(_) => true,
+        Err(DagError::RootTooLarge { .. }) => false,
+        Err(e) => panic!("searching the ceiling hit {e:?} at {count} links"),
+    };
+    let (mut lo, mut hi) = (1u64, leaves.len() as u64);
+    assert!(assembles(lo) && !assembles(hi), "the ceiling lies in range");
+    while hi - lo > 1 {
+        let mid = lo + (hi - lo) / 2;
+        if assembles(mid) { lo = mid } else { hi = mid }
+    }
+    lo
+}
+
+fn build_dag_capacity_accept(pool: &[SealedChunk]) -> DagCapacityAcceptVector {
+    let profile = ContentProfile::PRODUCTION;
+    let chunk = profile.chunk_size() as u64;
+    let leaf_count = max_leaf_count(pool);
+    let size = leaf_count * chunk;
+    let dag = assemble(&pool[..leaf_count as usize], size, &profile)
+        .expect("the ceiling link count assembles");
+    verify_cid(&dag.content_cid, &dag.root_block).expect("root addresses its own bytes");
+    decode_root(&dag.root_block).expect("a ceiling root is still readable");
+
+    DagCapacityAcceptVector {
+        name: "flat-dag-ceiling-max-links".to_string(),
+        chunk_size: chunk,
+        leaf_count,
+        size,
+        root_block_len: dag.root_block.len(),
+        content_cid: hex::encode(&dag.content_cid),
+    }
+}
+
+fn build_dag_capacity_reject(pool: &[SealedChunk], leaf_count: u64) -> DagCapacityRejectVector {
+    let profile = ContentProfile::PRODUCTION;
+    let chunk = profile.chunk_size() as u64;
+    let size = leaf_count * chunk;
+    let error = assemble(&pool[..leaf_count as usize], size, &profile)
+        .expect_err("one link past the ceiling must fail closed");
+
+    DagCapacityRejectVector {
+        name: "flat-dag-ceiling-one-link-past".to_string(),
+        chunk_size: chunk,
+        leaf_count,
+        size,
+        check: error.check().to_string(),
+        class: error.class().to_string(),
+    }
+}

--- a/crates/engine/kat/manifest.json
+++ b/crates/engine/kat/manifest.json
@@ -1,0 +1,34 @@
+{
+  "manifestVersion": 1,
+  "profile": "cipherbox/v2 engine content-dag",
+  "content": {
+    "rootFormatVersion": 1,
+    "rootCidCodec": 113,
+    "productionChunkSize": 1048536,
+    "dagRootAccept": {
+      "file": "vectors/content/dag_root_accept.json",
+      "count": 4
+    },
+    "dagRootReject": {
+      "file": "vectors/content/dag_root_reject.json",
+      "count": 4,
+      "checks": [
+        "dag-unsupported-format",
+        "dag-zero-chunk-size",
+        "dag-malformed-leaf-cid",
+        "dag-link-count-mismatch"
+      ]
+    },
+    "dagCapacityAccept": {
+      "file": "vectors/content/dag_capacity_accept.json",
+      "count": 1
+    },
+    "dagCapacityReject": {
+      "file": "vectors/content/dag_capacity_reject.json",
+      "count": 1,
+      "checks": [
+        "dag-root-too-large"
+      ]
+    }
+  }
+}

--- a/crates/engine/kat/vectors/content/dag_capacity_accept.json
+++ b/crates/engine/kat/vectors/content/dag_capacity_accept.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "flat-dag-ceiling-max-links",
+    "chunkSize": 1048536,
+    "leafCount": 110375,
+    "size": 115732161000,
+    "rootBlockLen": 4194294,
+    "contentCid": "01711e20cce429fca648b0d71f89a985f66aa5cb4cb89652b99314f00444aca30652329a"
+  }
+]

--- a/crates/engine/kat/vectors/content/dag_capacity_reject.json
+++ b/crates/engine/kat/vectors/content/dag_capacity_reject.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "flat-dag-ceiling-one-link-past",
+    "chunkSize": 1048536,
+    "leafCount": 110376,
+    "size": 115733209536,
+    "check": "dag-root-too-large",
+    "class": "over-cap"
+  }
+]

--- a/crates/engine/kat/vectors/content/dag_root_accept.json
+++ b/crates/engine/kat/vectors/content/dag_root_accept.json
@@ -1,0 +1,49 @@
+[
+  {
+    "name": "production-multi-chunk-short-tail",
+    "chunkSize": 1048536,
+    "size": 2109417,
+    "leafCids": [
+      "01551e205c504f0368d8d99a1e7b812ba59acd1132860fc2f9f3890f2de4713eafb9314e",
+      "01551e206f0a8416f6224eb25b00b48bad1063bff80da07d6a7a9192a4376547e277ffbb",
+      "01551e2071dc56dcfb78ea7d05a032bd6a047f482a05596af444ffe78e7866328e2e46ea"
+    ],
+    "rootBlock": "a46176016473697a651a00202fe9656c696e6b7383582401551e205c504f0368d8d99a1e7b812ba59acd1132860fc2f9f3890f2de4713eafb9314e582401551e206f0a8416f6224eb25b00b48bad1063bff80da07d6a7a9192a4376547e277ffbb582401551e2071dc56dcfb78ea7d05a032bd6a047f482a05596af444ffe78e7866328e2e46ea696368756e6b53697a651a000fffd8",
+    "contentCid": "01711e20852c04916feef6195416178cca11a120155ed5ee42d51704937c86edf8564416",
+    "contentCidStr": "bafyr4ieffqcjc37o6ymvifqxrtfbdijacvpnl3sc2ulqje34q3w7qvsecy"
+  },
+  {
+    "name": "production-single-chunk",
+    "chunkSize": 1048536,
+    "size": 1000,
+    "leafCids": [
+      "01551e2098cd779778b3bd3fd25d93ca827f7ed7e56b29057b109b62827204fc554e1e71"
+    ],
+    "rootBlock": "a46176016473697a651903e8656c696e6b7381582401551e2098cd779778b3bd3fd25d93ca827f7ed7e56b29057b109b62827204fc554e1e71696368756e6b53697a651a000fffd8",
+    "contentCid": "01711e2028f16a5229aa3c362f6da14cf9805eb65b8de9f87bdc0be22cfc7cdcffab64db",
+    "contentCidStr": "bafyr4ibi6fvfeknkhq3c63nbjt4yaxvwlog6t6d33qf6elh4ptop7k3e3m"
+  },
+  {
+    "name": "production-empty-version",
+    "chunkSize": 1048536,
+    "size": 0,
+    "leafCids": [
+      "01551e2070a9b329da6fff17b72434302be94343ec3e1f72ae74b0661b3ed8a80d5b874a"
+    ],
+    "rootBlock": "a46176016473697a6500656c696e6b7381582401551e2070a9b329da6fff17b72434302be94343ec3e1f72ae74b0661b3ed8a80d5b874a696368756e6b53697a651a000fffd8",
+    "contentCid": "01711e207de04d2ca61eef8c8e5b8771b13c0da936df26cff10332b37aa7bfe09bb402b2",
+    "contentCidStr": "bafyr4id54bgszjq656gi4w4hogytydnjg3psnt7ramzlg6vhx7qjxnacwi"
+  },
+  {
+    "name": "production-exact-multiple",
+    "chunkSize": 1048536,
+    "size": 2097072,
+    "leafCids": [
+      "01551e205c504f0368d8d99a1e7b812ba59acd1132860fc2f9f3890f2de4713eafb9314e",
+      "01551e206f0a8416f6224eb25b00b48bad1063bff80da07d6a7a9192a4376547e277ffbb"
+    ],
+    "rootBlock": "a46176016473697a651a001fffb0656c696e6b7382582401551e205c504f0368d8d99a1e7b812ba59acd1132860fc2f9f3890f2de4713eafb9314e582401551e206f0a8416f6224eb25b00b48bad1063bff80da07d6a7a9192a4376547e277ffbb696368756e6b53697a651a000fffd8",
+    "contentCid": "01711e20482e9f19f29ce1d948ad5af0b11fcb363246d3e95d5588842c1016c3f4bfd44c",
+    "contentCidStr": "bafyr4icif2prt4u44hmurlk26cyr7szwgjdnh2k5kweiilaqc3b7jp6ujq"
+  }
+]

--- a/crates/engine/kat/vectors/content/dag_root_reject.json
+++ b/crates/engine/kat/vectors/content/dag_root_reject.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "unsupported-format-version",
+    "rootBlock": "a46176026473697a651a002fff88656c696e6b7381516e6f742d612d636f6e74656e742d636964696368756e6b53697a651a000fffd8",
+    "check": "dag-unsupported-format",
+    "class": "unsupported"
+  },
+  {
+    "name": "zero-chunk-size",
+    "rootBlock": "a46176016473697a6500656c696e6b7380696368756e6b53697a6500",
+    "check": "dag-zero-chunk-size",
+    "class": "trust"
+  },
+  {
+    "name": "malformed-leaf-cid",
+    "rootBlock": "a46176016473697a651a000fffd8656c696e6b7381516e6f742d612d636f6e74656e742d636964696368756e6b53697a651a000fffd8",
+    "check": "dag-malformed-leaf-cid",
+    "class": "trust"
+  },
+  {
+    "name": "link-count-inconsistent-with-size",
+    "rootBlock": "a46176016473697a651a002fff88656c696e6b7381582401551e206ba14306b6dda722da8e997d39e50857390d97e51a473c223ac338b60bdacde3696368756e6b53697a651a000fffd8",
+    "check": "dag-link-count-mismatch",
+    "class": "trust"
+  }
+]

--- a/crates/engine/src/content/dag.rs
+++ b/crates/engine/src/content/dag.rs
@@ -3,17 +3,17 @@
 //! version's `contentCid`, shaped so ranged block/CAR fetches map
 //! chunk-aligned").
 //!
-//! The DAG *shape* is engine-owned (an open edge); the *encoding* and the
-//! content-address are core's — the root node is serialized with core's
-//! deterministic CBOR ([`cipherbox_core::codec`], a strict DAG-CBOR subset) and
-//! addressed by [`cipherbox_core::content::compute_cid`] under the engine-chosen
-//! `dag-cbor` codec, so there is one codec and one KAT set (AGENTS.md rules 4-5).
+//! The DAG *shape* is engine-owned; the *encoding* and the content-address are
+//! core's — the root node is serialized with core's deterministic CBOR
+//! ([`cipherbox_core::codec`], a strict DAG-CBOR subset) and addressed by
+//! [`cipherbox_core::content::compute_cid`] under the engine-chosen `dag-cbor`
+//! codec, so there is one codec and one KAT set (AGENTS.md rules 4-5).
 //!
-//! Shape today is a single flat root over the ordered leaf CIDs plus the fixed
-//! chunk size and the plaintext length. Flat keeps the byte→leaf map trivial
-//! (offset / chunkSize), which is exactly the chunk-alignment a ranged fetch
-//! needs; a fan-out/balancing profile is the open edge deferred with the chunk
-//! size (blueprint/engine.md "Open edges").
+//! The shape is frozen (#820, blueprint/engine.md "Content plane"): a single
+//! flat root over the ordered leaf CIDs plus the fixed chunk size, the
+//! plaintext length, and [`ROOT_FORMAT_VERSION`]. Flat keeps the byte→leaf map
+//! a single division, which is the chunk-alignment a ranged fetch needs, and
+//! costs the ceiling documented on [`DagError::RootTooLarge`].
 
 use cipherbox_core::codec::{Map, Value, decode, encode_fixed_depth};
 use cipherbox_core::content::{
@@ -30,27 +30,41 @@ use super::profile::ContentProfile;
 /// codec as a parameter. Single-byte, inside core's frozen content-plane set.
 pub const DAG_ROOT_CODEC: u8 = 0x71;
 
+/// The root-manifest format version this crate writes and the only one it
+/// reads. A discriminator, not a compatibility arm: a root carrying any other
+/// version is refused as [`DagError::UnsupportedFormat`], so a client meeting a
+/// future shape reports "upgrade" instead of a rule-6 trust violation (#820).
+pub const ROOT_FORMAT_VERSION: u64 = 1;
+
 /// CIDv1 version byte, and the digest-length byte (BLAKE3-256 = 32) — the two
 /// fixed CIDv1 framing bytes core does not expose as public constants; used to
 /// validate that a decoded leaf link is a well-formed content CID.
 const CID_VERSION: u8 = 0x01;
 const CID_DIGEST_LEN: u8 = 32;
 
-/// Why decoding a root block failed, fail-closed.
+/// Why assembling or decoding a root block failed, fail-closed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DagError {
     /// The root block was not valid deterministic CBOR, or not the root map
     /// shape (a non-canonical encoding, a missing field, a wrong-typed field) —
     /// a core [`CodecError`] surfaced verbatim.
     Cbor(CodecError),
-    /// The root decoded but violated a manifest invariant: a zero chunk size, a
-    /// leaf link that is not a well-formed content CID, or a link count
-    /// inconsistent with the byte size. An internally inconsistent manifest is
-    /// never trusted, even when its own `contentCid` verifies.
-    InvalidManifest {
-        /// Which invariant failed.
-        reason: &'static str,
+    /// The root declared a format version other than [`ROOT_FORMAT_VERSION`].
+    /// Deliberately distinct from the invariant rejects below: the content is
+    /// not suspect, this build simply cannot read the shape.
+    UnsupportedFormat {
+        /// The version the root declared.
+        version: u64,
     },
+    /// The root declared a zero chunk size, which no framing can produce and
+    /// which would make the byte→leaf map a division by zero.
+    ZeroChunkSize,
+    /// A leaf link was not a well-formed `raw` content CID.
+    MalformedLeafCid,
+    /// The link count disagreed with `ceil(size / chunkSize)`. An internally
+    /// inconsistent manifest is never trusted, even when its own `contentCid`
+    /// verifies.
+    LinkCountMismatch,
     /// The assembled root manifest exceeded [`MAX_RESOLVED_RECORD_BYTES`]: the
     /// flat root inlines every leaf CID, so a file past the flat-DAG ceiling
     /// (~108 GiB) produces a root [`read_block`](super::read::read_block) would
@@ -62,6 +76,42 @@ pub enum DagError {
         /// The enforced ceiling ([`MAX_RESOLVED_RECORD_BYTES`]).
         limit: usize,
     },
+}
+
+impl DagError {
+    /// Every engine-owned DAG check, in declaration order — the surface
+    /// `crates/engine/tests/kat_content.rs` pins. The `dag-` prefix keeps an
+    /// engine check from ever colliding with a core one.
+    pub const CHECKS: &'static [&'static str] = &[
+        "dag-unsupported-format",
+        "dag-zero-chunk-size",
+        "dag-malformed-leaf-cid",
+        "dag-link-count-mismatch",
+        "dag-root-too-large",
+    ];
+
+    /// The stable name of the check that fired.
+    pub fn check(&self) -> &'static str {
+        match self {
+            Self::Cbor(error) => error.check(),
+            Self::UnsupportedFormat { .. } => "dag-unsupported-format",
+            Self::ZeroChunkSize => "dag-zero-chunk-size",
+            Self::MalformedLeafCid => "dag-malformed-leaf-cid",
+            Self::LinkCountMismatch => "dag-link-count-mismatch",
+            Self::RootTooLarge { .. } => "dag-root-too-large",
+        }
+    }
+
+    /// The class label used in reject vectors. Exhaustive so a new variant must
+    /// state its class rather than inherit `"trust"`.
+    pub fn class(&self) -> &'static str {
+        match self {
+            Self::Cbor(error) => error.class(),
+            Self::UnsupportedFormat { .. } => "unsupported",
+            Self::RootTooLarge { .. } => "over-cap",
+            Self::ZeroChunkSize | Self::MalformedLeafCid | Self::LinkCountMismatch => "trust",
+        }
+    }
 }
 
 impl From<CodecError> for DagError {
@@ -76,6 +126,7 @@ impl From<Malformed> for DagError {
     }
 }
 
+const VERSION_KEY: &str = "v";
 const CHUNK_SIZE_KEY: &str = "chunkSize";
 const SIZE_KEY: &str = "size";
 const LINKS_KEY: &str = "links";
@@ -98,26 +149,27 @@ pub struct ContentDag {
 /// size bound). Deterministic: identical leaves + length + profile give a
 /// byte-identical root block and CID.
 ///
-/// Fails closed when the leaf count does not match [`decode_root`]'s
-/// `ceil(size / chunkSize)`. Enforced in every build (not a release-compiled-out
-/// `debug_assert`): a mis-wired caller must never emit a root this crate's own
-/// [`decode_root`] would reject as `link count inconsistent with size`, which
-/// would leave the published version permanently unreadable.
+/// Every caller-supplied invariant [`decode_root`] rejects on is enforced here
+/// too, in every build (not a release-compiled-out `debug_assert`): a mis-wired
+/// caller must never emit a root this crate's own decoder rejects, which would
+/// leave the published version permanently unreadable (AGENTS.md rule 8).
 pub fn assemble(
     leaves: &[SealedChunk],
     plaintext_len: u64,
     profile: &ContentProfile,
 ) -> Result<ContentDag, DagError> {
+    if !leaves.iter().all(|leaf| is_raw_leaf_cid(&leaf.cid)) {
+        return Err(DagError::MalformedLeafCid);
+    }
     if leaves.len() as u64 != expected_leaf_count(plaintext_len, profile.chunk_size() as u64) {
-        return Err(DagError::InvalidManifest {
-            reason: "link count inconsistent with size",
-        });
+        return Err(DagError::LinkCountMismatch);
     }
     let links = leaves
         .iter()
         .map(|leaf| Value::Bytes(leaf.cid.clone()))
         .collect();
     let mut root = Map::new();
+    root.insert(VERSION_KEY, Value::Unsigned(ROOT_FORMAT_VERSION));
     root.insert(CHUNK_SIZE_KEY, Value::Unsigned(profile.chunk_size() as u64));
     root.insert(SIZE_KEY, Value::Unsigned(plaintext_len));
     root.insert(LINKS_KEY, Value::Array(links));
@@ -150,15 +202,21 @@ pub struct RootManifest {
 }
 
 /// Decode a root block (already verified against its `contentCid` by the
-/// caller) into its manifest, fail-closed. Beyond the core-CBOR checks (a
-/// non-canonical encoding, a missing or wrong-typed field), the manifest
-/// invariants are enforced here so a `contentCid`-valid-but-inconsistent root is
-/// rejected, not silently trusted: the chunk size must be nonzero, every leaf
-/// link must be a well-formed `raw` content CID, and the link count must match
-/// `ceil(size / chunkSize)` (an empty version is exactly one empty leaf).
+/// caller) into its manifest, fail-closed — a `contentCid`-valid-but-internally
+/// inconsistent root is rejected, not silently trusted. The format version is
+/// read first, so a future shape is refused as
+/// [`DagError::UnsupportedFormat`] rather than by whichever invariant it
+/// happens to trip.
 pub fn decode_root(root_block: &[u8]) -> Result<RootManifest, DagError> {
     let root = decode(root_block)?;
     let map = root.as_map()?;
+    let version = map
+        .get(VERSION_KEY)
+        .ok_or(Malformed::MissingField { field: "v" })?
+        .as_unsigned()?;
+    if version != ROOT_FORMAT_VERSION {
+        return Err(DagError::UnsupportedFormat { version });
+    }
     let chunk_size = map
         .get(CHUNK_SIZE_KEY)
         .ok_or(Malformed::MissingField { field: "chunkSize" })?
@@ -176,19 +234,13 @@ pub fn decode_root(root_block: &[u8]) -> Result<RootManifest, DagError> {
         .collect::<Result<Vec<_>, Malformed>>()?;
 
     if chunk_size == 0 {
-        return Err(DagError::InvalidManifest {
-            reason: "zero chunk size",
-        });
+        return Err(DagError::ZeroChunkSize);
     }
     if !leaf_cids.iter().all(|cid| is_raw_leaf_cid(cid)) {
-        return Err(DagError::InvalidManifest {
-            reason: "malformed leaf cid",
-        });
+        return Err(DagError::MalformedLeafCid);
     }
     if leaf_cids.len() as u64 != expected_leaf_count(size, chunk_size) {
-        return Err(DagError::InvalidManifest {
-            reason: "link count inconsistent with size",
-        });
+        return Err(DagError::LinkCountMismatch);
     }
 
     Ok(RootManifest {
@@ -243,8 +295,9 @@ mod tests {
 
     /// Hand-build a root block with arbitrary fields, bypassing `assemble`, to
     /// drive the fail-closed manifest checks.
-    fn root_bytes(chunk_size: u64, size: u64, links: &[Vec<u8>]) -> Vec<u8> {
+    fn root_bytes(version: u64, chunk_size: u64, size: u64, links: &[Vec<u8>]) -> Vec<u8> {
         let mut root = Map::new();
+        root.insert(VERSION_KEY, Value::Unsigned(version));
         root.insert(CHUNK_SIZE_KEY, Value::Unsigned(chunk_size));
         root.insert(SIZE_KEY, Value::Unsigned(size));
         root.insert(
@@ -254,10 +307,10 @@ mod tests {
         encode(&Value::Map(root)).unwrap()
     }
 
-    fn invalid_manifest_reason(block: &[u8]) -> &'static str {
+    fn reject_check(block: &[u8]) -> &'static str {
         match decode_root(block) {
-            Err(DagError::InvalidManifest { reason }) => reason,
-            other => panic!("expected an InvalidManifest error, got {other:?}"),
+            Err(error) => error.check(),
+            Ok(manifest) => panic!("expected a fail-closed reject, got {manifest:?}"),
         }
     }
 
@@ -314,25 +367,74 @@ mod tests {
     #[test]
     fn decode_root_rejects_a_zero_chunk_size() {
         assert_eq!(
-            invalid_manifest_reason(&root_bytes(0, 0, &[])),
-            "zero chunk size"
+            reject_check(&root_bytes(ROOT_FORMAT_VERSION, 0, 0, &[])),
+            "dag-zero-chunk-size"
         );
     }
 
     #[test]
     fn decode_root_rejects_a_malformed_leaf_cid() {
         // chunkSize 16, size 16 => one leaf expected; the one link is not a CID.
-        let block = root_bytes(16, 16, &[b"not-a-content-cid".to_vec()]);
-        assert_eq!(invalid_manifest_reason(&block), "malformed leaf cid");
+        let block = root_bytes(
+            ROOT_FORMAT_VERSION,
+            16,
+            16,
+            &[b"not-a-content-cid".to_vec()],
+        );
+        assert_eq!(reject_check(&block), "dag-malformed-leaf-cid");
     }
 
     #[test]
     fn decode_root_rejects_a_link_count_size_mismatch() {
         // size 40 at chunkSize 16 expects 3 leaves; only one (valid) link given.
-        let block = root_bytes(16, 40, &[compute_cid(CONTENT_CID_CODEC, b"x")]);
+        let block = root_bytes(
+            ROOT_FORMAT_VERSION,
+            16,
+            40,
+            &[compute_cid(CONTENT_CID_CODEC, b"x")],
+        );
+        assert_eq!(reject_check(&block), "dag-link-count-mismatch");
+    }
+
+    #[test]
+    fn assemble_stamps_the_frozen_format_version() {
+        let (leaves, profile) = framed(b"abc", 13);
+        let dag = assemble(&leaves, 3, &profile).unwrap();
+        let root = decode(&dag.root_block).unwrap();
         assert_eq!(
-            invalid_manifest_reason(&block),
-            "link count inconsistent with size"
+            root.as_map().unwrap().get(VERSION_KEY).unwrap(),
+            &Value::Unsigned(ROOT_FORMAT_VERSION),
+            "every published root carries the format discriminator"
+        );
+    }
+
+    #[test]
+    fn decode_root_refuses_an_unrecognized_format_version() {
+        // A future fan-out root: the version check fires first, so the client
+        // learns it is out of date instead of reporting a trust violation.
+        let block = root_bytes(
+            ROOT_FORMAT_VERSION + 1,
+            16,
+            16,
+            &[b"not-a-content-cid".to_vec()],
+        );
+        assert_eq!(
+            decode_root(&block),
+            Err(DagError::UnsupportedFormat {
+                version: ROOT_FORMAT_VERSION + 1
+            })
+        );
+    }
+
+    #[test]
+    fn decode_root_rejects_a_root_with_no_format_version() {
+        let mut root = Map::new();
+        root.insert(CHUNK_SIZE_KEY, Value::Unsigned(16));
+        root.insert(SIZE_KEY, Value::Unsigned(0));
+        root.insert(LINKS_KEY, Value::Array(Vec::new()));
+        assert_eq!(
+            reject_check(&encode(&Value::Map(root)).unwrap()),
+            "missing-field"
         );
     }
 
@@ -346,14 +448,12 @@ mod tests {
         assert_eq!(manifest.leaf_cids.len(), 1);
     }
 
-    /// `count` dummy leaves with 36-byte (`CONTENT_CID_LEN`) CIDs and empty
-    /// sealed bytes, framed to match a `chunk_size`-16 profile — enough to size
-    /// the root manifest without materializing any file bytes. `assemble` only
-    /// reads `leaf.cid`, so the sealed payload can stay empty.
+    /// `count` distinct well-formed leaf CIDs. `assemble` reads only `leaf.cid`,
+    /// so the root can be sized without materializing any file bytes.
     fn dummy_leaves(count: usize) -> Vec<SealedChunk> {
         (0..count)
-            .map(|_| SealedChunk {
-                cid: vec![0u8; CONTENT_CID_LEN],
+            .map(|i| SealedChunk {
+                cid: compute_cid(CONTENT_CID_CODEC, &(i as u64).to_be_bytes()),
                 sealed: Vec::new(),
             })
             .collect()
@@ -401,9 +501,36 @@ mod tests {
         assert_eq!(leaves.len(), 1);
         assert_eq!(
             assemble(&leaves, 40, &profile),
-            Err(DagError::InvalidManifest {
-                reason: "link count inconsistent with size",
-            })
+            Err(DagError::LinkCountMismatch)
         );
+    }
+
+    #[test]
+    fn assemble_rejects_a_malformed_leaf_cid_in_every_build() {
+        // The encode-side half of `decode_root`'s leaf-CID reject (rule 8).
+        let profile = ContentProfile::CI;
+        let leaves = vec![SealedChunk {
+            cid: b"not-a-content-cid".to_vec(),
+            sealed: Vec::new(),
+        }];
+        assert_eq!(
+            assemble(&leaves, profile.chunk_size() as u64, &profile),
+            Err(DagError::MalformedLeafCid)
+        );
+    }
+
+    #[test]
+    fn the_check_surface_matches_the_engine_owned_variants_in_order() {
+        let named: Vec<&str> = [
+            DagError::UnsupportedFormat { version: 2 },
+            DagError::ZeroChunkSize,
+            DagError::MalformedLeafCid,
+            DagError::LinkCountMismatch,
+            DagError::RootTooLarge { size: 1, limit: 0 },
+        ]
+        .iter()
+        .map(DagError::check)
+        .collect();
+        assert_eq!(named, DagError::CHECKS);
     }
 }

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -14,7 +14,7 @@
 //! - [`provider`] — the pin-provider layer and BYO reachability probe.
 //! - [`read`] — verified reads (accelerator + public fallback), fail-closed.
 //! - [`retention`] — pre-flight quota and the explicit prune op.
-//! - [`profile`] — the open-edge chunk-size constant.
+//! - [`profile`] — the frozen chunk-size constant.
 
 pub mod chunk;
 pub mod dag;
@@ -25,7 +25,9 @@ pub mod read;
 pub mod retention;
 
 pub use chunk::{ContentKey, SealedChunk, frame_and_seal};
-pub use dag::{ContentDag, DAG_ROOT_CODEC, DagError, RootManifest, assemble, decode_root};
+pub use dag::{
+    ContentDag, DAG_ROOT_CODEC, DagError, ROOT_FORMAT_VERSION, RootManifest, assemble, decode_root,
+};
 pub use profile::ContentProfile;
 pub use provider::{
     ByoIpfsConfig, ByoKind, PinMode, ProviderError, test_connection, validate_endpoint,
@@ -108,6 +110,12 @@ pub enum OpenError {
     Trust(String),
     /// Availability — retryable, never a trust verdict.
     Unavailable(String),
+    /// The root declared a root-manifest format this build cannot read; see
+    /// [`DagError::UnsupportedFormat`].
+    UnsupportedFormat {
+        /// The version the root declared.
+        version: u64,
+    },
 }
 
 /// Map a content-block read failure onto the [`OpenError`] classification.
@@ -119,6 +127,24 @@ fn open_read_error(e: ReadError) -> OpenError {
         ReadError::Unavailable => OpenError::Unavailable("content block unavailable".to_owned()),
         ReadError::TooLarge { size, limit } => {
             OpenError::Unavailable(format!("content block exceeds the cap ({size} > {limit})"))
+        }
+    }
+}
+
+/// Map a DAG-root rejection onto the [`OpenError`] classification. Exhaustive
+/// for the same reason [`DagError::class`] is: a new variant must state its
+/// classification here rather than inherit a trust verdict from a wildcard.
+fn open_dag_error(e: DagError) -> OpenError {
+    match e {
+        DagError::UnsupportedFormat { version } => OpenError::UnsupportedFormat { version },
+        DagError::RootTooLarge { size, limit } => OpenError::Unavailable(format!(
+            "content DAG root exceeds the cap: {size} > {limit}"
+        )),
+        e @ (DagError::Cbor(_)
+        | DagError::ZeroChunkSize
+        | DagError::MalformedLeafCid
+        | DagError::LinkCountMismatch) => {
+            OpenError::Trust(format!("content DAG root rejected: [{}]", e.check()))
         }
     }
 }
@@ -142,8 +168,7 @@ pub async fn open_content<H: Http>(
     )
     .await
     .map_err(open_read_error)?;
-    let manifest = decode_root(&root_block)
-        .map_err(|e| OpenError::Trust(format!("content DAG root rejected: {e:?}")))?;
+    let manifest = decode_root(&root_block).map_err(open_dag_error)?;
     if manifest.size != version.size {
         return Err(OpenError::Trust(format!(
             "manifest size {} disagrees with version size {}",
@@ -181,6 +206,7 @@ mod tests {
     use super::*;
     use crate::testkit::SeededEntropy;
     use cipherbox_core::content::verify_cid;
+    use cipherbox_core::error::Malformed;
     use cipherbox_core::suite::aead::KEY_LEN;
 
     #[test]
@@ -217,6 +243,32 @@ mod tests {
         assert_eq!(
             recovered, plaintext,
             "verified reassembly equals the original"
+        );
+    }
+
+    #[test]
+    fn an_unreadable_root_format_is_classified_apart_from_a_trust_verdict() {
+        assert_eq!(
+            open_dag_error(DagError::UnsupportedFormat { version: 2 }),
+            OpenError::UnsupportedFormat { version: 2 },
+            "an out-of-date client is not a forged record (#820)"
+        );
+        assert!(matches!(
+            open_dag_error(DagError::LinkCountMismatch),
+            OpenError::Trust(_)
+        ));
+        assert!(matches!(
+            open_dag_error(DagError::Cbor(
+                Malformed::MissingField { field: "v" }.into()
+            )),
+            OpenError::Trust(_)
+        ));
+        assert!(
+            matches!(
+                open_dag_error(DagError::RootTooLarge { size: 5, limit: 4 }),
+                OpenError::Unavailable(_)
+            ),
+            "an over-cap root matches read_block's own cap verdict"
         );
     }
 

--- a/crates/engine/src/content/profile.rs
+++ b/crates/engine/src/content/profile.rs
@@ -1,14 +1,13 @@
-//! The content profile — the open-edge chunk-framing constant
-//! (blueprint/engine.md "Content plane"; "Open edges": "Chunk size, DAG shape,
-//! retention defaults ... freeze alongside the KAT manifest").
+//! The content profile — the frozen chunk-framing constant
+//! (blueprint/engine.md "Content plane"; frozen by #820 and pinned by the
+//! engine KAT).
 //!
 //! Chunk size is engine-owned per core.md's hand-off and, like the sync timing
 //! profile, is injected rather than hardcoded at a call site: framing reads the
-//! size from the profile handed in, so a future measured value lands as one
-//! profile-constant change.
+//! size from the profile handed in.
 
-/// The content-plane framing profile (#630). Fixed-size chunking is the whole
-/// of the shape today; DAG fan-out/balancing stays flat (an open edge below).
+/// The content-plane framing profile (#630). Fixed-size chunking over a flat
+/// DAG is the whole of the shape, frozen by #820.
 ///
 /// There is deliberately **no `Default`** (mirrors [`crate::profile`]): every
 /// construction site names its profile, and the chunk size is always a real,
@@ -27,14 +26,15 @@ pub struct ContentProfile {
 }
 
 impl ContentProfile {
-    /// Shipped framing: 1 MiB chunks.
+    /// Shipped framing, frozen by #820: the **sealed leaf** is exactly 1 MiB.
     ///
-    /// A placeholder pending the measurement process in blueprint/testing.md
-    /// ("The profile is where measured constants land"); it lands as a
-    /// profile-constant change with its measurement linked, and the DAG fan-out
-    /// open edge is settled alongside it.
+    /// The 1 MiB budget belongs to the block, not the plaintext, because the
+    /// ecosystem imposes its limits on blocks — so the plaintext chunk is
+    /// 1 MiB less core's seal overhead (`nonce || ciphertext||tag`). Frozen in
+    /// every published root and pinned by the engine KAT: changing it changes
+    /// the wire format.
     pub const PRODUCTION: Self = Self {
-        chunk_size: 1 << 20,
+        chunk_size: 1_048_536,
     };
 
     /// CI framing: 16-byte chunks so multi-chunk framing and DAG assembly are
@@ -65,10 +65,18 @@ impl ContentProfile {
 #[allow(clippy::assertions_on_constants)]
 mod tests {
     use super::*;
+    use cipherbox_core::content::seal_chunk;
+    use cipherbox_core::suite::aead::{KEY_LEN, NONCE_LEN};
 
     #[test]
-    fn production_chunk_size_is_one_mib() {
-        assert_eq!(ContentProfile::PRODUCTION.chunk_size(), 1 << 20);
+    fn a_production_chunk_seals_to_exactly_a_one_mib_block() {
+        let plaintext = vec![0u8; ContentProfile::PRODUCTION.chunk_size()];
+        let sealed = seal_chunk(&[0u8; KEY_LEN], &[0u8; NONCE_LEN], &plaintext);
+        assert_eq!(
+            sealed.len(),
+            1 << 20,
+            "the 1 MiB budget belongs to the block, not the plaintext"
+        );
     }
 
     #[test]

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -489,6 +489,12 @@ pub enum EngineError {
         /// The verdict classification; never carries key material.
         message: String,
     },
+    /// The content's DAG root declared a format version this build cannot
+    /// read; see [`DagError::UnsupportedFormat`](crate::DagError).
+    UnsupportedContentFormat {
+        /// The version the root declared.
+        version: u64,
+    },
     /// The command's pipeline slice has not landed yet (scaffold state).
     Unimplemented {
         /// [`Command::name`] of the rejected command.
@@ -582,6 +588,10 @@ impl fmt::Display for EngineError {
                 write!(f, "content unavailable: {message}")
             }
             EngineError::TrustViolation { message } => write!(f, "trust violation: {message}"),
+            EngineError::UnsupportedContentFormat { version } => write!(
+                f,
+                "content format version {version} is not supported by this client"
+            ),
             EngineError::Unimplemented { command } => {
                 write!(f, "command not implemented yet: {command}")
             }
@@ -1542,6 +1552,9 @@ impl<T: SeamTypes> Engine<T> {
             .map_err(|e| match e {
                 OpenError::Trust(message) => EngineError::TrustViolation { message },
                 OpenError::Unavailable(message) => EngineError::ContentUnavailable { message },
+                OpenError::UnsupportedFormat { version } => {
+                    EngineError::UnsupportedContentFormat { version }
+                }
             })?;
         Ok((
             plaintext,
@@ -1943,6 +1956,10 @@ mod tests {
             "command not implemented yet: create"
         );
         assert_eq!(EngineError::NotStarted.to_string(), "engine not started");
+        assert_eq!(
+            EngineError::UnsupportedContentFormat { version: 2 }.to_string(),
+            "content format version 2 is not supported by this client"
+        );
     }
 
     // --- facade wiring: reads, command execution, event emission ---

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -49,8 +49,8 @@ pub use api::{
 pub use content::{
     ByoIpfsConfig, ByoKind, ContentDag, ContentKey, ContentPlane, ContentProfile, ContentVersion,
     DAG_ROOT_CODEC, DagError, Gateway, GatewayConfig, GatewaySource, PinMode, ProviderError,
-    PrunePlan, QuotaExceeded, ReadError, RootManifest, SealError, SealedChunk, SealedContent,
-    assemble, decode_root, frame_and_seal, leaf_range_for_byte_range, plan_prune,
+    PrunePlan, QuotaExceeded, ROOT_FORMAT_VERSION, ReadError, RootManifest, SealError, SealedChunk,
+    SealedContent, assemble, decode_root, frame_and_seal, leaf_range_for_byte_range, plan_prune,
     pre_flight_quota_check, read_block, seal_content, test_connection, validate_endpoint,
 };
 pub use entropy::{Entropy, EntropyError};

--- a/crates/engine/tests/kat_content.rs
+++ b/crates/engine/tests/kat_content.rs
@@ -1,0 +1,456 @@
+//! The engine's content-DAG KAT suite — the sibling of core's manifest sweep
+//! (#820 §5). Core's sweep is core-scoped by construction: it enumerates core's
+//! error surface and cannot regenerate engine-produced bytes.
+//!
+//! Fixtures are embedded at compile time, so the suite never depends on the
+//! working directory. `crates/engine/kat` is written only by
+//! `cargo run -p cipherbox-engine --example kat_gen`; CI diffs the regenerated
+//! tree, so a format change that is not a deliberate re-freeze fails there.
+
+use std::collections::BTreeSet;
+
+use cipherbox_core::codec::{Value, decode};
+use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, encode_content_cid_str, verify_cid};
+use cipherbox_engine::content::{
+    ContentProfile, DAG_ROOT_CODEC, DagError, ROOT_FORMAT_VERSION, SealedChunk, assemble,
+    decode_root,
+};
+use serde::Deserialize;
+
+const MANIFEST: &str = include_str!("../kat/manifest.json");
+
+/// Every vector file the manifest may reference. Path keys are
+/// manifest-relative (relative to `kat/`).
+const FIXTURES: &[(&str, &str)] = &[
+    (
+        "vectors/content/dag_root_accept.json",
+        include_str!("../kat/vectors/content/dag_root_accept.json"),
+    ),
+    (
+        "vectors/content/dag_root_reject.json",
+        include_str!("../kat/vectors/content/dag_root_reject.json"),
+    ),
+    (
+        "vectors/content/dag_capacity_accept.json",
+        include_str!("../kat/vectors/content/dag_capacity_accept.json"),
+    ),
+    (
+        "vectors/content/dag_capacity_reject.json",
+        include_str!("../kat/vectors/content/dag_capacity_reject.json"),
+    ),
+];
+
+// deny_unknown_fields: a field the schema does not know is a manifest drift,
+// not a tolerance.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Manifest {
+    manifest_version: u64,
+    profile: String,
+    content: ContentSection,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ContentSection {
+    root_format_version: u64,
+    root_cid_codec: u8,
+    production_chunk_size: u64,
+    dag_root_accept: FileCount,
+    dag_root_reject: RejectSection,
+    dag_capacity_accept: FileCount,
+    dag_capacity_reject: RejectSection,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FileCount {
+    file: String,
+    count: usize,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RejectSection {
+    file: String,
+    count: usize,
+    checks: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DagRootAcceptVector {
+    name: String,
+    chunk_size: u64,
+    size: u64,
+    leaf_cids: Vec<String>,
+    root_block: String,
+    content_cid: String,
+    content_cid_str: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DagRootRejectVector {
+    name: String,
+    root_block: String,
+    check: String,
+    class: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DagCapacityAcceptVector {
+    name: String,
+    chunk_size: u64,
+    leaf_count: u64,
+    size: u64,
+    root_block_len: usize,
+    content_cid: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DagCapacityRejectVector {
+    name: String,
+    chunk_size: u64,
+    leaf_count: u64,
+    size: u64,
+    check: String,
+    class: String,
+}
+
+/// The DAG check surface, restated independently of the code under test —
+/// core's manifest sweep uses the same kind of anchor. Without it, dropping a
+/// variant, its `check()` arm, its `CHECKS` entry and its vector in one commit
+/// would leave every gate green.
+const DAG_CHECKS: &[&str] = &[
+    "dag-unsupported-format",
+    "dag-zero-chunk-size",
+    "dag-malformed-leaf-cid",
+    "dag-link-count-mismatch",
+    "dag-root-too-large",
+];
+
+fn manifest() -> Manifest {
+    serde_json::from_str(MANIFEST).expect("kat/manifest.json must match the manifest schema")
+}
+
+fn fixture(path: &str) -> &'static str {
+    FIXTURES
+        .iter()
+        .find(|(p, _)| *p == path)
+        .unwrap_or_else(|| panic!("manifest references {path}, which is not include_str!-embedded"))
+        .1
+}
+
+fn root_accept_vectors(m: &Manifest) -> Vec<DagRootAcceptVector> {
+    serde_json::from_str(fixture(&m.content.dag_root_accept.file)).expect("accept vector shape")
+}
+
+fn root_reject_vectors(m: &Manifest) -> Vec<DagRootRejectVector> {
+    serde_json::from_str(fixture(&m.content.dag_root_reject.file)).expect("reject vector shape")
+}
+
+fn capacity_accept_vectors(m: &Manifest) -> Vec<DagCapacityAcceptVector> {
+    serde_json::from_str(fixture(&m.content.dag_capacity_accept.file)).expect("capacity accept")
+}
+
+fn capacity_reject_vectors(m: &Manifest) -> Vec<DagCapacityRejectVector> {
+    serde_json::from_str(fixture(&m.content.dag_capacity_reject.file)).expect("capacity reject")
+}
+
+fn unhex(s: &str) -> Vec<u8> {
+    hex::decode(s).expect("vector bytes are lowercase hex")
+}
+
+fn profile_of(chunk_size: u64) -> ContentProfile {
+    ContentProfile::new(chunk_size as usize).expect("a vector's chunk size is nonzero")
+}
+
+/// Leaves carrying the given links. `assemble` reads only the CID, so a vector
+/// need not commit the sealed payload.
+fn leaves_with(cids: impl IntoIterator<Item = Vec<u8>>) -> Vec<SealedChunk> {
+    cids.into_iter()
+        .map(|cid| SealedChunk {
+            cid,
+            sealed: Vec::new(),
+        })
+        .collect()
+}
+
+/// A capacity vector's synthetic links: the `raw` content CID of the big-endian
+/// link index, the rule the generator froze the root CID under.
+fn capacity_leaves(count: u64) -> Vec<SealedChunk> {
+    leaves_with((0..count).map(|i| compute_cid(CONTENT_CID_CODEC, &i.to_be_bytes())))
+}
+
+#[test]
+fn manifest_header_pins_the_frozen_content_format() {
+    let m = manifest();
+    assert_eq!(m.manifest_version, 1);
+    assert_eq!(m.profile, "cipherbox/v2 engine content-dag");
+    assert_eq!(m.content.root_format_version, ROOT_FORMAT_VERSION);
+    assert_eq!(m.content.root_cid_codec, DAG_ROOT_CODEC);
+    assert_eq!(
+        m.content.production_chunk_size,
+        ContentProfile::PRODUCTION.chunk_size() as u64,
+        "the manifest and the shipped profile freeze the same chunk size"
+    );
+}
+
+#[test]
+fn fixture_table_matches_manifest_files() {
+    let m = manifest();
+    let referenced: BTreeSet<&str> = [
+        m.content.dag_root_accept.file.as_str(),
+        m.content.dag_root_reject.file.as_str(),
+        m.content.dag_capacity_accept.file.as_str(),
+        m.content.dag_capacity_reject.file.as_str(),
+    ]
+    .into_iter()
+    .collect();
+    let embedded: BTreeSet<&str> = FIXTURES.iter().map(|(p, _)| *p).collect();
+    assert_eq!(
+        referenced, embedded,
+        "every embedded fixture is referenced and every reference is embedded"
+    );
+}
+
+#[test]
+fn vector_counts_are_exact() {
+    let m = manifest();
+    assert_eq!(
+        root_accept_vectors(&m).len(),
+        m.content.dag_root_accept.count
+    );
+    assert_eq!(
+        root_reject_vectors(&m).len(),
+        m.content.dag_root_reject.count
+    );
+    assert_eq!(
+        capacity_accept_vectors(&m).len(),
+        m.content.dag_capacity_accept.count
+    );
+    assert_eq!(
+        capacity_reject_vectors(&m).len(),
+        m.content.dag_capacity_reject.count
+    );
+}
+
+#[test]
+fn vector_names_are_unique_within_each_file() {
+    let m = manifest();
+    let mut names = BTreeSet::new();
+    for name in root_accept_vectors(&m).iter().map(|v| v.name.clone()) {
+        assert!(names.insert(name.clone()), "duplicate accept vector {name}");
+    }
+    names.clear();
+    for name in root_reject_vectors(&m).iter().map(|v| v.name.clone()) {
+        assert!(names.insert(name.clone()), "duplicate reject vector {name}");
+    }
+    names.clear();
+    for name in capacity_accept_vectors(&m).iter().map(|v| v.name.clone()) {
+        assert!(
+            names.insert(name.clone()),
+            "duplicate capacity-accept vector {name}"
+        );
+    }
+    names.clear();
+    for name in capacity_reject_vectors(&m).iter().map(|v| v.name.clone()) {
+        assert!(
+            names.insert(name.clone()),
+            "duplicate capacity-reject vector {name}"
+        );
+    }
+}
+
+#[test]
+fn accept_vectors_reproduce_the_frozen_root_bytes() {
+    let m = manifest();
+    for v in root_accept_vectors(&m) {
+        let leaf_cids: Vec<Vec<u8>> = v.leaf_cids.iter().map(|c| unhex(c)).collect();
+        let dag = assemble(
+            &leaves_with(leaf_cids.clone()),
+            v.size,
+            &profile_of(v.chunk_size),
+        )
+        .unwrap_or_else(|e| panic!("{}: accept vector must assemble, got {e:?}", v.name));
+
+        assert_eq!(
+            dag.root_block,
+            unhex(&v.root_block),
+            "{}: root bytes",
+            v.name
+        );
+        assert_eq!(dag.content_cid, unhex(&v.content_cid), "{}: cid", v.name);
+        assert_eq!(
+            encode_content_cid_str(&dag.content_cid),
+            v.content_cid_str,
+            "{}: cid string",
+            v.name
+        );
+        assert!(
+            verify_cid(&dag.content_cid, &dag.root_block).is_ok(),
+            "{}: the root addresses its own bytes",
+            v.name
+        );
+
+        let decoded = decode_root(&dag.root_block)
+            .unwrap_or_else(|e| panic!("{}: own root must decode, got {e:?}", v.name));
+        assert_eq!(decoded.chunk_size, v.chunk_size, "{}: chunk size", v.name);
+        assert_eq!(decoded.size, v.size, "{}: size", v.name);
+        assert_eq!(decoded.leaf_cids, leaf_cids, "{}: link order", v.name);
+    }
+}
+
+#[test]
+fn every_accept_vector_carries_the_frozen_format_version() {
+    let m = manifest();
+    for v in root_accept_vectors(&m) {
+        let root = decode(&unhex(&v.root_block)).expect("a frozen root is valid det-CBOR");
+        assert_eq!(
+            root.as_map().expect("root is a map").get("v"),
+            Some(&Value::Unsigned(ROOT_FORMAT_VERSION)),
+            "{}: the discriminator is in the published bytes",
+            v.name
+        );
+    }
+}
+
+#[test]
+fn every_accept_vector_frames_at_the_production_chunk_size() {
+    let m = manifest();
+    let production = ContentProfile::PRODUCTION.chunk_size() as u64;
+    for v in root_accept_vectors(&m) {
+        assert_eq!(
+            v.chunk_size, production,
+            "{}: the freeze is only real at production framing",
+            v.name
+        );
+    }
+}
+
+#[test]
+fn reject_vectors_fail_closed_with_the_named_verdict() {
+    let m = manifest();
+    for v in root_reject_vectors(&m) {
+        let error = decode_root(&unhex(&v.root_block))
+            .map(|ok| panic!("{}: reject vector decoded to {ok:?}", v.name))
+            .unwrap_err();
+        assert_eq!(error.check(), v.check, "{}: check", v.name);
+        assert_eq!(error.class(), v.class, "{}: class", v.name);
+    }
+}
+
+#[test]
+fn an_unreadable_format_version_is_never_a_trust_verdict() {
+    let m = manifest();
+    let unsupported: Vec<DagRootRejectVector> = root_reject_vectors(&m)
+        .into_iter()
+        .filter(|v| v.check == "dag-unsupported-format")
+        .collect();
+    assert!(
+        !unsupported.is_empty(),
+        "the format discriminator must be reject-pinned"
+    );
+    for v in unsupported {
+        let error = decode_root(&unhex(&v.root_block)).expect_err("must fail closed");
+        assert_eq!(
+            error.class(),
+            "unsupported",
+            "{}: an out-of-date client is not a forged record (#820)",
+            v.name
+        );
+    }
+}
+
+#[test]
+fn the_flat_dag_ceiling_assembles_and_stays_readable() {
+    let m = manifest();
+    for v in capacity_accept_vectors(&m) {
+        let leaves = capacity_leaves(v.leaf_count);
+        let dag = assemble(&leaves, v.size, &profile_of(v.chunk_size))
+            .unwrap_or_else(|e| panic!("{}: the ceiling must assemble, got {e:?}", v.name));
+        assert_eq!(dag.root_block.len(), v.root_block_len, "{}: size", v.name);
+        assert_eq!(dag.content_cid, unhex(&v.content_cid), "{}: cid", v.name);
+        assert_eq!(
+            decode_root(&dag.root_block)
+                .unwrap_or_else(|e| panic!("{}: ceiling root must decode, got {e:?}", v.name))
+                .leaf_cids
+                .len() as u64,
+            v.leaf_count,
+            "{}: every link survives the round trip",
+            v.name
+        );
+    }
+}
+
+#[test]
+fn one_link_past_the_ceiling_fails_closed_at_assemble() {
+    let m = manifest();
+    for v in capacity_reject_vectors(&m) {
+        let leaves = capacity_leaves(v.leaf_count);
+        let error = assemble(&leaves, v.size, &profile_of(v.chunk_size))
+            .map(|ok| panic!("{}: over-ceiling assembled to {ok:?}", v.name))
+            .unwrap_err();
+        assert_eq!(error.check(), v.check, "{}: check", v.name);
+        assert_eq!(error.class(), v.class, "{}: class", v.name);
+    }
+}
+
+#[test]
+fn reject_checks_lists_match_their_vectors_and_the_error_surface() {
+    let m = manifest();
+    for (listed, present) in [
+        (
+            &m.content.dag_root_reject.checks,
+            root_reject_vectors(&m)
+                .into_iter()
+                .map(|v| v.check)
+                .collect::<BTreeSet<_>>(),
+        ),
+        (
+            &m.content.dag_capacity_reject.checks,
+            capacity_reject_vectors(&m)
+                .into_iter()
+                .map(|v| v.check)
+                .collect::<BTreeSet<_>>(),
+        ),
+    ] {
+        let expected: Vec<String> = DagError::CHECKS
+            .iter()
+            .filter(|c| present.contains(**c))
+            .map(|c| (*c).to_string())
+            .collect();
+        assert_eq!(
+            *listed, expected,
+            "a manifest checks list is the vectors' distinct checks in surface order"
+        );
+    }
+}
+
+/// The engine sweep: no DAG fail-closed check ships unpinned.
+#[test]
+fn every_dag_check_is_pinned_by_a_vector_family() {
+    let m = manifest();
+    let mut covered: BTreeSet<String> = BTreeSet::new();
+    covered.extend(root_reject_vectors(&m).into_iter().map(|v| v.check));
+    covered.extend(capacity_reject_vectors(&m).into_iter().map(|v| v.check));
+
+    assert_eq!(
+        DagError::CHECKS,
+        DAG_CHECKS,
+        "the shipped surface must match this suite's independent anchor"
+    );
+    let surface: BTreeSet<String> = DAG_CHECKS.iter().map(|c| (*c).to_string()).collect();
+    assert_eq!(
+        surface.difference(&covered).collect::<Vec<_>>(),
+        Vec::<&String>::new(),
+        "every DAG check must have a reject vector"
+    );
+    assert!(
+        covered.is_subset(&surface),
+        "every reject-vector check must exist on the error surface"
+    );
+}

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -270,6 +270,7 @@ fn engine_error(error: EngineError) -> JsValue {
         EngineError::NotAFile => "notAFile",
         EngineError::ContentUnavailable { .. } => "contentUnavailable",
         EngineError::TrustViolation { .. } => "trustViolation",
+        EngineError::UnsupportedContentFormat { .. } => "unsupportedContentFormat",
         EngineError::Unimplemented { .. } => "unimplemented",
         EngineError::Seam { .. } => "seam",
         EngineError::Entropy { .. } => "entropy",


### PR DESCRIPTION
Closes #862. Freezes the content format settled by #820 and decomposed by #825, and lands the first engine-side KAT manifest.

## The frozen constants

**`ContentProfile::PRODUCTION.chunk_size = 1_048_536`** (was `1 << 20`). The 1 MiB budget belongs to the **block**, not the plaintext, because the ecosystem imposes its limits on blocks. Core's seal frames a leaf as `nonce || ciphertext || tag` — a 24 B XChaCha20-Poly1305 nonce plus a 16 B Poly1305 tag, 40 B of overhead — so:

```text
1_048_536 plaintext + 40 seal overhead = 1_048_576 = exactly 1 MiB sealed leaf
```

The field stays private behind its nonzero invariant, so a zero chunk size is unrepresentable rather than a fail-late panic in framing.

**`ROOT_FORMAT_VERSION = 1`**, written into every root by `assemble` under the `"v"` key and read **first** by `decode_root`. This is a discriminator, not a compatibility arm: it buys the *quality* of a future failure. A client that meets a fan-out root reports "upgrade your client" instead of a rule-6 trust violation.

**The flat DAG is committed knowingly.** The root inlines every leaf CID, so `MAX_RESOLVED_RECORD_BYTES` caps a single file at **110,375 links = 107.78 GiB**. Both sides of that boundary are now pinned by a capacity vector.

## The error taxonomy

`DagError::InvalidManifest { reason: &'static str }` — free-form strings, unpinnable — splits into four real variants: `UnsupportedFormat { version }`, `ZeroChunkSize`, `MalformedLeafCid`, `LinkCountMismatch`. Each gains a stable `check()` name under a `dag-` prefix that cannot collide with a core check, a `CHECKS` const in declaration order, and an exhaustive `class()` so a new variant must *state* its class rather than silently inherit `"trust"`.

That last part is the point of `OpenError::UnsupportedFormat`, threaded up through `EngineError::UnsupportedContentFormat` and surfaced to wasm as `"unsupportedContentFormat"`: an unreadable *format* is not a verdict about the content. Misfiling it as a trust violation would tell an out-of-date client it had met a forgery.

## The defect this found

`assemble` did not check leaf-CID well-formedness, while `decode_root` hard-rejects it. That is an encode/decode fail-closed asymmetry — AGENTS.md rule 8 — and it means a mis-wired caller could publish a root this crate's own decoder permanently refuses, leaving that version unreadable forever. `assemble` now returns a release-active `Err(DagError::MalformedLeafCid)`, never a `debug_assert!`, covered by a test verified to fire in a release build.

## The KAT

New committed generator `crates/engine/examples/kat_gen.rs` is the only writer of `crates/engine/kat/**`. Ten vectors, **5 accept / 5 reject**:

| Family | Accept | Reject |
| --- | --- | --- |
| `dag_root` | 4 | 4 — one per `DagError` decode check |
| `dag_capacity` | 1 — max links at the ceiling | 1 — one link past it |

The suite `crates/engine/tests/kat_content.rs` (13 tests) asserts behavior against the vectors, never source text, and pins `CHECKS` against the variant list so a new check without a vector fails. Core's own sweep is core-scoped by construction and cannot regenerate engine-produced bytes, which is why the engine needs a sibling manifest.

`Engine Tests` gains a freshness step ahead of the test run, so the committed generator stays the only writer:

```yaml
cargo run -p cipherbox-engine --example kat_gen
git diff --exit-code -- crates/engine/kat
test -z "$(git status --porcelain -- crates/engine/kat)"
```

## Deliberately not in this diff

No write-plane code. `assemble`, `decode_root` and `RootManifest` all have live read-path callers today, so this lands against the existing tested read path. The content write slice is separate per #825 and must be written once, against these final constants — which is why this lands first.

## Test results

- `cargo test -p cipherbox-engine` — 433 lib + 13 KAT + every seam conformance kit, 0 failed
- `cargo test --release -p cipherbox-engine --test kat_content` — 13 passed, confirming the encode-side guard is release-active
- `cargo test --workspace` — 833 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- KAT generator idempotent: regeneration produces no diff

## Review gates

`/security-review`, `/crypto-privacy-review` and `/simplify` all run against `git diff origin/main...HEAD`.

No P0 or P1 findings from any gate. Triage: **7 fixed now, 3 tracked, 14 discarded.**

Fixed in this PR:

1. **`open_dag_error` used a wildcard arm** — exactly the inheritance `DagError::class()` is exhaustive to prevent. A new variant would silently become a trust verdict at the host. Now exhaustive, and `RootTooLarge` maps to `Unavailable` to match `read_block`'s own cap verdict rather than accusing the content.
2. **The `unsupported-format-version` reject vector was otherwise valid**, so it did not prove that the version check outranks the trust invariants — the vector would still pass with that check moved last. Rebuilt invariant-invalid as well, so the frozen corpus pins the precedence on its own.
3. **`max_leaf_count` rebuilt the leaf vector inside every binary-search probe** and pre-checked at `1 << 20` links, computing ~4M leaf CIDs to find a ceiling of 110,375 — on every Rust PR, via the new freshness gate. One pooled vector, subsliced, bounded at `1 << 17`; generator wall time drops from ~7 s to ~1.6 s.
4. **`EngineError::UnsupportedContentFormat`'s Display string shipped unpinned** on every surface. Now asserted.
5. **Comment discipline** — dropped the absence-justifying sentence on `assemble`.
6. **Comment discipline** — collapsed the "not a trust verdict, the client is out of date" rationale from five restatements to its home on `DagError::UnsupportedFormat`.
7. **`crates/core`'s AEAD ceiling test** described the engine as framing 1 MiB chunks; this freeze makes 1 MiB the sealed leaf, not the plaintext.

Tracked, not folded in: the `CHECKS` sweep for the other ten engine planes (#876), plus two acceptance criteria added to #868 — binding the publisher-declared `chunkSize` at the read path, which needs an engine-held `ContentProfile` that arrives with the write plane, and verifying a 1,048,576-byte raw block round-trips through a real gateway before the write plane ships.

Follow-up filed: #876 — this slice's `check()` sweep covers `DagError` only; the other ten engine fail-closed surfaces across the adoption gate, grants, and rotation planes have a `check()` string with no `CHECKS` const and no vectors. That is a cross-plane slice, so it is tracked rather than folded in, with a dependency edge to #635.

## Merge ordering

Queued behind #875. Overlaps #864 in `blueprint/engine.md`, `crates/engine/src/facade.rs`, `crates/engine/src/lib.rs` and `crates/wasm/src/host.rs`; all four auto-merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic content-DAG reference vectors covering valid roots, invalid formats, malformed links, and capacity limits.
  * Added clear error reporting for unsupported content formats, including stable client-side error codes.
  * Production content framing now produces sealed 1 MiB leaves.

* **Bug Fixes**
  * Strengthened validation for malformed roots, zero chunk sizes, mismatched link counts, and oversized DAGs.

* **Documentation**
  * Documented fixed chunking, DAG structure, format versioning, and capacity limits.

* **Tests**
  * CI now verifies generated reference vectors remain current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->