### PR TITLE
feat: build the crates/fuse operation core and host-adapter trait

### DIFF
--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -110,8 +110,7 @@ pub enum PendingClass {
 }
 
 /// A node's host-facing attributes, projected from the rendered view for a
-/// FUSE getattr/readdir. Kind-uniform metadata only — content size and
-/// timestamps land with the content-plane slice.
+/// FUSE getattr/readdir.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeAttrs {
     /// Stable node id.
@@ -120,6 +119,10 @@ pub struct NodeAttrs {
     pub name: String,
     /// File or folder.
     pub kind: NodeKind,
+    /// Plaintext content size in bytes, once the content plane projects it.
+    pub size: Option<u64>,
+    /// Modification time (Unix millis), once projected.
+    pub mtime: Option<u64>,
     /// Retained version count, `None` until projected.
     pub content_version: Option<u64>,
 }
@@ -684,6 +687,8 @@ fn node_attrs(meta: &NodeMeta) -> NodeAttrs {
         id: meta.id,
         name: meta.name.clone(),
         kind: meta.kind,
+        size: meta.size,
+        mtime: meta.mtime,
         content_version: meta.content_version,
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -56,8 +56,9 @@ pub use content::{
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{
-    Breadcrumb, Command, Engine, EngineError, Event, EventStream, LoginSecret, NodeId, NodeKind,
-    OpPhase, Permission, PlaintextContent, SnapshotChild, SnapshotView, Staleness,
+    Breadcrumb, Command, Engine, EngineError, EngineView, Event, EventStream, LoginSecret,
+    NodeAttrs, NodeId, NodeKind, OpPhase, Permission, PlaintextContent, SnapshotChild,
+    SnapshotView, Staleness, StatFs,
 };
 pub use gate::{
     Adopted, Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason,

--- a/crates/fuse/Cargo.toml
+++ b/crates/fuse/Cargo.toml
@@ -9,3 +9,8 @@ publish.workspace = true
 
 [dependencies]
 cipherbox-engine.workspace = true
+
+[dev-dependencies]
+# The vfs suite drives a real engine over the in-memory seam fakes and the
+# virtual clock — no kernel, no network, no wall clock.
+cipherbox-engine = { workspace = true, features = ["test-kit"] }

--- a/crates/fuse/src/adapter.rs
+++ b/crates/fuse/src/adapter.rs
@@ -3,9 +3,7 @@
 //!
 //! Inbound, an adapter decodes its own wire protocol and calls the operation
 //! core with platform-normalized names; outbound, the core hands it
-//! invalidations to push at the kernel. Everything platform-shaped —
-//! errno/NTSTATUS mapping, case-insensitive presentation, readdir cookie
-//! quirks — lives on this side of the trait, and nothing else does.
+//! invalidations to push at the kernel.
 
 use core::time::Duration;
 
@@ -55,11 +53,8 @@ pub struct CacheTtls {
 }
 
 impl CacheTtls {
-    /// Cache lifetimes for a mount with these capabilities, read off the sync
-    /// timing profile rather than hardcoded: a push-capable mount may hold a
-    /// cache entry until the staleness threshold, since a real change arrives
-    /// as an invalidation. Without push, nothing revalidates on its own, so
-    /// the ceiling is one poll cycle.
+    /// Without push, nothing revalidates on its own, so the ceiling is one
+    /// poll cycle.
     pub fn for_host(capabilities: &HostCapabilities, profile: &SyncTimingProfile) -> Self {
         let ttl = if capabilities.push_invalidation {
             profile.stale_after
@@ -124,7 +119,7 @@ mod tests {
     }
 
     #[test]
-    fn no_profile_yields_a_zero_ttl() {
+    fn every_configuration_yields_a_nonzero_ttl() {
         for profile in [SyncTimingProfile::PRODUCTION, SyncTimingProfile::CI] {
             for push_invalidation in [true, false] {
                 let ttls = CacheTtls::for_host(&HostCapabilities { push_invalidation }, &profile);

--- a/crates/fuse/src/adapter.rs
+++ b/crates/fuse/src/adapter.rs
@@ -1,0 +1,136 @@
+//! The host-adapter trait — one implementation per mount technology
+//! (blueprint/desktop.md "The FS core and host adapters").
+//!
+//! Inbound, an adapter decodes its own wire protocol and calls the operation
+//! core with platform-normalized names; outbound, the core hands it
+//! invalidations to push at the kernel. Everything platform-shaped —
+//! errno/NTSTATUS mapping, case-insensitive presentation, readdir cookie
+//! quirks — lives on this side of the trait, and nothing else does.
+
+use core::time::Duration;
+
+use cipherbox_engine::SyncTimingProfile;
+
+/// What the core tells an adapter has changed, so the kernel's cache for it
+/// stops being trusted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Invalidation {
+    /// The node's content bytes changed.
+    Data {
+        /// The affected inode.
+        ino: u64,
+    },
+    /// The node's attributes changed.
+    Attributes {
+        /// The affected inode.
+        ino: u64,
+    },
+    /// A directory entry appeared, changed, or vanished.
+    Entry {
+        /// The directory holding the entry.
+        parent: u64,
+        /// The entry's name.
+        name: String,
+    },
+}
+
+/// What a mount technology can do for the core.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostCapabilities {
+    /// Whether the adapter can push invalidation at the kernel. An adapter
+    /// that cannot must say so: the core then falls back to short cache TTLs
+    /// for that mount, because nothing else would ever revalidate.
+    pub push_invalidation: bool,
+}
+
+/// The kernel-facing cache lifetimes for one mount, derived from what its
+/// adapter declared. Never zero — v1's dir-TTL-0 workaround was the symptom of
+/// a mount that could not invalidate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CacheTtls {
+    /// How long a name→inode binding may be cached.
+    pub entry: Duration,
+    /// How long attributes may be cached.
+    pub attr: Duration,
+}
+
+impl CacheTtls {
+    /// Cache lifetimes for a mount with these capabilities, read off the sync
+    /// timing profile rather than hardcoded: a push-capable mount may hold a
+    /// cache entry until the staleness threshold, since a real change arrives
+    /// as an invalidation. Without push, nothing revalidates on its own, so
+    /// the ceiling is one poll cycle.
+    pub fn for_host(capabilities: &HostCapabilities, profile: &SyncTimingProfile) -> Self {
+        let ttl = if capabilities.push_invalidation {
+            profile.stale_after
+        } else {
+            profile.poll_cadence
+        };
+        Self {
+            entry: ttl,
+            attr: ttl,
+        }
+    }
+}
+
+/// One mount technology's host adapter.
+///
+/// Invalidation is infallible from the core's side: a mutation has already
+/// happened durably by the time the core reports it, so a kernel that refuses
+/// the notification is the adapter's problem to absorb, never a reason to fail
+/// the operation back to the caller.
+pub trait HostAdapter {
+    /// What this mount can do.
+    fn capabilities(&self) -> HostCapabilities;
+
+    /// Push one invalidation at the kernel.
+    fn invalidate(&self, invalidation: Invalidation);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_push_capable_mount_may_cache_up_to_the_staleness_threshold() {
+        let profile = SyncTimingProfile::PRODUCTION;
+        let ttls = CacheTtls::for_host(
+            &HostCapabilities {
+                push_invalidation: true,
+            },
+            &profile,
+        );
+        assert_eq!(ttls.entry, profile.stale_after);
+        assert_eq!(ttls.attr, profile.stale_after);
+    }
+
+    #[test]
+    fn a_mount_without_push_falls_back_to_a_shorter_ttl() {
+        let profile = SyncTimingProfile::PRODUCTION;
+        let with_push = CacheTtls::for_host(
+            &HostCapabilities {
+                push_invalidation: true,
+            },
+            &profile,
+        );
+        let without_push = CacheTtls::for_host(
+            &HostCapabilities {
+                push_invalidation: false,
+            },
+            &profile,
+        );
+        assert!(without_push.entry < with_push.entry);
+        assert!(without_push.attr < with_push.attr);
+    }
+
+    #[test]
+    fn no_profile_yields_a_zero_ttl() {
+        for profile in [SyncTimingProfile::PRODUCTION, SyncTimingProfile::CI] {
+            for push_invalidation in [true, false] {
+                let ttls = CacheTtls::for_host(&HostCapabilities { push_invalidation }, &profile);
+                assert!(!ttls.entry.is_zero());
+                assert!(!ttls.attr.is_zero());
+            }
+        }
+    }
+}

--- a/crates/fuse/src/error.rs
+++ b/crates/fuse/src/error.rs
@@ -1,10 +1,5 @@
-//! The operation core's failure vocabulary.
-//!
-//! Semantic, not numeric: each host adapter maps these onto its own protocol
-//! (errno on the FUSE hosts, NTSTATUS on WinFsp). Deciding *what* failed once,
-//! centrally, is what stops the two v1 operation trees from disagreeing about
-//! the same condition — the divergence that produced a revocation bypass in
-//! exactly one of them.
+//! The operation core's failure vocabulary. Semantic, not numeric: each host
+//! adapter maps these onto its own protocol (errno, NTSTATUS).
 
 use core::fmt;
 
@@ -36,6 +31,9 @@ pub enum VfsError {
     NotEmpty,
     /// A node of that name already exists under the parent.
     AlreadyExists,
+    /// The operation is structurally impossible — moving a folder inside
+    /// itself, which would detach the whole subtree from the root.
+    Invalid,
     /// The name is not admissible.
     InvalidName(NameError),
     /// The handle is not open.
@@ -61,9 +59,11 @@ pub enum VfsError {
     },
 }
 
-impl VfsError {
-    /// Classify a facade error for the mount.
-    pub fn from_engine(error: EngineError) -> Self {
+impl From<EngineError> for VfsError {
+    /// Exhaustive by construction: no wildcard arm, so a new `EngineError`
+    /// variant is a compile error here rather than a fail-closed verdict that
+    /// silently degrades to [`Internal`](VfsError::Internal).
+    fn from(error: EngineError) -> Self {
         match error {
             EngineError::UnknownNode => VfsError::NotFound,
             EngineError::NotAFolder => VfsError::NotADirectory,
@@ -75,8 +75,14 @@ impl VfsError {
             EngineError::UnsupportedContentFormat { version } => VfsError::Unavailable {
                 message: format!("unsupported content format version {version}"),
             },
-            other => VfsError::Internal {
-                message: other.to_string(),
+            EngineError::Seam { message }
+            | EngineError::Entropy { message }
+            | EngineError::Auth { message } => VfsError::Internal { message },
+            error @ (EngineError::NotStarted
+            | EngineError::AlreadyStarted
+            | EngineError::InvalidSecret
+            | EngineError::Unimplemented { .. }) => VfsError::Internal {
+                message: error.to_string(),
             },
         }
     }
@@ -96,6 +102,7 @@ impl fmt::Display for VfsError {
             VfsError::IsADirectory => f.write_str("is a directory"),
             VfsError::NotEmpty => f.write_str("directory not empty"),
             VfsError::AlreadyExists => f.write_str("already exists"),
+            VfsError::Invalid => f.write_str("invalid operation"),
             VfsError::InvalidName(reason) => write!(f, "invalid name: {reason:?}"),
             VfsError::BadHandle => f.write_str("bad file handle"),
             VfsError::OverBudget(cause) => write!(f, "over budget: {cause:?}"),
@@ -114,16 +121,13 @@ mod tests {
 
     #[test]
     fn node_shape_errors_map_to_their_posix_counterparts() {
+        assert_eq!(VfsError::from(EngineError::UnknownNode), VfsError::NotFound);
         assert_eq!(
-            VfsError::from_engine(EngineError::UnknownNode),
-            VfsError::NotFound
-        );
-        assert_eq!(
-            VfsError::from_engine(EngineError::NotAFolder),
+            VfsError::from(EngineError::NotAFolder),
             VfsError::NotADirectory
         );
         assert_eq!(
-            VfsError::from_engine(EngineError::NotAFile),
+            VfsError::from(EngineError::NotAFile),
             VfsError::IsADirectory
         );
     }
@@ -140,7 +144,7 @@ mod tests {
         ] {
             assert!(
                 matches!(
-                    VfsError::from_engine(error.clone()),
+                    VfsError::from(error.clone()),
                     VfsError::TrustViolation { .. }
                 ),
                 "{error} must never degrade to availability"
@@ -157,7 +161,7 @@ mod tests {
             EngineError::UnsupportedContentFormat { version: 9 },
         ] {
             assert!(matches!(
-                VfsError::from_engine(error),
+                VfsError::from(error),
                 VfsError::Unavailable { .. }
             ));
         }
@@ -181,17 +185,9 @@ mod tests {
             },
         ] {
             assert!(
-                matches!(VfsError::from_engine(error), VfsError::Internal { .. }),
+                matches!(VfsError::from(error), VfsError::Internal { .. }),
                 "a host-local failure must not read as a trust verdict"
             );
         }
-    }
-
-    #[test]
-    fn the_two_over_budget_causes_stay_distinguishable() {
-        assert_ne!(
-            VfsError::OverBudget(OverBudgetCause::DeviceStaging),
-            VfsError::OverBudget(OverBudgetCause::AccountQuota),
-        );
     }
 }

--- a/crates/fuse/src/error.rs
+++ b/crates/fuse/src/error.rs
@@ -1,0 +1,197 @@
+//! The operation core's failure vocabulary.
+//!
+//! Semantic, not numeric: each host adapter maps these onto its own protocol
+//! (errno on the FUSE hosts, NTSTATUS on WinFsp). Deciding *what* failed once,
+//! centrally, is what stops the two v1 operation trees from disagreeing about
+//! the same condition — the divergence that produced a revocation bypass in
+//! exactly one of them.
+
+use core::fmt;
+
+use cipherbox_engine::EngineError;
+
+use crate::name::NameError;
+
+/// Which budget a write exceeded. The two are different facts about the world
+/// and different errnos to the user: a full device is not a full account.
+/// Which errno each maps to is the adapter's call (#867).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OverBudgetCause {
+    /// This device's offline staging budget is exhausted.
+    DeviceStaging,
+    /// The account's hosted storage quota refused the write.
+    AccountQuota,
+}
+
+/// Why a vfs operation failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VfsError {
+    /// No such node.
+    NotFound,
+    /// The operation named a file where it needed a folder.
+    NotADirectory,
+    /// The operation named a folder where it needed a file.
+    IsADirectory,
+    /// A folder with children cannot be removed.
+    NotEmpty,
+    /// A node of that name already exists under the parent.
+    AlreadyExists,
+    /// The name is not admissible.
+    InvalidName(NameError),
+    /// The handle is not open.
+    BadHandle,
+    /// A write exceeded a storage budget.
+    OverBudget(OverBudgetCause),
+    /// A fail-closed trust verdict below the facade. Never retried, never
+    /// rendered, and never conflated with staleness (security rule 6).
+    TrustViolation {
+        /// The verdict classification; never key material.
+        message: String,
+    },
+    /// The engine could not serve the read right now. Availability, retryable.
+    Unavailable {
+        /// Diagnostic message; never key material.
+        message: String,
+    },
+    /// A host-local failure: durable-queue I/O, or a facade call the mount had
+    /// no business making.
+    Internal {
+        /// Diagnostic message; never key material.
+        message: String,
+    },
+}
+
+impl VfsError {
+    /// Classify a facade error for the mount.
+    pub fn from_engine(error: EngineError) -> Self {
+        match error {
+            EngineError::UnknownNode => VfsError::NotFound,
+            EngineError::NotAFolder => VfsError::NotADirectory,
+            EngineError::NotAFile => VfsError::IsADirectory,
+            EngineError::TrustViolation { message } | EngineError::ColdStart { message } => {
+                VfsError::TrustViolation { message }
+            }
+            EngineError::ContentUnavailable { message } => VfsError::Unavailable { message },
+            EngineError::UnsupportedContentFormat { version } => VfsError::Unavailable {
+                message: format!("unsupported content format version {version}"),
+            },
+            other => VfsError::Internal {
+                message: other.to_string(),
+            },
+        }
+    }
+}
+
+impl From<NameError> for VfsError {
+    fn from(error: NameError) -> Self {
+        VfsError::InvalidName(error)
+    }
+}
+
+impl fmt::Display for VfsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VfsError::NotFound => f.write_str("no such node"),
+            VfsError::NotADirectory => f.write_str("not a directory"),
+            VfsError::IsADirectory => f.write_str("is a directory"),
+            VfsError::NotEmpty => f.write_str("directory not empty"),
+            VfsError::AlreadyExists => f.write_str("already exists"),
+            VfsError::InvalidName(reason) => write!(f, "invalid name: {reason:?}"),
+            VfsError::BadHandle => f.write_str("bad file handle"),
+            VfsError::OverBudget(cause) => write!(f, "over budget: {cause:?}"),
+            VfsError::TrustViolation { message } => write!(f, "trust violation: {message}"),
+            VfsError::Unavailable { message } => write!(f, "unavailable: {message}"),
+            VfsError::Internal { message } => write!(f, "internal: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for VfsError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_shape_errors_map_to_their_posix_counterparts() {
+        assert_eq!(
+            VfsError::from_engine(EngineError::UnknownNode),
+            VfsError::NotFound
+        );
+        assert_eq!(
+            VfsError::from_engine(EngineError::NotAFolder),
+            VfsError::NotADirectory
+        );
+        assert_eq!(
+            VfsError::from_engine(EngineError::NotAFile),
+            VfsError::IsADirectory
+        );
+    }
+
+    #[test]
+    fn every_fail_closed_verdict_stays_a_trust_violation() {
+        for error in [
+            EngineError::TrustViolation {
+                message: "rejected child record".into(),
+            },
+            EngineError::ColdStart {
+                message: "regressed floor".into(),
+            },
+        ] {
+            assert!(
+                matches!(
+                    VfsError::from_engine(error.clone()),
+                    VfsError::TrustViolation { .. }
+                ),
+                "{error} must never degrade to availability"
+            );
+        }
+    }
+
+    #[test]
+    fn availability_failures_stay_availability() {
+        for error in [
+            EngineError::ContentUnavailable {
+                message: "no reachable source".into(),
+            },
+            EngineError::UnsupportedContentFormat { version: 9 },
+        ] {
+            assert!(matches!(
+                VfsError::from_engine(error),
+                VfsError::Unavailable { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn host_side_failures_are_internal_and_never_trust_verdicts() {
+        for error in [
+            EngineError::NotStarted,
+            EngineError::AlreadyStarted,
+            EngineError::InvalidSecret,
+            EngineError::Unimplemented { command: "grant" },
+            EngineError::Seam {
+                message: "fsync failed".into(),
+            },
+            EngineError::Entropy {
+                message: "no entropy".into(),
+            },
+            EngineError::Auth {
+                message: "401".into(),
+            },
+        ] {
+            assert!(
+                matches!(VfsError::from_engine(error), VfsError::Internal { .. }),
+                "a host-local failure must not read as a trust verdict"
+            );
+        }
+    }
+
+    #[test]
+    fn the_two_over_budget_causes_stay_distinguishable() {
+        assert_ne!(
+            VfsError::OverBudget(OverBudgetCause::DeviceStaging),
+            VfsError::OverBudget(OverBudgetCause::AccountQuota),
+        );
+    }
+}

--- a/crates/fuse/src/handle.rs
+++ b/crates/fuse/src/handle.rs
@@ -1,9 +1,6 @@
 //! Open-file handles for one mount session. Key-free like the inode map: a
 //! handle records which node it addresses and how it was opened, never
 //! anything derived from a key.
-//!
-//! The byte paths behind a handle — ranged chunk reads and the sealed spill
-//! file a write lands in — are `crates/fuse`'s next slice.
 
 use std::collections::HashMap;
 
@@ -71,16 +68,6 @@ impl HandleTable {
     pub fn close(&mut self, id: HandleId) -> Option<OpenFile> {
         self.open.remove(&id)
     }
-
-    /// How many handles are open.
-    pub fn len(&self) -> usize {
-        self.open.len()
-    }
-
-    /// Whether no handle is open.
-    pub fn is_empty(&self) -> bool {
-        self.open.is_empty()
-    }
 }
 
 #[cfg(test)]
@@ -111,7 +98,6 @@ mod tests {
         assert!(table.close(id).is_some());
         assert_eq!(table.get(id), None);
         assert!(table.close(id).is_none(), "a second close is not an open");
-        assert!(table.is_empty());
     }
 
     #[test]
@@ -129,8 +115,8 @@ mod tests {
         let reader = table.open(node(1), Access::Read);
         let writer = table.open(node(1), Access::Write);
         assert_ne!(reader, writer);
-        assert_eq!(table.len(), 2);
         table.close(reader);
+        assert_eq!(table.get(reader), None);
         assert_eq!(table.get(writer).map(|h| h.access), Some(Access::Write));
     }
 

--- a/crates/fuse/src/handle.rs
+++ b/crates/fuse/src/handle.rs
@@ -1,0 +1,143 @@
+//! Open-file handles for one mount session. Key-free like the inode map: a
+//! handle records which node it addresses and how it was opened, never
+//! anything derived from a key.
+//!
+//! The byte paths behind a handle — ranged chunk reads and the sealed spill
+//! file a write lands in — are `crates/fuse`'s next slice.
+
+use std::collections::HashMap;
+
+use cipherbox_engine::NodeId;
+
+/// A kernel file-handle token, unique for the mount session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct HandleId(pub u64);
+
+/// How a handle was opened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Access {
+    /// Reads only.
+    Read,
+    /// Writes only.
+    Write,
+    /// Reads and writes.
+    ReadWrite,
+}
+
+impl Access {
+    /// Whether this handle may write.
+    pub fn writable(self) -> bool {
+        matches!(self, Access::Write | Access::ReadWrite)
+    }
+}
+
+/// What one open handle addresses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpenFile {
+    /// The node the handle is open on.
+    pub node: NodeId,
+    /// How it was opened.
+    pub access: Access,
+}
+
+/// The session's open handles.
+#[derive(Debug, Default)]
+pub struct HandleTable {
+    open: HashMap<HandleId, OpenFile>,
+    next: u64,
+}
+
+impl HandleTable {
+    /// An empty table.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Open a handle on `node`. Ids are monotonic and never reused, so a
+    /// release cannot be raced onto a later open.
+    pub fn open(&mut self, node: NodeId, access: Access) -> HandleId {
+        let id = HandleId(self.next);
+        self.next += 1;
+        self.open.insert(id, OpenFile { node, access });
+        id
+    }
+
+    /// The handle's target, if it is still open.
+    pub fn get(&self, id: HandleId) -> Option<OpenFile> {
+        self.open.get(&id).copied()
+    }
+
+    /// Close a handle, reporting whether it was open.
+    pub fn close(&mut self, id: HandleId) -> Option<OpenFile> {
+        self.open.remove(&id)
+    }
+
+    /// How many handles are open.
+    pub fn len(&self) -> usize {
+        self.open.len()
+    }
+
+    /// Whether no handle is open.
+    pub fn is_empty(&self) -> bool {
+        self.open.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(byte: u8) -> NodeId {
+        NodeId([byte; 16])
+    }
+
+    #[test]
+    fn an_open_handle_resolves_to_its_node() {
+        let mut table = HandleTable::new();
+        let id = table.open(node(1), Access::Read);
+        assert_eq!(
+            table.get(id),
+            Some(OpenFile {
+                node: node(1),
+                access: Access::Read
+            })
+        );
+    }
+
+    #[test]
+    fn closing_releases_the_handle_exactly_once() {
+        let mut table = HandleTable::new();
+        let id = table.open(node(1), Access::ReadWrite);
+        assert!(table.close(id).is_some());
+        assert_eq!(table.get(id), None);
+        assert!(table.close(id).is_none(), "a second close is not an open");
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn ids_are_never_reused_after_a_close() {
+        let mut table = HandleTable::new();
+        let first = table.open(node(1), Access::Read);
+        table.close(first);
+        let second = table.open(node(1), Access::Read);
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn two_opens_on_one_node_are_independent() {
+        let mut table = HandleTable::new();
+        let reader = table.open(node(1), Access::Read);
+        let writer = table.open(node(1), Access::Write);
+        assert_ne!(reader, writer);
+        assert_eq!(table.len(), 2);
+        table.close(reader);
+        assert_eq!(table.get(writer).map(|h| h.access), Some(Access::Write));
+    }
+
+    #[test]
+    fn write_access_is_reported_for_writable_opens_only() {
+        assert!(!Access::Read.writable());
+        assert!(Access::Write.writable());
+        assert!(Access::ReadWrite.writable());
+    }
+}

--- a/crates/fuse/src/inode.rs
+++ b/crates/fuse/src/inode.rs
@@ -37,18 +37,39 @@ impl InodeTable {
         }
     }
 
-    /// Bind the rendered root to [`ROOT_INO`]. Idempotent, and re-points the
-    /// root inode if cold start replaces the anchored root the session opened
-    /// on.
-    pub fn bind_root(&mut self, root: NodeId) {
+    /// Bind the rendered root to [`ROOT_INO`], reporting whether it *moved* —
+    /// a cold start can replace the anchored root the session opened on, and
+    /// then [`ROOT_INO`] addresses a different node than the kernel has
+    /// cached, so the caller must push an invalidation. The first bind of a
+    /// session moves nothing.
+    pub fn bind_root(&mut self, root: NodeId) -> bool {
         if self.root == Some(root) {
-            return;
+            return false;
         }
-        if let Some(previous) = self.root.replace(root) {
+        let previous = self.root.replace(root);
+        if let Some(previous) = previous {
             self.by_node.remove(&previous);
         }
+        // The incoming root may already hold an ordinary number from an
+        // earlier listing; drop it, or the node answers to two inodes.
+        if let Some(stale) = self.by_node.insert(root, ROOT_INO) {
+            self.by_ino.remove(&stale);
+        }
         self.by_ino.insert(ROOT_INO, root);
-        self.by_node.insert(root, ROOT_INO);
+        previous.is_some()
+    }
+
+    /// Drop a binding the kernel has forgotten. Safe because numbers are never
+    /// reused: a later [`ino_for`](Self::ino_for) mints a fresh one rather
+    /// than resurrecting this. The root is never forgotten — the mount would
+    /// lose its anchor.
+    pub fn forget(&mut self, ino: u64) {
+        if ino == ROOT_INO {
+            return;
+        }
+        if let Some(node) = self.by_ino.remove(&ino) {
+            self.by_node.remove(&node);
+        }
     }
 
     /// The node bound to `ino`, if the session has seen it.
@@ -114,14 +135,44 @@ mod tests {
     #[test]
     fn cold_start_repointing_the_root_moves_the_root_inode() {
         let mut table = InodeTable::new();
-        table.bind_root(node(0));
+        assert!(!table.bind_root(node(0)), "the first bind moves nothing");
         let child = table.ino_for(node(9));
+        let promoted = table.ino_for(node(3));
 
-        table.bind_root(node(3));
+        assert!(table.bind_root(node(3)), "a re-anchor must be reported");
+        assert!(
+            !table.bind_root(node(3)),
+            "rebinding the same root does not"
+        );
 
         assert_eq!(table.node(ROOT_INO), Some(node(3)));
         assert_eq!(table.ino_for(node(3)), ROOT_INO);
+        assert_eq!(
+            table.node(promoted),
+            None,
+            "the promoted node must not answer to two inodes"
+        );
         assert_eq!(table.ino_for(node(9)), child, "other bindings survive");
+    }
+
+    #[test]
+    fn a_forgotten_inode_is_dropped_and_never_resurrected() {
+        let mut table = InodeTable::new();
+        table.bind_root(node(0));
+        let ino = table.ino_for(node(7));
+
+        table.forget(ino);
+
+        assert_eq!(table.node(ino), None);
+        assert_ne!(table.ino_for(node(7)), ino, "numbers are never reused");
+    }
+
+    #[test]
+    fn the_root_is_never_forgotten() {
+        let mut table = InodeTable::new();
+        table.bind_root(node(0));
+        table.forget(ROOT_INO);
+        assert_eq!(table.node(ROOT_INO), Some(node(0)));
     }
 
     #[test]

--- a/crates/fuse/src/inode.rs
+++ b/crates/fuse/src/inode.rs
@@ -1,0 +1,133 @@
+//! The key-free inode map: kernel inode numbers ↔ engine node ids, allocated
+//! per mount session (blueprint/desktop.md "Names and attributes").
+//!
+//! Keying on the engine's stable node id — never on `(parent, name)` — is what
+//! makes an inode survive a rename for free, and keeps the map free of any key
+//! material: it holds two integers' worth of identity and nothing else.
+
+use std::collections::HashMap;
+
+use cipherbox_engine::NodeId;
+
+/// The mount root's inode number, fixed by every FUSE-family protocol.
+pub const ROOT_INO: u64 = 1;
+
+/// Kernel inode numbers for one mount session.
+///
+/// Numbers are allocated monotonically and never reused, so a node the kernel
+/// still remembers can never collide with a later one — v1 reallocated and
+/// paid for it in stale-handle disconnects. Bindings live for the session; a
+/// remount renumbers from scratch.
+#[derive(Debug)]
+pub struct InodeTable {
+    by_ino: HashMap<u64, NodeId>,
+    by_node: HashMap<NodeId, u64>,
+    root: Option<NodeId>,
+    next: u64,
+}
+
+impl InodeTable {
+    /// An empty table; [`ROOT_INO`] binds on the first [`bind_root`](Self::bind_root).
+    pub fn new() -> Self {
+        Self {
+            by_ino: HashMap::new(),
+            by_node: HashMap::new(),
+            root: None,
+            next: ROOT_INO + 1,
+        }
+    }
+
+    /// Bind the rendered root to [`ROOT_INO`]. Idempotent, and re-points the
+    /// root inode if cold start replaces the anchored root the session opened
+    /// on.
+    pub fn bind_root(&mut self, root: NodeId) {
+        if self.root == Some(root) {
+            return;
+        }
+        if let Some(previous) = self.root.replace(root) {
+            self.by_node.remove(&previous);
+        }
+        self.by_ino.insert(ROOT_INO, root);
+        self.by_node.insert(root, ROOT_INO);
+    }
+
+    /// The node bound to `ino`, if the session has seen it.
+    pub fn node(&self, ino: u64) -> Option<NodeId> {
+        self.by_ino.get(&ino).copied()
+    }
+
+    /// The inode number for `node`, allocating one on first sight.
+    pub fn ino_for(&mut self, node: NodeId) -> u64 {
+        if let Some(ino) = self.by_node.get(&node) {
+            return *ino;
+        }
+        let ino = self.next;
+        self.next += 1;
+        self.by_ino.insert(ino, node);
+        self.by_node.insert(node, ino);
+        ino
+    }
+}
+
+impl Default for InodeTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(byte: u8) -> NodeId {
+        NodeId([byte; 16])
+    }
+
+    #[test]
+    fn the_root_binds_to_ino_one() {
+        let mut table = InodeTable::new();
+        table.bind_root(node(0));
+        assert_eq!(table.node(ROOT_INO), Some(node(0)));
+        assert_eq!(table.ino_for(node(0)), ROOT_INO);
+    }
+
+    #[test]
+    fn a_node_keeps_its_inode_across_repeated_lookups() {
+        let mut table = InodeTable::new();
+        table.bind_root(node(0));
+        let first = table.ino_for(node(7));
+        assert_eq!(table.ino_for(node(7)), first);
+        assert_eq!(table.node(first), Some(node(7)));
+    }
+
+    #[test]
+    fn distinct_nodes_never_share_an_inode() {
+        let mut table = InodeTable::new();
+        table.bind_root(node(0));
+        let a = table.ino_for(node(1));
+        let b = table.ino_for(node(2));
+        assert_ne!(a, b);
+        assert_ne!(a, ROOT_INO);
+        assert_ne!(b, ROOT_INO);
+    }
+
+    #[test]
+    fn cold_start_repointing_the_root_moves_the_root_inode() {
+        let mut table = InodeTable::new();
+        table.bind_root(node(0));
+        let child = table.ino_for(node(9));
+
+        table.bind_root(node(3));
+
+        assert_eq!(table.node(ROOT_INO), Some(node(3)));
+        assert_eq!(table.ino_for(node(3)), ROOT_INO);
+        assert_eq!(table.ino_for(node(9)), child, "other bindings survive");
+    }
+
+    #[test]
+    fn unknown_inodes_resolve_to_nothing() {
+        let table = InodeTable::new();
+        assert_eq!(table.node(ROOT_INO), None);
+        assert_eq!(table.node(4242), None);
+    }
+}

--- a/crates/fuse/src/lib.rs
+++ b/crates/fuse/src/lib.rs
@@ -1,20 +1,31 @@
-//! CipherBox fuse: filesystem projection core over the engine, backing the
-//! desktop mounts (FUSE-T SMB on macOS, libfuse3 on Linux, WinFsp on Windows).
+//! CipherBox fuse: the filesystem projection over the engine facade, and the
+//! host-adapter trait each mount technology implements — FUSE-T SMB on macOS,
+//! libfuse3 on Linux, WinFsp on Windows.
 //!
-//! Normative design: blueprint/desktop.md
+//! Normative design: blueprint/desktop.md.
+//!
+//! One operation core serves every platform: v1's duplicated per-host
+//! operation trees produced a revocation bypass that existed in exactly one of
+//! them. Everything platform-shaped lives behind [`HostAdapter`] and nothing
+//! else does. The projection holds no key material — the inode and handle maps
+//! carry identity only.
+//!
+//! Content byte paths and the journal ack land with the read/write slice; the
+//! concrete adapters with the adapter slice.
 
-/// Placeholder identity item; the real FS projection lands in later PRs.
-pub const CRATE: &str = "cipherbox-fuse";
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn crate_name() {
-        assert_eq!(super::CRATE, "cipherbox-fuse");
-    }
+pub mod adapter;
+pub mod error;
+pub mod handle;
+pub mod inode;
+pub mod name;
+pub mod ops;
 
-    #[test]
-    fn depends_on_engine() {
-        assert_eq!(cipherbox_engine::CRATE, "cipherbox-engine");
-    }
-}
+pub use adapter::{CacheTtls, HostAdapter, HostCapabilities, Invalidation};
+pub use error::{OverBudgetCause, VfsError};
+pub use handle::{Access, HandleId, HandleTable, OpenFile};
+pub use inode::{InodeTable, ROOT_INO};
+pub use name::{MAX_NAME_BYTES, NameError, is_platform_junk, validate_name};
+pub use ops::{Attributes, DirEntry, FsStats, OperationCore};

--- a/crates/fuse/src/lib.rs
+++ b/crates/fuse/src/lib.rs
@@ -9,23 +9,20 @@
 //! them. Everything platform-shaped lives behind [`HostAdapter`] and nothing
 //! else does. The projection holds no key material — the inode and handle maps
 //! carry identity only.
-//!
-//! Content byte paths and the journal ack land with the read/write slice; the
-//! concrete adapters with the adapter slice.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
-pub mod adapter;
-pub mod error;
-pub mod handle;
-pub mod inode;
-pub mod name;
-pub mod ops;
+mod adapter;
+mod error;
+mod handle;
+mod inode;
+mod name;
+mod ops;
 
 pub use adapter::{CacheTtls, HostAdapter, HostCapabilities, Invalidation};
 pub use error::{OverBudgetCause, VfsError};
 pub use handle::{Access, HandleId, HandleTable, OpenFile};
 pub use inode::{InodeTable, ROOT_INO};
-pub use name::{MAX_NAME_BYTES, NameError, is_platform_junk, validate_name};
-pub use ops::{Attributes, DirEntry, FsStats, OperationCore};
+pub use name::{MAX_NAME_BYTES, NameError, is_emittable, is_platform_junk, validate_name};
+pub use ops::{Attributes, DirEntry, OperationCore};

--- a/crates/fuse/src/name.rs
+++ b/crates/fuse/src/name.rs
@@ -6,6 +6,13 @@
 //! must be creatable on Windows too, or a committed folder stops mounting
 //! everywhere. Uniqueness itself is not decided here — that is the engine's
 //! strict comparator.
+//!
+//! Admission is two-tier, because names also arrive *from* the engine and no
+//! layer below validates them — a peer on any client can commit whatever CBOR
+//! text string it likes. [`is_emittable`] is the narrow tier: names no kernel
+//! protocol can carry at all. [`validate_name`] adds the create-only policy on
+//! top. Everything the wider tier refuses stays listable and removable, or a
+//! name another client committed would be stranded in the vault forever.
 
 /// The longest name the projection admits, in bytes. `statfs` advertises this
 /// same constant, so what is advertised is what is enforced.
@@ -22,8 +29,12 @@ pub enum NameError {
     DotEntry,
     /// The name contained a path separator (`/` or `\`).
     Separator,
-    /// The name contained NUL or another C0 control character.
+    /// The name contained NUL or another control character.
     Control,
+    /// The name contained a bidi-override or zero-width character. These
+    /// render as a different name than they compare as, so a hostile grant
+    /// recipient could dress an executable up as a document.
+    DeceptiveCharacter,
     /// The name contained a character Windows reserves (`< > : " | ? *`).
     ReservedCharacter,
     /// The name ended in a dot or a space, which Windows silently strips.
@@ -42,9 +53,23 @@ const RESERVED_CHARACTERS: &[char] = &['<', '>', ':', '"', '|', '?', '*'];
 /// Windows device names, reserved with or without an extension.
 const RESERVED_DEVICES: &[&str] = &["con", "prn", "aux", "nul"];
 
-/// Exact platform-junk names, ASCII-lowercased for comparison. One list for
-/// every platform: v1 kept a POSIX list and a Windows list that disagreed, so
-/// a `.DS_Store` rejected on macOS synced happily from Windows.
+/// Whether the character reorders or hides the rest of the name when a file
+/// manager draws it. `char::is_control` is category `Cc` only and misses all
+/// of these; the engine's comparator folds case but not format characters, so
+/// nothing downstream catches them either.
+fn is_deceptive(c: char) -> bool {
+    matches!(
+        c,
+        '\u{200B}'..='\u{200F}' // zero-width space/joiners, LRM/RLM
+            | '\u{202A}'..='\u{202E}' // bidi embeddings and overrides
+            | '\u{2066}'..='\u{2069}' // bidi isolates
+            | '\u{FEFF}' // zero-width no-break space
+    )
+}
+
+/// Exact platform-junk names, already folded. One list for every platform: v1
+/// kept a POSIX list and a Windows list that disagreed, so a `.DS_Store`
+/// rejected on macOS synced happily from Windows.
 const JUNK_NAMES: &[&str] = &[
     // macOS
     ".ds_store",
@@ -76,18 +101,43 @@ const JUNK_NAMES: &[&str] = &[
     ".xdg-volume-info",
 ];
 
-/// Platform-junk name prefixes, ASCII-lowercased for comparison.
+/// Platform-junk name prefixes, already folded.
 const JUNK_PREFIXES: &[&str] = &["._", ".trash-"];
+
+/// Case-folded name equality, matching the engine's `collation_key` fold
+/// rather than an ASCII one — U+212A KELVIN SIGN lowercases to `k`, so
+/// `des\u{212A}top.ini` is `desktop.ini` to the engine's comparator and must
+/// be to the junk filter too. Folds lazily so a listing allocates nothing.
+fn folds_to(name: &str, folded: &str) -> bool {
+    name.chars().flat_map(char::to_lowercase).eq(folded.chars())
+}
 
 /// Whether the name is platform junk: refused on create, hidden from
 /// listings, and still reachable by an explicit lookup or unlink so junk that
 /// arrived from another client stays removable through the mount.
 pub fn is_platform_junk(name: &str) -> bool {
-    let folded = name.to_ascii_lowercase();
-    JUNK_NAMES.contains(&folded.as_str())
-        || JUNK_PREFIXES
-            .iter()
-            .any(|prefix| folded.starts_with(prefix))
+    JUNK_NAMES.iter().any(|junk| folds_to(name, junk))
+        || JUNK_PREFIXES.iter().any(|prefix| {
+            let head: String = name
+                .chars()
+                .flat_map(char::to_lowercase)
+                .take(prefix.chars().count())
+                .collect();
+            head == *prefix
+        })
+}
+
+/// Whether the name can be handed to a kernel at all: within the advertised
+/// length, no separator, no NUL or other control character, not a synthesized
+/// dot entry. A name failing this is not a listing the user could act on — it
+/// is a malformed dirent, and every host protocol would mangle or misroute it.
+pub fn is_emittable(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MAX_NAME_BYTES
+        && name != "."
+        && name != ".."
+        && !name.contains(['/', '\\'])
+        && !name.chars().any(char::is_control)
 }
 
 /// Admit a name for create, mkdir, or a rename destination.
@@ -104,8 +154,11 @@ pub fn validate_name(name: &str) -> Result<(), NameError> {
     if name.contains('/') || name.contains('\\') {
         return Err(NameError::Separator);
     }
-    if name.chars().any(|c| c.is_control()) {
+    if name.chars().any(char::is_control) {
         return Err(NameError::Control);
+    }
+    if name.chars().any(is_deceptive) {
+        return Err(NameError::DeceptiveCharacter);
     }
     if name.contains(RESERVED_CHARACTERS) {
         return Err(NameError::ReservedCharacter);
@@ -183,6 +236,23 @@ mod tests {
     }
 
     #[test]
+    fn names_that_render_differently_than_they_compare_are_refused() {
+        for name in [
+            "invoice\u{202E}cod.exe", // right-to-left override: renders "invoiceexe.doc"
+            "report\u{200B}.txt",     // zero-width space: a twin of "report.txt"
+            "a\u{2066}b",
+            "\u{FEFF}notes",
+        ] {
+            assert_eq!(
+                validate_name(name),
+                Err(NameError::DeceptiveCharacter),
+                "{name:?} must not enter the vault"
+            );
+        }
+        assert_eq!(validate_name("naïve — ünïcode.md"), Ok(()));
+    }
+
+    #[test]
     fn windows_hostile_names_are_refused_on_every_platform() {
         for name in ["a<b", "a>b", "a:b", "a\"b", "a|b", "a?b", "a*b"] {
             assert_eq!(
@@ -221,6 +291,31 @@ mod tests {
         ] {
             assert!(is_platform_junk(name), "{name} is junk");
             assert_eq!(validate_name(name), Err(NameError::PlatformJunk));
+        }
+    }
+
+    #[test]
+    fn junk_folds_the_way_the_engines_comparator_does() {
+        // U+212A KELVIN SIGN lowercases to `k`, so the engine's comparator
+        // sees `desktop.ini`. An ASCII-only fold here would let it through as
+        // a distinct name that is nonetheless name-equal in the vault.
+        assert!(is_platform_junk("des\u{212A}top.ini"));
+        assert_eq!(
+            validate_name("des\u{212A}top.ini"),
+            Err(NameError::PlatformJunk)
+        );
+    }
+
+    #[test]
+    fn emittability_is_the_narrow_tier_of_admission() {
+        // Names no kernel protocol can carry — the read path drops these.
+        for name in ["", ".", "..", "a/b", "a\\b", "a\0b", &"x".repeat(256)] {
+            assert!(!is_emittable(name), "{name:?} is not emittable");
+        }
+        // Refused at create, but still listable so they stay removable.
+        for name in [".DS_Store", "re:port", "COM1", "report.", "a\u{202E}b"] {
+            assert!(is_emittable(name), "{name:?} must stay reachable");
+            assert!(validate_name(name).is_err(), "{name:?} is not creatable");
         }
     }
 

--- a/crates/fuse/src/name.rs
+++ b/crates/fuse/src/name.rs
@@ -1,0 +1,234 @@
+//! Name admission for the projection: syntax validation and the platform-junk
+//! filter, decided once for every mount technology
+//! (blueprint/desktop.md "Names and attributes").
+//!
+//! One rule set on all platforms is the point: a name a Linux mount accepts
+//! must be creatable on Windows too, or a committed folder stops mounting
+//! everywhere. Uniqueness itself is not decided here — that is the engine's
+//! strict comparator.
+
+/// The longest name the projection admits, in bytes. `statfs` advertises this
+/// same constant, so what is advertised is what is enforced.
+pub const MAX_NAME_BYTES: usize = 255;
+
+/// Why a name was refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NameError {
+    /// The name was empty.
+    Empty,
+    /// The name exceeded [`MAX_NAME_BYTES`].
+    TooLong,
+    /// The name was `.` or `..`.
+    DotEntry,
+    /// The name contained a path separator (`/` or `\`).
+    Separator,
+    /// The name contained NUL or another C0 control character.
+    Control,
+    /// The name contained a character Windows reserves (`< > : " | ? *`).
+    ReservedCharacter,
+    /// The name ended in a dot or a space, which Windows silently strips.
+    TrailingDotOrSpace,
+    /// The name is a Windows reserved device name (`CON`, `NUL`, `COM1`, …),
+    /// with or without an extension.
+    ReservedDevice,
+    /// The name is platform junk (`.DS_Store`, `Thumbs.db`, …).
+    PlatformJunk,
+}
+
+/// Characters Windows refuses in a path component. `/` and `\` are checked
+/// separately so a caller sees [`NameError::Separator`].
+const RESERVED_CHARACTERS: &[char] = &['<', '>', ':', '"', '|', '?', '*'];
+
+/// Windows device names, reserved with or without an extension.
+const RESERVED_DEVICES: &[&str] = &["con", "prn", "aux", "nul"];
+
+/// Exact platform-junk names, ASCII-lowercased for comparison. One list for
+/// every platform: v1 kept a POSIX list and a Windows list that disagreed, so
+/// a `.DS_Store` rejected on macOS synced happily from Windows.
+const JUNK_NAMES: &[&str] = &[
+    // macOS
+    ".ds_store",
+    ".apdisk",
+    ".documentrevisions-v100",
+    ".fseventsd",
+    ".hidden",
+    ".localized",
+    ".metadata_direct_scope_only",
+    ".metadata_never_index",
+    ".metadata_never_index_unless_rootfs",
+    ".ql_disablecache",
+    ".ql_disablethumbnails",
+    ".spotlight-v100",
+    ".temporaryitems",
+    ".trashes",
+    // Windows
+    "$recycle.bin",
+    "desktop.ini",
+    "hiberfil.sys",
+    "pagefile.sys",
+    "recycler",
+    "swapfile.sys",
+    "system volume information",
+    "thumbs.db",
+    // Linux
+    ".directory",
+    ".gvfs",
+    ".xdg-volume-info",
+];
+
+/// Platform-junk name prefixes, ASCII-lowercased for comparison.
+const JUNK_PREFIXES: &[&str] = &["._", ".trash-"];
+
+/// Whether the name is platform junk: refused on create, hidden from
+/// listings, and still reachable by an explicit lookup or unlink so junk that
+/// arrived from another client stays removable through the mount.
+pub fn is_platform_junk(name: &str) -> bool {
+    let folded = name.to_ascii_lowercase();
+    JUNK_NAMES.contains(&folded.as_str())
+        || JUNK_PREFIXES
+            .iter()
+            .any(|prefix| folded.starts_with(prefix))
+}
+
+/// Admit a name for create, mkdir, or a rename destination.
+pub fn validate_name(name: &str) -> Result<(), NameError> {
+    if name.is_empty() {
+        return Err(NameError::Empty);
+    }
+    if name.len() > MAX_NAME_BYTES {
+        return Err(NameError::TooLong);
+    }
+    if name == "." || name == ".." {
+        return Err(NameError::DotEntry);
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err(NameError::Separator);
+    }
+    if name.chars().any(|c| c.is_control()) {
+        return Err(NameError::Control);
+    }
+    if name.contains(RESERVED_CHARACTERS) {
+        return Err(NameError::ReservedCharacter);
+    }
+    if name.ends_with('.') || name.ends_with(' ') {
+        return Err(NameError::TrailingDotOrSpace);
+    }
+    if is_reserved_device(name) {
+        return Err(NameError::ReservedDevice);
+    }
+    if is_platform_junk(name) {
+        return Err(NameError::PlatformJunk);
+    }
+    Ok(())
+}
+
+fn is_reserved_device(name: &str) -> bool {
+    let stem = name.split('.').next().unwrap_or(name).to_ascii_lowercase();
+    if RESERVED_DEVICES.contains(&stem.as_str()) {
+        return true;
+    }
+    let Some(digit) = stem
+        .strip_prefix("com")
+        .or_else(|| stem.strip_prefix("lpt"))
+    else {
+        return false;
+    };
+    matches!(digit, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ordinary_names_are_admitted() {
+        for name in [
+            "notes.txt",
+            "Photos",
+            "a",
+            "naïve — ünïcode.md",
+            "..leading",
+        ] {
+            assert_eq!(validate_name(name), Ok(()), "{name} should be admitted");
+        }
+    }
+
+    #[test]
+    fn the_advertised_length_limit_is_the_enforced_one() {
+        let longest = "a".repeat(MAX_NAME_BYTES);
+        assert_eq!(validate_name(&longest), Ok(()));
+        assert_eq!(
+            validate_name(&"a".repeat(MAX_NAME_BYTES + 1)),
+            Err(NameError::TooLong)
+        );
+    }
+
+    #[test]
+    fn length_is_counted_in_bytes_not_characters() {
+        // 128 two-byte characters: well under 255 chars, over 255 bytes.
+        let name = "é".repeat(128);
+        assert!(name.chars().count() < MAX_NAME_BYTES);
+        assert_eq!(validate_name(&name), Err(NameError::TooLong));
+    }
+
+    #[test]
+    fn structurally_impossible_names_are_refused() {
+        assert_eq!(validate_name(""), Err(NameError::Empty));
+        assert_eq!(validate_name("."), Err(NameError::DotEntry));
+        assert_eq!(validate_name(".."), Err(NameError::DotEntry));
+        assert_eq!(validate_name("a/b"), Err(NameError::Separator));
+        assert_eq!(validate_name("a\\b"), Err(NameError::Separator));
+        assert_eq!(validate_name("a\0b"), Err(NameError::Control));
+        assert_eq!(validate_name("a\nb"), Err(NameError::Control));
+    }
+
+    #[test]
+    fn windows_hostile_names_are_refused_on_every_platform() {
+        for name in ["a<b", "a>b", "a:b", "a\"b", "a|b", "a?b", "a*b"] {
+            assert_eq!(
+                validate_name(name),
+                Err(NameError::ReservedCharacter),
+                "{name} must be refused everywhere, not only on Windows"
+            );
+        }
+        assert_eq!(validate_name("report."), Err(NameError::TrailingDotOrSpace));
+        assert_eq!(validate_name("report "), Err(NameError::TrailingDotOrSpace));
+        for name in ["CON", "nul", "Aux", "prn", "COM1", "lpt9", "con.txt"] {
+            assert_eq!(
+                validate_name(name),
+                Err(NameError::ReservedDevice),
+                "{name} is a reserved device name"
+            );
+        }
+        for name in ["com", "com0", "lpt10", "console"] {
+            assert_eq!(validate_name(name), Ok(()), "{name} is not reserved");
+        }
+    }
+
+    #[test]
+    fn junk_is_refused_and_folds_case() {
+        for name in [
+            ".DS_Store",
+            ".ds_store",
+            "Thumbs.db",
+            "THUMBS.DB",
+            "desktop.ini",
+            "._resource",
+            ".Trash-1000",
+            "$RECYCLE.BIN",
+            "System Volume Information",
+            ".gvfs",
+        ] {
+            assert!(is_platform_junk(name), "{name} is junk");
+            assert_eq!(validate_name(name), Err(NameError::PlatformJunk));
+        }
+    }
+
+    #[test]
+    fn junk_matching_does_not_swallow_real_names() {
+        for name in ["DCIM", "Desktop", "recycle.bin", "trash", "directory"] {
+            assert!(!is_platform_junk(name), "{name} is a legitimate name");
+            assert_eq!(validate_name(name), Ok(()));
+        }
+    }
+}

--- a/crates/fuse/src/ops.rs
+++ b/crates/fuse/src/ops.rs
@@ -8,6 +8,8 @@
 //! machinery, no freshness policy — those decisions all happened below the
 //! facade.
 
+use std::collections::BTreeSet;
+
 use cipherbox_engine::seams::SeamTypes;
 use cipherbox_engine::{Command, Engine, EngineView, NodeAttrs, NodeId, NodeKind, StatFs};
 
@@ -231,8 +233,11 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
         Ok(view)
     }
 
+    /// Stage an intent op. The staged `OpId` is the journal-ack handle, which
+    /// the write plane claims in #648; the projection needs only the outcome.
     async fn command(&mut self, command: Command) -> Result<(), VfsError> {
-        Ok(self.engine.command(command).await?)
+        self.engine.command(command).await?;
+        Ok(())
     }
 
     fn entry_changed(&self, parent: u64, name: &str) {
@@ -312,14 +317,17 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
         Ok(())
     }
 
-    /// Delete a node that has already passed [`removable`], sweeping whatever
-    /// children it still has — only junk can survive that check, and junk the
-    /// mount hides is junk the user could never clear by hand.
+    /// Delete a node that has already passed [`removable`], sweeping the whole
+    /// subtree it still holds — only junk can survive that check, and junk the
+    /// mount hides is junk the user could never clear by hand. A junk folder
+    /// can hold real descendants, and `Command::Delete` unlinks exactly one
+    /// node, so the sweep has to reach them or they outlive the mount point
+    /// they hung from.
     async fn delete(&mut self, view: &EngineView, victim: NodeId) -> Result<(), VfsError> {
-        for child in view.children(victim) {
-            self.command(Command::Delete { node: child.id }).await?;
+        for node in subtree(view, victim) {
+            self.command(Command::Delete { node }).await?;
         }
-        self.command(Command::Delete { node: victim }).await
+        Ok(())
     }
 }
 
@@ -327,14 +335,28 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
 /// folder into its own subtree would detach that subtree from the root for
 /// good; POSIX rename answers `EINVAL` and so does the projection.
 fn contains(view: &EngineView, node: NodeId, candidate: NodeId) -> bool {
-    let mut frontier = vec![node];
+    subtree(view, node).contains(&candidate)
+}
+
+/// `root` and everything beneath it, deepest first — the order deletes must
+/// run in, since each one unlinks a single node. Visit-tracked like the
+/// engine snapshot's own `ancestors` walk: a malformed cycle has to terminate
+/// rather than hang the mount.
+fn subtree(view: &EngineView, root: NodeId) -> Vec<NodeId> {
+    let mut order = Vec::new();
+    let mut seen = BTreeSet::from([root]);
+    let mut frontier = vec![root];
     while let Some(next) = frontier.pop() {
-        if next == candidate {
-            return true;
+        order.push(next);
+        for child in view.children(next) {
+            if seen.insert(child.id) {
+                frontier.push(child.id);
+            }
         }
-        frontier.extend(view.children(next).into_iter().map(|child| child.id));
     }
-    false
+    // Preorder puts every node before its descendants; reversed, after them.
+    order.reverse();
+    order
 }
 
 /// The POSIX preconditions for making a node vanish: it must be the kind the

--- a/crates/fuse/src/ops.rs
+++ b/crates/fuse/src/ops.rs
@@ -9,13 +9,13 @@
 //! facade.
 
 use cipherbox_engine::seams::SeamTypes;
-use cipherbox_engine::{Command, Engine, EngineView, NodeAttrs, NodeId, NodeKind};
+use cipherbox_engine::{Command, Engine, EngineView, NodeAttrs, NodeId, NodeKind, StatFs};
 
 use crate::adapter::{CacheTtls, HostAdapter, Invalidation};
 use crate::error::VfsError;
 use crate::handle::{Access, HandleId, HandleTable, OpenFile};
-use crate::inode::InodeTable;
-use crate::name::{MAX_NAME_BYTES, is_platform_junk, validate_name};
+use crate::inode::{InodeTable, ROOT_INO};
+use crate::name::{is_emittable, is_platform_junk, validate_name};
 
 /// A node as the kernel sees it.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,8 +26,10 @@ pub struct Attributes {
     pub node: NodeId,
     /// File or folder.
     pub kind: NodeKind,
-    /// Plaintext size in bytes; zero until the content plane projects one.
-    pub size: u64,
+    /// Plaintext size in bytes, `None` until the content plane projects one.
+    /// Never collapsed to zero: a kernel that believes `st_size == 0` stops
+    /// reading at byte zero, and `cp` writes an empty copy of a real file.
+    pub size: Option<u64>,
     /// Modification time in Unix millis, once projected.
     pub mtime_millis: Option<u64>,
 }
@@ -43,16 +45,6 @@ pub struct DirEntry {
     pub kind: NodeKind,
 }
 
-/// Filesystem-level counters for statfs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct FsStats {
-    /// Nodes reachable from the mount root.
-    pub nodes: u64,
-    /// The longest admissible name, in bytes — the same limit create
-    /// enforces, so the advertised value is never a fiction.
-    pub name_max: u32,
-}
-
 /// The operation core for one mount session: the engine it projects, the host
 /// adapter it pushes invalidation to, and the session's inode and handle maps.
 pub struct OperationCore<T: SeamTypes, A: HostAdapter> {
@@ -60,29 +52,29 @@ pub struct OperationCore<T: SeamTypes, A: HostAdapter> {
     adapter: A,
     inodes: InodeTable,
     handles: HandleTable,
-    ttls: CacheTtls,
 }
 
 impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
     /// Mount `engine` behind `adapter`. The engine must already be started.
     pub fn new(engine: Engine<T>, adapter: A) -> Self {
-        let ttls = CacheTtls::for_host(&adapter.capabilities(), engine.profile());
         Self {
             engine,
             adapter,
             inodes: InodeTable::new(),
             handles: HandleTable::new(),
-            ttls,
         }
     }
 
     /// The kernel cache lifetimes this mount's adapter earned.
     pub fn cache_ttls(&self) -> CacheTtls {
-        self.ttls
+        CacheTtls::for_host(&self.adapter.capabilities(), self.engine.profile())
     }
 
     /// Resolve a name under a directory.
     pub async fn lookup(&mut self, parent: u64, name: &str) -> Result<Attributes, VfsError> {
+        if !is_emittable(name) {
+            return Err(VfsError::NotFound);
+        }
         let view = self.render().await?;
         let parent_node = self.directory(&view, parent)?;
         let meta = view.lookup(parent_node, name).ok_or(VfsError::NotFound)?;
@@ -98,14 +90,16 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
     }
 
     /// List a directory's children in the engine's deterministic order,
-    /// hiding platform junk that arrived from another client. `.` and `..`
-    /// are the adapter's to synthesize, along with any offset cookies.
+    /// hiding platform junk and names no kernel could carry — both classes
+    /// arrive from other clients, which validate nothing. `.` and `..` are the
+    /// adapter's to synthesize, along with any offset cookies.
     pub async fn readdir(&mut self, ino: u64) -> Result<Vec<DirEntry>, VfsError> {
         let view = self.render().await?;
         let node = self.directory(&view, ino)?;
-        let mut entries = Vec::new();
-        for child in view.children(node) {
-            if is_platform_junk(&child.name) {
+        let children = view.children(node);
+        let mut entries = Vec::with_capacity(children.len());
+        for child in children {
+            if is_platform_junk(&child.name) || !is_emittable(&child.name) {
                 continue;
             }
             entries.push(DirEntry {
@@ -158,27 +152,22 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
         let parent_node = self.directory(&view, parent)?;
         let new_parent_node = self.directory(&view, new_parent)?;
         let source = view.lookup(parent_node, name).ok_or(VfsError::NotFound)?;
+        if contains(&view, source.id, new_parent_node) {
+            return Err(VfsError::Invalid);
+        }
         // A case- or normalization-only respell folds onto the source itself
         // under the engine's strict comparator; it is a rename, not a replace.
         let replaced = view
             .lookup(new_parent_node, new_name)
             .filter(|dest| dest.id != source.id);
         if let Some(dest) = &replaced {
-            match (source.kind, dest.kind) {
-                (NodeKind::File, NodeKind::Folder) => return Err(VfsError::IsADirectory),
-                (NodeKind::Folder, NodeKind::File) => return Err(VfsError::NotADirectory),
-                (NodeKind::Folder, NodeKind::Folder) if !view.children(dest.id).is_empty() => {
-                    return Err(VfsError::NotEmpty);
-                }
-                _ => {}
-            }
+            removable(&view, dest, source.kind)?;
         }
 
-        // The facade has no combined move-and-rename op, so the projection
-        // spells the request as the minimal ordered intent-op sequence:
-        // vacate the destination, relink, then respell.
+        // The facade has no combined move-and-rename op, so a rename that
+        // replaces has a window where the destination is already gone (#884).
         if let Some(dest) = replaced {
-            self.command(Command::Delete { node: dest.id }).await?;
+            self.delete(&view, dest.id).await?;
         }
         if new_parent_node != parent_node {
             self.command(Command::Relink {
@@ -196,14 +185,8 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
         }
 
         let ino = self.inodes.ino_for(source.id);
-        self.adapter.invalidate(Invalidation::Entry {
-            parent,
-            name: name.to_owned(),
-        });
-        self.adapter.invalidate(Invalidation::Entry {
-            parent: new_parent,
-            name: new_name.to_owned(),
-        });
+        self.entry_changed(parent, name);
+        self.entry_changed(new_parent, new_name);
         self.adapter.invalidate(Invalidation::Attributes { ino });
         Ok(())
     }
@@ -230,28 +213,33 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
         Ok(())
     }
 
-    /// Filesystem counters.
-    pub async fn statfs(&mut self) -> Result<FsStats, VfsError> {
-        let view = self.render().await?;
-        Ok(FsStats {
-            nodes: view.statfs().nodes,
-            name_max: MAX_NAME_BYTES as u32,
-        })
+    /// Filesystem counters. The longest admissible name is
+    /// [`MAX_NAME_BYTES`](crate::MAX_NAME_BYTES), the same limit create
+    /// enforces.
+    pub async fn statfs(&mut self) -> Result<StatFs, VfsError> {
+        Ok(self.render().await?.statfs())
     }
 
     /// One internally-consistent read of the facade's rendered state, with the
     /// mount root bound to its inode.
     async fn render(&mut self) -> Result<EngineView, VfsError> {
-        let view = self.engine.view().await.map_err(VfsError::from_engine)?;
-        self.inodes.bind_root(view.root());
+        let view = self.engine.view().await?;
+        if self.inodes.bind_root(view.root()) {
+            self.adapter
+                .invalidate(Invalidation::Attributes { ino: ROOT_INO });
+        }
         Ok(view)
     }
 
     async fn command(&mut self, command: Command) -> Result<(), VfsError> {
-        self.engine
-            .command(command)
-            .await
-            .map_err(VfsError::from_engine)
+        Ok(self.engine.command(command).await?)
+    }
+
+    fn entry_changed(&self, parent: u64, name: &str) {
+        self.adapter.invalidate(Invalidation::Entry {
+            parent,
+            name: name.to_owned(),
+        });
     }
 
     fn node_of(&self, ino: u64) -> Result<NodeId, VfsError> {
@@ -261,11 +249,11 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
     /// Resolve an inode that must be a directory.
     fn directory(&self, view: &EngineView, ino: u64) -> Result<NodeId, VfsError> {
         let node = self.node_of(ino)?;
-        match view.attrs(node) {
-            None => Err(VfsError::NotFound),
-            Some(meta) if meta.kind != NodeKind::Folder => Err(VfsError::NotADirectory),
-            Some(_) => Ok(node),
+        let meta = view.attrs(node).ok_or(VfsError::NotFound)?;
+        if meta.kind != NodeKind::Folder {
+            return Err(VfsError::NotADirectory);
         }
+        Ok(node)
     }
 
     fn attributes(&mut self, meta: &NodeAttrs) -> Attributes {
@@ -273,7 +261,7 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
             ino: self.inodes.ino_for(meta.id),
             node: meta.id,
             kind: meta.kind,
-            size: meta.size.unwrap_or(0),
+            size: meta.size,
             mtime_millis: meta.mtime,
         }
     }
@@ -305,10 +293,7 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
                 message: "a staged create is missing from the rendered view".to_owned(),
             })?;
         let attrs = self.attributes(&meta);
-        self.adapter.invalidate(Invalidation::Entry {
-            parent,
-            name: name.to_owned(),
-        });
+        self.entry_changed(parent, name);
         Ok(attrs)
     }
 
@@ -320,24 +305,56 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
     ) -> Result<(), VfsError> {
         let view = self.render().await?;
         let parent_node = self.directory(&view, parent)?;
-        // No junk filtering here: junk hidden from listings must still be
-        // removable through the mount, or a name another client committed is
-        // stranded forever.
         let meta = view.lookup(parent_node, name).ok_or(VfsError::NotFound)?;
-        if meta.kind != expected {
-            return Err(match expected {
-                NodeKind::File => VfsError::IsADirectory,
-                NodeKind::Folder => VfsError::NotADirectory,
-            });
-        }
-        if expected == NodeKind::Folder && !view.children(meta.id).is_empty() {
-            return Err(VfsError::NotEmpty);
-        }
-        self.command(Command::Delete { node: meta.id }).await?;
-        self.adapter.invalidate(Invalidation::Entry {
-            parent,
-            name: name.to_owned(),
-        });
+        removable(&view, &meta, expected)?;
+        self.delete(&view, meta.id).await?;
+        self.entry_changed(parent, name);
         Ok(())
     }
+
+    /// Delete a node that has already passed [`removable`], sweeping whatever
+    /// children it still has — only junk can survive that check, and junk the
+    /// mount hides is junk the user could never clear by hand.
+    async fn delete(&mut self, view: &EngineView, victim: NodeId) -> Result<(), VfsError> {
+        for child in view.children(victim) {
+            self.command(Command::Delete { node: child.id }).await?;
+        }
+        self.command(Command::Delete { node: victim }).await
+    }
+}
+
+/// Whether `candidate` is `node` or lives somewhere beneath it. Relinking a
+/// folder into its own subtree would detach that subtree from the root for
+/// good; POSIX rename answers `EINVAL` and so does the projection.
+fn contains(view: &EngineView, node: NodeId, candidate: NodeId) -> bool {
+    let mut frontier = vec![node];
+    while let Some(next) = frontier.pop() {
+        if next == candidate {
+            return true;
+        }
+        frontier.extend(view.children(next).into_iter().map(|child| child.id));
+    }
+    false
+}
+
+/// The POSIX preconditions for making a node vanish: it must be the kind the
+/// caller expects, and a folder must be empty.
+fn removable(view: &EngineView, victim: &NodeAttrs, expected: NodeKind) -> Result<(), VfsError> {
+    if victim.kind != expected {
+        return Err(match expected {
+            NodeKind::File => VfsError::IsADirectory,
+            NodeKind::Folder => VfsError::NotADirectory,
+        });
+    }
+    // Junk does not count: it is hidden from listings, so a folder holding
+    // nothing else reads as empty through the mount and must behave that way.
+    if expected == NodeKind::Folder
+        && view
+            .children(victim.id)
+            .iter()
+            .any(|child| !is_platform_junk(&child.name))
+    {
+        return Err(VfsError::NotEmpty);
+    }
+    Ok(())
 }

--- a/crates/fuse/src/ops.rs
+++ b/crates/fuse/src/ops.rs
@@ -1,0 +1,343 @@
+//! The platform-neutral vfs operation core: one implementation of every
+//! filesystem operation, over the engine facade and nothing else
+//! (blueprint/desktop.md "The FS core and host adapters").
+//!
+//! It is a projection, not a second brain. Reads render the facade's snapshot
+//! (with the pending-op overlay already applied) and never wait on the
+//! network; mutations become facade intent ops. No keys, no publish
+//! machinery, no freshness policy — those decisions all happened below the
+//! facade.
+
+use cipherbox_engine::seams::SeamTypes;
+use cipherbox_engine::{Command, Engine, EngineView, NodeAttrs, NodeId, NodeKind};
+
+use crate::adapter::{CacheTtls, HostAdapter, Invalidation};
+use crate::error::VfsError;
+use crate::handle::{Access, HandleId, HandleTable, OpenFile};
+use crate::inode::InodeTable;
+use crate::name::{MAX_NAME_BYTES, is_platform_junk, validate_name};
+
+/// A node as the kernel sees it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Attributes {
+    /// The session's inode number for the node.
+    pub ino: u64,
+    /// The engine's stable node id.
+    pub node: NodeId,
+    /// File or folder.
+    pub kind: NodeKind,
+    /// Plaintext size in bytes; zero until the content plane projects one.
+    pub size: u64,
+    /// Modification time in Unix millis, once projected.
+    pub mtime_millis: Option<u64>,
+}
+
+/// One entry in a directory listing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirEntry {
+    /// The session's inode number for the child.
+    pub ino: u64,
+    /// The child's name, as entered.
+    pub name: String,
+    /// File or folder.
+    pub kind: NodeKind,
+}
+
+/// Filesystem-level counters for statfs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FsStats {
+    /// Nodes reachable from the mount root.
+    pub nodes: u64,
+    /// The longest admissible name, in bytes — the same limit create
+    /// enforces, so the advertised value is never a fiction.
+    pub name_max: u32,
+}
+
+/// The operation core for one mount session: the engine it projects, the host
+/// adapter it pushes invalidation to, and the session's inode and handle maps.
+pub struct OperationCore<T: SeamTypes, A: HostAdapter> {
+    engine: Engine<T>,
+    adapter: A,
+    inodes: InodeTable,
+    handles: HandleTable,
+    ttls: CacheTtls,
+}
+
+impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
+    /// Mount `engine` behind `adapter`. The engine must already be started.
+    pub fn new(engine: Engine<T>, adapter: A) -> Self {
+        let ttls = CacheTtls::for_host(&adapter.capabilities(), engine.profile());
+        Self {
+            engine,
+            adapter,
+            inodes: InodeTable::new(),
+            handles: HandleTable::new(),
+            ttls,
+        }
+    }
+
+    /// The kernel cache lifetimes this mount's adapter earned.
+    pub fn cache_ttls(&self) -> CacheTtls {
+        self.ttls
+    }
+
+    /// Resolve a name under a directory.
+    pub async fn lookup(&mut self, parent: u64, name: &str) -> Result<Attributes, VfsError> {
+        let view = self.render().await?;
+        let parent_node = self.directory(&view, parent)?;
+        let meta = view.lookup(parent_node, name).ok_or(VfsError::NotFound)?;
+        Ok(self.attributes(&meta))
+    }
+
+    /// Read one node's attributes.
+    pub async fn getattr(&mut self, ino: u64) -> Result<Attributes, VfsError> {
+        let view = self.render().await?;
+        let node = self.node_of(ino)?;
+        let meta = view.attrs(node).ok_or(VfsError::NotFound)?;
+        Ok(self.attributes(&meta))
+    }
+
+    /// List a directory's children in the engine's deterministic order,
+    /// hiding platform junk that arrived from another client. `.` and `..`
+    /// are the adapter's to synthesize, along with any offset cookies.
+    pub async fn readdir(&mut self, ino: u64) -> Result<Vec<DirEntry>, VfsError> {
+        let view = self.render().await?;
+        let node = self.directory(&view, ino)?;
+        let mut entries = Vec::new();
+        for child in view.children(node) {
+            if is_platform_junk(&child.name) {
+                continue;
+            }
+            entries.push(DirEntry {
+                ino: self.inodes.ino_for(child.id),
+                name: child.name,
+                kind: child.kind,
+            });
+        }
+        Ok(entries)
+    }
+
+    /// Create an empty file and open a handle on it.
+    pub async fn create(
+        &mut self,
+        parent: u64,
+        name: &str,
+        access: Access,
+    ) -> Result<(Attributes, HandleId), VfsError> {
+        let attrs = self.make(parent, name, NodeKind::File).await?;
+        let handle = self.handles.open(attrs.node, access);
+        Ok((attrs, handle))
+    }
+
+    /// Create a directory.
+    pub async fn mkdir(&mut self, parent: u64, name: &str) -> Result<Attributes, VfsError> {
+        self.make(parent, name, NodeKind::Folder).await
+    }
+
+    /// Remove a file.
+    pub async fn unlink(&mut self, parent: u64, name: &str) -> Result<(), VfsError> {
+        self.remove(parent, name, NodeKind::File).await
+    }
+
+    /// Remove an empty directory.
+    pub async fn rmdir(&mut self, parent: u64, name: &str) -> Result<(), VfsError> {
+        self.remove(parent, name, NodeKind::Folder).await
+    }
+
+    /// Move and/or rename a node, replacing an existing destination the way
+    /// POSIX rename does.
+    pub async fn rename(
+        &mut self,
+        parent: u64,
+        name: &str,
+        new_parent: u64,
+        new_name: &str,
+    ) -> Result<(), VfsError> {
+        validate_name(new_name)?;
+        let view = self.render().await?;
+        let parent_node = self.directory(&view, parent)?;
+        let new_parent_node = self.directory(&view, new_parent)?;
+        let source = view.lookup(parent_node, name).ok_or(VfsError::NotFound)?;
+        // A case- or normalization-only respell folds onto the source itself
+        // under the engine's strict comparator; it is a rename, not a replace.
+        let replaced = view
+            .lookup(new_parent_node, new_name)
+            .filter(|dest| dest.id != source.id);
+        if let Some(dest) = &replaced {
+            match (source.kind, dest.kind) {
+                (NodeKind::File, NodeKind::Folder) => return Err(VfsError::IsADirectory),
+                (NodeKind::Folder, NodeKind::File) => return Err(VfsError::NotADirectory),
+                (NodeKind::Folder, NodeKind::Folder) if !view.children(dest.id).is_empty() => {
+                    return Err(VfsError::NotEmpty);
+                }
+                _ => {}
+            }
+        }
+
+        // The facade has no combined move-and-rename op, so the projection
+        // spells the request as the minimal ordered intent-op sequence:
+        // vacate the destination, relink, then respell.
+        if let Some(dest) = replaced {
+            self.command(Command::Delete { node: dest.id }).await?;
+        }
+        if new_parent_node != parent_node {
+            self.command(Command::Relink {
+                node: source.id,
+                new_parent: new_parent_node,
+            })
+            .await?;
+        }
+        if source.name != new_name {
+            self.command(Command::Rename {
+                node: source.id,
+                new_name: new_name.to_owned(),
+            })
+            .await?;
+        }
+
+        let ino = self.inodes.ino_for(source.id);
+        self.adapter.invalidate(Invalidation::Entry {
+            parent,
+            name: name.to_owned(),
+        });
+        self.adapter.invalidate(Invalidation::Entry {
+            parent: new_parent,
+            name: new_name.to_owned(),
+        });
+        self.adapter.invalidate(Invalidation::Attributes { ino });
+        Ok(())
+    }
+
+    /// Open a file handle.
+    pub async fn open(&mut self, ino: u64, access: Access) -> Result<HandleId, VfsError> {
+        let view = self.render().await?;
+        let node = self.node_of(ino)?;
+        let meta = view.attrs(node).ok_or(VfsError::NotFound)?;
+        if meta.kind != NodeKind::File {
+            return Err(VfsError::IsADirectory);
+        }
+        Ok(self.handles.open(node, access))
+    }
+
+    /// What an open handle addresses.
+    pub fn handle(&self, handle: HandleId) -> Result<OpenFile, VfsError> {
+        self.handles.get(handle).ok_or(VfsError::BadHandle)
+    }
+
+    /// Close a file handle.
+    pub fn release(&mut self, handle: HandleId) -> Result<(), VfsError> {
+        self.handles.close(handle).ok_or(VfsError::BadHandle)?;
+        Ok(())
+    }
+
+    /// Filesystem counters.
+    pub async fn statfs(&mut self) -> Result<FsStats, VfsError> {
+        let view = self.render().await?;
+        Ok(FsStats {
+            nodes: view.statfs().nodes,
+            name_max: MAX_NAME_BYTES as u32,
+        })
+    }
+
+    /// One internally-consistent read of the facade's rendered state, with the
+    /// mount root bound to its inode.
+    async fn render(&mut self) -> Result<EngineView, VfsError> {
+        let view = self.engine.view().await.map_err(VfsError::from_engine)?;
+        self.inodes.bind_root(view.root());
+        Ok(view)
+    }
+
+    async fn command(&mut self, command: Command) -> Result<(), VfsError> {
+        self.engine
+            .command(command)
+            .await
+            .map_err(VfsError::from_engine)
+    }
+
+    fn node_of(&self, ino: u64) -> Result<NodeId, VfsError> {
+        self.inodes.node(ino).ok_or(VfsError::NotFound)
+    }
+
+    /// Resolve an inode that must be a directory.
+    fn directory(&self, view: &EngineView, ino: u64) -> Result<NodeId, VfsError> {
+        let node = self.node_of(ino)?;
+        match view.attrs(node) {
+            None => Err(VfsError::NotFound),
+            Some(meta) if meta.kind != NodeKind::Folder => Err(VfsError::NotADirectory),
+            Some(_) => Ok(node),
+        }
+    }
+
+    fn attributes(&mut self, meta: &NodeAttrs) -> Attributes {
+        Attributes {
+            ino: self.inodes.ino_for(meta.id),
+            node: meta.id,
+            kind: meta.kind,
+            size: meta.size.unwrap_or(0),
+            mtime_millis: meta.mtime,
+        }
+    }
+
+    async fn make(
+        &mut self,
+        parent: u64,
+        name: &str,
+        kind: NodeKind,
+    ) -> Result<Attributes, VfsError> {
+        validate_name(name)?;
+        let view = self.render().await?;
+        let parent_node = self.directory(&view, parent)?;
+        if view.lookup(parent_node, name).is_some() {
+            return Err(VfsError::AlreadyExists);
+        }
+        self.command(Command::Create {
+            parent: parent_node,
+            name: name.to_owned(),
+            kind,
+            content: None,
+        })
+        .await?;
+
+        let view = self.render().await?;
+        let meta = view
+            .lookup(parent_node, name)
+            .ok_or_else(|| VfsError::Internal {
+                message: "a staged create is missing from the rendered view".to_owned(),
+            })?;
+        let attrs = self.attributes(&meta);
+        self.adapter.invalidate(Invalidation::Entry {
+            parent,
+            name: name.to_owned(),
+        });
+        Ok(attrs)
+    }
+
+    async fn remove(
+        &mut self,
+        parent: u64,
+        name: &str,
+        expected: NodeKind,
+    ) -> Result<(), VfsError> {
+        let view = self.render().await?;
+        let parent_node = self.directory(&view, parent)?;
+        // No junk filtering here: junk hidden from listings must still be
+        // removable through the mount, or a name another client committed is
+        // stranded forever.
+        let meta = view.lookup(parent_node, name).ok_or(VfsError::NotFound)?;
+        if meta.kind != expected {
+            return Err(match expected {
+                NodeKind::File => VfsError::IsADirectory,
+                NodeKind::Folder => VfsError::NotADirectory,
+            });
+        }
+        if expected == NodeKind::Folder && !view.children(meta.id).is_empty() {
+            return Err(VfsError::NotEmpty);
+        }
+        self.command(Command::Delete { node: meta.id }).await?;
+        self.adapter.invalidate(Invalidation::Entry {
+            parent,
+            name: name.to_owned(),
+        });
+        Ok(())
+    }
+}

--- a/crates/fuse/tests/fuse_op_core.rs
+++ b/crates/fuse/tests/fuse_op_core.rs
@@ -2,9 +2,8 @@
 //! over the in-memory seam fakes, plus the never-block law
 //! (blueprint/desktop.md "Reads, writes, and the never-block law").
 //!
-//! No kernel and no adapter — the operation core is the unit under test, and a
-//! recording adapter stands in for the mount so the outbound invalidation
-//! direction is observable.
+//! No kernel: a recording adapter stands in for the mount so the outbound
+//! invalidation direction is observable.
 
 use std::cell::RefCell;
 use std::future::Future;
@@ -13,11 +12,11 @@ use std::task::{Context, Poll, Waker};
 
 use cipherbox_engine::testkit::{FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
 use cipherbox_engine::{
-    Engine, GatewayConfig, LoginSecret, NodeKind, StoragePolicy, SyncTimingProfile,
+    Command, Engine, GatewayConfig, LoginSecret, NodeKind, StoragePolicy, SyncTimingProfile,
 };
 use cipherbox_fuse::{
-    Access, HostAdapter, HostCapabilities, Invalidation, NameError, OperationCore, ROOT_INO,
-    VfsError,
+    Access, HostAdapter, HostCapabilities, Invalidation, MAX_NAME_BYTES, NameError, OperationCore,
+    ROOT_INO, VfsError,
 };
 
 /// A mount that records what it was told to invalidate.
@@ -55,6 +54,18 @@ impl HostAdapter for RecordingAdapter {
 type Core = OperationCore<FakeSeamTypes, RecordingAdapter>;
 
 fn mount() -> (Core, RecordingAdapter) {
+    let adapter = RecordingAdapter::push_capable();
+    (mount_with(adapter.clone()), adapter)
+}
+
+fn mount_with(adapter: RecordingAdapter) -> Core {
+    mount_seeded(adapter, &[])
+}
+
+/// Mount over an engine seeded by issuing facade commands directly, which is
+/// how a name the projection would never create — one another client
+/// committed — gets into the rendered view.
+fn mount_seeded(adapter: RecordingAdapter, root_children: &[(&str, NodeKind)]) -> Core {
     let world = FakeWorld::new();
     let device = world.device(b"alice-pk");
     let (mut engine, _events) = Engine::new(
@@ -66,8 +77,17 @@ fn mount() -> (Core, RecordingAdapter) {
         GatewayConfig::disabled(),
     );
     block_on(engine.start(LoginSecret::new(vec![7u8; 32]))).expect("engine starts");
-    let adapter = RecordingAdapter::push_capable();
-    (OperationCore::new(engine, adapter.clone()), adapter)
+    let root = block_on(engine.view()).expect("view").root();
+    for (name, kind) in root_children {
+        block_on(engine.command(Command::Create {
+            parent: root,
+            name: (*name).to_owned(),
+            kind: *kind,
+            content: None,
+        }))
+        .expect("seeded create");
+    }
+    OperationCore::new(engine, adapter)
 }
 
 /// Poll a future exactly once. `Ready` proves the operation reached its answer
@@ -98,28 +118,24 @@ fn an_empty_mount_lists_nothing_under_a_root_that_is_a_directory() {
 }
 
 #[test]
-fn a_created_node_is_immediately_visible_through_lookup_and_readdir() {
+fn created_nodes_are_immediately_visible_and_lookup_agrees_with_readdir() {
     let (mut core, _adapter) = mount();
-    let created = block_on(core.mkdir(ROOT_INO, "Photos")).expect("mkdir");
+    let folder = block_on(core.mkdir(ROOT_INO, "Photos")).expect("mkdir");
+    let (file, _handle) = block_on(core.create(ROOT_INO, "f.txt", Access::ReadWrite)).unwrap();
 
     let found = block_on(core.lookup(ROOT_INO, "Photos")).expect("lookup");
-    assert_eq!(found.ino, created.ino);
+    assert_eq!(found.ino, folder.ino);
     assert_eq!(found.kind, NodeKind::Folder);
-    assert_eq!(names(&mut core, ROOT_INO), vec!["Photos".to_owned()]);
-}
-
-#[test]
-fn lookup_and_readdir_agree_on_inode_numbers() {
-    let (mut core, _adapter) = mount();
-    block_on(core.mkdir(ROOT_INO, "dir")).unwrap();
-    let (attrs, _handle) = block_on(core.create(ROOT_INO, "f.txt", Access::ReadWrite)).unwrap();
 
     let listed = block_on(core.readdir(ROOT_INO)).unwrap();
     for entry in &listed {
         let looked_up = block_on(core.lookup(ROOT_INO, &entry.name)).unwrap();
         assert_eq!(looked_up.ino, entry.ino, "{} renumbered", entry.name);
     }
-    assert!(listed.iter().any(|entry| entry.ino == attrs.ino));
+    assert!(listed.iter().any(|entry| entry.ino == file.ino));
+    let mut listed_names = names(&mut core, ROOT_INO);
+    listed_names.sort();
+    assert_eq!(listed_names, vec!["Photos".to_owned(), "f.txt".to_owned()]);
 }
 
 #[test]
@@ -142,17 +158,16 @@ fn a_missing_name_is_not_found_and_a_file_is_not_a_directory() {
 }
 
 #[test]
-fn statfs_counts_reachable_nodes_and_advertises_the_enforced_name_limit() {
+fn statfs_counts_reachable_nodes_and_the_advertised_name_limit_is_enforced() {
     let (mut core, _adapter) = mount();
     assert_eq!(block_on(core.statfs()).unwrap().nodes, 1, "root only");
     block_on(core.mkdir(ROOT_INO, "a")).unwrap();
     block_on(core.create(ROOT_INO, "b", Access::Write)).unwrap();
-    let stats = block_on(core.statfs()).unwrap();
-    assert_eq!(stats.nodes, 3);
+    assert_eq!(block_on(core.statfs()).unwrap().nodes, 3);
 
-    let longest = "x".repeat(stats.name_max as usize);
+    let longest = "x".repeat(MAX_NAME_BYTES);
     block_on(core.mkdir(ROOT_INO, &longest)).expect("the advertised limit is creatable");
-    let too_long = "x".repeat(stats.name_max as usize + 1);
+    let too_long = "x".repeat(MAX_NAME_BYTES + 1);
     assert_eq!(
         block_on(core.mkdir(ROOT_INO, &too_long)),
         Err(VfsError::InvalidName(NameError::TooLong)),
@@ -167,8 +182,6 @@ fn the_read_surface_never_yields() {
     let (mut core, _adapter) = mount();
     block_on(core.mkdir(ROOT_INO, "dir")).unwrap();
 
-    // Each of these must reach its answer from the rendered snapshot alone:
-    // a yield here would mean a kernel callback waiting on resolve or publish.
     assert!(matches!(
         poll_once(core.readdir(ROOT_INO)),
         Poll::Ready(Ok(_))
@@ -186,8 +199,7 @@ fn the_read_surface_never_yields() {
 
 #[test]
 fn a_cold_mount_reads_without_yielding() {
-    // Nothing is cached and nothing has resolved: the read surface still
-    // answers from last-known-good rather than waiting on the network.
+    // Nothing is cached and nothing has resolved: last-known-good still answers.
     let (mut core, _adapter) = mount();
     assert!(matches!(
         poll_once(core.readdir(ROOT_INO)),
@@ -390,10 +402,6 @@ fn platform_junk_cannot_be_created_through_the_mount() {
 
 #[test]
 fn removal_does_not_gate_on_name_admission() {
-    // A name another client committed is inadmissible here but must stay
-    // reachable for removal, or it is stranded in the vault forever. The
-    // removal path therefore reports what it found, never why the name would
-    // have been refused at create.
     let (mut core, _adapter) = mount();
     for name in [".DS_Store", "re:port", "COM1"] {
         assert_eq!(
@@ -406,23 +414,6 @@ fn removal_does_not_gate_on_name_admission() {
             Err(VfsError::NotFound)
         );
     }
-}
-
-#[test]
-fn a_windows_hostile_name_is_refused_on_this_platform_too() {
-    let (mut core, _adapter) = mount();
-    assert_eq!(
-        block_on(core.mkdir(ROOT_INO, "re:port")),
-        Err(VfsError::InvalidName(NameError::ReservedCharacter))
-    );
-    assert_eq!(
-        block_on(core.mkdir(ROOT_INO, "COM1")),
-        Err(VfsError::InvalidName(NameError::ReservedDevice))
-    );
-    assert_eq!(
-        block_on(core.mkdir(ROOT_INO, "")),
-        Err(VfsError::InvalidName(NameError::Empty))
-    );
 }
 
 // --- the outbound adapter direction ---
@@ -495,19 +486,126 @@ fn a_refused_operation_pushes_nothing() {
 #[test]
 fn a_mount_that_cannot_push_gets_a_shorter_cache_ttl() {
     let (with_push, _adapter) = mount();
+    let without_push = mount_with(RecordingAdapter::default());
+
+    assert!(without_push.cache_ttls().entry < with_push.cache_ttls().entry);
+    assert!(!without_push.cache_ttls().attr.is_zero());
+}
+
+// --- names arriving from other clients ---
+
+#[test]
+fn a_name_no_kernel_could_carry_never_reaches_a_listing() {
+    // Nothing below the facade validates names: a peer on any client can
+    // commit whatever text string it likes, and this crate is the only
+    // enforcement point in the stack.
+    let hostile = [
+        "a/b",
+        "a\\b",
+        "..",
+        ".",
+        "",
+        "a\0b",
+        "a\nb",
+        &"x".repeat(MAX_NAME_BYTES + 1),
+    ];
+    let seed: Vec<(&str, NodeKind)> = hostile
+        .iter()
+        .map(|name| (*name, NodeKind::File))
+        .chain([("keeper.txt", NodeKind::File)])
+        .collect();
+    let mut core = mount_seeded(RecordingAdapter::push_capable(), &seed);
+
+    assert_eq!(names(&mut core, ROOT_INO), vec!["keeper.txt".to_owned()]);
+    for name in hostile {
+        assert_eq!(
+            block_on(core.lookup(ROOT_INO, name)),
+            Err(VfsError::NotFound),
+            "{name:?} must not resolve through the mount"
+        );
+    }
+}
+
+#[test]
+fn a_folder_holding_only_hidden_junk_is_removable() {
+    // Junk is hidden from listings, so a user who cannot see it could never
+    // clear it by hand; the folder must not be stranded behind ENOTEMPTY.
+    let mut core = seeded_junk_folder();
+    let dir = block_on(core.lookup(ROOT_INO, "dir")).unwrap();
+    assert!(names(&mut core, dir.ino).is_empty(), "junk stays hidden");
+
+    block_on(core.rmdir(ROOT_INO, "dir")).expect("a junk-only folder is empty to the user");
+    assert!(names(&mut core, ROOT_INO).is_empty());
+}
+
+/// A `dir` holding one `.DS_Store` and nothing else, both committed elsewhere.
+fn seeded_junk_folder() -> Core {
     let world = FakeWorld::new();
-    let device = world.device(b"bob-pk");
+    let device = world.device(b"alice-pk");
     let (mut engine, _events) = Engine::new(
         device.seam_set(),
-        Box::new(SeededEntropy::new(7)),
+        Box::new(SeededEntropy::new(42)),
         SyncTimingProfile::CI,
         StoragePolicy::CI,
         String::new(),
         GatewayConfig::disabled(),
     );
-    block_on(engine.start(LoginSecret::new(vec![9u8; 32]))).unwrap();
-    let without_push = OperationCore::new(engine, RecordingAdapter::default());
+    block_on(engine.start(LoginSecret::new(vec![7u8; 32]))).expect("engine starts");
+    let root = block_on(engine.view()).expect("view").root();
+    block_on(engine.command(Command::Create {
+        parent: root,
+        name: "dir".to_owned(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .unwrap();
+    let dir = block_on(engine.view())
+        .unwrap()
+        .lookup(root, "dir")
+        .unwrap()
+        .id;
+    block_on(engine.command(Command::Create {
+        parent: dir,
+        name: ".DS_Store".to_owned(),
+        kind: NodeKind::File,
+        content: None,
+    }))
+    .unwrap();
+    OperationCore::new(engine, RecordingAdapter::push_capable())
+}
 
-    assert!(without_push.cache_ttls().entry < with_push.cache_ttls().entry);
-    assert!(!without_push.cache_ttls().attr.is_zero());
+// --- structurally impossible moves ---
+
+#[test]
+fn a_folder_cannot_be_moved_inside_itself() {
+    let (mut core, _adapter) = mount();
+    let outer = block_on(core.mkdir(ROOT_INO, "outer")).unwrap();
+    let inner = block_on(core.mkdir(outer.ino, "inner")).unwrap();
+
+    assert_eq!(
+        block_on(core.rename(ROOT_INO, "outer", outer.ino, "loop")),
+        Err(VfsError::Invalid),
+        "a folder is not its own parent"
+    );
+    assert_eq!(
+        block_on(core.rename(ROOT_INO, "outer", inner.ino, "loop")),
+        Err(VfsError::Invalid),
+        "nor its descendant's"
+    );
+
+    // The subtree is still reachable from the root.
+    assert_eq!(names(&mut core, ROOT_INO), vec!["outer".to_owned()]);
+    assert_eq!(names(&mut core, outer.ino), vec!["inner".to_owned()]);
+}
+
+// --- attributes ---
+
+#[test]
+fn an_unprojected_size_is_reported_as_unknown_never_as_empty() {
+    // A kernel told st_size == 0 stops reading at byte zero, so `cp` would
+    // write an empty copy of a file whose bytes simply have not landed yet.
+    let (mut core, _adapter) = mount();
+    let (file, _handle) = block_on(core.create(ROOT_INO, "f.txt", Access::Write)).unwrap();
+    assert_eq!(file.size, None);
+    assert_eq!(block_on(core.getattr(file.ino)).unwrap().size, None);
 }

--- a/crates/fuse/tests/fuse_op_core.rs
+++ b/crates/fuse/tests/fuse_op_core.rs
@@ -1,0 +1,513 @@
+//! The `fuse-op-core` suite: every vfs operation driven against a real engine
+//! over the in-memory seam fakes, plus the never-block law
+//! (blueprint/desktop.md "Reads, writes, and the never-block law").
+//!
+//! No kernel and no adapter — the operation core is the unit under test, and a
+//! recording adapter stands in for the mount so the outbound invalidation
+//! direction is observable.
+
+use std::cell::RefCell;
+use std::future::Future;
+use std::rc::Rc;
+use std::task::{Context, Poll, Waker};
+
+use cipherbox_engine::testkit::{FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
+use cipherbox_engine::{
+    Engine, GatewayConfig, LoginSecret, NodeKind, StoragePolicy, SyncTimingProfile,
+};
+use cipherbox_fuse::{
+    Access, HostAdapter, HostCapabilities, Invalidation, NameError, OperationCore, ROOT_INO,
+    VfsError,
+};
+
+/// A mount that records what it was told to invalidate.
+#[derive(Clone, Default)]
+struct RecordingAdapter {
+    push_invalidation: bool,
+    seen: Rc<RefCell<Vec<Invalidation>>>,
+}
+
+impl RecordingAdapter {
+    fn push_capable() -> Self {
+        Self {
+            push_invalidation: true,
+            seen: Rc::new(RefCell::new(Vec::new())),
+        }
+    }
+
+    fn drain(&self) -> Vec<Invalidation> {
+        self.seen.borrow_mut().drain(..).collect()
+    }
+}
+
+impl HostAdapter for RecordingAdapter {
+    fn capabilities(&self) -> HostCapabilities {
+        HostCapabilities {
+            push_invalidation: self.push_invalidation,
+        }
+    }
+
+    fn invalidate(&self, invalidation: Invalidation) {
+        self.seen.borrow_mut().push(invalidation);
+    }
+}
+
+type Core = OperationCore<FakeSeamTypes, RecordingAdapter>;
+
+fn mount() -> (Core, RecordingAdapter) {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (mut engine, _events) = Engine::new(
+        device.seam_set(),
+        Box::new(SeededEntropy::new(42)),
+        SyncTimingProfile::CI,
+        StoragePolicy::CI,
+        String::new(),
+        GatewayConfig::disabled(),
+    );
+    block_on(engine.start(LoginSecret::new(vec![7u8; 32]))).expect("engine starts");
+    let adapter = RecordingAdapter::push_capable();
+    (OperationCore::new(engine, adapter.clone()), adapter)
+}
+
+/// Poll a future exactly once. `Ready` proves the operation reached its answer
+/// without ever yielding — the never-block law's testable form.
+fn poll_once<F: Future>(future: F) -> Poll<F::Output> {
+    let mut future = Box::pin(future);
+    let mut cx = Context::from_waker(Waker::noop());
+    future.as_mut().poll(&mut cx)
+}
+
+fn names(core: &mut Core, ino: u64) -> Vec<String> {
+    block_on(core.readdir(ino))
+        .expect("readdir")
+        .into_iter()
+        .map(|entry| entry.name)
+        .collect()
+}
+
+// --- the read surface ---
+
+#[test]
+fn an_empty_mount_lists_nothing_under_a_root_that_is_a_directory() {
+    let (mut core, _adapter) = mount();
+    assert!(names(&mut core, ROOT_INO).is_empty());
+    let root = block_on(core.getattr(ROOT_INO)).expect("root getattr");
+    assert_eq!(root.ino, ROOT_INO);
+    assert_eq!(root.kind, NodeKind::Folder);
+}
+
+#[test]
+fn a_created_node_is_immediately_visible_through_lookup_and_readdir() {
+    let (mut core, _adapter) = mount();
+    let created = block_on(core.mkdir(ROOT_INO, "Photos")).expect("mkdir");
+
+    let found = block_on(core.lookup(ROOT_INO, "Photos")).expect("lookup");
+    assert_eq!(found.ino, created.ino);
+    assert_eq!(found.kind, NodeKind::Folder);
+    assert_eq!(names(&mut core, ROOT_INO), vec!["Photos".to_owned()]);
+}
+
+#[test]
+fn lookup_and_readdir_agree_on_inode_numbers() {
+    let (mut core, _adapter) = mount();
+    block_on(core.mkdir(ROOT_INO, "dir")).unwrap();
+    let (attrs, _handle) = block_on(core.create(ROOT_INO, "f.txt", Access::ReadWrite)).unwrap();
+
+    let listed = block_on(core.readdir(ROOT_INO)).unwrap();
+    for entry in &listed {
+        let looked_up = block_on(core.lookup(ROOT_INO, &entry.name)).unwrap();
+        assert_eq!(looked_up.ino, entry.ino, "{} renumbered", entry.name);
+    }
+    assert!(listed.iter().any(|entry| entry.ino == attrs.ino));
+}
+
+#[test]
+fn a_missing_name_is_not_found_and_a_file_is_not_a_directory() {
+    let (mut core, _adapter) = mount();
+    assert_eq!(
+        block_on(core.lookup(ROOT_INO, "nope")),
+        Err(VfsError::NotFound)
+    );
+    let (file, _handle) = block_on(core.create(ROOT_INO, "f.txt", Access::Read)).unwrap();
+    assert_eq!(
+        block_on(core.readdir(file.ino)),
+        Err(VfsError::NotADirectory)
+    );
+    assert_eq!(
+        block_on(core.lookup(file.ino, "child")),
+        Err(VfsError::NotADirectory)
+    );
+    assert_eq!(block_on(core.getattr(9999)), Err(VfsError::NotFound));
+}
+
+#[test]
+fn statfs_counts_reachable_nodes_and_advertises_the_enforced_name_limit() {
+    let (mut core, _adapter) = mount();
+    assert_eq!(block_on(core.statfs()).unwrap().nodes, 1, "root only");
+    block_on(core.mkdir(ROOT_INO, "a")).unwrap();
+    block_on(core.create(ROOT_INO, "b", Access::Write)).unwrap();
+    let stats = block_on(core.statfs()).unwrap();
+    assert_eq!(stats.nodes, 3);
+
+    let longest = "x".repeat(stats.name_max as usize);
+    block_on(core.mkdir(ROOT_INO, &longest)).expect("the advertised limit is creatable");
+    let too_long = "x".repeat(stats.name_max as usize + 1);
+    assert_eq!(
+        block_on(core.mkdir(ROOT_INO, &too_long)),
+        Err(VfsError::InvalidName(NameError::TooLong)),
+        "one byte past the advertised limit is refused"
+    );
+}
+
+// --- the never-block law ---
+
+#[test]
+fn the_read_surface_never_yields() {
+    let (mut core, _adapter) = mount();
+    block_on(core.mkdir(ROOT_INO, "dir")).unwrap();
+
+    // Each of these must reach its answer from the rendered snapshot alone:
+    // a yield here would mean a kernel callback waiting on resolve or publish.
+    assert!(matches!(
+        poll_once(core.readdir(ROOT_INO)),
+        Poll::Ready(Ok(_))
+    ));
+    assert!(matches!(
+        poll_once(core.lookup(ROOT_INO, "dir")),
+        Poll::Ready(Ok(_))
+    ));
+    assert!(matches!(
+        poll_once(core.getattr(ROOT_INO)),
+        Poll::Ready(Ok(_))
+    ));
+    assert!(matches!(poll_once(core.statfs()), Poll::Ready(Ok(_))));
+}
+
+#[test]
+fn a_cold_mount_reads_without_yielding() {
+    // Nothing is cached and nothing has resolved: the read surface still
+    // answers from last-known-good rather than waiting on the network.
+    let (mut core, _adapter) = mount();
+    assert!(matches!(
+        poll_once(core.readdir(ROOT_INO)),
+        Poll::Ready(Ok(_))
+    ));
+}
+
+// --- mutations ---
+
+#[test]
+fn create_opens_a_handle_that_releases_exactly_once() {
+    let (mut core, _adapter) = mount();
+    let (attrs, handle) = block_on(core.create(ROOT_INO, "f.txt", Access::ReadWrite)).unwrap();
+    assert_eq!(core.handle(handle).unwrap().node, attrs.node);
+    assert!(core.handle(handle).unwrap().access.writable());
+
+    assert_eq!(core.release(handle), Ok(()));
+    assert_eq!(core.handle(handle), Err(VfsError::BadHandle));
+    assert_eq!(core.release(handle), Err(VfsError::BadHandle));
+}
+
+#[test]
+fn opening_a_directory_is_refused_and_opening_a_file_is_not() {
+    let (mut core, _adapter) = mount();
+    let dir = block_on(core.mkdir(ROOT_INO, "dir")).unwrap();
+    assert_eq!(
+        block_on(core.open(dir.ino, Access::Read)),
+        Err(VfsError::IsADirectory)
+    );
+    let (file, handle) = block_on(core.create(ROOT_INO, "f.txt", Access::Read)).unwrap();
+    core.release(handle).unwrap();
+    let reopened = block_on(core.open(file.ino, Access::Read)).unwrap();
+    assert_eq!(core.handle(reopened).unwrap().node, file.node);
+}
+
+#[test]
+fn a_duplicate_name_is_refused_under_the_engines_strict_comparator() {
+    let (mut core, _adapter) = mount();
+    block_on(core.mkdir(ROOT_INO, "Photos")).unwrap();
+    assert_eq!(
+        block_on(core.mkdir(ROOT_INO, "Photos")),
+        Err(VfsError::AlreadyExists)
+    );
+    assert_eq!(
+        block_on(core.create(ROOT_INO, "photos", Access::Write)).err(),
+        Some(VfsError::AlreadyExists),
+        "uniqueness folds case on every platform"
+    );
+}
+
+#[test]
+fn unlink_and_rmdir_hold_each_other_to_their_own_kind() {
+    let (mut core, _adapter) = mount();
+    let dir = block_on(core.mkdir(ROOT_INO, "dir")).unwrap();
+    block_on(core.create(ROOT_INO, "f.txt", Access::Write)).unwrap();
+
+    assert_eq!(
+        block_on(core.unlink(ROOT_INO, "dir")),
+        Err(VfsError::IsADirectory)
+    );
+    assert_eq!(
+        block_on(core.rmdir(ROOT_INO, "f.txt")),
+        Err(VfsError::NotADirectory)
+    );
+
+    block_on(core.create(dir.ino, "inner", Access::Write)).unwrap();
+    assert_eq!(
+        block_on(core.rmdir(ROOT_INO, "dir")),
+        Err(VfsError::NotEmpty)
+    );
+    block_on(core.unlink(dir.ino, "inner")).unwrap();
+    block_on(core.rmdir(ROOT_INO, "dir")).unwrap();
+
+    block_on(core.unlink(ROOT_INO, "f.txt")).unwrap();
+    assert!(names(&mut core, ROOT_INO).is_empty());
+    assert_eq!(
+        block_on(core.unlink(ROOT_INO, "f.txt")),
+        Err(VfsError::NotFound)
+    );
+}
+
+#[test]
+fn an_inode_survives_a_rename() {
+    let (mut core, _adapter) = mount();
+    let (before, _handle) = block_on(core.create(ROOT_INO, "old.txt", Access::Write)).unwrap();
+
+    block_on(core.rename(ROOT_INO, "old.txt", ROOT_INO, "new.txt")).unwrap();
+
+    assert_eq!(
+        block_on(core.lookup(ROOT_INO, "old.txt")),
+        Err(VfsError::NotFound)
+    );
+    let after = block_on(core.lookup(ROOT_INO, "new.txt")).unwrap();
+    assert_eq!(after.ino, before.ino, "renaming must not renumber the node");
+    assert_eq!(block_on(core.getattr(before.ino)).unwrap().ino, before.ino);
+}
+
+#[test]
+fn an_inode_survives_a_move_between_directories() {
+    let (mut core, _adapter) = mount();
+    let dir = block_on(core.mkdir(ROOT_INO, "dir")).unwrap();
+    let (file, _handle) = block_on(core.create(ROOT_INO, "f.txt", Access::Write)).unwrap();
+
+    block_on(core.rename(ROOT_INO, "f.txt", dir.ino, "moved.txt")).unwrap();
+
+    assert_eq!(names(&mut core, ROOT_INO), vec!["dir".to_owned()]);
+    let moved = block_on(core.lookup(dir.ino, "moved.txt")).unwrap();
+    assert_eq!(moved.ino, file.ino);
+}
+
+#[test]
+fn rename_over_an_existing_file_replaces_it() {
+    let (mut core, _adapter) = mount();
+    let (source, _a) = block_on(core.create(ROOT_INO, "new.txt", Access::Write)).unwrap();
+    let (victim, _b) = block_on(core.create(ROOT_INO, "target.txt", Access::Write)).unwrap();
+    assert_ne!(source.ino, victim.ino);
+
+    block_on(core.rename(ROOT_INO, "new.txt", ROOT_INO, "target.txt")).unwrap();
+
+    assert_eq!(names(&mut core, ROOT_INO), vec!["target.txt".to_owned()]);
+    assert_eq!(
+        block_on(core.lookup(ROOT_INO, "target.txt")).unwrap().ino,
+        source.ino,
+        "the surviving entry is the source node, not the replaced one"
+    );
+}
+
+#[test]
+fn rename_refuses_to_replace_across_kinds_or_over_a_populated_directory() {
+    let (mut core, _adapter) = mount();
+    block_on(core.create(ROOT_INO, "f.txt", Access::Write)).unwrap();
+    let dir = block_on(core.mkdir(ROOT_INO, "dir")).unwrap();
+    let full = block_on(core.mkdir(ROOT_INO, "full")).unwrap();
+    block_on(core.create(full.ino, "inner", Access::Write)).unwrap();
+
+    assert_eq!(
+        block_on(core.rename(ROOT_INO, "f.txt", ROOT_INO, "dir")),
+        Err(VfsError::IsADirectory)
+    );
+    assert_eq!(
+        block_on(core.rename(ROOT_INO, "dir", ROOT_INO, "f.txt")),
+        Err(VfsError::NotADirectory)
+    );
+    assert_eq!(
+        block_on(core.rename(ROOT_INO, "dir", ROOT_INO, "full")),
+        Err(VfsError::NotEmpty)
+    );
+    // Nothing moved.
+    assert_eq!(block_on(core.lookup(ROOT_INO, "dir")).unwrap().ino, dir.ino);
+}
+
+#[test]
+fn a_case_only_rename_respells_rather_than_replacing_the_node() {
+    let (mut core, _adapter) = mount();
+    let (file, _handle) = block_on(core.create(ROOT_INO, "notes.txt", Access::Write)).unwrap();
+
+    block_on(core.rename(ROOT_INO, "notes.txt", ROOT_INO, "Notes.txt")).unwrap();
+
+    assert_eq!(names(&mut core, ROOT_INO), vec!["Notes.txt".to_owned()]);
+    assert_eq!(
+        block_on(core.lookup(ROOT_INO, "Notes.txt")).unwrap().ino,
+        file.ino
+    );
+}
+
+#[test]
+fn a_rename_onto_a_missing_source_or_a_bad_name_changes_nothing() {
+    let (mut core, _adapter) = mount();
+    block_on(core.create(ROOT_INO, "f.txt", Access::Write)).unwrap();
+
+    assert_eq!(
+        block_on(core.rename(ROOT_INO, "ghost", ROOT_INO, "x")),
+        Err(VfsError::NotFound)
+    );
+    assert_eq!(
+        block_on(core.rename(ROOT_INO, "f.txt", ROOT_INO, "a/b")),
+        Err(VfsError::InvalidName(NameError::Separator))
+    );
+    assert_eq!(names(&mut core, ROOT_INO), vec!["f.txt".to_owned()]);
+}
+
+// --- name admission ---
+
+#[test]
+fn platform_junk_cannot_be_created_through_the_mount() {
+    let (mut core, _adapter) = mount();
+    for name in [".DS_Store", "Thumbs.db", "._resource", ".Trash-1000"] {
+        assert_eq!(
+            block_on(core.create(ROOT_INO, name, Access::Write)).err(),
+            Some(VfsError::InvalidName(NameError::PlatformJunk)),
+            "{name} must not enter the vault"
+        );
+        assert_eq!(
+            block_on(core.mkdir(ROOT_INO, name)),
+            Err(VfsError::InvalidName(NameError::PlatformJunk))
+        );
+    }
+    assert!(names(&mut core, ROOT_INO).is_empty());
+}
+
+#[test]
+fn removal_does_not_gate_on_name_admission() {
+    // A name another client committed is inadmissible here but must stay
+    // reachable for removal, or it is stranded in the vault forever. The
+    // removal path therefore reports what it found, never why the name would
+    // have been refused at create.
+    let (mut core, _adapter) = mount();
+    for name in [".DS_Store", "re:port", "COM1"] {
+        assert_eq!(
+            block_on(core.unlink(ROOT_INO, name)),
+            Err(VfsError::NotFound),
+            "{name} must reach the lookup, not a name guard"
+        );
+        assert_eq!(
+            block_on(core.rmdir(ROOT_INO, name)),
+            Err(VfsError::NotFound)
+        );
+    }
+}
+
+#[test]
+fn a_windows_hostile_name_is_refused_on_this_platform_too() {
+    let (mut core, _adapter) = mount();
+    assert_eq!(
+        block_on(core.mkdir(ROOT_INO, "re:port")),
+        Err(VfsError::InvalidName(NameError::ReservedCharacter))
+    );
+    assert_eq!(
+        block_on(core.mkdir(ROOT_INO, "COM1")),
+        Err(VfsError::InvalidName(NameError::ReservedDevice))
+    );
+    assert_eq!(
+        block_on(core.mkdir(ROOT_INO, "")),
+        Err(VfsError::InvalidName(NameError::Empty))
+    );
+}
+
+// --- the outbound adapter direction ---
+
+#[test]
+fn every_mutation_pushes_an_invalidation_at_the_mount() {
+    let (mut core, adapter) = mount();
+
+    block_on(core.mkdir(ROOT_INO, "dir")).unwrap();
+    assert_eq!(
+        adapter.drain(),
+        vec![Invalidation::Entry {
+            parent: ROOT_INO,
+            name: "dir".to_owned()
+        }]
+    );
+
+    block_on(core.create(ROOT_INO, "f.txt", Access::Write)).unwrap();
+    assert_eq!(
+        adapter.drain(),
+        vec![Invalidation::Entry {
+            parent: ROOT_INO,
+            name: "f.txt".to_owned()
+        }]
+    );
+
+    block_on(core.unlink(ROOT_INO, "f.txt")).unwrap();
+    assert_eq!(
+        adapter.drain(),
+        vec![Invalidation::Entry {
+            parent: ROOT_INO,
+            name: "f.txt".to_owned()
+        }]
+    );
+
+    let dir = block_on(core.lookup(ROOT_INO, "dir")).unwrap();
+    block_on(core.rename(ROOT_INO, "dir", ROOT_INO, "renamed")).unwrap();
+    assert_eq!(
+        adapter.drain(),
+        vec![
+            Invalidation::Entry {
+                parent: ROOT_INO,
+                name: "dir".to_owned()
+            },
+            Invalidation::Entry {
+                parent: ROOT_INO,
+                name: "renamed".to_owned()
+            },
+            Invalidation::Attributes { ino: dir.ino },
+        ]
+    );
+}
+
+#[test]
+fn a_refused_operation_pushes_nothing() {
+    let (mut core, adapter) = mount();
+    block_on(core.mkdir(ROOT_INO, "dir")).unwrap();
+    adapter.drain();
+
+    block_on(core.mkdir(ROOT_INO, ".DS_Store")).unwrap_err();
+    block_on(core.mkdir(ROOT_INO, "dir")).unwrap_err();
+    block_on(core.unlink(ROOT_INO, "ghost")).unwrap_err();
+
+    assert!(
+        adapter.drain().is_empty(),
+        "the kernel is only told about changes that happened"
+    );
+}
+
+#[test]
+fn a_mount_that_cannot_push_gets_a_shorter_cache_ttl() {
+    let (with_push, _adapter) = mount();
+    let world = FakeWorld::new();
+    let device = world.device(b"bob-pk");
+    let (mut engine, _events) = Engine::new(
+        device.seam_set(),
+        Box::new(SeededEntropy::new(7)),
+        SyncTimingProfile::CI,
+        StoragePolicy::CI,
+        String::new(),
+        GatewayConfig::disabled(),
+    );
+    block_on(engine.start(LoginSecret::new(vec![9u8; 32]))).unwrap();
+    let without_push = OperationCore::new(engine, RecordingAdapter::default());
+
+    assert!(without_push.cache_ttls().entry < with_push.cache_ttls().entry);
+    assert!(!without_push.cache_ttls().attr.is_zero());
+}

--- a/crates/fuse/tests/fuse_op_core.rs
+++ b/crates/fuse/tests/fuse_op_core.rs
@@ -12,7 +12,7 @@ use std::task::{Context, Poll, Waker};
 
 use cipherbox_engine::testkit::{FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
 use cipherbox_engine::{
-    Command, Engine, GatewayConfig, LoginSecret, NodeKind, StoragePolicy, SyncTimingProfile,
+    Command, Engine, GatewayConfig, LoginSecret, NodeId, NodeKind, StoragePolicy, SyncTimingProfile,
 };
 use cipherbox_fuse::{
     Access, HostAdapter, HostCapabilities, Invalidation, MAX_NAME_BYTES, NameError, OperationCore,
@@ -62,10 +62,8 @@ fn mount_with(adapter: RecordingAdapter) -> Core {
     mount_seeded(adapter, &[])
 }
 
-/// Mount over an engine seeded by issuing facade commands directly, which is
-/// how a name the projection would never create — one another client
-/// committed — gets into the rendered view.
-fn mount_seeded(adapter: RecordingAdapter, root_children: &[(&str, NodeKind)]) -> Core {
+/// A started engine over fresh in-memory seams, with its rendered root id.
+fn started_engine() -> (Engine<FakeSeamTypes>, NodeId) {
     let world = FakeWorld::new();
     let device = world.device(b"alice-pk");
     let (mut engine, _events) = Engine::new(
@@ -78,14 +76,37 @@ fn mount_seeded(adapter: RecordingAdapter, root_children: &[(&str, NodeKind)]) -
     );
     block_on(engine.start(LoginSecret::new(vec![7u8; 32]))).expect("engine starts");
     let root = block_on(engine.view()).expect("view").root();
+    (engine, root)
+}
+
+/// Seed a child by issuing a facade command directly, which is how a name the
+/// projection would never create — one another client committed — gets into
+/// the rendered view.
+fn seed_child(
+    engine: &mut Engine<FakeSeamTypes>,
+    parent: NodeId,
+    name: &str,
+    kind: NodeKind,
+) -> NodeId {
+    block_on(engine.command(Command::Create {
+        parent,
+        name: name.to_owned(),
+        kind,
+        content: None,
+    }))
+    .expect("seeded create");
+    block_on(engine.view())
+        .expect("view")
+        .lookup(parent, name)
+        .expect("seeded child is rendered")
+        .id
+}
+
+/// Mount over an engine seeded with the given root children.
+fn mount_seeded(adapter: RecordingAdapter, root_children: &[(&str, NodeKind)]) -> Core {
+    let (mut engine, root) = started_engine();
     for (name, kind) in root_children {
-        block_on(engine.command(Command::Create {
-            parent: root,
-            name: (*name).to_owned(),
-            kind: *kind,
-            content: None,
-        }))
-        .expect("seeded create");
+        seed_child(&mut engine, root, name, *kind);
     }
     OperationCore::new(engine, adapter)
 }
@@ -538,39 +559,40 @@ fn a_folder_holding_only_hidden_junk_is_removable() {
     assert!(names(&mut core, ROOT_INO).is_empty());
 }
 
+#[test]
+fn removing_a_junk_only_folder_sweeps_what_the_junk_itself_holds() {
+    // A junk *folder* can hold real descendants the user can never see, let
+    // alone clear. One delete per direct child would leave them behind with
+    // no reachable parent.
+    let mut core = seeded_nested_junk_folder();
+    let dir = block_on(core.lookup(ROOT_INO, "dir")).unwrap();
+    let junk = block_on(core.lookup(dir.ino, ".Trash-1000")).unwrap();
+    let buried = block_on(core.lookup(junk.ino, "buried.txt")).unwrap();
+
+    block_on(core.rmdir(ROOT_INO, "dir")).expect("a junk-only folder is empty to the user");
+
+    assert_eq!(block_on(core.getattr(junk.ino)), Err(VfsError::NotFound));
+    assert_eq!(
+        block_on(core.getattr(buried.ino)),
+        Err(VfsError::NotFound),
+        "nothing survives the swept subtree"
+    );
+}
+
 /// A `dir` holding one `.DS_Store` and nothing else, both committed elsewhere.
 fn seeded_junk_folder() -> Core {
-    let world = FakeWorld::new();
-    let device = world.device(b"alice-pk");
-    let (mut engine, _events) = Engine::new(
-        device.seam_set(),
-        Box::new(SeededEntropy::new(42)),
-        SyncTimingProfile::CI,
-        StoragePolicy::CI,
-        String::new(),
-        GatewayConfig::disabled(),
-    );
-    block_on(engine.start(LoginSecret::new(vec![7u8; 32]))).expect("engine starts");
-    let root = block_on(engine.view()).expect("view").root();
-    block_on(engine.command(Command::Create {
-        parent: root,
-        name: "dir".to_owned(),
-        kind: NodeKind::Folder,
-        content: None,
-    }))
-    .unwrap();
-    let dir = block_on(engine.view())
-        .unwrap()
-        .lookup(root, "dir")
-        .unwrap()
-        .id;
-    block_on(engine.command(Command::Create {
-        parent: dir,
-        name: ".DS_Store".to_owned(),
-        kind: NodeKind::File,
-        content: None,
-    }))
-    .unwrap();
+    let (mut engine, root) = started_engine();
+    let dir = seed_child(&mut engine, root, "dir", NodeKind::Folder);
+    seed_child(&mut engine, dir, ".DS_Store", NodeKind::File);
+    OperationCore::new(engine, RecordingAdapter::push_capable())
+}
+
+/// A `dir` holding one junk-prefixed folder, which itself holds a real file.
+fn seeded_nested_junk_folder() -> Core {
+    let (mut engine, root) = started_engine();
+    let dir = seed_child(&mut engine, root, "dir", NodeKind::Folder);
+    let junk = seed_child(&mut engine, dir, ".Trash-1000", NodeKind::Folder);
+    seed_child(&mut engine, junk, "buried.txt", NodeKind::File);
     OperationCore::new(engine, RecordingAdapter::push_capable())
 }
 


### PR DESCRIPTION
Builds the platform-neutral vfs operation core in `crates/fuse` and the host-adapter trait every mount technology will implement, over the engine facade and nothing else.

Closes #647

## What landed

- **`ops.rs` — the operation core.** `lookup`, `getattr`, `readdir`, `create`, `mkdir`, `unlink`, `rmdir`, `rename`, `open`, `release`, `statfs`, implemented once for every platform. Reads render the facade's snapshot with the pending-op overlay already applied and never wait on the network; mutations become facade intent ops. No keys, no publish machinery, no freshness policy — those decisions all happened below the facade.
- **`adapter.rs` — the `HostAdapter` trait.** Inbound an adapter calls the operation core with platform-normalized names; outbound the core hands it `Invalidation::{Data, Attributes, Entry}` to push at the kernel. An adapter declares `push_invalidation` in `HostCapabilities`; a mount that cannot push falls back to a shorter kernel cache TTL, read off the sync timing profile rather than hardcoded — v1's dir-TTL-0 was the symptom of a mount that could not invalidate.
- **`inode.rs` / `handle.rs` — the key-free identity maps.** Inodes are allocated per mount session, keyed by the engine's stable node id, monotonic and never reused, so a node survives a rename without renumbering. Neither table holds anything derived from a key.
- **`name.rs` — one name rule set on every platform, in two tiers.** Names also arrive *from* the engine, and nothing below the facade validates them — a peer on any client can commit whatever CBOR text string it likes, so this crate is the only enforcement point in the stack. `is_emittable` is the narrow tier the read path applies: names no kernel protocol can carry at all (empty, over 255 bytes, a separator, a control character, a synthesized dot entry) never reach a listing. `validate_name` adds the create-only policy on top — Windows-reserved characters and device names, trailing dot or space, bidi-override and zero-width characters, and the platform-junk list. Everything the wider tier refuses stays listable and removable, or a name another client committed would be stranded forever.
- **`error.rs` — the semantic failure vocabulary.** Each adapter maps these onto its own protocol. The `EngineError` mapping is exhaustive by construction — no wildcard arm — so a new fail-closed variant in the facade is a compile error here rather than a trust verdict that silently degrades to `Internal`.

## Engine-side footprint

Two minimal edits, both required by the projection:

- `lib.rs` re-exports `EngineView`, `NodeAttrs`, and `StatFs` — all three already existed in the facade and are the types the operation core reads through.
- `NodeAttrs` carries the `size` and `mtime` the underlying `NodeMeta` already projects, so `getattr` can answer with them.

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` all ran against `main...HEAD`; the second commit folds their findings back in. The ones worth calling out:

- A rename could relink a folder into its own subtree, detaching it from the root for good. Now `VfsError::Invalid`, the POSIX `EINVAL`.
- `getattr` reported an unprojected size as `0`. A kernel that believes `st_size == 0` stops reading at byte zero, so `cp` would write an empty copy of a file whose bytes simply had not landed yet — `Attributes::size` is `Option<u64>` and the unknown survives to the adapter.
- The junk filter folded ASCII-only while the engine's comparator folds full Unicode, so `des\u{212A}top.ini` slipped the filter yet was name-equal to `desktop.ini` in the vault. Both now fold the same way, still without allocating per listing entry.
- A folder holding only hidden junk listed as empty but refused `rmdir`, and the user could never see the entry blocking it. Emptiness now ignores junk and the removal sweeps it.
- A cold start that re-anchors the root left `ROOT_INO` addressing a different node than the kernel had cached, with nothing pushed; it also left the promoted node answering to two inodes.

One finding is deliberately not fixed here: a rename that replaces an existing destination is three separately-staged facade ops with the destructive one first, so a failure mid-sequence loses the destination. The fix is a combined `Command::Move` intent op on the facade — engine-side work, filed as #884 with a dependency edge. Reordering the three is not an improvement: the engine auto-suffixes collisions on rebase, so relinking before vacating trades the loss window for a wrong name on the success path.

## Tests and gate

`crates/fuse/tests/fuse_op_core.rs` is the `fuse-op-core` suite: every operation driven against a real engine over the in-memory seam fakes, with a recording adapter standing in for the mount so the outbound invalidation direction is observable. The never-block law gets a testable form — the read surface is polled exactly once and must come back `Ready`, so a kernel callback can never be left waiting on resolve or publish. Names another client committed are seeded by issuing facade commands directly, since the projection would never create them itself. 54 tests in all.

The suite blocks a merge the day it lands: `crates/**` triggers the Rust CI jobs, and `Cargo Check & Test (Linux)`, `Cargo Check & Test (macOS)`, and `Cargo Check & Test (Windows)` each run `cargo test --workspace`, which picks up `cipherbox-fuse`.

## Out of scope

- Read/write byte paths, the sealed spill file, journal ack, and the FUSE-op TTL freshness trigger — #648.
- The concrete FUSE-T SMB, libfuse3, and WinFsp adapters — #649.
- `blueprint/desktop.md`'s ENOSPC/EDQUOT conflation — #867. `VfsError::OverBudget` already carries an `OverBudgetCause` so the two causes stay distinguishable at the trait; which errno each maps to is the adapter's call.
- An atomic rename — #884.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a filesystem mount interface supporting file and directory lookup, creation, removal, renaming, opening, and status reporting.
  * Added stable file handles and inode tracking during mount sessions.
  * Added filesystem metadata reporting, including optional file sizes and modification times.
  * Added platform-safe filename validation and filtering of incompatible or misleading names.
  * Added host cache tuning and change notifications for fresher directory and file information.

* **Bug Fixes**
  * Improved error handling for invalid operations, unavailable data, quota limits, and trust failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->