### PR TITLE
feat(engine): publish a folder create end to end

### DIFF
--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -18,7 +18,7 @@
 
 pub mod chunk;
 pub mod dag;
-mod limits;
+pub(crate) mod limits;
 pub mod profile;
 pub mod provider;
 pub mod read;

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -33,8 +33,8 @@ pub use provider::{
     ByoIpfsConfig, ByoKind, PinMode, ProviderError, test_connection, validate_endpoint,
 };
 pub use read::{
-    ContentPlane, Gateway, GatewayConfig, GatewaySource, ReadError, leaf_range_for_byte_range,
-    read_block,
+    ContentPlane, Gateway, GatewayConfig, GatewaySource, ReadError, is_plane_anchor,
+    leaf_range_for_byte_range, read_block,
 };
 pub use retention::{ContentVersion, PrunePlan, QuotaExceeded, plan_prune, pre_flight_quota_check};
 

--- a/crates/engine/src/content/read.rs
+++ b/crates/engine/src/content/read.rs
@@ -149,6 +149,16 @@ pub enum ReadError {
     Unavailable,
 }
 
+/// Whether the pair names a canonical block address on `plane`: the CID is
+/// well-formed for that plane's codec and the string is its canonical spelling.
+/// The anchor check every block read makes before trusting any bytes for it —
+/// a locally-held block must clear the same bar as a fetched one.
+pub fn is_plane_anchor(cid_str: &str, expected_cid: &[u8], plane: ContentPlane) -> bool {
+    expected_cid.len() == CONTENT_CID_LEN
+        && expected_cid[CID_CODEC_INDEX] == plane.codec()
+        && is_canonical_content_cid_str(cid_str)
+}
+
 /// Fetch and verify one block addressed by `cid_str` against its binary
 /// `expected_cid`. `cid_str` is the gateway address (the canonical CIDv1
 /// base32 string as it appears in metadata/links); `expected_cid` is the binary
@@ -179,11 +189,8 @@ pub async fn read_block(
     expected_cid: &[u8],
     plane: ContentPlane,
 ) -> Result<Vec<u8>, ReadError> {
-    // Reject a non-anchor request before any fetch, fail-closed (codec
-    // out-of-set/wrong-plane, or a non-canonical address).
-    let codec_ok =
-        expected_cid.len() == CONTENT_CID_LEN && expected_cid[CID_CODEC_INDEX] == plane.codec();
-    if !codec_ok || !is_canonical_content_cid_str(cid_str) {
+    // Reject a non-anchor request before any fetch, fail-closed.
+    if !is_plane_anchor(cid_str, expected_cid, plane) {
         return Err(ReadError::TrustViolation(
             TrustViolation::ContentCidMismatch.into(),
         ));

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -46,6 +46,7 @@ use crate::seams::{OpId, Scheduler, SeamError, SeamSet, SeamTypes, StagingStore,
 use crate::session::SessionIdentity;
 use crate::storage_policy::StoragePolicy;
 use crate::sync::boot::{ColdStartError, ColdStartOutcome, ColdStartParams, cold_start};
+use crate::sync::drain::{Drain, DrainReport, DrainScope};
 use crate::sync::model::{NodeMeta, Snapshot, collation_key};
 use crate::sync::op::Op;
 use crate::sync::overlay::apply_overlay;
@@ -719,6 +720,24 @@ fn emit_renewal_failures(events: &mpsc::UnboundedSender<Event>, results: &[EolRe
     }
 }
 
+/// Fold one drain pass's report into the host-visible surface: retain and emit
+/// every dead letter, and emit one [`Event::SnapshotUpdated`] if the pass moved
+/// anything off the queue (the overlay the host renders just shrank). Both sends
+/// are best-effort over the in-process channel — a dropped receiver is fine.
+fn surface_drain_report(
+    events: &mpsc::UnboundedSender<Event>,
+    dead_letters: &RefCell<BTreeMap<OpId, Option<NodeId>>>,
+    report: &DrainReport,
+) {
+    for (op_id, target, _reason) in &report.dead_letters {
+        dead_letters.borrow_mut().insert(*op_id, Some(*target));
+        let _ = events.unbounded_send(Event::DeadLetter { op_id: *op_id });
+    }
+    if !report.is_empty() {
+        let _ = events.unbounded_send(Event::SnapshotUpdated);
+    }
+}
+
 /// Count nodes reachable from the root via the link graph, cycle-guarded (a
 /// malformed link cycle terminates rather than looping).
 fn count_nodes(snapshot: &Snapshot) -> u64 {
@@ -892,6 +911,7 @@ impl<T: SeamTypes> Engine<T> {
         T::CredentialStore: Clone + 'static,
         T::FloorStore: Clone + 'static,
         T::SnapshotCache: Clone + 'static,
+        T::StagingStore: Clone + 'static,
     {
         if self.started {
             return Err(EngineError::AlreadyStarted);
@@ -972,6 +992,11 @@ impl<T: SeamTypes> Engine<T> {
                 .borrow_mut()
                 .insert(root_scope_id, seed);
         }
+        // The same adopt recovered the scope write seed: the drain derives every
+        // new node's `ipnsName` and its narrow per-name signer from it.
+        if let Some((scope_id, seed)) = outcome.write_scope_seed.take() {
+            self.scope_write_seeds.borrow_mut().insert(scope_id, seed);
+        }
 
         // The gate-passing base becomes the state law's left operand (reads render
         // this ⊕ the pending-op overlay). The resolved root name — the vault
@@ -987,7 +1012,7 @@ impl<T: SeamTypes> Engine<T> {
         self.sync_status.borrow_mut().last_success = Some(self.seams.scheduler.now());
 
         self.spawn_liveness_loop(api.clone());
-        self.spawn_resolve_tick_loop(root_name);
+        self.spawn_resolve_tick_loop(root_name, api.clone());
         self.api = Some(api);
         self.started = true;
         Ok(())
@@ -1323,7 +1348,11 @@ impl<T: SeamTypes> Engine<T> {
     /// law), so an op rebases against the state the host saw. Content sealing,
     /// grants, rotation, and auth land with their own slices and stay
     /// [`EngineError::Unimplemented`].
-    pub async fn command(&mut self, command: Command) -> Result<(), EngineError> {
+    ///
+    /// Returns the durable queue id of the staged op, so a host can correlate a
+    /// later [`Event::DeadLetter`] or [`Event::OpProgress`] back to the call
+    /// that made it; `None` for a command that queues nothing.
+    pub async fn command(&mut self, command: Command) -> Result<Option<OpId>, EngineError> {
         if !self.started {
             return Err(EngineError::NotStarted);
         }
@@ -1386,7 +1415,7 @@ impl<T: SeamTypes> Engine<T> {
                 api.siwe_login(&message, &hex_lower(&signature))
                     .await
                     .map_err(EngineError::from_api)?;
-                Ok(())
+                Ok(None)
             }
             other => Err(EngineError::Unimplemented {
                 command: other.name(),
@@ -1718,8 +1747,9 @@ impl<T: SeamTypes> Engine<T> {
         Ok(NodeId(id))
     }
 
-    /// Stage a metadata op and emit [`Event::SnapshotUpdated`] on success.
-    async fn stage_and_notify(&mut self, op: &Op) -> Result<(), EngineError> {
+    /// Stage a metadata op and emit [`Event::SnapshotUpdated`] on success,
+    /// returning the durable queue id the drain will report the op under.
+    async fn stage_and_notify(&mut self, op: &Op) -> Result<Option<OpId>, EngineError> {
         let seal = self.record_seal()?;
         // Metadata ops queue unbounded, so any rejection here means a content
         // op reached this path — fail closed rather than report a storage
@@ -1734,11 +1764,11 @@ impl<T: SeamTypes> Engine<T> {
         .await
         .map_err(EngineError::from_seam)?
         {
-            StageOutcome::Queued { .. } => {
+            StageOutcome::Queued { op_id } => {
                 // Best-effort push-invalidation trigger; a dropped receiver
                 // (host torn down) is fine.
                 let _ = self.events.unbounded_send(Event::SnapshotUpdated);
-                Ok(())
+                Ok(Some(op_id))
             }
             StageOutcome::RejectedOverBudget { .. }
             | StageOutcome::RejectedStorageUnmeasured { .. } => Err(EngineError::Seam {

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -701,6 +701,9 @@ fn emit_renewal_failures(events: &mpsc::UnboundedSender<Event>, results: &[EolRe
                     "lost CAS race: published {published_sequence}, observed {observed_sequence}"
                 )
             }
+            Ok(Some(PublishOutcome::Unconfirmed { sequence })) => {
+                format!("published sequence {sequence} but no record resolved back")
+            }
             Err(PublishError::Register(_)) => "register-first publish failed".to_owned(),
             Err(PublishError::AllEndpointsFailed) => "all record endpoints failed".to_owned(),
             Err(PublishError::FloorRead(_)) => "sequence floor read failed".to_owned(),
@@ -746,6 +749,10 @@ struct SyncStatus {
 /// scope read seed (zeroized on removal/drop).
 type ScopeReadSeeds = BTreeMap<[u8; 16], Zeroizing<[u8; 32]>>;
 
+/// The engine's in-memory per-scope write-seed cell: scope id → the recovered
+/// scope write seed (zeroized on removal/drop).
+type ScopeWriteSeeds = BTreeMap<[u8; 16], Zeroizing<[u8; 32]>>;
+
 /// The re-point pointer-payload wire version the owner's own vault seals under
 /// and the cold-start walk verifies against (`crates/core` pointer payload) — the
 /// sole v2 version (CONTEXT.md "Vault pointer").
@@ -760,8 +767,9 @@ const POINTER_PAYLOAD_VERSION: u64 = 1;
 /// compiles to worker-hosted WASM on web.
 pub struct Engine<T: SeamTypes> {
     seams: SeamSet<T>,
-    /// Seeds, nonces, jitter, and command-path node-id minting.
-    entropy: Box<dyn Entropy>,
+    /// Seeds, nonces, jitter, and command-path node-id minting. Shared with the
+    /// spawned drain, which needs a fresh seal nonce per authored record.
+    entropy: Rc<RefCell<Box<dyn Entropy>>>,
     profile: SyncTimingProfile,
     /// The measured storage split this device runs under, injected whole at
     /// construction so no staging read-modify-write queries the host mid-flight.
@@ -799,6 +807,11 @@ pub struct Engine<T: SeamTypes> {
     /// never crossing the facade (security rules 1/3); the child read pipeline
     /// derives per-node read keys from them (`node-seed` → `read-key`).
     scope_read_seeds: Rc<RefCell<ScopeReadSeeds>>,
+    /// Per-scope write seeds recovered by gate-passing adopts (the
+    /// owner-write-blob seed), keyed by scope id. In-memory only, exactly like
+    /// [`scope_read_seeds`](Self::scope_read_seeds); the drain derives each new
+    /// node's `ipnsName` and its narrow per-name signer from them.
+    scope_write_seeds: Rc<RefCell<ScopeWriteSeeds>>,
     /// Retained dead-lettered ops, mapped to the target node when known
     /// (`None` for an undecodable queue entry). Feeds [`SnapshotView`]'s
     /// dead-letter surface (#33 D6: dead letters are retained, never silent).
@@ -834,7 +847,7 @@ impl<T: SeamTypes> Engine<T> {
         (
             Self {
                 seams,
-                entropy,
+                entropy: Rc::new(RefCell::new(entropy)),
                 profile,
                 storage_policy,
                 api_base_url,
@@ -846,6 +859,7 @@ impl<T: SeamTypes> Engine<T> {
                 held_records: Rc::new(RefCell::new(HeldRecords::new())),
                 sync_status: Rc::new(RefCell::new(SyncStatus::default())),
                 scope_read_seeds: Rc::new(RefCell::new(BTreeMap::new())),
+                scope_write_seeds: Rc::new(RefCell::new(BTreeMap::new())),
                 dead_letters: Rc::new(RefCell::new(BTreeMap::new())),
                 alive: Rc::new(Cell::new(true)),
                 session: None,
@@ -1140,18 +1154,27 @@ impl<T: SeamTypes> Engine<T> {
     /// `root_name` is the vault pointer's resolved `currentRoot`; `None` (an empty
     /// chain) spawns nothing — there is no root to poll until a later start
     /// rediscovers one.
-    fn spawn_resolve_tick_loop(&self, root_name: Option<IpnsName>)
-    where
+    fn spawn_resolve_tick_loop(
+        &self,
+        root_name: Option<IpnsName>,
+        api: Rc<ApiClient<T::Http, T::CredentialStore>>,
+    ) where
         T::Scheduler: Clone + 'static,
         T::RecordTransport: Clone + 'static,
         T::Http: Clone + 'static,
+        T::CredentialStore: Clone + 'static,
         T::FloorStore: Clone + 'static,
         T::SnapshotCache: Clone + 'static,
+        T::StagingStore: Clone + 'static,
     {
         let (Some(root_name), Some(session)) = (root_name, self.session.clone()) else {
             return;
         };
         let scheduler = self.seams.scheduler.clone();
+        let staging = self.seams.staging_store.clone();
+        let entropy = self.entropy.clone();
+        let scope_write_seeds = self.scope_write_seeds.clone();
+        let dead_letters = self.dead_letters.clone();
         let transport = self.seams.record_transport.clone();
         let snapshot_cache = self.seams.snapshot_cache.clone();
         let floors = self.seams.floor_store.clone();
@@ -1209,18 +1232,54 @@ impl<T: SeamTypes> Engine<T> {
                     &material,
                 )
                 .await
-                .map(|(resolved, read_scope_seed)| {
-                    // A gate-passing adopt re-surfaces the scope read seed:
-                    // refresh the in-memory per-scope cell.
-                    if let Some(seed) = read_scope_seed {
+                .map(|held_resolve| {
+                    // A gate-passing adopt re-surfaces the scope seeds: refresh
+                    // the in-memory per-scope cells the child read pipeline and
+                    // the drain derive from.
+                    if let Some(seed) = held_resolve.read_scope_seed {
                         scope_read_seeds.borrow_mut().insert(root_id, seed);
                     }
-                    resolved
+                    if let Some((node_id, seed)) = held_resolve.write_scope_seed {
+                        scope_write_seeds.borrow_mut().insert(node_id, seed);
+                    }
+                    held_resolve.resolved
                 });
                 if let Ok(resolved) = &resolved {
                     if refresh_base_from_outcome(&base, NodeId(root_id), &resolved.outcome) {
                         let _ = events.unbounded_send(Event::SnapshotUpdated);
                     }
+                }
+                // The drain rides the same tick: it publishes onto exactly the
+                // gate-passing state this pass just reconciled. Both scope seeds
+                // are required — without them there is no name to publish under
+                // and no key to seal with, so the queue simply waits.
+                let read_seed = scope_read_seeds.borrow().get(&root_id).cloned();
+                let write_seed = scope_write_seeds.borrow().get(&root_id).cloned();
+                if let (Some(read_seed), Some(write_seed)) = (read_seed, write_seed) {
+                    let report = Drain {
+                        transport: &transport,
+                        api: &api,
+                        floors: &floors,
+                        snapshot_cache: &snapshot_cache,
+                        staging: &staging,
+                        scheduler: &scheduler,
+                        http: &http,
+                        gateway: &gateway,
+                        profile: &profile,
+                        entropy: &entropy,
+                        base: &base,
+                        held: &held,
+                    }
+                    .run(&DrainScope {
+                        root: NodeId(root_id),
+                        root_name: &root_name,
+                        scope_read_seed: &read_seed,
+                        write_scope_seed: &write_seed,
+                        enc_secret: session.enc_subkey(),
+                        owner_identity: &owner_identity,
+                    })
+                    .await;
+                    surface_drain_report(&events, &dead_letters, &report);
                 }
                 // `Adopted`/`Current` are the reconciled outcomes: both prove the
                 // record plane answered with gate-passing state, so both stamp
@@ -1648,9 +1707,10 @@ impl<T: SeamTypes> Engine<T> {
     /// Mint a fresh random 16-byte node id from the injected entropy seam
     /// (id16, non-secret; blueprint/core.md). Fails closed on entropy failure —
     /// never a predictable id.
-    fn mint_node_id(&mut self) -> Result<NodeId, EngineError> {
+    fn mint_node_id(&self) -> Result<NodeId, EngineError> {
         let mut id = [0u8; 16];
         self.entropy
+            .borrow_mut()
             .fill(&mut id)
             .map_err(|e| EngineError::Entropy {
                 message: e.message().to_owned(),
@@ -1691,7 +1751,7 @@ impl<T: SeamTypes> Engine<T> {
     /// public half plus a fresh ephemeral scalar. Fails closed on entropy
     /// failure — a reused HPKE ephemeral is a confidentiality break, never a
     /// degraded mode.
-    fn record_seal(&mut self) -> Result<RecordSeal, EngineError> {
+    fn record_seal(&self) -> Result<RecordSeal, EngineError> {
         let owner_enc_pub = self
             .session
             .as_ref()
@@ -1699,6 +1759,7 @@ impl<T: SeamTypes> Engine<T> {
             .enc_subkey_public();
         let mut ephemeral_scalar = Zeroizing::new([0u8; 32]);
         self.entropy
+            .borrow_mut()
             .fill(ephemeral_scalar.as_mut())
             .map_err(|e| EngineError::Entropy {
                 message: e.message().to_owned(),

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -704,7 +704,7 @@ fn emit_renewal_failures(events: &mpsc::UnboundedSender<Event>, results: &[EolRe
                 )
             }
             Ok(Some(PublishOutcome::Unconfirmed { sequence })) => {
-                format!("published sequence {sequence} but no record resolved back")
+                format!("published sequence {sequence} but it did not resolve back")
             }
             Err(PublishError::Register(_)) => "register-first publish failed".to_owned(),
             Err(PublishError::AllEndpointsFailed) => "all record endpoints failed".to_owned(),

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -42,6 +42,7 @@ use crate::net::{
     run_liveness_loop,
 };
 use crate::profile::SyncTimingProfile;
+use crate::rotation::derive_write_name;
 use crate::seams::{OpId, Scheduler, SeamError, SeamSet, SeamTypes, StagingStore, UnixMillis};
 use crate::session::SessionIdentity;
 use crate::storage_policy::StoragePolicy;
@@ -738,6 +739,23 @@ fn surface_drain_report(
     }
 }
 
+/// Deposit a recovered scope write seed, but only if it derives the very name
+/// the scope root publishes under. A write-capable grantee can commit an
+/// owner-write-blob wrapping a seed of its choosing; holding it would make the
+/// drain mint every new node's `ipnsName` and signer from a key that party also
+/// holds. A seed that cannot name our own root is not our scope's — held
+/// keyless, never a trust verdict.
+fn deposit_write_seed(
+    cell: &RefCell<ScopeWriteSeeds>,
+    scope_id: [u8; 16],
+    seed: Zeroizing<[u8; 32]>,
+    root_name: Option<&IpnsName>,
+) {
+    if root_name.is_some_and(|name| derive_write_name(&seed, &scope_id) == *name) {
+        cell.borrow_mut().insert(scope_id, seed);
+    }
+}
+
 /// Count nodes reachable from the root via the link graph, cycle-guarded (a
 /// malformed link cycle terminates rather than looping).
 fn count_nodes(snapshot: &Snapshot) -> u64 {
@@ -992,12 +1010,6 @@ impl<T: SeamTypes> Engine<T> {
                 .borrow_mut()
                 .insert(root_scope_id, seed);
         }
-        // The same adopt recovered the scope write seed: the drain derives every
-        // new node's `ipnsName` and its narrow per-name signer from it.
-        if let Some((scope_id, seed)) = outcome.write_scope_seed.take() {
-            self.scope_write_seeds.borrow_mut().insert(scope_id, seed);
-        }
-
         // The gate-passing base becomes the state law's left operand (reads render
         // this ⊕ the pending-op overlay). The resolved root name — the vault
         // pointer's `currentRoot` — drives the resolve-tick loop; `None` on an
@@ -1006,6 +1018,11 @@ impl<T: SeamTypes> Engine<T> {
             .vault_pointer
             .as_ref()
             .map(|vp| vp.repoint.current_root.clone());
+        // The same adopt recovered the scope write seed: the drain derives every
+        // new node's `ipnsName` and its narrow per-name signer from it.
+        if let Some((scope_id, seed)) = outcome.write_scope_seed.take() {
+            deposit_write_seed(&self.scope_write_seeds, scope_id, seed, root_name.as_ref());
+        }
         *self.snapshot.borrow_mut() = outcome.base;
         // A successful cold start is a successful reconcile: stamp it so the
         // ladder starts Fresh rather than Reconciling.
@@ -1265,7 +1282,7 @@ impl<T: SeamTypes> Engine<T> {
                         scope_read_seeds.borrow_mut().insert(root_id, seed);
                     }
                     if let Some((node_id, seed)) = held_resolve.write_scope_seed {
-                        scope_write_seeds.borrow_mut().insert(node_id, seed);
+                        deposit_write_seed(&scope_write_seeds, node_id, seed, Some(&root_name));
                     }
                     held_resolve.resolved
                 });
@@ -1298,7 +1315,7 @@ impl<T: SeamTypes> Engine<T> {
                     .run(&DrainScope {
                         root: NodeId(root_id),
                         root_name: &root_name,
-                        scope_read_seed: &read_seed,
+                        read_scope_seed: &read_seed,
                         write_scope_seed: &write_seed,
                         enc_secret: session.enc_subkey(),
                         owner_identity: &owner_identity,

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -25,7 +25,7 @@ use cipherbox_core::kdf;
 use cipherbox_core::seal::{
     AadContext, Envelope, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB, SignedOwnerBlob,
     SignedOwnerWriteBlob, decode_envelope, decode_grant_section, grant_section_bytes,
-    open_owner_blob, open_owner_write_blob,
+    open_owner_blob, open_owner_write_blob, open_read_body,
 };
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
 use cipherbox_core::suite::x25519::X25519Secret;
@@ -767,6 +767,26 @@ mod tests {
         );
     }
 
+    /// Drive the real equal-floor `Current` sequence: the durable floor already
+    /// sits at the record's sequence, so `adopt` rejects at the sequence stage
+    /// and caches its candidate, and recovery runs off that.
+    async fn recover_at_floor(
+        adopter: &RootAdopter<'_, ScriptedHttp, InMemoryFloorStore>,
+        floors: &InMemoryFloorStore,
+        fx: &Fixture,
+    ) -> Result<Option<OwnScopeMaterial>, SeamError> {
+        floors
+            .raise_sequence_floor(fx.name.as_str().as_bytes(), 1)
+            .await
+            .expect("seed the floor");
+        let record = fx.record(1);
+        assert!(
+            adopter.adopt(&fx.name, &record).await.is_err(),
+            "an equal-floor record must reject at the sequence stage"
+        );
+        adopter.recover_own_scope_material(&fx.name, &record).await
+    }
+
     #[test]
     fn recovery_returns_both_scope_seeds_for_our_own_current_root() {
         let fx = Fixture::build(Some(OWB_WRITE_EPOCH));
@@ -776,8 +796,7 @@ mod tests {
         seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
         let gw = gateway();
         let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
-
-        let material = block_on(adopter.recover_own_scope_material(&fx.name, &fx.record(1)))
+        let material = block_on(recover_at_floor(&adopter, &floors, &fx))
             .expect("recovery is fail-open, never an error")
             .expect("the owner recovers its own scope seeds on the Current path");
         assert_eq!(material.node_id, fx.root_id, "keyed by the envelope id");
@@ -837,7 +856,7 @@ mod tests {
         let gw = gateway();
         let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
         assert!(
-            block_on(adopter.recover_own_scope_material(&fx.name, &fx.record(1)))
+            block_on(recover_at_floor(&adopter, &floors, &fx))
                 .expect("fail-open")
                 .expect("the read seed still recovers")
                 .write_scope_seed
@@ -854,7 +873,7 @@ mod tests {
         let gw = gateway();
         let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
         assert!(
-            block_on(adopter.recover_own_scope_material(&fx.name, &fx.record(1)))
+            block_on(recover_at_floor(&adopter, &floors, &fx))
                 .expect("fail-open")
                 .expect("the read seed still recovers")
                 .write_scope_seed
@@ -872,7 +891,7 @@ mod tests {
         let gw = gateway();
         let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
         assert!(
-            block_on(adopter.recover_own_scope_material(&fx.name, &fx.record(1)))
+            block_on(recover_at_floor(&adopter, &floors, &fx))
                 .expect("fail-open")
                 .expect("the read seed still recovers")
                 .write_scope_seed

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -19,7 +19,7 @@
 use core::cell::RefCell;
 
 use cipherbox_core::content::{decode_content_cid_str, verify_cid};
-use cipherbox_core::error::{CodecError, Malformed};
+use cipherbox_core::error::{CodecError, Malformed, TrustViolation};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
@@ -33,7 +33,7 @@ use zeroize::Zeroizing;
 
 use super::publish::head_cid_from_value;
 use super::resolve::{AdoptOutcome, Adopter, OwnScopeMaterial};
-use crate::content::{ContentPlane, Gateway, ReadError, read_block};
+use crate::content::{ContentPlane, Gateway, ReadError, is_plane_anchor, read_block};
 use crate::gate::{
     Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason, SeedBlob,
     adopt, floor,
@@ -338,6 +338,11 @@ pub(crate) async fn assemble_head_envelope<H: Http>(
 
     let block = match local.filter(|held| held.cid == cid_str) {
         Some(held) => {
+            // A locally-held block clears the same bar as a fetched one: the
+            // plane's anchor check, then the content address itself.
+            if !is_plane_anchor(&cid_str, &expected_cid, ContentPlane::Root) {
+                return Err(assembly_reject(TrustViolation::ContentCidMismatch.into()));
+            }
             verify_cid(&expected_cid, &held.block).map_err(assembly_reject)?;
             held.block.clone()
         }
@@ -531,6 +536,62 @@ mod tests {
         assert_eq!(candidate.grant_section, fx.grant_section);
         // The head block was fetched at its canonical content-CID address.
         assert!(http.requests()[0].url.contains(&fx.head_cid_str));
+    }
+
+    #[test]
+    fn a_held_local_head_serves_the_assembly_without_a_fetch() {
+        let fx = Fixture::new();
+        // No scripted response at all: a fetch here would fail the assembly.
+        let http = ScriptedHttp::default();
+        let floors = InMemoryFloorStore::default();
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+        adopter.hold_local_head(LocalHead {
+            cid: fx.head_cid_str.clone(),
+            block: fx.head_block.clone(),
+        });
+
+        let candidate = block_on(adopter.assemble_candidate(&fx.name, &fx.record(1)))
+            .expect("the held block stands in for the fetch");
+        assert_eq!(candidate.envelope, fx.envelope);
+        assert!(http.requests().is_empty(), "the write path skips the fetch");
+    }
+
+    #[test]
+    fn a_held_local_head_that_is_not_the_records_own_block_is_never_trusted() {
+        let fx = Fixture::new();
+        let http = ScriptedHttp::default();
+        let floors = InMemoryFloorStore::default();
+        let gw = gateway();
+
+        // Right address, wrong bytes: the content-address check refuses them
+        // exactly as it refuses a tampered fetched block.
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+        adopter.hold_local_head(LocalHead {
+            cid: fx.head_cid_str.clone(),
+            block: b"not the block this record anchors".to_vec(),
+        });
+        match block_on(adopter.assemble_candidate(&fx.name, &fx.record(1))) {
+            Err(GateError::Rejected(r)) => assert_eq!(r.check(), "content-cid-mismatch"),
+            Err(GateError::Seam(e)) => panic!("expected a rejection, got seam {e}"),
+            Ok(_) => panic!("a mis-addressed local head must fail closed"),
+        }
+
+        // A held block for some other record is simply not this record's head:
+        // the assembly falls back to the network for the one it does anchor.
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+        adopter.hold_local_head(LocalHead {
+            cid: "bafkreiotherblockaddress".to_owned(),
+            block: b"another record's head".to_vec(),
+        });
+        assert_eq!(
+            block_on(adopter.assemble_candidate(&fx.name, &fx.record(1)))
+                .expect("falls back to the fetch")
+                .envelope,
+            fx.envelope
+        );
     }
 
     #[test]

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -18,7 +18,7 @@
 
 use core::cell::RefCell;
 
-use cipherbox_core::content::decode_content_cid_str;
+use cipherbox_core::content::{decode_content_cid_str, verify_cid};
 use cipherbox_core::error::{CodecError, Malformed};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
@@ -63,6 +63,8 @@ pub struct RootAdopter<'a, H, F> {
     /// equal-floor `Current` recovery ([`Adopter::recover_own_write_seed`])
     /// reuses it instead of re-fetching the same head block per resolve tick.
     assembled: RefCell<Option<Candidate>>,
+    /// A head block the caller already holds ([`Self::hold_local_head`]).
+    local_head: RefCell<Option<LocalHead>>,
 }
 
 impl<'a, H, F> RootAdopter<'a, H, F> {
@@ -84,7 +86,15 @@ impl<'a, H, F> RootAdopter<'a, H, F> {
             owner_identity,
             root_scope_id,
             assembled: RefCell::new(None),
+            local_head: RefCell::new(None),
         }
+    }
+
+    /// Supply a head block the caller already holds, so a self-adopt of our own
+    /// just-published record skips the fetch. The CID the signed record anchors
+    /// still decides: a block that does not match it is ignored.
+    pub fn hold_local_head(&self, head: LocalHead) {
+        *self.local_head.borrow_mut() = Some(head);
     }
 }
 
@@ -100,8 +110,10 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
     ) -> Result<Candidate, GateError> {
         // Steps 1-4 are the shared head-envelope assembly; the sequence is
         // discarded — the gate re-verifies the record from scratch.
+        let local = self.local_head.borrow().clone();
         let (_sequence, envelope) =
-            assemble_head_envelope(self.gateway, self.http, name, record_bytes).await?;
+            assemble_head_envelope(self.gateway, self.http, name, record_bytes, local.as_ref())
+                .await?;
 
         // Step 5 — decode the grant section.
         let section_bytes = grant_section_bytes(&envelope).ok_or_else(|| {
@@ -279,15 +291,28 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
     }
 }
 
+/// A head block the caller already holds — the write path's own just-uploaded
+/// block. Supplying it lets a self-adopt skip the fetch (never the gate): the
+/// block is still checked against the CID the signed record anchors, so a
+/// mismatched local head falls back to the network rather than being trusted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalHead {
+    /// The block's content CID, as the record `Value` spells it.
+    pub cid: String,
+    /// The head block bytes.
+    pub block: Vec<u8>,
+}
+
 /// The head-envelope assembly shared by both adopters: verify the record to
 /// read its signed `/ipfs/<cid>` head anchor (trust is the gate's — this only
-/// extracts the anchor), fetch the head block fail-closed on a CID mismatch,
-/// and decode the envelope. Returns the verified record sequence alongside it.
-pub(super) async fn assemble_head_envelope<H: Http>(
+/// extracts the anchor), take the head block fail-closed on a CID mismatch, and
+/// decode the envelope. Returns the verified record sequence alongside it.
+pub(crate) async fn assemble_head_envelope<H: Http>(
     gateway: &Gateway,
     http: &H,
     name: &IpnsName,
     record_bytes: &[u8],
+    local: Option<&LocalHead>,
 ) -> Result<(u64, Envelope), GateError> {
     let verified = IpnsRecord::unmarshal(record_bytes)
         .and_then(|record| record.verify(name))
@@ -297,9 +322,15 @@ pub(super) async fn assemble_head_envelope<H: Http>(
         .ok_or_else(|| assembly_reject(Malformed::ContentCidStrMalformed.into()))?;
     let expected_cid = decode_content_cid_str(&cid_str).map_err(assembly_reject)?;
 
-    let block = read_block(gateway, http, &cid_str, &expected_cid, ContentPlane::Root)
-        .await
-        .map_err(map_read_error)?;
+    let block = match local.filter(|held| held.cid == cid_str) {
+        Some(held) => {
+            verify_cid(&expected_cid, &held.block).map_err(assembly_reject)?;
+            held.block.clone()
+        }
+        None => read_block(gateway, http, &cid_str, &expected_cid, ContentPlane::Root)
+            .await
+            .map_err(map_read_error)?,
+    };
 
     let envelope = decode_envelope(&block).map_err(assembly_reject)?;
     Ok((verified.sequence, envelope))

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -422,8 +422,8 @@ mod tests {
     use crate::session::SessionIdentity;
     use crate::testkit::fakes::{InMemoryFloorStore, ScriptedHttp};
     use crate::testkit::{
-        OWNER_ROOT_SCOPE_SEED, OWNER_ROOT_WRITE_SCOPE_SEED, OwnerRootFixture, OwnerRootSpec,
-        block_on, owner_root_fixture,
+        OWNER_ROOT_EPOCH, OWNER_ROOT_SCOPE_SEED, OWNER_ROOT_WRITE_SCOPE_SEED, OwnerRootFixture,
+        OwnerRootSpec, block_on, owner_root_fixture,
     };
 
     const TTL_NANOS: u64 = 2_000_000_000;
@@ -811,6 +811,29 @@ mod tests {
         // The recovered seed reproduces the record's IPNS routing name.
         let signer = SessionIdentity::write_name_signer(&seed, &fx.root_id);
         assert_eq!(IpnsName::from_public_key(&signer.verifying_key()), fx.name);
+    }
+
+    #[test]
+    fn equal_floor_recovery_refuses_a_record_below_the_read_epoch_floor() {
+        // Stages 4/5 never ran for a `Current`, so recovery re-imposes the
+        // read-epoch floor itself: a forgery-window writer re-serving a
+        // pre-rotation section at the floor must not hand back the revoked
+        // epoch's read seed.
+        let fx = Fixture::build(Some(OWB_WRITE_EPOCH));
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        block_on(floors.raise_epoch_floor(&fx.scope_id, OWNER_ROOT_EPOCH + 1)).unwrap();
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+
+        assert!(
+            block_on(recover_at_floor(&adopter, &floors, &fx))
+                .expect("fail-open")
+                .is_none(),
+            "a record below the read-epoch floor recovers no seed"
+        );
     }
 
     #[test]

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -201,29 +201,46 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
         name: &IpnsName,
         record_bytes: &[u8],
     ) -> Result<Option<OwnScopeMaterial>, SeamError> {
-        // Recovery is fail-open, never a trust verdict: an unopenable/absent blob
-        // yields `Ok(None)`, held keyless (#752 F3: a Current never hardens).
-        // Reuse the candidate the rejected `adopt` assembled for these same
-        // bytes; assembling again re-fetches the head block.
-        let cached = self
+        // Recovery is fail-open, never a trust verdict: anything unproved yields
+        // `Ok(None)`, held keyless (#752 F3: a Current never hardens).
+        //
+        // Only the candidate the rejected [`Adopter::adopt`] cached for these
+        // exact bytes is eligible. That candidate reached the floor stages, so
+        // the gate's stages 1-3 authenticated the grant section it carries;
+        // re-assembling here would run none of them.
+        let Some(candidate) = self
             .assembled
             .borrow_mut()
             .take()
-            .filter(|c| c.name == *name && c.record_bytes == record_bytes);
-        let candidate = match cached {
-            Some(candidate) => candidate,
-            None => match self.assemble_candidate(name, record_bytes).await {
-                Ok(candidate) => candidate,
-                Err(GateError::Seam(seam)) => return Err(seam),
-                Err(GateError::Rejected(_)) => return Ok(None),
-            },
+            .filter(|c| c.name == *name && c.record_bytes == record_bytes)
+        else {
+            return Ok(None);
         };
         let env = &candidate.envelope;
+        // Stages 4/5 did NOT run: `floor::check` returns `SequenceNotNewer`
+        // before it reads the epoch floor. Re-impose what they would have —
+        // scope binding and the read-epoch floor — or a forgery-window writer
+        // re-serving a pre-rotation section at the floor would hand back the
+        // revoked epoch's read seed.
+        let epoch_floor = floor::read_epoch_floor(self.floors, &self.root_scope_id)
+            .await?
+            .unwrap_or(0);
+        if env.scope != self.root_scope_id || env.epoch < epoch_floor {
+            return Ok(None);
+        }
         let Ok(read_scope_seed) =
             self.open_read_scope_seed(env, &candidate.grant_section.owner_blob)
         else {
             return Ok(None);
         };
+        // Unseal-confirm the seed, exactly as stage 6 does for an adopt: a seed
+        // that does not derive the key this record's own body opens under is not
+        // this scope's seed.
+        let node_seed = kdf::node_seed(&read_scope_seed, &env.id);
+        let read_key = Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes());
+        if open_read_body(env, &read_key).is_err() {
+            return Ok(None);
+        }
         let write_scope_seed = match &candidate.grant_section.owner_write_blob {
             None => None,
             // Map a recovery seam to availability, never a trust verdict.
@@ -243,9 +260,7 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
 
 impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
     /// Open the record's owner blob with the owner's own encryption secret and
-    /// take the scope read seed it wraps. The blob's structure signature is
-    /// authenticated by the gate's stage 3, which runs before the floor stages,
-    /// so an equal-floor `Current` has already proved it committed.
+    /// take the scope read seed it wraps.
     fn open_read_scope_seed(
         &self,
         env: &Envelope,

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -23,16 +23,16 @@ use cipherbox_core::error::{CodecError, Malformed};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
-    AadContext, Envelope, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB, SignedOwnerWriteBlob,
-    decode_envelope, decode_grant_section, grant_section_bytes, open_owner_blob,
-    open_owner_write_blob,
+    AadContext, Envelope, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB, SignedOwnerBlob,
+    SignedOwnerWriteBlob, decode_envelope, decode_grant_section, grant_section_bytes,
+    open_owner_blob, open_owner_write_blob,
 };
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
 use cipherbox_core::suite::x25519::X25519Secret;
 use zeroize::Zeroizing;
 
 use super::publish::head_cid_from_value;
-use super::resolve::{AdoptOutcome, Adopter};
+use super::resolve::{AdoptOutcome, Adopter, OwnScopeMaterial};
 use crate::content::{ContentPlane, Gateway, ReadError, read_block};
 use crate::gate::{
     Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason, SeedBlob,
@@ -60,7 +60,7 @@ pub struct RootAdopter<'a, H, F> {
     /// the gate rejects fail-closed.
     root_scope_id: [u8; 16],
     /// The candidate a rejected [`Adopter::adopt`] assembled, kept so the
-    /// equal-floor `Current` recovery ([`Adopter::recover_own_write_seed`])
+    /// equal-floor `Current` recovery ([`Adopter::recover_own_scope_material`])
     /// reuses it instead of re-fetching the same head block per resolve tick.
     assembled: RefCell<Option<Candidate>>,
     /// A head block the caller already holds ([`Self::hold_local_head`]).
@@ -145,26 +145,15 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
         // seed derives this key, and unseals the read-body.
         let env = &candidate.envelope;
         let owner_blob = &candidate.grant_section.owner_blob;
-        let owner_blob_aad = AadContext {
-            v: env.v,
-            id: env.id,
-            scope: env.scope,
-            epoch: env.epoch,
-            struct_tag: STRUCT_TAG_OWNER_BLOB,
-        };
-        let payload = open_owner_blob(
-            self.owner_enc_secret,
-            &owner_blob.enc,
-            &owner_blob_aad,
-            &owner_blob.ciphertext,
-        )
-        .map_err(|e| reject(GateStage::Unseal, e))?;
+        let owner_blob_aad = owner_blob_aad(env);
+        let read_scope_seed = self
+            .open_read_scope_seed(env, owner_blob)
+            .map_err(|e| reject(GateStage::Unseal, e))?;
 
         // The derived read key is secret; this fn is its terminal owner, so it
         // zeroizes on drop (the gate borrows it and never zeroizes a caller buffer).
         // The recovered scope read seed rides the outcome on a gate pass — the
         // engine's per-scope seed cell feeds the child read pipeline from it.
-        let read_scope_seed = Zeroizing::new(*payload.override_seed());
         let node_seed = kdf::node_seed(&read_scope_seed, &env.id);
         let read_key = Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes());
 
@@ -207,11 +196,11 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
         })
     }
 
-    async fn recover_own_write_seed(
+    async fn recover_own_scope_material(
         &self,
         name: &IpnsName,
         record_bytes: &[u8],
-    ) -> Result<Option<([u8; 16], Zeroizing<[u8; 32]>)>, SeamError> {
+    ) -> Result<Option<OwnScopeMaterial>, SeamError> {
         // Recovery is fail-open, never a trust verdict: an unopenable/absent blob
         // yields `Ok(None)`, held keyless (#752 F3: a Current never hardens).
         // Reuse the candidate the rejected `adopt` assembled for these same
@@ -229,23 +218,48 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
                 Err(GateError::Rejected(_)) => return Ok(None),
             },
         };
-        let Some(owb) = &candidate.grant_section.owner_write_blob else {
+        let env = &candidate.envelope;
+        let Ok(read_scope_seed) =
+            self.open_read_scope_seed(env, &candidate.grant_section.owner_blob)
+        else {
             return Ok(None);
         };
-        // Map a recovery seam to availability, never a trust verdict.
-        let seed = match self
-            .recover_write_scope_seed(&candidate.envelope, owb)
-            .await
-        {
-            Ok(seed) => seed,
-            Err(GateError::Seam(seam)) => return Err(seam),
-            Err(GateError::Rejected(_)) => return Ok(None),
+        let write_scope_seed = match &candidate.grant_section.owner_write_blob {
+            None => None,
+            // Map a recovery seam to availability, never a trust verdict.
+            Some(owb) => match self.recover_write_scope_seed(env, owb).await {
+                Ok(seed) => seed,
+                Err(GateError::Seam(seam)) => return Err(seam),
+                Err(GateError::Rejected(_)) => return Ok(None),
+            },
         };
-        Ok(seed.map(|seed| (candidate.envelope.id, seed)))
+        Ok(Some(OwnScopeMaterial {
+            node_id: env.id,
+            read_scope_seed,
+            write_scope_seed,
+        }))
     }
 }
 
 impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
+    /// Open the record's owner blob with the owner's own encryption secret and
+    /// take the scope read seed it wraps. The blob's structure signature is
+    /// authenticated by the gate's stage 3, which runs before the floor stages,
+    /// so an equal-floor `Current` has already proved it committed.
+    fn open_read_scope_seed(
+        &self,
+        env: &Envelope,
+        owner_blob: &SignedOwnerBlob,
+    ) -> Result<Zeroizing<[u8; 32]>, CodecError> {
+        let payload = open_owner_blob(
+            self.owner_enc_secret,
+            &owner_blob.enc,
+            &owner_blob_aad(env),
+            &owner_blob.ciphertext,
+        )?;
+        Ok(Zeroizing::new(*payload.override_seed()))
+    }
+
     /// Recover the owner's write-scope seed (a KDF non-edge the owner cannot
     /// re-derive) from the record's owner-write-blob for cold-start write-plane
     /// self-renewal (blueprint/core.md "Grant section").
@@ -336,6 +350,17 @@ pub(crate) async fn assemble_head_envelope<H: Http>(
     Ok((verified.sequence, envelope))
 }
 
+/// The structured AAD an owner blob is sealed under.
+fn owner_blob_aad(env: &Envelope) -> AadContext {
+    AadContext {
+        v: env.v,
+        id: env.id,
+        scope: env.scope,
+        epoch: env.epoch,
+        struct_tag: STRUCT_TAG_OWNER_BLOB,
+    }
+}
+
 /// A fail-closed content-plane assembly failure: the head the signed record
 /// anchors is malformed or tampered, so the record's content anchor is
 /// untrustworthy. Assembly runs before the gate's six stages, so it surfaces as
@@ -377,7 +402,8 @@ mod tests {
     use crate::session::SessionIdentity;
     use crate::testkit::fakes::{InMemoryFloorStore, ScriptedHttp};
     use crate::testkit::{
-        OWNER_ROOT_WRITE_SCOPE_SEED, OwnerRootFixture, OwnerRootSpec, block_on, owner_root_fixture,
+        OWNER_ROOT_SCOPE_SEED, OWNER_ROOT_WRITE_SCOPE_SEED, OwnerRootFixture, OwnerRootSpec,
+        block_on, owner_root_fixture,
     };
 
     const TTL_NANOS: u64 = 2_000_000_000;
@@ -666,7 +692,7 @@ mod tests {
     }
 
     #[test]
-    fn recover_own_write_seed_returns_the_seed_for_our_own_current_root() {
+    fn recovery_returns_both_scope_seeds_for_our_own_current_root() {
         let fx = Fixture::build(Some(OWB_WRITE_EPOCH));
         let http = ScriptedHttp::default();
         http.enqueue_response(ok_response(fx.head_block.clone()));
@@ -675,10 +701,17 @@ mod tests {
         let gw = gateway();
         let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
 
-        let (node_id, seed) = block_on(adopter.recover_own_write_seed(&fx.name, &fx.record(1)))
+        let material = block_on(adopter.recover_own_scope_material(&fx.name, &fx.record(1)))
             .expect("recovery is fail-open, never an error")
-            .expect("the owner recovers its own write seed on the Current path");
-        assert_eq!(node_id, fx.root_id, "keyed by the envelope id");
+            .expect("the owner recovers its own scope seeds on the Current path");
+        assert_eq!(material.node_id, fx.root_id, "keyed by the envelope id");
+        assert_eq!(
+            *material.read_scope_seed, OWNER_ROOT_SCOPE_SEED,
+            "the read seed the write plane seals under survives a session that adopts nothing",
+        );
+        let seed = material
+            .write_scope_seed
+            .expect("the write seed is recovered");
         assert_eq!(*seed, OWNER_ROOT_WRITE_SCOPE_SEED);
         // The recovered seed reproduces the record's IPNS routing name.
         let signer = SessionIdentity::write_name_signer(&seed, &fx.root_id);
@@ -704,9 +737,11 @@ mod tests {
             Ok(_) => panic!("an equal-floor record must reject at the sequence stage"),
             Err(GateError::Seam(e)) => panic!("expected a rejection, got seam {e}"),
         }
-        let (_, seed) = block_on(adopter.recover_own_write_seed(&fx.name, &record))
+        let seed = block_on(adopter.recover_own_scope_material(&fx.name, &record))
             .expect("recovery is fail-open, never an error")
-            .expect("the owner recovers its write seed from the reused candidate");
+            .expect("the owner recovers its seeds from the reused candidate")
+            .write_scope_seed
+            .expect("the write seed is recovered");
         assert_eq!(*seed, OWNER_ROOT_WRITE_SCOPE_SEED);
         assert_eq!(
             http.requests().len(),
@@ -716,7 +751,7 @@ mod tests {
     }
 
     #[test]
-    fn recover_own_write_seed_is_none_when_the_blob_is_absent_stale_or_transplanted() {
+    fn no_write_seed_is_recovered_when_the_blob_is_absent_stale_or_transplanted() {
         // Missing owner-write-blob → held keyless, never a seed.
         let fx = Fixture::new();
         let http = ScriptedHttp::default();
@@ -726,10 +761,12 @@ mod tests {
         let gw = gateway();
         let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
         assert!(
-            block_on(adopter.recover_own_write_seed(&fx.name, &fx.record(1)))
+            block_on(adopter.recover_own_scope_material(&fx.name, &fx.record(1)))
                 .expect("fail-open")
+                .expect("the read seed still recovers")
+                .write_scope_seed
                 .is_none(),
-            "no owner-write-blob ⇒ no recovered seed"
+            "no owner-write-blob ⇒ held keyless"
         );
 
         // Stale blob one write epoch below the floor → won't open → None.
@@ -741,10 +778,12 @@ mod tests {
         let gw = gateway();
         let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
         assert!(
-            block_on(adopter.recover_own_write_seed(&fx.name, &fx.record(1)))
+            block_on(adopter.recover_own_scope_material(&fx.name, &fx.record(1)))
                 .expect("fail-open")
+                .expect("the read seed still recovers")
+                .write_scope_seed
                 .is_none(),
-            "a stale owner-write-blob below the floor recovers no seed"
+            "a stale owner-write-blob below the floor recovers no write seed"
         );
 
         // Transplanted: the floor names a different write epoch than the blob was
@@ -757,10 +796,12 @@ mod tests {
         let gw = gateway();
         let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
         assert!(
-            block_on(adopter.recover_own_write_seed(&fx.name, &fx.record(1)))
+            block_on(adopter.recover_own_scope_material(&fx.name, &fx.record(1)))
                 .expect("fail-open")
+                .expect("the read seed still recovers")
+                .write_scope_seed
                 .is_none(),
-            "a transplanted owner-write-blob recovers no seed"
+            "a transplanted owner-write-blob recovers no write seed"
         );
     }
 }

--- a/crates/engine/src/net/author.rs
+++ b/crates/engine/src/net/author.rs
@@ -90,7 +90,9 @@ pub struct EnvelopeAuthoring<'a> {
 
 /// Author a **child** record's envelope: a non-scope-root node, which must
 /// carry no grant section (guard 1, release-active).
-pub fn author_child_envelope(authoring: EnvelopeAuthoring<'_>) -> Result<AuthoredHead, AuthorError> {
+pub fn author_child_envelope(
+    authoring: EnvelopeAuthoring<'_>,
+) -> Result<AuthoredHead, AuthorError> {
     let envelope = seal(&authoring)?;
     if has_grant_section(&envelope) {
         return Err(AuthorError::GrantSectionOnChild);
@@ -234,8 +236,7 @@ mod tests {
 
     #[test]
     fn a_scope_root_envelope_carries_its_grant_section_through() {
-        let head =
-            author_scope_root_envelope(authoring(&folder(), grant_section_field())).unwrap();
+        let head = author_scope_root_envelope(authoring(&folder(), grant_section_field())).unwrap();
         assert!(has_grant_section(&head.envelope));
         assert!(has_grant_section(&decode_envelope(&head.block).unwrap()));
     }

--- a/crates/engine/src/net/author.rs
+++ b/crates/engine/src/net/author.rs
@@ -8,6 +8,9 @@
 //!
 //! - a child envelope carrying a grant section returns `Err`, off core's own
 //!   `has_grant_section` — the produce guard and the decode reject cannot drift;
+//! - a scope root missing its grant section, or carrying one whose commitment
+//!   names another `ipnsName`, returns `Err` off the same decoder the gate's
+//!   stages 2 and 5 run;
 //! - a kind transplant and a non-canonical child-ref `ipnsName` are
 //!   unrepresentable: [`new_child`] feeds one [`NodeKind`] and one typed
 //!   [`IpnsName`] to both the body and the parent's ref.
@@ -17,7 +20,8 @@ use cipherbox_core::content::{compute_cid, encode_content_cid_str};
 use cipherbox_core::error::CodecError;
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::seal::{
-    ChildRef, Envelope, NodeKind, ReadBody, encode_envelope, has_grant_section, seal_read_body,
+    ChildRef, Envelope, NodeKind, ReadBody, decode_grant_section, encode_envelope,
+    grant_section_bytes, has_grant_section, seal_read_body,
 };
 
 use crate::content::DAG_ROOT_CODEC;
@@ -34,6 +38,12 @@ pub enum AuthorError {
     /// child adoption always rejects (`net/child.rs`). Refusing here keeps the
     /// produce side and the decode side on the same predicate.
     GrantSectionOnChild,
+    /// A scope root carried no decodable `grantSection` — the marker every root
+    /// adoption requires (`net/adopter.rs` step 5).
+    MissingGrantSection,
+    /// The carried grant-set commitment names a different `ipnsName` than the
+    /// record is published under, which the gate's stage 2 rejects.
+    CommitmentNameMismatch,
     /// Core refused to seal or encode the authored body (a body decode would
     /// refuse to reopen, e.g. duplicate child ids).
     Seal(CodecError),
@@ -43,6 +53,10 @@ impl core::fmt::Display for AuthorError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::GrantSectionOnChild => f.write_str("child envelope carries a grantSection"),
+            Self::MissingGrantSection => f.write_str("scope root carries no grantSection"),
+            Self::CommitmentNameMismatch => {
+                f.write_str("carried commitment names another ipnsName")
+            }
             Self::Seal(e) => write!(f, "seal failed: {}", e.check()),
         }
     }
@@ -96,13 +110,24 @@ pub fn author_child_envelope(
     encode(envelope)
 }
 
-/// Author a **scope root**'s envelope. The grant section is the root's marker
-/// and rides `carried_unknown` verbatim, so the seed-bearing structures and
-/// their signatures survive a metadata republish untouched.
+/// Author a **scope root**'s envelope for publication under `name`. The grant
+/// section is the root's marker and rides `carried_unknown` verbatim, so the
+/// seed-bearing structures and their signatures survive a metadata republish
+/// untouched — which also means a republish must not carry a section belonging
+/// to some other name, so the two checks the gate's stages 2 and 5 make on
+/// arrival run here first (release-active).
 pub fn author_scope_root_envelope(
     authoring: EnvelopeAuthoring<'_>,
+    name: &IpnsName,
 ) -> Result<AuthoredHead, AuthorError> {
-    encode(seal(&authoring)?)
+    let envelope = seal(&authoring)?;
+    let section = grant_section_bytes(&envelope)
+        .and_then(|bytes| decode_grant_section(bytes).ok())
+        .ok_or(AuthorError::MissingGrantSection)?;
+    if section.commitment.ipns_name != name.as_str().as_bytes() {
+        return Err(AuthorError::CommitmentNameMismatch);
+    }
+    encode(envelope)
 }
 
 fn seal(authoring: &EnvelopeAuthoring<'_>) -> Result<Envelope, AuthorError> {
@@ -185,7 +210,10 @@ mod tests {
     use super::*;
     use cipherbox_core::ipns::IpnsName;
     use cipherbox_core::kdf;
-    use cipherbox_core::seal::{decode_envelope, open_read_body};
+    use cipherbox_core::seal::{decode_envelope, encode_grant_section, open_read_body};
+    use cipherbox_core::suite::ecdsa::EcdsaSigner;
+
+    use crate::testkit::{OwnerRootFixture, OwnerRootSpec, owner_root_fixture};
 
     const READ_KEY: [u8; 32] = [9u8; 32];
     const NONCE: [u8; 24] = [5u8; 24];
@@ -220,6 +248,26 @@ mod tests {
         vec![("grantSection".to_owned(), Value::Bytes(b"section".to_vec()))]
     }
 
+    /// A real scope root's grant section and the name its commitment binds.
+    fn owner_root() -> OwnerRootFixture {
+        let owner_identity = EcdsaSigner::from_scalar(&[0x11; 32]).expect("valid scalar");
+        owner_root_fixture(OwnerRootSpec {
+            owner_identity: &owner_identity,
+            owner_enc: &kdf::enc_subkey(&[0x33; 32]).public(),
+            scope_id: [2u8; 16],
+            root_id: [1u8; 16],
+            children: Vec::new(),
+            owner_write_blob_epoch: None,
+        })
+    }
+
+    fn carried_section(fixture: &OwnerRootFixture) -> Vec<(String, Value)> {
+        vec![(
+            "grantSection".to_owned(),
+            Value::Bytes(encode_grant_section(&fixture.grant_section).expect("encodes")),
+        )]
+    }
+
     #[test]
     fn a_child_envelope_carrying_a_grant_section_is_refused() {
         // Release-active: the guard returns `Err`, so this assertion holds
@@ -232,9 +280,36 @@ mod tests {
 
     #[test]
     fn a_scope_root_envelope_carries_its_grant_section_through() {
-        let head = author_scope_root_envelope(authoring(&folder(), grant_section_field())).unwrap();
+        let fixture = owner_root();
+        let head = author_scope_root_envelope(
+            authoring(&folder(), carried_section(&fixture)),
+            &fixture.name,
+        )
+        .unwrap();
         assert!(has_grant_section(&head.envelope));
         assert!(has_grant_section(&decode_envelope(&head.block).unwrap()));
+    }
+
+    #[test]
+    fn a_scope_root_envelope_republished_under_another_name_is_refused() {
+        // The commitment signs the name it belongs to, so a section carried onto
+        // a record published elsewhere is one the gate's stage 2 always rejects.
+        let fixture = owner_root();
+        assert_eq!(
+            author_scope_root_envelope(authoring(&folder(), carried_section(&fixture)), &name())
+                .unwrap_err(),
+            AuthorError::CommitmentNameMismatch,
+        );
+    }
+
+    #[test]
+    fn a_scope_root_envelope_without_a_grant_section_is_refused() {
+        // A root that lost its section is a root no reader can open: child
+        // adoption refuses the missing marker and the gate has no commitment.
+        assert_eq!(
+            author_scope_root_envelope(authoring(&folder(), Vec::new()), &name()).unwrap_err(),
+            AuthorError::MissingGrantSection,
+        );
     }
 
     #[test]

--- a/crates/engine/src/net/author.rs
+++ b/crates/engine/src/net/author.rs
@@ -1,0 +1,311 @@
+//! Record authoring — the write plane's producer half: build a node's read
+//! body, seal it into an envelope, and mint the parent's ref to it
+//! (blueprint/engine.md "Resolve/publish pipeline: Publish").
+//!
+//! This is where #812's encode-side fail-closed guards live (security rule 8;
+//! #823 assigned them here rather than to core, so the produce-side guard and
+//! the decode-side reject are the same function and cannot drift):
+//!
+//! | Guard                             | Form       | Mechanism                                     |
+//! | --------------------------------- | ---------- | --------------------------------------------- |
+//! | Grant section on a child envelope | checked    | [`author_child_envelope`] calls core's `has_grant_section` |
+//! | Kind transplant                   | structural | [`new_child`] feeds one [`NodeKind`] to both sides |
+//! | Child-ref `ipnsName` well-formed  | structural | authoring takes a typed [`IpnsName`]          |
+//!
+//! No guard is a `debug_assert!`: the checked one returns `Err`, the structural
+//! ones are unrepresentable, so every guard behaves identically under
+//! `--release`.
+
+use cipherbox_core::codec::Value;
+use cipherbox_core::content::{compute_cid, encode_content_cid_str};
+use cipherbox_core::error::CodecError;
+use cipherbox_core::ipns::IpnsName;
+use cipherbox_core::seal::{
+    ChildRef, Envelope, NodeKind, ReadBody, encode_envelope, has_grant_section, seal_read_body,
+};
+
+use crate::content::DAG_ROOT_CODEC;
+
+/// The envelope format+suite version this build authors (blueprint/core.md).
+pub const ENVELOPE_V: u64 = 1;
+
+/// An authoring refusal. Every variant is release-active: authoring returns
+/// `Err` rather than asserting, so a debug and a release build refuse the same
+/// bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthorError {
+    /// A child envelope carried a `grantSection` key — the scope-root marker
+    /// child adoption always rejects (`net/child.rs`). Refusing here keeps the
+    /// produce side and the decode side on the same predicate.
+    GrantSectionOnChild,
+    /// Core refused to seal or encode the authored body (a body decode would
+    /// refuse to reopen, e.g. duplicate child ids).
+    Seal(CodecError),
+}
+
+impl core::fmt::Display for AuthorError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::GrantSectionOnChild => f.write_str("child envelope carries a grantSection"),
+            Self::Seal(e) => write!(f, "seal failed: {}", e.check()),
+        }
+    }
+}
+
+impl std::error::Error for AuthorError {}
+
+/// A sealed record head, ready for the pre-publish preflight: the encoded
+/// envelope block and the CID the published record's `Value` will point at.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthoredHead {
+    /// The sealed envelope.
+    pub envelope: Envelope,
+    /// The canonical det-CBOR encoding of [`Self::envelope`] — the head block.
+    pub block: Vec<u8>,
+    /// `block`'s content CID as a record `Value` spells it.
+    pub cid: String,
+}
+
+/// The inputs one node's envelope is sealed from. `carried_*` are the unknown
+/// fields a republish preserves byte-stable (#27 D10) — empty for a node's
+/// first record.
+pub struct EnvelopeAuthoring<'a> {
+    /// The node id this record is for.
+    pub node_id: [u8; 16],
+    /// The scope this record belongs to.
+    pub scope_id: [u8; 16],
+    /// The scope's read epoch.
+    pub epoch: u64,
+    /// The per-node read key (`node-seed` → `read-key`).
+    pub read_key: &'a [u8; 32],
+    /// Injected per-seal nonce (entropy is a parameter, never read here).
+    pub nonce: &'a [u8; 24],
+    /// The body to seal.
+    pub body: &'a ReadBody,
+    /// Top-level envelope fields carried forward from the previous record.
+    pub carried_unknown: Vec<(String, Value)>,
+    /// `epochTag` fields carried forward from the previous record.
+    pub carried_epoch_tag_unknown: Vec<(String, Value)>,
+}
+
+/// Author a **child** record's envelope: a non-scope-root node, which must
+/// carry no grant section (guard 1, release-active).
+pub fn author_child_envelope(authoring: EnvelopeAuthoring<'_>) -> Result<AuthoredHead, AuthorError> {
+    let envelope = seal(&authoring)?;
+    if has_grant_section(&envelope) {
+        return Err(AuthorError::GrantSectionOnChild);
+    }
+    encode(envelope)
+}
+
+/// Author a **scope root**'s envelope. The grant section is the root's marker
+/// and rides `carried_unknown` verbatim, so the seed-bearing structures and
+/// their signatures survive a metadata republish untouched.
+pub fn author_scope_root_envelope(
+    authoring: EnvelopeAuthoring<'_>,
+) -> Result<AuthoredHead, AuthorError> {
+    encode(seal(&authoring)?)
+}
+
+fn seal(authoring: &EnvelopeAuthoring<'_>) -> Result<Envelope, AuthorError> {
+    let mut envelope = seal_read_body(
+        authoring.read_key,
+        authoring.nonce,
+        ENVELOPE_V,
+        authoring.node_id,
+        authoring.scope_id,
+        authoring.epoch,
+        authoring.body,
+    )
+    .map_err(AuthorError::Seal)?;
+    envelope.unknown = authoring.carried_unknown.clone();
+    envelope.epoch_tag_unknown = authoring.carried_epoch_tag_unknown.clone();
+    Ok(envelope)
+}
+
+fn encode(envelope: Envelope) -> Result<AuthoredHead, AuthorError> {
+    let block = encode_envelope(&envelope).map_err(AuthorError::Seal)?;
+    let cid = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &block));
+    Ok(AuthoredHead {
+        envelope,
+        block,
+        cid,
+    })
+}
+
+/// A newly created node: its own read body and the ref its parent links it by.
+/// Both are built from one [`NodeKind`] and one typed [`IpnsName`], so a kind
+/// transplant and a non-canonical `ipnsName` are unrepresentable rather than
+/// rejected (guards 2 and 4).
+pub struct NewChild {
+    /// The child's own read body.
+    pub body: ReadBody,
+    /// The ref the parent folder carries for it.
+    pub child_ref: ChildRef,
+}
+
+/// Build a newly created empty node and its parent ref. `authored_at` is the
+/// op's journaled time (never a clock read here), and `link_counter` comes from
+/// the rebased snapshot's link allocation.
+pub fn new_child(
+    node_id: [u8; 16],
+    name: String,
+    ipns_name: &IpnsName,
+    kind: NodeKind,
+    link_counter: u64,
+    authored_at: u64,
+) -> NewChild {
+    let body = match kind {
+        NodeKind::Folder => ReadBody::Folder {
+            created_at: authored_at,
+            modified_at: authored_at,
+            children: Vec::new(),
+            unknown: Vec::new(),
+        },
+        NodeKind::File => ReadBody::File {
+            created_at: authored_at,
+            modified_at: authored_at,
+            versions: Vec::new(),
+            unknown: Vec::new(),
+        },
+    };
+    NewChild {
+        child_ref: ChildRef {
+            id: node_id,
+            name,
+            ipns_name: ipns_name.as_str().as_bytes().to_vec(),
+            kind,
+            link_counter,
+            unknown: Vec::new(),
+        },
+        body,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cipherbox_core::ipns::IpnsName;
+    use cipherbox_core::kdf;
+    use cipherbox_core::seal::{decode_envelope, open_read_body};
+
+    const READ_KEY: [u8; 32] = [9u8; 32];
+    const NONCE: [u8; 24] = [5u8; 24];
+
+    fn name() -> IpnsName {
+        IpnsName::from_public_key(&kdf::ipns_keypair(&[3u8; 32]).verifying_key())
+    }
+
+    fn folder() -> ReadBody {
+        ReadBody::Folder {
+            created_at: 1,
+            modified_at: 2,
+            children: Vec::new(),
+            unknown: Vec::new(),
+        }
+    }
+
+    fn authoring(body: &ReadBody, carried: Vec<(String, Value)>) -> EnvelopeAuthoring<'_> {
+        EnvelopeAuthoring {
+            node_id: [1u8; 16],
+            scope_id: [2u8; 16],
+            epoch: 3,
+            read_key: &READ_KEY,
+            nonce: &NONCE,
+            body,
+            carried_unknown: carried,
+            carried_epoch_tag_unknown: Vec::new(),
+        }
+    }
+
+    fn grant_section_field() -> Vec<(String, Value)> {
+        vec![("grantSection".to_owned(), Value::Bytes(b"section".to_vec()))]
+    }
+
+    #[test]
+    fn a_child_envelope_carrying_a_grant_section_is_refused() {
+        // Release-active: the guard returns `Err`, so this assertion holds
+        // identically in a `--release` build (security rule 8).
+        assert_eq!(
+            author_child_envelope(authoring(&folder(), grant_section_field())).unwrap_err(),
+            AuthorError::GrantSectionOnChild,
+        );
+    }
+
+    #[test]
+    fn a_scope_root_envelope_carries_its_grant_section_through() {
+        let head =
+            author_scope_root_envelope(authoring(&folder(), grant_section_field())).unwrap();
+        assert!(has_grant_section(&head.envelope));
+        assert!(has_grant_section(&decode_envelope(&head.block).unwrap()));
+    }
+
+    #[test]
+    fn an_authored_head_decodes_back_to_the_body_it_sealed() {
+        let body = folder();
+        let head = author_child_envelope(authoring(&body, Vec::new())).unwrap();
+        let decoded = decode_envelope(&head.block).unwrap();
+        assert_eq!(decoded, head.envelope, "the block is the envelope");
+        assert_eq!(open_read_body(&decoded, &READ_KEY).unwrap(), body);
+        assert_eq!(
+            head.cid,
+            encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head.block)),
+            "the record value points at the block's own address"
+        );
+    }
+
+    #[test]
+    fn a_body_the_decoder_would_refuse_is_never_sealed() {
+        let dup = ChildRef {
+            id: [7u8; 16],
+            name: "a".into(),
+            ipns_name: b"n".to_vec(),
+            kind: NodeKind::File,
+            link_counter: 1,
+            unknown: Vec::new(),
+        };
+        let body = ReadBody::Folder {
+            created_at: 0,
+            modified_at: 0,
+            children: vec![dup.clone(), dup],
+            unknown: Vec::new(),
+        };
+        assert!(matches!(
+            author_child_envelope(authoring(&body, Vec::new())).unwrap_err(),
+            AuthorError::Seal(_)
+        ));
+    }
+
+    #[test]
+    fn a_new_child_agrees_with_its_parent_ref_on_kind_for_every_kind() {
+        for kind in [NodeKind::Folder, NodeKind::File] {
+            let child = new_child([4u8; 16], "n".into(), &name(), kind, 1, 77);
+            assert_eq!(child.child_ref.kind, child.body.kind());
+            assert_eq!(child.child_ref.kind, kind);
+        }
+    }
+
+    #[test]
+    fn a_new_child_ref_carries_the_canonical_ipns_name_the_read_path_parses() {
+        let ipns = name();
+        let child = new_child([4u8; 16], "n".into(), &ipns, NodeKind::Folder, 1, 77);
+        // The read path's exact chain (`facade.rs` child-ref resolution).
+        let parsed =
+            IpnsName::parse(core::str::from_utf8(&child.child_ref.ipns_name).unwrap()).unwrap();
+        assert_eq!(parsed, ipns);
+    }
+
+    #[test]
+    fn a_new_child_stamps_the_journaled_time_not_a_clock() {
+        let child = new_child([4u8; 16], "n".into(), &name(), NodeKind::Folder, 1, 4_242);
+        let ReadBody::Folder {
+            created_at,
+            modified_at,
+            ..
+        } = child.body
+        else {
+            panic!("folder");
+        };
+        assert_eq!((created_at, modified_at), (4_242, 4_242));
+    }
+}

--- a/crates/engine/src/net/author.rs
+++ b/crates/engine/src/net/author.rs
@@ -25,6 +25,7 @@ use cipherbox_core::seal::{
 };
 
 use crate::content::DAG_ROOT_CODEC;
+use crate::content::limits::MAX_RESOLVED_RECORD_BYTES;
 
 /// The envelope format+suite version this build authors (blueprint/core.md).
 pub const ENVELOPE_V: u64 = 1;
@@ -47,6 +48,16 @@ pub enum AuthorError {
     /// Core refused to seal or encode the authored body (a body decode would
     /// refuse to reopen, e.g. duplicate child ids).
     Seal(CodecError),
+    /// The encoded head block exceeds the ceiling every block read enforces
+    /// ([`MAX_RESOLVED_RECORD_BYTES`]). Publishing it would sign a pointer to a
+    /// block this build's own reader always refuses, leaving the node
+    /// permanently unopenable.
+    HeadTooLarge {
+        /// The encoded block's size.
+        size: usize,
+        /// The enforced ceiling.
+        limit: usize,
+    },
 }
 
 impl core::fmt::Display for AuthorError {
@@ -58,6 +69,9 @@ impl core::fmt::Display for AuthorError {
                 f.write_str("carried commitment names another ipnsName")
             }
             Self::Seal(e) => write!(f, "seal failed: {}", e.check()),
+            Self::HeadTooLarge { size, limit } => {
+                write!(f, "head block exceeds the content cap ({size} > {limit})")
+            }
         }
     }
 }
@@ -148,6 +162,12 @@ fn seal(authoring: &EnvelopeAuthoring<'_>) -> Result<Envelope, AuthorError> {
 
 fn encode(envelope: Envelope) -> Result<AuthoredHead, AuthorError> {
     let block = encode_envelope(&envelope).map_err(AuthorError::Seal)?;
+    if block.len() > MAX_RESOLVED_RECORD_BYTES {
+        return Err(AuthorError::HeadTooLarge {
+            size: block.len(),
+            limit: MAX_RESOLVED_RECORD_BYTES,
+        });
+    }
     let cid = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &block));
     Ok(AuthoredHead {
         envelope,
@@ -323,6 +343,40 @@ mod tests {
             head.cid,
             encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head.block)),
             "the record value points at the block's own address"
+        );
+    }
+
+    #[test]
+    fn a_head_block_past_the_read_cap_is_never_published() {
+        // Release-active (security rule 8): every block read refuses an
+        // over-cap body, so authoring one would sign a pointer to a block this
+        // build's own reader always rejects — an unopenable node.
+        let children = (0..40_000u32)
+            .map(|i| ChildRef {
+                id: {
+                    let mut id = [0u8; 16];
+                    id[..4].copy_from_slice(&i.to_be_bytes());
+                    id
+                },
+                name: "x".repeat(96),
+                ipns_name: i.to_be_bytes().to_vec(),
+                kind: NodeKind::File,
+                link_counter: 1,
+                unknown: Vec::new(),
+            })
+            .collect();
+        let body = ReadBody::Folder {
+            created_at: 0,
+            modified_at: 0,
+            children,
+            unknown: Vec::new(),
+        };
+        assert!(
+            matches!(
+                author_child_envelope(authoring(&body, Vec::new())).unwrap_err(),
+                AuthorError::HeadTooLarge { limit, .. } if limit == MAX_RESOLVED_RECORD_BYTES
+            ),
+            "an over-cap head must fail closed on the produce side"
         );
     }
 

--- a/crates/engine/src/net/author.rs
+++ b/crates/engine/src/net/author.rs
@@ -2,19 +2,15 @@
 //! body, seal it into an envelope, and mint the parent's ref to it
 //! (blueprint/engine.md "Resolve/publish pipeline: Publish").
 //!
-//! This is where #812's encode-side fail-closed guards live (security rule 8;
-//! #823 assigned them here rather than to core, so the produce-side guard and
-//! the decode-side reject are the same function and cannot drift):
+//! Home of the encode-side fail-closed guards #823 assigned to the engine
+//! rather than to core (security rule 8). None is a `debug_assert!`, so a
+//! release build refuses exactly the bytes a debug build does:
 //!
-//! | Guard                             | Form       | Mechanism                                     |
-//! | --------------------------------- | ---------- | --------------------------------------------- |
-//! | Grant section on a child envelope | checked    | [`author_child_envelope`] calls core's `has_grant_section` |
-//! | Kind transplant                   | structural | [`new_child`] feeds one [`NodeKind`] to both sides |
-//! | Child-ref `ipnsName` well-formed  | structural | authoring takes a typed [`IpnsName`]          |
-//!
-//! No guard is a `debug_assert!`: the checked one returns `Err`, the structural
-//! ones are unrepresentable, so every guard behaves identically under
-//! `--release`.
+//! - a child envelope carrying a grant section returns `Err`, off core's own
+//!   `has_grant_section` — the produce guard and the decode reject cannot drift;
+//! - a kind transplant and a non-canonical child-ref `ipnsName` are
+//!   unrepresentable: [`new_child`] feeds one [`NodeKind`] and one typed
+//!   [`IpnsName`] to both the body and the parent's ref.
 
 use cipherbox_core::codec::Value;
 use cipherbox_core::content::{compute_cid, encode_content_cid_str};

--- a/crates/engine/src/net/child.rs
+++ b/crates/engine/src/net/child.rs
@@ -20,7 +20,7 @@ use cipherbox_core::kdf;
 use cipherbox_core::seal::{Envelope, ReadBody, has_grant_section, open_read_body};
 use zeroize::Zeroizing;
 
-use super::adopter::{assemble_head_envelope, reject};
+use super::adopter::{LocalHead, assemble_head_envelope, reject};
 use super::resolve::{AdoptOutcome, Adopter};
 use crate::content::Gateway;
 use crate::gate::{Adopted, GateError, GateStage, floor};
@@ -49,6 +49,8 @@ pub struct ChildAdopter<'a, H, F> {
     /// re-fetching the same head block (mirrors
     /// [`RootAdopter`](super::RootAdopter)).
     assembled: RefCell<Option<AssembledChild>>,
+    /// A head block the caller already holds ([`Self::hold_local_head`]).
+    local_head: RefCell<Option<LocalHead>>,
 }
 
 /// One assembled child head, keyed by the record it came from.
@@ -78,7 +80,15 @@ impl<'a, H, F> ChildAdopter<'a, H, F> {
             scope_read_seed,
             expected_node,
             assembled: RefCell::new(None),
+            local_head: RefCell::new(None),
         }
+    }
+
+    /// Supply a head block the caller already holds, so a self-adopt of our own
+    /// just-published record skips the fetch. The CID the signed record anchors
+    /// still decides: a block that does not match it is ignored.
+    pub fn hold_local_head(&self, head: LocalHead) {
+        *self.local_head.borrow_mut() = Some(head);
     }
 }
 
@@ -91,8 +101,10 @@ impl<H: Http, F: FloorStore> ChildAdopter<'_, H, F> {
         name: &IpnsName,
         record_bytes: &[u8],
     ) -> Result<(u64, Envelope), GateError> {
+        let local = self.local_head.borrow().clone();
         let (sequence, envelope) =
-            assemble_head_envelope(self.gateway, self.http, name, record_bytes).await?;
+            assemble_head_envelope(self.gateway, self.http, name, record_bytes, local.as_ref())
+                .await?;
         // A grant section marks a scope root; granted-subscope reads are a
         // later slice — fail closed, no partial support.
         if has_grant_section(&envelope) {

--- a/crates/engine/src/net/liveness.rs
+++ b/crates/engine/src/net/liveness.rs
@@ -200,7 +200,7 @@ where
     // Republish the same content at seq+1 (floor + 1) with a fresh EOL.
     publish(transport, api, floors, scheduler, profile, request)
         .await
-        .map(Some)
+        .map(|receipt| Some(receipt.outcome))
 }
 
 /// One held record's sub-EOL renewal outcome.

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -51,7 +51,7 @@ pub use liveness::{
 };
 pub use pointer_fetch::RecordPointerFetch;
 pub use publish::{PublishError, PublishOutcome, PublishReceipt, PublishRequest, publish};
-pub use resolve::{AdoptOutcome, Adopter, ResolveOutcome, Resolved, resolve};
+pub use resolve::{AdoptOutcome, Adopter, OwnScopeMaterial, ResolveOutcome, Resolved, resolve};
 pub(crate) use resolve::{
     GatedResolve, HeldMaterial, refresh_base_from_outcome, resolve_and_hold, resolve_gated,
 };

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -41,14 +41,9 @@ pub mod resolve;
 pub mod retire;
 pub mod revival;
 
-pub use adopter::{LocalHead, RootAdopter};
 pub(crate) use adopter::assemble_head_envelope;
-pub use author::{AuthorError, AuthoredHead, EnvelopeAuthoring, NewChild};
+pub use adopter::{LocalHead, RootAdopter};
 pub use child::ChildAdopter;
-pub use record_publish::{
-    HeadBinding, PreflightError, PreflightedHead, RecordPublishError, RecordPublishOutcome,
-    RecordPublishRequest, preflight, publish_record,
-};
 pub(crate) use liveness::eol_renew_pass;
 pub use liveness::{
     EolRenewResult, HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, RePutResult,
@@ -58,8 +53,7 @@ pub use pointer_fetch::RecordPointerFetch;
 pub use publish::{PublishError, PublishOutcome, PublishReceipt, PublishRequest, publish};
 pub use resolve::{AdoptOutcome, Adopter, ResolveOutcome, Resolved, resolve};
 pub(crate) use resolve::{
-    GatedResolve, HeldMaterial, HeldResolve, refresh_base_from_outcome, resolve_and_hold,
-    resolve_gated,
+    GatedResolve, HeldMaterial, refresh_base_from_outcome, resolve_and_hold, resolve_gated,
 };
 pub use retire::{retire, root_retire_ready};
 pub use revival::{ReviveError, ReviveRequest, revive};

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -32,25 +32,34 @@ mod child;
 mod fanout;
 mod pointer_fetch;
 
+pub mod author;
 pub mod eol;
 pub mod liveness;
 pub mod publish;
+pub mod record_publish;
 pub mod resolve;
 pub mod retire;
 pub mod revival;
 
-pub use adopter::RootAdopter;
+pub use adopter::{LocalHead, RootAdopter};
+pub(crate) use adopter::assemble_head_envelope;
+pub use author::{AuthorError, AuthoredHead, EnvelopeAuthoring, NewChild};
 pub use child::ChildAdopter;
+pub use record_publish::{
+    HeadBinding, PreflightError, PreflightedHead, RecordPublishError, RecordPublishOutcome,
+    RecordPublishRequest, preflight, publish_record,
+};
 pub(crate) use liveness::eol_renew_pass;
 pub use liveness::{
     EolRenewResult, HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, RePutResult,
     eol_republish, keyless_re_put, run_liveness_loop,
 };
 pub use pointer_fetch::RecordPointerFetch;
-pub use publish::{PublishError, PublishOutcome, PublishRequest, publish};
+pub use publish::{PublishError, PublishOutcome, PublishReceipt, PublishRequest, publish};
 pub use resolve::{AdoptOutcome, Adopter, ResolveOutcome, Resolved, resolve};
 pub(crate) use resolve::{
-    GatedResolve, HeldMaterial, refresh_base_from_outcome, resolve_and_hold, resolve_gated,
+    GatedResolve, HeldMaterial, HeldResolve, refresh_base_from_outcome, resolve_and_hold,
+    resolve_gated,
 };
 pub use retire::{retire, root_retire_ready};
 pub use revival::{ReviveError, ReviveRequest, revive};

--- a/crates/engine/src/net/publish.rs
+++ b/crates/engine/src/net/publish.rs
@@ -79,6 +79,16 @@ pub enum PublishOutcome {
         /// The sequence embedded in the published record.
         sequence: u64,
     },
+    /// The PUT was acknowledged but confirm-by-re-resolve observed **no**
+    /// resolvable record at the name. Availability, never a trust verdict: the
+    /// record may simply not have propagated to a readable endpoint yet.
+    /// Retrying is idempotent-in-sequence — the caller must not adopt these
+    /// bytes, so the sequence floor stays put and a re-publish re-mints the
+    /// same sequence.
+    Unconfirmed {
+        /// The sequence embedded in the published record.
+        sequence: u64,
+    },
     /// A concurrent writer's record at a strictly higher sequence was observed
     /// on the confirm re-resolve: a lost CAS race. The caller re-resolves and
     /// rebases (rebase is a later slice; this slice only reports the race).
@@ -88,6 +98,17 @@ pub enum PublishOutcome {
         /// The higher sequence a concurrent writer landed first.
         observed_sequence: u64,
     },
+}
+
+/// A completed publish: the outcome plus the signed record bytes that were PUT,
+/// so a caller can feed its own record back through the adoption gate without a
+/// re-fetch (the write path's self-adopt).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublishReceipt {
+    /// The confirm-by-re-resolve verdict.
+    pub outcome: PublishOutcome,
+    /// The signed record bytes this publish PUT.
+    pub record_bytes: Vec<u8>,
 }
 
 /// A fail-closed publish failure.
@@ -119,7 +140,7 @@ pub async fn publish<T, H, C, F, Sch>(
     scheduler: &Sch,
     profile: &SyncTimingProfile,
     request: &PublishRequest<'_>,
-) -> Result<PublishOutcome, PublishError>
+) -> Result<PublishReceipt, PublishError>
 where
     T: RecordTransport + Clone + 'static,
     H: Http,
@@ -179,16 +200,22 @@ where
     }
 
     // Confirm by re-resolve: a strictly higher record means a concurrent writer
-    // won the CAS race; anything else confirms our record landed.
+    // won the CAS race; observing nothing at all confirms nothing, so it must
+    // not report success (that arm is how an acked-but-unresolvable publish used
+    // to pass for `Published`).
     let observed = fanout_get_verify(transport, request.name).await;
     let outcome = match observed {
         Some((observed_sequence, _)) if observed_sequence > sequence => PublishOutcome::LostRace {
             published_sequence: sequence,
             observed_sequence,
         },
-        _ => PublishOutcome::Published { sequence },
+        Some(_) => PublishOutcome::Published { sequence },
+        None => PublishOutcome::Unconfirmed { sequence },
     };
-    Ok(outcome)
+    Ok(PublishReceipt {
+        outcome,
+        record_bytes,
+    })
 }
 
 /// Spawn the background re-PUT for endpoints that missed the first ack: sleep a

--- a/crates/engine/src/net/publish.rs
+++ b/crates/engine/src/net/publish.rs
@@ -205,12 +205,23 @@ where
     // to pass for `Published`).
     let observed = fanout_get_verify(transport, request.name).await;
     let outcome = match observed {
+        // `fanout_get_verify` reports the freshest record across the endpoint
+        // set. Only our own bytes prove a readable endpoint holds *our* record:
+        // a different record at the same sequence is a fork — a retry that
+        // re-authored after an unconfirmed PUT — and adopting it would advance
+        // the floor past bytes the network may never serve.
+        Some((observed_sequence, bytes)) if observed_sequence == sequence => {
+            if bytes == record_bytes {
+                PublishOutcome::Published { sequence }
+            } else {
+                PublishOutcome::Unconfirmed { sequence }
+            }
+        }
         Some((observed_sequence, _)) if observed_sequence > sequence => PublishOutcome::LostRace {
             published_sequence: sequence,
             observed_sequence,
         },
-        Some(_) => PublishOutcome::Published { sequence },
-        None => PublishOutcome::Unconfirmed { sequence },
+        _ => PublishOutcome::Unconfirmed { sequence },
     };
     Ok(PublishReceipt {
         outcome,

--- a/crates/engine/src/net/publish.rs
+++ b/crates/engine/src/net/publish.rs
@@ -79,9 +79,11 @@ pub enum PublishOutcome {
         /// The sequence embedded in the published record.
         sequence: u64,
     },
-    /// The PUT was acknowledged but confirm-by-re-resolve observed **no**
-    /// resolvable record at the name. Availability, never a trust verdict: the
-    /// record may simply not have propagated to a readable endpoint yet.
+    /// The PUT was acknowledged but confirm-by-re-resolve did not read **our**
+    /// bytes back at our sequence: nothing resolvable, a stale lower sequence,
+    /// or different bytes at the same sequence (a fork from a retry that
+    /// re-authored after an earlier unconfirmed PUT). Availability, never a
+    /// trust verdict.
     /// Retrying is idempotent-in-sequence — the caller must not adopt these
     /// bytes, so the sequence floor stays put and a re-publish re-mints the
     /// same sequence.

--- a/crates/engine/src/net/record_publish.rs
+++ b/crates/engine/src/net/record_publish.rs
@@ -14,7 +14,7 @@ use cipherbox_core::seal::open_read_body;
 use cipherbox_core::suite::ed25519::Ed25519Signer;
 
 use super::author::AuthoredHead;
-use super::publish::{PublishError, PublishOutcome, PublishRequest, publish};
+use super::publish::{PublishError, PublishReceipt, PublishRequest, publish};
 use crate::api::{ApiClient, ApiError};
 use crate::profile::SyncTimingProfile;
 use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
@@ -109,34 +109,6 @@ pub struct RecordPublishRequest<'a> {
     pub min_current_sequence: Option<u64>,
 }
 
-/// What a record publish produced. `Published` is the only outcome whose bytes
-/// a caller may self-adopt: adopting an `Unconfirmed` publish would advance the
-/// sequence floor and destroy the idempotent-in-sequence retry.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum RecordPublishOutcome {
-    /// The record landed and re-resolved as the freshest at the name.
-    Published {
-        /// The sequence embedded in the published record.
-        sequence: u64,
-        /// The signed record bytes, for the caller's self-adopt.
-        record_bytes: Vec<u8>,
-    },
-    /// The PUT was acked but nothing resolved back — availability, not trust.
-    Unconfirmed {
-        /// The sequence embedded in the published record.
-        sequence: u64,
-        /// The signed record bytes.
-        record_bytes: Vec<u8>,
-    },
-    /// A concurrent writer landed a strictly higher sequence first.
-    LostRace {
-        /// The sequence this publish embedded.
-        published_sequence: u64,
-        /// The higher sequence a concurrent writer landed first.
-        observed_sequence: u64,
-    },
-}
-
 /// A fail-closed record-publish failure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RecordPublishError {
@@ -156,7 +128,10 @@ pub enum RecordPublishError {
 }
 
 /// Publish one authored record: upload its head block, then run the
-/// register-first CAS publish and hand back the signed bytes.
+/// register-first CAS publish and hand back the signed bytes. Only
+/// [`PublishOutcome::Published`] bytes may be self-adopted — adopting an
+/// unconfirmed publish would advance the sequence floor and destroy the
+/// idempotent-in-sequence retry.
 pub async fn publish_record<T, H, C, F, Sch>(
     transport: &T,
     api: &ApiClient<H, C>,
@@ -164,7 +139,7 @@ pub async fn publish_record<T, H, C, F, Sch>(
     scheduler: &Sch,
     profile: &SyncTimingProfile,
     request: &RecordPublishRequest<'_>,
-) -> Result<RecordPublishOutcome, RecordPublishError>
+) -> Result<PublishReceipt, RecordPublishError>
 where
     T: RecordTransport + Clone + 'static,
     H: Http,
@@ -183,7 +158,7 @@ where
         });
     }
 
-    let receipt = publish(
+    publish(
         transport,
         api,
         floors,
@@ -198,25 +173,7 @@ where
         },
     )
     .await
-    .map_err(RecordPublishError::Publish)?;
-
-    Ok(match receipt.outcome {
-        PublishOutcome::Published { sequence } => RecordPublishOutcome::Published {
-            sequence,
-            record_bytes: receipt.record_bytes,
-        },
-        PublishOutcome::Unconfirmed { sequence } => RecordPublishOutcome::Unconfirmed {
-            sequence,
-            record_bytes: receipt.record_bytes,
-        },
-        PublishOutcome::LostRace {
-            published_sequence,
-            observed_sequence,
-        } => RecordPublishOutcome::LostRace {
-            published_sequence,
-            observed_sequence,
-        },
-    })
+    .map_err(RecordPublishError::Publish)
 }
 
 #[cfg(test)]

--- a/crates/engine/src/net/record_publish.rs
+++ b/crates/engine/src/net/record_publish.rs
@@ -49,9 +49,7 @@ pub enum PreflightError {
 impl core::fmt::Display for PreflightError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::BlockEnvelopeMismatch => {
-                f.write_str("head block is not the envelope beside it")
-            }
+            Self::BlockEnvelopeMismatch => f.write_str("head block is not the envelope beside it"),
             Self::BindingMismatch => f.write_str("authored envelope binding mismatch"),
             Self::Unseal(e) => write!(f, "authored envelope does not reopen: {}", e.check()),
         }

--- a/crates/engine/src/net/record_publish.rs
+++ b/crates/engine/src/net/record_publish.rs
@@ -279,6 +279,21 @@ mod tests {
         );
     }
 
+    /// The block is what ships and the envelope is what the rest of the dry run
+    /// inspects, so a head pairing one with the other's bytes would publish a
+    /// block nothing checked.
+    #[test]
+    fn a_head_whose_block_is_not_its_envelope_never_gets_a_witness() {
+        let binding = binding();
+        let mut authored = head(&binding);
+        authored.block.push(0);
+
+        assert_eq!(
+            preflight(&binding, &READ_KEY, &authored).unwrap_err(),
+            PreflightError::BlockEnvelopeMismatch,
+        );
+    }
+
     #[test]
     fn an_envelope_claiming_another_identity_never_gets_a_witness() {
         let authored = head(&binding());

--- a/crates/engine/src/net/record_publish.rs
+++ b/crates/engine/src/net/record_publish.rs
@@ -10,7 +10,7 @@
 
 use cipherbox_core::error::CodecError;
 use cipherbox_core::ipns::IpnsName;
-use cipherbox_core::seal::open_read_body;
+use cipherbox_core::seal::{decode_envelope, open_read_body};
 use cipherbox_core::suite::ed25519::Ed25519Signer;
 
 use super::author::AuthoredHead;
@@ -19,8 +19,8 @@ use crate::api::{ApiClient, ApiError};
 use crate::profile::SyncTimingProfile;
 use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
 
-/// The identity an authored envelope must claim, supplied independently of the
-/// envelope so the preflight compares rather than echoes.
+/// The identity an authored envelope must claim, as the caller believes it —
+/// carried alongside the envelope rather than read out of it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HeadBinding {
     /// The node the record is for.
@@ -36,6 +36,9 @@ pub struct HeadBinding {
 /// rejection would have diagnostic value and no preventive value.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PreflightError {
+    /// The head block is not the encoding of the envelope beside it, so the
+    /// bytes checked here are not the bytes that would ship.
+    BlockEnvelopeMismatch,
     /// The authored envelope does not claim the identity the caller expects.
     BindingMismatch,
     /// The authored envelope does not reopen under the key the gate will
@@ -46,6 +49,9 @@ pub enum PreflightError {
 impl core::fmt::Display for PreflightError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            Self::BlockEnvelopeMismatch => {
+                f.write_str("head block is not the envelope beside it")
+            }
             Self::BindingMismatch => f.write_str("authored envelope binding mismatch"),
             Self::Unseal(e) => write!(f, "authored envelope does not reopen: {}", e.check()),
         }
@@ -64,22 +70,28 @@ pub struct PreflightedHead {
 }
 
 impl PreflightedHead {
-    /// The head block's content CID, as a record `Value` spells it.
+    /// The head block's content CID, as the record `Value` spells it.
     pub fn cid(&self) -> &str {
         &self.cid
     }
 }
 
-/// Envelope-level dry run: check the authored envelope claims the expected
-/// `(id, scope, epoch)` and reopens under the read key the adoption gate will
-/// re-derive. No network, no record, no floor advance — the full six-stage gate
-/// still runs post-publish on the returned bytes.
+/// Envelope-level dry run: check the head block really is the envelope beside
+/// it, that the envelope claims the expected `(id, scope, epoch)`, and that it
+/// reopens under the read key the adoption gate will re-derive. No network, no
+/// record, no floor advance — the full six-stage gate still runs post-publish
+/// on the returned bytes.
 pub fn preflight(
     binding: &HeadBinding,
     read_key: &[u8; 32],
     head: &AuthoredHead,
 ) -> Result<PreflightedHead, PreflightError> {
     let envelope = &head.envelope;
+    // The block ships; the envelope is what the rest of this dry run inspects.
+    // A head that pairs one with the other's bytes would publish unchecked.
+    if decode_envelope(&head.block).ok().as_ref() != Some(envelope) {
+        return Err(PreflightError::BlockEnvelopeMismatch);
+    }
     if envelope.id != binding.node_id
         || envelope.scope != binding.scope_id
         || envelope.epoch != binding.epoch
@@ -180,6 +192,8 @@ where
 mod tests {
     use super::*;
     use crate::net::author::{EnvelopeAuthoring, author_child_envelope};
+    use crate::seams::{HttpResponse, RecordTransport};
+    use crate::testkit::{FakeWorld, block_on};
     use cipherbox_core::seal::ReadBody;
 
     const READ_KEY: [u8; 32] = [8u8; 32];
@@ -213,12 +227,58 @@ mod tests {
         .unwrap()
     }
 
+    /// A pin store that answers with an address other than the block's own is
+    /// not holding the bytes we authored, so signing a record at our CID would
+    /// point at a block nothing pinned.
     #[test]
-    fn a_dry_run_head_carries_its_own_block_address() {
+    fn a_pin_store_that_reports_another_address_publishes_nothing() {
+        let world = FakeWorld::new();
+        let device = world.device(b"me");
         let binding = binding();
         let authored = head(&binding);
-        let flighted = preflight(&binding, &READ_KEY, &authored).unwrap();
-        assert_eq!(flighted.cid(), authored.cid);
+        let preflighted = preflight(&binding, &READ_KEY, &authored).expect("dry run");
+        let api = ApiClient::new(
+            device.http.clone(),
+            device.credential_store.clone(),
+            "http://api.test",
+        );
+        device.http.enqueue_response(HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: br#"{"cid":"bafkreisomeotherblock","size":1}"#.to_vec(),
+        });
+        let signer = Ed25519Signer::from_seed([9u8; 32]);
+        let name = IpnsName::from_public_key(&signer.verifying_key());
+
+        let outcome = block_on(publish_record(
+            &device.record_store,
+            &api,
+            &device.floor_store,
+            &world.scheduler,
+            &SyncTimingProfile::CI,
+            &RecordPublishRequest {
+                name: &name,
+                signer: &signer,
+                head: &preflighted,
+                content_cids: Vec::new(),
+                min_current_sequence: None,
+            },
+        ));
+
+        assert_eq!(
+            outcome.unwrap_err(),
+            RecordPublishError::HeadCidMismatch {
+                expected: authored.cid,
+                returned: "bafkreisomeotherblock".to_owned(),
+            }
+        );
+        assert!(
+            device
+                .record_store
+                .record_at(&device.record_store.endpoints()[0], name.as_str())
+                .is_none(),
+            "nothing reached the record plane"
+        );
     }
 
     #[test]

--- a/crates/engine/src/net/record_publish.rs
+++ b/crates/engine/src/net/record_publish.rs
@@ -1,0 +1,299 @@
+//! The one shared publish port: move an authored record to the network and
+//! hand back the signed bytes (blueprint/engine.md "Resolve/publish pipeline").
+//!
+//! Custody-free by design — it holds no read-key material, seals nothing, and
+//! runs no gate; the name and its signer are injected, mirroring the layer
+//! below ([`publish`]). What custody would have bought is recovered
+//! structurally: [`PreflightedHead`]'s only constructor is [`preflight`], so an
+//! envelope that has not been dry-run against the key the gate will re-derive
+//! cannot reach the network.
+
+use cipherbox_core::error::CodecError;
+use cipherbox_core::ipns::IpnsName;
+use cipherbox_core::seal::open_read_body;
+use cipherbox_core::suite::ed25519::Ed25519Signer;
+
+use super::author::AuthoredHead;
+use super::publish::{PublishError, PublishOutcome, PublishRequest, publish};
+use crate::api::{ApiClient, ApiError};
+use crate::profile::SyncTimingProfile;
+use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
+
+/// The identity an authored envelope must claim, supplied independently of the
+/// envelope so the preflight compares rather than echoes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HeadBinding {
+    /// The node the record is for.
+    pub node_id: [u8; 16],
+    /// The scope it belongs to.
+    pub scope_id: [u8; 16],
+    /// The scope read epoch it is sealed at.
+    pub epoch: u64,
+}
+
+/// A pre-publish dry-run failure. The op fails locally and **nothing** is
+/// published — a signed record cannot be unpublished, so a post-publish
+/// rejection would have diagnostic value and no preventive value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreflightError {
+    /// The authored envelope does not claim the identity the caller expects.
+    BindingMismatch,
+    /// The authored envelope does not reopen under the key the gate will
+    /// re-derive — an encoder bug caught before it reaches the network.
+    Unseal(CodecError),
+}
+
+impl core::fmt::Display for PreflightError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::BindingMismatch => f.write_str("authored envelope binding mismatch"),
+            Self::Unseal(e) => write!(f, "authored envelope does not reopen: {}", e.check()),
+        }
+    }
+}
+
+impl std::error::Error for PreflightError {}
+
+/// A head block that passed [`preflight`]. Private fields and no other
+/// constructor: this type *is* the guarantee that every published head was
+/// dry-run first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreflightedHead {
+    block: Vec<u8>,
+    cid: String,
+}
+
+impl PreflightedHead {
+    /// The head block's content CID, as a record `Value` spells it.
+    pub fn cid(&self) -> &str {
+        &self.cid
+    }
+}
+
+/// Envelope-level dry run: check the authored envelope claims the expected
+/// `(id, scope, epoch)` and reopens under the read key the adoption gate will
+/// re-derive. No network, no record, no floor advance — the full six-stage gate
+/// still runs post-publish on the returned bytes.
+pub fn preflight(
+    binding: &HeadBinding,
+    read_key: &[u8; 32],
+    head: &AuthoredHead,
+) -> Result<PreflightedHead, PreflightError> {
+    let envelope = &head.envelope;
+    if envelope.id != binding.node_id
+        || envelope.scope != binding.scope_id
+        || envelope.epoch != binding.epoch
+    {
+        return Err(PreflightError::BindingMismatch);
+    }
+    open_read_body(envelope, read_key).map_err(PreflightError::Unseal)?;
+    Ok(PreflightedHead {
+        block: head.block.clone(),
+        cid: head.cid.clone(),
+    })
+}
+
+/// One record publish: the name and its narrow per-name signer, the
+/// preflighted head, and the content CIDs to register alongside it.
+pub struct RecordPublishRequest<'a> {
+    /// The IPNS name being published.
+    pub name: &'a IpnsName,
+    /// The narrow per-name Ed25519 signer for [`Self::name`].
+    pub signer: &'a Ed25519Signer,
+    /// The dry-run head block to upload and point the record at.
+    pub head: &'a PreflightedHead,
+    /// The content CIDs to register/pin under this name.
+    pub content_cids: Vec<String>,
+    /// Raises the CAS expected-current sequence (revival only; see
+    /// [`PublishRequest::min_current_sequence`]).
+    pub min_current_sequence: Option<u64>,
+}
+
+/// What a record publish produced. `Published` is the only outcome whose bytes
+/// a caller may self-adopt: adopting an `Unconfirmed` publish would advance the
+/// sequence floor and destroy the idempotent-in-sequence retry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecordPublishOutcome {
+    /// The record landed and re-resolved as the freshest at the name.
+    Published {
+        /// The sequence embedded in the published record.
+        sequence: u64,
+        /// The signed record bytes, for the caller's self-adopt.
+        record_bytes: Vec<u8>,
+    },
+    /// The PUT was acked but nothing resolved back — availability, not trust.
+    Unconfirmed {
+        /// The sequence embedded in the published record.
+        sequence: u64,
+        /// The signed record bytes.
+        record_bytes: Vec<u8>,
+    },
+    /// A concurrent writer landed a strictly higher sequence first.
+    LostRace {
+        /// The sequence this publish embedded.
+        published_sequence: u64,
+        /// The higher sequence a concurrent writer landed first.
+        observed_sequence: u64,
+    },
+}
+
+/// A fail-closed record-publish failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecordPublishError {
+    /// The head block upload failed; nothing was published.
+    Upload(ApiError),
+    /// The pin store reported a CID other than the block's own address, so the
+    /// bytes it holds are not the bytes we authored. Publishing our CID anyway
+    /// would sign a pointer to a block nothing pinned — refused fail-closed.
+    HeadCidMismatch {
+        /// The head block's own content address.
+        expected: String,
+        /// What the pin store reported.
+        returned: String,
+    },
+    /// The publish pipeline failed.
+    Publish(PublishError),
+}
+
+/// Publish one authored record: upload its head block, then run the
+/// register-first CAS publish and hand back the signed bytes.
+pub async fn publish_record<T, H, C, F, Sch>(
+    transport: &T,
+    api: &ApiClient<H, C>,
+    floors: &F,
+    scheduler: &Sch,
+    profile: &SyncTimingProfile,
+    request: &RecordPublishRequest<'_>,
+) -> Result<RecordPublishOutcome, RecordPublishError>
+where
+    T: RecordTransport + Clone + 'static,
+    H: Http,
+    C: CredentialStore,
+    F: FloorStore,
+    Sch: Scheduler + Clone + 'static,
+{
+    let uploaded = api
+        .upload(&request.head.block)
+        .await
+        .map_err(RecordPublishError::Upload)?;
+    if uploaded.cid != request.head.cid {
+        return Err(RecordPublishError::HeadCidMismatch {
+            expected: request.head.cid.clone(),
+            returned: uploaded.cid,
+        });
+    }
+
+    let receipt = publish(
+        transport,
+        api,
+        floors,
+        scheduler,
+        profile,
+        &PublishRequest {
+            name: request.name,
+            signer: request.signer,
+            head_cid: request.head.cid.clone(),
+            content_cids: request.content_cids.clone(),
+            min_current_sequence: request.min_current_sequence,
+        },
+    )
+    .await
+    .map_err(RecordPublishError::Publish)?;
+
+    Ok(match receipt.outcome {
+        PublishOutcome::Published { sequence } => RecordPublishOutcome::Published {
+            sequence,
+            record_bytes: receipt.record_bytes,
+        },
+        PublishOutcome::Unconfirmed { sequence } => RecordPublishOutcome::Unconfirmed {
+            sequence,
+            record_bytes: receipt.record_bytes,
+        },
+        PublishOutcome::LostRace {
+            published_sequence,
+            observed_sequence,
+        } => RecordPublishOutcome::LostRace {
+            published_sequence,
+            observed_sequence,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::net::author::{EnvelopeAuthoring, author_child_envelope};
+    use cipherbox_core::seal::ReadBody;
+
+    const READ_KEY: [u8; 32] = [8u8; 32];
+    const NONCE: [u8; 24] = [6u8; 24];
+
+    fn binding() -> HeadBinding {
+        HeadBinding {
+            node_id: [1u8; 16],
+            scope_id: [2u8; 16],
+            epoch: 3,
+        }
+    }
+
+    fn head(binding: &HeadBinding) -> AuthoredHead {
+        let body = ReadBody::Folder {
+            created_at: 0,
+            modified_at: 0,
+            children: Vec::new(),
+            unknown: Vec::new(),
+        };
+        author_child_envelope(EnvelopeAuthoring {
+            node_id: binding.node_id,
+            scope_id: binding.scope_id,
+            epoch: binding.epoch,
+            read_key: &READ_KEY,
+            nonce: &NONCE,
+            body: &body,
+            carried_unknown: Vec::new(),
+            carried_epoch_tag_unknown: Vec::new(),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn a_dry_run_head_carries_its_own_block_address() {
+        let binding = binding();
+        let authored = head(&binding);
+        let flighted = preflight(&binding, &READ_KEY, &authored).unwrap();
+        assert_eq!(flighted.cid(), authored.cid);
+    }
+
+    #[test]
+    fn an_envelope_claiming_another_identity_never_gets_a_witness() {
+        let authored = head(&binding());
+        for wrong in [
+            HeadBinding {
+                node_id: [9u8; 16],
+                ..binding()
+            },
+            HeadBinding {
+                scope_id: [9u8; 16],
+                ..binding()
+            },
+            HeadBinding {
+                epoch: 4,
+                ..binding()
+            },
+        ] {
+            assert_eq!(
+                preflight(&wrong, &READ_KEY, &authored).unwrap_err(),
+                PreflightError::BindingMismatch,
+            );
+        }
+    }
+
+    #[test]
+    fn an_envelope_the_gates_key_cannot_reopen_never_gets_a_witness() {
+        let binding = binding();
+        assert!(matches!(
+            preflight(&binding, &[0u8; 32], &head(&binding)).unwrap_err(),
+            PreflightError::Unseal(_)
+        ));
+    }
+}

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -521,7 +521,7 @@ mod tests {
             write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
             content_cids: vec!["bafycontent".into()],
         };
-        let (resolved, _) = block_on(resolve_and_hold(
+        let resolved = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
             &StubAdopter::new(Verdict::Accept),
@@ -529,7 +529,8 @@ mod tests {
             &held,
             &material,
         ))
-        .expect("resolve_and_hold");
+        .expect("resolve_and_hold")
+        .resolved;
 
         assert!(matches!(resolved.outcome, ResolveOutcome::Adopted(_)));
         let map = held.borrow();
@@ -562,7 +563,7 @@ mod tests {
 
         // A fail-closed trust violation is never held.
         let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
-        let (out, _) = block_on(resolve_and_hold(
+        let out = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
             &StubAdopter::new(Verdict::TrustViolation),
@@ -570,7 +571,8 @@ mod tests {
             &held,
             &material,
         ))
-        .unwrap();
+        .unwrap()
+        .resolved;
         assert!(matches!(out.outcome, ResolveOutcome::TrustViolation(_)));
         assert!(held.borrow().is_empty(), "a trust violation is never held");
     }
@@ -597,7 +599,7 @@ mod tests {
             write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
             content_cids: Vec::new(),
         };
-        let (resolved, _) = block_on(resolve_and_hold(
+        let resolved = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
             &StubAdopter::new(Verdict::EqualSequence),
@@ -605,7 +607,8 @@ mod tests {
             &held,
             &material,
         ))
-        .expect("resolve_and_hold");
+        .expect("resolve_and_hold")
+        .resolved;
 
         // Our own current record at the floor is `Current`, carrying the verified
         // bytes verbatim (no re-fetch), and is held for the keyless re-PUT.
@@ -660,7 +663,7 @@ mod tests {
             write_scope_seed: None,
             content_cids: Vec::new(),
         };
-        let (resolved, _) = block_on(resolve_and_hold(
+        let resolved = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
             &StubAdopter::own_current(write_scope_seed, node_id),
@@ -668,7 +671,8 @@ mod tests {
             &held,
             &material,
         ))
-        .expect("resolve_and_hold");
+        .expect("resolve_and_hold")
+        .resolved;
         assert!(matches!(resolved.outcome, ResolveOutcome::Current { .. }));
 
         let hr = held
@@ -741,7 +745,7 @@ mod tests {
             write_scope_seed: None,
             content_cids: Vec::new(),
         };
-        let (resolved, _) = block_on(resolve_and_hold(
+        let resolved = block_on(resolve_and_hold(
             &device.record_store,
             &device.snapshot_cache,
             &StubAdopter::new(Verdict::EqualSequence),
@@ -749,7 +753,8 @@ mod tests {
             &held,
             &material,
         ))
-        .expect("resolve_and_hold");
+        .expect("resolve_and_hold")
+        .resolved;
         assert!(matches!(resolved.outcome, ResolveOutcome::Current { .. }));
         assert!(
             held.borrow().is_empty(),
@@ -799,7 +804,8 @@ mod tests {
             &held,
             &material,
         ))
-        .expect("resolve_and_hold");
+        .expect("resolve_and_hold")
+        .resolved;
 
         // The gate-surfaced write seed derived the renewal signer, keyed by the
         // gate's node id, and it signs for exactly the held name.
@@ -878,7 +884,8 @@ mod tests {
             &held,
             &material,
         ))
-        .expect("resolve_and_hold");
+        .expect("resolve_and_hold")
+        .resolved;
 
         let expected = head_cid_from_value(VALUE).expect("fixture value has a head cid");
         assert!(!expected.is_empty());
@@ -928,7 +935,8 @@ mod tests {
             &held,
             &material,
         ))
-        .expect("resolve_and_hold");
+        .expect("resolve_and_hold")
+        .resolved;
         let hr = held
             .borrow()
             .get(&node_id)

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -254,13 +254,29 @@ pub(crate) struct HeldMaterial {
     pub content_cids: Vec<String>,
 }
 
+/// What [`resolve_and_hold`] produced: the public resolve result plus the
+/// transient scope material a gate-passing adopt recovered. Kept off the public
+/// [`Resolved`] so no seed ever rides the facade-visible surface.
+pub(crate) struct HeldResolve {
+    /// The public resolve result.
+    pub(crate) resolved: Resolved,
+    /// The scope read seed the child read pipeline derives per-node read keys
+    /// from.
+    pub(crate) read_scope_seed: Option<Zeroizing<[u8; 32]>>,
+    /// The (node id, scope write seed) the drain derives new names and per-name
+    /// signers from.
+    pub(crate) write_scope_seed: Option<AdoptHold>,
+}
+
 /// [`resolve`] a name, then hold it for liveness **iff** it passed the gate:
 /// on [`ResolveOutcome::Adopted`], insert (replacing any prior entry for the
 /// same node) a [`HeldRecord`] so the keyless re-PUT loop keeps it alive. Only a
 /// gate-passing record enters the set — a `TrustViolation`/`NoUpdate` never
 /// does (blueprint/engine.md "Liveness": never re-PUT a stale record).
-/// Additionally surfaces the recovered scope read seed (see
-/// [`AdoptOutcome::read_scope_seed`]) for the tick driver's deposit.
+/// Additionally surfaces the scope seeds a gate-passing adopt recovered (see
+/// [`AdoptOutcome::read_scope_seed`]) for the tick driver's deposit — the write
+/// seed among them, because the drain derives every new node's name and signer
+/// from it.
 pub(crate) async fn resolve_and_hold<T, S, A>(
     transport: &T,
     snapshot_cache: &S,
@@ -268,7 +284,7 @@ pub(crate) async fn resolve_and_hold<T, S, A>(
     name: &IpnsName,
     held: &RefCell<HeldRecords>,
     material: &HeldMaterial,
-) -> Result<(Resolved, Option<Zeroizing<[u8; 32]>>), SeamError>
+) -> Result<HeldResolve, SeamError>
 where
     T: RecordTransport,
     S: SnapshotCache,
@@ -280,6 +296,12 @@ where
         held_bytes,
         read_scope_seed,
     } = resolve_gated(transport, snapshot_cache, adopter, name).await?;
+    let write_scope_seed = adopt_hold.clone();
+    let done = |resolved| HeldResolve {
+        resolved,
+        read_scope_seed,
+        write_scope_seed,
+    };
     // A gate-passing adopt (`Adopted`) and our own current record (`Current`)
     // are both alive-worthy and ride their verified bytes back here; a
     // `TrustViolation`/`NoUpdate` holds nothing (blueprint/engine.md "Liveness").
@@ -294,7 +316,7 @@ where
             .ok()
             .and_then(|verified| head_cid_from_value(&verified.value))
         else {
-            return Ok((resolved, read_scope_seed));
+            return Ok(done(resolved));
         };
         // The renewal (node id, write seed) comes from the gate for a write
         // grantee, else from the caller for an own-scope record. No seed on
@@ -306,7 +328,7 @@ where
                 .as_ref()
                 .map(|seed| (material.node_id, seed.clone()))
         }) else {
-            return Ok((resolved, read_scope_seed));
+            return Ok(done(resolved));
         };
         // Derive the narrow per-name signer once from the transient seed and hold
         // only it — the seed drops at this scope's end. Fail-closed encode-side
@@ -315,7 +337,7 @@ where
         // the hold rather than store a mismatched signer.
         let signer = SessionIdentity::write_name_signer(&write_scope_seed, &node_id);
         if IpnsName::from_public_key(&signer.verifying_key()) != *name {
-            return Ok((resolved, read_scope_seed));
+            return Ok(done(resolved));
         }
         // Content re-pin on renewal is a deferred slice; the record still
         // republishes validly under its head CID (only re-pinning is deferred).
@@ -330,7 +352,7 @@ where
             },
         );
     }
-    Ok((resolved, read_scope_seed))
+    Ok(done(resolved))
 }
 
 /// Fold a completed resolve's verdict into the shared base cell. A gate-passing

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -44,19 +44,34 @@ pub trait Adopter {
     /// `Err(GateError::Seam)` is host I/O.
     async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<AdoptOutcome, GateError>;
 
-    /// Recover the OWNER's own write-scope seed for an equal-floor `Current` own
-    /// record so the liveness loop can hold+renew it (#752 F3). `Ok(None)` when
-    /// not our own / no owner-write-blob / the blob won't open under the durable
-    /// write floor — held keyless, never force-held. Fail-OPEN: returns a
-    /// [`SeamError`], never a `Rejected` verdict (a `Current` must never harden
-    /// into a trust error). The default suits every non-owner adopter stub.
-    async fn recover_own_write_seed(
+    /// Recover the OWNER's own scope material for an equal-floor `Current` own
+    /// record: the read seed the child pipeline and the drain seal under, and
+    /// the write seed the liveness loop renews with (#752 F3). `Ok(None)` when
+    /// the record is not our own or its owner blob will not open. Fail-OPEN:
+    /// returns a [`SeamError`], never a `Rejected` verdict (a `Current` must
+    /// never harden into a trust error). The default suits every non-owner
+    /// adopter stub.
+    async fn recover_own_scope_material(
         &self,
         _name: &IpnsName,
         _record_bytes: &[u8],
-    ) -> Result<Option<([u8; 16], Zeroizing<[u8; 32]>)>, SeamError> {
+    ) -> Result<Option<OwnScopeMaterial>, SeamError> {
         Ok(None)
     }
+}
+
+/// The owner's own-scope seeds, recovered from a record already at the durable
+/// sequence floor. Both come from grant-section structures the gate's stages
+/// 1-3 authenticated before the floor stages ran, so an equal-floor `Current`
+/// has proved them committed; neither is ever persisted.
+pub struct OwnScopeMaterial {
+    /// The scope-root node id the seeds belong to.
+    pub node_id: [u8; 16],
+    /// The scope read seed (the owner blob's override seed).
+    pub read_scope_seed: Zeroizing<[u8; 32]>,
+    /// The scope write seed, `None` when the root is held keyless (no
+    /// owner-write-blob, or it will not open under the durable write floor).
+    pub write_scope_seed: Option<Zeroizing<[u8; 32]>>,
 }
 
 /// A gate pass plus the transient write material a write-capable holder needs to
@@ -204,17 +219,28 @@ where
                 Err(GateError::Rejected(rejection)) => match &rejection.reason {
                     RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor => {
                         // Our own current root at exactly the floor: recover the
-                        // owner's write seed (fail-open) so the liveness loop can
-                        // hold+renew it before its EOL lapses (#752 F3). A non-owner
-                        // record or an unopenable owner-write-blob yields no hold.
-                        let hold = adopter.recover_own_write_seed(name, &bytes).await?;
+                        // owner's own scope seeds (fail-open) so the liveness loop
+                        // can hold+renew it before its EOL lapses (#752 F3) and the
+                        // write plane keeps the keys it seals under across a
+                        // session that adopts nothing. A non-owner record yields
+                        // neither.
+                        let material = adopter.recover_own_scope_material(name, &bytes).await?;
+                        let (hold, read_scope_seed) = match material {
+                            Some(material) => (
+                                material
+                                    .write_scope_seed
+                                    .map(|seed| (material.node_id, seed)),
+                                Some(material.read_scope_seed),
+                            ),
+                            None => (None, None),
+                        };
                         (
                             ResolveOutcome::Current {
                                 record_bytes: bytes.clone(),
                             },
                             hold,
                             Some(bytes),
-                            None,
+                            read_scope_seed,
                         )
                     }
                     _ => (ResolveOutcome::TrustViolation(rejection), None, None, None),
@@ -378,7 +404,9 @@ pub(crate) fn refresh_base_from_outcome(
 
 #[cfg(test)]
 mod tests {
-    use super::{HeldMaterial, ResolveOutcome, head_cid_from_value, resolve_and_hold};
+    use super::{
+        HeldMaterial, OwnScopeMaterial, ResolveOutcome, head_cid_from_value, resolve_and_hold,
+    };
 
     use core::cell::RefCell;
 
@@ -484,14 +512,16 @@ mod tests {
             }
         }
 
-        async fn recover_own_write_seed(
+        async fn recover_own_scope_material(
             &self,
             _name: &IpnsName,
             _record_bytes: &[u8],
-        ) -> Result<Option<([u8; 16], Zeroizing<[u8; 32]>)>, crate::seams::SeamError> {
-            Ok(self
-                .own_seed
-                .map(|(node_id, seed)| (node_id, Zeroizing::new(seed))))
+        ) -> Result<Option<OwnScopeMaterial>, crate::seams::SeamError> {
+            Ok(self.own_seed.map(|(node_id, seed)| OwnScopeMaterial {
+                node_id,
+                read_scope_seed: Zeroizing::new([0u8; 32]),
+                write_scope_seed: Some(Zeroizing::new(seed)),
+            }))
         }
     }
 
@@ -804,8 +834,7 @@ mod tests {
             &held,
             &material,
         ))
-        .expect("resolve_and_hold")
-        .resolved;
+        .expect("resolve_and_hold");
 
         // The gate-surfaced write seed derived the renewal signer, keyed by the
         // gate's node id, and it signs for exactly the held name.
@@ -884,8 +913,7 @@ mod tests {
             &held,
             &material,
         ))
-        .expect("resolve_and_hold")
-        .resolved;
+        .expect("resolve_and_hold");
 
         let expected = head_cid_from_value(VALUE).expect("fixture value has a head cid");
         assert!(!expected.is_empty());
@@ -935,8 +963,7 @@ mod tests {
             &held,
             &material,
         ))
-        .expect("resolve_and_hold")
-        .resolved;
+        .expect("resolve_and_hold");
         let hr = held
             .borrow()
             .get(&node_id)

--- a/crates/engine/src/net/revival.rs
+++ b/crates/engine/src/net/revival.rs
@@ -83,5 +83,6 @@ where
     };
     publish(transport, api, floors, scheduler, profile, &publish_request)
         .await
+        .map(|receipt| receipt.outcome)
         .map_err(ReviveError::Publish)
 }

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -128,6 +128,11 @@ pub struct ColdStartOutcome {
     /// blob; `None` when nothing adopted. The engine deposits it in its
     /// in-memory per-scope seed cell (never persisted).
     pub read_scope_seed: Option<Zeroizing<[u8; 32]>>,
+    /// The (node id, scope write seed) the same adopt recovered from the
+    /// owner-write-blob; `None` when nothing adopted or the root is held
+    /// keyless. The drain derives every new node's name and per-name signer
+    /// from it (never persisted).
+    pub write_scope_seed: Option<([u8; 16], Zeroizing<[u8; 32]>)>,
 }
 
 impl core::fmt::Debug for ColdStartOutcome {
@@ -141,6 +146,10 @@ impl core::fmt::Debug for ColdStartOutcome {
             .field(
                 "read_scope_seed",
                 &self.read_scope_seed.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "write_scope_seed",
+                &self.write_scope_seed.as_ref().map(|_| "<redacted>"),
             )
             .finish()
     }
@@ -194,6 +203,7 @@ where
             base,
             rendered,
             read_scope_seed: None,
+            write_scope_seed: None,
         });
     };
 
@@ -216,6 +226,7 @@ where
     let GatedResolve {
         resolved,
         read_scope_seed,
+        hold: write_scope_seed,
         ..
     } = resolve_gated(
         transport,
@@ -251,6 +262,7 @@ where
         base,
         rendered,
         read_scope_seed,
+        write_scope_seed,
     })
 }
 

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -17,6 +17,7 @@
 //! the pass with the op still queued, so FIFO order is never broken.
 
 use core::cell::RefCell;
+use std::collections::BTreeSet;
 
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
@@ -38,13 +39,14 @@ use crate::net::record_publish::{
     publish_record,
 };
 use crate::net::{
-    Adopter, AdoptOutcome, ChildAdopter, HeldRecord, HeldRecords, LocalHead, RootAdopter,
+    AdoptOutcome, Adopter, ChildAdopter, HeldRecord, HeldRecords, LocalHead, RootAdopter,
     assemble_head_envelope,
 };
 use crate::profile::SyncTimingProfile;
 use crate::rotation::derive_write_name;
 use crate::seams::{
-    CredentialStore, FloorStore, Http, OpId, RecordTransport, Scheduler, SnapshotCache, StagingStore,
+    CredentialStore, FloorStore, Http, OpId, RecordTransport, Scheduler, SnapshotCache,
+    StagingStore,
 };
 use crate::session::SessionIdentity;
 use crate::sync::model::Snapshot;
@@ -54,14 +56,11 @@ use crate::sync::project::project_root;
 use crate::sync::rebase::{DeadLetterReason, decode_queue, replay};
 use crate::sync::record::RecordReader;
 
-/// The durable drained-op high-water mark's floor key: every op id at or below
-/// the stored value has left this device's queue (published, dropped, or
-/// dead-lettered).
-///
-/// It rides the sequence-floor namespace because it is exactly that namespace's
-/// contract — a durable monotonic-max `u64` under engine-chosen opaque key
-/// bytes. The `/` makes it unrepresentable as an `ipnsName` (base36 alphanumeric
-/// only), so it can never collide with a real per-name floor.
+/// The durable drained-op high-water mark: every op id at or below the stored
+/// value has left this device's queue (#860). It rides the sequence-floor
+/// namespace, whose contract it is — a durable monotonic-max `u64` under opaque
+/// key bytes — under a key the base36 `ipnsName` alphabet cannot spell, so it
+/// never collides with a real per-name floor.
 const DRAINED_OP_FLOOR_KEY: &[u8] = b"cipherbox/drained-op";
 
 /// What one drain pass did.
@@ -79,6 +78,16 @@ pub(crate) struct DrainReport {
     /// Why the pass stopped early, if it did. FIFO is strict: the op stays
     /// queued and the next pass retries it.
     pub(crate) halted: Option<DrainHalt>,
+}
+
+impl DrainReport {
+    /// Whether the pass left the durable queue exactly as it found it.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.published.is_empty()
+            && self.dropped.is_empty()
+            && self.dead_letters.is_empty()
+            && self.restore_residue.is_empty()
+    }
 }
 
 /// Why a drain pass stopped before the queue was empty.
@@ -159,9 +168,18 @@ where
     /// applied op it can, stopping at the first it cannot.
     pub(crate) async fn run(&self, scope: &DrainScope<'_>) -> DrainReport {
         let mut report = DrainReport::default();
-        match self.pass(scope, &mut report).await {
-            Ok(()) => {}
-            Err(halt) => report.halted = Some(halt),
+        let queued = match self.queued_ops(scope, &mut report).await {
+            Ok(queued) => queued,
+            Err(halt) => {
+                report.halted = Some(halt);
+                return report;
+            }
+        };
+        if let Err(halt) = self.pass(scope, &queued, &mut report).await {
+            report.halted = Some(halt);
+        }
+        if let Err(halt) = self.mark_drained(&queued, &report).await {
+            report.halted.get_or_insert(halt);
         }
         report
     }
@@ -169,9 +187,9 @@ where
     async fn pass(
         &self,
         scope: &DrainScope<'_>,
+        queued: &[(OpId, Op)],
         report: &mut DrainReport,
     ) -> Result<(), DrainHalt> {
-        let queued = self.queued_ops(scope, report).await?;
         if queued.is_empty() {
             return Ok(());
         }
@@ -181,7 +199,7 @@ where
             let base = self.base.borrow();
             let ops: Vec<Op> = queued.iter().map(|(_, op)| op.clone()).collect();
             let local = apply_overlay(&base, &ops);
-            replay(&base, &local, &queued)
+            replay(&base, &local, queued)
         };
 
         for (op_id, reason) in &rebased.dead_letters {
@@ -485,12 +503,36 @@ where
         );
     }
 
-    /// Remove a resolved op from the durable queue and raise the completion
-    /// mark past it, so a restored queue cannot replay it (#860).
+    /// Remove a resolved op from the durable queue.
     async fn retire_op(&self, op_id: OpId) -> Result<(), DrainHalt> {
-        self.staging.remove_op(op_id).await.map_err(seam)?;
+        self.staging.remove_op(op_id).await.map_err(seam)
+    }
+
+    /// Raise the completion mark over this pass's **contiguous** drained prefix.
+    /// The mark is a high-water line, so it may only pass ops that have all
+    /// left the queue: advancing it over a halted op would make a restored data
+    /// dir discard that op as residue instead of publishing it (#860).
+    async fn mark_drained(
+        &self,
+        queued: &[(OpId, Op)],
+        report: &DrainReport,
+    ) -> Result<(), DrainHalt> {
+        let retired: BTreeSet<OpId> = report
+            .published
+            .iter()
+            .chain(&report.dropped)
+            .copied()
+            .chain(report.dead_letters.iter().map(|(op_id, ..)| *op_id))
+            .collect();
+        let Some(mark) = queued
+            .iter()
+            .map_while(|(op_id, _)| retired.contains(op_id).then_some(op_id.0))
+            .last()
+        else {
+            return Ok(());
+        };
         self.floors
-            .raise_sequence_floor(DRAINED_OP_FLOOR_KEY, op_id.0)
+            .raise_sequence_floor(DRAINED_OP_FLOOR_KEY, mark)
             .await
             .map_err(seam)?;
         Ok(())

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -61,7 +61,7 @@ use crate::sync::record::RecordReader;
 /// namespace, whose contract it is — a durable monotonic-max `u64` under opaque
 /// key bytes — under a key the base36 `ipnsName` alphabet cannot spell, so it
 /// never collides with a real per-name floor.
-const DRAINED_OP_FLOOR_KEY: &[u8] = b"cipherbox/drained-op";
+pub const DRAINED_OP_FLOOR_KEY: &[u8] = b"cipherbox/drained-op";
 
 /// What one drain pass did.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -34,9 +34,9 @@ use crate::net::author::{
     AuthorError, AuthoredHead, ENVELOPE_V, EnvelopeAuthoring, author_child_envelope,
     author_scope_root_envelope, new_child,
 };
+use crate::net::publish::{PublishOutcome, PublishReceipt};
 use crate::net::record_publish::{
-    HeadBinding, PreflightError, RecordPublishOutcome, RecordPublishRequest, preflight,
-    publish_record,
+    HeadBinding, PreflightError, RecordPublishRequest, preflight, publish_record,
 };
 use crate::net::{
     AdoptOutcome, Adopter, ChildAdopter, HeldRecord, HeldRecords, LocalHead, RootAdopter,
@@ -313,15 +313,16 @@ where
     ) -> Result<(), DrainHalt> {
         let OpKind::Create {
             parent,
-            kind: NodeKind::Folder,
+            kind,
             content: None,
             ..
         } = &applied.op.kind
         else {
             return Err(DrainHalt::Unsupported);
         };
-        // Deeper folders need their own parent record authored, which is the
-        // next slice; this one publishes creates directly under the scope root.
+        // A deeper parent's own record is not authorable yet: the base snapshot
+        // projects the root's direct children only, so there is no gate-passing
+        // sub-folder body to re-author onto.
         if *parent != scope.root {
             return Err(DrainHalt::Unsupported);
         }
@@ -336,7 +337,7 @@ where
             child_id.0,
             name,
             &child_name,
-            CoreNodeKind::Folder,
+            core_kind(*kind),
             rebased.max_link_counter(child_id),
             applied.op.authored_at.0,
         );
@@ -450,7 +451,10 @@ where
         let preflighted = preflight(&binding, &self.node_read_key(scope, node_id), head)
             .map_err(DrainHalt::Preflight)?;
         let signer = SessionIdentity::write_name_signer(scope.write_scope_seed, node_id);
-        let outcome = publish_record(
+        let PublishReceipt {
+            outcome,
+            record_bytes,
+        } = publish_record(
             self.transport,
             self.api,
             self.floors,
@@ -467,11 +471,11 @@ where
         .await
         .map_err(|e| DrainHalt::Publish(format!("{e:?}")))?;
         match outcome {
-            RecordPublishOutcome::Published { record_bytes, .. } => Ok(record_bytes),
-            RecordPublishOutcome::Unconfirmed { sequence, .. } => Err(DrainHalt::Publish(format!(
+            PublishOutcome::Published { .. } => Ok(record_bytes),
+            PublishOutcome::Unconfirmed { sequence } => Err(DrainHalt::Publish(format!(
                 "sequence {sequence} published but nothing resolved back"
             ))),
-            RecordPublishOutcome::LostRace {
+            PublishOutcome::LostRace {
                 published_sequence,
                 observed_sequence,
             } => Err(DrainHalt::Publish(format!(
@@ -554,6 +558,14 @@ where
             .fill(&mut nonce)
             .map_err(|e| DrainHalt::Seam(e.message().to_owned()))?;
         Ok(nonce)
+    }
+}
+
+/// Map the facade node kind onto the structurally-identical wire kind.
+fn core_kind(kind: NodeKind) -> CoreNodeKind {
+    match kind {
+        NodeKind::Folder => CoreNodeKind::Folder,
+        NodeKind::File => CoreNodeKind::File,
     }
 }
 

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -31,13 +31,11 @@ use crate::content::Gateway;
 use crate::entropy::Entropy;
 use crate::facade::{NodeId, NodeKind};
 use crate::net::author::{
-    AuthorError, AuthoredHead, ENVELOPE_V, EnvelopeAuthoring, author_child_envelope,
-    author_scope_root_envelope, new_child,
+    AuthoredHead, ENVELOPE_V, EnvelopeAuthoring, author_child_envelope, author_scope_root_envelope,
+    new_child,
 };
 use crate::net::publish::{PublishOutcome, PublishReceipt};
-use crate::net::record_publish::{
-    HeadBinding, PreflightError, RecordPublishRequest, preflight, publish_record,
-};
+use crate::net::record_publish::{HeadBinding, RecordPublishRequest, preflight, publish_record};
 use crate::net::{
     AdoptOutcome, Adopter, ChildAdopter, HeldRecord, HeldRecords, LocalHead, RootAdopter,
     assemble_head_envelope,
@@ -75,9 +73,6 @@ pub(crate) struct DrainReport {
     /// Ops removed as restore residue: already drained on this device, so the
     /// queue that holds them is older than the completion record (#860).
     pub(crate) restore_residue: Vec<OpId>,
-    /// Why the pass stopped early, if it did. FIFO is strict: the op stays
-    /// queued and the next pass retries it.
-    pub(crate) halted: Option<DrainHalt>,
 }
 
 impl DrainReport {
@@ -90,20 +85,11 @@ impl DrainReport {
     }
 }
 
-/// Why a drain pass stopped before the queue was empty.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum DrainHalt {
-    /// The op kind has no publisher in this slice.
-    Unsupported,
-    /// Authoring refused to produce the record.
-    Author(AuthorError),
-    /// The pre-publish dry run refused the authored envelope.
-    Preflight(PreflightError),
-    /// The publish itself failed, or landed unconfirmed/lost the CAS race.
-    Publish(String),
-    /// A durable seam or a gate rejection stopped the pass.
-    Seam(String),
-}
+/// A drain pass stopped before the queue was empty. Strict FIFO: the op that
+/// stopped it stays queued and the next tick retries it, so the durable queue
+/// is the record of the failure. Classifying it — dead-letter thresholds,
+/// attempt budgets — is the failure-policy slice's.
+struct Halt;
 
 /// The owner-scope material one drain pass publishes under. Every field is
 /// borrowed from the live session; the drain zeroizes none of it.
@@ -168,19 +154,11 @@ where
     /// applied op it can, stopping at the first it cannot.
     pub(crate) async fn run(&self, scope: &DrainScope<'_>) -> DrainReport {
         let mut report = DrainReport::default();
-        let queued = match self.queued_ops(scope, &mut report).await {
-            Ok(queued) => queued,
-            Err(halt) => {
-                report.halted = Some(halt);
-                return report;
-            }
+        let Ok(queued) = self.queued_ops(scope, &mut report).await else {
+            return report;
         };
-        if let Err(halt) = self.pass(scope, &queued, &mut report).await {
-            report.halted = Some(halt);
-        }
-        if let Err(halt) = self.mark_drained(&queued, &report).await {
-            report.halted.get_or_insert(halt);
-        }
+        let _ = self.pass(scope, &queued, &mut report).await;
+        let _ = self.mark_drained(&queued, &report).await;
         report
     }
 
@@ -189,7 +167,7 @@ where
         scope: &DrainScope<'_>,
         queued: &[(OpId, Op)],
         report: &mut DrainReport,
-    ) -> Result<(), DrainHalt> {
+    ) -> Result<(), Halt> {
         if queued.is_empty() {
             return Ok(());
         }
@@ -232,7 +210,7 @@ where
         &self,
         scope: &DrainScope<'_>,
         report: &mut DrainReport,
-    ) -> Result<Vec<(OpId, Op)>, DrainHalt> {
+    ) -> Result<Vec<(OpId, Op)>, Halt> {
         let raw = self.staging.queued_ops().await.map_err(seam)?;
         let scan = decode_queue(&RecordReader::new(scope.enc_secret), &raw);
         let drained = self
@@ -255,13 +233,13 @@ where
 
     /// The scope root as currently published: its envelope's carried fields and
     /// its unsealed folder body.
-    async fn load_root(&self, scope: &DrainScope<'_>) -> Result<RootState, DrainHalt> {
+    async fn load_root(&self, scope: &DrainScope<'_>) -> Result<RootState, Halt> {
         let record_bytes = self
             .snapshot_cache
             .get(scope.root_name.as_str().as_bytes())
             .await
             .map_err(seam)?
-            .ok_or_else(|| DrainHalt::Seam("no gate-passing root record to publish onto".into()))?;
+            .ok_or(Halt)?;
         let (_sequence, envelope) = assemble_head_envelope(
             self.gateway,
             self.http,
@@ -270,19 +248,15 @@ where
             None,
         )
         .await
-        .map_err(|e| DrainHalt::Seam(format!("root head assembly failed: {e}")))?;
+        .map_err(|_| Halt)?;
         // Encode/decode fail-closed symmetry: this build authors exactly
         // `ENVELOPE_V`, so republishing a newer client's root would silently
         // downgrade `v` — the exact rollback the read-body AAD defends against.
         if envelope.v != ENVELOPE_V {
-            return Err(DrainHalt::Seam(format!(
-                "root envelope v{} is not authorable by this build",
-                envelope.v
-            )));
+            return Err(Halt);
         }
         let read_key = self.node_read_key(scope, &scope.root.0);
-        let body = open_read_body(&envelope, &read_key)
-            .map_err(|e| DrainHalt::Seam(format!("root read body: {}", e.check())))?;
+        let body = open_read_body(&envelope, &read_key).map_err(|_| Halt)?;
         let ReadBody::Folder {
             created_at,
             children,
@@ -290,7 +264,7 @@ where
             ..
         } = body
         else {
-            return Err(DrainHalt::Seam("scope root is not a folder".into()));
+            return Err(Halt);
         };
         Ok(RootState {
             envelope_unknown: envelope.unknown,
@@ -310,7 +284,7 @@ where
         root: &mut RootState,
         applied: &crate::sync::rebase::AppliedOp,
         rebased: &Snapshot,
-    ) -> Result<(), DrainHalt> {
+    ) -> Result<(), Halt> {
         let OpKind::Create {
             parent,
             kind,
@@ -318,18 +292,15 @@ where
             ..
         } = &applied.op.kind
         else {
-            return Err(DrainHalt::Unsupported);
+            return Err(Halt);
         };
         // A deeper parent's own record is not authorable yet: the base snapshot
         // projects the root's direct children only, so there is no gate-passing
         // sub-folder body to re-author onto.
         if *parent != scope.root {
-            return Err(DrainHalt::Unsupported);
+            return Err(Halt);
         }
-        let name = applied
-            .effective_name
-            .clone()
-            .ok_or_else(|| DrainHalt::Seam("a create resolved to no name".into()))?;
+        let name = applied.effective_name.clone().ok_or(Halt)?;
 
         let child_id = applied.op.target;
         let child_name = derive_write_name(scope.write_scope_seed, &child_id.0);
@@ -352,7 +323,7 @@ where
             carried_unknown: Vec::new(),
             carried_epoch_tag_unknown: Vec::new(),
         })
-        .map_err(DrainHalt::Author)?;
+        .map_err(|_| Halt)?;
         let record_bytes = self
             .publish_head(scope, &child_name, &child_id.0, root.epoch, &head)
             .await?;
@@ -369,7 +340,7 @@ where
         adopter
             .adopt(&child_name, &record_bytes)
             .await
-            .map_err(|e| DrainHalt::Seam(format!("child self-adopt rejected: {e}")))?;
+            .map_err(|_| Halt)?;
         self.hold(scope, child_id.0, &child_name, &head, record_bytes);
 
         // Referent published: only now does the parent gain the ref to it.
@@ -385,7 +356,7 @@ where
         scope: &DrainScope<'_>,
         root: &mut RootState,
         modified_at: u64,
-    ) -> Result<(), DrainHalt> {
+    ) -> Result<(), Halt> {
         let read_key = self.node_read_key(scope, &scope.root.0);
         let body = ReadBody::Folder {
             created_at: root.created_at,
@@ -403,7 +374,7 @@ where
             carried_unknown: root.envelope_unknown.clone(),
             carried_epoch_tag_unknown: root.epoch_tag_unknown.clone(),
         })
-        .map_err(DrainHalt::Author)?;
+        .map_err(|_| Halt)?;
         let record_bytes = self
             .publish_head(scope, scope.root_name, &scope.root.0, root.epoch, &head)
             .await?;
@@ -420,7 +391,7 @@ where
         let AdoptOutcome { adopted, .. } = adopter
             .adopt(scope.root_name, &record_bytes)
             .await
-            .map_err(|e| DrainHalt::Seam(format!("root self-adopt rejected: {e}")))?;
+            .map_err(|_| Halt)?;
         // Cached implies gate-passing: these bytes just cleared all six stages.
         self.snapshot_cache
             .put(scope.root_name.as_str().as_bytes(), &record_bytes)
@@ -442,14 +413,14 @@ where
         node_id: &[u8; 16],
         epoch: u64,
         head: &AuthoredHead,
-    ) -> Result<Vec<u8>, DrainHalt> {
+    ) -> Result<Vec<u8>, Halt> {
         let binding = HeadBinding {
             node_id: *node_id,
             scope_id: scope.root.0,
             epoch,
         };
-        let preflighted = preflight(&binding, &self.node_read_key(scope, node_id), head)
-            .map_err(DrainHalt::Preflight)?;
+        let preflighted =
+            preflight(&binding, &self.node_read_key(scope, node_id), head).map_err(|_| Halt)?;
         let signer = SessionIdentity::write_name_signer(scope.write_scope_seed, node_id);
         let PublishReceipt {
             outcome,
@@ -469,18 +440,11 @@ where
             },
         )
         .await
-        .map_err(|e| DrainHalt::Publish(format!("{e:?}")))?;
+        .map_err(|_| Halt)?;
         match outcome {
             PublishOutcome::Published { .. } => Ok(record_bytes),
-            PublishOutcome::Unconfirmed { sequence } => Err(DrainHalt::Publish(format!(
-                "sequence {sequence} published but nothing resolved back"
-            ))),
-            PublishOutcome::LostRace {
-                published_sequence,
-                observed_sequence,
-            } => Err(DrainHalt::Publish(format!(
-                "lost CAS race: published {published_sequence}, observed {observed_sequence}"
-            ))),
+            PublishOutcome::Unconfirmed { .. } => Err(Halt),
+            PublishOutcome::LostRace { .. } => Err(Halt),
         }
     }
 
@@ -508,7 +472,7 @@ where
     }
 
     /// Remove a resolved op from the durable queue.
-    async fn retire_op(&self, op_id: OpId) -> Result<(), DrainHalt> {
+    async fn retire_op(&self, op_id: OpId) -> Result<(), Halt> {
         self.staging.remove_op(op_id).await.map_err(seam)
     }
 
@@ -516,11 +480,7 @@ where
     /// The mark is a high-water line, so it may only pass ops that have all
     /// left the queue: advancing it over a halted op would make a restored data
     /// dir discard that op as residue instead of publishing it (#860).
-    async fn mark_drained(
-        &self,
-        queued: &[(OpId, Op)],
-        report: &DrainReport,
-    ) -> Result<(), DrainHalt> {
+    async fn mark_drained(&self, queued: &[(OpId, Op)], report: &DrainReport) -> Result<(), Halt> {
         let retired: BTreeSet<OpId> = report
             .published
             .iter()
@@ -551,12 +511,12 @@ where
 
     /// A fresh injected seal nonce. Fails closed: a reused nonce under one key
     /// is a confidentiality break, never a degraded mode.
-    fn nonce(&self) -> Result<[u8; 24], DrainHalt> {
+    fn nonce(&self) -> Result<[u8; 24], Halt> {
         let mut nonce = [0u8; 24];
         self.entropy
             .borrow_mut()
             .fill(&mut nonce)
-            .map_err(|e| DrainHalt::Seam(e.message().to_owned()))?;
+            .map_err(|_| Halt)?;
         Ok(nonce)
     }
 }
@@ -576,6 +536,6 @@ fn local_head(head: &AuthoredHead) -> LocalHead {
     }
 }
 
-fn seam(err: crate::seams::SeamError) -> DrainHalt {
-    DrainHalt::Seam(err.message().to_owned())
+fn seam(_: crate::seams::SeamError) -> Halt {
+    Halt
 }

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -364,16 +364,19 @@ where
             children: root.children.clone(),
             unknown: root.body_unknown.clone(),
         };
-        let head = author_scope_root_envelope(EnvelopeAuthoring {
-            node_id: scope.root.0,
-            scope_id: scope.root.0,
-            epoch: root.epoch,
-            read_key: &read_key,
-            nonce: &self.nonce()?,
-            body: &body,
-            carried_unknown: root.envelope_unknown.clone(),
-            carried_epoch_tag_unknown: root.epoch_tag_unknown.clone(),
-        })
+        let head = author_scope_root_envelope(
+            EnvelopeAuthoring {
+                node_id: scope.root.0,
+                scope_id: scope.root.0,
+                epoch: root.epoch,
+                read_key: &read_key,
+                nonce: &self.nonce()?,
+                body: &body,
+                carried_unknown: root.envelope_unknown.clone(),
+                carried_epoch_tag_unknown: root.epoch_tag_unknown.clone(),
+            },
+            scope.root_name,
+        )
         .map_err(|_| Halt)?;
         let record_bytes = self
             .publish_head(scope, scope.root_name, &scope.root.0, root.epoch, &head)
@@ -421,7 +424,14 @@ where
         };
         let preflighted =
             preflight(&binding, &self.node_read_key(scope, node_id), head).map_err(|_| Halt)?;
+        // The name and the seed the signer comes from have independent sources
+        // for the scope root — the vault pointer's `currentRoot` and the
+        // owner-write-blob. Publishing under a name this signer cannot sign for
+        // would burn a CAS sequence on a record nothing can verify.
         let signer = SessionIdentity::write_name_signer(scope.write_scope_seed, node_id);
+        if IpnsName::from_public_key(&signer.verifying_key()) != *name {
+            return Err(Halt);
+        }
         let PublishReceipt {
             outcome,
             record_bytes,

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -532,8 +532,8 @@ where
             .map_err(seam)
     }
 
-    /// The stored drained-op mark; `0` when nothing has drained on this device
-    /// (op ids start at 1) or the stored bytes are not a mark this build wrote.
+    /// The stored drained-op mark; `None` when nothing has drained on this
+    /// device or the stored bytes are not a mark this build wrote.
     async fn drained_mark(&self) -> Result<Option<u64>, Halt> {
         let stored = self
             .staging

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -1,0 +1,527 @@
+//! The metadata publish driver: turn queued intent ops into published,
+//! resolvable records (blueprint/engine.md "Sync core", "Resolve/publish
+//! pipeline").
+//!
+//! One pass rebases the durable queue onto gate-passing state
+//! ([`replay`]) and publishes each applied op **referent before reference** —
+//! the child's own record first, then the parent that names it — so a partial
+//! drain can leave an unreferenced record but never a child ref pointing at a
+//! name nothing resolves.
+//!
+//! Every published record is fed straight back through the adoption gate from
+//! the bytes in hand: the write path skips the fetch, never the gate, and the
+//! per-name sequence floor advances only as the gate's stage-6 consequence
+//! (#817; `gate/floor.rs` stays the only place floors move).
+//!
+//! This slice drains folder creates only; the first op it cannot publish stops
+//! the pass with the op still queued, so FIFO order is never broken.
+
+use core::cell::RefCell;
+
+use cipherbox_core::ipns::IpnsName;
+use cipherbox_core::kdf;
+use cipherbox_core::seal::{ChildRef, NodeKind as CoreNodeKind, ReadBody, open_read_body};
+use cipherbox_core::suite::ecdsa::EcdsaVerifier;
+use cipherbox_core::suite::x25519::X25519Secret;
+use zeroize::Zeroizing;
+
+use crate::api::ApiClient;
+use crate::content::Gateway;
+use crate::entropy::Entropy;
+use crate::facade::{NodeId, NodeKind};
+use crate::net::author::{
+    AuthorError, AuthoredHead, ENVELOPE_V, EnvelopeAuthoring, author_child_envelope,
+    author_scope_root_envelope, new_child,
+};
+use crate::net::record_publish::{
+    HeadBinding, PreflightError, RecordPublishOutcome, RecordPublishRequest, preflight,
+    publish_record,
+};
+use crate::net::{
+    Adopter, AdoptOutcome, ChildAdopter, HeldRecord, HeldRecords, LocalHead, RootAdopter,
+    assemble_head_envelope,
+};
+use crate::profile::SyncTimingProfile;
+use crate::rotation::derive_write_name;
+use crate::seams::{
+    CredentialStore, FloorStore, Http, OpId, RecordTransport, Scheduler, SnapshotCache, StagingStore,
+};
+use crate::session::SessionIdentity;
+use crate::sync::model::Snapshot;
+use crate::sync::op::{Op, OpKind};
+use crate::sync::overlay::apply_overlay;
+use crate::sync::project::project_root;
+use crate::sync::rebase::{DeadLetterReason, decode_queue, replay};
+use crate::sync::record::RecordReader;
+
+/// The durable drained-op high-water mark's floor key: every op id at or below
+/// the stored value has left this device's queue (published, dropped, or
+/// dead-lettered).
+///
+/// It rides the sequence-floor namespace because it is exactly that namespace's
+/// contract — a durable monotonic-max `u64` under engine-chosen opaque key
+/// bytes. The `/` makes it unrepresentable as an `ipnsName` (base36 alphanumeric
+/// only), so it can never collide with a real per-name floor.
+const DRAINED_OP_FLOOR_KEY: &[u8] = b"cipherbox/drained-op";
+
+/// What one drain pass did.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct DrainReport {
+    /// Ops whose records published and self-adopted.
+    pub(crate) published: Vec<OpId>,
+    /// Ops rebase resolved away (already satisfied, or a lost race).
+    pub(crate) dropped: Vec<OpId>,
+    /// Terminally unrebasable ops, with the reason to surface.
+    pub(crate) dead_letters: Vec<(OpId, NodeId, DeadLetterReason)>,
+    /// Ops removed as restore residue: already drained on this device, so the
+    /// queue that holds them is older than the completion record (#860).
+    pub(crate) restore_residue: Vec<OpId>,
+    /// Why the pass stopped early, if it did. FIFO is strict: the op stays
+    /// queued and the next pass retries it.
+    pub(crate) halted: Option<DrainHalt>,
+}
+
+/// Why a drain pass stopped before the queue was empty.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DrainHalt {
+    /// The op kind has no publisher in this slice.
+    Unsupported,
+    /// Authoring refused to produce the record.
+    Author(AuthorError),
+    /// The pre-publish dry run refused the authored envelope.
+    Preflight(PreflightError),
+    /// The publish itself failed, or landed unconfirmed/lost the CAS race.
+    Publish(String),
+    /// A durable seam or a gate rejection stopped the pass.
+    Seam(String),
+}
+
+/// The owner-scope material one drain pass publishes under. Every field is
+/// borrowed from the live session; the drain zeroizes none of it.
+pub(crate) struct DrainScope<'a> {
+    /// The vault root node — also the root scope id (the cold-start anchor).
+    pub(crate) root: NodeId,
+    /// The root's write-plane IPNS name.
+    pub(crate) root_name: &'a IpnsName,
+    /// The scope read seed per-node read keys derive from.
+    pub(crate) scope_read_seed: &'a Zeroizing<[u8; 32]>,
+    /// The scope write seed per-node IPNS names and signers derive from.
+    pub(crate) write_scope_seed: &'a Zeroizing<[u8; 32]>,
+    /// The owner's encryption secret (the root's own seed source, and the op
+    /// queue's HPKE-to-self reader).
+    pub(crate) enc_secret: &'a X25519Secret,
+    /// The contact-anchored owner identity the gate verifies against.
+    pub(crate) owner_identity: &'a EcdsaVerifier,
+}
+
+/// One drain pass over the durable queue, holding every seam it needs by
+/// reference.
+pub(crate) struct Drain<'a, T, H: Http, C: CredentialStore, F, S, St, Sch> {
+    pub(crate) transport: &'a T,
+    pub(crate) api: &'a ApiClient<H, C>,
+    pub(crate) floors: &'a F,
+    pub(crate) snapshot_cache: &'a S,
+    pub(crate) staging: &'a St,
+    pub(crate) scheduler: &'a Sch,
+    pub(crate) http: &'a H,
+    pub(crate) gateway: &'a Gateway,
+    pub(crate) profile: &'a SyncTimingProfile,
+    /// Seal nonces enter as injected entropy; the drain reads no RNG of its own.
+    pub(crate) entropy: &'a RefCell<Box<dyn Entropy>>,
+    /// The gate-passing base snapshot, repainted in place on each publish.
+    pub(crate) base: &'a RefCell<Snapshot>,
+    /// The live held-record set the liveness loop keeps alive.
+    pub(crate) held: &'a RefCell<HeldRecords>,
+}
+
+/// The scope root's current published state, carried across the ops of one
+/// pass so each publish authors onto the previous one.
+struct RootState {
+    envelope_unknown: Vec<(String, cipherbox_core::codec::Value)>,
+    epoch_tag_unknown: Vec<(String, cipherbox_core::codec::Value)>,
+    epoch: u64,
+    created_at: u64,
+    children: Vec<ChildRef>,
+    body_unknown: Vec<(String, cipherbox_core::codec::Value)>,
+}
+
+impl<T, H, C, F, S, St, Sch> Drain<'_, T, H, C, F, S, St, Sch>
+where
+    T: RecordTransport + Clone + 'static,
+    H: Http,
+    C: CredentialStore,
+    F: FloorStore,
+    S: SnapshotCache,
+    St: StagingStore,
+    Sch: Scheduler + Clone + 'static,
+{
+    /// Run one pass: rebase the queue onto gate-passing state and publish every
+    /// applied op it can, stopping at the first it cannot.
+    pub(crate) async fn run(&self, scope: &DrainScope<'_>) -> DrainReport {
+        let mut report = DrainReport::default();
+        match self.pass(scope, &mut report).await {
+            Ok(()) => {}
+            Err(halt) => report.halted = Some(halt),
+        }
+        report
+    }
+
+    async fn pass(
+        &self,
+        scope: &DrainScope<'_>,
+        report: &mut DrainReport,
+    ) -> Result<(), DrainHalt> {
+        let queued = self.queued_ops(scope, report).await?;
+        if queued.is_empty() {
+            return Ok(());
+        }
+
+        let mut root = self.load_root(scope).await?;
+        let rebased = {
+            let base = self.base.borrow();
+            let ops: Vec<Op> = queued.iter().map(|(_, op)| op.clone()).collect();
+            let local = apply_overlay(&base, &ops);
+            replay(&base, &local, &queued)
+        };
+
+        for (op_id, reason) in &rebased.dead_letters {
+            let target = queued
+                .iter()
+                .find(|(id, _)| id == op_id)
+                .map(|(_, op)| op.target)
+                .unwrap_or(scope.root);
+            self.retire_op(*op_id).await?;
+            report.dead_letters.push((*op_id, target, *reason));
+        }
+        for (op_id, _) in &rebased.dropped {
+            self.retire_op(*op_id).await?;
+            report.dropped.push(*op_id);
+        }
+
+        for applied in &rebased.applied {
+            self.publish_applied(scope, &mut root, applied, &rebased.rebased)
+                .await?;
+            self.retire_op(applied.op_id).await?;
+            report.published.push(applied.op_id);
+        }
+        Ok(())
+    }
+
+    /// This identity's queued ops, minus restore residue: an op at or below the
+    /// durable drained-op mark already left this queue once, so the queue it
+    /// came back in predates the completion record (#860).
+    async fn queued_ops(
+        &self,
+        scope: &DrainScope<'_>,
+        report: &mut DrainReport,
+    ) -> Result<Vec<(OpId, Op)>, DrainHalt> {
+        let raw = self.staging.queued_ops().await.map_err(seam)?;
+        let scan = decode_queue(&RecordReader::new(scope.enc_secret), &raw);
+        let drained = self
+            .floors
+            .sequence_floor(DRAINED_OP_FLOOR_KEY)
+            .await
+            .map_err(seam)?
+            .unwrap_or(0);
+        let mut live = Vec::with_capacity(scan.mine.len());
+        for (op_id, op) in scan.mine {
+            if op_id.0 <= drained {
+                self.staging.remove_op(op_id).await.map_err(seam)?;
+                report.restore_residue.push(op_id);
+                continue;
+            }
+            live.push((op_id, op));
+        }
+        Ok(live)
+    }
+
+    /// The scope root as currently published: its envelope's carried fields and
+    /// its unsealed folder body.
+    async fn load_root(&self, scope: &DrainScope<'_>) -> Result<RootState, DrainHalt> {
+        let record_bytes = self
+            .snapshot_cache
+            .get(scope.root_name.as_str().as_bytes())
+            .await
+            .map_err(seam)?
+            .ok_or_else(|| DrainHalt::Seam("no gate-passing root record to publish onto".into()))?;
+        let (_sequence, envelope) = assemble_head_envelope(
+            self.gateway,
+            self.http,
+            scope.root_name,
+            &record_bytes,
+            None,
+        )
+        .await
+        .map_err(|e| DrainHalt::Seam(format!("root head assembly failed: {e}")))?;
+        // Encode/decode fail-closed symmetry: this build authors exactly
+        // `ENVELOPE_V`, so republishing a newer client's root would silently
+        // downgrade `v` — the exact rollback the read-body AAD defends against.
+        if envelope.v != ENVELOPE_V {
+            return Err(DrainHalt::Seam(format!(
+                "root envelope v{} is not authorable by this build",
+                envelope.v
+            )));
+        }
+        let read_key = self.node_read_key(scope, &scope.root.0);
+        let body = open_read_body(&envelope, &read_key)
+            .map_err(|e| DrainHalt::Seam(format!("root read body: {}", e.check())))?;
+        let ReadBody::Folder {
+            created_at,
+            children,
+            unknown,
+            ..
+        } = body
+        else {
+            return Err(DrainHalt::Seam("scope root is not a folder".into()));
+        };
+        Ok(RootState {
+            envelope_unknown: envelope.unknown,
+            epoch_tag_unknown: envelope.epoch_tag_unknown,
+            epoch: envelope.epoch,
+            created_at,
+            children,
+            body_unknown: unknown,
+        })
+    }
+
+    /// Publish one applied op: the new node's own record, then the parent that
+    /// names it.
+    async fn publish_applied(
+        &self,
+        scope: &DrainScope<'_>,
+        root: &mut RootState,
+        applied: &crate::sync::rebase::AppliedOp,
+        rebased: &Snapshot,
+    ) -> Result<(), DrainHalt> {
+        let OpKind::Create {
+            parent,
+            kind: NodeKind::Folder,
+            content: None,
+            ..
+        } = &applied.op.kind
+        else {
+            return Err(DrainHalt::Unsupported);
+        };
+        // Deeper folders need their own parent record authored, which is the
+        // next slice; this one publishes creates directly under the scope root.
+        if *parent != scope.root {
+            return Err(DrainHalt::Unsupported);
+        }
+        let name = applied
+            .effective_name
+            .clone()
+            .ok_or_else(|| DrainHalt::Seam("a create resolved to no name".into()))?;
+
+        let child_id = applied.op.target;
+        let child_name = derive_write_name(scope.write_scope_seed, &child_id.0);
+        let child = new_child(
+            child_id.0,
+            name,
+            &child_name,
+            CoreNodeKind::Folder,
+            rebased.max_link_counter(child_id),
+            applied.op.authored_at.0,
+        );
+
+        let head = author_child_envelope(EnvelopeAuthoring {
+            node_id: child_id.0,
+            scope_id: scope.root.0,
+            epoch: root.epoch,
+            read_key: &self.node_read_key(scope, &child_id.0),
+            nonce: &self.nonce()?,
+            body: &child.body,
+            carried_unknown: Vec::new(),
+            carried_epoch_tag_unknown: Vec::new(),
+        })
+        .map_err(DrainHalt::Author)?;
+        let record_bytes = self
+            .publish_head(scope, &child_name, &child_id.0, root.epoch, &head)
+            .await?;
+
+        let adopter = ChildAdopter::new(
+            self.gateway,
+            self.http,
+            self.floors,
+            scope.root.0,
+            scope.scope_read_seed.clone(),
+            child_id.0,
+        );
+        adopter.hold_local_head(local_head(&head));
+        adopter
+            .adopt(&child_name, &record_bytes)
+            .await
+            .map_err(|e| DrainHalt::Seam(format!("child self-adopt rejected: {e}")))?;
+        self.hold(scope, child_id.0, &child_name, &head, record_bytes);
+
+        // Referent published: only now does the parent gain the ref to it.
+        root.children.push(child.child_ref);
+        self.publish_root(scope, root, applied.op.authored_at.0)
+            .await
+    }
+
+    /// Re-author and publish the scope root over its current children, then
+    /// self-adopt it into the base snapshot.
+    async fn publish_root(
+        &self,
+        scope: &DrainScope<'_>,
+        root: &mut RootState,
+        modified_at: u64,
+    ) -> Result<(), DrainHalt> {
+        let read_key = self.node_read_key(scope, &scope.root.0);
+        let body = ReadBody::Folder {
+            created_at: root.created_at,
+            modified_at,
+            children: root.children.clone(),
+            unknown: root.body_unknown.clone(),
+        };
+        let head = author_scope_root_envelope(EnvelopeAuthoring {
+            node_id: scope.root.0,
+            scope_id: scope.root.0,
+            epoch: root.epoch,
+            read_key: &read_key,
+            nonce: &self.nonce()?,
+            body: &body,
+            carried_unknown: root.envelope_unknown.clone(),
+            carried_epoch_tag_unknown: root.epoch_tag_unknown.clone(),
+        })
+        .map_err(DrainHalt::Author)?;
+        let record_bytes = self
+            .publish_head(scope, scope.root_name, &scope.root.0, root.epoch, &head)
+            .await?;
+
+        let adopter = RootAdopter::new(
+            self.gateway,
+            self.http,
+            self.floors,
+            scope.enc_secret,
+            scope.owner_identity,
+            scope.root.0,
+        );
+        adopter.hold_local_head(local_head(&head));
+        let AdoptOutcome { adopted, .. } = adopter
+            .adopt(scope.root_name, &record_bytes)
+            .await
+            .map_err(|e| DrainHalt::Seam(format!("root self-adopt rejected: {e}")))?;
+        // Cached implies gate-passing: these bytes just cleared all six stages.
+        self.snapshot_cache
+            .put(scope.root_name.as_str().as_bytes(), &record_bytes)
+            .await
+            .map_err(seam)?;
+        let projected = project_root(scope.root, &adopted, &self.base.borrow());
+        *self.base.borrow_mut() = projected;
+        self.hold(scope, scope.root.0, scope.root_name, &head, record_bytes);
+        Ok(())
+    }
+
+    /// Dry-run, publish, and return the signed bytes. Only a confirmed publish
+    /// yields bytes to self-adopt: adopting an unconfirmed one would advance the
+    /// sequence floor and destroy the idempotent-in-sequence retry (#821).
+    async fn publish_head(
+        &self,
+        scope: &DrainScope<'_>,
+        name: &IpnsName,
+        node_id: &[u8; 16],
+        epoch: u64,
+        head: &AuthoredHead,
+    ) -> Result<Vec<u8>, DrainHalt> {
+        let binding = HeadBinding {
+            node_id: *node_id,
+            scope_id: scope.root.0,
+            epoch,
+        };
+        let preflighted = preflight(&binding, &self.node_read_key(scope, node_id), head)
+            .map_err(DrainHalt::Preflight)?;
+        let signer = SessionIdentity::write_name_signer(scope.write_scope_seed, node_id);
+        let outcome = publish_record(
+            self.transport,
+            self.api,
+            self.floors,
+            self.scheduler,
+            self.profile,
+            &RecordPublishRequest {
+                name,
+                signer: &signer,
+                head: &preflighted,
+                content_cids: Vec::new(),
+                min_current_sequence: None,
+            },
+        )
+        .await
+        .map_err(|e| DrainHalt::Publish(format!("{e:?}")))?;
+        match outcome {
+            RecordPublishOutcome::Published { record_bytes, .. } => Ok(record_bytes),
+            RecordPublishOutcome::Unconfirmed { sequence, .. } => Err(DrainHalt::Publish(format!(
+                "sequence {sequence} published but nothing resolved back"
+            ))),
+            RecordPublishOutcome::LostRace {
+                published_sequence,
+                observed_sequence,
+            } => Err(DrainHalt::Publish(format!(
+                "lost CAS race: published {published_sequence}, observed {observed_sequence}"
+            ))),
+        }
+    }
+
+    /// Insert a just-published record into the live held set so the liveness
+    /// loop keeps it alive; the narrow per-name signer is derived here and the
+    /// scope seed is not stored (least privilege, `net/liveness.rs`).
+    fn hold(
+        &self,
+        scope: &DrainScope<'_>,
+        node_id: [u8; 16],
+        name: &IpnsName,
+        head: &AuthoredHead,
+        record_bytes: Vec<u8>,
+    ) {
+        self.held.borrow_mut().insert(
+            node_id,
+            HeldRecord {
+                routing_key: name.as_str().to_owned(),
+                record_bytes,
+                signer: SessionIdentity::write_name_signer(scope.write_scope_seed, &node_id),
+                head_cid: head.cid.clone(),
+                content_cids: Vec::new(),
+            },
+        );
+    }
+
+    /// Remove a resolved op from the durable queue and raise the completion
+    /// mark past it, so a restored queue cannot replay it (#860).
+    async fn retire_op(&self, op_id: OpId) -> Result<(), DrainHalt> {
+        self.staging.remove_op(op_id).await.map_err(seam)?;
+        self.floors
+            .raise_sequence_floor(DRAINED_OP_FLOOR_KEY, op_id.0)
+            .await
+            .map_err(seam)?;
+        Ok(())
+    }
+
+    /// The per-node read key (`node-seed` → `read-key`), owned by the caller of
+    /// this fn — it is the terminal owner and zeroizes on drop.
+    fn node_read_key(&self, scope: &DrainScope<'_>, node_id: &[u8; 16]) -> Zeroizing<[u8; 32]> {
+        let node_seed = kdf::node_seed(scope.scope_read_seed, node_id);
+        Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes())
+    }
+
+    /// A fresh injected seal nonce. Fails closed: a reused nonce under one key
+    /// is a confidentiality break, never a degraded mode.
+    fn nonce(&self) -> Result<[u8; 24], DrainHalt> {
+        let mut nonce = [0u8; 24];
+        self.entropy
+            .borrow_mut()
+            .fill(&mut nonce)
+            .map_err(|e| DrainHalt::Seam(e.message().to_owned()))?;
+        Ok(nonce)
+    }
+}
+
+fn local_head(head: &AuthoredHead) -> LocalHead {
+    LocalHead {
+        cid: head.cid.clone(),
+        block: head.block.clone(),
+    }
+}
+
+fn seam(err: crate::seams::SeamError) -> DrainHalt {
+    DrainHalt::Seam(err.message().to_owned())
+}

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -54,12 +54,17 @@ use crate::sync::project::project_root;
 use crate::sync::rebase::{DeadLetterReason, decode_queue, replay};
 use crate::sync::record::RecordReader;
 
-/// The durable drained-op high-water mark: every op id at or below the stored
-/// value has left this device's queue (#860). It rides the sequence-floor
-/// namespace, whose contract it is — a durable monotonic-max `u64` under opaque
-/// key bytes — under a key the base36 `ipnsName` alphabet cannot spell, so it
-/// never collides with a real per-name floor.
-pub const DRAINED_OP_FLOOR_KEY: &[u8] = b"cipherbox/drained-op";
+/// The staging key holding the drained-op high-water mark: every op id at or
+/// below the stored value has left this device's queue (#860).
+///
+/// It lives in the staging store rather than the floors so the mark and the op
+/// ids it names share one durability domain — a store that loses its queue
+/// loses the mark with it, instead of retaining a mark that would delete every
+/// id the restarted counter reissues. [`orphan_staging_keys`] treats it as
+/// referenced so orphan GC never collects it.
+///
+/// [`orphan_staging_keys`]: crate::sync::staging::orphan_staging_keys
+pub const DRAINED_OP_MARK_KEY: &[u8] = b"cipherbox/drained-op";
 
 /// What one drain pass did.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -99,7 +104,7 @@ pub(crate) struct DrainScope<'a> {
     /// The root's write-plane IPNS name.
     pub(crate) root_name: &'a IpnsName,
     /// The scope read seed per-node read keys derive from.
-    pub(crate) scope_read_seed: &'a Zeroizing<[u8; 32]>,
+    pub(crate) read_scope_seed: &'a Zeroizing<[u8; 32]>,
     /// The scope write seed per-node IPNS names and signers derive from.
     pub(crate) write_scope_seed: &'a Zeroizing<[u8; 32]>,
     /// The owner's encryption secret (the root's own seed source, and the op
@@ -213,15 +218,13 @@ where
     ) -> Result<Vec<(OpId, Op)>, Halt> {
         let raw = self.staging.queued_ops().await.map_err(seam)?;
         let scan = decode_queue(&RecordReader::new(scope.enc_secret), &raw);
-        let drained = self
-            .floors
-            .sequence_floor(DRAINED_OP_FLOOR_KEY)
-            .await
-            .map_err(seam)?
-            .unwrap_or(0);
+        // `None` is "no op has ever drained here", not "id 0 drained": the seam
+        // contract promises only strictly-increasing ids, so a host that starts
+        // at 0 must not lose its first op.
+        let drained = self.drained_mark().await?;
         let mut live = Vec::with_capacity(scan.mine.len());
         for (op_id, op) in scan.mine {
-            if op_id.0 <= drained {
+            if drained.is_some_and(|mark| op_id.0 <= mark) {
                 self.staging.remove_op(op_id).await.map_err(seam)?;
                 report.restore_residue.push(op_id);
                 continue;
@@ -240,7 +243,7 @@ where
             .await
             .map_err(seam)?
             .ok_or(Halt)?;
-        let (_sequence, envelope) = assemble_head_envelope(
+        let (sequence, envelope) = assemble_head_envelope(
             self.gateway,
             self.http,
             scope.root_name,
@@ -249,6 +252,18 @@ where
         )
         .await
         .map_err(|_| Halt)?;
+        // The cache can be older than the floors — a restored data dir is
+        // exactly that (#860). Re-authoring over a below-floor root would erase
+        // every child added since, durably and at a sequence the gate accepts.
+        let floor = self
+            .floors
+            .sequence_floor(scope.root_name.as_str().as_bytes())
+            .await
+            .map_err(seam)?
+            .unwrap_or(0);
+        if sequence < floor {
+            return Err(Halt);
+        }
         // Encode/decode fail-closed symmetry: this build authors exactly
         // `ENVELOPE_V`, so republishing a newer client's root would silently
         // downgrade `v` — the exact rollback the read-body AAD defends against.
@@ -333,7 +348,7 @@ where
             self.http,
             self.floors,
             scope.root.0,
-            scope.scope_read_seed.clone(),
+            scope.read_scope_seed.clone(),
             child_id.0,
         );
         adopter.hold_local_head(local_head(&head));
@@ -341,12 +356,15 @@ where
             .adopt(&child_name, &record_bytes)
             .await
             .map_err(|_| Halt)?;
-        self.hold(scope, child_id.0, &child_name, &head, record_bytes);
 
         // Referent published: only now does the parent gain the ref to it.
         root.children.push(child.child_ref);
         self.publish_root(scope, root, applied.op.authored_at.0)
-            .await
+            .await?;
+        // Held only once the parent names it: a record nothing references is
+        // not one the liveness loop should keep alive.
+        self.hold(scope, child_id.0, &child_name, &head, record_bytes);
+        Ok(())
     }
 
     /// Re-author and publish the scope root over its current children, then
@@ -505,17 +523,32 @@ where
         else {
             return Ok(());
         };
-        self.floors
-            .raise_sequence_floor(DRAINED_OP_FLOOR_KEY, mark)
+        // Monotonic by construction: the engine is the single writer, and the
+        // mark only ever names ops that have already left the queue.
+        let raised = mark.max(self.drained_mark().await?.unwrap_or(0));
+        self.staging
+            .put_staged_bytes(DRAINED_OP_MARK_KEY, &raised.to_be_bytes())
+            .await
+            .map_err(seam)
+    }
+
+    /// The stored drained-op mark; `0` when nothing has drained on this device
+    /// (op ids start at 1) or the stored bytes are not a mark this build wrote.
+    async fn drained_mark(&self) -> Result<Option<u64>, Halt> {
+        let stored = self
+            .staging
+            .staged_bytes(DRAINED_OP_MARK_KEY)
             .await
             .map_err(seam)?;
-        Ok(())
+        Ok(stored
+            .and_then(|bytes| <[u8; 8]>::try_from(bytes.as_slice()).ok())
+            .map(u64::from_be_bytes))
     }
 
     /// The per-node read key (`node-seed` → `read-key`), owned by the caller of
     /// this fn — it is the terminal owner and zeroizes on drop.
     fn node_read_key(&self, scope: &DrainScope<'_>, node_id: &[u8; 16]) -> Zeroizing<[u8; 32]> {
-        let node_seed = kdf::node_seed(scope.scope_read_seed, node_id);
+        let node_seed = kdf::node_seed(scope.read_scope_seed, node_id);
         Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes())
     }
 

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -46,6 +46,7 @@ pub mod staleness;
 pub mod tick;
 
 pub use boot::{ColdStartError, ColdStartOutcome, ColdStartParams, RootResolve, cold_start};
+pub use drain::DRAINED_OP_FLOOR_KEY;
 pub use model::{Link, NodeMeta, Snapshot, collation_key, suffix_name};
 pub use op::{Op, OpDecodeError, OpKind, StagedContent};
 pub use overlay::apply_overlay;

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -33,6 +33,7 @@
 //! primitives themselves land with the rotation slice.
 
 pub mod boot;
+pub(crate) mod drain;
 pub mod model;
 pub mod op;
 pub mod overlay;

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -46,7 +46,7 @@ pub mod staleness;
 pub mod tick;
 
 pub use boot::{ColdStartError, ColdStartOutcome, ColdStartParams, RootResolve, cold_start};
-pub use drain::DRAINED_OP_FLOOR_KEY;
+pub use drain::DRAINED_OP_MARK_KEY;
 pub use model::{Link, NodeMeta, Snapshot, collation_key, suffix_name};
 pub use op::{Op, OpDecodeError, OpKind, StagedContent};
 pub use overlay::apply_overlay;

--- a/crates/engine/src/sync/staging.rs
+++ b/crates/engine/src/sync/staging.rs
@@ -380,6 +380,21 @@ mod tests {
         });
     }
 
+    /// Collecting the drain's completion mark would let a restored queue replay
+    /// ops that already published (#860), so it is never orphan residue.
+    #[test]
+    fn the_drained_op_mark_is_never_classed_an_orphan() {
+        let store = InMemoryStagingStore::default();
+        block_on(async {
+            store
+                .put_staged_bytes(DRAINED_OP_MARK_KEY, &7u64.to_be_bytes())
+                .await
+                .unwrap();
+
+            assert!(orphan_staging_keys(&store).await.unwrap().is_empty());
+        });
+    }
+
     #[test]
     fn orphan_keys_are_the_unreferenced_staged_bytes() {
         let store = InMemoryStagingStore::default();

--- a/crates/engine/src/sync/staging.rs
+++ b/crates/engine/src/sync/staging.rs
@@ -12,6 +12,7 @@ use cipherbox_core::content::verify_cid;
 
 use crate::seams::{OpId, SeamError, SeamResult, StagingStore};
 use crate::storage_policy::{Headroom, StoragePolicy};
+use crate::sync::drain::DRAINED_OP_MARK_KEY;
 use crate::sync::op::Op;
 use crate::sync::record::{RecordSeal, encode_op_record, record_content_root_cid};
 
@@ -118,7 +119,9 @@ pub async fn stage_op<S: StagingStore>(
 /// account's staged bytes are counted as referenced rather than collected.
 pub async fn orphan_staging_keys<S: StagingStore>(store: &S) -> SeamResult<Vec<Vec<u8>>> {
     let queued = store.queued_ops().await?;
-    let mut referenced = std::collections::HashSet::new();
+    // The drain's completion mark is queue bookkeeping under a staging key, not
+    // upload residue.
+    let mut referenced = std::collections::HashSet::from([DRAINED_OP_MARK_KEY.to_vec()]);
     for (_, record) in &queued {
         match record_content_root_cid(record) {
             Ok(Some(cid)) => {

--- a/crates/engine/src/testkit/fakes/http.rs
+++ b/crates/engine/src/testkit/fakes/http.rs
@@ -5,9 +5,18 @@ use std::sync::{Arc, Mutex};
 
 use crate::seams::{Http, HttpRequest, HttpResponse, SeamError, SeamResult};
 
+/// A reply computed from the request it answers.
+type DerivedReply = Box<dyn FnOnce(&HttpRequest) -> SeamResult<HttpResponse> + Send>;
+
+/// A queued reply: either fixed bytes or a reply derived from the request.
+enum Reply {
+    Fixed(SeamResult<HttpResponse>),
+    Derived(DerivedReply),
+}
+
 #[derive(Default)]
 struct Inner {
-    responses: VecDeque<SeamResult<HttpResponse>>,
+    responses: VecDeque<Reply>,
     requests: Vec<HttpRequest>,
 }
 
@@ -23,20 +32,26 @@ pub struct ScriptedHttp {
 impl ScriptedHttp {
     /// Queues a successful response.
     pub fn enqueue_response(&self, response: HttpResponse) {
-        self.inner
-            .lock()
-            .expect("lock")
-            .responses
-            .push_back(Ok(response));
+        self.enqueue(Reply::Fixed(Ok(response)));
     }
 
     /// Queues a transport-level failure.
     pub fn enqueue_error(&self, error: SeamError) {
-        self.inner
-            .lock()
-            .expect("lock")
-            .responses
-            .push_back(Err(error));
+        self.enqueue(Reply::Fixed(Err(error)));
+    }
+
+    /// Queues a reply computed from the request — for an endpoint whose answer
+    /// is a function of what was sent (a content upload echoing the CID of the
+    /// bytes it received, say).
+    pub fn enqueue_derived(
+        &self,
+        reply: impl FnOnce(&HttpRequest) -> SeamResult<HttpResponse> + Send + 'static,
+    ) {
+        self.enqueue(Reply::Derived(Box::new(reply)));
+    }
+
+    fn enqueue(&self, reply: Reply) {
+        self.inner.lock().expect("lock").responses.push_back(reply);
     }
 
     /// Every request sent so far, in order.
@@ -48,11 +63,14 @@ impl ScriptedHttp {
 impl Http for ScriptedHttp {
     async fn send(&self, request: HttpRequest) -> SeamResult<HttpResponse> {
         let mut inner = self.inner.lock().expect("lock");
+        let reply = inner.responses.pop_front();
         inner.requests.push(request);
-        inner
-            .responses
-            .pop_front()
-            .unwrap_or_else(|| Err(SeamError::new("ScriptedHttp: no scripted response left")))
+        let request = inner.requests.last().expect("just pushed");
+        match reply {
+            Some(Reply::Fixed(response)) => response,
+            Some(Reply::Derived(reply)) => reply(request),
+            None => Err(SeamError::new("ScriptedHttp: no scripted response left")),
+        }
     }
 }
 

--- a/crates/engine/tests/net.rs
+++ b/crates/engine/tests/net.rs
@@ -375,7 +375,7 @@ fn publish_registers_first_embeds_sequence_one_and_confirms() {
     ))
     .expect("publish");
 
-    assert_eq!(outcome, PublishOutcome::Published { sequence: 1 });
+    assert_eq!(outcome.outcome, PublishOutcome::Published { sequence: 1 });
     assert_all_endpoints_at(&world.record_store, &name, 1);
 
     // The register call went out (register-first ordering), to the registry.
@@ -418,7 +418,7 @@ fn publish_cas_embeds_the_exact_expected_sequence_floor_plus_one() {
     ))
     .expect("publish");
 
-    assert_eq!(outcome, PublishOutcome::Published { sequence: 4 });
+    assert_eq!(outcome.outcome, PublishOutcome::Published { sequence: 4 });
     assert_all_endpoints_at(&world.record_store, &name, 4);
 }
 
@@ -561,7 +561,7 @@ fn publish_succeeds_on_any_ack_and_the_background_retry_reaches_the_failed_endpo
     .expect("publish");
 
     assert_eq!(
-        outcome,
+        outcome.outcome,
         PublishOutcome::Published { sequence: 1 },
         "any ack is success"
     );
@@ -669,7 +669,7 @@ fn publish_confirm_detects_a_lost_cas_race() {
     .expect("publish");
 
     assert_eq!(
-        outcome,
+        outcome.outcome,
         PublishOutcome::LostRace {
             published_sequence: 2,
             observed_sequence: 3,

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -13,6 +13,7 @@ use cipherbox_core::content::{compute_cid, encode_content_cid_str};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::payload::RepointObject;
+use cipherbox_core::seal::{ReadBody, decode_envelope, open_read_body};
 use cipherbox_core::suite::ecdsa::EcdsaSigner;
 
 use cipherbox_engine::content::{DAG_ROOT_CODEC, GatewaySource};
@@ -25,8 +26,8 @@ use cipherbox_engine::sync::DRAINED_OP_MARK_KEY;
 use cipherbox_engine::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
 use cipherbox_engine::testkit::{
     FakeDevice, FakeSeamTypes, FakeWorld, OWNER_ROOT_EPOCH as EPOCH,
-    OWNER_ROOT_WRITE_SCOPE_SEED as WRITE_SCOPE_SEED, OwnerRootSpec, SeededEntropy, block_on,
-    owner_root_fixture,
+    OWNER_ROOT_SCOPE_SEED as READ_SCOPE_SEED, OWNER_ROOT_WRITE_SCOPE_SEED as WRITE_SCOPE_SEED,
+    OwnerRootSpec, SeededEntropy, block_on, owner_root_fixture,
 };
 use cipherbox_engine::{
     Command, Engine, EventStream, GatewayConfig, LoginSecret, NodeId, NodeKind, StoragePolicy,
@@ -283,6 +284,60 @@ fn a_folder_create_publishes_and_resolves_back() {
             .unwrap()
             .is_empty(),
         "and left the durable queue"
+    );
+}
+
+/// The two KDF edges the write plane hangs off must not be crossed: a node's
+/// name comes from the WRITE scope seed and its body opens under a key derived
+/// from the READ scope seed. Swapping them would still publish, so only this
+/// pins them.
+#[test]
+fn a_published_child_sits_on_the_write_name_edge_and_the_read_key_edge() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    serve_http(&alice, &blocks, 16);
+    let (mut engine, _events) = engine_on(&alice, 42);
+    block_on(engine.start(secret())).unwrap();
+    block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "photos".into(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .unwrap();
+    let mut tasks = world.scheduler.take_spawned_tasks();
+    poll_each(&mut tasks);
+    tick(&world, &engine, &mut tasks);
+
+    let child = block_on(engine.view()).unwrap().children(ROOT)[0].id;
+
+    // The name edge: `writeSeed(writeScopeSeed, id) -> ipnsKeypair`.
+    let expected_name = IpnsName::from_public_key(
+        &kdf::ipns_keypair(kdf::write_seed(&WRITE_SCOPE_SEED, &child.0).as_bytes()).verifying_key(),
+    );
+    let record = world
+        .record_store
+        .record_at(&world.record_store.endpoints()[0], expected_name.as_str())
+        .expect("the child publishes under the write-seed name");
+    let verified = IpnsRecord::unmarshal(&record)
+        .and_then(|r| r.verify(&expected_name))
+        .expect("and is signed by that name's own key");
+
+    // The read-key edge: `nodeSeed(readScopeSeed, id) -> readKey`.
+    let head_cid = core::str::from_utf8(&verified.value)
+        .unwrap()
+        .strip_prefix("/ipfs/")
+        .unwrap();
+    let envelope = decode_envelope(&blocks.get(head_cid).expect("the head block")).unwrap();
+    let read_key = kdf::read_key(kdf::node_seed(&READ_SCOPE_SEED, &child.0).as_bytes());
+    let body = open_read_body(&envelope, read_key.as_bytes())
+        .expect("the child body opens under the read-seed key");
+    assert!(
+        matches!(body, ReadBody::Folder { ref children, .. } if children.is_empty()),
+        "a fresh folder publishes an empty child list"
     );
 }
 

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -1,0 +1,384 @@
+//! The write plane, joined end to end (#865): a `Command::Create` for a folder
+//! is staged, drained, authored, published, self-adopted, and resolved back —
+//! first by the device that wrote it, then by a second device of the same
+//! account that only ever saw the network.
+//!
+//! Later write-plane slices extend this file rather than starting their own.
+
+use core::task::{Context, Poll, Waker};
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use cipherbox_core::content::{compute_cid, encode_content_cid_str};
+use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::kdf;
+use cipherbox_core::payload::RepointObject;
+use cipherbox_core::suite::ecdsa::EcdsaSigner;
+
+use cipherbox_engine::content::{DAG_ROOT_CODEC, GatewaySource};
+use cipherbox_engine::facade::PendingClass;
+use cipherbox_engine::seams::{
+    BoxedTask, FloorStore, HttpRequest, HttpResponse, OpId, RecordTransport, SeamError, SeamResult,
+    StagingStore,
+};
+use cipherbox_engine::sync::DRAINED_OP_FLOOR_KEY;
+use cipherbox_engine::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
+use cipherbox_engine::testkit::{
+    FakeDevice, FakeSeamTypes, FakeWorld, OWNER_ROOT_EPOCH as EPOCH,
+    OWNER_ROOT_WRITE_SCOPE_SEED as WRITE_SCOPE_SEED, OwnerRootSpec, SeededEntropy, block_on,
+    owner_root_fixture,
+};
+use cipherbox_engine::{
+    Command, Engine, EventStream, GatewayConfig, LoginSecret, NodeId, NodeKind, StoragePolicy,
+    SyncTimingProfile,
+};
+
+const SECRET: [u8; 32] = [7u8; 32];
+/// The all-zero bootstrap anchor `start` binds its cold-start scope to.
+const SCOPE: [u8; 16] = [0u8; 16];
+const ROOT: NodeId = NodeId(SCOPE);
+/// The sole v2 re-point payload version (`facade::POINTER_PAYLOAD_VERSION`).
+const POINTER_PAYLOAD_VERSION: u64 = 1;
+const TTL_NANOS: u64 = 2_000_000_000;
+const EOL: &str = "2099-01-01T00:00:00Z";
+
+fn owner_identity() -> EcdsaSigner {
+    EcdsaSigner::from_scalar(&SECRET).expect("valid scalar")
+}
+
+// ---------------------------------------------------------------------------
+// The block plane: one content-addressed store behind both the pin API and the
+// gateway, so a block the engine uploads is a block it can later fetch.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Default)]
+struct Blocks(Arc<Mutex<BTreeMap<String, Vec<u8>>>>);
+
+impl Blocks {
+    fn put(&self, block: Vec<u8>) -> String {
+        let cid = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &block));
+        self.0.lock().expect("lock").insert(cid.clone(), block);
+        cid
+    }
+
+    fn get(&self, cid: &str) -> Option<Vec<u8>> {
+        self.0.lock().expect("lock").get(cid).cloned()
+    }
+
+    /// Answer one engine HTTP call: a content upload lands its bytes here and
+    /// echoes their address, a registry call acks, and a gateway GET serves the
+    /// block back. Enqueued as many times as the pass needs, so no test depends
+    /// on the exact order the engine happens to make its calls in.
+    fn reply(&self, request: &HttpRequest) -> SeamResult<HttpResponse> {
+        let ok = |body: Vec<u8>| {
+            Ok(HttpResponse {
+                status: 200,
+                headers: Vec::new(),
+                body,
+            })
+        };
+        let url = &request.url;
+        if url.ends_with("/content/upload") {
+            let block = request.body.clone().unwrap_or_default();
+            let size = block.len();
+            let cid = self.put(block);
+            return ok(format!("{{\"cid\":\"{cid}\",\"size\":{size}}}").into_bytes());
+        }
+        if url.contains("/registry/") {
+            return ok(Vec::new());
+        }
+        let cid = url
+            .rsplit('/')
+            .next()
+            .and_then(|tail| tail.split('?').next())
+            .unwrap_or_default();
+        match self.get(cid) {
+            Some(block) => ok(block),
+            None => Err(SeamError::new("no such block")),
+        }
+    }
+}
+
+/// Wire `device`'s scripted HTTP to the block plane for `calls` requests.
+fn serve_http(device: &FakeDevice, blocks: &Blocks, calls: usize) {
+    for _ in 0..calls {
+        let blocks = blocks.clone();
+        device
+            .http
+            .enqueue_derived(move |request| blocks.reply(request));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Account fixture: the owner vault pointer and the initial empty scope root.
+// ---------------------------------------------------------------------------
+
+/// Publish the account's initial state to the shared network: an empty owner
+/// root at sequence 1 and the vault pointer naming it. Returns the root's
+/// write-plane name.
+fn seed_account(world: &FakeWorld, blocks: &Blocks) -> IpnsName {
+    let fixture = owner_root_fixture(OwnerRootSpec {
+        owner_identity: &owner_identity(),
+        owner_enc: &kdf::enc_subkey(&SECRET).public(),
+        scope_id: SCOPE,
+        root_id: ROOT.0,
+        children: Vec::new(),
+        // At the read epoch, so the cold-seeded write floor opens the
+        // owner-write-blob and the owner recovers its scope write seed — the
+        // seed the drain derives every new node's name and signer from.
+        owner_write_blob_epoch: Some(EPOCH),
+    });
+    blocks.put(fixture.head_block.clone());
+
+    let root_signer = {
+        let write_seed = kdf::write_seed(&WRITE_SCOPE_SEED, &ROOT.0);
+        kdf::ipns_keypair(write_seed.as_bytes())
+    };
+    let root_record = IpnsRecord::create_v2(
+        &root_signer,
+        format!("/ipfs/{}", fixture.head_cid_str).as_bytes(),
+        1,
+        TTL_NANOS,
+        EOL,
+    )
+    .marshal();
+
+    let pointer_block = seal_repoint(
+        SessionRole::Owner,
+        &mut SeededEntropy::new(0),
+        kdf::pointer_read_key(kdf::owner_pointer_seed(&SECRET).as_bytes(), &SCOPE).as_bytes(),
+        POINTER_PAYLOAD_VERSION,
+        &owner_identity(),
+        &RepointObject {
+            scope_id: SCOPE,
+            current_root: fixture.name.clone(),
+            write_epoch: EPOCH,
+            min_read_epoch: EPOCH,
+            prev_root: None,
+        },
+    )
+    .expect("seal the re-point");
+    let pointer_record = IpnsRecord::create_v2(
+        &kdf::vault_pointer_index(&SECRET, 0),
+        &pointer_block,
+        1,
+        TTL_NANOS,
+        EOL,
+    )
+    .marshal();
+    let pointer_name = vault_pointer_name(&SECRET, 0);
+
+    for endpoint in world.record_store.endpoints() {
+        world
+            .record_store
+            .seed_record(&endpoint, fixture.name.as_str(), root_record.clone());
+        world
+            .record_store
+            .seed_record(&endpoint, pointer_name.as_str(), pointer_record.clone());
+    }
+    fixture.name
+}
+
+fn engine_on(device: &FakeDevice, entropy_seed: u64) -> (Engine<FakeSeamTypes>, EventStream) {
+    Engine::new(
+        device.seam_set(),
+        Box::new(SeededEntropy::new(entropy_seed)),
+        SyncTimingProfile::CI,
+        StoragePolicy::CI,
+        // The API base URL is empty, so `start` skips login: this suite exercises
+        // the record plane, not the auth handshake.
+        String::new(),
+        GatewayConfig {
+            accelerator: Some(GatewaySource {
+                base_url: "https://gw.test".into(),
+                bearer: None,
+            }),
+            public_fallbacks: Vec::new(),
+        },
+    )
+}
+
+fn secret() -> LoginSecret {
+    LoginSecret::new(SECRET.to_vec())
+}
+
+/// Poll every spawned loop once with a no-op waker (the loops never yield
+/// inside a pass over the synchronous fakes).
+fn poll_each(tasks: &mut [BoxedTask]) -> Vec<Poll<()>> {
+    let mut cx = Context::from_waker(Waker::noop());
+    tasks.iter_mut().map(|t| t.as_mut().poll(&mut cx)).collect()
+}
+
+/// Run one resolve-tick interval, which is also one drain pass.
+fn tick(world: &FakeWorld, engine: &Engine<FakeSeamTypes>, tasks: &mut [BoxedTask]) {
+    world.scheduler.advance(engine.profile().poll_cadence);
+    poll_each(tasks);
+}
+
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_folder_create_publishes_and_resolves_back() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let root_name = seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    serve_http(&alice, &blocks, 16);
+    let (mut engine, _events) = engine_on(&alice, 42);
+    block_on(engine.start(secret())).expect("cold start adopts the owner root");
+    assert!(
+        block_on(engine.view()).unwrap().children(ROOT).is_empty(),
+        "the account starts with an empty root"
+    );
+
+    let op_id = block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "photos".into(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .expect("a metadata create stages");
+    assert!(
+        op_id.is_some(),
+        "a staged op is addressable by its queue id"
+    );
+
+    let mut tasks = world.scheduler.take_spawned_tasks();
+    poll_each(&mut tasks); // park both loops at their first sleep
+    tick(&world, &engine, &mut tasks);
+
+    // The op left the queue and the child is in gate-passing state, not the
+    // pending overlay: the drain published it and self-adopted its own bytes.
+    let view = block_on(engine.snapshot(ROOT)).unwrap();
+    assert_eq!(view.children.len(), 1, "the create published");
+    assert_eq!(view.children[0].name, "photos");
+    assert_eq!(view.children[0].kind, NodeKind::Folder);
+    assert_eq!(
+        view.children[0].pending,
+        PendingClass::None,
+        "a published op is no longer pending"
+    );
+
+    // The record plane really carries it: the root republished at sequence 2.
+    let published = world
+        .record_store
+        .record_at(&world.record_store.endpoints()[0], root_name.as_str())
+        .expect("the root record is published");
+    let sequence = IpnsRecord::unmarshal(&published)
+        .and_then(|record| record.verify(&root_name))
+        .expect("the published root verifies under its own name")
+        .sequence;
+    assert_eq!(sequence, 2, "the root advanced past the seeded sequence 1");
+
+    // The completion record marks the op as drained, so a restored copy of this
+    // queue cannot replay it (#860).
+    assert_eq!(
+        block_on(alice.floor_store.sequence_floor(DRAINED_OP_FLOOR_KEY)).unwrap(),
+        op_id.map(|id| id.0),
+        "the drained op raised the durable completion mark"
+    );
+    assert!(
+        block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .is_empty(),
+        "and left the durable queue"
+    );
+}
+
+#[test]
+fn a_second_device_of_the_same_account_resolves_the_write() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    serve_http(&alice, &blocks, 16);
+    let (mut engine_a, _events_a) = engine_on(&alice, 42);
+    block_on(engine_a.start(secret())).unwrap();
+    block_on(engine_a.command(Command::Create {
+        parent: ROOT,
+        name: "photos".into(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .unwrap();
+    let mut tasks = world.scheduler.take_spawned_tasks();
+    poll_each(&mut tasks);
+    tick(&world, &engine_a, &mut tasks);
+
+    // A second device of the same account, cold: its own floors, cache, and
+    // queue, sharing only the network and the clock.
+    let bob = world.device(b"alice-second-device");
+    serve_http(&bob, &blocks, 8);
+    let (mut engine_b, _events_b) = engine_on(&bob, 7);
+    block_on(engine_b.start(secret()))
+        .expect("the second device cold-starts off the published record plane");
+
+    let children = block_on(engine_b.view()).unwrap().children(ROOT);
+    assert_eq!(children.len(), 1, "device B resolves device A's write");
+    assert_eq!(children[0].name, "photos");
+    assert_eq!(
+        children[0].id,
+        block_on(engine_a.view()).unwrap().children(ROOT)[0].id
+    );
+}
+
+/// An op the completion record already covers is restore residue: a data dir
+/// whose queue predates its own high-water mark. It leaves the queue without
+/// publishing, so a restored backup cannot re-apply mutations the user never
+/// asked for again (#860).
+#[test]
+fn an_op_the_completion_record_already_covers_never_republishes() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let root_name = seed_account(&world, &blocks);
+    let seeded = world
+        .record_store
+        .record_at(&world.record_store.endpoints()[0], root_name.as_str())
+        .expect("the account's initial root");
+
+    let alice = world.device(b"alice");
+    serve_http(&alice, &blocks, 16);
+    // The restored dir's mark says op 1 already drained — the id the create
+    // below reclaims from the stale queue.
+    block_on(
+        alice
+            .floor_store
+            .raise_sequence_floor(DRAINED_OP_FLOOR_KEY, 1),
+    )
+    .unwrap();
+
+    let (mut engine, _events) = engine_on(&alice, 42);
+    block_on(engine.start(secret())).unwrap();
+    let op_id = block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "photos".into(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .unwrap();
+    assert_eq!(op_id, Some(OpId(1)), "the create reclaims the covered id");
+
+    let mut tasks = world.scheduler.take_spawned_tasks();
+    poll_each(&mut tasks);
+    tick(&world, &engine, &mut tasks);
+
+    assert!(
+        block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .is_empty(),
+        "the residue op leaves the queue"
+    );
+    assert_eq!(
+        world
+            .record_store
+            .record_at(&world.record_store.endpoints()[0], root_name.as_str()),
+        Some(seeded),
+        "and nothing was published under the root's name"
+    );
+    assert!(
+        block_on(engine.view()).unwrap().children(ROOT).is_empty(),
+        "so the folder it would have created never appears"
+    );
+}

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -286,6 +286,109 @@ fn a_folder_create_publishes_and_resolves_back() {
     );
 }
 
+/// A restart whose root is unchanged resolves `Current`, which adopts nothing.
+/// The write plane must still keep the seeds it seals and signs under, or the
+/// very bug this slice fixes — a `mkdir` that publishes nothing — returns on
+/// the second run.
+#[test]
+fn a_restart_that_adopts_nothing_still_drains() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let root_name = seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    serve_http(&alice, &blocks, 40);
+    let (mut engine, _events) = engine_on(&alice, 42);
+    block_on(engine.start(secret())).unwrap();
+    block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "photos".into(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .unwrap();
+    let mut tasks = world.scheduler.take_spawned_tasks();
+    poll_each(&mut tasks);
+    tick(&world, &engine, &mut tasks);
+    drop(engine);
+
+    // Same device, second run: the network root is exactly at this device's
+    // durable floor, so cold start reconciles without adopting.
+    let (mut engine, _events) = engine_on(&alice, 43);
+    block_on(engine.start(secret())).unwrap();
+    block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "docs".into(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .unwrap();
+    let mut tasks = world.scheduler.take_spawned_tasks();
+    poll_each(&mut tasks);
+    tick(&world, &engine, &mut tasks);
+
+    let mut names: Vec<String> = block_on(engine.view())
+        .unwrap()
+        .children(ROOT)
+        .into_iter()
+        .map(|child| child.name)
+        .collect();
+    names.sort();
+    assert_eq!(names, ["docs", "photos"], "both runs published");
+
+    let published = world
+        .record_store
+        .record_at(&world.record_store.endpoints()[0], root_name.as_str())
+        .expect("the root record is published");
+    let sequence = IpnsRecord::unmarshal(&published)
+        .and_then(|record| record.verify(&root_name))
+        .expect("the published root verifies under its own name")
+        .sequence;
+    assert_eq!(sequence, 3, "the second run advanced the root again");
+}
+
+/// The drain covers `Create { content: None }`, which is both kinds: a file
+/// with no content yet is a metadata-only create exactly like a folder, and its
+/// record is a file body with an empty version list.
+#[test]
+fn an_empty_file_create_publishes_under_the_same_metadata_path() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    serve_http(&alice, &blocks, 16);
+    let (mut engine, _events) = engine_on(&alice, 42);
+    block_on(engine.start(secret())).unwrap();
+    block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "notes.txt".into(),
+        kind: NodeKind::File,
+        content: None,
+    }))
+    .unwrap();
+
+    let mut tasks = world.scheduler.take_spawned_tasks();
+    poll_each(&mut tasks);
+    tick(&world, &engine, &mut tasks);
+
+    let view = block_on(engine.snapshot(ROOT)).unwrap();
+    assert_eq!(view.children.len(), 1);
+    assert_eq!(view.children[0].name, "notes.txt");
+    assert_eq!(
+        view.children[0].kind,
+        NodeKind::File,
+        "the kind the parent ref carries is the kind the child body was sealed as"
+    );
+    assert_eq!(view.children[0].pending, PendingClass::None);
+    assert!(
+        block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .is_empty(),
+        "the queue drained rather than wedging on an unsupported kind"
+    );
+}
+
 #[test]
 fn a_second_device_of_the_same_account_resolves_the_write() {
     let world = FakeWorld::new();

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -18,10 +18,10 @@ use cipherbox_core::suite::ecdsa::EcdsaSigner;
 use cipherbox_engine::content::{DAG_ROOT_CODEC, GatewaySource};
 use cipherbox_engine::facade::PendingClass;
 use cipherbox_engine::seams::{
-    BoxedTask, FloorStore, HttpRequest, HttpResponse, OpId, RecordTransport, SeamError, SeamResult,
+    BoxedTask, HttpRequest, HttpResponse, OpId, RecordTransport, SeamError, SeamResult,
     StagingStore,
 };
-use cipherbox_engine::sync::DRAINED_OP_FLOOR_KEY;
+use cipherbox_engine::sync::DRAINED_OP_MARK_KEY;
 use cipherbox_engine::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
 use cipherbox_engine::testkit::{
     FakeDevice, FakeSeamTypes, FakeWorld, OWNER_ROOT_EPOCH as EPOCH,
@@ -274,7 +274,7 @@ fn a_folder_create_publishes_and_resolves_back() {
     // The completion record marks the op as drained, so a restored copy of this
     // queue cannot replay it (#860).
     assert_eq!(
-        block_on(alice.floor_store.sequence_floor(DRAINED_OP_FLOOR_KEY)).unwrap(),
+        block_on(drained_mark(&alice)),
         op_id.map(|id| id.0),
         "the drained op raised the durable completion mark"
     );
@@ -445,11 +445,11 @@ fn an_op_the_completion_record_already_covers_never_republishes() {
     serve_http(&alice, &blocks, 16);
     // The restored dir's mark says op 1 already drained — the id the create
     // below reclaims from the stale queue.
-    block_on(
-        alice
-            .floor_store
-            .raise_sequence_floor(DRAINED_OP_FLOOR_KEY, 1),
-    )
+    block_on(StagingStore::put_staged_bytes(
+        &alice.staging_store,
+        DRAINED_OP_MARK_KEY,
+        &1u64.to_be_bytes(),
+    ))
     .unwrap();
 
     let (mut engine, _events) = engine_on(&alice, 42);
@@ -484,4 +484,13 @@ fn an_op_the_completion_record_already_covers_never_republishes() {
         block_on(engine.view()).unwrap().children(ROOT).is_empty(),
         "so the folder it would have created never appears"
     );
+}
+
+/// The device's durable drained-op completion mark. It lives beside the op
+/// queue it names, so a store that loses one loses the other.
+async fn drained_mark(device: &FakeDevice) -> Option<u64> {
+    StagingStore::staged_bytes(&device.staging_store, DRAINED_OP_MARK_KEY)
+        .await
+        .expect("the staging store answers")
+        .map(|bytes| u64::from_be_bytes(bytes.try_into().expect("an 8-byte mark")))
 }

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -212,18 +212,20 @@ impl EngineHandle {
     }
 
     /// Executes one engine command — the single write entry point. Consumes the
-    /// command value. Resolves on success; rejects with the engine error.
+    /// command value. Resolves with the staged op's durable queue id (the same
+    /// `u64` an `opProgress`/`deadLetter` event carries), or `undefined` for a
+    /// command that queues nothing; rejects with the engine error.
     pub fn command(&self, command: Command) -> Promise {
         let engine = self.engine.clone();
         let facade_command = command.into_facade();
         future_to_promise(async move {
-            engine
+            let op_id = engine
                 .write()
                 .await
                 .command(facade_command)
                 .await
                 .map_err(engine_error)?;
-            Ok(JsValue::UNDEFINED)
+            Ok(op_id.map_or(JsValue::UNDEFINED, |op| JsValue::from_f64(op.0 as f64)))
         })
     }
 

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -18,6 +18,7 @@ use std::rc::Rc;
 
 use async_lock::{Mutex, RwLock};
 use cipherbox_engine::facade::{Engine, EngineError, EventStream, LoginSecret};
+use cipherbox_engine::seams::OpId;
 use cipherbox_engine::{
     Entropy, EntropyError, GatewayConfig, GatewaySource, SeamSet, SeamTypes, StoragePlatform,
     StoragePolicy, SyncTimingProfile,
@@ -225,7 +226,7 @@ impl EngineHandle {
                 .command(facade_command)
                 .await
                 .map_err(engine_error)?;
-            Ok(op_id.map_or(JsValue::UNDEFINED, |op| JsValue::from_f64(op.0 as f64)))
+            Ok(op_id_value(op_id))
         })
     }
 
@@ -277,6 +278,13 @@ impl EngineHandle {
     }
 }
 
+/// A staged op id as the boundary spells it. Op ids run the whole `u64` range,
+/// so they cross as `bigint` — the same marshalling the `opId` getter on
+/// `opProgress`/`deadLetter` uses, or a client could not correlate the two.
+fn op_id_value(op_id: Option<OpId>) -> JsValue {
+    op_id.map_or(JsValue::UNDEFINED, |op| JsValue::from(op.0))
+}
+
 /// Renders an engine error as a rejection value: a `js_sys::Error` whose
 /// message is the diagnostic `Display` string (no key material — redacted by
 /// construction) and whose `code` property is the stable camelCase variant
@@ -302,4 +310,37 @@ fn engine_error(error: EngineError) -> JsValue {
     // Setting a plain property on a fresh `Error` cannot fail.
     let _ = Reflect::set(&js, &JsValue::from_str("code"), &JsValue::from_str(code));
     js.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use js_sys::BigInt;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    /// `command()` resolves with the id an `opProgress`/`deadLetter` event
+    /// later carries, so both must cross as the same JS type — an f64 `number`
+    /// would neither compare equal to the event's `bigint` nor survive an id
+    /// past 2^53.
+    #[wasm_bindgen_test]
+    fn a_staged_op_id_crosses_as_a_bigint() {
+        let value = op_id_value(Some(OpId(u64::MAX)));
+
+        assert_eq!(value.js_typeof(), JsValue::from_str("bigint"));
+        assert_eq!(
+            String::from(
+                value
+                    .unchecked_into::<BigInt>()
+                    .to_string(10)
+                    .expect("bigint renders in base 10")
+            ),
+            u64::MAX.to_string(),
+        );
+    }
+
+    /// A command that queues nothing resolves `undefined`, never `0n`.
+    #[wasm_bindgen_test]
+    fn a_command_that_queues_nothing_crosses_as_undefined() {
+        assert!(op_id_value(None).is_undefined());
+    }
 }

--- a/crates/wasm/src/seams_bridge.rs
+++ b/crates/wasm/src/seams_bridge.rs
@@ -206,6 +206,7 @@ impl SnapshotCache for SnapshotCacheAdapter {
 #[wasm_bindgen]
 extern "C" {
     /// JS `StagingStoreSeam` (packages/client).
+    #[derive(Clone)]
     pub type JsStagingStoreSeam;
 
     #[wasm_bindgen(method, catch, js_name = enqueueOp)]
@@ -236,6 +237,7 @@ extern "C" {
     async fn staged_bytes_total(this: &JsStagingStoreSeam) -> Result<JsValue, JsValue>;
 }
 
+#[derive(Clone)]
 pub(crate) struct StagingStoreAdapter {
     pub(crate) js: JsStagingStoreSeam,
 }


### PR DESCRIPTION
The first vertical through the write plane: a `mkdir` becomes a published, resolvable record, and the standing bug where a plain `Create { content: None }` staged an op, emitted `SnapshotUpdated`, and published nothing is gone.

The deliverable is the joined test. `crates/engine/tests/write_plane.rs` runs a real `Command::Create` from the facade through the drain, authoring, the publish port, the self-adopt, and back out of a rendered snapshot — with the two-device assertion standing from here on. Later write-plane slices extend this file rather than starting their own.

## What landed

**Record authoring** — `crates/engine/src/net/author.rs`, a new module. Carries two of #823's four guards:

- Guard 1, checked: `author_child_envelope` refuses a child envelope carrying a grant section, off core's own `has_grant_section`, so the produce guard and the decode reject are literally the same function.
- Guard 4, structural: authoring takes a typed `IpnsName` and `new_child` feeds one `NodeKind` to both the child's body and the parent's `ChildRef`, so a kind transplant and a non-canonical name are unrepresentable.
- No guard is a `debug_assert!`; every test asserts on a returned value, so they behave identically under `--release`.

**The shared publish port** — `crates/engine/src/net/record_publish.rs` (#821). `publish_record` is custody-free, one thin layer above `net::publish::publish`: it moves bytes to the network and hands back the signed record, holds no read-key material, seals nothing, and runs no gate. `PreflightedHead` is the only thing it accepts and `preflight` is its only constructor, so an un-dry-run envelope cannot reach the network. A third `Unconfirmed` outcome replaces the silent `Published` that confirm-by-re-resolve used to report when it observed nothing; self-adopt runs only on `Published`, so a retry re-mints the same sequence.

**The drain** — `crates/engine/src/sync/drain.rs`, wired into the live resolve tick. `sync::rebase::replay` gets its first production caller. Publishes referent before reference — the child's own record, then the parent that names it. Publish self-adopts (#817): the write path feeds its own signed bytes back through the adoption gate with no fetch, preceded by the envelope-level preflight; the floor advance stays inside the gate at stage 6 and the write path raises nothing itself. A completion record marks a drained op so a restored data dir cannot replay it (#860), and `stage_and_notify` stops discarding what `stage_op` returns, so `command()` is now `Result<Option<OpId>, EngineError>` (#824).

## Review-gate findings folded back in

Run against this branch's own diff before opening.

- The decode side refuses an over-cap block, so authoring one would sign a pointer to a block this build's own reader always rejects. `author.rs` now returns `AuthorError::HeadTooLarge` release-active.
- The drained-op completion mark moved out of the floors and into the staging store, so it and the op ids it names share one durability domain. A store that loses its queue loses the mark with it, instead of retaining a mark that would delete every id the restarted counter reissues.
- Confirm-by-re-resolve treats an observed sequence *below* ours as unconfirmed. The fan-out reports the freshest record across the endpoint set, so only an exact match proves ours is readable.
- Equal-floor `Current` recovery now also surfaces the scope read seed, and re-imposes the scope binding and read-epoch floor the sequence stage short-circuits past, plus an unseal-confirm of the seed against the record's own body. Without the read seed a restart whose root is unchanged adopts nothing and can never publish again — the `mkdir` bug returning on the second run.
- Authoring binds a republished scope root to its own commitment: the grant section rides a metadata republish verbatim and its commitment signs the `ipnsName` it belongs to, so a section carried onto another name is refused, as is a scope root with no section at all.
- A locally-held head block clears the same plane-anchor check a fetched one does; a child is held for liveness only once its parent names it.

## Deliberately not here

- **Failure surfacing.** A drain pass that stops leaves its op queued and the next tick retries it, so the durable queue is the record of the failure. Classifying one — attempt budgets, dead-letter thresholds, the host-visible notice — is #867, and shipping a typed halt reason nothing reads would be the orphaned-primitive pattern this chain exists to end.
- **Distinct seed newtypes.** `ReadScopeSeed`/`WriteScopeSeed` would make crossing the two edges unrepresentable rather than pinned by test. It ripples through `AdoptOutcome`, `HeldMaterial`, `ColdStartOutcome`, and the session factories, none of which this slice otherwise touches. `a_published_child_sits_on_the_write_name_edge_and_the_read_key_edge` pins both edges meanwhile.
- **Creates below the scope root** halt the drain: the base snapshot projects the root's direct children only, so a deeper parent has no gate-passing body to re-author onto. Filed as #887, blocked by this issue.
- The op id crosses the wasm boundary but the TypeScript transport still types `command` as `Promise<void>`; threading it through tab leadership belongs with the slice that needs it.

## Gate

`Engine Tests` — `cargo test -p cipherbox-engine` already runs the new `write_plane.rs`, so it blocks a merge the day it lands with no workflow edit.

Closes #865
Part of #655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and publishing folder and file metadata across devices.
  * Commands that queue durable changes now return an operation ID.
  * Added reliable draining of staged changes, including ordered publishing and recovery after restart.

* **Bug Fixes**
  * Improved content integrity checks to reject mismatched or tampered records.
  * Prevented false publish confirmations when records conflict at the same sequence.
  * Improved handling of uncertain publication outcomes and recovery scenarios.

* **Performance**
  * Reduced unnecessary network requests by reusing locally available record heads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->