### PR TITLE
feat: build and serve the engine wasm artifact for apps/web

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,81 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # The web bundle needs the wasm-bindgen artifact, so it is gated by the
+      # `Web Bundle` job, which carries the Rust toolchain; this job stays
+      # TS-only. `!cipher-box` drops the root project, whose own `build` script
+      # would recurse back into every package.
       - name: Build packages
-        run: pnpm build
+        run: pnpm --filter '!@cipherbox/web' --filter '!cipher-box' run build
+
+  # apps/web's production wasm-bindgen artifact and the bundle that serves it
+  # (blueprint/web-client.md "WASM packaging"): the app build emits the engine
+  # module from crates/wasm and Vite fingerprints both files into `dist/assets`.
+  # Merge-blocking, and split out of `Build` so a TS-only change never waits on
+  # a Rust toolchain. Depends on both the crates and packages.
+  web-bundle:
+    name: Web Bundle
+    needs: [changes, lint]
+    if: |
+      !failure() && !cancelled() &&
+      (needs.changes.outputs.ts == 'true' || needs.changes.outputs.rust == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+            target
+          key: web-bundle-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: web-bundle-cargo-
+
+      - name: Add wasm target
+        run: rustup target add wasm32-unknown-unknown
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      # wasm-bindgen-cli generates the engine glue and must match the locked
+      # wasm-bindgen version exactly (a schema mismatch fails the run).
+      - name: Install wasm-bindgen-cli (matching Cargo.lock)
+        run: |
+          WB_VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "wasm-bindgen ${WB_VERSION}"
+          if wasm-bindgen --version 2>/dev/null | grep -qw "${WB_VERSION}"; then
+            echo "wasm-bindgen-cli ${WB_VERSION} already present (cache hit); skipping install"
+          else
+            cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked --force
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build the web bundle
+        run: pnpm --filter @cipherbox/web run build
+
+      # The worker's dynamic import resolves to whatever Vite emitted, so the
+      # bundle is only usable if both artifact files landed content-hashed.
+      - name: Bundle carries the fingerprinted engine artifact
+        run: |
+          shopt -s nullglob
+          glue=(apps/web/dist/assets/cipherbox_wasm-*.js)
+          binary=(apps/web/dist/assets/cipherbox_wasm_bg-*.wasm)
+          if [ ${#glue[@]} -ne 1 ] || [ ${#binary[@]} -ne 1 ]; then
+            echo "::error::apps/web/dist is missing the fingerprinted engine WASM artifact"
+            ls -R apps/web/dist
+            exit 1
+          fi
+          echo "engine artifact: ${glue[0]} ${binary[0]}"
 
   api-unit:
     name: API Unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       ts: ${{ steps.filter.outputs.ts }}
       rust: ${{ steps.filter.outputs.rust }}
+      web: ${{ steps.filter.outputs.web }}
       desktop: ${{ steps.filter.outputs.desktop }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -43,6 +44,19 @@ jobs:
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
               - '.cargo/config.toml'
+              - '.github/workflows/ci.yml'
+            web:
+              - 'apps/web/**'
+              - 'packages/client/**'
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.cargo/config.toml'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'package.json'
+              - 'tsconfig*.json'
               - '.github/workflows/ci.yml'
             desktop:
               - 'apps/desktop/**'
@@ -139,37 +153,37 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # The web bundle needs the wasm-bindgen artifact, so it is gated by the
-      # `Web Bundle` job, which carries the Rust toolchain; this job stays
-      # TS-only. `!cipher-box` drops the root project, whose own `build` script
-      # would recurse back into every package.
+      # apps/web is built by `Web Bundle`, which carries the Rust toolchain its
+      # WASM artifact needs. `!cipher-box` drops the root project, whose own
+      # `build` script would recurse back into every package.
       - name: Build packages
         run: pnpm --filter '!@cipherbox/web' --filter '!cipher-box' run build
 
-  # apps/web's production wasm-bindgen artifact and the bundle that serves it
-  # (blueprint/web-client.md "WASM packaging"): the app build emits the engine
-  # module from crates/wasm and Vite fingerprints both files into `dist/assets`.
-  # Merge-blocking, and split out of `Build` so a TS-only change never waits on
-  # a Rust toolchain. Depends on both the crates and packages.
+  # apps/web's production WASM artifact and the bundle that fingerprints it
+  # (blueprint/web-client.md "WASM packaging"). Split out of `Build` so a change
+  # that touches neither the web app nor the crates pays no Rust toolchain.
   web-bundle:
     name: Web Bundle
     needs: [changes, lint]
     if: |
       !failure() && !cancelled() &&
-      (needs.changes.outputs.ts == 'true' || needs.changes.outputs.rust == 'true')
+      needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Only the browser target's build tree: the native `target/` subtrees the
+      # cargo jobs cache are dead weight here, and a fourth full copy would push
+      # the repo's other cargo caches out under LRU.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin
-            target
+            target/wasm32-unknown-unknown
           key: web-bundle-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: web-bundle-cargo-
 
@@ -201,19 +215,8 @@ jobs:
       - name: Build the web bundle
         run: pnpm --filter @cipherbox/web run build
 
-      # The worker's dynamic import resolves to whatever Vite emitted, so the
-      # bundle is only usable if both artifact files landed content-hashed.
       - name: Bundle carries the fingerprinted engine artifact
-        run: |
-          shopt -s nullglob
-          glue=(apps/web/dist/assets/cipherbox_wasm-*.js)
-          binary=(apps/web/dist/assets/cipherbox_wasm_bg-*.wasm)
-          if [ ${#glue[@]} -ne 1 ] || [ ${#binary[@]} -ne 1 ]; then
-            echo "::error::apps/web/dist is missing the fingerprinted engine WASM artifact"
-            ls -R apps/web/dist
-            exit 1
-          fi
-          echo "engine artifact: ${glue[0]} ${binary[0]}"
+        run: ls apps/web/dist/assets/cipherbox_wasm-*.js apps/web/dist/assets/cipherbox_wasm_bg-*.wasm
 
   api-unit:
     name: API Unit
@@ -548,8 +551,8 @@ jobs:
           fi
 
       # The single wasm-bindgen ES module and its generated .d.ts contract must
-      # build (blueprint/web-client.md); packages/client hosts and fingerprints
-      # it later.
+      # build (blueprint/web-client.md) on any crate change, including one that
+      # touches no TS; `Web Bundle` is what ships it.
       - name: Build the wasm-bindgen ES module and .d.ts
         run: |
           cargo build -p cipherbox-wasm --release --target wasm32-unknown-unknown

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -69,8 +69,7 @@ jobs:
         with:
           ref: ${{ inputs.staging_tag || github.ref_name }}
 
-      # No cargo cache on the deploy path: the shipped artifact is built from a
-      # clean checkout, so no cache entry can reach a staging bundle.
+      # apps/web compiles crates/wasm into the engine artifact it bundles.
       - name: Add wasm target
         run: rustup target add wasm32-unknown-unknown
 
@@ -87,19 +86,18 @@ jobs:
         run: |
           WB_VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
           echo "wasm-bindgen ${WB_VERSION}"
-          if wasm-bindgen --version 2>/dev/null | grep -qw "${WB_VERSION}"; then
-            echo "wasm-bindgen-cli ${WB_VERSION} already present (cache hit); skipping install"
-          else
-            cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked --force
-          fi
+          cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Builds the engine WASM artifact first (apps/web `build:wasm`), then the
-      # bundle that fingerprints it.
+      # Kept separate from the bundle step so the staging secrets below never
+      # enter the environment of a cargo build script.
+      - name: Build the engine WASM artifact
+        run: pnpm --filter @cipherbox/web build:wasm
+
       - name: Build web app with staging env vars
-        run: pnpm --filter @cipherbox/web build
+        run: pnpm --filter @cipherbox/web build:bundle
         env:
           VITE_WEB3AUTH_CLIENT_ID: ${{ vars.VITE_WEB3AUTH_CLIENT_ID }}
           VITE_API_URL: ${{ vars.STAGING_API_URL }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -69,6 +69,11 @@ jobs:
         with:
           ref: ${{ inputs.staging_tag || github.ref_name }}
 
+      # No cargo cache on the deploy path: the shipped artifact is built from a
+      # clean checkout, so no cache entry can reach a staging bundle.
+      - name: Add wasm target
+        run: rustup target add wasm32-unknown-unknown
+
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -76,17 +81,23 @@ jobs:
           node-version-file: 'package.json'
           cache: 'pnpm'
 
+      # wasm-bindgen-cli generates the engine glue and must match the locked
+      # wasm-bindgen version exactly (a schema mismatch fails the run).
+      - name: Install wasm-bindgen-cli (matching Cargo.lock)
+        run: |
+          WB_VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "wasm-bindgen ${WB_VERSION}"
+          if wasm-bindgen --version 2>/dev/null | grep -qw "${WB_VERSION}"; then
+            echo "wasm-bindgen-cli ${WB_VERSION} already present (cache hit); skipping install"
+          else
+            cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked --force
+          fi
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build shared packages
-        run: |
-          pnpm --filter @cipherbox/crypto build
-          pnpm --filter @cipherbox/core build
-          pnpm --filter @cipherbox/api-client build
-          pnpm --filter @cipherbox/sdk-core build
-          pnpm --filter @cipherbox/sdk build
-
+      # Builds the engine WASM artifact first (apps/web `build:wasm`), then the
+      # bundle that fingerprints it.
       - name: Build web app with staging env vars
         run: pnpm --filter @cipherbox/web build
         env:

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -1,6 +1,8 @@
 # DORMANT during the v2 build: tests/web-e2e was demolished with the v1
 # layout; the v2 web suite lands per blueprint/testing.md and this reusable
-# workflow gets rewired to it then.
+# workflow gets rewired to it then. The rewire must add the wasm toolchain
+# `ci.yml`'s `Web Bundle` job carries — `@cipherbox/web build` compiles
+# crates/wasm.
 name: Web E2E Tests
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ yarn-error.log*
 # Test coverage
 coverage/
 
+# Generated wasm-bindgen glue for the web app's engine worker
+apps/web/src/wasm/
+
 # Playwright test results
 packages/client/test/browser/pkg/
 packages/client/playwright-report/

--- a/.prettierignore
+++ b/.prettierignore
@@ -23,6 +23,9 @@ crates/core/kat/
 # (CI openapi-freshness diffs a regeneration against the committed file)
 apps/api/openapi.json
 
+# Generated wasm-bindgen glue for the web app's engine worker
+apps/web/src/wasm/
+
 # Generated wasm-bindgen glue + Playwright output for the browser suite
 packages/client/test/browser/pkg/
 packages/client/playwright-report/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsc -b && vite",
-    "build": "tsc -b && vite build",
+    "dev": "pnpm build:wasm && tsc -b && vite",
+    "build": "pnpm build:wasm && tsc -b && vite build",
+    "build:wasm": "node scripts/build-wasm.mjs",
     "preview": "vite preview",
     "typecheck": "tsc -b",
     "test": "tsc -b && vitest run"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm build:wasm && tsc -b && vite",
-    "build": "pnpm build:wasm && tsc -b && vite build",
+    "build": "pnpm build:wasm && pnpm build:bundle",
     "build:wasm": "node scripts/build-wasm.mjs",
+    "build:bundle": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc -b",
     "test": "tsc -b && vitest run"

--- a/apps/web/scripts/build-wasm.mjs
+++ b/apps/web/scripts/build-wasm.mjs
@@ -1,21 +1,35 @@
-// Builds the production wasm-bindgen ES module the engine worker loads
-// (blueprint/web-client.md "WASM packaging"). Runs before `vite build`/`vite`
-// (see the `build:wasm` script); Vite fingerprints the emitted files through the
-// `?url` imports in src/engine/createEngineClient.ts. Release profile, and
-// without the `conformance` feature, so the engine test kit never reaches the
-// shipped artifact. Cargo is the freshness oracle — a re-run with unchanged
-// crates is a no-op.
+// Emits the engine's wasm-bindgen ES module + binary for the bundler to
+// fingerprint (blueprint/web-client.md "WASM packaging"). Release profile,
+// no `conformance` feature.
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 
 const here = import.meta.dirname;
 const repoRoot = resolve(here, '../../..');
 const outDir = resolve(here, '../src/wasm');
-const wasmArtifact = resolve(repoRoot, 'target/wasm32-unknown-unknown/release/cipherbox_wasm.wasm');
 
 const run = (command, args) => execFileSync(command, args, { cwd: repoRoot, stdio: 'inherit' });
 
-run('cargo', ['build', '-p', 'cipherbox-wasm', '--release', '--target', 'wasm32-unknown-unknown']);
+// Ask cargo where it writes rather than assuming `target/`, so a redirected
+// target dir cannot leave wasm-bindgen consuming a stale binary.
+const { target_directory: targetDir } = JSON.parse(
+  execFileSync('cargo', ['metadata', '--no-deps', '--format-version', '1'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+);
+
+// `--locked`: these are the bytes that ship, so lock drift must fail the build
+// rather than silently re-resolve the crypto crates' dependency graph.
+run('cargo', [
+  'build',
+  '--locked',
+  '-p',
+  'cipherbox-wasm',
+  '--release',
+  '--target',
+  'wasm32-unknown-unknown',
+]);
 
 run('wasm-bindgen', [
   '--target',
@@ -24,7 +38,7 @@ run('wasm-bindgen', [
   outDir,
   '--out-name',
   'cipherbox_wasm',
-  wasmArtifact,
+  resolve(targetDir, 'wasm32-unknown-unknown/release/cipherbox_wasm.wasm'),
 ]);
 
 console.log(`Engine WASM + bindings written to ${outDir}`);

--- a/apps/web/scripts/build-wasm.mjs
+++ b/apps/web/scripts/build-wasm.mjs
@@ -1,0 +1,30 @@
+// Builds the production wasm-bindgen ES module the engine worker loads
+// (blueprint/web-client.md "WASM packaging"). Runs before `vite build`/`vite`
+// (see the `build:wasm` script); Vite fingerprints the emitted files through the
+// `?url` imports in src/engine/createEngineClient.ts. Release profile, and
+// without the `conformance` feature, so the engine test kit never reaches the
+// shipped artifact. Cargo is the freshness oracle — a re-run with unchanged
+// crates is a no-op.
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const here = import.meta.dirname;
+const repoRoot = resolve(here, '../../..');
+const outDir = resolve(here, '../src/wasm');
+const wasmArtifact = resolve(repoRoot, 'target/wasm32-unknown-unknown/release/cipherbox_wasm.wasm');
+
+const run = (command, args) => execFileSync(command, args, { cwd: repoRoot, stdio: 'inherit' });
+
+run('cargo', ['build', '-p', 'cipherbox-wasm', '--release', '--target', 'wasm32-unknown-unknown']);
+
+run('wasm-bindgen', [
+  '--target',
+  'web',
+  '--out-dir',
+  outDir,
+  '--out-name',
+  'cipherbox_wasm',
+  wasmArtifact,
+]);
+
+console.log(`Engine WASM + bindings written to ${outDir}`);

--- a/apps/web/src/engine/config.test.ts
+++ b/apps/web/src/engine/config.test.ts
@@ -1,36 +1,40 @@
 import { describe, expect, it } from 'vitest';
 import { engineHostConfig } from './config';
 
+const artifact = {
+  wasmModuleUrl: '/assets/cipherbox_wasm-deadbeef.js',
+  wasmBinaryUrl: '/assets/cipherbox_wasm_bg-deadbeef.wasm',
+};
+
 describe('engineHostConfig', () => {
   it('splits the routing endpoint set on commas', () => {
-    const config = engineHostConfig({
-      VITE_ROUTING_ENDPOINTS: ' https://someguy.example.test , https://public.example.test ',
-    });
+    const config = engineHostConfig(
+      {
+        VITE_ROUTING_ENDPOINTS: ' https://someguy.example.test , https://public.example.test ',
+      },
+      artifact
+    );
     expect(config.recordEndpoints).toEqual([
       'https://someguy.example.test',
       'https://public.example.test',
     ]);
   });
 
-  it('carries the API origin and the wasm artifact URLs through', () => {
-    const config = engineHostConfig({
-      VITE_API_URL: 'https://api.example.test',
-      VITE_WASM_MODULE_URL: '/assets/engine.js',
-      VITE_WASM_BINARY_URL: '/assets/engine.wasm',
-    });
+  it('carries the API origin and the bundler-resolved artifact URLs through', () => {
+    const config = engineHostConfig({ VITE_API_URL: 'https://api.example.test' }, artifact);
     expect(config.apiBaseUrl).toBe('https://api.example.test');
-    expect(config.wasmModuleUrl).toBe('/assets/engine.js');
-    expect(config.wasmBinaryUrl).toBe('/assets/engine.wasm');
+    expect(config.wasmModuleUrl).toBe(artifact.wasmModuleUrl);
+    expect(config.wasmBinaryUrl).toBe(artifact.wasmBinaryUrl);
   });
 
   it('rejects a routing endpoint set that parses to nothing', () => {
-    expect(() => engineHostConfig({ VITE_ROUTING_ENDPOINTS: ' , ' })).toThrow(
+    expect(() => engineHostConfig({ VITE_ROUTING_ENDPOINTS: ' , ' }, artifact)).toThrow(
       /VITE_ROUTING_ENDPOINTS/
     );
   });
 
   it('falls back to defaults for an unconfigured environment', () => {
-    const config = engineHostConfig({});
+    const config = engineHostConfig({}, artifact);
     expect(config.apiBaseUrl).toBe('http://localhost:3000');
     expect(config.recordEndpoints).toEqual(['https://delegated-ipfs.dev']);
   });

--- a/apps/web/src/engine/config.ts
+++ b/apps/web/src/engine/config.ts
@@ -3,13 +3,13 @@ import type { EngineHostConfig } from '@cipherbox/client';
 const DEFAULT_API_URL = 'http://localhost:3000';
 const DEFAULT_ROUTING_ENDPOINTS = 'https://delegated-ipfs.dev';
 
-/** Where the bundler placed the engine's WASM artifact; not environment-configurable. */
-export type WasmArtifactUrls = Pick<EngineHostConfig, 'wasmModuleUrl' | 'wasmBinaryUrl'>;
-
-/** Reads the app's build-time environment into the engine host's configuration. */
+/**
+ * Reads the app's build-time environment into the engine host's configuration.
+ * The artifact URLs come from the bundler, not the environment.
+ */
 export function engineHostConfig(
   env: Partial<ImportMetaEnv>,
-  artifact: WasmArtifactUrls
+  artifact: Pick<EngineHostConfig, 'wasmModuleUrl' | 'wasmBinaryUrl'>
 ): EngineHostConfig {
   const recordEndpoints = (env.VITE_ROUTING_ENDPOINTS ?? DEFAULT_ROUTING_ENDPOINTS)
     .split(',')

--- a/apps/web/src/engine/config.ts
+++ b/apps/web/src/engine/config.ts
@@ -2,11 +2,15 @@ import type { EngineHostConfig } from '@cipherbox/client';
 
 const DEFAULT_API_URL = 'http://localhost:3000';
 const DEFAULT_ROUTING_ENDPOINTS = 'https://delegated-ipfs.dev';
-const DEFAULT_WASM_MODULE_URL = '/wasm/cipherbox_wasm.js';
-const DEFAULT_WASM_BINARY_URL = '/wasm/cipherbox_wasm_bg.wasm';
+
+/** Where the bundler placed the engine's WASM artifact; not environment-configurable. */
+export type WasmArtifactUrls = Pick<EngineHostConfig, 'wasmModuleUrl' | 'wasmBinaryUrl'>;
 
 /** Reads the app's build-time environment into the engine host's configuration. */
-export function engineHostConfig(env: Partial<ImportMetaEnv>): EngineHostConfig {
+export function engineHostConfig(
+  env: Partial<ImportMetaEnv>,
+  artifact: WasmArtifactUrls
+): EngineHostConfig {
   const recordEndpoints = (env.VITE_ROUTING_ENDPOINTS ?? DEFAULT_ROUTING_ENDPOINTS)
     .split(',')
     .map((endpoint) => endpoint.trim())
@@ -19,7 +23,6 @@ export function engineHostConfig(env: Partial<ImportMetaEnv>): EngineHostConfig 
   return {
     apiBaseUrl: env.VITE_API_URL ?? DEFAULT_API_URL,
     recordEndpoints,
-    wasmModuleUrl: env.VITE_WASM_MODULE_URL ?? DEFAULT_WASM_MODULE_URL,
-    wasmBinaryUrl: env.VITE_WASM_BINARY_URL ?? DEFAULT_WASM_BINARY_URL,
+    ...artifact,
   };
 }

--- a/apps/web/src/engine/createEngineClient.ts
+++ b/apps/web/src/engine/createEngineClient.ts
@@ -1,8 +1,7 @@
 import { EngineClient, spawnEngineWorker } from '@cipherbox/client';
 import { engineHostConfig } from './config';
-// `?url` hands the engine worker the artifact's built URL instead of inlining
-// it here: Vite emits both files as content-hashed assets, so the artifact is
-// fingerprinted and served immutable (blueprint/web-client.md "WASM packaging").
+// Content-hashed by Vite, so the artifact is served immutable
+// (blueprint/web-client.md "WASM packaging").
 import wasmModuleUrl from '../wasm/cipherbox_wasm.js?url';
 import wasmBinaryUrl from '../wasm/cipherbox_wasm_bg.wasm?url';
 

--- a/apps/web/src/engine/createEngineClient.ts
+++ b/apps/web/src/engine/createEngineClient.ts
@@ -1,5 +1,10 @@
 import { EngineClient, spawnEngineWorker } from '@cipherbox/client';
 import { engineHostConfig } from './config';
+// `?url` hands the engine worker the artifact's built URL instead of inlining
+// it here: Vite emits both files as content-hashed assets, so the artifact is
+// fingerprinted and served immutable (blueprint/web-client.md "WASM packaging").
+import wasmModuleUrl from '../wasm/cipherbox_wasm.js?url';
+import wasmBinaryUrl from '../wasm/cipherbox_wasm_bg.wasm?url';
 
 /**
  * Wires this tab's engine client to the browser: `navigator.locks` drives the
@@ -7,7 +12,7 @@ import { engineHostConfig } from './config';
  * (blueprint/web-client.md "Engine hosting and tab leadership").
  */
 export function createEngineClient(): EngineClient {
-  const host = engineHostConfig(import.meta.env);
+  const host = engineHostConfig(import.meta.env, { wasmModuleUrl, wasmBinaryUrl });
   return new EngineClient({
     locks: navigator.locks,
     spawnWorker: () => spawnEngineWorker(host),

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,6 +6,7 @@ import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 import { App } from './App';
+import { createEngineClient } from './engine/createEngineClient';
 import { EngineProvider } from './providers/EngineProvider';
 
 const rootElement = document.getElementById('root');
@@ -18,7 +19,7 @@ const queryClient = new QueryClient();
 createRoot(rootElement).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <EngineProvider>
+      <EngineProvider createClient={createEngineClient}>
         <BrowserRouter>
           <App />
         </BrowserRouter>

--- a/apps/web/src/providers/EngineProvider.tsx
+++ b/apps/web/src/providers/EngineProvider.tsx
@@ -1,14 +1,17 @@
 import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
 import type { EngineClient } from '@cipherbox/client';
-import { createEngineClient } from '../engine/createEngineClient';
 
 // `undefined` distinguishes "no provider above me" from "provider mounted,
 // client not built yet".
 const EngineContext = createContext<EngineClient | null | undefined>(undefined);
 
 export interface EngineProviderProps {
-  /** Builds this tab's engine client. Read once, on mount. */
-  createClient?: () => EngineClient;
+  /**
+   * Builds this tab's engine client. Read once, on mount. Injected rather than
+   * defaulted so the WASM artifact stays out of this module's import graph —
+   * only the composition root resolves it.
+   */
+  createClient: () => EngineClient;
   children: ReactNode;
 }
 
@@ -18,10 +21,7 @@ export interface EngineProviderProps {
  * never duplicated. Construction runs in an effect so a StrictMode double-mount
  * disposes the throwaway client rather than leaking a second lock contender.
  */
-export function EngineProvider({
-  createClient = createEngineClient,
-  children,
-}: EngineProviderProps) {
+export function EngineProvider({ createClient, children }: EngineProviderProps) {
   const [client, setClient] = useState<EngineClient | null>(null);
   const factory = useRef(createClient);
 

--- a/apps/web/src/providers/EngineProvider.tsx
+++ b/apps/web/src/providers/EngineProvider.tsx
@@ -6,11 +6,7 @@ import type { EngineClient } from '@cipherbox/client';
 const EngineContext = createContext<EngineClient | null | undefined>(undefined);
 
 export interface EngineProviderProps {
-  /**
-   * Builds this tab's engine client. Read once, on mount. Injected rather than
-   * defaulted so the WASM artifact stays out of this module's import graph —
-   * only the composition root resolves it.
-   */
+  /** Builds this tab's engine client. Read once, on mount. */
   createClient: () => EngineClient;
   children: ReactNode;
 }

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -5,6 +5,4 @@ interface ImportMetaEnv {
   readonly VITE_API_URL?: string;
   /** Comma-separated `/routing/v1` origins: someguy plus a public endpoint. */
   readonly VITE_ROUTING_ENDPOINTS?: string;
-  readonly VITE_WASM_MODULE_URL?: string;
-  readonly VITE_WASM_BINARY_URL?: string;
 }

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -12,9 +12,17 @@ This guide takes you from a fresh checkout to a running local stack.
 | Node.js        | 20+        | Used by all JS/TS workspaces                   |
 | pnpm           | 10.33.0    | Declared in `packageManager` field             |
 | Docker         | Any recent | Runs PostgreSQL, IPFS, Redis, and mock routing |
-| Rust toolchain | stable     | Desktop app only (`apps/desktop`)              |
+| Rust toolchain | stable     | Desktop app, and the web app's engine WASM     |
 
 No `.nvmrc` is present; use your system Node version manager to select Node 20+.
+
+`apps/web` compiles `crates/wasm` into the engine worker's artifact on every `dev`/`build`, so it also
+needs the browser target and a `wasm-bindgen-cli` matching the `wasm-bindgen` version in `Cargo.lock`:
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo install wasm-bindgen-cli --version "$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')" --locked
+```
 
 For the desktop app, also install the platform FUSE driver:
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,8 +15,7 @@ export default [
       '**/.learnings/**',
       '**/src-tauri/target/**',
       'target/**',
-      // Generated wasm-bindgen glue: the web app's engine artifact, and the
-      // browser suite's conformance copy alongside its Playwright output.
+      // Generated wasm-bindgen glue + Playwright output for the browser suite.
       'apps/web/src/wasm/**',
       '**/test/browser/pkg/**',
       '**/playwright-report/**',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,9 @@ export default [
       '**/.learnings/**',
       '**/src-tauri/target/**',
       'target/**',
-      // Generated wasm-bindgen glue + Playwright output for the browser suite.
+      // Generated wasm-bindgen glue: the web app's engine artifact, and the
+      // browser suite's conformance copy alongside its Playwright output.
+      'apps/web/src/wasm/**',
       '**/test/browser/pkg/**',
       '**/playwright-report/**',
       '**/test-results/**',


### PR DESCRIPTION
## Problem

`apps/web` handed the engine worker `/wasm/cipherbox_wasm.js` and `/wasm/cipherbox_wasm_bg.wasm`; nothing in the repo produced them. The worker's dynamic import 404'd, it posted `fatal`, and every facade call after that rejected — no cold start was possible.

## Serving decision

**Chosen: keep the URL-bootstrap contract from #883, and source the URLs from Vite's asset pipeline.** `apps/web` builds the production artifact into a git-ignored `src/wasm/` and imports it with `?url`; Vite emits both files as content-hashed assets and `createEngineClient` passes those URLs into `spawnEngineWorker`. That satisfies `blueprint/web-client.md` — "Vite fingerprints and serves it immutable" — with no copy step and no plugin. Verified in `dist/`:

```text
dist/assets/cipherbox_wasm-u_hqEYR0.js          53.75 kB
dist/assets/cipherbox_wasm_bg-5UKrWUfR.wasm  1,051.34 kB
```

**Rejected: `public/wasm/` at a fixed path.** `public/` does not fingerprint, so it fails the blueprint outright, and Caddy's `try_files {path} /index.html` on the staging vhost turns a missing artifact into a 200 `text/html` — a confusing MIME failure instead of a 404.

**Rejected: statically importing the glue in the worker** like the browser suite does. It would work, but it discards the `wasmModuleUrl`/`wasmBinaryUrl` seam #883 just landed and moves artifact resolution from the app into `packages/client`, which has no business knowing where the host put the file.

The `VITE_WASM_MODULE_URL` / `VITE_WASM_BINARY_URL` env vars are gone. They were a build-time knob that could aim the worker's `import()` at an arbitrary origin — the one realm that holds key material. The artifact is now same-origin and content-addressed by construction.

## Keeping Rust off the TS-only build path

- `pnpm --filter @cipherbox/web build` runs `build:wasm` first: `cargo build --locked -p cipherbox-wasm --release --target wasm32-unknown-unknown` plus `wasm-bindgen --target web`, mirroring the browser suite's script but with the release profile and no `conformance` feature. Cargo is the freshness oracle, so a re-run with unchanged crates is a no-op.
- The required `Build` job no longer builds `@cipherbox/web` and stays pnpm-only.
- A new `Web Bundle` job carries the wasm toolchain, gated on a new `web` paths-filter output — `apps/web/**`, `packages/client/**`, `crates/**`, the lockfiles. An `apps/api`- or `apps/desktop`-only PR pays nothing. It caches only `target/wasm32-unknown-unknown` rather than a fourth full `target` tree.
- The staging deploy's `build-web` job gets the same toolchain, but builds the artifact in its own step so the staging secrets never enter a cargo build script's environment. Its `Build shared packages` step, which enumerated five v1 packages that no longer exist, is dropped — `tsc -b` builds `@cipherbox/client` through the project reference.

## Gate

`Web Bundle` fails if the artifact is missing or the bundle does not carry it — verified both ways locally: `vite build` hard-errors on the unresolved `?url` import when `src/wasm/` is absent, and the post-build `ls` of the two fingerprinted assets exits non-zero when they are not emitted.

The gate named in the issue also includes the engine reaching its first snapshot event in the web login-and-CRUD e2e smoke slice, which is #809 and does not exist yet.

**`Web Bundle` must be added to `main`'s required status checks at merge time.** It is not there today, and this PR moves the web bundle out of the required `Build` job — `Typecheck` and `Test` still cover apps/web's `tsc -b`, but nothing required runs `vite build` until that entry is added.

## Runtime proof

Against the built bundle under `vite preview`, a module worker loaded from `dist/assets/engineWorker-*.js` and bootstrapped with the two emitted asset URLs answers `{"type":"ready"}` — the glue imported, `init` instantiated the binary, the browser seams built, and `serveEngine` came up. No `fatal`. Same result against the dev server. The shipped `index-*.js` contains those exact URLs, and the app takes the `cipherbox-engine` Web Lock on load.

## Review gates

`/simplify`, `/security-review`, and `/crypto-privacy-review` all ran against `git diff main...HEAD`; findings folded into the second commit. The crypto pass confirmed the `conformance` feature cannot reach the shipped artifact — not a default feature, no crate depends on `cipherbox-wasm`, no `--features` in the build, and the emitted `.d.ts` carries none of the conformance runners — and that `--release` loses no fail-closed check: the single `debug_assert!` in `crates/core`/`crates/engine` production code is a redundant early-catch behind a release-active `body.validate()?`.

Follow-up filed: #888, CSP and `nosniff` on the staging web vhost.

Not addressed here, deliberately: `Core KATs` still builds the same release artifact for its own freshness check, and the wasm toolchain setup block now exists in four workflow jobs. Both are dedup work across required jobs this slice does not touch.

Closes #882
Blocks #803
Part of #642


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic WebAssembly engine builds for web development and production bundles.
  * WebAssembly assets are now fingerprinted and loaded directly by the web application.

* **Bug Fixes**
  * Improved web build reliability by ensuring required Rust and WebAssembly tooling runs before bundling.

* **Documentation**
  * Updated setup instructions with Rust, WebAssembly target, and wasm-bindgen requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->