### PR TITLE
feat(engine): publish the remaining four op kinds under the reference-ordering law

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -33,3 +33,6 @@ hex = "0.4"
 # hand-feed the adoption-gate simulation harness (core is already a normal
 # dependency; this line makes it addressable from `tests/`).
 cipherbox-core.workspace = true
+# Same reason: `RecordSeal` takes a zeroizing ephemeral scalar, so a test that
+# stages an op directly needs the type addressable from `tests/`.
+zeroize.workspace = true

--- a/crates/engine/src/grants/child_index.rs
+++ b/crates/engine/src/grants/child_index.rs
@@ -69,7 +69,9 @@ pub fn insert_child(index: &[ChildScopeRef], child: ChildScopeRef) -> Vec<ChildS
     canonicalize(&next)
 }
 
-/// Presence-conditional remove by `scope_id`. Idempotent: removing an absent
+/// Presence-conditional remove by `scope_id` — also this index's race-loser
+/// dest-add compensation, which a distributed publish boundary must run through
+/// the fail-closed [`undo_dest_add_versioned`]. Idempotent: removing an absent
 /// `scope_id` is a no-op, never an error.
 pub fn remove_child(index: &[ChildScopeRef], scope_id: &[u8; 16]) -> Vec<ChildScopeRef> {
     let next: Vec<ChildScopeRef> = index
@@ -104,23 +106,17 @@ pub fn repair_observed(index: &[ChildScopeRef], child: ChildScopeRef) -> Vec<Chi
     insert_child(index, child)
 }
 
-/// Unversioned local dest-add compensation; a distributed publish boundary must
-/// use the fail-closed [`undo_dest_add_versioned`] instead.
-pub(crate) fn undo_dest_add(dest: &[ChildScopeRef], scope_id: &[u8; 16]) -> Vec<ChildScopeRef> {
-    remove_child(dest, scope_id)
-}
-
-/// The read-version a dest-add was derived against: the dest parent scope root's
-/// published record sequence — the same monotonic seq-CAS key the net publish
-/// path mints against (`net::publish`, blueprint/engine.md "CAS sequencing").
+/// The read-version a dest-add was derived against: the dest parent's published
+/// record sequence — the same monotonic seq-CAS key the net publish path mints
+/// against (`net::publish`, blueprint/engine.md "CAS sequencing").
 pub type DestIndexVersion = u64;
 
-/// Outcome of a versioned dest-add compensation.
+/// Outcome of a versioned dest-add compensation over an index of `T`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum UndoDestAdd {
+pub enum UndoDestAdd<T> {
     /// The dest index was still at the CAS base the add read: the dest-add was
     /// removed cleanly. Carries the recomputed index to publish.
-    Removed(Vec<ChildScopeRef>),
+    Removed(Vec<T>),
     /// A concurrent authoritative writer advanced the dest index past the CAS
     /// base: a blind remove would clobber the winner. Fail-closed.
     Conflict,
@@ -132,16 +128,20 @@ pub enum UndoDestAdd {
 /// [`UndoDestAdd::Conflict`] rather than blind-removing, so a concurrent
 /// authoritative write always wins and the caller re-reads + re-derives instead
 /// of clobbering it (#743, deferred from #741; blueprint/engine.md).
-pub fn undo_dest_add_versioned(
-    dest: &[ChildScopeRef],
-    scope_id: &[u8; 16],
+///
+/// The version rule is index-agnostic — it governs the direct-child-scope index
+/// here and a folder's own child list in the drain's relink envelope (#786) —
+/// so `remove` stays the caller's, carrying that index's own removal semantics.
+pub fn undo_dest_add_versioned<T>(
+    dest: &[T],
+    remove: impl FnOnce(&[T]) -> Vec<T>,
     cas_base: DestIndexVersion,
     observed: DestIndexVersion,
-) -> UndoDestAdd {
+) -> UndoDestAdd<T> {
     if observed != cas_base {
         return UndoDestAdd::Conflict;
     }
-    UndoDestAdd::Removed(undo_dest_add(dest, scope_id))
+    UndoDestAdd::Removed(remove(dest))
 }
 
 #[cfg(test)]
@@ -308,32 +308,39 @@ mod tests {
     }
 
     #[test]
-    fn undo_dest_add_reverses_insert() {
-        let moving = child(0x44, "x");
-        let dest = vec![child(0x10, "d1")];
-        let added = insert_child(&dest, moving.clone());
-        let undone = undo_dest_add(&added, &[0x44; 16]);
-        assert_eq!(undone, canonicalize(&dest));
-    }
-
-    #[test]
     fn versioned_compensation_removes_only_when_the_version_is_unchanged() {
         // The loser added itself to the dest index it read at CAS base seq 7.
         let moving = child(0x44, "x");
         let base = vec![child(0x10, "d1")];
         let added = insert_child(&base, moving.clone());
         let cas_base: DestIndexVersion = 7;
+        let undo = |dest: &[ChildScopeRef]| remove_child(dest, &[0x44; 16]);
 
         // Dest index still at seq 7: the compensation removes its own add.
-        let unchanged = undo_dest_add_versioned(&added, &[0x44; 16], cas_base, 7);
+        let unchanged = undo_dest_add_versioned(&added, undo, cas_base, 7);
         assert_eq!(unchanged, UndoDestAdd::Removed(canonicalize(&base)));
 
         // A concurrent authoritative writer bumped the dest to seq 8: fail closed,
         // never remove — the winner's newer state stands untouched.
-        let raced = undo_dest_add_versioned(&added, &[0x44; 16], cas_base, 8);
+        let raced = undo_dest_add_versioned(&added, undo, cas_base, 8);
         assert_eq!(raced, UndoDestAdd::Conflict);
         // A stale/lower observed version is a divergence too — also fail-closed.
-        let stale = undo_dest_add_versioned(&added, &[0x44; 16], cas_base, 6);
+        let stale = undo_dest_add_versioned(&added, undo, cas_base, 6);
         assert_eq!(stale, UndoDestAdd::Conflict);
+    }
+
+    #[test]
+    fn versioned_compensation_carries_any_indexs_own_removal() {
+        // The rule is the version compare; the removal belongs to the index.
+        let dest = vec![7u8, 8, 9];
+        let drop_eight = |d: &[u8]| d.iter().copied().filter(|e| *e != 8).collect();
+        assert_eq!(
+            undo_dest_add_versioned(&dest, drop_eight, 3, 3),
+            UndoDestAdd::Removed(vec![7, 9])
+        );
+        assert_eq!(
+            undo_dest_add_versioned(&dest, drop_eight, 3, 4),
+            UndoDestAdd::Conflict
+        );
     }
 }

--- a/crates/engine/src/net/author.rs
+++ b/crates/engine/src/net/author.rs
@@ -382,24 +382,33 @@ mod tests {
 
     #[test]
     fn a_body_the_decoder_would_refuse_is_never_sealed() {
-        let dup = ChildRef {
-            id: [7u8; 16],
+        // Release-active (security rule 8): core's `assert_children_unique`
+        // returns `Err` on both halves of the uniqueness invariant, so a folder
+        // rewrite — a create's parent add, a relink's dest-add — can never sign
+        // a listing its own decoder always rejects.
+        let child = |id: u8, ipns_name: &[u8]| ChildRef {
+            id: [id; 16],
             name: "a".into(),
-            ipns_name: b"n".to_vec(),
+            ipns_name: ipns_name.to_vec(),
             kind: NodeKind::File,
             link_counter: 1,
             unknown: Vec::new(),
         };
-        let body = ReadBody::Folder {
+        let folder = |children| ReadBody::Folder {
             created_at: 0,
             modified_at: 0,
-            children: vec![dup.clone(), dup],
+            children,
             unknown: Vec::new(),
         };
-        assert!(matches!(
-            author_child_envelope(authoring(&body, Vec::new())).unwrap_err(),
-            AuthorError::Seal(_)
-        ));
+        for children in [
+            vec![child(7, b"n"), child(7, b"other")],
+            vec![child(7, b"n"), child(8, b"n")],
+        ] {
+            assert!(matches!(
+                author_child_envelope(authoring(&folder(children), Vec::new())).unwrap_err(),
+                AuthorError::Seal(_)
+            ));
+        }
     }
 
     #[test]

--- a/crates/engine/src/net/child.rs
+++ b/crates/engine/src/net/child.rs
@@ -193,7 +193,17 @@ impl<H: Http, F: FloorStore> ChildAdopter<'_, H, F> {
 impl<H: Http, F: FloorStore> Adopter for ChildAdopter<'_, H, F> {
     async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<AdoptOutcome, GateError> {
         let (sequence, envelope) = self.assemble_envelope(name, record_bytes).await?;
-        if let Err(err) = floor::check(
+        // Keep the assembled head whatever the floor says: both the equal-floor
+        // re-open and the write path's carried-field read go back through
+        // [`open_carried_at_floor`], which re-fetches the same head block
+        // otherwise.
+        *self.assembled.borrow_mut() = Some(AssembledChild {
+            name: name.clone(),
+            record_bytes: record_bytes.to_vec(),
+            sequence,
+            envelope: envelope.clone(),
+        });
+        floor::check(
             self.floors,
             name.as_str().as_bytes(),
             &self.scope_id,
@@ -201,18 +211,7 @@ impl<H: Http, F: FloorStore> Adopter for ChildAdopter<'_, H, F> {
             envelope.epoch,
             floor::Strictness::StrictlyNewer,
         )
-        .await
-        {
-            // Keep the assembled head for the equal-floor re-open path — it
-            // re-fetches the same head block otherwise.
-            *self.assembled.borrow_mut() = Some(AssembledChild {
-                name: name.clone(),
-                record_bytes: record_bytes.to_vec(),
-                sequence,
-                envelope,
-            });
-            return Err(err);
-        }
+        .await?;
         let read_body = self.unseal(&envelope)?;
         // Sequence floor only, after the AAD-confirmed unseal (the floor law).
         floor::advance_sequence_on_unseal(self.floors, name.as_str().as_bytes(), sequence)

--- a/crates/engine/src/net/child.rs
+++ b/crates/engine/src/net/child.rs
@@ -146,6 +146,18 @@ impl<H: Http, F: FloorStore> ChildAdopter<'_, H, F> {
         name: &IpnsName,
         record_bytes: &[u8],
     ) -> Result<Adopted, GateError> {
+        self.open_carried_at_floor(name, record_bytes)
+            .await
+            .map(|(adopted, _)| adopted)
+    }
+
+    /// [`open_at_floor`](Self::open_at_floor) keeping the decoded envelope, so a
+    /// re-author can carry its unknown fields forward byte-stable (#27 D10).
+    pub(crate) async fn open_carried_at_floor(
+        &self,
+        name: &IpnsName,
+        record_bytes: &[u8],
+    ) -> Result<(Adopted, Envelope), GateError> {
         // Reuse the envelope the floor-rejected adopt assembled for these same
         // bytes; assembling again re-fetches the head block.
         let cached = self
@@ -167,11 +179,14 @@ impl<H: Http, F: FloorStore> ChildAdopter<'_, H, F> {
         )
         .await?;
         let read_body = self.unseal(&envelope)?;
-        Ok(Adopted {
-            read_body,
-            sequence,
-            epoch: envelope.epoch,
-        })
+        Ok((
+            Adopted {
+                read_body,
+                sequence,
+                epoch: envelope.epoch,
+            },
+            envelope,
+        ))
     }
 }
 

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -44,6 +44,7 @@ pub mod revival;
 pub(crate) use adopter::assemble_head_envelope;
 pub use adopter::{LocalHead, RootAdopter};
 pub use child::ChildAdopter;
+pub(crate) use fanout::fanout_get_verify;
 pub(crate) use liveness::eol_renew_pass;
 pub use liveness::{
     EolRenewResult, HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, RePutResult,

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -394,8 +394,7 @@ pub(crate) fn refresh_base_from_outcome(
 ) -> bool {
     match outcome {
         ResolveOutcome::Adopted(adopted) => {
-            let projected = project_root(root, adopted, &base.borrow());
-            *base.borrow_mut() = projected;
+            project_root(&mut base.borrow_mut(), root, adopted);
             true
         }
         _ => false,

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -239,10 +239,11 @@ where
     // Project the gate-passing root read-body to its direct children (E7); an
     // availability-stale current record leaves the base at the anchored root.
     let (root_resolve, base) = match resolved.outcome {
-        ResolveOutcome::Adopted(adopted) => (
-            RootResolve::Adopted,
-            project_root(params.root, &adopted, &base),
-        ),
+        ResolveOutcome::Adopted(adopted) => {
+            let mut base = base;
+            project_root(&mut base, params.root, &adopted);
+            (RootResolve::Adopted, base)
+        }
         // Cold start paints, it does not hold: our own current record at the
         // floor is availability staleness here, same as nothing newer fetched.
         ResolveOutcome::NoUpdate | ResolveOutcome::Current { .. } => (RootResolve::NoUpdate, base),

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -2,23 +2,25 @@
 //! resolvable records (blueprint/engine.md "Sync core", "Resolve/publish
 //! pipeline").
 //!
-//! One pass rebases the durable queue onto gate-passing state
-//! ([`replay`]) and publishes each applied op **referent before reference** —
-//! the child's own record first, then the parent that names it — so a partial
-//! drain can leave an unreferenced record but never a child ref pointing at a
-//! name nothing resolves.
+//! One pass rebases the durable queue onto gate-passing state ([`replay`]) and
+//! publishes each applied op under one law: **a reference must never outlive
+//! its referent** (#819). Child before parent, dest-add before source-remove,
+//! and strict FIFO stopping at the first failure — so a partial drain can leave
+//! an unreferenced record but never a ref pointing at a name nothing resolves.
 //!
 //! Every published record is fed straight back through the adoption gate from
 //! the bytes in hand: the write path skips the fetch, never the gate, and the
 //! per-name sequence floor advances only as the gate's stage-6 consequence
 //! (#817; `gate/floor.rs` stays the only place floors move).
 //!
-//! This slice drains folder creates only; the first op it cannot publish stops
-//! the pass with the op still queued, so FIFO order is never broken.
+//! Out of this slice: content bytes (#868), cross-scope re-seal and the
+//! scope-exit rotation trigger (#635), and failure classification (#867) — the
+//! first op this pass cannot publish stops it with the op still queued.
 
 use core::cell::RefCell;
 use std::collections::BTreeSet;
 
+use cipherbox_core::codec::Value;
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{ChildRef, NodeKind as CoreNodeKind, ReadBody, open_read_body};
@@ -30,6 +32,7 @@ use crate::api::ApiClient;
 use crate::content::Gateway;
 use crate::entropy::Entropy;
 use crate::facade::{NodeId, NodeKind};
+use crate::grants::{UndoDestAdd, undo_dest_add_versioned};
 use crate::net::author::{
     AuthoredHead, ENVELOPE_V, EnvelopeAuthoring, author_child_envelope, author_scope_root_envelope,
     new_child,
@@ -37,8 +40,8 @@ use crate::net::author::{
 use crate::net::publish::{PublishOutcome, PublishReceipt};
 use crate::net::record_publish::{HeadBinding, RecordPublishRequest, preflight, publish_record};
 use crate::net::{
-    AdoptOutcome, Adopter, ChildAdopter, HeldRecord, HeldRecords, LocalHead, RootAdopter,
-    assemble_head_envelope,
+    Adopter, ChildAdopter, HeldRecord, HeldRecords, LocalHead, ResolveOutcome, RootAdopter,
+    assemble_head_envelope, resolve,
 };
 use crate::profile::SyncTimingProfile;
 use crate::rotation::derive_write_name;
@@ -50,8 +53,8 @@ use crate::session::SessionIdentity;
 use crate::sync::model::Snapshot;
 use crate::sync::op::{Op, OpKind};
 use crate::sync::overlay::apply_overlay;
-use crate::sync::project::project_root;
-use crate::sync::rebase::{DeadLetterReason, decode_queue, replay};
+use crate::sync::project::project_folder;
+use crate::sync::rebase::{AppliedOp, DeadLetterReason, decode_queue, replay};
 use crate::sync::record::RecordReader;
 
 /// The staging key holding the drained-op high-water mark: every op id at or
@@ -134,15 +137,82 @@ pub(crate) struct Drain<'a, T, H: Http, C: CredentialStore, F, S, St, Sch> {
     pub(crate) held: &'a RefCell<HeldRecords>,
 }
 
-/// The scope root's current published state, carried across the ops of one
-/// pass so each publish authors onto the previous one.
-struct RootState {
-    envelope_unknown: Vec<(String, cipherbox_core::codec::Value)>,
-    epoch_tag_unknown: Vec<(String, cipherbox_core::codec::Value)>,
-    epoch: u64,
+/// One folder's current published state, carried across the ops of one pass so
+/// each publish authors onto the previous one.
+struct FolderState {
+    /// The write-plane name this folder publishes under.
+    name: IpnsName,
+    /// The scope root carries the grant section and authors through a different
+    /// envelope path; every other folder is a plain child record.
+    is_scope_root: bool,
+    envelope_unknown: Vec<(String, Value)>,
+    epoch_tag_unknown: Vec<(String, Value)>,
     created_at: u64,
+    modified_at: u64,
     children: Vec<ChildRef>,
-    body_unknown: Vec<(String, cipherbox_core::codec::Value)>,
+    body_unknown: Vec<(String, Value)>,
+    /// The record sequence this folder is published at — the dest-add
+    /// compensation's CAS base.
+    sequence: u64,
+}
+
+/// One node's record as loaded for re-authoring: the envelope fields a
+/// republish must carry forward byte-stable (#27 D10) plus the opened body.
+struct LoadedNode {
+    name: IpnsName,
+    sequence: u64,
+    envelope_unknown: Vec<(String, Value)>,
+    epoch_tag_unknown: Vec<(String, Value)>,
+    body: ReadBody,
+}
+
+/// One record as this pass published it.
+struct Published {
+    /// The sequence the self-adopt authenticated.
+    sequence: u64,
+    /// The live-set entry, held once something references the record.
+    held: HeldRecord,
+}
+
+/// The scope state one pass mutates: the epoch every record is sealed at, and
+/// the folders loaded so far in **ancestor-first load order**, which is also
+/// the order the base repaint depends on.
+struct Pass {
+    epoch: u64,
+    folders: Vec<(NodeId, FolderState)>,
+}
+
+impl Pass {
+    fn holds(&self, folder: NodeId) -> bool {
+        self.folders.iter().any(|(id, _)| *id == folder)
+    }
+
+    fn insert(&mut self, folder: NodeId, state: FolderState) {
+        self.folders.push((folder, state));
+    }
+
+    fn folder(&self, folder: NodeId) -> Result<&FolderState, Halt> {
+        self.folders
+            .iter()
+            .find(|(id, _)| *id == folder)
+            .map(|(_, state)| state)
+            .ok_or(Halt)
+    }
+
+    fn folder_mut(&mut self, folder: NodeId) -> Result<&mut FolderState, Halt> {
+        self.folders
+            .iter_mut()
+            .find(|(id, _)| *id == folder)
+            .map(|(_, state)| state)
+            .ok_or(Halt)
+    }
+
+    fn replace(&mut self, folder: NodeId, state: FolderState) {
+        match self.folders.iter_mut().find(|(id, _)| *id == folder) {
+            Some(slot) => slot.1 = state,
+            None => self.insert(folder, state),
+        }
+    }
 }
 
 impl<T, H, C, F, S, St, Sch> Drain<'_, T, H, C, F, S, St, Sch>
@@ -177,7 +247,7 @@ where
             return Ok(());
         }
 
-        let mut root = self.load_root(scope).await?;
+        let mut pass = self.open_pass(scope).await?;
         let rebased = {
             let base = self.base.borrow();
             let ops: Vec<Op> = queued.iter().map(|(_, op)| op.clone()).collect();
@@ -200,7 +270,7 @@ where
         }
 
         for applied in &rebased.applied {
-            self.publish_applied(scope, &mut root, applied, &rebased.rebased)
+            self.publish_applied(scope, &mut pass, applied, &rebased.rebased)
                 .await?;
             self.retire_op(applied.op_id).await?;
             report.published.push(applied.op_id);
@@ -234,9 +304,26 @@ where
         Ok(live)
     }
 
+    // -----------------------------------------------------------------------
+    // Loading the folders a pass authors onto.
+    // -----------------------------------------------------------------------
+
+    /// Open a pass anchored on the scope root, whose epoch every record this
+    /// pass seals is bound to.
+    async fn open_pass(&self, scope: &DrainScope<'_>) -> Result<Pass, Halt> {
+        let (root, epoch) = self.load_scope_root(scope).await?;
+        let mut pass = Pass {
+            epoch,
+            folders: Vec::new(),
+        };
+        self.repaint_folder(scope.root, &root.children, root.sequence, root.modified_at);
+        pass.insert(scope.root, root);
+        Ok(pass)
+    }
+
     /// The scope root as currently published: its envelope's carried fields and
-    /// its unsealed folder body.
-    async fn load_root(&self, scope: &DrainScope<'_>) -> Result<RootState, Halt> {
+    /// its unsealed folder body, plus the scope epoch.
+    async fn load_scope_root(&self, scope: &DrainScope<'_>) -> Result<(FolderState, u64), Halt> {
         let record_bytes = self
             .snapshot_cache
             .get(scope.root_name.as_str().as_bytes())
@@ -274,48 +361,199 @@ where
         let body = open_read_body(&envelope, &read_key).map_err(|_| Halt)?;
         let ReadBody::Folder {
             created_at,
+            modified_at,
             children,
             unknown,
-            ..
         } = body
         else {
             return Err(Halt);
         };
-        Ok(RootState {
+        let epoch = envelope.epoch;
+        Ok((
+            FolderState {
+                name: scope.root_name.clone(),
+                is_scope_root: true,
+                envelope_unknown: envelope.unknown,
+                epoch_tag_unknown: envelope.epoch_tag_unknown,
+                created_at,
+                modified_at,
+                children,
+                body_unknown: unknown,
+                sequence,
+            },
+            epoch,
+        ))
+    }
+
+    /// Resolve one non-root node's own record through the child pipeline and
+    /// open it for re-authoring. The gate decides: only a record that passes
+    /// the child bindings, the floors, and the AAD-bound unseal is authorable.
+    async fn load_child_node(
+        &self,
+        scope: &DrainScope<'_>,
+        epoch: u64,
+        node: NodeId,
+    ) -> Result<LoadedNode, Halt> {
+        let name = derive_write_name(scope.write_scope_seed, &node.0);
+        let adopter = ChildAdopter::new(
+            self.gateway,
+            self.http,
+            self.floors,
+            scope.root.0,
+            scope.read_scope_seed.clone(),
+            node.0,
+        );
+        let resolved = resolve(self.transport, self.snapshot_cache, &adopter, &name)
+            .await
+            .map_err(seam)?;
+        let record_bytes = match resolved.outcome {
+            // An adopt caches its own gate-passing bytes; the other two arms
+            // carry theirs.
+            ResolveOutcome::Adopted(_) => self
+                .snapshot_cache
+                .get(name.as_str().as_bytes())
+                .await
+                .map_err(seam)?
+                .ok_or(Halt)?,
+            ResolveOutcome::Current { record_bytes } => record_bytes,
+            ResolveOutcome::NoUpdate => resolved.last_known_good.ok_or(Halt)?,
+            ResolveOutcome::TrustViolation(_) => return Err(Halt),
+        };
+        let (adopted, envelope) = adopter
+            .open_carried_at_floor(&name, &record_bytes)
+            .await
+            .map_err(|_| Halt)?;
+        // The same two rollback guards the root load makes: this build authors
+        // exactly `ENVELOPE_V`, and re-sealing a node at another epoch than the
+        // scope's would cross the AAD epoch binding.
+        if envelope.v != ENVELOPE_V || adopted.epoch != epoch {
+            return Err(Halt);
+        }
+        Ok(LoadedNode {
+            name,
+            sequence: adopted.sequence,
             envelope_unknown: envelope.unknown,
             epoch_tag_unknown: envelope.epoch_tag_unknown,
-            epoch: envelope.epoch,
-            created_at,
-            children,
-            body_unknown: unknown,
+            body: adopted.read_body,
         })
     }
 
-    /// Publish one applied op: the new node's own record, then the parent that
-    /// names it.
-    async fn publish_applied(
+    /// Make `folder` and every ancestor between it and the scope root available
+    /// in `pass`, loading ancestor-first so the base repaint always has a parent
+    /// to hang a projection off.
+    async fn ensure_folder(
         &self,
         scope: &DrainScope<'_>,
-        root: &mut RootState,
-        applied: &crate::sync::rebase::AppliedOp,
-        rebased: &Snapshot,
+        pass: &mut Pass,
+        folder: NodeId,
     ) -> Result<(), Halt> {
-        let OpKind::Create {
-            parent,
-            kind,
-            content: None,
-            ..
-        } = &applied.op.kind
+        if pass.holds(folder) {
+            return Ok(());
+        }
+        let chain = {
+            let base = self.base.borrow();
+            let mut chain = base.ancestors(folder);
+            chain.reverse();
+            chain.push(folder);
+            chain
+        };
+        // A folder whose chain does not reach the scope root is not a folder
+        // this scope's write plane may author.
+        if chain.first() != Some(&scope.root) {
+            return Err(Halt);
+        }
+        for node in chain {
+            if pass.holds(node) {
+                continue;
+            }
+            let state = self.load_child_folder(scope, pass.epoch, node).await?;
+            self.repaint_folder(node, &state.children, state.sequence, state.modified_at);
+            pass.insert(node, state);
+        }
+        Ok(())
+    }
+
+    /// Load one non-root folder's state, refusing a node whose sealed body is
+    /// not a folder (a kind transplant).
+    async fn load_child_folder(
+        &self,
+        scope: &DrainScope<'_>,
+        epoch: u64,
+        folder: NodeId,
+    ) -> Result<FolderState, Halt> {
+        let loaded = self.load_child_node(scope, epoch, folder).await?;
+        let ReadBody::Folder {
+            created_at,
+            modified_at,
+            children,
+            unknown,
+        } = loaded.body
         else {
             return Err(Halt);
         };
-        // A deeper parent's own record is not authorable yet: the base snapshot
-        // projects the root's direct children only, so there is no gate-passing
-        // sub-folder body to re-author onto.
-        if *parent != scope.root {
-            return Err(Halt);
+        Ok(FolderState {
+            name: loaded.name,
+            is_scope_root: false,
+            envelope_unknown: loaded.envelope_unknown,
+            epoch_tag_unknown: loaded.epoch_tag_unknown,
+            created_at,
+            modified_at,
+            children,
+            body_unknown: unknown,
+            sequence: loaded.sequence,
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // The per-op publish plans.
+    // -----------------------------------------------------------------------
+
+    /// Publish one applied op's records, referent before reference.
+    async fn publish_applied(
+        &self,
+        scope: &DrainScope<'_>,
+        pass: &mut Pass,
+        applied: &AppliedOp,
+        rebased: &Snapshot,
+    ) -> Result<(), Halt> {
+        match &applied.op.kind {
+            OpKind::Create {
+                parent,
+                kind,
+                content: None,
+                ..
+            } => {
+                self.publish_create(scope, pass, applied, rebased, *parent, *kind)
+                    .await
+            }
+            OpKind::Rename { .. } => self.publish_rename(scope, pass, applied).await,
+            OpKind::Delete { .. } => self.publish_delete(scope, pass, applied).await,
+            OpKind::Relink {
+                new_parent,
+                cross_scope: false,
+                ..
+            } => {
+                self.publish_relink(scope, pass, applied, rebased, *new_parent)
+                    .await
+            }
+            OpKind::UpdateContent { .. } => self.publish_update_content(scope, pass, applied).await,
+            // Content bytes are #868's; cross-scope re-seal is #635's.
+            OpKind::Create { .. } | OpKind::Relink { .. } => Err(Halt),
         }
+    }
+
+    /// Create: the new node's own record, then the parent that names it.
+    async fn publish_create(
+        &self,
+        scope: &DrainScope<'_>,
+        pass: &mut Pass,
+        applied: &AppliedOp,
+        rebased: &Snapshot,
+        parent: NodeId,
+        kind: NodeKind,
+    ) -> Result<(), Halt> {
         let name = applied.effective_name.clone().ok_or(Halt)?;
+        self.ensure_folder(scope, pass, parent).await?;
 
         let child_id = applied.op.target;
         let child_name = derive_write_name(scope.write_scope_seed, &child_id.0);
@@ -323,110 +561,372 @@ where
             child_id.0,
             name,
             &child_name,
-            core_kind(*kind),
+            core_kind(kind),
             rebased.max_link_counter(child_id),
             applied.op.authored_at.0,
         );
-
-        let head = author_child_envelope(EnvelopeAuthoring {
-            node_id: child_id.0,
-            scope_id: scope.root.0,
-            epoch: root.epoch,
-            read_key: &self.node_read_key(scope, &child_id.0),
-            nonce: &self.nonce()?,
-            body: &child.body,
-            carried_unknown: Vec::new(),
-            carried_epoch_tag_unknown: Vec::new(),
-        })
-        .map_err(|_| Halt)?;
-        let record_bytes = self
-            .publish_head(scope, &child_name, &child_id.0, root.epoch, &head)
+        let published = self
+            .publish_node(
+                scope,
+                pass.epoch,
+                child_id,
+                &child_name,
+                false,
+                &child.body,
+                Vec::new(),
+                Vec::new(),
+            )
             .await?;
 
-        let adopter = ChildAdopter::new(
-            self.gateway,
-            self.http,
-            self.floors,
-            scope.root.0,
-            scope.read_scope_seed.clone(),
-            child_id.0,
-        );
-        adopter.hold_local_head(local_head(&head));
-        adopter
-            .adopt(&child_name, &record_bytes)
-            .await
-            .map_err(|_| Halt)?;
-
         // Referent published: only now does the parent gain the ref to it.
-        root.children.push(child.child_ref);
-        self.publish_root(scope, root, applied.op.authored_at.0)
+        pass.folder_mut(parent)?.children.push(child.child_ref);
+        self.publish_folder(scope, pass, parent, applied.op.authored_at.0)
             .await?;
         // Held only once the parent names it: a record nothing references is
         // not one the liveness loop should keep alive.
-        self.hold(scope, child_id.0, &child_name, &head, record_bytes);
+        self.hold(child_id.0, published.held);
         Ok(())
     }
 
-    /// Re-author and publish the scope root over its current children, then
-    /// self-adopt it into the base snapshot.
-    async fn publish_root(
+    /// Rename: the name lives only in the parent's child ref
+    /// (`crates/core/src/seal/body.rs`), so one parent republish is the whole op.
+    async fn publish_rename(
         &self,
         scope: &DrainScope<'_>,
-        root: &mut RootState,
-        modified_at: u64,
+        pass: &mut Pass,
+        applied: &AppliedOp,
     ) -> Result<(), Halt> {
-        let read_key = self.node_read_key(scope, &scope.root.0);
-        let body = ReadBody::Folder {
-            created_at: root.created_at,
-            modified_at,
-            children: root.children.clone(),
-            unknown: root.body_unknown.clone(),
-        };
-        let head = author_scope_root_envelope(
-            EnvelopeAuthoring {
-                node_id: scope.root.0,
-                scope_id: scope.root.0,
-                epoch: root.epoch,
-                read_key: &read_key,
-                nonce: &self.nonce()?,
-                body: &body,
-                carried_unknown: root.envelope_unknown.clone(),
-                carried_epoch_tag_unknown: root.epoch_tag_unknown.clone(),
-            },
-            scope.root_name,
-        )
-        .map_err(|_| Halt)?;
-        let record_bytes = self
-            .publish_head(scope, scope.root_name, &scope.root.0, root.epoch, &head)
+        let new_name = applied.effective_name.clone().ok_or(Halt)?;
+        let target = applied.op.target;
+        let parent = self.published_parent(target)?;
+        self.ensure_folder(scope, pass, parent).await?;
+        {
+            let child = pass
+                .folder_mut(parent)?
+                .children
+                .iter_mut()
+                .find(|child| child.id == target.0)
+                .ok_or(Halt)?;
+            child.name = new_name;
+        }
+        self.publish_folder(scope, pass, parent, applied.op.authored_at.0)
             .await?;
-
-        let adopter = RootAdopter::new(
-            self.gateway,
-            self.http,
-            self.floors,
-            scope.enc_secret,
-            scope.owner_identity,
-            scope.root.0,
-        );
-        adopter.hold_local_head(local_head(&head));
-        let AdoptOutcome { adopted, .. } = adopter
-            .adopt(scope.root_name, &record_bytes)
-            .await
-            .map_err(|_| Halt)?;
-        // Cached implies gate-passing: these bytes just cleared all six stages.
-        self.snapshot_cache
-            .put(scope.root_name.as_str().as_bytes(), &record_bytes)
-            .await
-            .map_err(seam)?;
-        let projected = project_root(scope.root, &adopted, &self.base.borrow());
-        *self.base.borrow_mut() = projected;
-        self.hold(scope, scope.root.0, scope.root_name, &head, record_bytes);
         Ok(())
     }
 
-    /// Dry-run, publish, and return the signed bytes. Only a confirmed publish
-    /// yields bytes to self-adopt: adopting an unconfirmed one would advance the
+    /// Delete: drop the parent's ref. The name itself is retired only on
+    /// abandonment (#819 as amended by #824), which is the failure-policy
+    /// slice's (#867).
+    async fn publish_delete(
+        &self,
+        scope: &DrainScope<'_>,
+        pass: &mut Pass,
+        applied: &AppliedOp,
+    ) -> Result<(), Halt> {
+        let target = applied.op.target;
+        let parent = self.published_parent(target)?;
+        self.ensure_folder(scope, pass, parent).await?;
+        let children = &mut pass.folder_mut(parent)?.children;
+        let before = children.len();
+        children.retain(|child| child.id != target.0);
+        // Removing an absent ref is the op already satisfied, never a publish.
+        if children.len() == before {
+            return Ok(());
+        }
+        self.publish_folder(scope, pass, parent, applied.op.authored_at.0)
+            .await?;
+        Ok(())
+    }
+
+    /// Relink: dest-add published before the source-remove, so no window leaves
+    /// the child absent from both parents. A source-remove that will not
+    /// publish compensates its own dest-add rather than leaving a dual link.
+    async fn publish_relink(
+        &self,
+        scope: &DrainScope<'_>,
+        pass: &mut Pass,
+        applied: &AppliedOp,
+        rebased: &Snapshot,
+        dest: NodeId,
+    ) -> Result<(), Halt> {
+        let target = applied.op.target;
+        let source = self.published_parent(target)?;
+        if source == dest {
+            return Ok(());
+        }
+        let modified_at = applied.op.authored_at.0;
+
+        self.ensure_folder(scope, pass, source).await?;
+        self.ensure_folder(scope, pass, dest).await?;
+
+        // The dest gains the source's own ref, so id/ipnsName/kind and any
+        // newer client's fields ride verbatim; only the link counter advances
+        // to the winner replay allocated (#33 D5).
+        let mut moved = pass
+            .folder(source)?
+            .children
+            .iter()
+            .find(|child| child.id == target.0)
+            .cloned()
+            .ok_or(Halt)?;
+        moved.link_counter = rebased
+            .max_link_counter(target)
+            .max(moved.link_counter.saturating_add(1));
+
+        pass.folder_mut(dest)?.children.push(moved);
+        let cas_base = self.publish_folder(scope, pass, dest, modified_at).await?;
+
+        pass.folder_mut(source)?
+            .children
+            .retain(|child| child.id != target.0);
+        if self
+            .publish_folder(scope, pass, source, modified_at)
+            .await
+            .is_err()
+        {
+            self.compensate_dest_add(scope, pass, dest, target, cas_base, modified_at)
+                .await?;
+            return Err(Halt);
+        }
+        Ok(())
+    }
+
+    /// Undo a published dest-add when the source-remove will not follow it.
+    /// Fail-closed on a concurrent writer: the versioned compare-and-remove
+    /// refuses to replay our stale copy over a dest that moved, and the
+    /// re-derive lands the removal on the winner's record instead (#786).
+    async fn compensate_dest_add(
+        &self,
+        scope: &DrainScope<'_>,
+        pass: &mut Pass,
+        dest: NodeId,
+        target: NodeId,
+        cas_base: u64,
+        modified_at: u64,
+    ) -> Result<(), Halt> {
+        let staged = pass.folder(dest)?.children.clone();
+        // Re-read at whatever sequence the dest now carries — the same read the
+        // compensating publish's seq-CAS will assert against.
+        let observed = self.reload_folder(scope, pass, dest).await?;
+        let drop_target = |children: &[ChildRef]| -> Vec<ChildRef> {
+            children
+                .iter()
+                .filter(|child| child.id != target.0)
+                .cloned()
+                .collect()
+        };
+        let children = match undo_dest_add_versioned(&staged, drop_target, cas_base, observed) {
+            UndoDestAdd::Removed(children) => children,
+            UndoDestAdd::Conflict => drop_target(&pass.folder(dest)?.children),
+        };
+        pass.folder_mut(dest)?.children = children;
+        self.publish_folder(scope, pass, dest, modified_at).await?;
+        Ok(())
+    }
+
+    /// Re-read a folder from the network, replacing this pass's copy. Returns
+    /// the sequence it now carries.
+    async fn reload_folder(
+        &self,
+        scope: &DrainScope<'_>,
+        pass: &mut Pass,
+        folder: NodeId,
+    ) -> Result<u64, Halt> {
+        let state = if folder == scope.root {
+            self.load_scope_root(scope).await?.0
+        } else {
+            self.load_child_folder(scope, pass.epoch, folder).await?
+        };
+        let sequence = state.sequence;
+        self.repaint_folder(folder, &state.children, sequence, state.modified_at);
+        pass.replace(folder, state);
+        Ok(sequence)
+    }
+
+    /// `updateContent`'s metadata half: a file's own record carries its
+    /// `modifiedAt` and version list, and its parent holds no size/mtime mirror
+    /// to republish (`crates/core/src/seal/body.rs`). The version this op
+    /// stages is the content slice's (#868).
+    async fn publish_update_content(
+        &self,
+        scope: &DrainScope<'_>,
+        pass: &mut Pass,
+        applied: &AppliedOp,
+    ) -> Result<(), Halt> {
+        let target = applied.op.target;
+        let modified_at = applied.op.authored_at.0;
+        let loaded = self.load_child_node(scope, pass.epoch, target).await?;
+        let ReadBody::File {
+            created_at,
+            versions,
+            unknown,
+            ..
+        } = loaded.body
+        else {
+            return Err(Halt);
+        };
+        let body = ReadBody::File {
+            created_at,
+            modified_at,
+            versions,
+            unknown,
+        };
+        let published = self
+            .publish_node(
+                scope,
+                pass.epoch,
+                target,
+                &loaded.name,
+                false,
+                &body,
+                loaded.envelope_unknown,
+                loaded.epoch_tag_unknown,
+            )
+            .await?;
+        if let Some(node) = self.base.borrow_mut().node_mut(target) {
+            node.record_sequence = published.sequence;
+            node.mtime = Some(modified_at);
+        }
+        self.hold(target.0, published.held);
+        Ok(())
+    }
+
+    /// The parent a node is published under, from the base the pass repaints as
+    /// it goes — so an op rebases onto exactly what the ops before it published.
+    fn published_parent(&self, node: NodeId) -> Result<NodeId, Halt> {
+        self.base.borrow().parent_of(node).ok_or(Halt)
+    }
+
+    // -----------------------------------------------------------------------
+    // Authoring and publishing one record.
+    // -----------------------------------------------------------------------
+
+    /// Re-author and publish one folder over its current children, self-adopt
+    /// it, and repaint the base from the result. Returns its new sequence.
+    async fn publish_folder(
+        &self,
+        scope: &DrainScope<'_>,
+        pass: &mut Pass,
+        folder: NodeId,
+        modified_at: u64,
+    ) -> Result<u64, Halt> {
+        let (name, is_scope_root, body, envelope_unknown, epoch_tag_unknown) = {
+            let state = pass.folder(folder)?;
+            (
+                state.name.clone(),
+                state.is_scope_root,
+                ReadBody::Folder {
+                    created_at: state.created_at,
+                    modified_at,
+                    children: state.children.clone(),
+                    unknown: state.body_unknown.clone(),
+                },
+                state.envelope_unknown.clone(),
+                state.epoch_tag_unknown.clone(),
+            )
+        };
+        let published = self
+            .publish_node(
+                scope,
+                pass.epoch,
+                folder,
+                &name,
+                is_scope_root,
+                &body,
+                envelope_unknown,
+                epoch_tag_unknown,
+            )
+            .await?;
+
+        let state = pass.folder_mut(folder)?;
+        state.sequence = published.sequence;
+        state.modified_at = modified_at;
+        let children = state.children.clone();
+        self.repaint_folder(folder, &children, published.sequence, modified_at);
+        self.hold(folder.0, published.held);
+        Ok(published.sequence)
+    }
+
+    /// Author, publish and self-adopt one node's record. Only a confirmed
+    /// publish reaches the gate: adopting an unconfirmed one would advance the
     /// sequence floor and destroy the idempotent-in-sequence retry (#821).
+    #[expect(clippy::too_many_arguments, reason = "one record's full authoring")]
+    async fn publish_node(
+        &self,
+        scope: &DrainScope<'_>,
+        epoch: u64,
+        node: NodeId,
+        name: &IpnsName,
+        is_scope_root: bool,
+        body: &ReadBody,
+        carried_unknown: Vec<(String, Value)>,
+        carried_epoch_tag_unknown: Vec<(String, Value)>,
+    ) -> Result<Published, Halt> {
+        let read_key = self.node_read_key(scope, &node.0);
+        let nonce = self.nonce()?;
+        let authoring = EnvelopeAuthoring {
+            node_id: node.0,
+            scope_id: scope.root.0,
+            epoch,
+            read_key: &read_key,
+            nonce: &nonce,
+            body,
+            carried_unknown,
+            carried_epoch_tag_unknown,
+        };
+        let head = if is_scope_root {
+            author_scope_root_envelope(authoring, name)
+        } else {
+            author_child_envelope(authoring)
+        }
+        .map_err(|_| Halt)?;
+
+        let record_bytes = self.publish_head(scope, name, &node.0, epoch, &head).await?;
+        let local = local_head(&head);
+        let sequence = if is_scope_root {
+            let adopter = RootAdopter::new(
+                self.gateway,
+                self.http,
+                self.floors,
+                scope.enc_secret,
+                scope.owner_identity,
+                scope.root.0,
+            );
+            adopter.hold_local_head(local);
+            adopter.adopt(name, &record_bytes).await.map_err(|_| Halt)?
+        } else {
+            let adopter = ChildAdopter::new(
+                self.gateway,
+                self.http,
+                self.floors,
+                scope.root.0,
+                scope.read_scope_seed.clone(),
+                node.0,
+            );
+            adopter.hold_local_head(local);
+            adopter.adopt(name, &record_bytes).await.map_err(|_| Halt)?
+        }
+        .adopted
+        .sequence;
+
+        // Cached implies gate-passing: these bytes just cleared the gate.
+        self.snapshot_cache
+            .put(name.as_str().as_bytes(), &record_bytes)
+            .await
+            .map_err(seam)?;
+        Ok(Published {
+            sequence,
+            held: HeldRecord {
+                routing_key: name.as_str().to_owned(),
+                record_bytes,
+                signer: SessionIdentity::write_name_signer(scope.write_scope_seed, &node.0),
+                head_cid: head.cid,
+                content_cids: Vec::new(),
+            },
+        })
+    }
+
+    /// Dry-run, publish, and return the signed bytes.
     async fn publish_head(
         &self,
         scope: &DrainScope<'_>,
@@ -476,27 +976,27 @@ where
         }
     }
 
-    /// Insert a just-published record into the live held set so the liveness
-    /// loop keeps it alive; the narrow per-name signer is derived here and the
-    /// scope seed is not stored (least privilege, `net/liveness.rs`).
-    fn hold(
+    /// Merge one folder's published children into the base snapshot.
+    fn repaint_folder(
         &self,
-        scope: &DrainScope<'_>,
-        node_id: [u8; 16],
-        name: &IpnsName,
-        head: &AuthoredHead,
-        record_bytes: Vec<u8>,
+        folder: NodeId,
+        children: &[ChildRef],
+        sequence: u64,
+        modified_at: u64,
     ) {
-        self.held.borrow_mut().insert(
-            node_id,
-            HeldRecord {
-                routing_key: name.as_str().to_owned(),
-                record_bytes,
-                signer: SessionIdentity::write_name_signer(scope.write_scope_seed, &node_id),
-                head_cid: head.cid.clone(),
-                content_cids: Vec::new(),
-            },
+        project_folder(
+            &mut self.base.borrow_mut(),
+            folder,
+            children,
+            sequence,
+            modified_at,
         );
+    }
+
+    /// Insert a just-published record into the live held set so the liveness
+    /// loop keeps it alive.
+    fn hold(&self, node_id: [u8; 16], held: HeldRecord) {
+        self.held.borrow_mut().insert(node_id, held);
     }
 
     /// Remove a resolved op from the durable queue.

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -716,7 +716,14 @@ where
                 link.link_counter
             });
 
-        pass.folder_mut(dest)?.children.push(moved);
+        // The rebase resolves against a dest it has not loaded yet, so a dest
+        // already naming the target is reachable; a second ref would sign a
+        // listing `author_child_envelope` rejects, wedging every retry.
+        let dest_children = &mut pass.folder_mut(dest)?.children;
+        match dest_children.iter_mut().find(|child| child.id == target.0) {
+            Some(existing) => *existing = moved,
+            None => dest_children.push(moved),
+        }
         let cas_base = self.publish_folder(scope, pass, dest, modified_at).await?;
 
         pass.folder_mut(source)?

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -881,7 +881,9 @@ where
         }
         .map_err(|_| Halt)?;
 
-        let record_bytes = self.publish_head(scope, name, &node.0, epoch, &head).await?;
+        let record_bytes = self
+            .publish_head(scope, name, &node.0, epoch, &head)
+            .await?;
         let local = local_head(&head);
         let sequence = if is_scope_root {
             let adopter = RootAdopter::new(

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -32,6 +32,7 @@ use crate::api::ApiClient;
 use crate::content::Gateway;
 use crate::entropy::Entropy;
 use crate::facade::{NodeId, NodeKind};
+use crate::gate::floor;
 use crate::grants::{UndoDestAdd, undo_dest_add_versioned};
 use crate::net::author::{
     AuthoredHead, ENVELOPE_V, EnvelopeAuthoring, author_child_envelope, author_scope_root_envelope,
@@ -41,7 +42,7 @@ use crate::net::publish::{PublishOutcome, PublishReceipt};
 use crate::net::record_publish::{HeadBinding, RecordPublishRequest, preflight, publish_record};
 use crate::net::{
     Adopter, ChildAdopter, HeldRecord, HeldRecords, LocalHead, ResolveOutcome, RootAdopter,
-    assemble_head_envelope, resolve,
+    assemble_head_envelope, fanout_get_verify, resolve,
 };
 use crate::profile::SyncTimingProfile;
 use crate::rotation::derive_write_name;
@@ -151,8 +152,7 @@ struct FolderState {
     modified_at: u64,
     children: Vec<ChildRef>,
     body_unknown: Vec<(String, Value)>,
-    /// The record sequence this folder is published at — the dest-add
-    /// compensation's CAS base.
+    /// The record sequence this folder was last loaded or published at.
     sequence: u64,
 }
 
@@ -205,13 +205,6 @@ impl Pass {
             .find(|(id, _)| *id == folder)
             .map(|(_, state)| state)
             .ok_or(Halt)
-    }
-
-    fn replace(&mut self, folder: NodeId, state: FolderState) {
-        match self.folders.iter_mut().find(|(id, _)| *id == folder) {
-            Some(slot) => slot.1 = state,
-            None => self.insert(folder, state),
-        }
     }
 }
 
@@ -340,17 +333,22 @@ where
         .await
         .map_err(|_| Halt)?;
         // The cache can be older than the floors — a restored data dir is
-        // exactly that (#860). Re-authoring over a below-floor root would erase
-        // every child added since, durably and at a sequence the gate accepts.
-        let floor = self
-            .floors
-            .sequence_floor(scope.root_name.as_str().as_bytes())
-            .await
-            .map_err(seam)?
-            .unwrap_or(0);
-        if sequence < floor {
-            return Err(Halt);
-        }
+        // exactly that (#860). The whole pass anchors here: this record's epoch
+        // becomes the epoch every record it publishes is sealed at, so a
+        // below-floor anchor would bind a stale epoch into the AAD while the
+        // live session seed derives the key — records nobody can open. One
+        // at-floor gate call covers both floors (encode-side of the gate's
+        // stage-5 reject; security rule 8).
+        floor::check(
+            self.floors,
+            scope.root_name.as_str().as_bytes(),
+            &scope.root.0,
+            sequence,
+            envelope.epoch,
+            floor::Strictness::AtFloor,
+        )
+        .await
+        .map_err(|_| Halt)?;
         // Encode/decode fail-closed symmetry: this build authors exactly
         // `ENVELOPE_V`, so republishing a newer client's root would silently
         // downgrade `v` — the exact rollback the read-body AAD defends against.
@@ -383,6 +381,35 @@ where
             },
             epoch,
         ))
+    }
+
+    /// Resolve the scope root through its own gate so the snapshot cache holds
+    /// whatever the network now carries. Only a gate-passing adopt writes the
+    /// cache, so a rejected or unreachable record leaves last-known-good.
+    async fn refresh_scope_root_cache(&self, scope: &DrainScope<'_>) -> Result<(), Halt> {
+        let adopter = RootAdopter::new(
+            self.gateway,
+            self.http,
+            self.floors,
+            scope.enc_secret,
+            scope.owner_identity,
+            scope.root.0,
+        );
+        let resolved = resolve(
+            self.transport,
+            self.snapshot_cache,
+            &adopter,
+            scope.root_name,
+        )
+        .await
+        .map_err(seam)?;
+        // A gate failure is a trust violation, never staleness: re-authoring on
+        // top of last-known-good while the record plane serves a rejected root
+        // is exactly the fail-open this rule forbids.
+        match resolved.outcome {
+            ResolveOutcome::TrustViolation(_) => Err(Halt),
+            _ => Ok(()),
+        }
     }
 
     /// Resolve one non-root node's own record through the child pipeline and
@@ -529,11 +556,12 @@ where
             OpKind::Rename { .. } => self.publish_rename(scope, pass, applied).await,
             OpKind::Delete { .. } => self.publish_delete(scope, pass, applied).await,
             OpKind::Relink {
+                from_parent,
                 new_parent,
                 cross_scope: false,
                 ..
             } => {
-                self.publish_relink(scope, pass, applied, rebased, *new_parent)
+                self.publish_relink(scope, pass, applied, rebased, *from_parent, *new_parent)
                     .await
             }
             OpKind::UpdateContent { .. } => self.publish_update_content(scope, pass, applied).await,
@@ -647,12 +675,25 @@ where
         pass: &mut Pass,
         applied: &AppliedOp,
         rebased: &Snapshot,
+        from_parent: NodeId,
         dest: NodeId,
     ) -> Result<(), Halt> {
         let target = applied.op.target;
         let source = self.published_parent(target)?;
+        // The op's own presence condition: a source the rebase did not resolve
+        // against is a concurrent move this op lost (`sync/op.rs`), and removing
+        // from it would clobber the winner.
+        if source != from_parent {
+            return Err(Halt);
+        }
         if source == dest {
             return Ok(());
+        }
+        // A cycle detaches the whole subtree from the scope root irrecoverably,
+        // and no walk can find it again. Release-active, and refused again at
+        // rebase so the op dead-letters instead of wedging the queue.
+        if dest == target || self.base.borrow().ancestors(dest).contains(&target) {
+            return Err(Halt);
         }
         let modified_at = applied.op.authored_at.0;
 
@@ -670,8 +711,10 @@ where
             .cloned()
             .ok_or(Halt)?;
         moved.link_counter = rebased
-            .max_link_counter(target)
-            .max(moved.link_counter.saturating_add(1));
+            .winning_link(target)
+            .map_or(moved.link_counter.saturating_add(1), |link| {
+                link.link_counter
+            });
 
         pass.folder_mut(dest)?.children.push(moved);
         let cas_base = self.publish_folder(scope, pass, dest, modified_at).await?;
@@ -684,30 +727,48 @@ where
             .await
             .is_err()
         {
-            self.compensate_dest_add(scope, pass, dest, target, cas_base, modified_at)
+            self.compensate_dest_add(scope, pass, dest, source, target, cas_base, modified_at)
                 .await?;
             return Err(Halt);
         }
         Ok(())
     }
 
-    /// Undo a published dest-add when the source-remove will not follow it.
-    /// Fail-closed on a concurrent writer: the versioned compare-and-remove
-    /// refuses to replay our stale copy over a dest that moved, and the
-    /// re-derive lands the removal on the winner's record instead (#786).
+    /// Undo a published dest-add when the source-remove did not follow it.
+    ///
+    /// Two fail-closed conditions, because undoing wrongly is the one error the
+    /// ordering law cannot absorb — it leaves the child referenced by neither
+    /// parent. The source must still name the child (the publish may have
+    /// landed and only its self-adopt failed), and the dest must still be at the
+    /// sequence our dest-add published; a dest that moved is re-read and the
+    /// removal re-derived onto the winner's record rather than replayed over it
+    /// (#786).
+    #[expect(clippy::too_many_arguments, reason = "one compensation's full state")]
     async fn compensate_dest_add(
         &self,
         scope: &DrainScope<'_>,
         pass: &mut Pass,
         dest: NodeId,
+        source: NodeId,
         target: NodeId,
         cas_base: u64,
         modified_at: u64,
     ) -> Result<(), Halt> {
+        self.reload_folder(scope, pass, source).await?;
+        if !pass
+            .folder(source)?
+            .children
+            .iter()
+            .any(|child| child.id == target.0)
+        {
+            return Ok(());
+        }
+
         let staged = pass.folder(dest)?.children.clone();
-        // Re-read at whatever sequence the dest now carries — the same read the
-        // compensating publish's seq-CAS will assert against.
-        let observed = self.reload_folder(scope, pass, dest).await?;
+        // The version read is the record plane's own, never this device's cache:
+        // a cache hit would answer with the bytes we just published and make the
+        // compare vacuous.
+        let observed = self.observed_sequence(&pass.folder(dest)?.name).await?;
         let drop_target = |children: &[ChildRef]| -> Vec<ChildRef> {
             children
                 .iter()
@@ -717,30 +778,48 @@ where
         };
         let children = match undo_dest_add_versioned(&staged, drop_target, cas_base, observed) {
             UndoDestAdd::Removed(children) => children,
-            UndoDestAdd::Conflict => drop_target(&pass.folder(dest)?.children),
+            UndoDestAdd::Conflict => {
+                self.reload_folder(scope, pass, dest).await?;
+                drop_target(&pass.folder(dest)?.children)
+            }
         };
         pass.folder_mut(dest)?.children = children;
         self.publish_folder(scope, pass, dest, modified_at).await?;
         Ok(())
     }
 
-    /// Re-read a folder from the network, replacing this pass's copy. Returns
-    /// the sequence it now carries.
+    /// The freshest sequence the record plane shows at `name` — the same
+    /// record-verify read the publish confirm asserts against. Nothing
+    /// resolvable fails closed: the compensation may not treat an unanswered
+    /// name as "unchanged".
+    async fn observed_sequence(&self, name: &IpnsName) -> Result<u64, Halt> {
+        fanout_get_verify(self.transport, name)
+            .await
+            .map(|(sequence, _)| sequence)
+            .ok_or(Halt)
+    }
+
+    /// Re-read a folder from the record plane, replacing this pass's copy.
+    ///
+    /// The scope root is otherwise read from the snapshot cache, which is this
+    /// device's own — a compensation that read it there could never see the
+    /// concurrent writer it exists to yield to — so the root is re-resolved
+    /// through its own gate first.
     async fn reload_folder(
         &self,
         scope: &DrainScope<'_>,
         pass: &mut Pass,
         folder: NodeId,
-    ) -> Result<u64, Halt> {
+    ) -> Result<(), Halt> {
         let state = if folder == scope.root {
+            self.refresh_scope_root_cache(scope).await?;
             self.load_scope_root(scope).await?.0
         } else {
             self.load_child_folder(scope, pass.epoch, folder).await?
         };
-        let sequence = state.sequence;
-        self.repaint_folder(folder, &state.children, sequence, state.modified_at);
-        pass.replace(folder, state);
-        Ok(sequence)
+        self.repaint_folder(folder, &state.children, state.sequence, state.modified_at);
+        *pass.folder_mut(folder)? = state;
+        Ok(())
     }
 
     /// `updateContent`'s metadata half: a file's own record carries its
@@ -755,6 +834,17 @@ where
     ) -> Result<(), Halt> {
         let target = applied.op.target;
         let modified_at = applied.op.authored_at.0;
+        // This plan authors the target's own record and nothing else, so a
+        // resolution that also needs a parent-side write — the rebase's
+        // resurrect arm, which re-links under a resolved name — has no publish
+        // plan here and must not report success.
+        if applied.effective_name.is_some() {
+            return Err(Halt);
+        }
+        // Same reachability rule every other plan gets from `ensure_folder`: a
+        // node no parent links is not one this scope's write plane may author.
+        self.ensure_folder(scope, pass, self.published_parent(target)?)
+            .await?;
         let loaded = self.load_child_node(scope, pass.epoch, target).await?;
         let ReadBody::File {
             created_at,

--- a/crates/engine/src/sync/project.rs
+++ b/crates/engine/src/sync/project.rs
@@ -33,8 +33,9 @@ pub(crate) fn project_root(snapshot: &mut Snapshot, root: NodeId, adopted: &Adop
 ///
 /// Only a gate-passing body reaches here — the gate already enforced child
 /// id/ipnsName uniqueness at unseal — so child uniqueness is trusted and not
-/// re-validated. `link_counter` is carried verbatim (it feeds the dual-link
-/// tiebreak in [`Snapshot::winning_link`]).
+/// re-validated. `link_counter` merges monotonically per link ([`Snapshot::link`]
+/// keeps the higher of the two) and feeds the dual-link tiebreak in
+/// [`Snapshot::winning_link`].
 ///
 /// `size`, `mtime`, the content-version count and the child's own record
 /// sequence have no `ChildRef` to come from (`crates/core/src/seal/body.rs`: no

--- a/crates/engine/src/sync/project.rs
+++ b/crates/engine/src/sync/project.rs
@@ -1,9 +1,12 @@
-//! Projection of a gate-passing adopted root read-body into a facade
-//! [`Snapshot`] — direct children only, no recursion, no network, no seams
-//! (blueprint/engine.md "Sync core"; the deeper content-plane assembly is a
-//! later slice).
+//! Projection of a gate-passing adopted read-body into a facade [`Snapshot`] —
+//! one folder's direct children at a time, no recursion, no network, no seams
+//! (blueprint/engine.md "Sync core").
+//!
+//! [`project_root`] rebuilds the snapshot from the scope root; [`project_folder`]
+//! merges any one folder's children into an existing snapshot, so a write plane
+//! that authors below the root keeps the tree it published.
 
-use cipherbox_core::seal::{NodeKind as CoreNodeKind, ReadBody};
+use cipherbox_core::seal::{ChildRef, NodeKind as CoreNodeKind, ReadBody};
 
 use crate::facade::{NodeId, NodeKind};
 use crate::gate::Adopted;
@@ -51,6 +54,55 @@ pub(crate) fn project_root(root: NodeId, adopted: &Adopted, previous: &Snapshot)
     }
 
     snapshot
+}
+
+/// Merge one folder's gate-passing children into `snapshot` **in place**: the
+/// deeper counterpart to [`project_root`], which can only rebuild from the scope
+/// root. Children the folder no longer names are unlinked, and dropped entirely
+/// once no parent links them.
+///
+/// Same trust posture and same carry-forward rule as [`project_root`]: only a
+/// gate-passing body reaches here, and `size`/`mtime`/the version count have no
+/// `ChildRef` to come from, so they survive from whatever the snapshot already
+/// held for that node.
+pub(crate) fn project_folder(
+    snapshot: &mut Snapshot,
+    folder: NodeId,
+    children: &[ChildRef],
+    sequence: u64,
+    modified_at: u64,
+) {
+    if let Some(node) = snapshot.node_mut(folder) {
+        node.record_sequence = sequence;
+        node.mtime = Some(modified_at);
+    }
+
+    let departed: Vec<NodeId> = snapshot
+        .children(folder)
+        .into_iter()
+        .map(|node| node.id)
+        .filter(|id| !children.iter().any(|child| child.id == id.0))
+        .collect();
+    for id in departed {
+        snapshot.unlink(folder, id);
+        if snapshot.links_to(id).is_empty() {
+            snapshot.remove_node(id);
+        }
+    }
+
+    for child in children {
+        let id = NodeId(child.id);
+        let mut meta = NodeMeta::new(id, child.name.clone(), map_kind(child.kind));
+        meta.ipns_name = Some(child.ipns_name.clone());
+        if let Some(prior) = snapshot.node(id) {
+            meta.size = prior.size;
+            meta.mtime = prior.mtime;
+            meta.content_version = prior.content_version;
+            meta.record_sequence = prior.record_sequence;
+        }
+        snapshot.upsert_node(meta);
+        snapshot.link(folder, id, child.link_counter);
+    }
 }
 
 /// Fold a verified file read-body's plaintext `(size, mtime)` and version count

--- a/crates/engine/src/sync/project.rs
+++ b/crates/engine/src/sync/project.rs
@@ -2,9 +2,11 @@
 //! one folder's direct children at a time, no recursion, no network, no seams
 //! (blueprint/engine.md "Sync core").
 //!
-//! [`project_root`] rebuilds the snapshot from the scope root; [`project_folder`]
-//! merges any one folder's children into an existing snapshot, so a write plane
-//! that authors below the root keeps the tree it published.
+//! [`project_folder`] is the single merge model. A snapshot is only ever
+//! *merged into*, never rebuilt: the write plane authors below the scope root,
+//! and a re-projection of the root that installed a fresh snapshot would delete
+//! the deeper tree the drain just published — and with it every queued op that
+//! rebases onto a node below depth 1.
 
 use cipherbox_core::seal::{ChildRef, NodeKind as CoreNodeKind, ReadBody};
 
@@ -12,59 +14,32 @@ use crate::facade::{NodeId, NodeKind};
 use crate::gate::Adopted;
 use crate::sync::model::{NodeMeta, Snapshot};
 
-/// Project a gate-passing adopted root read-body into a [`Snapshot`] holding
-/// the root and its **direct** children, merged over `previous`. Pure: the
-/// child read-bodies (and thus the deeper tree) are not fetched here.
-///
-/// Only a gate-passing [`Adopted`] reaches this fn — the gate already enforced
-/// child id/ipnsName uniqueness at unseal — so child uniqueness is trusted and
-/// not re-validated. `link_counter` is carried verbatim (feeds the dual-link
-/// tiebreak in [`Snapshot::winning_link`]).
-///
-/// `size`, `mtime` and the content-version count have no `ChildRef` to come
-/// from (`crates/core/src/seal/body.rs`: no size/mtime mirrors), so they carry
-/// forward from `previous`; every other field is rebuilt from the adopted body.
-pub(crate) fn project_root(root: NodeId, adopted: &Adopted, previous: &Snapshot) -> Snapshot {
-    let mut snapshot = Snapshot::new(root);
-    if let Some(node) = snapshot.node_mut(root) {
-        node.record_sequence = adopted.sequence;
-    }
-
+/// Merge a gate-passing adopted **scope root** body into `snapshot`. A body that
+/// is not a folder leaves the snapshot untouched.
+pub(crate) fn project_root(snapshot: &mut Snapshot, root: NodeId, adopted: &Adopted) {
     if let ReadBody::Folder {
         modified_at,
         children,
         ..
     } = &adopted.read_body
     {
-        if let Some(node) = snapshot.node_mut(root) {
-            node.mtime = Some(*modified_at);
-        }
-        for child in children {
-            let id = NodeId(child.id);
-            let mut meta = NodeMeta::new(id, child.name.clone(), map_kind(child.kind));
-            meta.ipns_name = Some(child.ipns_name.clone());
-            if let Some(prior) = previous.node(id) {
-                meta.size = prior.size;
-                meta.mtime = prior.mtime;
-                meta.content_version = prior.content_version;
-            }
-            snapshot.upsert_node(meta);
-            snapshot.link(root, id, child.link_counter);
-        }
+        project_folder(snapshot, root, children, adopted.sequence, *modified_at);
     }
-
-    snapshot
 }
 
-/// Merge one folder's gate-passing children into `snapshot` **in place**: the
-/// deeper counterpart to [`project_root`], which can only rebuild from the scope
-/// root. Children the folder no longer names are unlinked, and dropped entirely
-/// once no parent links them.
+/// Merge one folder's gate-passing children into `snapshot` **in place**.
+/// Children the folder no longer names are unlinked, and dropped entirely once
+/// no parent links them.
 ///
-/// Same trust posture and same carry-forward rule as [`project_root`]: only a
-/// gate-passing body reaches here, and `size`/`mtime`/the version count have no
-/// `ChildRef` to come from, so they survive from whatever the snapshot already
-/// held for that node.
+/// Only a gate-passing body reaches here — the gate already enforced child
+/// id/ipnsName uniqueness at unseal — so child uniqueness is trusted and not
+/// re-validated. `link_counter` is carried verbatim (it feeds the dual-link
+/// tiebreak in [`Snapshot::winning_link`]).
+///
+/// `size`, `mtime`, the content-version count and the child's own record
+/// sequence have no `ChildRef` to come from (`crates/core/src/seal/body.rs`: no
+/// size/mtime mirrors), so they survive from whatever the snapshot already held;
+/// every other field is rebuilt from the body.
 pub(crate) fn project_folder(
     snapshot: &mut Snapshot,
     folder: NodeId,
@@ -157,7 +132,9 @@ mod tests {
 
     /// Project with nothing to merge over — the cold-start shape.
     fn project_fresh(root: NodeId, adopted: &Adopted) -> Snapshot {
-        project_root(root, adopted, &Snapshot::new(root))
+        let mut snapshot = Snapshot::new(root);
+        project_root(&mut snapshot, root, adopted);
+        snapshot
     }
 
     fn adopted_folder(children: Vec<ChildRef>, sequence: u64) -> Adopted {
@@ -277,7 +254,8 @@ mod tests {
 
         // The same child renamed, re-linked and re-kinded by the newer body.
         let next = adopted_folder(vec![child(1, "renamed.txt", CoreNodeKind::Folder, 9)], 2);
-        let snap = project_root(root, &next, &previous);
+        let mut snap = previous;
+        project_root(&mut snap, root, &next);
 
         let meta = snap.node(node_id(1)).unwrap();
         assert_eq!(meta.size, Some(2_048), "size has no ChildRef to come from");
@@ -307,13 +285,14 @@ mod tests {
         ));
 
         // The child left the root body; it takes its projected values with it.
-        let snap = project_root(root, &adopted_folder(vec![], 2), &previous);
+        let mut snap = previous;
+        project_root(&mut snap, root, &adopted_folder(vec![], 2));
 
         assert!(!snap.contains(node_id(1)));
 
         // And a re-appearance is a fresh projection, not a resurrection.
         let back = adopted_folder(vec![child(1, "a.txt", CoreNodeKind::File, 1)], 3);
-        let snap = project_root(root, &back, &snap);
+        project_root(&mut snap, root, &back);
         let meta = snap.node(node_id(1)).unwrap();
         assert_eq!(meta.size, None);
         assert_eq!(meta.mtime, None);

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -324,6 +324,12 @@ fn rebase_relink(
     if !working.contains(new_parent) {
         return OpResolution::DeadLetter(DeadLetterReason::DestinationGone);
     }
+    // A move into the subtree it is moving detaches that subtree from the scope
+    // root with nothing left to walk it from, so no later op could reach it —
+    // unrepresentable rather than merely refused at publish.
+    if new_parent == op.target || working.ancestors(new_parent).contains(&op.target) {
+        return OpResolution::DeadLetter(DeadLetterReason::DestinationGone);
+    }
 
     let scope_exit_trigger = exits_granted_source.then_some(from_parent);
     match working.parent_of(op.target) {

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -77,6 +77,9 @@ pub enum DeadLetterReason {
     TargetGone,
     /// A relink destination is absent from gate-passing state.
     DestinationGone,
+    /// A relink destination is the moved target itself or lies inside its
+    /// subtree — the move would detach that subtree from the scope root.
+    DestinationInsideTarget,
     /// A folder is pathologically saturated with colliding names.
     SuffixExhausted,
     /// The durable op record failed to decode: corrupt or truncated. A record
@@ -328,7 +331,7 @@ fn rebase_relink(
     // root with nothing left to walk it from, so no later op could reach it —
     // unrepresentable rather than merely refused at publish.
     if new_parent == op.target || working.ancestors(new_parent).contains(&op.target) {
-        return OpResolution::DeadLetter(DeadLetterReason::DestinationGone);
+        return OpResolution::DeadLetter(DeadLetterReason::DestinationInsideTarget);
     }
 
     let scope_exit_trigger = exits_granted_source.then_some(from_parent);
@@ -834,6 +837,27 @@ mod tests {
             ),
         );
         assert_eq!(res, OpResolution::DeadLetter(DeadLetterReason::TargetGone));
+    }
+
+    #[test]
+    fn a_relink_inside_the_moved_subtree_names_its_own_reason() {
+        let mut base = tree();
+        with_node(&mut base, id(0), id(1), "photos", NodeKind::Folder);
+        with_node(&mut base, id(1), id(2), "2026", NodeKind::Folder);
+        let local = base.clone();
+
+        for dest in [id(1), id(2)] {
+            let res = rebase_one(
+                &mut base.clone(),
+                &local,
+                &Op::relink(id(1), id(0), dest, 1, AT, false, false),
+            );
+            assert_eq!(
+                res,
+                OpResolution::DeadLetter(DeadLetterReason::DestinationInsideTarget),
+                "a present destination inside the target is not a missing one"
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -293,7 +293,8 @@ fn published(world: &FakeWorld, node: NodeId) -> (u64, String) {
 /// The child refs a node's published folder body seals.
 fn published_children(world: &FakeWorld, blocks: &Blocks, node: NodeId) -> Vec<ChildRef> {
     let (_, head_cid) = published(world, node);
-    let envelope = decode_envelope(&blocks.get(&head_cid).expect("the head block")).expect("decodes");
+    let envelope =
+        decode_envelope(&blocks.get(&head_cid).expect("the head block")).expect("decodes");
     match open_read_body(&envelope, &read_key_of(node)).expect("opens under the read-seed key") {
         ReadBody::Folder { children, .. } => children,
         ReadBody::File { .. } => panic!("expected a folder body"),
@@ -853,7 +854,11 @@ fn an_update_content_republishes_the_files_own_record_and_not_its_parent() {
     tick(&world, &engine, &mut tasks);
 
     let (sequence, head_cid) = published(&world, file);
-    assert_eq!(sequence, file_sequence + 1, "the file's own record advanced");
+    assert_eq!(
+        sequence,
+        file_sequence + 1,
+        "the file's own record advanced"
+    );
     assert_eq!(
         published(&world, ROOT).0,
         root_sequence,
@@ -930,7 +935,10 @@ fn a_rename_of_a_still_queued_create_publishes_child_before_parent() {
     assert!(
         world
             .record_store
-            .record_at(&world.record_store.endpoints()[0], write_name(node).as_str())
+            .record_at(
+                &world.record_store.endpoints()[0],
+                write_name(node).as_str()
+            )
             .is_some(),
         "the name the parent points at resolves"
     );
@@ -1095,7 +1103,10 @@ fn seed_folder_and_file(
     }))
     .unwrap();
     tick(world, engine, tasks);
-    (child_id(engine, ROOT, "photos"), child_id(engine, ROOT, "a.txt"))
+    (
+        child_id(engine, ROOT, "photos"),
+        child_id(engine, ROOT, "a.txt"),
+    )
 }
 
 /// Stage an op straight into the durable queue, for a mutation the facade
@@ -1116,12 +1127,7 @@ fn stage(device: &FakeDevice, op: &Op, upload: Option<&[u8]>) {
 
 /// Another writer publishes `folder`'s next record, adding `extra` on top of
 /// whatever the folder currently carries.
-fn concurrent_add(
-    records: &InMemoryRecordStore,
-    blocks: &Blocks,
-    folder: NodeId,
-    extra: ChildRef,
-) {
+fn concurrent_add(records: &InMemoryRecordStore, blocks: &Blocks, folder: NodeId, extra: ChildRef) {
     let name = write_name(folder);
     let current = records
         .record_at(&records.endpoints()[0], name.as_str())
@@ -1133,7 +1139,8 @@ fn concurrent_add(
         .expect("utf8")
         .strip_prefix("/ipfs/")
         .expect("an /ipfs/ pointer");
-    let envelope = decode_envelope(&blocks.get(head_cid).expect("the head block")).expect("decodes");
+    let envelope =
+        decode_envelope(&blocks.get(head_cid).expect("the head block")).expect("decodes");
     let read_key = read_key_of(folder);
     let ReadBody::Folder {
         created_at,

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -1355,7 +1355,7 @@ fn stage(device: &FakeDevice, op: &Op, upload: Option<&[u8]>) {
         &device.staging_store,
         &StoragePolicy::CI,
         RecordSeal {
-            owner_enc_pub: kdf::enc_subkey(&SECRET).public(),
+            owner_enc_secret: &kdf::enc_subkey(&SECRET),
             ephemeral_scalar: Zeroizing::new([0x5A; 32]),
         },
         op,

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -1,7 +1,7 @@
-//! The write plane, joined end to end (#865): a `Command::Create` for a folder
-//! is staged, drained, authored, published, self-adopted, and resolved back —
-//! first by the device that wrote it, then by a second device of the same
-//! account that only ever saw the network.
+//! The write plane, joined end to end: every metadata op kind is staged,
+//! drained, authored, published, self-adopted, and resolved back — first by the
+//! device that wrote it, then by a second device of the same account that only
+//! ever saw the network (#865, #866).
 //!
 //! Later write-plane slices extend this file rather than starting their own.
 
@@ -13,25 +13,30 @@ use cipherbox_core::content::{compute_cid, encode_content_cid_str};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::payload::RepointObject;
-use cipherbox_core::seal::{ReadBody, decode_envelope, open_read_body};
+use cipherbox_core::seal::{
+    ChildRef, NodeKind as CoreNodeKind, ReadBody, decode_envelope, open_read_body,
+};
 use cipherbox_core::suite::ecdsa::EcdsaSigner;
+use zeroize::Zeroizing;
 
 use cipherbox_engine::content::{DAG_ROOT_CODEC, GatewaySource};
 use cipherbox_engine::facade::PendingClass;
+use cipherbox_engine::net::author::{EnvelopeAuthoring, author_child_envelope};
 use cipherbox_engine::seams::{
     BoxedTask, HttpRequest, HttpResponse, OpId, RecordTransport, SeamError, SeamResult,
-    StagingStore,
+    StagingStore, UnixMillis,
 };
-use cipherbox_engine::sync::DRAINED_OP_MARK_KEY;
 use cipherbox_engine::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
+use cipherbox_engine::sync::{DRAINED_OP_MARK_KEY, StagedContent};
+use cipherbox_engine::testkit::fakes::InMemoryRecordStore;
 use cipherbox_engine::testkit::{
     FakeDevice, FakeSeamTypes, FakeWorld, OWNER_ROOT_EPOCH as EPOCH,
     OWNER_ROOT_SCOPE_SEED as READ_SCOPE_SEED, OWNER_ROOT_WRITE_SCOPE_SEED as WRITE_SCOPE_SEED,
     OwnerRootSpec, SeededEntropy, block_on, owner_root_fixture,
 };
 use cipherbox_engine::{
-    Command, Engine, EventStream, GatewayConfig, LoginSecret, NodeId, NodeKind, StoragePolicy,
-    SyncTimingProfile,
+    Command, Engine, EventStream, GatewayConfig, LoginSecret, NodeId, NodeKind, Op, RecordSeal,
+    StoragePolicy, SyncTimingProfile, stage_op,
 };
 
 const SECRET: [u8; 32] = [7u8; 32];

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -859,7 +859,7 @@ fn an_update_content_republishes_the_files_own_record_and_not_its_parent() {
             file,
             StagedContent {
                 root_cid: compute_cid(CONTENT_CID_CODEC, STAGED_ROOT),
-                plaintext_size: 11,
+                plaintext_size: STAGED_ROOT.len() as u64,
             },
             file_sequence,
             UnixMillis(4_242),
@@ -1064,14 +1064,7 @@ fn a_concurrent_dest_writer_is_re_derived_onto_never_clobbered() {
     let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
     let (photos, moved) = seed_folder_and_file(&world, &mut engine, &mut tasks);
 
-    let winner = ChildRef {
-        id: [0xAA; 16],
-        name: "winner.txt".into(),
-        ipns_name: write_name(NodeId([0xAA; 16])).as_str().as_bytes().to_vec(),
-        kind: CoreNodeKind::File,
-        link_counter: 1,
-        unknown: Vec::new(),
-    };
+    let winner = file_ref([0xAA; 16], "winner.txt");
     let records = world.record_store.clone();
     let plane = blocks.clone();
     blocks.refuse_upload(Box::new(move |block| {
@@ -1147,6 +1140,59 @@ fn a_concurrent_writer_at_the_root_dest_is_re_derived_onto_never_clobbered() {
         published_names(&world.record_store, &blocks, ROOT),
         ["photos", "winner.txt"],
         "the winner's entry survived and our dest-add was undone"
+    );
+    assert_eq!(
+        published_names(&world.record_store, &blocks, photos),
+        ["a.txt"],
+        "the source kept the child it could not release"
+    );
+}
+
+/// The rebase resolves a move against a destination it has not loaded, so the
+/// dest can already name the target — dual-link residue a failed compensation
+/// leaves behind. A second ref would sign a listing `author_child_envelope`
+/// always rejects, wedging the op on every retry.
+#[test]
+fn a_dest_that_already_names_the_target_gains_no_second_ref() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let (photos, moved) = seed_folder_and_file(&world, &mut engine, &mut tasks);
+    concurrent_add(
+        &world.record_store,
+        &blocks,
+        photos,
+        file_ref(moved.0, "a.txt"),
+    );
+
+    block_on(engine.command(Command::Relink {
+        node: moved,
+        new_parent: photos,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(
+        published_children(&world.record_store, &blocks, photos)
+            .iter()
+            .filter(|child| child.id == moved.0)
+            .count(),
+        1,
+        "the dest names the moved child exactly once"
+    );
+    assert_eq!(
+        published_names(&world.record_store, &blocks, ROOT),
+        ["photos"],
+        "the source released the child"
+    );
+    assert!(
+        block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .is_empty(),
+        "the op drained rather than wedging the queue"
     );
 }
 

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -9,7 +9,7 @@ use core::task::{Context, Poll, Waker};
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
-use cipherbox_core::content::{compute_cid, encode_content_cid_str};
+use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, encode_content_cid_str};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::payload::RepointObject;
@@ -57,18 +57,31 @@ fn owner_identity() -> EcdsaSigner {
 // gateway, so a block the engine uploads is a block it can later fetch.
 // ---------------------------------------------------------------------------
 
+/// A test hook on the upload path: given a head block about to be stored,
+/// answer whether the upload is refused. Lets a test fail exactly one record's
+/// publish — and interleave a concurrent writer at that instant.
+type UploadHook = Box<dyn FnMut(&[u8]) -> bool + Send>;
+
 #[derive(Clone, Default)]
-struct Blocks(Arc<Mutex<BTreeMap<String, Vec<u8>>>>);
+struct Blocks {
+    store: Arc<Mutex<BTreeMap<String, Vec<u8>>>>,
+    on_upload: Arc<Mutex<Option<UploadHook>>>,
+}
 
 impl Blocks {
     fn put(&self, block: Vec<u8>) -> String {
         let cid = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &block));
-        self.0.lock().expect("lock").insert(cid.clone(), block);
+        self.store.lock().expect("lock").insert(cid.clone(), block);
         cid
     }
 
     fn get(&self, cid: &str) -> Option<Vec<u8>> {
-        self.0.lock().expect("lock").get(cid).cloned()
+        self.store.lock().expect("lock").get(cid).cloned()
+    }
+
+    /// Install the upload hook, replacing any previous one.
+    fn refuse_upload(&self, hook: UploadHook) {
+        *self.on_upload.lock().expect("lock") = Some(hook);
     }
 
     /// Answer one engine HTTP call: a content upload lands its bytes here and
@@ -86,6 +99,11 @@ impl Blocks {
         let url = &request.url;
         if url.ends_with("/content/upload") {
             let block = request.body.clone().unwrap_or_default();
+            if let Some(hook) = self.on_upload.lock().expect("lock").as_mut()
+                && hook(&block)
+            {
+                return Err(SeamError::new("upload refused"));
+            }
             let size = block.len();
             let cid = self.put(block);
             return ok(format!("{{\"cid\":\"{cid}\",\"size\":{size}}}").into_bytes());
@@ -219,6 +237,106 @@ fn poll_each(tasks: &mut [BoxedTask]) -> Vec<Poll<()>> {
 fn tick(world: &FakeWorld, engine: &Engine<FakeSeamTypes>, tasks: &mut [BoxedTask]) {
     world.scheduler.advance(engine.profile().poll_cadence);
     poll_each(tasks);
+}
+
+/// A cold-started engine on `device`, with both spawned loops parked at their
+/// first sleep and the block plane wired for a whole scenario's worth of calls.
+fn boot(
+    world: &FakeWorld,
+    blocks: &Blocks,
+    device: &FakeDevice,
+    entropy_seed: u64,
+) -> (Engine<FakeSeamTypes>, EventStream, Vec<BoxedTask>) {
+    serve_http(device, blocks, 400);
+    let (mut engine, events) = engine_on(device, entropy_seed);
+    block_on(engine.start(secret())).expect("cold start adopts the owner root");
+    let mut tasks = world.scheduler.take_spawned_tasks();
+    poll_each(&mut tasks);
+    (engine, events, tasks)
+}
+
+// ---------------------------------------------------------------------------
+// Record-plane inspection: what a node's published record actually carries.
+// ---------------------------------------------------------------------------
+
+/// A node's write-plane IPNS name (`writeSeed(writeScopeSeed, id)` → keypair).
+fn write_name(node: NodeId) -> IpnsName {
+    IpnsName::from_public_key(
+        &kdf::ipns_keypair(kdf::write_seed(&WRITE_SCOPE_SEED, &node.0).as_bytes()).verifying_key(),
+    )
+}
+
+/// A node's per-node read key (`nodeSeed(readScopeSeed, id)` → `readKey`).
+fn read_key_of(node: NodeId) -> [u8; 32] {
+    *kdf::read_key(kdf::node_seed(&READ_SCOPE_SEED, &node.0).as_bytes()).as_bytes()
+}
+
+/// The `(sequence, headCid)` of the record currently published under `node`'s
+/// write-plane name, verified under that name.
+fn published(world: &FakeWorld, node: NodeId) -> (u64, String) {
+    let name = write_name(node);
+    let bytes = world
+        .record_store
+        .record_at(&world.record_store.endpoints()[0], name.as_str())
+        .expect("the node has a published record");
+    let verified = IpnsRecord::unmarshal(&bytes)
+        .and_then(|record| record.verify(&name))
+        .expect("the published record verifies under its own name");
+    let head_cid = core::str::from_utf8(&verified.value)
+        .expect("utf8 value")
+        .strip_prefix("/ipfs/")
+        .expect("an /ipfs/ pointer")
+        .to_owned();
+    (verified.sequence, head_cid)
+}
+
+/// The child refs a node's published folder body seals.
+fn published_children(world: &FakeWorld, blocks: &Blocks, node: NodeId) -> Vec<ChildRef> {
+    let (_, head_cid) = published(world, node);
+    let envelope = decode_envelope(&blocks.get(&head_cid).expect("the head block")).expect("decodes");
+    match open_read_body(&envelope, &read_key_of(node)).expect("opens under the read-seed key") {
+        ReadBody::Folder { children, .. } => children,
+        ReadBody::File { .. } => panic!("expected a folder body"),
+    }
+}
+
+/// The names a node's published folder body lists, sorted.
+fn published_names(world: &FakeWorld, blocks: &Blocks, node: NodeId) -> Vec<String> {
+    let mut names: Vec<String> = published_children(world, blocks, node)
+        .into_iter()
+        .map(|child| child.name)
+        .collect();
+    names.sort();
+    names
+}
+
+/// The node id every head block this device uploaded was sealed for, in upload
+/// order — the observable record of what published before what.
+fn uploaded_node_ids(device: &FakeDevice) -> Vec<[u8; 16]> {
+    device
+        .http
+        .requests()
+        .iter()
+        .filter(|request| request.url.ends_with("/content/upload"))
+        .filter_map(|request| decode_envelope(request.body.as_deref()?).ok())
+        .map(|envelope| envelope.id)
+        .collect()
+}
+
+/// The node a head block about to be uploaded was sealed for.
+fn head_of(block: &[u8]) -> Option<[u8; 16]> {
+    decode_envelope(block).ok().map(|envelope| envelope.id)
+}
+
+/// The id of `parent`'s child named `name`, from the rendered view.
+fn child_id(engine: &Engine<FakeSeamTypes>, parent: NodeId, name: &str) -> NodeId {
+    block_on(engine.view())
+        .expect("a rendered view")
+        .children(parent)
+        .into_iter()
+        .find(|child| child.name == name)
+        .unwrap_or_else(|| panic!("no child named {name}"))
+        .id
 }
 
 // ---------------------------------------------------------------------------
@@ -553,4 +671,509 @@ async fn drained_mark(device: &FakeDevice) -> Option<u64> {
         .await
         .expect("the staging store answers")
         .map(|bytes| u64::from_be_bytes(bytes.try_into().expect("an 8-byte mark")))
+}
+
+// ---------------------------------------------------------------------------
+// The four remaining op kinds (#866), each to a second device.
+// ---------------------------------------------------------------------------
+
+/// The display name lives only in the parent's child ref
+/// (`crates/core/src/seal/body.rs`), so a rename is one parent republish and
+/// the renamed node's own record never moves.
+#[test]
+fn a_rename_republishes_only_the_parent_and_a_second_device_resolves_it() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "photos".into(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+    let node = child_id(&engine, ROOT, "photos");
+    let (child_sequence, _) = published(&world, node);
+
+    block_on(engine.command(Command::Rename {
+        node,
+        new_name: "pictures".into(),
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(published_names(&world, &blocks, ROOT), ["pictures"]);
+    assert_eq!(
+        published(&world, node).0,
+        child_sequence,
+        "the renamed node's own record never republished"
+    );
+    assert!(
+        block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .is_empty(),
+        "the rename drained"
+    );
+
+    let bob = world.device(b"alice-second-device");
+    let (engine_b, _events_b, _tasks_b) = boot(&world, &blocks, &bob, 7);
+    let children = block_on(engine_b.view()).unwrap().children(ROOT);
+    assert_eq!(children.len(), 1);
+    assert_eq!(children[0].name, "pictures", "device B resolves the rename");
+}
+
+/// A delete drops the parent's ref. The name itself is not retired here —
+/// retire fires on abandonment only (#819 as amended by #824), which is #867's.
+#[test]
+fn a_delete_drops_the_parent_ref_and_a_second_device_resolves_it() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    for name in ["photos", "notes.txt"] {
+        block_on(engine.command(Command::Create {
+            parent: ROOT,
+            name: name.into(),
+            kind: NodeKind::File,
+            content: None,
+        }))
+        .unwrap();
+    }
+    tick(&world, &engine, &mut tasks);
+    let doomed = child_id(&engine, ROOT, "notes.txt");
+
+    block_on(engine.command(Command::Delete { node: doomed })).unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(published_names(&world, &blocks, ROOT), ["photos"]);
+    assert!(
+        block_on(engine.view()).unwrap().attrs(doomed).is_none(),
+        "the deleted node left the rendered view"
+    );
+
+    let bob = world.device(b"alice-second-device");
+    let (engine_b, _events_b, _tasks_b) = boot(&world, &blocks, &bob, 7);
+    let names: Vec<String> = block_on(engine_b.view())
+        .unwrap()
+        .children(ROOT)
+        .into_iter()
+        .map(|child| child.name)
+        .collect();
+    assert_eq!(names, ["photos"], "device B resolves the delete");
+}
+
+/// An intra-scope relink publishes the dest-add before the source-remove, so no
+/// window leaves the child absent from both parents.
+#[test]
+fn a_relink_publishes_the_dest_before_the_source_and_a_second_device_resolves_it() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let (photos, moved) = seed_folder_and_file(&world, &mut engine, &mut tasks);
+    let before = uploaded_node_ids(&alice).len();
+
+    block_on(engine.command(Command::Relink {
+        node: moved,
+        new_parent: photos,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(published_names(&world, &blocks, photos), ["a.txt"]);
+    assert_eq!(published_names(&world, &blocks, ROOT), ["photos"]);
+    assert_eq!(
+        uploaded_node_ids(&alice)[before..],
+        [photos.0, ROOT.0],
+        "dest-add published before the source-remove"
+    );
+    assert_eq!(
+        block_on(engine.snapshot(photos)).unwrap().children.len(),
+        1,
+        "the dest folder's own children are projected into the base"
+    );
+
+    let bob = world.device(b"alice-second-device");
+    let (engine_b, _events_b, _tasks_b) = boot(&world, &blocks, &bob, 7);
+    let names: Vec<String> = block_on(engine_b.view())
+        .unwrap()
+        .children(ROOT)
+        .into_iter()
+        .map(|child| child.name)
+        .collect();
+    assert_eq!(names, ["photos"], "device B resolves the source-remove");
+}
+
+/// `updateContent`'s metadata half: a file's own record carries its
+/// `modifiedAt`, and its parent holds no size/mtime mirror to republish. The
+/// facade cannot form this op until the content slice (#868), so it is staged
+/// straight into the durable queue the drain reads.
+#[test]
+fn an_update_content_republishes_the_files_own_record_and_not_its_parent() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "notes.txt".into(),
+        kind: NodeKind::File,
+        content: None,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+    let file = child_id(&engine, ROOT, "notes.txt");
+    let (file_sequence, _) = published(&world, file);
+    let (root_sequence, _) = published(&world, ROOT);
+
+    const STAGED_ROOT: &[u8] = b"a staged version root";
+    stage(
+        &alice,
+        &Op::update_content(
+            file,
+            StagedContent {
+                root_cid: compute_cid(CONTENT_CID_CODEC, STAGED_ROOT),
+                plaintext_size: 11,
+            },
+            file_sequence,
+            UnixMillis(4_242),
+        ),
+        Some(STAGED_ROOT),
+    );
+    tick(&world, &engine, &mut tasks);
+
+    let (sequence, head_cid) = published(&world, file);
+    assert_eq!(sequence, file_sequence + 1, "the file's own record advanced");
+    assert_eq!(
+        published(&world, ROOT).0,
+        root_sequence,
+        "a child write never republishes its parent"
+    );
+    let envelope = decode_envelope(&blocks.get(&head_cid).unwrap()).unwrap();
+    let ReadBody::File {
+        modified_at,
+        versions,
+        ..
+    } = open_read_body(&envelope, &read_key_of(file)).unwrap()
+    else {
+        panic!("expected a file body");
+    };
+    assert_eq!(
+        modified_at, 4_242,
+        "the journaled authoring time, never a clock read at publish"
+    );
+    assert!(
+        versions.is_empty(),
+        "the version this op stages is the content slice's"
+    );
+
+    let bob = world.device(b"alice-second-device");
+    let (engine_b, _events_b, _tasks_b) = boot(&world, &blocks, &bob, 7);
+    assert_eq!(
+        block_on(engine_b.view()).unwrap().children(ROOT).len(),
+        1,
+        "device B resolves a root the metadata write left alone"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The reference-ordering law (#819) and the dest-add compensation (#786).
+// ---------------------------------------------------------------------------
+
+/// The one rule whose violation cannot be retracted: a reference must never
+/// outlive its referent. A rename of a node whose create is still queued
+/// publishes the child's own record before the parent that names it.
+#[test]
+fn a_rename_of_a_still_queued_create_publishes_child_before_parent() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let op = block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "photos".into(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .unwrap();
+    assert!(op.is_some());
+    let node = child_id(&engine, ROOT, "photos");
+    // Renamed while the create is still queued: both drain in one pass.
+    block_on(engine.command(Command::Rename {
+        node,
+        new_name: "pictures".into(),
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(
+        uploaded_node_ids(&alice),
+        [node.0, ROOT.0, ROOT.0],
+        "the child's record precedes every parent that names it"
+    );
+    assert_eq!(published_names(&world, &blocks, ROOT), ["pictures"]);
+    // The parent's ref resolves: no reference outlived its referent.
+    let child = &published_children(&world, &blocks, ROOT)[0];
+    assert_eq!(child.ipns_name, write_name(node).as_str().as_bytes());
+    assert!(
+        world
+            .record_store
+            .record_at(&world.record_store.endpoints()[0], write_name(node).as_str())
+            .is_some(),
+        "the name the parent points at resolves"
+    );
+}
+
+/// A create below the scope root publishes, and its parent folder is authored
+/// through the child envelope path rather than the root's (#887).
+#[test]
+fn a_create_below_the_scope_root_publishes_and_projects() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "photos".into(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+    let photos = child_id(&engine, ROOT, "photos");
+
+    block_on(engine.command(Command::Create {
+        parent: photos,
+        name: "2026".into(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    assert!(
+        block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .is_empty(),
+        "a deeper create no longer halts the drain"
+    );
+    assert_eq!(published_names(&world, &blocks, photos), ["2026"]);
+    assert_eq!(
+        published_names(&world, &blocks, ROOT),
+        ["photos"],
+        "a child write stops at the immediate parent"
+    );
+    let view = block_on(engine.snapshot(photos)).unwrap();
+    assert_eq!(view.children.len(), 1);
+    assert_eq!(view.children[0].name, "2026");
+}
+
+/// A source-remove that will not publish compensates its own dest-add rather
+/// than leaving the child linked under both parents.
+#[test]
+fn a_source_remove_that_cannot_publish_undoes_its_own_dest_add() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let (photos, moved) = seed_folder_and_file(&world, &mut engine, &mut tasks);
+
+    // The root's own head upload is refused, so the source-remove cannot land.
+    blocks.refuse_upload(Box::new(|block| head_of(block) == Some(ROOT.0)));
+    block_on(engine.command(Command::Relink {
+        node: moved,
+        new_parent: photos,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    assert!(
+        published_children(&world, &blocks, photos).is_empty(),
+        "the dest-add was compensated, not left as a dual link"
+    );
+    assert_eq!(
+        published_names(&world, &blocks, ROOT),
+        ["a.txt", "photos"],
+        "the source kept the child it could not release"
+    );
+    assert_eq!(
+        block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .len(),
+        1,
+        "the halted op stays queued for the next tick"
+    );
+}
+
+/// The adversarial interleave at the compensation seam: a concurrent writer
+/// lands a strictly-newer dest record between the dest-add and its undo. The
+/// versioned compare-and-remove refuses to replay a stale copy over the winner
+/// and re-derives the removal onto the record the winner published (#786).
+#[test]
+fn a_concurrent_dest_writer_is_re_derived_onto_never_clobbered() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let (photos, moved) = seed_folder_and_file(&world, &mut engine, &mut tasks);
+
+    let winner = ChildRef {
+        id: [0xAA; 16],
+        name: "winner.txt".into(),
+        ipns_name: write_name(NodeId([0xAA; 16])).as_str().as_bytes().to_vec(),
+        kind: CoreNodeKind::File,
+        link_counter: 1,
+        unknown: Vec::new(),
+    };
+    let records = world.record_store.clone();
+    let plane = blocks.clone();
+    blocks.refuse_upload(Box::new(move |block| {
+        if head_of(block) != Some(ROOT.0) {
+            return false;
+        }
+        // The instant our source-remove fails, another writer advances the dest.
+        concurrent_add(&records, &plane, photos, winner.clone());
+        true
+    }));
+    block_on(engine.command(Command::Relink {
+        node: moved,
+        new_parent: photos,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(
+        published_names(&world, &blocks, photos),
+        ["winner.txt"],
+        "the winner's entry survived and our dest-add was undone"
+    );
+    assert_eq!(
+        published_names(&world, &blocks, ROOT),
+        ["a.txt", "photos"],
+        "the source kept the child"
+    );
+}
+
+// ---------------------------------------------------------------------------
+
+/// A root holding an empty `photos` folder and a file `a.txt`, both published.
+fn seed_folder_and_file(
+    world: &FakeWorld,
+    engine: &mut Engine<FakeSeamTypes>,
+    tasks: &mut [BoxedTask],
+) -> (NodeId, NodeId) {
+    block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "photos".into(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .unwrap();
+    block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "a.txt".into(),
+        kind: NodeKind::File,
+        content: None,
+    }))
+    .unwrap();
+    tick(world, engine, tasks);
+    (child_id(engine, ROOT, "photos"), child_id(engine, ROOT, "a.txt"))
+}
+
+/// Stage an op straight into the durable queue, for a mutation the facade
+/// cannot form yet.
+fn stage(device: &FakeDevice, op: &Op, upload: Option<&[u8]>) {
+    block_on(stage_op(
+        &device.staging_store,
+        &StoragePolicy::CI,
+        RecordSeal {
+            owner_enc_pub: kdf::enc_subkey(&SECRET).public(),
+            ephemeral_scalar: Zeroizing::new([0x5A; 32]),
+        },
+        op,
+        upload,
+    ))
+    .expect("the op queues");
+}
+
+/// Another writer publishes `folder`'s next record, adding `extra` on top of
+/// whatever the folder currently carries.
+fn concurrent_add(
+    records: &InMemoryRecordStore,
+    blocks: &Blocks,
+    folder: NodeId,
+    extra: ChildRef,
+) {
+    let name = write_name(folder);
+    let current = records
+        .record_at(&records.endpoints()[0], name.as_str())
+        .expect("the dest is published");
+    let verified = IpnsRecord::unmarshal(&current)
+        .and_then(|record| record.verify(&name))
+        .expect("verifies");
+    let head_cid = core::str::from_utf8(&verified.value)
+        .expect("utf8")
+        .strip_prefix("/ipfs/")
+        .expect("an /ipfs/ pointer");
+    let envelope = decode_envelope(&blocks.get(head_cid).expect("the head block")).expect("decodes");
+    let read_key = read_key_of(folder);
+    let ReadBody::Folder {
+        created_at,
+        modified_at,
+        mut children,
+        unknown,
+    } = open_read_body(&envelope, &read_key).expect("opens")
+    else {
+        panic!("expected a folder body");
+    };
+    children.push(extra);
+
+    let head = author_child_envelope(EnvelopeAuthoring {
+        node_id: folder.0,
+        scope_id: SCOPE,
+        epoch: envelope.epoch,
+        read_key: &read_key,
+        nonce: &[0x3C; 24],
+        body: &ReadBody::Folder {
+            created_at,
+            modified_at,
+            children,
+            unknown,
+        },
+        carried_unknown: envelope.unknown.clone(),
+        carried_epoch_tag_unknown: envelope.epoch_tag_unknown.clone(),
+    })
+    .expect("the concurrent writer authors a valid record");
+    blocks.put(head.block.clone());
+
+    let signer = kdf::ipns_keypair(kdf::write_seed(&WRITE_SCOPE_SEED, &folder.0).as_bytes());
+    let record = IpnsRecord::create_v2(
+        &signer,
+        format!("/ipfs/{}", head.cid).as_bytes(),
+        verified.sequence + 1,
+        TTL_NANOS,
+        EOL,
+    )
+    .marshal();
+    for endpoint in records.endpoints() {
+        records.seed_record(&endpoint, name.as_str(), record.clone());
+    }
 }

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -273,11 +273,10 @@ fn read_key_of(node: NodeId) -> [u8; 32] {
 
 /// The `(sequence, headCid)` of the record currently published under `node`'s
 /// write-plane name, verified under that name.
-fn published(world: &FakeWorld, node: NodeId) -> (u64, String) {
+fn published(records: &InMemoryRecordStore, node: NodeId) -> (u64, String) {
     let name = write_name(node);
-    let bytes = world
-        .record_store
-        .record_at(&world.record_store.endpoints()[0], name.as_str())
+    let bytes = records
+        .record_at(&records.endpoints()[0], name.as_str())
         .expect("the node has a published record");
     let verified = IpnsRecord::unmarshal(&bytes)
         .and_then(|record| record.verify(&name))
@@ -291,8 +290,12 @@ fn published(world: &FakeWorld, node: NodeId) -> (u64, String) {
 }
 
 /// The child refs a node's published folder body seals.
-fn published_children(world: &FakeWorld, blocks: &Blocks, node: NodeId) -> Vec<ChildRef> {
-    let (_, head_cid) = published(world, node);
+fn published_children(
+    records: &InMemoryRecordStore,
+    blocks: &Blocks,
+    node: NodeId,
+) -> Vec<ChildRef> {
+    let (_, head_cid) = published(records, node);
     let envelope =
         decode_envelope(&blocks.get(&head_cid).expect("the head block")).expect("decodes");
     match open_read_body(&envelope, &read_key_of(node)).expect("opens under the read-seed key") {
@@ -302,8 +305,8 @@ fn published_children(world: &FakeWorld, blocks: &Blocks, node: NodeId) -> Vec<C
 }
 
 /// The names a node's published folder body lists, sorted.
-fn published_names(world: &FakeWorld, blocks: &Blocks, node: NodeId) -> Vec<String> {
-    let mut names: Vec<String> = published_children(world, blocks, node)
+fn published_names(records: &InMemoryRecordStore, blocks: &Blocks, node: NodeId) -> Vec<String> {
+    let mut names: Vec<String> = published_children(records, blocks, node)
         .into_iter()
         .map(|child| child.name)
         .collect();
@@ -698,7 +701,7 @@ fn a_rename_republishes_only_the_parent_and_a_second_device_resolves_it() {
     .unwrap();
     tick(&world, &engine, &mut tasks);
     let node = child_id(&engine, ROOT, "photos");
-    let (child_sequence, _) = published(&world, node);
+    let (child_sequence, _) = published(&world.record_store, node);
 
     block_on(engine.command(Command::Rename {
         node,
@@ -707,9 +710,12 @@ fn a_rename_republishes_only_the_parent_and_a_second_device_resolves_it() {
     .unwrap();
     tick(&world, &engine, &mut tasks);
 
-    assert_eq!(published_names(&world, &blocks, ROOT), ["pictures"]);
     assert_eq!(
-        published(&world, node).0,
+        published_names(&world.record_store, &blocks, ROOT),
+        ["pictures"]
+    );
+    assert_eq!(
+        published(&world.record_store, node).0,
         child_sequence,
         "the renamed node's own record never republished"
     );
@@ -752,7 +758,10 @@ fn a_delete_drops_the_parent_ref_and_a_second_device_resolves_it() {
     block_on(engine.command(Command::Delete { node: doomed })).unwrap();
     tick(&world, &engine, &mut tasks);
 
-    assert_eq!(published_names(&world, &blocks, ROOT), ["photos"]);
+    assert_eq!(
+        published_names(&world.record_store, &blocks, ROOT),
+        ["photos"]
+    );
     assert!(
         block_on(engine.view()).unwrap().attrs(doomed).is_none(),
         "the deleted node left the rendered view"
@@ -789,8 +798,14 @@ fn a_relink_publishes_the_dest_before_the_source_and_a_second_device_resolves_it
     .unwrap();
     tick(&world, &engine, &mut tasks);
 
-    assert_eq!(published_names(&world, &blocks, photos), ["a.txt"]);
-    assert_eq!(published_names(&world, &blocks, ROOT), ["photos"]);
+    assert_eq!(
+        published_names(&world.record_store, &blocks, photos),
+        ["a.txt"]
+    );
+    assert_eq!(
+        published_names(&world.record_store, &blocks, ROOT),
+        ["photos"]
+    );
     assert_eq!(
         uploaded_node_ids(&alice)[before..],
         [photos.0, ROOT.0],
@@ -834,8 +849,8 @@ fn an_update_content_republishes_the_files_own_record_and_not_its_parent() {
     .unwrap();
     tick(&world, &engine, &mut tasks);
     let file = child_id(&engine, ROOT, "notes.txt");
-    let (file_sequence, _) = published(&world, file);
-    let (root_sequence, _) = published(&world, ROOT);
+    let (file_sequence, _) = published(&world.record_store, file);
+    let (root_sequence, _) = published(&world.record_store, ROOT);
 
     const STAGED_ROOT: &[u8] = b"a staged version root";
     stage(
@@ -853,14 +868,14 @@ fn an_update_content_republishes_the_files_own_record_and_not_its_parent() {
     );
     tick(&world, &engine, &mut tasks);
 
-    let (sequence, head_cid) = published(&world, file);
+    let (sequence, head_cid) = published(&world.record_store, file);
     assert_eq!(
         sequence,
         file_sequence + 1,
         "the file's own record advanced"
     );
     assert_eq!(
-        published(&world, ROOT).0,
+        published(&world.record_store, ROOT).0,
         root_sequence,
         "a child write never republishes its parent"
     );
@@ -928,9 +943,12 @@ fn a_rename_of_a_still_queued_create_publishes_child_before_parent() {
         [node.0, ROOT.0, ROOT.0],
         "the child's record precedes every parent that names it"
     );
-    assert_eq!(published_names(&world, &blocks, ROOT), ["pictures"]);
+    assert_eq!(
+        published_names(&world.record_store, &blocks, ROOT),
+        ["pictures"]
+    );
     // The parent's ref resolves: no reference outlived its referent.
-    let child = &published_children(&world, &blocks, ROOT)[0];
+    let child = &published_children(&world.record_store, &blocks, ROOT)[0];
     assert_eq!(child.ipns_name, write_name(node).as_str().as_bytes());
     assert!(
         world
@@ -979,9 +997,12 @@ fn a_create_below_the_scope_root_publishes_and_projects() {
             .is_empty(),
         "a deeper create no longer halts the drain"
     );
-    assert_eq!(published_names(&world, &blocks, photos), ["2026"]);
     assert_eq!(
-        published_names(&world, &blocks, ROOT),
+        published_names(&world.record_store, &blocks, photos),
+        ["2026"]
+    );
+    assert_eq!(
+        published_names(&world.record_store, &blocks, ROOT),
         ["photos"],
         "a child write stops at the immediate parent"
     );
@@ -1012,11 +1033,11 @@ fn a_source_remove_that_cannot_publish_undoes_its_own_dest_add() {
     tick(&world, &engine, &mut tasks);
 
     assert!(
-        published_children(&world, &blocks, photos).is_empty(),
+        published_children(&world.record_store, &blocks, photos).is_empty(),
         "the dest-add was compensated, not left as a dual link"
     );
     assert_eq!(
-        published_names(&world, &blocks, ROOT),
+        published_names(&world.record_store, &blocks, ROOT),
         ["a.txt", "photos"],
         "the source kept the child it could not release"
     );
@@ -1069,18 +1090,236 @@ fn a_concurrent_dest_writer_is_re_derived_onto_never_clobbered() {
     tick(&world, &engine, &mut tasks);
 
     assert_eq!(
-        published_names(&world, &blocks, photos),
+        published_names(&world.record_store, &blocks, photos),
         ["winner.txt"],
         "the winner's entry survived and our dest-add was undone"
     );
     assert_eq!(
-        published_names(&world, &blocks, ROOT),
+        published_names(&world.record_store, &blocks, ROOT),
         ["a.txt", "photos"],
         "the source kept the child"
     );
 }
 
+/// #786's guarantee has to hold when the destination is the scope root — the
+/// commonest move there is. The root is otherwise read from this device's own
+/// cache, which could never show the concurrent writer the compare exists to
+/// yield to.
+#[test]
+fn a_concurrent_writer_at_the_root_dest_is_re_derived_onto_never_clobbered() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let (photos, moved) = seed_folder_and_file(&world, &mut engine, &mut tasks);
+    // Park the file inside `photos` so the move back out has the root as dest.
+    block_on(engine.command(Command::Relink {
+        node: moved,
+        new_parent: photos,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+    assert_eq!(
+        published_names(&world.record_store, &blocks, photos),
+        ["a.txt"]
+    );
+
+    let winner = file_ref([0xAA; 16], "winner.txt");
+    let records = world.record_store.clone();
+    let plane = blocks.clone();
+    blocks.refuse_upload(Box::new(move |block| {
+        if head_of(block) != Some(photos.0) {
+            return false;
+        }
+        concurrent_root_add(&records, &plane, winner.clone());
+        true
+    }));
+    block_on(engine.command(Command::Relink {
+        node: moved,
+        new_parent: ROOT,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(
+        published_names(&world.record_store, &blocks, ROOT),
+        ["photos", "winner.txt"],
+        "the winner's entry survived and our dest-add was undone"
+    );
+}
+
+/// A move into the subtree it is moving would detach that subtree from the
+/// scope root with nothing left to walk it from.
+#[test]
+fn a_relink_into_its_own_descendant_or_itself_is_refused() {
+    for into_itself in [true, false] {
+        let world = FakeWorld::new();
+        let blocks = Blocks::default();
+        seed_account(&world, &blocks);
+
+        let alice = world.device(b"alice");
+        let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+        block_on(engine.command(Command::Create {
+            parent: ROOT,
+            name: "photos".into(),
+            kind: NodeKind::Folder,
+            content: None,
+        }))
+        .unwrap();
+        tick(&world, &engine, &mut tasks);
+        let photos = child_id(&engine, ROOT, "photos");
+        block_on(engine.command(Command::Create {
+            parent: photos,
+            name: "2026".into(),
+            kind: NodeKind::Folder,
+            content: None,
+        }))
+        .unwrap();
+        tick(&world, &engine, &mut tasks);
+        let inner = child_id(&engine, photos, "2026");
+
+        block_on(engine.command(Command::Relink {
+            node: photos,
+            new_parent: if into_itself { photos } else { inner },
+        }))
+        .unwrap();
+        tick(&world, &engine, &mut tasks);
+
+        assert_eq!(
+            published_names(&world.record_store, &blocks, ROOT),
+            ["photos"],
+            "the subtree stays reachable from the scope root"
+        );
+        assert_eq!(
+            published_names(&world.record_store, &blocks, inner),
+            Vec::<String>::new(),
+            "no folder ever names its own ancestor"
+        );
+        assert!(
+            block_on(StagingStore::queued_ops(&alice.staging_store))
+                .unwrap()
+                .is_empty(),
+            "the op dead-letters rather than wedging the queue"
+        );
+    }
+}
+
+/// State below the scope root is the drain's own output. A remote root advance
+/// must merge into the base, never replace it — a rebuilt base would erase the
+/// deeper tree and dead-letter every queued op that rebases onto it.
+#[test]
+fn a_remote_root_advance_leaves_a_queued_deep_op_publishable() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "photos".into(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+    let photos = child_id(&engine, ROOT, "photos");
+    block_on(engine.command(Command::Create {
+        parent: photos,
+        name: "2026".into(),
+        kind: NodeKind::Folder,
+        content: None,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+    let inner = child_id(&engine, photos, "2026");
+
+    // A depth-2 rename queued, then another device advances the root under us.
+    block_on(engine.command(Command::Rename {
+        node: inner,
+        new_name: "2027".into(),
+    }))
+    .unwrap();
+    concurrent_root_add(
+        &world.record_store,
+        &blocks,
+        file_ref([0xAA; 16], "winner.txt"),
+    );
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(
+        published_names(&world.record_store, &blocks, photos),
+        ["2027"],
+        "the deep rename published rather than dead-lettering onto a truncated base"
+    );
+    assert_eq!(
+        published_names(&world.record_store, &blocks, ROOT),
+        ["photos", "winner.txt"],
+        "and the remote writer's own entry survived"
+    );
+    assert!(
+        block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .is_empty()
+    );
+}
+
+/// A pass now seals many records. Each must draw its own nonce: a reused nonce
+/// under one key is a confidentiality break, not a degraded mode.
+#[test]
+fn every_record_one_pass_seals_carries_a_distinct_nonce() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let (photos, moved) = seed_folder_and_file(&world, &mut engine, &mut tasks);
+    block_on(engine.command(Command::Relink {
+        node: moved,
+        new_parent: photos,
+    }))
+    .unwrap();
+    block_on(engine.command(Command::Rename {
+        node: photos,
+        new_name: "pictures".into(),
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    let nonces: Vec<Vec<u8>> = alice
+        .http
+        .requests()
+        .iter()
+        .filter(|request| request.url.ends_with("/content/upload"))
+        .filter_map(|request| decode_envelope(request.body.as_deref()?).ok())
+        // `readSealed` is `nonce(24) || ciphertext||tag`.
+        .map(|envelope| envelope.read_sealed[..24].to_vec())
+        .collect();
+    let distinct: std::collections::BTreeSet<Vec<u8>> = nonces.iter().cloned().collect();
+    assert!(nonces.len() > 3, "the pass sealed several records");
+    assert_eq!(
+        distinct.len(),
+        nonces.len(),
+        "every seal drew a fresh nonce"
+    );
+}
+
 // ---------------------------------------------------------------------------
+
+/// A file child ref under this account's write-name edge.
+fn file_ref(id: [u8; 16], name: &str) -> ChildRef {
+    ChildRef {
+        id,
+        name: name.into(),
+        ipns_name: write_name(NodeId(id)).as_str().as_bytes().to_vec(),
+        kind: CoreNodeKind::File,
+        link_counter: 1,
+        unknown: Vec::new(),
+    }
+}
 
 /// A root holding an empty `photos` folder and a file `a.txt`, both published.
 fn seed_folder_and_file(
@@ -1125,22 +1364,43 @@ fn stage(device: &FakeDevice, op: &Op, upload: Option<&[u8]>) {
     .expect("the op queues");
 }
 
+/// Another writer publishes the **scope root**'s next record, adding `extra` on
+/// top of whatever the root currently carries. The root carries a grant section,
+/// so it re-authors through the owner-root fixture rather than the child path.
+fn concurrent_root_add(records: &InMemoryRecordStore, blocks: &Blocks, extra: ChildRef) {
+    let (sequence, _) = published(records, ROOT);
+    let mut children = published_children(records, blocks, ROOT);
+    children.push(extra);
+    let fixture = owner_root_fixture(OwnerRootSpec {
+        owner_identity: &owner_identity(),
+        owner_enc: &kdf::enc_subkey(&SECRET).public(),
+        scope_id: SCOPE,
+        root_id: ROOT.0,
+        children,
+        owner_write_blob_epoch: Some(EPOCH),
+    });
+    blocks.put(fixture.head_block.clone());
+    let signer = kdf::ipns_keypair(kdf::write_seed(&WRITE_SCOPE_SEED, &ROOT.0).as_bytes());
+    let record = IpnsRecord::create_v2(
+        &signer,
+        format!("/ipfs/{}", fixture.head_cid_str).as_bytes(),
+        sequence + 1,
+        TTL_NANOS,
+        EOL,
+    )
+    .marshal();
+    for endpoint in records.endpoints() {
+        records.seed_record(&endpoint, fixture.name.as_str(), record.clone());
+    }
+}
+
 /// Another writer publishes `folder`'s next record, adding `extra` on top of
 /// whatever the folder currently carries.
 fn concurrent_add(records: &InMemoryRecordStore, blocks: &Blocks, folder: NodeId, extra: ChildRef) {
     let name = write_name(folder);
-    let current = records
-        .record_at(&records.endpoints()[0], name.as_str())
-        .expect("the dest is published");
-    let verified = IpnsRecord::unmarshal(&current)
-        .and_then(|record| record.verify(&name))
-        .expect("verifies");
-    let head_cid = core::str::from_utf8(&verified.value)
-        .expect("utf8")
-        .strip_prefix("/ipfs/")
-        .expect("an /ipfs/ pointer");
+    let (sequence, head_cid) = published(records, folder);
     let envelope =
-        decode_envelope(&blocks.get(head_cid).expect("the head block")).expect("decodes");
+        decode_envelope(&blocks.get(&head_cid).expect("the head block")).expect("decodes");
     let read_key = read_key_of(folder);
     let ReadBody::Folder {
         created_at,
@@ -1175,7 +1435,7 @@ fn concurrent_add(records: &InMemoryRecordStore, blocks: &Blocks, folder: NodeId
     let record = IpnsRecord::create_v2(
         &signer,
         format!("/ipfs/{}", head.cid).as_bytes(),
-        verified.sequence + 1,
+        sequence + 1,
         TTL_NANOS,
         EOL,
     )


### PR DESCRIPTION
Widens the drain from the folder-create vertical to every metadata op kind, and lands the one rule whose violation cannot be retracted.

## What landed

**The four remaining `OpKind`s** — `Delete` (conditional on `target_sequence`), `Rename`, intra-scope `Relink`, and `UpdateContent`'s metadata half — publish under #819's reference-ordering law: a reference must never outlive its referent.

**`undo_dest_add_versioned` gets its first non-test caller.** It shipped as an unwired primitive. The compensation call site now uses the versioned variant, threads `observed` from the same dest-parent record read the publish seq-CAS asserts against, and on `Conflict` re-reads the dest parent at its new sequence and re-derives.

**Folders below the scope root become authorable**, so a deeper create no longer halts the drain.

## Two data-loss paths the widening itself opened, closed before merge

Both were found by the review gates and fixed in `c6e3033d7`, each pinned by a test:

- **A relink into its own subtree** would detach the moved folder from the root permanently — `a_relink_into_its_own_descendant_or_itself_is_refused`.
- **A root re-projection rebuilt the base and erased the deeper tree** that every queued op rebases onto, dead-lettering deep ops onto a truncated base — `a_remote_root_advance_leaves_a_queued_deep_op_publishable`.

The dest-add compensation was also made fail-closed for real: an authoritative version read, a presence-conditional source check, and the scope root's own gate on re-read — `a_source_remove_that_cannot_publish_undoes_its_own_dest_add`, plus concurrent-writer re-derivation at both the dest and the root.

## Gate

`crates/engine/tests/write_plane.rs` grows to cover every widened kind end to end, on the existing **`Engine Tests`** gate (`cargo test -p cipherbox-engine`) — no workflow change needed.

## Verification

Rebased onto `efcff7944` (post-#891) and re-verified after the rebase, not before:

- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test --workspace` — all suites pass, 0 failures. This includes `crates/fuse` at 29 unit + 26 integration: #885 and #886 were each individually green yet did not compile together, so the workspace-scoped run is the one that matters here.
- `cargo check --target wasm32-unknown-unknown` clean for `cipherbox-core` and `cipherbox-wasm` — `--workspace` does not cover the wasm target.
- No KAT vector drift.

`RecordSeal` was updated for #891's switch to HPKE auth mode (`owner_enc_pub` → `owner_enc_secret`).

## Out of scope

Cross-scope re-seal and the scope-exit rotation trigger stay with #635; content bytes with #868; drain failure policy — dead-letter, blocked, abandonment — with #867.

Closes #866
Closes #786
Closes #887
Part of #655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved synchronization across devices for creates, renames, deletions, moves, and content updates.
  * More reliable preservation and reuse of staged folder/file data during queued operations and re-projection.
* **Bug Fixes**
  * Prevented relinking into the moved target’s own subtree, marking such operations as dead-lettered.
  * Strengthened validation and invariant checks so invalid records are rejected more consistently.
  * Improved reconciliation when remote updates happen during queued publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->