### PR TITLE
docs: sweep the engine and core comments back to the AGENTS.md discipline

### DIFF
--- a/crates/core/examples/kat_gen.rs
+++ b/crates/core/examples/kat_gen.rs
@@ -2899,13 +2899,10 @@ fn build_read_body_reject() -> Vec<RejectVector> {
 }
 
 fn build_envelope_accept() -> Vec<EnvelopeAcceptVector> {
-    // Every seal below reuses the one fixed (key, nonce) from `seal_probe()`.
-    // That is deliberate and required here: KAT vectors must be byte-reproducible,
-    // so the generator injects a pinned nonce rather than sampling one. It is NOT
-    // a sanctioned production pattern — production sources a unique nonce per seal
-    // from the entropy seam (see `seal()`'s doc: XChaCha20-Poly1305 nonce reuse
-    // under one key breaks confidentiality and integrity). These fixtures protect
-    // no real data; they only pin the wire format and the accept verdict.
+    // Every seal below reuses the one fixed (key, nonce) from `seal_probe()`:
+    // KAT vectors must be byte-reproducible, so the generator injects a pinned
+    // nonce. NOT a production pattern — production sources a unique nonce per
+    // seal from the entropy seam (see `seal()`'s doc for why).
     let p = seal_probe();
     let bodies: Vec<(&str, ReadBody)> = vec![("folder", sample_folder()), ("file", sample_file())];
 

--- a/crates/core/src/codec/encode.rs
+++ b/crates/core/src/codec/encode.rs
@@ -22,11 +22,10 @@ pub(super) const SIMPLE_NULL: u8 = 22;
 ///
 /// Two-pass: [`encoded_len`] sizes the buffer up front so the single allocation
 /// is exact and the write never reallocates. A grow-from-empty `Vec` frees each
-/// intermediate backing store un-zeroized, stranding secret bytes (content keys,
-/// scope/override/history seeds) in freed heap; with one right-sized buffer only
-/// the terminal owner's plaintext ever holds them, and that owner zeroizes it.
-/// Sizing first is also what makes [`check_depth`] fail closed instead of
-/// overflowing the stack: the deeper pass runs before anything is allocated.
+/// intermediate backing store un-zeroized, stranding secret bytes in freed heap;
+/// one right-sized buffer keeps them to the terminal owner's plaintext, which
+/// that owner zeroizes. Sizing first is also what makes [`check_depth`] fail
+/// closed instead of overflowing the stack: it runs before anything is allocated.
 pub fn encode(value: &Value) -> Result<Vec<u8>, CodecError> {
     let mut out = Vec::with_capacity(encoded_len(value)?);
     write_value(&mut out, value, 0)?;
@@ -258,11 +257,9 @@ mod tests {
         assert_eq!(super::super::decode(&bytes).unwrap(), deepest);
     }
 
-    /// The security invariant: encoding secret-bearing bytes performs a single
-    /// allocation and never reallocates, so no intermediate backing store is
-    /// freed un-zeroized. Capturing the pointer and capacity after the reserve
-    /// and asserting both are unchanged after the write proves the buffer never
-    /// moved (a realloc would move it and/or grow capacity), independent of any
+    /// The security invariant: encoding secret-bearing bytes never reallocates,
+    /// so no intermediate backing store is freed un-zeroized. An unchanged
+    /// pointer *and* capacity across the write proves it, independent of any
     /// allocator over-allocation.
     #[test]
     fn secret_bearing_encode_never_reallocates() {

--- a/crates/core/src/codec/mod.rs
+++ b/crates/core/src/codec/mod.rs
@@ -10,8 +10,8 @@
 //! The profile is a strict subset of DAG-CBOR, so every encoding this module
 //! emits is a valid DAG-CBOR block. (With text-only map keys, RFC 8949's
 //! bytewise key order and DAG-CBOR's length-first order coincide — pinned by
-//! test.) Envelope, body, and structure schema codecs build on this module in
-//! later slices; nothing outside it touches raw CBOR.
+//! test.) Every schema codec builds on this module; nothing outside it touches
+//! raw CBOR.
 
 mod decode;
 mod encode;

--- a/crates/core/src/codec/value.rs
+++ b/crates/core/src/codec/value.rs
@@ -119,25 +119,19 @@ impl Value {
     }
 
     /// Scrub every owned byte and text buffer in this value tree in place: each
-    /// [`Value::Bytes`] and each [`Value::Text`] has its contents wiped from
-    /// memory and is cleared to empty (`Vec`/`String` `zeroize` semantics),
-    /// while the tree's shape and every other value are left intact.
+    /// [`Value::Bytes`] and each [`Value::Text`] is wiped from memory and cleared
+    /// to empty (`Vec`/`String` `zeroize` semantics), while the tree's shape and
+    /// every other value are left intact.
     ///
-    /// A sealed-body encode/decode path builds a transient `Value` tree that
-    /// carries verbatim copies of secret material — inline **content-key** bytes
-    /// (one [`Value::Bytes`] per file version, [`encode_read_body`]) and scope
-    /// **seed** bytes (grant/owner/history payloads). That tree is built and
-    /// owned by the codec layer, so the codec is its terminal owner and wipes it
-    /// here before it drops, closing the window where a freed-but-uncleared copy
-    /// of key material would linger on the heap (blueprint/core.md "Crypto
-    /// suite": key material lives only in zeroizing owners). Non-secret buffers
-    /// (ids, cids, ipnsNames) are wiped too: they are all transient copies, so a
-    /// whole-tree wipe needs no per-field secret classification and stays correct
-    /// as later bodies add secret fields. [`Value::Text`] is wiped for the same
-    /// reason — a transient copy of a filename is user-private metadata in a ZK
-    /// system, so it never lingers uncleared either. This only ever touches the
-    /// codec's own transient copies — the caller's
-    /// [`SecretBytes`](crate::suite::secret::SecretBytes) inputs are untouched.
+    /// The codec builds and owns the transient `Value` tree of a sealed-body
+    /// encode/decode, which carries verbatim copies of secret material — inline
+    /// content-key bytes ([`encode_read_body`]) and scope seed bytes — so the
+    /// codec is that tree's terminal owner and wipes it before it drops
+    /// (blueprint/core.md "Crypto suite": key material lives only in zeroizing
+    /// owners). Non-secret buffers are wiped too — every buffer here is a
+    /// transient copy, so a whole-tree wipe needs no per-field secret
+    /// classification and stays correct as later bodies add secret fields; text
+    /// included, since a filename is user-private metadata in a ZK system.
     ///
     /// [`encode_read_body`]: crate::seal::encode_read_body
     pub(crate) fn zeroize_bytes(&mut self) {
@@ -231,8 +225,7 @@ impl Map {
     }
 
     /// Zeroize every entry value's owned byte buffers in place (keys are text,
-    /// never secret). See [`Value::zeroize_bytes`] for the terminal-owner
-    /// rationale — the caller owns this map and is its terminal owner.
+    /// never secret). See [`Value::zeroize_bytes`].
     pub(crate) fn zeroize_bytes(&mut self) {
         for (_, v) in &mut self.entries {
             v.zeroize_bytes();
@@ -360,9 +353,8 @@ mod tests {
 
     #[test]
     fn zeroize_bytes_wipes_every_nested_byte_buffer() {
-        // A tree shaped like the sealed-body encode tree: a map holding an
-        // array of maps, each with a secret-carrying `Bytes` value plus
-        // non-byte fields, and a top-level non-secret `Bytes`.
+        // Shaped like the sealed-body encode tree: nested maps carrying a
+        // secret `Bytes` alongside non-byte fields.
         let mut version = Map::new();
         version.insert("contentKey", Value::Bytes(vec![0xab; SECRET_LEN_TEST]));
         version.insert("size", Value::Unsigned(4096));
@@ -376,10 +368,8 @@ mod tests {
 
         tree.zeroize_bytes();
 
-        // `Vec`/`String` `zeroize` wipes the whole buffer (contents scrubbed
-        // from memory) and clears it to empty; the tree keeps its shape and
-        // every non-byte, non-text value is untouched. Text (filename metadata)
-        // is scrubbed alongside bytes.
+        // Buffers scrubbed and cleared to empty; the tree keeps its shape and
+        // every non-byte, non-text value is untouched.
         let root = tree.as_map().unwrap();
         assert_eq!(root.get("id"), Some(&Value::Bytes(Vec::new())));
         assert_eq!(root.get("kind"), Some(&Value::Text(String::new())));

--- a/crates/core/src/content/cid.rs
+++ b/crates/core/src/content/cid.rs
@@ -1,11 +1,8 @@
-//! The content-DAG CID codec (blueprint/core.md "Open edges"; AGENTS.md rules
-//! 4-5: content-address codecs live in core, one KAT set).
+//! The content-DAG CID codec (blueprint/core.md "Open edges").
 //!
-//! The deterministic CIDv1 content address of a content blob, computed beside
-//! the in-core name codec ([`crate::ipns::name`], which likewise hand-assembles
-//! a fixed CIDv1 byte prefix). The digest is the frozen suite hash BLAKE3-256
-//! ([`crate::suite::hash::hash`]) — no content hash lives outside the suite
-//! (AGENTS.md rule 4) — so the CID is byte-identical on native and wasm32.
+//! The deterministic CIDv1 content address of a content blob. The digest is the
+//! frozen suite hash BLAKE3-256 ([`crate::suite::hash::hash`]), so the CID is
+//! byte-identical on native and wasm32.
 //!
 //! CIDv1 layout — all four framing bytes are single-byte multicodec varints, so
 //! the CID is a fixed 4-byte prefix followed by the digest:
@@ -18,13 +15,12 @@
 //! | `0x20` | multihash digest length = 32                                |
 //! | …      | 32-byte BLAKE3 digest of `bytes`                            |
 //!
-//! Core addresses *leaf* sealed chunks as `raw` ([`CONTENT_CID_CODEC`]). The
-//! version's `contentCid` is a DAG **root** (engine.md:473-474) whose codec —
-//! `dag-pb`/`dag-cbor` — is engine-owned (#630, engine.md:497 open edge), so the
-//! codec is a parameter here, not a constant. Core must verify that root CID on
-//! every block/CAR response (engine.md:468); [`verify_cid`] therefore keys off
-//! the claimed CID's *own* codec byte, validating both a raw leaf and a DAG root
-//! while the version, multihash, and length framing stay fixed and fail-closed.
+//! Core addresses *leaf* sealed chunks as `raw` ([`CONTENT_CID_CODEC`]); a
+//! version's `contentCid` is a DAG **root** whose codec is engine-owned (#630,
+//! engine.md:497), so the codec is a parameter here, not a constant.
+//! [`verify_cid`] therefore keys off the claimed CID's *own* codec byte —
+//! validating a raw leaf and a DAG root alike (engine.md:468) — while the
+//! version, multihash, and length framing stay fixed and fail-closed.
 
 use crate::error::{CodecError, Malformed, TrustViolation};
 use crate::suite::hash::hash;
@@ -61,12 +57,11 @@ pub const CONTENT_CID_LEN: usize = CID_PREFIX_LEN + DIGEST_LEN;
 /// byte-identical across native and wasm32; a public content address, so no key
 /// material flows through here.
 ///
-/// The content plane's frozen multicodec set is single-byte — `raw` (0x55) leaf,
-/// `dag-cbor` (0x71) root (core.md:56) — like the name codec's libp2p-key 0x72
-/// ([`crate::ipns::name`]). A `codec >= 0x80` is a multi-byte unsigned varint,
-/// outside the frozen set and unrepresentable in this fixed layout, so callers
-/// must pass a single-byte multicodec; the guard fails closed (panics in every
-/// build) rather than silently emitting a malformed one-byte-truncated CID.
+/// # Panics
+///
+/// If `codec >= 0x80`: a multi-byte unsigned varint is outside the frozen
+/// single-byte content-plane set — `raw` 0x55 leaf, `dag-cbor` 0x71 root
+/// (core.md:56) — and unrepresentable in this fixed layout.
 pub fn compute_cid(codec: u8, bytes: &[u8]) -> Vec<u8> {
     // `assert!` (not `debug_assert!`): a one-byte-truncated CID from a
     // multi-byte codec must fail closed in release too (core.md:56).
@@ -91,10 +86,9 @@ pub fn compute_cid(codec: u8, bytes: &[u8]) -> Vec<u8> {
 /// is over a public content address (no secret), so ordinary equality is used.
 pub fn verify_cid(claimed_cid: &[u8], bytes: &[u8]) -> Result<(), CodecError> {
     // Untrusted claimed CID: reject a multi-byte-varint codec byte (>= 0x80)
-    // before mirroring it into `compute_cid`. A 36-byte CID with a high codec byte
-    // passes the length check, so without this guard it would trip the internal
-    // `debug_assert!` (debug DoS) and — with asserts stripped — fail open by
-    // matching the recomputed malformed CID byte-for-byte. Fail-closed in both.
+    // before mirroring it into `compute_cid`. A full-length CID with a high codec
+    // byte would otherwise either trip that guard (panic-as-DoS) or, in a build
+    // with asserts stripped, fail open by matching the recomputed malformed CID.
     if claimed_cid.len() == CONTENT_CID_LEN
         && claimed_cid[CID_CODEC_INDEX] < 0x80
         && compute_cid(claimed_cid[CID_CODEC_INDEX], bytes) == claimed_cid
@@ -107,11 +101,10 @@ pub fn verify_cid(claimed_cid: &[u8], bytes: &[u8]) -> Result<(), CodecError> {
 
 // ---------------------------------------------------------------------------
 // Content-CID string codec (blueprint/core.md "Content-CID string codec"). A
-// scope's metadata IPNS record carries `/ipfs/<head_cid>` where `<head_cid>` is
-// the binary CIDv1 above rendered in base32-lowercase multibase (leading `b`),
-// the form IPFS emits. The Adopter must recover the binary anchor from that
-// string before `read_block` can trust-check the fetched head, so encode + strict
-// decode are core exports — mirroring the base36 name codec ([`crate::ipns::name`]).
+// scope's metadata IPNS record carries `/ipfs/<head_cid>`: the binary CIDv1
+// above in base32-lowercase multibase (leading `b`), the form IPFS emits. The
+// Adopter must recover the binary anchor from that string before a fetched head
+// can be trust-checked, so encode + strict decode are core exports.
 // ---------------------------------------------------------------------------
 
 /// The multibase prefix for lowercase base32 (RFC 4648 `base32`, no padding).
@@ -135,9 +128,11 @@ pub fn is_wellformed_content_cid(cid: &[u8]) -> bool {
 /// Encode a binary content CIDv1 as its canonical base32-lowercase multibase
 /// string (leading `b`). Every valid content CID has exactly one such string.
 ///
-/// `assert!` (release-active, like [`compute_cid`]): emitting a `b…` string over
-/// bytes the decoder rejects would publish an unresolvable scope head (AGENTS.md
-/// rule 8 encode/decode symmetry), so a malformed CID fails closed in every build.
+/// # Panics
+///
+/// If `cid` is not the frozen framing: emitting a `b…` string over bytes the
+/// decoder rejects would publish an unresolvable scope head (AGENTS.md rule 8
+/// encode/decode symmetry), so the guard is release-active.
 pub fn encode_content_cid_str(cid: &[u8]) -> String {
     assert!(
         is_wellformed_content_cid(cid),
@@ -250,8 +245,7 @@ mod tests {
 
     #[test]
     fn compute_cid_carries_the_caller_codec() {
-        // The DAG-root codec (dag-cbor 0x71) is engine-chosen (#630): only the
-        // codec byte moves; version/multihash/len/digest stay frozen.
+        // The DAG-root codec (dag-cbor 0x71) is engine-chosen (#630).
         let cid = compute_cid(0x71, b"dag root bytes");
         assert_eq!(cid[CID_CODEC_INDEX], 0x71, "codec byte is the parameter");
         assert_eq!(
@@ -289,8 +283,7 @@ mod tests {
 
     #[test]
     fn verify_accepts_a_dag_root_cid_off_its_own_codec() {
-        // A non-raw (dag-cbor) DAG-root CID must verify — core keys off the
-        // claimed CID's codec byte, not a hardcoded raw prefix (engine.md:468).
+        // Core keys off the claimed CID's codec byte, not a hardcoded raw prefix.
         let bytes = b"the assembled dag root node";
         let cid = compute_cid(0x71, bytes);
         assert_ne!(cid[CID_CODEC_INDEX], CONTENT_CID_CODEC, "non-raw codec");
@@ -317,23 +310,20 @@ mod tests {
         );
     }
 
-    // Native-only: the always-on assert holds in every build (debug and
-    // release), and `#[should_panic]` is unsafe on the panic=abort wasm legs.
+    // Native-only: the guard is release-active, but `#[should_panic]` is unsafe
+    // on the panic=abort wasm legs.
     #[cfg(not(target_family = "wasm"))]
     #[test]
     #[should_panic(expected = "single-byte")]
     fn compute_cid_guards_a_multibyte_codec_fail_closed() {
-        // A codec >= 0x80 (e.g. dag-json 0x0129) is a multi-byte unsigned varint,
-        // outside the frozen single-byte content-plane set (core.md:56): the guard
-        // must trip rather than silently emit a one-byte-truncated CID.
+        // A codec >= 0x80 must trip the guard, not emit a truncated CID.
         let _ = compute_cid(0x80, b"multi-byte codec is out of the frozen set");
     }
 
     #[test]
     fn verify_rejects_a_multibyte_prefixed_oversized_cid_fail_closed() {
         // A real multi-byte-codec CID (dag-json 0x0129 = varint [0xa9, 0x02]) is
-        // 37 bytes; the fixed `len == CONTENT_CID_LEN` check rejects it fail-closed
-        // even though the multihash and digest tail match.
+        // 37 bytes: the fixed-length check rejects it even with a matching digest.
         let bytes = b"content";
         let cid = compute_cid(CONTENT_CID_CODEC, bytes);
         let mut oversized = vec![CID_VERSION, 0xa9, 0x02];
@@ -351,12 +341,10 @@ mod tests {
 
     #[test]
     fn verify_rejects_a_high_codec_byte_exact_len_cid_fail_closed() {
-        // Release-mode fail-open guard: a full-length (CONTENT_CID_LEN) CID whose
-        // codec byte is >= 0x80 with an otherwise valid framing and a *matching*
-        // BLAKE3 digest. Without the codec guard, release builds (asserts stripped)
-        // would mirror the byte and accept this malformed CID byte-for-byte, and
-        // debug builds would panic on the internal assert. verify_cid must return
-        // Err — never panic — in both, so this test runs on every leg incl. wasm.
+        // A full-length CID with a high codec byte, valid framing, and a
+        // *matching* digest: without the codec guard this fails open (asserts
+        // stripped) or panics (asserts live). `verify_cid` must return Err in
+        // both, so this runs on every leg including wasm.
         let bytes = b"content";
         let mut cid = vec![CID_VERSION, 0x80, CONTENT_CID_MULTIHASH, DIGEST_LEN as u8];
         cid.extend_from_slice(&hash(bytes));
@@ -427,8 +415,7 @@ mod tests {
 
     #[test]
     fn decode_rejects_wrong_framing_even_when_base32_canonical() {
-        // A canonical base32 body over 36 bytes with a corrupted multihash code:
-        // valid base32, wrong CIDv1 framing → fail closed.
+        // Valid base32 body, corrupted multihash code → wrong framing, fail closed.
         let mut cid = compute_cid(CONTENT_CID_CODEC, b"anchor");
         cid[2] ^= 0xff;
         let mut s = String::from("b");
@@ -439,8 +426,8 @@ mod tests {
         );
     }
 
-    // Native-only: the always-on encode guard fires in every build; `#[should_panic]`
-    // is unsafe on the panic=abort wasm legs (mirrors compute_cid's guard test).
+    // Native-only, like `compute_cid`'s guard test: `#[should_panic]` is unsafe
+    // on the panic=abort wasm legs.
     #[cfg(not(target_family = "wasm"))]
     #[test]
     #[should_panic(expected = "frozen CIDv1 framing")]

--- a/crates/core/src/content/mod.rs
+++ b/crates/core/src/content/mod.rs
@@ -1,20 +1,9 @@
-//! The content-plane cryptographic edge (blueprint/core.md "Open edges":
-//! "core ships the content-seal primitive over caller-framed chunks").
+//! The content-plane cryptographic edge (blueprint/core.md "Open edges").
 //!
 //! Two core-owned pieces, and nothing more — chunk framing, DAG assembly shape,
-//! and version-retention policy stay engine-owned (#630):
-//!
-//! - **content-seal** ([`seal::seal_chunk`]/[`seal::open_chunk`]):
-//!   XChaCha20-Poly1305 over caller-framed chunk bytes under a caller-supplied
-//!   per-version content key, reusing the frozen suite AEAD
-//!   ([`crate::suite::aead`]). The content key is caller-owned — the seal never
-//!   zeroizes it.
-//! - **content-DAG CID** ([`cid::compute_cid`]/[`cid::verify_cid`]): the
-//!   deterministic CIDv1 content address over the sealed bytes and a fail-closed
-//!   verify. One implementation, one KAT set, byte-identical native + wasm32. The
-//!   string codec ([`cid::encode_content_cid_str`]/[`cid::decode_content_cid_str`])
-//!   renders that CID as its base32-lowercase multibase `b…` form and strictly
-//!   recovers the binary anchor from a scope's `/ipfs/<head_cid>` record value.
+//! and version-retention policy stay engine-owned (#630): the content-seal over
+//! caller-framed chunks ([`seal`]), and the content-DAG CID with its fail-closed
+//! verify and base32 string codec ([`cid`]).
 
 pub mod cid;
 pub mod seal;

--- a/crates/core/src/content/seal.rs
+++ b/crates/core/src/content/seal.rs
@@ -13,8 +13,7 @@
 //! live): a chunk's authenticity anchor is its `contentCid` — a BLAKE3 digest
 //! over these sealed bytes ([`super::cid`]) that the metadata read-body carries
 //! and the metadata envelope binds into its own AAD — so the content plane
-//! inherits that binding transitively. This primitive seals caller bytes and
-//! nothing more.
+//! inherits that binding transitively.
 
 use crate::error::{CodecError, Malformed, TrustViolation};
 use crate::suite::aead::{self, KEY_LEN, NONCE_LEN, TAG_LEN};
@@ -25,9 +24,7 @@ use crate::suite::aead::{self, KEY_LEN, NONCE_LEN, TAG_LEN};
 /// `nonce` **must be unique for every seal performed under a given `key`** —
 /// XChaCha20-Poly1305 nonce reuse under one key is a confidentiality and
 /// integrity break (the content key is random per version; the caller sources a
-/// fresh nonce per chunk from its injected entropy seam). `key` and `plaintext`
-/// are caller-owned; this callee borrows them and never zeroizes a caller-owned
-/// buffer.
+/// fresh nonce per chunk from its injected entropy seam).
 pub fn seal_chunk(key: &[u8; KEY_LEN], nonce: &[u8; NONCE_LEN], plaintext: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(NONCE_LEN + plaintext.len() + TAG_LEN);
     out.extend_from_slice(nonce);
@@ -123,9 +120,8 @@ mod tests {
 
     #[test]
     fn caller_key_is_not_zeroized() {
-        // The content key is caller-owned: sealing borrows it and must leave it
-        // intact (the "zeroize at the terminal owner only" rule — a broken
-        // callee-zero once failed 48/89 E2E).
+        // "Zeroize at the terminal owner only" (AGENTS.md rule 7): a callee-zero
+        // of the caller's content key once failed 48/89 E2E.
         let key = [0xcd; KEY_LEN];
         let _ = seal_chunk(&key, &[1u8; NONCE_LEN], b"x");
         assert_eq!(key, [0xcd; KEY_LEN], "seal must not zero the caller's key");

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -2,10 +2,9 @@
 //!
 //! Two classes, disjoint types, no reused codes: [`TrustViolation`] for
 //! failures the engine treats fail-closed (canonicality, uniqueness, and the
-//! cryptographic checks the suite layer contributes — subkey-binding verify,
-//! HPKE open — with signature/commitment/AAD following in later slices) and
-//! [`Malformed`] for structurally invalid or unsupported input. Every
-//! rejection names the check that fired via [`TrustViolation::check`] /
+//! cryptographic checks — signature, commitment, AAD, subkey-binding verify,
+//! HPKE open) and [`Malformed`] for structurally invalid or unsupported input.
+//! Every rejection names the check that fired via [`TrustViolation::check`] /
 //! [`Malformed::check`]; the check names are part of the frozen contract and
 //! are pinned by the KAT reject vectors.
 //!
@@ -16,17 +15,16 @@
 use core::fmt;
 
 /// A fail-closed trust violation: the input is well-formed enough to prove a
-/// writer did not follow the deterministic profile (or, in later slices,
-/// failed a cryptographic check). Never mere staleness, never retried.
+/// writer did not follow the deterministic profile, or it failed a
+/// cryptographic check. Never mere staleness, never retried.
 ///
 /// The codec-layer boundary between the classes, frozen by the KAT reject
 /// vectors: a violation is *trust* when a canonical encoding of the same data
 /// exists and the writer emitted a different one (non-shortest forms,
-/// indefinite lengths, unsorted or duplicate keys) — the signature of a
-/// tampering or non-conforming re-encode. Shapes the profile has no
-/// representation for at all (tags, floats, extra simple values, non-text
-/// keys) are [`Malformed`]: foreign data, not a non-canonical form of valid
-/// data.
+/// indefinite lengths, unsorted or duplicate keys) — the signature of tampering
+/// or a non-conforming re-encode. Shapes the profile has no representation for
+/// at all (tags, floats, extra simple values, non-text keys) are [`Malformed`]:
+/// foreign data, not a non-canonical form of valid data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TrustViolation {
     /// An integer (major type 0/1) used a longer encoding than the shortest
@@ -43,41 +41,35 @@ pub enum TrustViolation {
     /// The same key encoded twice in one map.
     DuplicateMapKey { offset: usize, key: String },
     /// A subkey binding signature did not verify over the det-CBOR
-    /// `{encSubkey, identityPk}` preimage. This is *trust*, never mere
-    /// malformation: the contact code is structurally well-formed (both keys
-    /// decode, the signature is a valid ECDSA encoding), yet the identity did
-    /// not attest this encryption subkey — the exact forgery the mandatory
-    /// import-time verify exists to reject fail-closed.
+    /// `{encSubkey, identityPk}` preimage. *Trust*, not malformation: the code
+    /// is structurally well-formed, yet the identity did not attest this
+    /// encryption subkey — the forgery the mandatory import-time verify rejects.
     SubkeyBindingInvalid,
-    /// An HPKE ciphertext failed to open: the AEAD authentication tag did not
-    /// verify under the derived key and AAD. *Trust*, not availability —
-    /// unseal failure never silently degrades, and a tag mismatch is the
-    /// signature of tampering or an AAD/enc transplant, not a retryable fetch
-    /// error.
+    /// An HPKE ciphertext failed to open: the AEAD tag did not verify under the
+    /// derived key and AAD. *Trust*, not availability — a tag mismatch is the
+    /// signature of tampering or an AAD/enc transplant, never a retryable error.
     HpkeOpenFailed,
     /// A low-order X25519 peer/recipient key forced a non-contributory (all-zero)
-    /// DHKEM shared secret, or a contact code's `encSubkey` was such a low-order
-    /// point (RFC 9180 §7.1.4). *Trust*: the bytes are structurally a valid
-    /// 32-byte key, so this is not malformation — it is a **chosen-key** attack,
-    /// a degenerate point picked so the derived AEAD key depends only on public
-    /// material (the sealed seed becomes openable by anyone). Fires before any
-    /// open at HPKE decap and at contact import, distinct from a mere tag
-    /// mismatch ([`Self::HpkeOpenFailed`]).
+    /// DHKEM shared secret, or a contact code's `encSubkey` was such a point
+    /// (RFC 9180 §7.1.4). *Trust*, not malformation: the bytes are a valid
+    /// 32-byte key, so this is a **chosen-key** attack — a degenerate point
+    /// picked so the derived AEAD key depends only on public material (the
+    /// sealed seed becomes openable by anyone). Fires before any open, at HPKE
+    /// decap and at contact import, distinct from a tag mismatch
+    /// ([`Self::HpkeOpenFailed`]).
     HpkeNonContributory,
     /// A symmetric sealed body failed to open: the XChaCha20-Poly1305 tag did
     /// not verify under the read/structure key and the structured AAD
     /// `(v, id, scope, epoch, structTag)`. *Trust*, not availability — the
-    /// signature of tampering, an AAD transplant (a body re-hung under a
-    /// different id/scope/epoch/tag), or a version downgrade (`v` is bound into
-    /// the AAD, so a rolled-back `v` fails the tag). Unseal never silently
-    /// degrades to staleness.
+    /// signature of an AAD transplant (a body re-hung under a different
+    /// id/scope/epoch/tag) or a `v` downgrade, both bound into the AAD. Unseal
+    /// never silently degrades to staleness.
     SealOpenFailed,
     /// A sealed content blob did not content-address to its claimed `contentCid`
-    /// (blueprint/core.md "Open edges"; the content-DAG CID verify). *Trust*,
-    /// never staleness: the CID is a BLAKE3 digest over the sealed bytes, so a
-    /// mismatch is evidence the bytes were substituted or the claimed CID is
-    /// wrong — the fail-closed content-address check, distinct from an unopened
-    /// seal ([`Self::SealOpenFailed`]).
+    /// (blueprint/core.md "Open edges"). *Trust*, never staleness: the CID is a
+    /// BLAKE3 digest over the sealed bytes, so a mismatch is evidence the bytes
+    /// were substituted — distinct from an unopened seal
+    /// ([`Self::SealOpenFailed`]).
     ContentCidMismatch,
     /// Two child refs in one folder read-body carried the same `id`. Uniqueness
     /// is fail-closed at decode (#39 D7): duplicate ids anywhere are a trust
@@ -90,12 +82,10 @@ pub enum TrustViolation {
     /// leaves the name out for — rejected here instead of by the tag.
     DuplicateIpnsName,
     /// Two rows of a grant ledger or grant-set commitment carried the same
-    /// blinded `tag`. The exact analog of [`Self::DuplicateId`] (#39 D7): a
-    /// recipient's tag locates its grant blob and its committed
-    /// `(permission, pseudonymPk)`, so a duplicate is a confused-deputy over
-    /// read-vs-write authority (a second row injecting the victim's tag with a
-    /// different permission/enc key makes the lookup ambiguous). Fail-closed at
-    /// decode, never first-match.
+    /// blinded `tag`. The exact analog of [`Self::DuplicateId`] (#39 D7): a tag
+    /// locates its grant blob and its committed `(permission, pseudonymPk)`, so
+    /// a duplicate is a confused-deputy over read-vs-write authority. Fail-closed
+    /// at decode, never first-match.
     DuplicateGrantTag,
     /// An IPNS record's `signatureV2` did not verify over
     /// `"ipns-signature:" || data` under the Ed25519 key **extracted from the
@@ -341,12 +331,11 @@ pub enum Malformed {
     UnknownRecordField { key: String },
     /// A durable op record declared a format version this build does not
     /// implement. *Malformed*, not trust: a forward-version record is intact
-    /// input this decoder cannot interpret, carrying no evidence of tampering.
-    /// A rewritten `v` is indistinguishable from a genuine one and lands here
-    /// too — deliberately, since the gate runs before the AEAD; the AAD's
-    /// version binding closes downgrade *between* supported versions instead.
-    /// The distinction is load-bearing — the engine **retains** such a record
-    /// rather than dead-lettering and deleting a queue it cannot yet read.
+    /// input this decoder cannot interpret. A rewritten `v` lands here too —
+    /// deliberately, since the gate runs before the AEAD; the AAD's version
+    /// binding closes downgrade *between* supported versions instead. The
+    /// distinction is load-bearing: the engine **retains** such a record rather
+    /// than dead-lettering a queue it cannot yet read.
     UnsupportedRecordVersion { version: u64 },
     /// An IPNS record's protobuf could not be parsed, or it was missing a field
     /// the V2 verify chain requires (`value`, `signatureV2`, or `data`), or its

--- a/crates/core/src/ipns/mod.rs
+++ b/crates/core/src/ipns/mod.rs
@@ -2,14 +2,11 @@
 //! "IPNS records").
 //!
 //! Core owns records end-to-end on both platforms (#28 D2); transports are dumb
-//! byte movers injected by the engine. This module ships three pure pieces:
-//!
-//! - [`IpnsName`] — the `ipnsName` codec: encode + strict decode of the base36
-//!   CIDv1 libp2p-key of an Ed25519 public key, and the extraction of that key
-//!   from the name (the verify chain's sole trust anchor).
-//! - [`IpnsRecord`] — spec-compliant V2 record create/sign, byte-stable keyless
-//!   marshal/unmarshal for re-PUT, and the pure verify chain.
-//! - [`VerifiedRecord`] — the authenticated fields the adoption gate compares.
+//! byte movers injected by the engine. Three pure pieces: [`IpnsName`] (the
+//! `ipnsName` codec, and the verify chain's sole trust anchor), [`IpnsRecord`]
+//! (create/sign, byte-stable keyless marshal/unmarshal for re-PUT, the pure
+//! verify chain), and [`VerifiedRecord`] (the authenticated fields the adoption
+//! gate compares).
 
 pub mod name;
 pub mod record;

--- a/crates/core/src/ipns/name.rs
+++ b/crates/core/src/ipns/name.rs
@@ -7,11 +7,10 @@
 //! anchor the name itself: [`IpnsName::public_key`] extracts the Ed25519 key
 //! from the name, never from a side channel or a DB column (#39 D7).
 //!
-//! Encode and strict decode are the two core exports; everything downstream
-//! treats names as opaque. Decode is deliberately strict — it matches the one
-//! canonical Ed25519-identity layout byte-for-byte and re-derives the canonical
-//! text, rejecting anything that does not round-trip to the exact bytes we would
-//! emit (the cross-language `$`-before-`\n` lesson: keep the Rust side strict).
+//! Decode is deliberately strict: it matches the one canonical
+//! Ed25519-identity layout byte-for-byte and re-derives the canonical text,
+//! rejecting anything that does not round-trip to the exact bytes we would emit
+//! (the cross-language `$`-before-`\n` lesson: keep the Rust side strict).
 
 use crate::error::{CodecError, Malformed};
 use crate::suite::ed25519::{Ed25519Verifier, PUBLIC_LEN};
@@ -67,10 +66,9 @@ impl IpnsName {
     /// a wrong CID/multihash/protobuf layout, or a 32-byte digest that is not a
     /// valid compressed Edwards point.
     pub fn parse(text: &str) -> Result<Self, CodecError> {
-        // A canonical name is one multibase char plus the base36 of a
-        // fixed-size CID; reject anything longer up front, before the O(n^2)
-        // base36 division, so a giant string cannot burn work (the base36 upper
-        // bound never rejects a real name — it always exceeds their true width).
+        // Bound the input before the O(n^2) base36 division so a giant string
+        // cannot burn work. The base36 upper bound always exceeds a real name's
+        // true width, so it never rejects one.
         if text.len() > 1 + base36_len(CID_LEN) {
             return Err(malformed());
         }

--- a/crates/core/src/ipns/record.rs
+++ b/crates/core/src/ipns/record.rs
@@ -1,28 +1,25 @@
 //! IPNS V2 records: create/sign, byte-stable marshal/unmarshal, and the pure
 //! verify chain (blueprint/core.md "IPNS records").
 //!
-//! A record is the spec-compliant IPFS `IpnsEntry` protobuf: the `signatureV2`
-//! (field 8) signs the DAG-CBOR `data` (field 9), and the deprecated top-level
-//! fields (value/validityType/validity/sequence/ttl) are emitted for ecosystem
-//! compatibility. `Value = /ipfs/<CID>` of the DAG-CBOR envelope; the first
-//! publish embeds sequence 1 and a CAS publish embeds the exact expected
-//! sequence (both are the caller's injected `sequence` — core embeds it
-//! faithfully, the strict floor gate is the engine's). Validity is a 90-day
-//! client-signed EOL and the TTL is always explicit, injected from the sync
-//! timing profile — core reads no clock and defaults neither (#33 D3).
+//! A record is the spec-compliant IPFS `IpnsEntry` protobuf: `signatureV2`
+//! (field 8) signs the DAG-CBOR `data` (field 9) whose `Value = /ipfs/<CID>` of
+//! the DAG-CBOR envelope, and the deprecated top-level fields are emitted for
+//! ecosystem compatibility. `sequence` (1 on first publish, the exact expected
+//! next on CAS), the 90-day client-signed EOL, and the always-explicit TTL are
+//! all caller-injected — core reads no clock and defaults neither (#33 D3); the
+//! strict floor gate is the engine's.
 //!
 //! **Marshal/unmarshal is keyless and byte-stable** (blueprint/core.md
 //! "Keyless re-PUT"): [`IpnsRecord::unmarshal`] preserves every field's exact
 //! wire segment in order, so [`IpnsRecord::marshal`] reproduces a foreign signed
-//! record byte-for-byte with no key material — the republisher and every
-//! accelerator depend on it, including fields this codec does not model
-//! (`signatureV1`, `pubKey`, any future field).
+//! record byte-for-byte with no key material — including fields this codec does
+//! not model (`signatureV1`, `pubKey`, any future field), which the republisher
+//! and every accelerator depend on.
 //!
 //! **Verify is pure** (blueprint/core.md "Verify"): the Ed25519 key comes from
 //! the [`IpnsName`] itself (never a side channel), `signatureV2` verifies over
-//! `"ipns-signature:" || data`, the signed `data.Value` must equal the
-//! top-level `value`, and the EOL + sequence are extracted for the gate's
-//! comparators.
+//! `"ipns-signature:" || data`, and the signed `data.Value` must equal the
+//! top-level `value`.
 
 use zeroize::Zeroize;
 
@@ -107,12 +104,9 @@ pub struct IpnsRecord {
 }
 
 impl IpnsRecord {
-    /// Build and sign a spec-compliant V2 record. `signer` is the injected
-    /// Ed25519 node key; `value` is the `/ipfs/<CID>` path; `sequence` is the
-    /// caller-chosen sequence (1 on first publish, the expected next on CAS);
-    /// `ttl_nanos` is the explicit injected TTL; `validity_eol` is the injected
-    /// RFC3339 EOL string. The top-level compat fields are emitted to match the
-    /// signed `data`.
+    /// Build and sign a spec-compliant V2 record from the injected signer,
+    /// `/ipfs/<CID>` value, sequence, TTL, and RFC3339 EOL. The top-level
+    /// compat fields are emitted to match the signed `data`.
     pub fn create_v2(
         signer: &Ed25519Signer,
         value: &[u8],
@@ -162,21 +156,17 @@ impl IpnsRecord {
     }
 
     /// The full pure verify chain against `name` — whose Ed25519 key is the sole
-    /// trust anchor (never a side channel). Fail-closed and two-class:
-    ///
-    /// - a structurally incomplete record (missing/duplicated `value`,
-    ///   `signatureV2`, or `data`, or an ill-shaped `data`) is
-    ///   [`Malformed::IpnsRecordMalformed`];
-    /// - a `signatureV2` that does not verify is
-    ///   [`TrustViolation::IpnsSignatureInvalid`];
-    /// - a signed `data.Value` disagreeing with the top-level `value` is
-    ///   [`TrustViolation::IpnsValueMismatch`].
+    /// trust anchor (never a side channel). Fail-closed and two-class: a
+    /// structurally incomplete record is [`Malformed::IpnsRecordMalformed`], a
+    /// `signatureV2` that does not verify is
+    /// [`TrustViolation::IpnsSignatureInvalid`], and a signed `data.Value`
+    /// disagreeing with the top-level `value` is
+    /// [`TrustViolation::IpnsValueMismatch`].
     pub fn verify(&self, name: &IpnsName) -> Result<VerifiedRecord, CodecError> {
         let top_value = self.unique_len_field(FIELD_VALUE)?;
         let signature_bytes = self.unique_len_field(FIELD_SIGNATURE_V2)?;
         let data = self.unique_len_field(FIELD_DATA)?;
 
-        // signatureV2 over "ipns-signature:" || data, under the name's key.
         let sig_array: [u8; SIGNATURE_LEN] = signature_bytes
             .try_into()
             .map_err(|_| Malformed::IpnsRecordMalformed)?;
@@ -319,7 +309,6 @@ fn parse_fields(bytes: &[u8]) -> Option<Vec<ProtoField>> {
         let wire_type = tag & 0x07;
         let value = match wire_type {
             WIRE_VARINT => {
-                // Validate + advance past the varint; its value is not retained.
                 read_varint(bytes, &mut pos)?;
                 FieldValue::Varint
             }
@@ -384,10 +373,9 @@ fn varint_field(number: u64, v: u64) -> ProtoField {
 
 impl Drop for IpnsRecord {
     fn drop(&mut self) {
-        // Records carry no secret key material (signatures/values are public),
-        // but wiping the buffers on drop keeps published bytes from lingering.
-        // `raw` and the decoded `Bytes` view are separate allocations, so wipe
-        // both to honor the contract fully.
+        // Records hold no secret material, but `raw` and the decoded `Bytes`
+        // view are separate allocations — wipe both so published bytes do not
+        // linger.
         for f in &mut self.fields {
             f.raw.zeroize();
             if let FieldValue::Bytes(b) = &mut f.value {

--- a/crates/core/src/kdf/mod.rs
+++ b/crates/core/src/kdf/mod.rs
@@ -2,22 +2,20 @@
 //!
 //! Nothing in CipherBox derives a key outside these fifteen edges. Every edge
 //! is domain-separated by a fixed `cipherbox/v2/<edge>` context string fed to
-//! BLAKE3 `derive_key`; per-node/per-id material then takes the frozen shape
+//! BLAKE3 `derive_key`; per-node/per-id material takes the frozen shape
 //! `keyed_hash(derive_key(context, seed), id)` — ids, tags, and indices are
-//! **fixed-length message input**, never variable context (a variable context
-//! would admit cross-edge collisions). Composite-material edges hash a
-//! fixed-prefix concatenation as the `derive_key` ikm instead.
+//! **fixed-length message input**, never variable context, which would admit
+//! cross-edge collisions. Composite-material edges hash a fixed-prefix
+//! concatenation as the `derive_key` ikm instead.
 //!
-//! The catalog is `pure` and deterministic: seeds and login secrets enter as
-//! parameters, and outputs are the zeroizing owning types from [`crate::suite`].
-//! The context-string table, input layouts, and per-edge outputs are frozen in
-//! the KAT manifest, and [`edge_probe_outputs`] backs both the mechanical
-//! separation KAT (no two edges share an output for equal inputs) and its
-//! property test.
+//! Pure and deterministic: seeds and login secrets enter as parameters, and
+//! outputs are the zeroizing owning types from [`crate::suite`]. The KAT
+//! manifest freezes the context strings, input layouts, and per-edge outputs;
+//! [`edge_probe_outputs`] backs the mechanical separation KAT.
 //!
-//! Non-edges, stated to stay non-edges (blueprint/core.md): content keys
-//! (random per version), scope override seeds (random at rotation), and scope
-//! seeds at grant cuts (random) — none derive through here.
+//! Non-edges, stated to stay non-edges (blueprint/core.md): content keys,
+//! scope override seeds, and scope seeds at grant cuts — all random, none
+//! derived here.
 
 use zeroize::Zeroize;
 
@@ -138,9 +136,9 @@ pub const EDGES: &[EdgeSpec] = &[
 ];
 
 // ---------------------------------------------------------------------------
-// Core derivations. Each returns the 32-byte material its edge is built on,
-// in the zeroizing owning type; the public edge functions below wrap it into
-// the purpose type, and the probe reads its bytes.
+// Core derivations: each edge's raw 32-byte material, in the zeroizing owning
+// type. The public edge functions below wrap it into the purpose type; the
+// probe reads its bytes.
 // ---------------------------------------------------------------------------
 
 fn node_seed_bytes(scope_seed: &[u8; SECRET_LEN], node_id: &[u8; 16]) -> SecretBytes {
@@ -280,13 +278,10 @@ pub fn enc_subkey(login_secret: &[u8]) -> X25519Secret {
 /// `blinded-tag`: the public grant-blob tag from an ECDH secret and the scope
 /// root's `ipnsName`.
 ///
-/// `ecdh_shared` is expected to be a **contributory** X25519 result. A
-/// low-order peer public key forces an all-zero shared secret and thus a tag
-/// that depends only on the `ipnsName` — degenerate, not a secrecy break (the
-/// tag is public), but callers computing the ECDH get the contributory check for
-/// free from the [`x25519`](crate::suite::x25519) seam: `diffie_hellman` returns
-/// `None` on a non-contributory result, and `X25519Public::from_bytes` rejects
-/// low-order peer keys up front.
+/// `ecdh_shared` must be a **contributory** X25519 result: an all-zero shared
+/// secret yields a tag depending only on the `ipnsName` — degenerate, not a
+/// secrecy break (the tag is public). Callers get that check for free from
+/// [`X25519Secret::diffie_hellman`](crate::suite::x25519::X25519Secret::diffie_hellman).
 pub fn blinded_tag(
     ecdh_shared: &[u8; SECRET_LEN],
     scope_root_ipns_name: &[u8],
@@ -334,16 +329,12 @@ pub fn settings_ipns_keypair(login_secret: &[u8]) -> Ed25519Signer {
 // Separation surface: the whole edge table under one set of probe inputs.
 // ---------------------------------------------------------------------------
 
-/// Fixed inputs driving every edge through [`edge_probe_outputs`]. The same
-/// probe fills each edge's seed-shaped and id-shaped slots, so a difference in
-/// any two outputs is attributable to the context string alone — exactly what
-/// the mechanical separation KAT asserts.
+/// Fixed inputs driving every edge through [`edge_probe_outputs`]. One probe
+/// fills every seed-shaped and id-shaped slot, so any two outputs differing is
+/// attributable to the context string alone — what the separation KAT asserts.
 ///
-/// `seed` is caller key material, so `Debug` is redacted.
-///
-/// `#[doc(hidden)]`: `pub` only so the KAT integration tests and the `kat_gen`
-/// example (separate crates) can drive the separation surface. Not part of the
-/// supported API — production derives keys through the typed edge functions.
+/// `#[doc(hidden)]`: `pub` only for the cross-crate KAT tests and the `kat_gen`
+/// example, not supported API. `seed` is key material, so `Debug` is redacted.
 #[doc(hidden)]
 #[derive(Clone, Copy)]
 pub struct EdgeProbe<'a> {
@@ -394,18 +385,14 @@ impl core::fmt::Debug for EdgeProbeOutput {
 }
 
 /// Run every edge under one probe, in [`EDGES`] order. Backs the separation KAT
-/// (the fifteen outputs must be pairwise distinct) and its property test, and
-/// is the frozen-vector surface the KAT generator writes.
+/// (the fifteen outputs must be pairwise distinct), its property test, and the
+/// frozen vectors the KAT generator writes.
 ///
-/// This is the **catalog-freezing / separation surface**, not the production
-/// derivation path: it returns each edge's raw derived bytes in the clear
-/// (redacted `Debug` notwithstanding). Production code derives keys through the
-/// typed edge functions above ([`node_seed`], [`read_key`], …), which return
-/// zeroizing owning types. Do not feed production seeds through this function.
-///
-/// `#[doc(hidden)]`: `pub` exists only for the cross-crate KAT tests and the
-/// `kat_gen` example; it is not part of the crate's supported surface and the
-/// engine must never call it.
+/// The **catalog-freezing / separation surface**, not the production derivation
+/// path: it returns each edge's raw derived bytes in the clear. Never feed
+/// production seeds through it — derive through the typed edge functions above
+/// ([`node_seed`], [`read_key`], …), which return zeroizing owning types.
+/// `#[doc(hidden)]`: see [`EdgeProbe`].
 #[doc(hidden)]
 pub fn edge_probe_outputs(probe: &EdgeProbe) -> Vec<EdgeProbeOutput> {
     let b = |s: SecretBytes| *s.as_bytes();

--- a/crates/core/src/payload/mailbox.rs
+++ b/crates/core/src/payload/mailbox.rs
@@ -12,14 +12,12 @@
 //! `{payload, senderIdentityPk, senderSig}`: the opaque application `payload`,
 //! the sender's 33-byte compressed secp256k1 identity key, and the 64-byte
 //! ECDSA signature over `[domain, v, recipientEncPk, senderIdentityPk, payload]`
-//! (domain-, version-, recipient-, and key-bound so a signature can never be
-//! lifted onto a different sender, recipient, or protocol version — a recipient
-//! cannot relay-lift an opened item's `{payload, senderSig}` onto a second
-//! recipient). That plaintext is HPKE-sealed with the
-//! `mailbox-payload` AAD as the RFC 9180 `info`, and the published block is
-//! det-CBOR `{enc, ct}`. The recipient supplies the protocol version `v`
-//! out-of-band, so a version downgrade recomputes a different key schedule and
-//! fails the AEAD tag ([`TrustViolation::HpkeOpenFailed`]).
+//! — domain-, version-, recipient-, and key-bound, so a signature can never be
+//! lifted onto a different sender, recipient, or protocol version. That
+//! plaintext is HPKE-sealed with the `mailbox-payload` AAD as the RFC 9180
+//! `info`, and the published block is det-CBOR `{enc, ct}`. The recipient
+//! supplies `v` out-of-band, so a version downgrade recomputes a different key
+//! schedule and fails the AEAD tag ([`TrustViolation::HpkeOpenFailed`]).
 
 use zeroize::Zeroize;
 
@@ -218,8 +216,7 @@ mod tests {
 
     #[test]
     fn forged_sender_signature_fails_identity_check() {
-        // Seal a well-formed item whose senderSig is garbage: HPKE opens (anyone
-        // can seal), but the sender signature does not verify.
+        // HPKE opens (anyone can seal), but the sender signature does not verify.
         let eph = [0x51; 32];
         let sender_pk = sender().verifying_key().to_sec1();
         let mut inner = Map::new();
@@ -245,9 +242,8 @@ mod tests {
 
     #[test]
     fn relay_to_other_recipient_fails_identity_check() {
-        // R1 opens an item sealed to it, then re-seals the untouched inner
-        // plaintext — sender signature included — to a second recipient R2.
-        // Recipient binding makes R2's signature check fail (#712).
+        // R1 re-seals its untouched inner plaintext — sender signature included —
+        // to R2; recipient binding makes R2's signature check fail (#712).
         let r1 = recipient();
         let r2 = X25519Secret::from_scalar([0x42; 32]);
         let block = seal_mailbox_payload(&r1.public(), &[0x54; 32], 2, &sender(), b"relayed");
@@ -274,9 +270,8 @@ mod tests {
 
     #[test]
     fn per_recipient_binding_both_verify() {
-        // The binding is per-recipient, not pinned to one key: a sender seals
-        // separately to R1 and R2 and both verify, while a cross-open fails
-        // HPKE rather than silently verifying (#712).
+        // The binding is per-recipient, not pinned to one key: separate seals to
+        // R1 and R2 both verify, and a cross-open fails HPKE (#712).
         let s = sender();
         let r1 = recipient();
         let r2 = X25519Secret::from_scalar([0x42; 32]);
@@ -293,9 +288,7 @@ mod tests {
     #[test]
     fn same_recipient_reseal_still_verifies() {
         // The reject is specifically cross-recipient (#712), not "any re-seal
-        // breaks": R1 re-seals its own item to itself under a fresh ephemeral
-        // and it still verifies — the recipient tag, not the reseal act, is
-        // what the signature binds.
+        // breaks": the signature binds the recipient, not the reseal act.
         let r1 = recipient();
         let block = seal_mailbox_payload(&r1.public(), &[0x54; 32], 2, &sender(), b"relayed");
 

--- a/crates/core/src/payload/mod.rs
+++ b/crates/core/src/payload/mod.rs
@@ -3,21 +3,17 @@
 //!
 //! Two owner/sender-authenticated transports core owns end to end:
 //!
-//! - **Pointer payload** ([`pointer`]) — the re-point object
-//!   `{scopeId, currentRootName, writeEpoch, minReadEpoch, prevRootName}`,
-//!   owner-identity-signed (secp256k1 ECDSA) inside the record and then sealed
-//!   under the scope's stable `pointerReadKey` with the `pointer-payload`
-//!   structured AAD. The vault pointer carries the same object for the root
-//!   scope (#39 D5).
-//! - **Mailbox payload** ([`mailbox`]) — an HPKE-sealed item with the sender's
-//!   identity signature **inside the seal** (#39 D9); the recipient opens, then
-//!   verifies the sender signature against the contact-code-anchored key.
+//! - **Pointer payload** ([`pointer`]) — the owner-identity-signed re-point
+//!   object, sealed under the scope's stable `pointerReadKey` via the symmetric
+//!   [`seal`](crate::seal) path. The vault pointer carries the same object for
+//!   the root scope (#39 D5).
+//! - **Mailbox payload** ([`mailbox`]) — an [`hpke`](crate::suite::hpke)-sealed
+//!   item with the sender's identity signature **inside the seal** (#39 D9),
+//!   verified against the contact-code-anchored key after opening.
 //!
-//! Both reuse the vetted primitives the seal slice landed: the symmetric
-//! [`seal`](crate::seal) path (structured AAD + XChaCha20-Poly1305) for the
-//! pointer, and [`hpke`](crate::suite::hpke) for the mailbox. The structure-tag
-//! registry (`pointer-payload = 0x07`, `mailbox-payload = 0x08`) is the one #620
-//! froze — this slice consumes it, never redefines it.
+//! The structure-tag registry (`pointer-payload = 0x07`,
+//! `mailbox-payload = 0x08`) is the one #620 froze — consumed here, never
+//! redefined.
 
 pub mod mailbox;
 pub mod pointer;

--- a/crates/core/src/payload/pointer.rs
+++ b/crates/core/src/payload/pointer.rs
@@ -7,17 +7,14 @@
 //! 64-byte compact signature. That plaintext is sealed with the symmetric
 //! [`seal`](crate::seal) path under `pointerReadKey`, binding the
 //! `pointer-payload` AAD `(v, scope, scope, 0, tag)`. The published block is
-//! that sealed blob (`nonce || ciphertext||tag`); the consulting reader already
-//! knows the scope (it derived `pointerReadKey` from the owner pointer seed and
-//! the scope id), so the AAD context is reconstructible without any plaintext
-//! envelope.
+//! that sealed blob (`nonce || ciphertext||tag`); the reader already knows the
+//! scope, so the AAD context is reconstructible without a plaintext envelope.
 //!
 //! The AAD `epoch` is fixed to `0`: a pointer is the epoch-*advancing* anchor,
 //! not an epoch-tagged node body, and the reader cannot know the write epoch
 //! before unsealing — the authoritative `writeEpoch`/`minReadEpoch` are the
-//! sealed, owner-signed payload. `id` and `scope` both carry the scope id (the
-//! scope root's node UUID), so a pointer sealed for one scope can never open
-//! under another (the AAD tag closes the transplant).
+//! sealed, owner-signed payload. `id` and `scope` both carry the scope id, so a
+//! pointer sealed for one scope can never open under another.
 
 use zeroize::Zeroize;
 
@@ -161,13 +158,11 @@ fn decode_and_verify(
         }
         .into());
     }
-    // A parseable signature that fails to verify — and a non-canonical (e.g.
-    // high-S) encoding that can never verify — are both the one trust check.
     let sig =
         EcdsaSignature::from_compact(sig_bytes).ok_or(TrustViolation::IdentitySignatureInvalid)?;
 
-    // The object bytes the owner signed are the verbatim canonical re-encoding
-    // of the decoded (canonical) `object` value.
+    // The decoder admits canonical input only, so re-encoding the decoded
+    // `object` reproduces the exact bytes the owner signed.
     let mut object_bytes = encode(object_value)?;
     let verified = owner_identity.verify_detcbor(&object_bytes, &sig);
     object_bytes.zeroize();

--- a/crates/core/src/seal/aad.rs
+++ b/crates/core/src/seal/aad.rs
@@ -2,23 +2,16 @@
 //! (blueprint/core.md "Envelope and structures", "Structure-tag registry").
 //!
 //! The AAD is the authenticated-but-not-encrypted context every sealed body is
-//! bound to: `(v, id, scope, epoch, structTag)` under the fresh `cipherbox/v2`
-//! domain separator (#27 D3/D4 — a structured AAD replacing v1's 45-byte
-//! role-byte layout). It is a det-CBOR array so the layout is unambiguous and
-//! byte-frozen by the KAT; it is never decoded (only fed to the AEAD), so it
-//! carries no unknown-field tolerance.
+//! bound to: `(v, id, scope, epoch, structTag)` under the `cipherbox/v2` domain
+//! separator (#27 D3/D4). It is a det-CBOR array, byte-frozen by the KAT, and is
+//! never decoded — only fed to the AEAD — so it carries no unknown-field
+//! tolerance.
 //!
-//! What the AAD binds, and why each element is load-bearing:
-//!
-//! - **`v`** — the single small-int format+suite version. Binding it into the
-//!   AAD is the downgrade defence: a rolled-back `v` recomputes a different AAD
-//!   and fails the tag (blueprint/core.md "Wire format").
-//! - **`id` + `scope` + `epoch`** — the node identity and its epoch-tag
-//!   membership. A body re-hung under a different node, scope, or epoch fails
-//!   the tag; this is the transplant closure the AAD provides.
-//! - **`structTag`** — the domain-separation byte from the registry below, so a
-//!   read-body ciphertext can never be reinterpreted as a write-body, grant
-//!   blob, pointer payload, etc.
+//! What each bound element buys: **`v`** is the downgrade defence (a rolled-back
+//! `v` recomputes a different AAD and fails the tag); **`id` + `scope` + `epoch`**
+//! close transplant of a body across nodes, scopes, and epochs; **`structTag`**
+//! stops a read-body ciphertext being reinterpreted as a write-body, grant blob,
+//! or pointer payload.
 //!
 //! **`ipnsName` is deliberately excluded** (#39 D7): the name wave republishes
 //! epoch-lagged bodies under fresh names, so binding the name would break the
@@ -41,22 +34,21 @@ pub const AAD_DOMAIN: &str = "cipherbox/v2/aad";
 // has no v2 analog and is not carried).
 // ---------------------------------------------------------------------------
 
-/// `read-body` — the sealed node body (folder children / file versions). The
-/// only tag this slice exercises with vectors; the rest are reserved skeleton.
+/// `read-body` — the sealed node body (folder children / file versions).
 pub const STRUCT_TAG_READ_BODY: u8 = 0x01;
-/// `write-body` — the scope-root write-plane payload (later slice).
+/// `write-body` — the scope-root write-plane payload.
 pub const STRUCT_TAG_WRITE_BODY: u8 = 0x02;
-/// `grant-blob` — a scope seed sealed to one recipient (later slice).
+/// `grant-blob` — a scope seed sealed to one recipient.
 pub const STRUCT_TAG_GRANT_BLOB: u8 = 0x03;
-/// `owner-blob` — the override seed wrapped to the owner (later slice).
+/// `owner-blob` — the override seed wrapped to the owner.
 pub const STRUCT_TAG_OWNER_BLOB: u8 = 0x04;
-/// `ascent-link` — the override seed sealed to the parent keypair (later slice).
+/// `ascent-link` — the override seed sealed to the parent keypair.
 pub const STRUCT_TAG_ASCENT_LINK: u8 = 0x05;
-/// `history-link` — the previous epoch's seed under the current one (later slice).
+/// `history-link` — the previous epoch's seed under the current one.
 pub const STRUCT_TAG_HISTORY_LINK: u8 = 0x06;
-/// `pointer-payload` — the re-point object at a scope/vault pointer (later slice).
+/// `pointer-payload` — the re-point object at a scope/vault pointer.
 pub const STRUCT_TAG_POINTER_PAYLOAD: u8 = 0x07;
-/// `mailbox-payload` — the HPKE-sealed mailbox item (later slice).
+/// `mailbox-payload` — the HPKE-sealed mailbox item.
 pub const STRUCT_TAG_MAILBOX_PAYLOAD: u8 = 0x08;
 /// `owner-write-blob` — the write-scope seed HPKE-sealed to the owner's enc
 /// subkey, the write-plane mirror of the owner blob (owner cold-start write-seed
@@ -76,9 +68,8 @@ pub struct StructTagSpec {
     pub tag: u8,
 }
 
-/// The ten structure tags, in registry (byte) order. Every new tag extends
-/// this table and its manifest vectors before merge (blueprint/core.md); this
-/// slice populates and exercises only `read-body`.
+/// The ten structure tags, in registry (byte) order. Every new tag extends this
+/// table and its manifest vectors before merge (blueprint/core.md).
 pub const STRUCT_TAGS: &[StructTagSpec] = &[
     StructTagSpec {
         name: "read-body",

--- a/crates/core/src/seal/body.rs
+++ b/crates/core/src/seal/body.rs
@@ -2,26 +2,18 @@
 //! (blueprint/core.md "Envelope and structures", CONTEXT.md "Envelope").
 //!
 //! `kind` lives *inside* this sealed structure (#27 D4), so an observer of the
-//! plaintext envelope cannot tell a file from a folder. The read-body is a
-//! tagged union — `folder { children[] }` or `file { versions[] }` — plus the
-//! injected `createdAt`/`modifiedAt` timestamps (core reads no clock; times
-//! enter as parameters).
+//! plaintext envelope cannot tell a file from a folder. The body is a tagged
+//! union — `folder { children[] }` or `file { versions[] }` — plus injected
+//! timestamps (core reads no clock).
 //!
-//! - **Child refs** are `{id, name, ipnsName, kind, linkCounter}` (#27 D7): an
-//!   immutable location-independent id, the display name, the child's opaque
-//!   `ipnsName`, the immutable `kind`, and the monotonic link counter that
-//!   picks the deterministic loser in dual-link repair (#33 D5). No key wraps,
-//!   no size/mtime mirrors — a child write never republishes its parent.
-//! - **File versions** are one inline newest-first list
-//!   `[{contentCid, contentKey, size, modifiedAt}]`; head is current. Content
-//!   keys are **random per version**, stored inline (never derived): rotation
-//!   re-wraps them for free via the metadata re-seal, so the key material is
-//!   held in a zeroizing owning type here.
+//! A child ref (#27 D7) carries no key wraps and no size/mtime mirrors, so a
+//! child write never republishes its parent. File-version content keys are
+//! **random per version** and stored inline rather than derived: rotation
+//! re-wraps them for free via the metadata re-seal.
 //!
-//! **Uniqueness is fail-closed at decode** (#39 D7): within one folder's child
-//! listing, duplicate `id`s and duplicate `ipnsName`s reject as trust
-//! violations. Duplicate-`ipnsName` closes the name-transplant hole the AAD
-//! leaves open by design ([`super::aad`]).
+//! **Uniqueness is fail-closed at decode** (#39 D7): duplicate child `id`s and
+//! duplicate `ipnsName`s reject as trust violations, the latter closing the
+//! name-transplant hole the AAD leaves open by design ([`super::aad`]).
 //!
 //! One strictness policy, everywhere (#27 D10): every map level decodes strict
 //! det-CBOR and preserves unknown fields byte-stable, so an old client
@@ -79,8 +71,7 @@ pub struct ChildRef {
     pub id: [u8; 16],
     /// The display name.
     pub name: String,
-    /// The child's opaque `ipnsName` bytes (the base36 name codec is a later
-    /// slice; treated as opaque here and ordered by [`name_cmp`]).
+    /// The child's opaque `ipnsName` bytes, ordered by [`name_cmp`].
     pub ipns_name: Vec<u8>,
     /// The child's immutable kind.
     pub kind: NodeKind,
@@ -128,14 +119,11 @@ impl ChildRef {
 // File version. Content keys are secret material → zeroizing owning type.
 // ---------------------------------------------------------------------------
 
-/// One file version: the content CID, its random inline content key, the
-/// plaintext size, and the injected modification time. Newest-first in the
-/// version list; head is current.
+/// One file version; newest-first in the version list, head is current.
 ///
-/// The `content_key` is random per-version symmetric key material, held in a
-/// zeroizing owning type ([`SecretBytes`]) with a redacted `Debug` — the
-/// blueprint's inline-random-content-key rule crossed with the never-log-keys
-/// rule. It is private; read it through [`Version::content_key`].
+/// The private `content_key` is random per-version symmetric key material, held
+/// in a zeroizing owner ([`SecretBytes`]) with a redacted `Debug` (never-log-keys
+/// rule); read it through [`Version::content_key`].
 #[derive(Clone)]
 pub struct Version {
     /// The content CID bytes.
@@ -263,10 +251,9 @@ impl ReadBody {
         }
     }
 
-    /// Check the decode-time invariants a *constructed* body must also satisfy
-    /// before it is sealed and persisted: a folder's children carry
-    /// pairwise-unique ids and pairwise-unique ipnsNames (#39 D7). The seal path
-    /// runs this so it never persists a body that decode would refuse to reopen.
+    /// The decode-time uniqueness invariants (#39 D7) re-checked on a
+    /// *constructed* body: the seal path runs this so it never persists a body
+    /// that decode would refuse to reopen.
     pub fn validate(&self) -> Result<(), CodecError> {
         match self {
             Self::Folder { children, .. } => assert_children_unique(children),
@@ -278,24 +265,18 @@ impl ReadBody {
 /// The strict name comparator: a platform-stable total order over opaque
 /// `ipnsName` bytes (blueprint/testing.md — the strict name comparator).
 ///
-/// The base36 name codec is a later slice, so names are raw bytes here.
 /// Bytewise-lexicographic order depends only on the bytes — no length prefix,
 /// no locale — so duplicate detection is deterministic and identical on native
-/// and WASM. Backs the duplicate-`ipnsName` uniqueness check and its
-/// total-order property test.
+/// and WASM. Backs the duplicate-`ipnsName` uniqueness check.
 pub fn name_cmp(a: &[u8], b: &[u8]) -> Ordering {
     a.cmp(b)
 }
 
 /// Decode a sealed read-body plaintext (strict det-CBOR, uniqueness enforced).
 ///
-/// The transient decoded `Value` tree carries a verbatim copy of every file
-/// version's inline **content key**. Those bytes are read into zeroizing
-/// [`SecretBytes`] owners, but the tree itself must be scrubbed before it drops
-/// (terminal-owner rule, symmetric with [`encode_read_body`]). An owning
-/// [`ScrubOwned`] guard wraps the tree and wipes it on drop — covering the Ok
-/// return, every `?` early return, and a panic-unwind — while `map` reads
-/// through the guard's immutable accessor.
+/// The transient decoded tree carries a verbatim copy of every inline **content
+/// key**, so it is scrubbed through the owning [`ScrubOwned`] guard
+/// (terminal-owner rule; symmetric with [`encode_read_body`]).
 pub fn decode_read_body(bytes: &[u8]) -> Result<ReadBody, CodecError> {
     let value = ScrubOwned(decode(bytes)?);
     let map = value.value().as_map()?;
@@ -336,15 +317,14 @@ pub fn decode_read_body(bytes: &[u8]) -> Result<ReadBody, CodecError> {
 
 /// Encode a read-body to its canonical det-CBOR plaintext.
 ///
-/// The returned buffer carries any inline **content-key** material verbatim, so
-/// its caller is the terminal owner and must zeroize it after use (the seal
-/// path, [`seal_read_body`](super::seal_read_body), does exactly this).
+/// The returned buffer carries inline **content-key** material verbatim, so its
+/// caller is the terminal owner and must zeroize it (the seal path,
+/// [`seal_read_body`](super::seal_read_body), does).
 ///
-/// Encoding does *not* re-check uniqueness: a caller-built folder with duplicate
-/// child ids/ipnsNames still encodes but its bytes reject on decode. Callers
-/// that *persist* a body must go through [`seal_read_body`](super::seal_read_body)
-/// (or call [`ReadBody::validate`] first), which refuses to seal a body that
-/// would not reopen; a `debug_assert` catches the divergence early in tests.
+/// Encoding does *not* re-check uniqueness — persisting callers go through
+/// [`seal_read_body`](super::seal_read_body) (or [`ReadBody::validate`]), which
+/// refuses to seal a body that would not reopen; the `debug_assert` only catches
+/// that divergence early in tests.
 pub fn encode_read_body(body: &ReadBody) -> Result<Vec<u8>, CodecError> {
     debug_assert!(
         body.validate().is_ok(),
@@ -395,10 +375,9 @@ pub fn encode_read_body(body: &ReadBody) -> Result<Vec<u8>, CodecError> {
 
 /// Scrubs a codec-owned transient `Value` tree on drop, so the secret copies it
 /// carries (inline content keys, scope seeds) are wiped on both normal return
-/// and panic-unwind out of `encode` (blueprint/core.md terminal-owner rule). It
-/// borrows the tree rather than owning it, leaving the wiped buffers observable
-/// to a caller/test after the guard falls. `pub(crate)` so the grant-section
-/// encoders share the one guard.
+/// and panic-unwind (blueprint/core.md terminal-owner rule). It borrows rather
+/// than owns the tree, leaving the wiped buffers observable to a caller/test
+/// after the guard falls.
 pub(crate) struct ScrubOnDrop<'a>(pub(crate) &'a mut Value);
 
 impl Drop for ScrubOnDrop<'_> {
@@ -408,11 +387,9 @@ impl Drop for ScrubOnDrop<'_> {
 }
 
 /// The owning sibling of [`ScrubOnDrop`], for the decode side: it takes the
-/// transient decoded `Value` tree by value and scrubs it on drop. The decoder
-/// reads its fields through [`Self::value`], an immutable borrow that coexists
-/// with the guard (a `&mut` guard cannot, since decode holds a live `&Map` into
-/// the same tree). Covers Ok, Err, and panic-unwind. `pub(crate)` so the
-/// grant-section decoders share the one guard.
+/// decoded tree by value and scrubs it on drop, covering Ok, Err, and unwind.
+/// Owning rather than borrowing because decode holds a live `&Map` into the
+/// tree, which a `&mut` guard cannot coexist with; read it via [`Self::value`].
 pub(crate) struct ScrubOwned(pub(crate) Value);
 
 impl ScrubOwned {
@@ -502,12 +479,10 @@ pub(super) fn collect_unknown(map: &Map, known: &[&str]) -> Vec<(String, Value)>
 }
 
 /// Merge preserved unknown fields into a typed map, **typed fields taking
-/// precedence**. Decode guarantees the unknown keys never overlap the typed
-/// ones (they were partitioned by [`collect_unknown`]), so the round-trip path
-/// never collides and stays byte-stable. The skip-on-collision guard hardens
-/// the *construction* path: a caller-built struct whose public `unknown` list
-/// happens to carry a schema key can never overwrite the typed value and forge
-/// bytes that disagree with it. `Map::insert` re-imposes canonical order.
+/// precedence**. Decode already partitions the two ([`collect_unknown`]), so the
+/// skip-on-collision guard is for the *construction* path: a caller-built
+/// `unknown` list carrying a schema key can never overwrite the typed value and
+/// forge bytes that disagree with it. `Map::insert` re-imposes canonical order.
 pub(super) fn merge_unknown(map: &mut Map, unknown: &[(String, Value)]) {
     for (k, v) in unknown {
         if !map.contains_key(k) {

--- a/crates/core/src/seal/envelope.rs
+++ b/crates/core/src/seal/envelope.rs
@@ -74,10 +74,9 @@ pub fn decode_envelope(bytes: &[u8]) -> Result<Envelope, CodecError> {
 
 /// The `grantSection` bytes carried in the envelope's preserved unknown
 /// top-level fields (#27 D10 — `grantSection` rides `unknown`, never a typed
-/// field, so an envelope stays kind-uniform and byte-stable on rewrite). A
-/// non-crypto accessor: it hands the raw section bytes to the caller (see
-/// [`super::decode_grant_section`]) so the engine never matches raw `Value`s.
-/// `None` when the field is absent or not a byte string.
+/// field, so an envelope stays kind-uniform and byte-stable on rewrite). Raw
+/// bytes for [`super::decode_grant_section`], so the engine never matches raw
+/// `Value`s; `None` when the field is absent or not a byte string.
 pub fn grant_section_bytes(env: &Envelope) -> Option<&[u8]> {
     env.unknown
         .iter()
@@ -115,10 +114,8 @@ pub fn encode_envelope(env: &Envelope) -> Result<Vec<u8>, CodecError> {
 /// caller-injected entropy the KATs pin.
 ///
 /// The body is [`ReadBody::validate`]d first, so this never persists a folder
-/// with duplicate child ids/ipnsNames that decode would refuse to reopen —
-/// returning a [`TrustViolation`](crate::error::TrustViolation) if it would.
-/// The encoded plaintext (which carries inline content keys) is zeroized here —
-/// this function is its terminal owner.
+/// decode would refuse to reopen. The encoded plaintext carries inline content
+/// keys and is zeroized here — this function is its terminal owner.
 pub fn seal_read_body(
     key: &[u8; KEY_LEN],
     nonce: &[u8; NONCE_LEN],
@@ -150,12 +147,11 @@ pub fn seal_read_body(
     })
 }
 
-/// Open and decode an envelope's read-body under the read key. Rebuilds the
-/// `read-body` AAD from the envelope's own plaintext fields, so any transplant
-/// (a body re-hung under a different `v`/id/scope/epoch) or a `v` downgrade
-/// fails the tag as [`crate::error::TrustViolation::SealOpenFailed`]. The
-/// recovered plaintext buffer is zeroized here; the returned [`ReadBody`]'s
-/// content keys are the caller's to own.
+/// Open and decode an envelope's read-body under the read key. The AAD is
+/// rebuilt from the envelope's own plaintext fields, so any transplant or `v`
+/// downgrade fails the tag as [`crate::error::TrustViolation::SealOpenFailed`].
+/// The recovered plaintext is zeroized here; the returned [`ReadBody`]'s content
+/// keys are the caller's to own.
 pub fn open_read_body(env: &Envelope, key: &[u8; KEY_LEN]) -> Result<ReadBody, CodecError> {
     let ctx = AadContext {
         v: env.v,

--- a/crates/core/src/seal/grant.rs
+++ b/crates/core/src/seal/grant.rs
@@ -12,17 +12,13 @@
 //!   owner's encryption subkey; the owner is an implicit, unrevokable grantee of
 //!   every scope.
 //! - **Ascent link** — the current override seed HPKE-sealed to an X25519
-//!   keypair derived from the **parent's** node seed. The public half rides
-//!   plaintext so any writer can re-seal; unsealing needs the parent seed, so
-//!   only ancestor-scope readers descend. An ancestor re-derives the expected
-//!   keypair and **rejects a mismatched public half** before opening (the
-//!   derive-and-verify check).
+//!   keypair derived from the **parent's** node seed, so only ancestor-scope
+//!   readers descend ([`open_ascent_link`] is the derive-and-verify check).
 //! - **History link** — the previous epoch's seed symmetrically sealed under
 //!   the current one (struct tag `history-link`); the key-regression ratchet.
 //! - **Grant-set commitment** — the owner-signed, **epoch-free**
-//!   `{ipnsName, ownerPseudonymPk, [(tag, permission, pseudonymPk)]}`. A
-//!   recipient verifies their tag is committed before trusting a grant; being
-//!   epoch-free, a grantee-triggered rotation needs no fresh owner signature.
+//!   `{ipnsName, ownerPseudonymPk, [(tag, permission, pseudonymPk)]}`
+//!   ([`GrantSetCommitment`]).
 //!
 //! All crypto is composed from [`crate::suite`]; the whole-record fail-closed
 //! adoption policy over these verdicts is the engine's gate, not this layer.
@@ -177,10 +173,8 @@ impl Eq for GrantBlobPayload {}
 
 /// Decode a grant-blob plaintext (strict det-CBOR, unknown fields preserved).
 ///
-/// The transient decoded tree carries verbatim copies of the read/write scope
-/// seeds and the pointer read key; those bytes land in zeroizing owners, but the
-/// tree itself is scrubbed on drop via [`ScrubOwned`] (terminal-owner rule,
-/// symmetric with [`encode_grant_blob_payload`]).
+/// The transient decoded tree carries verbatim seed copies, so it is scrubbed on
+/// drop via [`ScrubOwned`].
 pub fn decode_grant_blob_payload(bytes: &[u8]) -> Result<GrantBlobPayload, CodecError> {
     let value = ScrubOwned(decode(bytes)?);
     let map = value.value().as_map()?;
@@ -220,9 +214,8 @@ pub fn encode_grant_blob_payload(payload: &GrantBlobPayload) -> Result<Vec<u8>, 
         m.insert("writeScopeSeed", Value::Bytes(w.as_bytes().to_vec()));
     }
     merge_unknown(&mut m, &payload.unknown);
-    // The transient tree carries verbatim seed copies; scrub the whole tree
-    // through the drop guard so the wipe runs on return and on panic-unwind
-    // (terminal-owner rule). The returned buffer stays the seal path's to zero.
+    // The transient tree carries verbatim seed copies; the drop guard wipes it
+    // on both return and panic-unwind.
     let mut value = Value::Map(m);
     let guard = ScrubOnDrop(&mut value);
     encode(guard.0)
@@ -259,8 +252,6 @@ pub fn open_grant_blob(
     ctx: &AadContext,
     ciphertext: &[u8],
 ) -> Result<GrantBlobPayload, CodecError> {
-    // `hpke_open` returns `Zeroizing<Vec<u8>>`, so this seed-bearing plaintext is
-    // wiped on drop — no explicit zeroize needed at this terminal owner.
     let plaintext = hpke::hpke_open(
         recipient_secret,
         enc,
@@ -327,10 +318,8 @@ impl Eq for OverrideSeedPayload {}
 
 /// Decode an override-seed plaintext (strict det-CBOR, unknown fields preserved).
 ///
-/// The transient decoded tree carries a verbatim copy of the override seed; it
-/// lands in a zeroizing owner, but the tree itself is scrubbed on drop via
-/// [`ScrubOwned`] (terminal-owner rule, symmetric with
-/// [`encode_override_seed_payload`]).
+/// The transient decoded tree carries a verbatim copy of the override seed, so
+/// it is scrubbed on drop via [`ScrubOwned`].
 pub fn decode_override_seed_payload(bytes: &[u8]) -> Result<OverrideSeedPayload, CodecError> {
     let value = ScrubOwned(decode(bytes)?);
     let map = value.value().as_map()?;
@@ -354,8 +343,8 @@ pub fn encode_override_seed_payload(payload: &OverrideSeedPayload) -> Result<Vec
         Value::Bytes(payload.override_seed.as_bytes().to_vec()),
     );
     merge_unknown(&mut m, &payload.unknown);
-    // Whole-tree scrub via the drop guard (terminal-owner rule); the returned
-    // buffer stays the seal path's to zeroize.
+    // The transient tree carries a verbatim seed copy; the drop guard wipes it
+    // on both return and panic-unwind.
     let mut value = Value::Map(m);
     let guard = ScrubOnDrop(&mut value);
     encode(guard.0)
@@ -390,8 +379,6 @@ pub fn open_owner_blob(
     ctx: &AadContext,
     ciphertext: &[u8],
 ) -> Result<OverrideSeedPayload, CodecError> {
-    // `hpke_open` returns `Zeroizing<Vec<u8>>`, so this seed-bearing plaintext is
-    // wiped on drop — no explicit zeroize needed at this terminal owner.
     let plaintext = hpke::hpke_open(
         owner_enc_secret,
         enc,
@@ -465,10 +452,8 @@ impl Eq for OwnerWriteBlobPayload {}
 /// Decode an owner-write-blob plaintext (strict det-CBOR, unknown fields
 /// preserved).
 ///
-/// The transient decoded tree carries a verbatim copy of the write-scope seed; it
-/// lands in a zeroizing owner, but the tree itself is scrubbed on drop via
-/// [`ScrubOwned`] (terminal-owner rule, symmetric with
-/// [`encode_owner_write_blob_payload`]).
+/// The transient decoded tree carries a verbatim copy of the write-scope seed,
+/// so it is scrubbed on drop via [`ScrubOwned`].
 pub fn decode_owner_write_blob_payload(bytes: &[u8]) -> Result<OwnerWriteBlobPayload, CodecError> {
     let value = ScrubOwned(decode(bytes)?);
     let map = value.value().as_map()?;
@@ -495,8 +480,8 @@ pub fn encode_owner_write_blob_payload(
         Value::Bytes(payload.write_scope_seed.as_bytes().to_vec()),
     );
     merge_unknown(&mut m, &payload.unknown);
-    // Whole-tree scrub via the drop guard (terminal-owner rule); the returned
-    // buffer stays the seal path's to zeroize.
+    // The transient tree carries a verbatim seed copy; the drop guard wipes it
+    // on both return and panic-unwind.
     let mut value = Value::Map(m);
     let guard = ScrubOnDrop(&mut value);
     encode(guard.0)
@@ -533,8 +518,6 @@ pub fn open_owner_write_blob(
     ctx: &AadContext,
     ciphertext: &[u8],
 ) -> Result<OwnerWriteBlobPayload, CodecError> {
-    // `hpke_open` returns `Zeroizing<Vec<u8>>`, so this seed-bearing plaintext is
-    // wiped on drop — no explicit zeroize needed at this terminal owner.
     let plaintext = hpke::hpke_open(
         owner_enc_secret,
         enc,
@@ -636,8 +619,6 @@ pub fn open_ascent_link(
     if ascent_secret.public().to_bytes() != link.ascent_public {
         return Err(TrustViolation::AscentLinkMismatch.into());
     }
-    // `hpke_open` returns `Zeroizing<Vec<u8>>`, so this seed-bearing plaintext is
-    // wiped on drop — no explicit zeroize needed at this terminal owner.
     let plaintext = hpke::hpke_open(
         &ascent_secret,
         &link.enc,
@@ -707,9 +688,7 @@ impl Eq for HistoryLinkPayload {}
 /// Decode a history-link plaintext (strict det-CBOR, unknown fields preserved).
 ///
 /// The transient decoded tree carries a verbatim copy of the previous epoch's
-/// seed; it lands in a zeroizing owner, but the tree itself is scrubbed on drop
-/// via [`ScrubOwned`] (terminal-owner rule, symmetric with
-/// [`encode_history_link_payload`]).
+/// seed, so it is scrubbed on drop via [`ScrubOwned`].
 pub fn decode_history_link_payload(bytes: &[u8]) -> Result<HistoryLinkPayload, CodecError> {
     let value = ScrubOwned(decode(bytes)?);
     let map = value.value().as_map()?;
@@ -733,8 +712,8 @@ pub fn encode_history_link_payload(payload: &HistoryLinkPayload) -> Result<Vec<u
         Value::Bytes(payload.prev_seed.as_bytes().to_vec()),
     );
     merge_unknown(&mut m, &payload.unknown);
-    // Whole-tree scrub via the drop guard (terminal-owner rule); the returned
-    // buffer stays the seal path's to zeroize.
+    // The transient tree carries a verbatim seed copy; the drop guard wipes it
+    // on both return and panic-unwind.
     let mut value = Value::Map(m);
     let guard = ScrubOnDrop(&mut value);
     encode(guard.0)
@@ -764,9 +743,8 @@ pub fn open_history_link(
     ctx: &AadContext,
     sealed: &[u8],
 ) -> Result<HistoryLinkPayload, CodecError> {
-    // `unseal` returns a plain buffer carrying the previous epoch's seed; this
-    // function is its terminal owner, so wipe it after decode (mirroring
-    // `open_read_body`). The HPKE open paths get this for free via `Zeroizing`.
+    // `unseal` returns a plain buffer carrying the previous epoch's seed, so
+    // this terminal owner wipes it after decode.
     let mut plaintext = super::unseal(key, ctx, sealed)?;
     let result = decode_history_link_payload(&plaintext);
     plaintext.zeroize();
@@ -904,8 +882,7 @@ pub fn sign_grant_set(
 /// Verify a grant-set commitment's owner signature. Fails closed with
 /// [`TrustViolation::CommitmentInvalid`] when the owner identity key did not
 /// attest this tag/pseudonym set — the fail-closed check a recipient runs
-/// before trusting a grant. The fail-closed *policy* over this verdict is the
-/// engine's adoption gate.
+/// before trusting a grant.
 pub fn verify_grant_set(
     verifier: &EcdsaVerifier,
     c: &GrantSetCommitment,

--- a/crates/core/src/seal/mod.rs
+++ b/crates/core/src/seal/mod.rs
@@ -6,11 +6,9 @@
 //! Pure and deterministic: the sealing key and the nonce are injected (KATs pin
 //! them); core samples no entropy and reads no clock.
 //!
-//! The wire framing of a sealed body is `nonce(24) || ciphertext||tag`: the
-//! XChaCha20-Poly1305 24-byte nonce is prefixed so [`unseal`] can recover it,
-//! and it is authenticated by the AEAD itself (a flipped nonce breaks the tag).
-//! The nonce is deliberately **not** in the AAD — only `(v, id, scope, epoch,
-//! structTag)` is ([`aad`]).
+//! The wire framing of a sealed body is `nonce(24) || ciphertext||tag`; the
+//! nonce is authenticated by the AEAD itself and deliberately **not** in the
+//! AAD, which binds only `(v, id, scope, epoch, structTag)` ([`aad`]).
 
 pub mod aad;
 pub mod body;
@@ -66,11 +64,9 @@ use crate::suite::aead::{self, KEY_LEN, NONCE_LEN, TAG_LEN};
 ///
 /// `nonce` **must be unique for every seal performed with a given `key`**:
 /// XChaCha20-Poly1305 nonce reuse under one key is a confidentiality and
-/// integrity break. It is caller-injected entropy (KATs pin it; production
-/// callers source it from their injected entropy seam), prefixed so [`unseal`]
-/// can recover it, and authenticated by the AEAD rather than by the AAD
-/// (#39 D7). The caller owns `plaintext` and is its terminal owner for
-/// zeroization (a callee never zeroizes a caller-owned buffer).
+/// integrity break. It is caller-injected entropy (the KATs pin it), prefixed
+/// so [`unseal`] can recover it, and authenticated by the AEAD rather than by
+/// the AAD (#39 D7).
 pub fn seal(
     key: &[u8; KEY_LEN],
     nonce: &[u8; NONCE_LEN],

--- a/crates/core/src/seal/section.rs
+++ b/crates/core/src/seal/section.rs
@@ -11,25 +11,13 @@
 //! recomputes each `H(ciphertext)` before verifying the signatures — so the
 //! record itself is the completeness authority, never a side list.
 //!
-//! Layout (det-CBOR map, one strictness policy, unknown fields preserved):
-//!
-//! - `commitment` — the encoded [`GrantSetCommitment`] (the exact owner-signed
-//!   preimage) and `commitmentSig` — its 64-byte compact ECDSA signature.
-//! - `grantBlobs` — `[{tag, enc, ciphertext, sig}]`, keyed and structure-signed
-//!   per recipient blinded tag; the tags are unique fail-closed (#39 D7).
-//! - `ownerBlob` — `{enc, ciphertext, sig}`.
-//! - `ascentLink` — `{ascentPublic, enc, ciphertext, sig}`, present only when
-//!   the scope has a parent (interior vault root omits it).
-//! - `historyLinks` — `[{sealed, sig}]`, the per-epoch key-regression links
-//!   (empty at epoch 1).
-//! - `writeBody` — `{sealed, sig}`, the scope root's sealed write-body.
-//!
+//! The frame is a det-CBOR map under one strictness policy, unknown fields
+//! preserved; its members are enumerated and documented on [`GrantSection`].
 //! Each `sig` is the 64-byte Ed25519 structure signature over the
 //! `{scopeId, epoch, structTag, recipientTag?, H(ciphertext)}` preimage
-//! ([`super::structure`]); the byte string a signature binds is:
-//!
-//! - the HPKE `ciphertext` (not `enc`) for grant blob / owner blob / ascent link;
-//! - the whole symmetric sealed blob `nonce||ct||tag` for history link / write-body.
+//! ([`super::structure`]); the byte string it binds is the HPKE `ciphertext`
+//! (**not** `enc`) for grant blob / owner blob / ascent link, and the whole
+//! symmetric sealed blob `nonce||ct||tag` for history link / write-body.
 //!
 //! Signatures are carried as raw fixed-width bytes and never parsed or verified
 //! here — that is the gate's crypto step. This codec only frames and enforces

--- a/crates/core/src/seal/structure.rs
+++ b/crates/core/src/seal/structure.rs
@@ -5,22 +5,17 @@
 //! owner blob, the ascent link, the history links, and the write-body — carries
 //! a **detached** Ed25519 signature by the rotator's writer pseudonym over the
 //! det-CBOR preimage `{scopeId, epoch, structTag, recipientTag?, H(ciphertext)}`.
-//! Binding the ciphertext hash and the full context makes a signature
-//! non-transferable:
+//! Binding the whole context makes a signature non-transferable: `structTag`
+//! closes transplanting it onto a different structure kind, `recipientTag`
+//! (grant blobs only) closes replaying one recipient's grant-blob signature
+//! under another recipient's tag, `H(ciphertext)` binds the exact sealed bytes,
+//! and `scopeId + epoch` bind the structure to its scope and rotation.
 //!
-//! - the **structTag** closes transplanting a signature onto a different
-//!   structure kind;
-//! - the **recipientTag** (present only for grant blobs) closes replaying one
-//!   recipient's grant-blob signature under another recipient's tag;
-//! - **H(ciphertext)** binds the exact sealed bytes, so a swapped ciphertext
-//!   fails; and
-//! - **scopeId + epoch** bind the structure to its scope and rotation.
-//!
-//! The preimage is a det-CBOR map (never decoded — only signed and verified —
-//! so, like the AAD, it carries no unknown-field tolerance). Verification is
-//! per-structure and pure; the whole-record fail-closed policy over these
-//! verdicts (a missing or invalid signature is a whole-record trust violation)
-//! is the engine's adoption gate, which composes [`verify_structure`].
+//! The preimage is a det-CBOR map, never decoded — only signed and verified — so
+//! it carries no unknown-field tolerance. Verification is per-structure and
+//! pure; the whole-record fail-closed policy over these verdicts (a missing or
+//! invalid signature is a whole-record trust violation) is the engine's adoption
+//! gate, which composes [`verify_structure`].
 
 use crate::codec::{Map, Value, encode_fixed_depth};
 use crate::error::{CodecError, TrustViolation};
@@ -90,10 +85,9 @@ pub fn sign_structure(signer: &Ed25519Signer, input: &StructureSigInput) -> Ed25
 
 /// Verify a detached structure signature against the writer pseudonym public
 /// key. Fails closed with [`TrustViolation::StructureSignatureInvalid`] on a
-/// forged signature, a signature transplanted to a different `structTag`, a
-/// grant-blob signature replayed under a different `recipientTag`, or a swapped
-/// ciphertext (all recompute a different preimage). A pure per-structure check
-/// the adoption gate composes.
+/// forgery or any transplant — everything the preimage binds (see the module
+/// docs) recomputes differently. A pure per-structure check the adoption gate
+/// composes.
 pub fn verify_structure(
     verifier: &Ed25519Verifier,
     input: &StructureSigInput,

--- a/crates/core/src/seal/write_body.rs
+++ b/crates/core/src/seal/write_body.rs
@@ -3,18 +3,13 @@
 //!
 //! Present **only at scope roots**: interior nodes publish no write-body at all
 //! — their write material (write seed, `writeKey`, IPNS keypair) is derived flat
-//! within the write scope. The write-body is sealed under the root's `writeKey`
-//! (struct tag `write-body`) and carries three things:
+//! within the write scope. Sealed under the root's `writeKey` (struct tag
+//! `write-body`), it carries the authoritative grant ledger, the write-plane
+//! history link (opaque sealed bytes here; codec in [`super::grant`]), and the
+//! `directChildScopeIndex` for the F-4 rotation cascade (#38 D6).
 //!
-//! - the **grant ledger** — the authoritative `(recipientIdentityPk,
-//!   recipientEncPk, permission, tag)` record of a scope's grants. Writers
-//!   re-wrap grant blobs for the recorded set during re-seals but cannot change
-//!   the set; grant changes are owner-only.
-//! - the **write-plane history link** — the previous write epoch's seed sealed
-//!   under the current one (opaque sealed bytes here; the codec is
-//!   [`super::grant`]).
-//! - the **directChildScopeIndex** — the directly-descendant scope roots, for
-//!   the F-4 rotation cascade (#38 D6).
+//! Writers re-wrap grant blobs for the ledger's recorded set during re-seals but
+//! cannot change the set; grant changes are owner-only.
 //!
 //! One strictness policy, everywhere (#27 D10): every map level decodes strict
 //! det-CBOR and preserves unknown fields byte-stable, so an old client
@@ -33,10 +28,9 @@ use super::grant::Permission;
 // Grant-ledger entry.
 // ---------------------------------------------------------------------------
 
-/// One authoritative grant-ledger row: the recipient's identity and encryption
-/// public keys, their permission, and their blinded tag. The identity key is
-/// the 33-byte compressed secp256k1 SEC1 form; the encryption subkey is the
-/// 32-byte X25519 public key.
+/// One authoritative grant-ledger row. The identity key is the 33-byte
+/// compressed secp256k1 SEC1 form; the encryption subkey is a 32-byte X25519
+/// public key.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GrantLedgerEntry {
     /// The recipient's compressed secp256k1 identity public key (SEC1).
@@ -113,9 +107,7 @@ impl GrantLedgerEntry {
 // Child-scope index entry.
 // ---------------------------------------------------------------------------
 
-/// One directly-descendant scope root, enumerated for the F-4 rotation cascade:
-/// its scope id (the scope-root node UUID) and its opaque `ipnsName` (needed to
-/// resolve it).
+/// One directly-descendant scope root, enumerated for the F-4 rotation cascade.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChildScopeRef {
     /// The child scope root's node id (16-byte UUID) = its scope id.
@@ -162,9 +154,7 @@ impl ChildScopeRef {
 // The write-body.
 // ---------------------------------------------------------------------------
 
-/// The sealed write-plane payload of a scope root. `write_history_link` is the
-/// opaque sealed bytes of the write-plane history link (empty at write epoch 1,
-/// before any prior write epoch exists).
+/// The sealed write-plane payload of a scope root.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WriteBody {
     /// The authoritative grant ledger.
@@ -181,9 +171,8 @@ const WRITE_BODY_KNOWN: &[&str] = &["directChildScopeIndex", "grantLedger", "wri
 
 /// Decode a write-body plaintext (strict det-CBOR, unknown fields preserved).
 ///
-/// The write-body is a scope-root-only structure; this codec does not (and
-/// cannot) enforce that — whether a node is a scope root is the engine's
-/// decision.
+/// Scope-root-only by construction; this codec cannot enforce that — whether a
+/// node is a scope root is the engine's decision.
 pub fn decode_write_body(bytes: &[u8]) -> Result<WriteBody, CodecError> {
     let value = decode(bytes)?;
     let map = value.as_map()?;
@@ -210,13 +199,10 @@ pub fn decode_write_body(bytes: &[u8]) -> Result<WriteBody, CodecError> {
 /// Encode a write-body to its canonical det-CBOR plaintext (sealed under the
 /// root's `writeKey` with struct tag `write-body` by the caller / seal path).
 ///
-/// Fails closed on a duplicate-tag ledger with the same `duplicate-grant-tag`
-/// verdict `decode_write_body` raises. Unlike [`encode_read_body`] — whose core
-/// seal boundary [`seal_read_body`](super::seal_read_body) runs `ReadBody::validate`
-/// — the write body is sealed outside core, so this encode is its release-active
-/// guard: it never hands back bytes its own decoder rejects.
-///
-/// [`encode_read_body`]: super::encode_read_body
+/// The write body is sealed outside core, so this encode is its release-active
+/// fail-closed guard: a duplicate-tag ledger fails here with the same
+/// `duplicate-grant-tag` verdict [`decode_write_body`] raises, so it never hands
+/// back bytes its own decoder rejects.
 pub fn encode_write_body(body: &WriteBody) -> Result<Vec<u8>, CodecError> {
     assert_grant_tags_unique(body.grant_ledger.iter().map(|e| e.tag))?;
     let mut m = Map::new();

--- a/crates/core/src/suite/aead.rs
+++ b/crates/core/src/suite/aead.rs
@@ -1,10 +1,10 @@
 //! XChaCha20-Poly1305 AEAD primitive (blueprint/core.md "Crypto suite":
 //! symmetric sealing, 24-byte nonce).
 //!
-//! This is the raw AEAD only — the CipherBox seal/unseal layer (structured AAD
-//! construction, the `cipherbox/v2` domain separator, envelope framing) is a
-//! later slice and is deliberately *not* here. HPKE ([`super::hpke`]) composes
-//! this primitive under a per-message derived key and nonce.
+//! The raw AEAD only; the CipherBox seal/unseal layer (structured AAD, the
+//! `cipherbox/v2` domain separator, envelope framing) is [`crate::seal`]. HPKE
+//! ([`super::hpke`]) composes this primitive under a per-message derived key
+//! and nonce.
 
 use chacha20poly1305::aead::{Aead, Payload};
 use chacha20poly1305::{KeyInit, XChaCha20Poly1305, XNonce};
@@ -21,13 +21,11 @@ pub const TAG_LEN: usize = 16;
 ///
 /// # Security — plaintext length (caller invariant)
 ///
-/// [`encrypt`] treats sealing as **infallible** and would panic on a single
-/// message strictly longer than this. Core exports the raw AEAD over
-/// caller-framed chunks (the engine frames content well below this, at 1 MiB),
-/// so the framing seam owns the ceiling — the same caller-invariant class as the
-/// per-call ephemeral-scalar uniqueness [`hpke_seal`](super::hpke::hpke_seal)
-/// documents. A `u64` keeps the constant representable on the 32-bit WASM leg,
-/// where the value exceeds `usize::MAX`.
+/// [`encrypt`] treats sealing as **infallible** and would panic past this
+/// ceiling, so the caller's framing seam owns it (the engine frames content at
+/// 1 MiB) — the same caller-invariant class as the per-call ephemeral-scalar
+/// uniqueness [`hpke_seal`](super::hpke::hpke_seal) documents. `u64`, not
+/// `usize`: the value exceeds `usize::MAX` on the 32-bit WASM leg.
 pub const MAX_PLAINTEXT_LEN: u64 = 64 * ((1u64 << 32) - 1);
 
 /// Seal `plaintext` under `key`/`nonce` with additional authenticated data

--- a/crates/core/src/suite/contact.rs
+++ b/crates/core/src/suite/contact.rs
@@ -4,10 +4,8 @@
 //! Every user's identity key only signs and their X25519 encryption subkey only
 //! seals. The **subkey binding** is an ECDSA signature over the det-CBOR
 //! `{encSubkey, identityPk}` preimage; the **contact code** is the det-CBOR
-//! `{bindingSig, encSubkey, identityPk}` triple (~130 bytes, QR/URL-encodable).
-//! [`import_contact_code`] verifies the binding **mandatorily and fail-closed**:
-//! a code whose binding does not verify is rejected as a trust violation, never
-//! imported and never treated as stale.
+//! `{bindingSig, encSubkey, identityPk}` triple (~130 bytes, QR/URL-encodable),
+//! which [`import_contact_code`] verifies mandatorily and fail-closed.
 
 use crate::codec::{Map, Value, decode, encode_fixed_depth};
 use crate::error::{CodecError, Malformed, TrustViolation};

--- a/crates/core/src/suite/ecdsa.rs
+++ b/crates/core/src/suite/ecdsa.rs
@@ -1,8 +1,7 @@
 //! secp256k1 ECDSA over det-CBOR (blueprint/core.md "Crypto suite": identity
 //! signing — subkey binding, grant-set commitment, re-point object, mailbox
-//! sender signature). Nonces are RFC 6979 deterministic (the `rfc6979` crate,
-//! no RNG), and messages are hashed with SHA-256 before signing, so a fixed key
-//! and message always produce the same signature.
+//! sender signature). Nonces are RFC 6979 deterministic (no RNG) and messages
+//! are hashed with SHA-256 before signing.
 //!
 //! Signatures are the canonical 64-byte compact `r || s` form (low-S is what
 //! the deterministic signer emits); the `sec1` compressed public key is 33
@@ -66,15 +65,12 @@ impl fmt::Debug for EcdsaSigner {
 }
 
 impl EcdsaVerifier {
-    /// Parse a **compressed** SEC1 public key. `None` when the bytes are not
-    /// exactly the frozen 33-byte compressed width, or are not a valid point on
-    /// secp256k1. The explicit length guard runs *before* `from_sec1_bytes`
-    /// (which also accepts 65-byte uncompressed/hybrid forms): a compressed key
-    /// re-emitted uncompressed is byte-distinct yet decodes to the same point,
-    /// so admitting it would break the frozen 33-byte-width canonical doctrine —
-    /// a `PartialEq`-equal contact code with different bytes, and (in the mailbox
-    /// path, where `sig_preimage` hashes the raw sender key) a distinct signed
-    /// preimage that still verifies.
+    /// Parse a **compressed** SEC1 public key. `None` unless the bytes are the
+    /// frozen 33-byte compressed width *and* a valid secp256k1 point. The length
+    /// guard runs *before* `from_sec1_bytes`, which also accepts the 65-byte
+    /// uncompressed/hybrid forms: the same point re-encoded uncompressed is
+    /// byte-distinct, breaking the single-valued byte doctrine the contact code
+    /// and the mailbox `sig_preimage` (which hashes the raw sender key) rest on.
     pub fn from_sec1(bytes: &[u8]) -> Option<Self> {
         if bytes.len() != IDENTITY_PUBLIC_LEN {
             return None;
@@ -105,14 +101,12 @@ impl fmt::Debug for EcdsaVerifier {
 
 impl EcdsaSignature {
     /// Parse a compact signature. `None` when it is not exactly 64 bytes, when
-    /// `r`/`s` are out of range, or when `s` is **high** (non-canonical) — the
-    /// `invalid-binding-sig-encoding` gate. Rejecting high-S at the encoding
-    /// layer makes the byte form canonical and non-malleable: `s` and `n - s`
-    /// are two encodings of the same signature, so pinning low-S here keeps any
-    /// invariant keyed on the signature bytes single-valued (grant-set
-    /// commitment, one contact-code encoding). (k256's verifier also rejects
-    /// high-S, so this is defence in depth on the parse side.) The deterministic
-    /// signer already emits low-S, so this only rejects tampered inputs.
+    /// `r`/`s` are out of range, or when `s` is **high** — the
+    /// `invalid-binding-sig-encoding` gate. `s` and `n - s` encode the same
+    /// signature, so pinning low-S here keeps any invariant keyed on the
+    /// signature bytes single-valued (grant-set commitment, one contact-code
+    /// encoding). Defence in depth: k256's verifier also rejects high-S, and the
+    /// deterministic signer only ever emits low-S.
     pub fn from_compact(bytes: &[u8]) -> Option<Self> {
         if bytes.len() != SIGNATURE_LEN {
             return None;

--- a/crates/core/src/suite/ed25519.rs
+++ b/crates/core/src/suite/ed25519.rs
@@ -1,9 +1,7 @@
 //! Ed25519 signing (blueprint/core.md "Crypto suite": pseudonym + record
 //! signing). Deterministic by construction — no RNG — so seeds injected by the
-//! [`crate::kdf`] catalog's Ed25519 edges yield reproducible keypairs.
-//!
-//! The structure-signature verify *policy* (fail-closed, whole-record) is the
-//! engine's gate; this module ships only the pure primitive.
+//! [`crate::kdf`] catalog's Ed25519 edges yield reproducible keypairs. The pure
+//! primitive only — the verify *policy* is the engine's gate.
 
 use core::fmt;
 
@@ -66,15 +64,13 @@ impl Ed25519Verifier {
         self.0.to_bytes()
     }
 
-    /// Verify a detached signature over `message`. Returns `true` on a valid
-    /// signature; the fail-closed trust policy over this boolean lives in the
-    /// engine.
+    /// Verify a detached signature over `message`. The fail-closed trust policy
+    /// over this boolean lives in the engine.
     ///
-    /// Uses dalek's **strict** verification: it rejects the S-malleability
-    /// (`S` and `S + L` both satisfy cofactored verification) and small-order
-    /// `A`/`R`, so each (key, message) has a single accepting signature. That
-    /// non-malleability is required where signed structures/records may be
-    /// compared or committed in a zero-knowledge store.
+    /// Uses dalek's **strict** verification: it rejects S-malleability (`S` and
+    /// `S + L` both satisfy cofactored verification) and small-order `A`/`R`, so
+    /// each (key, message) has a single accepting signature — required where
+    /// signed structures may be compared or committed in a zero-knowledge store.
     pub fn verify(&self, message: &[u8], signature: &Ed25519Signature) -> bool {
         let sig = ed25519_dalek::Signature::from_bytes(&signature.0);
         self.0.verify_strict(message, &sig).is_ok()

--- a/crates/core/src/suite/hpke.rs
+++ b/crates/core/src/suite/hpke.rs
@@ -71,10 +71,9 @@ pub struct HpkeCiphertext {
 ///
 /// `ephemeral_scalar` **must be fresh, uniformly-random 32 bytes on every
 /// call.** Reusing it across two different plaintexts for the same
-/// `recipient_pub`/`info` re-derives the identical AEAD key **and** base nonce:
-/// XChaCha20-Poly1305 under a repeated (key, nonce) is a catastrophic break
-/// (keystream reuse leaks the plaintext XOR, and the one-time Poly1305 key
-/// enables forgeries). Core cannot sample entropy or enforce this (determinism
+/// `recipient_pub`/`info` re-derives the identical AEAD key **and** base nonce,
+/// and XChaCha20-Poly1305 under a repeated (key, nonce) is a catastrophic
+/// break. Core cannot sample entropy or enforce this (determinism
 /// doctrine), so the engine seam that calls `hpke_seal` owns the invariant: the
 /// ephemeral is in the same *random-per-use* class as content keys, **not** a
 /// KDF-catalog edge. KATs reuse a fixed scalar only because they seal one fixed
@@ -230,8 +229,7 @@ fn labeled_extract(salt: &[u8], suite_id: &[u8], label: &[u8], ikm: &[u8]) -> [u
     labeled_ikm.extend_from_slice(ikm);
     let (prk, _) = Hkdf::<Sha256>::extract(Some(salt), &labeled_ikm);
     // The scratch buffer copies `ikm` verbatim — in the KEM path that is the DH
-    // shared secret. Wipe it before it drops; the derived PRK is kept in the
-    // caller's `Zeroizing` binding when it is secret.
+    // shared secret — so wipe it before it drops.
     labeled_ikm.zeroize();
     prk.into()
 }
@@ -281,9 +279,8 @@ pub(crate) fn dhkem_encap(
 ) -> (SecretBytes, [u8; ENC_LEN]) {
     let sk_e = X25519Secret::from_scalar(*ephemeral_scalar);
     let enc = sk_e.public().to_bytes();
-    // Sound only because every `X25519Public` is built through the low-order-
-    // rejecting `from_bytes`, guaranteeing a contributory exchange; a future
-    // constructor that bypasses `from_bytes` would require re-auditing this.
+    // Sound only while every `X25519Public` is built through the low-order-
+    // rejecting `from_bytes`; a constructor that bypasses it needs a re-audit.
     let dh = sk_e
         .diffie_hellman(pk_r)
         .expect("recipient key is validated non-low-order, so ECDH is contributory");
@@ -372,15 +369,12 @@ pub(crate) fn dhkem_auth_decap(
 }
 
 /// The key schedule outputs (seq 0). `key`/`base_nonce` seal; the
-/// exporter secret is derived so the A.1 conformance test can pin it, though
-/// the export interface itself is a later slice.
+/// exporter secret is derived only so the RFC 9180 A.1 conformance test can
+/// pin it.
 pub(crate) struct KeySchedule {
-    // Key material: zeroized on drop so the derived AEAD key never lingers on
-    // the heap. The base nonce is not secret and stays a plain Vec.
     pub key: Zeroizing<Vec<u8>>,
+    // Not secret — the AEAD authenticates it, so no zeroizing owner.
     pub base_nonce: Vec<u8>,
-    // Derived so the RFC 9180 A.1 conformance test can pin it; the HPKE export
-    // interface that consumes it in production is a later slice.
     #[cfg_attr(not(test), allow(dead_code))]
     pub exporter_secret: Zeroizing<Vec<u8>>,
 }

--- a/crates/core/src/suite/mod.rs
+++ b/crates/core/src/suite/mod.rs
@@ -6,11 +6,11 @@
 //! is injected (HPKE's ephemeral scalar, every keypair seed), never sampled;
 //! this layer holds no state and reads no clock.
 //!
-//! What lands here: XChaCha20-Poly1305 ([`aead`]), BLAKE3 ([`hash`]), X25519
+//! Primitives only: XChaCha20-Poly1305 ([`aead`]), BLAKE3 ([`hash`]), X25519
 //! ([`x25519`]) and RFC 9180 HPKE ([`hpke`]), secp256k1 ECDSA ([`ecdsa`]),
 //! Ed25519 ([`ed25519`]), and the encryption-subkey binding + contact code
-//! codec ([`contact`]). The CipherBox seal/unseal layer (structured AAD,
-//! envelope framing) and structure signatures are later slices.
+//! codec ([`contact`]). The CipherBox seal/unseal layer — structured AAD,
+//! envelope framing, structure signatures — is [`crate::seal`].
 
 pub mod aead;
 pub mod contact;

--- a/crates/core/src/suite/x25519.rs
+++ b/crates/core/src/suite/x25519.rs
@@ -57,12 +57,11 @@ impl fmt::Debug for X25519Secret {
 
 impl X25519Public {
     /// Adopt a 32-byte public key, **rejecting** the RFC 7748 small-order
-    /// u-coordinates. `None` for a low-order point (identity or an order-2/4/8
-    /// point); `Some` otherwise. Holding an `X25519Public` therefore means "not
-    /// low-order", so [`super::hpke::dhkem_encap`] (seal) needs no separate
-    /// check. The exhaustive security gate is the contributory check in
-    /// [`Self::diffie_hellman`]; this rejects the canonical attack encodings up
-    /// front so a chosen low-order key never reaches contact import or decap.
+    /// u-coordinates. Holding an `X25519Public` therefore means "not low-order",
+    /// so [`super::hpke::dhkem_encap`] (seal) needs no separate check. This
+    /// rejects the canonical chosen-key encodings up front, before contact
+    /// import or decap; the exhaustive gate is the contributory check in
+    /// [`Self::diffie_hellman`].
     pub fn from_bytes(bytes: [u8; SECRET_LEN]) -> Option<Self> {
         if is_small_order(&bytes) {
             return None;
@@ -190,9 +189,8 @@ mod tests {
             let mut high = enc;
             high[31] |= 0x80;
             assert_eq!(X25519Public::from_bytes(high), None, "high-bit variant");
-            // Backstop: ECDH against a constructed peer of this u-coordinate (via
-            // dalek's total `PublicKey`) is non-contributory. `from_bytes` guards
-            // the encoding, so drive the peer through the dalek type directly.
+            // Backstop: `from_bytes` guards the encoding, so drive the peer
+            // through dalek's total `PublicKey` to reach the ECDH check.
             let peer = crate::suite::x25519::testonly_public_from_bytes(enc);
             assert!(probe.diffie_hellman(&peer).is_none(), "non-contributory");
         }

--- a/crates/core/tests/kat_manifest.rs
+++ b/crates/core/tests/kat_manifest.rs
@@ -1713,7 +1713,6 @@ fn seal_vectors_are_frozen_and_round_trip() {
             "seal {}: sealed drift",
             v.name
         );
-        // The nonce is prefixed, and the recipient recovers the plaintext.
         assert_eq!(
             &sealed[..NONCE_LEN],
             &nonce,
@@ -1844,7 +1843,6 @@ fn read_body_accept_vectors_decode_and_round_trip() {
         assert_eq!(body.kind(), expected, "read-body accept {}: kind", v.name);
         kinds.insert(v.kind.clone());
     }
-    // Both kinds are exercised.
     assert!(
         kinds.contains("folder") && kinds.contains("file"),
         "both kinds covered"
@@ -2166,7 +2164,6 @@ fn hpke_seal_vectors_are_frozen_and_open() {
             v.name
         );
 
-        // And the recipient must recover the plaintext.
         let recipient = X25519Secret::from_scalar(unhex32(&v.name, &v.recipient_secret));
         let enc = unhex32(&v.name, &v.enc);
         let opened = hpke_open(
@@ -2253,7 +2250,6 @@ fn contact_accept_vectors_import_and_round_trip() {
         let bytes = unhex(&v.name, &v.hex);
         let code = import_contact_code(&bytes)
             .unwrap_or_else(|e| panic!("contact accept {}: must import: {e}", v.name));
-        // Re-encode is byte-stable, and the components match the vector.
         assert_eq!(
             hex::encode(code.encode()),
             v.hex,
@@ -2415,7 +2411,6 @@ fn ipns_name_accept_vectors_encode_and_parse() {
             v.name
         );
         let key = Ed25519Signer::from_seed(unhex32(&v.name, &v.signer_seed)).verifying_key();
-        // Encode: the frozen name is the key's one canonical name.
         assert_eq!(
             IpnsName::from_public_key(&key).as_str(),
             v.ipns_name,
@@ -2519,7 +2514,6 @@ fn ipns_record_accept_vectors_are_frozen_and_verify() {
             "record-accept {}: record bytes drift",
             v.name
         );
-        // Keyless re-PUT is byte-stable.
         let reparsed = IpnsRecord::unmarshal(&record)
             .unwrap_or_else(|e| panic!("record-accept {}: unmarshal: {e}", v.name));
         assert_eq!(
@@ -2528,7 +2522,6 @@ fn ipns_record_accept_vectors_are_frozen_and_verify() {
             "record-accept {}: re-PUT byte-stable",
             v.name
         );
-        // Verify under the name's key extracts the injected fields.
         let name = IpnsName::parse(&v.ipns_name).expect("record-accept name parses");
         let verified = reparsed
             .verify(&name)
@@ -2692,7 +2685,6 @@ fn pointer_accept_vectors_are_frozen_and_open() {
             "pointer-accept {}: sealed drift",
             v.name
         );
-        // And it opens back to the object under the owner's identity key.
         let opened = open_pointer_payload(
             &key,
             v.v,
@@ -2803,7 +2795,6 @@ fn mailbox_accept_vectors_are_frozen_and_open() {
             "mailbox-accept {}: block drift",
             v.name
         );
-        // The recipient opens and the sender identity verifies.
         let item = open_mailbox_payload(&recipient, v.v, &unhex(&v.name, &v.block))
             .unwrap_or_else(|e| panic!("mailbox-accept {}: open: {e}", v.name));
         assert_eq!(item.payload, payload, "mailbox-accept {}: payload", v.name);
@@ -4010,7 +4001,6 @@ fn content_seal_vectors_are_frozen_and_round_trip() {
             "content seal {}: sealed drift",
             v.name
         );
-        // The nonce is prefixed and the recipient recovers the plaintext.
         assert_eq!(
             &sealed[..NONCE_LEN],
             &nonce,
@@ -4111,7 +4101,6 @@ fn content_cid_vectors_are_frozen_and_verify() {
             "content cid {}: v1||codec||blake3||len prefix",
             v.name
         );
-        // Verify accepts the blob against its own CID.
         verify_cid(&cid, &sealed)
             .unwrap_or_else(|e| panic!("content cid {}: verify must accept: {e}", v.name));
     }

--- a/crates/engine/src/content/chunk.rs
+++ b/crates/engine/src/content/chunk.rs
@@ -1,7 +1,5 @@
-//! Fixed-size chunk framing over core's content-seal (blueprint/engine.md
-//! "Content plane": "the engine frames content into fixed-size chunks, seals
-//! each with core's content-seal primitive ... fresh random per-version content
-//! key").
+//! Fixed-size chunk framing over core's content-seal, under a fresh random
+//! per-version content key (blueprint/engine.md "Content plane").
 //!
 //! Framing is the engine's job; the seal and the leaf content-address are
 //! core's ([`cipherbox_core::content`], #691). This module owns only the

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -8,13 +8,6 @@
 //! and the content-address codec are core's ([`cipherbox_core::content`], #691);
 //! this plane composes them and owns the framing/DAG shape and the placement,
 //! quota, and retention judgment (#630).
-//!
-//! - [`chunk`] — fixed-size framing + per-version key + core seal + leaf CID.
-//! - [`dag`] — the version root addressed by its `contentCid`, chunk-aligned.
-//! - [`provider`] — the pin-provider layer and BYO reachability probe.
-//! - [`read`] — verified reads (accelerator + public fallback), fail-closed.
-//! - [`retention`] — pre-flight quota and the explicit prune op.
-//! - [`profile`] — the frozen chunk-size constant.
 
 pub mod chunk;
 pub mod dag;

--- a/crates/engine/src/content/profile.rs
+++ b/crates/engine/src/content/profile.rs
@@ -41,10 +41,8 @@ impl ContentProfile {
     /// reachable from tiny fixtures (blueprint/testing.md "The DX hook").
     pub const CI: Self = Self { chunk_size: 16 };
 
-    /// A custom profile with the given chunk size, or `None` for a zero size.
-    /// The nonzero invariant is enforced here so framing never divides or
-    /// `chunks()` by zero — a zero chunk size is rejected at construction, not
-    /// discovered as a panic during a seal.
+    /// A custom profile with the given chunk size, or `None` for a zero size —
+    /// the construction site that enforces the nonzero invariant.
     pub const fn new(chunk_size: usize) -> Option<Self> {
         if chunk_size == 0 {
             None

--- a/crates/engine/src/content/provider.rs
+++ b/crates/engine/src/content/provider.rs
@@ -1,9 +1,6 @@
-//! The pin-provider layer (blueprint/engine.md "Content plane": "hosted
-//! (default), external (own Kubo/PSA/Pinata endpoint), or dual — the engine
-//! decides where bytes go; every mode's publish flow still traverses
-//! registration. `ByoIpfsConfig` stays sealed in vault settings; provider
-//! connection testing is engine-side over the Http seam (the TEE tester is
-//! gone)").
+//! The pin-provider layer — hosted / external / dual placement and the
+//! engine-side BYO connection test over the `Http` seam (blueprint/engine.md
+//! "Content plane").
 //!
 //! This module owns the placement decision surface and the BYO config type plus
 //! its engine-side reachability probe. Registration and the publish pipeline
@@ -93,11 +90,9 @@ pub enum ProviderError {
 /// over the Http seam. Issues the provider's standard health/auth probe and
 /// treats any 2xx as success.
 ///
-/// The endpoint is member-controlled by design (it is the member's own
-/// provider), but it is still validated to an absolute `http(s)` URL before it
-/// reaches the seam — a `file:`, relative, or hostless target is
-/// [`ProviderError::InvalidEndpoint`], never sent. A transport failure is
-/// [`ProviderError::Unreachable`]; a non-2xx is [`ProviderError::Rejected`].
+/// The member-controlled endpoint passes [`validate_endpoint`] before it reaches
+/// the seam. A transport failure is [`ProviderError::Unreachable`]; a non-2xx is
+/// [`ProviderError::Rejected`].
 pub async fn test_connection(
     config: &ByoIpfsConfig,
     http: &impl Http,

--- a/crates/engine/src/content/retention.rs
+++ b/crates/engine/src/content/retention.rs
@@ -1,7 +1,4 @@
-//! Quota pre-flight and version retention (blueprint/engine.md "Content plane":
-//! "Retention default: keep all versions within quota, with an explicit
-//! user-initiated prune op"; "a pre-flight quota-query check to fail fast before
-//! bytes move is judgment").
+//! Quota pre-flight and version retention (blueprint/engine.md "Content plane").
 //!
 //! Retention is keep-all by default — nothing here evicts a version
 //! automatically; the network is authoritative on quota (enforced at the API

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -9,13 +9,11 @@
 //! facade — hosts render, they never decide.
 //!
 //! The surface shape (constructor over the whole seam set, `start(secret)`,
-//! the [`Command`] enum, the [`Event`] stream) is frozen. This slice wires the
-//! facade onto the sync core: the metadata intent ops (create/delete/rename/
-//! relink) stage through the durable op queue, reads render the gate-passing
-//! base snapshot ⊕ pending-op overlay (blueprint/engine.md "Sync core: State
-//! law"), and every successful stage emits [`Event::SnapshotUpdated`]. The
-//! non-metadata commands (grants, rotation, auth, content seal) stay
-//! [`EngineError::Unimplemented`] until their slices land.
+//! the [`Command`] enum, the [`Event`] stream) is frozen. Metadata intent ops
+//! stage through the durable op queue, reads render the gate-passing base
+//! snapshot ⊕ pending-op overlay (blueprint/engine.md "Sync core: State law"),
+//! and every successful stage emits [`Event::SnapshotUpdated`]. A command whose
+//! slice has not landed returns [`EngineError::Unimplemented`].
 
 use core::cell::{Cell, RefCell};
 use core::fmt;
@@ -837,8 +835,7 @@ pub struct Engine<T: SeamTypes> {
     /// The session's live held-record set, keyed by node id: the resolve path
     /// ([`resolve_and_hold`](crate::net::resolve_and_hold)) inserts each
     /// gate-passing record here, and the cold-start liveness loop keyless
-    /// re-PUTs the map's values on the hourly cadence. Empty until the resolve
-    /// tick driver (next slice) wires it in.
+    /// re-PUTs the map's values on the hourly cadence.
     held_records: Rc<RefCell<HeldRecords>>,
     /// Staleness bookkeeping shared with the resolve-tick loop: it stamps
     /// successes and reports rung changes; [`snapshot`](Self::snapshot)
@@ -917,10 +914,8 @@ impl<T: SeamTypes> Engine<T> {
     /// Derives the cold-start [`SessionIdentity`] from the secret — the
     /// owner-plane identity that needs no network (enc subkey, owner pointer
     /// seed, vault-pointer signer chain), plus the per-scope/per-name signer
-    /// factories the pipeline layers scope material onto. The remaining
-    /// cold-start steps (vault-pointer resolve, floor cold-seed, root
-    /// adoption, first snapshot event) land with the resolve/gate slices,
-    /// which read their key material from the session assembled here.
+    /// factories the pipeline layers scope material onto — then runs the
+    /// cold-start data path off it ([`cold_start_data_path`](Self::cold_start_data_path)).
     ///
     /// The lifecycle contract holds: exactly one successful `start` per
     /// instance, and the secret is zeroized on consumption — derivation is the
@@ -1044,8 +1039,6 @@ impl<T: SeamTypes> Engine<T> {
     /// `pub(crate)`: the in-crate pipeline (resolve, publish, rotation, the
     /// liveness loop) reads its signers here; hosts wrap the facade and never
     /// hold key material.
-    // Read by the pipeline slices that consume the session (resolve #745/#746);
-    // the liveness loop (#750) shares the `Rc` directly.
     #[allow(dead_code)]
     pub(crate) fn session(&self) -> Option<&SessionIdentity> {
         self.session.as_deref()
@@ -1060,18 +1053,12 @@ impl<T: SeamTypes> Engine<T> {
     /// an [`Event::DeadLetter`] and dropped from the durable queue before the
     /// chain runs, so a corrupt entry is not re-emitted on the next boot.
     ///
-    /// Reads every seam from the engine, the login secret from
-    /// [`session`](Self::session), and the pending ops from the durable staging
-    /// store; emits no clock/RNG-derived value, so the whole chain is
-    /// deterministic off the injected seams. The record-plane fetchers enter as
-    /// the two seam traits the resolver slices (#745/#746) implement:
-    /// [`PointerFetch`] for the pointer block and [`Adopter`] for the root record.
+    /// Emits no clock/RNG-derived value, so the whole chain is deterministic off
+    /// the injected seams; the record plane enters through the [`PointerFetch`]
+    /// and [`Adopter`] seam traits.
     ///
     /// `owner_identity` is the auth-provided contact-code-anchored identity that
     /// signs the re-point object — the vault-pointer walk's fail-closed anchor.
-    // Takes `&self`: `start` runs the production `RootAdopter`/`RecordPointerFetch`
-    // through it while they borrow the engine's own gateway/seams — a `&mut self`
-    // receiver would alias those shared borrows.
     pub(crate) async fn cold_start_data_path<Pf, Ad>(
         &self,
         pointer_fetch: &Pf,
@@ -1168,8 +1155,6 @@ impl<T: SeamTypes> Engine<T> {
         let held = self.held_records.clone();
         let alive = self.alive.clone();
         let events = self.events.clone();
-        // The shared client from `start` (see the `api` field): the renewal pass
-        // only fires once the resolve-tick driver populates the held set.
         self.seams.scheduler.spawn(Box::pin(async move {
             run_liveness_loop(&scheduler, RE_PUT_INTERVAL, || async {
                 if !alive.get() {
@@ -1178,8 +1163,7 @@ impl<T: SeamTypes> Engine<T> {
                 let records: Vec<HeldRecord> = held.borrow().values().cloned().collect();
                 keyless_re_put(&transport, &records).await;
                 // Surface every renewal that did not land (LostRace/PublishError)
-                // as an Event — never a silent failure (blueprint/engine.md). The
-                // held set is empty until the resolve-tick driver populates it.
+                // as an Event — never a silent failure (blueprint/engine.md).
                 let renewals =
                     eol_renew_pass(&transport, &api, &floors, &scheduler, &profile, &records).await;
                 emit_renewal_failures(&events, &renewals);
@@ -1246,8 +1230,6 @@ impl<T: SeamTypes> Engine<T> {
                 if !alive.get() {
                     return LivenessControl::Stop;
                 }
-                // Rebuild the owner-root adopter from the Rc'd session + task-owned
-                // seams each pass (the adopter borrows; the task owns the clones).
                 let adopter = RootAdopter::new(
                     &gateway,
                     &http,

--- a/crates/engine/src/gate/adoption.rs
+++ b/crates/engine/src/gate/adoption.rs
@@ -287,12 +287,10 @@ impl PendingAdoption {
     /// then yield the [`Adopted`] result. Call only after the accepted state is
     /// durably persisted.
     ///
-    /// The stage-4/5 floor reads and this advance are not a CAS pair and do not
-    /// need to be: the engine is the single writer (blueprint/engine.md
-    /// "Facade" — one live instance), so no concurrent adopt races this device's
-    /// floors between the read and the advance. Cross-writer contention is
-    /// resolved on the publish/RecordTransport plane (CAS), never on the local
-    /// floor read. `advance_on_unseal` itself orders its two raises fail-safe.
+    /// The stage-4/5 floor reads and this advance are deliberately not a CAS
+    /// pair: the engine is the single writer (blueprint/engine.md "Facade"), and
+    /// cross-writer contention is resolved on the publish plane, never on the
+    /// local floor read.
     pub async fn commit<F: FloorStore>(self, floors: &F) -> Result<Adopted, GateError> {
         floor::advance_on_unseal(
             floors,
@@ -449,13 +447,8 @@ pub async fn adopt_deferred<F: FloorStore>(
         ));
     }
 
-    // Stage 3 — grant-section authentication. Enumerate every seed-bearing
-    // structure **from this record's grant section** and recompute each
-    // `H(ciphertext)` over the actual sealed bytes with `scope`/`epoch` taken
-    // from the authenticated envelope (#687): a signature proves the committed
-    // writer signed *these* bytes at *this* rotation, so a swapped ciphertext or
-    // a cross-epoch replay recomputes a preimage the signature never covered.
-    // Any failure rejects the whole record (#39 D3).
+    // Stage 3 — grant-section authentication under `authenticate_structure`'s
+    // recompute contract (#687). Any failure rejects the whole record (#39 D3).
     let committed = committed_write_pseudonyms(&section.commitment);
     let scope = candidate.envelope.scope;
     let epoch = candidate.envelope.epoch;

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -35,11 +35,8 @@ use crate::seams::{FloorRaise, FloorStore, SeamError, SeamResult};
 /// rolled-back re-point object, a fail-closed trust violation and never mere
 /// staleness (the floor law: revocation boundaries cannot be rolled back).
 ///
-/// The comparison is sound at the vault/root anchor: the root scope's read
-/// epoch is authored only by the owner (no grantee rotation advances the
-/// envelope read epoch past `minReadEpoch` there), so `min_read_epoch` and the
-/// durable read-epoch floor share the owner's authorship, and `write_epoch` is
-/// owner-vouched and never unseal-advanced.
+/// Where the read-epoch comparison is sound — and where it must not run — is
+/// [`AnchorRole`]'s contract.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FloorRegression {
     /// The re-point's `minReadEpoch` is strictly below the durable read-epoch
@@ -111,9 +108,7 @@ impl std::error::Error for ColdSeedError {}
 /// false-positive into a self-inflicted fail-closed **DoS** (a bricked boot) —
 /// never a security hole, since no rollback is accepted and the write-epoch
 /// check stays unconditionally sound. `Shared` therefore never runs the
-/// read-epoch check; only `Root` does (#763). Making the role explicit means no
-/// caller can express "read-epoch check on a shared scope": the check lives
-/// behind the `Root` arm alone.
+/// read-epoch check; only `Root` does (#763).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AnchorRole {
     /// The vault/root anchor: read-epoch check runs (alongside write-epoch).
@@ -307,10 +302,9 @@ pub async fn cold_seed<F: FloorStore>(floors: &F, repoint: &RepointObject) -> Se
 /// The read-epoch check runs under [`AnchorRole::Root`] only; the write-epoch
 /// check is unconditional — see [`AnchorRole`] for why.
 ///
-/// The single-writer engine reads the floors and advances them with no
-/// concurrent adopt in between (blueprint/engine.md "Facade" — one live
-/// instance), so the check-then-advance is not a CAS pair; the monotonic-max
-/// store is the backstop either way.
+/// Check-then-advance is deliberately not a CAS pair: the engine is the single
+/// writer (blueprint/engine.md "Facade"), and the monotonic-max store backstops
+/// it either way.
 pub async fn cold_seed_checked<F: FloorStore>(
     floors: &F,
     repoint: &RepointObject,

--- a/crates/engine/src/grants/accept.rs
+++ b/crates/engine/src/grants/accept.rs
@@ -457,16 +457,13 @@ pub async fn accept_share<F: FloorStore, M: Mailbox, S: ReceivedShareStore>(
     let grant = open_grant_blob(my_enc_secret, &blob.enc, &grant_aad, &blob.ciphertext)
         .map_err(AcceptError::GrantBlobOpen)?;
     let node_seed = kdf::node_seed(grant.read_scope_seed(), &candidate.envelope.id);
-    // The derived read key is secret; this fn is its terminal owner, so wipe it
-    // on drop (the gate borrows it and never zeroizes a caller-owned buffer).
+    // The derived read key is secret and this fn is its terminal owner.
     let read_key = Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes());
 
-    // The adoption gate: commitment verified against the contact-anchored owner,
-    // grant-section authenticated, seeds cross-checked, read-body unsealed.
     let reader = ReaderContext {
         owner_identity: &owner_identity,
         scope_id: candidate.envelope.scope,
-        read_key: &read_key, // Zeroizing<[u8; 32]> derefs to the borrowed array
+        read_key: &read_key,
         parent_node_seed: None,
         seed_blob: Some(SeedBlob::Grantee {
             enc_secret: my_enc_secret,
@@ -475,10 +472,8 @@ pub async fn accept_share<F: FloorStore, M: Mailbox, S: ReceivedShareStore>(
             aad: grant_aad,
         }),
     };
-    // Gate the record but DEFER the floor-law advance: the durable sequence
-    // floor must not move ahead of the bookmark it accepts. If the persist below
-    // fails the floor stays put, so redelivery re-adopts cleanly instead of being
-    // stranded below an already-advanced floor (a permanently-lost share).
+    // Gate the record but DEFER the floor-law advance so the durable sequence
+    // floor never moves ahead of the bookmark it accepts (see `PendingAdoption`).
     // The share-accept flow does not hold the scope for liveness here, so the
     // write-grantee seed the gate surfaces is dropped (the `_`).
     let pending = match adopt_deferred(floors, &reader, candidate).await {
@@ -513,8 +508,6 @@ pub async fn accept_share<F: FloorStore, M: Mailbox, S: ReceivedShareStore>(
         }
     };
 
-    // Reconcile the self-healing bookmark: append if new, heal in place if the
-    // committed permission or pointer read key drifted, no-op if byte-identical.
     let reconciled = received.reconcile(ReceivedShare {
         scope_root_name: pointer.scope_root_name.clone(),
         sharer_identity_pk: pointer.sharer_identity_pk,
@@ -524,9 +517,8 @@ pub async fn accept_share<F: FloorStore, M: Mailbox, S: ReceivedShareStore>(
     });
     let newly_added = matches!(reconciled, Reconciled::Added);
 
-    // Persist durably BEFORE the floor advance and the ack. A failure rolls the
-    // in-memory bookmark back and returns un-acked, so the item redelivers rather
-    // than being lost. A true no-op re-accept needs no durable write.
+    // Persist durably BEFORE the floor advance and the ack; a failure rolls the
+    // in-memory bookmark back and returns un-acked, so the item redelivers.
     if reconciled.is_durable_change() {
         if let Err(e) = store.persist(received).await {
             received.revert(&pointer.scope_root_name, reconciled);

--- a/crates/engine/src/grants/child_index.rs
+++ b/crates/engine/src/grants/child_index.rs
@@ -24,10 +24,8 @@
 //! # Deterministic convergence
 //!
 //! Entries are ordered and deduped by `scope_id` byte `Ord` so replayed /
-//! multi-writer runs converge to identical bytes. A `scope_id` names exactly one
-//! child, so **first-seen** dedup is the deliberate replace-wins operation policy
-//! (ops prepend the authoritative entry), not a content tie-break — see
-//! [`canonicalize`].
+//! multi-writer runs converge to identical bytes; the first-seen dedup rule and
+//! why it is a replace-wins operation policy live on [`canonicalize`].
 
 use cipherbox_core::seal::ChildScopeRef;
 

--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -5,10 +5,9 @@
 //! fixes: converge the subtree, mint the grantee scope at read epoch 1, publish
 //! grantee-first, re-key the reparented descendants under the fresh derivation,
 //! then post the sealed share pointer. Convergence is the load-bearing
-//! correctness rule — a grant over a
-//! subtree that cannot be proven epoch-converged is refused **fail-closed**, so a
-//! new grantee can never regress through an ancestor scope's history (CONTEXT.md
-//! "Epoch-converged"). Each step carries its rationale inline.
+//! correctness rule — a grant over a subtree that cannot be proven
+//! epoch-converged is refused **fail-closed**, so a new grantee can never regress
+//! through an ancestor scope's history (CONTEXT.md "Epoch-converged").
 //!
 //! # Simulation boundary
 //!
@@ -150,14 +149,10 @@ pub struct CreateGrantOutcome {
 /// A read-grant creation failure.
 ///
 /// Failures **through the grantee scope-root publish (step 5)** are truly
-/// fail-closed — nothing is minted or shared: `Converge`,
-/// `SubtreeNotConverged`, `UnusableRecipientKey`, `CommitmentEncode`,
-/// `Entropy`, `Mint`, and `Publish` (register-first: a failed grantee publish
-/// pushes nothing to the network). Failures **after** that publish are NOT
-/// atomic: the grantee root — and, for `Mailbox`, the reparented parent — is
-/// already committed to the network, so a stale orphan can outlive the error.
-/// Orphan reconciliation belongs to the deferred resume machinery (#745/#746);
-/// each post-publish variant documents what it leaves behind.
+/// fail-closed — nothing is minted or shared. Failures **after** that publish
+/// are NOT atomic: the grantee root is already committed to the network, so a
+/// stale orphan can outlive the error. Each post-publish variant below documents
+/// what it leaves behind; orphan reconciliation is deferred to #745/#746.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CreateGrantError {
     /// The pre-grant convergence sweep aborted (enumeration/floor/publish/reseal).
@@ -257,11 +252,8 @@ impl std::error::Error for CreateGrantError {}
 /// Converge → mint (epoch 1) → publish (grantee first) → re-key the reparented
 /// descendants under the fresh grantee derivation → parent index update → post
 /// the mailbox share pointer. Fail-closed **through the grantee publish** (step
-/// 5): any earlier error mints and shares nothing. Past
-/// that point the sequence is not atomic — see [`CreateGrantError`] for what
-/// each post-publish variant leaves committed (orphan cleanup is deferred to
-/// #745/#746). See the module docs for the full sequence and the deferred
-/// write-grant / invite slices.
+/// 5); past that point the sequence is not atomic — see [`CreateGrantError`] for
+/// what each post-publish variant leaves committed.
 #[allow(clippy::too_many_arguments)]
 pub async fn create_read_grant<E, F, R, P, M>(
     entropy: &mut E,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -3,14 +3,13 @@
 //!
 //! Normative design: blueprint/engine.md
 //!
-//! This slice freezes the architecture surface: the nine host seam traits
-//! and the whole-set constructor bundle ([`seams`]), injected entropy
-//! ([`entropy`]), the environment-scoped sync timing profile ([`profile`]),
-//! and the facade skeleton ([`facade`]) — one async command-and-event
-//! surface with start of secret. The [`api`] module lands the single
-//! hand-written API client and token lifecycle. The rest of the pipeline
-//! (gate, sync, rotation, grants, pointer, mailbox, net, content) lands in
-//! later slices behind this exact surface.
+//! The architecture surface: the nine host seam traits and their whole-set
+//! constructor bundle ([`seams`]), injected entropy ([`entropy`]), the
+//! environment-scoped sync timing profile ([`profile`]) and storage policy
+//! ([`storage_policy`]), the hand-written API client and token lifecycle
+//! ([`api`]), and the facade ([`facade`]) — one async command-and-event
+//! surface with start of secret. The pipeline modules ([`gate`], [`sync`],
+//! [`rotation`], [`grants`], [`mailbox`], [`net`], [`content`]) sit behind it.
 //!
 //! The `test-kit` feature adds [`testkit`]: in-memory fakes for every seam,
 //! a virtual-clock scheduler, seeded entropy, and the reusable per-seam

--- a/crates/engine/src/net/eol.rs
+++ b/crates/engine/src/net/eol.rs
@@ -8,10 +8,8 @@
 //! injected [`Scheduler`](crate::seams::Scheduler) clock here and compares a
 //! resolved record's EOL against the same clock to drive the two liveness
 //! decisions: **renewal** (below the threshold, republish at seq+1) and
-//! **expiry** (a >EOL lapse, revive from the recovery endpoint).
-//!
-//! Determinism: this module reads no wall clock — every function takes the
-//! instant as a [`UnixMillis`] argument sourced from the scheduler seam.
+//! **expiry** (a >EOL lapse, revive from the recovery endpoint). Determinism
+//! law: every function here takes the instant as a [`UnixMillis`] argument.
 
 use core::time::Duration;
 

--- a/crates/engine/src/net/fanout.rs
+++ b/crates/engine/src/net/fanout.rs
@@ -95,8 +95,6 @@ pub async fn fanout_get_verify<T: RecordTransport>(
     let key = name.as_str();
     let mut best: Option<(u64, Vec<u8>)> = None;
     for endpoint in transport.endpoints() {
-        // A per-endpoint transport error is availability staleness, not a trust
-        // decision: skip it and keep the freshest copy the other endpoints hold.
         let Ok(Some(bytes)) = transport.get_record(&endpoint, key).await else {
             continue;
         };

--- a/crates/engine/src/net/liveness.rs
+++ b/crates/engine/src/net/liveness.rs
@@ -112,8 +112,7 @@ pub async fn keyless_re_put<T: RecordTransport>(
 ) -> Vec<RePutResult> {
     let mut results = Vec::with_capacity(held.len());
     for record in held {
-        // Byte-stable keyless re-PUT (blueprint/core.md): a record that does not
-        // round-trip marshal is not a record we can keep alive — skip it.
+        // Byte-stable keyless marshal (blueprint/core.md).
         let bytes = match IpnsRecord::unmarshal(&record.record_bytes) {
             Ok(parsed) => parsed.marshal(),
             Err(_) => {
@@ -146,9 +145,8 @@ pub enum LivenessControl {
 /// Drive a liveness pass on a fixed cadence off the injected [`Scheduler`]
 /// clock: sleep `interval`, run `pass`, repeat until it returns
 /// [`LivenessControl::Stop`]. This is the ~hourly loop the facade spawns at
-/// [`RE_PUT_INTERVAL`] over [`keyless_re_put`] (and, once cold-start derives the
-/// per-name signers, the sub-EOL [`eol_republish`] renewal composes into the
-/// same `pass`). Determinism law: the only time source is `scheduler.sleep`.
+/// [`RE_PUT_INTERVAL`] over [`keyless_re_put`]. Determinism law: the only time
+/// source is `scheduler.sleep`.
 pub async fn run_liveness_loop<Sch, F, Fut>(scheduler: &Sch, interval: Duration, mut pass: F)
 where
     Sch: Scheduler,
@@ -183,7 +181,6 @@ where
     F: FloorStore,
     Sch: Scheduler + Clone + 'static,
 {
-    // Inspect the name's current record EOL against the injected clock.
     let Some((_sequence, bytes)) = fanout_get_verify(transport, request.name).await else {
         return Ok(None);
     };

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -7,25 +7,10 @@
 //! endpoint's copy is freshest, register-first ordering, CAS sequencing,
 //! confirm-by-re-resolve, when to re-PUT or renew or revive — lives here.
 //!
-//! - [`resolve`] — cache-first resolve: last-known-good renders immediately, a
-//!   fan-out GET + core verify picks the freshest record, and the adoption gate
-//!   runs on **every** resolve (through the [`resolve::Adopter`] seam); only a
-//!   gate-passing record touches the snapshot.
-//! - [`publish`] — register-first, fail-closed publish: core-signed with the
-//!   exact CAS sequence, parallel PUT with any-ack success + background retry,
-//!   and confirm-by-re-resolve with lost-race detection.
-//! - [`liveness`] — the ~hourly keyless re-PUT job and the sub-EOL seq+1
-//!   renewal.
-//! - [`revival`] — re-mint after a >EOL lapse via the recovery endpoint.
-//! - [`retire`] — registry-row retirement (root linger stubbed on the open-edge
-//!   migration-window constant).
-//! - [`eol`] — the 90-day EOL policy and RFC3339 codec, off the injected clock.
-//!
-//! What this slice deliberately does not land: rebase (a lost race is reported,
-//! not rebased) and the pointer planes (the re-point channels). The seams for
-//! both are left where the blueprint expects them — [`resolve::Adopter`] fronts
-//! the content/pointer/key assembly, and a lost race surfaces as
-//! [`publish::PublishOutcome::LostRace`] for the rebase slice.
+//! The adoption gate runs on **every** resolve through the [`resolve::Adopter`]
+//! seam; only a gate-passing record touches the snapshot. A lost CAS race is
+//! reported, not rebased — it surfaces as
+//! [`publish::PublishOutcome::LostRace`] for [`crate::sync::rebase`].
 
 mod adopter;
 mod child;

--- a/crates/engine/src/net/pointer_fetch.rs
+++ b/crates/engine/src/net/pointer_fetch.rs
@@ -35,10 +35,9 @@ impl<T: RecordTransport> PointerFetch for RecordPointerFetch<'_, T> {
         let Some((_sequence, record_bytes)) = fanout_get_verify(self.transport, name).await else {
             return Ok(None);
         };
-        // Fan-out returns the marshaled record (already Ed25519-from-name
-        // verified); re-extract the authenticated value — the inlined re-point
-        // block. The same bytes just verified, so a failure here is an internal
-        // inconsistency, surfaced as a seam error, never a trust reclassification.
+        // Re-extract the authenticated value from bytes fan-out already verified,
+        // so a failure here is an internal inconsistency (a seam error), never a
+        // trust reclassification.
         let value = IpnsRecord::unmarshal(&record_bytes)
             .and_then(|record| record.verify(name))
             .map_err(|e| SeamError::new(format!("verified record re-extract failed: {e}")))?

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -9,11 +9,9 @@
 //! record touches the snapshot; a gate failure is a fail-closed trust violation
 //! that pins last-known-good and never renders the rejected record.
 //!
-//! The gate itself is a composition over content-plane and reader state that
-//! lands with the content/pointer/grants and key-lifecycle slices, so this slice
-//! reaches it through the [`Adopter`] seam. The pipeline's contract is fixed
-//! now: **every** fetched record is routed through [`Adopter::adopt`] — there is
-//! no ungated path to the snapshot.
+//! The gate itself is a composition over content-plane and reader state, reached
+//! through the [`Adopter`] seam. **Every** fetched record is routed through
+//! [`Adopter::adopt`] — there is no ungated path to the snapshot.
 
 use core::cell::RefCell;
 
@@ -32,9 +30,8 @@ use crate::sync::project::project_root;
 
 /// Runs the adoption gate over a fetched record. The concrete implementation
 /// assembles the content-plane candidate and the reader's private context and
-/// calls [`crate::gate::adopt`]; it lands with the content/pointer/grants and
-/// key-lifecycle slices. The resolve pipeline requires only this: every record
-/// it fetches is adopted through here before it can touch the snapshot
+/// calls [`crate::gate::adopt`]. The resolve pipeline requires only this: every
+/// record it fetches is adopted through here before it can touch the snapshot
 /// (blueprint/engine.md: "only gate-passing records touch the snapshot").
 pub trait Adopter {
     /// Assemble and gate the record fetched under `name`. `Ok` carries the

--- a/crates/engine/src/net/retire.rs
+++ b/crates/engine/src/net/retire.rs
@@ -25,12 +25,11 @@ where
 }
 
 /// Whether the old scope-root name may be retired yet. **Stubbed to `false`**:
-/// the migration-window constant that bounds how long the old root lingers
-/// serving the tombstone is an open edge (blueprint/engine.md "Open edges:
-/// Migration-window closure" — #38 fixed the channel architecture but not the
-/// window, proposed as a sync-timing-profile constant to settle with the
-/// testing-strategy blueprint). Until it lands the root never auto-retires, so
-/// a revokee or a lagging reader can always chase the tombstone to the new root.
+/// the migration window that bounds how long the old root lingers serving the
+/// tombstone is an open edge (blueprint/engine.md "Open edges: Migration-window
+/// closure"; #38 fixed the channel architecture but not the window). Until it
+/// lands the root never auto-retires, so a revokee or a lagging reader can
+/// always chase the tombstone to the new root.
 pub fn root_retire_ready() -> bool {
     false
 }

--- a/crates/engine/src/rotation/cascade.rs
+++ b/crates/engine/src/rotation/cascade.rs
@@ -28,8 +28,7 @@
 //! derivation, so the walk runs **top-down**, threading each parent's
 //! freshly-minted seed so the child's ascent link re-seals under the parent's
 //! **new** seed — else the link still opens under the stale seed, leaving a
-//! revoked ancestor a path in. [`CascadeTarget`] carries **no** `parent_node_seed`:
-//! it is always threaded, never taken from the descendant's own stale record.
+//! revoked ancestor a path in.
 //!
 //! # Fail-closed completeness
 //!
@@ -80,19 +79,14 @@ use crate::seams::{BoxedTask, FloorStore, Scheduler, SeamError};
 /// published record — everything [`reseal_scope_root`] needs **except** the
 /// parent node seed and any self-identifying `scope_id`/`ipns_name`.
 ///
-/// Those omissions are deliberate and load-bearing. The cascade re-seals each
-/// descendant's ascent link under its **parent's freshly-minted** derivation
-/// (`node_seed(parent_fresh_seed, child_scope_id)`), threaded top-down — never
-/// under the descendant's own stale published parent seed; carrying a
-/// `parent_node_seed` here would invite re-sealing under the wrong (stale)
-/// derivation (contrast [`SweepTarget`](super::sweep::SweepTarget), which *does*
-/// carry it because the sweep reuses the published derivation). A resolved
-/// record carries no self-identifying `scope_id` or `ipns_name` either: the
-/// re-seal identity, CAS-publish destination, parent-seed derivation, and
-/// floor-raise all run under the **enumerated** [`ChildScopeRef`]
-/// (`child.scope_id` / `child.ipns_name`) alone — there is no second copy for a
-/// network hint to diverge from, so the #756 divergence class is
-/// unrepresentable.
+/// Both omissions are load-bearing. No `parent_node_seed`: the ascent link
+/// re-seals under the parent's **freshly-minted** derivation, threaded top-down,
+/// never the descendant's own stale published one (contrast
+/// [`SweepTarget`](super::sweep::SweepTarget), which *does* carry it because the
+/// sweep reuses the published derivation). No self-identifying `scope_id` /
+/// `ipns_name`: re-seal, publish, parent-seed derivation, and floor-raise all run
+/// under the **enumerated** [`ChildScopeRef`] alone, so there is no second copy
+/// for a network hint to diverge from (#756).
 ///
 /// Owns its secrets so the cascade is their terminal owner: the seed fields are
 /// [`Zeroizing`] and the pseudonym signer zeroizes on drop. Seeds are handed to
@@ -147,14 +141,10 @@ pub trait CascadeResealResolver {
     /// # Binding contract (obligation on the real resolver, #745/#746)
     ///
     /// The resolver MUST gate `scope`'s record under the enumerated
-    /// `scope.scope_id` and `scope.ipns_name` — the adoption gate binds
-    /// `ipns_name -> record` via the Ed25519 key derived from the name, and the
-    /// gated record's `commitment.ipns_name` MUST equal `scope.ipns_name`. It
-    /// returns **no** self-identifying `scope_id` or `ipns_name`: the engine
-    /// re-seals, derives the parent node seed, CAS-publishes, and floor-raises
-    /// under the enumerated [`ChildScopeRef`] alone (see [`CascadeTarget`], which
-    /// carries neither, making the #756 divergence unrepresentable). In this
-    /// slice the resolver is faked.
+    /// `scope.scope_id` and `scope.ipns_name`, and the gated record's
+    /// `commitment.ipns_name` MUST equal `scope.ipns_name`. It returns **no**
+    /// self-identifying `scope_id` or `ipns_name` — see [`CascadeTarget`] for why
+    /// (#756).
     async fn resolve(&self, scope: &ChildScopeRef) -> Result<CascadeTarget, ResolveFailure>;
 }
 
@@ -460,14 +450,11 @@ where
         rekeyed: vec![root_rekeyed],
     };
 
-    // 2) Top-down threaded walk over the descendant tree. Each frontier entry
-    //    carries its parent's freshly-minted override seed so the child's ascent
-    //    link re-seals under the parent's NEW derivation. Mirrors
-    //    `enumerate_eager_set`: canonicalized frontiers, a `scope_id`-keyed visited
-    //    set that terminates diamonds and cycles, and a `scope_id -> ipns_name`
-    //    label map that aborts a same-`scope_id`/different-`ipns_name` conflict
-    //    (C2, #746) rather than picking a coin-flip first-seen name. The re-key
-    //    needs these ordered edges, which the flat `EagerSet` does not carry.
+    // 2) Top-down threaded walk over the descendant tree, each frontier entry
+    //    carrying its parent's freshly-minted seed (module docs). Re-implements
+    //    `enumerate_eager_set`'s canonicalized-frontier walk — including its C2
+    //    label-conflict abort (#746) — because the re-key needs the parent edges
+    //    the flat `EagerSet` does not carry.
     let mut visited: BTreeSet<[u8; 16]> = BTreeSet::new();
     visited.insert(root_scope_id);
 
@@ -530,10 +517,8 @@ where
             let plan = RotateScopePlan {
                 identity: ScopeRootIdentity {
                     v: target.v,
-                    // The enumerated ChildScopeRef is the sole identity authority:
-                    // re-seal, publish, and floor-raise all run under
-                    // `child.scope_id`/`child.ipns_name`, never a resolver-returned
-                    // copy (#756; see CascadeTarget).
+                    // The enumerated ChildScopeRef is the sole identity authority
+                    // (#756; see CascadeTarget).
                     scope_id: child.scope_id,
                     ipns_name: &child.ipns_name,
                     owner_enc_pub: &target.owner_enc_pub,

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -202,22 +202,18 @@ pub fn reseal_scope_root<E: Entropy>(
     committed: &CommittedSet<'_>,
     carried_history_links: &[SignedSealed],
 ) -> Result<GrantSection, ResealError> {
-    // Fail-closed BEFORE any seal: the rotator's pseudonym signer MUST be the
-    // owner-committed pseudonym key, else every detach-signature is minted under a
-    // key the commitment does not name — an unopenable root the gate always
-    // rejects (encode-side mirror of the gate's signer check). The pseudonym pubkey
-    // is public, so a plain byte compare is correct.
+    // Fail-closed BEFORE any seal (see `ResealError::SignerNotCommitted`). The
+    // pseudonym pubkey is public, so a plain byte compare is correct.
     if identity.pseudonym_signer.verifying_key().to_bytes()
         != committed.commitment.owner_pseudonym_pk
     {
         return Err(ResealError::SignerNotCommitted);
     }
 
-    // Fail-closed BEFORE any seal: the re-wrap set must equal the owner-signed
-    // committed set. This is the revocation-completeness guarantee and the
-    // encode-side mirror of the gate's `enforce_committed_ledger` resolve check.
-    // Reseal trusts each entry's `recipient_enc_pk` verbatim from the committed
-    // ledger; the tag<->enc_pk binding is enforced at resolve time (#745).
+    // Fail-closed BEFORE any seal (see `ResealError::LedgerDivergesFromCommitment`
+    // and the module's revocation-completeness rule). Reseal trusts each entry's
+    // `recipient_enc_pk` verbatim from the committed ledger; the tag<->enc_pk
+    // binding is enforced at resolve time (#745).
     enforce_committed_ledger(committed.commitment, committed.grant_ledger)
         .map_err(|_| ResealError::LedgerDivergesFromCommitment)?;
 
@@ -502,7 +498,7 @@ mod tests {
     }
 
     // `owner_enc_pub` needs a `&X25519Public`; hold it in a local so the borrow
-    // outlives the call. A tiny builder keeps every test terse.
+    // outlives the call.
     fn identity<'a>(
         fx: &'a Fixture,
         owner_pub: &'a X25519Public,

--- a/crates/engine/src/rotation/rotate.rs
+++ b/crates/engine/src/rotation/rotate.rs
@@ -30,10 +30,8 @@
 //!   best-effort and idempotent, so losing it to a crash costs only a delayed
 //!   lazy wave the next ordinary write or scheduled sweep advances.
 //!
-//! The eager-set descendant scope roots (#744's enumeration) are re-sealed
-//! through this same [`reseal_scope_root`] helper by the cascade once the
-//! resolver/tree wiring lands (#745/#746); this primitive lands the root cut and
-//! its crash-safe effect ordering.
+//! This primitive is the root cut alone; the descendant re-key runs through the
+//! same [`reseal_scope_root`] helper in [`cascade`](super::cascade).
 
 use zeroize::Zeroizing;
 

--- a/crates/engine/src/rotation/rotate_write.rs
+++ b/crates/engine/src/rotation/rotate_write.rs
@@ -13,36 +13,30 @@
 //! fresh write scope seed moves every node to a fresh name under a fresh signing
 //! key. The read plane is untouched — override seeds, read keys, and `minReadEpoch`
 //! carry verbatim, and no rotation path re-encrypts content bytes (#26 D6).
-//! Write-grantees derive the new names locally; read-only survivors follow the
-//! owner-signed re-point object.
 //!
 //! # Ordering is the safety property (#34 D4)
 //!
-//! Republish descendants first at their new names, the root last, then flip the
-//! stable scope pointer. A new name is **registered before** its predecessor is
-//! retired (register-first, never orphan a live name — the API's pin/name-registry
-//! quota discipline); interior old names batch-retire only **after** the root
-//! re-point, and the old root name lingers past the migration window. Old names
-//! stay live until the flip and the pointer flips last, so at every instant a
-//! resolver reaches every node by at least one live name.
+//! A new name is **registered before** its predecessor is retired, old names stay
+//! live until the pointer flips, and the pointer flips last — so at every instant
+//! a resolver reaches every node by at least one live name. Interior old names
+//! batch-retire only **after** the root re-point; the old root name lingers past
+//! the migration window.
 //!
 //! # Three-channel re-point (#38 D3)
 //!
-//! The owner-identity-signed re-point object `{scopeId, currentRootName,
-//! writeEpoch, minReadEpoch, prevRootName}` publishes to the scope pointer record
+//! The owner-identity-signed re-point object publishes to the scope pointer record
 //! (canonical), the mailbox, and the old root name's tombstone (feeding the
 //! depth-guarded `movedTo` chase). `writeEpoch` advances here; `minReadEpoch` is
-//! carried unchanged, so each plane's clock is authored by its owning authority
+//! carried unchanged, so each plane's clock stays authored by its owning authority
 //! (#38 D1).
 //!
 //! # Crash recovery from published records only (#26 D8)
 //!
 //! No cross-crash state: a resumed wave re-derives each node's deterministic new
 //! name and skips already-republished nodes via
-//! [`WriteWavePublisher::is_republished`]; register/republish/retire/re-point are
-//! idempotent, so it converges to the same terminal state. The fresh write scope
-//! seed is recovered from the published root (the write-plane history link) — the
-//! deferred #745/#746 resolver wiring, faked here and threaded via
+//! [`WriteWavePublisher::is_republished`]; every effect is idempotent, so it
+//! converges to the same terminal state. The fresh write scope seed is recovered
+//! from the published root — deferred #745/#746 wiring, faked here via
 //! [`RotateScopeWritePlan::resume_write_scope_seed`]. Accepted limitation: a crash
 //! after the pointer flip but before interior retirement orphans the prior run's
 //! interior old names — the fail-safe direction (leaking a registration beats
@@ -51,15 +45,12 @@
 //! # Owner-only, fail-closed, deterministic
 //!
 //! The caller must present the owner identity signer that authored the current
-//! grant-set commitment, verified up front ([`WriteRotateError::NotOwner`]), and
-//! that commitment must name this scope's current root
-//! ([`WriteRotateError::CommitmentScopeMismatch`]). A
-//! non-advancing `writeEpoch` or an identity re-point is rejected release-active
-//! ([`build_repoint_object`]), never a `debug_assert!` — the encode-side mirror of
-//! the floor law's monotonic write-epoch reject (AGENTS.md rule 8). Entropy enters
-//! only through the [`Entropy`] seam (fresh seed + re-point nonce); the impure edges
-//! are the injected [`WriteSubtreeResolver`] and [`WriteWavePublisher`] (network
-//! wiring is #745/#746, faked in this slice).
+//! grant-set commitment, and that commitment must name this scope's current root
+//! ([`WriteRotateError::NotOwner`], [`WriteRotateError::CommitmentScopeMismatch`]).
+//! [`build_repoint_object`]'s two encode-side invariants are release-active, never
+//! a `debug_assert!` (AGENTS.md rule 8). Entropy enters only through the
+//! [`Entropy`] seam; the impure edges are the injected [`WriteSubtreeResolver`] and
+//! [`WriteWavePublisher`] (network wiring is #745/#746, faked in this slice).
 
 use std::collections::{BTreeSet, VecDeque};
 
@@ -381,12 +372,11 @@ pub fn derive_write_name(write_scope_seed: &[u8; SECRET_LEN], node_id: &[u8; 16]
     IpnsName::from_public_key(&kdf::ipns_keypair(write_seed.as_bytes()).verifying_key())
 }
 
-/// Assemble the re-point object, enforcing the two encode-side invariants
-/// release-active (never a `debug_assert!`): `new_write_epoch` MUST advance past
-/// `prev_write_epoch` (the floor law's monotonic write-epoch reject, mirrored on
-/// the encode side), and `new_root` MUST differ from `prev_root` (an identity
-/// re-point is not progress). Read plane is untouched, so `min_read_epoch` is
-/// carried verbatim.
+/// Assemble the re-point object, enforcing release-active (never a
+/// `debug_assert!`, AGENTS.md rule 8) that `new_write_epoch` advances past
+/// `prev_write_epoch` ([`WriteRotateError::WriteEpochNotAdvancing`]) and that
+/// `new_root` differs from `prev_root` ([`WriteRotateError::IdentityRepoint`]).
+/// The read plane is untouched, so `min_read_epoch` is carried verbatim.
 pub fn build_repoint_object(
     scope_id: [u8; 16],
     new_root: IpnsName,
@@ -431,10 +421,9 @@ where
 {
     let scope_id = plan.scope_id;
 
-    // 1) Owner-only, fail-closed BEFORE anything is minted or published: the
-    //    presented identity signer MUST be the one that authored the current
-    //    commitment. The current commitment is owner-authentic (it passed the gate
-    //    to resolve), so binding the signer to it anchors the rotation to the owner
+    // 1) Owner-only, fail-closed BEFORE anything is minted or published. The
+    //    current commitment is owner-authentic (it passed the gate to resolve), so
+    //    binding the presented signer to it anchors the rotation to the owner
     //    identity — the same gate the read-revoke trigger enforces.
     let current_sig =
         EcdsaSignature::from_compact(plan.commitment_sig).ok_or(WriteRotateError::NotOwner)?;
@@ -508,8 +497,7 @@ where
     .await?;
 
     // 7) Three-channel re-point: seal the owner-signed re-point object and publish
-    //    it to the scope pointer (canonical), the mailbox, and the old-root
-    //    tombstone (accelerators). Built through the release-active encode guards.
+    //    it in `REPOINT_CHANNELS` order.
     let repoint = build_repoint_object(
         scope_id,
         new_root_name.clone(),
@@ -540,8 +528,7 @@ where
     }
 
     // 8) Batch-retire the interior old names — only now, after the re-point flipped
-    //    the pointer. Register-first already enrolled every successor, so no name is
-    //    ever orphaned. The old root name is absent (it lingers).
+    //    the pointer. The old root name is absent (it lingers).
     if !interior_old_names.is_empty() {
         publisher
             .retire(&interior_old_names)

--- a/crates/engine/src/rotation/sweep.rs
+++ b/crates/engine/src/rotation/sweep.rs
@@ -11,12 +11,10 @@
 //! **existing** override seed, `prev = None`, minting no new seed, epoch, or
 //! history link. Content bytes are never re-encrypted (#26 D6).
 //!
-//! It deliberately does **not** mint fresh descendant seeds — that fresh-seed
-//! eager-set republish, the part that defeats a revokee's cached descendant
-//! seeds, is the [`cascade`](super::cascade)'s job (blueprint/engine.md
-//! "rotateScope", L243-252). The sweep completes only epoch-lag convergence and
-//! the direct-child-scope index self-heal, so re-sealing a descendant with its
-//! existing seed does not on its own complete a read revoke.
+//! It deliberately mints **no** fresh descendant seeds, so it does not on its own
+//! complete a read revoke: that fresh-seed republish is the
+//! [`cascade`](super::cascade)'s job. The sweep completes only epoch-lag
+//! convergence and the direct-child-scope index self-heal.
 //!
 //! # Completeness is fail-closed
 //!
@@ -127,25 +125,17 @@ pub trait SweepResolver {
     /// Resolve `scope`'s current re-seal material, or a fail-closed
     /// [`ResolveFailure`] if its record cannot be authoritatively obtained.
     ///
-    /// One resolve returns the whole [`SweepTarget`] — the enumeration/lag
-    /// fields (`ipns_name`, `current_read_epoch`, `direct_child_scope_index`)
-    /// and the heavy re-seal material (seeds, signer, committed set). The real
-    /// resolver (#745/#746) fetches and gates a scope root's record once, so
-    /// unsealing the owner blob to hand back its seeds is incremental; splitting
-    /// this into a light enumeration edge plus a heavy re-seal edge fetched only
-    /// for lagging nodes is a designed-for optimization for that slice, not a
-    /// correctness requirement here.
+    /// One resolve returns the whole [`SweepTarget`] — enumeration/lag fields
+    /// *and* the heavy re-seal material. Splitting it into a light enumeration
+    /// edge plus a heavy re-seal edge fetched only for lagging nodes is a
+    /// designed-for optimization for #745/#746, not a correctness requirement.
     ///
     /// # Binding contract (obligation on the real resolver, #745/#746)
     ///
-    /// The same edge discipline [`ChildIndexResolver`] carries applies. The
-    /// resolver MUST gate `scope`'s record under the enumerated `scope.scope_id`
-    /// and `scope.ipns_name` — the adoption gate binds `ipns_name -> record` via
-    /// the Ed25519 key derived from the name, and the gated record's
-    /// `commitment.ipns_name` MUST equal `scope.ipns_name`. It returns **no**
-    /// self-identifying `scope_id` or `ipns_name`: the sweep re-seals and
-    /// CAS-publishes under the enumerated [`ChildScopeRef`] alone (see
-    /// [`SweepTarget`]).
+    /// The same edge discipline [`ChildIndexResolver`] carries applies: gate
+    /// `scope`'s record under the enumerated `scope.scope_id`/`scope.ipns_name`,
+    /// with `commitment.ipns_name` equal to `scope.ipns_name`, and return **no**
+    /// self-identifying ids (see [`SweepTarget`]).
     async fn resolve(&self, scope: &ChildScopeRef) -> Result<SweepTarget, ResolveFailure>;
 }
 
@@ -344,10 +334,7 @@ where
         // deduplicated form; flag the node when the stored index needed repair
         // (#38 D6 "repaired and flagged"). The heal rides the re-seal, so it
         // reaches only nodes being re-sealed this pass — a converged node's index
-        // heals on its next ordinary write ("ordinary writes advance it for
-        // free"). Detecting a child *missing from a different parent's* index is
-        // the resolver/tree wiring's job (#745/#746);
-        // this slice heals each re-sealed node's own index.
+        // heals on its next ordinary write ("ordinary writes advance it for free").
         let canonical_index = canonicalize(&target.direct_child_scope_index);
         // Flagged only after the canonical index durably publishes below — a
         // repair that loses the CAS never landed, so it must not be reported
@@ -449,9 +436,8 @@ where
 /// Scheduling is engineering judgment (blueprint/engine.md L275-278): the cadence
 /// and attempt cap are the host's, injected here; time enters only through the
 /// scheduler seam so the harness runs multi-tick timelines in virtual time.
-// Each seam is a distinct injected dependency (the determinism law keeps entropy,
-// time, and the two network edges separate); bundling them into an ad-hoc struct
-// purely to shrink the arg count would be abstraction for its own sake.
+// The determinism law keeps entropy, time, and the two network edges as separate
+// injected seams.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_sweep<E, F, S, R, P>(
     entropy: &mut E,

--- a/crates/engine/src/rotation/trigger.rs
+++ b/crates/engine/src/rotation/trigger.rs
@@ -11,14 +11,9 @@
 //! | Manual       | none                 | per-scope, same primitive                  |
 //!
 //! On an owner read-revocation the rotation is the fresh-seed **eager cascade**
-//! ([`cascade_rotate_scope`](super::cascade::cascade_rotate_scope)): the rotated
-//! root **and every transitively-reachable descendant scope root** are re-keyed
-//! with a fresh override seed (blueprint/engine.md "rotateScope", L243-252).
-//! **That cascade — not the sweep — completes a read revoke**: a revokee who
-//! cached a descendant's override seed can open it at any epoch, so only a fresh
-//! seed per descendant locks them out; a floor-raise + sweep ([`super::sweep`])
-//! would merely walk the cached seed forward. The cascade is proven in simulation
-//! against faked seams; the production per-descendant resolver wiring is #745/#746.
+//! ([`cascade_rotate_scope`](super::cascade::cascade_rotate_scope)) — that
+//! cascade, not the sweep, is what completes a read revoke (rationale on
+//! [`super::cascade`]).
 //!
 //! Scope-exit and manual rotations re-seal the **unchanged** committed set: a
 //! grantee re-wraps blobs verbatim and can neither extend nor shrink the tag set
@@ -132,12 +127,9 @@ pub fn revoke_read_grant(
     revoked_tag: &[u8; 32],
     owner_signer: &EcdsaSigner,
 ) -> Result<RevokedCommittedSet, RevokeError> {
-    // Fail-closed BEFORE the cut: `owner_signer` MUST be the identity that signed
-    // the current commitment, else the re-signed cut mints a commitment the
-    // adoption gate rejects (an unreadable root). Encode-side mirror of the gate's
-    // owner-identity verify (fail-closed symmetry). The current commitment is
-    // owner-authentic (it passed the gate to resolve), so binding the new signer
-    // to it transitively anchors the cut to the owner identity.
+    // Fail-closed BEFORE the cut (see `RevokeError::UnauthorizedSigner`). The
+    // current commitment is owner-authentic — it passed the gate to resolve — so
+    // binding the new signer to it transitively anchors the cut to the owner.
     let current_sig =
         EcdsaSignature::from_compact(commitment_sig).ok_or(RevokeError::UnauthorizedSigner)?;
     verify_grant_set(&owner_signer.verifying_key(), commitment, &current_sig)

--- a/crates/engine/src/seams/floor_store.rs
+++ b/crates/engine/src/seams/floor_store.rs
@@ -39,30 +39,19 @@ pub trait FloorStore {
     /// returning the resulting stored floor for each entry in order.
     ///
     /// A single floor advance raises several distinctly-keyed floors at once
-    /// (read-epoch, write-epoch, per-name sequence). Two backing shapes close
-    /// the partial-advance hazard (#685), differently:
-    ///
-    /// - **Transactional (all-or-nothing)** — a backing with a cross-key
-    ///   transaction (the in-memory fake's single lock guard) leaves *no* entry
-    ///   durably changed on a seam error, so a partial advance is never
-    ///   observable at all.
-    /// - **Roll-forward (write-ahead journal)** — the desktop file store fsyncs
-    ///   the batch to an intent record before any per-key write and replays it on
-    ///   reopen, so an interrupted advance *completes forward* on the next open
-    ///   rather than lingering as a partial. It heals forward; it never rewinds.
+    /// (read-epoch, write-epoch, per-name sequence). An implementation closes the
+    /// partial-advance hazard (#685) one of two ways: **transactionally** (a
+    /// cross-key transaction leaves no entry durably changed on error) or by
+    /// **roll-forward** (the desktop store fsyncs a batch intent record before any
+    /// per-key write and replays it on reopen — it heals forward, never rewinds).
     ///
     /// The default fallback applies the raises one key at a time in the given
-    /// order — not atomic, but the caller passes the trust-critical (revocation)
-    /// floor first, so an interrupted fallback fails toward *more* restriction and
-    /// re-converges idempotently on retry, exactly the #682 mitigation this method
-    /// subsumes. Callers MUST order entries revocation-before-liveness for that
-    /// guarantee to hold.
-    ///
-    /// The web IndexedDB seam intentionally rides this fallback (its JS boundary
-    /// exposes only the per-key methods, no batch), which stays #682-safe.
-    /// Web-atomic commit is designed-for but deferred: #685 is a durability /
-    /// liveness concern, not a trust hole, and the ordered fallback already fails
-    /// closed on the revocation floor.
+    /// order — not atomic. **Callers MUST order entries revocation-before-
+    /// liveness**: an interrupted fallback then fails toward *more* restriction
+    /// and re-converges idempotently on retry (the #682 mitigation this method
+    /// subsumes). The web IndexedDB seam rides this fallback — its JS boundary
+    /// exposes only the per-key methods — and web-atomic commit is deferred as a
+    /// durability/liveness concern, not a trust hole.
     async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<Vec<u64>> {
         let mut resulting = Vec::with_capacity(raises.len());
         for raise in raises {

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -7,9 +7,8 @@
 //! (blueprint/engine.md "Pointer planes"; CONTEXT.md "Vault pointer", "Scope
 //! pointer", "Encryption subkey"). Per-scope read/write material and the
 //! per-name write-plane signers layer on top through the factory methods here,
-//! fed the scope seeds the resolve/gate path unseals later — this module owns
-//! the derivation edges, the resolve slices (#745/#746) and the liveness
-//! composition (#750/#751) own the inputs.
+//! fed the scope seeds the resolve/gate path unseals — this module owns the
+//! derivation edges, its callers own the inputs.
 //!
 //! Every derivation composes `crates/core`'s frozen KDF edge catalog
 //! ([`cipherbox_core::kdf`]); nothing here derives a key of its own. The whole
@@ -39,9 +38,7 @@ use crate::facade::{EngineError, LoginSecret};
 /// signer/seal factories that return secret-bearing material are `pub(crate)`,
 /// reachable only by the in-crate pipeline (resolve, publish, rotation, the
 /// liveness loop) — hosts wrap the facade and never hold signers.
-// The factory surface is the hook the deferred slices consume (resolve
-// #745/#746, liveness composition #750/#751, rotation); `derive` is live at
-// cold start now, the readers of each factory land with those slices.
+// Not every derivation factory has a live caller yet.
 #[allow(dead_code)]
 pub(crate) struct SessionIdentity {
     /// The login secret, retained for the runtime vault-pointer index probe.
@@ -98,8 +95,7 @@ impl SessionIdentity {
     }
 
     /// The owner identity verifier — the owner-trust anchor a resolved record
-    /// is gated against (later slices pass this to `cold_start_data_path`).
-    /// Public material.
+    /// is gated against. Public material.
     pub fn owner_identity(&self) -> EcdsaVerifier {
         self.identity.verifying_key()
     }

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -11,22 +11,6 @@
 //! the five per-op race rules — and a terminally unrebasable op dead-letters
 //! with its staged bytes preserved rather than being silently dropped.
 //!
-//! Submodules:
-//!
-//! - [`model`] — the working tree (the state law's left operand) and the one
-//!   strict name comparator.
-//! - [`op`] — the intent-op grammar.
-//! - [`record`] — the sealed, owner-tagged durable queue record.
-//! - [`overlay`] — the state law: snapshot ⊕ pending ops → rendered view.
-//! - [`rebase`] — FIFO replay, the five race rules, dead-lettering, and
-//!   dual-link observed repair.
-//! - [`staging`] — the budgeted offline staging policy over `StagingStore`.
-//! - [`staleness`] — the staleness ladder and the withheld-update escalation.
-//! - [`pointer`] — the scope/vault pointer planes, the re-point object, the
-//!   consult discipline, and the cold-start floor cold-seed.
-//! - [`tick`] — the jittered focus-window tick, immediate hint ticks, and
-//!   on-access refresh.
-//!
 //! Out of this slice, by design (CONTEXT.md #632): scope-exit rotation
 //! *triggering* — a cross-scope relink out of a granted scope **queues** the
 //! trigger event ([`rebase::ReplayReport::scope_exit_triggers`]); the rotation

--- a/crates/engine/src/sync/pointer.rs
+++ b/crates/engine/src/sync/pointer.rs
@@ -2,24 +2,19 @@
 //! consult discipline (blueprint/engine.md "Pointer planes"; CONTEXT.md
 //! "Scope pointer", "Vault pointer", "Re-point object"; #38, #39 D5).
 //!
-//! Three planes (#38 D1): the owner plane (stable pointer names, owner-only
-//! keys), the write plane (rotating derived names), the read plane (seeds).
-//! The engine publishes to the owner plane **only in owner sessions**. Every
-//! re-point object is owner-identity-signed and sealed under the scope's stable
-//! `pointerReadKey`; core owns the codec, sign, and verify
+//! The engine publishes the owner plane (#38 D1) **only in owner sessions**.
+//! Every re-point object is owner-identity-signed and sealed under the scope's
+//! stable `pointerReadKey`; core owns that codec, sign, and verify
 //! ([`seal_pointer_payload`]/[`open_pointer_payload`]) — this module owns name
-//! derivation, the vault-pointer index walk, the owner-plane write gate, and
-//! the consult discipline. The floor cold-seed itself is the floor law's
+//! derivation, the index walk, the write gate, and the consult discipline. The
+//! floor cold-seed is the floor law's
 //! ([`floor::cold_seed_checked`](crate::gate::floor::cold_seed_checked)) — cold
 //! start feeds it the re-point this walk authenticated.
 //!
 //! **Consult discipline: polled, not fallback** (#38 D4). A revokee's forged
-//! old-epoch record passes every *other* gate stage (valid old-key signature,
-//! fresh sequence, floor-level epoch, old-seed unseal), so staleness never
-//! fires and a fallback-only pointer would never be consulted. The pointer
-//! resolve therefore *joins the focus-window tick* for open shared scopes,
-//! runs on access for cached ones, and is the first act on cold start — it is
-//! never gated behind a staleness signal.
+//! old-epoch record passes every *other* gate stage, so staleness never fires
+//! and a fallback-only pointer would never be consulted; the resolve therefore
+//! joins the focus-window tick rather than sitting behind a staleness signal.
 
 use cipherbox_core::error::CodecError;
 use cipherbox_core::ipns::IpnsName;
@@ -122,8 +117,6 @@ pub struct VaultPointerAdoption {
 /// walk fail-closed at that index: it is never adopted and the walk never
 /// reaches beyond it, so a forged record cannot truncate the chain *below* an
 /// already-adopted valid index.
-///
-/// `login_secret` is a read-only borrow; sole consumer; zeroized at the session owner.
 pub async fn resolve_vault_pointer<F: PointerFetch>(
     fetch: &F,
     login_secret: &[u8],
@@ -152,8 +145,7 @@ pub async fn resolve_vault_pointer<F: PointerFetch>(
                     best = Some(VaultPointerAdoption { index, repoint });
                     index += 1;
                 }
-                // Fail-closed: an invalid payload is never adopted and stops the
-                // walk (a forged record cannot extend or masquerade the chain).
+                // Fail-closed: an invalid payload is never adopted and stops the walk.
                 Err(e) => return Err(e),
             },
         }
@@ -208,11 +200,9 @@ pub fn open_repoint(
     .map_err(PointerError::Open)
 }
 
-/// Whether to consult the scope pointer now — the polled discipline, decided
-/// independently of any staleness signal. Consult on cold start, on the focus
-/// tick for an open shared scope, and on access to a cached shared scope past
-/// staleness. Never a staleness fallback (a forged old-epoch record that passes
-/// staleness must not suppress the consult, #38 D4).
+/// Whether to consult the scope pointer now — the polled discipline (#38 D4),
+/// decided independently of any staleness signal. The reasons are enumerated on
+/// [`ConsultReason`].
 pub fn should_consult(
     is_cold_start: bool,
     is_open_shared_scope: bool,

--- a/crates/engine/src/sync/staleness.rs
+++ b/crates/engine/src/sync/staleness.rs
@@ -26,18 +26,13 @@ pub enum Connectivity {
     Offline,
 }
 
-/// Classify the staleness rung. The ladder, top to bottom:
-///
-/// - `Offline` — connectivity is down.
-/// - `Reconciling` — a background reconcile is in flight (quiet indicator).
-/// - `Stale` — online and idle, but the last success is older than the
-///   profile threshold (`stale_after` ≈ 3 missed poll cycles).
-/// - `Fresh` — online and within the freshness window.
+/// Classify the [`Staleness`] rung, in precedence order: `Offline`, then
+/// `Reconciling`, then `Stale`/`Fresh` split on the profile's `stale_after`
+/// (≈ 3 missed poll cycles).
 ///
 /// A cold cache (`last_success` is `None`) with no reconcile in flight while
-/// online is reported as `Reconciling`: the first tick is implied, and the
-/// empty-cache cold-start *error* is the caller's separate concern, not a
-/// staleness rung.
+/// online reports `Reconciling`: the empty-cache cold-start *error* is the
+/// caller's separate concern, not a staleness rung.
 pub fn classify(
     now: UnixMillis,
     last_success: Option<UnixMillis>,

--- a/crates/engine/src/sync/tick.rs
+++ b/crates/engine/src/sync/tick.rs
@@ -80,10 +80,9 @@ pub fn resolve_mode(cause: TickCause) -> ResolveMode {
     }
 }
 
-/// The focus set a tick refreshes, deterministically ordered: the vault pointer
-/// first (cold-boot anchor), then open shared-scope pointers (polled
-/// discipline), the mailbox poll, then the open folder and its ancestor chain
-/// to root. Everything else is out of the window (on-access refresh only).
+/// The focus set a tick refreshes, in deterministic order: vault pointer, open
+/// shared-scope pointers, mailbox poll, open folder, ancestors to root.
+/// Everything else is out of the window (on-access refresh only).
 pub fn focus_set(snapshot: &Snapshot, focus: &FocusWindow) -> Vec<FocusTarget> {
     let mut targets = vec![FocusTarget::VaultPointer];
     for scope in &focus.open_shared_scopes {
@@ -119,10 +118,8 @@ pub fn jittered_cadence(cadence: Duration, entropy: &mut dyn Entropy) -> Duratio
         return cadence;
     }
     let mut bytes = [0u8; 8];
-    // Entropy is fail-closed elsewhere; jitter is best-effort scheduling, so a
-    // (practically impossible) fill error degrades to the un-jittered cadence
-    // rather than propagating — losing jitter costs only herd spread, never
-    // correctness.
+    // Jitter is best-effort scheduling: a fill error degrades to the un-jittered
+    // cadence rather than propagating — it costs herd spread, never correctness.
     if entropy.fill(&mut bytes).is_err() {
         return cadence;
     }

--- a/crates/engine/tests/adoption_gate.rs
+++ b/crates/engine/tests/adoption_gate.rs
@@ -3,12 +3,10 @@
 //! six-stage matrix and the floor-law scenarios hard-asserted 1:1 against the
 //! design tables in blueprint/engine.md ("Adoption gate and floors").
 //!
-//! Every record is hand-fed (this slice lands no resolve/publish wiring): the
-//! IPNS record plane rides the shared fake record store; the metadata (grant
-//! commitment, seed-bearing structures, envelope) is constructed directly with
-//! `crates/core`'s crypto. The gate composes only core's verify/unseal
-//! functions — so the reject rows assert core's exact named `TrustViolation`
-//! error, never an engine reinvention.
+//! Every record is hand-fed: the IPNS record plane rides the shared fake record
+//! store and the metadata is built directly with `crates/core`'s crypto. The
+//! gate composes only core's verify/unseal functions, so the reject rows assert
+//! core's exact named `TrustViolation` error, never an engine reinvention.
 
 use std::collections::BTreeSet;
 
@@ -322,11 +320,10 @@ impl Fixture {
         }
     }
 
-    /// A well-formed published ascent link sealed under `parent_node_seed`
-    /// (uncorrupted public half) with a valid owner-pseudonym structure signature.
-    /// The stage-3 verdict now hinges on whether the *reader's* `parent_node_seed`
-    /// re-derives this keypair — a mismatched reader seed is a natural
-    /// `ascent-link-mismatch`, no hand-corruption needed.
+    /// A well-formed published ascent link sealed under `parent_node_seed` with a
+    /// valid owner-pseudonym structure signature. The stage-3 verdict hinges on
+    /// whether the *reader's* `parent_node_seed` re-derives this keypair, so a
+    /// mismatched reader seed is a natural `ascent-link-mismatch`.
     fn ascent_link_under(&self, parent_node_seed: &[u8; 32]) -> SignedAscentLink {
         self.ascent_link_under_aad(parent_node_seed, self.ascent_aad())
     }
@@ -615,8 +612,7 @@ fn run_matrix_case(name: &str) -> Result<Adopted, GateError> {
         parent_node_seed: reader_parent_seed,
         seed_blob: Some(fx.owner_seed_blob(tamper_seed_blob)),
     };
-    // Drop the transient write-grantee seed the gate now surfaces; the matrix
-    // asserts only the adoption verdict.
+    // The matrix asserts only the adoption verdict.
     block_on(adopt(&floors, &reader, &candidate)).map(|(adopted, _)| adopted)
 }
 
@@ -690,14 +686,12 @@ fn matrix_table_and_reject_surface_mirror_one_to_one() {
 
 #[test]
 fn foreign_scope_label_rejected_at_stage_six_binding() {
-    // Test A (resolver binding, #745/#756): the record is a fully valid scope root
-    // sealed for its own scope, and the reader's read_key opens it (the scope UUID
-    // is not in the read-key KDF). Only the reader's `scope_id` — the trusted
-    // parent-index label — is foreign. Adopting under it would dedup/rotate the
-    // WRONG scope key, a silent revocation hole. Stage 6 binds `envelope.scope` to
-    // `reader.scope_id` and rejects fail-closed. With the returned `scope_id`
-    // dropped from the rotation targets, a divergent label can no longer even reach
-    // a re-key: this gate check is the sole surviving edge, and it fails closed.
+    // Resolver binding (#745/#756): the record is a fully valid scope root sealed
+    // for its own scope and the reader's read_key opens it (the scope UUID is not
+    // in the read-key KDF) — only the reader's `scope_id`, the trusted parent-index
+    // label, is foreign. Adopting under it would dedup/rotate the WRONG scope key,
+    // a silent revocation hole, so stage 6 binds `envelope.scope` to
+    // `reader.scope_id` and fails closed.
     let fx = Fixture::new();
     let floors = InMemoryFloorStore::default();
     let candidate = fx.candidate(1);
@@ -1091,10 +1085,7 @@ fn simulation_n_engines_one_record_store_adversarial() {
 #[test]
 fn non_empty_history_link_authenticates_and_rejects_tamper_and_replay() {
     // Every other fixture leaves history_links empty, so the STRUCT_TAG_HISTORY_LINK
-    // recompute-and-verify loop is exercised here over a populated list (#687): a
-    // valid link authenticates, a tampered sealed body is rejected, and a link
-    // validly signed for a different epoch (cross-epoch replay) recomputes a
-    // preimage the authenticated envelope epoch never covered.
+    // recompute-and-verify loop is exercised here over a populated list (#687).
     let fx = Fixture::new();
     let sealed = b"prior-write-epoch-history-link".to_vec();
     let sign_link = |epoch: u64, bytes: &[u8]| -> [u8; 64] {
@@ -1125,8 +1116,7 @@ fn non_empty_history_link_authenticates_and_rejects_tamper_and_replay() {
     ))
     .expect("valid non-empty history link adopts");
 
-    // Tamper: mutate the sealed bytes but keep the old signature — the recomputed
-    // preimage no longer matches, rejecting the whole record.
+    // Tamper: mutate the sealed bytes but keep the old signature.
     let mut tampered = fx.candidate(1);
     let mut bad = sealed.clone();
     bad[0] ^= 0xFF;
@@ -1306,10 +1296,8 @@ fn cross_epoch_structure_replay_rejected_at_grant_section() {
         &folder,
     )
     .expect("epoch-2 folder seals");
-    // The grant section's structures are all signed at epoch 1; presenting them
-    // in an epoch-2 envelope makes the gate recompute each preimage at epoch 2,
-    // so the epoch-1 signatures no longer verify — the cross-epoch replay is
-    // rejected without any caller-asserted epoch to trust (#687).
+    // The gate recomputes each preimage at the envelope's epoch, so there is no
+    // caller-asserted epoch to trust (#687).
     let mut candidate = fx.candidate(1);
     candidate.envelope = envelope_e2;
     let err = block_on(adopt(&floors, &fx.reader(), &candidate)).unwrap_err();
@@ -1329,7 +1317,6 @@ fn swapped_structure_ciphertext_rejected_at_grant_section() {
     let fx = Fixture::new();
     let floors = InMemoryFloorStore::default();
     let mut candidate = fx.candidate(1);
-    // Flip a byte of the owner-blob ciphertext, leaving the (valid) signature.
     candidate.grant_section.owner_blob.ciphertext[0] ^= 0xFF;
     let err = block_on(adopt(&floors, &fx.reader(), &candidate)).unwrap_err();
     let rej = err.rejection().unwrap();

--- a/crates/engine/tests/grants_mailbox.rs
+++ b/crates/engine/tests/grants_mailbox.rs
@@ -2,13 +2,12 @@
 //! read-grantee) exchange a share over one fake mailbox hub and one fake record
 //! store on virtual time, plus the adversarial reject rows the design demands.
 //!
-//! Every record and grant blob is hand-fed (this slice lands no resolve/publish
-//! wiring): the IPNS record plane rides the shared fake record store; the scope
-//! root's metadata (grant blob, commitment, structures, envelope) is built
-//! directly with `crates/core`'s crypto, exactly as the owner would publish it.
-//! The engine layer under test composes only core's verify/unseal/open — so the
-//! reject rows assert core's named checks or the engine's own fail-closed
-//! classifications, never a reinvented crypto code.
+//! Every record and grant blob is hand-fed: the IPNS record plane rides the
+//! shared fake record store and the scope root's metadata is built directly with
+//! `crates/core`'s crypto, exactly as the owner would publish it. The engine
+//! layer under test composes only core's verify/unseal/open, so the reject rows
+//! assert core's named checks or the engine's own fail-closed classifications,
+//! never a reinvented crypto code.
 
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
@@ -376,7 +375,6 @@ fn two_instance_share_accept_end_to_end() {
     ))
     .expect("post");
 
-    // Owner records the sent share in its denormalized index.
     let mut sent = SentIndex::new();
     let recipient_identity = EcdsaSigner::from_scalar(&[0xAA; 32]).unwrap();
     sent.record(SentShare {
@@ -391,7 +389,6 @@ fn two_instance_share_accept_end_to_end() {
         .record_store
         .seed_record(&endpoint, fx.name.as_str(), fx.record_bytes(1));
 
-    // Recipient imports the owner's contact (fail-closed verify) and polls.
     let contact = import_contact(&fx.owner_contact).expect("valid contact imports");
     let items = block_on(poll_verified(
         &recipient_device.mailbox,
@@ -441,7 +438,6 @@ fn two_instance_share_accept_end_to_end() {
         "pointer read key mismatch"
     );
 
-    // The item was acked only after the durable append: the inbox is now empty.
     assert!(
         block_on(poll_verified(
             &recipient_device.mailbox,
@@ -878,7 +874,6 @@ fn a_failed_ack_after_commit_recovers_via_idempotent_reack() {
         block_on(recipient.floor_store.sequence_floor(name_bytes)).unwrap(),
         Some(1)
     );
-    // ...but the item stays pending because the ack failed.
     assert_eq!(
         inbox_len(&fx, &recipient),
         1,
@@ -1491,11 +1486,9 @@ fn mailbox_lifecycle_through_the_api_client() {
         "recipient: {post_body}"
     );
 
-    // poll: a GET on the mailbox collection.
     assert_eq!(requests[1].url, "http://api.test/mailbox/messages");
     assert_eq!(requests[1].method, HttpMethod::Get);
 
-    // ack: a DELETE on the item.
     assert_eq!(requests[2].url, "http://api.test/mailbox/messages/m1");
     assert_eq!(requests[2].method, HttpMethod::Delete);
 }

--- a/crates/engine/tests/net.rs
+++ b/crates/engine/tests/net.rs
@@ -6,12 +6,10 @@
 //! "the simulation harness").
 //!
 //! Records are real (core-signed via `IpnsRecord::create_v2`), so the fan-out
-//! verify step runs core's actual chain; the adoption gate — whose full
-//! candidate/reader assembly lands with the content/pointer/key slices — is
-//! reached through a scripted [`Adopter`] so this slice can prove the pipeline
-//! contract (every resolve is gated; only gate-passing records touch the
-//! snapshot) without re-deriving the whole crypto fixture the adoption-gate
-//! suite already owns.
+//! verify step runs core's actual chain. The adoption gate is reached through a
+//! scripted [`Adopter`]: this suite proves the pipeline contract (every resolve
+//! is gated; only gate-passing records touch the snapshot) without re-deriving
+//! the crypto fixture the adoption-gate suite already owns.
 
 use core::cell::RefCell;
 use core::time::Duration;

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -10,12 +10,10 @@
 //!
 //! The wasm-bindgen-generated `.d.ts` is the single boundary contract that
 //! `packages/client` re-exports — there is no hand-maintained TS mirror of
-//! engine structures. Boundary hygiene is structural: `u64`s (op ids, sizes,
-//! IPNS sequence numbers) cross as `bigint`, binary payloads as `Uint8Array`,
-//! and no secret key material crosses at all — the command surface exposes
-//! only intent (a grant carries the recipient's *public* identity key, never
-//! a secret), and the event and read surfaces only key-free view state and
-//! decrypted user content (snapshot views, downloaded plaintext bytes).
+//! engine structures. Boundary hygiene is structural: `u64`s cross as `bigint`,
+//! binary payloads as `Uint8Array`, and no secret key material crosses at all —
+//! the command surface exposes only intent, the event and read surfaces only
+//! key-free view state and decrypted user content.
 
 // wasm-bindgen's macro-generated glue is unsafe by nature and exempt; this
 // forbids only unsafe we would hand-write (there is none).
@@ -25,20 +23,14 @@
 use cipherbox_engine::facade;
 use wasm_bindgen::prelude::*;
 
-// Shared JS-seam → engine-seam adapters (browser wasm target only): both the
-// production engine host and the test-only conformance bridge build on them.
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 mod seams_bridge;
 
-// The production engine host: constructs the one engine instance over the
-// browser seams and exposes `start`/`command`/`snapshot`/`download`/`nextEvent`
-// to the worker.
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 mod host;
 
-// Test-only browser seam conformance bridge. Compiled only for the browser
-// suite's WASM build (`--features conformance` on the wasm target); the
-// production artifact never pulls the engine test kit or these bindings.
+// Test-only: the production artifact never pulls the engine test kit or these
+// bindings.
 #[cfg(all(feature = "conformance", target_family = "wasm", target_os = "unknown"))]
 mod conformance;
 
@@ -683,9 +675,8 @@ mod tests {
     use super::*;
     use cipherbox_engine::seams::OpId;
 
-    // The wrong-length rejection path builds a `JsError`, which only runs on
-    // wasm; it is asserted in `tests/boundary.rs`. Here we cover the accepted
-    // path and the byte round-trip.
+    // The wrong-length rejection builds a `JsError` (wasm-only) — see
+    // `tests/boundary.rs`.
     #[test]
     fn node_id_accepts_16_bytes_and_round_trips() {
         assert!(NodeId::from_bytes(&[0u8; 16]).is_ok());


### PR DESCRIPTION
## What this is

A **non-behavioral comment sweep** across `crates/core`, `crates/engine`, and the peripheral crates. Comments, doc comments, and module headers only — no logic, signature, import, or ordering changes. `git diff` contains no non-comment line.

**66 files, +624 / −1087 → net −463 lines.**

## The discipline being applied

`AGENTS.md` → "Code Style / Comments". Comments explain _why_, not _what_, and stay short. The shapes cut here:

- **Happy-path narration** — a comment restating what the next lines plainly do. The code is the narrative; such comments rot out of sync and mislead.
- **Absence-justifying comments** — prose explaining why a path that is _not_ in the code does not happen. Several had already rotted into falsehoods (see below).
- **Restated invariants** — an invariant stated at its home and then re-derived at every call site. Kept at the home, replaced with a one-line cross-reference at the callers.
- **Spec re-derivation** — prose re-deriving what `blueprint/*.md` or `CONTEXT.md` already says, replaced with a one-line citation. Module headers past ~25 lines are almost always restating the spec.
- **Member enumerations that duplicate a type's own docs** — one had already rotted, omitting `ownerWriteBlob`.
- **Design-alternative apologia** — paragraphs defending why the code is not shaped some other way.

## Note on provenance

This re-derives an unshipped comment sweep from 2026-07-23. **Correction worth recording:** that sweep was not in fact unshipped — the branch it lived on was squash-merged in full as #776 on 2026-07-23, code and all, together with the `AGENTS.md` guidance it introduced. `AGENTS.md` therefore needs no change here; the length-discipline paragraph is already on `main`.

So this PR is not a re-application of that work. It sweeps the comment drift that has accrued **since**, across #779 through #892 — plus `crates/core`'s codec, kdf, ipns, suite, error, and payload modules, which #776 never touched and which carried the heaviest untouched load.

## Stale claims corrected

Four comments had already become false and were the highest-value cuts:

- `crates/engine/src/lib.rs` — the header claimed the gate, sync, rotation, grants, pointer, mailbox, net, and content modules "land in later slices". All eight are `pub mod` today.
- `crates/core/src/seal/aad.rs` — tagged eight of ten structure tags "later slice" while all ten are in live use.
- `crates/core/src/suite/mod.rs` and `suite/aead.rs` — said the seal layer "is a later slice", with `crates/core/src/seal/` sitting alongside.
- `crates/engine/tests/adoption_gate.rs`, `tests/grants_mailbox.rs` — "this slice lands no resolve/publish wiring", superseded by #789 and #886.

## Deliberately kept

Rationale authored by the four most recent PRs was checked with `git blame` before any cut, defaulting to **keep**:

- `crates/core/src/seal/op_record.rs` — **untouched entirely**. Every hunk blames to #891 or #878; the header carries the auth-mode-to-self rationale, the clear-header freeze law, and the trust-vs-malformed classification.
- `crates/core/src/suite/hpke.rs` — the #891 auth-mode / square-CDH header is untouched; only pre-#891 lines were compressed.
- `crates/engine/src/grants/child_index.rs` — the #892 `DestIndexVersion` CAS-key provenance, `UndoDestAdd<T>`, and index-agnostic version rule with the #786 relink cross-reference.
- `crates/engine/tests/write_plane.rs` — **already clean, zero cuts** (#886/#892 test-contract docs and named laws).
- `crates/fuse` — **already clean, zero cuts** across src and tests. The whole crate is #885 and every comment is a genuine _why_.
- `crates/engine/src/testkit/**` — already clean.
- Every KDF label/edge citation, the CIDv1 byte table, all encode/decode fail-closed symmetry blocks, and every `assert!`-vs-`debug_assert!` justification (AGENTS.md rule 8) survive, compressed only where they were re-derived.
- `crates/engine/src/rotation/cascade.rs` "Why only the fresh-seed cascade completes a revoke" and "Fail-closed completeness"; `gate/floor.rs`'s four-way floor law; `gate/adoption.rs`'s stage-5 ascent cross-check and stage-6 reader-scope binding.

## Flagged, not fixed

Per the AGENTS.md rule that a paragraph justifying a workaround means the code is wrong — these are left verbatim rather than deleted, because each explains a real hazard:

- `crates/wasm/src/seams_bridge.rs` — five lines explaining that the `Http` cap bounds an already-buffered response, not peak memory, because the real streaming bound must live in the JS seam. Tracked as #641.
- `crates/engine/src/rotation/rotate_write.rs` — the accepted limitation that a crash after the pointer flip but before interior retirement orphans the prior run's interior names. Tracked as #764.

Two further observations, neither actioned here:

- `crates/engine/src/lib.rs` — `pub const CRATE` is documented as a placeholder for "the sibling crate stubs' dependency tests". Those crates are all real now, so the const and its test look like dead scaffolding. Removing it is a code change; a `/simplify` candidate.
- `crates/core/src/suite/ecdsa.rs` credited "the `rfc6979` crate", which is not a dependency of either manifest — signing goes through `k256`'s `sign_prehash`. The determinism claim was correct, only the attribution was wrong; the comment now states the property without the false crate reference.

One genuine defect was found and filed rather than fixed here:

- #893 — `encode_map_partial` still builds its output with `Vec::new()` and grows it, while `encode.rs` documents the two-pass sized buffer as the reason grow-from-empty is banned for secret-bearing writes. A residual of the closed #681. Latent, not a live leak: no production caller feeds it secret-bearing fields yet. Edged as a blocker of #655.

## Verification

| Gate | Result |
| --- | --- |
| `cargo fmt --all --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo test --workspace` | exit 0 — 985 passed, 0 failed, 2 ignored |
| `crates/fuse` | 29 unit + 26 integration, all passing |
| `cargo check --target wasm32-unknown-unknown -p cipherbox-core -p cipherbox-wasm` | exit 0 |

## Review note

The one thing worth checking closely is that no cut removed rationale added by #886, #891, or #892. Every hunk in those PRs' files was blame-checked first and the default was to keep. The fastest confirmation:

```
git diff main...HEAD -- crates/engine/src/net/ crates/engine/src/sync/drain.rs crates/core/src/seal/op_record.rs
```

The last of those three paths is empty.
