### PR TITLE
feat(engine): add a combined move intent op so a kernel rename is one entry

### DIFF
--- a/blueprint/desktop.md
+++ b/blueprint/desktop.md
@@ -176,7 +176,9 @@ there is no `block_on` freeze of the whole mount behind one slow call.
   plaintext `cb-write-*` exposure class is gone (judgment; the zero-overwrite
   cleanup papers over what this closes structurally).
 - **release** (and create/mkdir/rename/unlink/rmdir) — becomes exactly one
-  facade intent op (`updateContent`, `create`, `rename`, `relink`, `delete`).
+  facade intent op (`updateContent`, `create`, `move`, `delete`). A kernel
+  rename is one `move`, which carries the relink, the rename, and the
+  destination it replaces, so a replace is never observable half-done.
   The kernel is acked when the op is **journaled durably in the StagingStore**
   — the v1 INV-1 no-false-ack discipline, now uniform across every mutation
   instead of two. Everything after the ack (seal, upload, publish, CAS rebase)

--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -218,11 +218,11 @@ poll timer, desktop from FUSE-op TTL checks — the core is identical.
   exactly two things: trust violations and an empty-cache cold start. Manual
   refresh resolves with nocache semantics everywhere.
 - **Ops**: every mutation is an intent op — `create`, `delete`, `rename`,
-  `relink`, `updateContent` — carrying its base sequence and its authored
+  `relink`, `move`, `updateContent` — carrying its base sequence and its authored
   time, journaled FIFO in the durable op queue (all mutations, both platforms)
   as a versioned, owner-tagged record whose intent body seals HPKE-to-self in
   **auth mode**, so authoring one requires the owner's enc secret rather than
-  the public tag stamped beside it. That authenticates a record's *author*, not
+  the public tag stamped beside it. That authenticates a record's _author_, not
   its freshness or its position: a store co-tenant can still copy, delete, or
   reorder whole records, which queue-integrity work covers separately. The queue
   is per device, not per account, and is shared with whatever build wrote it: a
@@ -232,7 +232,10 @@ poll timer, desktop from FUSE-op TTL checks — the core is identical.
   dead-lettered and dropped. An intra-scope
   `relink` is a pure relink; a cross-scope `relink` re-seals the moved subtree
   at the destination scope's epoch, and one that leaves a granted source scope
-  is a scope-exit rotation trigger for the source (#26 D1/D7). Replay is FIFO
+  is a scope-exit rotation trigger for the source (#26 D1/D7). A `move` is a
+  relink and a rename in one entry, optionally vacating the node already at the
+  destination name — one POSIX rename is exactly one `move`, so the whole
+  operation is journaled or none of it is. Replay is FIFO
   in performed order through the standard rebase, and rebases only onto
   gate-passing state (#33 D5–D7).
 - **Withheld-update escalation**: shared scopes only — a name pinned past a

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -321,8 +321,9 @@ pub enum Command {
         /// Destination parent.
         new_parent: NodeId,
     },
-    /// Relink and rename a node in one intent op, replacing whatever sits at
-    /// the destination name ([`OpKind::Move`](crate::OpKind::Move)).
+    /// Relink and rename a node in one intent op, conditionally replacing the
+    /// node at the destination name — a concurrent edit to it wins and the move
+    /// auto-suffixes instead ([`OpKind::Move`](crate::OpKind::Move)).
     Move {
         /// Node being moved.
         node: NodeId,

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -322,8 +322,7 @@ pub enum Command {
         new_parent: NodeId,
     },
     /// Relink and rename a node in one intent op, replacing whatever sits at
-    /// the destination name. One kernel rename is exactly one of these
-    /// (blueprint/desktop.md "Reads, writes, and the never-block law").
+    /// the destination name ([`OpKind::Move`](crate::OpKind::Move)).
     Move {
         /// Node being moved.
         node: NodeId,
@@ -1484,10 +1483,7 @@ impl<T: SeamTypes> Engine<T> {
             }
             Command::Relink { node, new_parent } => {
                 let rendered = self.render().await?;
-                let from_parent = rendered
-                    .parent_of(node)
-                    .unwrap_or(self.snapshot.borrow().root);
-                let base_sequence = rendered.record_sequence(node).unwrap_or(1);
+                let (from_parent, base_sequence) = self.relocation_anchors(&rendered, node);
                 // trailing bools: cross_scope=false, exits_granted_source=false — intra-scope pure relink
                 let op = Op::relink(
                     node,
@@ -1507,12 +1503,12 @@ impl<T: SeamTypes> Engine<T> {
                 replacing,
             } => {
                 let rendered = self.render().await?;
-                let from_parent = rendered
-                    .parent_of(node)
-                    .unwrap_or(self.snapshot.borrow().root);
-                let base_sequence = rendered.record_sequence(node).unwrap_or(1);
+                let (from_parent, base_sequence) = self.relocation_anchors(&rendered, node);
                 let replacing = replacing.map(|replaced| Replaced {
                     node: replaced,
+                    // The conditional-delete anchor: a concurrent edit that
+                    // advances the replaced node past this keeps it, and the
+                    // move auto-suffixes off the name it could not free.
                     sequence: rendered.record_sequence(replaced).unwrap_or(1),
                 });
                 let op = Op::move_node(
@@ -1847,6 +1843,15 @@ impl<T: SeamTypes> Engine<T> {
             .into_iter()
             .map(|(_id, op)| op)
             .collect())
+    }
+
+    /// What a relocation op anchors on: the parent the move was formed against
+    /// (the scope root for an unlinked node) and the target's base sequence.
+    fn relocation_anchors(&self, rendered: &Snapshot, node: NodeId) -> (NodeId, u64) {
+        let from_parent = rendered
+            .parent_of(node)
+            .unwrap_or(self.snapshot.borrow().root);
+        (from_parent, rendered.record_sequence(node).unwrap_or(1))
     }
 
     /// The base sequence to anchor an op at: the target's own record sequence in

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -47,7 +47,7 @@ use crate::storage_policy::StoragePolicy;
 use crate::sync::boot::{ColdStartError, ColdStartOutcome, ColdStartParams, cold_start};
 use crate::sync::drain::{Drain, DrainReport, DrainScope};
 use crate::sync::model::{NodeMeta, Snapshot, collation_key};
-use crate::sync::op::Op;
+use crate::sync::op::{Op, Replaced};
 use crate::sync::overlay::apply_overlay;
 use crate::sync::pointer::PointerFetch;
 use crate::sync::project::project_child_version;
@@ -321,6 +321,19 @@ pub enum Command {
         /// Destination parent.
         new_parent: NodeId,
     },
+    /// Relink and rename a node in one intent op, replacing whatever sits at
+    /// the destination name. One kernel rename is exactly one of these
+    /// (blueprint/desktop.md "Reads, writes, and the never-block law").
+    Move {
+        /// Node being moved.
+        node: NodeId,
+        /// Destination parent (the current parent for a pure rename).
+        new_parent: NodeId,
+        /// Name at the destination, as entered.
+        new_name: String,
+        /// The node the destination name currently holds, if any.
+        replacing: Option<NodeId>,
+    },
     /// Write new content to a file node (fresh per-version content key).
     UpdateContent {
         /// Target file node.
@@ -412,6 +425,7 @@ impl Command {
             Command::Delete { .. } => "delete",
             Command::Rename { .. } => "rename",
             Command::Relink { .. } => "relink",
+            Command::Move { .. } => "move",
             Command::UpdateContent { .. } => "updateContent",
             Command::SetFocus { .. } => "setFocus",
             Command::ManualRefresh => "manualRefresh",
@@ -1483,6 +1497,32 @@ impl<T: SeamTypes> Engine<T> {
                     authored_at,
                     false,
                     false,
+                );
+                self.stage_and_notify(&op).await
+            }
+            Command::Move {
+                node,
+                new_parent,
+                new_name,
+                replacing,
+            } => {
+                let rendered = self.render().await?;
+                let from_parent = rendered
+                    .parent_of(node)
+                    .unwrap_or(self.snapshot.borrow().root);
+                let base_sequence = rendered.record_sequence(node).unwrap_or(1);
+                let replacing = replacing.map(|replaced| Replaced {
+                    node: replaced,
+                    sequence: rendered.record_sequence(replaced).unwrap_or(1),
+                });
+                let op = Op::move_node(
+                    node,
+                    from_parent,
+                    new_parent,
+                    new_name,
+                    replacing,
+                    base_sequence,
+                    authored_at,
                 );
                 self.stage_and_notify(&op).await
             }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -88,10 +88,10 @@ pub use storage_policy::{Headroom, StoragePlatform, StoragePolicy};
 pub use sync::{
     AppliedOp, BlockedOp, Connectivity, DeadLetterReason, DropReason, FocusTarget, FocusWindow,
     HeadReconciliation, Link, NodeMeta, Op, OpKind, OpRecordError, OpResolution, PointerError,
-    PointerFetch, RecordClass, RecordReader, RecordSeal, Repair, ReplayReport, SessionRole,
-    Snapshot, StageOutcome, StagedContent, TickCause, TickControl, VaultPointerAdoption,
-    apply_overlay, apply_repairs, classify, decode_queue, encode_op_record, focus_set,
-    observed_repair, rebase_one, reconcile_head, record_content_root_cid, replay,
+    PointerFetch, RecordClass, RecordReader, RecordSeal, Repair, Replaced, ReplayReport,
+    SessionRole, Snapshot, StageOutcome, StagedContent, TickCause, TickControl,
+    VaultPointerAdoption, apply_overlay, apply_repairs, classify, decode_queue, encode_op_record,
+    focus_set, observed_repair, rebase_one, reconcile_head, record_content_root_cid, replay,
     resolve_vault_pointer, stage_op,
 };
 

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -56,7 +56,7 @@ use crate::seams::{
     StagingStore,
 };
 use crate::session::SessionIdentity;
-use crate::sync::model::Snapshot;
+use crate::sync::model::{Snapshot, collation_key};
 use crate::sync::op::{Op, OpKind};
 use crate::sync::overlay::apply_overlay;
 use crate::sync::project::project_folder;
@@ -983,8 +983,16 @@ where
         }
 
         let dest_children = &mut pass.folder_mut(dest)?.children;
+        // The one destructive step in the plan, so it re-checks against the
+        // record the gate just handed us: the ref this drops must still be the
+        // one holding the name the move is taking. A concurrent writer that
+        // renamed it away made it a bystander.
         let replaced = vacated
-            .and_then(|node| dest_children.iter().position(|child| child.id == node.0))
+            .and_then(|node| {
+                dest_children.iter().position(|child| {
+                    child.id == node.0 && collation_key(&child.name) == collation_key(&moved.name)
+                })
+            })
             .map(|at| dest_children.remove(at));
         // The rebase resolves against a dest it has not loaded yet, so a dest
         // already naming the target is reachable; a second ref would sign a

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -289,6 +289,31 @@ struct FolderState {
     sequence: u64,
 }
 
+/// Where one child ref is going, under what name, and what it displaces —
+/// rename, relink, and move all reduce to this.
+struct MovePlan {
+    /// The source parent the op anchored on.
+    from_parent: NodeId,
+    /// The destination parent; the source parent for a rename in place.
+    dest: NodeId,
+    /// `None` keeps the name the ref already carries.
+    new_name: Option<String>,
+    /// The node the rebase vacated at the destination name, if any.
+    vacated: Option<NodeId>,
+}
+
+/// A published dest-add, as its compensation must invert it.
+struct DestAdd {
+    dest: NodeId,
+    source: NodeId,
+    target: NodeId,
+    /// The ref the dest-add vacated in the same publish, if any.
+    replaced: Option<ChildRef>,
+    /// The dest sequence the add published at.
+    cas_base: u64,
+    modified_at: u64,
+}
+
 /// One node's record as loaded for re-authoring: the envelope fields a
 /// republish must carry forward byte-stable (#27 D10) plus the opened body.
 struct LoadedNode {
@@ -768,7 +793,20 @@ where
                 self.publish_create(scope, pass, applied, rebased, *parent, *kind)
                     .await
             }
-            OpKind::Rename { .. } => self.publish_rename(scope, pass, applied).await,
+            // The name lives only in the parent's child ref
+            // (`crates/core/src/seal/body.rs`), so a rename never leaves the
+            // folder it is already in.
+            OpKind::Rename { .. } => {
+                let parent = self.published_parent(applied.op.target)?;
+                let plan = MovePlan {
+                    from_parent: parent,
+                    dest: parent,
+                    new_name: Some(applied.effective_name.clone().ok_or(Halt::Unclassified)?),
+                    vacated: None,
+                };
+                self.publish_ref_move(scope, pass, applied, rebased, plan)
+                    .await
+            }
             OpKind::Delete { .. } => self.publish_delete(scope, pass, applied).await,
             OpKind::Relink {
                 from_parent,
@@ -776,7 +814,13 @@ where
                 cross_scope: false,
                 ..
             } => {
-                self.publish_relink(scope, pass, applied, rebased, *from_parent, *new_parent)
+                let plan = MovePlan {
+                    from_parent: *from_parent,
+                    dest: *new_parent,
+                    new_name: None,
+                    vacated: None,
+                };
+                self.publish_ref_move(scope, pass, applied, rebased, plan)
                     .await
             }
             OpKind::Move {
@@ -785,16 +829,19 @@ where
                 replacing,
                 ..
             } => {
-                self.publish_move(
-                    scope,
-                    pass,
-                    applied,
-                    rebased,
-                    *from_parent,
-                    *new_parent,
-                    replacing.map(|replaced| replaced.node),
-                )
-                .await
+                let plan = MovePlan {
+                    from_parent: *from_parent,
+                    dest: *new_parent,
+                    new_name: Some(applied.effective_name.clone().ok_or(Halt::Unclassified)?),
+                    // Only the node the rebase actually vacated loses its ref:
+                    // one that won the conditional delete keeps its entry, and
+                    // the move already resolved onto a name beside it.
+                    vacated: replacing
+                        .map(|replaced| replaced.node)
+                        .filter(|node| !rebased.contains(*node)),
+                };
+                self.publish_ref_move(scope, pass, applied, rebased, plan)
+                    .await
             }
             OpKind::UpdateContent { .. } => self.publish_update_content(scope, pass, applied).await,
             // Content bytes are #868's; cross-scope re-seal is #635's.
@@ -848,32 +895,6 @@ where
         Ok(())
     }
 
-    /// Rename: the name lives only in the parent's child ref
-    /// (`crates/core/src/seal/body.rs`), so one parent republish is the whole op.
-    async fn publish_rename(
-        &self,
-        scope: &DrainScope<'_>,
-        pass: &mut Pass,
-        applied: &AppliedOp,
-    ) -> Result<(), Halt> {
-        let new_name = applied.effective_name.clone().ok_or(Halt::Unclassified)?;
-        let target = applied.op.target;
-        let parent = self.published_parent(target)?;
-        self.ensure_folder(scope, pass, parent).await?;
-        {
-            let child = pass
-                .folder_mut(parent)?
-                .children
-                .iter_mut()
-                .find(|child| child.id == target.0)
-                .ok_or(Halt::Unclassified)?;
-            child.name = new_name;
-        }
-        self.publish_folder(scope, pass, parent, applied.op.authored_at.0)
-            .await?;
-        Ok(())
-    }
-
     /// Delete: drop the parent's ref. The name itself is retired only on
     /// abandonment (#819 as amended by #824), which is the failure-policy
     /// slice's (#867).
@@ -898,27 +919,34 @@ where
         Ok(())
     }
 
-    /// Relink: dest-add published before the source-remove, so no window leaves
-    /// the child absent from both parents. A source-remove that will not
-    /// publish compensates its own dest-add rather than leaving a dual link.
-    async fn publish_relink(
+    /// The one plan behind rename, relink, and move: relocate a child ref,
+    /// dest-add before source-remove, so no window leaves the child absent from
+    /// both parents. A source-remove that will not publish compensates its own
+    /// dest-add rather than leaving a dual link. Source and destination being
+    /// one folder collapses the whole plan into a single record.
+    async fn publish_ref_move(
         &self,
         scope: &DrainScope<'_>,
         pass: &mut Pass,
         applied: &AppliedOp,
         rebased: &Snapshot,
-        from_parent: NodeId,
-        dest: NodeId,
+        plan: MovePlan,
     ) -> Result<(), Halt> {
+        let MovePlan {
+            from_parent,
+            dest,
+            new_name,
+            vacated,
+        } = plan;
         let target = applied.op.target;
         let source = self.published_parent(target)?;
         // The op's own presence condition: a source the rebase did not resolve
         // against is a concurrent move this op lost (`sync/op.rs`), and removing
         // from it would clobber the winner.
-        if source != from_parent {
+        if source != from_parent && source != dest {
             return Err(Halt::Unclassified);
         }
-        if source == dest {
+        if source == dest && new_name.is_none() && vacated.is_none() {
             return Ok(());
         }
         // A cycle detaches the whole subtree from the scope root irrecoverably,
@@ -933,8 +961,7 @@ where
         self.ensure_folder(scope, pass, dest).await?;
 
         // The dest gains the source's own ref, so id/ipnsName/kind and any
-        // newer client's fields ride verbatim; only the link counter advances
-        // to the winner replay allocated (#33 D5).
+        // newer client's fields ride verbatim.
         let mut moved = pass
             .folder(source)?
             .children
@@ -942,122 +969,35 @@ where
             .find(|child| child.id == target.0)
             .cloned()
             .ok_or(Halt::Unclassified)?;
-        moved.link_counter = rebased
-            .winning_link(target)
-            .map_or(moved.link_counter.saturating_add(1), |link| {
-                link.link_counter
-            });
+        if let Some(new_name) = new_name {
+            moved.name = new_name;
+        }
+        if source != dest {
+            // Only a newly-established link advances the counter, to the winner
+            // replay allocated (#33 D5).
+            moved.link_counter = rebased
+                .winning_link(target)
+                .map_or(moved.link_counter.saturating_add(1), |link| {
+                    link.link_counter
+                });
+        }
 
+        let dest_children = &mut pass.folder_mut(dest)?.children;
+        let replaced = vacated
+            .and_then(|node| dest_children.iter().position(|child| child.id == node.0))
+            .map(|at| dest_children.remove(at));
         // The rebase resolves against a dest it has not loaded yet, so a dest
         // already naming the target is reachable; a second ref would sign a
         // listing `author_child_envelope` rejects, wedging every retry.
-        let dest_children = &mut pass.folder_mut(dest)?.children;
         match dest_children.iter_mut().find(|child| child.id == target.0) {
             Some(existing) => *existing = moved,
             None => dest_children.push(moved),
         }
         let cas_base = self.publish_folder(scope, pass, dest, modified_at).await?;
-
-        pass.folder_mut(source)?
-            .children
-            .retain(|child| child.id != target.0);
-        if self
-            .publish_folder(scope, pass, source, modified_at)
-            .await
-            .is_err()
-        {
-            self.compensate_dest_add(
-                scope,
-                pass,
-                dest,
-                source,
-                target,
-                None,
-                cas_base,
-                modified_at,
-            )
-            .await?;
-            return Err(Halt::Unclassified);
-        }
-        Ok(())
-    }
-
-    /// Move: one publish plan for the whole kernel rename. The destination
-    /// folder drops the replaced ref and gains the moved one in a **single**
-    /// record, so no observer ever sees the destination name unresolvable; a
-    /// cross-folder move then removes from the source under the same dest-first
-    /// ordering a relink uses.
-    #[expect(clippy::too_many_arguments, reason = "one move's full publish plan")]
-    async fn publish_move(
-        &self,
-        scope: &DrainScope<'_>,
-        pass: &mut Pass,
-        applied: &AppliedOp,
-        rebased: &Snapshot,
-        from_parent: NodeId,
-        dest: NodeId,
-        replacing: Option<NodeId>,
-    ) -> Result<(), Halt> {
-        let target = applied.op.target;
-        let new_name = applied.effective_name.clone().ok_or(Halt::Unclassified)?;
-        let source = self.published_parent(target)?;
-        // The op's own presence condition (`sync/op.rs`): a parent neither
-        // anchor names is a concurrent move this op lost.
-        if source != from_parent && source != dest {
-            return Err(Halt::Unclassified);
-        }
-        if dest == target || self.base.borrow().ancestors(dest).contains(&target) {
-            return Err(Halt::Unclassified);
-        }
-        let modified_at = applied.op.authored_at.0;
-
-        self.ensure_folder(scope, pass, source).await?;
-        self.ensure_folder(scope, pass, dest).await?;
-
-        // Only the node the rebase actually vacated loses its ref: one that won
-        // the conditional delete keeps its entry, and the move already resolved
-        // onto an auto-suffixed name beside it.
-        let vacated = replacing.filter(|replaced| !rebased.contains(*replaced));
-
-        let mut moved = pass
-            .folder(source)?
-            .children
-            .iter()
-            .find(|child| child.id == target.0)
-            .cloned()
-            .ok_or(Halt::Unclassified)?;
-        moved.name = new_name;
-        // The counter the replay allocated (#33 D5) — unchanged for a rename in
-        // place, advanced to the winner for a relink.
-        moved.link_counter = rebased.winning_link(target).ok_or(Halt::Unclassified)?.link_counter;
-
         if source == dest {
-            let children = &mut pass.folder_mut(dest)?.children;
-            if let Some(replaced) = vacated {
-                children.retain(|child| child.id != replaced.0);
-            }
-            let entry = children
-                .iter_mut()
-                .find(|child| child.id == target.0)
-                .ok_or(Halt::Unclassified)?;
-            *entry = moved;
-            self.publish_folder(scope, pass, dest, modified_at).await?;
             return Ok(());
         }
 
-        let dest_children = &mut pass.folder_mut(dest)?.children;
-        let replaced_ref = vacated
-            .and_then(|replaced| dest_children.iter().position(|c| c.id == replaced.0))
-            .map(|at| dest_children.remove(at));
-        // A dest already naming the target is reachable (the rebase resolves
-        // against a dest it has not loaded); a second ref would sign a listing
-        // `author_child_envelope` rejects, wedging every retry.
-        match dest_children.iter_mut().find(|child| child.id == target.0) {
-            Some(existing) => *existing = moved,
-            None => dest_children.push(moved),
-        }
-        let cas_base = self.publish_folder(scope, pass, dest, modified_at).await?;
-
         pass.folder_mut(source)?
             .children
             .retain(|child| child.id != target.0);
@@ -1069,12 +1009,14 @@ where
             self.compensate_dest_add(
                 scope,
                 pass,
-                dest,
-                source,
-                target,
-                replaced_ref,
-                cas_base,
-                modified_at,
+                DestAdd {
+                    dest,
+                    source,
+                    target,
+                    replaced,
+                    cas_base,
+                    modified_at,
+                },
             )
             .await?;
             return Err(Halt::Unclassified);
@@ -1092,21 +1034,23 @@ where
     /// removal re-derived onto the winner's record rather than replayed over it
     /// (#786).
     ///
-    /// `replaced` is the ref the dest-add vacated in the same publish, if any;
-    /// the undo restores it, because a dest that keeps neither the moved node
-    /// nor the one it replaced has lost an entry outright.
-    #[expect(clippy::too_many_arguments, reason = "one compensation's full state")]
+    /// The undo also restores the ref the dest-add vacated: a dest keeping
+    /// neither the moved node nor the one it replaced has lost an entry
+    /// outright.
     async fn compensate_dest_add(
         &self,
         scope: &DrainScope<'_>,
         pass: &mut Pass,
-        dest: NodeId,
-        source: NodeId,
-        target: NodeId,
-        replaced: Option<ChildRef>,
-        cas_base: u64,
-        modified_at: u64,
+        add: DestAdd,
     ) -> Result<(), Halt> {
+        let DestAdd {
+            dest,
+            source,
+            target,
+            replaced,
+            cas_base,
+            modified_at,
+        } = add;
         self.reload_folder(scope, pass, source).await?;
         if !pass
             .folder(source)?

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -779,6 +779,23 @@ where
                 self.publish_relink(scope, pass, applied, rebased, *from_parent, *new_parent)
                     .await
             }
+            OpKind::Move {
+                from_parent,
+                new_parent,
+                replacing,
+                ..
+            } => {
+                self.publish_move(
+                    scope,
+                    pass,
+                    applied,
+                    rebased,
+                    *from_parent,
+                    *new_parent,
+                    replacing.map(|replaced| replaced.node),
+                )
+                .await
+            }
             OpKind::UpdateContent { .. } => self.publish_update_content(scope, pass, applied).await,
             // Content bytes are #868's; cross-scope re-seal is #635's.
             OpKind::Create { .. } | OpKind::Relink { .. } => Err(Halt::Unclassified),
@@ -949,8 +966,117 @@ where
             .await
             .is_err()
         {
-            self.compensate_dest_add(scope, pass, dest, source, target, cas_base, modified_at)
-                .await?;
+            self.compensate_dest_add(
+                scope,
+                pass,
+                dest,
+                source,
+                target,
+                None,
+                cas_base,
+                modified_at,
+            )
+            .await?;
+            return Err(Halt::Unclassified);
+        }
+        Ok(())
+    }
+
+    /// Move: one publish plan for the whole kernel rename. The destination
+    /// folder drops the replaced ref and gains the moved one in a **single**
+    /// record, so no observer ever sees the destination name unresolvable; a
+    /// cross-folder move then removes from the source under the same dest-first
+    /// ordering a relink uses.
+    #[expect(clippy::too_many_arguments, reason = "one move's full publish plan")]
+    async fn publish_move(
+        &self,
+        scope: &DrainScope<'_>,
+        pass: &mut Pass,
+        applied: &AppliedOp,
+        rebased: &Snapshot,
+        from_parent: NodeId,
+        dest: NodeId,
+        replacing: Option<NodeId>,
+    ) -> Result<(), Halt> {
+        let target = applied.op.target;
+        let new_name = applied.effective_name.clone().ok_or(Halt::Unclassified)?;
+        let source = self.published_parent(target)?;
+        // The op's own presence condition (`sync/op.rs`): a parent neither
+        // anchor names is a concurrent move this op lost.
+        if source != from_parent && source != dest {
+            return Err(Halt::Unclassified);
+        }
+        if dest == target || self.base.borrow().ancestors(dest).contains(&target) {
+            return Err(Halt::Unclassified);
+        }
+        let modified_at = applied.op.authored_at.0;
+
+        self.ensure_folder(scope, pass, source).await?;
+        self.ensure_folder(scope, pass, dest).await?;
+
+        // Only the node the rebase actually vacated loses its ref: one that won
+        // the conditional delete keeps its entry, and the move already resolved
+        // onto an auto-suffixed name beside it.
+        let vacated = replacing.filter(|replaced| !rebased.contains(*replaced));
+
+        let mut moved = pass
+            .folder(source)?
+            .children
+            .iter()
+            .find(|child| child.id == target.0)
+            .cloned()
+            .ok_or(Halt::Unclassified)?;
+        moved.name = new_name;
+        // The counter the replay allocated (#33 D5) — unchanged for a rename in
+        // place, advanced to the winner for a relink.
+        moved.link_counter = rebased.winning_link(target).ok_or(Halt::Unclassified)?.link_counter;
+
+        if source == dest {
+            let children = &mut pass.folder_mut(dest)?.children;
+            if let Some(replaced) = vacated {
+                children.retain(|child| child.id != replaced.0);
+            }
+            let entry = children
+                .iter_mut()
+                .find(|child| child.id == target.0)
+                .ok_or(Halt::Unclassified)?;
+            *entry = moved;
+            self.publish_folder(scope, pass, dest, modified_at).await?;
+            return Ok(());
+        }
+
+        let dest_children = &mut pass.folder_mut(dest)?.children;
+        let replaced_ref = vacated
+            .and_then(|replaced| dest_children.iter().position(|c| c.id == replaced.0))
+            .map(|at| dest_children.remove(at));
+        // A dest already naming the target is reachable (the rebase resolves
+        // against a dest it has not loaded); a second ref would sign a listing
+        // `author_child_envelope` rejects, wedging every retry.
+        match dest_children.iter_mut().find(|child| child.id == target.0) {
+            Some(existing) => *existing = moved,
+            None => dest_children.push(moved),
+        }
+        let cas_base = self.publish_folder(scope, pass, dest, modified_at).await?;
+
+        pass.folder_mut(source)?
+            .children
+            .retain(|child| child.id != target.0);
+        if self
+            .publish_folder(scope, pass, source, modified_at)
+            .await
+            .is_err()
+        {
+            self.compensate_dest_add(
+                scope,
+                pass,
+                dest,
+                source,
+                target,
+                replaced_ref,
+                cas_base,
+                modified_at,
+            )
+            .await?;
             return Err(Halt::Unclassified);
         }
         Ok(())
@@ -965,6 +1091,10 @@ where
     /// sequence our dest-add published; a dest that moved is re-read and the
     /// removal re-derived onto the winner's record rather than replayed over it
     /// (#786).
+    ///
+    /// `replaced` is the ref the dest-add vacated in the same publish, if any;
+    /// the undo restores it, because a dest that keeps neither the moved node
+    /// nor the one it replaced has lost an entry outright.
     #[expect(clippy::too_many_arguments, reason = "one compensation's full state")]
     async fn compensate_dest_add(
         &self,
@@ -973,6 +1103,7 @@ where
         dest: NodeId,
         source: NodeId,
         target: NodeId,
+        replaced: Option<ChildRef>,
         cas_base: u64,
         modified_at: u64,
     ) -> Result<(), Halt> {
@@ -991,18 +1122,25 @@ where
         // a cache hit would answer with the bytes we just published and make the
         // compare vacuous.
         let observed = self.observed_sequence(&pass.folder(dest)?.name).await?;
-        let drop_target = |children: &[ChildRef]| -> Vec<ChildRef> {
-            children
+        let replaced = replaced.as_ref();
+        let undo = |children: &[ChildRef]| -> Vec<ChildRef> {
+            let mut next: Vec<ChildRef> = children
                 .iter()
                 .filter(|child| child.id != target.0)
                 .cloned()
-                .collect()
+                .collect();
+            if let Some(replaced) = replaced
+                && !next.iter().any(|child| child.id == replaced.id)
+            {
+                next.push(replaced.clone());
+            }
+            next
         };
-        let children = match undo_dest_add_versioned(&staged, drop_target, cas_base, observed) {
+        let children = match undo_dest_add_versioned(&staged, undo, cas_base, observed) {
             UndoDestAdd::Removed(children) => children,
             UndoDestAdd::Conflict => {
                 self.reload_folder(scope, pass, dest).await?;
-                drop_target(&pass.folder(dest)?.children)
+                undo(&pass.folder(dest)?.children)
             }
         };
         pass.folder_mut(dest)?.children = children;

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -1074,25 +1074,31 @@ where
         // a cache hit would answer with the bytes we just published and make the
         // compare vacuous.
         let observed = self.observed_sequence(&pass.folder(dest)?.name).await?;
-        let replaced = replaced.as_ref();
-        let undo = |children: &[ChildRef]| -> Vec<ChildRef> {
-            let mut next: Vec<ChildRef> = children
+        let drop_target = |children: &[ChildRef]| -> Vec<ChildRef> {
+            children
                 .iter()
                 .filter(|child| child.id != target.0)
                 .cloned()
-                .collect();
-            if let Some(replaced) = replaced
-                && !next.iter().any(|child| child.id == replaced.id)
-            {
-                next.push(replaced.clone());
-            }
-            next
+                .collect()
         };
-        let children = match undo_dest_add_versioned(&staged, undo, cas_base, observed) {
-            UndoDestAdd::Removed(children) => children,
+        let children = match undo_dest_add_versioned(&staged, drop_target, cas_base, observed) {
+            // Our own bytes are still the head, so the undo is an exact inverse
+            // of our own edit: the vacated ref goes back too.
+            UndoDestAdd::Removed(mut children) => {
+                if let Some(replaced) = replaced
+                    && !children.iter().any(|child| child.id == replaced.id)
+                {
+                    children.push(replaced);
+                }
+                children
+            }
+            // A winner owns the dest and built on the listing our dest-add
+            // published. Subtract our add and stop there — re-asserting a ref
+            // whose absence the winner has already built on would resurrect it
+            // against an intent that may be permanently retired.
             UndoDestAdd::Conflict => {
                 self.reload_folder(scope, pass, dest).await?;
-                undo(&pass.folder(dest)?.children)
+                drop_target(&pass.folder(dest)?.children)
             }
         };
         pass.folder_mut(dest)?.children = children;

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -32,7 +32,7 @@ pub mod tick;
 pub use boot::{ColdStartError, ColdStartOutcome, ColdStartParams, RootResolve, cold_start};
 pub use drain::{BlockedOp, DRAINED_OP_MARK_KEY, OP_ATTEMPTS_KEY};
 pub use model::{Link, NodeMeta, Snapshot, collation_key, suffix_name};
-pub use op::{Op, OpDecodeError, OpKind, StagedContent};
+pub use op::{Op, OpDecodeError, OpKind, Replaced, StagedContent};
 pub use overlay::apply_overlay;
 pub use pointer::{
     ConsultReason, PointerError, PointerFetch, SessionRole, VaultPointerAdoption, open_repoint,

--- a/crates/engine/src/sync/op.rs
+++ b/crates/engine/src/sync/op.rs
@@ -54,7 +54,17 @@ pub struct StagedContent {
     pub plaintext_size: u64,
 }
 
-/// The five intent-op mutations (#33 D6).
+/// The destination node a [`OpKind::Move`] replaces, with the sequence
+/// snapshot the conditional-delete rule compares against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Replaced {
+    /// The node being replaced at the destination.
+    pub node: NodeId,
+    /// Its record sequence at the time the move was formed.
+    pub sequence: u64,
+}
+
+/// The six intent-op mutations (#33 D6).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OpKind {
     /// Create a node under a parent.
@@ -98,6 +108,21 @@ pub enum OpKind {
         /// Whether the move leaves a granted source scope (a scope-exit
         /// rotation trigger for the source).
         exits_granted_source: bool,
+    },
+    /// Relink **and** rename a node in one entry, optionally replacing the node
+    /// already at the destination name. One kernel rename is one of these, so
+    /// the whole POSIX-atomic operation is journaled or none of it is
+    /// (blueprint/desktop.md "Reads, writes, and the never-block law").
+    Move {
+        /// The source parent the move was formed against — the presence
+        /// condition for the source-remove and the move-race detector.
+        from_parent: NodeId,
+        /// The destination parent (the source parent for a pure rename).
+        new_parent: NodeId,
+        /// The name at the destination, as entered.
+        new_name: String,
+        /// The destination node this move vacates, if any.
+        replacing: Option<Replaced>,
     },
     /// Write a new file version (fresh per-version content key).
     UpdateContent {
@@ -181,6 +206,29 @@ impl Op {
                 new_parent,
                 cross_scope,
                 exits_granted_source,
+            },
+        }
+    }
+
+    /// A combined `move` op.
+    pub fn move_node(
+        target: NodeId,
+        from_parent: NodeId,
+        new_parent: NodeId,
+        new_name: impl Into<String>,
+        replacing: Option<Replaced>,
+        base_sequence: u64,
+        authored_at: UnixMillis,
+    ) -> Self {
+        Self {
+            target,
+            base_sequence,
+            authored_at,
+            kind: OpKind::Move {
+                from_parent,
+                new_parent,
+                new_name: new_name.into(),
+                replacing,
             },
         }
     }
@@ -306,6 +354,19 @@ mod tests {
             Op::rename(id(3), "b.txt", 5, at(1_002)),
             Op::relink(id(4), id(0), id(9), 6, at(1_003), true, true),
             Op::update_content(id(5), staged(b"stage2", 12), 8, at(1_004)),
+            Op::move_node(
+                id(6),
+                id(0),
+                id(9),
+                "c.txt",
+                Some(Replaced {
+                    node: id(7),
+                    sequence: 4,
+                }),
+                9,
+                at(1_005),
+            ),
+            Op::move_node(id(6), id(0), id(9), "c.txt", None, 9, at(1_005)),
         ];
         for op in ops {
             assert_eq!(Op::decode_body(&op.encode_body()).unwrap(), op);
@@ -366,12 +427,14 @@ mod tests {
             Op::delete(id(2), 1, at(1), 1).pending_class(),
             Op::rename(id(3), "b", 1, at(1)).pending_class(),
             Op::relink(id(4), id(0), id(9), 1, at(1), false, false).pending_class(),
+            Op::move_node(id(4), id(0), id(9), "b", None, 1, at(1)).pending_class(),
             Op::update_content(id(5), staged(b"k", 1), 1, at(1)).pending_class(),
         ];
         assert_eq!(
             classes,
             [
                 PendingClass::Content,
+                PendingClass::Metadata,
                 PendingClass::Metadata,
                 PendingClass::Metadata,
                 PendingClass::Metadata,

--- a/crates/engine/src/sync/overlay.rs
+++ b/crates/engine/src/sync/overlay.rs
@@ -83,7 +83,9 @@ fn relocate(
     new_name: Option<&str>,
     replacing: Option<crate::facade::NodeId>,
 ) {
-    if let Some(replaced) = replacing {
+    // A node never replaces itself — vacating the target would erase the very
+    // node this op moves (`crate::sync::rebase` refuses it the same way).
+    if let Some(replaced) = replacing.filter(|node| *node != op.target) {
         view.remove_node(replaced);
     }
     let current = view.parent_of(op.target);
@@ -205,6 +207,33 @@ mod tests {
         assert_eq!(view.parent_of(id(2)), Some(id(1)));
         assert_eq!(view.node(id(2)).unwrap().name, "target.txt");
         assert!(view.children(id(0)).iter().all(|c| c.id != id(2)));
+    }
+
+    #[test]
+    fn overlay_move_keeps_a_target_named_as_its_own_replaced_node() {
+        let mut base = base();
+        base.upsert_node(NodeMeta::new(id(1), "f.txt", NodeKind::File));
+        base.link(id(0), id(1), 1);
+
+        let replacing = Some(Replaced {
+            node: id(1),
+            sequence: 1,
+        });
+        let view = apply_overlay(
+            &base,
+            &[Op::move_node(
+                id(1),
+                id(0),
+                id(0),
+                "g.txt",
+                replacing,
+                1,
+                AT,
+            )],
+        );
+
+        assert!(view.contains(id(1)), "the target survives its own replace");
+        assert_eq!(view.node(id(1)).unwrap().name, "g.txt");
     }
 
     #[test]

--- a/crates/engine/src/sync/overlay.rs
+++ b/crates/engine/src/sync/overlay.rs
@@ -52,41 +52,52 @@ fn apply_one(view: &mut Snapshot, op: &Op) {
                 op.stamp_authored(node);
             }
         }
-        OpKind::Relink { new_parent, .. } => {
-            if let Some(old_parent) = view.parent_of(op.target) {
-                view.unlink(old_parent, op.target);
-            }
-            view.link_next(*new_parent, op.target);
-            if let Some(node) = view.node_mut(op.target) {
-                op.stamp_authored(node);
-            }
-        }
+        OpKind::Relink { new_parent, .. } => relocate(view, op, *new_parent, None, None),
         OpKind::Move {
             new_parent,
             new_name,
             replacing,
             ..
-        } => {
-            if let Some(replaced) = replacing {
-                view.remove_node(replaced.node);
-            }
-            if view.parent_of(op.target) != Some(*new_parent) {
-                if let Some(old_parent) = view.parent_of(op.target) {
-                    view.unlink(old_parent, op.target);
-                }
-                view.link_next(*new_parent, op.target);
-            }
-            if let Some(node) = view.node_mut(op.target) {
-                node.name = new_name.clone();
-                op.stamp_authored(node);
-            }
-        }
+        } => relocate(
+            view,
+            op,
+            *new_parent,
+            Some(new_name.as_str()),
+            replacing.map(|replaced| replaced.node),
+        ),
         OpKind::UpdateContent { .. } => {
             if let Some(node) = view.node_mut(op.target) {
                 node.content_version = node.content_version.map(|count| count + 1);
                 op.stamp_authored(node);
             }
         }
+    }
+}
+
+/// Render a relink or a move: vacate the node the op replaces, re-link under
+/// the destination when the parent actually changes, and take the new name.
+fn relocate(
+    view: &mut Snapshot,
+    op: &Op,
+    new_parent: crate::facade::NodeId,
+    new_name: Option<&str>,
+    replacing: Option<crate::facade::NodeId>,
+) {
+    if let Some(replaced) = replacing {
+        view.remove_node(replaced);
+    }
+    let current = view.parent_of(op.target);
+    if current != Some(new_parent) {
+        if let Some(current) = current {
+            view.unlink(current, op.target);
+        }
+        view.link_next(new_parent, op.target);
+    }
+    if let Some(node) = view.node_mut(op.target) {
+        if let Some(new_name) = new_name {
+            node.name = new_name.to_owned();
+        }
+        op.stamp_authored(node);
     }
 }
 

--- a/crates/engine/src/sync/overlay.rs
+++ b/crates/engine/src/sync/overlay.rs
@@ -61,6 +61,26 @@ fn apply_one(view: &mut Snapshot, op: &Op) {
                 op.stamp_authored(node);
             }
         }
+        OpKind::Move {
+            new_parent,
+            new_name,
+            replacing,
+            ..
+        } => {
+            if let Some(replaced) = replacing {
+                view.remove_node(replaced.node);
+            }
+            if view.parent_of(op.target) != Some(*new_parent) {
+                if let Some(old_parent) = view.parent_of(op.target) {
+                    view.unlink(old_parent, op.target);
+                }
+                view.link_next(*new_parent, op.target);
+            }
+            if let Some(node) = view.node_mut(op.target) {
+                node.name = new_name.clone();
+                op.stamp_authored(node);
+            }
+        }
         OpKind::UpdateContent { .. } => {
             if let Some(node) = view.node_mut(op.target) {
                 node.content_version = node.content_version.map(|count| count + 1);
@@ -74,7 +94,7 @@ fn apply_one(view: &mut Snapshot, op: &Op) {
 mod tests {
     use super::*;
     use crate::facade::{NodeId, NodeKind};
-    use crate::sync::op::StagedContent;
+    use crate::sync::op::{Replaced, StagedContent};
 
     /// Journal time for ops whose narrative does not turn on it.
     const AT: crate::seams::UnixMillis = crate::seams::UnixMillis(0);
@@ -143,6 +163,37 @@ mod tests {
         let view = apply_overlay(&base, &ops);
         assert_eq!(view.parent_of(id(2)), Some(id(1)));
         assert_eq!(view.children(id(0)).len(), 1, "moved out of root");
+    }
+
+    #[test]
+    fn overlay_move_relinks_renames_and_replaces_in_one_step() {
+        let mut base = base();
+        base.upsert_node(NodeMeta::new(id(1), "dir", NodeKind::Folder));
+        base.upsert_node(NodeMeta::new(id(2), "f.txt", NodeKind::File));
+        base.upsert_node(NodeMeta::new(id(3), "target.txt", NodeKind::File));
+        base.link(id(0), id(1), 1);
+        base.link(id(0), id(2), 1);
+        base.link(id(1), id(3), 1);
+
+        let replacing = Some(Replaced {
+            node: id(3),
+            sequence: 1,
+        });
+        let ops = vec![Op::move_node(
+            id(2),
+            id(0),
+            id(1),
+            "target.txt",
+            replacing,
+            1,
+            AT,
+        )];
+        let view = apply_overlay(&base, &ops);
+
+        assert!(!view.contains(id(3)));
+        assert_eq!(view.parent_of(id(2)), Some(id(1)));
+        assert_eq!(view.node(id(2)).unwrap().name, "target.txt");
+        assert!(view.children(id(0)).iter().all(|c| c.id != id(2)));
     }
 
     #[test]

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -334,17 +334,8 @@ fn rebase_relink(
     new_parent: crate::facade::NodeId,
     exits_granted_source: bool,
 ) -> OpResolution {
-    if !working.contains(op.target) {
-        return OpResolution::DeadLetter(DeadLetterReason::TargetGone);
-    }
-    if !working.contains(new_parent) {
-        return OpResolution::DeadLetter(DeadLetterReason::DestinationGone);
-    }
-    // A move into the subtree it is moving detaches that subtree from the scope
-    // root with nothing left to walk it from, so no later op could reach it —
-    // unrepresentable rather than merely refused at publish.
-    if new_parent == op.target || working.ancestors(new_parent).contains(&op.target) {
-        return OpResolution::DeadLetter(DeadLetterReason::DestinationInsideTarget);
+    if let Some(dead_letter) = relocation_guards(working, op, new_parent) {
+        return dead_letter;
     }
 
     let scope_exit_trigger = exits_granted_source.then_some(from_parent);
@@ -370,14 +361,33 @@ fn rebase_relink(
     }
 }
 
+/// What a relocation cannot rebase onto at all, in one place for the relink and
+/// move rules: an absent target or destination, and a destination inside the
+/// moved subtree — which detaches that subtree from the scope root with nothing
+/// left to walk it from, so no later op could reach it (unrepresentable rather
+/// than merely refused at publish).
+fn relocation_guards(
+    working: &Snapshot,
+    op: &Op,
+    new_parent: crate::facade::NodeId,
+) -> Option<OpResolution> {
+    let reason = if !working.contains(op.target) {
+        DeadLetterReason::TargetGone
+    } else if !working.contains(new_parent) {
+        DeadLetterReason::DestinationGone
+    } else if new_parent == op.target || working.ancestors(new_parent).contains(&op.target) {
+        DeadLetterReason::DestinationInsideTarget
+    } else {
+        return None;
+    };
+    Some(OpResolution::DeadLetter(reason))
+}
+
 /// Combined move: the relink rule's races, then the rename rule's collision
-/// resolution, over a destination this op vacates first. Vacating first is what
-/// makes a replace land under the entered name instead of auto-suffixing off
-/// the node it is replacing.
-///
-/// The replaced node is dropped under the conditional-delete rule, so a
-/// concurrent edit to it still wins — the mover then auto-suffixes off the name
-/// it could not free, and no version is lost in either direction.
+/// resolution, over a destination this op vacates first — which is what makes a
+/// replace land under the entered name instead of auto-suffixing off the node
+/// it is replacing. The replaced node drops under the conditional-delete rule,
+/// so a concurrent edit to it still wins.
 fn rebase_move(
     working: &mut Snapshot,
     op: &Op,
@@ -386,14 +396,8 @@ fn rebase_move(
     new_name: &str,
     replacing: Option<Replaced>,
 ) -> OpResolution {
-    if !working.contains(op.target) {
-        return OpResolution::DeadLetter(DeadLetterReason::TargetGone);
-    }
-    if !working.contains(new_parent) {
-        return OpResolution::DeadLetter(DeadLetterReason::DestinationGone);
-    }
-    if new_parent == op.target || working.ancestors(new_parent).contains(&op.target) {
-        return OpResolution::DeadLetter(DeadLetterReason::DestinationInsideTarget);
+    if let Some(dead_letter) = relocation_guards(working, op, new_parent) {
+        return dead_letter;
     }
     let current_parent = working.parent_of(op.target);
     // A concurrent move relocated the child somewhere this op never anchored
@@ -405,7 +409,7 @@ fn rebase_move(
 
     // Already where it was going, under the name it was going to take, with
     // nothing left at the destination to vacate.
-    if !replacing.is_some_and(|replaced| working.contains(replaced.node))
+    if replacing.is_none_or(|replaced| !working.contains(replaced.node))
         && current_parent == Some(new_parent)
         && working.node(op.target).is_some_and(|n| n.name == new_name)
     {

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -414,7 +414,10 @@ fn rebase_move(
     // because a name lives in the parent's child ref and renaming a node never
     // advances the node's own record sequence.
     let vacating = replacing.filter(|replaced| {
-        working.parent_of(replaced.node) == Some(new_parent)
+        // A node never replaces itself: the facade is a public surface, and
+        // vacating the target would erase the very node this op moves.
+        replaced.node != op.target
+            && working.parent_of(replaced.node) == Some(new_parent)
             && working
                 .node(replaced.node)
                 .is_some_and(|node| collation_key(&node.name) == collation_key(new_name))
@@ -1023,6 +1026,35 @@ mod tests {
             Some(id(0)),
             "the relocated bystander is untouched where it now lives"
         );
+    }
+
+    #[test]
+    fn a_move_that_names_its_own_target_as_the_replaced_node_keeps_it() {
+        // `Command::Move` is a public facade surface; vacating the target would
+        // erase the very node the op moves, and every later op on it would then
+        // dead-letter as `TargetGone`.
+        let mut base = replace_tree(1);
+        let local = base.clone();
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::move_node(
+                id(2),
+                id(0),
+                id(0),
+                "renamed.txt",
+                Some(Replaced {
+                    node: id(2),
+                    sequence: 1,
+                }),
+                1,
+                AT,
+            ),
+        );
+        assert!(matches!(res, OpResolution::Applied { .. }));
+        assert!(base.contains(id(2)), "the target survives its own replace");
+        assert_eq!(base.node(id(2)).unwrap().name, "renamed.txt");
+        assert_eq!(base.parent_of(id(2)), Some(id(0)));
     }
 
     #[test]

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -25,7 +25,7 @@ use std::collections::HashSet;
 
 use crate::seams::OpId;
 use crate::sync::model::{NodeMeta, Snapshot, collation_key, suffix_name};
-use crate::sync::op::{Op, OpKind};
+use crate::sync::op::{Op, OpKind, Replaced};
 use crate::sync::record::{RecordClass, RecordReader};
 
 /// The highest auto-suffix a loser probes before dead-lettering — a folder
@@ -242,6 +242,12 @@ pub fn rebase_one(working: &mut Snapshot, local: &Snapshot, op: &Op) -> OpResolu
             *new_parent,
             *exits_granted_source,
         ),
+        OpKind::Move {
+            from_parent,
+            new_parent,
+            new_name,
+            replacing,
+        } => rebase_move(working, op, *from_parent, *new_parent, new_name, *replacing),
         OpKind::UpdateContent { .. } => rebase_update_content(working, local, op),
     }
 }
@@ -262,7 +268,7 @@ fn rebase_create(
         return OpResolution::DeadLetter(DeadLetterReason::TargetGone);
     }
 
-    let (effective, suffixed) = match resolve_name(working, parent, name, op.target) {
+    let (effective, suffixed) = match resolve_name(working, parent, name, &[op.target]) {
         Some(resolved) => resolved,
         None => return OpResolution::DeadLetter(DeadLetterReason::SuffixExhausted),
     };
@@ -301,7 +307,7 @@ fn rebase_rename(working: &mut Snapshot, op: &Op, new_name: &str) -> OpResolutio
     }
     let parent = working.parent_of(op.target);
     let (effective, suffixed) = match parent {
-        Some(parent) => match resolve_name(working, parent, new_name, op.target) {
+        Some(parent) => match resolve_name(working, parent, new_name, &[op.target]) {
             Some(resolved) => resolved,
             None => return OpResolution::DeadLetter(DeadLetterReason::SuffixExhausted),
         },
@@ -364,6 +370,82 @@ fn rebase_relink(
     }
 }
 
+/// Combined move: the relink rule's races, then the rename rule's collision
+/// resolution, over a destination this op vacates first. Vacating first is what
+/// makes a replace land under the entered name instead of auto-suffixing off
+/// the node it is replacing.
+///
+/// The replaced node is dropped under the conditional-delete rule, so a
+/// concurrent edit to it still wins — the mover then auto-suffixes off the name
+/// it could not free, and no version is lost in either direction.
+fn rebase_move(
+    working: &mut Snapshot,
+    op: &Op,
+    from_parent: crate::facade::NodeId,
+    new_parent: crate::facade::NodeId,
+    new_name: &str,
+    replacing: Option<Replaced>,
+) -> OpResolution {
+    if !working.contains(op.target) {
+        return OpResolution::DeadLetter(DeadLetterReason::TargetGone);
+    }
+    if !working.contains(new_parent) {
+        return OpResolution::DeadLetter(DeadLetterReason::DestinationGone);
+    }
+    if new_parent == op.target || working.ancestors(new_parent).contains(&op.target) {
+        return OpResolution::DeadLetter(DeadLetterReason::DestinationInsideTarget);
+    }
+    let current_parent = working.parent_of(op.target);
+    // A concurrent move relocated the child somewhere this op never anchored
+    // against: we are the race loser, and removing it from there would clobber
+    // the winner.
+    if current_parent.is_some_and(|current| current != from_parent && current != new_parent) {
+        return OpResolution::Dropped(DropReason::MoveRaceLost);
+    }
+
+    // Already where it was going, under the name it was going to take, with
+    // nothing left at the destination to vacate.
+    if !replacing.is_some_and(|replaced| working.contains(replaced.node))
+        && current_parent == Some(new_parent)
+        && working.node(op.target).is_some_and(|n| n.name == new_name)
+    {
+        return OpResolution::Dropped(DropReason::AlreadySatisfied);
+    }
+
+    let vacating = replacing.filter(|replaced| {
+        working
+            .record_sequence(replaced.node)
+            .is_some_and(|current| current <= replaced.sequence)
+    });
+
+    // Resolved before any mutation: an exhausted probe dead-letters, and a
+    // dead-lettered op must leave the working base as it found it.
+    let mut exclude = vec![op.target];
+    exclude.extend(vacating.map(|replaced| replaced.node));
+    let (effective, suffixed) = match resolve_name(working, new_parent, new_name, &exclude) {
+        Some(resolved) => resolved,
+        None => return OpResolution::DeadLetter(DeadLetterReason::SuffixExhausted),
+    };
+
+    if let Some(replaced) = vacating {
+        working.remove_node(replaced.node);
+    }
+    if current_parent != Some(new_parent) {
+        if let Some(current) = current_parent {
+            working.unlink(current, op.target);
+        }
+        working.link_next(new_parent, op.target);
+    }
+    if let Some(node) = working.node_mut(op.target) {
+        node.name = effective.clone();
+    }
+    OpResolution::Applied {
+        effective_name: Some(effective),
+        suffixed,
+        scope_exit_trigger: None,
+    }
+}
+
 /// Edit: applies onto a present target; onto a concurrently-deleted target the
 /// edit **resurrects** it from the local overlay view (edit wins in both
 /// directions). A target absent from both is a dead-letter.
@@ -381,10 +463,11 @@ fn rebase_update_content(working: &mut Snapshot, local: &Snapshot, op: &Op) -> O
             // Re-link under the freed name only if it is still free: a concurrent
             // sibling may have taken it, so route through the one collision
             // resolver every other insert uses.
-            let (effective, suffixed) = match resolve_name(working, parent, &meta.name, op.target) {
-                Some(resolved) => resolved,
-                None => return OpResolution::DeadLetter(DeadLetterReason::SuffixExhausted),
-            };
+            let (effective, suffixed) =
+                match resolve_name(working, parent, &meta.name, &[op.target]) {
+                    Some(resolved) => resolved,
+                    None => return OpResolution::DeadLetter(DeadLetterReason::SuffixExhausted),
+                };
             let mut resurrected = meta.clone();
             resurrected.name = effective.clone();
             resurrected.content_version = resurrected.content_version.map(|count| count + 1);
@@ -407,14 +490,14 @@ fn resolve_name(
     snap: &Snapshot,
     parent: crate::facade::NodeId,
     name: &str,
-    exclude: crate::facade::NodeId,
+    exclude: &[crate::facade::NodeId],
 ) -> Option<(String, bool)> {
     // Fold the sibling collation keys once instead of rescanning the children on
     // every probe — identical to `name_taken`, which folds the same set.
     let taken: HashSet<String> = snap
         .children(parent)
         .into_iter()
-        .filter(|child| child.id != exclude)
+        .filter(|child| !exclude.contains(&child.id))
         .map(|child| collation_key(&child.name))
         .collect();
     if !taken.contains(&collation_key(name)) {
@@ -807,6 +890,154 @@ mod tests {
             },
             "the trigger is queued; no rotation happens in this slice"
         );
+    }
+
+    /// The `(base, local)` pair for a move over `dir`/`f` plus an occupied
+    /// destination name, with the replaced node at `sequence`.
+    fn replace_tree(replaced_sequence: u64) -> Snapshot {
+        let mut base = tree();
+        with_node(&mut base, id(0), id(1), "dir", NodeKind::Folder);
+        with_node(&mut base, id(0), id(2), "f.txt", NodeKind::File);
+        with_node(&mut base, id(1), id(3), "target.txt", NodeKind::File);
+        base.node_mut(id(3)).unwrap().record_sequence = replaced_sequence;
+        base
+    }
+
+    fn replacing(sequence: u64) -> Option<Replaced> {
+        Some(Replaced {
+            node: id(3),
+            sequence,
+        })
+    }
+
+    #[test]
+    fn a_move_that_replaces_lands_under_the_entered_name() {
+        let mut base = replace_tree(1);
+        let local = base.clone();
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::move_node(id(2), id(0), id(1), "target.txt", replacing(1), 1, AT),
+        );
+        assert_eq!(
+            res,
+            OpResolution::Applied {
+                effective_name: Some("target.txt".to_owned()),
+                suffixed: false,
+                scope_exit_trigger: None,
+            },
+            "vacating the destination first is what keeps the entered name"
+        );
+        assert!(!base.contains(id(3)), "the replaced node is gone");
+        assert_eq!(base.parent_of(id(2)), Some(id(1)));
+        assert_eq!(base.node(id(2)).unwrap().name, "target.txt");
+        assert!(base.children(id(0)).iter().all(|c| c.id != id(2)));
+    }
+
+    #[test]
+    fn a_move_auto_suffixes_when_a_concurrent_edit_saves_the_node_it_would_replace() {
+        // Conditional delete in both directions: the edit keeps the destination
+        // and the mover lands beside it rather than over it.
+        let mut base = replace_tree(9);
+        let local = base.clone();
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::move_node(id(2), id(0), id(1), "target.txt", replacing(1), 1, AT),
+        );
+        assert_eq!(
+            res,
+            OpResolution::Applied {
+                effective_name: Some("target (2).txt".to_owned()),
+                suffixed: true,
+                scope_exit_trigger: None,
+            }
+        );
+        assert!(base.contains(id(3)), "the edited node survives");
+        assert_eq!(base.node(id(2)).unwrap().name, "target (2).txt");
+    }
+
+    #[test]
+    fn a_move_renames_in_place_without_disturbing_the_link() {
+        let mut base = replace_tree(1);
+        let counter_before = base.winning_link(id(2)).unwrap().link_counter;
+        let local = base.clone();
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::move_node(id(2), id(0), id(0), "g.txt", None, 1, AT),
+        );
+        assert!(matches!(
+            res,
+            OpResolution::Applied {
+                suffixed: false,
+                ..
+            }
+        ));
+        assert_eq!(base.node(id(2)).unwrap().name, "g.txt");
+        assert_eq!(base.parent_of(id(2)), Some(id(0)));
+        assert_eq!(
+            base.winning_link(id(2)).unwrap().link_counter,
+            counter_before,
+            "a rename in place is not a relink"
+        );
+    }
+
+    #[test]
+    fn a_move_whose_child_a_concurrent_move_took_loses_the_race_untouched() {
+        let mut base = replace_tree(1);
+        with_node(&mut base, id(0), id(4), "elsewhere", NodeKind::Folder);
+        base.unlink(id(0), id(2));
+        base.link(id(4), id(2), 2);
+        let local = base.clone();
+
+        let before = base.clone();
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::move_node(id(2), id(0), id(1), "target.txt", replacing(1), 1, AT),
+        );
+        assert_eq!(res, OpResolution::Dropped(DropReason::MoveRaceLost));
+        assert_eq!(
+            base, before,
+            "a dropped move must not have vacated the destination"
+        );
+    }
+
+    #[test]
+    fn a_move_dead_letters_rather_than_vacating_a_destination_it_cannot_reach() {
+        let base = replace_tree(1);
+        let cases = [
+            (id(9), id(2), DeadLetterReason::DestinationGone),
+            (id(1), id(9), DeadLetterReason::TargetGone),
+        ];
+        for (dest, target, reason) in cases {
+            let mut working = base.clone();
+            let res = rebase_one(
+                &mut working,
+                &base,
+                &Op::move_node(target, id(0), dest, "target.txt", replacing(1), 1, AT),
+            );
+            assert_eq!(res, OpResolution::DeadLetter(reason));
+            assert_eq!(working, base, "a dead letter changes nothing");
+        }
+    }
+
+    #[test]
+    fn a_move_already_landed_drops_as_satisfied() {
+        let mut base = replace_tree(1);
+        base.remove_node(id(3));
+        base.unlink(id(0), id(2));
+        base.link(id(1), id(2), 2);
+        base.node_mut(id(2)).unwrap().name = "target.txt".into();
+        let local = base.clone();
+
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::move_node(id(2), id(0), id(1), "target.txt", replacing(1), 1, AT),
+        );
+        assert_eq!(res, OpResolution::Dropped(DropReason::AlreadySatisfied));
     }
 
     #[test]

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -407,20 +407,31 @@ fn rebase_move(
         return OpResolution::Dropped(DropReason::MoveRaceLost);
     }
 
+    // The destination node this move may free — and it may free it only while
+    // it is still the one holding the contested name. A node a concurrent
+    // writer renamed or moved away is a bystander: the name is free and the
+    // move simply takes it. Anchoring on the sequence alone would not see that,
+    // because a name lives in the parent's child ref and renaming a node never
+    // advances the node's own record sequence.
+    let vacating = replacing.filter(|replaced| {
+        working.parent_of(replaced.node) == Some(new_parent)
+            && working
+                .node(replaced.node)
+                .is_some_and(|node| collation_key(&node.name) == collation_key(new_name))
+            // Conditional delete: a concurrent edit that advanced it wins.
+            && working
+                .record_sequence(replaced.node)
+                .is_some_and(|current| current <= replaced.sequence)
+    });
+
     // Already where it was going, under the name it was going to take, with
     // nothing left at the destination to vacate.
-    if replacing.is_none_or(|replaced| !working.contains(replaced.node))
+    if vacating.is_none()
         && current_parent == Some(new_parent)
         && working.node(op.target).is_some_and(|n| n.name == new_name)
     {
         return OpResolution::Dropped(DropReason::AlreadySatisfied);
     }
-
-    let vacating = replacing.filter(|replaced| {
-        working
-            .record_sequence(replaced.node)
-            .is_some_and(|current| current <= replaced.sequence)
-    });
 
     // Resolved before any mutation: an exhausted probe dead-letters, and a
     // dead-lettered op must leave the working base as it found it.
@@ -959,6 +970,59 @@ mod tests {
         );
         assert!(base.contains(id(3)), "the edited node survives");
         assert_eq!(base.node(id(2)).unwrap().name, "target (2).txt");
+    }
+
+    #[test]
+    fn a_move_spares_a_node_a_concurrent_writer_renamed_out_of_its_way() {
+        // A name lives in the parent's child ref, so renaming a node never
+        // advances the node's own sequence — the conditional-delete anchor
+        // alone would see this as "unchanged" and destroy a bystander.
+        let mut base = replace_tree(1);
+        base.node_mut(id(3)).unwrap().name = "keep.txt".into();
+        let local = base.clone();
+
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::move_node(id(2), id(0), id(1), "target.txt", replacing(1), 1, AT),
+        );
+        assert_eq!(
+            res,
+            OpResolution::Applied {
+                effective_name: Some("target.txt".to_owned()),
+                suffixed: false,
+                scope_exit_trigger: None,
+            },
+            "the contested name is free, so the move just takes it"
+        );
+        assert!(base.contains(id(3)), "the renamed bystander survives");
+        assert_eq!(base.node(id(3)).unwrap().name, "keep.txt");
+    }
+
+    #[test]
+    fn a_move_spares_a_node_a_concurrent_writer_moved_out_of_its_way() {
+        let mut base = replace_tree(1);
+        base.unlink(id(1), id(3));
+        base.link(id(0), id(3), 2);
+        let local = base.clone();
+
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::move_node(id(2), id(0), id(1), "target.txt", replacing(1), 1, AT),
+        );
+        assert!(matches!(
+            res,
+            OpResolution::Applied {
+                suffixed: false,
+                ..
+            }
+        ));
+        assert_eq!(
+            base.parent_of(id(3)),
+            Some(id(0)),
+            "the relocated bystander is untouched where it now lives"
+        );
     }
 
     #[test]

--- a/crates/engine/src/testkit/fakes/staging_store.rs
+++ b/crates/engine/src/testkit/fakes/staging_store.rs
@@ -11,6 +11,7 @@ struct Inner {
     staged: BTreeMap<Vec<u8>, Vec<u8>>,
     fail_queued_ops: bool,
     fail_remove_op: bool,
+    enqueue_budget: Option<u64>,
 }
 
 impl Default for Inner {
@@ -21,6 +22,7 @@ impl Default for Inner {
             staged: BTreeMap::new(),
             fail_queued_ops: false,
             fail_remove_op: false,
+            enqueue_budget: None,
         }
     }
 }
@@ -45,11 +47,23 @@ impl InMemoryStagingStore {
     pub fn fail_remove_op(&self) {
         self.inner.lock().expect("lock").fail_remove_op = true;
     }
+
+    /// Lets the next `budget` enqueues through and fails every one after, so a
+    /// test can drop a durable-queue outage in the middle of a multi-op
+    /// sequence and see what the earlier entries already committed.
+    pub fn fail_enqueue_after(&self, budget: u64) {
+        self.inner.lock().expect("lock").enqueue_budget = Some(budget);
+    }
 }
 
 impl StagingStore for InMemoryStagingStore {
     async fn enqueue_op(&self, op: &[u8]) -> SeamResult<OpId> {
         let mut inner = self.inner.lock().expect("lock");
+        match inner.enqueue_budget {
+            Some(0) => return Err(SeamError::new("enqueue_op unavailable")),
+            Some(budget) => inner.enqueue_budget = Some(budget - 1),
+            None => {}
+        }
         let op_id = OpId(inner.next_op_id);
         inner.next_op_id += 1;
         inner.ops.push((op_id, op.to_vec()));

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -882,6 +882,112 @@ fn a_relink_publishes_the_dest_before_the_source_and_a_second_device_resolves_it
     assert_eq!(names, ["photos"], "device B resolves the source-remove");
 }
 
+/// A replacing rename in place: the vacated ref and the moved one land in a
+/// **single** destination record, so no observer sees the destination name
+/// unresolvable (#884).
+#[test]
+fn a_replacing_rename_lands_the_vacated_and_moved_refs_in_one_record() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    for name in ["new.txt", "target.txt"] {
+        block_on(engine.command(Command::Create {
+            parent: ROOT,
+            name: name.into(),
+            kind: NodeKind::File,
+            content: None,
+        }))
+        .unwrap();
+    }
+    tick(&world, &engine, &mut tasks);
+    let source = child_id(&engine, ROOT, "new.txt");
+    let replaced = child_id(&engine, ROOT, "target.txt");
+    let (root_sequence, _) = published(&world.record_store, ROOT);
+
+    block_on(engine.command(Command::Move {
+        node: source,
+        new_parent: ROOT,
+        new_name: "target.txt".into(),
+        replacing: Some(replaced),
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    let children = published_children(&world.record_store, &blocks, ROOT);
+    assert_eq!(children.len(), 1);
+    assert_eq!(children[0].name, "target.txt");
+    assert_eq!(
+        children[0].id, source.0,
+        "the surviving entry is the moved node, not the one it replaced"
+    );
+    assert_eq!(
+        published(&world.record_store, ROOT).0,
+        root_sequence + 1,
+        "one record carries the whole replace"
+    );
+    assert!(
+        block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .is_empty(),
+        "the move drained"
+    );
+
+    let bob = world.device(b"alice-second-device");
+    let (engine_b, _events_b, _tasks_b) = boot(&world, &blocks, &bob, 7);
+    let seen = block_on(engine_b.view()).unwrap().children(ROOT);
+    assert_eq!(seen.len(), 1);
+    assert_eq!(seen[0].id, source, "device B resolves the replace");
+}
+
+/// A move across folders keeps the relink's dest-first ordering while the
+/// destination's replace rides the same record as the dest-add.
+#[test]
+fn a_cross_folder_move_that_replaces_publishes_the_dest_before_the_source() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let (photos, moved) = seed_folder_and_file(&world, &mut engine, &mut tasks);
+    block_on(engine.command(Command::Create {
+        parent: photos,
+        name: "a.txt".into(),
+        kind: NodeKind::File,
+        content: None,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+    let replaced = child_id(&engine, photos, "a.txt");
+    let before = uploaded_node_ids(&alice).len();
+
+    block_on(engine.command(Command::Move {
+        node: moved,
+        new_parent: photos,
+        new_name: "a.txt".into(),
+        replacing: Some(replaced),
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    let children = published_children(&world.record_store, &blocks, photos);
+    assert_eq!(children.len(), 1);
+    assert_eq!(children[0].name, "a.txt");
+    assert_eq!(children[0].id, moved.0);
+    assert_eq!(
+        published_names(&world.record_store, &blocks, ROOT),
+        ["photos"]
+    );
+    assert_eq!(
+        uploaded_node_ids(&alice)[before..],
+        [photos.0, ROOT.0],
+        "dest-add published before the source-remove"
+    );
+}
+
 /// `updateContent`'s metadata half: a file's own record carries its
 /// `modifiedAt`, and its parent holds no size/mtime mirror to republish. The
 /// facade cannot form this op until the content slice (#868), so it is staged
@@ -1091,6 +1197,60 @@ fn a_source_remove_that_cannot_publish_undoes_its_own_dest_add() {
     assert!(
         published_children(&world.record_store, &blocks, photos).is_empty(),
         "the dest-add was compensated, not left as a dual link"
+    );
+    assert_eq!(
+        published_names(&world.record_store, &blocks, ROOT),
+        ["a.txt", "photos"],
+        "the source kept the child it could not release"
+    );
+    assert_eq!(
+        block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .len(),
+        1,
+        "the halted op stays queued for the next tick"
+    );
+}
+
+/// The compensation must restore what the dest-add vacated too: a destination
+/// left holding neither the moved node nor the one it replaced has lost an
+/// entry outright (#884).
+#[test]
+fn a_compensated_move_restores_the_ref_its_dest_add_replaced() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let (photos, moved) = seed_folder_and_file(&world, &mut engine, &mut tasks);
+    block_on(engine.command(Command::Create {
+        parent: photos,
+        name: "a.txt".into(),
+        kind: NodeKind::File,
+        content: None,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+    let replaced = child_id(&engine, photos, "a.txt");
+
+    blocks.refuse_upload(Box::new(|block| {
+        (head_of(block) == Some(ROOT.0)).then(unreachable_upload)
+    }));
+    block_on(engine.command(Command::Move {
+        node: moved,
+        new_parent: photos,
+        new_name: "a.txt".into(),
+        replacing: Some(replaced),
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    let children = published_children(&world.record_store, &blocks, photos);
+    assert_eq!(children.len(), 1);
+    assert_eq!(
+        children[0].id, replaced.0,
+        "the node the move never replaced is back where it was"
     );
     assert_eq!(
         published_names(&world.record_store, &blocks, ROOT),

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -1266,6 +1266,61 @@ fn a_compensated_move_restores_the_ref_its_dest_add_replaced() {
     );
 }
 
+/// The compensation's restore is an inverse of **our own** edit, so it may only
+/// run while our bytes are still the destination head. A winner that built on
+/// the listing our dest-add published must not have the vacated ref re-asserted
+/// over it (#786's rule, extended to the replace).
+#[test]
+fn a_compensated_move_does_not_resurrect_a_replaced_ref_over_a_concurrent_winner() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let (photos, moved) = seed_folder_and_file(&world, &mut engine, &mut tasks);
+    block_on(engine.command(Command::Create {
+        parent: photos,
+        name: "a.txt".into(),
+        kind: NodeKind::File,
+        content: None,
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+    let replaced = child_id(&engine, photos, "a.txt");
+
+    let winner = file_ref([0xAA; 16], "winner.txt");
+    let records = world.record_store.clone();
+    let plane = blocks.clone();
+    blocks.refuse_upload(Box::new(move |block| {
+        if head_of(block) != Some(ROOT.0) {
+            return None;
+        }
+        // The instant our source-remove fails, another writer advances the dest.
+        concurrent_add(&records, &plane, photos, winner.clone());
+        Some(unreachable_upload())
+    }));
+    block_on(engine.command(Command::Move {
+        node: moved,
+        new_parent: photos,
+        new_name: "a.txt".into(),
+        replacing: Some(replaced),
+    }))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(
+        published_names(&world.record_store, &blocks, photos),
+        ["winner.txt"],
+        "our dest-add was undone without re-asserting the ref we vacated"
+    );
+    assert_eq!(
+        published_names(&world.record_store, &blocks, ROOT),
+        ["a.txt", "photos"],
+        "the source kept the child it could not release"
+    );
+}
+
 /// The adversarial interleave at the compensation seam: a concurrent writer
 /// lands a strictly-newer dest record between the dest-add and its undo. The
 /// versioned compare-and-remove refuses to replay a stale copy over the winner

--- a/crates/fuse/src/ops.rs
+++ b/crates/fuse/src/ops.rs
@@ -164,17 +164,14 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
             .filter(|dest| dest.id != source.id);
         if let Some(dest) = &replaced {
             removable(&view, dest, source.kind)?;
+            // The replaced node's own unlink rides the move op; only the hidden
+            // junk it may still hold needs deletes of its own.
+            self.delete_descendants(&view, dest.id).await?;
         }
-
-        // The replaced node's own unlink rides the move op. Only descendants
-        // the mount hides need their own deletes, and a listing the user cannot
-        // see is not one POSIX promises to keep.
-        if let Some(dest) = &replaced {
-            for node in subtree(&view, dest.id) {
-                if node != dest.id {
-                    self.command(Command::Delete { node }).await?;
-                }
-            }
+        // POSIX renaming a node onto itself changes nothing, so it journals
+        // nothing.
+        if replaced.is_none() && new_parent_node == parent_node && source.name == new_name {
+            return Ok(());
         }
         self.command(Command::Move {
             node: source.id,
@@ -322,7 +319,21 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
     /// node, so the sweep has to reach them or they outlive the mount point
     /// they hung from.
     async fn delete(&mut self, view: &EngineView, victim: NodeId) -> Result<(), VfsError> {
-        for node in subtree(view, victim) {
+        self.delete_descendants(view, victim).await?;
+        self.command(Command::Delete { node: victim }).await
+    }
+
+    /// The [`delete`](Self::delete) sweep without the node itself, for a caller
+    /// that unlinks the root of the subtree by other means.
+    async fn delete_descendants(
+        &mut self,
+        view: &EngineView,
+        root: NodeId,
+    ) -> Result<(), VfsError> {
+        let mut order = subtree(view, root);
+        // `subtree` is deepest-first, so the root is the last entry.
+        order.pop();
+        for node in order {
             self.command(Command::Delete { node }).await?;
         }
         Ok(())

--- a/crates/fuse/src/ops.rs
+++ b/crates/fuse/src/ops.rs
@@ -166,25 +166,23 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
             removable(&view, dest, source.kind)?;
         }
 
-        // The facade has no combined move-and-rename op, so a rename that
-        // replaces has a window where the destination is already gone (#884).
-        if let Some(dest) = replaced {
-            self.delete(&view, dest.id).await?;
+        // The replaced node's own unlink rides the move op. Only descendants
+        // the mount hides need their own deletes, and a listing the user cannot
+        // see is not one POSIX promises to keep.
+        if let Some(dest) = &replaced {
+            for node in subtree(&view, dest.id) {
+                if node != dest.id {
+                    self.command(Command::Delete { node }).await?;
+                }
+            }
         }
-        if new_parent_node != parent_node {
-            self.command(Command::Relink {
-                node: source.id,
-                new_parent: new_parent_node,
-            })
-            .await?;
-        }
-        if source.name != new_name {
-            self.command(Command::Rename {
-                node: source.id,
-                new_name: new_name.to_owned(),
-            })
-            .await?;
-        }
+        self.command(Command::Move {
+            node: source.id,
+            new_parent: new_parent_node,
+            new_name: new_name.to_owned(),
+            replacing: replaced.map(|dest| dest.id),
+        })
+        .await?;
 
         let ino = self.inodes.ino_for(source.id);
         self.entry_changed(parent, name);

--- a/crates/fuse/tests/fuse_op_core.rs
+++ b/crates/fuse/tests/fuse_op_core.rs
@@ -10,6 +10,7 @@ use std::future::Future;
 use std::rc::Rc;
 use std::task::{Context, Poll, Waker};
 
+use cipherbox_engine::testkit::fakes::InMemoryStagingStore;
 use cipherbox_engine::testkit::{FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
 use cipherbox_engine::{
     Command, Engine, GatewayConfig, LoginSecret, NodeId, NodeKind, StoragePolicy, SyncTimingProfile,
@@ -64,8 +65,16 @@ fn mount_with(adapter: RecordingAdapter) -> Core {
 
 /// A started engine over fresh in-memory seams, with its rendered root id.
 fn started_engine() -> (Engine<FakeSeamTypes>, NodeId) {
+    let (engine, root, _staging) = started_engine_with_staging();
+    (engine, root)
+}
+
+/// A started engine plus a handle on its durable op queue, for tests that
+/// inject a staging outage.
+fn started_engine_with_staging() -> (Engine<FakeSeamTypes>, NodeId, InMemoryStagingStore) {
     let world = FakeWorld::new();
     let device = world.device(b"alice-pk");
+    let staging = device.staging_store.clone();
     let (mut engine, _events) = Engine::new(
         device.seam_set(),
         Box::new(SeededEntropy::new(42)),
@@ -76,7 +85,7 @@ fn started_engine() -> (Engine<FakeSeamTypes>, NodeId) {
     );
     block_on(engine.start(LoginSecret::new(vec![7u8; 32]))).expect("engine starts");
     let root = block_on(engine.view()).expect("view").root();
-    (engine, root)
+    (engine, root, staging)
 }
 
 /// Seed a child by issuing a facade command directly, which is how a name the
@@ -346,6 +355,43 @@ fn rename_over_an_existing_file_replaces_it() {
         source.ino,
         "the surviving entry is the source node, not the replaced one"
     );
+}
+
+#[test]
+fn a_durable_queue_outage_never_destroys_the_destination_a_rename_did_not_replace() {
+    // POSIX: an observer always sees either the old destination or the new one.
+    // A rename that replaces is one journal entry, so a queue that accepts only
+    // one more write either takes the whole rename or none of it — never the
+    // destination's removal while the source stays put (#884).
+    for budget in [0, 1] {
+        let (mut engine, root, staging) = started_engine_with_staging();
+        let source = seed_child(&mut engine, root, "new.txt", NodeKind::File);
+        let victim = seed_child(&mut engine, root, "target.txt", NodeKind::File);
+        let mut core = OperationCore::new(engine, RecordingAdapter::push_capable());
+        staging.fail_enqueue_after(budget);
+
+        let outcome = block_on(core.rename(ROOT_INO, "new.txt", ROOT_INO, "target.txt"));
+
+        let survivor = block_on(core.lookup(ROOT_INO, "target.txt"))
+            .unwrap_or_else(|_| panic!("budget {budget}: the destination name vanished"))
+            .node;
+        match outcome {
+            Ok(()) => {
+                assert_eq!(names(&mut core, ROOT_INO), vec!["target.txt".to_owned()]);
+                assert_eq!(survivor, source, "the replace completed");
+            }
+            Err(_) => {
+                let mut listed = names(&mut core, ROOT_INO);
+                listed.sort();
+                assert_eq!(
+                    listed,
+                    vec!["new.txt".to_owned(), "target.txt".to_owned()],
+                    "budget {budget}: a refused rename left something half-done"
+                );
+                assert_eq!(survivor, victim);
+            }
+        }
+    }
 }
 
 #[test]

--- a/crates/fuse/tests/fuse_op_core.rs
+++ b/crates/fuse/tests/fuse_op_core.rs
@@ -372,26 +372,59 @@ fn a_durable_queue_outage_never_destroys_the_destination_a_rename_did_not_replac
 
         let outcome = block_on(core.rename(ROOT_INO, "new.txt", ROOT_INO, "target.txt"));
 
+        // The destination name resolves either way: to the moved node when the
+        // rename landed, to the node it would have replaced when it did not.
         let survivor = block_on(core.lookup(ROOT_INO, "target.txt"))
             .unwrap_or_else(|_| panic!("budget {budget}: the destination name vanished"))
             .node;
-        match outcome {
-            Ok(()) => {
-                assert_eq!(names(&mut core, ROOT_INO), vec!["target.txt".to_owned()]);
-                assert_eq!(survivor, source, "the replace completed");
-            }
-            Err(_) => {
-                let mut listed = names(&mut core, ROOT_INO);
-                listed.sort();
-                assert_eq!(
-                    listed,
-                    vec!["new.txt".to_owned(), "target.txt".to_owned()],
-                    "budget {budget}: a refused rename left something half-done"
-                );
-                assert_eq!(survivor, victim);
-            }
-        }
+        let landed = outcome.is_ok();
+        assert_eq!(survivor, if landed { source } else { victim });
+        assert_eq!(
+            names(&mut core, ROOT_INO).len(),
+            if landed { 1 } else { 2 },
+            "budget {budget}: a refused rename left something half-done"
+        );
     }
+}
+
+#[test]
+fn renaming_a_node_onto_itself_journals_nothing() {
+    // POSIX `rename(a, a)` succeeds and changes nothing, so it must not spend a
+    // journal entry — proven by refusing every durable write.
+    let (mut engine, root, staging) = started_engine_with_staging();
+    seed_child(&mut engine, root, "f.txt", NodeKind::File);
+    let mut core = OperationCore::new(engine, RecordingAdapter::push_capable());
+    staging.fail_enqueue_after(0);
+
+    block_on(core.rename(ROOT_INO, "f.txt", ROOT_INO, "f.txt")).expect("a no-op rename succeeds");
+    assert_eq!(names(&mut core, ROOT_INO), vec!["f.txt".to_owned()]);
+}
+
+#[test]
+fn replacing_a_junk_holding_folder_keeps_the_destination_entry_when_the_queue_fails() {
+    // The replaced folder's own unlink rides the move, but the hidden junk it
+    // holds still needs deletes of its own. A queue that dies between them may
+    // lose junk the user could never see — never the destination entry itself.
+    let (mut engine, root, staging) = started_engine_with_staging();
+    let source = seed_child(&mut engine, root, "dir", NodeKind::Folder);
+    let victim = seed_child(&mut engine, root, "target", NodeKind::Folder);
+    seed_child(&mut engine, victim, ".DS_Store", NodeKind::File);
+    let mut core = OperationCore::new(engine, RecordingAdapter::push_capable());
+    // The junk delete lands; the move that would unlink the folder does not.
+    staging.fail_enqueue_after(1);
+
+    block_on(core.rename(ROOT_INO, "dir", ROOT_INO, "target")).expect_err("the move is refused");
+
+    assert_eq!(
+        block_on(core.lookup(ROOT_INO, "target")).unwrap().node,
+        victim,
+        "the destination entry POSIX promises survives"
+    );
+    assert_eq!(
+        block_on(core.lookup(ROOT_INO, "dir")).unwrap().node,
+        source,
+        "and the source never moved"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #884
Part of #655

## Problem

`blueprint/desktop.md` says a kernel rename becomes exactly one facade intent op. It did not: the facade had no combined move-and-rename command, so `crates/fuse`'s `OperationCore::rename` spelled one kernel rename as up to three separately-staged ops — `Delete` the destination, `Relink`, `Rename` — with a `?` between each. The destructive one ran first and had to (the engine auto-suffixes name collisions on rebase, so relinking before vacating the destination lands `target (2).txt` instead of a replace).

If `Delete` succeeded and a later op failed, the call returned `Err` and the caller believed nothing happened — but the destination was permanently gone and the source never moved. POSIX guarantees an observer always sees either the old or the new destination.

## Fix

`Command::Move { node, new_parent, new_name, replacing }` → `OpKind::Move { from_parent, new_parent, new_name, replacing }`, staged as **one** durable op-queue entry. `OperationCore::rename` collapses onto it and the three-op sequence is gone. The invalidation pushes stay after the single `?`, which is now correct by construction: there is no partial-failure state for a cached positive dentry to survive into.

`replacing` carries a `Replaced { node, sequence }` — the facade snapshots the replaced node's own record sequence, the same anchor `Delete` uses.

### Rebase rule

`rebase_move` runs the relink rule's races first, then the rename rule's collision resolution, over a destination it vacates first:

1. `TargetGone` / `DestinationGone` / `DestinationInsideTarget` dead-letter — one `relocation_guards` shared with `rebase_relink`.
2. A current parent that is neither `from_parent` nor `new_parent` is `MoveRaceLost`.
3. The move vacates the destination node only while that node is **still the one holding the contested name**: same parent, name collates equal, and not advanced past the conditional-delete anchor. A node a concurrent writer renamed or moved away is a bystander — the name is free and the move simply takes it. A move never replaces its own target.
4. Already at the destination under the entered name with nothing to vacate is `AlreadySatisfied`.
5. `resolve_name` runs with both the target and the node being vacated excluded — which is what makes a replace land under the entered name instead of `target (2).txt`. It resolves **before** any mutation, so a `SuffixExhausted` dead-letter leaves the working base as it found it. Its `exclude` parameter became a slice to carry the second exclusion.

### Publish plan

Rename, relink, and move now share one plan, `publish_ref_move`, driven by a `MovePlan`. It keeps the reference-ordering law: dest-add before source-remove, and when source and destination are the same folder the vacated ref and the moved ref land in a **single** record — so a replacing rename in place is one publish and the destination name is never observably unresolvable. The one destructive step re-checks, against the record the gate just handed it, that the ref it drops still holds the name the move is taking.

`compensate_dest_add` takes a `DestAdd` and restores the ref the dest-add vacated — but only in the versioned-safe branch, where the observed sequence proves our own bytes are still the head and the undo is an exact inverse of our own edit. On a `Conflict` it subtracts our add and stops, since a winner has already built on the listing we published.

## Tests

- `crates/fuse`: a durable-queue outage never destroys the destination a rename did not replace, at journal budgets 0 and 1 — verified red against the pre-change three-op sequence (`budget 1: the destination name vanished`). Plus: `rename(a, a)` journals nothing, and a replaced junk-holding folder keeps its destination entry through a mid-sweep outage.
- `crates/engine` rebase: replace lands under the entered name; a concurrent edit that saves the replaced node forces the auto-suffix; a bystander renamed **or** moved out of the way survives (both verified red without the guard); a self-replacing move keeps its target; rename in place does not churn the link counter; the race loser and both dead-letter reasons leave the working base untouched.
- `crates/engine` overlay: one `Move` relinks, renames and replaces in one step, and keeps a target named as its own replaced node.
- `crates/engine` write-plane (drain, end to end): a replacing rename lands the vacated and moved refs in one record and a second device resolves it; a cross-folder replacing move still publishes dest before source; a compensated move restores the ref its dest-add replaced (verified red without the restore) and does **not** resurrect it over a concurrent winner.

`cargo fmt --all`, `cargo clippy --workspace --all-targets` (zero warnings), and `cargo test --workspace` (31 suites) are green, plus `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` since the `Command` enum changed.

## Review gates

All three ran on `git diff main...HEAD`; findings are folded in as the three follow-up commits.

- `/simplify` — `publish_move` duplicated ~85% of `publish_relink`, and the rebase and overlay arms restated the relink+rename bodies. Now one `MovePlan`/`publish_ref_move`, one `relocation_guards`, one overlay `relocate`, one `relocation_anchors` in the facade, and a shared `delete_descendants` in the fuse crate. Also caught a real regression: the collapsed `rename` was staging an op for a no-op `rename(a, a)`.
- `/security-review` — found the vacate was anchored on the replaced node's record sequence alone. A name lives in the parent's child ref, so renaming a node never advances that node's own sequence; a concurrently-renamed destination read as unchanged and the bystander was unlinked. Fixed in the rebase and re-checked in the drain.
- `/crypto-privacy-review` — found the self-replace hole (`replacing == node` erased the target, dead-lettering every later op on it) and the compensation's additive undo replaying over a `Conflict` winner. Both fixed. No new crypto surface: the diff adds no `kdf::*`/`seal_*`/entropy/signer calls, every record still reaches the plane through the unchanged `publish_node` chain with one fresh injected nonce per seal, and no filename, node id, or sequence reaches an error, event, or log.

## Notes for review

- Expect a rebase on `main` before merge: #867 lands in `drain.rs`, `facade.rs`, and `api/client.rs`. This PR adds a publish path rather than restructuring `Halt`, the `pass`/`run` loop, or the attempt-budget surface.
- No failure-policy behaviour here. `publish_ref_move` fails with the same bare `Halt` every other plan uses, so #867's classification applies to it unchanged with no new seam.
- Cross-scope move stays out: `OpKind::Move` carries no `cross_scope`/`exits_granted_source`, exactly as the facade stages `Relink` today. That is #635's. A cross-scope destination cannot produce a mis-keyed record — `ensure_folder` requires the chain to reach the scope root, so it halts.
- `Command::Rename` and `Command::Relink` stay — the web client drives them as separate user actions — but they no longer have publish plans of their own.
- Residual, deliberately not closed here: when the destination is a folder holding hidden platform junk, those descendants still get their own deletes before the move, and the engine may then decline to vacate the destination (conditional delete, or a bystander). The POSIX-visible entry always survives — only junk the mount hides can be lost. Covered by `replacing_a_junk_holding_folder_keeps_the_destination_entry_when_the_queue_fails`.
- One markdown line in `blueprint/engine.md` changed emphasis style on an untouched line: the file was previously outside lint-staged's reach, and both prettier and markdownlint demand it the moment the file is edited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified move operations that combine relinking, renaming, and optional destination replacement in one step.
  * Publishing updates ensure replacement moves appear atomically and preserve moved node identity.

* **Bug Fixes**
  * Improved rename/move compensation so vacated destination entries are restored correctly without resurrecting replaced refs after concurrent winners.
  * Added safer handling for self-renames and durable-queue interruption scenarios to keep directory entries consistent.

* **Documentation**
  * Updated engine blueprint documentation to reflect the unified move model.

* **Tests**
  * Expanded write-plane and failure-mode tests covering atomic publishing, replacement semantics, and compensation correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->