### PR TITLE
fix(core): size the encode_map_partial buffer up front

### DIFF
--- a/crates/core/src/codec/encode.rs
+++ b/crates/core/src/codec/encode.rs
@@ -54,7 +54,7 @@ pub fn encoded_len(value: &Value) -> Result<usize, CodecError> {
     Ok(len)
 }
 
-fn count_value(len: &mut usize, value: &Value, depth: usize) -> Result<(), CodecError> {
+pub(super) fn count_value(len: &mut usize, value: &Value, depth: usize) -> Result<(), CodecError> {
     check_depth(depth, *len)?;
     match value {
         Value::Unsigned(n) | Value::Negative(n) => *len += head_len(*n),
@@ -89,12 +89,12 @@ fn check_depth(depth: usize, offset: usize) -> Result<(), CodecError> {
 }
 
 /// The byte length of a text item: its head plus its UTF-8 bytes.
-fn text_len(t: &str) -> usize {
+pub(super) fn text_len(t: &str) -> usize {
     head_len(t.len() as u64) + t.len()
 }
 
 /// The byte length of a shortest-form head for `arg` (mirrors [`write_head`]).
-fn head_len(arg: u64) -> usize {
+pub(super) fn head_len(arg: u64) -> usize {
     match arg {
         0..=23 => 1,
         24..=0xff => 2,

--- a/crates/core/src/codec/fields.rs
+++ b/crates/core/src/codec/fields.rs
@@ -217,19 +217,34 @@ mod tests {
 
     /// AGENTS.md rule 8: the merged encoder's `depth-exceeded` reject is
     /// release-active, and now fires from the sizing pass — before a byte is
-    /// allocated for the output.
+    /// allocated for the output. The deep value sits behind two preserved
+    /// unknowns, so its reported offset only matches the equivalent full-map
+    /// encode's if the sizing pass counted in emit order.
     #[test]
     fn merged_encode_rejects_past_max_depth() {
+        fn depth_offset(err: &CodecError) -> usize {
+            match err {
+                CodecError::Malformed(Malformed::DepthExceeded { offset }) => *offset,
+                other => panic!("expected depth-exceeded, got {}", other.check()),
+            }
+        }
+
         let original = encode(&Value::Map(sample_map())).unwrap();
         let (mut known, unknown) =
-            decode_map_partial(&original, known_key_set(&["v", "id"])).unwrap();
+            decode_map_partial(&original, known_key_set(&["v", "zz-later"])).unwrap();
         let mut deep = Value::Null;
         for _ in 0..crate::codec::MAX_DEPTH {
             deep = Value::Array(vec![deep]);
         }
-        known.insert("v", deep);
-        let err = encode_map_partial(&known, &unknown).unwrap_err();
-        assert_eq!(err.check(), "depth-exceeded");
+        known.insert("zz-later", deep.clone());
+        let mut full = sample_map();
+        full.insert("zz-later", deep);
+
+        assert_eq!(
+            depth_offset(&encode_map_partial(&known, &unknown).unwrap_err()),
+            depth_offset(&encode(&Value::Map(full)).unwrap_err()),
+            "merged reject offset diverged from the full-map encode"
+        );
     }
 
     #[test]

--- a/crates/core/src/codec/fields.rs
+++ b/crates/core/src/codec/fields.rs
@@ -12,7 +12,7 @@ use super::decode::Decoder;
 use super::encode::{
     MAJOR_MAP, count_value, head_len, text_len, write_head, write_text, write_value,
 };
-use super::value::{Map, canonical_key_cmp};
+use super::value::{Map, Value, canonical_key_cmp};
 use crate::error::{CodecError, Malformed};
 
 /// The depth a top-level map's values sit at: the map itself is the enclosing
@@ -84,9 +84,35 @@ pub fn decode_map_partial(
 /// emitted byte-stable. A key present on both sides is a caller bug and
 /// rejects fail-closed.
 pub fn encode_map_partial(known: &Map, unknown: &UnknownFields) -> Result<Vec<u8>, CodecError> {
-    let mut out = Vec::with_capacity(merged_len(known, unknown)?);
-    write_head(&mut out, MAJOR_MAP, (known.len() + unknown.len()) as u64);
+    let merged = merge(known, unknown)?;
+    let mut out = Vec::with_capacity(merged_len(&merged)?);
+    write_head(&mut out, MAJOR_MAP, merged.len() as u64);
+    for (key, value) in &merged {
+        write_text(&mut out, key);
+        match value {
+            MergedValue::Known(v) => write_value(&mut out, v, MAP_ENTRY_DEPTH)?,
+            MergedValue::Raw(raw) => out.extend_from_slice(raw),
+        }
+    }
+    Ok(out)
+}
 
+/// A merged entry's value: a re-built known value, or a preserved unknown
+/// value's raw canonical bytes.
+enum MergedValue<'a> {
+    Known(&'a Value),
+    Raw(&'a [u8]),
+}
+
+/// Interleave the two canonically-ordered sides into the emit sequence. Holds
+/// borrows only, so no secret bytes are copied into it. Walking the merge here
+/// rather than in each pass is what lets both rejects — collision and
+/// `depth-exceeded` — fire before the output buffer exists.
+fn merge<'a>(
+    known: &'a Map,
+    unknown: &'a UnknownFields,
+) -> Result<Vec<(&'a str, MergedValue<'a>)>, CodecError> {
+    let mut merged = Vec::with_capacity(known.len() + unknown.len());
     let mut k = known.entries().iter().peekable();
     let mut u = unknown.entries.iter().peekable();
     loop {
@@ -104,27 +130,26 @@ pub fn encode_map_partial(known: &Map, unknown: &UnknownFields) -> Result<Vec<u8
         };
         if take_known {
             let (key, value) = k.next().expect("peeked");
-            write_text(&mut out, key);
-            write_value(&mut out, value, MAP_ENTRY_DEPTH)?;
+            merged.push((key.as_str(), MergedValue::Known(value)));
         } else {
             let (key, raw) = u.next().expect("peeked");
-            write_text(&mut out, key);
-            out.extend_from_slice(raw);
+            merged.push((key.as_str(), MergedValue::Raw(raw)));
         }
     }
-    Ok(out)
+    Ok(merged)
 }
 
 /// The exact byte length of the merged map, sizing [`encode_map_partial`]'s one
 /// allocation for the realloc-hygiene reason [`super::encode::encode`] documents.
-fn merged_len(known: &Map, unknown: &UnknownFields) -> Result<usize, CodecError> {
-    let mut len = head_len((known.len() + unknown.len()) as u64);
-    for (key, value) in known.entries() {
+/// Counting in emit order keeps `depth-exceeded`'s reported offset exact.
+fn merged_len(merged: &[(&str, MergedValue<'_>)]) -> Result<usize, CodecError> {
+    let mut len = head_len(merged.len() as u64);
+    for (key, value) in merged {
         len += text_len(key);
-        count_value(&mut len, value, MAP_ENTRY_DEPTH)?;
-    }
-    for (key, raw) in &unknown.entries {
-        len += text_len(key) + raw.len();
+        match value {
+            MergedValue::Known(v) => count_value(&mut len, v, MAP_ENTRY_DEPTH)?,
+            MergedValue::Raw(raw) => len += raw.len(),
+        }
     }
     Ok(len)
 }
@@ -137,7 +162,7 @@ pub fn known_key_set(known: &'static [&'static str]) -> impl Fn(&str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::codec::{Value, decode, encode};
+    use crate::codec::{decode, encode};
 
     fn sample_map() -> Map {
         let mut m = Map::new();
@@ -179,11 +204,32 @@ mod tests {
         let out = encode_map_partial(&known, &unknown).unwrap();
         assert!(out.len() > 1024, "test payload must force multiple growths");
         assert_eq!(out, original, "wire bytes unchanged");
+        // Allocator-independent oracle, plus the witness that the reservation
+        // was the one the buffer kept.
+        let sized = merged_len(&merge(&known, &unknown).unwrap()).unwrap();
+        assert_eq!(sized, out.len(), "sizing oracle diverged");
         assert_eq!(
             out.capacity(),
             out.len(),
             "buffer was resized after its up-front reservation"
         );
+    }
+
+    /// AGENTS.md rule 8: the merged encoder's `depth-exceeded` reject is
+    /// release-active, and now fires from the sizing pass — before a byte is
+    /// allocated for the output.
+    #[test]
+    fn merged_encode_rejects_past_max_depth() {
+        let original = encode(&Value::Map(sample_map())).unwrap();
+        let (mut known, unknown) =
+            decode_map_partial(&original, known_key_set(&["v", "id"])).unwrap();
+        let mut deep = Value::Null;
+        for _ in 0..crate::codec::MAX_DEPTH {
+            deep = Value::Array(vec![deep]);
+        }
+        known.insert("v", deep);
+        let err = encode_map_partial(&known, &unknown).unwrap_err();
+        assert_eq!(err.check(), "depth-exceeded");
     }
 
     #[test]

--- a/crates/core/src/codec/fields.rs
+++ b/crates/core/src/codec/fields.rs
@@ -9,9 +9,15 @@
 //! rewrite canonical.
 
 use super::decode::Decoder;
-use super::encode::{MAJOR_MAP, write_head, write_text, write_value};
+use super::encode::{
+    MAJOR_MAP, count_value, head_len, text_len, write_head, write_text, write_value,
+};
 use super::value::{Map, canonical_key_cmp};
 use crate::error::{CodecError, Malformed};
+
+/// The depth a top-level map's values sit at: the map itself is the enclosing
+/// item, so its entries are one level in.
+const MAP_ENTRY_DEPTH: usize = 1;
 
 /// Fields preserved through a decode the caller's schema did not recognize:
 /// key plus the exact canonical bytes of the value. Ordered canonically.
@@ -58,8 +64,7 @@ pub fn decode_map_partial(
     for _ in 0..head.arg {
         let key = d.read_map_key(prev.as_deref())?;
         let start = d.pos();
-        // Depth 1: the top-level map is the enclosing item.
-        let value = d.read_value(1)?;
+        let value = d.read_value(MAP_ENTRY_DEPTH)?;
         if is_known(&key) {
             known.push((key.clone(), value));
         } else {
@@ -79,9 +84,8 @@ pub fn decode_map_partial(
 /// emitted byte-stable. A key present on both sides is a caller bug and
 /// rejects fail-closed.
 pub fn encode_map_partial(known: &Map, unknown: &UnknownFields) -> Result<Vec<u8>, CodecError> {
-    let mut out = Vec::new();
-    let total = known.len() + unknown.len();
-    write_head(&mut out, MAJOR_MAP, total as u64);
+    let mut out = Vec::with_capacity(merged_len(known, unknown)?);
+    write_head(&mut out, MAJOR_MAP, (known.len() + unknown.len()) as u64);
 
     let mut k = known.entries().iter().peekable();
     let mut u = unknown.entries.iter().peekable();
@@ -101,8 +105,7 @@ pub fn encode_map_partial(known: &Map, unknown: &UnknownFields) -> Result<Vec<u8
         if take_known {
             let (key, value) = k.next().expect("peeked");
             write_text(&mut out, key);
-            // Depth 1: the emitted map is the enclosing item.
-            write_value(&mut out, value, 1)?;
+            write_value(&mut out, value, MAP_ENTRY_DEPTH)?;
         } else {
             let (key, raw) = u.next().expect("peeked");
             write_text(&mut out, key);
@@ -110,6 +113,20 @@ pub fn encode_map_partial(known: &Map, unknown: &UnknownFields) -> Result<Vec<u8
         }
     }
     Ok(out)
+}
+
+/// The exact byte length of the merged map, sizing [`encode_map_partial`]'s one
+/// allocation for the realloc-hygiene reason [`super::encode::encode`] documents.
+fn merged_len(known: &Map, unknown: &UnknownFields) -> Result<usize, CodecError> {
+    let mut len = head_len((known.len() + unknown.len()) as u64);
+    for (key, value) in known.entries() {
+        len += text_len(key);
+        count_value(&mut len, value, MAP_ENTRY_DEPTH)?;
+    }
+    for (key, raw) in &unknown.entries {
+        len += text_len(key) + raw.len();
+    }
+    Ok(len)
 }
 
 /// Convenience for schema codecs: `true` when `key` is in `known`.
@@ -132,6 +149,41 @@ mod tests {
         );
         m.insert("zz-later", Value::Text("kept".into()));
         m
+    }
+
+    /// A merged map big enough to force several growths from an empty `Vec`,
+    /// spanning both key-head size classes and a >23-entry map head.
+    fn wide_secret_shaped_map() -> Map {
+        let mut m = Map::new();
+        for i in 0..40u8 {
+            m.insert(format!("k{i:02}"), Value::Bytes(vec![0xAB; 32]));
+            m.insert(
+                format!("a-preserved-future-field-name-{i:02}"),
+                Value::Text("x".repeat(40)),
+            );
+        }
+        m
+    }
+
+    /// The security invariant, as `encode` pins it: the merged write runs
+    /// inside one exact reservation, so no intermediate backing store is freed
+    /// un-zeroized. `merged_len` being exact makes `capacity == len` the
+    /// witness — growing from empty leaves a doubled capacity behind.
+    #[test]
+    fn merged_write_never_reallocates() {
+        let original = encode(&Value::Map(wide_secret_shaped_map())).unwrap();
+        let (known, unknown) = decode_map_partial(&original, |key| key.starts_with('k')).unwrap();
+        assert_eq!(known.len(), 40);
+        assert_eq!(unknown.len(), 40);
+
+        let out = encode_map_partial(&known, &unknown).unwrap();
+        assert!(out.len() > 1024, "test payload must force multiple growths");
+        assert_eq!(out, original, "wire bytes unchanged");
+        assert_eq!(
+            out.capacity(),
+            out.len(),
+            "buffer was resized after its up-front reservation"
+        );
     }
 
     #[test]

--- a/crates/core/tests/codec_props.rs
+++ b/crates/core/tests/codec_props.rs
@@ -122,6 +122,9 @@ proptest! {
             prop_assert!(!flags[k], "unknown side holds a known key {:?}", k);
         }
         let reencoded = encode_map_partial(&known, &unknown).expect("no collisions by construction");
+        // The merged sizing pass is exact, so the write never reallocates —
+        // property (d) for the partial encoder.
+        prop_assert_eq!(reencoded.capacity(), reencoded.len());
         prop_assert_eq!(reencoded, bytes);
     }
 

--- a/crates/core/tests/codec_props.rs
+++ b/crates/core/tests/codec_props.rs
@@ -122,8 +122,7 @@ proptest! {
             prop_assert!(!flags[k], "unknown side holds a known key {:?}", k);
         }
         let reencoded = encode_map_partial(&known, &unknown).expect("no collisions by construction");
-        // The merged sizing pass is exact, so the write never reallocates —
-        // property (d) for the partial encoder.
+        // The merged sizing pass is exact, so the write never reallocates.
         prop_assert_eq!(reencoded.capacity(), reencoded.len());
         prop_assert_eq!(reencoded, bytes);
     }


### PR DESCRIPTION
## What

`encode_map_partial` was the one encoder left building its output from an empty `Vec`. Every reallocation during the append frees the previous backing store un-zeroized, stranding partially-serialized known-field values in freed heap — the property #681 closed for `codec::encode` and that `crates/core/src/codec/encode.rs` documents in its own rustdoc.

This mirrors `encode`'s two-pass shape, and goes one step further: **every reject now fires before the output buffer exists.**

- `merge` walks the two canonically-ordered sides once, producing the emit sequence and rejecting a key present on both sides. It holds borrows only, so no secret bytes are copied into it, and it is itself sized exactly.
- `merged_len` sizes the merged map exactly, in emit order: the map head, each key's text head + bytes, and either `count_value` of a known value at the emit loop's depth or a preserved unknown value's raw canonical byte length.
- `encode_map_partial` then does a single `Vec::with_capacity` and writes.

Both rejects — `unknown-field-collision` and `depth-exceeded` — therefore run before a byte is allocated for the output. Previously the collision reject fired mid-write and dropped a buffer already holding written known-field bytes un-zeroized, which is the same leak class this issue is about. Counting in emit order also restores `depth-exceeded`'s reported offset, which a split known-then-unknown sum under-reported.

`count_value`, `head_len`, and `text_len` in `encode.rs` widen from private to `pub(super)` (`super` = `codec`, which is a private module) — no public API surface added and no wire-format change.

### Why the sizing pass rather than splicing through `encode`

The issue offered "route the known-field writes through `encode` and splice" as an alternative. That is strictly worse for the property being fixed: it would mint one intermediate `Vec` per known value, each holding secret bytes and each dropped un-zeroized. The second length pass keeps the secret bytes to exactly one buffer.

## Wire bytes are unchanged

This is purely allocation hygiene. **No KAT vector was regenerated** and the KAT generator was not run — the `crates/core/kat` tree hash is identical to `main` (`b6b0901a7dad3f4e8198ac02eb35c932fcf00dc7`), and the diff touches three files, none of them vectors. The KAT manifest suite passes unchanged in debug and release, and the `Core KATs (native + WASM)` gate is green.

## Tests

- `merged_write_never_reallocates` (unit): an 80-entry merged map — 40 known, 40 preserved unknown — spanning both key-head size classes (short keys, and 32-byte keys whose text head is two bytes) and a >23-entry map head, with 32-byte secret-shaped values. Asserts `capacity == len` on the buffer the public `encode_map_partial` returns, an allocator-independent `merged_len` sizing oracle against `out.len()`, and byte-equality against the direct `encode`. Verified **red** against the pre-fix allocation: `capacity 5120` vs `len 4562`.
- `merged_encode_rejects_past_max_depth` (unit): the merged path's `depth-exceeded` reject, release-active per AGENTS.md rule 8. The partial encoder had no coverage of it on either side of this change.
- Codec property suite (b) `unknown_field_round_trip` gains the same `capacity == len` assertion, fuzz-covering `merged_len` against the emit loop across arbitrary maps. Also verified red against the pre-fix allocation.

## Gates

`cargo fmt --all --check`, `cargo clippy --all-targets`, `cargo test --workspace`, `cargo test --release -p cipherbox-core`, and `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` all green.

Review gates run on `git diff main...HEAD`: `/simplify`, `/security-review`, `/crypto-privacy-review`. Findings folded in: the collision-reject leak, the `depth-exceeded` offset regression, the missing depth-reject test, and the allocator-dependent sizing witness. Both reviewers independently confirmed `merged_len` is exact head-for-head against the emit loop, that the `usize` sum cannot overflow, that `pub(super)` adds no public surface, and that the change introduces no timing signal.

Out of scope: #812 (encode-side fail-closed guards for the child read-path rejects) is disjoint sibling AGENTS.md rule 8 debt, owned by #868. The pre-existing gap that `UnknownFields` and `Map` give out-of-crate callers no way to wipe secret-bearing values is filed as #902.

Closes #893
Part of #655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved unknown fields during partial map decoding and re-encoding.
  * Ensured canonical, byte-stable output for partially decoded maps.
  * Detected excessive nesting before encoding begins.
  * Prevented unnecessary buffer reallocations during map encoding.
* **Tests**
  * Added coverage for unknown-field round trips, exact buffer sizing, canonical output, and nested-data validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->