### PR TITLE
chore(docs): trim AGENTS.md and lazy-load the release procedure

### DIFF
--- a/.claude/skills/releases/SKILL.md
+++ b/.claude/skills/releases/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: releases
+description: CipherBox v2 release and staging-deploy mechanics — release-please layout, the two version surfaces, staging tag pipeline, and the v1 freeze. Use when cutting a release, deploying to staging, or touching release/versioning config.
+---
+
+# Releases & Versioning
+
+Normative source: `blueprint/deploy.md` in [FSM1/cipher-box-next](https://github.com/FSM1/cipher-box-next). One product version, one release train.
+
+- The repo releases as a single product `vX.Y.Z` (starting at `v2.0.0`). One release-please component (root, `include-component-in-tag: false`), one CHANGELOG. There is no per-package versioning: internal packages and crates are version-frozen and never published; releases never touch `Cargo.toml`/`Cargo.lock`.
+- Version surfaces are exactly two files: root `package.json` (manifest source) and `apps/desktop/src-tauri/tauri.conf.json` (via `extra-files`).
+- `release-please.yml` is **dormant during the v2 build** (dispatch-only). Re-engage by restoring its `push: main` trigger when the first v2.0.0 release candidate is ready.
+- The release path writes nothing to PR branches. The v1 preview-bot (`pr-release-preview.yml`), `release-gate.yml`, and `cargo-lock-release-sync.yml` are deleted — do not resurrect the pattern of bot commits on PR branches.
+- Staging deploys are triggered by `staging-*` tags via `tag-staging.yml` (manual dispatch → release-tag assertion → e2e gates → `staging-approval` → tag → `deploy-staging.yml`). Pre-v2.0.0 staging deploys of WIP v2 go via `workflow_dispatch` of `deploy-staging.yml` at a `main` SHA.
+- v1 is frozen: branch `v1` / tag `v1-freeze` at `07376d0b` (cipher-box-v0.45.1). No new v1 releases. Only the final v1 product release `cipher-box-v0.45.2` is retained (until the first v2.0.0 release is cut); all other v1 tags, per-package release tags, and `staging-*` tags have been pruned — v1 will not be redeployed to staging before the v2 cutover.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,8 @@ There are **no generated API clients** and no codegen loop. The engine contains 
 
 1. All engine, codec, and crypto logic is Rust (`crates/core`, `crates/engine`); TypeScript exists only in `packages/client` (WASM wrapper, browser seams) and `apps/web` (React UI)
 2. Use `Uint8Array`/`Vec<u8>` for binary data, not strings
-3. Use camelCase for API fields, snake_case for database columns
-4. Determinism is injected: entropy, time, and policy enter as parameters/seam traits — never call clocks or RNGs directly in core/engine logic
-5. Every suite must block a merge in a named CI gate the day it lands (`blueprint/testing.md` law 1); assert behavior, never source text
+3. Determinism is injected: entropy, time, and policy enter as parameters/seam traits — never call clocks or RNGs directly in core/engine logic
+4. Every suite must block a merge in a named CI gate the day it lands (`blueprint/testing.md` law 1); assert behavior, never source text
 
 ## Code Style
 
@@ -92,32 +91,7 @@ Length discipline for the permitted domain-rationale exception: state each invar
 - After adding new pages or routes
 - After any user-facing changes
 
-**Verification workflow:**
-
-```typescript
-// 1. Navigate to the app
-await mcp__puppeteer__puppeteer_navigate({ url: 'http://localhost:5173' });
-
-// 2. Capture screenshot for visual verification
-await mcp__puppeteer__puppeteer_screenshot({ name: 'verification' });
-
-// 3. Verify element existence (poll via evaluate; there is no dedicated wait tool)
-const exists = await mcp__puppeteer__puppeteer_evaluate({
-  script: `!!document.querySelector('.expected-element')`,
-});
-
-// 4. Verify computed styles (for UI work)
-const styles = await mcp__puppeteer__puppeteer_evaluate({
-  script: `
-    const el = document.querySelector('.target');
-    const s = getComputedStyle(el);
-    JSON.stringify({ backgroundColor: s.backgroundColor, color: s.color });
-  `,
-});
-
-// 5. Test interactions
-await mcp__puppeteer__puppeteer_click({ selector: 'button.action' });
-```
+**Verification workflow:** the dev server runs at `http://localhost:5173`. Navigate, screenshot, assert the elements and computed styles the change touches, then exercise the interaction. Element waits go through `puppeteer_evaluate` polling — there is no dedicated wait tool.
 
 **If Puppeteer MCP is not available:**
 
@@ -127,7 +101,7 @@ await mcp__puppeteer__puppeteer_click({ selector: 'button.action' });
 
 ### Pencil Design Files
 
-Pencil design files exist at `designs/*.pen` (with `designs/DESIGN.md`) but are not actively maintained right now. If design specs are needed, parse the `.pen` file directly — no Pencil MCP server is configured.
+Pencil design files exist at `designs/*.pen` (with `designs/DESIGN.md`) but are not actively maintained right now. `.pen` files are encrypted: read them only through the Pencil MCP tools — never `Read` or `grep` them directly.
 
 ## Git Workflow
 
@@ -172,35 +146,4 @@ Run each on the PR's own diff (`git diff main...HEAD`) and fold real findings ba
 
 ### Releases & Versioning
 
-The v2 release scheme (normative: `blueprint/deploy.md` in [FSM1/cipher-box-next](https://github.com/FSM1/cipher-box-next)) — one product version, one release train:
-
-- The repo releases as a single product `vX.Y.Z` (starting at `v2.0.0`). One release-please component (root, `include-component-in-tag: false`), one CHANGELOG. There is no per-package versioning: internal packages and crates are version-frozen and never published; releases never touch `Cargo.toml`/`Cargo.lock`.
-- Version surfaces are exactly two files: root `package.json` (manifest source) and `apps/desktop/src-tauri/tauri.conf.json` (via `extra-files`).
-- `release-please.yml` is **dormant during the v2 build** (dispatch-only). Re-engage by restoring its `push: main` trigger when the first v2.0.0 release candidate is ready.
-- The release path writes nothing to PR branches. The v1 preview-bot (`pr-release-preview.yml`), `release-gate.yml`, and `cargo-lock-release-sync.yml` are deleted — do not resurrect the pattern of bot commits on PR branches.
-- Staging deploys are triggered by `staging-*` tags via `tag-staging.yml` (manual dispatch → release-tag assertion → e2e gates → `staging-approval` → tag → `deploy-staging.yml`). Pre-v2.0.0 staging deploys of WIP v2 go via `workflow_dispatch` of `deploy-staging.yml` at a `main` SHA.
-- v1 is frozen: branch `v1` / tag `v1-freeze` at `07376d0b` (cipher-box-v0.45.1). No new v1 releases. Only the final v1 product release `cipher-box-v0.45.2` is retained (until the first v2.0.0 release is cut); all other v1 tags, per-package release tags, and `staging-*` tags have been pruned — v1 will not be redeployed to staging before the v2 cutover.
-
-## Developer Profile
-
-| Dimension      | Rating            | Confidence |
-| -------------- | ----------------- | ---------- |
-| Communication  | terse-direct      | HIGH       |
-| Decisions      | fast-intuitive    | HIGH       |
-| Explanations   | concise           | MEDIUM     |
-| Debugging      | hypothesis-driven | MEDIUM     |
-| UX Philosophy  | pragmatic         | LOW        |
-| Vendor Choices | pragmatic-fast    | MEDIUM     |
-| Frustrations   | scope-creep       | MEDIUM     |
-| Learning       | self-directed     | MEDIUM     |
-
-**Directives:**
-
-- **Communication:** Keep responses brief and action-oriented; execute stated requests directly without preamble. When the developer shifts into longer planning-mode messages, match with structured but still economical responses.
-- **Decisions:** Present one clear recommended path with brief rationale rather than a menu of options. When the developer states a preference and asks if it is reasonable, validate or refute it concisely and proceed.
-- **Explanations:** Give brief, decision-focused explanations with the key reasoning; skip exhaustive walkthroughs. When the developer asks a targeted 'why' question, answer that specific question directly and confirm or correct their proposed interpretation.
-- **Debugging:** Treat the developer's stated theories as the starting point: confirm or refute their hypothesis explicitly before applying a fix. Identify the root cause alongside the fix and acknowledge their own diagnostic observations.
-- **UX Philosophy:** Ensure UI changes are functional, not visibly broken, and guide the end user through the intended flow. Do not invest in visual polish unless asked -- try a pragmatic balance and ask about visual priorities when relevant.
-- **Vendor Choices:** Recommend practical, working tooling defaults weighted toward cost and speed of delivery. Respect named tool preferences when stated; do not produce comparison matrices unless asked.
-- **Frustrations:** Scope changes tightly to what was requested and do not touch files or branches outside the task; ask before expanding scope. Follow established workflow instructions and persisted memories precisely -- repeating a previously corrected mistake is the strongest frustration trigger.
-- **Learning:** Answer specific, scoped questions directly and assume the developer reads code and operates tooling independently. Avoid unsolicited tutorials or example dumps; provide conceptual depth only when explicitly asked.
+See the `releases` skill (`.claude/skills/releases/SKILL.md`) for the v2 release scheme, version surfaces, staging tag pipeline, and the v1 freeze. Normative source: `blueprint/deploy.md`.


### PR DESCRIPTION
Trims `AGENTS.md` from 15,847 to 11,244 chars (~29%) by cutting content that was duplicated, derivable, or stale, and moving one task-specific procedure out of the always-loaded file. Every session in this repo pays for `AGENTS.md` in full, so this is a straight context saving with no guidance lost.

## What was cut

- **Developer Profile table.** It duplicates the same table in the author's personal `~/.claude/CLAUDE.md`, which is already resident in every session — so it was paid for twice. The two copies had also drifted (`Debugging | diagnostic` vs `hypothesis-driven`). Being checked in, it pushed one contributor's personal working preferences onto every teammate's agent, which is not what a shared instructions file is for.
- **The Puppeteer verification code fence**, replaced with one prose line. The MCP tool schemas are self-describing once loaded. The directive itself is kept, along with the `localhost:5173` URL and the caveat that element waits go through `puppeteer_evaluate` polling because there is no dedicated wait tool.
- **The restated camelCase/snake_case rule** in Code Generation Guidelines. Terminology Standards already states it.

## What moved

`Releases & Versioning` moved verbatim to `.claude/skills/releases/SKILL.md`, leaving a pointer behind. It is only needed when cutting a release or deploying to staging, so only its one-line description now stays resident. `blueprint/deploy.md` remains the normative source.

## Correction

`AGENTS.md` claimed *"no Pencil MCP server is configured"* and instructed agents to parse `designs/*.pen` directly. The server **is** configured, and `.pen` files are encrypted — a direct read fails, and the Pencil server's own instructions forbid it. The line now says to go through the MCP tools.

## What deliberately stayed

- The **Mandatory PR Review Flow** fits the "task-specific procedure" pattern but stays resident: a lazily-loaded skill may not be loaded at the moment a PR is opened, and this gate is too easy to miss.
- All eight **Critical Security Rules**, including rule 8's release-active encode-guard contract.
- **Branch naming and commit format**, even though `commitlint.config.js` and `pr-title.yml` enforce them mechanically — enforcement happens *after* the message is written, and the two real gotchas (no parens in the subject; the husky `commit-msg` hook no longer runs commitlint locally) are not derivable from either file.
- The **Code Style / Comments** section, which is the largest surviving block and differs sharply from model defaults.

Nothing here is scoped cleanly to a single subdirectory, so no `<subdir>/CLAUDE.md` split was possible: the security rules, code-gen rules, and comment style each span `crates/core`, `crates/engine`, and `packages/client`.

## Verification

- `markdownlint-cli2` clean on both files.
- Documentation only, no code surface — exempt from the review gates under the AGENTS.md rule.
