### PR TITLE
fix(api): pin uploaded blocks under their caller-computed content address

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -738,6 +738,9 @@ jobs:
       CONTRACT_API_URL: http://localhost:3000
       CONTRACT_API_PROD_URL: http://localhost:3100
       CONTRACT_TEST_LOGIN_SECRET: contract-suite-secret
+      # The stack's gateway, so the suite can fetch back a block the ingress
+      # pinned and prove it landed under the caller-computed address (#906).
+      CONTRACT_GATEWAY_URL: http://localhost:8080
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
 name = "cipherbox-contract"
 version = "0.0.0"
 dependencies = [
+ "cipherbox-core",
  "cipherbox-engine",
  "getrandom 0.2.17",
  "reqwest 0.13.4",

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -18,9 +18,7 @@
           }
         },
         "summary": "Liveness check",
-        "tags": [
-          "Ops"
-        ]
+        "tags": ["Ops"]
       }
     },
     "/metrics": {
@@ -40,9 +38,7 @@
           }
         },
         "summary": "Prometheus metrics in text exposition format",
-        "tags": [
-          "Ops"
-        ]
+        "tags": ["Ops"]
       }
     },
     "/auth/challenge": {
@@ -72,9 +68,7 @@
           }
         },
         "summary": "Issue a single-use login challenge bound to an identity publicKey",
-        "tags": [
-          "Auth"
-        ]
+        "tags": ["Auth"]
       }
     },
     "/auth/login": {
@@ -104,9 +98,7 @@
           }
         },
         "summary": "Challenge-signature login against the secp256k1 identity key; creates the account implicitly at first login",
-        "tags": [
-          "Auth"
-        ]
+        "tags": ["Auth"]
       }
     },
     "/auth/siwe/challenge": {
@@ -126,9 +118,7 @@
           }
         },
         "summary": "Issue a single-use SIWE nonce",
-        "tags": [
-          "Auth"
-        ]
+        "tags": ["Auth"]
       }
     },
     "/auth/siwe/login": {
@@ -158,9 +148,7 @@
           }
         },
         "summary": "SIWE wallet login (secondary method; the wallet must already be linked)",
-        "tags": [
-          "Auth"
-        ]
+        "tags": ["Auth"]
       }
     },
     "/auth/siwe/link": {
@@ -195,9 +183,7 @@
           }
         ],
         "summary": "Link a SIWE wallet to the authenticated account",
-        "tags": [
-          "Auth"
-        ]
+        "tags": ["Auth"]
       }
     },
     "/auth/refresh": {
@@ -227,9 +213,7 @@
           }
         },
         "summary": "Rotate the refresh token (one-time-use; reuse revokes the whole family)",
-        "tags": [
-          "Auth"
-        ]
+        "tags": ["Auth"]
       }
     },
     "/auth/logout": {
@@ -254,9 +238,7 @@
           }
         ],
         "summary": "Revoke every refresh token for the account (hard delete)",
-        "tags": [
-          "Auth"
-        ]
+        "tags": ["Auth"]
       }
     },
     "/auth/test-login": {
@@ -286,9 +268,7 @@
           }
         },
         "summary": "Staging-gated deterministic login for e2e (hard-blocked in production)",
-        "tags": [
-          "Auth"
-        ]
+        "tags": ["Auth"]
       }
     },
     "/mailbox/messages": {
@@ -344,9 +324,7 @@
           }
         ],
         "summary": "Post an HPKE-sealed blob to a recipient identity publicKey; unknown recipients are rejected (rate-limited existence oracle)",
-        "tags": [
-          "Mailbox"
-        ]
+        "tags": ["Mailbox"]
       },
       "get": {
         "operationId": "MailboxController_poll",
@@ -375,9 +353,7 @@
           }
         ],
         "summary": "Poll the authenticated mailbox; returns sealed blobs with no sender metadata in the clear",
-        "tags": [
-          "Mailbox"
-        ]
+        "tags": ["Mailbox"]
       }
     },
     "/mailbox/messages/{id}": {
@@ -417,9 +393,7 @@
           }
         ],
         "summary": "Ack a message: hard delete by id, scoped to the caller mailbox",
-        "tags": [
-          "Mailbox"
-        ]
+        "tags": ["Mailbox"]
       }
     },
     "/registry/register": {
@@ -470,9 +444,7 @@
           }
         ],
         "summary": "Batch register [{ipnsName, headCid?, contentCids[]}] under the caller account; register-first, idempotent upserts",
-        "tags": [
-          "Registry"
-        ]
+        "tags": ["Registry"]
       }
     },
     "/registry/retire": {
@@ -524,9 +496,7 @@
           }
         ],
         "summary": "Batch retire [ipnsName | cid] for the caller account; union liveness, refcounted physical unpin at global zero",
-        "tags": [
-          "Registry"
-        ]
+        "tags": ["Registry"]
       }
     },
     "/account/quota": {
@@ -554,9 +524,7 @@
           }
         ],
         "summary": "The caller per-account quota: usedBytes is the gated sum the upload gate enforces, pinnedBytes the all-rows sum, limitBytes the override or env default, advisory the BYO flag",
-        "tags": [
-          "Account"
-        ]
+        "tags": ["Account"]
       }
     },
     "/account/byo": {
@@ -597,9 +565,7 @@
           }
         ],
         "summary": "Toggle the caller BYO-IPFS flag; advisory pin rows follow it",
-        "tags": [
-          "Account"
-        ]
+        "tags": ["Account"]
       }
     },
     "/account": {
@@ -630,9 +596,7 @@
           }
         ],
         "summary": "Immediate hard-delete of the caller account: retire inventory/pin rows (refcounted unpin), purge mailbox, delete auth rows",
-        "tags": [
-          "Account"
-        ]
+        "tags": ["Account"]
       }
     },
     "/content/upload": {
@@ -640,9 +604,9 @@
         "operationId": "ContentController_upload",
         "parameters": [
           {
-            "name": "cid",
+            "name": "x-content-cid",
             "required": true,
-            "in": "query",
+            "in": "header",
             "description": "The caller-computed content address of the body: a CIDv1 base32 BLAKE3-256 CID whose codec is `raw` (sealed content leaf) or `dag-cbor` (DAG root or record head). The pin store rejects the upload if the bytes do not address to it.",
             "schema": {
               "type": "string"
@@ -672,7 +636,7 @@
             }
           },
           "400": {
-            "description": "Empty or non-binary upload body, a malformed `cid`, or bytes that do not address to the declared `cid`"
+            "description": "Empty or non-binary upload body, a malformed declared CID, or bytes that do not address to it"
           },
           "401": {
             "description": "Missing or invalid access token"
@@ -703,9 +667,7 @@
           }
         ],
         "summary": "Upload content bytes to the hosted pin store under their caller-computed content address; quota-gated for hosted accounts, refused for BYO",
-        "tags": [
-          "Content"
-        ]
+        "tags": ["Content"]
       }
     },
     "/recovery/{ipnsName}": {
@@ -750,9 +712,7 @@
           }
         ],
         "summary": "Fetch cached (possibly expired) record bytes for a name — the revival aid after a >EOL lapse. Non-canonical: verify against the network.",
-        "tags": [
-          "Recovery"
-        ]
+        "tags": ["Recovery"]
       }
     }
   },
@@ -810,9 +770,7 @@
             "example": "ok"
           }
         },
-        "required": [
-          "status"
-        ]
+        "required": ["status"]
       },
       "ChallengeRequestDto": {
         "type": "object",
@@ -823,9 +781,7 @@
             "example": "02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc"
           }
         },
-        "required": [
-          "publicKey"
-        ]
+        "required": ["publicKey"]
       },
       "ChallengeResponseDto": {
         "type": "object",
@@ -839,10 +795,7 @@
             "description": "Challenge expiry, ISO 8601"
           }
         },
-        "required": [
-          "challenge",
-          "expiresAt"
-        ]
+        "required": ["challenge", "expiresAt"]
       },
       "LoginRequestDto": {
         "type": "object",
@@ -860,11 +813,7 @@
             "description": "Compact secp256k1 signature over sha256(challenge), 64 bytes hex"
           }
         },
-        "required": [
-          "publicKey",
-          "challenge",
-          "signature"
-        ]
+        "required": ["publicKey", "challenge", "signature"]
       },
       "TokenResponseDto": {
         "type": "object",
@@ -882,10 +831,7 @@
             "description": "True when this login created the account implicitly"
           }
         },
-        "required": [
-          "accessToken",
-          "refreshToken"
-        ]
+        "required": ["accessToken", "refreshToken"]
       },
       "SiweChallengeResponseDto": {
         "type": "object",
@@ -899,10 +845,7 @@
             "description": "Nonce expiry, ISO 8601"
           }
         },
-        "required": [
-          "nonce",
-          "expiresAt"
-        ]
+        "required": ["nonce", "expiresAt"]
       },
       "SiweLoginRequestDto": {
         "type": "object",
@@ -916,10 +859,7 @@
             "description": "EIP-191 signature over the message, 0x-prefixed hex"
           }
         },
-        "required": [
-          "message",
-          "signature"
-        ]
+        "required": ["message", "signature"]
       },
       "LogoutResponseDto": {
         "type": "object",
@@ -928,9 +868,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "success"
-        ]
+        "required": ["success"]
       },
       "RefreshRequestDto": {
         "type": "object",
@@ -953,10 +891,7 @@
             "description": "Must match TEST_LOGIN_SECRET"
           }
         },
-        "required": [
-          "handle",
-          "secret"
-        ]
+        "required": ["handle", "secret"]
       },
       "TestLoginResponseDto": {
         "type": "object",
@@ -982,12 +917,7 @@
             "description": "Deterministic secp256k1 privateKey, hex (test hook only)"
           }
         },
-        "required": [
-          "accessToken",
-          "refreshToken",
-          "publicKey",
-          "privateKey"
-        ]
+        "required": ["accessToken", "refreshToken", "publicKey", "privateKey"]
       },
       "PostMessageDto": {
         "type": "object",
@@ -1006,11 +936,7 @@
             "description": "Sender-supplied idempotency key; a replay returns the original message id. MUST be a high-entropy per-message random value: it is blended into a one-way sender digest, and a low-entropy key would let a server-side observer brute-force the sender→recipient edge."
           }
         },
-        "required": [
-          "recipientPublicKey",
-          "blob",
-          "idempotencyKey"
-        ]
+        "required": ["recipientPublicKey", "blob", "idempotencyKey"]
       },
       "PostMessageResponseDto": {
         "type": "object",
@@ -1020,9 +946,7 @@
             "description": "Server-assigned message id"
           }
         },
-        "required": [
-          "id"
-        ]
+        "required": ["id"]
       },
       "MailboxMessageDto": {
         "type": "object",
@@ -1040,11 +964,7 @@
             "description": "HPKE-sealed opaque payload, base64 (owner-signed inside the seal)"
           }
         },
-        "required": [
-          "id",
-          "receivedAt",
-          "blob"
-        ]
+        "required": ["id", "receivedAt", "blob"]
       },
       "PollResponseDto": {
         "type": "object",
@@ -1057,9 +977,7 @@
             }
           }
         },
-        "required": [
-          "messages"
-        ]
+        "required": ["messages"]
       },
       "AckResponseDto": {
         "type": "object",
@@ -1068,9 +986,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "success"
-        ]
+        "required": ["success"]
       },
       "RegisterEntryDto": {
         "type": "object",
@@ -1092,10 +1008,7 @@
             }
           }
         },
-        "required": [
-          "ipnsName",
-          "contentCids"
-        ]
+        "required": ["ipnsName", "contentCids"]
       },
       "RegisterResponseDto": {
         "type": "object",
@@ -1109,10 +1022,7 @@
             "description": "Distinct content CIDs pinned/counted in this batch"
           }
         },
-        "required": [
-          "names",
-          "cids"
-        ]
+        "required": ["names", "cids"]
       },
       "RetireResponseDto": {
         "type": "object",
@@ -1126,10 +1036,7 @@
             "description": "CIDs physically unpinned because global refcount reached zero"
           }
         },
-        "required": [
-          "retired",
-          "unpinned"
-        ]
+        "required": ["retired", "unpinned"]
       },
       "QuotaResponseDto": {
         "type": "object",
@@ -1151,12 +1058,7 @@
             "description": "True for BYO accounts, whose rows never gate uploads (quota always allows)"
           }
         },
-        "required": [
-          "usedBytes",
-          "pinnedBytes",
-          "limitBytes",
-          "advisory"
-        ]
+        "required": ["usedBytes", "pinnedBytes", "limitBytes", "advisory"]
       },
       "SetByoDto": {
         "type": "object",
@@ -1166,9 +1068,7 @@
             "description": "Enable BYO-IPFS: pin rows become advisory, never quota-enforced"
           }
         },
-        "required": [
-          "byo"
-        ]
+        "required": ["byo"]
       },
       "ByoResponseDto": {
         "type": "object",
@@ -1178,9 +1078,7 @@
             "description": "The account BYO flag after the update"
           }
         },
-        "required": [
-          "byo"
-        ]
+        "required": ["byo"]
       },
       "DeleteAccountResponseDto": {
         "type": "object",
@@ -1202,12 +1100,7 @@
             "description": "CIDs physically unpinned because global refcount reached zero"
           }
         },
-        "required": [
-          "namesRetired",
-          "pinsRetired",
-          "mailboxPurged",
-          "unpinned"
-        ]
+        "required": ["namesRetired", "pinsRetired", "mailboxPurged", "unpinned"]
       },
       "UploadResponseDto": {
         "type": "object",
@@ -1221,20 +1114,14 @@
             "description": "The pinned size in bytes"
           }
         },
-        "required": [
-          "cid",
-          "size"
-        ]
+        "required": ["cid", "size"]
       },
       "UploadTooLargeDto": {
         "type": "object",
         "properties": {
           "code": {
             "type": "string",
-            "enum": [
-              "UPLOAD_TOO_LARGE",
-              "QUOTA_EXCEEDED"
-            ],
+            "enum": ["UPLOAD_TOO_LARGE", "QUOTA_EXCEEDED"],
             "description": "The refusal cause"
           },
           "message": {
@@ -1252,12 +1139,7 @@
             "example": "Payload Too Large"
           }
         },
-        "required": [
-          "code",
-          "message",
-          "statusCode",
-          "error"
-        ]
+        "required": ["code", "message", "statusCode", "error"]
       }
     }
   }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -638,7 +638,17 @@
     "/content/upload": {
       "post": {
         "operationId": "ContentController_upload",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "cid",
+            "required": true,
+            "in": "query",
+            "description": "The caller-computed content address of the body: a CIDv1 base32 BLAKE3-256 CID whose codec is `raw` (sealed content leaf) or `dag-cbor` (DAG root or record head). The pin store rejects the upload if the bytes do not address to it.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -662,7 +672,7 @@
             }
           },
           "400": {
-            "description": "Empty or non-binary upload body"
+            "description": "Empty or non-binary upload body, a malformed `cid`, or bytes that do not address to the declared `cid`"
           },
           "401": {
             "description": "Missing or invalid access token"
@@ -692,7 +702,7 @@
             "bearer": []
           }
         ],
-        "summary": "Upload content bytes to the hosted pin store; quota-gated for hosted accounts, refused for BYO",
+        "summary": "Upload content bytes to the hosted pin store under their caller-computed content address; quota-gated for hosted accounts, refused for BYO",
         "tags": [
           "Content"
         ]
@@ -1204,7 +1214,7 @@
         "properties": {
           "cid": {
             "type": "string",
-            "description": "The content CID Kubo pinned"
+            "description": "The declared content CID the bytes are pinned under"
           },
           "size": {
             "type": "number",

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -18,7 +18,9 @@
           }
         },
         "summary": "Liveness check",
-        "tags": ["Ops"]
+        "tags": [
+          "Ops"
+        ]
       }
     },
     "/metrics": {
@@ -38,7 +40,9 @@
           }
         },
         "summary": "Prometheus metrics in text exposition format",
-        "tags": ["Ops"]
+        "tags": [
+          "Ops"
+        ]
       }
     },
     "/auth/challenge": {
@@ -68,7 +72,9 @@
           }
         },
         "summary": "Issue a single-use login challenge bound to an identity publicKey",
-        "tags": ["Auth"]
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/auth/login": {
@@ -98,7 +104,9 @@
           }
         },
         "summary": "Challenge-signature login against the secp256k1 identity key; creates the account implicitly at first login",
-        "tags": ["Auth"]
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/auth/siwe/challenge": {
@@ -118,7 +126,9 @@
           }
         },
         "summary": "Issue a single-use SIWE nonce",
-        "tags": ["Auth"]
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/auth/siwe/login": {
@@ -148,7 +158,9 @@
           }
         },
         "summary": "SIWE wallet login (secondary method; the wallet must already be linked)",
-        "tags": ["Auth"]
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/auth/siwe/link": {
@@ -183,7 +195,9 @@
           }
         ],
         "summary": "Link a SIWE wallet to the authenticated account",
-        "tags": ["Auth"]
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/auth/refresh": {
@@ -213,7 +227,9 @@
           }
         },
         "summary": "Rotate the refresh token (one-time-use; reuse revokes the whole family)",
-        "tags": ["Auth"]
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/auth/logout": {
@@ -238,7 +254,9 @@
           }
         ],
         "summary": "Revoke every refresh token for the account (hard delete)",
-        "tags": ["Auth"]
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/auth/test-login": {
@@ -268,7 +286,9 @@
           }
         },
         "summary": "Staging-gated deterministic login for e2e (hard-blocked in production)",
-        "tags": ["Auth"]
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/mailbox/messages": {
@@ -324,7 +344,9 @@
           }
         ],
         "summary": "Post an HPKE-sealed blob to a recipient identity publicKey; unknown recipients are rejected (rate-limited existence oracle)",
-        "tags": ["Mailbox"]
+        "tags": [
+          "Mailbox"
+        ]
       },
       "get": {
         "operationId": "MailboxController_poll",
@@ -353,7 +375,9 @@
           }
         ],
         "summary": "Poll the authenticated mailbox; returns sealed blobs with no sender metadata in the clear",
-        "tags": ["Mailbox"]
+        "tags": [
+          "Mailbox"
+        ]
       }
     },
     "/mailbox/messages/{id}": {
@@ -393,7 +417,9 @@
           }
         ],
         "summary": "Ack a message: hard delete by id, scoped to the caller mailbox",
-        "tags": ["Mailbox"]
+        "tags": [
+          "Mailbox"
+        ]
       }
     },
     "/registry/register": {
@@ -444,7 +470,9 @@
           }
         ],
         "summary": "Batch register [{ipnsName, headCid?, contentCids[]}] under the caller account; register-first, idempotent upserts",
-        "tags": ["Registry"]
+        "tags": [
+          "Registry"
+        ]
       }
     },
     "/registry/retire": {
@@ -496,7 +524,9 @@
           }
         ],
         "summary": "Batch retire [ipnsName | cid] for the caller account; union liveness, refcounted physical unpin at global zero",
-        "tags": ["Registry"]
+        "tags": [
+          "Registry"
+        ]
       }
     },
     "/account/quota": {
@@ -524,7 +554,9 @@
           }
         ],
         "summary": "The caller per-account quota: usedBytes is the gated sum the upload gate enforces, pinnedBytes the all-rows sum, limitBytes the override or env default, advisory the BYO flag",
-        "tags": ["Account"]
+        "tags": [
+          "Account"
+        ]
       }
     },
     "/account/byo": {
@@ -565,7 +597,9 @@
           }
         ],
         "summary": "Toggle the caller BYO-IPFS flag; advisory pin rows follow it",
-        "tags": ["Account"]
+        "tags": [
+          "Account"
+        ]
       }
     },
     "/account": {
@@ -596,7 +630,9 @@
           }
         ],
         "summary": "Immediate hard-delete of the caller account: retire inventory/pin rows (refcounted unpin), purge mailbox, delete auth rows",
-        "tags": ["Account"]
+        "tags": [
+          "Account"
+        ]
       }
     },
     "/content/upload": {
@@ -667,7 +703,9 @@
           }
         ],
         "summary": "Upload content bytes to the hosted pin store under their caller-computed content address; quota-gated for hosted accounts, refused for BYO",
-        "tags": ["Content"]
+        "tags": [
+          "Content"
+        ]
       }
     },
     "/recovery/{ipnsName}": {
@@ -712,7 +750,9 @@
           }
         ],
         "summary": "Fetch cached (possibly expired) record bytes for a name — the revival aid after a >EOL lapse. Non-canonical: verify against the network.",
-        "tags": ["Recovery"]
+        "tags": [
+          "Recovery"
+        ]
       }
     }
   },
@@ -770,7 +810,9 @@
             "example": "ok"
           }
         },
-        "required": ["status"]
+        "required": [
+          "status"
+        ]
       },
       "ChallengeRequestDto": {
         "type": "object",
@@ -781,7 +823,9 @@
             "example": "02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc"
           }
         },
-        "required": ["publicKey"]
+        "required": [
+          "publicKey"
+        ]
       },
       "ChallengeResponseDto": {
         "type": "object",
@@ -795,7 +839,10 @@
             "description": "Challenge expiry, ISO 8601"
           }
         },
-        "required": ["challenge", "expiresAt"]
+        "required": [
+          "challenge",
+          "expiresAt"
+        ]
       },
       "LoginRequestDto": {
         "type": "object",
@@ -813,7 +860,11 @@
             "description": "Compact secp256k1 signature over sha256(challenge), 64 bytes hex"
           }
         },
-        "required": ["publicKey", "challenge", "signature"]
+        "required": [
+          "publicKey",
+          "challenge",
+          "signature"
+        ]
       },
       "TokenResponseDto": {
         "type": "object",
@@ -831,7 +882,10 @@
             "description": "True when this login created the account implicitly"
           }
         },
-        "required": ["accessToken", "refreshToken"]
+        "required": [
+          "accessToken",
+          "refreshToken"
+        ]
       },
       "SiweChallengeResponseDto": {
         "type": "object",
@@ -845,7 +899,10 @@
             "description": "Nonce expiry, ISO 8601"
           }
         },
-        "required": ["nonce", "expiresAt"]
+        "required": [
+          "nonce",
+          "expiresAt"
+        ]
       },
       "SiweLoginRequestDto": {
         "type": "object",
@@ -859,7 +916,10 @@
             "description": "EIP-191 signature over the message, 0x-prefixed hex"
           }
         },
-        "required": ["message", "signature"]
+        "required": [
+          "message",
+          "signature"
+        ]
       },
       "LogoutResponseDto": {
         "type": "object",
@@ -868,7 +928,9 @@
             "type": "boolean"
           }
         },
-        "required": ["success"]
+        "required": [
+          "success"
+        ]
       },
       "RefreshRequestDto": {
         "type": "object",
@@ -891,7 +953,10 @@
             "description": "Must match TEST_LOGIN_SECRET"
           }
         },
-        "required": ["handle", "secret"]
+        "required": [
+          "handle",
+          "secret"
+        ]
       },
       "TestLoginResponseDto": {
         "type": "object",
@@ -917,7 +982,12 @@
             "description": "Deterministic secp256k1 privateKey, hex (test hook only)"
           }
         },
-        "required": ["accessToken", "refreshToken", "publicKey", "privateKey"]
+        "required": [
+          "accessToken",
+          "refreshToken",
+          "publicKey",
+          "privateKey"
+        ]
       },
       "PostMessageDto": {
         "type": "object",
@@ -936,7 +1006,11 @@
             "description": "Sender-supplied idempotency key; a replay returns the original message id. MUST be a high-entropy per-message random value: it is blended into a one-way sender digest, and a low-entropy key would let a server-side observer brute-force the sender→recipient edge."
           }
         },
-        "required": ["recipientPublicKey", "blob", "idempotencyKey"]
+        "required": [
+          "recipientPublicKey",
+          "blob",
+          "idempotencyKey"
+        ]
       },
       "PostMessageResponseDto": {
         "type": "object",
@@ -946,7 +1020,9 @@
             "description": "Server-assigned message id"
           }
         },
-        "required": ["id"]
+        "required": [
+          "id"
+        ]
       },
       "MailboxMessageDto": {
         "type": "object",
@@ -964,7 +1040,11 @@
             "description": "HPKE-sealed opaque payload, base64 (owner-signed inside the seal)"
           }
         },
-        "required": ["id", "receivedAt", "blob"]
+        "required": [
+          "id",
+          "receivedAt",
+          "blob"
+        ]
       },
       "PollResponseDto": {
         "type": "object",
@@ -977,7 +1057,9 @@
             }
           }
         },
-        "required": ["messages"]
+        "required": [
+          "messages"
+        ]
       },
       "AckResponseDto": {
         "type": "object",
@@ -986,7 +1068,9 @@
             "type": "boolean"
           }
         },
-        "required": ["success"]
+        "required": [
+          "success"
+        ]
       },
       "RegisterEntryDto": {
         "type": "object",
@@ -1008,7 +1092,10 @@
             }
           }
         },
-        "required": ["ipnsName", "contentCids"]
+        "required": [
+          "ipnsName",
+          "contentCids"
+        ]
       },
       "RegisterResponseDto": {
         "type": "object",
@@ -1022,7 +1109,10 @@
             "description": "Distinct content CIDs pinned/counted in this batch"
           }
         },
-        "required": ["names", "cids"]
+        "required": [
+          "names",
+          "cids"
+        ]
       },
       "RetireResponseDto": {
         "type": "object",
@@ -1036,7 +1126,10 @@
             "description": "CIDs physically unpinned because global refcount reached zero"
           }
         },
-        "required": ["retired", "unpinned"]
+        "required": [
+          "retired",
+          "unpinned"
+        ]
       },
       "QuotaResponseDto": {
         "type": "object",
@@ -1058,7 +1151,12 @@
             "description": "True for BYO accounts, whose rows never gate uploads (quota always allows)"
           }
         },
-        "required": ["usedBytes", "pinnedBytes", "limitBytes", "advisory"]
+        "required": [
+          "usedBytes",
+          "pinnedBytes",
+          "limitBytes",
+          "advisory"
+        ]
       },
       "SetByoDto": {
         "type": "object",
@@ -1068,7 +1166,9 @@
             "description": "Enable BYO-IPFS: pin rows become advisory, never quota-enforced"
           }
         },
-        "required": ["byo"]
+        "required": [
+          "byo"
+        ]
       },
       "ByoResponseDto": {
         "type": "object",
@@ -1078,7 +1178,9 @@
             "description": "The account BYO flag after the update"
           }
         },
-        "required": ["byo"]
+        "required": [
+          "byo"
+        ]
       },
       "DeleteAccountResponseDto": {
         "type": "object",
@@ -1100,7 +1202,12 @@
             "description": "CIDs physically unpinned because global refcount reached zero"
           }
         },
-        "required": ["namesRetired", "pinsRetired", "mailboxPurged", "unpinned"]
+        "required": [
+          "namesRetired",
+          "pinsRetired",
+          "mailboxPurged",
+          "unpinned"
+        ]
       },
       "UploadResponseDto": {
         "type": "object",
@@ -1114,14 +1221,20 @@
             "description": "The pinned size in bytes"
           }
         },
-        "required": ["cid", "size"]
+        "required": [
+          "cid",
+          "size"
+        ]
       },
       "UploadTooLargeDto": {
         "type": "object",
         "properties": {
           "code": {
             "type": "string",
-            "enum": ["UPLOAD_TOO_LARGE", "QUOTA_EXCEEDED"],
+            "enum": [
+              "UPLOAD_TOO_LARGE",
+              "QUOTA_EXCEEDED"
+            ],
             "description": "The refusal cause"
           },
           "message": {
@@ -1139,7 +1252,12 @@
             "example": "Payload Too Large"
           }
         },
-        "required": ["code", "message", "statusCode", "error"]
+        "required": [
+          "code",
+          "message",
+          "statusCode",
+          "error"
+        ]
       }
     }
   }

--- a/apps/api/src/app-setup.ts
+++ b/apps/api/src/app-setup.ts
@@ -5,8 +5,13 @@ import type { NextFunction, Request, Response } from 'express';
 import { UPLOAD_TOO_LARGE, uploadTooLargeBody } from './content/upload-error-codes';
 import { verifiedUnexpiredSubjectFromBearer } from './ops/account-throttler.guard';
 
-/** Absolute upload-size cap (coarse DoS guard); the quota gate is the fine one. */
-const DEFAULT_MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
+/**
+ * Absolute upload-size cap (coarse DoS guard); the quota gate is the fine one.
+ * One request is one block, and Kubo's `block/put` refuses anything over 2 MiB —
+ * a larger body would buffer in full only to fail at the pin store as a
+ * retryable 503, so the transport cap refuses it here as a permanent 413.
+ */
+const DEFAULT_MAX_UPLOAD_BYTES = 2 * 1024 * 1024;
 
 function maxUploadBytes(): number {
   const raw = process.env.MAX_UPLOAD_BYTES;

--- a/apps/api/src/common/content-cid.test.ts
+++ b/apps/api/src/common/content-cid.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { contentCidCodec } from './content-cid';
+
+// 59-char strings: 7-char prefix + 52 filler chars from the base32 alphabet.
+const FILLER = 'a'.repeat(52);
+
+describe('contentCidCodec', () => {
+  it('reads raw off a bafkr4i-prefixed CID', () => {
+    expect(contentCidCodec(`bafkr4i${FILLER}`)).toBe('raw');
+  });
+
+  it('reads dag-cbor off a bafyr4i-prefixed CID', () => {
+    expect(contentCidCodec(`bafyr4i${FILLER}`)).toBe('dag-cbor');
+  });
+
+  it('rejects a string one character short of the 59-char CID', () => {
+    expect(contentCidCodec(`bafkr4i${FILLER.slice(0, -1)}`)).toBeUndefined();
+  });
+
+  it('rejects a string one character over the 59-char CID', () => {
+    expect(contentCidCodec(`bafkr4i${FILLER}a`)).toBeUndefined();
+  });
+
+  it('rejects non-base32 characters (0, 1, 8, 9 are excluded from the alphabet)', () => {
+    expect(contentCidCodec(`bafkr4i0${FILLER.slice(1)}`)).toBeUndefined();
+    expect(contentCidCodec(`bafkr4i1${FILLER.slice(1)}`)).toBeUndefined();
+    expect(contentCidCodec(`bafkr4i8${FILLER.slice(1)}`)).toBeUndefined();
+    expect(contentCidCodec(`bafkr4i9${FILLER.slice(1)}`)).toBeUndefined();
+  });
+
+  it('rejects uppercase characters (multibase base32 here is lowercase-only)', () => {
+    expect(contentCidCodec(`bafkr4iA${FILLER.slice(1)}`)).toBeUndefined();
+  });
+
+  it('rejects a string missing the leading b multibase tag', () => {
+    expect(contentCidCodec(`xafkr4i${FILLER}`)).toBeUndefined();
+  });
+
+  it('rejects a well-formed but unknown prefix', () => {
+    expect(contentCidCodec(`bafkr4j${FILLER}`)).toBeUndefined();
+  });
+});

--- a/apps/api/src/common/content-cid.ts
+++ b/apps/api/src/common/content-cid.ts
@@ -1,20 +1,13 @@
 /**
- * The declared content address a hosted upload carries (blueprint/api.md,
- * Content plane — Ingress). The engine computes every content address in
- * `crates/core`; the API only routes on it, so this reads the multicodec out of
- * the frozen CIDv1 framing without decoding or recomputing anything.
- *
- * The two frozen content-plane shapes (blueprint/core.md): CIDv1 + BLAKE3-256,
- * `raw` for sealed content leaves, `dag-cbor` for DAG roots and record heads.
- * Both share the fixed 4-byte framing `01 <codec> 1e 20`, whose base32 spans the
- * first seven characters — so the prefix identifies the codec exactly.
- *
- * This is a routing hint, never a trust decision: the pin store hands the codec
- * to Kubo, Kubo re-derives the address from the bytes, and the equality check
- * against the declared string is what actually binds bytes to CID.
+ * Reads the Kubo `cid-codec` off a declared content address (blueprint/api.md,
+ * Content plane — Ingress). The multicodec of the fixed CIDv1 framing
+ * `01 <codec> 1e 20` lands wholly inside the first six base32 characters, so the
+ * prefix names it exactly — no decoding, and no content address computed in
+ * TypeScript. Drift from core's framing fails the contract suite's upload leg,
+ * which pins a core-computed leaf and DAG root through this lookup.
  */
 
-/** Kubo `cid-codec` names for the frozen content-plane multicodecs. */
+/** The frozen content-plane multicodecs (blueprint/core.md), by CID prefix. */
 const CODEC_BY_PREFIX = {
   bafkr4i: 'raw',
   bafyr4i: 'dag-cbor',

--- a/apps/api/src/common/content-cid.ts
+++ b/apps/api/src/common/content-cid.ts
@@ -1,0 +1,38 @@
+/**
+ * The declared content address a hosted upload carries (blueprint/api.md,
+ * Content plane — Ingress). The engine computes every content address in
+ * `crates/core`; the API only routes on it, so this reads the multicodec out of
+ * the frozen CIDv1 framing without decoding or recomputing anything.
+ *
+ * The two frozen content-plane shapes (blueprint/core.md): CIDv1 + BLAKE3-256,
+ * `raw` for sealed content leaves, `dag-cbor` for DAG roots and record heads.
+ * Both share the fixed 4-byte framing `01 <codec> 1e 20`, whose base32 spans the
+ * first seven characters — so the prefix identifies the codec exactly.
+ *
+ * This is a routing hint, never a trust decision: the pin store hands the codec
+ * to Kubo, Kubo re-derives the address from the bytes, and the equality check
+ * against the declared string is what actually binds bytes to CID.
+ */
+
+/** Kubo `cid-codec` names for the frozen content-plane multicodecs. */
+const CODEC_BY_PREFIX = {
+  bafkr4i: 'raw',
+  bafyr4i: 'dag-cbor',
+} as const;
+
+export type ContentCidCodec = (typeof CODEC_BY_PREFIX)[keyof typeof CODEC_BY_PREFIX];
+
+/** `b` multibase tag plus the unpadded base32 of the 36 CIDv1 bytes. */
+const CONTENT_CID_PATTERN = /^b[a-z2-7]{58}$/;
+
+/**
+ * The Kubo `cid-codec` for a declared content CID, or `undefined` when the
+ * string is not one of the two frozen content-plane shapes — the caller fails
+ * closed on `undefined` rather than guessing a codec.
+ */
+export function contentCidCodec(cid: string): ContentCidCodec | undefined {
+  if (!CONTENT_CID_PATTERN.test(cid)) {
+    return undefined;
+  }
+  return CODEC_BY_PREFIX[cid.slice(0, 7) as keyof typeof CODEC_BY_PREFIX];
+}

--- a/apps/api/src/content/content.controller.ts
+++ b/apps/api/src/content/content.controller.ts
@@ -1,15 +1,17 @@
-import { BadRequestException, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { BadRequestException, Controller, Post, Query, Req, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiBody,
   ApiConsumes,
   ApiCreatedResponse,
   ApiOperation,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { AuthenticatedRequest, JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { contentCidCodec } from '../common/content-cid';
 import { THROTTLE_SURFACES } from '../ops/throttling';
 import { ContentService } from './content.service';
 import { UploadResponseDto, UploadTooLargeDto } from './dto/content.dto';
@@ -17,9 +19,10 @@ import { QUOTA_EXCEEDED, UPLOAD_TOO_LARGE } from './upload-error-codes';
 
 /**
  * The hosted content ingress surface (blueprint/api.md, Content plane): an
- * authenticated, quota-gated upload that pins opaque bytes to CipherBox Kubo.
- * The raw `application/octet-stream` body is buffered by the global raw-body
- * middleware (app-setup); BYO/dual byte paths bypass the API entirely.
+ * authenticated, quota-gated upload that pins opaque bytes to CipherBox Kubo
+ * under the `cid` the caller computed for them. The raw
+ * `application/octet-stream` body is buffered by the global raw-body middleware
+ * (app-setup); BYO/dual byte paths bypass the API entirely.
  */
 @ApiTags('Content')
 @ApiBearerAuth()
@@ -32,12 +35,22 @@ export class ContentController {
   @Throttle(THROTTLE_SURFACES.content)
   @ApiOperation({
     summary:
-      'Upload content bytes to the hosted pin store; quota-gated for hosted accounts, refused for BYO',
+      'Upload content bytes to the hosted pin store under their caller-computed content address; quota-gated for hosted accounts, refused for BYO',
   })
   @ApiConsumes('application/octet-stream')
   @ApiBody({ schema: { type: 'string', format: 'binary' } })
+  @ApiQuery({
+    name: 'cid',
+    required: true,
+    description:
+      'The caller-computed content address of the body: a CIDv1 base32 BLAKE3-256 CID whose codec is `raw` (sealed content leaf) or `dag-cbor` (DAG root or record head). The pin store rejects the upload if the bytes do not address to it.',
+  })
   @ApiCreatedResponse({ type: UploadResponseDto })
-  @ApiResponse({ status: 400, description: 'Empty or non-binary upload body' })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Empty or non-binary upload body, a malformed `cid`, or bytes that do not address to the declared `cid`',
+  })
   @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
   @ApiResponse({
     status: 409,
@@ -53,11 +66,19 @@ export class ContentController {
   })
   @ApiResponse({ status: 429, description: 'Upload rate limit exceeded' })
   @ApiResponse({ status: 503, description: 'Pin store contended or unavailable; retry shortly' })
-  upload(@Req() request: AuthenticatedRequest): Promise<UploadResponseDto> {
+  upload(
+    @Req() request: AuthenticatedRequest,
+    @Query('cid') cid?: string
+  ): Promise<UploadResponseDto> {
     const body: unknown = request.body;
     if (!Buffer.isBuffer(body) || body.length === 0) {
       throw new BadRequestException('Empty or non-binary upload body');
     }
-    return this.contentService.upload(request.user.userId, body);
+    // Reject a shape the pin store could not route before any lock or quota
+    // work; the byte-level bind is the pin store's put-and-compare.
+    if (!cid || !contentCidCodec(cid)) {
+      throw new BadRequestException('Missing or malformed content CID');
+    }
+    return this.contentService.upload(request.user.userId, cid, body);
   }
 }

--- a/apps/api/src/content/content.controller.ts
+++ b/apps/api/src/content/content.controller.ts
@@ -1,11 +1,11 @@
-import { BadRequestException, Controller, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { BadRequestException, Controller, Headers, Post, Req, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiBody,
   ApiConsumes,
   ApiCreatedResponse,
+  ApiHeader,
   ApiOperation,
-  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -18,9 +18,17 @@ import { UploadResponseDto, UploadTooLargeDto } from './dto/content.dto';
 import { QUOTA_EXCEEDED, UPLOAD_TOO_LARGE } from './upload-error-codes';
 
 /**
+ * The header carrying the caller's own content address for the body. A header,
+ * not a query parameter: content addresses correlate across accounts, and edge
+ * proxies log request URLs — so they stay out of the URL plane, as they already
+ * do on the registry's JSON bodies (blueprint/api.md, Accepted exposure).
+ */
+const CONTENT_CID_HEADER = 'x-content-cid';
+
+/**
  * The hosted content ingress surface (blueprint/api.md, Content plane): an
  * authenticated, quota-gated upload that pins opaque bytes to CipherBox Kubo
- * under the `cid` the caller computed for them. The raw
+ * under the address the caller computed for them. The raw
  * `application/octet-stream` body is buffered by the global raw-body middleware
  * (app-setup); BYO/dual byte paths bypass the API entirely.
  */
@@ -39,8 +47,8 @@ export class ContentController {
   })
   @ApiConsumes('application/octet-stream')
   @ApiBody({ schema: { type: 'string', format: 'binary' } })
-  @ApiQuery({
-    name: 'cid',
+  @ApiHeader({
+    name: CONTENT_CID_HEADER,
     required: true,
     description:
       'The caller-computed content address of the body: a CIDv1 base32 BLAKE3-256 CID whose codec is `raw` (sealed content leaf) or `dag-cbor` (DAG root or record head). The pin store rejects the upload if the bytes do not address to it.',
@@ -49,7 +57,7 @@ export class ContentController {
   @ApiResponse({
     status: 400,
     description:
-      'Empty or non-binary upload body, a malformed `cid`, or bytes that do not address to the declared `cid`',
+      'Empty or non-binary upload body, a malformed declared CID, or bytes that do not address to it',
   })
   @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
   @ApiResponse({
@@ -68,7 +76,7 @@ export class ContentController {
   @ApiResponse({ status: 503, description: 'Pin store contended or unavailable; retry shortly' })
   upload(
     @Req() request: AuthenticatedRequest,
-    @Query('cid') cid?: string
+    @Headers(CONTENT_CID_HEADER) cid?: string
   ): Promise<UploadResponseDto> {
     const body: unknown = request.body;
     if (!Buffer.isBuffer(body) || body.length === 0) {
@@ -76,7 +84,7 @@ export class ContentController {
     }
     // Reject a shape the pin store could not route before any lock or quota
     // work; the byte-level bind is the pin store's put-and-compare.
-    if (!cid || !contentCidCodec(cid)) {
+    if (typeof cid !== 'string' || !contentCidCodec(cid)) {
       throw new BadRequestException('Missing or malformed content CID');
     }
     return this.contentService.upload(request.user.userId, cid, body);

--- a/apps/api/src/content/content.http.integration.test.ts
+++ b/apps/api/src/content/content.http.integration.test.ts
@@ -33,30 +33,36 @@ const GIB = 1024 * 1024 * 1024;
 /** Base32 alphabet of the CID's multibase, per `content-cid.ts`'s `CONTENT_CID_PATTERN`. */
 const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
 
-/**
- * Deterministic CID from bytes, shaped like a real `raw`-codec content CID
- * (`bafkr4i` prefix + 52 base32 chars = the 58-char body `contentCidCodec`
- * requires) so it survives the controller's shape check.
- */
+/** The CID prefix each content-plane codec takes, per `content-cid.ts`. */
+const CODEC_PREFIX = { raw: 'bafkr4i', 'dag-cbor': 'bafyr4i' } as const;
+
 class FakePinStore extends PinStore {
   readonly pinned: string[] = [];
   readonly unpinned: string[] = [];
   failPin = false;
 
-  cidFor(bytes: Uint8Array): string {
+  /**
+   * Deterministic CID from bytes, shaped like a real content CID (7-char codec
+   * prefix + 52 base32 chars = the 58-char body `contentCidCodec` requires) so
+   * it survives the controller's shape check.
+   */
+  cidFor(bytes: Uint8Array, codec: keyof typeof CODEC_PREFIX = 'raw'): string {
     const hex = createHash('sha256').update(bytes).digest('hex');
     const suffix = hex
       .slice(0, 52)
       .split('')
       .map((nibble) => BASE32_ALPHABET[parseInt(nibble, 16)])
       .join('');
-    return `bafkr4i${suffix}`;
+    return `${CODEC_PREFIX[codec]}${suffix}`;
   }
   override async pin(cid: string, bytes: Uint8Array): Promise<void> {
     if (this.failPin) {
       throw new Error('pin store unavailable');
     }
-    const actual = this.cidFor(bytes);
+    // Kubo addresses the block under the declared CID's own codec, so the fake
+    // reads the codec back off the declared address before comparing.
+    const codec = cid.startsWith(CODEC_PREFIX['dag-cbor']) ? 'dag-cbor' : 'raw';
+    const actual = this.cidFor(bytes, codec);
     if (actual !== cid) {
       throw new PinCidMismatchError(cid, actual);
     }
@@ -158,6 +164,15 @@ describe('content HTTP (real Postgres)', () => {
         .send(bytes)
         .expect(201);
       expect(res.body).toEqual({ cid, size: 2 });
+      expect(pinStore.pinned).toEqual([cid]);
+    });
+
+    it('accepts a dag-cbor-codec declared CID, pinning a DAG root under it', async () => {
+      const acct = await account();
+      const bytes = Buffer.from([0xa1, 0x61, 0x61, 0x01]);
+      const cid = pinStore.cidFor(bytes, 'dag-cbor');
+      const res = await post(acct.token, cid).send(bytes).expect(201);
+      expect(res.body).toEqual({ cid, size: 4 });
       expect(pinStore.pinned).toEqual([cid]);
     });
 

--- a/apps/api/src/content/content.http.integration.test.ts
+++ b/apps/api/src/content/content.http.integration.test.ts
@@ -126,7 +126,7 @@ describe('content HTTP (real Postgres)', () => {
     function post(token: string, cid: string) {
       return request(ctx.http)
         .post('/content/upload')
-        .query({ cid })
+        .set('x-content-cid', cid)
         .set('Authorization', `Bearer ${token}`)
         .set('Content-Type', 'application/octet-stream');
     }
@@ -152,7 +152,7 @@ describe('content HTTP (real Postgres)', () => {
       const cid = pinStore.cidFor(bytes);
       const res = await request(ctx.http)
         .post('/content/upload')
-        .query({ cid })
+        .set('x-content-cid', cid)
         .set('Authorization', `Bearer ${acct.token}`)
         .set('Content-Type', 'Application/Octet-Stream')
         .send(bytes)
@@ -168,7 +168,7 @@ describe('content HTTP (real Postgres)', () => {
       expect(pinStore.pinned).toEqual([]);
     });
 
-    it('rejects a request with no cid query param (400), reaching neither pin store', async () => {
+    it('rejects a request with no declared CID (400), reaching neither pin store', async () => {
       const acct = await account();
       await request(ctx.http)
         .post('/content/upload')
@@ -183,7 +183,7 @@ describe('content HTTP (real Postgres)', () => {
       const acct = await account();
       await request(ctx.http)
         .post('/content/upload')
-        .query({ cid: 'not-a-cid' })
+        .set('x-content-cid', 'not-a-cid')
         .set('Authorization', `Bearer ${acct.token}`)
         .set('Content-Type', 'application/octet-stream')
         .send(Buffer.from([9]))
@@ -195,7 +195,7 @@ describe('content HTTP (real Postgres)', () => {
       const cid = pinStore.cidFor(Buffer.from([9]));
       await request(ctx.http)
         .post('/content/upload')
-        .query({ cid })
+        .set('x-content-cid', cid)
         .set('Content-Type', 'application/octet-stream')
         .send(Buffer.from([9]))
         .expect(401);
@@ -294,7 +294,7 @@ describe('content HTTP (real Postgres)', () => {
       const bytes = Buffer.alloc(MAX + 8, 1);
       const res = await request(ctx.http)
         .post('/content/upload')
-        .query({ cid: pinStore.cidFor(bytes) })
+        .set('x-content-cid', pinStore.cidFor(bytes))
         .set('Authorization', `Bearer ${token}`)
         .set('Content-Type', 'application/octet-stream')
         .send(bytes)
@@ -310,7 +310,7 @@ describe('content HTTP (real Postgres)', () => {
       const bytes = Buffer.alloc(MAX + 8, 1);
       await request(ctx.http)
         .post('/content/upload')
-        .query({ cid: pinStore.cidFor(bytes) })
+        .set('x-content-cid', pinStore.cidFor(bytes))
         .set('Content-Type', 'application/octet-stream')
         .send(bytes)
         .expect(401);
@@ -321,7 +321,7 @@ describe('content HTTP (real Postgres)', () => {
       const bytes = Buffer.alloc(MAX + 8, 1);
       await request(ctx.http)
         .post('/content/upload')
-        .query({ cid: pinStore.cidFor(bytes) })
+        .set('x-content-cid', pinStore.cidFor(bytes))
         .set('Authorization', `Bearer ${expired}`)
         .set('Content-Type', 'application/octet-stream')
         .send(bytes)
@@ -333,7 +333,7 @@ describe('content HTTP (real Postgres)', () => {
       const bytes = Buffer.from([1, 2, 3]);
       const res = await request(ctx.http)
         .post('/content/upload')
-        .query({ cid: pinStore.cidFor(bytes) })
+        .set('x-content-cid', pinStore.cidFor(bytes))
         .set('Authorization', `Bearer ${token}`)
         .set('Content-Type', 'application/octet-stream')
         .send(bytes)

--- a/apps/api/src/content/content.http.integration.test.ts
+++ b/apps/api/src/content/content.http.integration.test.ts
@@ -6,7 +6,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { User } from '../auth/entities/user.entity';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { PinnedCid } from '../registry/entities/pinned-cid.entity';
-import { PinStore } from '../registry/pin-store';
+import { PinCidMismatchError, PinStore } from '../registry/pin-store';
 import { fakeConfig } from '../testing/fakes';
 import {
   createHttpIntegrationApp,
@@ -30,25 +30,37 @@ import { QUOTA_EXCEEDED, UPLOAD_TOO_LARGE } from './upload-error-codes';
 
 const GIB = 1024 * 1024 * 1024;
 
-/** Deterministic CID from bytes so hash() and pin() always agree; records effects. */
+/** Base32 alphabet of the CID's multibase, per `content-cid.ts`'s `CONTENT_CID_PATTERN`. */
+const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
+
+/**
+ * Deterministic CID from bytes, shaped like a real `raw`-codec content CID
+ * (`bafkr4i` prefix + 52 base32 chars = the 58-char body `contentCidCodec`
+ * requires) so it survives the controller's shape check.
+ */
 class FakePinStore extends PinStore {
   readonly pinned: string[] = [];
   readonly unpinned: string[] = [];
   failPin = false;
 
   cidFor(bytes: Uint8Array): string {
-    return `ba${createHash('sha256').update(bytes).digest('hex')}`;
+    const hex = createHash('sha256').update(bytes).digest('hex');
+    const suffix = hex
+      .slice(0, 52)
+      .split('')
+      .map((nibble) => BASE32_ALPHABET[parseInt(nibble, 16)])
+      .join('');
+    return `bafkr4i${suffix}`;
   }
-  override async hash(bytes: Uint8Array): Promise<string> {
-    return this.cidFor(bytes);
-  }
-  override async pin(bytes: Uint8Array): Promise<string> {
+  override async pin(cid: string, bytes: Uint8Array): Promise<void> {
     if (this.failPin) {
       throw new Error('pin store unavailable');
     }
-    const cid = this.cidFor(bytes);
+    const actual = this.cidFor(bytes);
+    if (actual !== cid) {
+      throw new PinCidMismatchError(cid, actual);
+    }
     this.pinned.push(cid);
-    return cid;
   }
   async unpin(cid: string): Promise<boolean> {
     this.unpinned.push(cid);
@@ -111,9 +123,10 @@ describe('content HTTP (real Postgres)', () => {
       return { id: userId, token };
     }
 
-    function post(token: string) {
+    function post(token: string, cid: string) {
       return request(ctx.http)
         .post('/content/upload')
+        .query({ cid })
         .set('Authorization', `Bearer ${token}`)
         .set('Content-Type', 'application/octet-stream');
     }
@@ -121,39 +134,68 @@ describe('content HTTP (real Postgres)', () => {
     it('buffers the raw octet-stream body and durably pins it, returning the DTO', async () => {
       const acct = await account();
       const bytes = Buffer.from([1, 2, 3, 4, 5]);
-      const res = await post(acct.token).send(bytes).expect(201);
-      expect(res.body).toEqual({ cid: pinStore.cidFor(bytes), size: 5 });
+      const cid = pinStore.cidFor(bytes);
+      const res = await post(acct.token, cid).send(bytes).expect(201);
+      expect(res.body).toEqual({ cid, size: 5 });
       // The body reached the service as bytes and was durably pinned.
-      expect(pinStore.pinned).toEqual([pinStore.cidFor(bytes)]);
+      expect(pinStore.pinned).toEqual([cid]);
       const rows = await db.dataSource
         .getRepository(PinnedCid)
         .find({ where: { accountId: acct.id } });
       expect(rows).toHaveLength(1);
-      expect(rows[0]).toMatchObject({ cid: pinStore.cidFor(bytes), size: '5' });
+      expect(rows[0]).toMatchObject({ cid, size: '5' });
     });
 
     it('buffers a mixed-case Application/Octet-Stream content-type (case-insensitive per RFC 9110)', async () => {
       const acct = await account();
       const bytes = Buffer.from([7, 8]);
+      const cid = pinStore.cidFor(bytes);
       const res = await request(ctx.http)
         .post('/content/upload')
+        .query({ cid })
         .set('Authorization', `Bearer ${acct.token}`)
         .set('Content-Type', 'Application/Octet-Stream')
         .send(bytes)
         .expect(201);
-      expect(res.body).toEqual({ cid: pinStore.cidFor(bytes), size: 2 });
-      expect(pinStore.pinned).toEqual([pinStore.cidFor(bytes)]);
+      expect(res.body).toEqual({ cid, size: 2 });
+      expect(pinStore.pinned).toEqual([cid]);
     });
 
     it('rejects an empty body with 400 before the service pins anything', async () => {
       const acct = await account();
-      await post(acct.token).send(Buffer.alloc(0)).expect(400);
+      const cid = pinStore.cidFor(Buffer.alloc(0));
+      await post(acct.token, cid).send(Buffer.alloc(0)).expect(400);
+      expect(pinStore.pinned).toEqual([]);
+    });
+
+    it('rejects a request with no cid query param (400), reaching neither pin store', async () => {
+      const acct = await account();
+      await request(ctx.http)
+        .post('/content/upload')
+        .set('Authorization', `Bearer ${acct.token}`)
+        .set('Content-Type', 'application/octet-stream')
+        .send(Buffer.from([9]))
+        .expect(400);
+      expect(pinStore.pinned).toEqual([]);
+    });
+
+    it('rejects a request with a malformed cid (400), reaching neither pin store', async () => {
+      const acct = await account();
+      await request(ctx.http)
+        .post('/content/upload')
+        .query({ cid: 'not-a-cid' })
+        .set('Authorization', `Bearer ${acct.token}`)
+        .set('Content-Type', 'application/octet-stream')
+        .send(Buffer.from([9]))
+        .expect(400);
       expect(pinStore.pinned).toEqual([]);
     });
 
     it('rejects a request with no access token (401)', async () => {
+      const cid = pinStore.cidFor(Buffer.from([9]));
       await request(ctx.http)
         .post('/content/upload')
+        .query({ cid })
         .set('Content-Type', 'application/octet-stream')
         .send(Buffer.from([9]))
         .expect(401);
@@ -166,7 +208,8 @@ describe('content HTTP (real Postgres)', () => {
         .getRepository(PinnedCid)
         .save({ accountId: acct.id, cid: 'baExisting', size: '60', advisory: false });
       // 60 already used + 60 incoming > 100.
-      const res = await post(acct.token).send(Buffer.alloc(60, 1)).expect(413);
+      const bytes = Buffer.alloc(60, 1);
+      const res = await post(acct.token, pinStore.cidFor(bytes)).send(bytes).expect(413);
       expect(res.body).toMatchObject({
         statusCode: 413,
         error: 'Payload Too Large',
@@ -178,10 +221,21 @@ describe('content HTTP (real Postgres)', () => {
     it('maps a pin-store fault to a retryable 503', async () => {
       const acct = await account();
       pinStore.failPin = true;
-      await post(acct.token)
-        .send(Buffer.from([1, 2, 3]))
-        .expect(503);
+      const bytes = Buffer.from([1, 2, 3]);
+      await post(acct.token, pinStore.cidFor(bytes)).send(bytes).expect(503);
       // The failed pin was compensated away — the account is charged nothing.
+      expect(
+        await db.dataSource.getRepository(PinnedCid).find({ where: { accountId: acct.id } })
+      ).toHaveLength(0);
+    });
+
+    it('maps a declared cid that does not address the bytes to a 400, compensating the charge', async () => {
+      const acct = await account();
+      const bytes = Buffer.from([4, 5, 6]);
+      const wrongCid = pinStore.cidFor(Buffer.from([9, 9, 9]));
+      await post(acct.token, wrongCid).send(bytes).expect(400);
+      // Compensated, not just uncharged-on-failure: no row, nothing pinned.
+      expect(pinStore.pinned).toEqual([]);
       expect(
         await db.dataSource.getRepository(PinnedCid).find({ where: { accountId: acct.id } })
       ).toHaveLength(0);
@@ -193,10 +247,12 @@ describe('content HTTP (real Postgres)', () => {
     let ctx: HttpIntegrationApp;
     let jwt: JwtService;
     let priorMax: string | undefined;
+    let pinStore: FakePinStore;
 
     beforeAll(async () => {
       priorMax = process.env.MAX_UPLOAD_BYTES;
       process.env.MAX_UPLOAD_BYTES = String(MAX);
+      pinStore = new FakePinStore();
       ctx = await createHttpIntegrationApp({
         db,
         entities: [User, PinnedCid],
@@ -204,7 +260,7 @@ describe('content HTTP (real Postgres)', () => {
         providers: [
           ContentService,
           JwtAuthGuard,
-          { provide: PinStore, useValue: new FakePinStore() },
+          { provide: PinStore, useValue: pinStore },
           {
             provide: ConfigService,
             useValue: fakeConfig({
@@ -235,11 +291,13 @@ describe('content HTTP (real Postgres)', () => {
 
     it('answers an over-cap authenticated upload with a real 413 JSON body discriminated by code UPLOAD_TOO_LARGE', async () => {
       const token = await authToken();
+      const bytes = Buffer.alloc(MAX + 8, 1);
       const res = await request(ctx.http)
         .post('/content/upload')
+        .query({ cid: pinStore.cidFor(bytes) })
         .set('Authorization', `Bearer ${token}`)
         .set('Content-Type', 'application/octet-stream')
-        .send(Buffer.alloc(MAX + 8, 1))
+        .send(bytes)
         .expect(413);
       expect(res.body).toMatchObject({
         statusCode: 413,
@@ -249,30 +307,36 @@ describe('content HTTP (real Postgres)', () => {
     });
 
     it('refuses an over-cap UNAUTHENTICATED upload with 401 before buffering (not 413)', async () => {
+      const bytes = Buffer.alloc(MAX + 8, 1);
       await request(ctx.http)
         .post('/content/upload')
+        .query({ cid: pinStore.cidFor(bytes) })
         .set('Content-Type', 'application/octet-stream')
-        .send(Buffer.alloc(MAX + 8, 1))
+        .send(bytes)
         .expect(401);
     });
 
     it('refuses an over-cap EXPIRED-but-signed upload with 401 before buffering (not 413)', async () => {
       const expired = await authToken(-10);
+      const bytes = Buffer.alloc(MAX + 8, 1);
       await request(ctx.http)
         .post('/content/upload')
+        .query({ cid: pinStore.cidFor(bytes) })
         .set('Authorization', `Bearer ${expired}`)
         .set('Content-Type', 'application/octet-stream')
-        .send(Buffer.alloc(MAX + 8, 1))
+        .send(bytes)
         .expect(401);
     });
 
     it('still buffers and uploads for an unexpired valid token', async () => {
       const token = await authToken();
+      const bytes = Buffer.from([1, 2, 3]);
       const res = await request(ctx.http)
         .post('/content/upload')
+        .query({ cid: pinStore.cidFor(bytes) })
         .set('Authorization', `Bearer ${token}`)
         .set('Content-Type', 'application/octet-stream')
-        .send(Buffer.from([1, 2, 3]))
+        .send(bytes)
         .expect(201);
       expect(res.body).toMatchObject({ size: 3 });
     });

--- a/apps/api/src/content/content.service.integration.test.ts
+++ b/apps/api/src/content/content.service.integration.test.ts
@@ -10,7 +10,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { User } from '../auth/entities/user.entity';
 import { advisoryLockKey } from '../common/advisory-lock';
 import { PinnedCid } from '../registry/entities/pinned-cid.entity';
-import { PinStore } from '../registry/pin-store';
+import { PinCidMismatchError, PinStore } from '../registry/pin-store';
 import { RegistryService } from '../registry/services/registry.service';
 import { fakeConfig } from '../testing/fakes';
 import { createIntegrationDatabase, IntegrationDatabase } from '../testing/integration-db';
@@ -35,7 +35,7 @@ function compressedPublicKey(): string {
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-/** Deterministic CID from bytes so hash() and pin() always agree; records effects. */
+/** Deterministic CID from bytes; declared and actual agree unless a test deliberately mismatches. */
 class FakePinStore extends PinStore {
   readonly pinned: string[] = [];
   readonly unpinned: string[] = [];
@@ -47,20 +47,18 @@ class FakePinStore extends PinStore {
     return `ba${createHash('sha256').update(bytes).digest('hex')}`;
   }
 
-  override async hash(bytes: Uint8Array): Promise<string> {
-    return this.cidFor(bytes);
-  }
-
-  override async pin(bytes: Uint8Array): Promise<string> {
+  override async pin(cid: string, bytes: Uint8Array): Promise<void> {
     if (this.pinGate) {
       await this.pinGate.onReach();
     }
     if (this.failPin) {
       throw new Error('pin store unavailable');
     }
-    const cid = this.cidFor(bytes);
+    const actual = this.cidFor(bytes);
+    if (actual !== cid) {
+      throw new PinCidMismatchError(cid, actual);
+    }
     this.pinned.push(cid);
-    return cid;
   }
 
   async unpin(cid: string): Promise<boolean> {
@@ -263,11 +261,13 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       const accountId = await seedAccount({ quotaLimitOverride: '100' });
       const gate = makeGate();
       const pinStore = new FakePinStore();
+      const firstBytes = Buffer.alloc(60, 1);
+      const secondBytes = Buffer.alloc(60, 2);
 
       const first = buildService(
         gatedDataSource(db.dataSource, { beforeInsert: gate.onReach }),
         pinStore
-      ).upload(accountId, Buffer.alloc(60, 1));
+      ).upload(accountId, pinStore.cidFor(firstBytes), firstBytes);
 
       // first holds the account lock, passed the gate (used 0 + 60 <= 100), and
       // paused just before its insert.
@@ -275,7 +275,7 @@ describe('ContentService upload concurrency (real Postgres)', () => {
 
       let secondDone = false;
       const second = buildService(db.dataSource, pinStore)
-        .upload(accountId, Buffer.alloc(60, 2))
+        .upload(accountId, pinStore.cidFor(secondBytes), secondBytes)
         .then((r) => {
           secondDone = true;
           return r;
@@ -308,17 +308,20 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       // two per-account serializers); their CIDs differ, so the CID lock never
       // serializes them either — nothing does.
       const gateHooks = { skipLockKeys: [skipLockKey], stripUserLock: true };
+      const firstBytes = Buffer.alloc(60, 1);
+      const secondBytes = Buffer.alloc(60, 2);
       const first = buildService(
         gatedDataSource(db.dataSource, { ...gateHooks, beforeInsert: gate.onReach }),
         pinStore
-      ).upload(accountId, Buffer.alloc(60, 1));
+      ).upload(accountId, pinStore.cidFor(firstBytes), firstBytes);
 
       await gate.reached; // first read used=0, passed the gate, paused before insert
 
       // second runs fully with no account serializer: it also reads used=0 and inserts.
       await buildService(gatedDataSource(db.dataSource, gateHooks), pinStore).upload(
         accountId,
-        Buffer.alloc(60, 2)
+        pinStore.cidFor(secondBytes),
+        secondBytes
       );
 
       gate.release();
@@ -337,17 +340,18 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       const bytes = Buffer.alloc(40, 7);
       const gate = makeGate();
       const pinStore = new FakePinStore();
+      const cid = pinStore.cidFor(bytes);
 
       const first = buildService(
         gatedDataSource(db.dataSource, { beforeInsert: gate.onReach }),
         pinStore
-      ).upload(accountId, bytes);
+      ).upload(accountId, cid, bytes);
 
       await gate.reached;
 
       let secondDone = false;
       const second = buildService(db.dataSource, pinStore)
-        .upload(accountId, bytes)
+        .upload(accountId, cid, bytes)
         .then((r) => {
           secondDone = true;
           return r;
@@ -381,13 +385,13 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       const first = buildService(
         gatedDataSource(db.dataSource, { ...skipHooks, beforeInsert: gate.onReach }),
         pinStore
-      ).upload(accountId, bytes);
+      ).upload(accountId, cid, bytes);
 
       await gate.reached; // first found no existing row and paused before insert
 
       // second runs fully with no locks: it also sees no existing row and inserts.
       const secondResult = await buildService(gatedDataSource(db.dataSource, skipHooks), pinStore)
-        .upload(accountId, bytes)
+        .upload(accountId, cid, bytes)
         .catch((e: unknown) => e);
 
       // first now inserts the duplicate (account, cid) and hits the unique index.
@@ -419,8 +423,9 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       expect(Number(limit) + 1 <= Number(limit)).toBe(true);
 
       const pinStore = new FakePinStore();
+      const bytes = Buffer.alloc(1, 9);
       await expect(
-        buildService(db.dataSource, pinStore).upload(accountId, Buffer.alloc(1, 9))
+        buildService(db.dataSource, pinStore).upload(accountId, pinStore.cidFor(bytes), bytes)
       ).rejects.toBeInstanceOf(PayloadTooLargeException);
 
       // Nothing was pinned; the ledger is unchanged.
@@ -439,9 +444,11 @@ describe('ContentService upload concurrency (real Postgres)', () => {
         .save({ accountId, cid: 'baAdvisoryStale', size: '500', advisory: true });
 
       const pinStore = new FakePinStore();
+      const bytes = Buffer.alloc(60, 1);
       const result = await buildService(db.dataSource, pinStore).upload(
         accountId,
-        Buffer.alloc(60, 1)
+        pinStore.cidFor(bytes),
+        bytes
       );
 
       expect(result.size).toBe(60);
@@ -458,8 +465,9 @@ describe('ContentService upload concurrency (real Postgres)', () => {
         .save({ accountId, cid: 'baHosted', size: '60', advisory: false });
 
       const pinStore = new FakePinStore();
+      const bytes = Buffer.alloc(60, 2);
       await expect(
-        buildService(db.dataSource, pinStore).upload(accountId, Buffer.alloc(60, 2))
+        buildService(db.dataSource, pinStore).upload(accountId, pinStore.cidFor(bytes), bytes)
       ).rejects.toBeInstanceOf(PayloadTooLargeException);
       // Nothing pinned; the authoritative 60 + incoming 60 > 100 refused.
       expect(pinStore.pinned).toEqual([]);
@@ -474,9 +482,10 @@ describe('ContentService upload concurrency (real Postgres)', () => {
     it('rejects the upload with 409 and pins nothing, leaving no uncounted row', async () => {
       const accountId = await seedAccount({ byo: true, quotaLimitOverride: '100' });
       const pinStore = new FakePinStore();
+      const bytes = Buffer.alloc(4096, 1);
 
       await expect(
-        buildService(db.dataSource, pinStore).upload(accountId, Buffer.alloc(4096, 1))
+        buildService(db.dataSource, pinStore).upload(accountId, pinStore.cidFor(bytes), bytes)
       ).rejects.toBeInstanceOf(ConflictException);
 
       // The adversarial invariant: bytes were NOT pinned to hosted Kubo, and no
@@ -497,7 +506,7 @@ describe('ContentService upload concurrency (real Postgres)', () => {
         .save({ accountId, cid, size: '0', advisory: true });
 
       await expect(
-        buildService(db.dataSource, pinStore).upload(accountId, bytes)
+        buildService(db.dataSource, pinStore).upload(accountId, cid, bytes)
       ).rejects.toBeInstanceOf(ConflictException);
 
       // The registry row is untouched (never promoted/charged) and nothing pinned.
@@ -531,13 +540,14 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       const bytes = Buffer.alloc(40, 1);
       const gate = makeGate();
       const pinStore = new FakePinStore();
+      const cid = pinStore.cidFor(bytes);
 
       // The upload takes the row lock, reads byo=false, then parks — still
       // holding the lock, uncommitted.
       const uploaded = buildService(
         gatedDataSource(db.dataSource, { afterUserRead: gate.onReach }),
         pinStore
-      ).upload(accountId, bytes);
+      ).upload(accountId, cid, bytes);
       await gate.reached;
 
       let setByoDone = false;
@@ -570,13 +580,14 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       const bytes = Buffer.alloc(40, 2);
       const gate = makeGate();
       const pinStore = new FakePinStore();
+      const cid = pinStore.cidFor(bytes);
 
       // The user read drops the FOR UPDATE lock (the pre-fix path); nothing
       // serializes the upload against the toggle.
       const uploaded = buildService(
         gatedDataSource(db.dataSource, { stripUserLock: true, afterUserRead: gate.onReach }),
         pinStore
-      ).upload(accountId, bytes);
+      ).upload(accountId, cid, bytes);
       await gate.reached; // upload read byo=false with no lock, then paused
 
       // The toggle commits immediately, mid-upload.
@@ -603,7 +614,11 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       const bytes = Buffer.alloc(20, 5);
       const pinStore = new FakePinStore();
 
-      const result = await buildService(db.dataSource, pinStore).upload(accountId, bytes);
+      const result = await buildService(db.dataSource, pinStore).upload(
+        accountId,
+        pinStore.cidFor(bytes),
+        bytes
+      );
 
       expect(result.size).toBe(20);
       expect(pinStore.pinned).toEqual([result.cid]);
@@ -619,7 +634,7 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       pinStore.failPin = true;
 
       await expect(
-        buildService(db.dataSource, pinStore).upload(accountId, bytes)
+        buildService(db.dataSource, pinStore).upload(accountId, pinStore.cidFor(bytes), bytes)
       ).rejects.toBeInstanceOf(ServiceUnavailableException);
 
       // Byte-pin + register are all-or-nothing: the row it registered was
@@ -640,13 +655,23 @@ describe('ContentService upload concurrency (real Postgres)', () => {
 
       const failing = new FakePinStore();
       failing.failPin = true;
+      const failingBytes = Buffer.alloc(20, 1);
       await expect(
-        buildService(db.dataSource, failing).upload(accountId, Buffer.alloc(20, 1))
+        buildService(db.dataSource, failing).upload(
+          accountId,
+          failing.cidFor(failingBytes),
+          failingBytes
+        )
       ).rejects.toBeInstanceOf(ServiceUnavailableException);
       expect(await usedBytes(accountId)).toBe(0n);
 
       const ok = new FakePinStore();
-      const result = await buildService(db.dataSource, ok).upload(accountId, Buffer.alloc(20, 2));
+      const okBytes = Buffer.alloc(20, 2);
+      const result = await buildService(db.dataSource, ok).upload(
+        accountId,
+        ok.cidFor(okBytes),
+        okBytes
+      );
       expect(result.size).toBe(20);
       expect(await usedBytes(accountId)).toBe(20n);
     });
@@ -666,7 +691,7 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       // A: commits its row, then reaches the (failing) pin while still holding
       // the session durability lock.
       const a = buildService(db.dataSource, failing)
-        .upload(accountId, bytes)
+        .upload(accountId, cid, bytes)
         .catch((e: unknown) => e);
       await pinGate.reached;
 
@@ -674,7 +699,7 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       const okStore = new FakePinStore();
       let bResult: UploadResult | undefined;
       const b = buildService(db.dataSource, okStore)
-        .upload(accountId, bytes)
+        .upload(accountId, cid, bytes)
         .then((r) => (bResult = r));
 
       await delay(200);
@@ -708,7 +733,7 @@ describe('ContentService upload concurrency (real Postgres)', () => {
         gatedDataSource(db.dataSource, { skipLockKeys: skipDurability }),
         failing
       )
-        .upload(accountId, bytes)
+        .upload(accountId, cid, bytes)
         .catch((e: unknown) => e);
       await pinGate.reached; // A committed its row, paused in the failing pin
 
@@ -718,7 +743,7 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       const bResult = (await buildService(
         gatedDataSource(db.dataSource, { skipLockKeys: skipDurability }),
         okStore
-      ).upload(accountId, bytes)) as UploadResult;
+      ).upload(accountId, cid, bytes)) as UploadResult;
       expect(bResult).toMatchObject({ cid, size: 30 });
       expect(okStore.pinned).toEqual([]); // B pinned nothing — it trusted A's row
 
@@ -761,7 +786,7 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       expect(registered).toMatchObject({ size: '0', advisory: false });
       expect(pinStore.pinned).toEqual([]); // register pins nothing
 
-      const result = await buildService(db.dataSource, pinStore).upload(accountId, bytes);
+      const result = await buildService(db.dataSource, pinStore).upload(accountId, cid, bytes);
 
       // The bytes are now DURABLY pinned, the row carries the real size, and the
       // quota is charged — closing the skip-with-size-0 durability/quota hole.
@@ -777,14 +802,15 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       const accountId = await seedAccount({ quotaLimitOverride: '1000' });
       const bytes = Buffer.alloc(30, 9);
       const pinStore = new FakePinStore();
+      const cid = pinStore.cidFor(bytes);
 
-      const first = await buildService(db.dataSource, pinStore).upload(accountId, bytes);
+      const first = await buildService(db.dataSource, pinStore).upload(accountId, cid, bytes);
       expect(first.size).toBe(30);
       expect(pinStore.pinned).toEqual([first.cid]);
 
       // The second upload finds a COMPLETED hosted pin (size > 0): idempotent
       // no-op — no second pin, no second charge.
-      const second = await buildService(db.dataSource, pinStore).upload(accountId, bytes);
+      const second = await buildService(db.dataSource, pinStore).upload(accountId, cid, bytes);
       expect(second).toMatchObject({ cid: first.cid, size: 30 });
       expect(pinStore.pinned).toEqual([first.cid]); // not re-pinned
       expect(await pinsFor(accountId)).toHaveLength(1);
@@ -802,7 +828,7 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       ]);
 
       await expect(
-        buildService(db.dataSource, pinStore).upload(accountId, bytes)
+        buildService(db.dataSource, pinStore).upload(accountId, cid, bytes)
       ).rejects.toBeInstanceOf(PayloadTooLargeException);
 
       // Refused before any pin; the registry-only row is untouched (still size 0).
@@ -825,7 +851,7 @@ describe('ContentService upload concurrency (real Postgres)', () => {
       const failing = new FakePinStore();
       failing.failPin = true;
       await expect(
-        buildService(db.dataSource, failing).upload(accountId, bytes)
+        buildService(db.dataSource, failing).upload(accountId, cid, bytes)
       ).rejects.toBeInstanceOf(ServiceUnavailableException);
 
       // Compensation reverts the size charge but MUST keep the pre-existing

--- a/apps/api/src/content/content.service.ts
+++ b/apps/api/src/content/content.service.ts
@@ -93,11 +93,9 @@ export interface UploadResult {
  * bytes to CipherBox Kubo under the address the caller declared for them,
  * quota-gated, registering the pin row in the same traversal. The API is
  * zero-knowledge — it pins bytes it never inspects and computes no content
- * address of its own; the pin store's put re-derives the address and the
- * declared CID is only honoured if Kubo agrees. Only hosted accounts may ingress
- * here: a BYO account pins to its own provider and its bytes bypass the API, so
- * a BYO upload is refused (409) rather than pinned to hosted Kubo off the
- * quota's books.
+ * address of its own. Only hosted accounts may ingress here: a BYO account pins
+ * to its own provider and its bytes bypass the API, so a BYO upload is refused
+ * (409) rather than pinned to hosted Kubo off the quota's books.
  *
  * Concurrency (two shared resources under contention):
  *  - the per-account quota SUM — a check-then-act serialized by a per-account
@@ -309,7 +307,9 @@ export class ContentService {
         await this.pinStore.unpin(cid);
       }
     } catch (error) {
-      this.logger.warn(`compensation for ${cid} failed: ${String(error)}`);
+      // Alertable: a stranded charged row makes every later upload of these
+      // bytes short-circuit as already-pinned, for a pin that never landed.
+      this.logger.error(`compensation for ${cid} failed: ${String(error)}`);
     }
   }
 }

--- a/apps/api/src/content/content.service.ts
+++ b/apps/api/src/content/content.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ConflictException,
   Injectable,
   Logger,
@@ -22,7 +23,7 @@ import {
 import { resolveDbPoolSize } from '../common/db-pool';
 import { Semaphore } from '../common/semaphore';
 import { PinnedCid } from '../registry/entities/pinned-cid.entity';
-import { PinStore } from '../registry/pin-store';
+import { PinCidMismatchError, PinStore } from '../registry/pin-store';
 import {
   byteConfigBigInt,
   DEFAULT_QUOTA_BYTES,
@@ -89,11 +90,14 @@ export interface UploadResult {
 
 /**
  * The hosted ingress upload path (blueprint/api.md, Content plane): pin opaque
- * bytes to CipherBox Kubo, quota-gated, registering the pin row in the same
- * traversal. The API is zero-knowledge — it pins bytes it never inspects. Only
- * hosted accounts may ingress here: a BYO account pins to its own provider and
- * its bytes bypass the API, so a BYO upload is refused (409) rather than pinned
- * to hosted Kubo off the quota's books.
+ * bytes to CipherBox Kubo under the address the caller declared for them,
+ * quota-gated, registering the pin row in the same traversal. The API is
+ * zero-knowledge — it pins bytes it never inspects and computes no content
+ * address of its own; the pin store's put re-derives the address and the
+ * declared CID is only honoured if Kubo agrees. Only hosted accounts may ingress
+ * here: a BYO account pins to its own provider and its bytes bypass the API, so
+ * a BYO upload is refused (409) rather than pinned to hosted Kubo off the
+ * quota's books.
  *
  * Concurrency (two shared resources under contention):
  *  - the per-account quota SUM — a check-then-act serialized by a per-account
@@ -150,7 +154,7 @@ export class ContentService {
     this.pinSlots = new Semaphore(pinConcurrency.ceiling);
   }
 
-  async upload(accountId: string, bytes: Buffer): Promise<UploadResult> {
+  async upload(accountId: string, cid: string, bytes: Buffer): Promise<UploadResult> {
     // Fail closed on a pool too small (< 2 connections) to host one upload: the
     // pin path needs its session-lock connection AND a second for the commit tx,
     // so admitting a request here would self-deadlock waiting for the second.
@@ -158,9 +162,6 @@ export class ContentService {
       throw new ServiceUnavailableException('Content pin path unavailable; DB pool too small');
     }
     const size = bytes.byteLength;
-    // Phase 1 — derive the CID with no durable side effect (only-hash), so the
-    // ledger below can key on it before any bytes are pinned.
-    const cid = await this.pinStore.hash(bytes);
 
     // Admit at most `pinSlots` uploads into the session-lock → pin → compensate
     // span at once. That span holds a pooled connection across the external pin,
@@ -180,28 +181,26 @@ export class ContentService {
     size: number,
     bytes: Buffer
   ): Promise<UploadResult> {
-    // Phase 2 — the source of truth: gate + register under the account and CID
+    // Phase 1 — the source of truth: gate + register under the account and CID
     // advisory locks, atomically.
     const outcome = await runLockGuardedTransaction(this.dataSource, (manager) =>
       this.registerPin(manager, accountId, cid, size)
     );
 
-    // Phase 3 — durable pin AFTER commit. Byte-pin + register are all-or-nothing:
-    // a pin failure (or a CID mismatch) compensates — retiring a row it inserted,
-    // or reverting a promoted row's size charge.
+    // Phase 2 — durable pin AFTER commit, under the declared CID. Byte-pin +
+    // register are all-or-nothing: a pin failure compensates — retiring a row it
+    // inserted, or reverting a promoted row's size charge. A declared CID that
+    // does not address the bytes is a permanent caller fault (400), not a
+    // retriable outage (503).
     if (outcome.created) {
-      let pinnedCid: string;
       try {
-        pinnedCid = await this.pinStore.pin(bytes);
-      } catch {
+        await this.pinStore.pin(cid, bytes);
+      } catch (error) {
         await this.compensate(accountId, cid, outcome.promoted);
+        if (error instanceof PinCidMismatchError) {
+          throw new BadRequestException('Declared CID does not address the uploaded bytes');
+        }
         throw new ServiceUnavailableException('Pin store unavailable; upload not durable');
-      }
-      if (pinnedCid !== cid) {
-        // Fail closed: the row keys on `cid`; a mismatch means Kubo pinned bytes
-        // under a different CID than the ledger references.
-        await this.compensate(accountId, cid, outcome.promoted);
-        throw new ServiceUnavailableException('Pin CID mismatch; upload rejected');
       }
     }
 

--- a/apps/api/src/content/dto/content.dto.ts
+++ b/apps/api/src/content/dto/content.dto.ts
@@ -2,12 +2,12 @@ import { ApiProperty } from '@nestjs/swagger';
 import { QUOTA_EXCEEDED, UPLOAD_TOO_LARGE, UploadTooLargeCode } from '../upload-error-codes';
 
 /**
- * The hosted-upload result (blueprint/api.md, Content plane — Ingress). The
- * client references content by the returned CID; `size` is the byte count
- * charged against the account's quota.
+ * The hosted-upload result (blueprint/api.md, Content plane — Ingress). `cid`
+ * echoes the declared content address, now confirmed durably pinned under it;
+ * `size` is the byte count charged against the account's quota.
  */
 export class UploadResponseDto {
-  @ApiProperty({ description: 'The content CID Kubo pinned' })
+  @ApiProperty({ description: 'The declared content CID the bytes are pinned under' })
   cid!: string;
 
   @ApiProperty({ description: 'The pinned size in bytes' })

--- a/apps/api/src/registry/pin-store.test.ts
+++ b/apps/api/src/registry/pin-store.test.ts
@@ -1,0 +1,88 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeConfig } from '../testing/fakes';
+import { KuboPinStore, PinCidMismatchError } from './pin-store';
+
+const RAW_CID = `bafkr4i${'a'.repeat(52)}`;
+const OTHER_CID = `bafkr4i${'b'.repeat(52)}`;
+const DAG_CBOR_CID = `bafyr4i${'a'.repeat(52)}`;
+
+/** The Kubo RPC path (no query) of each call, in order. */
+let calls: string[];
+type Reply = { status?: number; body?: string };
+let replies: Map<string, Reply>;
+
+function store(apiUrl = 'http://kubo.test'): KuboPinStore {
+  return new KuboPinStore(fakeConfig({ KUBO_API_URL: apiUrl }).service);
+}
+
+/**
+ * The pin store's Kubo effects (#906): the block is written under the declared
+ * CID's own codec, pinned only once Kubo agrees on the address, and removed
+ * again on every path that will not pin it — an unpinned block is not reclaimed,
+ * so a refused upload must not leave one behind.
+ */
+describe('KuboPinStore.pin', () => {
+  beforeEach(() => {
+    calls = [];
+    replies = new Map();
+    vi.stubGlobal('fetch', (url: string) => {
+      const path = new URL(url).pathname.replace('/api/v0/', '');
+      calls.push(path);
+      const reply = replies.get(path) ?? {};
+      return Promise.resolve(new Response(reply.body ?? '{}', { status: reply.status ?? 200 }));
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('puts the block under the declared codec, then pins it direct', async () => {
+    replies.set('block/put', { body: JSON.stringify({ Key: DAG_CBOR_CID, Size: 3 }) });
+    await store().pin(DAG_CBOR_CID, new Uint8Array([1, 2, 3]));
+    expect(calls).toEqual(['block/put', 'pin/add']);
+  });
+
+  it('removes the block and refuses when Kubo addresses the bytes differently', async () => {
+    replies.set('block/put', { body: JSON.stringify({ Key: OTHER_CID, Size: 3 }) });
+    await expect(store().pin(RAW_CID, new Uint8Array([1, 2, 3]))).rejects.toBeInstanceOf(
+      PinCidMismatchError
+    );
+    // The written block is dropped; nothing is pinned.
+    expect(calls).toEqual(['block/put', 'block/rm']);
+  });
+
+  it('removes the block when the pin itself fails', async () => {
+    replies.set('block/put', { body: JSON.stringify({ Key: RAW_CID, Size: 3 }) });
+    replies.set('pin/add', { status: 500 });
+    await expect(store().pin(RAW_CID, new Uint8Array([1, 2, 3]))).rejects.toBeInstanceOf(
+      ServiceUnavailableException
+    );
+    expect(calls).toEqual(['block/put', 'pin/add', 'block/rm']);
+  });
+
+  it('reports a put that returned no address as a store fault, not a mismatch', async () => {
+    // Kubo streams NDJSON and can trail an error object under a 200; reading
+    // that as a disagreeing address would blame the caller for a store fault.
+    replies.set('block/put', { body: JSON.stringify({ Message: 'boom', Type: 'error' }) });
+    await expect(store().pin(RAW_CID, new Uint8Array([1]))).rejects.toBeInstanceOf(
+      ServiceUnavailableException
+    );
+    expect(calls).toEqual(['block/put']);
+  });
+
+  it('refuses a CID outside the frozen content-plane shapes before any RPC', async () => {
+    await expect(store().pin('not-a-cid', new Uint8Array([1]))).rejects.toBeInstanceOf(
+      PinCidMismatchError
+    );
+    expect(calls).toEqual([]);
+  });
+
+  it('fails closed when Kubo is unconfigured — an upload with no pin store is not durable', async () => {
+    await expect(store('').pin(RAW_CID, new Uint8Array([1]))).rejects.toBeInstanceOf(
+      ServiceUnavailableException
+    );
+    expect(calls).toEqual([]);
+  });
+});

--- a/apps/api/src/registry/pin-store.ts
+++ b/apps/api/src/registry/pin-store.ts
@@ -1,48 +1,69 @@
 import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { contentCidCodec } from '../common/content-cid';
 
 /**
  * The hosted pin-store port (blueprint/api.md, Content plane + "physical unpin
  * fires at global refcount zero" — v1's `guardedUnpin` survives). It owns every
- * side effect against CipherBox Kubo: computing a content CID, durably pinning
- * bytes on the ingress path, and releasing bytes at refcount zero. The registry
- * and content services own the row DECISIONS; this port owns the byte effects.
+ * side effect against CipherBox Kubo: durably pinning bytes under the address
+ * the caller declared for them, and releasing bytes at refcount zero. The
+ * registry and content services own the row DECISIONS; this port owns the byte
+ * effects.
  *
  * `unpin` is a best-effort liveness optimization, not a correctness dependency:
  * the per-account row bookkeeping is the source of truth, so a failed or
  * unconfigured unpin never fails a retire — the CID lingers and decays from the
  * pin store's own GC. It returns whether the CID was physically released (`true`)
  * so callers report a truthful unpin count; a no-op or swallowed failure returns
- * `false` (never throws). `hash`/`pin` are the ingress byte path; a consumer that
- * only retires (the registry) never calls them, so the base rejects rather than
- * forcing every unpin-only fake to stub the byte methods.
+ * `false` (never throws). `pin` is the ingress byte path; a consumer that only
+ * retires (the registry) never calls it, so the base rejects rather than forcing
+ * every unpin-only fake to stub the byte method.
  */
 @Injectable()
 export abstract class PinStore {
   abstract unpin(cid: string): Promise<boolean>;
 
-  /** Content CID of `bytes` with no durable pin (the pre-commit CID derivation). */
-  hash(_bytes: Uint8Array): Promise<string> {
-    throw new ServiceUnavailableException('Hosted pin store does not support content hashing');
-  }
-
-  /** Durably pin `bytes`, returning the pinned CID (the post-commit byte effect). */
-  pin(_bytes: Uint8Array): Promise<string> {
+  /**
+   * Durably pin `bytes` under the caller-declared content address `cid`,
+   * rejecting with [`PinCidMismatchError`] when the store addresses those bytes
+   * differently — the check that binds a declared CID to the bytes behind it.
+   */
+  pin(_cid: string, _bytes: Uint8Array): Promise<void> {
     throw new ServiceUnavailableException('Hosted pin store does not support pinning');
   }
 }
 
-/** One Kubo `add` result line; only `Hash` is consumed. */
-interface KuboAddResult {
-  Hash: string;
+/**
+ * The declared CID does not address the uploaded bytes. A caller fault, not a
+ * store outage: the ingress path answers 400 so the client fails fast instead
+ * of retrying an upload that can never succeed.
+ */
+export class PinCidMismatchError extends Error {
+  constructor(
+    readonly declared: string,
+    readonly actual: string
+  ) {
+    super(`Declared CID ${declared} does not address the uploaded bytes (${actual})`);
+    this.name = 'PinCidMismatchError';
+  }
+}
+
+/** One Kubo `block/put` result; only `Key` (the block's address) is consumed. */
+interface KuboBlockPutResult {
+  Key: string;
 }
 
 /**
- * Default hosted implementation over the Kubo RPC API (`KUBO_API_URL`). `hash`
- * and `pin` share identical `add` parameters so the pre-commit CID always
- * matches the pinned CID (content addressing is deterministic). `unpin` no-ops
- * when Kubo is unconfigured (unit tests, BYO-only deployments); the byte path
- * fails closed instead, since an upload with no pin store cannot be durable.
+ * Default hosted implementation over the Kubo RPC API (`KUBO_API_URL`). `unpin`
+ * no-ops when Kubo is unconfigured (unit tests, BYO-only deployments); the byte
+ * path fails closed instead, since an upload with no pin store cannot be
+ * durable.
+ *
+ * `pin` writes the block under the declared CID's own multicodec and BLAKE3-256
+ * multihash, so Kubo addresses it exactly as the engine does, then pins it
+ * **direct** (`recursive=false`). Direct is the correct shape for this plane:
+ * every block is uploaded and registered individually, and a recursive pin would
+ * make repo GC walk sealed bytes it cannot interpret.
  */
 @Injectable()
 export class KuboPinStore extends PinStore {
@@ -55,13 +76,18 @@ export class KuboPinStore extends PinStore {
     this.apiUrl = raw && raw.trim() ? raw.replace(/\/+$/, '') : undefined;
   }
 
-  override async hash(bytes: Uint8Array): Promise<string> {
-    // `only-hash` chunks and hashes without writing blocks — no durable effect.
-    return (await this.add(bytes, 'only-hash=true')).Hash;
-  }
-
-  override async pin(bytes: Uint8Array): Promise<string> {
-    return (await this.add(bytes, 'pin=true')).Hash;
+  override async pin(cid: string, bytes: Uint8Array): Promise<void> {
+    const codec = contentCidCodec(cid);
+    if (!codec) {
+      throw new PinCidMismatchError(cid, 'not a content-plane CID');
+    }
+    // Written unpinned first: a block whose address disagrees is never pinned,
+    // so a wrong declaration leaves nothing but GC-reclaimable bytes behind.
+    const put = await this.blockPut(bytes, codec);
+    if (put.Key !== cid) {
+      throw new PinCidMismatchError(cid, put.Key);
+    }
+    await this.pinAdd(cid);
   }
 
   async unpin(cid: string): Promise<boolean> {
@@ -86,28 +112,43 @@ export class KuboPinStore extends PinStore {
     }
   }
 
-  private async add(bytes: Uint8Array, params: string): Promise<KuboAddResult> {
-    if (!this.apiUrl) {
-      throw new ServiceUnavailableException('Hosted pin store not configured');
-    }
+  /** Write one block under `codec` + BLAKE3-256, unpinned. */
+  private async blockPut(bytes: Uint8Array, codec: string): Promise<KuboBlockPutResult> {
     const form = new FormData();
     // Copy into an ArrayBuffer-backed view so the Blob part type is exact. Kubo
     // requires the part to carry a filename, so pass one explicitly.
-    form.append('file', new Blob([new Uint8Array(bytes)]), 'blob');
-    const response = await fetch(`${this.apiUrl}/api/v0/add?${params}`, {
+    form.append('data', new Blob([new Uint8Array(bytes)]), 'blob');
+    const body = await this.rpc(
+      `block/put?cid-codec=${encodeURIComponent(codec)}&mhtype=blake3&mhlen=32&pin=false`,
+      form
+    );
+    // Kubo streams newline-delimited JSON; one block yields one final object.
+    const lines = body.trim().split('\n').filter(Boolean);
+    const last = lines[lines.length - 1];
+    if (!last) {
+      throw new ServiceUnavailableException('Kubo block/put returned no result');
+    }
+    return JSON.parse(last) as KuboBlockPutResult;
+  }
+
+  private async pinAdd(cid: string): Promise<void> {
+    await this.rpc(`pin/add?arg=${encodeURIComponent(cid)}&recursive=false`);
+  }
+
+  private async rpc(path: string, body?: FormData): Promise<string> {
+    if (!this.apiUrl) {
+      throw new ServiceUnavailableException('Hosted pin store not configured');
+    }
+    const response = await fetch(`${this.apiUrl}/api/v0/${path}`, {
       method: 'POST',
-      body: form,
+      body,
       signal: AbortSignal.timeout(30_000),
     });
     if (!response.ok) {
-      throw new ServiceUnavailableException(`Kubo add failed: ${response.status}`);
+      throw new ServiceUnavailableException(
+        `Kubo ${path.split('?')[0]} failed: ${response.status}`
+      );
     }
-    // Kubo streams newline-delimited JSON; a single file yields one final object.
-    const lines = (await response.text()).trim().split('\n').filter(Boolean);
-    const last = lines[lines.length - 1];
-    if (!last) {
-      throw new ServiceUnavailableException('Kubo add returned no result');
-    }
-    return JSON.parse(last) as KuboAddResult;
+    return response.text();
   }
 }

--- a/apps/api/src/registry/pin-store.ts
+++ b/apps/api/src/registry/pin-store.ts
@@ -61,9 +61,7 @@ interface KuboBlockPutResult {
  *
  * `pin` writes the block under the declared CID's own multicodec and BLAKE3-256
  * multihash, so Kubo addresses it exactly as the engine does, then pins it
- * **direct** (`recursive=false`). Direct is the correct shape for this plane:
- * every block is uploaded and registered individually, and a recursive pin would
- * make repo GC walk sealed bytes it cannot interpret.
+ * **direct** — see blueprint/api.md, Content plane, for why not recursive.
  */
 @Injectable()
 export class KuboPinStore extends PinStore {
@@ -81,13 +79,22 @@ export class KuboPinStore extends PinStore {
     if (!codec) {
       throw new PinCidMismatchError(cid, 'not a content-plane CID');
     }
-    // Written unpinned first: a block whose address disagrees is never pinned,
-    // so a wrong declaration leaves nothing but GC-reclaimable bytes behind.
+    // The block is written before its address can be checked, so every failure
+    // past this point removes it again: an unpinned block is not reclaimed
+    // (the daemon runs without --enable-gc), and leaving one behind would let a
+    // refused upload grow the datastore off the quota's books.
     const put = await this.blockPut(bytes, codec);
     if (put.Key !== cid) {
+      await this.blockRm(put.Key);
+      this.logger.warn(`upload declared ${cid} for bytes addressing ${put.Key}`);
       throw new PinCidMismatchError(cid, put.Key);
     }
-    await this.pinAdd(cid);
+    try {
+      await this.pinAdd(cid);
+    } catch (error) {
+      await this.blockRm(put.Key);
+      throw error;
+    }
   }
 
   async unpin(cid: string): Promise<boolean> {
@@ -123,16 +130,29 @@ export class KuboPinStore extends PinStore {
       form
     );
     // Kubo streams newline-delimited JSON; one block yields one final object.
+    // A trailing error object parses but carries no `Key`, and reading that as
+    // a disagreeing address would report a store fault as a permanent 400.
     const lines = body.trim().split('\n').filter(Boolean);
     const last = lines[lines.length - 1];
-    if (!last) {
-      throw new ServiceUnavailableException('Kubo block/put returned no result');
+    const parsed: unknown = last ? JSON.parse(last) : undefined;
+    if (typeof (parsed as KuboBlockPutResult | undefined)?.Key !== 'string') {
+      throw new ServiceUnavailableException('Kubo block/put returned no address');
     }
-    return JSON.parse(last) as KuboBlockPutResult;
+    return parsed as KuboBlockPutResult;
   }
 
   private async pinAdd(cid: string): Promise<void> {
     await this.rpc(`pin/add?arg=${encodeURIComponent(cid)}&recursive=false`);
+  }
+
+  /** Drop a block this upload wrote but will not pin. Best-effort: Kubo refuses
+   * to remove a pinned block, so this can never release another account's. */
+  private async blockRm(cid: string): Promise<void> {
+    try {
+      await this.rpc(`block/rm?arg=${encodeURIComponent(cid)}`);
+    } catch (error) {
+      this.logger.warn(`block/rm failed for ${cid}: ${String(error)}`);
+    }
   }
 
   private async rpc(path: string, body?: FormData): Promise<string> {

--- a/blueprint/api.md
+++ b/blueprint/api.md
@@ -99,21 +99,29 @@ decay) inverted into structure.
 - **Ingress (hosted)**: authenticated upload endpoint, quota-gated, pins to
   CipherBox Kubo, registers pins in the same traversal. BYO/dual bytes bypass
   the API entirely.
-- **The caller declares the address.** `POST /content/upload?cid=<cidv1>` carries
-  the client's own content address for the body; the API pins under exactly that
-  CID and computes none of its own. It writes the block under the declared CID's
-  multicodec (`raw` for sealed leaves, `dag-cbor` for DAG roots and record heads)
-  with a BLAKE3-256 multihash, and refuses — **400, permanent** — when the store
-  addresses the bytes differently or the declared CID is not one of those two
-  frozen shapes. Kubo's re-derivation is what binds bytes to CID; the declared
-  string is only a routing hint until it matches. The declared CID is also what
-  takes the per-CID advisory lock and keys the pin row, so a refusal compensates
-  the row exactly as a pin failure does. Blocks are pinned **direct**, not
-  recursive: every block is uploaded and registered individually, and a recursive
-  pin would make repo GC walk sealed bytes it cannot interpret.
+- **The caller declares the address.** `POST /content/upload` carries the
+  client's own content address for the body in an `X-Content-Cid` header — a
+  header, not a query parameter, because content addresses correlate across
+  accounts and edge proxies log request URLs; they stay out of the URL plane just
+  as the registry's `contentCids` stay inside JSON bodies. The API pins under
+  exactly that CID and computes none of its own. It writes the block under the
+  declared CID's multicodec (`raw` for sealed leaves, `dag-cbor` for DAG roots
+  and record heads) with a BLAKE3-256 multihash, and refuses — **400,
+  permanent** — when the store addresses the bytes differently or the declared
+  CID is not one of those two frozen shapes. Kubo's re-derivation is what binds
+  bytes to CID; the declared string is only a routing hint until it matches.
   Without this the ingress addresses blocks by its own UnixFS chunking, every
   published record points at a CID the accelerator does not hold, and the
   engine's head-CID check fails closed forever.
+- **One request, one block.** The declared CID takes the per-CID advisory lock
+  and keys the pin row, so a refusal compensates the row exactly as a pin failure
+  does — and every path that will not pin the block **removes** it, since an
+  unpinned block is not reclaimed and a refused upload must not grow the
+  datastore off the quota's books. The transport cap is the block ceiling
+  (`block/put` refuses over 2 MiB), so an over-size body is a permanent 413 here
+  rather than a retryable pin-store failure. Blocks are pinned **direct**, not
+  recursive: every block is uploaded and registered individually, and a recursive
+  pin would make repo GC walk sealed bytes it cannot interpret.
 - **Egress**: the API process serves no bytes. CipherBox runs a Kubo-backed
   **trustless gateway** (block/CAR responses, client-side CID verification)
   gated by a CipherBox auth token — an accelerator for members. Any public

--- a/blueprint/api.md
+++ b/blueprint/api.md
@@ -99,6 +99,21 @@ decay) inverted into structure.
 - **Ingress (hosted)**: authenticated upload endpoint, quota-gated, pins to
   CipherBox Kubo, registers pins in the same traversal. BYO/dual bytes bypass
   the API entirely.
+- **The caller declares the address.** `POST /content/upload?cid=<cidv1>` carries
+  the client's own content address for the body; the API pins under exactly that
+  CID and computes none of its own. It writes the block under the declared CID's
+  multicodec (`raw` for sealed leaves, `dag-cbor` for DAG roots and record heads)
+  with a BLAKE3-256 multihash, and refuses — **400, permanent** — when the store
+  addresses the bytes differently or the declared CID is not one of those two
+  frozen shapes. Kubo's re-derivation is what binds bytes to CID; the declared
+  string is only a routing hint until it matches. The declared CID is also what
+  takes the per-CID advisory lock and keys the pin row, so a refusal compensates
+  the row exactly as a pin failure does. Blocks are pinned **direct**, not
+  recursive: every block is uploaded and registered individually, and a recursive
+  pin would make repo GC walk sealed bytes it cannot interpret.
+  Without this the ingress addresses blocks by its own UnixFS chunking, every
+  published record points at a CID the accelerator does not hold, and the
+  engine's head-CID check fails closed forever.
 - **Egress**: the API process serves no bytes. CipherBox runs a Kubo-backed
   **trustless gateway** (block/CAR responses, client-side CID verification)
   gated by a CipherBox auth token — an accelerator for members. Any public

--- a/blueprint/testing.md
+++ b/blueprint/testing.md
@@ -130,7 +130,10 @@ refresh rotation, SIWE secondary; test-login environment gating asserted
 (production mode must refuse); **register-first fail-closed** — publishing
 an unregistered name is refused; batch register/retire idempotency; union
 liveness and refcounted physical unpin; quota (hosted authoritative, BYO
-`advisory: true`); hosted upload; the mailbox lifecycle (post/poll/ack,
+`advisory: true`); hosted upload — including that the pinned address **equals**
+the caller-computed one under both content-plane codecs, and that a declared
+address the bytes do not hash to is refused and compensated;
+the mailbox lifecycle (post/poll/ack,
 idempotency keys, pending-cap reject-new, unknown-recipient rejection);
 the recovery endpoint (auth + rate limit); account hard-delete cascade;
 the republisher module's inventory walk and resolve-failure alerting; and

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -15,6 +15,7 @@ publish.workspace = true
 # merge-blocking `contract-suite` CI job, which stands up that stack.
 
 [dependencies]
+cipherbox-core.workspace = true
 cipherbox-engine.workspace = true
 # featureless reqwest (no TLS backend, matching the tauri resolution): the API
 # is reached over plain http on localhost in CI, so no TLS/OpenSSL is linked.

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -146,6 +146,14 @@ pub fn prod_api_url() -> Option<String> {
     non_empty("CONTRACT_API_PROD_URL")
 }
 
+/// The base URL of the stack's IPFS gateway, from `CONTRACT_GATEWAY_URL` — how
+/// a read path fetches a block the ingress pinned. Set by the CI job alongside
+/// [`api_url`]; a suite that has an API but no gateway is a misconfiguration,
+/// so the leg that needs it fails loudly rather than skipping.
+pub fn gateway_url() -> Option<String> {
+    non_empty("CONTRACT_GATEWAY_URL")
+}
+
 /// The shared test-login secret; must equal the API's `TEST_LOGIN_SECRET`.
 pub fn test_login_secret() -> String {
     std::env::var("CONTRACT_TEST_LOGIN_SECRET").unwrap_or_else(|_| "contract-suite-secret".into())

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -14,7 +14,7 @@
 //! sets it (and boots the stack), so the assertions always run there.
 
 use cipherbox_contract::{
-    MemoryCredentialStore, ReqwestHttp, api_url, hex_to_scalar, prod_api_url,
+    MemoryCredentialStore, ReqwestHttp, api_url, gateway_url, hex_to_scalar, prod_api_url,
     random_identity_signer, test_login_secret,
 };
 use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, encode_content_cid_str};
@@ -475,14 +475,39 @@ fn leaf_cid(bytes: &[u8]) -> String {
     encode_content_cid_str(&compute_cid(CONTENT_CID_CODEC, bytes))
 }
 
+/// Fetch one block back from the stack's trustless gateway by CID — the read
+/// path's view of what the ingress actually pinned.
+async fn fetch_block(cid: &str) -> Vec<u8> {
+    let gateway = gateway_url().expect(
+        "CONTRACT_GATEWAY_URL must be set alongside CONTRACT_API_URL; the suite cannot prove a \
+         pinned block is retrievable without the stack's gateway",
+    );
+    let response = ReqwestHttp::new()
+        .send(HttpRequest {
+            method: HttpMethod::Get,
+            url: format!("{gateway}/ipfs/{cid}?format=raw"),
+            headers: vec![("Accept".to_owned(), "application/vnd.ipld.raw".to_owned())],
+            body: None,
+        })
+        .await
+        .expect("gateway request");
+    assert_eq!(
+        response.status, 200,
+        "the gateway serves the pinned block at {cid}"
+    );
+    response.body
+}
+
 /// Hosted ingress pins under the **caller-computed** content address (#906,
 /// blueprint/api.md Ingress). The engine addresses every block as CIDv1 base32
 /// over a BLAKE3-256 multihash — `raw` for sealed leaves, `dag-cbor` for DAG
 /// roots and record heads — and a published record's value is `/ipfs/<that
 /// CID>`. If the store pinned bytes under an address of its own choosing, every
-/// record would point at a block the accelerator does not hold; only comparing
-/// the returned address to the declared one can catch that, which is exactly
-/// what no test could assert before the declared CID existed on the wire.
+/// record would point at a block the accelerator does not hold.
+///
+/// The proof is the gateway round-trip, not the echoed CID: the API answers
+/// with the address it was handed, so only fetching `/ipfs/<declared>` back and
+/// byte-comparing shows the block really landed there.
 #[tokio::test]
 async fn upload_pins_under_the_caller_computed_content_address() {
     let base = require_stack!("upload_pins_under_the_caller_computed_content_address");
@@ -497,7 +522,12 @@ async fn upload_pins_under_the_caller_computed_content_address() {
         .expect("a leaf uploads under its own address");
     assert_eq!(
         pinned.cid, declared_leaf,
-        "the pinned address is the address the caller computed"
+        "the API answers about our address"
+    );
+    assert_eq!(
+        fetch_block(&declared_leaf).await,
+        leaf,
+        "the gateway serves our exact bytes at the address we computed"
     );
 
     // A DAG root over that leaf: `dag-cbor` codec, real det-CBOR bytes — the
@@ -520,9 +550,11 @@ async fn upload_pins_under_the_caller_computed_content_address() {
         .upload(&declared_root, &dag.root_block)
         .await
         .expect("a dag-cbor root uploads under its own address");
+    assert_eq!(pinned_root.cid, declared_root);
     assert_eq!(
-        pinned_root.cid, declared_root,
-        "a dag-cbor root pins under the caller's address, not a re-chunked one"
+        fetch_block(&declared_root).await,
+        dag.root_block,
+        "a dag-cbor root is served at the caller's address, not a re-chunked one"
     );
 
     // Fail closed on a declared address the bytes do not hash to: a permanent

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -534,9 +534,9 @@ async fn upload_pins_under_the_caller_computed_content_address() {
         .used_bytes;
     // A CID no row references yet, so the ledger's idempotent re-upload
     // short-circuit cannot stand in for a real pin.
-    let unregistered = leaf_cid(&vec![7u8; 96]);
+    let unregistered = leaf_cid(&[7u8; 96]);
     let mismatch = client
-        .upload(&unregistered, &vec![9u8; 96])
+        .upload(&unregistered, &[9u8; 96])
         .await
         .expect_err("bytes that do not address to the declared CID are refused");
     assert!(

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -21,7 +21,7 @@ use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, encode_content_cid
 use cipherbox_engine::api::{
     ApiClient, ApiError, ChallengeSigner, IdentityChallengeSigner, NameRegistration,
 };
-use cipherbox_engine::content::{ContentProfile, DAG_ROOT_CODEC, SealedChunk, assemble};
+use cipherbox_engine::content::{ContentProfile, DAG_ROOT_CODEC, assemble};
 use cipherbox_engine::seams::{CredentialStore, Http, HttpMethod, HttpRequest};
 
 type Client = ApiClient<ReqwestHttp, MemoryCredentialStore>;
@@ -533,10 +533,7 @@ async fn upload_pins_under_the_caller_computed_content_address() {
     // A DAG root over that leaf: `dag-cbor` codec, real det-CBOR bytes — the
     // same shape a record head block takes on the metadata publish path.
     let dag = assemble(
-        &[SealedChunk {
-            cid: compute_cid(CONTENT_CID_CODEC, &leaf),
-            sealed: leaf.clone(),
-        }],
+        &[compute_cid(CONTENT_CID_CODEC, &leaf)],
         ContentProfile::CI.chunk_size() as u64,
         &ContentProfile::CI,
     )
@@ -697,14 +694,19 @@ async fn a_content_version_uploads_registers_and_retires_as_one_block_set() {
     // suffix, so a resumed drain re-sends only what has not landed.
     let mut content_cids = Vec::new();
     for block in leaves.iter().chain(core::iter::once(&root)) {
+        let declared = leaf_cid(block);
         let uploaded = client
-            .upload(block)
+            .upload(&declared, block)
             .await
             .unwrap_or_else(|e| panic!("a version block uploads: {e:?}"));
         assert_eq!(
             uploaded.size,
             block.len() as u64,
             "the ingress reports the byte count it counted"
+        );
+        assert_eq!(
+            uploaded.cid, declared,
+            "every block of the version pins under the address the drain computed"
         );
         content_cids.push(uploaded.cid);
     }

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -17,9 +17,11 @@ use cipherbox_contract::{
     MemoryCredentialStore, ReqwestHttp, api_url, hex_to_scalar, prod_api_url,
     random_identity_signer, test_login_secret,
 };
+use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, encode_content_cid_str};
 use cipherbox_engine::api::{
     ApiClient, ApiError, ChallengeSigner, IdentityChallengeSigner, NameRegistration,
 };
+use cipherbox_engine::content::{ContentProfile, DAG_ROOT_CODEC, SealedChunk, assemble};
 use cipherbox_engine::seams::{CredentialStore, Http, HttpMethod, HttpRequest};
 
 type Client = ApiClient<ReqwestHttp, MemoryCredentialStore>;
@@ -467,6 +469,101 @@ async fn union_liveness_is_per_account_and_permissionless() {
         .expect("bob retires the last row");
 }
 
+/// The engine's own content address for a sealed leaf — the `raw` codec core
+/// fixes for content blocks.
+fn leaf_cid(bytes: &[u8]) -> String {
+    encode_content_cid_str(&compute_cid(CONTENT_CID_CODEC, bytes))
+}
+
+/// Hosted ingress pins under the **caller-computed** content address (#906,
+/// blueprint/api.md Ingress). The engine addresses every block as CIDv1 base32
+/// over a BLAKE3-256 multihash — `raw` for sealed leaves, `dag-cbor` for DAG
+/// roots and record heads — and a published record's value is `/ipfs/<that
+/// CID>`. If the store pinned bytes under an address of its own choosing, every
+/// record would point at a block the accelerator does not hold; only comparing
+/// the returned address to the declared one can catch that, which is exactly
+/// what no test could assert before the declared CID existed on the wire.
+#[tokio::test]
+async fn upload_pins_under_the_caller_computed_content_address() {
+    let base = require_stack!("upload_pins_under_the_caller_computed_content_address");
+    let client = fresh_account(&base).await;
+
+    // A sealed content leaf: `raw` codec.
+    let leaf = vec![42u8; 96];
+    let declared_leaf = leaf_cid(&leaf);
+    let pinned = client
+        .upload(&declared_leaf, &leaf)
+        .await
+        .expect("a leaf uploads under its own address");
+    assert_eq!(
+        pinned.cid, declared_leaf,
+        "the pinned address is the address the caller computed"
+    );
+
+    // A DAG root over that leaf: `dag-cbor` codec, real det-CBOR bytes — the
+    // same shape a record head block takes on the metadata publish path.
+    let dag = assemble(
+        &[SealedChunk {
+            cid: compute_cid(CONTENT_CID_CODEC, &leaf),
+            sealed: leaf.clone(),
+        }],
+        ContentProfile::CI.chunk_size() as u64,
+        &ContentProfile::CI,
+    )
+    .expect("assemble a one-leaf root");
+    assert_eq!(
+        dag.content_cid[1], DAG_ROOT_CODEC,
+        "the root carries the dag-cbor codec, so both content-plane codecs are exercised"
+    );
+    let declared_root = encode_content_cid_str(&dag.content_cid);
+    let pinned_root = client
+        .upload(&declared_root, &dag.root_block)
+        .await
+        .expect("a dag-cbor root uploads under its own address");
+    assert_eq!(
+        pinned_root.cid, declared_root,
+        "a dag-cbor root pins under the caller's address, not a re-chunked one"
+    );
+
+    // Fail closed on a declared address the bytes do not hash to: a permanent
+    // 400, and the refused upload leaves no quota charge behind.
+    let used_before = client
+        .quota()
+        .await
+        .expect("quota before the mismatch")
+        .used_bytes;
+    // A CID no row references yet, so the ledger's idempotent re-upload
+    // short-circuit cannot stand in for a real pin.
+    let unregistered = leaf_cid(&vec![7u8; 96]);
+    let mismatch = client
+        .upload(&unregistered, &vec![9u8; 96])
+        .await
+        .expect_err("bytes that do not address to the declared CID are refused");
+    assert!(
+        matches!(mismatch, ApiError::Status { status: 400, .. }),
+        "a CID/bytes mismatch is a permanent 400, got {mismatch:?}"
+    );
+    assert_eq!(
+        client
+            .quota()
+            .await
+            .expect("quota after the mismatch")
+            .used_bytes,
+        used_before,
+        "a refused upload is compensated, not charged"
+    );
+
+    // A malformed declaration never reaches the pin path.
+    let malformed = client
+        .upload("not-a-cid", &leaf)
+        .await
+        .expect_err("a non-canonical content CID is refused");
+    assert!(
+        matches!(malformed, ApiError::MalformedContentCid),
+        "the client refuses a non-canonical CID before the wire, got {malformed:?}"
+    );
+}
+
 /// Quota + hosted ingress (blueprint/api.md; #629, #701): hosted accounts are
 /// authoritative (`advisory: false`) with a positive limit and gate uploads; a
 /// BYO account's quota is advisory (`advisory: true`, quota always allows) and
@@ -491,11 +588,11 @@ async fn quota_is_hosted_authoritative_and_byo_advisory() {
     );
 
     // A sub-limit hosted upload is pinned to Kubo and counts against the quota.
+    let under = vec![7u8; 512];
     let pinned = client
-        .upload(&vec![7u8; 512])
+        .upload(&leaf_cid(&under), &under)
         .await
         .expect("hosted upload under quota is pinned");
-    assert!(!pinned.cid.is_empty(), "the pinned CID is returned");
     assert_eq!(pinned.size, 512, "size is the uploaded byte count");
     assert_eq!(
         client.quota().await.expect("quota after upload").used_bytes,
@@ -504,8 +601,9 @@ async fn quota_is_hosted_authoritative_and_byo_advisory() {
     );
 
     // An upload crossing the 1 KiB limit is refused for a hosted account.
+    let over = vec![9u8; 600];
     let error = client
-        .upload(&vec![9u8; 600])
+        .upload(&leaf_cid(&over), &over)
         .await
         .expect_err("an over-quota upload is refused for a hosted account");
     assert!(
@@ -524,8 +622,9 @@ async fn quota_is_hosted_authoritative_and_byo_advisory() {
         byo.limit_bytes, hosted.limit_bytes,
         "the limit is unchanged"
     );
+    let byo_bytes = vec![3u8; 4096];
     let refused = client
-        .upload(&vec![3u8; 4096])
+        .upload(&leaf_cid(&byo_bytes), &byo_bytes)
         .await
         .expect_err("a BYO account cannot ingress to hosted Kubo");
     assert!(

--- a/crates/engine/src/api/client.rs
+++ b/crates/engine/src/api/client.rs
@@ -11,7 +11,7 @@ use core::cell::RefCell;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use cipherbox_core::content::decode_content_cid_str;
+use cipherbox_core::content::{CONTENT_CID_CODEC, decode_content_cid_str};
 use futures_channel::oneshot;
 use serde::Serialize;
 use zeroize::Zeroizing;
@@ -24,12 +24,19 @@ use super::types::{
     SiweChallengeResponse, SiweLoginRequest, SiweNonce, TestLoginOutcome, TestLoginRequest,
     TestLoginResponse, TokenResponse, UploadResult,
 };
+use crate::content::DAG_ROOT_CODEC;
 use crate::seams::{CredentialStore, Http, HttpMethod, HttpRequest, HttpResponse};
 
 const CONTENT_TYPE: &str = "Content-Type";
 const AUTHORIZATION: &str = "Authorization";
 const APPLICATION_JSON: &str = "application/json";
 const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";
+/// Carries an upload's declared content address. A header, not a query
+/// parameter: content addresses correlate across accounts and edge proxies log
+/// URLs (blueprint/api.md, Accepted exposure).
+const CONTENT_CID: &str = "X-Content-Cid";
+/// Byte offset of the multicodec in the frozen CIDv1 framing.
+const CID_CODEC_INDEX: usize = 1;
 
 /// Mutable client state, single-owner behind a [`RefCell`]: the engine is the
 /// single writer (blueprint/engine.md Facade), so interior mutability with no
@@ -292,13 +299,21 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
     /// own content address for them. The API pins under exactly that address
     /// and refuses bytes that do not hash to it, so the block the network
     /// serves is the block the engine authored (blueprint/api.md, Ingress).
+    ///
+    /// Refused fail-closed unless `cid` is a canonical content-plane address
+    /// under one of the two codecs the ingress accepts — matching the API's
+    /// own set, so a wider one breaks here rather than as a 400 in production.
     pub async fn upload(&self, cid: &str, content: &[u8]) -> Result<UploadResult, ApiError> {
-        decode_content_cid_str(cid).map_err(|_| ApiError::MalformedContentCid)?;
+        let decoded = decode_content_cid_str(cid).map_err(|_| ApiError::MalformedContentCid)?;
+        if !matches!(decoded[CID_CODEC_INDEX], CONTENT_CID_CODEC | DAG_ROOT_CODEC) {
+            return Err(ApiError::MalformedContentCid);
+        }
         let response = self
-            .request_authed(
+            .request_authed_with(
                 HttpMethod::Post,
-                &format!("/content/upload?cid={cid}"),
+                "/content/upload",
                 Some(APPLICATION_OCTET_STREAM),
+                &[(CONTENT_CID, cid)],
                 Some(content.to_vec()),
             )
             .await?;
@@ -448,8 +463,21 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
         content_type: Option<&str>,
         body: Option<Vec<u8>>,
     ) -> Result<HttpResponse, ApiError> {
+        self.request_authed_with(method, path, content_type, &[], body)
+            .await
+    }
+
+    /// [`Self::request_authed`], plus request-specific headers.
+    async fn request_authed_with(
+        &self,
+        method: HttpMethod,
+        path: &str,
+        content_type: Option<&str>,
+        extra_headers: &[(&str, &str)],
+        body: Option<Vec<u8>>,
+    ) -> Result<HttpResponse, ApiError> {
         let first = self
-            .send_with_token(method, path, content_type, body.clone())
+            .send_with_token(method, path, content_type, extra_headers, body.clone())
             .await?;
         if first.status != 401 {
             return Ok(first);
@@ -457,7 +485,8 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
         // One refresh, then one retry; a second 401 is terminal (the caller
         // maps it via `ok_or_err`).
         self.refresh().await?;
-        self.send_with_token(method, path, content_type, body).await
+        self.send_with_token(method, path, content_type, extra_headers, body)
+            .await
     }
 
     /// Send a request, attaching the in-memory access token as a bearer when
@@ -469,11 +498,15 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
         method: HttpMethod,
         path: &str,
         content_type: Option<&str>,
+        extra_headers: &[(&str, &str)],
         body: Option<Vec<u8>>,
     ) -> Result<HttpResponse, ApiError> {
         let mut headers = Vec::new();
         if let Some(content_type) = content_type {
             headers.push((CONTENT_TYPE.to_owned(), content_type.to_owned()));
+        }
+        for (name, value) in extra_headers {
+            headers.push(((*name).to_owned(), (*value).to_owned()));
         }
         // Scope the borrow so it never crosses the await below.
         if let Some(token) = self.state.borrow().access_token.as_ref() {
@@ -1053,8 +1086,15 @@ mod tests {
         assert_eq!(result.cid, cid);
         let request = http.requests().pop().expect("upload request");
         assert_eq!(
-            request.url,
-            format!("http://api.test/content/upload?cid={cid}")
+            request.url, "http://api.test/content/upload",
+            "the address rides a header, never the URL"
+        );
+        assert!(
+            request
+                .headers
+                .iter()
+                .any(|(name, value)| name == CONTENT_CID && *value == cid),
+            "the declared address is sent"
         );
         assert_eq!(request.body.as_deref(), Some(&block[..]));
     }
@@ -1065,9 +1105,26 @@ mod tests {
         login(&http, &client);
         let sent_after_login = http.requests().len();
 
-        // A query-splicing attempt is not core's canonical CID string, so it is
-        // refused before it can reach the URL.
-        let error = block_on(client.upload("bafkr4i&pin=false", b"bytes")).expect_err("refused");
+        let error = block_on(client.upload("not-a-canonical-cid", b"bytes")).expect_err("refused");
+
+        assert!(matches!(error, ApiError::MalformedContentCid));
+        assert_eq!(
+            http.requests().len(),
+            sent_after_login,
+            "no request left the client"
+        );
+    }
+
+    #[test]
+    fn upload_refuses_a_codec_the_ingress_does_not_accept() {
+        let (http, _creds, client) = fakes();
+        login(&http, &client);
+        let sent_after_login = http.requests().len();
+
+        // Canonically framed, but `dag-pb` (0x70) is outside the frozen
+        // content-plane set the ingress routes.
+        let cid = encode_content_cid_str(&compute_cid(0x70, b"block"));
+        let error = block_on(client.upload(&cid, b"block")).expect_err("refused");
 
         assert!(matches!(error, ApiError::MalformedContentCid));
         assert_eq!(

--- a/crates/engine/src/api/client.rs
+++ b/crates/engine/src/api/client.rs
@@ -597,6 +597,8 @@ fn decode<T: serde::de::DeserializeOwned>(response: &HttpResponse) -> Result<T, 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, encode_content_cid_str};
+
     use crate::testkit::block_on;
     use crate::testkit::fakes::{InMemoryCredentialStore, ScriptedHttp};
     use serde_json::{Value, json};
@@ -1033,5 +1035,45 @@ mod tests {
         assert!(matches!(second.as_mut().poll(&mut cx), Poll::Ready(Ok(()))));
         assert_eq!(http.request_count(), 1, "one refresh served both callers");
         assert!(client.is_authenticated());
+    }
+
+    #[test]
+    fn upload_declares_the_block_address_on_the_wire() {
+        let (http, _creds, client) = fakes();
+        login(&http, &client);
+        let block = b"sealed-block".to_vec();
+        let cid = encode_content_cid_str(&compute_cid(CONTENT_CID_CODEC, &block));
+        http.enqueue_response(json_response(
+            201,
+            json!({ "cid": cid, "size": block.len() }),
+        ));
+
+        let result = block_on(client.upload(&cid, &block)).expect("upload");
+
+        assert_eq!(result.cid, cid);
+        let request = http.requests().pop().expect("upload request");
+        assert_eq!(
+            request.url,
+            format!("http://api.test/content/upload?cid={cid}")
+        );
+        assert_eq!(request.body.as_deref(), Some(&block[..]));
+    }
+
+    #[test]
+    fn upload_refuses_a_non_canonical_content_cid_before_the_wire() {
+        let (http, _creds, client) = fakes();
+        login(&http, &client);
+        let sent_after_login = http.requests().len();
+
+        // A query-splicing attempt is not core's canonical CID string, so it is
+        // refused before it can reach the URL.
+        let error = block_on(client.upload("bafkr4i&pin=false", b"bytes")).expect_err("refused");
+
+        assert!(matches!(error, ApiError::MalformedContentCid));
+        assert_eq!(
+            http.requests().len(),
+            sent_after_login,
+            "no request left the client"
+        );
     }
 }

--- a/crates/engine/src/api/client.rs
+++ b/crates/engine/src/api/client.rs
@@ -11,6 +11,7 @@ use core::cell::RefCell;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use cipherbox_core::content::decode_content_cid_str;
 use futures_channel::oneshot;
 use serde::Serialize;
 use zeroize::Zeroizing;
@@ -287,12 +288,16 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
         decode(&response)
     }
 
-    /// Upload content bytes to the hosted pin store.
-    pub async fn upload(&self, content: &[u8]) -> Result<UploadResult, ApiError> {
+    /// Upload content bytes to the hosted pin store under `cid`, the caller's
+    /// own content address for them. The API pins under exactly that address
+    /// and refuses bytes that do not hash to it, so the block the network
+    /// serves is the block the engine authored (blueprint/api.md, Ingress).
+    pub async fn upload(&self, cid: &str, content: &[u8]) -> Result<UploadResult, ApiError> {
+        decode_content_cid_str(cid).map_err(|_| ApiError::MalformedContentCid)?;
         let response = self
             .request_authed(
                 HttpMethod::Post,
-                "/content/upload",
+                &format!("/content/upload?cid={cid}"),
                 Some(APPLICATION_OCTET_STREAM),
                 Some(content.to_vec()),
             )

--- a/crates/engine/src/api/error.rs
+++ b/crates/engine/src/api/error.rs
@@ -49,9 +49,9 @@ pub enum ApiError {
     /// never the body bytes.
     Decode(String),
     /// A caller-supplied content address was not core's canonical CIDv1 base32
-    /// string, so no request was sent. Refused here because the address is
-    /// interpolated into the request URL and may originate in resolved
-    /// metadata — a non-canonical one must never reach the wire.
+    /// string under a content-plane codec, so no request was sent. Refused
+    /// here because the address is what the ingress pins under — a
+    /// non-canonical one must never reach the wire.
     MalformedContentCid,
 }
 

--- a/crates/engine/src/api/error.rs
+++ b/crates/engine/src/api/error.rs
@@ -48,6 +48,11 @@ pub enum ApiError {
     /// A 2xx body did not match the expected shape. Carries a short reason,
     /// never the body bytes.
     Decode(String),
+    /// A caller-supplied content address was not core's canonical CIDv1 base32
+    /// string, so no request was sent. Refused here because the address is
+    /// interpolated into the request URL and may originate in resolved
+    /// metadata — a non-canonical one must never reach the wire.
+    MalformedContentCid,
 }
 
 impl From<SeamError> for ApiError {
@@ -74,6 +79,9 @@ impl fmt::Display for ApiError {
                 ..
             } => write!(f, "api returned status {status}"),
             ApiError::Decode(reason) => write!(f, "api response decode error: {reason}"),
+            ApiError::MalformedContentCid => {
+                f.write_str("api call carried a non-canonical content CID")
+            }
         }
     }
 }

--- a/crates/engine/src/net/record_publish.rs
+++ b/crates/engine/src/net/record_publish.rs
@@ -160,13 +160,15 @@ pub struct RecordPublishRequest<'a> {
 pub enum RecordPublishError {
     /// The head block upload failed; nothing was published.
     Upload(ApiError),
-    /// The pin store reported a CID other than the block's own address, so the
-    /// bytes it holds are not the bytes we authored. Publishing our CID anyway
-    /// would sign a pointer to a block nothing pinned — refused fail-closed.
+    /// The API did not echo the address we declared, so it is not answering
+    /// about the block we uploaded. Publishing our CID on that answer would
+    /// sign a pointer to a block nothing confirmed — refused fail-closed. The
+    /// bytes/CID binding itself is enforced at the ingress, which refuses bytes
+    /// that do not hash to the declared address (blueprint/api.md).
     HeadCidMismatch {
-        /// The head block's own content address.
+        /// The head block's own content address, as declared.
         expected: String,
-        /// What the pin store reported.
+        /// What the API echoed back.
         returned: String,
     },
     /// The publish pipeline failed.

--- a/crates/engine/src/net/record_publish.rs
+++ b/crates/engine/src/net/record_publish.rs
@@ -194,7 +194,7 @@ where
     Sch: Scheduler + Clone + 'static,
 {
     let uploaded = api
-        .upload(&request.head.block)
+        .upload(&request.head.cid, &request.head.block)
         .await
         .map_err(RecordPublishError::Upload)?;
     if uploaded.cid != request.head.cid {

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -1314,7 +1314,7 @@ where
         for (index, leaf_cid) in content.leaf_cids().iter().enumerate() {
             match self.staged_block(leaf_cid).await? {
                 Some(block) => {
-                    self.upload_block(&block).await?;
+                    self.upload_block(leaf_cid, &block).await?;
                     self.staging
                         .remove_staged_bytes(leaf_cid)
                         .await
@@ -1330,7 +1330,7 @@ where
         // The root goes up last and stays staged until the publish confirms: it
         // is the manifest every retry re-derives the plan from, so releasing it
         // before the record lands would strand a fully-uploaded version.
-        self.upload_block(&root_block).await?;
+        self.upload_block(&staged.root_cid, &root_block).await?;
 
         let content_cids = core::iter::once(&staged.root_cid)
             .chain(content.leaf_cids())
@@ -1386,12 +1386,14 @@ where
         Ok(Some(block))
     }
 
-    /// Upload one block to the pin provider. A block is only ever removed from
-    /// staging on a confirmed [`UploadResult`](crate::UploadResult), which is
-    /// what makes the still-staged set a suffix.
-    async fn upload_block(&self, block: &[u8]) -> Result<(), Halt> {
+    /// Upload one block to the pin provider under `cid`, its staging key and
+    /// own content address, so the ingress pins it where the published record
+    /// points (#906). A block is only ever removed from staging on a confirmed
+    /// [`UploadResult`](crate::UploadResult), which is what makes the
+    /// still-staged set a suffix.
+    async fn upload_block(&self, cid: &[u8], block: &[u8]) -> Result<(), Halt> {
         self.api
-            .upload(block)
+            .upload(&encode_content_cid_str(cid), block)
             .await
             .map(drop)
             .map_err(|error| classify_upload(error, block.len() as u64))

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -114,6 +114,22 @@ impl Blocks {
         root_cid
     }
 
+    /// Store an uploaded block under the address its caller declared, refusing
+    /// one the bytes do not hash to under either content-plane codec — the
+    /// ingress's put-and-compare (#906).
+    fn put_declared(&self, declared: &str, block: Vec<u8>) {
+        let raw = encode_content_cid_str(&compute_cid(CONTENT_CID_CODEC, &block));
+        let root = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &block));
+        assert!(
+            declared == raw || declared == root,
+            "upload declared an address it does not hash to"
+        );
+        self.store
+            .lock()
+            .expect("lock")
+            .insert(declared.to_owned(), block);
+    }
+
     fn get(&self, cid: &str) -> Option<Vec<u8>> {
         self.store.lock().expect("lock").get(cid).cloned()
     }
@@ -161,13 +177,10 @@ impl Blocks {
             }
             let size = block.len();
             // Mirror the API's fail-closed bind (#906): the block is stored —
-            // and served back — only under the address the caller declared.
-            let cid = self.put(block);
-            assert_eq!(
-                declared, cid,
-                "upload declared an address it does not hash to"
-            );
-            return ok(format!("{{\"cid\":\"{cid}\",\"size\":{size}}}").into_bytes());
+            // and served back — only under the address the caller declared,
+            // and only once those bytes really address to it.
+            self.put_declared(&declared, block);
+            return ok(format!("{{\"cid\":\"{declared}\",\"size\":{size}}}").into_bytes());
         }
         if url.ends_with("/account/quota") {
             let (used, limit) = self

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -160,7 +160,10 @@ impl Blocks {
             // Mirror the API's fail-closed bind (#906): the block is stored —
             // and served back — only under the address the caller declared.
             let cid = self.put(block);
-            assert_eq!(declared, cid, "upload declared an address it does not hash to");
+            assert_eq!(
+                declared, cid,
+                "upload declared an address it does not hash to"
+            );
             return ok(format!("{{\"cid\":\"{cid}\",\"size\":{size}}}").into_bytes());
         }
         if url.ends_with("/account/quota") {

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -146,10 +146,13 @@ impl Blocks {
             })
         };
         let url = &request.url;
-        if let Some((path, query)) = url.split_once('?')
-            && path.ends_with("/content/upload")
-        {
-            let declared = query.strip_prefix("cid=").expect("upload declares its CID");
+        if url.ends_with("/content/upload") {
+            let declared = request
+                .headers
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case("X-Content-Cid"))
+                .map(|(_, value)| value.clone())
+                .expect("upload declares its CID");
             let block = request.body.clone().unwrap_or_default();
             if let Some(hook) = self.on_upload.lock().expect("lock").as_mut()
                 && let Some(reply) = hook(&block)
@@ -394,7 +397,7 @@ fn uploaded_node_ids(device: &FakeDevice) -> Vec<[u8; 16]> {
         .http
         .requests()
         .iter()
-        .filter(|request| request.url.contains("/content/upload?"))
+        .filter(|request| request.url.ends_with("/content/upload"))
         .filter_map(|request| decode_envelope(request.body.as_deref()?).ok())
         .map(|envelope| envelope.id)
         .collect()
@@ -2036,7 +2039,7 @@ fn every_record_one_pass_seals_carries_a_distinct_nonce() {
         .http
         .requests()
         .iter()
-        .filter(|request| request.url.contains("/content/upload?"))
+        .filter(|request| request.url.ends_with("/content/upload"))
         .filter_map(|request| decode_envelope(request.body.as_deref()?).ok())
         // `readSealed` is `nonce(24) || ciphertext||tag`.
         .map(|envelope| envelope.read_sealed[..24].to_vec())
@@ -2409,7 +2412,7 @@ fn uploads(device: &FakeDevice) -> usize {
         .http
         .requests()
         .iter()
-        .filter(|request| request.url.contains("/content/upload?"))
+        .filter(|request| request.url.ends_with("/content/upload"))
         .count()
 }
 

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -146,7 +146,10 @@ impl Blocks {
             })
         };
         let url = &request.url;
-        if url.ends_with("/content/upload") {
+        if let Some((path, query)) = url.split_once('?')
+            && path.ends_with("/content/upload")
+        {
+            let declared = query.strip_prefix("cid=").expect("upload declares its CID");
             let block = request.body.clone().unwrap_or_default();
             if let Some(hook) = self.on_upload.lock().expect("lock").as_mut()
                 && let Some(reply) = hook(&block)
@@ -154,7 +157,10 @@ impl Blocks {
                 return reply;
             }
             let size = block.len();
+            // Mirror the API's fail-closed bind (#906): the block is stored —
+            // and served back — only under the address the caller declared.
             let cid = self.put(block);
+            assert_eq!(declared, cid, "upload declared an address it does not hash to");
             return ok(format!("{{\"cid\":\"{cid}\",\"size\":{size}}}").into_bytes());
         }
         if url.ends_with("/account/quota") {
@@ -385,7 +391,7 @@ fn uploaded_node_ids(device: &FakeDevice) -> Vec<[u8; 16]> {
         .http
         .requests()
         .iter()
-        .filter(|request| request.url.ends_with("/content/upload"))
+        .filter(|request| request.url.contains("/content/upload?"))
         .filter_map(|request| decode_envelope(request.body.as_deref()?).ok())
         .map(|envelope| envelope.id)
         .collect()
@@ -2027,7 +2033,7 @@ fn every_record_one_pass_seals_carries_a_distinct_nonce() {
         .http
         .requests()
         .iter()
-        .filter(|request| request.url.ends_with("/content/upload"))
+        .filter(|request| request.url.contains("/content/upload?"))
         .filter_map(|request| decode_envelope(request.body.as_deref()?).ok())
         // `readSealed` is `nonce(24) || ciphertext||tag`.
         .map(|envelope| envelope.read_sealed[..24].to_vec())
@@ -2400,7 +2406,7 @@ fn uploads(device: &FakeDevice) -> usize {
         .http
         .requests()
         .iter()
-        .filter(|request| request.url.ends_with("/content/upload"))
+        .filter(|request| request.url.contains("/content/upload?"))
         .count()
 }
 


### PR DESCRIPTION
Closes #906. Unblocks #871 and #653.

## The defect

`KuboPinStore` uploaded through `/api/v0/add`, so Kubo returned a CIDv0 `dag-pb` sha2-256 hash. The engine addresses every block as CIDv1 base32 over a BLAKE3-256 multihash — `raw` for sealed content leaves, `dag-cbor` for DAG roots and record heads. The two can never be equal, so every published record pointed at a CID the accelerator does not hold and `publish_record` failed closed forever on `HeadCidMismatch`.

## The surface

The issue's preferred option, confirmed workable against the local Kubo v0.42.0 before it was built:

- `POST /content/upload` carries the caller's own content address in an **`X-Content-Cid` header**. A header rather than a query parameter: content addresses correlate across accounts, and edge proxies log request URLs — so they stay out of the URL plane exactly as the registry's `contentCids` stay inside JSON bodies. It also keeps URL interpolation out of the engine client entirely.
- The pin store writes the block with `block/put?cid-codec=<from the declared CID>&mhtype=blake3&mhlen=32&pin=false`, compares Kubo's returned `Key` to the declared string, and only then pins it. A disagreement is a permanent **400**, not a retriable 503 — the declaration is wrong and retrying the same body can never succeed.
- `PinStore.hash` is gone. The API computes no content address of its own; the declared CID is what takes the per-CID advisory lock, keys the pin row, and is echoed back. Kubo's re-derivation is what binds bytes to CID — the declared string is only a routing hint until it matches.
- The API reads the multicodec out of the frozen CIDv1 framing by prefix (`bafkr4i` -> `raw`, `bafyr4i` -> `dag-cbor`) rather than decoding or recomputing anything, so no codec or crypto lands in TypeScript. Anything outside those two frozen shapes is refused before any lock or quota work. The mapping cannot be a trust hole: the codec is embedded in the address Kubo returns, so a wrong one simply fails the comparison.
- **Every path that will not pin the block removes it.** `block/put` persists before the address can be checked, and an unpinned block is not reclaimed — the daemon runs without `--enable-gc`. So a refused upload cleans up after itself; Kubo refuses to remove a *pinned* block, so the cleanup can never release another account's content.
- **One request, one block.** `MAX_UPLOAD_BYTES` now defaults to the 2 MiB `block/put` ceiling, so an over-size body is a permanent 413 (`UPLOAD_TOO_LARGE`, which the drain dead-letters) rather than a retry-forever 503.

### Direct pins, not recursive

`block/put --pin` produces a **recursive** pin, and Kubo's repo GC then walks it. A `dag-cbor`-codec block whose bytes are not decodable CBOR aborts GC for the whole node — reproduced locally: `could not retrieve links for bafyr4i...: unexpected content after end of cbor object; garbage collection aborted`. Any authenticated account could have parked one there. Blocks are therefore written unpinned and pinned **direct** via `pin/add?recursive=false`, which is also the correct shape for this plane: every block is uploaded and registered individually, and Kubo itself rejects an undecodable `dag-cbor` block at `pin/add`.

## What the contract assertion now proves

`upload_pins_under_the_caller_computed_content_address` runs in the merge-blocking `contract-suite` job against a real API and a real Kubo. The load-bearing proof is a **gateway round-trip**, not the echoed CID — the API answers with the address it was handed, so only fetching `/ipfs/<declared>?format=raw` back and byte-comparing shows the block really landed there:

- a sealed leaf under `raw` and a real assembled DAG root under `dag-cbor` (genuine det-CBOR bytes) are each served back byte-identical at the address the caller computed;
- bytes that do not hash to the declared CID are refused with a permanent 400 **and** the account's quota usage is unchanged afterwards, so the compensation is proven, not assumed;
- a non-canonical CID, and a canonically-framed CID under a codec the ingress does not accept, never leave the client.

The job gains `CONTRACT_GATEWAY_URL`; the leg fails loudly if it is missing rather than skipping silently (verified by unsetting it).

New unit coverage pins the pin store's actual Kubo effects: `block/put` -> `pin/add` on success, `block/put` -> `block/rm` on a mismatch, `block/rm` after a failed pin, and a put that returns no address reported as a store fault rather than a caller mismatch.

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` all ran against `git diff main...HEAD`. Folded back in:

- **A refused upload grew the datastore for free** (HIGH, both reviews). The block was written before the compare and never removed, while the quota charge was refunded — an authenticated account could add ~120 MiB/min of permanent, unmetered storage. Fixed by removing the block on every non-pinning path.
- **`MAX_UPLOAD_BYTES` was 50x the block ceiling**, turning a permanent size failure into a retryable 503 that re-ran the row insert and wrote another orphan on each attempt.
- **The declared CID sat in the URL**, exporting per-account content-address and timing edges to the edge log plane. Moved to a header.
- A `block/put` response with no `Key` (Kubo can trail an error object under a 200) read as a disagreeing address and blamed the caller with a permanent 400; it is a store fault now.
- The client-side guard accepted any single-byte multicodec while the ingress accepts two — narrowed so a wider codec breaks at the client instead of as a production 400.
- A failed compensation logs at `error`: it strands a charged row that makes later uploads of those bytes short-circuit as already-pinned.
- `RecordPublishError::HeadCidMismatch`'s doc claimed the returned CID proves what bytes the store holds. With an echoed CID that is no longer true, and the crypto review flagged it as a stale in-code claim; the doc now says what the check actually means. The bytes/CID binding is enforced at the ingress and, client-side, by `verify_cid` on read — unchanged.
- Comment trimming: the GC rationale and the frozen-shape derivation are stated once at their home in `blueprint/api.md` rather than restated on three callers.

## Verification

- `cargo test --workspace` green; `cargo clippy --workspace --all-targets -D warnings` clean; `cargo fmt --all`.
- `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` green.
- API unit suite 177 passed, integration suite 132 passed against real Postgres; `tsc --noEmit`, eslint, prettier and markdownlint clean.
- Contract suite 15/15 against the local stack, including the gateway round-trip; `apps/api/openapi.json` regenerated for the `openapi-freshness` gate.

## Deliberately out of scope

- **#915** — the engine authors head blocks and DAG roots up to 4 MiB (`MAX_RESOLVED_RECORD_BYTES`) while IPFS caps a block at 2 MiB. Not currently reachable (sealed leaves are exactly 1 MiB), and the ceiling is a frozen wire-format limit owned by the content slice, so this PR fixes only the API-side half. Filed with a dependency edge back here.
- The drain classifies a 400 as `Halt::Unclassified`, so a mis-declared CID retries rather than dead-letters. Only reachable from a client bug; publish-failure classification belongs to the content-write slice.
- The API does not validate that `dag-cbor` bytes are decodable — Kubo's `pin/add` already refuses them, and doing it in the API would mean a CBOR codec in TypeScript.

## Collision note

#907, for #868, touches `crates/engine/src/content/`, `crates/core/src/seal/`, and `crates/contract/tests/contract.rs`. Engine changes here are confined to `api/client.rs`, `api/error.rs` and one call site in `net/record_publish.rs`; everything else is expressed API-side, including the block-ceiling fix. The contract-suite additions are appended and do not touch the areas #907 edits, but expect a rebase there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content uploads now require a caller-provided content address.
  * Raw and DAG-CBOR addresses are validated, and successful uploads confirm storage under the declared address.
  * Added end-to-end integrity checks, including gateway retrieval verification.

* **Bug Fixes**
  * Invalid addresses and content mismatches return clear client errors.
  * Failed uploads clean up incomplete data without charging quota.

* **Changes**
  * Uploads are limited to 2 MiB (one block).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->