### PR TITLE
perf: memoize the durable queue scan so a render is not one HPKE open per queued op

### DIFF
--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -55,7 +55,7 @@ use crate::sync::op::{NewNode, Op, Replaced, StagedContent};
 use crate::sync::overlay::apply_overlay;
 use crate::sync::pointer::PointerFetch;
 use crate::sync::project::project_child_version;
-use crate::sync::rebase::{QueueScan, decode_queue};
+use crate::sync::rebase::{QueueScan, QueueScanCache, decode_queue};
 
 pub use crate::sync::drain::BlockedOp;
 pub use crate::sync::rebase::DeadLetterReason;
@@ -1087,6 +1087,9 @@ pub struct Engine<T: SeamTypes> {
     /// Retained dead-lettered ops. Feeds [`SnapshotView`]'s dead-letter surface
     /// (#33 D6: dead letters are retained, never silent).
     dead_letters: Rc<RefCell<RetainedDeadLetters>>,
+    /// Memo of the durable queue scan every read renders through
+    /// ([`scan_queue`](Self::scan_queue)).
+    queue_scan: RefCell<QueueScanCache>,
     /// The drain's over-quota hold, written by the drain tick and read by
     /// [`snapshot`](Self::snapshot). In-memory: a restart re-derives it from the
     /// next drain attempt's own 413 rather than trusting a stale verdict.
@@ -1139,6 +1142,7 @@ impl<T: SeamTypes> Engine<T> {
                 scope_read_seeds: Rc::new(RefCell::new(BTreeMap::new())),
                 scope_write_seeds: Rc::new(RefCell::new(BTreeMap::new())),
                 dead_letters: Rc::new(RefCell::new(BTreeMap::new())),
+                queue_scan: RefCell::new(QueueScanCache::default()),
                 blocked: Rc::new(RefCell::new(None)),
                 alive: Rc::new(Cell::new(true)),
                 session: None,
@@ -2261,6 +2265,10 @@ impl<T: SeamTypes> Engine<T> {
     /// Scan the durable staging store's queue for this session. Undecodable
     /// entries are dropped from the render here; the cold-start path
     /// dead-letters and removes them from the durable queue.
+    ///
+    /// Memoized on the queue's own shape ([`QueueScanCache`]), so the HPKE open
+    /// per owned record is paid once per queue mutation rather than once per
+    /// read.
     async fn scan_queue(&self) -> Result<QueueScan, EngineError> {
         let session = self.session.as_ref().ok_or(EngineError::NotStarted)?;
         let raw = self
@@ -2269,7 +2277,12 @@ impl<T: SeamTypes> Engine<T> {
             .queued_ops()
             .await
             .map_err(EngineError::from_seam)?;
-        Ok(decode_queue(&RecordReader::new(session.enc_subkey()), &raw))
+        let reader = RecordReader::new(session.enc_subkey());
+        // Borrow only after the await: a `RefCell` borrow must never span one.
+        let mut cache = self.queue_scan.borrow_mut();
+        Ok(cache
+            .scan(reader.owner_tag(), &raw, |raw| decode_queue(&reader, raw))
+            .clone())
     }
 
     /// This session's pending ops, FIFO.
@@ -3188,6 +3201,43 @@ mod tests {
                 view.retained_records, 1,
                 "but the count says the device is not empty"
             );
+        }
+
+        /// Ops enqueue and drain through the staging seam, not through the
+        /// engine's command path, so the memoized queue scan (#880) has to key
+        /// on the durable queue itself.
+        #[test]
+        fn a_record_enqueued_behind_the_engines_back_renders_on_the_next_read() {
+            let (mut engine, _events) = started();
+            let root = engine.root();
+            create(&mut engine, root, "mine.txt", NodeKind::File);
+            // Prime the memo with a scan that predates the enqueue below.
+            assert_eq!(block_on(engine.snapshot(root)).unwrap().children.len(), 1);
+
+            let ours = crate::sync::record::encode_op_record(
+                RecordSeal {
+                    owner_enc_secret: engine.session.as_ref().expect("started").enc_subkey(),
+                    ephemeral_scalar: Zeroizing::new([0x2B; 32]),
+                },
+                &Op::create(
+                    NodeId([8; 16]),
+                    root,
+                    "out-of-band.txt",
+                    NewNode::File { content: None },
+                    1,
+                    crate::seams::UnixMillis(1),
+                ),
+            )
+            .unwrap();
+            block_on(engine.seams.staging_store.enqueue_op(&ours)).unwrap();
+
+            let names: Vec<String> = block_on(engine.snapshot(root))
+                .unwrap()
+                .children
+                .into_iter()
+                .map(|child| child.name)
+                .collect();
+            assert_eq!(names, vec!["out-of-band.txt", "mine.txt"]);
         }
 
         #[test]

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -55,7 +55,7 @@ use crate::sync::op::{NewNode, Op, Replaced, StagedContent};
 use crate::sync::overlay::apply_overlay;
 use crate::sync::pointer::PointerFetch;
 use crate::sync::project::project_child_version;
-use crate::sync::rebase::{QueueScan, QueueScanCache, decode_queue};
+use crate::sync::rebase::{QueueScan, QueueScanMemo, decode_queue};
 
 pub use crate::sync::drain::BlockedOp;
 pub use crate::sync::rebase::DeadLetterReason;
@@ -1089,7 +1089,7 @@ pub struct Engine<T: SeamTypes> {
     dead_letters: Rc<RefCell<RetainedDeadLetters>>,
     /// Memo of the durable queue scan every read renders through
     /// ([`scan_queue`](Self::scan_queue)).
-    queue_scan: RefCell<QueueScanCache>,
+    queue_scan: RefCell<QueueScanMemo>,
     /// The drain's over-quota hold, written by the drain tick and read by
     /// [`snapshot`](Self::snapshot). In-memory: a restart re-derives it from the
     /// next drain attempt's own 413 rather than trusting a stale verdict.
@@ -1142,7 +1142,7 @@ impl<T: SeamTypes> Engine<T> {
                 scope_read_seeds: Rc::new(RefCell::new(BTreeMap::new())),
                 scope_write_seeds: Rc::new(RefCell::new(BTreeMap::new())),
                 dead_letters: Rc::new(RefCell::new(BTreeMap::new())),
-                queue_scan: RefCell::new(QueueScanCache::default()),
+                queue_scan: RefCell::new(QueueScanMemo::default()),
                 blocked: Rc::new(RefCell::new(None)),
                 alive: Rc::new(Cell::new(true)),
                 session: None,
@@ -2266,9 +2266,8 @@ impl<T: SeamTypes> Engine<T> {
     /// entries are dropped from the render here; the cold-start path
     /// dead-letters and removes them from the durable queue.
     ///
-    /// Memoized on the queue's own shape ([`QueueScanCache`]), so the HPKE open
-    /// per owned record is paid once per queue mutation rather than once per
-    /// read.
+    /// Memoized on the queue's own shape ([`QueueScanMemo`]), so reads pay the
+    /// HPKE open per owned record once per queue mutation, not once per render.
     async fn scan_queue(&self) -> Result<QueueScan, EngineError> {
         let session = self.session.as_ref().ok_or(EngineError::NotStarted)?;
         let raw = self
@@ -2278,11 +2277,8 @@ impl<T: SeamTypes> Engine<T> {
             .await
             .map_err(EngineError::from_seam)?;
         let reader = RecordReader::new(session.enc_subkey());
-        // Borrow only after the await: a `RefCell` borrow must never span one.
-        let mut cache = self.queue_scan.borrow_mut();
-        Ok(cache
-            .scan(reader.owner_tag(), &raw, |raw| decode_queue(&reader, raw))
-            .clone())
+        let mut memo = self.queue_scan.borrow_mut();
+        Ok(memo.scan(&reader, &raw, decode_queue).clone())
     }
 
     /// This session's pending ops, FIFO.

--- a/crates/engine/src/seams/staging_store.rs
+++ b/crates/engine/src/seams/staging_store.rs
@@ -18,9 +18,13 @@ pub struct OpId(pub u64);
 /// enforcement is engine policy fed by [`StagingStore::staged_bytes_total`].
 ///
 /// Contract, enforced by the conformance kit: FIFO ordering with strictly
-/// increasing never-reused ids, durability of queue and staged bytes across
-/// reopen, and enumeration/removal exact enough that orphan GC is
-/// implementable. Hosts: IndexedDB + OPFS (web), local journal (desktop).
+/// increasing ids that are never reused — not after the highest is removed,
+/// not after the queue drains empty and the store reopens — the bytes at an id
+/// being immutable for that id's lifetime, durability of queue and staged bytes
+/// across reopen, and enumeration/removal exact enough that orphan GC is
+/// implementable. The engine reads the id progression as evidence about the
+/// queue, so a host that restarts or recycles ids is not merely untidy.
+/// Hosts: IndexedDB + OPFS (web), local journal (desktop).
 pub trait StagingStore {
     /// Appends an opaque op record to the durable FIFO queue and returns
     /// its id.

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -40,8 +40,9 @@ pub use pointer::{
     vault_pointer_name,
 };
 pub use rebase::{
-    AppliedOp, DeadLetterReason, DropReason, HeadReconciliation, OpResolution, QueueScan, Repair,
-    ReplayReport, apply_repairs, decode_queue, observed_repair, rebase_one, reconcile_head, replay,
+    AppliedOp, DeadLetterReason, DropReason, HeadReconciliation, OpResolution, QueueScan,
+    QueueScanCache, Repair, ReplayReport, apply_repairs, decode_queue, observed_repair, rebase_one,
+    reconcile_head, replay,
 };
 pub use record::{
     OpRecordError, RecordClass, RecordReader, RecordSeal, RetainedReason, encode_op_record,

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -40,9 +40,8 @@ pub use pointer::{
     vault_pointer_name,
 };
 pub use rebase::{
-    AppliedOp, DeadLetterReason, DropReason, HeadReconciliation, OpResolution, QueueScan,
-    QueueScanCache, Repair, ReplayReport, apply_repairs, decode_queue, observed_repair, rebase_one,
-    reconcile_head, replay,
+    AppliedOp, DeadLetterReason, DropReason, HeadReconciliation, OpResolution, QueueScan, Repair,
+    ReplayReport, apply_repairs, decode_queue, observed_repair, rebase_one, reconcile_head, replay,
 };
 pub use record::{
     OpRecordError, RecordClass, RecordReader, RecordSeal, RetainedReason, encode_op_record,

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -172,6 +172,59 @@ pub fn decode_queue(reader: &RecordReader<'_>, raw: &[(OpId, Vec<u8>)]) -> Queue
     scan
 }
 
+/// A memo of one [`decode_queue`] pass. The decode is an HPKE open per record
+/// this identity owns, so without it every render pays for the whole backlog
+/// — a queue the design refuses to cap (#880).
+///
+/// The key is everything that can change the answer: the reading identity's
+/// owner tag, plus the durable queue's shape. [`OpId`]s are strictly increasing
+/// and never reused per store
+/// ([`StagingStore`](crate::seams::StagingStore)), so an unchanged high-water
+/// id *and* an unchanged length admit no set of enqueues and removals other
+/// than none — including through mutation paths the engine does not observe.
+/// The bytes at an id never change either, so a hit re-serves the
+/// classification of exactly the bytes the store still holds: every check the
+/// miss path runs, sender authentication included, stays binding.
+///
+/// One slot, so it holds at most one scan's worth of decoded intent — the same
+/// copy a render already materializes.
+// No `Debug`: the memo holds decoded op plaintext.
+#[derive(Default)]
+pub struct QueueScanCache {
+    key: Option<QueueKey>,
+    scan: QueueScan,
+}
+
+/// The queue state a memoized scan is the answer for.
+#[derive(PartialEq, Eq)]
+struct QueueKey {
+    owner_tag: [u8; 32],
+    high_water: Option<OpId>,
+    len: usize,
+}
+
+impl QueueScanCache {
+    /// The scan of `raw` for the identity `owner_tag` names, running `decode`
+    /// only when the memo does not already cover that exact queue.
+    pub fn scan(
+        &mut self,
+        owner_tag: [u8; 32],
+        raw: &[(OpId, Vec<u8>)],
+        decode: impl FnOnce(&[(OpId, Vec<u8>)]) -> QueueScan,
+    ) -> &QueueScan {
+        let key = QueueKey {
+            owner_tag,
+            high_water: raw.iter().map(|(op_id, _)| *op_id).max(),
+            len: raw.len(),
+        };
+        if self.key.as_ref() != Some(&key) {
+            self.scan = decode(raw);
+            self.key = Some(key);
+        }
+        &self.scan
+    }
+}
+
 /// Replay `ops` FIFO onto the gate-passing base. `local` (the pre-rebase
 /// overlay view) supplies node metadata for the edit-resurrects-a-delete case
 /// — the only rule that must re-materialize a node the gate-passing base no
@@ -1408,5 +1461,140 @@ mod tests {
             },
             "the other client sees itself as the loser and re-mints above"
         );
+    }
+
+    /// The memo every read renders through (#880). Each test counts the records
+    /// a decode pass opened, because that count *is* the per-render HPKE cost.
+    mod queue_scan_cache {
+        use super::*;
+        use crate::sync::record::RecordClass;
+        use std::cell::Cell;
+
+        fn owner(b: u8) -> X25519Secret {
+            X25519Secret::from_scalar([b; 32])
+        }
+
+        /// One durable queue entry sealed to `secret`.
+        fn entry(secret: &X25519Secret, op_id: u64) -> (OpId, Vec<u8>) {
+            let record = encode_op_record(
+                RecordSeal {
+                    owner_enc_secret: secret,
+                    ephemeral_scalar: Zeroizing::new([op_id as u8; 32]),
+                },
+                &Op::rename(id(op_id as u8), "n", 1, AT),
+            )
+            .unwrap();
+            (OpId(op_id), record)
+        }
+
+        /// Scan through the memo, tallying every record the decode pass read.
+        fn scan(
+            cache: &mut QueueScanCache,
+            secret: &X25519Secret,
+            raw: &[(OpId, Vec<u8>)],
+            opened: &Cell<usize>,
+        ) -> QueueScan {
+            let reader = RecordReader::new(secret);
+            cache
+                .scan(reader.owner_tag(), raw, |raw| {
+                    opened.set(opened.get() + raw.len());
+                    decode_queue(&reader, raw)
+                })
+                .clone()
+        }
+
+        #[test]
+        fn an_unchanged_queue_is_opened_once_however_often_it_is_read() {
+            let me = owner(1);
+            let queue = vec![entry(&me, 1), entry(&me, 2)];
+            let opened = Cell::new(0);
+            let mut cache = QueueScanCache::default();
+
+            let first = scan(&mut cache, &me, &queue, &opened);
+            for _ in 0..5 {
+                assert_eq!(scan(&mut cache, &me, &queue, &opened), first);
+            }
+            assert_eq!(first.mine.len(), 2);
+            assert_eq!(opened.get(), 2, "six reads, one open per record");
+        }
+
+        #[test]
+        fn an_enqueued_op_is_read_on_the_next_scan() {
+            let me = owner(2);
+            let mut queue = vec![entry(&me, 1)];
+            let opened = Cell::new(0);
+            let mut cache = QueueScanCache::default();
+            scan(&mut cache, &me, &queue, &opened);
+
+            queue.push(entry(&me, 2));
+            assert_eq!(
+                scan(&mut cache, &me, &queue, &opened).mine.len(),
+                2,
+                "the memo must not outlive an enqueue it did not perform"
+            );
+            assert_eq!(opened.get(), 3);
+        }
+
+        #[test]
+        fn a_removed_op_is_gone_from_the_next_scan() {
+            let me = owner(3);
+            let mut queue = vec![entry(&me, 1), entry(&me, 2)];
+            let opened = Cell::new(0);
+            let mut cache = QueueScanCache::default();
+            scan(&mut cache, &me, &queue, &opened);
+
+            queue.remove(0);
+            assert_eq!(
+                scan(&mut cache, &me, &queue, &opened).mine,
+                vec![(OpId(2), Op::rename(id(2), "n", 1, AT))],
+                "a drained op must never re-render off the memo"
+            );
+            assert_eq!(opened.get(), 3);
+        }
+
+        /// The one shape a length check alone would miss: the queue keeps its
+        /// size while its contents turn over. Ids are strictly increasing and
+        /// never reused, so the high-water id catches it.
+        #[test]
+        fn a_removal_paired_with_an_enqueue_is_read_on_the_next_scan() {
+            let me = owner(4);
+            let mut queue = vec![entry(&me, 1), entry(&me, 2)];
+            let opened = Cell::new(0);
+            let mut cache = QueueScanCache::default();
+            scan(&mut cache, &me, &queue, &opened);
+
+            queue.remove(0);
+            queue.push(entry(&me, 3));
+            assert_eq!(
+                scan(&mut cache, &me, &queue, &opened)
+                    .mine
+                    .iter()
+                    .map(|(op_id, _)| *op_id)
+                    .collect::<Vec<_>>(),
+                vec![OpId(2), OpId(3)]
+            );
+            assert_eq!(opened.get(), 4);
+        }
+
+        #[test]
+        fn another_identity_never_reads_the_first_ones_scan() {
+            let me = owner(5);
+            let stranger = owner(6);
+            let queue = vec![entry(&me, 1)];
+            let opened = Cell::new(0);
+            let mut cache = QueueScanCache::default();
+            assert_eq!(scan(&mut cache, &me, &queue, &opened).mine.len(), 1);
+
+            let theirs = scan(&mut cache, &stranger, &queue, &opened);
+            assert!(
+                theirs.mine.is_empty() && theirs.retained == 1,
+                "a memo hit must never hand one identity another's opened intent"
+            );
+            assert_eq!(opened.get(), 2, "the reading identity is part of the key");
+            assert!(matches!(
+                RecordReader::new(&stranger).classify(&queue[0].1),
+                RecordClass::Retained(_)
+            ));
+        }
     }
 }

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -172,25 +172,17 @@ pub fn decode_queue(reader: &RecordReader<'_>, raw: &[(OpId, Vec<u8>)]) -> Queue
     scan
 }
 
-/// A memo of one [`decode_queue`] pass. The decode is an HPKE open per record
-/// this identity owns, so without it every render pays for the whole backlog
-/// — a queue the design refuses to cap (#880).
+/// A memo of one [`decode_queue`] pass: the decode is an HPKE open per record
+/// this identity owns, and the queue is uncapped, so an un-memoized render pays
+/// for the whole backlog (#880).
 ///
-/// The key is everything that can change the answer: the reading identity's
-/// owner tag, plus the durable queue's shape. [`OpId`]s are strictly increasing
-/// and never reused per store
-/// ([`StagingStore`](crate::seams::StagingStore)), so an unchanged high-water
-/// id *and* an unchanged length admit no set of enqueues and removals other
-/// than none — including through mutation paths the engine does not observe.
-/// The bytes at an id never change either, so a hit re-serves the
-/// classification of exactly the bytes the store still holds: every check the
-/// miss path runs, sender authentication included, stays binding.
-///
-/// One slot, so it holds at most one scan's worth of decoded intent — the same
-/// copy a render already materializes.
-// No `Debug`: the memo holds decoded op plaintext.
+/// Keyed on the reading identity plus the queue's high-water [`OpId`] and its
+/// length — no enqueue or removal leaves both unchanged
+/// ([`StagingStore`](crate::seams::StagingStore)). Nothing rewrites a queued
+/// record's bytes, so a hit re-serves a verdict that still binds, sender
+/// authentication included.
 #[derive(Default)]
-pub struct QueueScanCache {
+pub(crate) struct QueueScanMemo {
     key: Option<QueueKey>,
     scan: QueueScan,
 }
@@ -203,22 +195,26 @@ struct QueueKey {
     len: usize,
 }
 
-impl QueueScanCache {
-    /// The scan of `raw` for the identity `owner_tag` names, running `decode`
-    /// only when the memo does not already cover that exact queue.
-    pub fn scan(
+impl QueueScanMemo {
+    /// The scan of `raw` for `reader`'s identity, running `decode` only when
+    /// the memo does not already cover that exact queue.
+    ///
+    /// The key and the decode take the one `reader`, so a scan is always filed
+    /// under the identity that opened it. `decode` is a parameter so a test can
+    /// count the records a pass opened — the cost this memo exists to cut.
+    pub(crate) fn scan(
         &mut self,
-        owner_tag: [u8; 32],
+        reader: &RecordReader<'_>,
         raw: &[(OpId, Vec<u8>)],
-        decode: impl FnOnce(&[(OpId, Vec<u8>)]) -> QueueScan,
+        decode: impl FnOnce(&RecordReader<'_>, &[(OpId, Vec<u8>)]) -> QueueScan,
     ) -> &QueueScan {
         let key = QueueKey {
-            owner_tag,
+            owner_tag: reader.owner_tag(),
             high_water: raw.iter().map(|(op_id, _)| *op_id).max(),
             len: raw.len(),
         };
         if self.key.as_ref() != Some(&key) {
-            self.scan = decode(raw);
+            self.scan = decode(reader, raw);
             self.key = Some(key);
         }
         &self.scan
@@ -1463,11 +1459,11 @@ mod tests {
         );
     }
 
-    /// The memo every read renders through (#880). Each test counts the records
-    /// a decode pass opened, because that count *is* the per-render HPKE cost.
-    mod queue_scan_cache {
+    // --- queue-scan memo: every test counts the records a decode pass opened,
+    // because that count is the per-render HPKE cost ---
+
+    mod queue_scan_memo {
         use super::*;
-        use crate::sync::record::RecordClass;
         use std::cell::Cell;
 
         fn owner(b: u8) -> X25519Secret {
@@ -1489,18 +1485,16 @@ mod tests {
 
         /// Scan through the memo, tallying every record the decode pass read.
         fn scan(
-            cache: &mut QueueScanCache,
+            memo: &mut QueueScanMemo,
             secret: &X25519Secret,
             raw: &[(OpId, Vec<u8>)],
             opened: &Cell<usize>,
         ) -> QueueScan {
-            let reader = RecordReader::new(secret);
-            cache
-                .scan(reader.owner_tag(), raw, |raw| {
-                    opened.set(opened.get() + raw.len());
-                    decode_queue(&reader, raw)
-                })
-                .clone()
+            memo.scan(&RecordReader::new(secret), raw, |reader, raw| {
+                opened.set(opened.get() + raw.len());
+                decode_queue(reader, raw)
+            })
+            .clone()
         }
 
         #[test]
@@ -1508,11 +1502,11 @@ mod tests {
             let me = owner(1);
             let queue = vec![entry(&me, 1), entry(&me, 2)];
             let opened = Cell::new(0);
-            let mut cache = QueueScanCache::default();
+            let mut memo = QueueScanMemo::default();
 
-            let first = scan(&mut cache, &me, &queue, &opened);
+            let first = scan(&mut memo, &me, &queue, &opened);
             for _ in 0..5 {
-                assert_eq!(scan(&mut cache, &me, &queue, &opened), first);
+                assert_eq!(scan(&mut memo, &me, &queue, &opened), first);
             }
             assert_eq!(first.mine.len(), 2);
             assert_eq!(opened.get(), 2, "six reads, one open per record");
@@ -1523,12 +1517,12 @@ mod tests {
             let me = owner(2);
             let mut queue = vec![entry(&me, 1)];
             let opened = Cell::new(0);
-            let mut cache = QueueScanCache::default();
-            scan(&mut cache, &me, &queue, &opened);
+            let mut memo = QueueScanMemo::default();
+            scan(&mut memo, &me, &queue, &opened);
 
             queue.push(entry(&me, 2));
             assert_eq!(
-                scan(&mut cache, &me, &queue, &opened).mine.len(),
+                scan(&mut memo, &me, &queue, &opened).mine.len(),
                 2,
                 "the memo must not outlive an enqueue it did not perform"
             );
@@ -1540,12 +1534,12 @@ mod tests {
             let me = owner(3);
             let mut queue = vec![entry(&me, 1), entry(&me, 2)];
             let opened = Cell::new(0);
-            let mut cache = QueueScanCache::default();
-            scan(&mut cache, &me, &queue, &opened);
+            let mut memo = QueueScanMemo::default();
+            scan(&mut memo, &me, &queue, &opened);
 
             queue.remove(0);
             assert_eq!(
-                scan(&mut cache, &me, &queue, &opened).mine,
+                scan(&mut memo, &me, &queue, &opened).mine,
                 vec![(OpId(2), Op::rename(id(2), "n", 1, AT))],
                 "a drained op must never re-render off the memo"
             );
@@ -1553,20 +1547,19 @@ mod tests {
         }
 
         /// The one shape a length check alone would miss: the queue keeps its
-        /// size while its contents turn over. Ids are strictly increasing and
-        /// never reused, so the high-water id catches it.
+        /// size while its contents turn over.
         #[test]
         fn a_removal_paired_with_an_enqueue_is_read_on_the_next_scan() {
             let me = owner(4);
             let mut queue = vec![entry(&me, 1), entry(&me, 2)];
             let opened = Cell::new(0);
-            let mut cache = QueueScanCache::default();
-            scan(&mut cache, &me, &queue, &opened);
+            let mut memo = QueueScanMemo::default();
+            scan(&mut memo, &me, &queue, &opened);
 
             queue.remove(0);
             queue.push(entry(&me, 3));
             assert_eq!(
-                scan(&mut cache, &me, &queue, &opened)
+                scan(&mut memo, &me, &queue, &opened)
                     .mine
                     .iter()
                     .map(|(op_id, _)| *op_id)
@@ -1582,19 +1575,15 @@ mod tests {
             let stranger = owner(6);
             let queue = vec![entry(&me, 1)];
             let opened = Cell::new(0);
-            let mut cache = QueueScanCache::default();
-            assert_eq!(scan(&mut cache, &me, &queue, &opened).mine.len(), 1);
+            let mut memo = QueueScanMemo::default();
+            assert_eq!(scan(&mut memo, &me, &queue, &opened).mine.len(), 1);
 
-            let theirs = scan(&mut cache, &stranger, &queue, &opened);
+            let theirs = scan(&mut memo, &stranger, &queue, &opened);
             assert!(
                 theirs.mine.is_empty() && theirs.retained == 1,
                 "a memo hit must never hand one identity another's opened intent"
             );
             assert_eq!(opened.get(), 2, "the reading identity is part of the key");
-            assert!(matches!(
-                RecordReader::new(&stranger).classify(&queue[0].1),
-                RecordClass::Retained(_)
-            ));
         }
     }
 }

--- a/crates/engine/src/sync/record.rs
+++ b/crates/engine/src/sync/record.rs
@@ -77,7 +77,7 @@ impl<'a> RecordReader<'a> {
 
     /// The clear tag this reader answers to — the owner's `enc-subkey` public
     /// half, and so the identity a classification is only valid for.
-    pub fn owner_tag(&self) -> [u8; 32] {
+    pub(crate) fn owner_tag(&self) -> [u8; 32] {
         self.owner_tag
     }
 

--- a/crates/engine/src/sync/record.rs
+++ b/crates/engine/src/sync/record.rs
@@ -75,6 +75,12 @@ impl<'a> RecordReader<'a> {
         }
     }
 
+    /// The clear tag this reader answers to — the owner's `enc-subkey` public
+    /// half, and so the identity a classification is only valid for.
+    pub fn owner_tag(&self) -> [u8; 32] {
+        self.owner_tag
+    }
+
     /// Classify one durable record. Every discriminator that can say "not for
     /// me" runs before the [`Undecodable`](RecordClass::Undecodable) verdict,
     /// because that verdict *deletes*.

--- a/crates/engine/src/testkit/conformance/staging_store.rs
+++ b/crates/engine/src/testkit/conformance/staging_store.rs
@@ -97,4 +97,21 @@ where
         id_d > id_c,
         "op ids must never be reused, even across reopen"
     );
+
+    // Draining the queue empty must not restart the id progression either. The
+    // engine's queue-scan memo reads an unchanged high-water id plus an
+    // unchanged length as proof that nothing was enqueued or removed (#880), so
+    // a store that allocated `max + 1` — or restarted at 1 once empty — would
+    // let a fresh op wear a drained op's id and go unread.
+    for id in [id_a, id_c, id_d] {
+        reopened.remove_op(id).await.unwrap();
+    }
+    assert!(reopened.queued_ops().await.unwrap().is_empty());
+
+    let drained = open().await;
+    let id_e = drained.enqueue_op(b"op-e").await.unwrap();
+    assert!(
+        id_e > id_d,
+        "an op id must never be reused, not even after the queue drains empty"
+    );
 }

--- a/crates/engine/src/testkit/conformance/staging_store.rs
+++ b/crates/engine/src/testkit/conformance/staging_store.rs
@@ -98,20 +98,28 @@ where
         "op ids must never be reused, even across reopen"
     );
 
-    // Draining the queue empty must not restart the id progression either. The
-    // engine's queue-scan memo reads an unchanged high-water id plus an
-    // unchanged length as proof that nothing was enqueued or removed (#880), so
-    // a store that allocated `max + 1` — or restarted at 1 once empty — would
-    // let a fresh op wear a drained op's id and go unread.
-    for id in [id_a, id_c, id_d] {
+    // Removing the highest id must not release it while lower ids are still
+    // queued. The engine's queue-scan memo reads an unchanged high-water id plus
+    // an unchanged length as proof that nothing was enqueued or removed (#880),
+    // so a store allocating `max(queued) + 1` would hand the next op the id it
+    // just freed and rebuild that exact pair over different records.
+    reopened.remove_op(id_d).await.unwrap();
+    let id_e = reopened.enqueue_op(b"op-e").await.unwrap();
+    assert!(
+        id_e > id_d,
+        "a removed high-water op id must never be handed out again"
+    );
+
+    // Nor may draining the queue empty restart the progression.
+    for id in [id_a, id_c, id_e] {
         reopened.remove_op(id).await.unwrap();
     }
     assert!(reopened.queued_ops().await.unwrap().is_empty());
 
     let drained = open().await;
-    let id_e = drained.enqueue_op(b"op-e").await.unwrap();
+    let id_f = drained.enqueue_op(b"op-f").await.unwrap();
     assert!(
-        id_e > id_d,
+        id_f > id_e,
         "an op id must never be reused, not even after the queue drains empty"
     );
 }


### PR DESCRIPTION
## What

Every rendered read ran a full `decode_queue` over the durable op queue — per record this identity owns, an X25519 DHKEM decap, an HKDF-SHA256 key schedule, and an XChaCha20-Poly1305 open. That runs inside `Engine::scan_queue`, which every read path funnels through: `snapshot()` on each folder paint, `render()`/`view()` on each view read, and the content-read miss path. FUSE reaches it once per VFS op, so one directory listing of N children is roughly 2N+1 scans. The op queue is deliberately uncapped — it is the durable divergence — so the per-render cost grew without bound with a user's offline backlog.

`scan_queue` now serves a single-slot memo, `QueueScanMemo`. Only reads consult it; the drain and cold start still decode the queue themselves, and both of those are the paths that *remove* from it, so no removal is ever driven off a memoized verdict.

## The invalidation rule

The key is everything that can change the answer:

- the **reading identity's owner tag** — the `enc-subkey` public half a classification is only valid for, so one identity can never be served another's opened intent;
- the **highest `OpId` present** in the durable queue;
- the queue **length**.

`OpId`s are strictly increasing per store and never reused, and the `StagingStore` seam offers only enqueue and remove — no in-place update. An enqueue always draws an id above every id ever issued, so an unchanged high-water id means the current id set is a subset of the memoized one; with an unchanged length that forces the two sets to be equal. The bytes at an id never change, so equal id sets mean byte-identical input to a pure `decode_queue`.

That reasoning holds for the mutation paths the engine does **not** observe — `stage_op` writes through the staging seam directly, the drain removes through it, and another tab over the same store draws from the same store-global id generator — which is why the key is the durable queue's own shape rather than the engine's command path.

So a hit re-serves the classification of exactly the bytes the store still holds. No authenticity check is skipped: the header-version gate, the owner-tag comparison, the HPKE auth-mode open that authenticates the sender, and the content-cid-mismatch hard reject all ran on those same bytes. The adoption gate is not in this path at all — it operates on resolved records, and `snapshot()` still applies the overlay onto a freshly borrowed gate-passing base.

The memo key and the decode both take one `RecordReader`, so a scan is always filed under the identity that opened it — key confusion is unrepresentable rather than merely unreached.

## Bound

One slot, replaced in place, so the memo holds at most one scan's worth of decoded intent — the same copy a single render already materialized and handed to its caller. No per-entry growth, and no new class of resident plaintext: the engine's base snapshot already holds plaintext names for the session's whole life.

## Contract hardening

The memo reads the id progression as evidence about the queue, and the conformance kit only half-asserted it: it never removed the highest id, and never drained the queue empty before reopening. A host that allocated `max + 1`, or restarted at 1 once empty, would let a fresh op wear a drained op's id and go unread — and would have passed. The kit now covers both, against every host implementation, and the seam contract states the byte-immutability and never-restart properties the engine depends on.

No implementation was actually vulnerable: the desktop journal takes `max(persisted counter, highest + 1)`, and IndexedDB's key generator is not reset by `delete` or `clear`.

## Tests

- `crates/engine/src/sync/rebase.rs` — five unit tests over `QueueScanMemo`, each counting the records a decode pass opened, because that count is the per-render HPKE cost: an unchanged queue is opened once across six reads; an enqueue, a removal, and a removal paired with an enqueue each re-open; a second identity never reads the first one's scan.
- `crates/engine/src/facade.rs` — a record enqueued behind the engine's back, after the memo was primed, still renders on the next read.
- `crates/engine/src/testkit/conformance/staging_store.rs` — a removed high-water id, and a queue drained empty and reopened, must both still yield a fresh id.

All three files are already in named CI gates: `Engine Tests`, `Cargo Check & Test`, and — for the kit, via `crates/wasm` and `crates/desktop-seams` — `Core KATs` and `Client Browser Suite`.

## Deliberately out of scope

- The drain re-decodes the same backlog per tick, unmemoized. Lending the memo through `DrainScope` is a real option but it is a different call path with a different lifetime, and `drain.rs` has two other slices in flight.
- Decoded `Op` plaintext is never zeroized — pre-existing across all three `decode_queue` call sites, filed as #918. Not fixable in the memo: it hands callers a clone, so zeroizing its slot would clear only its own allocation.

Closes #880
Part of #655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queue snapshots now reliably show newly added records, including after prior reads or queue changes.
  * Improved handling of queue updates when records are added, removed, or replaced.
  * Operation IDs now remain strictly increasing across queue drains and store restarts, preventing ID reuse.

* **Tests**
  * Added coverage for repeated reads, queue turnover, reopening stores, and preserving operation ID progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->