### PR TITLE
test(engine): assert a deep create is adoptable by a second device

### DIFF
--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -23,6 +23,7 @@ use zeroize::Zeroizing;
 use cipherbox_engine::content::{DAG_ROOT_CODEC, GatewaySource, SealedChunk, decode_root};
 use cipherbox_engine::facade::PendingClass;
 use cipherbox_engine::net::author::{EnvelopeAuthoring, author_child_envelope};
+use cipherbox_engine::net::{ChildAdopter, ResolveOutcome, resolve};
 use cipherbox_engine::seams::{
     BoxedTask, HttpRequest, HttpResponse, OpId, RecordTransport, SeamError, SeamResult,
     StagingStore, UnixMillis,
@@ -1617,6 +1618,83 @@ fn a_create_below_the_scope_root_publishes_and_projects() {
     let view = block_on(engine.snapshot(photos)).unwrap();
     assert_eq!(view.children.len(), 1);
     assert_eq!(view.children[0].name, "2026");
+}
+
+/// The deep create's round trip: a device that never authored it adopts the
+/// non-root parent's own record — the only record that carries the depth-2
+/// child — through the child gate, on its own cold floors and cache. The
+/// facade has no descent below the scope root yet, so the assertion sits at
+/// the record plane (#895, #917).
+#[test]
+fn a_create_below_the_scope_root_is_adoptable_by_a_second_device() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine_a, _events_a, mut tasks) = boot(&world, &blocks, &alice, 42);
+    block_on(engine_a.command(Command::Create {
+        parent: ROOT,
+        name: "photos".into(),
+        kind: NodeKind::Folder,
+    }))
+    .unwrap();
+    tick(&world, &engine_a, &mut tasks);
+    let photos = child_id(&engine_a, ROOT, "photos");
+
+    block_on(engine_a.command(Command::Create {
+        parent: photos,
+        name: "2026".into(),
+        kind: NodeKind::Folder,
+    }))
+    .unwrap();
+    tick(&world, &engine_a, &mut tasks);
+    let deep = child_id(&engine_a, photos, "2026");
+
+    let bob = world.device(b"alice-second-device");
+    let (engine_b, _events_b, _tasks_b) = boot(&world, &blocks, &bob, 7);
+    let parents = block_on(engine_b.view()).unwrap().children(ROOT);
+    assert_eq!(parents.len(), 1, "device B resolves the depth-1 parent");
+    assert_eq!(parents[0].id, photos);
+
+    // Device B's own seams: its cold floor store, its own cache and HTTP. Only
+    // the account's scope read seed and the network are shared with device A.
+    let gateway = GatewayConfig {
+        accelerator: Some(GatewaySource {
+            base_url: "https://gw.test".into(),
+            bearer: None,
+        }),
+        public_fallbacks: Vec::new(),
+    }
+    .into_gateway();
+    let adopter = ChildAdopter::new(
+        &gateway,
+        &bob.http,
+        &bob.floor_store,
+        SCOPE,
+        Zeroizing::new(READ_SCOPE_SEED),
+        photos.0,
+    );
+    let outcome = block_on(resolve(
+        &bob.record_store,
+        &bob.snapshot_cache,
+        &adopter,
+        &write_name(photos),
+    ))
+    .expect("the parent record resolves")
+    .outcome;
+    let ResolveOutcome::Adopted(adopted) = outcome else {
+        panic!("the parent record passes device B's child gate, got {outcome:?}");
+    };
+    let ReadBody::Folder { children, .. } = adopted.read_body else {
+        panic!("expected a folder body");
+    };
+    assert_eq!(children.len(), 1, "device B reads the depth-2 create");
+    assert_eq!(children[0].name, "2026");
+    assert_eq!(
+        children[0].id, deep.0,
+        "and the same node id device A published it under"
+    );
 }
 
 /// A source-remove that will not publish compensates its own dest-add rather


### PR DESCRIPTION
## What

Every other op kind in `crates/engine/tests/write_plane.rs` carries a two-device
round trip. The create below the scope root did not, so nothing proved that a
**non-root parent's** published record is resolvable by a device that did not
author it — the scope root's record cannot stand in for it, because a child write
stops at the immediate parent.

`a_create_below_the_scope_root_is_adoptable_by_a_second_device` closes that: device
A creates `photos/` then `photos/2026/`, a cold second device boots on its own
floor store, snapshot cache and HTTP, resolves the depth-1 parent off the root
record through its own cold start, and then adopts `photos`' **own** record through
the child gate — `ChildAdopter` + `resolve`, the same pipeline `Engine::read_content`
uses — and reads `2026` out of the gate-passing body, matching device A's node id.

Test-only. No production code changed.

## The finding: the assertion cannot be made through the facade

#895 asked for the round trip through `snapshot`/`view` on device B. Written that
way it **fails**: `engine_b.snapshot(photos).children` is empty.

That is not a defect in the deep-create publish path — the record plane is correct,
which is exactly what this test now pins. It is a missing read-plane capability:

- `spawn_resolve_tick_loop` resolves the **vault root only**; `refresh_base_from_outcome`
  to `project_root` lifts **direct children only** (its unit test is literally named
  `project_root_lifts_direct_children_only`).
- The only other writer into the base below the root is the drain's own self-adopt.
- `Command::SetFocus` falls through the `command` dispatch to `EngineError::Unimplemented`.
- `ChildAdopter` has exactly one caller, `read_content`, which is file-only.
- `focus_set` / `FocusWindow` / `FocusTarget::Folder` are pure planning with no caller.

So any device that did not author a subtree lists nothing below the scope root.
`apps/web/src/engine/snapshotStore.ts` already calls `facade.setFocus(node)` on
navigation and takes the `Unimplemented` rejection into its error state.

Filed as #917 with the reciprocal edge recorded on #805 whose "Engine seams" list
already names `setFocus`. #917 owns the facade half; this PR ships the record-plane
half.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo check --workspace --all-targets` — clean
- `cargo test -p cipherbox-engine` — 38 passed in `write_plane`, 0 failed; the new
  test is named in the output. Gate: `Engine Tests` runs `cargo test -p cipherbox-engine`.

The test fails when the invariant it pins is broken — confirmed by deliberate breaks:

| Break | Result |
| --- | --- |
| Drop device A's second drain tick, so the depth-2 create never publishes | fails: `device B reads the depth-2 create, left: 0, right: 1` |
| Point the adopter at the wrong `expected_node` | fails: `TrustViolation(GateRejection { stage: Unseal, reason: Trust(Trust(SealOpenFailed)) })` |
| Bind the adopter to a foreign `scope_id` | fails: same fail-closed `Unseal` rejection |

The last two confirm the adoption gate is genuinely exercised rather than bypassed
with shared in-process state: only the record store, the block plane and the clock
are shared with device A; device B's floors, cache and HTTP are cold and its own.

## Review gates

- `/simplify` — tightened the doc comment to a single cross-reference. Skipped the one
  other finding: the `GatewayConfig` literal duplicates the one inlined in the shared
  `engine_on` helper, and de-duplicating it means editing a shared fixture in a file
  #916 is concurrently adding tests to.
- `/security-review` — no findings. Confirmed every gate stage the assertion claims is
  actually run: record signature verify under the name, real head-block fetch with CID
  verification, envelope id and scope binding, per-name sequence floor against device B's
  cold floor store, AAD-bound unseal.
- `/crypto-privacy-review` — no findings. `ChildAdopter` takes the seed by value and is
  its terminal owner, so the zeroize-at-the-terminal-owner rule holds; no encode/decode
  path is touched, so AGENTS.md rule 8 does not apply; no `ResolveOutcome` variant can
  render key or seed bytes through the panic message.

Closes #895
Part of #655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when deeply nested folders are created and synchronized across multiple devices.
  - Ensured child folders are correctly adopted and retain their identity when discovered by another device.

- **Tests**
  - Added coverage for cross-device synchronization of nested folder structures, including parent resolution and child visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->