### PR TITLE
fix: retire every uploaded content block on abandonment

### DIFF
--- a/blueprint/api.md
+++ b/blueprint/api.md
@@ -53,6 +53,11 @@ decay) inverted into structure.
   retire `[ipnsName | cid]`. Ordinary writes send single-item batches; name waves
   and sweeps send bulk. v1's BYO-only `register-cid` folds into the same register
   call.
+- **Batch bounds**: both batches cap at **1000 items** (register additionally
+  caps `contentCids` at 1000 per entry), enforced fail-closed with `400` before
+  per-item validation and published as `maxItems` in the OpenAPI document. A bulk
+  caller — a name wave, or an abandoned version whose leaves all need retiring —
+  chunks to the cap; retire is idempotent, so a replayed chunk is a no-op.
 - **Register-first, fail-closed**: registration precedes the first publish of a
   name, and publish is blocked on it. A live-but-uninventoried name is
   structurally impossible; the worst failure is a registered-never-published

--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -135,7 +135,14 @@ bytes (#28 D2).
 - **Retirement**: retire = remove my registry rows; timing is engine policy
   (#34 D4). Interior old names batch-retire at name-wave completion; the old
   scope-root name lingers serving the tombstone until the migration window
-  closes (open edge below).
+  closes (open edge below). An abandoned op retires the **whole** set its
+  publish charged — the name it registered and every block it uploaded, root
+  and leaves — because each upload is its own accountable pin row (api.md);
+  batches chunk to the registry's batch cap, and retirement is idempotent, so a
+  target that never landed costs nothing. An op whose record PUT was
+  **acknowledged** retires nothing: the record may be resolvable at its name, and
+  unpinning content a live record still references is loss, where leaving the
+  rows charged is only a leak.
 
 ## Adoption gate and floors
 

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -760,44 +760,34 @@ async fn an_abandoned_versions_whole_block_set_retires_back_to_the_pre_upload_fi
         "an_abandoned_versions_whole_block_set_retires_back_to_the_pre_upload_figure"
     );
     let client = fresh_account(&base).await;
-    let before = client
-        .quota()
-        .await
-        .expect("quota before upload")
-        .used_bytes;
 
     // Refused mid-set, the way a 413 halts a drain: the leaves before the halt
     // landed, the ones after never did, and the root never went up at all.
     let landed: Vec<Vec<u8>> = (0..3u8).map(|i| vec![0xB0 | i; 96]).collect();
-    let mut uploaded_cids = Vec::new();
+    let mut targets = vec!["bafyContractAbandonedRoot".to_owned()];
     for block in &landed {
-        uploaded_cids.push(
+        targets.push(
             client
-                .upload(block)
+                .upload(&leaf_cid(block), block)
                 .await
                 .unwrap_or_else(|e| panic!("a version block uploads: {e:?}"))
                 .cid,
         );
     }
+    targets.push("bafyContractAbandonedLeafNeverSent".to_owned());
     assert_eq!(
         client.quota().await.expect("quota after upload").used_bytes,
-        before + (landed.len() * 96) as u64,
-        "each uploaded block charges the account on its own"
+        (landed.len() * 96) as u64,
+        "an upload with no registration behind it still charges the account"
     );
 
-    // What the abandonment retires: the root and every leaf the manifest names,
-    // landed or not. The never-uploaded ones are retired idempotently.
-    let mut targets = vec!["bafyContractAbandonedRoot".to_owned()];
-    targets.extend(uploaded_cids);
-    targets.push("bafyContractAbandonedLeafNeverSent".to_owned());
     client
         .retire(&targets)
         .await
         .expect("an abandoned version retires its whole block set");
-
     assert_eq!(
         client.quota().await.expect("quota after retire").used_bytes,
-        before,
+        0,
         "abandonment returns the account to its pre-upload figure"
     );
 }

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -749,6 +749,85 @@ async fn a_content_version_uploads_registers_and_retires_as_one_block_set() {
         .expect("a replayed retire is a no-op");
 }
 
+/// An abandoned version never registers: its blocks uploaded, the publish then
+/// failed, and the `upload` calls alone are what created the accountable pin
+/// rows. Retirement therefore has to name **every** block — a root-only retire
+/// leaves the leaves charged forever against an account that can no longer
+/// reach them (#916). Hosted bytes must come back to the pre-upload figure.
+#[tokio::test]
+async fn an_abandoned_versions_whole_block_set_retires_back_to_the_pre_upload_figure() {
+    let base = require_stack!(
+        "an_abandoned_versions_whole_block_set_retires_back_to_the_pre_upload_figure"
+    );
+    let client = fresh_account(&base).await;
+    let before = client
+        .quota()
+        .await
+        .expect("quota before upload")
+        .used_bytes;
+
+    // Refused mid-set, the way a 413 halts a drain: the leaves before the halt
+    // landed, the ones after never did, and the root never went up at all.
+    let landed: Vec<Vec<u8>> = (0..3u8).map(|i| vec![0xB0 | i; 96]).collect();
+    let mut uploaded_cids = Vec::new();
+    for block in &landed {
+        uploaded_cids.push(
+            client
+                .upload(block)
+                .await
+                .unwrap_or_else(|e| panic!("a version block uploads: {e:?}"))
+                .cid,
+        );
+    }
+    assert_eq!(
+        client.quota().await.expect("quota after upload").used_bytes,
+        before + (landed.len() * 96) as u64,
+        "each uploaded block charges the account on its own"
+    );
+
+    // What the abandonment retires: the root and every leaf the manifest names,
+    // landed or not. The never-uploaded ones are retired idempotently.
+    let mut targets = vec!["bafyContractAbandonedRoot".to_owned()];
+    targets.extend(uploaded_cids);
+    targets.push("bafyContractAbandonedLeafNeverSent".to_owned());
+    client
+        .retire(&targets)
+        .await
+        .expect("an abandoned version retires its whole block set");
+
+    assert_eq!(
+        client.quota().await.expect("quota after retire").used_bytes,
+        before,
+        "abandonment returns the account to its pre-upload figure"
+    );
+}
+
+/// The retire batch is bounded fail-closed (blueprint/api.md, "Batch bounds"):
+/// an oversize array is refused, never truncated or partially applied. That
+/// refusal is what makes the engine's client-side chunking mandatory rather than
+/// cosmetic, so the bound belongs under the live gate.
+#[tokio::test]
+async fn an_oversize_retire_batch_is_refused_fail_closed() {
+    let base = require_stack!("an_oversize_retire_batch_is_refused_fail_closed");
+    let client = fresh_account(&base).await;
+
+    // One past the documented 1000-item cap.
+    let targets: Vec<String> = (0..1001).map(|i| format!("bafyContractBound{i}")).collect();
+    let error = client
+        .retire(&targets)
+        .await
+        .expect_err("an oversize retire batch must be refused");
+    assert!(
+        matches!(error, ApiError::Status { status: 400, .. }),
+        "the retire bound is fail-closed: a 400, got {error:?}"
+    );
+    // The cap itself is the boundary the engine chunks to, so it must pass.
+    client
+        .retire(&targets[..1000])
+        .await
+        .expect("a batch at the cap is accepted");
+}
+
 // --- mailbox (blueprint/api.md, Mailbox; #827) ------------------------------
 
 /// An account addressable as a mailbox recipient: the client plus its identity

--- a/crates/engine/src/net/retire.rs
+++ b/crates/engine/src/net/retire.rs
@@ -9,10 +9,8 @@
 use crate::api::{ApiClient, ApiError};
 use crate::seams::{CredentialStore, Http};
 
-/// The server's retire batch cap (blueprint/api.md "Pin/name registry"). A
-/// larger array is refused fail-closed, so a caller that cannot chunk cannot
-/// reconcile at all — an abandoned version at the flat-DAG ceiling names far
-/// more leaves than this.
+/// The server's retire batch cap, which refuses a larger array fail-closed
+/// (blueprint/api.md "Batch bounds").
 const RETIRE_BATCH_MAX: usize = 1000;
 
 /// Batch-retire registry rows for `targets` (`ipnsName`s or CIDs). Idempotent
@@ -20,8 +18,8 @@ const RETIRE_BATCH_MAX: usize = 1000;
 /// a chunk a failed pass already sent — is a no-op, never an error. This is the
 /// interior-name path: it retires the moment the caller says a name is dead.
 ///
-/// Chunked to [`RETIRE_BATCH_MAX`]. A chunk that fails leaves the earlier ones
-/// retired and returns `Err`; the caller's retry replays the whole batch.
+/// Chunked to [`RETIRE_BATCH_MAX`]; a failing chunk leaves the earlier ones
+/// retired and returns `Err`.
 pub async fn retire<H, C>(api: &ApiClient<H, C>, targets: &[String]) -> Result<(), ApiError>
 where
     H: Http,
@@ -112,12 +110,6 @@ mod tests {
         assert_eq!(
             sent, targets,
             "every target still reaches the registry once"
-        );
-        assert!(
-            requests
-                .iter()
-                .all(|request| request.url.ends_with("/registry/retire")),
-            "every chunk goes to the retire endpoint"
         );
     }
 

--- a/crates/engine/src/net/retire.rs
+++ b/crates/engine/src/net/retire.rs
@@ -9,19 +9,28 @@
 use crate::api::{ApiClient, ApiError};
 use crate::seams::{CredentialStore, Http};
 
+/// The server's retire batch cap (blueprint/api.md "Pin/name registry"). A
+/// larger array is refused fail-closed, so a caller that cannot chunk cannot
+/// reconcile at all — an abandoned version at the flat-DAG ceiling names far
+/// more leaves than this.
+const RETIRE_BATCH_MAX: usize = 1000;
+
 /// Batch-retire registry rows for `targets` (`ipnsName`s or CIDs). Idempotent
-/// server-side (blueprint/api.md), so a replayed batch — a resumed name wave —
-/// is a no-op, never an error. This is the interior-name path: it retires the
-/// moment the caller says a name is dead.
+/// server-side (blueprint/api.md), so a replayed batch — a resumed name wave, or
+/// a chunk a failed pass already sent — is a no-op, never an error. This is the
+/// interior-name path: it retires the moment the caller says a name is dead.
+///
+/// Chunked to [`RETIRE_BATCH_MAX`]. A chunk that fails leaves the earlier ones
+/// retired and returns `Err`; the caller's retry replays the whole batch.
 pub async fn retire<H, C>(api: &ApiClient<H, C>, targets: &[String]) -> Result<(), ApiError>
 where
     H: Http,
     C: CredentialStore,
 {
-    if targets.is_empty() {
-        return Ok(());
+    for chunk in targets.chunks(RETIRE_BATCH_MAX) {
+        api.retire(chunk).await?;
     }
-    api.retire(targets).await
+    Ok(())
 }
 
 /// Whether the old scope-root name may be retired yet. **Stubbed to `false`**:
@@ -74,6 +83,42 @@ mod tests {
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].method, HttpMethod::Post);
         assert!(requests[0].url.ends_with("/registry/retire"));
+    }
+
+    #[test]
+    fn an_oversize_batch_splits_into_chunks_the_server_accepts() {
+        let (http, client) = client();
+        let targets: Vec<String> = (0..RETIRE_BATCH_MAX + 1)
+            .map(|i| format!("cid{i}"))
+            .collect();
+        for _ in 0..2 {
+            http.enqueue_response(HttpResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: Vec::new(),
+            });
+        }
+        block_on(retire(&client, &targets)).expect("retire");
+
+        let requests = http.requests();
+        assert_eq!(requests.len(), 2, "the batch splits at the server's cap");
+        let sent: Vec<String> = requests
+            .iter()
+            .flat_map(|request| {
+                let body = request.body.as_deref().expect("a retire call has a body");
+                serde_json::from_slice::<Vec<String>>(body).expect("a retire body is a JSON array")
+            })
+            .collect();
+        assert_eq!(
+            sent, targets,
+            "every target still reaches the registry once"
+        );
+        assert!(
+            requests
+                .iter()
+                .all(|request| request.url.ends_with("/registry/retire")),
+            "every chunk goes to the retire endpoint"
+        );
     }
 
     #[test]

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -488,20 +488,17 @@ where
                 if attempts.charge(op_id) < ATTEMPT_BUDGET {
                     return;
                 }
-                if self.dequeue_op(op_id).await.is_ok() {
-                    self.release_staged_blocks(op).await;
-                    report.dead_letters.push((
-                        op_id,
-                        op.target,
-                        DeadLetterReason::AttemptsExhausted,
-                    ));
-                }
+                self.dead_letter(
+                    scope,
+                    op_id,
+                    op,
+                    DeadLetterReason::AttemptsExhausted,
+                    report,
+                )
+                .await;
             }
             Halt::Permanent(reason) => {
-                if self.abandon(scope, op_id, op).await.is_ok() {
-                    self.release_staged_blocks(op).await;
-                    report.dead_letters.push((op_id, op.target, reason));
-                }
+                self.dead_letter(scope, op_id, op, reason, report).await;
             }
             Halt::Blocked { needed_bytes } => {
                 *self.blocked.borrow_mut() = Some(BlockedOp {
@@ -1664,10 +1661,58 @@ where
     /// it published.
     async fn abandon(&self, scope: &DrainScope<'_>, op_id: OpId, op: &Op) -> Result<(), Halt> {
         let target_published = self.base.borrow().contains(op.target);
-        retire(self.api, &registered_by(scope, op, target_published))
-            .await
-            .map_err(|_| Halt::Unclassified)?;
+        let content_cids = self.uploaded_content_cids(op).await;
+        retire(
+            self.api,
+            &registered_by(scope, op, target_published, content_cids),
+        )
+        .await
+        .map_err(|_| Halt::Unclassified)?;
         self.dequeue_op(op_id).await
+    }
+
+    /// Dead-letter one op: the single reconciliation point both terminal valve
+    /// arms go through, so what an abandonment retires is decided in one place.
+    /// A failed retire leaves the op queued for the next pass rather than
+    /// dropping it with rows still charged.
+    async fn dead_letter(
+        &self,
+        scope: &DrainScope<'_>,
+        op_id: OpId,
+        op: &Op,
+        reason: DeadLetterReason,
+        report: &mut DrainReport,
+    ) {
+        if self.abandon(scope, op_id, op).await.is_ok() {
+            self.release_staged_blocks(op).await;
+            report.dead_letters.push((op_id, op.target, reason));
+        }
+    }
+
+    /// Every content CID an abandoned op's uploads may have left charged: the
+    /// version root and every leaf its staged manifest names. Each `POST
+    /// /content/upload` creates its own accountable pin row (blueprint/api.md
+    /// "Pin/name registry"), so retiring the root alone would spend account
+    /// quota forever on blocks no record reaches (#916).
+    ///
+    /// Reads the manifest before [`Self::release_staged_blocks`] drops it —
+    /// after that the leaf CIDs are recoverable from nowhere.
+    async fn uploaded_content_cids(&self, op: &Op) -> Vec<String> {
+        let Some(root_cid) = op.content_root_cid() else {
+            return Vec::new();
+        };
+        let mut cids = vec![encode_content_cid_str(root_cid)];
+        if let Ok(Some(root_block)) = self.staging.staged_bytes(root_cid).await
+            && let Ok(content) = SealedContent::from_root_block(&root_block)
+        {
+            cids.extend(
+                content
+                    .leaf_cids()
+                    .iter()
+                    .map(|cid| encode_content_cid_str(cid)),
+            );
+        }
+        cids
     }
 
     /// The attempt record, pruned to the ops still queued. `live` is every id
@@ -1810,18 +1855,21 @@ fn classify_upload(error: ApiError, refused_bytes: u64) -> Halt {
 /// whether the op's node survives in gate-passing state.
 ///
 /// The child name goes only with an abandoned create whose target never became
-/// reachable — a landed node still publishes under it. The version root goes
-/// with **any** content-bearing op: no record ever links a version whose op was
+/// reachable — a landed node still publishes under it. `content_cids` goes with
+/// **any** content-bearing op: no record ever links a version whose op was
 /// abandoned, whatever became of the node it was authored for.
-fn registered_by(scope: &DrainScope<'_>, op: &Op, target_published: bool) -> Vec<String> {
+fn registered_by(
+    scope: &DrainScope<'_>,
+    op: &Op,
+    target_published: bool,
+    content_cids: Vec<String>,
+) -> Vec<String> {
     let name = (!target_published && matches!(op.kind, OpKind::Create { .. })).then(|| {
         derive_write_name(scope.write_scope_seed, &op.target.0)
             .as_str()
             .to_owned()
     });
-    name.into_iter()
-        .chain(op.content_root_cid().map(encode_content_cid_str))
-        .collect()
+    name.into_iter().chain(content_cids).collect()
 }
 
 #[cfg(test)]

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -174,6 +174,11 @@ enum Halt {
     /// against the attempt budget, because a retry re-signs at the same
     /// sequence and a jammed name would otherwise retry forever.
     Attempt,
+    /// An upload refusal this pass cannot attribute. Charged like
+    /// [`Halt::Attempt`], but raised strictly **before** the record PUT — so
+    /// exhausting the budget may retire what the op uploaded, which an acked
+    /// PUT's may not.
+    UploadAttempt,
     /// Classified-permanent: the same bytes are refused on every retry.
     Permanent(DeadLetterReason),
     /// Over the account quota. Not a failure of the op — it holds the head and
@@ -203,7 +208,8 @@ pub const UPLOAD_MARK_KEY: &[u8] = b"cipherbox/upload-mark";
 
 /// How many non-confirming publish attempts one op gets before it dead-letters.
 ///
-/// Bounds a pathology, not a network outage — only [`Halt::Attempt`] is charged.
+/// Bounds a pathology, not a network outage — only [`Halt::Attempt`] and
+/// [`Halt::UploadAttempt`] are charged.
 const ATTEMPT_BUDGET: u32 = 5;
 
 /// The staging key holding per-op drain attempt counts: a one-byte format tag
@@ -484,18 +490,20 @@ where
     ) {
         match halt {
             Halt::Unclassified => {}
-            Halt::Attempt => {
+            Halt::Attempt | Halt::UploadAttempt => {
                 if attempts.charge(op_id) < ATTEMPT_BUDGET {
                     return;
                 }
-                self.dead_letter(
-                    scope,
-                    op_id,
-                    op,
-                    DeadLetterReason::AttemptsExhausted,
-                    report,
-                )
-                .await;
+                let reason = DeadLetterReason::AttemptsExhausted;
+                if halt == Halt::UploadAttempt {
+                    self.dead_letter(scope, op_id, op, reason, report).await;
+                } else if self.dequeue_op(op_id).await.is_ok() {
+                    // An acked PUT may be resolvable at the name, so nothing is
+                    // retired: unpinning content a live record still names is
+                    // loss, where leaving the rows charged is only a leak.
+                    self.release_staged_blocks(op).await;
+                    report.dead_letters.push((op_id, op.target, reason));
+                }
             }
             Halt::Permanent(reason) => {
                 self.dead_letter(scope, op_id, op, reason, report).await;
@@ -1329,10 +1337,7 @@ where
         // before the record lands would strand a fully-uploaded version.
         self.upload_block(&staged.root_cid, &root_block).await?;
 
-        let content_cids = core::iter::once(&staged.root_cid)
-            .chain(content.leaf_cids())
-            .map(|cid| encode_content_cid_str(cid))
-            .collect();
+        let content_cids = registry_cids(&staged.root_cid, content.leaf_cids());
         Ok(UploadedVersion {
             version: content.version(*key, applied.op.authored_at.0),
             content_cids,
@@ -1383,6 +1388,14 @@ where
         Ok(Some(block))
     }
 
+    /// The version manifest a staged root block carries. `None` when the block
+    /// is gone or unreadable: both callers are reconciliation paths that must
+    /// still make progress on a store that has lost bytes.
+    async fn staged_manifest(&self, root_cid: &[u8]) -> Option<SealedContent> {
+        let block = self.staged_block(root_cid).await.ok()??;
+        SealedContent::from_root_block(&block).ok()
+    }
+
     /// Upload one block to the pin provider under `cid`, its staging key and
     /// own content address, so the ingress pins it where the published record
     /// points (#906). A block is only ever removed from staging on a confirmed
@@ -1413,9 +1426,7 @@ where
         let Some(staged) = op.staged_content() else {
             return;
         };
-        if let Ok(Some(root_block)) = self.staging.staged_bytes(&staged.root_cid).await
-            && let Ok(content) = SealedContent::from_root_block(&root_block)
-        {
+        if let Some(content) = self.staged_manifest(&staged.root_cid).await {
             for leaf_cid in content.leaf_cids() {
                 let _ = self.staging.remove_staged_bytes(leaf_cid).await;
             }
@@ -1654,27 +1665,15 @@ where
 
     /// Abandon one op: retire what its publish registered, then drop it from
     /// the queue (#819 as amended by #824).
-    ///
-    /// A name some published record already references is never retired — that
-    /// would leave a reference outliving its referent. The gate-passing base is
-    /// the evidence: a created node reaches it only once a parent record naming
-    /// it published.
     async fn abandon(&self, scope: &DrainScope<'_>, op_id: OpId, op: &Op) -> Result<(), Halt> {
-        let target_published = self.base.borrow().contains(op.target);
-        let content_cids = self.uploaded_content_cids(op).await;
-        retire(
-            self.api,
-            &registered_by(scope, op, target_published, content_cids),
-        )
-        .await
-        .map_err(|_| Halt::Unclassified)?;
+        retire(self.api, &self.registered_by(scope, op).await)
+            .await
+            .map_err(|_| Halt::Unclassified)?;
         self.dequeue_op(op_id).await
     }
 
-    /// Dead-letter one op: the single reconciliation point both terminal valve
-    /// arms go through, so what an abandonment retires is decided in one place.
-    /// A failed retire leaves the op queued for the next pass rather than
-    /// dropping it with rows still charged.
+    /// Dead-letter one op. A failed retire leaves it queued for the next pass
+    /// rather than dropping it with its registry rows still charged.
     async fn dead_letter(
         &self,
         scope: &DrainScope<'_>,
@@ -1689,30 +1688,37 @@ where
         }
     }
 
-    /// Every content CID an abandoned op's uploads may have left charged: the
-    /// version root and every leaf its staged manifest names. Each `POST
-    /// /content/upload` creates its own accountable pin row (blueprint/api.md
-    /// "Pin/name registry"), so retiring the root alone would spend account
-    /// quota forever on blocks no record reaches (#916).
+    /// The registry rows one op's publish registered, mirroring what the publish
+    /// pipeline sends (`PublishRequest::registration`).
     ///
-    /// Reads the manifest before [`Self::release_staged_blocks`] drops it —
-    /// after that the leaf CIDs are recoverable from nowhere.
-    async fn uploaded_content_cids(&self, op: &Op) -> Vec<String> {
-        let Some(root_cid) = op.content_root_cid() else {
-            return Vec::new();
+    /// The child name goes only with an abandoned create whose target never
+    /// became reachable: a name some published record already references would
+    /// leave a reference outliving its referent, and the gate-passing base is
+    /// the evidence — a created node reaches it only once a parent record naming
+    /// it published. The content CIDs go with **any** content-bearing op that
+    /// reaches here: an abandonment only retires when no PUT for the op was
+    /// acked, so no record can link the version.
+    ///
+    /// Reads the manifest before [`Self::release_staged_blocks`] drops it: after
+    /// that the leaf CIDs are recoverable from nowhere (#916).
+    async fn registered_by(&self, scope: &DrainScope<'_>, op: &Op) -> Vec<String> {
+        let target_published = self.base.borrow().contains(op.target);
+        let name = (!target_published && matches!(op.kind, OpKind::Create { .. })).then(|| {
+            derive_write_name(scope.write_scope_seed, &op.target.0)
+                .as_str()
+                .to_owned()
+        });
+        let content = match op.content_root_cid() {
+            Some(root_cid) => {
+                let manifest = self.staged_manifest(root_cid).await;
+                registry_cids(
+                    root_cid,
+                    manifest.as_ref().map_or(&[], SealedContent::leaf_cids),
+                )
+            }
+            None => Vec::new(),
         };
-        let mut cids = vec![encode_content_cid_str(root_cid)];
-        if let Ok(Some(root_block)) = self.staging.staged_bytes(root_cid).await
-            && let Ok(content) = SealedContent::from_root_block(&root_block)
-        {
-            cids.extend(
-                content
-                    .leaf_cids()
-                    .iter()
-                    .map(|cid| encode_content_cid_str(cid)),
-            );
-        }
-        cids
+        name.into_iter().chain(content).collect()
     }
 
     /// The attempt record, pruned to the ops still queued. `live` is every id
@@ -1846,30 +1852,20 @@ fn classify_upload(error: ApiError, refused_bytes: u64) -> Halt {
             needed_bytes: refused_bytes,
         },
         Some(UPLOAD_TOO_LARGE) => Halt::Permanent(DeadLetterReason::PayloadRefused),
-        _ => Halt::Attempt,
+        _ => Halt::UploadAttempt,
     }
 }
 
-/// The registry rows one op's publish registered, mirroring what the publish
-/// pipeline sends (`PublishRequest::registration`). `target_published` is
-/// whether the op's node survives in gate-passing state.
-///
-/// The child name goes only with an abandoned create whose target never became
-/// reachable — a landed node still publishes under it. `content_cids` goes with
-/// **any** content-bearing op: no record ever links a version whose op was
-/// abandoned, whatever became of the node it was authored for.
-fn registered_by(
-    scope: &DrainScope<'_>,
-    op: &Op,
-    target_published: bool,
-    content_cids: Vec<String>,
-) -> Vec<String> {
-    let name = (!target_published && matches!(op.kind, OpKind::Create { .. })).then(|| {
-        derive_write_name(scope.write_scope_seed, &op.target.0)
-            .as_str()
-            .to_owned()
-    });
-    name.into_iter().chain(content_cids).collect()
+/// One version as the registry names it: the root first, then every leaf in
+/// file order. Registration and retirement both go through here, so a retire
+/// batch names exactly what a register batch claimed — and every block is its
+/// own accountable pin row (blueprint/api.md "Pin/name registry"), so leaving
+/// a leaf out of a retirement spends account quota forever.
+fn registry_cids(root_cid: &[u8], leaf_cids: &[Vec<u8>]) -> Vec<String> {
+    core::iter::once(root_cid)
+        .chain(leaf_cids.iter().map(Vec::as_slice))
+        .map(encode_content_cid_str)
+        .collect()
 }
 
 #[cfg(test)]
@@ -1950,7 +1946,7 @@ mod tests {
         for code in [None, Some("SOMETHING_NEW")] {
             assert_eq!(
                 refusal(code),
-                Halt::Attempt,
+                Halt::UploadAttempt,
                 "a 413 the API did not stamp is a proxy, and supports neither verdict"
             );
         }

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -92,9 +92,9 @@ pub enum DeadLetterReason {
     /// The network refused the op's own bytes for a reason no retry changes —
     /// an over-cap payload, not a full account.
     PayloadRefused,
-    /// The op's drain attempt budget ran out. Its record reached the record
-    /// plane and never confirmed, so the publish may have landed: this reason
-    /// is the one abandonment that must **not** retire (#819 as amended).
+    /// The op's drain attempt budget ran out. A budget spent before the record
+    /// PUT retires what the op uploaded; once a PUT is acked the publish may
+    /// have landed, so that half retires nothing (#819 as amended).
     AttemptsExhausted,
     /// The op's staged content can never publish: its per-version key will not
     /// open, its root block is gone or unreadable, or a leaf is missing from the

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -2218,34 +2218,25 @@ fn a_publish_that_never_confirms_dead_letters_once_its_attempt_budget_runs_out()
     let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
 
     let op_id = create(&mut engine, "photos");
-    let photos = child_id(&engine, ROOT, "photos");
-    jam_name(&world.record_store, photos);
+    jam_name(&world.record_store, child_id(&engine, ROOT, "photos"));
 
     // The budget is spent one non-confirming publish per pass: finite, but more
     // than one — a single lost race is a retry, not an abandonment.
-    let dead_letters =
-        |engine: &Engine<FakeSeamTypes>| block_on(engine.snapshot(ROOT)).unwrap().dead_letters;
-    let mut passes = 0;
-    while dead_letters(&engine).is_empty() {
-        tick(&world, &engine, &mut tasks);
-        passes += 1;
-        assert!(passes < 50, "the attempt budget must be finite");
-    }
+    let (dead_letters, passes) = tick_until_dead_lettered(&world, &engine, &mut tasks);
     assert!(
         passes > 1,
         "one non-confirming publish is a retry, not an abandonment"
     );
     assert_eq!(
-        dead_letters(&engine),
+        dead_letters,
         vec![DeadLetter {
             op_id,
             reason: DeadLetterReason::AttemptsExhausted
         }]
     );
-    assert_eq!(
-        retire_targets(&alice),
-        vec![write_name(photos).as_str().to_owned()],
-        "an exhausted budget abandons: the name it registered leaves the inventory with it"
+    assert!(
+        retire_targets(&alice).is_empty(),
+        "an unconfirmed publish is never retired out from under itself"
     );
 }
 
@@ -2288,29 +2279,20 @@ fn an_abandoned_version_retires_every_block_it_uploaded_and_keeps_the_files_name
     let blocks = Blocks::default();
     seed_account(&world, &blocks);
     let alice = world.device(b"alice");
-    let (mut engine, mut tasks) = seed_file(&world, &blocks, &alice);
-    let file = child_id(&engine, ROOT, "photo.bin");
+    let (engine, mut tasks, version) = stage_a_second_version(&world, &blocks, &alice);
 
-    write_file(
-        &mut engine,
-        WriteTarget::Version { node: file },
-        &(0..200u8).collect::<Vec<_>>(),
-    )
-    .unwrap();
-    let version = staged_version_cids(&alice);
-    // Refused mid-set, so leaves land before the halt and the retire batch has
-    // to name blocks that are already charged.
-    let refused_upload = 8;
-    let mut sent = 0;
-    blocks.refuse_upload(Box::new(move |_| {
-        sent += 1;
-        (sent == refused_upload).then(|| upload_413(Some("UPLOAD_TOO_LARGE")))
-    }));
+    refuse_uploads_from(&blocks, MID_SET_UPLOAD, || {
+        upload_413(Some("UPLOAD_TOO_LARGE"))
+    });
     tick(&world, &engine, &mut tasks);
 
+    let landed = version
+        .iter()
+        .filter(|cid| blocks.get(cid).is_some())
+        .count();
     assert!(
-        uploads(&alice) >= refused_upload,
-        "the halt came after leaves had already landed"
+        (1..version.len()).contains(&landed),
+        "the halt came mid-set: some of the version is charged, not all of it"
     );
     assert_eq!(
         retire_targets(&alice),
@@ -2319,43 +2301,25 @@ fn an_abandoned_version_retires_every_block_it_uploaded_and_keeps_the_files_name
     );
 }
 
-/// The attempts-exhausted arm is an abandonment too: an op whose publish burned
-/// its budget retires what its uploads charged, exactly as a permanent refusal
-/// does (#916).
+/// Exhausting the budget on refusals raised **before** any record PUT is an
+/// abandonment too: nothing can link the version, so it retires what its uploads
+/// charged, exactly as a permanent refusal does (#916). The acked-PUT arm is the
+/// opposite case and retires nothing.
 #[test]
-fn a_version_whose_attempt_budget_runs_out_retires_every_block_it_uploaded() {
+fn a_version_whose_upload_budget_runs_out_retires_every_block_it_uploaded() {
     let world = FakeWorld::new();
     let blocks = Blocks::default();
     seed_account(&world, &blocks);
     let alice = world.device(b"alice");
-    let (mut engine, mut tasks) = seed_file(&world, &blocks, &alice);
-    let file = child_id(&engine, ROOT, "photo.bin");
+    let (engine, mut tasks, version) = stage_a_second_version(&world, &blocks, &alice);
 
-    write_file(
-        &mut engine,
-        WriteTarget::Version { node: file },
-        &(0..200u8).collect::<Vec<_>>(),
-    )
-    .unwrap();
-    let version = staged_version_cids(&alice);
-    // Leaves land, then an unattributable 413 stalls the set: charged rows with
-    // an op that will never publish.
-    let mut sent = 0;
-    blocks.refuse_upload(Box::new(move |_| {
-        sent += 1;
-        (sent >= 8).then(proxy_413)
-    }));
+    // An unattributable 413 is charged, never abandoned on one response, so the
+    // set stalls with rows already charged until the budget runs out.
+    refuse_uploads_from(&blocks, MID_SET_UPLOAD, proxy_413);
+    let (dead_letters, _) = tick_until_dead_lettered(&world, &engine, &mut tasks);
 
-    let dead_letters =
-        |engine: &Engine<FakeSeamTypes>| block_on(engine.snapshot(ROOT)).unwrap().dead_letters;
-    let mut passes = 0;
-    while dead_letters(&engine).is_empty() {
-        tick(&world, &engine, &mut tasks);
-        passes += 1;
-        assert!(passes < 50, "the attempt budget must be finite");
-    }
     assert_eq!(
-        dead_letters(&engine)
+        dead_letters
             .iter()
             .map(|letter| letter.reason)
             .collect::<Vec<_>>(),
@@ -2368,31 +2332,77 @@ fn a_version_whose_attempt_budget_runs_out_retires_every_block_it_uploaded() {
     );
 }
 
-/// Land one multi-leaf file so a later version has something to update.
-fn seed_file(
+/// The opposite arm: an acked PUT may already be resolvable at the name, so
+/// exhausting the budget there retires nothing. Unpinning content a live record
+/// still names is loss, where leaving the rows charged is only a leak (#916).
+#[test]
+fn an_unconfirmed_publish_never_retires_the_version_it_may_already_name() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+
+    let target = WriteTarget::NewFile {
+        parent: ROOT,
+        name: "photo.bin".into(),
+    };
+    write_file(&mut engine, target, &(0..200u8).collect::<Vec<_>>()).unwrap();
+    jam_name(&world.record_store, child_id(&engine, ROOT, "photo.bin"));
+
+    let (dead_letters, _) = tick_until_dead_lettered(&world, &engine, &mut tasks);
+    assert_eq!(
+        dead_letters
+            .iter()
+            .map(|letter| letter.reason)
+            .collect::<Vec<_>>(),
+        vec![DeadLetterReason::AttemptsExhausted]
+    );
+    assert!(
+        uploads(&alice) > 0,
+        "the version uploaded before the publish burned its budget"
+    );
+    assert!(
+        retire_targets(&alice).is_empty(),
+        "an acked PUT may be live at the name, so its blocks are not ours to unpin"
+    );
+}
+
+/// The upload a refusal lands on to halt a 200-byte version mid-set: past the
+/// first leaves, well short of the 13 the CI framing produces.
+const MID_SET_UPLOAD: usize = 8;
+
+/// Refuse every upload from the `nth` on, so a halted set stays halted across
+/// the passes that retry it.
+fn refuse_uploads_from(blocks: &Blocks, nth: usize, refusal: fn() -> SeamResult<HttpResponse>) {
+    let mut sent = 0;
+    blocks.refuse_upload(Box::new(move |_| {
+        sent += 1;
+        (sent >= nth).then(refusal)
+    }));
+}
+
+/// Land one multi-leaf file, then queue a second version over it. Returns the
+/// queued version's whole block set as the registry names it: the root first,
+/// then every leaf in file order.
+fn stage_a_second_version(
     world: &FakeWorld,
     blocks: &Blocks,
     device: &FakeDevice,
-) -> (Engine<FakeSeamTypes>, Vec<BoxedTask>) {
+) -> (Engine<FakeSeamTypes>, Vec<BoxedTask>, Vec<String>) {
     let (mut engine, _events, mut tasks) = boot(world, blocks, device, 42);
-    write_file(
-        &mut engine,
-        WriteTarget::NewFile {
-            parent: ROOT,
-            name: "photo.bin".into(),
-        },
-        &(0..200u8).collect::<Vec<_>>(),
-    )
-    .unwrap();
+    let target = WriteTarget::NewFile {
+        parent: ROOT,
+        name: "photo.bin".into(),
+    };
+    write_file(&mut engine, target, &(0..200u8).collect::<Vec<_>>()).unwrap();
     tick(world, &engine, &mut tasks);
     assert!(retire_targets(device).is_empty(), "the create landed");
-    (engine, tasks)
-}
 
-/// The queued content op's whole block set as the registry names it: the version
-/// root first, then every leaf in file order.
-fn staged_version_cids(device: &FakeDevice) -> Vec<String> {
-    block_on(async {
+    let file = child_id(&engine, ROOT, "photo.bin");
+    let next: Vec<u8> = (0..200u8).rev().collect();
+    write_file(&mut engine, WriteTarget::Version { node: file }, &next).unwrap();
+    let version = block_on(async {
         let queued = device.staging_store.queued_ops().await.unwrap();
         let root_cid = record_content_root_cid(&queued[0].1).unwrap().unwrap();
         let root_block = device
@@ -2405,7 +2415,25 @@ fn staged_version_cids(device: &FakeDevice) -> Vec<String> {
             .chain(&decode_root(&root_block).unwrap().leaf_cids)
             .map(|cid| encode_content_cid_str(cid))
             .collect()
-    })
+    });
+    (engine, tasks, version)
+}
+
+/// Tick until the drain dead-letters something, and report how many passes that
+/// took — the budget is finite, but spending it takes more than one pass.
+fn tick_until_dead_lettered(
+    world: &FakeWorld,
+    engine: &Engine<FakeSeamTypes>,
+    tasks: &mut [BoxedTask],
+) -> (Vec<DeadLetter>, usize) {
+    let dead_letters = || block_on(engine.snapshot(ROOT)).unwrap().dead_letters;
+    let mut passes = 0;
+    while dead_letters().is_empty() {
+        tick(world, engine, tasks);
+        passes += 1;
+        assert!(passes < 50, "the attempt budget must be finite");
+    }
+    (dead_letters(), passes)
 }
 
 #[test]

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -2218,7 +2218,8 @@ fn a_publish_that_never_confirms_dead_letters_once_its_attempt_budget_runs_out()
     let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
 
     let op_id = create(&mut engine, "photos");
-    jam_name(&world.record_store, child_id(&engine, ROOT, "photos"));
+    let photos = child_id(&engine, ROOT, "photos");
+    jam_name(&world.record_store, photos);
 
     // The budget is spent one non-confirming publish per pass: finite, but more
     // than one — a single lost race is a retry, not an abandonment.
@@ -2241,9 +2242,10 @@ fn a_publish_that_never_confirms_dead_letters_once_its_attempt_budget_runs_out()
             reason: DeadLetterReason::AttemptsExhausted
         }]
     );
-    assert!(
-        retire_targets(&alice).is_empty(),
-        "an unconfirmed publish is never retired out from under itself"
+    assert_eq!(
+        retire_targets(&alice),
+        vec![write_name(photos).as_str().to_owned()],
+        "an exhausted budget abandons: the name it registered leaves the inventory with it"
     );
 }
 
@@ -2275,44 +2277,135 @@ fn an_abandoned_create_retires_the_child_name_it_registered_exactly_once() {
     );
 }
 
-/// An abandoned `updateContent` uploaded a version root no record will ever
-/// link — its file still publishes the versions it had — so the root leaves the
-/// republish inventory with the op while the file's own name stays live.
+/// An abandoned `updateContent` uploaded a version no record will ever link —
+/// its file still publishes the versions it had — so every block it uploaded
+/// leaves the republish inventory with the op while the file's own name stays
+/// live. Each upload creates its own charged pin row, so a leaf the root
+/// retirement misses spends account quota forever (#916).
 #[test]
-fn an_abandoned_version_retires_its_root_and_keeps_the_files_name() {
+fn an_abandoned_version_retires_every_block_it_uploaded_and_keeps_the_files_name() {
     let world = FakeWorld::new();
     let blocks = Blocks::default();
     seed_account(&world, &blocks);
     let alice = world.device(b"alice");
-    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
-
-    let target = WriteTarget::NewFile {
-        parent: ROOT,
-        name: "photo.bin".into(),
-    };
-    write_file(&mut engine, target, &(0..200u8).collect::<Vec<_>>()).unwrap();
-    tick(&world, &engine, &mut tasks);
+    let (mut engine, mut tasks) = seed_file(&world, &blocks, &alice);
     let file = child_id(&engine, ROOT, "photo.bin");
-    assert!(retire_targets(&alice).is_empty(), "the create landed");
 
     write_file(
         &mut engine,
         WriteTarget::Version { node: file },
-        &(0..120u8).collect::<Vec<_>>(),
+        &(0..200u8).collect::<Vec<_>>(),
     )
     .unwrap();
-    let version_root = block_on(async {
-        let queued = alice.staging_store.queued_ops().await.unwrap();
-        record_content_root_cid(&queued[0].1).unwrap().unwrap()
-    });
-    blocks.refuse_upload(Box::new(|_| Some(upload_413(Some("UPLOAD_TOO_LARGE")))));
+    let version = staged_version_cids(&alice);
+    // Refused mid-set, so leaves land before the halt and the retire batch has
+    // to name blocks that are already charged.
+    let refused_upload = 8;
+    let mut sent = 0;
+    blocks.refuse_upload(Box::new(move |_| {
+        sent += 1;
+        (sent == refused_upload).then(|| upload_413(Some("UPLOAD_TOO_LARGE")))
+    }));
     tick(&world, &engine, &mut tasks);
 
+    assert!(
+        uploads(&alice) >= refused_upload,
+        "the halt came after leaves had already landed"
+    );
     assert_eq!(
         retire_targets(&alice),
-        vec![encode_content_cid_str(&version_root)],
-        "the version root leaves the inventory; the file's own name does not"
+        version,
+        "every uploaded block leaves the inventory; the file's own name does not"
     );
+}
+
+/// The attempts-exhausted arm is an abandonment too: an op whose publish burned
+/// its budget retires what its uploads charged, exactly as a permanent refusal
+/// does (#916).
+#[test]
+fn a_version_whose_attempt_budget_runs_out_retires_every_block_it_uploaded() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    let (mut engine, mut tasks) = seed_file(&world, &blocks, &alice);
+    let file = child_id(&engine, ROOT, "photo.bin");
+
+    write_file(
+        &mut engine,
+        WriteTarget::Version { node: file },
+        &(0..200u8).collect::<Vec<_>>(),
+    )
+    .unwrap();
+    let version = staged_version_cids(&alice);
+    // Leaves land, then an unattributable 413 stalls the set: charged rows with
+    // an op that will never publish.
+    let mut sent = 0;
+    blocks.refuse_upload(Box::new(move |_| {
+        sent += 1;
+        (sent >= 8).then(proxy_413)
+    }));
+
+    let dead_letters =
+        |engine: &Engine<FakeSeamTypes>| block_on(engine.snapshot(ROOT)).unwrap().dead_letters;
+    let mut passes = 0;
+    while dead_letters(&engine).is_empty() {
+        tick(&world, &engine, &mut tasks);
+        passes += 1;
+        assert!(passes < 50, "the attempt budget must be finite");
+    }
+    assert_eq!(
+        dead_letters(&engine)
+            .iter()
+            .map(|letter| letter.reason)
+            .collect::<Vec<_>>(),
+        vec![DeadLetterReason::AttemptsExhausted]
+    );
+    assert_eq!(
+        retire_targets(&alice),
+        version,
+        "an exhausted budget retires the same block set a permanent refusal does"
+    );
+}
+
+/// Land one multi-leaf file so a later version has something to update.
+fn seed_file(
+    world: &FakeWorld,
+    blocks: &Blocks,
+    device: &FakeDevice,
+) -> (Engine<FakeSeamTypes>, Vec<BoxedTask>) {
+    let (mut engine, _events, mut tasks) = boot(world, blocks, device, 42);
+    write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<_>>(),
+    )
+    .unwrap();
+    tick(world, &engine, &mut tasks);
+    assert!(retire_targets(device).is_empty(), "the create landed");
+    (engine, tasks)
+}
+
+/// The queued content op's whole block set as the registry names it: the version
+/// root first, then every leaf in file order.
+fn staged_version_cids(device: &FakeDevice) -> Vec<String> {
+    block_on(async {
+        let queued = device.staging_store.queued_ops().await.unwrap();
+        let root_cid = record_content_root_cid(&queued[0].1).unwrap().unwrap();
+        let root_block = device
+            .staging_store
+            .staged_bytes(&root_cid)
+            .await
+            .unwrap()
+            .unwrap();
+        core::iter::once(&root_cid)
+            .chain(&decode_root(&root_block).unwrap().leaf_cids)
+            .map(|cid| encode_content_cid_str(cid))
+            .collect()
+    })
 }
 
 #[test]


### PR DESCRIPTION
Closes #916
Part of #655

Every content block a version uploads becomes its own **charged** `PinnedCid` row — `POST /content/upload` inserts `{ accountId, cid, size, advisory: false }` and `sumHostedBytes` counts exactly those rows. Abandonment retired only the version root, so an abandoned upload spent account quota forever on blocks no record reaches, and `release_staged_blocks` dropped the staged copies in the same breath so the client could not even recover the CID list.

Abandonment now enumerates the version's leaves from its staged root manifest — read before the blocks are released, which is the last moment the list exists anywhere — and retires the whole block set.

## The two open decisions

**Batch bound: chunk client-side, no new API limit.** The endpoint already has one. `BatchSizePipe` refuses a retire array over `MAX_BATCH = 1000` with a `400` before `ParseArrayPipe` and before any DB work, and the controller publishes it as `maxItems` in the OpenAPI document. The issue's "no documented cap" premise is stale against as-built code. So the fix is on the client: `net::retire::retire` chunks to that cap. It is the single chokepoint every retire batch goes through — name waves and sweeps get the same treatment for free — and it is the layer that already owns retire timing as engine policy. The cap was undocumented in `blueprint/api.md`; it is now, under "Batch bounds", along with register's per-entry `contentCids` cap.

A failing chunk leaves the earlier ones retired and returns `Err`, so `abandon` does not dequeue and the next pass replays the whole batch. Retire is idempotent, so the replay converges.

**`Halt::Attempt`: split it, and route only the safe half through `abandon`.** The issue asks for the arm to retire. Running the whole arm through `abandon` is a regression, and both the security and crypto gates flagged it independently as the highest finding in the diff:

`Halt::Attempt` is documented as "the op's record reached the record plane and did not confirm", and the only publish-side source is `PublishOutcome::Unconfirmed | LostRace`. `Unconfirmed` is reached only after `fanout.any_acked()` was true, with `spawn_background_reput` still re-PUTting afterwards — one of its documented sub-cases is literally a resolvable fork at the same sequence. So a live record may already name the version. Retiring there drops the last pin row, `RegistryService.retire` physically unpins at global refcount zero, `release_staged_blocks` deletes the local copy, and a live signed gate-passing head now points at content nothing holds. That converts a quota leak into irreversible content loss. The pre-existing test assertion "an unconfirmed publish is never retired out from under itself" was encoding exactly this, and is restored.

The other half of the arm is safe and is where the leak actually lives: `classify_upload`'s unattributable-413 is raised strictly **before** any PUT, on a content or head block upload. That splits out as `Halt::UploadAttempt` — charged against the same budget, but abandonable. Both terminal retiring arms (`Permanent`, `UploadAttempt`) go through one `dead_letter` reconciliation point, so what an abandonment retires is decided in one place; the acked arm keeps its rows charged and only leaves the queue.

`registered_by`'s comment about root retirement dropping a server-walked refcount is not in the tree — it was reworded before #907 merged. The doc that is there now states the name/content split and the acked-PUT rule.

## Also in the diff

- `staged_manifest` is the one CID-verifying reader for the staged root manifest, shared by `release_staged_blocks` and the retire path. The retire batch drives a destructive authenticated call, and a staged block is authenticated only by its CID, so an unverified manifest would let a store co-tenant pick the leaf list.
- `registry_cids` builds the root-first CID list once, so a retire batch names exactly what a register batch claimed.
- `registered_by` moves onto `Drain` and computes both halves itself.

## Tests

`Engine Tests`
- an abandoned version refused mid-set retires every block, not only the root, and keeps the file's own name
- the pre-PUT budget running out retires the same block set a permanent refusal does
- an acked-but-unconfirmed publish retires nothing, even though it uploaded a version — the regression guard for the decision above
- an oversize batch splits into chunks the server accepts, in order, each target once

`Contract Suite`
- hosted bytes return to the pre-upload figure after an abandoned version retires, with no registration behind the uploads — the shape where the upload alone created the charged row
- an oversize retire batch is refused fail-closed with a `400`, and a batch at the cap is accepted

## Verified locally

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check --workspace --all-targets`, `cargo test --workspace` (32 suites green), and `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets`.

The contract-suite legs were **not** run locally — they need a live API, Postgres and Kubo, and skip loudly without `CONTRACT_API_URL`. They run in the merge-blocking `contract-suite` job.

## Follow-ups filed

- #920 — the register path is not chunked to the registry's per-entry `contentCids` cap. A version past ~1 GiB is `400`'d, classifies as `Halt::Unclassified`, and loops at the queue head forever instead of dead-lettering. This also means the >1000-target retire chunking is currently unreachable in practice.
- #921 — the head block an op registers is its own charged pin row and is retired on no path, for any op kind. Each retry re-authors under a fresh nonce, so an op that burns its budget leaves several orphaned charged rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards limiting registration and retirement batches to 1,000 items.
  * Larger retirement requests are automatically split into smaller batches.
* **Bug Fixes**
  * Improved cleanup after abandoned or repeatedly failed uploads, including all uploaded content.
  * Preserved live file names when cleaning up failed content versions.
  * Prevented cleanup after successfully acknowledged publishes.
  * Added clear failure handling for requests exceeding batch limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->