### PR TITLE
feat: report upload progress on the op that drives it

### DIFF
--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -530,10 +530,8 @@ pub enum Event {
 }
 
 /// How far a content transfer has got, in whole blocks of the version's DAG
-/// (its leaves plus the root manifest). Blocks rather than bytes because a
-/// resumed upload's confirmed prefix is no longer on this device to measure,
-/// while the manifest names every block up front — and the leaves are uniform,
-/// so the fraction tracks bytes.
+/// (its leaves plus the root manifest). Blocks, not bytes: a resumed upload's
+/// confirmed prefix is no longer on this device to measure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BlockProgress {
     /// Blocks confirmed so far, counting a previous pass's durable progress.
@@ -543,11 +541,6 @@ pub struct BlockProgress {
 }
 
 /// The phase an [`Event::OpProgress`] reports.
-///
-/// The upload phases are the ones the drain's content path actually reaches.
-/// Two upload outcomes are deliberately *not* phases: an over-quota hold is
-/// [`SnapshotView::blocked`], and a terminal give-up is [`Event::DeadLetter`]
-/// with its reason.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OpPhase {
     /// A content download started.
@@ -562,8 +555,9 @@ pub enum OpPhase {
     UploadProgress,
     /// Every block of the version is on the network; its record publishes next.
     UploadCompleted,
-    /// One upload attempt stopped. The op keeps its place at the head of the
-    /// queue and the next drain tick retries it, so this is not terminal.
+    /// One attempt at sending the version's blocks stopped, classified in
+    /// `error`. Not itself terminal: an [`Event::DeadLetter`] in the same pass
+    /// is what says the op will never publish.
     UploadFailed,
     /// The user cancelled the upload and its staged blocks were released
     /// (`Command::CancelUpload`, #869).
@@ -2273,8 +2267,7 @@ impl<T: SeamTypes> Engine<T> {
     }
 
     /// Best-effort [`Event::OpProgress`] emission for a content read (a dropped
-    /// receiver is fine). A read serves published content, which no queued op
-    /// drives, so it reports neither an op id nor a block count.
+    /// receiver is fine).
     fn emit_op_progress(&self, node: NodeId, phase: OpPhase, error: Option<String>) {
         let _ = self.events.unbounded_send(Event::OpProgress {
             op_id: None,

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -511,21 +511,43 @@ pub enum Event {
         detail: String,
     },
     /// Progress of a content-plane transfer for one node: the driving op (if
-    /// any), the phase reached, and the failure classification on a failed
-    /// phase.
+    /// any), the phase reached, how far the transfer has got, and the failure
+    /// classification on a failed phase.
     OpProgress {
-        /// The queued op driving the transfer, if any.
+        /// The queued op driving the transfer, if any. A read of published
+        /// content is driven by no op; an upload always carries the id
+        /// [`Engine::commit_write`] returned, so a host keys progress per op.
         op_id: Option<OpId>,
         /// The node the transfer is for.
         node: NodeId,
         /// The phase reached.
         phase: OpPhase,
+        /// How far the transfer has got, on the phases that count blocks.
+        progress: Option<BlockProgress>,
         /// Failure classification for a failed phase (no key material).
         error: Option<String>,
     },
 }
 
+/// How far a content transfer has got, in whole blocks of the version's DAG
+/// (its leaves plus the root manifest). Blocks rather than bytes because a
+/// resumed upload's confirmed prefix is no longer on this device to measure,
+/// while the manifest names every block up front — and the leaves are uniform,
+/// so the fraction tracks bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockProgress {
+    /// Blocks confirmed so far, counting a previous pass's durable progress.
+    pub confirmed: u32,
+    /// Blocks the version has in total; never zero.
+    pub total: u32,
+}
+
 /// The phase an [`Event::OpProgress`] reports.
+///
+/// The upload phases are the ones the drain's content path actually reaches.
+/// Two upload outcomes are deliberately *not* phases: an over-quota hold is
+/// [`SnapshotView::blocked`], and a terminal give-up is [`Event::DeadLetter`]
+/// with its reason.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OpPhase {
     /// A content download started.
@@ -534,6 +556,18 @@ pub enum OpPhase {
     DownloadCompleted,
     /// A content download failed.
     DownloadFailed,
+    /// The drain began uploading a queued op's content version.
+    UploadStarted,
+    /// One more of the version's blocks is confirmed on the network.
+    UploadProgress,
+    /// Every block of the version is on the network; its record publishes next.
+    UploadCompleted,
+    /// One upload attempt stopped. The op keeps its place at the head of the
+    /// queue and the next drain tick retries it, so this is not terminal.
+    UploadFailed,
+    /// The user cancelled the upload and its staged blocks were released
+    /// (`Command::CancelUpload`, #869).
+    UploadCancelled,
 }
 
 /// Errors returned by facade calls.
@@ -1549,6 +1583,7 @@ impl<T: SeamTypes> Engine<T> {
                         base: &base,
                         held: &held,
                         blocked: &blocked,
+                        events: &events,
                     }
                     .run(&DrainScope {
                         root: NodeId(root_id),
@@ -2237,12 +2272,15 @@ impl<T: SeamTypes> Engine<T> {
         ))
     }
 
-    /// Best-effort [`Event::OpProgress`] emission (a dropped receiver is fine).
+    /// Best-effort [`Event::OpProgress`] emission for a content read (a dropped
+    /// receiver is fine). A read serves published content, which no queued op
+    /// drives, so it reports neither an op id nor a block count.
     fn emit_op_progress(&self, node: NodeId, phase: OpPhase, error: Option<String>) {
         let _ = self.events.unbounded_send(Event::OpProgress {
             op_id: None,
             node,
             phase,
+            progress: None,
             error,
         });
     }
@@ -4380,6 +4418,7 @@ mod tests {
                     op_id: None,
                     node,
                     phase,
+                    progress: None,
                     error: None,
                 }
             }
@@ -4484,6 +4523,7 @@ mod tests {
                             op_id: None,
                             node,
                             phase: OpPhase::DownloadFailed,
+                            progress: None,
                             error: Some(err.to_string()),
                         },
                     ],

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -58,9 +58,9 @@ pub use content::{
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{
-    Breadcrumb, Command, DeadLetter, Engine, EngineError, EngineView, Event, EventStream,
-    LoginSecret, NodeAttrs, NodeId, NodeKind, OpPhase, OverBudgetCause, Permission, SnapshotChild,
-    SnapshotView, Staleness, StatFs, WriteHandle, WriteTarget,
+    BlockProgress, Breadcrumb, Command, DeadLetter, Engine, EngineError, EngineView, Event,
+    EventStream, LoginSecret, NodeAttrs, NodeId, NodeKind, OpPhase, OverBudgetCause, Permission,
+    SnapshotChild, SnapshotView, Staleness, StatFs, WriteHandle, WriteTarget,
 };
 pub use gate::{
     Adopted, Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason,

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -1338,16 +1338,16 @@ where
         let uploaded = self.upload_mark(&staged.root_cid).await?;
         // The root manifest is block zero and goes up last, so the version's
         // whole block count is its leaves plus one.
-        let total = blocks(content.leaf_cids().len()).saturating_add(1);
-        self.emit_upload(
-            applied,
-            OpPhase::UploadStarted,
-            Some(BlockProgress {
-                confirmed: blocks(uploaded),
-                total,
-            }),
-            None,
-        );
+        let total = blocks(content.leaf_cids().len() + 1);
+        let emit = |phase: OpPhase, confirmed: u32| {
+            self.emit_upload(
+                applied,
+                phase,
+                Some(BlockProgress { confirmed, total }),
+                None,
+            );
+        };
+        emit(OpPhase::UploadStarted, blocks(uploaded));
         for (index, leaf_cid) in content.leaf_cids().iter().enumerate() {
             match self.staged_block(leaf_cid).await? {
                 Some(block) => {
@@ -1357,15 +1357,7 @@ where
                         .await
                         .map_err(seam)?;
                     self.mark_uploaded(&staged.root_cid, index + 1).await?;
-                    self.emit_upload(
-                        applied,
-                        OpPhase::UploadProgress,
-                        Some(BlockProgress {
-                            confirmed: blocks(index + 1),
-                            total,
-                        }),
-                        None,
-                    );
+                    emit(OpPhase::UploadProgress, blocks(index + 1));
                 }
                 // Absent and not covered by the mark: these bytes were never
                 // uploaded and are simply gone.
@@ -1377,15 +1369,7 @@ where
         // is the manifest every retry re-derives the plan from, so releasing it
         // before the record lands would strand a fully-uploaded version.
         self.upload_block(&staged.root_cid, &root_block).await?;
-        self.emit_upload(
-            applied,
-            OpPhase::UploadCompleted,
-            Some(BlockProgress {
-                confirmed: total,
-                total,
-            }),
-            None,
-        );
+        emit(OpPhase::UploadCompleted, total);
 
         let content_cids = registry_cids(&staged.root_cid, content.leaf_cids());
         Ok(UploadedVersion {
@@ -1924,9 +1908,8 @@ fn classify_upload(error: ApiError, refused_bytes: u64) -> Halt {
     }
 }
 
-/// A block count as [`BlockProgress`] carries it. The root manifest's own
-/// ceiling bounds a version's leaves far below `u32::MAX`, so the saturation is
-/// unreachable and never misreports a real transfer.
+/// A block count as [`BlockProgress`] carries it; the root manifest's own
+/// ceiling bounds a version's leaves far below `u32::MAX`.
 fn blocks(count: usize) -> u32 {
     u32::try_from(count).unwrap_or(u32::MAX)
 }

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -29,12 +29,13 @@ use cipherbox_core::kdf;
 use cipherbox_core::seal::{ChildRef, ReadBody, Version, open_content_key, open_read_body};
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
 use cipherbox_core::suite::x25519::X25519Secret;
+use futures_channel::mpsc;
 use zeroize::Zeroizing;
 
 use crate::api::{ApiClient, ApiError, QUOTA_EXCEEDED, UPLOAD_TOO_LARGE};
 use crate::content::{Gateway, SealedContent, pre_flight_quota_check};
 use crate::entropy::Entropy;
-use crate::facade::NodeId;
+use crate::facade::{BlockProgress, Event, NodeId, OpPhase};
 use crate::gate::floor;
 use crate::grants::{UndoDestAdd, undo_dest_add_versioned};
 use crate::net::author::{
@@ -292,6 +293,8 @@ pub(crate) struct Drain<'a, T, H: Http, C: CredentialStore, F, S, St, Sch> {
     /// The over-quota hold, shared with the facade's read surface. It clears
     /// only here, on a quota probe reporting room.
     pub(crate) blocked: &'a RefCell<Option<BlockedOp>>,
+    /// The facade's outbound event stream, for upload progress.
+    pub(crate) events: &'a mpsc::UnboundedSender<Event>,
 }
 
 /// One folder's current published state, carried across the ops of one pass so
@@ -1276,9 +1279,26 @@ where
     // The content plane: staged blocks out, a published version back.
     // -----------------------------------------------------------------------
 
+    /// One version's blocks, uploaded and pinned, with the transfer's progress
+    /// reported on the event stream throughout.
+    async fn upload_version(
+        &self,
+        scope: &DrainScope<'_>,
+        applied: &AppliedOp,
+        staged: &StagedContent,
+    ) -> Result<UploadedVersion, Halt> {
+        let uploaded = self.upload_blocks(scope, applied, staged).await;
+        if let Err(halt) = &uploaded
+            && let Some(error) = upload_failure(*halt)
+        {
+            self.emit_upload(applied, OpPhase::UploadFailed, None, Some(error));
+        }
+        uploaded
+    }
+
     /// One version's blocks, uploaded and pinned: the `Version` its record
     /// carries and every content CID the registration must name.
-    async fn upload_version(
+    async fn upload_blocks(
         &self,
         scope: &DrainScope<'_>,
         applied: &AppliedOp,
@@ -1316,6 +1336,18 @@ where
         // absence is only progress up to the durable mark this pass keeps: past
         // it, a missing block is loss, and the version can never be assembled.
         let uploaded = self.upload_mark(&staged.root_cid).await?;
+        // The root manifest is block zero and goes up last, so the version's
+        // whole block count is its leaves plus one.
+        let total = blocks(content.leaf_cids().len()).saturating_add(1);
+        self.emit_upload(
+            applied,
+            OpPhase::UploadStarted,
+            Some(BlockProgress {
+                confirmed: blocks(uploaded),
+                total,
+            }),
+            None,
+        );
         for (index, leaf_cid) in content.leaf_cids().iter().enumerate() {
             match self.staged_block(leaf_cid).await? {
                 Some(block) => {
@@ -1325,6 +1357,15 @@ where
                         .await
                         .map_err(seam)?;
                     self.mark_uploaded(&staged.root_cid, index + 1).await?;
+                    self.emit_upload(
+                        applied,
+                        OpPhase::UploadProgress,
+                        Some(BlockProgress {
+                            confirmed: blocks(index + 1),
+                            total,
+                        }),
+                        None,
+                    );
                 }
                 // Absent and not covered by the mark: these bytes were never
                 // uploaded and are simply gone.
@@ -1336,12 +1377,39 @@ where
         // is the manifest every retry re-derives the plan from, so releasing it
         // before the record lands would strand a fully-uploaded version.
         self.upload_block(&staged.root_cid, &root_block).await?;
+        self.emit_upload(
+            applied,
+            OpPhase::UploadCompleted,
+            Some(BlockProgress {
+                confirmed: total,
+                total,
+            }),
+            None,
+        );
 
         let content_cids = registry_cids(&staged.root_cid, content.leaf_cids());
         Ok(UploadedVersion {
             version: content.version(*key, applied.op.authored_at.0),
             content_cids,
         })
+    }
+
+    /// Best-effort upload progress for the op driving this transfer (a dropped
+    /// receiver is fine).
+    fn emit_upload(
+        &self,
+        applied: &AppliedOp,
+        phase: OpPhase,
+        progress: Option<BlockProgress>,
+        error: Option<&str>,
+    ) {
+        let _ = self.events.unbounded_send(Event::OpProgress {
+            op_id: Some(applied.op_id),
+            node: applied.op.target,
+            phase,
+            progress,
+            error: error.map(str::to_owned),
+        });
     }
 
     /// How many of this version's leaves a previous pass durably confirmed. A
@@ -1853,6 +1921,32 @@ fn classify_upload(error: ApiError, refused_bytes: u64) -> Halt {
         },
         Some(UPLOAD_TOO_LARGE) => Halt::Permanent(DeadLetterReason::PayloadRefused),
         _ => Halt::UploadAttempt,
+    }
+}
+
+/// A block count as [`BlockProgress`] carries it. The root manifest's own
+/// ceiling bounds a version's leaves far below `u32::MAX`, so the saturation is
+/// unreachable and never misreports a real transfer.
+fn blocks(count: usize) -> u32 {
+    u32::try_from(count).unwrap_or(u32::MAX)
+}
+
+/// The key-free classification an [`OpPhase::UploadFailed`] carries, or `None`
+/// where the halt is not a failed attempt: an over-quota hold keeps the op and
+/// its reservation, and the host reads it from `SnapshotView::blocked` (#841).
+fn upload_failure(halt: Halt) -> Option<&'static str> {
+    match halt {
+        Halt::Blocked { .. } => None,
+        Halt::Unclassified => Some("the upload did not complete"),
+        // Both charge the attempt budget; which one it is decides only what
+        // exhausting that budget retires, not what the host is told.
+        Halt::Attempt | Halt::UploadAttempt => {
+            Some("the upload was refused without a classification")
+        }
+        Halt::Permanent(DeadLetterReason::PayloadRefused) => {
+            Some("the network refused the payload")
+        }
+        Halt::Permanent(_) => Some("the staged version can never publish"),
     }
 }
 

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -1182,31 +1182,88 @@ fn an_upload_reports_its_phases_and_block_counts_keyed_on_its_op_id() {
     let file = child_id(&engine, ROOT, "photo.bin");
 
     let reported = upload_progress(&mut events, op_id, file);
-    let (phases, counts): (Vec<OpPhase>, Vec<Option<BlockProgress>>) = reported.into_iter().unzip();
-    let total = counts[0].expect("the opening phase counts blocks").total;
+    let total = reported[0]
+        .1
+        .expect("the opening phase counts blocks")
+        .total;
     assert!(
         total > 2,
         "a multi-leaf version, not a degenerate single-block one"
     );
-    let mut expected = vec![OpPhase::UploadStarted];
-    expected.extend(std::iter::repeat_n(
-        OpPhase::UploadProgress,
-        total as usize - 1,
-    ));
-    expected.push(OpPhase::UploadCompleted);
+    let expected: Vec<(OpPhase, u32)> = core::iter::once((OpPhase::UploadStarted, 0))
+        .chain((1..total).map(|confirmed| (OpPhase::UploadProgress, confirmed)))
+        .chain(core::iter::once((OpPhase::UploadCompleted, total)))
+        .collect();
     assert_eq!(
-        phases, expected,
-        "started, one report per confirmed leaf, then completed"
-    );
-    assert_eq!(
-        counts
+        reported
             .into_iter()
-            .map(|count| count.expect("every upload phase counts blocks").confirmed)
+            .map(|(phase, count)| (
+                phase,
+                count.expect("every upload phase counts blocks").confirmed
+            ))
             .collect::<Vec<_>>(),
-        (0..total)
-            .chain(core::iter::once(total))
+        expected,
+        "started, then one report per confirmed leaf, landing on the whole version"
+    );
+}
+
+/// A pass that stopped partway resumes from its durable mark: the opening
+/// report carries the leaves an earlier pass confirmed, and the counts pick up
+/// from there rather than replaying a leaf already on the network.
+#[test]
+fn a_resumed_upload_opens_on_the_leaves_an_earlier_pass_confirmed() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    // Two leaves land, then the pin store goes away: the pass halts holding a
+    // durable mark it must not lose.
+    let mut sent = 0;
+    blocks.refuse_upload(Box::new(move |_| {
+        sent += 1;
+        (sent > 2).then(unreachable_upload)
+    }));
+    let op_id = write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<_>>(),
+    )
+    .expect("the write commits");
+    tick(&world, &engine, &mut tasks);
+    let file = child_id(&engine, ROOT, "photo.bin");
+    let first = upload_progress(&mut events, op_id, file);
+    let total = first[0].1.expect("the opening phase counts blocks").total;
+
+    blocks.accept_uploads();
+    tick(&world, &engine, &mut tasks);
+
+    let resumed = upload_progress(&mut events, op_id, file);
+    let (phase, opening) = resumed[0];
+    let confirmed = opening.expect("the opening phase counts blocks").confirmed;
+    assert_eq!(phase, OpPhase::UploadStarted);
+    assert!(
+        confirmed > 0 && confirmed < total,
+        "the resumed pass opens on real prior progress, not on zero"
+    );
+    let expected: Vec<(OpPhase, u32)> = core::iter::once((OpPhase::UploadStarted, confirmed))
+        .chain((confirmed + 1..total).map(|count| (OpPhase::UploadProgress, count)))
+        .chain(core::iter::once((OpPhase::UploadCompleted, total)))
+        .collect();
+    assert_eq!(
+        resumed
+            .into_iter()
+            .map(|(phase, count)| (
+                phase,
+                count.expect("every upload phase counts blocks").confirmed
+            ))
             .collect::<Vec<_>>(),
-        "the count climbs one leaf at a time and lands on the whole version"
+        expected,
+        "the resumed counts continue upward and never re-report a confirmed leaf"
     );
 }
 
@@ -1256,6 +1313,50 @@ fn a_halted_upload_attempt_is_reported_and_leaves_the_op_queued() {
         block_on(alice.staging_store.queued_ops()).unwrap().len(),
         1,
         "the op keeps its place and its staged bytes"
+    );
+}
+
+/// A permanently refused upload reports the stopped attempt *and* the dead
+/// letter that settles it. The pair is the contract: the phase says the transfer
+/// stopped, the dead letter says the op will never publish.
+#[test]
+fn a_permanently_refused_upload_reports_the_attempt_and_the_dead_letter() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    blocks.refuse_upload(Box::new(|_| Some(upload_413(Some("UPLOAD_TOO_LARGE")))));
+    let op_id = write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<_>>(),
+    )
+    .expect("the write commits");
+    tick(&world, &engine, &mut tasks);
+
+    let emitted = events_so_far(&mut events);
+    assert!(
+        emitted.iter().any(|event| matches!(
+            event,
+            Event::OpProgress {
+                op_id: Some(id),
+                phase: OpPhase::UploadFailed,
+                ..
+            } if *id == op_id
+        )),
+        "the stopped transfer reaches the host"
+    );
+    assert!(
+        emitted.contains(&Event::DeadLetter {
+            op_id,
+            reason: DeadLetterReason::PayloadRefused,
+        }),
+        "and the dead letter says it will never publish"
     );
 }
 

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -1270,50 +1270,56 @@ fn a_resumed_upload_opens_on_the_leaves_an_earlier_pass_confirmed() {
 /// A halted upload attempt is reported, but it is not terminal: the op keeps its
 /// place at the head of the queue and the next tick retries it. Terminal failure
 /// is the dead letter, with its reason.
+///
+/// Both shapes a stopped attempt takes are covered: a transport that never
+/// answered, and an unattributable 413 that is charged against the budget but
+/// abandons nothing on one response (#916).
 #[test]
 fn a_halted_upload_attempt_is_reported_and_leaves_the_op_queued() {
-    let world = FakeWorld::new();
-    let blocks = Blocks::default();
-    seed_account(&world, &blocks);
+    for refusal in [unreachable_upload(), proxy_413()] {
+        let world = FakeWorld::new();
+        let blocks = Blocks::default();
+        seed_account(&world, &blocks);
 
-    let alice = world.device(b"alice");
-    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
-    blocks.refuse_upload(Box::new(|_| Some(unreachable_upload())));
-    let op_id = write_file(
-        &mut engine,
-        WriteTarget::NewFile {
-            parent: ROOT,
-            name: "photo.bin".into(),
-        },
-        &(0..200u8).collect::<Vec<_>>(),
-    )
-    .expect("the write commits");
-    tick(&world, &engine, &mut tasks);
+        let alice = world.device(b"alice");
+        let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+        blocks.refuse_upload(Box::new(move |_| Some(refusal.clone())));
+        let op_id = write_file(
+            &mut engine,
+            WriteTarget::NewFile {
+                parent: ROOT,
+                name: "photo.bin".into(),
+            },
+            &(0..200u8).collect::<Vec<_>>(),
+        )
+        .expect("the write commits");
+        tick(&world, &engine, &mut tasks);
 
-    let emitted = events_so_far(&mut events);
-    assert!(
-        emitted.iter().any(|event| matches!(
-            event,
-            Event::OpProgress {
-                op_id: Some(id),
-                phase: OpPhase::UploadFailed,
-                error: Some(_),
-                ..
-            } if *id == op_id
-        )),
-        "the halted attempt reaches the host with a classification"
-    );
-    assert!(
-        !emitted
-            .iter()
-            .any(|event| matches!(event, Event::DeadLetter { .. })),
-        "an unreachable upload is availability, never a terminal failure"
-    );
-    assert_eq!(
-        block_on(alice.staging_store.queued_ops()).unwrap().len(),
-        1,
-        "the op keeps its place and its staged bytes"
-    );
+        let emitted = events_so_far(&mut events);
+        assert!(
+            emitted.iter().any(|event| matches!(
+                event,
+                Event::OpProgress {
+                    op_id: Some(id),
+                    phase: OpPhase::UploadFailed,
+                    error: Some(_),
+                    ..
+                } if *id == op_id
+            )),
+            "the halted attempt reaches the host with a classification"
+        );
+        assert!(
+            !emitted
+                .iter()
+                .any(|event| matches!(event, Event::DeadLetter { .. })),
+            "one stopped attempt is availability, never a terminal failure"
+        );
+        assert_eq!(
+            block_on(alice.staging_store.queued_ops()).unwrap().len(),
+            1,
+            "the op keeps its place and its staged bytes"
+        );
+    }
 }
 
 /// A permanently refused upload reports the stopped attempt *and* the dead

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -38,9 +38,9 @@ use cipherbox_engine::testkit::{
     OwnerRootSpec, SeededEntropy, block_on, frame_version as frame, owner_root_fixture,
 };
 use cipherbox_engine::{
-    Command, ContentProfile, DeadLetter, DeadLetterReason, Engine, EngineError, Event, EventStream,
-    GatewayConfig, LoginSecret, NodeId, NodeKind, Op, RecordSeal, StoragePolicy, SyncTimingProfile,
-    WriteTarget, stage_op,
+    BlockProgress, Command, ContentProfile, DeadLetter, DeadLetterReason, Engine, EngineError,
+    Event, EventStream, GatewayConfig, LoginSecret, NodeId, NodeKind, Op, OpPhase, RecordSeal,
+    StoragePolicy, SyncTimingProfile, WriteTarget, stage_op,
 };
 
 const SECRET: [u8; 32] = [7u8; 32];
@@ -1128,6 +1128,191 @@ fn assert_no_blocks_staged(device: &FakeDevice, version: &[Vec<u8>]) {
             "an abandoned version holds no staging budget"
         );
     }
+}
+
+/// Every upload progress event of one op, in emission order.
+fn upload_progress(
+    events: &mut EventStream,
+    op_id: OpId,
+    node: NodeId,
+) -> Vec<(OpPhase, Option<BlockProgress>)> {
+    events_so_far(events)
+        .into_iter()
+        .filter_map(|event| match event {
+            Event::OpProgress {
+                op_id: id,
+                node: target,
+                phase,
+                progress,
+                ..
+            } => {
+                assert_eq!(id, Some(op_id), "progress is keyed on the driving op");
+                assert_eq!(target, node, "progress names the node being written");
+                Some((phase, progress))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// The upload half of the progress surface: a host that committed a write is
+/// told when its blocks start, how many of them are confirmed, and when the
+/// whole version is on the network — all keyed on the op id `commitWrite`
+/// returned, so per-file progress needs no node-to-upload guesswork.
+#[test]
+fn an_upload_reports_its_phases_and_block_counts_keyed_on_its_op_id() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    // Multi-leaf at the CI framing, so there is real progress to count.
+    let plaintext: Vec<u8> = (0..200u8).collect();
+    let op_id = write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &plaintext,
+    )
+    .expect("the write commits");
+    tick(&world, &engine, &mut tasks);
+    let file = child_id(&engine, ROOT, "photo.bin");
+
+    let reported = upload_progress(&mut events, op_id, file);
+    let (phases, counts): (Vec<OpPhase>, Vec<Option<BlockProgress>>) = reported.into_iter().unzip();
+    let total = counts[0].expect("the opening phase counts blocks").total;
+    assert!(
+        total > 2,
+        "a multi-leaf version, not a degenerate single-block one"
+    );
+    let mut expected = vec![OpPhase::UploadStarted];
+    expected.extend(std::iter::repeat_n(
+        OpPhase::UploadProgress,
+        total as usize - 1,
+    ));
+    expected.push(OpPhase::UploadCompleted);
+    assert_eq!(
+        phases, expected,
+        "started, one report per confirmed leaf, then completed"
+    );
+    assert_eq!(
+        counts
+            .into_iter()
+            .map(|count| count.expect("every upload phase counts blocks").confirmed)
+            .collect::<Vec<_>>(),
+        (0..total)
+            .chain(core::iter::once(total))
+            .collect::<Vec<_>>(),
+        "the count climbs one leaf at a time and lands on the whole version"
+    );
+}
+
+/// A halted upload attempt is reported, but it is not terminal: the op keeps its
+/// place at the head of the queue and the next tick retries it. Terminal failure
+/// is the dead letter, with its reason.
+#[test]
+fn a_halted_upload_attempt_is_reported_and_leaves_the_op_queued() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    blocks.refuse_upload(Box::new(|_| Some(unreachable_upload())));
+    let op_id = write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<_>>(),
+    )
+    .expect("the write commits");
+    tick(&world, &engine, &mut tasks);
+
+    let emitted = events_so_far(&mut events);
+    assert!(
+        emitted.iter().any(|event| matches!(
+            event,
+            Event::OpProgress {
+                op_id: Some(id),
+                phase: OpPhase::UploadFailed,
+                error: Some(_),
+                ..
+            } if *id == op_id
+        )),
+        "the halted attempt reaches the host with a classification"
+    );
+    assert!(
+        !emitted
+            .iter()
+            .any(|event| matches!(event, Event::DeadLetter { .. })),
+        "an unreachable upload is availability, never a terminal failure"
+    );
+    assert_eq!(
+        block_on(alice.staging_store.queued_ops()).unwrap().len(),
+        1,
+        "the op keeps its place and its staged bytes"
+    );
+}
+
+/// An over-quota refusal is a hold, not a failed attempt: the op and its
+/// reservation stand until a probe finds room (#841), and the host reads it from
+/// the snapshot rather than from a failure it cannot act on.
+#[test]
+fn an_over_quota_upload_holds_the_op_without_reporting_a_failure() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    blocks.refuse_upload(Box::new(|_| Some(upload_413(Some("QUOTA_EXCEEDED")))));
+    blocks.set_quota(1_000, 1_000);
+    let op_id = write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<_>>(),
+    )
+    .expect("the write commits");
+    tick(&world, &engine, &mut tasks);
+
+    let emitted = events_so_far(&mut events);
+    assert!(
+        emitted.iter().any(|event| matches!(
+            event,
+            Event::OpProgress {
+                phase: OpPhase::UploadStarted,
+                ..
+            }
+        )),
+        "the transfer did start"
+    );
+    assert!(
+        !emitted.iter().any(|event| matches!(
+            event,
+            Event::OpProgress {
+                phase: OpPhase::UploadFailed,
+                ..
+            }
+        )),
+        "a full account is not a failed upload attempt"
+    );
+    assert_eq!(
+        block_on(engine.snapshot(ROOT))
+            .expect("a snapshot")
+            .blocked
+            .expect("the over-quota head is held")
+            .op_id,
+        op_id,
+        "the hold is what the host acts on"
+    );
 }
 
 /// An op the completion record already covers is restore residue: a data dir

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -222,6 +222,16 @@ pub enum OpPhase {
     DownloadCompleted,
     /// A content download failed.
     DownloadFailed,
+    /// The drain began uploading a queued op's content version.
+    UploadStarted,
+    /// One more of the version's blocks is confirmed on the network.
+    UploadProgress,
+    /// Every block of the version is on the network.
+    UploadCompleted,
+    /// One upload attempt stopped; the op retries on the next drain tick.
+    UploadFailed,
+    /// The user cancelled the upload.
+    UploadCancelled,
 }
 
 impl From<facade::OpPhase> for OpPhase {
@@ -230,6 +240,11 @@ impl From<facade::OpPhase> for OpPhase {
             facade::OpPhase::DownloadStarted => OpPhase::DownloadStarted,
             facade::OpPhase::DownloadCompleted => OpPhase::DownloadCompleted,
             facade::OpPhase::DownloadFailed => OpPhase::DownloadFailed,
+            facade::OpPhase::UploadStarted => OpPhase::UploadStarted,
+            facade::OpPhase::UploadProgress => OpPhase::UploadProgress,
+            facade::OpPhase::UploadCompleted => OpPhase::UploadCompleted,
+            facade::OpPhase::UploadFailed => OpPhase::UploadFailed,
+            facade::OpPhase::UploadCancelled => OpPhase::UploadCancelled,
         }
     }
 }
@@ -709,6 +724,26 @@ impl Event {
         }
     }
 
+    /// `opProgress`: blocks of the version confirmed so far, on the phases that
+    /// count them; otherwise `undefined`.
+    #[wasm_bindgen(getter, js_name = blocksConfirmed)]
+    pub fn blocks_confirmed(&self) -> Option<u32> {
+        match self.inner {
+            facade::Event::OpProgress { progress, .. } => progress.map(|p| p.confirmed),
+            _ => None,
+        }
+    }
+
+    /// `opProgress`: the version's whole block count, on the phases that count
+    /// them; otherwise `undefined`.
+    #[wasm_bindgen(getter, js_name = blocksTotal)]
+    pub fn blocks_total(&self) -> Option<u32> {
+        match self.inner {
+            facade::Event::OpProgress { progress, .. } => progress.map(|p| p.total),
+            _ => None,
+        }
+    }
+
     /// `opProgress`: the key-free failure classification for a failed phase;
     /// otherwise `undefined`.
     #[wasm_bindgen(getter)]
@@ -848,6 +883,7 @@ mod tests {
             op_id: None,
             node: facade::NodeId([0u8; 16]),
             phase: facade::OpPhase::DownloadStarted,
+            progress: None,
             error: None,
         });
         assert_eq!(progress.kind(), "opProgress");
@@ -859,17 +895,35 @@ mod tests {
             op_id: Some(OpId(7)),
             node: facade::NodeId([3u8; 16]),
             phase: facade::OpPhase::DownloadFailed,
+            progress: None,
             error: Some("unavailable".into()),
         });
         assert_eq!(progress.op_id(), Some(7));
         assert_eq!(progress.node(), Some(vec![3u8; 16]));
         assert_eq!(progress.phase(), Some(OpPhase::DownloadFailed));
         assert_eq!(progress.error(), Some("unavailable".into()));
+        assert!(progress.blocks_confirmed().is_none());
+
+        let upload = Event::from_facade(facade::Event::OpProgress {
+            op_id: Some(OpId(9)),
+            node: facade::NodeId([4u8; 16]),
+            phase: facade::OpPhase::UploadProgress,
+            progress: Some(facade::BlockProgress {
+                confirmed: 3,
+                total: 8,
+            }),
+            error: None,
+        });
+        assert_eq!(upload.op_id(), Some(9));
+        assert_eq!(upload.phase(), Some(OpPhase::UploadProgress));
+        assert_eq!(upload.blocks_confirmed(), Some(3));
+        assert_eq!(upload.blocks_total(), Some(8));
 
         let op_less = Event::from_facade(facade::Event::OpProgress {
             op_id: None,
             node: facade::NodeId([0u8; 16]),
             phase: facade::OpPhase::DownloadStarted,
+            progress: None,
             error: None,
         });
         assert!(op_less.op_id().is_none());

--- a/crates/wasm/tests/boundary.rs
+++ b/crates/wasm/tests/boundary.rs
@@ -124,6 +124,7 @@ fn op_progress_getters_cross_and_stay_undefined_off_variant() {
         op_id: Some(OpId(u64::MAX)),
         node: facade::NodeId([5u8; 16]),
         phase: facade::OpPhase::DownloadFailed,
+        progress: None,
         error: Some("unavailable".into()),
     });
     assert_eq!(progress.kind(), "opProgress");
@@ -141,10 +142,13 @@ fn op_progress_getters_cross_and_stay_undefined_off_variant() {
         op_id: None,
         node: facade::NodeId([0u8; 16]),
         phase: facade::OpPhase::DownloadStarted,
+        progress: None,
         error: None,
     });
     assert!(op_less.op_id().is_none());
     assert!(op_less.error().is_none());
+    assert!(op_less.blocks_confirmed().is_none());
+    assert!(op_less.blocks_total().is_none());
     let js: JsValue = op_less.into();
     assert!(
         Reflect::get(&js, &JsValue::from_str("opId"))
@@ -158,7 +162,14 @@ fn op_progress_getters_cross_and_stay_undefined_off_variant() {
     );
 
     let other: JsValue = Event::from_facade(facade::Event::SnapshotUpdated).into();
-    for key in ["node", "phase", "error", "opId"] {
+    for key in [
+        "node",
+        "phase",
+        "error",
+        "opId",
+        "blocksConfirmed",
+        "blocksTotal",
+    ] {
         assert!(
             Reflect::get(&other, &JsValue::from_str(key))
                 .expect("getter is readable")
@@ -166,6 +177,41 @@ fn op_progress_getters_cross_and_stay_undefined_off_variant() {
             "{key} must be undefined off-variant"
         );
     }
+}
+
+/// An upload's progress crosses with its op id and its block counters: the id
+/// as `bigint` (it is a `u64`), the counters as plain JS `number`s a host can do
+/// progress arithmetic on without widening.
+#[wasm_bindgen_test]
+fn upload_progress_crosses_with_its_op_id_and_block_counters() {
+    let event = Event::from_facade(facade::Event::OpProgress {
+        op_id: Some(OpId(7)),
+        node: facade::NodeId([3u8; 16]),
+        phase: facade::OpPhase::UploadProgress,
+        progress: Some(facade::BlockProgress {
+            confirmed: 2,
+            total: 5,
+        }),
+        error: None,
+    });
+    assert_eq!(event.phase(), Some(OpPhase::UploadProgress));
+    assert_eq!(event.blocks_confirmed(), Some(2));
+    assert_eq!(event.blocks_total(), Some(5));
+
+    let js: JsValue = event.into();
+    let confirmed = Reflect::get(&js, &JsValue::from_str("blocksConfirmed"))
+        .expect("blocksConfirmed getter is readable");
+    assert_eq!(confirmed.js_typeof(), JsValue::from_str("number"));
+    assert_eq!(confirmed.as_f64(), Some(2.0));
+    let total = Reflect::get(&js, &JsValue::from_str("blocksTotal"))
+        .expect("blocksTotal getter is readable");
+    assert_eq!(total.as_f64(), Some(5.0));
+    assert_eq!(
+        Reflect::get(&js, &JsValue::from_str("opId"))
+            .expect("opId getter is readable")
+            .js_typeof(),
+        JsValue::from_str("bigint")
+    );
 }
 
 /// The snapshot read surface crosses with boundary-correct JS shapes: node ids

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -27,7 +27,16 @@ export const fakeWasmEnums = {
   PendingClass: { None: 0, Metadata: 1, Content: 2 },
   Permission: { Read: 0, Write: 1 },
   Staleness: { Fresh: 0, Reconciling: 1, Stale: 2, Offline: 3 },
-  OpPhase: { DownloadStarted: 0, DownloadCompleted: 1, DownloadFailed: 2 },
+  OpPhase: {
+    DownloadStarted: 0,
+    DownloadCompleted: 1,
+    DownloadFailed: 2,
+    UploadStarted: 3,
+    UploadProgress: 4,
+    UploadCompleted: 5,
+    UploadFailed: 6,
+    UploadCancelled: 7,
+  },
   DeadLetterReason: {
     TargetGone: 0,
     DestinationGone: 1,

--- a/packages/client/src/transport.test.ts
+++ b/packages/client/src/transport.test.ts
@@ -213,6 +213,8 @@ describe('LocalTransport', () => {
         opId: null,
         node: new Uint8Array(16),
         phase: 'downloadStarted',
+        blocksConfirmed: null,
+        blocksTotal: null,
         error: null,
       },
     ];

--- a/packages/client/src/worker/commandCodec.test.ts
+++ b/packages/client/src/worker/commandCodec.test.ts
@@ -67,6 +67,8 @@ describe('readEvent', () => {
       opId: 7n,
       node,
       phase: 'downloadFailed',
+      blocksConfirmed: null,
+      blocksTotal: null,
       error: 'unavailable',
     });
   });
@@ -78,6 +80,29 @@ describe('readEvent', () => {
       opId: null,
       node: new Uint8Array(16),
       phase: 'downloadStarted',
+      blocksConfirmed: null,
+      blocksTotal: null,
+      error: null,
+    });
+  });
+
+  it('carries an upload phase and its block counters through to the descriptor', () => {
+    const node = new Uint8Array(16).fill(4);
+    const event: WasmEvent = {
+      kind: 'opProgress',
+      opId: 9n,
+      node,
+      phase: fakeWasm.OpPhase.UploadProgress,
+      blocksConfirmed: 3,
+      blocksTotal: 8,
+    };
+    expect(readEvent(fakeWasm, event)).toEqual({
+      kind: 'opProgress',
+      opId: 9n,
+      node,
+      phase: 'uploadProgress',
+      blocksConfirmed: 3,
+      blocksTotal: 8,
       error: null,
     });
   });

--- a/packages/client/src/worker/commandCodec.ts
+++ b/packages/client/src/worker/commandCodec.ts
@@ -119,6 +119,16 @@ function opPhase(wasm: EngineWasm, phase: number | undefined): OpProgressPhase {
       return 'downloadCompleted';
     case wasm.OpPhase.DownloadFailed:
       return 'downloadFailed';
+    case wasm.OpPhase.UploadStarted:
+      return 'uploadStarted';
+    case wasm.OpPhase.UploadProgress:
+      return 'uploadProgress';
+    case wasm.OpPhase.UploadCompleted:
+      return 'uploadCompleted';
+    case wasm.OpPhase.UploadFailed:
+      return 'uploadFailed';
+    case wasm.OpPhase.UploadCancelled:
+      return 'uploadCancelled';
     default:
       // Fail closed: an unmapped value means a JS/WASM version mismatch, not a
       // safe-to-ignore state (the event pump turns this throw into a fatal).
@@ -217,6 +227,8 @@ export function readEvent(wasm: EngineWasm, event: WasmEvent): EventDescriptor {
         opId: event.opId ?? null,
         node: event.node ?? new Uint8Array(),
         phase: opPhase(wasm, event.phase),
+        blocksConfirmed: event.blocksConfirmed ?? null,
+        blocksTotal: event.blocksTotal ?? null,
         error: event.error ?? null,
       };
     default:

--- a/packages/client/src/worker/engineWasm.ts
+++ b/packages/client/src/worker/engineWasm.ts
@@ -26,6 +26,8 @@ export interface WasmEvent {
   readonly description?: string;
   readonly node?: Uint8Array;
   readonly phase?: number;
+  readonly blocksConfirmed?: number;
+  readonly blocksTotal?: number;
   readonly error?: string;
   readonly routingKey?: string;
   readonly detail?: string;
@@ -138,6 +140,11 @@ export interface EngineWasm {
     readonly DownloadStarted: number;
     readonly DownloadCompleted: number;
     readonly DownloadFailed: number;
+    readonly UploadStarted: number;
+    readonly UploadProgress: number;
+    readonly UploadCompleted: number;
+    readonly UploadFailed: number;
+    readonly UploadCancelled: number;
   };
   Staleness: {
     readonly Fresh: number;

--- a/packages/client/src/worker/protocol.ts
+++ b/packages/client/src/worker/protocol.ts
@@ -27,7 +27,15 @@ export type NodeKind = 'file' | 'folder';
 export type Staleness = 'fresh' | 'reconciling' | 'stale' | 'offline';
 
 /** The phase an `opProgress` event reports (mirrors the facade `OpPhase`). */
-export type OpProgressPhase = 'downloadStarted' | 'downloadCompleted' | 'downloadFailed';
+export type OpProgressPhase =
+  | 'downloadStarted'
+  | 'downloadCompleted'
+  | 'downloadFailed'
+  | 'uploadStarted'
+  | 'uploadProgress'
+  | 'uploadCompleted'
+  | 'uploadFailed'
+  | 'uploadCancelled';
 
 /** One ancestor step in a snapshot's breadcrumb trail, as data. */
 export interface BreadcrumbDescriptor {
@@ -148,6 +156,12 @@ export type EventDescriptor =
       opId: bigint | null;
       node: Uint8Array;
       phase: OpProgressPhase;
+      /**
+       * Blocks of the version confirmed so far and its whole block count, on
+       * the phases that count them; `null` on the phases that do not.
+       */
+      blocksConfirmed: number | null;
+      blocksTotal: number | null;
       error: string | null;
     };
 

--- a/packages/client/src/worker/protocol.ts
+++ b/packages/client/src/worker/protocol.ts
@@ -26,7 +26,11 @@ export type NodeKind = 'file' | 'folder';
 /** The staleness ladder (mirrors the facade `Staleness`). */
 export type Staleness = 'fresh' | 'reconciling' | 'stale' | 'offline';
 
-/** The phase an `opProgress` event reports (mirrors the facade `OpPhase`). */
+/**
+ * The phase an `opProgress` event reports (mirrors the facade `OpPhase`).
+ * `uploadCompleted` means the version's blocks are on the network, not that its
+ * record published — the op leaves the pending-op overlay when it does.
+ */
 export type OpProgressPhase =
   | 'downloadStarted'
   | 'downloadCompleted'
@@ -158,7 +162,7 @@ export type EventDescriptor =
       phase: OpProgressPhase;
       /**
        * Blocks of the version confirmed so far and its whole block count, on
-       * the phases that count them; `null` on the phases that do not.
+       * the phases that count them.
        */
       blocksConfirmed: number | null;
       blocksTotal: number | null;

--- a/packages/client/src/worker/serve.test.ts
+++ b/packages/client/src/worker/serve.test.ts
@@ -345,6 +345,8 @@ describe('serveEngine event pump over the real EngineHost', () => {
         opId: 5n,
         node: new Uint8Array(16).fill(7),
         phase: 'downloadCompleted',
+        blocksConfirmed: null,
+        blocksTotal: null,
         error: null,
       },
       { kind: 'snapshotUpdated' },


### PR DESCRIPTION
`OpPhase` was download-only and `emit_op_progress` hardcoded `op_id: None`, so nothing on the write plane could report progress and no event could be attributed to a queued op. This adds the upload half and binds it to the op that drives it.

## The phase set, settled

#813's fog note left "started, per-block progress, published" to follow the drain driver, and #824 fixed the terminal cancel phase. This slice settles the whole set against what the drain's content path actually reaches:

| Phase | Emitted when |
| --- | --- |
| `UploadStarted` | the drain begins sending a version's blocks, carrying a resumed pass's durable progress |
| `UploadProgress` | one more leaf is confirmed and the durable upload mark advanced |
| `UploadCompleted` | the root manifest went up last; the whole version is on the network |
| `UploadFailed` | one attempt at sending the blocks stopped — **not terminal**, the op keeps its place and the next tick retries |
| `UploadCancelled` | reserved for #869's `CancelUpload`; defined here so that slice does not have to reshape the surface |

Two upload outcomes are deliberately **not** phases, because each already has a better surface:

- an **over-quota hold** is `SnapshotView.blocked` with `neededBytes` (#841) — the op and its staging reservation stand, so reporting it as a failed attempt would tell a host to act on something it cannot act on. `Halt::Blocked` is carved out explicitly and a test pins it.
- a **terminal give-up** is `Event::DeadLetter` with its structured `DeadLetterReason` (#859), which is strictly richer than a phase.

`Upload*` scopes to the **content transfer**, not to the op's whole life. A publish/CAS halt after the blocks land is a record-plane failure: the op stays in the pending-op overlay until it publishes or dead-letters, which is what a host renders it from.

## Progress payload

`Event::OpProgress` gains `progress: Option<BlockProgress>` — `{ confirmed, total }` in whole blocks of the version's DAG (its leaves plus the root manifest). Blocks rather than bytes because a resumed upload's confirmed prefix has already left staging and cannot be measured, while the manifest names every block up front. The leaves are uniform, so the fraction tracks bytes closely enough for a progress bar, and the file's own size is already on the snapshot.

## `op_id`

Every upload emission carries `Some(op_id)` — the id `commitWrite` returned — so a host keys progress per op rather than per node. The content-read path still reports `None`: a read serves published content, which no queued op drives.

## Out of scope, deliberately

- No cancel: #869 owns `Command::CancelUpload`, the block-boundary yield, and emitting `UploadCancelled`.
- No download-side block counters. Nothing consumes them and the read path fetches under a different loop; the field is `Option`, so adding them later is additive.
- No throttling of `UploadProgress`. One event per confirmed block is one per MiB at `ContentProfile::PRODUCTION`, against a network PUT per block.

## Tests

`Engine Tests` (`crates/engine/tests/write_plane.rs`):

- an upload reports started, then per-leaf progress, then completed — every event keyed on its op id and its target node, with the count climbing one leaf at a time and landing on the whole version.
- a pass that stopped partway resumes on its durable mark: the second pass opens on a non-zero count and continues upward without re-reporting a confirmed leaf.
- a halted attempt reports `UploadFailed` with a classification, emits no dead letter, and leaves the op queued.
- a permanently refused upload reports `UploadFailed` **and** the `DeadLetter` that settles it — the pair is the contract, since the phase alone never says the op is finished.
- an over-quota refusal starts the transfer, reports **no** `UploadFailed`, and lands on `SnapshotView.blocked`.

`Client Browser Suite` (`crates/wasm/tests/boundary.rs`): an upload's op id crosses as `bigint` and the block counters as plain JS `number`s; both are `undefined` off-variant.

Client unit (`packages/client`): the codec maps the five new phases and carries the counters into the descriptor; the fail-closed throw on an unmapped phase value still stands.

## Verification

- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo check --workspace --all-targets` clean
- `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets` clean
- `cargo test --workspace` green
- `packages/client`: `typecheck`, `vitest run`, eslint, prettier all clean

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` all ran on this diff.

- **Security: no findings.** Every emission sits strictly after the durable step it reports, no `?` early return was reordered or swallowed, and the `error` strings are static literals — no CID, key, seed, or plaintext can reach an event. Rule 8 does not apply: nothing here is a wire format.
- **Crypto/privacy: no crypto, key-handling, zeroization or fail-closed defect.** `total` is the plaintext size bucketed to 1 MiB, strictly coarser than the exact `size` the host already declared at `beginWrite` and already carries on the snapshot, so the counters expose nothing new — and nothing reaches the network.
- Folded back: the `UploadFailed` doc no longer over-promises a retry (a permanent halt emits it too, then dead-letters), plus the two extra tests and the `uploadCompleted` durability caveat on the TS union.
- **Kept against review advice:** `UploadCancelled` stays, defined but unemitted. Settling the whole phase set is this slice's job — #869 lands the producer, and having the variant already mirrored through wasm and the TS codec is precisely what stops that slice from reshaping four layers.

Filed #924 out of the crypto gate: a pre-existing crash window in the same loop (`remove → mark`, untouched by this PR) can turn a successful upload into `CONTENT_LOST` and discard the user's write. Reciprocal link added to #869.

Closes #896
Part of #655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added upload lifecycle progress events for start, block-by-block progress, completion, failure, and cancellation.
  * Upload progress now reports confirmed and total block counts when available.
  * Exposed upload phases and block counters through the client and WebAssembly interfaces.

* **Bug Fixes**
  * Improved reporting for upload failures, retries, permanent refusals, and quota-related holds.
  * Preserved progress when resuming uploads from confirmed blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->