### PR TITLE
feat(web): ask the engine for the vault root instead of seeding an anchor

### DIFF
--- a/apps/web/src/engine/snapshotStore.test.ts
+++ b/apps/web/src/engine/snapshotStore.test.ts
@@ -45,13 +45,30 @@ describe('snapshotStore', () => {
     expect([first, second]).toEqual([1, 2]);
   });
 
-  it('pulls the vault root until a focus is set', () => {
+  it('asks for the vault root rather than naming it until a focus is set', () => {
     const engine = fakeEngine();
     const store = createSnapshotStore(engine.client);
 
     engine.emit({ kind: 'snapshotUpdated' });
-    expect(engine.pulls[0].folder).toEqual(ROOT_ID);
+    expect(engine.pulls[0].folder).toBeNull();
     expect(store.getSnapshot().view).toBeNull();
+  });
+
+  it('paints a vault whose adopted base roots off the anchor', async () => {
+    const engine = fakeEngine();
+    const store = createSnapshotStore(engine.client);
+    // A cold start that adopted a base rooted at a non-anchor id: this engine
+    // knows no all-zero node, so a pull naming one is `unknownNode`.
+    const adopted = new Uint8Array(16).fill(0xa7);
+
+    engine.emit({ kind: 'snapshotUpdated' });
+    const pull = engine.pulls[0];
+    if (pull.folder === null) pull.resolve({ ...view(adopted), root: adopted });
+    else pull.reject(new EngineRequestError('unknown node', 'unknownNode'));
+    await flush();
+
+    expect(store.getSnapshot().error).toBeNull();
+    expect(store.getSnapshot().view?.root).toEqual(adopted);
   });
 
   it('sets the engine focus window and the cross-tab hint before pulling', async () => {

--- a/apps/web/src/engine/snapshotStore.test.ts
+++ b/apps/web/src/engine/snapshotStore.test.ts
@@ -45,28 +45,19 @@ describe('snapshotStore', () => {
     expect([first, second]).toEqual([1, 2]);
   });
 
-  it('asks for the vault root rather than naming it until a focus is set', () => {
+  it('asks for the vault root rather than naming it until a focus is set', async () => {
     const engine = fakeEngine();
     const store = createSnapshotStore(engine.client);
+    // A cold start whose adopted base roots at a non-anchor id: that engine
+    // knows no all-zero node, so naming one would be `unknownNode`.
+    const adopted = new Uint8Array(16).fill(0xa7);
 
     engine.emit({ kind: 'snapshotUpdated' });
     expect(engine.pulls[0].folder).toBeNull();
     expect(store.getSnapshot().view).toBeNull();
-  });
 
-  it('paints a vault whose adopted base roots off the anchor', async () => {
-    const engine = fakeEngine();
-    const store = createSnapshotStore(engine.client);
-    // A cold start that adopted a base rooted at a non-anchor id: this engine
-    // knows no all-zero node, so a pull naming one is `unknownNode`.
-    const adopted = new Uint8Array(16).fill(0xa7);
-
-    engine.emit({ kind: 'snapshotUpdated' });
-    const pull = engine.pulls[0];
-    if (pull.folder === null) pull.resolve({ ...view(adopted), root: adopted });
-    else pull.reject(new EngineRequestError('unknown node', 'unknownNode'));
+    engine.pulls[0].resolve({ ...view(adopted), root: adopted });
     await flush();
-
     expect(store.getSnapshot().error).toBeNull();
     expect(store.getSnapshot().view?.root).toEqual(adopted);
   });

--- a/apps/web/src/engine/snapshotStore.ts
+++ b/apps/web/src/engine/snapshotStore.ts
@@ -89,7 +89,6 @@ export function createSnapshotStore(client: EngineClient): SnapshotStore {
     inFlight = true;
     const id = ++generation;
     const seq = stalenessSeq;
-    // No focus asks the engine for its own root, never names one.
     void client.facade
       .snapshot(focus)
       .then(

--- a/apps/web/src/engine/snapshotStore.ts
+++ b/apps/web/src/engine/snapshotStore.ts
@@ -8,14 +8,6 @@
 import { EngineRequestError } from '@cipherbox/client';
 import type { EngineClient, SnapshotDescriptor, Staleness } from '@cipherbox/client';
 
-/**
- * The folder the first pull asks for, before any view names a root: the
- * engine's cold-start anchor (`crates/engine/src/facade.rs`, `Snapshot::new`).
- * Every later pull uses the root the engine reported. Retiring this seed needs
- * a snapshot seam that takes no folder — #900.
- */
-const VAULT_ROOT_SEED_ID: Uint8Array = new Uint8Array(16);
-
 /** A failed pull, carrying the engine's stable code so the UI can classify it. */
 export interface SnapshotError {
   message: string;
@@ -97,9 +89,9 @@ export function createSnapshotStore(client: EngineClient): SnapshotStore {
     inFlight = true;
     const id = ++generation;
     const seq = stalenessSeq;
-    const folder = focus ?? state.view?.root ?? VAULT_ROOT_SEED_ID;
+    // No focus asks the engine for its own root, never names one.
     void client.facade
-      .snapshot(folder)
+      .snapshot(focus)
       .then(
         (view) => {
           if (id !== generation) return;

--- a/apps/web/src/engine/testFakes.ts
+++ b/apps/web/src/engine/testFakes.ts
@@ -10,7 +10,7 @@ import type {
   Staleness,
 } from '@cipherbox/client';
 
-/** The folder id the store seeds its first pull with. */
+/** The anchored root id a first-run vault reports. */
 export const ROOT_ID: Uint8Array = new Uint8Array(16);
 
 export function view(
@@ -40,7 +40,8 @@ export function view(
 }
 
 interface Pull {
-  folder: Uint8Array;
+  /** The folder asked for, or `null` for "whatever the engine's root is". */
+  folder: Uint8Array | null;
   resolve: (view: SnapshotDescriptor) => void;
   reject: (error: Error) => void;
 }
@@ -59,7 +60,7 @@ export function fakeEngine() {
         listeners.add(listener);
         return () => listeners.delete(listener);
       },
-      snapshot(folder: Uint8Array) {
+      snapshot(folder: Uint8Array | null) {
         return new Promise<SnapshotDescriptor>((resolve, reject) => {
           pulls.push({ folder, resolve, reject });
         });

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -329,18 +329,17 @@ impl EngineHandle {
         })
     }
 
-    /// Reads a key-free [`SnapshotView`] of `folder` for a UI paint. Resolves
-    /// with the view; rejects with the engine error.
-    pub fn snapshot(&self, folder: &NodeId) -> Promise {
+    /// Reads a key-free [`SnapshotView`] for a UI paint: of `folder`, or of the
+    /// engine's own current root when `folder` is absent — a host asks for the
+    /// root, it never names one (blueprint/web-client.md "UI state law").
+    /// Resolves with the view; rejects with the engine error.
+    pub fn snapshot(&self, folder: Option<NodeId>) -> Promise {
         let engine = self.engine.clone();
-        let folder = folder.facade();
+        let folder = folder.map(|node| node.facade());
         future_to_promise(async move {
-            let view = engine
-                .read()
-                .await
-                .snapshot(folder)
-                .await
-                .map_err(engine_error)?;
+            let engine = engine.read().await;
+            let folder = folder.unwrap_or_else(|| engine.root());
+            let view = engine.snapshot(folder).await.map_err(engine_error)?;
             Ok(SnapshotView::from_facade(view).into())
         })
     }

--- a/packages/client/src/broadcast.ts
+++ b/packages/client/src/broadcast.ts
@@ -34,7 +34,7 @@ export interface BroadcastChannelLike {
 
 /** A follower read intent: served by the leader's engine, answered by value. */
 export type WireRead =
-  | { kind: 'snapshot'; folder: Uint8Array }
+  | { kind: 'snapshot'; folder: Uint8Array | null }
   | { kind: 'download'; node: Uint8Array };
 
 /** A follower streaming-write step, driven against the leader's engine. */

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -206,6 +206,14 @@ describe('broadcast transport ↔ leader relay', () => {
     expect(engine.snapshots).toEqual([folder]);
   });
 
+  it('carries a rootless follower snapshot to the leader as no folder at all', async () => {
+    const { engine, follower } = wire();
+    // A follower that has not named a folder asks for the vault root; `null`
+    // must survive the structured clone rather than arrive as a seeded id.
+    await expect(follower.snapshot(null)).resolves.toEqual(emptySnapshot());
+    expect(engine.snapshots).toEqual([null]);
+  });
+
   it('serves a follower download as a Blob and rebuilds identical bytes', async () => {
     const { engine, follower } = wire();
     const plaintext = Uint8Array.from({ length: 64 }, (_, i) => (i * 11 + 5) & 0xff);

--- a/packages/client/src/broadcastTransport.ts
+++ b/packages/client/src/broadcastTransport.ts
@@ -90,7 +90,7 @@ export class BroadcastTransport extends CorrelatedTransport {
     return this.write<void>({ kind: 'abortWrite', handle });
   }
 
-  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
+  snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor> {
     return this.read<SnapshotDescriptor>({ kind: 'snapshot', folder });
   }
 

--- a/packages/client/src/correlatedTransport.ts
+++ b/packages/client/src/correlatedTransport.ts
@@ -69,7 +69,7 @@ export abstract class CorrelatedTransport implements EngineTransport {
   abstract pushChunk(handle: WriteHandle, chunk: ArrayBuffer): Promise<void>;
   abstract commitWrite(handle: WriteHandle): Promise<bigint>;
   abstract abortWrite(handle: WriteHandle): Promise<void>;
-  abstract snapshot(folder: Uint8Array): Promise<SnapshotDescriptor>;
+  abstract snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor>;
   abstract download(node: Uint8Array): Promise<ArrayBuffer>;
   abstract close(): void;
 

--- a/packages/client/src/engineClient.ts
+++ b/packages/client/src/engineClient.ts
@@ -148,7 +148,7 @@ export class EngineClient implements EngineTransport {
     return this.current.abortWrite(handle);
   }
 
-  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
+  snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor> {
     return this.current.snapshot(folder);
   }
 

--- a/packages/client/src/facade.ts
+++ b/packages/client/src/facade.ts
@@ -56,8 +56,8 @@ export class EngineFacade {
     return this.transport.subscribe(listener);
   }
 
-  /** Reads a key-free snapshot of `folder` for a UI paint. */
-  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
+  /** Reads a key-free snapshot of `folder`, or of the vault root for `null`. */
+  snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor> {
     return this.transport.snapshot(folder);
   }
 

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -180,7 +180,7 @@ export class FakeLockManager implements LockManagerLike {
 /** A minimal in-process EngineTransport for relay/orchestrator tests. */
 export class FakeEngineTransport implements EngineTransport {
   readonly commands: CommandDescriptor[] = [];
-  readonly snapshots: Uint8Array[] = [];
+  readonly snapshots: Array<Uint8Array | null> = [];
   readonly downloads: Uint8Array[] = [];
   readonly beginWrites: Array<{ target: WriteTarget; size: number }> = [];
   readonly chunks: Array<{ handle: WriteHandle; chunk: ArrayBuffer }> = [];
@@ -192,8 +192,8 @@ export class FakeEngineTransport implements EngineTransport {
   writeHandle: WriteHandle = 1n;
   commitOpId = 42n;
   respond: (command: CommandDescriptor) => Promise<void> = () => Promise.resolve();
-  respondSnapshot: (folder: Uint8Array) => Promise<SnapshotDescriptor> = (folder) =>
-    Promise.resolve(emptySnapshot(folder));
+  respondSnapshot: (folder: Uint8Array | null) => Promise<SnapshotDescriptor> = (folder) =>
+    Promise.resolve(emptySnapshot(folder ?? undefined));
   respondDownload: (node: Uint8Array) => Promise<ArrayBuffer> = () =>
     Promise.resolve(new ArrayBuffer(0));
   private readonly listeners = new Set<EngineEventListener>();
@@ -228,7 +228,7 @@ export class FakeEngineTransport implements EngineTransport {
     return Promise.resolve();
   }
 
-  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
+  snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor> {
     this.snapshots.push(folder);
     return this.respondSnapshot(folder);
   }

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -36,8 +36,8 @@ export interface EngineTransport {
   commitWrite(handle: WriteHandle): Promise<bigint>;
   /** Abandons the handle, releasing its reservation and staged blocks. */
   abortWrite(handle: WriteHandle): Promise<void>;
-  /** Reads a key-free snapshot of `folder` for a UI paint. */
-  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor>;
+  /** Reads a key-free snapshot of `folder`, or of the vault root for `null`. */
+  snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor>;
   /** Downloads one file node's plaintext through the verified read pipeline. */
   download(node: Uint8Array): Promise<ArrayBuffer>;
   /** Subscribes to the one-way event stream; returns an unsubscribe. */
@@ -136,7 +136,7 @@ export class LocalTransport extends CorrelatedTransport {
     );
   }
 
-  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
+  snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor> {
     return this.request<SnapshotDescriptor>(this.ready, (id) =>
       this.worker.postMessage({ type: 'snapshot', id, folder }, [])
     );

--- a/packages/client/src/worker/engineHost.ts
+++ b/packages/client/src/worker/engineHost.ts
@@ -28,7 +28,6 @@ export interface EngineHostLike {
   /** Closes the handle and journals its op; resolves with the durable op id. */
   commitWrite(handle: WriteHandle): Promise<bigint>;
   abortWrite(handle: WriteHandle): Promise<void>;
-  /** Reads `folder`, or the engine's own root when `folder` is `null`. */
   snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor>;
   download(node: Uint8Array): Promise<ArrayBuffer>;
   nextEvent(): Promise<EventDescriptor | null>;

--- a/packages/client/src/worker/engineHost.ts
+++ b/packages/client/src/worker/engineHost.ts
@@ -28,7 +28,8 @@ export interface EngineHostLike {
   /** Closes the handle and journals its op; resolves with the durable op id. */
   commitWrite(handle: WriteHandle): Promise<bigint>;
   abortWrite(handle: WriteHandle): Promise<void>;
-  snapshot(folder: Uint8Array): Promise<SnapshotDescriptor>;
+  /** Reads `folder`, or the engine's own root when `folder` is `null`. */
+  snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor>;
   download(node: Uint8Array): Promise<ArrayBuffer>;
   nextEvent(): Promise<EventDescriptor | null>;
 }
@@ -99,8 +100,10 @@ export class EngineHost implements EngineHostLike {
     await this.handle.abortWrite(handle);
   }
 
-  async snapshot(folder: Uint8Array): Promise<SnapshotDescriptor> {
-    const view = await this.handle.snapshot(this.wasm.NodeId.fromBytes(folder));
+  async snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor> {
+    const view = await this.handle.snapshot(
+      folder === null ? undefined : this.wasm.NodeId.fromBytes(folder)
+    );
     return readSnapshot(this.wasm, view);
   }
 

--- a/packages/client/src/worker/engineWasm.ts
+++ b/packages/client/src/worker/engineWasm.ts
@@ -91,7 +91,6 @@ export interface WasmEngineHandle {
   pushChunk(handle: bigint, chunk: Uint8Array): Promise<unknown>;
   commitWrite(handle: bigint): Promise<bigint>;
   abortWrite(handle: bigint): Promise<unknown>;
-  /** No folder reads the engine's own root. */
   snapshot(folder?: WasmNodeId): Promise<WasmSnapshotView>;
   download(node: WasmNodeId): Promise<Uint8Array>;
   nextEvent(): Promise<WasmEvent | undefined>;

--- a/packages/client/src/worker/engineWasm.ts
+++ b/packages/client/src/worker/engineWasm.ts
@@ -91,7 +91,8 @@ export interface WasmEngineHandle {
   pushChunk(handle: bigint, chunk: Uint8Array): Promise<unknown>;
   commitWrite(handle: bigint): Promise<bigint>;
   abortWrite(handle: bigint): Promise<unknown>;
-  snapshot(folder: WasmNodeId): Promise<WasmSnapshotView>;
+  /** No folder reads the engine's own root. */
+  snapshot(folder?: WasmNodeId): Promise<WasmSnapshotView>;
   download(node: WasmNodeId): Promise<Uint8Array>;
   nextEvent(): Promise<WasmEvent | undefined>;
 }

--- a/packages/client/src/worker/protocol.ts
+++ b/packages/client/src/worker/protocol.ts
@@ -177,7 +177,7 @@ export type WorkerRequest =
   | { type: 'pushChunk'; id: number; handle: WriteHandle; chunk: ArrayBuffer }
   | { type: 'commitWrite'; id: number; handle: WriteHandle }
   | { type: 'abortWrite'; id: number; handle: WriteHandle }
-  | { type: 'snapshot'; id: number; folder: Uint8Array }
+  | { type: 'snapshot'; id: number; folder: Uint8Array | null }
   | { type: 'download'; id: number; node: Uint8Array };
 
 /** A worker → UI message. */

--- a/packages/client/test/browser/engine.spec.ts
+++ b/packages/client/test/browser/engine.spec.ts
@@ -56,6 +56,10 @@ test.describe('engine worker host', () => {
     // The snapshot echoes the anchored all-zero root as both root and folder.
     expect(result.rootEchoed).toBe(true);
 
+    // A rootless read is answered from the engine's own root, so a host never
+    // has to name one before it has seen a view (#900).
+    expect(result.rootlessFolderHex).toBe(result.rootHex);
+
     // Both metadata creates project as pending children with no content plane.
     expect(result.children).toHaveLength(2);
     const docs = result.children.find((child) => child.name === 'docs');

--- a/packages/client/test/browser/engineHarness.ts
+++ b/packages/client/test/browser/engineHarness.ts
@@ -35,6 +35,8 @@ export interface SnapshotSuiteResult {
   }>;
   nestedAncestors: Array<{ idHex: string; name: string }>;
   rootHex: string;
+  /** The folder a rootless `snapshot(null)` answered with. */
+  rootlessFolderHex: string;
   unknownError: string;
   unknownCode: string;
   downloadError: string;
@@ -128,6 +130,8 @@ window.runSnapshotSuite = async (): Promise<SnapshotSuiteResult> => {
     if (!docs || !file) throw new Error('created children missing from the root snapshot');
 
     const nested = await facade.snapshot(docs.id);
+    // No folder named: the engine answers with its own current root.
+    const rootless = await facade.snapshot(null);
 
     let unknownError = '';
     let unknownCode = '';
@@ -158,6 +162,7 @@ window.runSnapshotSuite = async (): Promise<SnapshotSuiteResult> => {
         name: ancestor.name,
       })),
       rootHex: hex(view.root),
+      rootlessFolderHex: hex(rootless.folder),
       unknownError,
       unknownCode,
       downloadError,

--- a/packages/client/test/browser/engineHarness.ts
+++ b/packages/client/test/browser/engineHarness.ts
@@ -35,7 +35,6 @@ export interface SnapshotSuiteResult {
   }>;
   nestedAncestors: Array<{ idHex: string; name: string }>;
   rootHex: string;
-  /** The folder a rootless `snapshot(null)` answered with. */
   rootlessFolderHex: string;
   unknownError: string;
   unknownCode: string;
@@ -130,7 +129,6 @@ window.runSnapshotSuite = async (): Promise<SnapshotSuiteResult> => {
     if (!docs || !file) throw new Error('created children missing from the root snapshot');
 
     const nested = await facade.snapshot(docs.id);
-    // No folder named: the engine answers with its own current root.
     const rootless = await facade.snapshot(null);
 
     let unknownError = '';


### PR DESCRIPTION
## Problem

`apps/web/src/engine/snapshotStore.ts` seeded its first pull with a hardcoded
all-zero id16 (`VAULT_ROOT_SEED_ID`) because the wasm host exposed no way to ask
for "the vault root": `snapshot(folder: &NodeId)` required a folder id, and the
UI cannot name one before it has seen a view — the root only arrives inside
`SnapshotDescriptor.root`.

That seed was correct only by coincidence. Cold start replaces the whole base
snapshot, so an adopted base rooted at anything but the anchor made the very
first `snapshot()` reject with `UnknownNode` and painted a bare error where the
vault should be. `crates/fuse/src/ops.rs` already calls `view.root()` — the
desktop host asks. Now the web host asks too.

## Change

1. `crates/wasm/src/host.rs` — `snapshot(folder: Option<NodeId>)`, falling back
   to `Engine::root()` under the same read lock. No facade change, no new
   command, no new event.
2. `folder` widened to `Uint8Array | null` through the TS chain — signature-only
   edits in `protocol.ts`, `engineWasm.ts`, `engineHost.ts`, `transport.ts`,
   `correlatedTransport.ts`, `broadcast.ts`, `broadcastTransport.ts`,
   `facade.ts`, `engineClient.ts`, `testkit.ts`. `serve.ts` and `leaderRelay.ts`
   needed no edit — the widened type flows through them.
3. `VAULT_ROOT_SEED_ID` and the `state.view?.root` fallback chain are gone from
   `snapshotStore.ts`; it pulls with `focus` directly.

## Tests

- `packages/client/test/browser/engine.spec.ts` — the real WASM engine answers a
  rootless `snapshot(null)` from its own root. Reverting only the `host.rs`
  signature fails it with `EngineRequestError: expected instance of NodeId`.
- `apps/web/src/engine/snapshotStore.test.ts` — the unfocused pull names no
  folder at all, and a base rooted at a non-anchor id paints. Against the seeded
  constant it failed with `expected Uint8Array[ 0, 0, 0, … ] to be null`.
- `packages/client/src/broadcastTransport.test.ts` — `null` survives the
  cross-tab structured clone, so a follower's rootless read reaches the leader as
  no folder at all.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo check --workspace --all-targets`, `cargo check -p cipherbox-wasm --target
wasm32-unknown-unknown --all-targets`, `pnpm -r --if-present run typecheck`,
`pnpm -r --if-present run test`, `eslint .`, and the full browser suite
`pnpm --filter @cipherbox/client test:browser` (19 passed) — all exit 0.

Closes #900


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Snapshot requests can now omit a folder to automatically use the vault’s root.
  * Root-level snapshots are consistently supported across local, browser, worker, and broadcast operations.
* **Bug Fixes**
  * Improved initial snapshot handling for vaults with adopted roots.
  * Prevented errors caused by incorrect or unavailable root identifiers.
* **Tests**
  * Added coverage validating rootless snapshots and root propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->