### PR TITLE
feat: settle the BYO endpoint transport and address-range policy

### DIFF
--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -512,18 +512,23 @@ contract-test suite owned by the testing-strategy blueprint (#28 D6).
   identically to a member-typed config and to one resolved back off the
   network, and release-active on the encode side so nothing is published that
   the reader would refuse. The rules: an absolute `http(s)` URL whose
-  authority is host-and-port bytes only; `https` unless the host is a
-  **literal** loopback address (`127.0.0.0/8`, `::1`, `localhost`), because
-  the probe carries the member's bearer and plaintext to anything else puts it
-  on the wire; the cloud-metadata address (`169.254.169.254`, its IPv6
-  spellings, and `fd00:ec2::254`) refused outright, since no IPFS provider
-  serves it; and an access token restricted to the bytes a header value may
-  carry. Private and link-local ranges otherwise stay **allowed** — self-hosting
-  on a LAN is the feature. The engine has no resolver and does not acquire one
-  for this: a name's address is the host's to resolve at request time, so
-  loopback is decided from the literal alone and the metadata refusal is a
-  legibility rule, not an SSRF containment boundary. Each refusal is its own
-  `ProviderError` verdict so the host can say which rule bit.
+  authority is host-and-port bytes only; `https` unless the host is a loopback
+  address (`127.0.0.0/8`, `::1`) or the name RFC 6761 reserves for one
+  (`localhost`), because the probe carries the member's bearer and plaintext
+  to anything else puts it on the wire; the cloud-metadata address
+  (`169.254.169.254` and its IPv6 spellings, `fd00:ec2::254`) refused
+  outright, since no IPFS provider serves it; and an access token restricted
+  to visible ASCII. A host that this gate would read as a name while the
+  transport's URL parser would read it as an address (`0xa9fea9fe`,
+  `2852039166`) is refused rather than classified twice. Private and
+  link-local ranges otherwise stay **allowed** — self-hosting on a LAN is the
+  feature. The engine has no resolver and does not acquire one for this: every
+  other name's address is the host's to resolve at request time, so the
+  verdict comes from the literal and the metadata refusal is a legibility
+  rule, not an SSRF containment boundary. Each refusal is its own
+  `ProviderError` verdict so the host can say which rule bit. The transport
+  decision binds the whole exchange, so the `Http` seam must not follow a
+  redirect that downgrades `https` to `http`.
 - **Reads**: the token-authed trustless gateway is a member accelerator; any
   public trustless gateway is the no-auth fallback. The engine verifies CIDs
   client-side via core on every block/CAR response; media uses ranged fetches

--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -508,6 +508,22 @@ contract-test suite owned by the testing-strategy blueprint (#28 D6).
   every mode's publish flow still traverses registration. `ByoIpfsConfig`
   stays sealed in vault settings; provider connection testing is engine-side
   over the Http seam (the TEE tester is gone).
+- **BYO endpoint policy** (#905): one gate over the whole config, applied
+  identically to a member-typed config and to one resolved back off the
+  network, and release-active on the encode side so nothing is published that
+  the reader would refuse. The rules: an absolute `http(s)` URL whose
+  authority is host-and-port bytes only; `https` unless the host is a
+  **literal** loopback address (`127.0.0.0/8`, `::1`, `localhost`), because
+  the probe carries the member's bearer and plaintext to anything else puts it
+  on the wire; the cloud-metadata address (`169.254.169.254`, its IPv6
+  spellings, and `fd00:ec2::254`) refused outright, since no IPFS provider
+  serves it; and an access token restricted to the bytes a header value may
+  carry. Private and link-local ranges otherwise stay **allowed** — self-hosting
+  on a LAN is the feature. The engine has no resolver and does not acquire one
+  for this: a name's address is the host's to resolve at request time, so
+  loopback is decided from the literal alone and the metadata refusal is a
+  legibility rule, not an SSRF containment boundary. Each refusal is its own
+  `ProviderError` verdict so the host can say which rule bit.
 - **Reads**: the token-authed trustless gateway is a member accelerator; any
   public trustless gateway is the no-auth fallback. The engine verifies CIDs
   client-side via core on every block/CAR response; media uses ranged fetches

--- a/crates/desktop-seams/src/http.rs
+++ b/crates/desktop-seams/src/http.rs
@@ -32,6 +32,25 @@ impl ReqwestHttp {
     pub fn new() -> SeamResult<Self> {
         let client = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(10))
+            .redirect(reqwest::redirect::Policy::custom(|attempt| {
+                // The engine decides over which transport a request carrying an
+                // `Authorization` header may go (blueprint/engine.md "Content
+                // plane"). A redirect that downgrades to plaintext would carry
+                // the credential onto the clear network past that decision, so
+                // it is surfaced as the 3xx it is rather than followed.
+                let downgrade = attempt.url().scheme() == "http"
+                    && attempt
+                        .previous()
+                        .last()
+                        .is_some_and(|previous| previous.scheme() == "https");
+                if downgrade {
+                    attempt.stop()
+                } else if attempt.previous().len() > 10 {
+                    attempt.error("too many redirects")
+                } else {
+                    attempt.follow()
+                }
+            }))
             .build()
             .map_err(|err| SeamError::new(format!("http client build: {err}")))?;
         Ok(Self { client })

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -27,7 +27,7 @@ pub use dag::{
 };
 pub use profile::ContentProfile;
 pub use provider::{
-    ByoIpfsConfig, ByoKind, PinMode, ProviderError, test_connection, validate_endpoint,
+    ByoIpfsConfig, ByoKind, PinMode, ProviderError, test_connection, validate_byo_config,
 };
 pub use read::{
     ContentPlane, Gateway, GatewayConfig, GatewaySource, ReadError, is_plane_anchor,

--- a/crates/engine/src/content/provider.rs
+++ b/crates/engine/src/content/provider.rs
@@ -9,7 +9,7 @@
 //! plaintext it seals.
 
 use core::fmt;
-use core::net::{Ipv4Addr, Ipv6Addr};
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use zeroize::Zeroizing;
 
@@ -17,10 +17,14 @@ use crate::seams::{Http, HttpMethod, HttpRequest};
 
 const AUTHORIZATION: &str = "Authorization";
 
-/// The cloud metadata service, which no IPFS provider serves: the IPv4
-/// link-local address and the IPv6 address AWS answers on.
-const METADATA_V4: Ipv4Addr = Ipv4Addr::new(169, 254, 169, 254);
-const METADATA_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 0x0ec2, 0, 0, 0, 0, 0, 0x0254);
+/// The cloud metadata service, which no IPFS provider serves: the link-local
+/// address in the two IPv6 spellings `to_canonical` does not fold, and the IPv6
+/// address AWS answers on.
+const METADATA: [IpAddr; 3] = [
+    IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254)),
+    IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0xa9fe, 0xa9fe)),
+    IpAddr::V6(Ipv6Addr::new(0xfd00, 0x0ec2, 0, 0, 0, 0, 0, 0x0254)),
+];
 
 /// Where a version's bytes are pinned (#34 D1). Every mode still registers with
 /// the API for union-liveness accounting; only the byte destination differs.
@@ -79,13 +83,16 @@ impl fmt::Debug for ByoIpfsConfig {
 /// say which rule refused the config instead of showing a bare failure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProviderError {
-    /// The endpoint is not an absolute `http(s)` URL with a host-and-port
-    /// authority — a member-supplied string must not reach the Http seam as a
-    /// `file:`/relative/hostless target (SSRF and scheme-exfiltration surface).
+    /// The endpoint is not an absolute `http(s)` URL whose authority is
+    /// host-and-port bytes. It is spliced into a request URL, so a `file:`,
+    /// relative or hostless target, or one carrying whitespace, a control
+    /// character or URL syntax (`@`, `?`, `#`, `\`), could reshape the request
+    /// or inject a header — and which one happens would depend on the host
+    /// `Http` implementation. That decision does not belong to the seam.
     InvalidEndpoint,
-    /// Plaintext `http://` to a host that is not a literal loopback address:
-    /// the probe carries the member's bearer, so the credential would cross the
-    /// network in the clear.
+    /// Plaintext `http://` to a host that is not loopback: the probe carries
+    /// the member's bearer, so the credential would cross the network in the
+    /// clear.
     InsecureTransport,
     /// The endpoint names the cloud metadata service.
     BlockedAddress,
@@ -134,9 +141,11 @@ pub async fn test_connection(
 pub fn validate_byo_config(config: &ByoIpfsConfig) -> Result<(), ProviderError> {
     validate_endpoint(&config.endpoint)?;
     match &config.access_token {
-        // The token is spliced into a header value verbatim, so it may carry
-        // only the bytes one admits — a control character would inject a header.
-        Some(token) if !token.bytes().all(is_header_value_byte) => {
+        // The token is spliced into a header value verbatim, so a control
+        // character in it would inject a header. A present-but-empty one is an
+        // `Authorization: Bearer ` no provider accepts; `None` is how a
+        // credential-less provider is spelled.
+        Some(token) if token.is_empty() || !token.bytes().all(is_bearer_byte) => {
             Err(ProviderError::InvalidCredential)
         }
         _ => Ok(()),
@@ -144,27 +153,18 @@ pub fn validate_byo_config(config: &ByoIpfsConfig) -> Result<(), ProviderError> 
 }
 
 /// Require an absolute `http(s)` URL whose authority is a host and optional
-/// port, then hold the host to the transport and address policy. A lightweight
-/// scheme+authority check (the engine has no URL parser): it rejects other
-/// schemes (`file:`, `ftp:`, …), scheme-less or relative strings, and a hostless
-/// `http:///path`, closing the scheme-exfiltration / SSRF surface a raw member
-/// string would open.
-///
-/// The endpoint is spliced into a request URL, so the authority is restricted to
-/// the bytes a host and port may contain: whitespace, a control character, or
-/// URL syntax (`@`, `?`, `#`, `\`) could reshape the request target or inject a
-/// header, and which one happens would depend on the host `Http` implementation.
-/// That decision does not belong to the seam.
+/// port, then hold the host to the transport and address policy
+/// (blueprint/engine.md "Content plane"). A lightweight scheme+authority check —
+/// the engine has no URL parser — enforcing the byte rule
+/// [`ProviderError::InvalidEndpoint`] states.
 fn validate_endpoint(endpoint: &str) -> Result<(), ProviderError> {
     let lower = endpoint.to_ascii_lowercase();
-    let (tls, authority) = match lower.strip_prefix("https://") {
-        Some(rest) => (true, rest),
-        None => (
-            false,
-            lower
-                .strip_prefix("http://")
-                .ok_or(ProviderError::InvalidEndpoint)?,
-        ),
+    let (tls, authority) = if let Some(rest) = lower.strip_prefix("https://") {
+        (true, rest)
+    } else if let Some(rest) = lower.strip_prefix("http://") {
+        (false, rest)
+    } else {
+        return Err(ProviderError::InvalidEndpoint);
     };
     // A host must follow the scheme (not empty, not straight into a path).
     let host_port = authority.split('/').next().unwrap_or_default();
@@ -175,62 +175,78 @@ fn validate_endpoint(endpoint: &str) -> Result<(), ProviderError> {
     if authority.bytes().any(|b| !is_path_byte(b)) {
         return Err(ProviderError::InvalidEndpoint);
     }
-    let host = host_of(host_port)?;
-    if is_metadata_literal(host) {
+    let (host, ip) = host_of(host_port)?;
+    if ip.is_some_and(|ip| METADATA.contains(&ip)) {
         return Err(ProviderError::BlockedAddress);
     }
-    if !tls && !is_loopback_literal(host) {
+    if !tls && !is_loopback(host, ip) {
         return Err(ProviderError::InsecureTransport);
     }
     Ok(())
 }
 
-/// The host of a `host`, `host:port`, `[v6]` or `[v6]:port` authority. Fail
-/// closed: an authority that does not split cleanly is refused, never guessed,
-/// because everything downstream keys off the host it yields.
-fn host_of(authority: &str) -> Result<&str, ProviderError> {
+/// The host of a `host`, `host:port`, `[v6]` or `[v6]:port` authority, with the
+/// address it denotes when it is a literal — IPv4-mapped forms folded, so one
+/// address gets one verdict. Fail closed: an authority that does not split
+/// cleanly is refused, never guessed, because the policy keys off the host.
+fn host_of(authority: &str) -> Result<(&str, Option<IpAddr>), ProviderError> {
     let bad = || ProviderError::InvalidEndpoint;
-    let (host, port) = match authority.strip_prefix('[') {
-        Some(rest) => {
-            let (host, tail) = rest.split_once(']').ok_or_else(bad)?;
-            // A bracketed authority holds an IPv6 literal and nothing else.
-            host.parse::<Ipv6Addr>().map_err(|_| bad())?;
-            match tail {
-                "" => (host, None),
-                _ => (host, Some(tail.strip_prefix(':').ok_or_else(bad)?)),
-            }
+    let (host, port) = if let Some(rest) = authority.strip_prefix('[') {
+        let (host, tail) = rest.split_once(']').ok_or_else(bad)?;
+        // A bracketed authority holds an IPv6 literal and nothing else.
+        if !host.parse::<IpAddr>().is_ok_and(|ip| ip.is_ipv6()) {
+            return Err(bad());
         }
-        None => {
-            let (host, port) = match authority.split_once(':') {
-                Some((host, port)) => (host, Some(port)),
-                None => (authority, None),
-            };
-            if host.is_empty() || host.contains(['[', ']']) {
-                return Err(bad());
-            }
-            (host, port)
+        match tail {
+            "" => (host, None),
+            _ => (host, Some(tail.strip_prefix(':').ok_or_else(bad)?)),
         }
+    } else if let Some((host, port)) = authority.split_once(':') {
+        (host, Some(port))
+    } else {
+        (authority, None)
     };
+    if host.is_empty() || host.contains(['[', ']']) {
+        return Err(bad());
+    }
     if port.is_some_and(|p| p.parse::<u16>().is_err()) {
         return Err(bad());
     }
-    Ok(host)
+    let ip = host.parse::<IpAddr>().ok().map(|ip| ip.to_canonical());
+    if ip.is_none() && !is_dns_name(host) {
+        return Err(bad());
+    }
+    Ok((host, ip))
 }
 
-/// Loopback decided from the literal alone. The engine has no resolver and does
-/// not acquire one for this: a name's address is the host's to resolve at
-/// request time, so a resolved verdict here would be a TOCTOU hole.
-fn is_loopback_literal(host: &str) -> bool {
-    host == "localhost"
-        || host.parse::<Ipv4Addr>().is_ok_and(|ip| ip.is_loopback())
-        || host.parse::<Ipv6Addr>().is_ok_and(|ip| ip.is_loopback())
+/// A host the engine and the seam's URL parser will read the same way. Core's
+/// address parser is strict, but a WHATWG one reads `0xa9fea9fe` and
+/// `0251.0376.0251.0376` as addresses — so a name whose last label could be
+/// read as a number is refused rather than classified as a name here and an
+/// address there.
+fn is_dns_name(host: &str) -> bool {
+    let shaped = |label: &str| {
+        !label.is_empty()
+            && label.len() <= 63
+            && !label.starts_with('-')
+            && !label.ends_with('-')
+            && label
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-')
+    };
+    let last = host.rsplit('.').next().unwrap_or_default();
+    host.len() <= 253
+        && host.split('.').all(shaped)
+        && !last.starts_with("0x")
+        && !last.bytes().all(|b| b.is_ascii_digit())
 }
 
-fn is_metadata_literal(host: &str) -> bool {
-    host.parse::<Ipv4Addr>().is_ok_and(|ip| ip == METADATA_V4)
-        || host
-            .parse::<Ipv6Addr>()
-            .is_ok_and(|ip| ip == METADATA_V6 || ip.to_ipv4() == Some(METADATA_V4))
+/// Loopback decided without a resolver: a literal loopback address, or the name
+/// RFC 6761 reserves for one. Every other name is treated as off-host, because
+/// its address is the host's to resolve at request time and a resolved verdict
+/// here would be a TOCTOU hole.
+fn is_loopback(host: &str, ip: Option<IpAddr>) -> bool {
+    host == "localhost" || ip.is_some_and(|ip| ip.is_loopback())
 }
 
 /// The bytes a host-and-port may contain: letters, digits, `-`, `.`, `:`, plus
@@ -246,9 +262,10 @@ fn is_path_byte(b: u8) -> bool {
     is_authority_byte(b) || matches!(b, b'/' | b'_' | b'~' | b'%' | b'+' | b'=' | b'&' | b',')
 }
 
-/// The bytes an HTTP field value admits: visible ASCII plus space and tab.
-fn is_header_value_byte(b: u8) -> bool {
-    matches!(b, 0x20 | 0x09 | 0x21..=0x7e)
+/// The bytes a bearer credential admits: visible ASCII, the header-value set
+/// minus the whitespace no token carries.
+fn is_bearer_byte(b: u8) -> bool {
+    matches!(b, 0x21..=0x7e)
 }
 
 /// The per-kind reachability probe. The endpoints are each provider's standard
@@ -376,35 +393,37 @@ mod tests {
             ("http://", InvalidEndpoint),          // no host
             ("https:///pins", InvalidEndpoint),    // hostless
             ("", InvalidEndpoint),
-            // A record-sourced endpoint is spliced into a request URL, so the
-            // authority may carry only host-and-port bytes: no control
-            // characters, no whitespace, and no syntax that redirects the
-            // target or injects a header.
             ("http://host\r\nX-Evil: 1", InvalidEndpoint),
             ("http://host with space", InvalidEndpoint),
             ("http://user@evil.test", InvalidEndpoint),
             ("http://host/path?query", InvalidEndpoint),
             ("http://host/path#frag", InvalidEndpoint),
             ("http://host\\evil.test", InvalidEndpoint),
-            // An authority that does not split into host and port is refused
-            // rather than guessed at, because the policy below keys off the host.
             ("http://[::1", InvalidEndpoint),
             ("http://[kubo.example]", InvalidEndpoint),
             ("http://[::1]x", InvalidEndpoint),
             ("http://::1:5001", InvalidEndpoint),
             ("https://kubo.example:no", InvalidEndpoint),
             ("https://kubo.example:99999", InvalidEndpoint),
-            // Plaintext carries the bearer in the clear: only a literal
-            // loopback host may use it, and a name is never one.
+            // A host the seam's URL parser would read as an address while this
+            // gate reads it as a name is refused, not classified twice.
+            ("https://2852039166", InvalidEndpoint),
+            ("https://0251.0376.0251.0376", InvalidEndpoint),
+            ("https://0xa9fea9fe", InvalidEndpoint),
+            ("https://169.254.169.254.", InvalidEndpoint),
+            ("https://-kubo.example", InvalidEndpoint),
+            ("https://kubo..example", InvalidEndpoint),
             ("http://kubo.example", InsecureTransport),
             ("http://127.0.0.1.evil.test", InsecureTransport),
             ("http://localhost.evil.test", InsecureTransport),
             ("http://192.168.1.9:5001", InsecureTransport),
-            // The cloud metadata service, under either scheme and in the IPv6
-            // spellings of the same address.
+            // The metadata address is refused under either scheme, in each
+            // address spelling of it (the numeric-host spellings above are
+            // refused a step earlier, as unreadable rather than as metadata).
             ("http://169.254.169.254", BlockedAddress),
             ("https://169.254.169.254/pins", BlockedAddress),
             ("https://[::ffff:169.254.169.254]", BlockedAddress),
+            ("https://[::169.254.169.254]", BlockedAddress),
             ("https://[fd00:ec2::254]", BlockedAddress),
         ] {
             let cfg = ByoIpfsConfig {
@@ -424,49 +443,36 @@ mod tests {
         );
     }
 
+    /// Plaintext to a loopback literal is the local-node case, and a private
+    /// range over TLS is the LAN case: self-hosting is the feature.
     #[test]
     fn a_local_http_kubo_endpoint_is_allowed() {
-        for host in [
-            "127.0.0.1:5001",
-            "127.1.2.3:5001",
-            "localhost:5001",
-            "[::1]",
+        for endpoint in [
+            "http://127.0.0.1:5001",
+            "http://127.1.2.3:5001",
+            "http://localhost:5001",
+            "http://[::1]",
+            "http://[::ffff:127.0.0.1]",
+            "https://192.168.1.9:5001",
         ] {
             let http = ScriptedHttp::default();
             http.enqueue_response(ok());
             let cfg = ByoIpfsConfig {
-                endpoint: format!("http://{host}"),
+                endpoint: endpoint.to_owned(),
                 kind: ByoKind::Kubo,
                 access_token: None,
             };
             block_on(test_connection(&cfg, &http)).unwrap();
-            assert_eq!(http.requests()[0].url, format!("http://{host}/api/v0/id"));
+            assert_eq!(http.requests()[0].url, format!("{endpoint}/api/v0/id"));
         }
-    }
-
-    #[test]
-    fn a_private_range_endpoint_over_tls_is_allowed() {
-        let http = ScriptedHttp::default();
-        http.enqueue_response(ok());
-        let cfg = ByoIpfsConfig {
-            endpoint: "https://192.168.1.9:5001".into(),
-            kind: ByoKind::Kubo,
-            access_token: None,
-        };
-        block_on(test_connection(&cfg, &http)).unwrap();
     }
 
     #[test]
     fn an_access_token_that_could_inject_a_header_is_refused() {
         let http = ScriptedHttp::default();
-        for bad in ["tok\r\nX-Evil: 1", "tok\n", "tok\u{7f}"] {
-            let cfg = ByoIpfsConfig {
-                endpoint: "https://ipfs.member.test".into(),
-                kind: ByoKind::Psa,
-                access_token: Some(Zeroizing::new(bad.to_owned())),
-            };
+        for bad in ["tok\r\nX-Evil: 1", "tok\n", "tok\u{7f}", "tok tok", ""] {
             assert_eq!(
-                block_on(test_connection(&cfg, &http)).unwrap_err(),
+                block_on(test_connection(&config(ByoKind::Psa, Some(bad)), &http)).unwrap_err(),
                 ProviderError::InvalidCredential,
                 "{bad:?} must be rejected"
             );

--- a/crates/engine/src/content/provider.rs
+++ b/crates/engine/src/content/provider.rs
@@ -9,12 +9,18 @@
 //! plaintext it seals.
 
 use core::fmt;
+use core::net::{Ipv4Addr, Ipv6Addr};
 
 use zeroize::Zeroizing;
 
 use crate::seams::{Http, HttpMethod, HttpRequest};
 
 const AUTHORIZATION: &str = "Authorization";
+
+/// The cloud metadata service, which no IPFS provider serves: the IPv4
+/// link-local address and the IPv6 address AWS answers on.
+const METADATA_V4: Ipv4Addr = Ipv4Addr::new(169, 254, 169, 254);
+const METADATA_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 0x0ec2, 0, 0, 0, 0, 0, 0x0254);
 
 /// Where a version's bytes are pinned (#34 D1). Every mode still registers with
 /// the API for union-liveness accounting; only the byte destination differs.
@@ -68,14 +74,23 @@ impl fmt::Debug for ByoIpfsConfig {
     }
 }
 
-/// Why a provider connection test did not succeed.
+/// Why a provider connection test did not succeed. The first four are policy
+/// verdicts reached before any request is issued, kept distinct so a host can
+/// say which rule refused the config instead of showing a bare failure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProviderError {
-    /// The endpoint is not an absolute `http(s)` URL with a host, so it is
-    /// rejected before any request is issued — a member-supplied string must not
-    /// reach the Http seam as a `file:`/relative/hostless target (SSRF and
-    /// scheme-exfiltration surface).
+    /// The endpoint is not an absolute `http(s)` URL with a host-and-port
+    /// authority — a member-supplied string must not reach the Http seam as a
+    /// `file:`/relative/hostless target (SSRF and scheme-exfiltration surface).
     InvalidEndpoint,
+    /// Plaintext `http://` to a host that is not a literal loopback address:
+    /// the probe carries the member's bearer, so the credential would cross the
+    /// network in the clear.
+    InsecureTransport,
+    /// The endpoint names the cloud metadata service.
+    BlockedAddress,
+    /// The access token carries bytes a header value may not.
+    InvalidCredential,
     /// The provider could not be reached (transport-level failure).
     Unreachable,
     /// The provider was reached but rejected the probe (bad endpoint, auth
@@ -90,14 +105,14 @@ pub enum ProviderError {
 /// over the Http seam. Issues the provider's standard health/auth probe and
 /// treats any 2xx as success.
 ///
-/// The member-controlled endpoint passes [`validate_endpoint`] before it reaches
+/// The member-controlled config passes [`validate_byo_config`] before it reaches
 /// the seam. A transport failure is [`ProviderError::Unreachable`]; a non-2xx is
 /// [`ProviderError::Rejected`].
 pub async fn test_connection(
     config: &ByoIpfsConfig,
     http: &impl Http,
 ) -> Result<(), ProviderError> {
-    validate_endpoint(&config.endpoint)?;
+    validate_byo_config(config)?;
     let request = probe_request(config);
     let response = http
         .send(request)
@@ -112,35 +127,110 @@ pub async fn test_connection(
     }
 }
 
-/// Require an absolute `http(s)` URL with a non-empty host before the endpoint
-/// reaches the Http seam. A lightweight scheme+authority check (the engine has
-/// no URL parser): it rejects other schemes (`file:`, `ftp:`, …), scheme-less or
-/// relative strings, and a hostless `http:///path`, closing the
-/// scheme-exfiltration / SSRF surface a raw member string would open.
+/// The one gate over a member's BYO config, run before anything it names
+/// reaches the Http seam (blueprint/engine.md "Content plane"). A member types
+/// this config, but the vault settings record also carries it back off the
+/// network, so the same bar applies in both directions.
+pub fn validate_byo_config(config: &ByoIpfsConfig) -> Result<(), ProviderError> {
+    validate_endpoint(&config.endpoint)?;
+    match &config.access_token {
+        // The token is spliced into a header value verbatim, so it may carry
+        // only the bytes one admits — a control character would inject a header.
+        Some(token) if !token.bytes().all(is_header_value_byte) => {
+            Err(ProviderError::InvalidCredential)
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Require an absolute `http(s)` URL whose authority is a host and optional
+/// port, then hold the host to the transport and address policy. A lightweight
+/// scheme+authority check (the engine has no URL parser): it rejects other
+/// schemes (`file:`, `ftp:`, …), scheme-less or relative strings, and a hostless
+/// `http:///path`, closing the scheme-exfiltration / SSRF surface a raw member
+/// string would open.
 ///
-/// The authority is additionally restricted to the bytes a host and port may
-/// contain. A member types this string, but the vault settings record also
-/// carries it back off the network, and it is spliced into a request URL: an
-/// endpoint carrying whitespace, a control character, or URL syntax (`@`, `?`,
-/// `#`, `\`) could reshape the request target or inject a header, and which one
-/// happens would depend on the host `Http` implementation. That decision does
-/// not belong to the seam.
-pub fn validate_endpoint(endpoint: &str) -> Result<(), ProviderError> {
+/// The endpoint is spliced into a request URL, so the authority is restricted to
+/// the bytes a host and port may contain: whitespace, a control character, or
+/// URL syntax (`@`, `?`, `#`, `\`) could reshape the request target or inject a
+/// header, and which one happens would depend on the host `Http` implementation.
+/// That decision does not belong to the seam.
+fn validate_endpoint(endpoint: &str) -> Result<(), ProviderError> {
     let lower = endpoint.to_ascii_lowercase();
-    let authority = lower
-        .strip_prefix("https://")
-        .or_else(|| lower.strip_prefix("http://"))
-        .ok_or(ProviderError::InvalidEndpoint)?;
+    let (tls, authority) = match lower.strip_prefix("https://") {
+        Some(rest) => (true, rest),
+        None => (
+            false,
+            lower
+                .strip_prefix("http://")
+                .ok_or(ProviderError::InvalidEndpoint)?,
+        ),
+    };
     // A host must follow the scheme (not empty, not straight into a path).
-    let host = authority.split('/').next().unwrap_or_default();
-    if host.is_empty() || !host.bytes().all(is_authority_byte) {
+    let host_port = authority.split('/').next().unwrap_or_default();
+    if host_port.is_empty() || !host_port.bytes().all(is_authority_byte) {
         return Err(ProviderError::InvalidEndpoint);
     }
     // The path may still not carry URL syntax that reshapes the target.
     if authority.bytes().any(|b| !is_path_byte(b)) {
         return Err(ProviderError::InvalidEndpoint);
     }
+    let host = host_of(host_port)?;
+    if is_metadata_literal(host) {
+        return Err(ProviderError::BlockedAddress);
+    }
+    if !tls && !is_loopback_literal(host) {
+        return Err(ProviderError::InsecureTransport);
+    }
     Ok(())
+}
+
+/// The host of a `host`, `host:port`, `[v6]` or `[v6]:port` authority. Fail
+/// closed: an authority that does not split cleanly is refused, never guessed,
+/// because everything downstream keys off the host it yields.
+fn host_of(authority: &str) -> Result<&str, ProviderError> {
+    let bad = || ProviderError::InvalidEndpoint;
+    let (host, port) = match authority.strip_prefix('[') {
+        Some(rest) => {
+            let (host, tail) = rest.split_once(']').ok_or_else(bad)?;
+            // A bracketed authority holds an IPv6 literal and nothing else.
+            host.parse::<Ipv6Addr>().map_err(|_| bad())?;
+            match tail {
+                "" => (host, None),
+                _ => (host, Some(tail.strip_prefix(':').ok_or_else(bad)?)),
+            }
+        }
+        None => {
+            let (host, port) = match authority.split_once(':') {
+                Some((host, port)) => (host, Some(port)),
+                None => (authority, None),
+            };
+            if host.is_empty() || host.contains(['[', ']']) {
+                return Err(bad());
+            }
+            (host, port)
+        }
+    };
+    if port.is_some_and(|p| p.parse::<u16>().is_err()) {
+        return Err(bad());
+    }
+    Ok(host)
+}
+
+/// Loopback decided from the literal alone. The engine has no resolver and does
+/// not acquire one for this: a name's address is the host's to resolve at
+/// request time, so a resolved verdict here would be a TOCTOU hole.
+fn is_loopback_literal(host: &str) -> bool {
+    host == "localhost"
+        || host.parse::<Ipv4Addr>().is_ok_and(|ip| ip.is_loopback())
+        || host.parse::<Ipv6Addr>().is_ok_and(|ip| ip.is_loopback())
+}
+
+fn is_metadata_literal(host: &str) -> bool {
+    host.parse::<Ipv4Addr>().is_ok_and(|ip| ip == METADATA_V4)
+        || host
+            .parse::<Ipv6Addr>()
+            .is_ok_and(|ip| ip == METADATA_V6 || ip.to_ipv4() == Some(METADATA_V4))
 }
 
 /// The bytes a host-and-port may contain: letters, digits, `-`, `.`, `:`, plus
@@ -154,6 +244,11 @@ fn is_authority_byte(b: u8) -> bool {
 /// (`@`, `?`, `#`, `\`) or that no URL may carry raw (controls, whitespace).
 fn is_path_byte(b: u8) -> bool {
     is_authority_byte(b) || matches!(b, b'/' | b'_' | b'~' | b'%' | b'+' | b'=' | b'&' | b',')
+}
+
+/// The bytes an HTTP field value admits: visible ASCII plus space and tab.
+fn is_header_value_byte(b: u8) -> bool {
+    matches!(b, 0x20 | 0x09 | 0x21..=0x7e)
 }
 
 /// The per-kind reachability probe. The endpoints are each provider's standard
@@ -270,25 +365,47 @@ mod tests {
     }
 
     #[test]
-    fn a_non_http_or_hostless_endpoint_is_rejected_before_any_request() {
+    fn an_endpoint_outside_the_policy_is_rejected_before_any_request() {
+        use ProviderError::{BlockedAddress, InsecureTransport, InvalidEndpoint};
+
         let http = ScriptedHttp::default();
-        for bad in [
-            "file:///etc/passwd",
-            "ftp://host/x",
-            "ipfs.member.test", // no scheme
-            "http://",          // no host
-            "https:///pins",    // hostless
-            "",
+        for (bad, verdict) in [
+            ("file:///etc/passwd", InvalidEndpoint),
+            ("ftp://host/x", InvalidEndpoint),
+            ("ipfs.member.test", InvalidEndpoint), // no scheme
+            ("http://", InvalidEndpoint),          // no host
+            ("https:///pins", InvalidEndpoint),    // hostless
+            ("", InvalidEndpoint),
             // A record-sourced endpoint is spliced into a request URL, so the
             // authority may carry only host-and-port bytes: no control
             // characters, no whitespace, and no syntax that redirects the
             // target or injects a header.
-            "http://host\r\nX-Evil: 1",
-            "http://host with space",
-            "http://user@evil.test",
-            "http://host/path?query",
-            "http://host/path#frag",
-            "http://host\\evil.test",
+            ("http://host\r\nX-Evil: 1", InvalidEndpoint),
+            ("http://host with space", InvalidEndpoint),
+            ("http://user@evil.test", InvalidEndpoint),
+            ("http://host/path?query", InvalidEndpoint),
+            ("http://host/path#frag", InvalidEndpoint),
+            ("http://host\\evil.test", InvalidEndpoint),
+            // An authority that does not split into host and port is refused
+            // rather than guessed at, because the policy below keys off the host.
+            ("http://[::1", InvalidEndpoint),
+            ("http://[kubo.example]", InvalidEndpoint),
+            ("http://[::1]x", InvalidEndpoint),
+            ("http://::1:5001", InvalidEndpoint),
+            ("https://kubo.example:no", InvalidEndpoint),
+            ("https://kubo.example:99999", InvalidEndpoint),
+            // Plaintext carries the bearer in the clear: only a literal
+            // loopback host may use it, and a name is never one.
+            ("http://kubo.example", InsecureTransport),
+            ("http://127.0.0.1.evil.test", InsecureTransport),
+            ("http://localhost.evil.test", InsecureTransport),
+            ("http://192.168.1.9:5001", InsecureTransport),
+            // The cloud metadata service, under either scheme and in the IPv6
+            // spellings of the same address.
+            ("http://169.254.169.254", BlockedAddress),
+            ("https://169.254.169.254/pins", BlockedAddress),
+            ("https://[::ffff:169.254.169.254]", BlockedAddress),
+            ("https://[fd00:ec2::254]", BlockedAddress),
         ] {
             let cfg = ByoIpfsConfig {
                 endpoint: bad.into(),
@@ -297,27 +414,67 @@ mod tests {
             };
             assert_eq!(
                 block_on(test_connection(&cfg, &http)).unwrap_err(),
-                ProviderError::InvalidEndpoint,
+                verdict,
                 "{bad:?} must be rejected"
             );
         }
         assert!(
             http.requests().is_empty(),
-            "an invalid endpoint never reaches the seam"
+            "a refused endpoint never reaches the seam"
         );
     }
 
     #[test]
     fn a_local_http_kubo_endpoint_is_allowed() {
+        for host in [
+            "127.0.0.1:5001",
+            "127.1.2.3:5001",
+            "localhost:5001",
+            "[::1]",
+        ] {
+            let http = ScriptedHttp::default();
+            http.enqueue_response(ok());
+            let cfg = ByoIpfsConfig {
+                endpoint: format!("http://{host}"),
+                kind: ByoKind::Kubo,
+                access_token: None,
+            };
+            block_on(test_connection(&cfg, &http)).unwrap();
+            assert_eq!(http.requests()[0].url, format!("http://{host}/api/v0/id"));
+        }
+    }
+
+    #[test]
+    fn a_private_range_endpoint_over_tls_is_allowed() {
         let http = ScriptedHttp::default();
         http.enqueue_response(ok());
         let cfg = ByoIpfsConfig {
-            endpoint: "http://127.0.0.1:5001".into(),
+            endpoint: "https://192.168.1.9:5001".into(),
             kind: ByoKind::Kubo,
             access_token: None,
         };
         block_on(test_connection(&cfg, &http)).unwrap();
-        assert_eq!(http.requests()[0].url, "http://127.0.0.1:5001/api/v0/id");
+    }
+
+    #[test]
+    fn an_access_token_that_could_inject_a_header_is_refused() {
+        let http = ScriptedHttp::default();
+        for bad in ["tok\r\nX-Evil: 1", "tok\n", "tok\u{7f}"] {
+            let cfg = ByoIpfsConfig {
+                endpoint: "https://ipfs.member.test".into(),
+                kind: ByoKind::Psa,
+                access_token: Some(Zeroizing::new(bad.to_owned())),
+            };
+            assert_eq!(
+                block_on(test_connection(&cfg, &http)).unwrap_err(),
+                ProviderError::InvalidCredential,
+                "{bad:?} must be rejected"
+            );
+        }
+        assert!(
+            http.requests().is_empty(),
+            "a refused credential never reaches the seam"
+        );
     }
 
     #[test]

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -54,7 +54,7 @@ pub use content::{
     GatewaySource, PinMode, ProviderError, PrunePlan, QuotaExceeded, ROOT_FORMAT_VERSION,
     ReadError, RetentionPolicy, RootManifest, SealError, SealedChunk, SealedContent, assemble,
     decode_root, frame_and_seal, leaf_range_for_byte_range, plan_prune, pre_flight_quota_check,
-    read_block, seal_one_chunk, test_connection, validate_endpoint,
+    read_block, seal_one_chunk, test_connection, validate_byo_config,
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{

--- a/crates/engine/src/seams/http.rs
+++ b/crates/engine/src/seams/http.rs
@@ -129,6 +129,11 @@ impl fmt::Debug for HttpResponse {
 /// Non-2xx statuses are responses, not errors — a seam `Err` is reserved
 /// for transport-level failure (unreachable, aborted).
 ///
+/// One obligation the transport owns: a request the engine sent over `https`
+/// must not be replayed over `http` by following a redirect, or an
+/// `Authorization` header would reach the clear network past the engine's
+/// transport decision (blueprint/engine.md "Content plane").
+///
 /// No conformance kit ships for this seam: it has no seam-local durable
 /// semantics; its behavior is exercised end-to-end by the live contract
 /// suite (blueprint/testing.md).

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -70,7 +70,7 @@ impl Default for VaultSettings {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SettingsPublishError {
     /// The BYO config is not one the Http seam may be pointed at.
-    Endpoint(ProviderError),
+    Byo(ProviderError),
     /// Core refused to encode or seal the body.
     Codec(CodecError),
     /// The host could not supply the per-record HPKE ephemeral scalar.
@@ -156,7 +156,7 @@ where
     F: FloorStore,
     Sch: Scheduler + Clone + 'static,
 {
-    validate(settings).map_err(SettingsPublishError::Endpoint)?;
+    validate(settings).map_err(SettingsPublishError::Byo)?;
     let body = encode_settings_body(settings).map_err(SettingsPublishError::Codec)?;
     let mut ephemeral = Zeroizing::new([0u8; 32]);
     entropy
@@ -330,7 +330,7 @@ enum BodyError {
     /// network input naming a host the engine will later talk to, so it clears
     /// the same bar as a member-typed config (AGENTS.md rule 8: the encode
     /// path refuses the same value, release-active).
-    Endpoint(ProviderError),
+    Byo(ProviderError),
 }
 
 impl From<CodecError> for BodyError {
@@ -401,7 +401,7 @@ fn decode_settings_body(bytes: &[u8]) -> Result<VaultSettings, BodyError> {
     // every exit, including the early returns a malformed body takes.
     tree.zeroize_bytes();
     let settings = decoded?;
-    validate(&settings).map_err(BodyError::Endpoint)?;
+    validate(&settings).map_err(BodyError::Byo)?;
     Ok(settings)
 }
 
@@ -623,7 +623,7 @@ mod tests {
             assert_eq!(
                 decode_settings_body(&encode_settings_body(&settings).expect("encode"))
                     .unwrap_err(),
-                BodyError::Endpoint(refused),
+                BodyError::Byo(refused),
                 "{endpoint}: the reader must refuse what the writer refuses",
             );
         }

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -31,7 +31,7 @@ use cipherbox_core::suite::x25519::X25519Secret;
 use zeroize::Zeroizing;
 
 use crate::api::ApiClient;
-use crate::content::validate_endpoint;
+use crate::content::validate_byo_config;
 use crate::content::{ByoIpfsConfig, ByoKind, Gateway, PinMode, ProviderError, RetentionPolicy};
 use crate::entropy::{Entropy, EntropyError};
 use crate::gate::floor;
@@ -69,7 +69,7 @@ impl Default for VaultSettings {
 /// fail-closed: nothing is published.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SettingsPublishError {
-    /// The BYO endpoint is not one the Http seam may be pointed at.
+    /// The BYO config is not one the Http seam may be pointed at.
     Endpoint(ProviderError),
     /// Core refused to encode or seal the body.
     Codec(CodecError),
@@ -326,9 +326,9 @@ enum BodyError {
     /// the live version along with its history. Unrepresentable on the encode
     /// side ([`RetentionPolicy::KeepLatest`] takes a [`NonZeroU64`]).
     RetainsNoVersions,
-    /// A BYO endpoint the Http seam may not be pointed at. A resolved record is
+    /// A BYO config the Http seam may not be pointed at. A resolved record is
     /// network input naming a host the engine will later talk to, so it clears
-    /// the same bar as a member-typed endpoint (AGENTS.md rule 8: the encode
+    /// the same bar as a member-typed config (AGENTS.md rule 8: the encode
     /// path refuses the same value, release-active).
     Endpoint(ProviderError),
 }
@@ -350,7 +350,7 @@ impl From<Malformed> for BodyError {
 /// would refuse to read back.
 fn validate(settings: &VaultSettings) -> Result<(), ProviderError> {
     match &settings.byo {
-        Some(byo) => validate_endpoint(&byo.endpoint),
+        Some(byo) => validate_byo_config(byo),
         None => Ok(()),
     }
 }
@@ -541,7 +541,7 @@ mod tests {
         let bare = VaultSettings::default();
         assert_eq!(round_trip(&bare), bare);
         let tokenless = VaultSettings {
-            byo: Some(byo("http://node.example", ByoKind::Kubo, None)),
+            byo: Some(byo("http://127.0.0.1:5001", ByoKind::Kubo, None)),
             ..VaultSettings::default()
         };
         assert_eq!(round_trip(&tokenless), tokenless);
@@ -602,18 +602,24 @@ mod tests {
         );
     }
 
-    /// The endpoint half: one predicate, both directions. The encode guard is
+    /// The BYO half: one predicate, both directions. The encode guard is
     /// release-active (`publish_settings` returns `Err`), and the reader reaches
     /// the same verdict on bytes hand-sealed past it.
     #[test]
-    fn an_endpoint_the_seam_may_not_be_pointed_at_is_refused_on_both_sides() {
-        for endpoint in ["file:///etc/passwd", "ftp://node.example", "node.example"] {
+    fn a_byo_config_the_seam_may_not_be_pointed_at_is_refused_on_both_sides() {
+        for (endpoint, token) in [
+            ("file:///etc/passwd", None),
+            ("ftp://node.example", None),
+            ("node.example", None),
+            ("http://node.example", None),
+            ("https://169.254.169.254", None),
+            ("https://node.example", Some("tok\r\nX-Evil: 1")),
+        ] {
             let settings = VaultSettings {
-                byo: Some(byo(endpoint, ByoKind::Kubo, None)),
+                byo: Some(byo(endpoint, ByoKind::Kubo, token)),
                 ..VaultSettings::default()
             };
             let refused = validate(&settings).unwrap_err();
-            assert_eq!(refused, ProviderError::InvalidEndpoint);
             assert_eq!(
                 decode_settings_body(&encode_settings_body(&settings).expect("encode"))
                     .unwrap_err(),

--- a/crates/engine/tests/vault_settings.rs
+++ b/crates/engine/tests/vault_settings.rs
@@ -682,7 +682,7 @@ fn settings_the_reader_would_refuse_are_never_published() {
         ));
         assert_eq!(
             outcome.unwrap_err(),
-            SettingsPublishError::Endpoint(verdict),
+            SettingsPublishError::Byo(verdict),
             "the guard returns Err in every build, never a stripped assertion",
         );
         assert!(

--- a/crates/engine/tests/vault_settings.rs
+++ b/crates/engine/tests/vault_settings.rs
@@ -652,8 +652,15 @@ fn settings_the_reader_would_refuse_are_never_published() {
         "http://api.test",
     );
 
-    // A scheme the Http seam must never be pointed at.
-    for endpoint in ["file:///etc/passwd", "ftp://node.example"] {
+    // Endpoints the Http seam must never be pointed at: a foreign scheme, and
+    // the two policy refusals — plaintext to a non-loopback host, and the cloud
+    // metadata address.
+    for (endpoint, verdict) in [
+        ("file:///etc/passwd", ProviderError::InvalidEndpoint),
+        ("ftp://node.example", ProviderError::InvalidEndpoint),
+        ("http://node.example", ProviderError::InsecureTransport),
+        ("https://169.254.169.254", ProviderError::BlockedAddress),
+    ] {
         let settings = VaultSettings {
             byo: Some(ByoIpfsConfig {
                 endpoint: endpoint.to_owned(),
@@ -675,7 +682,7 @@ fn settings_the_reader_would_refuse_are_never_published() {
         ));
         assert_eq!(
             outcome.unwrap_err(),
-            SettingsPublishError::Endpoint(ProviderError::InvalidEndpoint),
+            SettingsPublishError::Endpoint(verdict),
             "the guard returns Err in every build, never a stripped assertion",
         );
         assert!(
@@ -712,17 +719,16 @@ fn a_body_carrying_a_refused_endpoint_is_rejected_on_the_way_back_in() {
     ));
 
     // Hand-sealed past the encode guard: the decode side must refuse the same
-    // invariant, or a resolved record could point the engine at any URL.
-    seed_settings(
-        &device,
-        &blocks,
-        &hand_encoded_body("file:///etc/passwd"),
-        2,
-    );
-    assert_eq!(
-        load(&world, &device, &blocks, &SECRET),
-        SettingsLoad::Defaults(DefaultsReason::Unreadable),
-    );
+    // invariant, or a resolved record could point the engine at any URL — or at
+    // a public host over plaintext, putting the member's bearer on the wire.
+    for (sequence, endpoint) in [(2, "file:///etc/passwd"), (3, "http://kubo.example")] {
+        seed_settings(&device, &blocks, &hand_encoded_body(endpoint), sequence);
+        assert_eq!(
+            load(&world, &device, &blocks, &SECRET),
+            SettingsLoad::Defaults(DefaultsReason::Unreadable),
+            "{endpoint}",
+        );
+    }
 }
 
 /// A settings body built straight in core's codec, bypassing the encode guard.


### PR DESCRIPTION
Settles the two policy questions #870 left open on the BYO provider gate, and writes the result into `blueprint/engine.md`'s content-plane section so it stops being folklore.

## The policy

One gate, `validate_byo_config`, over the whole BYO config — applied identically to a member-typed config and to one resolved back off the network, release-active on the encode side so nothing is published the reader would refuse.

- **Transport**: `https` is required unless the host is a loopback address (`127.0.0.0/8`, `::1`) or the name RFC 6761 reserves for one (`localhost`). The probe attaches `Authorization: Bearer <token>`, so plaintext to anything else puts the member's credential on the wire. Loopback is decided from the literal alone — the engine has no resolver, does not acquire one, and a resolved verdict would be TOCTOU as well.
- **Addresses**: private and link-local ranges stay allowed, because self-hosting on a LAN is the feature. The cloud-metadata address is refused outright under either scheme — `169.254.169.254`, the IPv6 spellings of it, and `fd00:ec2::254` — since no IPFS provider serves it.
- **Legibility**: each refusal is its own `ProviderError` verdict, so `test_connection` tells a host which rule bit rather than showing a bare failure. `InsecureTransport`, `BlockedAddress` and `InvalidCredential` join `InvalidEndpoint`; the settings wrappers are renamed `Endpoint` to `Byo` to match what they now carry.

## What the review gates added

- A host this gate would read as a name while the transport's URL parser would read it as an address — `0xa9fea9fe`, `2852039166`, `0251.0376.0251.0376`, a trailing-dot quad — is refused rather than classified twice. That closes the numeric spellings of the metadata address at the same time.
- The access token is an input to the same gate: it is spliced verbatim into a header value, so it is held to visible ASCII and may not be empty. A record-sourced token carrying CRLF would otherwise inject a header.
- The desktop transport no longer follows a redirect that downgrades `https` to `http`; a downgrade surfaces as the 3xx it is. Without it the credential reaches the clear network past the engine's transport decision, since reqwest 0.12's sensitive-header strip compares host and port but not scheme. Stated as an obligation on the `Http` seam.

The metadata refusal is a legibility rule, not an SSRF containment boundary — a resolver would be needed for that, and the blueprint says so rather than over-claiming.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check --workspace --all-targets`, `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets`, and `cargo test -p cipherbox-engine` all pass. Each new assertion was verified to bite by deliberately breaking the rule it covers and confirming the specific failure.

Closes #905


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added stronger validation for custom IPFS endpoints and access tokens.
  * Blocked unsafe cloud-metadata addresses, ambiguous hosts, unsupported schemes, and insecure public connections.
  * Prevented HTTPS requests from being redirected to HTTP.

* **Bug Fixes**
  * Improved handling of invalid provider configurations with clearer validation errors.
  * Added safeguards for DNS resolution and IPv4-mapped addresses.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->