### PR TITLE
feat(engine): prefer last-known-good vault settings over defaults on a degraded load

### DIFF
--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -188,6 +188,37 @@ name → envelope grant blob → seeds → render. Residual, honestly scoped
 epochs (which revoke nobody — pure staleness) plus within-epoch staleness;
 revocation boundaries cannot be rolled back.
 
+## Vault settings load
+
+The vault settings record (`CONTEXT.md`) resolves at cold start, ahead of any
+vault resolve, and never blocks it: every failure degrades inside the sync
+timing profile's settings budget, measured on the Scheduler seam. What it
+degrades _to_ is a trust decision, because unlike every other resolve its
+degraded outcome applies a different policy rather than showing stale data.
+
+- **Last-known-good before defaults.** The head block of a settings record
+  that cleared its sequence floor and opened is cached in `SnapshotCache` —
+  ciphertext only, like every other value in that store. A degraded load
+  prefers that copy over the built-in defaults and reports it as stale
+  alongside the reason it degraded. Being cached buys the bytes nothing: the
+  copy clears the same seal open and the same body grammar a freshly fetched
+  head block does, or it is discarded.
+- **A degraded load never widens placement.** Withholding the record, running
+  the budget out, making its head block unreadable, or failing the floor read
+  must not move a member from `External` onto CipherBox's hosted store.
+  Reverting an explicit placement choice to the hosted default is precisely
+  what an adversary who controls the record plane gains, so a load that cannot
+  authenticate the member's current choice must not invent a wider one.
+- **No last-known-good copy fails the placement decision closed.** The
+  built-in defaults describe a first run — no record anywhere, no durable
+  floor. Under any other reason, with no cached copy to fall back on, a
+  placement decision refuses the hosted upload rather than resolving to
+  `PinMode::Hosted`; the member is told their settings are unavailable.
+- **Residual.** The cached copy is bound to the account by its seal, not to a
+  point in time: a party who can write this device's durable store can replay
+  an older copy the account itself authored. Bounding that needs a freshness
+  anchor the settings body does not carry today.
+
 ## Sync core
 
 One model, two trigger sources (#33 D2): web drives it from navigation and the

--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -208,16 +208,34 @@ degraded outcome applies a different policy rather than showing stale data.
   must not move a member from `External` onto CipherBox's hosted store.
   Reverting an explicit placement choice to the hosted default is precisely
   what an adversary who controls the record plane gains, so a load that cannot
-  authenticate the member's current choice must not invent a wider one.
+  authenticate the member's current choice must not invent a wider one. The
+  guarantee is relative to this device: the widest placement a degraded load
+  can report is the one this device last authenticated, never the built-in
+  default. A rollback takes the same path — pinning last-known-good is what
+  the gate already owes a rejected record.
 - **No last-known-good copy fails the placement decision closed.** The
   built-in defaults describe a first run — no record anywhere, no durable
   floor. Under any other reason, with no cached copy to fall back on, a
   placement decision refuses the hosted upload rather than resolving to
-  `PinMode::Hosted`; the member is told their settings are unavailable.
-- **Residual.** The cached copy is bound to the account by its seal, not to a
-  point in time: a party who can write this device's durable store can replay
-  an older copy the account itself authored. Bounding that needs a freshness
-  anchor the settings body does not carry today.
+  `PinMode::Hosted`; the member is told their settings are unavailable. A
+  consumer that branches only on the resolved case, letting the degraded ones
+  fall through to the defaults, reintroduces exactly the widening this policy
+  exists to prevent.
+- **Residual: the cached copy has no freshness bound.** It is bound to the
+  account by its seal alone — no sequence, no name, no time — so a party who
+  can write this device's durable store can pin it to any settings generation
+  the account ever published; every historical head block is a public,
+  content-addressed object, so only the store write is privileged. The
+  per-name sequence floor is no defence here: it is device-local and lives
+  beside the cache, so the same party moves both. That party can equally
+  _delete_ the entry and force the defaults path, which is the pre-cache
+  behaviour — so the anti-downgrade property holds against a record-plane
+  adversary, not against one already inside the device's storage. The same
+  staleness arrives with no adversary at all: a device stuck degraded keeps
+  its copy indefinitely, including a BYO credential the member has since
+  rotated, which is why the reason is reported rather than swallowed. A real
+  bound needs a per-account anchor — an EOL check or a monotonic revision in
+  the sealed body — neither of which the settings record carries today.
 
 ## Sync core
 

--- a/crates/engine/src/profile.rs
+++ b/crates/engine/src/profile.rs
@@ -38,8 +38,9 @@ pub struct SyncTimingProfile {
     /// bounds the read-only-survivor residual.
     pub pointer_consult_interval: Duration,
     /// Ceiling on the vault settings load. A settings record that will not
-    /// resolve must never block cold start, so the load yields the documented
-    /// defaults once this elapses (v1's 10 s, carried forward).
+    /// resolve must never block cold start, so once this elapses the load
+    /// yields the device's last-known-good settings, or the documented defaults
+    /// where it has none (v1's 10 s, carried forward).
     pub settings_load_budget: Duration,
 }
 

--- a/crates/engine/src/seams/snapshot_cache.rs
+++ b/crates/engine/src/seams/snapshot_cache.rs
@@ -9,8 +9,9 @@ use super::SeamResult;
 /// (blueprint/web-client.md seam table). The store must treat values as
 /// opaque: arbitrary, non-decodable bytes round-trip verbatim; the
 /// conformance kit feeds it garbage to prove the store never requires
-/// parseable content. Only gate-passing records ever reach this cache — the
-/// adoption gate runs upstream, in the engine.
+/// parseable content. Nothing unauthenticated ever reaches this cache: the
+/// record plane writes only gate-passing records, the settings plane only a
+/// head block that cleared its sequence floor and opened.
 ///
 /// Keys are opaque bytes chosen by the engine. Contents survive logout by
 /// design (cache-first rendering after restart); an explicit

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -11,12 +11,11 @@
 //!
 //! **A settings record that will not resolve never blocks cold start.** A
 //! degraded load prefers this device's last-known-good copy and only then
-//! [`VaultSettings::default`], each step bounded by
+//! [`VaultSettings::default`], and the whole load is bounded by
 //! [`SyncTimingProfile::settings_load_budget`] measured on the injected
 //! scheduler. The reason is reported rather than swallowed
 //! ([`DefaultsReason`]) — silently reverting a member's placement choice to the
-//! hosted default is what an adversary who can withhold the record gains, so a
-//! degraded load never widens placement (blueprint/engine.md).
+//! hosted default is what an adversary who can withhold the record gains.
 
 use core::future::{Future, poll_fn};
 use core::num::NonZeroU64;
@@ -91,16 +90,17 @@ pub enum SettingsPublishError {
     Floor(SeamError),
 }
 
-/// Why a load fell back to [`VaultSettings::default`]. Reported rather than
-/// collapsed, because the reasons are not equally benign: `NoRecord` is a
-/// first run, while `Suppressed` and `RolledBack` are what an adversary who
-/// controls the record plane produces, and reverting a member's placement
-/// choice to the hosted default is exactly what they gain by it.
+/// Why a load did not use the published record, carried by both degraded
+/// outcomes. Reported rather than collapsed, because the reasons are not
+/// equally benign: `NoRecord` is a first run, while `Suppressed` and
+/// `RolledBack` are what an adversary who controls the record plane produces,
+/// and reverting a member's placement choice to the hosted default is exactly
+/// what they gain by it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DefaultsReason {
     /// No endpoint served a record, and this device has no durable floor for
-    /// the name — the account has never published settings from anywhere this
-    /// device has seen.
+    /// the name — no evidence here that the account has ever published
+    /// settings.
     NoRecord,
     /// No usable record, but the durable sequence floor proves one was adopted
     /// here before: the record is being withheld or its head block is
@@ -136,10 +136,9 @@ pub enum SettingsLoad {
         /// Why the published record was not used.
         reason: DefaultsReason,
     },
-    /// Neither a published record nor a cached one. The documented defaults
-    /// describe a first run; a placement decision taken under any other reason
-    /// fails closed rather than resolving to [`PinMode::Hosted`]
-    /// (blueprint/engine.md).
+    /// Neither a published record nor a cached one: nothing here is the
+    /// member's choice, only the documented defaults. What a placement decision
+    /// owes this outcome is the settings-load policy in blueprint/engine.md.
     Defaults(DefaultsReason),
 }
 
@@ -222,7 +221,7 @@ where
     Ok(receipt)
 }
 
-/// Resolve the vault settings record, each stage bounded by
+/// Resolve the vault settings record, bounded by
 /// [`SyncTimingProfile::settings_load_budget`]. Never fails: a record that will
 /// not resolve, will not open, or will not validate degrades to this device's
 /// last-known-good settings and only then to the documented defaults, because
@@ -247,33 +246,27 @@ where
 {
     let name = settings_name(login_secret);
     let enc_secret = kdf::enc_subkey(login_secret);
-    let budget = profile.settings_load_budget;
+    // Held outside the budget so a load that runs out of it mid-resolve still
+    // has the cached ciphertext the resolve read on its way in.
+    let mut cached = None;
     let load = resolve_settings(
         transport,
         gateway,
         http,
         floors,
         snapshots,
+        &mut cached,
         &enc_secret,
         &name,
     );
-    let loaded = within(scheduler, budget, load)
-        .await
-        .unwrap_or(SettingsLoad::Defaults(DefaultsReason::TimedOut));
-    let SettingsLoad::Defaults(reason) = loaded else {
-        return loaded;
+    let reason = match within(scheduler, profile.settings_load_budget, load).await {
+        Some(Ok(settings)) => return SettingsLoad::Resolved(settings),
+        Some(Err(reason)) => reason,
+        None => DefaultsReason::TimedOut,
     };
-    // Every degraded reason takes this arm: whichever way the published record
-    // became unusable, the settings this device last resolved outrank the
-    // hosted defaults, and reaching for them must not outlast the budget either.
-    match within(
-        scheduler,
-        budget,
-        last_known_good(snapshots, &enc_secret, &name),
-    )
-    .await
-    .flatten()
-    {
+    // A rollback takes this arm like every other reason: pinning last-known-good
+    // is what the record plane already owes a gate failure (blueprint/engine.md).
+    match cached.and_then(|block| open_settings_head(&enc_secret, &block)) {
         Some(settings) => SettingsLoad::Stale { settings, reason },
         None => SettingsLoad::Defaults(reason),
     }
@@ -288,29 +281,25 @@ fn settings_cache_key(name: &IpnsName) -> Vec<u8> {
     key
 }
 
-/// Re-open this device's cached settings head block. Being cached buys the
-/// bytes nothing: they clear the same seal and the same body grammar a freshly
-/// fetched block does, so a copy this build cannot authenticate is discarded
-/// rather than applied.
-async fn last_known_good<Sn: SnapshotCache>(
-    snapshots: &Sn,
-    enc_secret: &X25519Secret,
-    name: &IpnsName,
-) -> Option<VaultSettings> {
-    let block = snapshots.get(&settings_cache_key(name)).await.ok()??;
-    let body = open_settings_record(enc_secret, &block).ok()?;
-    decode_settings_body(&body).ok()
+/// Open a settings head block. Being cached buys bytes nothing — the cached and
+/// the fetched copy reach their verdict here, through one seal open and one
+/// body grammar — so a copy this build cannot authenticate is discarded rather
+/// than applied.
+fn open_settings_head(enc_secret: &X25519Secret, block: &[u8]) -> Option<VaultSettings> {
+    decode_settings_body(&open_settings_record(enc_secret, block).ok()?).ok()
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn resolve_settings<T, H, F, Sn>(
     transport: &T,
     gateway: &Gateway,
     http: &H,
     floors: &F,
     snapshots: &Sn,
+    cached: &mut Option<Vec<u8>>,
     enc_secret: &X25519Secret,
     name: &IpnsName,
-) -> SettingsLoad
+) -> Result<VaultSettings, DefaultsReason>
 where
     T: RecordTransport,
     H: Http,
@@ -318,44 +307,42 @@ where
     Sn: SnapshotCache,
 {
     let key = name.as_str().as_bytes();
+    let cache_key = settings_cache_key(name);
+    // Cache-first, like every resolve (blueprint/engine.md).
+    *cached = snapshots.get(&cache_key).await.ok().flatten();
     // The settings record belongs to no scope and carries no epoch, so the
     // per-name sequence floor is its whole floor law. A floor the host cannot
     // read is never treated as no floor.
     let Ok(durable) = floor::sequence_floor(floors, key).await else {
-        return SettingsLoad::Defaults(DefaultsReason::FloorUnreadable);
+        return Err(DefaultsReason::FloorUnreadable);
     };
     let Some((sequence, record_bytes)) = fanout_get_verify(transport, name).await else {
         // A durable floor is proof this account has published settings, so
         // finding none now is a suppression rather than a first run.
-        return SettingsLoad::Defaults(match durable {
+        return Err(match durable {
             Some(_) => DefaultsReason::Suppressed,
             None => DefaultsReason::NoRecord,
         });
     };
     let floor = durable.unwrap_or(0);
     if sequence < floor {
-        return SettingsLoad::Defaults(DefaultsReason::RolledBack { floor, sequence });
+        return Err(DefaultsReason::RolledBack { floor, sequence });
     }
 
     // The record verified under a name only this account can sign for, so a
     // head block that will not come back is a withheld settings record.
     let Ok((_, block)) = fetch_head_block(gateway, http, name, &record_bytes, None).await else {
-        return SettingsLoad::Defaults(DefaultsReason::Suppressed);
+        return Err(DefaultsReason::Suppressed);
     };
-    let Ok(body) = open_settings_record(enc_secret, &block) else {
-        return SettingsLoad::Defaults(DefaultsReason::Unreadable);
-    };
-    let Ok(settings) = decode_settings_body(&body) else {
-        return SettingsLoad::Defaults(DefaultsReason::Unreadable);
-    };
+    let settings = open_settings_head(enc_secret, &block).ok_or(DefaultsReason::Unreadable)?;
     // Only a record that cleared its floor and opened becomes last-known-good,
     // and what is stored is the sealed block, so ciphertext-only-at-rest holds.
-    let _ = snapshots.put(&settings_cache_key(name), &block).await;
+    let _ = snapshots.put(&cache_key, &block).await;
     // Advancing behind the open, never ahead of it, is the floor law: a record
     // that will not open must not raise the bar the next resolve is held to.
     // Neither store failing is a verdict on settings we just authenticated.
     let _ = floor::advance_sequence_on_unseal(floors, key, sequence).await;
-    SettingsLoad::Resolved(settings)
+    Ok(settings)
 }
 
 /// Run `work`, giving up once `budget` has elapsed on the injected scheduler.

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -99,8 +99,8 @@ pub enum SettingsPublishError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DefaultsReason {
     /// No endpoint served a record, and this device has no durable floor for
-    /// the name — no evidence here that the account has ever published
-    /// settings.
+    /// the name. Floor evidence only: a cached last-known-good block can
+    /// accompany this, since the floor advance is not gated on the cache write.
     NoRecord,
     /// No usable record, but the durable sequence floor proves one was adopted
     /// here before: the record is being withheld or its head block is
@@ -308,7 +308,8 @@ where
 {
     let key = name.as_str().as_bytes();
     let cache_key = settings_cache_key(name);
-    // Cache-first, like every resolve (blueprint/engine.md).
+    // Read ahead of the resolve so a degraded outcome has last-known-good to
+    // fall back on; the cache never short-circuits the fetch.
     *cached = snapshots.get(&cache_key).await.ok().flatten();
     // The settings record belongs to no scope and carries no epoch, so the
     // per-name sequence floor is its whole floor law. A floor the host cannot

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -9,12 +9,14 @@
 //! server-free; the head block still comes from the gateway set, and publishing
 //! still traverses registration like every other record.
 //!
-//! **A settings record that will not resolve never blocks cold start.** Every
-//! failure degrades to [`VaultSettings::default`], and the whole load is
-//! bounded by [`SyncTimingProfile::settings_load_budget`] measured on the
-//! injected scheduler. The reason is reported rather than swallowed
+//! **A settings record that will not resolve never blocks cold start.** A
+//! degraded load prefers this device's last-known-good copy and only then
+//! [`VaultSettings::default`], each step bounded by
+//! [`SyncTimingProfile::settings_load_budget`] measured on the injected
+//! scheduler. The reason is reported rather than swallowed
 //! ([`DefaultsReason`]) — silently reverting a member's placement choice to the
-//! hosted default is what an adversary who can withhold the record gains.
+//! hosted default is what an adversary who can withhold the record gains, so a
+//! degraded load never widens placement (blueprint/engine.md).
 
 use core::future::{Future, poll_fn};
 use core::num::NonZeroU64;
@@ -42,7 +44,9 @@ use crate::net::record_publish::{
     PreflightError, RecordPublishError, RecordPublishRequest, preflight_settings, publish_record,
 };
 use crate::profile::SyncTimingProfile;
-use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler, SeamError};
+use crate::seams::{
+    CredentialStore, FloorStore, Http, RecordTransport, Scheduler, SeamError, SnapshotCache,
+};
 
 /// The owner's client configuration, sealed into the vault settings record.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -124,7 +128,18 @@ pub enum DefaultsReason {
 pub enum SettingsLoad {
     /// The published record opened and validated.
     Resolved(VaultSettings),
-    /// No usable record; the documented defaults apply.
+    /// No usable published record, but this device's last-known-good copy
+    /// opened and validated: stale but still the member's own choice.
+    Stale {
+        /// The settings this device last resolved.
+        settings: VaultSettings,
+        /// Why the published record was not used.
+        reason: DefaultsReason,
+    },
+    /// Neither a published record nor a cached one. The documented defaults
+    /// describe a first run; a placement decision taken under any other reason
+    /// fails closed rather than resolving to [`PinMode::Hosted`]
+    /// (blueprint/engine.md).
     Defaults(DefaultsReason),
 }
 
@@ -207,15 +222,18 @@ where
     Ok(receipt)
 }
 
-/// Resolve the vault settings record, bounded by
+/// Resolve the vault settings record, each stage bounded by
 /// [`SyncTimingProfile::settings_load_budget`]. Never fails: a record that will
-/// not resolve, will not open, or will not validate yields the documented
-/// defaults, because cold start must proceed without one.
-pub async fn load_settings<T, H, F, Sch>(
+/// not resolve, will not open, or will not validate degrades to this device's
+/// last-known-good settings and only then to the documented defaults, because
+/// cold start must proceed without one.
+#[allow(clippy::too_many_arguments)]
+pub async fn load_settings<T, H, F, Sn, Sch>(
     transport: &T,
     gateway: &Gateway,
     http: &H,
     floors: &F,
+    snapshots: &Sn,
     scheduler: &Sch,
     profile: &SyncTimingProfile,
     login_secret: &[u8],
@@ -224,21 +242,72 @@ where
     T: RecordTransport,
     H: Http,
     F: FloorStore,
+    Sn: SnapshotCache,
     Sch: Scheduler,
 {
     let name = settings_name(login_secret);
     let enc_secret = kdf::enc_subkey(login_secret);
-    let load = resolve_settings(transport, gateway, http, floors, &enc_secret, &name);
-    within(scheduler, profile.settings_load_budget, load)
+    let budget = profile.settings_load_budget;
+    let load = resolve_settings(
+        transport,
+        gateway,
+        http,
+        floors,
+        snapshots,
+        &enc_secret,
+        &name,
+    );
+    let loaded = within(scheduler, budget, load)
         .await
-        .unwrap_or(SettingsLoad::Defaults(DefaultsReason::TimedOut))
+        .unwrap_or(SettingsLoad::Defaults(DefaultsReason::TimedOut));
+    let SettingsLoad::Defaults(reason) = loaded else {
+        return loaded;
+    };
+    // Every degraded reason takes this arm: whichever way the published record
+    // became unusable, the settings this device last resolved outrank the
+    // hosted defaults, and reaching for them must not outlast the budget either.
+    match within(
+        scheduler,
+        budget,
+        last_known_good(snapshots, &enc_secret, &name),
+    )
+    .await
+    .flatten()
+    {
+        Some(settings) => SettingsLoad::Stale { settings, reason },
+        None => SettingsLoad::Defaults(reason),
+    }
 }
 
-async fn resolve_settings<T, H, F>(
+/// The settings head block's own snapshot-cache key, kept apart from the
+/// record-plane keys [`crate::net::resolve`] writes — those hold record bytes,
+/// this holds the block the record anchors.
+fn settings_cache_key(name: &IpnsName) -> Vec<u8> {
+    let mut key = b"settings-head/".to_vec();
+    key.extend_from_slice(name.as_str().as_bytes());
+    key
+}
+
+/// Re-open this device's cached settings head block. Being cached buys the
+/// bytes nothing: they clear the same seal and the same body grammar a freshly
+/// fetched block does, so a copy this build cannot authenticate is discarded
+/// rather than applied.
+async fn last_known_good<Sn: SnapshotCache>(
+    snapshots: &Sn,
+    enc_secret: &X25519Secret,
+    name: &IpnsName,
+) -> Option<VaultSettings> {
+    let block = snapshots.get(&settings_cache_key(name)).await.ok()??;
+    let body = open_settings_record(enc_secret, &block).ok()?;
+    decode_settings_body(&body).ok()
+}
+
+async fn resolve_settings<T, H, F, Sn>(
     transport: &T,
     gateway: &Gateway,
     http: &H,
     floors: &F,
+    snapshots: &Sn,
     enc_secret: &X25519Secret,
     name: &IpnsName,
 ) -> SettingsLoad
@@ -246,6 +315,7 @@ where
     T: RecordTransport,
     H: Http,
     F: FloorStore,
+    Sn: SnapshotCache,
 {
     let key = name.as_str().as_bytes();
     // The settings record belongs to no scope and carries no epoch, so the
@@ -278,9 +348,12 @@ where
     let Ok(settings) = decode_settings_body(&body) else {
         return SettingsLoad::Defaults(DefaultsReason::Unreadable);
     };
+    // Only a record that cleared its floor and opened becomes last-known-good,
+    // and what is stored is the sealed block, so ciphertext-only-at-rest holds.
+    let _ = snapshots.put(&settings_cache_key(name), &block).await;
     // Advancing behind the open, never ahead of it, is the floor law: a record
-    // that will not open must not raise the bar the next resolve is held to. A
-    // failed raise is host I/O, not a verdict on settings we just authenticated.
+    // that will not open must not raise the bar the next resolve is held to.
+    // Neither store failing is a verdict on settings we just authenticated.
     let _ = floor::advance_sequence_on_unseal(floors, key, sequence).await;
     SettingsLoad::Resolved(settings)
 }

--- a/crates/engine/tests/vault_settings.rs
+++ b/crates/engine/tests/vault_settings.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, Mutex};
 use cipherbox_core::content::{compute_cid, encode_content_cid_str};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
-use cipherbox_core::seal::seal_settings_record;
+use cipherbox_core::seal::{open_settings_record, seal_settings_record};
 use zeroize::Zeroizing;
 
 use cipherbox_engine::api::ApiClient;
@@ -748,6 +748,17 @@ fn a_record_this_build_cannot_read_prefers_the_cached_copy() {
             settings: external_only(),
             reason: DefaultsReason::Unreadable,
         },
+        "the unreadable record is refused and the device's own copy stands in",
+    );
+
+    withhold_the_record(&bob);
+    assert_eq!(
+        load(&world, &bob, &blocks, &SECRET),
+        SettingsLoad::Stale {
+            settings: external_only(),
+            reason: DefaultsReason::Suppressed,
+        },
+        "the refused record never became this device's last-known-good",
     );
 }
 
@@ -810,25 +821,27 @@ impl SnapshotCache for ServesCiphertext {
     }
 }
 
-/// Being cached buys bytes nothing: the copy clears the same seal and the same
-/// body grammar a freshly fetched head block does, or the load falls through to
-/// the defaults.
 #[test]
 fn a_cached_copy_that_does_not_authenticate_is_not_used() {
     let world = FakeWorld::new();
-    let blocks = Blocks::default();
     let device = world.device(b"me");
 
-    // Sealed to another account's enc subkey: verbatim ciphertext, wrong owner.
-    let transplanted = seal_settings_record(
+    // One planted copy per gate the cached bytes must clear: the seal, then
+    // this build's body grammar.
+    let wrong_owner = seal_settings_record(
         &kdf::enc_subkey(&OTHER_SECRET),
         &[5u8; 32],
         &hand_encoded_body("https://kubo.example"),
     )
     .expect("seal");
+    let unknown_schema = seal_settings_record(
+        &kdf::enc_subkey(&SECRET),
+        &[6u8; 32],
+        &body_with_an_unknown_pin_mode(),
+    )
+    .expect("seal");
 
-    for planted in [transplanted, b"not a settings block at all".to_vec()] {
-        serve_http(&device, &blocks, 4);
+    for planted in [wrong_owner, unknown_schema, b"not a block".to_vec()] {
         assert_eq!(
             block_on(load_settings(
                 &device.record_store,
@@ -844,6 +857,190 @@ fn a_cached_copy_that_does_not_authenticate_is_not_used() {
             "a cached copy is re-opened on every read, never trusted for being cached",
         );
     }
+}
+
+/// A snapshot cache that keeps what the engine writes visible to the test.
+#[derive(Clone, Default)]
+struct SpyCache {
+    inner: Arc<Mutex<BTreeMap<Vec<u8>, Vec<u8>>>>,
+}
+
+impl SpyCache {
+    fn values(&self) -> Vec<Vec<u8>> {
+        self.inner.lock().expect("lock").values().cloned().collect()
+    }
+}
+
+impl SnapshotCache for SpyCache {
+    async fn put(&self, cache_key: &[u8], ciphertext: &[u8]) -> SeamResult<()> {
+        self.inner
+            .lock()
+            .expect("lock")
+            .insert(cache_key.to_vec(), ciphertext.to_vec());
+        Ok(())
+    }
+
+    async fn get(&self, cache_key: &[u8]) -> SeamResult<Option<Vec<u8>>> {
+        Ok(self.inner.lock().expect("lock").get(cache_key).cloned())
+    }
+
+    async fn remove(&self, cache_key: &[u8]) -> SeamResult<()> {
+        self.inner.lock().expect("lock").remove(cache_key);
+        Ok(())
+    }
+
+    async fn clear(&self) -> SeamResult<()> {
+        self.inner.lock().expect("lock").clear();
+        Ok(())
+    }
+}
+
+/// The seam is ciphertext-only at rest, so what the load caches must be the
+/// sealed head block. Caching the opened body instead would put the member's
+/// BYO bearer in host storage in the clear, and every other test here would
+/// still pass.
+#[test]
+fn the_cache_holds_the_sealed_block_never_the_opened_body() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let alice = world.device(b"alice-laptop");
+    publish(&world, &alice, &blocks, &SECRET, &configured());
+
+    let bob = world.device(b"alice-phone");
+    let cache = SpyCache::default();
+    serve_http(&bob, &blocks, 4);
+    assert_eq!(
+        block_on(load_settings(
+            &bob.record_store,
+            &gateway(),
+            &bob.http,
+            &bob.floor_store,
+            &cache,
+            &world.scheduler,
+            &SyncTimingProfile::CI,
+            &SECRET,
+        )),
+        SettingsLoad::Resolved(configured()),
+    );
+
+    let stored = cache.values();
+    assert_eq!(stored.len(), 1, "one settings head block");
+    assert!(
+        !stored[0].windows(6).any(|window| window == b"s3cret"),
+        "the BYO credential never reaches host storage in the clear",
+    );
+    assert!(
+        open_settings_record(&kdf::enc_subkey(&SECRET), &stored[0]).is_ok(),
+        "what is stored re-opens under the account's enc subkey",
+    );
+}
+
+/// A replay must not become last-known-good. The cache write sits behind the
+/// floor check and the open; hoisting it above either would let a chosen-record
+/// adversary overwrite the member's own copy permanently.
+#[test]
+fn a_rolled_back_record_never_becomes_last_known_good() {
+    let (world, blocks, bob) = device_with_warm_cache();
+    let key = settings_name(&SECRET).as_str().as_bytes().to_vec();
+    block_on(bob.floor_store.raise_sequence_floor(&key, 9)).expect("raise");
+    // Openable, and carrying the hosted default the adversary wants applied.
+    seed_settings(&bob, &blocks, &hand_encoded_body("https://kubo.example"), 3);
+
+    assert_eq!(
+        load(&world, &bob, &blocks, &SECRET),
+        SettingsLoad::Stale {
+            settings: external_only(),
+            reason: DefaultsReason::RolledBack {
+                floor: 9,
+                sequence: 3
+            },
+        },
+        "the replay is refused and the device's own copy stands in for it",
+    );
+
+    withhold_the_record(&bob);
+    assert_eq!(
+        load(&world, &bob, &blocks, &SECRET),
+        SettingsLoad::Stale {
+            settings: external_only(),
+            reason: DefaultsReason::Suppressed,
+        },
+        "the refused record left the cached copy where it found it",
+    );
+}
+
+#[test]
+fn a_second_account_on_the_device_never_sees_the_first_accounts_cached_settings() {
+    let (world, blocks, bob) = device_with_warm_cache();
+
+    // The same device stores, driving the other account's load. Nothing is
+    // published at its name, so only the cache could answer.
+    serve_http(&bob, &blocks, 4);
+    assert_eq!(
+        block_on(load_settings(
+            &bob.record_store,
+            &gateway(),
+            &bob.http,
+            &bob.floor_store,
+            &bob.snapshot_cache,
+            &world.scheduler,
+            &SyncTimingProfile::CI,
+            &OTHER_SECRET,
+        )),
+        SettingsLoad::Defaults(DefaultsReason::NoRecord),
+        "another account's copy is both keyed and sealed out of reach",
+    );
+}
+
+/// A snapshot cache whose reads never settle — the shape of a stalled host
+/// store.
+struct NeverReads;
+
+impl SnapshotCache for NeverReads {
+    async fn put(&self, _cache_key: &[u8], _ciphertext: &[u8]) -> SeamResult<()> {
+        Ok(())
+    }
+
+    async fn get(&self, _cache_key: &[u8]) -> SeamResult<Option<Vec<u8>>> {
+        poll_fn(|_| Poll::<SeamResult<Option<Vec<u8>>>>::Pending).await
+    }
+
+    async fn remove(&self, _cache_key: &[u8]) -> SeamResult<()> {
+        Ok(())
+    }
+
+    async fn clear(&self) -> SeamResult<()> {
+        Ok(())
+    }
+}
+
+/// The cache read is inside the budget like every other stage: a stalled host
+/// store must not turn the one load that never blocks cold start into one that
+/// does, nor push the ceiling past the profile's single budget.
+#[test]
+fn a_snapshot_cache_that_never_answers_does_not_block_cold_start() {
+    let scheduler = VirtualScheduler::new().with_auto_advance();
+    let device = FakeWorld::new().device(b"offline");
+    let profile = SyncTimingProfile::CI;
+
+    assert_eq!(
+        block_on(load_settings(
+            &device.record_store,
+            &gateway(),
+            &device.http,
+            &device.floor_store,
+            &NeverReads,
+            &scheduler,
+            &profile,
+            &SECRET,
+        )),
+        SettingsLoad::Defaults(DefaultsReason::TimedOut),
+    );
+    assert_eq!(
+        scheduler.now(),
+        UnixMillis(profile.settings_load_budget.as_millis() as u64),
+        "one budget covers the whole load, cache read included",
+    );
 }
 
 /// A body core's codec accepts and this build's schema does not.

--- a/crates/engine/tests/vault_settings.rs
+++ b/crates/engine/tests/vault_settings.rs
@@ -23,7 +23,7 @@ use cipherbox_engine::api::ApiClient;
 use cipherbox_engine::content::{ByoIpfsConfig, ByoKind, DAG_ROOT_CODEC, PinMode};
 use cipherbox_engine::seams::{
     EndpointId, FloorStore, HttpRequest, HttpResponse, RecordTransport, Scheduler, SeamError,
-    SeamResult, UnixMillis,
+    SeamResult, SnapshotCache, UnixMillis,
 };
 use cipherbox_engine::testkit::fakes::VirtualScheduler;
 use cipherbox_engine::testkit::{FakeDevice, FakeWorld, SeededEntropy, block_on};
@@ -175,6 +175,7 @@ fn load(world: &FakeWorld, device: &FakeDevice, blocks: &Blocks, secret: &[u8]) 
         &gateway(),
         &device.http,
         &device.floor_store,
+        &device.snapshot_cache,
         &world.scheduler,
         &SyncTimingProfile::CI,
         secret,
@@ -498,6 +499,7 @@ fn an_unresolvable_settings_name_does_not_block_cold_start_past_the_budget() {
         &gateway(),
         &device.http,
         &device.floor_store,
+        &device.snapshot_cache,
         &scheduler,
         &profile,
         &SECRET,
@@ -573,6 +575,7 @@ fn an_unavailable_head_block_yields_defaults() {
             &gateway(),
             &device.http,
             &device.floor_store,
+            &device.snapshot_cache,
             &world.scheduler,
             &SyncTimingProfile::CI,
             &SECRET,
@@ -622,12 +625,16 @@ fn a_floor_the_host_cannot_read_is_reported_apart_from_an_unusable_record() {
         SettingsLoad::Resolved(_)
     ));
 
+    // A device that never resolved these settings, so nothing but the floor
+    // read stands between the load and its verdict.
+    let cold = world.device(b"cold");
     assert_eq!(
         block_on(load_settings(
-            &device.record_store,
+            &cold.record_store,
             &gateway(),
-            &device.http,
+            &cold.http,
             &UnreadableFloors,
+            &cold.snapshot_cache,
             &world.scheduler,
             &SyncTimingProfile::CI,
             &SECRET,
@@ -635,6 +642,219 @@ fn a_floor_the_host_cannot_read_is_reported_apart_from_an_unusable_record() {
         SettingsLoad::Defaults(DefaultsReason::FloorUnreadable),
         "a floor the host cannot read is never treated as no floor",
     );
+}
+
+// ---------------------------------------------------------------------------
+// Last-known-good: a degraded load never widens placement
+// ---------------------------------------------------------------------------
+
+/// "Never put my bytes in CipherBox's store" — the choice a degraded load must
+/// not silently revert to [`PinMode::Hosted`].
+fn external_only() -> VaultSettings {
+    VaultSettings {
+        pin_mode: PinMode::External,
+        byo: Some(ByoIpfsConfig {
+            endpoint: "https://kubo.example".to_owned(),
+            kind: ByoKind::Kubo,
+            access_token: None,
+        }),
+        retention: RetentionPolicy::KeepAll,
+    }
+}
+
+/// A device holding `external_only` as its last-known-good copy, plus the
+/// world and block plane it resolved them from.
+fn device_with_warm_cache() -> (FakeWorld, Blocks, FakeDevice) {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let alice = world.device(b"alice-laptop");
+    publish(&world, &alice, &blocks, &SECRET, &external_only());
+
+    let bob = world.device(b"alice-phone");
+    assert_eq!(
+        load(&world, &bob, &blocks, &SECRET),
+        SettingsLoad::Resolved(external_only()),
+        "the copy cached below is one this device actually resolved",
+    );
+    (world, blocks, bob)
+}
+
+/// Stop every endpoint serving records: the durable floor is then the only
+/// proof the account ever published settings, which is a suppression.
+fn withhold_the_record(device: &FakeDevice) {
+    for endpoint in device.record_store.endpoints() {
+        device.record_store.fail_endpoint(&endpoint);
+    }
+}
+
+/// The headline. An adversary who can withhold the record must not be able to
+/// move a member from `External` onto CipherBox's hosted store.
+#[test]
+fn a_withheld_record_never_downgrades_external_to_hosted() {
+    let (world, blocks, bob) = device_with_warm_cache();
+    withhold_the_record(&bob);
+
+    let degraded = load(&world, &bob, &blocks, &SECRET);
+    let SettingsLoad::Stale { settings, reason } = degraded else {
+        panic!("a withheld record must degrade to last-known-good, got {degraded:?}");
+    };
+    assert_eq!(reason, DefaultsReason::Suppressed);
+    assert_eq!(
+        settings.pin_mode,
+        PinMode::External,
+        "withholding the record must never widen placement to the hosted default",
+    );
+    assert_eq!(
+        settings,
+        external_only(),
+        "stale, but the member's own choice"
+    );
+}
+
+#[test]
+fn a_load_that_runs_out_of_budget_prefers_the_cached_copy() {
+    let (_world, _blocks, bob) = device_with_warm_cache();
+    let scheduler = VirtualScheduler::new().with_auto_advance();
+
+    assert_eq!(
+        block_on(load_settings(
+            &NeverAnswers,
+            &gateway(),
+            &bob.http,
+            &bob.floor_store,
+            &bob.snapshot_cache,
+            &scheduler,
+            &SyncTimingProfile::CI,
+            &SECRET,
+        )),
+        SettingsLoad::Stale {
+            settings: external_only(),
+            reason: DefaultsReason::TimedOut,
+        },
+    );
+}
+
+#[test]
+fn a_record_this_build_cannot_read_prefers_the_cached_copy() {
+    let (world, blocks, bob) = device_with_warm_cache();
+    // Openable under the account's enc subkey, but carrying a discriminant no
+    // build of this schema knows — the shape of a record that authenticates and
+    // still yields no settings.
+    seed_settings(&bob, &blocks, &body_with_an_unknown_pin_mode(), 2);
+
+    assert_eq!(
+        load(&world, &bob, &blocks, &SECRET),
+        SettingsLoad::Stale {
+            settings: external_only(),
+            reason: DefaultsReason::Unreadable,
+        },
+    );
+}
+
+#[test]
+fn a_floor_the_host_cannot_read_prefers_the_cached_copy() {
+    let (world, _blocks, bob) = device_with_warm_cache();
+
+    assert_eq!(
+        block_on(load_settings(
+            &bob.record_store,
+            &gateway(),
+            &bob.http,
+            &UnreadableFloors,
+            &bob.snapshot_cache,
+            &world.scheduler,
+            &SyncTimingProfile::CI,
+            &SECRET,
+        )),
+        SettingsLoad::Stale {
+            settings: external_only(),
+            reason: DefaultsReason::FloorUnreadable,
+        },
+    );
+}
+
+/// With no cached copy the load reports `Defaults`, which is the verdict a
+/// placement decision fails closed on (blueprint/engine.md) — it must never be
+/// confusable with settings the member chose.
+#[test]
+fn a_degraded_load_with_no_cached_copy_reports_defaults_not_stale() {
+    let (world, blocks, bob) = device_with_warm_cache();
+    block_on(bob.snapshot_cache.clear()).expect("forget this device");
+    withhold_the_record(&bob);
+
+    assert_eq!(
+        load(&world, &bob, &blocks, &SECRET),
+        SettingsLoad::Defaults(DefaultsReason::Suppressed),
+    );
+}
+
+/// A snapshot cache that answers every key with bytes of the test's choosing —
+/// the shape of a tampered or transplanted last-known-good entry.
+struct ServesCiphertext(Vec<u8>);
+
+impl SnapshotCache for ServesCiphertext {
+    async fn put(&self, _cache_key: &[u8], _ciphertext: &[u8]) -> SeamResult<()> {
+        Ok(())
+    }
+
+    async fn get(&self, _cache_key: &[u8]) -> SeamResult<Option<Vec<u8>>> {
+        Ok(Some(self.0.clone()))
+    }
+
+    async fn remove(&self, _cache_key: &[u8]) -> SeamResult<()> {
+        Ok(())
+    }
+
+    async fn clear(&self) -> SeamResult<()> {
+        Ok(())
+    }
+}
+
+/// Being cached buys bytes nothing: the copy clears the same seal and the same
+/// body grammar a freshly fetched head block does, or the load falls through to
+/// the defaults.
+#[test]
+fn a_cached_copy_that_does_not_authenticate_is_not_used() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let device = world.device(b"me");
+
+    // Sealed to another account's enc subkey: verbatim ciphertext, wrong owner.
+    let transplanted = seal_settings_record(
+        &kdf::enc_subkey(&OTHER_SECRET),
+        &[5u8; 32],
+        &hand_encoded_body("https://kubo.example"),
+    )
+    .expect("seal");
+
+    for planted in [transplanted, b"not a settings block at all".to_vec()] {
+        serve_http(&device, &blocks, 4);
+        assert_eq!(
+            block_on(load_settings(
+                &device.record_store,
+                &gateway(),
+                &device.http,
+                &device.floor_store,
+                &ServesCiphertext(planted),
+                &world.scheduler,
+                &SyncTimingProfile::CI,
+                &SECRET,
+            )),
+            SettingsLoad::Defaults(DefaultsReason::NoRecord),
+            "a cached copy is re-opened on every read, never trusted for being cached",
+        );
+    }
+}
+
+/// A body core's codec accepts and this build's schema does not.
+fn body_with_an_unknown_pin_mode() -> Vec<u8> {
+    use cipherbox_core::codec::{Map, Value, encode};
+
+    let mut m = Map::new();
+    m.insert("byo", Value::Null);
+    m.insert("keepLatest", Value::Null);
+    m.insert("pinMode", Value::Text("everywhere".to_owned()));
+    encode(&Value::Map(m)).expect("encode")
 }
 
 // ---------------------------------------------------------------------------
@@ -723,10 +943,18 @@ fn a_body_carrying_a_refused_endpoint_is_rejected_on_the_way_back_in() {
     // a public host over plaintext, putting the member's bearer on the wire.
     for (sequence, endpoint) in [(2, "file:///etc/passwd"), (3, "http://kubo.example")] {
         seed_settings(&device, &blocks, &hand_encoded_body(endpoint), sequence);
+        let degraded = load(&world, &device, &blocks, &SECRET);
+        let SettingsLoad::Stale { settings, reason } = degraded else {
+            panic!("{endpoint}: the refused body degrades to last-known-good, got {degraded:?}");
+        };
+        assert_eq!(reason, DefaultsReason::Unreadable, "{endpoint}");
         assert_eq!(
-            load(&world, &device, &blocks, &SECRET),
-            SettingsLoad::Defaults(DefaultsReason::Unreadable),
-            "{endpoint}",
+            settings
+                .byo
+                .expect("the cached copy carries a provider")
+                .endpoint,
+            "https://kubo.example",
+            "{endpoint}: the refused endpoint never reaches the caller",
         );
     }
 }

--- a/crates/engine/tests/vault_settings.rs
+++ b/crates/engine/tests/vault_settings.rs
@@ -4,8 +4,9 @@
 //! same account that only ever saw the network (#870).
 //!
 //! Its contract is the inverse of the write plane's: a settings record that
-//! will not resolve must never block cold start, so every failure degrades to
-//! the documented defaults inside a scheduler-measured budget.
+//! will not resolve must never block cold start, so every failure degrades —
+//! to this device's last-known-good copy where one opens, and only then to the
+//! documented defaults — inside a scheduler-measured budget.
 
 use core::future::poll_fn;
 use core::num::NonZeroU64;


### PR DESCRIPTION
A degraded vault settings load resolved to `VaultSettings::default()`, so a member who chose `PinMode::External` — "never put my bytes in CipherBox's store" — was silently placed on `Hosted` whenever the settings record was withheld, timed out, or its head block was unreadable. `DefaultsReason::{Suppressed, RolledBack, TimedOut, Unreadable, FloorUnreadable}` already named each case, but nothing acted on any of them and there was no last-known-good copy to prefer.

## What lands

1. `SettingsLoad::Stale { settings, reason }` plus a durable last-known-good copy. `resolve_settings` writes the gate-passing head-block **ciphertext** into the existing `SnapshotCache` seam under `settings-head/<ipnsName>` and, cache-first like every other resolve, reads that key back before it touches the network. A degraded load prefers the cached copy over the defaults, reporting the reason it degraded alongside it. The ciphertext is cached rather than the decoded record because suppression breaks at the head-block fetch — caching the decoded record alone leaves the hole open, and would put the member's BYO bearer in host storage in the clear.

2. The written policy, in `blueprint/engine.md` — a new `## Vault settings load` section at lines 184-232, in the record-plane area clear of PR #923's line-135 hunk and of the content-plane section PR #932 took. It states that a degraded settings load never widens placement, that with no last-known-good copy the placement decision fails closed rather than resolving to `PinMode::Hosted`, and what the cached copy is and is not bound to. This is the actual security fix and is independent of the cache.

The cached copy is preferred on **every** degraded reason, a superset of the four the issue enumerates. `RolledBack` reaches the same arm because pinning last-known-good is already what the record plane owes a gate failure; `NoRecord` because the argument does not change with the reason. Enumerating four of six would be strictly weaker code for more of it.

The whole load — cache read included — stays inside one `settings_load_budget`. The cached ciphertext is held in an out-slot so a load that runs out of budget mid-resolve still degrades to the member's own settings rather than the defaults.

## Where cached ciphertext is re-verified

In `open_settings_head`, which is the single place both the cached and the freshly fetched block reach their verdict:

- `cipherbox_core::seal::open_settings_record` — the version gate ahead of the AEAD, HPKE auth mode, and the owner tag rebuilt from the opening key rather than read off the wire. A copy sealed to any other identity, or tampered by a byte, does not open.
- `decode_settings_body` — this build's body grammar: exhaustive `BODY_KEYS`, the tagged-union discriminants, the non-zero retention bar, and the BYO endpoint check.

Either failing discards the copy and the load falls through to `Defaults`. A cache is storage, never a trust bypass. `a_cached_copy_that_does_not_authenticate_is_not_used` proves it against one planted copy per gate: wrong owner, unknown schema, and raw garbage.

What the cached form deliberately does not re-check is the IPNS signature and sequence — it is a head block, not a record. Its binding to the account is the seal itself, which only the login-secret holder can produce.

## Rule 8 determination — no encode guard needed

This diff adds **no** new decode-side rejection. `open_settings_head` introduces no predicate of its own; it composes `open_settings_record` and `decode_settings_body`, both already on the network path, and both already carry their release-active encode-side counterparts: `validate()` returns `Err` from `publish_settings` before anything is sealed, and `RetentionPolicy::KeepLatest(NonZeroU64)` makes a zero-version policy unrepresentable. The one new producer is the `SnapshotCache::put`, and it is symmetric by construction rather than by a guard: the only bytes it can write are the bytes its own reader accepted one statement earlier, in the same function, in release and debug alike. There is no `debug_assert!` or `assert!` anywhere in the diff.

## Scope

`PinMode` is inert today — no `match` anywhere in the repo, and `load_settings`/`publish_settings` have no production callers. This lands the load semantics and the policy, not placement dispatch: that is #871, which carries a depends-on edge here precisely because it writes the first `PinMode` dispatch and would otherwise ship the `External` -> `Hosted` downgrade on day one. The EOL check, the cold-device anchor and the body revision are separate slices sequenced after this one.

## Residual

The cached copy is bound to the account by its seal alone — no sequence, no name, no time. A party who can write this device's durable store can pin it to any settings generation the account ever published, and every historical head block is a public content-addressed object, so only the store write is privileged. The per-name sequence floor is no defence: it is device-local and lives beside the cache, so the same party moves both. That party can equally *delete* the entry and force the defaults path, which is the pre-cache behaviour — so the anti-downgrade property holds against a record-plane adversary, not against one already inside the device's storage. The same staleness also arrives with no adversary at all: a device stuck degraded keeps its copy indefinitely, including a BYO credential the member has since rotated, which is why the reason is reported rather than swallowed.

A real bound needs a per-account anchor — an EOL check or a monotonic revision in the sealed body. Stated in `blueprint/engine.md` and noted on #931, the slice that would add one.

## Tests

In `crates/engine/tests/vault_settings.rs`:

- `a_withheld_record_never_downgrades_external_to_hosted` — the headline.
- `a_load_that_runs_out_of_budget_prefers_the_cached_copy` — `TimedOut`.
- `a_record_this_build_cannot_read_prefers_the_cached_copy` — `Unreadable`, plus a follow-up load proving the refused record never became last-known-good.
- `a_floor_the_host_cannot_read_prefers_the_cached_copy` — `FloorUnreadable`.
- `a_rolled_back_record_never_becomes_last_known_good` — `RolledBack`, same poisoning check.
- `a_degraded_load_with_no_cached_copy_reports_defaults_not_stale` — the fail-closed verdict is never confusable with settings the member chose.
- `a_cached_copy_that_does_not_authenticate_is_not_used` — one planted copy per gate.
- `the_cache_holds_the_sealed_block_never_the_opened_body` — the BYO bearer never reaches host storage in the clear.
- `a_second_account_on_the_device_never_sees_the_first_accounts_cached_settings`.
- `a_snapshot_cache_that_never_answers_does_not_block_cold_start` — one budget covers the whole load.

Each was verified to bite by breaking the behaviour deliberately and confirming the specific failure before restoring it.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check --workspace --all-targets`, `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets`, and `cargo test -p cipherbox-engine` all exit 0, debug and release. Gate: `Engine Tests`. No `crates/core` change, so no `Core KATs`.

## Two files beyond the issue's list

`crates/engine/src/seams/snapshot_cache.rs` and `crates/engine/src/profile.rs`, one doc comment each. Both stated something this change made false — the seam said only gate-passing *records* reach the cache, and the profile said the budget's expiry yields the documented defaults. Fixed at their home rather than contradicted from `settings.rs`.

## Merge sequencing with PR #932

PR #932 also touches `crates/engine/src/settings.rs` and `crates/engine/tests/vault_settings.rs`, and renames the settings error wrapper. This branch adds, removes and matches on **no** variant of `SettingsPublishError` or `ProviderError`, adds no `Map::insert` call site in `settings.rs`, and does not touch `validate_endpoint` or its call site. The one overlap needing attention on rebase is `a_body_carrying_a_refused_endpoint_is_rejected_on_the_way_back_in`, whose tail assertion changed from `Defaults(Unreadable)` to `Stale { .., Unreadable }` — the refused endpoint now never reaches the caller at all, which is a strictly stronger assertion.

Closes #928
Part of #904


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault settings now retain a validated last-known-good version for use during temporary loading failures.
  * Settings remain available during timeouts, unreadable data, rollbacks, or connectivity issues, with staleness and degradation details reported.
  * Cached settings are securely validated, account-specific, and loaded within startup timing limits.

* **Bug Fixes**
  * Invalid or unavailable settings now fall back to the previous valid configuration before using defaults.
  * Hosted placement is rejected when no authenticated prior settings are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->