### PR TITLE
fix(core): wipe secret-bearing unknown fields and replaced map values

### DIFF
--- a/crates/core/src/codec/fields.rs
+++ b/crates/core/src/codec/fields.rs
@@ -8,12 +8,16 @@
 //! canonical by construction, so re-emitting it verbatim keeps the whole
 //! rewrite canonical.
 
+use core::fmt;
+
+use zeroize::Zeroizing;
+
 use super::decode::Decoder;
 use super::encode::{
     MAJOR_MAP, count_value, head_len, text_len, write_head, write_text, write_value,
 };
 use super::value::{Map, Value, canonical_key_cmp};
-use crate::error::{CodecError, Malformed};
+use crate::error::{CodecError, DisplayKey, Malformed};
 
 /// The depth a top-level map's values sit at: the map itself is the enclosing
 /// item, so its entries are one level in.
@@ -21,15 +25,34 @@ const MAP_ENTRY_DEPTH: usize = 1;
 
 /// Fields preserved through a decode the caller's schema did not recognize:
 /// key plus the exact canonical bytes of the value. Ordered canonically.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+///
+/// A preserved value is a verbatim copy of whatever the field carried, and this
+/// set is that copy's terminal owner: the bytes sit in a zeroizing owner so the
+/// wipe is type-enforced rather than a caller's to remember, and they are kept
+/// out of every rendering (blueprint/core.md "Crypto suite"). Keys are field
+/// names, never secret.
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct UnknownFields {
-    entries: Vec<(String, Vec<u8>)>,
+    entries: Vec<(String, Zeroizing<Vec<u8>>)>,
+}
+
+impl fmt::Debug for UnknownFields {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut m = f.debug_map();
+        for (key, _) in &self.entries {
+            m.key(&DisplayKey(key)).value(&"<redacted>");
+        }
+        m.finish()
+    }
 }
 
 impl UnknownFields {
-    /// Preserved entries in canonical key order.
-    pub fn entries(&self) -> &[(String, Vec<u8>)] {
-        &self.entries
+    /// Preserved entries in canonical key order. Borrowed as plain bytes: the
+    /// wipe belongs to this set, so a borrow cannot carry it.
+    pub fn entries(&self) -> impl Iterator<Item = (&str, &[u8])> {
+        self.entries
+            .iter()
+            .map(|(key, raw)| (key.as_str(), raw.as_slice()))
     }
 
     pub fn len(&self) -> usize {
@@ -44,10 +67,26 @@ impl UnknownFields {
 /// Decode a top-level map, splitting entries into known fields (decoded
 /// values, selected by `is_known`) and unknown fields (raw canonical bytes).
 /// Every entry — known or not — passes the full strict profile.
+///
+/// The returned [`Map`] is the caller's to wipe once it is done with it
+/// ([`Map::zeroize_bytes`]); the preserved unknowns wipe themselves.
 pub fn decode_map_partial(
     bytes: &[u8],
     is_known: impl Fn(&str) -> bool,
 ) -> Result<(Map, UnknownFields), CodecError> {
+    let mut known = Map::new();
+    let unknown = decode_entries(bytes, is_known, &mut known)?;
+    Ok((known, unknown))
+}
+
+/// The entry loop, over a `known` the caller owns so it survives the success
+/// path. Anything else — a reject, or a panic out of `is_known` — leaves it to
+/// the scrub guard rather than stranding decoded secrets in freed heap.
+fn decode_entries(
+    bytes: &[u8],
+    is_known: impl Fn(&str) -> bool,
+    known: &mut Map,
+) -> Result<UnknownFields, CodecError> {
     let mut d = Decoder::new(bytes);
     let head = d.read_head()?;
     if head.major != MAJOR_MAP {
@@ -58,25 +97,39 @@ pub fn decode_map_partial(
         .into());
     }
 
-    let mut known = Vec::new();
-    let mut unknown = Vec::new();
+    let known = ScrubOnDrop(known);
+    let mut unknown = UnknownFields::default();
     let mut prev: Option<String> = None;
     for _ in 0..head.arg {
         let key = d.read_map_key(prev.as_deref())?;
         let start = d.pos();
-        let value = d.read_value(MAP_ENTRY_DEPTH)?;
+        let mut value = d.read_value(MAP_ENTRY_DEPTH)?;
         if is_known(&key) {
-            known.push((key.clone(), value));
+            known.0.insert(key.clone(), value);
         } else {
-            unknown.push((key.clone(), bytes[start..d.pos()].to_vec()));
+            // An unknown entry is decoded and *also* copied verbatim; the
+            // decoded tree is this loop's to discard, so it goes wiped.
+            unknown
+                .entries
+                .push((key.clone(), Zeroizing::new(bytes[start..d.pos()].to_vec())));
+            value.zeroize_bytes();
         }
         prev = Some(key);
     }
     d.expect_end()?;
-    Ok((
-        known.into_iter().collect(),
-        UnknownFields { entries: unknown },
-    ))
+    core::mem::forget(known);
+    Ok(unknown)
+}
+
+/// The scrub guard of [`crate::seal`], borrowing rather than owning: the known
+/// fields belong to the caller, and only the paths that never return them wipe.
+/// Disarmed by forgetting it, which leaks nothing — it holds one borrow.
+struct ScrubOnDrop<'a>(&'a mut Map);
+
+impl Drop for ScrubOnDrop<'_> {
+    fn drop(&mut self) {
+        self.0.zeroize_bytes();
+    }
 }
 
 /// Canonically re-encode a map from re-built known fields plus preserved
@@ -133,7 +186,7 @@ fn merge<'a>(
             merged.push((key.as_str(), MergedValue::Known(value)));
         } else {
             let (key, raw) = u.next().expect("peeked");
-            merged.push((key.as_str(), MergedValue::Raw(raw)));
+            merged.push((key.as_str(), MergedValue::Raw(raw.as_slice())));
         }
     }
     Ok(merged)
@@ -148,6 +201,9 @@ fn merged_len(merged: &[(&str, MergedValue<'_>)]) -> Result<usize, CodecError> {
         len += text_len(key);
         match value {
             MergedValue::Known(v) => count_value(&mut len, v, MAP_ENTRY_DEPTH)?,
+            // AGENTS.md rule 8: an empty preserved value would splice a key
+            // with nothing after it — bytes this codec's decoder rejects.
+            MergedValue::Raw([]) => return Err(Malformed::Truncated { offset: len }.into()),
             MergedValue::Raw(raw) => len += raw.len(),
         }
     }
@@ -245,6 +301,60 @@ mod tests {
             depth_offset(&encode(&Value::Map(full)).unwrap_err()),
             "merged reject offset diverged from the full-map encode"
         );
+    }
+
+    /// A preserved value never reaches a log line, and a crafted field name
+    /// cannot flood one.
+    #[test]
+    fn debug_redacts_preserved_values() {
+        let mut m = Map::new();
+        m.insert("v", Value::Unsigned(2));
+        m.insert("futureKey", Value::Bytes(vec![0xAB; 32]));
+        m.insert("z".repeat(200), Value::Unsigned(1));
+        let bytes = encode(&Value::Map(m)).unwrap();
+
+        let (_, unknown) = decode_map_partial(&bytes, known_key_set(&["v"])).unwrap();
+        let rendered = format!("{unknown:?}");
+
+        assert!(rendered.starts_with(r#"{"futureKey": "<redacted>", "zzz"#));
+        assert!(rendered.ends_with(r#"…: "<redacted>"}"#), "{rendered}");
+        assert!(rendered.len() < 160, "a crafted key flooded it: {rendered}");
+    }
+
+    /// A decode that rejects is the terminal owner of the known fields it had
+    /// already lifted out of its input.
+    #[test]
+    fn a_failed_decode_wipes_what_it_already_lifted() {
+        const SECRET: [u8; 32] = [0xAB; 32];
+        let mut m = Map::new();
+        m.insert("a", Value::Bytes(SECRET.to_vec()));
+        let mut bytes = encode(&Value::Map(m)).unwrap();
+        // A second entry the head promises and the input cuts off.
+        bytes[0] = 0xa2;
+        bytes.extend_from_slice(&[0x61, b'b', 0x18]);
+
+        let mut known = Map::new();
+        assert_eq!(
+            decode_entries(&bytes, |_| true, &mut known)
+                .unwrap_err()
+                .check(),
+            "truncated"
+        );
+        assert_eq!(known.get("a"), Some(&Value::Bytes(Vec::new())));
+    }
+
+    /// AGENTS.md rule 8: the encoder refuses to splice a preserved value that
+    /// would leave a key with nothing after it, which its decoder rejects.
+    #[test]
+    fn merged_encode_rejects_an_empty_preserved_value() {
+        let unknown = UnknownFields {
+            entries: vec![("future".into(), Zeroizing::new(Vec::new()))],
+        };
+        let mut known = Map::new();
+        known.insert("v", Value::Unsigned(2));
+
+        let err = encode_map_partial(&known, &unknown).unwrap_err();
+        assert_eq!(err.check(), "truncated");
     }
 
     #[test]

--- a/crates/core/src/codec/value.rs
+++ b/crates/core/src/codec/value.rs
@@ -235,8 +235,9 @@ impl Map {
     /// never secret). The wipe for a caller holding decoded known fields — see
     /// [`Value::zeroize_bytes`].
     ///
-    /// Terminal: a wiped map still encodes, to zero-length fields a schema
-    /// decoder rejects, so nothing may re-encode from it afterwards.
+    /// Terminal: a wiped map still encodes. Fixed-length fields then fail
+    /// their schema decode, but variable-length ones round-trip empty, so
+    /// nothing may re-encode from it afterwards.
     pub fn zeroize_bytes(&mut self) {
         for (_, v) in &mut self.entries {
             v.zeroize_bytes();

--- a/crates/core/src/codec/value.rs
+++ b/crates/core/src/codec/value.rs
@@ -177,19 +177,17 @@ impl Map {
         Self::default()
     }
 
-    /// Insert or replace, keeping canonical order. Returns the value a
-    /// replaced entry held.
-    pub fn insert(&mut self, key: impl Into<String>, value: Value) -> Option<Value> {
+    /// Insert or replace, keeping canonical order. A replaced value is wiped
+    /// rather than handed back: the map is its terminal owner unless a caller
+    /// takes ownership, which is what [`Map::remove`] is for.
+    pub fn insert(&mut self, key: impl Into<String>, value: Value) {
         let key = key.into();
         match self
             .entries
             .binary_search_by(|(k, _)| canonical_key_cmp(k, &key))
         {
-            Ok(i) => Some(core::mem::replace(&mut self.entries[i].1, value)),
-            Err(i) => {
-                self.entries.insert(i, (key, value));
-                None
-            }
+            Ok(i) => core::mem::replace(&mut self.entries[i].1, value).zeroize_bytes(),
+            Err(i) => self.entries.insert(i, (key, value)),
         }
     }
 
@@ -207,6 +205,8 @@ impl Map {
             .map(|i| &mut self.entries[i].1)
     }
 
+    /// Take an entry out, transferring its buffers: the caller becomes their
+    /// terminal owner. The way to get at a value [`Map::insert`] would wipe.
     pub fn remove(&mut self, key: &str) -> Option<Value> {
         self.entries
             .binary_search_by(|(k, _)| canonical_key_cmp(k, key))
@@ -232,8 +232,12 @@ impl Map {
     }
 
     /// Zeroize every entry value's owned byte buffers in place (keys are text,
-    /// never secret). See [`Value::zeroize_bytes`].
-    pub(crate) fn zeroize_bytes(&mut self) {
+    /// never secret). The wipe for a caller holding decoded known fields — see
+    /// [`Value::zeroize_bytes`].
+    ///
+    /// Terminal: a wiped map still encodes, to zero-length fields a schema
+    /// decoder rejects, so nothing may re-encode from it afterwards.
+    pub fn zeroize_bytes(&mut self) {
         for (_, v) in &mut self.entries {
             v.zeroize_bytes();
         }
@@ -241,7 +245,7 @@ impl Map {
 }
 
 impl FromIterator<(String, Value)> for Map {
-    /// Later duplicates replace earlier ones, like `BTreeMap`.
+    /// Later duplicates replace earlier ones; the replaced value is wiped.
     fn from_iter<I: IntoIterator<Item = (String, Value)>>(iter: I) -> Self {
         let mut map = Map::new();
         for (k, v) in iter {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -223,7 +223,7 @@ impl std::error::Error for TrustViolation {}
 /// into upstream logs. Full redaction policy belongs to the engine.
 const DISPLAY_KEY_MAX_CHARS: usize = 64;
 
-struct DisplayKey<'a>(&'a str);
+pub(crate) struct DisplayKey<'a>(pub(crate) &'a str);
 
 impl fmt::Debug for DisplayKey<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/core/tests/codec_props.rs
+++ b/crates/core/tests/codec_props.rs
@@ -91,6 +91,41 @@ fn build_map_and_flags(entries: &FlaggedEntries) -> (Map, HashMap<String, bool>)
     (map, flags)
 }
 
+/// The wipe seam from outside `crates/core` (#902): a caller holding the known
+/// fields `decode_map_partial` split out is their terminal owner and can scrub
+/// them, in the buffer that held the secret rather than a fresh one.
+#[test]
+fn a_caller_can_wipe_what_it_decoded() {
+    const SECRET: [u8; 32] = [0xAB; 32];
+    let mut m = Map::new();
+    m.insert("contentKey", Value::Bytes(SECRET.to_vec()));
+    m.insert("futureKey", Value::Bytes(SECRET.to_vec()));
+    let bytes = encode(&Value::Map(m)).unwrap();
+
+    let (mut known, unknown) = decode_map_partial(&bytes, |k| k == "contentKey").unwrap();
+    let (key, preserved) = unknown.entries().next().unwrap();
+    assert_eq!(key, "futureKey");
+    assert!(
+        preserved.windows(SECRET.len()).any(|w| w == SECRET),
+        "the preserved raw value must carry the secret"
+    );
+    let held = match known.get("contentKey") {
+        Some(Value::Bytes(b)) if b.as_slice() == SECRET => b.capacity(),
+        other => panic!("the known field must carry the secret before the wipe: {other:?}"),
+    };
+
+    known.zeroize_bytes();
+
+    match known.get("contentKey") {
+        Some(Value::Bytes(b)) => {
+            assert!(b.is_empty(), "content key scrubbed and cleared");
+            // A wipe that swapped in a fresh `Vec` would strand the old one.
+            assert_eq!(b.capacity(), held);
+        }
+        other => panic!("the key set is left intact: {other:?}"),
+    }
+}
+
 proptest! {
     #![proptest_config(config())]
 


### PR DESCRIPTION
## What

`decode_map_partial` is re-exported from `crates/core`, so a caller outside the crate receives preserved unknown-field bytes and decoded known fields with no reachable way to scrub either. Both are verbatim copies of whatever the field carried — inline content keys and grant/owner/history seed material on the seal surfaces. PR #901 closed the encoder-side half of this and filed the seam half as #902.

- **`UnknownFields` preserves into `Zeroizing<Vec<u8>>`.** The wipe is type-enforced at drop rather than a step an out-of-crate holder has to remember, and there is deliberately no public wipe: a wiped set would re-encode to bytes the decoder rejects, so the only wipe is the one after which nothing follows.
- **`entries()` borrows as plain bytes** rather than handing out `&Zeroizing<…>`. A borrow cannot carry the wipe, and `Zeroizing`'s derived `Debug` forwards to the inner `Vec`, so the old signature was a hole straight through the redaction below.
- **`Map::zeroize_bytes` is now `pub`.** The caller holding the decoded known fields is their terminal owner and can scrub them; `decode_map_partial`'s rustdoc states that obligation.
- **`Map::insert` wipes the value it replaces instead of returning it.** Discarding the return was the ergonomic form and the leak. `Map::remove` is the documented path for a caller that wants ownership.
- **The decode loop wipes the transient tree for an unknown entry** — an unknown field is decoded *and* copied verbatim, and the decoded `Value` is a second copy that dies in the loop.
- **A scrub guard covers every exit that does not return the known fields** — a reject or a panic out of the caller's `is_known` — matching `seal`'s `ScrubOnDrop`/`ScrubOwned` convention instead of a wipe on the `Err` arm only.
- **`UnknownFields` renders redacted**, with field names bounded through the same `DisplayKey` cap the error surface already uses on writer-controlled keys.

Terminal-owner discipline, AGENTS.md rule 7, holds throughout: every wipe runs on a buffer the wiping frame owns and is about to drop. The input `bytes: &[u8]` is caller-owned and left untouched.

No wire-format change and no KAT regeneration — the `crates/core/kat` tree is byte-identical to `main`.

## Fail-closed symmetry

`encode_map_partial` now rejects an empty preserved value. Verbatim-splicing one would emit a map head promising an entry with nothing after it — bytes this codec's own decoder rejects as `truncated`. The check is release-active and returns `Err`, per AGENTS.md rule 8 and the `assert_children_unique` convention, and the state is not reachable through the public API today, so the guard is what keeps that true.

## `Map::insert` signature — merge sequencing

`Map::insert` changes from `-> Option<Value>` to `-> ()`. **It is not `#[must_use]`,** so this is source-compatible with every existing call site: `crates/engine/src/settings.rs` calls it at `:363`, `:367`, `:374`, `:375`, `:379`, `:386` plus test sites, and all of them discard the result. `cargo check --workspace --all-targets` is green, so nothing in the workspace consumed the returned value. #928 and #932 touch `settings.rs` concurrently; neither is affected, and no merge order is forced.

## Tests

Three new, each verified red against a deliberate break:

- `a_caller_can_wipe_what_it_decoded` — the out-of-crate seam. Asserts the decoded known field and the preserved raw value both carry the secret, then that `Map::zeroize_bytes` scrubs the content key **in the buffer that held it** — capacity retained, so a wipe that swapped in a fresh `Vec` fails. Red with `Value::zeroize_bytes`'s `Bytes` arm removed: `left: Some(Bytes([171, 171, …])) right: Some(Bytes([]))`.
- `a_failed_decode_wipes_what_it_already_lifted` — a truncated second entry; the first entry's secret is scrubbed before the error propagates. Red with the scrub guard removed, same shape.
- `merged_encode_rejects_an_empty_preserved_value` — the rule-8 guard, **verified red in a release build**: gated behind `cfg!(debug_assertions)` the encoder happily produced `[162, 97, 118, 2, 102, 102, 117, 116, 117, 114, 101]`, a two-entry map head whose second key `"future"` has no value.
- `debug_redacts_preserved_values` — pins the rendering and that a 200-char crafted field name cannot flood a log line.

## Gates

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check --workspace --all-targets`, `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets`, `cargo test -p cipherbox-core`, `cargo test --release -p cipherbox-core`, `cargo test -p cipherbox-engine` — all green.

`/simplify`, `/security-review` and `/crypto-privacy-review` all ran on `git diff main...HEAD`. Findings folded in: the `entries()` bypass of the redaction, the unwind hole in the `Err`-path wipe, the missing test for that wipe, the rule-8 empty-raw guard, unbounded key names in `Debug`, and weak assertions in two tests. Two findings are out of scope and filed with dependency edges: the seal layer's own preserved unknowns and the decoder's in-flight tree are still dropped un-zeroized, and `Value`/`Map` still render secrets in full.

Deliberately not taken: a validate-only `Decoder::skip_value` for unknown entries. It would remove the second copy and the wipe, but a second walker that must accept exactly what `read_value` accepts is a fail-closed divergence risk that outweighs the allocation saving on a latent path.

Closes #902
Part of #655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Sensitive decoded and replaced values are now securely wiped from memory.
  * Debug output redacts preserved unknown values to help prevent accidental disclosure.
  * Callers can explicitly clear decoded data while preserving unrelated unknown-field data.

* **Bug Fixes**
  * Improved cleanup when partial decoding fails.
  * Empty preserved values are now correctly rejected as truncated input.

* **API Updates**
  * Updated map insertion behavior and added an explicit method for retrieving removed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->