### PR TITLE
fix: mark a leaf uploaded before releasing its staged bytes

### DIFF
--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -1352,7 +1352,13 @@ where
             match self.staged_block(leaf_cid).await? {
                 Some(block) => {
                     self.upload_block(leaf_cid, &block).await?;
-                    self.mark_uploaded(&staged.root_cid, index + 1).await?;
+                    // A leaf a lost release left staged behind the mark is
+                    // re-uploaded here, and must not drag the mark back down
+                    // over the leaves past it — those are released, so an
+                    // uncovered one reads as loss (#924).
+                    if index + 1 > uploaded {
+                        self.mark_uploaded(&staged.root_cid, index + 1).await?;
+                    }
                     self.staging
                         .remove_staged_bytes(leaf_cid)
                         .await
@@ -1417,12 +1423,11 @@ where
         Ok(<[u8; 4]>::try_from(count).map_or(0, |c| u32::from_be_bytes(c) as usize))
     }
 
-    /// Record that `count` of this version's leaves have uploaded. Written
-    /// *before* the leaf is released, so an interruption between the two leaves
-    /// that leaf both marked and staged and the next pass simply re-uploads and
-    /// re-removes it. The reverse order strands a released leaf behind the mark,
-    /// where the hole guard reads bytes that did upload as unrecoverable loss
-    /// and the valve destroys the version (#924).
+    /// Record that `count` of this version's leaves have uploaded. A high-water
+    /// mark, written *before* the leaf is released: it may over-claim a leaf
+    /// still staged, which the next pass re-uploads, but must never lag or
+    /// regress below one already released — the hole guard would read those
+    /// uploaded bytes as loss (#924).
     async fn mark_uploaded(&self, root_cid: &[u8], count: usize) -> Result<(), Halt> {
         let mut mark = root_cid.to_vec();
         mark.extend_from_slice(&(count as u32).to_be_bytes());

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -1352,11 +1352,11 @@ where
             match self.staged_block(leaf_cid).await? {
                 Some(block) => {
                     self.upload_block(leaf_cid, &block).await?;
+                    self.mark_uploaded(&staged.root_cid, index + 1).await?;
                     self.staging
                         .remove_staged_bytes(leaf_cid)
                         .await
                         .map_err(seam)?;
-                    self.mark_uploaded(&staged.root_cid, index + 1).await?;
                     emit(OpPhase::UploadProgress, blocks(index + 1));
                 }
                 // Absent and not covered by the mark: these bytes were never
@@ -1417,8 +1417,12 @@ where
         Ok(<[u8; 4]>::try_from(count).map_or(0, |c| u32::from_be_bytes(c) as usize))
     }
 
-    /// Record that `count` of this version's leaves have uploaded. Written after
-    /// the removal, so the mark never claims more than the store has released.
+    /// Record that `count` of this version's leaves have uploaded. Written
+    /// *before* the leaf is released, so an interruption between the two leaves
+    /// that leaf both marked and staged and the next pass simply re-uploads and
+    /// re-removes it. The reverse order strands a released leaf behind the mark,
+    /// where the hole guard reads bytes that did upload as unrecoverable loss
+    /// and the valve destroys the version (#924).
     async fn mark_uploaded(&self, root_cid: &[u8], count: usize) -> Result<(), Halt> {
         let mut mark = root_cid.to_vec();
         mark.extend_from_slice(&(count as u32).to_be_bytes());

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -1332,9 +1332,10 @@ where
         })?;
 
         // File order, root last, each leaf removed on its confirmed
-        // `UploadResult` — so the blocks still staged are a **suffix**. An
-        // absence is only progress up to the durable mark this pass keeps: past
-        // it, a missing block is loss, and the version can never be assembled.
+        // `UploadResult` — but a lost release can strand one staged anywhere
+        // below the mark (#924). An absence is only progress up to the durable
+        // mark this pass keeps: past it, a missing block is loss, and the
+        // version can never be assembled.
         let uploaded = self.upload_mark(&staged.root_cid).await?;
         // The root manifest is block zero and goes up last, so the version's
         // whole block count is its leaves plus one.

--- a/crates/engine/src/testkit/fakes/staging_store.rs
+++ b/crates/engine/src/testkit/fakes/staging_store.rs
@@ -14,6 +14,7 @@ struct Inner {
     enqueue_budget: Option<u64>,
     staged_write_budget: Option<(Vec<u8>, u64)>,
     staged_removal_budget: Option<(Vec<u8>, u64)>,
+    dropped_removal_budget: Option<(Vec<u8>, u64)>,
 }
 
 impl Default for Inner {
@@ -27,6 +28,7 @@ impl Default for Inner {
             enqueue_budget: None,
             staged_write_budget: None,
             staged_removal_budget: None,
+            dropped_removal_budget: None,
         }
     }
 }
@@ -59,23 +61,32 @@ impl InMemoryStagingStore {
         self.inner.lock().expect("lock").enqueue_budget = Some(budget);
     }
 
-    /// Lets `budget` writes at `staging_key` through, fails the next one, and
-    /// then lets every write through again — so a test can drop a caller
-    /// between two durable effects at an exact step and let its retry proceed.
-    pub fn fail_staged_write_after(&self, staging_key: &[u8], budget: u64) {
+    /// Lets `budget` writes at `staging_key` through, fails the next one, then
+    /// disarms — a caller dropped at an exact step whose retry still proceeds.
+    pub fn interrupt_staged_write_after(&self, staging_key: &[u8], budget: u64) {
         self.inner.lock().expect("lock").staged_write_budget = Some((staging_key.to_vec(), budget));
     }
 
-    /// The removal counterpart of [`Self::fail_staged_write_after`]: the other
-    /// side of every crash window between a durable write and a release.
-    pub fn fail_staged_removal_after(&self, staging_key: &[u8], budget: u64) {
+    /// The removal counterpart of [`Self::interrupt_staged_write_after`]: the
+    /// other side of every crash window between a durable write and a release.
+    pub fn interrupt_staged_removal_after(&self, staging_key: &[u8], budget: u64) {
         self.inner.lock().expect("lock").staged_removal_budget =
+            Some((staging_key.to_vec(), budget));
+    }
+
+    /// Reports the next removal at `staging_key` past `budget` as done without
+    /// dropping the bytes — an unlink that never reached the disk while a later
+    /// write did, which is what a host that releases staged bytes without a
+    /// durability barrier leaves behind after a crash.
+    pub fn drop_staged_removal_after(&self, staging_key: &[u8], budget: u64) {
+        self.inner.lock().expect("lock").dropped_removal_budget =
             Some((staging_key.to_vec(), budget));
     }
 }
 
 /// Charge one call at `staging_key` against a one-shot injected failure.
-/// `true` when this is the call that must fail, which also disarms it.
+/// `true` when this is the call that must fail, which also disarms it. Each
+/// injector holds one armed key, so arming a second replaces the first.
 fn interrupts(budget: &mut Option<(Vec<u8>, u64)>, staging_key: &[u8]) -> bool {
     match budget {
         Some((key, _)) if key != staging_key => false,
@@ -145,6 +156,9 @@ impl StagingStore for InMemoryStagingStore {
         let mut inner = self.inner.lock().expect("lock");
         if interrupts(&mut inner.staged_removal_budget, staging_key) {
             return Err(SeamError::new("remove_staged_bytes unavailable"));
+        }
+        if interrupts(&mut inner.dropped_removal_budget, staging_key) {
+            return Ok(());
         }
         inner.staged.remove(staging_key);
         Ok(())

--- a/crates/engine/src/testkit/fakes/staging_store.rs
+++ b/crates/engine/src/testkit/fakes/staging_store.rs
@@ -12,6 +12,8 @@ struct Inner {
     fail_queued_ops: bool,
     fail_remove_op: bool,
     enqueue_budget: Option<u64>,
+    staged_write_budget: Option<(Vec<u8>, u64)>,
+    staged_removal_budget: Option<(Vec<u8>, u64)>,
 }
 
 impl Default for Inner {
@@ -23,6 +25,8 @@ impl Default for Inner {
             fail_queued_ops: false,
             fail_remove_op: false,
             enqueue_budget: None,
+            staged_write_budget: None,
+            staged_removal_budget: None,
         }
     }
 }
@@ -53,6 +57,37 @@ impl InMemoryStagingStore {
     /// sequence and see what the earlier entries already committed.
     pub fn fail_enqueue_after(&self, budget: u64) {
         self.inner.lock().expect("lock").enqueue_budget = Some(budget);
+    }
+
+    /// Lets `budget` writes at `staging_key` through, fails the next one, and
+    /// then lets every write through again — so a test can drop a caller
+    /// between two durable effects at an exact step and let its retry proceed.
+    pub fn fail_staged_write_after(&self, staging_key: &[u8], budget: u64) {
+        self.inner.lock().expect("lock").staged_write_budget = Some((staging_key.to_vec(), budget));
+    }
+
+    /// The removal counterpart of [`Self::fail_staged_write_after`]: the other
+    /// side of every crash window between a durable write and a release.
+    pub fn fail_staged_removal_after(&self, staging_key: &[u8], budget: u64) {
+        self.inner.lock().expect("lock").staged_removal_budget =
+            Some((staging_key.to_vec(), budget));
+    }
+}
+
+/// Charge one call at `staging_key` against a one-shot injected failure.
+/// `true` when this is the call that must fail, which also disarms it.
+fn interrupts(budget: &mut Option<(Vec<u8>, u64)>, staging_key: &[u8]) -> bool {
+    match budget {
+        Some((key, _)) if key != staging_key => false,
+        Some((_, 0)) => {
+            *budget = None;
+            true
+        }
+        Some((_, remaining)) => {
+            *remaining -= 1;
+            false
+        }
+        None => false,
     }
 }
 
@@ -88,11 +123,11 @@ impl StagingStore for InMemoryStagingStore {
     }
 
     async fn put_staged_bytes(&self, staging_key: &[u8], bytes: &[u8]) -> SeamResult<()> {
-        self.inner
-            .lock()
-            .expect("lock")
-            .staged
-            .insert(staging_key.to_vec(), bytes.to_vec());
+        let mut inner = self.inner.lock().expect("lock");
+        if interrupts(&mut inner.staged_write_budget, staging_key) {
+            return Err(SeamError::new("put_staged_bytes unavailable"));
+        }
+        inner.staged.insert(staging_key.to_vec(), bytes.to_vec());
         Ok(())
     }
 
@@ -107,7 +142,11 @@ impl StagingStore for InMemoryStagingStore {
     }
 
     async fn remove_staged_bytes(&self, staging_key: &[u8]) -> SeamResult<()> {
-        self.inner.lock().expect("lock").staged.remove(staging_key);
+        let mut inner = self.inner.lock().expect("lock");
+        if interrupts(&mut inner.staged_removal_budget, staging_key) {
+            return Err(SeamError::new("remove_staged_bytes unavailable"));
+        }
+        inner.staged.remove(staging_key);
         Ok(())
     }
 

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -1147,7 +1147,7 @@ fn assert_round_trips(world: &FakeWorld, blocks: &Blocks, name: &str, plaintext:
     let file = children
         .iter()
         .find(|child| child.name == name)
-        .expect("the interrupted version still published");
+        .expect("the version published");
     assert_eq!(
         block_on(engine_b.read_content(file.id)).expect("the verified read serves it"),
         plaintext,
@@ -1156,12 +1156,9 @@ fn assert_round_trips(world: &FakeWorld, blocks: &Blocks, name: &str, plaintext:
 }
 
 /// The per-leaf durable sequence is `upload → mark → release`, and an
-/// interruption anywhere in it must cost the version nothing: the bytes reached
-/// the pin store, so the write is recoverable by definition. This drops the
-/// process at the *mark* of every leaf in turn — under the reverse ordering
-/// each of these strands an already-released leaf behind the mark, the hole
-/// guard reads it as `ContentUnrecoverable`, and the valve destroys a write
-/// whose bytes had in fact uploaded (#924).
+/// interruption at the mark must cost the version nothing: those bytes reached
+/// the pin store, so the write is recoverable by definition. Every leaf is
+/// interrupted in turn, since the window is reachable on any of them (#924).
 #[test]
 fn an_interrupted_leaf_mark_never_costs_the_version_its_uploaded_bytes() {
     let plaintext: Vec<u8> = (0..200u8).collect();
@@ -1182,7 +1179,7 @@ fn an_interrupted_leaf_mark_never_costs_the_version_its_uploaded_bytes() {
         // staging store, died the instant after that leaf uploaded.
         alice
             .staging_store
-            .fail_staged_write_after(UPLOAD_MARK_KEY, interrupted as u64);
+            .interrupt_staged_write_after(UPLOAD_MARK_KEY, interrupted as u64);
         write_file(
             &mut engine,
             WriteTarget::NewFile {
@@ -1227,13 +1224,74 @@ fn an_interrupted_leaf_mark_never_costs_the_version_its_uploaded_bytes() {
     }
 }
 
-/// The window marking first opens, shown to be harmless: an interruption
-/// between a leaf's mark and its release leaves that leaf both marked *and*
-/// staged. The `Some` arm re-uploads it regardless of the mark — a pinned CID
-/// short-circuits (#819) — and re-removes it, so no arm of the loop misreads
-/// the residue.
+/// The residue that marking first leaves — a leaf both marked and still staged
+/// — costs nothing: the next pass re-uploads it, a pinned CID short-circuiting
+/// the transfer (#819), and re-removes it.
 #[test]
 fn a_leaf_left_marked_and_staged_is_re_uploaded_and_released_by_the_next_pass() {
+    let plaintext: Vec<u8> = (0..200u8).collect();
+    let leaf_count = frame_version(&plaintext).0.len();
+
+    for interrupted in 0..leaf_count {
+        let world = FakeWorld::new();
+        let blocks = Blocks::default();
+        seed_account(&world, &blocks);
+
+        let alice = world.device(b"alice");
+        let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+        write_file(
+            &mut engine,
+            WriteTarget::NewFile {
+                parent: ROOT,
+                name: "photo.bin".into(),
+            },
+            &plaintext,
+        )
+        .expect("the write commits");
+        let (root_cid, leaves) = staged_version(&alice);
+        alice
+            .staging_store
+            .interrupt_staged_removal_after(&leaves[interrupted], 0);
+        tick(&world, &engine, &mut tasks);
+
+        assert_eq!(
+            upload_mark(&alice),
+            Some((root_cid, interrupted as u32 + 1)),
+            "the mark covers the leaf whose release was interrupted"
+        );
+        assert!(
+            block_on(alice.staging_store.staged_keys())
+                .unwrap()
+                .contains(&leaves[interrupted]),
+            "that leaf is still staged: marked and present is the residue this ordering leaves"
+        );
+
+        tick(&world, &engine, &mut tasks);
+
+        assert!(
+            !events_so_far(&mut events)
+                .iter()
+                .any(|event| matches!(event, Event::DeadLetter { .. })),
+            "a marked, still-staged leaf is re-uploaded, never read as loss"
+        );
+        assert_eq!(
+            block_on(alice.staging_store.staged_keys()).unwrap(),
+            vec![DRAINED_OP_MARK_KEY.to_vec(), UPLOAD_MARK_KEY.to_vec()],
+            "the retry re-removes it, so the residue holds no staging budget"
+        );
+        assert_round_trips(&world, &blocks, "photo.bin", &plaintext);
+    }
+}
+
+/// A release that is *reported done* and never persists is the other half of
+/// the same crash: leaf 0 comes back from the dead behind a mark that later
+/// leaves already advanced. Re-uploading it must not pull the mark back down
+/// over the leaves between — those are released, so an uncovered one reads as
+/// loss and the valve destroys the version. That is #924 with one extra step,
+/// and it is reachable because `packages/client` flushes a staged write but
+/// releases with a bare `removeEntry`.
+#[test]
+fn a_re_uploaded_leaf_never_pulls_the_mark_back_over_leaves_it_covers() {
     let world = FakeWorld::new();
     let blocks = Blocks::default();
     seed_account(&world, &blocks);
@@ -1251,33 +1309,51 @@ fn a_leaf_left_marked_and_staged_is_re_uploaded_and_released_by_the_next_pass() 
     )
     .expect("the write commits");
     let (root_cid, leaves) = staged_version(&alice);
-    alice.staging_store.fail_staged_removal_after(&leaves[0], 0);
+    assert!(
+        leaves.len() > 4,
+        "enough leaves for the mark to advance past the lost release"
+    );
+
+    // Every pass stops at leaf 3, so what it leaves durably behind is what the
+    // next pass has to work from.
+    let stop_at = block_on(alice.staging_store.staged_bytes(&leaves[3]))
+        .unwrap()
+        .unwrap();
+    blocks.refuse_upload(Box::new(move |block| {
+        (block == stop_at).then(unreachable_upload)
+    }));
+    alice.staging_store.drop_staged_removal_after(&leaves[0], 0);
+
     tick(&world, &engine, &mut tasks);
 
     assert_eq!(
         upload_mark(&alice),
-        Some((root_cid, 1)),
-        "the mark covers the leaf whose release was interrupted"
+        Some((root_cid.clone(), 3)),
+        "three leaves uploaded and marked before the pass stopped"
     );
     assert!(
         block_on(alice.staging_store.staged_keys())
             .unwrap()
             .contains(&leaves[0]),
-        "that leaf is still staged: marked and present is the residue this ordering leaves"
+        "the lost release left leaf 0 staged behind a mark that already covers it"
     );
 
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(
+        upload_mark(&alice),
+        Some((root_cid, 3)),
+        "re-uploading leaf 0 leaves the mark where it stood: it only ever rises"
+    );
+
+    blocks.accept_uploads();
     tick(&world, &engine, &mut tasks);
 
     assert!(
         !events_so_far(&mut events)
             .iter()
             .any(|event| matches!(event, Event::DeadLetter { .. })),
-        "a marked, still-staged leaf is re-uploaded, never read as loss"
-    );
-    assert_eq!(
-        block_on(alice.staging_store.staged_keys()).unwrap(),
-        vec![DRAINED_OP_MARK_KEY.to_vec(), UPLOAD_MARK_KEY.to_vec()],
-        "the retry re-removes it, so the residue holds no staging budget"
+        "leaves 1 and 2 stay covered, so nothing reads their absence as loss"
     );
     assert_round_trips(&world, &blocks, "photo.bin", &plaintext);
 }

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -1094,9 +1094,9 @@ fn a_hole_in_the_staged_block_suffix_is_loss_and_fails_closed() {
     assert_no_blocks_staged(&alice, &version);
 }
 
-/// Remove one of the queued version's leaves, chosen by index from the leaf
-/// count, and return every block the version framed.
-fn evict_leaf(device: &FakeDevice, index: impl Fn(usize) -> usize) -> Vec<Vec<u8>> {
+/// The version the head queued op carries: its root CID and its leaf CIDs, in
+/// file order — the order the drain uploads and releases them in.
+fn staged_version(device: &FakeDevice) -> (Vec<u8>, Vec<Vec<u8>>) {
     block_on(async {
         let queued = device.staging_store.queued_ops().await.unwrap();
         let root_cid = record_content_root_cid(&queued[0].1).unwrap().unwrap();
@@ -1107,16 +1107,179 @@ fn evict_leaf(device: &FakeDevice, index: impl Fn(usize) -> usize) -> Vec<Vec<u8
             .unwrap()
             .unwrap();
         let leaves = decode_root(&root_block).unwrap().leaf_cids;
+        (root_cid, leaves)
+    })
+}
+
+/// Remove one of the queued version's leaves, chosen by index from the leaf
+/// count, and return every block the version framed.
+fn evict_leaf(device: &FakeDevice, index: impl Fn(usize) -> usize) -> Vec<Vec<u8>> {
+    let (root_cid, leaves) = staged_version(device);
+    block_on(
         device
             .staging_store
-            .remove_staged_bytes(&leaves[index(leaves.len())])
-            .await
-            .unwrap();
-        leaves
-            .into_iter()
-            .chain(core::iter::once(root_cid))
-            .collect()
-    })
+            .remove_staged_bytes(&leaves[index(leaves.len())]),
+    )
+    .unwrap();
+    leaves
+        .into_iter()
+        .chain(core::iter::once(root_cid))
+        .collect()
+}
+
+/// The durable upload mark as [`UPLOAD_MARK_KEY`] holds it: the version root it
+/// names and the leaf count it claims.
+fn upload_mark(device: &FakeDevice) -> Option<(Vec<u8>, u32)> {
+    let stored = block_on(device.staging_store.staged_bytes(UPLOAD_MARK_KEY)).unwrap()?;
+    let (root, count) = stored.split_at(stored.len() - 4);
+    Some((root.to_vec(), u32::from_be_bytes(count.try_into().unwrap())))
+}
+
+/// A second device that only ever saw the network reads `plaintext` back off
+/// the published version — the end-to-end statement that no leaf was lost.
+fn assert_round_trips(world: &FakeWorld, blocks: &Blocks, name: &str, plaintext: &[u8]) {
+    let bob = world.device(b"alice-second-device");
+    serve_http(&bob, blocks, 400);
+    let (mut engine_b, _events_b) = engine_on(&bob, 7);
+    block_on(engine_b.start(secret()))
+        .expect("the second device cold-starts off the published record plane");
+    let children = block_on(engine_b.view()).unwrap().children(ROOT);
+    let file = children
+        .iter()
+        .find(|child| child.name == name)
+        .expect("the interrupted version still published");
+    assert_eq!(
+        block_on(engine_b.read_content(file.id)).expect("the verified read serves it"),
+        plaintext,
+        "every leaf is on the network and the version assembles from them"
+    );
+}
+
+/// The per-leaf durable sequence is `upload → mark → release`, and an
+/// interruption anywhere in it must cost the version nothing: the bytes reached
+/// the pin store, so the write is recoverable by definition. This drops the
+/// process at the *mark* of every leaf in turn — under the reverse ordering
+/// each of these strands an already-released leaf behind the mark, the hole
+/// guard reads it as `ContentUnrecoverable`, and the valve destroys a write
+/// whose bytes had in fact uploaded (#924).
+#[test]
+fn an_interrupted_leaf_mark_never_costs_the_version_its_uploaded_bytes() {
+    let plaintext: Vec<u8> = (0..200u8).collect();
+    let leaves = frame_version(&plaintext).0.len();
+    assert!(
+        leaves > 2,
+        "a multi-leaf version, so the interior interruption points are real"
+    );
+
+    for interrupted in 0..leaves {
+        let world = FakeWorld::new();
+        let blocks = Blocks::default();
+        seed_account(&world, &blocks);
+
+        let alice = world.device(b"alice");
+        let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+        // The mark for leaf `interrupted` never lands: the process, or the
+        // staging store, died the instant after that leaf uploaded.
+        alice
+            .staging_store
+            .fail_staged_write_after(UPLOAD_MARK_KEY, interrupted as u64);
+        write_file(
+            &mut engine,
+            WriteTarget::NewFile {
+                parent: ROOT,
+                name: "photo.bin".into(),
+            },
+            &plaintext,
+        )
+        .expect("the write commits");
+        let (root_cid, _) = staged_version(&alice);
+        tick(&world, &engine, &mut tasks);
+
+        assert_eq!(
+            upload_mark(&alice),
+            (interrupted > 0).then_some((root_cid, interrupted as u32)),
+            "the pass stopped at exactly the interruption point under test"
+        );
+        assert!(
+            !events_so_far(&mut events)
+                .iter()
+                .any(|event| matches!(event, Event::DeadLetter { .. })),
+            "an interrupted durable sequence is an outage, never an abandonment"
+        );
+        assert!(
+            !block_on(alice.staging_store.queued_ops())
+                .unwrap()
+                .is_empty(),
+            "the op keeps its place at the head of the queue for the next pass"
+        );
+
+        // The staging store is back: the next pass must finish the very version
+        // whose leaves already uploaded.
+        tick(&world, &engine, &mut tasks);
+
+        assert!(
+            !events_so_far(&mut events)
+                .iter()
+                .any(|event| matches!(event, Event::DeadLetter { .. })),
+            "the resumed pass reads the residue as progress, not as content loss"
+        );
+        assert_round_trips(&world, &blocks, "photo.bin", &plaintext);
+    }
+}
+
+/// The window marking first opens, shown to be harmless: an interruption
+/// between a leaf's mark and its release leaves that leaf both marked *and*
+/// staged. The `Some` arm re-uploads it regardless of the mark — a pinned CID
+/// short-circuits (#819) — and re-removes it, so no arm of the loop misreads
+/// the residue.
+#[test]
+fn a_leaf_left_marked_and_staged_is_re_uploaded_and_released_by_the_next_pass() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let plaintext: Vec<u8> = (0..200u8).collect();
+    write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &plaintext,
+    )
+    .expect("the write commits");
+    let (root_cid, leaves) = staged_version(&alice);
+    alice.staging_store.fail_staged_removal_after(&leaves[0], 0);
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(
+        upload_mark(&alice),
+        Some((root_cid, 1)),
+        "the mark covers the leaf whose release was interrupted"
+    );
+    assert!(
+        block_on(alice.staging_store.staged_keys())
+            .unwrap()
+            .contains(&leaves[0]),
+        "that leaf is still staged: marked and present is the residue this ordering leaves"
+    );
+
+    tick(&world, &engine, &mut tasks);
+
+    assert!(
+        !events_so_far(&mut events)
+            .iter()
+            .any(|event| matches!(event, Event::DeadLetter { .. })),
+        "a marked, still-staged leaf is re-uploaded, never read as loss"
+    );
+    assert_eq!(
+        block_on(alice.staging_store.staged_keys()).unwrap(),
+        vec![DRAINED_OP_MARK_KEY.to_vec(), UPLOAD_MARK_KEY.to_vec()],
+        "the retry re-removes it, so the residue holds no staging budget"
+    );
+    assert_round_trips(&world, &blocks, "photo.bin", &plaintext);
 }
 
 /// The abandonment released the version: none of its blocks still hold staging


### PR DESCRIPTION
## Problem

The drain's per-leaf upload step ordered its three durable effects `upload → remove → mark`. A crash — or a staging-store failure — between the removal and the mark leaves the mark at `index` while leaf `index` is already gone from staging. The next pass reads the mark as `index`, reaches leaf `index`, gets `None` from `staged_block`, and the hole guard `None if index >= uploaded => Err(CONTENT_LOST)` fires.

`CONTENT_LOST` is `Halt::Permanent(DeadLetterReason::ContentUnrecoverable)`, so the failure valve abandons the op and `release_staged_blocks` discards the rest of the version — destroying a write whose bytes had in fact uploaded successfully. The window is one `remove_staged_bytes` wide per leaf, and it is reachable on any leaf of any version.

## Change

Two changes, both about the same invariant.

### 1. The mark is written before the staged bytes are released

The ordering argument, which is the substance of this slice:

- The mark is only ever consulted on the `None` arm. A leaf that is still *present* is uploaded again regardless of what the mark says, and re-upload is free — `registerPin` short-circuits an already-pinned CID (#819).
- So the old invariant ("the mark never claims more than the store has released") protected nothing that any reader depends on, while the state it permitted — a released leaf the mark does not cover — is exactly the state the hole guard reads as unrecoverable loss.
- Under the new ordering the residue is a leaf both *marked* and *staged*. The `Some` arm re-uploads and re-removes it. The "still-staged blocks are a suffix" invariant is untouched, because removal still happens only after a confirmed `UploadResult`, in file order.

This is the same rule `crates/desktop-seams` already applies to the op record and its sidecar (hard constraint 5, `staging_store_removal_ordering_leaves_only_a_reclaimable_orphan`): order the durable effects so an interruption leaves a **harmless orphan**, never a dangling reference. A marked-and-staged leaf is the harmless orphan; a released-but-unmarked leaf is the dangling reference.

### 2. The mark only ever rises

Marking first makes "staged at an index *below* the durable mark" a reachable state for the first time, and the `Some` arm wrote `mark_uploaded(index + 1)` unconditionally — so re-uploading such a leaf would **lower** the durable mark below leaves an earlier pass had already released. One further interruption and those genuinely-uploaded leaves are absent and uncovered: `CONTENT_LOST`, valve, version destroyed. The same destruction, one step later.

The reachable source is a release that is *reported done and never persists*: `packages/client/src/seams/stagingStore.ts` flushes a staged write with `handle.flush()` but releases with a bare `dir.removeEntry` and no durability barrier, so "the later flushed mark survives, the earlier unflushed unlink does not" is the crash shape to expect on OPFS. The mark is now written only when it advances, which also saves a durable write per re-uploaded leaf.

Found by the `/crypto-privacy-review` gate on this PR's own diff.

## Tests

All in `crates/engine/tests/write_plane.rs`, gated by `Engine Tests`. The test fakes had no way to reach an interrupted-between-steps state, so this adds injection to `InMemoryStagingStore`: `interrupt_staged_write_after` / `interrupt_staged_removal_after` let `n` calls at a given staging key through, fail the next, and disarm — a one-shot outage at an exact step whose retry then proceeds — and `drop_staged_removal_after` reports a removal done without performing it, the lost-unlink shape.

- **`an_interrupted_leaf_mark_never_costs_the_version_its_uploaded_bytes`** — drops the durable mark at **every leaf in turn**. At each interruption point it asserts the state explicitly: the mark stands exactly at the leaf under test, no dead letter fired, and the op keeps its place at the head of the queue. Then the store returns, the next pass runs, and a second device that only ever saw the network reads the file back byte-for-byte.
- **`a_leaf_left_marked_and_staged_is_re_uploaded_and_released_by_the_next_pass`** — the window the fix opens, at **every leaf in turn**. Asserts the residue directly: the mark covers the leaf **and** the leaf is still staged. The next pass re-uploads it, re-removes it, dead-letters nothing, and leaves only queue bookkeeping.
- **`a_re_uploaded_leaf_never_pulls_the_mark_back_over_leaves_it_covers`** — the regression path for change 2. Leaf 0's release is silently lost while leaves 1 and 2 upload and mark; every pass is stopped at leaf 3. The resumed pass re-uploads leaf 0 and must leave the mark at 3, not pull it back to 1.

Reverting each fix on its own:

```text
# statements swapped back to upload -> remove -> mark
---- an_interrupted_leaf_mark_never_costs_the_version_its_uploaded_bytes ----
panicked at: the resumed pass reads the residue as progress, not as content loss
---- a_leaf_left_marked_and_staged_is_re_uploaded_and_released_by_the_next_pass ----
panicked at: the mark covers the leaf whose release was interrupted
  left: None      right: Some((<root cid>, 1))
test result: FAILED. 45 passed; 2 failed

# high-water guard removed, ordering kept
---- a_re_uploaded_leaf_never_pulls_the_mark_back_over_leaves_it_covers ----
panicked at: re-uploading leaf 0 leaves the mark where it stood: it only ever rises
  left: Some((<root cid>, 1))      right: Some((<root cid>, 3))
test result: FAILED. 47 passed; 1 failed
```

`an_evicted_prefix_of_the_block_set_is_loss_not_progress` and `a_hole_in_the_staged_block_suffix_is_loss_and_fails_closed` both still pass — a genuinely evicted prefix and a genuine hole stay loss. Only the crash residue becomes recoverable.

## Verification

All exit 0 on this branch:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets`
- `cargo test -p cipherbox-engine` — 734 passed, 0 failed
- `pnpm -r --if-present run typecheck` and `pnpm -r --if-present run test` — api 177, web 67, all passed
- `pnpm exec eslint .` — clean. No TypeScript surface changed.

Review gates run on this diff: `/security-review` found nothing; `/simplify` returned six cleanups, all folded in — doc trims, and the injectors renamed from `fail_*` to `interrupt_*` so they do not read as the permanently-failing `fail_enqueue_after` convention in the same fake; `/crypto-privacy-review` found the mark-regression defect above, also folded in.

## Deferred

#940 — `upload_mark` bounds the root CID it accepts but not the count, so a corrupt-but-parseable mark can skip every absent leaf and publish a manifest naming blocks nothing holds. Pre-existing, and left out because the repair is a real design choice: reading a corrupt mark as zero destroys a write whose bytes are on the network, while clamping is the maximally trusting reading of bytes already known to be corrupt. #940 depends on this PR and should land after it.

## Note on parallel work

#869 owns reconciling the four-way staged-byte lifetime and will rewrite this loop. This change is scoped to the `Some` arm and the fake's new injection hooks, and touches no shared staging helper, so it should rebase cleanly either way. Per #924 it should land before #869 rewrites the loop, but neither blocks the other.

Closes #924

Part of #655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when uploading and releasing staged data.
  * Upload progress now remains consistent across retries and recovery scenarios.
  * Previously processed data is safely re-uploaded when needed without losing progress.
  * Fixed interruptions that could leave staged content unreleased or incorrectly marked as complete.
  * Added safeguards to prevent valid uploaded content from being incorrectly discarded.
  * Improved recovery of partially completed uploads across devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->