### PR TITLE
feat: resolve the focus window's folders below the scope root

### DIFF
--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -38,10 +38,10 @@ use crate::entropy::Entropy;
 use crate::gate::{GateError, floor};
 use crate::hex::hex_lower;
 use crate::net::{
-    Adopter, ChildAdopter, EolRenewResult, FolderRefresh, FolderRefreshReport, HeldMaterial,
+    Adopter, ChildAdopter, ChildResolveError, EolRenewResult, FolderRefresh, HeldMaterial,
     HeldRecord, HeldRecords, LivenessControl, PublishError, PublishOutcome, RE_PUT_INTERVAL,
     RecordPointerFetch, ResolveOutcome, RootAdopter, eol_renew_pass, keyless_re_put,
-    refresh_base_from_outcome, resolve, resolve_and_hold, run_liveness_loop,
+    refresh_base_from_outcome, resolve_and_hold, resolve_child, run_liveness_loop,
 };
 use crate::profile::SyncTimingProfile;
 use crate::rotation::derive_write_name;
@@ -62,7 +62,7 @@ pub use crate::sync::rebase::DeadLetterReason;
 use crate::sync::record::{RecordReader, RecordSeal};
 use crate::sync::staging::stage_op;
 use crate::sync::staleness::{Connectivity, classify};
-use crate::sync::tick::{FocusWindow, focus_folders, on_access_refresh_due};
+use crate::sync::tick::{FocusWindow, focus_folders, focus_folders_due};
 
 /// The stable 16-byte node identifier (`id16`, blueprint/core.md). Public,
 /// non-secret, and location-independent — routes and commands key on it,
@@ -880,16 +880,17 @@ fn node_attrs(meta: &NodeMeta) -> NodeAttrs {
     }
 }
 
-/// Stamp every folder a focus pass merged with the caller's clock reading, so
-/// the on-access threshold measures from the last gate-passing merge. A folder
-/// the pass could not merge keeps its old stamp and stays due.
+/// Stamp every folder a focus pass attempted against the caller's clock
+/// reading. Attempts, not merges: an unresolvable folder must not turn every
+/// navigation into a fresh endpoint fan-out, and the poll leg refreshes the
+/// window regardless, so recovery stays automatic.
 fn stamp_focus_refreshed(
     stamps: &RefCell<BTreeMap<NodeId, UnixMillis>>,
-    report: &FolderRefreshReport,
+    folders: &[NodeId],
     now: UnixMillis,
 ) {
     let mut stamps = stamps.borrow_mut();
-    for folder in &report.refreshed {
+    for folder in folders {
         stamps.insert(*folder, now);
     }
 }
@@ -1131,9 +1132,9 @@ pub struct Engine<T: SeamTypes> {
     /// open, whose record and whole ancestor chain every resolve tick refreshes.
     /// Shared with the tick loop, which reads it on each pass.
     focus: Rc<RefCell<FocusWindow>>,
-    /// When each focus folder last merged a gate-passing body, so a navigation
-    /// inside the staleness threshold renders state already held instead of
-    /// re-resolving (blueprint/engine.md: refresh on access past the threshold).
+    /// When each focus folder was last refreshed, so a navigation inside the
+    /// staleness threshold renders state already held instead of re-probing the
+    /// record plane (blueprint/engine.md: refresh on access past the threshold).
     focus_refreshed: Rc<RefCell<BTreeMap<NodeId, UnixMillis>>>,
     /// Retained dead-lettered ops. Feeds [`SnapshotView`]'s dead-letter surface
     /// (#33 D6: dead letters are retained, never silent).
@@ -1592,7 +1593,7 @@ impl<T: SeamTypes> Engine<T> {
                 if let Some(read_seed) = &read_seed
                     && !open.is_empty()
                 {
-                    let report = FolderRefresh {
+                    let changed = FolderRefresh {
                         transport: &transport,
                         snapshot_cache: &snapshot_cache,
                         http: &http,
@@ -1604,8 +1605,8 @@ impl<T: SeamTypes> Engine<T> {
                     }
                     .run(&open)
                     .await;
-                    stamp_focus_refreshed(&focus_refreshed, &report, scheduler.now());
-                    if report.changed {
+                    stamp_focus_refreshed(&focus_refreshed, &open, scheduler.now());
+                    if changed {
                         let _ = events.unbounded_send(Event::SnapshotUpdated);
                     }
                 }
@@ -1784,31 +1785,23 @@ impl<T: SeamTypes> Engine<T> {
     }
 
     /// Refresh the focus window's folders that are past the on-access staleness
-    /// threshold, returning whether the base changed. A folder refreshed inside
-    /// the threshold is left alone — the window still rides every resolve tick.
+    /// threshold, returning whether the base changed.
     async fn refresh_focus_on_access(&self, now: UnixMillis) -> bool {
-        let due: Vec<NodeId> = {
-            let refreshed = self.focus_refreshed.borrow();
-            focus_folders(&self.snapshot.borrow(), &self.focus.borrow())
-                .into_iter()
-                .filter(|folder| {
-                    refreshed
-                        .get(folder)
-                        .is_none_or(|last| on_access_refresh_due(now, *last, &self.profile))
-                })
-                .collect()
-        };
+        let due = focus_folders_due(
+            &self.snapshot.borrow(),
+            &self.focus.borrow(),
+            &self.focus_refreshed.borrow(),
+            now,
+            &self.profile,
+        );
         if due.is_empty() {
             return false;
         }
-        // The vault root scope: granted-subscope focus is a later slice. A
-        // missing read seed is missing held material (availability), never a
-        // trust verdict — the window simply does not refresh this pass.
         let scope_id = self.snapshot.borrow().root.0;
         let Some(scope_read_seed) = self.scope_read_seeds.borrow().get(&scope_id).cloned() else {
             return false;
         };
-        let report = FolderRefresh {
+        let changed = FolderRefresh {
             transport: &self.seams.record_transport,
             snapshot_cache: &self.seams.snapshot_cache,
             http: &self.seams.http,
@@ -1820,8 +1813,8 @@ impl<T: SeamTypes> Engine<T> {
         }
         .run(&due)
         .await;
-        stamp_focus_refreshed(&self.focus_refreshed, &report, now);
-        report.changed
+        stamp_focus_refreshed(&self.focus_refreshed, &due, now);
+        changed
     }
 
     // -----------------------------------------------------------------------
@@ -2305,39 +2298,17 @@ impl<T: SeamTypes> Engine<T> {
             scope_read_seed,
             node.0,
         );
-        let resolved = resolve(
+        let adopted = resolve_child(
             &self.seams.record_transport,
             &self.seams.snapshot_cache,
             &adopter,
             &name,
         )
         .await
-        .map_err(|e| EngineError::ContentUnavailable {
-            message: e.message().to_owned(),
+        .map_err(|e| match e {
+            ChildResolveError::Unavailable(message) => EngineError::ContentUnavailable { message },
+            ChildResolveError::Gate(gate) => EngineError::from_gate(gate),
         })?;
-        // One at-floor re-open serves both non-adopt outcomes: `Current` carries
-        // the re-fetched bytes, `NoUpdate` falls back to the cached
-        // last-known-good; neither advances a floor.
-        let adopted = 'adopted: {
-            let record_bytes = match resolved.outcome {
-                ResolveOutcome::Adopted(adopted) => break 'adopted adopted,
-                ResolveOutcome::TrustViolation(rejection) => {
-                    return Err(EngineError::from_gate(GateError::Rejected(rejection)));
-                }
-                ResolveOutcome::Current { record_bytes } => record_bytes,
-                ResolveOutcome::NoUpdate => {
-                    resolved
-                        .last_known_good
-                        .ok_or_else(|| EngineError::ContentUnavailable {
-                            message: "no record source reachable and no cached record".to_owned(),
-                        })?
-                }
-            };
-            adopter
-                .open_at_floor(&name, &record_bytes)
-                .await
-                .map_err(EngineError::from_gate)?
-        };
 
         let ReadBody::File { versions, .. } = adopted.read_body else {
             // The parent's child ref said file: a sealed folder body is a kind

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -38,10 +38,10 @@ use crate::entropy::Entropy;
 use crate::gate::{GateError, floor};
 use crate::hex::hex_lower;
 use crate::net::{
-    Adopter, ChildAdopter, EolRenewResult, HeldMaterial, HeldRecord, HeldRecords, LivenessControl,
-    PublishError, PublishOutcome, RE_PUT_INTERVAL, RecordPointerFetch, ResolveOutcome, RootAdopter,
-    eol_renew_pass, keyless_re_put, refresh_base_from_outcome, resolve, resolve_and_hold,
-    run_liveness_loop,
+    Adopter, ChildAdopter, EolRenewResult, FolderRefresh, FolderRefreshReport, HeldMaterial,
+    HeldRecord, HeldRecords, LivenessControl, PublishError, PublishOutcome, RE_PUT_INTERVAL,
+    RecordPointerFetch, ResolveOutcome, RootAdopter, eol_renew_pass, keyless_re_put,
+    refresh_base_from_outcome, resolve, resolve_and_hold, run_liveness_loop,
 };
 use crate::profile::SyncTimingProfile;
 use crate::rotation::derive_write_name;
@@ -62,6 +62,7 @@ pub use crate::sync::rebase::DeadLetterReason;
 use crate::sync::record::{RecordReader, RecordSeal};
 use crate::sync::staging::stage_op;
 use crate::sync::staleness::{Connectivity, classify};
+use crate::sync::tick::{FocusWindow, focus_folders, on_access_refresh_due};
 
 /// The stable 16-byte node identifier (`id16`, blueprint/core.md). Public,
 /// non-secret, and location-independent — routes and commands key on it,
@@ -879,6 +880,20 @@ fn node_attrs(meta: &NodeMeta) -> NodeAttrs {
     }
 }
 
+/// Stamp every folder a focus pass merged with the caller's clock reading, so
+/// the on-access threshold measures from the last gate-passing merge. A folder
+/// the pass could not merge keeps its old stamp and stays due.
+fn stamp_focus_refreshed(
+    stamps: &RefCell<BTreeMap<NodeId, UnixMillis>>,
+    report: &FolderRefreshReport,
+    now: UnixMillis,
+) {
+    let mut stamps = stamps.borrow_mut();
+    for folder in &report.refreshed {
+        stamps.insert(*folder, now);
+    }
+}
+
 /// Emit an [`Event::RenewalFailed`] for every sub-EOL renewal that did not land
 /// (a lost CAS race or a fail-closed publish failure). A comfortably-ahead or
 /// republished record emits nothing. Best-effort over the in-process channel: a
@@ -1112,6 +1127,14 @@ pub struct Engine<T: SeamTypes> {
     /// [`scope_read_seeds`](Self::scope_read_seeds); the drain derives each new
     /// node's `ipnsName` and its narrow per-name signer from them.
     scope_write_seeds: Rc<RefCell<ScopeWriteSeeds>>,
+    /// The open focus window ([`Command::SetFocus`]): the folder the host has
+    /// open, whose record and whole ancestor chain every resolve tick refreshes.
+    /// Shared with the tick loop, which reads it on each pass.
+    focus: Rc<RefCell<FocusWindow>>,
+    /// When each focus folder last merged a gate-passing body, so a navigation
+    /// inside the staleness threshold renders state already held instead of
+    /// re-resolving (blueprint/engine.md: refresh on access past the threshold).
+    focus_refreshed: Rc<RefCell<BTreeMap<NodeId, UnixMillis>>>,
     /// Retained dead-lettered ops. Feeds [`SnapshotView`]'s dead-letter surface
     /// (#33 D6: dead letters are retained, never silent).
     dead_letters: Rc<RefCell<RetainedDeadLetters>>,
@@ -1169,6 +1192,8 @@ impl<T: SeamTypes> Engine<T> {
                 sync_status: Rc::new(RefCell::new(SyncStatus::default())),
                 scope_read_seeds: Rc::new(RefCell::new(BTreeMap::new())),
                 scope_write_seeds: Rc::new(RefCell::new(BTreeMap::new())),
+                focus: Rc::new(RefCell::new(FocusWindow::default())),
+                focus_refreshed: Rc::new(RefCell::new(BTreeMap::new())),
                 dead_letters: Rc::new(RefCell::new(BTreeMap::new())),
                 queue_scan: RefCell::new(QueueScanMemo::default()),
                 blocked: Rc::new(RefCell::new(None)),
@@ -1495,6 +1520,8 @@ impl<T: SeamTypes> Engine<T> {
         let alive = self.alive.clone();
         let sync_status = self.sync_status.clone();
         let scope_read_seeds = self.scope_read_seeds.clone();
+        let focus = self.focus.clone();
+        let focus_refreshed = self.focus_refreshed.clone();
         let profile = self.profile;
         let interval = self.profile.poll_cadence;
         let owner_identity = session.owner_identity();
@@ -1556,11 +1583,36 @@ impl<T: SeamTypes> Engine<T> {
                         let _ = events.unbounded_send(Event::SnapshotUpdated);
                     }
                 }
+                let read_seed = scope_read_seeds.borrow().get(&root_id).cloned();
+                // The focus window's folders below the root — the read leg for a
+                // subtree this device did not author. It runs before the drain,
+                // so the queue rebases onto the deepest state this pass
+                // reconciled, not just the root's.
+                let open = focus_folders(&base.borrow(), &focus.borrow());
+                if let Some(read_seed) = &read_seed
+                    && !open.is_empty()
+                {
+                    let report = FolderRefresh {
+                        transport: &transport,
+                        snapshot_cache: &snapshot_cache,
+                        http: &http,
+                        floors: &floors,
+                        gateway: &gateway,
+                        base: &base,
+                        scope_id: root_id,
+                        scope_read_seed: read_seed,
+                    }
+                    .run(&open)
+                    .await;
+                    stamp_focus_refreshed(&focus_refreshed, &report, scheduler.now());
+                    if report.changed {
+                        let _ = events.unbounded_send(Event::SnapshotUpdated);
+                    }
+                }
                 // The drain rides the same tick: it publishes onto exactly the
                 // gate-passing state this pass just reconciled. Both scope seeds
                 // are required — without them there is no name to publish under
                 // and no key to seal with, so the queue simply waits.
-                let read_seed = scope_read_seeds.borrow().get(&root_id).cloned();
                 let write_seed = scope_write_seeds.borrow().get(&root_id).cloned();
                 if let (Some(read_seed), Some(write_seed)) = (read_seed, write_seed) {
                     let report = Drain {
@@ -1707,6 +1759,17 @@ impl<T: SeamTypes> Engine<T> {
                 );
                 self.stage_and_notify(&op).await
             }
+            Command::SetFocus { node } => {
+                self.focus.borrow_mut().open_folder = node;
+                // Navigation is the tick model's second trigger source (#33 D2):
+                // refresh the newly-focused chain now rather than waiting out a
+                // poll cadence, and only past the staleness threshold — a repeat
+                // visit renders the state already held.
+                if self.refresh_focus_on_access(authored_at).await {
+                    let _ = self.events.unbounded_send(Event::SnapshotUpdated);
+                }
+                Ok(None)
+            }
             Command::SiweLogin { message, signature } => {
                 let api = self.api.as_ref().ok_or(EngineError::NotStarted)?;
                 api.siwe_login(&message, &hex_lower(&signature))
@@ -1718,6 +1781,47 @@ impl<T: SeamTypes> Engine<T> {
                 command: other.name(),
             }),
         }
+    }
+
+    /// Refresh the focus window's folders that are past the on-access staleness
+    /// threshold, returning whether the base changed. A folder refreshed inside
+    /// the threshold is left alone — the window still rides every resolve tick.
+    async fn refresh_focus_on_access(&self, now: UnixMillis) -> bool {
+        let due: Vec<NodeId> = {
+            let refreshed = self.focus_refreshed.borrow();
+            focus_folders(&self.snapshot.borrow(), &self.focus.borrow())
+                .into_iter()
+                .filter(|folder| {
+                    refreshed
+                        .get(folder)
+                        .is_none_or(|last| on_access_refresh_due(now, *last, &self.profile))
+                })
+                .collect()
+        };
+        if due.is_empty() {
+            return false;
+        }
+        // The vault root scope: granted-subscope focus is a later slice. A
+        // missing read seed is missing held material (availability), never a
+        // trust verdict — the window simply does not refresh this pass.
+        let scope_id = self.snapshot.borrow().root.0;
+        let Some(scope_read_seed) = self.scope_read_seeds.borrow().get(&scope_id).cloned() else {
+            return false;
+        };
+        let report = FolderRefresh {
+            transport: &self.seams.record_transport,
+            snapshot_cache: &self.seams.snapshot_cache,
+            http: &self.seams.http,
+            floors: &self.seams.floor_store,
+            gateway: &self.gateway,
+            base: &self.snapshot,
+            scope_id,
+            scope_read_seed: &scope_read_seed,
+        }
+        .run(&due)
+        .await;
+        stamp_focus_refreshed(&self.focus_refreshed, &report, now);
+        report.changed
     }
 
     // -----------------------------------------------------------------------

--- a/crates/engine/src/net/child.rs
+++ b/crates/engine/src/net/child.rs
@@ -21,10 +21,10 @@ use cipherbox_core::seal::{Envelope, ReadBody, has_grant_section, open_read_body
 use zeroize::Zeroizing;
 
 use super::adopter::{LocalHead, assemble_head_envelope, reject};
-use super::resolve::{AdoptOutcome, Adopter};
+use super::resolve::{AdoptOutcome, Adopter, ResolveOutcome, resolve};
 use crate::content::Gateway;
 use crate::gate::{Adopted, GateError, GateStage, floor};
-use crate::seams::{FloorStore, Http};
+use crate::seams::{FloorStore, Http, RecordTransport, SnapshotCache};
 
 /// The child-record [`Adopter`] for one non-root node of an owned scope.
 /// Borrows the content seams from the live session; terminally owns a
@@ -188,6 +188,54 @@ impl<H: Http, F: FloorStore> ChildAdopter<'_, H, F> {
             envelope,
         ))
     }
+}
+
+/// Why a child-record resolve produced no adopted body.
+pub(crate) enum ChildResolveError {
+    /// No reachable source and no cached record — availability staleness.
+    Unavailable(String),
+    /// The record failed the gate — fail-closed.
+    Gate(GateError),
+}
+
+/// One child record's cache-first gated resolve: the child gate on a strictly
+/// newer record, then an at-floor re-open of the current or cached bytes so a
+/// process starting over durable floors still renders.
+///
+/// Both read paths that descend below the scope root — a file's content read
+/// and the focus-window folder refresh — walk this one function, so neither can
+/// drift on which outcome is staleness and which is a fail-closed violation.
+pub(crate) async fn resolve_child<T, S, H, F>(
+    transport: &T,
+    snapshot_cache: &S,
+    adopter: &ChildAdopter<'_, H, F>,
+    name: &IpnsName,
+) -> Result<Adopted, ChildResolveError>
+where
+    T: RecordTransport,
+    S: SnapshotCache,
+    H: Http,
+    F: FloorStore,
+{
+    let resolved = resolve(transport, snapshot_cache, adopter, name)
+        .await
+        .map_err(|e| ChildResolveError::Unavailable(e.message().to_owned()))?;
+    let record_bytes = match resolved.outcome {
+        ResolveOutcome::Adopted(adopted) => return Ok(adopted),
+        ResolveOutcome::TrustViolation(rejection) => {
+            return Err(ChildResolveError::Gate(GateError::Rejected(rejection)));
+        }
+        ResolveOutcome::Current { record_bytes } => record_bytes,
+        ResolveOutcome::NoUpdate => resolved.last_known_good.ok_or_else(|| {
+            ChildResolveError::Unavailable(
+                "no record source reachable and no cached record".to_owned(),
+            )
+        })?,
+    };
+    adopter
+        .open_at_floor(name, &record_bytes)
+        .await
+        .map_err(ChildResolveError::Gate)
 }
 
 impl<H: Http, F: FloorStore> Adopter for ChildAdopter<'_, H, F> {

--- a/crates/engine/src/net/focus.rs
+++ b/crates/engine/src/net/focus.rs
@@ -1,0 +1,132 @@
+//! The focus-window folder refresh: the read leg that renders a folder **below**
+//! the scope root on a device that did not author it (blueprint/engine.md
+//! "Sync core: focus-window tick").
+//!
+//! The vault-pointer leg lifts the root's direct children only, and the drain
+//! only ever repaints folders this device published itself. Everything deeper
+//! comes from here: each folder the focus window names resolves its own record
+//! cache-first, passes the [`ChildAdopter`] gate on this device's floors, and
+//! merges into the base through [`project_folder`] — the same merge model the
+//! root leg uses, one level down. No new crypto and no new seam.
+
+use core::cell::RefCell;
+
+use cipherbox_core::ipns::IpnsName;
+use cipherbox_core::seal::ReadBody;
+use zeroize::Zeroizing;
+
+use super::child::ChildAdopter;
+use super::resolve::{ResolveOutcome, resolve};
+use crate::content::Gateway;
+use crate::facade::{NodeId, NodeKind};
+use crate::gate::Adopted;
+use crate::seams::{FloorStore, Http, RecordTransport, SnapshotCache};
+use crate::sync::model::Snapshot;
+use crate::sync::project::project_folder;
+
+/// What one focus-window folder pass did.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct FolderRefreshReport {
+    /// The folders whose gate-passing body merged into the base. The caller
+    /// stamps these against its own clock — this module reads no time source
+    /// (the determinism law).
+    pub(crate) refreshed: Vec<NodeId>,
+    /// Whether any merge actually changed the base, so the caller emits
+    /// `SnapshotUpdated` on a real change and stays quiet otherwise.
+    pub(crate) changed: bool,
+}
+
+/// The focus-window folder refresh over one owned scope's read material.
+/// Borrows the content/record seams from the live session; the scope read seed
+/// stays borrowed, so this pass zeroizes nothing the caller owns.
+pub(crate) struct FolderRefresh<'a, T, S, H, F> {
+    pub(crate) transport: &'a T,
+    pub(crate) snapshot_cache: &'a S,
+    pub(crate) http: &'a H,
+    pub(crate) floors: &'a F,
+    pub(crate) gateway: &'a Gateway,
+    /// The gate-passing base snapshot, merged into in place.
+    pub(crate) base: &'a RefCell<Snapshot>,
+    /// The scope every focus folder is sealed under — the vault root scope;
+    /// granted-subscope focus is a later slice.
+    pub(crate) scope_id: [u8; 16],
+    pub(crate) scope_read_seed: &'a Zeroizing<[u8; 32]>,
+}
+
+impl<T, S, H, F> FolderRefresh<'_, T, S, H, F>
+where
+    T: RecordTransport,
+    S: SnapshotCache,
+    H: Http,
+    F: FloorStore,
+{
+    /// Refresh `folders` in order, merging each gate-passing body into the base.
+    /// Every failure mode is per-folder and non-fatal: an unresolvable record is
+    /// availability staleness and a gate rejection is fail-closed — both leave
+    /// last-known-good rendering and neither stops the pass.
+    pub(crate) async fn run(&self, folders: &[NodeId]) -> FolderRefreshReport {
+        let mut report = FolderRefreshReport::default();
+        for folder in folders {
+            if let Some(adopted) = self.adopt(*folder).await {
+                let ReadBody::Folder {
+                    modified_at,
+                    children,
+                    ..
+                } = &adopted.read_body
+                else {
+                    // The parent's child ref said folder: a sealed file body is
+                    // a kind transplant, fail-closed.
+                    continue;
+                };
+                report.changed |= project_folder(
+                    &mut self.base.borrow_mut(),
+                    *folder,
+                    children,
+                    adopted.sequence,
+                    *modified_at,
+                );
+                report.refreshed.push(*folder);
+            }
+        }
+        report
+    }
+
+    /// One folder's cache-first gated resolve: the child gate on a strictly
+    /// newer record, and an at-floor re-open of the current or cached bytes so a
+    /// process that starts over durable floors still renders (the same two-step
+    /// [`Engine::read_content`](crate::Engine::read_content) walks for a file).
+    async fn adopt(&self, folder: NodeId) -> Option<Adopted> {
+        let name = self.folder_name(folder)?;
+        let adopter = ChildAdopter::new(
+            self.gateway,
+            self.http,
+            self.floors,
+            self.scope_id,
+            self.scope_read_seed.clone(),
+            folder.0,
+        );
+        let resolved = resolve(self.transport, self.snapshot_cache, &adopter, &name)
+            .await
+            .ok()?;
+        let record_bytes = match resolved.outcome {
+            ResolveOutcome::Adopted(adopted) => return Some(adopted),
+            ResolveOutcome::TrustViolation(_) => return None,
+            ResolveOutcome::Current { record_bytes } => record_bytes,
+            ResolveOutcome::NoUpdate => resolved.last_known_good?,
+        };
+        adopter.open_at_floor(&name, &record_bytes).await.ok()
+    }
+
+    /// The folder's write-plane name as its parent's `ChildRef` carried it.
+    /// `None` for a node absent from gate-passing state, a non-folder, or a ref
+    /// whose bytes are not a canonical IPNS name.
+    fn folder_name(&self, folder: NodeId) -> Option<IpnsName> {
+        let base = self.base.borrow();
+        let meta = base.node(folder)?;
+        if meta.kind != NodeKind::Folder {
+            return None;
+        }
+        let name = meta.ipns_name.as_deref()?;
+        IpnsName::parse(core::str::from_utf8(name).ok()?).ok()
+    }
+}

--- a/crates/engine/src/net/focus.rs
+++ b/crates/engine/src/net/focus.rs
@@ -1,13 +1,10 @@
 //! The focus-window folder refresh: the read leg that renders a folder **below**
-//! the scope root on a device that did not author it (blueprint/engine.md
-//! "Sync core: focus-window tick").
+//! the scope root (blueprint/engine.md "Sync core: focus-window tick").
 //!
-//! The vault-pointer leg lifts the root's direct children only, and the drain
-//! only ever repaints folders this device published itself. Everything deeper
-//! comes from here: each folder the focus window names resolves its own record
-//! cache-first, passes the [`ChildAdopter`] gate on this device's floors, and
-//! merges into the base through [`project_folder`] — the same merge model the
-//! root leg uses, one level down. No new crypto and no new seam.
+//! Each folder the window names resolves its own record cache-first through
+//! [`resolve_child`], passes the [`ChildAdopter`] gate on this device's floors,
+//! and merges into the base with [`project_folder`] — the root leg's merge
+//! model, one level down.
 
 use core::cell::RefCell;
 
@@ -15,30 +12,16 @@ use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::seal::ReadBody;
 use zeroize::Zeroizing;
 
-use super::child::ChildAdopter;
-use super::resolve::{ResolveOutcome, resolve};
+use super::child::{ChildAdopter, resolve_child};
 use crate::content::Gateway;
 use crate::facade::{NodeId, NodeKind};
-use crate::gate::Adopted;
 use crate::seams::{FloorStore, Http, RecordTransport, SnapshotCache};
 use crate::sync::model::Snapshot;
 use crate::sync::project::project_folder;
 
-/// What one focus-window folder pass did.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub(crate) struct FolderRefreshReport {
-    /// The folders whose gate-passing body merged into the base. The caller
-    /// stamps these against its own clock — this module reads no time source
-    /// (the determinism law).
-    pub(crate) refreshed: Vec<NodeId>,
-    /// Whether any merge actually changed the base, so the caller emits
-    /// `SnapshotUpdated` on a real change and stays quiet otherwise.
-    pub(crate) changed: bool,
-}
-
 /// The focus-window folder refresh over one owned scope's read material.
-/// Borrows the content/record seams from the live session; the scope read seed
-/// stays borrowed, so this pass zeroizes nothing the caller owns.
+/// Borrows the content/record seams from the live session; the caller's read
+/// seed is borrowed and never zeroized here.
 pub(crate) struct FolderRefresh<'a, T, S, H, F> {
     pub(crate) transport: &'a T,
     pub(crate) snapshot_cache: &'a S,
@@ -60,61 +43,53 @@ where
     H: Http,
     F: FloorStore,
 {
-    /// Refresh `folders` in order, merging each gate-passing body into the base.
-    /// Every failure mode is per-folder and non-fatal: an unresolvable record is
-    /// availability staleness and a gate rejection is fail-closed — both leave
-    /// last-known-good rendering and neither stops the pass.
-    pub(crate) async fn run(&self, folders: &[NodeId]) -> FolderRefreshReport {
-        let mut report = FolderRefreshReport::default();
-        for folder in folders {
-            if let Some(adopted) = self.adopt(*folder).await {
-                let ReadBody::Folder {
-                    modified_at,
-                    children,
-                    ..
-                } = &adopted.read_body
-                else {
-                    // The parent's child ref said folder: a sealed file body is
-                    // a kind transplant, fail-closed.
-                    continue;
-                };
-                report.changed |= project_folder(
-                    &mut self.base.borrow_mut(),
-                    *folder,
-                    children,
-                    adopted.sequence,
-                    *modified_at,
-                );
-                report.refreshed.push(*folder);
-            }
+    /// Merge each of `folders` into the base, reporting whether the base moved.
+    /// They arrive nearest-first; the merge runs root-ward, so a parent that
+    /// dropped a child unlinks it before the pass would project into it.
+    ///
+    /// Every failure is per-folder and non-fatal: an unresolvable record is
+    /// availability staleness, a gate rejection is fail-closed, and both leave
+    /// last-known-good rendering without stopping the pass.
+    pub(crate) async fn run(&self, folders: &[NodeId]) -> bool {
+        let mut changed = false;
+        for folder in folders.iter().rev() {
+            let Some(name) = self.folder_name(*folder) else {
+                continue;
+            };
+            let adopter = ChildAdopter::new(
+                self.gateway,
+                self.http,
+                self.floors,
+                self.scope_id,
+                self.scope_read_seed.clone(),
+                folder.0,
+            );
+            // Staleness and gate rejection alike leave the base untouched; the
+            // host is told apart from neither today (surfacing: #796).
+            let Ok(adopted) =
+                resolve_child(self.transport, self.snapshot_cache, &adopter, &name).await
+            else {
+                continue;
+            };
+            let ReadBody::Folder {
+                modified_at,
+                children,
+                ..
+            } = &adopted.read_body
+            else {
+                // The parent's child ref said folder: a sealed file body is a
+                // kind transplant, fail-closed.
+                continue;
+            };
+            changed |= project_folder(
+                &mut self.base.borrow_mut(),
+                *folder,
+                children,
+                adopted.sequence,
+                *modified_at,
+            );
         }
-        report
-    }
-
-    /// One folder's cache-first gated resolve: the child gate on a strictly
-    /// newer record, and an at-floor re-open of the current or cached bytes so a
-    /// process that starts over durable floors still renders (the same two-step
-    /// [`Engine::read_content`](crate::Engine::read_content) walks for a file).
-    async fn adopt(&self, folder: NodeId) -> Option<Adopted> {
-        let name = self.folder_name(folder)?;
-        let adopter = ChildAdopter::new(
-            self.gateway,
-            self.http,
-            self.floors,
-            self.scope_id,
-            self.scope_read_seed.clone(),
-            folder.0,
-        );
-        let resolved = resolve(self.transport, self.snapshot_cache, &adopter, &name)
-            .await
-            .ok()?;
-        let record_bytes = match resolved.outcome {
-            ResolveOutcome::Adopted(adopted) => return Some(adopted),
-            ResolveOutcome::TrustViolation(_) => return None,
-            ResolveOutcome::Current { record_bytes } => record_bytes,
-            ResolveOutcome::NoUpdate => resolved.last_known_good?,
-        };
-        adopter.open_at_floor(&name, &record_bytes).await.ok()
+        changed
     }
 
     /// The folder's write-plane name as its parent's `ChildRef` carried it.
@@ -126,7 +101,6 @@ where
         if meta.kind != NodeKind::Folder {
             return None;
         }
-        let name = meta.ipns_name.as_deref()?;
-        IpnsName::parse(core::str::from_utf8(name).ok()?).ok()
+        IpnsName::parse(core::str::from_utf8(meta.ipns_name.as_deref()?).ok()?).ok()
     }
 }

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -15,6 +15,7 @@
 mod adopter;
 mod child;
 mod fanout;
+mod focus;
 mod pointer_fetch;
 
 pub mod author;
@@ -30,6 +31,7 @@ pub use adopter::{LocalHead, RootAdopter};
 pub(crate) use adopter::{assemble_head_envelope, fetch_head_block};
 pub use child::ChildAdopter;
 pub(crate) use fanout::fanout_get_verify;
+pub(crate) use focus::{FolderRefresh, FolderRefreshReport};
 pub(crate) use liveness::eol_renew_pass;
 pub use liveness::{
     EolRenewResult, HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, RePutResult,

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -30,8 +30,9 @@ pub mod revival;
 pub use adopter::{LocalHead, RootAdopter};
 pub(crate) use adopter::{assemble_head_envelope, fetch_head_block};
 pub use child::ChildAdopter;
+pub(crate) use child::{ChildResolveError, resolve_child};
 pub(crate) use fanout::fanout_get_verify;
-pub(crate) use focus::{FolderRefresh, FolderRefreshReport};
+pub(crate) use focus::FolderRefresh;
 pub(crate) use liveness::eol_renew_pass;
 pub use liveness::{
     EolRenewResult, HeldRecord, HeldRecords, LivenessControl, RE_PUT_INTERVAL, RePutResult,

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -380,20 +380,17 @@ where
 
 /// Fold a completed resolve's verdict into the shared base cell. A gate-passing
 /// `Adopted` re-projects ([`project_root`], merging over the current base) and
-/// installs the result, returning true (the caller emits `SnapshotUpdated`);
-/// `Current`/`NoUpdate`/`TrustViolation` leave last-known-good intact and return
-/// false. Non-await by construction — the short borrows never span an `.await`
-/// (facade single-threaded executor rule).
+/// returns whether the merge changed anything (the caller emits
+/// `SnapshotUpdated`); `Current`/`NoUpdate`/`TrustViolation` leave
+/// last-known-good intact and return false. Non-await by construction — the
+/// short borrows never span an `.await` (facade single-threaded executor rule).
 pub(crate) fn refresh_base_from_outcome(
     base: &RefCell<Snapshot>,
     root: NodeId,
     outcome: &ResolveOutcome,
 ) -> bool {
     match outcome {
-        ResolveOutcome::Adopted(adopted) => {
-            project_root(&mut base.borrow_mut(), root, adopted);
-            true
-        }
+        ResolveOutcome::Adopted(adopted) => project_root(&mut base.borrow_mut(), root, adopted),
         _ => false,
     }
 }
@@ -1094,11 +1091,14 @@ mod tests {
                 2,
             ));
 
-            assert!(refresh_base_from_outcome(
-                &cell,
-                root,
-                &ResolveOutcome::Adopted(adopted_with_one_child(child_id)),
-            ));
+            assert!(
+                !refresh_base_from_outcome(
+                    &cell,
+                    root,
+                    &ResolveOutcome::Adopted(adopted_with_one_child(child_id)),
+                ),
+                "re-projecting the same body repaints nothing"
+            );
 
             let base = cell.borrow();
             let child = base.node(NodeId(child_id)).expect("child still projected");

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -50,8 +50,9 @@ pub use record::{
 pub use staging::{orphan_staging_keys, stage_op};
 pub use staleness::{Connectivity, classify, withheld_escalation};
 pub use tick::{
-    FocusTarget, FocusWindow, ResolveMode, TickCause, TickControl, focus_folders, focus_set,
-    jittered_cadence, on_access_refresh_due, resolve_mode, run_tick_loop,
+    FocusTarget, FocusWindow, ResolveMode, TickCause, TickControl, focus_folders,
+    focus_folders_due, focus_set, jittered_cadence, on_access_refresh_due, resolve_mode,
+    run_tick_loop,
 };
 
 /// Whole milliseconds of `duration`, truncating and saturating — the engine's

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -50,8 +50,8 @@ pub use record::{
 pub use staging::{orphan_staging_keys, stage_op};
 pub use staleness::{Connectivity, classify, withheld_escalation};
 pub use tick::{
-    FocusTarget, FocusWindow, ResolveMode, TickCause, TickControl, focus_set, jittered_cadence,
-    on_access_refresh_due, resolve_mode, run_tick_loop,
+    FocusTarget, FocusWindow, ResolveMode, TickCause, TickControl, focus_folders, focus_set,
+    jittered_cadence, on_access_refresh_due, resolve_mode, run_tick_loop,
 };
 
 /// Whole milliseconds of `duration`, truncating and saturating — the engine's

--- a/crates/engine/src/sync/model.rs
+++ b/crates/engine/src/sync/model.rs
@@ -123,22 +123,25 @@ impl Snapshot {
         self.nodes.get(&id).map(|n| n.record_sequence)
     }
 
-    /// Adds a parent→child link. Idempotent on `(parent, child)`: a repeat
-    /// keeps the higher `link_counter` (a re-link never lowers it).
-    pub fn link(&mut self, parent: NodeId, child: NodeId, link_counter: u64) {
+    /// Adds a parent→child link, reporting whether the link was established or
+    /// its counter raised. Idempotent on `(parent, child)`: a repeat keeps the
+    /// higher `link_counter` (a re-link never lowers it).
+    pub fn link(&mut self, parent: NodeId, child: NodeId, link_counter: u64) -> bool {
         if let Some(existing) = self
             .links
             .iter_mut()
             .find(|l| l.parent == parent && l.child == child)
         {
+            let raised = existing.link_counter < link_counter;
             existing.link_counter = existing.link_counter.max(link_counter);
-            return;
+            return raised;
         }
         self.links.push(Link {
             parent,
             child,
             link_counter,
         });
+        true
     }
 
     /// Links `child` under `parent` with a **fresh winning counter** — one

--- a/crates/engine/src/sync/project.rs
+++ b/crates/engine/src/sync/project.rs
@@ -14,22 +14,26 @@ use crate::facade::{NodeId, NodeKind};
 use crate::gate::Adopted;
 use crate::sync::model::{NodeMeta, Snapshot};
 
-/// Merge a gate-passing adopted **scope root** body into `snapshot`. A body that
-/// is not a folder leaves the snapshot untouched.
-pub(crate) fn project_root(snapshot: &mut Snapshot, root: NodeId, adopted: &Adopted) {
-    if let ReadBody::Folder {
-        modified_at,
-        children,
-        ..
-    } = &adopted.read_body
-    {
-        project_folder(snapshot, root, children, adopted.sequence, *modified_at);
+/// Merge a gate-passing adopted **scope root** body into `snapshot`, reporting
+/// whether anything changed. A body that is not a folder leaves the snapshot
+/// untouched.
+pub(crate) fn project_root(snapshot: &mut Snapshot, root: NodeId, adopted: &Adopted) -> bool {
+    match &adopted.read_body {
+        ReadBody::Folder {
+            modified_at,
+            children,
+            ..
+        } => project_folder(snapshot, root, children, adopted.sequence, *modified_at),
+        ReadBody::File { .. } => false,
     }
 }
 
-/// Merge one folder's gate-passing children into `snapshot` **in place**.
-/// Children the folder no longer names are unlinked, and dropped entirely once
-/// no parent links them.
+/// Merge one folder's gate-passing children into `snapshot` **in place**,
+/// reporting whether the merge changed anything. Children the folder no longer
+/// names are unlinked, and dropped entirely once no parent links them.
+///
+/// The change report is what keeps a repeated projection of the same body from
+/// repainting the host: the focus-window refresh re-merges a folder every tick.
 ///
 /// Only a gate-passing body reaches here — the gate already enforced child
 /// id/ipnsName uniqueness at unseal — so child uniqueness is trusted and not
@@ -47,8 +51,10 @@ pub(crate) fn project_folder(
     children: &[ChildRef],
     sequence: u64,
     modified_at: u64,
-) {
+) -> bool {
+    let mut changed = false;
     if let Some(node) = snapshot.node_mut(folder) {
+        changed |= node.record_sequence != sequence || node.mtime != Some(modified_at);
         node.record_sequence = sequence;
         node.mtime = Some(modified_at);
     }
@@ -59,6 +65,7 @@ pub(crate) fn project_folder(
         .map(|node| node.id)
         .filter(|id| !children.iter().any(|child| child.id == id.0))
         .collect();
+    changed |= !departed.is_empty();
     for id in departed {
         snapshot.unlink(folder, id);
         if snapshot.links_to(id).is_empty() {
@@ -76,9 +83,22 @@ pub(crate) fn project_folder(
             meta.content_version = prior.content_version;
             meta.record_sequence = prior.record_sequence;
         }
+        changed |= snapshot.node(id) != Some(&meta) || link_raises(snapshot, folder, child);
         snapshot.upsert_node(meta);
         snapshot.link(folder, id, child.link_counter);
     }
+    changed
+}
+
+/// Whether linking `child` under `folder` would establish the link or raise its
+/// counter — [`Snapshot::link`] merges monotonically, so a lower counter is a
+/// no-op and not a change.
+fn link_raises(snapshot: &Snapshot, folder: NodeId, child: &ChildRef) -> bool {
+    snapshot
+        .links_to(NodeId(child.id))
+        .into_iter()
+        .find(|link| link.parent == folder)
+        .is_none_or(|link| link.link_counter < child.link_counter)
 }
 
 /// Fold a verified file read-body's plaintext `(size, mtime)` and version count
@@ -178,6 +198,59 @@ mod tests {
         );
         assert_eq!(snap.parent_of(node_id(1)), Some(root));
         assert_eq!(snap.parent_of(node_id(2)), Some(root));
+    }
+
+    #[test]
+    fn project_root_reports_a_change_only_when_the_body_moves_the_base() {
+        let root = node_id(0);
+        let first = adopted_folder(vec![child(1, "a", CoreNodeKind::Folder, 1)], 5);
+        let mut snap = Snapshot::new(root);
+
+        assert!(
+            project_root(&mut snap, root, &first),
+            "the first projection"
+        );
+        assert!(
+            !project_root(&mut snap, root, &first),
+            "the identical body repaints nothing"
+        );
+        assert!(
+            !project_root(
+                &mut snap,
+                root,
+                &adopted_folder(vec![child(1, "a", CoreNodeKind::Folder, 0)], 5),
+            ),
+            "a lower link counter is a monotonic no-op, not a change"
+        );
+        assert!(
+            project_root(
+                &mut snap,
+                root,
+                &adopted_folder(vec![child(1, "renamed", CoreNodeKind::Folder, 1)], 5),
+            ),
+            "a renamed child is a change"
+        );
+        assert!(
+            project_root(&mut snap, root, &adopted_folder(vec![], 5)),
+            "a departed child is a change"
+        );
+        assert!(
+            !project_root(
+                &mut snap,
+                root,
+                &Adopted {
+                    read_body: ReadBody::File {
+                        created_at: 0,
+                        modified_at: 0,
+                        versions: Vec::new(),
+                        unknown: Vec::new(),
+                    },
+                    sequence: 9,
+                    epoch: 0,
+                },
+            ),
+            "a non-folder body leaves the snapshot untouched"
+        );
     }
 
     #[test]

--- a/crates/engine/src/sync/project.rs
+++ b/crates/engine/src/sync/project.rs
@@ -83,22 +83,11 @@ pub(crate) fn project_folder(
             meta.content_version = prior.content_version;
             meta.record_sequence = prior.record_sequence;
         }
-        changed |= snapshot.node(id) != Some(&meta) || link_raises(snapshot, folder, child);
+        changed |= snapshot.node(id) != Some(&meta);
         snapshot.upsert_node(meta);
-        snapshot.link(folder, id, child.link_counter);
+        changed |= snapshot.link(folder, id, child.link_counter);
     }
     changed
-}
-
-/// Whether linking `child` under `folder` would establish the link or raise its
-/// counter — [`Snapshot::link`] merges monotonically, so a lower counter is a
-/// no-op and not a change.
-fn link_raises(snapshot: &Snapshot, folder: NodeId, child: &ChildRef) -> bool {
-    snapshot
-        .links_to(NodeId(child.id))
-        .into_iter()
-        .find(|link| link.parent == folder)
-        .is_none_or(|link| link.link_counter < child.link_counter)
 }
 
 /// Fold a verified file read-body's plaintext `(size, mtime)` and version count

--- a/crates/engine/src/sync/tick.rs
+++ b/crates/engine/src/sync/tick.rs
@@ -15,6 +15,7 @@ use core::future::Future;
 use core::pin::pin;
 use core::task::Poll;
 use core::time::Duration;
+use std::collections::BTreeMap;
 
 use crate::entropy::Entropy;
 use crate::facade::NodeId;
@@ -108,6 +109,27 @@ pub fn focus_folders(snapshot: &Snapshot, focus: &FocusWindow) -> Vec<NodeId> {
         .filter_map(|target| match target {
             FocusTarget::Folder(node) if node != snapshot.root => Some(node),
             _ => None,
+        })
+        .collect()
+}
+
+/// The focus window's folders due for an on-access refresh: those no pass has
+/// touched inside the staleness threshold ([`on_access_refresh_due`]). The poll
+/// leg refreshes the whole window regardless; this is the navigation leg's
+/// damper.
+pub fn focus_folders_due(
+    snapshot: &Snapshot,
+    focus: &FocusWindow,
+    last_refreshed: &BTreeMap<NodeId, UnixMillis>,
+    now: UnixMillis,
+    profile: &SyncTimingProfile,
+) -> Vec<NodeId> {
+    focus_folders(snapshot, focus)
+        .into_iter()
+        .filter(|folder| {
+            last_refreshed
+                .get(folder)
+                .is_none_or(|last| on_access_refresh_due(now, *last, profile))
         })
         .collect()
 }
@@ -265,6 +287,37 @@ mod tests {
         };
         assert_eq!(focus_folders(&snap, &focus), vec![id(2), id(1)]);
         assert!(focus_folders(&snap, &FocusWindow::default()).is_empty());
+    }
+
+    #[test]
+    fn focus_folders_due_damps_a_repeat_visit_inside_the_threshold() {
+        let mut snap = Snapshot::new(id(0));
+        snap.upsert_node(NodeMeta::new(id(1), "a", NodeKind::Folder));
+        snap.upsert_node(NodeMeta::new(id(2), "b", NodeKind::Folder));
+        snap.link(id(0), id(1), 1);
+        snap.link(id(1), id(2), 1);
+        let focus = FocusWindow {
+            open_folder: Some(id(2)),
+            open_shared_scopes: Vec::new(),
+        };
+        let profile = SyncTimingProfile::PRODUCTION; // stale_after 90 s
+        let due = |stamps: &BTreeMap<NodeId, UnixMillis>, now| {
+            focus_folders_due(&snap, &focus, stamps, UnixMillis(now), &profile)
+        };
+
+        assert_eq!(
+            due(&BTreeMap::new(), 0),
+            vec![id(2), id(1)],
+            "a never-refreshed window is due whole"
+        );
+
+        let stamps = BTreeMap::from([(id(2), UnixMillis(0))]);
+        assert_eq!(
+            due(&stamps, 89_000),
+            vec![id(1)],
+            "the stamped folder is damped, its unstamped ancestor is not"
+        );
+        assert_eq!(due(&stamps, 90_000), vec![id(2), id(1)]);
     }
 
     #[test]

--- a/crates/engine/src/sync/tick.rs
+++ b/crates/engine/src/sync/tick.rs
@@ -98,6 +98,20 @@ pub fn focus_set(snapshot: &Snapshot, focus: &FocusWindow) -> Vec<FocusTarget> {
     targets
 }
 
+/// The focus window's folder targets **below** the scope root, nearest first.
+/// The root rides the vault-pointer leg of the same tick, so it is not a folder
+/// target here; every remaining entry is a child record resolved through the
+/// child gate.
+pub fn focus_folders(snapshot: &Snapshot, focus: &FocusWindow) -> Vec<NodeId> {
+    focus_set(snapshot, focus)
+        .into_iter()
+        .filter_map(|target| match target {
+            FocusTarget::Folder(node) if node != snapshot.root => Some(node),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Whether a cached folder outside the focus window is due for an on-access
 /// refresh: it was last refreshed longer ago than the staleness threshold. No
 /// background churn — this fires only when the folder is actually accessed.
@@ -234,6 +248,35 @@ mod tests {
                 FocusTarget::Folder(id(1)),
                 FocusTarget::Folder(id(0)),
             ]
+        );
+    }
+
+    #[test]
+    fn focus_folders_are_the_chain_below_the_root_nearest_first() {
+        let mut snap = Snapshot::new(id(0));
+        snap.upsert_node(NodeMeta::new(id(1), "a", NodeKind::Folder));
+        snap.upsert_node(NodeMeta::new(id(2), "b", NodeKind::Folder));
+        snap.link(id(0), id(1), 1);
+        snap.link(id(1), id(2), 1);
+
+        let focus = FocusWindow {
+            open_folder: Some(id(2)),
+            open_shared_scopes: vec![id(7)],
+        };
+        assert_eq!(focus_folders(&snap, &focus), vec![id(2), id(1)]);
+        assert!(focus_folders(&snap, &FocusWindow::default()).is_empty());
+    }
+
+    #[test]
+    fn focus_folders_on_the_root_itself_is_empty() {
+        let snap = Snapshot::new(id(0));
+        let focus = FocusWindow {
+            open_folder: Some(id(0)),
+            open_shared_scopes: Vec::new(),
+        };
+        assert!(
+            focus_folders(&snap, &focus).is_empty(),
+            "the root rides the vault-pointer leg, never the child gate"
         );
     }
 

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -31,7 +31,6 @@ fn secret() -> LoginSecret {
 fn unimplemented_commands() -> Vec<(Command, &'static str)> {
     let node = NodeId([1; 16]);
     vec![
-        (Command::SetFocus { node: Some(node) }, "setFocus"),
         (Command::ManualRefresh, "manualRefresh"),
         (
             Command::ImportContact {
@@ -134,6 +133,27 @@ fn unimplemented_commands_return_their_typed_error() {
             "`{expected_name}` must reject as typed-unimplemented until its slice lands"
         );
     }
+}
+
+/// Focus is recorded whatever the window resolves to: a node absent from
+/// gate-passing state has nothing to descend into, which is not an error.
+#[test]
+fn set_focus_records_a_window_with_nothing_to_resolve() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (mut engine, _events) = new_engine(&device);
+    block_on(engine.start(secret())).unwrap();
+
+    assert_eq!(
+        block_on(engine.command(Command::SetFocus {
+            node: Some(NodeId([1; 16]))
+        })),
+        Ok(None)
+    );
+    assert_eq!(
+        block_on(engine.command(Command::SetFocus { node: None })),
+        Ok(None)
+    );
 }
 
 #[test]

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -22,7 +22,7 @@ use zeroize::Zeroizing;
 
 use cipherbox_engine::content::{DAG_ROOT_CODEC, GatewaySource, SealedChunk, decode_root};
 use cipherbox_engine::facade::PendingClass;
-use cipherbox_engine::net::author::{EnvelopeAuthoring, author_child_envelope};
+use cipherbox_engine::net::author::{AuthoredHead, EnvelopeAuthoring, author_child_envelope};
 use cipherbox_engine::net::{ChildAdopter, ResolveOutcome, resolve};
 use cipherbox_engine::seams::{
     BoxedTask, HttpRequest, HttpResponse, OpId, RecordTransport, SeamError, SeamResult,
@@ -1989,8 +1989,8 @@ fn a_create_below_the_scope_root_is_adoptable_by_a_second_device() {
     );
 }
 
-/// Device A's deep create, as a second device that never authored it sees it:
-/// returns `(world, blocks, bob, engine_b, tasks_b, photos, deep)`.
+/// Device A creates `photos/2026`, then a second device that never authored it
+/// cold-boots onto the same network.
 fn deep_create_seen_by_a_second_device() -> (
     FakeWorld,
     Blocks,
@@ -2040,52 +2040,45 @@ fn listed_names(engine: &Engine<FakeSeamTypes>, folder: NodeId) -> Vec<String> {
     names
 }
 
-/// Publish a transplanted record under `folder`'s write name at the next
-/// sequence: a well-formed child record sealed for a **different** node. It
-/// verifies under the name and its head CID matches, so only the child gate's
-/// envelope id/scope binding stands between it and the base snapshot.
-fn transplant_record(
+/// A record planted under `folder`'s write name. It verifies under that name
+/// and its head CID matches, so only the child gate's bindings stand between it
+/// and the base snapshot; each field is one binding a test bends away from
+/// `folder`'s own.
+struct Planted<'a> {
+    node_id: [u8; 16],
+    scope_id: [u8; 16],
+    read_key: [u8; 32],
+    body: &'a ReadBody,
+}
+
+fn plant_record(
     records: &InMemoryRecordStore,
     blocks: &Blocks,
     folder: NodeId,
-    foreign: NodeId,
+    planted: Planted<'_>,
 ) {
-    let (sequence, _) = published(records, folder);
     let head = author_child_envelope(EnvelopeAuthoring {
-        node_id: foreign.0,
-        scope_id: SCOPE,
+        node_id: planted.node_id,
+        scope_id: planted.scope_id,
         epoch: EPOCH,
-        read_key: &read_key_of(foreign),
+        read_key: &planted.read_key,
         nonce: &[0x5A; 24],
-        body: &ReadBody::Folder {
-            created_at: 0,
-            modified_at: 0,
-            children: vec![ChildRef {
-                id: [0x9B; 16],
-                name: "planted".into(),
-                ipns_name: write_name(NodeId([0x9B; 16])).as_str().as_bytes().to_vec(),
-                kind: CoreNodeKind::Folder,
-                link_counter: 1,
-                unknown: Vec::new(),
-            }],
-            unknown: Vec::new(),
-        },
+        body: planted.body,
         carried_unknown: Vec::new(),
         carried_epoch_tag_unknown: Vec::new(),
     })
-    .expect("a well-formed child record for the wrong node");
-    blocks.put(head.block.clone());
+    .expect("a well-formed child record");
+    publish_next_record(records, blocks, folder, &head);
+}
 
-    let record = IpnsRecord::create_v2(
-        &write_signer(folder),
-        format!("/ipfs/{}", head.cid).as_bytes(),
-        sequence + 1,
-        TTL_NANOS,
-        EOL,
-    )
-    .marshal();
-    for endpoint in records.endpoints() {
-        records.seed_record(&endpoint, write_name(folder).as_str(), record.clone());
+/// A folder body listing one child that exists nowhere else — what a planted
+/// record would add if the gate let it through.
+fn planted_body() -> ReadBody {
+    ReadBody::Folder {
+        created_at: 0,
+        modified_at: 0,
+        children: vec![child_ref([0x9B; 16], "planted", CoreNodeKind::Folder)],
+        unknown: Vec::new(),
     }
 }
 
@@ -2113,43 +2106,88 @@ fn a_second_device_lists_below_the_scope_root_once_it_focuses_there() {
     );
 }
 
-/// The focus refresh is fail-closed: a transplanted record published under the
-/// focused folder's name is a trust violation, never staleness — it never
-/// renders, and last-known-good stands.
+/// The focus refresh is fail-closed on every binding the child gate holds. Each
+/// planted record is strictly newer and otherwise well-formed; only the bent
+/// binding stops it, and last-known-good stands through all three.
 #[test]
-fn a_transplanted_focus_record_never_renders() {
+fn a_planted_focus_record_never_renders() {
     let (world, blocks, mut engine_b, mut tasks_b, photos, deep) =
         deep_create_seen_by_a_second_device();
     block_on(engine_b.command(Command::SetFocus { node: Some(photos) })).unwrap();
     assert_eq!(listed_names(&engine_b, photos), ["2026"]);
 
     // The tick leg is live: a legitimate concurrent record at the focused name
-    // reconciles without any further navigation.
-    let added = NodeId([0x27; 16]);
+    // reconciles without any further navigation. Without this the negatives
+    // below would pass on a leg that never ran.
     concurrent_add(
         &world.record_store,
         &blocks,
         photos,
-        ChildRef {
-            id: added.0,
-            name: "2027".into(),
-            ipns_name: write_name(added).as_str().as_bytes().to_vec(),
-            kind: CoreNodeKind::Folder,
-            link_counter: 1,
-            unknown: Vec::new(),
-        },
+        child_ref([0x27; 16], "2027", CoreNodeKind::Folder),
     );
     tick(&world, &engine_b, &mut tasks_b);
     assert_eq!(listed_names(&engine_b, photos), ["2026", "2027"]);
 
-    transplant_record(&world.record_store, &blocks, photos, deep);
+    let held = ["2026", "2027"];
+    for (planted, bent) in [
+        (
+            Planted {
+                node_id: deep.0,
+                scope_id: SCOPE,
+                read_key: read_key_of(deep),
+                body: &planted_body(),
+            },
+            "a record sealed for another node",
+        ),
+        (
+            Planted {
+                node_id: photos.0,
+                scope_id: [0xF0; 16],
+                read_key: read_key_of(photos),
+                body: &planted_body(),
+            },
+            "a record sealed under another scope",
+        ),
+        (
+            Planted {
+                node_id: photos.0,
+                scope_id: SCOPE,
+                read_key: read_key_of(photos),
+                body: &ReadBody::File {
+                    created_at: 0,
+                    modified_at: 0,
+                    versions: Vec::new(),
+                    unknown: Vec::new(),
+                },
+            },
+            "a record whose sealed body is a file",
+        ),
+    ] {
+        plant_record(&world.record_store, &blocks, photos, planted);
+        tick(&world, &engine_b, &mut tasks_b);
+        assert_eq!(
+            listed_names(&engine_b, photos),
+            held,
+            "{bent} never renders; last-known-good is pinned"
+        );
+    }
+}
+
+/// An unreachable record plane is availability staleness, never data loss: the
+/// focused folder keeps rendering the state it last adopted, off the cache.
+#[test]
+fn an_unreachable_record_plane_leaves_the_focused_folder_rendering() {
+    let (world, _blocks, mut engine_b, mut tasks_b, photos, _deep) =
+        deep_create_seen_by_a_second_device();
+    block_on(engine_b.command(Command::SetFocus { node: Some(photos) })).unwrap();
+    assert_eq!(listed_names(&engine_b, photos), ["2026"]);
+
+    for endpoint in world.record_store.endpoints() {
+        world.record_store.fail_endpoint(&endpoint);
+    }
     tick(&world, &engine_b, &mut tasks_b);
 
-    assert_eq!(
-        listed_names(&engine_b, photos),
-        ["2026", "2027"],
-        "the transplant failed the child gate; last-known-good is pinned"
-    );
+    assert_eq!(listed_names(&engine_b, photos), ["2026"]);
 }
 
 /// Navigation refreshes a folder only past the staleness threshold: a repeat
@@ -2162,19 +2200,11 @@ fn navigation_re_resolves_a_folder_only_past_the_staleness_threshold() {
     block_on(engine_b.command(Command::SetFocus { node: Some(photos) })).unwrap();
     assert_eq!(listed_names(&engine_b, photos), ["2026"]);
 
-    let added = NodeId([0x27; 16]);
     concurrent_add(
         &world.record_store,
         &blocks,
         photos,
-        ChildRef {
-            id: added.0,
-            name: "2027".into(),
-            ipns_name: write_name(added).as_str().as_bytes().to_vec(),
-            kind: CoreNodeKind::Folder,
-            link_counter: 1,
-            unknown: Vec::new(),
-        },
+        child_ref([0x27; 16], "2027", CoreNodeKind::Folder),
     );
 
     block_on(engine_b.command(Command::SetFocus { node: Some(photos) })).unwrap();
@@ -3215,8 +3245,7 @@ fn concurrent_root_add(records: &InMemoryRecordStore, blocks: &Blocks, extra: Ch
 /// Another writer publishes `folder`'s next record, adding `extra` on top of
 /// whatever the folder currently carries.
 fn concurrent_add(records: &InMemoryRecordStore, blocks: &Blocks, folder: NodeId, extra: ChildRef) {
-    let name = write_name(folder);
-    let (sequence, head_cid) = published(records, folder);
+    let (_, head_cid) = published(records, folder);
     let envelope =
         decode_envelope(&blocks.get(&head_cid).expect("the head block")).expect("decodes");
     let read_key = read_key_of(folder);
@@ -3247,8 +3276,19 @@ fn concurrent_add(records: &InMemoryRecordStore, blocks: &Blocks, folder: NodeId
         carried_epoch_tag_unknown: envelope.epoch_tag_unknown.clone(),
     })
     .expect("the concurrent writer authors a valid record");
-    blocks.put(head.block.clone());
+    publish_next_record(records, blocks, folder, &head);
+}
 
+/// Publish `head` under `folder`'s write name at the sequence after its current
+/// record — how every "another writer moved this folder on" fixture lands.
+fn publish_next_record(
+    records: &InMemoryRecordStore,
+    blocks: &Blocks,
+    folder: NodeId,
+    head: &AuthoredHead,
+) {
+    let (sequence, _) = published(records, folder);
+    blocks.put(head.block.clone());
     let record = IpnsRecord::create_v2(
         &write_signer(folder),
         format!("/ipfs/{}", head.cid).as_bytes(),
@@ -3258,6 +3298,6 @@ fn concurrent_add(records: &InMemoryRecordStore, blocks: &Blocks, folder: NodeId
     )
     .marshal();
     for endpoint in records.endpoints() {
-        records.seed_record(&endpoint, name.as_str(), record.clone());
+        records.seed_record(&endpoint, write_name(folder).as_str(), record.clone());
     }
 }

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -1915,42 +1915,23 @@ fn a_create_below_the_scope_root_publishes_and_projects() {
 /// The deep create's round trip: a device that never authored it adopts the
 /// non-root parent's own record — the only record that carries the depth-2
 /// child — through the child gate, on its own cold floors and cache. The
-/// facade has no descent below the scope root yet, so the assertion sits at
-/// the record plane (#895, #917).
+/// assertion sits at the record plane; its facade half is
+/// `a_second_device_lists_below_the_scope_root_once_it_focuses_there`
+/// (#895, #917).
 #[test]
 fn a_create_below_the_scope_root_is_adoptable_by_a_second_device() {
-    let world = FakeWorld::new();
-    let blocks = Blocks::default();
-    seed_account(&world, &blocks);
+    let DeepCreate {
+        bob,
+        engine_b,
+        photos,
+        deep,
+        ..
+    } = deep_create_seen_by_a_second_device();
 
-    let alice = world.device(b"alice");
-    let (mut engine_a, _events_a, mut tasks) = boot(&world, &blocks, &alice, 42);
-    block_on(engine_a.command(Command::Create {
-        parent: ROOT,
-        name: "photos".into(),
-        kind: NodeKind::Folder,
-    }))
-    .unwrap();
-    tick(&world, &engine_a, &mut tasks);
-    let photos = child_id(&engine_a, ROOT, "photos");
-
-    block_on(engine_a.command(Command::Create {
-        parent: photos,
-        name: "2026".into(),
-        kind: NodeKind::Folder,
-    }))
-    .unwrap();
-    tick(&world, &engine_a, &mut tasks);
-    let deep = child_id(&engine_a, photos, "2026");
-
-    let bob = world.device(b"alice-second-device");
-    let (engine_b, _events_b, _tasks_b) = boot(&world, &blocks, &bob, 7);
     let parents = block_on(engine_b.view()).unwrap().children(ROOT);
     assert_eq!(parents.len(), 1, "device B resolves the depth-1 parent");
     assert_eq!(parents[0].id, photos);
 
-    // Device B's own seams: its cold floor store, its own cache and HTTP. Only
-    // the account's scope read seed and the network are shared with device A.
     let gateway = GatewayConfig {
         accelerator: Some(GatewaySource {
             base_url: "https://gw.test".into(),
@@ -1991,14 +1972,19 @@ fn a_create_below_the_scope_root_is_adoptable_by_a_second_device() {
 
 /// Device A creates `photos/2026`, then a second device that never authored it
 /// cold-boots onto the same network.
-fn deep_create_seen_by_a_second_device() -> (
-    FakeWorld,
-    Blocks,
-    Engine<FakeSeamTypes>,
-    Vec<BoxedTask>,
-    NodeId,
-    NodeId,
-) {
+struct DeepCreate {
+    world: FakeWorld,
+    blocks: Blocks,
+    /// Device B's own seams: its cold floor store, its own cache and HTTP. Only
+    /// the account's scope read seed and the network are shared with device A.
+    bob: FakeDevice,
+    engine_b: Engine<FakeSeamTypes>,
+    tasks_b: Vec<BoxedTask>,
+    photos: NodeId,
+    deep: NodeId,
+}
+
+fn deep_create_seen_by_a_second_device() -> DeepCreate {
     let world = FakeWorld::new();
     let blocks = Blocks::default();
     seed_account(&world, &blocks);
@@ -2025,7 +2011,15 @@ fn deep_create_seen_by_a_second_device() -> (
 
     let bob = world.device(b"alice-second-device");
     let (engine_b, _events_b, tasks_b) = boot(&world, &blocks, &bob, 7);
-    (world, blocks, engine_b, tasks_b, photos, deep)
+    DeepCreate {
+        world,
+        blocks,
+        bob,
+        engine_b,
+        tasks_b,
+        photos,
+        deep,
+    }
 }
 
 /// The names a device's rendered view lists under `folder`, sorted.
@@ -2087,8 +2081,12 @@ fn planted_body() -> ReadBody {
 /// child out of its own rendered view — the assertion #895 could not make.
 #[test]
 fn a_second_device_lists_below_the_scope_root_once_it_focuses_there() {
-    let (_world, _blocks, mut engine_b, _tasks_b, photos, deep) =
-        deep_create_seen_by_a_second_device();
+    let DeepCreate {
+        mut engine_b,
+        photos,
+        deep,
+        ..
+    } = deep_create_seen_by_a_second_device();
 
     assert!(
         listed_names(&engine_b, photos).is_empty(),
@@ -2111,8 +2109,15 @@ fn a_second_device_lists_below_the_scope_root_once_it_focuses_there() {
 /// binding stops it, and last-known-good stands through all three.
 #[test]
 fn a_planted_focus_record_never_renders() {
-    let (world, blocks, mut engine_b, mut tasks_b, photos, deep) =
-        deep_create_seen_by_a_second_device();
+    let DeepCreate {
+        world,
+        blocks,
+        mut engine_b,
+        mut tasks_b,
+        photos,
+        deep,
+        ..
+    } = deep_create_seen_by_a_second_device();
     block_on(engine_b.command(Command::SetFocus { node: Some(photos) })).unwrap();
     assert_eq!(listed_names(&engine_b, photos), ["2026"]);
 
@@ -2177,8 +2182,13 @@ fn a_planted_focus_record_never_renders() {
 /// focused folder keeps rendering the state it last adopted, off the cache.
 #[test]
 fn an_unreachable_record_plane_leaves_the_focused_folder_rendering() {
-    let (world, _blocks, mut engine_b, mut tasks_b, photos, _deep) =
-        deep_create_seen_by_a_second_device();
+    let DeepCreate {
+        world,
+        mut engine_b,
+        mut tasks_b,
+        photos,
+        ..
+    } = deep_create_seen_by_a_second_device();
     block_on(engine_b.command(Command::SetFocus { node: Some(photos) })).unwrap();
     assert_eq!(listed_names(&engine_b, photos), ["2026"]);
 
@@ -2195,8 +2205,13 @@ fn an_unreachable_record_plane_leaves_the_focused_folder_rendering() {
 /// reconciles (blueprint/engine.md "Sync core").
 #[test]
 fn navigation_re_resolves_a_folder_only_past_the_staleness_threshold() {
-    let (world, blocks, mut engine_b, _tasks_b, photos, _deep) =
-        deep_create_seen_by_a_second_device();
+    let DeepCreate {
+        world,
+        blocks,
+        mut engine_b,
+        photos,
+        ..
+    } = deep_create_seen_by_a_second_device();
     block_on(engine_b.command(Command::SetFocus { node: Some(photos) })).unwrap();
     assert_eq!(listed_names(&engine_b, photos), ["2026"]);
 

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -1989,6 +1989,210 @@ fn a_create_below_the_scope_root_is_adoptable_by_a_second_device() {
     );
 }
 
+/// Device A's deep create, as a second device that never authored it sees it:
+/// returns `(world, blocks, bob, engine_b, tasks_b, photos, deep)`.
+fn deep_create_seen_by_a_second_device() -> (
+    FakeWorld,
+    Blocks,
+    Engine<FakeSeamTypes>,
+    Vec<BoxedTask>,
+    NodeId,
+    NodeId,
+) {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine_a, _events_a, mut tasks) = boot(&world, &blocks, &alice, 42);
+    block_on(engine_a.command(Command::Create {
+        parent: ROOT,
+        name: "photos".into(),
+        kind: NodeKind::Folder,
+    }))
+    .unwrap();
+    tick(&world, &engine_a, &mut tasks);
+    let photos = child_id(&engine_a, ROOT, "photos");
+
+    block_on(engine_a.command(Command::Create {
+        parent: photos,
+        name: "2026".into(),
+        kind: NodeKind::Folder,
+    }))
+    .unwrap();
+    tick(&world, &engine_a, &mut tasks);
+    let deep = child_id(&engine_a, photos, "2026");
+
+    let bob = world.device(b"alice-second-device");
+    let (engine_b, _events_b, tasks_b) = boot(&world, &blocks, &bob, 7);
+    (world, blocks, engine_b, tasks_b, photos, deep)
+}
+
+/// The names a device's rendered view lists under `folder`, sorted.
+fn listed_names(engine: &Engine<FakeSeamTypes>, folder: NodeId) -> Vec<String> {
+    let mut names: Vec<String> = block_on(engine.snapshot(folder))
+        .expect("a folder view")
+        .children
+        .into_iter()
+        .map(|child| child.name)
+        .collect();
+    names.sort();
+    names
+}
+
+/// Publish a transplanted record under `folder`'s write name at the next
+/// sequence: a well-formed child record sealed for a **different** node. It
+/// verifies under the name and its head CID matches, so only the child gate's
+/// envelope id/scope binding stands between it and the base snapshot.
+fn transplant_record(
+    records: &InMemoryRecordStore,
+    blocks: &Blocks,
+    folder: NodeId,
+    foreign: NodeId,
+) {
+    let (sequence, _) = published(records, folder);
+    let head = author_child_envelope(EnvelopeAuthoring {
+        node_id: foreign.0,
+        scope_id: SCOPE,
+        epoch: EPOCH,
+        read_key: &read_key_of(foreign),
+        nonce: &[0x5A; 24],
+        body: &ReadBody::Folder {
+            created_at: 0,
+            modified_at: 0,
+            children: vec![ChildRef {
+                id: [0x9B; 16],
+                name: "planted".into(),
+                ipns_name: write_name(NodeId([0x9B; 16])).as_str().as_bytes().to_vec(),
+                kind: CoreNodeKind::Folder,
+                link_counter: 1,
+                unknown: Vec::new(),
+            }],
+            unknown: Vec::new(),
+        },
+        carried_unknown: Vec::new(),
+        carried_epoch_tag_unknown: Vec::new(),
+    })
+    .expect("a well-formed child record for the wrong node");
+    blocks.put(head.block.clone());
+
+    let record = IpnsRecord::create_v2(
+        &write_signer(folder),
+        format!("/ipfs/{}", head.cid).as_bytes(),
+        sequence + 1,
+        TTL_NANOS,
+        EOL,
+    )
+    .marshal();
+    for endpoint in records.endpoints() {
+        records.seed_record(&endpoint, write_name(folder).as_str(), record.clone());
+    }
+}
+
+/// The facade half of the deep create's round trip: a device that never
+/// authored the subtree sets focus on the depth-1 parent and lists the depth-2
+/// child out of its own rendered view — the assertion #895 could not make.
+#[test]
+fn a_second_device_lists_below_the_scope_root_once_it_focuses_there() {
+    let (_world, _blocks, mut engine_b, _tasks_b, photos, deep) =
+        deep_create_seen_by_a_second_device();
+
+    assert!(
+        listed_names(&engine_b, photos).is_empty(),
+        "the vault-pointer leg lifts the root's direct children only"
+    );
+
+    block_on(engine_b.command(Command::SetFocus { node: Some(photos) })).unwrap();
+
+    let view = block_on(engine_b.snapshot(photos)).unwrap();
+    assert_eq!(view.children.len(), 1, "the focus refresh descended");
+    assert_eq!(view.children[0].name, "2026");
+    assert_eq!(
+        view.children[0].id, deep,
+        "and under the node id device A published it with"
+    );
+}
+
+/// The focus refresh is fail-closed: a transplanted record published under the
+/// focused folder's name is a trust violation, never staleness — it never
+/// renders, and last-known-good stands.
+#[test]
+fn a_transplanted_focus_record_never_renders() {
+    let (world, blocks, mut engine_b, mut tasks_b, photos, deep) =
+        deep_create_seen_by_a_second_device();
+    block_on(engine_b.command(Command::SetFocus { node: Some(photos) })).unwrap();
+    assert_eq!(listed_names(&engine_b, photos), ["2026"]);
+
+    // The tick leg is live: a legitimate concurrent record at the focused name
+    // reconciles without any further navigation.
+    let added = NodeId([0x27; 16]);
+    concurrent_add(
+        &world.record_store,
+        &blocks,
+        photos,
+        ChildRef {
+            id: added.0,
+            name: "2027".into(),
+            ipns_name: write_name(added).as_str().as_bytes().to_vec(),
+            kind: CoreNodeKind::Folder,
+            link_counter: 1,
+            unknown: Vec::new(),
+        },
+    );
+    tick(&world, &engine_b, &mut tasks_b);
+    assert_eq!(listed_names(&engine_b, photos), ["2026", "2027"]);
+
+    transplant_record(&world.record_store, &blocks, photos, deep);
+    tick(&world, &engine_b, &mut tasks_b);
+
+    assert_eq!(
+        listed_names(&engine_b, photos),
+        ["2026", "2027"],
+        "the transplant failed the child gate; last-known-good is pinned"
+    );
+}
+
+/// Navigation refreshes a folder only past the staleness threshold: a repeat
+/// visit renders state already held, and the same navigation past the threshold
+/// reconciles (blueprint/engine.md "Sync core").
+#[test]
+fn navigation_re_resolves_a_folder_only_past_the_staleness_threshold() {
+    let (world, blocks, mut engine_b, _tasks_b, photos, _deep) =
+        deep_create_seen_by_a_second_device();
+    block_on(engine_b.command(Command::SetFocus { node: Some(photos) })).unwrap();
+    assert_eq!(listed_names(&engine_b, photos), ["2026"]);
+
+    let added = NodeId([0x27; 16]);
+    concurrent_add(
+        &world.record_store,
+        &blocks,
+        photos,
+        ChildRef {
+            id: added.0,
+            name: "2027".into(),
+            ipns_name: write_name(added).as_str().as_bytes().to_vec(),
+            kind: CoreNodeKind::Folder,
+            link_counter: 1,
+            unknown: Vec::new(),
+        },
+    );
+
+    block_on(engine_b.command(Command::SetFocus { node: Some(photos) })).unwrap();
+    assert_eq!(
+        listed_names(&engine_b, photos),
+        ["2026"],
+        "a repeat visit inside the threshold renders what is already held"
+    );
+
+    world.scheduler.advance(engine_b.profile().stale_after);
+    block_on(engine_b.command(Command::SetFocus { node: Some(photos) })).unwrap();
+    assert_eq!(
+        listed_names(&engine_b, photos),
+        ["2026", "2027"],
+        "past the threshold the same navigation reconciles"
+    );
+}
+
 /// A source-remove that will not publish compensates its own dest-add rather
 /// than leaving the child linked under both parents.
 #[test]


### PR DESCRIPTION
## Problem

Nothing resolved a folder record below the scope root on a device that did not author it, so such a device rendered every subtree empty — indefinitely.

- `spawn_resolve_tick_loop` refreshed the **vault root only**; `refresh_base_from_outcome` to `project_root` lifts direct children only.
- The only other writer into the base below the root was the drain's self-adopt — state this device published itself.
- `Command::SetFocus` fell through to `EngineError::Unimplemented`, which `apps/web/src/engine/snapshotStore.ts` turns into a committed error state on every navigation.
- `ChildAdopter`'s single caller was `read_content`, which is file-only.
- `focus_set` / `FocusWindow` / `FocusTarget::Folder` were pure planning with no caller.

`blueprint/engine.md` "Sync core" specifies both halves — the focus-window tick and the on-access refresh past the staleness threshold. Neither was wired.

## Change

- **`crates/engine/src/net/focus.rs` (new)** — `FolderRefresh` resolves each focus folder's own record cache-first, passes the `ChildAdopter` gate on this device's floors, and merges the gate-passing body with `project_folder`. A gate rejection is fail-closed: last-known-good stands and no floor moves. The pass merges root-ward, so a parent that dropped a child unlinks it before the pass would project into it, and it reads no clock — the caller stamps.
- **`resolve_child` in `net/child.rs`** — the `Adopted` / `Current` / `NoUpdate` + at-floor re-open walk, previously duplicated. Both read paths that descend below the scope root (a file's content read and this refresh) now share it, so neither can drift on which outcome is staleness and which is a fail-closed violation.
- **`Command::SetFocus`** records the focus window and refreshes it immediately, but only for folders past the staleness threshold — navigation is the tick model's second trigger source, and a repeat visit renders state already held. Stamps record *attempts*, so a folder that never gate-passes cannot turn every navigation into a fresh endpoint fan-out; the poll leg still refreshes the window unconditionally, so recovery is automatic.
- **The resolve tick** refreshes the same window every pass, after the root leg and before the drain, so the queue rebases onto the deepest state the pass reconciled.
- **`focus_folders` / `focus_folders_due`** in `sync/tick.rs` — the window's folder targets below the scope root, and the threshold filter. The root rides the vault-pointer leg, never the child gate.
- **`project_folder` reports whether the merge moved the base**, so re-merging the same body every tick does not repaint the host. `Snapshot::link` reports whether it established or raised a link, so the projection no longer predicts it; `project_root` and `refresh_base_from_outcome` forward the report.

No new crypto, no new seam, no TypeScript change — `setFocus` was already plumbed through `crates/wasm` and `packages/client`, and the web store already pulls on success.

## Tests

`crates/engine/tests/write_plane.rs`, gated by **Engine Tests** (`cargo test -p cipherbox-engine`):

- `a_second_device_lists_below_the_scope_root_once_it_focuses_there` — the facade half of #895's round trip. A cold second device lists the depth-2 child with device A's name and node id after setting focus on the depth-1 parent, having listed nothing there before.
- `a_planted_focus_record_never_renders` — fail-closed on all three child-gate bindings the pass rests on. A legitimate concurrent record reconciles first, so the negatives cannot pass on a leg that never ran; then a foreign node id, a foreign scope, and a file body behind a folder ref are each planted at the focused name at a strictly newer sequence, and last-known-good is pinned through all three.
- `an_unreachable_record_plane_leaves_the_focused_folder_rendering` — every endpoint failed, the folder keeps rendering off the cache rather than clearing.
- `navigation_re_resolves_a_folder_only_past_the_staleness_threshold` — a repeat visit inside the threshold renders held state; the same navigation past it reconciles.

Plus `crates/engine/tests/facade.rs::set_focus_records_a_window_with_nothing_to_resolve`, `sync/tick.rs` unit tests for `focus_folders` and `focus_folders_due`, and `sync/project.rs::project_root_reports_a_change_only_when_the_body_moves_the_base`.

**Revert check:** stubbing `focus_folders` to return an empty list fails exactly the four new `write_plane` tests and nothing else.

## Verification

All exit 0:

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo check --workspace --all-targets`
- `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets`
- `cargo test --workspace` — 32 suites green, 0 failures
- `pnpm -r --if-present run typecheck` — api, client, web all clean
- `pnpm -r --if-present run test` — client, api 177, web 67 all pass
- `npx eslint .` — clean

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` were each run on `git diff main...HEAD`. Security and crypto returned no findings. The second commit folds in the real items from all three: the shared `resolve_child` walk, the attempt-stamped on-access damper, `Snapshot::link`'s change report, the root-ward merge order, the extra fail-closed test coverage, and a comment-discipline pass.

One deferral: a child-gate trust violation on the focus leg is fail-closed but unsurfaced to the host, exactly as the root leg is. That is #796's scope; this PR widens what #796 has to cover from one record to the focus chain, and #796 has been updated to say so.

Closes #917


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Focused folders now refresh automatically when stale and immediately after focus changes.
  * Deep-folder views update with newly available content while preserving existing state during refresh failures.
  * Snapshot updates are emitted when refreshed data changes.

* **Bug Fixes**
  * Improved handling of unavailable or rejected child content.
  * Prevented invalid records from replacing valid folder data.
  * Avoided reporting changes when refreshed data is identical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->