### PR TITLE
feat(web): land the Service Worker byte pipe and app-shell precache

### DIFF
--- a/apps/web/src/engine/createMediaService.test.ts
+++ b/apps/web/src/engine/createMediaService.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { serviceWorkerScript } from './createMediaService';
+
+describe('serviceWorkerScript', () => {
+  it('registers the transformed source entry as a module in dev', () => {
+    expect(serviceWorkerScript({ DEV: true })).toEqual({ url: '/src/sw.ts', type: 'module' });
+  });
+
+  it('registers the built root script as a classic worker in a build', () => {
+    expect(serviceWorkerScript({ DEV: false })).toEqual({ url: '/sw.js', type: 'classic' });
+  });
+});

--- a/apps/web/src/engine/createMediaService.ts
+++ b/apps/web/src/engine/createMediaService.ts
@@ -1,0 +1,27 @@
+import { MediaService, type MediaReader } from '@cipherbox/client';
+
+/**
+ * Dev serves the source entry as a transformed ES module under the
+ * `Service-Worker-Allowed` root scope; the build emits a classic script.
+ */
+export function serviceWorkerScript(env: Partial<ImportMetaEnv>): {
+  url: string;
+  type: 'classic' | 'module';
+} {
+  return env.DEV ? { url: '/src/sw.ts', type: 'module' } : { url: '/sw.js', type: 'classic' };
+}
+
+/**
+ * This tab's streaming pipe, or `null` where the browser offers no Service
+ * Worker — an insecure context loses streaming, never its boot.
+ */
+export function createMediaService(reader: MediaReader): MediaService | null {
+  if (!('serviceWorker' in navigator)) return null;
+  const script = serviceWorkerScript(import.meta.env);
+  return new MediaService({
+    container: navigator.serviceWorker,
+    scriptUrl: script.url,
+    scriptType: script.type,
+    reader,
+  });
+}

--- a/apps/web/src/engine/createMediaService.ts
+++ b/apps/web/src/engine/createMediaService.ts
@@ -11,10 +11,7 @@ export function serviceWorkerScript(env: Partial<ImportMetaEnv>): {
   return env.DEV ? { url: '/src/sw.ts', type: 'module' } : { url: '/sw.js', type: 'classic' };
 }
 
-/**
- * This tab's streaming pipe, or `null` where the browser offers no Service
- * Worker — an insecure context loses streaming, never its boot.
- */
+/** This tab's streaming pipe, or `null` where the browser offers no Service Worker. */
 export function createMediaService(reader: MediaReader): MediaService | null {
   if (!('serviceWorker' in navigator)) return null;
   const script = serviceWorkerScript(import.meta.env);

--- a/apps/web/src/providers/EngineProvider.test.tsx
+++ b/apps/web/src/providers/EngineProvider.test.tsx
@@ -1,8 +1,33 @@
-import type { EngineClient, SecretSource } from '@cipherbox/client';
+import type { EngineClient, MediaService, SecretSource } from '@cipherbox/client';
 import { render, renderHook, screen } from '@testing-library/react';
 import { StrictMode, type ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
-import { EngineProvider, useEngine, useLoginSecretSource } from './EngineProvider';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EngineProvider, useEngine, useLoginSecretSource, useMediaService } from './EngineProvider';
+
+// The real factory reads `navigator.serviceWorker`, which jsdom does not
+// implement; the seam is what lets both outcomes be exercised.
+const mediaControl = vi.hoisted(() => ({
+  create: (): MediaService | null => null,
+}));
+vi.mock('../engine/createMediaService', () => ({
+  createMediaService: () => mediaControl.create(),
+}));
+
+afterEach(() => {
+  mediaControl.create = () => null;
+});
+
+/** A media service that records only whether it was started and disposed. */
+function mediaLedger(log: string[] = []) {
+  const media = {
+    start: () => Promise.resolve(),
+    dispose: () => {
+      log.push('media');
+      return Promise.resolve();
+    },
+  } as unknown as MediaService;
+  return { media, log };
+}
 
 /** Counts the clients a provider builds and disposes; that is all it touches. */
 function clientLedger() {
@@ -80,6 +105,45 @@ describe('EngineProvider', () => {
     );
 
     expect(built.length - disposed.length).toBe(1);
+  });
+
+  it("hands consumers this tab's media service", () => {
+    const { createClient } = clientLedger();
+    const { media } = mediaLedger();
+    mediaControl.create = () => media;
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <EngineProvider createClient={createClient}>{children}</EngineProvider>
+    );
+
+    const { result } = renderHook(() => useMediaService(), { wrapper });
+
+    expect(result.current).toBe(media);
+  });
+
+  it('reports no media service where the browser offers no Service Worker', () => {
+    const { createClient } = clientLedger();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <EngineProvider createClient={createClient}>{children}</EngineProvider>
+    );
+
+    const { result } = renderHook(() => useMediaService(), { wrapper });
+
+    expect(result.current).toBeNull();
+  });
+
+  it("disposes this tab's media service with the provider", async () => {
+    const { createClient } = clientLedger();
+    const { media, log } = mediaLedger();
+    mediaControl.create = () => media;
+
+    const { unmount } = render(
+      <EngineProvider createClient={createClient}>
+        <span />
+      </EngineProvider>
+    );
+    unmount();
+
+    await vi.waitFor(() => expect(log).toEqual(['media']));
   });
 
   it('rejects a consumer mounted outside the provider', () => {

--- a/apps/web/src/providers/EngineProvider.tsx
+++ b/apps/web/src/providers/EngineProvider.tsx
@@ -10,6 +10,7 @@ import {
 import type { EngineClient, MediaService, SecretSource } from '@cipherbox/client';
 import { createMediaService } from '../engine/createMediaService';
 import { LoginSecretSource } from '../engine/loginHandoff';
+import { errorMessage } from '../lib/errorMessage';
 import {
   createSnapshotStore,
   idleSnapshotStore,
@@ -55,20 +56,20 @@ export function EngineProvider({ createClient, children }: EngineProviderProps) 
     const client = factory.current(secrets);
     const snapshots = createSnapshotStore(client);
     const media = createMediaService(client);
-    media?.start().catch((error: unknown) => {
-      console.error('[media] start failed', error instanceof Error ? error.message : error);
-    });
+    media
+      ?.start()
+      .catch((error: unknown) => console.error('[media] start failed', errorMessage(error)));
     setValue({ client, snapshots, secrets, media, rebuild });
     return () => {
       // Drop the exporter first: no re-export capability outlives the client.
       secrets.use(null);
       snapshots.dispose();
-      media?.dispose().catch((error: unknown) => {
-        console.error('[media] dispose failed', error instanceof Error ? error.message : error);
-      });
-      client.dispose().catch((error: unknown) => {
-        console.error('[engine] dispose failed', error instanceof Error ? error.message : error);
-      });
+      media
+        ?.dispose()
+        .catch((error: unknown) => console.error('[media] dispose failed', errorMessage(error)));
+      client
+        .dispose()
+        .catch((error: unknown) => console.error('[engine] dispose failed', errorMessage(error)));
     };
   }, [generation, rebuild]);
 

--- a/apps/web/src/providers/EngineProvider.tsx
+++ b/apps/web/src/providers/EngineProvider.tsx
@@ -7,7 +7,8 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import type { EngineClient, SecretSource } from '@cipherbox/client';
+import type { EngineClient, MediaService, SecretSource } from '@cipherbox/client';
+import { createMediaService } from '../engine/createMediaService';
 import { LoginSecretSource } from '../engine/loginHandoff';
 import {
   createSnapshotStore,
@@ -19,6 +20,7 @@ interface EngineContextValue {
   client: EngineClient;
   snapshots: SnapshotStore;
   secrets: LoginSecretSource;
+  media: MediaService | null;
   rebuild: () => void;
 }
 
@@ -52,11 +54,18 @@ export function EngineProvider({ createClient, children }: EngineProviderProps) 
     const secrets = new LoginSecretSource();
     const client = factory.current(secrets);
     const snapshots = createSnapshotStore(client);
-    setValue({ client, snapshots, secrets, rebuild });
+    const media = createMediaService(client);
+    media?.start().catch((error: unknown) => {
+      console.error('[media] start failed', error instanceof Error ? error.message : error);
+    });
+    setValue({ client, snapshots, secrets, media, rebuild });
     return () => {
       // Drop the exporter first: no re-export capability outlives the client.
       secrets.use(null);
       snapshots.dispose();
+      media?.dispose().catch((error: unknown) => {
+        console.error('[media] dispose failed', error instanceof Error ? error.message : error);
+      });
       client.dispose().catch((error: unknown) => {
         console.error('[engine] dispose failed', error instanceof Error ? error.message : error);
       });
@@ -82,6 +91,11 @@ export function useEngine(): EngineClient | null {
 /** This tab's snapshot adapter; an inert store until the client exists. */
 export function useSnapshotStore(): SnapshotStore {
   return useEngineContext()?.snapshots ?? idleSnapshotStore;
+}
+
+/** This tab's streaming pipe; `null` where the browser has no Service Worker. */
+export function useMediaService(): MediaService | null {
+  return useEngineContext()?.media ?? null;
 }
 
 /** Where login registers its Core Kit session for a failover re-export. */

--- a/apps/web/src/sw.ts
+++ b/apps/web/src/sw.ts
@@ -1,0 +1,3 @@
+// Not the UI barrel: importing `@cipherbox/client` here drags the engine client
+// into the worker bundle.
+import '@cipherbox/client/sw';

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -49,7 +49,9 @@ function serviceWorkerBuild(): Plugin {
           emptyOutDir: false,
           rollupOptions: {
             input: SW_ENTRY,
-            output: { entryFileNames: SW_FILE, codeSplitting: false },
+            // `iife` keeps the classic-script contract: an `es` chunk reaching for
+            // a dynamic import emits `import.meta`, which a classic worker rejects.
+            output: { entryFileNames: SW_FILE, codeSplitting: false, format: 'iife' },
           },
         },
       });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,9 +1,64 @@
 import { fileURLToPath } from 'node:url';
 import react from '@vitejs/plugin-react';
+import { build, type Plugin } from 'vite';
 import { defineConfig } from 'vitest/config';
 
+const OUT_DIR = fileURLToPath(new URL('dist', import.meta.url));
+const SW_ENTRY = fileURLToPath(new URL('src/sw.ts', import.meta.url));
+const SW_FILE = 'sw.js';
+const MANIFEST_FILE = 'precache-manifest.json';
+
+/**
+ * The app-shell manifest the Service Worker precaches on install: every emitted
+ * chunk, as same-origin absolute paths. Never the worker itself — a worker that
+ * precached itself could never be replaced.
+ */
+function precacheManifest(): Plugin {
+  return {
+    name: 'cipherbox:precache-manifest',
+    enforce: 'post',
+    generateBundle(_options, bundle) {
+      const shell = Object.keys(bundle)
+        .filter((fileName) => !fileName.endsWith('.map'))
+        .map((fileName) => `/${fileName}`)
+        .sort();
+      this.emitFile({
+        type: 'asset',
+        fileName: MANIFEST_FILE,
+        source: `${JSON.stringify(shell, null, 2)}\n`,
+      });
+    },
+  };
+}
+
+/**
+ * A separate pass so the worker lands unhashed at the output root — its scope is
+ * bounded by its own URL path — and as a classic script, not the ES module the
+ * app's chunk graph would emit.
+ */
+function serviceWorkerBuild(): Plugin {
+  return {
+    name: 'cipherbox:service-worker',
+    apply: 'build',
+    async closeBundle() {
+      await build({
+        configFile: false,
+        logLevel: 'warn',
+        build: {
+          outDir: OUT_DIR,
+          emptyOutDir: false,
+          rollupOptions: {
+            input: SW_ENTRY,
+            output: { entryFileNames: SW_FILE, codeSplitting: false },
+          },
+        },
+      });
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), precacheManifest(), serviceWorkerBuild()],
   // `@cipherbox/client`'s engine worker dynamically imports the wasm-bindgen ES
   // module, which a classic worker cannot do (blueprint/web-client.md).
   worker: { format: 'es' },
@@ -16,8 +71,12 @@ export default defineConfig({
   },
   define: { global: 'globalThis' },
   server: {
-    // The Web3Auth login popup posts its result back to the opener.
-    headers: { 'Cross-Origin-Opener-Policy': 'same-origin-allow-popups' },
+    headers: {
+      // The Web3Auth login popup posts its result back to the opener.
+      'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',
+      // Lets the dev worker at /src/sw.ts claim the root scope it needs.
+      'Service-Worker-Allowed': '/',
+    },
   },
   test: {
     environment: 'jsdom',

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,8 +10,7 @@ const MANIFEST_FILE = 'precache-manifest.json';
 
 /**
  * The app-shell manifest the Service Worker precaches on install: every emitted
- * chunk, as same-origin absolute paths. Never the worker itself — a worker that
- * precached itself could never be replaced.
+ * chunk, as same-origin absolute paths.
  */
 function precacheManifest(): Plugin {
   return {

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -185,6 +185,26 @@ fn open_dag_error(e: DagError) -> OpenError {
     }
 }
 
+/// Make room in `buf` for `additional` more bytes, wiping the allocation it
+/// leaves behind.
+///
+/// A `Zeroizing<Vec<u8>>` wipes only the allocation it currently owns, so
+/// letting `Vec` reallocate would free the old one with plaintext still in it
+/// (AGENTS.md 7). Doubling keeps the new allocation within twice the leaves
+/// already authenticated, so an unproven size field still cannot commit an
+/// outsized one.
+fn grow_wiping(buf: &mut Zeroizing<Vec<u8>>, additional: usize) {
+    let needed = buf.len().saturating_add(additional);
+    if needed <= buf.capacity() {
+        return;
+    }
+    let mut grown = Zeroizing::new(Vec::with_capacity(
+        buf.capacity().saturating_mul(2).max(needed),
+    ));
+    grown.extend_from_slice(buf);
+    std::mem::swap(buf, &mut grown);
+}
+
 /// Fetch, verify, and reassemble the plaintext window `[offset, offset +
 /// length)` of one content version, fetching only the leaves it covers. The
 /// request is clamped to the version, so an offset at or past the end yields no
@@ -225,10 +245,11 @@ pub async fn open_content_range<H: Http>(
     }
     let chunk_size = manifest.chunk_size;
     let leaves = leaf_range_for_byte_range(offset, length, chunk_size, manifest.leaf_cids.len());
-    // Preallocate up to a fixed budget, then grow as leaves arrive: the size is
-    // authenticated but unproven until every leaf is fetched, so a large size
-    // field must not commit an outsized allocation upfront (on wasm32 it would
-    // also truncate). The assembled-length cross-check below is the gate.
+    // Preallocate up to a fixed budget, then grow through `grow_wiping` as
+    // leaves arrive: the size is authenticated but unproven until every leaf is
+    // fetched, so a large size field must not commit an outsized allocation
+    // upfront (on wasm32 it would also truncate). The assembled-length
+    // cross-check below is the gate.
     let prealloc = length.min(limits::MAX_RESOLVED_RECORD_BYTES as u64) as usize;
     // Owns already-assembled plaintext until it is handed to the caller: the
     // trust rejects below abandon a partly-filled buffer (AGENTS.md 7).
@@ -258,6 +279,7 @@ pub async fn open_content_range<H: Http>(
         let to = (offset.saturating_add(length))
             .saturating_sub(leaf_start)
             .min(expected) as usize;
+        grow_wiping(&mut plaintext, to - from);
         plaintext.extend_from_slice(&chunk[from..to]);
     }
     if plaintext.len() as u64 != length {

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -51,7 +51,7 @@ use crate::seams::Http;
 /// addresses under it.
 ///
 /// The three always come from one decoded root manifest, so the published
-/// [`Version`] cannot disagree with the manifest [`open_content`] checks it
+/// [`Version`] cannot disagree with the manifest [`open_content_range`] checks it
 /// against — the encode side of that reject is unrepresentable rather than
 /// merely guarded (AGENTS.md rule 8; #812 guard 3).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -185,17 +185,6 @@ fn open_dag_error(e: DagError) -> OpenError {
     }
 }
 
-/// Fetch, verify, and reassemble one content version's whole plaintext — the
-/// read dual of [`ContentWriter`]. The full-file case of
-/// [`open_content_range`].
-pub async fn open_content<H: Http>(
-    gateway: &Gateway,
-    http: &H,
-    version: &Version,
-) -> Result<Vec<u8>, OpenError> {
-    open_content_range(gateway, http, version, 0, version.size).await
-}
-
 /// Fetch, verify, and reassemble the plaintext window `[offset, offset +
 /// length)` of one content version, fetching only the leaves it covers. The
 /// request is clamped to the version, so an offset at or past the end yields no
@@ -241,7 +230,9 @@ pub async fn open_content_range<H: Http>(
     // field must not commit an outsized allocation upfront (on wasm32 it would
     // also truncate). The assembled-length cross-check below is the gate.
     let prealloc = length.min(limits::MAX_RESOLVED_RECORD_BYTES as u64) as usize;
-    let mut plaintext = Vec::with_capacity(prealloc);
+    // Owns already-assembled plaintext until it is handed to the caller: the
+    // trust rejects below abandon a partly-filled buffer (AGENTS.md 7).
+    let mut plaintext = Zeroizing::new(Vec::with_capacity(prealloc));
     for index in leaves {
         let leaf_cid = &manifest.leaf_cids[index];
         let leaf_cid_str = encode_content_cid_str(leaf_cid);
@@ -275,7 +266,8 @@ pub async fn open_content_range<H: Http>(
             plaintext.len(),
         )));
     }
-    Ok(plaintext)
+    // The caller becomes the terminal owner of the window it asked for.
+    Ok(std::mem::take(&mut *plaintext))
 }
 
 #[cfg(test)]
@@ -317,7 +309,7 @@ mod tests {
         assert_eq!(content.size(), plaintext.len() as u64);
     }
 
-    /// The encode side of [`open_content`]'s manifest-vs-version size reject:
+    /// The encode side of [`open_content_range`]'s manifest-vs-version size reject:
     /// both figures come from one value, so they cannot be made to disagree
     /// (AGENTS.md rule 8; #812 guard 3). Fires in a release build.
     #[test]
@@ -367,9 +359,8 @@ mod tests {
 
     mod ranged {
         use super::*;
-        use crate::seams::{HttpResponse, SeamError};
-        use crate::testkit::block_on;
         use crate::testkit::fakes::ScriptedHttp;
+        use crate::testkit::{block_on, block_store, gateway, requested_cid, serve};
         use std::collections::BTreeMap;
 
         const CONTENT_KEY: [u8; KEY_LEN] = [0x5Au8; KEY_LEN];
@@ -399,10 +390,7 @@ mod tests {
         fn from_leaves(leaves: Vec<SealedChunk>, size: u64) -> Fixture {
             let leaf_cids: Vec<Vec<u8>> = leaves.iter().map(|leaf| leaf.cid.clone()).collect();
             let dag = assemble(&leaf_cids, size, &ContentProfile::CI).unwrap();
-            let mut blocks = BTreeMap::new();
-            for leaf in &leaves {
-                blocks.insert(encode_content_cid_str(&leaf.cid), leaf.sealed.clone());
-            }
+            let mut blocks = block_store(&leaves);
             blocks.insert(
                 encode_content_cid_str(&dag.content_cid),
                 dag.root_block.clone(),
@@ -411,45 +399,6 @@ mod tests {
                 version: Version::new(dag.content_cid, CONTENT_KEY, size, 0),
                 blocks,
             }
-        }
-
-        fn gateway() -> Gateway {
-            Gateway {
-                accelerator: None,
-                public_fallbacks: vec![GatewaySource {
-                    base_url: "https://public.gw.test".into(),
-                    bearer: None,
-                }],
-            }
-        }
-
-        /// The CID a trustless-gateway raw-block URL addresses.
-        fn requested_cid(url: &str) -> String {
-            url.rsplit('/')
-                .next()
-                .and_then(|tail| tail.split('?').next())
-                .unwrap_or_default()
-                .to_owned()
-        }
-
-        /// Serve `blocks` for more requests than any test here makes; anything
-        /// unstored is an availability failure.
-        fn serve(blocks: &BTreeMap<String, Vec<u8>>) -> ScriptedHttp {
-            let http = ScriptedHttp::default();
-            for _ in 0..32 {
-                let blocks = blocks.clone();
-                http.enqueue_derived(move |request| {
-                    match blocks.get(&requested_cid(&request.url)) {
-                        Some(block) => Ok(HttpResponse {
-                            status: 200,
-                            headers: Vec::new(),
-                            body: block.clone(),
-                        }),
-                        None => Err(SeamError::new("no such block")),
-                    }
-                });
-            }
-            http
         }
 
         /// Every CID fetched, in request order.
@@ -560,20 +509,6 @@ mod tests {
         }
 
         #[test]
-        fn the_full_range_equals_the_whole_file_read() {
-            let plaintext: Vec<u8> = (0..100u8).collect();
-            let fixture = fixture(&plaintext);
-            let (out, _) = read_range(&fixture, 0, plaintext.len() as u64);
-            assert_eq!(out, plaintext);
-            let http = serve(&fixture.blocks);
-            assert_eq!(
-                block_on(open_content(&gateway(), &http, &fixture.version)).unwrap(),
-                plaintext,
-                "the whole-file read is the full-range case"
-            );
-        }
-
-        #[test]
         fn every_offset_and_length_matches_the_whole_file_slice() {
             let plaintext: Vec<u8> = (0..48u8).collect();
             let fixture = fixture(&plaintext);
@@ -585,6 +520,9 @@ mod tests {
                     assert_eq!(out, plaintext[start..end], "range {offset}+{length}");
                 }
             }
+            // The whole-file read `Engine::read_content` issues.
+            let (out, _) = read_range(&fixture, 0, u64::MAX);
+            assert_eq!(out, plaintext, "an unbounded window is the whole file");
         }
 
         /// The encode side of the per-leaf length reject: the framer splits on

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -41,6 +41,7 @@ pub use write::{ContentWriter, FinishedContent};
 use cipherbox_core::content::{compute_cid, encode_content_cid_str, open_chunk};
 use cipherbox_core::seal::Version;
 use cipherbox_core::suite::secret::SECRET_LEN;
+use zeroize::Zeroizing;
 
 use crate::entropy::EntropyError;
 use crate::seams::Http;
@@ -184,14 +185,32 @@ fn open_dag_error(e: DagError) -> OpenError {
     }
 }
 
-/// Fetch, verify, and reassemble one content version's plaintext — the read
-/// dual of [`ContentWriter`]: DAG root fetch (CID-verified fail-closed) →
-/// manifest-vs-version size cross-check → per-leaf CID-verified fetch + unseal
-/// under the version content key → reassembled-length cross-check.
+/// Fetch, verify, and reassemble one content version's whole plaintext — the
+/// read dual of [`ContentWriter`]. The full-file case of
+/// [`open_content_range`].
 pub async fn open_content<H: Http>(
     gateway: &Gateway,
     http: &H,
     version: &Version,
+) -> Result<Vec<u8>, OpenError> {
+    open_content_range(gateway, http, version, 0, version.size).await
+}
+
+/// Fetch, verify, and reassemble the plaintext window `[offset, offset +
+/// length)` of one content version, fetching only the leaves it covers. The
+/// request is clamped to the version, so an offset at or past the end yields no
+/// bytes.
+///
+/// Every leaf must unseal to the length the flat framing implies — `chunk_size`
+/// but for the final one. A disagreement is a fail-closed trust violation: a
+/// short middle leaf shifts every downstream byte, so tolerating one would serve
+/// silently misaligned plaintext.
+pub async fn open_content_range<H: Http>(
+    gateway: &Gateway,
+    http: &H,
+    version: &Version,
+    offset: u64,
+    length: u64,
 ) -> Result<Vec<u8>, OpenError> {
     let root_cid_str = encode_content_cid_str(&version.content_cid);
     let root_block = read_block(
@@ -211,26 +230,49 @@ pub async fn open_content<H: Http>(
         )));
     }
 
+    let length = length.min(manifest.size.saturating_sub(offset));
+    if length == 0 {
+        return Ok(Vec::new());
+    }
+    let chunk_size = manifest.chunk_size;
+    let leaves = leaf_range_for_byte_range(offset, length, chunk_size, manifest.leaf_cids.len());
     // Preallocate up to a fixed budget, then grow as leaves arrive: the size is
     // authenticated but unproven until every leaf is fetched, so a large size
     // field must not commit an outsized allocation upfront (on wasm32 it would
-    // also truncate). The reassembled-length cross-check below is the gate.
-    let prealloc = manifest.size.min(limits::MAX_RESOLVED_RECORD_BYTES as u64) as usize;
+    // also truncate). The assembled-length cross-check below is the gate.
+    let prealloc = length.min(limits::MAX_RESOLVED_RECORD_BYTES as u64) as usize;
     let mut plaintext = Vec::with_capacity(prealloc);
-    for leaf_cid in &manifest.leaf_cids {
+    for index in leaves {
+        let leaf_cid = &manifest.leaf_cids[index];
         let leaf_cid_str = encode_content_cid_str(leaf_cid);
         let sealed = read_block(gateway, http, &leaf_cid_str, leaf_cid, ContentPlane::Leaf)
             .await
             .map_err(open_read_error)?;
-        let chunk = open_chunk(version.content_key(), &sealed)
-            .map_err(|e| OpenError::Trust(format!("leaf unseal rejected: [{}]", e.check())))?;
-        plaintext.extend_from_slice(&chunk);
+        // Terminal owner of this leaf's plaintext: a ranged read discards the
+        // trimmed head and tail, so they must not outlive the loop (AGENTS.md 7).
+        let chunk = Zeroizing::new(
+            open_chunk(version.content_key(), &sealed)
+                .map_err(|e| OpenError::Trust(format!("leaf unseal rejected: [{}]", e.check())))?,
+        );
+
+        let leaf_start = (index as u64).saturating_mul(chunk_size);
+        let expected = chunk_size.min(manifest.size.saturating_sub(leaf_start));
+        if chunk.len() as u64 != expected {
+            return Err(OpenError::Trust(format!(
+                "leaf {index} unsealed to {} bytes, not the {expected} the manifest implies",
+                chunk.len()
+            )));
+        }
+        let from = offset.saturating_sub(leaf_start).min(expected) as usize;
+        let to = (offset.saturating_add(length))
+            .saturating_sub(leaf_start)
+            .min(expected) as usize;
+        plaintext.extend_from_slice(&chunk[from..to]);
     }
-    if plaintext.len() as u64 != manifest.size {
+    if plaintext.len() as u64 != length {
         return Err(OpenError::Trust(format!(
-            "reassembled length {} disagrees with manifest size {}",
+            "assembled length {} disagrees with the {length}-byte range requested",
             plaintext.len(),
-            manifest.size
         )));
     }
     Ok(plaintext)
@@ -321,5 +363,323 @@ mod tests {
     #[test]
     fn framing_is_deterministic() {
         assert_eq!(sealed(b"determinism", 7).0, sealed(b"determinism", 7).0);
+    }
+
+    mod ranged {
+        use super::*;
+        use crate::seams::{HttpResponse, SeamError};
+        use crate::testkit::block_on;
+        use crate::testkit::fakes::ScriptedHttp;
+        use std::collections::BTreeMap;
+
+        const CONTENT_KEY: [u8; KEY_LEN] = [0x5Au8; KEY_LEN];
+
+        /// A version and the blocks that serve it, keyed by gateway address.
+        struct Fixture {
+            version: Version,
+            blocks: BTreeMap<String, Vec<u8>>,
+        }
+
+        /// Frame `plaintext` at the CI profile (16-byte chunks) into a version
+        /// whose every block is served by the returned store.
+        fn fixture(plaintext: &[u8]) -> Fixture {
+            let key = ContentKey::from_bytes(CONTENT_KEY);
+            let leaves = frame_and_seal(
+                plaintext,
+                &key,
+                &mut SeededEntropy::new(1),
+                &ContentProfile::CI,
+            )
+            .unwrap();
+            from_leaves(leaves, plaintext.len() as u64)
+        }
+
+        /// Assemble a version over already-sealed `leaves` declaring `size` —
+        /// the seam a hostile manifest is built through.
+        fn from_leaves(leaves: Vec<SealedChunk>, size: u64) -> Fixture {
+            let leaf_cids: Vec<Vec<u8>> = leaves.iter().map(|leaf| leaf.cid.clone()).collect();
+            let dag = assemble(&leaf_cids, size, &ContentProfile::CI).unwrap();
+            let mut blocks = BTreeMap::new();
+            for leaf in &leaves {
+                blocks.insert(encode_content_cid_str(&leaf.cid), leaf.sealed.clone());
+            }
+            blocks.insert(
+                encode_content_cid_str(&dag.content_cid),
+                dag.root_block.clone(),
+            );
+            Fixture {
+                version: Version::new(dag.content_cid, CONTENT_KEY, size, 0),
+                blocks,
+            }
+        }
+
+        fn gateway() -> Gateway {
+            Gateway {
+                accelerator: None,
+                public_fallbacks: vec![GatewaySource {
+                    base_url: "https://public.gw.test".into(),
+                    bearer: None,
+                }],
+            }
+        }
+
+        /// The CID a trustless-gateway raw-block URL addresses.
+        fn requested_cid(url: &str) -> String {
+            url.rsplit('/')
+                .next()
+                .and_then(|tail| tail.split('?').next())
+                .unwrap_or_default()
+                .to_owned()
+        }
+
+        /// Serve `blocks` for more requests than any test here makes; anything
+        /// unstored is an availability failure.
+        fn serve(blocks: &BTreeMap<String, Vec<u8>>) -> ScriptedHttp {
+            let http = ScriptedHttp::default();
+            for _ in 0..32 {
+                let blocks = blocks.clone();
+                http.enqueue_derived(move |request| {
+                    match blocks.get(&requested_cid(&request.url)) {
+                        Some(block) => Ok(HttpResponse {
+                            status: 200,
+                            headers: Vec::new(),
+                            body: block.clone(),
+                        }),
+                        None => Err(SeamError::new("no such block")),
+                    }
+                });
+            }
+            http
+        }
+
+        /// Every CID fetched, in request order.
+        fn fetched(http: &ScriptedHttp) -> Vec<String> {
+            http.requests()
+                .iter()
+                .map(|request| requested_cid(&request.url))
+                .collect()
+        }
+
+        /// The gateway address of leaf `index` of `fixture`'s version.
+        fn leaf_address(fixture: &Fixture, index: usize) -> String {
+            let root =
+                fixture.blocks[&encode_content_cid_str(&fixture.version.content_cid)].clone();
+            encode_content_cid_str(&decode_root(&root).unwrap().leaf_cids[index])
+        }
+
+        fn read_range(fixture: &Fixture, offset: u64, length: u64) -> (Vec<u8>, Vec<String>) {
+            let http = serve(&fixture.blocks);
+            let out = block_on(open_content_range(
+                &gateway(),
+                &http,
+                &fixture.version,
+                offset,
+                length,
+            ))
+            .unwrap();
+            (out, fetched(&http))
+        }
+
+        #[test]
+        fn a_chunk_aligned_range_serves_exactly_its_own_leaf() {
+            let plaintext: Vec<u8> = (0..48u8).collect();
+            let fixture = fixture(&plaintext);
+            let (out, cids) = read_range(&fixture, 16, 16);
+            assert_eq!(out, plaintext[16..32]);
+            assert_eq!(
+                cids,
+                vec![
+                    encode_content_cid_str(&fixture.version.content_cid),
+                    leaf_address(&fixture, 1),
+                ],
+                "the root plus the one leaf the range covers, nothing else"
+            );
+        }
+
+        #[test]
+        fn a_range_straddling_a_leaf_boundary_is_assembled_from_both() {
+            let plaintext: Vec<u8> = (0..48u8).collect();
+            let fixture = fixture(&plaintext);
+            let (out, cids) = read_range(&fixture, 15, 2);
+            assert_eq!(out, plaintext[15..17]);
+            assert_eq!(
+                cids,
+                vec![
+                    encode_content_cid_str(&fixture.version.content_cid),
+                    leaf_address(&fixture, 0),
+                    leaf_address(&fixture, 1),
+                ]
+            );
+        }
+
+        #[test]
+        fn a_suffix_range_running_past_the_end_is_clamped() {
+            let plaintext: Vec<u8> = (0..40u8).collect();
+            let fixture = fixture(&plaintext);
+            let (out, _) = read_range(&fixture, 33, 1000);
+            assert_eq!(out, plaintext[33..], "clamped to the version's own size");
+        }
+
+        #[test]
+        fn an_offset_at_or_past_the_end_yields_no_bytes_and_no_leaf_fetch() {
+            let fixture = fixture(&(0..40u8).collect::<Vec<_>>());
+            for offset in [40u64, 41, u64::MAX] {
+                let (out, cids) = read_range(&fixture, offset, 16);
+                assert!(out.is_empty(), "offset {offset} is past the end");
+                assert_eq!(
+                    cids,
+                    vec![encode_content_cid_str(&fixture.version.content_cid)],
+                    "only the root is consulted"
+                );
+            }
+        }
+
+        #[test]
+        fn a_zero_length_range_yields_no_bytes() {
+            let fixture = fixture(&(0..40u8).collect::<Vec<_>>());
+            let (out, cids) = read_range(&fixture, 8, 0);
+            assert!(out.is_empty());
+            assert_eq!(cids.len(), 1, "no leaf is fetched for an empty window");
+        }
+
+        #[test]
+        fn only_the_leaves_the_window_covers_are_fetched() {
+            // 5 leaves at 16 bytes; the window sits inside leaves 2..4.
+            let plaintext: Vec<u8> = (0..80u8).collect();
+            let fixture = fixture(&plaintext);
+            let (out, cids) = read_range(&fixture, 40, 20);
+            assert_eq!(out, plaintext[40..60]);
+            assert_eq!(
+                cids,
+                vec![
+                    encode_content_cid_str(&fixture.version.content_cid),
+                    leaf_address(&fixture, 2),
+                    leaf_address(&fixture, 3),
+                ]
+            );
+        }
+
+        #[test]
+        fn the_full_range_equals_the_whole_file_read() {
+            let plaintext: Vec<u8> = (0..100u8).collect();
+            let fixture = fixture(&plaintext);
+            let (out, _) = read_range(&fixture, 0, plaintext.len() as u64);
+            assert_eq!(out, plaintext);
+            let http = serve(&fixture.blocks);
+            assert_eq!(
+                block_on(open_content(&gateway(), &http, &fixture.version)).unwrap(),
+                plaintext,
+                "the whole-file read is the full-range case"
+            );
+        }
+
+        #[test]
+        fn every_offset_and_length_matches_the_whole_file_slice() {
+            let plaintext: Vec<u8> = (0..48u8).collect();
+            let fixture = fixture(&plaintext);
+            for offset in 0..=48u64 {
+                for length in 0..=8u64 {
+                    let (out, _) = read_range(&fixture, offset, length);
+                    let start = offset.min(48) as usize;
+                    let end = (offset + length).min(48) as usize;
+                    assert_eq!(out, plaintext[start..end], "range {offset}+{length}");
+                }
+            }
+        }
+
+        /// The encode side of the per-leaf length reject: the framer splits on
+        /// the chunk boundary, so a short non-final leaf is unrepresentable
+        /// rather than merely guarded (AGENTS.md rule 8). Fires in a release
+        /// build.
+        #[test]
+        fn the_framer_cannot_produce_a_short_non_final_leaf() {
+            let chunk_size = ContentProfile::CI.chunk_size();
+            let key = ContentKey::from_bytes(CONTENT_KEY);
+            for len in [0usize, 1, 15, 16, 17, 40, 100] {
+                let leaves = frame_and_seal(
+                    &vec![7u8; len],
+                    &key,
+                    &mut SeededEntropy::new(1),
+                    &ContentProfile::CI,
+                )
+                .unwrap();
+                for (index, leaf) in leaves.iter().enumerate() {
+                    let chunk = open_chunk(&CONTENT_KEY, &leaf.sealed).unwrap();
+                    let expected = if index + 1 < leaves.len() {
+                        chunk_size
+                    } else {
+                        len - index * chunk_size
+                    };
+                    assert_eq!(chunk.len(), expected, "{len}-byte version, leaf {index}");
+                }
+            }
+        }
+
+        #[test]
+        fn a_short_middle_leaf_fails_closed_as_a_trust_violation() {
+            // Leaf 1 carries 8 bytes where the framing implies 16; the manifest
+            // is otherwise well-formed — 3 leaves for 40 bytes at a 16-byte chunk.
+            let key = ContentKey::from_bytes(CONTENT_KEY);
+            let mut entropy = SeededEntropy::new(2);
+            let leaves: Vec<SealedChunk> = [16usize, 8, 16]
+                .into_iter()
+                .map(|len| seal_one_chunk(&key, &vec![0xA5u8; len], &mut entropy).unwrap())
+                .collect();
+            let fixture = from_leaves(leaves, 40);
+            let http = serve(&fixture.blocks);
+
+            let err = block_on(open_content_range(
+                &gateway(),
+                &http,
+                &fixture.version,
+                0,
+                40,
+            ))
+            .unwrap_err();
+            match err {
+                OpenError::Trust(message) => assert!(
+                    message.contains("leaf 1"),
+                    "the reject names the offending leaf: {message}"
+                ),
+                other => panic!("expected a trust violation, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn a_final_leaf_disagreeing_with_the_declared_size_fails_closed() {
+            // Two full leaves declared as 24 bytes: the final leaf unseals to 16
+            // where the manifest implies 8.
+            let key = ContentKey::from_bytes(CONTENT_KEY);
+            let mut entropy = SeededEntropy::new(3);
+            let leaves: Vec<SealedChunk> = (0..2)
+                .map(|_| seal_one_chunk(&key, &[0xC3u8; 16], &mut entropy).unwrap())
+                .collect();
+            let fixture = from_leaves(leaves, 24);
+            let http = serve(&fixture.blocks);
+
+            let err = block_on(open_content_range(
+                &gateway(),
+                &http,
+                &fixture.version,
+                16,
+                8,
+            ))
+            .unwrap_err();
+            assert!(matches!(err, OpenError::Trust(_)), "got {err:?}");
+        }
+
+        #[test]
+        fn a_manifest_disagreeing_with_the_version_size_fails_closed_before_any_leaf() {
+            let fixture = fixture(&(0..40u8).collect::<Vec<_>>());
+            let version = Version::new(fixture.version.content_cid.clone(), CONTENT_KEY, 41, 0);
+            let http = serve(&fixture.blocks);
+            let err = block_on(open_content_range(&gateway(), &http, &version, 0, 16)).unwrap_err();
+            assert!(matches!(err, OpenError::Trust(_)), "got {err:?}");
+            assert_eq!(
+                fetched(&http).len(),
+                1,
+                "no leaf is fetched past the reject"
+            );
+        }
     }
 }

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -23,7 +23,7 @@ use std::rc::Rc;
 
 use cipherbox_core::content::encode_content_cid_str;
 use cipherbox_core::ipns::IpnsName;
-use cipherbox_core::seal::{ReadBody, seal_content_key};
+use cipherbox_core::seal::{ReadBody, Version, seal_content_key};
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
 use futures_channel::mpsc;
 use futures_core::Stream;
@@ -33,7 +33,7 @@ use crate::api::{ApiClient, ApiError, IdentityChallengeSigner};
 use crate::content::budget::{Refusal, ReservationId};
 use crate::content::{
     ContentKey, ContentProfile, ContentWriter, Gateway, GatewayConfig, OpenError, Refused,
-    SealError, StagingLedger, open_content, sealed_total_bytes,
+    SealError, StagingLedger, open_content, open_content_range, sealed_total_bytes,
 };
 use crate::entropy::Entropy;
 use crate::gate::{GateError, floor};
@@ -2414,15 +2414,54 @@ impl<T: SeamTypes> Engine<T> {
         }
     }
 
+    /// Read one byte window of a file node's plaintext, fetching only the leaves
+    /// the window covers (blueprint/engine.md "Content plane"). Emits no
+    /// [`Event::OpProgress`]: a media element issues one ranged read per seek and
+    /// per buffer refill, and a phase pair each would drown the stream.
+    pub async fn read_content_range(
+        &self,
+        node: NodeId,
+        offset: u64,
+        length: u64,
+    ) -> Result<Vec<u8>, EngineError> {
+        if !self.started {
+            return Err(EngineError::NotStarted);
+        }
+        let (version, version_count) = self.head_version(node).await?;
+        let bytes = open_content_range(&self.gateway, &self.seams.http, &version, offset, length)
+            .await
+            .map_err(open_engine_error)?;
+        if project_child_version(
+            &mut self.snapshot.borrow_mut(),
+            node,
+            version.size,
+            version.modified_at,
+            version_count,
+        ) {
+            let _ = self.events.unbounded_send(Event::SnapshotUpdated);
+        }
+        Ok(bytes)
+    }
+
     /// The verified read pipeline behind [`read_content`](Self::read_content):
-    /// base-snapshot lookup → gated child resolve →
-    /// [`open_content`] (version-DAG fetch, per-leaf unseal, length
-    /// cross-checks). Returns the plaintext plus the head version's
-    /// `(size, modifiedAt)` and the body's version count.
+    /// [`head_version`](Self::head_version) → [`open_content`] (version-DAG
+    /// fetch, per-leaf unseal, length cross-checks). Returns the plaintext plus
+    /// the head version's `(size, modifiedAt)` and the body's version count.
     async fn read_content_inner(
         &self,
         node: NodeId,
     ) -> Result<(Vec<u8>, u64, u64, u64), EngineError> {
+        let (version, version_count) = self.head_version(node).await?;
+        let plaintext = open_content(&self.gateway, &self.seams.http, &version)
+            .await
+            .map_err(open_engine_error)?;
+        Ok((plaintext, version.size, version.modified_at, version_count))
+    }
+
+    /// Resolve one file node's head content version: base-snapshot lookup →
+    /// gated child resolve → head of the sealed body's version list. Returns
+    /// the version and the body's version count.
+    async fn head_version(&self, node: NodeId) -> Result<(Version, u64), EngineError> {
         // The base snapshot alone answers the lookup (kind and ipnsName never
         // come from the overlay) — no full render for a single node. The borrow
         // never spans an await.
@@ -2502,31 +2541,17 @@ impl<T: SeamTypes> Engine<T> {
             });
         };
         // Newest-first; head is current (crates/core/src/seal/body.rs).
-        let Some(version) = versions.first() else {
+        let version_count = versions.len() as u64;
+        let Some(version) = versions.into_iter().next() else {
             return Err(EngineError::ContentUnavailable {
                 message: "file has no published content version".to_owned(),
             });
         };
-
-        let plaintext = open_content(&self.gateway, &self.seams.http, version)
-            .await
-            .map_err(|e| match e {
-                OpenError::Trust(message) => EngineError::TrustViolation { message },
-                OpenError::Unavailable(message) => EngineError::ContentUnavailable { message },
-                OpenError::UnsupportedFormat { version } => {
-                    EngineError::UnsupportedContentFormat { version }
-                }
-            })?;
-        Ok((
-            plaintext,
-            version.size,
-            version.modified_at,
-            versions.len() as u64,
-        ))
+        Ok((version, version_count))
     }
 
-    /// Best-effort [`Event::OpProgress`] emission for a content read (a dropped
-    /// receiver is fine).
+    /// Best-effort [`Event::OpProgress`] emission for a full content read (a
+    /// dropped receiver is fine).
     fn emit_op_progress(&self, node: NodeId, phase: OpPhase, error: Option<String>) {
         let _ = self.events.unbounded_send(Event::OpProgress {
             op_id: None,
@@ -2655,6 +2680,17 @@ impl<T: SeamTypes> Engine<T> {
     /// The measured storage split this engine runs under.
     pub fn storage_policy(&self) -> &StoragePolicy {
         &self.storage_policy
+    }
+}
+
+/// Map a verified-read failure onto the facade error surface.
+fn open_engine_error(error: OpenError) -> EngineError {
+    match error {
+        OpenError::Trust(message) => EngineError::TrustViolation { message },
+        OpenError::Unavailable(message) => EngineError::ContentUnavailable { message },
+        OpenError::UnsupportedFormat { version } => {
+            EngineError::UnsupportedContentFormat { version }
+        }
     }
 }
 

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -33,7 +33,7 @@ use crate::api::{ApiClient, ApiError, IdentityChallengeSigner};
 use crate::content::budget::{Refusal, ReservationId};
 use crate::content::{
     ContentKey, ContentProfile, ContentWriter, Gateway, GatewayConfig, OpenError, Refused,
-    SealError, StagingLedger, open_content, open_content_range, sealed_total_bytes,
+    SealError, StagingLedger, open_content_range, sealed_total_bytes,
 };
 use crate::entropy::Entropy;
 use crate::gate::{GateError, floor};
@@ -2390,20 +2390,10 @@ impl<T: SeamTypes> Engine<T> {
             return Err(EngineError::NotStarted);
         }
         self.emit_op_progress(node, OpPhase::DownloadStarted, None);
-        match self.read_content_inner(node).await {
-            Ok((plaintext, size, modified_at, version_count)) => {
-                // The verified head version is gate-passing state, so it may
-                // legally touch the base node's projected size/mtime. Repaint
-                // only on a real change — a repeat read must not cascade.
-                if project_child_version(
-                    &mut self.snapshot.borrow_mut(),
-                    node,
-                    size,
-                    modified_at,
-                    version_count,
-                ) {
-                    let _ = self.events.unbounded_send(Event::SnapshotUpdated);
-                }
+        // The range clamps to the version's size, so the whole file is the
+        // unbounded window.
+        match self.read_content_range(node, 0, u64::MAX).await {
+            Ok(plaintext) => {
                 self.emit_op_progress(node, OpPhase::DownloadCompleted, None);
                 Ok(plaintext)
             }
@@ -2431,6 +2421,9 @@ impl<T: SeamTypes> Engine<T> {
         let bytes = open_content_range(&self.gateway, &self.seams.http, &version, offset, length)
             .await
             .map_err(open_engine_error)?;
+        // The verified head version is gate-passing state, so it may legally
+        // touch the base node's projected size/mtime. Repaint only on a real
+        // change — a repeat read must not cascade.
         if project_child_version(
             &mut self.snapshot.borrow_mut(),
             node,
@@ -2441,21 +2434,6 @@ impl<T: SeamTypes> Engine<T> {
             let _ = self.events.unbounded_send(Event::SnapshotUpdated);
         }
         Ok(bytes)
-    }
-
-    /// The verified read pipeline behind [`read_content`](Self::read_content):
-    /// [`head_version`](Self::head_version) → [`open_content`] (version-DAG
-    /// fetch, per-leaf unseal, length cross-checks). Returns the plaintext plus
-    /// the head version's `(size, modifiedAt)` and the body's version count.
-    async fn read_content_inner(
-        &self,
-        node: NodeId,
-    ) -> Result<(Vec<u8>, u64, u64, u64), EngineError> {
-        let (version, version_count) = self.head_version(node).await?;
-        let plaintext = open_content(&self.gateway, &self.seams.http, &version)
-            .await
-            .map_err(open_engine_error)?;
-        Ok((plaintext, version.size, version.modified_at, version_count))
     }
 
     /// Resolve one file node's head content version: base-snapshot lookup →
@@ -2540,9 +2518,11 @@ impl<T: SeamTypes> Engine<T> {
                 message: "sealed body kind disagrees with the child ref".to_owned(),
             });
         };
-        // Newest-first; head is current (crates/core/src/seal/body.rs).
+        // Newest-first; head is current (crates/core/src/seal/body.rs). Clone the
+        // head rather than moving it out: `into_iter().next()` bitwise-moves slot
+        // 0, so its content key would reach the allocator unzeroized.
         let version_count = versions.len() as u64;
-        let Some(version) = versions.into_iter().next() else {
+        let Some(version) = versions.first().cloned() else {
             return Err(EngineError::ContentUnavailable {
                 message: "file has no published content version".to_owned(),
             });

--- a/crates/engine/src/seams/http.rs
+++ b/crates/engine/src/seams/http.rs
@@ -4,10 +4,6 @@ use core::fmt;
 
 use super::{SeamError, SeamResult};
 
-/// The `Content-Length` response header, consulted by [`Http::send_capped`] for
-/// an up-front reject before any body bytes are read.
-pub const CONTENT_LENGTH: &str = "content-length";
-
 /// Why a size-capped fetch ([`Http::send_capped`]) did not return a body.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CappedFetchError {
@@ -149,10 +145,9 @@ pub trait Http {
     ///   `Content-Length` pre-check plus a capped streaming read that aborts
     ///   past the cap — the true peak-memory bound at the content fetch
     ///   boundary (#787).
-    /// - WASM (the JS fetch bridge) applies a `Content-Length` pre-check plus a
-    ///   post-buffer size check: it fails closed on size but is *not* a
-    ///   peak-memory bound, because the JS seam buffers the whole body before it
-    ///   reaches Rust. The streaming bound is tracked in #641.
+    /// - WASM (the JS fetch bridge) enforces the same bound in the JS seam,
+    ///   which drains `Response.body` under the cap and never materializes an
+    ///   over-cap body (#641).
     ///
     /// The default implementation only backstops: it buffers the whole body via
     /// [`send`](Self::send) and then checks the length, which bounds nothing. It

--- a/crates/engine/src/seams/mod.rs
+++ b/crates/engine/src/seams/mod.rs
@@ -22,7 +22,7 @@ mod staging_store;
 
 pub use credential_store::CredentialStore;
 pub use floor_store::{FloorNamespace, FloorRaise, FloorStore};
-pub use http::{CONTENT_LENGTH, CappedFetchError, Http, HttpMethod, HttpRequest, HttpResponse};
+pub use http::{CappedFetchError, Http, HttpMethod, HttpRequest, HttpResponse};
 pub use mailbox::{Mailbox, MailboxItem};
 pub use record_transport::{EndpointId, RecordTransport};
 pub use refresh_hint::{RefreshHint, RefreshHintSource};

--- a/crates/engine/src/testkit/content.rs
+++ b/crates/engine/src/testkit/content.rs
@@ -4,6 +4,7 @@
 //! every suite that hand-rolls it.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use cipherbox_core::content::encode_content_cid_str;
 use cipherbox_core::suite::aead::KEY_LEN;
@@ -25,12 +26,20 @@ pub fn frame_version(
     key: [u8; KEY_LEN],
     seed: u64,
 ) -> (Vec<SealedChunk>, Vec<u8>, SealedContent) {
+    frame_version_with(plaintext, key, seed, ContentProfile::CI)
+}
+
+/// [`frame_version`] under a caller-chosen framing profile, for a suite whose
+/// property only shows up at a chunk size the CI profile cannot reach.
+pub fn frame_version_with(
+    plaintext: &[u8],
+    key: [u8; KEY_LEN],
+    seed: u64,
+    profile: ContentProfile,
+) -> (Vec<SealedChunk>, Vec<u8>, SealedContent) {
     let mut entropy = SeededEntropy::new(seed);
-    let mut writer = ContentWriter::new(
-        ContentKey::from_bytes(key),
-        ContentProfile::CI,
-        plaintext.len() as u64,
-    );
+    let mut writer =
+        ContentWriter::new(ContentKey::from_bytes(key), profile, plaintext.len() as u64);
     let mut blocks = Vec::new();
     let mut rest = plaintext;
     while !rest.is_empty() {
@@ -82,8 +91,10 @@ pub fn block_store<'a>(
 /// is an availability failure, never a trust verdict.
 pub fn serve(blocks: &BTreeMap<String, Vec<u8>>) -> ScriptedHttp {
     let http = ScriptedHttp::default();
+    // Shared, not copied per reply: a multi-MiB block store costs one copy.
+    let blocks = Arc::new(blocks.clone());
     for _ in 0..32 {
-        let blocks = blocks.clone();
+        let blocks = Arc::clone(&blocks);
         http.enqueue_derived(
             move |request| match blocks.get(&requested_cid(&request.url)) {
                 Some(block) => Ok(HttpResponse {

--- a/crates/engine/src/testkit/content.rs
+++ b/crates/engine/src/testkit/content.rs
@@ -1,11 +1,19 @@
-//! Version framing for fixtures: one definition of the write handle's
-//! push/finish loop, so a change to the [`ContentWriter`] contract lands in one
-//! place rather than in every suite that hand-rolls it.
+//! Content-plane fixtures: one definition of the write handle's push/finish
+//! loop and of the block store a verified read is served from, so a change to
+//! the [`ContentWriter`] or gateway contract lands in one place rather than in
+//! every suite that hand-rolls it.
 
+use std::collections::BTreeMap;
+
+use cipherbox_core::content::encode_content_cid_str;
 use cipherbox_core::suite::aead::KEY_LEN;
 
 use super::SeededEntropy;
-use crate::content::{ContentKey, ContentProfile, ContentWriter, SealedChunk, SealedContent};
+use super::fakes::ScriptedHttp;
+use crate::content::{
+    ContentKey, ContentProfile, ContentWriter, Gateway, GatewaySource, SealedChunk, SealedContent,
+};
+use crate::seams::{HttpResponse, SeamError};
 
 /// Frame `plaintext` the way a write handle does, without the facade: every
 /// sealed block in file order, the root block, and the version's own identity.
@@ -37,4 +45,55 @@ pub fn frame_version(
         blocks.push(tail);
     }
     (blocks, finished.root_block, finished.content)
+}
+
+/// A gateway with no accelerator: every block is fetched from one public
+/// trustless-gateway source.
+pub fn gateway() -> Gateway {
+    Gateway {
+        accelerator: None,
+        public_fallbacks: vec![GatewaySource {
+            base_url: "https://public.gw.test".into(),
+            bearer: None,
+        }],
+    }
+}
+
+/// The CID a trustless-gateway raw-block URL addresses.
+pub fn requested_cid(url: &str) -> String {
+    url.rsplit('/')
+        .next()
+        .and_then(|tail| tail.split('?').next())
+        .unwrap_or_default()
+        .to_owned()
+}
+
+/// Index sealed leaves by the gateway address that serves them.
+pub fn block_store<'a>(
+    leaves: impl IntoIterator<Item = &'a SealedChunk>,
+) -> BTreeMap<String, Vec<u8>> {
+    leaves
+        .into_iter()
+        .map(|leaf| (encode_content_cid_str(&leaf.cid), leaf.sealed.clone()))
+        .collect()
+}
+
+/// Serve `blocks` for more requests than a single read makes; anything unstored
+/// is an availability failure, never a trust verdict.
+pub fn serve(blocks: &BTreeMap<String, Vec<u8>>) -> ScriptedHttp {
+    let http = ScriptedHttp::default();
+    for _ in 0..32 {
+        let blocks = blocks.clone();
+        http.enqueue_derived(
+            move |request| match blocks.get(&requested_cid(&request.url)) {
+                Some(block) => Ok(HttpResponse {
+                    status: 200,
+                    headers: Vec::new(),
+                    body: block.clone(),
+                }),
+                None => Err(SeamError::new("no such block")),
+            },
+        );
+    }
+    http
 }

--- a/crates/engine/src/testkit/mod.rs
+++ b/crates/engine/src/testkit/mod.rs
@@ -22,7 +22,7 @@ pub mod fakes;
 mod owner_root;
 mod world;
 
-pub use content::frame_version;
+pub use content::{block_store, frame_version, gateway, requested_cid, serve};
 pub use entropy::SeededEntropy;
 pub use executor::block_on;
 pub use owner_root::{

--- a/crates/engine/src/testkit/mod.rs
+++ b/crates/engine/src/testkit/mod.rs
@@ -22,7 +22,7 @@ pub mod fakes;
 mod owner_root;
 mod world;
 
-pub use content::{block_store, frame_version, gateway, requested_cid, serve};
+pub use content::{block_store, frame_version, frame_version_with, gateway, requested_cid, serve};
 pub use entropy::SeededEntropy;
 pub use executor::block_on;
 pub use owner_root::{

--- a/crates/engine/tests/content_wipe.rs
+++ b/crates/engine/tests/content_wipe.rs
@@ -1,34 +1,44 @@
-//! A ranged read must not strand a leaf's plaintext in freed memory.
+//! A ranged read must not strand plaintext in freed memory.
 //!
 //! The window a media element asks for rarely lines up with a chunk boundary, so
-//! every seek unseals head and tail bytes the caller never receives. This suite
-//! owns the whole test binary because it installs a global allocator that
-//! inspects each block as it is freed.
+//! every seek unseals head and tail bytes the caller never receives, and a
+//! mid-read trust reject abandons whatever the assembly buffer already holds.
+//! This suite owns the whole test binary because it installs a global allocator
+//! that inspects each block as it is freed.
 
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 
 use cipherbox_core::content::encode_content_cid_str;
 use cipherbox_core::suite::aead::KEY_LEN;
-use cipherbox_engine::content::{Gateway, GatewaySource, open_content_range};
-use cipherbox_engine::seams::{HttpResponse, SeamError};
-use cipherbox_engine::testkit::fakes::ScriptedHttp;
-use cipherbox_engine::testkit::{block_on, frame_version};
+use cipherbox_engine::content::{
+    ContentKey, ContentProfile, SealedContent, assemble, open_content_range, seal_one_chunk,
+};
+use cipherbox_engine::testkit::{
+    SeededEntropy, block_on, block_store, frame_version, gateway, serve,
+};
 
 const CONTENT_KEY: [u8; KEY_LEN] = [0x5Au8; KEY_LEN];
 /// The CI content profile's chunk size; one leaf of plaintext.
 const CHUNK: usize = 16;
-/// Leaf ciphertext is the chunk plus a Poly1305 tag — the only block size scanned.
-const SEALED_LEN: usize = CHUNK + 16;
-/// The plaintext of leaf 1, recognizable in a raw memory block.
-const MARKER: [u8; CHUNK] = [0xA7u8; CHUNK];
+/// A run of this many identical bytes in a freed block is stranded plaintext.
+const MARKER_LEN: usize = CHUNK;
 
 static WATCHING: AtomicBool = AtomicBool::new(false);
 static LEAKED: AtomicBool = AtomicBool::new(false);
+/// Blocks the scan actually looked at. Without it a `!LEAKED` assertion passes
+/// vacuously whenever nothing in the armed window matched the filter.
+static INSPECTED: AtomicUsize = AtomicUsize::new(0);
+/// The byte the armed scenario's marker is made of. Each scenario picks its own:
+/// the harness runs the tests on parallel threads, and one scenario's fixture
+/// buffers drop inside another's window.
+static MARKER_BYTE: AtomicU8 = AtomicU8::new(0);
+/// The watchdog statics are global, so only one scenario may be armed at a time.
+static SERIAL: Mutex<()> = Mutex::new(());
 
-/// Flags any freed block that still carries [`MARKER`]. Only blocks the size of
-/// a leaf's ciphertext are inspected, and only while a read is in flight.
+/// Flags any freed block still carrying a marker run, while a read is in flight.
+/// A block too small to hold one cannot carry it.
 struct Watchdog;
 
 unsafe impl GlobalAlloc for Watchdog {
@@ -37,12 +47,14 @@ unsafe impl GlobalAlloc for Watchdog {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        if layout.size() == SEALED_LEN && WATCHING.load(Ordering::Relaxed) {
+        if layout.size() >= MARKER_LEN && WATCHING.load(Ordering::Relaxed) {
+            INSPECTED.fetch_add(1, Ordering::Relaxed);
+            let wanted = MARKER_BYTE.load(Ordering::Relaxed);
             let mut matched = 0usize;
-            for offset in 0..SEALED_LEN {
+            for offset in 0..layout.size() {
                 let byte = unsafe { ptr.add(offset).read_volatile() };
-                matched = if byte == MARKER[0] { matched + 1 } else { 0 };
-                if matched == MARKER.len() {
+                matched = if byte == wanted { matched + 1 } else { 0 };
+                if matched == MARKER_LEN {
                     LEAKED.store(true, Ordering::Relaxed);
                     break;
                 }
@@ -55,65 +67,119 @@ unsafe impl GlobalAlloc for Watchdog {
 #[global_allocator]
 static ALLOCATOR: Watchdog = Watchdog;
 
-fn gateway() -> Gateway {
-    Gateway {
-        accelerator: None,
-        public_fallbacks: vec![GatewaySource {
-            base_url: "https://public.gw.test".into(),
-            bearer: None,
-        }],
-    }
+/// What the watchdog saw over one armed read.
+struct Watched<T> {
+    outcome: T,
+    leaked: bool,
+    inspected: usize,
 }
 
-/// Serves `blocks` by the CID the trustless-gateway URL addresses.
-fn serve(blocks: BTreeMap<String, Vec<u8>>) -> ScriptedHttp {
-    let http = ScriptedHttp::default();
-    for _ in 0..8 {
-        let blocks = blocks.clone();
-        http.enqueue_derived(move |request| {
-            let cid = request
-                .url
-                .rsplit('/')
-                .next()
-                .and_then(|tail| tail.split('?').next())
-                .unwrap_or_default();
-            match blocks.get(cid) {
-                Some(block) => Ok(HttpResponse {
-                    status: 200,
-                    headers: Vec::new(),
-                    body: block.clone(),
-                }),
-                None => Err(SeamError::new("no such block")),
-            }
-        });
+/// Runs `body` with the watchdog armed for `marker`, serialized against every
+/// other scenario.
+fn watched<T>(marker: u8, body: impl FnOnce() -> T) -> Watched<T> {
+    let _serial = SERIAL
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    LEAKED.store(false, Ordering::Relaxed);
+    INSPECTED.store(0, Ordering::Relaxed);
+    MARKER_BYTE.store(marker, Ordering::Relaxed);
+    WATCHING.store(true, Ordering::Relaxed);
+    let outcome = body();
+    WATCHING.store(false, Ordering::Relaxed);
+    Watched {
+        outcome,
+        leaked: LEAKED.load(Ordering::Relaxed),
+        inspected: INSPECTED.load(Ordering::Relaxed),
     }
-    http
 }
 
 #[test]
 fn a_ranged_read_wipes_each_leafs_plaintext_before_it_drops() {
+    const MARKER: u8 = 0xA7;
     // Three leaves; the marker fills leaf 1, and the window asks for four of its
     // bytes, so the leaf is fetched and unsealed but mostly trimmed away.
     let mut plaintext = vec![1u8; CHUNK];
-    plaintext.extend_from_slice(&MARKER);
+    plaintext.extend_from_slice(&[MARKER; CHUNK]);
     plaintext.extend_from_slice(&[2u8; CHUNK]);
     let (leaves, root_block, content) = frame_version(&plaintext, CONTENT_KEY, 1);
 
-    let mut blocks = BTreeMap::new();
-    for leaf in &leaves {
-        blocks.insert(encode_content_cid_str(&leaf.cid), leaf.sealed.clone());
-    }
+    let mut blocks = block_store(&leaves);
     blocks.insert(encode_content_cid_str(content.content_cid()), root_block);
-    let http = serve(blocks);
+    let http = serve(&blocks);
     let version = content.version(CONTENT_KEY, 0);
 
-    WATCHING.store(true, Ordering::Relaxed);
-    let out = block_on(open_content_range(&gateway(), &http, &version, 20, 4)).expect("range read");
-    WATCHING.store(false, Ordering::Relaxed);
+    let seen = watched(MARKER, || {
+        block_on(open_content_range(&gateway(), &http, &version, 20, 4))
+    });
 
-    assert_eq!(out, &MARKER[4..8], "the window the caller asked for");
+    assert_eq!(
+        seen.outcome.expect("range read"),
+        &[MARKER; 4],
+        "the window the caller asked for"
+    );
+    assert!(seen.inspected > 0, "the watchdog scanned nothing");
     assert!(
-        !LEAKED.load(Ordering::Relaxed),
+        !seen.leaked,
         "a leaf's plaintext reached the allocator unwiped"
+    );
+}
+
+#[test]
+fn a_mid_read_trust_reject_wipes_what_the_assembly_buffer_already_holds() {
+    const MARKER: u8 = 0xB3;
+    // Leaf 0 is the marker; leaf 1 is a short leaf the flat framing forbids. The
+    // read appends leaf 0, then abandons the buffer on leaf 1's length reject.
+    let mut plaintext = vec![MARKER; CHUNK];
+    plaintext.extend_from_slice(&[2u8; CHUNK]);
+    plaintext.extend_from_slice(&[3u8; CHUNK]);
+    let (leaves, _, _) = frame_version(&plaintext, CONTENT_KEY, 2);
+
+    let mut entropy = SeededEntropy::new(3);
+    let short = seal_one_chunk(
+        &ContentKey::from_bytes(CONTENT_KEY),
+        &[4u8; CHUNK / 2],
+        &mut entropy,
+    )
+    .expect("seeded entropy");
+    let dag = assemble(
+        &[
+            leaves[0].cid.clone(),
+            short.cid.clone(),
+            leaves[2].cid.clone(),
+        ],
+        plaintext.len() as u64,
+        &ContentProfile::CI,
+    )
+    .expect("three leaves for 48 bytes at chunk 16");
+
+    let mut blocks = block_store([&leaves[0], &short, &leaves[2]]);
+    blocks.insert(
+        encode_content_cid_str(&dag.content_cid),
+        dag.root_block.clone(),
+    );
+    let http = serve(&blocks);
+    let version = SealedContent::from_root_block(&dag.root_block)
+        .expect("the root this build just assembled")
+        .version(CONTENT_KEY, 0);
+
+    let seen = watched(MARKER, || {
+        block_on(open_content_range(
+            &gateway(),
+            &http,
+            &version,
+            0,
+            plaintext.len() as u64,
+        ))
+    });
+
+    let err = seen.outcome.expect_err("leaf 1 disagrees with the framing");
+    assert!(
+        format!("{err:?}").contains("leaf 1 unsealed to"),
+        "rejected for the per-leaf length, not something else: {err:?}"
+    );
+    assert!(seen.inspected > 0, "the watchdog scanned nothing");
+    assert!(
+        !seen.leaked,
+        "the abandoned assembly buffer reached the allocator unwiped"
     );
 }

--- a/crates/engine/tests/content_wipe.rs
+++ b/crates/engine/tests/content_wipe.rs
@@ -1,0 +1,119 @@
+//! A ranged read must not strand a leaf's plaintext in freed memory.
+//!
+//! The window a media element asks for rarely lines up with a chunk boundary, so
+//! every seek unseals head and tail bytes the caller never receives. This suite
+//! owns the whole test binary because it installs a global allocator that
+//! inspects each block as it is freed.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use cipherbox_core::content::encode_content_cid_str;
+use cipherbox_core::suite::aead::KEY_LEN;
+use cipherbox_engine::content::{Gateway, GatewaySource, open_content_range};
+use cipherbox_engine::seams::{HttpResponse, SeamError};
+use cipherbox_engine::testkit::fakes::ScriptedHttp;
+use cipherbox_engine::testkit::{block_on, frame_version};
+
+const CONTENT_KEY: [u8; KEY_LEN] = [0x5Au8; KEY_LEN];
+/// The CI content profile's chunk size; one leaf of plaintext.
+const CHUNK: usize = 16;
+/// Leaf ciphertext is the chunk plus a Poly1305 tag — the only block size scanned.
+const SEALED_LEN: usize = CHUNK + 16;
+/// The plaintext of leaf 1, recognizable in a raw memory block.
+const MARKER: [u8; CHUNK] = [0xA7u8; CHUNK];
+
+static WATCHING: AtomicBool = AtomicBool::new(false);
+static LEAKED: AtomicBool = AtomicBool::new(false);
+
+/// Flags any freed block that still carries [`MARKER`]. Only blocks the size of
+/// a leaf's ciphertext are inspected, and only while a read is in flight.
+struct Watchdog;
+
+unsafe impl GlobalAlloc for Watchdog {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if layout.size() == SEALED_LEN && WATCHING.load(Ordering::Relaxed) {
+            let mut matched = 0usize;
+            for offset in 0..SEALED_LEN {
+                let byte = unsafe { ptr.add(offset).read_volatile() };
+                matched = if byte == MARKER[0] { matched + 1 } else { 0 };
+                if matched == MARKER.len() {
+                    LEAKED.store(true, Ordering::Relaxed);
+                    break;
+                }
+            }
+        }
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Watchdog = Watchdog;
+
+fn gateway() -> Gateway {
+    Gateway {
+        accelerator: None,
+        public_fallbacks: vec![GatewaySource {
+            base_url: "https://public.gw.test".into(),
+            bearer: None,
+        }],
+    }
+}
+
+/// Serves `blocks` by the CID the trustless-gateway URL addresses.
+fn serve(blocks: BTreeMap<String, Vec<u8>>) -> ScriptedHttp {
+    let http = ScriptedHttp::default();
+    for _ in 0..8 {
+        let blocks = blocks.clone();
+        http.enqueue_derived(move |request| {
+            let cid = request
+                .url
+                .rsplit('/')
+                .next()
+                .and_then(|tail| tail.split('?').next())
+                .unwrap_or_default();
+            match blocks.get(cid) {
+                Some(block) => Ok(HttpResponse {
+                    status: 200,
+                    headers: Vec::new(),
+                    body: block.clone(),
+                }),
+                None => Err(SeamError::new("no such block")),
+            }
+        });
+    }
+    http
+}
+
+#[test]
+fn a_ranged_read_wipes_each_leafs_plaintext_before_it_drops() {
+    // Three leaves; the marker fills leaf 1, and the window asks for four of its
+    // bytes, so the leaf is fetched and unsealed but mostly trimmed away.
+    let mut plaintext = vec![1u8; CHUNK];
+    plaintext.extend_from_slice(&MARKER);
+    plaintext.extend_from_slice(&[2u8; CHUNK]);
+    let (leaves, root_block, content) = frame_version(&plaintext, CONTENT_KEY, 1);
+
+    let mut blocks = BTreeMap::new();
+    for leaf in &leaves {
+        blocks.insert(encode_content_cid_str(&leaf.cid), leaf.sealed.clone());
+    }
+    blocks.insert(encode_content_cid_str(content.content_cid()), root_block);
+    let http = serve(blocks);
+    let version = content.version(CONTENT_KEY, 0);
+
+    WATCHING.store(true, Ordering::Relaxed);
+    let out = block_on(open_content_range(&gateway(), &http, &version, 20, 4)).expect("range read");
+    WATCHING.store(false, Ordering::Relaxed);
+
+    assert_eq!(out, &MARKER[4..8], "the window the caller asked for");
+    assert!(
+        !LEAKED.load(Ordering::Relaxed),
+        "a leaf's plaintext reached the allocator unwiped"
+    );
+}

--- a/crates/engine/tests/content_wipe.rs
+++ b/crates/engine/tests/content_wipe.rs
@@ -16,7 +16,7 @@ use cipherbox_engine::content::{
     ContentKey, ContentProfile, SealedContent, assemble, open_content_range, seal_one_chunk,
 };
 use cipherbox_engine::testkit::{
-    SeededEntropy, block_on, block_store, frame_version, gateway, serve,
+    SeededEntropy, block_on, block_store, frame_version, frame_version_with, gateway, serve,
 };
 
 const CONTENT_KEY: [u8; KEY_LEN] = [0x5Au8; KEY_LEN];
@@ -181,5 +181,45 @@ fn a_mid_read_trust_reject_wipes_what_the_assembly_buffer_already_holds() {
     assert!(
         !seen.leaked,
         "the abandoned assembly buffer reached the allocator unwiped"
+    );
+}
+
+#[test]
+fn outgrowing_the_assembly_buffer_wipes_the_allocation_it_leaves_behind() {
+    const MARKER: u8 = 0xC5;
+    // The assembly buffer preallocates a 4 MiB budget, so growth is only
+    // reachable from a window wider than that: two 2 MiB leaves fill the budget
+    // exactly and a 16-byte tail leaf forces the grow.
+    const BIG_CHUNK: usize = 2 * 1024 * 1024;
+    let profile = ContentProfile::new(BIG_CHUNK).expect("nonzero chunk size");
+    let mut plaintext = vec![MARKER; BIG_CHUNK];
+    plaintext.extend_from_slice(&vec![0x11u8; BIG_CHUNK]);
+    plaintext.extend_from_slice(&[0x22u8; CHUNK]);
+    let (leaves, root_block, content) = frame_version_with(&plaintext, CONTENT_KEY, 4, profile);
+
+    let mut blocks = block_store(&leaves);
+    blocks.insert(encode_content_cid_str(content.content_cid()), root_block);
+    let http = serve(&blocks);
+    let version = content.version(CONTENT_KEY, 0);
+
+    let seen = watched(MARKER, || {
+        block_on(open_content_range(
+            &gateway(),
+            &http,
+            &version,
+            0,
+            plaintext.len() as u64,
+        ))
+    });
+
+    assert_eq!(
+        seen.outcome.expect("range read").len(),
+        plaintext.len(),
+        "the whole window the caller asked for"
+    );
+    assert!(seen.inspected > 0, "the watchdog scanned nothing");
+    assert!(
+        !seen.leaked,
+        "the outgrown assembly buffer reached the allocator unwiped"
     );
 }

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -946,12 +946,14 @@ fn a_ranged_read_serves_the_same_bytes_as_the_slice_of_the_whole_file() {
             "range {offset}+{length}"
         );
     }
-    assert!(
-        block_on(engine_b.read_content_range(node, whole.len() as u64, 16))
-            .unwrap()
-            .is_empty(),
-        "a window past the end is empty, not an error"
-    );
+    for offset in [whole.len() as u64, whole.len() as u64 + 1, u64::MAX] {
+        assert!(
+            block_on(engine_b.read_content_range(node, offset, 16))
+                .unwrap()
+                .is_empty(),
+            "a window past the end is empty, not an error: offset {offset}"
+        );
+    }
 }
 
 /// A new version of an existing file takes the head of its version list and is

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -905,6 +905,55 @@ fn a_file_create_round_trips_its_bytes_to_a_second_device() {
     );
 }
 
+/// A ranged read walks the same gated resolve as the whole-file read and serves
+/// the matching slice — the media pipe's read path (#641).
+#[test]
+fn a_ranged_read_serves_the_same_bytes_as_the_slice_of_the_whole_file() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    // Several CI leaves, so a window can land inside, across, and past them.
+    let plaintext: Vec<u8> = (0..200u8).collect();
+
+    let alice = world.device(b"alice");
+    let (mut engine_a, _events_a, mut tasks) = boot(&world, &blocks, &alice, 42);
+    write_file(
+        &mut engine_a,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "clip.bin".into(),
+        },
+        &plaintext,
+    )
+    .expect("the write commits");
+    tick(&world, &engine_a, &mut tasks);
+
+    let bob = world.device(b"alice-second-device");
+    serve_http(&bob, &blocks, 400);
+    let (mut engine_b, _events_b) = engine_on(&bob, 7);
+    block_on(engine_b.start(secret())).unwrap();
+    let node = block_on(engine_b.view()).unwrap().children(ROOT)[0].id;
+
+    let whole = block_on(engine_b.read_content(node)).expect("the verified read serves it");
+    assert_eq!(whole, plaintext);
+
+    for (offset, length) in [(0u64, 16u64), (16, 16), (15, 2), (40, 100), (190, 999)] {
+        let end = (offset + length).min(whole.len() as u64) as usize;
+        assert_eq!(
+            block_on(engine_b.read_content_range(node, offset, length))
+                .expect("the ranged read serves it"),
+            whole[offset as usize..end],
+            "range {offset}+{length}"
+        );
+    }
+    assert!(
+        block_on(engine_b.read_content_range(node, whole.len() as u64, 16))
+            .unwrap()
+            .is_empty(),
+        "a window past the end is empty, not an error"
+    );
+}
+
 /// A new version of an existing file takes the head of its version list and is
 /// what a second device downloads.
 #[test]

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -378,6 +378,32 @@ impl EngineHandle {
         })
     }
 
+    /// Downloads and decrypts one byte window of a file node's content, fetching
+    /// only the leaves the window covers. The range is clamped to the file, so a
+    /// window past the end resolves empty. Resolves with the plaintext bytes as a
+    /// `Uint8Array`; rejects with the engine error.
+    #[wasm_bindgen(js_name = downloadRange)]
+    pub fn download_range(&self, node: &NodeId, offset: f64, length: f64) -> Promise {
+        let engine = self.engine.clone();
+        let node = node.facade();
+        future_to_promise(async move {
+            // A saturating float-to-int cast would silently read a different window.
+            if !offset.is_finite() || offset < 0.0 || !length.is_finite() || length < 0.0 {
+                return Err(JsError::new(
+                    "downloadRange offset and length must be non-negative finite numbers",
+                )
+                .into());
+            }
+            let bytes = engine
+                .read()
+                .await
+                .read_content_range(node, offset as u64, length as u64)
+                .await
+                .map_err(engine_error)?;
+            Ok(Uint8Array::from(bytes.as_slice()).into())
+        })
+    }
+
     /// Awaits the next event on the one-way stream, or resolves to `undefined`
     /// once the engine is gone. At most one call may be outstanding.
     #[wasm_bindgen(js_name = nextEvent)]

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -374,6 +374,9 @@ impl EngineHandle {
                 .read_content(node)
                 .await
                 .map_err(engine_error)?;
+            // Terminal owner of the Rust-side plaintext: the copy crosses into
+            // the JS heap here, so this buffer is wiped rather than freed.
+            let bytes = Zeroizing::new(bytes);
             Ok(Uint8Array::from(bytes.as_slice()).into())
         })
     }
@@ -400,6 +403,7 @@ impl EngineHandle {
                 .read_content_range(node, offset as u64, length as u64)
                 .await
                 .map_err(engine_error)?;
+            let bytes = Zeroizing::new(bytes);
             Ok(Uint8Array::from(bytes.as_slice()).into())
         })
     }

--- a/crates/wasm/src/seams_bridge.rs
+++ b/crates/wasm/src/seams_bridge.rs
@@ -19,10 +19,9 @@
 //! crosses as `bigint` and lives in `lib.rs`, not here.
 
 use cipherbox_engine::seams::{
-    BoxedTask, CONTENT_LENGTH, CappedFetchError, CredentialStore, EndpointId, FloorStore, Http,
-    HttpMethod, HttpRequest, HttpResponse, Mailbox, MailboxItem, OpId, RecordTransport,
-    RefreshHint, RefreshHintSource, Scheduler, SeamError, SeamResult, SnapshotCache, StagingStore,
-    UnixMillis,
+    BoxedTask, CappedFetchError, CredentialStore, EndpointId, FloorStore, Http, HttpMethod,
+    HttpRequest, HttpResponse, Mailbox, MailboxItem, OpId, RecordTransport, RefreshHint,
+    RefreshHintSource, Scheduler, SeamError, SeamResult, SnapshotCache, StagingStore, UnixMillis,
 };
 use core::time::Duration;
 use js_sys::{Array, Object, Reflect, Uint8Array};
@@ -473,12 +472,22 @@ impl RecordTransport for RecordTransportAdapter {
 
 #[wasm_bindgen]
 extern "C" {
-    /// JS `HttpSeam` (packages/client) — `send(HttpRequestData)`.
+    /// JS `HttpSeam` (packages/client) — `send(HttpRequestData)` and
+    /// `sendCapped(HttpRequestData, maxBytes)`.
     #[derive(Clone)]
     pub type JsHttpSeam;
 
     #[wasm_bindgen(method, catch, js_name = send)]
     async fn send(this: &JsHttpSeam, request: JsValue) -> Result<JsValue, JsValue>;
+    /// Resolves a `CappedHttpResult`: `{kind:'response', …}` or
+    /// `{kind:'tooLarge', observed, limit}`. The JS side enforces `max_bytes`
+    /// while it drains `Response.body`, so it is the authoritative bound.
+    #[wasm_bindgen(method, catch, js_name = sendCapped)]
+    async fn send_capped(
+        this: &JsHttpSeam,
+        request: JsValue,
+        max_bytes: f64,
+    ) -> Result<JsValue, JsValue>;
 }
 
 fn http_method_str(method: HttpMethod) -> &'static str {
@@ -574,39 +583,46 @@ impl Http for HttpAdapter {
         request: HttpRequest,
         max_bytes: usize,
     ) -> Result<HttpResponse, CappedFetchError> {
-        // Residual (#641): the JS `HttpSeam.send` materializes the whole body
-        // before it returns here, so this bounds one already-buffered response,
-        // not peak memory. The Content-Length reject and the body-length check
-        // both fail closed on an over-cap block; the true streaming bound must
-        // live in the JS seam (enforce `maxBytes` while reading `Response.body`).
-        let response = self
+        let result = self
             .js
-            .send(http_request_to_js(&request))
+            .send_capped(http_request_to_js(&request), max_bytes as f64)
             .await
             .map_err(|err| CappedFetchError::Transport(seam_error(err)))?;
-        let response = http_response_from_js(response).map_err(CappedFetchError::Transport)?;
-
-        let declared = response
-            .headers
-            .iter()
-            .find(|(name, _)| name.eq_ignore_ascii_case(CONTENT_LENGTH))
-            .and_then(|(_, value)| value.parse::<u64>().ok());
-        if let Some(declared) = declared {
-            if declared > max_bytes as u64 {
-                return Err(CappedFetchError::BodyTooLarge {
-                    observed: usize::try_from(declared).unwrap_or(usize::MAX),
-                    limit: max_bytes,
-                });
+        let kind = Reflect::get(&result, &JsValue::from_str("kind"))
+            .ok()
+            .and_then(|kind| kind.as_string());
+        match kind.as_deref() {
+            Some("response") => {
+                let response =
+                    http_response_from_js(result).map_err(CappedFetchError::Transport)?;
+                // The JS seam is the streaming bound; this is the backstop a
+                // buggy seam cannot talk the engine past.
+                if response.body.len() > max_bytes {
+                    return Err(CappedFetchError::BodyTooLarge {
+                        observed: response.body.len(),
+                        limit: max_bytes,
+                    });
+                }
+                Ok(response)
             }
+            Some("tooLarge") => Err(CappedFetchError::BodyTooLarge {
+                observed: capped_count(&result, "observed"),
+                limit: capped_count(&result, "limit"),
+            }),
+            // Fail closed: an unrecognized result carries no body the engine
+            // may treat as within the cap.
+            _ => Err(CappedFetchError::Transport(SeamError::new(
+                "sendCapped returned an unknown result kind",
+            ))),
         }
-        if response.body.len() > max_bytes {
-            return Err(CappedFetchError::BodyTooLarge {
-                observed: response.body.len(),
-                limit: max_bytes,
-            });
-        }
-        Ok(response)
     }
+}
+
+/// A byte count off a `CappedHttpResult`, saturating: a count past `usize` is
+/// over any cap either way.
+fn capped_count(result: &JsValue, field: &str) -> usize {
+    let value = Reflect::get(result, &JsValue::from_str(field)).unwrap_or(JsValue::UNDEFINED);
+    usize::try_from(required_u64(value)).unwrap_or(usize::MAX)
 }
 
 // ---------------------------------------------------------------------------
@@ -706,5 +722,160 @@ impl RefreshHintSource for RefreshHintSourceAdapter {
             Ok(value) if !value.is_null() && !value.is_undefined() => Some(RefreshHint),
             _ => None,
         }
+    }
+}
+
+// Capped-fetch boundary tests. Crate-private adapters, so these live here rather
+// than in `tests/boundary.rs`. Browser-target only: `cargo test -p cipherbox-wasm
+// --target wasm32-unknown-unknown`.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::cell::Cell;
+    use js_sys::Promise;
+    use std::rc::Rc;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    /// A `JsHttpSeam` double whose `sendCapped` resolves `result`, recording the
+    /// `maxBytes` it was handed.
+    fn seam_resolving(result: JsValue) -> (JsHttpSeam, Rc<Cell<f64>>) {
+        let seen = Rc::new(Cell::new(f64::NAN));
+        let recorded = seen.clone();
+        (
+            seam_with(move |max_bytes| {
+                recorded.set(max_bytes);
+                Promise::resolve(&result)
+            }),
+            seen,
+        )
+    }
+
+    /// A `JsHttpSeam` double whose `sendCapped` returns `reply`.
+    fn seam_with(mut reply: impl FnMut(f64) -> Promise + 'static) -> JsHttpSeam {
+        let send_capped = Closure::<dyn FnMut(JsValue, f64) -> Promise>::new(
+            move |_request: JsValue, max_bytes: f64| reply(max_bytes),
+        );
+        let object = Object::new();
+        let _ = Reflect::set(
+            &object,
+            &JsValue::from_str("sendCapped"),
+            send_capped.as_ref(),
+        );
+        // The double outlives the call; the closure must not be freed under it.
+        send_capped.forget();
+        object.unchecked_into()
+    }
+
+    fn a_request() -> HttpRequest {
+        HttpRequest {
+            method: HttpMethod::Get,
+            url: "https://gw.test/ipfs/bafy?format=raw".to_owned(),
+            headers: Vec::new(),
+            body: None,
+        }
+    }
+
+    /// A `CappedHttpResult`-shaped JS object carrying `entries`.
+    fn js_result(entries: Vec<(&str, JsValue)>) -> JsValue {
+        let object = Object::new();
+        for (key, value) in entries {
+            let _ = Reflect::set(&object, &JsValue::from_str(key), &value);
+        }
+        object.into()
+    }
+
+    #[wasm_bindgen_test]
+    async fn a_response_result_crosses_the_seam_with_the_cap_it_was_given() {
+        let headers = Array::new();
+        let pair = Array::new();
+        pair.push(&JsValue::from_str("Content-Type"));
+        pair.push(&JsValue::from_str("application/vnd.ipld.raw"));
+        headers.push(&pair);
+        let (js, seen) = seam_resolving(js_result(vec![
+            ("kind", JsValue::from_str("response")),
+            ("status", JsValue::from_f64(200.0)),
+            ("headers", headers.into()),
+            ("body", Uint8Array::from(&[1u8, 2, 3][..]).into()),
+        ]));
+
+        let response = HttpAdapter { js }
+            .send_capped(a_request(), 4096)
+            .await
+            .expect("a within-cap response crosses as a response");
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, vec![1u8, 2, 3]);
+        assert_eq!(seen.get(), 4096.0, "the cap crosses as the JS number");
+    }
+
+    #[wasm_bindgen_test]
+    async fn a_response_body_over_the_cap_is_refused_even_when_the_seam_passed_it() {
+        let (js, _) = seam_resolving(js_result(vec![
+            ("kind", JsValue::from_str("response")),
+            ("status", JsValue::from_f64(200.0)),
+            ("headers", Array::new().into()),
+            ("body", Uint8Array::from(&[7u8; 64][..]).into()),
+        ]));
+
+        let err = HttpAdapter { js }
+            .send_capped(a_request(), 32)
+            .await
+            .expect_err("the engine enforces the cap the seam waved through");
+        assert_eq!(
+            err,
+            CappedFetchError::BodyTooLarge {
+                observed: 64,
+                limit: 32
+            }
+        );
+    }
+
+    #[wasm_bindgen_test]
+    async fn a_too_large_result_maps_to_the_body_too_large_verdict() {
+        let (js, _) = seam_resolving(js_result(vec![
+            ("kind", JsValue::from_str("tooLarge")),
+            ("observed", JsValue::from_f64(9001.0)),
+            ("limit", JsValue::from_f64(4096.0)),
+        ]));
+
+        let err = HttpAdapter { js }
+            .send_capped(a_request(), 4096)
+            .await
+            .expect_err("an over-cap body never returns a response");
+        assert_eq!(
+            err,
+            CappedFetchError::BodyTooLarge {
+                observed: 9001,
+                limit: 4096
+            }
+        );
+    }
+
+    #[wasm_bindgen_test]
+    async fn an_unknown_result_kind_fails_closed_as_transport() {
+        for entries in [
+            vec![("kind", JsValue::from_str("somethingElse"))],
+            vec![("status", JsValue::from_f64(200.0))],
+        ] {
+            let (js, _) = seam_resolving(js_result(entries));
+            let err = HttpAdapter { js }
+                .send_capped(a_request(), 8)
+                .await
+                .expect_err("an unrecognized result is never a body");
+            assert!(
+                matches!(err, CappedFetchError::Transport(_)),
+                "expected a transport verdict, got {err:?}"
+            );
+        }
+    }
+
+    #[wasm_bindgen_test]
+    async fn a_rejected_call_is_a_transport_failure() {
+        let js = seam_with(|_| Promise::reject(&JsValue::from_str("network down")));
+        let err = HttpAdapter { js }
+            .send_capped(a_request(), 8)
+            .await
+            .expect_err("a rejection never yields a response");
+        assert!(matches!(err, CappedFetchError::Transport(_)));
     }
 }

--- a/crates/wasm/src/seams_bridge.rs
+++ b/crates/wasm/src/seams_bridge.rs
@@ -480,8 +480,7 @@ extern "C" {
     #[wasm_bindgen(method, catch, js_name = send)]
     async fn send(this: &JsHttpSeam, request: JsValue) -> Result<JsValue, JsValue>;
     /// Resolves a `CappedHttpResult`: `{kind:'response', …}` or
-    /// `{kind:'tooLarge', observed, limit}`. The JS side enforces `max_bytes`
-    /// while it drains `Response.body`, so it is the authoritative bound.
+    /// `{kind:'tooLarge', observed, limit}`.
     #[wasm_bindgen(method, catch, js_name = sendCapped)]
     async fn send_capped(
         this: &JsHttpSeam,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./sw": {
+      "types": "./dist/sw/serviceWorker.d.ts",
+      "import": "./dist/sw/serviceWorker.js"
     }
   },
   "scripts": {

--- a/packages/client/src/broadcast.ts
+++ b/packages/client/src/broadcast.ts
@@ -36,7 +36,8 @@ export interface BroadcastChannelLike {
 export type WireRead =
   | { kind: 'snapshot'; folder: Uint8Array | null }
   | { kind: 'siweChallenge' }
-  | { kind: 'download'; node: Uint8Array };
+  | { kind: 'download'; node: Uint8Array }
+  | { kind: 'downloadRange'; node: Uint8Array; offset: number; length: number };
 
 /** A follower streaming-write step, driven against the leader's engine. */
 export type WireWrite =
@@ -75,8 +76,8 @@ export type LeaderMessage =
   | { type: 'cb:leaderGone'; token: string }
   /**
    * The correlated result of a follower's command, read, or write step. A
-   * snapshot read's ok carries the descriptor in `result`; a download's carries
-   * a `Blob`; a SIWE challenge's carries the nonce string;
+   * snapshot read's ok carries the descriptor in `result`; a plaintext read's
+   * carries a `Blob`; a SIWE challenge's carries the nonce string;
    * `beginWrite`/`commitWrite` carry the handle / durable op id.
    */
   | {

--- a/packages/client/src/broadcast.ts
+++ b/packages/client/src/broadcast.ts
@@ -76,8 +76,8 @@ export type LeaderMessage =
   | { type: 'cb:leaderGone'; token: string }
   /**
    * The correlated result of a follower's command, read, or write step. A
-   * snapshot read's ok carries the descriptor in `result`; a plaintext read's
-   * carries a `Blob`; a SIWE challenge's carries the nonce string;
+   * snapshot read's ok carries the descriptor in `result`; a plaintext read
+   * carries a `Blob`; a SIWE challenge carries the nonce string;
    * `beginWrite`/`commitWrite` carry the handle / durable op id.
    */
   | {

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -233,6 +233,41 @@ describe('broadcast transport ↔ leader relay', () => {
     expect(engine.siweChallenges).toBe(1);
   });
 
+  it('serves a follower downloadRange as a Blob and rebuilds the window bytes', async () => {
+    const { engine, follower } = wire();
+    const file = Uint8Array.from({ length: 256 }, (_, i) => (i * 3 + 1) & 0xff);
+    engine.respondDownloadRange = (_node, offset, length) =>
+      Promise.resolve(file.slice(offset, offset + length).buffer);
+
+    const node = new Uint8Array(16).fill(6);
+    const window = await follower.downloadRange(node, 64, 32);
+    expect([...new Uint8Array(window)]).toEqual([...file.slice(64, 96)]);
+    // A dropped or clamped offset slices the wrong plaintext with every
+    // integrity check still passing.
+    expect(engine.downloadRanges).toEqual([{ node, offset: 64, length: 32 }]);
+  });
+
+  it('rejects an in-flight downloadRange retryably when the leader steps down', async () => {
+    const bus = new FakeBus();
+    const engineA = new FakeEngineTransport();
+    engineA.respondDownloadRange = () => new Promise(() => undefined); // leader A never answers
+    const relayA = new LeaderRelay(bus.channel(), engineA);
+    const follower = new BroadcastTransport(bus.channel(), 'f');
+    await follower.start();
+
+    const inFlight = follower.downloadRange(new Uint8Array(16), 0, 8);
+    await tick();
+    relayA.close();
+    await expect(inFlight).rejects.toThrow(/retry/);
+
+    // The next leader serves the retry, so the swap costs a retry, never a hang.
+    const engineB = new FakeEngineTransport();
+    engineB.respondDownloadRange = () => Promise.resolve(new Uint8Array([1, 2]).buffer);
+    new LeaderRelay(bus.channel(), engineB);
+    const retried = await follower.downloadRange(new Uint8Array(16), 0, 2);
+    expect([...new Uint8Array(retried)]).toEqual([1, 2]);
+  });
+
   it('propagates a read rejection back to the follower with the stable code', async () => {
     const { engine, follower } = wire();
     engine.respondSnapshot = () =>

--- a/packages/client/src/broadcastTransport.ts
+++ b/packages/client/src/broadcastTransport.ts
@@ -105,6 +105,11 @@ export class BroadcastTransport extends CorrelatedTransport {
     return content.arrayBuffer();
   }
 
+  async downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
+    const content = await this.read<Blob>({ kind: 'downloadRange', node, offset, length });
+    return content.arrayBuffer();
+  }
+
   private read<T>(read: WireRead): Promise<T> {
     return this.request<T>(this.leaderReady, (requestId) =>
       this.channel.postMessage({ type: 'cb:read', clientId: this.clientId, requestId, read })

--- a/packages/client/src/correlatedTransport.ts
+++ b/packages/client/src/correlatedTransport.ts
@@ -72,6 +72,7 @@ export abstract class CorrelatedTransport implements EngineTransport {
   abstract snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor>;
   abstract siweChallenge(): Promise<string>;
   abstract download(node: Uint8Array): Promise<ArrayBuffer>;
+  abstract downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer>;
   abstract close(): void;
 
   subscribe(listener: EngineEventListener): () => void {

--- a/packages/client/src/engineClient.ts
+++ b/packages/client/src/engineClient.ts
@@ -160,6 +160,10 @@ export class EngineClient implements EngineTransport {
     return this.current.download(node);
   }
 
+  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
+    return this.current.downloadRange(node, offset, length);
+  }
+
   subscribe(listener: EngineEventListener): () => void {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);

--- a/packages/client/src/errorMessage.ts
+++ b/packages/client/src/errorMessage.ts
@@ -1,0 +1,4 @@
+/** Renders an unknown throw as the one line a wire message or log carries. */
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/client/src/facade.test.ts
+++ b/packages/client/src/facade.test.ts
@@ -16,6 +16,7 @@ class FakeTransport implements EngineTransport {
   snapshots: Uint8Array[] = [];
   downloads: Uint8Array[] = [];
   siweChallenges = 0;
+  downloadRanges: Array<{ node: Uint8Array; offset: number; length: number }> = [];
   beginWrites: Array<{ target: WriteTarget; size: number }> = [];
   chunks: Array<{ handle: WriteHandle; chunk: ArrayBuffer }> = [];
   commits: WriteHandle[] = [];
@@ -66,6 +67,11 @@ class FakeTransport implements EngineTransport {
   download(node: Uint8Array): Promise<ArrayBuffer> {
     this.downloads.push(node);
     return Promise.resolve(new Uint8Array([1, 2, 3]).buffer);
+  }
+
+  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
+    this.downloadRanges.push({ node, offset, length });
+    return Promise.resolve(new Uint8Array([4, 5]).buffer);
   }
 
   subscribe(listener: EngineEventListener): () => void {
@@ -163,6 +169,15 @@ describe('EngineFacade', () => {
       permission: 'write',
       recipientIdentityPublicKey: recipient,
     });
+  });
+
+  it('delegates a ranged read to the transport, window intact', async () => {
+    const transport = new FakeTransport();
+    const node = new Uint8Array(16).fill(3);
+
+    const window = await new EngineFacade(transport).downloadRange(node, 4096, 2);
+    expect([...new Uint8Array(window)]).toEqual([4, 5]);
+    expect(transport.downloadRanges).toEqual([{ node, offset: 4096, length: 2 }]);
   });
 
   it('delegates snapshot and download reads to the transport', async () => {

--- a/packages/client/src/facade.ts
+++ b/packages/client/src/facade.ts
@@ -66,6 +66,10 @@ export class EngineFacade {
     return this.transport.download(node);
   }
 
+  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
+    return this.transport.downloadRange(node, offset, length);
+  }
+
   /** Creates an empty node. File content is written through a write handle. */
   create(parent: Uint8Array, name: string, kind: NodeKind): Promise<void> {
     return this.command({ kind: 'create', parent, name, nodeKind: kind });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -31,8 +31,7 @@ export { LeaderRelay } from './leaderRelay.js';
 export { BROADCAST_CHANNEL_NAME, newClientId } from './broadcast.js';
 export type { BroadcastChannelLike } from './broadcast.js';
 
-// The tab side of the Service Worker byte pipe. The worker realm is reached by
-// URL through the `./sw` subpath, never this barrel.
+// The tab side of the Service Worker byte pipe.
 export { MediaService } from './media/service.js';
 export type { MediaReader } from './media/broker.js';
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -31,6 +31,11 @@ export { LeaderRelay } from './leaderRelay.js';
 export { BROADCAST_CHANNEL_NAME, newClientId } from './broadcast.js';
 export type { BroadcastChannelLike } from './broadcast.js';
 
+// The tab side of the Service Worker byte pipe. The worker realm is reached by
+// URL through the `./sw` subpath, never this barrel.
+export { MediaService } from './media/service.js';
+export type { MediaReader } from './media/broker.js';
+
 // The one hex codec in TypeScript, for hosts that receive hex-encoded bytes
 // from a third-party SDK.
 export { fromHex } from './seams/bytes.js';

--- a/packages/client/src/leaderRelay.ts
+++ b/packages/client/src/leaderRelay.ts
@@ -184,10 +184,12 @@ export class LeaderRelay {
         return this.transport.snapshot(read.folder);
       case 'siweChallenge':
         return this.transport.siweChallenge();
+      // Wrap the plaintext in a `Blob` so the per-receiver structured clone
+      // shares the immutable backing store instead of copying the bytes.
       case 'download':
-        // Wrap the plaintext in a `Blob` so the per-receiver structured clone
-        // shares the immutable backing store instead of copying the bytes.
         return new Blob([await this.transport.download(read.node)]);
+      case 'downloadRange':
+        return new Blob([await this.transport.downloadRange(read.node, read.offset, read.length)]);
     }
   }
 

--- a/packages/client/src/media/broker.test.ts
+++ b/packages/client/src/media/broker.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { MediaBroker, type MediaReader } from './broker.js';
+import type { MediaRequest, MediaResponse } from './protocol.js';
+import { StreamRegistry } from './registry.js';
+
+const NODE = new Uint8Array([1, 2, 3, 4]);
+const WINDOW = 4;
+
+/** Deterministic plaintext so a reassembled range can be compared byte for byte. */
+const plaintext = (size: number): Uint8Array =>
+  Uint8Array.from({ length: size }, (_, index) => (index * 7 + 3) % 251);
+
+interface ReadCall {
+  offset: number;
+  length: number;
+}
+
+class FakeReader implements MediaReader {
+  readonly calls: ReadCall[] = [];
+  concurrent = 0;
+  maxConcurrent = 0;
+  /** Set to make reads reject. */
+  failure: Error | null = null;
+  /** Set below the registered size to model a version that shrank after the ticket was minted. */
+  liveSize: number | null = null;
+
+  constructor(private readonly bytes: Uint8Array) {}
+
+  async downloadRange(_node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
+    this.calls.push({ offset, length });
+    this.concurrent += 1;
+    this.maxConcurrent = Math.max(this.maxConcurrent, this.concurrent);
+    try {
+      // A real ranged read suspends; unserialized pulls would overlap here.
+      await flush();
+      if (this.failure) throw this.failure;
+      const end = Math.min(offset + length, this.liveSize ?? this.bytes.length);
+      return this.bytes.slice(offset, Math.max(offset, end)).buffer as ArrayBuffer;
+    } finally {
+      this.concurrent -= 1;
+    }
+  }
+}
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (predicate()) return;
+    await flush();
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+interface Harness {
+  reader: FakeReader;
+  registry: StreamRegistry;
+  broker: MediaBroker;
+  send: (request: MediaRequest) => void;
+  received: MediaResponse[];
+  ticket: string;
+  close: () => void;
+}
+
+const openHarnesses: Array<() => void> = [];
+
+function harness(size: number, windowBytes = WINDOW): Harness {
+  const reader = new FakeReader(plaintext(size));
+  const registry = new StreamRegistry('https://vault.example', () => 'ticket-1');
+  registry.register({ node: NODE, size, mimeType: 'video/mp4' });
+  const broker = new MediaBroker(registry, reader, windowBytes);
+
+  const channel = new MessageChannel();
+  const received: MediaResponse[] = [];
+  channel.port2.addEventListener('message', (event) => {
+    received.push(event.data as MediaResponse);
+  });
+  channel.port2.start();
+  broker.serve(channel.port1);
+
+  const close = (): void => {
+    broker.close();
+    channel.port1.close();
+    channel.port2.close();
+  };
+  openHarnesses.push(close);
+
+  return {
+    reader,
+    registry,
+    broker,
+    received,
+    ticket: 'ticket-1',
+    send: (request) => channel.port2.postMessage(request),
+    close,
+  };
+}
+
+const bodyOf = (received: MediaResponse[]): Uint8Array => {
+  const chunks = received.filter((message) => message.type === 'cb:media:chunk');
+  const total = chunks.reduce((sum, message) => sum + message.chunk.byteLength, 0);
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const message of chunks) {
+    out.set(new Uint8Array(message.chunk), at);
+    at += message.chunk.byteLength;
+  }
+  return out;
+};
+
+const kinds = (received: MediaResponse[]): string[] => received.map((message) => message.type);
+
+afterEach(() => {
+  for (const close of openHarnesses.splice(0)) close();
+});
+
+describe('MediaBroker', () => {
+  it('reassembles a 206 range from windowed reads', async () => {
+    const size = 20;
+    const h = harness(size);
+
+    h.send({ type: 'cb:media:open', requestId: 1, ticket: h.ticket, range: 'bytes=3-12' });
+    await waitFor(() => h.received.length === 1, 'head');
+    for (let pull = 0; pull < 4; pull += 1) {
+      h.send({ type: 'cb:media:pull', requestId: 1 });
+      await waitFor(() => h.received.length === pull + 2, `chunk ${pull}`);
+    }
+
+    const head = h.received[0];
+    expect(head).toMatchObject({ ok: true, status: 206 });
+    expect(head.type === 'cb:media:head' ? head.headers : []).toContainEqual([
+      'content-range',
+      `bytes 3-12/${size}`,
+    ]);
+    expect(kinds(h.received)).toEqual([
+      'cb:media:head',
+      'cb:media:chunk',
+      'cb:media:chunk',
+      'cb:media:chunk',
+      'cb:media:end',
+    ]);
+    expect(bodyOf(h.received)).toEqual(plaintext(size).slice(3, 13));
+    // Window-aligned from the range start, and never wider than the window.
+    expect(h.reader.calls).toEqual([
+      { offset: 3, length: 4 },
+      { offset: 7, length: 4 },
+      { offset: 11, length: 2 },
+    ]);
+  });
+
+  it('answers an unknown ticket with a 404 head and reads nothing', async () => {
+    const h = harness(16);
+
+    h.send({ type: 'cb:media:open', requestId: 5, ticket: 'not-a-ticket', range: null });
+    await waitFor(() => h.received.length === 1, 'head');
+    h.send({ type: 'cb:media:pull', requestId: 5 });
+    await flush();
+
+    expect(h.received).toEqual([
+      { type: 'cb:media:head', requestId: 5, ok: false, status: 404, headers: [] },
+    ]);
+    expect(h.reader.calls).toEqual([]);
+  });
+
+  it('answers an unsatisfiable range with a 416 head and opens no stream', async () => {
+    const h = harness(16);
+
+    h.send({ type: 'cb:media:open', requestId: 2, ticket: h.ticket, range: 'bytes=99-' });
+    await waitFor(() => h.received.length === 1, 'head');
+    h.send({ type: 'cb:media:pull', requestId: 2 });
+    await flush();
+
+    const head = h.received[0];
+    expect(head).toMatchObject({ type: 'cb:media:head', ok: false, status: 416 });
+    expect(head.type === 'cb:media:head' ? head.headers : []).toContainEqual([
+      'content-range',
+      'bytes */16',
+    ]);
+    expect(h.received).toHaveLength(1);
+    expect(h.reader.calls).toEqual([]);
+  });
+
+  it('ends a zero-length window without reading', async () => {
+    const h = harness(0);
+
+    h.send({ type: 'cb:media:open', requestId: 3, ticket: h.ticket, range: null });
+    h.send({ type: 'cb:media:pull', requestId: 3 });
+    await waitFor(() => h.received.length === 2, 'end');
+
+    expect(kinds(h.received)).toEqual(['cb:media:head', 'cb:media:end']);
+    expect(h.received[0]).toMatchObject({ ok: true, status: 200 });
+    expect(h.reader.calls).toEqual([]);
+  });
+
+  it('stops reading once the stream is closed mid-body', async () => {
+    const h = harness(20);
+
+    h.send({ type: 'cb:media:open', requestId: 4, ticket: h.ticket, range: null });
+    h.send({ type: 'cb:media:pull', requestId: 4 });
+    await waitFor(() => h.received.length === 2, 'first chunk');
+
+    h.send({ type: 'cb:media:close', requestId: 4 });
+    await flush();
+    h.send({ type: 'cb:media:pull', requestId: 4 });
+    await flush();
+
+    expect(h.reader.calls).toEqual([{ offset: 0, length: 4 }]);
+    expect(kinds(h.received)).toEqual(['cb:media:head', 'cb:media:chunk']);
+  });
+
+  it('reports a read failure as cb:media:error and drops the stream', async () => {
+    const h = harness(20);
+    h.reader.failure = new Error('gateway unreachable');
+
+    h.send({ type: 'cb:media:open', requestId: 6, ticket: h.ticket, range: null });
+    h.send({ type: 'cb:media:pull', requestId: 6 });
+    await waitFor(() => h.received.length === 2, 'error');
+    h.send({ type: 'cb:media:pull', requestId: 6 });
+    await flush();
+
+    expect(h.received[1]).toEqual({
+      type: 'cb:media:error',
+      requestId: 6,
+      message: 'gateway unreachable',
+    });
+    expect(h.reader.calls).toHaveLength(1);
+  });
+
+  it('serializes back-to-back pulls into sequential non-overlapping reads', async () => {
+    const h = harness(20);
+
+    h.send({ type: 'cb:media:open', requestId: 7, ticket: h.ticket, range: null });
+    await waitFor(() => h.received.length === 1, 'head');
+    h.send({ type: 'cb:media:pull', requestId: 7 });
+    h.send({ type: 'cb:media:pull', requestId: 7 });
+    await waitFor(() => h.received.length === 3, 'two chunks');
+
+    expect(h.reader.maxConcurrent).toBe(1);
+    expect(h.reader.calls).toEqual([
+      { offset: 0, length: 4 },
+      { offset: 4, length: 4 },
+    ]);
+    expect(bodyOf(h.received)).toEqual(plaintext(20).slice(0, 8));
+  });
+
+  it('ends cleanly when a read comes back short of the window it asked for', async () => {
+    const h = harness(20);
+    // The head promised 20 bytes; the live version only has 6.
+    h.reader.liveSize = 6;
+
+    h.send({ type: 'cb:media:open', requestId: 9, ticket: h.ticket, range: null });
+    await waitFor(() => h.received.length === 1, 'head');
+    for (let pull = 0; pull < 3; pull += 1) {
+      h.send({ type: 'cb:media:pull', requestId: 9 });
+      await flush();
+    }
+    await waitFor(() => h.received.length === 4, 'end');
+
+    expect(kinds(h.received)).toEqual([
+      'cb:media:head',
+      'cb:media:chunk',
+      'cb:media:chunk',
+      'cb:media:end',
+    ]);
+    expect(bodyOf(h.received)).toEqual(plaintext(20).slice(0, 6));
+    // Advanced by what arrived, and stopped there instead of re-reading past it.
+    expect(h.reader.calls).toEqual([
+      { offset: 0, length: 4 },
+      { offset: 4, length: 4 },
+    ]);
+  });
+
+  it('ignores an unknown requestId and a malformed message', async () => {
+    const h = harness(20);
+
+    h.send({ type: 'cb:media:pull', requestId: 99 });
+    h.send({ type: 'cb:media:close', requestId: 99 });
+    h.send({ type: 'cb:media:open', requestId: 1, ticket: 42 } as unknown as MediaRequest);
+    h.send('nonsense' as unknown as MediaRequest);
+    await flush();
+
+    expect(h.received).toEqual([]);
+    expect(h.reader.calls).toEqual([]);
+  });
+
+  it('drops open streams when a new port supersedes the old one', async () => {
+    const h = harness(20);
+
+    h.send({ type: 'cb:media:open', requestId: 8, ticket: h.ticket, range: null });
+    await waitFor(() => h.received.length === 1, 'head');
+
+    const next = new MessageChannel();
+    const later: MediaResponse[] = [];
+    next.port2.addEventListener('message', (event) => later.push(event.data as MediaResponse));
+    next.port2.start();
+    h.broker.serve(next.port1);
+
+    h.send({ type: 'cb:media:pull', requestId: 8 });
+    next.port2.postMessage({ type: 'cb:media:pull', requestId: 8 });
+    await flush();
+
+    expect(h.received).toHaveLength(1);
+    expect(later).toEqual([]);
+    expect(h.reader.calls).toEqual([]);
+    next.port1.close();
+    next.port2.close();
+  });
+});

--- a/packages/client/src/media/broker.test.ts
+++ b/packages/client/src/media/broker.test.ts
@@ -128,7 +128,7 @@ describe('MediaBroker', () => {
     }
 
     const head = h.received[0];
-    expect(head).toMatchObject({ ok: true, status: 206 });
+    expect(head).toMatchObject({ type: 'cb:media:head', status: 206 });
     expect(head.type === 'cb:media:head' ? head.headers : []).toContainEqual([
       'content-range',
       `bytes 3-12/${size}`,
@@ -157,9 +157,7 @@ describe('MediaBroker', () => {
     h.send({ type: 'cb:media:pull', requestId: 5 });
     await flush();
 
-    expect(h.received).toEqual([
-      { type: 'cb:media:head', requestId: 5, ok: false, status: 404, headers: [] },
-    ]);
+    expect(h.received).toEqual([{ type: 'cb:media:head', requestId: 5, status: 404, headers: [] }]);
     expect(h.reader.calls).toEqual([]);
   });
 
@@ -172,7 +170,7 @@ describe('MediaBroker', () => {
     await flush();
 
     const head = h.received[0];
-    expect(head).toMatchObject({ type: 'cb:media:head', ok: false, status: 416 });
+    expect(head).toMatchObject({ type: 'cb:media:head', status: 416 });
     expect(head.type === 'cb:media:head' ? head.headers : []).toContainEqual([
       'content-range',
       'bytes */16',
@@ -189,7 +187,7 @@ describe('MediaBroker', () => {
     await waitFor(() => h.received.length === 2, 'end');
 
     expect(kinds(h.received)).toEqual(['cb:media:head', 'cb:media:end']);
-    expect(h.received[0]).toMatchObject({ ok: true, status: 200 });
+    expect(h.received[0]).toMatchObject({ type: 'cb:media:head', status: 200 });
     expect(h.reader.calls).toEqual([]);
   });
 

--- a/packages/client/src/media/broker.ts
+++ b/packages/client/src/media/broker.ts
@@ -1,0 +1,179 @@
+/** The tab-side server for the media byte pipe, answering over a brokered `MessagePort`. */
+
+import {
+  MEDIA_WINDOW_BYTES,
+  type MediaRequest,
+  type MediaResponse,
+  type MessagePortLike,
+} from './protocol.js';
+import { resolveMediaRequest } from './range.js';
+import type { StreamRegistry } from './registry.js';
+
+/** The one engine capability the pipe needs; `EngineClient` satisfies it. */
+export interface MediaReader {
+  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer>;
+}
+
+/** An open response body: the unread remainder of a resolved window. */
+interface Cursor {
+  readonly node: Uint8Array;
+  /** The mint-time window end, pulled in when a read proves the version is shorter. */
+  end: number;
+  offset: number;
+  /** Reads chain onto this so two pulls can never straddle one cursor. */
+  pump: Promise<void>;
+}
+
+export class MediaBroker {
+  private readonly streams = new Map<number, Cursor>();
+  private port: MessagePortLike | null = null;
+  private listener: ((event: MessageEvent) => void) | null = null;
+
+  constructor(
+    private readonly registry: StreamRegistry,
+    private readonly reader: MediaReader,
+    private readonly windowBytes: number = MEDIA_WINDOW_BYTES
+  ) {}
+
+  /** The pipe carries one port; a fresh offer supersedes the port it replaces. */
+  serve(port: MessagePortLike): void {
+    this.close();
+    const listener = (event: MessageEvent): void => {
+      this.dispatch(port, event.data);
+    };
+    port.addEventListener('message', listener);
+    port.start?.();
+    this.port = port;
+    this.listener = listener;
+  }
+
+  close(): void {
+    if (this.port !== null && this.listener !== null) {
+      this.port.removeEventListener('message', this.listener);
+    }
+    this.port = null;
+    this.listener = null;
+    this.streams.clear();
+  }
+
+  private dispatch(port: MessagePortLike, data: unknown): void {
+    const request = asRequest(data);
+    if (request === null) return;
+    switch (request.type) {
+      case 'cb:media:open':
+        this.open(port, request.requestId, request.ticket, request.range);
+        return;
+      case 'cb:media:pull':
+        this.pull(port, request.requestId);
+        return;
+      case 'cb:media:close':
+        this.streams.delete(request.requestId);
+        return;
+    }
+  }
+
+  private open(
+    port: MessagePortLike,
+    requestId: number,
+    ticket: string,
+    range: string | null
+  ): void {
+    const source = this.registry.lookup(ticket);
+    if (source === undefined) {
+      post(port, { type: 'cb:media:head', requestId, ok: false, status: 404, headers: [] });
+      return;
+    }
+
+    const head = resolveMediaRequest(range, source.size, source.mimeType);
+    if (head.status === 416) {
+      post(port, {
+        type: 'cb:media:head',
+        requestId,
+        ok: false,
+        status: head.status,
+        headers: head.headers,
+      });
+      return;
+    }
+
+    this.streams.set(requestId, {
+      node: source.node,
+      offset: head.window.offset,
+      end: head.window.offset + head.window.length,
+      pump: Promise.resolve(),
+    });
+    post(port, {
+      type: 'cb:media:head',
+      requestId,
+      ok: true,
+      status: head.status,
+      headers: head.headers,
+    });
+  }
+
+  private pull(port: MessagePortLike, requestId: number): void {
+    const cursor = this.streams.get(requestId);
+    if (cursor === undefined) return;
+    cursor.pump = cursor.pump.then(() => this.pump(port, requestId, cursor));
+  }
+
+  private async pump(port: MessagePortLike, requestId: number, cursor: Cursor): Promise<void> {
+    if (this.streams.get(requestId) !== cursor) return;
+
+    const remaining = cursor.end - cursor.offset;
+    if (remaining <= 0) {
+      this.streams.delete(requestId);
+      post(port, { type: 'cb:media:end', requestId });
+      return;
+    }
+
+    const offset = cursor.offset;
+    const length = Math.min(this.windowBytes, remaining);
+    try {
+      const chunk = await this.reader.downloadRange(cursor.node, offset, length);
+      if (this.streams.get(requestId) !== cursor) return;
+      cursor.offset = offset + chunk.byteLength;
+      // A short read means the live version is smaller than the head promised;
+      // ending here is a clean EOF, where under-delivering content-length is a
+      // network error to the media element.
+      if (chunk.byteLength < length) cursor.end = cursor.offset;
+      const response: MediaResponse = { type: 'cb:media:chunk', requestId, chunk };
+      port.postMessage(response, [chunk]);
+    } catch (error) {
+      if (this.streams.get(requestId) !== cursor) return;
+      this.streams.delete(requestId);
+      post(port, { type: 'cb:media:error', requestId, message: describe(error) });
+    }
+  }
+}
+
+function post(port: MessagePortLike, response: MediaResponse): void {
+  port.postMessage(response);
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** A same-origin port is still untrusted input: anything off-shape is dropped. */
+function asRequest(data: unknown): MediaRequest | null {
+  if (typeof data !== 'object' || data === null) return null;
+  const message = data as {
+    type?: unknown;
+    requestId?: unknown;
+    ticket?: unknown;
+    range?: unknown;
+  };
+  const requestId = message.requestId;
+  if (typeof requestId !== 'number') return null;
+
+  if (message.type === 'cb:media:open') {
+    const { ticket, range } = message;
+    if (typeof ticket !== 'string') return null;
+    if (typeof range !== 'string' && range !== null) return null;
+    return { type: 'cb:media:open', requestId, ticket, range };
+  }
+  if (message.type === 'cb:media:pull') return { type: 'cb:media:pull', requestId };
+  if (message.type === 'cb:media:close') return { type: 'cb:media:close', requestId };
+  return null;
+}

--- a/packages/client/src/media/broker.ts
+++ b/packages/client/src/media/broker.ts
@@ -80,19 +80,13 @@ export class MediaBroker {
   ): void {
     const source = this.registry.lookup(ticket);
     if (source === undefined) {
-      post(port, { type: 'cb:media:head', requestId, ok: false, status: 404, headers: [] });
+      post(port, { type: 'cb:media:head', requestId, status: 404, headers: [] });
       return;
     }
 
     const head = resolveMediaRequest(range, source.size, source.mimeType);
     if (head.status === 416) {
-      post(port, {
-        type: 'cb:media:head',
-        requestId,
-        ok: false,
-        status: head.status,
-        headers: head.headers,
-      });
+      post(port, { type: 'cb:media:head', requestId, status: head.status, headers: head.headers });
       return;
     }
 
@@ -102,13 +96,7 @@ export class MediaBroker {
       end: head.window.offset + head.window.length,
       pump: Promise.resolve(),
     });
-    post(port, {
-      type: 'cb:media:head',
-      requestId,
-      ok: true,
-      status: head.status,
-      headers: head.headers,
-    });
+    post(port, { type: 'cb:media:head', requestId, status: head.status, headers: head.headers });
   }
 
   private pull(port: MessagePortLike, requestId: number): void {

--- a/packages/client/src/media/broker.ts
+++ b/packages/client/src/media/broker.ts
@@ -1,5 +1,6 @@
 /** The tab-side server for the media byte pipe, answering over a brokered `MessagePort`. */
 
+import { errorMessage } from '../errorMessage.js';
 import {
   MEDIA_WINDOW_BYTES,
   type MediaRequest,
@@ -78,15 +79,19 @@ export class MediaBroker {
     ticket: string,
     range: string | null
   ): void {
+    const postHead = (status: number, headers: Array<[string, string]>): void => {
+      post(port, { type: 'cb:media:head', requestId, status, headers });
+    };
+
     const source = this.registry.lookup(ticket);
     if (source === undefined) {
-      post(port, { type: 'cb:media:head', requestId, status: 404, headers: [] });
+      postHead(404, []);
       return;
     }
 
     const head = resolveMediaRequest(range, source.size, source.mimeType);
     if (head.status === 416) {
-      post(port, { type: 'cb:media:head', requestId, status: head.status, headers: head.headers });
+      postHead(head.status, head.headers);
       return;
     }
 
@@ -96,7 +101,7 @@ export class MediaBroker {
       end: head.window.offset + head.window.length,
       pump: Promise.resolve(),
     });
-    post(port, { type: 'cb:media:head', requestId, status: head.status, headers: head.headers });
+    postHead(head.status, head.headers);
   }
 
   private pull(port: MessagePortLike, requestId: number): void {
@@ -105,8 +110,17 @@ export class MediaBroker {
     cursor.pump = cursor.pump.then(() => this.pump(port, requestId, cursor));
   }
 
+  /**
+   * Whether this cursor still owns the request. A close or a superseding open
+   * can land at any await, and answering off a dropped cursor would post another
+   * stream's plaintext under this request id.
+   */
+  private isCurrent(requestId: number, cursor: Cursor): boolean {
+    return this.streams.get(requestId) === cursor;
+  }
+
   private async pump(port: MessagePortLike, requestId: number, cursor: Cursor): Promise<void> {
-    if (this.streams.get(requestId) !== cursor) return;
+    if (!this.isCurrent(requestId, cursor)) return;
 
     const remaining = cursor.end - cursor.offset;
     if (remaining <= 0) {
@@ -119,7 +133,7 @@ export class MediaBroker {
     const length = Math.min(this.windowBytes, remaining);
     try {
       const chunk = await this.reader.downloadRange(cursor.node, offset, length);
-      if (this.streams.get(requestId) !== cursor) return;
+      if (!this.isCurrent(requestId, cursor)) return;
       cursor.offset = offset + chunk.byteLength;
       // A short read means the live version is smaller than the head promised;
       // ending here is a clean EOF, where under-delivering content-length is a
@@ -128,19 +142,15 @@ export class MediaBroker {
       const response: MediaResponse = { type: 'cb:media:chunk', requestId, chunk };
       port.postMessage(response, [chunk]);
     } catch (error) {
-      if (this.streams.get(requestId) !== cursor) return;
+      if (!this.isCurrent(requestId, cursor)) return;
       this.streams.delete(requestId);
-      post(port, { type: 'cb:media:error', requestId, message: describe(error) });
+      post(port, { type: 'cb:media:error', requestId, message: errorMessage(error) });
     }
   }
 }
 
 function post(port: MessagePortLike, response: MediaResponse): void {
   port.postMessage(response);
-}
-
-function describe(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 /** A same-origin port is still untrusted input: anything off-shape is dropped. */

--- a/packages/client/src/media/protocol.ts
+++ b/packages/client/src/media/protocol.ts
@@ -35,7 +35,6 @@ export type MediaResponse =
   | {
       type: 'cb:media:head';
       requestId: number;
-      ok: boolean;
       status: number;
       headers: Array<[string, string]>;
     }
@@ -46,14 +45,14 @@ export type MediaResponse =
   /** The read failed; the response body errors out. */
   | { type: 'cb:media:error'; requestId: number; message: string };
 
-/** Tab → Service Worker, carrying the tab's end of a fresh `MessageChannel`. */
-export type MediaPortOffer = { type: 'cb:media:port' };
-
-/** Service Worker → every window client, when it holds no usable port. */
-export type MediaPortRequest = { type: 'cb:media:needPort' };
-
 export const MEDIA_PORT_OFFER = 'cb:media:port';
 export const MEDIA_PORT_REQUEST = 'cb:media:needPort';
+
+/** Tab → Service Worker, carrying the tab's end of a fresh `MessageChannel`. */
+export type MediaPortOffer = { type: typeof MEDIA_PORT_OFFER };
+
+/** Service Worker → every window client, when it holds no usable port. */
+export type MediaPortRequest = { type: typeof MEDIA_PORT_REQUEST };
 
 /** The ticket in a `/stream/<ticket>` path, or `null` for any other path. */
 export function ticketFromPath(pathname: string): string | null {

--- a/packages/client/src/media/protocol.ts
+++ b/packages/client/src/media/protocol.ts
@@ -1,0 +1,79 @@
+/**
+ * The Service Worker byte-pipe wire (blueprint/web-client.md "Streaming media —
+ * the SW is a dumb pipe"). Everything semantic — ticket lookup, Range
+ * resolution, windowing — runs tab-side, so the worker holds no keys, no crypto
+ * and no state beyond the port it currently has.
+ */
+
+/** The subset of `MessagePort` the pipe and the broker drive (injectable). */
+export interface MessagePortLike {
+  postMessage(message: unknown, transfer?: Transferable[]): void;
+  addEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+  removeEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+  start?(): void;
+  close(): void;
+}
+
+/** Ticket URLs live under one path prefix so the fetch handler can be exact. */
+export const STREAM_PATH_PREFIX = '/stream/';
+
+/** The plaintext window read per pull: peak memory on both sides of the port is one window, never the file. */
+export const MEDIA_WINDOW_BYTES = 1024 * 1024;
+
+/** Service Worker → port. */
+export type MediaRequest =
+  /** Open a stream for `ticket`, resolving `range` (a raw `Range` header value). */
+  | { type: 'cb:media:open'; requestId: number; ticket: string; range: string | null }
+  /** Demand the next window; the stream's `ReadableStream.pull` drives this. */
+  | { type: 'cb:media:pull'; requestId: number }
+  /** The response body was cancelled or the stream is done with. */
+  | { type: 'cb:media:close'; requestId: number };
+
+/** Port → Service Worker. */
+export type MediaResponse =
+  /** The resolved status and headers; the body follows as `chunk`s until `end`. */
+  | {
+      type: 'cb:media:head';
+      requestId: number;
+      ok: boolean;
+      status: number;
+      headers: Array<[string, string]>;
+    }
+  /** One plaintext window, transferred. */
+  | { type: 'cb:media:chunk'; requestId: number; chunk: ArrayBuffer }
+  /** The window sequence is complete. */
+  | { type: 'cb:media:end'; requestId: number }
+  /** The read failed; the response body errors out. */
+  | { type: 'cb:media:error'; requestId: number; message: string };
+
+/** Tab → Service Worker, carrying the tab's end of a fresh `MessageChannel`. */
+export type MediaPortOffer = { type: 'cb:media:port' };
+
+/** Service Worker → every window client, when it holds no usable port. */
+export type MediaPortRequest = { type: 'cb:media:needPort' };
+
+export const MEDIA_PORT_OFFER = 'cb:media:port';
+export const MEDIA_PORT_REQUEST = 'cb:media:needPort';
+
+/** The ticket in a `/stream/<ticket>` path, or `null` for any other path. */
+export function ticketFromPath(pathname: string): string | null {
+  if (!pathname.startsWith(STREAM_PATH_PREFIX)) return null;
+  const ticket = pathname.slice(STREAM_PATH_PREFIX.length);
+  // A nested path is not a ticket: `/stream/a/b` must not resolve as `a/b`.
+  return ticket.length > 0 && !ticket.includes('/') ? ticket : null;
+}
+
+/**
+ * The ticket in any form of a stream URL the DOM hands back — absolute,
+ * relative, query- or fragment-bearing. A URL resolving off `origin` names no
+ * ticket of ours.
+ */
+export function ticketFromUrl(url: string, origin: string): string | null {
+  let resolved: URL;
+  try {
+    resolved = new URL(url, origin);
+  } catch {
+    return null;
+  }
+  return resolved.origin === origin ? ticketFromPath(resolved.pathname) : null;
+}

--- a/packages/client/src/media/range.test.ts
+++ b/packages/client/src/media/range.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveMediaRequest, type MediaHead } from './range.js';
+
+const SIZE = 4096;
+
+const headerMap = (head: MediaHead): Map<string, string> => new Map(head.headers);
+
+const contentTypeFor = (mimeType: string): string | undefined =>
+  headerMap(resolveMediaRequest(null, SIZE, mimeType)).get('content-type');
+
+describe('resolveMediaRequest content-type', () => {
+  it('downgrades a type that would execute on the app origin', () => {
+    expect(contentTypeFor('text/html')).toBe('application/octet-stream');
+    expect(contentTypeFor('image/svg+xml')).toBe('application/octet-stream');
+    expect(contentTypeFor('application/javascript')).toBe('application/octet-stream');
+  });
+
+  it('passes a playable media type through', () => {
+    expect(contentTypeFor('video/mp4')).toBe('video/mp4');
+    expect(contentTypeFor('audio/mpeg')).toBe('audio/mpeg');
+    expect(contentTypeFor('image/png')).toBe('image/png');
+  });
+
+  it('downgrades on the 206 head too', () => {
+    const head = resolveMediaRequest('bytes=0-99', SIZE, 'text/html');
+    expect(head.status).toBe(206);
+    expect(headerMap(head).get('content-type')).toBe('application/octet-stream');
+  });
+});
+
+describe('resolveMediaRequest hardening headers', () => {
+  const cases: Array<[string, MediaHead]> = [
+    ['200', resolveMediaRequest(null, SIZE, 'video/mp4')],
+    ['206', resolveMediaRequest('bytes=0-99', SIZE, 'video/mp4')],
+    ['416', resolveMediaRequest(`bytes=${SIZE}-`, SIZE, 'video/mp4')],
+  ];
+
+  for (const [status, head] of cases) {
+    it(`sets nosniff and a no-source content-security-policy on the ${status} head`, () => {
+      expect(String(head.status)).toBe(status);
+      const headers = headerMap(head);
+      expect(headers.get('x-content-type-options')).toBe('nosniff');
+      expect(headers.get('content-security-policy')).toBe("default-src 'none'; sandbox");
+    });
+  }
+});

--- a/packages/client/src/media/range.ts
+++ b/packages/client/src/media/range.ts
@@ -1,0 +1,129 @@
+/**
+ * Range resolution for the media byte pipe: a raw `Range` header plus the file
+ * size to the response head and the plaintext window it carries.
+ */
+
+/** A half-open plaintext window `[offset, offset + length)`. */
+export interface MediaWindow {
+  readonly offset: number;
+  readonly length: number;
+}
+
+/** The response head for a media request, with the window its body carries. */
+export type MediaHead =
+  | { status: 200 | 206; headers: Array<[string, string]>; window: MediaWindow }
+  | { status: 416; headers: Array<[string, string]> };
+
+const SUFFIX_FORM = /^-(\d+)$/;
+const INTERVAL_FORM = /^(\d+)-(\d*)$/;
+
+/**
+ * A ticket URL is same-origin and top-level navigable, so a shared file's
+ * attacker-chosen type would execute as the app itself. Only non-executable
+ * media types survive; SVG scripts, so it is not one of them.
+ */
+function safeMimeType(mimeType: string): string {
+  const type = mimeType.split(';')[0].trim().toLowerCase();
+  const playable =
+    type.startsWith('audio/') || type.startsWith('video/') || type.startsWith('image/');
+  return playable && !type.startsWith('image/svg') ? type : 'application/octet-stream';
+}
+
+/** Belt to `safeMimeType`'s braces: no sniffing, and nothing the body names may load or run. */
+const hardening: Array<[string, string]> = [
+  ['x-content-type-options', 'nosniff'],
+  ['content-security-policy', "default-src 'none'; sandbox"],
+];
+
+/**
+ * `no-store` keeps vault plaintext out of the HTTP cache: the pipe hands the
+ * media element decrypted bytes, and nothing decrypted may outlive the response.
+ */
+function baseHeaders(mimeType: string, length: number): Array<[string, string]> {
+  return [
+    ['content-type', safeMimeType(mimeType)],
+    ['content-length', String(length)],
+    ['accept-ranges', 'bytes'],
+    ['cache-control', 'no-store'],
+    ...hardening,
+  ];
+}
+
+function unsatisfiable(totalSize: number): MediaHead {
+  return {
+    status: 416,
+    headers: [
+      ['content-range', `bytes */${totalSize}`],
+      ['cache-control', 'no-store'],
+      ...hardening,
+    ],
+  };
+}
+
+function whole(totalSize: number, mimeType: string): MediaHead {
+  return {
+    status: 200,
+    headers: baseHeaders(mimeType, totalSize),
+    window: { offset: 0, length: totalSize },
+  };
+}
+
+/** Digit runs past `Number.MAX_SAFE_INTEGER` are not addressable — fail closed. */
+function parseOffset(digits: string): number | null {
+  const value = Number(digits);
+  return Number.isSafeInteger(value) ? value : null;
+}
+
+/**
+ * Resolves one media request. An absent, non-`bytes`, multi-range, or malformed
+ * `Range` is answered with the whole file, which RFC 9110 permits and every
+ * media element handles; only a syntactically valid range that addresses no
+ * bytes of the file is a 416.
+ */
+export function resolveMediaRequest(
+  rangeHeader: string | null,
+  totalSize: number,
+  mimeType: string
+): MediaHead {
+  if (rangeHeader === null || rangeHeader.trim() === '') return whole(totalSize, mimeType);
+
+  const spec = rangeHeader.trim();
+  if (!spec.toLowerCase().startsWith('bytes=')) return whole(totalSize, mimeType);
+  const set = spec.slice('bytes='.length).trim();
+  if (set.includes(',')) return whole(totalSize, mimeType);
+
+  const suffix = SUFFIX_FORM.exec(set);
+  if (suffix) {
+    const wanted = parseOffset(suffix[1]);
+    if (wanted === null) return unsatisfiable(totalSize);
+    if (wanted === 0 || totalSize === 0) return unsatisfiable(totalSize);
+    const offset = Math.max(0, totalSize - wanted);
+    return partial(offset, totalSize - 1, totalSize, mimeType);
+  }
+
+  const interval = INTERVAL_FORM.exec(set);
+  if (!interval) return whole(totalSize, mimeType);
+
+  const offset = parseOffset(interval[1]);
+  if (offset === null || offset >= totalSize) return unsatisfiable(totalSize);
+  let last = totalSize - 1;
+  if (interval[2] !== '') {
+    const requestedLast = parseOffset(interval[2]);
+    if (requestedLast === null) return unsatisfiable(totalSize);
+    last = Math.min(requestedLast, last);
+  }
+  if (last < offset) return unsatisfiable(totalSize);
+  return partial(offset, last, totalSize, mimeType);
+}
+
+function partial(offset: number, last: number, totalSize: number, mimeType: string): MediaHead {
+  const length = last - offset + 1;
+  return {
+    status: 206,
+    headers: [
+      ...baseHeaders(mimeType, length),
+      ['content-range', `bytes ${offset}-${last}/${totalSize}`],
+    ],
+    window: { offset, length },
+  };
+}

--- a/packages/client/src/media/range.ts
+++ b/packages/client/src/media/range.ts
@@ -22,29 +22,30 @@ const INTERVAL_FORM = /^(\d+)-(\d*)$/;
  * attacker-chosen type would execute as the app itself. Only non-executable
  * media types survive; SVG scripts, so it is not one of them.
  */
-function safeMimeType(mimeType: string): string {
+export function safeMimeType(mimeType: string): string {
   const type = mimeType.split(';')[0].trim().toLowerCase();
   const playable =
     type.startsWith('audio/') || type.startsWith('video/') || type.startsWith('image/');
   return playable && !type.startsWith('image/svg') ? type : 'application/octet-stream';
 }
 
-/** Belt to `safeMimeType`'s braces: no sniffing, and nothing the body names may load or run. */
+/**
+ * Belt to `safeMimeType`'s braces: no sniffing, and nothing the body names may
+ * load or run. `no-store` keeps vault plaintext out of the HTTP cache — the pipe
+ * hands the media element decrypted bytes, and nothing decrypted may outlive the
+ * response.
+ */
 const hardening: Array<[string, string]> = [
+  ['cache-control', 'no-store'],
   ['x-content-type-options', 'nosniff'],
   ['content-security-policy', "default-src 'none'; sandbox"],
 ];
 
-/**
- * `no-store` keeps vault plaintext out of the HTTP cache: the pipe hands the
- * media element decrypted bytes, and nothing decrypted may outlive the response.
- */
 function baseHeaders(mimeType: string, length: number): Array<[string, string]> {
   return [
     ['content-type', safeMimeType(mimeType)],
     ['content-length', String(length)],
     ['accept-ranges', 'bytes'],
-    ['cache-control', 'no-store'],
     ...hardening,
   ];
 }
@@ -52,11 +53,7 @@ function baseHeaders(mimeType: string, length: number): Array<[string, string]> 
 function unsatisfiable(totalSize: number): MediaHead {
   return {
     status: 416,
-    headers: [
-      ['content-range', `bytes */${totalSize}`],
-      ['cache-control', 'no-store'],
-      ...hardening,
-    ],
+    headers: [['content-range', `bytes */${totalSize}`], ...hardening],
   };
 }
 

--- a/packages/client/src/media/registry.test.ts
+++ b/packages/client/src/media/registry.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { STREAM_PATH_PREFIX, ticketFromPath } from './protocol.js';
+import { StreamRegistry, type MediaSource } from './registry.js';
+
+const ORIGIN = 'https://vault.example';
+
+const source = (byte: number): MediaSource => ({
+  node: new Uint8Array([byte, byte, byte]),
+  size: 1024,
+  mimeType: 'video/mp4',
+});
+
+const ticketOf = (url: string): string => {
+  const ticket = ticketFromPath(url);
+  if (ticket === null) throw new Error(`not a stream url: ${url}`);
+  return ticket;
+};
+
+describe('StreamRegistry', () => {
+  it('resolves a registered ticket back to its source', () => {
+    const registry = new StreamRegistry(ORIGIN);
+    const media = source(7);
+
+    const url = registry.register(media);
+
+    expect(url.startsWith(STREAM_PATH_PREFIX)).toBe(true);
+    expect(registry.lookup(ticketOf(url))).toBe(media);
+  });
+
+  it('stops resolving a revoked url', () => {
+    const registry = new StreamRegistry(ORIGIN);
+    const url = registry.register(source(1));
+
+    expect(registry.revoke(url)).toBe(true);
+
+    expect(registry.lookup(ticketOf(url))).toBeUndefined();
+  });
+
+  it('revokes the absolute url a media element reads back off its src', () => {
+    const registry = new StreamRegistry(ORIGIN);
+    const url = registry.register(source(1));
+
+    expect(registry.revoke(`${ORIGIN}${url}`)).toBe(true);
+
+    expect(registry.lookup(ticketOf(url))).toBeUndefined();
+  });
+
+  it('revokes a url carrying a media fragment', () => {
+    const registry = new StreamRegistry(ORIGIN);
+    const url = registry.register(source(1));
+
+    expect(registry.revoke(`${ORIGIN}${url}#t=10`)).toBe(true);
+
+    expect(registry.lookup(ticketOf(url))).toBeUndefined();
+  });
+
+  it('refuses a url naming another origin', () => {
+    const registry = new StreamRegistry(ORIGIN);
+    const url = registry.register(source(1));
+
+    expect(registry.revoke(`https://evil.example${url}`)).toBe(false);
+
+    expect(registry.lookup(ticketOf(url))).toBeDefined();
+  });
+
+  it('reports a revoke for a url it never minted', () => {
+    const registry = new StreamRegistry(ORIGIN);
+    const url = registry.register(source(1));
+
+    expect(registry.revoke('/elsewhere/abc')).toBe(false);
+    expect(registry.revoke(`${ORIGIN}/stream/no-such-ticket`)).toBe(false);
+
+    expect(registry.lookup(ticketOf(url))).toBeDefined();
+  });
+
+  it('mints a distinct random ticket per registration, never derived from the node', () => {
+    const registry = new StreamRegistry(ORIGIN);
+    const media = source(9);
+
+    const first = ticketOf(registry.register(media));
+    const second = ticketOf(registry.register(media));
+
+    // Identical sources minting distinct random tickets is what makes a ticket
+    // unguessable from the content it names.
+    expect(first).not.toBe(second);
+    expect(first).toMatch(/^[0-9a-f-]{36}$/);
+    expect(second).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('drops every ticket on clear', () => {
+    const registry = new StreamRegistry(ORIGIN);
+    const a = ticketOf(registry.register(source(1)));
+    const b = ticketOf(registry.register(source(2)));
+
+    registry.clear();
+
+    expect(registry.lookup(a)).toBeUndefined();
+    expect(registry.lookup(b)).toBeUndefined();
+  });
+
+  it('mints through the injected ticket source', () => {
+    let n = 0;
+    const registry = new StreamRegistry(ORIGIN, () => `t${(n += 1)}`);
+
+    expect(registry.register(source(1))).toBe(`${STREAM_PATH_PREFIX}t1`);
+    expect(registry.register(source(2))).toBe(`${STREAM_PATH_PREFIX}t2`);
+  });
+});

--- a/packages/client/src/media/registry.ts
+++ b/packages/client/src/media/registry.ts
@@ -1,0 +1,49 @@
+/**
+ * Ticket minting for the media byte pipe. A `/stream/<ticket>` URL is a bearer
+ * capability to one file's plaintext, readable by any same-origin script that
+ * can name it — so tickets are random and opaque, never derived from the node.
+ */
+
+import { STREAM_PATH_PREFIX, ticketFromUrl } from './protocol.js';
+
+/** What a ticket resolves to: the content node plus what the head must declare. */
+export interface MediaSource {
+  readonly node: Uint8Array;
+  readonly size: number;
+  readonly mimeType: string;
+}
+
+export class StreamRegistry {
+  private readonly sources = new Map<string, MediaSource>();
+
+  constructor(
+    /** The origin a stream URL must resolve to; tickets are same-origin capabilities. */
+    private readonly origin: string,
+    private readonly mintTicket: () => string = () => globalThis.crypto.randomUUID()
+  ) {}
+
+  /** Mints a ticket for `source` and returns the URL a media element requests. */
+  register(source: MediaSource): string {
+    const ticket = this.mintTicket();
+    this.sources.set(ticket, source);
+    return `${STREAM_PATH_PREFIX}${ticket}`;
+  }
+
+  lookup(ticket: string): MediaSource | undefined {
+    return this.sources.get(ticket);
+  }
+
+  /**
+   * Takes any form of the URL `register` returned — including the absolute one a
+   * media element reads back off `src`. Reports whether a ticket was dropped, so
+   * a caller is never left believing plaintext is unreachable when it is not.
+   */
+  revoke(url: string): boolean {
+    const ticket = ticketFromUrl(url, this.origin);
+    return ticket !== null && this.sources.delete(ticket);
+  }
+
+  clear(): void {
+    this.sources.clear();
+  }
+}

--- a/packages/client/src/media/service.test.ts
+++ b/packages/client/src/media/service.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MediaReader } from './broker.js';
+import {
+  MEDIA_PORT_OFFER,
+  MEDIA_PORT_REQUEST,
+  type MediaResponse,
+  type MessagePortLike,
+} from './protocol.js';
+import {
+  MediaService,
+  type ServiceWorkerContainerLike,
+  type ServiceWorkerLike,
+  type ServiceWorkerRegistrationLike,
+} from './service.js';
+
+class FakePort implements MessagePortLike {
+  peer: FakePort | null = null;
+  readonly sent: Array<{ message: unknown; transfer?: Transferable[] }> = [];
+  started = false;
+  closed = false;
+  private readonly listeners = new Set<(event: MessageEvent) => void>();
+
+  postMessage(message: unknown, transfer?: Transferable[]): void {
+    this.sent.push({ message, transfer });
+    this.peer?.deliver(message);
+  }
+
+  deliver(message: unknown): void {
+    if (this.closed) return;
+    for (const listener of this.listeners) listener({ data: message } as MessageEvent);
+  }
+
+  addEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
+    this.listeners.add(listener);
+  }
+
+  removeEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
+    this.listeners.delete(listener);
+  }
+
+  start(): void {
+    this.started = true;
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+class FakeChannel {
+  readonly port1 = new FakePort();
+  readonly port2 = new FakePort();
+
+  constructor() {
+    this.port1.peer = this.port2;
+    this.port2.peer = this.port1;
+  }
+}
+
+class FakeWorker implements ServiceWorkerLike {
+  readonly offers: Array<{ message: unknown; transfer: Transferable[] }> = [];
+
+  postMessage(message: unknown, transfer: Transferable[]): void {
+    this.offers.push({ message, transfer });
+  }
+}
+
+class FakeContainer implements ServiceWorkerContainerLike {
+  controller: ServiceWorkerLike | null = null;
+  readonly registration: { active: ServiceWorkerLike | null } = { active: null };
+  readonly registered: Array<{ scriptUrl: string | URL; scope?: string }> = [];
+  readonly ready: Promise<ServiceWorkerRegistrationLike>;
+  failRegister = false;
+  private readonly listeners = new Map<string, Set<(event: MessageEvent) => void>>();
+
+  constructor() {
+    this.ready = Promise.resolve(this.registration);
+  }
+
+  register(
+    scriptUrl: string | URL,
+    options?: { scope?: string }
+  ): Promise<ServiceWorkerRegistrationLike> {
+    if (this.failRegister) return Promise.reject(new Error('no service workers here'));
+    this.registered.push({ scriptUrl, scope: options?.scope });
+    return Promise.resolve(this.registration);
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void): void {
+    const set = this.listeners.get(type) ?? new Set();
+    set.add(listener);
+    this.listeners.set(type, set);
+  }
+
+  removeEventListener(type: string, listener: (event: MessageEvent) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(type: 'message' | 'controllerchange', data?: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) listener({ data } as MessageEvent);
+  }
+
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.size ?? 0;
+  }
+}
+
+const ORIGIN = 'https://vault.example';
+
+const reader: MediaReader = {
+  downloadRange: (_node, _offset, length) => Promise.resolve(new ArrayBuffer(length)),
+};
+
+interface Setup {
+  container: FakeContainer;
+  worker: FakeWorker;
+  service: MediaService;
+  channels: FakeChannel[];
+}
+
+function setup(): Setup {
+  const container = new FakeContainer();
+  const worker = new FakeWorker();
+  const channels: FakeChannel[] = [];
+  const service = new MediaService({
+    container,
+    scriptUrl: '/sw.js',
+    reader,
+    origin: ORIGIN,
+    createChannel: () => {
+      const channel = new FakeChannel();
+      channels.push(channel);
+      return channel as unknown as MessageChannel;
+    },
+  });
+  return { container, worker, service, channels };
+}
+
+const brokeredPort = (channels: FakeChannel[]): FakePort => channels[channels.length - 1].port1;
+
+describe('MediaService', () => {
+  it('registers the worker at the root scope and offers a port to the controller', async () => {
+    const { container, worker, service, channels } = setup();
+    container.controller = worker;
+
+    await service.start();
+
+    expect(container.registered).toEqual([{ scriptUrl: '/sw.js', scope: '/' }]);
+    expect(channels).toHaveLength(1);
+    expect(worker.offers).toHaveLength(1);
+    expect(worker.offers[0].message).toEqual({ type: MEDIA_PORT_OFFER });
+    expect(worker.offers[0].transfer).toEqual([channels[0].port2]);
+    expect(channels[0].port1.started).toBe(true);
+    expect(service.streaming).toBe(true);
+  });
+
+  it('offers to the registration active worker when no controller has claimed the tab', async () => {
+    const { container, worker, service, channels } = setup();
+    container.registration.active = worker;
+
+    await service.start();
+
+    expect(worker.offers).toHaveLength(1);
+    expect(worker.offers[0].transfer).toEqual([channels[0].port2]);
+    // The offer primes a worker that has not claimed yet; until it does, this
+    // tab's fetches still go to the network.
+    expect(service.streaming).toBe(false);
+  });
+
+  it('refuses to mint a ticket while no worker controls the tab', async () => {
+    const { container, worker, service } = setup();
+    container.registration.active = worker;
+    await service.start();
+
+    expect(() =>
+      service.createStreamUrl({ node: new Uint8Array(1), size: 1, mimeType: 'video/mp4' })
+    ).toThrow(/controlling Service Worker/);
+  });
+
+  it('serves media requests over the brokered port', async () => {
+    const { container, worker, service, channels } = setup();
+    container.controller = worker;
+    await service.start();
+
+    const url = service.createStreamUrl({
+      node: new Uint8Array([9]),
+      size: 8,
+      mimeType: 'audio/o',
+    });
+    const ticket = url.slice('/stream/'.length);
+    const answers: MediaResponse[] = [];
+    channels[0].port2.addEventListener('message', (event) =>
+      answers.push(event.data as MediaResponse)
+    );
+    channels[0].port2.postMessage({ type: 'cb:media:open', requestId: 1, ticket, range: null });
+
+    expect(answers[0]).toMatchObject({ type: 'cb:media:head', ok: true, status: 200 });
+
+    expect(service.revokeStreamUrl(url)).toBe(true);
+    channels[0].port2.postMessage({ type: 'cb:media:open', requestId: 2, ticket, range: null });
+    expect(answers[1]).toMatchObject({ ok: false, status: 404 });
+  });
+
+  it('revokes the absolute form of a minted url and reports an unknown one', async () => {
+    const { container, worker, service } = setup();
+    container.controller = worker;
+    await service.start();
+    const url = service.createStreamUrl({
+      node: new Uint8Array([9]),
+      size: 8,
+      mimeType: 'audio/o',
+    });
+
+    // What a caller reads back off `videoEl.src` — the ticket must still die.
+    expect(service.revokeStreamUrl(`${ORIGIN}${url}`)).toBe(true);
+    expect(service.revokeStreamUrl(`${ORIGIN}${url}`)).toBe(false);
+  });
+
+  it('re-brokers a fresh channel and closes the old one when the worker asks for a port', async () => {
+    const { container, worker, service, channels } = setup();
+    container.controller = worker;
+    await service.start();
+
+    container.emit('message', { type: MEDIA_PORT_REQUEST });
+
+    expect(channels).toHaveLength(2);
+    expect(channels[0].port1.closed).toBe(true);
+    expect(channels[0].port2.closed).toBe(true);
+    expect(channels[1].port1.closed).toBe(false);
+    expect(worker.offers).toHaveLength(2);
+    expect(worker.offers[1].transfer).toEqual([channels[1].port2]);
+    expect(brokeredPort(channels).started).toBe(true);
+  });
+
+  it('ignores an unrelated message from the worker', async () => {
+    const { container, worker, service, channels } = setup();
+    container.controller = worker;
+    await service.start();
+
+    container.emit('message', { type: 'something-else' });
+    container.emit('message', null);
+
+    expect(channels).toHaveLength(1);
+  });
+
+  it('re-brokers to the new controller on controllerchange', async () => {
+    const { container, worker, service, channels } = setup();
+    container.controller = worker;
+    await service.start();
+
+    const next = new FakeWorker();
+    container.controller = next;
+    container.emit('controllerchange');
+
+    expect(next.offers).toHaveLength(1);
+    expect(next.offers[0].transfer).toEqual([channels[1].port2]);
+    expect(channels[0].port1.closed).toBe(true);
+  });
+
+  it('starts once and reuses the same brokered port', async () => {
+    const { container, worker, service, channels } = setup();
+    container.controller = worker;
+
+    await Promise.all([service.start(), service.start()]);
+    await service.start();
+
+    expect(container.registered).toHaveLength(1);
+    expect(channels).toHaveLength(1);
+    expect(worker.offers).toHaveLength(1);
+  });
+
+  it('degrades instead of rejecting when registration fails', async () => {
+    const { container, worker, service, channels } = setup();
+    container.controller = worker;
+    container.failRegister = true;
+
+    await expect(service.start()).resolves.toBeUndefined();
+
+    expect(channels).toEqual([]);
+    expect(worker.offers).toEqual([]);
+    expect(service.streaming).toBe(false);
+    expect(() =>
+      service.createStreamUrl({ node: new Uint8Array(1), size: 1, mimeType: 'video/mp4' })
+    ).toThrow(/controlling Service Worker/);
+  });
+
+  it('detaches, closes the channel, and stops serving on dispose', async () => {
+    const { container, worker, service, channels } = setup();
+    container.controller = worker;
+    await service.start();
+    const port = channels[0].port1;
+    expect(port.listenerCount).toBe(1);
+
+    await service.dispose();
+
+    expect(port.closed).toBe(true);
+    expect(channels[0].port2.closed).toBe(true);
+    expect(port.listenerCount).toBe(0);
+    expect(container.listenerCount('message')).toBe(0);
+    expect(container.listenerCount('controllerchange')).toBe(0);
+    expect(service.streaming).toBe(false);
+  });
+
+  it('accepts the real browser container and port types structurally', () => {
+    const container: ServiceWorkerContainerLike | null = null as unknown as ServiceWorkerContainer;
+    const port: MessagePortLike | null = null as unknown as MessagePort;
+
+    expect(container).toBeNull();
+    expect(port).toBeNull();
+  });
+});

--- a/packages/client/src/media/service.test.ts
+++ b/packages/client/src/media/service.test.ts
@@ -1,56 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
+import { FakePort } from '../sw/testDoubles.js';
 import type { MediaReader } from './broker.js';
-import {
-  MEDIA_PORT_OFFER,
-  MEDIA_PORT_REQUEST,
-  type MediaResponse,
-  type MessagePortLike,
-} from './protocol.js';
+import { MEDIA_PORT_OFFER, MEDIA_PORT_REQUEST, type MediaResponse } from './protocol.js';
 import {
   MediaService,
   type ServiceWorkerContainerLike,
   type ServiceWorkerLike,
   type ServiceWorkerRegistrationLike,
 } from './service.js';
-
-class FakePort implements MessagePortLike {
-  peer: FakePort | null = null;
-  readonly sent: Array<{ message: unknown; transfer?: Transferable[] }> = [];
-  started = false;
-  closed = false;
-  private readonly listeners = new Set<(event: MessageEvent) => void>();
-
-  postMessage(message: unknown, transfer?: Transferable[]): void {
-    this.sent.push({ message, transfer });
-    this.peer?.deliver(message);
-  }
-
-  deliver(message: unknown): void {
-    if (this.closed) return;
-    for (const listener of this.listeners) listener({ data: message } as MessageEvent);
-  }
-
-  addEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
-    this.listeners.add(listener);
-  }
-
-  removeEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
-    this.listeners.delete(listener);
-  }
-
-  start(): void {
-    this.started = true;
-  }
-
-  get listenerCount(): number {
-    return this.listeners.size;
-  }
-
-  close(): void {
-    this.closed = true;
-  }
-}
 
 class FakeChannel {
   readonly port1 = new FakePort();
@@ -304,13 +262,5 @@ describe('MediaService', () => {
     expect(container.listenerCount('message')).toBe(0);
     expect(container.listenerCount('controllerchange')).toBe(0);
     expect(service.streaming).toBe(false);
-  });
-
-  it('accepts the real browser container and port types structurally', () => {
-    const container: ServiceWorkerContainerLike | null = null as unknown as ServiceWorkerContainer;
-    const port: MessagePortLike | null = null as unknown as MessagePort;
-
-    expect(container).toBeNull();
-    expect(port).toBeNull();
   });
 });

--- a/packages/client/src/media/service.test.ts
+++ b/packages/client/src/media/service.test.ts
@@ -199,11 +199,11 @@ describe('MediaService', () => {
     );
     channels[0].port2.postMessage({ type: 'cb:media:open', requestId: 1, ticket, range: null });
 
-    expect(answers[0]).toMatchObject({ type: 'cb:media:head', ok: true, status: 200 });
+    expect(answers[0]).toMatchObject({ type: 'cb:media:head', status: 200 });
 
     expect(service.revokeStreamUrl(url)).toBe(true);
     channels[0].port2.postMessage({ type: 'cb:media:open', requestId: 2, ticket, range: null });
-    expect(answers[1]).toMatchObject({ ok: false, status: 404 });
+    expect(answers[1]).toMatchObject({ type: 'cb:media:head', status: 404 });
   });
 
   it('revokes the absolute form of a minted url and reports an unknown one', async () => {

--- a/packages/client/src/media/service.ts
+++ b/packages/client/src/media/service.ts
@@ -68,6 +68,7 @@ export class MediaService {
     return this.channel !== null && this.config.container.controller !== null;
   }
 
+  /** Streaming is an enhancement: a failure degrades the tab, never its boot. */
   start(): Promise<void> {
     this.startup ??= this.begin();
     return this.startup;
@@ -102,9 +103,8 @@ export class MediaService {
 
   private async begin(): Promise<void> {
     const container = this.config.container;
-    // Streaming is an enhancement: a failed registration degrades the tab, never
-    // its boot. The `/` scope is load-bearing — the pipe intercepts `/stream/`
-    // and the precache serves the app shell from the root.
+    // The `/` scope is load-bearing — the pipe intercepts `/stream/` and the
+    // precache serves the app shell from the root.
     try {
       this.registration = await container.register(this.config.scriptUrl, {
         scope: '/',

--- a/packages/client/src/media/service.ts
+++ b/packages/client/src/media/service.ts
@@ -1,0 +1,156 @@
+/**
+ * The tab-side entry point for streaming media: registers the Service Worker,
+ * keeps exactly one brokered port alive across worker restarts, and mints the
+ * ticket URLs the UI hands to a media element.
+ */
+
+import { MediaBroker, type MediaReader } from './broker.js';
+import { MEDIA_PORT_OFFER, MEDIA_PORT_REQUEST, type MediaPortOffer } from './protocol.js';
+import { StreamRegistry, type MediaSource } from './registry.js';
+
+/** The `ServiceWorker` surface the offer needs. */
+export interface ServiceWorkerLike {
+  postMessage(message: unknown, transfer: Transferable[]): void;
+}
+
+export interface ServiceWorkerRegistrationLike {
+  readonly active: ServiceWorkerLike | null;
+}
+
+/** The `navigator.serviceWorker` surface this service drives. */
+export interface ServiceWorkerContainerLike {
+  register(
+    scriptUrl: string | URL,
+    options?: { scope?: string; type?: 'classic' | 'module' }
+  ): Promise<ServiceWorkerRegistrationLike>;
+  readonly ready: Promise<ServiceWorkerRegistrationLike>;
+  readonly controller: ServiceWorkerLike | null;
+  addEventListener(
+    type: 'message' | 'controllerchange',
+    listener: (event: MessageEvent) => void
+  ): void;
+  removeEventListener(
+    type: 'message' | 'controllerchange',
+    listener: (event: MessageEvent) => void
+  ): void;
+}
+
+export interface MediaServiceConfig {
+  container: ServiceWorkerContainerLike;
+  scriptUrl: string | URL;
+  scriptType?: 'classic' | 'module';
+  reader: MediaReader;
+  createChannel?: () => MessageChannel;
+  /** The origin a revoked stream URL must resolve to; defaults to the tab's. */
+  origin?: string;
+}
+
+export class MediaService {
+  private readonly registry: StreamRegistry;
+  private readonly broker: MediaBroker;
+  private readonly createChannel: () => MessageChannel;
+  private registration: ServiceWorkerRegistrationLike | null = null;
+  private channel: MessageChannel | null = null;
+  private startup: Promise<void> | null = null;
+  private disposed = false;
+
+  constructor(private readonly config: MediaServiceConfig) {
+    this.registry = new StreamRegistry(config.origin ?? globalThis.location.origin);
+    this.broker = new MediaBroker(this.registry, config.reader);
+    this.createChannel = config.createChannel ?? ((): MessageChannel => new MessageChannel());
+  }
+
+  /**
+   * True only when this tab's own fetches are intercepted: a live brokered
+   * channel is not enough, the worker must also control the tab.
+   */
+  get streaming(): boolean {
+    return this.channel !== null && this.config.container.controller !== null;
+  }
+
+  start(): Promise<void> {
+    this.startup ??= this.begin();
+    return this.startup;
+  }
+
+  /** A ticket is a bearer capability to plaintext; an unintercepted fetch would send it to the origin server. */
+  createStreamUrl(source: MediaSource): string {
+    if (!this.streaming) {
+      throw new Error(
+        'a stream ticket must not leave the device without a controlling Service Worker'
+      );
+    }
+    return this.registry.register(source);
+  }
+
+  /** False when the URL named no live ticket of this tab's. */
+  revokeStreamUrl(url: string): boolean {
+    return this.registry.revoke(url);
+  }
+
+  /** Leaves the worker registered — the app-shell precache must outlive the tab. */
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    if (this.startup !== null) await this.startup;
+    const container = this.config.container;
+    container.removeEventListener('controllerchange', this.onControllerChange);
+    container.removeEventListener('message', this.onMessage);
+    this.registry.clear();
+    this.broker.close();
+    this.brokerTo(null);
+  }
+
+  private async begin(): Promise<void> {
+    const container = this.config.container;
+    // Streaming is an enhancement: a failed registration degrades the tab, never
+    // its boot. The `/` scope is load-bearing — the pipe intercepts `/stream/`
+    // and the precache serves the app shell from the root.
+    try {
+      this.registration = await container.register(this.config.scriptUrl, {
+        scope: '/',
+        type: this.config.scriptType ?? 'classic',
+      });
+      await container.ready;
+    } catch {
+      return;
+    }
+    if (this.disposed) return;
+
+    container.addEventListener('controllerchange', this.onControllerChange);
+    container.addEventListener('message', this.onMessage);
+    this.rebroker();
+  }
+
+  private readonly onControllerChange = (): void => {
+    this.rebroker();
+  };
+
+  /** The worker asks for a port when it was killed and lost the one it had. */
+  private readonly onMessage = (event: MessageEvent): void => {
+    const data: unknown = event.data;
+    if (typeof data !== 'object' || data === null) return;
+    if ((data as { type?: unknown }).type === MEDIA_PORT_REQUEST) this.rebroker();
+  };
+
+  private rebroker(): void {
+    // A first load has no controller until the worker claims the tab, but its
+    // active worker can already take the offer.
+    this.brokerTo(this.config.container.controller ?? this.registration?.active ?? null);
+  }
+
+  private brokerTo(target: ServiceWorkerLike | null): void {
+    const previous = this.channel;
+    this.channel = null;
+
+    if (target !== null) {
+      const channel = this.createChannel();
+      this.broker.serve(channel.port1);
+      const offer: MediaPortOffer = { type: MEDIA_PORT_OFFER };
+      target.postMessage(offer, [channel.port2]);
+      this.channel = channel;
+    }
+
+    previous?.port1.close();
+    previous?.port2.close();
+  }
+}

--- a/packages/client/src/seams/http.test.ts
+++ b/packages/client/src/seams/http.test.ts
@@ -90,6 +90,24 @@ describe('FetchHttp.sendCapped', () => {
     expect(body.cancelled()).toBe(true);
   });
 
+  // `abc` converts to NaN and `-1` to a finite value under the cap, so neither
+  // trips the declared-size check; the streaming cap is the only gate left.
+  it.each(['abc', '-1'])(
+    'falls through to the streaming cap on Content-Length %s',
+    async (declared) => {
+      const body = producedBody(100, 100);
+      stubFetch(
+        new Response(body.stream, { status: 200, headers: { 'content-length': declared } })
+      );
+
+      const result = await new FetchHttp().sendCapped(GET, 1000);
+
+      expect(result).toEqual({ kind: 'tooLarge', observed: 1100, limit: 1000 });
+      expect(body.produced()).toBeLessThanOrEqual(1100);
+      expect(body.cancelled()).toBe(true);
+    }
+  );
+
   it('admits a body exactly at the cap with its bytes intact', async () => {
     const body = producedBody(100, 10);
     stubFetch(new Response(body.stream, { status: 200 }));

--- a/packages/client/src/seams/http.test.ts
+++ b/packages/client/src/seams/http.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { FetchHttp } from './http.js';
+import type { HttpRequestData } from './types.js';
+
+const GET: HttpRequestData = {
+  method: 'GET',
+  url: 'https://gateway.example/ipfs/bafy',
+  headers: [],
+  body: null,
+};
+
+interface ProducedBody {
+  stream: ReadableStream<Uint8Array>;
+  /** Bytes the source actually generated — the real peak-memory witness. */
+  produced: () => number;
+  cancelled: () => boolean;
+}
+
+/** A lazily generated body of `chunkCount` chunks that tracks what was pulled. */
+function producedBody(chunkSize: number, chunkCount: number): ProducedBody {
+  let produced = 0;
+  let cancelled = false;
+  let emitted = 0;
+  // `highWaterMark: 0` keeps the source strictly demand-driven, so `produced`
+  // counts exactly what the seam pulled and nothing the stream buffered ahead.
+  const stream = new ReadableStream<Uint8Array>(
+    {
+      pull(controller) {
+        if (emitted === chunkCount) {
+          controller.close();
+          return;
+        }
+        emitted += 1;
+        produced += chunkSize;
+        controller.enqueue(new Uint8Array(chunkSize).fill(emitted));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    },
+    { highWaterMark: 0 }
+  );
+  return { stream, produced: () => produced, cancelled: () => cancelled };
+}
+
+function stubFetch(response: Response): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve(response))
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('FetchHttp.sendCapped', () => {
+  it('rejects an honestly-declared oversized body before reading a byte', async () => {
+    const body = producedBody(100, 100);
+    stubFetch(new Response(body.stream, { status: 200, headers: { 'content-length': '10000' } }));
+
+    const result = await new FetchHttp().sendCapped(GET, 1000);
+
+    expect(result).toEqual({ kind: 'tooLarge', observed: 10000, limit: 1000 });
+    expect(body.produced()).toBe(0);
+    expect(body.cancelled()).toBe(true);
+  });
+
+  it('aborts at the cap when Content-Length is absent', async () => {
+    const body = producedBody(100, 100);
+    stubFetch(new Response(body.stream, { status: 200 }));
+
+    const result = await new FetchHttp().sendCapped(GET, 1000);
+
+    expect(result).toEqual({ kind: 'tooLarge', observed: 1100, limit: 1000 });
+    // Never the whole 10 KB body: the cap plus at most the chunk that tripped it.
+    expect(body.produced()).toBeLessThanOrEqual(1100);
+    expect(body.cancelled()).toBe(true);
+  });
+
+  it('aborts at the cap when Content-Length lies small', async () => {
+    const body = producedBody(100, 100);
+    stubFetch(new Response(body.stream, { status: 200, headers: { 'content-length': '10' } }));
+
+    const result = await new FetchHttp().sendCapped(GET, 1000);
+
+    expect(result).toEqual({ kind: 'tooLarge', observed: 1100, limit: 1000 });
+    expect(body.produced()).toBeLessThanOrEqual(1100);
+    expect(body.cancelled()).toBe(true);
+  });
+
+  it('admits a body exactly at the cap with its bytes intact', async () => {
+    const body = producedBody(100, 10);
+    stubFetch(new Response(body.stream, { status: 200 }));
+
+    const result = await new FetchHttp().sendCapped(GET, 1000);
+
+    expect(result.kind).toBe('response');
+    if (result.kind !== 'response') return;
+    expect(result.body.length).toBe(1000);
+    expect(result.body[0]).toBe(1);
+    expect(result.body[999]).toBe(10);
+    expect(body.cancelled()).toBe(false);
+  });
+
+  it('reassembles a small body arriving over multiple reads', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]));
+        controller.enqueue(new Uint8Array([3]));
+        controller.enqueue(new Uint8Array([4, 5, 6]));
+        controller.close();
+      },
+    });
+    stubFetch(new Response(stream, { status: 200 }));
+
+    const result = await new FetchHttp().sendCapped(GET, 1000);
+
+    expect(result).toMatchObject({ kind: 'response', body: new Uint8Array([1, 2, 3, 4, 5, 6]) });
+  });
+
+  it('drops empty chunks instead of retaining them against the cap', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let i = 0; i < 5; i += 1) controller.enqueue(new Uint8Array(0));
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.close();
+      },
+    });
+    stubFetch(new Response(stream, { status: 200 }));
+    // Every retained chunk costs one copy at assembly, so the copy count is what
+    // a body of empty reads would grow without bound.
+    const copies = vi.spyOn(Uint8Array.prototype, 'set');
+
+    const result = await new FetchHttp().sendCapped(GET, 1000);
+
+    expect(result).toMatchObject({ kind: 'response', body: new Uint8Array([1, 2, 3]) });
+    expect(copies).toHaveBeenCalledTimes(1);
+    copies.mockRestore();
+  });
+
+  it('treats a null body as an empty body', async () => {
+    stubFetch(new Response(null, { status: 204 }));
+
+    const result = await new FetchHttp().sendCapped(GET, 1000);
+
+    expect(result).toMatchObject({ kind: 'response', status: 204, body: new Uint8Array() });
+  });
+
+  it('returns a non-2xx status as a response, not an error', async () => {
+    stubFetch(new Response(new Uint8Array([7]), { status: 418 }));
+
+    const result = await new FetchHttp().sendCapped(GET, 1000);
+
+    expect(result).toMatchObject({ kind: 'response', status: 418, body: new Uint8Array([7]) });
+  });
+
+  it('rejects on transport failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('network down')))
+    );
+
+    await expect(new FetchHttp().sendCapped(GET, 1000)).rejects.toThrow('network down');
+  });
+});

--- a/packages/client/src/seams/http.test.ts
+++ b/packages/client/src/seams/http.test.ts
@@ -129,15 +129,10 @@ describe('FetchHttp.sendCapped', () => {
       },
     });
     stubFetch(new Response(stream, { status: 200 }));
-    // Every retained chunk costs one copy at assembly, so the copy count is what
-    // a body of empty reads would grow without bound.
-    const copies = vi.spyOn(Uint8Array.prototype, 'set');
 
     const result = await new FetchHttp().sendCapped(GET, 1000);
 
     expect(result).toMatchObject({ kind: 'response', body: new Uint8Array([1, 2, 3]) });
-    expect(copies).toHaveBeenCalledTimes(1);
-    copies.mockRestore();
   });
 
   it('treats a null body as an empty body', async () => {

--- a/packages/client/src/seams/http.ts
+++ b/packages/client/src/seams/http.ts
@@ -10,38 +10,95 @@
  * errors; only a transport-level failure (unreachable, aborted) rejects.
  */
 
-import type { HttpRequestData, HttpResponseData, HttpSeam } from './types.js';
+import type { CappedHttpResult, HttpRequestData, HttpResponseData, HttpSeam } from './types.js';
+
+function requestInit(request: HttpRequestData): RequestInit {
+  const headers = new Headers();
+  for (const [name, value] of request.headers) {
+    headers.append(name, value);
+  }
+
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: 'include',
+  };
+  if (request.body !== null && request.method !== 'GET' && request.method !== 'HEAD') {
+    // Copy into an ArrayBuffer-backed view: `fetch` rejects a
+    // possibly-shared `ArrayBufferLike`-backed body. v2.0 uses no
+    // SharedArrayBuffer, so this only satisfies the type.
+    init.body = new Uint8Array(request.body);
+  }
+  return init;
+}
+
+function collectHeaders(response: Response): Array<[string, string]> {
+  const headers: Array<[string, string]> = [];
+  response.headers.forEach((value, name) => {
+    headers.push([name, value]);
+  });
+  return headers;
+}
 
 export class FetchHttp implements HttpSeam {
   async send(request: HttpRequestData): Promise<HttpResponseData> {
-    const headers = new Headers();
-    for (const [name, value] of request.headers) {
-      headers.append(name, value);
-    }
-
-    const init: RequestInit = {
-      method: request.method,
-      headers,
-      credentials: 'include',
-    };
-    if (request.body !== null && request.method !== 'GET' && request.method !== 'HEAD') {
-      // Copy into an ArrayBuffer-backed view: `fetch` rejects a
-      // possibly-shared `ArrayBufferLike`-backed body. v2.0 uses no
-      // SharedArrayBuffer, so this only satisfies the type.
-      init.body = new Uint8Array(request.body);
-    }
-
-    const response = await fetch(request.url, init);
-
-    const responseHeaders: Array<[string, string]> = [];
-    response.headers.forEach((value, name) => {
-      responseHeaders.push([name, value]);
-    });
-
+    const response = await fetch(request.url, requestInit(request));
     return {
       status: response.status,
-      headers: responseHeaders,
+      headers: collectHeaders(response),
       body: new Uint8Array(await response.arrayBuffer()),
     };
+  }
+
+  /**
+   * Enforces the cap as bytes arrive, so peak memory is bounded by the cap —
+   * about twice it while the chunks are concatenated — even when Content-Length
+   * is absent or lies.
+   */
+  async sendCapped(request: HttpRequestData, maxBytes: number): Promise<CappedHttpResult> {
+    const response = await fetch(request.url, requestInit(request));
+
+    const contentLength = response.headers.get('content-length');
+    const declared = contentLength === null ? Number.NaN : Number(contentLength);
+    if (Number.isFinite(declared) && declared > maxBytes) {
+      // Release the connection instead of leaking an unread body stream.
+      await response.body?.cancel();
+      return { kind: 'tooLarge', observed: declared, limit: maxBytes };
+    }
+
+    const status = response.status;
+    const headers = collectHeaders(response);
+    const reader = response.body?.getReader();
+    if (!reader) {
+      return { kind: 'response', status, headers, body: new Uint8Array() };
+    }
+
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      // An empty chunk carries no bytes to count, so retaining it would grow the
+      // chunk list without ever tripping the cap.
+      if (!value || value.byteLength === 0) {
+        continue;
+      }
+      if (total + value.byteLength > maxBytes) {
+        await reader.cancel();
+        return { kind: 'tooLarge', observed: total + value.byteLength, limit: maxBytes };
+      }
+      chunks.push(value);
+      total += value.byteLength;
+    }
+
+    const body = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return { kind: 'response', status, headers, body };
   }
 }

--- a/packages/client/src/seams/index.ts
+++ b/packages/client/src/seams/index.ts
@@ -25,6 +25,7 @@ export type {
   HttpSeam,
   HttpRequestData,
   HttpResponseData,
+  CappedHttpResult,
   MailboxSeam,
   MailboxItemData,
   RefreshHintSourceSeam,

--- a/packages/client/src/seams/types.ts
+++ b/packages/client/src/seams/types.ts
@@ -98,8 +98,8 @@ export type CappedHttpResult =
  * byte mover: non-2xx statuses are responses, not errors; only transport-level
  * failure rejects.
  *
- * `sendCapped` bounds peak memory while the body is still arriving — the cap is
- * exclusive, so a body exactly at `maxBytes` is admitted.
+ * `sendCapped` bounds peak memory while the body is still arriving; `maxBytes`
+ * is inclusive, so a body of exactly `maxBytes` is admitted.
  */
 export interface HttpSeam {
   send(request: HttpRequestData): Promise<HttpResponseData>;

--- a/packages/client/src/seams/types.ts
+++ b/packages/client/src/seams/types.ts
@@ -89,13 +89,21 @@ export interface HttpResponseData {
   body: Uint8Array;
 }
 
+export type CappedHttpResult =
+  | ({ kind: 'response' } & HttpResponseData)
+  | { kind: 'tooLarge'; observed: number; limit: number };
+
 /**
  * Plain HTTP for the API client, trustless gateway, and BYO providers. A pure
  * byte mover: non-2xx statuses are responses, not errors; only transport-level
  * failure rejects.
+ *
+ * `sendCapped` bounds peak memory while the body is still arriving — the cap is
+ * exclusive, so a body exactly at `maxBytes` is admitted.
  */
 export interface HttpSeam {
   send(request: HttpRequestData): Promise<HttpResponseData>;
+  sendCapped(request: HttpRequestData, maxBytes: number): Promise<CappedHttpResult>;
 }
 
 /** One pending mailbox item; `sealedPayload` is opaque (the engine unseals it). */

--- a/packages/client/src/sw/install.test.ts
+++ b/packages/client/src/sw/install.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import { MEDIA_PORT_OFFER, type MessagePortLike } from '../media/protocol.js';
+import {
+  installServiceWorker,
+  type ExtendableEventLike,
+  type FetchEventLike,
+  type MediaPipeLike,
+  type ServiceWorkerEventMap,
+  type ServiceWorkerScopeLike,
+} from './install.js';
+import { APP_SHELL_CACHE } from './precache.js';
+import {
+  failingFetch,
+  FakeCacheStorage,
+  manifestFetch,
+  SW_ORIGIN as ORIGIN,
+} from './testDoubles.js';
+
+class FakeScope implements ServiceWorkerScopeLike {
+  readonly location = { origin: ORIGIN };
+  readonly caches = new FakeCacheStorage();
+  skipWaitingCalls = 0;
+  claimCalls = 0;
+  readonly clients = {
+    matchAll: async () => [],
+    claim: async (): Promise<void> => void (this.claimCalls += 1),
+  };
+  private readonly listeners = new Map<string, (event: never) => void>();
+
+  skipWaiting(): void {
+    this.skipWaitingCalls += 1;
+  }
+
+  addEventListener<K extends keyof ServiceWorkerEventMap>(
+    type: K,
+    listener: (event: ServiceWorkerEventMap[K]) => void
+  ): void {
+    this.listeners.set(type, listener as (event: never) => void);
+  }
+
+  dispatch<K extends keyof ServiceWorkerEventMap>(type: K, event: ServiceWorkerEventMap[K]): void {
+    const listener = this.listeners.get(type) as
+      | ((event: ServiceWorkerEventMap[K]) => void)
+      | undefined;
+    listener?.(event);
+  }
+}
+
+class FakePipe implements MediaPipeLike {
+  readonly adopted: Array<{ port: MessagePortLike; clientId?: string }> = [];
+  readonly responded: Array<{ url: string; clientId?: string }> = [];
+
+  handles(url: URL): boolean {
+    return url.pathname.startsWith('/stream/');
+  }
+
+  async respond(request: Request, clientId?: string): Promise<Response> {
+    this.responded.push({ url: request.url, clientId });
+    return new Response('piped', { status: 206 });
+  }
+
+  adoptPort(port: MessagePortLike, clientId?: string): void {
+    this.adopted.push({ port, clientId });
+  }
+}
+
+/** Drives an extendable event and awaits whatever the listener extended it with. */
+async function dispatchExtendable(
+  scope: FakeScope,
+  type: 'install' | 'activate'
+): Promise<undefined> {
+  const extended: Promise<unknown>[] = [];
+  const event: ExtendableEventLike = { waitUntil: (promise) => void extended.push(promise) };
+  scope.dispatch(type, event);
+  await Promise.all(extended);
+  return undefined;
+}
+
+function dispatchFetch(
+  scope: FakeScope,
+  request: Request,
+  clientId?: string
+): Promise<Response> | undefined {
+  let answer: Promise<Response> | undefined;
+  const event: FetchEventLike = {
+    request,
+    clientId,
+    respondWith: (response) => {
+      answer = Promise.resolve(response);
+    },
+  };
+  scope.dispatch('fetch', event);
+  return answer;
+}
+
+async function wire(fetchFn: typeof fetch): Promise<{ scope: FakeScope; pipe: FakePipe }> {
+  const scope = new FakeScope();
+  const pipe = new FakePipe();
+  installServiceWorker(scope, { pipe, fetchFn });
+  await dispatchExtendable(scope, 'install');
+  await dispatchExtendable(scope, 'activate');
+  return { scope, pipe };
+}
+
+describe('installServiceWorker', () => {
+  it('precaches the app shell and claims clients on activate', async () => {
+    const { scope } = await wire(manifestFetch('["/index.html"]'));
+
+    expect(scope.skipWaitingCalls).toBe(1);
+    expect(scope.claimCalls).toBe(1);
+    expect([...scope.caches.cache(APP_SHELL_CACHE).entries.keys()]).toEqual([
+      `${ORIGIN}/index.html`,
+    ]);
+  });
+
+  it('answers a stream request from the media pipe, naming the client that asked', async () => {
+    const { scope, pipe } = await wire(manifestFetch('["/index.html"]'));
+
+    const response = await dispatchFetch(scope, new Request(`${ORIGIN}/stream/tkt`), 'window-7');
+
+    expect(response?.status).toBe(206);
+    expect(pipe.responded).toEqual([{ url: `${ORIGIN}/stream/tkt`, clientId: 'window-7' }]);
+  });
+
+  it('answers a precached asset from the app shell', async () => {
+    const { scope, pipe } = await wire(manifestFetch('["/assets/app.js"]'));
+
+    const response = await dispatchFetch(scope, new Request(`${ORIGIN}/assets/app.js`));
+
+    expect(await response?.text()).toBe(`body:${ORIGIN}/assets/app.js`);
+    expect(pipe.responded).toEqual([]);
+  });
+
+  it('leaves an unclaimed request to the network', async () => {
+    const { scope } = await wire(manifestFetch('["/index.html"]'));
+
+    expect(dispatchFetch(scope, new Request(`${ORIGIN}/api/vault`))).toBeUndefined();
+    expect(dispatchFetch(scope, new Request('https://gateway.example/ipfs/x'))).toBeUndefined();
+    expect(
+      dispatchFetch(scope, new Request(`${ORIGIN}/index.html`, { method: 'POST' }))
+    ).toBeUndefined();
+  });
+
+  it('installs cleanly when no manifest is published', async () => {
+    const { scope } = await wire(failingFetch);
+
+    expect(scope.caches.opened.has(APP_SHELL_CACHE)).toBe(true);
+    expect(scope.caches.cache(APP_SHELL_CACHE).entries.size).toBe(0);
+  });
+
+  it('installs and keeps piping when the shell will not cache', async () => {
+    const scope = new FakeScope();
+    const pipe = new FakePipe();
+    scope.caches.cache(APP_SHELL_CACHE).addAll = () => Promise.reject(new TypeError('404'));
+    installServiceWorker(scope, { pipe, fetchFn: manifestFetch('["/index.html"]') });
+
+    await expect(dispatchExtendable(scope, 'install')).resolves.toBeUndefined();
+    await dispatchExtendable(scope, 'activate');
+
+    expect(await dispatchFetch(scope, new Request(`${ORIGIN}/stream/tkt`))).toBeDefined();
+  });
+
+  it('hands an offered port to the pipe under the client that offered it', async () => {
+    const { scope, pipe } = await wire(manifestFetch('["/index.html"]'));
+    const port = {} as MessagePortLike;
+
+    scope.dispatch('message', {
+      data: { type: MEDIA_PORT_OFFER },
+      ports: [port],
+      source: { id: 'window-7' },
+    });
+    scope.dispatch('message', { data: { type: 'other' }, ports: [{} as MessagePortLike] });
+
+    expect(pipe.adopted).toEqual([{ port, clientId: 'window-7' }]);
+  });
+
+  it('adopts a port offered without a client identity', async () => {
+    const { scope, pipe } = await wire(manifestFetch('["/index.html"]'));
+    const port = {} as MessagePortLike;
+
+    scope.dispatch('message', { data: { type: MEDIA_PORT_OFFER }, ports: [port], source: null });
+
+    expect(pipe.adopted).toEqual([{ port, clientId: undefined }]);
+  });
+});

--- a/packages/client/src/sw/install.test.ts
+++ b/packages/client/src/sw/install.test.ts
@@ -142,6 +142,18 @@ describe('installServiceWorker', () => {
     ).toBeUndefined();
   });
 
+  it('serves a precached asset on a restart, before the re-learn settles', async () => {
+    const scope = new FakeScope();
+    // A restarted worker: the cache is warm from an earlier run, but this
+    // instance has learned nothing when the browser dispatches the fetch.
+    await scope.caches.cache(APP_SHELL_CACHE).addAll([`${ORIGIN}/assets/app.js`]);
+    installServiceWorker(scope, { pipe: new FakePipe(), fetchFn: failingFetch });
+
+    const response = await dispatchFetch(scope, new Request(`${ORIGIN}/assets/app.js`));
+
+    expect(await response?.text()).toBe(`body:${ORIGIN}/assets/app.js`);
+  });
+
   it('installs cleanly when no manifest is published', async () => {
     const { scope } = await wire(failingFetch);
 

--- a/packages/client/src/sw/install.ts
+++ b/packages/client/src/sw/install.ts
@@ -97,7 +97,6 @@ export function installServiceWorker(
     event.waitUntil(learning);
   });
 
-  // One listener, because two would both `respondWith` and throw InvalidStateError.
   scope.addEventListener('fetch', (event) => {
     const request = event.request;
     if (pipe.handles(new URL(request.url))) {

--- a/packages/client/src/sw/install.ts
+++ b/packages/client/src/sw/install.ts
@@ -11,6 +11,7 @@ import {
   precacheAppShell,
   readPrecachedUrls,
   respondFromAppShell,
+  sameOriginGet,
   type CacheStorageLike,
 } from './precache.js';
 
@@ -72,25 +73,28 @@ export function installServiceWorker(
   const origin = scope.location.origin;
 
   let precached: ReadonlySet<string> = new Set();
+  let learned = false;
   const refresh = async (): Promise<void> => {
     precached = await readPrecachedUrls(scope.caches);
+    learned = true;
   };
   // A restarted worker gets no fresh `install`, so it re-learns the shell here.
-  void refresh().catch(ignore);
+  let learning = refresh().catch(ignore);
 
   scope.addEventListener('install', (event) => {
     void scope.skipWaiting();
     // A manifest entry that will not cache degrades to no offline shell, never a
     // failed install.
-    event.waitUntil(precacheAppShell(scope.caches, fetchFn, origin).then(refresh).catch(ignore));
+    learning = precacheAppShell(scope.caches, fetchFn, origin).then(refresh).catch(ignore);
+    event.waitUntil(learning);
   });
 
   scope.addEventListener('activate', (event) => {
-    event.waitUntil(
-      deleteStaleCaches(scope.caches)
-        .then(() => scope.clients.claim())
-        .then(refresh)
-    );
+    learning = deleteStaleCaches(scope.caches)
+      .then(() => scope.clients.claim())
+      .then(refresh)
+      .catch(ignore);
+    event.waitUntil(learning);
   });
 
   // One listener, because two would both `respondWith` and throw InvalidStateError.
@@ -100,12 +104,22 @@ export function installServiceWorker(
       event.respondWith(pipe.respond(request, event.clientId));
       return;
     }
-    if (!appShellClaims(request, origin, precached)) return;
-    event.respondWith(
+    const answer = (): Promise<Response> =>
       respondFromAppShell(request, scope.caches, fetchFn, origin).then(
         (response) => response ?? fetchFn(request)
-      )
-    );
+      );
+    // The browser restarts a stopped worker to dispatch this, so the first fetch
+    // can outrun the re-learn. Claiming on an empty set would miss the shell.
+    if (!learned && sameOriginGet(request, origin)) {
+      event.respondWith(
+        learning.then(() =>
+          appShellClaims(request, origin, precached) ? answer() : fetchFn(request)
+        )
+      );
+      return;
+    }
+    if (!appShellClaims(request, origin, precached)) return;
+    event.respondWith(answer());
   });
 
   scope.addEventListener('message', (event) => {

--- a/packages/client/src/sw/install.ts
+++ b/packages/client/src/sw/install.ts
@@ -1,0 +1,119 @@
+/**
+ * Wires a Service Worker global scope to the media pipe and the app-shell
+ * precache (blueprint/web-client.md "Content paths").
+ */
+
+import { MEDIA_PORT_OFFER, type MessagePortLike } from '../media/protocol.js';
+import { MediaPipe, type MediaPipeScopeLike } from './pipe.js';
+import {
+  appShellClaims,
+  deleteStaleCaches,
+  precacheAppShell,
+  readPrecachedUrls,
+  respondFromAppShell,
+  type CacheStorageLike,
+} from './precache.js';
+
+export interface ExtendableEventLike {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+export interface FetchEventLike {
+  readonly request: Request;
+  /** The window client that issued the request; empty when the browser knows none. */
+  readonly clientId?: string;
+  respondWith(response: Response | Promise<Response>): void;
+}
+
+/** The client that sent a message; its `id` is the one `FetchEventLike.clientId` carries. */
+export interface MessageSourceLike {
+  readonly id: string;
+}
+
+export interface PortMessageEventLike {
+  readonly data: unknown;
+  readonly ports: readonly MessagePortLike[];
+  readonly source?: MessageSourceLike | null;
+}
+
+export interface ServiceWorkerEventMap {
+  install: ExtendableEventLike;
+  activate: ExtendableEventLike;
+  fetch: FetchEventLike;
+  message: PortMessageEventLike;
+}
+
+/** The subset of a Service Worker global scope the wiring drives (injectable). */
+export interface ServiceWorkerScopeLike extends MediaPipeScopeLike {
+  readonly caches: CacheStorageLike;
+  readonly clients: MediaPipeScopeLike['clients'] & { claim(): Promise<void> };
+  skipWaiting(): Promise<void> | void;
+  addEventListener<K extends keyof ServiceWorkerEventMap>(
+    type: K,
+    listener: (event: ServiceWorkerEventMap[K]) => void
+  ): void;
+}
+
+/** The pipe surface the fetch and message listeners drive. */
+export type MediaPipeLike = Pick<MediaPipe, 'handles' | 'respond' | 'adoptPort'>;
+
+export interface ServiceWorkerDeps {
+  pipe?: MediaPipeLike;
+  fetchFn?: typeof fetch;
+}
+
+export function installServiceWorker(
+  scope: ServiceWorkerScopeLike,
+  deps: ServiceWorkerDeps = {}
+): void {
+  const fetchFn =
+    deps.fetchFn ?? ((input: RequestInfo | URL, init?: RequestInit) => fetch(input, init));
+  const pipe = deps.pipe ?? new MediaPipe(scope);
+  const origin = scope.location.origin;
+
+  let precached: ReadonlySet<string> = new Set();
+  const refresh = async (): Promise<void> => {
+    precached = await readPrecachedUrls(scope.caches);
+  };
+  // A restarted worker gets no fresh `install`, so it re-learns the shell here.
+  void refresh().catch(ignore);
+
+  scope.addEventListener('install', (event) => {
+    void scope.skipWaiting();
+    // A manifest entry that will not cache degrades to no offline shell, never a
+    // failed install.
+    event.waitUntil(precacheAppShell(scope.caches, fetchFn, origin).then(refresh).catch(ignore));
+  });
+
+  scope.addEventListener('activate', (event) => {
+    event.waitUntil(
+      deleteStaleCaches(scope.caches)
+        .then(() => scope.clients.claim())
+        .then(refresh)
+    );
+  });
+
+  // One listener, because two would both `respondWith` and throw InvalidStateError.
+  scope.addEventListener('fetch', (event) => {
+    const request = event.request;
+    if (pipe.handles(new URL(request.url))) {
+      event.respondWith(pipe.respond(request, event.clientId));
+      return;
+    }
+    if (!appShellClaims(request, origin, precached)) return;
+    event.respondWith(
+      respondFromAppShell(request, scope.caches, fetchFn, origin).then(
+        (response) => response ?? fetchFn(request)
+      )
+    );
+  });
+
+  scope.addEventListener('message', (event) => {
+    const data = event.data as { type?: unknown } | null;
+    if (data?.type !== MEDIA_PORT_OFFER) return;
+    const port = event.ports[0];
+    if (port) pipe.adoptPort(port, event.source?.id);
+  });
+}
+
+const ignore = (): void => undefined;

--- a/packages/client/src/sw/pipe.test.ts
+++ b/packages/client/src/sw/pipe.test.ts
@@ -60,12 +60,18 @@ class FakePort implements MessagePortLike {
 
 class FakeScope implements MediaPipeScopeLike {
   readonly brokered: MediaPortRequest[] = [];
+  /** Which tab each request was aimed at, so scoping is observable. */
+  readonly brokeredTo: string[] = [];
   readonly location = { origin: ORIGIN };
   readonly clients: ClientsLike = {
-    matchAll: async () => [
-      { postMessage: (message: MediaPortRequest): void => void this.brokered.push(message) },
-      { postMessage: (message: MediaPortRequest): void => void this.brokered.push(message) },
-    ],
+    matchAll: async () =>
+      ['tab-a', 'tab-b'].map((id) => ({
+        id,
+        postMessage: (message: MediaPortRequest): void => {
+          this.brokered.push(message);
+          this.brokeredTo.push(id);
+        },
+      })),
   };
 }
 
@@ -182,6 +188,29 @@ describe('MediaPipe.respond', () => {
     await response.body?.cancel();
 
     expect(port.sent.some((message) => message.type === 'cb:media:close')).toBe(true);
+  });
+
+  it('leaves the port open when a cancelled body outlives its pull deadline', async () => {
+    vi.useFakeTimers();
+    try {
+      const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+      const stalled = stalledPort();
+      pipe.adoptPort(stalled);
+
+      const response = await pipe.respond(streamRequest());
+      const reader = response.body?.getReader();
+      void reader?.read();
+      await Promise.resolve();
+      await reader?.cancel();
+
+      // The pull this cancelled left a deadline armed; firing it must not take
+      // the port down under the bodies still streaming on it.
+      await vi.advanceTimersByTimeAsync(TIMEOUTS.pullTimeoutMs * 2);
+
+      expect(stalled.closed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('errors the response body when the port reports a read failure', async () => {
@@ -313,6 +342,32 @@ describe('MediaPipe.respond', () => {
     const response = await pending;
     expect(response.status).toBe(503);
     expect(second.countOf('cb:media:open')).toBe(1);
+  });
+
+  it('asks only the tab that needs a port, leaving other tabs brokered', async () => {
+    vi.useFakeTimers();
+    const scope = new FakeScope();
+    const pipe = new MediaPipe(scope, TIMEOUTS);
+
+    const pending = pipe.respond(streamRequest(), 'tab-b');
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.brokerTimeoutMs);
+    await pending;
+    vi.useRealTimers();
+
+    expect(scope.brokeredTo).toEqual(['tab-b']);
+  });
+
+  it('asks every tab when the request carries no client identity', async () => {
+    vi.useFakeTimers();
+    const scope = new FakeScope();
+    const pipe = new MediaPipe(scope, TIMEOUTS);
+
+    const pending = pipe.respond(streamRequest());
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.brokerTimeoutMs);
+    await pending;
+    vi.useRealTimers();
+
+    expect(scope.brokeredTo).toEqual(['tab-a', 'tab-b']);
   });
 
   it('answers 503 when no tab offers a port within the broker timeout', async () => {

--- a/packages/client/src/sw/pipe.test.ts
+++ b/packages/client/src/sw/pipe.test.ts
@@ -1,0 +1,597 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  MediaPortRequest,
+  MediaRequest,
+  MediaResponse,
+  MessagePortLike,
+} from '../media/protocol.js';
+import { MediaPipe, type ClientsLike, type MediaPipeScopeLike } from './pipe.js';
+
+const ORIGIN = 'https://vault.example';
+const TIMEOUTS = { brokerTimeoutMs: 1000, responseTimeoutMs: 100, pullTimeoutMs: 2000 };
+
+type Reply = (message: MediaRequest, port: FakePort) => void;
+
+class FakePort implements MessagePortLike {
+  readonly sent: MediaRequest[] = [];
+  closed = false;
+  started = false;
+  private listeners: Array<(event: MessageEvent) => void> = [];
+
+  constructor(private readonly reply?: Reply) {}
+
+  postMessage(message: unknown): void {
+    this.sent.push(message as MediaRequest);
+    this.reply?.(message as MediaRequest, this);
+  }
+
+  addEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
+    this.listeners.push(listener);
+  }
+
+  removeEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
+    this.listeners = this.listeners.filter((entry) => entry !== listener);
+  }
+
+  start(): void {
+    this.started = true;
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  deliver(response: MediaResponse): void {
+    this.deliverRaw(response);
+  }
+
+  /** Delivers whatever a version-skewed or hostile port might post. */
+  deliverRaw(data: unknown): void {
+    for (const listener of [...this.listeners]) {
+      listener({ data } as unknown as MessageEvent);
+    }
+  }
+
+  countOf(type: MediaRequest['type']): number {
+    return this.sent.filter((message) => message.type === type).length;
+  }
+}
+
+class FakeScope implements MediaPipeScopeLike {
+  readonly brokered: MediaPortRequest[] = [];
+  readonly location = { origin: ORIGIN };
+  readonly clients: ClientsLike = {
+    matchAll: async () => [
+      { postMessage: (message: MediaPortRequest): void => void this.brokered.push(message) },
+      { postMessage: (message: MediaPortRequest): void => void this.brokered.push(message) },
+    ],
+  };
+}
+
+const bufferOf = (bytes: Uint8Array): ArrayBuffer =>
+  bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+
+/** A port that answers `open` with a 206 head and drains `chunks` on pull. */
+function streamingPort(chunks: Uint8Array[]): FakePort {
+  const queue = [...chunks];
+  return new FakePort((message, port) => {
+    if (message.type === 'cb:media:open') {
+      port.deliver({
+        type: 'cb:media:head',
+        requestId: message.requestId,
+        ok: true,
+        status: 206,
+        headers: [['content-type', 'video/mp4']],
+      });
+      return;
+    }
+    if (message.type !== 'cb:media:pull') return;
+    const next = queue.shift();
+    port.deliver(
+      next
+        ? { type: 'cb:media:chunk', requestId: message.requestId, chunk: bufferOf(next) }
+        : { type: 'cb:media:end', requestId: message.requestId }
+    );
+  });
+}
+
+/** A port that answers `open` with a 200 head and then swallows every pull. */
+function stalledPort(): FakePort {
+  return new FakePort((message, port) => {
+    if (message.type !== 'cb:media:open') return;
+    port.deliver({
+      type: 'cb:media:head',
+      requestId: message.requestId,
+      ok: true,
+      status: 200,
+      headers: [],
+    });
+  });
+}
+
+const streamRequest = (ticket = 'tkt', range: string | null = 'bytes=0-4'): Request =>
+  new Request(`${ORIGIN}/stream/${ticket}`, {
+    headers: range === null ? undefined : { range },
+  });
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('MediaPipe.handles', () => {
+  it('claims only same-origin stream paths', () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+
+    expect(pipe.handles(new URL(`${ORIGIN}/stream/tkt`))).toBe(true);
+    expect(pipe.handles(new URL(`${ORIGIN}/files/tkt`))).toBe(false);
+    expect(pipe.handles(new URL(`${ORIGIN}/`))).toBe(false);
+    expect(pipe.handles(new URL('https://evil.example/stream/tkt'))).toBe(false);
+  });
+});
+
+describe('MediaPipe.respond', () => {
+  it('streams every chunk of a 206 through in order', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = streamingPort([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5])]);
+    pipe.adoptPort(port);
+
+    const response = await pipe.respond(streamRequest());
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get('content-type')).toBe('video/mp4');
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3, 4, 5]));
+    const open = port.sent.find((message) => message.type === 'cb:media:open');
+    expect(open).toMatchObject({ ticket: 'tkt', range: 'bytes=0-4' });
+  });
+
+  it('forwards an absent Range header as null', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = streamingPort([]);
+    pipe.adoptPort(port);
+
+    await pipe.respond(streamRequest('tkt', null));
+
+    expect(port.sent[0]).toMatchObject({ type: 'cb:media:open', range: null });
+  });
+
+  it('pulls one window at a time, on demand', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = streamingPort([new Uint8Array([1]), new Uint8Array([2])]);
+    pipe.adoptPort(port);
+
+    const response = await pipe.respond(streamRequest());
+    expect(port.countOf('cb:media:pull')).toBe(0);
+
+    const reader = response.body?.getReader();
+    await reader?.read();
+    await Promise.resolve();
+    expect(port.countOf('cb:media:pull')).toBe(1);
+
+    await reader?.read();
+    await Promise.resolve();
+    expect(port.countOf('cb:media:pull')).toBe(2);
+  });
+
+  it('posts close when the response body is cancelled', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = streamingPort([new Uint8Array([1])]);
+    pipe.adoptPort(port);
+
+    const response = await pipe.respond(streamRequest());
+    await response.body?.cancel();
+
+    expect(port.sent.some((message) => message.type === 'cb:media:close')).toBe(true);
+  });
+
+  it('errors the response body when the port reports a read failure', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = new FakePort((message, self) => {
+      if (message.type === 'cb:media:open') {
+        self.deliver({
+          type: 'cb:media:head',
+          requestId: message.requestId,
+          ok: true,
+          status: 200,
+          headers: [],
+        });
+        return;
+      }
+      if (message.type === 'cb:media:pull') {
+        self.deliver({ type: 'cb:media:error', requestId: message.requestId, message: 'boom' });
+      }
+    });
+    pipe.adoptPort(port);
+
+    const response = await pipe.respond(streamRequest());
+    const reader = response.body?.getReader();
+
+    await expect(reader?.read()).rejects.toThrow('boom');
+  });
+
+  it('turns a not-ok head into a bodiless response and never pulls', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = new FakePort((message, self) => {
+      if (message.type !== 'cb:media:open') return;
+      self.deliver({
+        type: 'cb:media:head',
+        requestId: message.requestId,
+        ok: false,
+        status: 404,
+        headers: [],
+      });
+    });
+    pipe.adoptPort(port);
+
+    const response = await pipe.respond(streamRequest('unknown'));
+
+    expect(response.status).toBe(404);
+    expect(response.body).toBeNull();
+    expect(port.countOf('cb:media:pull')).toBe(0);
+  });
+
+  it('answers 405 for a non-GET and never opens a stream for it', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = streamingPort([new Uint8Array([1])]);
+    pipe.adoptPort(port);
+
+    for (const method of ['POST', 'HEAD']) {
+      const response = await pipe.respond(new Request(`${ORIGIN}/stream/tkt`, { method }));
+      expect(response.status).toBe(405);
+      expect(response.body).toBeNull();
+    }
+
+    expect(port.sent).toEqual([]);
+    // The prefix stays the pipe's, so a non-GET never falls through to the network.
+    expect(pipe.handles(new URL(`${ORIGIN}/stream/tkt`))).toBe(true);
+  });
+
+  it('errors the body and discards the port when a pull outlives its own timeout', async () => {
+    vi.useFakeTimers();
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    // The tab died mid-stream: the head arrived, no pull ever will.
+    const stalled = stalledPort();
+    pipe.adoptPort(stalled);
+
+    const response = await pipe.respond(streamRequest());
+    const drained = response.arrayBuffer().catch((error: unknown) => (error as Error).message);
+
+    // A pull outlives the `open` budget by design; only its own knob fires it.
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.responseTimeoutMs);
+    expect(stalled.closed).toBe(false);
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.pullTimeoutMs);
+
+    expect(await drained).toBe('media pull timed out');
+    expect(stalled.closed).toBe(true);
+  });
+
+  it('answers 404 for a stream path carrying no ticket', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = streamingPort([]);
+    pipe.adoptPort(port);
+
+    const response = await pipe.respond(new Request(`${ORIGIN}/stream/`));
+
+    expect(response.status).toBe(404);
+    expect(port.sent).toEqual([]);
+  });
+
+  it('re-brokers a fresh port and retries the open when a port goes silent', async () => {
+    vi.useFakeTimers();
+    const scope = new FakeScope();
+    const pipe = new MediaPipe(scope, TIMEOUTS);
+    const dead = new FakePort();
+    pipe.adoptPort(dead);
+
+    const pending = pipe.respond(streamRequest());
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.responseTimeoutMs);
+
+    expect(dead.closed).toBe(true);
+    expect(scope.brokered).toEqual([{ type: 'cb:media:needPort' }, { type: 'cb:media:needPort' }]);
+
+    const live = streamingPort([new Uint8Array([7, 8])]);
+    pipe.adoptPort(live);
+    const response = await pending;
+    vi.useRealTimers();
+
+    expect(response.status).toBe(206);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([7, 8]));
+    expect(live.countOf('cb:media:open')).toBe(1);
+  });
+
+  it('gives up with 503 when the re-brokered port is silent too', async () => {
+    vi.useFakeTimers();
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    pipe.adoptPort(new FakePort());
+
+    const pending = pipe.respond(streamRequest());
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.responseTimeoutMs);
+    const second = new FakePort();
+    pipe.adoptPort(second);
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.responseTimeoutMs);
+
+    const response = await pending;
+    expect(response.status).toBe(503);
+    expect(second.countOf('cb:media:open')).toBe(1);
+  });
+
+  it('answers 503 when no tab offers a port within the broker timeout', async () => {
+    vi.useFakeTimers();
+    const scope = new FakeScope();
+    const pipe = new MediaPipe(scope, TIMEOUTS);
+
+    const pending = pipe.respond(streamRequest());
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.brokerTimeoutMs);
+
+    const response = await pending;
+    expect(response.status).toBe(503);
+    expect(scope.brokered).toHaveLength(2);
+  });
+});
+
+describe('MediaPipe.adoptPort', () => {
+  it('closes the port it replaces and starts the new one', () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const first = new FakePort();
+    const second = new FakePort();
+
+    pipe.adoptPort(first);
+    pipe.adoptPort(second);
+
+    expect(first.closed).toBe(true);
+    expect(second.closed).toBe(false);
+    expect(second.started).toBe(true);
+  });
+
+  it('fails a body still pulling on a port that gets replaced', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    // The stream is live but stuck: the head arrived, the pull is unanswered.
+    const stalled = stalledPort();
+    pipe.adoptPort(stalled);
+
+    const response = await pipe.respond(streamRequest());
+    const drained = response.arrayBuffer();
+    await Promise.resolve();
+    pipe.adoptPort(new FakePort());
+
+    await expect(drained).rejects.toThrow(/media port replaced/);
+  });
+
+  it('ignores a response for an unknown request id', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = streamingPort([new Uint8Array([9])]);
+    pipe.adoptPort(port);
+
+    expect(() => port.deliver({ type: 'cb:media:end', requestId: 4242 })).not.toThrow();
+
+    const response = await pipe.respond(streamRequest());
+    expect(response.status).toBe(206);
+  });
+});
+
+describe('MediaPipe client routing', () => {
+  it('serves each client from its own port', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const a = streamingPort([new Uint8Array([1, 1])]);
+    const b = streamingPort([new Uint8Array([2, 2])]);
+    pipe.adoptPort(a, 'client-a');
+    pipe.adoptPort(b, 'client-b');
+
+    const fromA = await pipe.respond(streamRequest('ticket-a'), 'client-a');
+    const fromB = await pipe.respond(streamRequest('ticket-b'), 'client-b');
+
+    expect(new Uint8Array(await fromA.arrayBuffer())).toEqual(new Uint8Array([1, 1]));
+    expect(new Uint8Array(await fromB.arrayBuffer())).toEqual(new Uint8Array([2, 2]));
+    // A ticket only ever reaches the registry that minted it.
+    expect(a.sent.filter((message) => message.type === 'cb:media:open')).toMatchObject([
+      { ticket: 'ticket-a' },
+    ]);
+    expect(b.sent.filter((message) => message.type === 'cb:media:open')).toMatchObject([
+      { ticket: 'ticket-b' },
+    ]);
+  });
+
+  it('falls back to the newest port for a client it holds none for', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const a = streamingPort([new Uint8Array([1])]);
+    const b = streamingPort([new Uint8Array([2])]);
+    pipe.adoptPort(a, 'client-a');
+    pipe.adoptPort(b, 'client-b');
+
+    const response = await pipe.respond(streamRequest(), 'client-never-seen');
+
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([2]));
+    expect(a.countOf('cb:media:open')).toBe(0);
+  });
+
+  it('closes only the port of the client being replaced', () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const a = streamingPort([]);
+    const b = streamingPort([]);
+    pipe.adoptPort(a, 'client-a');
+    pipe.adoptPort(b, 'client-b');
+
+    pipe.adoptPort(streamingPort([]), 'client-a');
+
+    expect(a.closed).toBe(true);
+    expect(b.closed).toBe(false);
+  });
+
+  it('fails the replaced client body while another client keeps streaming', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const stalled = stalledPort();
+    const live = streamingPort([new Uint8Array([5])]);
+    pipe.adoptPort(stalled, 'client-a');
+    pipe.adoptPort(live, 'client-b');
+
+    const stuck = await pipe.respond(streamRequest(), 'client-a');
+    const drained = stuck.arrayBuffer();
+    await Promise.resolve();
+    pipe.adoptPort(new FakePort(), 'client-a');
+
+    await expect(drained).rejects.toThrow(/media port replaced/);
+    const response = await pipe.respond(streamRequest(), 'client-b');
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([5]));
+  });
+
+  it('drops a discarded client port instead of retrying it', async () => {
+    vi.useFakeTimers();
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const live = streamingPort([new Uint8Array([3])]);
+    const dead = new FakePort();
+    pipe.adoptPort(live, 'client-live');
+    pipe.adoptPort(dead, 'client-dead');
+
+    const pending = pipe.respond(streamRequest(), 'client-dead');
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.responseTimeoutMs);
+    const response = await pending;
+    vi.useRealTimers();
+
+    expect(dead.closed).toBe(true);
+    expect(dead.countOf('cb:media:open')).toBe(1);
+    // The dead client's entry is gone, so the retry falls back to a live port.
+    expect(response.status).toBe(206);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([3]));
+  });
+});
+
+describe('MediaPipe port-message validation', () => {
+  const headPort = (head: (requestId: number) => unknown): FakePort =>
+    new FakePort((message, port) => {
+      if (message.type !== 'cb:media:open') return;
+      port.deliverRaw(head(message.requestId));
+    });
+
+  it.each([
+    { case: 'a status outside the HTTP range', ok: true, status: 999, headers: [] },
+    { case: 'a status that is not an integer', ok: true, status: 200.5, headers: [] },
+    { case: 'headers that are not string pairs', ok: true, status: 200, headers: 'video/mp4' },
+    { case: 'headers holding a malformed pair', ok: true, status: 200, headers: [['only']] },
+    { case: 'an ok flag that is not a boolean', ok: 'yes', status: 200, headers: [] },
+  ])('never builds a response from a head with $case', async (head) => {
+    vi.useFakeTimers();
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    pipe.adoptPort(
+      headPort((requestId) => ({
+        type: 'cb:media:head',
+        requestId,
+        ok: head.ok,
+        status: head.status,
+        headers: head.headers,
+      }))
+    );
+
+    const pending = pipe.respond(streamRequest());
+    await vi.advanceTimersByTimeAsync(
+      TIMEOUTS.responseTimeoutMs * 2 + TIMEOUTS.brokerTimeoutMs + 1
+    );
+
+    await expect(pending).resolves.toMatchObject({ status: 503 });
+  });
+
+  it('drops a chunk whose payload is not an ArrayBuffer', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = new FakePort((message, self) => {
+      if (message.type === 'cb:media:open') {
+        self.deliver({
+          type: 'cb:media:head',
+          requestId: message.requestId,
+          ok: true,
+          status: 200,
+          headers: [],
+        });
+        return;
+      }
+      if (message.type !== 'cb:media:pull') return;
+      self.deliverRaw({ type: 'cb:media:chunk', requestId: message.requestId, chunk: 64 });
+      self.deliver({
+        type: 'cb:media:chunk',
+        requestId: message.requestId,
+        chunk: bufferOf(new Uint8Array([9])),
+      });
+    });
+    pipe.adoptPort(port);
+
+    const response = await pipe.respond(streamRequest());
+    const first = await response.body?.getReader().read();
+
+    // A number would have become that many zero bytes of fabricated plaintext.
+    expect(first?.value).toEqual(new Uint8Array([9]));
+  });
+
+  it('drops an error whose message is not a string', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = new FakePort((message, self) => {
+      if (message.type === 'cb:media:open') {
+        self.deliver({
+          type: 'cb:media:head',
+          requestId: message.requestId,
+          ok: true,
+          status: 200,
+          headers: [],
+        });
+        return;
+      }
+      if (message.type !== 'cb:media:pull') return;
+      self.deliverRaw({ type: 'cb:media:error', requestId: message.requestId, message: { a: 1 } });
+      self.deliver({ type: 'cb:media:end', requestId: message.requestId });
+    });
+    pipe.adoptPort(port);
+
+    const response = await pipe.respond(streamRequest());
+
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array());
+  });
+});
+
+describe('MediaPipe cache policy', () => {
+  it('marks every status it synthesizes no-store', async () => {
+    vi.useFakeTimers();
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    pipe.adoptPort(new FakePort());
+
+    const rejected = await pipe.respond(new Request(`${ORIGIN}/stream/tkt`, { method: 'POST' }));
+    const ticketless = await pipe.respond(new Request(`${ORIGIN}/stream/`));
+    const pending = pipe.respond(streamRequest());
+    await vi.advanceTimersByTimeAsync(
+      TIMEOUTS.responseTimeoutMs * 2 + TIMEOUTS.brokerTimeoutMs + 1
+    );
+    const unavailable = await pending;
+
+    expect([rejected.status, ticketless.status, unavailable.status]).toEqual([405, 404, 503]);
+    for (const response of [rejected, ticketless, unavailable]) {
+      expect(response.headers.get('cache-control')).toBe('no-store');
+    }
+  });
+
+  it('marks a forwarded head no-store even when the tab omitted it', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    pipe.adoptPort(streamingPort([]));
+
+    const streamed = await pipe.respond(streamRequest());
+
+    expect(streamed.headers.get('cache-control')).toBe('no-store');
+    expect(streamed.headers.get('content-type')).toBe('video/mp4');
+  });
+
+  it('marks a not-ok head no-store', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    pipe.adoptPort(
+      new FakePort((message, self) => {
+        if (message.type !== 'cb:media:open') return;
+        self.deliver({
+          type: 'cb:media:head',
+          requestId: message.requestId,
+          ok: false,
+          status: 404,
+          headers: [],
+        });
+      })
+    );
+
+    const response = await pipe.respond(streamRequest('unknown'));
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+  });
+});

--- a/packages/client/src/sw/pipe.test.ts
+++ b/packages/client/src/sw/pipe.test.ts
@@ -86,7 +86,6 @@ function streamingPort(chunks: Uint8Array[]): FakePort {
       port.deliver({
         type: 'cb:media:head',
         requestId: message.requestId,
-        ok: true,
         status: 206,
         headers: [['content-type', 'video/mp4']],
       });
@@ -109,7 +108,6 @@ function stalledPort(): FakePort {
     port.deliver({
       type: 'cb:media:head',
       requestId: message.requestId,
-      ok: true,
       status: 200,
       headers: [],
     });
@@ -220,7 +218,6 @@ describe('MediaPipe.respond', () => {
         self.deliver({
           type: 'cb:media:head',
           requestId: message.requestId,
-          ok: true,
           status: 200,
           headers: [],
         });
@@ -238,14 +235,13 @@ describe('MediaPipe.respond', () => {
     await expect(reader?.read()).rejects.toThrow('boom');
   });
 
-  it('turns a not-ok head into a bodiless response and never pulls', async () => {
+  it('turns an error-status head into a bodiless response and never pulls', async () => {
     const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
     const port = new FakePort((message, self) => {
       if (message.type !== 'cb:media:open') return;
       self.deliver({
         type: 'cb:media:head',
         requestId: message.requestId,
-        ok: false,
         status: 404,
         headers: [],
       });
@@ -446,17 +442,42 @@ describe('MediaPipe client routing', () => {
     ]);
   });
 
-  it('falls back to the newest port for a client it holds none for', async () => {
-    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
-    const a = streamingPort([new Uint8Array([1])]);
+  it('re-brokers to the owning tab instead of borrowing another client port', async () => {
+    vi.useFakeTimers();
+    const scope = new FakeScope();
+    const pipe = new MediaPipe(scope, TIMEOUTS);
     const b = streamingPort([new Uint8Array([2])]);
-    pipe.adoptPort(a, 'client-a');
-    pipe.adoptPort(b, 'client-b');
+    pipe.adoptPort(b, 'tab-b');
 
-    const response = await pipe.respond(streamRequest(), 'client-never-seen');
+    const pending = pipe.respond(streamRequest(), 'tab-a');
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.brokerTimeoutMs);
+    const response = await pending;
+    vi.useRealTimers();
 
-    expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([2]));
-    expect(a.countOf('cb:media:open')).toBe(0);
+    // Tab B's registry never minted tab A's ticket, so its port cannot answer.
+    expect(b.countOf('cb:media:open')).toBe(0);
+    expect(scope.brokeredTo).toEqual(['tab-a']);
+    expect(response.status).toBe(503);
+  });
+
+  it('keeps a client waiting when an unrelated client offers a port', async () => {
+    vi.useFakeTimers();
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+
+    const pending = pipe.respond(streamRequest(), 'tab-a');
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.brokerTimeoutMs / 2);
+    const other = streamingPort([new Uint8Array([9])]);
+    pipe.adoptPort(other, 'tab-b');
+    await vi.advanceTimersByTimeAsync(1);
+    expect(other.countOf('cb:media:open')).toBe(0);
+
+    const own = streamingPort([new Uint8Array([4])]);
+    pipe.adoptPort(own, 'tab-a');
+    const response = await pending;
+    vi.useRealTimers();
+
+    expect(response.status).toBe(206);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([4]));
   });
 
   it('closes only the port of the client being replaced', () => {
@@ -494,19 +515,19 @@ describe('MediaPipe client routing', () => {
     const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
     const live = streamingPort([new Uint8Array([3])]);
     const dead = new FakePort();
-    pipe.adoptPort(live, 'client-live');
-    pipe.adoptPort(dead, 'client-dead');
+    pipe.adoptPort(live, 'tab-a');
+    pipe.adoptPort(dead, 'tab-b');
 
-    const pending = pipe.respond(streamRequest(), 'client-dead');
-    await vi.advanceTimersByTimeAsync(TIMEOUTS.responseTimeoutMs);
+    const pending = pipe.respond(streamRequest(), 'tab-b');
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.responseTimeoutMs + TIMEOUTS.brokerTimeoutMs);
     const response = await pending;
     vi.useRealTimers();
 
     expect(dead.closed).toBe(true);
     expect(dead.countOf('cb:media:open')).toBe(1);
-    // The dead client's entry is gone, so the retry falls back to a live port.
-    expect(response.status).toBe(206);
-    expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([3]));
+    // The retry re-brokers its own tab rather than answering off another's port.
+    expect(live.countOf('cb:media:open')).toBe(0);
+    expect(response.status).toBe(503);
   });
 });
 
@@ -518,11 +539,11 @@ describe('MediaPipe port-message validation', () => {
     });
 
   it.each([
-    { case: 'a status outside the HTTP range', ok: true, status: 999, headers: [] },
-    { case: 'a status that is not an integer', ok: true, status: 200.5, headers: [] },
-    { case: 'headers that are not string pairs', ok: true, status: 200, headers: 'video/mp4' },
-    { case: 'headers holding a malformed pair', ok: true, status: 200, headers: [['only']] },
-    { case: 'an ok flag that is not a boolean', ok: 'yes', status: 200, headers: [] },
+    { case: 'a status outside the HTTP range', status: 999, headers: [] },
+    { case: 'a status that is not an integer', status: 200.5, headers: [] },
+    { case: 'a status that is not a number', status: '200', headers: [] },
+    { case: 'headers that are not string pairs', status: 200, headers: 'video/mp4' },
+    { case: 'headers holding a malformed pair', status: 200, headers: [['only']] },
   ])('never builds a response from a head with $case', async (head) => {
     vi.useFakeTimers();
     const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
@@ -530,7 +551,6 @@ describe('MediaPipe port-message validation', () => {
       headPort((requestId) => ({
         type: 'cb:media:head',
         requestId,
-        ok: head.ok,
         status: head.status,
         headers: head.headers,
       }))
@@ -551,7 +571,6 @@ describe('MediaPipe port-message validation', () => {
         self.deliver({
           type: 'cb:media:head',
           requestId: message.requestId,
-          ok: true,
           status: 200,
           headers: [],
         });
@@ -581,7 +600,6 @@ describe('MediaPipe port-message validation', () => {
         self.deliver({
           type: 'cb:media:head',
           requestId: message.requestId,
-          ok: true,
           status: 200,
           headers: [],
         });
@@ -599,7 +617,7 @@ describe('MediaPipe port-message validation', () => {
   });
 });
 
-describe('MediaPipe cache policy', () => {
+describe('MediaPipe response headers', () => {
   it('marks every status it synthesizes no-store', async () => {
     vi.useFakeTimers();
     const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
@@ -629,7 +647,7 @@ describe('MediaPipe cache policy', () => {
     expect(streamed.headers.get('content-type')).toBe('video/mp4');
   });
 
-  it('marks a not-ok head no-store', async () => {
+  it('marks an error-status head no-store', async () => {
     const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
     pipe.adoptPort(
       new FakePort((message, self) => {
@@ -637,7 +655,6 @@ describe('MediaPipe cache policy', () => {
         self.deliver({
           type: 'cb:media:head',
           requestId: message.requestId,
-          ok: false,
           status: 404,
           headers: [],
         });
@@ -648,5 +665,26 @@ describe('MediaPipe cache policy', () => {
 
     expect(response.status).toBe(404);
     expect(response.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('hardens a body head the port left executable', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    pipe.adoptPort(
+      new FakePort((message, self) => {
+        if (message.type !== 'cb:media:open') return;
+        self.deliver({
+          type: 'cb:media:head',
+          requestId: message.requestId,
+          status: 200,
+          headers: [['content-type', 'text/html']],
+        });
+      })
+    );
+
+    const response = await pipe.respond(streamRequest());
+
+    expect(response.headers.get('content-type')).toBe('application/octet-stream');
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(response.headers.get('content-security-policy')).toBe("default-src 'none'; sandbox");
   });
 });

--- a/packages/client/src/sw/pipe.test.ts
+++ b/packages/client/src/sw/pipe.test.ts
@@ -1,62 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type {
-  MediaPortRequest,
-  MediaRequest,
-  MediaResponse,
-  MessagePortLike,
-} from '../media/protocol.js';
+import type { MediaPortRequest } from '../media/protocol.js';
+import { FakePort } from './testDoubles.js';
 import { MediaPipe, type ClientsLike, type MediaPipeScopeLike } from './pipe.js';
 
 const ORIGIN = 'https://vault.example';
 const TIMEOUTS = { brokerTimeoutMs: 1000, responseTimeoutMs: 100, pullTimeoutMs: 2000 };
-
-type Reply = (message: MediaRequest, port: FakePort) => void;
-
-class FakePort implements MessagePortLike {
-  readonly sent: MediaRequest[] = [];
-  closed = false;
-  started = false;
-  private listeners: Array<(event: MessageEvent) => void> = [];
-
-  constructor(private readonly reply?: Reply) {}
-
-  postMessage(message: unknown): void {
-    this.sent.push(message as MediaRequest);
-    this.reply?.(message as MediaRequest, this);
-  }
-
-  addEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
-    this.listeners.push(listener);
-  }
-
-  removeEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
-    this.listeners = this.listeners.filter((entry) => entry !== listener);
-  }
-
-  start(): void {
-    this.started = true;
-  }
-
-  close(): void {
-    this.closed = true;
-  }
-
-  deliver(response: MediaResponse): void {
-    this.deliverRaw(response);
-  }
-
-  /** Delivers whatever a version-skewed or hostile port might post. */
-  deliverRaw(data: unknown): void {
-    for (const listener of [...this.listeners]) {
-      listener({ data } as unknown as MessageEvent);
-    }
-  }
-
-  countOf(type: MediaRequest['type']): number {
-    return this.sent.filter((message) => message.type === type).length;
-  }
-}
 
 class FakeScope implements MediaPipeScopeLike {
   readonly brokered: MediaPortRequest[] = [];

--- a/packages/client/src/sw/pipe.ts
+++ b/packages/client/src/sw/pipe.ts
@@ -16,6 +16,8 @@ import {
 
 /** The subset of a window client the pipe drives (injectable). */
 export interface WindowClientLike {
+  /** Matches `FetchEventLike.clientId`, so a request can be aimed at one tab. */
+  readonly id?: string;
   postMessage(message: MediaPortRequest): void;
 }
 
@@ -67,6 +69,8 @@ export class MediaPipe {
   private readonly ports = new Map<string, PortEntry>();
   private readonly portWaiters = new Set<() => void>();
   private readonly sinks = new Map<number, ResponseSink>();
+  /** The armed pull deadline per request, so a cancel can disarm its own. */
+  private readonly pullTimers = new Map<number, ReturnType<typeof setTimeout>>();
   private nextRequestId = 1;
   private readonly brokerTimeoutMs: number;
   private readonly responseTimeoutMs: number;
@@ -164,6 +168,9 @@ export class MediaPipe {
       {
         pull: (controller) => this.pullWindow(port, requestId, controller),
         cancel: () => {
+          // The pull this cancels leaves its timer armed, and that timer discards
+          // the port — taking every other body streaming on it down too.
+          this.clearPull(requestId);
           this.sinks.delete(requestId);
           this.post(port, { type: 'cb:media:close', requestId });
         },
@@ -179,7 +186,7 @@ export class MediaPipe {
   ): Promise<void> {
     return new Promise<void>((resolve) => {
       const settle = (finish: () => void): void => {
-        clearTimeout(timer);
+        this.clearPull(requestId);
         this.sinks.delete(requestId);
         finish();
         resolve();
@@ -192,6 +199,7 @@ export class MediaPipe {
           controller.error(new Error('media pull timed out'));
         });
       }, this.pullTimeoutMs);
+      this.pullTimers.set(requestId, timer);
       this.sinks.set(requestId, {
         port,
         deliver: (response) => {
@@ -218,7 +226,12 @@ export class MediaPipe {
     const held = this.portFor(clientId);
     if (held) return held;
     const clients = await this.scope.clients.matchAll({ type: 'window' });
-    for (const client of clients) client.postMessage({ type: MEDIA_PORT_REQUEST });
+    // Only the tab that needs a port may re-broker: a tab that answers replaces
+    // its channel, and the superseded broker drops the cursors of live bodies.
+    // An unidentified client has no target, so it falls back to asking everyone.
+    const owner = clients.filter((client) => client.id === clientId);
+    const targets = clientId !== ANONYMOUS_CLIENT && owner.length > 0 ? owner : clients;
+    for (const client of targets) client.postMessage({ type: MEDIA_PORT_REQUEST });
     return this.waitForPort(clientId);
   }
 
@@ -243,6 +256,13 @@ export class MediaPipe {
       }, this.brokerTimeoutMs);
       this.portWaiters.add(waiter);
     });
+  }
+
+  private clearPull(requestId: number): void {
+    const timer = this.pullTimers.get(requestId);
+    if (timer === undefined) return;
+    clearTimeout(timer);
+    this.pullTimers.delete(requestId);
   }
 
   private post(port: MessagePortLike, message: MediaRequest): void {
@@ -279,7 +299,16 @@ function sealed(
   headers: Array<[string, string]> = [],
   body: BodyInit | null = null
 ): Response {
-  const merged = new Headers(headers);
+  const merged = new Headers();
+  // `asResponse` proves the pairs are strings, not that they are legal header
+  // tokens; a name or value `Headers` rejects must not fail the whole response.
+  for (const [name, value] of headers) {
+    try {
+      merged.append(name, value);
+    } catch {
+      continue;
+    }
+  }
   merged.set('cache-control', 'no-store');
   return new Response(body, { status, headers: merged });
 }

--- a/packages/client/src/sw/pipe.ts
+++ b/packages/client/src/sw/pipe.ts
@@ -13,6 +13,7 @@ import {
   type MediaResponse,
   type MessagePortLike,
 } from '../media/protocol.js';
+import { safeMimeType } from '../media/range.js';
 
 /** The subset of a window client the pipe drives (injectable). */
 export interface WindowClientLike {
@@ -67,7 +68,7 @@ export class MediaPipe {
    * ticket.
    */
   private readonly ports = new Map<string, PortEntry>();
-  private readonly portWaiters = new Set<() => void>();
+  private readonly portWaiters = new Set<(adopted: string) => void>();
   private readonly sinks = new Map<number, ResponseSink>();
   /** The armed pull deadline per request, so a cancel can disarm its own. */
   private readonly pullTimers = new Map<number, ReturnType<typeof setTimeout>>();
@@ -96,11 +97,9 @@ export class MediaPipe {
     const listener = (event: MessageEvent): void => this.onMessage(port, event);
     port.addEventListener('message', listener);
     port.start?.();
-    // Insertion order is adoption order, which is what the newest-port fallback reads.
+    // Insertion order is adoption order, which the anonymous fallback reads.
     this.ports.set(clientId, { port, listener });
-    const waiters = [...this.portWaiters];
-    this.portWaiters.clear();
-    for (const waiter of waiters) waiter();
+    for (const waiter of [...this.portWaiters]) waiter(clientId);
   }
 
   async respond(request: Request, clientId: string = ANONYMOUS_CLIENT): Promise<Response> {
@@ -123,7 +122,7 @@ export class MediaPipe {
         this.discardPort(port);
         continue;
       }
-      if (!head.ok) return sealed(head.status, head.headers);
+      if (head.status >= 300) return sealed(head.status, head.headers);
       return sealed(head.status, head.headers, this.body(port, requestId));
     }
     return sealed(503);
@@ -235,10 +234,11 @@ export class MediaPipe {
     return this.waitForPort(clientId);
   }
 
-  /** A client the pipe holds no port for falls back to the newest port offered. */
+  /** Only an unidentified client may borrow a port, and only the newest offered. */
   private portFor(clientId: string): MessagePortLike | null {
     const own = this.ports.get(clientId);
     if (own) return own.port;
+    if (clientId !== ANONYMOUS_CLIENT) return null;
     let newest: PortEntry | undefined;
     for (const entry of this.ports.values()) newest = entry;
     return newest?.port ?? null;
@@ -246,8 +246,10 @@ export class MediaPipe {
 
   private waitForPort(clientId: string): Promise<MessagePortLike | null> {
     return new Promise((resolve) => {
-      const waiter = (): void => {
+      const waiter = (adopted: string): void => {
+        if (adopted !== clientId && clientId !== ANONYMOUS_CLIENT) return;
         clearTimeout(timer);
+        this.portWaiters.delete(waiter);
         resolve(this.portFor(clientId));
       };
       const timer = setTimeout(() => {
@@ -310,6 +312,13 @@ function sealed(
     }
   }
   merged.set('cache-control', 'no-store');
+  // A ticket URL is same-origin and navigable, and the port that named the type
+  // is untrusted input, so a body only ever renders under a clamped type.
+  if (body !== null) {
+    merged.set('content-type', safeMimeType(merged.get('content-type') ?? ''));
+    merged.set('x-content-type-options', 'nosniff');
+    merged.set('content-security-policy', "default-src 'none'; sandbox");
+  }
   return new Response(body, { status, headers: merged });
 }
 
@@ -319,7 +328,6 @@ function asResponse(data: unknown): MediaResponse | null {
   const message = data as {
     type?: unknown;
     requestId?: unknown;
-    ok?: unknown;
     status?: unknown;
     headers?: unknown;
     chunk?: unknown;
@@ -330,13 +338,12 @@ function asResponse(data: unknown): MediaResponse | null {
 
   switch (message.type) {
     case 'cb:media:head': {
-      const { ok, status, headers } = message;
-      if (typeof ok !== 'boolean') return null;
+      const { status, headers } = message;
       // Outside this range `Response` throws, which would kill the fetch handler.
       if (typeof status !== 'number' || !Number.isInteger(status)) return null;
       if (status < 200 || status > 599) return null;
       if (!isHeaderPairs(headers)) return null;
-      return { type: 'cb:media:head', requestId, ok, status, headers };
+      return { type: 'cb:media:head', requestId, status, headers };
     }
     case 'cb:media:chunk':
       if (!(message.chunk instanceof ArrayBuffer)) return null;

--- a/packages/client/src/sw/pipe.ts
+++ b/packages/client/src/sw/pipe.ts
@@ -1,0 +1,336 @@
+/**
+ * The Service Worker end of the media byte pipe (blueprint/web-client.md
+ * "Streaming media — the SW is a dumb pipe"). Nothing here survives a worker
+ * kill, so a port that stops answering is re-brokered, not reported as a failure.
+ */
+
+import {
+  MEDIA_PORT_REQUEST,
+  STREAM_PATH_PREFIX,
+  ticketFromPath,
+  type MediaPortRequest,
+  type MediaRequest,
+  type MediaResponse,
+  type MessagePortLike,
+} from '../media/protocol.js';
+
+/** The subset of a window client the pipe drives (injectable). */
+export interface WindowClientLike {
+  postMessage(message: MediaPortRequest): void;
+}
+
+/** The subset of `ServiceWorkerGlobalScope.clients` the pipe drives. */
+export interface ClientsLike {
+  matchAll(options: { type: 'window' }): Promise<readonly WindowClientLike[]>;
+}
+
+/** The subset of a Service Worker global scope the pipe drives. */
+export interface MediaPipeScopeLike {
+  readonly clients: ClientsLike;
+  readonly location: { readonly origin: string };
+}
+
+export interface MediaPipeOptions {
+  brokerTimeoutMs?: number;
+  responseTimeoutMs?: number;
+  pullTimeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/** A pull drives a real ranged engine read over the network, so it gets a far longer leash. */
+const DEFAULT_PULL_TIMEOUT_MS = 30000;
+
+/** One entry for every offer and request without a client identity; a real client id is never empty. */
+const ANONYMOUS_CLIENT = '';
+
+type MediaHeadResponse = Extract<MediaResponse, { type: 'cb:media:head' }>;
+
+/** A client's end of the pipe, with the listener bound to it. */
+interface PortEntry {
+  readonly port: MessagePortLike;
+  readonly listener: (event: MessageEvent) => void;
+}
+
+/** Receives every port message correlated to one request id, until it settles. */
+interface ResponseSink {
+  readonly port: MessagePortLike;
+  readonly deliver: (response: MediaResponse) => void;
+}
+
+export class MediaPipe {
+  /**
+   * One port per client: a tab's registry only knows the tickets that tab
+   * minted, so a request answered by another tab's port dies as an unknown
+   * ticket.
+   */
+  private readonly ports = new Map<string, PortEntry>();
+  private readonly portWaiters = new Set<() => void>();
+  private readonly sinks = new Map<number, ResponseSink>();
+  private nextRequestId = 1;
+  private readonly brokerTimeoutMs: number;
+  private readonly responseTimeoutMs: number;
+  private readonly pullTimeoutMs: number;
+
+  constructor(
+    private readonly scope: MediaPipeScopeLike,
+    options: MediaPipeOptions = {}
+  ) {
+    this.brokerTimeoutMs = options.brokerTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.pullTimeoutMs = options.pullTimeoutMs ?? DEFAULT_PULL_TIMEOUT_MS;
+  }
+
+  /** The whole prefix is the pipe's: a malformed ticket is its 404, not the network's. */
+  handles(url: URL): boolean {
+    return url.origin === this.scope.location.origin && url.pathname.startsWith(STREAM_PATH_PREFIX);
+  }
+
+  /** Takes a client's end of a fresh channel, replacing whatever that client held. */
+  adoptPort(port: MessagePortLike, clientId: string = ANONYMOUS_CLIENT): void {
+    this.detachPort(clientId);
+    const listener = (event: MessageEvent): void => this.onMessage(port, event);
+    port.addEventListener('message', listener);
+    port.start?.();
+    // Insertion order is adoption order, which is what the newest-port fallback reads.
+    this.ports.set(clientId, { port, listener });
+    const waiters = [...this.portWaiters];
+    this.portWaiters.clear();
+    for (const waiter of waiters) waiter();
+  }
+
+  async respond(request: Request, clientId: string = ANONYMOUS_CLIENT): Promise<Response> {
+    // The prefix is navigable, so a cross-site form POST reaches here; only a
+    // GET may ever draw plaintext out of the pipe.
+    if (request.method !== 'GET') return sealed(405);
+    const ticket = ticketFromPath(new URL(request.url).pathname);
+    if (ticket === null) return sealed(404);
+    const range = request.headers.get('range');
+
+    // A dead tab's port silently swallows `open` and the timeout is the only
+    // signal; retry the open once against a freshly brokered port.
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const port = await this.acquirePort(clientId);
+      if (!port) break;
+      const requestId = this.nextRequestId;
+      this.nextRequestId += 1;
+      const head = await this.open(port, requestId, ticket, range);
+      if (!head) {
+        this.discardPort(port);
+        continue;
+      }
+      if (!head.ok) return sealed(head.status, head.headers);
+      return sealed(head.status, head.headers, this.body(port, requestId));
+    }
+    return sealed(503);
+  }
+
+  private onMessage(port: MessagePortLike, event: MessageEvent): void {
+    const response = asResponse(event.data);
+    if (response === null) return;
+    const sink = this.sinks.get(response.requestId);
+    // An unknown or already-settled id is stale traffic; another client's id is
+    // not this port's to answer.
+    if (sink?.port === port) sink.deliver(response);
+  }
+
+  private open(
+    port: MessagePortLike,
+    requestId: number,
+    ticket: string,
+    range: string | null
+  ): Promise<MediaHeadResponse | null> {
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        this.sinks.delete(requestId);
+        resolve(null);
+      }, this.responseTimeoutMs);
+      this.sinks.set(requestId, {
+        port,
+        deliver: (response) => {
+          if (response.type !== 'cb:media:head') return;
+          clearTimeout(timer);
+          this.sinks.delete(requestId);
+          resolve(response);
+        },
+      });
+      this.post(port, { type: 'cb:media:open', requestId, ticket, range });
+    });
+  }
+
+  /** A zero high-water mark keeps exactly one window in flight: pull on demand. */
+  private body(port: MessagePortLike, requestId: number): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>(
+      {
+        pull: (controller) => this.pullWindow(port, requestId, controller),
+        cancel: () => {
+          this.sinks.delete(requestId);
+          this.post(port, { type: 'cb:media:close', requestId });
+        },
+      },
+      { highWaterMark: 0 }
+    );
+  }
+
+  private pullWindow(
+    port: MessagePortLike,
+    requestId: number,
+    controller: ReadableStreamDefaultController<Uint8Array>
+  ): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const settle = (finish: () => void): void => {
+        clearTimeout(timer);
+        this.sinks.delete(requestId);
+        finish();
+        resolve();
+      };
+      // A tab that died mid-stream swallows the pull; without this the body
+      // never settles and the response hangs open forever.
+      const timer = setTimeout(() => {
+        settle(() => {
+          this.discardPort(port);
+          controller.error(new Error('media pull timed out'));
+        });
+      }, this.pullTimeoutMs);
+      this.sinks.set(requestId, {
+        port,
+        deliver: (response) => {
+          switch (response.type) {
+            case 'cb:media:chunk':
+              settle(() => controller.enqueue(new Uint8Array(response.chunk)));
+              return;
+            case 'cb:media:end':
+              settle(() => controller.close());
+              return;
+            case 'cb:media:error':
+              settle(() => controller.error(new Error(response.message)));
+              return;
+            default:
+              return;
+          }
+        },
+      });
+      this.post(port, { type: 'cb:media:pull', requestId });
+    });
+  }
+
+  private async acquirePort(clientId: string): Promise<MessagePortLike | null> {
+    const held = this.portFor(clientId);
+    if (held) return held;
+    const clients = await this.scope.clients.matchAll({ type: 'window' });
+    for (const client of clients) client.postMessage({ type: MEDIA_PORT_REQUEST });
+    return this.waitForPort(clientId);
+  }
+
+  /** A client the pipe holds no port for falls back to the newest port offered. */
+  private portFor(clientId: string): MessagePortLike | null {
+    const own = this.ports.get(clientId);
+    if (own) return own.port;
+    let newest: PortEntry | undefined;
+    for (const entry of this.ports.values()) newest = entry;
+    return newest?.port ?? null;
+  }
+
+  private waitForPort(clientId: string): Promise<MessagePortLike | null> {
+    return new Promise((resolve) => {
+      const waiter = (): void => {
+        clearTimeout(timer);
+        resolve(this.portFor(clientId));
+      };
+      const timer = setTimeout(() => {
+        this.portWaiters.delete(waiter);
+        resolve(null);
+      }, this.brokerTimeoutMs);
+      this.portWaiters.add(waiter);
+    });
+  }
+
+  private post(port: MessagePortLike, message: MediaRequest): void {
+    port.postMessage(message);
+  }
+
+  private discardPort(port: MessagePortLike): void {
+    for (const [clientId, entry] of this.ports) {
+      if (entry.port !== port) continue;
+      this.detachPort(clientId);
+      return;
+    }
+  }
+
+  private detachPort(clientId: string): void {
+    const entry = this.ports.get(clientId);
+    if (!entry) return;
+    this.ports.delete(clientId);
+    entry.port.removeEventListener('message', entry.listener);
+    entry.port.close();
+    // Bodies still pulling on the dead port would hang forever; failing them
+    // makes the media element re-request, which re-brokers and re-buffers.
+    for (const [requestId, sink] of [...this.sinks]) {
+      if (sink.port !== entry.port) continue;
+      this.sinks.delete(requestId);
+      sink.deliver({ type: 'cb:media:error', requestId, message: 'media port replaced' });
+    }
+  }
+}
+
+/** Vault plaintext must never reach a cache, whatever headers the tab sent. */
+function sealed(
+  status: number,
+  headers: Array<[string, string]> = [],
+  body: BodyInit | null = null
+): Response {
+  const merged = new Headers(headers);
+  merged.set('cache-control', 'no-store');
+  return new Response(body, { status, headers: merged });
+}
+
+/** A same-origin port is still untrusted input: anything off-shape is dropped. */
+function asResponse(data: unknown): MediaResponse | null {
+  if (typeof data !== 'object' || data === null) return null;
+  const message = data as {
+    type?: unknown;
+    requestId?: unknown;
+    ok?: unknown;
+    status?: unknown;
+    headers?: unknown;
+    chunk?: unknown;
+    message?: unknown;
+  };
+  const requestId = message.requestId;
+  if (typeof requestId !== 'number') return null;
+
+  switch (message.type) {
+    case 'cb:media:head': {
+      const { ok, status, headers } = message;
+      if (typeof ok !== 'boolean') return null;
+      // Outside this range `Response` throws, which would kill the fetch handler.
+      if (typeof status !== 'number' || !Number.isInteger(status)) return null;
+      if (status < 200 || status > 599) return null;
+      if (!isHeaderPairs(headers)) return null;
+      return { type: 'cb:media:head', requestId, ok, status, headers };
+    }
+    case 'cb:media:chunk':
+      if (!(message.chunk instanceof ArrayBuffer)) return null;
+      return { type: 'cb:media:chunk', requestId, chunk: message.chunk };
+    case 'cb:media:end':
+      return { type: 'cb:media:end', requestId };
+    case 'cb:media:error':
+      if (typeof message.message !== 'string') return null;
+      return { type: 'cb:media:error', requestId, message: message.message };
+    default:
+      return null;
+  }
+}
+
+function isHeaderPairs(value: unknown): value is Array<[string, string]> {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (pair) =>
+        Array.isArray(pair) &&
+        pair.length === 2 &&
+        typeof pair[0] === 'string' &&
+        typeof pair[1] === 'string'
+    )
+  );
+}

--- a/packages/client/src/sw/precache.test.ts
+++ b/packages/client/src/sw/precache.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  APP_SHELL_CACHE,
+  appShellClaims,
+  deleteStaleCaches,
+  precacheAppShell,
+  readPrecachedUrls,
+  respondFromAppShell,
+} from './precache.js';
+import {
+  failingFetch,
+  FakeCacheStorage,
+  manifestFetch,
+  SW_ORIGIN as ORIGIN,
+} from './testDoubles.js';
+
+/** `mode: 'navigate'` cannot be set through the `Request` constructor. */
+const navigation = (url: string): Request =>
+  ({ method: 'GET', url, mode: 'navigate' }) as unknown as Request;
+
+describe('precacheAppShell', () => {
+  it('caches every same-origin manifest entry', async () => {
+    const caches = new FakeCacheStorage();
+
+    await precacheAppShell(caches, manifestFetch('["/index.html","/assets/app.js"]'), ORIGIN);
+
+    expect([...caches.cache(APP_SHELL_CACHE).entries.keys()]).toEqual([
+      `${ORIGIN}/index.html`,
+      `${ORIGIN}/assets/app.js`,
+    ]);
+  });
+
+  it('is a no-op when the build ships no manifest', async () => {
+    const caches = new FakeCacheStorage();
+
+    await precacheAppShell(caches, manifestFetch('', false), ORIGIN);
+
+    expect(caches.opened.size).toBe(0);
+  });
+
+  it('is a no-op when the manifest body is not a JSON array', async () => {
+    const caches = new FakeCacheStorage();
+
+    await precacheAppShell(caches, manifestFetch('<!doctype html>'), ORIGIN);
+    await precacheAppShell(caches, manifestFetch('{"files":[]}'), ORIGIN);
+
+    expect(caches.opened.size).toBe(0);
+  });
+
+  it('rejects manifest entries that resolve to another origin or the media path', async () => {
+    const caches = new FakeCacheStorage();
+
+    await precacheAppShell(
+      caches,
+      manifestFetch(
+        '["/index.html","https://evil.example/x.js","//evil.example/y.js","/stream/t"]'
+      ),
+      ORIGIN
+    );
+
+    expect([...caches.cache(APP_SHELL_CACHE).entries.keys()]).toEqual([`${ORIGIN}/index.html`]);
+  });
+
+  it('prunes entries a later manifest no longer lists', async () => {
+    const caches = new FakeCacheStorage();
+
+    await precacheAppShell(caches, manifestFetch('["/index.html","/assets/old.js"]'), ORIGIN);
+    await precacheAppShell(caches, manifestFetch('["/index.html","/assets/new.js"]'), ORIGIN);
+
+    expect([...caches.cache(APP_SHELL_CACHE).entries.keys()]).toEqual([
+      `${ORIGIN}/index.html`,
+      `${ORIGIN}/assets/new.js`,
+    ]);
+  });
+});
+
+describe('deleteStaleCaches', () => {
+  it('drops cipherbox caches from earlier deploys and keeps the shell', async () => {
+    const caches = new FakeCacheStorage();
+    caches.cache(APP_SHELL_CACHE);
+    caches.cache('cipherbox-app-shell-v0');
+    caches.cache('unrelated-cache');
+
+    await deleteStaleCaches(caches);
+
+    expect([...caches.opened.keys()]).toEqual([APP_SHELL_CACHE, 'unrelated-cache']);
+  });
+});
+
+describe('appShellClaims', () => {
+  it('claims navigations and precached same-origin GETs only', () => {
+    const precached = new Set([`${ORIGIN}/assets/app.js`]);
+
+    expect(appShellClaims(navigation(`${ORIGIN}/files`), ORIGIN, precached)).toBe(true);
+    expect(appShellClaims(new Request(`${ORIGIN}/assets/app.js`), ORIGIN, precached)).toBe(true);
+    expect(appShellClaims(new Request(`${ORIGIN}/api/vault`), ORIGIN, precached)).toBe(false);
+    expect(appShellClaims(new Request('https://gateway.example/ipfs/x'), ORIGIN, precached)).toBe(
+      false
+    );
+    expect(
+      appShellClaims(new Request(`${ORIGIN}/assets/app.js`, { method: 'POST' }), ORIGIN, precached)
+    ).toBe(false);
+  });
+});
+
+describe('respondFromAppShell', () => {
+  it('serves a precached asset from the cache without a network fetch', async () => {
+    const caches = new FakeCacheStorage();
+    await precacheAppShell(caches, manifestFetch('["/assets/app.js"]'), ORIGIN);
+
+    const response = await respondFromAppShell(
+      new Request(`${ORIGIN}/assets/app.js`),
+      caches,
+      failingFetch,
+      ORIGIN
+    );
+
+    expect(await response?.text()).toBe(`body:${ORIGIN}/assets/app.js`);
+  });
+
+  it('falls back to the cached shell when a navigation cannot reach the network', async () => {
+    const caches = new FakeCacheStorage();
+    await precacheAppShell(caches, manifestFetch('["/index.html"]'), ORIGIN);
+
+    const response = await respondFromAppShell(
+      navigation(`${ORIGIN}/files/abc`),
+      caches,
+      failingFetch,
+      ORIGIN
+    );
+
+    expect(await response?.text()).toBe(`body:${ORIGIN}/index.html`);
+  });
+
+  it('prefers the network for a navigation', async () => {
+    const caches = new FakeCacheStorage();
+    await precacheAppShell(caches, manifestFetch('["/index.html"]'), ORIGIN);
+    const online = (async () => new Response('fresh')) as unknown as typeof fetch;
+
+    const response = await respondFromAppShell(
+      navigation(`${ORIGIN}/files/abc`),
+      caches,
+      online,
+      ORIGIN
+    );
+
+    expect(await response?.text()).toBe('fresh');
+  });
+
+  it('does not intercept non-GET, cross-origin, or uncached requests', async () => {
+    const caches = new FakeCacheStorage();
+    await precacheAppShell(caches, manifestFetch('["/index.html"]'), ORIGIN);
+
+    expect(
+      await respondFromAppShell(
+        new Request(`${ORIGIN}/index.html`, { method: 'POST' }),
+        caches,
+        failingFetch,
+        ORIGIN
+      )
+    ).toBeUndefined();
+    expect(
+      await respondFromAppShell(
+        new Request('https://gateway.example/ipfs/x'),
+        caches,
+        failingFetch,
+        ORIGIN
+      )
+    ).toBeUndefined();
+    expect(
+      await respondFromAppShell(new Request(`${ORIGIN}/api/vault`), caches, failingFetch, ORIGIN)
+    ).toBeUndefined();
+  });
+
+  it('never writes a response into the cache', async () => {
+    const caches = new FakeCacheStorage();
+    await precacheAppShell(caches, manifestFetch('["/index.html"]'), ORIGIN);
+    const online = (async () => new Response('fresh')) as unknown as typeof fetch;
+
+    await respondFromAppShell(navigation(`${ORIGIN}/files`), caches, online, ORIGIN);
+    await respondFromAppShell(new Request(`${ORIGIN}/api/vault`), caches, online, ORIGIN);
+
+    expect(caches.cache(APP_SHELL_CACHE).putCalls).toBe(0);
+    expect([...caches.cache(APP_SHELL_CACHE).entries.keys()]).toEqual([`${ORIGIN}/index.html`]);
+  });
+});
+
+describe('readPrecachedUrls', () => {
+  it('mirrors the cached URLs', async () => {
+    const caches = new FakeCacheStorage();
+    await precacheAppShell(caches, manifestFetch('["/index.html","/assets/app.js"]'), ORIGIN);
+
+    expect([...(await readPrecachedUrls(caches))]).toEqual([
+      `${ORIGIN}/index.html`,
+      `${ORIGIN}/assets/app.js`,
+    ]);
+  });
+});

--- a/packages/client/src/sw/precache.test.ts
+++ b/packages/client/src/sw/precache.test.ts
@@ -224,7 +224,6 @@ describe('respondFromAppShell', () => {
     await respondFromAppShell(navigation(`${ORIGIN}/files`), caches, online, ORIGIN);
     await respondFromAppShell(new Request(`${ORIGIN}/api/vault`), caches, online, ORIGIN);
 
-    expect(caches.cache(APP_SHELL_CACHE).putCalls).toBe(0);
     expect([...caches.cache(APP_SHELL_CACHE).entries.keys()]).toEqual([`${ORIGIN}/index.html`]);
   });
 });

--- a/packages/client/src/sw/precache.test.ts
+++ b/packages/client/src/sw/precache.test.ts
@@ -62,6 +62,35 @@ describe('precacheAppShell', () => {
     expect([...caches.cache(APP_SHELL_CACHE).entries.keys()]).toEqual([`${ORIGIN}/index.html`]);
   });
 
+  it('caches the reachable entries when one manifest entry will not cache', async () => {
+    const caches = new FakeCacheStorage();
+    caches.cache(APP_SHELL_CACHE).unreachable.add(`${ORIGIN}/assets/gone.js`);
+
+    await precacheAppShell(
+      caches,
+      manifestFetch('["/index.html","/assets/gone.js","/assets/app.js"]'),
+      ORIGIN
+    );
+
+    expect([...caches.cache(APP_SHELL_CACHE).entries.keys()]).toEqual([
+      `${ORIGIN}/index.html`,
+      `${ORIGIN}/assets/app.js`,
+    ]);
+  });
+
+  it('keeps an entry the manifest still lists when its refresh fails', async () => {
+    const caches = new FakeCacheStorage();
+
+    await precacheAppShell(caches, manifestFetch('["/index.html","/assets/app.js"]'), ORIGIN);
+    caches.cache(APP_SHELL_CACHE).unreachable.add(`${ORIGIN}/assets/app.js`);
+    await precacheAppShell(caches, manifestFetch('["/index.html","/assets/app.js"]'), ORIGIN);
+
+    expect([...caches.cache(APP_SHELL_CACHE).entries.keys()]).toEqual([
+      `${ORIGIN}/index.html`,
+      `${ORIGIN}/assets/app.js`,
+    ]);
+  });
+
   it('prunes entries a later manifest no longer lists', async () => {
     const caches = new FakeCacheStorage();
 

--- a/packages/client/src/sw/precache.test.ts
+++ b/packages/client/src/sw/precache.test.ts
@@ -20,6 +20,20 @@ const navigation = (url: string): Request =>
   ({ method: 'GET', url, mode: 'navigate' }) as unknown as Request;
 
 describe('precacheAppShell', () => {
+  it('requests the manifest same-origin and uncached', async () => {
+    const calls: Array<[string, RequestInit | undefined]> = [];
+    const recording = (async (input: string, init?: RequestInit) => {
+      calls.push([input, init]);
+      return new Response('["/index.html"]');
+    }) as unknown as typeof fetch;
+
+    await precacheAppShell(new FakeCacheStorage(), recording, ORIGIN);
+
+    // A cached manifest would pin the shell to a superseded deploy.
+    expect(calls[0][0]).toBe(`${ORIGIN}/precache-manifest.json`);
+    expect(calls[0][1]?.cache).toBe('no-store');
+  });
+
   it('caches every same-origin manifest entry', async () => {
     const caches = new FakeCacheStorage();
 

--- a/packages/client/src/sw/precache.ts
+++ b/packages/client/src/sw/precache.ts
@@ -45,8 +45,18 @@ export async function precacheAppShell(
   if (!urls) return;
 
   const cache = await caches.open(APP_SHELL_CACHE);
-  await cache.addAll(urls);
+  // `addAll` is atomic, so one entry that will not cache would drop the whole
+  // shell; per entry, a miss costs only that asset.
+  for (const url of urls) {
+    try {
+      await cache.addAll([url]);
+    } catch {
+      continue;
+    }
+  }
 
+  // Pruning follows the manifest, not what cached: an entry the build still
+  // lists is wanted even when this pass failed to refresh it.
   const wanted = new Set(urls);
   for (const entry of await cache.keys()) {
     if (!wanted.has(entry.url)) await cache.delete(entry.url);
@@ -66,16 +76,19 @@ export async function deleteStaleCaches(caches: CacheStorageLike): Promise<void>
   }
 }
 
+/** The requests the shell could ever own; the cheap gate before the claim itself. */
+export function sameOriginGet(request: Request, origin: string): boolean {
+  return request.method === 'GET' && new URL(request.url).origin === origin;
+}
+
 /** Whether the shell owns this request — decided synchronously, before `respondWith`. */
 export function appShellClaims(
   request: Request,
   origin: string,
   precached: ReadonlySet<string>
 ): boolean {
-  if (request.method !== 'GET') return false;
-  const url = new URL(request.url);
-  if (url.origin !== origin) return false;
-  return request.mode === 'navigate' || precached.has(url.toString());
+  if (!sameOriginGet(request, origin)) return false;
+  return request.mode === 'navigate' || precached.has(new URL(request.url).toString());
 }
 
 /**

--- a/packages/client/src/sw/precache.ts
+++ b/packages/client/src/sw/precache.ts
@@ -1,10 +1,6 @@
 /**
  * The app-shell precache (blueprint/web-client.md: a vault you can mutate
  * offline is a vault whose UI must boot offline).
- *
- * `precacheAppShell` is the only writer and it writes only manifest entries;
- * `CacheLike` exposes no `put`, so vault data — never in the manifest — cannot
- * structurally reach the cache.
  */
 
 import { STREAM_PATH_PREFIX } from '../media/protocol.js';
@@ -102,9 +98,8 @@ export async function respondFromAppShell(
   fetchFn: typeof fetch,
   origin: string
 ): Promise<Response | undefined> {
-  if (request.method !== 'GET') return undefined;
+  if (!sameOriginGet(request, origin)) return undefined;
   const url = new URL(request.url);
-  if (url.origin !== origin) return undefined;
 
   const cache = await caches.open(APP_SHELL_CACHE);
   if (request.mode === 'navigate') {

--- a/packages/client/src/sw/precache.ts
+++ b/packages/client/src/sw/precache.ts
@@ -1,0 +1,139 @@
+/**
+ * The app-shell precache (blueprint/web-client.md: a vault you can mutate
+ * offline is a vault whose UI must boot offline).
+ *
+ * `precacheAppShell` is the only writer and it writes only manifest entries;
+ * `CacheLike` exposes no `put`, so vault data — never in the manifest — cannot
+ * structurally reach the cache.
+ */
+
+import { STREAM_PATH_PREFIX } from '../media/protocol.js';
+
+export const APP_SHELL_CACHE = 'cipherbox-app-shell';
+
+const PRECACHE_MANIFEST_URL = '/precache-manifest.json';
+
+/** The document a navigation falls back to when the network is unreachable. */
+const APP_SHELL_DOCUMENT = '/index.html';
+const CACHE_PREFIX = 'cipherbox-';
+
+/** The subset of `Cache` the shell drives (injectable). */
+export interface CacheLike {
+  addAll(requests: readonly string[]): Promise<void>;
+  match(request: string): Promise<Response | undefined>;
+  keys(): Promise<readonly { readonly url: string }[]>;
+  delete(request: string): Promise<boolean>;
+}
+
+/** The subset of `CacheStorage` the shell drives (injectable). */
+export interface CacheStorageLike {
+  open(name: string): Promise<CacheLike>;
+  keys(): Promise<readonly string[]>;
+  delete(name: string): Promise<boolean>;
+}
+
+/**
+ * Fetches the build's manifest and brings the cache in line with it. A dev build
+ * ships no manifest, so an unreachable or unparseable one is a no-op.
+ */
+export async function precacheAppShell(
+  caches: CacheStorageLike,
+  fetchFn: typeof fetch,
+  origin: string
+): Promise<void> {
+  const urls = await readManifest(fetchFn, origin);
+  if (!urls) return;
+
+  const cache = await caches.open(APP_SHELL_CACHE);
+  await cache.addAll(urls);
+
+  const wanted = new Set(urls);
+  for (const entry of await cache.keys()) {
+    if (!wanted.has(entry.url)) await cache.delete(entry.url);
+  }
+}
+
+/** The URLs currently precached, mirrored so a fetch handler can claim synchronously. */
+export async function readPrecachedUrls(caches: CacheStorageLike): Promise<ReadonlySet<string>> {
+  const cache = await caches.open(APP_SHELL_CACHE);
+  return new Set((await cache.keys()).map((entry) => entry.url));
+}
+
+/** Drops caches left by earlier deploys so a redeploy does not accumulate. */
+export async function deleteStaleCaches(caches: CacheStorageLike): Promise<void> {
+  for (const name of await caches.keys()) {
+    if (name.startsWith(CACHE_PREFIX) && name !== APP_SHELL_CACHE) await caches.delete(name);
+  }
+}
+
+/** Whether the shell owns this request — decided synchronously, before `respondWith`. */
+export function appShellClaims(
+  request: Request,
+  origin: string,
+  precached: ReadonlySet<string>
+): boolean {
+  if (request.method !== 'GET') return false;
+  const url = new URL(request.url);
+  if (url.origin !== origin) return false;
+  return request.mode === 'navigate' || precached.has(url.toString());
+}
+
+/**
+ * Answers a request from the shell: navigations network-first with the cached
+ * document as the offline fallback, precached URLs cache-first. `undefined`
+ * means "not the shell's" — do not intercept.
+ */
+export async function respondFromAppShell(
+  request: Request,
+  caches: CacheStorageLike,
+  fetchFn: typeof fetch,
+  origin: string
+): Promise<Response | undefined> {
+  if (request.method !== 'GET') return undefined;
+  const url = new URL(request.url);
+  if (url.origin !== origin) return undefined;
+
+  const cache = await caches.open(APP_SHELL_CACHE);
+  if (request.mode === 'navigate') {
+    try {
+      return await fetchFn(request);
+    } catch (error) {
+      const shell = await cache.match(new URL(APP_SHELL_DOCUMENT, origin).toString());
+      if (!shell) throw error;
+      return shell;
+    }
+  }
+  return cache.match(url.toString());
+}
+
+async function readManifest(fetchFn: typeof fetch, origin: string): Promise<string[] | null> {
+  let parsed: unknown;
+  try {
+    const manifest = new URL(PRECACHE_MANIFEST_URL, origin).toString();
+    const response = await fetchFn(manifest, { cache: 'no-store' });
+    if (!response.ok) return null;
+    parsed = await response.json();
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  return parsed
+    .map((entry) => (typeof entry === 'string' ? resolveEntry(entry, origin) : null))
+    .filter((url): url is string => url !== null);
+}
+
+/**
+ * A stale or tampered manifest must not make the worker cache a third party's
+ * bytes, nor the media path, whose responses are vault plaintext.
+ */
+function resolveEntry(entry: string, origin: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(entry, origin);
+  } catch {
+    return null;
+  }
+  if (url.origin !== origin) return null;
+  if (url.pathname.startsWith(STREAM_PATH_PREFIX)) return null;
+  return url.toString();
+}

--- a/packages/client/src/sw/serviceWorker.ts
+++ b/packages/client/src/sw/serviceWorker.ts
@@ -1,0 +1,9 @@
+/**
+ * The production Service Worker entry (blueprint/web-client.md "Content paths").
+ *
+ * This is a worker entry — register it, never import it into the UI realm.
+ */
+
+import { installServiceWorker, type ServiceWorkerScopeLike } from './install.js';
+
+installServiceWorker(globalThis as unknown as ServiceWorkerScopeLike);

--- a/packages/client/src/sw/testDoubles.ts
+++ b/packages/client/src/sw/testDoubles.ts
@@ -1,20 +1,19 @@
 /**
- * Cache doubles for the Service Worker unit suite. Excluded from the build
+ * Doubles for the Service Worker and media unit suites. Excluded from the build
  * (tsconfig.build.json).
  */
 
+import type { MediaRequest, MediaResponse, MessagePortLike } from '../media/protocol.js';
 import type { CacheLike, CacheStorageLike } from './precache.js';
 
 export const SW_ORIGIN = 'https://vault.example';
 
 export class FakeCache implements CacheLike {
   readonly entries = new Map<string, string>();
-  putCalls = 0;
-  /** URLs the real `Cache.addAll` would reject on, so its atomicity is testable. */
+  /** URLs the real `Cache.addAll` would reject on. */
   readonly unreachable = new Set<string>();
 
   async addAll(requests: readonly string[]): Promise<void> {
-    // The real `addAll` is atomic: one non-OK response rejects the whole call.
     if (requests.some((request) => this.unreachable.has(request))) {
       throw new TypeError('addAll: a request did not respond OK');
     }
@@ -32,11 +31,6 @@ export class FakeCache implements CacheLike {
 
   async delete(request: string): Promise<boolean> {
     return this.entries.delete(request);
-  }
-
-  /** Not on `CacheLike`; present only so a test can prove nothing calls it. */
-  put(): void {
-    this.putCalls += 1;
   }
 }
 
@@ -70,3 +64,62 @@ export const manifestFetch = (body: string, ok = true): typeof fetch =>
 export const failingFetch: typeof fetch = (async () => {
   throw new TypeError('offline');
 }) as unknown as typeof fetch;
+
+/** Answers a post synchronously, standing in for the far side of the port. */
+export type PortReply = (message: MediaRequest, port: FakePort) => void;
+
+/**
+ * One end of a `MessageChannel`. A post reaches the far side either through
+ * `peer` (a wired pair) or through `reply` (a scripted answer).
+ */
+export class FakePort implements MessagePortLike {
+  peer: FakePort | null = null;
+  readonly sent: Array<MediaRequest | MediaResponse> = [];
+  started = false;
+  closed = false;
+  private listeners: Array<(event: MessageEvent) => void> = [];
+
+  constructor(private readonly reply?: PortReply) {}
+
+  postMessage(message: unknown): void {
+    this.sent.push(message as MediaRequest);
+    this.reply?.(message as MediaRequest, this);
+    this.peer?.deliverRaw(message);
+  }
+
+  addEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
+    this.listeners.push(listener);
+  }
+
+  removeEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
+    this.listeners = this.listeners.filter((entry) => entry !== listener);
+  }
+
+  start(): void {
+    this.started = true;
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  deliver(response: MediaResponse): void {
+    this.deliverRaw(response);
+  }
+
+  /** Delivers whatever a version-skewed or hostile port might post. */
+  deliverRaw(data: unknown): void {
+    if (this.closed) return;
+    for (const listener of [...this.listeners]) {
+      listener({ data } as unknown as MessageEvent);
+    }
+  }
+
+  get listenerCount(): number {
+    return this.listeners.length;
+  }
+
+  countOf(type: MediaRequest['type']): number {
+    return this.sent.filter((message) => message.type === type).length;
+  }
+}

--- a/packages/client/src/sw/testDoubles.ts
+++ b/packages/client/src/sw/testDoubles.ts
@@ -10,8 +10,14 @@ export const SW_ORIGIN = 'https://vault.example';
 export class FakeCache implements CacheLike {
   readonly entries = new Map<string, string>();
   putCalls = 0;
+  /** URLs the real `Cache.addAll` would reject on, so its atomicity is testable. */
+  readonly unreachable = new Set<string>();
 
   async addAll(requests: readonly string[]): Promise<void> {
+    // The real `addAll` is atomic: one non-OK response rejects the whole call.
+    if (requests.some((request) => this.unreachable.has(request))) {
+      throw new TypeError('addAll: a request did not respond OK');
+    }
     for (const request of requests) this.entries.set(request, `body:${request}`);
   }
 

--- a/packages/client/src/sw/testDoubles.ts
+++ b/packages/client/src/sw/testDoubles.ts
@@ -1,0 +1,66 @@
+/**
+ * Cache doubles for the Service Worker unit suite. Excluded from the build
+ * (tsconfig.build.json).
+ */
+
+import type { CacheLike, CacheStorageLike } from './precache.js';
+
+export const SW_ORIGIN = 'https://vault.example';
+
+export class FakeCache implements CacheLike {
+  readonly entries = new Map<string, string>();
+  putCalls = 0;
+
+  async addAll(requests: readonly string[]): Promise<void> {
+    for (const request of requests) this.entries.set(request, `body:${request}`);
+  }
+
+  async match(request: string): Promise<Response | undefined> {
+    const body = this.entries.get(request);
+    return body === undefined ? undefined : new Response(body);
+  }
+
+  async keys(): Promise<readonly { readonly url: string }[]> {
+    return [...this.entries.keys()].map((url) => ({ url }));
+  }
+
+  async delete(request: string): Promise<boolean> {
+    return this.entries.delete(request);
+  }
+
+  /** Not on `CacheLike`; present only so a test can prove nothing calls it. */
+  put(): void {
+    this.putCalls += 1;
+  }
+}
+
+export class FakeCacheStorage implements CacheStorageLike {
+  readonly opened = new Map<string, FakeCache>();
+
+  async open(name: string): Promise<CacheLike> {
+    return this.cache(name);
+  }
+
+  async keys(): Promise<readonly string[]> {
+    return [...this.opened.keys()];
+  }
+
+  async delete(name: string): Promise<boolean> {
+    return this.opened.delete(name);
+  }
+
+  cache(name: string): FakeCache {
+    const existing = this.opened.get(name);
+    if (existing) return existing;
+    const created = new FakeCache();
+    this.opened.set(name, created);
+    return created;
+  }
+}
+
+export const manifestFetch = (body: string, ok = true): typeof fetch =>
+  (async () => new Response(body, { status: ok ? 200 : 404 })) as unknown as typeof fetch;
+
+export const failingFetch: typeof fetch = (async () => {
+  throw new TypeError('offline');
+}) as unknown as typeof fetch;

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -186,6 +186,7 @@ export class FakeEngineTransport implements EngineTransport {
   readonly snapshots: Array<Uint8Array | null> = [];
   readonly downloads: Uint8Array[] = [];
   siweChallenges = 0;
+  readonly downloadRanges: Array<{ node: Uint8Array; offset: number; length: number }> = [];
   readonly beginWrites: Array<{ target: WriteTarget; size: number }> = [];
   readonly chunks: Array<{ handle: WriteHandle; chunk: ArrayBuffer }> = [];
   readonly commits: WriteHandle[] = [];
@@ -201,6 +202,8 @@ export class FakeEngineTransport implements EngineTransport {
   respondDownload: (node: Uint8Array) => Promise<ArrayBuffer> = () =>
     Promise.resolve(new ArrayBuffer(0));
   respondSiweChallenge: () => Promise<string> = () => Promise.resolve(FAKE_SIWE_NONCE);
+  respondDownloadRange: (node: Uint8Array, offset: number, length: number) => Promise<ArrayBuffer> =
+    (_node, _offset, length) => Promise.resolve(new ArrayBuffer(length));
   private readonly listeners = new Set<EngineEventListener>();
 
   start(secret: ArrayBuffer): Promise<void> {
@@ -246,6 +249,11 @@ export class FakeEngineTransport implements EngineTransport {
   download(node: Uint8Array): Promise<ArrayBuffer> {
     this.downloads.push(node);
     return this.respondDownload(node);
+  }
+
+  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
+    this.downloadRanges.push({ node, offset, length });
+    return this.respondDownloadRange(node, offset, length);
   }
 
   subscribe(listener: EngineEventListener): () => void {

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -9,6 +9,7 @@
 import type { BroadcastChannelLike } from './broadcast.js';
 import type { LockManagerLike, LockRequestCallback } from './leadership.js';
 import type { EngineEventListener, EngineTransport, EngineWorkerLike } from './transport.js';
+import type { EngineHostLike } from './worker/engineHost.js';
 import type {
   CommandDescriptor,
   EventDescriptor,
@@ -64,6 +65,60 @@ export function emptySnapshot(folder: Uint8Array = new Uint8Array(16)): Snapshot
     retainedRecords: 0,
     staleness: 'fresh',
   };
+}
+
+const notStubbed = (method: string): Promise<never> =>
+  Promise.reject(new Error(`${method} not stubbed`));
+
+/**
+ * The base for every `EngineHostLike` double: a method a double does not
+ * override rejects, so a new member of the interface lands here once instead of
+ * in each double.
+ */
+export class StubEngineHost implements EngineHostLike {
+  start(_secret: ArrayBuffer): Promise<void> {
+    return notStubbed('start');
+  }
+
+  command(_command: CommandDescriptor): Promise<void> {
+    return notStubbed('command');
+  }
+
+  beginWrite(_target: WriteTarget, _size: number): Promise<WriteHandle> {
+    return notStubbed('beginWrite');
+  }
+
+  pushChunk(_handle: WriteHandle, _chunk: ArrayBuffer): Promise<void> {
+    return notStubbed('pushChunk');
+  }
+
+  commitWrite(_handle: WriteHandle): Promise<bigint> {
+    return notStubbed('commitWrite');
+  }
+
+  abortWrite(_handle: WriteHandle): Promise<void> {
+    return notStubbed('abortWrite');
+  }
+
+  snapshot(_folder: Uint8Array | null): Promise<SnapshotDescriptor> {
+    return notStubbed('snapshot');
+  }
+
+  siweChallenge(): Promise<string> {
+    return notStubbed('siweChallenge');
+  }
+
+  download(_node: Uint8Array): Promise<ArrayBuffer> {
+    return notStubbed('download');
+  }
+
+  downloadRange(_node: Uint8Array, _offset: number, _length: number): Promise<ArrayBuffer> {
+    return notStubbed('downloadRange');
+  }
+
+  nextEvent(): Promise<EventDescriptor | null> {
+    return notStubbed('nextEvent');
+  }
 }
 
 /** A same-origin broadcast bus: a posted message reaches every *other* channel. */

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -42,6 +42,8 @@ export interface EngineTransport {
   siweChallenge(): Promise<string>;
   /** Downloads one file node's plaintext through the verified read pipeline. */
   download(node: Uint8Array): Promise<ArrayBuffer>;
+  /** The verified read pipeline over one byte window; only the leaves it covers are fetched. */
+  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer>;
   /** Subscribes to the one-way event stream; returns an unsubscribe. */
   subscribe(listener: EngineEventListener): () => void;
   /** Tears the transport down; pending requests reject. */
@@ -153,6 +155,12 @@ export class LocalTransport extends CorrelatedTransport {
   download(node: Uint8Array): Promise<ArrayBuffer> {
     return this.request<ArrayBuffer>(this.ready, (id) =>
       this.worker.postMessage({ type: 'download', id, node }, [])
+    );
+  }
+
+  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
+    return this.request<ArrayBuffer>(this.ready, (id) =>
+      this.worker.postMessage({ type: 'downloadRange', id, node, offset, length }, [])
     );
   }
 

--- a/packages/client/src/worker/engineHost.ts
+++ b/packages/client/src/worker/engineHost.ts
@@ -31,7 +31,18 @@ export interface EngineHostLike {
   snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor>;
   siweChallenge(): Promise<string>;
   download(node: Uint8Array): Promise<ArrayBuffer>;
+  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer>;
   nextEvent(): Promise<EventDescriptor | null>;
+}
+
+/**
+ * The handle returns a JS-owned copy (never a WASM-memory view); reuse its exact
+ * backing buffer for the transfer, re-slicing only a partial view.
+ */
+function ownedBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
+    ? (bytes.buffer as ArrayBuffer)
+    : (bytes.slice().buffer as ArrayBuffer);
 }
 
 export class EngineHost implements EngineHostLike {
@@ -112,12 +123,13 @@ export class EngineHost implements EngineHostLike {
   }
 
   async download(node: Uint8Array): Promise<ArrayBuffer> {
-    const bytes = await this.handle.download(this.wasm.NodeId.fromBytes(node));
-    // The handle returns a JS-owned copy (never a WASM-memory view); reuse its
-    // exact backing buffer for the transfer, re-slicing only a partial view.
-    return bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
-      ? (bytes.buffer as ArrayBuffer)
-      : (bytes.slice().buffer as ArrayBuffer);
+    return ownedBuffer(await this.handle.download(this.wasm.NodeId.fromBytes(node)));
+  }
+
+  async downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
+    return ownedBuffer(
+      await this.handle.downloadRange(this.wasm.NodeId.fromBytes(node), offset, length)
+    );
   }
 
   async nextEvent(): Promise<EventDescriptor | null> {

--- a/packages/client/src/worker/engineWasm.ts
+++ b/packages/client/src/worker/engineWasm.ts
@@ -94,6 +94,8 @@ export interface WasmEngineHandle {
   snapshot(folder?: WasmNodeId): Promise<WasmSnapshotView>;
   siweChallenge(): Promise<string>;
   download(node: WasmNodeId): Promise<Uint8Array>;
+  /** `offset`/`length` cross as plain JS numbers (the seam's `f64` convention). */
+  downloadRange(node: WasmNodeId, offset: number, length: number): Promise<Uint8Array>;
   nextEvent(): Promise<WasmEvent | undefined>;
 }
 

--- a/packages/client/src/worker/protocol.ts
+++ b/packages/client/src/worker/protocol.ts
@@ -180,7 +180,8 @@ export type WorkerRequest =
   | { type: 'abortWrite'; id: number; handle: WriteHandle }
   | { type: 'snapshot'; id: number; folder: Uint8Array | null }
   | { type: 'siweChallenge'; id: number }
-  | { type: 'download'; id: number; node: Uint8Array };
+  | { type: 'download'; id: number; node: Uint8Array }
+  | { type: 'downloadRange'; id: number; node: Uint8Array; offset: number; length: number };
 
 /** A worker → UI message. */
 export type WorkerMessage =
@@ -189,9 +190,9 @@ export type WorkerMessage =
   /**
    * The correlated result of a request. A value-bearing ok response carries it:
    * a `SnapshotDescriptor` for `snapshot`, the plaintext `ArrayBuffer`
-   * (transferred, not copied) for `download`, the nonce string for
-   * `siweChallenge`, the write handle for `beginWrite`, the durable op id for
-   * `commitWrite`.
+   * (transferred, not copied) for `download`/`downloadRange`, the nonce string
+   * for `siweChallenge`, the write handle for `beginWrite`, the durable op id
+   * for `commitWrite`.
    */
   | {
       type: 'response';

--- a/packages/client/src/worker/serve.test.ts
+++ b/packages/client/src/worker/serve.test.ts
@@ -61,6 +61,7 @@ const SNAPSHOT: SnapshotDescriptor = {
 class ReadHost implements EngineHostLike {
   readonly snapshots: Uint8Array[] = [];
   readonly downloads: Uint8Array[] = [];
+  readonly downloadRanges: Array<{ node: Uint8Array; offset: number; length: number }> = [];
   readonly beginWrites: Array<{ target: WriteTarget; size: number }> = [];
   readonly chunks: Array<{ handle: bigint; bytes: number[] }> = [];
   readonly commits: bigint[] = [];
@@ -68,6 +69,8 @@ class ReadHost implements EngineHostLike {
   respondSnapshot: () => Promise<SnapshotDescriptor> = () => Promise.resolve(SNAPSHOT);
   respondDownload: () => Promise<ArrayBuffer> = () =>
     Promise.resolve(new Uint8Array([9, 8, 7]).buffer);
+  respondDownloadRange: () => Promise<ArrayBuffer> = () =>
+    Promise.resolve(new Uint8Array([5, 4]).buffer);
   siweChallenges = 0;
 
   start(): Promise<void> {
@@ -113,6 +116,11 @@ class ReadHost implements EngineHostLike {
     return this.respondDownload();
   }
 
+  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
+    this.downloadRanges.push({ node, offset, length });
+    return this.respondDownloadRange();
+  }
+
   nextEvent(): Promise<EventDescriptor | null> {
     return new Promise<EventDescriptor | null>(() => undefined);
   }
@@ -138,6 +146,24 @@ describe('serveEngine read requests', () => {
 
     const content = await transport.download(new Uint8Array(16).fill(4));
     expect([...new Uint8Array(content)]).toEqual([9, 8, 7]);
+
+    const response = toUi.find(
+      (entry) => entry.message.type === 'response' && 'result' in entry.message
+    );
+    expect(response).toBeDefined();
+    expect(response!.transfer).toEqual([content]);
+  });
+
+  it('serves a downloadRange with its window and the plaintext buffer transferred', async () => {
+    const { scope, worker, toUi } = loopback();
+    const host = new ReadHost();
+    serveEngine(scope, host);
+    const transport = new LocalTransport(worker);
+
+    const node = new Uint8Array(16).fill(4);
+    const content = await transport.downloadRange(node, 1024, 2);
+    expect([...new Uint8Array(content)]).toEqual([5, 4]);
+    expect(host.downloadRanges).toEqual([{ node, offset: 1024, length: 2 }]);
 
     const response = toUi.find(
       (entry) => entry.message.type === 'response' && 'result' in entry.message
@@ -334,6 +360,7 @@ describe('serveEngine event pump over the real EngineHost', () => {
       snapshot: () => Promise.reject(new Error('unused')),
       siweChallenge: () => Promise.reject(new Error('unused')),
       download: () => Promise.reject(new Error('unused')),
+      downloadRange: () => Promise.reject(new Error('unused')),
       nextEvent: () =>
         pumped.length > 0
           ? Promise.resolve(pumped.shift())

--- a/packages/client/src/worker/serve.test.ts
+++ b/packages/client/src/worker/serve.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { emptySnapshot, FAKE_SIWE_NONCE, fakeWasmEnums } from '../testkit.js';
+import { emptySnapshot, FAKE_SIWE_NONCE, fakeWasmEnums, StubEngineHost } from '../testkit.js';
 import { LocalTransport, type EngineWorkerLike } from '../transport.js';
-import { EngineHost, type EngineHostLike } from './engineHost.js';
+import { EngineHost } from './engineHost.js';
 import type { EngineWasm, WasmEngineHandle, WasmEvent } from './engineWasm.js';
 import type {
   EventDescriptor,
@@ -58,7 +58,7 @@ const SNAPSHOT: SnapshotDescriptor = {
   retainedRecords: 0,
 };
 
-class ReadHost implements EngineHostLike {
+class ReadHost extends StubEngineHost {
   readonly snapshots: Uint8Array[] = [];
   readonly downloads: Uint8Array[] = [];
   readonly downloadRanges: Array<{ node: Uint8Array; offset: number; length: number }> = [];

--- a/packages/client/src/worker/serve.ts
+++ b/packages/client/src/worker/serve.ts
@@ -10,6 +10,7 @@
  * order with no drops.
  */
 
+import { errorMessage } from '../errorMessage.js';
 import { WriteQueue } from '../writeQueue.js';
 import type { EngineHostLike } from './engineHost.js';
 import type { WorkerMessage, WorkerRequest } from './protocol.js';
@@ -28,10 +29,6 @@ export interface WorkerScopeLike {
   addEventListener(type: 'message', listener: (event: MessageEvent<WorkerRequest>) => void): void;
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 /** The engine's stable error code, when the thrown value carries one. */
 function errorCode(error: unknown): string | undefined {
   const code = (error as { code?: unknown } | null)?.code;
@@ -41,6 +38,9 @@ function errorCode(error: unknown): string | undefined {
 /** Wires `scope` to `host`, then signals readiness. */
 export function serveEngine(scope: WorkerScopeLike, host: EngineHostLike): void {
   const post = (message: WorkerMessage): void => scope.postMessage(message);
+  // Transfer the plaintext buffer: no byte copy through the boundary.
+  const postOwned = (id: number, result: ArrayBuffer): void =>
+    scope.postMessage({ type: 'response', id, ok: true, result }, [result]);
   const writes = new WriteQueue();
 
   const handle = async (request: WorkerRequest): Promise<void> => {
@@ -79,15 +79,14 @@ export function serveEngine(scope: WorkerScopeLike, host: EngineHostLike): void 
           return;
         }
         case 'download':
-        case 'downloadRange': {
-          const result =
-            request.type === 'download'
-              ? await host.download(request.node)
-              : await host.downloadRange(request.node, request.offset, request.length);
-          // Transfer the plaintext buffer: no byte copy through the boundary.
-          scope.postMessage({ type: 'response', id: request.id, ok: true, result }, [result]);
+          postOwned(request.id, await host.download(request.node));
           return;
-        }
+        case 'downloadRange':
+          postOwned(
+            request.id,
+            await host.downloadRange(request.node, request.offset, request.length)
+          );
+          return;
         default:
           return; // ignore non-request messages (e.g. a bootstrap handshake)
       }

--- a/packages/client/src/worker/serve.ts
+++ b/packages/client/src/worker/serve.ts
@@ -78,8 +78,12 @@ export function serveEngine(scope: WorkerScopeLike, host: EngineHostLike): void 
           post({ type: 'response', id: request.id, ok: true, result });
           return;
         }
-        case 'download': {
-          const result = await host.download(request.node);
+        case 'download':
+        case 'downloadRange': {
+          const result =
+            request.type === 'download'
+              ? await host.download(request.node)
+              : await host.downloadRange(request.node, request.offset, request.length);
           // Transfer the plaintext buffer: no byte copy through the boundary.
           scope.postMessage({ type: 'response', id: request.id, ok: true, result }, [result]);
           return;

--- a/packages/client/test/browser/conformance.worker.ts
+++ b/packages/client/test/browser/conformance.worker.ts
@@ -87,6 +87,35 @@ async function runHttpBehavioral(): Promise<void> {
   if (!method || method[1] !== 'POST') {
     throw new Error('Http: request method was not forwarded');
   }
+
+  // A chunked body with no Content-Length is bounded by the streaming cap.
+  const overrun = await http.sendCapped(
+    { method: 'GET', url: `${origin}/mock-http/stream`, headers: [], body: null },
+    4096
+  );
+  if (overrun.kind !== 'tooLarge') {
+    throw new Error(`Http: expected tooLarge for an uncapped stream, got ${overrun.kind}`);
+  }
+  if (overrun.limit !== 4096 || overrun.observed <= 4096) {
+    throw new Error(`Http: tooLarge reported ${overrun.observed}/${overrun.limit}`);
+  }
+
+  // The cap is exclusive: a body exactly at it is admitted.
+  const atCap = await http.sendCapped(
+    {
+      method: 'POST',
+      url: `${origin}/mock-http/echo`,
+      headers: [],
+      body: new Uint8Array([1, 2, 3, 4]),
+    },
+    4
+  );
+  if (atCap.kind !== 'response') {
+    throw new Error('Http: an at-cap body was not admitted');
+  }
+  if (atCap.body.length !== 4 || atCap.body[3] !== 4) {
+    throw new Error('Http: at-cap body did not round-trip');
+  }
 }
 
 async function run(seam: string): Promise<void> {

--- a/packages/client/test/browser/election.ts
+++ b/packages/client/test/browser/election.ts
@@ -1,0 +1,47 @@
+/**
+ * Waits out the engine-lock election for the tab-leadership and media browser
+ * harnesses, so a caller's role assertion reads a decided outcome rather than
+ * `EngineClient`'s pre-election `follower` default.
+ */
+import type { EngineClient } from '../../src/engineClient.js';
+
+const POLL_MS = 10;
+const TIMEOUT_MS = 10_000;
+
+/** This tab's Web Locks client id, read back off a lock only this tab can hold. */
+async function ownClientId(): Promise<string> {
+  const probe = `cb-election-probe-${crypto.randomUUID()}`;
+  let mine: string | undefined;
+  await navigator.locks.request(probe, async () => {
+    const { held = [] } = await navigator.locks.query();
+    mine = held.find((lock) => lock.name === probe)?.clientId;
+  });
+  if (mine === undefined) throw new Error('navigator.locks.query() reported no client id');
+  return mine;
+}
+
+/**
+ * Leader is `currentRole()`, which promotion flips only once the engine worker
+ * is live; follower is this tab's *own* request queued behind another tab's held
+ * lock. Matching the client id keeps a leader's momentarily-pending request from
+ * reading as a follower's.
+ */
+export async function awaitElection(
+  client: EngineClient,
+  lockName: string
+): Promise<'leader' | 'follower'> {
+  const mine = await ownClientId();
+  const deadline = Date.now() + TIMEOUT_MS;
+  for (;;) {
+    if (client.currentRole() === 'leader') return 'leader';
+    const { held = [], pending = [] } = await navigator.locks.query();
+    if (
+      held.some((lock) => lock.name === lockName && lock.clientId !== mine) &&
+      pending.some((lock) => lock.name === lockName && lock.clientId === mine)
+    ) {
+      return 'follower';
+    }
+    if (Date.now() > deadline) throw new Error(`engine-lock election never settled: ${lockName}`);
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+  }
+}

--- a/packages/client/test/browser/fakeEngine.worker.ts
+++ b/packages/client/test/browser/fakeEngine.worker.ts
@@ -68,6 +68,10 @@ class FakeHost implements EngineHostLike {
     return Promise.reject(new Error('fake host serves no downloads'));
   }
 
+  downloadRange(): Promise<ArrayBuffer> {
+    return Promise.reject(new Error('fake host serves no downloads'));
+  }
+
   nextEvent(): Promise<EventDescriptor | null> {
     const next = this.queued.shift();
     if (next) return Promise.resolve(next);

--- a/packages/client/test/browser/fakeEngine.worker.ts
+++ b/packages/client/test/browser/fakeEngine.worker.ts
@@ -10,16 +10,12 @@
  *   the single event pump streams in order.
  */
 import { serveEngine, type WorkerScopeLike } from '../../src/worker/serve.js';
-import type { EngineHostLike } from '../../src/worker/engineHost.js';
-import type {
-  CommandDescriptor,
-  EventDescriptor,
-  SnapshotDescriptor,
-} from '../../src/worker/protocol.js';
+import { StubEngineHost } from '../../src/testkit.js';
+import type { CommandDescriptor, EventDescriptor } from '../../src/worker/protocol.js';
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-class FakeHost implements EngineHostLike {
+class FakeHost extends StubEngineHost {
   private commandCount = 0;
   private queued: EventDescriptor[] = [];
   private waiters: Array<(event: EventDescriptor | null) => void> = [];
@@ -40,36 +36,8 @@ class FakeHost implements EngineHostLike {
     await sleep(this.commandCount === 1 ? 40 : 5);
   }
 
-  beginWrite(): Promise<bigint> {
-    return Promise.reject(new Error('fake host serves no writes'));
-  }
-
-  pushChunk(): Promise<void> {
-    return Promise.reject(new Error('fake host serves no writes'));
-  }
-
-  commitWrite(): Promise<bigint> {
-    return Promise.reject(new Error('fake host serves no writes'));
-  }
-
   abortWrite(): Promise<void> {
     return Promise.resolve();
-  }
-
-  snapshot(): Promise<SnapshotDescriptor> {
-    return Promise.reject(new Error('fake host serves no snapshots'));
-  }
-
-  siweChallenge(): Promise<string> {
-    return Promise.reject(new Error('fake host serves no siwe challenges'));
-  }
-
-  download(): Promise<ArrayBuffer> {
-    return Promise.reject(new Error('fake host serves no downloads'));
-  }
-
-  downloadRange(): Promise<ArrayBuffer> {
-    return Promise.reject(new Error('fake host serves no downloads'));
   }
 
   nextEvent(): Promise<EventDescriptor | null> {

--- a/packages/client/test/browser/index.html
+++ b/packages/client/test/browser/index.html
@@ -8,8 +8,10 @@
     <main id="status">Browser seam conformance harness ready.</main>
     <main id="engine-status">Engine worker harness loading…</main>
     <main id="leadership-status">Tab leadership harness loading…</main>
+    <main id="media-status">Media brokerage harness loading…</main>
     <script type="module" src="./harness.ts"></script>
     <script type="module" src="./engineHarness.ts"></script>
     <script type="module" src="./leadership.ts"></script>
+    <script type="module" src="./media.ts"></script>
   </body>
 </html>

--- a/packages/client/test/browser/journalEngine.worker.ts
+++ b/packages/client/test/browser/journalEngine.worker.ts
@@ -105,6 +105,10 @@ class JournalHost implements EngineHostLike {
     return Promise.reject(new Error('journal host serves no downloads'));
   }
 
+  downloadRange(): Promise<ArrayBuffer> {
+    return Promise.reject(new Error('journal host serves no downloads'));
+  }
+
   nextEvent(): Promise<EventDescriptor | null> {
     // No engine events in this fake; park the pump forever.
     return new Promise<EventDescriptor | null>(() => undefined);

--- a/packages/client/test/browser/journalEngine.worker.ts
+++ b/packages/client/test/browser/journalEngine.worker.ts
@@ -10,13 +10,8 @@
  * every op the dead leader had already accepted — no accepted work is lost.
  */
 import { serveEngine, type WorkerScopeLike } from '../../src/worker/serve.js';
-import type { EngineHostLike } from '../../src/worker/engineHost.js';
-import type {
-  CommandDescriptor,
-  EventDescriptor,
-  SnapshotDescriptor,
-  WriteTarget,
-} from '../../src/worker/protocol.js';
+import { StubEngineHost } from '../../src/testkit.js';
+import type { CommandDescriptor, EventDescriptor, WriteTarget } from '../../src/worker/protocol.js';
 
 const DB_NAME = 'cb-leadership-journal';
 const STORE = 'ops';
@@ -46,7 +41,7 @@ async function journal(kind: string): Promise<void> {
   }
 }
 
-class JournalHost implements EngineHostLike {
+class JournalHost extends StubEngineHost {
   private nextHandle = 1n;
   // Op ids are a separate id space from write handles; keep them disjoint so a
   // client that conflates the two cannot pass against this fake.
@@ -91,22 +86,6 @@ class JournalHost implements EngineHostLike {
   abortWrite(handle: bigint): Promise<void> {
     this.open.delete(handle);
     return Promise.resolve();
-  }
-
-  snapshot(): Promise<SnapshotDescriptor> {
-    return Promise.reject(new Error('journal host serves no snapshots'));
-  }
-
-  siweChallenge(): Promise<string> {
-    return Promise.reject(new Error('journal host serves no siwe challenges'));
-  }
-
-  download(): Promise<ArrayBuffer> {
-    return Promise.reject(new Error('journal host serves no downloads'));
-  }
-
-  downloadRange(): Promise<ArrayBuffer> {
-    return Promise.reject(new Error('journal host serves no downloads'));
   }
 
   nextEvent(): Promise<EventDescriptor | null> {

--- a/packages/client/test/browser/leadership.ts
+++ b/packages/client/test/browser/leadership.ts
@@ -9,6 +9,7 @@
  */
 import { EngineClient } from '../../src/engineClient.js';
 import type { PendingClass } from '../../src/worker/protocol.js';
+import { awaitElection } from './election.js';
 import { hex, unhex } from './hexUtil.js';
 
 const JOURNAL_DB = 'cb-leadership-journal';
@@ -73,7 +74,7 @@ function settle(error: unknown): string {
 // A valid secp256k1 identity scalar placeholder (the journal fake ignores it).
 const secret = (): ArrayBuffer => new Uint8Array(32).fill(1).buffer;
 
-window.cbCreate = ({ lockName, channelName, worker }: HarnessOptions): Promise<void> => {
+window.cbCreate = async ({ lockName, channelName, worker }: HarnessOptions): Promise<void> => {
   const workerUrl =
     worker === 'engine'
       ? new URL('./engine.worker.ts', import.meta.url)
@@ -86,8 +87,7 @@ window.cbCreate = ({ lockName, channelName, worker }: HarnessOptions): Promise<v
     // Failover re-derivation: a real login re-exports this from Core Kit.
     secretSource: { provideSecret: () => Promise.resolve(secret()) },
   });
-  // Let the lock election settle so role() is meaningful to the caller.
-  return new Promise<void>((resolve) => setTimeout(resolve, 50));
+  await awaitElection(client, lockName);
 };
 
 window.cbRole = (): string => client?.currentRole() ?? 'none';

--- a/packages/client/test/browser/media.spec.ts
+++ b/packages/client/test/browser/media.spec.ts
@@ -1,0 +1,252 @@
+import { createHash } from 'node:crypto';
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+
+import { hex } from './hexUtil.js';
+import { fixtureSlice, LEADER_SEED, TAB_SEED } from './mediaFixture.js';
+import type { MediaFetchResult } from './media.js';
+
+/**
+ * The Service Worker media-brokerage slice of the merge-blocking browser suite
+ * (blueprint/testing.md law 1, blueprint/web-client.md "Streaming media — the SW
+ * is a dumb pipe"). A real Service Worker intercepts real `/stream/` fetches and
+ * forwards them over a real `MessageChannel` to the tab-side broker, whose
+ * windowed reads come back as a real `ReadableStream`.
+ */
+
+interface MediaHarness {
+  cbMediaEngine(options: { lockName: string; channelName: string }): Promise<string>;
+  cbMediaStart(options: { reader: 'local' | 'engine' }): Promise<boolean>;
+  cbMediaAwaitControl(): Promise<boolean>;
+  cbMediaTicket(size: number, mimeType: string): string;
+  cbMediaFetch(url: string, range: string | null): Promise<MediaFetchResult>;
+  cbMediaReaderCalls(): number;
+  cbMediaPortRequests(): number;
+  cbMediaDispose(): Promise<void>;
+}
+
+const MIME = 'video/mp4';
+const WINDOW_BYTES = 1024 * 1024;
+
+let testSeq = 0;
+
+function digestOf(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function headers(result: MediaFetchResult): Map<string, string> {
+  return new Map(result.headers);
+}
+
+function names(): { lockName: string; channelName: string } {
+  testSeq += 1;
+  return { lockName: `cb-media-lock-${testSeq}`, channelName: `cb-media-chan-${testSeq}` };
+}
+
+interface Tab {
+  page: Page;
+  engine(lockName: string, channelName: string): Promise<string>;
+  start(reader: 'local' | 'engine'): Promise<boolean>;
+  awaitControl(): Promise<boolean>;
+  ticket(size: number): Promise<string>;
+  fetch(url: string, range?: string): Promise<MediaFetchResult>;
+  readerCalls(): Promise<number>;
+  portRequests(): Promise<number>;
+  dispose(): Promise<void>;
+}
+
+async function openTab(context: BrowserContext): Promise<Tab> {
+  const page = await context.newPage();
+  page.on('pageerror', (error) => console.log(`[browser:pageerror] ${error.message}`));
+  await page.goto('/');
+  await page.waitForFunction(
+    () => typeof (window as unknown as { cbMediaStart?: unknown }).cbMediaStart === 'function'
+  );
+  return {
+    page,
+    engine: (lockName, channelName) =>
+      page.evaluate((opts) => (window as unknown as MediaHarness).cbMediaEngine(opts), {
+        lockName,
+        channelName,
+      }),
+    start: (reader) =>
+      page.evaluate((r) => (window as unknown as MediaHarness).cbMediaStart({ reader: r }), reader),
+    awaitControl: () =>
+      page.evaluate(() => (window as unknown as MediaHarness).cbMediaAwaitControl()),
+    ticket: (size) =>
+      page.evaluate(
+        (args) => (window as unknown as MediaHarness).cbMediaTicket(args.size, args.mime),
+        { size, mime: MIME }
+      ),
+    fetch: (url, range) =>
+      page.evaluate(
+        (args) => (window as unknown as MediaHarness).cbMediaFetch(args.url, args.range),
+        {
+          url,
+          range: range ?? null,
+        }
+      ),
+    readerCalls: () =>
+      page.evaluate(() => (window as unknown as MediaHarness).cbMediaReaderCalls()),
+    portRequests: () =>
+      page.evaluate(() => (window as unknown as MediaHarness).cbMediaPortRequests()),
+    dispose: () => page.evaluate(() => (window as unknown as MediaHarness).cbMediaDispose()),
+  };
+}
+
+/** A controlled tab whose broker serves the tab-seeded fixture. */
+async function localTab(context: BrowserContext): Promise<Tab> {
+  const tab = await openTab(context);
+  expect(await tab.start('local')).toBe(true);
+  expect(await tab.awaitControl()).toBe(true);
+  return tab;
+}
+
+test.describe('Service Worker media brokerage over a real byte pipe', () => {
+  test('a whole-file request returns 200 with the exact bytes, ranges offered and no-store', async ({
+    context,
+  }) => {
+    const tab = await localTab(context);
+    const size = 4096;
+
+    const result = await tab.fetch(await tab.ticket(size));
+
+    expect(result.status).toBe(200);
+    expect(result.bodyHex).toBe(hex(fixtureSlice(0, size, TAB_SEED)));
+    const head = headers(result);
+    expect(head.get('accept-ranges')).toBe('bytes');
+    expect(head.get('cache-control')).toBe('no-store');
+    expect(head.get('content-type')).toBe(MIME);
+    expect(head.get('content-length')).toBe(String(size));
+
+    await tab.dispose();
+  });
+
+  test('a Range request returns 206 with the window bytes and a matching content-range', async ({
+    context,
+  }) => {
+    const tab = await localTab(context);
+    const size = 4096;
+
+    const result = await tab.fetch(await tab.ticket(size), 'bytes=1000-1999');
+
+    expect(result.status).toBe(206);
+    expect(result.bodyHex).toBe(hex(fixtureSlice(1000, 1000, TAB_SEED)));
+    const head = headers(result);
+    expect(head.get('content-range')).toBe(`bytes 1000-1999/${size}`);
+    expect(head.get('content-length')).toBe('1000');
+
+    await tab.dispose();
+  });
+
+  test('a range past EOF returns 416 with the unsatisfiable content-range', async ({ context }) => {
+    const tab = await localTab(context);
+    const size = 4096;
+
+    const result = await tab.fetch(await tab.ticket(size), `bytes=${size}-`);
+
+    expect(result.status).toBe(416);
+    expect(result.byteLength).toBe(0);
+    expect(headers(result).get('content-range')).toBe(`bytes */${size}`);
+
+    await tab.dispose();
+  });
+
+  test('an unknown ticket returns 404', async ({ context }) => {
+    const tab = await localTab(context);
+
+    const result = await tab.fetch('/stream/no-such-ticket');
+
+    expect(result.status).toBe(404);
+    expect(result.byteLength).toBe(0);
+
+    await tab.dispose();
+  });
+
+  test('a file larger than one window streams through several windows, byte-exact', async ({
+    context,
+  }) => {
+    const tab = await localTab(context);
+    const size = WINDOW_BYTES * 2 + 512 * 1024;
+
+    const result = await tab.fetch(await tab.ticket(size));
+
+    expect(result.status).toBe(200);
+    expect(result.byteLength).toBe(size);
+    expect(result.digestHex).toBe(digestOf(fixtureSlice(0, size, TAB_SEED)));
+    // Peak memory is one window, not the file: one read per window, no more.
+    expect(await tab.readerCalls()).toBe(Math.ceil(size / WINDOW_BYTES));
+
+    await tab.dispose();
+  });
+
+  test('two open tabs each stream from their own broker', async ({ context }) => {
+    const a = await localTab(context);
+    const b = await localTab(context);
+    const sizeA = 4096;
+    const sizeB = 2048;
+    const ticketA = await a.ticket(sizeA);
+    const ticketB = await b.ticket(sizeB);
+
+    // B brokered last, so a worker holding one port would answer A's ticket from
+    // B's registry — which has never seen it.
+    const fromA = await a.fetch(ticketA);
+    const fromB = await b.fetch(ticketB);
+
+    expect(fromA.status).toBe(200);
+    expect(fromA.bodyHex).toBe(hex(fixtureSlice(0, sizeA, TAB_SEED)));
+    expect(fromB.status).toBe(200);
+    expect(fromB.bodyHex).toBe(hex(fixtureSlice(0, sizeB, TAB_SEED)));
+
+    await b.dispose();
+    await a.dispose();
+  });
+
+  test('a killed Service Worker re-brokers a port and the next request still streams', async ({
+    context,
+  }) => {
+    const tab = await localTab(context);
+    const size = 2048;
+    const ticket = await tab.ticket(size);
+    expect((await tab.fetch(ticket)).status).toBe(200);
+
+    const before = await tab.portRequests();
+    const cdp = await context.newCDPSession(tab.page);
+    await cdp.send('ServiceWorker.enable');
+    await cdp.send('ServiceWorker.stopAllWorkers');
+    await cdp.detach();
+
+    // A restarted worker holds no port, so it must ask the tab for a fresh one
+    // before it can answer — this request succeeds only if it re-brokered.
+    const result = await tab.fetch(ticket);
+    expect(result.status).toBe(200);
+    expect(result.bodyHex).toBe(hex(fixtureSlice(0, size, TAB_SEED)));
+    expect(await tab.portRequests()).toBeGreaterThan(before);
+
+    await tab.dispose();
+  });
+
+  test('a follower tab routes its media read through the leader engine', async ({ context }) => {
+    const { lockName, channelName } = names();
+    const a = await openTab(context);
+    const b = await openTab(context);
+
+    expect(await a.engine(lockName, channelName)).toBe('leader');
+    expect(await b.engine(lockName, channelName)).toBe('follower');
+
+    // Only the follower brokers a port, so the pipe answers from its reader —
+    // the broadcast wire to the leader's engine worker.
+    expect(await b.start('engine')).toBe(true);
+    expect(await b.awaitControl()).toBe(true);
+
+    const size = 96 * 1024;
+    const result = await b.fetch(await b.ticket(size));
+
+    expect(result.status).toBe(200);
+    expect(result.byteLength).toBe(size);
+    // The leader's seed: bytes the follower's own tab never synthesizes.
+    expect(result.digestHex).toBe(digestOf(fixtureSlice(0, size, LEADER_SEED)));
+
+    await b.dispose();
+    await a.dispose();
+  });
+});

--- a/packages/client/test/browser/media.ts
+++ b/packages/client/test/browser/media.ts
@@ -1,0 +1,164 @@
+/**
+ * Page harness for the Service Worker media-brokerage browser suite. Each
+ * Playwright page is a real tab: the Service Worker, its `fetch` interception,
+ * the brokered `MessageChannel`, and the response `ReadableStream` are all the
+ * browser's own — nothing here is a double.
+ */
+import { EngineClient } from '../../src/engineClient.js';
+import { MediaService } from '../../src/media/service.js';
+import { MEDIA_PORT_REQUEST } from '../../src/media/protocol.js';
+import type { MediaReader } from '../../src/media/broker.js';
+import { hex } from './hexUtil.js';
+import { fixtureBuffer, TAB_SEED } from './mediaFixture.js';
+
+/** The dev server transpiles TS per module, so the worker must be a module worker. */
+const SW_SCRIPT = '/sw.ts';
+
+/** Bodies above this are asserted by digest; hex would blow up the page bridge. */
+const HEX_BODY_LIMIT = 64 * 1024;
+
+/** Which `MediaReader` backs the tab's broker. */
+export type MediaReaderKind = 'local' | 'engine';
+
+export interface MediaStartOptions {
+  reader: MediaReaderKind;
+}
+
+export interface MediaEngineOptions {
+  lockName: string;
+  channelName: string;
+}
+
+/** A page.evaluate-safe response projection; bytes as hex, plus a SHA-256. */
+export interface MediaFetchResult {
+  status: number;
+  headers: Array<[string, string]>;
+  byteLength: number;
+  digestHex: string;
+  /** Empty for bodies over `HEX_BODY_LIMIT`; `digestHex` carries those. */
+  bodyHex: string;
+  error?: string;
+}
+
+declare global {
+  interface Window {
+    cbMediaEngine(options: MediaEngineOptions): Promise<string>;
+    cbMediaStart(options: MediaStartOptions): Promise<boolean>;
+    cbMediaAwaitControl(): Promise<boolean>;
+    cbMediaTicket(size: number, mimeType: string): string;
+    cbMediaFetch(url: string, range: string | null): Promise<MediaFetchResult>;
+    cbMediaReaderCalls(): number;
+    cbMediaPortRequests(): number;
+    cbMediaDispose(): Promise<void>;
+  }
+}
+
+let service: MediaService | null = null;
+let client: EngineClient | null = null;
+let readerCalls = 0;
+let portRequests = 0;
+
+// A worker that restarted lost its port and must ask for one; counting the asks
+// is how the spec distinguishes a re-broker from a port that never died.
+navigator.serviceWorker.addEventListener('message', (event: MessageEvent) => {
+  if ((event.data as { type?: unknown } | null)?.type === MEDIA_PORT_REQUEST) portRequests += 1;
+});
+
+/** Serves the tab's own fixture, counting reads so the spec can see windowing. */
+const localReader: MediaReader = {
+  downloadRange: (_node, offset, length) => {
+    readerCalls += 1;
+    return Promise.resolve(fixtureBuffer(offset, length, TAB_SEED));
+  },
+};
+
+/** Routes every read through this tab's engine client — a follower's wire. */
+const engineReader: MediaReader = {
+  downloadRange: (node, offset, length) => {
+    readerCalls += 1;
+    return client!.downloadRange(node, offset, length);
+  },
+};
+
+window.cbMediaEngine = ({ lockName, channelName }: MediaEngineOptions): Promise<string> => {
+  client = new EngineClient({
+    locks: navigator.locks,
+    lockName,
+    createChannel: () => new BroadcastChannel(channelName),
+    spawnWorker: () =>
+      new Worker(new URL('./mediaEngine.worker.ts', import.meta.url), {
+        type: 'module',
+      }),
+  });
+  // Let the lock election settle so the caller's role assertion is meaningful.
+  return new Promise<string>((resolve) =>
+    setTimeout(() => resolve(client?.currentRole() ?? 'none'), 50)
+  );
+};
+
+window.cbMediaStart = async ({ reader }: MediaStartOptions): Promise<boolean> => {
+  service = new MediaService({
+    container: navigator.serviceWorker,
+    scriptUrl: SW_SCRIPT,
+    scriptType: 'module',
+    reader: reader === 'engine' ? engineReader : localReader,
+  });
+  await service.start();
+  // A registration does not control the tab until it claims, and only a
+  // controlled tab streams; wait for that before reporting the pipe live.
+  await window.cbMediaAwaitControl();
+  return service.streaming;
+};
+
+/** A registration does not control the tab until it claims; a fetch before that misses the pipe. */
+window.cbMediaAwaitControl = async (): Promise<boolean> => {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (navigator.serviceWorker.controller !== null) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return false;
+};
+
+window.cbMediaTicket = (size: number, mimeType: string): string =>
+  service!.createStreamUrl({ node: new Uint8Array(16).fill(3), size, mimeType });
+
+window.cbMediaReaderCalls = (): number => readerCalls;
+
+window.cbMediaPortRequests = (): number => portRequests;
+
+window.cbMediaFetch = async (url: string, range: string | null): Promise<MediaFetchResult> => {
+  try {
+    const response = await fetch(url, range === null ? {} : { headers: { range } });
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
+    return {
+      status: response.status,
+      headers: [...response.headers].map(([name, value]) => [name, value]),
+      byteLength: bytes.byteLength,
+      digestHex: hex(digest),
+      bodyHex: bytes.byteLength <= HEX_BODY_LIMIT ? hex(bytes) : '',
+    };
+  } catch (error) {
+    return {
+      status: 0,
+      headers: [],
+      byteLength: 0,
+      digestHex: '',
+      bodyHex: '',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+};
+
+window.cbMediaDispose = async (): Promise<void> => {
+  await service?.dispose();
+  service = null;
+  await client?.dispose();
+  client = null;
+  readerCalls = 0;
+  const registrations = await navigator.serviceWorker.getRegistrations();
+  await Promise.all(registrations.map((registration) => registration.unregister()));
+};
+
+const status = document.getElementById('media-status');
+if (status) status.textContent = 'Media brokerage harness ready.';

--- a/packages/client/test/browser/media.ts
+++ b/packages/client/test/browser/media.ts
@@ -8,6 +8,7 @@ import { EngineClient } from '../../src/engineClient.js';
 import { MediaService } from '../../src/media/service.js';
 import { MEDIA_PORT_REQUEST } from '../../src/media/protocol.js';
 import type { MediaReader } from '../../src/media/broker.js';
+import { awaitElection } from './election.js';
 import { hex } from './hexUtil.js';
 import { fixtureBuffer, TAB_SEED } from './mediaFixture.js';
 
@@ -80,7 +81,7 @@ const engineReader: MediaReader = {
   },
 };
 
-window.cbMediaEngine = async ({ lockName, channelName }: MediaEngineOptions): Promise<string> => {
+window.cbMediaEngine = ({ lockName, channelName }: MediaEngineOptions): Promise<string> => {
   client = new EngineClient({
     locks: navigator.locks,
     lockName,
@@ -90,14 +91,7 @@ window.cbMediaEngine = async ({ lockName, channelName }: MediaEngineOptions): Pr
         type: 'module',
       }),
   });
-  // The caller asserts an exact role, so wait for the election rather than
-  // guessing at how long a loaded CI machine needs to settle it.
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    const role = client?.currentRole() ?? 'none';
-    if (role !== 'none') return role;
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
-  return 'none';
+  return awaitElection(client, lockName);
 };
 
 window.cbMediaStart = async ({ reader }: MediaStartOptions): Promise<boolean> => {

--- a/packages/client/test/browser/media.ts
+++ b/packages/client/test/browser/media.ts
@@ -102,8 +102,6 @@ window.cbMediaStart = async ({ reader }: MediaStartOptions): Promise<boolean> =>
     reader: reader === 'engine' ? engineReader : localReader,
   });
   await service.start();
-  // A registration does not control the tab until it claims, and only a
-  // controlled tab streams; wait for that before reporting the pipe live.
   await window.cbMediaAwaitControl();
   return service.streaming;
 };

--- a/packages/client/test/browser/media.ts
+++ b/packages/client/test/browser/media.ts
@@ -80,7 +80,7 @@ const engineReader: MediaReader = {
   },
 };
 
-window.cbMediaEngine = ({ lockName, channelName }: MediaEngineOptions): Promise<string> => {
+window.cbMediaEngine = async ({ lockName, channelName }: MediaEngineOptions): Promise<string> => {
   client = new EngineClient({
     locks: navigator.locks,
     lockName,
@@ -90,10 +90,14 @@ window.cbMediaEngine = ({ lockName, channelName }: MediaEngineOptions): Promise<
         type: 'module',
       }),
   });
-  // Let the lock election settle so the caller's role assertion is meaningful.
-  return new Promise<string>((resolve) =>
-    setTimeout(() => resolve(client?.currentRole() ?? 'none'), 50)
-  );
+  // The caller asserts an exact role, so wait for the election rather than
+  // guessing at how long a loaded CI machine needs to settle it.
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const role = client?.currentRole() ?? 'none';
+    if (role !== 'none') return role;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return 'none';
 };
 
 window.cbMediaStart = async ({ reader }: MediaStartOptions): Promise<boolean> => {
@@ -156,6 +160,7 @@ window.cbMediaDispose = async (): Promise<void> => {
   await client?.dispose();
   client = null;
   readerCalls = 0;
+  portRequests = 0;
   const registrations = await navigator.serviceWorker.getRegistrations();
   await Promise.all(registrations.map((registration) => registration.unregister()));
 };

--- a/packages/client/test/browser/mediaEngine.worker.ts
+++ b/packages/client/test/browser/mediaEngine.worker.ts
@@ -1,0 +1,54 @@
+/**
+ * A protocol-speaking engine worker (no WASM) that serves ranged plaintext, for
+ * the follower media-routing slice of the browser suite. Only the leader tab
+ * spawns it, so bytes carrying `LEADER_SEED` prove a follower's `/stream/` read
+ * travelled the broadcast wire to the leader's worker.
+ */
+import { serveEngine, type WorkerScopeLike } from '../../src/worker/serve.js';
+import type { EngineHostLike } from '../../src/worker/engineHost.js';
+import type { EventDescriptor, SnapshotDescriptor } from '../../src/worker/protocol.js';
+import { fixtureBuffer, LEADER_SEED } from './mediaFixture.js';
+
+class MediaHost implements EngineHostLike {
+  start(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  command(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  beginWrite(): Promise<bigint> {
+    return Promise.reject(new Error('media host serves no writes'));
+  }
+
+  pushChunk(): Promise<void> {
+    return Promise.reject(new Error('media host serves no writes'));
+  }
+
+  commitWrite(): Promise<bigint> {
+    return Promise.reject(new Error('media host serves no writes'));
+  }
+
+  abortWrite(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  snapshot(): Promise<SnapshotDescriptor> {
+    return Promise.reject(new Error('media host serves no snapshots'));
+  }
+
+  download(): Promise<ArrayBuffer> {
+    return Promise.reject(new Error('media host serves whole files only by range'));
+  }
+
+  downloadRange(_node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
+    return Promise.resolve(fixtureBuffer(offset, length, LEADER_SEED));
+  }
+
+  nextEvent(): Promise<EventDescriptor | null> {
+    return new Promise<EventDescriptor | null>(() => undefined);
+  }
+}
+
+serveEngine(self as unknown as WorkerScopeLike, new MediaHost());

--- a/packages/client/test/browser/mediaEngine.worker.ts
+++ b/packages/client/test/browser/mediaEngine.worker.ts
@@ -5,11 +5,11 @@
  * travelled the broadcast wire to the leader's worker.
  */
 import { serveEngine, type WorkerScopeLike } from '../../src/worker/serve.js';
-import type { EngineHostLike } from '../../src/worker/engineHost.js';
-import type { EventDescriptor, SnapshotDescriptor } from '../../src/worker/protocol.js';
+import { StubEngineHost } from '../../src/testkit.js';
+import type { EventDescriptor } from '../../src/worker/protocol.js';
 import { fixtureBuffer, LEADER_SEED } from './mediaFixture.js';
 
-class MediaHost implements EngineHostLike {
+class MediaHost extends StubEngineHost {
   start(): Promise<void> {
     return Promise.resolve();
   }
@@ -18,28 +18,8 @@ class MediaHost implements EngineHostLike {
     return Promise.resolve();
   }
 
-  beginWrite(): Promise<bigint> {
-    return Promise.reject(new Error('media host serves no writes'));
-  }
-
-  pushChunk(): Promise<void> {
-    return Promise.reject(new Error('media host serves no writes'));
-  }
-
-  commitWrite(): Promise<bigint> {
-    return Promise.reject(new Error('media host serves no writes'));
-  }
-
   abortWrite(): Promise<void> {
     return Promise.resolve();
-  }
-
-  snapshot(): Promise<SnapshotDescriptor> {
-    return Promise.reject(new Error('media host serves no snapshots'));
-  }
-
-  download(): Promise<ArrayBuffer> {
-    return Promise.reject(new Error('media host serves whole files only by range'));
   }
 
   downloadRange(_node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {

--- a/packages/client/test/browser/mediaFixture.ts
+++ b/packages/client/test/browser/mediaFixture.ts
@@ -1,0 +1,22 @@
+/**
+ * The deterministic plaintext the media browser suite streams. Every realm —
+ * page, engine worker, and the Node-side spec — derives the same bytes from
+ * `offset` alone, so a byte-exact assertion needs no shared buffer.
+ */
+
+/** Bytes produced tab-side, by the harness's own in-page reader. */
+export const TAB_SEED = 7;
+
+/** Bytes produced only inside the leader's engine worker. */
+export const LEADER_SEED = 199;
+
+export function fixtureBuffer(offset: number, length: number, seed: number): ArrayBuffer {
+  const buffer = new ArrayBuffer(length);
+  const bytes = new Uint8Array(buffer);
+  for (let i = 0; i < length; i += 1) bytes[i] = ((offset + i) * 31 + seed) & 0xff;
+  return buffer;
+}
+
+export function fixtureSlice(offset: number, length: number, seed: number): Uint8Array {
+  return new Uint8Array(fixtureBuffer(offset, length, seed));
+}

--- a/packages/client/test/browser/sw.ts
+++ b/packages/client/test/browser/sw.ts
@@ -1,0 +1,6 @@
+/**
+ * The Service Worker entry for the browser suite. It is the production entry
+ * verbatim — the suite exercises the real worker, not a stand-in — and lives at
+ * the dev-server root so a `/sw.ts` registration takes root scope.
+ */
+import '../../src/sw/serviceWorker.js';

--- a/packages/client/test/browser/vite.config.ts
+++ b/packages/client/test/browser/vite.config.ts
@@ -50,6 +50,16 @@ function mockNetwork(): Plugin {
           return;
         }
 
+        if (url.startsWith('/mock-http/stream')) {
+          // Chunked with no Content-Length: only the streaming cap can bound it.
+          res.statusCode = 200;
+          for (let sent = 0; sent < 64 * 1024; sent += 1024) {
+            res.write(Buffer.alloc(1024, 7));
+          }
+          res.end();
+          return;
+        }
+
         if (url.startsWith('/mock-http/echo')) {
           const chunks: Buffer[] = [];
           req.on('data', (chunk: Buffer) => chunks.push(chunk));

--- a/packages/client/tsconfig.build.json
+++ b/packages/client/tsconfig.build.json
@@ -8,5 +8,5 @@
     // The worker body is debugged in the browser from apps/web's build.
     "sourceMap": true
   },
-  "exclude": ["src/**/*.test.ts", "src/testkit.ts"]
+  "exclude": ["src/**/*.test.ts", "src/testkit.ts", "src/sw/testDoubles.ts"]
 }


### PR DESCRIPTION
## Problem

`blueprint/web-client.md` resolves the #28 D4 open point by demoting the v1 decrypt Service Worker — a crypto layer doing CTR streaming over a whole buffered file — to a **dumb byte pipe**: a media element requests an opaque `/stream/…` ticket URL, the worker forwards the Range over a `MessageChannel` port brokered at registration, and plaintext streams back through the port. The worker holds no keys, no crypto, and no state worth keeping. The same worker precaches the app shell, because a vault you can mutate offline is a vault whose UI must boot offline.

None of it existed. There was no Service Worker, no `/stream/` surface, no precache, and no ranged read to sit under any of it — `leaf_range_for_byte_range` shipped in #700 with zero call sites, and the engine could only return whole files.

This slice also carries the cross-cutting residual of #742/#787 (closed engine-side by #783): the browser `HttpSeam` did only a `Content-Length` pre-check, so a gateway that omits or lies about `Content-Length` could still force a full-body buffer in the tab — a browser-tab OOM. Desktop already enforced a true streaming peak-memory bound; web did not.

## Change

**A ranged plaintext read, end to end.** `open_content_range` replaces `open_content`, which is now the whole-file case of it: it CID-verifies the DAG root, maps the byte window to leaf indices, fetches and unseals **only** those leaves, and trims. It fails closed as a trust violation if any leaf's unsealed length disagrees with what the manifest implies — a short middle leaf silently shifts every downstream byte, so that is a trust violation, not a size quirk. Preallocation is bounded by the clamped range, never the declared size. `read_content_range` shares the resolve, adoption gate, and head-version selection with `read_content` through a new `head_version` helper, and deliberately emits no `OpProgress` events: one ranged read per seek and per buffer refill would drown the event stream. `downloadRange` threads it through the WASM boundary and every TypeScript transport seam, including the follower broadcast path and the leader relay.

**A real streaming peak-memory bound in the JS `HttpSeam`.** `FetchHttp.sendCapped` mirrors `crates/desktop-seams/src/http.rs`: a `Content-Length` pre-check before a byte is read, then a `ReadableStream` reader drain that cancels the moment the running total would exceed `maxBytes`. The bound is exclusive, so a body exactly at the cap is admitted. The WASM bridge binds it as `sendCapped` over a `{ kind: 'response' | 'tooLarge' }` result, fails closed on an unknown `kind`, and keeps a release-active body-length backstop so a buggy seam cannot talk the engine past the cap.

**The byte pipe.** Everything semantic — ticket lookup, Range resolution, windowing — runs tab-side in `packages/client/src/media/**`, where it is unit-testable without a worker; `packages/client/src/sw/**` is the forwarder. The worker owns only the ports it currently holds, so a killed worker or a dead port re-brokers and re-buffers. Bodies are `ReadableStream`s with a zero high-water mark, so peak memory is one 1 MiB window per stream, never the file. Followers route media through the leader because the port terminates at `EngineClient`, whose transport already swaps under them.

**The app-shell precache.** The `apps/web` build emits `dist/sw.js` unhashed at the output root — a worker's scope is bounded by its own URL — from a separate single-input pass, so being self-contained is structural rather than incidental; alongside it goes a `precache-manifest.json` of the emitted chunks. The worker caches only manifest entries, rejects cross-origin and `/stream/` entries, and `CacheLike` structurally exposes no `put`, so vault data cannot reach the cache. A manifest that will not cache degrades to no offline shell, never a failed installation.

Media responses carry `cache-control: no-store`, `x-content-type-options: nosniff`, and `content-security-policy: default-src 'none'; sandbox`, and their `Content-Type` is clamped to an `audio`/`video`/`image` allowlist with `image/svg+xml` excluded: a shared file is attacker-controlled content and `/stream/` is a same-origin URL.

## Tests

- **The named CI gate** — `packages/client/test/browser/media.spec.ts`, in the merge-blocking `Client Browser Suite`, against a real Service Worker, real `fetch` interception, real `MessageChannel` and real `ReadableStream`: 200 with exact bytes, 206 with a matching `content-range`, 416 past EOF, 404 unknown ticket, a 2.5 MiB file streaming through three windows byte-exact, **port re-broker after a real Service Worker kill**, and **follower media routing** across two real tabs on real Web Locks and a real `BroadcastChannel`. The kill is a genuine CDP `ServiceWorker.stopAllWorkers`; a negative control with the kill removed fails the assertion, so the test measures a re-broker rather than a port that never died.
- **The streaming cap** — reverting the drain to `await response.arrayBuffer()` fails `aborts at the cap when Content-Length is absent` and `aborts at the cap when Content-Length lies small`. Both assert the produced-byte count never exceeded the cap plus one chunk, which is the peak-memory claim itself. The browser suite asserts the same against a real chunked response with no `Content-Length`.
- **The ranged read** — engine tests including a short-middle-leaf trust rejection, a final leaf disagreeing with the declared size, an exhaustive offset x length differential against whole-file slicing, and assertions on the exact ordered CID list the scripted HTTP seam saw: only the leaves the window covers are fetched, which is the whole point of the path. A two-device integration test in `write_plane.rs` compares ranged reads against slices of `read_content`. wasm-target tests pin the capped-fetch bridge, including the unknown-`kind` fail-closed and the over-cap backstop.
- **The pipe and precache** — Vitest suites over injected scopes, ports, and cache storage. Reverting the re-broker retry fails `re-brokers a fresh port and retries the open when a port goes silent`; reverting the port-replacement orphan-erroring hangs `fails a body still pulling on a port that gets replaced`.

## Verification

All exit 0, from the worktree root:

```
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo check --workspace --all-targets
cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets
cargo test -p cipherbox-engine
cargo test -p cipherbox-core
cargo test -p cipherbox-wasm --target wasm32-unknown-unknown
pnpm -r --if-present run typecheck
pnpm -r --if-present run test
pnpm --filter @cipherbox/client test:browser
pnpm --filter @cipherbox/web run build:bundle
pnpm exec eslint .
```

The build output was inspected rather than assumed: `dist/sw.js` sits at the root with zero `import` occurrences and no engine-client code, and `dist/precache-manifest.json` lists exactly the emitted chunks plus `/index.html`, with `/sw.js` and the manifest itself absent.

## Review gates

`/simplify`, `/security-review`, and `/crypto-privacy-review` all ran on this diff. The crypto gate confirmed the ranged path skips no check the whole-file read performs, and accepted the encode/decode fail-closed symmetry argument for the new leaf-length invariant: `ContentWriter::push` seals only at exactly `chunk_size` and `assemble` already carries a release-active `LinkCountMismatch`, so a short middle leaf is unrepresentable rather than merely unguarded — a guard would be dead code, and the property is pinned by a release-running test instead.

Findings folded in: the media `Content-Type` hardening, the controlling-worker gate on ticket minting, the Rust-side capped-fetch backstop, `Zeroizing` on unsealed leaf plaintext, a 405 for non-GET `/stream/`, the delivered-length cursor advance, a pull timeout so a dead broker cannot hang a response body, per-client port routing so two open tabs stop breaking each other's streams, port-message shape validation in the worker, structural `no-store` on every synthesized response, the zero-length-chunk accounting guard, and a non-silent `revokeStreamUrl`.

Two findings were deferred, each with a dependency edge: #948 (pin the content version for the life of a stream — `read_content_range` re-resolves per window, so a stream can splice two versions and a large read costs one IPNS fan-out per megabyte; wants an engine-side stream handle) and #949 (the record-transport fetch is still uncapped, and `credentials: 'include'` goes to third-party gateways rather than being scoped to the API origin as the blueprint specifies).

No playback UI ships here — this slice lands the pipe and the registration; consuming `createStreamUrl` in a preview view belongs to #807. Per `blueprint/web-client.md` "Open edges", no web app manifest or install prompt is added: the precache is decided, installability is deployment territory.

Closes #641


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added partial media downloads by byte range across browser, worker, and multi-tab experiences.
  - Added Service Worker–based media streaming with stream URLs, range responses, recovery, and offline app-shell caching.
  - Added safeguards for oversized responses, invalid ranges, unsafe media types, and cross-origin requests.
- **Bug Fixes**
  - Improved handling of interrupted streams, stale caches, unavailable Service Workers, and malformed requests.
- **Tests**
  - Added extensive unit, integration, and browser coverage for range reads, streaming, caching, security, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->