### PR TITLE
fix: barrier desktop store unlink ordering where directories cannot be fsynced

### DIFF
--- a/crates/desktop-seams/src/fs_util.rs
+++ b/crates/desktop-seams/src/fs_util.rs
@@ -63,7 +63,7 @@ pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
             return Err(err);
         }
     }
-    fsync_dir(dir)
+    fsync_dir(dir).map_err(|err| io::Error::new(err.kind(), format!("write barrier: {err}")))
 }
 
 /// Durably removes a file. Idempotent: a missing file is success. The

--- a/crates/desktop-seams/src/fs_util.rs
+++ b/crates/desktop-seams/src/fs_util.rs
@@ -48,22 +48,14 @@ pub(crate) fn ensure_dir(dir: &Path) -> io::Result<()> {
 /// Durably writes `bytes` to `path`, replacing any existing file atomically.
 ///
 /// Barrier order: write a fresh temp file in the same directory, `sync_all`
-/// its contents, `rename` it over the target (atomic replace on Unix and on
-/// Windows — Rust's `fs::rename` maps to `MoveFileExW` with
-/// `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH`), then fsync the
-/// directory so the rename itself is durable. A crash can only ever leave
-/// the old value or the new value — never a torn one.
+/// its contents, `rename` it over the target (an atomic replace on both Unix
+/// and Windows), then [`fsync_dir`] so the rename itself is durable. A crash
+/// can only ever leave the old value or the new value — never a torn one.
 pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
     let dir = path
         .parent()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no parent"))?;
-    let tmp = temp_path(dir);
-    // Scope the handle so it is closed before the rename.
-    {
-        let mut file = File::create(&tmp)?;
-        file.write_all(bytes)?;
-        file.sync_all()?;
-    }
+    let tmp = write_synced_temp(dir, bytes)?;
     match fs::rename(&tmp, path) {
         Ok(()) => {}
         Err(err) => {
@@ -75,9 +67,9 @@ pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
 }
 
 /// Durably removes a file. Idempotent: a missing file is success. The
-/// removal is barriered with a directory fsync so an ordered caller (e.g.
-/// the StagingStore's op-before-sidecar removal) can rely on it having hit
-/// the platter before the next removal begins.
+/// removal is followed by [`fsync_dir`] so an ordered caller (e.g. the
+/// StagingStore's op-before-sidecar removal) can rely on it having hit the
+/// platter before the next removal begins.
 pub(crate) fn remove_file_durable(path: &Path) -> io::Result<()> {
     match fs::remove_file(path) {
         Ok(()) => {}
@@ -85,7 +77,8 @@ pub(crate) fn remove_file_durable(path: &Path) -> io::Result<()> {
         Err(err) => return Err(err),
     }
     if let Some(dir) = path.parent() {
-        fsync_dir(dir)?;
+        fsync_dir(dir)
+            .map_err(|err| io::Error::new(err.kind(), format!("unlink barrier: {err}")))?;
     }
     Ok(())
 }
@@ -121,19 +114,43 @@ pub(crate) fn list_file_names(dir: &Path) -> io::Result<Vec<String>> {
     Ok(names)
 }
 
-/// Fsyncs a directory so a create/rename/unlink inside it is durable.
-///
-/// Unix opens the directory and `sync_all`s it. Windows has no directory
-/// fsync; `fs::rename`'s `MOVEFILE_WRITE_THROUGH` and NTFS metadata
-/// journaling cover the same guarantee, so this is a no-op there.
+/// Barriers a directory so a create/rename/unlink inside it is durable
+/// before the next one is issued.
 #[cfg(unix)]
 fn fsync_dir(dir: &Path) -> io::Result<()> {
     File::open(dir)?.sync_all()
 }
 
 #[cfg(not(unix))]
-fn fsync_dir(_dir: &Path) -> io::Result<()> {
+fn fsync_dir(dir: &Path) -> io::Result<()> {
+    metadata_log_barrier(dir)
+}
+
+/// The [`fsync_dir`] barrier where a directory handle cannot be fsynced.
+///
+/// NTFS journals metadata to a per-volume log flushed as an LSN-ordered
+/// prefix, so `sync_all`ing a file created *after* an unlink or rename also
+/// persists it. This covers both barriers, not just unlinks: std's Windows
+/// `rename` passes `MOVEFILE_REPLACE_EXISTING` alone, never
+/// `MOVEFILE_WRITE_THROUGH` (#665). The temp carries [`TEMP_PREFIX`], so a
+/// crash before its removal leaves debris [`ensure_dir`] sweeps on reopen.
+#[cfg(any(not(unix), test))]
+fn metadata_log_barrier(dir: &Path) -> io::Result<()> {
+    // A byte of content makes the flush a data-and-metadata transaction
+    // rather than a flush of an untouched handle.
+    let path = write_synced_temp(dir, b"\0")?;
+    let _ = fs::remove_file(&path);
     Ok(())
+}
+
+/// Writes `bytes` to a fresh temp file in `dir` and `sync_all`s it, returning
+/// its path with the handle already closed.
+fn write_synced_temp(dir: &Path, bytes: &[u8]) -> io::Result<PathBuf> {
+    let path = temp_path(dir);
+    let mut file = File::create(&path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(path)
 }
 
 /// A process-unique filename component (`<pid>.<seq>`), so two in-flight
@@ -218,6 +235,32 @@ mod tests {
         remove_file_durable(&path).unwrap();
         remove_file_durable(&path).unwrap();
         assert_eq!(read_file_opt(&path).unwrap(), None);
+    }
+
+    #[test]
+    fn metadata_log_barrier_leaves_the_directory_as_it_found_it() {
+        let dir = tempfile::tempdir().unwrap();
+        atomic_write(&dir.path().join("value"), b"x").unwrap();
+        metadata_log_barrier(dir.path()).unwrap();
+        metadata_log_barrier(dir.path()).unwrap();
+        assert_eq!(
+            fs::read_dir(dir.path()).unwrap().count(),
+            1,
+            "successive barriers must neither collide on a temp name nor accumulate debris"
+        );
+        assert_eq!(
+            read_file_opt(&dir.path().join("value")).unwrap(),
+            Some(b"x".to_vec())
+        );
+    }
+
+    /// The barrier reports a failure rather than returning success without
+    /// having established one — an unbarriered removal is a fail-closed error,
+    /// never a fast path, because callers order two removals against it.
+    #[test]
+    fn metadata_log_barrier_fails_closed_when_it_cannot_be_established() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(metadata_log_barrier(&dir.path().join("absent")).is_err());
     }
 
     #[test]

--- a/crates/desktop-seams/src/staging_store.rs
+++ b/crates/desktop-seams/src/staging_store.rs
@@ -34,12 +34,13 @@ const COUNTER_FILE: &str = "next_op_id";
 ///   reopens.
 ///
 /// **Removal ordering is a correctness property** (hard constraint 5): every
-/// mutating method fsyncs before returning, so when the engine completes an
-/// op by removing the op record *before* its sidecar, that ordering actually
-/// reaches the platter in order. A crash can then only ever leave an orphan
-/// sidecar (harmless, reclaimed by orphan-sidecar GC via [`staged_keys`] +
-/// [`remove_staged_bytes`]) — never an op record pointing at a sidecar that
-/// is already gone.
+/// mutating method barriers its directory entry before returning (see
+/// `fs_util::fsync_dir`), so when a caller completes an op by removing the
+/// op record *before* its sidecar, that
+/// ordering actually reaches the platter in order. A crash can then only ever
+/// leave an orphan sidecar (harmless, reclaimed by orphan-sidecar GC via
+/// [`staged_keys`] + [`remove_staged_bytes`]) — never an op record pointing
+/// at a sidecar that is already gone.
 pub struct FileStagingStore {
     ops_dir: PathBuf,
     staged_dir: PathBuf,

--- a/crates/desktop-seams/tests/conformance.rs
+++ b/crates/desktop-seams/tests/conformance.rs
@@ -68,52 +68,105 @@ fn file_credential_store_passes_the_credential_store_kit() {
 // StagingStore desktop-specific durability — beyond what the kit asserts.
 // ---------------------------------------------------------------------------
 
-/// The json-record-before-bin-sidecar removal ordering (hard constraint 5).
+/// The json-record-before-bin-sidecar removal ordering (hard constraint 5),
+/// asserted at **every** interruption point in one op's life rather than only
+/// on the happy path.
 ///
-/// Simulates a crash at the kill point *between* `remove_op` (the op record,
-/// the "json" of the v1 journal) and `remove_staged_bytes` (the sidecar):
-/// after reopen the op is durably gone while the sidecar survives as a
-/// harmless orphan — never the dangerous inverse (an op record referencing a
-/// sidecar that is already gone). Orphan-sidecar GC then reclaims it.
+/// After each kill point the store is dropped and reopened, and the surviving
+/// state must never be the dangerous inverse — an op record whose staged
+/// sidecar is already gone. What it may leave is an orphan sidecar, which
+/// orphan-sidecar GC ([`StagingStore::staged_keys`] + `remove_staged_bytes`)
+/// reclaims.
 #[test]
 fn staging_store_removal_ordering_leaves_only_a_reclaimable_orphan() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("staging");
 
+    // Kill point 1: bytes staged, op not yet journaled.
     block_on(async {
         let store = FileStagingStore::open(&path).unwrap();
-        let op_id = store.enqueue_op(b"update-content-op").await.unwrap();
         store
             .put_staged_bytes(b"chunk-key", b"sealed-ciphertext")
             .await
             .unwrap();
-
-        // Engine completes the op: op record removed durably FIRST...
-        store.remove_op(op_id).await.unwrap();
-        // ...and the process dies here, before remove_staged_bytes.
     });
+    assert_survivors(
+        &path,
+        Survivors {
+            op: false,
+            sidecar: true,
+        },
+    );
 
-    // Reopen (post-"crash"): the op is gone, the sidecar is an orphan.
+    // Kill point 2: op journaled, nothing removed yet.
+    let op_id = block_on(async {
+        let store = FileStagingStore::open(&path).unwrap();
+        store.enqueue_op(b"update-content-op").await.unwrap()
+    });
+    assert_survivors(
+        &path,
+        Survivors {
+            op: true,
+            sidecar: true,
+        },
+    );
+
+    // Kill point 3: op record removed, sidecar not yet — the orphan.
     block_on(async {
-        let reopened = FileStagingStore::open(&path).unwrap();
-        assert!(
-            reopened.queued_ops().await.unwrap().is_empty(),
-            "the op record must be durably gone after remove_op"
-        );
-        assert_eq!(
-            reopened.staged_bytes(b"chunk-key").await.unwrap(),
-            Some(b"sealed-ciphertext".to_vec()),
-            "the sidecar must survive as a harmless orphan, never a dangling op"
-        );
+        let store = FileStagingStore::open(&path).unwrap();
+        store.remove_op(op_id).await.unwrap();
+    });
+    assert_survivors(
+        &path,
+        Survivors {
+            op: false,
+            sidecar: true,
+        },
+    );
 
-        // Orphan-sidecar GC reclaims it.
+    // Kill point 4: GC reclaims the orphan and the budget goes back to zero.
+    block_on(async {
+        let store = FileStagingStore::open(&path).unwrap();
         assert_eq!(
-            reopened.staged_keys().await.unwrap(),
+            store.staged_keys().await.unwrap(),
             vec![b"chunk-key".to_vec()]
         );
-        reopened.remove_staged_bytes(b"chunk-key").await.unwrap();
-        assert!(reopened.staged_keys().await.unwrap().is_empty());
-        assert_eq!(reopened.staged_bytes_total().await.unwrap(), 0);
+        store.remove_staged_bytes(b"chunk-key").await.unwrap();
+        assert_eq!(store.staged_bytes_total().await.unwrap(), 0);
+    });
+    assert_survivors(
+        &path,
+        Survivors {
+            op: false,
+            sidecar: false,
+        },
+    );
+}
+
+/// What one kill point expects to find after the store is reopened.
+struct Survivors {
+    op: bool,
+    sidecar: bool,
+}
+
+/// Reopens the staging store and asserts exactly what survived the kill point.
+fn assert_survivors(path: &std::path::Path, expected: Survivors) {
+    assert!(
+        !expected.op || expected.sidecar,
+        "no kill point may expect an op record without the sidecar it references"
+    );
+    block_on(async {
+        let store = FileStagingStore::open(path).unwrap();
+        assert_eq!(
+            !store.queued_ops().await.unwrap().is_empty(),
+            expected.op,
+            "op record survival"
+        );
+        let staged = store.staged_bytes(b"chunk-key").await.unwrap();
+        assert_eq!(staged.is_some(), expected.sidecar, "sidecar survival");
+        if expected.sidecar {
+            assert_eq!(staged.as_deref(), Some(&b"sealed-ciphertext"[..]));
+        }
     });
 }
 


### PR DESCRIPTION
## Problem

`FileStagingStore` documents removal ordering as a correctness property (desktop-seams hard constraint 5): the op record goes first, its staged-ciphertext sidecar second, so an interruption can only orphan a sidecar — never leave an op record naming a sidecar that is already gone. `remove_file_durable` enforces that by fsyncing the parent directory after each unlink.

`fsync_dir` was `Ok(())` on non-Unix. Windows has no directory fsync, so on that platform the ordering was never barriered at all and the store silently reported a durability it had not obtained.

**The over-claim is wider than the issue recorded.** #665 assumed `atomic_write` was still covered on Windows by `MOVEFILE_WRITE_THROUGH`, per the comment in `fs_util.rs`. That comment is wrong. Rust std's Windows `rename` is `MoveFileExW(old, new, MOVEFILE_REPLACE_EXISTING)` — write-through is not among the flags (`library/std/src/sys/fs/windows.rs`, `fn rename`, checked against the 1.88 sources this workspace builds with). So the rename was unbarriered too, and the fix has to cover both barriers, not just unlinks.

## Change

`fsync_dir` on non-Unix now calls `metadata_log_barrier`: write a byte to a fresh temp file in the same directory and `sync_all` it. NTFS journals metadata to a per-volume write-ahead log flushed as an LSN-ordered prefix, so flushing a transaction issued *after* a directory-entry change also persists that change. The temp carries the existing `.cbtmp.` prefix, so it is invisible to `list_file_names` and a crash before its removal leaves debris `ensure_dir` already sweeps — the harmless orphan, in line with the same principle the store's ordering rule serves.

The barrier is plain `std::fs`; the crate is `#![forbid(unsafe_code)]` and no Win32 call was added. It is compiled under `cfg(any(not(unix), test))`, so the Windows algorithm is exercised by the Unix CI legs too rather than only by the Windows one.

Also in the diff:

- `atomic_write` and `metadata_log_barrier` share a `write_synced_temp` helper instead of two copies of create/write/`sync_all`.
- A barrier failure in `remove_file_durable` is labelled `unlink barrier: …`, so the new Windows-only failure mode (the barrier's `File::create` hitting `ENOSPC` or a read-only directory after the unlink already succeeded) is diagnosable rather than surfacing as a bare `staging_store remove_op` error.
- The over-claiming comments in `fs_util.rs` and on `FileStagingStore` are corrected; the store's doc now cross-references `fs_util::fsync_dir` rather than restating the platform mechanism.

## Dependencies

The issue carries no dependency statement. Established from its body and the surrounding desktop slices:

- **No blocking prerequisite.** `crates/desktop-seams` is a leaf adapter crate. The change is confined to its private `fs_util` module and touches no seam trait, no engine code, and no wire format. It is independently mergeable.
- **Depends on #646 only historically** — the seam set whose ship review surfaced this. That work is landed.
- **Not fixable a layer down.** `FileStagingStore` stores op bytes verbatim and never parses them, so it cannot know which sidecar an op references and cannot repair the dangerous state at reopen. An ordering barrier is the only enforcement available at this layer.

### Relationship to #941 and #950

Both are open against the **engine-side** staged-block lifecycle; this is the **desktop seam** underneath them. No overlap in files, and the rules do not contradict:

- **#941** (issue #924, `crates/engine/sync/drain.rs`) reorders mark-before-release for a leaf so an interruption leaves a marked-and-staged leaf rather than a released-but-unmarked one, and cites this store's hard constraint 5 by name as the rule it is applying. This PR makes that same rule actually hold on Windows, where the barrier it depends on was absent. Strictly reinforcing.
- **#950** (issue #869) adds cancel plus orphan-staged-block GC. Its GC is the reclaimer for exactly the orphan this store's ordering is designed to leave behind, and it decides which blocks are collectible from the queued op records — which this change makes more trustworthy on Windows. No shared file; the `staging_store_removal_ordering_leaves_only_a_reclaimable_orphan` test name #941's body references is preserved.

## Tests

`crates/desktop-seams/src/fs_util.rs`:

- `metadata_log_barrier_fails_closed_when_it_cannot_be_established` — **the revert guard.** Restoring the old `Ok(())` body makes it fail on every platform, verified locally. It pins that the barrier is a real operation with real failure modes, so an unbarriered removal is an error rather than a silent fast path.
- `metadata_log_barrier_leaves_the_directory_as_it_found_it` — successive barriers neither collide on a temp name nor accumulate debris, and do not disturb neighbouring files. This one is a residue guard, not a revert guard: it passes against the old no-op too.

`crates/desktop-seams/tests/conformance.rs`:

- `staging_store_removal_ordering_leaves_only_a_reclaimable_orphan` now walks all four interruption points of one op's life — bytes staged before the op is journaled, op journaled, op record removed before the sidecar, sidecar reclaimed — reopening the store at each and asserting exactly what survived. A `Survivors` precondition rejects any kill point that expects an op record without its sidecar, so the forbidden state cannot be encoded into the table.

## Verification

All exit 0 on macOS (aarch64, Rust 1.88): `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check --workspace --all-targets`, `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets`, `cargo test -p cipherbox-desktop-seams` in both debug and `--release`, `pnpm -r --if-present run typecheck`, `pnpm -r --if-present run test`, `eslint .`.

Beyond that, the non-Unix path was forced on locally — `fsync_dir` temporarily rewired so `metadata_log_barrier` was the only implementation — and the whole `cipherbox-desktop-seams` suite passed against it. That proves the Windows code path compiles and is semantically correct as a barrier-shaped operation.

**What only the Windows CI leg can confirm**, stated plainly:

- That the `#[cfg(not(unix))]` arm compiles and links on `x86_64-pc-windows-msvc`. Cross-checking from macOS is not possible here: `cargo check --target x86_64-pc-windows-msvc` fails in `blake3`'s build script for want of `ml64.exe`. The authoritative check is the `Cargo Check & Test (Windows)` job in `ci.yml`, which runs `cargo test --workspace` on `windows-latest` and therefore executes both new tests against the real production path.
- That the barrier behaves on a real NTFS volume — file creation in the store directories, and the temp's removal, under Windows sharing semantics and any AV or indexer holding handles.

**What no CI leg can confirm**, and I am not claiming: that the NTFS LSN-ordered-log-prefix premise actually delivers the ordering. Proving it needs power-loss or crash-injection testing on real Windows hardware, which is out of reach of this repo's suites. The tests here assert the barrier's shape and its fail-closed behaviour, not the durability guarantee itself. This is a strict improvement over the previous no-op regardless — the old code obtained no ordering under any model.

Desktop E2E is not required for this change; no FUSE or shell surface is touched.

**Windows cost, accepted deliberately.** Every `atomic_write` and every `remove_file_durable` on Windows now pays an extra file create + write + `FlushFileBuffers` + unlink. Scoping the barrier to unlinks only was considered and rejected: with `MOVEFILE_WRITE_THROUGH` absent from std's `rename`, the write path needs it too. Batching the barrier across the delete loops in `snapshot_cache` and `floor_store`, and skipping it in `ensure_dir` when the sweep removed nothing, are real wins but sit outside this diff.

## Review gates

- **`/security-review`** — no HIGH or MEDIUM findings. The diff adds no untrusted input, no crypto, no network surface and no secret handling; the barrier file carries a single NUL byte and never sees key or sealed material. Failure propagates fail-closed, so a failed barrier fails the removal instead of letting the caller proceed to the sidecar.
- **`/simplify`** — findings folded in: the duplicated temp-write block extracted to `write_synced_temp`; the barrier doc cut from 13 lines to 6; the platform mechanism no longer restated on `FileStagingStore`; a tautological assertion in the test replaced with a real precondition on the kill-point table; positional bools replaced with a named `Survivors` struct; absent-versus-corrupted sidecar states no longer conflated. One finding was rejected on evidence — scoping the barrier away from `atomic_write` rests on the `MOVEFILE_WRITE_THROUGH` claim, which the std sources disprove. One accepted change was then reverted: barriering the already-absent `remove_file_durable` path closes a retry-after-barrier-failure window, but costs a directory fsync per already-removed leaf on the per-block GC path, which is not a trade worth making here.
- **`/crypto-privacy-review`** — not applicable; the diff touches no key material and no sealed bytes.

Closes #665


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved durability when saving, updating, and removing staged data, helping ensure changes persist correctly across interruptions or system failures.
  * Strengthened cleanup behavior so incomplete operations and leftover temporary data are handled safely.
  * Added safeguards to detect and report situations where durable filesystem updates cannot be completed.

* **Tests**
  * Expanded coverage for interrupted staging operations, recovery scenarios, orphaned data, and final cleanup states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->