### PR TITLE
fix: bring the browser mailbox seam onto the served API routes

### DIFF
--- a/crates/wasm/src/conformance.rs
+++ b/crates/wasm/src/conformance.rs
@@ -25,8 +25,9 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
 use crate::seams_bridge::{
-    CredentialStoreAdapter, FloorStoreAdapter, JsRecordTransportSeam, JsSchedulerSeam,
-    RecordTransportAdapter, SchedulerAdapter, SnapshotCacheAdapter, StagingStoreAdapter,
+    CredentialStoreAdapter, FloorStoreAdapter, JsMailboxSeam, JsRecordTransportSeam,
+    JsSchedulerSeam, MailboxAdapter, RecordTransportAdapter, SchedulerAdapter,
+    SnapshotCacheAdapter, StagingStoreAdapter,
 };
 
 /// Calls a JS `() => Promise<Seam>` factory and awaits the fresh seam handle
@@ -105,6 +106,15 @@ pub async fn run_record_transport_conformance(
     console_error_panic_hook::set_once();
     let adapter = RecordTransportAdapter { js: transport };
     conformance::record_transport::check(&adapter, &routing_key, &record).await;
+}
+
+/// Runs the `Mailbox` conformance kit against a JS `MailboxSeam`. The caller
+/// supplies the recipient public key naming the inbox the seam is bound to.
+#[wasm_bindgen(js_name = runMailboxConformance)]
+pub async fn run_mailbox_conformance(mailbox: JsMailboxSeam, own_recipient_public_key: Vec<u8>) {
+    console_error_panic_hook::set_once();
+    let adapter = MailboxAdapter { js: mailbox };
+    conformance::mailbox::check(&adapter, &own_recipient_public_key).await;
 }
 
 /// Test-only: builds a `deadLetter` facade event carrying `opId`. The op id is

--- a/packages/client/src/seams/bytes.test.ts
+++ b/packages/client/src/seams/bytes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { fromHex, toHex } from './bytes.js';
+import { fromBase64, fromHex, toBase64, toHex } from './bytes.js';
 
 const ALL_BYTES = Uint8Array.from({ length: 256 }, (_, i) => i);
 
@@ -30,5 +30,32 @@ describe('hex codec', () => {
 
     expect(RegExp.input).toBe('sentinel');
     expect(RegExp.lastMatch).toBe('sentinel');
+  });
+});
+
+describe('base64 codec', () => {
+  it('round-trips every byte value and every padding length', () => {
+    expect(fromBase64(toBase64(ALL_BYTES))).toEqual(ALL_BYTES);
+    expect(toBase64(new Uint8Array())).toBe('');
+    expect(fromBase64('')).toEqual(new Uint8Array());
+    for (const length of [1, 2, 3, 4]) {
+      const bytes = ALL_BYTES.subarray(0, length);
+      expect(fromBase64(toBase64(bytes)), `${length} bytes`).toEqual(bytes);
+    }
+  });
+
+  it('emits the API-accepted standard alphabet', () => {
+    // The API's PostMessageDto rejects anything outside `[A-Za-z0-9+/]+={0,2}`,
+    // so a url-safe variant here would 400 every post.
+    expect(toBase64(Uint8Array.of(0xfb, 0xef, 0xff))).toBe('++//');
+  });
+
+  it('round-trips a blob past the chunked-encode boundary', () => {
+    const large = Uint8Array.from({ length: 0x8000 + 7 }, (_, i) => i & 0xff);
+    expect(fromBase64(toBase64(large))).toEqual(large);
+  });
+
+  it('rejects a non-base64 string', () => {
+    expect(() => fromBase64('!!!!')).toThrow(/not a base64 string/);
   });
 });

--- a/packages/client/src/seams/bytes.ts
+++ b/packages/client/src/seams/bytes.ts
@@ -4,7 +4,9 @@
  * The seams key durable stores (IndexedDB records, OPFS file names) by opaque
  * engine-chosen byte strings. A stable lowercase-hex encoding gives every
  * `Uint8Array` a deterministic, collision-free, filesystem-safe string key —
- * no seam ever interprets the bytes it stores, only addresses them.
+ * no seam ever interprets the bytes it stores, only addresses them. Base64 is
+ * the same kind of addressing, for the API's JSON wire framing of an opaque
+ * blob.
  */
 
 const HEX = '0123456789abcdef';
@@ -42,6 +44,33 @@ export function fromHex(hex: string): Uint8Array {
       throw new TypeError('fromHex: hex string contains a non-hex character');
     }
     out[i] = (high << 4) | low;
+  }
+  return out;
+}
+
+/** Standard-alphabet base64 encoding of a byte string. */
+export function toBase64(bytes: Uint8Array): string {
+  // Chunked: `String.fromCharCode` spreads one argument per byte, and a whole
+  // blob at once can overflow the call-stack argument limit.
+  const CHUNK = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
+/** Inverse of {@link toBase64}; throws on anything that is not base64. */
+export function fromBase64(text: string): Uint8Array {
+  let binary: string;
+  try {
+    binary = atob(text);
+  } catch {
+    throw new TypeError('fromBase64: not a base64 string');
+  }
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = binary.charCodeAt(i);
   }
   return out;
 }

--- a/packages/client/src/seams/mailbox.test.ts
+++ b/packages/client/src/seams/mailbox.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { toBase64 } from './bytes.js';
 import { ApiMailbox } from './mailbox.js';
-import type { HttpRequestData, HttpResponseData, HttpSeam } from './types.js';
+import type { CappedHttpResult, HttpRequestData, HttpResponseData, HttpSeam } from './types.js';
 
 const BASE = 'https://api.example/';
 const SEALED = new Uint8Array([0, 1, 2, 250, 255]);
@@ -21,6 +21,14 @@ class ScriptedHttp implements HttpSeam {
       return Promise.reject(new Error(`unscripted request: ${request.method} ${request.url}`));
     }
     return Promise.resolve({ status: 200, headers: [], body: new Uint8Array(), ...next });
+  }
+
+  async sendCapped(request: HttpRequestData, maxBytes: number): Promise<CappedHttpResult> {
+    const response = await this.send(request);
+    if (response.body.byteLength > maxBytes) {
+      return { kind: 'tooLarge', observed: response.body.byteLength, limit: maxBytes };
+    }
+    return { kind: 'response', ...response };
   }
 }
 

--- a/packages/client/src/seams/mailbox.test.ts
+++ b/packages/client/src/seams/mailbox.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import { toBase64 } from './bytes.js';
+import { ApiMailbox } from './mailbox.js';
+import type { HttpRequestData, HttpResponseData, HttpSeam } from './types.js';
+
+const BASE = 'https://api.example/';
+const SEALED = new Uint8Array([0, 1, 2, 250, 255]);
+const RECIPIENT = Uint8Array.from({ length: 33 }, (_, i) => (i === 0 ? 0x02 : i));
+
+/** Records every request and replays a scripted response queue. */
+class ScriptedHttp implements HttpSeam {
+  readonly sent: HttpRequestData[] = [];
+
+  constructor(private readonly responses: Array<Partial<HttpResponseData>>) {}
+
+  send(request: HttpRequestData): Promise<HttpResponseData> {
+    this.sent.push(request);
+    const next = this.responses.shift();
+    if (next === undefined) {
+      return Promise.reject(new Error(`unscripted request: ${request.method} ${request.url}`));
+    }
+    return Promise.resolve({ status: 200, headers: [], body: new Uint8Array(), ...next });
+  }
+}
+
+function json(status: number, body: unknown): Partial<HttpResponseData> {
+  return { status, body: new TextEncoder().encode(JSON.stringify(body)) };
+}
+
+describe('ApiMailbox post', () => {
+  it('sends the served route and the PostMessageDto body', async () => {
+    const http = new ScriptedHttp([json(201, { id: 'mid' })]);
+    await new ApiMailbox(http, BASE).post(RECIPIENT, SEALED, 'idem-1');
+
+    const [request] = http.sent;
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('https://api.example/mailbox/messages');
+    expect(request.headers).toEqual([['content-type', 'application/json']]);
+    expect(JSON.parse(new TextDecoder().decode(request.body ?? new Uint8Array()))).toEqual({
+      recipientPublicKey: '020102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20',
+      blob: toBase64(SEALED),
+      idempotencyKey: 'idem-1',
+    });
+  });
+
+  it('rejects a non-2xx post', async () => {
+    const http = new ScriptedHttp([json(404, {})]);
+    await expect(new ApiMailbox(http, BASE).post(RECIPIENT, SEALED, 'k')).rejects.toThrow(
+      /post failed: 404/
+    );
+  });
+});
+
+describe('ApiMailbox poll', () => {
+  it('reads the messages envelope and decodes each sealed blob', async () => {
+    const http = new ScriptedHttp([
+      json(200, {
+        messages: [
+          { id: 'a', receivedAt: '2026-01-01T00:00:00.000Z', blob: toBase64(SEALED) },
+          { id: 'b', receivedAt: '2026-01-02T00:00:00.000Z', blob: '' },
+        ],
+      }),
+    ]);
+    const items = await new ApiMailbox(http, BASE).poll();
+
+    expect(http.sent[0].method).toBe('GET');
+    expect(http.sent[0].url).toBe('https://api.example/mailbox/messages');
+    expect(items).toEqual([
+      { itemId: 'a', sealedPayload: SEALED },
+      { itemId: 'b', sealedPayload: new Uint8Array() },
+    ]);
+  });
+
+  it('reports an empty inbox only when the API says so', async () => {
+    const http = new ScriptedHttp([json(200, { messages: [] })]);
+    await expect(new ApiMailbox(http, BASE).poll()).resolves.toEqual([]);
+  });
+
+  it('rejects a non-2xx poll and an envelope with no messages array', async () => {
+    await expect(new ApiMailbox(new ScriptedHttp([json(429, {})]), BASE).poll()).rejects.toThrow(
+      /poll failed: 429/
+    );
+    await expect(new ApiMailbox(new ScriptedHttp([json(200, {})]), BASE).poll()).rejects.toThrow(
+      /messages envelope/
+    );
+  });
+
+  it('rejects a message that is not an id/blob pair', async () => {
+    for (const message of [null, { id: 'a' }, { id: 7, blob: '' }]) {
+      const http = new ScriptedHttp([json(200, { messages: [message] })]);
+      await expect(new ApiMailbox(http, BASE).poll(), JSON.stringify(message)).rejects.toThrow(
+        /malformed message/
+      );
+    }
+  });
+});
+
+describe('ApiMailbox ack', () => {
+  it('deletes on the served route', async () => {
+    const http = new ScriptedHttp([json(200, { success: true })]);
+    await new ApiMailbox(http, BASE).ack('mid 1/2');
+
+    expect(http.sent[0].method).toBe('DELETE');
+    expect(http.sent[0].url).toBe('https://api.example/mailbox/messages/mid%201%2F2');
+  });
+
+  it('rejects a 404 instead of recording a delete that never happened', async () => {
+    const http = new ScriptedHttp([json(404, {})]);
+    await expect(new ApiMailbox(http, BASE).ack('mid')).rejects.toThrow(/ack failed: 404/);
+  });
+});

--- a/packages/client/src/seams/mailbox.ts
+++ b/packages/client/src/seams/mailbox.ts
@@ -1,57 +1,83 @@
 /**
- * `Mailbox` — the sealed-blob discovery transport over the API, via the `Http`
- * seam (blueprint/web-client.md seam table: "the engine's own API client over
- * the Http seam — nothing web-specific").
+ * `Mailbox` — the sealed-blob discovery transport over the API mailbox routes
+ * (blueprint/api.md "Mailbox"), via the `Http` seam.
  *
  * A pure byte mover: it addresses the recipient and moves the opaque sealed
  * payload, and does no crypto or codec — the engine seals, unseals, and
- * authenticates every item (#39 D9). Response parsing (the pending-item list)
- * lands with the engine's mailbox pipeline slice; until then `poll` reports an
- * empty inbox, which is availability, never a trust decision — nothing on this
- * transport is load-bearing for safety.
+ * authenticates every item (#39 D9).
  */
 
-import { toHex } from './bytes.js';
+import { fromBase64, toBase64, toHex } from './bytes.js';
 import type { HttpSeam, MailboxItemData, MailboxSeam } from './types.js';
 
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
 export class ApiMailbox implements MailboxSeam {
+  private readonly messagesUrl: string;
+
   constructor(
     private readonly http: HttpSeam,
-    private readonly mailboxUrl: string
-  ) {}
+    apiBaseUrl: string
+  ) {
+    this.messagesUrl = `${apiBaseUrl.replace(/\/+$/, '')}/mailbox/messages`;
+  }
 
   async post(
     recipientPublicKey: Uint8Array,
     sealedPayload: Uint8Array,
     idempotencyKey: string
   ): Promise<void> {
+    const body = JSON.stringify({
+      recipientPublicKey: toHex(recipientPublicKey),
+      blob: toBase64(sealedPayload),
+      idempotencyKey,
+    });
     const response = await this.http.send({
       method: 'POST',
-      url: this.mailboxUrl,
-      headers: [
-        ['content-type', 'application/octet-stream'],
-        ['idempotency-key', idempotencyKey],
-        ['x-recipient', toHex(recipientPublicKey)],
-      ],
-      body: sealedPayload,
+      url: this.messagesUrl,
+      headers: [['content-type', 'application/json']],
+      body: encoder.encode(body),
     });
     if (response.status >= 300) {
       throw new Error(`mailbox post failed: ${response.status}`);
     }
   }
 
-  poll(): Promise<MailboxItemData[]> {
-    return Promise.resolve([]);
+  async poll(): Promise<MailboxItemData[]> {
+    const response = await this.http.send({
+      method: 'GET',
+      url: this.messagesUrl,
+      headers: [],
+      body: null,
+    });
+    if (response.status >= 300) {
+      throw new Error(`mailbox poll failed: ${response.status}`);
+    }
+    // Fail-closed: an unreadable envelope is not an empty inbox.
+    const wire = JSON.parse(decoder.decode(response.body)) as { messages?: unknown };
+    if (!Array.isArray(wire.messages)) {
+      throw new Error('mailbox poll returned no messages envelope');
+    }
+    return (wire.messages as unknown[]).map((message) => {
+      const { id, blob } = (message ?? {}) as { id?: unknown; blob?: unknown };
+      if (typeof id !== 'string' || typeof blob !== 'string') {
+        throw new Error('mailbox poll returned a malformed message');
+      }
+      return { itemId: id, sealedPayload: fromBase64(blob) };
+    });
   }
 
   async ack(itemId: string): Promise<void> {
     const response = await this.http.send({
       method: 'DELETE',
-      url: `${this.mailboxUrl}/${encodeURIComponent(itemId)}`,
+      url: `${this.messagesUrl}/${encodeURIComponent(itemId)}`,
       headers: [],
       body: null,
     });
-    if (response.status >= 300 && response.status !== 404) {
+    // The API's ack is idempotent — an unknown id answers 200 — so a 404 here
+    // means the route is wrong, not that the item was already acked.
+    if (response.status >= 300) {
       throw new Error(`mailbox ack failed: ${response.status}`);
     }
   }

--- a/packages/client/src/spawnEngineWorker.test.ts
+++ b/packages/client/src/spawnEngineWorker.test.ts
@@ -22,7 +22,7 @@ describe('spawnEngineWorker', () => {
       {
         type: 'bootstrap',
         recordEndpoints: ['https://routing.example.test'],
-        mailboxUrl: 'https://api.example.test/mailbox/messages',
+        apiBaseUrl: 'https://api.example.test/',
         dbPrefix: undefined,
         wasmModuleUrl: '/wasm/cipherbox_wasm.js',
         wasmBinaryUrl: '/wasm/cipherbox_wasm_bg.wasm',

--- a/packages/client/src/spawnEngineWorker.ts
+++ b/packages/client/src/spawnEngineWorker.ts
@@ -10,7 +10,7 @@ import type { EngineWorkerBootstrap } from './worker/engineWorker.js';
 
 /** What a host tab must know to stand the engine worker up. */
 export interface EngineHostConfig {
-  /** Base URL of the CipherBox API; the mailbox collection hangs off it. */
+  /** Base URL of the CipherBox API; the `Mailbox` seam appends its own routes. */
   apiBaseUrl: string;
   /** `/routing/v1` origins: someguy plus at least one public endpoint. */
   recordEndpoints: string[];
@@ -35,7 +35,7 @@ export function spawnEngineWorker(
   const bootstrap: EngineWorkerBootstrap = {
     type: 'bootstrap',
     recordEndpoints: config.recordEndpoints,
-    mailboxUrl: `${config.apiBaseUrl.replace(/\/+$/, '')}/mailbox/messages`,
+    apiBaseUrl: config.apiBaseUrl,
     dbPrefix: config.dbPrefix,
     wasmModuleUrl: config.wasmModuleUrl,
     wasmBinaryUrl: config.wasmBinaryUrl,

--- a/packages/client/src/worker/browserSeams.ts
+++ b/packages/client/src/worker/browserSeams.ts
@@ -19,8 +19,8 @@ import {
 export interface BrowserSeamsConfig {
   /** Delegated-routing endpoint set for `RecordTransport` (someguy + public). */
   recordEndpoints: string[];
-  /** Absolute URL of the API mailbox collection. */
-  mailboxUrl: string;
+  /** Absolute base URL of the API; `Mailbox` appends its own routes. */
+  apiBaseUrl: string;
   /** Prefix for the IndexedDB/OPFS store names (namespaces per origin/test). */
   dbPrefix?: string;
 }
@@ -45,7 +45,7 @@ export function makeBrowserSeams(config: BrowserSeamsConfig): BrowserSeams {
     floorStore: new IdbFloorStore(`${prefix}-floors`),
     recordTransport: new FetchRecordTransport(config.recordEndpoints),
     http,
-    mailbox: new ApiMailbox(http, config.mailboxUrl),
+    mailbox: new ApiMailbox(http, config.apiBaseUrl),
     refreshHints: new QueueRefreshHintSource(),
     scheduler: new WorkerScheduler(),
     stagingStore: new OpfsStagingStore(`${prefix}-staging`),

--- a/packages/client/test/browser/conformance.spec.ts
+++ b/packages/client/test/browser/conformance.spec.ts
@@ -18,6 +18,7 @@ const kitSeams = [
   'credentialStore',
   'scheduler',
   'recordTransport',
+  'mailbox',
 ] as const;
 
 function runSeam(page: Page, seam: string): Promise<SeamOutcome> {

--- a/packages/client/test/browser/conformance.worker.ts
+++ b/packages/client/test/browser/conformance.worker.ts
@@ -11,6 +11,7 @@
 import init, {
   runCredentialStoreConformance,
   runFloorStoreConformance,
+  runMailboxConformance,
   runRecordTransportConformance,
   runSchedulerConformance,
   runSnapshotCacheConformance,
@@ -19,6 +20,7 @@ import init, {
 import wasmUrl from './pkg/cipherbox_wasm_bg.wasm?url';
 
 import {
+  ApiMailbox,
   FetchHttp,
   FetchRecordTransport,
   IdbFloorStore,
@@ -26,6 +28,7 @@ import {
   NoopCredentialStore,
   OpfsStagingStore,
   WorkerScheduler,
+  toHex,
 } from '../../src/seams/index.js';
 import { deleteDatabase } from '../../src/seams/idb.js';
 
@@ -155,6 +158,17 @@ async function run(seam: string): Promise<void> {
       const routingKey = `conf-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       const record = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
       await runRecordTransportConformance(transport, routingKey, record);
+      return;
+    }
+    case 'mailbox': {
+      // A fresh compressed-secp256k1-shaped key per run: it names both the
+      // recipient the DTO carries and the mock account whose inbox is polled.
+      const ownPublicKey = new Uint8Array(33);
+      crypto.getRandomValues(ownPublicKey);
+      ownPublicKey[0] = 0x02;
+      const { origin } = scope.location;
+      const mailbox = new ApiMailbox(new FetchHttp(), `${origin}/mock-api/${toHex(ownPublicKey)}`);
+      await runMailboxConformance(mailbox, ownPublicKey);
       return;
     }
     case 'http': {

--- a/packages/client/test/browser/engine.worker.ts
+++ b/packages/client/test/browser/engine.worker.ts
@@ -22,7 +22,7 @@ async function boot(): Promise<void> {
   const { origin } = scope.location;
   const seams = makeBrowserSeams({
     recordEndpoints: [`${origin}/routing`],
-    mailboxUrl: `${origin}/mailbox`,
+    apiBaseUrl: `${origin}/mock-api/engine`,
     dbPrefix: `engine-${Date.now()}`,
   });
   const host = new EngineHost(wasm, seams, 'ci');

--- a/packages/client/test/browser/mockMailbox.ts
+++ b/packages/client/test/browser/mockMailbox.ts
@@ -1,0 +1,129 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+/**
+ * In-memory mock of the API mailbox surface (blueprint/api.md "Mailbox"), for
+ * the browser suite's `Mailbox` conformance run.
+ *
+ * It serves only the routes the real API serves and re-validates
+ * `PostMessageDto` the way `apps/api/src/mailbox/dto/mailbox.dto.ts` does, so a
+ * seam that drifts off the wire protocol fails here rather than in production.
+ * Blobs stay opaque.
+ *
+ * The one deliberate substitution: the account whose inbox `poll`/`ack` read
+ * comes from a path segment rather than a bearer JWT, since the browser suite
+ * mints no tokens. Everything under `/mock-api/` that is not a served route is
+ * a 404, so a route regression cannot fall through to the Vite HTML handler.
+ */
+
+const HEX_PUBLIC_KEY = /^(02|03)[0-9a-fA-F]{64}$|^04[0-9a-fA-F]{128}$/;
+const BASE64 = /^[A-Za-z0-9+/]+={0,2}$/;
+const IDEMPOTENCY_KEY = /^[A-Za-z0-9._~-]{1,128}$/;
+
+interface StoredMessage {
+  id: string;
+  receivedAt: string;
+  blob: string;
+}
+
+const MESSAGES = /^\/mock-api\/([^/]+)\/mailbox\/messages(?:\/([^/?]+))?\/?(?:\?.*)?$/;
+
+export function mockMailboxRequest(req: IncomingMessage, res: ServerResponse): boolean {
+  const url = req.url ?? '';
+  if (!url.startsWith('/mock-api/')) return false;
+
+  const match = url.match(MESSAGES);
+  if (!match) {
+    send(res, 404, { error: 'no such mailbox route' });
+    return true;
+  }
+  const account = decodeURIComponent(match[1]);
+  const messageId = match[2] === undefined ? null : decodeURIComponent(match[2]);
+
+  if (req.method === 'POST' && messageId === null) {
+    void readBody(req).then(
+      (body) => post(res, account, body),
+      () => send(res, 400, { error: 'request aborted' })
+    );
+    return true;
+  }
+  if (req.method === 'GET' && messageId === null) {
+    send(res, 200, { messages: inbox(account) });
+    return true;
+  }
+  if (req.method === 'DELETE' && messageId !== null) {
+    const pending = inbox(account);
+    const index = pending.findIndex((message) => message.id === messageId);
+    if (index >= 0) pending.splice(index, 1);
+    send(res, 200, { success: true });
+    return true;
+  }
+
+  send(res, 404, { error: 'no such mailbox route' });
+  return true;
+}
+
+/** Pending messages per recipient publicKey, oldest first. */
+const inboxes = new Map<string, StoredMessage[]>();
+/** `sender|recipient|idempotencyKey` → the id its first post minted. */
+const idempotency = new Map<string, string>();
+
+function inbox(recipientPublicKey: string): StoredMessage[] {
+  let pending = inboxes.get(recipientPublicKey);
+  if (!pending) {
+    pending = [];
+    inboxes.set(recipientPublicKey, pending);
+  }
+  return pending;
+}
+
+function post(res: ServerResponse, sender: string, body: Buffer): void {
+  let dto: { recipientPublicKey?: unknown; blob?: unknown; idempotencyKey?: unknown };
+  try {
+    dto = JSON.parse(body.toString('utf8')) as typeof dto;
+  } catch {
+    send(res, 400, { error: 'body must be JSON' });
+    return;
+  }
+
+  const { recipientPublicKey, blob, idempotencyKey } = dto;
+  if (typeof recipientPublicKey !== 'string' || !HEX_PUBLIC_KEY.test(recipientPublicKey)) {
+    send(res, 400, { error: 'recipientPublicKey must be a hex secp256k1 public key' });
+    return;
+  }
+  if (typeof blob !== 'string' || !BASE64.test(blob)) {
+    send(res, 400, { error: 'blob must be base64' });
+    return;
+  }
+  if (typeof idempotencyKey !== 'string' || !IDEMPOTENCY_KEY.test(idempotencyKey)) {
+    send(res, 400, { error: 'idempotencyKey must be 1-128 url-safe characters' });
+    return;
+  }
+
+  const scope = `${sender}|${recipientPublicKey}|${idempotencyKey}`;
+  const seen = idempotency.get(scope);
+  if (seen !== undefined) {
+    send(res, 201, { id: seen });
+    return;
+  }
+
+  const id = crypto.randomUUID();
+  idempotency.set(scope, id);
+  inbox(recipientPublicKey).push({ id, receivedAt: new Date().toISOString(), blob });
+  send(res, 201, { id });
+}
+
+/** Collects a request body; an abort rejects rather than parking the promise. */
+export function readBody(req: IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+}
+
+function send(res: ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}

--- a/packages/client/test/browser/vite.config.ts
+++ b/packages/client/test/browser/vite.config.ts
@@ -37,11 +37,17 @@ function mockNetwork(): Plugin {
             return;
           }
           if (req.method === 'PUT') {
-            void readBody(req).then((record) => {
-              records.set(key, record);
-              res.statusCode = 200;
-              res.end();
-            });
+            void readBody(req).then(
+              (record) => {
+                records.set(key, record);
+                res.statusCode = 200;
+                res.end();
+              },
+              () => {
+                res.statusCode = 400;
+                res.end();
+              }
+            );
             return;
           }
         }
@@ -63,11 +69,17 @@ function mockNetwork(): Plugin {
         }
 
         if (url.startsWith('/mock-http/echo')) {
-          void readBody(req).then((body) => {
-            res.statusCode = 200;
-            res.setHeader('x-echo-method', req.method ?? '');
-            res.end(body);
-          });
+          void readBody(req).then(
+            (body) => {
+              res.statusCode = 200;
+              res.setHeader('x-echo-method', req.method ?? '');
+              res.end(body);
+            },
+            () => {
+              res.statusCode = 400;
+              res.end();
+            }
+          );
           return;
         }
 

--- a/packages/client/test/browser/vite.config.ts
+++ b/packages/client/test/browser/vite.config.ts
@@ -1,12 +1,14 @@
 import { defineConfig, type Plugin } from 'vite';
 
+import { mockMailboxRequest, readBody } from './mockMailbox.js';
+
 /**
- * Serves the browser-suite harness and stands up an in-memory mock of the two
+ * Serves the browser-suite harness and stands up an in-memory mock of the
  * network surfaces the seams touch: the `/routing/v1` delegated-routing
- * endpoint set (for `RecordTransport`) and a couple of plain HTTP endpoints
- * (for the `Http` seam behavioral check). No crypto, no real network — the
- * mock stores and returns opaque bytes, exactly the shape the seam contracts
- * exercise.
+ * endpoint set (for `RecordTransport`), the API mailbox routes (for
+ * `Mailbox`), and a couple of plain HTTP endpoints (for the `Http` seam
+ * behavioral check). No crypto, no real network — the mock stores and returns
+ * opaque bytes, exactly the shape the seam contracts exercise.
  */
 function mockNetwork(): Plugin {
   const records = new Map<string, Buffer>();
@@ -16,6 +18,8 @@ function mockNetwork(): Plugin {
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
         const url = req.url ?? '';
+
+        if (mockMailboxRequest(req, res)) return;
 
         const routing = url.match(/\/routing\/v1\/ipns\/([^/?]+)/);
         if (routing) {
@@ -33,10 +37,8 @@ function mockNetwork(): Plugin {
             return;
           }
           if (req.method === 'PUT') {
-            const chunks: Buffer[] = [];
-            req.on('data', (chunk: Buffer) => chunks.push(chunk));
-            req.on('end', () => {
-              records.set(key, Buffer.concat(chunks));
+            void readBody(req).then((record) => {
+              records.set(key, record);
               res.statusCode = 200;
               res.end();
             });
@@ -61,12 +63,10 @@ function mockNetwork(): Plugin {
         }
 
         if (url.startsWith('/mock-http/echo')) {
-          const chunks: Buffer[] = [];
-          req.on('data', (chunk: Buffer) => chunks.push(chunk));
-          req.on('end', () => {
+          void readBody(req).then((body) => {
             res.statusCode = 200;
             res.setHeader('x-echo-method', req.method ?? '');
-            res.end(Buffer.concat(chunks));
+            res.end(body);
           });
           return;
         }


### PR DESCRIPTION
## Problem

`ApiMailbox` — the browser `Mailbox` seam — spoke a mailbox wire protocol the API has never served. It is the same class of defect as #827 (fixed for the Rust client in #835), in the copy that ships to the web client.

| Method | Sent | API serves |
| --- | --- | --- |
| `post` | `POST {mailboxUrl}`, `content-type: application/octet-stream`, raw sealed bytes as the body, `idempotency-key` / `x-recipient` **headers** | `POST /mailbox/messages` with a JSON `PostMessageDto`: `recipientPublicKey`, base64 `blob`, `idempotencyKey` |
| `poll` | nothing — returned `[]` unconditionally | `GET /mailbox/messages` returning `{ messages: [...] }` |
| `ack` | `DELETE {mailboxUrl}/{id}`, treating **404 as success** | `DELETE /mailbox/messages/{id}` |

`ack` was the one with silent-corruption potential: the API's ack is idempotent — an unknown id answers 200 — so a 404 means the route is wrong, not that the item was already acked. Swallowing it recorded a delete that never happened and stranded the message until the 90-day TTL.

Latent today only because the web runtime is still stubbed and nothing drives the seam.

## Change

`post` and `poll` now speak the served JSON DTO and the `{ messages: [...] }` envelope; `ack` rejects a 404. Three supporting decisions:

- **The seam owns its route suffix.** `ApiMailbox` takes `apiBaseUrl` and appends `/mailbox/messages` itself, matching `FetchRecordTransport` on the TS side and `ApiClient` on the Rust side. That deletes the `mailboxUrl` join from `spawnEngineWorker` and the `BrowserSeamsConfig` field, so a host supplies a base URL and nothing else.
- **A malformed poll fails closed.** An unreadable envelope, or a message that is not an `id`/`blob` string pair, throws rather than collapsing to `[]` — a silent empty inbox reads as "nothing pending" and strands every item.
- **No crypto or codec in TypeScript.** `toBase64`/`fromBase64` join `toHex`/`fromHex` in `seams/bytes.ts` as transport framing for bytes the seam never interprets; the engine still seals, unseals, and authenticates every payload.

Issue item 2 — the gate — lands with it: `runMailboxConformance` joins the other kit runners in `crates/wasm/src/conformance.rs`, `mailbox` joins `kitSeams` in the browser conformance switch, and a new `test/browser/mockMailbox.ts` serves only the routes the API serves, re-validating `PostMessageDto` the way `apps/api/src/mailbox/dto/mailbox.dto.ts` does. Anything under `/mock-api/` that is not a served route is a 404, so a route regression cannot fall through to the Vite HTML handler. The mock names the polled account by a path segment rather than a bearer JWT — the browser suite mints no tokens; see "Not closed here".

## Tests

Two named merge-blocking gates, both confirmed red on revert:

- **`Test`** (root `pnpm test`, which covers the `packages/client` vitest suite) — new `packages/client/src/seams/mailbox.test.ts`. Reverting `mailbox.ts` to `main` fails **5 of its 6 tests**, including `sends the served route and the PostMessageDto body`, `reads the messages envelope and decodes each sealed blob`, and `rejects a 404 instead of recording a delete that never happened`.
- **`Client Browser Suite`** (`pnpm --filter @cipherbox/client test:browser`) — `mailbox passes its engine conformance kit`. Reverting `mailbox.ts` fails it with `Uncaught RuntimeError: unreachable`, the kit's assertion trap.

Also added: base64 round-trip coverage in `bytes.test.ts`, including the standard-alphabet assertion — a url-safe variant would 400 every post — and the chunked-encode boundary.

## Verification

All exit 0 locally:

- `cargo fmt --all --check`, `cargo clippy --workspace --exclude cipherbox-desktop --exclude cipherbox-contract --all-targets -- -D warnings`, `cargo check --workspace --exclude cipherbox-desktop --all-targets`
- `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets` and `cargo clippy -p cipherbox-wasm --features conformance --target wasm32-unknown-unknown --all-targets -- -D warnings` — the conformance runner only compiles under that feature
- `cargo test -p cipherbox-engine` — the mailbox conformance kit itself is unchanged
- `pnpm -r --if-present run typecheck`, `pnpm -r --if-present run test` — client 123, api 177, web 67
- `eslint .`
- `pnpm --filter @cipherbox/client test:browser` — **20 passed**, including the new mailbox kit run

The live contract suite was not run: it gates `ApiClient::mailbox_*`, which this diff does not touch.

## Review gates

- **`/security-review`** — no exploitable findings in the diff. Two real defects found *outside* it, both confirmed against source and filed below. In-diff fixes folded in: a per-message `typeof` shape check on the poll response so fail-closed is deliberate rather than incidental, and an `error` handler on the mock's body reader so an aborted request rejects instead of parking the promise.
- **`/crypto-privacy-review`** — no crypto added to TypeScript, correctly. Metadata privacy is a **net improvement**: the recipient hex and idempotency key move out of custom request headers into the JSON body, which drops them from the surfaces proxies and access logs capture by default, drops the custom header names from the CORS preflight, and removes a header-value injection surface. Idempotency-key entropy is unaffected — the seam passes the engine's per-recipient blinded-tag key through opaquely. Nothing is logged or persisted, and only ciphertext transits the base64 helpers.
- **`/simplify`** — 9 findings folded in: dropped the `PollResponseWire` interface that typed unvalidated wire input as validated, so the runtime guard is the single source of truth; hoisted `TextEncoder`/`TextDecoder` to module consts; collapsed three restatements of the same rationale to one home; trimmed two over-long comments; removed the mock's two unreachable blob-size bounds; deduplicated `readBody` across all three `vite.config.ts` mock handlers, which propagates the abort fix to them; made the test `ScriptedHttp` reject an unscripted request instead of answering an empty 200; and fixed a `[object Object]` test label. Two skipped: retiring `test/browser/hexUtil.ts` touches unrelated harnesses, and making the mock demand a bearer would land a permanently red merge-blocking test — that is #953 instead.

## Not closed here

Both filed with dependency edges and cross-linked from #836:

- **#953** — the seam sends no `Authorization` bearer and has no 401 refresh-retry, so every call 401s against a real API. The fix is not a header: the token lives in-memory inside the Rust engine, and exporting it to a JS seam moves a bearer secret into unwipeable JS strings. The altitude fix is the `impl Mailbox for ApiClient` collapse that #836 already flags as a later design call.
- **#954** — the engine's grant-delivery path posts an X25519 subkey as `recipientPublicKey`, where the DTO demands secp256k1, and a `grant:`-prefixed idempotency key whose `:` is outside the allowed charset. Engine-side, and it affects the Rust client identically, so it is outside this browser-seam scope.

`poll` stays all-or-nothing on an undecodable blob, deliberately: `ApiClient::mailbox_poll` has the same shape, and divergence between the two implementations is the exact bug class this PR fixes. The engine's "drop, never stall" invariant lives above the seam, in `poll_verified`.

## Parallel work

PR #951, issue #641, touches `packages/client` heavily — the Service Worker, `src/media/**`, the transports, and `src/seams/http.ts`. This PR stays in the mailbox seam and does not touch `http.ts`, but it does edit `test/browser/vite.config.ts` and `src/worker/browserSeams.ts`. Whichever merges second should re-check those two.

Closes #836


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Base64 encoding and decoding for binary data exchanged through the API.
  * Added mailbox support for posting, polling, and acknowledging messages.
  * Added mailbox conformance checks for browser and WebAssembly integrations.

* **Bug Fixes**
  * Improved validation and error handling for malformed mailbox responses and failed requests.
  * Standardized API base URL handling for mailbox operations.

* **Tests**
  * Expanded coverage for encoding, mailbox operations, browser integrations, and conformance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->