### PR TITLE
fix: wipe the decoder in-flight tree and the seal layer preserved unknowns

### DIFF
--- a/crates/core/examples/kat_gen.rs
+++ b/crates/core/examples/kat_gen.rs
@@ -35,10 +35,10 @@ use cipherbox_core::seal::{
     self, AAD_DOMAIN, AadContext, AscentLink, CONTENT_KEY_HPKE_INFO, CONTENT_KEY_V, ChildRef,
     ChildScopeRef, GrantBlobPayload, GrantLedgerEntry, GrantSetCommitment, GrantSetEntry,
     HistoryLinkPayload, NodeKind, OP_RECORD_HPKE_INFO, OP_RECORD_V, OpRecordHeader,
-    OverrideSeedPayload, OwnerWriteBlobPayload, Permission, ReadBody, SETTINGS_RECORD_HPKE_INFO,
-    SETTINGS_RECORD_V, STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_CONTENT_KEY, STRUCT_TAG_GRANT_BLOB,
-    STRUCT_TAG_HISTORY_LINK, STRUCT_TAG_MAILBOX_PAYLOAD, STRUCT_TAG_OP_RECORD,
-    STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB, STRUCT_TAG_READ_BODY,
+    OverrideSeedPayload, OwnerWriteBlobPayload, Permission, PreservedFields, ReadBody,
+    SETTINGS_RECORD_HPKE_INFO, SETTINGS_RECORD_V, STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_CONTENT_KEY,
+    STRUCT_TAG_GRANT_BLOB, STRUCT_TAG_HISTORY_LINK, STRUCT_TAG_MAILBOX_PAYLOAD,
+    STRUCT_TAG_OP_RECORD, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB, STRUCT_TAG_READ_BODY,
     STRUCT_TAG_SETTINGS_RECORD, STRUCT_TAG_WRITE_BODY, STRUCT_TAGS, SettingsRecordHeader,
     SignedAscentLink, SignedGrantBlob, SignedOwnerBlob, SignedSealed, StructureSigInput, Version,
     WriteBody, build_aad, content_key_aad, decode_ascent_link, decode_envelope,
@@ -2741,7 +2741,7 @@ fn sample_folder() -> ReadBody {
                 ipns_name: b"ipns-name-a".to_vec(),
                 kind: NodeKind::File,
                 link_counter: 1,
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             },
             ChildRef {
                 id: [0x22; 16],
@@ -2749,10 +2749,10 @@ fn sample_folder() -> ReadBody {
                 ipns_name: b"ipns-name-b".to_vec(),
                 kind: NodeKind::Folder,
                 link_counter: 2,
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             },
         ],
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     }
 }
 
@@ -2765,7 +2765,7 @@ fn sample_file() -> ReadBody {
             Version::new(b"content-cid-new".to_vec(), [0x77; 32], 8192, 2500),
             Version::new(b"content-cid-old".to_vec(), [0x66; 32], 4096, 1500),
         ],
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     }
 }
 
@@ -2940,13 +2940,13 @@ fn build_read_body_accept() -> Vec<ReadBodyAcceptVector> {
         created_at: 1,
         modified_at: 2,
         children: Vec::new(),
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
     let single_version = ReadBody::File {
         created_at: 3,
         modified_at: 4,
         versions: vec![Version::new(b"cid".to_vec(), [0x55; 32], 512, 4)],
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
     let cases: Vec<(&str, ReadBody)> = vec![
         ("empty-folder", empty_folder),
@@ -4526,7 +4526,7 @@ fn build_write_body_accept() -> Vec<WriteBodyAcceptVector> {
             ChildScopeRef::new([0x55; 16], b"child-scope-ipns-a".to_vec()),
             ChildScopeRef::new([0x66; 16], b"child-scope-ipns-b".to_vec()),
         ],
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
     // Write epoch 1: no prior write epoch, so no history link, and a scope root
     // with no descendant scopes and no grants yet.
@@ -4534,7 +4534,7 @@ fn build_write_body_accept() -> Vec<WriteBodyAcceptVector> {
         grant_ledger: Vec::new(),
         write_history_link: Vec::new(),
         direct_child_scope_index: Vec::new(),
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
     let read_only = WriteBody {
         grant_ledger: vec![GrantLedgerEntry::new(
@@ -4545,7 +4545,7 @@ fn build_write_body_accept() -> Vec<WriteBodyAcceptVector> {
         )],
         write_history_link: b"h".to_vec(),
         direct_child_scope_index: vec![ChildScopeRef::new([0x77; 16], b"one-child".to_vec())],
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
     let cases: Vec<(&str, WriteBody)> = vec![
         ("full", full),
@@ -4674,7 +4674,7 @@ fn section_commitment(entries: Vec<GrantSetEntry>) -> GrantSetCommitment {
         ipns_name: b"grant-section-scope-root".to_vec(),
         owner_pseudonym_pk: [0x88; 32],
         entries,
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     }
 }
 
@@ -4684,7 +4684,7 @@ fn section_grant_blob(tag: u8) -> SignedGrantBlob {
         enc: [0x0a; 32],
         ciphertext: vec![0x0b, 0x0c, 0x0d],
         signature: [0x0e; 64],
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     }
 }
 
@@ -4700,32 +4700,32 @@ fn build_grant_section_accept() -> Vec<SectionAcceptVector> {
             enc: [0x20; 32],
             ciphertext: vec![0x21, 0x22],
             signature: [0x23; 64],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         },
         owner_write_blob: Some(seal::SignedOwnerWriteBlob {
             enc: [0x24; 32],
             ciphertext: vec![0x25, 0x26],
             signature: [0x27; 64],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }),
         ascent_link: Some(SignedAscentLink {
             ascent_public: [0x30; 32],
             enc: [0x31; 32],
             ciphertext: vec![0x32, 0x33],
             signature: [0x34; 64],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }),
         history_links: vec![SignedSealed {
             sealed: vec![0x40, 0x41, 0x42],
             signature: [0x43; 64],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }],
         write_body: SignedSealed {
             sealed: vec![0x50, 0x51, 0x52],
             signature: [0x53; 64],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         },
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
     // Epoch 1 at the vault root: no grants, no history link, no ascent link.
     let minimal = seal::GrantSection {
@@ -4736,7 +4736,7 @@ fn build_grant_section_accept() -> Vec<SectionAcceptVector> {
             enc: [0x20; 32],
             ciphertext: vec![0x21],
             signature: [0x23; 64],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         },
         owner_write_blob: None,
         ascent_link: None,
@@ -4744,9 +4744,9 @@ fn build_grant_section_accept() -> Vec<SectionAcceptVector> {
         write_body: SignedSealed {
             sealed: vec![0x50],
             signature: [0x53; 64],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         },
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
     let cases: Vec<(&str, seal::GrantSection)> =
         vec![("full", full), ("vault-root-epoch-1", minimal)];
@@ -5584,7 +5584,7 @@ fn grant_set_sample() -> GrantSetCommitment {
             GrantSetEntry::new([0x01; 32], Permission::Read, [0x02; 32]),
             GrantSetEntry::new([0x03; 32], Permission::Write, [0x04; 32]),
         ],
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     }
 }
 

--- a/crates/core/src/codec/decode.rs
+++ b/crates/core/src/codec/decode.rs
@@ -7,50 +7,21 @@ use super::encode::{
     MAJOR_ARRAY, MAJOR_BYTES, MAJOR_MAP, MAJOR_NEGATIVE, MAJOR_SIMPLE, MAJOR_TEXT, MAJOR_UNSIGNED,
     SIMPLE_FALSE, SIMPLE_NULL, SIMPLE_TRUE,
 };
+use super::scrub::ScrubOnDrop;
 use super::value::{Map, Value, canonical_key_cmp};
 use crate::error::{CodecError, Malformed, TrustViolation};
 
 /// Decode exactly one deterministic-profile item spanning the whole input.
+///
+/// A reject anywhere past the first byte leaves the decoder holding values it
+/// has already read, so every accumulator here stands under a [`ScrubOnDrop`].
 pub fn decode(bytes: &[u8]) -> Result<Value, CodecError> {
     let mut d = Decoder::new(bytes);
     let mut value = d.read_value(0)?;
-    let guard = InFlight(&mut value);
+    let guard = ScrubOnDrop(&mut value);
     d.expect_end()?;
     core::mem::forget(guard);
     Ok(value)
-}
-
-/// Wipes what a decode has already read when a later read rejects. Every
-/// decoded buffer is a verbatim copy of what the input carried — inline content
-/// keys and seed material on the seal surfaces — and the decoder owns it until
-/// it returns, below any guard a caller can install (blueprint/core.md "Crypto
-/// suite": key material lives only in zeroizing owners). Borrows rather than
-/// owns, so forgetting it disarms it and leaks nothing.
-struct InFlight<'a, T: Scrub>(&'a mut T);
-
-/// What an [`InFlight`] guard wipes.
-trait Scrub {
-    fn scrub(&mut self);
-}
-
-impl Scrub for Value {
-    fn scrub(&mut self) {
-        self.zeroize_bytes();
-    }
-}
-
-impl Scrub for Vec<Value> {
-    fn scrub(&mut self) {
-        for value in self {
-            value.zeroize_bytes();
-        }
-    }
-}
-
-impl<T: Scrub> Drop for InFlight<'_, T> {
-    fn drop(&mut self) {
-        self.0.scrub();
-    }
 }
 
 pub(super) struct Decoder<'a> {
@@ -200,7 +171,7 @@ impl<'a> Decoder<'a> {
             }
             MAJOR_ARRAY => {
                 let mut items = Vec::new();
-                let guard = InFlight(&mut items);
+                let guard = ScrubOnDrop(&mut items);
                 for _ in 0..head.arg {
                     guard.0.push(self.read_value(depth + 1)?);
                 }
@@ -208,21 +179,17 @@ impl<'a> Decoder<'a> {
                 Ok(Value::Array(items))
             }
             MAJOR_MAP => {
-                // Keys are field names, never secret, so they sit outside the
-                // guard and carry the ascending-order check.
-                let mut keys: Vec<String> = Vec::new();
-                let mut values = Vec::new();
-                let guard = InFlight(&mut values);
+                let mut entries: Vec<(String, Value)> = Vec::new();
+                let guard = ScrubOnDrop(&mut entries);
                 for _ in 0..head.arg {
-                    let key = self.read_map_key(keys.last().map(String::as_str))?;
+                    let key = self.read_map_key(guard.0.last().map(|(k, _)| k.as_str()))?;
                     let value = self.read_value(depth + 1)?;
-                    keys.push(key);
-                    guard.0.push(value);
+                    guard.0.push((key, value));
                 }
                 core::mem::forget(guard);
                 // Order and uniqueness were enforced entry-by-entry, so this
                 // rebuild cannot reorder or drop anything.
-                Ok(Value::Map(keys.into_iter().zip(values).collect::<Map>()))
+                Ok(Value::Map(entries.into_iter().collect::<Map>()))
             }
             // Dispatch on the additional info, never the argument: ai 25–27
             // carry float bit patterns in `arg`, which would otherwise alias
@@ -271,40 +238,5 @@ impl<'a> Decoder<'a> {
             }
         }
         Ok(key.to_owned())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The guard standing between a mid-item reject and a heap holding every
-    /// secret the decode had already lifted out of its input.
-    #[test]
-    fn the_in_flight_guard_wipes_what_it_guards() {
-        let mut items = vec![Value::Bytes(vec![0xAB; 32]), Value::Unsigned(7)];
-        drop(InFlight(&mut items));
-        assert_eq!(items[0], Value::Bytes(Vec::new()));
-        assert_eq!(items[1], Value::Unsigned(7), "shape and scalars kept");
-
-        let mut value = Value::Array(vec![Value::Text("secret-file.txt".into())]);
-        drop(InFlight(&mut value));
-        assert_eq!(
-            value.as_array().unwrap()[0],
-            Value::Text(String::new()),
-            "the whole-tree guard wipes nested buffers too"
-        );
-    }
-
-    /// The map arm accumulates keys and values apart; the ordering checks still
-    /// see the previous key.
-    #[test]
-    fn map_key_order_checks_survive_the_split_accumulators() {
-        // {"b": 1, "a": 2}
-        let unsorted = [0xa2, 0x61, b'b', 0x01, 0x61, b'a', 0x02];
-        assert_eq!(decode(&unsorted).unwrap_err().check(), "unsorted-map-keys");
-        // {"a": 1, "a": 2}
-        let duplicate = [0xa2, 0x61, b'a', 0x01, 0x61, b'a', 0x02];
-        assert_eq!(decode(&duplicate).unwrap_err().check(), "duplicate-map-key");
     }
 }

--- a/crates/core/src/codec/decode.rs
+++ b/crates/core/src/codec/decode.rs
@@ -13,9 +13,44 @@ use crate::error::{CodecError, Malformed, TrustViolation};
 /// Decode exactly one deterministic-profile item spanning the whole input.
 pub fn decode(bytes: &[u8]) -> Result<Value, CodecError> {
     let mut d = Decoder::new(bytes);
-    let value = d.read_value(0)?;
+    let mut value = d.read_value(0)?;
+    let guard = InFlight(&mut value);
     d.expect_end()?;
+    core::mem::forget(guard);
     Ok(value)
+}
+
+/// Wipes what a decode has already read when a later read rejects. Every
+/// decoded buffer is a verbatim copy of what the input carried — inline content
+/// keys and seed material on the seal surfaces — and the decoder owns it until
+/// it returns, below any guard a caller can install (blueprint/core.md "Crypto
+/// suite": key material lives only in zeroizing owners). Borrows rather than
+/// owns, so forgetting it disarms it and leaks nothing.
+struct InFlight<'a, T: Scrub>(&'a mut T);
+
+/// What an [`InFlight`] guard wipes.
+trait Scrub {
+    fn scrub(&mut self);
+}
+
+impl Scrub for Value {
+    fn scrub(&mut self) {
+        self.zeroize_bytes();
+    }
+}
+
+impl Scrub for Vec<Value> {
+    fn scrub(&mut self) {
+        for value in self {
+            value.zeroize_bytes();
+        }
+    }
+}
+
+impl<T: Scrub> Drop for InFlight<'_, T> {
+    fn drop(&mut self) {
+        self.0.scrub();
+    }
 }
 
 pub(super) struct Decoder<'a> {
@@ -165,21 +200,29 @@ impl<'a> Decoder<'a> {
             }
             MAJOR_ARRAY => {
                 let mut items = Vec::new();
+                let guard = InFlight(&mut items);
                 for _ in 0..head.arg {
-                    items.push(self.read_value(depth + 1)?);
+                    guard.0.push(self.read_value(depth + 1)?);
                 }
+                core::mem::forget(guard);
                 Ok(Value::Array(items))
             }
             MAJOR_MAP => {
-                let mut entries: Vec<(String, Value)> = Vec::new();
+                // Keys are field names, never secret, so they sit outside the
+                // guard and carry the ascending-order check.
+                let mut keys: Vec<String> = Vec::new();
+                let mut values = Vec::new();
+                let guard = InFlight(&mut values);
                 for _ in 0..head.arg {
-                    let key = self.read_map_key(entries.last().map(|(k, _)| k.as_str()))?;
+                    let key = self.read_map_key(keys.last().map(String::as_str))?;
                     let value = self.read_value(depth + 1)?;
-                    entries.push((key, value));
+                    keys.push(key);
+                    guard.0.push(value);
                 }
+                core::mem::forget(guard);
                 // Order and uniqueness were enforced entry-by-entry, so this
                 // rebuild cannot reorder or drop anything.
-                Ok(Value::Map(entries.into_iter().collect::<Map>()))
+                Ok(Value::Map(keys.into_iter().zip(values).collect::<Map>()))
             }
             // Dispatch on the additional info, never the argument: ai 25–27
             // carry float bit patterns in `arg`, which would otherwise alias
@@ -228,5 +271,40 @@ impl<'a> Decoder<'a> {
             }
         }
         Ok(key.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The guard standing between a mid-item reject and a heap holding every
+    /// secret the decode had already lifted out of its input.
+    #[test]
+    fn the_in_flight_guard_wipes_what_it_guards() {
+        let mut items = vec![Value::Bytes(vec![0xAB; 32]), Value::Unsigned(7)];
+        drop(InFlight(&mut items));
+        assert_eq!(items[0], Value::Bytes(Vec::new()));
+        assert_eq!(items[1], Value::Unsigned(7), "shape and scalars kept");
+
+        let mut value = Value::Array(vec![Value::Text("secret-file.txt".into())]);
+        drop(InFlight(&mut value));
+        assert_eq!(
+            value.as_array().unwrap()[0],
+            Value::Text(String::new()),
+            "the whole-tree guard wipes nested buffers too"
+        );
+    }
+
+    /// The map arm accumulates keys and values apart; the ordering checks still
+    /// see the previous key.
+    #[test]
+    fn map_key_order_checks_survive_the_split_accumulators() {
+        // {"b": 1, "a": 2}
+        let unsorted = [0xa2, 0x61, b'b', 0x01, 0x61, b'a', 0x02];
+        assert_eq!(decode(&unsorted).unwrap_err().check(), "unsorted-map-keys");
+        // {"a": 1, "a": 2}
+        let duplicate = [0xa2, 0x61, b'a', 0x01, 0x61, b'a', 0x02];
+        assert_eq!(decode(&duplicate).unwrap_err().check(), "duplicate-map-key");
     }
 }

--- a/crates/core/src/codec/encode.rs
+++ b/crates/core/src/codec/encode.rs
@@ -1,7 +1,7 @@
 //! The deterministic encoder. Canonical by construction: shortest-form
 //! arguments, definite lengths, and [`super::Map`]'s ordering invariant are
-//! the only forms this module can emit, so [`check_depth`] is the one way
-//! encoding fails.
+//! the only forms this module can emit, so [`check_depth`] and
+//! [`Map::reject_if_wiped`] are the only ways encoding fails.
 
 use super::value::{Map, Value};
 use crate::error::{CodecError, Malformed};
@@ -38,10 +38,11 @@ pub fn encode(value: &Value) -> Result<Vec<u8>, CodecError> {
 ///
 /// # Panics
 ///
-/// If `value` nests to [`super::MAX_DEPTH`]. Use [`encode`] for any tree whose
-/// depth comes from input rather than from the schema.
+/// If `value` nests to [`super::MAX_DEPTH`], or carries a map [`Map::zeroize_bytes`]
+/// already wiped. Use [`encode`] for any tree whose depth comes from input
+/// rather than from the schema.
 pub fn encode_fixed_depth(value: &Value) -> Vec<u8> {
-    encode(value).expect("fixed-shape tree is within MAX_DEPTH")
+    encode(value).expect("fixed-shape, unwiped tree")
 }
 
 /// The exact number of bytes [`encode`] emits for `value`. Mirrors
@@ -67,7 +68,7 @@ pub(super) fn count_value(len: &mut usize, value: &Value, depth: usize) -> Resul
             }
         }
         Value::Map(map) => {
-            reject_wiped(map)?;
+            map.reject_if_wiped()?;
             *len += head_len(map.len() as u64);
             for (k, v) in map.entries() {
                 *len += text_len(k);
@@ -85,17 +86,6 @@ pub(super) fn count_value(len: &mut usize, value: &Value, depth: usize) -> Resul
 fn check_depth(depth: usize, offset: usize) -> Result<(), CodecError> {
     if depth >= super::MAX_DEPTH {
         return Err(Malformed::DepthExceeded { offset }.into());
-    }
-    Ok(())
-}
-
-/// The terminal half of [`Map::zeroize_bytes`]: a wiped map's fields are all
-/// zero-length, and a variable-length schema read round-trips one as empty
-/// instead of rejecting it, so emitting from a wiped map is silent data loss.
-/// Release-active on both passes, like [`check_depth`].
-pub(super) fn reject_wiped(map: &Map) -> Result<(), CodecError> {
-    if map.is_wiped() {
-        return Err(Malformed::WipedMap.into());
     }
     Ok(())
 }
@@ -154,7 +144,7 @@ fn write_map_head_and_entries(
     map: &Map,
     depth: usize,
 ) -> Result<(), CodecError> {
-    reject_wiped(map)?;
+    map.reject_if_wiped()?;
     write_head(out, MAJOR_MAP, map.len() as u64);
     for (k, v) in map.entries() {
         write_text(out, k);
@@ -270,10 +260,8 @@ mod tests {
         assert_eq!(super::super::decode(&bytes).unwrap(), deepest);
     }
 
-    /// AGENTS.md rule 8's misuse-resistance sibling, release-active: a wiped map
-    /// re-encodes to fields its own decoder accepts as empty, so the wipe is
-    /// terminal and both passes refuse it — at every nesting level, since the
-    /// hazard is a version map inside a body, not only a top-level map.
+    /// The wipe is terminal, and both passes enforce it at every nesting level —
+    /// the hazard is a version map inside a body, not only a top-level map.
     #[test]
     fn a_wiped_map_refuses_to_encode() {
         let mut value = secret_shaped_value(2);
@@ -291,7 +279,6 @@ mod tests {
             panic!("expected a version map")
         };
         version.zeroize_bytes();
-        assert!(version.is_wiped());
 
         assert_eq!(encoded_len(&value).unwrap_err().check(), "wiped-map");
         assert_eq!(encode(&value).unwrap_err().check(), "wiped-map");

--- a/crates/core/src/codec/encode.rs
+++ b/crates/core/src/codec/encode.rs
@@ -67,6 +67,7 @@ pub(super) fn count_value(len: &mut usize, value: &Value, depth: usize) -> Resul
             }
         }
         Value::Map(map) => {
+            reject_wiped(map)?;
             *len += head_len(map.len() as u64);
             for (k, v) in map.entries() {
                 *len += text_len(k);
@@ -84,6 +85,17 @@ pub(super) fn count_value(len: &mut usize, value: &Value, depth: usize) -> Resul
 fn check_depth(depth: usize, offset: usize) -> Result<(), CodecError> {
     if depth >= super::MAX_DEPTH {
         return Err(Malformed::DepthExceeded { offset }.into());
+    }
+    Ok(())
+}
+
+/// The terminal half of [`Map::zeroize_bytes`]: a wiped map's fields are all
+/// zero-length, and a variable-length schema read round-trips one as empty
+/// instead of rejecting it, so emitting from a wiped map is silent data loss.
+/// Release-active on both passes, like [`check_depth`].
+pub(super) fn reject_wiped(map: &Map) -> Result<(), CodecError> {
+    if map.is_wiped() {
+        return Err(Malformed::WipedMap.into());
     }
     Ok(())
 }
@@ -142,6 +154,7 @@ fn write_map_head_and_entries(
     map: &Map,
     depth: usize,
 ) -> Result<(), CodecError> {
+    reject_wiped(map)?;
     write_head(out, MAJOR_MAP, map.len() as u64);
     for (k, v) in map.entries() {
         write_text(out, k);
@@ -255,6 +268,38 @@ mod tests {
         let bytes = encode(&deepest).expect("the deepest admissible tree encodes");
         assert_eq!(encoded_len(&deepest).unwrap(), bytes.len());
         assert_eq!(super::super::decode(&bytes).unwrap(), deepest);
+    }
+
+    /// AGENTS.md rule 8's misuse-resistance sibling, release-active: a wiped map
+    /// re-encodes to fields its own decoder accepts as empty, so the wipe is
+    /// terminal and both passes refuse it — at every nesting level, since the
+    /// hazard is a version map inside a body, not only a top-level map.
+    #[test]
+    fn a_wiped_map_refuses_to_encode() {
+        let mut value = secret_shaped_value(2);
+        assert!(encode(&value).is_ok(), "encodes before the wipe");
+
+        // Wipe one nested version map, the way a caller scrubbing decoded known
+        // fields would, and leave the enclosing tree untouched.
+        let Value::Map(body) = &mut value else {
+            panic!("expected a map body")
+        };
+        let Some(Value::Array(versions)) = body.get_mut("versions") else {
+            panic!("expected a version list")
+        };
+        let Value::Map(version) = &mut versions[0] else {
+            panic!("expected a version map")
+        };
+        version.zeroize_bytes();
+        assert!(version.is_wiped());
+
+        assert_eq!(encoded_len(&value).unwrap_err().check(), "wiped-map");
+        assert_eq!(encode(&value).unwrap_err().check(), "wiped-map");
+        let mut out = Vec::new();
+        assert_eq!(
+            write_value(&mut out, &value, 0).unwrap_err().check(),
+            "wiped-map"
+        );
     }
 
     /// The security invariant: encoding secret-bearing bytes never reallocates,

--- a/crates/core/src/codec/fields.rs
+++ b/crates/core/src/codec/fields.rs
@@ -14,8 +14,9 @@ use zeroize::Zeroizing;
 
 use super::decode::Decoder;
 use super::encode::{
-    MAJOR_MAP, count_value, head_len, reject_wiped, text_len, write_head, write_text, write_value,
+    MAJOR_MAP, count_value, head_len, text_len, write_head, write_text, write_value,
 };
+use super::scrub::ScrubOnDrop;
 use super::value::{Map, Value, canonical_key_cmp};
 use crate::error::{CodecError, DisplayKey, Malformed};
 
@@ -38,12 +39,22 @@ pub struct UnknownFields {
 
 impl fmt::Debug for UnknownFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut m = f.debug_map();
-        for (key, _) in &self.entries {
-            m.key(&DisplayKey(key)).value(&"<redacted>");
-        }
-        m.finish()
+        fmt_redacted_keys(f, self.entries.iter().map(|(key, _)| key.as_str()))
     }
+}
+
+/// Render a preserved-field set as keys only, with the field names bounded the
+/// way the error surface bounds writer-controlled keys. Shared by both
+/// preserve-unknowns carriers so neither can grow a value into a log line.
+pub(crate) fn fmt_redacted_keys<'a>(
+    f: &mut fmt::Formatter<'_>,
+    keys: impl Iterator<Item = &'a str>,
+) -> fmt::Result {
+    let mut m = f.debug_map();
+    for key in keys {
+        m.key(&DisplayKey(key)).value(&"<redacted>");
+    }
+    m.finish()
 }
 
 impl UnknownFields {
@@ -121,25 +132,13 @@ fn decode_entries(
     Ok(unknown)
 }
 
-/// The scrub guard of [`crate::seal`], borrowing rather than owning: the known
-/// fields belong to the caller, and only the paths that never return them wipe.
-/// Disarmed by forgetting it, which leaks nothing — it holds one borrow.
-struct ScrubOnDrop<'a>(&'a mut Map);
-
-impl Drop for ScrubOnDrop<'_> {
-    fn drop(&mut self) {
-        self.0.zeroize_bytes();
-    }
-}
-
 /// Canonically re-encode a map from re-built known fields plus preserved
 /// unknown fields: one merged map in canonical key order, unknown values
 /// emitted byte-stable. A key present on both sides is a caller bug and
 /// rejects fail-closed.
 pub fn encode_map_partial(known: &Map, unknown: &UnknownFields) -> Result<Vec<u8>, CodecError> {
-    // The merged map's own head is written here, so its wiped mark is read here
-    // too — the nested ones ride `count_value`/`write_value`.
-    reject_wiped(known)?;
+    // This writes the merged head itself, so the known side's mark is read here.
+    known.reject_if_wiped()?;
     let merged = merge(known, unknown)?;
     let mut out = Vec::with_capacity(merged_len(&merged)?);
     write_head(&mut out, MAJOR_MAP, merged.len() as u64);

--- a/crates/core/src/codec/fields.rs
+++ b/crates/core/src/codec/fields.rs
@@ -14,7 +14,7 @@ use zeroize::Zeroizing;
 
 use super::decode::Decoder;
 use super::encode::{
-    MAJOR_MAP, count_value, head_len, text_len, write_head, write_text, write_value,
+    MAJOR_MAP, count_value, head_len, reject_wiped, text_len, write_head, write_text, write_value,
 };
 use super::value::{Map, Value, canonical_key_cmp};
 use crate::error::{CodecError, DisplayKey, Malformed};
@@ -137,6 +137,9 @@ impl Drop for ScrubOnDrop<'_> {
 /// emitted byte-stable. A key present on both sides is a caller bug and
 /// rejects fail-closed.
 pub fn encode_map_partial(known: &Map, unknown: &UnknownFields) -> Result<Vec<u8>, CodecError> {
+    // The merged map's own head is written here, so its wiped mark is read here
+    // too — the nested ones ride `count_value`/`write_value`.
+    reject_wiped(known)?;
     let merged = merge(known, unknown)?;
     let mut out = Vec::with_capacity(merged_len(&merged)?);
     write_head(&mut out, MAJOR_MAP, merged.len() as u64);
@@ -355,6 +358,20 @@ mod tests {
 
         let err = encode_map_partial(&known, &unknown).unwrap_err();
         assert_eq!(err.check(), "truncated");
+    }
+
+    /// The merged encoder reads the wiped mark on the known side it writes the
+    /// head for; a rewrite after a scrub would otherwise publish a record whose
+    /// variable-length fields silently came back empty.
+    #[test]
+    fn merged_encode_rejects_a_wiped_known_side() {
+        let original = encode(&Value::Map(sample_map())).unwrap();
+        let (mut known, unknown) =
+            decode_map_partial(&original, known_key_set(&["v", "id"])).unwrap();
+        known.zeroize_bytes();
+
+        let err = encode_map_partial(&known, &unknown).unwrap_err();
+        assert_eq!(err.check(), "wiped-map");
     }
 
     #[test]

--- a/crates/core/src/codec/mod.rs
+++ b/crates/core/src/codec/mod.rs
@@ -16,10 +16,12 @@
 mod decode;
 mod encode;
 mod fields;
+pub(crate) mod scrub;
 mod value;
 
 pub use decode::decode;
 pub use encode::{encode, encode_fixed_depth, encoded_len};
+pub(crate) use fields::fmt_redacted_keys;
 pub use fields::{UnknownFields, decode_map_partial, encode_map_partial, known_key_set};
 pub use value::{Map, Value, canonical_key_cmp};
 

--- a/crates/core/src/codec/scrub.rs
+++ b/crates/core/src/codec/scrub.rs
@@ -1,0 +1,110 @@
+//! The terminal-owner wipe guards.
+//!
+//! A codec or schema pass owns the transient `Value` tree it builds, and that
+//! tree carries verbatim copies of secret material — inline content keys, scope
+//! seeds. It is therefore that tree's terminal owner and wipes it on every exit
+//! a caller does not take ownership through, panic-unwind included
+//! (blueprint/core.md "Crypto suite": key material lives only in zeroizing
+//! owners). Map keys are field names, never secret, and are left intact.
+
+use super::value::{Map, Value};
+
+/// What a guard wipes.
+pub(crate) trait Scrub {
+    fn scrub(&mut self);
+}
+
+impl Scrub for Value {
+    fn scrub(&mut self) {
+        self.zeroize_bytes();
+    }
+}
+
+impl Scrub for Map {
+    fn scrub(&mut self) {
+        self.zeroize_bytes();
+    }
+}
+
+impl Scrub for Vec<Value> {
+    fn scrub(&mut self) {
+        for value in self {
+            value.zeroize_bytes();
+        }
+    }
+}
+
+impl Scrub for Vec<(String, Value)> {
+    fn scrub(&mut self) {
+        for (_, value) in self {
+            value.zeroize_bytes();
+        }
+    }
+}
+
+/// Wipes what it borrows on drop, leaving the wiped buffers observable to the
+/// borrow's owner. Disarmed by forgetting it, which leaks nothing — it holds
+/// one borrow.
+pub(crate) struct ScrubOnDrop<'a, T: Scrub>(pub(crate) &'a mut T);
+
+impl<T: Scrub> Drop for ScrubOnDrop<'_, T> {
+    fn drop(&mut self) {
+        self.0.scrub();
+    }
+}
+
+/// The owning sibling, for a decode that holds a live `&Map` into the tree —
+/// which a `&mut` guard cannot coexist with. Read it via [`Self::value`].
+pub(crate) struct ScrubOwned(pub(crate) Value);
+
+impl ScrubOwned {
+    pub(crate) fn value(&self) -> &Value {
+        &self.0
+    }
+}
+
+impl Drop for ScrubOwned {
+    fn drop(&mut self) {
+        self.0.zeroize_bytes();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The guard standing between a mid-item reject and a heap holding every
+    /// secret the pass had already lifted out of its input.
+    #[test]
+    fn a_borrowed_guard_wipes_what_it_guards() {
+        let mut items = vec![Value::Bytes(vec![0xAB; 32]), Value::Unsigned(7)];
+        drop(ScrubOnDrop(&mut items));
+        assert_eq!(items[0], Value::Bytes(Vec::new()));
+        assert_eq!(items[1], Value::Unsigned(7), "shape and scalars kept");
+
+        let mut entries = vec![("contentKey".to_string(), Value::Bytes(vec![0xAB; 32]))];
+        drop(ScrubOnDrop(&mut entries));
+        assert_eq!(entries[0].1, Value::Bytes(Vec::new()));
+        assert_eq!(entries[0].0, "contentKey", "keys are not secret");
+
+        let mut value = Value::Array(vec![Value::Text("secret-file.txt".into())]);
+        drop(ScrubOnDrop(&mut value));
+        assert_eq!(
+            value.as_array().unwrap()[0],
+            Value::Text(String::new()),
+            "the whole-tree guard wipes nested buffers too"
+        );
+    }
+
+    #[test]
+    fn an_owning_guard_wipes_the_tree_it_took() {
+        let mut m = Map::new();
+        m.insert("contentKey", Value::Bytes(vec![0xAB; 32]));
+        let guard = ScrubOwned(Value::Map(m));
+        assert_eq!(
+            guard.value().as_map().unwrap().get("contentKey"),
+            Some(&Value::Bytes(vec![0xAB; 32])),
+            "readable while the guard stands"
+        );
+    }
+}

--- a/crates/core/src/codec/scrub.rs
+++ b/crates/core/src/codec/scrub.rs
@@ -55,23 +55,24 @@ impl<T: Scrub> Drop for ScrubOnDrop<'_, T> {
 
 /// The owning sibling, for a decode that holds a live `&Map` into the tree —
 /// which a `&mut` guard cannot coexist with. Read it via [`Self::value`].
-pub(crate) struct ScrubOwned(pub(crate) Value);
+pub(crate) struct ScrubOwned<T: Scrub>(pub(crate) T);
 
-impl ScrubOwned {
-    pub(crate) fn value(&self) -> &Value {
+impl<T: Scrub> ScrubOwned<T> {
+    pub(crate) fn value(&self) -> &T {
         &self.0
     }
 }
 
-impl Drop for ScrubOwned {
+impl<T: Scrub> Drop for ScrubOwned<T> {
     fn drop(&mut self) {
-        self.0.zeroize_bytes();
+        self.0.scrub();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::cell::Cell;
 
     /// The guard standing between a mid-item reject and a heap holding every
     /// secret the pass had already lifted out of its input.
@@ -97,7 +98,7 @@ mod tests {
     }
 
     #[test]
-    fn an_owning_guard_wipes_the_tree_it_took() {
+    fn an_owning_guard_lends_out_the_tree_it_took() {
         let mut m = Map::new();
         m.insert("contentKey", Value::Bytes(vec![0xAB; 32]));
         let guard = ScrubOwned(Value::Map(m));
@@ -106,5 +107,24 @@ mod tests {
             Some(&Value::Bytes(vec![0xAB; 32])),
             "readable while the guard stands"
         );
+    }
+
+    /// A stand-in for the guarded tree. The owning guard drops what it wipes,
+    /// so the wipe is only observable from the scrubbed value's own side.
+    struct SpyTree<'a>(&'a Cell<bool>);
+
+    impl Scrub for SpyTree<'_> {
+        fn scrub(&mut self) {
+            self.0.set(true);
+        }
+    }
+
+    #[test]
+    fn an_owning_guard_wipes_the_tree_it_took() {
+        let scrubbed = Cell::new(false);
+        let guard = ScrubOwned(SpyTree(&scrubbed));
+        assert!(!scrubbed.get(), "not before the guard falls");
+        drop(guard);
+        assert!(scrubbed.get(), "the tree the guard owns is wiped on drop");
     }
 }

--- a/crates/core/src/codec/value.rs
+++ b/crates/core/src/codec/value.rs
@@ -10,7 +10,7 @@ use core::fmt;
 
 use zeroize::Zeroize;
 
-use crate::error::Malformed;
+use crate::error::{CodecError, Malformed};
 
 /// A value in the deterministic profile's data model.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -236,10 +236,11 @@ impl Map {
     /// never secret). The wipe for a caller holding decoded known fields — see
     /// [`Value::zeroize_bytes`].
     ///
-    /// Terminal: the map is marked wiped and every encoder then refuses it
-    /// ([`Map::is_wiped`]). Without that mark a wiped map still encodes —
-    /// fixed-length fields fail their schema decode afterwards, but
-    /// variable-length ones round-trip empty, which is silent data loss.
+    /// Terminal: the map is marked wiped and every encoder then refuses it.
+    /// Without that mark a wiped map still encodes — fixed-length fields fail
+    /// their schema decode afterwards, but variable-length ones round-trip
+    /// empty, which is silent data loss. The mark rides the map, not its
+    /// values, so a value lifted back out through [`Map::remove`] carries none.
     pub fn zeroize_bytes(&mut self) {
         for (_, v) in &mut self.entries {
             v.zeroize_bytes();
@@ -247,10 +248,12 @@ impl Map {
         self.wiped = true;
     }
 
-    /// Whether [`Map::zeroize_bytes`] has emptied this map's fields. The
-    /// encoders read it to refuse a map whose values are gone.
-    pub fn is_wiped(&self) -> bool {
-        self.wiped
+    /// The encoders' read of that mark, release-active on both passes.
+    pub(crate) fn reject_if_wiped(&self) -> Result<(), CodecError> {
+        if self.wiped {
+            return Err(Malformed::WipedMap.into());
+        }
+        Ok(())
     }
 }
 

--- a/crates/core/src/codec/value.rs
+++ b/crates/core/src/codec/value.rs
@@ -170,6 +170,7 @@ pub fn canonical_key_cmp(a: &str, b: &str) -> Ordering {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Map {
     entries: Vec<(String, Value)>,
+    wiped: bool,
 }
 
 impl Map {
@@ -235,13 +236,21 @@ impl Map {
     /// never secret). The wipe for a caller holding decoded known fields — see
     /// [`Value::zeroize_bytes`].
     ///
-    /// Terminal: a wiped map still encodes. Fixed-length fields then fail
-    /// their schema decode, but variable-length ones round-trip empty, so
-    /// nothing may re-encode from it afterwards.
+    /// Terminal: the map is marked wiped and every encoder then refuses it
+    /// ([`Map::is_wiped`]). Without that mark a wiped map still encodes —
+    /// fixed-length fields fail their schema decode afterwards, but
+    /// variable-length ones round-trip empty, which is silent data loss.
     pub fn zeroize_bytes(&mut self) {
         for (_, v) in &mut self.entries {
             v.zeroize_bytes();
         }
+        self.wiped = true;
+    }
+
+    /// Whether [`Map::zeroize_bytes`] has emptied this map's fields. The
+    /// encoders read it to refuse a map whose values are gone.
+    pub fn is_wiped(&self) -> bool {
+        self.wiped
     }
 }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -269,9 +269,7 @@ pub enum Malformed {
     /// unknown field of the same key (caller bug; rejected fail-closed).
     UnknownFieldCollision { key: String },
     /// An encode of a map [`crate::codec::Map::zeroize_bytes`] already wiped
-    /// (caller bug; rejected fail-closed). The wipe is terminal: its fields are
-    /// zero-length, and the variable-length ones re-decode as empty rather than
-    /// failing, so emitting from one is silent data loss.
+    /// (caller bug; rejected fail-closed).
     WipedMap,
     /// A schema decode required a field that the map did not carry. *Malformed*,
     /// not trust: an absent field is structurally incomplete input, carrying no

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -268,6 +268,11 @@ pub enum Malformed {
     /// A rewrite supplied a known field that collides with a preserved
     /// unknown field of the same key (caller bug; rejected fail-closed).
     UnknownFieldCollision { key: String },
+    /// An encode of a map [`crate::codec::Map::zeroize_bytes`] already wiped
+    /// (caller bug; rejected fail-closed). The wipe is terminal: its fields are
+    /// zero-length, and the variable-length ones re-decode as empty rather than
+    /// failing, so emitting from one is silent data loss.
+    WipedMap,
     /// A schema decode required a field that the map did not carry. *Malformed*,
     /// not trust: an absent field is structurally incomplete input, carrying no
     /// evidence a canonical form was tampered — the same class as a truncation.
@@ -362,6 +367,7 @@ impl Malformed {
         "depth-exceeded",
         "unexpected-type",
         "unknown-field-collision",
+        "wiped-map",
         "missing-field",
         "invalid-identity-key",
         "invalid-enc-subkey",
@@ -391,6 +397,7 @@ impl Malformed {
             Self::DepthExceeded { .. } => "depth-exceeded",
             Self::UnexpectedType { .. } => "unexpected-type",
             Self::UnknownFieldCollision { .. } => "unknown-field-collision",
+            Self::WipedMap => "wiped-map",
             Self::MissingField { .. } => "missing-field",
             Self::InvalidIdentityKey => "invalid-identity-key",
             Self::InvalidEncSubkey => "invalid-enc-subkey",
@@ -435,7 +442,8 @@ impl fmt::Display for Malformed {
             } => write!(f, " (field {field}: expected {expected}, found {found})"),
             Self::UnknownRecordField { key } => write!(f, " (key {:?})", DisplayKey(key)),
             Self::UnsupportedRecordVersion { version } => write!(f, " (version {version})"),
-            Self::InvalidIdentityKey
+            Self::WipedMap
+            | Self::InvalidIdentityKey
             | Self::InvalidEncSubkey
             | Self::InvalidBindingSigEncoding
             | Self::InvalidNodeKind

--- a/crates/core/src/seal/body.rs
+++ b/crates/core/src/seal/body.rs
@@ -23,8 +23,9 @@ use core::cmp::Ordering;
 use core::fmt;
 use std::collections::BTreeSet;
 
-use crate::codec::{Map, Value, decode, encode};
-use crate::error::{CodecError, DisplayKey, Malformed, TrustViolation};
+use crate::codec::scrub::{ScrubOnDrop, ScrubOwned};
+use crate::codec::{Map, Value, decode, encode, fmt_redacted_keys};
+use crate::error::{CodecError, Malformed, TrustViolation};
 use crate::suite::secret::{SECRET_LEN, SecretBytes};
 
 // ---------------------------------------------------------------------------
@@ -321,15 +322,10 @@ pub fn decode_read_body(bytes: &[u8]) -> Result<ReadBody, CodecError> {
 /// caller is the terminal owner and must zeroize it (the seal path,
 /// [`seal_read_body`](super::seal_read_body), does).
 ///
-/// Encoding does *not* re-check uniqueness — persisting callers go through
-/// [`seal_read_body`](super::seal_read_body) (or [`ReadBody::validate`]), which
-/// refuses to seal a body that would not reopen; the `debug_assert` only catches
-/// that divergence early in tests.
+/// Uniqueness is re-checked release-active (AGENTS.md rule 8): these bytes are
+/// what a peer decodes, and [`decode_read_body`] hard-rejects a duplicate child.
 pub fn encode_read_body(body: &ReadBody) -> Result<Vec<u8>, CodecError> {
-    debug_assert!(
-        body.validate().is_ok(),
-        "encoding a read-body that violates child uniqueness; its bytes would reject on decode"
-    );
+    body.validate()?;
     let mut m = Map::new();
     match body {
         ReadBody::Folder {
@@ -371,38 +367,6 @@ pub fn encode_read_body(body: &ReadBody) -> Result<Vec<u8>, CodecError> {
     let mut value = Value::Map(m);
     let guard = ScrubOnDrop(&mut value);
     encode(guard.0)
-}
-
-/// Scrubs a codec-owned transient `Value` tree on drop, so the secret copies it
-/// carries (inline content keys, scope seeds) are wiped on both normal return
-/// and panic-unwind (blueprint/core.md terminal-owner rule). It borrows rather
-/// than owns the tree, leaving the wiped buffers observable to a caller/test
-/// after the guard falls.
-pub(crate) struct ScrubOnDrop<'a>(pub(crate) &'a mut Value);
-
-impl Drop for ScrubOnDrop<'_> {
-    fn drop(&mut self) {
-        self.0.zeroize_bytes();
-    }
-}
-
-/// The owning sibling of [`ScrubOnDrop`], for the decode side: it takes the
-/// decoded tree by value and scrubs it on drop, covering Ok, Err, and unwind.
-/// Owning rather than borrowing because decode holds a live `&Map` into the
-/// tree, which a `&mut` guard cannot coexist with; read it via [`Self::value`].
-pub(crate) struct ScrubOwned(pub(crate) Value);
-
-impl ScrubOwned {
-    /// Borrow the guarded tree for reading.
-    pub(crate) fn value(&self) -> &Value {
-        &self.0
-    }
-}
-
-impl Drop for ScrubOwned {
-    fn drop(&mut self) {
-        self.0.zeroize_bytes();
-    }
 }
 
 /// Fail-closed uniqueness over a set of grant blinded tags (#39 D7): a
@@ -467,21 +431,14 @@ pub(super) fn bytes_fixed<const N: usize>(
     })
 }
 
-/// Fields a schema decode did not recognize, kept as the canonical values the
-/// decoder built. The seal layer's counterpart to [`crate::codec::UnknownFields`],
-/// which preserves raw bytes for the partial codec.
-///
-/// Every value is a verbatim copy of what the field carried — cloned out of the
-/// decoded tree, so it outlives that tree's scrub guard. This set is the copies'
-/// terminal owner and wipes them on drop; keys are field names, never secret,
-/// and are kept out of every rendering all the same.
+/// The seal layer's counterpart to [`crate::codec::UnknownFields`], holding the
+/// values a decode built rather than the partial codec's raw bytes. Same
+/// terminal-owner wipe and redacted rendering; the clones it holds outlive the
+/// decoded tree's scrub guard, so the wipe has to be its own.
 #[derive(Clone, Default, PartialEq, Eq)]
-pub struct PreservedFields {
-    entries: Vec<(String, Value)>,
-}
+pub struct PreservedFields(Map);
 
 impl PreservedFields {
-    /// An empty set — the construction path, which preserves nothing.
     pub fn new() -> Self {
         Self::default()
     }
@@ -489,54 +446,42 @@ impl PreservedFields {
     /// The preserved entries in canonical key order. Borrowed as plain values:
     /// the wipe belongs to this set, so a borrow cannot carry it.
     pub fn entries(&self) -> &[(String, Value)] {
-        &self.entries
+        self.0.entries()
     }
 
-    /// Add a field a caller wants carried through the next encode — the
-    /// construction path for a key this build's schema does not type, such as
-    /// the envelope's `grantSection`. The encode side re-imposes canonical
-    /// order, so insertion order does not reach the wire.
-    pub fn push(&mut self, key: String, value: Value) {
-        self.entries.push((key, value));
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.0.get(key)
     }
 
     pub fn len(&self) -> usize {
-        self.entries.len()
+        self.0.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
+        self.0.is_empty()
     }
 
-    /// The wipe [`Drop`] runs.
-    fn wipe(&mut self) {
-        for (_, v) in &mut self.entries {
-            v.zeroize_bytes();
-        }
+    /// Carry a field this build's schema does not type through the next encode.
+    pub(crate) fn insert(&mut self, key: String, value: Value) {
+        self.0.insert(key, value);
     }
 }
 
 impl FromIterator<(String, Value)> for PreservedFields {
     fn from_iter<I: IntoIterator<Item = (String, Value)>>(iter: I) -> Self {
-        Self {
-            entries: iter.into_iter().collect(),
-        }
+        Self(iter.into_iter().collect())
     }
 }
 
 impl fmt::Debug for PreservedFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut m = f.debug_map();
-        for (key, _) in &self.entries {
-            m.key(&DisplayKey(key)).value(&"<redacted>");
-        }
-        m.finish()
+        fmt_redacted_keys(f, self.0.entries().iter().map(|(k, _)| k.as_str()))
     }
 }
 
 impl Drop for PreservedFields {
     fn drop(&mut self) {
-        self.wipe();
+        self.0.zeroize_bytes();
     }
 }
 
@@ -589,8 +534,8 @@ mod tests {
     }
 
     /// Encode a folder read-body directly through the codec, bypassing
-    /// `encode_read_body`'s uniqueness debug-assert — the way a hostile or buggy
-    /// peer's bytes arrive, so decode-side uniqueness rejection can be tested.
+    /// `encode_read_body`'s uniqueness check — the way a hostile or buggy peer's
+    /// bytes arrive, so decode-side uniqueness rejection can be tested.
     fn raw_folder_bytes(children: &[ChildRef]) -> Vec<u8> {
         let mut m = Map::new();
         m.insert("kind", Value::Text("folder".into()));
@@ -682,7 +627,7 @@ mod tests {
             "the clone outlives the decoded tree carrying the secret verbatim"
         );
 
-        unknown.wipe();
+        unknown.0.zeroize_bytes();
         assert_eq!(unknown.entries()[0].1, Value::Bytes(Vec::new()));
         assert_eq!(unknown.entries()[0].0, "futureKey", "keys are not secret");
     }
@@ -691,17 +636,15 @@ mod tests {
     /// cannot flood one.
     #[test]
     fn preserved_fields_debug_redacts_its_values() {
-        let preserved: PreservedFields = [
-            ("futureKey".to_string(), Value::Bytes(vec![0xAB; 32])),
-            ("z".repeat(200), Value::Unsigned(1)),
-        ]
-        .into_iter()
-        .collect();
+        let preserved: PreservedFields = [("futureKey".to_string(), Value::Bytes(vec![0xAB; 32]))]
+            .into_iter()
+            .collect();
 
-        let rendered = format!("{preserved:?}");
-        assert!(rendered.starts_with(r#"{"futureKey": "<redacted>", "zzz"#));
-        assert!(rendered.ends_with(r#"…: "<redacted>"}"#), "{rendered}");
-        assert!(rendered.len() < 160, "a crafted key flooded it: {rendered}");
+        assert_eq!(
+            format!("{preserved:?}"),
+            r#"{"futureKey": "<redacted>"}"#,
+            "a preserved value must never reach a log line"
+        );
     }
 
     #[test]
@@ -805,6 +748,14 @@ mod tests {
             NodeKind::Folder,
             "typed kind wins over unknown"
         );
+    }
+
+    /// AGENTS.md rule 8, release-active: the encoder refuses a body its own
+    /// decoder would reject, rather than producing an unopenable folder.
+    #[test]
+    fn encode_rejects_a_body_decode_would_refuse() {
+        let dup = folder(vec![child(1, "a", b"ipns-a"), child(1, "b", b"ipns-b")]);
+        assert_eq!(encode_read_body(&dup).unwrap_err().check(), "duplicate-id");
     }
 
     #[test]

--- a/crates/core/src/seal/body.rs
+++ b/crates/core/src/seal/body.rs
@@ -24,7 +24,7 @@ use core::fmt;
 use std::collections::BTreeSet;
 
 use crate::codec::{Map, Value, decode, encode};
-use crate::error::{CodecError, Malformed, TrustViolation};
+use crate::error::{CodecError, DisplayKey, Malformed, TrustViolation};
 use crate::suite::secret::{SECRET_LEN, SecretBytes};
 
 // ---------------------------------------------------------------------------
@@ -79,7 +79,7 @@ pub struct ChildRef {
     pub link_counter: u64,
     /// Preserved unknown fields (never any of the known keys); re-emitted
     /// canonically on rewrite.
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const CHILD_KNOWN: &[&str] = &["id", "ipnsName", "kind", "linkCounter", "name"];
@@ -134,7 +134,7 @@ pub struct Version {
     /// The injected modification time.
     pub modified_at: u64,
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const VERSION_KNOWN: &[&str] = &["contentCid", "contentKey", "modifiedAt", "size"];
@@ -152,7 +152,7 @@ impl Version {
             content_key: SecretBytes::new(content_key),
             size,
             modified_at,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -229,13 +229,13 @@ pub enum ReadBody {
         created_at: u64,
         modified_at: u64,
         children: Vec<ChildRef>,
-        unknown: Vec<(String, Value)>,
+        unknown: PreservedFields,
     },
     File {
         created_at: u64,
         modified_at: u64,
         versions: Vec<Version>,
-        unknown: Vec<(String, Value)>,
+        unknown: PreservedFields,
     },
 }
 
@@ -467,10 +467,83 @@ pub(super) fn bytes_fixed<const N: usize>(
     })
 }
 
+/// Fields a schema decode did not recognize, kept as the canonical values the
+/// decoder built. The seal layer's counterpart to [`crate::codec::UnknownFields`],
+/// which preserves raw bytes for the partial codec.
+///
+/// Every value is a verbatim copy of what the field carried — cloned out of the
+/// decoded tree, so it outlives that tree's scrub guard. This set is the copies'
+/// terminal owner and wipes them on drop; keys are field names, never secret,
+/// and are kept out of every rendering all the same.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct PreservedFields {
+    entries: Vec<(String, Value)>,
+}
+
+impl PreservedFields {
+    /// An empty set — the construction path, which preserves nothing.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The preserved entries in canonical key order. Borrowed as plain values:
+    /// the wipe belongs to this set, so a borrow cannot carry it.
+    pub fn entries(&self) -> &[(String, Value)] {
+        &self.entries
+    }
+
+    /// Add a field a caller wants carried through the next encode — the
+    /// construction path for a key this build's schema does not type, such as
+    /// the envelope's `grantSection`. The encode side re-imposes canonical
+    /// order, so insertion order does not reach the wire.
+    pub fn push(&mut self, key: String, value: Value) {
+        self.entries.push((key, value));
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The wipe [`Drop`] runs.
+    fn wipe(&mut self) {
+        for (_, v) in &mut self.entries {
+            v.zeroize_bytes();
+        }
+    }
+}
+
+impl FromIterator<(String, Value)> for PreservedFields {
+    fn from_iter<I: IntoIterator<Item = (String, Value)>>(iter: I) -> Self {
+        Self {
+            entries: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl fmt::Debug for PreservedFields {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut m = f.debug_map();
+        for (key, _) in &self.entries {
+            m.key(&DisplayKey(key)).value(&"<redacted>");
+        }
+        m.finish()
+    }
+}
+
+impl Drop for PreservedFields {
+    fn drop(&mut self) {
+        self.wipe();
+    }
+}
+
 /// The map entries whose key is not in `known`, cloned as canonical values.
 /// Because the source map decoded strict det-CBOR, each value is already
 /// canonical, so re-encoding it verbatim keeps the whole rewrite byte-stable.
-pub(super) fn collect_unknown(map: &Map, known: &[&str]) -> Vec<(String, Value)> {
+pub(super) fn collect_unknown(map: &Map, known: &[&str]) -> PreservedFields {
     map.entries()
         .iter()
         .filter(|(k, _)| !known.contains(&k.as_str()))
@@ -483,8 +556,8 @@ pub(super) fn collect_unknown(map: &Map, known: &[&str]) -> Vec<(String, Value)>
 /// skip-on-collision guard is for the *construction* path: a caller-built
 /// `unknown` list carrying a schema key can never overwrite the typed value and
 /// forge bytes that disagree with it. `Map::insert` re-imposes canonical order.
-pub(super) fn merge_unknown(map: &mut Map, unknown: &[(String, Value)]) {
-    for (k, v) in unknown {
+pub(super) fn merge_unknown(map: &mut Map, unknown: &PreservedFields) {
+    for (k, v) in unknown.entries() {
         if !map.contains_key(k) {
             map.insert(k.clone(), v.clone());
         }
@@ -502,7 +575,7 @@ mod tests {
             ipns_name: ipns.to_vec(),
             kind: NodeKind::File,
             link_counter: 0,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -511,7 +584,7 @@ mod tests {
             created_at: 100,
             modified_at: 200,
             children,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -556,7 +629,7 @@ mod tests {
                 Version::new(b"cid-new".to_vec(), [9; 32], 4096, 2),
                 Version::new(b"cid-old".to_vec(), [8; 32], 1024, 1),
             ],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let bytes = encode_read_body(&body).unwrap();
         let decoded = decode_read_body(&bytes).expect("decodes");
@@ -586,6 +659,51 @@ mod tests {
         );
     }
 
+    /// A preserved field is a clone the decoded tree's scrub guard cannot reach,
+    /// so this set is its terminal owner — and the same wipe runs from `Drop`.
+    #[test]
+    fn preserved_fields_own_the_wipe_of_what_a_decode_cloned_out() {
+        const SECRET: [u8; 32] = [0xAB; 32];
+        let mut m = Map::new();
+        m.insert("kind", Value::Text("folder".into()));
+        m.insert("children", Value::Array(vec![]));
+        m.insert("createdAt", Value::Unsigned(1));
+        m.insert("modifiedAt", Value::Unsigned(2));
+        m.insert("futureKey", Value::Bytes(SECRET.to_vec()));
+        let bytes = encode(&Value::Map(m)).unwrap();
+
+        let ReadBody::Folder { mut unknown, .. } = decode_read_body(&bytes).expect("decodes")
+        else {
+            panic!("expected folder");
+        };
+        assert_eq!(
+            unknown.entries()[0].1,
+            Value::Bytes(SECRET.to_vec()),
+            "the clone outlives the decoded tree carrying the secret verbatim"
+        );
+
+        unknown.wipe();
+        assert_eq!(unknown.entries()[0].1, Value::Bytes(Vec::new()));
+        assert_eq!(unknown.entries()[0].0, "futureKey", "keys are not secret");
+    }
+
+    /// A preserved value never reaches a log line, and a crafted field name
+    /// cannot flood one.
+    #[test]
+    fn preserved_fields_debug_redacts_its_values() {
+        let preserved: PreservedFields = [
+            ("futureKey".to_string(), Value::Bytes(vec![0xAB; 32])),
+            ("z".repeat(200), Value::Unsigned(1)),
+        ]
+        .into_iter()
+        .collect();
+
+        let rendered = format!("{preserved:?}");
+        assert!(rendered.starts_with(r#"{"futureKey": "<redacted>", "zzz"#));
+        assert!(rendered.ends_with(r#"…: "<redacted>"}"#), "{rendered}");
+        assert!(rendered.len() < 160, "a crafted key flooded it: {rendered}");
+    }
+
     #[test]
     fn unknown_read_body_field_preserved_byte_stable() {
         // A folder body with a future top-level field the current schema does
@@ -605,7 +723,7 @@ mod tests {
         );
         if let ReadBody::Folder { unknown, .. } = &decoded {
             assert_eq!(unknown.len(), 1);
-            assert_eq!(unknown[0].0, "futureField");
+            assert_eq!(unknown.entries()[0].0, "futureField");
         } else {
             panic!("expected folder");
         }
@@ -676,7 +794,9 @@ mod tests {
             created_at: 1,
             modified_at: 2,
             children: Vec::new(),
-            unknown: vec![("kind".to_string(), Value::Text("file".into()))],
+            unknown: [("kind".to_string(), Value::Text("file".into()))]
+                .into_iter()
+                .collect(),
         };
         let bytes = encode_read_body(&body).unwrap();
         let decoded = decode_read_body(&bytes).expect("decodes");
@@ -696,7 +816,7 @@ mod tests {
             created_at: 1,
             modified_at: 2,
             versions: vec![Version::new(b"c".to_vec(), [0; 32], 1, 1)],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         assert!(file.validate().is_ok());
     }

--- a/crates/core/src/seal/content_key.rs
+++ b/crates/core/src/seal/content_key.rs
@@ -20,11 +20,12 @@
 
 use zeroize::Zeroizing;
 
+use crate::codec::scrub::{ScrubOnDrop, ScrubOwned};
 use crate::codec::{Map, Value, decode, encode, encode_fixed_depth};
 use crate::content::is_wellformed_content_cid;
 use crate::error::{CodecError, Malformed, TrustViolation};
 use crate::seal::aad::{AAD_DOMAIN, STRUCT_TAG_CONTENT_KEY};
-use crate::seal::body::{ScrubOnDrop, ScrubOwned, bytes_fixed, req};
+use crate::seal::body::{bytes_fixed, req};
 use crate::suite::hpke::{self, ENC_LEN};
 use crate::suite::secret::SECRET_LEN;
 use crate::suite::x25519::X25519Secret;

--- a/crates/core/src/seal/envelope.rs
+++ b/crates/core/src/seal/envelope.rs
@@ -79,22 +79,24 @@ pub fn decode_envelope(bytes: &[u8]) -> Result<Envelope, CodecError> {
 /// bytes for [`super::decode_grant_section`], so the engine never matches raw
 /// `Value`s; `None` when the field is absent or not a byte string.
 pub fn grant_section_bytes(env: &Envelope) -> Option<&[u8]> {
-    env.unknown
-        .entries()
-        .iter()
-        .find(|(key, _)| key == "grantSection")
-        .and_then(|(_, value)| value.as_bytes().ok())
+    env.unknown.get(GRANT_SECTION_KEY)?.as_bytes().ok()
 }
 
 /// Whether the envelope carries a `grantSection` key at all, regardless of its
 /// value — the scope-root marker (a child envelope must carry none). Stricter
 /// than [`grant_section_bytes`], which also requires a byte-string value.
 pub fn has_grant_section(env: &Envelope) -> bool {
-    env.unknown
-        .entries()
-        .iter()
-        .any(|(key, _)| key == "grantSection")
+    env.unknown.get(GRANT_SECTION_KEY).is_some()
 }
+
+/// Attach the scope-root marker, the writer half of [`grant_section_bytes`].
+/// The key and its byte-string shape live here rather than at each caller.
+pub fn set_grant_section(env: &mut Envelope, section: Vec<u8>) {
+    env.unknown
+        .insert(GRANT_SECTION_KEY.to_string(), Value::Bytes(section));
+}
+
+const GRANT_SECTION_KEY: &str = "grantSection";
 
 /// Encode an envelope to its canonical det-CBOR plaintext.
 pub fn encode_envelope(env: &Envelope) -> Result<Vec<u8>, CodecError> {
@@ -277,10 +279,7 @@ mod tests {
         let mut env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &folder()).unwrap();
         assert_eq!(grant_section_bytes(&env), None, "absent without the field");
 
-        env.unknown.push(
-            "grantSection".to_string(),
-            Value::Bytes(b"section-bytes".to_vec()),
-        );
+        set_grant_section(&mut env, b"section-bytes".to_vec());
         assert_eq!(
             grant_section_bytes(&env),
             Some(b"section-bytes".as_slice()),
@@ -294,7 +293,7 @@ mod tests {
         let nonce = [4u8; NONCE_LEN];
         let mut env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &folder()).unwrap();
         env.unknown
-            .push("grantSection".to_string(), Value::Unsigned(7));
+            .insert("grantSection".to_string(), Value::Unsigned(7));
         assert_eq!(
             grant_section_bytes(&env),
             None,
@@ -312,13 +311,12 @@ mod tests {
         // A non-bytes value still marks the key present (stricter than
         // grant_section_bytes, which requires a byte string).
         env.unknown
-            .push("grantSection".to_string(), Value::Unsigned(7));
+            .insert("grantSection".to_string(), Value::Unsigned(7));
         assert!(has_grant_section(&env));
         assert_eq!(grant_section_bytes(&env), None);
 
         let mut env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &folder()).unwrap();
-        env.unknown
-            .push("grantSection".to_string(), Value::Bytes(b"s".to_vec()));
+        set_grant_section(&mut env, b"s".to_vec());
         assert!(has_grant_section(&env));
     }
 

--- a/crates/core/src/seal/envelope.rs
+++ b/crates/core/src/seal/envelope.rs
@@ -20,7 +20,8 @@ use crate::suite::aead::{KEY_LEN, NONCE_LEN};
 
 use super::aad::{AadContext, STRUCT_TAG_READ_BODY};
 use super::body::{
-    ReadBody, bytes_fixed, collect_unknown, decode_read_body, encode_read_body, merge_unknown, req,
+    PreservedFields, ReadBody, bytes_fixed, collect_unknown, decode_read_body, encode_read_body,
+    merge_unknown, req,
 };
 
 /// A node's kind-uniform envelope. `scope`/`epoch` are the flattened `epochTag`
@@ -40,9 +41,9 @@ pub struct Envelope {
     pub read_sealed: Vec<u8>,
     /// Preserved unknown top-level fields (`writeSealed`, `grantSection`, and
     /// any future additive field), re-emitted canonically on rewrite.
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
     /// Preserved unknown fields inside `epochTag`.
-    pub epoch_tag_unknown: Vec<(String, Value)>,
+    pub epoch_tag_unknown: PreservedFields,
 }
 
 const ENVELOPE_KNOWN: &[&str] = &["epochTag", "id", "readSealed", "v"];
@@ -79,6 +80,7 @@ pub fn decode_envelope(bytes: &[u8]) -> Result<Envelope, CodecError> {
 /// `Value`s; `None` when the field is absent or not a byte string.
 pub fn grant_section_bytes(env: &Envelope) -> Option<&[u8]> {
     env.unknown
+        .entries()
         .iter()
         .find(|(key, _)| key == "grantSection")
         .and_then(|(_, value)| value.as_bytes().ok())
@@ -88,7 +90,10 @@ pub fn grant_section_bytes(env: &Envelope) -> Option<&[u8]> {
 /// value — the scope-root marker (a child envelope must carry none). Stricter
 /// than [`grant_section_bytes`], which also requires a byte-string value.
 pub fn has_grant_section(env: &Envelope) -> bool {
-    env.unknown.iter().any(|(key, _)| key == "grantSection")
+    env.unknown
+        .entries()
+        .iter()
+        .any(|(key, _)| key == "grantSection")
 }
 
 /// Encode an envelope to its canonical det-CBOR plaintext.
@@ -142,8 +147,8 @@ pub fn seal_read_body(
         scope,
         epoch,
         read_sealed,
-        unknown: Vec::new(),
-        epoch_tag_unknown: Vec::new(),
+        unknown: PreservedFields::new(),
+        epoch_tag_unknown: PreservedFields::new(),
     })
 }
 
@@ -181,9 +186,9 @@ mod tests {
                 ipns_name: b"child-name".to_vec(),
                 kind: NodeKind::File,
                 link_counter: 1,
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             }],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -255,7 +260,7 @@ mod tests {
 
         let decoded = decode_envelope(&bytes).expect("tolerant decode");
         assert_eq!(decoded.unknown.len(), 1);
-        assert_eq!(decoded.unknown[0].0, "writeSealed");
+        assert_eq!(decoded.unknown.entries()[0].0, "writeSealed");
         assert_eq!(
             encode_envelope(&decoded).unwrap(),
             bytes,
@@ -272,10 +277,10 @@ mod tests {
         let mut env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &folder()).unwrap();
         assert_eq!(grant_section_bytes(&env), None, "absent without the field");
 
-        env.unknown.push((
+        env.unknown.push(
             "grantSection".to_string(),
             Value::Bytes(b"section-bytes".to_vec()),
-        ));
+        );
         assert_eq!(
             grant_section_bytes(&env),
             Some(b"section-bytes".as_slice()),
@@ -289,7 +294,7 @@ mod tests {
         let nonce = [4u8; NONCE_LEN];
         let mut env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &folder()).unwrap();
         env.unknown
-            .push(("grantSection".to_string(), Value::Unsigned(7)));
+            .push("grantSection".to_string(), Value::Unsigned(7));
         assert_eq!(
             grant_section_bytes(&env),
             None,
@@ -307,13 +312,13 @@ mod tests {
         // A non-bytes value still marks the key present (stricter than
         // grant_section_bytes, which requires a byte string).
         env.unknown
-            .push(("grantSection".to_string(), Value::Unsigned(7)));
+            .push("grantSection".to_string(), Value::Unsigned(7));
         assert!(has_grant_section(&env));
         assert_eq!(grant_section_bytes(&env), None);
 
         let mut env = seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &folder()).unwrap();
         env.unknown
-            .push(("grantSection".to_string(), Value::Bytes(b"s".to_vec())));
+            .push("grantSection".to_string(), Value::Bytes(b"s".to_vec()));
         assert!(has_grant_section(&env));
     }
 
@@ -351,7 +356,7 @@ mod tests {
                     ipns_name: b"x".to_vec(),
                     kind: NodeKind::File,
                     link_counter: 0,
-                    unknown: Vec::new(),
+                    unknown: PreservedFields::new(),
                 },
                 ChildRef {
                     id: [9; 16],
@@ -359,10 +364,10 @@ mod tests {
                     ipns_name: b"y".to_vec(),
                     kind: NodeKind::File,
                     link_counter: 0,
-                    unknown: Vec::new(),
+                    unknown: PreservedFields::new(),
                 },
             ],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         assert_eq!(
             seal_read_body(&key, &nonce, 2, [1; 16], [2; 16], 5, &dup)

--- a/crates/core/src/seal/grant.rs
+++ b/crates/core/src/seal/grant.rs
@@ -38,10 +38,11 @@ use crate::suite::hpke::{self, ENC_LEN, HpkeCiphertext};
 use crate::suite::secret::{SECRET_LEN, SecretBytes};
 use crate::suite::x25519::{X25519Public, X25519Secret};
 
+use crate::codec::scrub::{ScrubOnDrop, ScrubOwned};
+
 use super::aad::{AadContext, build_aad};
 use super::body::{
-    PreservedFields, ScrubOnDrop, ScrubOwned, assert_grant_tags_unique, bytes_fixed,
-    collect_unknown, merge_unknown, req,
+    PreservedFields, assert_grant_tags_unique, bytes_fixed, collect_unknown, merge_unknown, req,
 };
 
 /// The HPKE `info` for every grant-section seal. The structured AAD already

--- a/crates/core/src/seal/grant.rs
+++ b/crates/core/src/seal/grant.rs
@@ -40,8 +40,8 @@ use crate::suite::x25519::{X25519Public, X25519Secret};
 
 use super::aad::{AadContext, build_aad};
 use super::body::{
-    ScrubOnDrop, ScrubOwned, assert_grant_tags_unique, bytes_fixed, collect_unknown, merge_unknown,
-    req,
+    PreservedFields, ScrubOnDrop, ScrubOwned, assert_grant_tags_unique, bytes_fixed,
+    collect_unknown, merge_unknown, req,
 };
 
 /// The HPKE `info` for every grant-section seal. The structured AAD already
@@ -102,7 +102,7 @@ pub struct GrantBlobPayload {
     pub epoch: u64,
     pointer_read_key: SecretBytes,
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const GRANT_BLOB_KNOWN: &[&str] = &["epoch", "pointerReadKey", "readScopeSeed", "writeScopeSeed"];
@@ -120,7 +120,7 @@ impl GrantBlobPayload {
             write_scope_seed: write_scope_seed.map(SecretBytes::new),
             epoch,
             pointer_read_key: SecretBytes::new(pointer_read_key),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -275,7 +275,7 @@ pub struct OverrideSeedPayload {
     /// The epoch this override seed belongs to.
     pub epoch: u64,
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const OVERRIDE_SEED_KNOWN: &[&str] = &["epoch", "overrideSeed"];
@@ -286,7 +286,7 @@ impl OverrideSeedPayload {
         Self {
             override_seed: SecretBytes::new(override_seed),
             epoch,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -408,7 +408,7 @@ pub struct OwnerWriteBlobPayload {
     /// The write epoch this write-scope seed belongs to.
     pub write_epoch: u64,
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const OWNER_WRITE_BLOB_KNOWN: &[&str] = &["writeEpoch", "writeScopeSeed"];
@@ -419,7 +419,7 @@ impl OwnerWriteBlobPayload {
         Self {
             write_scope_seed: SecretBytes::new(write_scope_seed),
             write_epoch,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -545,7 +545,7 @@ pub struct AscentLink {
     /// The HPKE ciphertext (`ciphertext || tag`) of the override-seed payload.
     pub ciphertext: Vec<u8>,
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const ASCENT_LINK_KNOWN: &[&str] = &["ascentPublic", "ciphertext", "enc"];
@@ -600,7 +600,7 @@ pub fn seal_ascent_link(
         ascent_public: ascent_public.to_bytes(),
         enc: sealed.enc,
         ciphertext: sealed.ciphertext,
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     })
 }
 
@@ -644,7 +644,7 @@ pub struct HistoryLinkPayload {
     /// The previous epoch this seed belongs to.
     pub prev_epoch: u64,
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const HISTORY_LINK_KNOWN: &[&str] = &["prevEpoch", "prevSeed"];
@@ -655,7 +655,7 @@ impl HistoryLinkPayload {
         Self {
             prev_seed: SecretBytes::new(prev_seed),
             prev_epoch,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -767,7 +767,7 @@ pub struct GrantSetEntry {
     /// The writer pseudonym public key (Ed25519).
     pub pseudonym_pk: [u8; 32],
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const GRANT_SET_ENTRY_KNOWN: &[&str] = &["permission", "pseudonymPk", "tag"];
@@ -779,7 +779,7 @@ impl GrantSetEntry {
             tag,
             permission,
             pseudonym_pk,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -823,7 +823,7 @@ pub struct GrantSetCommitment {
     /// The committed grants.
     pub entries: Vec<GrantSetEntry>,
     /// Preserved unknown top-level fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const GRANT_SET_KNOWN: &[&str] = &["entries", "ipnsName", "ownerPseudonymPk"];
@@ -1095,7 +1095,7 @@ mod tests {
                 GrantSetEntry::new([0x01; 32], Permission::Read, [0x02; 32]),
                 GrantSetEntry::new([0x03; 32], Permission::Write, [0x04; 32]),
             ],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let bytes = encode_grant_set_commitment(&c).expect("encodes");
         assert_eq!(decode_grant_set_commitment(&bytes).unwrap(), c);
@@ -1154,7 +1154,7 @@ mod tests {
                 GrantSetEntry::new([0x01; 32], Permission::Read, [0x02; 32]),
                 GrantSetEntry::new([0x01; 32], Permission::Write, [0x04; 32]),
             ],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         assert_eq!(
             encode_grant_set_commitment(&c).unwrap_err().check(),

--- a/crates/core/src/seal/mod.rs
+++ b/crates/core/src/seal/mod.rs
@@ -29,7 +29,8 @@ pub use aad::{
     StructTagSpec, build_aad,
 };
 pub use body::{
-    ChildRef, NodeKind, ReadBody, Version, decode_read_body, encode_read_body, name_cmp,
+    ChildRef, NodeKind, PreservedFields, ReadBody, Version, decode_read_body, encode_read_body,
+    name_cmp,
 };
 pub use content_key::{
     CONTENT_KEY_HPKE_INFO, CONTENT_KEY_V, content_key_aad, open_content_key, seal_content_key,

--- a/crates/core/src/seal/mod.rs
+++ b/crates/core/src/seal/mod.rs
@@ -37,7 +37,7 @@ pub use content_key::{
 };
 pub use envelope::{
     Envelope, decode_envelope, encode_envelope, grant_section_bytes, has_grant_section,
-    open_read_body, seal_read_body,
+    open_read_body, seal_read_body, set_grant_section,
 };
 pub use grant::{
     AscentLink, GrantBlobPayload, GrantSetCommitment, GrantSetEntry, HistoryLinkPayload,

--- a/crates/core/src/seal/section.rs
+++ b/crates/core/src/seal/section.rs
@@ -30,7 +30,9 @@ use crate::suite::ed25519::SIGNATURE_LEN as ED_SIG_LEN;
 use crate::suite::hpke::ENC_LEN;
 use crate::suite::secret::SECRET_LEN;
 
-use super::body::{assert_grant_tags_unique, bytes_fixed, collect_unknown, merge_unknown, req};
+use super::body::{
+    PreservedFields, assert_grant_tags_unique, bytes_fixed, collect_unknown, merge_unknown, req,
+};
 use super::grant::{GrantSetCommitment, decode_grant_set_commitment, encode_grant_set_commitment};
 
 /// A grant blob as published in the grant section: its recipient blinded `tag`
@@ -48,7 +50,7 @@ pub struct SignedGrantBlob {
     /// The 64-byte Ed25519 structure signature over `H(ciphertext)`.
     pub signature: [u8; ED_SIG_LEN],
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const GRANT_BLOB_KNOWN: &[&str] = &["ciphertext", "enc", "sig", "tag"];
@@ -87,7 +89,7 @@ pub struct SignedOwnerBlob {
     /// The 64-byte Ed25519 structure signature over `H(ciphertext)`.
     pub signature: [u8; ED_SIG_LEN],
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const OWNER_BLOB_KNOWN: &[&str] = &["ciphertext", "enc", "sig"];
@@ -127,7 +129,7 @@ pub struct SignedOwnerWriteBlob {
     /// The 64-byte Ed25519 structure signature over `H(ciphertext)`.
     pub signature: [u8; ED_SIG_LEN],
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const OWNER_WRITE_BLOB_KNOWN: &[&str] = &["ciphertext", "enc", "sig"];
@@ -166,7 +168,7 @@ pub struct SignedAscentLink {
     /// The 64-byte Ed25519 structure signature over `H(ciphertext)`.
     pub signature: [u8; ED_SIG_LEN],
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const ASCENT_LINK_KNOWN: &[&str] = &["ascentPublic", "ciphertext", "enc", "sig"];
@@ -204,7 +206,7 @@ pub struct SignedSealed {
     /// The 64-byte Ed25519 structure signature over `H(sealed)`.
     pub signature: [u8; ED_SIG_LEN],
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const SEALED_KNOWN: &[&str] = &["sealed", "sig"];
@@ -255,7 +257,7 @@ pub struct GrantSection {
     /// The scope root's sealed write-body.
     pub write_body: SignedSealed,
     /// Preserved unknown top-level fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const GRANT_SECTION_KNOWN: &[&str] = &[
@@ -374,7 +376,7 @@ mod tests {
             ipns_name: b"scope-root-name".to_vec(),
             owner_pseudonym_pk: [0x88; 32],
             entries,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -384,7 +386,7 @@ mod tests {
             enc: [0x0a; ENC_LEN],
             ciphertext: vec![0x0b, 0x0c],
             signature: [0x0d; ED_SIG_LEN],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -400,32 +402,32 @@ mod tests {
                 enc: [0x20; ENC_LEN],
                 ciphertext: vec![0x21, 0x22],
                 signature: [0x23; ED_SIG_LEN],
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             },
             owner_write_blob: Some(SignedOwnerWriteBlob {
                 enc: [0x24; ENC_LEN],
                 ciphertext: vec![0x25, 0x26],
                 signature: [0x27; ED_SIG_LEN],
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             }),
             ascent_link: Some(SignedAscentLink {
                 ascent_public: [0x30; ENC_LEN],
                 enc: [0x31; ENC_LEN],
                 ciphertext: vec![0x32, 0x33],
                 signature: [0x34; ED_SIG_LEN],
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             }),
             history_links: vec![SignedSealed {
                 sealed: vec![0x40, 0x41],
                 signature: [0x42; ED_SIG_LEN],
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             }],
             write_body: SignedSealed {
                 sealed: vec![0x50, 0x51],
                 signature: [0x52; ED_SIG_LEN],
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             },
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -453,7 +455,7 @@ mod tests {
                 enc: [0x20; ENC_LEN],
                 ciphertext: vec![0x21],
                 signature: [0x23; ED_SIG_LEN],
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             },
             owner_write_blob: None,
             ascent_link: None,
@@ -461,9 +463,9 @@ mod tests {
             write_body: SignedSealed {
                 sealed: vec![0x50],
                 signature: [0x52; ED_SIG_LEN],
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             },
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let bytes = encode_grant_section(&section).expect("encodes");
         assert_eq!(decode_grant_section(&bytes).unwrap(), section);

--- a/crates/core/src/seal/write_body.rs
+++ b/crates/core/src/seal/write_body.rs
@@ -21,7 +21,9 @@ use crate::error::CodecError;
 use crate::suite::ecdsa::IDENTITY_PUBLIC_LEN;
 use crate::suite::secret::SECRET_LEN;
 
-use super::body::{assert_grant_tags_unique, bytes_fixed, collect_unknown, merge_unknown, req};
+use super::body::{
+    PreservedFields, assert_grant_tags_unique, bytes_fixed, collect_unknown, merge_unknown, req,
+};
 use super::grant::Permission;
 
 // ---------------------------------------------------------------------------
@@ -42,7 +44,7 @@ pub struct GrantLedgerEntry {
     /// The recipient's blinded tag (the grant blob's key).
     pub tag: [u8; SECRET_LEN],
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const LEDGER_ENTRY_KNOWN: &[&str] = &["permission", "recipientEncPk", "recipientIdentityPk", "tag"];
@@ -60,7 +62,7 @@ impl GrantLedgerEntry {
             recipient_enc_pk,
             permission,
             tag,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -115,7 +117,7 @@ pub struct ChildScopeRef {
     /// The child scope root's opaque `ipnsName` bytes.
     pub ipns_name: Vec<u8>,
     /// Preserved unknown fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const CHILD_SCOPE_KNOWN: &[&str] = &["ipnsName", "scopeId"];
@@ -126,7 +128,7 @@ impl ChildScopeRef {
         Self {
             scope_id,
             ipns_name,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -164,7 +166,7 @@ pub struct WriteBody {
     /// The directly-descendant scope roots (the F-4 cascade index).
     pub direct_child_scope_index: Vec<ChildScopeRef>,
     /// Preserved unknown top-level fields (never any of the known keys).
-    pub unknown: Vec<(String, Value)>,
+    pub unknown: PreservedFields,
 }
 
 const WRITE_BODY_KNOWN: &[&str] = &["directChildScopeIndex", "grantLedger", "writeHistoryLink"];
@@ -247,7 +249,7 @@ mod tests {
                 [0x55; 16],
                 b"child-scope-name".to_vec(),
             )],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -266,7 +268,7 @@ mod tests {
             grant_ledger: Vec::new(),
             write_history_link: Vec::new(),
             direct_child_scope_index: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let bytes = encode_write_body(&body).expect("encodes");
         assert_eq!(decode_write_body(&bytes).unwrap(), body);
@@ -380,7 +382,7 @@ mod tests {
             ],
             write_history_link: Vec::new(),
             direct_child_scope_index: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         assert_eq!(
             encode_write_body(&body).unwrap_err().check(),

--- a/crates/core/tests/codec_props.rs
+++ b/crates/core/tests/codec_props.rs
@@ -91,6 +91,24 @@ fn build_map_and_flags(entries: &FlaggedEntries) -> (Map, HashMap<String, bool>)
     (map, flags)
 }
 
+/// The wipe is terminal across the crate boundary too (#936): once a caller has
+/// scrubbed the fields it decoded, the public encoder refuses to emit from them
+/// rather than publishing a record whose values silently came back empty.
+#[test]
+fn the_public_encoder_refuses_a_wiped_map() {
+    let mut m = Map::new();
+    m.insert("contentKey", Value::Bytes(vec![0xAB; 32]));
+    m.insert("name", Value::Text("secret-file.txt".into()));
+    assert!(
+        encode(&Value::Map(m.clone())).is_ok(),
+        "encodes before the wipe"
+    );
+
+    m.zeroize_bytes();
+
+    assert_eq!(encode(&Value::Map(m)).unwrap_err().check(), "wiped-map");
+}
+
 /// The wipe seam from outside `crates/core` (#902): a caller holding the known
 /// fields `decode_map_partial` split out is their terminal owner and can scrub
 /// them, in the buffer that held the secret rather than a fresh one.

--- a/crates/core/tests/kat_manifest.rs
+++ b/crates/core/tests/kat_manifest.rs
@@ -1476,11 +1476,12 @@ fn reject_checks_list_matches_vectors_and_error_surface() {
     }
 }
 
-/// The whole error surface is vector-pinned save the one check `decode` and the
-/// suite decoders can never emit: `unknown-field-collision` (an
-/// `encode_map_partial` caller bug), which stays unit-test-pinned in
-/// src/codec/fields.rs. This is the crate-wide extension of the reject-coverage
-/// law across the codec, contact, hpke, seal, ipns, and payload families.
+/// The whole error surface is vector-pinned save the two checks `decode` and
+/// the suite decoders can never emit — both encoder caller bugs, unit-test
+/// pinned instead: `unknown-field-collision` (src/codec/fields.rs) and
+/// `wiped-map` (src/codec/encode.rs). This is the crate-wide extension of the
+/// reject-coverage law across the codec, contact, hpke, seal, ipns, and payload
+/// families.
 #[test]
 fn every_crate_check_is_pinned_by_a_vector_family() {
     let m = manifest();
@@ -1545,11 +1546,14 @@ fn every_crate_check_is_pinned_by_a_vector_family() {
         .map(|s| s.to_string())
         .collect();
     let uncovered: Vec<&String> = surface.difference(&covered).collect();
-    let expected_uncovered = "unknown-field-collision".to_string();
+    let expected_uncovered = [
+        "unknown-field-collision".to_string(),
+        "wiped-map".to_string(),
+    ];
     assert_eq!(
         uncovered,
-        vec![&expected_uncovered],
-        "every crate check but the one unit-pinned collision check must have a reject vector"
+        expected_uncovered.iter().collect::<Vec<_>>(),
+        "every crate check but the unit-pinned encoder caller-bug checks must have a reject vector"
     );
     assert!(
         covered.is_subset(&surface),

--- a/crates/core/tests/seal_props.rs
+++ b/crates/core/tests/seal_props.rs
@@ -21,9 +21,9 @@ use std::collections::BTreeSet;
 
 use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, open_chunk, seal_chunk, verify_cid};
 use cipherbox_core::seal::{
-    AadContext, ChildRef, NodeKind, ReadBody, STRUCT_TAG_READ_BODY, Version, decode_envelope,
-    decode_read_body, encode_envelope, encode_read_body, name_cmp, open_read_body, seal,
-    seal_read_body, unseal,
+    AadContext, ChildRef, NodeKind, PreservedFields, ReadBody, STRUCT_TAG_READ_BODY, Version,
+    decode_envelope, decode_read_body, encode_envelope, encode_read_body, name_cmp, open_read_body,
+    seal, seal_read_body, unseal,
 };
 use proptest::prelude::*;
 
@@ -65,7 +65,7 @@ fn arb_child() -> impl Strategy<Value = ChildRef> {
             ipns_name,
             kind,
             link_counter,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         })
 }
 
@@ -104,7 +104,7 @@ fn arb_read_body() -> impl Strategy<Value = ReadBody> {
             created_at,
             modified_at,
             children: dedup_children(children),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         });
     let file = (
         any::<u64>(),
@@ -115,7 +115,7 @@ fn arb_read_body() -> impl Strategy<Value = ReadBody> {
             created_at,
             modified_at,
             versions,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         });
     prop_oneof![folder, file]
 }

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -4125,14 +4125,13 @@ mod tests {
 
         use core::task::{Context, Poll, Waker};
 
-        use cipherbox_core::codec::Value;
         use cipherbox_core::content::{compute_cid, encode_content_cid_str};
         use cipherbox_core::ipns::{IpnsName, IpnsRecord};
         use cipherbox_core::kdf;
         use cipherbox_core::payload::RepointObject;
         use cipherbox_core::seal::{
             ChildRef, NodeKind as CoreNodeKind, PreservedFields, ReadBody, encode_envelope,
-            seal_read_body,
+            seal_read_body, set_grant_section,
         };
         use cipherbox_core::suite::ecdsa::EcdsaSigner;
 
@@ -4623,9 +4622,7 @@ mod tests {
                     seal_read_body(&read_key, &[13u8; 24], 1, envelope_id, scope, epoch, body)
                         .unwrap();
                 if with_grant_section {
-                    envelope
-                        .unknown
-                        .push("grantSection".to_string(), Value::Bytes(vec![1, 2, 3]));
+                    set_grant_section(&mut envelope, vec![1, 2, 3]);
                 }
                 let head_block = encode_envelope(&envelope).unwrap();
                 let cid = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head_block));

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -3363,7 +3363,7 @@ mod tests {
     mod snapshot_read {
         use super::*;
 
-        use cipherbox_core::seal::{ChildRef, NodeKind as CoreNodeKind, ReadBody};
+        use cipherbox_core::seal::{ChildRef, NodeKind as CoreNodeKind, PreservedFields, ReadBody};
 
         use crate::gate::Adopted;
         use crate::net::{ResolveOutcome, refresh_base_from_outcome};
@@ -3376,7 +3376,7 @@ mod tests {
                     created_at: 0,
                     modified_at: 456,
                     children,
-                    unknown: Vec::new(),
+                    unknown: PreservedFields::new(),
                 },
                 sequence: 2,
                 epoch: 1,
@@ -3390,7 +3390,7 @@ mod tests {
                 ipns_name: vec![id],
                 kind,
                 link_counter: 1,
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             }
         }
 
@@ -3621,7 +3621,7 @@ mod tests {
         use cipherbox_core::ipns::{IpnsName, IpnsRecord};
         use cipherbox_core::kdf;
         use cipherbox_core::payload::RepointObject;
-        use cipherbox_core::seal::ReadBody;
+        use cipherbox_core::seal::{PreservedFields, ReadBody};
         use cipherbox_core::suite::ecdsa::EcdsaSigner;
         use cipherbox_core::suite::ed25519::Ed25519Signer;
 
@@ -3703,7 +3703,7 @@ mod tests {
                             created_at: 0,
                             modified_at: 0,
                             children: Vec::new(),
-                            unknown: Vec::new(),
+                            unknown: PreservedFields::new(),
                         },
                         sequence: 1,
                         epoch: 1,
@@ -3815,7 +3815,7 @@ mod tests {
         /// A gate-passing `Adopted` folder carrying one child — the projected
         /// material a newer live resolve folds into the shared base cell.
         fn adopted_with_child(child_id: [u8; 16], name: &str) -> Adopted {
-            use cipherbox_core::seal::{ChildRef, NodeKind as CoreNodeKind};
+            use cipherbox_core::seal::{ChildRef, NodeKind as CoreNodeKind, PreservedFields};
             Adopted {
                 read_body: ReadBody::Folder {
                     created_at: 0,
@@ -3826,9 +3826,9 @@ mod tests {
                         ipns_name: vec![1],
                         kind: CoreNodeKind::File,
                         link_counter: 1,
-                        unknown: Vec::new(),
+                        unknown: PreservedFields::new(),
                     }],
-                    unknown: Vec::new(),
+                    unknown: PreservedFields::new(),
                 },
                 sequence: 2,
                 epoch: 1,
@@ -4131,7 +4131,8 @@ mod tests {
         use cipherbox_core::kdf;
         use cipherbox_core::payload::RepointObject;
         use cipherbox_core::seal::{
-            ChildRef, NodeKind as CoreNodeKind, ReadBody, encode_envelope, seal_read_body,
+            ChildRef, NodeKind as CoreNodeKind, PreservedFields, ReadBody, encode_envelope,
+            seal_read_body,
         };
         use cipherbox_core::suite::ecdsa::EcdsaSigner;
 
@@ -4179,7 +4180,7 @@ mod tests {
                     ipns_name: child_name().as_str().as_bytes().to_vec(),
                     kind: CoreNodeKind::File,
                     link_counter: 1,
-                    unknown: Vec::new(),
+                    unknown: PreservedFields::new(),
                 }],
                 // At the read epoch (write plane == read plane here), so the
                 // cold-seeded write floor opens it and the owner recovers its
@@ -4601,7 +4602,7 @@ mod tests {
                     created_at: 0,
                     modified_at: CHILD_MTIME,
                     versions,
-                    unknown: Vec::new(),
+                    unknown: PreservedFields::new(),
                 }
             }
 
@@ -4624,7 +4625,7 @@ mod tests {
                 if with_grant_section {
                     envelope
                         .unknown
-                        .push(("grantSection".to_string(), Value::Bytes(vec![1, 2, 3])));
+                        .push("grantSection".to_string(), Value::Bytes(vec![1, 2, 3]));
                 }
                 let head_block = encode_envelope(&envelope).unwrap();
                 let cid = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head_block));
@@ -5130,7 +5131,7 @@ mod tests {
                     created_at: 0,
                     modified_at: 0,
                     children: Vec::new(),
-                    unknown: Vec::new(),
+                    unknown: PreservedFields::new(),
                 };
                 let (head_block, head_cid) =
                     sealed_child_head(CHILD_ID, SCOPE, EPOCH, &folder_body, false);

--- a/crates/engine/src/gate/adoption.rs
+++ b/crates/engine/src/gate/adoption.rs
@@ -22,10 +22,11 @@ use cipherbox_core::error::{CodecError, TrustViolation};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
-    AadContext, AscentLink, Envelope, GrantSection, GrantSetCommitment, Permission, ReadBody,
-    STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_GRANT_BLOB, STRUCT_TAG_HISTORY_LINK, STRUCT_TAG_OWNER_BLOB,
-    STRUCT_TAG_OWNER_WRITE_BLOB, STRUCT_TAG_WRITE_BODY, StructureSigInput, open_ascent_link,
-    open_grant_blob, open_owner_blob, open_read_body, verify_grant_set, verify_structure,
+    AadContext, AscentLink, Envelope, GrantSection, GrantSetCommitment, Permission,
+    PreservedFields, ReadBody, STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_GRANT_BLOB,
+    STRUCT_TAG_HISTORY_LINK, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB,
+    STRUCT_TAG_WRITE_BODY, StructureSigInput, open_ascent_link, open_grant_blob, open_owner_blob,
+    open_read_body, verify_grant_set, verify_structure,
 };
 use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaVerifier};
 use cipherbox_core::suite::ed25519::{Ed25519Signature, Ed25519Verifier};
@@ -524,7 +525,7 @@ pub async fn adopt_deferred<F: FloorStore>(
             ascent_public: ascent.ascent_public,
             enc: ascent.enc,
             ciphertext: ascent.ciphertext.clone(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         // Cross-check the recovered override seed: the ascent public key is
         // published, so anyone can seal a rogue payload to it. The seed the link

--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -28,8 +28,8 @@
 use cipherbox_core::error::CodecError;
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
-    ChildScopeRef, GrantLedgerEntry, GrantSetCommitment, GrantSetEntry, Permission, SignedSealed,
-    sign_grant_set,
+    ChildScopeRef, GrantLedgerEntry, GrantSetCommitment, GrantSetEntry, Permission,
+    PreservedFields, SignedSealed, sign_grant_set,
 };
 use cipherbox_core::suite::ecdsa::{
     EcdsaSigner, IDENTITY_PUBLIC_LEN, SIGNATURE_LEN as ECDSA_SIG_LEN,
@@ -322,7 +322,7 @@ where
             Permission::Read,
             recipient_pseudonym_pk,
         )],
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
     let commitment_sig = sign_grant_set(owner.identity_signer, &commitment)
         .map_err(CreateGrantError::CommitmentEncode)?
@@ -635,7 +635,7 @@ mod tests {
                 ipns_name: DESCENDANT_NAME.to_vec(),
                 owner_pseudonym_pk: pseudonym.verifying_key().to_bytes(),
                 entries: Vec::new(),
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             };
             let commitment_sig = sign_grant_set(&owner_identity(), &commitment)
                 .unwrap()
@@ -736,7 +736,7 @@ mod tests {
             ipns_name: PARENT_NAME.to_vec(),
             owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
             entries: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let parent_commitment_sig = sign_grant_set(&owner_identity, &parent_commitment)
             .unwrap()
@@ -844,7 +844,7 @@ mod tests {
             ipns_name: PARENT_NAME.to_vec(),
             owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
             entries: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let parent_commitment_sig = sign_grant_set(&owner_identity, &parent_commitment)
             .unwrap()
@@ -1185,7 +1185,7 @@ mod tests {
             ascent_public: ascent.ascent_public,
             enc: ascent.enc,
             ciphertext: ascent.ciphertext.clone(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let descend = open_ascent_link(&parent_node_seed, &ascent_ctx, &link)
             .expect("grantee derivation opens the descendant ascent link");

--- a/crates/engine/src/grants/ledger.rs
+++ b/crates/engine/src/grants/ledger.rs
@@ -124,7 +124,7 @@ pub fn enforce_committed_ledger(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cipherbox_core::seal::GrantSetEntry;
+    use cipherbox_core::seal::{GrantSetEntry, PreservedFields};
     use cipherbox_core::suite::ecdsa::IDENTITY_PUBLIC_LEN;
 
     fn commitment(entries: Vec<GrantSetEntry>) -> GrantSetCommitment {
@@ -132,7 +132,7 @@ mod tests {
             ipns_name: b"scope-root".to_vec(),
             owner_pseudonym_pk: [0x88; 32],
             entries,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 

--- a/crates/engine/src/net/author.rs
+++ b/crates/engine/src/net/author.rs
@@ -15,12 +15,11 @@
 //!   unrepresentable: [`new_child`] feeds one [`NodeKind`] and one typed
 //!   [`IpnsName`] to both the body and the parent's ref.
 
-use cipherbox_core::codec::Value;
 use cipherbox_core::error::CodecError;
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::seal::{
-    ChildRef, Envelope, NodeKind, ReadBody, Version, decode_grant_section, encode_envelope,
-    grant_section_bytes, has_grant_section, seal_read_body,
+    ChildRef, Envelope, NodeKind, PreservedFields, ReadBody, Version, decode_grant_section,
+    encode_envelope, grant_section_bytes, has_grant_section, seal_read_body,
 };
 
 use crate::content::limits::MAX_RESOLVED_RECORD_BYTES;
@@ -106,9 +105,9 @@ pub struct EnvelopeAuthoring<'a> {
     /// The body to seal.
     pub body: &'a ReadBody,
     /// Top-level envelope fields carried forward from the previous record.
-    pub carried_unknown: Vec<(String, Value)>,
+    pub carried_unknown: PreservedFields,
     /// `epochTag` fields carried forward from the previous record.
-    pub carried_epoch_tag_unknown: Vec<(String, Value)>,
+    pub carried_epoch_tag_unknown: PreservedFields,
 }
 
 /// Author a **child** record's envelope: a non-scope-root node, which must
@@ -225,13 +224,13 @@ pub fn new_child(
             created_at: authored_at,
             modified_at: authored_at,
             children: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         },
         NewNodeBody::File { versions } => ReadBody::File {
             created_at: authored_at,
             modified_at: authored_at,
             versions,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         },
     };
     NewChild {
@@ -241,7 +240,7 @@ pub fn new_child(
             ipns_name: ipns_name.as_str().as_bytes().to_vec(),
             kind,
             link_counter,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         },
         body,
     }
@@ -250,6 +249,7 @@ pub fn new_child(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cipherbox_core::codec::Value;
     use cipherbox_core::content::{compute_cid, encode_content_cid_str};
     use cipherbox_core::ipns::IpnsName;
     use cipherbox_core::kdf;
@@ -271,11 +271,11 @@ mod tests {
             created_at: 1,
             modified_at: 2,
             children: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
-    fn authoring(body: &ReadBody, carried: Vec<(String, Value)>) -> EnvelopeAuthoring<'_> {
+    fn authoring(body: &ReadBody, carried: PreservedFields) -> EnvelopeAuthoring<'_> {
         EnvelopeAuthoring {
             node_id: [1u8; 16],
             scope_id: [2u8; 16],
@@ -284,12 +284,14 @@ mod tests {
             nonce: &NONCE,
             body,
             carried_unknown: carried,
-            carried_epoch_tag_unknown: Vec::new(),
+            carried_epoch_tag_unknown: PreservedFields::new(),
         }
     }
 
-    fn grant_section_field() -> Vec<(String, Value)> {
-        vec![("grantSection".to_owned(), Value::Bytes(b"section".to_vec()))]
+    fn grant_section_field() -> PreservedFields {
+        [("grantSection".to_owned(), Value::Bytes(b"section".to_vec()))]
+            .into_iter()
+            .collect()
     }
 
     /// A real scope root's grant section and the name its commitment binds.
@@ -305,11 +307,13 @@ mod tests {
         })
     }
 
-    fn carried_section(fixture: &OwnerRootFixture) -> Vec<(String, Value)> {
-        vec![(
+    fn carried_section(fixture: &OwnerRootFixture) -> PreservedFields {
+        [(
             "grantSection".to_owned(),
             Value::Bytes(encode_grant_section(&fixture.grant_section).expect("encodes")),
         )]
+        .into_iter()
+        .collect()
     }
 
     #[test]
@@ -351,7 +355,8 @@ mod tests {
         // A root that lost its section is a root no reader can open: child
         // adoption refuses the missing marker and the gate has no commitment.
         assert_eq!(
-            author_scope_root_envelope(authoring(&folder(), Vec::new()), &name()).unwrap_err(),
+            author_scope_root_envelope(authoring(&folder(), PreservedFields::new()), &name())
+                .unwrap_err(),
             AuthorError::MissingGrantSection,
         );
     }
@@ -359,7 +364,7 @@ mod tests {
     #[test]
     fn an_authored_head_decodes_back_to_the_body_it_sealed() {
         let body = folder();
-        let head = author_child_envelope(authoring(&body, Vec::new())).unwrap();
+        let head = author_child_envelope(authoring(&body, PreservedFields::new())).unwrap();
         let decoded = decode_envelope(&head.block).unwrap();
         assert_eq!(decoded, head.envelope, "the block is the envelope");
         assert_eq!(open_read_body(&decoded, &READ_KEY).unwrap(), body);
@@ -386,18 +391,18 @@ mod tests {
                 ipns_name: i.to_be_bytes().to_vec(),
                 kind: NodeKind::File,
                 link_counter: 1,
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             })
             .collect();
         let body = ReadBody::Folder {
             created_at: 0,
             modified_at: 0,
             children,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         assert!(
             matches!(
-                author_child_envelope(authoring(&body, Vec::new())).unwrap_err(),
+                author_child_envelope(authoring(&body, PreservedFields::new())).unwrap_err(),
                 AuthorError::HeadTooLarge { limit, .. } if limit == MAX_RESOLVED_RECORD_BYTES
             ),
             "an over-cap head must fail closed on the produce side"
@@ -416,20 +421,21 @@ mod tests {
             ipns_name: ipns_name.to_vec(),
             kind: NodeKind::File,
             link_counter: 1,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let folder = |children| ReadBody::Folder {
             created_at: 0,
             modified_at: 0,
             children,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         for children in [
             vec![child(7, b"n"), child(7, b"other")],
             vec![child(7, b"n"), child(8, b"n")],
         ] {
             assert!(matches!(
-                author_child_envelope(authoring(&folder(children), Vec::new())).unwrap_err(),
+                author_child_envelope(authoring(&folder(children), PreservedFields::new()))
+                    .unwrap_err(),
                 AuthorError::Seal(_)
             ));
         }

--- a/crates/engine/src/net/record_publish.rs
+++ b/crates/engine/src/net/record_publish.rs
@@ -230,7 +230,7 @@ mod tests {
     use crate::net::author::{EnvelopeAuthoring, author_child_envelope};
     use crate::seams::{HttpResponse, RecordTransport};
     use crate::testkit::{FakeWorld, block_on};
-    use cipherbox_core::seal::ReadBody;
+    use cipherbox_core::seal::{PreservedFields, ReadBody};
 
     const READ_KEY: [u8; 32] = [8u8; 32];
     const NONCE: [u8; 24] = [6u8; 24];
@@ -248,7 +248,7 @@ mod tests {
             created_at: 0,
             modified_at: 0,
             children: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         author_child_envelope(EnvelopeAuthoring {
             node_id: binding.node_id,
@@ -257,8 +257,8 @@ mod tests {
             read_key: &READ_KEY,
             nonce: &NONCE,
             body: &body,
-            carried_unknown: Vec::new(),
-            carried_epoch_tag_unknown: Vec::new(),
+            carried_unknown: PreservedFields::new(),
+            carried_epoch_tag_unknown: PreservedFields::new(),
         })
         .unwrap()
     }

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -405,7 +405,7 @@ mod tests {
 
     use cipherbox_core::error::TrustViolation;
     use cipherbox_core::ipns::{IpnsName, IpnsRecord};
-    use cipherbox_core::seal::ReadBody;
+    use cipherbox_core::seal::{PreservedFields, ReadBody};
     use cipherbox_core::suite::ed25519::Ed25519Signer;
     use zeroize::Zeroizing;
 
@@ -482,7 +482,7 @@ mod tests {
                             created_at: 0,
                             modified_at: 0,
                             children: Vec::new(),
-                            unknown: Vec::new(),
+                            unknown: PreservedFields::new(),
                         },
                         sequence,
                         epoch: 1,
@@ -1024,7 +1024,7 @@ mod tests {
         use core::cell::RefCell;
 
         use cipherbox_core::error::TrustViolation;
-        use cipherbox_core::seal::{ChildRef, NodeKind, ReadBody};
+        use cipherbox_core::seal::{ChildRef, NodeKind, PreservedFields, ReadBody};
 
         use crate::facade::NodeId;
         use crate::gate::Adopted;
@@ -1043,9 +1043,9 @@ mod tests {
                         ipns_name: vec![1],
                         kind: NodeKind::File,
                         link_counter: 1,
-                        unknown: Vec::new(),
+                        unknown: PreservedFields::new(),
                     }],
-                    unknown: Vec::new(),
+                    unknown: PreservedFields::new(),
                 },
                 sequence: 2,
                 epoch: 1,

--- a/crates/engine/src/rotation/cascade.rs
+++ b/crates/engine/src/rotation/cascade.rs
@@ -589,7 +589,7 @@ mod tests {
     use crate::testkit::fakes::{InMemoryFloorStore, VirtualScheduler};
     use crate::testkit::{SeededEntropy, block_on};
     use cipherbox_core::seal::{
-        AadContext, AscentLink, GrantSetEntry, Permission, STRUCT_TAG_ASCENT_LINK,
+        AadContext, AscentLink, GrantSetEntry, Permission, PreservedFields, STRUCT_TAG_ASCENT_LINK,
         STRUCT_TAG_OWNER_BLOB, open_ascent_link, open_owner_blob, sign_grant_set,
     };
     use cipherbox_core::suite::ecdsa::EcdsaSigner;
@@ -652,7 +652,7 @@ mod tests {
                 ipns_name: format!("ipns-{byte:02x}").into_bytes(),
                 owner_pseudonym_pk: self.pseudonym.verifying_key().to_bytes(),
                 entries: vec![GrantSetEntry::new(tag, Permission::Read, [0x02; 32])],
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             };
             let commitment_sig = sign_grant_set(&self.ecdsa, &commitment)
                 .unwrap()
@@ -792,7 +792,7 @@ mod tests {
                 ascent_public: ascent.ascent_public,
                 enc: ascent.enc,
                 ciphertext: ascent.ciphertext.clone(),
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             };
             open_ascent_link(parent_node_seed, &ctx, &link)
                 .ok()

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -32,7 +32,7 @@ use zeroize::Zeroize;
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
     AadContext, GrantBlobPayload, GrantLedgerEntry, GrantSection, GrantSetCommitment,
-    HistoryLinkPayload, OverrideSeedPayload, OwnerWriteBlobPayload, Permission,
+    HistoryLinkPayload, OverrideSeedPayload, OwnerWriteBlobPayload, Permission, PreservedFields,
     STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_GRANT_BLOB, STRUCT_TAG_HISTORY_LINK, STRUCT_TAG_OWNER_BLOB,
     STRUCT_TAG_OWNER_WRITE_BLOB, STRUCT_TAG_WRITE_BODY, SignedAscentLink, SignedGrantBlob,
     SignedOwnerBlob, SignedOwnerWriteBlob, SignedSealed, StructureSigInput, WriteBody,
@@ -265,7 +265,7 @@ pub fn reseal_scope_root<E: Entropy>(
             enc: sealed.enc,
             ciphertext: sealed.ciphertext,
             signature,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         });
     }
     grant_blobs.sort_by(|a, b| a.tag.cmp(&b.tag));
@@ -283,7 +283,7 @@ pub fn reseal_scope_root<E: Entropy>(
             enc: sealed.enc,
             ciphertext: sealed.ciphertext,
             signature,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     };
 
@@ -314,7 +314,7 @@ pub fn reseal_scope_root<E: Entropy>(
             enc: sealed.enc,
             ciphertext: sealed.ciphertext,
             signature,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         })
     };
 
@@ -334,7 +334,7 @@ pub fn reseal_scope_root<E: Entropy>(
                 enc: link.enc,
                 ciphertext: link.ciphertext,
                 signature,
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             })
         }
         None => None,
@@ -353,7 +353,7 @@ pub fn reseal_scope_root<E: Entropy>(
         history_links.push(SignedSealed {
             sealed,
             signature,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         });
     }
 
@@ -363,7 +363,7 @@ pub fn reseal_scope_root<E: Entropy>(
             grant_ledger: committed.grant_ledger.to_vec(),
             write_history_link: committed.write_history_link.to_vec(),
             direct_child_scope_index: committed.direct_child_scope_index.to_vec(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let mut plaintext = encode_write_body(&wb).map_err(ResealError::Encode)?;
         let write_seed = kdf::write_seed(seeds.write_scope_seed, &scope_id);
@@ -381,7 +381,7 @@ pub fn reseal_scope_root<E: Entropy>(
         SignedSealed {
             sealed,
             signature,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     };
 
@@ -394,7 +394,7 @@ pub fn reseal_scope_root<E: Entropy>(
         ascent_link,
         history_links,
         write_body,
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     })
 }
 
@@ -474,7 +474,7 @@ mod tests {
                 ipns_name: b"scope-root-name".to_vec(),
                 owner_pseudonym_pk: self.pseudonym.verifying_key().to_bytes(),
                 entries,
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             };
             let sig = sign_grant_set(&self.owner_ecdsa, &commitment)
                 .unwrap()
@@ -675,7 +675,7 @@ mod tests {
             ascent_public: ascent.ascent_public,
             enc: ascent.enc,
             ciphertext: ascent.ciphertext.clone(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let ascent_payload =
             open_ascent_link(&fx.parent_node_seed, &ascent_ctx, &ascent_link).unwrap();
@@ -726,7 +726,7 @@ mod tests {
         let carried = vec![SignedSealed {
             sealed: b"prior-epoch-link".to_vec(),
             signature: [0x01; 64],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }];
         let mut e = SeededEntropy::new(3);
         let section = reseal_scope_root(&mut e, &id, &s, &cs, &carried).expect("reseal");
@@ -755,7 +755,7 @@ mod tests {
             ipns_name: b"n".to_vec(),
             owner_pseudonym_pk: fx.pseudonym.verifying_key().to_bytes(),
             entries,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let ledger = vec![
             GrantLedgerEntry::new(
@@ -910,7 +910,7 @@ mod tests {
                 Permission::Read,
                 [0x02; 32],
             )],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let sig = sign_grant_set(&fx.owner_ecdsa, &commitment)
             .unwrap()

--- a/crates/engine/src/rotation/rotate.rs
+++ b/crates/engine/src/rotation/rotate.rs
@@ -280,7 +280,8 @@ mod tests {
     use crate::testkit::fakes::{InMemoryFloorStore, VirtualScheduler};
     use crate::testkit::{SeededEntropy, block_on};
     use cipherbox_core::seal::{
-        GrantLedgerEntry, GrantSetCommitment, GrantSetEntry, Permission, sign_grant_set,
+        GrantLedgerEntry, GrantSetCommitment, GrantSetEntry, Permission, PreservedFields,
+        sign_grant_set,
     };
     use cipherbox_core::suite::ecdsa::EcdsaSigner;
     use cipherbox_core::suite::ed25519::Ed25519Signer;
@@ -359,7 +360,7 @@ mod tests {
                 ipns_name: b"scope-root".to_vec(),
                 owner_pseudonym_pk: self.pseudonym.verifying_key().to_bytes(),
                 entries: vec![GrantSetEntry::new([0xa1; 32], Permission::Read, [0x02; 32])],
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             };
             let sig = sign_grant_set(&self.owner_ecdsa, &commitment)
                 .unwrap()

--- a/crates/engine/src/rotation/rotate_write.rs
+++ b/crates/engine/src/rotation/rotate_write.rs
@@ -642,7 +642,7 @@ async fn collect_subtree<R: WriteSubtreeResolver>(
 mod tests {
     use super::*;
     use crate::testkit::{SeededEntropy, block_on};
-    use cipherbox_core::seal::sign_grant_set;
+    use cipherbox_core::seal::{PreservedFields, sign_grant_set};
     use std::cell::RefCell;
     use std::collections::{HashMap, HashSet};
     use std::rc::Rc;
@@ -669,7 +669,7 @@ mod tests {
             ipns_name: name.as_str().as_bytes().to_vec(),
             owner_pseudonym_pk: [0x22; 32],
             entries: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let sig = sign_grant_set(owner, &c).unwrap().to_compact();
         (c, sig)

--- a/crates/engine/src/rotation/sweep.rs
+++ b/crates/engine/src/rotation/sweep.rs
@@ -496,8 +496,8 @@ mod tests {
     use crate::testkit::fakes::{InMemoryFloorStore, VirtualScheduler};
     use crate::testkit::{SeededEntropy, block_on};
     use cipherbox_core::seal::{
-        AadContext, GrantSetCommitment, GrantSetEntry, Permission, STRUCT_TAG_OWNER_BLOB,
-        open_owner_blob, sign_grant_set,
+        AadContext, GrantSetCommitment, GrantSetEntry, Permission, PreservedFields,
+        STRUCT_TAG_OWNER_BLOB, open_owner_blob, sign_grant_set,
     };
     use cipherbox_core::suite::ecdsa::EcdsaSigner;
     use cipherbox_core::suite::x25519::X25519Secret;
@@ -598,7 +598,7 @@ mod tests {
                 ipns_name: format!("ipns-{byte:02x}").into_bytes(),
                 owner_pseudonym_pk: self.owner.pseudonym.verifying_key().to_bytes(),
                 entries: vec![GrantSetEntry::new(tag, Permission::Read, [0x02; 32])],
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             };
             let commitment_sig = sign_grant_set(&self.owner.ecdsa, &commitment)
                 .unwrap()

--- a/crates/engine/src/rotation/trigger.rs
+++ b/crates/engine/src/rotation/trigger.rs
@@ -162,7 +162,7 @@ pub fn revoke_read_grant(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cipherbox_core::seal::{GrantSetEntry, Permission, verify_grant_set};
+    use cipherbox_core::seal::{GrantSetEntry, Permission, PreservedFields, verify_grant_set};
     use cipherbox_core::suite::ecdsa::EcdsaSignature;
 
     fn owner() -> EcdsaSigner {
@@ -183,7 +183,7 @@ mod tests {
             ipns_name: b"n".to_vec(),
             owner_pseudonym_pk: [0x88; 32],
             entries,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let sig = sign_grant_set(&owner(), &c).unwrap().to_compact();
         let ledger = vec![

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -281,7 +281,7 @@ mod tests {
     use cipherbox_core::ipns::{IpnsName, IpnsRecord};
     use cipherbox_core::kdf;
     use cipherbox_core::payload::RepointObject;
-    use cipherbox_core::seal::ReadBody;
+    use cipherbox_core::seal::{PreservedFields, ReadBody};
     use cipherbox_core::suite::ecdsa::EcdsaSigner;
     use cipherbox_core::suite::ed25519::Ed25519Signer;
 
@@ -353,7 +353,7 @@ mod tests {
                         created_at: 0,
                         modified_at: 0,
                         children: Vec::new(),
-                        unknown: Vec::new(),
+                        unknown: PreservedFields::new(),
                     },
                     sequence: 1,
                     epoch: 1,

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -22,11 +22,12 @@
 use core::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 
-use cipherbox_core::codec::Value;
 use cipherbox_core::content::{encode_content_cid_str, verify_cid};
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
-use cipherbox_core::seal::{ChildRef, ReadBody, Version, open_content_key, open_read_body};
+use cipherbox_core::seal::{
+    ChildRef, PreservedFields, ReadBody, Version, open_content_key, open_read_body,
+};
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
 use cipherbox_core::suite::x25519::X25519Secret;
 use futures_channel::mpsc;
@@ -315,12 +316,12 @@ struct FolderState {
     /// The scope root carries the grant section and authors through a different
     /// envelope path; every other folder is a plain child record.
     is_scope_root: bool,
-    envelope_unknown: Vec<(String, Value)>,
-    epoch_tag_unknown: Vec<(String, Value)>,
+    envelope_unknown: PreservedFields,
+    epoch_tag_unknown: PreservedFields,
     created_at: u64,
     modified_at: u64,
     children: Vec<ChildRef>,
-    body_unknown: Vec<(String, Value)>,
+    body_unknown: PreservedFields,
     /// The record sequence this folder was last loaded or published at.
     sequence: u64,
 }
@@ -355,8 +356,8 @@ struct DestAdd {
 struct LoadedNode {
     name: IpnsName,
     sequence: u64,
-    envelope_unknown: Vec<(String, Value)>,
-    epoch_tag_unknown: Vec<(String, Value)>,
+    envelope_unknown: PreservedFields,
+    epoch_tag_unknown: PreservedFields,
     body: ReadBody,
 }
 
@@ -978,8 +979,8 @@ where
                 false,
                 &child.body,
                 content_cids,
-                Vec::new(),
-                Vec::new(),
+                PreservedFields::new(),
+                PreservedFields::new(),
             )
             .await?;
 
@@ -1618,8 +1619,8 @@ where
         is_scope_root: bool,
         body: &ReadBody,
         content_cids: Vec<String>,
-        carried_unknown: Vec<(String, Value)>,
-        carried_epoch_tag_unknown: Vec<(String, Value)>,
+        carried_unknown: PreservedFields,
+        carried_epoch_tag_unknown: PreservedFields,
     ) -> Result<Published, Halt> {
         let read_key = self.node_read_key(scope, &node.0);
         let nonce = self.nonce()?;

--- a/crates/engine/src/sync/project.rs
+++ b/crates/engine/src/sync/project.rs
@@ -232,7 +232,7 @@ mod tests {
                         created_at: 0,
                         modified_at: 0,
                         versions: Vec::new(),
-                        unknown: Vec::new(),
+                        unknown: PreservedFields::new(),
                     },
                     sequence: 9,
                     epoch: 0,

--- a/crates/engine/src/sync/project.rs
+++ b/crates/engine/src/sync/project.rs
@@ -123,7 +123,7 @@ fn map_kind(kind: CoreNodeKind) -> NodeKind {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cipherbox_core::seal::ChildRef;
+    use cipherbox_core::seal::{ChildRef, PreservedFields};
 
     fn node_id(b: u8) -> NodeId {
         NodeId([b; 16])
@@ -136,7 +136,7 @@ mod tests {
             ipns_name: vec![id],
             kind,
             link_counter,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -153,7 +153,7 @@ mod tests {
                 created_at: 0,
                 modified_at: 0,
                 children,
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             },
             sequence,
             epoch: 0,
@@ -370,7 +370,7 @@ mod tests {
                 created_at: 5,
                 modified_at: 777,
                 children: Vec::new(),
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             },
             sequence: 1,
             epoch: 0,

--- a/crates/engine/src/testkit/owner_root.rs
+++ b/crates/engine/src/testkit/owner_root.rs
@@ -5,7 +5,6 @@
 //! Sealing inputs (nonces, HPKE ephemerals, the pseudonym seed) are fixed
 //! constants, keeping the head block byte-for-byte reproducible across runs.
 
-use cipherbox_core::codec::Value;
 use cipherbox_core::content::{compute_cid, encode_content_cid_str};
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
@@ -15,7 +14,7 @@ use cipherbox_core::seal::{
     STRUCT_TAG_OWNER_WRITE_BLOB, STRUCT_TAG_WRITE_BODY, SignedOwnerBlob, SignedOwnerWriteBlob,
     SignedSealed, StructureSigInput, WriteBody, encode_envelope, encode_grant_section,
     encode_write_body, seal, seal_owner_blob, seal_owner_write_blob, seal_read_body,
-    sign_grant_set, sign_structure,
+    set_grant_section, sign_grant_set, sign_structure,
 };
 use cipherbox_core::suite::ecdsa::EcdsaSigner;
 use cipherbox_core::suite::ed25519::Ed25519Signer;
@@ -194,10 +193,7 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         &folder,
     )
     .unwrap();
-    envelope.unknown.push(
-        "grantSection".to_string(),
-        Value::Bytes(encode_grant_section(&grant_section).unwrap()),
-    );
+    set_grant_section(&mut envelope, encode_grant_section(&grant_section).unwrap());
 
     let head_block = encode_envelope(&envelope).unwrap();
     let head_cid_str = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head_block));

--- a/crates/engine/src/testkit/owner_root.rs
+++ b/crates/engine/src/testkit/owner_root.rs
@@ -11,10 +11,11 @@ use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
     AadContext, ChildRef, Envelope, GrantSection, GrantSetCommitment, OverrideSeedPayload,
-    OwnerWriteBlobPayload, ReadBody, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB,
-    STRUCT_TAG_WRITE_BODY, SignedOwnerBlob, SignedOwnerWriteBlob, SignedSealed, StructureSigInput,
-    WriteBody, encode_envelope, encode_grant_section, encode_write_body, seal, seal_owner_blob,
-    seal_owner_write_blob, seal_read_body, sign_grant_set, sign_structure,
+    OwnerWriteBlobPayload, PreservedFields, ReadBody, STRUCT_TAG_OWNER_BLOB,
+    STRUCT_TAG_OWNER_WRITE_BLOB, STRUCT_TAG_WRITE_BODY, SignedOwnerBlob, SignedOwnerWriteBlob,
+    SignedSealed, StructureSigInput, WriteBody, encode_envelope, encode_grant_section,
+    encode_write_body, seal, seal_owner_blob, seal_owner_write_blob, seal_read_body,
+    sign_grant_set, sign_structure,
 };
 use cipherbox_core::suite::ecdsa::EcdsaSigner;
 use cipherbox_core::suite::ed25519::Ed25519Signer;
@@ -118,7 +119,7 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         signature: sign(STRUCT_TAG_OWNER_BLOB, &sealed_owner.ciphertext),
         enc: sealed_owner.enc,
         ciphertext: sealed_owner.ciphertext,
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
 
     // Write body — a second seed-bearing structure the gate authenticates.
@@ -130,14 +131,14 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
             grant_ledger: Vec::new(),
             write_history_link: Vec::new(),
             direct_child_scope_index: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         })
         .unwrap(),
     );
     let write_body = SignedSealed {
         signature: sign(STRUCT_TAG_WRITE_BODY, &write_body_sealed),
         sealed: write_body_sealed,
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
 
     let owner_write_blob = owner_write_blob_epoch.map(|write_epoch| {
@@ -152,7 +153,7 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
             signature: sign(STRUCT_TAG_OWNER_WRITE_BLOB, &sealed.ciphertext),
             enc: sealed.enc,
             ciphertext: sealed.ciphertext,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     });
 
@@ -160,7 +161,7 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         ipns_name: name.as_str().as_bytes().to_vec(),
         owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
         entries: Vec::new(),
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
     let commitment_sig = sign_grant_set(owner_identity, &commitment)
         .unwrap()
@@ -174,14 +175,14 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         ascent_link: None,
         history_links: Vec::new(),
         write_body,
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
 
     let folder = ReadBody::Folder {
         created_at: 0,
         modified_at: 0,
         children,
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
     let mut envelope = seal_read_body(
         &read_key,
@@ -193,10 +194,10 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         &folder,
     )
     .unwrap();
-    envelope.unknown.push((
+    envelope.unknown.push(
         "grantSection".to_string(),
         Value::Bytes(encode_grant_section(&grant_section).unwrap()),
-    ));
+    );
 
     let head_block = encode_envelope(&envelope).unwrap();
     let head_cid_str = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &head_block));

--- a/crates/engine/tests/adoption_gate.rs
+++ b/crates/engine/tests/adoption_gate.rs
@@ -17,12 +17,12 @@ use cipherbox_core::kdf;
 use cipherbox_core::payload::{RepointObject, open_pointer_payload, seal_pointer_payload};
 use cipherbox_core::seal::{
     AadContext, Envelope, GrantBlobPayload, GrantSection, GrantSetCommitment, OverrideSeedPayload,
-    OwnerWriteBlobPayload, ReadBody, STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_GRANT_BLOB,
-    STRUCT_TAG_HISTORY_LINK, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB,
-    STRUCT_TAG_READ_BODY, STRUCT_TAG_WRITE_BODY, SignedAscentLink, SignedGrantBlob,
-    SignedOwnerBlob, SignedOwnerWriteBlob, SignedSealed, StructureSigInput, WriteBody,
-    encode_write_body, open_grant_blob, seal, seal_ascent_link, seal_grant_blob, seal_owner_blob,
-    seal_owner_write_blob, seal_read_body, sign_grant_set, sign_structure,
+    OwnerWriteBlobPayload, PreservedFields, ReadBody, STRUCT_TAG_ASCENT_LINK,
+    STRUCT_TAG_GRANT_BLOB, STRUCT_TAG_HISTORY_LINK, STRUCT_TAG_OWNER_BLOB,
+    STRUCT_TAG_OWNER_WRITE_BLOB, STRUCT_TAG_READ_BODY, STRUCT_TAG_WRITE_BODY, SignedAscentLink,
+    SignedGrantBlob, SignedOwnerBlob, SignedOwnerWriteBlob, SignedSealed, StructureSigInput,
+    WriteBody, encode_write_body, open_grant_blob, seal, seal_ascent_link, seal_grant_blob,
+    seal_owner_blob, seal_owner_write_blob, seal_read_body, sign_grant_set, sign_structure,
 };
 use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
 use cipherbox_core::suite::ed25519::Ed25519Signer;
@@ -131,7 +131,7 @@ impl Fixture {
             enc: owner_blob_enc,
             ciphertext: owner_blob_ct.clone(),
             signature: sign(STRUCT_TAG_OWNER_BLOB, None, &owner_blob_ct),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
 
         // Write-body (a second seed-bearing structure, to exercise the loop).
@@ -139,7 +139,7 @@ impl Fixture {
             grant_ledger: Vec::new(),
             write_history_link: Vec::new(),
             direct_child_scope_index: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let write_body_aad = AadContext {
             v: V,
@@ -157,7 +157,7 @@ impl Fixture {
         let signed_write_body = SignedSealed {
             signature: sign(STRUCT_TAG_WRITE_BODY, None, &write_body_sealed),
             sealed: write_body_sealed,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
 
         // Owner-write-blob (the write-plane mirror of the owner blob): its AAD
@@ -182,7 +182,7 @@ impl Fixture {
             signature: sign(STRUCT_TAG_OWNER_WRITE_BLOB, None, &owner_write.ciphertext),
             enc: owner_write.enc,
             ciphertext: owner_write.ciphertext,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
 
         // Grant-set commitment (grant-less scope: the owner pseudonym is the
@@ -191,7 +191,7 @@ impl Fixture {
             ipns_name: name.as_str().as_bytes().to_vec(),
             owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
             entries: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let commitment_sig = sign_grant_set(&owner_identity, &commitment)
             .expect("signs")
@@ -205,7 +205,7 @@ impl Fixture {
             ascent_link: None,
             history_links: Vec::new(),
             write_body: signed_write_body,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
 
         // Valid empty-folder read-body sealed into the envelope.
@@ -213,7 +213,7 @@ impl Fixture {
             created_at: 0,
             modified_at: 0,
             children: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let valid_envelope = seal_read_body(
             &read_key,
@@ -279,8 +279,8 @@ impl Fixture {
             scope: self.scope_id,
             epoch: self.epoch,
             read_sealed,
-            unknown: Vec::new(),
-            epoch_tag_unknown: Vec::new(),
+            unknown: PreservedFields::new(),
+            epoch_tag_unknown: PreservedFields::new(),
         }
     }
 
@@ -368,7 +368,7 @@ impl Fixture {
             enc: link.enc,
             ciphertext: link.ciphertext,
             signature: sign_structure(&self.owner_pseudonym, &input).to_bytes(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         }
     }
 
@@ -882,7 +882,7 @@ fn run_floor_scenario(rule: &str) {
                 enc: blob.enc,
                 ciphertext: blob.ciphertext.clone(),
                 signature: sign_structure(&fx.owner_pseudonym, &input).to_bytes(),
-                unknown: Vec::new(),
+                unknown: PreservedFields::new(),
             };
             let mut candidate = fx.candidate(1);
             candidate.grant_section.grant_blobs.push(signed_blob);
@@ -1107,7 +1107,7 @@ fn non_empty_history_link_authenticates_and_rejects_tamper_and_replay() {
     candidate.grant_section.history_links.push(SignedSealed {
         sealed: sealed.clone(),
         signature: sign_link(fx.epoch, &sealed),
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     });
     block_on(adopt(
         &InMemoryFloorStore::default(),
@@ -1123,7 +1123,7 @@ fn non_empty_history_link_authenticates_and_rejects_tamper_and_replay() {
     tampered.grant_section.history_links.push(SignedSealed {
         sealed: bad,
         signature: sign_link(fx.epoch, &sealed),
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     });
     let rej = block_on(adopt(
         &InMemoryFloorStore::default(),
@@ -1141,7 +1141,7 @@ fn non_empty_history_link_authenticates_and_rejects_tamper_and_replay() {
     replayed.grant_section.history_links.push(SignedSealed {
         sealed: sealed.clone(),
         signature: sign_link(fx.epoch + 1, &sealed),
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     });
     let rej = block_on(adopt(
         &InMemoryFloorStore::default(),
@@ -1284,7 +1284,7 @@ fn cross_epoch_structure_replay_rejected_at_grant_section() {
         created_at: 0,
         modified_at: 0,
         children: Vec::new(),
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
     let envelope_e2 = seal_read_body(
         &fx.read_key,
@@ -1425,7 +1425,7 @@ fn envelope_scope_must_equal_reader_scope() {
         created_at: 0,
         modified_at: 0,
         children: Vec::new(),
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
     let envelope_b = seal_read_body(
         &fx.read_key,

--- a/crates/engine/tests/grants_mailbox.rs
+++ b/crates/engine/tests/grants_mailbox.rs
@@ -13,10 +13,10 @@ use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
     AadContext, Envelope, GrantBlobPayload, GrantSection, GrantSetCommitment, GrantSetEntry,
-    OverrideSeedPayload, Permission, ReadBody, STRUCT_TAG_GRANT_BLOB, STRUCT_TAG_OWNER_BLOB,
-    STRUCT_TAG_WRITE_BODY, SignedGrantBlob, SignedOwnerBlob, SignedSealed, StructureSigInput,
-    WriteBody, encode_write_body, seal, seal_grant_blob, seal_owner_blob, seal_read_body,
-    sign_grant_set, sign_structure,
+    OverrideSeedPayload, Permission, PreservedFields, ReadBody, STRUCT_TAG_GRANT_BLOB,
+    STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_WRITE_BODY, SignedGrantBlob, SignedOwnerBlob, SignedSealed,
+    StructureSigInput, WriteBody, encode_write_body, seal, seal_grant_blob, seal_owner_blob,
+    seal_read_body, sign_grant_set, sign_structure,
 };
 use cipherbox_core::suite::contact::ContactCode;
 use cipherbox_core::suite::ecdsa::{
@@ -131,7 +131,7 @@ impl GrantFixture {
             enc: grant_blob.enc,
             ciphertext: grant_blob.ciphertext.clone(),
             signature: sign(STRUCT_TAG_GRANT_BLOB, Some(tag), &grant_blob.ciphertext),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
 
         // The owner blob (a mandatory scope-root structure): the override seed
@@ -154,7 +154,7 @@ impl GrantFixture {
             enc: owner_blob.enc,
             ciphertext: owner_blob.ciphertext.clone(),
             signature: sign(STRUCT_TAG_OWNER_BLOB, None, &owner_blob.ciphertext),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
 
         // A write-body structure, to exercise the multi-structure loop.
@@ -162,7 +162,7 @@ impl GrantFixture {
             grant_ledger: Vec::new(),
             write_history_link: Vec::new(),
             direct_child_scope_index: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let write_body_aad = AadContext {
             v: V,
@@ -180,7 +180,7 @@ impl GrantFixture {
         let write_body_signed = SignedSealed {
             signature: sign(STRUCT_TAG_WRITE_BODY, None, &write_body_sealed),
             sealed: write_body_sealed,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
 
         // The owner-signed commitment: the recipient's tag is committed as a read
@@ -190,7 +190,7 @@ impl GrantFixture {
             ipns_name: name.as_str().as_bytes().to_vec(),
             owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
             entries: vec![GrantSetEntry::new(tag, Permission::Read, [0xC0; 32])],
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let commitment_sig = sign_grant_set(&owner_identity, &commitment).expect("signs");
         let grant_section = GrantSection {
@@ -202,14 +202,14 @@ impl GrantFixture {
             ascent_link: None,
             history_links: Vec::new(),
             write_body: write_body_signed,
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
 
         let folder = ReadBody::Folder {
             created_at: 0,
             modified_at: 0,
             children: Vec::new(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
         let envelope = seal_read_body(
             &read_key,
@@ -323,7 +323,7 @@ impl GrantFixture {
                 ),
             )
             .to_bytes(),
-            unknown: Vec::new(),
+            unknown: PreservedFields::new(),
         };
 
         let mut commitment = self.commitment.clone();

--- a/crates/engine/tests/net.rs
+++ b/crates/engine/tests/net.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 
 use cipherbox_core::error::TrustViolation;
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
-use cipherbox_core::seal::ReadBody;
+use cipherbox_core::seal::{PreservedFields, ReadBody};
 use cipherbox_core::suite::ed25519::Ed25519Signer;
 
 use cipherbox_engine::SyncTimingProfile;
@@ -166,7 +166,7 @@ impl Adopter for StubAdopter {
                         created_at: 0,
                         modified_at: 0,
                         children: Vec::new(),
-                        unknown: Vec::new(),
+                        unknown: PreservedFields::new(),
                     },
                     sequence,
                     epoch: 1,

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -2596,8 +2596,8 @@ fn plant_record(
         read_key: &planted.read_key,
         nonce: &[0x5A; 24],
         body: planted.body,
-        carried_unknown: Vec::new(),
-        carried_epoch_tag_unknown: Vec::new(),
+        carried_unknown: PreservedFields::new(),
+        carried_epoch_tag_unknown: PreservedFields::new(),
     })
     .expect("a well-formed child record");
     publish_next_record(records, blocks, folder, &head);
@@ -2610,7 +2610,7 @@ fn planted_body() -> ReadBody {
         created_at: 0,
         modified_at: 0,
         children: vec![child_ref([0x9B; 16], "planted", CoreNodeKind::Folder)],
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     }
 }
 
@@ -2700,7 +2700,7 @@ fn a_planted_focus_record_never_renders() {
                     created_at: 0,
                     modified_at: 0,
                     versions: Vec::new(),
-                    unknown: Vec::new(),
+                    unknown: PreservedFields::new(),
                 },
             },
             "a record whose sealed body is a file",

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -14,7 +14,7 @@ use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::payload::RepointObject;
 use cipherbox_core::seal::{
-    ChildRef, NodeKind as CoreNodeKind, ReadBody, decode_envelope, open_read_body,
+    ChildRef, NodeKind as CoreNodeKind, PreservedFields, ReadBody, decode_envelope, open_read_body,
 };
 use cipherbox_core::suite::ecdsa::EcdsaSigner;
 use cipherbox_core::suite::ed25519::Ed25519Signer;
@@ -4455,7 +4455,7 @@ fn child_ref(id: [u8; 16], name: &str, kind: CoreNodeKind) -> ChildRef {
         ipns_name: write_name(NodeId(id)).as_str().as_bytes().to_vec(),
         kind,
         link_counter: 1,
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     }
 }
 


### PR DESCRIPTION
## Problem

#902 closed the wipe seam on `codec::UnknownFields` and `codec::Map`. Three adjacent surfaces in the same crate still dropped verbatim copies of secret bytes un-zeroized, and unlike the partial codec #902 hardened, all three are on paths that ship today.

1. **The decoder stranded its in-flight tree on a reject.** `read_value`'s array and map arms accumulated into a bare local, so `{"k": [<32B secret>, <32B secret>, <malformed>]}` dropped the two already-decoded `Value::Bytes` un-wiped inside the decoder — below any guard a caller can install, on every sealed-body and grant open. The top-level `expect_end` reject had the same shape: a whole body decoded, then dropped intact on trailing bytes.
2. **The seal layer's preserved unknowns outlived their scrub guard.** `collect_unknown` *clones* values out of the decoded tree into `pub unknown: Vec<(String, Value)>`. Those clones survive `ScrubOwned`'s wipe and were never scrubbed. This is the shipping preserve-unknowns carrier — the seal layer does not route through `codec::UnknownFields`.
3. **A wiped `Map` re-encoded to silently-empty fields.** Nothing marked the map after `zeroize_bytes`, so both encoders still accepted it. `bytes_fixed::<N>` rejects `h''` afterwards, but the variable-length reads next to it do not — a wiped `ChildRef` round-trips clean with an empty `name` and an empty `ipnsName`. Silent data loss, not a loud reject.

## Change

- **`crates/core/src/codec/scrub.rs`** (new) — one `Scrub` trait plus `ScrubOnDrop` (borrowed, `mem::forget` to disarm) and `ScrubOwned` (owned, for a decode holding a live `&Map` into its tree). This replaces the three near-identical guards the crate had grown in `codec::fields` and `seal::body`, so the terminal-owner rationale is stated once at the mechanism instead of at each copy.
- **`codec::decode`** — the array accumulator, the map accumulator, and the top-level value all stand under `ScrubOnDrop`. The map arm keeps its single `Vec<(String, Value)>`: the guard wipes the values and leaves the keys, which are field names and never secret.
- **`seal::body::PreservedFields`** — a `Map`-backed carrier replacing `Vec<(String, Value)>` across the seal layer. It wipes on `Drop`, renders redacted, and makes duplicate preserved keys unrepresentable. Because `collect_unknown`/`merge_unknown` are shared, one carrier covers `ChildRef`, `Version`, `ReadBody`, `Envelope`, and the grant/section/write-body structs at once.
- **`Map::zeroize_bytes` marks the map**, and `Map::reject_if_wiped` — release-active, returning `Malformed::WipedMap` — runs on both encoder passes and on `encode_map_partial`'s merged head, so the reject fires at every nesting level before a byte is allocated.
- **`seal::envelope::set_grant_section`** — a writer to match the existing `grant_section_bytes`/`has_grant_section` readers, so the `grantSection` key and its byte-string shape live in core rather than being spelled at each engine call site. `PreservedFields::insert` is `pub(crate)`, which narrows what was previously a fully public `Vec` field.
- **`encode_read_body`** re-checks child uniqueness release-active rather than under a `debug_assert!` a release build strips (AGENTS.md rule 8). Not live — `seal_read_body` already calls `validate()?` first — but `encode_read_body` is public.

No wire-format change; the KAT tree is byte-identical.

### Note for #937

#937 (redact `Value`, `Map`, and `Version` renderings) is not started and touches these types, so this PR deliberately stays off that surface: `Value`'s `Display`, `Map`'s derived `Debug`, and `Version`'s hand-written `Debug` are untouched. The only rendering this PR adds is `PreservedFields`' own redacted `Debug`, which shares a new `fmt_redacted_keys` helper with `codec::UnknownFields`. #937 should rebase cleanly.

One thing the crypto gate found that #937 as scoped does **not** reach: `ChildRef` still derives `Debug`, so a `{:?}` on a `ReadBody::Folder` renders every plaintext filename and `ipnsName`. Pre-existing and out of scope here — raised on #937 to widen it.

## Tests

Each new test is confirmed red when its fix is reverted, verified by stubbing out `Map::zeroize_bytes`'s mark, `PreservedFields::Drop`, `ScrubOnDrop::drop`, and `encode_read_body`'s `validate()?`, then re-running `cargo test -p cipherbox-core`:

| Test | Fires when |
| ---- | ---------- |
| `codec::scrub::tests::a_borrowed_guard_wipes_what_it_guards` | the guard stops wiping the accumulator a reject abandons |
| `codec::encode::tests::a_wiped_map_refuses_to_encode` | a wiped map nested inside a body encodes instead of rejecting |
| `codec::fields::tests::merged_encode_rejects_a_wiped_known_side` | the partial encoder emits from a scrubbed known side |
| `seal::body::tests::preserved_fields_own_the_wipe_of_what_a_decode_cloned_out` | the carrier stops scrubbing the clones it holds |
| `seal::body::tests::encode_rejects_a_body_decode_would_refuse` | the encode-side uniqueness check goes back to being release-stripped |
| `codec_props::the_public_encoder_refuses_a_wiped_map` | the `wiped-map` verdict stops being reachable across the crate boundary |

Also pinned: `seal::body::tests::preserved_fields_debug_redacts_its_values`, and `kat_manifest::every_crate_check_is_pinned_by_a_vector_family` now expects two unit-pinned encoder caller-bug checks rather than one.

The `Drop` wiring on `PreservedFields` is not observable in safe Rust — same as `UnknownFields`' `Zeroizing`, which #902 also left unpinned. The tests pin the wipe it calls.

## Verification

All exit 0:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets`
- `cargo test --workspace` — 32 suites green
- `cargo test --release -p cipherbox-core` — the fail-closed checks are release-active
- `pnpm -r --if-present run typecheck`
- `pnpm -r --if-present run test` — 111 client, 177 api, 67 web
- `eslint .`

Review gates run on `git diff main...HEAD`: `/security-review` found nothing at confidence 8 or above. `/simplify` ran four parallel passes — the guard unification, the `Map`-backed carrier, the shared redaction helper, the reverted accumulator split, and the doc trimming above are its findings folded in. `/crypto-privacy-review` rated the diff LOW risk with no CRITICAL or HIGH findings; the `encode_fixed_depth` panic doc, the `Map` mark-boundary note, the release-active `encode_read_body` check, and the public-API `wiped-map` pin are its findings folded in.

Deferred with a dependency edge: #956 — extend the scrub guard to the write-body, section, and mailbox codecs, which strand pseudonymous identifiers and already-sealed bytes rather than key material.

Closes #936
Part of #655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a preserved-fields type for safely retaining unknown data during encoding and decoding.
  * Added a supported way to set grant-section data on envelopes.

* **Bug Fixes**
  * Prevented encoding of data that has already been securely wiped.
  * Improved cleanup of partially decoded values after decoding failures.
  * Added validation to reject invalid or duplicate fields consistently, including in release builds.

* **Security**
  * Enhanced zeroization of sensitive buffers and transient decoded data.
  * Redacted preserved-field keys in debug output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->