### PR TITLE
fix: address grant delivery to the recipient identity key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,7 @@ dependencies = [
  "cipherbox-core",
  "cipherbox-engine",
  "getrandom 0.2.17",
+ "hex",
  "reqwest 0.13.4",
  "serde_json",
  "tokio",

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -25,3 +25,8 @@ getrandom = "0.2"
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }
 serde_json.workspace = true
+# Self-shaped dev-dependency: enables the engine's `test-kit` for the suite's
+# own tests, so a leg can drive a real engine primitive (seeded entropy, the
+# in-memory floor store) against the live API without leaking the feature into
+# any production build.
+cipherbox-engine = { workspace = true, features = ["test-kit"] }

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -21,12 +21,13 @@ cipherbox-engine.workspace = true
 # is reached over plain http on localhost in CI, so no TLS/OpenSSL is linked.
 reqwest = { version = "0.13", default-features = false }
 getrandom = "0.2"
+# Lowercase hex, the API's wire form for public keys — the same crate core and
+# the engine already use.
+hex = "0.4"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }
 serde_json.workspace = true
-# Self-shaped dev-dependency: enables the engine's `test-kit` for the suite's
-# own tests, so a leg can drive a real engine primitive (seeded entropy, the
-# in-memory floor store) against the live API without leaking the feature into
-# any production build.
+# `test-kit` for this suite's own tests: seeded entropy + the in-memory floor
+# store, so a leg can drive a real engine primitive against the live API.
 cipherbox-engine = { workspace = true, features = ["test-kit"] }

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -120,16 +120,34 @@ pub fn random_identity_signer() -> IdentityChallengeSigner {
 /// Decode a 64-char hex string into a 32-byte scalar. `None` on any malformed
 /// input.
 pub fn hex_to_scalar(hex: &str) -> Option<[u8; 32]> {
-    if hex.len() != 64 {
+    let bytes = hex_to_bytes(hex)?;
+    bytes.try_into().ok()
+}
+
+/// Decode an even-length hex string into bytes. `None` on any malformed input.
+pub fn hex_to_bytes(hex: &str) -> Option<Vec<u8>> {
+    if !hex.len().is_multiple_of(2) {
         return None;
     }
-    let mut out = [0u8; 32];
-    for (index, byte) in out.iter_mut().enumerate() {
-        let high = (hex.as_bytes()[index * 2] as char).to_digit(16)?;
-        let low = (hex.as_bytes()[index * 2 + 1] as char).to_digit(16)?;
-        *byte = ((high << 4) | low) as u8;
+    let raw = hex.as_bytes();
+    let mut out = Vec::with_capacity(hex.len() / 2);
+    for pair in raw.chunks_exact(2) {
+        let high = (pair[0] as char).to_digit(16)?;
+        let low = (pair[1] as char).to_digit(16)?;
+        out.push(((high << 4) | low) as u8);
     }
     Some(out)
+}
+
+/// Lowercase hex encoding — how the mailbox seam's byte address reaches the
+/// API's hex `recipientPublicKey` field.
+pub fn bytes_to_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(char::from_digit((byte >> 4) as u32, 16).expect("high nibble is < 16"));
+        out.push(char::from_digit((byte & 0x0f) as u32, 16).expect("low nibble is < 16"));
+    }
+    out
 }
 
 /// The API base URL for the live stack, from `CONTRACT_API_URL`. When unset the

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -119,35 +119,22 @@ pub fn random_identity_signer() -> IdentityChallengeSigner {
 
 /// Decode a 64-char hex string into a 32-byte scalar. `None` on any malformed
 /// input.
-pub fn hex_to_scalar(hex: &str) -> Option<[u8; 32]> {
-    let bytes = hex_to_bytes(hex)?;
-    bytes.try_into().ok()
+pub fn hex_to_scalar(hex_str: &str) -> Option<[u8; 32]> {
+    if hex_str.len() != 64 {
+        return None;
+    }
+    hex_to_bytes(hex_str)?.try_into().ok()
 }
 
 /// Decode an even-length hex string into bytes. `None` on any malformed input.
-pub fn hex_to_bytes(hex: &str) -> Option<Vec<u8>> {
-    if !hex.len().is_multiple_of(2) {
-        return None;
-    }
-    let raw = hex.as_bytes();
-    let mut out = Vec::with_capacity(hex.len() / 2);
-    for pair in raw.chunks_exact(2) {
-        let high = (pair[0] as char).to_digit(16)?;
-        let low = (pair[1] as char).to_digit(16)?;
-        out.push(((high << 4) | low) as u8);
-    }
-    Some(out)
+pub fn hex_to_bytes(hex_str: &str) -> Option<Vec<u8>> {
+    hex::decode(hex_str).ok()
 }
 
-/// Lowercase hex encoding — how the mailbox seam's byte address reaches the
-/// API's hex `recipientPublicKey` field.
+/// Lowercase hex — how the mailbox seam's byte address reaches the API's hex
+/// `recipientPublicKey` field.
 pub fn bytes_to_hex(bytes: &[u8]) -> String {
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        out.push(char::from_digit((byte >> 4) as u32, 16).expect("high nibble is < 16"));
-        out.push(char::from_digit((byte & 0x0f) as u32, 16).expect("low nibble is < 16"));
-    }
-    out
+    hex::encode(bytes)
 }
 
 /// The API base URL for the live stack, from `CONTRACT_API_URL`. When unset the

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -1075,11 +1075,8 @@ async fn mailbox_post_is_bounded_by_recipient_existence_and_blob_size() {
 
 // --- grant delivery over the live mailbox (blueprint/engine.md; #954) -------
 
-/// The mailbox seam over the engine's real API client — the production bridge
-/// from the seam's byte address to the API's hex `recipientPublicKey`. Standing
-/// it up here is what lets the grant path's *own* address and idempotency key
-/// meet the real `PostMessageDto`, instead of a hand-built fixture that happens
-/// to be well-formed.
+/// The `Mailbox` seam over the engine's real API client: byte address → the
+/// API's hex `recipientPublicKey`.
 struct ApiMailbox {
     client: Client,
 }
@@ -1144,13 +1141,8 @@ impl ScopeRootPublisher for LocalNet {
     }
 }
 
-/// A real read grant, minted by `create_read_grant`, delivers its share pointer
-/// through the live mailbox (blueprint/api.md "Mailbox").
-///
-/// The grant path picks the recipient address and the idempotency key itself:
-/// posting the X25519 subkey, or a `:`-separated key, is a `PostMessageDto` 400
-/// (#954). Driving the real primitive rather than a fixture is what binds those
-/// two choices to the served contract.
+/// A real read grant's share pointer reaches the live mailbox: the grant path's
+/// own routing address and idempotency key must satisfy `PostMessageDto` (#954).
 #[tokio::test]
 async fn a_read_grant_delivers_its_share_pointer_through_the_live_mailbox() {
     let base = require_stack!("a_read_grant_delivers_its_share_pointer_through_the_live_mailbox");

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -18,7 +18,9 @@ use cipherbox_contract::{
     hex_to_scalar, prod_api_url, random_identity_signer, test_login_secret,
 };
 use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, encode_content_cid_str};
-use cipherbox_core::seal::{ChildScopeRef, GrantSetCommitment, Permission, sign_grant_set};
+use cipherbox_core::seal::{
+    ChildScopeRef, GrantSetCommitment, Permission, PreservedFields, sign_grant_set,
+};
 use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
 use cipherbox_core::suite::ed25519::Ed25519Signer;
 use cipherbox_core::suite::x25519::X25519Secret;
@@ -1175,7 +1177,7 @@ async fn a_read_grant_delivers_its_share_pointer_through_the_live_mailbox() {
         ipns_name: b"contract-parent-scope-root".to_vec(),
         owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
         entries: Vec::new(),
-        unknown: Vec::new(),
+        unknown: PreservedFields::new(),
     };
     let parent_commitment_sig = sign_grant_set(&owner_identity, &parent_commitment)
         .expect("sign the parent commitment")

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -14,17 +14,35 @@
 //! sets it (and boots the stack), so the assertions always run there.
 
 use cipherbox_contract::{
-    MemoryCredentialStore, ReqwestHttp, api_url, gateway_url, hex_to_scalar, prod_api_url,
-    random_identity_signer, test_login_secret,
+    MemoryCredentialStore, ReqwestHttp, api_url, bytes_to_hex, gateway_url, hex_to_bytes,
+    hex_to_scalar, prod_api_url, random_identity_signer, test_login_secret,
 };
 use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, encode_content_cid_str};
+use cipherbox_core::seal::{ChildScopeRef, GrantSetCommitment, Permission, sign_grant_set};
+use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
+use cipherbox_core::suite::ed25519::Ed25519Signer;
+use cipherbox_core::suite::x25519::X25519Secret;
 use cipherbox_engine::api::{
     ApiClient, ApiError, ChallengeSigner, IdentityChallengeSigner, NameRegistration,
     REGISTRY_BATCH_REFUSED,
 };
 use cipherbox_engine::content::{ContentProfile, DAG_ROOT_CODEC, assemble};
+use cipherbox_engine::grants::{
+    GrantRecipient, GranteeScopePlan, OwnerGrantKeys, ParentScopePlan, SharePointer,
+    create_read_grant,
+};
+use cipherbox_engine::mailbox::poll_verified;
 use cipherbox_engine::net::REGISTRY_BATCH_MAX;
-use cipherbox_engine::seams::{CredentialStore, Http, HttpMethod, HttpRequest};
+use cipherbox_engine::rotation::{
+    PrevEpochSeed, ResealSeeds, ResealedScopeRoot, ResolveFailure, ScopeRootIdentity,
+    ScopeRootPublishError, ScopeRootPublisher, SweepResolver, SweepTarget,
+};
+use cipherbox_engine::seams::{
+    CredentialStore, Http, HttpMethod, HttpRequest, Mailbox, MailboxItem as SealedMailboxItem,
+    SeamError, SeamResult,
+};
+use cipherbox_engine::testkit::SeededEntropy;
+use cipherbox_engine::testkit::fakes::InMemoryFloorStore;
 
 type Client = ApiClient<ReqwestHttp, MemoryCredentialStore>;
 
@@ -1053,4 +1071,209 @@ async fn mailbox_post_is_bounded_by_recipient_existence_and_blob_size() {
         matches!(error, ApiError::Status { status: 413, .. }),
         "an oversized sealed blob is a 413, got {error:?}"
     );
+}
+
+// --- grant delivery over the live mailbox (blueprint/engine.md; #954) -------
+
+/// The mailbox seam over the engine's real API client — the production bridge
+/// from the seam's byte address to the API's hex `recipientPublicKey`. Standing
+/// it up here is what lets the grant path's *own* address and idempotency key
+/// meet the real `PostMessageDto`, instead of a hand-built fixture that happens
+/// to be well-formed.
+struct ApiMailbox {
+    client: Client,
+}
+
+impl Mailbox for ApiMailbox {
+    async fn post(
+        &self,
+        recipient_public_key: &[u8],
+        sealed_payload: &[u8],
+        idempotency_key: &str,
+    ) -> SeamResult<()> {
+        self.client
+            .mailbox_post(
+                &bytes_to_hex(recipient_public_key),
+                sealed_payload,
+                idempotency_key,
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| SeamError::new(format!("mailbox post: {error}")))
+    }
+
+    async fn poll(&self) -> SeamResult<Vec<SealedMailboxItem>> {
+        let items = self
+            .client
+            .mailbox_poll()
+            .await
+            .map_err(|error| SeamError::new(format!("mailbox poll: {error}")))?;
+        Ok(items
+            .into_iter()
+            .map(|item| SealedMailboxItem {
+                item_id: item.id,
+                sealed_payload: item.blob,
+            })
+            .collect())
+    }
+
+    async fn ack(&self, item_id: &str) -> SeamResult<()> {
+        self.client
+            .mailbox_ack(item_id)
+            .await
+            .map_err(|error| SeamError::new(format!("mailbox ack: {error}")))
+    }
+}
+
+/// A `SweepResolver` + `ScopeRootPublisher` that keeps the grant's network side
+/// local: this leg asserts the *delivery* the grant path emits, not IPNS.
+struct LocalNet;
+
+impl SweepResolver for LocalNet {
+    async fn resolve(&self, _scope: &ChildScopeRef) -> Result<SweepTarget, ResolveFailure> {
+        Err(ResolveFailure::Rejected)
+    }
+}
+
+impl ScopeRootPublisher for LocalNet {
+    async fn publish_scope_root(
+        &self,
+        _record: &ResealedScopeRoot,
+    ) -> Result<(), ScopeRootPublishError> {
+        Ok(())
+    }
+}
+
+/// A real read grant, minted by `create_read_grant`, delivers its share pointer
+/// through the live mailbox (blueprint/api.md "Mailbox").
+///
+/// The grant path picks the recipient address and the idempotency key itself:
+/// posting the X25519 subkey, or a `:`-separated key, is a `PostMessageDto` 400
+/// (#954). Driving the real primitive rather than a fixture is what binds those
+/// two choices to the served contract.
+#[tokio::test]
+async fn a_read_grant_delivers_its_share_pointer_through_the_live_mailbox() {
+    let base = require_stack!("a_read_grant_delivers_its_share_pointer_through_the_live_mailbox");
+    const V: u64 = 1;
+
+    let (owner_client, _) = addressable_account(&base, "contract-grant-owner").await;
+    let (recipient_client, recipient_key_hex) =
+        addressable_account(&base, "contract-grant-recipient").await;
+
+    // The recipient's mailbox address is their account identity key, exactly as
+    // the API stores it — normalized compressed SEC1.
+    let recipient_identity =
+        EcdsaVerifier::from_sec1(&hex_to_bytes(&recipient_key_hex).expect("account key is hex"))
+            .expect("account publicKey is a compressed secp256k1 point");
+
+    let owner_enc = X25519Secret::from_scalar([0x11; 32]);
+    let owner_enc_pub = owner_enc.public();
+    let owner_identity = EcdsaSigner::from_scalar(&[0x33; 32]).expect("valid scalar");
+    let owner_pseudonym = Ed25519Signer::from_seed([0x22; 32]);
+    let recipient_enc = X25519Secret::from_scalar([0x44; 32]);
+    let recipient_enc_pub = recipient_enc.public();
+
+    let parent_node_seed = [0x44u8; 32];
+    let grantee_write_scope_seed = [0x55u8; 32];
+    let grantee_pointer_read_key = [0x66u8; 32];
+    let parent_override_seed = [0x0au8; 32];
+    let parent_write_scope_seed = [0x0bu8; 32];
+    let parent_pointer_read_key = [0x0cu8; 32];
+    let parent_commitment = GrantSetCommitment {
+        ipns_name: b"contract-parent-scope-root".to_vec(),
+        owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
+        entries: Vec::new(),
+        unknown: Vec::new(),
+    };
+    let parent_commitment_sig = sign_grant_set(&owner_identity, &parent_commitment)
+        .expect("sign the parent commitment")
+        .to_compact();
+
+    let mut entropy = SeededEntropy::new(954);
+    let floors = InMemoryFloorStore::default();
+    let net = LocalNet;
+    let mailbox = ApiMailbox {
+        client: owner_client,
+    };
+
+    create_read_grant(
+        &mut entropy,
+        &floors,
+        &net,
+        &net,
+        &mailbox,
+        &GranteeScopePlan {
+            v: V,
+            scope_id: [0x5c; 16],
+            parent_node_seed: &parent_node_seed,
+            owner_enc_pub: &owner_enc_pub,
+            write_scope_seed: &grantee_write_scope_seed,
+            write_epoch: 1,
+            pointer_read_key: &grantee_pointer_read_key,
+            subtree_child_index: &[],
+        },
+        &GrantRecipient {
+            identity_pk: recipient_identity,
+            enc_pub: &recipient_enc_pub,
+            display_name: "Shared Folder".to_string(),
+        },
+        &OwnerGrantKeys {
+            enc_secret: &owner_enc,
+            identity_signer: &owner_identity,
+            pseudonym_signer: &owner_pseudonym,
+        },
+        &ParentScopePlan {
+            identity: ScopeRootIdentity {
+                v: V,
+                scope_id: [0x0e; 16],
+                ipns_name: b"contract-parent-scope-root",
+                owner_enc_pub: &owner_enc_pub,
+                parent_node_seed: None,
+                pseudonym_signer: &owner_pseudonym,
+            },
+            seeds: ResealSeeds {
+                override_seed: &parent_override_seed,
+                read_epoch: 3,
+                prev: None::<PrevEpochSeed<'_>>,
+                write_scope_seed: &parent_write_scope_seed,
+                write_epoch: 2,
+                pointer_read_key: &parent_pointer_read_key,
+            },
+            commitment: &parent_commitment,
+            commitment_sig: &parent_commitment_sig,
+            grant_ledger: &[],
+            write_history_link: &[],
+            current_child_index: &[],
+            carried_history_links: &[],
+        },
+    )
+    .await
+    .expect("the live mailbox accepts the grant path's own address and idempotency key");
+
+    // The pointer landed in the recipient's real inbox, opens under their
+    // encryption subkey, and carries the owner's signature — so the address the
+    // grant path chose is the one the API routes on.
+    let recipient_mailbox = ApiMailbox {
+        client: recipient_client,
+    };
+    let items = poll_verified(&recipient_mailbox, &recipient_enc, V)
+        .await
+        .expect("recipient polls its inbox");
+    assert_eq!(items.len(), 1, "exactly one delivered share pointer");
+    assert_eq!(
+        items[0].sender_identity,
+        owner_identity.verifying_key(),
+        "the pointer is sender-authenticated as the owner"
+    );
+    let pointer = SharePointer::decode(&items[0].payload).expect("decode the share pointer");
+    assert_eq!(pointer.permission, Permission::Read);
+    assert_eq!(
+        pointer.sharer_identity_pk,
+        owner_identity.verifying_key().to_sec1()
+    );
+
+    recipient_mailbox
+        .ack(&items[0].item_id)
+        .await
+        .expect("ack the delivered pointer");
 }

--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -31,9 +31,7 @@ use cipherbox_core::seal::{
     ChildScopeRef, GrantLedgerEntry, GrantSetCommitment, GrantSetEntry, Permission,
     PreservedFields, SignedSealed, sign_grant_set,
 };
-use cipherbox_core::suite::ecdsa::{
-    EcdsaSigner, IDENTITY_PUBLIC_LEN, SIGNATURE_LEN as ECDSA_SIG_LEN,
-};
+use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier, SIGNATURE_LEN as ECDSA_SIG_LEN};
 use cipherbox_core::suite::ed25519::Ed25519Signer;
 use cipherbox_core::suite::secret::SECRET_LEN;
 use cipherbox_core::suite::x25519::{X25519Public, X25519Secret};
@@ -89,10 +87,13 @@ pub struct GranteeScopePlan<'a> {
 
 /// The recipient of the read grant.
 pub struct GrantRecipient<'a> {
-    /// Compressed secp256k1 SEC1 identity key (for the ledger + share pointer).
-    pub identity_pk: [u8; IDENTITY_PUBLIC_LEN],
-    /// X25519 encryption subkey public key: the grant-blob HPKE wrap target and
-    /// the mailbox routing address.
+    /// secp256k1 identity key (the ledger entry, the share pointer, and the
+    /// mailbox routing address), as carried by the imported [`Contact`].
+    ///
+    /// [`Contact`]: super::Contact
+    pub identity_pk: EcdsaVerifier,
+    /// X25519 encryption subkey public key: the grant-blob and mailbox HPKE
+    /// wrap target.
     pub enc_pub: &'a X25519Public,
     /// Courtesy host label carried in the share pointer.
     pub display_name: String,
@@ -328,7 +329,7 @@ where
         .map_err(CreateGrantError::CommitmentEncode)?
         .to_compact();
     let ledger = vec![GrantLedgerEntry::new(
-        recipient.identity_pk,
+        recipient.identity_pk.to_sec1(),
         recipient.enc_pub.to_bytes(),
         Permission::Read,
         tag,
@@ -507,17 +508,16 @@ where
     entropy
         .fill(&mut *ephemeral)
         .map_err(CreateGrantError::Entropy)?;
-    let recipient_address = recipient.enc_pub.to_bytes();
     // Key off the per-recipient blinded tag, not the shared scope_id: the API
     // stores sha256(senderPublicKey : idempotencyKey) per recipient, so a
     // scope-derived key would be identical across two recipients of the same
     // folder and let the server correlate the sharing edge. The tag is
     // deterministic (retry-safe), 32-byte high-entropy, and differs per recipient.
-    let idempotency_key = format!("grant:{}", hex_lower(&tag));
+    let idempotency_key = format!("grant-{}", hex_lower(&tag));
     post_sealed(
         mailbox,
         recipient.enc_pub,
-        &recipient_address,
+        &recipient.identity_pk,
         &ephemeral,
         grantee.v,
         owner.identity_signer,
@@ -584,6 +584,13 @@ mod tests {
     }
     fn recipient_enc() -> X25519Secret {
         X25519Secret::from_scalar([0x44; 32])
+    }
+    /// The recipient's secp256k1 identity — the mailbox routing address and the
+    /// ledger/share-pointer identity.
+    fn recipient_identity() -> EcdsaVerifier {
+        EcdsaSigner::from_scalar(&[0x45; 32])
+            .expect("valid scalar")
+            .verifying_key()
     }
 
     /// A combined `SweepResolver` + `ScopeRootPublisher` fake: it records every
@@ -686,23 +693,31 @@ mod tests {
         }
     }
 
-    /// A `Mailbox` fake that records the idempotency key of every post, so a test
-    /// can assert two recipients of the same folder get distinct keys.
+    /// What the grant path actually put on the wire for one post.
+    #[derive(Clone)]
+    struct PostedDelivery {
+        address: Vec<u8>,
+        idempotency_key: String,
+    }
+
+    /// A `Mailbox` fake that records every post, so a test can assert the
+    /// delivery values the grant path chose.
     #[derive(Clone, Default)]
     struct RecordingMailbox {
-        idempotency_keys: Rc<RefCell<Vec<String>>>,
+        posts: Rc<RefCell<Vec<PostedDelivery>>>,
     }
 
     impl Mailbox for RecordingMailbox {
         async fn post(
             &self,
-            _recipient_public_key: &[u8],
+            recipient_public_key: &[u8],
             _sealed_payload: &[u8],
             idempotency_key: &str,
         ) -> crate::seams::SeamResult<()> {
-            self.idempotency_keys
-                .borrow_mut()
-                .push(idempotency_key.to_owned());
+            self.posts.borrow_mut().push(PostedDelivery {
+                address: recipient_public_key.to_vec(),
+                idempotency_key: idempotency_key.to_owned(),
+            });
             Ok(())
         }
         async fn poll(&self) -> crate::seams::SeamResult<Vec<crate::seams::MailboxItem>> {
@@ -713,9 +728,9 @@ mod tests {
         }
     }
 
-    /// The mailbox idempotency key the primitive posts for `recipient_enc` over
-    /// the fixed grantee folder (empty subtree, converged, publishing OK).
-    fn idempotency_key_for(recipient_enc: &X25519Secret) -> String {
+    /// The delivery the primitive posts for `recipient_enc` over the fixed
+    /// grantee folder (empty subtree, converged, publishing OK).
+    fn delivery_for(recipient_enc: &X25519Secret) -> PostedDelivery {
         let floors = InMemoryFloorStore::default();
         let net = FakeNet::new(Ok(()));
         let recorder = RecordingMailbox::default();
@@ -754,7 +769,7 @@ mod tests {
             subtree_child_index: &[],
         };
         let recipient = GrantRecipient {
-            identity_pk: [0x02; IDENTITY_PUBLIC_LEN],
+            identity_pk: recipient_identity(),
             enc_pub: &recipient_pub,
             display_name: "Shared Folder".to_string(),
         };
@@ -800,9 +815,9 @@ mod tests {
         ))
         .expect("grant creation succeeds");
 
-        let keys = recorder.idempotency_keys.borrow();
-        assert_eq!(keys.len(), 1, "exactly one mailbox post per grant");
-        keys[0].clone()
+        let posts = recorder.posts.borrow();
+        assert_eq!(posts.len(), 1, "exactly one mailbox post per grant");
+        posts[0].clone()
     }
 
     /// A read grant with the given subtree, run against fresh fakes on seed
@@ -824,7 +839,7 @@ mod tests {
             block_on(floors.raise_epoch_floor(&scope, epoch)).unwrap();
         }
         let hub = InMemoryMailboxHub::default();
-        let mailbox = hub.mailbox_for(&recipient_enc().public().to_bytes());
+        let mailbox = hub.mailbox_for(&recipient_identity().to_sec1());
 
         let owner_enc = owner_enc();
         let owner_enc_pub = owner_enc.public();
@@ -863,7 +878,7 @@ mod tests {
                 subtree_child_index: subtree,
             };
             let recipient = GrantRecipient {
-                identity_pk: [0x02; IDENTITY_PUBLIC_LEN],
+                identity_pk: recipient_identity(),
                 enc_pub: &recipient_pub,
                 display_name: "Shared Folder".to_string(),
             };
@@ -964,7 +979,7 @@ mod tests {
         );
 
         // The recipient receives the sealed share pointer.
-        let recip_box = hub.mailbox_for(&recipient_enc().public().to_bytes());
+        let recip_box = hub.mailbox_for(&recipient_identity().to_sec1());
         let items = block_on(poll_verified(&recip_box, &recipient_enc(), V)).unwrap();
         assert_eq!(items.len(), 1);
         let pointer = SharePointer::decode(&items[0].payload).unwrap();
@@ -1000,7 +1015,7 @@ mod tests {
         }
         // Fail-closed: no grantee/parent record published, no share pointer.
         assert!(published.is_empty(), "nothing published on a refused grant");
-        let recip_box = hub.mailbox_for(&recipient_enc().public().to_bytes());
+        let recip_box = hub.mailbox_for(&recipient_identity().to_sec1());
         let items = block_on(poll_verified(&recip_box, &recipient_enc(), V)).unwrap();
         assert!(items.is_empty(), "no share pointer on a refused grant");
     }
@@ -1039,7 +1054,7 @@ mod tests {
         assert_eq!(published.len(), 1, "grantee root committed, parent not");
         assert_eq!(published[0].scope_id, GRANTEE_SCOPE);
         // No share pointer is posted when publishing aborts before the mailbox step.
-        let recip_box = hub.mailbox_for(&recipient_enc().public().to_bytes());
+        let recip_box = hub.mailbox_for(&recipient_identity().to_sec1());
         let items = block_on(poll_verified(&recip_box, &recipient_enc(), V)).unwrap();
         assert!(items.is_empty(), "no share pointer when publish aborts");
     }
@@ -1073,7 +1088,7 @@ mod tests {
         assert_eq!(published[0].scope_id, GRANTEE_SCOPE);
         // Fail-safe: with no share pointer the recipient cannot locate the grantee
         // root, so the partial commit exposes nothing.
-        let recip_box = hub.mailbox_for(&recipient_enc().public().to_bytes());
+        let recip_box = hub.mailbox_for(&recipient_identity().to_sec1());
         let items = block_on(poll_verified(&recip_box, &recipient_enc(), V)).unwrap();
         assert!(
             items.is_empty(),
@@ -1102,12 +1117,42 @@ mod tests {
         // shared scope_id: two recipients of the SAME folder must post distinct
         // keys so the server can't correlate the sharing edge via
         // sha256(sender : key).
-        let key_a = idempotency_key_for(&recipient_enc());
-        let key_b = idempotency_key_for(&X25519Secret::from_scalar([0x77; 32]));
-        assert!(key_a.starts_with("grant:"));
+        let key_a = delivery_for(&recipient_enc()).idempotency_key;
+        let key_b = delivery_for(&X25519Secret::from_scalar([0x77; 32])).idempotency_key;
+        assert!(key_a.starts_with("grant-"));
         assert_ne!(
             key_a, key_b,
             "same folder, different recipients → different idempotency keys"
+        );
+    }
+
+    #[test]
+    fn delivery_is_addressed_and_keyed_in_the_shape_the_transport_accepts() {
+        // #954: the grant path posted the X25519 subkey as the routing address
+        // and a `grant:`-prefixed key, both of which the mailbox transport
+        // rejects (blueprint/api.md "Mailbox").
+        let PostedDelivery {
+            address,
+            idempotency_key: key,
+        } = delivery_for(&recipient_enc());
+
+        assert_eq!(
+            address,
+            recipient_identity().to_sec1(),
+            "routing address is the recipient's compressed SEC1 identity key"
+        );
+        assert_ne!(
+            address,
+            recipient_enc().public().to_bytes(),
+            "the encryption subkey never routes"
+        );
+        assert!(EcdsaVerifier::from_sec1(&address).is_some());
+
+        assert!(!key.is_empty() && key.len() <= 128);
+        assert!(
+            key.bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'~' | b'-')),
+            "idempotency key {key:?} leaves the transport alphabet"
         );
     }
 

--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -87,8 +87,9 @@ pub struct GranteeScopePlan<'a> {
 
 /// The recipient of the read grant.
 pub struct GrantRecipient<'a> {
-    /// secp256k1 identity key (the ledger entry, the share pointer, and the
-    /// mailbox routing address), as carried by the imported [`Contact`].
+    /// secp256k1 identity key — the ledger entry and the mailbox routing
+    /// address. Source it from the imported [`Contact`], whose binding
+    /// signature is what ties it to `enc_pub`.
     ///
     /// [`Contact`]: super::Contact
     pub identity_pk: EcdsaVerifier,
@@ -214,8 +215,8 @@ pub enum CreateGrantError {
     ParentPublish(ScopeRootPublishError),
     /// Posting the sealed share pointer to the recipient mailbox failed.
     /// Post-publish: both scope roots are published and the parent index is
-    /// updated; only the share pointer is missing. Retry re-posts under the
-    /// same idempotency key.
+    /// updated; only the share pointer is missing. A retry posts a fresh item —
+    /// delivery is at-least-once, and the accept flow is the dedup point.
     Mailbox(SeamError),
 }
 
@@ -508,12 +509,17 @@ where
     entropy
         .fill(&mut *ephemeral)
         .map_err(CreateGrantError::Entropy)?;
-    // Key off the per-recipient blinded tag, not the shared scope_id: the API
-    // stores sha256(senderPublicKey : idempotencyKey) per recipient, so a
-    // scope-derived key would be identical across two recipients of the same
-    // folder and let the server correlate the sharing edge. The tag is
-    // deterministic (retry-safe), 32-byte high-entropy, and differs per recipient.
-    let idempotency_key = format!("grant-{}", hex_lower(&tag));
+    // Fresh random, never derived: the API keeps only
+    // sha256(senderPublicKey : idempotencyKey), so any key an observer can
+    // recompute hands it back the sender→recipient edge. The blinded tag is
+    // public (`kdf::blinded_tag`) and ships in the clear in every scope root's
+    // grant section, so deriving from it would rebuild that edge — and the
+    // granted folder — from a cached record.
+    let mut idempotency_bytes = [0u8; 16];
+    entropy
+        .fill(&mut idempotency_bytes)
+        .map_err(CreateGrantError::Entropy)?;
+    let idempotency_key = format!("grant-{}", hex_lower(&idempotency_bytes));
     post_sealed(
         mailbox,
         recipient.enc_pub,
@@ -585,8 +591,6 @@ mod tests {
     fn recipient_enc() -> X25519Secret {
         X25519Secret::from_scalar([0x44; 32])
     }
-    /// The recipient's secp256k1 identity — the mailbox routing address and the
-    /// ledger/share-pointer identity.
     fn recipient_identity() -> EcdsaVerifier {
         EcdsaSigner::from_scalar(&[0x45; 32])
             .expect("valid scalar")
@@ -729,8 +733,9 @@ mod tests {
     }
 
     /// The delivery the primitive posts for `recipient_enc` over the fixed
-    /// grantee folder (empty subtree, converged, publishing OK).
-    fn delivery_for(recipient_enc: &X25519Secret) -> PostedDelivery {
+    /// grantee folder (empty subtree, converged, publishing OK), with the
+    /// grant's blinded tag alongside it.
+    fn delivery_for(entropy_seed: u64, recipient_enc: &X25519Secret) -> (PostedDelivery, [u8; 32]) {
         let floors = InMemoryFloorStore::default();
         let net = FakeNet::new(Ok(()));
         let recorder = RecordingMailbox::default();
@@ -757,7 +762,7 @@ mod tests {
             .unwrap()
             .to_compact();
 
-        let mut entropy = SeededEntropy::new(7);
+        let mut entropy = SeededEntropy::new(entropy_seed);
         let grantee = GranteeScopePlan {
             v: V,
             scope_id: GRANTEE_SCOPE,
@@ -802,7 +807,7 @@ mod tests {
             current_child_index: &[],
             carried_history_links: &[],
         };
-        block_on(create_read_grant(
+        let outcome = block_on(create_read_grant(
             &mut entropy,
             &floors,
             &net,
@@ -817,7 +822,7 @@ mod tests {
 
         let posts = recorder.posts.borrow();
         assert_eq!(posts.len(), 1, "exactly one mailbox post per grant");
-        posts[0].clone()
+        (posts[0].clone(), outcome.tag)
     }
 
     /// A read grant with the given subtree, run against fresh fakes on seed
@@ -1112,47 +1117,38 @@ mod tests {
     }
 
     #[test]
-    fn idempotency_key_differs_per_recipient_for_the_same_folder() {
-        // The mailbox idempotency key binds the per-recipient blinded tag, not the
-        // shared scope_id: two recipients of the SAME folder must post distinct
-        // keys so the server can't correlate the sharing edge via
-        // sha256(sender : key).
-        let key_a = delivery_for(&recipient_enc()).idempotency_key;
-        let key_b = delivery_for(&X25519Secret::from_scalar([0x77; 32])).idempotency_key;
-        assert!(key_a.starts_with("grant-"));
+    fn the_idempotency_key_is_entropy_drawn_and_carries_no_public_material() {
+        // The API keeps only sha256(sender : key), so a key an observer can
+        // recompute hands back the sharing edge. The blinded tag is public and
+        // ships in the clear in the grant section, so it must not appear here.
+        let (a, tag) = delivery_for(7, &recipient_enc());
+        let (b, _) = delivery_for(9, &recipient_enc());
+
         assert_ne!(
-            key_a, key_b,
-            "same folder, different recipients → different idempotency keys"
+            a.idempotency_key, b.idempotency_key,
+            "the key follows the entropy seam, not the grant's own material"
+        );
+        assert!(
+            !a.idempotency_key.contains(&hex_lower(&tag)),
+            "the public blinded tag never reaches the wire as the key"
         );
     }
 
     #[test]
     fn delivery_is_addressed_and_keyed_in_the_shape_the_transport_accepts() {
         // #954: the grant path posted the X25519 subkey as the routing address
-        // and a `grant:`-prefixed key, both of which the mailbox transport
-        // rejects (blueprint/api.md "Mailbox").
-        let PostedDelivery {
-            address,
-            idempotency_key: key,
-        } = delivery_for(&recipient_enc());
+        // and a `grant:`-prefixed key, each a `PostMessageDto` refusal.
+        let (delivery, _) = delivery_for(7, &recipient_enc());
 
         assert_eq!(
-            address,
+            delivery.address,
             recipient_identity().to_sec1(),
             "routing address is the recipient's compressed SEC1 identity key"
         );
-        assert_ne!(
-            address,
-            recipient_enc().public().to_bytes(),
-            "the encryption subkey never routes"
-        );
-        assert!(EcdsaVerifier::from_sec1(&address).is_some());
-
-        assert!(!key.is_empty() && key.len() <= 128);
         assert!(
-            key.bytes()
-                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'~' | b'-')),
-            "idempotency key {key:?} leaves the transport alphabet"
+            crate::mailbox::idempotency_key_is_legal(&delivery.idempotency_key),
+            "idempotency key {:?} leaves the transport alphabet",
+            delivery.idempotency_key
         );
     }
 

--- a/crates/engine/src/mailbox/mod.rs
+++ b/crates/engine/src/mailbox/mod.rs
@@ -27,10 +27,12 @@ use cipherbox_core::suite::x25519::{X25519Public, X25519Secret};
 
 use crate::seams::{Mailbox, SeamError, SeamResult};
 
-/// The transport's idempotency-key alphabet and bound (RFC 3986 unreserved,
-/// 1-128), enforced here on the produce side because the transport hard-rejects
-/// anything else (blueprint/api.md "Mailbox").
-fn idempotency_key_is_legal(key: &str) -> bool {
+/// The transport's sealed-payload bound (API `PostMessageDto`).
+const MAX_SEALED_BYTES: usize = 8192;
+
+/// The transport's idempotency-key alphabet and bound: RFC 3986 unreserved,
+/// 1-128 (API `PostMessageDto`).
+pub(crate) fn idempotency_key_is_legal(key: &str) -> bool {
     !key.is_empty()
         && key.len() <= 128
         && key
@@ -60,11 +62,8 @@ pub struct VerifiedMailboxItem {
 /// entropy input, never a clock or a constant).
 ///
 /// Routing and sealing use *different* keys: the [`Mailbox`] seam addresses on
-/// the recipient's secp256k1 **identity** key, while the seal targets their
-/// X25519 encryption subkey. Taking the identity as an [`EcdsaVerifier`] makes
-/// the address a valid compressed SEC1 point by construction; the idempotency
-/// key is charset-checked, so no post leaves here in a shape the transport
-/// rejects.
+/// the recipient's secp256k1 identity key, the seal targets their X25519
+/// encryption subkey (see [`Mailbox`] for the wire shape it enforces).
 #[allow(clippy::too_many_arguments)]
 pub async fn post_sealed<M: Mailbox>(
     mailbox: &M,
@@ -88,6 +87,9 @@ pub async fn post_sealed<M: Mailbox>(
         sender_signer,
         payload,
     );
+    if sealed.len() > MAX_SEALED_BYTES {
+        return Err(SeamError::new("sealed payload exceeds the transport bound"));
+    }
     mailbox
         .post(&recipient_identity.to_sec1(), &sealed, idempotency_key)
         .await
@@ -138,7 +140,6 @@ mod tests {
         X25519Secret::from_scalar([0x40; 32])
     }
 
-    /// The recipient's secp256k1 identity — the mailbox routing address.
     fn recipient_identity() -> EcdsaVerifier {
         EcdsaSigner::from_scalar(&[0x41; 32])
             .expect("valid scalar")
@@ -233,29 +234,38 @@ mod tests {
     }
 
     #[test]
-    fn an_idempotency_key_outside_the_transport_alphabet_is_refused() {
+    fn a_post_the_transport_would_reject_never_leaves_the_produce_site() {
         let hub = InMemoryMailboxHub::default();
         let recip = recipient();
+        let identity = recipient_identity();
         let poster = hub.mailbox_for(b"poster");
+
+        let post = |payload: &[u8], idempotency_key: &str| {
+            block_on(post_sealed(
+                &poster,
+                &recip.public(),
+                &identity,
+                &[0x55; 32],
+                V,
+                &sender(),
+                payload,
+                idempotency_key,
+            ))
+        };
 
         for illegal in ["grant:abc", "", &"k".repeat(129), "a b", "a/b", "é"] {
             assert!(
-                block_on(post_sealed(
-                    &poster,
-                    &recip.public(),
-                    &recipient_identity(),
-                    &[0x55; 32],
-                    V,
-                    &sender(),
-                    b"p",
-                    illegal,
-                ))
-                .is_err(),
+                post(b"p", illegal).is_err(),
                 "{illegal:?} must not reach the transport"
             );
         }
         assert!(
-            block_on(hub.mailbox_for(&recipient_identity().to_sec1()).poll())
+            post(&vec![0u8; MAX_SEALED_BYTES], "idem").is_err(),
+            "a payload sealing past the transport bound must not be posted"
+        );
+
+        assert!(
+            block_on(hub.mailbox_for(&identity.to_sec1()).poll())
                 .unwrap()
                 .is_empty(),
             "a refused post delivers nothing"

--- a/crates/engine/src/mailbox/mod.rs
+++ b/crates/engine/src/mailbox/mod.rs
@@ -25,7 +25,18 @@ use cipherbox_core::payload::{open_mailbox_payload, seal_mailbox_payload};
 use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
 use cipherbox_core::suite::x25519::{X25519Public, X25519Secret};
 
-use crate::seams::{Mailbox, SeamResult};
+use crate::seams::{Mailbox, SeamError, SeamResult};
+
+/// The transport's idempotency-key alphabet and bound (RFC 3986 unreserved,
+/// 1-128), enforced here on the produce side because the transport hard-rejects
+/// anything else (blueprint/api.md "Mailbox").
+fn idempotency_key_is_legal(key: &str) -> bool {
+    !key.is_empty()
+        && key.len() <= 128
+        && key
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'~' | b'-'))
+}
 
 /// An opened, sender-authenticated mailbox item: the transport id needed to
 /// [`ack`], the verified sender identity to anchor against a contact, and the
@@ -43,25 +54,33 @@ pub struct VerifiedMailboxItem {
 }
 
 /// Seal `payload` to `recipient_enc_pub` (sender-signed inside the seal) and
-/// post it to `recipient_address`'s inbox with a sender-supplied idempotency
+/// post it to `recipient_identity`'s inbox with a sender-supplied idempotency
 /// key. `ephemeral_scalar` is injected, fresh-per-call HPKE entropy (reuse under
 /// one recipient is a catastrophic break — the caller sources it from the
 /// entropy input, never a clock or a constant).
 ///
-/// `recipient_address` is the opaque pubkey the [`Mailbox`] seam routes on; in
-/// v2.0 that is the recipient's encryption-subkey public bytes, i.e. the same
-/// key `payload` is sealed to.
+/// Routing and sealing use *different* keys: the [`Mailbox`] seam addresses on
+/// the recipient's secp256k1 **identity** key, while the seal targets their
+/// X25519 encryption subkey. Taking the identity as an [`EcdsaVerifier`] makes
+/// the address a valid compressed SEC1 point by construction; the idempotency
+/// key is charset-checked, so no post leaves here in a shape the transport
+/// rejects.
 #[allow(clippy::too_many_arguments)]
 pub async fn post_sealed<M: Mailbox>(
     mailbox: &M,
     recipient_enc_pub: &X25519Public,
-    recipient_address: &[u8],
+    recipient_identity: &EcdsaVerifier,
     ephemeral_scalar: &[u8; 32],
     v: u64,
     sender_signer: &EcdsaSigner,
     payload: &[u8],
     idempotency_key: &str,
 ) -> SeamResult<()> {
+    if !idempotency_key_is_legal(idempotency_key) {
+        return Err(SeamError::new(
+            "idempotency key must be 1-128 unreserved characters",
+        ));
+    }
     let sealed = seal_mailbox_payload(
         recipient_enc_pub,
         ephemeral_scalar,
@@ -70,7 +89,7 @@ pub async fn post_sealed<M: Mailbox>(
         payload,
     );
     mailbox
-        .post(recipient_address, &sealed, idempotency_key)
+        .post(&recipient_identity.to_sec1(), &sealed, idempotency_key)
         .await
 }
 
@@ -119,18 +138,25 @@ mod tests {
         X25519Secret::from_scalar([0x40; 32])
     }
 
+    /// The recipient's secp256k1 identity — the mailbox routing address.
+    fn recipient_identity() -> EcdsaVerifier {
+        EcdsaSigner::from_scalar(&[0x41; 32])
+            .expect("valid scalar")
+            .verifying_key()
+    }
+
     #[test]
     fn post_then_poll_round_trips_a_verified_item() {
         let hub = InMemoryMailboxHub::default();
         let recip = recipient();
-        let address = recip.public().to_bytes();
+        let address = recipient_identity().to_sec1();
         let sender_box = hub.mailbox_for(b"sender-inbox");
         let recip_box = hub.mailbox_for(&address);
 
         block_on(post_sealed(
             &sender_box,
             &recip.public(),
-            &address,
+            &recipient_identity(),
             &[0x51; 32],
             V,
             &sender(),
@@ -149,7 +175,7 @@ mod tests {
     fn unauthenticated_items_are_dropped_before_resolve() {
         let hub = InMemoryMailboxHub::default();
         let recip = recipient();
-        let address = recip.public().to_bytes();
+        let address = recipient_identity().to_sec1();
         let recip_box = hub.mailbox_for(&address);
         let poster = hub.mailbox_for(b"poster");
 
@@ -160,7 +186,7 @@ mod tests {
         block_on(post_sealed(
             &poster,
             &other.public(),
-            &address,
+            &recipient_identity(),
             &[0x52; 32],
             V,
             &sender(),
@@ -174,17 +200,80 @@ mod tests {
     }
 
     #[test]
+    fn routing_addresses_the_identity_key_not_the_seal_target() {
+        let hub = InMemoryMailboxHub::default();
+        let recip = recipient();
+        let poster = hub.mailbox_for(b"poster");
+
+        block_on(post_sealed(
+            &poster,
+            &recip.public(),
+            &recipient_identity(),
+            &[0x54; 32],
+            V,
+            &sender(),
+            b"p",
+            "idem",
+        ))
+        .unwrap();
+
+        assert!(
+            block_on(hub.mailbox_for(&recip.public().to_bytes()).poll())
+                .unwrap()
+                .is_empty(),
+            "the encryption subkey addresses no inbox"
+        );
+        assert_eq!(
+            block_on(hub.mailbox_for(&recipient_identity().to_sec1()).poll())
+                .unwrap()
+                .len(),
+            1,
+            "the identity key is the routing address"
+        );
+    }
+
+    #[test]
+    fn an_idempotency_key_outside_the_transport_alphabet_is_refused() {
+        let hub = InMemoryMailboxHub::default();
+        let recip = recipient();
+        let poster = hub.mailbox_for(b"poster");
+
+        for illegal in ["grant:abc", "", &"k".repeat(129), "a b", "a/b", "é"] {
+            assert!(
+                block_on(post_sealed(
+                    &poster,
+                    &recip.public(),
+                    &recipient_identity(),
+                    &[0x55; 32],
+                    V,
+                    &sender(),
+                    b"p",
+                    illegal,
+                ))
+                .is_err(),
+                "{illegal:?} must not reach the transport"
+            );
+        }
+        assert!(
+            block_on(hub.mailbox_for(&recipient_identity().to_sec1()).poll())
+                .unwrap()
+                .is_empty(),
+            "a refused post delivers nothing"
+        );
+    }
+
+    #[test]
     fn ack_removes_only_after_the_call() {
         let hub = InMemoryMailboxHub::default();
         let recip = recipient();
-        let address = recip.public().to_bytes();
+        let address = recipient_identity().to_sec1();
         let recip_box = hub.mailbox_for(&address);
         let poster = hub.mailbox_for(b"poster");
 
         block_on(post_sealed(
             &poster,
             &recip.public(),
-            &address,
+            &recipient_identity(),
             &[0x53; 32],
             V,
             &sender(),

--- a/crates/engine/src/seams/mailbox.rs
+++ b/crates/engine/src/seams/mailbox.rs
@@ -24,6 +24,11 @@ pub struct MailboxItem {
 ///   ack deletes, and acking is idempotent.
 /// - **Idempotent post**: re-posting with an already-seen idempotency key
 ///   for the same recipient creates no second item.
+/// - **Wire shape**: `recipient_public_key` is the recipient's compressed SEC1
+///   secp256k1 **identity** key (33 bytes) — the account the transport resolves
+///   an inbox from, never the X25519 subkey the payload is sealed to — and
+///   `idempotency_key` is 1-128 RFC 3986 unreserved characters
+///   (blueprint/api.md "Mailbox").
 ///
 /// v2.0 rides the API mailbox via the engine's own API client on both
 /// platforms; a decentralized inbox stays swappable behind this trait

--- a/crates/engine/src/seams/mailbox.rs
+++ b/crates/engine/src/seams/mailbox.rs
@@ -26,9 +26,10 @@ pub struct MailboxItem {
 ///   for the same recipient creates no second item.
 /// - **Wire shape**: `recipient_public_key` is the recipient's compressed SEC1
 ///   secp256k1 **identity** key (33 bytes) — the account the transport resolves
-///   an inbox from, never the X25519 subkey the payload is sealed to — and
-///   `idempotency_key` is 1-128 RFC 3986 unreserved characters
-///   (blueprint/api.md "Mailbox").
+///   an inbox from, never the X25519 subkey the payload is sealed to
+///   (blueprint/api.md "Mailbox"). `sealed_payload` is at most 8 KiB and
+///   `idempotency_key` is 1-128 RFC 3986 unreserved characters, both as the
+///   API's `PostMessageDto` fixes them.
 ///
 /// v2.0 rides the API mailbox via the engine's own API client on both
 /// platforms; a decentralized inbox stays swappable behind this trait

--- a/crates/engine/tests/grants_mailbox.rs
+++ b/crates/engine/tests/grants_mailbox.rs
@@ -59,8 +59,6 @@ struct GrantFixture {
     owner_identity: EcdsaSigner,
     owner_identity_pub: EcdsaVerifier,
     recipient_enc: X25519Secret,
-    /// The recipient's secp256k1 identity: the mailbox routing address (the
-    /// enc subkey is only the seal target).
     recipient_identity: EcdsaVerifier,
     scope_id: [u8; 16],
     scope_seed: [u8; 32],

--- a/crates/engine/tests/grants_mailbox.rs
+++ b/crates/engine/tests/grants_mailbox.rs
@@ -59,6 +59,9 @@ struct GrantFixture {
     owner_identity: EcdsaSigner,
     owner_identity_pub: EcdsaVerifier,
     recipient_enc: X25519Secret,
+    /// The recipient's secp256k1 identity: the mailbox routing address (the
+    /// enc subkey is only the seal target).
+    recipient_identity: EcdsaVerifier,
     scope_id: [u8; 16],
     scope_seed: [u8; 32],
     epoch: u64,
@@ -83,6 +86,9 @@ impl GrantFixture {
         let owner_pseudonym = Ed25519Signer::from_seed([0x22; 32]);
         let owner_enc = X25519Secret::from_scalar([0x33; 32]);
         let recipient_enc = X25519Secret::from_scalar([0x44; 32]);
+        let recipient_identity = EcdsaSigner::from_scalar(&[0x45; 32])
+            .expect("valid scalar")
+            .verifying_key();
 
         let scope_id = [0x55; 16];
         let root_id = [0x55; 16];
@@ -228,6 +234,7 @@ impl GrantFixture {
             owner_identity,
             owner_identity_pub,
             recipient_enc,
+            recipient_identity,
             scope_id,
             scope_seed,
             epoch,
@@ -359,14 +366,14 @@ impl GrantFixture {
 fn two_instance_share_accept_end_to_end() {
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient_address = fx.recipient_enc.public().to_bytes();
+    let recipient_address = fx.recipient_identity.to_sec1();
     let owner_device = world.device(b"owner-inbox");
     let recipient_device = world.device(&recipient_address);
 
     block_on(post_sealed(
         &owner_device.mailbox,
         &fx.recipient_enc.public(),
-        &recipient_address,
+        &fx.recipient_identity,
         &EPH_MAILBOX,
         V,
         &fx.owner_identity,
@@ -455,7 +462,7 @@ fn two_instance_share_accept_end_to_end() {
     block_on(post_sealed(
         &owner_device.mailbox,
         &fx.recipient_enc.public(),
-        &recipient_address,
+        &fx.recipient_identity,
         &EPH_MAILBOX,
         V,
         &fx.owner_identity,
@@ -496,14 +503,14 @@ fn two_instance_share_accept_end_to_end() {
 fn uncommitted_tag_is_rejected_before_the_gate() {
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient_address = fx.recipient_enc.public().to_bytes();
+    let recipient_address = fx.recipient_identity.to_sec1();
     let recipient_device = world.device(&recipient_address);
     let poster = world.device(b"owner-inbox");
 
     block_on(post_sealed(
         &poster.mailbox,
         &fx.recipient_enc.public(),
-        &recipient_address,
+        &fx.recipient_identity,
         &EPH_MAILBOX,
         V,
         &fx.owner_identity,
@@ -564,7 +571,7 @@ fn uncommitted_tag_is_rejected_before_the_gate() {
 fn unauthenticated_sender_is_dropped_and_wrong_contact_is_rejected() {
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient_address = fx.recipient_enc.public().to_bytes();
+    let recipient_address = fx.recipient_identity.to_sec1();
     let recipient_device = world.device(&recipient_address);
     let poster = world.device(b"poster");
 
@@ -583,7 +590,7 @@ fn unauthenticated_sender_is_dropped_and_wrong_contact_is_rejected() {
     block_on(post_sealed(
         &poster.mailbox,
         &fx.recipient_enc.public(),
-        &recipient_address,
+        &fx.recipient_identity,
         &EPH_MAILBOX,
         V,
         &attacker,
@@ -630,14 +637,14 @@ fn unauthenticated_sender_is_dropped_and_wrong_contact_is_rejected() {
 fn a_failed_gate_never_acks_the_item() {
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient_address = fx.recipient_enc.public().to_bytes();
+    let recipient_address = fx.recipient_identity.to_sec1();
     let recipient_device = world.device(&recipient_address);
     let poster = world.device(b"owner-inbox");
 
     block_on(post_sealed(
         &poster.mailbox,
         &fx.recipient_enc.public(),
-        &recipient_address,
+        &fx.recipient_identity,
         &EPH_MAILBOX,
         V,
         &fx.owner_identity,
@@ -698,7 +705,7 @@ fn a_failed_gate_never_acks_the_item() {
 fn a_failed_persist_never_acks_the_item() {
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient = world.device(&fx.recipient_enc.public().to_bytes());
+    let recipient = world.device(&fx.recipient_identity.to_sec1());
     let poster = world.device(b"owner-inbox");
     let item = deliver_pointer(
         &fx,
@@ -746,7 +753,7 @@ fn a_failed_persist_never_acks_the_item() {
 fn a_persist_failure_leaves_the_floor_unadvanced_and_redelivery_recovers() {
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient = world.device(&fx.recipient_enc.public().to_bytes());
+    let recipient = world.device(&fx.recipient_identity.to_sec1());
     let poster = world.device(b"owner-inbox");
     let item = deliver_pointer(
         &fx,
@@ -836,7 +843,7 @@ fn a_persist_failure_leaves_the_floor_unadvanced_and_redelivery_recovers() {
 fn a_failed_ack_after_commit_recovers_via_idempotent_reack() {
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient = world.device(&fx.recipient_enc.public().to_bytes());
+    let recipient = world.device(&fx.recipient_identity.to_sec1());
     let poster = world.device(b"owner-inbox");
     let item = deliver_pointer(
         &fx,
@@ -932,7 +939,7 @@ fn a_failed_ack_after_commit_recovers_via_idempotent_reack() {
 fn a_sequence_replay_for_an_unheld_scope_stays_rejected() {
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient = world.device(&fx.recipient_enc.public().to_bytes());
+    let recipient = world.device(&fx.recipient_identity.to_sec1());
     let poster = world.device(b"owner-inbox");
     let item = deliver_pointer(
         &fx,
@@ -989,7 +996,7 @@ fn reaccept_self_heals_changed_permission_and_rotated_pointer_key() {
 
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient_address = fx.recipient_enc.public().to_bytes();
+    let recipient_address = fx.recipient_identity.to_sec1();
     let recipient = world.device(&recipient_address);
     let poster = world.device(b"owner-inbox");
     let contact = import_contact(&fx.owner_contact).unwrap();
@@ -1036,7 +1043,7 @@ fn reaccept_self_heals_changed_permission_and_rotated_pointer_key() {
     block_on(post_sealed(
         &poster.mailbox,
         &fx.recipient_enc.public(),
-        &recipient_address,
+        &fx.recipient_identity,
         &EPH_MAILBOX,
         V,
         &fx.owner_identity,
@@ -1103,11 +1110,10 @@ fn deliver_pointer(
     signer: &EcdsaSigner,
     pointer: &SharePointer,
 ) -> VerifiedMailboxItem {
-    let recipient_address = fx.recipient_enc.public().to_bytes();
     block_on(post_sealed(
         &poster.mailbox,
         &fx.recipient_enc.public(),
-        &recipient_address,
+        &fx.recipient_identity,
         &EPH_MAILBOX,
         V,
         signer,
@@ -1138,7 +1144,7 @@ fn inbox_len(fx: &GrantFixture, recipient: &FakeDevice) -> usize {
 fn pointer_sharer_mismatch_is_rejected_and_unacked() {
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient = world.device(&fx.recipient_enc.public().to_bytes());
+    let recipient = world.device(&fx.recipient_identity.to_sec1());
     let poster = world.device(b"owner-inbox");
 
     let mut pointer = fx.share_pointer();
@@ -1172,7 +1178,7 @@ fn pointer_sharer_mismatch_is_rejected_and_unacked() {
 fn tampered_commitment_is_rejected_at_the_gate_and_unacked() {
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient = world.device(&fx.recipient_enc.public().to_bytes());
+    let recipient = world.device(&fx.recipient_identity.to_sec1());
     let poster = world.device(b"owner-inbox");
     let item = deliver_pointer(
         &fx,
@@ -1214,7 +1220,7 @@ fn tampered_commitment_is_rejected_at_the_gate_and_unacked() {
 fn no_blob_at_tag_is_rejected_and_unacked() {
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient = world.device(&fx.recipient_enc.public().to_bytes());
+    let recipient = world.device(&fx.recipient_identity.to_sec1());
     let poster = world.device(b"owner-inbox");
     let item = deliver_pointer(
         &fx,
@@ -1253,7 +1259,7 @@ fn no_blob_at_tag_is_rejected_and_unacked() {
 fn tampered_grant_blob_fails_open_and_is_unacked() {
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient = world.device(&fx.recipient_enc.public().to_bytes());
+    let recipient = world.device(&fx.recipient_identity.to_sec1());
     let poster = world.device(b"owner-inbox");
     let item = deliver_pointer(
         &fx,
@@ -1291,7 +1297,7 @@ fn tampered_grant_blob_fails_open_and_is_unacked() {
 fn resolved_name_mismatch_is_rejected_and_unacked() {
     let fx = GrantFixture::new();
     let world = FakeWorld::new();
-    let recipient = world.device(&fx.recipient_enc.public().to_bytes());
+    let recipient = world.device(&fx.recipient_identity.to_sec1());
     let poster = world.device(b"owner-inbox");
     let item = deliver_pointer(
         &fx,


### PR DESCRIPTION
## Problem

Read-grant delivery could not work end to end against a real API. `crates/engine/src/grants/create.rs` minted two mailbox values that `PostMessageDto` rejects, each a 400 on its own:

1. **Wrong routing key.** `recipient_address` was `recipient.enc_pub.to_bytes()` — the recipient's 32-byte X25519 encryption subkey, hexing to 64 characters. `apps/api/src/mailbox/dto/mailbox.dto.ts` requires `^(02|03)[0-9a-fA-F]{64}$|^04[0-9a-fA-F]{128}$`. Even past the DTO, `MailboxService.post` resolves the recipient against `User.publicKey` and `poll` is scoped to the JWT's secp256k1 key, so an X25519-addressed item could never be delivered.
2. **Illegal idempotency key.** `format!("grant:{}", …)` carries a `:`, outside the DTO's `^[A-Za-z0-9._~-]{1,128}$`.

This is engine-side, so it affects the Rust client and the browser client identically. Neither the contract suite nor the WASM conformance kit caught it: both post hand-built fixtures, so `ApiClient::mailbox_post` was gated while the values the real caller hands it were never seen.

## Change

**The correct address is the recipient's secp256k1 identity key**, established from the API rather than the issue text: `blueprint/api.md` "Mailbox" states post targets the recipient identity pubkey (that is what makes the rate-limited existence oracle work and lets account deletion cascade a mailbox purge), `PostMessageDto.recipientPublicKey` is documented and regexed as a hex secp256k1 key, and `IdentityService.normalizePublicKey` runs `secp256k1.Point.fromHex(...).toHex(true)` — so the stored, matched form is **compressed SEC1**, exactly `EcdsaVerifier::to_sec1()`. Branch `v1` agrees: its share delivery addressed the recipient's secp256k1 identity publicKey, never an encryption subkey. The HPKE seal target stays `enc_pub`.

Rather than swap one byte array for another, the fix makes the defect unrepresentable:

- `GrantRecipient::identity_pk` is now an `EcdsaVerifier` (as `Contact::identity_pk()` already returns), so the address is a valid compressed secp256k1 point **by construction** — including the point-on-curve check the API's `Point.fromHex` performs.
- `post_sealed` takes `&EcdsaVerifier` instead of an opaque `&[u8]` address and routes on `.to_sec1()`. Passing the X25519 subkey no longer compiles.
- `post_sealed` release-active-rejects an idempotency key outside the transport alphabet and a sealed payload past the transport's 8 KiB — the produce-side half of the encode/decode fail-closed symmetry rule (AGENTS.md 8), since the DTO and service hard-reject both.
- The `Mailbox` seam doc states the wire shape once, at its home.

**The idempotency key is now drawn from the injected entropy seam, not derived from the blinded tag.** The issue asked to keep the tag and change only the separator; deriving the value from the DTO instead says otherwise, and the review gates confirmed it. The blinded tag is **public** — `kdf::blinded_tag` says so in its own doc, and `SignedGrantBlob.tag` ships in the clear in every scope root's grant section. The API stores only `sha256(senderPublicKey : idempotencyKey)` precisely so no durable sender→recipient edge exists; a key an observer can recompute from a cached record defeats that and additionally identifies the shared folder. `PostMessageDto` already spells out the requirement the old key missed: *"MUST be a high-entropy per-message **random** value."* Fresh entropy also gives the per-recipient distinctness the tag was originally chosen for, and costs nothing real: `create_read_grant` already draws a fresh random `override_seed` per call, so it was never idempotent across retries anyway. `CreateGrantError::Mailbox` is re-documented accordingly — delivery is at-least-once and the accept flow is the dedup point.

The diff stays local to the delivery values and their types so a later #635 rebase is cheap; the grant-creation flow is untouched.

## Tests

**The real-caller-path gap is the substantive half of this fix.** `crates/contract/tests/contract.rs` now has `a_read_grant_delivers_its_share_pointer_through_the_live_mailbox`, which drives the actual `create_read_grant` primitive — not a fixture — over an `ApiMailbox` seam built on the engine's real `ApiClient` against the live API. Two real accounts are minted through test-login; the recipient's account `publicKey` is parsed into the `GrantRecipient`, so the address under test is the one the API actually stores. The grant path picks its own address and idempotency key, posts them to the served route, and the recipient polls the item back through `poll_verified` and decodes the `SharePointer`. That binds both values to the served DTO permanently.

It runs in the existing merge-blocking **Contract Suite** CI job (`contract-suite` in `.github/workflows/ci.yml`), which already stands up Postgres, Kubo, the mock `/routing/v1` store and the real NestJS API. No new gate was needed.

Revert-red on that test, all three confirmed against a live local API:

| Reverted | Result |
| --- | --- |
| routing back to `enc_pub` | `400: recipientPublicKey must be a hex secp256k1 public key` |
| idempotency key back to `grant:<hex>` | engine guard: `idempotency key must be 1-128 unreserved characters` |
| idempotency key back to `grant:<hex>` and the guard disabled | `400: idempotencyKey must be 1-128 url-safe characters` |

The third confirms the produce-side guard mirrors a real decode-side reject rather than inventing a rule.

Engine-level cover alongside it:

- `delivery_is_addressed_and_keyed_in_the_shape_the_transport_accepts` — the posted address is the recipient identity key and the key is transport-legal.
- `the_idempotency_key_is_entropy_drawn_and_carries_no_public_material` — two entropy seeds give two keys, and the public blinded tag never appears in one.
- `a_post_the_transport_would_reject_never_leaves_the_produce_site` — six illegal keys plus an over-bound payload all fail before the seam, and nothing is delivered.
- `routing_addresses_the_identity_key_not_the_seal_target` — the enc subkey addresses no inbox.

## Verification

All exit 0:

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets`
- `cargo test --workspace --exclude cipherbox-desktop --exclude cipherbox-contract`
- `cargo test -p cipherbox-contract` against a live local stack — 19/19, including the new leg
- `pnpm -r --if-present run typecheck`, `pnpm -r --if-present run test`, `eslint .`

## Review gates

`/security-review` (no findings), `/crypto-privacy-review`, and `/simplify` all ran on `git diff main...HEAD`. The public-blinded-tag finding above was the material one; the 8 KiB bound, the `identity_pk` doc overclaim, the wrong blueprint citation, the hex duplication, and several comment-discipline items were folded in. Two were declined with evidence:

- **Bind `identity_pk` and `enc_pub` structurally by taking `&Contact`.** Correct in principle, but not buildable here: the contract suite's recipient identity comes from a server-derived test-login account whose scalar the suite never holds, so it cannot mint a valid binding signature and could not construct a `Contact`. That would cost the live-API test this PR exists to add. There is no production `GrantRecipient` producer yet; the field doc now points at `Contact` as the source.
- **Deriving a secret per-recipient idempotency key from a new KDF edge.** Would need a frozen KDF-catalog addition, which `blueprint/core.md` puts out of scope here; fresh entropy meets the DTO's stated requirement without one.

Closes #954


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added encrypted grant delivery through recipient identity-based mailbox routing.
  * Added hexadecimal encoding and decoding utilities for binary data interoperability.

* **Bug Fixes**
  * Improved mailbox validation for recipient addresses, message sizes, and idempotency keys.
  * Prevented oversized or invalid messages from being submitted.
  * Improved grant delivery reliability by separating recipient identity and encryption keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->