### PR TITLE
fix: harden the desktop floor store read-modify-write and intent length prefix

### DIFF
--- a/crates/desktop-seams/src/floor_store.rs
+++ b/crates/desktop-seams/src/floor_store.rs
@@ -35,10 +35,9 @@ pub struct FileFloorStore {
     epoch_dir: PathBuf,
     seq_dir: PathBuf,
     intent_dir: PathBuf,
-    /// Serializes the read-modify-write in [`Self::raise_floor`]. Concurrent
-    /// raises on one key could otherwise interleave read/read/write-high/
-    /// write-low and durably regress the floor — a loss no intent record can
-    /// heal, because both commits succeeded and cleared their own records.
+    /// Serializes the read-modify-write in [`Self::raise_floor`] within this
+    /// handle: interleaved raises can durably regress a floor, and intent
+    /// replay cannot heal that loss (#704).
     write_lock: Mutex<()>,
 }
 
@@ -187,9 +186,8 @@ impl FloorStore for FileFloorStore {
     }
 }
 
-/// The 4-byte little-endian key-length prefix, rejecting a key the prefix
-/// cannot represent. Truncating instead would reframe the record: the decoder
-/// would read a short key and then parse key bytes as the next raise's value.
+/// The 4-byte little-endian key-length prefix. Fails closed on a key the
+/// prefix cannot represent: a truncated length reframes the whole record.
 fn intent_key_len(len: u64) -> SeamResult<[u8; 4]> {
     u32::try_from(len)
         .map(u32::to_le_bytes)
@@ -220,8 +218,8 @@ fn corrupt_intent() -> SeamError {
 }
 
 /// Reads a fixed slice at `start`, failing closed if it runs past the record.
-/// The end offset is checked: `len` comes from the corrupt-controlled length
-/// prefix, so on a 32-bit target it can wrap `usize`.
+/// `len` is corrupt-controlled, so `start + len` can wrap `usize` on a 32-bit
+/// target.
 fn intent_slice(bytes: &[u8], start: usize, len: usize) -> SeamResult<&[u8]> {
     start
         .checked_add(len)
@@ -276,7 +274,6 @@ mod tests {
         );
     }
 
-    /// A record claiming more key bytes than it carries fails closed.
     #[test]
     fn decode_rejects_an_oversized_key_length() {
         let mut bytes = vec![INTENT_TAG_EPOCH];
@@ -284,28 +281,19 @@ mod tests {
         assert!(decode_intent(&bytes).is_err());
     }
 
-    /// An end offset past `usize` fails closed rather than wrapping into an
-    /// in-range slice — the length is corrupt-controlled, and on a 32-bit
-    /// target it can exceed what the start offset leaves.
     #[test]
     fn intent_slice_fails_closed_on_an_overflowing_end() {
-        assert!(intent_slice(b"abc", usize::MAX, 1).is_err());
         assert!(intent_slice(b"abc", 1, usize::MAX).is_err());
     }
 
-    /// Encode fails closed on a key the 4-byte prefix cannot represent instead
-    /// of truncating it — a truncated prefix reframes the record and the
-    /// decoder would parse key bytes as the next raise.
     #[test]
     fn encode_rejects_a_key_longer_than_its_length_prefix() {
         assert!(intent_key_len(u32::MAX as u64).is_ok());
         assert!(intent_key_len(u32::MAX as u64 + 1).is_err());
     }
 
-    /// Two writers racing on one key cannot interleave read/read/write-high/
-    /// write-low: whichever lands second re-reads the raised floor and keeps
-    /// it. A durable regression here is unhealable — both commits return `Ok`
-    /// and clear their own intent records, leaving nothing for replay.
+    /// The #704 regression: with the raises unserialized, the low one can read
+    /// the pre-raise floor and land last.
     #[test]
     fn concurrent_raises_never_regress_a_floor() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/desktop-seams/src/floor_store.rs
+++ b/crates/desktop-seams/src/floor_store.rs
@@ -2,6 +2,7 @@
 //! write-ahead intent record for cross-key atomic batch commits.
 
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use cipherbox_engine::seams::{FloorNamespace, FloorRaise, FloorStore, SeamError, SeamResult};
 
@@ -34,6 +35,11 @@ pub struct FileFloorStore {
     epoch_dir: PathBuf,
     seq_dir: PathBuf,
     intent_dir: PathBuf,
+    /// Serializes the read-modify-write in [`Self::raise_floor`]. Concurrent
+    /// raises on one key could otherwise interleave read/read/write-high/
+    /// write-low and durably regress the floor — a loss no intent record can
+    /// heal, because both commits succeeded and cleared their own records.
+    write_lock: Mutex<()>,
 }
 
 /// Intent-record tag for an epoch-namespace raise.
@@ -58,6 +64,7 @@ impl FileFloorStore {
             epoch_dir,
             seq_dir,
             intent_dir,
+            write_lock: Mutex::new(()),
         };
         store.replay_intents()?;
         Ok(store)
@@ -79,6 +86,10 @@ impl FileFloorStore {
     }
 
     fn raise_floor(&self, dir: &Path, key: &[u8], value: u64, op: &str) -> SeamResult<u64> {
+        let _guard = self
+            .write_lock
+            .lock()
+            .map_err(|_| SeamError::new(format!("{op}: floor write lock poisoned")))?;
         let current = self.read_floor(dir, key, op)?;
         let raised = current.map_or(value, |stored| stored.max(value));
         // Monotonic-max: only touch the platter when the floor actually
@@ -167,7 +178,7 @@ impl FloorStore for FileFloorStore {
             return Ok(Vec::new());
         }
         let intent_path = self.intent_dir.join(unique_component());
-        atomic_write(&intent_path, &encode_intent(raises))
+        atomic_write(&intent_path, &encode_intent(raises)?)
             .map_err(|err| seam_err("floor_store write intent", &err))?;
         let resulting = self.apply_raises(raises, "floor_store commit_floors")?;
         remove_file_durable(&intent_path)
@@ -176,10 +187,19 @@ impl FloorStore for FileFloorStore {
     }
 }
 
+/// The 4-byte little-endian key-length prefix, rejecting a key the prefix
+/// cannot represent. Truncating instead would reframe the record: the decoder
+/// would read a short key and then parse key bytes as the next raise's value.
+fn intent_key_len(len: u64) -> SeamResult<[u8; 4]> {
+    u32::try_from(len)
+        .map(u32::to_le_bytes)
+        .map_err(|_| SeamError::new("floor_store: intent key exceeds its 4-byte length prefix"))
+}
+
 /// Serializes a batch into the intent record: for each raise, a 1-byte
 /// namespace tag, a 4-byte little-endian key length, the key bytes, then the
 /// 8-byte little-endian value.
-fn encode_intent(raises: &[FloorRaise]) -> Vec<u8> {
+fn encode_intent(raises: &[FloorRaise]) -> SeamResult<Vec<u8>> {
     let mut out = Vec::new();
     for raise in raises {
         let tag = match raise.namespace {
@@ -187,11 +207,11 @@ fn encode_intent(raises: &[FloorRaise]) -> Vec<u8> {
             FloorNamespace::Sequence => INTENT_TAG_SEQUENCE,
         };
         out.push(tag);
-        out.extend_from_slice(&(raise.key.len() as u32).to_le_bytes());
+        out.extend_from_slice(&intent_key_len(raise.key.len() as u64)?);
         out.extend_from_slice(&raise.key);
         out.extend_from_slice(&raise.value.to_le_bytes());
     }
-    out
+    Ok(out)
 }
 
 /// The corruption error surfaced by [`decode_intent`].
@@ -200,8 +220,13 @@ fn corrupt_intent() -> SeamError {
 }
 
 /// Reads a fixed slice at `start`, failing closed if it runs past the record.
+/// The end offset is checked: `len` comes from the corrupt-controlled length
+/// prefix, so on a 32-bit target it can wrap `usize`.
 fn intent_slice(bytes: &[u8], start: usize, len: usize) -> SeamResult<&[u8]> {
-    bytes.get(start..start + len).ok_or_else(corrupt_intent)
+    start
+        .checked_add(len)
+        .and_then(|end| bytes.get(start..end))
+        .ok_or_else(corrupt_intent)
 }
 
 /// Parses an intent record. The record is written whole through the
@@ -245,12 +270,73 @@ mod tests {
             FloorRaise::sequence(b"k51-name".to_vec(), 42),
             FloorRaise::epoch(Vec::new(), 1),
         ];
-        assert_eq!(decode_intent(&encode_intent(&raises)).unwrap(), raises);
+        assert_eq!(
+            decode_intent(&encode_intent(&raises).unwrap()).unwrap(),
+            raises
+        );
+    }
+
+    /// A record claiming more key bytes than it carries fails closed.
+    #[test]
+    fn decode_rejects_an_oversized_key_length() {
+        let mut bytes = vec![INTENT_TAG_EPOCH];
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes());
+        assert!(decode_intent(&bytes).is_err());
+    }
+
+    /// An end offset past `usize` fails closed rather than wrapping into an
+    /// in-range slice — the length is corrupt-controlled, and on a 32-bit
+    /// target it can exceed what the start offset leaves.
+    #[test]
+    fn intent_slice_fails_closed_on_an_overflowing_end() {
+        assert!(intent_slice(b"abc", usize::MAX, 1).is_err());
+        assert!(intent_slice(b"abc", 1, usize::MAX).is_err());
+    }
+
+    /// Encode fails closed on a key the 4-byte prefix cannot represent instead
+    /// of truncating it — a truncated prefix reframes the record and the
+    /// decoder would parse key bytes as the next raise.
+    #[test]
+    fn encode_rejects_a_key_longer_than_its_length_prefix() {
+        assert!(intent_key_len(u32::MAX as u64).is_ok());
+        assert!(intent_key_len(u32::MAX as u64 + 1).is_err());
+    }
+
+    /// Two writers racing on one key cannot interleave read/read/write-high/
+    /// write-low: whichever lands second re-reads the raised floor and keeps
+    /// it. A durable regression here is unhealable — both commits return `Ok`
+    /// and clear their own intent records, leaving nothing for replay.
+    #[test]
+    fn concurrent_raises_never_regress_a_floor() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileFloorStore::open(dir.path().join("floors")).unwrap();
+
+        for key in 0u64..32 {
+            let key = key.to_le_bytes();
+            let barrier = std::sync::Barrier::new(2);
+            std::thread::scope(|scope| {
+                let racers = [2u64, 1].map(|value| {
+                    let (store, barrier) = (&store, &barrier);
+                    scope.spawn(move || {
+                        barrier.wait();
+                        block_on(store.raise_epoch_floor(&key, value)).unwrap()
+                    })
+                });
+                for racer in racers {
+                    racer.join().unwrap();
+                }
+            });
+            assert_eq!(
+                block_on(store.epoch_floor(&key)).unwrap(),
+                Some(2),
+                "the low raise must never land on the platter after the high one"
+            );
+        }
     }
 
     #[test]
     fn decode_rejects_a_truncated_intent() {
-        let bytes = encode_intent(&[FloorRaise::epoch(b"scope".to_vec(), 7)]);
+        let bytes = encode_intent(&[FloorRaise::epoch(b"scope".to_vec(), 7)]).unwrap();
         assert!(decode_intent(&bytes[..bytes.len() - 1]).is_err());
     }
 
@@ -276,7 +362,7 @@ mod tests {
         ];
         atomic_write(
             &path.join("intent").join("crashed-commit"),
-            &encode_intent(&interrupted),
+            &encode_intent(&interrupted).unwrap(),
         )
         .unwrap();
 
@@ -319,8 +405,16 @@ mod tests {
             FloorRaise::sequence(b"name-b".to_vec(), 9),
         ];
         let intent_dir = path.join("intent");
-        atomic_write(&intent_dir.join("commit-1"), &encode_intent(&first)).unwrap();
-        atomic_write(&intent_dir.join("commit-2"), &encode_intent(&second)).unwrap();
+        atomic_write(
+            &intent_dir.join("commit-1"),
+            &encode_intent(&first).unwrap(),
+        )
+        .unwrap();
+        atomic_write(
+            &intent_dir.join("commit-2"),
+            &encode_intent(&second).unwrap(),
+        )
+        .unwrap();
 
         block_on(async {
             let reopened = FileFloorStore::open(&path).unwrap();
@@ -347,7 +441,7 @@ mod tests {
         FileFloorStore::open(&path).unwrap();
 
         // A valid record truncated by one byte: structurally corrupt, not torn.
-        let good = encode_intent(&[FloorRaise::epoch(b"scope".to_vec(), 1)]);
+        let good = encode_intent(&[FloorRaise::epoch(b"scope".to_vec(), 1)]).unwrap();
         atomic_write(
             &path.join("intent").join("corrupt"),
             &good[..good.len() - 1],


### PR DESCRIPTION
Closes #704

Retro `/security-review` hardening on `crates/desktop-seams/src/floor_store.rs`. Both items are LOW / defence-in-depth. I re-verified the reachability claims rather than taking them on trust — both hold — so this makes the store's monotonic-floor invariant structural rather than incidental, without changing observable behaviour.

## 1 — Unserialized read-modify-write in `raise_floor`

`raise_floor` read the stored floor, took `max`, then wrote, with nothing serializing the two halves. Two concurrent raises on one key could interleave read/read/write-high/write-low and durably regress the floor. That loss is unhealable: both commits return `Ok` and clear their own intent records, so replay has nothing left to roll forward.

Fix: a `Mutex<()>` on `FileFloorStore`, held across the whole RMW in `raise_floor` — `floor_store.rs:38-42` and `:88-92`. A poisoned lock fails closed with a `SeamError`.

Per-key serialization rather than per-batch is deliberate and sufficient. Monotonic-max is a per-key invariant, and the seam contract makes the desktop store roll-forward rather than transactional across keys, so an interleave between the keys of two batches heals idempotently on replay. `apply_raises` and `replay_intents` inherit the lock through `raise_floor`; there is one acquisition site, so no nesting and no deadlock edge. The guard never spans an `.await` — `raise_floor` is a sync fn.

Scope boundary: the lock is in-process, per handle. Two `FileFloorStore` handles over the same directory, or two processes, are not serialized by it. The engine constructs one store per session, and cross-process file locking is well beyond this issue.

## 2 — 32-bit intent overflow in `intent_slice`

`intent_slice` computed `start + len` on a `len` taken from the corrupt-controlled 4-byte length prefix, which can wrap `usize` on a 32-bit target and panic in debug rather than returning the clean `corrupt_intent()` error. Fix: `start.checked_add(len).and_then(|end| bytes.get(start..end))` — `floor_store.rs:223-231`.

While there, the encode side had the mirroring gap that AGENTS.md rule 8 requires closing: `encode_intent` wrote `raise.key.len() as u32`, a silently truncating cast. A truncated prefix does not merely produce a record the decoder rejects — it reframes the record, so the decoder reads a short key and then parses key bytes as the next raise's value. `encode_intent` now returns `SeamResult<Vec<u8>>` and rejects through `intent_key_len` — `floor_store.rs:190-197`. Release-active `Err`, no `debug_assert!`.

## Reachability — verified, neither is live

- Item 1: `Scheduler` spawns via `tokio::task::spawn_local` (`scheduler.rs:19`, `:49`), which requires a `LocalSet` on a current-thread runtime, so engine tasks are single-threaded. `raise_floor` is a sync fn with no `.await` between read and write, so a task cannot yield mid-RMW even under a multi-threaded executor. `FileFloorStore` is also not yet wired into a shell — the only in-tree constructions are the `lib.rs` re-export and the conformance suite.
- Item 2: 32-bit is not a supported desktop target, and even the panic is fail-closed.
- The encode-side truncation needs a 4 GiB key; keys are scope ids and `ipnsName` bytes.

## Tests

- `concurrent_raises_never_regress_a_floor` — 32 keys, two barrier-synced threads per key raising 2 and 1. Negative control: with the mutex removed this fails immediately with a durable `Some(1)` where `Some(2)` is required, reproducing the exact regression the issue describes. It passes deterministically with the fix.
- `intent_slice_fails_closed_on_an_overflowing_end` — the `usize` boundary, on any pointer width.
- `decode_rejects_an_oversized_key_length` — a record claiming `u32::MAX` key bytes.
- `encode_rejects_a_key_longer_than_its_length_prefix` — the `u32::MAX` encode boundary. `intent_key_len` takes a `u64` precisely so this is testable without a 4 GiB allocation, and so the test is pointer-width independent.

All four are ordinary `#[test]`s, so they fire in a release build.

## Gates

All exit 0, rebased onto `main` at 20d03b873, with a per-worktree `CARGO_TARGET_DIR`:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo test -p cipherbox-engine -p cipherbox-core -p cipherbox-desktop-seams` — all green; `cipherbox-desktop-seams` 19 lib + 13 conformance passed
- `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown`

## Parallel work

Confined to `floor_store.rs`. It does not touch `fs_util.rs`, `staging_store.rs`, or `tests/conformance.rs`, so it does not collide with #952.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent floor updates from overwriting newer persisted values.
  * Added validation for malformed or oversized intent data.
  * Improved handling of overflow conditions by failing safely instead of attempting invalid reads.

* **Tests**
  * Added coverage for concurrent updates, oversized lengths, and arithmetic overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
