### PR TITLE
fix(web): add CSP and nosniff to the staging web vhost

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -15,8 +15,25 @@ api-staging.cipherbox.cc {
 app-staging.cipherbox.cc {
 	tls /etc/caddy/certs/origin.pem /etc/caddy/certs/origin-key.pem
 	root * /srv/web
-	try_files {path} /index.html
-	file_server
+
+	# 'wasm-unsafe-eval' is required: Chromium blocks all WebAssembly compilation
+	# without it, killing the engine worker and the Core Kit tssLib. default-src is
+	# omitted so login and API calls to third-party origins stay unrestricted.
+	header {
+		Content-Security-Policy "script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+		X-Content-Type-Options nosniff
+	}
+
+	# Fingerprinted assets must 404 when absent; the SPA fallback would otherwise
+	# answer a missing script or wasm module with a 200 text/html index.html.
+	handle /assets/* {
+		file_server
+	}
+
+	handle {
+		try_files {path} /index.html
+		file_server
+	}
 }
 
 :80 {


### PR DESCRIPTION
The engine worker dynamically imports the WASM artifact from a content-hashed `/assets/` URL. That is same-origin by construction but nothing enforced it: the `app-staging.cipherbox.cc` vhost set no `Content-Security-Policy` and no `X-Content-Type-Options`, and `try_files {path} /index.html` answered a missing asset with a `200 text/html`.

## Final header set

```text
Content-Security-Policy: script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'
X-Content-Type-Options: nosniff
```

| Directive | Why |
| --- | --- |
| `script-src 'self' 'wasm-unsafe-eval'` | Pins script and the worker's dynamic `import()` to the origin. `'wasm-unsafe-eval'` is mandatory — see the deviation note below. |
| `worker-src 'self' blob:` | As scoped in the issue. The engine worker is a same-origin module worker. |
| `object-src 'none'` | No `<object>`/`<embed>` anywhere; removes a plugin execution sink. |
| `base-uri 'self'` | An injected `<base>` would repoint every relative `/assets/` URL, which is exactly the same-origin assumption this issue is about. |
| `frame-ancestors 'none'` | Clickjacking. The app is never framed; login is a top-level redirect, so this cannot touch it. |
| `X-Content-Type-Options: nosniff` | As scoped in the issue. |

`default-src` is deliberately **not** set, so `connect-src`, `frame-src`, `style-src`, `img-src` and `font-src` stay unrestricted. Login and API traffic reach third-party origins whose full set cannot be verified in this environment, and `script-src` does not fall back to `default-src` when present — so omitting it costs nothing on the execution surface this issue targets.

## Deviations from the issue's stated scope

### `script-src` gains `'wasm-unsafe-eval'`

The issue specifies bare `script-src 'self'`. That would break the app. Chromium refuses **all** WebAssembly compilation — `instantiateStreaming` included — whenever a `script-src` is present that grants neither `'wasm-unsafe-eval'` nor `'unsafe-eval'`. Two live paths hit it:

- the engine worker, via wasm-bindgen `init` in `packages/client/src/worker/engineWorker.ts`
- `@toruslabs/tss-dkls-lib@4.1.0`, whose `load()` reaches `WebAssembly.instantiate(bytes, imports)` after `atob`-decoding an inlined `data:application/wasm` blob

`'wasm-unsafe-eval'` permits WASM compilation only; it does not enable JS `eval`. `'unsafe-eval'` is **not** added.

### Three additions

`base-uri 'self'` and `frame-ancestors 'none'` are cheap hardening with no interaction with the login or worker paths. `object-src 'none'` was already in scope.

## Runtime-origin audit

Audited `apps/web/src`, `packages/client/src`, `apps/web/index.html`, the Vite config, and the resolved Web3Auth package bytes.

- **No inline scripts or styles.** `index.html` has a single `<script type="module" src>`. No CSS-in-JS library, no `dangerouslySetInnerHTML`, no `innerHTML`. So `script-src 'self'` needs no nonce or hash, and `style-src` needs no `'unsafe-inline'`.
- **No `eval` or `new Function`** in first-party code, and zero hits across the whole resolved auth tree.
- **One worker**, same-origin and static: `new Worker(new URL('./worker/engineWorker.js', import.meta.url), { type: 'module' })`. Not a blob worker.
- **One dynamic `import()`**, of the same-origin hashed `/assets/` wasm-bindgen glue inside that worker.
- **No `blob:` or `data:` URLs** are constructed in first-party code; no service worker is registered.
- **The login is a full-page redirect, not a popup.** `@web3auth/mpc-core-kit@3.5.0` defaults `uxMode` to `REDIRECT`, and the app never overrides it. It returns to `/serviceworker/redirect#state=…`, which the SPA fallback must keep serving — verified below.
- External origins reached at runtime are all `connect-src` or navigation traffic, which this policy does not restrict.

Two follow-ups worth noting, both out of scope here and neither blocking:

- `form-action` must **not** be added later without allowlisting `https://accounts.google.com` and `https://passwordless.web3auth.io`, and a `default-src` must not be added without a full `connect-src` covering the sapphire-devnet nodes over both `https:` and `wss:`.
- `apps/web/vite.config.ts` and `apps/web/src/auth/coreKit.ts` both describe a login *popup*; the resolved SDK uses a redirect. Stale comments only.

## `try_files`

`/assets/*` now routes to a plain `file_server`, so a missing fingerprinted asset returns a real `404` instead of falling through to the SPA shell. Every other path keeps `try_files {path} /index.html`, so real routes and the OAuth redirect landing are unchanged.

## Verification

Ran against the **real** `docker/Caddyfile` in `caddy:2-alpine`, the same image staging uses, with a self-signed origin cert and a fixture web root.

`caddy validate` returns `Valid configuration`. `caddy fmt` reports only the pre-existing unformatted blank line at line 4, which this change leaves alone. `caddy adapt` confirms the header handler is scoped to `app-staging.cipherbox.cc` only, leaving the API vhost untouched.

Live requests:

| Request | Before | After |
| --- | --- | --- |
| `/assets/MISSING-deadbeef.js` | `200` `text/html` | `404` |
| `/assets/MISSING-deadbeef.wasm` | `200` `text/html` | `404` |
| `/assets/nested/dir/missing.js` | `200` `text/html` | `404` |
| `/assets/index-abc123.js` | `200` | `200` `text/javascript` plus both headers |
| `/assets/engine-def456.wasm` | `200` | `200` `application/wasm` plus both headers |
| `/` and `/vault/some/deep/route` | `200` index.html | `200` index.html plus both headers |
| `/serviceworker/redirect` | `200` index.html | `200` index.html plus both headers |
| `/assets/../etc/passwd` | — | normalized, serves index.html, no file escape |

Both headers are present on every response including the JS and WASM assets, which matters because a worker takes its CSP from its own script response.

### Needs human verification on staging

The browser-side behaviour cannot be exercised here — no browser, and the Web3Auth deps are not installed locally. After deploy, on `https://app-staging.cipherbox.cc`:

1. Load the app. In DevTools Network, confirm the document response carries both headers.
2. In Console, confirm there are **no** `Refused to …` CSP violations. Watch specifically for `Refused to compile or instantiate WebAssembly module`, which would mean `'wasm-unsafe-eval'` is not reaching the worker.
3. Confirm the vault loads, i.e. the engine worker booted and the WASM compiled.
4. Run a full login end to end. It is a redirect, not a popup: the tab navigates to Google or the passwordless page and returns to `/serviceworker/redirect#state=…`. Confirm the return leg lands on the app and completes rather than 404ing.
5. In Network, confirm no `/assets/*` request 404s. A 404 there now means a genuinely missing asset rather than a silently served HTML shell.

Rollback if login regresses: revert this commit, or drop the `Content-Security-Policy` line and keep `X-Content-Type-Options` plus the `/assets/*` split, which carry no runtime risk.

One residual risk stated plainly: a transitive Babel-runtime shim in the auth tree could in principle call `new Function` at startup. Scanning the resolved auth packages found zero occurrences, but the built bundle was not produced here. If it fires it surfaces as an explicit console CSP violation at step 2.

### Unrelated pre-existing blocker found while verifying

`VITE_WEB3AUTH_VERIFIER` is in the env contract (`apps/web/src/vite-env.d.ts`) and `createCoreKitSession` throws without it, but `.github/workflows/deploy-staging.yml` never sets it. Staging login will therefore throw at session creation regardless of this change. Whoever runs step 4 needs that fixed first, or the failure will look like a CSP regression. Not touched here.

Closes #888


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added Content Security Policy and `X-Content-Type-Options` headers to the staging web app.
* **Bug Fixes**
  * Updated asset routing to serve files directly while preserving SPA fallback behavior for other paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->