### PR TITLE
fix: state the capped fetch bound honestly and cover the first-chunk overshoot

### DIFF
--- a/crates/desktop-seams/src/http.rs
+++ b/crates/desktop-seams/src/http.rs
@@ -129,7 +129,7 @@ impl Http for ReqwestHttp {
 
         // Reject a body that declares itself over the cap before reading a byte;
         // a missing or lying Content-Length is still bounded by the streaming
-        // cap below, which is the true peak-memory bound (#787).
+        // drain below (#787).
         if let Some(declared) = response.content_length() {
             if declared > max_bytes as u64 {
                 return Err(CappedFetchError::BodyTooLarge {

--- a/crates/desktop-seams/tests/conformance.rs
+++ b/crates/desktop-seams/tests/conformance.rs
@@ -341,7 +341,7 @@ async fn reqwest_http_capped_fetch_rejects_a_chunk_larger_than_the_cap() {
     // Chunked, so no Content-Length pre-check applies and the first chunk the
     // transport hands over already exceeds the cap on its own.
     let error = http
-        .send_capped(stream_request(&server, 1024 * 1024), 16)
+        .send_capped(stream_request(&server, 64 * 1024), 16)
         .await
         .expect_err("an over-cap body must fail closed");
 
@@ -350,7 +350,7 @@ async fn reqwest_http_capped_fetch_rejects_a_chunk_larger_than_the_cap() {
             assert_eq!(limit, 16);
             assert!(observed > limit, "observed {observed} must exceed the cap");
             assert!(
-                observed < 1024 * 1024,
+                observed < 64 * 1024,
                 "the drain must abort at a chunk, not buffer the whole body ({observed} bytes)"
             );
         }

--- a/crates/desktop-seams/tests/conformance.rs
+++ b/crates/desktop-seams/tests/conformance.rs
@@ -15,7 +15,9 @@ use cipherbox_desktop_seams::{
     FileCredentialStore, FileFloorStore, FileSnapshotCache, FileStagingStore, ReqwestHttp,
     ReqwestRecordTransport, TokioScheduler,
 };
-use cipherbox_engine::seams::{CredentialStore, Http, HttpMethod, HttpRequest, StagingStore};
+use cipherbox_engine::seams::{
+    CappedFetchError, CredentialStore, Http, HttpMethod, HttpRequest, StagingStore,
+};
 use cipherbox_engine::testkit::{block_on, conformance};
 
 mod mock_http;
@@ -329,6 +331,54 @@ async fn reqwest_http_returns_non_2xx_as_a_response_not_an_error() {
         .expect("a non-2xx status is a response, never a seam Err");
 
     assert_eq!(response.status, 418);
+}
+
+#[tokio::test]
+async fn reqwest_http_capped_fetch_rejects_a_chunk_larger_than_the_cap() {
+    let server = MockServer::start();
+    let http = ReqwestHttp::new().expect("client builds");
+
+    // Chunked, so no Content-Length pre-check applies and the first chunk the
+    // transport hands over already exceeds the cap on its own.
+    let error = http
+        .send_capped(stream_request(&server, 1024 * 1024), 16)
+        .await
+        .expect_err("an over-cap body must fail closed");
+
+    match error {
+        CappedFetchError::BodyTooLarge { observed, limit } => {
+            assert_eq!(limit, 16);
+            assert!(observed > limit, "observed {observed} must exceed the cap");
+            assert!(
+                observed < 1024 * 1024,
+                "the drain must abort at a chunk, not buffer the whole body ({observed} bytes)"
+            );
+        }
+        other => panic!("expected BodyTooLarge, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn reqwest_http_capped_fetch_admits_a_chunked_body_at_the_cap() {
+    let server = MockServer::start();
+    let http = ReqwestHttp::new().expect("client builds");
+
+    let response = http
+        .send_capped(stream_request(&server, 64), 64)
+        .await
+        .expect("the cap is inclusive");
+
+    assert_eq!(response.status, 200);
+    assert_eq!(response.body, vec![b'x'; 64]);
+}
+
+fn stream_request(server: &MockServer, bytes: usize) -> HttpRequest {
+    HttpRequest {
+        method: HttpMethod::Get,
+        url: format!("{}/stream/{bytes}", server.base_url()),
+        headers: Vec::new(),
+        body: None,
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/desktop-seams/tests/mock_http/mod.rs
+++ b/crates/desktop-seams/tests/mock_http/mod.rs
@@ -10,6 +10,9 @@
 //!   header; records the request for assertions.
 //! - `GET /teapot` — returns 418, to prove a non-2xx status is a response,
 //!   not a seam error.
+//! - `GET /stream/<n>` — `n` bytes with `Transfer-Encoding: chunked` and no
+//!   `Content-Length`, so a capped read has only the streaming drain to gate
+//!   on.
 //!
 //! Every response carries `Connection: close`, so each request is one
 //! connection and the accept loop stays single-threaded.
@@ -103,6 +106,9 @@ fn handle_conn(
     // blocking reads with a safety timeout.
     stream.set_nonblocking(false)?;
     stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    // A capped read aborts mid-body, leaving a large write unread; bound it so
+    // the accept thread cannot wedge the suite.
+    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
 
     let mut buf = Vec::new();
     let mut chunk = [0u8; 2048];
@@ -155,6 +161,11 @@ fn handle_conn(
         body: body.clone(),
     });
 
+    if let Some(size) = path.strip_prefix("/stream/") {
+        let size = size.parse().unwrap_or(0);
+        return write_chunked_response(&mut stream, &vec![b'x'; size]);
+    }
+
     let (status, reason, extra_headers, response_body): (u16, &str, Vec<(&str, &str)>, Vec<u8>) =
         if let Some(_key) = path.strip_prefix("/routing/v1/ipns/") {
             if method == "PUT" {
@@ -202,6 +213,17 @@ fn write_response(
     head.push_str("\r\n");
     stream.write_all(head.as_bytes())?;
     stream.write_all(body)?;
+    stream.flush()
+}
+
+/// Writes the body as one chunked frame. The client may abort mid-body, so a
+/// write failure is the expected end of a capped read, not a test failure.
+fn write_chunked_response(stream: &mut TcpStream, body: &[u8]) -> std::io::Result<()> {
+    stream
+        .write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n")?;
+    write!(stream, "{:x}\r\n", body.len())?;
+    stream.write_all(body)?;
+    stream.write_all(b"\r\n0\r\n\r\n")?;
     stream.flush()
 }
 

--- a/crates/engine/src/seams/http.rs
+++ b/crates/engine/src/seams/http.rs
@@ -142,9 +142,10 @@ pub trait Http {
     /// adoption. Both real transports — desktop (`reqwest`) and WASM (the JS
     /// fetch bridge) — enforce one bound the same way: a `Content-Length`
     /// pre-check, then a streaming drain that aborts as soon as the accumulated
-    /// body would pass the cap. The transport hands over whole chunks, so peak
-    /// memory is `max_bytes` plus at most the one chunk that tripped the cap;
-    /// the body itself is never accumulated past `max_bytes` (#641, #787).
+    /// body would pass the cap. The body is never accumulated past `max_bytes`;
+    /// the transport hands over whole chunks, so peak memory is `max_bytes` —
+    /// twice that on the arm that concatenates the chunks at the end — plus at
+    /// most the one chunk that tripped the cap (#641, #787).
     ///
     /// The default implementation only backstops: it buffers the whole body via
     /// [`send`](Self::send) and then checks the length, which bounds nothing. It

--- a/crates/engine/src/seams/http.rs
+++ b/crates/engine/src/seams/http.rs
@@ -17,7 +17,7 @@ pub enum CappedFetchError {
     BodyTooLarge {
         /// The observed lower bound on the body size — the declared
         /// `Content-Length` if that alone exceeded the cap, else the bytes
-        /// accumulated when the streaming read passed the cap.
+        /// drained so far including the chunk that passed it.
         observed: usize,
         /// The enforced ceiling (`max_bytes`).
         limit: usize,
@@ -139,15 +139,12 @@ pub trait Http {
 
     /// Like [`send`](Self::send), but fails closed if the response body would
     /// exceed `max_bytes`, so a lying/huge gateway cannot force an over-cap
-    /// adoption. The strength of the bound differs by transport:
-    ///
-    /// - Desktop (`reqwest`) enforces it *while* reading the body — a
-    ///   `Content-Length` pre-check plus a capped streaming read that aborts
-    ///   past the cap — the true peak-memory bound at the content fetch
-    ///   boundary (#787).
-    /// - WASM (the JS fetch bridge) enforces the same bound in the JS seam,
-    ///   which drains `Response.body` under the cap and never materializes an
-    ///   over-cap body (#641).
+    /// adoption. Both real transports — desktop (`reqwest`) and WASM (the JS
+    /// fetch bridge) — enforce one bound the same way: a `Content-Length`
+    /// pre-check, then a streaming drain that aborts as soon as the accumulated
+    /// body would pass the cap. The transport hands over whole chunks, so peak
+    /// memory is `max_bytes` plus at most the one chunk that tripped the cap;
+    /// the body itself is never accumulated past `max_bytes` (#641, #787).
     ///
     /// The default implementation only backstops: it buffers the whole body via
     /// [`send`](Self::send) and then checks the length, which bounds nothing. It

--- a/packages/client/src/seams/http.test.ts
+++ b/packages/client/src/seams/http.test.ts
@@ -108,6 +108,19 @@ describe('FetchHttp.sendCapped', () => {
     }
   );
 
+  it('rejects a single chunk larger than the whole cap', async () => {
+    const body = producedBody(4096, 4);
+    stubFetch(new Response(body.stream, { status: 200 }));
+
+    const result = await new FetchHttp().sendCapped(GET, 1000);
+
+    // Nothing is accumulated before the first chunk, so the whole overshoot is
+    // that one chunk — the peak the seam's bound admits.
+    expect(result).toEqual({ kind: 'tooLarge', observed: 4096, limit: 1000 });
+    expect(body.produced()).toBe(4096);
+    expect(body.cancelled()).toBe(true);
+  });
+
   it('admits a body exactly at the cap with its bytes intact', async () => {
     const body = producedBody(100, 10);
     stubFetch(new Response(body.stream, { status: 200 }));

--- a/packages/client/src/seams/http.ts
+++ b/packages/client/src/seams/http.ts
@@ -51,9 +51,11 @@ export class FetchHttp implements HttpSeam {
   }
 
   /**
-   * Enforces the cap as bytes arrive, so peak memory is bounded by the cap —
-   * about twice it while the chunks are concatenated — even when Content-Length
-   * is absent or lies.
+   * Enforces the cap as bytes arrive, even when Content-Length is absent or
+   * lies. `fetch` hands over whole chunks, so the drain aborts on the chunk
+   * that would pass the cap: the retained body never exceeds `maxBytes`, and
+   * peak memory is `maxBytes` — about twice it while the chunks are
+   * concatenated — plus that one chunk.
    */
   async sendCapped(request: HttpRequestData, maxBytes: number): Promise<CappedHttpResult> {
     const response = await fetch(request.url, requestInit(request));


### PR DESCRIPTION
## What

Both `send_capped` arms check the cap only after the transport has materialized
the chunk, so the real peak is `max_bytes` plus one transport chunk — not
`max_bytes`. The seam contract claimed a stronger bound and split it into a
desktop-vs-WASM distinction that does not exist: desktop was called "the true
peak-memory bound", WASM was said to "never materialize an over-cap body".
Neither is a memory-safety hole — the retained body still never passes the cap,
and both arms abort the drain — but other code reads that contract as exact.

## Changes

- `crates/engine/src/seams/http.rs` — `Http::send_capped` now states one bound
  for both real transports: a `Content-Length` pre-check, then a streaming drain
  that aborts as soon as the accumulated body would pass the cap, with peak
  memory `max_bytes` — twice that on the arm that concatenates chunks at the end
  — plus at most the one chunk that tripped it. `BodyTooLarge::observed` now says
  it includes the tripping chunk, which is what both arms report.
- `crates/desktop-seams/src/http.rs` — the local comment defers to that bound
  instead of re-asserting a stronger one.
- `packages/client/src/seams/http.ts` — same bound, stated for the fetch arm.

## Tests

- `packages/client/src/seams/http.test.ts` — a single 4096-byte chunk against a
  1000-byte cap, the branch where nothing is accumulated before the cap trips.
  Asserts `observed === 4096` and that the source produced exactly that one
  chunk before cancellation.
- `crates/desktop-seams/tests/conformance.rs` — the matching desktop shape over
  a new `GET /stream/<n>` mock route that responds `Transfer-Encoding: chunked`
  with no `Content-Length`, so only the streaming drain gates. 64 KiB against a
  16-byte cap fails closed on the first chunk — observed is one transport chunk
  locally, ~8 KiB, well short of the whole body, so an implementation that
  buffered first would fail the case. A companion test admits a chunked body
  exactly at the cap.

`packages/client` is gated by root `pnpm test`; the conformance test is in an
existing `cargo test` target — both block a merge the day they land.

Closes #964


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enforcement of response size limits for streamed HTTP responses.
  * Oversized responses are now rejected as soon as a chunk exceeds the configured limit, without buffering the full body.
  * Responses exactly at the configured limit continue to succeed.
  * Streaming bodies are cancelled promptly when the limit is exceeded.

* **Documentation**
  * Clarified response size limits, observed byte counts, streaming behavior, and peak memory expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->