### PR TITLE
test(client): cover the media range window arithmetic and seed each tab distinctly

### DIFF
--- a/packages/client/src/media/range.test.ts
+++ b/packages/client/src/media/range.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveMediaRequest, type MediaHead } from './range.js';
+import { resolveMediaRequest, type MediaHead, type MediaWindow } from './range.js';
 
 const SIZE = 4096;
+const MIME = 'video/mp4';
+
+/** The first integer past `Number.MAX_SAFE_INTEGER`. */
+const UNSAFE = '9007199254740992';
 
 const headerMap = (head: MediaHead): Map<string, string> => new Map(head.headers);
+
+const windowOf = (head: MediaHead): MediaWindow => {
+  if (head.status === 416) throw new Error('a 416 head carries no window');
+  return head.window;
+};
 
 const contentTypeFor = (mimeType: string): string | undefined =>
   headerMap(resolveMediaRequest(null, SIZE, mimeType)).get('content-type');
@@ -31,9 +40,9 @@ describe('resolveMediaRequest content-type', () => {
 
 describe('resolveMediaRequest hardening headers', () => {
   const cases: Array<[string, MediaHead]> = [
-    ['200', resolveMediaRequest(null, SIZE, 'video/mp4')],
-    ['206', resolveMediaRequest('bytes=0-99', SIZE, 'video/mp4')],
-    ['416', resolveMediaRequest(`bytes=${SIZE}-`, SIZE, 'video/mp4')],
+    ['200', resolveMediaRequest(null, SIZE, MIME)],
+    ['206', resolveMediaRequest('bytes=0-99', SIZE, MIME)],
+    ['416', resolveMediaRequest(`bytes=${SIZE}-`, SIZE, MIME)],
   ];
 
   for (const [status, head] of cases) {
@@ -42,6 +51,91 @@ describe('resolveMediaRequest hardening headers', () => {
       const headers = headerMap(head);
       expect(headers.get('x-content-type-options')).toBe('nosniff');
       expect(headers.get('content-security-policy')).toBe("default-src 'none'; sandbox");
+    });
+  }
+});
+
+describe('resolveMediaRequest 206 windows', () => {
+  const cases: Array<{ spec: string; offset: number; length: number }> = [
+    { spec: 'bytes=0-99', offset: 0, length: 100 },
+    { spec: 'bytes=4095-4095', offset: 4095, length: 1 },
+    { spec: 'bytes=4000-', offset: 4000, length: 96 },
+    // A last past EOF clamps to the last byte rather than over-reading.
+    { spec: 'bytes=4000-999999', offset: 4000, length: 96 },
+    { spec: 'bytes=-100', offset: 3996, length: 100 },
+    { spec: 'bytes=-1', offset: 4095, length: 1 },
+    // A suffix longer than the file is the whole file, not a 416.
+    { spec: 'bytes=-99999', offset: 0, length: SIZE },
+    { spec: 'BYTES=0-99', offset: 0, length: 100 },
+    { spec: '  bytes= 1000-1999 ', offset: 1000, length: 1000 },
+  ];
+
+  for (const { spec, offset, length } of cases) {
+    it(`serves '${spec}' as ${length} bytes from ${offset}`, () => {
+      const head = resolveMediaRequest(spec, SIZE, MIME);
+
+      expect(head.status).toBe(206);
+      expect(windowOf(head)).toEqual({ offset, length });
+      const headers = headerMap(head);
+      expect(headers.get('content-range')).toBe(`bytes ${offset}-${offset + length - 1}/${SIZE}`);
+      expect(headers.get('content-length')).toBe(String(length));
+    });
+  }
+});
+
+describe('resolveMediaRequest whole-file fall-through', () => {
+  const cases: Array<[string, string | null]> = [
+    ['an absent Range header', null],
+    ['a blank Range header', '   '],
+    ['a multi-range set', 'bytes=0-99,200-299'],
+    ['a non-bytes unit', 'items=0-99'],
+    ['a malformed spec', 'bytes=abc'],
+    ['an empty spec', 'bytes='],
+    ['a bare dash', 'bytes=-'],
+  ];
+
+  for (const [name, spec] of cases) {
+    it(`answers ${name} with the whole file`, () => {
+      const head = resolveMediaRequest(spec, SIZE, MIME);
+
+      expect(head.status).toBe(200);
+      expect(windowOf(head)).toEqual({ offset: 0, length: SIZE });
+      const headers = headerMap(head);
+      expect(headers.get('content-length')).toBe(String(SIZE));
+      expect(headers.has('content-range')).toBe(false);
+    });
+  }
+
+  it('answers an empty file with an empty window', () => {
+    const head = resolveMediaRequest(null, 0, MIME);
+
+    expect(head.status).toBe(200);
+    expect(windowOf(head)).toEqual({ offset: 0, length: 0 });
+  });
+});
+
+describe('resolveMediaRequest 416', () => {
+  const cases: Array<[string, string, number]> = [
+    ['an offset at EOF', `bytes=${SIZE}-`, SIZE],
+    ['an inverted interval', 'bytes=100-50', SIZE],
+    ['a zero-length suffix', 'bytes=-0', SIZE],
+    ['any suffix of an empty file', 'bytes=-10', 0],
+    ['an interval on an empty file', 'bytes=0-9', 0],
+    ['an offset past MAX_SAFE_INTEGER', `bytes=${UNSAFE}-`, SIZE],
+    ['a last past MAX_SAFE_INTEGER', `bytes=0-${UNSAFE}`, SIZE],
+    ['a suffix past MAX_SAFE_INTEGER', `bytes=-${UNSAFE}`, SIZE],
+  ];
+
+  for (const [name, spec, size] of cases) {
+    it(`rejects ${name} with no window`, () => {
+      const head = resolveMediaRequest(spec, size, MIME);
+
+      expect(head.status).toBe(416);
+      // A rejected range must read no plaintext at all.
+      expect('window' in head).toBe(false);
+      const headers = headerMap(head);
+      expect(headers.get('content-range')).toBe(`bytes */${size}`);
+      expect(headers.has('content-length')).toBe(false);
     });
   }
 });

--- a/packages/client/test/browser/media.spec.ts
+++ b/packages/client/test/browser/media.spec.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { expect, test, type BrowserContext, type Page } from '@playwright/test';
 
 import { hex } from './hexUtil.js';
-import { fixtureSlice, LEADER_SEED, TAB_SEED } from './mediaFixture.js';
+import { fixtureSlice, LEADER_SEED, SECOND_TAB_SEED, TAB_SEED } from './mediaFixture.js';
 import type { MediaFetchResult } from './media.js';
 
 /**
@@ -15,7 +15,7 @@ import type { MediaFetchResult } from './media.js';
 
 interface MediaHarness {
   cbMediaEngine(options: { lockName: string; channelName: string }): Promise<string>;
-  cbMediaStart(options: { reader: 'local' | 'engine' }): Promise<boolean>;
+  cbMediaStart(options: { reader: 'local' | 'engine'; seed?: number }): Promise<boolean>;
   cbMediaAwaitControl(): Promise<boolean>;
   cbMediaTicket(size: number, mimeType: string): string;
   cbMediaFetch(url: string, range: string | null): Promise<MediaFetchResult>;
@@ -45,7 +45,7 @@ function names(): { lockName: string; channelName: string } {
 interface Tab {
   page: Page;
   engine(lockName: string, channelName: string): Promise<string>;
-  start(reader: 'local' | 'engine'): Promise<boolean>;
+  start(reader: 'local' | 'engine', seed?: number): Promise<boolean>;
   awaitControl(): Promise<boolean>;
   ticket(size: number): Promise<string>;
   fetch(url: string, range?: string): Promise<MediaFetchResult>;
@@ -68,8 +68,11 @@ async function openTab(context: BrowserContext): Promise<Tab> {
         lockName,
         channelName,
       }),
-    start: (reader) =>
-      page.evaluate((r) => (window as unknown as MediaHarness).cbMediaStart({ reader: r }), reader),
+    start: (reader, seed) =>
+      page.evaluate((opts) => (window as unknown as MediaHarness).cbMediaStart(opts), {
+        reader,
+        seed,
+      }),
     awaitControl: () =>
       page.evaluate(() => (window as unknown as MediaHarness).cbMediaAwaitControl()),
     ticket: (size) =>
@@ -93,10 +96,10 @@ async function openTab(context: BrowserContext): Promise<Tab> {
   };
 }
 
-/** A controlled tab whose broker serves the tab-seeded fixture. */
-async function localTab(context: BrowserContext): Promise<Tab> {
+/** A controlled tab whose broker serves the fixture bytes for `seed`. */
+async function localTab(context: BrowserContext, seed?: number): Promise<Tab> {
   const tab = await openTab(context);
-  expect(await tab.start('local')).toBe(true);
+  expect(await tab.start('local', seed)).toBe(true);
   expect(await tab.awaitControl()).toBe(true);
   return tab;
 }
@@ -180,8 +183,8 @@ test.describe('Service Worker media brokerage over a real byte pipe', () => {
   });
 
   test('two open tabs each stream from their own broker', async ({ context }) => {
-    const a = await localTab(context);
-    const b = await localTab(context);
+    const a = await localTab(context, TAB_SEED);
+    const b = await localTab(context, SECOND_TAB_SEED);
     const sizeA = 4096;
     const sizeB = 2048;
     const ticketA = await a.ticket(sizeA);
@@ -195,7 +198,7 @@ test.describe('Service Worker media brokerage over a real byte pipe', () => {
     expect(fromA.status).toBe(200);
     expect(fromA.bodyHex).toBe(hex(fixtureSlice(0, sizeA, TAB_SEED)));
     expect(fromB.status).toBe(200);
-    expect(fromB.bodyHex).toBe(hex(fixtureSlice(0, sizeB, TAB_SEED)));
+    expect(fromB.bodyHex).toBe(hex(fixtureSlice(0, sizeB, SECOND_TAB_SEED)));
 
     await b.dispose();
     await a.dispose();

--- a/packages/client/test/browser/media.ts
+++ b/packages/client/test/browser/media.ts
@@ -23,6 +23,8 @@ export type MediaReaderKind = 'local' | 'engine';
 
 export interface MediaStartOptions {
   reader: MediaReaderKind;
+  /** Fixture seed for the local reader; defaults to `TAB_SEED`. */
+  seed?: number;
 }
 
 export interface MediaEngineOptions {
@@ -66,12 +68,12 @@ navigator.serviceWorker.addEventListener('message', (event: MessageEvent) => {
 });
 
 /** Serves the tab's own fixture, counting reads so the spec can see windowing. */
-const localReader: MediaReader = {
+const localReader = (seed: number): MediaReader => ({
   downloadRange: (_node, offset, length) => {
     readerCalls += 1;
-    return Promise.resolve(fixtureBuffer(offset, length, TAB_SEED));
+    return Promise.resolve(fixtureBuffer(offset, length, seed));
   },
-};
+});
 
 /** Routes every read through this tab's engine client — a follower's wire. */
 const engineReader: MediaReader = {
@@ -94,12 +96,12 @@ window.cbMediaEngine = ({ lockName, channelName }: MediaEngineOptions): Promise<
   return awaitElection(client, lockName);
 };
 
-window.cbMediaStart = async ({ reader }: MediaStartOptions): Promise<boolean> => {
+window.cbMediaStart = async ({ reader, seed }: MediaStartOptions): Promise<boolean> => {
   service = new MediaService({
     container: navigator.serviceWorker,
     scriptUrl: SW_SCRIPT,
     scriptType: 'module',
-    reader: reader === 'engine' ? engineReader : localReader,
+    reader: reader === 'engine' ? engineReader : localReader(seed ?? TAB_SEED),
   });
   await service.start();
   await window.cbMediaAwaitControl();

--- a/packages/client/test/browser/mediaFixture.ts
+++ b/packages/client/test/browser/mediaFixture.ts
@@ -7,6 +7,9 @@
 /** Bytes produced tab-side, by the harness's own in-page reader. */
 export const TAB_SEED = 7;
 
+/** A second tab's bytes, so one tab's stream can never pass as another's. */
+export const SECOND_TAB_SEED = 83;
+
 /** Bytes produced only inside the leader's engine worker. */
 export const LEADER_SEED = 199;
 


### PR DESCRIPTION
Closes #963

Two test-coverage residuals from the byte-pipe slice, both in the media path.

## `resolveMediaRequest` window arithmetic

`range.test.ts` asserted only the content-type downgrade and the hardening headers — it never read `head.window` and never asserted a `content-range` value, so the arithmetic deciding which plaintext bytes a viewer receives had no unit coverage. Three new table-driven blocks close that:

- **206 windows** — plain interval, last-byte boundary, open interval, a `last` past EOF clamped to `totalSize - 1`, the suffix form, a suffix longer than the file resolving to the whole file rather than a 416, plus case-insensitive and whitespace-padded specs. Each row asserts the exact `window`, the `content-range`, and a `content-length` that agrees with the window.
- **Whole-file fall-through** — absent, blank, multi-range, non-`bytes`, and malformed specs all answer 200 with the whole file and no `content-range`; a zero-byte file yields an empty window.
- **416** — offset at EOF, inverted interval, `bytes=-0`, any range on an empty file, and all three digit runs past `Number.MAX_SAFE_INTEGER` that `parseOffset` fails closed on. Every 416 row asserts `'window' in head === false`: a rejected range must read no plaintext at all.

Verified by mutation: thirteen single-line mutations of `range.ts` — dropping the `Math.min` EOF clamp, dropping the `Math.max(0, …)` suffix clamp, each of the three `parseOffset` null gates, the inverted-interval gate, the open-interval `totalSize - 1`, the `last - offset + 1` length, the multi-range fall-through, the `wanted === 0` and `totalSize === 0` suffix gates, the set `trim()`, and the `toLowerCase()` — each turn at least one new test red.

## Distinct fixture bytes per tab

`media.ts` hardcoded `TAB_SEED` in its `downloadRange` stub, so both tabs in `two open tabs each stream from their own broker` synthesized identical bytes: a cross-tab stream mix-up that answered one tab's ticket out of the other tab's broker would still have passed every byte assertion. `MediaStartOptions` now carries a `seed` and `localTab` threads it, so tab A serves `TAB_SEED` and tab B `SECOND_TAB_SEED`. Mutation-checked the same way — pinning the harness back to `TAB_SEED` turns the two-tab test red.

## Gates

- `pnpm typecheck` — pass, all four workspace projects.
- `pnpm --filter @cipherbox/client test` — 22 files, 252 tests, pass. Gated on merge by the root `pnpm test` fan-out, so no workflow change is needed.
- `pnpm --filter @cipherbox/client run test:browser` — 27 passed, including all 8 media specs.

`packages/client/test/browser` is not typechecked today (#975), so the harness changes there were verified by running them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media range handling, including partial content responses, empty files, whole-file requests, and invalid range rejection.
  * Strengthened media response validation and security-header coverage.
  * Improved multi-tab media isolation by ensuring each session serves distinct fixture data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->