### PR TITLE
fix: key the app-shell cache off a content-derived build id

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,3 +1,6 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import react from '@vitejs/plugin-react';
 import { build, type Plugin } from 'vite';
@@ -9,57 +12,75 @@ const SW_FILE = 'sw.js';
 const MANIFEST_FILE = 'precache-manifest.json';
 
 /**
- * The app-shell manifest the Service Worker precaches on install: every emitted
- * chunk, as same-origin absolute paths.
+ * The app-shell pair, sharing one build id: the manifest the Service Worker
+ * precaches on install — every emitted chunk, as same-origin absolute paths —
+ * and the worker itself, stamped with a digest of those same bytes so the shell
+ * cache rotates with the output.
+ *
+ * The worker is a second pass so it lands unhashed at the output root — its
+ * scope is bounded by its own URL path — and as a classic script, not the ES
+ * module the app's chunk graph would emit.
  */
-function precacheManifest(): Plugin {
-  return {
-    name: 'cipherbox:precache-manifest',
-    enforce: 'post',
-    generateBundle(_options, bundle) {
-      const shell = Object.keys(bundle)
-        .filter((fileName) => !fileName.endsWith('.map'))
-        .map((fileName) => `/${fileName}`)
-        .sort();
-      this.emitFile({
-        type: 'asset',
-        fileName: MANIFEST_FILE,
-        source: `${JSON.stringify(shell, null, 2)}\n`,
-      });
-    },
-  };
-}
+function appShell(): Plugin[] {
+  let buildId: string | null = null;
 
-/**
- * A separate pass so the worker lands unhashed at the output root — its scope is
- * bounded by its own URL path — and as a classic script, not the ES module the
- * app's chunk graph would emit.
- */
-function serviceWorkerBuild(): Plugin {
-  return {
-    name: 'cipherbox:service-worker',
-    apply: 'build',
-    async closeBundle() {
-      await build({
-        configFile: false,
-        logLevel: 'warn',
-        build: {
-          outDir: OUT_DIR,
-          emptyOutDir: false,
-          rollupOptions: {
-            input: SW_ENTRY,
-            // `iife` keeps the classic-script contract: an `es` chunk reaching for
-            // a dynamic import emits `import.meta`, which a classic worker rejects.
-            output: { entryFileNames: SW_FILE, codeSplitting: false, format: 'iife' },
-          },
-        },
-      });
+  return [
+    {
+      name: 'cipherbox:precache-manifest',
+      enforce: 'post',
+      generateBundle(_options, bundle) {
+        const fileNames = Object.keys(bundle)
+          .filter((fileName) => !fileName.endsWith('.map'))
+          .sort();
+
+        const digest = createHash('sha256');
+        for (const fileName of fileNames) {
+          const output = bundle[fileName];
+          digest.update(fileName);
+          digest.update(output.type === 'chunk' ? output.code : output.source);
+        }
+        buildId = digest.digest('hex').slice(0, 16);
+
+        const shell = fileNames.map((fileName) => `/${fileName}`);
+        this.emitFile({
+          type: 'asset',
+          fileName: MANIFEST_FILE,
+          source: `${JSON.stringify(shell, null, 2)}\n`,
+        });
+      },
     },
-  };
+    {
+      name: 'cipherbox:service-worker',
+      apply: 'build',
+      async closeBundle() {
+        if (buildId === null)
+          throw new Error('the precache manifest emitted no app-shell build id');
+        await build({
+          configFile: false,
+          logLevel: 'warn',
+          define: { __APP_SHELL_BUILD_ID__: JSON.stringify(buildId) },
+          build: {
+            outDir: OUT_DIR,
+            emptyOutDir: false,
+            rollupOptions: {
+              input: SW_ENTRY,
+              // `iife` keeps the classic-script contract: an `es` chunk reaching for
+              // a dynamic import emits `import.meta`, which a classic worker rejects.
+              output: { entryFileNames: SW_FILE, codeSplitting: false, format: 'iife' },
+            },
+          },
+        });
+        // The worker's bytes must vary per deploy or the browser finds no update
+        // to install, and the shell it precached is never rotated.
+        const emitted = await readFile(join(OUT_DIR, SW_FILE), 'utf8');
+        if (!emitted.includes(buildId)) throw new Error(`${SW_FILE} did not take the build stamp`);
+      },
+    },
+  ];
 }
 
 export default defineConfig({
-  plugins: [react(), precacheManifest(), serviceWorkerBuild()],
+  plugins: [react(), ...appShell()],
   // `@cipherbox/client`'s engine worker dynamically imports the wasm-bindgen ES
   // module, which a classic worker cannot do (blueprint/web-client.md).
   worker: { format: 'es' },

--- a/packages/client/src/sw/precache.test.ts
+++ b/packages/client/src/sw/precache.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   APP_SHELL_CACHE,
@@ -119,7 +119,7 @@ describe('precacheAppShell', () => {
 });
 
 describe('deleteStaleCaches', () => {
-  it('drops cipherbox caches from earlier deploys and keeps the shell', async () => {
+  it('drops shell caches from earlier deploys and keeps the live one', async () => {
     const caches = new FakeCacheStorage();
     caches.cache(APP_SHELL_CACHE);
     caches.cache('cipherbox-app-shell-v0');
@@ -128,6 +128,33 @@ describe('deleteStaleCaches', () => {
     await deleteStaleCaches(caches);
 
     expect([...caches.opened.keys()]).toEqual([APP_SHELL_CACHE, 'unrelated-cache']);
+  });
+});
+
+describe('the build stamp', () => {
+  /** Loads a fresh module instance under the stamp the web build defines. */
+  const loadStamped = async (buildId: string): Promise<typeof import('./precache.js')> => {
+    vi.resetModules();
+    vi.stubGlobal('__APP_SHELL_BUILD_ID__', buildId);
+    return import('./precache.js');
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rotates the shell cache so a redeploy installs fresh and evicts its predecessor', async () => {
+    const caches = new FakeCacheStorage();
+    const first = await loadStamped('build-1');
+    const second = await loadStamped('build-2');
+    expect(second.APP_SHELL_CACHE).not.toBe(first.APP_SHELL_CACHE);
+
+    await first.precacheAppShell(caches, manifestFetch('["/assets/old.js"]'), ORIGIN);
+    await second.precacheAppShell(caches, manifestFetch('["/assets/new.js"]'), ORIGIN);
+    await second.deleteStaleCaches(caches);
+
+    expect([...caches.opened.keys()]).toEqual([second.APP_SHELL_CACHE]);
+    expect([...(await second.readPrecachedUrls(caches))]).toEqual([`${ORIGIN}/assets/new.js`]);
   });
 });
 

--- a/packages/client/src/sw/precache.ts
+++ b/packages/client/src/sw/precache.ts
@@ -5,13 +5,19 @@
 
 import { STREAM_PATH_PREFIX } from '../media/protocol.js';
 
-export const APP_SHELL_CACHE = 'cipherbox-app-shell';
+/** Stamped by the web build from the build output's digest; absent in dev. */
+declare const __APP_SHELL_BUILD_ID__: string | undefined;
+
+const CACHE_PREFIX = 'cipherbox-app-shell';
+const BUILD_ID = typeof __APP_SHELL_BUILD_ID__ === 'string' ? __APP_SHELL_BUILD_ID__ : 'dev';
+
+/** Keyed by build id so a deploy installs fresh and `activate` evicts the shell it superseded. */
+export const APP_SHELL_CACHE = `${CACHE_PREFIX}-${BUILD_ID}`;
 
 const PRECACHE_MANIFEST_URL = '/precache-manifest.json';
 
 /** The document a navigation falls back to when the network is unreachable. */
 const APP_SHELL_DOCUMENT = '/index.html';
-const CACHE_PREFIX = 'cipherbox-';
 
 /** The subset of `Cache` the shell drives (injectable). */
 export interface CacheLike {


### PR DESCRIPTION
Closes #974

## The defect

`APP_SHELL_CACHE` was a constant and the emitted `sw.js` carried no build-varying bytes — its content is a pure function of `packages/client/src/sw/**`. A deploy that changed only app chunks therefore left the worker byte-identical, the browser found no update, `install` never re-fired, and `precacheAppShell` never re-ran. The offline navigation fallback served the first-installed deploy's `index.html` indefinitely, and `deleteStaleCaches` explicitly excluded the live cache so nothing could rotate it.

## The fix

- `apps/web/vite.config.ts` — the manifest plugin digests every emitted non-`.map` bundle entry (file name plus bytes, sorted) into a 16-hex-char build id, and the worker pass stamps it in via `define`.
- `packages/client/src/sw/precache.ts` — `APP_SHELL_CACHE` is now `cipherbox-app-shell-<buildId>`. A new deploy installs into a fresh cache; `deleteStaleCaches` on `activate` evicts every `cipherbox-app-shell*` except the live one, so redeploys no longer accumulate.

Three things worth calling out:

**The id is content-derived, not a timestamp.** An unchanged build produces an identical `sw.js`, verified byte-for-byte across repeated clean rebuilds. That keeps the browser from re-installing the worker on every deploy of identical input.

**The digest covers file contents, not just the hashed file names.** Vite already content-hashes chunk names, but `index.html` ships unhashed — a change confined to it (meta tag, CSP, title) would change the shipped shell without changing any chunk hash, and a name-only digest would leave the stale document pinned offline.

**The build fails closed if the stamp did not land.** `closeBundle` re-reads the emitted `sw.js` and throws unless it contains the id. Without that, a future change to how `define` folds would silently collapse the cache name back to `cipherbox-app-shell-dev` on every deploy — re-introducing this exact defect with every gate green.

## Relationship to #969

#974 had two halves. #969 has since landed the server half — carving `/assets/*` out of the Caddy SPA fallback so a missing fingerprinted asset returns a real 404 instead of a `200 text/html` shell. The two are complementary, and neither makes the other redundant:

- Without #969, `precacheAppShell` could cache `index.html` under an `/assets/*.js` URL and then serve it cache-first, indefinitely and silently.
- Without this PR, the worker's bytes never change, so `install` never re-runs and the shell stays pinned to the first deploy the user installed. A 404 alone cannot refresh anything.

They also compose correctly: `precacheAppShell` caches per entry rather than via one atomic `addAll`, so a 404 during a mid-deploy race costs that one asset instead of dropping the whole shell, and pruning follows the manifest rather than what happened to cache.

## Verification

Re-run in full after rebasing onto `bd30a0cbb`, which pulled 12 commits including #951's byte pipe, #969, and #971.

- `pnpm -r --if-present run typecheck` — clean across `apps/api`, `apps/web`, `packages/client`.
- `pnpm -r --if-present run test` — `packages/client` 23 files / 266 tests, `apps/api` 24 / 178, `apps/web` 13 / 99, all passing. `src/sw/precache.test.ts` contributes 17 cases, including the new `the build stamp > rotates the shell cache so a redeploy installs fresh and evicts its predecessor`. Picked up by the existing root `pnpm test` gate; no workflow edit needed.
- `pnpm --filter @cipherbox/client run test:browser` — 28 Playwright tests passing, including the Service Worker media brokerage suite.
- `pnpm exec eslint .` — clean. Rust gates (`cargo fmt --all --check`, `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown`) all clean; this PR touches no Rust but the rebase pulls 12 commits of it.

The build id was exercised against real `build:bundle` output rather than only in unit tests:

| Input | Build id | Manifest |
| --- | --- | --- |
| baseline | `02fa4f7dc2b9a119` | — |
| rebuilt, no change | `02fa4f7dc2b9a119` | identical |
| `index.html` title only | `079f68eaf4fbaf9d` | **byte-identical file list** |
| a `.tsx` source literal | `a4faf30232029cb1` | chunk hashes moved |
| reverted to baseline | `02fa4f7dc2b9a119` | identical |

The `index.html` row is the load-bearing one: every hashed asset name was unchanged, so a name-only digest would have produced the same id and left the shell pinned. The id moved anyway, which is what proves the digest reads contents.

The new test is non-circular: reverting `APP_SHELL_CACHE` to the bare constant fails exactly that one case with `expected 'cipherbox-app-shell' not to be 'cipherbox-app-shell'`, leaving the other 16 green. The fail-closed check is live rather than decorative: removing the `define` makes the build exit non-zero with `Error: sw.js did not take the build stamp`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved app shell caching with build-specific cache versions.
  * Automatically refreshes cached assets when a new build is available.
  * Removes outdated cached assets while retaining the latest version.

* **Bug Fixes**
  * Improved coordination between the service worker and generated asset manifest.
  * Added validation to ensure the service worker uses the correct build version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->