### PR TITLE
fix: pin the content version for the life of a ranged read stream

### DIFF
--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -263,10 +263,9 @@ pub(crate) async fn read_pinned_range<H: Http>(
     offset: u64,
     length: u64,
 ) -> Result<Vec<u8>, OpenError> {
-    // The two arrive as separate values, so re-assert the pairing rather than
-    // assume it: a manifest from another version would otherwise be read at this
-    // version's key, and the AEAD would be the only thing standing between the
-    // caller and a differently-framed body.
+    // `manifest` and `version` arrive as separate arguments: re-assert the
+    // pairing rather than trust the caller, or another version's manifest frames
+    // this version's leaves with only the AEAD to catch it.
     if manifest.size != version.size {
         return Err(OpenError::Trust(format!(
             "manifest size {} disagrees with version size {}",

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -205,22 +205,14 @@ fn grow_wiping(buf: &mut Zeroizing<Vec<u8>>, additional: usize) {
     std::mem::swap(buf, &mut grown);
 }
 
-/// Fetch, verify, and reassemble the plaintext window `[offset, offset +
-/// length)` of one content version, fetching only the leaves it covers. The
-/// request is clamped to the version, so an offset at or past the end yields no
-/// bytes.
-///
-/// Every leaf must unseal to the length the flat framing implies — `chunk_size`
-/// but for the final one. A disagreement is a fail-closed trust violation: a
-/// short middle leaf shifts every downstream byte, so tolerating one would serve
-/// silently misaligned plaintext.
-pub async fn open_content_range<H: Http>(
+/// Fetch and verify one version's DAG root, returning the manifest its leaves
+/// are read against. The manifest is complete on its own, so a caller may hold
+/// it and read many windows without re-verifying the root.
+pub(crate) async fn open_content_root<H: Http>(
     gateway: &Gateway,
     http: &H,
     version: &Version,
-    offset: u64,
-    length: u64,
-) -> Result<Vec<u8>, OpenError> {
+) -> Result<RootManifest, OpenError> {
     let root_cid_str = encode_content_cid_str(&version.content_cid);
     let root_block = read_block(
         gateway,
@@ -238,7 +230,49 @@ pub async fn open_content_range<H: Http>(
             manifest.size, version.size
         )));
     }
+    Ok(manifest)
+}
 
+/// Fetch, verify, and reassemble the plaintext window `[offset, offset +
+/// length)` of one content version, fetching only the leaves it covers. The
+/// request is clamped to the version, so an offset at or past the end yields no
+/// bytes.
+///
+/// Every leaf must unseal to the length the flat framing implies — `chunk_size`
+/// but for the final one. A disagreement is a fail-closed trust violation: a
+/// short middle leaf shifts every downstream byte, so tolerating one would serve
+/// silently misaligned plaintext.
+pub async fn open_content_range<H: Http>(
+    gateway: &Gateway,
+    http: &H,
+    version: &Version,
+    offset: u64,
+    length: u64,
+) -> Result<Vec<u8>, OpenError> {
+    let manifest = open_content_root(gateway, http, version).await?;
+    read_pinned_range(gateway, http, version, &manifest, offset, length).await
+}
+
+/// [`open_content_range`]'s leaf half, against a `manifest` [`open_content_root`]
+/// already verified against `version`.
+pub(crate) async fn read_pinned_range<H: Http>(
+    gateway: &Gateway,
+    http: &H,
+    version: &Version,
+    manifest: &RootManifest,
+    offset: u64,
+    length: u64,
+) -> Result<Vec<u8>, OpenError> {
+    // The two arrive as separate values, so re-assert the pairing rather than
+    // assume it: a manifest from another version would otherwise be read at this
+    // version's key, and the AEAD would be the only thing standing between the
+    // caller and a differently-framed body.
+    if manifest.size != version.size {
+        return Err(OpenError::Trust(format!(
+            "manifest size {} disagrees with version size {}",
+            manifest.size, version.size
+        )));
+    }
     let length = length.min(manifest.size.saturating_sub(offset));
     if length == 0 {
         return Ok(Vec::new());

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -669,6 +669,13 @@ pub enum EngineError {
     /// A read named a stream handle this engine does not hold — never minted,
     /// or already closed.
     UnknownStreamHandle,
+    /// Too many read streams are already open ([`MAX_OPEN_STREAMS`]). Each open
+    /// stream pins a content key and a root manifest, so an unbounded table is
+    /// a memory and key-pinning DoS.
+    TooManyStreams {
+        /// The ceiling that refused it, so a host can size its own pool.
+        limit: usize,
+    },
     /// [`Command::CancelUpload`] named an op that is no longer cancellable: its
     /// version's last block confirmed and its record is publishing, or it has
     /// already left the durable queue. Never converted into a compensating
@@ -835,6 +842,10 @@ impl fmt::Display for EngineError {
             ),
             EngineError::UnknownWriteHandle => f.write_str("unknown write handle"),
             EngineError::UnknownStreamHandle => f.write_str("unknown stream handle"),
+            EngineError::TooManyStreams { limit } => write!(
+                f,
+                "too many read streams are already open; at most {limit} may be open at once, so close one first"
+            ),
             EngineError::TooLateToCancel { op_id } => write!(
                 f,
                 "upload {} is already publishing and can no longer be cancelled",
@@ -1133,7 +1144,15 @@ struct LiveStream {
     manifest: RootManifest,
 }
 
-/// The engine's live read streams.
+/// How many read streams may be open at once.
+///
+/// A host holds one stream per open media element, so a real UI is two orders
+/// below this; the ceiling exists because each entry pins a content key and a
+/// root manifest carrying a CID per MiB of file, which an unbounded table turns
+/// into a memory and key-pinning DoS.
+pub const MAX_OPEN_STREAMS: usize = 256;
+
+/// The engine's live read streams, bounded by [`MAX_OPEN_STREAMS`].
 #[derive(Default)]
 struct LiveStreams {
     open: BTreeMap<StreamHandle, Rc<LiveStream>>,
@@ -2433,9 +2452,7 @@ impl<T: SeamTypes> Engine<T> {
             return Err(EngineError::NotStarted);
         }
         self.emit_op_progress(node, OpPhase::DownloadStarted, None);
-        // The range clamps to the version's size, so the whole file is the
-        // unbounded window.
-        match self.read_content_range(node, 0, u64::MAX).await {
+        match self.read_whole(node).await {
             Ok(plaintext) => {
                 self.emit_op_progress(node, OpPhase::DownloadCompleted, None);
                 Ok(plaintext)
@@ -2447,20 +2464,14 @@ impl<T: SeamTypes> Engine<T> {
         }
     }
 
-    /// Read one byte window of a file node's plaintext, fetching only the leaves
-    /// the window covers (blueprint/engine.md "Content plane"). A stream reads
-    /// many windows off one version; this reads one off the current head.
-    pub async fn read_content_range(
-        &self,
-        node: NodeId,
-        offset: u64,
-        length: u64,
-    ) -> Result<Vec<u8>, EngineError> {
-        if !self.started {
-            return Err(EngineError::NotStarted);
-        }
+    /// [`read_content`](Engine::read_content) without its progress phases. Kept
+    /// private and window-less: a multi-window read pins one version instead
+    /// ([`StreamHandle`], [`open_content_stream`](Engine::open_content_stream)).
+    async fn read_whole(&self, node: NodeId) -> Result<Vec<u8>, EngineError> {
         let (version, version_count) = self.head_version(node).await?;
-        let bytes = open_content_range(&self.gateway, &self.seams.http, &version, offset, length)
+        // The range clamps to the version's size, so the whole file is the
+        // unbounded window.
+        let bytes = open_content_range(&self.gateway, &self.seams.http, &version, 0, u64::MAX)
             .await
             .map_err(open_engine_error)?;
         self.project_head(node, &version, version_count);
@@ -2477,12 +2488,25 @@ impl<T: SeamTypes> Engine<T> {
         if !self.started {
             return Err(EngineError::NotStarted);
         }
+        // Refused before the resolve so a caller past the ceiling spends no
+        // network on it; re-checked at the insert, the only borrow that is
+        // atomic against opens which interleaved on the awaits between.
+        if self.streams.borrow().open.len() >= MAX_OPEN_STREAMS {
+            return Err(EngineError::TooManyStreams {
+                limit: MAX_OPEN_STREAMS,
+            });
+        }
         let (version, version_count) = self.head_version(node).await?;
         let manifest = open_content_root(&self.gateway, &self.seams.http, &version)
             .await
             .map_err(open_engine_error)?;
         self.project_head(node, &version, version_count);
         let mut streams = self.streams.borrow_mut();
+        if streams.open.len() >= MAX_OPEN_STREAMS {
+            return Err(EngineError::TooManyStreams {
+                limit: MAX_OPEN_STREAMS,
+            });
+        }
         streams.next += 1;
         let handle = StreamHandle(streams.next);
         streams

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -669,13 +669,8 @@ pub enum EngineError {
     /// A read named a stream handle this engine does not hold — never minted,
     /// or already closed.
     UnknownStreamHandle,
-    /// Too many read streams are already open ([`MAX_OPEN_STREAMS`]). Each open
-    /// stream pins a content key and a root manifest, so an unbounded table is
-    /// a memory and key-pinning DoS.
-    TooManyStreams {
-        /// The ceiling that refused it, so a host can size its own pool.
-        limit: usize,
-    },
+    /// The open-stream table is already at [`MAX_OPEN_STREAMS`]; close one first.
+    TooManyStreams,
     /// [`Command::CancelUpload`] named an op that is no longer cancellable: its
     /// version's last block confirmed and its record is publishing, or it has
     /// already left the durable queue. Never converted into a compensating
@@ -842,9 +837,9 @@ impl fmt::Display for EngineError {
             ),
             EngineError::UnknownWriteHandle => f.write_str("unknown write handle"),
             EngineError::UnknownStreamHandle => f.write_str("unknown stream handle"),
-            EngineError::TooManyStreams { limit } => write!(
+            EngineError::TooManyStreams => write!(
                 f,
-                "too many read streams are already open; at most {limit} may be open at once, so close one first"
+                "too many read streams are already open; at most {MAX_OPEN_STREAMS} may be open at once, so close one first"
             ),
             EngineError::TooLateToCancel { op_id } => write!(
                 f,
@@ -1149,7 +1144,7 @@ struct LiveStream {
 /// A host holds one stream per open media element, so a real UI is two orders
 /// below this; the ceiling exists because each entry pins a content key and a
 /// root manifest carrying a CID per MiB of file, which an unbounded table turns
-/// into a memory and key-pinning DoS.
+/// into a memory and key-pinning DoS ([`EngineError::TooManyStreams`]).
 pub const MAX_OPEN_STREAMS: usize = 256;
 
 /// The engine's live read streams, bounded by [`MAX_OPEN_STREAMS`].
@@ -2464,9 +2459,7 @@ impl<T: SeamTypes> Engine<T> {
         }
     }
 
-    /// [`read_content`](Engine::read_content) without its progress phases. Kept
-    /// private and window-less: a multi-window read pins one version instead
-    /// ([`StreamHandle`], [`open_content_stream`](Engine::open_content_stream)).
+    /// [`read_content`](Engine::read_content) without its progress phases.
     async fn read_whole(&self, node: NodeId) -> Result<Vec<u8>, EngineError> {
         let (version, version_count) = self.head_version(node).await?;
         // The range clamps to the version's size, so the whole file is the
@@ -2492,9 +2485,7 @@ impl<T: SeamTypes> Engine<T> {
         // network on it; re-checked at the insert, the only borrow that is
         // atomic against opens which interleaved on the awaits between.
         if self.streams.borrow().open.len() >= MAX_OPEN_STREAMS {
-            return Err(EngineError::TooManyStreams {
-                limit: MAX_OPEN_STREAMS,
-            });
+            return Err(EngineError::TooManyStreams);
         }
         let (version, version_count) = self.head_version(node).await?;
         let manifest = open_content_root(&self.gateway, &self.seams.http, &version)
@@ -2503,9 +2494,7 @@ impl<T: SeamTypes> Engine<T> {
         self.project_head(node, &version, version_count);
         let mut streams = self.streams.borrow_mut();
         if streams.open.len() >= MAX_OPEN_STREAMS {
-            return Err(EngineError::TooManyStreams {
-                limit: MAX_OPEN_STREAMS,
-            });
+            return Err(EngineError::TooManyStreams);
         }
         streams.next += 1;
         let handle = StreamHandle(streams.next);
@@ -2559,8 +2548,7 @@ impl<T: SeamTypes> Engine<T> {
     ///
     /// The verified head is gate-passing state, so it may legally touch the base
     /// node's projected size/mtime. Repaint only on a real change — a repeat read
-    /// must not cascade — and only once the read succeeded, so a fail-closed
-    /// rejection folds nothing.
+    /// must not cascade.
     fn project_head(&self, node: NodeId, version: &Version, version_count: u64) {
         if project_child_version(
             &mut self.snapshot.borrow_mut(),

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -33,7 +33,8 @@ use crate::api::{ApiClient, ApiError, IdentityChallengeSigner};
 use crate::content::budget::{Refusal, ReservationId};
 use crate::content::{
     ContentKey, ContentProfile, ContentWriter, Gateway, GatewayConfig, OpenError, Refused,
-    SealError, StagingLedger, open_content_range, sealed_total_bytes,
+    RootManifest, SealError, StagingLedger, open_content_range, open_content_root,
+    read_pinned_range, sealed_total_bytes,
 };
 use crate::entropy::Entropy;
 use crate::gate::{GateError, floor};
@@ -88,6 +89,17 @@ pub struct NodeId(pub [u8; 16]);
 /// #815).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WriteHandle(pub u64);
+
+/// A live ranged-read stream, minted by [`Engine::open_content_stream`].
+///
+/// The head version and its verified DAG root manifest are pinned when the
+/// stream opens, so every window [`Engine::read_stream`] serves is a slice of
+/// that one authenticated object. Re-resolving per window would let a head
+/// change mid-stream splice two versions into one response body, which no
+/// downstream check can detect — every byte is still CID-verified and unsealed
+/// under its own version's key (#948).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StreamHandle(pub u64);
 
 /// What a write handle is writing to.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -654,6 +666,9 @@ pub enum EngineError {
     /// A write-handle call named a handle this engine does not hold — never
     /// minted, or already committed, failed, or aborted.
     UnknownWriteHandle,
+    /// A read named a stream handle this engine does not hold — never minted,
+    /// or already closed.
+    UnknownStreamHandle,
     /// [`Command::CancelUpload`] named an op that is no longer cancellable: its
     /// version's last block confirmed and its record is publishing, or it has
     /// already left the durable queue. Never converted into a compensating
@@ -819,6 +834,7 @@ impl fmt::Display for EngineError {
                 "the file changed while it was being read: {declared} bytes were declared and {observed} arrived"
             ),
             EngineError::UnknownWriteHandle => f.write_str("unknown write handle"),
+            EngineError::UnknownStreamHandle => f.write_str("unknown stream handle"),
             EngineError::TooLateToCancel { op_id } => write!(
                 f,
                 "upload {} is already publishing and can no longer be cancelled",
@@ -1110,6 +1126,20 @@ struct LiveWrites {
     next: u64,
 }
 
+/// What one [`StreamHandle`] pins: the head version resolved at open (holding
+/// its content key) and the root manifest its leaves are read against.
+struct LiveStream {
+    version: Version,
+    manifest: RootManifest,
+}
+
+/// The engine's live read streams.
+#[derive(Default)]
+struct LiveStreams {
+    open: BTreeMap<StreamHandle, Rc<LiveStream>>,
+    next: u64,
+}
+
 /// The re-point pointer-payload wire version the owner's own vault seals under
 /// and the cold-start walk verifies against (`crates/core` pointer payload) — the
 /// sole v2 version (CONTEXT.md "Vault pointer").
@@ -1137,6 +1167,9 @@ pub struct Engine<T: SeamTypes> {
     /// only: a restart drops every reservation, and the blocks a dropped handle
     /// staged are unreferenced and collectible as orphans.
     writes: RefCell<LiveWrites>,
+    /// Live read streams and the content version each pins. In memory only: a
+    /// restart drops them, and a host reopens.
+    streams: RefCell<LiveStreams>,
     /// The staging keys those handles hold — orphan GC's live set, shared with
     /// the tick loop that sweeps after each drain pass.
     live_blocks: Rc<RefCell<LiveBlocks>>,
@@ -1238,6 +1271,7 @@ impl<T: SeamTypes> Engine<T> {
                 storage_policy,
                 content_profile,
                 writes: RefCell::new(LiveWrites::default()),
+                streams: RefCell::new(LiveStreams::default()),
                 live_blocks: Rc::new(RefCell::new(LiveBlocks::default())),
                 cancels: Rc::new(RefCell::new(UploadCancels::default())),
                 api_base_url,
@@ -2414,9 +2448,8 @@ impl<T: SeamTypes> Engine<T> {
     }
 
     /// Read one byte window of a file node's plaintext, fetching only the leaves
-    /// the window covers (blueprint/engine.md "Content plane"). Emits no
-    /// [`Event::OpProgress`]: a media element issues one ranged read per seek and
-    /// per buffer refill, and a phase pair each would drown the stream.
+    /// the window covers (blueprint/engine.md "Content plane"). A stream reads
+    /// many windows off one version; this reads one off the current head.
     pub async fn read_content_range(
         &self,
         node: NodeId,
@@ -2430,9 +2463,81 @@ impl<T: SeamTypes> Engine<T> {
         let bytes = open_content_range(&self.gateway, &self.seams.http, &version, offset, length)
             .await
             .map_err(open_engine_error)?;
-        // The verified head version is gate-passing state, so it may legally
-        // touch the base node's projected size/mtime. Repaint only on a real
-        // change — a repeat read must not cascade.
+        self.project_head(node, &version, version_count);
+        Ok(bytes)
+    }
+
+    /// Open a ranged-read stream over a file node, pinning the head version and
+    /// its verified root manifest for the handle's whole life ([`StreamHandle`]).
+    ///
+    /// This is where a media read pays its resolve, its adoption gate, and its
+    /// root-manifest fetch — once, not once per window. Closed with
+    /// [`close_stream`](Engine::close_stream).
+    pub async fn open_content_stream(&self, node: NodeId) -> Result<StreamHandle, EngineError> {
+        if !self.started {
+            return Err(EngineError::NotStarted);
+        }
+        let (version, version_count) = self.head_version(node).await?;
+        let manifest = open_content_root(&self.gateway, &self.seams.http, &version)
+            .await
+            .map_err(open_engine_error)?;
+        self.project_head(node, &version, version_count);
+        let mut streams = self.streams.borrow_mut();
+        streams.next += 1;
+        let handle = StreamHandle(streams.next);
+        streams
+            .open
+            .insert(handle, Rc::new(LiveStream { version, manifest }));
+        Ok(handle)
+    }
+
+    /// Read one byte window of an open stream's pinned version, fetching only
+    /// the leaves the window covers. Clamped to the pinned version, so an offset
+    /// at or past its end yields no bytes. Emits no [`Event::OpProgress`]: a
+    /// media element pulls a window per seek and per buffer refill, and a phase
+    /// pair each would drown the stream.
+    pub async fn read_stream(
+        &self,
+        handle: StreamHandle,
+        offset: u64,
+        length: u64,
+    ) -> Result<Vec<u8>, EngineError> {
+        if !self.started {
+            return Err(EngineError::NotStarted);
+        }
+        // Lifted out of the map so the borrow does not span the awaits below;
+        // the pinned content key zeroizes when the last `Rc` drops.
+        let stream = self
+            .streams
+            .borrow()
+            .open
+            .get(&handle)
+            .map(Rc::clone)
+            .ok_or(EngineError::UnknownStreamHandle)?;
+        read_pinned_range(
+            &self.gateway,
+            &self.seams.http,
+            &stream.version,
+            &stream.manifest,
+            offset,
+            length,
+        )
+        .await
+        .map_err(open_engine_error)
+    }
+
+    /// Release a read stream. Idempotent — an unknown handle is already gone.
+    pub fn close_stream(&self, handle: StreamHandle) {
+        self.streams.borrow_mut().open.remove(&handle);
+    }
+
+    /// Repaint the base node from a head version a read has just verified.
+    ///
+    /// The verified head is gate-passing state, so it may legally touch the base
+    /// node's projected size/mtime. Repaint only on a real change — a repeat read
+    /// must not cascade — and only once the read succeeded, so a fail-closed
+    /// rejection folds nothing.
+    fn project_head(&self, node: NodeId, version: &Version, version_count: u64) {
         if project_child_version(
             &mut self.snapshot.borrow_mut(),
             node,
@@ -2442,7 +2547,6 @@ impl<T: SeamTypes> Engine<T> {
         ) {
             let _ = self.events.unbounded_send(Event::SnapshotUpdated);
         }
-        Ok(bytes)
     }
 
     /// Resolve one file node's head content version: base-snapshot lookup →

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -59,8 +59,9 @@ pub use content::{
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{
     BlockProgress, Breadcrumb, Command, DeadLetter, Engine, EngineError, EngineView, Event,
-    EventStream, LoginSecret, NodeAttrs, NodeId, NodeKind, OpPhase, OverBudgetCause, Permission,
-    SnapshotChild, SnapshotView, Staleness, StatFs, StreamHandle, WriteHandle, WriteTarget,
+    EventStream, LoginSecret, MAX_OPEN_STREAMS, NodeAttrs, NodeId, NodeKind, OpPhase,
+    OverBudgetCause, Permission, SnapshotChild, SnapshotView, Staleness, StatFs, StreamHandle,
+    WriteHandle, WriteTarget,
 };
 pub use gate::{
     Adopted, Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -60,7 +60,7 @@ pub use entropy::{Entropy, EntropyError};
 pub use facade::{
     BlockProgress, Breadcrumb, Command, DeadLetter, Engine, EngineError, EngineView, Event,
     EventStream, LoginSecret, NodeAttrs, NodeId, NodeKind, OpPhase, OverBudgetCause, Permission,
-    SnapshotChild, SnapshotView, Staleness, StatFs, WriteHandle, WriteTarget,
+    SnapshotChild, SnapshotView, Staleness, StatFs, StreamHandle, WriteHandle, WriteTarget,
 };
 pub use gate::{
     Adopted, Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason,

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -956,6 +956,125 @@ fn a_ranged_read_serves_the_same_bytes_as_the_slice_of_the_whole_file() {
     }
 }
 
+/// A stream pins the head version it opened on: a head change mid-stream leaves
+/// every later window a slice of the pinned version, never a splice of two
+/// (#948). Every byte of a spliced body is still CID-verified and unsealed under
+/// its own version's key, so nothing downstream could detect it.
+#[test]
+fn a_stream_serves_the_pinned_version_across_a_head_change() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    // Same length, disjoint bytes: a spliced window is a wrong-byte failure, not
+    // a length one, so the assertion catches the splice itself.
+    let first: Vec<u8> = (0..200u8).collect();
+    let second: Vec<u8> = (0..200u8).map(|byte| 255 - byte).collect();
+
+    let alice = world.device(b"alice");
+    let (mut engine_a, _events_a, mut tasks) = boot(&world, &blocks, &alice, 42);
+    write_file(
+        &mut engine_a,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "clip.bin".into(),
+        },
+        &first,
+    )
+    .expect("the write commits");
+    tick(&world, &engine_a, &mut tasks);
+    let node = child_id(&engine_a, ROOT, "clip.bin");
+
+    let bob = world.device(b"alice-second-device");
+    serve_http(&bob, &blocks, 400);
+    let (mut engine_b, _events_b) = engine_on(&bob, 7);
+    block_on(engine_b.start(secret())).unwrap();
+
+    let stream = block_on(engine_b.open_content_stream(node)).expect("the stream opens");
+    let mut assembled = block_on(engine_b.read_stream(stream, 0, 16)).expect("the first window");
+
+    // The owner's other device republishes the file under a new version while
+    // the stream is mid-body.
+    write_file(&mut engine_a, WriteTarget::Version { node }, &second).expect("the update commits");
+    tick(&world, &engine_a, &mut tasks);
+
+    while (assembled.len() as u64) < first.len() as u64 {
+        let window = block_on(engine_b.read_stream(stream, assembled.len() as u64, 16))
+            .expect("a later window");
+        assembled.extend_from_slice(&window);
+    }
+    assert_eq!(
+        assembled, first,
+        "the whole body is a slice of the version the stream opened on"
+    );
+
+    // The head really did move: a fresh read serves the new version, so the
+    // pinning above is not just a stale-resolve artifact.
+    assert_eq!(
+        block_on(engine_b.read_content(node)).expect("the head version reads"),
+        second
+    );
+
+    engine_b.close_stream(stream);
+    assert_eq!(
+        block_on(engine_b.read_stream(stream, 0, 16)),
+        Err(EngineError::UnknownStreamHandle),
+        "a closed handle reads nothing"
+    );
+}
+
+/// A stream resolves, gates, and verifies its root once, however many windows it
+/// serves — the per-window cost #641's ranged read paid on every megabyte.
+#[test]
+fn a_stream_pays_one_resolve_and_one_root_fetch_for_the_whole_body() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let plaintext: Vec<u8> = (0..200u8).collect();
+    let window = ContentProfile::CI.chunk_size();
+    // One window per leaf, so the leaf fetches a stream makes are countable.
+    let leaves = plaintext.len().div_ceil(window);
+
+    let alice = world.device(b"alice");
+    let (mut engine_a, _events_a, mut tasks) = boot(&world, &blocks, &alice, 42);
+    write_file(
+        &mut engine_a,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "clip.bin".into(),
+        },
+        &plaintext,
+    )
+    .expect("the write commits");
+    tick(&world, &engine_a, &mut tasks);
+    let node = child_id(&engine_a, ROOT, "clip.bin");
+
+    let bob = world.device(b"alice-second-device");
+    serve_http(&bob, &blocks, 400);
+    let (mut engine_b, _events_b) = engine_on(&bob, 7);
+    block_on(engine_b.start(secret())).unwrap();
+
+    let stream = block_on(engine_b.open_content_stream(node)).expect("the stream opens");
+    // Every routing endpoint goes dark once the stream is open: a window that
+    // re-resolved the node would fail here rather than serve.
+    for endpoint in world.record_store.endpoints() {
+        world.record_store.fail_endpoint(&endpoint);
+    }
+
+    let fetches_at_open = bob.http.requests().len();
+    let mut assembled = Vec::new();
+    while assembled.len() < plaintext.len() {
+        let bytes = block_on(engine_b.read_stream(stream, assembled.len() as u64, window as u64))
+            .expect("a window off the pinned version");
+        assembled.extend_from_slice(&bytes);
+    }
+    assert_eq!(assembled, plaintext);
+    assert_eq!(
+        bob.http.requests().len() - fetches_at_open,
+        leaves,
+        "one leaf per window and no root re-fetch"
+    );
+}
+
 /// A new version of an existing file takes the head of its version list and is
 /// what a second device downloads.
 #[test]

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -839,6 +839,43 @@ fn write_file(
     block_on(engine.commit_write(handle))
 }
 
+/// Alice publishes `plaintext` as `clip.bin` under the root, handing back her
+/// engine and pump tasks so a caller can republish over it.
+fn publish_clip(
+    world: &FakeWorld,
+    blocks: &Blocks,
+    plaintext: &[u8],
+) -> (Engine<FakeSeamTypes>, EventStream, Vec<BoxedTask>, NodeId) {
+    let alice = world.device(b"alice");
+    let (mut engine, events, mut tasks) = boot(world, blocks, &alice, 42);
+    write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "clip.bin".into(),
+        },
+        plaintext,
+    )
+    .expect("the write commits");
+    tick(world, &engine, &mut tasks);
+    let node = child_id(&engine, ROOT, "clip.bin");
+    (engine, events, tasks, node)
+}
+
+/// A started second device of the same account, its block plane wired for
+/// `calls` HTTP calls — the reader that only ever saw the network.
+fn open_reader(
+    world: &FakeWorld,
+    blocks: &Blocks,
+    calls: usize,
+) -> (FakeDevice, Engine<FakeSeamTypes>, EventStream) {
+    let device = world.device(b"alice-second-device");
+    serve_http(&device, blocks, calls);
+    let (mut engine, events) = engine_on(&device, 7);
+    block_on(engine.start(secret())).unwrap();
+    (device, engine, events)
+}
+
 /// The slice's headline: content bytes sliced by the client, sealed and staged
 /// per block by the engine, uploaded and published by the drain, and downloaded
 /// and verified byte-for-byte by a second device that only ever saw the network.
@@ -957,9 +994,8 @@ fn a_stream_window_serves_the_same_bytes_as_the_slice_of_the_whole_file() {
     engine_b.close_stream(stream);
 }
 
-/// The live-stream table is bounded: each open stream pins a content key and a
-/// root manifest, so an unbounded one is a memory and key-pinning DoS. Past the
-/// ceiling the open is refused fail-closed, never evicting a live stream.
+/// Past [`MAX_OPEN_STREAMS`] an open is refused fail-closed, never evicting a
+/// live stream.
 #[test]
 fn opening_past_the_stream_ceiling_is_refused() {
     let world = FakeWorld::new();
@@ -967,25 +1003,9 @@ fn opening_past_the_stream_ceiling_is_refused() {
     seed_account(&world, &blocks);
     let plaintext: Vec<u8> = (0..64u8).collect();
 
-    let alice = world.device(b"alice");
-    let (mut engine_a, _events_a, mut tasks) = boot(&world, &blocks, &alice, 42);
-    write_file(
-        &mut engine_a,
-        WriteTarget::NewFile {
-            parent: ROOT,
-            name: "clip.bin".into(),
-        },
-        &plaintext,
-    )
-    .expect("the write commits");
-    tick(&world, &engine_a, &mut tasks);
-    let node = child_id(&engine_a, ROOT, "clip.bin");
-
-    let bob = world.device(b"alice-second-device");
+    let (_engine_a, _events_a, _tasks, node) = publish_clip(&world, &blocks, &plaintext);
     // A few calls per open, plus the reads below.
-    serve_http(&bob, &blocks, MAX_OPEN_STREAMS * 8 + 64);
-    let (mut engine_b, _events_b) = engine_on(&bob, 7);
-    block_on(engine_b.start(secret())).unwrap();
+    let (_bob, engine_b, _events_b) = open_reader(&world, &blocks, MAX_OPEN_STREAMS * 8 + 64);
 
     let handles: Vec<_> = (0..MAX_OPEN_STREAMS)
         .map(|open| {
@@ -996,9 +1016,7 @@ fn opening_past_the_stream_ceiling_is_refused() {
 
     assert_eq!(
         block_on(engine_b.open_content_stream(node)),
-        Err(EngineError::TooManyStreams {
-            limit: MAX_OPEN_STREAMS
-        }),
+        Err(EngineError::TooManyStreams),
         "the open past the ceiling is refused"
     );
 
@@ -1013,9 +1031,7 @@ fn opening_past_the_stream_ceiling_is_refused() {
     let reopened = block_on(engine_b.open_content_stream(node)).expect("a freed slot admits one");
     assert_eq!(
         block_on(engine_b.open_content_stream(node)),
-        Err(EngineError::TooManyStreams {
-            limit: MAX_OPEN_STREAMS
-        }),
+        Err(EngineError::TooManyStreams),
         "the table is full again"
     );
     engine_b.close_stream(reopened);
@@ -1023,8 +1039,7 @@ fn opening_past_the_stream_ceiling_is_refused() {
 
 /// A stream pins the head version it opened on: a head change mid-stream leaves
 /// every later window a slice of the pinned version, never a splice of two
-/// (#948). Every byte of a spliced body is still CID-verified and unsealed under
-/// its own version's key, so nothing downstream could detect it.
+/// (#948).
 #[test]
 fn a_stream_serves_the_pinned_version_across_a_head_change() {
     let world = FakeWorld::new();
@@ -1035,24 +1050,8 @@ fn a_stream_serves_the_pinned_version_across_a_head_change() {
     let first: Vec<u8> = (0..200u8).collect();
     let second: Vec<u8> = (0..200u8).map(|byte| 255 - byte).collect();
 
-    let alice = world.device(b"alice");
-    let (mut engine_a, _events_a, mut tasks) = boot(&world, &blocks, &alice, 42);
-    write_file(
-        &mut engine_a,
-        WriteTarget::NewFile {
-            parent: ROOT,
-            name: "clip.bin".into(),
-        },
-        &first,
-    )
-    .expect("the write commits");
-    tick(&world, &engine_a, &mut tasks);
-    let node = child_id(&engine_a, ROOT, "clip.bin");
-
-    let bob = world.device(b"alice-second-device");
-    serve_http(&bob, &blocks, 400);
-    let (mut engine_b, _events_b) = engine_on(&bob, 7);
-    block_on(engine_b.start(secret())).unwrap();
+    let (mut engine_a, _events_a, mut tasks, node) = publish_clip(&world, &blocks, &first);
+    let (_bob, engine_b, _events_b) = open_reader(&world, &blocks, 400);
 
     let stream = block_on(engine_b.open_content_stream(node)).expect("the stream opens");
     let mut assembled = block_on(engine_b.read_stream(stream, 0, 16)).expect("the first window");
@@ -1099,24 +1098,8 @@ fn a_stream_pays_one_resolve_and_one_root_fetch_for_the_whole_body() {
     // One window per leaf, so the leaf fetches a stream makes are countable.
     let leaves = plaintext.len().div_ceil(window);
 
-    let alice = world.device(b"alice");
-    let (mut engine_a, _events_a, mut tasks) = boot(&world, &blocks, &alice, 42);
-    write_file(
-        &mut engine_a,
-        WriteTarget::NewFile {
-            parent: ROOT,
-            name: "clip.bin".into(),
-        },
-        &plaintext,
-    )
-    .expect("the write commits");
-    tick(&world, &engine_a, &mut tasks);
-    let node = child_id(&engine_a, ROOT, "clip.bin");
-
-    let bob = world.device(b"alice-second-device");
-    serve_http(&bob, &blocks, 400);
-    let (mut engine_b, _events_b) = engine_on(&bob, 7);
-    block_on(engine_b.start(secret())).unwrap();
+    let (_engine_a, _events_a, _tasks, node) = publish_clip(&world, &blocks, &plaintext);
+    let (bob, engine_b, _events_b) = open_reader(&world, &blocks, 400);
 
     let stream = block_on(engine_b.open_content_stream(node)).expect("the stream opens");
     // Every routing endpoint goes dark once the stream is open: a window that

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -1064,6 +1064,10 @@ fn a_stream_serves_the_pinned_version_across_a_head_change() {
     while (assembled.len() as u64) < first.len() as u64 {
         let window = block_on(engine_b.read_stream(stream, assembled.len() as u64, 16))
             .expect("a later window");
+        assert!(
+            !window.is_empty(),
+            "a window short of the end made no progress"
+        );
         assembled.extend_from_slice(&window);
     }
     assert_eq!(
@@ -1113,6 +1117,10 @@ fn a_stream_pays_one_resolve_and_one_root_fetch_for_the_whole_body() {
     while assembled.len() < plaintext.len() {
         let bytes = block_on(engine_b.read_stream(stream, assembled.len() as u64, window as u64))
             .expect("a window off the pinned version");
+        assert!(
+            !bytes.is_empty(),
+            "a window short of the end made no progress"
+        );
         assembled.extend_from_slice(&bytes);
     }
     assert_eq!(assembled, plaintext);

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -41,8 +41,8 @@ use cipherbox_engine::testkit::{
 };
 use cipherbox_engine::{
     BlockProgress, Command, ContentProfile, DeadLetter, DeadLetterReason, Engine, EngineError,
-    Event, EventStream, GatewayConfig, LoginSecret, NodeId, NodeKind, Op, OpPhase, RecordSeal,
-    StoragePolicy, SyncTimingProfile, WriteTarget, stage_op,
+    Event, EventStream, GatewayConfig, LoginSecret, MAX_OPEN_STREAMS, NodeId, NodeKind, Op,
+    OpPhase, RecordSeal, StoragePolicy, SyncTimingProfile, WriteTarget, stage_op,
 };
 
 const SECRET: [u8; 32] = [7u8; 32];
@@ -905,10 +905,10 @@ fn a_file_create_round_trips_its_bytes_to_a_second_device() {
     );
 }
 
-/// A ranged read walks the same gated resolve as the whole-file read and serves
-/// the matching slice — the media pipe's read path (#641).
+/// A stream's windows serve the matching slices of the whole-file read — the
+/// media pipe's read path (#641).
 #[test]
-fn a_ranged_read_serves_the_same_bytes_as_the_slice_of_the_whole_file() {
+fn a_stream_window_serves_the_same_bytes_as_the_slice_of_the_whole_file() {
     let world = FakeWorld::new();
     let blocks = Blocks::default();
     seed_account(&world, &blocks);
@@ -937,23 +937,88 @@ fn a_ranged_read_serves_the_same_bytes_as_the_slice_of_the_whole_file() {
     let whole = block_on(engine_b.read_content(node)).expect("the verified read serves it");
     assert_eq!(whole, plaintext);
 
+    let stream = block_on(engine_b.open_content_stream(node)).expect("the stream opens");
     for (offset, length) in [(0u64, 16u64), (16, 16), (15, 2), (40, 100), (190, 999)] {
         let end = (offset + length).min(whole.len() as u64) as usize;
         assert_eq!(
-            block_on(engine_b.read_content_range(node, offset, length))
-                .expect("the ranged read serves it"),
+            block_on(engine_b.read_stream(stream, offset, length)).expect("the window serves it"),
             whole[offset as usize..end],
             "range {offset}+{length}"
         );
     }
     for offset in [whole.len() as u64, whole.len() as u64 + 1, u64::MAX] {
         assert!(
-            block_on(engine_b.read_content_range(node, offset, 16))
+            block_on(engine_b.read_stream(stream, offset, 16))
                 .unwrap()
                 .is_empty(),
             "a window past the end is empty, not an error: offset {offset}"
         );
     }
+    engine_b.close_stream(stream);
+}
+
+/// The live-stream table is bounded: each open stream pins a content key and a
+/// root manifest, so an unbounded one is a memory and key-pinning DoS. Past the
+/// ceiling the open is refused fail-closed, never evicting a live stream.
+#[test]
+fn opening_past_the_stream_ceiling_is_refused() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let plaintext: Vec<u8> = (0..64u8).collect();
+
+    let alice = world.device(b"alice");
+    let (mut engine_a, _events_a, mut tasks) = boot(&world, &blocks, &alice, 42);
+    write_file(
+        &mut engine_a,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "clip.bin".into(),
+        },
+        &plaintext,
+    )
+    .expect("the write commits");
+    tick(&world, &engine_a, &mut tasks);
+    let node = child_id(&engine_a, ROOT, "clip.bin");
+
+    let bob = world.device(b"alice-second-device");
+    // A few calls per open, plus the reads below.
+    serve_http(&bob, &blocks, MAX_OPEN_STREAMS * 8 + 64);
+    let (mut engine_b, _events_b) = engine_on(&bob, 7);
+    block_on(engine_b.start(secret())).unwrap();
+
+    let handles: Vec<_> = (0..MAX_OPEN_STREAMS)
+        .map(|open| {
+            block_on(engine_b.open_content_stream(node))
+                .unwrap_or_else(|err| panic!("stream {open} opens: {err}"))
+        })
+        .collect();
+
+    assert_eq!(
+        block_on(engine_b.open_content_stream(node)),
+        Err(EngineError::TooManyStreams {
+            limit: MAX_OPEN_STREAMS
+        }),
+        "the open past the ceiling is refused"
+    );
+
+    // The refusal did not evict: an earlier handle still serves its version.
+    assert_eq!(
+        block_on(engine_b.read_stream(handles[0], 0, 16)).expect("the first stream still reads"),
+        plaintext[..16]
+    );
+
+    // Closing one frees exactly one slot.
+    engine_b.close_stream(handles[0]);
+    let reopened = block_on(engine_b.open_content_stream(node)).expect("a freed slot admits one");
+    assert_eq!(
+        block_on(engine_b.open_content_stream(node)),
+        Err(EngineError::TooManyStreams {
+            limit: MAX_OPEN_STREAMS
+        }),
+        "the table is full again"
+    );
+    engine_b.close_stream(reopened);
 }
 
 /// A stream pins the head version it opened on: a head change mid-stream leaves

--- a/crates/fuse/src/error.rs
+++ b/crates/fuse/src/error.rs
@@ -67,6 +67,10 @@ impl From<EngineError> for VfsError {
             }
             EngineError::OverBudget { cause, .. } => VfsError::OverBudget(cause),
             EngineError::ContentUnavailable { message } => VfsError::Unavailable { message },
+            // Retryable once the mount closes a stream, not a storage verdict.
+            error @ EngineError::TooManyStreams { .. } => VfsError::Unavailable {
+                message: error.to_string(),
+            },
             EngineError::UnsupportedContentFormat { version } => VfsError::Unavailable {
                 message: format!("unsupported content format version {version}"),
             },

--- a/crates/fuse/src/error.rs
+++ b/crates/fuse/src/error.rs
@@ -68,7 +68,7 @@ impl From<EngineError> for VfsError {
             EngineError::OverBudget { cause, .. } => VfsError::OverBudget(cause),
             EngineError::ContentUnavailable { message } => VfsError::Unavailable { message },
             // Retryable once the mount closes a stream, not a storage verdict.
-            error @ EngineError::TooManyStreams { .. } => VfsError::Unavailable {
+            error @ EngineError::TooManyStreams => VfsError::Unavailable {
                 message: error.to_string(),
             },
             EngineError::UnsupportedContentFormat { version } => VfsError::Unavailable {

--- a/crates/fuse/src/error.rs
+++ b/crates/fuse/src/error.rs
@@ -83,6 +83,7 @@ impl From<EngineError> for VfsError {
             | EngineError::InvalidSecret
             | EngineError::ContentSizeMismatch { .. }
             | EngineError::UnknownWriteHandle
+            | EngineError::UnknownStreamHandle
             | EngineError::ContentKeySealFailed { .. }
             | EngineError::TooLateToCancel { .. }
             | EngineError::NotAnUpload { .. }

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -22,7 +22,7 @@ use cipherbox_engine::facade::{Engine, EngineError, EventStream, LoginSecret};
 use cipherbox_engine::seams::OpId;
 use cipherbox_engine::{
     ContentProfile, Entropy, EntropyError, GatewayConfig, GatewaySource, SeamSet, SeamTypes,
-    StoragePlatform, StoragePolicy, SyncTimingProfile, WriteHandle, WriteTarget,
+    StoragePlatform, StoragePolicy, StreamHandle, SyncTimingProfile, WriteHandle, WriteTarget,
 };
 use js_sys::{Promise, Reflect, Uint8Array};
 use wasm_bindgen::prelude::*;
@@ -381,30 +381,59 @@ impl EngineHandle {
         })
     }
 
-    /// Downloads and decrypts one byte window of a file node's content, fetching
-    /// only the leaves the window covers. The range is clamped to the file, so a
-    /// window past the end resolves empty. Resolves with the plaintext bytes as a
-    /// `Uint8Array`; rejects with the engine error.
-    #[wasm_bindgen(js_name = downloadRange)]
-    pub fn download_range(&self, node: &NodeId, offset: f64, length: f64) -> Promise {
+    /// Opens a ranged-read stream over a file node, pinning the head version for
+    /// the handle's whole life so no window can come from a different one.
+    /// Resolves with the handle id; rejects with the engine error.
+    #[wasm_bindgen(js_name = openContentStream)]
+    pub fn open_content_stream(&self, node: &NodeId) -> Promise {
         let engine = self.engine.clone();
         let node = node.facade();
         future_to_promise(async move {
-            // A saturating float-to-int cast would silently read a different window.
-            if !offset.is_finite() || offset < 0.0 || !length.is_finite() || length < 0.0 {
+            let handle = engine
+                .read()
+                .await
+                .open_content_stream(node)
+                .await
+                .map_err(engine_error)?;
+            Ok(JsValue::from(handle.0))
+        })
+    }
+
+    /// Decrypts one byte window of an open stream's pinned version, fetching
+    /// only the leaves the window covers. The range is clamped to the version,
+    /// so a window past the end resolves empty. Resolves with the plaintext
+    /// bytes as a `Uint8Array`; rejects with the engine error.
+    #[wasm_bindgen(js_name = readStream)]
+    pub fn read_stream(&self, handle: u64, offset: f64, length: f64) -> Promise {
+        let engine = self.engine.clone();
+        future_to_promise(async move {
+            // A float-to-int cast saturates and truncates, either of which would
+            // silently read a different window than the caller named.
+            let whole = |value: f64| value.is_finite() && value >= 0.0 && value.fract() == 0.0;
+            if !whole(offset) || !whole(length) {
                 return Err(JsError::new(
-                    "downloadRange offset and length must be non-negative finite numbers",
+                    "readStream offset and length must be non-negative whole numbers",
                 )
                 .into());
             }
             let bytes = engine
                 .read()
                 .await
-                .read_content_range(node, offset as u64, length as u64)
+                .read_stream(StreamHandle(handle), offset as u64, length as u64)
                 .await
                 .map_err(engine_error)?;
             let bytes = Zeroizing::new(bytes);
             Ok(Uint8Array::from(bytes.as_slice()).into())
+        })
+    }
+
+    /// Releases a read stream. Always resolves — an unknown handle is already gone.
+    #[wasm_bindgen(js_name = closeStream)]
+    pub fn close_stream(&self, handle: u64) -> Promise {
+        let engine = self.engine.clone();
+        future_to_promise(async move {
+            engine.read().await.close_stream(StreamHandle(handle));
+            Ok(JsValue::UNDEFINED)
         })
     }
 
@@ -449,6 +478,7 @@ fn engine_error(error: EngineError) -> JsValue {
         EngineError::OverBudget { .. } => "overBudget",
         EngineError::ContentSizeMismatch { .. } => "contentSizeMismatch",
         EngineError::UnknownWriteHandle => "unknownWriteHandle",
+        EngineError::UnknownStreamHandle => "unknownStreamHandle",
         EngineError::TooLateToCancel { .. } => "tooLateToCancel",
         EngineError::NotAnUpload { .. } => "notAnUpload",
         EngineError::ContentTooLarge { .. } => "contentTooLarge",

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -409,10 +409,12 @@ impl EngineHandle {
         future_to_promise(async move {
             // A float-to-int cast saturates and truncates, either of which would
             // silently read a different window than the caller named.
-            let whole = |value: f64| value.is_finite() && value >= 0.0 && value.fract() == 0.0;
+            let whole = |value: f64| {
+                value.is_finite() && value >= 0.0 && value < u64::MAX as f64 && value.fract() == 0.0
+            };
             if !whole(offset) || !whole(length) {
                 return Err(JsError::new(
-                    "readStream offset and length must be non-negative whole numbers",
+                    "readStream offset and length must be whole numbers in the u64 range",
                 )
                 .into());
             }

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -479,7 +479,7 @@ fn engine_error(error: EngineError) -> JsValue {
         EngineError::ContentSizeMismatch { .. } => "contentSizeMismatch",
         EngineError::UnknownWriteHandle => "unknownWriteHandle",
         EngineError::UnknownStreamHandle => "unknownStreamHandle",
-        EngineError::TooManyStreams { .. } => "tooManyStreams",
+        EngineError::TooManyStreams => "tooManyStreams",
         EngineError::TooLateToCancel { .. } => "tooLateToCancel",
         EngineError::NotAnUpload { .. } => "notAnUpload",
         EngineError::ContentTooLarge { .. } => "contentTooLarge",

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -479,6 +479,7 @@ fn engine_error(error: EngineError) -> JsValue {
         EngineError::ContentSizeMismatch { .. } => "contentSizeMismatch",
         EngineError::UnknownWriteHandle => "unknownWriteHandle",
         EngineError::UnknownStreamHandle => "unknownStreamHandle",
+        EngineError::TooManyStreams { .. } => "tooManyStreams",
         EngineError::TooLateToCancel { .. } => "tooLateToCancel",
         EngineError::NotAnUpload { .. } => "notAnUpload",
         EngineError::ContentTooLarge { .. } => "contentTooLarge",

--- a/packages/client/src/broadcast.ts
+++ b/packages/client/src/broadcast.ts
@@ -50,8 +50,10 @@ export type WireStream =
 
 /**
  * Follower → leader, over that follower's private read port. Streams ride here
- * rather than on the channel because a `readStream` window *is* plaintext, and
- * because possession of the port authenticates the owner of a stream handle.
+ * rather than on the channel because a `readStream` window *is* plaintext. The
+ * port is as authenticated as the `cb:leader` beacon and no more — its owner is
+ * self-asserted — so binding a handle to a client is lifecycle bookkeeping, not
+ * authorization; same origin remains the trust boundary.
  */
 export type ReadPortRequest =
   /** Names the sender, binding the port to a client the leader can reclaim it for. */

--- a/packages/client/src/broadcast.ts
+++ b/packages/client/src/broadcast.ts
@@ -50,10 +50,9 @@ export type WireStream =
 
 /**
  * Follower → leader, over that follower's private read port. Streams ride here
- * rather than on the channel because a `readStream` window *is* plaintext. The
- * port is as authenticated as the `cb:leader` beacon and no more — its owner is
- * self-asserted — so binding a handle to a client is lifecycle bookkeeping, not
- * authorization; same origin remains the trust boundary.
+ * rather than on the channel because a `readStream` window *is* plaintext. Port
+ * ownership is self-asserted, so binding a handle to a client is lifecycle
+ * bookkeeping, not authorization — same origin remains the trust boundary.
  */
 export type ReadPortRequest =
   /** Names the sender, binding the port to a client the leader can reclaim it for. */

--- a/packages/client/src/broadcast.ts
+++ b/packages/client/src/broadcast.ts
@@ -23,6 +23,7 @@ import type {
   CommandDescriptor,
   EventDescriptor,
   SnapshotDescriptor,
+  StreamHandle,
   WriteHandle,
   WriteTarget,
 } from './worker/protocol.js';
@@ -39,20 +40,32 @@ export interface BroadcastChannelLike {
 export type WireRead =
   | { kind: 'snapshot'; folder: Uint8Array | null }
   | { kind: 'siweChallenge' }
-  | { kind: 'download'; node: Uint8Array }
-  | { kind: 'downloadRange'; node: Uint8Array; offset: number; length: number };
+  | { kind: 'download'; node: Uint8Array };
 
-/** Follower → leader, over that follower's private read port. */
+/** A follower ranged-read step, driven against the leader's engine stream. */
+export type WireStream =
+  | { kind: 'openContentStream'; node: Uint8Array }
+  | { kind: 'readStream'; handle: StreamHandle; offset: number; length: number }
+  | { kind: 'closeStream'; handle: StreamHandle };
+
+/**
+ * Follower → leader, over that follower's private read port. Streams ride here
+ * rather than on the channel because a `readStream` window *is* plaintext, and
+ * because possession of the port authenticates the owner of a stream handle.
+ */
 export type ReadPortRequest =
   /** Names the sender, binding the port to a client the leader can reclaim it for. */
   | { type: 'cb:portHello'; clientId: string }
   /** A correlated read; the leader answers with a matching `cb:portResult`. */
-  | { type: 'cb:portRead'; requestId: number; read: WireRead };
+  | { type: 'cb:portRead'; requestId: number; read: WireRead }
+  /** A correlated ranged-read step, run against the leader's engine stream. */
+  | { type: 'cb:portStream'; requestId: number; stream: WireStream };
 
 /**
- * Leader → follower, over that follower's private read port. A `download` /
- * `downloadRange` result is the plaintext buffer itself, transferred rather than
- * cloned; a snapshot carries the descriptor; a SIWE challenge the nonce string.
+ * Leader → follower, over that follower's private read port. A `download` or
+ * `readStream` result is the plaintext buffer itself, transferred rather than
+ * cloned; a snapshot carries the descriptor; a SIWE challenge the nonce string;
+ * an `openContentStream` the handle naming the pinned content version.
  */
 export type ReadPortResponse =
   /** The leader adopted this port, naming the leadership that answers on it. */
@@ -64,7 +77,7 @@ export type ReadPortResponse =
       type: 'cb:portResult';
       requestId: number;
       ok: true;
-      result?: SnapshotDescriptor | ArrayBuffer | string;
+      result?: SnapshotDescriptor | ArrayBuffer | string | StreamHandle;
     }
   | { type: 'cb:portResult'; requestId: number; ok: false; error: string; code?: string };
 

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -257,39 +257,64 @@ describe('broadcast transport ↔ leader relay', () => {
     expect(engine.siweChallenges).toBe(1);
   });
 
-  it('serves a follower downloadRange over the private port and rebuilds the window bytes', async () => {
+  it('serves a follower stream window over the private port and rebuilds the window bytes', async () => {
     const { engine, follower } = wire();
     const file = Uint8Array.from({ length: 256 }, (_, i) => (i * 3 + 1) & 0xff);
-    engine.respondDownloadRange = (_node, offset, length) =>
+    engine.respondReadStream = (_handle, offset, length) =>
       Promise.resolve(file.slice(offset, offset + length).buffer);
 
     const node = new Uint8Array(16).fill(6);
-    const window = await follower.downloadRange(node, 64, 32);
+    const handle = await follower.openContentStream(node);
+    const window = await follower.readStream(handle, 64, 32);
+    await follower.closeStream(handle);
+
     expect([...new Uint8Array(window)]).toEqual([...file.slice(64, 96)]);
     // A dropped or clamped offset slices the wrong plaintext with every
     // integrity check still passing.
-    expect(engine.downloadRanges).toEqual([{ node, offset: 64, length: 32 }]);
+    expect(engine.opened).toEqual([node]);
+    expect(engine.reads).toEqual([{ handle, offset: 64, length: 32 }]);
+    expect(engine.closedStreams).toEqual([handle]);
   });
 
-  it('rejects an in-flight downloadRange retryably when the leader steps down', async () => {
+  it('refuses a stream handle the asking follower does not own', async () => {
+    const bus = new FakeBus();
+    const ports = new FakeCourierNetwork();
+    const engine = new FakeEngineTransport();
+    new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
+    const owner = new BroadcastTransport(bus.channel(), 'owner', ports.courier('owner'));
+    const other = new BroadcastTransport(bus.channel(), 'other', ports.courier('other'));
+    await owner.start();
+    await other.start();
+
+    const handle = await owner.openContentStream(new Uint8Array(16));
+    // A handle is a capability: the relay binds it to the tab that opened it.
+    await expect(other.readStream(handle, 0, 8)).rejects.toMatchObject({
+      code: 'unknownStreamHandle',
+    });
+    expect(engine.reads).toEqual([]);
+  });
+
+  it('rejects an in-flight stream read retryably when the leader steps down', async () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
     const engineA = new FakeEngineTransport();
-    engineA.respondDownloadRange = () => new Promise(() => undefined); // leader A never answers
+    engineA.respondReadStream = () => new Promise(() => undefined); // leader A never answers
     const relayA = new LeaderRelay(bus.channel(), engineA, ports.courier('leaderA'));
     const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
     await follower.start();
 
-    const inFlight = follower.downloadRange(new Uint8Array(16), 0, 8);
+    const handle = await follower.openContentStream(new Uint8Array(16));
+    const inFlight = follower.readStream(handle, 0, 8);
     await tick();
     relayA.close();
     await expect(inFlight).rejects.toThrow(/retry/);
 
     // The next leader serves the retry, so the swap costs a retry, never a hang.
     const engineB = new FakeEngineTransport();
-    engineB.respondDownloadRange = () => Promise.resolve(new Uint8Array([1, 2]).buffer);
+    engineB.respondReadStream = () => Promise.resolve(new Uint8Array([1, 2]).buffer);
     new LeaderRelay(bus.channel(), engineB, ports.courier('leaderB'));
-    const retried = await follower.downloadRange(new Uint8Array(16), 0, 2);
+    const reopened = await follower.openContentStream(new Uint8Array(16));
+    const retried = await follower.readStream(reopened, 0, 2);
     expect([...new Uint8Array(retried)]).toEqual([1, 2]);
   });
 
@@ -315,7 +340,7 @@ describe('broadcast transport ↔ leader relay', () => {
     const ports = new FakeCourierNetwork();
     const engine = new FakeEngineTransport();
     const plaintext = Uint8Array.from({ length: 96 }, (_, i) => (i * 17 + 9) & 0xff);
-    engine.respondDownloadRange = (_node, offset, length) =>
+    engine.respondReadStream = (_handle, offset, length) =>
       Promise.resolve(plaintext.slice(offset, offset + length).buffer);
     engine.respondSnapshot = () => Promise.resolve(emptySnapshot(new Uint8Array(16).fill(8)));
     new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
@@ -327,9 +352,11 @@ describe('broadcast transport ↔ leader relay', () => {
 
     const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
     await follower.snapshot(new Uint8Array(16));
+    const handle = await follower.openContentStream(new Uint8Array(16).fill(6));
     for (let offset = 0; offset < 96; offset += 32) {
-      await follower.downloadRange(new Uint8Array(16).fill(6), offset, 32);
+      await follower.readStream(handle, offset, 32);
     }
+    await follower.closeStream(handle);
     await tick();
 
     // Election and rendezvous only — every read result rode the private port.

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -482,6 +482,35 @@ describe('broadcast transport ↔ leader relay', () => {
     await expect(follower.snapshot(null)).resolves.toMatchObject({ staleness: 'fresh' });
   });
 
+  it('wipes a read window nobody can receive rather than leaving the plaintext behind', async () => {
+    const bus = new FakeBus();
+    const ports = new FakeCourierNetwork();
+    const engine = new FakeEngineTransport();
+    new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
+    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
+    await follower.snapshot(null); // brokers and adopts the port
+
+    const plaintext = Uint8Array.of(1, 2, 3, 4);
+    let release!: () => void;
+    engine.respondDownload = async () => {
+      await new Promise<void>((resolve) => (release = resolve));
+      return plaintext.buffer;
+    };
+
+    // Awaited only after the wipe, so the rejection is handled from the outset.
+    const settled = expect(follower.download(new Uint8Array(16).fill(1))).rejects.toThrow(/retry/);
+    await tick();
+    // Any same-origin context can post this; the leader then drops the port the
+    // window was going to be transferred down.
+    bus.channel().postMessage({ type: 'cb:bye', clientId: 'f' });
+    await tick();
+    release();
+    await settled;
+    await tick();
+
+    expect([...plaintext]).toEqual([0, 0, 0, 0]);
+  });
+
   it('reclaims a dialed port that never named the follower behind it', async () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
@@ -749,6 +778,42 @@ describe('leader relay write handles', () => {
     expect(engine.aborts).toEqual([orphan]);
     await expect(staying.pushChunk(kept, chunk(1))).resolves.toBeUndefined();
     expect(engine.chunks.map((entry) => entry.handle)).toEqual([kept]);
+  });
+
+  it('keeps serving a live follower after a cb:bye it never sent', async () => {
+    const { bus, ports, engine } = bench();
+    const follower = new BroadcastTransport(bus.channel(), 'f1', ports.courier('f1'));
+    await follower.beginWrite({ node: node(1) }, 4);
+
+    // Any same-origin context can forge this. It costs the tab its open handles,
+    // but must not refuse every handle it asks for afterwards.
+    bus.channel().postMessage({ type: 'cb:bye', clientId: 'f1' });
+    await tick();
+
+    engine.writeHandle = 2n;
+    await expect(follower.beginWrite({ node: node(2) }, 4)).resolves.toBe(2n);
+  });
+
+  it('refuses a handle minted for a client that left mid-mint, spelled as the engine spells it', async () => {
+    const { bus, engine } = bench();
+    // No courier: the forged `cb:bye` then has no read port to detach, so the
+    // refusal below is the relay's own and not a dropped-port retry.
+    const follower = new BroadcastTransport(bus.channel(), 'f1', unavailableCourier, {
+      portTimeoutMs: 5,
+    });
+    let releaseMint!: (handle: bigint) => void;
+    engine.beginWrite = () => new Promise((resolve) => (releaseMint = resolve));
+
+    const pending = follower.beginWrite({ node: node(1) }, 4);
+    await tick();
+    bus.channel().postMessage({ type: 'cb:bye', clientId: 'f1' });
+    await tick();
+    releaseMint(7n);
+
+    await expect(pending).rejects.toMatchObject({ code: 'unknownWriteHandle' });
+    // The handle the sweep could not see is released, not stranded.
+    await tick();
+    expect(engine.aborts).toEqual([7n]);
   });
 
   it('releases every open handle when the leader steps down', async () => {

--- a/packages/client/src/broadcastTransport.ts
+++ b/packages/client/src/broadcastTransport.ts
@@ -27,6 +27,7 @@ import {
   type ReadPortRequest,
   type ReadPortResponse,
   type WireRead,
+  type WireStream,
   type WireWrite,
 } from './broadcast.js';
 import { CorrelatedTransport } from './correlatedTransport.js';
@@ -34,6 +35,7 @@ import type { MessagePortLike, PortCourier } from './portRelay.js';
 import type {
   CommandDescriptor,
   SnapshotDescriptor,
+  StreamHandle,
   WriteHandle,
   WriteTarget,
 } from './worker/protocol.js';
@@ -134,13 +136,29 @@ export class BroadcastTransport extends CorrelatedTransport {
     return this.read<ArrayBuffer>({ kind: 'download', node });
   }
 
-  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
-    return this.read<ArrayBuffer>({ kind: 'downloadRange', node, offset, length });
+  openContentStream(node: Uint8Array): Promise<StreamHandle> {
+    return this.stream<StreamHandle>({ kind: 'openContentStream', node });
+  }
+
+  readStream(handle: StreamHandle, offset: number, length: number): Promise<ArrayBuffer> {
+    return this.stream<ArrayBuffer>({ kind: 'readStream', handle, offset, length });
+  }
+
+  closeStream(handle: StreamHandle): Promise<void> {
+    return this.stream<void>({ kind: 'closeStream', handle });
   }
 
   private read<T>(read: WireRead): Promise<T> {
+    return this.overPort<T>((requestId) => ({ type: 'cb:portRead', requestId, read }));
+  }
+
+  private stream<T>(stream: WireStream): Promise<T> {
+    return this.overPort<T>((requestId) => ({ type: 'cb:portStream', requestId, stream }));
+  }
+
+  private overPort<T>(build: (requestId: number) => ReadPortRequest): Promise<T> {
     return this.request<T, MessagePortLike>(this.ensurePort(), (requestId, port) => {
-      port.postMessage({ type: 'cb:portRead', requestId, read } satisfies ReadPortRequest);
+      port.postMessage(build(requestId));
     });
   }
 

--- a/packages/client/src/broadcastTransport.ts
+++ b/packages/client/src/broadcastTransport.ts
@@ -47,7 +47,7 @@ export interface BroadcastTransportOptions {
   portTimeoutMs?: number;
   /**
    * Fires when leadership moves while this tab stays a follower. The engine
-   * behind this transport is replaced without the transport object being, so
+   * behind this transport is replaced but the transport object is not, so
    * whatever the owner holds against the old engine has to be retired here.
    */
   onLeadershipChange?: () => void;

--- a/packages/client/src/broadcastTransport.ts
+++ b/packages/client/src/broadcastTransport.ts
@@ -45,6 +45,12 @@ const DEFAULT_PORT_TIMEOUT_MS = 5000;
 
 export interface BroadcastTransportOptions {
   portTimeoutMs?: number;
+  /**
+   * Fires when leadership moves while this tab stays a follower. The engine
+   * behind this transport is replaced without the transport object being, so
+   * whatever the owner holds against the old engine has to be retired here.
+   */
+  onLeadershipChange?: () => void;
 }
 
 export class BroadcastTransport extends CorrelatedTransport {
@@ -72,6 +78,7 @@ export class BroadcastTransport extends CorrelatedTransport {
   private settleHost: ((address: string) => void) | null = null;
   private settleBrokerage: (() => void) | null = null;
   private readonly portTimeoutMs: number;
+  private readonly onLeadershipChange: () => void;
 
   private readonly onMessage = (event: MessageEvent): void => this.receive(event.data);
 
@@ -83,6 +90,7 @@ export class BroadcastTransport extends CorrelatedTransport {
   ) {
     super();
     this.portTimeoutMs = options.portTimeoutMs ?? DEFAULT_PORT_TIMEOUT_MS;
+    this.onLeadershipChange = options.onLeadershipChange ?? ((): void => undefined);
     this.armLeaderReady();
     this.channel.addEventListener('message', this.onMessage);
     // Announce ourselves so a live leader replies with a `leader` beacon.
@@ -368,6 +376,7 @@ export class BroadcastTransport extends CorrelatedTransport {
       // leader crashed): reject requests bound to it so the UI retries the new
       // leader. New commands go to the new leader once the token is adopted.
       this.rejectPending(retryError());
+      this.onLeadershipChange();
     }
     this.leaderToken = token;
     this.resolveLeaderReady();
@@ -381,6 +390,7 @@ export class BroadcastTransport extends CorrelatedTransport {
     this.leaderToken = null;
     this.dropPort(retryError());
     this.rejectPending(retryError());
+    this.onLeadershipChange();
     // Re-arm so subsequent commands await the next leader rather than resolving
     // against the departed one.
     this.armLeaderReady();

--- a/packages/client/src/correlatedTransport.ts
+++ b/packages/client/src/correlatedTransport.ts
@@ -16,6 +16,7 @@ import type {
   CommandDescriptor,
   EventDescriptor,
   SnapshotDescriptor,
+  StreamHandle,
   WriteHandle,
   WriteTarget,
 } from './worker/protocol.js';
@@ -73,7 +74,9 @@ export abstract class CorrelatedTransport implements EngineTransport {
   abstract snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor>;
   abstract siweChallenge(): Promise<string>;
   abstract download(node: Uint8Array): Promise<ArrayBuffer>;
-  abstract downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer>;
+  abstract openContentStream(node: Uint8Array): Promise<StreamHandle>;
+  abstract readStream(handle: StreamHandle, offset: number, length: number): Promise<ArrayBuffer>;
+  abstract closeStream(handle: StreamHandle): Promise<void>;
   abstract close(): void;
 
   subscribe(listener: EngineEventListener): () => void {

--- a/packages/client/src/correlatedTransport.ts
+++ b/packages/client/src/correlatedTransport.ts
@@ -42,6 +42,21 @@ export class EngineRequestError extends Error {
   }
 }
 
+/** Which of the engine's handle tables a step addresses. */
+export type HandleKind = 'write' | 'stream';
+
+/**
+ * Refuses a step on a handle the refusing layer cannot serve, spelled exactly
+ * like the engine's own unknown-handle error: a probing tab learns nothing a
+ * legitimate one would not. Mirrors `EngineError::Unknown*Handle`.
+ */
+export function unknownHandle(kind: HandleKind): EngineRequestError {
+  return new EngineRequestError(
+    `unknown ${kind} handle`,
+    kind === 'write' ? 'unknownWriteHandle' : 'unknownStreamHandle'
+  );
+}
+
 /**
  * Delivers one event to every listener, isolating a throwing subscriber so it
  * cannot drop the event for the rest.

--- a/packages/client/src/engineClient.test.ts
+++ b/packages/client/src/engineClient.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { EngineClient, type EngineClientConfig } from './engineClient.js';
-import { FakeBus, FakeEngineWorker, FakeLockManager } from './testkit.js';
+import { FakeBus, FakeCourierNetwork, FakeEngineWorker, FakeLockManager } from './testkit.js';
 import type { EventDescriptor } from './worker/protocol.js';
 
 const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
@@ -10,6 +10,8 @@ const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0
 function origin() {
   const locks = new FakeLockManager();
   const bus = new FakeBus();
+  const ports = new FakeCourierNetwork();
+  let tabs = 0;
   const workers: FakeEngineWorker[] = [];
   const spawnWorker = (): FakeEngineWorker => {
     const worker = new FakeEngineWorker();
@@ -24,6 +26,7 @@ function origin() {
       locks,
       createChannel: () => bus.channel(),
       spawnWorker,
+      courier: ports.courier(`tab${(tabs += 1)}`),
       ...overrides,
     });
 
@@ -101,6 +104,36 @@ describe('EngineClient leadership + transport swap', () => {
       (m) => (m as { type?: string }).type === 'start'
     );
     expect(startPosted).toBe(true);
+    await follower.dispose();
+  });
+
+  it('refuses a stream handle minted by a leadership that has been replaced', async () => {
+    const { tab } = origin();
+    const secretSource = {
+      provideSecret: (): Promise<ArrayBuffer> => Promise.resolve(new Uint8Array([1]).buffer),
+    };
+    const leader = tab();
+    const follower = tab({ secretSource });
+    await tick();
+    await follower.facade.start(new Uint8Array([9]).buffer);
+
+    const stale = await follower.openContentStream(new Uint8Array(16).fill(1));
+
+    await leader.dispose();
+    await tick();
+    await tick();
+    expect(follower.currentRole()).toBe('leader');
+
+    // The promoted tab's fresh engine mints from 1 as well, so a handle carried
+    // across the swap would name whatever that engine opened next — a different
+    // node's bytes served at this stream's offsets, with every integrity check
+    // still passing.
+    const reopened = await follower.openContentStream(new Uint8Array(16).fill(2));
+    expect(reopened).not.toBe(stale);
+    await expect(follower.readStream(stale, 0, 8)).rejects.toMatchObject({
+      code: 'unknownStreamHandle',
+    });
+
     await follower.dispose();
   });
 

--- a/packages/client/src/engineClient.test.ts
+++ b/packages/client/src/engineClient.test.ts
@@ -145,10 +145,8 @@ describe('EngineClient leadership + transport swap', () => {
     await tick();
     expect(follower.currentRole()).toBe('leader');
 
-    // The promoted tab's fresh engine mints from 1 as well, so a handle carried
-    // across the swap would name whatever that engine opened next — a different
-    // node's bytes served at this stream's offsets, with every integrity check
-    // still passing.
+    // The promoted tab's engine mints from 1 too, so a carried-over handle would
+    // alias the next stream it opens (`EngineClient.streams`).
     const reopened = await follower.openContentStream(new Uint8Array(16).fill(2));
     expect(reopened).not.toBe(stale);
     await expect(follower.readStream(stale, 0, 8)).rejects.toMatchObject({
@@ -384,9 +382,8 @@ describe('EngineClient leadership + transport swap', () => {
     for (let i = 0; i < 4; i += 1) await tick();
     expect(follower.currentRole()).toBe('follower');
 
-    // Every engine's stream counter restarts at 1, so a handle carried across a
-    // leadership this tab merely observed would name a live stream over a
-    // different node on the new leader's engine.
+    // The fence has to fire on a leadership this tab merely observed, not only
+    // on one it was promoted through (`EngineClient.streams`).
     await follower.openContentStream(new Uint8Array(16).fill(2));
     await expect(follower.readStream(stale, 0, 8)).rejects.toMatchObject({
       code: 'unknownStreamHandle',

--- a/packages/client/src/engineClient.test.ts
+++ b/packages/client/src/engineClient.test.ts
@@ -129,7 +129,7 @@ describe('EngineClient leadership + transport swap', () => {
   });
 
   it('refuses a stream handle minted by a leadership that has been replaced', async () => {
-    const { tab } = origin();
+    const { tab, workers } = origin();
     const secretSource = {
       provideSecret: (): Promise<ArrayBuffer> => Promise.resolve(new Uint8Array([1]).buffer),
     };
@@ -149,6 +149,12 @@ describe('EngineClient leadership + transport swap', () => {
     // alias the next stream it opens (`EngineClient.streams`).
     const reopened = await follower.openContentStream(new Uint8Array(16).fill(2));
     expect(reopened).not.toBe(stale);
+    await follower.readStream(reopened, 0, 8);
+    const promoted = workers[workers.length - 1];
+    expect(promoted.posted).toContainEqual(
+      expect.objectContaining({ type: 'readStream', handle: 1n, offset: 0, length: 8 })
+    );
+
     await expect(follower.readStream(stale, 0, 8)).rejects.toMatchObject({
       code: 'unknownStreamHandle',
     });
@@ -384,11 +390,16 @@ describe('EngineClient leadership + transport swap', () => {
 
     // The fence has to fire on a leadership this tab merely observed, not only
     // on one it was promoted through (`EngineClient.streams`).
-    await follower.openContentStream(new Uint8Array(16).fill(2));
+    const fresh = await follower.openContentStream(new Uint8Array(16).fill(2));
+    const window_ = await follower.readStream(fresh, 0, 8);
+    expect(window_.byteLength).toBe(8);
+    expect(engineB.reads).toEqual([{ handle: 1n, offset: 0, length: 8 }]);
+
     await expect(follower.readStream(stale, 0, 8)).rejects.toMatchObject({
       code: 'unknownStreamHandle',
     });
-    expect(engineB.reads).toEqual([]);
+    // The refused stale read never reached the replacement engine.
+    expect(engineB.reads).toHaveLength(1);
 
     await follower.dispose();
     relayB.close();

--- a/packages/client/src/engineClient.test.ts
+++ b/packages/client/src/engineClient.test.ts
@@ -1,10 +1,31 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { EngineClient, type EngineClientConfig } from './engineClient.js';
-import { FakeBus, FakeCourierNetwork, FakeEngineWorker, FakeLockManager } from './testkit.js';
+import { LeaderRelay } from './leaderRelay.js';
+import type { LockManagerLike } from './leadership.js';
+import {
+  FakeBus,
+  FakeCourierNetwork,
+  FakeEngineTransport,
+  FakeEngineWorker,
+  FakeLockManager,
+} from './testkit.js';
 import type { EventDescriptor } from './worker/protocol.js';
 
 const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * Pins a tab as a follower: the lock is never granted, so it is never promoted.
+ * The request still settles on abort, so `dispose()` can await its election.
+ */
+const neverGrant: LockManagerLike = {
+  request: (_name, options) =>
+    new Promise((_resolve, reject) => {
+      options.signal?.addEventListener('abort', () =>
+        reject(new DOMException('aborted', 'AbortError'))
+      );
+    }),
+};
 
 /** A shared origin: one lock manager, one broadcast bus, one worker registry. */
 function origin() {
@@ -336,5 +357,43 @@ describe('EngineClient leadership + transport swap', () => {
     expect(errors.map((error) => error.message)).toEqual(['host blew up']);
     await client.dispose();
     vi.unstubAllGlobals();
+  });
+
+  it('refuses a stream handle across a leader change while this tab stays a follower', async () => {
+    const bus = new FakeBus();
+    const ports = new FakeCourierNetwork();
+    const engineA = new FakeEngineTransport();
+    const relayA = new LeaderRelay(bus.channel(), engineA, ports.courier('leaderA'));
+    const follower = new EngineClient({
+      locks: neverGrant,
+      createChannel: () => bus.channel(),
+      spawnWorker: () => {
+        throw new Error('follower never spawns');
+      },
+      courier: ports.courier('f'),
+      clientId: 'f',
+    });
+    await tick();
+
+    const stale = await follower.openContentStream(new Uint8Array(16).fill(1));
+    relayA.close();
+    await tick();
+
+    const engineB = new FakeEngineTransport();
+    const relayB = new LeaderRelay(bus.channel(), engineB, ports.courier('leaderB'));
+    for (let i = 0; i < 4; i += 1) await tick();
+    expect(follower.currentRole()).toBe('follower');
+
+    // Every engine's stream counter restarts at 1, so a handle carried across a
+    // leadership this tab merely observed would name a live stream over a
+    // different node on the new leader's engine.
+    await follower.openContentStream(new Uint8Array(16).fill(2));
+    await expect(follower.readStream(stale, 0, 8)).rejects.toMatchObject({
+      code: 'unknownStreamHandle',
+    });
+    expect(engineB.reads).toEqual([]);
+
+    await follower.dispose();
+    relayB.close();
   });
 });

--- a/packages/client/src/engineClient.ts
+++ b/packages/client/src/engineClient.ts
@@ -18,7 +18,7 @@
 
 import { BROADCAST_CHANNEL_NAME, newClientId, type BroadcastChannelLike } from './broadcast.js';
 import { BroadcastTransport } from './broadcastTransport.js';
-import { EngineRequestError, fanOut } from './correlatedTransport.js';
+import { fanOut, unknownHandle } from './correlatedTransport.js';
 import { EngineFacade } from './facade.js';
 import { LeaderRelay } from './leaderRelay.js';
 import { LeaderElection, type LockManagerLike } from './leadership.js';
@@ -67,10 +67,6 @@ export interface EngineClientConfig {
 }
 
 export type EngineClientRole = 'follower' | 'leader' | 'closed';
-
-/** The engine's own verdict for a handle it does not hold, spelled the same way. */
-const unknownStreamHandle = (): EngineRequestError =>
-  new EngineRequestError('unknown stream handle', 'unknownStreamHandle');
 
 /**
  * The object handed to `EngineFacade`: it *is* the transport, delegating to the
@@ -188,7 +184,7 @@ export class EngineClient implements EngineTransport {
     const generation = this.generation;
     const inner = await this.current.openContentStream(node);
     // The engine that minted this went away mid-open; its stream went with it.
-    if (generation !== this.generation) throw unknownStreamHandle();
+    if (generation !== this.generation) throw unknownHandle('stream');
     this.nextStream += 1n;
     this.streams.set(this.nextStream, inner);
     return this.nextStream;
@@ -196,7 +192,7 @@ export class EngineClient implements EngineTransport {
 
   readStream(handle: StreamHandle, offset: number, length: number): Promise<ArrayBuffer> {
     const inner = this.streams.get(handle);
-    if (inner === undefined) return Promise.reject(unknownStreamHandle());
+    if (inner === undefined) return Promise.reject(unknownHandle('stream'));
     return this.current.readStream(inner, offset, length);
   }
 

--- a/packages/client/src/engineClient.ts
+++ b/packages/client/src/engineClient.ts
@@ -18,7 +18,7 @@
 
 import { BROADCAST_CHANNEL_NAME, newClientId, type BroadcastChannelLike } from './broadcast.js';
 import { BroadcastTransport } from './broadcastTransport.js';
-import { fanOut } from './correlatedTransport.js';
+import { EngineRequestError, fanOut } from './correlatedTransport.js';
 import { EngineFacade } from './facade.js';
 import { LeaderRelay } from './leaderRelay.js';
 import { LeaderElection, type LockManagerLike } from './leadership.js';
@@ -30,6 +30,7 @@ import { LocalTransport } from './transport.js';
 import type {
   CommandDescriptor,
   SnapshotDescriptor,
+  StreamHandle,
   WriteHandle,
   WriteTarget,
 } from './worker/protocol.js';
@@ -67,6 +68,10 @@ export interface EngineClientConfig {
 
 export type EngineClientRole = 'follower' | 'leader' | 'closed';
 
+/** The engine's own verdict for a handle it does not hold, spelled the same way. */
+const unknownStreamHandle = (): EngineRequestError =>
+  new EngineRequestError('unknown stream handle', 'unknownStreamHandle');
+
 /**
  * The object handed to `EngineFacade`: it *is* the transport, delegating to the
  * live inner transport and re-homing the UI's event subscription across swaps.
@@ -81,6 +86,19 @@ export class EngineClient implements EngineTransport {
 
   private role: EngineClientRole = 'follower';
   private current!: EngineTransport;
+  /**
+   * The open read streams, as this client's own handle → the live engine's.
+   *
+   * The engine's `StreamHandle` is a per-engine counter that restarts at 1, so a
+   * handle from a departed leader names a live stream over a *different* node on
+   * the next one — the two-version splice #948 closes inside one engine, leaking
+   * straight back in across engines. Handing out an id that is monotonic for
+   * this client's whole life and dropping the table on every swap makes a stale
+   * handle unmatchable rather than ambiguous.
+   */
+  private readonly streams = new Map<StreamHandle, StreamHandle>();
+  private nextStream = 0n;
+  private generation = 0;
   private relay: LeaderRelay | null = null;
   private innerUnsub!: () => void;
   private readonly listeners = new Set<EngineEventListener>();
@@ -166,8 +184,27 @@ export class EngineClient implements EngineTransport {
     return this.current.download(node);
   }
 
-  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
-    return this.current.downloadRange(node, offset, length);
+  async openContentStream(node: Uint8Array): Promise<StreamHandle> {
+    const generation = this.generation;
+    const inner = await this.current.openContentStream(node);
+    // The engine that minted this went away mid-open; its stream went with it.
+    if (generation !== this.generation) throw unknownStreamHandle();
+    this.nextStream += 1n;
+    this.streams.set(this.nextStream, inner);
+    return this.nextStream;
+  }
+
+  readStream(handle: StreamHandle, offset: number, length: number): Promise<ArrayBuffer> {
+    const inner = this.streams.get(handle);
+    if (inner === undefined) return Promise.reject(unknownStreamHandle());
+    return this.current.readStream(inner, offset, length);
+  }
+
+  closeStream(handle: StreamHandle): Promise<void> {
+    const inner = this.streams.get(handle);
+    if (inner === undefined) return Promise.resolve();
+    this.streams.delete(handle);
+    return this.current.closeStream(inner);
   }
 
   subscribe(listener: EngineEventListener): () => void {
@@ -199,9 +236,16 @@ export class EngineClient implements EngineTransport {
     this.channel.close();
   }
 
+  /** Installs the live transport, retiring the streams the previous one held. */
+  private swapCurrent(transport: EngineTransport): void {
+    this.current = transport;
+    this.generation += 1;
+    this.streams.clear();
+  }
+
   private installFollower(): BroadcastTransport {
     const follower = new BroadcastTransport(this.channel, this.clientId, this.courier);
-    this.current = follower;
+    this.swapCurrent(follower);
     this.innerUnsub = follower.subscribe((event) => this.fanOut(event));
     return follower;
   }
@@ -261,7 +305,7 @@ export class EngineClient implements EngineTransport {
       // Startup resolved: only now install the transport as active, wire events,
       // and announce the relay so followers route commands to a live worker.
       this.role = 'leader';
-      this.current = local;
+      this.swapCurrent(local);
       this.innerUnsub = local.subscribe((event) => this.fanOut(event));
       this.relay = new LeaderRelay(this.channel, local, this.courier);
       if (this.ownFocus) this.relay.reportLocalFocus(this.clientId, this.ownFocus);

--- a/packages/client/src/engineClient.ts
+++ b/packages/client/src/engineClient.ts
@@ -239,12 +239,22 @@ export class EngineClient implements EngineTransport {
   /** Installs the live transport, retiring the streams the previous one held. */
   private swapCurrent(transport: EngineTransport): void {
     this.current = transport;
+    this.retireStreams();
+  }
+
+  /** Retires every open stream: the engine that minted them is gone. */
+  private retireStreams(): void {
     this.generation += 1;
     this.streams.clear();
   }
 
   private installFollower(): BroadcastTransport {
-    const follower = new BroadcastTransport(this.channel, this.clientId, this.courier);
+    // Leadership moving between two *other* tabs replaces the engine without
+    // replacing this transport, so the stream fence rides the same signal as the
+    // transport's own port fence.
+    const follower = new BroadcastTransport(this.channel, this.clientId, this.courier, {
+      onLeadershipChange: () => this.retireStreams(),
+    });
     this.swapCurrent(follower);
     this.innerUnsub = follower.subscribe((event) => this.fanOut(event));
     return follower;

--- a/packages/client/src/facade.test.ts
+++ b/packages/client/src/facade.test.ts
@@ -6,6 +6,7 @@ import type { EngineEventListener, EngineTransport } from './transport.js';
 import type {
   CommandDescriptor,
   SnapshotDescriptor,
+  StreamHandle,
   WriteHandle,
   WriteTarget,
 } from './worker/protocol.js';
@@ -16,7 +17,9 @@ class FakeTransport implements EngineTransport {
   snapshots: Uint8Array[] = [];
   downloads: Uint8Array[] = [];
   siweChallenges = 0;
-  downloadRanges: Array<{ node: Uint8Array; offset: number; length: number }> = [];
+  opened: Uint8Array[] = [];
+  reads: Array<{ handle: StreamHandle; offset: number; length: number }> = [];
+  closedStreams: StreamHandle[] = [];
   beginWrites: Array<{ target: WriteTarget; size: number }> = [];
   chunks: Array<{ handle: WriteHandle; chunk: ArrayBuffer }> = [];
   commits: WriteHandle[] = [];
@@ -69,9 +72,19 @@ class FakeTransport implements EngineTransport {
     return Promise.resolve(new Uint8Array([1, 2, 3]).buffer);
   }
 
-  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
-    this.downloadRanges.push({ node, offset, length });
+  openContentStream(node: Uint8Array): Promise<StreamHandle> {
+    this.opened.push(node);
+    return Promise.resolve(3n);
+  }
+
+  readStream(handle: StreamHandle, offset: number, length: number): Promise<ArrayBuffer> {
+    this.reads.push({ handle, offset, length });
     return Promise.resolve(new Uint8Array([4, 5]).buffer);
+  }
+
+  closeStream(handle: StreamHandle): Promise<void> {
+    this.closedStreams.push(handle);
+    return Promise.resolve();
   }
 
   subscribe(listener: EngineEventListener): () => void {
@@ -171,13 +184,19 @@ describe('EngineFacade', () => {
     });
   });
 
-  it('delegates a ranged read to the transport, window intact', async () => {
+  it('delegates the stream trio to the transport, window intact', async () => {
     const transport = new FakeTransport();
+    const facade = new EngineFacade(transport);
     const node = new Uint8Array(16).fill(3);
 
-    const window = await new EngineFacade(transport).downloadRange(node, 4096, 2);
+    const handle = await facade.openContentStream(node);
+    const window = await facade.readStream(handle, 4096, 2);
+    await facade.closeStream(handle);
+
     expect([...new Uint8Array(window)]).toEqual([4, 5]);
-    expect(transport.downloadRanges).toEqual([{ node, offset: 4096, length: 2 }]);
+    expect(transport.opened).toEqual([node]);
+    expect(transport.reads).toEqual([{ handle, offset: 4096, length: 2 }]);
+    expect(transport.closedStreams).toEqual([handle]);
   });
 
   it('delegates snapshot and download reads to the transport', async () => {

--- a/packages/client/src/facade.ts
+++ b/packages/client/src/facade.ts
@@ -16,6 +16,7 @@ import type {
   NodeKind,
   Permission,
   SnapshotDescriptor,
+  StreamHandle,
   WriteHandle,
   WriteTarget,
 } from './worker/protocol.js';
@@ -66,8 +67,22 @@ export class EngineFacade {
     return this.transport.download(node);
   }
 
-  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
-    return this.transport.downloadRange(node, offset, length);
+  /**
+   * Opens a read stream over one file node, pinned to the head content version
+   * for the handle's life. Released with `closeStream`.
+   */
+  openContentStream(node: Uint8Array): Promise<StreamHandle> {
+    return this.transport.openContentStream(node);
+  }
+
+  /** Reads one byte window of an open stream's pinned version. */
+  readStream(handle: StreamHandle, offset: number, length: number): Promise<ArrayBuffer> {
+    return this.transport.readStream(handle, offset, length);
+  }
+
+  /** Releases a read stream; an unknown handle is already gone. */
+  closeStream(handle: StreamHandle): Promise<void> {
+    return this.transport.closeStream(handle);
   }
 
   /** Creates an empty node. File content is written through a write handle. */

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -59,4 +59,5 @@ export type {
   BreadcrumbDescriptor,
   WriteTarget,
   WriteHandle,
+  StreamHandle,
 } from './worker/protocol.js';

--- a/packages/client/src/leaderRelay.ts
+++ b/packages/client/src/leaderRelay.ts
@@ -25,7 +25,7 @@ import type {
   WireRead,
   WireStream,
 } from './broadcast.js';
-import { EngineRequestError } from './correlatedTransport.js';
+import { EngineRequestError, unknownHandle, type HandleKind } from './correlatedTransport.js';
 import type { MessagePortLike, PortCourier } from './portRelay.js';
 import type { EngineTransport } from './transport.js';
 import type { SnapshotDescriptor, StreamHandle, WriteHandle } from './worker/protocol.js';
@@ -49,22 +49,6 @@ export interface LeaderRelayOptions {
 }
 
 const DEFAULT_NAMING_TIMEOUT_MS = 5000;
-
-/** Which handle table a step addresses. */
-type HandleKind = 'write' | 'stream';
-
-/**
- * Refuses a step on a handle the asking tab does not own. Handle ids are one
- * global namespace across tabs, so the refusal is spelled exactly like the
- * engine's own unknown-handle error: a probing tab learns nothing a legitimate
- * one would not.
- */
-function unknownHandle(kind: HandleKind): EngineRequestError {
-  return new EngineRequestError(
-    `unknown ${kind} handle`,
-    kind === 'write' ? 'unknownWriteHandle' : 'unknownStreamHandle'
-  );
-}
 
 /** Projects a caught failure onto the wire's `error`/`code` fields. */
 function wireError(error: unknown): { error: string; code?: string } {

--- a/packages/client/src/leaderRelay.ts
+++ b/packages/client/src/leaderRelay.ts
@@ -50,13 +50,16 @@ export interface LeaderRelayOptions {
 
 const DEFAULT_NAMING_TIMEOUT_MS = 5000;
 
+/** Which handle table a step addresses. */
+type HandleKind = 'write' | 'stream';
+
 /**
  * Refuses a step on a handle the asking tab does not own. Handle ids are one
  * global namespace across tabs, so the refusal is spelled exactly like the
  * engine's own unknown-handle error: a probing tab learns nothing a legitimate
  * one would not.
  */
-function unknownHandle(kind: 'write' | 'stream'): EngineRequestError {
+function unknownHandle(kind: HandleKind): EngineRequestError {
   return new EngineRequestError(
     `unknown ${kind} handle`,
     kind === 'write' ? 'unknownWriteHandle' : 'unknownStreamHandle'
@@ -124,7 +127,10 @@ export class LeaderRelay {
   // Clients that left while one of their handles was still being minted. The
   // mint completes after an await, so without this the release sweep runs
   // against a map the handle has not landed in yet and the handle is stranded.
+  // An entry lives only as long as the mints it guards: one that outlived them
+  // would refuse every later handle from a tab that is in fact still running.
   private readonly departed = new Set<string>();
+  private readonly mintsInFlight = new Map<string, number>();
   private readonly readPorts = new Set<ReadPortEntry>();
   private readonly namingTimeoutMs: number;
   private readonly unsubscribe: () => void;
@@ -199,7 +205,8 @@ export class LeaderRelay {
       case 'cb:bye': {
         const { clientId } = message as Extract<FollowerMessage, { type: 'cb:bye' }>;
         if (this.focus.remove(clientId)) this.refreshHint();
-        this.departed.add(clientId);
+        // Only a mint the sweep below cannot see needs guarding.
+        if (this.mintsInFlight.has(clientId)) this.departed.add(clientId);
         this.releaseHandles(clientId);
         this.detachPortOf(clientId);
         return;
@@ -262,8 +269,10 @@ export class LeaderRelay {
     if (message.type === 'cb:portHello') {
       const { clientId } = message as Extract<ReadPortRequest, { type: 'cb:portHello' }>;
       if (entry.clientId !== null || typeof clientId !== 'string') return;
-      // A re-brokering follower supersedes the port it held before.
+      // A re-brokering follower supersedes the port it held before, and by
+      // greeting proves it outlived whatever `cb:bye` marked it departed.
       this.detachPortOf(clientId);
+      this.departed.delete(clientId);
       clearTimeout(entry.naming);
       entry.clientId = clientId;
       this.postPort(entry.port, { type: 'cb:portReady', token: this.token });
@@ -277,30 +286,42 @@ export class LeaderRelay {
     if (typeof requestId !== 'number') return;
     if (message.type === 'cb:portRead') {
       const { read } = message as Extract<ReadPortRequest, { type: 'cb:portRead' }>;
-      void this.answerPort(entry.port, requestId, () => this.readValue(read));
+      void this.answerPort(entry, requestId, () => this.readValue(read));
       return;
     }
     if (message.type !== 'cb:portStream') return;
     const { stream } = message as Extract<ReadPortRequest, { type: 'cb:portStream' }>;
-    void this.answerPort(entry.port, requestId, () => this.streamStep(clientId, stream));
+    void this.answerPort(entry, requestId, () => this.streamStep(clientId, stream));
   }
 
   /** Runs one port-borne step and posts its correlated result down that port. */
   private async answerPort(
-    port: MessagePortLike,
+    entry: ReadPortEntry,
     requestId: number,
     step: () => Promise<SnapshotDescriptor | ArrayBuffer | string | StreamHandle | undefined>
   ): Promise<void> {
     try {
       const result = await step();
+      if (this.closed || !this.readPorts.has(entry)) {
+        // The port went away while the read ran, so nobody will receive this
+        // window: wipe it rather than leave plaintext for the collector
+        // (AGENTS.md 7 — with no transfer to make, this frame is its last owner).
+        if (result instanceof ArrayBuffer) new Uint8Array(result).fill(0);
+        return;
+      }
       // Transferred, not cloned: the plaintext leaves this tab's heap outright.
       this.postPort(
-        port,
+        entry.port,
         { type: 'cb:portResult', requestId, ok: true, result },
         result instanceof ArrayBuffer ? [result] : undefined
       );
     } catch (error) {
-      this.postPort(port, { type: 'cb:portResult', requestId, ok: false, ...wireError(error) });
+      this.postPort(entry.port, {
+        type: 'cb:portResult',
+        requestId,
+        ok: false,
+        ...wireError(error),
+      });
     }
   }
 
@@ -344,7 +365,7 @@ export class LeaderRelay {
     if (write.kind === 'beginWrite') {
       void this.answerStep(ack, () =>
         this.bind(
-          this.writeOwners,
+          'write',
           clientId,
           this.transport.beginWrite(write.target, write.size),
           (handle) => this.transport.abortWrite(handle)
@@ -393,7 +414,7 @@ export class LeaderRelay {
   ): Promise<StreamHandle | ArrayBuffer | undefined> {
     if (stream.kind === 'openContentStream') {
       return this.bind(
-        this.streamOwners,
+        'stream',
         clientId,
         this.transport.openContentStream(stream.node),
         (handle) => this.transport.closeStream(handle)
@@ -428,18 +449,38 @@ export class LeaderRelay {
    * instead if that client (or this relay) left while the mint was in flight.
    */
   private async bind(
-    owners: Map<bigint, string>,
+    kind: HandleKind,
     clientId: string,
     minting: Promise<bigint>,
     close: (handle: bigint) => Promise<unknown>
   ): Promise<bigint> {
-    const handle = await minting;
-    if (this.closed || this.departed.has(clientId)) {
-      void close(handle).catch(() => undefined);
-      throw new EngineRequestError('unknown handle', 'unknownHandle');
+    this.mintsInFlight.set(clientId, (this.mintsInFlight.get(clientId) ?? 0) + 1);
+    try {
+      const handle = await minting;
+      if (this.closed || this.departed.has(clientId)) {
+        void close(handle).catch(() => undefined);
+        throw unknownHandle(kind);
+      }
+      this.owners(kind).set(handle, clientId);
+      return handle;
+    } finally {
+      this.endMint(clientId);
     }
-    owners.set(handle, clientId);
-    return handle;
+  }
+
+  /** Drops the `departed` guard once the last mint it covered has settled. */
+  private endMint(clientId: string): void {
+    const left = (this.mintsInFlight.get(clientId) ?? 1) - 1;
+    if (left > 0) {
+      this.mintsInFlight.set(clientId, left);
+      return;
+    }
+    this.mintsInFlight.delete(clientId);
+    this.departed.delete(clientId);
+  }
+
+  private owners(kind: HandleKind): Map<bigint, string> {
+    return kind === 'write' ? this.writeOwners : this.streamOwners;
   }
 
   /**
@@ -450,17 +491,18 @@ export class LeaderRelay {
    * version in the engine just as long.
    */
   private releaseHandles(clientId: string | null): void {
-    this.release(this.writeOwners, clientId, (handle) =>
+    this.release('write', clientId, (handle) =>
       this.writes.run(handle, () => this.transport.abortWrite(handle))
     );
-    this.release(this.streamOwners, clientId, (handle) => this.transport.closeStream(handle));
+    this.release('stream', clientId, (handle) => this.transport.closeStream(handle));
   }
 
   private release(
-    owners: Map<bigint, string>,
+    kind: HandleKind,
     clientId: string | null,
     close: (handle: bigint) => Promise<unknown>
   ): void {
+    const owners = this.owners(kind);
     for (const [handle, owner] of owners) {
       if (clientId !== null && owner !== clientId) continue;
       owners.delete(handle);

--- a/packages/client/src/leaderRelay.ts
+++ b/packages/client/src/leaderRelay.ts
@@ -10,7 +10,7 @@
  *   follows whichever tab is focused (the RefreshHintSource seam, cross-tab).
  *
  * Nothing the leader sends on the channel carries plaintext: only key-free
- * `EventDescriptor`s and command/write acks. Read and ranged-read results go to
+ * `EventDescriptor`s and command/write acks. Read and stream results go to
  * the private `PortCourier` port that follower dialed, one per follower per
  * leadership. The follower→leader direction is unchanged and still broadcasts
  * command arguments and upload chunks.
@@ -391,7 +391,7 @@ export class LeaderRelay {
     );
   }
 
-  /** One ranged-read step, owned by the tab holding the port it arrived on. */
+  /** One `readStream` step, owned by the tab holding the port it arrived on. */
   private async streamStep(
     clientId: string,
     stream: WireStream

--- a/packages/client/src/leaderRelay.ts
+++ b/packages/client/src/leaderRelay.ts
@@ -10,10 +10,10 @@
  *   follows whichever tab is focused (the RefreshHintSource seam, cross-tab).
  *
  * Nothing the leader sends on the channel carries plaintext: only key-free
- * `EventDescriptor`s and command/write acks. Read results go to the private
- * `PortCourier` port that follower dialed, one per follower per leadership. The
- * follower→leader direction is unchanged and still broadcasts command arguments
- * and upload chunks.
+ * `EventDescriptor`s and command/write acks. Read and ranged-read results go to
+ * the private `PortCourier` port that follower dialed, one per follower per
+ * leadership. The follower→leader direction is unchanged and still broadcasts
+ * command arguments and upload chunks.
  */
 
 import type {
@@ -23,11 +23,12 @@ import type {
   ReadPortRequest,
   ReadPortResponse,
   WireRead,
+  WireStream,
 } from './broadcast.js';
 import { EngineRequestError } from './correlatedTransport.js';
 import type { MessagePortLike, PortCourier } from './portRelay.js';
 import type { EngineTransport } from './transport.js';
-import type { SnapshotDescriptor, WriteHandle } from './worker/protocol.js';
+import type { SnapshotDescriptor, StreamHandle, WriteHandle } from './worker/protocol.js';
 import { WriteQueue } from './writeQueue.js';
 
 /** The correlated ack envelope addressing one follower request. */
@@ -48,6 +49,19 @@ export interface LeaderRelayOptions {
 }
 
 const DEFAULT_NAMING_TIMEOUT_MS = 5000;
+
+/**
+ * Refuses a step on a handle the asking tab does not own. Handle ids are one
+ * global namespace across tabs, so the refusal is spelled exactly like the
+ * engine's own unknown-handle error: a probing tab learns nothing a legitimate
+ * one would not.
+ */
+function unknownHandle(kind: 'write' | 'stream'): EngineRequestError {
+  return new EngineRequestError(
+    `unknown ${kind} handle`,
+    kind === 'write' ? 'unknownWriteHandle' : 'unknownStreamHandle'
+  );
+}
 
 /** Projects a caught failure onto the wire's `error`/`code` fields. */
 function wireError(error: unknown): { error: string; code?: string } {
@@ -104,6 +118,13 @@ export class LeaderRelay {
   // across tabs, so this binds every step to the tab that owns the upload — and
   // lets a departing tab's handles be released.
   private readonly writeOwners = new Map<WriteHandle, string>();
+  // Same binding for read streams: a handle is a capability, and a stream left
+  // open pins a content version (and its key) in the leader's engine.
+  private readonly streamOwners = new Map<StreamHandle, string>();
+  // Clients that left while one of their handles was still being minted. The
+  // mint completes after an await, so without this the release sweep runs
+  // against a map the handle has not landed in yet and the handle is stranded.
+  private readonly departed = new Set<string>();
   private readonly readPorts = new Set<ReadPortEntry>();
   private readonly namingTimeoutMs: number;
   private readonly unsubscribe: () => void;
@@ -149,7 +170,7 @@ export class LeaderRelay {
     this.unsubscribePorts();
     for (const entry of [...this.readPorts]) this.detachPort(entry);
     this.closed = true;
-    this.releaseWrites(null);
+    this.releaseHandles(null);
     this.unsubscribe();
     this.channel.removeEventListener('message', this.onMessage);
   }
@@ -158,6 +179,7 @@ export class LeaderRelay {
     if (this.closed) return;
     switch (message.type) {
       case 'cb:hello':
+        this.departed.delete((message as Extract<FollowerMessage, { type: 'cb:hello' }>).clientId);
         this.post({ type: 'cb:leader', token: this.token });
         return;
       case 'cb:command':
@@ -177,7 +199,8 @@ export class LeaderRelay {
       case 'cb:bye': {
         const { clientId } = message as Extract<FollowerMessage, { type: 'cb:bye' }>;
         if (this.focus.remove(clientId)) this.refreshHint();
-        this.releaseWrites(clientId);
+        this.departed.add(clientId);
+        this.releaseHandles(clientId);
         this.detachPortOf(clientId);
         return;
       }
@@ -246,16 +269,30 @@ export class LeaderRelay {
       this.postPort(entry.port, { type: 'cb:portReady', token: this.token });
       return;
     }
-    // A port serves reads only once named — that name is how `cb:bye` reclaims it.
-    if (entry.clientId === null || message.type !== 'cb:portRead') return;
-    const { requestId, read } = message as Extract<ReadPortRequest, { type: 'cb:portRead' }>;
+    // A port serves reads only once named — that name is how `cb:bye` reclaims it,
+    // and how a stream step is bound to the tab that owns the handle.
+    const clientId = entry.clientId;
+    if (clientId === null) return;
+    const requestId = (message as { requestId?: unknown }).requestId;
     if (typeof requestId !== 'number') return;
-    void this.serveRead(entry.port, requestId, read);
+    if (message.type === 'cb:portRead') {
+      const { read } = message as Extract<ReadPortRequest, { type: 'cb:portRead' }>;
+      void this.answerPort(entry.port, requestId, () => this.readValue(read));
+      return;
+    }
+    if (message.type !== 'cb:portStream') return;
+    const { stream } = message as Extract<ReadPortRequest, { type: 'cb:portStream' }>;
+    void this.answerPort(entry.port, requestId, () => this.streamStep(clientId, stream));
   }
 
-  private async serveRead(port: MessagePortLike, requestId: number, read: WireRead): Promise<void> {
+  /** Runs one port-borne step and posts its correlated result down that port. */
+  private async answerPort(
+    port: MessagePortLike,
+    requestId: number,
+    step: () => Promise<SnapshotDescriptor | ArrayBuffer | string | StreamHandle | undefined>
+  ): Promise<void> {
     try {
-      const result = await this.readValue(read);
+      const result = await step();
       // Transferred, not cloned: the plaintext leaves this tab's heap outright.
       this.postPort(
         port,
@@ -276,8 +313,6 @@ export class LeaderRelay {
         return this.transport.siweChallenge();
       case 'download':
         return this.transport.download(read.node);
-      case 'downloadRange':
-        return this.transport.downloadRange(read.node, read.offset, read.length);
     }
   }
 
@@ -307,24 +342,27 @@ export class LeaderRelay {
     const ack: Ack = { type: 'cb:response', token: this.token, clientId, requestId };
 
     if (write.kind === 'beginWrite') {
-      void this.answerWrite(ack, async () => {
-        const handle = await this.transport.beginWrite(write.target, write.size);
-        this.writeOwners.set(handle, clientId);
-        return handle;
-      });
+      void this.answerStep(ack, () =>
+        this.bind(
+          this.writeOwners,
+          clientId,
+          this.transport.beginWrite(write.target, write.size),
+          (handle) => this.transport.abortWrite(handle)
+        )
+      );
       return;
     }
 
     const handle = write.handle;
     if (this.writeOwners.get(handle) !== clientId) {
-      this.post({ ...ack, ok: false, error: 'unknown write handle', code: 'unknownWriteHandle' });
+      this.post({ ...ack, ok: false, ...wireError(unknownHandle('write')) });
       return;
     }
 
     // Enqueued synchronously, before any await: `WriteQueue` orders a handle's
     // steps by call order.
     void this.writes.run(handle, () =>
-      this.answerWrite(ack, async () => {
+      this.answerStep(ack, async () => {
         switch (write.kind) {
           case 'pushChunk':
             // Materialize the follower's shared `Blob` only here, then transfer
@@ -348,27 +386,85 @@ export class LeaderRelay {
     );
   }
 
-  /** Runs one write step and posts its correlated ack. */
-  private async answerWrite(ack: Ack, step: () => Promise<bigint | void>): Promise<void> {
+  /** One ranged-read step, owned by the tab holding the port it arrived on. */
+  private async streamStep(
+    clientId: string,
+    stream: WireStream
+  ): Promise<StreamHandle | ArrayBuffer | undefined> {
+    if (stream.kind === 'openContentStream') {
+      return this.bind(
+        this.streamOwners,
+        clientId,
+        this.transport.openContentStream(stream.node),
+        (handle) => this.transport.closeStream(handle)
+      );
+    }
+
+    const handle = stream.handle;
+    if (this.streamOwners.get(handle) !== clientId) throw unknownHandle('stream');
+
+    if (stream.kind === 'closeStream') {
+      await this.transport.closeStream(handle);
+      // Dropped only once the close resolves: a rejected one leaves the handle
+      // owned, so the release sweep still knows to free the pin it holds.
+      this.streamOwners.delete(handle);
+      return undefined;
+    }
+    return this.transport.readStream(handle, stream.offset, stream.length);
+  }
+
+  /** Runs one handle-bound step and posts its correlated ack. */
+  private async answerStep(ack: Ack, step: () => Promise<bigint | void>): Promise<void> {
     try {
       const result = await step();
-      this.post(typeof result === 'bigint' ? { ...ack, ok: true, result } : { ...ack, ok: true });
+      this.post(result === undefined ? { ...ack, ok: true } : { ...ack, ok: true, result });
     } catch (error) {
       this.post({ ...ack, ok: false, ...wireError(error) });
     }
   }
 
   /**
-   * Abandons handles this relay can no longer serve — `clientId`'s, or all of
-   * them on teardown. A stranded handle holds its byte reservation against the
-   * staging ledger for the rest of the session, so every later write on every
-   * tab is refused as over-budget.
+   * Records the minted handle against the client that asked for it, releasing it
+   * instead if that client (or this relay) left while the mint was in flight.
    */
-  private releaseWrites(clientId: string | null): void {
-    for (const [handle, owner] of this.writeOwners) {
+  private async bind(
+    owners: Map<bigint, string>,
+    clientId: string,
+    minting: Promise<bigint>,
+    close: (handle: bigint) => Promise<unknown>
+  ): Promise<bigint> {
+    const handle = await minting;
+    if (this.closed || this.departed.has(clientId)) {
+      void close(handle).catch(() => undefined);
+      throw new EngineRequestError('unknown handle', 'unknownHandle');
+    }
+    owners.set(handle, clientId);
+    return handle;
+  }
+
+  /**
+   * Abandons handles this relay can no longer serve — `clientId`'s, or all of
+   * them on teardown. A stranded write handle holds its byte reservation against
+   * the staging ledger for the rest of the session, so every later write on every
+   * tab is refused as over-budget; a stranded read stream pins its content
+   * version in the engine just as long.
+   */
+  private releaseHandles(clientId: string | null): void {
+    this.release(this.writeOwners, clientId, (handle) =>
+      this.writes.run(handle, () => this.transport.abortWrite(handle))
+    );
+    this.release(this.streamOwners, clientId, (handle) => this.transport.closeStream(handle));
+  }
+
+  private release(
+    owners: Map<bigint, string>,
+    clientId: string | null,
+    close: (handle: bigint) => Promise<unknown>
+  ): void {
+    for (const [handle, owner] of owners) {
       if (clientId !== null && owner !== clientId) continue;
-      this.writeOwners.delete(handle);
-      void this.writes.run(handle, () => this.transport.abortWrite(handle)).catch(() => undefined);
+      owners.delete(handle);
+      void close(handle).catch(() => undefined);
     }
   }
 

--- a/packages/client/src/media/broker.test.ts
+++ b/packages/client/src/media/broker.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { MediaBroker, type MediaReader } from './broker.js';
+import type { StreamHandle } from '../worker/protocol.js';
 import type { MediaRequest, MediaResponse } from './protocol.js';
 import { StreamRegistry } from './registry.js';
 
@@ -18,16 +19,30 @@ interface ReadCall {
 
 class FakeReader implements MediaReader {
   readonly calls: ReadCall[] = [];
+  readonly opens: Uint8Array[] = [];
+  readonly closes: StreamHandle[] = [];
   concurrent = 0;
   maxConcurrent = 0;
   /** Set to make reads reject. */
   failure: Error | null = null;
   /** Set below the registered size to model a version that shrank after the ticket was minted. */
   liveSize: number | null = null;
+  private nextHandle = 1n;
+  private readonly live = new Set<StreamHandle>();
 
   constructor(private readonly bytes: Uint8Array) {}
 
-  async downloadRange(_node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
+  async openContentStream(node: Uint8Array): Promise<StreamHandle> {
+    this.opens.push(node);
+    // A real open resolves, gates, and fetches the root manifest; it suspends.
+    await flush();
+    const handle = this.nextHandle++;
+    this.live.add(handle);
+    return handle;
+  }
+
+  async readStream(handle: StreamHandle, offset: number, length: number): Promise<ArrayBuffer> {
+    if (!this.live.has(handle)) throw new Error('unknown stream handle');
     this.calls.push({ offset, length });
     this.concurrent += 1;
     this.maxConcurrent = Math.max(this.maxConcurrent, this.concurrent);
@@ -40,6 +55,12 @@ class FakeReader implements MediaReader {
     } finally {
       this.concurrent -= 1;
     }
+  }
+
+  closeStream(handle: StreamHandle): Promise<void> {
+    this.closes.push(handle);
+    this.live.delete(handle);
+    return Promise.resolve();
   }
 }
 
@@ -147,6 +168,26 @@ describe('MediaBroker', () => {
       { offset: 7, length: 4 },
       { offset: 11, length: 2 },
     ]);
+  });
+
+  it('pins one engine stream for the whole body and releases it at the end', async () => {
+    const size = 20;
+    const h = harness(size);
+
+    h.send({ type: 'cb:media:open', requestId: 1, ticket: h.ticket, range: null });
+    await waitFor(() => h.received.length === 1, 'head');
+    for (let pull = 0; pull < 6; pull += 1) {
+      h.send({ type: 'cb:media:pull', requestId: 1 });
+      await flush();
+    }
+    await waitFor(() => kinds(h.received).includes('cb:media:end'), 'end');
+
+    expect(bodyOf(h.received)).toEqual(plaintext(size));
+    // One open however many windows the body took: no per-window resolve, and
+    // no window that could come from a different content version.
+    expect(h.reader.opens).toEqual([NODE]);
+    expect(h.reader.calls).toHaveLength(5);
+    expect(h.reader.closes).toEqual([1n]);
   });
 
   it('answers an unknown ticket with a 404 head and reads nothing', async () => {

--- a/packages/client/src/media/broker.ts
+++ b/packages/client/src/media/broker.ts
@@ -2,18 +2,26 @@
 
 import { errorMessage } from '../errorMessage.js';
 import type { MessagePortLike } from '../portRelay.js';
+import type { StreamHandle } from '../worker/protocol.js';
 import { MEDIA_WINDOW_BYTES, type MediaRequest, type MediaResponse } from './protocol.js';
 import { resolveMediaRequest } from './range.js';
 import type { StreamRegistry } from './registry.js';
 
-/** The one engine capability the pipe needs; `EngineClient` satisfies it. */
+/** The engine capabilities the pipe needs; `EngineClient` satisfies them. */
 export interface MediaReader {
-  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer>;
+  openContentStream(node: Uint8Array): Promise<StreamHandle>;
+  readStream(handle: StreamHandle, offset: number, length: number): Promise<ArrayBuffer>;
+  closeStream(handle: StreamHandle): Promise<void>;
 }
 
 /** An open response body: the unread remainder of a resolved window. */
 interface Cursor {
   readonly node: Uint8Array;
+  /**
+   * The engine stream every window of this response is read against, opened on
+   * the first pull — a request abandoned after its head costs nothing.
+   */
+  stream: Promise<StreamHandle> | null;
   /** The mint-time window end, pulled in when a read proves the version is shorter. */
   end: number;
   offset: number;
@@ -50,7 +58,15 @@ export class MediaBroker {
     }
     this.port = null;
     this.listener = null;
-    this.streams.clear();
+    for (const requestId of [...this.streams.keys()]) this.drop(requestId);
+  }
+
+  /** Forgets a cursor and releases the engine stream it pinned, if it opened one. */
+  private drop(requestId: number): void {
+    const cursor = this.streams.get(requestId);
+    if (cursor === undefined) return;
+    this.streams.delete(requestId);
+    void cursor.stream?.then((handle) => this.reader.closeStream(handle)).catch(() => undefined);
   }
 
   private dispatch(port: MessagePortLike, data: unknown): void {
@@ -64,7 +80,7 @@ export class MediaBroker {
         this.pull(port, request.requestId);
         return;
       case 'cb:media:close':
-        this.streams.delete(request.requestId);
+        this.drop(request.requestId);
         return;
     }
   }
@@ -78,6 +94,9 @@ export class MediaBroker {
     const postHead = (status: number, headers: Array<[string, string]>): void => {
       post(port, { type: 'cb:media:head', requestId, status, headers });
     };
+
+    // A repeat id supersedes whatever it names, whatever this open resolves to.
+    this.drop(requestId);
 
     const source = this.registry.lookup(ticket);
     if (source === undefined) {
@@ -93,6 +112,7 @@ export class MediaBroker {
 
     this.streams.set(requestId, {
       node: source.node,
+      stream: null,
       offset: head.window.offset,
       end: head.window.offset + head.window.length,
       pump: Promise.resolve(),
@@ -120,7 +140,7 @@ export class MediaBroker {
 
     const remaining = cursor.end - cursor.offset;
     if (remaining <= 0) {
-      this.streams.delete(requestId);
+      this.drop(requestId);
       post(port, { type: 'cb:media:end', requestId });
       return;
     }
@@ -128,8 +148,16 @@ export class MediaBroker {
     const offset = cursor.offset;
     const length = Math.min(this.windowBytes, remaining);
     try {
-      const chunk = await this.reader.downloadRange(cursor.node, offset, length);
+      cursor.stream ??= this.reader.openContentStream(cursor.node);
+      const handle = await cursor.stream;
       if (!this.isCurrent(requestId, cursor)) return;
+      const chunk = await this.reader.readStream(handle, offset, length);
+      if (!this.isCurrent(requestId, cursor)) {
+        // Nobody will receive this window; wipe it rather than leave plaintext
+        // for the collector (AGENTS.md 7 — this is its terminal owner).
+        new Uint8Array(chunk).fill(0);
+        return;
+      }
       cursor.offset = offset + chunk.byteLength;
       // A short read means the live version is smaller than the head promised;
       // ending here is a clean EOF, where under-delivering content-length is a
@@ -139,7 +167,7 @@ export class MediaBroker {
       port.postMessage(response, [chunk]);
     } catch (error) {
       if (!this.isCurrent(requestId, cursor)) return;
-      this.streams.delete(requestId);
+      this.drop(requestId);
       post(port, { type: 'cb:media:error', requestId, message: errorMessage(error) });
     }
   }

--- a/packages/client/src/media/protocol.ts
+++ b/packages/client/src/media/protocol.ts
@@ -8,8 +8,13 @@
 /** Ticket URLs live under one path prefix so the fetch handler can be exact. */
 export const STREAM_PATH_PREFIX = '/stream/';
 
-/** The plaintext window read per pull: peak memory on both sides of the port is one window, never the file. */
-export const MEDIA_WINDOW_BYTES = 1024 * 1024;
+/**
+ * The plaintext window read per pull: peak memory on both sides of the port is
+ * one window, never the file. Exactly one content chunk, so a window at a
+ * chunk-aligned offset covers exactly one leaf (`ContentProfile::PRODUCTION`,
+ * frozen by blueprint/engine.md "Content plane").
+ */
+export const MEDIA_WINDOW_BYTES = 1_048_536;
 
 /** Service Worker → port. */
 export type MediaRequest =

--- a/packages/client/src/media/service.test.ts
+++ b/packages/client/src/media/service.test.ts
@@ -71,7 +71,9 @@ class FakeContainer implements ServiceWorkerContainerLike {
 const ORIGIN = 'https://vault.example';
 
 const reader: MediaReader = {
-  downloadRange: (_node, _offset, length) => Promise.resolve(new ArrayBuffer(length)),
+  openContentStream: () => Promise.resolve(1n),
+  readStream: (_handle, _offset, length) => Promise.resolve(new ArrayBuffer(length)),
+  closeStream: () => Promise.resolve(),
 };
 
 interface Setup {

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -15,6 +15,7 @@ import type {
   CommandDescriptor,
   EventDescriptor,
   SnapshotDescriptor,
+  StreamHandle,
   WorkerMessage,
   WriteHandle,
   WriteTarget,
@@ -114,8 +115,16 @@ export class StubEngineHost implements EngineHostLike {
     return notStubbed('download');
   }
 
-  downloadRange(_node: Uint8Array, _offset: number, _length: number): Promise<ArrayBuffer> {
-    return notStubbed('downloadRange');
+  openContentStream(_node: Uint8Array): Promise<StreamHandle> {
+    return notStubbed('openContentStream');
+  }
+
+  readStream(_handle: StreamHandle, _offset: number, _length: number): Promise<ArrayBuffer> {
+    return notStubbed('readStream');
+  }
+
+  closeStream(_handle: StreamHandle): Promise<void> {
+    return notStubbed('closeStream');
   }
 
   nextEvent(): Promise<EventDescriptor | null> {
@@ -324,7 +333,9 @@ export class FakeEngineTransport implements EngineTransport {
   readonly snapshots: Array<Uint8Array | null> = [];
   readonly downloads: Uint8Array[] = [];
   siweChallenges = 0;
-  readonly downloadRanges: Array<{ node: Uint8Array; offset: number; length: number }> = [];
+  readonly opened: Uint8Array[] = [];
+  readonly reads: Array<{ handle: StreamHandle; offset: number; length: number }> = [];
+  readonly closedStreams: StreamHandle[] = [];
   readonly beginWrites: Array<{ target: WriteTarget; size: number }> = [];
   readonly chunks: Array<{ handle: WriteHandle; chunk: ArrayBuffer }> = [];
   readonly commits: WriteHandle[] = [];
@@ -333,6 +344,8 @@ export class FakeEngineTransport implements EngineTransport {
   closed = false;
   /** What `beginWrite` hands back and what `commitWrite` resolves with. */
   writeHandle: WriteHandle = 1n;
+  /** What `openContentStream` hands back. */
+  streamHandle: StreamHandle = 1n;
   commitOpId = 42n;
   respond: (command: CommandDescriptor) => Promise<void> = () => Promise.resolve();
   respondSnapshot: (folder: Uint8Array | null) => Promise<SnapshotDescriptor> = (folder) =>
@@ -340,8 +353,12 @@ export class FakeEngineTransport implements EngineTransport {
   respondDownload: (node: Uint8Array) => Promise<ArrayBuffer> = () =>
     Promise.resolve(new ArrayBuffer(0));
   respondSiweChallenge: () => Promise<string> = () => Promise.resolve(FAKE_SIWE_NONCE);
-  respondDownloadRange: (node: Uint8Array, offset: number, length: number) => Promise<ArrayBuffer> =
-    (_node, _offset, length) => Promise.resolve(new ArrayBuffer(length));
+  respondReadStream: (
+    handle: StreamHandle,
+    offset: number,
+    length: number
+  ) => Promise<ArrayBuffer> = (_handle, _offset, length) =>
+    Promise.resolve(new ArrayBuffer(length));
   private readonly listeners = new Set<EngineEventListener>();
 
   start(secret: ArrayBuffer): Promise<void> {
@@ -389,9 +406,19 @@ export class FakeEngineTransport implements EngineTransport {
     return this.respondDownload(node);
   }
 
-  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
-    this.downloadRanges.push({ node, offset, length });
-    return this.respondDownloadRange(node, offset, length);
+  openContentStream(node: Uint8Array): Promise<StreamHandle> {
+    this.opened.push(node);
+    return Promise.resolve(this.streamHandle);
+  }
+
+  readStream(handle: StreamHandle, offset: number, length: number): Promise<ArrayBuffer> {
+    this.reads.push({ handle, offset, length });
+    return this.respondReadStream(handle, offset, length);
+  }
+
+  closeStream(handle: StreamHandle): Promise<void> {
+    this.closedStreams.push(handle);
+    return Promise.resolve();
   }
 
   subscribe(listener: EngineEventListener): () => void {
@@ -414,11 +441,15 @@ export class FakeEngineWorker implements EngineWorkerLike {
   terminated = false;
   private messageListeners: Array<(event: MessageEvent<WorkerMessage>) => void> = [];
 
-  postMessage(message: { id?: number }): void {
+  /** What `openContentStream` answers with — every engine's counter starts at 1. */
+  streamHandle: WriteHandle = 1n;
+
+  postMessage(message: { id?: number; type?: string }): void {
     this.posted.push(message);
-    if (typeof message.id === 'number') {
-      queueMicrotask(() => this.emit({ type: 'response', id: message.id!, ok: true }));
-    }
+    if (typeof message.id !== 'number') return;
+    const id = message.id;
+    const result = message.type === 'openContentStream' ? this.streamHandle : undefined;
+    queueMicrotask(() => this.emit({ type: 'response', id, ok: true, result }));
   }
 
   addEventListener(type: 'message' | 'error', listener: unknown): void {

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -442,7 +442,7 @@ export class FakeEngineWorker implements EngineWorkerLike {
   private messageListeners: Array<(event: MessageEvent<WorkerMessage>) => void> = [];
 
   /** What `openContentStream` answers with — every engine's counter starts at 1. */
-  streamHandle: WriteHandle = 1n;
+  streamHandle: StreamHandle = 1n;
 
   postMessage(message: { id?: number; type?: string }): void {
     this.posted.push(message);

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -14,6 +14,7 @@ import type {
   CommandDescriptor,
   EventDescriptor,
   SnapshotDescriptor,
+  StreamHandle,
   WorkerMessage,
   WorkerRequest,
   WriteHandle,
@@ -42,8 +43,15 @@ export interface EngineTransport {
   siweChallenge(): Promise<string>;
   /** Downloads one file node's plaintext through the verified read pipeline. */
   download(node: Uint8Array): Promise<ArrayBuffer>;
-  /** The verified read pipeline over one byte window; only the leaves it covers are fetched. */
-  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer>;
+  /**
+   * Opens a read stream over one file node, pinned to the head content version
+   * for the handle's life so no window can come from a different one.
+   */
+  openContentStream(node: Uint8Array): Promise<StreamHandle>;
+  /** One byte window of a pinned stream; only the leaves it covers are fetched. */
+  readStream(handle: StreamHandle, offset: number, length: number): Promise<ArrayBuffer>;
+  /** Releases the stream; an unknown handle is already gone. */
+  closeStream(handle: StreamHandle): Promise<void>;
   /** Subscribes to the one-way event stream; returns an unsubscribe. */
   subscribe(listener: EngineEventListener): () => void;
   /** Tears the transport down; pending requests reject. */
@@ -158,9 +166,21 @@ export class LocalTransport extends CorrelatedTransport {
     );
   }
 
-  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
+  openContentStream(node: Uint8Array): Promise<StreamHandle> {
+    return this.request<StreamHandle>(this.ready, (id) =>
+      this.worker.postMessage({ type: 'openContentStream', id, node }, [])
+    );
+  }
+
+  readStream(handle: StreamHandle, offset: number, length: number): Promise<ArrayBuffer> {
     return this.request<ArrayBuffer>(this.ready, (id) =>
-      this.worker.postMessage({ type: 'downloadRange', id, node, offset, length }, [])
+      this.worker.postMessage({ type: 'readStream', id, handle, offset, length }, [])
+    );
+  }
+
+  closeStream(handle: StreamHandle): Promise<void> {
+    return this.dispatch(this.ready, (id) =>
+      this.worker.postMessage({ type: 'closeStream', id, handle }, [])
     );
   }
 

--- a/packages/client/src/worker/engineHost.ts
+++ b/packages/client/src/worker/engineHost.ts
@@ -8,6 +8,7 @@ import type {
   CommandDescriptor,
   EventDescriptor,
   SnapshotDescriptor,
+  StreamHandle,
   WriteHandle,
   WriteTarget,
 } from './protocol.js';
@@ -31,7 +32,10 @@ export interface EngineHostLike {
   snapshot(folder: Uint8Array | null): Promise<SnapshotDescriptor>;
   siweChallenge(): Promise<string>;
   download(node: Uint8Array): Promise<ArrayBuffer>;
-  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer>;
+  /** Opens a read stream pinned to the node's current head content version. */
+  openContentStream(node: Uint8Array): Promise<StreamHandle>;
+  readStream(handle: StreamHandle, offset: number, length: number): Promise<ArrayBuffer>;
+  closeStream(handle: StreamHandle): Promise<void>;
   nextEvent(): Promise<EventDescriptor | null>;
 }
 
@@ -126,10 +130,16 @@ export class EngineHost implements EngineHostLike {
     return ownedBuffer(await this.handle.download(this.wasm.NodeId.fromBytes(node)));
   }
 
-  async downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
-    return ownedBuffer(
-      await this.handle.downloadRange(this.wasm.NodeId.fromBytes(node), offset, length)
-    );
+  openContentStream(node: Uint8Array): Promise<StreamHandle> {
+    return this.handle.openContentStream(this.wasm.NodeId.fromBytes(node));
+  }
+
+  async readStream(handle: StreamHandle, offset: number, length: number): Promise<ArrayBuffer> {
+    return ownedBuffer(await this.handle.readStream(handle, offset, length));
+  }
+
+  async closeStream(handle: StreamHandle): Promise<void> {
+    await this.handle.closeStream(handle);
   }
 
   async nextEvent(): Promise<EventDescriptor | null> {

--- a/packages/client/src/worker/engineWasm.ts
+++ b/packages/client/src/worker/engineWasm.ts
@@ -95,8 +95,10 @@ export interface WasmEngineHandle {
   snapshot(folder?: WasmNodeId): Promise<WasmSnapshotView>;
   siweChallenge(): Promise<string>;
   download(node: WasmNodeId): Promise<Uint8Array>;
+  openContentStream(node: WasmNodeId): Promise<bigint>;
   /** `offset`/`length` cross as plain JS numbers (the seam's `f64` convention). */
-  downloadRange(node: WasmNodeId, offset: number, length: number): Promise<Uint8Array>;
+  readStream(handle: bigint, offset: number, length: number): Promise<Uint8Array>;
+  closeStream(handle: bigint): Promise<unknown>;
   nextEvent(): Promise<WasmEvent | undefined>;
 }
 

--- a/packages/client/src/worker/protocol.ts
+++ b/packages/client/src/worker/protocol.ts
@@ -150,6 +150,13 @@ export type WriteTarget = { parent: Uint8Array; name: string } | { node: Uint8Ar
 /** An open write handle's id — the engine's `u64`, opaque to this layer. */
 export type WriteHandle = bigint;
 
+/**
+ * An open read stream's id — the engine's `u64`, opaque to this layer. The
+ * stream pins one content version, so every window read against the handle is a
+ * slice of one authenticated object.
+ */
+export type StreamHandle = bigint;
+
 /** One event the engine emitted, as data (mirrors the facade `Event`). */
 export type EventDescriptor =
   | { kind: 'snapshotUpdated' }
@@ -183,7 +190,9 @@ export type WorkerRequest =
   | { type: 'snapshot'; id: number; folder: Uint8Array | null }
   | { type: 'siweChallenge'; id: number }
   | { type: 'download'; id: number; node: Uint8Array }
-  | { type: 'downloadRange'; id: number; node: Uint8Array; offset: number; length: number };
+  | { type: 'openContentStream'; id: number; node: Uint8Array }
+  | { type: 'readStream'; id: number; handle: StreamHandle; offset: number; length: number }
+  | { type: 'closeStream'; id: number; handle: StreamHandle };
 
 /** A worker → UI message. */
 export type WorkerMessage =
@@ -192,9 +201,9 @@ export type WorkerMessage =
   /**
    * The correlated result of a request. A value-bearing ok response carries it:
    * a `SnapshotDescriptor` for `snapshot`, the plaintext `ArrayBuffer`
-   * (transferred, not copied) for `download`/`downloadRange`, the nonce string
-   * for `siweChallenge`, the write handle for `beginWrite`, the durable op id
-   * for `commitWrite`.
+   * (transferred, not copied) for `download`/`readStream`, the nonce string
+   * for `siweChallenge`, the write handle for `beginWrite`, the stream handle
+   * for `openContentStream`, the durable op id for `commitWrite`.
    */
   | {
       type: 'response';

--- a/packages/client/src/worker/serve.test.ts
+++ b/packages/client/src/worker/serve.test.ts
@@ -61,7 +61,9 @@ const SNAPSHOT: SnapshotDescriptor = {
 class ReadHost extends StubEngineHost {
   readonly snapshots: Uint8Array[] = [];
   readonly downloads: Uint8Array[] = [];
-  readonly downloadRanges: Array<{ node: Uint8Array; offset: number; length: number }> = [];
+  readonly opened: Uint8Array[] = [];
+  readonly reads: Array<{ handle: bigint; offset: number; length: number }> = [];
+  readonly closedStreams: bigint[] = [];
   readonly beginWrites: Array<{ target: WriteTarget; size: number }> = [];
   readonly chunks: Array<{ handle: bigint; bytes: number[] }> = [];
   readonly commits: bigint[] = [];
@@ -69,7 +71,7 @@ class ReadHost extends StubEngineHost {
   respondSnapshot: () => Promise<SnapshotDescriptor> = () => Promise.resolve(SNAPSHOT);
   respondDownload: () => Promise<ArrayBuffer> = () =>
     Promise.resolve(new Uint8Array([9, 8, 7]).buffer);
-  respondDownloadRange: () => Promise<ArrayBuffer> = () =>
+  respondReadStream: () => Promise<ArrayBuffer> = () =>
     Promise.resolve(new Uint8Array([5, 4]).buffer);
   siweChallenges = 0;
 
@@ -116,9 +118,19 @@ class ReadHost extends StubEngineHost {
     return this.respondDownload();
   }
 
-  downloadRange(node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
-    this.downloadRanges.push({ node, offset, length });
-    return this.respondDownloadRange();
+  openContentStream(node: Uint8Array): Promise<bigint> {
+    this.opened.push(node);
+    return Promise.resolve(11n);
+  }
+
+  readStream(handle: bigint, offset: number, length: number): Promise<ArrayBuffer> {
+    this.reads.push({ handle, offset, length });
+    return this.respondReadStream();
+  }
+
+  closeStream(handle: bigint): Promise<void> {
+    this.closedStreams.push(handle);
+    return Promise.resolve();
   }
 
   nextEvent(): Promise<EventDescriptor | null> {
@@ -154,19 +166,24 @@ describe('serveEngine read requests', () => {
     expect(response!.transfer).toEqual([content]);
   });
 
-  it('serves a downloadRange with its window and the plaintext buffer transferred', async () => {
+  it('serves a stream window with its args and the plaintext buffer transferred', async () => {
     const { scope, worker, toUi } = loopback();
     const host = new ReadHost();
     serveEngine(scope, host);
     const transport = new LocalTransport(worker);
 
     const node = new Uint8Array(16).fill(4);
-    const content = await transport.downloadRange(node, 1024, 2);
+    const handle = await transport.openContentStream(node);
+    const content = await transport.readStream(handle, 1024, 2);
+    await transport.closeStream(handle);
+
     expect([...new Uint8Array(content)]).toEqual([5, 4]);
-    expect(host.downloadRanges).toEqual([{ node, offset: 1024, length: 2 }]);
+    expect(host.opened).toEqual([node]);
+    expect(host.reads).toEqual([{ handle, offset: 1024, length: 2 }]);
+    expect(host.closedStreams).toEqual([handle]);
 
     const response = toUi.find(
-      (entry) => entry.message.type === 'response' && 'result' in entry.message
+      (entry) => entry.message.type === 'response' && (entry.transfer?.length ?? 0) > 0
     );
     expect(response).toBeDefined();
     expect(response!.transfer).toEqual([content]);
@@ -360,7 +377,9 @@ describe('serveEngine event pump over the real EngineHost', () => {
       snapshot: () => Promise.reject(new Error('unused')),
       siweChallenge: () => Promise.reject(new Error('unused')),
       download: () => Promise.reject(new Error('unused')),
-      downloadRange: () => Promise.reject(new Error('unused')),
+      openContentStream: () => Promise.reject(new Error('unused')),
+      readStream: () => Promise.reject(new Error('unused')),
+      closeStream: () => Promise.reject(new Error('unused')),
       nextEvent: () =>
         pumped.length > 0
           ? Promise.resolve(pumped.shift())

--- a/packages/client/src/worker/serve.ts
+++ b/packages/client/src/worker/serve.ts
@@ -81,12 +81,20 @@ export function serveEngine(scope: WorkerScopeLike, host: EngineHostLike): void 
         case 'download':
           postOwned(request.id, await host.download(request.node));
           return;
-        case 'downloadRange':
+        case 'openContentStream': {
+          const result = await host.openContentStream(request.node);
+          post({ type: 'response', id: request.id, ok: true, result });
+          return;
+        }
+        case 'readStream':
           postOwned(
             request.id,
-            await host.downloadRange(request.node, request.offset, request.length)
+            await host.readStream(request.handle, request.offset, request.length)
           );
           return;
+        case 'closeStream':
+          await host.closeStream(request.handle);
+          break;
         default:
           return; // ignore non-request messages (e.g. a bootstrap handshake)
       }

--- a/packages/client/test/browser/leadership.spec.ts
+++ b/packages/client/test/browser/leadership.spec.ts
@@ -22,7 +22,7 @@ interface LeadershipHarness {
   }): Promise<void>;
   cbObserve(channelName: string): void;
   cbObserved(): ObservedMessage[];
-  cbDownloadRange(offset: number, length: number): Promise<RangeResult>;
+  cbReadStream(offset: number, length: number): Promise<RangeResult>;
   cbRole(): string;
   cbStart(): Promise<string>;
   cbCreateFile(name: string): Promise<string>;
@@ -56,7 +56,7 @@ function harness(page: Page): {
   ): Promise<void>;
   observe(channelName: string): Promise<void>;
   observed(): Promise<ObservedMessage[]>;
-  downloadRange(offset: number, length: number): Promise<RangeResult>;
+  readStream(offset: number, length: number): Promise<RangeResult>;
   role(): Promise<string>;
   start(): Promise<string>;
   createFile(name: string): Promise<string>;
@@ -83,10 +83,9 @@ function harness(page: Page): {
         channelName
       ),
     observed: () => page.evaluate(() => (window as unknown as LeadershipHarness).cbObserved()),
-    downloadRange: (offset, length) =>
+    readStream: (offset, length) =>
       page.evaluate(
-        (args) =>
-          (window as unknown as LeadershipHarness).cbDownloadRange(args.offset, args.length),
+        (args) => (window as unknown as LeadershipHarness).cbReadStream(args.offset, args.length),
         { offset, length }
       ),
     role: () => page.evaluate(() => (window as unknown as LeadershipHarness).cbRole()),
@@ -260,7 +259,7 @@ test.describe('tab leadership over real Web Locks + BroadcastChannel', () => {
     // Three ranged windows, as a media element playing in the follower would.
     const WINDOW = 1024;
     for (let offset = 0; offset < 3 * WINDOW; offset += WINDOW) {
-      const read = await follower.downloadRange(offset, WINDOW);
+      const read = await follower.readStream(offset, WINDOW);
       expect(read.error).toBeUndefined();
       // Only the leader's worker holds `LEADER_SEED`, so these bytes prove the
       // read crossed to the leader engine and came back over the private port.

--- a/packages/client/test/browser/leadership.ts
+++ b/packages/client/test/browser/leadership.ts
@@ -67,7 +67,7 @@ declare global {
     cbCreate(options: HarnessOptions): Promise<void>;
     cbObserve(channelName: string): void;
     cbObserved(): ObservedMessage[];
-    cbDownloadRange(offset: number, length: number): Promise<RangeResult>;
+    cbReadStream(offset: number, length: number): Promise<RangeResult>;
     cbRole(): string;
     cbStart(): Promise<string>;
     cbCreateFile(name: string): Promise<string>;
@@ -196,12 +196,16 @@ window.cbSnapshot = async (folderHex: string): Promise<SnapshotResult> => {
   }
 };
 
-window.cbDownloadRange = async (offset: number, length: number): Promise<RangeResult> => {
+window.cbReadStream = async (offset: number, length: number): Promise<RangeResult> => {
+  let handle: bigint | null = null;
   try {
-    const window_ = await client!.downloadRange(rootNode, offset, length);
+    handle = await client!.openContentStream(rootNode);
+    const window_ = await client!.readStream(handle, offset, length);
     return { bytesHex: hex(new Uint8Array(window_)) };
   } catch (error) {
     return { error: settle(error) };
+  } finally {
+    if (handle !== null) await client!.closeStream(handle).catch(() => undefined);
   }
 };
 

--- a/packages/client/test/browser/media.spec.ts
+++ b/packages/client/test/browser/media.spec.ts
@@ -4,6 +4,7 @@ import { expect, test, type BrowserContext, type Page } from '@playwright/test';
 import { hex } from './hexUtil.js';
 import { fixtureSlice, LEADER_SEED, SECOND_TAB_SEED, TAB_SEED } from './mediaFixture.js';
 import type { MediaFetchResult } from './media.js';
+import { MEDIA_WINDOW_BYTES } from '../../src/media/protocol.js';
 
 /**
  * The Service Worker media-brokerage slice of the merge-blocking browser suite
@@ -20,13 +21,12 @@ interface MediaHarness {
   cbMediaTicket(size: number, mimeType: string): string;
   cbMediaFetch(url: string, range: string | null): Promise<MediaFetchResult>;
   cbMediaReaderCalls(): number;
+  cbMediaOpenCalls(): number;
   cbMediaPortRequests(): number;
   cbMediaDispose(): Promise<void>;
 }
 
 const MIME = 'video/mp4';
-const WINDOW_BYTES = 1024 * 1024;
-
 let testSeq = 0;
 
 function digestOf(bytes: Uint8Array): string {
@@ -50,6 +50,7 @@ interface Tab {
   ticket(size: number): Promise<string>;
   fetch(url: string, range?: string): Promise<MediaFetchResult>;
   readerCalls(): Promise<number>;
+  openCalls(): Promise<number>;
   portRequests(): Promise<number>;
   dispose(): Promise<void>;
 }
@@ -90,6 +91,7 @@ async function openTab(context: BrowserContext): Promise<Tab> {
       ),
     readerCalls: () =>
       page.evaluate(() => (window as unknown as MediaHarness).cbMediaReaderCalls()),
+    openCalls: () => page.evaluate(() => (window as unknown as MediaHarness).cbMediaOpenCalls()),
     portRequests: () =>
       page.evaluate(() => (window as unknown as MediaHarness).cbMediaPortRequests()),
     dispose: () => page.evaluate(() => (window as unknown as MediaHarness).cbMediaDispose()),
@@ -169,7 +171,7 @@ test.describe('Service Worker media brokerage over a real byte pipe', () => {
     context,
   }) => {
     const tab = await localTab(context);
-    const size = WINDOW_BYTES * 2 + 512 * 1024;
+    const size = MEDIA_WINDOW_BYTES * 2 + 512 * 1024;
 
     const result = await tab.fetch(await tab.ticket(size));
 
@@ -177,7 +179,9 @@ test.describe('Service Worker media brokerage over a real byte pipe', () => {
     expect(result.byteLength).toBe(size);
     expect(result.digestHex).toBe(digestOf(fixtureSlice(0, size, TAB_SEED)));
     // Peak memory is one window, not the file: one read per window, no more.
-    expect(await tab.readerCalls()).toBe(Math.ceil(size / WINDOW_BYTES));
+    expect(await tab.readerCalls()).toBe(Math.ceil(size / MEDIA_WINDOW_BYTES));
+    // And one pinned version for the whole body, not one resolve per window.
+    expect(await tab.openCalls()).toBe(1);
 
     await tab.dispose();
   });

--- a/packages/client/test/browser/media.ts
+++ b/packages/client/test/browser/media.ts
@@ -49,6 +49,7 @@ declare global {
     cbMediaTicket(size: number, mimeType: string): string;
     cbMediaFetch(url: string, range: string | null): Promise<MediaFetchResult>;
     cbMediaReaderCalls(): number;
+    cbMediaOpenCalls(): number;
     cbMediaPortRequests(): number;
     cbMediaDispose(): Promise<void>;
   }
@@ -57,6 +58,7 @@ declare global {
 let service: MediaService | null = null;
 let client: EngineClient | null = null;
 let readerCalls = 0;
+let openCalls = 0;
 let portRequests = 0;
 
 // A worker that restarted lost its port and must ask for one; counting the asks
@@ -65,20 +67,30 @@ navigator.serviceWorker.addEventListener('message', (event: MessageEvent) => {
   if ((event.data as { type?: unknown } | null)?.type === MEDIA_PORT_REQUEST) portRequests += 1;
 });
 
-/** Serves the tab's own fixture, counting reads so the spec can see windowing. */
+/** Serves the tab's own fixture, counting opens and reads so the spec can see windowing. */
 const localReader = (seed: number): MediaReader => ({
-  downloadRange: (_node, offset, length) => {
+  openContentStream: () => {
+    openCalls += 1;
+    return Promise.resolve(1n);
+  },
+  readStream: (_handle, offset, length) => {
     readerCalls += 1;
     return Promise.resolve(fixtureBuffer(offset, length, seed));
   },
+  closeStream: () => Promise.resolve(),
 });
 
 /** Routes every read through this tab's engine client — a follower's wire. */
 const engineReader: MediaReader = {
-  downloadRange: (node, offset, length) => {
-    readerCalls += 1;
-    return client!.downloadRange(node, offset, length);
+  openContentStream: (node) => {
+    openCalls += 1;
+    return client!.openContentStream(node);
   },
+  readStream: (handle, offset, length) => {
+    readerCalls += 1;
+    return client!.readStream(handle, offset, length);
+  },
+  closeStream: (handle) => client!.closeStream(handle),
 };
 
 window.cbMediaEngine = ({ lockName, channelName }: MediaEngineOptions): Promise<string> => {
@@ -114,6 +126,8 @@ window.cbMediaTicket = (size: number, mimeType: string): string =>
 
 window.cbMediaReaderCalls = (): number => readerCalls;
 
+window.cbMediaOpenCalls = (): number => openCalls;
+
 window.cbMediaPortRequests = (): number => portRequests;
 
 window.cbMediaFetch = async (url: string, range: string | null): Promise<MediaFetchResult> => {
@@ -146,6 +160,7 @@ window.cbMediaDispose = async (): Promise<void> => {
   await client?.dispose();
   client = null;
   readerCalls = 0;
+  openCalls = 0;
   portRequests = 0;
   const registrations = await navigator.serviceWorker.getRegistrations();
   await Promise.all(registrations.map((registration) => registration.unregister()));

--- a/packages/client/test/browser/mediaEngine.worker.ts
+++ b/packages/client/test/browser/mediaEngine.worker.ts
@@ -22,8 +22,16 @@ class MediaHost extends StubEngineHost {
     return Promise.resolve();
   }
 
-  downloadRange(_node: Uint8Array, offset: number, length: number): Promise<ArrayBuffer> {
+  openContentStream(_node: Uint8Array): Promise<bigint> {
+    return Promise.resolve(1n);
+  }
+
+  readStream(_handle: bigint, offset: number, length: number): Promise<ArrayBuffer> {
     return Promise.resolve(fixtureBuffer(offset, length, LEADER_SEED));
+  }
+
+  closeStream(_handle: bigint): Promise<void> {
+    return Promise.resolve();
   }
 
   nextEvent(): Promise<EventDescriptor | null> {


### PR DESCRIPTION
Closes #948

## The bug

`Engine::read_content_range` re-resolved the node on **every** window: full cache-first resolve, adoption gate, head-version selection, and a DAG-root fetch, before reading the requested leaves. `MediaBroker` pulls a media body one window at a time, so a head change mid-stream made window *n* come from version A and window *n+1* from version B. Every byte is still CID-verified and unsealed under its own version's key, so nothing downstream can detect the splice — the response body is simply not a slice of any single authentic object.

## The fix

An engine-side stream handle, pinned at open:

- `Engine::open_content_stream(node) -> StreamHandle` resolves, gates, and fetches + verifies the root manifest **once**, then pins the `Version` and its `RootManifest` behind the handle.
- `Engine::read_stream(handle, offset, length)` reads leaves against the pinned manifest, with the same leaf-length and assembled-length invariants.
- `Engine::close_stream(handle)` releases it; idempotent.

`open_content_range` splits into `open_content_root` (fetch + CID-verify the root, cross-check `manifest.size` against `version.size`) and `read_pinned_range` (fetch, verify, unseal, assemble the leaves), and is now the composition of the two — so the one-shot and pinned paths run provably identical checks. `read_pinned_range` takes the whole `&Version` rather than a bare key and re-asserts the manifest/version size pairing per window, so a mismatched pair is not representable as a silent unseal.

The handle replaces `downloadRange` across the seam chain: wasm host, worker protocol/`serve`/`engineHost`, `LocalTransport`, the broadcast wire (a `cb:stream` axis with per-follower handle ownership, like `cb:write`), `LeaderRelay`, `EngineClient`, `EngineFacade`, `MediaReader`/`MediaBroker`, and the testkit doubles.

### Handles are bound to the leadership that minted them

The engine's `StreamHandle` is a per-engine counter that restarts at 1, so a handle carried across a leadership swap would name a **different** node's live stream on the next engine — the same undetectable two-version splice, one layer up. `EngineClient` therefore mints its own handle, monotonic for the client's whole life, and clears the mapping on every transport swap; a stale handle is unmatchable rather than ambiguous.

### Window alignment

`MEDIA_WINDOW_BYTES` was a round 1 MiB while `ContentProfile::PRODUCTION`'s plaintext chunk is 1,048,536 bytes (the 1 MiB budget belongs to the sealed *block*), so every window sat 40 bytes past a chunk boundary and fetched two leaves. It is now exactly one chunk.

Also from the review passes: the broker opens its engine stream lazily on the first pull (a request abandoned after its head costs nothing), releases the pin on every exit path, and wipes an abandoned plaintext window; the relay binds a minted handle only if its client is still present, and drops ownership only once the close resolves; `readStream` rejects non-integral `offset`/`length` at the wasm boundary rather than truncating.

## Gates

Engine cargo tests — both new tests were verified red before the fix:

- `a_stream_serves_the_pinned_version_across_a_head_change` — a stream opened on version A keeps serving A after the other device publishes B mid-body, and a fresh read confirms the head really moved. Pre-fix it assembled window 0 from A and every later window from B.
- `a_stream_pays_one_resolve_and_one_root_fetch_for_the_whole_body` — every routing endpoint goes dark after the open and the body still serves; the gateway fetch count over N windows is exactly N leaves, no root re-fetch. Pre-fix: 39 fetches for 13 windows.

`packages/client` browser suite — `a file larger than one window streams through several windows, byte-exact` now also asserts exactly one `openContentStream` for a 2.5-window body. `packages/client` unit suite — one open per body with a close at the end, follower stream windows over the broadcast wire, a handle refused for a follower that does not own it, and a handle refused after a leadership swap that re-minted the same engine id.

## Deliberately out of scope

Filed as follow-ups rather than folded in: an admission cap / idle eviction on `LiveStreams` (the write plane is bounded by the staging ledger, the read plane is not); reclaiming a broker cursor when the Service Worker port dies without a `cb:media:close`; and binding `MEDIA_WINDOW_BYTES` to `ContentProfile::PRODUCTION` across the wasm seam instead of mirroring the constant in TypeScript. `Engine::read_content_range` stays public as the one-shot ranged read behind `read_content`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated content streaming with open, read, and close operations.
  * Media downloads now reuse a pinned stream across multiple windows.
  * Added stream lifecycle support across local, worker, browser, and follower transports.
  * Added safeguards for stale, unknown, closed, and excessive stream handles.

* **Bug Fixes**
  * Improved cleanup when connections, leadership, or media requests change.
  * Ensured unread or invalidated download data is safely cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->