### PR TITLE
chore: ignore worktree-local cargo target dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 # Build output
 dist/
 target/
+# Worktree-local CARGO_TARGET_DIR: a shared target dir silently reuses stale
+# test binaries across worktrees, so each one gets its own `target-<name>/`.
+target-*/
 *.tsbuildinfo
 
 # Environment files

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ export default [
       '**/.learnings/**',
       '**/src-tauri/target/**',
       'target/**',
+      'target-*/**',
       // Generated wasm-bindgen glue + Playwright output for the browser suite.
       'apps/web/src/wasm/**',
       '**/test/browser/pkg/**',


### PR DESCRIPTION
Every worktree that runs cargo needs its own `CARGO_TARGET_DIR` — a shared one silently reuses stale test binaries, so each branch reports identical passing counts while testing none of its own changes. The convention that has grown up around that is `target-<name>/` per worktree.

Those directories were untracked but not ignored, which bit twice today:

- `git add -A` in a worktree would have committed several GB of build cache. Agents have had to be told to stage specific files instead.
- `pnpm exec eslint .` failed on a generated Tauri script inside one, because `eslint.config.js` ignored `target/**` but not `target-*/`.

Both are the same missing pattern.

## Verification

Created `target-verify/debug/generated.ts` containing code that would otherwise fail lint, then:

- `git status --porcelain` — no mention of it; `git check-ignore -v` attributes it to `.gitignore:9: target-*/`
- `pnpm exec eslint target-verify/debug/generated.ts` — reports `File ignored because of a matching ignore pattern`, exit 0
- `pnpm exec eslint .` — exit 0

The probe directory was removed afterward.
