### PR TITLE
chore: retarget the crypto-privacy review gate at the v2 primitive set

### DIFF
--- a/.claude/agents/crypto-privacy-reviewer.md
+++ b/.claude/agents/crypto-privacy-reviewer.md
@@ -30,33 +30,33 @@ Your job: Find security issues before attackers do. Generate test cases that pro
 
 **Symmetric Encryption:**
 
-- AES modes (GCM vs CBC vs CTR) and when to use each
-- Nonce/IV requirements and reuse dangers
-- Authenticated encryption (AEAD) necessity
+- AEAD constructions, and why an extended nonce (XChaCha20-Poly1305) changes the reuse budget
+- Nonce requirements and reuse dangers
+- AAD binding and domain separation across structure kinds
 - Key sizes and security margins
 
 **Asymmetric Encryption:**
 
-- ECIES for hybrid encryption
-- Key exchange protocols (ECDH, X25519)
-- Digital signatures (ECDSA, EdDSA)
-- RSA pitfalls and modern alternatives
+- RFC 9180 HPKE, and when base mode is insufficient because the recipient half is public by construction
+- Key exchange protocols (X25519 ECDH)
+- Digital signatures (secp256k1 ECDSA, Ed25519)
 
 **Key Management:**
 
-- Key derivation functions (PBKDF2, Argon2, HKDF)
-- Key hierarchy design
+- Tree key derivation (BLAKE3 `derive_key` / `keyed_hash`) and frozen edge catalogs
+- Key hierarchy design: seeded per-scope derivation with key-regression epochs
 - Key wrapping and transport
-- Key rotation strategies
+- Key rotation as an O(1) root cut plus a lazy wave
 
 **Common Vulnerabilities:**
 
 - Nonce reuse attacks
-- Padding oracles
+- AAD and cross-family transplants
 - Timing side-channels
 - Key confusion
 - Downgrade attacks
 - Replay attacks
+- Fail-closed checks written as `debug_assert!`, and so absent in release
 
 </expertise>
 
@@ -88,10 +88,10 @@ Your job: Find security issues before attackers do. Generate test cases that pro
 
 ### 4. Check Implementation Details
 
-- Is randomness from secure source?
+- Is entropy injected rather than drawn inside a pure layer?
 - Are comparisons constant-time where needed?
-- Is error handling secure (no oracle)?
-- Are buffers cleared after use?
+- Is error handling secure (no oracle), and does a trust violation stay disjoint from a malformed/availability error?
+- Are buffers cleared at the terminal owner, and never by a callee that only borrows them?
 
 ### 5. Consider Attack Scenarios
 
@@ -106,32 +106,50 @@ Your job: Find security issues before attackers do. Generate test cases that pro
 
 ## CipherBox Security Model
 
-This project implements zero-knowledge encrypted storage. Key security properties:
+This project implements zero-knowledge encrypted storage. Normative sources:
+`blueprint/core.md` (primitives, KDF edge catalog, wire format) and `CONTEXT.md`
+(ubiquitous language).
 
 **Trust Model:**
 
 - Client: Fully trusted (user's device)
-- Server: Untrusted (zero-knowledge, never sees plaintext or keys)
-- TEE: Trusted for IPNS republishing only (hardware isolation)
+- Server: Untrusted (zero-knowledge, never sees plaintext or keys). The republisher is a keyless re-PUT module inside it; EOLs are client-signed, 90 days
 - IPFS: Untrusted (only sees ciphertext)
+- Any resolved record: Untrusted until it passes the adoption gate
 
 **Key Hierarchy:**
 
+Seeded per-scope derivation, not a random key per node.
+
 ```text
-User Private Key (secp256k1, from Web3Auth)
-    └── Root Folder Key (random, AES-256)
-        └── Folder Keys (per-folder, AES-256)
-            └── File Keys (per-file, AES-256)
+Login secret (secp256k1 identity key + X25519 encryption subkey, from Web3Auth)
+    └── Scope seed (random at a grant cut; replaced by a random override seed at rotation)
+        └── Node seed = keyed_hash(derive_key("<edge>", scopeSeed), id16) — flat within the scope
+            ├── Read key (per-node body sealing)
+            └── Structure keys (per structure tag)
 ```
+
+The write plane mirrors it from a `writeScopeSeed`: `writeSeed(X) =
+KDF(writeScopeSeed, X.id)` yields the node's `writeKey` and its Ed25519 IPNS
+keypair. Rotation is an O(1) root cut — a fresh override seed starts a new epoch,
+descendants re-seal on a lazy wave, and current-seed holders read epoch-lagged
+nodes backward through history links while old-seed holders can never walk
+forward. Content keys are random per version and stored inline in the sealed
+read-body; rotation re-wraps them via the metadata re-seal and never re-encrypts
+content bytes.
 
 **Critical Rules:**
 
-- ECIES for key wrapping
-- AES-256-GCM for content encryption
-- Web Crypto API only (no JS crypto libraries)
-- Uint8Array for all binary data
-- Never expose keys to server
-- TEE receives only encrypted IPNS keys
+- XChaCha20-Poly1305 for all sealing
+- RFC 9180 HPKE over X25519 for sealing to a person, auth mode wherever sender authentication is load-bearing
+- BLAKE3 for every derivation, and only through the frozen KDF edge catalog
+- Ed25519 for structure signatures and IPNS records; secp256k1 ECDSA for identity signing
+- All crypto in `crates/core` — TypeScript has no codec or crypto of its own
+- `Vec<u8>` / `Uint8Array` for all binary data
+- Never expose keys or seeds to the server
+- Every resolved record passes the adoption gate; a failure is a fail-closed trust violation, never mere staleness
+- Encode/decode fail-closed symmetry — a decode-side hard reject needs a release-active encode-side `Err`, never `debug_assert!`
+- Zeroize at the terminal owner only; a callee must not zero a caller-owned buffer
 
 </project_context>
 
@@ -148,7 +166,7 @@ For each issue found:
 
 **Code:**
 
-```typescript
+```rust
 // The problematic code
 ```
 
@@ -160,7 +178,7 @@ For each issue found:
 
 **Recommendation:**
 
-```typescript
+```rust
 // How to fix it
 ```
 
@@ -171,49 +189,41 @@ For each issue found:
 
 ## Test Case Format
 
-```typescript
-describe('[Component] Security Tests', () => {
-  describe('Positive Cases', () => {
-    it('encrypts data correctly with valid key', async () => {
-      // Arrange
-      const key = await generateKey();
-      const plaintext = new TextEncoder().encode('secret');
+```rust
+// Positive: an accept vector reproduces exact bytes under fixed parameters, then opens
+#[test]
+fn component_seals_and_opens_under_a_fixed_nonce() {
+    let key = fixed_key();
+    let aad = Aad::new(V, id, scope, epoch, StructTag::ReadBody);
+    let sealed = seal(&key, FIXED_NONCE, &aad, PLAINTEXT).unwrap();
+    assert_eq!(sealed, expected_bytes());
+    assert_eq!(open(&key, &aad, &sealed).unwrap(), PLAINTEXT);
+}
 
-      // Act
-      const ciphertext = await encrypt(plaintext, key);
-      const decrypted = await decrypt(ciphertext, key);
+// Negative: one reject vector per check that must fire
+#[test]
+fn component_rejects_a_wrong_key() {}
 
-      // Assert
-      expect(decrypted).toEqual(plaintext);
-    });
-  });
+#[test]
+fn component_rejects_a_tampered_tag() {}
 
-  describe('Negative Cases', () => {
-    it('rejects decryption with wrong key', async () => {
-      // Test suggestion
-    });
+#[test]
+fn component_rejects_a_struct_tag_aad_transplant() {}
 
-    it('rejects tampered ciphertext', async () => {
-      // Test suggestion
-    });
-  });
+// Edge cases
+#[test]
+fn component_handles_an_empty_plaintext() {}
 
-  describe('Edge Cases', () => {
-    it('handles empty plaintext', async () => {
-      // Test suggestion
-    });
+#[test]
+fn component_reads_an_epoch_lagged_node_through_history_links() {}
 
-    it('handles maximum size data', async () => {
-      // Test suggestion
-    });
-  });
+// Attack scenarios
+#[test]
+fn component_refuses_a_base_mode_forgery() {}
 
-  describe('Attack Scenarios', () => {
-    it('detects nonce reuse attempt', async () => {
-      // Test suggestion
-    });
-  });
-});
+// Encode-side symmetry — must fire in a release build, not only under debug_assert
+#[test]
+fn component_encode_refuses_what_decode_rejects() {}
 ```
 
 </output_format>
@@ -243,7 +253,8 @@ describe('[Component] Security Tests', () => {
 
 ### Report Location
 
-`.planning/security/REVIEW-[timestamp].md`
+Inline above, or a session-scratchpad path when too large to inline. Never
+written into the repository tree, never committed.
 
 ### Recommendations
 

--- a/.claude/commands/crypto-privacy-review.md
+++ b/.claude/commands/crypto-privacy-review.md
@@ -40,25 +40,31 @@ into the repository tree and do NOT commit them.
 
 ## Project Security Rules
 
-Reference the project's AGENTS.md security rules:
+Normative sources: `blueprint/core.md` (primitives, KDF edge catalog, wire
+format, KAT regime) and `CONTEXT.md` (ubiquitous language). AGENTS.md "Critical
+Security Rules" restates them; where they disagree, the blueprint wins.
 
-- Never store privateKey in localStorage/sessionStorage
-- Never log sensitive keys
-- Never send unencrypted keys to server
-- Always use ECIES for key wrapping
-- Always use AES-256-GCM for content encryption
-- Server NEVER has access to plaintext or unencrypted keys
-- Always encrypt ipnsPrivateKey with TEE public key before sending
-- TEE decrypts IPNS keys in hardware only, signs, and immediately discards
+- Never store `privateKey` or any seed in localStorage/sessionStorage
+- Never log sensitive keys or seeds
+- Never send unencrypted keys to the server — the server is zero-knowledge
+- All crypto lives in `crates/core`; TypeScript has no codec or crypto of its own
+- Nothing derives a key outside the frozen KDF edge catalog
+- Every resolved record passes the adoption gate; a failure is a fail-closed trust violation, never mere staleness
+- Zeroize at the terminal owner only — a callee must not zero a caller-owned buffer
+- Encode/decode fail-closed symmetry: wherever decode hard-rejects an invariant, the matching encode path returns `Err` under a release-active check, never `debug_assert!`/`assert!`
 
 ## Cryptographic Standards
 
-| Algorithm      | Use Case           | Notes                              |
-| -------------- | ------------------ | ---------------------------------- |
-| AES-256-GCM    | Content encryption | Authenticated encryption required  |
-| ECIES          | Key wrapping       | For asymmetric key transport       |
-| Web Crypto API | Browser crypto     | No polyfills or JS implementations |
-| Uint8Array     | Binary data        | Never strings for crypto data      |
+| Algorithm                                              | Use Case                     | Notes                                                                     |
+| ------------------------------------------------------ | ---------------------------- | ------------------------------------------------------------------------- |
+| XChaCha20-Poly1305                                     | Sealing                      | 24-byte nonce; sealed bodies, structures, content bytes                   |
+| BLAKE3 `derive_key` / `keyed_hash`                     | Key derivation               | The whole edge catalog; ids are fixed-length message input, never context |
+| RFC 9180 HPKE, X25519-HKDF-SHA256 + XChaCha20-Poly1305 | Sealing to a person          | Base mode for grant blobs and mailbox; auth mode for HPKE-to-self records |
+| X25519 ECDH                                            | Pairwise secrets             | Blinded tags, writer-pseudonym derivation                                 |
+| secp256k1 ECDSA, RFC 6979                              | Identity signing             | Grant-set commitment, subkey binding, re-point object                     |
+| Ed25519                                                | Pseudonym and record signing | Structure signatures; IPNS records                                        |
+| Deterministic CBOR, RFC 8949 §4.2                      | Wire format                  | DAG-CBOR blocks; one strictness policy everywhere                         |
+| `Vec<u8>` / `Uint8Array`                               | Binary data                  | Never strings for crypto data                                             |
 
 </execution_context>
 
@@ -87,17 +93,18 @@ Use AskUserQuestion:
 Based on scope, identify files to review:
 
 ```bash
-# Find crypto-related files
-grep -r -l "encrypt\|decrypt\|crypto\|Crypto\|cipher\|AES\|ECIES\|privateKey\|publicKey" --include="*.ts" --include="*.js" . | grep -v node_modules | grep -v ".test."
+# Find crypto-related files (crates/core and crates/engine own the crypto)
+grep -r -l "seal\|unseal\|derive_key\|keyed_hash\|hpke\|Hpke\|Zeroizing\|privateKey\|publicKey" --include="*.rs" --include="*.ts" crates packages apps | grep -v node_modules | grep -v "/target/"
 ```
 
 Also search for:
 
-- Key management code
+- New or changed KDF edges, structure tags, and AAD construction
+- Adoption-gate stages and anything that classifies a gate failure
+- Encode paths whose decode counterpart hard-rejects an invariant
+- Key material lifetimes: `Zeroizing` owners, borrows, and zeroize calls
 - Authentication/authorization
-- Data serialization of sensitive data
 - API endpoints handling secrets
-- Storage operations for keys
 
 ## Phase 3: Security Analysis
 
@@ -105,45 +112,57 @@ For each file/section, analyze through these lenses:
 
 ### 3.1 Cryptographic Correctness
 
-- [ ] Correct algorithm usage (AES-256-GCM, not AES-CBC without MAC)
-- [ ] Proper IV/nonce generation (crypto.getRandomValues, never predictable)
-- [ ] IV/nonce never reused with same key
-- [ ] Authenticated encryption used (GCM, not just encryption)
-- [ ] Key sizes appropriate (256-bit for AES, appropriate curves for EC)
+- [ ] Primitive matches the role in the `blueprint/core.md` suite table; nothing outside it
+- [ ] HPKE auth mode wherever sender authentication is load-bearing (the HPKE-to-self record families) — base mode there is a forgery hole when the recipient half is public by construction
+- [ ] Nonces and HPKE ephemerals come from injected entropy, never an RNG called inside core
+- [ ] Nonce never reused under the same key
+- [ ] AAD binds `(v, id, scope, epoch, structTag)` under the `cipherbox/v2` domain separator, so a downgrade or transplant fails the tag
 - [ ] No deprecated algorithms (MD5, SHA1 for security, DES, RC4)
 
 ### 3.2 Key Management
 
-- [ ] Keys derived using proper KDF (not just hashing)
+- [ ] Every derivation is a frozen KDF edge-catalog edge — no ad-hoc context strings, no inline hashing of a seed
+- [ ] Edge inputs use the frozen shape: `keyed_hash(key = derive_key("<edge context>", seed), message = id16)`, ids as fixed-length message input
+- [ ] Separation holds: a new edge cannot produce equal output to an existing one for equal inputs
+- [ ] Key hierarchy follows the scope/epoch model (scope seed → node seed → read and structure keys; write scope seed → write seed → writeKey and IPNS keypair)
+- [ ] Rotation stays an O(1) root cut plus a lazy wave: a fresh random override seed, a history link backward-only, no eager re-encryption of content bytes
+- [ ] Stated non-edges stay non-edges (content keys, override seeds, scope seeds at grant cuts are random)
+- [ ] Sealing to a person targets the recipient's X25519 encryption subkey, never their identity key
 - [ ] Keys never logged or exposed in errors
-- [ ] Keys cleared from memory after use
-- [ ] Key hierarchy follows spec (rootFolderKey → folderKey → fileKey)
-- [ ] Key wrapping uses ECIES as specified
+- [ ] Key material lives in `Zeroizing` owning types; zeroize happens at the terminal owner only, never in a callee that borrows a caller's buffer
 - [ ] No hardcoded keys or secrets
 
 ### 3.3 Trust Boundaries
 
-- [ ] Client-side encryption before any server transmission
-- [ ] Server never receives plaintext keys
-- [ ] TEE boundaries respected (encrypted IPNS keys only)
-- [ ] No trust assumptions on server for key material
+- [ ] Client-side sealing before any server transmission
+- [ ] Server never receives plaintext or key material
+- [ ] Every resolved record passes the adoption gate before adoption — signature verify, commitment verify, structure signatures against committed write pseudonyms, strictly-newer sequence vs floor, epoch at or above the scope floor, unseal success
+- [ ] A gate failure is typed as a trust violation, disjoint from malformed/availability errors — never degraded to staleness or a silent retry
+- [ ] Floors advance only on an AAD-confirmed unseal or the owner-vouched re-point object, never from a raw blob epoch field
+- [ ] IPNS verification takes the Ed25519 public key from the name itself, never a DB column or side channel
+- [ ] The republisher stays keyless: re-PUT round-trips foreign signed bytes byte-stable with no key material
 
 ### 3.4 Implementation Safety
 
-- [ ] Using Web Crypto API (not crypto-js or similar)
-- [ ] Uint8Array for all binary data
-- [ ] Constant-time comparison for authentication tokens
+- [ ] Crypto lives in `crates/core` — no crypto or codec implemented in TypeScript
+- [ ] Encode/decode fail-closed symmetry: a decode-side hard reject has a matching release-active encode-side `Err`, following the `crates/core/src/seal/body.rs` `assert_children_unique` convention — `debug_assert!`/`assert!` are stripped in release and let a build sign bytes its own decoder rejects
+- [ ] Decoders accept the deterministic CBOR profile only; duplicate keys, non-canonical encodings, and wrong major types reject
+- [ ] Unknown fields tolerated, preserved byte-stable, re-emitted canonically on rewrite
+- [ ] Purity holds: no clock, no RNG, no I/O in core — entropy, time, and policy enter as parameters
+- [ ] `Vec<u8>` / `Uint8Array` for all binary data
+- [ ] Constant-time comparison for tags and authentication tokens
 - [ ] No sensitive data in error messages
 - [ ] No sensitive data in logs
-- [ ] Proper error handling (no silent failures in crypto)
+- [ ] Proper error handling (no silent failures in crypto); every rejection names the check that fired
+- [ ] New structure tags and KDF edges extend the KAT manifest with accept and reject vectors before merge
 
 ### 3.5 Data Flow Security
 
-- [ ] Sensitive data encrypted at rest
-- [ ] Sensitive data encrypted in transit
+- [ ] Sensitive data sealed at rest
+- [ ] Sensitive data sealed in transit
 - [ ] No sensitive data in URLs or query params
-- [ ] No sensitive data in localStorage/sessionStorage (except encrypted)
-- [ ] Metadata leakage minimized
+- [ ] No seeds or private keys in localStorage/sessionStorage
+- [ ] Metadata leakage minimized — the envelope stays kind-uniform, blinded tags leak only blob count
 
 ## Phase 4: Generate Test Cases
 
@@ -159,26 +178,29 @@ For each crypto operation found, generate test cases:
 
 - Invalid key format
 - Corrupted ciphertext
-- Wrong key for decryption
-- Tampered authenticated data (GCM tag modification)
-- Truncated ciphertext
+- Wrong key for unseal
+- Tampered Poly1305 tag
+- Truncated ciphertext, and a short or low-order HPKE `enc`
+- AAD transplant: wrong `scope`, `epoch`, `structTag`, or `v`
+- Base-mode forgery where auth mode is required
 
 ### Edge Cases
 
-- Empty plaintext encryption
-- Very large data encryption (chunking behavior)
+- Empty plaintext seal
+- Very large data (chunking behavior)
 - Unicode/binary data handling
-- Concurrent encryption operations
-- Key rotation scenarios
-- Re-encryption with new keys
+- Concurrent seal operations
+- Rotation: an epoch-lagged node read backward through history links
+- Re-seal at a new epoch under the lazy wave
 
 ### Attack Scenarios
 
-- Replay attacks (nonce reuse detection)
-- Padding oracle (if applicable)
+- Replay attacks (sequence vs floor)
+- Downgrade attacks (`v` bound into the AAD)
 - Timing attacks (constant-time operations)
-- Key confusion attacks
-- Downgrade attacks
+- Key confusion: cross-family transplant between structure tags
+- Floor rollback from a raw blob epoch field
+- Forward regression: an old-seed holder reaching a newer epoch
 
 ## Phase 5: Generate Report
 
@@ -263,23 +285,18 @@ Report template:
 
 #### Unit Tests
 
-```typescript
-describe('[component] security', () => {
-  // Positive cases
-  it('should [expected behavior]', () => {
-    // Test suggestion
-  });
+```rust
+// Accept vector: exact bytes under a fixed key/nonce (or fixed ephemeral), then open
+#[test]
+fn [component]_accept_[case]() {}
 
-  // Negative cases
-  it('should reject [invalid input]', () => {
-    // Test suggestion
-  });
+// Reject vector: the check that must fire, named
+#[test]
+fn [component]_reject_[invalid_input]() {}
 
-  // Edge cases
-  it('should handle [edge case]', () => {
-    // Test suggestion
-  });
-});
+// Edge case
+#[test]
+fn [component]_handles_[edge_case]() {}
 ```
 
 #### Integration Tests
@@ -296,13 +313,15 @@ describe('[component] security', () => {
 
 Based on project security rules:
 
-- [ ] No privateKey in localStorage/sessionStorage
-- [ ] No sensitive keys logged
+- [ ] No `privateKey` or seed in localStorage/sessionStorage
+- [ ] No sensitive keys or seeds logged
 - [ ] No unencrypted keys sent to server
-- [ ] ECIES used for key wrapping
-- [ ] AES-256-GCM used for content encryption
+- [ ] Only `blueprint/core.md` suite primitives used
+- [ ] Every derivation is a frozen KDF edge-catalog edge
+- [ ] Adoption gate enforced fail-closed on every resolved record
+- [ ] Encode-side release-active `Err` mirrors every decode-side hard reject
+- [ ] Zeroize at the terminal owner only
 - [ ] Server has zero knowledge of plaintext
-- [ ] IPNS keys encrypted with TEE public key
 
 ## Recommendations Summary
 
@@ -374,56 +393,77 @@ Use AskUserQuestion:
 
 ## Common Crypto Vulnerabilities to Check
 
-### Nonce/IV Reuse
+### Nonce Reuse / Self-Sourced Randomness
 
-```typescript
-// BAD: Reusing IV
-const iv = new Uint8Array(12); // zeros!
-// GOOD: Random IV each time
-const iv = crypto.getRandomValues(new Uint8Array(12));
+```rust
+// BAD: a fixed nonce, or one core drew itself
+let nonce = [0u8; 24];
+// GOOD: fresh per seal, from injected entropy — core owns no RNG
+let nonce = entropy.nonce_24();
 ```
 
-### Missing Authentication
+### Missing Sender Authentication
 
-```typescript
-// BAD: AES-CBC without MAC
-// GOOD: AES-GCM (authenticated)
+```rust
+// BAD: HPKE base mode where the recipient half is public by construction —
+// any party who can see it can seal a well-formed record
+hpke_seal_base(recipient_enc_pk, aad, plaintext)
+// GOOD: auth mode binds the sender's static key
+hpke_seal_auth(sender_enc_sk, recipient_enc_pk, aad, plaintext)
 ```
 
-### Weak Key Derivation
+### Off-Catalog Key Derivation
 
-```typescript
-// BAD: Simple hash
-const key = await crypto.subtle.digest('SHA-256', password);
-// GOOD: PBKDF2/Argon2 with iterations
+```rust
+// BAD: an ad-hoc context string, id smuggled in as variable context
+blake3::derive_key(&format!("cipherbox/v2/node/{id}"), seed);
+// GOOD: a catalog edge — id is fixed-length message input
+kdf::node_seed(scope_seed, id16);
+```
+
+### Encode/Decode Asymmetry
+
+```rust
+// BAD: stripped in release — the build signs bytes its own decoder rejects
+debug_assert!(children_unique(&children));
+// GOOD: release-active, returns Err
+assert_children_unique(&children)?;
+```
+
+### Over-Eager Zeroization
+
+```rust
+// BAD: a callee zeroing a buffer its caller still owns and will reuse
+fn seal(key: &mut [u8; 32]) { /* … */ key.zeroize(); }
+// GOOD: zeroize at the terminal owner; callees borrow
+fn seal(key: &Zeroizing<[u8; 32]>) { /* … */ }
+```
+
+### Trust Violation Degraded to Staleness
+
+```rust
+// BAD: a failed gate stage becomes a retry, and the record is adopted later
+Err(_) => Ok(Adoption::Stale),
+// GOOD: fail closed, naming the check that fired
+Err(e) => Err(TrustViolation::StructureSignature(e)),
 ```
 
 ### Timing Attacks
 
-```typescript
-// BAD: Early return on mismatch
-if (a[i] !== b[i]) return false;
-// GOOD: Constant-time comparison
+```rust
+// BAD: early return on mismatch
+if a[i] != b[i] { return false; }
+// GOOD: constant-time comparison
+a.ct_eq(b).into()
 ```
 
 ### Key in Logs/Errors
 
-```typescript
+```rust
 // BAD
-console.log('Key:', key);
-throw new Error(`Failed with key ${key}`);
+tracing::debug!(?seed, "derived node seed");
 // GOOD
-console.log('Key operation failed');
-throw new Error('Decryption failed');
-```
-
-### Predictable Randomness
-
-```typescript
-// BAD
-Math.random();
-// GOOD
-crypto.getRandomValues();
+tracing::debug!("node seed derivation failed");
 ```
 
 </vulnerability_patterns>


### PR DESCRIPTION
Closes #973

`/crypto-privacy-review` is a mandatory gate on every PR touching crypto, and both halves of it — the command and the `crypto-privacy-reviewer` subagent it spawns — still described the v1 cryptosystem. Neither file contained a single occurrence of XChaCha20, BLAKE3, or HPKE. A reviewer running the gate reviewed against primitives v2 does not use: it would flag correct v2 code as non-compliant and, worse, never look for the invariants that actually matter.

The issue names only the command file. The subagent definition is fixed in the same PR because fixing only the command would close the issue while the reviewer that actually runs still holds the v1 mental model.

## What changed

Both files, against `blueprint/core.md` and `CONTEXT.md`:

- **Algorithm table and suite** — XChaCha20-Poly1305 sealing, BLAKE3 `derive_key`/`keyed_hash`, RFC 9180 HPKE over X25519-HKDF-SHA256, X25519 ECDH for pairwise secrets, secp256k1 ECDSA for identity signing, Ed25519 for structure signatures and IPNS records, deterministic CBOR for the wire format. AES-256-GCM and ECIES are gone.
- **Key hierarchy** — the v1 "Root Folder Key random AES-256 → Folder Keys → File Keys" tree is replaced by v2's seeded per-scope derivation: scope seed → node seed → read and structure keys, with the write-plane mirror from `writeScopeSeed`. Rotation is stated as an O(1) root cut plus a lazy wave, with history links backward-only and content keys random per version.
- **TEE** — every reference deleted, including the `ipnsPrivateKey`-to-TEE rule and the "TEE: trusted for IPNS republishing" trust-model row. The republisher is a keyless re-PUT module inside the API with client-signed 90-day EOLs.
- **PBKDF2/Argon2 and Web Crypto** — deleted. All crypto lives in `crates/core`; TypeScript has no codec or crypto of its own, so the code examples and test-case scaffolding move to Rust.

## Invariants added

Neither file had any notion of these:

- **Adoption gate** as a fail-closed trust boundary — the gate stages are enumerated, and a failure is a trust violation disjoint from malformed/availability errors, never degraded to staleness or a silent retry.
- **Frozen KDF edge catalog** — nothing derives a key outside it, edge inputs use the frozen `keyed_hash(key = derive_key(context, seed), message = id16)` shape, and separation must hold for any new edge.
- **Encode/decode fail-closed symmetry** — a decode-side hard reject needs a matching release-active encode-side `Err`, following the `crates/core/src/seal/body.rs` `assert_children_unique` convention, never `debug_assert!`/`assert!`.
- **Zeroize at the terminal owner only** — a callee must not zero a caller-owned buffer.

Also added, since they are the checks a v2 crypto review has to run: HPKE auth mode where sender authentication is load-bearing, floor law, IPNS pubkey taken from the name itself, deterministic-CBOR strictness with unknown-field tolerance, injected entropy/time, and the KAT accept/reject vector obligation for new tags and edges.

## Verification

Both files, after: zero occurrences of `AES`, `ECIES`, `PBKDF2`, `Argon2`, `Web Crypto`, `TEE`. `markdownlint` against the repo config and `prettier` both clean.

Out of scope, deliberately: `landing/` mentions AES-GCM and ECIES, but that is product marketing copy describing the deployed v1 system. `CONTEXT.md` also still says the owner blob is "ECIES-wrapped" — a genuine blueprint-corpus inconsistency worth a separate look, not something to fold into a tooling fix.
