### PR TITLE
chore: sweep the retro-audit cleanup backlog

### DIFF
--- a/crates/core/src/seal/body.rs
+++ b/crates/core/src/seal/body.rs
@@ -125,6 +125,8 @@ impl ChildRef {
 /// The private `content_key` is random per-version symmetric key material, held
 /// in a zeroizing owner ([`SecretBytes`]) with a redacted `Debug` (never-log-keys
 /// rule); read it through [`Version::content_key`].
+/// `PartialEq` short-circuits across fields — a round-trip comparator, not a
+/// security comparison (see [`crate::suite::secret`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Version {
     /// The content CID bytes.
@@ -618,6 +620,30 @@ mod tests {
             r#"{"futureKey": "<redacted>"}"#,
             "a preserved value must never reach a log line"
         );
+    }
+
+    /// A version's per-version content key never reaches a log line, through
+    /// the type itself or the [`ReadBody`] that carries it. Pinned as an exact
+    /// shape so an added field forces a redaction decision (security rule 2).
+    #[test]
+    fn version_debug_redacts_the_content_key() {
+        let version = Version::new(vec![0x01, 0x02], [0xab; SECRET_LEN], 7, 99);
+        assert_eq!(
+            format!("{version:?}"),
+            "Version { content_cid: [1, 2], content_key: SecretBytes(redacted), \
+             size: 7, modified_at: 99, unknown: {} }"
+        );
+
+        // And through the composing body, which is what a diagnostic renders.
+        let body = ReadBody::File {
+            versions: vec![version],
+            created_at: 1,
+            modified_at: 2,
+            unknown: PreservedFields::new(),
+        };
+        let rendered = format!("{body:?}");
+        assert!(rendered.contains("SecretBytes(redacted)"), "{rendered}");
+        assert!(!rendered.contains("171"), "content key leaked: {rendered}");
     }
 
     #[test]

--- a/crates/core/src/seal/grant.rs
+++ b/crates/core/src/seal/grant.rs
@@ -93,6 +93,8 @@ impl Permission {
 /// hint and the stable pointer read key. `write_scope_seed` is present only for
 /// write grants. Seeds are secret material in zeroizing owning types with a
 /// redacted `Debug`; read them through the accessors.
+/// `PartialEq` short-circuits across fields — a round-trip comparator, not a
+/// security comparison (see [`crate::suite::secret`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GrantBlobPayload {
     read_scope_seed: SecretBytes,
@@ -237,6 +239,8 @@ pub fn open_grant_blob(
 /// The sealed plaintext of an owner blob and of an ascent link: the scope's
 /// current override seed plus the epoch it belongs to. The seed is secret
 /// material in a zeroizing owning type; read it through [`Self::override_seed`].
+/// `PartialEq` short-circuits across fields — a round-trip comparator, not a
+/// security comparison (see [`crate::suite::secret`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OverrideSeedPayload {
     override_seed: SecretBytes,
@@ -350,6 +354,8 @@ pub fn open_owner_blob(
 /// subkey; never shared with the ascent link (which would leak write capability
 /// to ancestor read-only readers). The seed is secret material in a zeroizing
 /// owning type; read it through [`Self::write_scope_seed`].
+/// `PartialEq` short-circuits across fields — a round-trip comparator, not a
+/// security comparison (see [`crate::suite::secret`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OwnerWriteBlobPayload {
     write_scope_seed: SecretBytes,
@@ -566,6 +572,8 @@ pub fn open_ascent_link(
 /// belongs to. Symmetrically sealed under the current epoch's structure key
 /// (struct tag `history-link`) via [`super::seal`]. The seed is secret material
 /// in a zeroizing owning type.
+/// `PartialEq` short-circuits across fields — a round-trip comparator, not a
+/// security comparison (see [`crate::suite::secret`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HistoryLinkPayload {
     prev_seed: SecretBytes,
@@ -818,43 +826,66 @@ mod tests {
         }
     }
 
-    /// Every seed-bearing payload renders each secret field as exactly the
-    /// redaction marker, so no rendering (hex, decimal, or otherwise) of the
-    /// bytes can appear (security rule 2: never log key material). Counting
-    /// markers rather than searching for byte spellings is what makes this hold
-    /// for a field added later.
+    /// Every seed-bearing payload renders as an exact redacted shape (security
+    /// rule 2: never log key material). Pinned as a whole-string golden, not a
+    /// search for a byte spelling: any added field — of any type, including a
+    /// raw `[u8; 32]` held outside [`SecretBytes`] — breaks this test and forces
+    /// a redaction decision.
     #[test]
-    fn seed_payload_debug_renders_every_secret_field_as_the_redaction_marker() {
+    fn seed_payload_debug_renders_exactly_the_redacted_shape() {
         const SEED: [u8; SECRET_LEN] = [0xab; SECRET_LEN];
-        const MARKER: &str = "SecretBytes(redacted)";
+        const KEY: [u8; SECRET_LEN] = [0xcd; SECRET_LEN];
 
-        // (rendered payload, number of `SecretBytes` fields it holds)
-        let cases = [
-            (
-                format!(
-                    "{:?}",
-                    GrantBlobPayload::new(SEED, Some(SEED), 4, [0xcd; SECRET_LEN])
-                ),
-                3,
-            ),
-            (format!("{:?}", OverrideSeedPayload::new(SEED, 4)), 1),
-            (format!("{:?}", OwnerWriteBlobPayload::new(SEED, 4)), 1),
-            (format!("{:?}", HistoryLinkPayload::new(SEED, 4)), 1),
-        ];
-        for (rendered, secret_fields) in cases {
-            assert_eq!(
-                rendered.matches(MARKER).count(),
-                secret_fields,
-                "every secret field must render as {MARKER}: {rendered}"
-            );
-            // 0xab/0xcd in the two renderings a leak would take.
-            for spelling in ["ab", "cd", "171", "205"] {
-                assert!(
-                    !rendered.contains(spelling),
-                    "seed bytes leaked into Debug as {spelling}: {rendered}"
-                );
-            }
-        }
+        assert_eq!(
+            format!("{:?}", GrantBlobPayload::new(SEED, Some(SEED), 4, KEY)),
+            "GrantBlobPayload { read_scope_seed: SecretBytes(redacted), \
+             write_scope_seed: Some(SecretBytes(redacted)), epoch: 4, \
+             pointer_read_key: SecretBytes(redacted), unknown: {} }"
+        );
+        // The read-only arm, which the `Some` case never renders.
+        assert_eq!(
+            format!("{:?}", GrantBlobPayload::new(SEED, None, 4, KEY)),
+            "GrantBlobPayload { read_scope_seed: SecretBytes(redacted), \
+             write_scope_seed: None, epoch: 4, \
+             pointer_read_key: SecretBytes(redacted), unknown: {} }"
+        );
+        assert_eq!(
+            format!("{:?}", OverrideSeedPayload::new(SEED, 4)),
+            "OverrideSeedPayload { override_seed: SecretBytes(redacted), epoch: 4, unknown: {} }"
+        );
+        assert_eq!(
+            format!("{:?}", OwnerWriteBlobPayload::new(SEED, 4)),
+            "OwnerWriteBlobPayload { write_scope_seed: SecretBytes(redacted), \
+             write_epoch: 4, unknown: {} }"
+        );
+        assert_eq!(
+            format!("{:?}", HistoryLinkPayload::new(SEED, 4)),
+            "HistoryLinkPayload { prev_seed: SecretBytes(redacted), prev_epoch: 4, unknown: {} }"
+        );
+    }
+
+    /// An unknown field on a grant payload rode inside a sealed plaintext, so it
+    /// can carry future secret material verbatim. The composed rendering must
+    /// redact its values, not just the known secret fields.
+    #[test]
+    fn grant_payload_debug_redacts_preserved_unknown_values() {
+        let mut payload = GrantBlobPayload::new([0xab; SECRET_LEN], None, 4, [0xcd; SECRET_LEN]);
+        payload.unknown = [(
+            "futureSeed".to_owned(),
+            Value::Bytes(vec![0xee; SECRET_LEN]),
+        )]
+        .into_iter()
+        .collect();
+
+        let rendered = format!("{payload:?}");
+        assert!(
+            rendered.contains(r#""futureSeed": "<redacted>""#),
+            "{rendered}"
+        );
+        assert!(
+            !rendered.contains("238"),
+            "unknown-field bytes leaked: {rendered}"
+        );
     }
 
     /// The derived `PartialEq` still discriminates a one-byte seed difference

--- a/crates/core/src/suite/secret.rs
+++ b/crates/core/src/suite/secret.rs
@@ -25,7 +25,9 @@ pub fn ct_eq(a: &[u8; SECRET_LEN], b: &[u8; SECRET_LEN]) -> bool {
 }
 
 /// Owned 32-byte secret key material. Cloneable (derivation reuses seeds), but
-/// deliberately not `Copy` (an owning type with a `Drop` that zeroizes).
+/// deliberately not `Copy` (an owning type with a `Drop` that zeroizes), and
+/// deliberately neither `Hash` nor `Ord`: hashing key bytes into a std map
+/// reintroduces the timing channel [`ct_eq`] removes.
 #[derive(Clone)]
 pub struct SecretBytes([u8; SECRET_LEN]);
 

--- a/crates/desktop-seams/src/floor_store.rs
+++ b/crates/desktop-seams/src/floor_store.rs
@@ -108,12 +108,12 @@ impl FileFloorStore {
         }
     }
 
-    /// Applies a batch of raises to the per-key files, returning each result.
-    fn apply_raises(&self, raises: &[FloorRaise], op: &str) -> SeamResult<Vec<u64>> {
-        raises
-            .iter()
-            .map(|r| self.raise_floor(self.dir_for(r.namespace), &r.key, r.value, op))
-            .collect()
+    /// Applies a batch of raises to the per-key files, in order.
+    fn apply_raises(&self, raises: &[FloorRaise], op: &str) -> SeamResult<()> {
+        for r in raises {
+            self.raise_floor(self.dir_for(r.namespace), &r.key, r.value, op)?;
+        }
+        Ok(())
     }
 
     /// Replays every leftover intent record left by batch commits interrupted
@@ -172,17 +172,17 @@ impl FloorStore for FileFloorStore {
     /// by [`open`](Self::open)'s replay rather than left partial (#685). The
     /// unique filename keeps overlapping commits from clobbering or removing each
     /// other's record. A commit that returns `Ok` has cleared its intent.
-    async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<Vec<u64>> {
+    async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<()> {
         if raises.is_empty() {
-            return Ok(Vec::new());
+            return Ok(());
         }
         let intent_path = self.intent_dir.join(unique_component());
         atomic_write(&intent_path, &encode_intent(raises)?)
             .map_err(|err| seam_err("floor_store write intent", &err))?;
-        let resulting = self.apply_raises(raises, "floor_store commit_floors")?;
+        self.apply_raises(raises, "floor_store commit_floors")?;
         remove_file_durable(&intent_path)
             .map_err(|err| seam_err("floor_store clear intent", &err))?;
-        Ok(resulting)
+        Ok(())
     }
 }
 

--- a/crates/engine/src/api/client.rs
+++ b/crates/engine/src/api/client.rs
@@ -171,13 +171,11 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
 
     /// Link a SIWE wallet to the authenticated account (owner-authenticated).
     pub async fn siwe_link(&self, message: &str, signature: &str) -> Result<(), ApiError> {
-        let body = to_json(&SiweLoginRequest { message, signature });
         let response = self
-            .request_authed(
+            .json_authed(
                 HttpMethod::Post,
                 "/auth/siwe/link",
-                Some(APPLICATION_JSON),
-                Some(body),
+                &SiweLoginRequest { message, signature },
             )
             .await?;
         ok_or_err(response).map(drop)
@@ -250,7 +248,7 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
     /// Revoke every refresh token server-side and tear down the local session.
     pub async fn logout(&self) -> Result<(), ApiError> {
         let response = self
-            .request_authed(HttpMethod::Post, "/auth/logout", None, None)
+            .request_authed(HttpMethod::Post, "/auth/logout")
             .await?;
         let result = ok_or_err(response).map(drop);
         self.clear_session().await?;
@@ -263,28 +261,16 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
     /// Register-first ordering is the publish pipeline's concern, not the
     /// caller's; this is the raw endpoint.
     pub async fn register(&self, names: &[NameRegistration]) -> Result<(), ApiError> {
-        let body = to_json(names);
         let response = self
-            .request_authed(
-                HttpMethod::Post,
-                "/registry/register",
-                Some(APPLICATION_JSON),
-                Some(body),
-            )
+            .json_authed(HttpMethod::Post, "/registry/register", names)
             .await?;
         ok_or_err(response).map(drop)
     }
 
     /// Batch retire names or CIDs (`[ipnsName | cid]`).
     pub async fn retire(&self, targets: &[String]) -> Result<(), ApiError> {
-        let body = to_json(targets);
         let response = self
-            .request_authed(
-                HttpMethod::Post,
-                "/registry/retire",
-                Some(APPLICATION_JSON),
-                Some(body),
-            )
+            .json_authed(HttpMethod::Post, "/registry/retire", targets)
             .await?;
         ok_or_err(response).map(drop)
     }
@@ -292,7 +278,7 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
     /// The per-account quota (advisory for BYO accounts).
     pub async fn quota(&self) -> Result<Quota, ApiError> {
         let response = self
-            .request_authed(HttpMethod::Get, "/account/quota", None, None)
+            .request_authed(HttpMethod::Get, "/account/quota")
             .await?;
         let response = ok_or_err(response)?;
         decode(&response)
@@ -340,17 +326,15 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
             blob: String,
             idempotency_key: &'a str,
         }
-        let body = to_json(&Body {
-            recipient_public_key,
-            blob: BASE64.encode(blob),
-            idempotency_key,
-        });
         let response = self
-            .request_authed(
+            .json_authed(
                 HttpMethod::Post,
                 "/mailbox/messages",
-                Some(APPLICATION_JSON),
-                Some(body),
+                &Body {
+                    recipient_public_key,
+                    blob: BASE64.encode(blob),
+                    idempotency_key,
+                },
             )
             .await?;
         let response = ok_or_err(response)?;
@@ -361,7 +345,7 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
     /// Poll pending mailbox items, decoding each sealed blob from base64.
     pub async fn mailbox_poll(&self) -> Result<Vec<MailboxItem>, ApiError> {
         let response = self
-            .request_authed(HttpMethod::Get, "/mailbox/messages", None, None)
+            .request_authed(HttpMethod::Get, "/mailbox/messages")
             .await?;
         let response = ok_or_err(response)?;
         let wire: MailboxPollWire = decode(&response)?;
@@ -383,12 +367,7 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
     /// Ack (delete) a mailbox item by id.
     pub async fn mailbox_ack(&self, id: &str) -> Result<(), ApiError> {
         let response = self
-            .request_authed(
-                HttpMethod::Delete,
-                &format!("/mailbox/messages/{id}"),
-                None,
-                None,
-            )
+            .request_authed(HttpMethod::Delete, &format!("/mailbox/messages/{id}"))
             .await?;
         ok_or_err(response).map(drop)
     }
@@ -397,12 +376,7 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
     /// aid after a >EOL lapse. Returns the raw record bytes.
     pub async fn recovery_fetch(&self, ipns_name: &str) -> Result<Vec<u8>, ApiError> {
         let response = self
-            .request_authed(
-                HttpMethod::Get,
-                &format!("/recovery/{ipns_name}"),
-                None,
-                None,
-            )
+            .request_authed(HttpMethod::Get, &format!("/recovery/{ipns_name}"))
             .await?;
         let response = ok_or_err(response)?;
         Ok(response.body)
@@ -414,23 +388,15 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
         struct Body {
             byo: bool,
         }
-        let body = to_json(&Body { byo: enabled });
         let response = self
-            .request_authed(
-                HttpMethod::Patch,
-                "/account/byo",
-                Some(APPLICATION_JSON),
-                Some(body),
-            )
+            .json_authed(HttpMethod::Patch, "/account/byo", &Body { byo: enabled })
             .await?;
         ok_or_err(response).map(drop)
     }
 
     /// Immediate account hard-delete, then tear down the local session.
     pub async fn delete_account(&self) -> Result<(), ApiError> {
-        let response = self
-            .request_authed(HttpMethod::Delete, "/account", None, None)
-            .await?;
+        let response = self.request_authed(HttpMethod::Delete, "/account").await?;
         let result = ok_or_err(response).map(drop);
         self.clear_session().await?;
         result
@@ -458,19 +424,35 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
         Ok(self.http.send(request).await?)
     }
 
-    /// Send an authenticated request with one refresh-then-retry on 401.
+    /// [`Self::request_authed`] carrying a JSON body, so the serialize and the
+    /// `Content-Type` that must accompany it are never stated apart.
+    async fn json_authed<B: Serialize + ?Sized>(
+        &self,
+        method: HttpMethod,
+        path: &str,
+        body: &B,
+    ) -> Result<HttpResponse, ApiError> {
+        self.request_authed_with(
+            method,
+            path,
+            Some(APPLICATION_JSON),
+            &[],
+            Some(to_json(body)),
+        )
+        .await
+    }
+
+    /// Send a bodyless authenticated request with one refresh-then-retry on 401.
     async fn request_authed(
         &self,
         method: HttpMethod,
         path: &str,
-        content_type: Option<&str>,
-        body: Option<Vec<u8>>,
     ) -> Result<HttpResponse, ApiError> {
-        self.request_authed_with(method, path, content_type, &[], body)
+        self.request_authed_with(method, path, None, &[], None)
             .await
     }
 
-    /// [`Self::request_authed`], plus request-specific headers.
+    /// [`Self::request_authed`], plus a body and request-specific headers.
     async fn request_authed_with(
         &self,
         method: HttpMethod,

--- a/crates/engine/src/api/error.rs
+++ b/crates/engine/src/api/error.rs
@@ -28,10 +28,6 @@ pub enum ApiError {
     /// (unreachable host, aborted request). Distinct from an HTTP error
     /// status, which is a well-formed response.
     Transport(SeamError),
-    /// The request needed authentication the client does not hold — no access
-    /// token in memory and no refresh token to mint one (e.g. a call before
-    /// any login).
-    NotAuthenticated,
     /// The API answered 401 and a single refresh-then-retry did not recover
     /// it: the session is dead and the caller must re-login.
     Unauthorized,
@@ -70,7 +66,6 @@ impl fmt::Display for ApiError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ApiError::Transport(error) => write!(f, "api transport error: {error}"),
-            ApiError::NotAuthenticated => f.write_str("api call requires authentication"),
             ApiError::Unauthorized => f.write_str("api rejected the request as unauthorized"),
             ApiError::Forbidden => f.write_str("api refused the request as forbidden"),
             ApiError::Status {

--- a/crates/engine/src/api/types.rs
+++ b/crates/engine/src/api/types.rs
@@ -66,8 +66,6 @@ pub(crate) struct TokenResponse {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ChallengeResponse {
     pub challenge: String,
-    #[allow(dead_code)]
-    pub expires_at: String,
 }
 
 #[derive(Deserialize)]

--- a/crates/engine/src/net/fanout.rs
+++ b/crates/engine/src/net/fanout.rs
@@ -9,7 +9,7 @@
 use core::future::poll_fn;
 use core::task::Poll;
 
-use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::ipns::{IpnsName, IpnsRecord, VerifiedRecord};
 
 use crate::seams::{EndpointId, RecordTransport};
 
@@ -80,20 +80,21 @@ pub async fn fanout_put<T: RecordTransport>(transport: &T, key: &str, bytes: &[u
 }
 
 /// Fan-out GET across the endpoint set and core-verify each returned record
-/// against `name`, returning the freshest verified `(sequence, record_bytes)`
-/// or `None` when no endpoint serves a verifiable record. A malformed or
+/// against `name`, returning the freshest `(VerifiedRecord, record_bytes)` or
+/// `None` when no endpoint serves a verifiable record. A malformed or
 /// signature-invalid copy at one endpoint is ignored (an accelerator can serve
 /// stale garbage); a per-endpoint transport error is tolerated as availability
 /// staleness — only genuine host failure is surfaced.
 ///
 /// This is the record-plane verify step (core's Ed25519-from-the-name chain);
-/// the full adoption gate runs downstream on the chosen bytes.
+/// the full adoption gate runs downstream on the chosen bytes. The
+/// [`VerifiedRecord`] rides out so no caller re-verifies the same signature.
 pub async fn fanout_get_verify<T: RecordTransport>(
     transport: &T,
     name: &IpnsName,
-) -> Option<(u64, Vec<u8>)> {
+) -> Option<(VerifiedRecord, Vec<u8>)> {
     let key = name.as_str();
-    let mut best: Option<(u64, Vec<u8>)> = None;
+    let mut best: Option<(VerifiedRecord, Vec<u8>)> = None;
     for endpoint in transport.endpoints() {
         let Ok(Some(bytes)) = transport.get_record(&endpoint, key).await else {
             continue;
@@ -106,9 +107,9 @@ pub async fn fanout_get_verify<T: RecordTransport>(
         };
         if best
             .as_ref()
-            .is_none_or(|(seq, _)| verified.sequence > *seq)
+            .is_none_or(|(current, _)| verified.sequence > current.sequence)
         {
-            best = Some((verified.sequence, bytes));
+            best = Some((verified, bytes));
         }
     }
     best

--- a/crates/engine/src/net/liveness.rs
+++ b/crates/engine/src/net/liveness.rs
@@ -181,13 +181,7 @@ where
     F: FloorStore,
     Sch: Scheduler + Clone + 'static,
 {
-    let Some((_sequence, bytes)) = fanout_get_verify(transport, request.name).await else {
-        return Ok(None);
-    };
-    let Ok(record) = IpnsRecord::unmarshal(&bytes) else {
-        return Ok(None);
-    };
-    let Ok(verified) = record.verify(request.name) else {
+    let Some((verified, _bytes)) = fanout_get_verify(transport, request.name).await else {
         return Ok(None);
     };
     if !eol::needs_renewal(scheduler.now(), &verified.validity, EOL_RENEW_THRESHOLD) {

--- a/crates/engine/src/net/pointer_fetch.rs
+++ b/crates/engine/src/net/pointer_fetch.rs
@@ -10,10 +10,10 @@
 //!
 //! [`open_repoint`]: crate::sync::pointer::open_repoint
 
-use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::ipns::IpnsName;
 
 use super::fanout::fanout_get_verify;
-use crate::seams::{RecordTransport, SeamError, SeamResult};
+use crate::seams::{RecordTransport, SeamResult};
 use crate::sync::pointer::PointerFetch;
 
 /// The record-plane [`PointerFetch`]: resolves pointer names over the borrowed
@@ -32,17 +32,10 @@ impl<'a, T> RecordPointerFetch<'a, T> {
 
 impl<T: RecordTransport> PointerFetch for RecordPointerFetch<'_, T> {
     async fn fetch(&self, name: &IpnsName) -> SeamResult<Option<Vec<u8>>> {
-        let Some((_sequence, record_bytes)) = fanout_get_verify(self.transport, name).await else {
+        let Some((verified, _bytes)) = fanout_get_verify(self.transport, name).await else {
             return Ok(None);
         };
-        // Re-extract the authenticated value from bytes fan-out already verified,
-        // so a failure here is an internal inconsistency (a seam error), never a
-        // trust reclassification.
-        let value = IpnsRecord::unmarshal(&record_bytes)
-            .and_then(|record| record.verify(name))
-            .map_err(|e| SeamError::new(format!("verified record re-extract failed: {e}")))?
-            .value;
-        Ok(Some(value))
+        Ok(Some(verified.value))
     }
 }
 
@@ -50,6 +43,7 @@ impl<T: RecordTransport> PointerFetch for RecordPointerFetch<'_, T> {
 mod tests {
     use super::*;
 
+    use cipherbox_core::ipns::IpnsRecord;
     use cipherbox_core::kdf;
     use cipherbox_core::payload::RepointObject;
     use cipherbox_core::suite::ecdsa::EcdsaSigner;

--- a/crates/engine/src/net/publish.rs
+++ b/crates/engine/src/net/publish.rs
@@ -214,16 +214,16 @@ where
         // a different record at the same sequence is a fork — a retry that
         // re-authored after an unconfirmed PUT — and adopting it would advance
         // the floor past bytes the network may never serve.
-        Some((observed_sequence, bytes)) if observed_sequence == sequence => {
+        Some((observed, bytes)) if observed.sequence == sequence => {
             if bytes == record_bytes {
                 PublishOutcome::Published { sequence }
             } else {
                 PublishOutcome::Unconfirmed { sequence }
             }
         }
-        Some((observed_sequence, _)) if observed_sequence > sequence => PublishOutcome::LostRace {
+        Some((observed, _)) if observed.sequence > sequence => PublishOutcome::LostRace {
             published_sequence: sequence,
-            observed_sequence,
+            observed_sequence: observed.sequence,
         },
         _ => PublishOutcome::Unconfirmed { sequence },
     };

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -15,7 +15,7 @@
 
 use core::cell::RefCell;
 
-use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::ipns::{IpnsName, VerifiedRecord};
 use zeroize::Zeroizing;
 
 use super::fanout::fanout_get_verify;
@@ -164,8 +164,10 @@ pub(crate) struct GatedResolve {
     pub(crate) resolved: Resolved,
     /// The held-set (node id, write scope seed) from a gate-surfaced write grant.
     pub(crate) hold: Option<AdoptHold>,
-    /// The verified record bytes an alive-worthy outcome rides to the hold.
-    pub(crate) held_bytes: Option<Vec<u8>>,
+    /// The verified record an alive-worthy outcome rides to the hold, with the
+    /// bytes it verified over. Carrying the [`VerifiedRecord`] spares the hold a
+    /// second parse+verify of the same bytes.
+    pub(crate) held_record: Option<(VerifiedRecord, Vec<u8>)>,
     /// The scope read seed a gate-passing owner adopt recovered.
     pub(crate) read_scope_seed: Option<Zeroizing<[u8; 32]>>,
 }
@@ -187,10 +189,10 @@ where
     // Cache-first: last-known-good renders immediately, reconcile runs behind it.
     let last_known_good = snapshot_cache.get(cache_key).await?;
 
-    let (outcome, hold, held_bytes, read_scope_seed) =
+    let (outcome, hold, held_record, read_scope_seed) =
         match fanout_get_verify(transport, name).await {
             None => (ResolveOutcome::NoUpdate, None, None, None),
-            Some((_sequence, bytes)) => match adopter.adopt(name, &bytes).await {
+            Some((verified, bytes)) => match adopter.adopt(name, &bytes).await {
                 Ok(AdoptOutcome {
                     adopted,
                     write_scope_seed,
@@ -204,7 +206,7 @@ where
                     (
                         ResolveOutcome::Adopted(adopted),
                         hold,
-                        Some(bytes),
+                        Some((verified, bytes)),
                         read_scope_seed,
                     )
                 }
@@ -236,7 +238,7 @@ where
                                 record_bytes: bytes.clone(),
                             },
                             hold,
-                            Some(bytes),
+                            Some((verified, bytes)),
                             read_scope_seed,
                         )
                     }
@@ -252,7 +254,7 @@ where
             outcome,
         },
         hold,
-        held_bytes,
+        held_record,
         read_scope_seed,
     })
 }
@@ -316,7 +318,7 @@ where
     let GatedResolve {
         resolved,
         hold: adopt_hold,
-        held_bytes,
+        held_record,
         read_scope_seed,
     } = resolve_gated(transport, snapshot_cache, adopter, name).await?;
     let write_scope_seed = adopt_hold.clone();
@@ -328,17 +330,13 @@ where
     // A gate-passing adopt (`Adopted`) and our own current record (`Current`)
     // are both alive-worthy and ride their verified bytes back here; a
     // `TrustViolation`/`NoUpdate` holds nothing (blueprint/engine.md "Liveness").
-    if let Some(record_bytes) = held_bytes {
+    if let Some((verified, record_bytes)) = held_record {
         // Renew under the record's own adopted head CID, not a caller-supplied
-        // one: parse it from the signed `/ipfs/<cid>` value. A gate-passing
+        // one: it comes from the signed `/ipfs/<cid>` value. A gate-passing
         // record always carries a valid value; if it does not, skip the hold
         // rather than renew under `/ipfs/` — an empty head CID would clobber the
         // tip (security rule 8, fail-closed).
-        let Some(head_cid) = IpnsRecord::unmarshal(&record_bytes)
-            .and_then(|record| record.verify(name))
-            .ok()
-            .and_then(|verified| head_cid_from_value(&verified.value))
-        else {
+        let Some(head_cid) = head_cid_from_value(&verified.value) else {
             return Ok(done(resolved));
         };
         // The renewal (node id, write seed) comes from the gate for a write

--- a/crates/engine/src/seams/floor_store.rs
+++ b/crates/engine/src/seams/floor_store.rs
@@ -35,8 +35,7 @@ pub trait FloorStore {
     /// and returns the resulting stored floor.
     async fn raise_sequence_floor(&self, ipns_name: &[u8], sequence: u64) -> SeamResult<u64>;
 
-    /// Commits a batch of monotonic-max floor raises across both namespaces,
-    /// returning the resulting stored floor for each entry in order.
+    /// Commits a batch of monotonic-max floor raises across both namespaces.
     ///
     /// A single floor advance raises several distinctly-keyed floors at once
     /// (read-epoch, write-epoch, per-name sequence). An implementation closes the
@@ -52,18 +51,16 @@ pub trait FloorStore {
     /// subsumes). The web IndexedDB seam rides this fallback — its JS boundary
     /// exposes only the per-key methods — and web-atomic commit is deferred as a
     /// durability/liveness concern, not a trust hole.
-    async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<Vec<u64>> {
-        let mut resulting = Vec::with_capacity(raises.len());
+    async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<()> {
         for raise in raises {
-            let floor = match raise.namespace {
+            match raise.namespace {
                 FloorNamespace::Epoch => self.raise_epoch_floor(&raise.key, raise.value).await?,
                 FloorNamespace::Sequence => {
                     self.raise_sequence_floor(&raise.key, raise.value).await?
                 }
             };
-            resulting.push(floor);
         }
-        Ok(resulting)
+        Ok(())
     }
 }
 

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -317,7 +317,7 @@ where
     let Ok(durable) = floor::sequence_floor(floors, key).await else {
         return Err(DefaultsReason::FloorUnreadable);
     };
-    let Some((sequence, record_bytes)) = fanout_get_verify(transport, name).await else {
+    let Some((verified, record_bytes)) = fanout_get_verify(transport, name).await else {
         // A durable floor is proof this account has published settings, so
         // finding none now is a suppression rather than a first run.
         return Err(match durable {
@@ -325,6 +325,7 @@ where
             None => DefaultsReason::NoRecord,
         });
     };
+    let sequence = verified.sequence;
     let floor = durable.unwrap_or(0);
     if sequence < floor {
         return Err(DefaultsReason::RolledBack { floor, sequence });

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -1213,7 +1213,7 @@ where
     async fn observed_sequence(&self, name: &IpnsName) -> Result<u64, Halt> {
         fanout_get_verify(self.transport, name)
             .await
-            .map(|(sequence, _)| sequence)
+            .map(|(verified, _)| verified.sequence)
             .ok_or(Halt::Unclassified)
     }
 
@@ -2231,7 +2231,7 @@ mod tests {
                 false,
             ),
             (
-                RecordPublishError::Publish(PublishError::Register(ApiError::NotAuthenticated)),
+                RecordPublishError::Publish(PublishError::Register(ApiError::Unauthorized)),
                 true,
             ),
             (
@@ -2259,7 +2259,7 @@ mod tests {
                 }),
                 false,
             ),
-            (Upload(ApiError::NotAuthenticated), false),
+            (Upload(ApiError::Unauthorized), false),
             (
                 Upload(ApiError::Transport(crate::seams::SeamError::new("dropped"))),
                 true,
@@ -2284,7 +2284,7 @@ mod tests {
                 message: None,
                 code: None,
             }),
-            RecordPublishError::Upload(ApiError::NotAuthenticated),
+            RecordPublishError::Upload(ApiError::Unauthorized),
             RecordPublishError::HeadCidMismatch {
                 expected: "a".to_owned(),
                 returned: "b".to_owned(),

--- a/crates/engine/src/testkit/conformance/floor_store.rs
+++ b/crates/engine/src/testkit/conformance/floor_store.rs
@@ -75,20 +75,15 @@ where
     assert_eq!(store.epoch_floor(scope_a).await.unwrap(), Some(7));
 
     // Cross-key batch commit: a mixed-namespace batch raises every entry
-    // monotonic-max and reports the resulting floors in order.
-    let batch = store
+    // monotonic-max, in its own namespace.
+    store
         .commit_floors(&[
-            FloorRaise::epoch(scope_a.to_vec(), 6), // below stored 7 → no-op, reports 7
+            FloorRaise::epoch(scope_a.to_vec(), 6), // below stored 7 → no-op
             FloorRaise::epoch(scope_b.to_vec(), 8),
             FloorRaise::sequence(scope_a.to_vec(), 50),
         ])
         .await
         .unwrap();
-    assert_eq!(
-        batch,
-        vec![7, 8, 50],
-        "commit_floors must report each resulting floor in order, monotonic-max"
-    );
     assert_eq!(
         store.epoch_floor(scope_a).await.unwrap(),
         Some(7),
@@ -120,26 +115,49 @@ where
         "batch-committed sequence floors must survive reopen"
     );
 
-    // Retry convergence: re-committing the SAME batch (as a caller retry after
-    // an interrupted commit would) is idempotent — identical results, no floor
-    // regresses. This is the convergence property every impl's #685 contract
-    // rests on, whether it closes the hazard by all-or-nothing rollback, by
-    // roll-forward replay, or by the ordered fail-safe fallback: a partial or
-    // replayed commit always heals to the same floors on retry.
-    let retry = reopened
+    // Retry convergence: re-committing a batch (as a caller retry after an
+    // interrupted commit would) is idempotent — a re-applied entry never
+    // double-advances and never regresses. This is the convergence property
+    // every impl's #685 contract rests on, whether it closes the hazard by
+    // all-or-nothing rollback, by roll-forward replay, or by the ordered
+    // fail-safe fallback. `scope_b` advances so the retry has an observable:
+    // a `commit_floors` that silently applied nothing fails here.
+    reopened
         .commit_floors(&[
             FloorRaise::epoch(scope_a.to_vec(), 6), // still below 7 → no-op
-            FloorRaise::epoch(scope_b.to_vec(), 8),
+            FloorRaise::epoch(scope_b.to_vec(), 9),
             FloorRaise::sequence(scope_a.to_vec(), 50),
         ])
         .await
         .unwrap();
     assert_eq!(
-        retry,
-        vec![7, 8, 50],
-        "re-committing the same batch must converge to the identical floors"
+        reopened.epoch_floor(scope_b).await.unwrap(),
+        Some(9),
+        "a batch entry above its floor must advance on a retried commit"
     );
-    assert_eq!(reopened.epoch_floor(scope_a).await.unwrap(), Some(7));
-    assert_eq!(reopened.epoch_floor(scope_b).await.unwrap(), Some(8));
+    assert_eq!(
+        reopened.epoch_floor(scope_a).await.unwrap(),
+        Some(7),
+        "a re-applied at-or-below entry must neither regress nor double-advance"
+    );
     assert_eq!(reopened.sequence_floor(scope_a).await.unwrap(), Some(50));
+
+    // Two raises on one key inside a single batch: the last-wins maximum, in
+    // either order — what makes the ordered fallback and an atomic backing
+    // observationally equivalent.
+    for pair in [[3u64, 12], [12, 3]] {
+        let key = format!("batch-same-key-{}-{}", pair[0], pair[1]).into_bytes();
+        reopened
+            .commit_floors(&[
+                FloorRaise::epoch(key.clone(), pair[0]),
+                FloorRaise::epoch(key.clone(), pair[1]),
+            ])
+            .await
+            .unwrap();
+        assert_eq!(
+            reopened.epoch_floor(&key).await.unwrap(),
+            Some(12),
+            "two raises on one key in a batch must settle at their maximum"
+        );
+    }
 }

--- a/crates/engine/src/testkit/fakes/floor_store.rs
+++ b/crates/engine/src/testkit/fakes/floor_store.rs
@@ -63,15 +63,14 @@ impl FloorStore for InMemoryFloorStore {
     /// Genuinely all-or-nothing: the whole batch applies under one lock guard,
     /// so no observer sees a partial commit (the atomic contract #685 asks of a
     /// transactional backing).
-    async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<Vec<u64>> {
+    async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<()> {
         let mut inner = self.inner.lock().expect("lock");
-        let resulting = raises
-            .iter()
-            .map(|r| match r.namespace {
+        for r in raises {
+            match r.namespace {
                 FloorNamespace::Epoch => raise(&mut inner.epoch, &r.key, r.value),
                 FloorNamespace::Sequence => raise(&mut inner.sequence, &r.key, r.value),
-            })
-            .collect();
-        Ok(resulting)
+            };
+        }
+        Ok(())
     }
 }

--- a/crates/engine/tests/floor_atomic.rs
+++ b/crates/engine/tests/floor_atomic.rs
@@ -131,7 +131,7 @@ impl FloorStore for AtomicFaultyStore {
         self.inner.raise_sequence_floor(ipns_name, sequence).await
     }
 
-    async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<Vec<u64>> {
+    async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<()> {
         if self.fail_commit.load(Ordering::Relaxed) {
             return Err(SeamError::new("injected seam I/O fault (atomic commit)"));
         }

--- a/crates/wasm/src/seams_bridge.rs
+++ b/crates/wasm/src/seams_bridge.rs
@@ -100,9 +100,8 @@ extern "C" {
     ) -> Result<JsValue, JsValue>;
 }
 
-/// The JS `FloorStoreSeam` exposes only per-key methods, so this adapter does
-/// not override `commit_floors`: web batches ride the seam's ordered fail-safe
-/// fallback (#682-safe; web-atomic is deferred — see the trait doc).
+/// Bridges the per-key JS `FloorStoreSeam`; web batches ride the trait's
+/// ordered fail-safe fallback ([`FloorStore::commit_floors`]).
 #[derive(Clone)]
 pub(crate) struct FloorStoreAdapter {
     pub(crate) js: JsFloorStoreSeam,


### PR DESCRIPTION
The mechanical half of the #719 retro-audit backlog. The crypto-touching work was split into #1022, which has since merged; this PR was rebased onto it. No behavior change is intended; the one place coverage genuinely moves is called out under #1000.

Closes #997
Closes #999
Closes #1000
Closes #719

## Note — this PR also carries one crypto commit

`76dc4465` (`test: pin secret redaction as an exact shape rather than a marker count`) belongs to #1022's crypto work but **missed its merge window by one second**, so it rides here despite the cleanup-sweep title. It touches `crates/core` and is worth a crypto reviewer's eye rather than a skim:

- The redaction test counted `SecretBytes(redacted)` occurrences against a per-type constant. A field added later as a raw `[u8; 32]` — held *outside* the owning type, which is exactly the mistake `SecretBytes` exists to prevent — leaves the count unchanged and defaults to zeroes, so it matched no byte spelling the test searched for and would have passed silently. Replaced with whole-string goldens: any added field, of any type, now breaks the test and forces a redaction decision.
- Adds redaction coverage for `seal::body::Version`, the one converted type that had none, through the type itself and the `ReadBody` that carries it to a log line.
- Adds coverage for a payload carrying preserved unknown fields, which ride inside a sealed plaintext and so can hold future secret material verbatim, plus the `write_scope_seed: None` arm the `Some` case never renders.
- Documents on all five converted types that a derived `PartialEq` short-circuits **across** fields, so it is a round-trip comparator rather than a security comparison, and records that `SecretBytes` is deliberately neither `Hash` nor `Ord`.

Everything below is the mechanical work.

## #997 — `fanout_get_verify` returns the `VerifiedRecord` it built

It built one and threw it away, so callers re-parsed and re-verified the same bytes — a redundant protobuf parse plus Ed25519 verify per call. It now returns `(VerifiedRecord, Vec<u8>)`; the record and the bytes it verified over move out as one tuple, so a record/bytes mismatch is not representable.

`eol_republish`, the pointer fetch, and the gated resolve each drop a re-verify. The gated resolve carries the record through `GatedResolve` to the liveness hold, which had been reading the head CID by re-unmarshalling and re-verifying — the hottest of the call sites, and the one three reviewers flagged.

The two re-verifies that remain on a resolve are inside the adoption gate (`net/adopter.rs`, `gate/adoption.rs`), which re-verifies from scratch on purpose as a trust boundary. Threading the record through `Adopter::adopt` would move that boundary, so it stays.

## #999 — dead API surface

`ApiError::NotAuthenticated` had no constructor anywhere. Three `sync/drain.rs` tests used it as a stand-in for a non-transport, non-`Status` error; they are re-pointed to `ApiError::Unauthorized`, which lands in the same arms of `orphaned_head` and `classify_publish` — verified arm by arm, and it was not already present in either table, so no case collapsed into a duplicate. `ChallengeResponse.expires_at` was `#[allow(dead_code)]` and is gone.

Took the optional helper too: five authed endpoints stated `to_json` and the JSON `Content-Type` separately, so a new endpoint could set one and forget the other. One `json_authed` now carries both. With those folded, `request_authed`'s `content_type` and `body` parameters were `None, None` at every remaining caller, so they are dropped.

## #1000 — `commit_floors` returns `()`

**The conformance assertions were not load-bearing, but removing them cost real coverage that is restored and extended.**

No production caller read the `Vec<u64>`: `advance_on_unseal` and `cold_seed` both `.await?` and discard it, and `cold_seed_checked` derives its fail-closed verdict from its own floor reads *before* the commit. Three of the four invariants the kit asserted through the return value were already asserted independently through post-commit store reads — monotonic-max per entry, namespace separation, and durability across reopen.

The fourth was not. The retry-convergence case re-committed a batch whose entries were all at or below their stored floors, so once the return value went away the assertion held even for a `commit_floors` that did nothing at all. That case now advances one key so the retry has an observable. A new case also commits two raises for the same key in one batch, in both orders — the property that makes the ordered fallback and an atomic backing observationally equivalent, which nothing covered before.

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` all ran against this work. No HIGH or MEDIUM findings outstanding. Folded in from those passes and belonging to this half: the missed `resolve.rs` re-verify above, and the conformance observable. The crypto commit noted at the top is itself the product of the focused `/crypto-privacy-review` pass over #1022.

## Checks — rebased onto `main` @ `31f06c7e`, run from a clean build

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets` — clean
- `cargo test --workspace` — 1276 passed, 0 failed
- `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets` — clean
- `cargo test -p cipherbox-core --target wasm32-wasip1` — 0 failed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Sensitive seed and content-key values are now consistently redacted from diagnostic output.
  - Documentation clarifies that secret comparisons are not security checks and that hashing secret data may introduce timing concerns.

- **Reliability**
  - Network record verification results are reused throughout resolution and publishing flows, reducing redundant validation while preserving existing behavior.
  - Authentication failures now use consistent unauthorized-error handling.

- **API Changes**
  - Batch floor commits now report success or failure without returning per-entry floor values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->