### PR TITLE
feat: implement the concrete rotation resolvers and publishers

### DIFF
--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -4311,6 +4311,7 @@ mod tests {
                     link_counter: 1,
                     unknown: PreservedFields::new(),
                 }],
+                child_scope_index: Vec::new(),
                 // At the read epoch (write plane == read plane here), so the
                 // cold-seeded write floor opens it and the owner recovers its
                 // write-scope seed for the held-set renewal signer.

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -4312,6 +4312,7 @@ mod tests {
                     unknown: PreservedFields::new(),
                 }],
                 child_scope_index: Vec::new(),
+                parent_node_seed: None,
                 // At the read epoch (write plane == read plane here), so the
                 // cold-seeded write floor opens it and the owner recovers its
                 // write-scope seed for the held-set renewal signer.

--- a/crates/engine/src/gate/adoption.rs
+++ b/crates/engine/src/gate/adoption.rs
@@ -247,7 +247,7 @@ pub struct ReaderContext<'a> {
     /// `candidate.grant_section.ascent_link` is `Some`; a `None` here against a
     /// present ascent link is fail-closed
     /// (cannot verify).
-    pub parent_node_seed: Option<[u8; 32]>,
+    pub parent_node_seed: Option<&'a [u8; 32]>,
     /// The reader's HPKE seed source, opened at the unseal stage; `None` for a
     /// holder that already possesses the read key.
     pub seed_blob: Option<SeedBlob<'a>>,
@@ -464,8 +464,8 @@ pub async fn adopt_deferred<F: FloorStore>(
     )?;
     // Recipient-tag `None` — owner-scoped, not per-grantee. Its sealed AAD binds
     // the write epoch, yet its structure signature is recomputed at the read
-    // epoch off the authenticated envelope (dual-epoch rationale stated once at
-    // rotation/reseal.rs owner-write-blob).
+    // epoch off the authenticated envelope (produce side: `sign_over` in
+    // rotation/reseal.rs).
     if let Some(owner_write) = &section.owner_write_blob {
         authenticate(
             STRUCT_TAG_OWNER_WRITE_BLOB,
@@ -531,7 +531,7 @@ pub async fn adopt_deferred<F: FloorStore>(
         // carries is this scope root's current override seed (CONTEXT.md "Ascent
         // link"/"Override seed"), so it must belong to this epoch and derive this
         // node's read key — the ascent-link half of engine.md:406-408.
-        let payload = open_ascent_link(&parent_node_seed, &aad, &link)
+        let payload = open_ascent_link(parent_node_seed, &aad, &link)
             .map_err(|e| reject(GateStage::GrantSection, RejectionReason::Trust(e)))?;
         let node_seed = kdf::node_seed(payload.override_seed(), &candidate.envelope.id);
         let derived_read_key = kdf::read_key(node_seed.as_bytes());

--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -12,8 +12,8 @@
 //! # Simulation boundary
 //!
 //! Deterministic-simulation slice: entropy is the injected [`Entropy`] seam and
-//! the read/floor/publish/mailbox effects are faked. Production resolver/
-//! publisher wiring is deferred to #745/#746 (mirroring #744/#747/#749/#760).
+//! the read/floor/publish/mailbox effects are faked in tests. The production
+//! resolver/publisher this composes over lives in [`crate::net::rotation`].
 //!
 //! # Deferred (follow-on slices of #635)
 //!

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -65,6 +65,10 @@ pub struct RootAdopter<'a, H, F> {
     assembled: RefCell<Option<Candidate>>,
     /// A head block the caller already holds ([`Self::hold_local_head`]).
     local_head: RefCell<Option<LocalHead>>,
+    /// The reader's own ancestor node seed for this scope root, required
+    /// whenever the resolved record carries an ascent link — every interior
+    /// scope root does ([`Self::under_parent_node_seed`]).
+    parent_node_seed: Option<Zeroizing<[u8; 32]>>,
 }
 
 impl<'a, H, F> RootAdopter<'a, H, F> {
@@ -87,7 +91,17 @@ impl<'a, H, F> RootAdopter<'a, H, F> {
             root_scope_id,
             assembled: RefCell::new(None),
             local_head: RefCell::new(None),
+            parent_node_seed: None,
         }
+    }
+
+    /// Supply the reader's ancestor node seed, `nodeSeed(parentOverrideSeed,
+    /// scopeId)`. The vault root carries no ascent link and needs none; every
+    /// interior scope root carries one, and the gate fails closed without the
+    /// seed it derives the expected ascent keypair from.
+    pub(crate) fn under_parent_node_seed(mut self, seed: Zeroizing<[u8; 32]>) -> Self {
+        self.parent_node_seed = Some(seed);
+        self
     }
 
     /// Supply a head block the caller already holds, so a self-adopt of our own
@@ -147,87 +161,6 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
         name: &IpnsName,
         record_bytes: &[u8],
     ) -> Result<Option<OwnScopeMaterial>, SeamError> {
-        self.recover_own(name, record_bytes).await
-    }
-}
-
-impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
-    /// The gate pass **plus** the candidate it authenticated, for the callers
-    /// that need the record's own grant section (the rotation seams' gated
-    /// scope-root read) rather than only the read-body outcome.
-    pub(crate) async fn adopt_root(
-        &self,
-        name: &IpnsName,
-        record_bytes: &[u8],
-    ) -> Result<(Candidate, AdoptOutcome), GateError> {
-        let candidate = self.assemble_candidate(name, record_bytes).await?;
-
-        // Step 6 — owner-blob ReaderContext. The vault owner recovers its own root
-        // scope seed from the record's owner blob (the read-plane seed source) and
-        // derives the read key; the gate re-opens the same blob, cross-checks the
-        // seed derives this key, and unseals the read-body.
-        let env = &candidate.envelope;
-        let owner_blob = &candidate.grant_section.owner_blob;
-        let owner_blob_aad = owner_blob_aad(env);
-        let read_scope_seed = self
-            .open_read_scope_seed(env, owner_blob)
-            .map_err(|e| reject(GateStage::Unseal, e))?;
-
-        // The derived read key is secret; this fn is its terminal owner, so it
-        // zeroizes on drop (the gate borrows it and never zeroizes a caller buffer).
-        // The recovered scope read seed rides the outcome on a gate pass — the
-        // engine's per-scope seed cell feeds the child read pipeline from it.
-        let node_seed = kdf::node_seed(&read_scope_seed, &env.id);
-        let read_key = Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes());
-
-        let reader = ReaderContext {
-            owner_identity: self.owner_identity,
-            scope_id: self.root_scope_id,
-            read_key: &read_key,
-            parent_node_seed: None,
-            seed_blob: Some(SeedBlob::Owner {
-                enc_secret: self.owner_enc_secret,
-                enc: owner_blob.enc,
-                ciphertext: owner_blob.ciphertext.clone(),
-                aad: owner_blob_aad,
-            }),
-        };
-
-        // Step 7 — the gate owns all trust; the owner reader surfaces no gate write
-        // seed (that arm is the write-grantee's). The owner's own write-scope seed
-        // is recovered from the owner-write-blob below for cold-start self-renewal.
-        let (adopted, _) = match adopt(self.floors, &reader, &candidate).await {
-            Ok(pass) => pass,
-            Err(err) => {
-                // Keep the candidate for the equal-floor recovery path — it
-                // re-resolves the same head CID otherwise.
-                *self.assembled.borrow_mut() = Some(candidate);
-                return Err(err);
-            }
-        };
-
-        let write_scope_seed = match &candidate.grant_section.owner_write_blob {
-            // Re-authorable, NOT a trust failure — held keyless.
-            None => None,
-            Some(owb) => self.recover_write_scope_seed(env, owb).await?,
-        };
-        let node_id = env.id;
-        Ok((
-            candidate,
-            AdoptOutcome {
-                adopted,
-                write_scope_seed,
-                node_id,
-                read_scope_seed: Some(read_scope_seed),
-            },
-        ))
-    }
-
-    async fn recover_own(
-        &self,
-        name: &IpnsName,
-        record_bytes: &[u8],
-    ) -> Result<Option<OwnScopeMaterial>, SeamError> {
         // Recovery is fail-open, never a trust verdict: anything unproved yields
         // `Ok(None)`, held keyless (#752 F3: a Current never hardens).
         //
@@ -282,6 +215,79 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
             read_scope_seed,
             write_scope_seed,
         }))
+    }
+}
+
+impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
+    /// The gate pass **plus** the candidate it authenticated, for the callers
+    /// that need the record's own grant section (the rotation seams' gated
+    /// scope-root read) rather than only the read-body outcome.
+    pub(crate) async fn adopt_root(
+        &self,
+        name: &IpnsName,
+        record_bytes: &[u8],
+    ) -> Result<(Candidate, AdoptOutcome), GateError> {
+        let candidate = self.assemble_candidate(name, record_bytes).await?;
+
+        // Step 6 — owner-blob ReaderContext. The vault owner recovers its own root
+        // scope seed from the record's owner blob (the read-plane seed source) and
+        // derives the read key; the gate re-opens the same blob, cross-checks the
+        // seed derives this key, and unseals the read-body.
+        let env = &candidate.envelope;
+        let owner_blob = &candidate.grant_section.owner_blob;
+        let owner_blob_aad = owner_blob_aad(env);
+        let read_scope_seed = self
+            .open_read_scope_seed(env, owner_blob)
+            .map_err(|e| reject(GateStage::Unseal, e))?;
+
+        // The derived read key is secret; this fn is its terminal owner, so it
+        // zeroizes on drop (the gate borrows it and never zeroizes a caller buffer).
+        // The recovered scope read seed rides the outcome on a gate pass — the
+        // engine's per-scope seed cell feeds the child read pipeline from it.
+        let node_seed = kdf::node_seed(&read_scope_seed, &env.id);
+        let read_key = Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes());
+
+        let reader = ReaderContext {
+            owner_identity: self.owner_identity,
+            scope_id: self.root_scope_id,
+            read_key: &read_key,
+            parent_node_seed: self.parent_node_seed.as_deref().copied(),
+            seed_blob: Some(SeedBlob::Owner {
+                enc_secret: self.owner_enc_secret,
+                enc: owner_blob.enc,
+                ciphertext: owner_blob.ciphertext.clone(),
+                aad: owner_blob_aad,
+            }),
+        };
+
+        // Step 7 — the gate owns all trust; the owner reader surfaces no gate write
+        // seed (that arm is the write-grantee's). The owner's own write-scope seed
+        // is recovered from the owner-write-blob below for cold-start self-renewal.
+        let (adopted, _) = match adopt(self.floors, &reader, &candidate).await {
+            Ok(pass) => pass,
+            Err(err) => {
+                // Keep the candidate for the equal-floor recovery path — it
+                // re-resolves the same head CID otherwise.
+                *self.assembled.borrow_mut() = Some(candidate);
+                return Err(err);
+            }
+        };
+
+        let write_scope_seed = match &candidate.grant_section.owner_write_blob {
+            // Re-authorable, NOT a trust failure — held keyless.
+            None => None,
+            Some(owb) => self.recover_write_scope_seed(env, owb).await?,
+        };
+        let node_id = env.id;
+        Ok((
+            candidate,
+            AdoptOutcome {
+                adopted,
+                write_scope_seed,
+                node_id,
+                read_scope_seed: Some(read_scope_seed),
+            },
+        ))
     }
 }
 
@@ -517,6 +523,7 @@ mod tests {
                 root_id,
                 children: Vec::new(),
                 child_scope_index: Vec::new(),
+                parent_node_seed: None,
                 owner_write_blob_epoch: owb_write_epoch,
             });
 

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -137,6 +137,29 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
 
 impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
     async fn adopt(&self, name: &IpnsName, record_bytes: &[u8]) -> Result<AdoptOutcome, GateError> {
+        self.adopt_root(name, record_bytes)
+            .await
+            .map(|(_, outcome)| outcome)
+    }
+
+    async fn recover_own_scope_material(
+        &self,
+        name: &IpnsName,
+        record_bytes: &[u8],
+    ) -> Result<Option<OwnScopeMaterial>, SeamError> {
+        self.recover_own(name, record_bytes).await
+    }
+}
+
+impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
+    /// The gate pass **plus** the candidate it authenticated, for the callers
+    /// that need the record's own grant section (the rotation seams' gated
+    /// scope-root read) rather than only the read-body outcome.
+    pub(crate) async fn adopt_root(
+        &self,
+        name: &IpnsName,
+        record_bytes: &[u8],
+    ) -> Result<(Candidate, AdoptOutcome), GateError> {
         let candidate = self.assemble_candidate(name, record_bytes).await?;
 
         // Step 6 — owner-blob ReaderContext. The vault owner recovers its own root
@@ -188,15 +211,19 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
             None => None,
             Some(owb) => self.recover_write_scope_seed(env, owb).await?,
         };
-        Ok(AdoptOutcome {
-            adopted,
-            write_scope_seed,
-            node_id: env.id,
-            read_scope_seed: Some(read_scope_seed),
-        })
+        let node_id = env.id;
+        Ok((
+            candidate,
+            AdoptOutcome {
+                adopted,
+                write_scope_seed,
+                node_id,
+                read_scope_seed: Some(read_scope_seed),
+            },
+        ))
     }
 
-    async fn recover_own_scope_material(
+    async fn recover_own(
         &self,
         name: &IpnsName,
         record_bytes: &[u8],
@@ -489,6 +516,7 @@ mod tests {
                 scope_id,
                 root_id,
                 children: Vec::new(),
+                child_scope_index: Vec::new(),
                 owner_write_blob_epoch: owb_write_epoch,
             });
 

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -251,7 +251,7 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
             owner_identity: self.owner_identity,
             scope_id: self.root_scope_id,
             read_key: &read_key,
-            parent_node_seed: self.parent_node_seed.as_deref().copied(),
+            parent_node_seed: self.parent_node_seed.as_deref(),
             seed_blob: Some(SeedBlob::Owner {
                 enc_secret: self.owner_enc_secret,
                 enc: owner_blob.enc,

--- a/crates/engine/src/net/author.rs
+++ b/crates/engine/src/net/author.rs
@@ -18,8 +18,9 @@
 use cipherbox_core::error::CodecError;
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::seal::{
-    ChildRef, Envelope, NodeKind, PreservedFields, ReadBody, Version, decode_grant_section,
-    encode_envelope, grant_section_bytes, has_grant_section, seal_read_body,
+    ChildRef, Envelope, GrantSection, NodeKind, PreservedFields, ReadBody, Version,
+    decode_grant_section, encode_envelope, encode_grant_section, grant_section_bytes,
+    has_grant_section, seal_read_body, set_grant_section,
 };
 
 use crate::content::limits::MAX_RESOLVED_RECORD_BYTES;
@@ -133,13 +134,39 @@ pub fn author_scope_root_envelope(
     name: &IpnsName,
 ) -> Result<AuthoredHead, AuthorError> {
     let envelope = seal(&authoring)?;
-    let section = grant_section_bytes(&envelope)
+    check_scope_root(&envelope, name)?;
+    encode(envelope)
+}
+
+/// Author a scope root that installs a **freshly assembled** `section` — the
+/// re-seal path, where the section is not the carried one. `section` replaces
+/// whatever `carried_unknown` holds under the grant-section key, so the previous
+/// record's envelope fields can be carried in verbatim; the same two
+/// release-active checks then run on the result.
+pub fn author_scope_root_with_section(
+    authoring: EnvelopeAuthoring<'_>,
+    name: &IpnsName,
+    section: &GrantSection,
+) -> Result<AuthoredHead, AuthorError> {
+    let mut envelope = seal(&authoring)?;
+    set_grant_section(
+        &mut envelope,
+        encode_grant_section(section).map_err(AuthorError::Seal)?,
+    );
+    check_scope_root(&envelope, name)?;
+    encode(envelope)
+}
+
+/// The two checks the gate's stages 2 and 5 make on arrival, run here first so a
+/// root this build's own gate always rejects is never signed (release-active).
+fn check_scope_root(envelope: &Envelope, name: &IpnsName) -> Result<(), AuthorError> {
+    let section = grant_section_bytes(envelope)
         .and_then(|bytes| decode_grant_section(bytes).ok())
         .ok_or(AuthorError::MissingGrantSection)?;
     if section.commitment.ipns_name != name.as_str().as_bytes() {
         return Err(AuthorError::CommitmentNameMismatch);
     }
-    encode(envelope)
+    Ok(())
 }
 
 fn seal(authoring: &EnvelopeAuthoring<'_>) -> Result<Envelope, AuthorError> {
@@ -303,6 +330,7 @@ mod tests {
             scope_id: [2u8; 16],
             root_id: [1u8; 16],
             children: Vec::new(),
+            child_scope_index: Vec::new(),
             owner_write_blob_epoch: None,
         })
     }

--- a/crates/engine/src/net/author.rs
+++ b/crates/engine/src/net/author.rs
@@ -331,6 +331,7 @@ mod tests {
             root_id: [1u8; 16],
             children: Vec::new(),
             child_scope_index: Vec::new(),
+            parent_node_seed: None,
             owner_write_blob_epoch: None,
         })
     }

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -33,6 +33,7 @@ pub mod register;
 pub mod resolve;
 pub mod retire;
 pub mod revival;
+pub mod rotation;
 
 pub use adopter::{LocalHead, RootAdopter};
 pub(crate) use adopter::{assemble_head_envelope, fetch_head_block};
@@ -55,3 +56,4 @@ pub(crate) use resolve::{
 };
 pub use retire::{retire, root_retire_ready};
 pub use revival::{ReviveError, ReviveRequest, revive};
+pub use rotation::{OwnerRotationKeys, OwnerRotationNet};

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -12,14 +12,15 @@
 //! pipeline stays the only path to the transport.
 
 use core::cell::RefCell;
+use std::collections::BTreeMap;
 
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
     AadContext, ChildScopeRef, Envelope, GrantSection, ReadBody, STRUCT_TAG_OWNER_BLOB,
-    STRUCT_TAG_WRITE_BODY, WriteBody, decode_write_body, open_owner_blob, unseal,
+    STRUCT_TAG_WRITE_BODY, WriteBody, decode_write_body, open_owner_blob, unseal, verify_grant_set,
 };
-use cipherbox_core::suite::ecdsa::EcdsaVerifier;
+use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaVerifier};
 use cipherbox_core::suite::secret::SECRET_LEN;
 use cipherbox_core::suite::x25519::X25519Secret;
 use zeroize::Zeroizing;
@@ -73,6 +74,69 @@ pub struct OwnerRotationNet<'a, T, H: Http, C: CredentialStore, F, Sch, E> {
     pub entropy: &'a RefCell<E>,
     /// The owner material.
     pub keys: OwnerRotationKeys<'a>,
+    /// The ancestor seeds every interior scope root's gated read needs.
+    pub ancestry: RotationAncestry,
+}
+
+/// The `scope_id -> parent` edges and per-scope override seeds a walk needs to
+/// derive each interior scope root's ancestor node seed.
+///
+/// Every interior scope root carries an ascent link, and the adoption gate
+/// derives the expected ascent keypair from the **reader's** ancestor node seed
+/// rather than from the record — no seed, no gate pass. Seeded at the rotating
+/// root ([`Self::rooted_at`]) and extended as the walk gates each level: a
+/// descendant's parent edge comes from the gated parent index that named it, and
+/// the parent's override seed from that parent's own gate-passing owner blob, so
+/// no network-supplied field ever chooses which seed a scope is read under.
+#[derive(Default)]
+pub struct RotationAncestry {
+    inner: RefCell<Ancestry>,
+}
+
+#[derive(Default)]
+struct Ancestry {
+    parents: BTreeMap<[u8; 16], [u8; 16]>,
+    override_seeds: BTreeMap<[u8; 16], Zeroizing<[u8; SECRET_LEN]>>,
+}
+
+impl RotationAncestry {
+    /// Seed the walk at the rotating root: its own override seed, plus the
+    /// parent edge for each entry of its caller-held direct-child-scope index.
+    pub fn rooted_at(
+        scope_id: [u8; 16],
+        override_seed: &[u8; SECRET_LEN],
+        child_index: &[ChildScopeRef],
+    ) -> Self {
+        let ancestry = Self::default();
+        ancestry.record(scope_id, override_seed, child_index);
+        ancestry
+    }
+
+    fn record(
+        &self,
+        scope_id: [u8; 16],
+        override_seed: &[u8; SECRET_LEN],
+        child_index: &[ChildScopeRef],
+    ) {
+        let mut inner = self.inner.borrow_mut();
+        inner
+            .override_seeds
+            .insert(scope_id, Zeroizing::new(*override_seed));
+        for child in child_index {
+            inner.parents.insert(child.scope_id, scope_id);
+        }
+    }
+
+    /// `nodeSeed(parentOverrideSeed, scope_id)`, or `None` at the rotating root
+    /// (which has no parent edge here and carries no ascent link).
+    fn parent_node_seed(&self, scope_id: &[u8; 16]) -> Option<Zeroizing<[u8; SECRET_LEN]>> {
+        let inner = self.inner.borrow();
+        let parent = inner.parents.get(scope_id)?;
+        let parent_seed = inner.override_seeds.get(parent)?;
+        Some(Zeroizing::new(
+            *kdf::node_seed(parent_seed, scope_id).as_bytes(),
+        ))
+    }
 }
 
 /// One scope root as the adoption gate authenticated it, plus the seeds the
@@ -82,6 +146,9 @@ struct GatedScopeRoot {
     envelope: Envelope,
     section: GrantSection,
     read_body: ReadBody,
+    /// The override seed recovered from this root's own owner blob — the
+    /// ancestor seed its descendants' ascent links are derived from.
+    read_scope_seed: Zeroizing<[u8; SECRET_LEN]>,
     /// `None` when the root is held keyless — no owner-write-blob, or no
     /// durable write-epoch floor to open it under.
     write_scope_seed: Option<Zeroizing<[u8; SECRET_LEN]>>,
@@ -97,20 +164,61 @@ fn scope_name(ipns_name: &[u8]) -> Result<IpnsName, ResolveFailure> {
         .ok_or(ResolveFailure::Rejected)
 }
 
+/// Recover the freshly minted override seed from the re-sealed section's own
+/// owner blob, under the AAD the envelope about to carry it will claim.
+///
+/// The rotation primitive is the terminal owner of the seed it minted and hands
+/// the publisher none, so this is the only source of the seed the record must
+/// seal under — and a section that will not reopen under the owner key the
+/// adoption gate re-derives can therefore never be signed (release-active,
+/// security rule 8).
+fn new_override_seed(
+    enc_secret: &X25519Secret,
+    record: &ResealedScopeRoot,
+) -> Result<Zeroizing<[u8; SECRET_LEN]>, ScopeRootPublishError> {
+    let owner_blob = &record.section.owner_blob;
+    let aad = AadContext {
+        v: ENVELOPE_V,
+        id: record.scope_id,
+        scope: record.scope_id,
+        epoch: record.read_epoch,
+        struct_tag: STRUCT_TAG_OWNER_BLOB,
+    };
+    let payload = open_owner_blob(enc_secret, &owner_blob.enc, &aad, &owner_blob.ciphertext)
+        .map_err(|_| ScopeRootPublishError::NotPublished)?;
+    Ok(Zeroizing::new(*payload.override_seed()))
+}
+
+/// Carry a resolve verdict into the publish arm without laundering a
+/// fail-closed trust violation into a retryable transport failure (rule 6).
+fn publish_verdict(failure: ResolveFailure) -> ScopeRootPublishError {
+    match failure {
+        ResolveFailure::Unavailable => ScopeRootPublishError::NotPublished,
+        ResolveFailure::Rejected | ResolveFailure::ConflictingChildLabel => {
+            ScopeRootPublishError::Rejected
+        }
+    }
+}
+
+/// A fresh per-seal nonce from the injected entropy seam.
+fn nonce<E: Entropy>(entropy: &RefCell<E>) -> Result<[u8; 24], ScopeRootPublishError> {
+    let mut nonce = [0u8; 24];
+    entropy
+        .borrow_mut()
+        .fill(&mut nonce)
+        .map_err(|_| ScopeRootPublishError::NotPublished)?;
+    Ok(nonce)
+}
+
 impl<T, H: Http, C: CredentialStore, F, Sch, E> OwnerRotationNet<'_, T, H, C, F, Sch, E>
 where
     T: RecordTransport,
     F: FloorStore,
 {
     /// Fetch the freshest verified record at `name` and run it through the
-    /// adoption gate under `scope_id`.
-    ///
-    /// `name` is the sole gated identity edge — the gate binds it to the record
-    /// through the Ed25519 key the name itself carries — and `scope_id` is the
-    /// trusted label from the caller's own gated parent index, imposed on the
-    /// gate as the scope binding. A record whose envelope claims another scope
-    /// is a transplant the gate rejects, so no network-supplied field can
-    /// influence which scope a resolved record is taken to be.
+    /// adoption gate under `scope_id` — the caller's own trusted label, imposed
+    /// on the gate so a record claiming another scope is a transplant it
+    /// rejects ([`ChildIndexResolver::direct_child_index`]'s binding obligation).
     async fn gated_root(
         &self,
         scope_id: [u8; 16],
@@ -119,7 +227,7 @@ where
         let Some((_, record_bytes)) = fanout_get_verify(self.transport, name).await else {
             return Err(ResolveFailure::Unavailable);
         };
-        let adopter = RootAdopter::new(
+        let mut adopter = RootAdopter::new(
             self.gateway,
             self.http,
             self.floors,
@@ -127,6 +235,9 @@ where
             self.keys.identity,
             scope_id,
         );
+        if let Some(seed) = self.ancestry.parent_node_seed(&scope_id) {
+            adopter = adopter.under_parent_node_seed(seed);
+        }
         let (candidate, outcome) =
             adopter
                 .adopt_root(name, &record_bytes)
@@ -135,10 +246,12 @@ where
                     GateError::Rejected(_) => ResolveFailure::Rejected,
                     GateError::Seam(_) => ResolveFailure::Unavailable,
                 })?;
+        let read_scope_seed = outcome.read_scope_seed.ok_or(ResolveFailure::Unavailable)?;
         Ok(GatedScopeRoot {
             envelope: candidate.envelope,
             section: candidate.grant_section,
             read_body: outcome.adopted.read_body,
+            read_scope_seed,
             write_scope_seed: outcome.write_scope_seed,
         })
     }
@@ -178,6 +291,41 @@ where
         );
         decode_write_body(&plaintext).map_err(|_| ResolveFailure::Rejected)
     }
+
+    /// The three encode-side mirrors of gate rejects this build would itself
+    /// make on the record about to be signed — all release-active, because a
+    /// signed record cannot be unpublished (security rule 8):
+    ///
+    /// - the commitment must verify under the owner identity (gate stage 2);
+    /// - the read epoch must not sit below the durable revocation floor (stage 5);
+    /// - the write epoch must not sit below the durable write floor, which the
+    ///   owner-write-blob's AAD binds — below it the root publishes write-plane
+    ///   dead, and floors are monotonic, so it can never be rotated back.
+    async fn check_publishable(
+        &self,
+        record: &ResealedScopeRoot,
+    ) -> Result<(), ScopeRootPublishError> {
+        let section = &record.section;
+        let signature = EcdsaSignature::from_compact(&section.commitment_sig)
+            .ok_or(ScopeRootPublishError::Rejected)?;
+        verify_grant_set(self.keys.identity, &section.commitment, &signature)
+            .map_err(|_| ScopeRootPublishError::Rejected)?;
+
+        let floors = self.floors;
+        let scope_id = &record.scope_id;
+        let read_floor = floor::read_epoch_floor(floors, scope_id)
+            .await
+            .map_err(|_| ScopeRootPublishError::NotPublished)?
+            .unwrap_or(0);
+        let write_floor = floor::write_epoch_floor(floors, scope_id)
+            .await
+            .map_err(|_| ScopeRootPublishError::NotPublished)?
+            .unwrap_or(0);
+        if record.read_epoch < read_floor || record.write_epoch < write_floor {
+            return Err(ScopeRootPublishError::Rejected);
+        }
+        Ok(())
+    }
 }
 
 impl<T, H: Http, C: CredentialStore, F, Sch, E> ChildIndexResolver
@@ -192,56 +340,15 @@ where
     ) -> Result<Vec<ChildScopeRef>, ResolveFailure> {
         let name = scope_name(&child.ipns_name)?;
         let root = self.gated_root(child.scope_id, &name).await?;
-        Ok(self
+        let index = self
             .write_body(&root, child.scope_id)
             .await?
-            .direct_child_scope_index)
-    }
-}
-
-impl<T, H: Http, C: CredentialStore, F, Sch, E> OwnerRotationNet<'_, T, H, C, F, Sch, E>
-where
-    E: Entropy,
-{
-    /// Recover the freshly minted override seed from the re-sealed section's own
-    /// owner blob, under the AAD the envelope about to carry it will claim.
-    ///
-    /// The rotation primitive is the terminal owner of the seed it minted and
-    /// hands the publisher none, so this is where the seed the record must seal
-    /// under comes from — and, because the AAD binds this build's envelope
-    /// version and the record's identity/epoch, a section that will not reopen
-    /// under the owner key the adoption gate re-derives can never be signed
-    /// (release-active, security rule 8).
-    fn new_override_seed(
-        &self,
-        record: &ResealedScopeRoot,
-    ) -> Result<Zeroizing<[u8; SECRET_LEN]>, ScopeRootPublishError> {
-        let owner_blob = &record.section.owner_blob;
-        let aad = AadContext {
-            v: ENVELOPE_V,
-            id: record.scope_id,
-            scope: record.scope_id,
-            epoch: record.read_epoch,
-            struct_tag: STRUCT_TAG_OWNER_BLOB,
-        };
-        let payload = open_owner_blob(
-            self.keys.enc_secret,
-            &owner_blob.enc,
-            &aad,
-            &owner_blob.ciphertext,
-        )
-        .map_err(|_| ScopeRootPublishError::NotPublished)?;
-        Ok(Zeroizing::new(*payload.override_seed()))
-    }
-
-    /// A fresh per-seal nonce from the injected entropy seam.
-    fn nonce(&self) -> Result<[u8; 24], ScopeRootPublishError> {
-        let mut nonce = [0u8; 24];
-        self.entropy
-            .borrow_mut()
-            .fill(&mut nonce)
-            .map_err(|_| ScopeRootPublishError::NotPublished)?;
-        Ok(nonce)
+            .direct_child_scope_index;
+        // Extend the ancestry with what this gate pass just proved, so the next
+        // level down can derive its own ascent authority.
+        self.ancestry
+            .record(child.scope_id, &root.read_scope_seed, &index);
+        Ok(index)
     }
 }
 
@@ -257,16 +364,16 @@ where
         &self,
         record: &ResealedScopeRoot,
     ) -> Result<(), ScopeRootPublishError> {
-        let name =
-            scope_name(&record.ipns_name).map_err(|_| ScopeRootPublishError::NotPublished)?;
-        let override_seed = self.new_override_seed(record)?;
+        let name = scope_name(&record.ipns_name).map_err(publish_verdict)?;
+        let override_seed = new_override_seed(self.keys.enc_secret, record)?;
+        self.check_publishable(record).await?;
 
         // The read body and the envelope fields a republish preserves come from
         // the node's own current record, gated — the rotation carries neither.
         let current = self
             .gated_root(record.scope_id, &name)
             .await
-            .map_err(|_| ScopeRootPublishError::NotPublished)?;
+            .map_err(publish_verdict)?;
         let write_scope_seed = current
             .write_scope_seed
             .as_deref()
@@ -274,7 +381,7 @@ where
 
         let node_seed = kdf::node_seed(&override_seed, &record.scope_id);
         let read_key = Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes());
-        let nonce = self.nonce()?;
+        let nonce = nonce(self.entropy)?;
         let head = author_scope_root_with_section(
             EnvelopeAuthoring {
                 node_id: record.scope_id,
@@ -283,8 +390,8 @@ where
                 read_key: &read_key,
                 nonce: &nonce,
                 body: &current.read_body,
-                carried_unknown: current.envelope.unknown.clone(),
-                carried_epoch_tag_unknown: current.envelope.epoch_tag_unknown.clone(),
+                carried_unknown: current.envelope.unknown,
+                carried_epoch_tag_unknown: current.envelope.epoch_tag_unknown,
             },
             &name,
             &record.section,
@@ -373,10 +480,29 @@ mod tests {
         X25519Secret::from_scalar(OWNER_ENC_SCALAR)
     }
 
-    /// A scope root whose node id is its scope id, holding `child_scope_index`
-    /// in its write body and an owner-write-blob at the fixture's epoch, so the
-    /// owner recovers the write-scope seed that write body opens under.
-    fn scope_root(scope_id: [u8; 16], child_scope_index: Vec<ChildScopeRef>) -> OwnerRootFixture {
+    /// A vault root: no ascent link, an owner-write-blob at the fixture's epoch
+    /// so the owner recovers the write-scope seed its write body opens under.
+    fn vault_root(scope_id: [u8; 16], child_scope_index: Vec<ChildScopeRef>) -> OwnerRootFixture {
+        scope_root(scope_id, child_scope_index, None)
+    }
+
+    /// An interior scope root, whose ascent link seals under
+    /// `nodeSeed(parentOverrideSeed, scope_id)` — what every descendant in a
+    /// real eager set looks like.
+    fn interior(
+        scope_id: [u8; 16],
+        parent_override_seed: &[u8; 32],
+        child_scope_index: Vec<ChildScopeRef>,
+    ) -> OwnerRootFixture {
+        let parent_node_seed = *kdf::node_seed(parent_override_seed, &scope_id).as_bytes();
+        scope_root(scope_id, child_scope_index, Some(parent_node_seed))
+    }
+
+    fn scope_root(
+        scope_id: [u8; 16],
+        child_scope_index: Vec<ChildScopeRef>,
+        parent_node_seed: Option<[u8; 32]>,
+    ) -> OwnerRootFixture {
         owner_root_fixture(OwnerRootSpec {
             owner_identity: &owner_identity(),
             owner_enc: &owner_enc().public(),
@@ -384,6 +510,7 @@ mod tests {
             root_id: scope_id,
             children: Vec::new(),
             child_scope_index,
+            parent_node_seed,
             owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
         })
     }
@@ -533,17 +660,17 @@ mod tests {
             }
         }
 
-        fn net(
-            &self,
-        ) -> OwnerRotationNet<
-            '_,
-            T,
-            ScriptedHttp,
-            InMemoryCredentialStore,
-            InMemoryFloorStore,
-            VirtualScheduler,
-            SeededEntropy,
-        > {
+        /// The wiring rooted at the vault root, whose own record carries no
+        /// ascent link — the ancestry the walk extends from.
+        fn net(&self, root_child_index: &[ChildScopeRef]) -> Net<'_, T> {
+            self.net_rooted(RotationAncestry::rooted_at(
+                SCOPE,
+                &OWNER_ROOT_SCOPE_SEED,
+                root_child_index,
+            ))
+        }
+
+        fn net_rooted(&self, ancestry: RotationAncestry) -> Net<'_, T> {
             OwnerRotationNet {
                 transport: &self.transport,
                 api: &self.api,
@@ -557,9 +684,20 @@ mod tests {
                     enc_secret: &self.enc_secret,
                     identity: &self.identity,
                 },
+                ancestry,
             }
         }
     }
+
+    type Net<'a, T> = OwnerRotationNet<
+        'a,
+        T,
+        ScriptedHttp,
+        InMemoryCredentialStore,
+        InMemoryFloorStore,
+        VirtualScheduler,
+        SeededEntropy,
+    >;
 
     impl Harness<InMemoryRecordStore> {
         fn plain() -> Self {
@@ -617,52 +755,85 @@ mod tests {
         }
     }
 
+    /// A one-level tree: the vault root names `CHILD_SCOPE`, an interior scope
+    /// root whose own write body names a grandchild.
+    fn one_level() -> (OwnerRootFixture, ChildScopeRef, ChildScopeRef) {
+        let grandchild_scope = [0xd2; 16];
+        let child_seed = OWNER_ROOT_SCOPE_SEED;
+        let leaf = interior(grandchild_scope, &child_seed, Vec::new());
+        let grandchild = child_ref(grandchild_scope, &leaf);
+        let child = interior(
+            CHILD_SCOPE,
+            &OWNER_ROOT_SCOPE_SEED,
+            vec![grandchild.clone()],
+        );
+        let child_ref = child_ref(CHILD_SCOPE, &child);
+        (child, child_ref, grandchild)
+    }
+
     #[test]
     fn a_descendants_adjacency_comes_from_its_own_gated_write_body() {
-        let leaf = scope_root([0xd2; 16], Vec::new());
-        let grandchild = child_ref([0xd2; 16], &leaf);
-        let child = scope_root(CHILD_SCOPE, vec![grandchild.clone()]);
-
+        let (child, child_ref, grandchild) = one_level();
         let harness = Harness::plain();
         harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
 
         let index = block_on(
             harness
-                .net()
-                .direct_child_index(&child_ref(CHILD_SCOPE, &child)),
+                .net(core::slice::from_ref(&child_ref))
+                .direct_child_index(&child_ref),
         )
         .expect("the descendant's own index");
         assert_eq!(index, vec![grandchild]);
     }
 
-    /// The `scope_id` label comes from the caller's own gated parent index and is
-    /// imposed on the gate: a record published at the enumerated name but
-    /// claiming another scope is a transplant, never a silently relabelled node.
+    /// The ascent link every interior scope root carries is verified against a
+    /// keypair the **reader** derives from its ancestor seed, so a walk that
+    /// cannot place a descendant under its parent proves nothing about it.
+    #[test]
+    fn a_descendant_off_the_ancestry_never_passes_the_gate() {
+        let (child, child_ref, _) = one_level();
+        let harness = Harness::plain();
+        harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
+
+        assert_eq!(
+            block_on(
+                harness
+                    .net_rooted(RotationAncestry::default())
+                    .direct_child_index(&child_ref)
+            ),
+            Err(ResolveFailure::Rejected),
+        );
+    }
+
     #[test]
     fn a_record_claiming_another_scope_is_a_fail_closed_rejection() {
-        let child = scope_root(CHILD_SCOPE, Vec::new());
+        let (child, child_ref, _) = one_level();
         let harness = Harness::plain();
         harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
 
         let mislabelled = ChildScopeRef {
             scope_id: [0x9e; 16],
-            ..child_ref(CHILD_SCOPE, &child)
+            ..child_ref.clone()
         };
         assert_eq!(
-            block_on(harness.net().direct_child_index(&mislabelled)),
+            block_on(
+                harness
+                    .net(core::slice::from_ref(&child_ref))
+                    .direct_child_index(&mislabelled)
+            ),
             Err(ResolveFailure::Rejected),
         );
     }
 
     #[test]
     fn a_descendant_no_endpoint_serves_is_availability_not_a_trust_verdict() {
-        let child = scope_root(CHILD_SCOPE, Vec::new());
+        let (_, child_ref, _) = one_level();
         let harness = Harness::plain();
         assert_eq!(
             block_on(
                 harness
-                    .net()
-                    .direct_child_index(&child_ref(CHILD_SCOPE, &child))
+                    .net(core::slice::from_ref(&child_ref))
+                    .direct_child_index(&child_ref)
             ),
             Err(ResolveFailure::Unavailable),
         );
@@ -677,7 +848,7 @@ mod tests {
             unknown: PreservedFields::new(),
         };
         assert_eq!(
-            block_on(harness.net().direct_child_index(&malformed)),
+            block_on(harness.net(&[]).direct_child_index(&malformed)),
             Err(ResolveFailure::Rejected),
         );
         assert!(
@@ -690,15 +861,15 @@ mod tests {
     /// the write body has no key — re-authorable, never a trust verdict.
     #[test]
     fn a_root_held_keyless_yields_no_index_and_no_rejection() {
-        let child = scope_root(CHILD_SCOPE, Vec::new());
+        let (child, child_ref, _) = one_level();
         let harness = Harness::plain();
         harness.stage(CHILD_SCOPE, &child, None);
 
         assert_eq!(
             block_on(
                 harness
-                    .net()
-                    .direct_child_index(&child_ref(CHILD_SCOPE, &child))
+                    .net(core::slice::from_ref(&child_ref))
+                    .direct_child_index(&child_ref)
             ),
             Err(ResolveFailure::Unavailable),
         );
@@ -750,14 +921,25 @@ mod tests {
         }
     }
 
-    #[test]
-    fn a_resealed_root_lands_at_the_new_epoch_carrying_its_new_section() {
-        let root = scope_root(SCOPE, Vec::new());
+    /// `SCOPE`'s root staged at the fixture epoch on a plain harness, plus the
+    /// cut `rotate_scope` would hand the publisher for it.
+    fn staged_cut() -> (
+        Harness<InMemoryRecordStore>,
+        OwnerRootFixture,
+        ResealedScopeRoot,
+    ) {
+        let root = vault_root(SCOPE, Vec::new());
         let harness = Harness::plain();
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
         let cut = cut(&root, SCOPE, OWNER_ROOT_EPOCH + 1);
+        (harness, root, cut)
+    }
 
-        block_on(harness.net().publish_scope_root(&cut)).expect("the cut lands");
+    #[test]
+    fn a_resealed_root_lands_at_the_new_epoch_carrying_its_new_section() {
+        let (harness, root, cut) = staged_cut();
+
+        block_on(harness.net(&[]).publish_scope_root(&cut)).expect("the cut lands");
 
         let endpoint = &harness.store.endpoints()[0];
         let published = harness
@@ -795,20 +977,32 @@ mod tests {
             .expect("the body reopens under the freshly minted override seed");
     }
 
-    /// The publisher takes the seed it seals under from the section's own owner
-    /// blob, so a section the owner cannot reopen is refused before anything is
-    /// signed — release-active, never a debug assertion.
+    /// Rule 8 at the whole-record scale: a cut is published only if this build's
+    /// own adoption gate re-adopts it. The cut's read epoch runs ahead of its
+    /// write epoch, so every structure signature must be recomputable at the
+    /// envelope's read epoch — the one the gate authenticates from.
+    #[test]
+    fn a_published_cut_re_adopts_through_this_builds_own_gate() {
+        let (harness, root, cut) = staged_cut();
+        assert_ne!(
+            cut.read_epoch, cut.write_epoch,
+            "a read rotation is exactly where the two epochs diverge"
+        );
+
+        block_on(harness.net(&[]).publish_scope_root(&cut)).expect("the cut lands");
+
+        let regated = block_on(harness.net(&[]).gated_root(SCOPE, &root.name)).map(|_| ());
+        assert_eq!(regated, Ok(()), "the cut we signed passes our own gate");
+    }
+
     #[test]
     fn a_section_the_owner_cannot_reopen_is_never_signed() {
-        let root = scope_root(SCOPE, Vec::new());
-        let harness = Harness::plain();
-        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
-        let mut cut = cut(&root, SCOPE, OWNER_ROOT_EPOCH + 1);
+        let (harness, root, mut cut) = staged_cut();
         let last = cut.section.owner_blob.ciphertext.len() - 1;
         cut.section.owner_blob.ciphertext[last] ^= 0xff;
 
         assert_eq!(
-            block_on(harness.net().publish_scope_root(&cut)),
+            block_on(harness.net(&[]).publish_scope_root(&cut)),
             Err(ScopeRootPublishError::NotPublished),
         );
         let endpoint = &harness.store.endpoints()[0];
@@ -819,20 +1013,68 @@ mod tests {
         );
     }
 
-    /// A section minted for another epoch will not open under the AAD the
-    /// envelope about to carry it claims, so the mismatch is caught before the
-    /// record is signed rather than surfacing as an unopenable published root.
     #[test]
     fn a_section_minted_for_another_epoch_is_never_signed() {
-        let root = scope_root(SCOPE, Vec::new());
-        let harness = Harness::plain();
-        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
-        let mut cut = cut(&root, SCOPE, OWNER_ROOT_EPOCH + 1);
+        let (harness, _root, mut cut) = staged_cut();
         cut.read_epoch = OWNER_ROOT_EPOCH + 2;
 
         assert_eq!(
-            block_on(harness.net().publish_scope_root(&cut)),
+            block_on(harness.net(&[]).publish_scope_root(&cut)),
             Err(ScopeRootPublishError::NotPublished),
+        );
+    }
+
+    /// Gate stage 2's encode-side mirror: a commitment that will not verify
+    /// under the owner identity is refused before the record is signed.
+    #[test]
+    fn a_commitment_that_will_not_verify_is_never_signed() {
+        let (harness, root, mut cut) = staged_cut();
+        cut.section.commitment_sig[0] ^= 0xff;
+
+        assert_eq!(
+            block_on(harness.net(&[]).publish_scope_root(&cut)),
+            Err(ScopeRootPublishError::Rejected),
+        );
+        let endpoint = &harness.store.endpoints()[0];
+        assert_eq!(
+            harness.store.record_at(endpoint, root.name.as_str()),
+            Some(record_for(&SCOPE, &root.head_cid_str, 1)),
+            "the pre-rotation record still stands — nothing was published",
+        );
+    }
+
+    /// Gate stage 5's encode-side mirror: a plan built from a stale snapshot
+    /// would publish a root below the durable revocation floor, which this
+    /// build's own gate always rejects.
+    #[test]
+    fn a_cut_below_the_durable_revocation_floor_is_never_signed() {
+        let (harness, _root, cut) = staged_cut();
+        block_on(harness.floors.raise_epoch_floor(&SCOPE, cut.read_epoch + 1))
+            .expect("raise the revocation floor");
+
+        assert_eq!(
+            block_on(harness.net(&[]).publish_scope_root(&cut)),
+            Err(ScopeRootPublishError::Rejected),
+        );
+    }
+
+    /// A gate rejection on the record the publish must read first is a
+    /// fail-closed trust violation, never a retryable transport failure — a
+    /// forged record must not be retried like a flaky endpoint (rule 6).
+    #[test]
+    fn a_gate_rejected_current_record_is_not_laundered_into_a_retry() {
+        let (harness, root, _) = staged_cut();
+        // The staged record sits at epoch 1; raising the floor above it makes the
+        // gate reject it, while the cut itself still clears the floor.
+        let floor = OWNER_ROOT_EPOCH + 4;
+        block_on(harness.floors.raise_epoch_floor(&SCOPE, floor)).expect("raise the floor");
+        let cut = cut(&root, SCOPE, floor);
+
+        let outcome = block_on(harness.net(&[]).publish_scope_root(&cut));
+        assert_eq!(outcome, Err(ScopeRootPublishError::Rejected));
+        assert!(
+            !outcome.unwrap_err().is_retryable(),
+            "a trust rejection is never retryable",
         );
     }
 
@@ -841,9 +1083,16 @@ mod tests {
     /// alone.
     #[test]
     fn the_eager_set_walk_composes_over_the_production_resolver() {
-        let grandchild = scope_root([0xd2; 16], Vec::new());
+        // The grandchild's ascent link seals under its own parent's seed —
+        // every fixture shares OWNER_ROOT_SCOPE_SEED as its override seed, so
+        // the walk's derived ancestry is what has to line up.
+        let grandchild = interior([0xd2; 16], &OWNER_ROOT_SCOPE_SEED, Vec::new());
         let grandchild_ref = child_ref([0xd2; 16], &grandchild);
-        let child = scope_root(CHILD_SCOPE, vec![grandchild_ref.clone()]);
+        let child = interior(
+            CHILD_SCOPE,
+            &OWNER_ROOT_SCOPE_SEED,
+            vec![grandchild_ref.clone()],
+        );
         let child_ref = child_ref(CHILD_SCOPE, &child);
 
         let harness = Harness::plain();
@@ -853,7 +1102,7 @@ mod tests {
         let eager_set = block_on(enumerate_eager_set(
             SCOPE,
             core::slice::from_ref(&child_ref),
-            &harness.net(),
+            &harness.net(core::slice::from_ref(&child_ref)),
         ))
         .expect("every reachable descendant resolved");
         assert_eq!(
@@ -867,7 +1116,7 @@ mod tests {
     /// plane and only then does the durable `minReadEpoch` floor move.
     #[test]
     fn the_root_cut_composes_over_the_production_publisher() {
-        let root = scope_root(SCOPE, Vec::new());
+        let root = vault_root(SCOPE, Vec::new());
         let harness = Harness::plain();
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
         let pseudonym = Ed25519Signer::from_seed(OWNER_ROOT_PSEUDONYM_SEED);
@@ -878,7 +1127,7 @@ mod tests {
             &mut entropy,
             &harness.floors,
             &harness.world.scheduler,
-            &harness.net(),
+            &harness.net(&[]),
             &RotateScopePlan {
                 identity: ScopeRootIdentity {
                     v: ENVELOPE_V,
@@ -922,14 +1171,14 @@ mod tests {
 
     #[test]
     fn a_concurrent_writer_at_a_higher_sequence_is_a_retryable_lost_race() {
-        let root = scope_root(SCOPE, Vec::new());
+        let root = vault_root(SCOPE, Vec::new());
         let winner = record_for(&SCOPE, &root.head_cid_str, 9);
         let harness = Harness::racing(root.name.as_str(), winner);
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
         let cut = cut(&root, SCOPE, OWNER_ROOT_EPOCH + 1);
 
         assert_eq!(
-            block_on(harness.net().publish_scope_root(&cut)),
+            block_on(harness.net(&[]).publish_scope_root(&cut)),
             Err(ScopeRootPublishError::LostRace),
             "a lost CAS race is reported, never a silent drop",
         );

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -1,0 +1,937 @@
+//! The production rotation seams: the owner arm of the two impure edges the
+//! read-plane rotation primitives run on (blueprint/engine.md "Rotation
+//! primitives", "Pointer planes"; #1014).
+//!
+//! [`crate::rotation`] is pure apart from a gated read of a descendant scope
+//! root's own write-body index ([`ChildIndexResolver`]) and a register-first CAS
+//! publish of a re-sealed scope root ([`ScopeRootPublisher`]). Both land here,
+//! composed from the net plane already in place — fan-out GET plus
+//! [`RootAdopter`] for the read, [`author`](super::author) plus
+//! [`publish_record`] for the write. No crypto and no trust logic is added: the
+//! adoption gate stays the only judge of a resolved record, and the publish
+//! pipeline stays the only path to the transport.
+
+use core::cell::RefCell;
+
+use cipherbox_core::ipns::IpnsName;
+use cipherbox_core::kdf;
+use cipherbox_core::seal::{
+    AadContext, ChildScopeRef, Envelope, GrantSection, ReadBody, STRUCT_TAG_OWNER_BLOB,
+    STRUCT_TAG_WRITE_BODY, WriteBody, decode_write_body, open_owner_blob, unseal,
+};
+use cipherbox_core::suite::ecdsa::EcdsaVerifier;
+use cipherbox_core::suite::secret::SECRET_LEN;
+use cipherbox_core::suite::x25519::X25519Secret;
+use zeroize::Zeroizing;
+
+use super::adopter::RootAdopter;
+use super::author::{ENVELOPE_V, EnvelopeAuthoring, author_scope_root_with_section};
+use super::publish::PublishOutcome;
+use super::record_publish::{HeadBinding, RecordPublishRequest, preflight, publish_record};
+use crate::api::ApiClient;
+use crate::content::Gateway;
+use crate::entropy::Entropy;
+use crate::gate::{GateError, floor};
+use crate::net::fanout_get_verify;
+use crate::profile::SyncTimingProfile;
+use crate::rotation::{
+    ChildIndexResolver, ResealedScopeRoot, ResolveFailure, ScopeRootPublishError,
+    ScopeRootPublisher,
+};
+use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
+use crate::session::SessionIdentity;
+
+/// The owner key material both rotation edges run under. The owner is the
+/// terminal owner of its own key material, so nothing here is zeroized.
+pub struct OwnerRotationKeys<'a> {
+    /// Opens each scope root's owner blob — the owner's read-seed source, and
+    /// the key the re-sealed section must reopen under before it is signed.
+    pub enc_secret: &'a X25519Secret,
+    /// The contact-anchored owner identity: the adoption gate's stage-2 anchor.
+    pub identity: &'a EcdsaVerifier,
+}
+
+/// The owner-arm rotation seams over the live net plane.
+pub struct OwnerRotationNet<'a, T, H: Http, C: CredentialStore, F, Sch, E> {
+    /// The record-plane transport: fan-out GET for the read, CAS PUT for the
+    /// publish.
+    pub transport: &'a T,
+    /// The API client: register-first and the head-block upload.
+    pub api: &'a ApiClient<H, C>,
+    /// Content read sources for the head block.
+    pub gateway: &'a Gateway,
+    /// The HTTP seam the content fetch rides.
+    pub http: &'a H,
+    /// The durable floors the adoption gate reads and advances.
+    pub floors: &'a F,
+    /// The scheduler the publish pipeline's background re-PUT rides.
+    pub scheduler: &'a Sch,
+    /// The publish pipeline's timing policy.
+    pub profile: &'a SyncTimingProfile,
+    /// Injected entropy — the per-seal nonce source (determinism law: engine
+    /// logic never reaches for an RNG).
+    pub entropy: &'a RefCell<E>,
+    /// The owner material.
+    pub keys: OwnerRotationKeys<'a>,
+}
+
+/// One scope root as the adoption gate authenticated it, plus the seeds the
+/// owner recovered from its own blobs. Terminal owner of those seeds: they
+/// zeroize when the value is dropped.
+struct GatedScopeRoot {
+    envelope: Envelope,
+    section: GrantSection,
+    read_body: ReadBody,
+    /// `None` when the root is held keyless — no owner-write-blob, or no
+    /// durable write-epoch floor to open it under.
+    write_scope_seed: Option<Zeroizing<[u8; SECRET_LEN]>>,
+}
+
+/// Parse a `ChildScopeRef`'s opaque `ipnsName` bytes. A name that is not a
+/// canonical IPNS name has no verifying key to gate against, so it is a
+/// fail-closed rejection rather than an availability stall.
+fn scope_name(ipns_name: &[u8]) -> Result<IpnsName, ResolveFailure> {
+    core::str::from_utf8(ipns_name)
+        .ok()
+        .and_then(|text| IpnsName::parse(text).ok())
+        .ok_or(ResolveFailure::Rejected)
+}
+
+impl<T, H: Http, C: CredentialStore, F, Sch, E> OwnerRotationNet<'_, T, H, C, F, Sch, E>
+where
+    T: RecordTransport,
+    F: FloorStore,
+{
+    /// Fetch the freshest verified record at `name` and run it through the
+    /// adoption gate under `scope_id`.
+    ///
+    /// `name` is the sole gated identity edge — the gate binds it to the record
+    /// through the Ed25519 key the name itself carries — and `scope_id` is the
+    /// trusted label from the caller's own gated parent index, imposed on the
+    /// gate as the scope binding. A record whose envelope claims another scope
+    /// is a transplant the gate rejects, so no network-supplied field can
+    /// influence which scope a resolved record is taken to be.
+    async fn gated_root(
+        &self,
+        scope_id: [u8; 16],
+        name: &IpnsName,
+    ) -> Result<GatedScopeRoot, ResolveFailure> {
+        let Some((_, record_bytes)) = fanout_get_verify(self.transport, name).await else {
+            return Err(ResolveFailure::Unavailable);
+        };
+        let adopter = RootAdopter::new(
+            self.gateway,
+            self.http,
+            self.floors,
+            self.keys.enc_secret,
+            self.keys.identity,
+            scope_id,
+        );
+        let (candidate, outcome) =
+            adopter
+                .adopt_root(name, &record_bytes)
+                .await
+                .map_err(|error| match error {
+                    GateError::Rejected(_) => ResolveFailure::Rejected,
+                    GateError::Seam(_) => ResolveFailure::Unavailable,
+                })?;
+        Ok(GatedScopeRoot {
+            envelope: candidate.envelope,
+            section: candidate.grant_section,
+            read_body: outcome.adopted.read_body,
+            write_scope_seed: outcome.write_scope_seed,
+        })
+    }
+
+    /// Unseal a gated scope root's write-body under the owner's recovered write
+    /// scope seed at the durable write-epoch floor (the AAD epoch the owner
+    /// blob's own recovery already bound). A root held keyless has no readable
+    /// write-body — availability, not a trust verdict.
+    async fn write_body(
+        &self,
+        root: &GatedScopeRoot,
+        scope_id: [u8; 16],
+    ) -> Result<WriteBody, ResolveFailure> {
+        let (Some(write_scope_seed), Some(write_epoch)) = (
+            root.write_scope_seed.as_deref(),
+            floor::write_epoch_floor(self.floors, &scope_id)
+                .await
+                .map_err(|_| ResolveFailure::Unavailable)?,
+        ) else {
+            return Err(ResolveFailure::Unavailable);
+        };
+        let write_seed = kdf::write_seed(write_scope_seed, &scope_id);
+        let write_key = kdf::write_key(write_seed.as_bytes());
+        let env = &root.envelope;
+        let ctx = AadContext {
+            v: env.v,
+            id: env.id,
+            scope: env.scope,
+            epoch: write_epoch,
+            struct_tag: STRUCT_TAG_WRITE_BODY,
+        };
+        // The gate authenticated this structure's detached signature; the unseal
+        // is what proves it is *this* scope's write-body at *this* write epoch.
+        let plaintext = Zeroizing::new(
+            unseal(write_key.as_bytes(), &ctx, &root.section.write_body.sealed)
+                .map_err(|_| ResolveFailure::Rejected)?,
+        );
+        decode_write_body(&plaintext).map_err(|_| ResolveFailure::Rejected)
+    }
+}
+
+impl<T, H: Http, C: CredentialStore, F, Sch, E> ChildIndexResolver
+    for OwnerRotationNet<'_, T, H, C, F, Sch, E>
+where
+    T: RecordTransport,
+    F: FloorStore,
+{
+    async fn direct_child_index(
+        &self,
+        child: &ChildScopeRef,
+    ) -> Result<Vec<ChildScopeRef>, ResolveFailure> {
+        let name = scope_name(&child.ipns_name)?;
+        let root = self.gated_root(child.scope_id, &name).await?;
+        Ok(self
+            .write_body(&root, child.scope_id)
+            .await?
+            .direct_child_scope_index)
+    }
+}
+
+impl<T, H: Http, C: CredentialStore, F, Sch, E> OwnerRotationNet<'_, T, H, C, F, Sch, E>
+where
+    E: Entropy,
+{
+    /// Recover the freshly minted override seed from the re-sealed section's own
+    /// owner blob, under the AAD the envelope about to carry it will claim.
+    ///
+    /// The rotation primitive is the terminal owner of the seed it minted and
+    /// hands the publisher none, so this is where the seed the record must seal
+    /// under comes from — and, because the AAD binds this build's envelope
+    /// version and the record's identity/epoch, a section that will not reopen
+    /// under the owner key the adoption gate re-derives can never be signed
+    /// (release-active, security rule 8).
+    fn new_override_seed(
+        &self,
+        record: &ResealedScopeRoot,
+    ) -> Result<Zeroizing<[u8; SECRET_LEN]>, ScopeRootPublishError> {
+        let owner_blob = &record.section.owner_blob;
+        let aad = AadContext {
+            v: ENVELOPE_V,
+            id: record.scope_id,
+            scope: record.scope_id,
+            epoch: record.read_epoch,
+            struct_tag: STRUCT_TAG_OWNER_BLOB,
+        };
+        let payload = open_owner_blob(
+            self.keys.enc_secret,
+            &owner_blob.enc,
+            &aad,
+            &owner_blob.ciphertext,
+        )
+        .map_err(|_| ScopeRootPublishError::NotPublished)?;
+        Ok(Zeroizing::new(*payload.override_seed()))
+    }
+
+    /// A fresh per-seal nonce from the injected entropy seam.
+    fn nonce(&self) -> Result<[u8; 24], ScopeRootPublishError> {
+        let mut nonce = [0u8; 24];
+        self.entropy
+            .borrow_mut()
+            .fill(&mut nonce)
+            .map_err(|_| ScopeRootPublishError::NotPublished)?;
+        Ok(nonce)
+    }
+}
+
+impl<T, H: Http, C: CredentialStore, F, Sch, E> ScopeRootPublisher
+    for OwnerRotationNet<'_, T, H, C, F, Sch, E>
+where
+    T: RecordTransport + Clone + 'static,
+    F: FloorStore,
+    Sch: Scheduler + Clone + 'static,
+    E: Entropy,
+{
+    async fn publish_scope_root(
+        &self,
+        record: &ResealedScopeRoot,
+    ) -> Result<(), ScopeRootPublishError> {
+        let name =
+            scope_name(&record.ipns_name).map_err(|_| ScopeRootPublishError::NotPublished)?;
+        let override_seed = self.new_override_seed(record)?;
+
+        // The read body and the envelope fields a republish preserves come from
+        // the node's own current record, gated — the rotation carries neither.
+        let current = self
+            .gated_root(record.scope_id, &name)
+            .await
+            .map_err(|_| ScopeRootPublishError::NotPublished)?;
+        let write_scope_seed = current
+            .write_scope_seed
+            .as_deref()
+            .ok_or(ScopeRootPublishError::NotPublished)?;
+
+        let node_seed = kdf::node_seed(&override_seed, &record.scope_id);
+        let read_key = Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes());
+        let nonce = self.nonce()?;
+        let head = author_scope_root_with_section(
+            EnvelopeAuthoring {
+                node_id: record.scope_id,
+                scope_id: record.scope_id,
+                epoch: record.read_epoch,
+                read_key: &read_key,
+                nonce: &nonce,
+                body: &current.read_body,
+                carried_unknown: current.envelope.unknown.clone(),
+                carried_epoch_tag_unknown: current.envelope.epoch_tag_unknown.clone(),
+            },
+            &name,
+            &record.section,
+        )
+        .map_err(|_| ScopeRootPublishError::NotPublished)?;
+
+        let binding = HeadBinding {
+            node_id: record.scope_id,
+            scope_id: record.scope_id,
+            epoch: record.read_epoch,
+        };
+        let preflighted = preflight(&binding, &read_key, &head)
+            .map_err(|_| ScopeRootPublishError::NotPublished)?;
+
+        let signer = SessionIdentity::write_name_signer(write_scope_seed, &record.scope_id);
+        let receipt = publish_record(
+            self.transport,
+            self.api,
+            self.floors,
+            self.scheduler,
+            self.profile,
+            &RecordPublishRequest {
+                name: &name,
+                signer: &signer,
+                head: &preflighted,
+                content_cids: Vec::new(),
+                min_current_sequence: None,
+            },
+        )
+        .await
+        .map_err(|_| ScopeRootPublishError::NotPublished)?;
+
+        match receipt.outcome {
+            PublishOutcome::Published { .. } => Ok(()),
+            PublishOutcome::LostRace { .. } => Err(ScopeRootPublishError::LostRace),
+            // Acked but not read back as ours: nothing is proven durable, and
+            // re-publishing is idempotent-in-sequence.
+            PublishOutcome::Unconfirmed { .. } => Err(ScopeRootPublishError::NotPublished),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::{Arc, Mutex};
+
+    use cipherbox_core::ipns::IpnsRecord;
+    use cipherbox_core::seal::{
+        PreservedFields, decode_envelope, decode_grant_section, grant_section_bytes, open_read_body,
+    };
+    use cipherbox_core::suite::ecdsa::EcdsaSigner;
+    use cipherbox_core::suite::ed25519::Ed25519Signer;
+
+    use super::*;
+    use crate::content::GatewaySource;
+    use crate::rotation::{
+        CommittedSet, PrevEpochSeed, ResealSeeds, RotateScopePlan, ScopeRootIdentity,
+        enumerate_eager_set, reseal_scope_root, rotate_scope,
+    };
+    use crate::seams::{EndpointId, HttpResponse, SeamError, SeamResult};
+    use crate::testkit::fakes::{
+        InMemoryCredentialStore, InMemoryFloorStore, InMemoryRecordStore, ScriptedHttp,
+        VirtualScheduler,
+    };
+    use crate::testkit::{
+        FakeWorld, OWNER_ROOT_EPOCH, OWNER_ROOT_PSEUDONYM_SEED, OWNER_ROOT_SCOPE_SEED,
+        OWNER_ROOT_WRITE_SCOPE_SEED, OwnerRootFixture, OwnerRootSpec, SeededEntropy, block_on,
+        owner_root_fixture, requested_cid,
+    };
+
+    const SCOPE: [u8; 16] = [0x44; 16];
+    const CHILD_SCOPE: [u8; 16] = [0xc1; 16];
+    const OWNER_SCALAR: [u8; 32] = [0x11; 32];
+    const OWNER_ENC_SCALAR: [u8; 32] = [0x33; 32];
+    const POINTER_READ_KEY: [u8; 32] = [0x5a; 32];
+    const FRESH_SEED: [u8; 32] = [0xf0; 32];
+    const TTL_NANOS: u64 = 2_000_000_000;
+    const EOL: &str = "2099-01-01T00:00:00Z";
+
+    fn owner_identity() -> EcdsaSigner {
+        EcdsaSigner::from_scalar(&OWNER_SCALAR).expect("valid scalar")
+    }
+
+    fn owner_enc() -> X25519Secret {
+        X25519Secret::from_scalar(OWNER_ENC_SCALAR)
+    }
+
+    /// A scope root whose node id is its scope id, holding `child_scope_index`
+    /// in its write body and an owner-write-blob at the fixture's epoch, so the
+    /// owner recovers the write-scope seed that write body opens under.
+    fn scope_root(scope_id: [u8; 16], child_scope_index: Vec<ChildScopeRef>) -> OwnerRootFixture {
+        owner_root_fixture(OwnerRootSpec {
+            owner_identity: &owner_identity(),
+            owner_enc: &owner_enc().public(),
+            scope_id,
+            root_id: scope_id,
+            children: Vec::new(),
+            child_scope_index,
+            owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+        })
+    }
+
+    fn child_ref(scope_id: [u8; 16], fixture: &OwnerRootFixture) -> ChildScopeRef {
+        ChildScopeRef {
+            scope_id,
+            ipns_name: fixture.name.as_str().as_bytes().to_vec(),
+            unknown: PreservedFields::new(),
+        }
+    }
+
+    fn record_for(scope_id: &[u8; 16], head_cid_str: &str, sequence: u64) -> Vec<u8> {
+        let write_seed = kdf::write_seed(&OWNER_ROOT_WRITE_SCOPE_SEED, scope_id);
+        let signer = kdf::ipns_keypair(write_seed.as_bytes());
+        IpnsRecord::create_v2(
+            &signer,
+            format!("/ipfs/{head_cid_str}").as_bytes(),
+            sequence,
+            TTL_NANOS,
+            EOL,
+        )
+        .marshal()
+    }
+
+    /// The block store the content gateway and the API upload share, so a
+    /// published head is readable by the very next gated resolve.
+    type Blocks = Arc<Mutex<BTreeMap<String, Vec<u8>>>>;
+
+    /// One HTTP fake standing in for the content gateway and the API: block GETs
+    /// answer from `blocks`, `/content/upload` files the bytes under the CID the
+    /// caller declared, and the registry acks.
+    fn serve_plane(http: &ScriptedHttp, blocks: &Blocks) {
+        for _ in 0..64 {
+            let blocks = Arc::clone(blocks);
+            http.enqueue_derived(move |request| {
+                if request.url.contains("/content/upload") {
+                    let cid = request
+                        .headers
+                        .iter()
+                        .find(|(name, _)| name.eq_ignore_ascii_case("x-content-cid"))
+                        .map(|(_, value)| value.clone())
+                        .ok_or_else(|| SeamError::new("upload without a content CID"))?;
+                    let body = request.body.clone().unwrap_or_default();
+                    let size = body.len();
+                    blocks.lock().expect("lock").insert(cid.clone(), body);
+                    return Ok(HttpResponse {
+                        status: 200,
+                        headers: Vec::new(),
+                        body: format!(r#"{{"cid":"{cid}","size":{size}}}"#).into_bytes(),
+                    });
+                }
+                if request.url.contains("/registry/") {
+                    return Ok(HttpResponse {
+                        status: 200,
+                        headers: Vec::new(),
+                        body: Vec::new(),
+                    });
+                }
+                match blocks
+                    .lock()
+                    .expect("lock")
+                    .get(&requested_cid(&request.url))
+                {
+                    Some(block) => Ok(HttpResponse {
+                        status: 200,
+                        headers: Vec::new(),
+                        body: block.clone(),
+                    }),
+                    None => Err(SeamError::new("no such block")),
+                }
+            });
+        }
+    }
+
+    /// The seams one owner device runs the rotation edges over.
+    struct Harness<T> {
+        transport: T,
+        store: InMemoryRecordStore,
+        world: FakeWorld,
+        http: ScriptedHttp,
+        api: ApiClient<ScriptedHttp, InMemoryCredentialStore>,
+        floors: InMemoryFloorStore,
+        gateway: Gateway,
+        profile: SyncTimingProfile,
+        entropy: RefCell<SeededEntropy>,
+        enc_secret: X25519Secret,
+        identity: EcdsaVerifier,
+        blocks: Blocks,
+    }
+
+    impl<T: RecordTransport + Clone> Harness<T> {
+        fn build(make: impl FnOnce(InMemoryRecordStore) -> T) -> Self {
+            let world = FakeWorld::new();
+            let device = world.device(b"owner");
+            let http = device.http.clone();
+            let blocks: Blocks = Arc::new(Mutex::new(BTreeMap::new()));
+            serve_plane(&http, &blocks);
+            let api = ApiClient::new(
+                http.clone(),
+                device.credential_store.clone(),
+                "http://api.test",
+            );
+            let store = device.record_store.clone();
+            Self {
+                transport: make(store.clone()),
+                store,
+                world,
+                http,
+                api,
+                floors: device.floor_store.clone(),
+                gateway: Gateway {
+                    accelerator: Some(GatewaySource {
+                        base_url: "https://gw.test".into(),
+                        bearer: None,
+                    }),
+                    public_fallbacks: Vec::new(),
+                },
+                profile: SyncTimingProfile::CI,
+                entropy: RefCell::new(SeededEntropy::new(7)),
+                enc_secret: owner_enc(),
+                identity: owner_identity().verifying_key(),
+                blocks,
+            }
+        }
+
+        /// Stage `fixture`'s head block and a signed record for it at `sequence`
+        /// on every endpoint. `write_floor` seeds the scope's durable
+        /// write-epoch floor; without one the owner-write-blob never opens.
+        fn stage(&self, scope_id: [u8; 16], fixture: &OwnerRootFixture, write_floor: Option<u64>) {
+            self.blocks
+                .lock()
+                .expect("lock")
+                .insert(fixture.head_cid_str.clone(), fixture.head_block.clone());
+            let record = record_for(&scope_id, &fixture.head_cid_str, 1);
+            for endpoint in self.store.endpoints() {
+                self.store
+                    .seed_record(&endpoint, fixture.name.as_str(), record.clone());
+            }
+            if let Some(epoch) = write_floor {
+                block_on(floor::advance_write_epoch_on_sight(
+                    &self.floors,
+                    &scope_id,
+                    epoch,
+                ))
+                .expect("write floor");
+            }
+        }
+
+        fn net(
+            &self,
+        ) -> OwnerRotationNet<
+            '_,
+            T,
+            ScriptedHttp,
+            InMemoryCredentialStore,
+            InMemoryFloorStore,
+            VirtualScheduler,
+            SeededEntropy,
+        > {
+            OwnerRotationNet {
+                transport: &self.transport,
+                api: &self.api,
+                gateway: &self.gateway,
+                http: &self.http,
+                floors: &self.floors,
+                scheduler: &self.world.scheduler,
+                profile: &self.profile,
+                entropy: &self.entropy,
+                keys: OwnerRotationKeys {
+                    enc_secret: &self.enc_secret,
+                    identity: &self.identity,
+                },
+            }
+        }
+    }
+
+    impl Harness<InMemoryRecordStore> {
+        fn plain() -> Self {
+            Self::build(|store| store)
+        }
+    }
+
+    impl Harness<RacingTransport> {
+        fn racing(key: &str, winner: Vec<u8>) -> Self {
+            let key = key.to_owned();
+            Self::build(move |store| RacingTransport {
+                inner: store,
+                winner: Arc::new(Mutex::new(Some((key, winner)))),
+            })
+        }
+    }
+
+    /// The concurrent writer's record, keyed by the name it lands at.
+    type Winner = Arc<Mutex<Option<(String, Vec<u8>)>>>;
+
+    /// A transport where a concurrent writer lands a strictly-newer record the
+    /// instant our PUT goes out — the CAS race the publisher must report.
+    #[derive(Clone)]
+    struct RacingTransport {
+        inner: InMemoryRecordStore,
+        winner: Winner,
+    }
+
+    impl RecordTransport for RacingTransport {
+        fn endpoints(&self) -> Vec<EndpointId> {
+            self.inner.endpoints()
+        }
+
+        async fn get_record(
+            &self,
+            endpoint: &EndpointId,
+            routing_key: &str,
+        ) -> SeamResult<Option<Vec<u8>>> {
+            self.inner.get_record(endpoint, routing_key).await
+        }
+
+        async fn put_record(
+            &self,
+            endpoint: &EndpointId,
+            routing_key: &str,
+            record: &[u8],
+        ) -> SeamResult<()> {
+            self.inner.put_record(endpoint, routing_key, record).await?;
+            if let Some((key, winner)) = self.winner.lock().expect("lock").take() {
+                for endpoint in self.inner.endpoints() {
+                    self.inner.seed_record(&endpoint, &key, winner.clone());
+                }
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn a_descendants_adjacency_comes_from_its_own_gated_write_body() {
+        let leaf = scope_root([0xd2; 16], Vec::new());
+        let grandchild = child_ref([0xd2; 16], &leaf);
+        let child = scope_root(CHILD_SCOPE, vec![grandchild.clone()]);
+
+        let harness = Harness::plain();
+        harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
+
+        let index = block_on(
+            harness
+                .net()
+                .direct_child_index(&child_ref(CHILD_SCOPE, &child)),
+        )
+        .expect("the descendant's own index");
+        assert_eq!(index, vec![grandchild]);
+    }
+
+    /// The `scope_id` label comes from the caller's own gated parent index and is
+    /// imposed on the gate: a record published at the enumerated name but
+    /// claiming another scope is a transplant, never a silently relabelled node.
+    #[test]
+    fn a_record_claiming_another_scope_is_a_fail_closed_rejection() {
+        let child = scope_root(CHILD_SCOPE, Vec::new());
+        let harness = Harness::plain();
+        harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
+
+        let mislabelled = ChildScopeRef {
+            scope_id: [0x9e; 16],
+            ..child_ref(CHILD_SCOPE, &child)
+        };
+        assert_eq!(
+            block_on(harness.net().direct_child_index(&mislabelled)),
+            Err(ResolveFailure::Rejected),
+        );
+    }
+
+    #[test]
+    fn a_descendant_no_endpoint_serves_is_availability_not_a_trust_verdict() {
+        let child = scope_root(CHILD_SCOPE, Vec::new());
+        let harness = Harness::plain();
+        assert_eq!(
+            block_on(
+                harness
+                    .net()
+                    .direct_child_index(&child_ref(CHILD_SCOPE, &child))
+            ),
+            Err(ResolveFailure::Unavailable),
+        );
+    }
+
+    #[test]
+    fn a_non_canonical_ipns_name_is_rejected_before_any_fetch() {
+        let harness = Harness::plain();
+        let malformed = ChildScopeRef {
+            scope_id: CHILD_SCOPE,
+            ipns_name: b"not-an-ipns-name".to_vec(),
+            unknown: PreservedFields::new(),
+        };
+        assert_eq!(
+            block_on(harness.net().direct_child_index(&malformed)),
+            Err(ResolveFailure::Rejected),
+        );
+        assert!(
+            harness.http.requests().is_empty(),
+            "an unparseable name has no key to gate against, so nothing is fetched"
+        );
+    }
+
+    /// No durable write-epoch floor means the owner-write-blob never opens, so
+    /// the write body has no key — re-authorable, never a trust verdict.
+    #[test]
+    fn a_root_held_keyless_yields_no_index_and_no_rejection() {
+        let child = scope_root(CHILD_SCOPE, Vec::new());
+        let harness = Harness::plain();
+        harness.stage(CHILD_SCOPE, &child, None);
+
+        assert_eq!(
+            block_on(
+                harness
+                    .net()
+                    .direct_child_index(&child_ref(CHILD_SCOPE, &child))
+            ),
+            Err(ResolveFailure::Unavailable),
+        );
+    }
+
+    /// The record `rotate_scope` hands the publisher: `fixture`'s scope root
+    /// re-sealed at `read_epoch` under a fresh override seed.
+    fn cut(fixture: &OwnerRootFixture, scope_id: [u8; 16], read_epoch: u64) -> ResealedScopeRoot {
+        let pseudonym = Ed25519Signer::from_seed(OWNER_ROOT_PSEUDONYM_SEED);
+        let owner_enc_pub = owner_enc().public();
+        let mut entropy = SeededEntropy::new(11);
+        let section = reseal_scope_root(
+            &mut entropy,
+            &ScopeRootIdentity {
+                v: ENVELOPE_V,
+                scope_id,
+                ipns_name: fixture.name.as_str().as_bytes(),
+                owner_enc_pub: &owner_enc_pub,
+                parent_node_seed: None,
+                pseudonym_signer: &pseudonym,
+            },
+            &ResealSeeds {
+                override_seed: &FRESH_SEED,
+                read_epoch,
+                prev: Some(PrevEpochSeed {
+                    seed: &OWNER_ROOT_SCOPE_SEED,
+                    epoch: OWNER_ROOT_EPOCH,
+                }),
+                write_scope_seed: &OWNER_ROOT_WRITE_SCOPE_SEED,
+                write_epoch: OWNER_ROOT_EPOCH,
+                pointer_read_key: &POINTER_READ_KEY,
+            },
+            &CommittedSet {
+                commitment: &fixture.grant_section.commitment,
+                commitment_sig: &fixture.grant_section.commitment_sig,
+                grant_ledger: &[],
+                write_history_link: &[],
+                direct_child_scope_index: &[],
+            },
+            &[],
+        )
+        .expect("re-seal");
+        ResealedScopeRoot {
+            scope_id,
+            ipns_name: fixture.name.as_str().as_bytes().to_vec(),
+            read_epoch,
+            write_epoch: OWNER_ROOT_EPOCH,
+            section,
+        }
+    }
+
+    #[test]
+    fn a_resealed_root_lands_at_the_new_epoch_carrying_its_new_section() {
+        let root = scope_root(SCOPE, Vec::new());
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        let cut = cut(&root, SCOPE, OWNER_ROOT_EPOCH + 1);
+
+        block_on(harness.net().publish_scope_root(&cut)).expect("the cut lands");
+
+        let endpoint = &harness.store.endpoints()[0];
+        let published = harness
+            .store
+            .record_at(endpoint, root.name.as_str())
+            .expect("a record at the scope root");
+        let verified = IpnsRecord::unmarshal(&published)
+            .and_then(|record| record.verify(&root.name))
+            .expect("the published record verifies under its own name");
+        assert_eq!(
+            verified.sequence, 2,
+            "the CAS sequence advanced past the adopted floor"
+        );
+
+        let value = String::from_utf8(verified.value.clone()).expect("a utf8 record value");
+        let block = harness
+            .blocks
+            .lock()
+            .expect("lock")
+            .get(value.trim_start_matches("/ipfs/"))
+            .cloned()
+            .expect("the published head block reached the content plane");
+        let envelope = decode_envelope(&block).expect("the head decodes");
+        assert_eq!(envelope.epoch, OWNER_ROOT_EPOCH + 1);
+        assert_eq!(envelope.scope, SCOPE);
+        let section = decode_grant_section(grant_section_bytes(&envelope).expect("the marker"))
+            .expect("the section decodes");
+        assert_eq!(
+            section, cut.section,
+            "the record carries the re-sealed section verbatim"
+        );
+        let node_seed = kdf::node_seed(&FRESH_SEED, &SCOPE);
+        let read_key = *kdf::read_key(node_seed.as_bytes()).as_bytes();
+        open_read_body(&envelope, &read_key)
+            .expect("the body reopens under the freshly minted override seed");
+    }
+
+    /// The publisher takes the seed it seals under from the section's own owner
+    /// blob, so a section the owner cannot reopen is refused before anything is
+    /// signed — release-active, never a debug assertion.
+    #[test]
+    fn a_section_the_owner_cannot_reopen_is_never_signed() {
+        let root = scope_root(SCOPE, Vec::new());
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        let mut cut = cut(&root, SCOPE, OWNER_ROOT_EPOCH + 1);
+        let last = cut.section.owner_blob.ciphertext.len() - 1;
+        cut.section.owner_blob.ciphertext[last] ^= 0xff;
+
+        assert_eq!(
+            block_on(harness.net().publish_scope_root(&cut)),
+            Err(ScopeRootPublishError::NotPublished),
+        );
+        let endpoint = &harness.store.endpoints()[0];
+        assert_eq!(
+            harness.store.record_at(endpoint, root.name.as_str()),
+            Some(record_for(&SCOPE, &root.head_cid_str, 1)),
+            "the pre-rotation record still stands — nothing was published",
+        );
+    }
+
+    /// A section minted for another epoch will not open under the AAD the
+    /// envelope about to carry it claims, so the mismatch is caught before the
+    /// record is signed rather than surfacing as an unopenable published root.
+    #[test]
+    fn a_section_minted_for_another_epoch_is_never_signed() {
+        let root = scope_root(SCOPE, Vec::new());
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        let mut cut = cut(&root, SCOPE, OWNER_ROOT_EPOCH + 1);
+        cut.read_epoch = OWNER_ROOT_EPOCH + 2;
+
+        assert_eq!(
+            block_on(harness.net().publish_scope_root(&cut)),
+            Err(ScopeRootPublishError::NotPublished),
+        );
+    }
+
+    /// The eager-set walk over the production resolver: two levels of real
+    /// records, gated one by one, with completeness proved from published state
+    /// alone.
+    #[test]
+    fn the_eager_set_walk_composes_over_the_production_resolver() {
+        let grandchild = scope_root([0xd2; 16], Vec::new());
+        let grandchild_ref = child_ref([0xd2; 16], &grandchild);
+        let child = scope_root(CHILD_SCOPE, vec![grandchild_ref.clone()]);
+        let child_ref = child_ref(CHILD_SCOPE, &child);
+
+        let harness = Harness::plain();
+        harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
+        harness.stage([0xd2; 16], &grandchild, Some(OWNER_ROOT_EPOCH));
+
+        let eager_set = block_on(enumerate_eager_set(
+            SCOPE,
+            core::slice::from_ref(&child_ref),
+            &harness.net(),
+        ))
+        .expect("every reachable descendant resolved");
+        assert_eq!(
+            eager_set.into_descendants(),
+            vec![child_ref, grandchild_ref],
+            "the closure is both levels, ascending by scope id",
+        );
+    }
+
+    /// `rotate_scope` over the production publisher: the cut lands on the record
+    /// plane and only then does the durable `minReadEpoch` floor move.
+    #[test]
+    fn the_root_cut_composes_over_the_production_publisher() {
+        let root = scope_root(SCOPE, Vec::new());
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        let pseudonym = Ed25519Signer::from_seed(OWNER_ROOT_PSEUDONYM_SEED);
+        let owner_enc_pub = owner_enc().public();
+        let mut entropy = SeededEntropy::new(23);
+
+        let outcome = block_on(rotate_scope(
+            &mut entropy,
+            &harness.floors,
+            &harness.world.scheduler,
+            &harness.net(),
+            &RotateScopePlan {
+                identity: ScopeRootIdentity {
+                    v: ENVELOPE_V,
+                    scope_id: SCOPE,
+                    ipns_name: root.name.as_str().as_bytes(),
+                    owner_enc_pub: &owner_enc_pub,
+                    parent_node_seed: None,
+                    pseudonym_signer: &pseudonym,
+                },
+                committed: CommittedSet {
+                    commitment: &root.grant_section.commitment,
+                    commitment_sig: &root.grant_section.commitment_sig,
+                    grant_ledger: &[],
+                    write_history_link: &[],
+                    direct_child_scope_index: &[],
+                },
+                current_override_seed: &OWNER_ROOT_SCOPE_SEED,
+                current_read_epoch: OWNER_ROOT_EPOCH,
+                write_scope_seed: &OWNER_ROOT_WRITE_SCOPE_SEED,
+                write_epoch: OWNER_ROOT_EPOCH,
+                pointer_read_key: &POINTER_READ_KEY,
+                carried_history_links: &[],
+            },
+            || Box::pin(async {}),
+        ))
+        .expect("the root cut completes");
+
+        assert_eq!(outcome.new_read_epoch, OWNER_ROOT_EPOCH + 1);
+        assert_eq!(outcome.epoch_floor, OWNER_ROOT_EPOCH + 1);
+        let endpoint = &harness.store.endpoints()[0];
+        let published = harness
+            .store
+            .record_at(endpoint, root.name.as_str())
+            .expect("a record at the scope root");
+        assert_ne!(
+            published,
+            record_for(&SCOPE, &root.head_cid_str, 1),
+            "the pre-rotation record was replaced by the cut",
+        );
+    }
+
+    #[test]
+    fn a_concurrent_writer_at_a_higher_sequence_is_a_retryable_lost_race() {
+        let root = scope_root(SCOPE, Vec::new());
+        let winner = record_for(&SCOPE, &root.head_cid_str, 9);
+        let harness = Harness::racing(root.name.as_str(), winner);
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        let cut = cut(&root, SCOPE, OWNER_ROOT_EPOCH + 1);
+
+        assert_eq!(
+            block_on(harness.net().publish_scope_root(&cut)),
+            Err(ScopeRootPublishError::LostRace),
+            "a lost CAS race is reported, never a silent drop",
+        );
+    }
+}

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -95,6 +95,9 @@ pub struct RotationAncestry {
 
 #[derive(Default)]
 struct Ancestry {
+    /// The rotating root's own ancestor node seed, when it is itself an interior
+    /// scope root ([`RotationAncestry::under_parent_node_seed`]).
+    root: Option<([u8; 16], Zeroizing<[u8; SECRET_LEN]>)>,
     parents: BTreeMap<[u8; 16], [u8; 16]>,
     override_seeds: BTreeMap<[u8; 16], Zeroizing<[u8; SECRET_LEN]>>,
 }
@@ -112,6 +115,20 @@ impl RotationAncestry {
         ancestry
     }
 
+    /// Supply the **rotating root's own** ancestor node seed. Required whenever
+    /// the rotation is anchored at an interior scope root — a revoke or
+    /// scope-exit on a shared folder — whose record carries an ascent link the
+    /// gate verifies against a reader-derived keypair. A vault root carries no
+    /// ascent link and needs none.
+    pub fn under_parent_node_seed(
+        self,
+        scope_id: [u8; 16],
+        parent_node_seed: &[u8; SECRET_LEN],
+    ) -> Self {
+        self.inner.borrow_mut().root = Some((scope_id, Zeroizing::new(*parent_node_seed)));
+        self
+    }
+
     fn record(
         &self,
         scope_id: [u8; 16],
@@ -123,14 +140,22 @@ impl RotationAncestry {
             .override_seeds
             .insert(scope_id, Zeroizing::new(*override_seed));
         for child in child_index {
-            inner.parents.insert(child.scope_id, scope_id);
+            // First-seen wins, matching the walk's own dedup: a scope listed by
+            // two parents must gate under the same one whichever order the walk
+            // reaches it in.
+            inner.parents.entry(child.scope_id).or_insert(scope_id);
         }
     }
 
-    /// `nodeSeed(parentOverrideSeed, scope_id)`, or `None` at the rotating root
-    /// (which has no parent edge here and carries no ascent link).
+    /// `nodeSeed(parentOverrideSeed, scope_id)` — the caller-supplied seed at the
+    /// rotating root, otherwise derived from the parent this walk already gated.
     fn parent_node_seed(&self, scope_id: &[u8; 16]) -> Option<Zeroizing<[u8; SECRET_LEN]>> {
         let inner = self.inner.borrow();
+        if let Some((root, seed)) = &inner.root
+            && root == scope_id
+        {
+            return Some(seed.clone());
+        }
         let parent = inner.parents.get(scope_id)?;
         let parent_seed = inner.override_seeds.get(parent)?;
         Some(Zeroizing::new(
@@ -171,7 +196,8 @@ fn scope_name(ipns_name: &[u8]) -> Result<IpnsName, ResolveFailure> {
 /// the publisher none, so this is the only source of the seed the record must
 /// seal under — and a section that will not reopen under the owner key the
 /// adoption gate re-derives can therefore never be signed (release-active,
-/// security rule 8).
+/// security rule 8). That failure is permanent for these bytes, so it is a
+/// rejection rather than a retryable stall — the sweep must not re-run it.
 fn new_override_seed(
     enc_secret: &X25519Secret,
     record: &ResealedScopeRoot,
@@ -185,7 +211,7 @@ fn new_override_seed(
         struct_tag: STRUCT_TAG_OWNER_BLOB,
     };
     let payload = open_owner_blob(enc_secret, &owner_blob.enc, &aad, &owner_blob.ciphertext)
-        .map_err(|_| ScopeRootPublishError::NotPublished)?;
+        .map_err(|_| ScopeRootPublishError::Rejected)?;
     Ok(Zeroizing::new(*payload.override_seed()))
 }
 
@@ -301,6 +327,10 @@ where
     /// - the write epoch must not sit below the durable write floor, which the
     ///   owner-write-blob's AAD binds — below it the root publishes write-plane
     ///   dead, and floors are monotonic, so it can never be rotated back.
+    ///
+    /// Runs **after** the publish's own gated read, whose adoption advances the
+    /// read-epoch floor: measured before it, the floor comparison would miss a
+    /// cut minted below the epoch that very read just adopted.
     async fn check_publishable(
         &self,
         record: &ResealedScopeRoot,
@@ -366,7 +396,6 @@ where
     ) -> Result<(), ScopeRootPublishError> {
         let name = scope_name(&record.ipns_name).map_err(publish_verdict)?;
         let override_seed = new_override_seed(self.keys.enc_secret, record)?;
-        self.check_publishable(record).await?;
 
         // The read body and the envelope fields a republish preserves come from
         // the node's own current record, gated — the rotation carries neither.
@@ -374,6 +403,7 @@ where
             .gated_root(record.scope_id, &name)
             .await
             .map_err(publish_verdict)?;
+        self.check_publishable(record).await?;
         let write_scope_seed = current
             .write_scope_seed
             .as_deref()
@@ -1001,9 +1031,11 @@ mod tests {
         let last = cut.section.owner_blob.ciphertext.len() - 1;
         cut.section.owner_blob.ciphertext[last] ^= 0xff;
 
-        assert_eq!(
-            block_on(harness.net(&[]).publish_scope_root(&cut)),
-            Err(ScopeRootPublishError::NotPublished),
+        let outcome = block_on(harness.net(&[]).publish_scope_root(&cut));
+        assert_eq!(outcome, Err(ScopeRootPublishError::Rejected));
+        assert!(
+            !outcome.unwrap_err().is_retryable(),
+            "these bytes will never open — re-running the sweep cannot help",
         );
         let endpoint = &harness.store.endpoints()[0];
         assert_eq!(
@@ -1020,8 +1052,39 @@ mod tests {
 
         assert_eq!(
             block_on(harness.net(&[]).publish_scope_root(&cut)),
-            Err(ScopeRootPublishError::NotPublished),
+            Err(ScopeRootPublishError::Rejected),
         );
+    }
+
+    /// A revoke or scope-exit rotates an **interior** scope root, whose record
+    /// carries an ascent link — the caller supplies that root's own ancestor
+    /// node seed, and without it the gate cannot read the record to republish.
+    #[test]
+    fn an_interior_scope_root_rotates_under_its_supplied_ancestor_seed() {
+        let root = interior(CHILD_SCOPE, &OWNER_ROOT_SCOPE_SEED, Vec::new());
+        let harness = Harness::plain();
+        harness.stage(CHILD_SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        let cut = cut(&root, CHILD_SCOPE, OWNER_ROOT_EPOCH + 1);
+        let parent_node_seed = *kdf::node_seed(&OWNER_ROOT_SCOPE_SEED, &CHILD_SCOPE).as_bytes();
+
+        assert_eq!(
+            block_on(
+                harness
+                    .net_rooted(RotationAncestry::default())
+                    .publish_scope_root(&cut)
+            ),
+            Err(ScopeRootPublishError::Rejected),
+            "no ancestor seed means the gate cannot verify the ascent link",
+        );
+        block_on(
+            harness
+                .net_rooted(
+                    RotationAncestry::default()
+                        .under_parent_node_seed(CHILD_SCOPE, &parent_node_seed),
+                )
+                .publish_scope_root(&cut),
+        )
+        .expect("the interior root's cut lands under its supplied ancestor seed");
     }
 
     /// Gate stage 2's encode-side mirror: a commitment that will not verify
@@ -1055,6 +1118,32 @@ mod tests {
         assert_eq!(
             block_on(harness.net(&[]).publish_scope_root(&cut)),
             Err(ScopeRootPublishError::Rejected),
+        );
+    }
+
+    /// The gated read the publish runs first advances the durable read-epoch
+    /// floor to the record it adopts, so the stage-5 mirror must be measured
+    /// against the floor as it stands *after* that read: a cut minted from a
+    /// snapshot older than the published root would otherwise be signed below
+    /// the floor its own gate then enforces, leaving the root unadoptable.
+    #[test]
+    fn a_cut_below_the_epoch_the_gated_read_adopts_is_never_signed() {
+        let root = vault_root(SCOPE, Vec::new());
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        // Nothing has raised the read-epoch floor yet; the staged root sits at
+        // OWNER_ROOT_EPOCH and this cut was minted from a snapshot below it.
+        let stale = cut(&root, SCOPE, OWNER_ROOT_EPOCH - 1);
+
+        assert_eq!(
+            block_on(harness.net(&[]).publish_scope_root(&stale)),
+            Err(ScopeRootPublishError::Rejected),
+        );
+        let endpoint = &harness.store.endpoints()[0];
+        assert_eq!(
+            harness.store.record_at(endpoint, root.name.as_str()),
+            Some(record_for(&SCOPE, &root.head_cid_str, 1)),
+            "the pre-rotation record still stands — nothing was published",
         );
     }
 

--- a/crates/engine/src/rotation/cascade.rs
+++ b/crates/engine/src/rotation/cascade.rs
@@ -47,7 +47,7 @@
 //! Entropy enters only through [`Entropy`] and time only through [`Scheduler`];
 //! the sole impure edges are the injected [`CascadeResealResolver`] and
 //! [`ScopeRootPublisher`] (as `rotate_scope` and the sweep also carry). Real
-//! resolver wiring is #745/#746; this slice fakes it and proves the cascade in
+//! resolver wiring is #1025; this slice fakes it and proves the cascade in
 //! simulation.
 //!
 //! [`enumerate_eager_set`]: super::eager_set::enumerate_eager_set
@@ -131,14 +131,14 @@ pub struct CascadeTarget {
 /// material — the cascade's analogue of the eager-set walk's `ChildIndexResolver`
 /// and the sweep's [`SweepResolver`](super::sweep::SweepResolver). Resolve +
 /// adoption-gate + unseal live behind this trait; the real network/gate wiring is
-/// #745/#746 and tests fake it. A resolve either yields the full
+/// #1025 and tests fake it. A resolve either yields the full
 /// [`CascadeTarget`] or a fail-closed [`ResolveFailure`] — a partial or
 /// gate-failing record is never a work-list entry.
 pub trait CascadeResealResolver {
     /// Resolve `scope`'s current re-seal material, or a fail-closed
     /// [`ResolveFailure`] if its record cannot be authoritatively obtained.
     ///
-    /// # Binding contract (obligation on the real resolver, #745/#746)
+    /// # Binding contract (obligation on the real resolver, #1025)
     ///
     /// The resolver MUST gate `scope`'s record under the enumerated
     /// `scope.scope_id` and `scope.ipns_name`, and the gated record's

--- a/crates/engine/src/rotation/eager_set.rs
+++ b/crates/engine/src/rotation/eager_set.rs
@@ -151,9 +151,9 @@ impl EagerSet {
 /// The one impure edge of the walk: resolve + gate + unseal a descendant scope
 /// root's write-body and yield its `direct_child_scope_index` (its next-level
 /// adjacency). The traversal itself is pure and deterministic; only this edge
-/// touches the network and the adoption gate. The real resolve/gate/unseal
-/// wiring lands in a later slice / the facade — the walk depends only on this
-/// contract, and tests fake it.
+/// touches the network and the adoption gate. The production resolve/gate/unseal
+/// wiring is [`crate::net::rotation::OwnerRotationNet`]; the walk depends only
+/// on this contract, and tests fake it.
 pub trait ChildIndexResolver {
     /// Return `child`'s own `direct_child_scope_index`, or a fail-closed
     /// [`ResolveFailure`] if its record cannot be authoritatively obtained. An
@@ -170,8 +170,7 @@ pub trait ChildIndexResolver {
     /// `scope_id` independently of the gated parent record. The walk keys
     /// visited / dedup / rotation identity on `scope_id`, so an independently
     /// influenced `scope_id` would dedup or rotate the wrong scope key — a silent
-    /// revocation hole defeating the eager-set completeness guarantee. Enforcement
-    /// of this obligation in the real resolver-wiring slice is tracked in #745.
+    /// revocation hole defeating the eager-set completeness guarantee.
     async fn direct_child_index(
         &self,
         child: &ChildScopeRef,

--- a/crates/engine/src/rotation/mod.rs
+++ b/crates/engine/src/rotation/mod.rs
@@ -26,9 +26,11 @@
 //!   wave (root re-pointed last) with the three-channel re-point, register-first
 //!   inventory swap, and root linger. The write-plane sibling of `rotate_scope`.
 //!
-//! The read-plane seams' production implementations over the real transport live
-//! in [`crate::net::rotation`]; the write-plane [`WriteWavePublisher`] is still
-//! faked in tests (#1014).
+//! [`ChildIndexResolver`] and [`ScopeRootPublisher`] have production
+//! implementations over the real transport in [`crate::net::rotation`].
+//! [`CascadeResealResolver`] and [`SweepResolver`] are still faked in tests
+//! (#1025), as are the write-plane [`WriteSubtreeResolver`] and
+//! [`WriteWavePublisher`] (#1026).
 
 pub mod cascade;
 pub mod eager_set;

--- a/crates/engine/src/rotation/mod.rs
+++ b/crates/engine/src/rotation/mod.rs
@@ -19,14 +19,16 @@
 //!   revoke): re-key the root **and every transitively-reachable descendant scope
 //!   root** with a **fresh** override seed (`prev = Some`), threaded top-down.
 //!   This — not the sweep — completes a read revoke by locking out cached
-//!   descendant seeds. Proven in simulation; production resolver wiring is
-//!   #745/#746.
+//!   descendant seeds.
 //!
 //! - [`rotate_write`] — `rotateScopeWrite`, the owner-only write-plane rotation:
 //!   a fresh write override seed, a bumped `writeEpoch`, and a child-first name
 //!   wave (root re-pointed last) with the three-channel re-point, register-first
-//!   inventory swap, and root linger. The write-plane sibling of `rotate_scope`;
-//!   proven in simulation against faked resolve/publish seams (#745/#746).
+//!   inventory swap, and root linger. The write-plane sibling of `rotate_scope`.
+//!
+//! The read-plane seams' production implementations over the real transport live
+//! in [`crate::net::rotation`]; the write-plane [`WriteWavePublisher`] is still
+//! faked in tests (#1014).
 
 pub mod cascade;
 pub mod eager_set;

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -213,7 +213,7 @@ pub fn reseal_scope_root<E: Entropy>(
     // Fail-closed BEFORE any seal (see `ResealError::LedgerDivergesFromCommitment`
     // and the module's revocation-completeness rule). Reseal trusts each entry's
     // `recipient_enc_pk` verbatim from the committed ledger; the tag<->enc_pk
-    // binding is enforced at resolve time (#745).
+    // binding is enforced at resolve time.
     enforce_committed_ledger(committed.commitment, committed.grant_ledger)
         .map_err(|_| ResealError::LedgerDivergesFromCommitment)?;
 

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -357,7 +357,9 @@ pub fn reseal_scope_root<E: Entropy>(
         });
     }
 
-    // --- Write-body: sealed under the write key at the write epoch. ---
+    // --- Write-body: sealed under the write key at the write epoch; its
+    // structure signature binds the read epoch, per the owner-write-blob's
+    // dual-epoch rationale above. ---
     let write_body = {
         let wb = WriteBody {
             grant_ledger: committed.grant_ledger.to_vec(),
@@ -377,7 +379,7 @@ pub fn reseal_scope_root<E: Entropy>(
         );
         let sealed = seal(write_key.as_bytes(), &nonce, &ctx, &plaintext);
         plaintext.zeroize();
-        let signature = sign_over(STRUCT_TAG_WRITE_BODY, None, &sealed, seeds.write_epoch);
+        let signature = sign_over(STRUCT_TAG_WRITE_BODY, None, &sealed, read_epoch);
         SignedSealed {
             sealed,
             signature,

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -221,12 +221,17 @@ pub fn reseal_scope_root<E: Entropy>(
     let read_epoch = seeds.read_epoch;
     let signer = identity.pseudonym_signer;
 
-    let sign_over = |struct_tag: u8,
-                     recipient_tag: Option<[u8; SECRET_LEN]>,
-                     bytes: &[u8],
-                     epoch| {
-        let input =
-            StructureSigInput::over_ciphertext(scope_id, epoch, struct_tag, recipient_tag, bytes);
+    // Every structure signature binds the READ epoch, whatever epoch its own AAD
+    // seals under: the gate recomputes each preimage from the authenticated
+    // envelope, whose epoch tag is the read epoch (gate/adoption.rs stage 3).
+    let sign_over = |struct_tag: u8, recipient_tag: Option<[u8; SECRET_LEN]>, bytes: &[u8]| {
+        let input = StructureSigInput::over_ciphertext(
+            scope_id,
+            read_epoch,
+            struct_tag,
+            recipient_tag,
+            bytes,
+        );
         sign_structure(signer, &input).to_bytes()
     };
 
@@ -254,12 +259,7 @@ pub fn reseal_scope_root<E: Entropy>(
         let sealed = seal_grant_blob(&recipient_pub, &ephemeral, &ctx, &payload);
         ephemeral.zeroize();
         let sealed = sealed.map_err(ResealError::Encode)?;
-        let signature = sign_over(
-            STRUCT_TAG_GRANT_BLOB,
-            Some(entry.tag),
-            &sealed.ciphertext,
-            read_epoch,
-        );
+        let signature = sign_over(STRUCT_TAG_GRANT_BLOB, Some(entry.tag), &sealed.ciphertext);
         grant_blobs.push(SignedGrantBlob {
             tag: entry.tag,
             enc: sealed.enc,
@@ -278,7 +278,7 @@ pub fn reseal_scope_root<E: Entropy>(
         let sealed = seal_owner_blob(identity.owner_enc_pub, &ephemeral, &ctx, &payload);
         ephemeral.zeroize();
         let sealed = sealed.map_err(ResealError::Encode)?;
-        let signature = sign_over(STRUCT_TAG_OWNER_BLOB, None, &sealed.ciphertext, read_epoch);
+        let signature = sign_over(STRUCT_TAG_OWNER_BLOB, None, &sealed.ciphertext);
         SignedOwnerBlob {
             enc: sealed.enc,
             ciphertext: sealed.ciphertext,
@@ -289,9 +289,7 @@ pub fn reseal_scope_root<E: Entropy>(
 
     // --- Owner-write-blob: the write-scope seed wrapped to the owner (the
     // write-plane mirror of the owner blob), authored wherever the write-body
-    // lives. Its AAD binds the write epoch (the write plane's own clock); its
-    // structure signature binds the read epoch, like every structure the gate
-    // authenticates from the envelope. ---
+    // lives. Its AAD binds the write epoch — the write plane's own clock. ---
     let owner_write_blob = {
         let payload = OwnerWriteBlobPayload::new(*seeds.write_scope_seed, seeds.write_epoch);
         let mut ephemeral = fill::<32, E>(entropy)?;
@@ -304,12 +302,7 @@ pub fn reseal_scope_root<E: Entropy>(
         let sealed = seal_owner_write_blob(identity.owner_enc_pub, &ephemeral, &ctx, &payload);
         ephemeral.zeroize();
         let sealed = sealed.map_err(ResealError::Encode)?;
-        let signature = sign_over(
-            STRUCT_TAG_OWNER_WRITE_BLOB,
-            None,
-            &sealed.ciphertext,
-            read_epoch,
-        );
+        let signature = sign_over(STRUCT_TAG_OWNER_WRITE_BLOB, None, &sealed.ciphertext);
         Some(SignedOwnerWriteBlob {
             enc: sealed.enc,
             ciphertext: sealed.ciphertext,
@@ -328,7 +321,7 @@ pub fn reseal_scope_root<E: Entropy>(
             let link = seal_ascent_link(parent_node_seed, &ephemeral, &ctx, &payload);
             ephemeral.zeroize();
             let link = link.map_err(ResealError::Encode)?;
-            let signature = sign_over(STRUCT_TAG_ASCENT_LINK, None, &link.ciphertext, read_epoch);
+            let signature = sign_over(STRUCT_TAG_ASCENT_LINK, None, &link.ciphertext);
             Some(SignedAscentLink {
                 ascent_public: link.ascent_public,
                 enc: link.enc,
@@ -349,7 +342,7 @@ pub fn reseal_scope_root<E: Entropy>(
         let payload = HistoryLinkPayload::new(*prev.seed, prev.epoch);
         let sealed = seal_history_link(structure_key.as_bytes(), &nonce, &ctx, &payload)
             .map_err(ResealError::Encode)?;
-        let signature = sign_over(STRUCT_TAG_HISTORY_LINK, None, &sealed, read_epoch);
+        let signature = sign_over(STRUCT_TAG_HISTORY_LINK, None, &sealed);
         history_links.push(SignedSealed {
             sealed,
             signature,
@@ -357,9 +350,7 @@ pub fn reseal_scope_root<E: Entropy>(
         });
     }
 
-    // --- Write-body: sealed under the write key at the write epoch; its
-    // structure signature binds the read epoch, per the owner-write-blob's
-    // dual-epoch rationale above. ---
+    // --- Write-body: sealed under the write key at the write epoch. ---
     let write_body = {
         let wb = WriteBody {
             grant_ledger: committed.grant_ledger.to_vec(),
@@ -379,7 +370,7 @@ pub fn reseal_scope_root<E: Entropy>(
         );
         let sealed = seal(write_key.as_bytes(), &nonce, &ctx, &plaintext);
         plaintext.zeroize();
-        let signature = sign_over(STRUCT_TAG_WRITE_BODY, None, &sealed, read_epoch);
+        let signature = sign_over(STRUCT_TAG_WRITE_BODY, None, &sealed);
         SignedSealed {
             sealed,
             signature,

--- a/crates/engine/src/rotation/rotate.rs
+++ b/crates/engine/src/rotation/rotate.rs
@@ -47,8 +47,9 @@ use crate::seams::{BoxedTask, FloorStore, Scheduler, SeamError};
 /// A fully re-sealed scope-root record handed to the [`ScopeRootPublisher`]: its
 /// identity, the epochs it publishes at, and the signed grant section. Assembling
 /// the envelope bytes (read-body re-seal + IPNS record signing) and moving them
-/// CAS over the content plane + `/routing/v1` transport is the publisher's job —
-/// the network wiring deferred to #745/#746, faked in this slice's tests.
+/// CAS over the content plane + `/routing/v1` transport is the publisher's job.
+/// It carries no seed: the publisher recovers the freshly minted override seed
+/// from `section`'s own owner blob, so this type is not a key-material carrier.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResealedScopeRoot {
     /// The scope-root node id (== scope id).
@@ -90,9 +91,10 @@ impl std::error::Error for ScopeRootPublishError {}
 /// The one impure edge of `rotate_scope` besides the seams, mirroring the
 /// eager-set walk's `ChildIndexResolver`: the traversal/composition is pure and
 /// deterministic, and only this edge touches the content plane and the
-/// `/routing/v1` transport. The real implementation wraps the content-plane block
-/// store, register-first, and [`net::publish`](crate::net::publish) CAS (#745/#746);
-/// this slice's tests fake it.
+/// `/routing/v1` transport. The production implementation
+/// ([`crate::net::rotation::OwnerRotationNet`]) wraps the content-plane block
+/// store, register-first, and [`net::publish`](crate::net::publish) CAS; tests
+/// fake it.
 pub trait ScopeRootPublisher {
     /// Register-first CAS-publish `record` at its scope root's `ipnsName`. `Ok`
     /// means the record is durably the freshest at the name; `Err` means nothing

--- a/crates/engine/src/rotation/rotate.rs
+++ b/crates/engine/src/rotation/rotate.rs
@@ -64,8 +64,8 @@ pub struct ResealedScopeRoot {
     pub section: GrantSection,
 }
 
-/// Why a scope-root publish did not durably land as the freshest record. Both
-/// variants mean the rotation must not advance its floor — nothing was cut.
+/// Why a scope-root publish did not durably land as the freshest record. Every
+/// variant means the rotation must not advance its floor — nothing was cut.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScopeRootPublishError {
     /// Register-first or the record PUT failed; nothing durable landed. Retryable.
@@ -73,6 +73,19 @@ pub enum ScopeRootPublishError {
     /// A concurrent writer's record at a higher sequence won the CAS race; the
     /// caller re-resolves and rebases before retrying.
     LostRace,
+    /// The scope root the publish had to read first failed the adoption gate — a
+    /// fail-closed trust violation, never staleness (AGENTS.md rule 6). Kept
+    /// distinct from [`Self::NotPublished`] so a forged or transplanted record
+    /// is never retried as if it were a flaky endpoint.
+    Rejected,
+}
+
+impl ScopeRootPublishError {
+    /// Whether re-running the publish could clear this: an availability stall or
+    /// a lost race, but never a trust rejection.
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, Self::NotPublished | Self::LostRace)
+    }
 }
 
 impl core::fmt::Display for ScopeRootPublishError {
@@ -80,6 +93,9 @@ impl core::fmt::Display for ScopeRootPublishError {
         match self {
             ScopeRootPublishError::NotPublished => f.write_str("scope-root record not published"),
             ScopeRootPublishError::LostRace => f.write_str("scope-root publish lost the CAS race"),
+            ScopeRootPublishError::Rejected => {
+                f.write_str("scope-root record rejected by adoption gate")
+            }
         }
     }
 }

--- a/crates/engine/src/rotation/rotate_write.rs
+++ b/crates/engine/src/rotation/rotate_write.rs
@@ -36,7 +36,7 @@
 //! name and skips already-republished nodes via
 //! [`WriteWavePublisher::is_republished`]; every effect is idempotent, so it
 //! converges to the same terminal state. The fresh write scope seed is recovered
-//! from the published root — deferred #745/#746 wiring, faked here via
+//! from the published root — deferred #1026 wiring, faked here via
 //! [`RotateScopeWritePlan::resume_write_scope_seed`]. Accepted limitation: a crash
 //! after the pointer flip but before interior retirement orphans the prior run's
 //! interior old names — the fail-safe direction (leaking a registration beats
@@ -50,7 +50,7 @@
 //! [`build_repoint_object`]'s two encode-side invariants are release-active, never
 //! a `debug_assert!` (AGENTS.md rule 8). Entropy enters only through the
 //! [`Entropy`] seam; the impure edges are the injected [`WriteSubtreeResolver`] and
-//! [`WriteWavePublisher`] (network wiring is #745/#746, faked in this slice).
+//! [`WriteWavePublisher`] (network wiring is #1026, faked in this slice).
 
 use std::collections::{BTreeSet, VecDeque};
 
@@ -108,7 +108,7 @@ const REPOINT_CHANNELS: [RepointChannel; 3] = [
 /// One node re-published at its freshly derived name — the record the publisher
 /// CAS-installs. Assembling the record bytes (read-body carried verbatim, write-
 /// body re-sealed at the new write epoch for the root) and IPNS-signing them under
-/// the node's fresh write keypair is the deferred #745/#746 wiring; this slice
+/// the node's fresh write keypair is the deferred #1026 wiring; this slice
 /// fakes the publish and carries only the routing identity.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RepublishedNode {
@@ -124,7 +124,7 @@ pub struct RepublishedNode {
 
 /// Resolve the write scope's subtree from published records — the read edge, the
 /// analogue of the cascade's `CascadeResealResolver`. Resolve + adoption-gate +
-/// unseal live behind this trait; the real network/gate wiring is #745/#746 and
+/// unseal live behind this trait; the real network/gate wiring is #1026 and
 /// tests fake it. A resolve either yields the node or a fail-closed
 /// [`ResolveFailure`].
 pub trait WriteSubtreeResolver {
@@ -137,7 +137,7 @@ pub trait WriteSubtreeResolver {
 /// The write edge of the name wave: register-first name enrollment, CAS republish,
 /// batch retire, and the three-channel re-point — the analogue of the cascade's
 /// `ScopeRootPublisher`, mapping to the API pin/name registry and `/routing/v1`
-/// transport. Real wiring is #745/#746; tests fake it.
+/// transport. Real wiring is #1026; tests fake it.
 ///
 /// Contract the orchestrator relies on and the fake honours:
 ///
@@ -220,7 +220,7 @@ pub struct RotateScopeWritePlan<'a> {
     /// On a **resumed** wave, the fresh write scope seed recovered from the
     /// published root (the write-plane history link); `None` on a fresh rotation,
     /// which mints one via the entropy seam. Recovery wiring is deferred to
-    /// #745/#746 (faked in tests); the seam boundary is
+    /// #1026 (faked in tests); the seam boundary is
     /// [`Entropy`]-vs-published-record, never in-memory carry.
     pub resume_write_scope_seed: Option<&'a [u8; SECRET_LEN]>,
 }
@@ -1050,7 +1050,7 @@ mod tests {
         let current_root = old_name_of(&SCOPE);
 
         // The seed a fresh wave WOULD mint — captured so the resume threads it back
-        // in, standing in for recovery from the published root (#745/#746).
+        // in, standing in for recovery from the published root (#1026).
         let recovered_seed = {
             let mut e = SeededEntropy::new(9);
             let mut seed = [0u8; 32];

--- a/crates/engine/src/rotation/sweep.rs
+++ b/crates/engine/src/rotation/sweep.rs
@@ -180,13 +180,14 @@ pub enum SweepError {
         /// The underlying re-seal rejection.
         error: ResealError,
     },
-    /// A re-sealed record could not be published (register-first / PUT failed);
-    /// nothing landed for that node. Availability, retryable.
+    /// A re-sealed record could not be published; nothing landed for that node.
+    /// Retryable only when the publish failure is (see
+    /// [`ScopeRootPublishError::is_retryable`]).
     Publish {
         /// The scope whose record did not land.
         scope_id: [u8; 16],
-        /// The publish failure (always [`ScopeRootPublishError::NotPublished`]; a
-        /// lost race is not an error — it drops and re-resolves).
+        /// The publish failure (never [`ScopeRootPublishError::LostRace`] — a
+        /// lost race is not an error, it drops and re-resolves).
         error: ScopeRootPublishError,
     },
 }
@@ -235,7 +236,7 @@ impl SweepError {
                 ResolveFailure::Unavailable | ResolveFailure::ConflictingChildLabel
             ),
             SweepError::Floor(_) => true,
-            SweepError::Publish { .. } => true,
+            SweepError::Publish { error, .. } => error.is_retryable(),
             SweepError::Reseal { .. } => false,
         }
     }
@@ -398,9 +399,9 @@ where
             // write, so the node is not proven converged; `run_sweep` re-resolves
             // it until a pass drops nothing.
             Err(ScopeRootPublishError::LostRace) => outcome.dropped_lost_race.push(scope_id),
-            // Nothing landed: fail-closed rather than mark the node converged. The
-            // idle-cadence driver re-runs the idempotent pass to retry.
-            Err(error @ ScopeRootPublishError::NotPublished) => {
+            // Nothing landed: fail-closed rather than mark the node converged.
+            // Whether the idle-cadence driver re-runs is `is_retryable`'s call.
+            Err(error) => {
                 return Err(SweepError::Publish { scope_id, error });
             }
         }
@@ -744,7 +745,7 @@ mod tests {
                 s.lost_race_next -= 1;
                 return Err(ScopeRootPublishError::LostRace);
             }
-            match s.fault {
+            match &s.fault {
                 None => {
                     s.current_epoch = s.current_epoch.max(record.read_epoch);
                     Ok(())
@@ -756,10 +757,8 @@ mod tests {
                     s.current_epoch = s.current_epoch.max(record.read_epoch);
                     Err(ScopeRootPublishError::LostRace)
                 }
-                // Not published: nothing landed, epoch unchanged.
-                Some(ScopeRootPublishError::NotPublished) => {
-                    Err(ScopeRootPublishError::NotPublished)
-                }
+                // Nothing landed, epoch unchanged.
+                Some(error) => Err(error.clone()),
             }
         }
     }

--- a/crates/engine/src/rotation/sweep.rs
+++ b/crates/engine/src/rotation/sweep.rs
@@ -43,7 +43,7 @@
 //! Time (the idle cadence) enters only through [`Scheduler`] and entropy only
 //! through [`Entropy`]; the sole impure edges are the injected [`SweepResolver`]
 //! and [`ScopeRootPublisher`] (CAS-publish), mirroring `rotate_scope`. The real
-//! network wiring is #745/#746 and tests fake both.
+//! network wiring is #1025 and tests fake both.
 
 use core::time::Duration;
 use std::cell::RefCell;
@@ -118,7 +118,7 @@ pub struct SweepTarget {
 /// The impure edge that resolves a scope root's current re-seal material — the
 /// sweep's analogue of the eager-set walk's [`ChildIndexResolver`] and
 /// `rotate_scope`'s [`ScopeRootPublisher`]. Resolve + adoption-gate + unseal live
-/// behind this trait; the real network/gate wiring is #745/#746 and tests fake
+/// behind this trait; the real network/gate wiring is #1025 and tests fake
 /// it. A resolve either yields the full [`SweepTarget`] or a fail-closed
 /// [`ResolveFailure`] — a partial or gate-failing record is never a work-list
 /// entry.
@@ -129,9 +129,9 @@ pub trait SweepResolver {
     /// One resolve returns the whole [`SweepTarget`] — enumeration/lag fields
     /// *and* the heavy re-seal material. Splitting it into a light enumeration
     /// edge plus a heavy re-seal edge fetched only for lagging nodes is a
-    /// designed-for optimization for #745/#746, not a correctness requirement.
+    /// designed-for optimization for #1025, not a correctness requirement.
     ///
-    /// # Binding contract (obligation on the real resolver, #745/#746)
+    /// # Binding contract (obligation on the real resolver, #1025)
     ///
     /// The same edge discipline [`ChildIndexResolver`] carries applies: gate
     /// `scope`'s record under the enumerated `scope.scope_id`/`scope.ipns_name`,

--- a/crates/engine/src/testkit/mod.rs
+++ b/crates/engine/src/testkit/mod.rs
@@ -26,7 +26,7 @@ pub use content::{block_store, frame_version, frame_version_with, gateway, reque
 pub use entropy::SeededEntropy;
 pub use executor::block_on;
 pub use owner_root::{
-    OWNER_ROOT_EPOCH, OWNER_ROOT_SCOPE_SEED, OWNER_ROOT_WRITE_SCOPE_SEED, OwnerRootFixture,
-    OwnerRootSpec, owner_root_fixture,
+    OWNER_ROOT_EPOCH, OWNER_ROOT_PSEUDONYM_SEED, OWNER_ROOT_SCOPE_SEED,
+    OWNER_ROOT_WRITE_SCOPE_SEED, OwnerRootFixture, OwnerRootSpec, owner_root_fixture,
 };
 pub use world::{FakeDevice, FakeSeamTypes, FakeWorld};

--- a/crates/engine/src/testkit/owner_root.rs
+++ b/crates/engine/src/testkit/owner_root.rs
@@ -43,12 +43,12 @@ const EPH_ASCENT: [u8; 32] = [5u8; 32];
 
 /// The inputs that diverge between owner-root fixtures.
 ///
-/// Nonces and HPKE ephemerals are fixed, so the two varying plaintexts must be
-/// kept apart on independent axes: the read body's key comes from `root_id`
-/// alone, so specs with differing `children` or `child_scope_index` need
-/// differing `root_id`; the owner-write-blob's HPKE key comes from `owner_enc`
-/// alone, so specs with differing `owner_write_blob_epoch` need differing
-/// `owner_enc`.
+/// Nonces and HPKE ephemerals are fixed, so every varying plaintext must sit on
+/// its own key axis: the read body's key and the write body's key both come
+/// from `root_id` alone, so specs with differing `children` or
+/// `child_scope_index` need differing `root_id`; the owner-write-blob's HPKE key
+/// comes from `owner_enc` alone, so specs with differing `owner_write_blob_epoch`
+/// need differing `owner_enc`.
 pub struct OwnerRootSpec<'a> {
     /// Signs the grant-set commitment; its verifying key is the owner identity
     /// the adoption gate checks against.

--- a/crates/engine/src/testkit/owner_root.rs
+++ b/crates/engine/src/testkit/owner_root.rs
@@ -10,11 +10,12 @@ use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
     AadContext, ChildRef, ChildScopeRef, Envelope, GrantSection, GrantSetCommitment,
-    OverrideSeedPayload, OwnerWriteBlobPayload, PreservedFields, ReadBody, STRUCT_TAG_OWNER_BLOB,
-    STRUCT_TAG_OWNER_WRITE_BLOB, STRUCT_TAG_WRITE_BODY, SignedOwnerBlob, SignedOwnerWriteBlob,
-    SignedSealed, StructureSigInput, WriteBody, encode_envelope, encode_grant_section,
-    encode_write_body, seal, seal_owner_blob, seal_owner_write_blob, seal_read_body,
-    set_grant_section, sign_grant_set, sign_structure,
+    OverrideSeedPayload, OwnerWriteBlobPayload, PreservedFields, ReadBody, STRUCT_TAG_ASCENT_LINK,
+    STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB, STRUCT_TAG_WRITE_BODY, SignedAscentLink,
+    SignedOwnerBlob, SignedOwnerWriteBlob, SignedSealed, StructureSigInput, WriteBody,
+    encode_envelope, encode_grant_section, encode_write_body, seal, seal_ascent_link,
+    seal_owner_blob, seal_owner_write_blob, seal_read_body, set_grant_section, sign_grant_set,
+    sign_structure,
 };
 use cipherbox_core::suite::ecdsa::EcdsaSigner;
 use cipherbox_core::suite::ed25519::Ed25519Signer;
@@ -38,6 +39,7 @@ const NONCE_READ_BODY: [u8; 24] = [11u8; 24];
 const NONCE_WRITE_BODY: [u8; 24] = [22u8; 24];
 const EPH_OWNER: [u8; 32] = [3u8; 32];
 const EPH_OWNER_WRITE: [u8; 32] = [4u8; 32];
+const EPH_ASCENT: [u8; 32] = [5u8; 32];
 
 /// The inputs that diverge between owner-root fixtures.
 ///
@@ -62,6 +64,9 @@ pub struct OwnerRootSpec<'a> {
     /// The write-body's direct-child-scope index — the eager-set adjacency a
     /// rotation walk reads out of this root.
     pub child_scope_index: Vec<ChildScopeRef>,
+    /// `Some(nodeSeed(parentOverrideSeed, scope_id))` authors the ascent link
+    /// every interior scope root carries; `None` is a vault root.
+    pub parent_node_seed: Option<[u8; 32]>,
     /// `Some(epoch)` authors an owner-write-blob whose AAD binds that **write**
     /// epoch (its structure signature still binds the read epoch — mirrors
     /// reseal); `None` leaves the root held keyless.
@@ -91,6 +96,7 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         root_id,
         children,
         child_scope_index,
+        parent_node_seed,
         owner_write_blob_epoch,
     } = spec;
     let owner_pseudonym = Ed25519Signer::from_seed(OWNER_ROOT_PSEUDONYM_SEED);
@@ -163,6 +169,25 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         }
     });
 
+    // Ascent link — the marker of an interior scope root: the override seed
+    // sealed to the keypair its parent's node seed derives.
+    let ascent_link = parent_node_seed.map(|parent_node_seed| {
+        let link = seal_ascent_link(
+            &parent_node_seed,
+            &EPH_ASCENT,
+            &aad(OWNER_ROOT_EPOCH, STRUCT_TAG_ASCENT_LINK),
+            &OverrideSeedPayload::new(OWNER_ROOT_SCOPE_SEED, OWNER_ROOT_EPOCH),
+        )
+        .unwrap();
+        SignedAscentLink {
+            signature: sign(STRUCT_TAG_ASCENT_LINK, &link.ciphertext),
+            ascent_public: link.ascent_public,
+            enc: link.enc,
+            ciphertext: link.ciphertext,
+            unknown: PreservedFields::new(),
+        }
+    });
+
     let commitment = GrantSetCommitment {
         ipns_name: name.as_str().as_bytes().to_vec(),
         owner_pseudonym_pk: owner_pseudonym.verifying_key().to_bytes(),
@@ -178,7 +203,7 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         grant_blobs: Vec::new(),
         owner_blob,
         owner_write_blob,
-        ascent_link: None,
+        ascent_link,
         history_links: Vec::new(),
         write_body,
         unknown: PreservedFields::new(),

--- a/crates/engine/src/testkit/owner_root.rs
+++ b/crates/engine/src/testkit/owner_root.rs
@@ -9,8 +9,8 @@ use cipherbox_core::content::{compute_cid, encode_content_cid_str};
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
-    AadContext, ChildRef, Envelope, GrantSection, GrantSetCommitment, OverrideSeedPayload,
-    OwnerWriteBlobPayload, PreservedFields, ReadBody, STRUCT_TAG_OWNER_BLOB,
+    AadContext, ChildRef, ChildScopeRef, Envelope, GrantSection, GrantSetCommitment,
+    OverrideSeedPayload, OwnerWriteBlobPayload, PreservedFields, ReadBody, STRUCT_TAG_OWNER_BLOB,
     STRUCT_TAG_OWNER_WRITE_BLOB, STRUCT_TAG_WRITE_BODY, SignedOwnerBlob, SignedOwnerWriteBlob,
     SignedSealed, StructureSigInput, WriteBody, encode_envelope, encode_grant_section,
     encode_write_body, seal, seal_owner_blob, seal_owner_write_blob, seal_read_body,
@@ -29,9 +29,11 @@ pub const OWNER_ROOT_SCOPE_SEED: [u8; 32] = [0x66; 32];
 pub const OWNER_ROOT_WRITE_SCOPE_SEED: [u8; 32] = [0x77; 32];
 /// The read epoch every structure in the fixture is authored at.
 pub const OWNER_ROOT_EPOCH: u64 = 1;
+/// The seed of the writer pseudonym the fixture detach-signs every structure
+/// with — the key a re-seal of this root must sign under to stay committed.
+pub const OWNER_ROOT_PSEUDONYM_SEED: [u8; 32] = [0x22; 32];
 
 const V: u64 = 1;
-const PSEUDONYM_SEED: [u8; 32] = [0x22; 32];
 const NONCE_READ_BODY: [u8; 24] = [11u8; 24];
 const NONCE_WRITE_BODY: [u8; 24] = [22u8; 24];
 const EPH_OWNER: [u8; 32] = [3u8; 32];
@@ -41,9 +43,10 @@ const EPH_OWNER_WRITE: [u8; 32] = [4u8; 32];
 ///
 /// Nonces and HPKE ephemerals are fixed, so the two varying plaintexts must be
 /// kept apart on independent axes: the read body's key comes from `root_id`
-/// alone, so specs with differing `children` need differing `root_id`; the
-/// owner-write-blob's HPKE key comes from `owner_enc` alone, so specs with
-/// differing `owner_write_blob_epoch` need differing `owner_enc`.
+/// alone, so specs with differing `children` or `child_scope_index` need
+/// differing `root_id`; the owner-write-blob's HPKE key comes from `owner_enc`
+/// alone, so specs with differing `owner_write_blob_epoch` need differing
+/// `owner_enc`.
 pub struct OwnerRootSpec<'a> {
     /// Signs the grant-set commitment; its verifying key is the owner identity
     /// the adoption gate checks against.
@@ -56,6 +59,9 @@ pub struct OwnerRootSpec<'a> {
     pub root_id: [u8; 16],
     /// The root folder's children.
     pub children: Vec<ChildRef>,
+    /// The write-body's direct-child-scope index — the eager-set adjacency a
+    /// rotation walk reads out of this root.
+    pub child_scope_index: Vec<ChildScopeRef>,
     /// `Some(epoch)` authors an owner-write-blob whose AAD binds that **write**
     /// epoch (its structure signature still binds the read epoch — mirrors
     /// reseal); `None` leaves the root held keyless.
@@ -84,9 +90,10 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         scope_id,
         root_id,
         children,
+        child_scope_index,
         owner_write_blob_epoch,
     } = spec;
-    let owner_pseudonym = Ed25519Signer::from_seed(PSEUDONYM_SEED);
+    let owner_pseudonym = Ed25519Signer::from_seed(OWNER_ROOT_PSEUDONYM_SEED);
 
     let node_seed = kdf::node_seed(&OWNER_ROOT_SCOPE_SEED, &root_id);
     let read_key = *kdf::read_key(node_seed.as_bytes()).as_bytes();
@@ -129,7 +136,7 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         &encode_write_body(&WriteBody {
             grant_ledger: Vec::new(),
             write_history_link: Vec::new(),
-            direct_child_scope_index: Vec::new(),
+            direct_child_scope_index: child_scope_index,
             unknown: PreservedFields::new(),
         })
         .unwrap(),

--- a/crates/engine/tests/adoption_gate.rs
+++ b/crates/engine/tests/adoption_gate.rs
@@ -609,7 +609,7 @@ fn run_matrix_case(name: &str) -> Result<Adopted, GateError> {
         owner_identity: &fx.owner_identity_verifier,
         scope_id: fx.scope_id,
         read_key: &fx.read_key,
-        parent_node_seed: reader_parent_seed,
+        parent_node_seed: reader_parent_seed.as_ref(),
         seed_blob: Some(fx.owner_seed_blob(tamper_seed_blob)),
     };
     // The matrix asserts only the adoption verdict.
@@ -1170,7 +1170,8 @@ fn ascent_authority_is_reader_derived_not_candidate_supplied() {
     let mut candidate = fx.candidate(1);
     candidate.grant_section.ascent_link = Some(fx.ascent_link_under(&[0xAB; 32]));
     let mut reader = fx.reader();
-    reader.parent_node_seed = Some([0xCD; 32]);
+    let wrong_seed = [0xCD; 32];
+    reader.parent_node_seed = Some(&wrong_seed);
     let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();
     let rej = err.rejection().unwrap();
     assert_eq!(rej.stage, GateStage::GrantSection);
@@ -1202,7 +1203,7 @@ fn ascent_adopts_when_reader_seed_matches_sealed_link() {
     let mut candidate = fx.candidate(1);
     candidate.grant_section.ascent_link = Some(fx.ascent_link_under(&parent_seed));
     let mut reader = fx.reader();
-    reader.parent_node_seed = Some(parent_seed);
+    reader.parent_node_seed = Some(&parent_seed);
     let (adopted, _) = block_on(adopt(&floors, &reader, &candidate)).expect("valid ascent adopts");
     assert_eq!(adopted.sequence, 1);
 }
@@ -1226,7 +1227,7 @@ fn ascent_link_aad_must_bind_to_the_envelope() {
     let mut candidate = fx.candidate(1);
     candidate.grant_section.ascent_link = Some(fx.ascent_link_under_aad(&parent_seed, foreign_aad));
     let mut reader = fx.reader();
-    reader.parent_node_seed = Some(parent_seed);
+    reader.parent_node_seed = Some(&parent_seed);
     let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();
     let rej = err.rejection().unwrap();
     assert_eq!(rej.stage, GateStage::GrantSection);
@@ -1246,7 +1247,7 @@ fn ascent_link_rogue_seed_fails_read_key_cross_check() {
     candidate.grant_section.ascent_link =
         Some(fx.ascent_link_full(&parent_seed, fx.ascent_aad(), rogue));
     let mut reader = fx.reader();
-    reader.parent_node_seed = Some(parent_seed);
+    reader.parent_node_seed = Some(&parent_seed);
     let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();
     let rej = err.rejection().unwrap();
     assert_eq!(rej.stage, GateStage::GrantSection);
@@ -1266,7 +1267,7 @@ fn ascent_link_stale_epoch_payload_rejected() {
     candidate.grant_section.ascent_link =
         Some(fx.ascent_link_full(&parent_seed, fx.ascent_aad(), stale));
     let mut reader = fx.reader();
-    reader.parent_node_seed = Some(parent_seed);
+    reader.parent_node_seed = Some(&parent_seed);
     let err = block_on(adopt(&floors, &reader, &candidate)).unwrap_err();
     let rej = err.rejection().unwrap();
     assert_eq!(rej.stage, GateStage::GrantSection);

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -294,6 +294,7 @@ fn seed_account(world: &FakeWorld, blocks: &Blocks) -> IpnsName {
         scope_id: SCOPE,
         root_id: ROOT.0,
         children: Vec::new(),
+        child_scope_index: Vec::new(),
         // At the read epoch, so the cold-seeded write floor opens the
         // owner-write-blob and the owner recovers its scope write seed — the
         // seed the drain derives every new node's name and signer from.
@@ -4783,6 +4784,7 @@ fn concurrent_root_add(records: &InMemoryRecordStore, blocks: &Blocks, extra: Ch
         scope_id: SCOPE,
         root_id: ROOT.0,
         children,
+        child_scope_index: Vec::new(),
         owner_write_blob_epoch: Some(EPOCH),
     });
     blocks.put(fixture.head_block.clone());

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -295,6 +295,7 @@ fn seed_account(world: &FakeWorld, blocks: &Blocks) -> IpnsName {
         root_id: ROOT.0,
         children: Vec::new(),
         child_scope_index: Vec::new(),
+        parent_node_seed: None,
         // At the read epoch, so the cold-seeded write floor opens the
         // owner-write-blob and the owner recovers its scope write seed — the
         // seed the drain derives every new node's name and signer from.
@@ -4785,6 +4786,7 @@ fn concurrent_root_add(records: &InMemoryRecordStore, blocks: &Blocks, extra: Ch
         root_id: ROOT.0,
         children,
         child_scope_index: Vec::new(),
+        parent_node_seed: None,
         owner_write_blob_epoch: Some(EPOCH),
     });
     blocks.put(fixture.head_block.clone());


### PR DESCRIPTION
Closes #1014

Part of #635

## What lands

The owner arm of the two **read-plane** rotation seams, wired over the real net plane in `crates/engine/src/net/rotation.rs`:

- **`ChildIndexResolver`** — fan-out GET at the enumerated `ipnsName`, adoption gate under the caller's trusted `scope_id`, then unseal the scope root's own write body and hand back its `direct_child_scope_index`. The eager-set walk's only impure edge.
- **`ScopeRootPublisher`** — recover the freshly minted override seed from the re-sealed section's own owner blob, take the read body and carried envelope fields from the node's own gated current record, author the scope-root envelope at the new read epoch, preflight, and register-first CAS-publish through `net::publish_record`. `LostRace`, `Rejected` and `NotPublished` are distinct outcomes; nothing is silently dropped.

`RotationAncestry` carries the ancestor node seeds those gated reads need. Every interior scope root publishes an ascent link, and the gate derives the expected ascent keypair from the **reader's** ancestor seed rather than from the record — so a walk gates each descendant under the seed its own gate-passing parent published, and the rotating root's seed is supplied by the caller when the rotation is anchored at an interior scope root.

Supporting changes:

- `net/author.rs` gains `author_scope_root_with_section` — the re-seal path installs a freshly assembled section rather than carrying one verbatim, and the same two release-active checks the gate's stages 2 and 5 make on arrival run on the result.
- `net/adopter.rs` exposes `adopt_root`, returning the gate pass **plus** the `Candidate` it authenticated, and accepts the reader's ancestor node seed. Trust assembly keeps one home rather than growing a parallel one.
- The test kit's owner-root fixture can carry a direct-child-scope index and an ascent link, so a test can exercise a real interior scope root.
- The stale `#745`/`#746` pointers are retired — both closed 2026-07-23. Seams this slice leaves faked now name the issues that own them.

## Bugs the review gates caught, and the fixes

Three of these were latent because the seams were faked; wiring the real publisher is what would have made them fire.

1. **A published scope root its own gate always rejects.** `reseal_scope_root` signed the write body's detached structure signature at the **write** epoch, while the gate recomputes every structure preimage at the **read** epoch. A read rotation moves the two apart by construction, so the first production revocation would have signed a permanently unadoptable root. Fixed, and the signing closure no longer takes an epoch at all, so the invariant is structural. Covered by a test that re-adopts a published cut through the real gate.
2. **A stale cut published below the floor.** The encode-side floor mirror ran *before* the gated read — but a gate pass raises the read-epoch floor to the adopted record's epoch, so the check measured against a floor the next line then lifted above it. Moved after the read.
3. **Interior scope roots could never be gated.** The adopter hard-coded `parent_node_seed: None`, which the gate treats as a fail-closed ascent-link mismatch. Every descendant in a real eager set carries an ascent link, so the resolver could not have resolved one. Fixed by `RotationAncestry`.
4. A gate rejection on the record a publish must read first is now a non-retryable `Rejected`, not a retryable transport failure — a forged record must not be retried like a flaky endpoint.
5. The outgoing commitment signature is verified, and a cut below either durable floor refused, release-active, before anything is signed.
6. A diamond descendant gates under its first-seen parent, matching the walk's own dedup, so the outcome is order-independent. The ancestor node seed reaches the gate as a borrow, keeping the adopter its single terminal owner.

## Scope cut — what is NOT here

The issue named four seams. Two are deferred, because they are **not** wiring:

- **`SweepResolver` → #1025.** The sweep converges records whose epoch is *below* their durable read-epoch floor, and `gate::floor::check` rejects exactly those. A production resolver cannot obtain its own work-list through the gate as it stands, and skipping the floor stages would let a forgery-window writer have the sweep republish a revoked grant set — a silent revocation hole. That needs a decision about what authenticates a below-floor record under repair.
- **`WriteWavePublisher` → #1026.** `RepublishedNode` carries only routing identity. Authoring the record at the fresh name also needs the node's read body, its read key, and its predecessor name; the wave holds all three and hands none over. That is a seam-shape change to a landed primitive, not a net-plane impl.

Also out of scope by design, per the issue: facade command arms (#1016), the sweep Scheduler job (#1017), scope-exit trigger consumption (#1018), the write-revoke/downgrade trigger (#1019), discovered-link-expiry (#1020), invites (#1015).

## Tests

18 tests in `net::rotation`, against the real seam shapes over `FakeWorld` — real core-signed IPNS records, the real adoption gate, the real publish pipeline. Highlights:

- a descendant's adjacency comes from its own gated write body, through a real ascent link
- a descendant off the ancestry, and a record claiming another scope, are fail-closed rejections
- an unserved descendant and a keyless root are availability, not trust verdicts
- a published cut re-adopts through this build's own gate
- a section the owner cannot reopen, one minted for another epoch, one whose commitment will not verify, and one below either durable floor are never signed
- a gate-rejected current record is not laundered into a retry
- a concurrent writer at a higher sequence is a retryable lost race
- an interior scope root rotates under its supplied ancestor seed
- `enumerate_eager_set` and `rotate_scope` compose over the production impls


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added production support for rotating and publishing owner scope roots, including descendant scopes and ancestry-aware adoption.
  * Added grant-section support for authoring scope roots.
  * Added validation for scope labels, commitments, epochs, and adoption trust requirements.
* **Bug Fixes**
  * Improved handling of publish races, unavailable data, stale epochs, and invalid records.
  * Rejected untrusted records without retrying them.
* **Documentation**
  * Updated rotation and publishing guidance to reflect the production workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->