### PR TITLE
docs: state seam wiring status instead of naming tracking issues

### DIFF
--- a/crates/engine/src/rotation/cascade.rs
+++ b/crates/engine/src/rotation/cascade.rs
@@ -47,7 +47,7 @@
 //! Entropy enters only through [`Entropy`] and time only through [`Scheduler`];
 //! the sole impure edges are the injected [`CascadeResealResolver`] and
 //! [`ScopeRootPublisher`] (as `rotate_scope` and the sweep also carry). Real
-//! resolver wiring is #1025; this slice fakes it and proves the cascade in
+//! resolver wiring is not landed; this slice fakes it and proves the cascade in
 //! simulation.
 //!
 //! [`enumerate_eager_set`]: super::eager_set::enumerate_eager_set
@@ -131,14 +131,14 @@ pub struct CascadeTarget {
 /// material — the cascade's analogue of the eager-set walk's `ChildIndexResolver`
 /// and the sweep's [`SweepResolver`](super::sweep::SweepResolver). Resolve +
 /// adoption-gate + unseal live behind this trait; the real network/gate wiring is
-/// #1025 and tests fake it. A resolve either yields the full
+/// not landed and tests fake it. A resolve either yields the full
 /// [`CascadeTarget`] or a fail-closed [`ResolveFailure`] — a partial or
 /// gate-failing record is never a work-list entry.
 pub trait CascadeResealResolver {
     /// Resolve `scope`'s current re-seal material, or a fail-closed
     /// [`ResolveFailure`] if its record cannot be authoritatively obtained.
     ///
-    /// # Binding contract (obligation on the real resolver, #1025)
+    /// # Binding contract (obligation on the real resolver)
     ///
     /// The resolver MUST gate `scope`'s record under the enumerated
     /// `scope.scope_id` and `scope.ipns_name`, and the gated record's

--- a/crates/engine/src/rotation/mod.rs
+++ b/crates/engine/src/rotation/mod.rs
@@ -28,9 +28,9 @@
 //!
 //! [`ChildIndexResolver`] and [`ScopeRootPublisher`] have production
 //! implementations over the real transport in [`crate::net::rotation`].
-//! [`CascadeResealResolver`] and [`SweepResolver`] are still faked in tests
-//! (#1025), as are the write-plane [`WriteSubtreeResolver`] and
-//! [`WriteWavePublisher`] (#1026).
+//! [`CascadeResealResolver`], [`SweepResolver`] and the write-plane
+//! [`WriteSubtreeResolver`] and [`WriteWavePublisher`] have no production
+//! implementation yet; tests fake them.
 
 pub mod cascade;
 pub mod eager_set;

--- a/crates/engine/src/rotation/rotate_write.rs
+++ b/crates/engine/src/rotation/rotate_write.rs
@@ -36,7 +36,7 @@
 //! name and skips already-republished nodes via
 //! [`WriteWavePublisher::is_republished`]; every effect is idempotent, so it
 //! converges to the same terminal state. The fresh write scope seed is recovered
-//! from the published root — deferred #1026 wiring, faked here via
+//! from the published root — that wiring is not landed, faked here via
 //! [`RotateScopeWritePlan::resume_write_scope_seed`]. Accepted limitation: a crash
 //! after the pointer flip but before interior retirement orphans the prior run's
 //! interior old names — the fail-safe direction (leaking a registration beats
@@ -50,7 +50,7 @@
 //! [`build_repoint_object`]'s two encode-side invariants are release-active, never
 //! a `debug_assert!` (AGENTS.md rule 8). Entropy enters only through the
 //! [`Entropy`] seam; the impure edges are the injected [`WriteSubtreeResolver`] and
-//! [`WriteWavePublisher`] (network wiring is #1026, faked in this slice).
+//! [`WriteWavePublisher`] (network wiring not landed, faked in this slice).
 
 use std::collections::{BTreeSet, VecDeque};
 
@@ -108,7 +108,7 @@ const REPOINT_CHANNELS: [RepointChannel; 3] = [
 /// One node re-published at its freshly derived name — the record the publisher
 /// CAS-installs. Assembling the record bytes (read-body carried verbatim, write-
 /// body re-sealed at the new write epoch for the root) and IPNS-signing them under
-/// the node's fresh write keypair is the deferred #1026 wiring; this slice
+/// the node's fresh write keypair is not landed; this slice
 /// fakes the publish and carries only the routing identity.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RepublishedNode {
@@ -124,7 +124,7 @@ pub struct RepublishedNode {
 
 /// Resolve the write scope's subtree from published records — the read edge, the
 /// analogue of the cascade's `CascadeResealResolver`. Resolve + adoption-gate +
-/// unseal live behind this trait; the real network/gate wiring is #1026 and
+/// unseal live behind this trait; the real network/gate wiring is not landed and
 /// tests fake it. A resolve either yields the node or a fail-closed
 /// [`ResolveFailure`].
 pub trait WriteSubtreeResolver {
@@ -137,7 +137,7 @@ pub trait WriteSubtreeResolver {
 /// The write edge of the name wave: register-first name enrollment, CAS republish,
 /// batch retire, and the three-channel re-point — the analogue of the cascade's
 /// `ScopeRootPublisher`, mapping to the API pin/name registry and `/routing/v1`
-/// transport. Real wiring is #1026; tests fake it.
+/// transport. That wiring is not landed; tests fake it.
 ///
 /// Contract the orchestrator relies on and the fake honours:
 ///
@@ -219,8 +219,8 @@ pub struct RotateScopeWritePlan<'a> {
     pub current_root_name: &'a IpnsName,
     /// On a **resumed** wave, the fresh write scope seed recovered from the
     /// published root (the write-plane history link); `None` on a fresh rotation,
-    /// which mints one via the entropy seam. Recovery wiring is deferred to
-    /// #1026 (faked in tests); the seam boundary is
+    /// which mints one via the entropy seam. Recovery wiring is not landed
+    /// (faked in tests); the seam boundary is
     /// [`Entropy`]-vs-published-record, never in-memory carry.
     pub resume_write_scope_seed: Option<&'a [u8; SECRET_LEN]>,
 }
@@ -1050,7 +1050,7 @@ mod tests {
         let current_root = old_name_of(&SCOPE);
 
         // The seed a fresh wave WOULD mint — captured so the resume threads it back
-        // in, standing in for recovery from the published root (#1026).
+        // in, standing in for recovery from the published root.
         let recovered_seed = {
             let mut e = SeededEntropy::new(9);
             let mut seed = [0u8; 32];

--- a/crates/engine/src/rotation/sweep.rs
+++ b/crates/engine/src/rotation/sweep.rs
@@ -42,8 +42,9 @@
 //!
 //! Time (the idle cadence) enters only through [`Scheduler`] and entropy only
 //! through [`Entropy`]; the sole impure edges are the injected [`SweepResolver`]
-//! and [`ScopeRootPublisher`] (CAS-publish), mirroring `rotate_scope`. The real
-//! network wiring is #1025 and tests fake both.
+//! and [`ScopeRootPublisher`] (CAS-publish), mirroring `rotate_scope`. The
+//! publisher is wired in [`crate::net::rotation`]; the resolver has no
+//! production implementation yet and tests fake it.
 
 use core::time::Duration;
 use std::cell::RefCell;
@@ -118,7 +119,7 @@ pub struct SweepTarget {
 /// The impure edge that resolves a scope root's current re-seal material — the
 /// sweep's analogue of the eager-set walk's [`ChildIndexResolver`] and
 /// `rotate_scope`'s [`ScopeRootPublisher`]. Resolve + adoption-gate + unseal live
-/// behind this trait; the real network/gate wiring is #1025 and tests fake
+/// behind this trait; the real network/gate wiring is not landed and tests fake
 /// it. A resolve either yields the full [`SweepTarget`] or a fail-closed
 /// [`ResolveFailure`] — a partial or gate-failing record is never a work-list
 /// entry.
@@ -129,9 +130,9 @@ pub trait SweepResolver {
     /// One resolve returns the whole [`SweepTarget`] — enumeration/lag fields
     /// *and* the heavy re-seal material. Splitting it into a light enumeration
     /// edge plus a heavy re-seal edge fetched only for lagging nodes is a
-    /// designed-for optimization for #1025, not a correctness requirement.
+    /// designed-for optimization, not a correctness requirement.
     ///
-    /// # Binding contract (obligation on the real resolver, #1025)
+    /// # Binding contract (obligation on the real resolver)
     ///
     /// The same edge discipline [`ChildIndexResolver`] carries applies: gate
     /// `scope`'s record under the enumerated `scope.scope_id`/`scope.ipns_name`,


### PR DESCRIPTION
Replaces tracking-issue numbers in `crates/engine/src/rotation/` doc comments with the condition they were standing in for.

## Why

86% of the issue numbers referenced from `crates/` already point at closed issues — **317 of 365 refs across 86 issues**. Only 48 refs across 12 issues are live. `#746` appears 15 times, `#745` ten, `#685` thirteen; all closed.

The pattern fails structurally: a comment saying "tracked by #NNNN" makes a claim about the *tracker*, which changes independently of the code, so nothing in CI or review can catch it drifting. Four went stale in this one module recently — `#745`/`#746` closed, `#1014` closed on merge, `#1025` named the wrong seam, and `sweep.rs` claimed tests fake `ScopeRootPublisher` after its production impl landed.

## What changed

"the real wiring is `#NNNN`" becomes "the real wiring is not landed" — verifiable from the code, and false exactly when someone writes the impl, in the same diff that falsifies it. The binding-contract prose on each trait is untouched; that is the part worth having and it does not rot.

Also corrects `sweep.rs`, which still claimed `ScopeRootPublisher` was faked after `#1014` landed it in `net::rotation`.

Dependency direction is now one-way: issues point at code, code does not point back. An issue naming a stale path is a nuisance; code naming a stale issue is a lie a reader cannot cheaply check.

## Scope

`crates/engine/src/rotation/` only — 4 files, doc comments exclusively, no code surface. The remaining ~300 stale refs elsewhere in `crates/` are a separate sweep.

Documentation-only, so exempt from the review gates per `AGENTS.md`.
