### PR TITLE
refactor: redact secret-bearing renderings and extend the core scrub guard

### DIFF
--- a/crates/core/examples/kat_gen.rs
+++ b/crates/core/examples/kat_gen.rs
@@ -1385,7 +1385,7 @@ fn build_accept_vectors() -> Vec<AcceptVector> {
         out.push(AcceptVector {
             name: name.to_string(),
             hex: hex::encode(&bytes),
-            diag: value.to_string(),
+            diag: value.to_diag(),
             kinds: kinds.into_iter().map(str::to_string).collect(),
         });
     }
@@ -1730,7 +1730,10 @@ fn build_reject_vectors() -> Vec<RejectVector> {
             hex::decode(&hex).unwrap_or_else(|e| panic!("reject vector {name}: bad hex: {e}"));
         let err = match decode(&bytes) {
             Err(e) => e,
-            Ok(v) => panic!("reject vector {name}: decoder accepted it as {v}"),
+            Ok(v) => panic!(
+                "reject vector {name}: decoder accepted it as {}",
+                v.to_diag()
+            ),
         };
         assert_eq!(
             err.check(),

--- a/crates/core/src/codec/fields.rs
+++ b/crates/core/src/codec/fields.rs
@@ -16,9 +16,10 @@ use super::decode::Decoder;
 use super::encode::{
     MAJOR_MAP, count_value, head_len, text_len, write_head, write_text, write_value,
 };
+use super::redact::fmt_redacted_keys;
 use super::scrub::ScrubOnDrop;
 use super::value::{Map, Value, canonical_key_cmp};
-use crate::error::{CodecError, DisplayKey, Malformed};
+use crate::error::{CodecError, Malformed};
 
 /// The depth a top-level map's values sit at: the map itself is the enclosing
 /// item, so its entries are one level in.
@@ -41,20 +42,6 @@ impl fmt::Debug for UnknownFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_redacted_keys(f, self.entries.iter().map(|(key, _)| key.as_str()))
     }
-}
-
-/// Render a preserved-field set as keys only, with the field names bounded the
-/// way the error surface bounds writer-controlled keys. Shared by both
-/// preserve-unknowns carriers so neither can grow a value into a log line.
-pub(crate) fn fmt_redacted_keys<'a>(
-    f: &mut fmt::Formatter<'_>,
-    keys: impl Iterator<Item = &'a str>,
-) -> fmt::Result {
-    let mut m = f.debug_map();
-    for key in keys {
-        m.key(&DisplayKey(key)).value(&"<redacted>");
-    }
-    m.finish()
 }
 
 impl UnknownFields {

--- a/crates/core/src/codec/mod.rs
+++ b/crates/core/src/codec/mod.rs
@@ -16,13 +16,14 @@
 mod decode;
 mod encode;
 mod fields;
+mod redact;
 pub(crate) mod scrub;
 mod value;
 
 pub use decode::decode;
 pub use encode::{encode, encode_fixed_depth, encoded_len};
-pub(crate) use fields::fmt_redacted_keys;
 pub use fields::{UnknownFields, decode_map_partial, encode_map_partial, known_key_set};
+pub(crate) use redact::{RedactedBytes, RedactedText, fmt_redacted_keys};
 pub use value::{Map, Value, canonical_key_cmp};
 
 /// Maximum nesting depth the decoder admits. A profile constant: deeper input

--- a/crates/core/src/codec/redact.rs
+++ b/crates/core/src/codec/redact.rs
@@ -1,0 +1,51 @@
+//! Redacted renderings.
+//!
+//! Never log keys or seeds (AGENTS.md rule 2), and in a zero-knowledge system
+//! sealed plaintext — a filename, a child `ipnsName`, a recipient's identity key
+//! — is the very thing the server must never see, so it is redacted on the same
+//! terms. Public wire artifacts (ciphertexts, signatures, CIDs, node ids, epoch
+//! counters) render in full; only what a seal protects is withheld.
+//!
+//! Lengths are kept: a rendering with no shape at all is useless for diagnosis.
+
+use core::fmt;
+
+use crate::error::DisplayKey;
+
+/// A byte buffer rendered as its length alone.
+pub(crate) struct RedactedBytes(pub(crate) usize);
+
+impl fmt::Debug for RedactedBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "<{} bytes redacted>", self.0)
+    }
+}
+
+/// Text rendered as its character count alone.
+pub(crate) struct RedactedText(pub(crate) usize);
+
+impl RedactedText {
+    pub(crate) fn of(s: &str) -> Self {
+        Self(s.chars().count())
+    }
+}
+
+impl fmt::Debug for RedactedText {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "<{} chars redacted>", self.0)
+    }
+}
+
+/// Render a preserved-field set as keys only, with the field names bounded the
+/// way the error surface bounds writer-controlled keys. Shared by both
+/// preserve-unknowns carriers so neither can grow a value into a log line.
+pub(crate) fn fmt_redacted_keys<'a>(
+    f: &mut fmt::Formatter<'_>,
+    keys: impl Iterator<Item = &'a str>,
+) -> fmt::Result {
+    let mut m = f.debug_map();
+    for key in keys {
+        m.key(&DisplayKey(key)).value(&"<redacted>");
+    }
+    m.finish()
+}

--- a/crates/core/src/codec/redact.rs
+++ b/crates/core/src/codec/redact.rs
@@ -1,10 +1,16 @@
 //! Redacted renderings.
 //!
-//! Never log keys or seeds (AGENTS.md rule 2), and in a zero-knowledge system
-//! sealed plaintext — a filename, a child `ipnsName`, a recipient's identity key
-//! — is the very thing the server must never see, so it is redacted on the same
-//! terms. Public wire artifacts (ciphertexts, signatures, CIDs, node ids, epoch
-//! counters) render in full; only what a seal protects is withheld.
+//! What a rendering withholds is decoded **user content** — a filename, a child
+//! `ipnsName`, an application payload — which in a zero-knowledge system is
+//! exactly what the server must never see, so a log line must not carry it
+//! either (AGENTS.md rule 2). Public material renders in full: ciphertexts,
+//! signatures, CIDs, epoch counters, and public keys, which carry their own
+//! rendering policy at their type. Secret key material redacts at its type too
+//! ([`crate::suite::secret::SecretBytes`]).
+//!
+//! A node id renders while its `ipnsName` does not: the name is a live handle
+//! that resolves a record, whereas an id reaches one only through the write
+//! scope seed.
 //!
 //! Lengths are kept: a rendering with no shape at all is useless for diagnosis.
 
@@ -13,7 +19,13 @@ use core::fmt;
 use crate::error::DisplayKey;
 
 /// A byte buffer rendered as its length alone.
-pub(crate) struct RedactedBytes(pub(crate) usize);
+pub(crate) struct RedactedBytes(usize);
+
+impl RedactedBytes {
+    pub(crate) fn of(bytes: &[u8]) -> Self {
+        Self(bytes.len())
+    }
+}
 
 impl fmt::Debug for RedactedBytes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -22,7 +34,7 @@ impl fmt::Debug for RedactedBytes {
 }
 
 /// Text rendered as its character count alone.
-pub(crate) struct RedactedText(pub(crate) usize);
+pub(crate) struct RedactedText(usize);
 
 impl RedactedText {
     pub(crate) fn of(s: &str) -> Self {

--- a/crates/core/src/codec/value.rs
+++ b/crates/core/src/codec/value.rs
@@ -10,10 +10,11 @@ use core::fmt;
 
 use zeroize::Zeroize;
 
-use crate::error::{CodecError, Malformed};
+use super::redact::{RedactedBytes, RedactedText};
+use crate::error::{CodecError, DisplayKey, Malformed};
 
 /// A value in the deterministic profile's data model.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum Value {
     /// Major type 0: `0 ..= u64::MAX`.
     Unsigned(u64),
@@ -147,6 +148,36 @@ impl Value {
             Self::Unsigned(_) | Self::Negative(_) | Self::Bool(_) | Self::Null => {}
         }
     }
+
+    /// CBOR diagnostic notation (RFC 8949 §8), restricted to the profile's data
+    /// model. KAT accept vectors pin this rendering via their `diag` field.
+    ///
+    /// Not a [`fmt::Display`] impl: the rendering carries the value verbatim, so
+    /// it has to be asked for by name rather than being reachable from a stray
+    /// `{}` in a log line (see [`super::redact`]).
+    pub fn to_diag(&self) -> String {
+        Diag(self).to_string()
+    }
+}
+
+/// A decoded tree is sealed-body plaintext, so it renders shape and lengths
+/// only; [`Value::to_diag`] is the deliberate full rendering.
+impl fmt::Debug for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unsigned(n) => f.debug_tuple("Unsigned").field(n).finish(),
+            Self::Negative(n) => f.debug_tuple("Negative").field(n).finish(),
+            Self::Bytes(b) => f
+                .debug_tuple("Bytes")
+                .field(&RedactedBytes(b.len()))
+                .finish(),
+            Self::Text(t) => f.debug_tuple("Text").field(&RedactedText::of(t)).finish(),
+            Self::Array(items) => f.debug_tuple("Array").field(items).finish(),
+            Self::Map(map) => f.debug_tuple("Map").field(map).finish(),
+            Self::Bool(b) => f.debug_tuple("Bool").field(b).finish(),
+            Self::Null => f.write_str("Null"),
+        }
+    }
 }
 
 fn unexpected(expected: &'static str, found: &Value) -> Malformed {
@@ -167,10 +198,22 @@ pub fn canonical_key_cmp(a: &str, b: &str) -> Ordering {
 
 /// A map whose entries are always unique-keyed and canonically ordered.
 /// Building one cannot produce a non-canonical encoding.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct Map {
     entries: Vec<(String, Value)>,
     wiped: bool,
+}
+
+/// Keys are field names, so they render — bounded the way the error surface
+/// bounds writer-controlled keys; the values redact themselves.
+impl fmt::Debug for Map {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut m = f.debug_map();
+        for (key, value) in &self.entries {
+            m.key(&DisplayKey(key)).value(value);
+        }
+        m.finish()
+    }
 }
 
 impl Map {
@@ -268,46 +311,46 @@ impl FromIterator<(String, Value)> for Map {
     }
 }
 
-impl fmt::Display for Value {
-    /// CBOR diagnostic notation (RFC 8949 §8), restricted to the profile's
-    /// data model. KAT accept vectors pin this rendering via their `diag`
-    /// field.
+/// The diagnostic-notation renderer behind [`Value::to_diag`].
+struct Diag<'a>(&'a Value);
+
+impl fmt::Display for Diag<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Unsigned(n) => write!(f, "{n}"),
-            Self::Negative(n) => write!(f, "{}", -1 - i128::from(*n)),
-            Self::Bytes(b) => {
+        match self.0 {
+            Value::Unsigned(n) => write!(f, "{n}"),
+            Value::Negative(n) => write!(f, "{}", -1 - i128::from(*n)),
+            Value::Bytes(b) => {
                 write!(f, "h'")?;
                 for byte in b {
                     write!(f, "{byte:02x}")?;
                 }
                 write!(f, "'")
             }
-            Self::Text(t) => write_diag_text(f, t),
-            Self::Array(items) => {
+            Value::Text(t) => write_diag_text(f, t),
+            Value::Array(items) => {
                 write!(f, "[")?;
                 for (i, item) in items.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{item}")?;
+                    write!(f, "{}", Diag(item))?;
                 }
                 write!(f, "]")
             }
-            Self::Map(map) => {
+            Value::Map(map) => {
                 write!(f, "{{")?;
                 for (i, (k, v)) in map.entries().iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
                     write_diag_text(f, k)?;
-                    write!(f, ": {v}")?;
+                    write!(f, ": {}", Diag(v))?;
                 }
                 write!(f, "}}")
             }
-            Self::Bool(true) => write!(f, "true"),
-            Self::Bool(false) => write!(f, "false"),
-            Self::Null => write!(f, "null"),
+            Value::Bool(true) => write!(f, "true"),
+            Value::Bool(false) => write!(f, "false"),
+            Value::Null => write!(f, "null"),
         }
     }
 }
@@ -416,9 +459,38 @@ mod tests {
             assert_eq!(Value::from_i64(n).as_i64().unwrap(), n);
         }
         assert!(Value::Negative(u64::MAX).as_i64().is_err());
-        assert_eq!(
-            Value::Negative(u64::MAX).to_string(),
-            "-18446744073709551616"
+        assert_eq!(Value::Negative(u64::MAX).to_diag(), "-18446744073709551616");
+    }
+
+    /// The rule-2 property: no `{:?}` of a decoded tree can carry the bytes or
+    /// the text it decoded, however deeply they are nested.
+    #[test]
+    fn debug_redacts_every_buffer_but_keeps_shape() {
+        let mut version = Map::new();
+        version.insert("contentKey", Value::Bytes(vec![0xab; SECRET_LEN_TEST]));
+        version.insert("size", Value::Unsigned(4096));
+        let mut root = Map::new();
+        root.insert("versions", Value::Array(vec![Value::Map(version)]));
+        root.insert("name", Value::Text("tax-return-2026.pdf".into()));
+        let rendered = format!("{:?}", Value::Map(root));
+
+        assert!(!rendered.contains("171"), "no byte values: {rendered}");
+        assert!(!rendered.contains("ab"), "no hex either: {rendered}");
+        assert!(!rendered.contains("tax-return"), "no text: {rendered}");
+        assert!(rendered.contains("<32 bytes redacted>"), "{rendered}");
+        assert!(rendered.contains("<19 chars redacted>"), "{rendered}");
+        assert!(
+            rendered.contains("\"contentKey\"") && rendered.contains("4096"),
+            "field names and scalars survive: {rendered}"
         );
+    }
+
+    /// The diagnostic rendering is the deliberate full one, and it is reachable
+    /// only by name.
+    #[test]
+    fn to_diag_renders_verbatim() {
+        let mut m = Map::new();
+        m.insert("k", Value::Bytes(vec![0xab, 0xcd]));
+        assert_eq!(Value::Map(m).to_diag(), "{\"k\": h'abcd'}");
     }
 }

--- a/crates/core/src/codec/value.rs
+++ b/crates/core/src/codec/value.rs
@@ -152,9 +152,9 @@ impl Value {
     /// CBOR diagnostic notation (RFC 8949 §8), restricted to the profile's data
     /// model. KAT accept vectors pin this rendering via their `diag` field.
     ///
-    /// Not a [`fmt::Display`] impl: the rendering carries the value verbatim, so
-    /// it has to be asked for by name rather than being reachable from a stray
-    /// `{}` in a log line (see [`super::redact`]).
+    /// Deliberately not a [`fmt::Display`] impl — a verbatim rendering has to be
+    /// asked for by name. The returned `String` carries whatever the tree does,
+    /// so a caller rendering secret-bearing input owns wiping it.
     pub fn to_diag(&self) -> String {
         Diag(self).to_string()
     }
@@ -167,10 +167,7 @@ impl fmt::Debug for Value {
         match self {
             Self::Unsigned(n) => f.debug_tuple("Unsigned").field(n).finish(),
             Self::Negative(n) => f.debug_tuple("Negative").field(n).finish(),
-            Self::Bytes(b) => f
-                .debug_tuple("Bytes")
-                .field(&RedactedBytes(b.len()))
-                .finish(),
+            Self::Bytes(b) => f.debug_tuple("Bytes").field(&RedactedBytes::of(b)).finish(),
             Self::Text(t) => f.debug_tuple("Text").field(&RedactedText::of(t)).finish(),
             Self::Array(items) => f.debug_tuple("Array").field(items).finish(),
             Self::Map(map) => f.debug_tuple("Map").field(map).finish(),

--- a/crates/core/src/payload/mailbox.rs
+++ b/crates/core/src/payload/mailbox.rs
@@ -50,7 +50,7 @@ pub struct MailboxItem {
 impl fmt::Debug for MailboxItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MailboxItem")
-            .field("payload", &RedactedBytes(self.payload.len()))
+            .field("payload", &RedactedBytes::of(&self.payload))
             .field("sender_identity", &self.sender_identity)
             .finish()
     }
@@ -105,12 +105,11 @@ pub fn seal_mailbox_payload(
     inner_map.insert("payload", Value::Bytes(payload.to_vec()));
     inner_map.insert("senderIdentityPk", Value::Bytes(sender_pk.to_vec()));
     inner_map.insert("senderSig", Value::Bytes(sender_sig.to_compact().to_vec()));
-    // The transient tree holds a verbatim copy of the payload; the drop guard
-    // wipes it on both return and panic-unwind.
-    let mut inner_tree = Value::Map(inner_map);
-    let guard = ScrubOnDrop(&mut inner_tree);
-    let mut inner = encode_fixed_depth(guard.0);
-    drop(guard);
+    let mut inner = {
+        let mut tree = Value::Map(inner_map);
+        let guard = ScrubOnDrop(&mut tree);
+        encode_fixed_depth(guard.0)
+    };
 
     let info = build_aad(&mailbox_ctx(v));
     let sealed = hpke_seal(recipient_enc_pub, ephemeral_scalar, &info, &[], &inner);
@@ -146,9 +145,8 @@ pub fn open_mailbox_payload(
     result
 }
 
-/// The transient decoded tree holds a verbatim copy of the payload, so it is
-/// scrubbed on drop via [`ScrubOwned`]; the returned item's own copy is the
-/// caller's.
+/// The transient decoded tree copies the payload, so it is scrubbed on drop;
+/// the item's own copy is the caller's.
 fn verify_inner(inner: &[u8], v: u64, recipient_pk: &[u8]) -> Result<MailboxItem, CodecError> {
     let value = ScrubOwned(decode(inner)?);
     let map = value.value().as_map()?;
@@ -195,29 +193,14 @@ mod tests {
         assert_eq!(item.sender_identity, sender().verifying_key());
     }
 
-    /// The seal path guards two transient trees carrying a verbatim payload copy
-    /// (the signature preimage and the inner map) and the open path guards the
-    /// decoded one, from which the sender key is read *after* the payload is
-    /// lifted out. All three wipe their own tree only: the caller's payload and
-    /// the opened item survive (terminal-owner rule).
+    /// The seal path's two guards wipe their own transient trees, never the
+    /// caller's payload: one buffer seals to the same block twice.
     #[test]
-    fn scrub_guards_spare_the_payload_the_caller_and_the_item_own() {
+    fn sealing_one_borrowed_payload_twice_is_byte_identical() {
         let payload = b"discovery ping".to_vec();
-        let block =
-            seal_mailbox_payload(&recipient().public(), &[0x51; 32], 2, &sender(), &payload);
-        assert_eq!(
-            payload, b"discovery ping",
-            "the caller's buffer is untouched"
-        );
-        assert_eq!(
-            seal_mailbox_payload(&recipient().public(), &[0x51; 32], 2, &sender(), &payload),
-            block,
-            "a re-seal of the same inputs is byte-identical"
-        );
-
-        let item = open_mailbox_payload(&recipient(), 2, &block).unwrap();
-        assert_eq!(item.payload, payload);
-        assert_eq!(item.sender_identity, sender().verifying_key());
+        let seal =
+            || seal_mailbox_payload(&recipient().public(), &[0x51; 32], 2, &sender(), &payload);
+        assert_eq!(seal(), seal());
     }
 
     /// The payload is HPKE plaintext; no `{:?}` may carry it.

--- a/crates/core/src/payload/mailbox.rs
+++ b/crates/core/src/payload/mailbox.rs
@@ -19,9 +19,12 @@
 //! supplies `v` out-of-band, so a version downgrade recomputes a different key
 //! schedule and fails the AEAD tag ([`TrustViolation::HpkeOpenFailed`]).
 
+use core::fmt;
+
 use zeroize::Zeroize;
 
-use crate::codec::{Map, Value, decode, encode_fixed_depth};
+use crate::codec::scrub::{ScrubOnDrop, ScrubOwned};
+use crate::codec::{Map, RedactedBytes, Value, decode, encode_fixed_depth};
 use crate::error::{CodecError, TrustViolation};
 use crate::seal::{AadContext, STRUCT_TAG_MAILBOX_PAYLOAD, build_aad};
 use crate::suite::ecdsa::{EcdsaSignature, EcdsaSigner, EcdsaVerifier};
@@ -34,13 +37,23 @@ use super::{bytes_fixed, req};
 /// `[MAILBOX_SIG_DOMAIN, v, recipientEncPk, senderIdentityPk, payload]`.
 const MAILBOX_SIG_DOMAIN: &str = "cipherbox/v2/mailbox-sig";
 
-/// An opened, sender-verified mailbox item.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// An opened, sender-verified mailbox item. The payload is HPKE plaintext, so
+/// it renders redacted.
+#[derive(Clone, PartialEq, Eq)]
 pub struct MailboxItem {
     /// The opaque application payload (the caller frames its meaning).
     pub payload: Vec<u8>,
     /// The verified sender identity key (anchor it against the contact code).
     pub sender_identity: EcdsaVerifier,
+}
+
+impl fmt::Debug for MailboxItem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MailboxItem")
+            .field("payload", &RedactedBytes(self.payload.len()))
+            .field("sender_identity", &self.sender_identity)
+            .finish()
+    }
 }
 
 /// The AAD context of a mailbox payload at version `v`. A mailbox item is
@@ -60,13 +73,15 @@ fn mailbox_ctx(v: u64) -> AadContext {
 /// cross-recipient relay lift: an opened item cannot be re-sealed to a second
 /// recipient and still verify.
 fn sig_preimage(v: u64, recipient_pk: &[u8], sender_pk: &[u8], payload: &[u8]) -> Vec<u8> {
-    encode_fixed_depth(&Value::Array(vec![
+    let mut tree = Value::Array(vec![
         Value::Text(MAILBOX_SIG_DOMAIN.to_string()),
         Value::Unsigned(v),
         Value::Bytes(recipient_pk.to_vec()),
         Value::Bytes(sender_pk.to_vec()),
         Value::Bytes(payload.to_vec()),
-    ]))
+    ]);
+    let guard = ScrubOnDrop(&mut tree);
+    encode_fixed_depth(guard.0)
 }
 
 /// Seal a mailbox payload to `recipient_enc_pub`. `ephemeral_scalar` is the
@@ -90,7 +105,12 @@ pub fn seal_mailbox_payload(
     inner_map.insert("payload", Value::Bytes(payload.to_vec()));
     inner_map.insert("senderIdentityPk", Value::Bytes(sender_pk.to_vec()));
     inner_map.insert("senderSig", Value::Bytes(sender_sig.to_compact().to_vec()));
-    let mut inner = encode_fixed_depth(&Value::Map(inner_map));
+    // The transient tree holds a verbatim copy of the payload; the drop guard
+    // wipes it on both return and panic-unwind.
+    let mut inner_tree = Value::Map(inner_map);
+    let guard = ScrubOnDrop(&mut inner_tree);
+    let mut inner = encode_fixed_depth(guard.0);
+    drop(guard);
 
     let info = build_aad(&mailbox_ctx(v));
     let sealed = hpke_seal(recipient_enc_pub, ephemeral_scalar, &info, &[], &inner);
@@ -126,9 +146,12 @@ pub fn open_mailbox_payload(
     result
 }
 
+/// The transient decoded tree holds a verbatim copy of the payload, so it is
+/// scrubbed on drop via [`ScrubOwned`]; the returned item's own copy is the
+/// caller's.
 fn verify_inner(inner: &[u8], v: u64, recipient_pk: &[u8]) -> Result<MailboxItem, CodecError> {
-    let value = decode(inner)?;
-    let map = value.as_map()?;
+    let value = ScrubOwned(decode(inner)?);
+    let map = value.value().as_map()?;
     let payload = req(map, "payload")?.as_bytes()?.to_vec();
     let sender_pk = req(map, "senderIdentityPk")?.as_bytes()?;
     let sig_bytes = req(map, "senderSig")?.as_bytes()?;
@@ -170,6 +193,43 @@ mod tests {
         let item = open_mailbox_payload(&recipient(), 2, &block).unwrap();
         assert_eq!(item.payload, b"discovery ping");
         assert_eq!(item.sender_identity, sender().verifying_key());
+    }
+
+    /// The seal path guards two transient trees carrying a verbatim payload copy
+    /// (the signature preimage and the inner map) and the open path guards the
+    /// decoded one, from which the sender key is read *after* the payload is
+    /// lifted out. All three wipe their own tree only: the caller's payload and
+    /// the opened item survive (terminal-owner rule).
+    #[test]
+    fn scrub_guards_spare_the_payload_the_caller_and_the_item_own() {
+        let payload = b"discovery ping".to_vec();
+        let block =
+            seal_mailbox_payload(&recipient().public(), &[0x51; 32], 2, &sender(), &payload);
+        assert_eq!(
+            payload, b"discovery ping",
+            "the caller's buffer is untouched"
+        );
+        assert_eq!(
+            seal_mailbox_payload(&recipient().public(), &[0x51; 32], 2, &sender(), &payload),
+            block,
+            "a re-seal of the same inputs is byte-identical"
+        );
+
+        let item = open_mailbox_payload(&recipient(), 2, &block).unwrap();
+        assert_eq!(item.payload, payload);
+        assert_eq!(item.sender_identity, sender().verifying_key());
+    }
+
+    /// The payload is HPKE plaintext; no `{:?}` may carry it.
+    #[test]
+    fn debug_of_an_opened_item_redacts_the_payload() {
+        let item = MailboxItem {
+            payload: b"private-note".to_vec(),
+            sender_identity: sender().verifying_key(),
+        };
+        let rendered = format!("{item:?}");
+        assert!(!rendered.contains("private-note"), "{rendered}");
+        assert!(rendered.contains("<12 bytes redacted>"), "{rendered}");
     }
 
     #[test]

--- a/crates/core/src/payload/pointer.rs
+++ b/crates/core/src/payload/pointer.rs
@@ -16,9 +16,12 @@
 //! sealed, owner-signed payload. `id` and `scope` both carry the scope id, so a
 //! pointer sealed for one scope can never open under another.
 
+use core::fmt;
+
 use zeroize::Zeroize;
 
-use crate::codec::{Map, Value, decode, encode, encode_fixed_depth};
+use crate::codec::scrub::{ScrubOnDrop, ScrubOwned};
+use crate::codec::{Map, RedactedText, Value, decode, encode, encode_fixed_depth};
 use crate::error::{CodecError, Malformed, TrustViolation};
 use crate::ipns::IpnsName;
 use crate::seal::{AadContext, STRUCT_TAG_POINTER_PAYLOAD};
@@ -29,7 +32,11 @@ use super::{bytes_fixed, req};
 
 /// The re-point object published at a scope (or vault) pointer. Owner-signed
 /// and owner-maintained; the cold-start floor anchor (`minReadEpoch`).
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// The root names render redacted: hiding the pointer-to-current-root binding
+/// is what this payload's seal is *for*, and `prev_root` exposes the migration
+/// window on top of it.
+#[derive(Clone, PartialEq, Eq)]
 pub struct RepointObject {
     /// The scope id (the scope root's 16-byte node UUID).
     pub scope_id: [u8; 16],
@@ -42,6 +49,27 @@ pub struct RepointObject {
     pub min_read_epoch: u64,
     /// The previous root name during a migration window, if any.
     pub prev_root: Option<IpnsName>,
+}
+
+impl fmt::Debug for RepointObject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RepointObject")
+            .field("scope_id", &self.scope_id)
+            .field(
+                "current_root",
+                &RedactedText::of(self.current_root.as_str()),
+            )
+            .field("write_epoch", &self.write_epoch)
+            .field("min_read_epoch", &self.min_read_epoch)
+            .field(
+                "prev_root",
+                &self
+                    .prev_root
+                    .as_ref()
+                    .map(|n| RedactedText::of(n.as_str())),
+            )
+            .finish()
+    }
 }
 
 impl RepointObject {
@@ -110,7 +138,11 @@ pub fn seal_pointer_payload(
     let mut m = Map::new();
     m.insert("object", object_value);
     m.insert("ownerSig", Value::Bytes(owner_sig.to_compact().to_vec()));
-    let mut plaintext = encode_fixed_depth(&Value::Map(m));
+    let mut plaintext = {
+        let mut tree = Value::Map(m);
+        let guard = ScrubOnDrop(&mut tree);
+        encode_fixed_depth(guard.0)
+    };
 
     let sealed = crate::seal::seal(
         pointer_read_key,
@@ -141,12 +173,14 @@ pub fn open_pointer_payload(
     result
 }
 
+/// The transient decoded tree copies the root names, so it is scrubbed on drop;
+/// the returned object's own copies are the caller's.
 fn decode_and_verify(
     plaintext: &[u8],
     owner_identity: &EcdsaVerifier,
 ) -> Result<RepointObject, CodecError> {
-    let value = decode(plaintext)?;
-    let map = value.as_map()?;
+    let value = ScrubOwned(decode(plaintext)?);
+    let map = value.value().as_map()?;
 
     let object_value = req(map, "object")?;
     let sig_bytes = req(map, "ownerSig")?.as_bytes()?;
@@ -193,6 +227,23 @@ mod tests {
             min_read_epoch: 2,
             prev_root: Some(name(2)),
         }
+    }
+
+    /// Hiding the pointer-to-root binding is what the seal is for; no `{:?}`
+    /// may hand it back.
+    #[test]
+    fn debug_redacts_the_root_names() {
+        let obj = object();
+        let rendered = format!("{obj:?}");
+        assert!(!rendered.contains(obj.current_root.as_str()), "{rendered}");
+        assert!(
+            !rendered.contains(obj.prev_root.as_ref().unwrap().as_str()),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("min_read_epoch: 2"),
+            "the floor stays legible: {rendered}"
+        );
     }
 
     #[test]

--- a/crates/core/src/seal/body.rs
+++ b/crates/core/src/seal/body.rs
@@ -24,7 +24,7 @@ use core::fmt;
 use std::collections::BTreeSet;
 
 use crate::codec::scrub::{ScrubOnDrop, ScrubOwned};
-use crate::codec::{Map, Value, decode, encode, fmt_redacted_keys};
+use crate::codec::{Map, RedactedBytes, RedactedText, Value, decode, encode, fmt_redacted_keys};
 use crate::error::{CodecError, Malformed, TrustViolation};
 use crate::suite::secret::{SECRET_LEN, SecretBytes};
 
@@ -66,7 +66,9 @@ impl NodeKind {
 /// A folder's link to one child (#27 D7). Immutable identity fields plus the
 /// monotonic `link_counter`; `unknown` preserves any newer-client fields
 /// byte-stable.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `name` and `ipns_name` are sealed-body plaintext, so they render redacted.
+#[derive(Clone, PartialEq, Eq)]
 pub struct ChildRef {
     /// The child's location-independent node id (16-byte UUID).
     pub id: [u8; 16],
@@ -84,6 +86,19 @@ pub struct ChildRef {
 }
 
 const CHILD_KNOWN: &[&str] = &["id", "ipnsName", "kind", "linkCounter", "name"];
+
+impl fmt::Debug for ChildRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChildRef")
+            .field("id", &self.id)
+            .field("name", &RedactedText::of(&self.name))
+            .field("ipns_name", &RedactedBytes(self.ipns_name.len()))
+            .field("kind", &self.kind)
+            .field("link_counter", &self.link_counter)
+            .field("unknown", &self.unknown)
+            .finish()
+    }
+}
 
 impl ChildRef {
     fn from_value(v: &Value) -> Result<Self, CodecError> {
@@ -544,6 +559,24 @@ mod tests {
         m.insert("createdAt", Value::Unsigned(100));
         m.insert("modifiedAt", Value::Unsigned(200));
         encode(&Value::Map(m)).unwrap()
+    }
+
+    /// The filename set is exactly what a zero-knowledge server must never see,
+    /// so no `{:?}` of a decoded folder may carry it — nor the child names it
+    /// resolves through.
+    #[test]
+    fn debug_of_a_folder_body_redacts_child_names_and_ipns_names() {
+        let body = folder(vec![child(1, "tax-return-2026.pdf", b"k51q-secret-name")]);
+        let rendered = format!("{body:?}");
+
+        assert!(!rendered.contains("tax-return"), "no filename: {rendered}");
+        assert!(!rendered.contains("k51q"), "no ipnsName: {rendered}");
+        assert!(rendered.contains("<19 chars redacted>"), "{rendered}");
+        assert!(rendered.contains("<16 bytes redacted>"), "{rendered}");
+        assert!(
+            rendered.contains("File") && rendered.contains("link_counter"),
+            "structure still legible: {rendered}"
+        );
     }
 
     #[test]

--- a/crates/core/src/seal/body.rs
+++ b/crates/core/src/seal/body.rs
@@ -92,7 +92,7 @@ impl fmt::Debug for ChildRef {
         f.debug_struct("ChildRef")
             .field("id", &self.id)
             .field("name", &RedactedText::of(&self.name))
-            .field("ipns_name", &RedactedBytes(self.ipns_name.len()))
+            .field("ipns_name", &RedactedBytes::of(&self.ipns_name))
             .field("kind", &self.kind)
             .field("link_counter", &self.link_counter)
             .field("unknown", &self.unknown)

--- a/crates/core/src/seal/section.rs
+++ b/crates/core/src/seal/section.rs
@@ -23,6 +23,7 @@
 //! here — that is the gate's crypto step. This codec only frames and enforces
 //! structure (lengths, required fields, tag uniqueness), fail-closed.
 
+use crate::codec::scrub::{ScrubOnDrop, ScrubOwned};
 use crate::codec::{Map, Value, decode, encode};
 use crate::error::CodecError;
 use crate::suite::ecdsa::SIGNATURE_LEN as ECDSA_SIG_LEN;
@@ -274,9 +275,12 @@ const GRANT_SECTION_KNOWN: &[&str] = &[
 /// Decode a grant section (strict det-CBOR, unknown fields preserved). Fails
 /// closed on a malformed frame, a duplicate grant-blob tag (`duplicate-grant-tag`,
 /// #39 D7), or a duplicate-tag commitment (surfaced by the commitment codec).
+///
+/// The transient decoded tree carries a verbatim copy of the whole signed blob
+/// set, so it is scrubbed on drop via [`ScrubOwned`].
 pub fn decode_grant_section(bytes: &[u8]) -> Result<GrantSection, CodecError> {
-    let value = decode(bytes)?;
-    let map = value.as_map()?;
+    let value = ScrubOwned(decode(bytes)?);
+    let map = value.value().as_map()?;
 
     let commitment = decode_grant_set_commitment(req(map, "commitment")?.as_bytes()?)?;
     let commitment_sig = bytes_fixed::<ECDSA_SIG_LEN>(req(map, "commitmentSig")?, "commitmentSig")?;
@@ -363,7 +367,11 @@ pub fn encode_grant_section(section: &GrantSection) -> Result<Vec<u8>, CodecErro
     }
     m.insert("writeBody", section.write_body.to_value());
     merge_unknown(&mut m, &section.unknown);
-    encode(&Value::Map(m))
+    // The transient tree copies the whole signed blob set; the drop guard wipes
+    // it on both return and panic-unwind.
+    let mut value = Value::Map(m);
+    let guard = ScrubOnDrop(&mut value);
+    encode(guard.0)
 }
 
 #[cfg(test)]
@@ -442,6 +450,18 @@ mod tests {
             bytes,
             "byte-stable"
         );
+    }
+
+    /// The decoder's [`ScrubOwned`] wipes only its own transient tree: the blob
+    /// set it lifted out survives (terminal-owner rule).
+    #[test]
+    fn decode_scrub_preserves_the_blob_set_it_lifted_out() {
+        let bytes = encode_grant_section(&sample()).expect("encodes");
+        let decoded = decode_grant_section(&bytes).expect("decodes");
+        assert_eq!(decoded.grant_blobs[0].ciphertext, vec![0x0b, 0x0c]);
+        assert_eq!(decoded.owner_blob.ciphertext, vec![0x21, 0x22]);
+        assert_eq!(decoded.write_body.sealed, vec![0x50, 0x51]);
+        assert_eq!(decoded.commitment.ipns_name, b"scope-root-name");
     }
 
     #[test]

--- a/crates/core/src/seal/section.rs
+++ b/crates/core/src/seal/section.rs
@@ -276,8 +276,8 @@ const GRANT_SECTION_KNOWN: &[&str] = &[
 /// closed on a malformed frame, a duplicate grant-blob tag (`duplicate-grant-tag`,
 /// #39 D7), or a duplicate-tag commitment (surfaced by the commitment codec).
 ///
-/// The transient decoded tree carries a verbatim copy of the whole signed blob
-/// set, so it is scrubbed on drop via [`ScrubOwned`].
+/// The transient decoded tree copies the whole signed blob set, so it is
+/// scrubbed on drop.
 pub fn decode_grant_section(bytes: &[u8]) -> Result<GrantSection, CodecError> {
     let value = ScrubOwned(decode(bytes)?);
     let map = value.value().as_map()?;
@@ -367,8 +367,6 @@ pub fn encode_grant_section(section: &GrantSection) -> Result<Vec<u8>, CodecErro
     }
     m.insert("writeBody", section.write_body.to_value());
     merge_unknown(&mut m, &section.unknown);
-    // The transient tree copies the whole signed blob set; the drop guard wipes
-    // it on both return and panic-unwind.
     let mut value = Value::Map(m);
     let guard = ScrubOnDrop(&mut value);
     encode(guard.0)
@@ -452,16 +450,15 @@ mod tests {
         );
     }
 
-    /// The decoder's [`ScrubOwned`] wipes only its own transient tree: the blob
-    /// set it lifted out survives (terminal-owner rule).
+    /// The encode guard wipes its own transient tree, never the caller's
+    /// section — see [`super::super::write_body`]'s sibling test.
     #[test]
-    fn decode_scrub_preserves_the_blob_set_it_lifted_out() {
-        let bytes = encode_grant_section(&sample()).expect("encodes");
-        let decoded = decode_grant_section(&bytes).expect("decodes");
-        assert_eq!(decoded.grant_blobs[0].ciphertext, vec![0x0b, 0x0c]);
-        assert_eq!(decoded.owner_blob.ciphertext, vec![0x21, 0x22]);
-        assert_eq!(decoded.write_body.sealed, vec![0x50, 0x51]);
-        assert_eq!(decoded.commitment.ipns_name, b"scope-root-name");
+    fn encoding_one_borrowed_section_twice_is_byte_identical() {
+        let section = sample();
+        assert_eq!(
+            encode_grant_section(&section).unwrap(),
+            encode_grant_section(&section).unwrap()
+        );
     }
 
     #[test]

--- a/crates/core/src/seal/write_body.rs
+++ b/crates/core/src/seal/write_body.rs
@@ -16,9 +16,11 @@
 //! re-sealing a write-body under shared write never strips a newer client's
 //! fields.
 
+use core::fmt;
 use core::num::NonZeroU64;
 
-use crate::codec::{Map, Value, decode, encode};
+use crate::codec::scrub::{ScrubOnDrop, ScrubOwned};
+use crate::codec::{Map, RedactedBytes, Value, decode, encode};
 use crate::error::{CodecError, Malformed};
 use crate::suite::ecdsa::IDENTITY_PUBLIC_LEN;
 use crate::suite::secret::SECRET_LEN;
@@ -36,7 +38,10 @@ use super::grant::Permission;
 /// One authoritative grant-ledger row. The identity key is the 33-byte
 /// compressed secp256k1 SEC1 form; the encryption subkey is a 32-byte X25519
 /// public key.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// The recipient keys and blinded tag are the scope's sealed social graph, so
+/// they render redacted.
+#[derive(Clone, PartialEq, Eq)]
 pub struct GrantLedgerEntry {
     /// The recipient's compressed secp256k1 identity public key (SEC1).
     pub recipient_identity_pk: [u8; IDENTITY_PUBLIC_LEN],
@@ -71,6 +76,25 @@ const LEDGER_ENTRY_KNOWN: &[&str] = &[
     "recipientIdentityPk",
     "tag",
 ];
+
+impl fmt::Debug for GrantLedgerEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GrantLedgerEntry")
+            .field(
+                "recipient_identity_pk",
+                &RedactedBytes(self.recipient_identity_pk.len()),
+            )
+            .field(
+                "recipient_enc_pk",
+                &RedactedBytes(self.recipient_enc_pk.len()),
+            )
+            .field("permission", &self.permission)
+            .field("tag", &RedactedBytes(self.tag.len()))
+            .field("expires_at", &self.expires_at)
+            .field("unknown", &self.unknown)
+            .finish()
+    }
+}
 
 impl GrantLedgerEntry {
     /// A ledger entry that never expires and preserves no unknown fields.
@@ -144,7 +168,8 @@ impl GrantLedgerEntry {
 // ---------------------------------------------------------------------------
 
 /// One directly-descendant scope root, enumerated for the F-4 rotation cascade.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// `ipns_name` is sealed-body plaintext, so it renders redacted.
+#[derive(Clone, PartialEq, Eq)]
 pub struct ChildScopeRef {
     /// The child scope root's node id (16-byte UUID) = its scope id.
     pub scope_id: [u8; 16],
@@ -155,6 +180,16 @@ pub struct ChildScopeRef {
 }
 
 const CHILD_SCOPE_KNOWN: &[&str] = &["ipnsName", "scopeId"];
+
+impl fmt::Debug for ChildScopeRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChildScopeRef")
+            .field("scope_id", &self.scope_id)
+            .field("ipns_name", &RedactedBytes(self.ipns_name.len()))
+            .field("unknown", &self.unknown)
+            .finish()
+    }
+}
 
 impl ChildScopeRef {
     /// A child-scope ref with no preserved unknown fields.
@@ -209,9 +244,13 @@ const WRITE_BODY_KNOWN: &[&str] = &["directChildScopeIndex", "grantLedger", "wri
 ///
 /// Scope-root-only by construction; this codec cannot enforce that — whether a
 /// node is a scope root is the engine's decision.
+///
+/// The transient decoded tree carries verbatim copies of the recipient keys,
+/// blinded tags and child-scope `ipnsName`s, so it is scrubbed on drop via
+/// [`ScrubOwned`].
 pub fn decode_write_body(bytes: &[u8]) -> Result<WriteBody, CodecError> {
-    let value = decode(bytes)?;
-    let map = value.as_map()?;
+    let value = ScrubOwned(decode(bytes)?);
+    let map = value.value().as_map()?;
 
     let mut grant_ledger = Vec::new();
     for item in req(map, "grantLedger")?.as_array()? {
@@ -271,7 +310,11 @@ pub fn encode_write_body(body: &WriteBody) -> Result<Vec<u8>, CodecError> {
         Value::Bytes(body.write_history_link.clone()),
     );
     merge_unknown(&mut m, &body.unknown);
-    encode(&Value::Map(m))
+    // The transient tree copies the ledger's recipient keys and tags; the drop
+    // guard wipes it on both return and panic-unwind.
+    let mut value = Value::Map(m);
+    let guard = ScrubOnDrop(&mut value);
+    encode(guard.0)
 }
 
 #[cfg(test)]
@@ -291,6 +334,36 @@ mod tests {
             )],
             unknown: PreservedFields::new(),
         }
+    }
+
+    /// The decoder's [`ScrubOwned`] wipes only its own transient tree: the
+    /// values it lifted out survive (terminal-owner rule).
+    #[test]
+    fn decode_scrub_preserves_the_values_it_lifted_out() {
+        let bytes = encode_write_body(&sample()).expect("encodes");
+        let decoded = decode_write_body(&bytes).expect("decodes");
+        assert_eq!(decoded.grant_ledger[0].tag, [0x21; SECRET_LEN]);
+        assert_eq!(decoded.grant_ledger[0].recipient_identity_pk, [0x02; 33]);
+        assert_eq!(decoded.write_history_link, b"sealed-write-history");
+        assert_eq!(
+            decoded.direct_child_scope_index[0].ipns_name,
+            b"child-scope-name"
+        );
+    }
+
+    /// The ledger is the scope's sealed social graph; no `{:?}` may carry it.
+    #[test]
+    fn debug_redacts_recipient_keys_tags_and_child_scope_names() {
+        let body = sample();
+        let rendered = format!("{body:?}");
+        assert!(!rendered.contains("child-scope-name"), "{rendered}");
+        assert!(!rendered.contains("33, 33"), "no tag bytes: {rendered}");
+        assert!(rendered.contains("<33 bytes redacted>"), "{rendered}");
+        assert!(rendered.contains("<16 bytes redacted>"), "{rendered}");
+        assert!(
+            rendered.contains("Read") && rendered.contains("Write"),
+            "permissions still legible: {rendered}"
+        );
     }
 
     #[test]

--- a/crates/core/src/seal/write_body.rs
+++ b/crates/core/src/seal/write_body.rs
@@ -38,10 +38,7 @@ use super::grant::Permission;
 /// One authoritative grant-ledger row. The identity key is the 33-byte
 /// compressed secp256k1 SEC1 form; the encryption subkey is a 32-byte X25519
 /// public key.
-///
-/// The recipient keys and blinded tag are the scope's sealed social graph, so
-/// they render redacted.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GrantLedgerEntry {
     /// The recipient's compressed secp256k1 identity public key (SEC1).
     pub recipient_identity_pk: [u8; IDENTITY_PUBLIC_LEN],
@@ -76,25 +73,6 @@ const LEDGER_ENTRY_KNOWN: &[&str] = &[
     "recipientIdentityPk",
     "tag",
 ];
-
-impl fmt::Debug for GrantLedgerEntry {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("GrantLedgerEntry")
-            .field(
-                "recipient_identity_pk",
-                &RedactedBytes(self.recipient_identity_pk.len()),
-            )
-            .field(
-                "recipient_enc_pk",
-                &RedactedBytes(self.recipient_enc_pk.len()),
-            )
-            .field("permission", &self.permission)
-            .field("tag", &RedactedBytes(self.tag.len()))
-            .field("expires_at", &self.expires_at)
-            .field("unknown", &self.unknown)
-            .finish()
-    }
-}
 
 impl GrantLedgerEntry {
     /// A ledger entry that never expires and preserves no unknown fields.
@@ -185,7 +163,7 @@ impl fmt::Debug for ChildScopeRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ChildScopeRef")
             .field("scope_id", &self.scope_id)
-            .field("ipns_name", &RedactedBytes(self.ipns_name.len()))
+            .field("ipns_name", &RedactedBytes::of(&self.ipns_name))
             .field("unknown", &self.unknown)
             .finish()
     }
@@ -245,9 +223,8 @@ const WRITE_BODY_KNOWN: &[&str] = &["directChildScopeIndex", "grantLedger", "wri
 /// Scope-root-only by construction; this codec cannot enforce that — whether a
 /// node is a scope root is the engine's decision.
 ///
-/// The transient decoded tree carries verbatim copies of the recipient keys,
-/// blinded tags and child-scope `ipnsName`s, so it is scrubbed on drop via
-/// [`ScrubOwned`].
+/// The transient decoded tree copies the recipient keys, blinded tags and
+/// child-scope `ipnsName`s, so it is scrubbed on drop.
 pub fn decode_write_body(bytes: &[u8]) -> Result<WriteBody, CodecError> {
     let value = ScrubOwned(decode(bytes)?);
     let map = value.value().as_map()?;
@@ -310,8 +287,6 @@ pub fn encode_write_body(body: &WriteBody) -> Result<Vec<u8>, CodecError> {
         Value::Bytes(body.write_history_link.clone()),
     );
     merge_unknown(&mut m, &body.unknown);
-    // The transient tree copies the ledger's recipient keys and tags; the drop
-    // guard wipes it on both return and panic-unwind.
     let mut value = Value::Map(m);
     let guard = ScrubOnDrop(&mut value);
     encode(guard.0)
@@ -336,33 +311,27 @@ mod tests {
         }
     }
 
-    /// The decoder's [`ScrubOwned`] wipes only its own transient tree: the
-    /// values it lifted out survive (terminal-owner rule).
+    /// The encode guard wipes its own transient tree, never the caller's body:
+    /// one borrow encodes to the same bytes twice. The round-trip test cannot
+    /// catch this — it encodes two distinct values.
     #[test]
-    fn decode_scrub_preserves_the_values_it_lifted_out() {
-        let bytes = encode_write_body(&sample()).expect("encodes");
-        let decoded = decode_write_body(&bytes).expect("decodes");
-        assert_eq!(decoded.grant_ledger[0].tag, [0x21; SECRET_LEN]);
-        assert_eq!(decoded.grant_ledger[0].recipient_identity_pk, [0x02; 33]);
-        assert_eq!(decoded.write_history_link, b"sealed-write-history");
+    fn encoding_one_borrowed_body_twice_is_byte_identical() {
+        let body = sample();
         assert_eq!(
-            decoded.direct_child_scope_index[0].ipns_name,
-            b"child-scope-name"
+            encode_write_body(&body).unwrap(),
+            encode_write_body(&body).unwrap()
         );
     }
 
-    /// The ledger is the scope's sealed social graph; no `{:?}` may carry it.
+    /// A child scope's `ipnsName` is sealed-body plaintext, like a child ref's.
     #[test]
-    fn debug_redacts_recipient_keys_tags_and_child_scope_names() {
-        let body = sample();
-        let rendered = format!("{body:?}");
+    fn debug_redacts_child_scope_names() {
+        let rendered = format!("{:?}", sample());
         assert!(!rendered.contains("child-scope-name"), "{rendered}");
-        assert!(!rendered.contains("33, 33"), "no tag bytes: {rendered}");
-        assert!(rendered.contains("<33 bytes redacted>"), "{rendered}");
         assert!(rendered.contains("<16 bytes redacted>"), "{rendered}");
         assert!(
             rendered.contains("Read") && rendered.contains("Write"),
-            "permissions still legible: {rendered}"
+            "the ledger's public fields stay legible: {rendered}"
         );
     }
 

--- a/crates/core/tests/codec_props.rs
+++ b/crates/core/tests/codec_props.rs
@@ -236,7 +236,9 @@ proptest! {
                 Ok(value) => prop_assert!(
                     false,
                     "defect {} was accepted as {} (bytes {:02x?})",
-                    expected, value, bytes
+                    expected,
+                    value.to_diag(),
+                    bytes
                 ),
                 Err(err) => prop_assert_eq!(
                     err.check(),

--- a/crates/core/tests/kat_manifest.rs
+++ b/crates/core/tests/kat_manifest.rs
@@ -1632,7 +1632,7 @@ fn accept_vectors_decode_reencode_and_render_diag() {
             v.name
         );
         assert_eq!(
-            value.to_string(),
+            value.to_diag(),
             v.diag,
             "accept vector {}: diagnostic-notation drift",
             v.name
@@ -1647,7 +1647,11 @@ fn reject_vectors_fire_the_named_check() {
         let bytes = unhex(&v.name, &v.hex);
         let err = match decode(&bytes) {
             Err(e) => e,
-            Ok(value) => panic!("reject vector {}: decoder accepted it as {value}", v.name),
+            Ok(value) => panic!(
+                "reject vector {}: decoder accepted it as {}",
+                v.name,
+                value.to_diag()
+            ),
         };
         assert_eq!(
             err.check(),


### PR DESCRIPTION
Two `crates/core` hygiene gaps, grouped because both edit `codec/value.rs` and `seal/body.rs`.

Closes #937
Closes #956

## Redaction

`Value` and `Map` get hand-written `Debug` impls that render buffer lengths instead of contents, so every downstream derive — the decoded known-field map, preserved unknowns, every schema struct holding a `Value` — redacts in one place. Map keys still render, bounded by the same 64-char `DisplayKey` cap the error surface uses.

The diagnostic renderer moves off `Display` to an explicit `Value::to_diag`, so no stray `{}` can leak a tree. Its rendering is byte-identical and the KAT accept vectors regenerate with zero drift; removing the `Display` impl makes an accidental `value.to_string()` a compile error.

The seal-layer sweep covers typed fields a `Value` impl cannot reach. The rule, stated once in the new `codec/redact.rs`:

> Withhold decoded **user content** — a filename, a child `ipnsName`, an application payload, the pointer's root names. Render public material in full — ciphertexts, signatures, CIDs, node ids, epoch counters, and public keys, which carry their own rendering policy at their type.

So `ChildRef` name/ipnsName, `ChildScopeRef` ipnsName, `MailboxItem` payload and `RepointObject`'s root names redact, while the blinded grant tag does not — it is published verbatim in the envelope's grant section, so withholding it in one struct and printing it in two others would buy nothing. Same reasoning leaves `GrantSetCommitment.ipns_name` alone: that commitment rides `envelope.grantSection` in the clear.

A node id renders while its `ipnsName` does not, because the name is a live handle that resolves a record and an id reaches one only through the write scope seed.

## Scrub

The terminal-owner wipe guards now cover every remaining sealed-plaintext codec in the crate: `decode`/`encode_write_body`, the grant-section codec, the mailbox seal and open paths, and the pointer payload. Each wipes only its own transient tree — caller buffers and decoded outputs are untouched.

The pointer payload is not in either issue's file list; two of the three review gates flagged it independently, and it is the same shape as the three codecs the issues do name, so it is folded in rather than deferred.

## Tests

- Redaction: each newly-redacting type asserts no `{:?}` carries the content it seals, and that the surrounding structure stays legible.
- Scrub: each newly-guarded codec asserts that encoding one **borrowed** value twice is byte-identical. The pre-existing round-trip tests encode two distinct values, so they cannot catch a guard that wipes what its caller still owns.

## Verification

`cargo fmt --all --check`, `cargo clippy --all-targets` and `cargo test --workspace` are clean; `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` builds, and nothing outside `crates/core` needed a change. `cargo run --example kat_gen` reproduces every vector file byte-for-byte.

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` all ran against this diff. Security found nothing. The other two converged on the pointer-payload gap and on the redaction rule being applied inconsistently to the blinded tag and the recipient keys; both are fixed in the second commit, along with dropping three tests that were strict subsets of an existing round-trip assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Redacted sensitive fields (cryptographic material, names, payloads) from debug output to prevent accidental exposure in logs.
  * Added memory scrubbing for sensitive data to ensure cryptographic material is zeroed after use.

* **Chores**
  * Refactored diagnostic rendering to use explicit methods for clarity and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->