### PR TITLE
fix: narrow the facade background loops and surface their trust violations

### DIFF
--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -25,6 +25,7 @@ use cipherbox_core::content::encode_content_cid_str;
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::seal::{ReadBody, Version, seal_content_key};
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
+use cipherbox_core::suite::x25519::X25519Secret;
 use futures_channel::mpsc;
 use futures_core::Stream;
 use zeroize::Zeroizing;
@@ -999,6 +1000,41 @@ fn emit_renewal_failures(events: &mpsc::UnboundedSender<Event>, results: &[EolRe
     }
 }
 
+/// Surface a fail-closed resolve rejection as [`Event::AttributableAbuse`].
+/// The data stays unheld and unrendered either way — this only stops a forged
+/// record from being indistinguishable from silence, since a trust violation is
+/// never mere staleness (AGENTS.md rule 6). `routing_key` is the record's
+/// `ipnsName` and `detail` a classification; neither carries key material.
+pub(crate) fn emit_trust_violation(
+    events: &mpsc::UnboundedSender<Event>,
+    routing_key: &str,
+    detail: &str,
+) {
+    let _ = events.unbounded_send(Event::AttributableAbuse {
+        description: format!("{routing_key}: {detail}"),
+    });
+}
+
+/// The record bytes already held for `name` under `node`, when the scope seeds
+/// recovered alongside them are still in hand. Re-fetching exactly these bytes
+/// at the sequence floor can only re-derive material the caller already has —
+/// the record signs its head CID, so identical bytes address an identical head
+/// block — so the adopter skips the owner-blob opens and the hold stands as is.
+fn steady_state_hold(
+    held: &RefCell<HeldRecords>,
+    node: [u8; 16],
+    name: &IpnsName,
+    read_seeds: &RefCell<ScopeReadSeeds>,
+    write_seeds: &RefCell<ScopeWriteSeeds>,
+) -> Option<Vec<u8>> {
+    if !read_seeds.borrow().contains_key(&node) || !write_seeds.borrow().contains_key(&node) {
+        return None;
+    }
+    let held = held.borrow();
+    let record = held.get(&node)?;
+    (record.routing_key == name.as_str()).then(|| record.record_bytes.clone())
+}
+
 /// Fold one drain pass's report into the host-visible surface: retain and emit
 /// every dead letter, and emit one [`Event::SnapshotUpdated`] if the pass moved
 /// anything off the queue (the overlay the host renders just shrank). Both sends
@@ -1257,9 +1293,17 @@ pub struct Engine<T: SeamTypes> {
     /// The cold-start session identity, derived from the login secret at
     /// [`start`](Self::start). `None` until then; the single place derived key
     /// material lives once the engine is live. The resolve/publish/rotation
-    /// slices read every signer from here. Behind an [`Rc`] so the spawned
-    /// liveness loop shares it for the sub-EOL renewal's per-name signers.
-    session: Option<Rc<SessionIdentity>>,
+    /// slices read every signer from here. Owned outright, never shared: the
+    /// retained login secret must drop with the engine, so a spawned loop takes
+    /// the narrow material it needs ([`tick_enc_subkey`](Self::tick_enc_subkey))
+    /// rather than a handle on the whole session.
+    session: Option<SessionIdentity>,
+    /// The one piece of session secret the resolve-tick loop needs — the
+    /// encryption subkey it opens owner blobs and op records with — in a cell
+    /// the engine empties on drop. A parked task is not polled until its next
+    /// scheduler wake, so a captured copy would stay resident for up to a poll
+    /// cadence past the engine (security rules 1/7).
+    tick_enc_subkey: Rc<RefCell<Option<X25519Secret>>>,
     /// The one shared API client, built and logged in at [`start`](Self::start)
     /// and handed to the liveness loop so the access JWT is shared across
     /// publish/renew (no redundant 401→refresh). `None` until then.
@@ -1309,6 +1353,7 @@ impl<T: SeamTypes> Engine<T> {
                 orphan_heads: Rc::new(RefCell::new(Vec::new())),
                 alive: Rc::new(Cell::new(true)),
                 session: None,
+                tick_enc_subkey: Rc::new(RefCell::new(None)),
                 api: None,
                 started: false,
             },
@@ -1346,7 +1391,7 @@ impl<T: SeamTypes> Engine<T> {
         }
         // Pure derivation from the injected secret — no clock, no RNG — then
         // the secret zeroizes on drop here, at its terminal owner.
-        let session = Rc::new(SessionIdentity::derive(&secret)?);
+        let session = SessionIdentity::derive(&secret)?;
         drop(secret);
 
         // The one shared client for login, publish, and renewal. Login is
@@ -1453,7 +1498,28 @@ impl<T: SeamTypes> Engine<T> {
     /// hold key material.
     #[allow(dead_code)]
     pub(crate) fn session(&self) -> Option<&SessionIdentity> {
-        self.session.as_deref()
+        self.session.as_ref()
+    }
+
+    /// Drop every piece of key material the engine shares with its spawned
+    /// loops: the tick's enc subkey, the held records' per-name renewal signers,
+    /// and the recovered scope seeds. Clearing the alive latch alone would leave
+    /// all of it resident until each parked task's next scheduler wake — up to
+    /// [`RE_PUT_INTERVAL`] away — so the engine clears it here, at the terminal
+    /// owner (security rule 7). `try_borrow_mut` because a panic while dropping
+    /// aborts the process.
+    fn zeroize_shared_key_material(&self) {
+        if let Ok(mut enc_subkey) = self.tick_enc_subkey.try_borrow_mut() {
+            *enc_subkey = None;
+        }
+        if let Ok(mut held) = self.held_records.try_borrow_mut() {
+            held.clear();
+        }
+        for seeds in [&self.scope_read_seeds, &self.scope_write_seeds] {
+            if let Ok(mut seeds) = seeds.try_borrow_mut() {
+                seeds.clear();
+            }
+        }
     }
 
     /// Run the cold-start live-session data path — the ordered chain composed on
@@ -1596,8 +1662,8 @@ impl<T: SeamTypes> Engine<T> {
     /// held set the liveness loop keeps alive. Fixed cadence off the injected
     /// scheduler's focus-window `poll_cadence` — the determinism law's only time
     /// source is `scheduler.sleep`, so it holds under virtual time. The task holds
-    /// only `Rc`/seam-handle clones and the alive latch, so it stops once the
-    /// engine drops.
+    /// only `Rc`/seam-handle clones and the narrow enc-subkey cell, so it stops
+    /// once the engine empties that cell on drop.
     ///
     /// `root_name` is the vault pointer's resolved `currentRoot`; `None` (an empty
     /// chain) spawns nothing — there is no root to poll until a later start
@@ -1615,9 +1681,14 @@ impl<T: SeamTypes> Engine<T> {
         T::SnapshotCache: Clone + 'static,
         T::StagingStore: Clone + 'static,
     {
-        let (Some(root_name), Some(session)) = (root_name, self.session.clone()) else {
+        let (Some(root_name), Some(session)) = (root_name, self.session.as_ref()) else {
             return;
         };
+        // Least privilege: the pass needs the enc subkey and the (public) owner
+        // verifier, never the login secret or the pointer seeds the session also
+        // holds.
+        *self.tick_enc_subkey.borrow_mut() = Some(session.enc_subkey().clone());
+        let tick_enc_subkey = self.tick_enc_subkey.clone();
         let scheduler = self.seams.scheduler.clone();
         let staging = self.seams.staging_store.clone();
         let entropy = self.entropy.clone();
@@ -1635,7 +1706,6 @@ impl<T: SeamTypes> Engine<T> {
         let held = self.held_records.clone();
         let base = self.snapshot.clone();
         let events = self.events.clone();
-        let alive = self.alive.clone();
         let sync_status = self.sync_status.clone();
         let scope_read_seeds = self.scope_read_seeds.clone();
         let focus = self.focus.clone();
@@ -1650,17 +1720,28 @@ impl<T: SeamTypes> Engine<T> {
 
         self.seams.scheduler.spawn(Box::pin(async move {
             run_liveness_loop(&scheduler, interval, || async {
-                if !alive.get() {
+                // The engine empties this cell on drop, so the pass owns a
+                // secret copy for exactly its own duration and the loop stops
+                // the moment the engine is gone.
+                let enc_subkey = tick_enc_subkey.borrow().clone();
+                let Some(enc_subkey) = enc_subkey else {
                     return LivenessControl::Stop;
-                }
+                };
                 let adopter = RootAdopter::new(
                     &gateway,
                     &http,
                     &floors,
-                    session.enc_subkey(),
+                    &enc_subkey,
                     &owner_identity,
                     root_id,
-                );
+                )
+                .holding(steady_state_hold(
+                    &held,
+                    root_id,
+                    &root_name,
+                    &scope_read_seeds,
+                    &scope_write_seeds,
+                ));
                 // Own-root material: the write-scope seed the owner cannot
                 // re-derive rides the adopt (recovered from the owner-write-blob),
                 // so the caller-side seed is `None` and the gate's authenticated
@@ -1673,7 +1754,7 @@ impl<T: SeamTypes> Engine<T> {
                 };
                 // A gate-passing `Adopted` repaints the shared base cell and emits
                 // `SnapshotUpdated`; `Current`/`NoUpdate`/`TrustViolation` leave
-                // last-known-good intact (fail-closed for data). (surfacing: #796)
+                // last-known-good intact (fail-closed for data).
                 sync_status.borrow_mut().reconcile_in_flight = true;
                 let resolved = resolve_and_hold(
                     &transport,
@@ -1697,6 +1778,9 @@ impl<T: SeamTypes> Engine<T> {
                     held_resolve.resolved
                 });
                 if let Ok(resolved) = &resolved {
+                    if let ResolveOutcome::TrustViolation(rejection) = &resolved.outcome {
+                        emit_trust_violation(&events, root_name.as_str(), &rejection.to_string());
+                    }
                     if refresh_base_from_outcome(&base, NodeId(root_id), &resolved.outcome) {
                         let _ = events.unbounded_send(Event::SnapshotUpdated);
                     }
@@ -1717,6 +1801,7 @@ impl<T: SeamTypes> Engine<T> {
                         floors: &floors,
                         gateway: &gateway,
                         base: &base,
+                        events: &events,
                         scope_id: root_id,
                         scope_read_seed: read_seed,
                     }
@@ -1756,7 +1841,7 @@ impl<T: SeamTypes> Engine<T> {
                         root_name: &root_name,
                         read_scope_seed: &read_seed,
                         write_scope_seed: &write_seed,
-                        enc_secret: session.enc_subkey(),
+                        enc_secret: &enc_subkey,
                         owner_identity: &owner_identity,
                     })
                     .await;
@@ -1931,6 +2016,7 @@ impl<T: SeamTypes> Engine<T> {
             floors: &self.seams.floor_store,
             gateway: &self.gateway,
             base: &self.snapshot,
+            events: &self.events,
             scope_id,
             scope_read_seed: &scope_read_seed,
         }
@@ -2807,6 +2893,7 @@ impl<T: SeamTypes> Drop for Engine<T> {
         // Signal the spawned liveness loop to stop; it holds only `Rc` clones,
         // so it outlives the engine unless the latch is cleared here.
         self.alive.set(false);
+        self.zeroize_shared_key_material();
     }
 }
 
@@ -4560,6 +4647,163 @@ mod tests {
                 engine.scope_read_seeds.borrow().get(&SCOPE).map(|s| **s),
                 Some(SCOPE_SEED),
                 "the tick adopt deposited the recovered scope read seed"
+            );
+        }
+
+        /// A started engine over the full cold-start fixture, with its spawned
+        /// loops taken and parked at their first sleep. The cold-start adopt
+        /// raises the sequence floor to the record's own sequence, so every
+        /// later poll of the same record is an equal-floor `Current`.
+        fn started_and_parked(
+            world: &FakeWorld,
+            device: &FakeDevice,
+        ) -> (Engine<FakeSeamTypes>, EventStream, Vec<BoxedTask>) {
+            let (head_block, head_cid, root_name) = owner_root();
+            seed_vault_pointer(device, &root_name);
+            for endpoint in device.record_store.endpoints() {
+                seed_root_record_at(device, &endpoint, &root_name, &head_cid);
+            }
+            device.http.enqueue_response(head_response(&head_block));
+            let (mut engine, events) = engine_on(device);
+            block_on(engine.start(LoginSecret::new(CAP_SECRET.to_vec()))).unwrap();
+            let mut tasks = world.scheduler.take_spawned_tasks();
+            poll_each(&mut tasks);
+            (engine, events, tasks)
+        }
+
+        /// Advance one poll cadence and run one pass of each loop, serving the
+        /// head block the root record anchors.
+        fn tick(world: &FakeWorld, device: &FakeDevice, tasks: &mut [BoxedTask]) {
+            let (head_block, _, _) = owner_root();
+            device.http.enqueue_response(head_response(&head_block));
+            world.scheduler.advance(SyncTimingProfile::CI.poll_cadence);
+            poll_each(tasks);
+        }
+
+        /// Nothing the spawned loops share may outlive the engine: a parked task
+        /// is not polled again until its next scheduler wake, so `Drop` — not the
+        /// next pass — has to clear the key material.
+        #[test]
+        fn engine_drop_clears_the_key_material_the_spawned_loops_share() {
+            let world = FakeWorld::new();
+            let device = world.device(b"alice-pk");
+            let (engine, _events, mut tasks) = started_and_parked(&world, &device);
+            tick(&world, &device, &mut tasks);
+
+            let held = engine.held_records.clone();
+            let read_seeds = engine.scope_read_seeds.clone();
+            let write_seeds = engine.scope_write_seeds.clone();
+            let enc_subkey = engine.tick_enc_subkey.clone();
+            assert!(
+                !held.borrow().is_empty(),
+                "the tick holds the root under a per-name renewal signer"
+            );
+            assert!(!read_seeds.borrow().is_empty());
+            assert!(!write_seeds.borrow().is_empty());
+            assert!(enc_subkey.borrow().is_some());
+
+            // The tasks stay parked across the drop — only `Drop` can clear this.
+            drop(engine);
+            assert!(
+                held.borrow().is_empty(),
+                "the per-name renewal signers go with the engine"
+            );
+            assert!(read_seeds.borrow().is_empty(), "and the scope read seed");
+            assert!(write_seeds.borrow().is_empty(), "and the scope write seed");
+            assert!(
+                enc_subkey.borrow().is_none(),
+                "and the session secret the tick borrowed"
+            );
+
+            world.scheduler.advance(RE_PUT_INTERVAL);
+            assert!(
+                poll_each(&mut tasks).iter().all(Poll::is_ready),
+                "both loops stop at their next wake"
+            );
+        }
+
+        /// A forged owner-root record is fail-closed either way; without an event
+        /// a persistent forgery is indistinguishable from an idle vault.
+        #[test]
+        fn a_persistently_forged_steady_state_record_raises_an_abuse_event() {
+            let world = FakeWorld::new();
+            let device = world.device(b"alice-pk");
+            let (_, head_cid, root_name) = owner_root();
+            let (engine, mut events, mut tasks) = started_and_parked(&world, &device);
+            let adopted = block_on(engine.view()).unwrap().children(ROOT);
+            let _ = drain(&mut events);
+
+            // A strictly newer record whose signed head anchor the served block
+            // does not address: fail-closed at assembly, on every poll.
+            for endpoint in device.record_store.endpoints() {
+                device.record_store.seed_record(
+                    &endpoint,
+                    root_name.as_str(),
+                    root_record(&head_cid, 2),
+                );
+            }
+            for _ in 0..2 {
+                device
+                    .http
+                    .enqueue_response(head_response(b"forged head block"));
+                world.scheduler.advance(SyncTimingProfile::CI.poll_cadence);
+                poll_each(&mut tasks);
+
+                let abuse: Vec<String> = drain(&mut events)
+                    .into_iter()
+                    .filter_map(|event| match event {
+                        Event::AttributableAbuse { description } => Some(description),
+                        _ => None,
+                    })
+                    .collect();
+                assert_eq!(abuse.len(), 1, "every forged poll raises one abuse event");
+                assert!(
+                    abuse[0].contains(root_name.as_str())
+                        && abuse[0].contains("content-cid-mismatch"),
+                    "the event names the record and the check that rejected it: {}",
+                    abuse[0]
+                );
+            }
+            assert_eq!(
+                block_on(engine.view()).unwrap().children(ROOT),
+                adopted,
+                "and the forgery still never renders"
+            );
+        }
+
+        /// An idle vault re-fetching its own unchanged record must not re-open
+        /// the owner blobs and re-insert the hold on every poll.
+        #[test]
+        fn a_steady_state_poll_neither_re_recovers_nor_re_holds() {
+            let world = FakeWorld::new();
+            let device = world.device(b"alice-pk");
+            let (engine, _events, mut tasks) = started_and_parked(&world, &device);
+
+            tick(&world, &device, &mut tasks);
+            assert_eq!(
+                engine.held_records.borrow().len(),
+                1,
+                "the first steady-state poll recovers the write seed and holds"
+            );
+            // Stamp the entry: a re-hold rebuilds it from the tick's own
+            // (content-CID-less) material and would drop the stamp.
+            engine
+                .held_records
+                .borrow_mut()
+                .get_mut(&ROOT.0)
+                .expect("held under the root node id")
+                .content_cids = vec!["bafystamp".to_owned()];
+
+            tick(&world, &device, &mut tasks);
+            assert_eq!(
+                engine.held_records.borrow()[&ROOT.0].content_cids,
+                vec!["bafystamp".to_owned()],
+                "the next poll left the hold alone"
+            );
+            assert_eq!(
+                engine.scope_write_seeds.borrow().get(&SCOPE).map(|s| **s),
+                Some(WRITE_SCOPE_SEED),
+                "and the material recovered once stays in hand"
             );
         }
 

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -531,8 +531,9 @@ pub enum Event {
         /// (#859).
         reason: DeadLetterReason,
     },
-    /// Attributable abuse: owner-blob / ascent-link / unseal cross-check
-    /// disagreement (#39 D6) — never a silent failure.
+    /// Attributable abuse: a fail-closed adoption-gate rejection, or an
+    /// owner-blob / ascent-link / unseal cross-check disagreement (#39 D6) —
+    /// never a silent failure.
     AttributableAbuse {
         /// Human-readable classification (no key material).
         description: String,
@@ -1000,15 +1001,14 @@ fn emit_renewal_failures(events: &mpsc::UnboundedSender<Event>, results: &[EolRe
     }
 }
 
-/// Surface a fail-closed resolve rejection as [`Event::AttributableAbuse`].
-/// The data stays unheld and unrendered either way — this only stops a forged
-/// record from being indistinguishable from silence, since a trust violation is
-/// never mere staleness (AGENTS.md rule 6). `routing_key` is the record's
-/// `ipnsName` and `detail` a classification; neither carries key material.
+/// Surface a fail-closed resolve rejection as [`Event::AttributableAbuse`]: a
+/// trust violation is never mere staleness (AGENTS.md rule 6), so it must not
+/// poll silently. `routing_key` is the record's `ipnsName` and `detail` a
+/// classification; neither carries key material.
 pub(crate) fn emit_trust_violation(
     events: &mpsc::UnboundedSender<Event>,
     routing_key: &str,
-    detail: &str,
+    detail: impl fmt::Display,
 ) {
     let _ = events.unbounded_send(Event::AttributableAbuse {
         description: format!("{routing_key}: {detail}"),
@@ -1016,22 +1016,22 @@ pub(crate) fn emit_trust_violation(
 }
 
 /// The record bytes already held for `name` under `node`, when the scope seeds
-/// recovered alongside them are still in hand. Re-fetching exactly these bytes
-/// at the sequence floor can only re-derive material the caller already has —
-/// the record signs its head CID, so identical bytes address an identical head
-/// block — so the adopter skips the owner-blob opens and the hold stands as is.
+/// recovered alongside them are still in hand — the precondition for
+/// [`RootAdopter::holding`]'s steady-state skip.
 fn steady_state_hold(
     held: &RefCell<HeldRecords>,
-    node: [u8; 16],
+    scope_root: [u8; 16],
     name: &IpnsName,
     read_seeds: &RefCell<ScopeReadSeeds>,
     write_seeds: &RefCell<ScopeWriteSeeds>,
 ) -> Option<Vec<u8>> {
-    if !read_seeds.borrow().contains_key(&node) || !write_seeds.borrow().contains_key(&node) {
+    if !read_seeds.borrow().contains_key(&scope_root)
+        || !write_seeds.borrow().contains_key(&scope_root)
+    {
         return None;
     }
     let held = held.borrow();
-    let record = held.get(&node)?;
+    let record = held.get(&scope_root)?;
     (record.routing_key == name.as_str()).then(|| record.record_bytes.clone())
 }
 
@@ -1293,16 +1293,15 @@ pub struct Engine<T: SeamTypes> {
     /// The cold-start session identity, derived from the login secret at
     /// [`start`](Self::start). `None` until then; the single place derived key
     /// material lives once the engine is live. The resolve/publish/rotation
-    /// slices read every signer from here. Owned outright, never shared: the
-    /// retained login secret must drop with the engine, so a spawned loop takes
-    /// the narrow material it needs ([`tick_enc_subkey`](Self::tick_enc_subkey))
-    /// rather than a handle on the whole session.
+    /// slices read every signer from here. Owned outright, never shared, so the
+    /// retained login secret drops with the engine.
     session: Option<SessionIdentity>,
     /// The one piece of session secret the resolve-tick loop needs — the
     /// encryption subkey it opens owner blobs and op records with — in a cell
     /// the engine empties on drop. A parked task is not polled until its next
-    /// scheduler wake, so a captured copy would stay resident for up to a poll
-    /// cadence past the engine (security rules 1/7).
+    /// scheduler wake, so anything the loop captured outright would stay
+    /// resident for up to that wake past the engine (security rules 1/7); every
+    /// shared cell below carrying key material is cleared the same way.
     tick_enc_subkey: Rc<RefCell<Option<X25519Secret>>>,
     /// The one shared API client, built and logged in at [`start`](Self::start)
     /// and handed to the liveness loop so the access JWT is shared across
@@ -1501,14 +1500,12 @@ impl<T: SeamTypes> Engine<T> {
         self.session.as_ref()
     }
 
-    /// Drop every piece of key material the engine shares with its spawned
-    /// loops: the tick's enc subkey, the held records' per-name renewal signers,
-    /// and the recovered scope seeds. Clearing the alive latch alone would leave
-    /// all of it resident until each parked task's next scheduler wake — up to
-    /// [`RE_PUT_INTERVAL`] away — so the engine clears it here, at the terminal
-    /// owner (security rule 7). `try_borrow_mut` because a panic while dropping
-    /// aborts the process.
-    fn zeroize_shared_key_material(&self) {
+    /// Stop the spawned loops at their next wake and drop the key material they
+    /// share with the engine here and now, at the terminal owner (security rule
+    /// 7) — see [`tick_enc_subkey`](Self::tick_enc_subkey). `try_borrow_mut`
+    /// because a panic while dropping aborts the process.
+    fn shut_down(&self) {
+        self.alive.set(false);
         if let Ok(mut enc_subkey) = self.tick_enc_subkey.try_borrow_mut() {
             *enc_subkey = None;
         }
@@ -1662,8 +1659,8 @@ impl<T: SeamTypes> Engine<T> {
     /// held set the liveness loop keeps alive. Fixed cadence off the injected
     /// scheduler's focus-window `poll_cadence` — the determinism law's only time
     /// source is `scheduler.sleep`, so it holds under virtual time. The task holds
-    /// only `Rc`/seam-handle clones and the narrow enc-subkey cell, so it stops
-    /// once the engine empties that cell on drop.
+    /// only `Rc`/seam-handle clones and the alive latch, so it stops once the
+    /// engine drops.
     ///
     /// `root_name` is the vault pointer's resolved `currentRoot`; `None` (an empty
     /// chain) spawns nothing — there is no root to poll until a later start
@@ -1685,8 +1682,7 @@ impl<T: SeamTypes> Engine<T> {
             return;
         };
         // Least privilege: the pass needs the enc subkey and the (public) owner
-        // verifier, never the login secret or the pointer seeds the session also
-        // holds.
+        // verifier, never the login secret or the pointer seeds beside them.
         *self.tick_enc_subkey.borrow_mut() = Some(session.enc_subkey().clone());
         let tick_enc_subkey = self.tick_enc_subkey.clone();
         let scheduler = self.seams.scheduler.clone();
@@ -1706,6 +1702,7 @@ impl<T: SeamTypes> Engine<T> {
         let held = self.held_records.clone();
         let base = self.snapshot.clone();
         let events = self.events.clone();
+        let alive = self.alive.clone();
         let sync_status = self.sync_status.clone();
         let scope_read_seeds = self.scope_read_seeds.clone();
         let focus = self.focus.clone();
@@ -1720,9 +1717,11 @@ impl<T: SeamTypes> Engine<T> {
 
         self.seams.scheduler.spawn(Box::pin(async move {
             run_liveness_loop(&scheduler, interval, || async {
-                // The engine empties this cell on drop, so the pass owns a
-                // secret copy for exactly its own duration and the loop stops
-                // the moment the engine is gone.
+                if !alive.get() {
+                    return LivenessControl::Stop;
+                }
+                // The pass owns a copy for exactly its own duration; the engine
+                // emptied the cell if it is already gone.
                 let enc_subkey = tick_enc_subkey.borrow().clone();
                 let Some(enc_subkey) = enc_subkey else {
                     return LivenessControl::Stop;
@@ -1779,7 +1778,7 @@ impl<T: SeamTypes> Engine<T> {
                 });
                 if let Ok(resolved) = &resolved {
                     if let ResolveOutcome::TrustViolation(rejection) = &resolved.outcome {
-                        emit_trust_violation(&events, root_name.as_str(), &rejection.to_string());
+                        emit_trust_violation(&events, root_name.as_str(), rejection);
                     }
                     if refresh_base_from_outcome(&base, NodeId(root_id), &resolved.outcome) {
                         let _ = events.unbounded_send(Event::SnapshotUpdated);
@@ -2890,10 +2889,9 @@ fn open_engine_error(error: OpenError) -> EngineError {
 
 impl<T: SeamTypes> Drop for Engine<T> {
     fn drop(&mut self) {
-        // Signal the spawned liveness loop to stop; it holds only `Rc` clones,
-        // so it outlives the engine unless the latch is cleared here.
-        self.alive.set(false);
-        self.zeroize_shared_key_material();
+        // The spawned loops hold only `Rc` clones, so they outlive the engine
+        // unless it tears them down here.
+        self.shut_down();
     }
 }
 
@@ -4714,12 +4712,6 @@ mod tests {
                 enc_subkey.borrow().is_none(),
                 "and the session secret the tick borrowed"
             );
-
-            world.scheduler.advance(RE_PUT_INTERVAL);
-            assert!(
-                poll_each(&mut tasks).iter().all(Poll::is_ready),
-                "both loops stop at their next wake"
-            );
         }
 
         /// A forged owner-root record is fail-closed either way; without an event
@@ -4785,8 +4777,8 @@ mod tests {
                 1,
                 "the first steady-state poll recovers the write seed and holds"
             );
-            // Stamp the entry: a re-hold rebuilds it from the tick's own
-            // (content-CID-less) material and would drop the stamp.
+            // Stamp the entry: a re-hold rebuilds it wholesale, so the stamp
+            // surviving is the observable proof that no re-hold ran.
             engine
                 .held_records
                 .borrow_mut()

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -69,6 +69,9 @@ pub struct RootAdopter<'a, H, F> {
     /// whenever the resolved record carries an ascent link — every interior
     /// scope root does ([`Self::under_parent_node_seed`]).
     parent_node_seed: Option<Zeroizing<[u8; 32]>>,
+    /// Record bytes the caller already holds with the scope material recovered
+    /// from them ([`Self::holding`]).
+    held_current: Option<Vec<u8>>,
 }
 
 impl<'a, H, F> RootAdopter<'a, H, F> {
@@ -92,7 +95,20 @@ impl<'a, H, F> RootAdopter<'a, H, F> {
             assembled: RefCell::new(None),
             local_head: RefCell::new(None),
             parent_node_seed: None,
+            held_current: None,
         }
+    }
+
+    /// Declare the record bytes the caller already holds for this name, with the
+    /// scope material it recovered from them still in hand. An equal-floor
+    /// `Current` re-resolve of exactly those bytes then recovers nothing: the
+    /// record signs its head CID, so identical bytes address the identical head
+    /// block and would only reproduce the seeds already held — at the cost of two
+    /// HPKE opens every poll on an idle vault. `None` disables the skip.
+    #[must_use]
+    pub(crate) fn holding(mut self, record_bytes: Option<Vec<u8>>) -> Self {
+        self.held_current = record_bytes;
+        self
     }
 
     /// Supply the reader's ancestor node seed, `nodeSeed(parentOverrideSeed,
@@ -161,6 +177,11 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
         name: &IpnsName,
         record_bytes: &[u8],
     ) -> Result<Option<OwnScopeMaterial>, SeamError> {
+        // Steady state ([`Self::holding`]): these exact bytes are already held
+        // with their material recovered, so there is nothing left to open.
+        if self.held_current.as_deref() == Some(record_bytes) {
+            return Ok(None);
+        }
         // Recovery is fail-open, never a trust verdict: anything unproved yields
         // `Ok(None)`, held keyless (#752 F3: a Current never hardens).
         //
@@ -913,6 +934,49 @@ mod tests {
             http.requests().len(),
             1,
             "the head block is fetched once; recovery reuses adopt's candidate"
+        );
+    }
+
+    #[test]
+    fn bytes_already_held_short_circuit_the_equal_floor_recovery() {
+        let fx = Fixture::build(Some(OWB_WRITE_EPOCH));
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        let gw = gateway();
+        let adopter = fx
+            .adopter(&http, &floors, &fx.owner_identity_verifier, &gw)
+            .holding(Some(fx.record(1)));
+
+        assert!(
+            block_on(recover_at_floor(&adopter, &floors, &fx))
+                .expect("recovery is fail-open, never an error")
+                .is_none(),
+            "the caller already holds these bytes and the material behind them",
+        );
+    }
+
+    #[test]
+    fn a_hold_of_other_bytes_never_short_circuits_the_recovery() {
+        let fx = Fixture::build(Some(OWB_WRITE_EPOCH));
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        let gw = gateway();
+        // A hold on a different record of the same name: the fetched bytes are
+        // not the held ones, so the skip must not fire.
+        let adopter = fx
+            .adopter(&http, &floors, &fx.owner_identity_verifier, &gw)
+            .holding(Some(fx.record(2)));
+
+        assert_eq!(
+            block_on(recover_at_floor(&adopter, &floors, &fx))
+                .expect("fail-open")
+                .and_then(|material| material.write_scope_seed)
+                .as_deref(),
+            Some(&OWNER_ROOT_WRITE_SCOPE_SEED),
         );
     }
 

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -101,9 +101,9 @@ impl<'a, H, F> RootAdopter<'a, H, F> {
 
     /// Declare the record bytes the caller already holds for this name, with the
     /// scope material it recovered from them still in hand. An equal-floor
-    /// `Current` re-resolve of exactly those bytes then recovers nothing: the
+    /// `Current` re-resolve of exactly those bytes then recovers nothing — the
     /// record signs its head CID, so identical bytes address the identical head
-    /// block and would only reproduce the seeds already held — at the cost of two
+    /// block and can only reproduce the seeds already held, at the cost of two
     /// HPKE opens every poll on an idle vault. `None` disables the skip.
     #[must_use]
     pub(crate) fn holding(mut self, record_bytes: Option<Vec<u8>>) -> Self {
@@ -177,8 +177,7 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
         name: &IpnsName,
         record_bytes: &[u8],
     ) -> Result<Option<OwnScopeMaterial>, SeamError> {
-        // Steady state ([`Self::holding`]): these exact bytes are already held
-        // with their material recovered, so there is nothing left to open.
+        // Steady state — see [`Self::holding`].
         if self.held_current.as_deref() == Some(record_bytes) {
             return Ok(None);
         }

--- a/crates/engine/src/net/focus.rs
+++ b/crates/engine/src/net/focus.rs
@@ -10,11 +10,13 @@ use core::cell::RefCell;
 
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::seal::ReadBody;
+use futures_channel::mpsc;
 use zeroize::Zeroizing;
 
-use super::child::{ChildAdopter, resolve_child};
+use super::child::{ChildAdopter, ChildResolveError, resolve_child};
 use crate::content::Gateway;
-use crate::facade::{NodeId, NodeKind};
+use crate::facade::{Event, NodeId, NodeKind, emit_trust_violation};
+use crate::gate::GateError;
 use crate::seams::{FloorStore, Http, RecordTransport, SnapshotCache};
 use crate::sync::model::Snapshot;
 use crate::sync::project::project_folder;
@@ -30,6 +32,8 @@ pub(crate) struct FolderRefresh<'a, T, S, H, F> {
     pub(crate) gateway: &'a Gateway,
     /// The gate-passing base snapshot, merged into in place.
     pub(crate) base: &'a RefCell<Snapshot>,
+    /// Where a fail-closed rejection on a focused folder is surfaced.
+    pub(crate) events: &'a mpsc::UnboundedSender<Event>,
     /// The scope every focus folder is sealed under — the vault root scope;
     /// granted-subscope focus is a later slice.
     pub(crate) scope_id: [u8; 16],
@@ -48,8 +52,9 @@ where
     /// dropped a child unlinks it before the pass would project into it.
     ///
     /// Every failure is per-folder and non-fatal: an unresolvable record is
-    /// availability staleness, a gate rejection is fail-closed, and both leave
-    /// last-known-good rendering without stopping the pass.
+    /// availability staleness, a gate rejection is fail-closed and surfaced as
+    /// [`Event::AttributableAbuse`], and both leave last-known-good rendering
+    /// without stopping the pass.
     pub(crate) async fn run(&self, folders: &[NodeId]) -> bool {
         let mut changed = false;
         for folder in folders.iter().rev() {
@@ -64,13 +69,17 @@ where
                 self.scope_read_seed.clone(),
                 folder.0,
             );
-            // Staleness and gate rejection alike leave the base untouched; the
-            // host is told apart from neither today (surfacing: #796).
-            let Ok(adopted) =
-                resolve_child(self.transport, self.snapshot_cache, &adopter, &name).await
-            else {
-                continue;
-            };
+            let adopted =
+                match resolve_child(self.transport, self.snapshot_cache, &adopter, &name).await {
+                    Ok(adopted) => adopted,
+                    // Availability: the base keeps rendering last-known-good.
+                    Err(ChildResolveError::Unavailable(_))
+                    | Err(ChildResolveError::Gate(GateError::Seam(_))) => continue,
+                    Err(ChildResolveError::Gate(GateError::Rejected(rejection))) => {
+                        emit_trust_violation(self.events, name.as_str(), &rejection.to_string());
+                        continue;
+                    }
+                };
             let ReadBody::Folder {
                 modified_at,
                 children,
@@ -79,6 +88,11 @@ where
             else {
                 // The parent's child ref said folder: a sealed file body is a
                 // kind transplant, fail-closed.
+                emit_trust_violation(
+                    self.events,
+                    name.as_str(),
+                    "sealed file body behind a folder child ref",
+                );
                 continue;
             };
             changed |= project_folder(

--- a/crates/engine/src/net/focus.rs
+++ b/crates/engine/src/net/focus.rs
@@ -16,7 +16,7 @@ use zeroize::Zeroizing;
 use super::child::{ChildAdopter, ChildResolveError, resolve_child};
 use crate::content::Gateway;
 use crate::facade::{Event, NodeId, NodeKind, emit_trust_violation};
-use crate::gate::GateError;
+use crate::gate::{GateError, RejectionReason};
 use crate::seams::{FloorStore, Http, RecordTransport, SnapshotCache};
 use crate::sync::model::Snapshot;
 use crate::sync::project::project_folder;
@@ -52,9 +52,9 @@ where
     /// dropped a child unlinks it before the pass would project into it.
     ///
     /// Every failure is per-folder and non-fatal: an unresolvable record is
-    /// availability staleness, a gate rejection is fail-closed and surfaced as
-    /// [`Event::AttributableAbuse`], and both leave last-known-good rendering
-    /// without stopping the pass.
+    /// availability staleness, an attributable gate rejection is fail-closed and
+    /// surfaced as [`Event::AttributableAbuse`], and both leave last-known-good
+    /// rendering without stopping the pass.
     pub(crate) async fn run(&self, folders: &[NodeId]) -> bool {
         let mut changed = false;
         for folder in folders.iter().rev() {
@@ -69,17 +69,24 @@ where
                 self.scope_read_seed.clone(),
                 folder.0,
             );
-            let adopted =
-                match resolve_child(self.transport, self.snapshot_cache, &adopter, &name).await {
-                    Ok(adopted) => adopted,
-                    // Availability: the base keeps rendering last-known-good.
-                    Err(ChildResolveError::Unavailable(_))
-                    | Err(ChildResolveError::Gate(GateError::Seam(_))) => continue,
-                    Err(ChildResolveError::Gate(GateError::Rejected(rejection))) => {
-                        emit_trust_violation(self.events, name.as_str(), &rejection.to_string());
-                        continue;
+            let adopted = match resolve_child(self.transport, self.snapshot_cache, &adopter, &name)
+                .await
+            {
+                Ok(adopted) => adopted,
+                // Availability: the base keeps rendering last-known-good.
+                Err(
+                    ChildResolveError::Unavailable(_) | ChildResolveError::Gate(GateError::Seam(_)),
+                ) => continue,
+                Err(ChildResolveError::Gate(GateError::Rejected(rejection))) => {
+                    // A folder the lazy wave has not swept yet is epoch-lagged
+                    // (CONTEXT.md): sweep-pending staleness, not abuse. Every
+                    // other rejection here is an attributable one.
+                    if !matches!(rejection.reason, RejectionReason::EpochBelowFloor { .. }) {
+                        emit_trust_violation(self.events, name.as_str(), rejection);
                     }
-                };
+                    continue;
+                }
+            };
             let ReadBody::Folder {
                 modified_at,
                 children,

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -26,7 +26,7 @@ use cipherbox_engine::facade::PendingClass;
 use cipherbox_engine::net::author::{AuthoredHead, EnvelopeAuthoring, author_child_envelope};
 use cipherbox_engine::net::{ChildAdopter, REGISTRY_BATCH_MAX, ResolveOutcome, resolve};
 use cipherbox_engine::seams::{
-    BoxedTask, HttpRequest, HttpResponse, OpId, RecordTransport, SeamError, SeamResult,
+    BoxedTask, FloorStore, HttpRequest, HttpResponse, OpId, RecordTransport, SeamError, SeamResult,
     StagingStore, UnixMillis,
 };
 use cipherbox_engine::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
@@ -2905,6 +2905,42 @@ fn a_planted_focus_record_never_renders() {
             "{bent} raises exactly one abuse event"
         );
     }
+}
+
+/// Epoch lag is sweep-pending staleness, not abuse (CONTEXT.md "Epoch lag"): a
+/// focused folder the lazy wave has not swept yet rejects fail-closed, but the
+/// owner's own rotation must not read as an attack on the host's abuse channel.
+#[test]
+fn an_epoch_lagged_focus_folder_rejects_without_raising_abuse() {
+    let DeepCreate {
+        world,
+        bob,
+        mut engine_b,
+        mut events_b,
+        mut tasks_b,
+        photos,
+        ..
+    } = deep_create_seen_by_a_second_device();
+    block_on(engine_b.command(Command::SetFocus { node: Some(photos) })).unwrap();
+    assert_eq!(listed_names(&engine_b, photos), ["2026"]);
+
+    // A rotation raised the scope's read-epoch floor past the epoch this folder
+    // still publishes under.
+    block_on(bob.floor_store.raise_epoch_floor(&SCOPE, EPOCH + 1)).unwrap();
+    let _ = events_so_far(&mut events_b);
+    tick(&world, &engine_b, &mut tasks_b);
+
+    assert_eq!(
+        listed_names(&engine_b, photos),
+        ["2026"],
+        "last-known-good stays pinned"
+    );
+    assert!(
+        events_so_far(&mut events_b)
+            .iter()
+            .all(|event| !matches!(event, Event::AttributableAbuse { .. })),
+        "an unswept folder is not an attacker"
+    );
 }
 
 /// An unreachable record plane is availability staleness, never data loss: the

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -2694,6 +2694,7 @@ struct DeepCreate {
     /// the account's scope read seed and the network are shared with device A.
     bob: FakeDevice,
     engine_b: Engine<FakeSeamTypes>,
+    events_b: EventStream,
     tasks_b: Vec<BoxedTask>,
     photos: NodeId,
     deep: NodeId,
@@ -2725,12 +2726,13 @@ fn deep_create_seen_by_a_second_device() -> DeepCreate {
     let deep = child_id(&engine_a, photos, "2026");
 
     let bob = world.device(b"alice-second-device");
-    let (engine_b, _events_b, tasks_b) = boot(&world, &blocks, &bob, 7);
+    let (engine_b, events_b, tasks_b) = boot(&world, &blocks, &bob, 7);
     DeepCreate {
         world,
         blocks,
         bob,
         engine_b,
+        events_b,
         tasks_b,
         photos,
         deep,
@@ -2828,6 +2830,7 @@ fn a_planted_focus_record_never_renders() {
         world,
         blocks,
         mut engine_b,
+        mut events_b,
         mut tasks_b,
         photos,
         deep,
@@ -2884,11 +2887,22 @@ fn a_planted_focus_record_never_renders() {
         ),
     ] {
         plant_record(&world.record_store, &blocks, photos, planted);
+        let _ = events_so_far(&mut events_b);
         tick(&world, &engine_b, &mut tasks_b);
         assert_eq!(
             listed_names(&engine_b, photos),
             held,
             "{bent} never renders; last-known-good is pinned"
+        );
+        // Fail-closed is not silent: the focus leg surfaces the rejection so a
+        // persistent forgery cannot look like an idle folder.
+        assert_eq!(
+            events_so_far(&mut events_b)
+                .into_iter()
+                .filter(|event| matches!(event, Event::AttributableAbuse { .. }))
+                .count(),
+            1,
+            "{bent} raises exactly one abuse event"
         );
     }
 }


### PR DESCRIPTION
Three background-loop fixes in one region of `crates/engine/src/facade.rs`: what the spawned loops keep of the session secret, what they do with a fail-closed resolve outcome, and what a steady-state poll costs an idle vault.

Closes #795
Closes #796
Closes #800
Part of #752

## 795 — least-privilege capture, and no key material past the engine

The resolve-tick loop captured `Rc<SessionIdentity>`, which retains the raw login secret, the owner pointer seed and the ECDSA identity signer — while the pass needs only the encryption subkey and the (public) owner verifier. `Drop` cleared the alive latch, but a parked task is not polled until its next scheduler wake (up to `RE_PUT_INTERVAL` for the liveness loop), so the session, the held records' per-name renewal signers and the recovered scope seeds all stayed resident across that window.

- `Engine::session` is now `Option<SessionIdentity>`, owned outright — nothing can share it, so the login secret drops with the engine.
- The tick loop reads the enc subkey from a shared cell and owns a copy for exactly one pass.
- `Engine::shut_down`, called from `Drop`, sets the alive latch and drops the enc-subkey cell, the held records and both scope-seed maps in one place. `try_borrow_mut` throughout, because a panic while dropping aborts.

## 796 — a fail-closed rejection is no longer silent

`ResolveOutcome::TrustViolation` was discarded on the tick loop's root leg, and gate rejections were discarded on the focus-window leg (both the poll pass and `Command::SetFocus`). Data stayed fail-closed, but a persistently forged record produced no event and no log — indistinguishable from an idle vault.

Both legs now emit `Event::AttributableAbuse`, parallel to the liveness loop's existing `Event::RenewalFailed` surfacing. The description carries the record's `ipnsName` and `GateRejection`'s `Display` — a stage name and a check name, both `&'static str`; no key material, no floor or sequence values.

Fail-closed behaviour is unchanged: this is observability only. The rejected record is still never held and never rendered, and last-known-good stays pinned.

One carve-out, from the crypto-privacy gate: on the focus leg a `RejectionReason::EpochBelowFloor` is a folder the lazy wave has not swept yet — "sweep-pending staleness, not a revocation" per `CONTEXT.md` "Epoch lag" and `grants/revocation.rs`'s `ResolutionClass::EpochLag`. Reporting the owner's own rotation on the abuse channel every poll would bury real forgeries in noise, so that reason is excluded there and covered by its own reject vector.

## 800 — steady-state polls stop re-recovering and re-holding

On the owner's own root at equal-floor `Current`, every poll re-opened the owner blob and the owner-write-blob (two HPKE opens) and re-inserted an already-held record, forever, on an idle vault.

`RootAdopter::holding` lets the tick declare the record bytes it already holds; `recover_own_scope_material` short-circuits to `Ok(None)` when the freshly fetched, verified bytes are exactly those. Nothing is weakened: the record signs its head CID, so identical bytes address an identical head block and can only reproduce material already in hand. `Ok(None)` is the same value both re-imposed checks return on failure, and the seed maps are insert-only, so the skip can never install anything the checks would have rejected. Any different bytes at the same name miss the compare and take the full path.

The precondition is computed in the facade: both scope seeds present for the node and a held record whose routing key matches the polled name.

## Tests

- `engine_drop_clears_the_key_material_the_spawned_loops_share` — the shared cells are empty after `drop(engine)` while the tasks are still parked.
- `a_persistently_forged_steady_state_record_raises_an_abuse_event` — one event per forged poll, naming the record and the check, with last-known-good still rendering.
- `a_steady_state_poll_neither_re_recovers_nor_re_holds` — a stamped held entry survives the next tick.
- `bytes_already_held_short_circuit_the_equal_floor_recovery` plus its negative twin on different bytes.
- `an_epoch_lagged_focus_folder_rejects_without_raising_abuse` — verified non-vacuous against an inverted guard.
- `a_planted_focus_record_never_renders` now also asserts one abuse event per planted forgery.

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` all run against `git diff main...HEAD`. Security review returned no findings. Folded back: single teardown path, the alive latch kept as the one loop-stop signal, comment duplication trimmed, and the epoch-lag carve-out above.

Two findings were deliberately not folded in and are filed with dependency edges:

- #1040 — cached scope seeds are never evicted when the epoch floor rises. Pre-existing; the gate's floor check is an install guard, not a retention guard.
- #1041 — a re-hold wipes the content CIDs the drain published. Pre-existing; this PR reduces its incidence.

Not deduped: a persistent rejection emits one event per poll, matching how `RenewalFailed` surfaces per pass. Hosts already dedup `DeadLetter` by id.

## Scope

`Event::AttributableAbuse` keeps its single `description` field rather than splitting out a `routing_key`, because the client worker's event codec is owned by a concurrent PR and splitting it there would drop the name before it reached the host.

#775 and #793 remain open under #752 and are deferred to a follow-up — they land in `sync/boot.rs` and `gate/adoption.rs`, which a concurrent PR is editing. #752 stays open.

## Gates run

`cargo fmt --all --check`, `cargo clippy --all-targets`, `cargo test -p cipherbox-engine -p cipherbox-core`, and `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` — all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Improved handling of cleared encryption and session data during shutdown.
  * Added attributable abuse events for forged or invalid records while ignoring expected stale-data conditions.
  * Preserved last-known-good folder data when updates are behind the current epoch.

* **Performance**
  * Reduced redundant recovery work when records and encryption seeds are already available.

* **Tests**
  * Expanded coverage for key cleanup, trust-violation reporting, stale data, and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->