### PR TITLE
fix: bound vault settings freshness and op-drain correctness

### DIFF
--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -131,7 +131,9 @@ bytes (#28 D2).
   from the authenticated recovery endpoint and extracts the last-known CID —
   or recovers it from the pin set's name→CID mapping — then mints a fresh
   record with a fresh signature; lapse is an availability event, never loss
-  (#24 lapse semantics).
+  (#24 lapse semantics). The adoption gate therefore does **not** reject on
+  EOL; the one carve-out is the vault settings resolve, whose reader is always
+  its own signer (see "Vault settings load").
 - **Retirement**: retire = remove my registry rows; timing is engine policy
   (#34 D4). Interior old names batch-retire at name-wave completion; the old
   scope-root name lingers serving the tombstone until the migration window
@@ -227,21 +229,57 @@ degraded outcome applies a different policy rather than showing stale data.
   consumer that branches only on the resolved case, letting the degraded ones
   fall through to the defaults, reintroduces exactly the widening this policy
   exists to prevent.
+- **A lapsed EOL is refused here, and only here.** Plane-wide an EOL lapse is
+  an availability event recovered by revival (above), because a gate-level
+  rejection would lock every grantee out of a dormant owner's vault — a read
+  regression, not a hardening. The settings record is the one record whose
+  reader is always its signer, so refusing a lapsed one strands nobody: the
+  session holding the login secret can republish on the spot. That is the
+  principled carve-out, and it is what bounds replay on a device with no floor
+  to compare against — a fresh install otherwise admits any owner-signed
+  record the network serves, including one captured before the member rotated
+  a BYO `access_token` the engine would then present as a bearer credential.
+  The lapse degrades through the last-known-good path like every other
+  reason. The encode side needs no matching guard: the EOL is `now + 90 days`
+  off the injected clock, so a publish structurally cannot mint an
+  already-expired record.
+- **The sealed body carries a monotonic revision.** The outer sequence cannot
+  order two records at the *same* sequence, and an unconfirmed publish
+  followed by a retry mints exactly that: two owner-signed records at one
+  sequence, either of which a chosen-record adversary can serve forever. The
+  revision is minted **per publish attempt, advanced before the PUT** — one
+  derived from the confirm-gated sequence floor re-mints the same value on the
+  retry and disambiguates nothing. A reader refuses a revision below the
+  highest it has adopted, which is a trust violation and not staleness. The
+  writer's mint counter and the reader's adopted high-water are separate
+  durable values: an attempt that never landed advances only the former, so it
+  never makes a device refuse the live record it failed to replace.
+- **The cold-device anchor is the EOL, and only the EOL.** Every durable seam
+  is device-local, so a fresh install has neither a sequence floor nor an
+  adopted revision to hold a record to; the revision closes the fork residual
+  on a device with state, not on one without. Chaining the settings head CID
+  into the vault pointer would give a cold device an anchor, but it inverts
+  the record's whole purpose — settings resolve *before* any vault resolve
+  precisely so a self-hosting owner never needs CipherBox to tell them where
+  their own node is, and a BYO member would have to reach the network they
+  configured in settings in order to read those settings. An API-held counter
+  is refused outright: no client resolve path touches the API's record cache.
+  So a cold device's bound is the 90-day EOL window, stated rather than
+  closed.
 - **Residual: the cached copy has no freshness bound.** It is bound to the
   account by its seal alone — no sequence, no name, no time — so a party who
   can write this device's durable store can pin it to any settings generation
   the account ever published; every historical head block is a public,
   content-addressed object, so only the store write is privileged. The
-  per-name sequence floor is no defence here: it is device-local and lives
-  beside the cache, so the same party moves both. That party can equally
-  _delete_ the entry and force the defaults path, which is the pre-cache
-  behaviour — so the anti-downgrade property holds against a record-plane
-  adversary, not against one already inside the device's storage. The same
-  staleness arrives with no adversary at all: a device stuck degraded keeps
-  its copy indefinitely, including a BYO credential the member has since
-  rotated, which is why the reason is reported rather than swallowed. A real
-  bound needs a per-account anchor — an EOL check or a monotonic revision in
-  the sealed body — neither of which the settings record carries today.
+  per-name sequence floor and the adopted revision are no defence here: both
+  are device-local and live beside the cache, so the same party moves all
+  three. That party can equally _delete_ the entry and force the defaults
+  path, which is the pre-cache behaviour — so the anti-downgrade property
+  holds against a record-plane adversary, not against one already inside the
+  device's storage. The same staleness arrives with no adversary at all: a
+  device stuck degraded keeps its copy indefinitely, including a BYO
+  credential the member has since rotated, which is why the reason is reported
+  rather than swallowed.
 
 ## Sync core
 

--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -242,7 +242,10 @@ degraded outcome applies a different policy rather than showing stale data.
   The lapse degrades through the last-known-good path like every other
   reason. The encode side needs no matching guard: the EOL is `now + 90 days`
   off the injected clock, so a publish structurally cannot mint an
-  already-expired record.
+  already-expired record. Residual until the settings record joins the held set
+  the sub-EOL renewal loop walks: an account whose settings have not been
+  re-saved inside the window lapses on its own, and the placement decision then
+  fails closed for want of a copy it can authenticate.
 - **The sealed body carries a monotonic revision.** The outer sequence cannot
   order two records at the *same* sequence, and an unconfirmed publish
   followed by a retry mints exactly that: two owner-signed records at one
@@ -250,10 +253,16 @@ degraded outcome applies a different policy rather than showing stale data.
   revision is minted **per publish attempt, advanced before the PUT** — one
   derived from the confirm-gated sequence floor re-mints the same value on the
   retry and disambiguates nothing. A reader refuses a revision below the
-  highest it has adopted, which is a trust violation and not staleness. The
-  writer's mint counter and the reader's adopted high-water are separate
-  durable values: an attempt that never landed advances only the former, so it
-  never makes a device refuse the live record it failed to replace.
+  highest it has adopted **at that sequence**, which is a trust violation and
+  not staleness; a record at a strictly higher sequence won its own CAS and is
+  never held to a device-local counter, or a second device's legitimate publish
+  would be refused forever. The writer's mint counter and the reader's adopted
+  high-water are separate durable values: an attempt that never landed advances
+  only the former, so it never makes a device refuse the live record it failed
+  to replace. A confirmed publish raises the reader's bar and seeds
+  last-known-good with what it published, so a record withheld right after a
+  settings change cannot pin the device to the generation it replaced —
+  including a BYO credential the member has just rotated away from.
 - **The cold-device anchor is the EOL, and only the EOL.** Every durable seam
   is device-local, so a fresh install has neither a sequence floor nor an
   adopted revision to hold a record to; the revision closes the fork residual

--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -247,7 +247,7 @@ degraded outcome applies a different policy rather than showing stale data.
   re-saved inside the window lapses on its own, and the placement decision then
   fails closed for want of a copy it can authenticate.
 - **The sealed body carries a monotonic revision.** The outer sequence cannot
-  order two records at the *same* sequence, and an unconfirmed publish
+  order two records at the _same_ sequence, and an unconfirmed publish
   followed by a retry mints exactly that: two owner-signed records at one
   sequence, either of which a chosen-record adversary can serve forever. The
   revision is minted **per publish attempt, advanced before the PUT** — one
@@ -268,7 +268,7 @@ degraded outcome applies a different policy rather than showing stale data.
   adopted revision to hold a record to; the revision closes the fork residual
   on a device with state, not on one without. Chaining the settings head CID
   into the vault pointer would give a cold device an anchor, but it inverts
-  the record's whole purpose — settings resolve *before* any vault resolve
+  the record's whole purpose — settings resolve _before_ any vault resolve
   precisely so a self-hosting owner never needs CipherBox to tell them where
   their own node is, and a BYO member would have to reach the network they
   configured in settings in order to read those settings. An API-held counter

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -38,7 +38,7 @@ use crate::content::{
 };
 use crate::entropy::Entropy;
 use crate::gate::{GateError, floor};
-use crate::net::retire::retire;
+use crate::net::retire::{OrphanHeads, retire};
 use crate::net::{
     Adopter, ChildAdopter, ChildResolveError, EolRenewResult, FolderRefresh, HeldMaterial,
     HeldRecord, HeldRecords, LivenessControl, PublishError, PublishOutcome, RE_PUT_INTERVAL,
@@ -52,7 +52,7 @@ use crate::session::SessionIdentity;
 use crate::storage_policy::StoragePolicy;
 use crate::sync::boot::{ColdStartError, ColdStartOutcome, ColdStartParams, cold_start};
 use crate::sync::cancel::UploadCancels;
-use crate::sync::drain::{Drain, DrainReport, DrainScope};
+use crate::sync::drain::{Drain, DrainReport, DrainScope, published_op_mark};
 use crate::sync::model::{NodeMeta, Snapshot, collation_key};
 use crate::sync::op::{NewNode, Op, OpKind, Replaced, StagedContent};
 use crate::sync::overlay::apply_overlay;
@@ -1250,7 +1250,7 @@ pub struct Engine<T: SeamTypes> {
     /// Head blocks the drain uploaded for a publish that never reached the
     /// record transport, pending retirement. Session-lived so a retire the
     /// registry refused goes out again on a later pass (#921).
-    orphan_heads: Rc<RefCell<Vec<String>>>,
+    orphan_heads: Rc<OrphanHeads>,
     /// Session-alive latch: cleared on drop so the spawned liveness loop
     /// stops at its next wake instead of re-PUTting after the engine is gone.
     alive: Rc<Cell<bool>>,
@@ -1306,7 +1306,7 @@ impl<T: SeamTypes> Engine<T> {
                 dead_letters: Rc::new(RefCell::new(BTreeMap::new())),
                 queue_scan: RefCell::new(QueueScanMemo::default()),
                 blocked: Rc::new(RefCell::new(None)),
-                orphan_heads: Rc::new(RefCell::new(Vec::new())),
+                orphan_heads: Rc::new(OrphanHeads::default()),
                 alive: Rc::new(Cell::new(true)),
                 session: None,
                 api: None,
@@ -2257,6 +2257,16 @@ impl<T: SeamTypes> Engine<T> {
         let Some(root_cid) = op.content_root_cid().map(<[u8]>::to_vec) else {
             return Err(EngineError::NotAnUpload { op_id });
         };
+        // The durable half of the publish-entry interlock: a reboot clears the
+        // session-scoped one, and a version whose record PUT was acknowledged
+        // must stay uncancellable across it.
+        if published_op_mark(&self.seams.staging_store)
+            .await
+            .map_err(EngineError::from_seam)?
+            .is_some_and(|mark| op_id.0 <= mark)
+        {
+            return Err(EngineError::TooLateToCancel { op_id });
+        }
         // Claimed before anything is undone, and refused once the drain holds
         // the op for publish — cancel never mutates published state.
         if !self.cancels.borrow_mut().request(op_id) {

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -2250,6 +2250,7 @@ impl<T: SeamTypes> Engine<T> {
     /// Staged bytes are **released**, not preserved: the rule that splits the
     /// two is whether the engine gave up on the op or the user did (#824).
     async fn cancel_upload(&self, op_id: OpId) -> Result<(), EngineError> {
+        let session = self.session.as_ref().ok_or(EngineError::NotStarted)?;
         let queued = self.scan_queue().await?.mine;
         let Some((_, op)) = queued.iter().find(|(id, _)| *id == op_id) else {
             return Err(EngineError::TooLateToCancel { op_id });
@@ -2258,9 +2259,10 @@ impl<T: SeamTypes> Engine<T> {
             return Err(EngineError::NotAnUpload { op_id });
         };
         // The durable half of the publish-entry interlock: a reboot clears the
-        // session-scoped one, and a version whose record PUT was acknowledged
-        // must stay uncancellable across it.
-        if published_op_mark(&self.seams.staging_store)
+        // session-scoped one, and a version whose record publish was confirmed
+        // must stay uncancellable across it. Read under this session's own
+        // identity, the same one the mark was written under.
+        if published_op_mark(&self.seams.staging_store, session.enc_subkey())
             .await
             .map_err(EngineError::from_seam)?
             .is_some_and(|mark| op_id.0 <= mark)

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -28,6 +28,12 @@
 //!
 //! A grant blob's epoch field is an advisory routing hint and has **no**
 //! advancement path here — deliberately. Nothing reads it as authority.
+//!
+//! One non-floor value squats in the sequence namespace: the vault settings
+//! write plane's revision mint counter, under a `settings-revision-mint/`
+//! prefix ([`crate::settings`]). It is a local write clock, never an adoption
+//! bar, so it raises the store directly; the bar it feeds
+//! (`settings-revision/`) moves only through [`advance_sequence_on_unseal`].
 
 use cipherbox_core::payload::RepointObject;
 

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -73,9 +73,9 @@ pub use grants::{
 };
 pub use mailbox::{VerifiedMailboxItem, poll_verified, post_sealed};
 pub use net::{
-    AdoptOutcome, Adopter, HeldRecord, HeldRecords, PreflightError, PublishError, PublishOutcome,
-    PublishRequest, RePutResult, RecordPointerFetch, RecordPublishError, ResolveOutcome, Resolved,
-    ReviveError, ReviveRequest, RootAdopter, publish, resolve, revive,
+    AdoptOutcome, Adopter, HeldRecord, HeldRecords, OrphanHeads, PreflightError, PublishError,
+    PublishOutcome, PublishRequest, RePutResult, RecordPointerFetch, RecordPublishError,
+    ResolveOutcome, Resolved, ReviveError, ReviveRequest, RootAdopter, publish, resolve, revive,
 };
 pub use profile::SyncTimingProfile;
 pub use rotation::{

--- a/crates/engine/src/net/eol.rs
+++ b/crates/engine/src/net/eol.rs
@@ -10,6 +10,12 @@
 //! decisions: **renewal** (below the threshold, republish at seq+1) and
 //! **expiry** (a >EOL lapse, revive from the recovery endpoint). Determinism
 //! law: every function here takes the instant as a [`UnixMillis`] argument.
+//!
+//! [`is_expired`] carries one further verdict, outside liveness: the vault
+//! settings resolve refuses a lapsed record as non-authoritative rather than
+//! reviving it, because its reader is always its own signer
+//! (blueprint/engine.md "Vault settings load"). No other resolve path checks
+//! EOL — plane-wide a lapse is availability, not trust.
 
 use core::time::Duration;
 

--- a/crates/engine/src/net/eol.rs
+++ b/crates/engine/src/net/eol.rs
@@ -11,11 +11,8 @@
 //! **expiry** (a >EOL lapse, revive from the recovery endpoint). Determinism
 //! law: every function here takes the instant as a [`UnixMillis`] argument.
 //!
-//! [`is_expired`] carries one further verdict, outside liveness: the vault
-//! settings resolve refuses a lapsed record as non-authoritative rather than
-//! reviving it, because its reader is always its own signer
-//! (blueprint/engine.md "Vault settings load"). No other resolve path checks
-//! EOL — plane-wide a lapse is availability, not trust.
+//! [`is_expired`] carries one verdict outside liveness — the vault settings
+//! resolve's authority check (blueprint/engine.md "Vault settings load").
 
 use core::time::Duration;
 

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -55,6 +55,6 @@ pub use resolve::{AdoptOutcome, Adopter, OwnScopeMaterial, ResolveOutcome, Resol
 pub(crate) use resolve::{
     GatedResolve, HeldMaterial, refresh_base_from_outcome, resolve_and_hold, resolve_gated,
 };
-pub use retire::{retire, root_retire_ready};
+pub use retire::{OrphanHeads, orphaned_head, retire, root_retire_ready};
 pub use revival::{ReviveError, ReviveRequest, revive};
 pub use rotation::{OwnerRotationKeys, OwnerRotationNet};

--- a/crates/engine/src/net/retire.rs
+++ b/crates/engine/src/net/retire.rs
@@ -6,9 +6,85 @@
 //! scope-root name lingers serving the tombstone until the migration window
 //! closes ([`root_retire_ready`], stubbed — see below).
 
+use core::cell::RefCell;
+
 use super::REGISTRY_BATCH_MAX;
 use crate::api::{ApiClient, ApiError};
+use crate::net::publish::PublishError;
+use crate::net::record_publish::RecordPublishError;
 use crate::seams::{CredentialStore, Http};
+
+/// Head blocks a publish left charged and unreachable, pending retirement.
+///
+/// Session-lived and shared by every publisher — the drain clears it at the end
+/// of a pass, the settings publish at the point of failure — so a retire the
+/// registry refused goes out again rather than being lost.
+#[derive(Debug, Default)]
+pub struct OrphanHeads(RefCell<Vec<String>>);
+
+impl OrphanHeads {
+    /// Note one head block as orphaned, capped at [`REGISTRY_BATCH_MAX`] so a
+    /// session whose retires keep failing bounds its leak, not its memory.
+    pub fn record(&self, cid: &str) {
+        let mut pending = self.0.borrow_mut();
+        if pending.len() < REGISTRY_BATCH_MAX && !pending.iter().any(|held| held == cid) {
+            pending.push(cid.to_owned());
+        }
+    }
+
+    /// Retire what is pending. A refused retire keeps the set rather than
+    /// losing the only record of what to retire.
+    pub async fn retire_pending<H, C>(&self, api: &ApiClient<H, C>)
+    where
+        H: Http,
+        C: CredentialStore,
+    {
+        let pending = self.0.borrow().clone();
+        if pending.is_empty() {
+            return;
+        }
+        if retire(api, &pending).await.is_ok() {
+            let mut orphans = self.0.borrow_mut();
+            let sent = pending.len().min(orphans.len());
+            orphans.drain(..sent);
+        }
+    }
+
+    /// What is still pending, for tests and diagnostics.
+    #[must_use]
+    pub fn pending(&self) -> Vec<String> {
+        self.0.borrow().clone()
+    }
+}
+
+/// Whether a failed publish left its head block charged and unreachable: the
+/// upload landed under its own pin row, no record naming it reached the
+/// transport, and the retry re-authors under a fresh seal nonce
+/// (blueprint/engine.md "Resolve/publish pipeline: Retirement", #921).
+#[must_use]
+pub fn orphaned_head(error: &RecordPublishError) -> bool {
+    match error {
+        // A status answer is the server's own refusal, so it charged no row; a
+        // dropped connection or an unreadable 2xx may have left one behind.
+        RecordPublishError::Upload(error) => {
+            matches!(error, ApiError::Transport(_) | ApiError::Decode(_))
+        }
+        RecordPublishError::HeadCidMismatch { .. } => true,
+        RecordPublishError::Publish(error) => match error {
+            // The head block is already uploaded and charged when publish
+            // refuses, and no record naming it reached the transport.
+            PublishError::Register(_)
+            | PublishError::FloorRead(_)
+            | PublishError::RecordTooLarge { .. } => true,
+            // Nothing was ever addressed, so there is no CID to retire.
+            PublishError::EmptyHeadCid => false,
+            // No ack is not proof nothing stored: unpinning a head a live
+            // record may still name is loss, where the row is only a leak
+            // (#916).
+            PublishError::AllEndpointsFailed => false,
+        },
+    }
+}
 
 /// Batch-retire registry rows for `targets` (`ipnsName`s or CIDs). Idempotent
 /// server-side (blueprint/api.md), so a replayed batch — a resumed name wave, or

--- a/crates/engine/src/net/retire.rs
+++ b/crates/engine/src/net/retire.rs
@@ -33,7 +33,9 @@ impl OrphanHeads {
     }
 
     /// Retire what is pending. A refused retire keeps the set rather than
-    /// losing the only record of what to retire.
+    /// losing the only record of what to retire; a successful one clears the
+    /// heads it actually sent, so a head recorded by an overlapping publisher
+    /// mid-flight stays pending instead of being dropped unsent.
     pub async fn retire_pending<H, C>(&self, api: &ApiClient<H, C>)
     where
         H: Http,
@@ -44,9 +46,7 @@ impl OrphanHeads {
             return;
         }
         if retire(api, &pending).await.is_ok() {
-            let mut orphans = self.0.borrow_mut();
-            let sent = pending.len().min(orphans.len());
-            orphans.drain(..sent);
+            self.0.borrow_mut().retain(|cid| !pending.contains(cid));
         }
     }
 

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -167,12 +167,10 @@ pub fn settings_name(login_secret: &[u8]) -> IpnsName {
     IpnsName::from_public_key(&kdf::settings_ipns_keypair(login_secret).verifying_key())
 }
 
-/// Two prefixed keys in the floor store's sequence namespace, kept apart
-/// because the writer's counter and the reader's bar answer different
-/// questions: [`revision_adopted_key`] is the highest revision this device has
-/// *adopted*, [`revision_mint_key`] the highest it has ever *minted*. An
+/// The highest body revision this device has *adopted* — the reader's bar. Kept
+/// apart from [`revision_mint_key`], the highest it has ever *minted*: an
 /// attempt that never landed advances only the latter, so it never makes this
-/// device refuse the live record it failed to replace. Both are prefixed so
+/// device refuse the live record it failed to replace. Both are prefixed, so
 /// neither can collide with the bare `ipnsName` the per-name sequence floor is
 /// keyed by — a name carries no `/`.
 fn revision_adopted_key(name: &IpnsName) -> Vec<u8> {
@@ -194,10 +192,6 @@ fn prefixed_key(prefix: &[u8], name: &IpnsName) -> Vec<u8> {
 /// confirm-gated sequence floor re-mints the same value on a retry and so
 /// cannot tell two same-sequence forks apart.
 ///
-/// Seeded from the adopted high-water as well as this device's own mint
-/// counter, so a device that has read further than it has written still mints
-/// above what its own reader will accept.
-///
 /// AGENTS.md rule 8: the reader refuses a revision below its durable high-water,
 /// so a counter that did not actually advance fails the publish here,
 /// release-active, rather than sealing bytes the reader would reject.
@@ -206,18 +200,20 @@ async fn next_revision<F: FloorStore>(
     name: &IpnsName,
 ) -> Result<u64, SettingsPublishError> {
     let mint_key = revision_mint_key(name);
-    let read = |key: Vec<u8>| async move {
-        floors
-            .sequence_floor(&key)
+    let read = |key| async move {
+        floor::sequence_floor(floors, key)
             .await
+            .map(|floor| floor.unwrap_or(0))
             .map_err(SettingsPublishError::Floor)
     };
-    let minted = read(mint_key.clone()).await?.unwrap_or(0);
-    let adopted = read(revision_adopted_key(name)).await?.unwrap_or(0);
-    let next = minted
-        .max(adopted)
+    let next = read(&mint_key)
+        .await?
+        .max(read(&revision_adopted_key(name)).await?)
         .checked_add(1)
         .ok_or(SettingsPublishError::Revision)?;
+    // A local mint counter, not a record-plane advance, so it raises the store
+    // directly. Rule 8's guard is the compare: a store that reports a floor
+    // other than the one we asked for did not take our value.
     let stored = floors
         .raise_sequence_floor(&mint_key, next)
         .await
@@ -232,10 +228,11 @@ async fn next_revision<F: FloorStore>(
 /// publish port, so the record inherits register-first, seq-CAS, and confirm
 /// like every other record.
 #[allow(clippy::too_many_arguments)]
-pub async fn publish_settings<T, H, C, F, Sch>(
+pub async fn publish_settings<T, H, C, F, Sn, Sch>(
     transport: &T,
     api: &ApiClient<H, C>,
     floors: &F,
+    snapshots: &Sn,
     scheduler: &Sch,
     profile: &SyncTimingProfile,
     entropy: &mut dyn Entropy,
@@ -248,6 +245,7 @@ where
     H: Http,
     C: CredentialStore,
     F: FloorStore,
+    Sn: SnapshotCache,
     Sch: Scheduler + Clone + 'static,
 {
     validate(settings).map_err(SettingsPublishError::Byo)?;
@@ -270,7 +268,8 @@ where
     let enc_secret = kdf::enc_subkey(login_secret);
     let block = seal_settings_record(&enc_secret, &ephemeral, &body)
         .map_err(SettingsPublishError::Codec)?;
-    let head = preflight_settings(&enc_secret, block).map_err(SettingsPublishError::Preflight)?;
+    let head =
+        preflight_settings(&enc_secret, block.clone()).map_err(SettingsPublishError::Preflight)?;
 
     let receipt = match publish_record(
         transport,
@@ -307,7 +306,16 @@ where
     let PublishOutcome::Published { sequence } = receipt.outcome else {
         return Err(SettingsPublishError::Unconfirmed);
     };
+    // The confirm re-resolve read back our own bytes, so the writer has adopted
+    // what it just published: the bar rises, and last-known-good becomes these
+    // settings rather than the generation they replaced — otherwise a record
+    // withheld right after a change pins this device to a credential the member
+    // has already rotated away from.
+    let _ = snapshots.put(&settings_cache_key(&name), &block).await;
     floor::advance_sequence_on_unseal(floors, name.as_str().as_bytes(), sequence)
+        .await
+        .map_err(SettingsPublishError::Floor)?;
+    floor::advance_sequence_on_unseal(floors, &revision_adopted_key(&name), revision)
         .await
         .map_err(SettingsPublishError::Floor)?;
     Ok(receipt)
@@ -405,17 +413,13 @@ where
 {
     let key = name.as_str().as_bytes();
     let cache_key = settings_cache_key(name);
-    let adopted_key = revision_adopted_key(name);
     // Read ahead of the resolve so a degraded outcome has last-known-good to
     // fall back on; the cache never short-circuits the fetch.
     *cached = snapshots.get(&cache_key).await.ok().flatten();
     // The settings record belongs to no scope and carries no epoch, so the
-    // per-name sequence floor is its whole floor law. A floor the host cannot
-    // read is never treated as no floor.
+    // per-name sequence floor and the adopted body revision are its whole floor
+    // law. A floor the host cannot read is never treated as no floor.
     let Ok(durable) = floor::sequence_floor(floors, key).await else {
-        return Err(DefaultsReason::FloorUnreadable);
-    };
-    let Ok(adopted) = floor::sequence_floor(floors, &adopted_key).await else {
         return Err(DefaultsReason::FloorUnreadable);
     };
     let Some((verified, record_bytes)) = fanout_get_verify(transport, name).await else {
@@ -444,8 +448,16 @@ where
         return Err(DefaultsReason::Suppressed);
     };
     let body = open_settings_head(enc_secret, &block).ok_or(DefaultsReason::Unreadable)?;
+    let adopted_key = revision_adopted_key(name);
+    let Ok(adopted) = floor::sequence_floor(floors, &adopted_key).await else {
+        return Err(DefaultsReason::FloorUnreadable);
+    };
     let adopted = adopted.unwrap_or(0);
-    if body.revision < adopted {
+    // The revision arbitrates only what the sequence cannot: a fork *at* the
+    // sequence this device already adopted. A strictly newer record won its CAS
+    // against the network, and holding it to a device-local revision counter
+    // would refuse a second device's legitimate publish forever.
+    if sequence == floor && body.revision < adopted {
         return Err(DefaultsReason::RevisionRolledBack {
             floor: adopted,
             revision: body.revision,

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -36,15 +36,18 @@ use crate::content::validate_byo_config;
 use crate::content::{ByoIpfsConfig, ByoKind, Gateway, PinMode, ProviderError, RetentionPolicy};
 use crate::entropy::{Entropy, EntropyError};
 use crate::gate::floor;
+use crate::net::eol::is_expired;
 use crate::net::fanout_get_verify;
 use crate::net::fetch_head_block;
 use crate::net::publish::{PublishOutcome, PublishReceipt};
 use crate::net::record_publish::{
     PreflightError, RecordPublishError, RecordPublishRequest, preflight_settings, publish_record,
 };
+use crate::net::retire::{OrphanHeads, orphaned_head};
 use crate::profile::SyncTimingProfile;
 use crate::seams::{
     CredentialStore, FloorStore, Http, RecordTransport, Scheduler, SeamError, SnapshotCache,
+    UnixMillis,
 };
 
 /// The owner's client configuration, sealed into the vault settings record.
@@ -88,6 +91,9 @@ pub enum SettingsPublishError {
     Unconfirmed,
     /// The confirmed publish could not be recorded durably.
     Floor(SeamError),
+    /// The durable revision counter did not advance, so this publish would mint
+    /// a body revision the reader refuses (AGENTS.md rule 8).
+    Revision,
 }
 
 /// Why a load did not use the published record, carried by both degraded
@@ -113,6 +119,18 @@ pub enum DefaultsReason {
         /// The sequence the replayed record carried.
         sequence: u64,
     },
+    /// A record whose sealed body revision is below this device's durable
+    /// revision high-water: a same-sequence fork or a replay the outer sequence
+    /// cannot tell apart, never staleness.
+    RevisionRolledBack {
+        /// The durable revision high-water the record failed.
+        floor: u64,
+        /// The revision the refused body carried.
+        revision: u64,
+    },
+    /// The record's client-signed EOL has lapsed, so it is no longer
+    /// authoritative about the member's current configuration.
+    Expired,
     /// The load did not finish inside the profile's budget.
     TimedOut,
     /// A record was found but yielded no usable settings: it will not open
@@ -149,6 +167,67 @@ pub fn settings_name(login_secret: &[u8]) -> IpnsName {
     IpnsName::from_public_key(&kdf::settings_ipns_keypair(login_secret).verifying_key())
 }
 
+/// Two prefixed keys in the floor store's sequence namespace, kept apart
+/// because the writer's counter and the reader's bar answer different
+/// questions: [`revision_adopted_key`] is the highest revision this device has
+/// *adopted*, [`revision_mint_key`] the highest it has ever *minted*. An
+/// attempt that never landed advances only the latter, so it never makes this
+/// device refuse the live record it failed to replace. Both are prefixed so
+/// neither can collide with the bare `ipnsName` the per-name sequence floor is
+/// keyed by — a name carries no `/`.
+fn revision_adopted_key(name: &IpnsName) -> Vec<u8> {
+    prefixed_key(b"settings-revision/", name)
+}
+
+fn revision_mint_key(name: &IpnsName) -> Vec<u8> {
+    prefixed_key(b"settings-revision-mint/", name)
+}
+
+fn prefixed_key(prefix: &[u8], name: &IpnsName) -> Vec<u8> {
+    let mut key = prefix.to_vec();
+    key.extend_from_slice(name.as_str().as_bytes());
+    key
+}
+
+/// Mint the next body revision, advancing the durable counter **before** the
+/// PUT. Attempt-scoped, which is the whole point: a revision derived from the
+/// confirm-gated sequence floor re-mints the same value on a retry and so
+/// cannot tell two same-sequence forks apart.
+///
+/// Seeded from the adopted high-water as well as this device's own mint
+/// counter, so a device that has read further than it has written still mints
+/// above what its own reader will accept.
+///
+/// AGENTS.md rule 8: the reader refuses a revision below its durable high-water,
+/// so a counter that did not actually advance fails the publish here,
+/// release-active, rather than sealing bytes the reader would reject.
+async fn next_revision<F: FloorStore>(
+    floors: &F,
+    name: &IpnsName,
+) -> Result<u64, SettingsPublishError> {
+    let mint_key = revision_mint_key(name);
+    let read = |key: Vec<u8>| async move {
+        floors
+            .sequence_floor(&key)
+            .await
+            .map_err(SettingsPublishError::Floor)
+    };
+    let minted = read(mint_key.clone()).await?.unwrap_or(0);
+    let adopted = read(revision_adopted_key(name)).await?.unwrap_or(0);
+    let next = minted
+        .max(adopted)
+        .checked_add(1)
+        .ok_or(SettingsPublishError::Revision)?;
+    let stored = floors
+        .raise_sequence_floor(&mint_key, next)
+        .await
+        .map_err(SettingsPublishError::Floor)?;
+    if stored != next {
+        return Err(SettingsPublishError::Revision);
+    }
+    Ok(next)
+}
+
 /// Seal `settings` and publish them at [`settings_name`] through the shared
 /// publish port, so the record inherits register-first, seq-CAS, and confirm
 /// like every other record.
@@ -160,6 +239,7 @@ pub async fn publish_settings<T, H, C, F, Sch>(
     scheduler: &Sch,
     profile: &SyncTimingProfile,
     entropy: &mut dyn Entropy,
+    orphans: &OrphanHeads,
     login_secret: &[u8],
     settings: &VaultSettings,
 ) -> Result<PublishReceipt, SettingsPublishError>
@@ -171,7 +251,10 @@ where
     Sch: Scheduler + Clone + 'static,
 {
     validate(settings).map_err(SettingsPublishError::Byo)?;
-    let body = encode_settings_body(settings).map_err(SettingsPublishError::Codec)?;
+    let signer = kdf::settings_ipns_keypair(login_secret);
+    let name = IpnsName::from_public_key(&signer.verifying_key());
+    let revision = next_revision(floors, &name).await?;
+    let body = encode_settings_body(settings, revision).map_err(SettingsPublishError::Codec)?;
     let mut ephemeral = Zeroizing::new([0u8; 32]);
     entropy
         .fill(ephemeral.as_mut_slice())
@@ -189,9 +272,7 @@ where
         .map_err(SettingsPublishError::Codec)?;
     let head = preflight_settings(&enc_secret, block).map_err(SettingsPublishError::Preflight)?;
 
-    let signer = kdf::settings_ipns_keypair(login_secret);
-    let name = IpnsName::from_public_key(&signer.verifying_key());
-    let receipt = publish_record(
+    let receipt = match publish_record(
         transport,
         api,
         floors,
@@ -206,7 +287,18 @@ where
         },
     )
     .await
-    .map_err(SettingsPublishError::Publish)?;
+    {
+        Ok(receipt) => receipt,
+        Err(error) => {
+            // This publish runs outside a drain pass, so it clears its own
+            // orphan set rather than deferring to a pass boundary.
+            if orphaned_head(&error) {
+                orphans.record(head.cid());
+                orphans.retire_pending(api).await;
+            }
+            return Err(SettingsPublishError::Publish(error));
+        }
+    };
 
     // Only a confirmed publish advances the floor. Returning `Ok` on an
     // unconfirmed one would leave the writer's floor behind the network's
@@ -258,6 +350,7 @@ where
         &mut cached,
         &enc_secret,
         &name,
+        scheduler.now(),
     );
     let reason = match within(scheduler, profile.settings_load_budget, load).await {
         Some(Ok(settings)) => return SettingsLoad::Resolved(settings),
@@ -267,7 +360,10 @@ where
     // A rollback takes this arm like every other reason: pinning last-known-good
     // is what the record plane already owes a gate failure (blueprint/engine.md).
     match cached.and_then(|block| open_settings_head(&enc_secret, &block)) {
-        Some(settings) => SettingsLoad::Stale { settings, reason },
+        Some(body) => SettingsLoad::Stale {
+            settings: body.settings,
+            reason,
+        },
         None => SettingsLoad::Defaults(reason),
     }
 }
@@ -285,7 +381,7 @@ fn settings_cache_key(name: &IpnsName) -> Vec<u8> {
 /// the fetched copy reach their verdict here, through one seal open and one
 /// body grammar — so a copy this build cannot authenticate is discarded rather
 /// than applied.
-fn open_settings_head(enc_secret: &X25519Secret, block: &[u8]) -> Option<VaultSettings> {
+fn open_settings_head(enc_secret: &X25519Secret, block: &[u8]) -> Option<SettingsBody> {
     decode_settings_body(&open_settings_record(enc_secret, block).ok()?).ok()
 }
 
@@ -299,6 +395,7 @@ async fn resolve_settings<T, H, F, Sn>(
     cached: &mut Option<Vec<u8>>,
     enc_secret: &X25519Secret,
     name: &IpnsName,
+    now: UnixMillis,
 ) -> Result<VaultSettings, DefaultsReason>
 where
     T: RecordTransport,
@@ -308,6 +405,7 @@ where
 {
     let key = name.as_str().as_bytes();
     let cache_key = settings_cache_key(name);
+    let adopted_key = revision_adopted_key(name);
     // Read ahead of the resolve so a degraded outcome has last-known-good to
     // fall back on; the cache never short-circuits the fetch.
     *cached = snapshots.get(&cache_key).await.ok().flatten();
@@ -315,6 +413,9 @@ where
     // per-name sequence floor is its whole floor law. A floor the host cannot
     // read is never treated as no floor.
     let Ok(durable) = floor::sequence_floor(floors, key).await else {
+        return Err(DefaultsReason::FloorUnreadable);
+    };
+    let Ok(adopted) = floor::sequence_floor(floors, &adopted_key).await else {
         return Err(DefaultsReason::FloorUnreadable);
     };
     let Some((verified, record_bytes)) = fanout_get_verify(transport, name).await else {
@@ -325,6 +426,12 @@ where
             None => DefaultsReason::NoRecord,
         });
     };
+    // The reader of this record is always its signer, so a lapsed EOL is a
+    // refusal here rather than the availability event it is plane-wide
+    // (blueprint/engine.md "Vault settings load").
+    if is_expired(now, &verified.validity) {
+        return Err(DefaultsReason::Expired);
+    }
     let sequence = verified.sequence;
     let floor = durable.unwrap_or(0);
     if sequence < floor {
@@ -336,7 +443,14 @@ where
     let Ok((_, block)) = fetch_head_block(gateway, http, name, &record_bytes, None).await else {
         return Err(DefaultsReason::Suppressed);
     };
-    let settings = open_settings_head(enc_secret, &block).ok_or(DefaultsReason::Unreadable)?;
+    let body = open_settings_head(enc_secret, &block).ok_or(DefaultsReason::Unreadable)?;
+    let adopted = adopted.unwrap_or(0);
+    if body.revision < adopted {
+        return Err(DefaultsReason::RevisionRolledBack {
+            floor: adopted,
+            revision: body.revision,
+        });
+    }
     // Only a record that cleared its floor and opened becomes last-known-good,
     // and what is stored is the sealed block, so ciphertext-only-at-rest holds.
     let _ = snapshots.put(&cache_key, &block).await;
@@ -344,7 +458,8 @@ where
     // that will not open must not raise the bar the next resolve is held to.
     // Neither store failing is a verdict on settings we just authenticated.
     let _ = floor::advance_sequence_on_unseal(floors, key, sequence).await;
-    Ok(settings)
+    let _ = floor::advance_sequence_on_unseal(floors, &adopted_key, body.revision).await;
+    Ok(body.settings)
 }
 
 /// Run `work`, giving up once `budget` has elapsed on the injected scheduler.
@@ -417,10 +532,21 @@ fn validate(settings: &VaultSettings) -> Result<(), ProviderError> {
     }
 }
 
+/// The sealed body: the member's settings plus the attempt-scoped monotonic
+/// revision that orders two records the outer sequence cannot tell apart.
+#[derive(Debug)]
+struct SettingsBody {
+    settings: VaultSettings,
+    revision: u64,
+}
+
 /// Encode a settings body. Both the returned buffer and the transient `Value`
 /// tree carry the BYO access token verbatim, so this is the tree's terminal
 /// owner and the buffer is handed back in a zeroizing one.
-fn encode_settings_body(settings: &VaultSettings) -> Result<Zeroizing<Vec<u8>>, CodecError> {
+fn encode_settings_body(
+    settings: &VaultSettings,
+    revision: u64,
+) -> Result<Zeroizing<Vec<u8>>, CodecError> {
     let mut m = Map::new();
     m.insert(
         "byo",
@@ -449,6 +575,7 @@ fn encode_settings_body(settings: &VaultSettings) -> Result<Zeroizing<Vec<u8>>, 
         "pinMode",
         Value::Text(pin_mode_str(settings.pin_mode).to_string()),
     );
+    m.insert("revision", Value::Unsigned(revision));
 
     let mut tree = Value::Map(m);
     let encoded = encode(&tree).map(Zeroizing::new);
@@ -456,23 +583,23 @@ fn encode_settings_body(settings: &VaultSettings) -> Result<Zeroizing<Vec<u8>>, 
     encoded
 }
 
-fn decode_settings_body(bytes: &[u8]) -> Result<VaultSettings, BodyError> {
+fn decode_settings_body(bytes: &[u8]) -> Result<SettingsBody, BodyError> {
     let mut tree = decode(bytes)?;
     let decoded = read_settings_map(&mut tree);
     // Terminal owner of the decoded tree: the credential inside is wiped on
     // every exit, including the early returns a malformed body takes.
     tree.zeroize_bytes();
-    let settings = decoded?;
-    validate(&settings).map_err(BodyError::Byo)?;
-    Ok(settings)
+    let body = decoded?;
+    validate(&body.settings).map_err(BodyError::Byo)?;
+    Ok(body)
 }
 
 /// The body's keys, exhaustive at this version — a body carrying any other key
 /// was written by a build this one does not share a schema with.
-const BODY_KEYS: [&str; 3] = ["byo", "keepLatest", "pinMode"];
+const BODY_KEYS: [&str; 4] = ["byo", "keepLatest", "pinMode", "revision"];
 const BYO_KEYS: [&str; 3] = ["accessToken", "endpoint", "kind"];
 
-fn read_settings_map(tree: &mut Value) -> Result<VaultSettings, BodyError> {
+fn read_settings_map(tree: &mut Value) -> Result<SettingsBody, BodyError> {
     let Value::Map(map) = tree else {
         return Err(tree.as_map().unwrap_err().into());
     };
@@ -489,11 +616,15 @@ fn read_settings_map(tree: &mut Value) -> Result<VaultSettings, BodyError> {
             NonZeroU64::new(other.as_unsigned()?).ok_or(BodyError::RetainsNoVersions)?,
         ),
     };
+    let revision = req(map, "revision")?.as_unsigned()?;
     let byo = read_byo(map.get_mut("byo"))?;
-    Ok(VaultSettings {
-        pin_mode,
-        byo,
-        retention,
+    Ok(SettingsBody {
+        settings: VaultSettings {
+            pin_mode,
+            byo,
+            retention,
+        },
+        revision,
     })
 }
 
@@ -582,8 +713,15 @@ mod tests {
         }
     }
 
+    /// The revision the round-trip fixtures mint; any value works, so long as
+    /// the reader hands back the one the writer sealed.
+    const REVISION: u64 = 42;
+
     fn round_trip(settings: &VaultSettings) -> VaultSettings {
-        decode_settings_body(&encode_settings_body(settings).expect("encode")).expect("decode")
+        let body = decode_settings_body(&encode_settings_body(settings, REVISION).expect("encode"))
+            .expect("decode");
+        assert_eq!(body.revision, REVISION, "the revision round-trips");
+        body.settings
     }
 
     #[test]
@@ -616,15 +754,16 @@ mod tests {
             ..VaultSettings::default()
         };
         assert_eq!(
-            encode_settings_body(&settings).expect("encode"),
-            encode_settings_body(&settings).expect("encode"),
+            encode_settings_body(&settings, REVISION).expect("encode"),
+            encode_settings_body(&settings, REVISION).expect("encode"),
         );
     }
 
     #[test]
     fn a_body_this_version_does_not_share_a_schema_with_is_refused() {
         let settings = VaultSettings::default();
-        let mut tree = decode(&encode_settings_body(&settings).expect("encode")).expect("decode");
+        let mut tree =
+            decode(&encode_settings_body(&settings, REVISION).expect("encode")).expect("decode");
         let Value::Map(map) = &mut tree else {
             unreachable!("the body is a map")
         };
@@ -643,6 +782,7 @@ mod tests {
         m.insert("byo", Value::Null);
         m.insert("keepLatest", Value::Null);
         m.insert("pinMode", Value::Text("everywhere".to_owned()));
+        m.insert("revision", Value::Unsigned(1));
         assert_eq!(
             decode_settings_body(&encode(&Value::Map(m)).expect("encode")).unwrap_err(),
             BodyError::UnknownVariant { field: "pinMode" },
@@ -658,9 +798,24 @@ mod tests {
         m.insert("byo", Value::Null);
         m.insert("keepLatest", Value::Unsigned(0));
         m.insert("pinMode", Value::Text("hosted".to_owned()));
+        m.insert("revision", Value::Unsigned(1));
         assert_eq!(
             decode_settings_body(&encode(&Value::Map(m)).expect("encode")).unwrap_err(),
             BodyError::RetainsNoVersions,
+        );
+    }
+
+    /// A body from a build that predates the revision is not a body this one
+    /// can hold to a monotonic bar, so it is refused rather than read as zero.
+    #[test]
+    fn a_body_without_a_revision_is_refused() {
+        let mut m = Map::new();
+        m.insert("byo", Value::Null);
+        m.insert("keepLatest", Value::Null);
+        m.insert("pinMode", Value::Text("hosted".to_owned()));
+        assert_eq!(
+            decode_settings_body(&encode(&Value::Map(m)).expect("encode")).unwrap_err(),
+            BodyError::Codec(Malformed::MissingField { field: "revision" }.into()),
         );
     }
 
@@ -683,7 +838,7 @@ mod tests {
             };
             let refused = validate(&settings).unwrap_err();
             assert_eq!(
-                decode_settings_body(&encode_settings_body(&settings).expect("encode"))
+                decode_settings_body(&encode_settings_body(&settings, REVISION).expect("encode"))
                     .unwrap_err(),
                 BodyError::Byo(refused),
                 "{endpoint}: the reader must refuse what the writer refuses",

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -47,15 +47,15 @@ use crate::net::publish::{PublishError, PublishOutcome, PublishReceipt};
 use crate::net::record_publish::{
     HeadBinding, RecordPublishError, RecordPublishRequest, preflight, publish_record,
 };
-use crate::net::retire::retire;
+use crate::net::retire::{OrphanHeads, orphaned_head, retire};
 use crate::net::{
-    Adopter, ChildAdopter, HeldRecord, HeldRecords, LocalHead, REGISTRY_BATCH_MAX, ResolveOutcome,
-    RootAdopter, assemble_head_envelope, fanout_get_verify, resolve,
+    Adopter, ChildAdopter, HeldRecord, HeldRecords, LocalHead, ResolveOutcome, RootAdopter,
+    assemble_head_envelope, fanout_get_verify, resolve,
 };
 use crate::profile::SyncTimingProfile;
 use crate::rotation::derive_write_name;
 use crate::seams::{
-    CredentialStore, FloorStore, Http, OpId, RecordTransport, Scheduler, SnapshotCache,
+    CredentialStore, FloorStore, Http, OpId, RecordTransport, Scheduler, SeamResult, SnapshotCache,
     StagingStore,
 };
 use crate::session::SessionIdentity;
@@ -79,6 +79,24 @@ use crate::sync::staging::{preserve_dead_letter, release_version_blocks, version
 ///
 /// [`orphan_staging_keys`]: crate::sync::staging::orphan_staging_keys
 pub const DRAINED_OP_MARK_KEY: &[u8] = b"cipherbox/drained-op";
+
+/// The staging key holding the published-op high-water mark: every op id at or
+/// below the stored value had its record PUT acknowledged, so its version is
+/// live at its name even if the op is still queued.
+///
+/// The queue is strict FIFO and a pass stops at the first op it cannot publish,
+/// so every id below the one being marked has already left the queue — the mark
+/// is contiguous by construction, like [`DRAINED_OP_MARK_KEY`], and shares the
+/// same durability domain as the ids it names.
+///
+/// It is raised between the record PUT and the block release, which is the
+/// window a crash leaves a published op queued. Without it that op replays,
+/// re-uploads its leaves, and a cancel landing mid-replay unpins content a live
+/// record names — the session-scoped publish-entry interlock does not survive
+/// the reboot. [`orphan_staging_keys`] treats it as referenced.
+///
+/// [`orphan_staging_keys`]: crate::sync::staging::orphan_staging_keys
+pub const PUBLISHED_OP_MARK_KEY: &[u8] = b"cipherbox/published-op";
 
 /// What one drain pass did.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -299,9 +317,8 @@ pub(crate) struct Drain<'a, T, H: Http, C: CredentialStore, F, S, St, Sch> {
     /// The over-quota hold, shared with the facade's read surface. It clears
     /// only here, on a quota probe reporting room.
     pub(crate) blocked: &'a RefCell<Option<BlockedOp>>,
-    /// Head blocks this session's publishes orphaned, pending retirement
-    /// ([`Drain::retire_orphan_heads`]).
-    pub(crate) orphan_heads: &'a RefCell<Vec<String>>,
+    /// Head blocks this session's publishes orphaned, pending retirement.
+    pub(crate) orphan_heads: &'a OrphanHeads,
     /// The upload-cancel interlock, shared with the facade's cancel command.
     pub(crate) cancels: &'a RefCell<UploadCancels>,
     /// The facade's outbound event stream, for upload progress.
@@ -427,7 +444,7 @@ where
     /// pass orphaned.
     pub(crate) async fn run(&self, scope: &DrainScope<'_>) -> DrainReport {
         let report = self.drain_queue(scope).await;
-        self.retire_orphan_heads().await;
+        self.orphan_heads.retire_pending(self.api).await;
         report
     }
 
@@ -603,11 +620,21 @@ where
         // contract promises only strictly-increasing ids, so a host that starts
         // at 0 must not lose its first op.
         let drained = self.drained_mark().await?;
+        let published = published_op_mark(self.staging).await.map_err(seam)?;
         let mut mine = Vec::with_capacity(scan.mine.len());
         for (op_id, op) in scan.mine {
             if drained.is_some_and(|mark| op_id.0 <= mark) {
                 self.dequeue_op(op_id).await?;
                 report.restore_residue.push(op_id);
+                continue;
+            }
+            // Its record PUT was acknowledged before the crash that left it
+            // queued, so its version is already live: republishing it would
+            // re-expose blocks a live record names to the cancel path.
+            if published.is_some_and(|mark| op_id.0 <= mark) {
+                self.dequeue_op(op_id).await?;
+                self.release_staged_blocks(&op).await;
+                report.dropped.push(op_id);
                 continue;
             }
             mine.push((op_id, op));
@@ -1109,11 +1136,12 @@ where
         pass.folder_mut(source)?
             .children
             .retain(|child| child.id != target.0);
-        if self
-            .publish_folder(scope, pass, source, modified_at)
-            .await
-            .is_err()
-        {
+        // The source-remove keeps its own classification through the
+        // compensation: `Unclassified` is the one verdict that retries free and
+        // forever, so a quota refusal, a permanent one, or a spent attempt must
+        // not be flattened into it. Only the undo's own failure is genuinely
+        // unclassified.
+        if let Err(halt) = self.publish_folder(scope, pass, source, modified_at).await {
             self.compensate_dest_add(
                 scope,
                 pass,
@@ -1127,7 +1155,7 @@ where
                 },
             )
             .await?;
-            return Err(Halt::Unclassified);
+            return Err(halt);
         }
         Ok(())
     }
@@ -1307,6 +1335,9 @@ where
                 loaded.epoch_tag_unknown,
             )
             .await?;
+        // Durable before the release: the blocks stop being recoverable here,
+        // so this is the last point a crash can still leave a replayable op.
+        self.mark_published(applied.op_id).await?;
         self.release_staged_blocks(&applied.op).await;
         if let Some(node) = self.base.borrow_mut().node_mut(target) {
             node.record_sequence = published.sequence;
@@ -1394,10 +1425,11 @@ where
         // below the mark (#924). An absence is only progress up to the durable
         // mark this pass keeps: past it, a missing block is loss, and the
         // version can never be assembled.
-        let uploaded = self.upload_mark(&staged.root_cid).await?;
+        let leaves = content.leaf_cids().len();
+        let uploaded = self.upload_mark(&staged.root_cid, leaves).await?;
         // The root manifest is block zero and goes up last, so the version's
         // whole block count is its leaves plus one.
-        let total = blocks(content.leaf_cids().len() + 1);
+        let total = blocks(leaves + 1);
         let emit = |phase: OpPhase, confirmed: u32| {
             self.emit_upload(
                 applied,
@@ -1418,7 +1450,8 @@ where
                     // over the leaves past it — those are released, so an
                     // uncovered one reads as loss (#924).
                     if index + 1 > uploaded {
-                        self.mark_uploaded(&staged.root_cid, index + 1).await?;
+                        self.mark_uploaded(&staged.root_cid, index + 1, leaves)
+                            .await?;
                     }
                     self.staging
                         .remove_staged_bytes(leaf_cid)
@@ -1478,35 +1511,29 @@ where
         });
     }
 
-    /// How many of this version's leaves a previous pass durably confirmed. A
-    /// mark naming another version has nothing to say about this one, so it
-    /// reads as zero and every absent leaf is loss.
-    async fn upload_mark(&self, root_cid: &[u8]) -> Result<usize, Halt> {
-        let Some(stored) = self
+    /// How many of this version's `leaves` a previous pass durably confirmed
+    /// ([`decode_upload_mark`]).
+    async fn upload_mark(&self, root_cid: &[u8], leaves: usize) -> Result<usize, Halt> {
+        Ok(self
             .staging
             .staged_bytes(UPLOAD_MARK_KEY)
             .await
             .map_err(seam)?
-        else {
-            return Ok(0);
-        };
-        let Some((root, count)) = stored.split_at_checked(stored.len().saturating_sub(4)) else {
-            return Ok(0);
-        };
-        if root != root_cid {
-            return Ok(0);
-        }
-        Ok(<[u8; 4]>::try_from(count).map_or(0, |c| u32::from_be_bytes(c) as usize))
+            .map_or(0, |stored| decode_upload_mark(&stored, root_cid, leaves)))
     }
 
-    /// Record that `count` of this version's leaves have uploaded. A high-water
-    /// mark, written *before* the leaf is released: it may over-claim a leaf
-    /// still staged, which the next pass re-uploads, but must never lag or
-    /// regress below one already released — the hole guard would read those
-    /// uploaded bytes as loss (#924).
-    async fn mark_uploaded(&self, root_cid: &[u8], count: usize) -> Result<(), Halt> {
-        let mut mark = root_cid.to_vec();
-        mark.extend_from_slice(&(count as u32).to_be_bytes());
+    /// Record that `count` of this version's `leaves` have uploaded. A
+    /// high-water mark, written *before* the leaf is released: it may
+    /// over-claim a leaf still staged, which the next pass re-uploads, but must
+    /// never lag or regress below one already released — the hole guard would
+    /// read those uploaded bytes as loss (#924).
+    async fn mark_uploaded(
+        &self,
+        root_cid: &[u8],
+        count: usize,
+        leaves: usize,
+    ) -> Result<(), Halt> {
+        let mark = encode_upload_mark(root_cid, count, leaves).ok_or(Halt::Unclassified)?;
         self.staging
             .put_staged_bytes(UPLOAD_MARK_KEY, &mark)
             .await
@@ -1783,8 +1810,7 @@ where
         self.staging.remove_op(op_id).await.map_err(seam)
     }
 
-    /// Note one head block as orphaned, capped at [`REGISTRY_BATCH_MAX`] so a
-    /// session whose retires keep failing bounds its leak, not its memory.
+    /// Note one head block as orphaned.
     ///
     /// A head the live set still names never enters the queue: its only
     /// consumer physically unpins, and unpinning a head a live record names is
@@ -1798,25 +1824,7 @@ where
         {
             return;
         }
-        let mut orphans = self.orphan_heads.borrow_mut();
-        if orphans.len() < REGISTRY_BATCH_MAX {
-            orphans.push(cid.to_owned());
-        }
-    }
-
-    /// Retire the head blocks this session's publishes orphaned
-    /// ([`orphaned_head`]). A refused retire keeps them pending for the next
-    /// pass rather than losing the only record of what to retire.
-    async fn retire_orphan_heads(&self) {
-        let pending = self.orphan_heads.borrow().clone();
-        if pending.is_empty() {
-            return;
-        }
-        if retire(self.api, &pending).await.is_ok() {
-            let mut orphans = self.orphan_heads.borrow_mut();
-            let sent = pending.len().min(orphans.len());
-            orphans.drain(..sent);
-        }
+        self.orphan_heads.record(cid);
     }
 
     /// Retire every block a cancelled op put on the network. Best-effort: a
@@ -1956,6 +1964,21 @@ where
             .map_err(seam)
     }
 
+    /// Raise the published-op mark over `op_id`, between its record PUT and the
+    /// release of its staged blocks ([`PUBLISHED_OP_MARK_KEY`]).
+    async fn mark_published(&self, op_id: OpId) -> Result<(), Halt> {
+        let raised = op_id.0.max(
+            published_op_mark(self.staging)
+                .await
+                .map_err(seam)?
+                .unwrap_or(0),
+        );
+        self.staging
+            .put_staged_bytes(PUBLISHED_OP_MARK_KEY, &raised.to_be_bytes())
+            .await
+            .map_err(seam)
+    }
+
     /// The stored drained-op mark; `None` when nothing has drained on this
     /// device or the stored bytes are not a mark this build wrote.
     async fn drained_mark(&self) -> Result<Option<u64>, Halt> {
@@ -2031,6 +2054,50 @@ fn classify_publish(error: RecordPublishError, refused_bytes: u64) -> Halt {
     }
 }
 
+/// The upload mark's wire form: the version root CID followed by a big-endian
+/// `u32` leaf count. `None` where the count is not one this version could have
+/// reached — AGENTS.md rule 8's release-active mirror of
+/// [`decode_upload_mark`]'s bound, so a mark the reader discards as corrupt can
+/// never be written.
+fn encode_upload_mark(root_cid: &[u8], count: usize, leaves: usize) -> Option<Vec<u8>> {
+    let claim = u32::try_from(count).ok().filter(|_| count <= leaves)?;
+    let mut mark = root_cid.to_vec();
+    mark.extend_from_slice(&claim.to_be_bytes());
+    Some(mark)
+}
+
+/// How many of `root_cid`'s `leaves` the stored mark claims. A mark naming
+/// another version has nothing to say about this one, and one claiming more
+/// leaves than the version has is proof of a torn or rotted mark — both read as
+/// no progress, so every absent leaf stays loss.
+///
+/// Clamping the corrupt case to `leaves` would be the most trusting possible
+/// reading of bytes already known to be corrupt: it could cover every absent
+/// leaf and publish a manifest naming blocks nothing holds. Zero re-uploads
+/// whatever is still staged and leaves the rest to the hole guard.
+fn decode_upload_mark(stored: &[u8], root_cid: &[u8], leaves: usize) -> usize {
+    let Some((root, count)) = stored.split_at_checked(stored.len().saturating_sub(4)) else {
+        return 0;
+    };
+    if root != root_cid {
+        return 0;
+    }
+    let count = <[u8; 4]>::try_from(count).map_or(0, |c| u32::from_be_bytes(c) as usize);
+    if count > leaves { 0 } else { count }
+}
+
+/// The stored published-op mark ([`PUBLISHED_OP_MARK_KEY`]); `None` when
+/// nothing has published on this device or the stored bytes are not a mark this
+/// build wrote. Read by the drain and by the facade's cancel command, which owe
+/// the same answer about an op whose version is already live.
+pub(crate) async fn published_op_mark<St: StagingStore>(staging: &St) -> SeamResult<Option<u64>> {
+    Ok(staging
+        .staged_bytes(PUBLISHED_OP_MARK_KEY)
+        .await?
+        .and_then(|bytes| <[u8; 8]>::try_from(bytes.as_slice()).ok())
+        .map(u64::from_be_bytes))
+}
+
 /// Classify a register-first refusal on the discriminator the registry stamps,
 /// never the status alone (the [`classify_upload`] discipline): the batch this
 /// op builds is refused identically on every retry, and the queue is strict
@@ -2045,34 +2112,6 @@ fn classify_register(error: ApiError) -> Halt {
     match code.as_deref() {
         Some(REGISTRY_BATCH_REFUSED) => Halt::Permanent(DeadLetterReason::PayloadRefused),
         _ => Halt::UploadAttempt,
-    }
-}
-
-/// Whether a failed publish left its head block charged and unreachable: the
-/// upload landed under its own pin row, no record naming it reached the
-/// transport, and the retry re-authors under a fresh seal nonce
-/// (blueprint/engine.md "Resolve/publish pipeline: Retirement", #921).
-fn orphaned_head(error: &RecordPublishError) -> bool {
-    match error {
-        // A status answer is the server's own refusal, so it charged no row; a
-        // dropped connection or an unreadable 2xx may have left one behind.
-        RecordPublishError::Upload(error) => {
-            matches!(error, ApiError::Transport(_) | ApiError::Decode(_))
-        }
-        RecordPublishError::HeadCidMismatch { .. } => true,
-        RecordPublishError::Publish(error) => match error {
-            // The head block is already uploaded and charged when publish
-            // refuses, and no record naming it reached the transport.
-            PublishError::Register(_)
-            | PublishError::FloorRead(_)
-            | PublishError::RecordTooLarge { .. } => true,
-            // Nothing was ever addressed, so there is no CID to retire.
-            PublishError::EmptyHeadCid => false,
-            // No ack is not proof nothing stored: unpinning a head a live
-            // record may still name is loss, where the row is only a leak
-            // (#916).
-            PublishError::AllEndpointsFailed => false,
-        },
     }
 }
 
@@ -2182,6 +2221,40 @@ mod tests {
         ] {
             assert!(Attempts::decode(stored).counts.is_empty());
         }
+    }
+
+    /// AGENTS.md rule 8 for the upload mark: one bound, both directions. The
+    /// encode guard returns `None` in every build rather than asserting, and the
+    /// reader reaches the same verdict on bytes planted past it.
+    #[test]
+    fn a_mark_claiming_more_leaves_than_the_version_has_is_refused_on_both_sides() {
+        const ROOT: &[u8] = b"root-cid";
+        let planted = |count: u32| {
+            let mut mark = ROOT.to_vec();
+            mark.extend_from_slice(&count.to_be_bytes());
+            mark
+        };
+        for count in [4usize, 5, usize::try_from(u32::MAX).expect("64-bit")] {
+            assert!(
+                encode_upload_mark(ROOT, count, 3).is_none(),
+                "{count}: the writer refuses what the reader discards",
+            );
+            assert_eq!(
+                decode_upload_mark(&planted(u32::try_from(count).unwrap_or(u32::MAX)), ROOT, 3),
+                0,
+                "{count}: a corrupt mark covers no leaf at all",
+            );
+        }
+        // The in-range case still round-trips, so the bound is the only change.
+        assert_eq!(
+            decode_upload_mark(&encode_upload_mark(ROOT, 2, 3).expect("in range"), ROOT, 3),
+            2,
+        );
+        assert_eq!(
+            decode_upload_mark(&planted(2), b"another-root", 3),
+            0,
+            "a mark naming another version has nothing to say about this one",
+        );
     }
 
     #[test]

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -68,28 +68,43 @@ use crate::sync::rebase::{AppliedOp, DeadLetterReason, decode_queue, replay};
 use crate::sync::record::RecordReader;
 use crate::sync::staging::{preserve_dead_letter, release_version_blocks, version_leaf_cids};
 
-/// The staging key holding the drained-op high-water mark: every op id at or
+/// The staging-key prefix for the drained-op high-water mark: every op id at or
 /// below the stored value has left this device's queue (#860).
 ///
 /// It lives in the staging store rather than the floors so the mark and the op
 /// ids it names share one durability domain — a store that loses its queue
 /// loses the mark with it, instead of retaining a mark that would delete every
-/// id the restarted counter reissues. [`orphan_staging_keys`] treats it as
-/// referenced so orphan GC never collects it.
-///
-/// [`orphan_staging_keys`]: crate::sync::staging::orphan_staging_keys
-pub const DRAINED_OP_MARK_KEY: &[u8] = b"cipherbox/drained-op";
+/// id the restarted counter reissues.
+pub const DRAINED_OP_MARK_PREFIX: &[u8] = b"cipherbox/drained-op/";
 
-/// The staging key holding the published-op high-water mark: every op id at or
-/// below the stored value published and self-adopted its whole record set, so
-/// its version is live at its name even if the op is still queued.
+/// The staging-key prefix for the published-op high-water mark: every op id at
+/// or below the stored value published and self-adopted its whole record set,
+/// so its version is live at its name even if the op is still queued. What it
+/// is *for* is [`Drain::mark_published`].
+pub const PUBLISHED_OP_MARK_PREFIX: &[u8] = b"cipherbox/published-op/";
+
+/// One identity's op-id high-water key, under the same owner tag
+/// [`RecordReader`] classifies queue records against.
 ///
-/// Contiguous, and in the same durability domain as the ids it names, for the
-/// reasons [`DRAINED_OP_MARK_KEY`] gives; [`orphan_staging_keys`] treats it as
-/// referenced. What it is *for* is [`Drain::mark_published`].
+/// **Both marks are per-identity.** The durable queue is shared — a
+/// `RecordReader` holds another account's records as
+/// [`Retained`](crate::sync::record::RecordClass::Retained) rather than
+/// deleting them — and `OpId`s are per *store*, not per identity. A device-wide
+/// high-water would therefore let one account's progress discard another's
+/// queued op: as restore residue under the drained mark, or as already
+/// published under the other.
+///
+/// [`orphan_staging_keys`] treats both prefixes as referenced, including marks
+/// this session cannot read — their owner is exactly the identity that still
+/// needs them.
 ///
 /// [`orphan_staging_keys`]: crate::sync::staging::orphan_staging_keys
-pub const PUBLISHED_OP_MARK_KEY: &[u8] = b"cipherbox/published-op";
+#[must_use]
+pub fn op_mark_key(prefix: &[u8], enc_secret: &X25519Secret) -> Vec<u8> {
+    let mut key = prefix.to_vec();
+    key.extend_from_slice(&RecordReader::new(enc_secret).owner_tag());
+    key
+}
 
 /// What one drain pass did.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -218,7 +233,7 @@ const CONTENT_LOST: Halt = Halt::Permanent(DeadLetterReason::ContentUnrecoverabl
 /// Without it, a leaf missing before the first present one is indistinguishable
 /// from one a previous pass uploaded — so an evicted or deleted prefix would
 /// publish a version whose manifest names blocks nothing holds. It lives beside
-/// the queue's other bookkeeping for the same reason [`DRAINED_OP_MARK_KEY`]
+/// the queue's other bookkeeping for the same reason [`DRAINED_OP_MARK_PREFIX`]
 /// does, and [`orphan_staging_keys`] treats it as referenced.
 ///
 /// [`orphan_staging_keys`]: crate::sync::staging::orphan_staging_keys
@@ -234,7 +249,7 @@ const ATTEMPT_BUDGET: u32 = 5;
 /// followed by `(op_id, attempts)` pairs, big-endian and fixed-width, rewritten
 /// each pass over the live queue so a retired op's count leaves with it.
 ///
-/// It lives in the staging store for the same reason [`DRAINED_OP_MARK_KEY`]
+/// It lives in the staging store for the same reason [`DRAINED_OP_MARK_PREFIX`]
 /// does — the counts and the op ids they name share one durability domain — and
 /// [`orphan_staging_keys`] treats it as referenced. What the counts are *for* is
 /// [`Drain::abandon`].
@@ -456,7 +471,7 @@ where
         };
         let _ = self.pass(scope, &queued, &mut report, &mut attempts).await;
         let _ = self.store_attempts(&attempts).await;
-        let _ = self.mark_drained(&queued, &report).await;
+        let _ = self.mark_drained(scope, &queued, &report).await;
         report
     }
 
@@ -618,8 +633,10 @@ where
         // `None` is "no op has ever drained here", not "id 0 drained": the seam
         // contract promises only strictly-increasing ids, so a host that starts
         // at 0 must not lose its first op.
-        let drained = self.drained_mark().await?;
-        let published = published_op_mark(self.staging).await.map_err(seam)?;
+        let drained = self.drained_mark(scope).await?;
+        let published = published_op_mark(self.staging, scope.enc_secret)
+            .await
+            .map_err(seam)?;
         let mut mine = Vec::with_capacity(scan.mine.len());
         for (op_id, op) in scan.mine {
             if drained.is_some_and(|mark| op_id.0 <= mark) {
@@ -627,7 +644,7 @@ where
                 report.restore_residue.push(op_id);
                 continue;
             }
-            // Its record PUT was acknowledged before the crash that left it
+            // Its record publish was confirmed before the crash that left it
             // queued, so its version is already live: republishing it would
             // re-expose blocks a live record names to the cancel path.
             if published.is_some_and(|mark| op_id.0 <= mark) {
@@ -1014,7 +1031,7 @@ where
         pass.folder_mut(parent)?.children.push(child.child_ref);
         self.publish_folder(scope, pass, parent, applied.op.authored_at.0)
             .await?;
-        self.mark_published(applied.op_id).await?;
+        self.mark_published(scope, applied.op_id).await;
         self.release_staged_blocks(&applied.op).await;
         // Held only once the parent names it: a record nothing references is
         // not one the liveness loop should keep alive.
@@ -1337,7 +1354,7 @@ where
             .await?;
         // Durable before the release: the blocks stop being recoverable here,
         // so this is the last point a crash can still leave a replayable op.
-        self.mark_published(applied.op_id).await?;
+        self.mark_published(scope, applied.op_id).await;
         self.release_staged_blocks(&applied.op).await;
         if let Some(node) = self.base.borrow_mut().node_mut(target) {
             node.record_sequence = published.sequence;
@@ -1940,7 +1957,12 @@ where
     /// The mark is a high-water line, so it may only pass ops that have all
     /// left the queue: advancing it over a halted op would make a restored data
     /// dir discard that op as residue instead of publishing it (#860).
-    async fn mark_drained(&self, queued: &[(OpId, Op)], report: &DrainReport) -> Result<(), Halt> {
+    async fn mark_drained(
+        &self,
+        scope: &DrainScope<'_>,
+        queued: &[(OpId, Op)],
+        report: &DrainReport,
+    ) -> Result<(), Halt> {
         let retired: BTreeSet<OpId> = report
             .published
             .iter()
@@ -1957,18 +1979,30 @@ where
         };
         // Monotonic by construction: the engine is the single writer, and the
         // mark only ever names ops that have already left the queue.
-        self.raise_op_mark(DRAINED_OP_MARK_KEY, mark).await
+        self.raise_op_mark(&op_mark_key(DRAINED_OP_MARK_PREFIX, scope.enc_secret), mark)
+            .await
     }
 
-    /// Raise the published-op mark over `op_id` ([`PUBLISHED_OP_MARK_KEY`]).
+    /// Raise this identity's published-op mark over `op_id`
+    /// ([`PUBLISHED_OP_MARK_PREFIX`]).
     ///
     /// Raised between the op's last record publish and the block release, which
     /// is the window a crash leaves a published op queued. Without it that op
     /// replays, re-uploads its leaves, and a cancel landing mid-replay unpins
     /// content a live record names — the session-scoped publish-entry interlock
     /// does not survive the reboot.
-    async fn mark_published(&self, op_id: OpId) -> Result<(), Halt> {
-        self.raise_op_mark(PUBLISHED_OP_MARK_KEY, op_id.0).await
+    ///
+    /// Best-effort, unlike every other step of the publish: the record is
+    /// already live by the time this runs, so failing the op over the mark would
+    /// *cause* the replay the mark exists to prevent. The dequeue that follows
+    /// is the primary guard; the mark is what survives losing it.
+    async fn mark_published(&self, scope: &DrainScope<'_>, op_id: OpId) {
+        let _ = self
+            .raise_op_mark(
+                &op_mark_key(PUBLISHED_OP_MARK_PREFIX, scope.enc_secret),
+                op_id.0,
+            )
+            .await;
     }
 
     /// Raise the op-id high-water at `key` to `max(stored, mark)`.
@@ -1982,10 +2016,13 @@ where
 
     /// The stored drained-op mark; `None` when nothing has drained on this
     /// device or the stored bytes are not a mark this build wrote.
-    async fn drained_mark(&self) -> Result<Option<u64>, Halt> {
-        op_mark(self.staging, DRAINED_OP_MARK_KEY)
-            .await
-            .map_err(seam)
+    async fn drained_mark(&self, scope: &DrainScope<'_>) -> Result<Option<u64>, Halt> {
+        op_mark(
+            self.staging,
+            &op_mark_key(DRAINED_OP_MARK_PREFIX, scope.enc_secret),
+        )
+        .await
+        .map_err(seam)
     }
 
     /// The per-node read key (`node-seed` → `read-key`), owned by the caller of
@@ -2088,11 +2125,14 @@ async fn op_mark<St: StagingStore>(staging: &St, key: &[u8]) -> SeamResult<Optio
         .map(u64::from_be_bytes))
 }
 
-/// The stored published-op mark ([`PUBLISHED_OP_MARK_KEY`]). Read by the drain
-/// and by the facade's cancel command, which owe the same answer about an op
-/// whose version is already live.
-pub(crate) async fn published_op_mark<St: StagingStore>(staging: &St) -> SeamResult<Option<u64>> {
-    op_mark(staging, PUBLISHED_OP_MARK_KEY).await
+/// The published-op mark for `enc_secret`'s identity. Read by the drain and by
+/// the facade's cancel command, which owe the same answer about an op whose
+/// version is already live.
+pub(crate) async fn published_op_mark<St: StagingStore>(
+    staging: &St,
+    enc_secret: &X25519Secret,
+) -> SeamResult<Option<u64>> {
+    op_mark(staging, &op_mark_key(PUBLISHED_OP_MARK_PREFIX, enc_secret)).await
 }
 
 /// Classify a register-first refusal on the discriminator the registry stamps,

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -81,19 +81,12 @@ use crate::sync::staging::{preserve_dead_letter, release_version_blocks, version
 pub const DRAINED_OP_MARK_KEY: &[u8] = b"cipherbox/drained-op";
 
 /// The staging key holding the published-op high-water mark: every op id at or
-/// below the stored value had its record PUT acknowledged, so its version is
-/// live at its name even if the op is still queued.
+/// below the stored value published and self-adopted its whole record set, so
+/// its version is live at its name even if the op is still queued.
 ///
-/// The queue is strict FIFO and a pass stops at the first op it cannot publish,
-/// so every id below the one being marked has already left the queue — the mark
-/// is contiguous by construction, like [`DRAINED_OP_MARK_KEY`], and shares the
-/// same durability domain as the ids it names.
-///
-/// It is raised between the record PUT and the block release, which is the
-/// window a crash leaves a published op queued. Without it that op replays,
-/// re-uploads its leaves, and a cancel landing mid-replay unpins content a live
-/// record names — the session-scoped publish-entry interlock does not survive
-/// the reboot. [`orphan_staging_keys`] treats it as referenced.
+/// Contiguous, and in the same durability domain as the ids it names, for the
+/// reasons [`DRAINED_OP_MARK_KEY`] gives; [`orphan_staging_keys`] treats it as
+/// referenced. What it is *for* is [`Drain::mark_published`].
 ///
 /// [`orphan_staging_keys`]: crate::sync::staging::orphan_staging_keys
 pub const PUBLISHED_OP_MARK_KEY: &[u8] = b"cipherbox/published-op";
@@ -616,6 +609,12 @@ where
         let raw = self.staging.queued_ops().await.map_err(seam)?;
         let all_ids = raw.iter().map(|(op_id, _)| *op_id).collect();
         let scan = decode_queue(&RecordReader::new(scope.enc_secret), &raw);
+        if scan.mine.is_empty() {
+            return Ok(Queue {
+                mine: Vec::new(),
+                all_ids,
+            });
+        }
         // `None` is "no op has ever drained here", not "id 0 drained": the seam
         // contract promises only strictly-increasing ids, so a host that starts
         // at 0 must not lose its first op.
@@ -1015,6 +1014,7 @@ where
         pass.folder_mut(parent)?.children.push(child.child_ref);
         self.publish_folder(scope, pass, parent, applied.op.authored_at.0)
             .await?;
+        self.mark_published(applied.op_id).await?;
         self.release_staged_blocks(&applied.op).await;
         // Held only once the parent names it: a record nothing references is
         // not one the liveness loop should keep alive.
@@ -1957,24 +1957,25 @@ where
         };
         // Monotonic by construction: the engine is the single writer, and the
         // mark only ever names ops that have already left the queue.
-        let raised = mark.max(self.drained_mark().await?.unwrap_or(0));
-        self.staging
-            .put_staged_bytes(DRAINED_OP_MARK_KEY, &raised.to_be_bytes())
-            .await
-            .map_err(seam)
+        self.raise_op_mark(DRAINED_OP_MARK_KEY, mark).await
     }
 
-    /// Raise the published-op mark over `op_id`, between its record PUT and the
-    /// release of its staged blocks ([`PUBLISHED_OP_MARK_KEY`]).
+    /// Raise the published-op mark over `op_id` ([`PUBLISHED_OP_MARK_KEY`]).
+    ///
+    /// Raised between the op's last record publish and the block release, which
+    /// is the window a crash leaves a published op queued. Without it that op
+    /// replays, re-uploads its leaves, and a cancel landing mid-replay unpins
+    /// content a live record names — the session-scoped publish-entry interlock
+    /// does not survive the reboot.
     async fn mark_published(&self, op_id: OpId) -> Result<(), Halt> {
-        let raised = op_id.0.max(
-            published_op_mark(self.staging)
-                .await
-                .map_err(seam)?
-                .unwrap_or(0),
-        );
+        self.raise_op_mark(PUBLISHED_OP_MARK_KEY, op_id.0).await
+    }
+
+    /// Raise the op-id high-water at `key` to `max(stored, mark)`.
+    async fn raise_op_mark(&self, key: &[u8], mark: u64) -> Result<(), Halt> {
+        let raised = mark.max(op_mark(self.staging, key).await.map_err(seam)?.unwrap_or(0));
         self.staging
-            .put_staged_bytes(PUBLISHED_OP_MARK_KEY, &raised.to_be_bytes())
+            .put_staged_bytes(key, &raised.to_be_bytes())
             .await
             .map_err(seam)
     }
@@ -1982,14 +1983,9 @@ where
     /// The stored drained-op mark; `None` when nothing has drained on this
     /// device or the stored bytes are not a mark this build wrote.
     async fn drained_mark(&self) -> Result<Option<u64>, Halt> {
-        let stored = self
-            .staging
-            .staged_bytes(DRAINED_OP_MARK_KEY)
+        op_mark(self.staging, DRAINED_OP_MARK_KEY)
             .await
-            .map_err(seam)?;
-        Ok(stored
-            .and_then(|bytes| <[u8; 8]>::try_from(bytes.as_slice()).ok())
-            .map(u64::from_be_bytes))
+            .map_err(seam)
     }
 
     /// The per-node read key (`node-seed` → `read-key`), owned by the caller of
@@ -2069,12 +2065,8 @@ fn encode_upload_mark(root_cid: &[u8], count: usize, leaves: usize) -> Option<Ve
 /// How many of `root_cid`'s `leaves` the stored mark claims. A mark naming
 /// another version has nothing to say about this one, and one claiming more
 /// leaves than the version has is proof of a torn or rotted mark — both read as
-/// no progress, so every absent leaf stays loss.
-///
-/// Clamping the corrupt case to `leaves` would be the most trusting possible
-/// reading of bytes already known to be corrupt: it could cover every absent
-/// leaf and publish a manifest naming blocks nothing holds. Zero re-uploads
-/// whatever is still staged and leaves the rest to the hole guard.
+/// no progress, so every absent leaf stays loss rather than being covered by
+/// bytes already known to be corrupt.
 fn decode_upload_mark(stored: &[u8], root_cid: &[u8], leaves: usize) -> usize {
     let Some((root, count)) = stored.split_at_checked(stored.len().saturating_sub(4)) else {
         return 0;
@@ -2086,16 +2078,21 @@ fn decode_upload_mark(stored: &[u8], root_cid: &[u8], leaves: usize) -> usize {
     if count > leaves { 0 } else { count }
 }
 
-/// The stored published-op mark ([`PUBLISHED_OP_MARK_KEY`]); `None` when
-/// nothing has published on this device or the stored bytes are not a mark this
-/// build wrote. Read by the drain and by the facade's cancel command, which owe
-/// the same answer about an op whose version is already live.
-pub(crate) async fn published_op_mark<St: StagingStore>(staging: &St) -> SeamResult<Option<u64>> {
+/// The op-id high-water stored at `key`; `None` when nothing has been marked on
+/// this device or the stored bytes are not a mark this build wrote.
+async fn op_mark<St: StagingStore>(staging: &St, key: &[u8]) -> SeamResult<Option<u64>> {
     Ok(staging
-        .staged_bytes(PUBLISHED_OP_MARK_KEY)
+        .staged_bytes(key)
         .await?
         .and_then(|bytes| <[u8; 8]>::try_from(bytes.as_slice()).ok())
         .map(u64::from_be_bytes))
+}
+
+/// The stored published-op mark ([`PUBLISHED_OP_MARK_KEY`]). Read by the drain
+/// and by the facade's cancel command, which owe the same answer about an op
+/// whose version is already live.
+pub(crate) async fn published_op_mark<St: StagingStore>(staging: &St) -> SeamResult<Option<u64>> {
+    op_mark(staging, PUBLISHED_OP_MARK_KEY).await
 }
 
 /// Classify a register-first refusal on the discriminator the registry stamps,

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -32,7 +32,8 @@ pub mod tick;
 
 pub use boot::{ColdStartError, ColdStartOutcome, ColdStartParams, RootResolve, cold_start};
 pub use drain::{
-    BlockedOp, DRAINED_OP_MARK_KEY, OP_ATTEMPTS_KEY, PUBLISHED_OP_MARK_KEY, UPLOAD_MARK_KEY,
+    BlockedOp, DRAINED_OP_MARK_PREFIX, OP_ATTEMPTS_KEY, PUBLISHED_OP_MARK_PREFIX, UPLOAD_MARK_KEY,
+    op_mark_key,
 };
 pub use model::{Link, NodeMeta, Snapshot, collation_key, suffix_name};
 pub use op::{NewNode, Op, OpDecodeError, OpKind, Replaced, StagedContent};

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -31,7 +31,9 @@ pub mod staleness;
 pub mod tick;
 
 pub use boot::{ColdStartError, ColdStartOutcome, ColdStartParams, RootResolve, cold_start};
-pub use drain::{BlockedOp, DRAINED_OP_MARK_KEY, OP_ATTEMPTS_KEY, UPLOAD_MARK_KEY};
+pub use drain::{
+    BlockedOp, DRAINED_OP_MARK_KEY, OP_ATTEMPTS_KEY, PUBLISHED_OP_MARK_KEY, UPLOAD_MARK_KEY,
+};
 pub use model::{Link, NodeMeta, Snapshot, collation_key, suffix_name};
 pub use op::{NewNode, Op, OpDecodeError, OpKind, Replaced, StagedContent};
 pub use overlay::apply_overlay;

--- a/crates/engine/src/sync/staging.rs
+++ b/crates/engine/src/sync/staging.rs
@@ -23,7 +23,9 @@ use cipherbox_core::content::verify_cid;
 use crate::content::decode_root;
 use crate::facade::WriteHandle;
 use crate::seams::{OpId, SeamError, SeamResult, StagingStore};
-use crate::sync::drain::{DRAINED_OP_MARK_KEY, OP_ATTEMPTS_KEY, UPLOAD_MARK_KEY};
+use crate::sync::drain::{
+    DRAINED_OP_MARK_KEY, OP_ATTEMPTS_KEY, PUBLISHED_OP_MARK_KEY, UPLOAD_MARK_KEY,
+};
 use crate::sync::op::Op;
 use crate::sync::record::{RecordSeal, encode_op_record, record_content_root_cid};
 
@@ -296,6 +298,7 @@ pub async fn orphan_staging_keys<S: StagingStore>(
     let mut referenced = HashSet::from([
         DRAINED_OP_MARK_KEY.to_vec(),
         OP_ATTEMPTS_KEY.to_vec(),
+        PUBLISHED_OP_MARK_KEY.to_vec(),
         UPLOAD_MARK_KEY.to_vec(),
         PRESERVED_DEAD_LETTERS_KEY.to_vec(),
     ]);

--- a/crates/engine/src/sync/staging.rs
+++ b/crates/engine/src/sync/staging.rs
@@ -24,10 +24,16 @@ use crate::content::decode_root;
 use crate::facade::WriteHandle;
 use crate::seams::{OpId, SeamError, SeamResult, StagingStore};
 use crate::sync::drain::{
-    DRAINED_OP_MARK_KEY, OP_ATTEMPTS_KEY, PUBLISHED_OP_MARK_KEY, UPLOAD_MARK_KEY,
+    DRAINED_OP_MARK_PREFIX, OP_ATTEMPTS_KEY, PUBLISHED_OP_MARK_PREFIX, UPLOAD_MARK_KEY,
 };
 use crate::sync::op::Op;
 use crate::sync::record::{RecordSeal, encode_op_record, record_content_root_cid};
+
+/// Whether `key` is one of the per-identity op-id high-water marks
+/// ([`op_mark_key`](crate::sync::drain::op_mark_key)).
+fn is_op_mark(key: &[u8]) -> bool {
+    key.starts_with(DRAINED_OP_MARK_PREFIX) || key.starts_with(PUBLISHED_OP_MARK_PREFIX)
+}
 
 /// Journal one op onto the durable queue, returning its id.
 ///
@@ -296,21 +302,21 @@ pub async fn orphan_staging_keys<S: StagingStore>(
 ) -> SeamResult<Vec<Vec<u8>>> {
     // The drain's own queue bookkeeping is not upload residue.
     let mut referenced = HashSet::from([
-        DRAINED_OP_MARK_KEY.to_vec(),
         OP_ATTEMPTS_KEY.to_vec(),
-        PUBLISHED_OP_MARK_KEY.to_vec(),
         UPLOAD_MARK_KEY.to_vec(),
         PRESERVED_DEAD_LETTERS_KEY.to_vec(),
     ]);
     referenced.extend(live.iter().cloned());
     // Enumerated first, so an idle store answers without reading the queue at
     // all, and a version journaled mid-pass is decided by a queue read that
-    // already covers it.
+    // already covers it. The op-id marks are per-identity, so their whole
+    // prefixes are referenced — a mark this session cannot read belongs to the
+    // identity that still needs it.
     let candidates: Vec<Vec<u8>> = store
         .staged_keys()
         .await?
         .into_iter()
-        .filter(|key| !referenced.contains(key))
+        .filter(|key| !referenced.contains(key) && !is_op_mark(key))
         .collect();
     if candidates.is_empty() {
         return Ok(candidates);
@@ -525,20 +531,36 @@ mod tests {
 
     /// Collecting the drain's completion mark would let a restored queue replay
     /// ops that already published (#860), so it is never orphan residue.
+    ///
+    /// The op-id marks are per-identity, so this holds for a mark **this**
+    /// session cannot read too: its owner is the identity that still needs it,
+    /// and collecting it would discard their completion record.
     #[test]
     fn the_drains_own_bookkeeping_is_never_classed_an_orphan() {
         let store = InMemoryStagingStore::default();
         block_on(async {
-            store
-                .put_staged_bytes(DRAINED_OP_MARK_KEY, &7u64.to_be_bytes())
-                .await
-                .unwrap();
+            let foreign = |prefix: &[u8]| {
+                let mut key = prefix.to_vec();
+                key.extend_from_slice(&[7u8; 32]);
+                key
+            };
+            for prefix in [DRAINED_OP_MARK_PREFIX, PUBLISHED_OP_MARK_PREFIX] {
+                store
+                    .put_staged_bytes(&foreign(prefix), &7u64.to_be_bytes())
+                    .await
+                    .unwrap();
+            }
             store
                 .put_staged_bytes(OP_ATTEMPTS_KEY, &[0u8; 12])
                 .await
                 .unwrap();
+            store.put_staged_bytes(b"orphan", b"stale").await.unwrap();
 
-            assert!(orphan_staging_keys(&store, &[]).await.unwrap().is_empty());
+            assert_eq!(
+                orphan_staging_keys(&store, &[]).await.unwrap(),
+                vec![b"orphan".to_vec()],
+                "only the residue is collected, never anyone's mark"
+            );
         });
     }
 

--- a/crates/engine/tests/vault_settings.rs
+++ b/crates/engine/tests/vault_settings.rs
@@ -29,9 +29,9 @@ use cipherbox_engine::seams::{
 use cipherbox_engine::testkit::fakes::VirtualScheduler;
 use cipherbox_engine::testkit::{FakeDevice, FakeWorld, SeededEntropy, block_on};
 use cipherbox_engine::{
-    DefaultsReason, Gateway, GatewayConfig, GatewaySource, ProviderError, RetentionPolicy,
-    SettingsLoad, SettingsPublishError, SyncTimingProfile, VaultSettings, load_settings,
-    publish_settings, settings_name,
+    DefaultsReason, Gateway, GatewayConfig, GatewaySource, OrphanHeads, ProviderError,
+    RetentionPolicy, SettingsLoad, SettingsPublishError, SyncTimingProfile, VaultSettings,
+    load_settings, publish_settings, settings_name,
 };
 
 const SECRET: [u8; 32] = [7u8; 32];
@@ -47,6 +47,11 @@ const EOL: &str = "2099-01-01T00:00:00Z";
 #[derive(Clone, Default)]
 struct Blocks {
     store: Arc<Mutex<BTreeMap<String, Vec<u8>>>>,
+    /// Answer register-first with a refusal, so the publish stops with its head
+    /// block already uploaded and charged.
+    refuse_register: Arc<Mutex<bool>>,
+    /// Every retire request body, verbatim.
+    retired: Arc<Mutex<Vec<String>>>,
 }
 
 impl Blocks {
@@ -54,6 +59,21 @@ impl Blocks {
         let cid = encode_content_cid_str(&compute_cid(DAG_ROOT_CODEC, &block));
         self.store.lock().expect("lock").insert(cid.clone(), block);
         cid
+    }
+
+    fn refuse_register(&self) {
+        *self.refuse_register.lock().expect("lock") = true;
+    }
+
+    fn retired(&self) -> Vec<String> {
+        self.retired.lock().expect("lock").clone()
+    }
+
+    /// The one block on the plane, for a fixture that uploaded exactly one.
+    fn only_block(&self) -> String {
+        let store = self.store.lock().expect("lock");
+        assert_eq!(store.len(), 1, "exactly one block was uploaded");
+        store.keys().next().expect("one block").clone()
     }
 
     fn reply(&self, request: &HttpRequest) -> SeamResult<HttpResponse> {
@@ -70,6 +90,20 @@ impl Blocks {
             let size = block.len();
             let cid = self.put(block);
             return ok(format!("{{\"cid\":\"{cid}\",\"size\":{size}}}").into_bytes());
+        }
+        if url.ends_with("/registry/retire") {
+            self.retired.lock().expect("lock").push(
+                String::from_utf8(request.body.clone().unwrap_or_default())
+                    .unwrap_or_else(|_| String::new()),
+            );
+            return ok(Vec::new());
+        }
+        if url.ends_with("/registry/register") && *self.refuse_register.lock().expect("lock") {
+            return Ok(HttpResponse {
+                status: 400,
+                headers: Vec::new(),
+                body: Vec::new(),
+            });
         }
         if url.contains("/registry/") {
             return ok(Vec::new());
@@ -139,6 +173,7 @@ fn publish(
         &world.scheduler,
         &SyncTimingProfile::CI,
         &mut SeededEntropy::new(1),
+        &OrphanHeads::default(),
         secret,
         settings,
     ))
@@ -150,6 +185,18 @@ fn publish(
 /// ephemeral varies with the sequence: two bodies sealed under one key must
 /// never share one, in fixtures as in production.
 fn seed_settings(device: &FakeDevice, blocks: &Blocks, body: &[u8], sequence: u64) {
+    seed_settings_until(device, blocks, body, sequence, EOL);
+}
+
+/// [`seed_settings`] with the record's client-signed EOL under the fixture's
+/// control, so a lapsed one can be hand-minted.
+fn seed_settings_until(
+    device: &FakeDevice,
+    blocks: &Blocks,
+    body: &[u8],
+    sequence: u64,
+    eol: &str,
+) {
     let mut ephemeral = [8u8; 32];
     ephemeral[0] = u8::try_from(sequence).expect("fixture sequences are small");
     let block = seal_settings_record(&kdf::enc_subkey(&SECRET), &ephemeral, body).expect("seal");
@@ -159,7 +206,7 @@ fn seed_settings(device: &FakeDevice, blocks: &Blocks, body: &[u8], sequence: u6
         format!("/ipfs/{cid}").as_bytes(),
         sequence,
         TTL_NANOS,
-        EOL,
+        eol,
     )
     .marshal();
     for endpoint in device.record_store.endpoints() {
@@ -263,6 +310,7 @@ fn consecutive_publishes_never_reuse_the_hpke_ephemeral() {
             &world.scheduler,
             &SyncTimingProfile::CI,
             &mut entropy,
+            &OrphanHeads::default(),
             &SECRET,
             &settings,
         ))
@@ -355,6 +403,7 @@ fn an_unconfirmed_publish_is_reported_and_never_advances_the_floor() {
         &world.scheduler,
         &SyncTimingProfile::CI,
         &mut SeededEntropy::new(3),
+        &OrphanHeads::default(),
         &SECRET,
         &configured(),
     ));
@@ -1097,6 +1146,7 @@ fn settings_the_reader_would_refuse_are_never_published() {
             &world.scheduler,
             &SyncTimingProfile::CI,
             &mut SeededEntropy::new(2),
+            &OrphanHeads::default(),
             &SECRET,
             &settings,
         ));
@@ -1161,6 +1211,11 @@ fn a_body_carrying_a_refused_endpoint_is_rejected_on_the_way_back_in() {
 
 /// A settings body built straight in core's codec, bypassing the encode guard.
 fn hand_encoded_body(endpoint: &str) -> Vec<u8> {
+    hand_encoded_body_at(endpoint, 1)
+}
+
+/// [`hand_encoded_body`] at a chosen body revision.
+fn hand_encoded_body_at(endpoint: &str, revision: u64) -> Vec<u8> {
     use cipherbox_core::codec::{Map, Value, encode};
 
     let mut byo = Map::new();
@@ -1171,5 +1226,292 @@ fn hand_encoded_body(endpoint: &str) -> Vec<u8> {
     m.insert("byo", Value::Map(byo));
     m.insert("keepLatest", Value::Null);
     m.insert("pinMode", Value::Text("hosted".to_owned()));
+    m.insert("revision", Value::Unsigned(revision));
     encode(&Value::Map(m)).expect("encode")
+}
+
+/// The settings [`hand_encoded_body`] describes, as a load hands them back.
+fn hand_encoded_settings(endpoint: &str) -> VaultSettings {
+    VaultSettings {
+        pin_mode: PinMode::Hosted,
+        byo: Some(ByoIpfsConfig {
+            endpoint: endpoint.to_owned(),
+            kind: ByoKind::Kubo,
+            access_token: None,
+        }),
+        retention: RetentionPolicy::KeepAll,
+    }
+}
+
+/// The `revision` the sealed body at `name` carries.
+fn published_revision(device: &FakeDevice, blocks: &Blocks, name: &IpnsName) -> u64 {
+    let block = published_block(device, blocks, name);
+    let body = open_settings_record(&kdf::enc_subkey(&SECRET), &block).expect("open");
+    cipherbox_core::codec::decode(&body)
+        .expect("decode")
+        .as_map()
+        .expect("map")
+        .get("revision")
+        .expect("the body carries a revision")
+        .as_unsigned()
+        .expect("unsigned")
+}
+
+// ---------------------------------------------------------------------------
+// Freshness: the EOL bound and the body revision
+// ---------------------------------------------------------------------------
+
+/// A 2026 instant, so a fixture EOL can sit either side of the clock.
+const NOW: UnixMillis = UnixMillis(1_772_000_000_000);
+const LAPSED_EOL: &str = "2020-01-01T00:00:00Z";
+
+/// The settings record's reader is always its signer, so a lapsed EOL is a
+/// refusal rather than the availability event a lapse is plane-wide: nothing
+/// here waits on a dormant owner to revive.
+#[test]
+fn a_lapsed_eol_is_not_authoritative_and_degrades_to_last_known_good() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let device = world.device(b"me");
+    world.scheduler.advance_to(NOW);
+
+    // The control: the same shape inside its EOL resolves, so the verdict below
+    // is the lapse and nothing upstream of it.
+    seed_settings(
+        &device,
+        &blocks,
+        &hand_encoded_body("https://kubo.example"),
+        1,
+    );
+    assert_eq!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Resolved(hand_encoded_settings("https://kubo.example")),
+    );
+
+    seed_settings_until(
+        &device,
+        &blocks,
+        &hand_encoded_body_at("https://other.example", 2),
+        2,
+        LAPSED_EOL,
+    );
+    assert_eq!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Stale {
+            settings: hand_encoded_settings("https://kubo.example"),
+            reason: DefaultsReason::Expired,
+        },
+        "a lapsed record never replaces the copy this device authenticated",
+    );
+}
+
+/// A cold device has no last-known-good copy, so a lapsed record leaves it on
+/// the documented defaults with the reason named.
+#[test]
+fn a_lapsed_eol_on_a_cold_device_reports_expiry_rather_than_applying_the_record() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let device = world.device(b"me");
+    world.scheduler.advance_to(NOW);
+    seed_settings_until(
+        &device,
+        &blocks,
+        &hand_encoded_body("https://kubo.example"),
+        1,
+        LAPSED_EOL,
+    );
+    assert_eq!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Defaults(DefaultsReason::Expired),
+    );
+}
+
+/// Two owner-signed records at one sequence are equally fresh to the sequence
+/// floor and equally live to the EOL. The sealed body revision is what orders
+/// them, so the fork this device already adopted past is a replay.
+#[test]
+fn a_body_revision_below_the_adopted_high_water_is_refused() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let device = world.device(b"me");
+
+    seed_settings(
+        &device,
+        &blocks,
+        &hand_encoded_body_at("https://kubo.example", 5),
+        1,
+    );
+    assert_eq!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Resolved(hand_encoded_settings("https://kubo.example")),
+    );
+
+    // The losing fork of the same publish: same name, same sequence, same
+    // signer, a lower revision.
+    seed_settings(
+        &device,
+        &blocks,
+        &hand_encoded_body_at("https://attacker.example", 4),
+        1,
+    );
+    assert_eq!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Stale {
+            settings: hand_encoded_settings("https://kubo.example"),
+            reason: DefaultsReason::RevisionRolledBack {
+                floor: 5,
+                revision: 4,
+            },
+        },
+    );
+}
+
+/// The revision is minted per publish **attempt**, before the PUT: one derived
+/// from the confirm-gated sequence floor would re-mint the same value on the
+/// retry and tell the two forks apart from nothing.
+#[test]
+fn a_retry_mints_a_revision_above_the_attempt_it_replaces() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let device = world.device(b"me");
+    let api = ApiClient::new(
+        device.http.clone(),
+        device.credential_store.clone(),
+        "http://api.test",
+    );
+    serve_http(&device, &blocks, 4);
+    assert_eq!(
+        block_on(publish_settings(
+            &AcksNothingBack,
+            &api,
+            &device.floor_store,
+            &world.scheduler,
+            &SyncTimingProfile::CI,
+            &mut SeededEntropy::new(6),
+            &OrphanHeads::default(),
+            &SECRET,
+            &configured(),
+        ))
+        .unwrap_err(),
+        SettingsPublishError::Unconfirmed,
+    );
+
+    publish(&world, &device, &blocks, &SECRET, &configured());
+    assert_eq!(
+        published_revision(&device, &blocks, &settings_name(&SECRET)),
+        2,
+        "the retry mints above the attempt that never landed",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Orphan-head retirement
+// ---------------------------------------------------------------------------
+
+/// A transport that refuses every PUT, so the fan-out acknowledges nothing.
+#[derive(Clone)]
+struct AcksNoPut;
+
+impl RecordTransport for AcksNoPut {
+    fn endpoints(&self) -> Vec<EndpointId> {
+        vec![EndpointId::new("fake:refuses-writes")]
+    }
+
+    async fn get_record(
+        &self,
+        _endpoint: &EndpointId,
+        _routing_key: &str,
+        _max_bytes: usize,
+    ) -> SeamResult<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
+    async fn put_record(
+        &self,
+        _endpoint: &EndpointId,
+        _routing_key: &str,
+        _record: &[u8],
+    ) -> SeamResult<()> {
+        Err(SeamError::new("endpoint refused the write"))
+    }
+}
+
+/// The head block goes up under its own charged pin row before register-first
+/// runs, and the retry re-seals under a fresh nonce, so a refusal there leaves
+/// a block no record will ever name.
+#[test]
+fn a_register_first_refusal_retires_the_settings_head_it_uploaded() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let device = world.device(b"me");
+    let api = ApiClient::new(
+        device.http.clone(),
+        device.credential_store.clone(),
+        "http://api.test",
+    );
+    blocks.refuse_register();
+    serve_http(&device, &blocks, 4);
+    let orphans = OrphanHeads::default();
+
+    let outcome = block_on(publish_settings(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &world.scheduler,
+        &SyncTimingProfile::CI,
+        &mut SeededEntropy::new(7),
+        &orphans,
+        &SECRET,
+        &configured(),
+    ));
+    assert!(matches!(
+        outcome.unwrap_err(),
+        SettingsPublishError::Publish(_),
+    ));
+
+    let head = blocks.only_block();
+    let retired = blocks.retired();
+    assert_eq!(retired.len(), 1, "exactly one retire batch went out");
+    assert!(
+        retired[0].contains(&head),
+        "the retire names the head block the refused publish charged",
+    );
+    assert!(
+        orphans.pending().is_empty(),
+        "an accepted retire clears the pending set",
+    );
+}
+
+/// No ack is not proof nothing stored: unpinning a head a live record may still
+/// name is loss, where leaving the row charged is only a leak.
+#[test]
+fn a_settings_publish_whose_fan_out_acked_nothing_retires_nothing() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let device = world.device(b"me");
+    let api = ApiClient::new(
+        device.http.clone(),
+        device.credential_store.clone(),
+        "http://api.test",
+    );
+    serve_http(&device, &blocks, 4);
+    let orphans = OrphanHeads::default();
+
+    let outcome = block_on(publish_settings(
+        &AcksNoPut,
+        &api,
+        &device.floor_store,
+        &world.scheduler,
+        &SyncTimingProfile::CI,
+        &mut SeededEntropy::new(8),
+        &orphans,
+        &SECRET,
+        &configured(),
+    ));
+    assert!(matches!(
+        outcome.unwrap_err(),
+        SettingsPublishError::Publish(_),
+    ));
+    assert!(blocks.retired().is_empty(), "nothing was retired");
+    assert!(orphans.pending().is_empty(), "nothing is pending either");
 }

--- a/crates/engine/tests/vault_settings.rs
+++ b/crates/engine/tests/vault_settings.rs
@@ -170,6 +170,7 @@ fn publish(
         &device.record_store,
         &api,
         &device.floor_store,
+        &device.snapshot_cache,
         &world.scheduler,
         &SyncTimingProfile::CI,
         &mut SeededEntropy::new(1),
@@ -307,6 +308,7 @@ fn consecutive_publishes_never_reuse_the_hpke_ephemeral() {
             &device.record_store,
             &api,
             &device.floor_store,
+            &device.snapshot_cache,
             &world.scheduler,
             &SyncTimingProfile::CI,
             &mut entropy,
@@ -400,6 +402,7 @@ fn an_unconfirmed_publish_is_reported_and_never_advances_the_floor() {
         &AcksNothingBack,
         &api,
         &device.floor_store,
+        &device.snapshot_cache,
         &world.scheduler,
         &SyncTimingProfile::CI,
         &mut SeededEntropy::new(3),
@@ -1143,6 +1146,7 @@ fn settings_the_reader_would_refuse_are_never_published() {
             &device.record_store,
             &api,
             &device.floor_store,
+            &device.snapshot_cache,
             &world.scheduler,
             &SyncTimingProfile::CI,
             &mut SeededEntropy::new(2),
@@ -1366,6 +1370,39 @@ fn a_body_revision_below_the_adopted_high_water_is_refused() {
     );
 }
 
+/// A confirmed publish read our own bytes back, so the writer has adopted the
+/// revision it minted. Without that the losing fork of the retry it just
+/// replaced would stay admissible until some later load raised the bar.
+#[test]
+fn a_confirmed_publish_raises_the_writers_own_adopted_revision() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let device = world.device(b"me");
+    publish(&world, &device, &blocks, &SECRET, &configured());
+    let published = published_revision(&device, &blocks, &settings_name(&SECRET));
+
+    // The losing fork of that same publish, served back at the same sequence.
+    seed_settings(
+        &device,
+        &blocks,
+        &hand_encoded_body_at("https://attacker.example", published - 1),
+        1,
+    );
+    assert_eq!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Stale {
+            // The publish seeded last-known-good with what it published, so the
+            // refused fork cannot pin this device to the generation it replaced.
+            settings: configured(),
+            reason: DefaultsReason::RevisionRolledBack {
+                floor: published,
+                revision: published - 1,
+            },
+        },
+        "no load in between: the publish itself is what raised the bar",
+    );
+}
+
 /// The revision is minted per publish **attempt**, before the PUT: one derived
 /// from the confirm-gated sequence floor would re-mint the same value on the
 /// retry and tell the two forks apart from nothing.
@@ -1385,6 +1422,7 @@ fn a_retry_mints_a_revision_above_the_attempt_it_replaces() {
             &AcksNothingBack,
             &api,
             &device.floor_store,
+            &device.snapshot_cache,
             &world.scheduler,
             &SyncTimingProfile::CI,
             &mut SeededEntropy::new(6),
@@ -1402,6 +1440,187 @@ fn a_retry_mints_a_revision_above_the_attempt_it_replaces() {
         2,
         "the retry mints above the attempt that never landed",
     );
+}
+
+/// The revision arbitrates a fork at one sequence, never a record that won its
+/// own CAS. Two devices keep independent counters, so holding a strictly newer
+/// record to this device's bar would refuse a peer's legitimate publish forever.
+#[test]
+fn a_higher_sequence_record_is_admitted_whatever_revision_it_carries() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let device = world.device(b"me");
+
+    seed_settings(
+        &device,
+        &blocks,
+        &hand_encoded_body_at("https://kubo.example", 9),
+        1,
+    );
+    assert!(matches!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Resolved(_)
+    ));
+
+    seed_settings(
+        &device,
+        &blocks,
+        &hand_encoded_body_at("https://phone.example", 2),
+        2,
+    );
+    assert_eq!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Resolved(hand_encoded_settings("https://phone.example")),
+    );
+}
+
+/// A refused record never becomes last-known-good: the cache write sits behind
+/// the bar, so a replay cannot install itself as the copy the next degraded
+/// load falls back to.
+#[test]
+fn a_revision_rolled_back_record_never_becomes_last_known_good() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let device = world.device(b"me");
+
+    seed_settings(
+        &device,
+        &blocks,
+        &hand_encoded_body_at("https://kubo.example", 5),
+        1,
+    );
+    assert!(matches!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Resolved(_)
+    ));
+    seed_settings(
+        &device,
+        &blocks,
+        &hand_encoded_body_at("https://attacker.example", 4),
+        1,
+    );
+    assert!(matches!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Stale { .. }
+    ));
+
+    // Nothing serves a record now, so the load answers purely from the cache.
+    for endpoint in device.record_store.endpoints() {
+        device
+            .record_store
+            .seed_record(&endpoint, settings_name(&SECRET).as_str(), Vec::new());
+    }
+    assert_eq!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Stale {
+            settings: hand_encoded_settings("https://kubo.example"),
+            reason: DefaultsReason::Suppressed,
+        },
+        "the refused fork never displaced the copy this device authenticated",
+    );
+}
+
+/// An attempt that never landed advances only the writer's mint counter, so the
+/// live record it failed to replace stays admissible.
+#[test]
+fn an_unconfirmed_publish_leaves_the_live_record_still_admissible() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let device = world.device(b"me");
+    publish(&world, &device, &blocks, &SECRET, &configured());
+
+    let api = ApiClient::new(
+        device.http.clone(),
+        device.credential_store.clone(),
+        "http://api.test",
+    );
+    serve_http(&device, &blocks, 4);
+    assert_eq!(
+        block_on(publish_settings(
+            &AcksNothingBack,
+            &api,
+            &device.floor_store,
+            &device.snapshot_cache,
+            &world.scheduler,
+            &SyncTimingProfile::CI,
+            &mut SeededEntropy::new(9),
+            &OrphanHeads::default(),
+            &SECRET,
+            &VaultSettings::default(),
+        ))
+        .unwrap_err(),
+        SettingsPublishError::Unconfirmed,
+    );
+
+    assert_eq!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Resolved(configured()),
+        "the record on the network is still the member's own choice",
+    );
+}
+
+/// AGENTS.md rule 8 for the revision: the reader refuses one below its durable
+/// bar, so a counter that did not advance fails the publish in every build —
+/// `Err`, never a stripped assertion — with nothing reaching the record plane.
+#[test]
+fn a_mint_counter_that_does_not_advance_refuses_the_publish() {
+    let world = FakeWorld::new();
+    let device = world.device(b"me");
+    let api = ApiClient::new(
+        device.http.clone(),
+        device.credential_store.clone(),
+        "http://api.test",
+    );
+    serve_http(&device, &Blocks::default(), 4);
+
+    assert_eq!(
+        block_on(publish_settings(
+            &device.record_store,
+            &api,
+            &StuckCounter,
+            &device.snapshot_cache,
+            &world.scheduler,
+            &SyncTimingProfile::CI,
+            &mut SeededEntropy::new(10),
+            &OrphanHeads::default(),
+            &SECRET,
+            &configured(),
+        ))
+        .unwrap_err(),
+        SettingsPublishError::Revision,
+    );
+    assert!(
+        device
+            .record_store
+            .record_at(
+                &device.record_store.endpoints()[0],
+                settings_name(&SECRET).as_str()
+            )
+            .is_none(),
+        "nothing reached the record plane",
+    );
+}
+
+/// A floor store that reports a floor other than the one it was asked to raise
+/// to — the shape a non-monotonic mint would take.
+struct StuckCounter;
+
+impl FloorStore for StuckCounter {
+    async fn epoch_floor(&self, _scope_id: &[u8]) -> SeamResult<Option<u64>> {
+        Ok(None)
+    }
+
+    async fn raise_epoch_floor(&self, _scope_id: &[u8], epoch: u64) -> SeamResult<u64> {
+        Ok(epoch)
+    }
+
+    async fn sequence_floor(&self, _ipns_name: &[u8]) -> SeamResult<Option<u64>> {
+        Ok(None)
+    }
+
+    async fn raise_sequence_floor(&self, _ipns_name: &[u8], sequence: u64) -> SeamResult<u64> {
+        Ok(sequence.saturating_add(1))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1457,6 +1676,7 @@ fn a_register_first_refusal_retires_the_settings_head_it_uploaded() {
         &device.record_store,
         &api,
         &device.floor_store,
+        &device.snapshot_cache,
         &world.scheduler,
         &SyncTimingProfile::CI,
         &mut SeededEntropy::new(7),
@@ -1501,6 +1721,7 @@ fn a_settings_publish_whose_fan_out_acked_nothing_retires_nothing() {
         &AcksNoPut,
         &api,
         &device.floor_store,
+        &device.snapshot_cache,
         &world.scheduler,
         &SyncTimingProfile::CI,
         &mut SeededEntropy::new(8),

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -908,7 +908,11 @@ fn a_file_create_round_trips_its_bytes_to_a_second_device() {
     // blocks once its record has published, leaving only the queue bookkeeping.
     assert_eq!(
         block_on(alice.staging_store.staged_keys()).unwrap(),
-        vec![DRAINED_OP_MARK_KEY.to_vec(), UPLOAD_MARK_KEY.to_vec()],
+        vec![
+            DRAINED_OP_MARK_KEY.to_vec(),
+            PUBLISHED_OP_MARK_KEY.to_vec(),
+            UPLOAD_MARK_KEY.to_vec()
+        ],
         "no staged block survives a published version, only queue bookkeeping"
     );
     assert!(
@@ -1472,7 +1476,7 @@ fn a_version_whose_content_key_will_not_open_dead_letters_and_releases_its_block
     );
     assert_eq!(
         block_on(alice.staging_store.staged_keys()).unwrap(),
-        vec![DRAINED_OP_MARK_KEY.to_vec()],
+        vec![DRAINED_OP_MARK_KEY.to_vec(), PUBLISHED_OP_MARK_KEY.to_vec()],
         "blocks no key opens are released, never held against the budget"
     );
     assert_eq!(
@@ -1806,7 +1810,11 @@ fn a_leaf_left_marked_and_staged_is_re_uploaded_and_released_by_the_next_pass() 
         );
         assert_eq!(
             block_on(alice.staging_store.staged_keys()).unwrap(),
-            vec![DRAINED_OP_MARK_KEY.to_vec(), UPLOAD_MARK_KEY.to_vec()],
+            vec![
+                DRAINED_OP_MARK_KEY.to_vec(),
+                PUBLISHED_OP_MARK_KEY.to_vec(),
+                UPLOAD_MARK_KEY.to_vec()
+            ],
             "the retry re-removes it, so the residue holds no staging budget"
         );
         assert_round_trips(&world, &blocks, "photo.bin", &plaintext);
@@ -4254,6 +4262,50 @@ fn plant_published_mark(device: &FakeDevice, op_id: OpId) {
             .put_staged_bytes(PUBLISHED_OP_MARK_KEY, &op_id.0.to_be_bytes()),
     )
     .unwrap();
+}
+
+/// The durable interlock only holds if a real publish writes it, on every plan
+/// that puts content on the network — a create with content as much as a
+/// version update.
+#[test]
+fn every_content_publish_raises_the_published_op_mark() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let created = write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<u8>>(),
+    )
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+    assert_eq!(published_op_mark(&alice), Some(created.0), "the create");
+
+    let file = child_id(&engine, ROOT, "photo.bin");
+    let updated = write_file(
+        &mut engine,
+        WriteTarget::Version { node: file },
+        &(0..64u8).collect::<Vec<u8>>(),
+    )
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+    assert_eq!(
+        published_op_mark(&alice),
+        Some(updated.0),
+        "the version update"
+    );
+}
+
+/// The durable published-op high-water this device stored.
+fn published_op_mark(device: &FakeDevice) -> Option<u64> {
+    let stored = block_on(device.staging_store.staged_bytes(PUBLISHED_OP_MARK_KEY)).unwrap()?;
+    Some(u64::from_be_bytes(stored.try_into().unwrap()))
 }
 
 /// An op whose record PUT was acknowledged is already live at its name. A crash

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -31,7 +31,8 @@ use cipherbox_engine::seams::{
 };
 use cipherbox_engine::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
 use cipherbox_engine::sync::{
-    DRAINED_OP_MARK_KEY, StagedContent, UPLOAD_MARK_KEY, record_content_root_cid,
+    DRAINED_OP_MARK_KEY, PUBLISHED_OP_MARK_KEY, StagedContent, UPLOAD_MARK_KEY,
+    record_content_root_cid,
 };
 use cipherbox_engine::testkit::fakes::InMemoryRecordStore;
 use cipherbox_engine::testkit::{
@@ -1570,6 +1571,59 @@ fn a_hole_in_the_staged_block_suffix_is_loss_and_fails_closed() {
     assert_no_blocks_staged(&alice, &version);
 }
 
+/// The mark is host-local storage, so a torn or bit-rotted one that still
+/// parses is reachable. A count above the version's own leaf count is proof of
+/// corruption: trusting it would let every absent leaf skip the hole guard and
+/// publish a manifest naming blocks nothing holds, so it reads as no progress
+/// at all.
+#[test]
+fn a_corrupt_upload_mark_is_no_progress_rather_than_blanket_coverage() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<u8>>(),
+    )
+    .unwrap();
+
+    // A mark naming this very version and claiming more leaves than it has.
+    let version = evict_leaf(&alice, |leaves| leaves / 2);
+    let (root_cid, _) = staged_version(&alice);
+    let mut corrupt = root_cid;
+    corrupt.extend_from_slice(&u32::MAX.to_be_bytes());
+    block_on(
+        alice
+            .staging_store
+            .put_staged_bytes(UPLOAD_MARK_KEY, &corrupt),
+    )
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    assert!(
+        events_so_far(&mut events).iter().any(|event| matches!(
+            event,
+            Event::DeadLetter {
+                reason: DeadLetterReason::ContentUnrecoverable,
+                ..
+            }
+        )),
+        "a corrupt mark covers nothing, so the hole is still loss"
+    );
+    assert!(
+        block_on(engine.view()).unwrap().children(ROOT).is_empty(),
+        "no version publishes over a block nothing holds"
+    );
+    assert_no_blocks_staged(&alice, &version);
+}
+
 /// The version the head queued op carries: its root CID and its leaf CIDs, in
 /// file order — the order the drain uploads and releases them in.
 fn staged_version(device: &FakeDevice) -> (Vec<u8>, Vec<Vec<u8>>) {
@@ -2994,6 +3048,112 @@ fn a_source_remove_that_cannot_publish_undoes_its_own_dest_add() {
     );
 }
 
+/// Set up a relink whose source-remove leg is refused with `refusal`, and hand
+/// back the op the drain halts on. The dest-add lands and is compensated first,
+/// so what the queue sees afterwards is the classification of the source-remove
+/// alone.
+fn relink_whose_source_remove_is_refused(
+    world: &FakeWorld,
+    blocks: &Blocks,
+    engine: &mut Engine<FakeSeamTypes>,
+    tasks: &mut Vec<BoxedTask>,
+    refusal: impl Fn() -> SeamResult<HttpResponse> + Send + 'static,
+) -> OpId {
+    let (photos, moved) = seed_folder_and_file(world, engine, tasks);
+    blocks.refuse_upload(Box::new(move |block| {
+        (head_of(block) == Some(ROOT.0)).then(&refusal)
+    }));
+    block_on(engine.command(Command::Relink {
+        node: moved,
+        new_parent: photos,
+    }))
+    .unwrap()
+    .expect("a relink journals an op")
+}
+
+/// An over-quota source-remove is a hold, not an unclassified retry: the op
+/// keeps its place and the probe is given the byte figure it must find room for.
+#[test]
+fn an_over_quota_source_remove_holds_the_op_with_its_needed_bytes() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+
+    let op_id =
+        relink_whose_source_remove_is_refused(&world, &blocks, &mut engine, &mut tasks, || {
+            upload_413(Some("QUOTA_EXCEEDED"))
+        });
+    tick(&world, &engine, &mut tasks);
+
+    let blocked = block_on(engine.snapshot(ROOT))
+        .expect("a snapshot")
+        .blocked
+        .expect("the over-quota source-remove is held");
+    assert_eq!(blocked.op_id, op_id);
+    assert!(
+        blocked.needed_bytes > 0,
+        "the figure the resume probe must find room for survives the leg"
+    );
+}
+
+/// A permanently refused source-remove dead-letters instead of retrying the
+/// same bytes forever.
+#[test]
+fn a_permanently_refused_source_remove_dead_letters() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+
+    let op_id =
+        relink_whose_source_remove_is_refused(&world, &blocks, &mut engine, &mut tasks, || {
+            upload_413(Some("UPLOAD_TOO_LARGE"))
+        });
+    let (dead_letters, passes) = tick_until_dead_lettered(&world, &engine, &mut tasks);
+
+    assert_eq!(passes, 1, "the server's own verdict is permanent on sight");
+    assert_eq!(
+        dead_letters,
+        vec![DeadLetter {
+            op_id,
+            reason: DeadLetterReason::PayloadRefused
+        }]
+    );
+}
+
+/// An unattributable refusal on the source-remove is charged against the
+/// attempt budget: `Unclassified` would retry free and forever, so the budget
+/// that exists to bound exactly this pathology would never trip.
+#[test]
+fn an_unattributable_source_remove_refusal_spends_the_attempt_budget() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+
+    let op_id =
+        relink_whose_source_remove_is_refused(&world, &blocks, &mut engine, &mut tasks, || {
+            upload_413(None)
+        });
+    let (dead_letters, passes) = tick_until_dead_lettered(&world, &engine, &mut tasks);
+
+    assert!(
+        passes > 1,
+        "an unattributable refusal is a charged attempt, not a verdict"
+    );
+    assert_eq!(
+        dead_letters,
+        vec![DeadLetter {
+            op_id,
+            reason: DeadLetterReason::AttemptsExhausted
+        }]
+    );
+}
+
 /// The compensation must restore what the dest-add vacated too: a destination
 /// left holding neither the moved node nor the one it replaced has lost an
 /// entry outright (#884).
@@ -4078,6 +4238,101 @@ fn a_cancel_after_the_version_published_is_refused() {
         block_on(engine.view()).unwrap().children(ROOT).len(),
         1,
         "the published file is untouched"
+    );
+    assert!(
+        retire_targets(&alice).is_empty(),
+        "a refused cancel unpins nothing"
+    );
+}
+
+/// Plant the durable published-op mark over `op_id`, standing in for the crash
+/// between a record PUT the network acked and the op's removal from the queue.
+fn plant_published_mark(device: &FakeDevice, op_id: OpId) {
+    block_on(
+        device
+            .staging_store
+            .put_staged_bytes(PUBLISHED_OP_MARK_KEY, &op_id.0.to_be_bytes()),
+    )
+    .unwrap();
+}
+
+/// An op whose record PUT was acknowledged is already live at its name. A crash
+/// before its removal from the queue leaves it replayable, and a replay would
+/// re-upload every leaf into a set a cancel can retire — unpinning content a
+/// published record names. It drops as already satisfied instead.
+#[test]
+fn an_op_whose_record_already_published_is_dropped_rather_than_replayed() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let op_id = write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<u8>>(),
+    )
+    .unwrap();
+    let version = staged_version(&alice);
+    plant_published_mark(&alice, op_id);
+    tick(&world, &engine, &mut tasks);
+
+    assert!(
+        !events_so_far(&mut events).iter().any(|event| matches!(
+            event,
+            Event::OpProgress {
+                phase: OpPhase::UploadStarted,
+                ..
+            }
+        )),
+        "nothing re-uploads behind a record that already landed"
+    );
+    assert!(
+        block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .is_empty(),
+        "the op leaves the queue"
+    );
+    let leftover = version
+        .1
+        .into_iter()
+        .chain(core::iter::once(version.0))
+        .collect::<Vec<_>>();
+    assert_no_blocks_staged(&alice, &leftover);
+    assert!(
+        retire_targets(&alice).is_empty(),
+        "a drop is not an abandonment: nothing published is unpinned"
+    );
+}
+
+/// The publish-entry interlock is session-scoped, so a reboot clears it. The
+/// durable mark is what keeps a published version uncancellable across one.
+#[test]
+fn a_cancel_of_an_already_published_op_is_refused_across_a_restart() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, _tasks) = boot(&world, &blocks, &alice, 42);
+    let op_id = write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<u8>>(),
+    )
+    .unwrap();
+    plant_published_mark(&alice, op_id);
+
+    assert_eq!(
+        block_on(engine.command(Command::CancelUpload { op_id })),
+        Err(EngineError::TooLateToCancel { op_id })
     );
     assert!(
         retire_targets(&alice).is_empty(),

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -18,6 +18,7 @@ use cipherbox_core::seal::{
 };
 use cipherbox_core::suite::ecdsa::EcdsaSigner;
 use cipherbox_core::suite::ed25519::Ed25519Signer;
+use cipherbox_core::suite::x25519::X25519Secret;
 use zeroize::Zeroizing;
 
 use cipherbox_engine::api::REGISTRY_BATCH_REFUSED;
@@ -31,7 +32,7 @@ use cipherbox_engine::seams::{
 };
 use cipherbox_engine::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
 use cipherbox_engine::sync::{
-    DRAINED_OP_MARK_KEY, PUBLISHED_OP_MARK_KEY, StagedContent, UPLOAD_MARK_KEY,
+    DRAINED_OP_MARK_PREFIX, PUBLISHED_OP_MARK_PREFIX, StagedContent, UPLOAD_MARK_KEY, op_mark_key,
     record_content_root_cid,
 };
 use cipherbox_engine::testkit::fakes::InMemoryRecordStore;
@@ -908,11 +909,7 @@ fn a_file_create_round_trips_its_bytes_to_a_second_device() {
     // blocks once its record has published, leaving only the queue bookkeeping.
     assert_eq!(
         block_on(alice.staging_store.staged_keys()).unwrap(),
-        vec![
-            DRAINED_OP_MARK_KEY.to_vec(),
-            PUBLISHED_OP_MARK_KEY.to_vec(),
-            UPLOAD_MARK_KEY.to_vec()
-        ],
+        vec![drained_key(), mark_key(), UPLOAD_MARK_KEY.to_vec()],
         "no staged block survives a published version, only queue bookkeeping"
     );
     assert!(
@@ -1476,7 +1473,7 @@ fn a_version_whose_content_key_will_not_open_dead_letters_and_releases_its_block
     );
     assert_eq!(
         block_on(alice.staging_store.staged_keys()).unwrap(),
-        vec![DRAINED_OP_MARK_KEY.to_vec(), PUBLISHED_OP_MARK_KEY.to_vec()],
+        vec![drained_key(), mark_key()],
         "blocks no key opens are released, never held against the budget"
     );
     assert_eq!(
@@ -1810,11 +1807,7 @@ fn a_leaf_left_marked_and_staged_is_re_uploaded_and_released_by_the_next_pass() 
         );
         assert_eq!(
             block_on(alice.staging_store.staged_keys()).unwrap(),
-            vec![
-                DRAINED_OP_MARK_KEY.to_vec(),
-                PUBLISHED_OP_MARK_KEY.to_vec(),
-                UPLOAD_MARK_KEY.to_vec()
-            ],
+            vec![drained_key(), mark_key(), UPLOAD_MARK_KEY.to_vec()],
             "the retry re-removes it, so the residue holds no staging budget"
         );
         assert_round_trips(&world, &blocks, "photo.bin", &plaintext);
@@ -2220,7 +2213,7 @@ fn an_op_the_completion_record_already_covers_never_republishes() {
     // below reclaims from the stale queue.
     block_on(StagingStore::put_staged_bytes(
         &alice.staging_store,
-        DRAINED_OP_MARK_KEY,
+        &drained_key(),
         &1u64.to_be_bytes(),
     ))
     .unwrap();
@@ -2261,7 +2254,7 @@ fn an_op_the_completion_record_already_covers_never_republishes() {
 /// The device's durable drained-op completion mark. It lives beside the op
 /// queue it names, so a store that loses one loses the other.
 async fn drained_mark(device: &FakeDevice) -> Option<u64> {
-    StagingStore::staged_bytes(&device.staging_store, DRAINED_OP_MARK_KEY)
+    StagingStore::staged_bytes(&device.staging_store, &drained_key())
         .await
         .expect("the staging store answers")
         .map(|bytes| u64::from_be_bytes(bytes.try_into().expect("an 8-byte mark")))
@@ -4097,7 +4090,7 @@ fn a_cancel_mid_upload_releases_every_block_and_returns_the_staging_budget() {
         block_on(alice.staging_store.staged_keys())
             .unwrap()
             .iter()
-            .all(|key| key.as_slice() == DRAINED_OP_MARK_KEY || key.as_slice() == UPLOAD_MARK_KEY),
+            .all(|key| *key == drained_key() || key.as_slice() == UPLOAD_MARK_KEY),
         "the staging budget holds nothing but queue bookkeeping"
     );
     assert!(
@@ -4253,15 +4246,30 @@ fn a_cancel_after_the_version_published_is_refused() {
     );
 }
 
-/// Plant the durable published-op mark over `op_id`, standing in for the crash
-/// between a record PUT the network acked and the op's removal from the queue.
-fn plant_published_mark(device: &FakeDevice, op_id: OpId) {
-    block_on(
-        device
-            .staging_store
-            .put_staged_bytes(PUBLISHED_OP_MARK_KEY, &op_id.0.to_be_bytes()),
-    )
+/// This account's published-op mark key. The mark is per-identity, so a store
+/// shared with another account keeps one mark each.
+fn mark_key() -> Vec<u8> {
+    op_mark_key(PUBLISHED_OP_MARK_PREFIX, &kdf::enc_subkey(&SECRET))
+}
+
+/// This account's drained-op mark key.
+fn drained_key() -> Vec<u8> {
+    op_mark_key(DRAINED_OP_MARK_PREFIX, &kdf::enc_subkey(&SECRET))
+}
+
+/// Plant a published-op mark over `op_id` under `enc_secret`'s identity,
+/// standing in for the crash between a confirmed record publish and the op's
+/// removal from the queue.
+fn plant_published_mark_for(device: &FakeDevice, enc_secret: &X25519Secret, op_id: OpId) {
+    block_on(device.staging_store.put_staged_bytes(
+        &op_mark_key(PUBLISHED_OP_MARK_PREFIX, enc_secret),
+        &op_id.0.to_be_bytes(),
+    ))
     .unwrap();
+}
+
+fn plant_published_mark(device: &FakeDevice, op_id: OpId) {
+    plant_published_mark_for(device, &kdf::enc_subkey(&SECRET), op_id);
 }
 
 /// The durable interlock only holds if a real publish writes it, on every plan
@@ -4304,7 +4312,7 @@ fn every_content_publish_raises_the_published_op_mark() {
 
 /// The durable published-op high-water this device stored.
 fn published_op_mark(device: &FakeDevice) -> Option<u64> {
-    let stored = block_on(device.staging_store.staged_bytes(PUBLISHED_OP_MARK_KEY)).unwrap()?;
+    let stored = block_on(device.staging_store.staged_bytes(&mark_key())).unwrap()?;
     Some(u64::from_be_bytes(stored.try_into().unwrap()))
 }
 
@@ -4370,7 +4378,81 @@ fn a_cancel_of_an_already_published_op_is_refused_across_a_restart() {
     seed_account(&world, &blocks);
 
     let alice = world.device(b"alice");
-    let (mut engine, _events, _tasks) = boot(&world, &blocks, &alice, 42);
+    let op_id = {
+        let (mut engine, _events, _tasks) = boot(&world, &blocks, &alice, 42);
+        let op_id = write_file(
+            &mut engine,
+            WriteTarget::NewFile {
+                parent: ROOT,
+                name: "photo.bin".into(),
+            },
+            &(0..200u8).collect::<Vec<u8>>(),
+        )
+        .unwrap();
+        // The record published and the crash landed before the dequeue, so the
+        // op is still queued when this session ends.
+        plant_published_mark(&alice, op_id);
+        op_id
+    };
+
+    // A second session over the same device: fresh `UploadCancels`, so nothing
+    // but the durable mark stands between the cancel and the published version.
+    let (mut restarted, _events, _tasks) = boot(&world, &blocks, &alice, 43);
+    assert_eq!(
+        block_on(restarted.command(Command::CancelUpload { op_id })),
+        Err(EngineError::TooLateToCancel { op_id })
+    );
+    assert!(
+        retire_targets(&alice).is_empty(),
+        "a refused cancel unpins nothing"
+    );
+}
+
+/// The drained mark has the same shape and a worse outcome: an op discarded as
+/// restore residue never published, and nothing releases or retires it — the
+/// mutation is simply gone.
+#[test]
+fn another_identitys_drained_mark_never_discards_this_ones_queued_op() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let op_id = block_on(engine.command(Command::Create {
+        parent: ROOT,
+        name: "notes".into(),
+        kind: NodeKind::Folder,
+    }))
+    .unwrap()
+    .expect("the create queues");
+
+    let stranger = kdf::enc_subkey(&[9u8; 32]);
+    block_on(alice.staging_store.put_staged_bytes(
+        &op_mark_key(DRAINED_OP_MARK_PREFIX, &stranger),
+        &(op_id.0 + 100).to_be_bytes(),
+    ))
+    .unwrap();
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(
+        published_names(&world.record_store, &blocks, ROOT),
+        ["notes"],
+        "the stranger's completion record says nothing about this identity's op"
+    );
+}
+
+/// The queue is shared with other identities, and op ids are per-store. A
+/// device-wide mark would let one account's published op dequeue another's
+/// unpublished one and release its blocks.
+#[test]
+fn another_identitys_published_mark_never_retires_this_ones_queued_op() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
     let op_id = write_file(
         &mut engine,
         WriteTarget::NewFile {
@@ -4380,15 +4462,43 @@ fn a_cancel_of_an_already_published_op_is_refused_across_a_restart() {
         &(0..200u8).collect::<Vec<u8>>(),
     )
     .unwrap();
-    plant_published_mark(&alice, op_id);
+    // A second account sharing this staging store published far past alice's id.
+    let stranger = kdf::enc_subkey(&[9u8; 32]);
+    plant_published_mark_for(&alice, &stranger, OpId(op_id.0 + 100));
 
     assert_eq!(
         block_on(engine.command(Command::CancelUpload { op_id })),
-        Err(EngineError::TooLateToCancel { op_id })
+        Ok(None),
+        "the stranger's mark says nothing about this identity's op"
     );
+
+    // And the same op, re-queued, still publishes rather than being dropped.
+    let op_id = write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<u8>>(),
+    )
+    .unwrap();
+    plant_published_mark_for(&alice, &stranger, OpId(op_id.0 + 100));
+    tick(&world, &engine, &mut tasks);
+
     assert!(
-        retire_targets(&alice).is_empty(),
-        "a refused cancel unpins nothing"
+        events_so_far(&mut events).iter().any(|event| matches!(
+            event,
+            Event::OpProgress {
+                phase: OpPhase::UploadStarted,
+                ..
+            }
+        )),
+        "the op uploaded instead of being dropped as already published"
+    );
+    assert_eq!(
+        published_names(&world.record_store, &blocks, ROOT),
+        ["photo.bin"],
+        "the version published"
     );
 }
 


### PR DESCRIPTION
Hardens the vault settings resolve against suppression and cold-device replay, and closes four op-drain correctness gaps.

Closes #929
Closes #930
Closes #931
Closes #947
Closes #909
Closes #940
Closes #966
Closes #1044
Closes #904

## The #930 decision: option i, EOL is the cold-device anchor

**Decided: option (i).** A cold device's freshness bound is the 90-day EOL window, stated rather than closed; the rationale is written into `blueprint/engine.md`.

- **(iii), an API-held counter, is refused outright** — `blueprint/engine.md` "no client resolve path ever touches the API's record cache".
- **(ii), chaining the settings head CID into the vault pointer, defeats the record's own purpose.** Settings resolve *before* any vault resolve precisely so a self-hosting owner never needs CipherBox to tell them where their own node is. Chaining inverts that: a BYO member would have to reach the network they configured *in settings* in order to read those settings. The cold-start reorder the issue prices is the smaller half of the cost — the circular dependency for the External/BYO member, the exact member this hardening exists for, is the disqualifying one.

**#931 lands anyway**, against the gating sentence in its own body. #931 was gated on (ii)/(iii) because it was read as a *cold-device* anchor, which it is not — the counter is device-local, so it adds nothing to a fresh install. It does close **residual 3** in #904 (a same-sequence fork staying admissible forever), which is a warm-device problem the cold-device decision does not touch, and it is the only thing that closes it. Residual 3 is in the umbrella's scope, so the slice ships.

## Trust-boundary input binding, audited upfront

Every input to the settings freshness decision:

| Input | Source | Classification |
| --- | --- | --- |
| `verified.validity` (EOL) | inside the Ed25519-signed `data` field | **bound** — `IpnsRecord::verify` checks the signature against the pubkey derived from the name itself |
| `verified.sequence` | same signed field | **bound** — same signature |
| head-block bytes | gateway HTTP | **bound** — CID checked against the signed record value, then the HPKE seal open authenticates |
| body `revision` | inside the sealed body | **bound** — AEAD-authenticated under `enc-subkey`; only the account can produce it |
| `now` | `Scheduler::now` seam | **trusted** — a backwards-skewed clock widens the window, a forwards-skewed one refuses live records and degrades to last-known-good; not reachable through the record plane |
| durable sequence floor, adopted revision, mint counter | `FloorStore`, device-local | **trusted** — the device-storage-adversary residual is already documented in `blueprint/engine.md` |
| cached head block | `SnapshotCache`, device-local | **trusted-with-verification** — re-opened through the same seal and body grammar every time |
| `name`, `enc_secret` | `kdf::settings_ipns_keypair` / `kdf::enc_subkey` | **earlier-stage** — pure functions of the login secret |
| `profile.settings_load_budget` | policy parameter | **earlier-stage** |

No tracked-defer entries. No new KDF edge: the revision counters are opaque `FloorStore` keys, not derivations.

## What changed

**#929 — EOL on the settings resolve.** `now: UnixMillis` threads from the existing scheduler into `resolve_settings`; a lapsed record is `DefaultsReason::Expired` and degrades through the last-known-good path. Rule 8 needs **no** encode-side guard here: `eol_from(now)` is `now + 90 days` off the injected clock, so `publish_settings` structurally cannot mint an already-expired record — the same shape as `RetentionPolicy::KeepLatest(NonZeroU64)`. Covered instead by a test that hand-mints a past EOL and asserts the reader's verdict. The `net/eol.rs` framing and the blueprint's "a lapse is an availability event" both now name the carve-out.

**#931 — attempt-scoped body revision.** A `revision` key in `BODY_KEYS`, minted per publish attempt and advanced before the PUT. **Seam decision: reuse the `Sequence` namespace under prefixed keys**, not a new `FloorNamespace::Revision`. A new variant forces every host store to grow a third map for what is the same monotonic-max `u64` primitive, and the precedent for sub-namespacing under a derived key is already in the tree. `settings-revision/<name>` and `settings-revision-mint/<name>` cannot collide with the bare `ipnsName` the per-name sequence floor uses — a canonical base36 name contains no `/`. **So no seam change, and no TS leg: `crates/desktop-seams`, `crates/wasm/src/seams_bridge.rs`, `packages/client/src/seams/floorStore.ts` and the conformance kit are untouched.**

Two counters, not one: the writer's mint counter and the reader's adopted high-water. An attempt that never landed advances only the mint counter, so it never makes a device refuse the live record it failed to replace. Rule 8's encode-side guard is a release-active `Err` (`SettingsPublishError::Revision`) when the store does not take the minted value, with a test that passes under `--release`.

**#947 — settings orphan-head retirement.** `orphan_heads` and its retire lift out of `Drain` into `OrphanHeads` in `net/retire.rs`, shared with `publish_settings`; `orphaned_head` moves with them. Both #921 carve-outs stay intact — a fan-out that acked nothing is not an orphan, and the drain still refuses a head the live set names.

**#909 — source-remove classification.** The leg keeps the `Halt` from `publish_folder` through the compensation instead of flattening it to `Unclassified`. A `Blocked` source-remove parks with its `needed_bytes` and holds its staging reservation exactly as a blocked dest-add does — the dest-add is already rolled back, so the retry replays the whole move, which is the same shape the hold already assumes. Only the compensation's own failure stays unclassified.

**#940 — corrupt upload mark.** Decided: a count above the version's own leaf count reads as **no progress**. Clamping to the leaf count is the maximally trusting reading of bytes already known to be corrupt and can cover every absent leaf, publishing a manifest naming blocks nothing holds — which the issue's own bar rules out. Zero re-uploads whatever is still staged and leaves the rest to the hole guard. The third option, re-deriving progress from the pin provider, needs an API surface that does not exist. `encode_upload_mark`/`decode_upload_mark` share the bound, encode-side release-active, tested in a release build.

**#966 — replayed `UpdateContent`.** A durable `PUBLISHED_OP_MARK_KEY` op-id high-water, raised between the op's last record publish and the release of its staged blocks. `queued_ops` drops any queued op at or below it as already satisfied and releases its blocks; `cancel_upload` refuses it. That is the durable half of the publish-entry interlock, which is session-scoped and does not survive a reboot.

## CodeRabbit round

Three findings; all three folded in.

**Identity-scoped op-id marks — accepted, and extended to the sibling.** `OpId` is documented strictly-increasing *per store*, the web host names the staging DB origin-wide with no per-identity prefix, and a foreign record is `RecordClass::Retained` — held in the queue, never removed. So a device-wide high-water genuinely let one account's progress discard another's queued op. I had deferred this as #1044 on the grounds that it is pre-existing in `DRAINED_OP_MARK_KEY` and this PR only added a second instance; that was the wrong call, since the new doc block explains exactly why the shape is unsound six lines above the sibling that has it. Both marks are now `*_PREFIX` constants plus one shared `op_mark_key(prefix, enc_secret)` appending the owner tag `decode_queue` classifies against, and orphan GC exempts both prefixes. The drained mark turned out to be the worse of the two: `mark_drained` computes its prefix over `Queue.mine`, so a foreign op below it is dropped as restore residue having never published, with nothing released or retired. **This closes #1044.**

**In-doubt publish on a failed marker write — partly accepted.** The `?` on `mark_published` was itself the hazard: a failed staging write left the op queued *with* its blocks and no mark, so the next pass replayed a live version and reopened the cancel window — a benign hiccup converted into the exact failure the mark prevents. `mark_published` is now best-effort, matching `mark_drained`, with `dequeue_op` as the primary guard. Durable in-doubt state was not added: it moves the window rather than removing it, since any single durable write has a gap after the network ack, and deciding an in-doubt op needs a re-resolve, not a staging write. The genuinely uncovered case is narrower than reported — `publish_node` returns `Ok` only after the self-adopt, so a PUT-acked-but-unadopted record never reaches `mark_published` — and stays #1045.

**Restart the engine in the cancel test — accepted.** The first session now ends in its own scope and a second `boot` over the same device issues the cancel, so `UploadCancels` is genuinely fresh.

Every new test was verified to fail against the pre-fix behaviour: short-circuiting the cancel guard fails the restart test, and dropping the owner tag from the mark key fails both `another_identitys_*` tests.

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` all ran on `git diff main...HEAD`; findings are folded into the second commit.

- `/simplify`: one op-id mark codec instead of two copies, one upload-mark codec pair, the settings key/counter doc blocks stated once, the `eol.rs` header cut to a cross-reference, an early return so an idle tick reads no marks, and the adopted-revision floor read moved to its use site so a degraded load does not pay for it inside the budget.
- `/security-review`: no findings above the bar. Two sub-threshold observations were fixed anyway — `publish_create` now raises the published-op mark, and a confirmed publish raises the adopted revision.
- `/crypto-privacy-review`: 0 critical, 1 high, 4 medium, 4 low. Fixed here: the revision bar is scoped to `sequence == floor` (an unconditional bar false-rejects a peer device's legitimate higher-sequence record forever); a confirmed publish seeds last-known-good, closing the rotated-BYO-credential hazard the umbrella names; orphan heads retire by identity rather than by count; `gate/floor.rs` names the one non-floor value in its namespace; the published-op mark's doc states what the code guarantees; and the rule-8 test the revision guard was missing.

Clean: KDF catalog compliance, floor-key namespacing, the floor law, nonce/ephemeral discipline, determinism, zeroization across the new early return in the body decode, and `Debug` leakage.

## Deferred

Two follow-ups, each with a native dependency edge at filing:

- #1043 — the settings record never enters the held set, so its EOL lapses on its own. Availability, not a placement widening: the settings-load policy already fails the placement decision closed. Belongs with the slice that wires the settings plane into the facade, which has no production caller today. Residual noted in `blueprint/engine.md`.
- #1045 — a publish whose record acked but whose self-adopt failed is still replayable. Narrower than #966; closing it needs the op id threaded into `publish_head`.

## Verification

`cargo fmt --all --check`, `cargo clippy --all-targets` clean, `cargo test -p cipherbox-engine -p cipherbox-core` green, and `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` clean. Both rule-8 guards verified under `cargo test --release`. No TypeScript surface changed.

Gate: `Engine Tests`. `Core KATs` is not required — `crates/core` treats the settings body as opaque.

Part of #655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added safeguards against expired vault settings, replayed records, and revision rollbacks.
  - Improved cold-device validation using the configured end-of-life period.

- **Reliability**
  - Prevents already-published operations from being cancelled or uploaded again after interruptions or restarts.
  - Improves recovery when publishing is interrupted or refused.

- **Data Management**
  - Automatically tracks and retires orphaned uploaded content to reduce leftover storage.

- **Validation**
  - Strengthened upload progress checks to reject invalid or inconsistent transfer markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->