### PR TITLE
fix: mark an op published at its record ack and mirror the gate stage 2 on the produce side

### DIFF
--- a/crates/engine/src/net/author.rs
+++ b/crates/engine/src/net/author.rs
@@ -9,9 +9,10 @@
 //! - a child envelope carrying a grant section returns `Err`, off core's own
 //!   `has_grant_section` — the produce guard and the decode reject cannot drift;
 //! - a scope root missing its grant section, carrying one whose commitment
-//!   names another `ipnsName`, or carrying one whose structure signatures do not
-//!   recompute at the envelope's own scope/epoch, returns `Err` off the same
-//!   decoder and the same stage-3 predicate the gate runs;
+//!   names another `ipnsName` or is not signed by the anchored owner identity,
+//!   or carrying one whose structure signatures do not recompute at the
+//!   envelope's own scope/epoch, returns `Err` off the same decoder and the same
+//!   stage-2/stage-3 predicates the gate runs;
 //! - a kind transplant and a non-canonical child-ref `ipnsName` are
 //!   unrepresentable: [`new_child`] feeds one [`NodeKind`] and one typed
 //!   [`IpnsName`] to both the body and the parent's ref.
@@ -21,8 +22,9 @@ use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::seal::{
     ChildRef, Envelope, GrantSection, NodeKind, PreservedFields, ReadBody, Version,
     decode_grant_section, encode_envelope, encode_grant_section, grant_section_bytes,
-    has_grant_section, seal_read_body, set_grant_section,
+    has_grant_section, seal_read_body, set_grant_section, verify_grant_set,
 };
+use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaVerifier};
 
 use crate::content::limits::MAX_RESOLVED_RECORD_BYTES;
 use crate::content::root_block_cid;
@@ -46,6 +48,9 @@ pub enum AuthorError {
     /// The carried grant-set commitment names a different `ipnsName` than the
     /// record is published under, which the gate's stage 2 rejects.
     CommitmentNameMismatch,
+    /// The carried grant-set commitment is unsigned, malformed, or not signed by
+    /// the contact-anchored owner identity, which the gate's stage 2 rejects.
+    CommitmentSignatureInvalid,
     /// A structure signature in the carried grant section does not recompute at
     /// the envelope's own scope and epoch, which the gate's stage 3 rejects
     /// whole-record.
@@ -65,6 +70,45 @@ pub enum AuthorError {
     },
 }
 
+impl AuthorError {
+    /// The stable kebab-case name of this refusal — the produce-side counterpart
+    /// of [`GateRejection::check`], so a regression in the epoch or commitment
+    /// pairing is legible in the field rather than a silent retry.
+    ///
+    /// [`GateRejection::check`]: crate::gate::GateRejection::check
+    pub fn check(&self) -> &'static str {
+        match self {
+            Self::GrantSectionOnChild => "grant-section-on-child",
+            Self::MissingGrantSection => "missing-grant-section",
+            Self::CommitmentNameMismatch => "commitment-name-mismatch",
+            Self::CommitmentSignatureInvalid => "commitment-signature-invalid",
+            // The gate's own verdict name: this is the same predicate.
+            Self::SectionSignatureInvalid => "structure-signature-invalid",
+            Self::Seal(e) => e.check(),
+            Self::HeadTooLarge { .. } => "head-too-large",
+        }
+    }
+
+    /// Whether this is a **trust** refusal on the record's own bytes — the
+    /// produce-side mirror of an adoption-gate rejection — rather than a codec
+    /// or size refusal of the body this pass happened to build, which a rebase
+    /// onto other state may not reproduce.
+    ///
+    /// The write plane charges a trust refusal against its attempt budget:
+    /// re-authoring the same inputs repeats it verbatim, so leaving it
+    /// unclassified spins the queue uncharged and forever (#1048).
+    pub fn is_trust_refusal(&self) -> bool {
+        match self {
+            Self::GrantSectionOnChild
+            | Self::MissingGrantSection
+            | Self::CommitmentNameMismatch
+            | Self::CommitmentSignatureInvalid
+            | Self::SectionSignatureInvalid => true,
+            Self::Seal(_) | Self::HeadTooLarge { .. } => false,
+        }
+    }
+}
+
 impl core::fmt::Display for AuthorError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
@@ -72,6 +116,9 @@ impl core::fmt::Display for AuthorError {
             Self::MissingGrantSection => f.write_str("scope root carries no grantSection"),
             Self::CommitmentNameMismatch => {
                 f.write_str("carried commitment names another ipnsName")
+            }
+            Self::CommitmentSignatureInvalid => {
+                f.write_str("carried commitment is not signed by the anchored owner identity")
             }
             Self::SectionSignatureInvalid => {
                 f.write_str("carried grant section does not authenticate at this envelope's epoch")
@@ -136,14 +183,16 @@ pub fn author_child_envelope(
 /// section is the root's marker and rides `carried_unknown` verbatim, so the
 /// seed-bearing structures and their signatures survive a metadata republish
 /// untouched — which also means a republish must not carry a section belonging
-/// to some other name, or authored at some other epoch, so the checks the gate
-/// makes on arrival run here first (release-active).
+/// to some other name, authored at some other epoch, or authored by anyone but
+/// `owner_identity`, so the checks the gate makes on arrival run here first
+/// (release-active).
 pub fn author_scope_root_envelope(
     authoring: EnvelopeAuthoring<'_>,
     name: &IpnsName,
+    owner_identity: &EcdsaVerifier,
 ) -> Result<AuthoredHead, AuthorError> {
     let envelope = seal(&authoring)?;
-    check_scope_root(&envelope, name)?;
+    check_scope_root(&envelope, name, owner_identity)?;
     encode(envelope)
 }
 
@@ -156,23 +205,36 @@ pub fn author_scope_root_with_section(
     authoring: EnvelopeAuthoring<'_>,
     name: &IpnsName,
     section: &GrantSection,
+    owner_identity: &EcdsaVerifier,
 ) -> Result<AuthoredHead, AuthorError> {
     let mut envelope = seal(&authoring)?;
     set_grant_section(
         &mut envelope,
         encode_grant_section(section).map_err(AuthorError::Seal)?,
     );
-    check_scope_root(&envelope, name)?;
+    check_scope_root(&envelope, name, owner_identity)?;
     encode(envelope)
 }
 
 /// The checks the gate makes on arrival, run here first so a root this build's
-/// own gate always rejects is never signed (release-active).
-fn check_scope_root(envelope: &Envelope, name: &IpnsName) -> Result<(), AuthorError> {
+/// own gate always rejects is never signed (release-active). Stages 2 and 3 in
+/// the gate's own order: without the commitment signature the stage-3 pass is
+/// self-referential — it authenticates structures against the pseudonyms the
+/// section's own commitment names, so a wholly attacker-authored section is
+/// internally consistent.
+fn check_scope_root(
+    envelope: &Envelope,
+    name: &IpnsName,
+    owner_identity: &EcdsaVerifier,
+) -> Result<(), AuthorError> {
     let section = decode_grant_section(
         grant_section_bytes(envelope).ok_or(AuthorError::MissingGrantSection)?,
     )
     .map_err(AuthorError::Seal)?;
+    let commitment_sig = EcdsaSignature::from_compact(&section.commitment_sig)
+        .ok_or(AuthorError::CommitmentSignatureInvalid)?;
+    verify_grant_set(owner_identity, &section.commitment, &commitment_sig)
+        .map_err(|_| AuthorError::CommitmentSignatureInvalid)?;
     if section.commitment.ipns_name != name.as_str().as_bytes() {
         return Err(AuthorError::CommitmentNameMismatch);
     }
@@ -343,11 +405,15 @@ mod tests {
             .collect()
     }
 
-    /// A real scope root's grant section and the name its commitment binds.
+    fn owner_signer() -> EcdsaSigner {
+        EcdsaSigner::from_scalar(&[0x11; 32]).expect("valid scalar")
+    }
+
+    /// A real scope root's grant section and the name its commitment binds,
+    /// signed by [`owner_signer`].
     fn owner_root() -> OwnerRootFixture {
-        let owner_identity = EcdsaSigner::from_scalar(&[0x11; 32]).expect("valid scalar");
         owner_root_fixture(OwnerRootSpec {
-            owner_identity: &owner_identity,
+            owner_identity: &owner_signer(),
             owner_enc: &kdf::enc_subkey(&[0x33; 32]).public(),
             scope_id: [2u8; 16],
             root_id: [1u8; 16],
@@ -383,6 +449,7 @@ mod tests {
         let head = author_scope_root_envelope(
             authoring(&folder(), carried_section(&fixture.grant_section)),
             &fixture.name,
+            &owner_signer().verifying_key(),
         )
         .unwrap();
         assert!(has_grant_section(&head.envelope));
@@ -397,7 +464,8 @@ mod tests {
         assert_eq!(
             author_scope_root_envelope(
                 authoring(&folder(), carried_section(&fixture.grant_section)),
-                &name()
+                &name(),
+                &owner_signer().verifying_key(),
             )
             .unwrap_err(),
             AuthorError::CommitmentNameMismatch,
@@ -419,6 +487,7 @@ mod tests {
                     OWNER_ROOT_EPOCH + 1
                 ),
                 &fixture.name,
+                &owner_signer().verifying_key(),
             )
             .unwrap_err(),
             AuthorError::SectionSignatureInvalid,
@@ -435,6 +504,7 @@ mod tests {
                 authoring_at(&folder(), PreservedFields::new(), OWNER_ROOT_EPOCH + 1),
                 &fixture.name,
                 &fixture.grant_section,
+                &owner_signer().verifying_key(),
             )
             .unwrap_err(),
             AuthorError::SectionSignatureInvalid,
@@ -451,7 +521,8 @@ mod tests {
         assert_eq!(
             author_scope_root_envelope(
                 authoring(&folder(), carried_section(&section)),
-                &fixture.name
+                &fixture.name,
+                &owner_signer().verifying_key(),
             )
             .unwrap_err(),
             AuthorError::SectionSignatureInvalid,
@@ -459,12 +530,110 @@ mod tests {
     }
 
     #[test]
+    fn a_scope_root_envelope_whose_commitment_another_identity_signed_is_refused() {
+        // Release-active (security rule 8): stage 3 authenticates structures
+        // against the pseudonyms the section's *own* commitment names, so
+        // without stage 2's signature half a wholly attacker-authored section —
+        // own commitment, own pseudonym, own signatures, correct ipnsName —
+        // authors cleanly and is only caught by a reader.
+        let attacker = EcdsaSigner::from_scalar(&[0x44; 32]).expect("valid scalar");
+        let fixture = owner_root_fixture(OwnerRootSpec {
+            owner_identity: &attacker,
+            owner_enc: &kdf::enc_subkey(&[0x33; 32]).public(),
+            scope_id: [2u8; 16],
+            root_id: [1u8; 16],
+            children: Vec::new(),
+            child_scope_index: Vec::new(),
+            parent_node_seed: None,
+            owner_write_blob_epoch: None,
+        });
+        assert_eq!(
+            author_scope_root_envelope(
+                authoring(&folder(), carried_section(&fixture.grant_section)),
+                &fixture.name,
+                &owner_signer().verifying_key(),
+            )
+            .unwrap_err(),
+            AuthorError::CommitmentSignatureInvalid,
+        );
+    }
+
+    #[test]
+    fn a_scope_root_envelope_whose_commitment_signature_is_unusable_is_refused() {
+        // The other half of the gate's stage-2 reject: bytes that are not a
+        // compact ECDSA signature at all, which parse before they verify.
+        let fixture = owner_root();
+        let mut section = fixture.grant_section.clone();
+        section.commitment_sig = [0u8; 64];
+        assert_eq!(
+            author_scope_root_envelope(
+                authoring(&folder(), carried_section(&section)),
+                &fixture.name,
+                &owner_signer().verifying_key(),
+            )
+            .unwrap_err(),
+            AuthorError::CommitmentSignatureInvalid,
+        );
+    }
+
+    #[test]
+    fn a_freshly_assembled_section_another_identity_signed_is_refused() {
+        // The re-seal path installs its own section and gets the same stage-2
+        // refusal, so neither scope-root authoring path can drift from the gate.
+        let attacker = EcdsaSigner::from_scalar(&[0x44; 32]).expect("valid scalar");
+        let fixture = owner_root_fixture(OwnerRootSpec {
+            owner_identity: &attacker,
+            owner_enc: &kdf::enc_subkey(&[0x33; 32]).public(),
+            scope_id: [2u8; 16],
+            root_id: [1u8; 16],
+            children: Vec::new(),
+            child_scope_index: Vec::new(),
+            parent_node_seed: None,
+            owner_write_blob_epoch: None,
+        });
+        assert_eq!(
+            author_scope_root_with_section(
+                authoring(&folder(), PreservedFields::new()),
+                &fixture.name,
+                &fixture.grant_section,
+                &owner_signer().verifying_key(),
+            )
+            .unwrap_err(),
+            AuthorError::CommitmentSignatureInvalid,
+        );
+    }
+
+    /// Every trust refusal carries a distinct stable name, and only the trust
+    /// class is charged by the write plane — a codec or size refusal is a
+    /// property of the body this pass built, which a rebase may not reproduce.
+    #[test]
+    fn every_authoring_refusal_has_its_own_stable_check_name() {
+        let refusals = [
+            AuthorError::GrantSectionOnChild,
+            AuthorError::MissingGrantSection,
+            AuthorError::CommitmentNameMismatch,
+            AuthorError::CommitmentSignatureInvalid,
+            AuthorError::SectionSignatureInvalid,
+            AuthorError::HeadTooLarge { size: 1, limit: 0 },
+        ];
+        let names: std::collections::BTreeSet<&str> =
+            refusals.iter().map(AuthorError::check).collect();
+        assert_eq!(names.len(), refusals.len());
+        assert!(refusals[..5].iter().all(AuthorError::is_trust_refusal));
+        assert!(!AuthorError::HeadTooLarge { size: 1, limit: 0 }.is_trust_refusal());
+    }
+
+    #[test]
     fn a_scope_root_envelope_without_a_grant_section_is_refused() {
         // A root that lost its section is a root no reader can open: child
         // adoption refuses the missing marker and the gate has no commitment.
         assert_eq!(
-            author_scope_root_envelope(authoring(&folder(), PreservedFields::new()), &name())
-                .unwrap_err(),
+            author_scope_root_envelope(
+                authoring(&folder(), PreservedFields::new()),
+                &name(),
+                &owner_signer().verifying_key(),
+            )
+            .unwrap_err(),
             AuthorError::MissingGrantSection,
         );
     }

--- a/crates/engine/src/net/author.rs
+++ b/crates/engine/src/net/author.rs
@@ -12,7 +12,9 @@
 //!   names another `ipnsName` or is not signed by the anchored owner identity,
 //!   or carrying one whose structure signatures do not recompute at the
 //!   envelope's own scope/epoch, returns `Err` off the same decoder and the same
-//!   stage-2/stage-3 predicates the gate runs;
+//!   stage-2/stage-3 predicates the gate runs. The mirror stops where the gate
+//!   needs a reader's secrets: stage 3's ascent-link seed cross-check takes an
+//!   ancestor node seed [`EnvelopeAuthoring`] does not carry;
 //! - a kind transplant and a non-canonical child-ref `ipnsName` are
 //!   unrepresentable: [`new_child`] feeds one [`NodeKind`] and one typed
 //!   [`IpnsName`] to both the body and the parent's ref.
@@ -72,14 +74,19 @@ pub enum AuthorError {
 
 impl AuthorError {
     /// The stable kebab-case name of this refusal — the produce-side counterpart
-    /// of [`GateRejection::check`], so a regression in the epoch or commitment
-    /// pairing is legible in the field rather than a silent retry.
+    /// of [`GateRejection::check`], and what [`Display`] renders, so a
+    /// regression in the epoch or commitment pairing is legible in the field
+    /// rather than a silent retry.
     ///
     /// [`GateRejection::check`]: crate::gate::GateRejection::check
+    /// [`Display`]: core::fmt::Display
     pub fn check(&self) -> &'static str {
         match self {
             Self::GrantSectionOnChild => "grant-section-on-child",
             Self::MissingGrantSection => "missing-grant-section",
+            // Stage 2's single `commitment-invalid` verdict, split by cause: the
+            // producer knows which half of its own bytes is wrong, where a
+            // reader deliberately tells an attacker nothing.
             Self::CommitmentNameMismatch => "commitment-name-mismatch",
             Self::CommitmentSignatureInvalid => "commitment-signature-invalid",
             // The gate's own verdict name: this is the same predicate.
@@ -92,11 +99,9 @@ impl AuthorError {
     /// Whether this is a **trust** refusal on the record's own bytes — the
     /// produce-side mirror of an adoption-gate rejection — rather than a codec
     /// or size refusal of the body this pass happened to build, which a rebase
-    /// onto other state may not reproduce.
-    ///
-    /// The write plane charges a trust refusal against its attempt budget:
-    /// re-authoring the same inputs repeats it verbatim, so leaving it
-    /// unclassified spins the queue uncharged and forever (#1048).
+    /// onto other state may not reproduce. Re-authoring the same inputs repeats
+    /// a trust refusal verbatim, so a retry loop must charge it
+    /// (`sync/drain.rs::classify_author`).
     pub fn is_trust_refusal(&self) -> bool {
         match self {
             Self::GrantSectionOnChild
@@ -111,23 +116,11 @@ impl AuthorError {
 
 impl core::fmt::Display for AuthorError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::GrantSectionOnChild => f.write_str("child envelope carries a grantSection"),
-            Self::MissingGrantSection => f.write_str("scope root carries no grantSection"),
-            Self::CommitmentNameMismatch => {
-                f.write_str("carried commitment names another ipnsName")
-            }
-            Self::CommitmentSignatureInvalid => {
-                f.write_str("carried commitment is not signed by the anchored owner identity")
-            }
-            Self::SectionSignatureInvalid => {
-                f.write_str("carried grant section does not authenticate at this envelope's epoch")
-            }
-            Self::Seal(e) => write!(f, "seal failed: {}", e.check()),
-            Self::HeadTooLarge { size, limit } => {
-                write!(f, "head block exceeds the content cap ({size} > {limit})")
-            }
+        write!(f, "record authoring refused [{}]", self.check())?;
+        if let Self::HeadTooLarge { size, limit } = self {
+            write!(f, ": {size} > {limit}")?;
         }
+        Ok(())
     }
 }
 
@@ -405,15 +398,19 @@ mod tests {
             .collect()
     }
 
-    fn owner_signer() -> EcdsaSigner {
-        EcdsaSigner::from_scalar(&[0x11; 32]).expect("valid scalar")
+    /// The identity this suite's roots are anchored to.
+    fn owner() -> EcdsaVerifier {
+        EcdsaSigner::from_scalar(&[0x11; 32])
+            .expect("valid scalar")
+            .verifying_key()
     }
 
-    /// A real scope root's grant section and the name its commitment binds,
-    /// signed by [`owner_signer`].
-    fn owner_root() -> OwnerRootFixture {
+    /// A real scope root's grant section and the name its commitment binds.
+    /// Only the signer varies between fixtures: the name comes off the fixed
+    /// write seed, so a section signed by anyone else still binds this name.
+    fn root_signed_by(scalar: &[u8; 32]) -> OwnerRootFixture {
         owner_root_fixture(OwnerRootSpec {
-            owner_identity: &owner_signer(),
+            owner_identity: &EcdsaSigner::from_scalar(scalar).expect("valid scalar"),
             owner_enc: &kdf::enc_subkey(&[0x33; 32]).public(),
             scope_id: [2u8; 16],
             root_id: [1u8; 16],
@@ -422,6 +419,10 @@ mod tests {
             parent_node_seed: None,
             owner_write_blob_epoch: None,
         })
+    }
+
+    fn owner_root() -> OwnerRootFixture {
+        root_signed_by(&[0x11; 32])
     }
 
     fn carried_section(section: &GrantSection) -> PreservedFields {
@@ -449,7 +450,7 @@ mod tests {
         let head = author_scope_root_envelope(
             authoring(&folder(), carried_section(&fixture.grant_section)),
             &fixture.name,
-            &owner_signer().verifying_key(),
+            &owner(),
         )
         .unwrap();
         assert!(has_grant_section(&head.envelope));
@@ -465,7 +466,7 @@ mod tests {
             author_scope_root_envelope(
                 authoring(&folder(), carried_section(&fixture.grant_section)),
                 &name(),
-                &owner_signer().verifying_key(),
+                &owner(),
             )
             .unwrap_err(),
             AuthorError::CommitmentNameMismatch,
@@ -487,7 +488,7 @@ mod tests {
                     OWNER_ROOT_EPOCH + 1
                 ),
                 &fixture.name,
-                &owner_signer().verifying_key(),
+                &owner(),
             )
             .unwrap_err(),
             AuthorError::SectionSignatureInvalid,
@@ -504,7 +505,7 @@ mod tests {
                 authoring_at(&folder(), PreservedFields::new(), OWNER_ROOT_EPOCH + 1),
                 &fixture.name,
                 &fixture.grant_section,
-                &owner_signer().verifying_key(),
+                &owner(),
             )
             .unwrap_err(),
             AuthorError::SectionSignatureInvalid,
@@ -522,7 +523,7 @@ mod tests {
             author_scope_root_envelope(
                 authoring(&folder(), carried_section(&section)),
                 &fixture.name,
-                &owner_signer().verifying_key(),
+                &owner(),
             )
             .unwrap_err(),
             AuthorError::SectionSignatureInvalid,
@@ -536,22 +537,12 @@ mod tests {
         // without stage 2's signature half a wholly attacker-authored section —
         // own commitment, own pseudonym, own signatures, correct ipnsName —
         // authors cleanly and is only caught by a reader.
-        let attacker = EcdsaSigner::from_scalar(&[0x44; 32]).expect("valid scalar");
-        let fixture = owner_root_fixture(OwnerRootSpec {
-            owner_identity: &attacker,
-            owner_enc: &kdf::enc_subkey(&[0x33; 32]).public(),
-            scope_id: [2u8; 16],
-            root_id: [1u8; 16],
-            children: Vec::new(),
-            child_scope_index: Vec::new(),
-            parent_node_seed: None,
-            owner_write_blob_epoch: None,
-        });
+        let fixture = root_signed_by(&[0x44; 32]);
         assert_eq!(
             author_scope_root_envelope(
                 authoring(&folder(), carried_section(&fixture.grant_section)),
                 &fixture.name,
-                &owner_signer().verifying_key(),
+                &owner(),
             )
             .unwrap_err(),
             AuthorError::CommitmentSignatureInvalid,
@@ -569,7 +560,7 @@ mod tests {
             author_scope_root_envelope(
                 authoring(&folder(), carried_section(&section)),
                 &fixture.name,
-                &owner_signer().verifying_key(),
+                &owner(),
             )
             .unwrap_err(),
             AuthorError::CommitmentSignatureInvalid,
@@ -580,23 +571,13 @@ mod tests {
     fn a_freshly_assembled_section_another_identity_signed_is_refused() {
         // The re-seal path installs its own section and gets the same stage-2
         // refusal, so neither scope-root authoring path can drift from the gate.
-        let attacker = EcdsaSigner::from_scalar(&[0x44; 32]).expect("valid scalar");
-        let fixture = owner_root_fixture(OwnerRootSpec {
-            owner_identity: &attacker,
-            owner_enc: &kdf::enc_subkey(&[0x33; 32]).public(),
-            scope_id: [2u8; 16],
-            root_id: [1u8; 16],
-            children: Vec::new(),
-            child_scope_index: Vec::new(),
-            parent_node_seed: None,
-            owner_write_blob_epoch: None,
-        });
+        let fixture = root_signed_by(&[0x44; 32]);
         assert_eq!(
             author_scope_root_with_section(
                 authoring(&folder(), PreservedFields::new()),
                 &fixture.name,
                 &fixture.grant_section,
-                &owner_signer().verifying_key(),
+                &owner(),
             )
             .unwrap_err(),
             AuthorError::CommitmentSignatureInvalid,
@@ -609,18 +590,19 @@ mod tests {
     #[test]
     fn every_authoring_refusal_has_its_own_stable_check_name() {
         let refusals = [
-            AuthorError::GrantSectionOnChild,
-            AuthorError::MissingGrantSection,
-            AuthorError::CommitmentNameMismatch,
-            AuthorError::CommitmentSignatureInvalid,
-            AuthorError::SectionSignatureInvalid,
-            AuthorError::HeadTooLarge { size: 1, limit: 0 },
+            (AuthorError::GrantSectionOnChild, true),
+            (AuthorError::MissingGrantSection, true),
+            (AuthorError::CommitmentNameMismatch, true),
+            (AuthorError::CommitmentSignatureInvalid, true),
+            (AuthorError::SectionSignatureInvalid, true),
+            (AuthorError::HeadTooLarge { size: 1, limit: 0 }, false),
         ];
-        let names: std::collections::BTreeSet<&str> =
-            refusals.iter().map(AuthorError::check).collect();
-        assert_eq!(names.len(), refusals.len());
-        assert!(refusals[..5].iter().all(AuthorError::is_trust_refusal));
-        assert!(!AuthorError::HeadTooLarge { size: 1, limit: 0 }.is_trust_refusal());
+        let mut names = std::collections::BTreeSet::new();
+        for (error, trust) in &refusals {
+            assert_eq!(error.is_trust_refusal(), *trust, "{error}");
+            assert!(names.insert(error.check()), "{error} reuses a check name");
+            assert!(format!("{error}").contains(error.check()), "{error:?}");
+        }
     }
 
     #[test]
@@ -631,7 +613,7 @@ mod tests {
             author_scope_root_envelope(
                 authoring(&folder(), PreservedFields::new()),
                 &name(),
-                &owner_signer().verifying_key(),
+                &owner(),
             )
             .unwrap_err(),
             AuthorError::MissingGrantSection,

--- a/crates/engine/src/net/author.rs
+++ b/crates/engine/src/net/author.rs
@@ -44,9 +44,13 @@ pub enum AuthorError {
     /// child adoption always rejects (`net/child.rs`). Refusing here keeps the
     /// produce side and the decode side on the same predicate.
     GrantSectionOnChild,
-    /// A scope root carried no decodable `grantSection` — the marker every root
-    /// adoption requires (`net/adopter.rs` step 5).
+    /// A scope root carried no `grantSection` — the marker every root adoption
+    /// requires (`net/adopter.rs` step 5).
     MissingGrantSection,
+    /// A scope root's carried `grantSection` did not decode. The same bytes are
+    /// a whole-record reject on arrival (`net/adopter.rs` step 5), so they are a
+    /// trust refusal here rather than a codec failure of this pass's own body.
+    InvalidGrantSection,
     /// The carried grant-set commitment names a different `ipnsName` than the
     /// record is published under, which the gate's stage 2 rejects.
     CommitmentNameMismatch,
@@ -84,6 +88,7 @@ impl AuthorError {
         match self {
             Self::GrantSectionOnChild => "grant-section-on-child",
             Self::MissingGrantSection => "missing-grant-section",
+            Self::InvalidGrantSection => "invalid-grant-section",
             // Stage 2's single `commitment-invalid` verdict, split by cause: the
             // producer knows which half of its own bytes is wrong, where a
             // reader deliberately tells an attacker nothing.
@@ -106,6 +111,7 @@ impl AuthorError {
         match self {
             Self::GrantSectionOnChild
             | Self::MissingGrantSection
+            | Self::InvalidGrantSection
             | Self::CommitmentNameMismatch
             | Self::CommitmentSignatureInvalid
             | Self::SectionSignatureInvalid => true,
@@ -223,7 +229,7 @@ fn check_scope_root(
     let section = decode_grant_section(
         grant_section_bytes(envelope).ok_or(AuthorError::MissingGrantSection)?,
     )
-    .map_err(AuthorError::Seal)?;
+    .map_err(|_| AuthorError::InvalidGrantSection)?;
     let commitment_sig = EcdsaSignature::from_compact(&section.commitment_sig)
         .ok_or(AuthorError::CommitmentSignatureInvalid)?;
     verify_grant_set(owner_identity, &section.commitment, &commitment_sig)
@@ -592,6 +598,7 @@ mod tests {
         let refusals = [
             (AuthorError::GrantSectionOnChild, true),
             (AuthorError::MissingGrantSection, true),
+            (AuthorError::InvalidGrantSection, true),
             (AuthorError::CommitmentNameMismatch, true),
             (AuthorError::CommitmentSignatureInvalid, true),
             (AuthorError::SectionSignatureInvalid, true),
@@ -603,6 +610,20 @@ mod tests {
             assert!(names.insert(error.check()), "{error} reuses a check name");
             assert!(format!("{error}").contains(error.check()), "{error:?}");
         }
+    }
+
+    #[test]
+    fn a_scope_root_envelope_whose_grant_section_does_not_decode_is_refused() {
+        // Release-active (security rule 8).
+        assert_eq!(
+            author_scope_root_envelope(
+                authoring(&folder(), grant_section_field()),
+                &name(),
+                &owner(),
+            )
+            .unwrap_err(),
+            AuthorError::InvalidGrantSection,
+        );
     }
 
     #[test]

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -425,6 +425,7 @@ where
             },
             &name,
             &record.section,
+            self.keys.identity,
         )
         .map_err(|_| ScopeRootPublishError::NotPublished)?;
 

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -204,10 +204,11 @@ enum Halt {
     /// against the attempt budget, because a retry re-signs at the same
     /// sequence and a jammed name would otherwise retry forever.
     Attempt,
-    /// A refusal this pass cannot attribute, raised strictly **before** the
-    /// record PUT: an upload, a registration, or a produce-side trust refusal.
-    /// Charged like [`Halt::Attempt`], but exhausting the budget may retire what
-    /// the op uploaded, which an acked PUT's may not.
+    /// A refusal this pass cannot attribute, raised before the record it was
+    /// authoring reached the transport: an upload, a registration, or a
+    /// produce-side trust refusal. Charged like [`Halt::Attempt`], but
+    /// exhausting the budget may retire what the op uploaded — the op's target
+    /// is still unreachable, so no record a parent links names it.
     UploadAttempt,
     /// Classified-permanent: the same bytes are refused on every retry.
     Permanent(DeadLetterReason),
@@ -1290,7 +1291,16 @@ where
     ) -> Result<(), Halt> {
         let state = if folder == scope.root {
             self.refresh_scope_root_cache(scope).await?;
-            self.load_scope_root(scope).await?.0
+            let (state, epoch) = self.load_scope_root(scope).await?;
+            // A rotation landing mid-pass moves the root's epoch while this pass
+            // still seals at the one it opened on, and its grant section signs
+            // the new one — bytes this build's own authoring refuses. The next
+            // pass opens on one consistent epoch, so this stops rather than
+            // spending the op's budget on a skew that heals itself.
+            if epoch != pass.epoch {
+                return Err(Halt::Unclassified);
+            }
+            state
         } else {
             self.load_child_folder(scope, pass.epoch, folder).await?
         };
@@ -1705,16 +1715,11 @@ where
         .map_err(classify_author)?;
 
         let record_bytes = self
-            .publish_head(
-                scope,
-                name,
-                &node.0,
-                epoch,
-                &head,
-                content_cids.clone(),
-                completes,
-            )
+            .publish_head(scope, name, &node.0, epoch, &head, content_cids.clone())
             .await?;
+        if let Some(op_id) = completes {
+            self.mark_published(scope, op_id).await;
+        }
         let local = local_head(&head);
         let sequence = if is_scope_root {
             let adopter = RootAdopter::new(
@@ -1767,8 +1772,9 @@ where
         })
     }
 
-    /// Dry-run, publish, and return the signed bytes.
-    #[expect(clippy::too_many_arguments, reason = "one record's full publish")]
+    /// Dry-run, publish, and return the signed bytes. `Ok` means the record
+    /// confirmed at its name: an unconfirmed or race-losing publish is `Err`,
+    /// because its bytes may never have landed.
     async fn publish_head(
         &self,
         scope: &DrainScope<'_>,
@@ -1777,7 +1783,6 @@ where
         epoch: u64,
         head: &AuthoredHead,
         content_cids: Vec<String>,
-        completes: Option<OpId>,
     ) -> Result<Vec<u8>, Halt> {
         let binding = HeadBinding {
             node_id: *node_id,
@@ -1819,16 +1824,9 @@ where
             classify_publish(error, head.block.len() as u64)
         })?;
         match outcome {
-            PublishOutcome::Published { .. } => {
-                if let Some(op_id) = completes {
-                    self.mark_published(scope, op_id).await;
-                }
-                Ok(record_bytes)
-            }
+            PublishOutcome::Published { .. } => Ok(record_bytes),
             // Both burned a CAS sequence at this name without a record we could
-            // adopt, so both are charged against the attempt budget. Neither
-            // raises the mark: the bytes may never have landed, and dropping the
-            // op on the strength of that would be loss.
+            // adopt, so both are charged against the attempt budget.
             PublishOutcome::Unconfirmed { .. } | PublishOutcome::LostRace { .. } => {
                 Err(Halt::Attempt)
             }
@@ -1942,8 +1940,8 @@ where
     /// leave a reference outliving its referent, and the gate-passing base is
     /// the evidence — a created node reaches it only once a parent record naming
     /// it published. The content CIDs go with **any** content-bearing op that
-    /// reaches here: an abandonment only retires when no PUT for the op was
-    /// acked, so no record can link the version.
+    /// reaches here: an abandonment only retires while the op's target is
+    /// unreachable, so no record a parent links can name the version.
     ///
     /// Reads the manifest before [`Self::release_staged_blocks`] drops it: after
     /// that the leaf CIDs are recoverable from nowhere (#916).
@@ -2092,16 +2090,13 @@ fn seam(_: crate::seams::SeamError) -> Halt {
     Halt::Unclassified
 }
 
-/// Classify an authoring refusal for the valve. A produce-side trust refusal is
-/// the gate's own verdict reached before the PUT, and re-authoring the same
-/// inputs reaches it again, so it is charged against the attempt budget rather
-/// than retried free forever (#1048).
+/// Classify an authoring refusal for the valve, off
+/// [`AuthorError::is_trust_refusal`].
 ///
-/// Charged, not dead-lettered on sight: on the drain path these inputs are the
-/// cached scope root, which a later resolve replaces, so an immediate permanent
-/// verdict would abandon a user's ops over a cache another tick repairs. The
-/// budget bounds the spin either way. A codec or size refusal stays
-/// availability — it describes the body this pass built, not a trust verdict.
+/// Charged, not dead-lettered on sight: the scope root a trust refusal is
+/// authored from comes from the snapshot cache, which a later resolve replaces,
+/// so an immediate permanent verdict would abandon a user's ops over a cache
+/// another tick repairs. The budget bounds the spin either way.
 fn classify_author(error: AuthorError) -> Halt {
     if error.is_trust_refusal() {
         Halt::UploadAttempt
@@ -2471,37 +2466,28 @@ mod tests {
         }
     }
 
-    /// A produce-side trust refusal is the gate's own verdict reached before the
-    /// PUT: re-authoring the same inputs reaches it again, so it is charged and
-    /// the queue stops at the budget instead of spinning free.
+    /// A trust refusal is charged so the queue stops at the budget instead of
+    /// spinning free; a refusal of the body *this pass* built is not, or the
+    /// reclassification would turn a rebasable failure into a permanent halt.
     #[test]
-    fn a_produce_side_trust_refusal_is_charged_against_the_attempt_budget() {
-        for error in [
-            AuthorError::GrantSectionOnChild,
-            AuthorError::MissingGrantSection,
-            AuthorError::CommitmentNameMismatch,
-            AuthorError::CommitmentSignatureInvalid,
-            AuthorError::SectionSignatureInvalid,
+    fn only_a_produce_side_trust_refusal_is_charged_against_the_attempt_budget() {
+        for (error, expected) in [
+            (AuthorError::GrantSectionOnChild, Halt::UploadAttempt),
+            (AuthorError::MissingGrantSection, Halt::UploadAttempt),
+            (AuthorError::CommitmentNameMismatch, Halt::UploadAttempt),
+            (AuthorError::CommitmentSignatureInvalid, Halt::UploadAttempt),
+            (AuthorError::SectionSignatureInvalid, Halt::UploadAttempt),
+            (
+                AuthorError::Seal(cipherbox_core::error::TrustViolation::DuplicateId.into()),
+                Halt::Unclassified,
+            ),
+            (
+                AuthorError::HeadTooLarge { size: 2, limit: 1 },
+                Halt::Unclassified,
+            ),
         ] {
-            assert_eq!(
-                classify_author(error.clone()),
-                Halt::UploadAttempt,
-                "{} must be charged",
-                error.check()
-            );
-        }
-    }
-
-    /// The mirror-image bug the reclassification must not introduce: a refusal
-    /// of the body *this pass* built is not a trust verdict, and a rebase onto
-    /// other state may not build it again — so it stays free to retry.
-    #[test]
-    fn a_codec_or_size_refusal_of_this_passs_body_stays_availability() {
-        for error in [
-            AuthorError::Seal(cipherbox_core::error::TrustViolation::DuplicateId.into()),
-            AuthorError::HeadTooLarge { size: 2, limit: 1 },
-        ] {
-            assert_eq!(classify_author(error), Halt::Unclassified);
+            let check = error.check();
+            assert_eq!(classify_author(error), expected, "{check}");
         }
     }
 }

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -224,6 +224,40 @@ enum Halt {
     Cancelled,
 }
 
+/// A failed publish, and whether its record nonetheless confirmed at its name.
+/// The two are independent: the self-adopt and the snapshot-cache write both
+/// run with the record already live, so a caller that compensates must branch on
+/// the fact rather than re-read a name its own publish left stale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PublishHalt {
+    halt: Halt,
+    confirmed: bool,
+}
+
+impl PublishHalt {
+    /// A failure raised before the record reached the transport.
+    fn before_the_put(halt: Halt) -> Self {
+        Self {
+            halt,
+            confirmed: false,
+        }
+    }
+
+    /// A failure raised once the publish confirmed at its name.
+    fn past_the_put(halt: Halt) -> Self {
+        Self {
+            halt,
+            confirmed: true,
+        }
+    }
+}
+
+impl From<PublishHalt> for Halt {
+    fn from(failure: PublishHalt) -> Self {
+        failure.halt
+    }
+}
+
 /// The one verdict every unrecoverable-content path returns: the version's key,
 /// root, or a leaf is gone, and no retry brings any of them back.
 const CONTENT_LOST: Halt = Halt::Permanent(DeadLetterReason::ContentUnrecoverable);
@@ -1029,7 +1063,8 @@ where
                 // here would drop an op on restart whose child no parent names.
                 None,
             )
-            .await?;
+            .await
+            .map_err(Halt::from)?;
 
         // Referent published: only now does the parent gain the ref to it.
         pass.folder_mut(parent)?.children.push(child.child_ref);
@@ -1040,7 +1075,8 @@ where
             applied.op.authored_at.0,
             Some(applied.op_id),
         )
-        .await?;
+        .await
+        .map_err(Halt::from)?;
         self.release_staged_blocks(&applied.op).await;
         // Held only once the parent names it: a record nothing references is
         // not one the liveness loop should keep alive.
@@ -1067,8 +1103,15 @@ where
         if children.len() == before {
             return Ok(());
         }
-        self.publish_folder(scope, pass, parent, applied.op.authored_at.0, None)
-            .await?;
+        self.publish_folder(
+            scope,
+            pass,
+            parent,
+            applied.op.authored_at.0,
+            Some(applied.op_id),
+        )
+        .await
+        .map_err(Halt::from)?;
         Ok(())
     }
 
@@ -1154,10 +1197,20 @@ where
             Some(existing) => *existing = moved,
             None => dest_children.push(moved),
         }
+        // Only when one folder collapses the plan is the dest-add also its last
+        // record; otherwise the source-remove below is.
+        let single_record = source == dest;
         let cas_base = self
-            .publish_folder(scope, pass, dest, modified_at, None)
-            .await?;
-        if source == dest {
+            .publish_folder(
+                scope,
+                pass,
+                dest,
+                modified_at,
+                single_record.then_some(applied.op_id),
+            )
+            .await
+            .map_err(Halt::from)?;
+        if single_record {
             return Ok(());
         }
 
@@ -1169,24 +1222,31 @@ where
         // forever, so a quota refusal, a permanent one, or a spent attempt must
         // not be flattened into it. Only the undo's own failure is genuinely
         // unclassified.
-        if let Err(halt) = self
-            .publish_folder(scope, pass, source, modified_at, None)
+        if let Err(failure) = self
+            .publish_folder(scope, pass, source, modified_at, Some(applied.op_id))
             .await
         {
-            self.compensate_dest_add(
-                scope,
-                pass,
-                DestAdd {
-                    dest,
-                    source,
-                    target,
-                    replaced,
-                    cas_base,
-                    modified_at,
-                },
-            )
-            .await?;
-            return Err(halt);
+            // A confirmed source-remove is the move complete on the network, so
+            // undoing the dest-add would strip the child from the only parent
+            // that still names it. The compensation decides that by re-reading
+            // the source, which this very publish left stale in the cache; the
+            // publish itself already knows.
+            if !failure.confirmed {
+                self.compensate_dest_add(
+                    scope,
+                    pass,
+                    DestAdd {
+                        dest,
+                        source,
+                        target,
+                        replaced,
+                        cas_base,
+                        modified_at,
+                    },
+                )
+                .await?;
+            }
+            return Err(failure.halt);
         }
         Ok(())
     }
@@ -1262,7 +1322,8 @@ where
         };
         pass.folder_mut(dest)?.children = children;
         self.publish_folder(scope, pass, dest, modified_at, None)
-            .await?;
+            .await
+            .map_err(Halt::from)?;
         Ok(())
     }
 
@@ -1376,7 +1437,8 @@ where
                 loaded.epoch_tag_unknown,
                 Some(applied.op_id),
             )
-            .await?;
+            .await
+            .map_err(Halt::from)?;
         self.release_staged_blocks(&applied.op).await;
         if let Some(node) = self.base.borrow_mut().node_mut(target) {
             node.record_sequence = published.sequence;
@@ -1634,9 +1696,9 @@ where
         folder: NodeId,
         modified_at: u64,
         completes: Option<OpId>,
-    ) -> Result<u64, Halt> {
+    ) -> Result<u64, PublishHalt> {
         let (name, is_scope_root, body, envelope_unknown, epoch_tag_unknown) = {
-            let state = pass.folder(folder)?;
+            let state = pass.folder(folder).map_err(PublishHalt::before_the_put)?;
             (
                 state.name.clone(),
                 state.is_scope_root,
@@ -1665,7 +1727,7 @@ where
             )
             .await?;
 
-        let state = pass.folder_mut(folder)?;
+        let state = pass.folder_mut(folder).map_err(PublishHalt::past_the_put)?;
         state.sequence = published.sequence;
         state.modified_at = modified_at;
         let children = state.children.clone();
@@ -1694,9 +1756,9 @@ where
         carried_unknown: PreservedFields,
         carried_epoch_tag_unknown: PreservedFields,
         completes: Option<OpId>,
-    ) -> Result<Published, Halt> {
+    ) -> Result<Published, PublishHalt> {
         let read_key = self.node_read_key(scope, &node.0);
-        let nonce = self.nonce()?;
+        let nonce = self.nonce().map_err(PublishHalt::before_the_put)?;
         let authoring = EnvelopeAuthoring {
             node_id: node.0,
             scope_id: scope.root.0,
@@ -1712,14 +1774,16 @@ where
         } else {
             author_child_envelope(authoring)
         }
-        .map_err(classify_author)?;
+        .map_err(|error| PublishHalt::before_the_put(classify_author(error)))?;
 
         let record_bytes = self
             .publish_head(scope, name, &node.0, epoch, &head, content_cids.clone())
-            .await?;
+            .await
+            .map_err(PublishHalt::before_the_put)?;
         if let Some(op_id) = completes {
             self.mark_published(scope, op_id).await;
         }
+        // The record is live from here: everything below is a local step.
         let local = local_head(&head);
         let sequence = if is_scope_root {
             let adopter = RootAdopter::new(
@@ -1734,7 +1798,7 @@ where
             adopter
                 .adopt(name, &record_bytes)
                 .await
-                .map_err(|_| Halt::Unclassified)?
+                .map_err(|_| PublishHalt::past_the_put(Halt::Unclassified))?
         } else {
             let adopter = ChildAdopter::new(
                 self.gateway,
@@ -1748,7 +1812,7 @@ where
             adopter
                 .adopt(name, &record_bytes)
                 .await
-                .map_err(|_| Halt::Unclassified)?
+                .map_err(|_| PublishHalt::past_the_put(Halt::Unclassified))?
         }
         .adopted
         .sequence;
@@ -1757,7 +1821,7 @@ where
         self.snapshot_cache
             .put(name.as_str().as_bytes(), &record_bytes)
             .await
-            .map_err(seam)?;
+            .map_err(|e| PublishHalt::past_the_put(seam(e)))?;
         Ok(Published {
             sequence,
             held: HeldRecord {
@@ -2445,6 +2509,30 @@ mod tests {
         }
     }
 
+    /// The compensation branches on this and nothing else: a failure carries
+    /// its classification and, separately, whether the record it was publishing
+    /// is live. Collapsing the two would undo a move that landed.
+    #[test]
+    fn a_publish_failure_keeps_its_verdict_and_its_confirmation_apart() {
+        for halt in [Halt::Unclassified, Halt::Attempt] {
+            assert_eq!(
+                PublishHalt::before_the_put(halt),
+                PublishHalt {
+                    halt,
+                    confirmed: false
+                }
+            );
+            assert_eq!(
+                PublishHalt::past_the_put(halt),
+                PublishHalt {
+                    halt,
+                    confirmed: true
+                }
+            );
+            assert_eq!(Halt::from(PublishHalt::past_the_put(halt)), halt);
+        }
+    }
+
     /// Every other publish failure is availability: retried indefinitely and
     /// charged nothing, so an unreachable network never abandons an op.
     #[test]
@@ -2474,6 +2562,7 @@ mod tests {
         for (error, expected) in [
             (AuthorError::GrantSectionOnChild, Halt::UploadAttempt),
             (AuthorError::MissingGrantSection, Halt::UploadAttempt),
+            (AuthorError::InvalidGrantSection, Halt::UploadAttempt),
             (AuthorError::CommitmentNameMismatch, Halt::UploadAttempt),
             (AuthorError::CommitmentSignatureInvalid, Halt::UploadAttempt),
             (AuthorError::SectionSignatureInvalid, Halt::UploadAttempt),

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -40,7 +40,7 @@ use crate::facade::{BlockProgress, Event, NodeId, OpPhase};
 use crate::gate::floor;
 use crate::grants::{UndoDestAdd, undo_dest_add_versioned};
 use crate::net::author::{
-    AuthoredHead, ENVELOPE_V, EnvelopeAuthoring, NewNodeBody, author_child_envelope,
+    AuthorError, AuthoredHead, ENVELOPE_V, EnvelopeAuthoring, NewNodeBody, author_child_envelope,
     author_scope_root_envelope, new_child,
 };
 use crate::net::publish::{PublishError, PublishOutcome, PublishReceipt};
@@ -78,8 +78,8 @@ use crate::sync::staging::{preserve_dead_letter, release_version_blocks, version
 pub const DRAINED_OP_MARK_PREFIX: &[u8] = b"cipherbox/drained-op/";
 
 /// The staging-key prefix for the published-op high-water mark: every op id at
-/// or below the stored value published and self-adopted its whole record set,
-/// so its version is live at its name even if the op is still queued. What it
+/// or below the stored value had the last record of its plan confirmed at its
+/// name, so its version is live there even if the op is still queued. What it
 /// is *for* is [`Drain::mark_published`].
 pub const PUBLISHED_OP_MARK_PREFIX: &[u8] = b"cipherbox/published-op/";
 
@@ -204,10 +204,10 @@ enum Halt {
     /// against the attempt budget, because a retry re-signs at the same
     /// sequence and a jammed name would otherwise retry forever.
     Attempt,
-    /// An upload or registration refusal this pass cannot attribute. Charged
-    /// like [`Halt::Attempt`], but raised strictly **before** the record PUT —
-    /// so exhausting the budget may retire what the op uploaded, which an acked
-    /// PUT's may not.
+    /// A refusal this pass cannot attribute, raised strictly **before** the
+    /// record PUT: an upload, a registration, or a produce-side trust refusal.
+    /// Charged like [`Halt::Attempt`], but exhausting the budget may retire what
+    /// the op uploaded, which an acked PUT's may not.
     UploadAttempt,
     /// Classified-permanent: the same bytes are refused on every retry.
     Permanent(DeadLetterReason),
@@ -1024,14 +1024,22 @@ where
                 content_cids,
                 PreservedFields::new(),
                 PreservedFields::new(),
+                // The parent's record below is this plan's last: a mark raised
+                // here would drop an op on restart whose child no parent names.
+                None,
             )
             .await?;
 
         // Referent published: only now does the parent gain the ref to it.
         pass.folder_mut(parent)?.children.push(child.child_ref);
-        self.publish_folder(scope, pass, parent, applied.op.authored_at.0)
-            .await?;
-        self.mark_published(scope, applied.op_id).await;
+        self.publish_folder(
+            scope,
+            pass,
+            parent,
+            applied.op.authored_at.0,
+            Some(applied.op_id),
+        )
+        .await?;
         self.release_staged_blocks(&applied.op).await;
         // Held only once the parent names it: a record nothing references is
         // not one the liveness loop should keep alive.
@@ -1058,7 +1066,7 @@ where
         if children.len() == before {
             return Ok(());
         }
-        self.publish_folder(scope, pass, parent, applied.op.authored_at.0)
+        self.publish_folder(scope, pass, parent, applied.op.authored_at.0, None)
             .await?;
         Ok(())
     }
@@ -1145,7 +1153,9 @@ where
             Some(existing) => *existing = moved,
             None => dest_children.push(moved),
         }
-        let cas_base = self.publish_folder(scope, pass, dest, modified_at).await?;
+        let cas_base = self
+            .publish_folder(scope, pass, dest, modified_at, None)
+            .await?;
         if source == dest {
             return Ok(());
         }
@@ -1158,7 +1168,10 @@ where
         // forever, so a quota refusal, a permanent one, or a spent attempt must
         // not be flattened into it. Only the undo's own failure is genuinely
         // unclassified.
-        if let Err(halt) = self.publish_folder(scope, pass, source, modified_at).await {
+        if let Err(halt) = self
+            .publish_folder(scope, pass, source, modified_at, None)
+            .await
+        {
             self.compensate_dest_add(
                 scope,
                 pass,
@@ -1247,7 +1260,8 @@ where
             }
         };
         pass.folder_mut(dest)?.children = children;
-        self.publish_folder(scope, pass, dest, modified_at).await?;
+        self.publish_folder(scope, pass, dest, modified_at, None)
+            .await?;
         Ok(())
     }
 
@@ -1350,11 +1364,9 @@ where
                 content_cids,
                 loaded.envelope_unknown,
                 loaded.epoch_tag_unknown,
+                Some(applied.op_id),
             )
             .await?;
-        // Durable before the release: the blocks stop being recoverable here,
-        // so this is the last point a crash can still leave a replayable op.
-        self.mark_published(scope, applied.op_id).await;
         self.release_staged_blocks(&applied.op).await;
         if let Some(node) = self.base.borrow_mut().node_mut(target) {
             node.record_sequence = published.sequence;
@@ -1611,6 +1623,7 @@ where
         pass: &mut Pass,
         folder: NodeId,
         modified_at: u64,
+        completes: Option<OpId>,
     ) -> Result<u64, Halt> {
         let (name, is_scope_root, body, envelope_unknown, epoch_tag_unknown) = {
             let state = pass.folder(folder)?;
@@ -1638,6 +1651,7 @@ where
                 Vec::new(),
                 envelope_unknown,
                 epoch_tag_unknown,
+                completes,
             )
             .await?;
 
@@ -1653,6 +1667,10 @@ where
     /// Author, publish and self-adopt one node's record. Only a confirmed
     /// publish reaches the gate: adopting an unconfirmed one would advance the
     /// sequence floor and destroy the idempotent-in-sequence retry (#821).
+    ///
+    /// `completes` names the op this record is the **last** publish of, if any;
+    /// see [`Drain::mark_published`] for why the ack rather than the adopt is
+    /// where that op stops being replayable.
     #[expect(clippy::too_many_arguments, reason = "one record's full authoring")]
     async fn publish_node(
         &self,
@@ -1665,6 +1683,7 @@ where
         content_cids: Vec<String>,
         carried_unknown: PreservedFields,
         carried_epoch_tag_unknown: PreservedFields,
+        completes: Option<OpId>,
     ) -> Result<Published, Halt> {
         let read_key = self.node_read_key(scope, &node.0);
         let nonce = self.nonce()?;
@@ -1679,14 +1698,22 @@ where
             carried_epoch_tag_unknown,
         };
         let head = if is_scope_root {
-            author_scope_root_envelope(authoring, name)
+            author_scope_root_envelope(authoring, name, scope.owner_identity)
         } else {
             author_child_envelope(authoring)
         }
-        .map_err(|_| Halt::Unclassified)?;
+        .map_err(classify_author)?;
 
         let record_bytes = self
-            .publish_head(scope, name, &node.0, epoch, &head, content_cids.clone())
+            .publish_head(
+                scope,
+                name,
+                &node.0,
+                epoch,
+                &head,
+                content_cids.clone(),
+                completes,
+            )
             .await?;
         let local = local_head(&head);
         let sequence = if is_scope_root {
@@ -1741,6 +1768,7 @@ where
     }
 
     /// Dry-run, publish, and return the signed bytes.
+    #[expect(clippy::too_many_arguments, reason = "one record's full publish")]
     async fn publish_head(
         &self,
         scope: &DrainScope<'_>,
@@ -1749,6 +1777,7 @@ where
         epoch: u64,
         head: &AuthoredHead,
         content_cids: Vec<String>,
+        completes: Option<OpId>,
     ) -> Result<Vec<u8>, Halt> {
         let binding = HeadBinding {
             node_id: *node_id,
@@ -1790,9 +1819,16 @@ where
             classify_publish(error, head.block.len() as u64)
         })?;
         match outcome {
-            PublishOutcome::Published { .. } => Ok(record_bytes),
+            PublishOutcome::Published { .. } => {
+                if let Some(op_id) = completes {
+                    self.mark_published(scope, op_id).await;
+                }
+                Ok(record_bytes)
+            }
             // Both burned a CAS sequence at this name without a record we could
-            // adopt, so both are charged against the attempt budget.
+            // adopt, so both are charged against the attempt budget. Neither
+            // raises the mark: the bytes may never have landed, and dropping the
+            // op on the strength of that would be loss.
             PublishOutcome::Unconfirmed { .. } | PublishOutcome::LostRace { .. } => {
                 Err(Halt::Attempt)
             }
@@ -1986,11 +2022,12 @@ where
     /// Raise this identity's published-op mark over `op_id`
     /// ([`PUBLISHED_OP_MARK_PREFIX`]).
     ///
-    /// Raised between the op's last record publish and the block release, which
-    /// is the window a crash leaves a published op queued. Without it that op
-    /// replays, re-uploads its leaves, and a cancel landing mid-replay unpins
-    /// content a live record names — the session-scoped publish-entry interlock
-    /// does not survive the reboot.
+    /// Raised the instant the op's **last** record publish confirms — before its
+    /// self-adopt, and so before the block release — because everything from the
+    /// ack onwards is a window a crash leaves a published op queued. Without it
+    /// that op replays, re-uploads its leaves, and a cancel landing mid-replay
+    /// unpins content a live record names; the session-scoped publish-entry
+    /// interlock does not survive the reboot.
     ///
     /// Best-effort, unlike every other step of the publish: the record is
     /// already live by the time this runs, so failing the op over the mark would
@@ -2053,6 +2090,24 @@ fn local_head(head: &AuthoredHead) -> LocalHead {
 
 fn seam(_: crate::seams::SeamError) -> Halt {
     Halt::Unclassified
+}
+
+/// Classify an authoring refusal for the valve. A produce-side trust refusal is
+/// the gate's own verdict reached before the PUT, and re-authoring the same
+/// inputs reaches it again, so it is charged against the attempt budget rather
+/// than retried free forever (#1048).
+///
+/// Charged, not dead-lettered on sight: on the drain path these inputs are the
+/// cached scope root, which a later resolve replaces, so an immediate permanent
+/// verdict would abandon a user's ops over a cache another tick repairs. The
+/// budget bounds the spin either way. A codec or size refusal stays
+/// availability — it describes the body this pass built, not a trust verdict.
+fn classify_author(error: AuthorError) -> Halt {
+    if error.is_trust_refusal() {
+        Halt::UploadAttempt
+    } else {
+        Halt::Unclassified
+    }
 }
 
 /// Hand control back to the host's executor once, so a facade command queued
@@ -2413,6 +2468,40 @@ mod tests {
             RecordPublishError::Publish(crate::net::PublishError::AllEndpointsFailed),
         ] {
             assert_eq!(classify_publish(error, 4096), Halt::Unclassified);
+        }
+    }
+
+    /// A produce-side trust refusal is the gate's own verdict reached before the
+    /// PUT: re-authoring the same inputs reaches it again, so it is charged and
+    /// the queue stops at the budget instead of spinning free.
+    #[test]
+    fn a_produce_side_trust_refusal_is_charged_against_the_attempt_budget() {
+        for error in [
+            AuthorError::GrantSectionOnChild,
+            AuthorError::MissingGrantSection,
+            AuthorError::CommitmentNameMismatch,
+            AuthorError::CommitmentSignatureInvalid,
+            AuthorError::SectionSignatureInvalid,
+        ] {
+            assert_eq!(
+                classify_author(error.clone()),
+                Halt::UploadAttempt,
+                "{} must be charged",
+                error.check()
+            );
+        }
+    }
+
+    /// The mirror-image bug the reclassification must not introduce: a refusal
+    /// of the body *this pass* built is not a trust verdict, and a rebase onto
+    /// other state may not build it again — so it stays free to retry.
+    #[test]
+    fn a_codec_or_size_refusal_of_this_passs_body_stays_availability() {
+        for error in [
+            AuthorError::Seal(cipherbox_core::error::TrustViolation::DuplicateId.into()),
+            AuthorError::HeadTooLarge { size: 2, limit: 1 },
+        ] {
+            assert_eq!(classify_author(error), Halt::Unclassified);
         }
     }
 }

--- a/crates/engine/src/testkit/fakes/floor_store.rs
+++ b/crates/engine/src/testkit/fakes/floor_store.rs
@@ -1,9 +1,9 @@
 //! In-memory [`FloorStore`] fake.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
-use crate::seams::{FloorNamespace, FloorRaise, FloorStore, SeamResult};
+use crate::seams::{FloorNamespace, FloorRaise, FloorStore, SeamError, SeamResult};
 
 #[derive(Default)]
 struct Inner {
@@ -15,6 +15,27 @@ struct Inner {
 #[derive(Clone, Default)]
 pub struct InMemoryFloorStore {
     inner: Arc<Mutex<Inner>>,
+    /// Floor keys whose commit is injected to fail. Empty by default, so a
+    /// store's behavior is unchanged until a test injects a fault.
+    failing_commits: Arc<Mutex<HashSet<Vec<u8>>>>,
+}
+
+impl InMemoryFloorStore {
+    /// Make [`commit_floors`](FloorStore::commit_floors) fail for any batch that
+    /// raises `key`, until [`heal_commits`](Self::heal_commits) clears it. The
+    /// commit is an adoption's durable last step, so this drives a self-adopt
+    /// that fails after its record is already live at its name.
+    pub fn fail_commits_for(&self, key: &[u8]) {
+        self.failing_commits
+            .lock()
+            .expect("lock")
+            .insert(key.to_vec());
+    }
+
+    /// Restore every injected commit fault.
+    pub fn heal_commits(&self) {
+        self.failing_commits.lock().expect("lock").clear();
+    }
 }
 
 fn raise(map: &mut HashMap<Vec<u8>, u64>, key: &[u8], value: u64) -> u64 {
@@ -64,6 +85,15 @@ impl FloorStore for InMemoryFloorStore {
     /// so no observer sees a partial commit (the atomic contract #685 asks of a
     /// transactional backing).
     async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<()> {
+        {
+            let failing = self.failing_commits.lock().expect("lock");
+            if let Some(r) = raises.iter().find(|r| failing.contains(&r.key)) {
+                return Err(SeamError::new(format!(
+                    "floor commit injected to fail for key {:?}",
+                    r.key
+                )));
+            }
+        }
         let mut inner = self.inner.lock().expect("lock");
         for r in raises {
             match r.namespace {

--- a/crates/engine/src/testkit/fakes/floor_store.rs
+++ b/crates/engine/src/testkit/fakes/floor_store.rs
@@ -9,32 +9,40 @@ use crate::seams::{FloorNamespace, FloorRaise, FloorStore, SeamError, SeamResult
 struct Inner {
     epoch: HashMap<Vec<u8>, u64>,
     sequence: HashMap<Vec<u8>, u64>,
+    /// Floor keys whose raise is injected to fail.
+    failing: HashSet<Vec<u8>>,
+}
+
+impl Inner {
+    fn refuse(&self, key: &[u8]) -> Option<SeamError> {
+        self.failing
+            .contains(key)
+            .then(|| SeamError::new(format!("floor raise injected to fail for key {key:?}")))
+    }
 }
 
 /// In-memory monotonic-max floor store. Clones share state ("reopen").
 #[derive(Clone, Default)]
 pub struct InMemoryFloorStore {
     inner: Arc<Mutex<Inner>>,
-    /// Floor keys whose commit is injected to fail. Empty by default, so a
-    /// store's behavior is unchanged until a test injects a fault.
-    failing_commits: Arc<Mutex<HashSet<Vec<u8>>>>,
 }
 
 impl InMemoryFloorStore {
-    /// Make [`commit_floors`](FloorStore::commit_floors) fail for any batch that
-    /// raises `key`, until [`heal_commits`](Self::heal_commits) clears it. The
-    /// commit is an adoption's durable last step, so this drives a self-adopt
-    /// that fails after its record is already live at its name.
-    pub fn fail_commits_for(&self, key: &[u8]) {
-        self.failing_commits
+    /// Make every floor raise naming `key` fail until
+    /// [`heal_floors`](Self::heal_floors) clears it. The raise is an adoption's
+    /// durable last step, so this drives a self-adopt that fails after its
+    /// record is already live at its name.
+    pub fn fail_floor_raises_for(&self, key: &[u8]) {
+        self.inner
             .lock()
             .expect("lock")
+            .failing
             .insert(key.to_vec());
     }
 
-    /// Restore every injected commit fault.
-    pub fn heal_commits(&self) {
-        self.failing_commits.lock().expect("lock").clear();
+    /// Restore every injected floor fault.
+    pub fn heal_floors(&self) {
+        self.inner.lock().expect("lock").failing.clear();
     }
 }
 
@@ -56,11 +64,11 @@ impl FloorStore for InMemoryFloorStore {
     }
 
     async fn raise_epoch_floor(&self, scope_id: &[u8], epoch: u64) -> SeamResult<u64> {
-        Ok(raise(
-            &mut self.inner.lock().expect("lock").epoch,
-            scope_id,
-            epoch,
-        ))
+        let mut inner = self.inner.lock().expect("lock");
+        match inner.refuse(scope_id) {
+            Some(error) => Err(error),
+            None => Ok(raise(&mut inner.epoch, scope_id, epoch)),
+        }
     }
 
     async fn sequence_floor(&self, ipns_name: &[u8]) -> SeamResult<Option<u64>> {
@@ -74,27 +82,21 @@ impl FloorStore for InMemoryFloorStore {
     }
 
     async fn raise_sequence_floor(&self, ipns_name: &[u8], sequence: u64) -> SeamResult<u64> {
-        Ok(raise(
-            &mut self.inner.lock().expect("lock").sequence,
-            ipns_name,
-            sequence,
-        ))
+        let mut inner = self.inner.lock().expect("lock");
+        match inner.refuse(ipns_name) {
+            Some(error) => Err(error),
+            None => Ok(raise(&mut inner.sequence, ipns_name, sequence)),
+        }
     }
 
     /// Genuinely all-or-nothing: the whole batch applies under one lock guard,
     /// so no observer sees a partial commit (the atomic contract #685 asks of a
     /// transactional backing).
     async fn commit_floors(&self, raises: &[FloorRaise]) -> SeamResult<()> {
-        {
-            let failing = self.failing_commits.lock().expect("lock");
-            if let Some(r) = raises.iter().find(|r| failing.contains(&r.key)) {
-                return Err(SeamError::new(format!(
-                    "floor commit injected to fail for key {:?}",
-                    r.key
-                )));
-            }
-        }
         let mut inner = self.inner.lock().expect("lock");
+        if let Some(error) = raises.iter().find_map(|r| inner.refuse(&r.key)) {
+            return Err(error);
+        }
         for r in raises {
             match r.namespace {
                 FloorNamespace::Epoch => raise(&mut inner.epoch, &r.key, r.value),

--- a/crates/engine/src/testkit/fakes/record_store.rs
+++ b/crates/engine/src/testkit/fakes/record_store.rs
@@ -106,12 +106,20 @@ impl InMemoryRecordStore {
     }
 
     /// Refuse every PUT under `routing_key` while the rest of the name space
-    /// publishes normally.
+    /// publishes normally, until [`heal_put_for`](Self::heal_put_for) clears it.
     pub fn fail_put_for(&self, routing_key: &str) {
         self.put_failing_keys
             .lock()
             .expect("lock")
             .insert(routing_key.to_owned());
+    }
+
+    /// Restore `routing_key`'s PUT path.
+    pub fn heal_put_for(&self, routing_key: &str) {
+        self.put_failing_keys
+            .lock()
+            .expect("lock")
+            .remove(routing_key);
     }
 
     /// Whether `endpoint`'s GET path is currently injected to fail.

--- a/crates/engine/src/testkit/fakes/record_store.rs
+++ b/crates/engine/src/testkit/fakes/record_store.rs
@@ -34,6 +34,9 @@ pub struct InMemoryRecordStore {
     /// ignores our stale write while still serving the winner. Lets the harness
     /// drive a lost CAS race.
     put_failing: Arc<Mutex<HashSet<EndpointId>>>,
+    /// Routing keys whose PUT is refused at every endpoint, so one record of a
+    /// multi-record plan can fail while the rest of the plan publishes.
+    put_failing_keys: Arc<Mutex<HashSet<String>>>,
 }
 
 impl InMemoryRecordStore {
@@ -54,6 +57,7 @@ impl InMemoryRecordStore {
             inner: Arc::new(Mutex::new(inner)),
             failing: Arc::new(Mutex::new(HashSet::new())),
             put_failing: Arc::new(Mutex::new(HashSet::new())),
+            put_failing_keys: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -101,6 +105,15 @@ impl InMemoryRecordStore {
         self.put_failing.lock().expect("lock").remove(endpoint);
     }
 
+    /// Refuse every PUT under `routing_key` while the rest of the name space
+    /// publishes normally.
+    pub fn fail_put_for(&self, routing_key: &str) {
+        self.put_failing_keys
+            .lock()
+            .expect("lock")
+            .insert(routing_key.to_owned());
+    }
+
     /// Whether `endpoint`'s GET path is currently injected to fail.
     fn get_failing(&self, endpoint: &EndpointId) -> bool {
         self.failing.lock().expect("lock").contains(endpoint)
@@ -110,6 +123,14 @@ impl InMemoryRecordStore {
     /// fails PUT too).
     fn put_failing(&self, endpoint: &EndpointId) -> bool {
         self.get_failing(endpoint) || self.put_failing.lock().expect("lock").contains(endpoint)
+    }
+
+    /// Whether `routing_key`'s PUT is currently injected to fail everywhere.
+    fn put_failing_key(&self, routing_key: &str) -> bool {
+        self.put_failing_keys
+            .lock()
+            .expect("lock")
+            .contains(routing_key)
     }
 }
 
@@ -157,6 +178,9 @@ impl RecordTransport for InMemoryRecordStore {
                 "endpoint unreachable: {}",
                 endpoint.0
             )));
+        }
+        if self.put_failing_key(routing_key) {
+            return Err(SeamError::new(format!("put refused for {routing_key}")));
         }
         self.inner
             .lock()

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -4360,6 +4360,41 @@ fn every_content_publish_raises_the_published_op_mark() {
     );
 }
 
+/// What the mark buys: the op leaves the queue without re-uploading a byte, its
+/// staged blocks are released, and nothing a live record names is unpinned.
+fn assert_dropped_without_replay(
+    device: &FakeDevice,
+    events: &mut EventStream,
+    version: (Vec<u8>, Vec<Vec<u8>>),
+) {
+    assert!(
+        !events_so_far(events).iter().any(|event| matches!(
+            event,
+            Event::OpProgress {
+                phase: OpPhase::UploadStarted,
+                ..
+            }
+        )),
+        "nothing re-uploads behind a record that already landed"
+    );
+    assert!(
+        block_on(StagingStore::queued_ops(&device.staging_store))
+            .unwrap()
+            .is_empty(),
+        "the op leaves the queue"
+    );
+    let leftover = version
+        .1
+        .into_iter()
+        .chain(core::iter::once(version.0))
+        .collect::<Vec<_>>();
+    assert_no_blocks_staged(device, &leftover);
+    assert!(
+        retire_targets(device).is_empty(),
+        "a drop is not an abandonment: nothing published is unpinned"
+    );
+}
+
 /// The durable published-op high-water this device stored.
 fn published_op_mark(device: &FakeDevice) -> Option<u64> {
     let stored = block_on(device.staging_store.staged_bytes(&mark_key())).unwrap()?;
@@ -4391,32 +4426,7 @@ fn an_op_whose_record_already_published_is_dropped_rather_than_replayed() {
     plant_published_mark(&alice, op_id);
     tick(&world, &engine, &mut tasks);
 
-    assert!(
-        !events_so_far(&mut events).iter().any(|event| matches!(
-            event,
-            Event::OpProgress {
-                phase: OpPhase::UploadStarted,
-                ..
-            }
-        )),
-        "nothing re-uploads behind a record that already landed"
-    );
-    assert!(
-        block_on(StagingStore::queued_ops(&alice.staging_store))
-            .unwrap()
-            .is_empty(),
-        "the op leaves the queue"
-    );
-    let leftover = version
-        .1
-        .into_iter()
-        .chain(core::iter::once(version.0))
-        .collect::<Vec<_>>();
-    assert_no_blocks_staged(&alice, &leftover);
-    assert!(
-        retire_targets(&alice).is_empty(),
-        "a drop is not an abandonment: nothing published is unpinned"
-    );
+    assert_dropped_without_replay(&alice, &mut events, version);
 }
 
 /// The mark's line is the **ack**, not the self-adopt. A record whose PUT
@@ -4436,7 +4446,7 @@ fn a_publish_whose_self_adopt_failed_still_marks_the_op_published() {
     // the step that fails after its record is already live.
     alice
         .floor_store
-        .fail_commits_for(root_name.as_str().as_bytes());
+        .fail_floor_raises_for(root_name.as_str().as_bytes());
     let op_id = write_file(
         &mut engine,
         WriteTarget::NewFile {
@@ -4463,35 +4473,51 @@ fn a_publish_whose_self_adopt_failed_still_marks_the_op_published() {
 
     // A restart clears the session interlock, leaving only the mark to stop the
     // replay.
-    alice.floor_store.heal_commits();
+    alice.floor_store.heal_floors();
     let _ = events_so_far(&mut events);
     let (restarted, mut events, mut tasks) = boot(&world, &blocks, &alice, 43);
     tick(&world, &restarted, &mut tasks);
-    assert!(
-        !events_so_far(&mut events).iter().any(|event| matches!(
-            event,
-            Event::OpProgress {
-                phase: OpPhase::UploadStarted,
-                ..
-            }
-        )),
-        "nothing re-uploads behind a record that already landed"
+    assert_dropped_without_replay(&alice, &mut events, version);
+}
+
+/// The other half of the rule: only the **last** record of a plan may raise the
+/// mark. A create whose child published and whose parent never did has to stay
+/// replayable — dropping it would strand a live child no parent names.
+#[test]
+fn a_create_whose_parent_publish_never_ran_leaves_the_mark_down() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<u8>>(),
+    )
+    .unwrap();
+    // The child's own self-adopt fails, so the plan stops before the parent
+    // record that would name it.
+    let child = child_id(&engine, ROOT, "photo.bin");
+    alice
+        .floor_store
+        .fail_floor_raises_for(write_name(child).as_str().as_bytes());
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(
+        published_op_mark(&alice),
+        None,
+        "an unreferenced child is not a published op"
     );
     assert!(
-        block_on(StagingStore::queued_ops(&alice.staging_store))
+        !block_on(StagingStore::queued_ops(&alice.staging_store))
             .unwrap()
             .is_empty(),
-        "the op leaves the queue"
-    );
-    let leftover = version
-        .1
-        .into_iter()
-        .chain(core::iter::once(version.0))
-        .collect::<Vec<_>>();
-    assert_no_blocks_staged(&alice, &leftover);
-    assert!(
-        retire_targets(&alice).is_empty(),
-        "a drop is not an abandonment: nothing published is unpinned"
+        "the create stays queued for the retry that completes it"
     );
 }
 

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -4419,6 +4419,82 @@ fn an_op_whose_record_already_published_is_dropped_rather_than_replayed() {
     );
 }
 
+/// The mark's line is the **ack**, not the self-adopt. A record whose PUT
+/// confirmed is live at its name whether or not this device managed to adopt its
+/// own bytes, so an op left queued by a failed adopt must not replay: the replay
+/// re-uploads every leaf into a set a cancel can retire, unpinning content that
+/// live record names.
+#[test]
+fn a_publish_whose_self_adopt_failed_still_marks_the_op_published() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let root_name = seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    // The create's last record is the parent's, so the root's own self-adopt is
+    // the step that fails after its record is already live.
+    alice
+        .floor_store
+        .fail_commits_for(root_name.as_str().as_bytes());
+    let op_id = write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<u8>>(),
+    )
+    .unwrap();
+    let version = staged_version(&alice);
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(
+        published_op_mark(&alice),
+        Some(op_id.0),
+        "the ack raised the mark, not the adopt"
+    );
+    assert!(
+        !block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .is_empty(),
+        "the failed adopt left the op queued — that is the window"
+    );
+
+    // A restart clears the session interlock, leaving only the mark to stop the
+    // replay.
+    alice.floor_store.heal_commits();
+    let _ = events_so_far(&mut events);
+    let (restarted, mut events, mut tasks) = boot(&world, &blocks, &alice, 43);
+    tick(&world, &restarted, &mut tasks);
+    assert!(
+        !events_so_far(&mut events).iter().any(|event| matches!(
+            event,
+            Event::OpProgress {
+                phase: OpPhase::UploadStarted,
+                ..
+            }
+        )),
+        "nothing re-uploads behind a record that already landed"
+    );
+    assert!(
+        block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .is_empty(),
+        "the op leaves the queue"
+    );
+    let leftover = version
+        .1
+        .into_iter()
+        .chain(core::iter::once(version.0))
+        .collect::<Vec<_>>();
+    assert_no_blocks_staged(&alice, &leftover);
+    assert!(
+        retire_targets(&alice).is_empty(),
+        "a drop is not an abandonment: nothing published is unpinned"
+    );
+}
+
 /// The publish-entry interlock is session-scoped, so a reboot clears it. The
 /// durable mark is what keeps a published version uncancellable across one.
 #[test]

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -4699,6 +4699,57 @@ fn a_cross_folder_moves_dest_add_never_marks_on_its_own() {
     );
 }
 
+/// The retry the compensation leaves queued does complete the move: once the
+/// source-remove's PUT lands, the record that marks is the one that carries it.
+#[test]
+fn a_retried_cross_folder_move_marks_when_its_source_remove_lands() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let root_name = seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let (photos, moved) = seed_folder_and_file(&world, &mut engine, &mut tasks);
+    let before = published_op_mark(&alice);
+
+    world.record_store.fail_put_for(root_name.as_str());
+    let op_id = block_on(engine.command(Command::Move {
+        node: moved,
+        new_parent: photos,
+        new_name: "a.txt".into(),
+        replacing: None,
+    }))
+    .unwrap()
+    .expect("the move queues");
+    tick(&world, &engine, &mut tasks);
+    assert_eq!(
+        published_op_mark(&alice),
+        before,
+        "the compensated attempt must not have marked"
+    );
+
+    world.record_store.heal_put_for(root_name.as_str());
+    tick(&world, &engine, &mut tasks);
+
+    assert_eq!(
+        published_names(&world.record_store, &blocks, photos),
+        ["a.txt"],
+        "the retry republishes the dest-add the compensation undid"
+    );
+    assert_eq!(
+        published_op_mark(&alice),
+        Some(op_id.0),
+        "the landed source-remove marks the move published"
+    );
+    assert!(
+        !block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .iter()
+            .any(|(id, _)| *id == op_id),
+        "the completed move leaves the queue"
+    );
+}
+
 /// The publish-entry interlock is session-scoped, so a reboot clears it. The
 /// durable mark is what keeps a published version uncancellable across one.
 #[test]

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -4442,11 +4442,6 @@ fn a_publish_whose_self_adopt_failed_still_marks_the_op_published() {
 
     let alice = world.device(b"alice");
     let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
-    // The create's last record is the parent's, so the root's own self-adopt is
-    // the step that fails after its record is already live.
-    alice
-        .floor_store
-        .fail_floor_raises_for(root_name.as_str().as_bytes());
     let op_id = write_file(
         &mut engine,
         WriteTarget::NewFile {
@@ -4457,19 +4452,7 @@ fn a_publish_whose_self_adopt_failed_still_marks_the_op_published() {
     )
     .unwrap();
     let version = staged_version(&alice);
-    tick(&world, &engine, &mut tasks);
-
-    assert_eq!(
-        published_op_mark(&alice),
-        Some(op_id.0),
-        "the ack raised the mark, not the adopt"
-    );
-    assert!(
-        !block_on(StagingStore::queued_ops(&alice.staging_store))
-            .unwrap()
-            .is_empty(),
-        "the failed adopt left the op queued — that is the window"
-    );
+    assert_a_failed_root_adopt_still_marks(&world, &alice, &engine, &mut tasks, &root_name, op_id);
 
     // A restart clears the session interlock, leaving only the mark to stop the
     // replay.
@@ -4518,6 +4501,201 @@ fn a_create_whose_parent_publish_never_ran_leaves_the_mark_down() {
             .unwrap()
             .is_empty(),
         "the create stays queued for the retry that completes it"
+    );
+}
+
+/// The plan's last record confirms and marks the op, and only then does its
+/// self-adopt fail. The fault sits on the scope root because that is the one
+/// folder a pass reads from the cache rather than through an adopt, so the loads
+/// the plan makes before that record are left intact.
+fn assert_a_failed_root_adopt_still_marks(
+    world: &FakeWorld,
+    device: &FakeDevice,
+    engine: &Engine<FakeSeamTypes>,
+    tasks: &mut [BoxedTask],
+    root_name: &IpnsName,
+    op_id: OpId,
+) {
+    device
+        .floor_store
+        .fail_floor_raises_for(root_name.as_str().as_bytes());
+    let before = published(&world.record_store, ROOT).0;
+    tick(world, engine, tasks);
+
+    assert_eq!(
+        published(&world.record_store, ROOT).0,
+        before + 1,
+        "the record the mark rests on did land"
+    );
+    assert_eq!(
+        published_op_mark(device),
+        Some(op_id.0),
+        "the ack raised the mark, not the adopt"
+    );
+    assert!(
+        !block_on(StagingStore::queued_ops(&device.staging_store))
+            .unwrap()
+            .is_empty(),
+        "the failed adopt left the op queued — that is the window"
+    );
+}
+
+/// The restart the mark exists for: the op leaves the queue without re-authoring
+/// the record it already landed, and unpins nothing while doing it.
+fn assert_restart_drops_without_republishing(
+    world: &FakeWorld,
+    blocks: &Blocks,
+    device: &FakeDevice,
+) {
+    device.floor_store.heal_floors();
+    let before = published(&world.record_store, ROOT).0;
+    let (restarted, _events, mut tasks) = boot(world, blocks, device, 43);
+    tick(world, &restarted, &mut tasks);
+
+    assert!(
+        block_on(StagingStore::queued_ops(&device.staging_store))
+            .unwrap()
+            .is_empty(),
+        "the op leaves the queue"
+    );
+    assert_eq!(
+        published(&world.record_store, ROOT).0,
+        before,
+        "a dropped op republishes nothing"
+    );
+    assert!(
+        retire_targets(device).is_empty(),
+        "a drop is not an abandonment: nothing published is unpinned"
+    );
+}
+
+/// A delete authors exactly one record, so that record is its last and marks.
+#[test]
+fn a_delete_whose_self_adopt_failed_still_marks_the_op_published() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let root_name = seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    create(&mut engine, "doomed");
+    tick(&world, &engine, &mut tasks);
+    let doomed = child_id(&engine, ROOT, "doomed");
+
+    let op_id = block_on(engine.command(Command::Delete { node: doomed }))
+        .unwrap()
+        .expect("the delete queues");
+    assert_a_failed_root_adopt_still_marks(&world, &alice, &engine, &mut tasks, &root_name, op_id);
+    assert_restart_drops_without_republishing(&world, &blocks, &alice);
+}
+
+/// Source and destination being one folder collapses a reference move into a
+/// single record, so the dest-add is also the plan's last.
+#[test]
+fn a_rename_whose_self_adopt_failed_still_marks_the_op_published() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let root_name = seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    create(&mut engine, "before");
+    tick(&world, &engine, &mut tasks);
+
+    let op_id = block_on(engine.command(Command::Rename {
+        node: child_id(&engine, ROOT, "before"),
+        new_name: "after".into(),
+    }))
+    .unwrap()
+    .expect("the rename queues");
+    assert_a_failed_root_adopt_still_marks(&world, &alice, &engine, &mut tasks, &root_name, op_id);
+    assert_restart_drops_without_republishing(&world, &blocks, &alice);
+}
+
+/// Across folders the plan is dest-add then source-remove, so the **source**
+/// record is the last one and the one that marks.
+#[test]
+fn a_cross_folder_moves_source_remove_is_the_record_that_marks() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let root_name = seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    // The move leaves the root for `photos`, so the root carries the
+    // source-remove and the destination publishes first and adopts cleanly.
+    let (photos, moved) = seed_folder_and_file(&world, &mut engine, &mut tasks);
+
+    let op_id = block_on(engine.command(Command::Move {
+        node: moved,
+        new_parent: photos,
+        new_name: "a.txt".into(),
+        replacing: None,
+    }))
+    .unwrap()
+    .expect("the move queues");
+    assert_a_failed_root_adopt_still_marks(&world, &alice, &engine, &mut tasks, &root_name, op_id);
+    assert_eq!(
+        published_names(&world.record_store, &blocks, photos),
+        ["a.txt"],
+        "a confirmed source-remove is the move complete, never compensated"
+    );
+    assert_restart_drops_without_republishing(&world, &blocks, &alice);
+}
+
+/// A dest-add that lands while the source-remove never does is not a published
+/// move: the compensation undoes it. Marking there would drop the op on restart
+/// with the move rolled back and never retried, losing it outright.
+#[test]
+fn a_cross_folder_moves_dest_add_never_marks_on_its_own() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let root_name = seed_account(&world, &blocks);
+
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let (photos, moved) = seed_folder_and_file(&world, &mut engine, &mut tasks);
+    let before = published_op_mark(&alice);
+    let dest_sequence = published(&world.record_store, photos).0;
+
+    // The root carries the source-remove, so refusing its PUT stops the plan
+    // after the destination has published and adopted.
+    world.record_store.fail_put_for(root_name.as_str());
+    let op_id = block_on(engine.command(Command::Move {
+        node: moved,
+        new_parent: photos,
+        new_name: "a.txt".into(),
+        replacing: None,
+    }))
+    .unwrap()
+    .expect("the move queues");
+    tick(&world, &engine, &mut tasks);
+
+    assert!(
+        before < Some(op_id.0),
+        "the setup's own mark must not already cover the move"
+    );
+    assert_eq!(
+        published_op_mark(&alice),
+        before,
+        "a dest-add the compensation undid is not a published op"
+    );
+    assert_eq!(
+        published(&world.record_store, photos).0,
+        dest_sequence + 2,
+        "the dest-add published, then the compensation undid it"
+    );
+    assert_eq!(
+        published_names(&world.record_store, &blocks, photos),
+        [] as [String; 0],
+        "the destination keeps nothing the source still names"
+    );
+    assert!(
+        block_on(StagingStore::queued_ops(&alice.staging_store))
+            .unwrap()
+            .iter()
+            .any(|(id, _)| *id == op_id),
+        "the move stays queued for the retry that completes it"
     );
 }
 


### PR DESCRIPTION
Two gaps in the write plane's fail-closed publish path, both extending what landed tonight in #1046 and #1049.

## The mark's line is the ack, not the self-adopt

`publish_node` returns `Ok` only once the self-adopt has also succeeded, so a record whose PUT confirmed and whose adopt then failed left the op queued with the published-op mark unraised. On the next boot that op replayed, re-uploaded the identical content-addressed leaves, and a cancel landing in that transfer reached `retire_cancelled` and unpinned content the live record already names. Within one session the publish-entry interlock covers it; across a reboot `UploadCancels` is empty, so it does not.

The mark now rises inside `publish_node` the instant `publish_head` returns, which it does only on `PublishOutcome::Published`. An unconfirmed or race-losing publish raises nothing: those bytes may never have landed, and dropping the op on the strength of that would be loss.

The decision the issue flagged as open is which record of a plan marks. It is the plan's **last**: `updateContent` marks on the target's own publish, `create` on the parent-folder publish, and every other publish passes `None`. Marking the create's child publish would drop an op on restart whose child no parent names, so the negative direction is pinned by its own test.

## The produce mirror covered stage 3 but not stage 2

`check_scope_root` verified the commitment's `ipnsName` binding and every structure signature, but never `commitment_sig`. `authenticate_section_structures` authenticates structures against the pseudonyms the section's **own** commitment names, so a wholly self-consistent attacker-authored section — own commitment, own pseudonym, own signatures, correct `ipnsName` — passed it completely. The drain reads its scope root from the snapshot cache, which is floor-checked but never re-verifies the section, so a tampered entry was caught for internal consistency and not for owner authority.

`check_scope_root` now runs `verify_grant_set` at the gate's own stage-2 position, release-active, on both scope-root authoring paths. Reject rows for a foreign-signed commitment, an unusable signature, and the re-seal path's own equivalent, all returning `Err` so they fire in a release build.

Produce-side refusals also carry stable check names — `AuthorError::check`, rendered by `Display` — and the drain charges the trust class against the attempt budget instead of retrying it free forever.

## What differs from the issue bodies

- `#1048` asks for a permanent verdict. These refusals are charged instead. On the drain path they can only come from the cached scope root, which a later resolve replaces, so an immediate dead-letter would abandon a user's ops over a cache another tick repairs — the mirror-image of the bug being fixed. The budget bounds the spin either way, and `Seal`/`HeadTooLarge` stay availability because a rebase may not build that body again.
- `#1048`'s second half also names `net/rotation.rs`. That file is a sibling PR's, so this branch makes only the one-argument call-site change the new `check_scope_root` signature forces; the classification there is #1055.
- `#1045`'s `MissingGrantSection`/`GrantSectionOnChild` are unreachable from the drain today — a gated child never carries a section and a gated root always does — but they are classified with the rest rather than left as the one uncharged arm.

## Also folded in from the review gates

A reload that lands on a rotated root is now refused rather than authored at the epoch the pass opened on: that skew is a self-healing race, and the new classification would otherwise spend the op's budget on it. Two invariants the trust class made stale are corrected — an authoring refusal is raised before its own record reaches the transport, not before every PUT of the op, and the abandonment retires on the target still being unreachable rather than on no PUT having acked.

## Deferred

`#1055` rotation-path classification, `#1056` surfacing the refusal name past `AttemptsExhausted`, `#1057` the ascent-link half of stage 3 on the re-seal's produce side. Each carries a native dependency edge on `#1048`.

Closes #1045
Closes #1048


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of scope-root signatures and owner identities.
  * Added clearer handling for invalid or unauthorized commitment signatures.
  * Prevented replaying operations after confirmed publication, including after crashes or restarts.
  * Preserved queued operations when final publication does not complete.
  * Improved handling of moves, deletions, renames, and partial publication failures.
  * Improved classification of authoring refusals during publishing.

* **Tests**
  * Added coverage for signature mismatches, malformed sections, publication recovery, replay prevention, and publication failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark ops published at record PUT ack and verify commitment signatures on scope-root authoring
> - Published-op marks are now raised at the instant the last record's PUT confirms (in `publish_node`), rather than after self-adopt; this improves crash safety and prevents redundant re-uploads on restart.
> - Scope-root authoring in `check_scope_root` now performs stage-2/3 validation: decodes the grant section, verifies the commitment signature against the owner identity, checks `ipns_name` match, and authenticates structure signatures. Two new `AuthorError` variants (`InvalidGrantSection`, `CommitmentSignatureInvalid`) surface these failures.
> - Cross-folder move compensation in `publish_ref_move` no longer rolls back a dest-add if the source-remove already confirmed; compensation is gated on the `PublishHalt.confirmed` flag introduced by the new `PublishHalt` struct.
> - Mid-pass scope-root rotation is now detected in `reload_folder`: if the loaded epoch differs from the pass epoch, the pass halts and retries rather than authoring with a stale epoch.
> - Risk: ops that previously marked after self-adopt now mark earlier (on PUT ack); any crash between PUT ack and self-adopt no longer causes a replay, but callers that expected the old ordering may observe the mark sooner.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91cdac1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->