### PR TITLE
fix: hold a stream slot across the open and evict revoked scope seeds

### DIFF
--- a/crates/engine/examples/kat_gen.rs
+++ b/crates/engine/examples/kat_gen.rs
@@ -249,7 +249,7 @@ fn build_dag_root_accept() -> Vec<DagRootAcceptVector> {
         let manifest = decode_root(&dag.root_block).expect("own root decodes");
         assert_eq!(manifest.chunk_size, chunk as u64, "{name}: chunk size");
         assert_eq!(manifest.size, size as u64, "{name}: size");
-        let decoded: Vec<Vec<u8>> = manifest.leaf_cids.iter().map(|cid| cid.to_vec()).collect();
+        let decoded = manifest.leaf_cid_vecs();
         assert_eq!(decoded, leaf_cids, "{name}: links preserve file order");
 
         out.push(DagRootAcceptVector {

--- a/crates/engine/examples/kat_gen.rs
+++ b/crates/engine/examples/kat_gen.rs
@@ -249,10 +249,8 @@ fn build_dag_root_accept() -> Vec<DagRootAcceptVector> {
         let manifest = decode_root(&dag.root_block).expect("own root decodes");
         assert_eq!(manifest.chunk_size, chunk as u64, "{name}: chunk size");
         assert_eq!(manifest.size, size as u64, "{name}: size");
-        assert_eq!(
-            manifest.leaf_cids, leaf_cids,
-            "{name}: links preserve file order"
-        );
+        let decoded: Vec<Vec<u8>> = manifest.leaf_cids.iter().map(|cid| cid.to_vec()).collect();
+        assert_eq!(decoded, leaf_cids, "{name}: links preserve file order");
 
         out.push(DagRootAcceptVector {
             name: name.to_string(),

--- a/crates/engine/src/content/dag.rs
+++ b/crates/engine/src/content/dag.rs
@@ -204,9 +204,15 @@ pub struct RootManifest {
     pub chunk_size: u64,
     /// The total plaintext byte length across all leaves.
     pub size: u64,
-    /// The leaf content CIDs, in file order.
-    pub leaf_cids: Vec<Vec<u8>>,
+    /// The leaf content CIDs, in file order. One allocation for the whole list,
+    /// not one per leaf: a stream pins its manifest for the handle's whole life
+    /// and a leaf is a fixed [`CONTENT_CID_LEN`] bytes (#1009).
+    pub leaf_cids: Box<[LeafCid]>,
 }
+
+/// A leaf's content CID: fixed-width by construction, so the length half of
+/// [`is_raw_leaf_cid`] is a type-level fact rather than a runtime check.
+pub type LeafCid = [u8; CONTENT_CID_LEN];
 
 /// Decode a root block (already verified against its `contentCid` by the
 /// caller) into its manifest, fail-closed — a `contentCid`-valid-but-internally
@@ -232,19 +238,21 @@ pub fn decode_root(root_block: &[u8]) -> Result<RootManifest, DagError> {
         .get(SIZE_KEY)
         .ok_or(Malformed::MissingField { field: "size" })?
         .as_unsigned()?;
-    let leaf_cids = map
+    let links = map
         .get(LINKS_KEY)
         .ok_or(Malformed::MissingField { field: "links" })?
-        .as_array()?
-        .iter()
-        .map(|link| link.as_bytes().map(<[u8]>::to_vec))
-        .collect::<Result<Vec<_>, Malformed>>()?;
+        .as_array()?;
 
     if chunk_size == 0 {
         return Err(DagError::ZeroChunkSize);
     }
-    if !leaf_cids.iter().all(|cid| is_raw_leaf_cid(cid)) {
-        return Err(DagError::MalformedLeafCid);
+    let mut leaf_cids: Vec<LeafCid> = Vec::with_capacity(links.len());
+    for link in links {
+        let cid = LeafCid::try_from(link.as_bytes()?).map_err(|_| DagError::MalformedLeafCid)?;
+        if !is_raw_leaf_cid(&cid) {
+            return Err(DagError::MalformedLeafCid);
+        }
+        leaf_cids.push(cid);
     }
     if leaf_cids.len() as u64 != expected_leaf_count(size, chunk_size) {
         return Err(DagError::LinkCountMismatch);
@@ -253,7 +261,7 @@ pub fn decode_root(root_block: &[u8]) -> Result<RootManifest, DagError> {
     Ok(RootManifest {
         chunk_size,
         size,
-        leaf_cids,
+        leaf_cids: leaf_cids.into_boxed_slice(),
     })
 }
 
@@ -367,6 +375,12 @@ mod tests {
         encode(&Value::Map(root)).unwrap()
     }
 
+    /// The manifest's links as the `Vec<Vec<u8>>` shape `assemble` takes, so a
+    /// round-trip compares against its own input.
+    fn as_vecs(manifest: &RootManifest) -> Vec<Vec<u8>> {
+        manifest.leaf_cids.iter().map(|cid| cid.to_vec()).collect()
+    }
+
     fn reject_check(block: &[u8]) -> &'static str {
         match decode_root(block) {
             Err(error) => error.check(),
@@ -402,7 +416,7 @@ mod tests {
         let manifest = decode_root(&dag.root_block).unwrap();
         assert_eq!(manifest.chunk_size, profile.chunk_size() as u64);
         assert_eq!(manifest.size, plaintext.len() as u64);
-        assert_eq!(manifest.leaf_cids, leaves, "links preserve file order");
+        assert_eq!(as_vecs(&manifest), leaves, "links preserve file order");
     }
 
     #[test]
@@ -437,6 +451,17 @@ mod tests {
             16,
             &[b"not-a-content-cid".to_vec()],
         );
+        assert_eq!(reject_check(&block), "dag-malformed-leaf-cid");
+    }
+
+    #[test]
+    fn decode_root_rejects_an_over_wide_leaf_cid() {
+        // Correct framing prefix, one byte too long: the fixed-width manifest
+        // links must reject it rather than truncate to `CONTENT_CID_LEN`.
+        let (leaves, _) = framed(b"abc", 5);
+        let mut wide = leaves[0].clone();
+        wide.push(0);
+        let block = root_bytes(ROOT_FORMAT_VERSION, 16, 3, &[wide]);
         assert_eq!(reject_check(&block), "dag-malformed-leaf-cid");
     }
 

--- a/crates/engine/src/content/dag.rs
+++ b/crates/engine/src/content/dag.rs
@@ -592,13 +592,20 @@ mod tests {
 
     #[test]
     fn assemble_rejects_a_malformed_leaf_cid_in_every_build() {
-        // The encode-side half of `decode_root`'s leaf-CID reject (rule 8).
+        // The encode-side half of `decode_root`'s leaf-CID reject (rule 8) —
+        // including both widths the fixed-width manifest links cannot hold.
         let profile = ContentProfile::CI;
-        let leaves = vec![b"not-a-content-cid".to_vec()];
-        assert_eq!(
-            assemble(&leaves, profile.chunk_size() as u64, &profile),
-            Err(DagError::MalformedLeafCid)
-        );
+        let (framed, _) = framed(b"abc", 5);
+        let mut narrow = framed[0].clone();
+        narrow.pop();
+        let mut wide = framed[0].clone();
+        wide.push(0);
+        for bad in [b"not-a-content-cid".to_vec(), narrow, wide] {
+            assert_eq!(
+                assemble(&[bad], profile.chunk_size() as u64, &profile),
+                Err(DagError::MalformedLeafCid)
+            );
+        }
     }
 
     /// The arithmetic sizing and the real encoder must never drift: the staging

--- a/crates/engine/src/content/dag.rs
+++ b/crates/engine/src/content/dag.rs
@@ -210,8 +210,17 @@ pub struct RootManifest {
     pub leaf_cids: Box<[LeafCid]>,
 }
 
-/// A leaf's content CID: fixed-width by construction, so the length half of
-/// [`is_raw_leaf_cid`] is a type-level fact rather than a runtime check.
+impl RootManifest {
+    /// The links as owned byte vectors, for the consumers still keyed on
+    /// `Vec<u8>`.
+    #[must_use]
+    pub fn leaf_cid_vecs(&self) -> Vec<Vec<u8>> {
+        self.leaf_cids.iter().map(|cid| cid.to_vec()).collect()
+    }
+}
+
+/// A leaf's content CID: fixed-width by construction, so a manifest cannot hold
+/// a wrong-width link.
 pub type LeafCid = [u8; CONTENT_CID_LEN];
 
 /// Decode a root block (already verified against its `contentCid` by the
@@ -375,12 +384,6 @@ mod tests {
         encode(&Value::Map(root)).unwrap()
     }
 
-    /// The manifest's links as the `Vec<Vec<u8>>` shape `assemble` takes, so a
-    /// round-trip compares against its own input.
-    fn as_vecs(manifest: &RootManifest) -> Vec<Vec<u8>> {
-        manifest.leaf_cids.iter().map(|cid| cid.to_vec()).collect()
-    }
-
     fn reject_check(block: &[u8]) -> &'static str {
         match decode_root(block) {
             Err(error) => error.check(),
@@ -416,7 +419,11 @@ mod tests {
         let manifest = decode_root(&dag.root_block).unwrap();
         assert_eq!(manifest.chunk_size, profile.chunk_size() as u64);
         assert_eq!(manifest.size, plaintext.len() as u64);
-        assert_eq!(as_vecs(&manifest), leaves, "links preserve file order");
+        assert_eq!(
+            manifest.leaf_cid_vecs(),
+            leaves,
+            "links preserve file order"
+        );
     }
 
     #[test]

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -82,7 +82,7 @@ impl SealedContent {
         Ok(Self {
             content_cid: compute_cid(DAG_ROOT_CODEC, root_block),
             size: manifest.size,
-            leaf_cids: manifest.leaf_cids.iter().map(|cid| cid.to_vec()).collect(),
+            leaf_cids: manifest.leaf_cid_vecs(),
         })
     }
 

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -82,7 +82,7 @@ impl SealedContent {
         Ok(Self {
             content_cid: compute_cid(DAG_ROOT_CODEC, root_block),
             size: manifest.size,
-            leaf_cids: manifest.leaf_cids,
+            leaf_cids: manifest.leaf_cids.iter().map(|cid| cid.to_vec()).collect(),
         })
     }
 

--- a/crates/engine/src/content/write.rs
+++ b/crates/engine/src/content/write.rs
@@ -200,7 +200,7 @@ mod tests {
         let (leaves, finished) = stream(&plaintext, 9, 5);
         let manifest = decode_root(&finished.root_block).unwrap();
         assert_eq!(manifest.size, plaintext.len() as u64);
-        let decoded: Vec<Vec<u8>> = manifest.leaf_cids.iter().map(|cid| cid.to_vec()).collect();
+        let decoded = manifest.leaf_cid_vecs();
         assert_eq!(decoded, finished.content.leaf_cids());
 
         let mut recovered = Vec::new();

--- a/crates/engine/src/content/write.rs
+++ b/crates/engine/src/content/write.rs
@@ -200,7 +200,8 @@ mod tests {
         let (leaves, finished) = stream(&plaintext, 9, 5);
         let manifest = decode_root(&finished.root_block).unwrap();
         assert_eq!(manifest.size, plaintext.len() as u64);
-        assert_eq!(manifest.leaf_cids, finished.content.leaf_cids());
+        let decoded: Vec<Vec<u8>> = manifest.leaf_cids.iter().map(|cid| cid.to_vec()).collect();
+        assert_eq!(decoded, finished.content.leaf_cids());
 
         let mut recovered = Vec::new();
         for (leaf, cid) in leaves.iter().zip(&manifest.leaf_cids) {

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -1150,8 +1150,6 @@ struct SyncStatus {
     reported: Option<Staleness>,
 }
 
-/// A recovered scope seed and the durable epoch floor it was recovered under.
-///
 /// A recovered scope seed and a lower bound on the epoch it belongs to (see
 /// [`deposit_seed`]).
 ///

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -1112,15 +1112,15 @@ fn surface_drain_report(
 /// drain mint every new node's `ipnsName` and signer from a key that party also
 /// holds. A seed that cannot name our own root is not our scope's — held
 /// keyless, never a trust verdict.
-async fn deposit_write_seed<F: FloorStore>(
-    floors: &F,
+fn deposit_write_seed(
     cell: &RefCell<ScopeSeeds>,
     scope_id: [u8; 16],
     seed: Zeroizing<[u8; 32]>,
     root_name: Option<&IpnsName>,
+    floor: Option<u64>,
 ) {
     if root_name.is_some_and(|name| derive_write_name(&seed, &scope_id) == *name) {
-        deposit_seed(floors, cell, scope_id, seed, SeedFloor::Write).await;
+        deposit_seed(cell, scope_id, seed, floor);
     }
 }
 
@@ -1152,10 +1152,13 @@ struct SyncStatus {
 
 /// A recovered scope seed and the durable epoch floor it was recovered under.
 ///
-/// The floor is the seed's expiry: a rotation that raises the scope's floor past
-/// it revokes that epoch, so the seed is evicted rather than left resident for
-/// the rest of the session. Least privilege is a retention rule, not only an
-/// install rule (#795, #1040).
+/// A recovered scope seed and a lower bound on the epoch it belongs to (see
+/// [`deposit_seed`]).
+///
+/// The bound is the seed's expiry: a rotation that raises the scope's durable
+/// floor past it revokes that epoch, so the seed is evicted rather than left
+/// resident for the rest of the session. Least privilege is a retention rule,
+/// not only an install rule (#795, #1040).
 struct CachedSeed {
     seed: Zeroizing<[u8; 32]>,
     floor: u64,
@@ -1187,48 +1190,74 @@ impl SeedFloor {
     }
 }
 
-/// Drop `scope_id`'s cached seed once its durable floor has risen past the one
-/// the seed was recovered under. A floor read that fails evicts too: an
-/// unprovable seed is not held.
-async fn evict_seed_past_floor<F: FloorStore>(
+/// Read `scope_id`'s durable floor for `which`, evicting a cached seed stamped
+/// below it, and hand the floor back for the pass's own deposits.
+///
+/// `None` on a floor-store failure, which also evicts: a seed whose currency
+/// cannot be established is not held, and nothing may be stamped against a floor
+/// that was never read.
+async fn refresh_seed_floor<F: FloorStore>(
     floors: &F,
     cell: &RefCell<ScopeSeeds>,
     scope_id: &[u8; 16],
     which: SeedFloor,
-) {
-    if !cell.borrow().contains_key(scope_id) {
-        return;
-    }
-    let durable = which.durable(floors, scope_id).await;
+) -> Option<u64> {
+    let durable = which
+        .durable(floors, scope_id)
+        .await
+        .ok()
+        .map(|floor| floor.unwrap_or(0));
     let mut seeds = cell.borrow_mut();
-    let stale = durable.map_or(true, |floor| {
-        seeds
-            .get(scope_id)
-            .is_some_and(|cached| cached.floor < floor.unwrap_or(0))
-    });
-    if stale {
+    if durable.is_none_or(|floor| seeds.get(scope_id).is_some_and(|c| c.floor < floor)) {
         seeds.remove(scope_id);
     }
+    durable
 }
 
-/// Deposit a recovered scope seed, stamped with the durable floor the adopt that
-/// surfaced it left behind. A floor read that fails skips the deposit: an
-/// unstamped seed would be evicted on sight.
-async fn deposit_seed<F: FloorStore>(
-    floors: &F,
+/// Deposit a recovered scope seed under `stamp`, which must be **at or below the
+/// epoch the seed belongs to** — the seed's own epoch where the recovery names it
+/// (an adopted record's `epoch`, a re-point's vouched floors), else the durable
+/// floor read *before* the resolve.
+///
+/// A pre-resolve floor is a valid stamp because floors are monotonic and every
+/// recovery arm refuses an envelope below the floor it read (`gate::adoption`
+/// stage 5, `RootAdopter::recover_own_scope_material`). What is *not* valid is a
+/// floor re-read after the resolve: a rise that landed mid-pass would be absorbed
+/// into the stamp and keep a revoked-epoch seed resident (#1040).
+///
+/// `None` skips the deposit — the floor could not be read, so nothing can be
+/// stamped and the eviction pass has already cleared the cell.
+fn deposit_seed(
     cell: &RefCell<ScopeSeeds>,
     scope_id: [u8; 16],
     seed: Zeroizing<[u8; 32]>,
-    which: SeedFloor,
+    stamp: Option<u64>,
 ) {
-    if let Ok(floor) = which.durable(floors, &scope_id).await {
-        cell.borrow_mut().insert(
-            scope_id,
-            CachedSeed {
-                seed,
-                floor: floor.unwrap_or(0),
-            },
-        );
+    if let Some(floor) = stamp {
+        cell.borrow_mut()
+            .insert(scope_id, CachedSeed { seed, floor });
+    }
+}
+
+/// A scope's two durable epoch floors as one resolve pass observed them, before
+/// the resolve moved either. `None` on a floor-store failure (see
+/// [`refresh_seed_floor`]).
+struct SeedFloors {
+    read: Option<u64>,
+    write: Option<u64>,
+}
+
+/// Evict both of `scope_id`'s cached seeds against their durable floors and
+/// report those floors, the stamps this pass's deposits carry.
+async fn refresh_seed_floors<F: FloorStore>(
+    floors: &F,
+    scope_id: &[u8; 16],
+    read_seeds: &RefCell<ScopeSeeds>,
+    write_seeds: &RefCell<ScopeSeeds>,
+) -> SeedFloors {
+    SeedFloors {
+        read: refresh_seed_floor(floors, read_seeds, scope_id, SeedFloor::Read).await,
+        write: refresh_seed_floor(floors, write_seeds, scope_id, SeedFloor::Write).await,
     }
 }
 
@@ -1619,17 +1648,20 @@ impl<T: SeamTypes> Engine<T> {
                 return Err(EngineError::from_cold_start(err));
             }
         };
+        // Both seeds are stamped from the owner-vouched re-point the cold-seed
+        // installed the floors from, and which the adopt and the owner-write-blob
+        // AAD then bound to — the epochs they belong to, not a later floor read
+        // (see `deposit_seed`).
+        let vouched = outcome.vault_pointer.as_ref().map(|vp| &vp.repoint);
         // A gate-passing root adopt surfaced the scope read seed: deposit it in
         // the in-memory per-scope cell the child read pipeline derives from.
         if let Some(seed) = outcome.read_scope_seed.take() {
             deposit_seed(
-                &self.seams.floor_store,
                 &self.scope_read_seeds,
                 root_scope_id,
                 seed,
-                SeedFloor::Read,
-            )
-            .await;
+                vouched.map(|repoint| repoint.min_read_epoch),
+            );
         }
         // The gate-passing base becomes the state law's left operand (reads render
         // this ⊕ the pending-op overlay). The resolved root name — the vault
@@ -1643,13 +1675,12 @@ impl<T: SeamTypes> Engine<T> {
         // new node's `ipnsName` and its narrow per-name signer from it.
         if let Some((scope_id, seed)) = outcome.write_scope_seed.take() {
             deposit_write_seed(
-                &self.seams.floor_store,
                 &self.scope_write_seeds,
                 scope_id,
                 seed,
                 root_name.as_ref(),
-            )
-            .await;
+                vouched.map(|repoint| repoint.write_epoch),
+            );
         }
         *self.snapshot.borrow_mut() = outcome.base;
         // A successful cold start is a successful reconcile: stamp it so the
@@ -1688,6 +1719,11 @@ impl<T: SeamTypes> Engine<T> {
         }
         if let Ok(mut held) = self.held_records.try_borrow_mut() {
             held.clear();
+        }
+        // Each open stream pins a version's content key; releasing the table's
+        // `Rc`s here is what makes this the terminal owner (security rule 7).
+        if let Ok(mut streams) = self.streams.try_borrow_mut() {
+            streams.open.clear();
         }
         for seeds in [&self.scope_read_seeds, &self.scope_write_seeds] {
             if let Ok(mut seeds) = seeds.try_borrow_mut() {
@@ -1905,10 +1941,11 @@ impl<T: SeamTypes> Engine<T> {
                 };
                 // Before the steady-state hold consults them: a floor raised
                 // since the last pass revokes the seeds this pass would
-                // otherwise read and seal under (#1040).
-                evict_seed_past_floor(&floors, &scope_read_seeds, &root_id, SeedFloor::Read).await;
-                evict_seed_past_floor(&floors, &scope_write_seeds, &root_id, SeedFloor::Write)
-                    .await;
+                // otherwise read and seal under (#1040). The floors it reports
+                // stamp whatever this pass's own resolve recovers.
+                let floors_before =
+                    refresh_seed_floors(&floors, &root_id, &scope_read_seeds, &scope_write_seeds)
+                        .await;
                 let adopter = RootAdopter::new(
                     &gateway,
                     &http,
@@ -1951,18 +1988,23 @@ impl<T: SeamTypes> Engine<T> {
                 // drain derive from.
                 if let Ok(surfaced) = &mut held_resolve {
                     if let Some(seed) = surfaced.read_scope_seed.take() {
-                        deposit_seed(&floors, &scope_read_seeds, root_id, seed, SeedFloor::Read)
-                            .await;
+                        // An adopt names the epoch its own owner blob's seed
+                        // belongs to; an equal-floor `Current` recovery does not,
+                        // and takes the pre-resolve floor (see `deposit_seed`).
+                        let stamp = match &surfaced.resolved.outcome {
+                            ResolveOutcome::Adopted(adopted) => Some(adopted.epoch),
+                            _ => floors_before.read,
+                        };
+                        deposit_seed(&scope_read_seeds, root_id, seed, stamp);
                     }
                     if let Some((node_id, seed)) = surfaced.write_scope_seed.take() {
                         deposit_write_seed(
-                            &floors,
                             &scope_write_seeds,
                             node_id,
                             seed,
                             Some(&root_name),
-                        )
-                        .await;
+                            floors_before.write,
+                        );
                     }
                 }
                 let resolved = held_resolve.map(|surfaced| surfaced.resolved);
@@ -2185,7 +2227,7 @@ impl<T: SeamTypes> Engine<T> {
     /// floor has risen past the one it was recovered under (#1040). Every
     /// on-demand read goes through here; the resolve tick evicts once per pass.
     async fn scope_read_seed(&self, scope_id: &[u8; 16]) -> Option<Zeroizing<[u8; 32]>> {
-        evict_seed_past_floor(
+        refresh_seed_floor(
             &self.seams.floor_store,
             &self.scope_read_seeds,
             scope_id,
@@ -3833,6 +3875,42 @@ mod tests {
         );
         drop(in_flight);
         assert_eq!(streams.live.get(), 0, "the last holder released the slot");
+    }
+
+    /// The cache's retention rule, at the mechanism: a seed lives exactly as
+    /// long as the durable floor stays at or below its stamp, and an unreadable
+    /// floor holds nothing (#1040).
+    #[test]
+    fn a_cached_seed_lives_only_while_the_floor_stays_at_its_stamp() {
+        use crate::testkit::fakes::InMemoryFloorStore;
+
+        const SCOPE: [u8; 16] = [4u8; 16];
+        let floors = InMemoryFloorStore::default();
+        let cell = RefCell::new(ScopeSeeds::new());
+        block_on(async {
+            floors.raise_epoch_floor(&SCOPE, 5).await.unwrap();
+            let stamp = refresh_seed_floor(&floors, &cell, &SCOPE, SeedFloor::Read).await;
+            assert_eq!(stamp, Some(5));
+            deposit_seed(&cell, SCOPE, Zeroizing::new([3u8; 32]), stamp);
+
+            refresh_seed_floor(&floors, &cell, &SCOPE, SeedFloor::Read).await;
+            assert!(
+                cell.borrow().contains_key(&SCOPE),
+                "an unmoved floor keeps the seed"
+            );
+
+            floors.raise_epoch_floor(&SCOPE, 6).await.unwrap();
+            refresh_seed_floor(&floors, &cell, &SCOPE, SeedFloor::Read).await;
+            assert!(
+                !cell.borrow().contains_key(&SCOPE),
+                "the rise past the stamp revokes it"
+            );
+
+            // A stamp the caller could not read holds nothing, so a floor-store
+            // failure never leaves an unprovable seed resident.
+            deposit_seed(&cell, SCOPE, Zeroizing::new([3u8; 32]), None);
+            assert!(!cell.borrow().contains_key(&SCOPE));
+        });
     }
 
     #[test]

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -334,11 +334,9 @@ impl fmt::Debug for LoginSecret {
 /// Where [`Engine::start`] authenticates and the liveness loop registers
 /// renewals — a non-blank API origin, or the named harness mode that has no API.
 ///
-/// The two used to share one `String`, with the empty string standing in for
-/// "there is no API": a host that failed to configure a base got an engine that
-/// silently never logged in (#1032). [`parse`](Self::parse) is the only way to
-/// build a configured base, and the no-API mode is nameable only under the
-/// `test-kit` feature — so a shipped host cannot start unauthenticated.
+/// [`parse`](Self::parse) is the only way to build a configured base and
+/// [`offline`](Self::offline) exists only under `test-kit`, so a shipped host
+/// cannot bring up an engine that never authenticates (#1032).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApiBaseUrl(Option<String>);
 
@@ -1072,8 +1070,8 @@ fn steady_state_hold(
     held: &RefCell<HeldRecords>,
     scope_root: [u8; 16],
     name: &IpnsName,
-    read_seeds: &RefCell<ScopeReadSeeds>,
-    write_seeds: &RefCell<ScopeWriteSeeds>,
+    read_seeds: &RefCell<ScopeSeeds>,
+    write_seeds: &RefCell<ScopeSeeds>,
 ) -> Option<Vec<u8>> {
     if !read_seeds.borrow().contains_key(&scope_root)
         || !write_seeds.borrow().contains_key(&scope_root)
@@ -1114,27 +1112,15 @@ fn surface_drain_report(
 /// drain mint every new node's `ipnsName` and signer from a key that party also
 /// holds. A seed that cannot name our own root is not our scope's — held
 /// keyless, never a trust verdict.
-///
-/// Stamped with the durable write-epoch floor, exactly as
-/// [`deposit_read_seed`] stamps the read seed.
 async fn deposit_write_seed<F: FloorStore>(
     floors: &F,
-    cell: &RefCell<ScopeWriteSeeds>,
+    cell: &RefCell<ScopeSeeds>,
     scope_id: [u8; 16],
     seed: Zeroizing<[u8; 32]>,
     root_name: Option<&IpnsName>,
 ) {
-    if !root_name.is_some_and(|name| derive_write_name(&seed, &scope_id) == *name) {
-        return;
-    }
-    if let Ok(floor) = floor::write_epoch_floor(floors, &scope_id).await {
-        cell.borrow_mut().insert(
-            scope_id,
-            CachedSeed {
-                seed,
-                floor: floor.unwrap_or(0),
-            },
-        );
+    if root_name.is_some_and(|name| derive_write_name(&seed, &scope_id) == *name) {
+        deposit_seed(floors, cell, scope_id, seed, SeedFloor::Write).await;
     }
 }
 
@@ -1175,70 +1161,67 @@ struct CachedSeed {
     floor: u64,
 }
 
-/// The engine's in-memory per-scope read-seed cell: scope id → the recovered
-/// scope read seed (zeroized on removal/drop).
-type ScopeReadSeeds = BTreeMap<[u8; 16], CachedSeed>;
+/// One of the engine's in-memory per-scope seed cells: scope id → the recovered
+/// seed (zeroized on removal/drop).
+type ScopeSeeds = BTreeMap<[u8; 16], CachedSeed>;
 
-/// The engine's in-memory per-scope write-seed cell: scope id → the recovered
-/// scope write seed (zeroized on removal/drop).
-type ScopeWriteSeeds = BTreeMap<[u8; 16], CachedSeed>;
-
-/// Drop `scope_id`'s cached read and write seeds once the durable epoch floors
-/// have risen past the floors they were recovered under.
-///
-/// A floor-store read that fails evicts too: without the durable floor the seed
-/// cannot be shown to be unrevoked, and the next gate-passing adopt re-deposits
-/// it. Runs before the tick's own resolve and before every on-demand use of a
-/// cached seed.
-async fn evict_seeds_past_floor<F: FloorStore>(
-    floors: &F,
-    scope_id: &[u8; 16],
-    read_seeds: &RefCell<ScopeReadSeeds>,
-    write_seeds: &RefCell<ScopeWriteSeeds>,
-) {
-    evict_below(
-        read_seeds,
-        scope_id,
-        floor::read_epoch_floor(floors, scope_id).await,
-    );
-    evict_below(
-        write_seeds,
-        scope_id,
-        floor::write_epoch_floor(floors, scope_id).await,
-    );
+/// Which of a scope's two independent durable floors bounds a cached seed
+/// (`gate::floor`: the read-epoch floor is the revocation boundary, the
+/// write-epoch floor an owner-only clock).
+#[derive(Clone, Copy)]
+enum SeedFloor {
+    Read,
+    Write,
 }
 
-fn evict_below(
-    seeds: &RefCell<BTreeMap<[u8; 16], CachedSeed>>,
-    scope_id: &[u8; 16],
-    durable: SeamResult<Option<u64>>,
-) {
-    let stale = match durable {
-        Ok(floor) => {
-            let floor = floor.unwrap_or(0);
-            seeds
-                .borrow()
-                .get(scope_id)
-                .is_some_and(|cached| cached.floor < floor)
+impl SeedFloor {
+    async fn durable<F: FloorStore>(
+        self,
+        floors: &F,
+        scope_id: &[u8; 16],
+    ) -> SeamResult<Option<u64>> {
+        match self {
+            Self::Read => floor::read_epoch_floor(floors, scope_id).await,
+            Self::Write => floor::write_epoch_floor(floors, scope_id).await,
         }
-        Err(_) => true,
-    };
-    if stale {
-        seeds.borrow_mut().remove(scope_id);
     }
 }
 
-/// Deposit a recovered scope read seed, stamped with the durable read-epoch
-/// floor the adopt that surfaced it left behind — the boundary
-/// [`evict_seeds_past_floor`] later evicts it against. A floor-store read that
-/// fails skips the deposit: an unstampable seed would be evicted on sight.
-async fn deposit_read_seed<F: FloorStore>(
+/// Drop `scope_id`'s cached seed once its durable floor has risen past the one
+/// the seed was recovered under. A floor read that fails evicts too: an
+/// unprovable seed is not held.
+async fn evict_seed_past_floor<F: FloorStore>(
     floors: &F,
-    cell: &RefCell<ScopeReadSeeds>,
+    cell: &RefCell<ScopeSeeds>,
+    scope_id: &[u8; 16],
+    which: SeedFloor,
+) {
+    if !cell.borrow().contains_key(scope_id) {
+        return;
+    }
+    let durable = which.durable(floors, scope_id).await;
+    let mut seeds = cell.borrow_mut();
+    let stale = durable.map_or(true, |floor| {
+        seeds
+            .get(scope_id)
+            .is_some_and(|cached| cached.floor < floor.unwrap_or(0))
+    });
+    if stale {
+        seeds.remove(scope_id);
+    }
+}
+
+/// Deposit a recovered scope seed, stamped with the durable floor the adopt that
+/// surfaced it left behind. A floor read that fails skips the deposit: an
+/// unstamped seed would be evicted on sight.
+async fn deposit_seed<F: FloorStore>(
+    floors: &F,
+    cell: &RefCell<ScopeSeeds>,
     scope_id: [u8; 16],
     seed: Zeroizing<[u8; 32]>,
+    which: SeedFloor,
 ) {
-    if let Ok(floor) = floor::read_epoch_floor(floors, &scope_id).await {
+    if let Ok(floor) = which.durable(floors, &scope_id).await {
         cell.borrow_mut().insert(
             scope_id,
             CachedSeed {
@@ -1247,6 +1230,13 @@ async fn deposit_read_seed<F: FloorStore>(
             },
         );
     }
+}
+
+/// The scope's cached seed, without an eviction pass.
+fn cached_seed(cell: &RefCell<ScopeSeeds>, scope_id: &[u8; 16]) -> Option<Zeroizing<[u8; 32]>> {
+    cell.borrow()
+        .get(scope_id)
+        .map(|cached| cached.seed.clone())
 }
 
 /// Retained dead letters: op id → its target node when known (`None` for an
@@ -1333,9 +1323,7 @@ struct StreamSlot {
 }
 
 impl StreamSlot {
-    /// `None` once the ceiling is met. Single-threaded by construction (the
-    /// facade's `Rc`/`RefCell` state), and the read-modify-write spans no await,
-    /// so the reservation is atomic against every interleaved open.
+    /// `None` once the ceiling is met.
     fn acquire(live: &Rc<Cell<usize>>) -> Option<Self> {
         let count = live.get();
         if count >= MAX_OPEN_STREAMS {
@@ -1437,12 +1425,12 @@ pub struct Engine<T: SeamTypes> {
     /// override seed), keyed by scope id. In-memory only — never persisted,
     /// never crossing the facade (security rules 1/3); the child read pipeline
     /// derives per-node read keys from them (`node-seed` → `read-key`).
-    scope_read_seeds: Rc<RefCell<ScopeReadSeeds>>,
+    scope_read_seeds: Rc<RefCell<ScopeSeeds>>,
     /// Per-scope write seeds recovered by gate-passing adopts (the
     /// owner-write-blob seed), keyed by scope id. In-memory only, exactly like
     /// [`scope_read_seeds`](Self::scope_read_seeds); the drain derives each new
     /// node's `ipnsName` and its narrow per-name signer from them.
-    scope_write_seeds: Rc<RefCell<ScopeWriteSeeds>>,
+    scope_write_seeds: Rc<RefCell<ScopeSeeds>>,
     /// The open focus window ([`Command::SetFocus`]): the folder the host has
     /// open, whose record and whole ancestor chain every resolve tick refreshes.
     /// Shared with the tick loop, which reads it on each pass.
@@ -1574,15 +1562,13 @@ impl<T: SeamTypes> Engine<T> {
         // The one shared client for login, publish, and renewal. Login is
         // fail-closed: a rejected login returns before the session is committed
         // or any loop spawns, so the loop never runs unauthenticated (rules 3/6).
+        let base_url = self.api_base_url.configured();
         let api = Rc::new(ApiClient::new(
             self.seams.http.clone(),
             self.seams.credential_store.clone(),
-            self.api_base_url
-                .configured()
-                .unwrap_or_default()
-                .to_owned(),
+            base_url.unwrap_or_default().to_owned(),
         ));
-        if self.api_base_url.configured().is_some() {
+        if base_url.is_some() {
             let signer = IdentityChallengeSigner::from_signer(session.identity().clone());
             api.login_identity(&signer)
                 .await
@@ -1636,11 +1622,12 @@ impl<T: SeamTypes> Engine<T> {
         // A gate-passing root adopt surfaced the scope read seed: deposit it in
         // the in-memory per-scope cell the child read pipeline derives from.
         if let Some(seed) = outcome.read_scope_seed.take() {
-            deposit_read_seed(
+            deposit_seed(
                 &self.seams.floor_store,
                 &self.scope_read_seeds,
                 root_scope_id,
                 seed,
+                SeedFloor::Read,
             )
             .await;
         }
@@ -1919,7 +1906,8 @@ impl<T: SeamTypes> Engine<T> {
                 // Before the steady-state hold consults them: a floor raised
                 // since the last pass revokes the seeds this pass would
                 // otherwise read and seal under (#1040).
-                evict_seeds_past_floor(&floors, &root_id, &scope_read_seeds, &scope_write_seeds)
+                evict_seed_past_floor(&floors, &scope_read_seeds, &root_id, SeedFloor::Read).await;
+                evict_seed_past_floor(&floors, &scope_write_seeds, &root_id, SeedFloor::Write)
                     .await;
                 let adopter = RootAdopter::new(
                     &gateway,
@@ -1944,13 +1932,12 @@ impl<T: SeamTypes> Engine<T> {
                 let material = HeldMaterial {
                     node_id: root_id,
                     write_scope_seed: None,
-                    content_cids: Vec::new(),
                 };
                 // A gate-passing `Adopted` repaints the shared base cell and emits
                 // `SnapshotUpdated`; `Current`/`NoUpdate`/`TrustViolation` leave
                 // last-known-good intact (fail-closed for data).
                 sync_status.borrow_mut().reconcile_in_flight = true;
-                let held_resolve = resolve_and_hold(
+                let mut held_resolve = resolve_and_hold(
                     &transport,
                     &snapshot_cache,
                     &adopter,
@@ -1962,25 +1949,23 @@ impl<T: SeamTypes> Engine<T> {
                 // A gate-passing adopt re-surfaces the scope seeds: refresh the
                 // in-memory per-scope cells the child read pipeline and the
                 // drain derive from.
-                let resolved = match held_resolve {
-                    Ok(held_resolve) => {
-                        if let Some(seed) = held_resolve.read_scope_seed {
-                            deposit_read_seed(&floors, &scope_read_seeds, root_id, seed).await;
-                        }
-                        if let Some((node_id, seed)) = held_resolve.write_scope_seed {
-                            deposit_write_seed(
-                                &floors,
-                                &scope_write_seeds,
-                                node_id,
-                                seed,
-                                Some(&root_name),
-                            )
+                if let Ok(surfaced) = &mut held_resolve {
+                    if let Some(seed) = surfaced.read_scope_seed.take() {
+                        deposit_seed(&floors, &scope_read_seeds, root_id, seed, SeedFloor::Read)
                             .await;
-                        }
-                        Ok(held_resolve.resolved)
                     }
-                    Err(err) => Err(err),
-                };
+                    if let Some((node_id, seed)) = surfaced.write_scope_seed.take() {
+                        deposit_write_seed(
+                            &floors,
+                            &scope_write_seeds,
+                            node_id,
+                            seed,
+                            Some(&root_name),
+                        )
+                        .await;
+                    }
+                }
+                let resolved = held_resolve.map(|surfaced| surfaced.resolved);
                 if let Ok(resolved) = &resolved {
                     if let ResolveOutcome::TrustViolation(rejection) = &resolved.outcome {
                         emit_trust_violation(&events, root_name.as_str(), rejection);
@@ -1989,10 +1974,7 @@ impl<T: SeamTypes> Engine<T> {
                         let _ = events.unbounded_send(Event::SnapshotUpdated);
                     }
                 }
-                let read_seed = scope_read_seeds
-                    .borrow()
-                    .get(&root_id)
-                    .map(|cached| cached.seed.clone());
+                let read_seed = cached_seed(&scope_read_seeds, &root_id);
                 // The focus window's folders below the root — the read leg for a
                 // subtree this device did not author. It runs before the drain,
                 // so the queue rebases onto the deepest state this pass
@@ -2023,10 +2005,7 @@ impl<T: SeamTypes> Engine<T> {
                 // gate-passing state this pass just reconciled. Both scope seeds
                 // are required — without them there is no name to publish under
                 // and no key to seal with, so the queue simply waits.
-                let write_seed = scope_write_seeds
-                    .borrow()
-                    .get(&root_id)
-                    .map(|cached| cached.seed.clone());
+                let write_seed = cached_seed(&scope_write_seeds, &root_id);
                 if let (Some(read_seed), Some(write_seed)) = (read_seed, write_seed) {
                     let report = Drain {
                         transport: &transport,
@@ -2202,21 +2181,18 @@ impl<T: SeamTypes> Engine<T> {
         }
     }
 
-    /// The scope's cached read seed, evicted first if the durable epoch floor
-    /// has risen past the one it was recovered under (#1040). Every on-demand
-    /// read goes through here; the resolve tick evicts once per pass instead.
+    /// The scope's cached read seed, evicted first if the durable read-epoch
+    /// floor has risen past the one it was recovered under (#1040). Every
+    /// on-demand read goes through here; the resolve tick evicts once per pass.
     async fn scope_read_seed(&self, scope_id: &[u8; 16]) -> Option<Zeroizing<[u8; 32]>> {
-        evict_seeds_past_floor(
+        evict_seed_past_floor(
             &self.seams.floor_store,
-            scope_id,
             &self.scope_read_seeds,
-            &self.scope_write_seeds,
+            scope_id,
+            SeedFloor::Read,
         )
         .await;
-        self.scope_read_seeds
-            .borrow()
-            .get(scope_id)
-            .map(|cached| cached.seed.clone())
+        cached_seed(&self.scope_read_seeds, scope_id)
     }
 
     /// Refresh the focus window's folders that are past the on-access staleness

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -3913,6 +3913,55 @@ mod tests {
         });
     }
 
+    /// A floor store whose reads fail — the seam-outage arm of
+    /// [`refresh_seed_floor`], which no in-memory fake exercises.
+    struct UnreadableFloors;
+
+    impl FloorStore for UnreadableFloors {
+        async fn epoch_floor(&self, _scope_id: &[u8]) -> SeamResult<Option<u64>> {
+            Err(SeamError::new("floor store unavailable"))
+        }
+
+        async fn raise_epoch_floor(&self, _scope_id: &[u8], _epoch: u64) -> SeamResult<u64> {
+            Err(SeamError::new("floor store unavailable"))
+        }
+
+        async fn sequence_floor(&self, _ipns_name: &[u8]) -> SeamResult<Option<u64>> {
+            Err(SeamError::new("floor store unavailable"))
+        }
+
+        async fn raise_sequence_floor(&self, _ipns_name: &[u8], _sequence: u64) -> SeamResult<u64> {
+            Err(SeamError::new("floor store unavailable"))
+        }
+    }
+
+    /// A floor that cannot be read evicts: a seed whose currency cannot be
+    /// established is dropped, not trusted for the rest of the session (#1040).
+    /// Stamped far above any floor either arm could return, so only the read
+    /// failure can account for the eviction.
+    #[test]
+    fn an_unreadable_floor_evicts_the_cached_seed() {
+        const SCOPE: [u8; 16] = [5u8; 16];
+        let cell = RefCell::new(ScopeSeeds::new());
+        block_on(async {
+            for which in [SeedFloor::Read, SeedFloor::Write] {
+                cell.borrow_mut().insert(
+                    SCOPE,
+                    CachedSeed {
+                        seed: Zeroizing::new([3u8; 32]),
+                        floor: u64::MAX,
+                    },
+                );
+                let stamp = refresh_seed_floor(&UnreadableFloors, &cell, &SCOPE, which).await;
+                assert_eq!(stamp, None, "an unread floor stamps nothing");
+                assert!(
+                    !cell.borrow().contains_key(&SCOPE),
+                    "the seed goes with the floor that could not vouch for it"
+                );
+            }
+        });
+    }
+
     #[test]
     fn stream_slots_are_bounded_and_reusable() {
         let live = Rc::new(Cell::new(0usize));

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -48,7 +48,10 @@ use crate::net::{
 };
 use crate::profile::SyncTimingProfile;
 use crate::rotation::derive_write_name;
-use crate::seams::{OpId, Scheduler, SeamError, SeamSet, SeamTypes, StagingStore, UnixMillis};
+use crate::seams::{
+    FloorStore, OpId, Scheduler, SeamError, SeamResult, SeamSet, SeamTypes, StagingStore,
+    UnixMillis,
+};
 use crate::session::SessionIdentity;
 use crate::storage_policy::StoragePolicy;
 use crate::sync::boot::{ColdStartError, ColdStartOutcome, ColdStartParams, cold_start};
@@ -327,6 +330,53 @@ impl fmt::Debug for LoginSecret {
         f.write_str("LoginSecret(redacted)")
     }
 }
+
+/// Where [`Engine::start`] authenticates and the liveness loop registers
+/// renewals — a non-blank API origin, or the named harness mode that has no API.
+///
+/// The two used to share one `String`, with the empty string standing in for
+/// "there is no API": a host that failed to configure a base got an engine that
+/// silently never logged in (#1032). [`parse`](Self::parse) is the only way to
+/// build a configured base, and the no-API mode is nameable only under the
+/// `test-kit` feature — so a shipped host cannot start unauthenticated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApiBaseUrl(Option<String>);
+
+impl ApiBaseUrl {
+    /// The API origin, trimmed of surrounding whitespace. Blank or
+    /// whitespace-only is refused.
+    pub fn parse(base_url: &str) -> Result<Self, BlankApiBaseUrl> {
+        let trimmed = base_url.trim();
+        if trimmed.is_empty() {
+            return Err(BlankApiBaseUrl);
+        }
+        Ok(Self(Some(trimmed.to_owned())))
+    }
+
+    /// The harness's no-API mode: [`Engine::start`] skips login and the engine
+    /// never authenticates.
+    #[cfg(feature = "test-kit")]
+    pub fn offline() -> Self {
+        Self(None)
+    }
+
+    /// The configured origin, or `None` in offline mode.
+    fn configured(&self) -> Option<&str> {
+        self.0.as_deref()
+    }
+}
+
+/// [`ApiBaseUrl::parse`] refused a blank or whitespace-only base URL.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlankApiBaseUrl;
+
+impl fmt::Display for BlankApiBaseUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("apiBaseUrl is required: the engine must authenticate to the API")
+    }
+}
+
+impl std::error::Error for BlankApiBaseUrl {}
 
 /// Every command a host can issue — the intent ops, grant/rotation/share
 /// actions, auth, and manual refresh (blueprint/engine.md "Facade").
@@ -1064,14 +1114,27 @@ fn surface_drain_report(
 /// drain mint every new node's `ipnsName` and signer from a key that party also
 /// holds. A seed that cannot name our own root is not our scope's — held
 /// keyless, never a trust verdict.
-fn deposit_write_seed(
+///
+/// Stamped with the durable write-epoch floor, exactly as
+/// [`deposit_read_seed`] stamps the read seed.
+async fn deposit_write_seed<F: FloorStore>(
+    floors: &F,
     cell: &RefCell<ScopeWriteSeeds>,
     scope_id: [u8; 16],
     seed: Zeroizing<[u8; 32]>,
     root_name: Option<&IpnsName>,
 ) {
-    if root_name.is_some_and(|name| derive_write_name(&seed, &scope_id) == *name) {
-        cell.borrow_mut().insert(scope_id, seed);
+    if !root_name.is_some_and(|name| derive_write_name(&seed, &scope_id) == *name) {
+        return;
+    }
+    if let Ok(floor) = floor::write_epoch_floor(floors, &scope_id).await {
+        cell.borrow_mut().insert(
+            scope_id,
+            CachedSeed {
+                seed,
+                floor: floor.unwrap_or(0),
+            },
+        );
     }
 }
 
@@ -1101,13 +1164,90 @@ struct SyncStatus {
     reported: Option<Staleness>,
 }
 
+/// A recovered scope seed and the durable epoch floor it was recovered under.
+///
+/// The floor is the seed's expiry: a rotation that raises the scope's floor past
+/// it revokes that epoch, so the seed is evicted rather than left resident for
+/// the rest of the session. Least privilege is a retention rule, not only an
+/// install rule (#795, #1040).
+struct CachedSeed {
+    seed: Zeroizing<[u8; 32]>,
+    floor: u64,
+}
+
 /// The engine's in-memory per-scope read-seed cell: scope id → the recovered
 /// scope read seed (zeroized on removal/drop).
-type ScopeReadSeeds = BTreeMap<[u8; 16], Zeroizing<[u8; 32]>>;
+type ScopeReadSeeds = BTreeMap<[u8; 16], CachedSeed>;
 
 /// The engine's in-memory per-scope write-seed cell: scope id → the recovered
 /// scope write seed (zeroized on removal/drop).
-type ScopeWriteSeeds = BTreeMap<[u8; 16], Zeroizing<[u8; 32]>>;
+type ScopeWriteSeeds = BTreeMap<[u8; 16], CachedSeed>;
+
+/// Drop `scope_id`'s cached read and write seeds once the durable epoch floors
+/// have risen past the floors they were recovered under.
+///
+/// A floor-store read that fails evicts too: without the durable floor the seed
+/// cannot be shown to be unrevoked, and the next gate-passing adopt re-deposits
+/// it. Runs before the tick's own resolve and before every on-demand use of a
+/// cached seed.
+async fn evict_seeds_past_floor<F: FloorStore>(
+    floors: &F,
+    scope_id: &[u8; 16],
+    read_seeds: &RefCell<ScopeReadSeeds>,
+    write_seeds: &RefCell<ScopeWriteSeeds>,
+) {
+    evict_below(
+        read_seeds,
+        scope_id,
+        floor::read_epoch_floor(floors, scope_id).await,
+    );
+    evict_below(
+        write_seeds,
+        scope_id,
+        floor::write_epoch_floor(floors, scope_id).await,
+    );
+}
+
+fn evict_below(
+    seeds: &RefCell<BTreeMap<[u8; 16], CachedSeed>>,
+    scope_id: &[u8; 16],
+    durable: SeamResult<Option<u64>>,
+) {
+    let stale = match durable {
+        Ok(floor) => {
+            let floor = floor.unwrap_or(0);
+            seeds
+                .borrow()
+                .get(scope_id)
+                .is_some_and(|cached| cached.floor < floor)
+        }
+        Err(_) => true,
+    };
+    if stale {
+        seeds.borrow_mut().remove(scope_id);
+    }
+}
+
+/// Deposit a recovered scope read seed, stamped with the durable read-epoch
+/// floor the adopt that surfaced it left behind — the boundary
+/// [`evict_seeds_past_floor`] later evicts it against. A floor-store read that
+/// fails skips the deposit: an unstampable seed would be evicted on sight.
+async fn deposit_read_seed<F: FloorStore>(
+    floors: &F,
+    cell: &RefCell<ScopeReadSeeds>,
+    scope_id: [u8; 16],
+    seed: Zeroizing<[u8; 32]>,
+) {
+    if let Ok(floor) = floor::read_epoch_floor(floors, &scope_id).await {
+        cell.borrow_mut().insert(
+            scope_id,
+            CachedSeed {
+                seed,
+                floor: floor.unwrap_or(0),
+            },
+        );
+    }
+}
 
 /// Retained dead letters: op id → its target node when known (`None` for an
 /// undecodable queue entry, which never decoded far enough to name one) and why
@@ -1176,6 +1316,42 @@ struct LiveWrites {
 struct LiveStream {
     version: Version,
     manifest: RootManifest,
+    /// Released when the last [`Rc`] drops, which an in-flight
+    /// [`read_stream`](Engine::read_stream) can outlive the map entry by.
+    _slot: StreamSlot,
+}
+
+/// One of the [`MAX_OPEN_STREAMS`] slots, reserved before
+/// [`open_content_stream`](Engine::open_content_stream) spends any network and
+/// released when the [`LiveStream`] it lives in drops.
+///
+/// The ceiling bounds *live pinned versions*, not map entries: reserving across
+/// the open's awaits means a doomed open pays no resolve, and releasing on the
+/// last `Rc` means an in-flight read that outlives `close_stream` still counts.
+struct StreamSlot {
+    live: Rc<Cell<usize>>,
+}
+
+impl StreamSlot {
+    /// `None` once the ceiling is met. Single-threaded by construction (the
+    /// facade's `Rc`/`RefCell` state), and the read-modify-write spans no await,
+    /// so the reservation is atomic against every interleaved open.
+    fn acquire(live: &Rc<Cell<usize>>) -> Option<Self> {
+        let count = live.get();
+        if count >= MAX_OPEN_STREAMS {
+            return None;
+        }
+        live.set(count + 1);
+        Some(Self {
+            live: Rc::clone(live),
+        })
+    }
+}
+
+impl Drop for StreamSlot {
+    fn drop(&mut self) {
+        self.live.set(self.live.get() - 1);
+    }
 }
 
 /// How many read streams may be open at once.
@@ -1190,6 +1366,9 @@ pub const MAX_OPEN_STREAMS: usize = 256;
 #[derive(Default)]
 struct LiveStreams {
     open: BTreeMap<StreamHandle, Rc<LiveStream>>,
+    /// Slots reserved, counted outside `open` so a [`StreamSlot`] can release
+    /// itself without re-entering the [`RefCell`] this lives behind.
+    live: Rc<Cell<usize>>,
     next: u64,
 }
 
@@ -1229,8 +1408,8 @@ pub struct Engine<T: SeamTypes> {
     /// The upload-cancel interlock, shared with the drain the tick loop runs.
     cancels: Rc<RefCell<UploadCancels>>,
     /// The API base URL cold start logs in against and the liveness loop
-    /// registers renewals against. Empty is the harness's no-API mode.
-    api_base_url: String,
+    /// registers renewals against.
+    api_base_url: ApiBaseUrl,
     /// The resolved content read-source set, built once from the injected
     /// [`GatewayConfig`] at construction. Empty (dormant) until the host supplies
     /// endpoints; reads then fail closed as [`ReadError`](crate::ReadError)`::Unavailable`.
@@ -1318,7 +1497,7 @@ impl<T: SeamTypes> Engine<T> {
         profile: SyncTimingProfile,
         content_profile: ContentProfile,
         storage_policy: StoragePolicy,
-        api_base_url: String,
+        api_base_url: ApiBaseUrl,
         gateway: GatewayConfig,
     ) -> (Self, EventStream) {
         let (events, receiver) = mpsc::unbounded();
@@ -1398,9 +1577,12 @@ impl<T: SeamTypes> Engine<T> {
         let api = Rc::new(ApiClient::new(
             self.seams.http.clone(),
             self.seams.credential_store.clone(),
-            self.api_base_url.clone(),
+            self.api_base_url
+                .configured()
+                .unwrap_or_default()
+                .to_owned(),
         ));
-        if !self.api_base_url.is_empty() {
+        if self.api_base_url.configured().is_some() {
             let signer = IdentityChallengeSigner::from_signer(session.identity().clone());
             api.login_identity(&signer)
                 .await
@@ -1454,9 +1636,13 @@ impl<T: SeamTypes> Engine<T> {
         // A gate-passing root adopt surfaced the scope read seed: deposit it in
         // the in-memory per-scope cell the child read pipeline derives from.
         if let Some(seed) = outcome.read_scope_seed.take() {
-            self.scope_read_seeds
-                .borrow_mut()
-                .insert(root_scope_id, seed);
+            deposit_read_seed(
+                &self.seams.floor_store,
+                &self.scope_read_seeds,
+                root_scope_id,
+                seed,
+            )
+            .await;
         }
         // The gate-passing base becomes the state law's left operand (reads render
         // this ⊕ the pending-op overlay). The resolved root name — the vault
@@ -1469,7 +1655,14 @@ impl<T: SeamTypes> Engine<T> {
         // The same adopt recovered the scope write seed: the drain derives every
         // new node's `ipnsName` and its narrow per-name signer from it.
         if let Some((scope_id, seed)) = outcome.write_scope_seed.take() {
-            deposit_write_seed(&self.scope_write_seeds, scope_id, seed, root_name.as_ref());
+            deposit_write_seed(
+                &self.seams.floor_store,
+                &self.scope_write_seeds,
+                scope_id,
+                seed,
+                root_name.as_ref(),
+            )
+            .await;
         }
         *self.snapshot.borrow_mut() = outcome.base;
         // A successful cold start is a successful reconcile: stamp it so the
@@ -1723,6 +1916,11 @@ impl<T: SeamTypes> Engine<T> {
                 let Some(enc_subkey) = enc_subkey else {
                     return LivenessControl::Stop;
                 };
+                // Before the steady-state hold consults them: a floor raised
+                // since the last pass revokes the seeds this pass would
+                // otherwise read and seal under (#1040).
+                evict_seeds_past_floor(&floors, &root_id, &scope_read_seeds, &scope_write_seeds)
+                    .await;
                 let adopter = RootAdopter::new(
                     &gateway,
                     &http,
@@ -1752,7 +1950,7 @@ impl<T: SeamTypes> Engine<T> {
                 // `SnapshotUpdated`; `Current`/`NoUpdate`/`TrustViolation` leave
                 // last-known-good intact (fail-closed for data).
                 sync_status.borrow_mut().reconcile_in_flight = true;
-                let resolved = resolve_and_hold(
+                let held_resolve = resolve_and_hold(
                     &transport,
                     &snapshot_cache,
                     &adopter,
@@ -1760,19 +1958,29 @@ impl<T: SeamTypes> Engine<T> {
                     &held,
                     &material,
                 )
-                .await
-                .map(|held_resolve| {
-                    // A gate-passing adopt re-surfaces the scope seeds: refresh
-                    // the in-memory per-scope cells the child read pipeline and
-                    // the drain derive from.
-                    if let Some(seed) = held_resolve.read_scope_seed {
-                        scope_read_seeds.borrow_mut().insert(root_id, seed);
+                .await;
+                // A gate-passing adopt re-surfaces the scope seeds: refresh the
+                // in-memory per-scope cells the child read pipeline and the
+                // drain derive from.
+                let resolved = match held_resolve {
+                    Ok(held_resolve) => {
+                        if let Some(seed) = held_resolve.read_scope_seed {
+                            deposit_read_seed(&floors, &scope_read_seeds, root_id, seed).await;
+                        }
+                        if let Some((node_id, seed)) = held_resolve.write_scope_seed {
+                            deposit_write_seed(
+                                &floors,
+                                &scope_write_seeds,
+                                node_id,
+                                seed,
+                                Some(&root_name),
+                            )
+                            .await;
+                        }
+                        Ok(held_resolve.resolved)
                     }
-                    if let Some((node_id, seed)) = held_resolve.write_scope_seed {
-                        deposit_write_seed(&scope_write_seeds, node_id, seed, Some(&root_name));
-                    }
-                    held_resolve.resolved
-                });
+                    Err(err) => Err(err),
+                };
                 if let Ok(resolved) = &resolved {
                     if let ResolveOutcome::TrustViolation(rejection) = &resolved.outcome {
                         emit_trust_violation(&events, root_name.as_str(), rejection);
@@ -1781,7 +1989,10 @@ impl<T: SeamTypes> Engine<T> {
                         let _ = events.unbounded_send(Event::SnapshotUpdated);
                     }
                 }
-                let read_seed = scope_read_seeds.borrow().get(&root_id).cloned();
+                let read_seed = scope_read_seeds
+                    .borrow()
+                    .get(&root_id)
+                    .map(|cached| cached.seed.clone());
                 // The focus window's folders below the root — the read leg for a
                 // subtree this device did not author. It runs before the drain,
                 // so the queue rebases onto the deepest state this pass
@@ -1812,7 +2023,10 @@ impl<T: SeamTypes> Engine<T> {
                 // gate-passing state this pass just reconciled. Both scope seeds
                 // are required — without them there is no name to publish under
                 // and no key to seal with, so the queue simply waits.
-                let write_seed = scope_write_seeds.borrow().get(&root_id).cloned();
+                let write_seed = scope_write_seeds
+                    .borrow()
+                    .get(&root_id)
+                    .map(|cached| cached.seed.clone());
                 if let (Some(read_seed), Some(write_seed)) = (read_seed, write_seed) {
                     let report = Drain {
                         transport: &transport,
@@ -1988,6 +2202,23 @@ impl<T: SeamTypes> Engine<T> {
         }
     }
 
+    /// The scope's cached read seed, evicted first if the durable epoch floor
+    /// has risen past the one it was recovered under (#1040). Every on-demand
+    /// read goes through here; the resolve tick evicts once per pass instead.
+    async fn scope_read_seed(&self, scope_id: &[u8; 16]) -> Option<Zeroizing<[u8; 32]>> {
+        evict_seeds_past_floor(
+            &self.seams.floor_store,
+            scope_id,
+            &self.scope_read_seeds,
+            &self.scope_write_seeds,
+        )
+        .await;
+        self.scope_read_seeds
+            .borrow()
+            .get(scope_id)
+            .map(|cached| cached.seed.clone())
+    }
+
     /// Refresh the focus window's folders that are past the on-access staleness
     /// threshold, returning whether the base changed.
     async fn refresh_focus_on_access(&self, now: UnixMillis) -> bool {
@@ -2002,7 +2233,7 @@ impl<T: SeamTypes> Engine<T> {
             return false;
         }
         let scope_id = self.snapshot.borrow().root.0;
-        let Some(scope_read_seed) = self.scope_read_seeds.borrow().get(&scope_id).cloned() else {
+        let Some(scope_read_seed) = self.scope_read_seed(&scope_id).await else {
             return false;
         };
         let changed = FolderRefresh {
@@ -2578,26 +2809,26 @@ impl<T: SeamTypes> Engine<T> {
         if !self.started {
             return Err(EngineError::NotStarted);
         }
-        // Refused before the resolve so a caller past the ceiling spends no
-        // network on it; re-checked at the insert, the only borrow that is
-        // atomic against opens which interleaved on the awaits between.
-        if self.streams.borrow().open.len() >= MAX_OPEN_STREAMS {
-            return Err(EngineError::TooManyStreams);
-        }
+        // Reserved before the resolve, so an open past the ceiling spends no
+        // network and no open that reaches the insert can be refused there.
+        let slot =
+            StreamSlot::acquire(&self.streams.borrow().live).ok_or(EngineError::TooManyStreams)?;
         let (version, version_count) = self.head_version(node).await?;
         let manifest = open_content_root(&self.gateway, &self.seams.http, &version)
             .await
             .map_err(open_engine_error)?;
         self.project_head(node, &version, version_count);
         let mut streams = self.streams.borrow_mut();
-        if streams.open.len() >= MAX_OPEN_STREAMS {
-            return Err(EngineError::TooManyStreams);
-        }
         streams.next += 1;
         let handle = StreamHandle(streams.next);
-        streams
-            .open
-            .insert(handle, Rc::new(LiveStream { version, manifest }));
+        streams.open.insert(
+            handle,
+            Rc::new(LiveStream {
+                version,
+                manifest,
+                _slot: slot,
+            }),
+        );
         Ok(handle)
     }
 
@@ -2705,14 +2936,11 @@ impl<T: SeamTypes> Engine<T> {
         let scope_id = self.snapshot.borrow().root.0;
         // No untrusted input was judged here — a missing seed is missing held
         // material (availability), never a trust verdict.
-        let scope_read_seed = self
-            .scope_read_seeds
-            .borrow()
-            .get(&scope_id)
-            .cloned()
-            .ok_or_else(|| EngineError::ContentUnavailable {
+        let scope_read_seed = self.scope_read_seed(&scope_id).await.ok_or_else(|| {
+            EngineError::ContentUnavailable {
                 message: "no read seed held for the node's scope".to_owned(),
-            })?;
+            }
+        })?;
         let adopter = ChildAdopter::new(
             &self.gateway,
             &self.seams.http,
@@ -2924,7 +3152,7 @@ mod tests {
 
     /// An engine over a retained device (so the test scripts HTTP and inspects
     /// the credential store), against `base_url`.
-    fn engine_over(base_url: &str) -> (Engine<FakeSeamTypes>, EventStream, FakeDevice) {
+    fn engine_over(base_url: ApiBaseUrl) -> (Engine<FakeSeamTypes>, EventStream, FakeDevice) {
         let device = FakeWorld::new().device(b"alice-pk");
         let (engine, events) = Engine::new(
             device.seam_set(),
@@ -2932,7 +3160,7 @@ mod tests {
             SyncTimingProfile::CI,
             ContentProfile::CI,
             StoragePolicy::CI,
-            base_url.to_owned(),
+            base_url,
             GatewayConfig::disabled(),
         );
         (engine, events, device)
@@ -2946,7 +3174,7 @@ mod tests {
             SyncTimingProfile::CI,
             ContentProfile::CI,
             StoragePolicy::CI,
-            String::new(),
+            ApiBaseUrl::offline(),
             GatewayConfig::disabled(),
         )
     }
@@ -2963,7 +3191,7 @@ mod tests {
             SyncTimingProfile::CI,
             ContentProfile::CI,
             StoragePolicy::CI,
-            String::new(),
+            ApiBaseUrl::offline(),
             GatewayConfig::disabled(),
         );
         block_on(engine.start(LoginSecret::new(vec![secret_byte; 32]))).unwrap();
@@ -3017,7 +3245,8 @@ mod tests {
 
     #[test]
     fn start_performs_identity_login_and_persists_a_refresh_token() {
-        let (mut engine, _events, device) = engine_over("http://api.test");
+        let (mut engine, _events, device) =
+            engine_over(ApiBaseUrl::parse("http://api.test").expect("a configured base"));
         device.http.enqueue_response(json_response(
             200,
             json!({ "challenge": "cipherbox-login:v2:abc", "expiresAt": "2099-01-01T00:00:00Z" }),
@@ -3051,7 +3280,8 @@ mod tests {
 
     #[test]
     fn start_login_failure_is_fail_closed() {
-        let (mut engine, _events, device) = engine_over("http://api.test");
+        let (mut engine, _events, device) =
+            engine_over(ApiBaseUrl::parse("http://api.test").expect("a configured base"));
         device.http.enqueue_response(json_response(
             200,
             json!({ "challenge": "c", "expiresAt": "2099-01-01T00:00:00Z" }),
@@ -3086,9 +3316,9 @@ mod tests {
 
     #[test]
     fn siwe_login_command_forwards_message_and_hex_signature() {
-        // Empty base: `start` skips cold-start login, so only the SIWE exchange
-        // is scripted here.
-        let (mut engine, _events, device) = engine_over("");
+        // Offline: `start` skips cold-start login, so only the SIWE exchange is
+        // scripted here.
+        let (mut engine, _events, device) = engine_over(ApiBaseUrl::offline());
         block_on(engine.start(LoginSecret::new(vec![7u8; 32]))).unwrap();
         device.http.enqueue_response(json_response(
             200,
@@ -3580,6 +3810,69 @@ mod tests {
         );
     }
 
+    #[test]
+    fn a_blank_api_base_url_is_unrepresentable() {
+        for blank in ["", "   ", "\t\n"] {
+            assert_eq!(
+                ApiBaseUrl::parse(blank),
+                Err(BlankApiBaseUrl),
+                "a blank base is refused: {blank:?}"
+            );
+        }
+        assert_eq!(
+            ApiBaseUrl::parse("  http://api.test  ")
+                .expect("a configured base")
+                .configured(),
+            Some("http://api.test"),
+            "surrounding whitespace is trimmed, not carried into request URLs"
+        );
+    }
+
+    /// The stream ceiling bounds live pinned versions, and an in-flight
+    /// `read_stream` holds its `Rc` past the map removal `close_stream` does —
+    /// so the slot must ride the pin, not the table entry (#1008).
+    #[test]
+    fn a_pinned_stream_holds_its_slot_past_the_map_removal() {
+        let mut streams = LiveStreams::default();
+        let handle = StreamHandle(1);
+        streams.open.insert(
+            handle,
+            Rc::new(LiveStream {
+                version: Version::new(vec![0u8; 36], [0u8; 32], 0, 0),
+                manifest: RootManifest {
+                    chunk_size: 16,
+                    size: 0,
+                    leaf_cids: Vec::new().into_boxed_slice(),
+                },
+                _slot: StreamSlot::acquire(&streams.live).expect("a free slot"),
+            }),
+        );
+
+        let in_flight = streams.open.get(&handle).map(Rc::clone).expect("open");
+        streams.open.remove(&handle);
+        assert_eq!(
+            streams.live.get(),
+            1,
+            "the in-flight read still pins a version and its content key"
+        );
+        drop(in_flight);
+        assert_eq!(streams.live.get(), 0, "the last holder released the slot");
+    }
+
+    #[test]
+    fn stream_slots_are_bounded_and_reusable() {
+        let live = Rc::new(Cell::new(0usize));
+        let held: Vec<StreamSlot> = (0..MAX_OPEN_STREAMS)
+            .map(|open| StreamSlot::acquire(&live).unwrap_or_else(|| panic!("slot {open}")))
+            .collect();
+        assert!(StreamSlot::acquire(&live).is_none(), "the ceiling is met");
+        drop(held);
+        assert!(
+            StreamSlot::acquire(&live).is_some(),
+            "released slots are reusable"
+        );
+    }
+
     // --- snapshot read surface ---
 
     mod snapshot_read {
@@ -3976,7 +4269,7 @@ mod tests {
                 SyncTimingProfile::CI,
                 ContentProfile::CI,
                 StoragePolicy::CI,
-                String::new(),
+                ApiBaseUrl::offline(),
                 GatewayConfig::disabled(),
             );
             block_on(engine.start(LoginSecret::new(SECRET.to_vec()))).unwrap();
@@ -4145,7 +4438,7 @@ mod tests {
                 SyncTimingProfile::CI,
                 ContentProfile::CI,
                 StoragePolicy::CI,
-                String::new(),
+                ApiBaseUrl::offline(),
                 GatewayConfig::disabled(),
             );
             assert!(engine.session().is_none(), "no identity before start");
@@ -4498,7 +4791,7 @@ mod tests {
                 SyncTimingProfile::CI,
                 ContentProfile::CI,
                 StoragePolicy::CI,
-                String::new(),
+                ApiBaseUrl::offline(),
                 gateway_config(),
             )
         }
@@ -4651,7 +4944,11 @@ mod tests {
             let record = held.get(&ROOT.0).expect("held under the root node id");
             assert_eq!(record.routing_key, root_name.as_str());
             assert_eq!(
-                engine.scope_read_seeds.borrow().get(&SCOPE).map(|s| **s),
+                engine
+                    .scope_read_seeds
+                    .borrow()
+                    .get(&SCOPE)
+                    .map(|s| *s.seed),
                 Some(SCOPE_SEED),
                 "the tick adopt deposited the recovered scope read seed"
             );
@@ -4802,9 +5099,125 @@ mod tests {
                 "the next poll left the hold alone"
             );
             assert_eq!(
-                engine.scope_write_seeds.borrow().get(&SCOPE).map(|s| **s),
+                engine
+                    .scope_write_seeds
+                    .borrow()
+                    .get(&SCOPE)
+                    .map(|s| *s.seed),
                 Some(WRITE_SCOPE_SEED),
                 "and the material recovered once stays in hand"
+            );
+        }
+
+        /// The drain is the only source of a head's content CIDs, so a re-hold
+        /// that carries none must keep the set the publish registered (#1041).
+        #[test]
+        fn a_re_hold_keeps_the_content_cids_the_publish_registered() {
+            let world = FakeWorld::new();
+            let device = world.device(b"alice-pk");
+            let (_, head_cid, root_name) = owner_root();
+            let (engine, _events, mut tasks) = started_and_parked(&world, &device);
+            tick(&world, &device, &mut tasks);
+
+            let published = vec!["bafypublished".to_owned()];
+            let before = {
+                let mut held = engine.held_records.borrow_mut();
+                let record = held.get_mut(&ROOT.0).expect("held under the root node id");
+                record.content_cids.clone_from(&published);
+                record.record_bytes.clone()
+            };
+
+            // A strictly newer record over the same head: an `Adopted` poll,
+            // which rebuilds the hold wholesale rather than skipping it.
+            let reseed = |sequence| {
+                for endpoint in device.record_store.endpoints() {
+                    device.record_store.seed_record(
+                        &endpoint,
+                        root_name.as_str(),
+                        root_record(&head_cid, sequence),
+                    );
+                }
+            };
+            reseed(2);
+            tick(&world, &device, &mut tasks);
+            let held = engine.held_records.borrow();
+            assert_ne!(
+                held[&ROOT.0].record_bytes, before,
+                "the poll really did re-hold, so the assertion below is not vacuous"
+            );
+            assert_eq!(
+                held[&ROOT.0].content_cids, published,
+                "the re-hold carried the published set forward"
+            );
+            drop(held);
+
+            // Stamped against a head this device did not author: that block set
+            // is superseded, so it must not ride the new head's renewal.
+            engine
+                .held_records
+                .borrow_mut()
+                .get_mut(&ROOT.0)
+                .expect("held under the root node id")
+                .head_cid = "bafyotherhead".to_owned();
+            reseed(3);
+            tick(&world, &device, &mut tasks);
+            assert!(
+                engine.held_records.borrow()[&ROOT.0]
+                    .content_cids
+                    .is_empty(),
+                "CIDs held for a different head are dropped, not carried over"
+            );
+        }
+
+        /// A rotation that raises the scope's durable read-epoch floor revokes
+        /// the epoch the cached seed was recovered under, so the seed goes —
+        /// least privilege binds retention, not only install (#1040).
+        #[test]
+        fn a_read_epoch_floor_rise_evicts_the_cached_scope_read_seed() {
+            let world = FakeWorld::new();
+            let device = world.device(b"alice-pk");
+            let (engine, _events, mut tasks) = started_and_parked(&world, &device);
+            tick(&world, &device, &mut tasks);
+            assert!(engine.scope_read_seeds.borrow().contains_key(&SCOPE));
+
+            block_on(device.floor_store.raise_epoch_floor(&SCOPE, EPOCH + 1)).unwrap();
+            tick(&world, &device, &mut tasks);
+
+            assert!(
+                !engine.scope_read_seeds.borrow().contains_key(&SCOPE),
+                "the seed recovered below the new floor is evicted"
+            );
+            assert!(
+                engine.scope_write_seeds.borrow().contains_key(&SCOPE),
+                "the write-epoch floor is a separate clock and did not move"
+            );
+        }
+
+        /// The write-epoch floor is the same rule on the seed the drain mints
+        /// every new node's name and signer from.
+        #[test]
+        fn a_write_epoch_floor_rise_evicts_the_cached_scope_write_seed() {
+            let world = FakeWorld::new();
+            let device = world.device(b"alice-pk");
+            let (engine, _events, mut tasks) = started_and_parked(&world, &device);
+            tick(&world, &device, &mut tasks);
+            assert!(engine.scope_write_seeds.borrow().contains_key(&SCOPE));
+
+            block_on(floor::advance_write_epoch_on_sight(
+                &device.floor_store,
+                &SCOPE,
+                EPOCH + 1,
+            ))
+            .unwrap();
+            tick(&world, &device, &mut tasks);
+
+            assert!(
+                !engine.scope_write_seeds.borrow().contains_key(&SCOPE),
+                "the seed recovered below the new write floor is evicted"
+            );
+            assert!(
+                engine.scope_read_seeds.borrow().contains_key(&SCOPE),
+                "and the read seed, whose floor did not move, stays"
             );
         }
 

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -56,10 +56,10 @@ pub use content::{
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{
-    BlockProgress, Breadcrumb, Command, DeadLetter, Engine, EngineError, EngineView, Event,
-    EventStream, LoginSecret, MAX_OPEN_STREAMS, NodeAttrs, NodeId, NodeKind, OpPhase,
-    OverBudgetCause, Permission, SnapshotChild, SnapshotView, Staleness, StatFs, StreamHandle,
-    WriteHandle, WriteTarget,
+    ApiBaseUrl, BlankApiBaseUrl, BlockProgress, Breadcrumb, Command, DeadLetter, Engine,
+    EngineError, EngineView, Event, EventStream, LoginSecret, MAX_OPEN_STREAMS, NodeAttrs, NodeId,
+    NodeKind, OpPhase, OverBudgetCause, Permission, SnapshotChild, SnapshotView, Staleness, StatFs,
+    StreamHandle, WriteHandle, WriteTarget,
 };
 pub use gate::{
     Adopted, Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason,

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -275,10 +275,6 @@ pub(crate) struct HeldMaterial {
     /// instead (a write grantee). An insert-time derivation input, never
     /// persisted in the held set.
     pub write_scope_seed: Option<Zeroizing<[u8; 32]>>,
-    /// The content CIDs to re-register/pin at renewal. Empty from a caller that
-    /// has none of its own — a re-hold then keeps the set already held for this
-    /// head rather than clobbering it (see [`resolve_and_hold`]).
-    pub content_cids: Vec<String>,
 }
 
 /// What [`resolve_and_hold`] produced: the public resolve result plus the
@@ -363,19 +359,16 @@ where
             return Ok(done(resolved));
         }
         let mut held = held.borrow_mut();
-        // The drain is the only source of a head's content CIDs; the resolve
-        // tick re-holds the same head with none, so carry the held set forward
-        // rather than wipe what a publish registered (#1041). Bound to the head
-        // CID: a head this device did not author has a different block set, and
-        // re-pinning the superseded one would keep dead content alive.
-        let content_cids = if material.content_cids.is_empty() {
-            held.get(&node_id)
-                .filter(|prior| prior.head_cid == head_cid)
-                .map(|prior| prior.content_cids.clone())
-                .unwrap_or_default()
-        } else {
-            material.content_cids.clone()
-        };
+        // The drain registers a head's content CIDs when it publishes and is
+        // their only source, so a re-hold carries the held set forward rather
+        // than wiping it (#1041). Bound to the head CID: a head this device did
+        // not author lists a different block set, and re-pinning the superseded
+        // one would keep dead content alive.
+        let content_cids = held
+            .remove(&node_id)
+            .filter(|prior| prior.head_cid == head_cid)
+            .map(|prior| prior.content_cids)
+            .unwrap_or_default();
         held.insert(
             node_id,
             HeldRecord {
@@ -423,7 +416,7 @@ mod tests {
 
     use super::super::eol;
     use crate::gate::{Adopted, GateError, GateRejection, GateStage, RejectionReason};
-    use crate::net::HeldRecords;
+    use crate::net::{HeldRecord, HeldRecords};
     use crate::seams::{RecordTransport, UnixMillis};
     use crate::session::SessionIdentity;
     use crate::testkit::{FakeWorld, block_on};
@@ -554,7 +547,6 @@ mod tests {
         let material = HeldMaterial {
             node_id,
             write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
-            content_cids: vec!["bafycontent".into()],
         };
         let resolved = block_on(resolve_and_hold(
             &device.record_store,
@@ -572,11 +564,71 @@ mod tests {
         assert_eq!(map.len(), 1, "the adopted record is held, keyed by node id");
         let record = map.get(&node_id).expect("held under its node id");
         assert_eq!(record.routing_key, name.as_str());
-        assert_eq!(record.content_cids, vec!["bafycontent".to_owned()]);
+        assert!(
+            record.content_cids.is_empty(),
+            "a first hold registers nothing; the drain supplies the CIDs"
+        );
         // The held signer signs for the routing key (the insert-time bind).
         assert_eq!(
             IpnsName::from_public_key(&record.signer.verifying_key()),
             name
+        );
+    }
+
+    /// The drain registers a head's content CIDs; a re-hold of that same head
+    /// must carry them, and a re-hold under a different head must not (#1041).
+    #[test]
+    fn a_re_hold_carries_the_content_cids_held_for_the_same_head() {
+        let world = FakeWorld::new();
+        let device = world.device(b"me");
+        let write_scope_seed = [9u8; 32];
+        let node_id = [7u8; 16];
+        let signer = SessionIdentity::write_name_signer(&write_scope_seed, &node_id);
+        let name = IpnsName::from_public_key(&signer.verifying_key());
+        let endpoints = world.record_store.endpoints();
+        world
+            .record_store
+            .seed_record(&endpoints[0], name.as_str(), record(&signer, 1));
+        let material = HeldMaterial {
+            node_id,
+            write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
+        };
+
+        let registered = vec!["bafyleaf".to_owned()];
+        let re_hold = |head_cid: &str| {
+            let held: RefCell<HeldRecords> = RefCell::new(HeldRecords::new());
+            held.borrow_mut().insert(
+                node_id,
+                HeldRecord {
+                    routing_key: name.as_str().to_owned(),
+                    record_bytes: Vec::new(),
+                    signer: SessionIdentity::write_name_signer(&write_scope_seed, &node_id),
+                    head_cid: head_cid.to_owned(),
+                    content_cids: registered.clone(),
+                },
+            );
+            block_on(resolve_and_hold(
+                &device.record_store,
+                &device.snapshot_cache,
+                &StubAdopter::new(Verdict::Accept),
+                &name,
+                &held,
+                &material,
+            ))
+            .expect("resolve_and_hold");
+            held.borrow()[&node_id].content_cids.clone()
+        };
+
+        // `VALUE` is `/ipfs/<head>`, so this is the head the re-hold adopts.
+        let same_head = core::str::from_utf8(&VALUE[b"/ipfs/".len()..]).unwrap();
+        assert_eq!(
+            re_hold(same_head),
+            registered,
+            "the publish's CIDs survive a re-hold of the same head"
+        );
+        assert!(
+            re_hold("bafyotherhead").is_empty(),
+            "CIDs registered for another head name a superseded block set"
         );
     }
 
@@ -593,7 +645,6 @@ mod tests {
         let material = HeldMaterial {
             node_id: [1u8; 16],
             write_scope_seed: Some(Zeroizing::new([0u8; 32])),
-            content_cids: Vec::new(),
         };
 
         // A fail-closed trust violation is never held.
@@ -632,7 +683,6 @@ mod tests {
         let material = HeldMaterial {
             node_id,
             write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
-            content_cids: Vec::new(),
         };
         let resolved = block_on(resolve_and_hold(
             &device.record_store,
@@ -696,7 +746,6 @@ mod tests {
         let material = HeldMaterial {
             node_id: [0u8; 16],
             write_scope_seed: None,
-            content_cids: Vec::new(),
         };
         let resolved = block_on(resolve_and_hold(
             &device.record_store,
@@ -778,7 +827,6 @@ mod tests {
         let material = HeldMaterial {
             node_id: [0u8; 16],
             write_scope_seed: None,
-            content_cids: Vec::new(),
         };
         let resolved = block_on(resolve_and_hold(
             &device.record_store,
@@ -829,7 +877,6 @@ mod tests {
         let material = HeldMaterial {
             node_id: [0u8; 16],
             write_scope_seed: None,
-            content_cids: Vec::new(),
         };
         block_on(resolve_and_hold(
             &device.record_store,
@@ -908,7 +955,6 @@ mod tests {
         let material = HeldMaterial {
             node_id,
             write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
-            content_cids: Vec::new(),
         };
         block_on(resolve_and_hold(
             &device.record_store,
@@ -958,7 +1004,6 @@ mod tests {
         let material = HeldMaterial {
             node_id,
             write_scope_seed: Some(Zeroizing::new(write_scope_seed)),
-            content_cids: Vec::new(),
         };
         block_on(resolve_and_hold(
             &device.record_store,

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -275,7 +275,9 @@ pub(crate) struct HeldMaterial {
     /// instead (a write grantee). An insert-time derivation input, never
     /// persisted in the held set.
     pub write_scope_seed: Option<Zeroizing<[u8; 32]>>,
-    /// The content CIDs to re-register/pin at renewal.
+    /// The content CIDs to re-register/pin at renewal. Empty from a caller that
+    /// has none of its own — a re-hold then keeps the set already held for this
+    /// head rather than clobbering it (see [`resolve_and_hold`]).
     pub content_cids: Vec<String>,
 }
 
@@ -360,16 +362,28 @@ where
         if IpnsName::from_public_key(&signer.verifying_key()) != *name {
             return Ok(done(resolved));
         }
-        // Content re-pin on renewal is a deferred slice; the record still
-        // republishes validly under its head CID (only re-pinning is deferred).
-        held.borrow_mut().insert(
+        let mut held = held.borrow_mut();
+        // The drain is the only source of a head's content CIDs; the resolve
+        // tick re-holds the same head with none, so carry the held set forward
+        // rather than wipe what a publish registered (#1041). Bound to the head
+        // CID: a head this device did not author has a different block set, and
+        // re-pinning the superseded one would keep dead content alive.
+        let content_cids = if material.content_cids.is_empty() {
+            held.get(&node_id)
+                .filter(|prior| prior.head_cid == head_cid)
+                .map(|prior| prior.content_cids.clone())
+                .unwrap_or_default()
+        } else {
+            material.content_cids.clone()
+        };
+        held.insert(
             node_id,
             HeldRecord {
                 routing_key: name.as_str().to_owned(),
                 record_bytes,
                 signer,
                 head_cid,
-                content_cids: material.content_cids.clone(),
+                content_cids,
             },
         );
     }

--- a/crates/engine/src/net/resolve.rs
+++ b/crates/engine/src/net/resolve.rs
@@ -359,11 +359,8 @@ where
             return Ok(done(resolved));
         }
         let mut held = held.borrow_mut();
-        // The drain registers a head's content CIDs when it publishes and is
-        // their only source, so a re-hold carries the held set forward rather
-        // than wiping it (#1041). Bound to the head CID: a head this device did
-        // not author lists a different block set, and re-pinning the superseded
-        // one would keep dead content alive.
+        // The drain is the only source of a head's held content CIDs, so a
+        // re-hold carries the set forward rather than wiping it (#1041).
         let content_cids = held
             .remove(&node_id)
             .filter(|prior| prior.head_cid == head_cid)

--- a/crates/engine/src/sync/staging.rs
+++ b/crates/engine/src/sync/staging.rs
@@ -104,7 +104,7 @@ pub(crate) async fn version_leaf_cids<S: StagingStore>(store: &S, root_cid: &[u8
         return Vec::new();
     }
     decode_root(&block)
-        .map(|m| m.leaf_cids.iter().map(|cid| cid.to_vec()).collect())
+        .map(|m| m.leaf_cid_vecs())
         .unwrap_or_default()
 }
 
@@ -345,7 +345,7 @@ pub async fn orphan_staging_keys<S: StagingStore>(
             let Ok(manifest) = decode_root(&block) else {
                 return Ok(Vec::new());
             };
-            referenced.extend(manifest.leaf_cids.iter().map(|cid| cid.to_vec()));
+            referenced.extend(manifest.leaf_cid_vecs());
         }
         referenced.insert(root);
     }

--- a/crates/engine/src/sync/staging.rs
+++ b/crates/engine/src/sync/staging.rs
@@ -103,7 +103,9 @@ pub(crate) async fn version_leaf_cids<S: StagingStore>(store: &S, root_cid: &[u8
     if verify_cid(root_cid, &block).is_err() {
         return Vec::new();
     }
-    decode_root(&block).map(|m| m.leaf_cids).unwrap_or_default()
+    decode_root(&block)
+        .map(|m| m.leaf_cids.iter().map(|cid| cid.to_vec()).collect())
+        .unwrap_or_default()
 }
 
 /// Keep one dead letter's op record after it leaves the durable queue, so orphan
@@ -343,7 +345,7 @@ pub async fn orphan_staging_keys<S: StagingStore>(
             let Ok(manifest) = decode_root(&block) else {
                 return Ok(Vec::new());
             };
-            referenced.extend(manifest.leaf_cids);
+            referenced.extend(manifest.leaf_cids.iter().map(|cid| cid.to_vec()));
         }
         referenced.insert(root);
     }

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -5,8 +5,8 @@ use cipherbox_engine::net::RE_PUT_INTERVAL;
 use cipherbox_engine::seams::{HttpResponse, Scheduler, UnixMillis};
 use cipherbox_engine::testkit::{FakeDevice, FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
 use cipherbox_engine::{
-    Command, ContentProfile, Engine, EngineError, EventStream, GatewayConfig, LoginSecret, NodeId,
-    Permission, StoragePolicy, SyncTimingProfile,
+    ApiBaseUrl, Command, ContentProfile, Engine, EngineError, EventStream, GatewayConfig,
+    LoginSecret, NodeId, Permission, StoragePolicy, SyncTimingProfile,
 };
 
 fn new_engine(device: &FakeDevice) -> (Engine<FakeSeamTypes>, EventStream) {
@@ -16,7 +16,7 @@ fn new_engine(device: &FakeDevice) -> (Engine<FakeSeamTypes>, EventStream) {
         SyncTimingProfile::CI,
         ContentProfile::CI,
         StoragePolicy::CI,
-        String::new(),
+        ApiBaseUrl::offline(),
         GatewayConfig::disabled(),
     )
 }

--- a/crates/engine/tests/kat_content.rs
+++ b/crates/engine/tests/kat_content.rs
@@ -286,7 +286,7 @@ fn accept_vectors_reproduce_the_frozen_root_bytes() {
             .unwrap_or_else(|e| panic!("{}: own root must decode, got {e:?}", v.name));
         assert_eq!(decoded.chunk_size, v.chunk_size, "{}: chunk size", v.name);
         assert_eq!(decoded.size, v.size, "{}: size", v.name);
-        let links: Vec<Vec<u8>> = decoded.leaf_cids.iter().map(|cid| cid.to_vec()).collect();
+        let links = decoded.leaf_cid_vecs();
         assert_eq!(links, leaf_cids, "{}: link order", v.name);
     }
 }

--- a/crates/engine/tests/kat_content.rs
+++ b/crates/engine/tests/kat_content.rs
@@ -286,7 +286,8 @@ fn accept_vectors_reproduce_the_frozen_root_bytes() {
             .unwrap_or_else(|e| panic!("{}: own root must decode, got {e:?}", v.name));
         assert_eq!(decoded.chunk_size, v.chunk_size, "{}: chunk size", v.name);
         assert_eq!(decoded.size, v.size, "{}: size", v.name);
-        assert_eq!(decoded.leaf_cids, leaf_cids, "{}: link order", v.name);
+        let links: Vec<Vec<u8>> = decoded.leaf_cids.iter().map(|cid| cid.to_vec()).collect();
+        assert_eq!(links, leaf_cids, "{}: link order", v.name);
     }
 }
 

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -42,9 +42,9 @@ use cipherbox_engine::testkit::{
     OwnerRootSpec, SeededEntropy, block_on, frame_version as frame, owner_root_fixture,
 };
 use cipherbox_engine::{
-    BlockProgress, Command, ContentProfile, DeadLetter, DeadLetterReason, Engine, EngineError,
-    Event, EventStream, GatewayConfig, LoginSecret, MAX_OPEN_STREAMS, NodeId, NodeKind, Op,
-    OpPhase, RecordSeal, StoragePolicy, SyncTimingProfile, WriteTarget, stage_op,
+    ApiBaseUrl, BlockProgress, Command, ContentProfile, DeadLetter, DeadLetterReason, Engine,
+    EngineError, Event, EventStream, GatewayConfig, LoginSecret, MAX_OPEN_STREAMS, NodeId,
+    NodeKind, Op, OpPhase, RecordSeal, StoragePolicy, SyncTimingProfile, WriteTarget, stage_op,
 };
 
 const SECRET: [u8; 32] = [7u8; 32];
@@ -361,9 +361,9 @@ fn engine_on(device: &FakeDevice, entropy_seed: u64) -> (Engine<FakeSeamTypes>, 
         SyncTimingProfile::CI,
         ContentProfile::CI,
         StoragePolicy::CI,
-        // The API base URL is empty, so `start` skips login: this suite exercises
-        // the record plane, not the auth handshake.
-        String::new(),
+        // Offline: `start` skips login, because this suite exercises the record
+        // plane, not the auth handshake.
+        ApiBaseUrl::offline(),
         GatewayConfig {
             accelerator: Some(GatewaySource {
                 base_url: "https://gw.test".into(),
@@ -999,7 +999,8 @@ fn a_stream_window_serves_the_same_bytes_as_the_slice_of_the_whole_file() {
 }
 
 /// Past [`MAX_OPEN_STREAMS`] an open is refused fail-closed, never evicting a
-/// live stream.
+/// live stream, and the refusal costs no network: the slot is reserved before
+/// the resolve, so a doomed open never pays for one (#1008).
 #[test]
 fn opening_past_the_stream_ceiling_is_refused() {
     let world = FakeWorld::new();
@@ -1009,7 +1010,7 @@ fn opening_past_the_stream_ceiling_is_refused() {
 
     let (_engine_a, _events_a, _tasks, node) = publish_clip(&world, &blocks, &plaintext);
     // A few calls per open, plus the reads below.
-    let (_bob, engine_b, _events_b) = open_reader(&world, &blocks, MAX_OPEN_STREAMS * 8 + 64);
+    let (bob, engine_b, _events_b) = open_reader(&world, &blocks, MAX_OPEN_STREAMS * 8 + 64);
 
     let handles: Vec<_> = (0..MAX_OPEN_STREAMS)
         .map(|open| {
@@ -1018,10 +1019,16 @@ fn opening_past_the_stream_ceiling_is_refused() {
         })
         .collect();
 
+    let fetches_at_ceiling = bob.http.requests().len();
     assert_eq!(
         block_on(engine_b.open_content_stream(node)),
         Err(EngineError::TooManyStreams),
         "the open past the ceiling is refused"
+    );
+    assert_eq!(
+        bob.http.requests().len(),
+        fetches_at_ceiling,
+        "the refused open spent no network on a resolve it could not use"
     );
 
     // The refusal did not evict: an earlier handle still serves its version.
@@ -1637,7 +1644,12 @@ fn staged_version(device: &FakeDevice) -> (Vec<u8>, Vec<Vec<u8>>) {
             .await
             .unwrap()
             .unwrap();
-        let leaves = decode_root(&root_block).unwrap().leaf_cids;
+        let leaves = decode_root(&root_block)
+            .unwrap()
+            .leaf_cids
+            .iter()
+            .map(|cid| cid.to_vec())
+            .collect();
         (root_cid, leaves)
     })
 }
@@ -4015,8 +4027,9 @@ fn queued_version(device: &FakeDevice, op_id: OpId) -> Vec<Vec<u8>> {
             .await
             .unwrap()
             .unwrap();
+        let leaves = decode_root(&root_block).unwrap().leaf_cids;
         core::iter::once(root_cid)
-            .chain(decode_root(&root_block).unwrap().leaf_cids)
+            .chain(leaves.iter().map(|cid| cid.to_vec()))
             .collect()
     })
 }
@@ -5023,9 +5036,9 @@ fn stage_a_second_version(
             .await
             .unwrap()
             .unwrap();
-        core::iter::once(&root_cid)
-            .chain(&decode_root(&root_block).unwrap().leaf_cids)
-            .map(|cid| encode_content_cid_str(cid))
+        let leaves = decode_root(&root_block).unwrap().leaf_cids;
+        core::iter::once(encode_content_cid_str(&root_cid))
+            .chain(leaves.iter().map(|cid| encode_content_cid_str(cid)))
             .collect()
     });
     (engine, tasks, version)

--- a/crates/fuse/tests/fuse_op_core.rs
+++ b/crates/fuse/tests/fuse_op_core.rs
@@ -13,8 +13,8 @@ use std::task::{Context, Poll, Waker};
 use cipherbox_engine::testkit::fakes::InMemoryStagingStore;
 use cipherbox_engine::testkit::{FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
 use cipherbox_engine::{
-    Command, ContentProfile, Engine, GatewayConfig, LoginSecret, NodeId, NodeKind, StoragePolicy,
-    SyncTimingProfile,
+    ApiBaseUrl, Command, ContentProfile, Engine, GatewayConfig, LoginSecret, NodeId, NodeKind,
+    StoragePolicy, SyncTimingProfile,
 };
 use cipherbox_fuse::{
     Access, HostAdapter, HostCapabilities, Invalidation, MAX_NAME_BYTES, NameError, OperationCore,
@@ -82,7 +82,7 @@ fn started_engine_with_staging() -> (Engine<FakeSeamTypes>, NodeId, InMemoryStag
         SyncTimingProfile::CI,
         ContentProfile::CI,
         StoragePolicy::CI,
-        String::new(),
+        ApiBaseUrl::offline(),
         GatewayConfig::disabled(),
     );
     block_on(engine.start(LoginSecret::new(vec![7u8; 32]))).expect("engine starts");

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -18,7 +18,7 @@
 use std::rc::Rc;
 
 use async_lock::{Mutex, RwLock};
-use cipherbox_engine::facade::{Engine, EngineError, EventStream, LoginSecret};
+use cipherbox_engine::facade::{ApiBaseUrl, Engine, EngineError, EventStream, LoginSecret};
 use cipherbox_engine::seams::OpId;
 use cipherbox_engine::{
     ContentProfile, Entropy, EntropyError, GatewayConfig, GatewaySource, SeamSet, SeamTypes,
@@ -109,12 +109,7 @@ impl EngineHandle {
         // Rust-owned bearer String unzeroized (security rule 7).
         let accelerator_bearer = accelerator_bearer.map(Zeroizing::new);
 
-        let api_base_url = api_base_url
-            .map(|url| url.trim().to_owned())
-            .filter(|url| !url.is_empty())
-            .ok_or_else(|| {
-                JsError::new("apiBaseUrl is required: the engine must authenticate to the API")
-            })?;
+        let api_base_url = ApiBaseUrl::parse(api_base_url.as_deref().unwrap_or_default())?;
 
         let seam_set = SeamSet::<WebSeamTypes> {
             floor_store: FloorStoreAdapter {


### PR DESCRIPTION
Five engine hygiene fixes over the facade and its record/content plane.

Closes #1008
Closes #1009
Closes #1040
Closes #1032
Closes #1041

## What changed

**#1008 — a stream slot is reserved across the open and held for in-flight reads.** `StreamSlot` is an RAII lease over an `Rc<Cell<usize>>` taken before `open_content_stream` spends any network and released when the last `Rc<LiveStream>` drops. Two consequences: an open past the ceiling pays no resolve and no root fetch, and the ceiling now bounds *live pinned versions* rather than map entries, so a read still in flight past `close_stream` counts against it. The counter lives outside the `RefCell` because `close_stream` drops the `Rc` while holding `borrow_mut`. The redundant second ceiling check at the insert is gone — a reserved open cannot be refused there.

**#1009 — `RootManifest.leaf_cids` is `Box<[LeafCid]>`.** One allocation per open stream instead of one per MiB of file, and the fixed 36-byte leaf width becomes a type-level fact: `decode_root` gates it with `LeafCid::try_from`, which maps a wrong width to the same `dag-malformed-leaf-cid` verdict the old length check produced. Three consumers still keyed on `Vec<u8>` widen back through one `RootManifest::leaf_cid_vecs` adapter; pushing the type past them needs `sync/drain.rs`, which a concurrent PR owned this round — filed as #1059, blocked by #1009.

**#1040 — a cached scope seed is evicted when its epoch is revoked.** Each seed carries a stamp at or below the epoch it belongs to, and is dropped once the scope's durable floor rises past it. The stamp comes from provenance, never from a floor read taken after the recovery: an adopt names its own record's `epoch`, cold start takes the owner-vouched re-point's `minReadEpoch`/`writeEpoch`, and an equal-floor `Current` recovery takes the floor read *before* the resolve — which every recovery arm refuses to go below. A floor read that fails evicts and deposits nothing. The eviction runs at the top of each resolve tick and on every on-demand read, so the floor check is a retention guard and not only an install guard.

**#1032 — a blank API base is unrepresentable.** `ApiBaseUrl::parse` is the only way to build a configured base and rejects blank or whitespace-only; the no-API mode is `ApiBaseUrl::offline()`, nameable only under the `test-kit` feature, so no shipped host can bring up an engine that never authenticates. `start` asks once instead of sniffing an empty string. The browser host's own guard is now that one check.

**#1041 — a re-hold keeps the content CIDs a publish registered.** `resolve_and_hold` carries the held set forward instead of overwriting it with the empty one the resolve tick supplies, bound to head-CID equality so a head this device did not author never inherits a superseded block set. `HeldMaterial.content_cids` is deleted rather than kept as an empty-vec sentinel — the drain writes the held record directly and no caller ever supplied one.

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` all run on `git diff main...HEAD`; findings folded back in and the gates re-run.

The crypto gate found the substantive one: the #1040 stamp was originally a floor read taken *after* the resolve, so a rise landing mid-pass would have been absorbed into the stamp and left the revoked epoch's seed resident and sealable under until the next rise. Latent rather than live — `Command::RotateNow` is still unimplemented and nothing else calls `rotate`/`cascade` — but wrong by construction, so it is fixed by construction. The simplify gate collapsed the two seed cells onto one map with a `SeedFloor` selector, retired the dead `HeldMaterial` field, and de-duplicated the manifest widening. The security gate also asked for `shut_down` to release the open-stream table, since each entry pins a content key; that is in.

Two hardenings are deferred with dependency edges: #1059 (push `LeafCid` past the manifest) and #1060 (require an absolute origin in `ApiBaseUrl`, not merely a non-blank string).

## Gates

- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo check --workspace --all-targets` clean
- `cargo test --workspace` green, 36 suites
- `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` clean

`crates/core` is untouched, so the wasm32-wasip1 core run does not apply.

## Outside the owned file set

`crates/wasm/src/host.rs` and `crates/fuse/tests/fuse_op_core.rs` take the minimal `ApiBaseUrl` adapter change the #1032 signature change forces. `crates/engine/src/content/mod.rs` and `crates/engine/src/sync/staging.rs` take the two-line manifest-widening adapters #1009 forces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validated API base URL configuration, including clear errors for missing or blank URLs.
  * Improved offline operation and stream-limit handling, including accurate tracking of active streams.
  * Enhanced recovery behavior by preserving valid content references and removing revoked or outdated records.

* **Bug Fixes**
  * Strengthened content-link validation to reject malformed or incorrectly sized identifiers.
  * Improved synchronization and content handling for decoded manifest links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hold a stream slot before network calls and evict revoked scope seeds on floor rise
> - `StreamSlot::acquire` now reserves a stream slot before any network work in `open_content_stream`, and the slot is held inside `LiveStream` until all `Rc` references drop — preventing the ceiling from being bypassed by in-flight reads.
> - Cached scope seeds (`ScopeSeeds`) are now paired with a floor stamp (`CachedSeed`) and evicted automatically when the durable floor rises or is unreadable, using a new `refresh_seed_floors` pass at the start of each liveness tick.
> - `ApiBaseUrl` is introduced as a validated newtype replacing the raw `String` for the API base; blank or whitespace-only URLs are rejected at parse time with `BlankApiBaseUrl`.
> - `RootManifest` stores leaf CIDs as `Box<[LeafCid]>` (fixed-width `[u8; CONTENT_CID_LEN]`), and `decode_root` now rejects links that are not exactly the right width with `DagError::MalformedLeafCid`.
> - Risk: `open_content_stream` now returns `TooManyStreams` before any resolve or network work; reads may fail with `ContentUnavailable` when the cached read seed has been revoked by a floor rise.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e3183f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->