### PR TITLE
feat: wire web file upload through the facade write handles

### DIFF
--- a/apps/web/src/components/file-browser/FileBrowser.tsx
+++ b/apps/web/src/components/file-browser/FileBrowser.tsx
@@ -1,19 +1,14 @@
-import { isActiveUpload, useDropUpload } from '../../hooks/useDropUpload';
 import { useFolderNavigation } from '../../vault/useFolderNavigation';
 import { Breadcrumbs } from './Breadcrumbs';
 import { EmptyState } from './EmptyState';
 import { FileList } from './FileList';
-import { UploadListItem } from './UploadListItem';
-import { UploadZone } from './UploadZone';
+import { UploadPanel } from './UploadPanel';
 
 /** The vault browser: where you are, what is in it, and how to move. */
 export function FileBrowser() {
-  const { rows, breadcrumbs, isLoading, isRoot, error, navigateTo, navigateUp } =
+  const { rows, folder, breadcrumbs, isLoading, isRoot, error, navigateTo, navigateUp } =
     useFolderNavigation();
-  const { uploads, upload, cancel, retry, dismiss } = useDropUpload();
   const settled = !isLoading && error === null;
-  // The trail ends at the folder on screen, which is where a drop lands.
-  const folder = breadcrumbs.at(-1)?.id ?? null;
 
   return (
     <div className="file-browser" data-testid="file-browser">
@@ -28,25 +23,7 @@ export function FileBrowser() {
           {'// LOADING VAULT...'}
         </p>
       )}
-      {folder !== null && (
-        <UploadZone
-          onFiles={(files) => upload(files, folder)}
-          busy={uploads.some((entry) => isActiveUpload(entry.phase))}
-        />
-      )}
-      {uploads.length > 0 && (
-        <div className="upload-list" role="list" data-testid="upload-list">
-          {uploads.map((entry) => (
-            <UploadListItem
-              key={entry.id}
-              upload={entry}
-              onCancel={cancel}
-              onRetry={retry}
-              onDismiss={dismiss}
-            />
-          ))}
-        </div>
-      )}
+      {folder !== null && <UploadPanel folder={folder} />}
       {/* An empty non-root folder still lists, so `[..]` remains reachable. */}
       {settled && (rows.length > 0 || !isRoot) && (
         <FileList

--- a/apps/web/src/components/file-browser/FileBrowser.tsx
+++ b/apps/web/src/components/file-browser/FileBrowser.tsx
@@ -23,7 +23,9 @@ export function FileBrowser() {
           {'// LOADING VAULT...'}
         </p>
       )}
-      {folder !== null && <UploadPanel folder={folder} />}
+      {/* Mounted whatever the route says, so a running upload survives a folder
+          change; only its drop target waits for a folder that can take one. */}
+      <UploadPanel folder={settled ? folder : null} />
       {/* An empty non-root folder still lists, so `[..]` remains reachable. */}
       {settled && (rows.length > 0 || !isRoot) && (
         <FileList

--- a/apps/web/src/components/file-browser/FileBrowser.tsx
+++ b/apps/web/src/components/file-browser/FileBrowser.tsx
@@ -1,13 +1,19 @@
+import { isActiveUpload, useDropUpload } from '../../hooks/useDropUpload';
 import { useFolderNavigation } from '../../vault/useFolderNavigation';
 import { Breadcrumbs } from './Breadcrumbs';
 import { EmptyState } from './EmptyState';
 import { FileList } from './FileList';
+import { UploadListItem } from './UploadListItem';
+import { UploadZone } from './UploadZone';
 
 /** The vault browser: where you are, what is in it, and how to move. */
 export function FileBrowser() {
   const { rows, breadcrumbs, isLoading, isRoot, error, navigateTo, navigateUp } =
     useFolderNavigation();
+  const { uploads, upload, cancel, retry, dismiss } = useDropUpload();
   const settled = !isLoading && error === null;
+  // The trail ends at the folder on screen, which is where a drop lands.
+  const folder = breadcrumbs.at(-1)?.id ?? null;
 
   return (
     <div className="file-browser" data-testid="file-browser">
@@ -21,6 +27,25 @@ export function FileBrowser() {
         <p className="file-browser-loading" data-testid="file-browser-loading">
           {'// LOADING VAULT...'}
         </p>
+      )}
+      {folder !== null && (
+        <UploadZone
+          onFiles={(files) => upload(files, folder)}
+          busy={uploads.some((entry) => isActiveUpload(entry.phase))}
+        />
+      )}
+      {uploads.length > 0 && (
+        <div className="upload-list" role="list" data-testid="upload-list">
+          {uploads.map((entry) => (
+            <UploadListItem
+              key={entry.id}
+              upload={entry}
+              onCancel={cancel}
+              onRetry={retry}
+              onDismiss={dismiss}
+            />
+          ))}
+        </div>
       )}
       {/* An empty non-root folder still lists, so `[..]` remains reachable. */}
       {settled && (rows.length > 0 || !isRoot) && (

--- a/apps/web/src/components/file-browser/UploadListItem.test.tsx
+++ b/apps/web/src/components/file-browser/UploadListItem.test.tsx
@@ -32,12 +32,20 @@ describe('an upload row', () => {
     expect(screen.getByTestId('upload-row-status').textContent).toBe('50%');
   });
 
-  it('stays indeterminate while the engine has no block count to give', () => {
+  it('shimmers only while the client is feeding the engine', () => {
     show(entry({ phase: 'staging' }));
 
     const bar = screen.getByRole('progressbar');
     expect(bar.getAttribute('aria-valuenow')).toBeNull();
     expect(bar.className).toContain('upload-row-track--indeterminate');
+  });
+
+  it('leaves a queued row still, because nothing is moving yet', () => {
+    show(entry({ phase: 'queued', opId: 1n }));
+
+    const bar = screen.getByRole('progressbar');
+    expect(bar.getAttribute('aria-valuetext')).toBe('queued');
+    expect(bar.className).not.toContain('upload-row-track--indeterminate');
   });
 
   it('offers cancel while the engine still has work', () => {
@@ -53,7 +61,7 @@ describe('an upload row', () => {
     const handlers = show(entry({ phase: 'failed', error: 'no reachable pin provider' }));
 
     fireEvent.click(screen.getByLabelText('Retry upload of report.pdf'));
-    fireEvent.click(screen.getByLabelText('Dismiss failed upload of report.pdf'));
+    fireEvent.click(screen.getByLabelText('Dismiss upload of report.pdf'));
 
     expect(handlers.onRetry).toHaveBeenCalledWith('upload-1');
     expect(handlers.onDismiss).toHaveBeenCalledWith('upload-1');
@@ -61,7 +69,16 @@ describe('an upload row', () => {
     expect(screen.getByRole('alert').textContent).toBe('no reachable pin provider');
   });
 
-  it('marks an over-budget refusal apart from a terminal failure', () => {
+  it('lets a cancelled row be cleared, so none can strand its file', () => {
+    const handlers = show(entry({ phase: 'cancelled', opId: 1n }));
+
+    fireEvent.click(screen.getByLabelText('Dismiss upload of report.pdf'));
+
+    expect(handlers.onDismiss).toHaveBeenCalledWith('upload-1');
+    expect(screen.queryByLabelText('Cancel upload of report.pdf')).toBeNull();
+  });
+
+  it('marks an over-budget refusal apart from a failure that will never clear', () => {
     show(
       entry({
         phase: 'failed',
@@ -70,6 +87,17 @@ describe('an upload row', () => {
       })
     );
 
-    expect(screen.getByTestId('upload-row-error').className).toContain('upload-row-error--budget');
+    expect(screen.getByTestId('upload-row-error').className).toContain(
+      'upload-row-error--transient'
+    );
+  });
+
+  it('marks a stopped attempt as retryable, not settled', () => {
+    show(entry({ phase: 'stalled', opId: 1n, error: 'no reachable pin provider' }));
+
+    expect(screen.getByTestId('upload-row-error').className).toContain(
+      'upload-row-error--transient'
+    );
+    expect(screen.getByTestId('upload-row-error').getAttribute('role')).toBeNull();
   });
 });

--- a/apps/web/src/components/file-browser/UploadListItem.test.tsx
+++ b/apps/web/src/components/file-browser/UploadListItem.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { UploadEntry } from '../../hooks/useDropUpload';
+import { UploadListItem } from './UploadListItem';
+
+function entry(overrides: Partial<UploadEntry> = {}): UploadEntry {
+  return {
+    id: 'upload-1',
+    name: 'report.pdf',
+    size: 2048,
+    phase: 'staging',
+    progress: 0,
+    opId: null,
+    error: null,
+    code: null,
+    ...overrides,
+  };
+}
+
+function show(upload: UploadEntry) {
+  const handlers = { onCancel: vi.fn(), onRetry: vi.fn(), onDismiss: vi.fn() };
+  render(<UploadListItem upload={upload} {...handlers} />);
+  return handlers;
+}
+
+describe('an upload row', () => {
+  it('quotes the confirmed fraction once the drain reports blocks', () => {
+    show(entry({ phase: 'uploading', progress: 0.5, opId: 1n }));
+
+    const bar = screen.getByRole('progressbar');
+    expect(bar.getAttribute('aria-valuenow')).toBe('50');
+    expect(screen.getByTestId('upload-row-status').textContent).toBe('50%');
+  });
+
+  it('stays indeterminate while the engine has no block count to give', () => {
+    show(entry({ phase: 'staging' }));
+
+    const bar = screen.getByRole('progressbar');
+    expect(bar.getAttribute('aria-valuenow')).toBeNull();
+    expect(bar.className).toContain('upload-row-track--indeterminate');
+  });
+
+  it('offers cancel while the engine still has work', () => {
+    const handlers = show(entry({ phase: 'uploading', opId: 1n }));
+
+    fireEvent.click(screen.getByLabelText('Cancel upload of report.pdf'));
+
+    expect(handlers.onCancel).toHaveBeenCalledWith('upload-1');
+    expect(screen.queryByLabelText('Retry upload of report.pdf')).toBeNull();
+  });
+
+  it('offers retry and dismiss once a row has failed for good', () => {
+    const handlers = show(entry({ phase: 'failed', error: 'no reachable pin provider' }));
+
+    fireEvent.click(screen.getByLabelText('Retry upload of report.pdf'));
+    fireEvent.click(screen.getByLabelText('Dismiss failed upload of report.pdf'));
+
+    expect(handlers.onRetry).toHaveBeenCalledWith('upload-1');
+    expect(handlers.onDismiss).toHaveBeenCalledWith('upload-1');
+    expect(screen.queryByRole('progressbar')).toBeNull();
+    expect(screen.getByRole('alert').textContent).toBe('no reachable pin provider');
+  });
+
+  it('marks an over-budget refusal apart from a terminal failure', () => {
+    show(
+      entry({
+        phase: 'failed',
+        code: 'overBudget',
+        error: 'this write needs 900 bytes but only 100 are free',
+      })
+    );
+
+    expect(screen.getByTestId('upload-row-error').className).toContain('upload-row-error--budget');
+  });
+});

--- a/apps/web/src/components/file-browser/UploadListItem.tsx
+++ b/apps/web/src/components/file-browser/UploadListItem.tsx
@@ -21,9 +21,9 @@ const LABELS: Record<UploadPhase, string> = {
 /** One in-flight upload, in the columns the listing below it uses. */
 export function UploadListItem({ upload, onCancel, onRetry, onDismiss }: UploadListItemProps) {
   const { id, name, phase, error } = upload;
-  const measured = phase === 'uploading' || phase === 'uploaded';
   const percent = Math.round(upload.progress * 100);
   const settled = !isActiveUpload(phase);
+  const measured = phase === 'uploading';
   // Only the row the client is actually feeding animates; a queued or retrying
   // one has nothing moving to report.
   const indeterminate = phase === 'staging';

--- a/apps/web/src/components/file-browser/UploadListItem.tsx
+++ b/apps/web/src/components/file-browser/UploadListItem.tsx
@@ -1,0 +1,107 @@
+import { isActiveUpload, type UploadEntry, type UploadPhase } from '../../hooks/useDropUpload';
+import { formatBytes } from '../../utils/format';
+
+interface UploadListItemProps {
+  upload: UploadEntry;
+  onCancel: (id: string) => void;
+  onRetry: (id: string) => void;
+  onDismiss: (id: string) => void;
+}
+
+/** The phases whose bar can quote a fraction; the rest are indeterminate. */
+const MEASURED: readonly UploadPhase[] = ['uploading', 'uploaded'];
+
+const LABELS: Record<UploadPhase, string> = {
+  staging: 'sealing',
+  queued: 'queued',
+  uploading: 'uploading',
+  uploaded: 'done',
+  stalled: 'retrying',
+  cancelled: 'cancelled',
+  failed: 'failed',
+};
+
+/** One in-flight upload, in the columns the listing below it uses. */
+export function UploadListItem({ upload, onCancel, onRetry, onDismiss }: UploadListItemProps) {
+  const { id, name, phase, error } = upload;
+  const measured = MEASURED.includes(phase);
+  const percent = Math.round(upload.progress * 100);
+  const settled = !isActiveUpload(phase);
+
+  return (
+    <div
+      className={`file-list-item upload-row upload-row--${phase}`}
+      data-testid="upload-row"
+      data-phase={phase}
+      role="listitem"
+    >
+      <div className="file-list-item-row-top">
+        <span className="file-list-item-icon" aria-hidden="true">
+          {phase === 'failed' ? '[!]' : '[^]'}
+        </span>
+        <div className="upload-row-name">
+          <span className="file-list-item-name">{name}</span>
+          {!settled && (
+            <div
+              className={`upload-row-track${measured ? '' : ' upload-row-track--indeterminate'}`}
+              role="progressbar"
+              aria-label={`Upload progress for ${name}`}
+              {...(measured
+                ? { 'aria-valuenow': percent, 'aria-valuemin': 0, 'aria-valuemax': 100 }
+                : { 'aria-valuetext': LABELS[phase] })}
+            >
+              <div className="upload-row-fill" style={{ width: `${measured ? percent : 0}%` }} />
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="file-list-item-row-bottom">
+        <span className="file-list-item-size">{formatBytes(upload.size)}</span>
+        <span className="file-list-item-date upload-row-actions">
+          <span className="upload-row-status" data-testid="upload-row-status">
+            {phase === 'uploading' ? `${percent}%` : LABELS[phase]}
+          </span>
+          {isActiveUpload(phase) && (
+            <button
+              type="button"
+              className="upload-row-button"
+              aria-label={`Cancel upload of ${name}`}
+              onClick={() => onCancel(id)}
+            >
+              [x]
+            </button>
+          )}
+          {phase === 'failed' && (
+            <>
+              <button
+                type="button"
+                className="upload-row-button upload-row-button--retry"
+                aria-label={`Retry upload of ${name}`}
+                onClick={() => onRetry(id)}
+              >
+                [r]
+              </button>
+              <button
+                type="button"
+                className="upload-row-button"
+                aria-label={`Dismiss failed upload of ${name}`}
+                onClick={() => onDismiss(id)}
+              >
+                [x]
+              </button>
+            </>
+          )}
+        </span>
+      </div>
+      {error !== null && (
+        <p
+          className={`upload-row-error${upload.code === 'overBudget' ? ' upload-row-error--budget' : ''}`}
+          data-testid="upload-row-error"
+          role={phase === 'failed' ? 'alert' : undefined}
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/file-browser/UploadListItem.tsx
+++ b/apps/web/src/components/file-browser/UploadListItem.tsx
@@ -8,9 +8,6 @@ interface UploadListItemProps {
   onDismiss: (id: string) => void;
 }
 
-/** The phases whose bar can quote a fraction; the rest are indeterminate. */
-const MEASURED: readonly UploadPhase[] = ['uploading', 'uploaded'];
-
 const LABELS: Record<UploadPhase, string> = {
   staging: 'sealing',
   queued: 'queued',
@@ -24,9 +21,15 @@ const LABELS: Record<UploadPhase, string> = {
 /** One in-flight upload, in the columns the listing below it uses. */
 export function UploadListItem({ upload, onCancel, onRetry, onDismiss }: UploadListItemProps) {
   const { id, name, phase, error } = upload;
-  const measured = MEASURED.includes(phase);
+  const measured = phase === 'uploading' || phase === 'uploaded';
   const percent = Math.round(upload.progress * 100);
   const settled = !isActiveUpload(phase);
+  // Only the row the client is actually feeding animates; a queued or retrying
+  // one has nothing moving to report.
+  const indeterminate = phase === 'staging';
+  // An over-budget refusal is a ceiling and a stopped attempt is retried, so
+  // neither reads as the settled red of a row that will never publish.
+  const transient = phase === 'stalled' || upload.code === 'overBudget';
 
   return (
     <div
@@ -43,7 +46,7 @@ export function UploadListItem({ upload, onCancel, onRetry, onDismiss }: UploadL
           <span className="file-list-item-name">{name}</span>
           {!settled && (
             <div
-              className={`upload-row-track${measured ? '' : ' upload-row-track--indeterminate'}`}
+              className={`upload-row-track${indeterminate ? ' upload-row-track--indeterminate' : ''}`}
               role="progressbar"
               aria-label={`Upload progress for ${name}`}
               {...(measured
@@ -61,7 +64,7 @@ export function UploadListItem({ upload, onCancel, onRetry, onDismiss }: UploadL
           <span className="upload-row-status" data-testid="upload-row-status">
             {phase === 'uploading' ? `${percent}%` : LABELS[phase]}
           </span>
-          {isActiveUpload(phase) && (
+          {!settled && (
             <button
               type="button"
               className="upload-row-button"
@@ -71,20 +74,23 @@ export function UploadListItem({ upload, onCancel, onRetry, onDismiss }: UploadL
               [x]
             </button>
           )}
-          {phase === 'failed' && (
+          {settled && (
             <>
-              <button
-                type="button"
-                className="upload-row-button upload-row-button--retry"
-                aria-label={`Retry upload of ${name}`}
-                onClick={() => onRetry(id)}
-              >
-                [r]
-              </button>
+              {phase !== 'uploaded' && (
+                <button
+                  type="button"
+                  className="upload-row-button upload-row-button--retry"
+                  aria-label={`Retry upload of ${name}`}
+                  onClick={() => onRetry(id)}
+                >
+                  [r]
+                </button>
+              )}
+              {/* Every settled row is clearable, so none can strand its `File`. */}
               <button
                 type="button"
                 className="upload-row-button"
-                aria-label={`Dismiss failed upload of ${name}`}
+                aria-label={`Dismiss upload of ${name}`}
                 onClick={() => onDismiss(id)}
               >
                 [x]
@@ -95,7 +101,7 @@ export function UploadListItem({ upload, onCancel, onRetry, onDismiss }: UploadL
       </div>
       {error !== null && (
         <p
-          className={`upload-row-error${upload.code === 'overBudget' ? ' upload-row-error--budget' : ''}`}
+          className={`upload-row-error${transient ? ' upload-row-error--transient' : ''}`}
           data-testid="upload-row-error"
           role={phase === 'failed' ? 'alert' : undefined}
         >

--- a/apps/web/src/components/file-browser/UploadPanel.test.tsx
+++ b/apps/web/src/components/file-browser/UploadPanel.test.tsx
@@ -1,0 +1,93 @@
+import type { EngineClient, EventDescriptor } from '@cipherbox/client';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { EngineProvider } from '../../providers/EngineProvider';
+import { UploadPanel } from './UploadPanel';
+
+const FOLDER = new Uint8Array(16).fill(7);
+
+/** The write-handle surface `useDropUpload` drives, held open at the commit. */
+function uploadEngine() {
+  let settle = () => undefined as void;
+  const facade = {
+    subscribe: (_listener: (event: EventDescriptor) => void) => () => undefined,
+    snapshot: () => new Promise<never>(() => undefined),
+    setFocus: () => Promise.resolve(),
+    beginWrite: vi.fn(() => Promise.resolve(1n)),
+    pushChunk: vi.fn(() => Promise.resolve()),
+    commitWrite: vi.fn(
+      () =>
+        new Promise<bigint>((resolve) => {
+          settle = () => resolve(1n);
+        })
+    ),
+    abortWrite: vi.fn(() => Promise.resolve()),
+    cancelUpload: vi.fn(() => Promise.resolve()),
+  };
+  const client = {
+    facade,
+    reportFocus: () => undefined,
+    dispose: () => Promise.resolve(),
+  } as unknown as EngineClient;
+  return { client, facade, settle: () => settle() };
+}
+
+function draw(client: EngineClient, folder: Uint8Array | null) {
+  return render(
+    <EngineProvider createClient={() => client}>
+      <UploadPanel folder={folder} />
+    </EngineProvider>
+  );
+}
+
+describe('the upload panel', () => {
+  it('offers no drop target when no folder can take one', () => {
+    draw(uploadEngine().client, null);
+    expect(screen.queryByTestId('upload-zone')).toBeNull();
+  });
+
+  it('keeps a running upload on screen across a folder change', async () => {
+    const engine = uploadEngine();
+    const { rerender } = draw(engine.client, FOLDER);
+
+    fireEvent.change(screen.getByLabelText('Choose files to upload'), {
+      target: { files: [new File(['x'], 'notes.txt')] },
+    });
+    await waitFor(() => expect(screen.getByTestId('upload-row')).toBeTruthy());
+
+    // The next folder's snapshot has not landed, so there is nowhere to drop.
+    rerender(
+      <EngineProvider createClient={() => engine.client}>
+        <UploadPanel folder={null} />
+      </EngineProvider>
+    );
+
+    expect(screen.queryByTestId('upload-zone')).toBeNull();
+    expect(screen.getByTestId('upload-row')).toBeTruthy();
+    expect(screen.getByLabelText('Cancel upload of notes.txt')).toBeTruthy();
+    // The write kept its handle rather than being torn down with the zone.
+    expect(engine.facade.abortWrite).not.toHaveBeenCalled();
+    await act(async () => {
+      engine.settle();
+    });
+  });
+
+  it('drops files into the folder on screen', async () => {
+    const engine = uploadEngine();
+    draw(engine.client, FOLDER);
+
+    fireEvent.drop(screen.getByTestId('upload-zone'), {
+      dataTransfer: { files: [new File(['x'], 'notes.txt')], types: ['Files'], dropEffect: 'none' },
+    });
+
+    await waitFor(() =>
+      expect(engine.facade.beginWrite).toHaveBeenCalledWith(
+        { parent: FOLDER, name: 'notes.txt' },
+        1
+      )
+    );
+    await act(async () => {
+      engine.settle();
+    });
+  });
+});

--- a/apps/web/src/components/file-browser/UploadPanel.tsx
+++ b/apps/web/src/components/file-browser/UploadPanel.tsx
@@ -3,23 +3,27 @@ import { UploadListItem } from './UploadListItem';
 import { UploadZone } from './UploadZone';
 
 interface UploadPanelProps {
-  /** Where a drop lands: the folder on screen. */
-  folder: Uint8Array;
+  /** Where a drop lands, or `null` when nothing on screen can take one. */
+  folder: Uint8Array | null;
 }
 
 /**
- * The upload surface for one folder. It owns the upload rows so a block-confirmed
- * event repaints them alone, not the listing underneath.
+ * The upload surface. It owns the upload rows so a block-confirmed event
+ * repaints them alone, not the listing underneath, and it outlives a folder
+ * change so a running upload keeps its row, its controls, and its subscription
+ * to the engine's reports — only the drop target follows the folder.
  */
 export function UploadPanel({ folder }: UploadPanelProps) {
   const { uploads, upload, cancel, retry, dismiss } = useDropUpload();
 
   return (
     <>
-      <UploadZone
-        onFiles={(files) => upload(files, folder)}
-        busy={uploads.some((entry) => isActiveUpload(entry.phase))}
-      />
+      {folder !== null && (
+        <UploadZone
+          onFiles={(files) => upload(files, folder)}
+          busy={uploads.some((entry) => isActiveUpload(entry.phase))}
+        />
+      )}
       {uploads.length > 0 && (
         <div className="upload-list" role="list" data-testid="upload-list">
           {uploads.map((entry) => (

--- a/apps/web/src/components/file-browser/UploadPanel.tsx
+++ b/apps/web/src/components/file-browser/UploadPanel.tsx
@@ -1,0 +1,38 @@
+import { isActiveUpload, useDropUpload } from '../../hooks/useDropUpload';
+import { UploadListItem } from './UploadListItem';
+import { UploadZone } from './UploadZone';
+
+interface UploadPanelProps {
+  /** Where a drop lands: the folder on screen. */
+  folder: Uint8Array;
+}
+
+/**
+ * The upload surface for one folder. It owns the upload rows so a block-confirmed
+ * event repaints them alone, not the listing underneath.
+ */
+export function UploadPanel({ folder }: UploadPanelProps) {
+  const { uploads, upload, cancel, retry, dismiss } = useDropUpload();
+
+  return (
+    <>
+      <UploadZone
+        onFiles={(files) => upload(files, folder)}
+        busy={uploads.some((entry) => isActiveUpload(entry.phase))}
+      />
+      {uploads.length > 0 && (
+        <div className="upload-list" role="list" data-testid="upload-list">
+          {uploads.map((entry) => (
+            <UploadListItem
+              key={entry.id}
+              upload={entry}
+              onCancel={cancel}
+              onRetry={retry}
+              onDismiss={dismiss}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/file-browser/UploadZone.test.tsx
+++ b/apps/web/src/components/file-browser/UploadZone.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { UploadZone } from './UploadZone';
+
+const dropped = (files: File[]) => ({
+  dataTransfer: { files, types: ['Files'], dropEffect: 'none' },
+});
+
+describe('the upload drop zone', () => {
+  it('hands dropped files to its caller', () => {
+    const onFiles = vi.fn();
+    render(<UploadZone onFiles={onFiles} busy={false} />);
+    const zone = screen.getByTestId('upload-zone');
+    const file = new File(['x'], 'notes.txt');
+
+    fireEvent.drop(zone, dropped([file]));
+
+    expect(onFiles).toHaveBeenCalledWith([file]);
+  });
+
+  it('ignores a drag that carries no files', () => {
+    const onFiles = vi.fn();
+    render(<UploadZone onFiles={onFiles} busy={false} />);
+    const zone = screen.getByTestId('upload-zone');
+
+    fireEvent.dragEnter(zone, { dataTransfer: { files: [], types: ['text/plain'] } });
+    expect(zone.className).not.toContain('upload-zone--dragging');
+
+    fireEvent.drop(zone, { dataTransfer: { files: [], types: ['text/plain'] } });
+    expect(onFiles).not.toHaveBeenCalled();
+  });
+
+  it('highlights only while the drag is still over the zone', () => {
+    render(<UploadZone onFiles={vi.fn()} busy={false} />);
+    const zone = screen.getByTestId('upload-zone');
+
+    fireEvent.dragEnter(zone, dropped([]));
+    // Crossing a child fires enter/leave pairs the highlight must survive.
+    fireEvent.dragEnter(zone, dropped([]));
+    fireEvent.dragLeave(zone);
+    expect(zone.className).toContain('upload-zone--dragging');
+
+    fireEvent.dragLeave(zone);
+    expect(zone.className).not.toContain('upload-zone--dragging');
+  });
+
+  it('hands picked files over and clears the picker so the same file can repeat', () => {
+    const onFiles = vi.fn();
+    render(<UploadZone onFiles={onFiles} busy={false} />);
+    const picker = screen.getByLabelText('Choose files to upload') as HTMLInputElement;
+    const file = new File(['x'], 'notes.txt');
+
+    fireEvent.change(picker, { target: { files: [file] } });
+
+    expect(onFiles).toHaveBeenCalledWith([file]);
+    expect(picker.value).toBe('');
+  });
+
+  it('says so while an upload is running', () => {
+    render(<UploadZone onFiles={vi.fn()} busy />);
+    expect(screen.getByTestId('upload-zone-pick').textContent).toContain('UPLOADING');
+  });
+});

--- a/apps/web/src/components/file-browser/UploadZone.tsx
+++ b/apps/web/src/components/file-browser/UploadZone.tsx
@@ -1,0 +1,86 @@
+import { useRef, useState, type DragEvent } from 'react';
+
+interface UploadZoneProps {
+  /** Handed the dropped or picked files; never called with an empty list. */
+  onFiles: (files: File[]) => void;
+  /** True while the engine still has an upload in hand. */
+  busy: boolean;
+}
+
+/** Whether a drag carries files from outside the page rather than a page value. */
+function carriesFiles(transfer: DataTransfer): boolean {
+  return Array.from(transfer.types).includes('Files');
+}
+
+/** Where files enter the vault: a drop target that doubles as a file picker. */
+export function UploadZone({ onFiles, busy }: UploadZoneProps) {
+  const [dragging, setDragging] = useState(false);
+  // `dragleave` fires for every child the pointer crosses, so a boolean alone
+  // would clear the highlight while the drag is still over the zone.
+  const depth = useRef(0);
+  const picker = useRef<HTMLInputElement>(null);
+
+  const enter = (event: DragEvent<HTMLDivElement>) => {
+    if (!carriesFiles(event.dataTransfer)) return;
+    depth.current += 1;
+    setDragging(true);
+  };
+
+  const leave = () => {
+    depth.current = Math.max(depth.current - 1, 0);
+    if (depth.current === 0) setDragging(false);
+  };
+
+  const over = (event: DragEvent<HTMLDivElement>) => {
+    if (!carriesFiles(event.dataTransfer)) return;
+    // Without this the browser navigates to the dropped file instead.
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+  };
+
+  const drop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    depth.current = 0;
+    setDragging(false);
+    const files = Array.from(event.dataTransfer.files);
+    if (files.length > 0) onFiles(files);
+  };
+
+  return (
+    <div
+      className={`upload-zone${dragging ? ' upload-zone--dragging' : ''}`}
+      data-testid="upload-zone"
+      onDragEnter={enter}
+      onDragOver={over}
+      onDragLeave={leave}
+      onDrop={drop}
+    >
+      <button
+        type="button"
+        className="upload-zone-button"
+        data-testid="upload-zone-pick"
+        onClick={() => picker.current?.click()}
+      >
+        <span className="upload-zone-icon" aria-hidden="true">
+          [^]
+        </span>
+        <span className="upload-zone-text">
+          {dragging ? '// DROP TO UPLOAD' : busy ? '// UPLOADING...' : '// UPLOAD FILES'}
+        </span>
+      </button>
+      <input
+        ref={picker}
+        className="upload-zone-input"
+        type="file"
+        multiple
+        aria-label="Choose files to upload"
+        onChange={(event) => {
+          const files = Array.from(event.target.files ?? []);
+          // Cleared so picking the same file twice in a row still fires.
+          event.target.value = '';
+          if (files.length > 0) onFiles(files);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/file-browser/UploadZone.tsx
+++ b/apps/web/src/components/file-browser/UploadZone.tsx
@@ -15,8 +15,7 @@ function carriesFiles(transfer: DataTransfer): boolean {
 /** Where files enter the vault: a drop target that doubles as a file picker. */
 export function UploadZone({ onFiles, busy }: UploadZoneProps) {
   const [dragging, setDragging] = useState(false);
-  // `dragleave` fires for every child the pointer crosses, so a boolean alone
-  // would clear the highlight while the drag is still over the zone.
+  // `dragleave` fires for every child the pointer crosses.
   const depth = useRef(0);
   const picker = useRef<HTMLInputElement>(null);
 

--- a/apps/web/src/hooks/useDropUpload.test.tsx
+++ b/apps/web/src/hooks/useDropUpload.test.tsx
@@ -258,6 +258,37 @@ describe('reporting what the engine says about the op', () => {
     });
     expect(result.current.uploads).toHaveLength(0);
   });
+
+  it('keeps a row a dead letter overtook, rather than sweeping it on the old timer', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const engine = uploadEngine();
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+    await waitFor(() => expect(result.current.uploads[0].opId).toBe(1n));
+
+    act(() =>
+      engine.emit({
+        kind: 'opProgress',
+        opId: 1n,
+        node: new Uint8Array(16),
+        phase: 'uploadCompleted',
+        blocksConfirmed: 2,
+        blocksTotal: 2,
+        error: null,
+      })
+    );
+    // The record still has to publish, so a dead letter can follow the blocks.
+    act(() => engine.emit({ kind: 'deadLetter', opId: 1n, reason: 'targetGone' }));
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.uploads).toHaveLength(1);
+    expect(result.current.uploads[0].phase).toBe('failed');
+  });
 });
 
 describe('cancelling', () => {
@@ -309,6 +340,35 @@ describe('cancelling', () => {
       })
     );
     expect(result.current.uploads[0].phase).toBe('cancelled');
+  });
+
+  it('retires a row the engine cancelled, rather than stranding it', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const engine = uploadEngine();
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+    await waitFor(() => expect(result.current.uploads[0].opId).toBe(1n));
+
+    act(() => result.current.cancel(result.current.uploads[0].id));
+    act(() =>
+      engine.emit({
+        kind: 'opProgress',
+        opId: 1n,
+        node: new Uint8Array(16),
+        phase: 'uploadCancelled',
+        blocksConfirmed: null,
+        blocksTotal: null,
+        error: null,
+      })
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.uploads).toHaveLength(0);
   });
 
   it('shows a refused cancel without moving the row off the upload', async () => {

--- a/apps/web/src/hooks/useDropUpload.test.tsx
+++ b/apps/web/src/hooks/useDropUpload.test.tsx
@@ -371,6 +371,44 @@ describe('cancelling', () => {
     expect(result.current.uploads).toHaveLength(0);
   });
 
+  it('keeps a retried row that the cancel retirement timer would have swept', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const engine = uploadEngine();
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+    await waitFor(() => expect(result.current.uploads[0].opId).toBe(1n));
+
+    act(() => result.current.cancel(result.current.uploads[0].id));
+    act(() =>
+      engine.emit({
+        kind: 'opProgress',
+        opId: 1n,
+        node: new Uint8Array(16),
+        phase: 'uploadCancelled',
+        blocksConfirmed: null,
+        blocksTotal: null,
+        error: null,
+      })
+    );
+    expect(result.current.uploads[0].phase).toBe('cancelled');
+
+    // The retry button is on screen for the whole retirement window.
+    await act(async () => {
+      result.current.retry(result.current.uploads[0].id);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.uploads).toHaveLength(1);
+    expect(result.current.uploads[0].phase).toBe('queued');
+    expect(result.current.uploads[0].opId).toBe(2n);
+    expect(engine.facade.commitWrite).toHaveBeenCalledTimes(2);
+  });
+
   it('shows a refused cancel without moving the row off the upload', async () => {
     const engine = uploadEngine();
     engine.facade.cancelUpload.mockRejectedValueOnce(

--- a/apps/web/src/hooks/useDropUpload.test.tsx
+++ b/apps/web/src/hooks/useDropUpload.test.tsx
@@ -1,0 +1,401 @@
+import type { ReactNode } from 'react';
+import { EngineRequestError } from '@cipherbox/client';
+import type { EngineClient, EventDescriptor, WriteTarget } from '@cipherbox/client';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EngineProvider } from '../providers/EngineProvider';
+import { useDropUpload } from './useDropUpload';
+
+const PARENT = new Uint8Array(16).fill(4);
+const CHUNK_BYTES = 1024 * 1024;
+
+/** The write-handle surface the hook drives, with every call recorded in order. */
+function uploadEngine() {
+  const listeners = new Set<(event: EventDescriptor) => void>();
+  const log: string[] = [];
+  let handles = 0n;
+  let ops = 0n;
+
+  const facade = {
+    subscribe(listener: (event: EventDescriptor) => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    snapshot: () => new Promise<never>(() => undefined),
+    setFocus: () => Promise.resolve(),
+    beginWrite: vi.fn((target: WriteTarget, size: number) => {
+      log.push(`begin:${'name' in target ? target.name : 'version'}:${size}`);
+      handles += 1n;
+      return Promise.resolve(handles);
+    }),
+    pushChunk: vi.fn((_handle: bigint, chunk: ArrayBuffer) => {
+      log.push(`push:${chunk.byteLength}`);
+      return Promise.resolve();
+    }),
+    commitWrite: vi.fn(() => {
+      log.push('commit');
+      ops += 1n;
+      return Promise.resolve(ops);
+    }),
+    abortWrite: vi.fn(() => {
+      log.push('abort');
+      return Promise.resolve();
+    }),
+    cancelUpload: vi.fn((opId: bigint) => {
+      log.push(`cancelUpload:${opId}`);
+      return Promise.resolve();
+    }),
+  };
+
+  const client = {
+    facade,
+    reportFocus: () => undefined,
+    dispose: () => Promise.resolve(),
+  } as unknown as EngineClient;
+
+  return {
+    client,
+    facade,
+    log,
+    emit: (event: EventDescriptor) => {
+      for (const listener of listeners) listener(event);
+    },
+  };
+}
+
+function mount(client: EngineClient) {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <EngineProvider createClient={() => client}>{children}</EngineProvider>
+  );
+  return renderHook(() => useDropUpload(), { wrapper });
+}
+
+function file(name: string, bytes: number): File {
+  return new File([new Uint8Array(bytes)], name);
+}
+
+const progress = (opId: bigint, confirmed: number, total: number): EventDescriptor => ({
+  kind: 'opProgress',
+  opId,
+  node: new Uint8Array(16),
+  phase: 'uploadProgress',
+  blocksConfirmed: confirmed,
+  blocksTotal: total,
+  error: null,
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('driving an upload through the facade write handles', () => {
+  it('slices the file at the chunk boundary and commits one op', async () => {
+    const engine = uploadEngine();
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('report.pdf', CHUNK_BYTES + 100)], PARENT);
+    });
+
+    await waitFor(() => expect(result.current.uploads[0].phase).toBe('queued'));
+    expect(engine.log).toEqual([
+      `begin:report.pdf:${CHUNK_BYTES + 100}`,
+      `push:${CHUNK_BYTES}`,
+      'push:100',
+      'commit',
+    ]);
+    expect(engine.facade.beginWrite.mock.calls[0][0]).toEqual({
+      parent: PARENT,
+      name: 'report.pdf',
+    });
+    expect(result.current.uploads[0].opId).toBe(1n);
+  });
+
+  it('commits an empty file without pushing a chunk', async () => {
+    const engine = uploadEngine();
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('empty.txt', 0)], PARENT);
+    });
+
+    await waitFor(() => expect(result.current.uploads[0].phase).toBe('queued'));
+    expect(engine.log).toEqual(['begin:empty.txt:0', 'commit']);
+  });
+
+  it('runs queued files one at a time', async () => {
+    const engine = uploadEngine();
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10), file('b.bin', 20)], PARENT);
+    });
+
+    await waitFor(() => expect(result.current.uploads[1].phase).toBe('queued'));
+    expect(engine.log).toEqual([
+      'begin:a.bin:10',
+      'push:10',
+      'commit',
+      'begin:b.bin:20',
+      'push:20',
+      'commit',
+    ]);
+  });
+});
+
+describe('reporting what the engine says about the op', () => {
+  it('tracks confirmed blocks as the drain reports them', async () => {
+    const engine = uploadEngine();
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+    await waitFor(() => expect(result.current.uploads[0].opId).toBe(1n));
+
+    act(() => engine.emit(progress(1n, 3, 4)));
+
+    expect(result.current.uploads[0].phase).toBe('uploading');
+    expect(result.current.uploads[0].progress).toBeCloseTo(0.75);
+  });
+
+  it('binds an event that landed before commitWrite answered', async () => {
+    const engine = uploadEngine();
+    engine.facade.commitWrite.mockImplementationOnce(() => {
+      // The drain can report the op before the commit reply crosses back.
+      engine.emit(progress(1n, 2, 2));
+      return Promise.resolve(1n);
+    });
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+
+    await waitFor(() => expect(result.current.uploads[0].phase).toBe('uploading'));
+    expect(result.current.uploads[0].progress).toBe(1);
+  });
+
+  it('ignores op progress for an op this tab never opened', async () => {
+    const engine = uploadEngine();
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+    await waitFor(() => expect(result.current.uploads[0].opId).toBe(1n));
+
+    act(() => engine.emit(progress(99n, 1, 2)));
+
+    expect(result.current.uploads[0].phase).toBe('queued');
+  });
+
+  it('holds a failed attempt open, because the drain retries it', async () => {
+    const engine = uploadEngine();
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+    await waitFor(() => expect(result.current.uploads[0].opId).toBe(1n));
+
+    act(() =>
+      engine.emit({
+        kind: 'opProgress',
+        opId: 1n,
+        node: new Uint8Array(16),
+        phase: 'uploadFailed',
+        blocksConfirmed: null,
+        blocksTotal: null,
+        error: 'no reachable pin provider',
+      })
+    );
+
+    expect(result.current.uploads[0].phase).toBe('stalled');
+    expect(result.current.uploads[0].error).toBe('no reachable pin provider');
+  });
+
+  it('settles a dead-lettered op as terminal', async () => {
+    const engine = uploadEngine();
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+    await waitFor(() => expect(result.current.uploads[0].opId).toBe(1n));
+
+    act(() => engine.emit({ kind: 'deadLetter', opId: 1n, reason: 'targetGone' }));
+
+    expect(result.current.uploads[0].phase).toBe('failed');
+    expect(result.current.uploads[0].error).toContain('targetGone');
+  });
+
+  it('retires a published row on its own', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const engine = uploadEngine();
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+    await waitFor(() => expect(result.current.uploads[0].opId).toBe(1n));
+
+    act(() =>
+      engine.emit({
+        kind: 'opProgress',
+        opId: 1n,
+        node: new Uint8Array(16),
+        phase: 'uploadCompleted',
+        blocksConfirmed: 2,
+        blocksTotal: 2,
+        error: null,
+      })
+    );
+    expect(result.current.uploads[0].phase).toBe('uploaded');
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.uploads).toHaveLength(0);
+  });
+});
+
+describe('cancelling', () => {
+  it('aborts a staging write instead of committing it', async () => {
+    const engine = uploadEngine();
+    let admit = () => undefined as void;
+    engine.facade.beginWrite.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          admit = () => resolve(1n);
+        })
+    );
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+    act(() => result.current.cancel(result.current.uploads[0].id));
+    await act(async () => {
+      admit();
+    });
+
+    await waitFor(() => expect(result.current.uploads[0].phase).toBe('cancelled'));
+    expect(engine.facade.commitWrite).not.toHaveBeenCalled();
+    expect(engine.facade.abortWrite).toHaveBeenCalledWith(1n);
+  });
+
+  it('asks the engine to drop an op that has already committed', async () => {
+    const engine = uploadEngine();
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+    await waitFor(() => expect(result.current.uploads[0].opId).toBe(1n));
+
+    act(() => result.current.cancel(result.current.uploads[0].id));
+    expect(engine.facade.cancelUpload).toHaveBeenCalledWith(1n);
+
+    act(() =>
+      engine.emit({
+        kind: 'opProgress',
+        opId: 1n,
+        node: new Uint8Array(16),
+        phase: 'uploadCancelled',
+        blocksConfirmed: null,
+        blocksTotal: null,
+        error: null,
+      })
+    );
+    expect(result.current.uploads[0].phase).toBe('cancelled');
+  });
+
+  it('shows a refused cancel without moving the row off the upload', async () => {
+    const engine = uploadEngine();
+    engine.facade.cancelUpload.mockRejectedValueOnce(
+      new EngineRequestError('the version is already publishing', 'tooLateToCancel')
+    );
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+    await waitFor(() => expect(result.current.uploads[0].opId).toBe(1n));
+
+    await act(async () => {
+      result.current.cancel(result.current.uploads[0].id);
+    });
+
+    expect(result.current.uploads[0].phase).toBe('queued');
+    expect(result.current.uploads[0].error).toBe('the version is already publishing');
+  });
+});
+
+describe('refused writes', () => {
+  it('keeps the engine code so the caller can classify an over-budget refusal', async () => {
+    const engine = uploadEngine();
+    engine.facade.beginWrite.mockRejectedValueOnce(
+      new EngineRequestError('this write needs 900 bytes but only 100 are free', 'overBudget')
+    );
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('big.bin', 900)], PARENT);
+    });
+
+    await waitFor(() => expect(result.current.uploads[0].phase).toBe('failed'));
+    expect(result.current.uploads[0].code).toBe('overBudget');
+    expect(result.current.uploads[0].error).toContain('only 100 are free');
+    expect(engine.facade.commitWrite).not.toHaveBeenCalled();
+  });
+
+  it('releases the handle when a chunk is refused', async () => {
+    const engine = uploadEngine();
+    engine.facade.pushChunk.mockRejectedValueOnce(
+      new EngineRequestError('pushed 3 of 5 bytes', 'contentSizeMismatch')
+    );
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+
+    await waitFor(() => expect(result.current.uploads[0].phase).toBe('failed'));
+    expect(engine.facade.abortWrite).toHaveBeenCalledWith(1n);
+  });
+
+  it('re-runs a failed row from the file it was dropped with', async () => {
+    const engine = uploadEngine();
+    engine.facade.beginWrite.mockRejectedValueOnce(new Error('nope'));
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+    await waitFor(() => expect(result.current.uploads[0].phase).toBe('failed'));
+
+    await act(async () => {
+      result.current.retry(result.current.uploads[0].id);
+    });
+
+    await waitFor(() => expect(result.current.uploads[0].phase).toBe('queued'));
+    expect(result.current.uploads[0].error).toBeNull();
+    expect(result.current.uploads[0].code).toBeNull();
+  });
+
+  it('drops a dismissed row', async () => {
+    const engine = uploadEngine();
+    engine.facade.beginWrite.mockRejectedValueOnce(new Error('nope'));
+    const { result } = mount(engine.client);
+
+    await act(async () => {
+      result.current.upload([file('a.bin', 10)], PARENT);
+    });
+    await waitFor(() => expect(result.current.uploads[0].phase).toBe('failed'));
+
+    act(() => result.current.dismiss(result.current.uploads[0].id));
+
+    expect(result.current.uploads).toHaveLength(0);
+  });
+});

--- a/apps/web/src/hooks/useDropUpload.ts
+++ b/apps/web/src/hooks/useDropUpload.ts
@@ -1,7 +1,7 @@
 /**
  * The upload path: `File` handles in, facade write handles out
- * (blueprint/web-client.md "Content paths"). One slice of plaintext exists at a
- * time and is transferred into the engine, never copied through React state.
+ * (blueprint/web-client.md "Content paths"). A slice of plaintext is read and
+ * transferred into the engine in one step and never copied through React state.
  *
  * Rows are transient UI state keyed on the upload's op id; what the vault holds
  * stays the snapshot store's word alone (UI state law).
@@ -13,17 +13,13 @@ import type { EventDescriptor } from '@cipherbox/client';
 import { errorMessage } from '../lib/errorMessage';
 import { useEngine } from '../providers/EngineProvider';
 
-/** Plaintext crosses to the engine one slice at a time; peak heap is one slice. */
+/** Peak heap is one slice, however large the file. */
 const CHUNK_BYTES = 1024 * 1024;
 
 /** How long a settled row stays on screen before it retires itself. */
 const SETTLED_ROW_MILLIS = 1500;
 
-/**
- * Where an upload has got to. `uploaded` means the version's blocks are on the
- * network, not that its record published; `stalled` is one attempt the drain
- * will retry, where `failed` is terminal.
- */
+/** Where an upload has got to; `staging` is the only rung the engine does not name. */
 export type UploadPhase =
   | 'staging'
   | 'queued'
@@ -34,6 +30,9 @@ export type UploadPhase =
   | 'failed';
 
 const ACTIVE_PHASES: readonly UploadPhase[] = ['staging', 'queued', 'uploading', 'stalled'];
+
+/** Settled with nothing left to say, so the row clears itself. */
+const RETIRING_PHASES: readonly UploadPhase[] = ['uploaded', 'cancelled'];
 
 /** Whether the engine still has work for this row. */
 export function isActiveUpload(phase: UploadPhase): boolean {
@@ -70,6 +69,8 @@ export interface DropUpload {
 interface Job {
   file: File;
   parent: Uint8Array;
+  /** Set once the write commits, so a cancel names the op without a render read. */
+  opId: bigint | null;
 }
 
 /** What one engine event says about the row holding its op. */
@@ -86,21 +87,22 @@ export function useDropUpload(): DropUpload {
   const jobs = useRef(new Map<string, Job>());
   const cancelled = useRef(new Set<string>());
   const rowByOp = useRef(new Map<string, string>());
-  const timers = useRef(new Set<ReturnType<typeof setTimeout>>());
+  const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
   // Uploads run one at a time: `beginWrite` reserves the whole version against
   // the staging budget, so files started together contend for room only one has.
   const queue = useRef<Promise<void>>(Promise.resolve());
-  // A drain that reports an op before its `commitWrite` reply lands has no row
-  // to update yet; one slot covers it, because only one commit is ever open and
-  // the op id it is claimed under is unique.
+  // Replies and events cross on different channels, so an op can be reported
+  // before its `commitWrite` reply lands. Only events from inside a commit
+  // window may claim a slot, so a foreign op's report cannot accumulate here.
   const committing = useRef(false);
-  const unbound = useRef<RowUpdate | null>(null);
+  const unbound = useRef(new Map<string, Partial<UploadEntry>>());
 
   const patch = useCallback((id: string, change: Partial<UploadEntry>) => {
     setUploads((rows) => rows.map((row) => (row.id === id ? { ...row, ...change } : row)));
   }, []);
 
   const forget = useCallback((id: string) => {
+    stopRetire(timers.current, id);
     jobs.current.delete(id);
     cancelled.current.delete(id);
     unbind(rowByOp.current, id);
@@ -109,11 +111,11 @@ export function useDropUpload(): DropUpload {
 
   const retire = useCallback(
     (id: string) => {
-      const timer = setTimeout(() => {
-        timers.current.delete(timer);
-        forget(id);
-      }, SETTLED_ROW_MILLIS);
-      timers.current.add(timer);
+      stopRetire(timers.current, id);
+      timers.current.set(
+        id,
+        setTimeout(() => forget(id), SETTLED_ROW_MILLIS)
+      );
     },
     [forget]
   );
@@ -121,25 +123,38 @@ export function useDropUpload(): DropUpload {
   useEffect(() => {
     const pending = timers.current;
     return () => {
-      for (const timer of pending) clearTimeout(timer);
+      for (const timer of pending.values()) clearTimeout(timer);
       pending.clear();
     };
   }, []);
+
+  /** Lands one engine update on a row, retiring it once nothing is left to do. */
+  const apply = useCallback(
+    (id: string, change: Partial<UploadEntry>) => {
+      patch(id, change);
+      if (change.phase === undefined) return;
+      // A dead letter can follow the blocks landing, so a row that moves on must
+      // not be swept by the timer its earlier phase scheduled.
+      if (RETIRING_PHASES.includes(change.phase)) retire(id);
+      else stopRetire(timers.current, id);
+    },
+    [patch, retire]
+  );
 
   useEffect(() => {
     if (engine === null) return;
     return engine.facade.subscribe((event) => {
       const update = rowUpdate(event);
       if (update === null) return;
-      const row = rowByOp.current.get(update.opId.toString());
+      const key = update.opId.toString();
+      const row = rowByOp.current.get(key);
       if (row === undefined) {
-        if (committing.current) unbound.current = update;
+        if (committing.current) unbound.current.set(key, update.change);
         return;
       }
-      patch(row, update.change);
-      if (update.change.phase === 'uploaded') retire(row);
+      apply(row, update.change);
     });
-  }, [engine, patch, retire]);
+  }, [apply, engine]);
 
   /** Asks the engine to drop a committed op; a refusal says why on the row. */
   const dropOp = useCallback(
@@ -172,8 +187,7 @@ export function useDropUpload(): DropUpload {
       const abandoned = async (): Promise<boolean> => {
         if (!cancelled.current.has(id)) return false;
         await release();
-        patch(id, { phase: 'cancelled', error: null });
-        retire(id);
+        apply(id, { phase: 'cancelled', error: null });
         return true;
       };
 
@@ -185,8 +199,6 @@ export function useDropUpload(): DropUpload {
         );
         for (let offset = 0; offset < job.file.size; offset += CHUNK_BYTES) {
           if (await abandoned()) return;
-          // Read and handed over in one step: the push detaches the buffer, so
-          // no plaintext slice outlives the call that consumed it.
           await facade.pushChunk(
             handle,
             await job.file.slice(offset, offset + CHUNK_BYTES).arrayBuffer()
@@ -202,19 +214,19 @@ export function useDropUpload(): DropUpload {
           committing.current = false;
         }
         handle = null;
-
+        job.opId = opId;
         rowByOp.current.set(opId.toString(), id);
-        const early = unbound.current?.opId === opId ? unbound.current.change : undefined;
-        unbound.current = null;
-        patch(id, { opId, phase: 'queued', ...early });
-        if (early?.phase === 'uploaded') retire(id);
+        patch(id, { opId, phase: 'queued' });
+
+        const early = unbound.current.get(opId.toString());
+        unbound.current.clear();
+        if (early !== undefined) apply(id, early);
         // A cancel that arrived mid-commit has an op to name now.
         if (cancelled.current.has(id)) dropOp(id, opId);
       } catch (error) {
         await release();
         if (cancelled.current.has(id)) {
-          patch(id, { phase: 'cancelled', error: null });
-          retire(id);
+          apply(id, { phase: 'cancelled', error: null });
           return;
         }
         patch(id, {
@@ -224,7 +236,7 @@ export function useDropUpload(): DropUpload {
         });
       }
     },
-    [dropOp, engine, patch, retire]
+    [apply, dropOp, engine, patch, retire]
   );
 
   const enqueue = useCallback(
@@ -236,9 +248,10 @@ export function useDropUpload(): DropUpload {
 
   const upload = useCallback(
     (files: readonly File[], parent: Uint8Array) => {
+      if (files.length === 0) return;
       const started = files.map((file) => {
         const id = `upload-${(sequence += 1)}`;
-        jobs.current.set(id, { file, parent });
+        jobs.current.set(id, { file, parent, opId: null });
         return {
           id,
           name: file.name,
@@ -250,7 +263,6 @@ export function useDropUpload(): DropUpload {
           code: null,
         } satisfies UploadEntry;
       });
-      if (started.length === 0) return;
       setUploads((rows) => [...rows, ...started]);
       for (const row of started) enqueue(row.id);
     },
@@ -260,18 +272,19 @@ export function useDropUpload(): DropUpload {
   const cancel = useCallback(
     (id: string) => {
       cancelled.current.add(id);
-      const opId = uploads.find((row) => row.id === id)?.opId;
-      // Still staging: the run loop reads the flag at its next chunk boundary.
+      const opId = jobs.current.get(id)?.opId;
       if (opId != null) dropOp(id, opId);
     },
-    [dropOp, uploads]
+    [dropOp]
   );
 
   const retry = useCallback(
     (id: string) => {
-      if (!jobs.current.has(id)) return;
+      const job = jobs.current.get(id);
+      if (job === undefined) return;
       cancelled.current.delete(id);
       unbind(rowByOp.current, id);
+      job.opId = null;
       patch(id, { phase: 'staging', progress: 0, opId: null, error: null, code: null });
       enqueue(id);
     },
@@ -279,6 +292,13 @@ export function useDropUpload(): DropUpload {
   );
 
   return { uploads, upload, cancel, retry, dismiss: forget };
+}
+
+function stopRetire(timers: Map<string, ReturnType<typeof setTimeout>>, id: string): void {
+  const timer = timers.get(id);
+  if (timer === undefined) return;
+  clearTimeout(timer);
+  timers.delete(id);
 }
 
 function unbind(rowByOp: Map<string, string>, id: string): void {

--- a/apps/web/src/hooks/useDropUpload.ts
+++ b/apps/web/src/hooks/useDropUpload.ts
@@ -180,6 +180,8 @@ export function useDropUpload(): DropUpload {
 
       let handle: bigint | null = null;
       const release = async (): Promise<void> => {
+        // A refused abort has nothing to add: the row is already about to report
+        // the cancel or the error that brought it here.
         if (handle !== null) await facade.abortWrite(handle).catch(() => undefined);
         handle = null;
       };
@@ -236,7 +238,7 @@ export function useDropUpload(): DropUpload {
         });
       }
     },
-    [apply, dropOp, engine, patch, retire]
+    [apply, dropOp, engine, patch]
   );
 
   const enqueue = useCallback(
@@ -285,10 +287,12 @@ export function useDropUpload(): DropUpload {
       cancelled.current.delete(id);
       unbind(rowByOp.current, id);
       job.opId = null;
-      patch(id, { phase: 'staging', progress: 0, opId: null, error: null, code: null });
+      // Through `apply`, so the retirement timer the settled phase scheduled is
+      // stopped before it sweeps the row out from under the run about to start.
+      apply(id, { phase: 'staging', progress: 0, opId: null, error: null, code: null });
       enqueue(id);
     },
-    [enqueue, patch]
+    [apply, enqueue]
   );
 
   return { uploads, upload, cancel, retry, dismiss: forget };

--- a/apps/web/src/hooks/useDropUpload.ts
+++ b/apps/web/src/hooks/useDropUpload.ts
@@ -1,0 +1,314 @@
+/**
+ * The upload path: `File` handles in, facade write handles out
+ * (blueprint/web-client.md "Content paths"). One slice of plaintext exists at a
+ * time and is transferred into the engine, never copied through React state.
+ *
+ * Rows are transient UI state keyed on the upload's op id; what the vault holds
+ * stays the snapshot store's word alone (UI state law).
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { EngineRequestError } from '@cipherbox/client';
+import type { EventDescriptor } from '@cipherbox/client';
+import { errorMessage } from '../lib/errorMessage';
+import { useEngine } from '../providers/EngineProvider';
+
+/** Plaintext crosses to the engine one slice at a time; peak heap is one slice. */
+const CHUNK_BYTES = 1024 * 1024;
+
+/** How long a settled row stays on screen before it retires itself. */
+const SETTLED_ROW_MILLIS = 1500;
+
+/**
+ * Where an upload has got to. `uploaded` means the version's blocks are on the
+ * network, not that its record published; `stalled` is one attempt the drain
+ * will retry, where `failed` is terminal.
+ */
+export type UploadPhase =
+  | 'staging'
+  | 'queued'
+  | 'uploading'
+  | 'uploaded'
+  | 'stalled'
+  | 'cancelled'
+  | 'failed';
+
+const ACTIVE_PHASES: readonly UploadPhase[] = ['staging', 'queued', 'uploading', 'stalled'];
+
+/** Whether the engine still has work for this row. */
+export function isActiveUpload(phase: UploadPhase): boolean {
+  return ACTIVE_PHASES.includes(phase);
+}
+
+export interface UploadEntry {
+  /** Row identity from the drop; the op id only exists once the write commits. */
+  id: string;
+  name: string;
+  size: number;
+  phase: UploadPhase;
+  /** Blocks confirmed as a fraction, once the drain reports them. */
+  progress: number;
+  opId: bigint | null;
+  /** The engine's diagnostic for the current phase, or `null`. */
+  error: string | null;
+  /** The engine's stable code for a refused write, so a caller classifies it. */
+  code: string | null;
+}
+
+export interface DropUpload {
+  uploads: readonly UploadEntry[];
+  /** Stages and commits each file into `parent`, one at a time. */
+  upload(files: readonly File[], parent: Uint8Array): void;
+  /** Aborts a staging write, or asks the engine to drop a committed op. */
+  cancel(id: string): void;
+  /** Re-runs a settled row from the `File` it was dropped with. */
+  retry(id: string): void;
+  /** Clears a settled row. */
+  dismiss(id: string): void;
+}
+
+interface Job {
+  file: File;
+  parent: Uint8Array;
+}
+
+/** What one engine event says about the row holding its op. */
+interface RowUpdate {
+  opId: bigint;
+  change: Partial<UploadEntry>;
+}
+
+let sequence = 0;
+
+export function useDropUpload(): DropUpload {
+  const engine = useEngine();
+  const [uploads, setUploads] = useState<readonly UploadEntry[]>([]);
+  const jobs = useRef(new Map<string, Job>());
+  const cancelled = useRef(new Set<string>());
+  const rowByOp = useRef(new Map<string, string>());
+  const timers = useRef(new Set<ReturnType<typeof setTimeout>>());
+  // Uploads run one at a time: `beginWrite` reserves the whole version against
+  // the staging budget, so files started together contend for room only one has.
+  const queue = useRef<Promise<void>>(Promise.resolve());
+  // A drain that reports an op before its `commitWrite` reply lands has no row
+  // to update yet; one slot covers it, because only one commit is ever open and
+  // the op id it is claimed under is unique.
+  const committing = useRef(false);
+  const unbound = useRef<RowUpdate | null>(null);
+
+  const patch = useCallback((id: string, change: Partial<UploadEntry>) => {
+    setUploads((rows) => rows.map((row) => (row.id === id ? { ...row, ...change } : row)));
+  }, []);
+
+  const forget = useCallback((id: string) => {
+    jobs.current.delete(id);
+    cancelled.current.delete(id);
+    unbind(rowByOp.current, id);
+    setUploads((rows) => rows.filter((row) => row.id !== id));
+  }, []);
+
+  const retire = useCallback(
+    (id: string) => {
+      const timer = setTimeout(() => {
+        timers.current.delete(timer);
+        forget(id);
+      }, SETTLED_ROW_MILLIS);
+      timers.current.add(timer);
+    },
+    [forget]
+  );
+
+  useEffect(() => {
+    const pending = timers.current;
+    return () => {
+      for (const timer of pending) clearTimeout(timer);
+      pending.clear();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (engine === null) return;
+    return engine.facade.subscribe((event) => {
+      const update = rowUpdate(event);
+      if (update === null) return;
+      const row = rowByOp.current.get(update.opId.toString());
+      if (row === undefined) {
+        if (committing.current) unbound.current = update;
+        return;
+      }
+      patch(row, update.change);
+      if (update.change.phase === 'uploaded') retire(row);
+    });
+  }, [engine, patch, retire]);
+
+  /** Asks the engine to drop a committed op; a refusal says why on the row. */
+  const dropOp = useCallback(
+    (id: string, opId: bigint): void => {
+      const facade = engine?.facade;
+      if (facade === undefined) return;
+      facade.cancelUpload(opId).catch((error: unknown) => {
+        patch(id, { error: errorMessage(error) });
+      });
+    },
+    [engine, patch]
+  );
+
+  const run = useCallback(
+    async (id: string) => {
+      const job = jobs.current.get(id);
+      if (job === undefined) return;
+      const facade = engine?.facade;
+      if (facade === undefined) {
+        patch(id, { phase: 'failed', error: 'the engine is not running yet' });
+        return;
+      }
+
+      let handle: bigint | null = null;
+      const release = async (): Promise<void> => {
+        if (handle !== null) await facade.abortWrite(handle).catch(() => undefined);
+        handle = null;
+      };
+      /** True once the row is cancelled, having released what it held. */
+      const abandoned = async (): Promise<boolean> => {
+        if (!cancelled.current.has(id)) return false;
+        await release();
+        patch(id, { phase: 'cancelled', error: null });
+        retire(id);
+        return true;
+      };
+
+      try {
+        if (await abandoned()) return;
+        handle = await facade.beginWrite(
+          { parent: job.parent, name: job.file.name },
+          job.file.size
+        );
+        for (let offset = 0; offset < job.file.size; offset += CHUNK_BYTES) {
+          if (await abandoned()) return;
+          // Read and handed over in one step: the push detaches the buffer, so
+          // no plaintext slice outlives the call that consumed it.
+          await facade.pushChunk(
+            handle,
+            await job.file.slice(offset, offset + CHUNK_BYTES).arrayBuffer()
+          );
+        }
+        if (await abandoned()) return;
+
+        committing.current = true;
+        let opId: bigint;
+        try {
+          opId = await facade.commitWrite(handle);
+        } finally {
+          committing.current = false;
+        }
+        handle = null;
+
+        rowByOp.current.set(opId.toString(), id);
+        const early = unbound.current?.opId === opId ? unbound.current.change : undefined;
+        unbound.current = null;
+        patch(id, { opId, phase: 'queued', ...early });
+        if (early?.phase === 'uploaded') retire(id);
+        // A cancel that arrived mid-commit has an op to name now.
+        if (cancelled.current.has(id)) dropOp(id, opId);
+      } catch (error) {
+        await release();
+        if (cancelled.current.has(id)) {
+          patch(id, { phase: 'cancelled', error: null });
+          retire(id);
+          return;
+        }
+        patch(id, {
+          phase: 'failed',
+          error: errorMessage(error),
+          code: error instanceof EngineRequestError ? (error.code ?? null) : null,
+        });
+      }
+    },
+    [dropOp, engine, patch, retire]
+  );
+
+  const enqueue = useCallback(
+    (id: string) => {
+      queue.current = queue.current.then(() => run(id));
+    },
+    [run]
+  );
+
+  const upload = useCallback(
+    (files: readonly File[], parent: Uint8Array) => {
+      const started = files.map((file) => {
+        const id = `upload-${(sequence += 1)}`;
+        jobs.current.set(id, { file, parent });
+        return {
+          id,
+          name: file.name,
+          size: file.size,
+          phase: 'staging',
+          progress: 0,
+          opId: null,
+          error: null,
+          code: null,
+        } satisfies UploadEntry;
+      });
+      if (started.length === 0) return;
+      setUploads((rows) => [...rows, ...started]);
+      for (const row of started) enqueue(row.id);
+    },
+    [enqueue]
+  );
+
+  const cancel = useCallback(
+    (id: string) => {
+      cancelled.current.add(id);
+      const opId = uploads.find((row) => row.id === id)?.opId;
+      // Still staging: the run loop reads the flag at its next chunk boundary.
+      if (opId != null) dropOp(id, opId);
+    },
+    [dropOp, uploads]
+  );
+
+  const retry = useCallback(
+    (id: string) => {
+      if (!jobs.current.has(id)) return;
+      cancelled.current.delete(id);
+      unbind(rowByOp.current, id);
+      patch(id, { phase: 'staging', progress: 0, opId: null, error: null, code: null });
+      enqueue(id);
+    },
+    [enqueue, patch]
+  );
+
+  return { uploads, upload, cancel, retry, dismiss: forget };
+}
+
+function unbind(rowByOp: Map<string, string>, id: string): void {
+  for (const [op, row] of rowByOp) {
+    if (row === id) rowByOp.delete(op);
+  }
+}
+
+function rowUpdate(event: EventDescriptor): RowUpdate | null {
+  if (event.kind === 'deadLetter') {
+    const error = `${event.reason}, so this upload will never publish`;
+    return { opId: event.opId, change: { phase: 'failed', error } };
+  }
+  if (event.kind !== 'opProgress' || event.opId === null) return null;
+  switch (event.phase) {
+    case 'uploadStarted':
+    case 'uploadProgress':
+      return { opId: event.opId, change: { phase: 'uploading', progress: fraction(event) } };
+    case 'uploadCompleted':
+      return { opId: event.opId, change: { phase: 'uploaded', progress: 1, error: null } };
+    case 'uploadFailed':
+      return { opId: event.opId, change: { phase: 'stalled', error: event.error } };
+    case 'uploadCancelled':
+      return { opId: event.opId, change: { phase: 'cancelled', error: null } };
+    default:
+      return null;
+  }
+}
+
+function fraction(event: { blocksConfirmed: number | null; blocksTotal: number | null }): number {
+  const total = event.blocksTotal ?? 0;
+  return total > 0 ? Math.min((event.blocksConfirmed ?? 0) / total, 1) : 0;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import './index.css';
 import './styles/login.css';
 import './styles/layout.css';
 import './styles/file-browser.css';
+import './styles/upload.css';
 import './styles/breadcrumbs.css';
 import './styles/responsive.css';
 

--- a/apps/web/src/styles/upload.css
+++ b/apps/web/src/styles/upload.css
@@ -60,16 +60,17 @@
   margin-bottom: var(--spacing-sm);
 }
 
-.upload-row {
+/* Doubled up so the row's own affordances win wherever this sheet is loaded. */
+.file-list-item.upload-row {
   cursor: default;
 }
 
-.upload-row:hover {
+.file-list-item.upload-row:hover {
   background-color: transparent;
 }
 
-.upload-row--failed {
-  background-color: rgb(239 68 68 / 8%);
+.file-list-item.upload-row--failed {
+  background-color: color-mix(in srgb, var(--color-error) 8%, transparent);
 }
 
 .upload-row--failed .file-list-item-icon {
@@ -102,8 +103,8 @@
   transition: width 0.2s ease;
 }
 
-/* An indeterminate stage — sealing, queued, or waiting on a retry — animates
-   the track itself, so the fill has no width to jump back from. */
+/* Sealing animates the track itself, so the fill has no width to jump back from
+   when the drain's first block lands. */
 @keyframes upload-row-shimmer {
   from {
     background-position: -200% 0;
@@ -151,11 +152,6 @@
   color: var(--color-text-primary);
 }
 
-.upload-row-button:focus-visible {
-  outline: var(--border-thickness) solid var(--color-green-primary);
-  outline-offset: 1px;
-}
-
 .upload-row-button--retry {
   color: var(--color-green-primary);
 }
@@ -168,9 +164,7 @@
   color: var(--color-error);
 }
 
-/* An over-budget refusal is a ceiling, not a verdict: it reads as a warning
-   because the same write can be admitted once room frees. */
-.upload-row-error--budget {
+.upload-row-error--transient {
   color: var(--color-warning);
 }
 

--- a/apps/web/src/styles/upload.css
+++ b/apps/web/src/styles/upload.css
@@ -1,0 +1,183 @@
+/* ==========================================================================
+   Upload - Terminal Aesthetic
+   ========================================================================== */
+
+.upload-zone {
+  display: flex;
+  margin-bottom: var(--spacing-sm);
+  border: var(--border-thickness) dashed var(--color-border-dim);
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.upload-zone:hover {
+  border-color: var(--color-green-primary);
+}
+
+.upload-zone--dragging {
+  border-style: solid;
+  border-color: var(--color-green-primary);
+  background-color: var(--color-green-darker);
+  box-shadow: var(--glow-green);
+}
+
+.upload-zone-button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.upload-zone-button:focus-visible {
+  outline: var(--border-thickness) solid var(--color-green-primary);
+  outline-offset: -2px;
+}
+
+.upload-zone-icon {
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-secondary);
+}
+
+.upload-zone-input {
+  display: none;
+}
+
+/* ==========================================================================
+   Upload Rows
+   ========================================================================== */
+
+.upload-list {
+  border: var(--border-thickness) solid var(--color-border-dim);
+  border-bottom: none;
+  margin-bottom: var(--spacing-sm);
+}
+
+.upload-row {
+  cursor: default;
+}
+
+.upload-row:hover {
+  background-color: transparent;
+}
+
+.upload-row--failed {
+  background-color: rgb(239 68 68 / 8%);
+}
+
+.upload-row--failed .file-list-item-icon {
+  color: var(--color-error);
+}
+
+.upload-row--cancelled,
+.upload-row--uploaded {
+  opacity: 0.6;
+}
+
+.upload-row-name {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.upload-row-track {
+  height: 3px;
+  width: 100%;
+  overflow: hidden;
+  background-color: var(--color-border-dim);
+}
+
+.upload-row-fill {
+  height: 100%;
+  background-color: var(--color-green-primary);
+  transition: width 0.2s ease;
+}
+
+/* An indeterminate stage — sealing, queued, or waiting on a retry — animates
+   the track itself, so the fill has no width to jump back from. */
+@keyframes upload-row-shimmer {
+  from {
+    background-position: -200% 0;
+  }
+
+  to {
+    background-position: 200% 0;
+  }
+}
+
+.upload-row-track--indeterminate {
+  background: linear-gradient(
+    90deg,
+    var(--color-border-dim) 30%,
+    var(--color-green-primary) 50%,
+    var(--color-border-dim) 70%
+  );
+  background-size: 200% 100%;
+  animation: upload-row-shimmer 1.5s ease-in-out infinite;
+}
+
+.upload-row-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--spacing-xs);
+}
+
+.upload-row-status {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.upload-row-button {
+  padding: 2px var(--spacing-xs);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.upload-row-button:hover {
+  color: var(--color-text-primary);
+}
+
+.upload-row-button:focus-visible {
+  outline: var(--border-thickness) solid var(--color-green-primary);
+  outline-offset: 1px;
+}
+
+.upload-row-button--retry {
+  color: var(--color-green-primary);
+}
+
+.upload-row-error {
+  grid-column: 1 / -1;
+  margin: 4px 0 0;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-error);
+}
+
+/* An over-budget refusal is a ceiling, not a verdict: it reads as a warning
+   because the same write can be admitted once room frees. */
+.upload-row-error--budget {
+  color: var(--color-warning);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .upload-row-fill,
+  .upload-row-track--indeterminate {
+    transition: none;
+    animation: none;
+  }
+}

--- a/apps/web/src/vault/useFolderNavigation.test.tsx
+++ b/apps/web/src/vault/useFolderNavigation.test.tsx
@@ -268,4 +268,15 @@ describe('the vault browser read path', () => {
     expect(screen.getByTestId('file-browser-error').textContent).toBe('that is not a folder id');
     expect(engine.focus).toEqual([]);
   });
+
+  it('takes no drop for a route that is not a folder, whatever the store still holds', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine, '/files/not-a-node');
+
+    // The root view outlives the bad route, and must not stand in for it.
+    await landSnapshot(engine, folderView());
+
+    expect(screen.getByTestId('file-browser-error').textContent).toBe('that is not a folder id');
+    expect(screen.queryByTestId('upload-zone')).toBeNull();
+  });
 });

--- a/apps/web/src/vault/useFolderNavigation.ts
+++ b/apps/web/src/vault/useFolderNavigation.ts
@@ -19,6 +19,8 @@ const NOT_A_FOLDER: SnapshotError = { message: 'that is not a folder id' };
 export interface FolderNavigation {
   /** Direct children of the routed folder, folders first. */
   rows: ListingRow[];
+  /** The folder the snapshot listed, or `null` until one lands for this route. */
+  folder: Uint8Array | null;
   /** Root-first trail, ending at the folder on screen. */
   breadcrumbs: BreadcrumbDescriptor[];
   /** True until the engine reports a snapshot *of the routed folder*. */
@@ -75,6 +77,7 @@ export function useFolderNavigation(): FolderNavigation {
 
   return {
     rows,
+    folder: listed?.folder ?? null,
     breadcrumbs,
     isLoading: route.kind !== 'invalid' && listed === null && error === null,
     isRoot: listed !== null && sameNode(listed.folder, listed.root),


### PR DESCRIPTION
Closes #873.

The upload half of the web content path, on top of the write-handle surface `packages/client` already exposes. No engine or client command is added — this is UI wiring over `beginWrite` / `pushChunk` / `commitWrite` / `abortWrite` / `cancelUpload` and the `opProgress` event stream.

## What lands

- **`apps/web/src/hooks/useDropUpload.ts`** — the drive loop. A file is sliced at a 1 MiB boundary and each slice is read and handed to `pushChunk` in one step, so the buffer is detached by the transfer and no plaintext copy ever reaches a React value. Files run one at a time, because `beginWrite` reserves the whole version against the staging budget and files started together would otherwise contend for room only one can have.
- **`UploadZone.tsx`** — the drop target, doubling as a file picker. Ignores drags that carry no files, and uses an enter/leave depth counter so crossing a child does not drop the highlight.
- **`UploadListItem.tsx`** — one row per upload, in the same three columns as the listing below it. Determinate bar once the drain reports confirmed blocks, a shimmer only on the row actually being fed.
- **`UploadPanel.tsx`** — owns the rows, so a block-confirmed event repaints them alone rather than the whole folder listing.
- **`styles/upload.css`** — terminal-aesthetic styling carried over from the v1 upload surface, with `prefers-reduced-motion` honoured.

`useFolderNavigation` gains one field: the folder id the snapshot reported, which the drop target needs as its write target. It was already computing it to build the breadcrumb trail.

## Phases

Rows key on the op id `commitWrite` resolves with, and every phase past that point is the engine's word:

| phase | source |
| --- | --- |
| `staging` | the client is feeding chunks |
| `queued` | `commitWrite` returned an op id |
| `uploading` | `uploadStarted` / `uploadProgress` |
| `uploaded` | `uploadCompleted` — blocks on the network, record publishes next; the row retires itself |
| `stalled` | `uploadFailed` — one attempt stopped, and the drain retries it |
| `cancelled` | `uploadCancelled`, or a handle abandoned before commit |
| `failed` | a rejected write-handle call, or a `deadLetter` for the op |

`uploadFailed` is deliberately **not** terminal: the facade documents an `Event::DeadLetter` in the same pass as the thing that says the op will never publish, so the row stays open and offers cancel until a dead letter arrives.

## Cancel

Cancel before commit sets a flag the run loop reads at its next chunk boundary and aborts the handle; cancel after commit issues `cancelUpload(opId)`. A cancel that lands mid-commit is picked up as soon as the op id exists. A refusal — `tooLateToCancel`, `notAnUpload` — is shown on the row without moving it off the upload it is still doing.

## Over-budget

A refused write keeps `EngineRequestError.code`, so the UI renders `overBudget` in the warning colour with a retry — a ceiling, not a verdict — apart from the settled red of a row that will never publish. A stopped attempt reads the same way, for the same reason. The engine's own message is what distinguishes the six causes, verbatim. See below.

## Review gates

`/simplify` and `/security-review` both ran on this diff; the second commit is their output.

Security review found three real defects, all fixed and covered by tests:

- **An engine-driven cancel stranded its row.** Cancel was gated on the row being active and dismiss on it having failed, so a row the engine reported as `uploadCancelled` had no control at all and held its `File` for the life of the mount. Every settled row now retires itself and offers dismiss.
- **The retire timer was uncancellable.** `uploadCompleted` means blocks are on the network, not that the record published, so a `deadLetter` can legitimately follow — and the timer the completed phase scheduled would then sweep the failed row away. Timers are now per row and cleared whenever a row moves off a settled phase.
- **The unbound-update slot had no owner filter.** A foreign op reporting into the single slot could clobber the update a commit was waiting on, leaving a finished upload stuck at `queued`. It is now a map gated on an open commit window, so nothing accumulates and nothing clobbers.

Simplify's structural findings — the panel extraction, reading the folder id off the snapshot instead of the breadcrumb trail, taking the op id off the job rather than render state, and restricting the shimmer — are in the same commit.

## Not done, on purpose

- **Machine-readable over-budget causes.** #873 asks for the refusal in its three distinct forms. `OverBudgetCause` in `crates/engine/src/facade.rs` does separate them, but every variant collapses to the single code `overBudget` at the wasm boundary in `crates/wasm/src/host.rs`, so only the prose differs. Splitting them by substring-matching the diagnostic would be exactly the source-text assertion the testing law forbids, and the fix belongs in `crates/wasm` plus `packages/client`, which this PR does not own. Filed as #1073, with the rendering split as #1075 which it blocks. #873's scope bullet has been struck and pointed at that pair, so closing it here does not drop the requirement.
- **The drain's over-budget hold.** `SnapshotDescriptor.blocked` names the op the drain is holding, and nothing in `apps/web` reads it, so a held op sits at `queued` with no explanation. Wiring it needs the snapshot store and the upload rows to meet somewhere, which is a design choice bigger than this issue. Filed as #1075.
- **Duplicate-name resolution.** The engine suffixes on collision, so no replace dialog is needed, and dialogs are not this PR's surface.
- **Zeroizing the chunk buffer after the engine consumes it** — that is `packages/client/src/worker/engineHost.ts`, tracked separately. Nothing here retains an extra copy.
- **A cap on the drop batch size.** Dropping a very large directory renders a row per file. Uploads are serialised and peak heap stays one slice, so there is no byte-wise exhaustion; picking a limit is a product call, not a review fix.

## Issue-body corrections

The body is stale in three places, all of them now fixed on `main`:

- It lists #868 and #896 as blockers; both are closed. `OpPhase` carries the five `Upload*` variants and the upload path emits `op_id: Some(op_id)`.
- It cites `OpPhase` at `facade.rs:464-471` with "only `Download*` variants", and `emit_op_progress` hardcoding `op_id: None` at `:1684-1691`. Neither is true any more.
- It cites `Command::Create { content: Option<PlaintextContent> }` at `facade.rs:238-247` as the shape going away. It is already gone — `Command::Create` carries no content.

It also asks to harvest the v1 components. They were read for visual and interaction continuity, then rewritten: v1 leaned on `react-dropzone`, a Zustand upload store, and axios cancel tokens, none of which this app has, and its cancel was cosmetic once a batch was in flight.

## Gate

`web unit` — 31 new tests across the hook and both components; the full `apps/web` suite is 141 green.

Verified in a real browser against the dev server: the drag highlight survives crossing a child, a text-only drag is ignored, a drop delivers the `File`, the determinate bar measures 42% of its track for a 0.42 fraction, only the sealing row animates, the over-budget and retrying lines render in the warning colour while a dead letter renders red, and a cancelled row offers retry and dismiss.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add file upload UI with drag-and-drop, progress tracking, and cancellation to the file browser
> - Adds `UploadZone`, `UploadPanel`, and `UploadListItem` components to the file browser, providing drag-and-drop and file picker upload entry points with per-upload progress rows.
> - Implements `useDropUpload` hook to orchestrate the full upload pipeline: queuing, chunking files into 1MB pieces, staging via `beginWrite`, committing, tracking progress via engine events, and auto-retiring completed rows.
> - Supports cancel, retry, and dismiss actions per upload, with transient (stalled, over-budget) vs terminal error classification.
> - Extends `useFolderNavigation` to expose the currently settled folder id, used to enable the drop target only after the routed folder has landed.
> - Risk: early engine progress events arriving before the commit reply are correlated in-memory; any missed events during that window could leave a row stuck in an intermediate state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a0fd7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop and file-picker uploads within the current folder.
  * Added upload progress, status indicators, and accessibility-friendly feedback.
  * Added controls to cancel, retry, or dismiss uploads and upload errors.
  * Added support for multiple files, queued uploads, and automatic cleanup of completed items.
* **Bug Fixes**
  * Improved handling of nested drag events, cancelled uploads, stalled transfers, and transient errors.
* **Tests**
  * Added comprehensive coverage for upload interactions, progress states, retries, cancellation, and failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
