### PR TITLE
feat: wire the pin-provider layer across all three modes

### DIFF
--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -657,17 +657,35 @@ contract-test suite owned by the testing-strategy blueprint (#28 D6).
     write's second leg, and **external-only over a pin-by-CID provider is a
     placement refusal** — no leg would hold the block for the service to
     fetch, so the published record would name bytes that exist nowhere.
-  - **Dual runs both legs and only hosted can fail the op.** Under strict-FIFO
-    stop-at-first-failure a both-must-succeed rule would let an offline home
-    node stall every later mutation in the vault. The external leg's outcome
-    is reported per op rather than swallowed, and no retry is queued for it.
-    Under external, the member's provider _is_ the byte path, so its refusal
-    is the op's.
-  - **Durable upload progress is keyed by the placement it was written
-    under.** A resumed version's confirmed prefix is no longer on the device,
-    so progress towards one set of destinations can never be read as progress
-    towards another — a mode changed between sessions re-fetches rather than
-    publishing a version the new placement never received.
+  - **Dual runs both legs, both retrying inside the op, and only hosted can
+    fail it** (#34 D1). Under strict-FIFO stop-at-first-failure a
+    both-must-succeed rule would let an offline home node stall every later
+    mutation in the vault, so the op completes once hosted succeeds and
+    external has either succeeded or exhausted its attempts. That budget is
+    the **op's, not each block's**: a node that is down refuses every block
+    alike, so once it is spent the mirror is abandoned for that version rather
+    than re-asked per block. The outcome is reported per op rather than
+    swallowed, and no retry is queued for it. Under external, the member's
+    provider _is_ the byte path, so its refusal is the op's.
+  - **A partial-success report waits for the publish.** The external-pin
+    shortfall says the version published and its content is retrievable, so it
+    is emitted after the record lands, never at the end of block upload — a
+    pass that still fails to publish has made no such promise.
+  - **Durable upload progress is keyed by the destinations that took the
+    bytes.** A resumed version's confirmed prefix is no longer on the device,
+    so a session only skips it where the leg that can fail _this_ op already
+    holds it: the hosted store, except under external-only where the member's
+    provider is the only leg there is. A mark therefore records what the legs
+    actually took, not what the mode named — a dual write whose mirror missed
+    a block narrows its mark to the hosted leg, so a later external-only
+    session re-places rather than publishing content that node never received.
+  - **The destination identity is the provider, not the credential.** It
+    covers the provider kind and endpoint and deliberately excludes the
+    bearer: a mark that stops matching is not merely ignored, since the leaves
+    it covered are already released, so keying on a rotatable secret would
+    make a routine credential rotation leave the version unpublishable.
+    Residual: two accounts on one multi-tenant pin service tag alike, which
+    only ever reaches the best-effort mirror report.
   - The placement is decided once at start and holds for the session, so a
     provider or credential revoked elsewhere still receives blocks until the
     process restarts. Stated, not closed.

--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -223,7 +223,10 @@ degraded outcome applies a different policy rather than showing stale data.
   the gate already owes a rejected record.
 - **No last-known-good copy fails the placement decision closed.** The
   built-in defaults describe a first run — no record anywhere, no durable
-  floor. Under any other reason, with no cached copy to fall back on, a
+  floor. Residual: that is a verdict about _this device_, so a record-plane
+  adversary who withholds the record from one that has never synced still
+  reaches the first-run default; closing it needs positive evidence that the
+  account has never published settings, which no device-local seam carries. Under any other reason, with no cached copy to fall back on, a
   placement decision refuses the hosted upload rather than resolving to
   `PinMode::Hosted`; the member is told their settings are unavailable. A
   consumer that branches only on the resolved case, letting the degraded ones
@@ -660,6 +663,20 @@ contract-test suite owned by the testing-strategy blueprint (#28 D6).
     is reported per op rather than swallowed, and no retry is queued for it.
     Under external, the member's provider _is_ the byte path, so its refusal
     is the op's.
+  - **Durable upload progress is keyed by the placement it was written
+    under.** A resumed version's confirmed prefix is no longer on the device,
+    so progress towards one set of destinations can never be read as progress
+    towards another — a mode changed between sessions re-fetches rather than
+    publishing a version the new placement never received.
+  - The placement is decided once at start and holds for the session, so a
+    provider or credential revoked elsewhere still receives blocks until the
+    process restarts. Stated, not closed.
+- **A publish refuses settings no reader could place under** (AGENTS.md rule
+  8): the produce path runs the consumer's own placement predicate, so a
+  record naming a mode with no usable byte destination — an external leg with
+  no provider, or external-only over a pin-by-CID one — is never signed. Left
+  unchecked it would be a durable, account-wide refusal of every content
+  write, recoverable only by publishing a new record.
 - **The quota pre-flight gates this write's byte path, not the account.** It
   runs at command time, where the write already waits, sized in **sealed**
   bytes: `Hosted` and `Dual` are checked, `External` is skipped. `advisory` on

--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -639,6 +639,37 @@ contract-test suite owned by the testing-strategy blueprint (#28 D6).
   every mode's publish flow still traverses registration. `ByoIpfsConfig`
   stays sealed in vault settings; provider connection testing is engine-side
   over the Http seam (the TEE tester is gone).
+- **Dispatch is concrete over the Http seam, and only content versions
+  dispatch.** A record head block always takes the hosted path — the record
+  plane's publish compares the ingress's returned address against the head
+  block's own, and the republisher re-PUTs from the hosted store — so
+  placement decides a version's blocks, not a record's.
+  - The byte destinations a mode names are exactly what the provider's API
+    supports. Kubo takes bytes under the caller's own address (`block/put`
+    with the CID's multicodec and the frozen `blake3`/32 framing) and the
+    address it answers with is held to the one it was given. PSA and Pinata
+    are pin-by-CID services: they fetch the block from the network rather than
+    receive it, and their own ingress re-chunks under a different multihash,
+    so neither can preserve an address. They are therefore only ever a dual
+    write's second leg, and **external-only over a pin-by-CID provider is a
+    placement refusal** — no leg would hold the block for the service to
+    fetch, so the published record would name bytes that exist nowhere.
+  - **Dual runs both legs and only hosted can fail the op.** Under strict-FIFO
+    stop-at-first-failure a both-must-succeed rule would let an offline home
+    node stall every later mutation in the vault. The external leg's outcome
+    is reported per op rather than swallowed, and no retry is queued for it.
+    Under external, the member's provider _is_ the byte path, so its refusal
+    is the op's.
+- **The quota pre-flight gates this write's byte path, not the account.** It
+  runs at command time, where the write already waits, sized in **sealed**
+  bytes: `Hosted` and `Dual` are checked, `External` is skipped. `advisory` on
+  the quota response is a display hint that lags the vaulted mode — the mode
+  is the source of truth and the account flag is reconciled against it, since
+  `users.byo` is two-state where the mode is three and dual has no server
+  representation (`byo=true` is exactly `External`). The pre-flight can never
+  be authoritative — the API upload endpoint stays the enforcement — so an
+  unreachable or unconfigured API leaves the write to queue offline like any
+  other, while a placement that cannot be authenticated refuses it.
 - **BYO endpoint policy** (#905): one gate over the whole config, applied
   identically to a member-typed config and to one resolved back off the
   network, and release-active on the encode side so nothing is published that

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -26,9 +26,9 @@ pub use dag::{
     root_block_cid,
 };
 pub use profile::ContentProfile;
+pub(crate) use provider::place_block;
 pub use provider::{
-    ByoIpfsConfig, ByoKind, PinMode, Placement, PlacementDecision, PlacementRefusal, ProviderError,
-    decide_placement, place_block, test_connection, validate_byo_config,
+    ByoIpfsConfig, ByoKind, PinMode, ProviderError, test_connection, validate_byo_config,
 };
 pub use read::{
     ContentPlane, Gateway, GatewayConfig, GatewaySource, ReadError, is_plane_anchor,

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -27,7 +27,8 @@ pub use dag::{
 };
 pub use profile::ContentProfile;
 pub use provider::{
-    ByoIpfsConfig, ByoKind, PinMode, ProviderError, test_connection, validate_byo_config,
+    ByoIpfsConfig, ByoKind, PinMode, Placement, PlacementDecision, PlacementRefusal, ProviderError,
+    decide_placement, place_block, test_connection, validate_byo_config,
 };
 pub use read::{
     ContentPlane, Gateway, GatewayConfig, GatewaySource, ReadError, is_plane_anchor,

--- a/crates/engine/src/content/provider.rs
+++ b/crates/engine/src/content/provider.rs
@@ -207,9 +207,11 @@ fn pin_by_cid(config: &ByoIpfsConfig, path: &str, field: &str, cid: &str) -> Htt
     }
 }
 
-/// The address Kubo reports storing the block under, held to the caller's.
-/// Decoded to bytes before the compare, so a node that spells the same address
-/// in another multibase is a match rather than a disagreement.
+/// The address Kubo reports storing the block under, held to the caller's. The
+/// compare accepts only the canonical base32 spelling `encode_content_cid_str`
+/// sent — the strict `decode_content_cid_str` is deliberately the one decoder
+/// the content plane has, and widening it to every multibase alphabet to read a
+/// provider's echo would enlarge what a remote can steer for no safety gained.
 ///
 /// This catches a node that re-chunked or hashed the block differently — a
 /// misconfiguration, not an attack. A provider can always claim an address it

--- a/crates/engine/src/content/provider.rs
+++ b/crates/engine/src/content/provider.rs
@@ -1,30 +1,30 @@
-//! The pin-provider layer — hosted / external / dual placement and the
-//! engine-side BYO connection test over the `Http` seam (blueprint/engine.md
-//! "Content plane").
+//! The pin-provider layer — block dispatch to a member's own IPFS provider and
+//! the engine-side BYO connection test, both over the `Http` seam
+//! (blueprint/engine.md "Content plane").
 //!
-//! This module owns the placement decision surface, the BYO config type, its
-//! engine-side reachability probe, and the concrete block dispatch each provider
-//! kind takes. Registration and the publish pipeline (register-first, every
-//! mode) live in the net plane; sealing the config into vault settings is the
-//! vault-settings slice — the type here is the plaintext it seals.
+//! This module owns the BYO config type, its engine-side reachability probe,
+//! and the concrete block dispatch each provider kind takes. Which of them a
+//! write uses is the placement decision, which reads a vault settings load and
+//! so lives with it (`crate::settings`).
 
 use core::fmt;
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use cipherbox_core::content::{CONTENT_CID_CODEC, CONTENT_CID_LEN, encode_content_cid_str};
+use cipherbox_core::content::{
+    CONTENT_CID_CODEC, decode_content_cid_str, encode_content_cid_str, is_wellformed_content_cid,
+};
 use zeroize::Zeroizing;
 
 use crate::content::DAG_ROOT_CODEC;
 use crate::seams::{Http, HttpCredentials, HttpMethod, HttpRequest};
-use crate::settings::{DefaultsReason, SettingsLoad, VaultSettings};
 
 /// Deadline for a BYO-provider reachability probe: an unresponsive endpoint
 /// must read as unreachable rather than hang the settings flow.
 const PROBE_TIMEOUT_MS: u64 = 10_000;
 
-/// Deadline for one block placed on a member's provider — the same class of
-/// transfer the hosted ingress runs under, not the settings-flow probe above.
-const TRANSFER_TIMEOUT_MS: u64 = 60_000;
+/// Deadline for one block placed on a member's provider. Longer than the
+/// settings-flow probe above: this one moves up to a whole block.
+const PLACEMENT_TIMEOUT_MS: u64 = 60_000;
 
 const AUTHORIZATION: &str = "Authorization";
 const CONTENT_TYPE: &str = "Content-Type";
@@ -45,7 +45,8 @@ const METADATA: [IpAddr; 3] = [
 pub enum PinMode {
     /// CipherBox's hosted pin store (the default). Quota is authoritative.
     Hosted,
-    /// The member's own provider only. Quota is advisory.
+    /// The member's own provider only. No content block reaches the hosted
+    /// store; record heads and registration still do.
     External,
     /// Both hosted and the member's own provider.
     Dual,
@@ -91,104 +92,15 @@ impl fmt::Debug for ByoIpfsConfig {
     }
 }
 
-/// Where one write's bytes go, decided from the vault settings load and held
-/// for the session. The hosted leg is authoritative in both directions (#34 D1):
-/// only it can fail an op, and only it is quota-gated.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Placement {
-    /// CipherBox's hosted pin store only.
-    Hosted,
-    /// The member's own provider only — no byte reaches the hosted store.
-    External(ByoIpfsConfig),
-    /// Both legs.
-    Dual(ByoIpfsConfig),
-}
-
-impl Placement {
-    /// The mode this placement was decided from — what the quota pre-flight
-    /// gates on.
-    #[must_use]
-    pub fn mode(&self) -> PinMode {
-        match self {
-            Self::Hosted => PinMode::Hosted,
-            Self::External(_) => PinMode::External,
-            Self::Dual(_) => PinMode::Dual,
-        }
-    }
-
-    /// The member's own provider, when this placement names one.
-    #[must_use]
-    pub fn external(&self) -> Option<&ByoIpfsConfig> {
-        match self {
-            Self::Hosted => None,
-            Self::External(config) | Self::Dual(config) => Some(config),
-        }
-    }
-}
-
-/// The session's placement decision, as the command path and the drain both
-/// read it: where bytes go, or why no destination could be authenticated.
-pub type PlacementDecision = Result<Placement, PlacementRefusal>;
-
-/// Why no byte destination could be decided. Every variant refuses the write:
-/// a placement that cannot be authenticated must not widen to the hosted
-/// default (blueprint/engine.md "Settings-load policy").
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PlacementRefusal {
-    /// The settings load degraded past a first run with no last-known-good copy,
-    /// so the member's own placement choice is unavailable.
-    SettingsUnavailable(DefaultsReason),
-    /// The vaulted mode names an external leg the record carries no config for.
-    NoProvider,
-    /// External-only over a pin-by-CID provider, which has no byte ingress: no
-    /// leg would hold the block for it to fetch.
-    NoExternalIngress(ByoKind),
-}
-
-/// The byte destinations a settings load authorises.
+/// Place one already-addressed block on the member's own provider. `cid` must
+/// be the block's own content address, which the caller has already verified
+/// (`Drain::staged_block`).
 ///
-/// The built-in defaults describe a first run and nothing else: every other
-/// degraded reason with no last-known-good copy refuses rather than resolving
-/// to [`PinMode::Hosted`] (blueprint/engine.md "Settings-load policy").
-pub fn decide_placement(load: &SettingsLoad) -> Result<Placement, PlacementRefusal> {
-    let first_run;
-    let settings = match load {
-        SettingsLoad::Resolved(settings) | SettingsLoad::Stale { settings, .. } => settings,
-        SettingsLoad::Defaults(DefaultsReason::NoRecord) => {
-            first_run = VaultSettings::default();
-            &first_run
-        }
-        SettingsLoad::Defaults(reason) => {
-            return Err(PlacementRefusal::SettingsUnavailable(*reason));
-        }
-    };
-    let config = || settings.byo.clone().ok_or(PlacementRefusal::NoProvider);
-    match settings.pin_mode {
-        PinMode::Hosted => Ok(Placement::Hosted),
-        PinMode::Dual => Ok(Placement::Dual(config()?)),
-        PinMode::External => match config()? {
-            config @ ByoIpfsConfig {
-                kind: ByoKind::Kubo,
-                ..
-            } => Ok(Placement::External(config)),
-            config => Err(PlacementRefusal::NoExternalIngress(config.kind)),
-        },
-    }
-}
-
-/// Place one already-addressed block on the member's own provider.
-///
-/// Kubo takes the bytes under exactly the caller's address — `block/put` under
-/// the CID's own multicodec and the frozen BLAKE3-256 framing — and the address
-/// it answers with is checked against the caller's, so a provider that stored
-/// the block elsewhere is a failure rather than a silent divergence. PSA and
-/// Pinata have no byte ingress that preserves an address: they are asked to pin
-/// the CID and fetch it themselves, which is why [`decide_placement`] only ever
-/// pairs them with a hosted leg.
-///
-/// The config passes [`validate_byo_config`] here as it does everywhere else it
-/// reaches the seam — the endpoint and the bearer are spliced into a request.
-pub async fn place_block(
+/// Kubo takes the bytes under exactly that address — `block/put` under the CID's
+/// own multicodec and the frozen BLAKE3-256 framing. PSA and Pinata have no byte
+/// ingress that preserves an address: they are asked to pin the CID and fetch it
+/// themselves.
+pub(crate) async fn place_block(
     config: &ByoIpfsConfig,
     cid: &[u8],
     block: &[u8],
@@ -211,9 +123,7 @@ pub async fn place_block(
         });
     }
     match config.kind {
-        ByoKind::Kubo => kubo_stored_address(&response.body, &address.cid),
-        // A pin-by-CID service reports progress out of band; a 2xx is only an
-        // accepted request, so there is no address to check here.
+        ByoKind::Kubo => kubo_stored_address(&response.body, cid),
         ByoKind::Psa | ByoKind::Pinata => Ok(()),
     }
 }
@@ -226,12 +136,16 @@ struct ContentAddress {
 }
 
 /// Read a block's address, fail-closed on anything outside the two frozen
-/// content-plane shapes — a codec no provider could be told to store it under.
+/// content-plane shapes. Core's own framing predicate runs first: it is what
+/// [`encode_content_cid_str`] asserts on, so screening the codec alone would
+/// turn a malformed address into a panic instead of this verdict.
 fn content_address(cid: &[u8]) -> Result<ContentAddress, ProviderError> {
-    const CODEC: usize = 1;
-    let codec = match cid.get(CODEC) {
-        Some(&CONTENT_CID_CODEC) if cid.len() == CONTENT_CID_LEN => "raw",
-        Some(&DAG_ROOT_CODEC) if cid.len() == CONTENT_CID_LEN => "dag-cbor",
+    if !is_wellformed_content_cid(cid) {
+        return Err(ProviderError::MalformedBlockAddress);
+    }
+    let codec = match cid[1] {
+        CONTENT_CID_CODEC => "raw",
+        DAG_ROOT_CODEC => "dag-cbor",
         _ => return Err(ProviderError::MalformedBlockAddress),
     };
     Ok(ContentAddress {
@@ -244,23 +158,30 @@ fn content_address(cid: &[u8]) -> Result<ContentAddress, ProviderError> {
 /// pinned in the same call, so the member's node addresses it exactly as the
 /// engine does.
 fn kubo_block_put(config: &ByoIpfsConfig, address: &ContentAddress, block: &[u8]) -> HttpRequest {
-    // Derived from the block's own address: a block containing its own BLAKE3
-    // digest would be a preimage, so the delimiter cannot occur in the payload
-    // and the framing needs no escape or collision check.
+    // Derived from the block's own address, so the delimiter cannot occur in the
+    // payload it frames: that would take a block carrying the base32 of its own
+    // BLAKE3 digest, which is a preimage. 62 bytes of base32 and `-`, inside RFC
+    // 2046's 70-character cap.
     let boundary = format!("cb-{}", address.cid);
-    let mut body = format!(
+    let head = format!(
         "--{boundary}\r\n\
          Content-Disposition: form-data; name=\"data\"; filename=\"blob\"\r\n\
          Content-Type: application/octet-stream\r\n\r\n"
-    )
-    .into_bytes();
+    );
+    let tail = format!("\r\n--{boundary}--\r\n");
+    let mut body = Vec::with_capacity(head.len() + block.len() + tail.len());
+    body.extend_from_slice(head.as_bytes());
     body.extend_from_slice(block);
-    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    body.extend_from_slice(tail.as_bytes());
     let codec = address.codec;
     HttpRequest {
         method: HttpMethod::Post,
+        // A DAG root inlines a CID per leaf, so it passes Kubo's 1 MiB
+        // block/put advisory well before the flat-DAG ceiling does. The block is
+        // content-addressed and self-verifying, so the advice does not apply.
         url: format!(
-            "{}/api/v0/block/put?cid-codec={codec}&mhtype=blake3&mhlen=32&pin=true",
+            "{}/api/v0/block/put\
+             ?cid-codec={codec}&mhtype=blake3&mhlen=32&pin=true&allow-big-block=true",
             base(config)
         ),
         headers: headers(
@@ -269,7 +190,7 @@ fn kubo_block_put(config: &ByoIpfsConfig, address: &ContentAddress, block: &[u8]
         ),
         body: Some(body),
         credentials: HttpCredentials::Omit,
-        timeout_ms: Some(TRANSFER_TIMEOUT_MS),
+        timeout_ms: Some(PLACEMENT_TIMEOUT_MS),
     }
 }
 
@@ -282,16 +203,21 @@ fn pin_by_cid(config: &ByoIpfsConfig, path: &str, field: &str, cid: &str) -> Htt
         // The CID is base32 alphanumerics, so it needs no JSON escaping.
         body: Some(format!("{{\"{field}\":\"{cid}\"}}").into_bytes()),
         credentials: HttpCredentials::Omit,
-        timeout_ms: Some(TRANSFER_TIMEOUT_MS),
+        timeout_ms: Some(PLACEMENT_TIMEOUT_MS),
     }
 }
 
 /// The address Kubo reports storing the block under, held to the caller's.
+/// Decoded to bytes before the compare, so a node that spells the same address
+/// in another multibase is a match rather than a disagreement.
+///
+/// This catches a node that re-chunked or hashed the block differently — a
+/// misconfiguration, not an attack. A provider can always claim an address it
+/// does not serve; what makes a read safe is the reader's own `verify_cid`.
 ///
 /// Kubo streams newline-delimited JSON; a trailing error object parses but
-/// carries no `Key`, so an absent one is a store fault rather than a
-/// disagreeing address.
-fn kubo_stored_address(body: &[u8], expected: &str) -> Result<(), ProviderError> {
+/// carries no `Key`, so an absent one is no usable answer.
+fn kubo_stored_address(body: &[u8], expected: &[u8]) -> Result<(), ProviderError> {
     #[derive(serde::Deserialize)]
     struct BlockPut {
         #[serde(rename = "Key")]
@@ -302,11 +228,10 @@ fn kubo_stored_address(body: &[u8], expected: &str) -> Result<(), ProviderError>
         .and_then(|body| body.trim().lines().next_back().map(str::to_owned));
     let stored = last
         .and_then(|line| serde_json::from_str::<BlockPut>(&line).ok())
-        .ok_or(ProviderError::Unreachable)?;
-    if stored.key == expected {
-        Ok(())
-    } else {
-        Err(ProviderError::AddressMismatch)
+        .ok_or(ProviderError::NoVerdict)?;
+    match decode_content_cid_str(&stored.key) {
+        Ok(stored) if stored == expected => Ok(()),
+        _ => Err(ProviderError::AddressMismatch),
     }
 }
 
@@ -352,6 +277,8 @@ pub enum ProviderError {
     InvalidCredential,
     /// The provider could not be reached (transport-level failure).
     Unreachable,
+    /// The provider answered, but with nothing that says what it did.
+    NoVerdict,
     /// The provider was reached but rejected the request (bad endpoint, auth
     /// failure, or an unhealthy node): a non-2xx status.
     Rejected {
@@ -737,115 +664,6 @@ mod tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Placement: what a settings load authorises, and what it refuses.
-    // -----------------------------------------------------------------------
-
-    fn settings(mode: PinMode, byo: Option<ByoIpfsConfig>) -> VaultSettings {
-        VaultSettings {
-            pin_mode: mode,
-            byo,
-            ..VaultSettings::default()
-        }
-    }
-
-    #[test]
-    fn a_resolved_record_places_bytes_where_the_member_chose() {
-        let kubo = config(ByoKind::Kubo, Some("tok"));
-        for (mode, expected) in [
-            (PinMode::Hosted, Placement::Hosted),
-            (PinMode::External, Placement::External(kubo.clone())),
-            (PinMode::Dual, Placement::Dual(kubo.clone())),
-        ] {
-            let load = SettingsLoad::Resolved(settings(mode, Some(kubo.clone())));
-            assert_eq!(decide_placement(&load).unwrap(), expected);
-        }
-    }
-
-    /// The last-known-good copy is the member's own choice, so it decides
-    /// placement exactly as a resolved record does — that is the whole point of
-    /// keeping it (blueprint/engine.md "Settings-load policy").
-    #[test]
-    fn a_stale_copy_decides_placement_like_a_resolved_record() {
-        let load = SettingsLoad::Stale {
-            settings: settings(PinMode::External, Some(config(ByoKind::Kubo, None))),
-            reason: DefaultsReason::Suppressed,
-        };
-        assert_eq!(
-            decide_placement(&load).unwrap(),
-            Placement::External(config(ByoKind::Kubo, None))
-        );
-    }
-
-    /// The built-in defaults describe a first run and nothing else: every other
-    /// degraded reason refuses rather than widening an unknown choice onto the
-    /// hosted store.
-    #[test]
-    fn only_a_first_run_falls_back_to_the_hosted_default() {
-        assert_eq!(
-            decide_placement(&SettingsLoad::Defaults(DefaultsReason::NoRecord)).unwrap(),
-            Placement::Hosted
-        );
-        for reason in [
-            DefaultsReason::Suppressed,
-            DefaultsReason::RolledBack {
-                floor: 4,
-                sequence: 2,
-            },
-            DefaultsReason::RevisionRolledBack {
-                floor: 4,
-                revision: 2,
-            },
-            DefaultsReason::Expired,
-            DefaultsReason::TimedOut,
-            DefaultsReason::Unreadable,
-            DefaultsReason::FloorUnreadable,
-        ] {
-            assert_eq!(
-                decide_placement(&SettingsLoad::Defaults(reason)).unwrap_err(),
-                PlacementRefusal::SettingsUnavailable(reason),
-                "{reason:?} must not widen placement"
-            );
-        }
-    }
-
-    #[test]
-    fn a_mode_naming_an_external_leg_with_no_provider_is_refused() {
-        for mode in [PinMode::External, PinMode::Dual] {
-            let load = SettingsLoad::Resolved(settings(mode, None));
-            assert_eq!(
-                decide_placement(&load).unwrap_err(),
-                PlacementRefusal::NoProvider
-            );
-        }
-    }
-
-    /// A pinning service fetches content from the network rather than receiving
-    /// it, so external-only over one would publish a record naming bytes no leg
-    /// holds. Paired with a hosted leg it is exactly right.
-    #[test]
-    fn a_pin_by_cid_provider_cannot_be_the_only_byte_destination() {
-        for kind in [ByoKind::Psa, ByoKind::Pinata] {
-            let byo = Some(config(kind, Some("tok")));
-            assert_eq!(
-                decide_placement(&SettingsLoad::Resolved(settings(
-                    PinMode::External,
-                    byo.clone()
-                )))
-                .unwrap_err(),
-                PlacementRefusal::NoExternalIngress(kind)
-            );
-            assert!(
-                decide_placement(&SettingsLoad::Resolved(settings(PinMode::Dual, byo))).is_ok(),
-                "{kind:?} is a fine second leg"
-            );
-        }
-    }
-
-    // -----------------------------------------------------------------------
-    // Block placement: what each provider kind is actually sent.
-    // -----------------------------------------------------------------------
-
     fn leaf(bytes: &[u8]) -> Vec<u8> {
         compute_cid(CONTENT_CID_CODEC, bytes)
     }
@@ -874,7 +692,7 @@ mod tests {
         assert_eq!(
             request.url,
             "https://ipfs.member.test/api/v0/block/put\
-             ?cid-codec=raw&mhtype=blake3&mhlen=32&pin=true"
+             ?cid-codec=raw&mhtype=blake3&mhlen=32&pin=true&allow-big-block=true"
         );
         let boundary = request
             .headers
@@ -884,12 +702,6 @@ mod tests {
             .expect("the request declares its multipart boundary")
             .to_owned();
         let body = request.body.as_ref().expect("a block/put carries a body");
-        assert!(
-            !block
-                .windows(boundary.len())
-                .any(|w| w == boundary.as_bytes()),
-            "the delimiter cannot occur in the payload it frames"
-        );
         assert!(
             body.windows(block.len()).any(|window| window == block),
             "the block rides the body verbatim"
@@ -1035,15 +847,29 @@ mod tests {
         assert!(http.requests().is_empty());
     }
 
+    /// Every byte of the frozen framing, not just the codec: the address is
+    /// rendered for the request, and core's renderer aborts rather than returns
+    /// on a malformed one.
     #[test]
     fn a_block_address_outside_the_frozen_shapes_is_refused_before_the_seam() {
         let http = ScriptedHttp::default();
-        let mut wrong_codec = leaf(b"x");
-        wrong_codec[1] = 0x70; // dag-pb: not a content-plane codec.
-        for cid in [wrong_codec, leaf(b"x")[..8].to_vec(), Vec::new()] {
+        let mutated = |index: usize, byte: u8| {
+            let mut cid = leaf(b"x");
+            cid[index] = byte;
+            cid
+        };
+        for cid in [
+            mutated(0, 0x02), // CID version
+            mutated(1, 0x70), // dag-pb: not a content-plane codec
+            mutated(2, 0x12), // sha2-256: not the frozen multihash
+            mutated(3, 0x40), // a digest width the framing does not carry
+            leaf(b"x")[..8].to_vec(),
+            Vec::new(),
+        ] {
             assert_eq!(
                 block_on(place_block(&config(ByoKind::Kubo, None), &cid, b"x", &http)).unwrap_err(),
-                ProviderError::MalformedBlockAddress
+                ProviderError::MalformedBlockAddress,
+                "{cid:02x?}"
             );
         }
         assert!(http.requests().is_empty());

--- a/crates/engine/src/content/provider.rs
+++ b/crates/engine/src/content/provider.rs
@@ -16,7 +16,9 @@ use cipherbox_core::content::{
 use zeroize::Zeroizing;
 
 use crate::content::DAG_ROOT_CODEC;
-use crate::seams::{Http, HttpCredentials, HttpMethod, HttpRequest};
+use crate::seams::{
+    CappedFetchError, Http, HttpCredentials, HttpMethod, HttpRequest, HttpResponse,
+};
 
 /// Deadline for a BYO-provider reachability probe: an unresponsive endpoint
 /// must read as unreachable rather than hang the settings flow.
@@ -25,6 +27,13 @@ const PROBE_TIMEOUT_MS: u64 = 10_000;
 /// Deadline for one block placed on a member's provider. Longer than the
 /// settings-flow probe above: this one moves up to a whole block.
 const PLACEMENT_TIMEOUT_MS: u64 = 60_000;
+
+/// Ceiling on what a BYO provider may answer with. The endpoint is
+/// member-supplied and answers over the network, so an uncapped read lets it
+/// size this process's memory. Every reply these requests have a use for is a
+/// status line and a small JSON object; Kubo's newline-delimited `block/put`
+/// stream is the largest, one short object per block put.
+const MAX_PROVIDER_RESPONSE_BYTES: usize = 64 * 1024;
 
 const AUTHORIZATION: &str = "Authorization";
 const CONTENT_TYPE: &str = "Content-Type";
@@ -113,10 +122,7 @@ pub(crate) async fn place_block(
         ByoKind::Psa => pin_by_cid(config, "/pins", "cid", &address.cid),
         ByoKind::Pinata => pin_by_cid(config, "/pinning/pinByHash", "hashToPin", &address.cid),
     };
-    let response = http
-        .send(request)
-        .await
-        .map_err(|_| ProviderError::Unreachable)?;
+    let response = capped(http, request).await?;
     if !(200..300).contains(&response.status) {
         return Err(ProviderError::Rejected {
             status: response.status,
@@ -126,6 +132,19 @@ pub(crate) async fn place_block(
         ByoKind::Kubo => kubo_stored_address(&response.body, cid),
         ByoKind::Psa | ByoKind::Pinata => Ok(()),
     }
+}
+
+/// One request to a member's provider, its response bounded by
+/// [`MAX_PROVIDER_RESPONSE_BYTES`]. An over-cap body is
+/// [`ProviderError::NoVerdict`]: the transport aborted before the answer was
+/// whole, so nothing in it says what the provider did.
+async fn capped(http: &impl Http, request: HttpRequest) -> Result<HttpResponse, ProviderError> {
+    http.send_capped(request, MAX_PROVIDER_RESPONSE_BYTES)
+        .await
+        .map_err(|error| match error {
+            CappedFetchError::Transport(_) => ProviderError::Unreachable,
+            CappedFetchError::BodyTooLarge { .. } => ProviderError::NoVerdict,
+        })
 }
 
 /// One block's content address in the two spellings a provider request needs.
@@ -307,11 +326,7 @@ pub async fn test_connection(
     http: &impl Http,
 ) -> Result<(), ProviderError> {
     validate_byo_config(config)?;
-    let request = probe_request(config);
-    let response = http
-        .send(request)
-        .await
-        .map_err(|_| ProviderError::Unreachable)?;
+    let response = capped(http, probe_request(config)).await?;
     if (200..300).contains(&response.status) {
         Ok(())
     } else {
@@ -875,6 +890,37 @@ mod tests {
             );
         }
         assert!(http.requests().is_empty());
+    }
+
+    /// The endpoint is member-supplied and answers over the network, so what it
+    /// returns is bounded before it is read. An over-cap body is no answer at
+    /// all, never bytes this process accumulates.
+    #[test]
+    fn an_over_cap_provider_body_is_no_verdict() {
+        let oversized = || HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: vec![b'{'; MAX_PROVIDER_RESPONSE_BYTES + 1],
+        };
+        let block = b"sealed leaf bytes".to_vec();
+        let cid = leaf(&block);
+        for kind in [ByoKind::Kubo, ByoKind::Psa, ByoKind::Pinata] {
+            let http = ScriptedHttp::default();
+            http.enqueue_response(oversized());
+            assert_eq!(
+                block_on(place_block(&config(kind, Some("tok")), &cid, &block, &http)).unwrap_err(),
+                ProviderError::NoVerdict,
+                "{kind:?}"
+            );
+
+            let http = ScriptedHttp::default();
+            http.enqueue_response(oversized());
+            assert_eq!(
+                block_on(test_connection(&config(kind, Some("tok")), &http)).unwrap_err(),
+                ProviderError::NoVerdict,
+                "{kind:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/src/content/provider.rs
+++ b/crates/engine/src/content/provider.rs
@@ -2,24 +2,33 @@
 //! engine-side BYO connection test over the `Http` seam (blueprint/engine.md
 //! "Content plane").
 //!
-//! This module owns the placement decision surface and the BYO config type plus
-//! its engine-side reachability probe. Registration and the publish pipeline
-//! (register-first, every mode) live in the net plane; sealing the config into
-//! vault settings is the payload/vault-settings slice — the type here is the
-//! plaintext it seals.
+//! This module owns the placement decision surface, the BYO config type, its
+//! engine-side reachability probe, and the concrete block dispatch each provider
+//! kind takes. Registration and the publish pipeline (register-first, every
+//! mode) live in the net plane; sealing the config into vault settings is the
+//! vault-settings slice — the type here is the plaintext it seals.
 
 use core::fmt;
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+use cipherbox_core::content::{CONTENT_CID_CODEC, CONTENT_CID_LEN, encode_content_cid_str};
 use zeroize::Zeroizing;
 
+use crate::content::DAG_ROOT_CODEC;
 use crate::seams::{Http, HttpCredentials, HttpMethod, HttpRequest};
+use crate::settings::{DefaultsReason, SettingsLoad, VaultSettings};
 
 /// Deadline for a BYO-provider reachability probe: an unresponsive endpoint
 /// must read as unreachable rather than hang the settings flow.
 const PROBE_TIMEOUT_MS: u64 = 10_000;
 
+/// Deadline for one block placed on a member's provider — the same class of
+/// transfer the hosted ingress runs under, not the settings-flow probe above.
+const TRANSFER_TIMEOUT_MS: u64 = 60_000;
+
 const AUTHORIZATION: &str = "Authorization";
+const CONTENT_TYPE: &str = "Content-Type";
+const APPLICATION_JSON: &str = "application/json";
 
 /// The cloud metadata service, which no IPFS provider serves: the link-local
 /// address in the two IPv6 spellings `to_canonical` does not fold, and the IPv6
@@ -82,6 +91,245 @@ impl fmt::Debug for ByoIpfsConfig {
     }
 }
 
+/// Where one write's bytes go, decided from the vault settings load and held
+/// for the session. The hosted leg is authoritative in both directions (#34 D1):
+/// only it can fail an op, and only it is quota-gated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Placement {
+    /// CipherBox's hosted pin store only.
+    Hosted,
+    /// The member's own provider only — no byte reaches the hosted store.
+    External(ByoIpfsConfig),
+    /// Both legs.
+    Dual(ByoIpfsConfig),
+}
+
+impl Placement {
+    /// The mode this placement was decided from — what the quota pre-flight
+    /// gates on.
+    #[must_use]
+    pub fn mode(&self) -> PinMode {
+        match self {
+            Self::Hosted => PinMode::Hosted,
+            Self::External(_) => PinMode::External,
+            Self::Dual(_) => PinMode::Dual,
+        }
+    }
+
+    /// The member's own provider, when this placement names one.
+    #[must_use]
+    pub fn external(&self) -> Option<&ByoIpfsConfig> {
+        match self {
+            Self::Hosted => None,
+            Self::External(config) | Self::Dual(config) => Some(config),
+        }
+    }
+}
+
+/// The session's placement decision, as the command path and the drain both
+/// read it: where bytes go, or why no destination could be authenticated.
+pub type PlacementDecision = Result<Placement, PlacementRefusal>;
+
+/// Why no byte destination could be decided. Every variant refuses the write:
+/// a placement that cannot be authenticated must not widen to the hosted
+/// default (blueprint/engine.md "Settings-load policy").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlacementRefusal {
+    /// The settings load degraded past a first run with no last-known-good copy,
+    /// so the member's own placement choice is unavailable.
+    SettingsUnavailable(DefaultsReason),
+    /// The vaulted mode names an external leg the record carries no config for.
+    NoProvider,
+    /// External-only over a pin-by-CID provider, which has no byte ingress: no
+    /// leg would hold the block for it to fetch.
+    NoExternalIngress(ByoKind),
+}
+
+/// The byte destinations a settings load authorises.
+///
+/// The built-in defaults describe a first run and nothing else: every other
+/// degraded reason with no last-known-good copy refuses rather than resolving
+/// to [`PinMode::Hosted`] (blueprint/engine.md "Settings-load policy").
+pub fn decide_placement(load: &SettingsLoad) -> Result<Placement, PlacementRefusal> {
+    let first_run;
+    let settings = match load {
+        SettingsLoad::Resolved(settings) | SettingsLoad::Stale { settings, .. } => settings,
+        SettingsLoad::Defaults(DefaultsReason::NoRecord) => {
+            first_run = VaultSettings::default();
+            &first_run
+        }
+        SettingsLoad::Defaults(reason) => {
+            return Err(PlacementRefusal::SettingsUnavailable(*reason));
+        }
+    };
+    let config = || settings.byo.clone().ok_or(PlacementRefusal::NoProvider);
+    match settings.pin_mode {
+        PinMode::Hosted => Ok(Placement::Hosted),
+        PinMode::Dual => Ok(Placement::Dual(config()?)),
+        PinMode::External => match config()? {
+            config @ ByoIpfsConfig {
+                kind: ByoKind::Kubo,
+                ..
+            } => Ok(Placement::External(config)),
+            config => Err(PlacementRefusal::NoExternalIngress(config.kind)),
+        },
+    }
+}
+
+/// Place one already-addressed block on the member's own provider.
+///
+/// Kubo takes the bytes under exactly the caller's address — `block/put` under
+/// the CID's own multicodec and the frozen BLAKE3-256 framing — and the address
+/// it answers with is checked against the caller's, so a provider that stored
+/// the block elsewhere is a failure rather than a silent divergence. PSA and
+/// Pinata have no byte ingress that preserves an address: they are asked to pin
+/// the CID and fetch it themselves, which is why [`decide_placement`] only ever
+/// pairs them with a hosted leg.
+///
+/// The config passes [`validate_byo_config`] here as it does everywhere else it
+/// reaches the seam — the endpoint and the bearer are spliced into a request.
+pub async fn place_block(
+    config: &ByoIpfsConfig,
+    cid: &[u8],
+    block: &[u8],
+    http: &impl Http,
+) -> Result<(), ProviderError> {
+    validate_byo_config(config)?;
+    let address = content_address(cid)?;
+    let request = match config.kind {
+        ByoKind::Kubo => kubo_block_put(config, &address, block),
+        ByoKind::Psa => pin_by_cid(config, "/pins", "cid", &address.cid),
+        ByoKind::Pinata => pin_by_cid(config, "/pinning/pinByHash", "hashToPin", &address.cid),
+    };
+    let response = http
+        .send(request)
+        .await
+        .map_err(|_| ProviderError::Unreachable)?;
+    if !(200..300).contains(&response.status) {
+        return Err(ProviderError::Rejected {
+            status: response.status,
+        });
+    }
+    match config.kind {
+        ByoKind::Kubo => kubo_stored_address(&response.body, &address.cid),
+        // A pin-by-CID service reports progress out of band; a 2xx is only an
+        // accepted request, so there is no address to check here.
+        ByoKind::Psa | ByoKind::Pinata => Ok(()),
+    }
+}
+
+/// One block's content address in the two spellings a provider request needs.
+struct ContentAddress {
+    cid: String,
+    /// The Kubo `cid-codec` name for the CID's own multicodec.
+    codec: &'static str,
+}
+
+/// Read a block's address, fail-closed on anything outside the two frozen
+/// content-plane shapes — a codec no provider could be told to store it under.
+fn content_address(cid: &[u8]) -> Result<ContentAddress, ProviderError> {
+    const CODEC: usize = 1;
+    let codec = match cid.get(CODEC) {
+        Some(&CONTENT_CID_CODEC) if cid.len() == CONTENT_CID_LEN => "raw",
+        Some(&DAG_ROOT_CODEC) if cid.len() == CONTENT_CID_LEN => "dag-cbor",
+        _ => return Err(ProviderError::MalformedBlockAddress),
+    };
+    Ok(ContentAddress {
+        cid: encode_content_cid_str(cid),
+        codec,
+    })
+}
+
+/// `block/put` under the block's own codec and the frozen BLAKE3-256 framing,
+/// pinned in the same call, so the member's node addresses it exactly as the
+/// engine does.
+fn kubo_block_put(config: &ByoIpfsConfig, address: &ContentAddress, block: &[u8]) -> HttpRequest {
+    // Derived from the block's own address: a block containing its own BLAKE3
+    // digest would be a preimage, so the delimiter cannot occur in the payload
+    // and the framing needs no escape or collision check.
+    let boundary = format!("cb-{}", address.cid);
+    let mut body = format!(
+        "--{boundary}\r\n\
+         Content-Disposition: form-data; name=\"data\"; filename=\"blob\"\r\n\
+         Content-Type: application/octet-stream\r\n\r\n"
+    )
+    .into_bytes();
+    body.extend_from_slice(block);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    let codec = address.codec;
+    HttpRequest {
+        method: HttpMethod::Post,
+        url: format!(
+            "{}/api/v0/block/put?cid-codec={codec}&mhtype=blake3&mhlen=32&pin=true",
+            base(config)
+        ),
+        headers: headers(
+            config,
+            Some(format!("multipart/form-data; boundary={boundary}")),
+        ),
+        body: Some(body),
+        credentials: HttpCredentials::Omit,
+        timeout_ms: Some(TRANSFER_TIMEOUT_MS),
+    }
+}
+
+/// Ask a pin-by-CID service to pin an address it fetches itself.
+fn pin_by_cid(config: &ByoIpfsConfig, path: &str, field: &str, cid: &str) -> HttpRequest {
+    HttpRequest {
+        method: HttpMethod::Post,
+        url: format!("{}{path}", base(config)),
+        headers: headers(config, Some(APPLICATION_JSON.to_owned())),
+        // The CID is base32 alphanumerics, so it needs no JSON escaping.
+        body: Some(format!("{{\"{field}\":\"{cid}\"}}").into_bytes()),
+        credentials: HttpCredentials::Omit,
+        timeout_ms: Some(TRANSFER_TIMEOUT_MS),
+    }
+}
+
+/// The address Kubo reports storing the block under, held to the caller's.
+///
+/// Kubo streams newline-delimited JSON; a trailing error object parses but
+/// carries no `Key`, so an absent one is a store fault rather than a
+/// disagreeing address.
+fn kubo_stored_address(body: &[u8], expected: &str) -> Result<(), ProviderError> {
+    #[derive(serde::Deserialize)]
+    struct BlockPut {
+        #[serde(rename = "Key")]
+        key: String,
+    }
+    let last = core::str::from_utf8(body)
+        .ok()
+        .and_then(|body| body.trim().lines().next_back().map(str::to_owned));
+    let stored = last
+        .and_then(|line| serde_json::from_str::<BlockPut>(&line).ok())
+        .ok_or(ProviderError::Unreachable)?;
+    if stored.key == expected {
+        Ok(())
+    } else {
+        Err(ProviderError::AddressMismatch)
+    }
+}
+
+fn base(config: &ByoIpfsConfig) -> &str {
+    config.endpoint.trim_end_matches('/')
+}
+
+/// The bearer the config carries, plus a content type when the request has a
+/// body. The configured access token is the only credential a BYO endpoint gets.
+fn headers(config: &ByoIpfsConfig, content_type: Option<String>) -> Vec<(String, String)> {
+    let mut headers = Vec::new();
+    if let Some(token) = &config.access_token {
+        headers.push((
+            AUTHORIZATION.to_owned(),
+            format!("Bearer {}", token.as_str()),
+        ));
+    }
+    if let Some(content_type) = content_type {
+        headers.push((CONTENT_TYPE.to_owned(), content_type));
+    }
+    headers
+}
+
 /// Why a provider connection test did not succeed. The first four are policy
 /// verdicts reached before any request is issued, kept distinct so a host can
 /// say which rule refused the config instead of showing a bare failure.
@@ -104,12 +352,18 @@ pub enum ProviderError {
     InvalidCredential,
     /// The provider could not be reached (transport-level failure).
     Unreachable,
-    /// The provider was reached but rejected the probe (bad endpoint, auth
+    /// The provider was reached but rejected the request (bad endpoint, auth
     /// failure, or an unhealthy node): a non-2xx status.
     Rejected {
         /// The status the provider returned.
         status: u16,
     },
+    /// The block's address is not one of the two frozen content-plane shapes,
+    /// so no provider can be told the codec to store it under.
+    MalformedBlockAddress,
+    /// The provider stored the block under an address other than the one it was
+    /// given, so the published record would name bytes it does not serve.
+    AddressMismatch,
 }
 
 /// Test that a member's BYO provider is reachable and authenticated, engine-side
@@ -276,26 +530,16 @@ fn is_bearer_byte(b: u8) -> bool {
 /// identity/auth check: Kubo `POST /api/v0/id`, PSA `GET /pins?limit=1`, Pinata
 /// `GET /data/testAuthentication`.
 fn probe_request(config: &ByoIpfsConfig) -> HttpRequest {
-    let base = config.endpoint.trim_end_matches('/');
     let (method, path) = match config.kind {
         ByoKind::Kubo => (HttpMethod::Post, "/api/v0/id"),
         ByoKind::Psa => (HttpMethod::Get, "/pins?limit=1"),
         ByoKind::Pinata => (HttpMethod::Get, "/data/testAuthentication"),
     };
-    let mut headers = Vec::new();
-    if let Some(token) = &config.access_token {
-        headers.push((
-            AUTHORIZATION.to_owned(),
-            format!("Bearer {}", token.as_str()),
-        ));
-    }
     HttpRequest {
         method,
-        url: format!("{base}{path}"),
-        headers,
+        url: format!("{}{path}", base(config)),
+        headers: headers(config, None),
         body: None,
-        // The configured access token above is the only credential a BYO
-        // endpoint gets.
         credentials: HttpCredentials::Omit,
         timeout_ms: Some(PROBE_TIMEOUT_MS),
     }
@@ -304,6 +548,8 @@ fn probe_request(config: &ByoIpfsConfig) -> HttpRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cipherbox_core::content::compute_cid;
+
     use crate::seams::HttpResponse;
     use crate::testkit::block_on;
     use crate::testkit::fakes::ScriptedHttp;
@@ -489,6 +735,318 @@ mod tests {
             http.requests().is_empty(),
             "a refused credential never reaches the seam"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Placement: what a settings load authorises, and what it refuses.
+    // -----------------------------------------------------------------------
+
+    fn settings(mode: PinMode, byo: Option<ByoIpfsConfig>) -> VaultSettings {
+        VaultSettings {
+            pin_mode: mode,
+            byo,
+            ..VaultSettings::default()
+        }
+    }
+
+    #[test]
+    fn a_resolved_record_places_bytes_where_the_member_chose() {
+        let kubo = config(ByoKind::Kubo, Some("tok"));
+        for (mode, expected) in [
+            (PinMode::Hosted, Placement::Hosted),
+            (PinMode::External, Placement::External(kubo.clone())),
+            (PinMode::Dual, Placement::Dual(kubo.clone())),
+        ] {
+            let load = SettingsLoad::Resolved(settings(mode, Some(kubo.clone())));
+            assert_eq!(decide_placement(&load).unwrap(), expected);
+        }
+    }
+
+    /// The last-known-good copy is the member's own choice, so it decides
+    /// placement exactly as a resolved record does — that is the whole point of
+    /// keeping it (blueprint/engine.md "Settings-load policy").
+    #[test]
+    fn a_stale_copy_decides_placement_like_a_resolved_record() {
+        let load = SettingsLoad::Stale {
+            settings: settings(PinMode::External, Some(config(ByoKind::Kubo, None))),
+            reason: DefaultsReason::Suppressed,
+        };
+        assert_eq!(
+            decide_placement(&load).unwrap(),
+            Placement::External(config(ByoKind::Kubo, None))
+        );
+    }
+
+    /// The built-in defaults describe a first run and nothing else: every other
+    /// degraded reason refuses rather than widening an unknown choice onto the
+    /// hosted store.
+    #[test]
+    fn only_a_first_run_falls_back_to_the_hosted_default() {
+        assert_eq!(
+            decide_placement(&SettingsLoad::Defaults(DefaultsReason::NoRecord)).unwrap(),
+            Placement::Hosted
+        );
+        for reason in [
+            DefaultsReason::Suppressed,
+            DefaultsReason::RolledBack {
+                floor: 4,
+                sequence: 2,
+            },
+            DefaultsReason::RevisionRolledBack {
+                floor: 4,
+                revision: 2,
+            },
+            DefaultsReason::Expired,
+            DefaultsReason::TimedOut,
+            DefaultsReason::Unreadable,
+            DefaultsReason::FloorUnreadable,
+        ] {
+            assert_eq!(
+                decide_placement(&SettingsLoad::Defaults(reason)).unwrap_err(),
+                PlacementRefusal::SettingsUnavailable(reason),
+                "{reason:?} must not widen placement"
+            );
+        }
+    }
+
+    #[test]
+    fn a_mode_naming_an_external_leg_with_no_provider_is_refused() {
+        for mode in [PinMode::External, PinMode::Dual] {
+            let load = SettingsLoad::Resolved(settings(mode, None));
+            assert_eq!(
+                decide_placement(&load).unwrap_err(),
+                PlacementRefusal::NoProvider
+            );
+        }
+    }
+
+    /// A pinning service fetches content from the network rather than receiving
+    /// it, so external-only over one would publish a record naming bytes no leg
+    /// holds. Paired with a hosted leg it is exactly right.
+    #[test]
+    fn a_pin_by_cid_provider_cannot_be_the_only_byte_destination() {
+        for kind in [ByoKind::Psa, ByoKind::Pinata] {
+            let byo = Some(config(kind, Some("tok")));
+            assert_eq!(
+                decide_placement(&SettingsLoad::Resolved(settings(
+                    PinMode::External,
+                    byo.clone()
+                )))
+                .unwrap_err(),
+                PlacementRefusal::NoExternalIngress(kind)
+            );
+            assert!(
+                decide_placement(&SettingsLoad::Resolved(settings(PinMode::Dual, byo))).is_ok(),
+                "{kind:?} is a fine second leg"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Block placement: what each provider kind is actually sent.
+    // -----------------------------------------------------------------------
+
+    fn leaf(bytes: &[u8]) -> Vec<u8> {
+        compute_cid(CONTENT_CID_CODEC, bytes)
+    }
+
+    #[test]
+    fn kubo_puts_the_block_under_its_own_codec_and_the_frozen_hash() {
+        let http = ScriptedHttp::default();
+        let block = b"sealed leaf bytes".to_vec();
+        let cid = leaf(&block);
+        let address = encode_content_cid_str(&cid);
+        http.enqueue_response(HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: format!("{{\"Key\":\"{address}\",\"Size\":17}}\n").into_bytes(),
+        });
+        block_on(place_block(
+            &config(ByoKind::Kubo, Some("tok")),
+            &cid,
+            &block,
+            &http,
+        ))
+        .unwrap();
+
+        let request = &http.requests()[0];
+        assert_eq!(request.method, HttpMethod::Post);
+        assert_eq!(
+            request.url,
+            "https://ipfs.member.test/api/v0/block/put\
+             ?cid-codec=raw&mhtype=blake3&mhlen=32&pin=true"
+        );
+        let boundary = request
+            .headers
+            .iter()
+            .find(|(name, _)| name == CONTENT_TYPE)
+            .and_then(|(_, value)| value.split("boundary=").nth(1))
+            .expect("the request declares its multipart boundary")
+            .to_owned();
+        let body = request.body.as_ref().expect("a block/put carries a body");
+        assert!(
+            !block
+                .windows(boundary.len())
+                .any(|w| w == boundary.as_bytes()),
+            "the delimiter cannot occur in the payload it frames"
+        );
+        assert!(
+            body.windows(block.len()).any(|window| window == block),
+            "the block rides the body verbatim"
+        );
+        assert!(
+            body.ends_with(format!("\r\n--{boundary}--\r\n").as_bytes()),
+            "and the body closes on the boundary"
+        );
+    }
+
+    #[test]
+    fn a_dag_root_is_put_under_the_dag_cbor_codec() {
+        let http = ScriptedHttp::default();
+        let block = b"root manifest".to_vec();
+        let cid = compute_cid(DAG_ROOT_CODEC, &block);
+        let address = encode_content_cid_str(&cid);
+        http.enqueue_response(HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: format!("{{\"Key\":\"{address}\"}}").into_bytes(),
+        });
+        block_on(place_block(
+            &config(ByoKind::Kubo, None),
+            &cid,
+            &block,
+            &http,
+        ))
+        .unwrap();
+        assert!(http.requests()[0].url.contains("cid-codec=dag-cbor"));
+    }
+
+    /// A provider that stored the block somewhere else would leave the published
+    /// record naming bytes it does not serve, so the address it answers with is
+    /// held to the one it was given.
+    #[test]
+    fn a_kubo_node_that_stored_the_block_elsewhere_is_a_failure() {
+        let block = b"sealed leaf bytes".to_vec();
+        let cid = leaf(&block);
+        for body in [
+            r#"{"Key":"bafkr4iamjdirj4vmqmpizgefavwr4nftqhx6p4bbqdigodc6ja2g3lwumi"}"#,
+            // A trailing error object parses but names no address: a store
+            // fault, never a disagreeing one.
+            r#"{"Message":"boom","Type":"error"}"#,
+            "",
+        ] {
+            let http = ScriptedHttp::default();
+            http.enqueue_response(HttpResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: body.as_bytes().to_vec(),
+            });
+            assert!(
+                block_on(place_block(
+                    &config(ByoKind::Kubo, None),
+                    &cid,
+                    &block,
+                    &http
+                ))
+                .is_err(),
+                "{body:?} must not read as a stored block"
+            );
+        }
+    }
+
+    #[test]
+    fn a_pinning_service_is_asked_to_pin_the_address_it_fetches_itself() {
+        let block = b"sealed leaf bytes".to_vec();
+        let cid = leaf(&block);
+        let address = encode_content_cid_str(&cid);
+        for (kind, path, field) in [
+            (ByoKind::Psa, "/pins", "cid"),
+            (ByoKind::Pinata, "/pinning/pinByHash", "hashToPin"),
+        ] {
+            let http = ScriptedHttp::default();
+            http.enqueue_response(ok());
+            block_on(place_block(&config(kind, Some("tok")), &cid, &block, &http)).unwrap();
+            let request = &http.requests()[0];
+            assert_eq!(request.url, format!("https://ipfs.member.test{path}"));
+            assert_eq!(
+                request.body.as_deref(),
+                Some(format!("{{\"{field}\":\"{address}\"}}").as_bytes()),
+                "the request names the address and carries no block bytes"
+            );
+            assert!(
+                request
+                    .headers
+                    .iter()
+                    .any(|(n, v)| n == CONTENT_TYPE && v == APPLICATION_JSON)
+            );
+        }
+    }
+
+    #[test]
+    fn a_provider_that_refuses_or_cannot_be_reached_is_classified() {
+        let block = b"sealed leaf bytes".to_vec();
+        let cid = leaf(&block);
+        let http = ScriptedHttp::default();
+        http.enqueue_response(HttpResponse {
+            status: 507,
+            headers: Vec::new(),
+            body: Vec::new(),
+        });
+        assert_eq!(
+            block_on(place_block(
+                &config(ByoKind::Psa, Some("t")),
+                &cid,
+                &block,
+                &http
+            ))
+            .unwrap_err(),
+            ProviderError::Rejected { status: 507 }
+        );
+        let http = ScriptedHttp::default();
+        http.enqueue_error(crate::seams::SeamError::new("connection refused"));
+        assert_eq!(
+            block_on(place_block(
+                &config(ByoKind::Kubo, None),
+                &cid,
+                &block,
+                &http
+            ))
+            .unwrap_err(),
+            ProviderError::Unreachable
+        );
+    }
+
+    /// The same gate the settings record passes, applied here because the
+    /// endpoint and the bearer are spliced into this request too.
+    #[test]
+    fn a_config_the_seam_may_not_be_pointed_at_never_reaches_it() {
+        let block = b"sealed leaf bytes".to_vec();
+        let cid = leaf(&block);
+        let http = ScriptedHttp::default();
+        let bad = ByoIpfsConfig {
+            endpoint: "http://169.254.169.254".into(),
+            kind: ByoKind::Kubo,
+            access_token: None,
+        };
+        assert_eq!(
+            block_on(place_block(&bad, &cid, &block, &http)).unwrap_err(),
+            ProviderError::BlockedAddress
+        );
+        assert!(http.requests().is_empty());
+    }
+
+    #[test]
+    fn a_block_address_outside_the_frozen_shapes_is_refused_before_the_seam() {
+        let http = ScriptedHttp::default();
+        let mut wrong_codec = leaf(b"x");
+        wrong_codec[1] = 0x70; // dag-pb: not a content-plane codec.
+        for cid in [wrong_codec, leaf(b"x")[..8].to_vec(), Vec::new()] {
+            assert_eq!(
+                block_on(place_block(&config(ByoKind::Kubo, None), &cid, b"x", &http)).unwrap_err(),
+                ProviderError::MalformedBlockAddress
+            );
+        }
+        assert!(http.requests().is_empty());
     }
 
     #[test]

--- a/crates/engine/src/content/provider.rs
+++ b/crates/engine/src/content/provider.rs
@@ -718,14 +718,20 @@ mod tests {
             .and_then(|(_, value)| value.split("boundary=").nth(1))
             .expect("the request declares its multipart boundary")
             .to_owned();
+        // Kubo parses exactly these bytes, so the part is asserted whole: an
+        // opening delimiter that disagreed with the declared boundary, or a
+        // malformed part header, would frame the block out of the request.
         let body = request.body.as_ref().expect("a block/put carries a body");
-        assert!(
-            body.windows(block.len()).any(|window| window == block),
-            "the block rides the body verbatim"
+        let head = format!(
+            "--{boundary}\r\n\
+             Content-Disposition: form-data; name=\"data\"; filename=\"blob\"\r\n\
+             Content-Type: application/octet-stream\r\n\r\n"
         );
-        assert!(
-            body.ends_with(format!("\r\n--{boundary}--\r\n").as_bytes()),
-            "and the body closes on the boundary"
+        let tail = format!("\r\n--{boundary}--\r\n");
+        assert_eq!(
+            *body,
+            [head.as_bytes(), &block, tail.as_bytes()].concat(),
+            "the block rides the declared boundary verbatim"
         );
     }
 
@@ -757,12 +763,18 @@ mod tests {
     fn a_kubo_node_that_stored_the_block_elsewhere_is_a_failure() {
         let block = b"sealed leaf bytes".to_vec();
         let cid = leaf(&block);
-        for body in [
-            r#"{"Key":"bafkr4iamjdirj4vmqmpizgefavwr4nftqhx6p4bbqdigodc6ja2g3lwumi"}"#,
+        for (body, verdict) in [
+            (
+                r#"{"Key":"bafkr4iamjdirj4vmqmpizgefavwr4nftqhx6p4bbqdigodc6ja2g3lwumi"}"#,
+                ProviderError::AddressMismatch,
+            ),
             // A trailing error object parses but names no address: a store
             // fault, never a disagreeing one.
-            r#"{"Message":"boom","Type":"error"}"#,
-            "",
+            (
+                r#"{"Message":"boom","Type":"error"}"#,
+                ProviderError::NoVerdict,
+            ),
+            ("", ProviderError::NoVerdict),
         ] {
             let http = ScriptedHttp::default();
             http.enqueue_response(HttpResponse {
@@ -770,14 +782,15 @@ mod tests {
                 headers: Vec::new(),
                 body: body.as_bytes().to_vec(),
             });
-            assert!(
+            assert_eq!(
                 block_on(place_block(
                     &config(ByoKind::Kubo, None),
                     &cid,
                     &block,
                     &http
                 ))
-                .is_err(),
+                .unwrap_err(),
+                verdict,
                 "{body:?} must not read as a stored block"
             );
         }

--- a/crates/engine/src/content/retention.rs
+++ b/crates/engine/src/content/retention.rs
@@ -9,10 +9,11 @@
 use core::num::NonZeroU64;
 
 use crate::api::Quota;
+use crate::content::PinMode;
 
 /// A pre-flight quota rejection: the hosted account cannot admit `needed_bytes`.
-/// Advisory (BYO) accounts never produce this — their bytes live on the member's
-/// own provider and are counted, never gated.
+/// A write that takes no hosted byte path never produces this — its bytes live
+/// on the member's own provider and are counted, never gated.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QuotaExceeded {
     /// Bytes already counted against the account.
@@ -24,12 +25,22 @@ pub struct QuotaExceeded {
 }
 
 /// Fail fast before bytes move if a hosted upload of `needed_bytes` would exceed
-/// the account limit. A BYO account's quota is advisory (`advisory: true`) and
-/// always admits — its rows are counted for accounting, never quota-enforced
-/// (CONTEXT.md "Advisory pin row"). The API upload endpoint remains the
-/// authoritative gate; this is the fail-fast pre-flight, not the enforcement.
-pub fn pre_flight_quota_check(needed_bytes: u64, quota: &Quota) -> Result<(), QuotaExceeded> {
-    if quota.advisory {
+/// the account limit.
+///
+/// The gate is this write's own byte path, not the account's server-side flag:
+/// [`PinMode::External`] sends nothing to the hosted store and so is never
+/// gated, while [`PinMode::Dual`] is, because its hosted leg is a real hosted
+/// upload however the account is classified. `quota.advisory` is a display hint
+/// — it lags the vaulted mode, which is the source of truth, so gating on it
+/// admits a hosted upload the ingress then refuses (and refuses an external one
+/// it would never see). The API upload endpoint remains the authoritative gate;
+/// this is the fail-fast pre-flight, not the enforcement.
+pub fn pre_flight_quota_check(
+    needed_bytes: u64,
+    quota: &Quota,
+    mode: PinMode,
+) -> Result<(), QuotaExceeded> {
+    if matches!(mode, PinMode::External) {
         return Ok(());
     }
     // Saturating so a pathological used+needed can never wrap under the limit.
@@ -111,12 +122,12 @@ mod tests {
 
     #[test]
     fn admits_an_upload_that_fits() {
-        assert!(pre_flight_quota_check(100, &hosted(400, 1000)).is_ok());
+        assert!(pre_flight_quota_check(100, &hosted(400, 1000), PinMode::Hosted).is_ok());
     }
 
     #[test]
     fn rejects_an_upload_that_would_exceed_the_limit() {
-        let err = pre_flight_quota_check(700, &hosted(400, 1000)).unwrap_err();
+        let err = pre_flight_quota_check(700, &hosted(400, 1000), PinMode::Hosted).unwrap_err();
         assert_eq!(
             err,
             QuotaExceeded {
@@ -129,19 +140,34 @@ mod tests {
 
     #[test]
     fn exactly_filling_the_limit_is_admitted() {
-        assert!(pre_flight_quota_check(600, &hosted(400, 1000)).is_ok());
+        assert!(pre_flight_quota_check(600, &hosted(400, 1000), PinMode::Hosted).is_ok());
     }
 
+    /// The write's own byte path decides, not the account's advisory flag: a
+    /// mode that sends nothing to the hosted store is never gated, and one that
+    /// does is gated however the server classified the account.
     #[test]
-    fn advisory_byo_quota_always_admits() {
-        let byo = Quota {
-            used_bytes: u64::MAX - 1,
-            limit_bytes: 0,
+    fn the_gate_follows_the_byte_path_not_the_advisory_flag() {
+        let advisory = Quota {
+            used_bytes: 400,
+            limit_bytes: 1000,
             advisory: true,
         };
         assert!(
-            pre_flight_quota_check(u64::MAX, &byo).is_ok(),
-            "BYO is never gated"
+            pre_flight_quota_check(u64::MAX, &advisory, PinMode::External).is_ok(),
+            "external sends no hosted byte"
+        );
+        assert!(
+            pre_flight_quota_check(700, &advisory, PinMode::Dual).is_err(),
+            "dual's hosted leg is a hosted upload"
+        );
+        assert!(
+            pre_flight_quota_check(700, &advisory, PinMode::Hosted).is_err(),
+            "an advisory flag does not open the hosted store"
+        );
+        assert!(
+            pre_flight_quota_check(u64::MAX, &hosted(0, 1000), PinMode::External).is_ok(),
+            "a non-advisory account on external is still never gated"
         );
     }
 

--- a/crates/engine/src/content/retention.rs
+++ b/crates/engine/src/content/retention.rs
@@ -9,7 +9,6 @@
 use core::num::NonZeroU64;
 
 use crate::api::Quota;
-use crate::content::PinMode;
 
 /// A pre-flight quota rejection: the hosted account cannot admit `needed_bytes`.
 /// A write that takes no hosted byte path never produces this — its bytes live
@@ -24,23 +23,20 @@ pub struct QuotaExceeded {
     pub needed_bytes: u64,
 }
 
-/// Fail fast before bytes move if a hosted upload of `needed_bytes` would exceed
-/// the account limit.
+/// Fail fast before bytes move if a hosted upload of `needed_bytes` would
+/// exceed the account limit.
 ///
-/// The gate is this write's own byte path, not the account's server-side flag:
-/// [`PinMode::External`] sends nothing to the hosted store and so is never
-/// gated, while [`PinMode::Dual`] is, because its hosted leg is a real hosted
-/// upload however the account is classified. `quota.advisory` is a display hint
-/// — it lags the vaulted mode, which is the source of truth, so gating on it
-/// admits a hosted upload the ingress then refuses (and refuses an external one
-/// it would never see). The API upload endpoint remains the authoritative gate;
-/// this is the fail-fast pre-flight, not the enforcement.
+/// The gate is `hosted_leg` — whether *this write* puts bytes in the hosted
+/// store — not `quota.advisory`, which is a display hint that lags the vaulted
+/// mode. Gating on the flag would admit a hosted upload the ingress then refuses
+/// and refuse an external one it would never see. The API upload endpoint
+/// remains the authoritative gate; this is the fail-fast pre-flight.
 pub fn pre_flight_quota_check(
     needed_bytes: u64,
     quota: &Quota,
-    mode: PinMode,
+    hosted_leg: bool,
 ) -> Result<(), QuotaExceeded> {
-    if matches!(mode, PinMode::External) {
+    if !hosted_leg {
         return Ok(());
     }
     // Saturating so a pathological used+needed can never wrap under the limit.
@@ -122,12 +118,12 @@ mod tests {
 
     #[test]
     fn admits_an_upload_that_fits() {
-        assert!(pre_flight_quota_check(100, &hosted(400, 1000), PinMode::Hosted).is_ok());
+        assert!(pre_flight_quota_check(100, &hosted(400, 1000), true).is_ok());
     }
 
     #[test]
     fn rejects_an_upload_that_would_exceed_the_limit() {
-        let err = pre_flight_quota_check(700, &hosted(400, 1000), PinMode::Hosted).unwrap_err();
+        let err = pre_flight_quota_check(700, &hosted(400, 1000), true).unwrap_err();
         assert_eq!(
             err,
             QuotaExceeded {
@@ -140,12 +136,10 @@ mod tests {
 
     #[test]
     fn exactly_filling_the_limit_is_admitted() {
-        assert!(pre_flight_quota_check(600, &hosted(400, 1000), PinMode::Hosted).is_ok());
+        assert!(pre_flight_quota_check(600, &hosted(400, 1000), true).is_ok());
     }
 
-    /// The write's own byte path decides, not the account's advisory flag: a
-    /// mode that sends nothing to the hosted store is never gated, and one that
-    /// does is gated however the server classified the account.
+    /// The write's own byte path decides, not the account's advisory flag.
     #[test]
     fn the_gate_follows_the_byte_path_not_the_advisory_flag() {
         let advisory = Quota {
@@ -154,20 +148,16 @@ mod tests {
             advisory: true,
         };
         assert!(
-            pre_flight_quota_check(u64::MAX, &advisory, PinMode::External).is_ok(),
-            "external sends no hosted byte"
+            pre_flight_quota_check(u64::MAX, &advisory, false).is_ok(),
+            "a write with no hosted leg is never gated"
         );
         assert!(
-            pre_flight_quota_check(700, &advisory, PinMode::Dual).is_err(),
-            "dual's hosted leg is a hosted upload"
-        );
-        assert!(
-            pre_flight_quota_check(700, &advisory, PinMode::Hosted).is_err(),
+            pre_flight_quota_check(700, &advisory, true).is_err(),
             "an advisory flag does not open the hosted store"
         );
         assert!(
-            pre_flight_quota_check(u64::MAX, &hosted(0, 1000), PinMode::External).is_ok(),
-            "a non-advisory account on external is still never gated"
+            pre_flight_quota_check(u64::MAX, &hosted(0, 1000), false).is_ok(),
+            "nor does a non-advisory one gate what it never receives"
         );
     }
 

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -33,10 +33,9 @@ use zeroize::Zeroizing;
 use crate::api::{ApiClient, ApiError, IdentityChallengeSigner};
 use crate::content::budget::{Refusal, ReservationId};
 use crate::content::{
-    ContentKey, ContentProfile, ContentWriter, Gateway, GatewayConfig, OpenError, PinMode,
-    PlacementDecision, PlacementRefusal, Refused, RootManifest, SealError, StagingLedger,
-    decide_placement, open_content_range, open_content_root, pre_flight_quota_check,
-    read_pinned_range, sealed_total_bytes,
+    ContentKey, ContentProfile, ContentWriter, Gateway, GatewayConfig, OpenError, Refused,
+    RootManifest, SealError, StagingLedger, open_content_range, open_content_root,
+    pre_flight_quota_check, read_pinned_range, sealed_total_bytes,
 };
 use crate::entropy::Entropy;
 use crate::gate::{GateError, floor};
@@ -54,7 +53,7 @@ use crate::seams::{
     UnixMillis,
 };
 use crate::session::SessionIdentity;
-use crate::settings::load_settings;
+use crate::settings::{PlacementDecision, PlacementRefusal, decide_placement, load_settings};
 use crate::storage_policy::StoragePolicy;
 use crate::sync::boot::{ColdStartError, ColdStartOutcome, ColdStartParams, cold_start};
 use crate::sync::cancel::UploadCancels;
@@ -318,10 +317,7 @@ impl LoginSecret {
     }
 
     /// Borrow the raw secret bytes for in-crate cold-start derivation only.
-    /// `pub(crate)` so the secret never leaves engine memory; the callers are
-    /// [`SessionIdentity::derive`](crate::session::SessionIdentity::derive) and
-    /// the settings-record load, whose name and seal are both pure functions of
-    /// it (blueprint/engine.md "Vault settings record").
+    /// `pub(crate)` so the secret never leaves engine memory.
     pub(crate) fn expose(&self) -> &[u8] {
         &self.0
     }
@@ -1525,6 +1521,11 @@ pub struct Engine<T: SeamTypes> {
     /// then, and emptied on drop like [`tick_enc_subkey`](Self::tick_enc_subkey)
     /// — the config it holds carries the member's provider bearer.
     placement: Rc<RefCell<Option<PlacementDecision>>>,
+    /// Whether this session has already held the account's `byo` flag to the
+    /// vaulted mode. Once a session: the flag is account-wide and the mode is
+    /// fixed at [`start`](Self::start), so re-deriving it per write would only
+    /// let two devices flap it.
+    byo_reconciled: Cell<bool>,
     /// The one shared API client, built and logged in at [`start`](Self::start)
     /// and handed to the liveness loop so the access JWT is shared across
     /// publish/renew (no redundant 401→refresh). `None` until then.
@@ -1576,6 +1577,7 @@ impl<T: SeamTypes> Engine<T> {
                 session: None,
                 tick_enc_subkey: Rc::new(RefCell::new(None)),
                 placement: Rc::new(RefCell::new(None)),
+                byo_reconciled: Cell::new(false),
                 api: None,
                 started: false,
             },
@@ -1632,9 +1634,7 @@ impl<T: SeamTypes> Engine<T> {
 
         // Where this session's bytes go. Server-free and ahead of any vault
         // resolve, so a self-hosting owner never needs CipherBox to tell them
-        // where their own node is (blueprint/engine.md "Vault settings record");
-        // the profile's own budget bounds it, so an unreachable record plane
-        // degrades the decision rather than blocking start.
+        // where their own node is (blueprint/engine.md "Vault settings record").
         let settings = load_settings(
             &self.seams.record_transport,
             &self.gateway,
@@ -1990,8 +1990,8 @@ impl<T: SeamTypes> Engine<T> {
                 let Some(enc_subkey) = enc_subkey else {
                     return LivenessControl::Stop;
                 };
-                // The placement decision carries the member's BYO bearer, so the
-                // pass borrows it on the same terms as the enc subkey above.
+                // Carries the member's BYO bearer, so the pass owns a copy on the
+                // same terms as the enc subkey above.
                 let decision = placement.borrow().clone();
                 let Some(decision) = decision else {
                     return LivenessControl::Stop;
@@ -2363,8 +2363,7 @@ impl<T: SeamTypes> Engine<T> {
                 check: error.check(),
             }
         })?;
-        // Sized in sealed bytes, which is what the hosted ingress counts, and
-        // run here because this is where the write already waits.
+        // Sized in sealed bytes, which is what the hosted ingress counts.
         self.hosted_quota_pre_flight(requested).await?;
         let staged = self
             .seams
@@ -2414,31 +2413,32 @@ impl<T: SeamTypes> Engine<T> {
     /// Refuse a write whose hosted leg the account quota cannot admit, before
     /// the version is sealed and staged rather than at the drain.
     ///
-    /// Two directions, deliberately different. The placement decision is
-    /// fail-closed: a session that cannot authenticate the member's choice
-    /// refuses rather than picking a destination. The quota probe is not: the
-    /// API upload endpoint is the authoritative gate and this is only a
-    /// fail-fast, so an unreachable or unconfigured API leaves the write to
-    /// queue offline like any other.
+    /// Two directions, deliberately different: the placement decision is
+    /// fail-closed, while the quota probe is not — the API upload endpoint is
+    /// the authoritative gate, so an unreachable one leaves the write to queue
+    /// offline like any other.
     async fn hosted_quota_pre_flight(&self, requested: u64) -> Result<(), EngineError> {
-        let decision = self.placement.borrow().clone();
-        let placement = decision
-            .ok_or(EngineError::NotStarted)?
-            .map_err(|refusal| EngineError::NoPlacement { refusal })?;
+        // Only the predicate leaves the borrow: cloning the placement would copy
+        // the member's provider bearer on every write.
+        let hosted_leg = match self.placement.borrow().as_ref() {
+            None => return Err(EngineError::NotStarted),
+            Some(Err(refusal)) => return Err(EngineError::NoPlacement { refusal: *refusal }),
+            Some(Ok(placement)) => placement.has_hosted_leg(),
+        };
         let Some(api) = self.api.as_ref() else {
             return Ok(());
         };
         let Ok(quota) = api.quota().await else {
             return Ok(());
         };
-        // The vaulted mode is the source of truth; the server flag is what it is
-        // reconciled against. Best-effort — a failed reconcile leaves the flag
-        // stale, which costs accounting, never correctness.
-        let byo = placement.mode() == PinMode::External;
-        if quota.advisory != byo {
-            let _ = api.set_byo(byo).await;
+        // The account's flag is two-state where the mode is three and dual has
+        // no server representation, so `byo=true` is exactly `External`. The
+        // vaulted mode is the source of truth; the flag is reconciled to it at
+        // most once a session, so two devices cannot flap it per file.
+        if !self.byo_reconciled.replace(true) && quota.advisory == hosted_leg {
+            let _ = api.set_byo(!hosted_leg).await;
         }
-        pre_flight_quota_check(requested, &quota, placement.mode()).map_err(|refused| {
+        pre_flight_quota_check(requested, &quota, hosted_leg).map_err(|refused| {
             EngineError::OverBudget {
                 cause: OverBudgetCause::AccountQuota,
                 requested,

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -2433,10 +2433,16 @@ impl<T: SeamTypes> Engine<T> {
         };
         // The account's flag is two-state where the mode is three and dual has
         // no server representation, so `byo=true` is exactly `External`. The
-        // vaulted mode is the source of truth; the flag is reconciled to it at
-        // most once a session, so two devices cannot flap it per file.
-        if !self.byo_reconciled.replace(true) && quota.advisory == hosted_leg {
-            let _ = api.set_byo(!hosted_leg).await;
+        // vaulted mode is the source of truth; the flag is latched only once the
+        // PATCH lands, so two devices still cannot flap it per file while a
+        // transient failure stays retryable — the hosted ingress rejects a BYO
+        // account, so an unreconciled flag fails every hosted upload the session
+        // makes.
+        if !self.byo_reconciled.get()
+            && quota.advisory == hosted_leg
+            && api.set_byo(!hosted_leg).await.is_ok()
+        {
+            self.byo_reconciled.set(true);
         }
         pre_flight_quota_check(requested, &quota, hosted_leg).map_err(|refused| {
             EngineError::OverBudget {

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -33,8 +33,9 @@ use zeroize::Zeroizing;
 use crate::api::{ApiClient, ApiError, IdentityChallengeSigner};
 use crate::content::budget::{Refusal, ReservationId};
 use crate::content::{
-    ContentKey, ContentProfile, ContentWriter, Gateway, GatewayConfig, OpenError, Refused,
-    RootManifest, SealError, StagingLedger, open_content_range, open_content_root,
+    ContentKey, ContentProfile, ContentWriter, Gateway, GatewayConfig, OpenError, PinMode,
+    PlacementDecision, PlacementRefusal, Refused, RootManifest, SealError, StagingLedger,
+    decide_placement, open_content_range, open_content_root, pre_flight_quota_check,
     read_pinned_range, sealed_total_bytes,
 };
 use crate::entropy::Entropy;
@@ -53,6 +54,7 @@ use crate::seams::{
     UnixMillis,
 };
 use crate::session::SessionIdentity;
+use crate::settings::load_settings;
 use crate::storage_policy::StoragePolicy;
 use crate::sync::boot::{ColdStartError, ColdStartOutcome, ColdStartParams, cold_start};
 use crate::sync::cancel::UploadCancels;
@@ -316,8 +318,10 @@ impl LoginSecret {
     }
 
     /// Borrow the raw secret bytes for in-crate cold-start derivation only.
-    /// `pub(crate)` so the secret never leaves engine memory; the only caller
-    /// is [`SessionIdentity::derive`](crate::session::SessionIdentity::derive).
+    /// `pub(crate)` so the secret never leaves engine memory; the callers are
+    /// [`SessionIdentity::derive`](crate::session::SessionIdentity::derive) and
+    /// the settings-record load, whose name and seal are both pure functions of
+    /// it (blueprint/engine.md "Vault settings record").
     pub(crate) fn expose(&self) -> &[u8] {
         &self.0
     }
@@ -644,6 +648,10 @@ pub enum OpPhase {
     /// The user cancelled the upload and its staged blocks were released
     /// (`Command::CancelUpload`).
     UploadCancelled,
+    /// A dual write's hosted leg landed but the member's own provider did not
+    /// take the version. The op published and the content is retrievable; it is
+    /// simply not on their node, and no retry is queued.
+    ExternalPinFailed,
 }
 
 /// Errors returned by facade calls.
@@ -681,6 +689,14 @@ pub enum EngineError {
     UnsupportedContentFormat {
         /// The version the root declared.
         version: u64,
+    },
+    /// No byte destination could be decided, so the write is refused rather
+    /// than placed on a store the member did not choose (blueprint/engine.md
+    /// "Settings-load policy"). Recoverable: republishing or re-resolving the
+    /// vault settings record clears it.
+    NoPlacement {
+        /// Which rule refused, so a host can say what to fix.
+        refusal: PlacementRefusal,
     },
     /// The command's pipeline slice has not landed yet (scaffold state).
     Unimplemented {
@@ -876,6 +892,17 @@ impl fmt::Display for EngineError {
                 OverBudgetCause::AccountQuota => write!(
                     f,
                     "this write needs {requested} bytes but the account's storage quota leaves {available}"
+                ),
+            },
+            EngineError::NoPlacement { refusal } => match refusal {
+                PlacementRefusal::SettingsUnavailable(_) => f.write_str(
+                    "your vault settings are unavailable, so this device cannot tell where your files should be stored; reconnect or save your settings again",
+                ),
+                PlacementRefusal::NoProvider => f.write_str(
+                    "your vault settings choose your own IPFS provider but name none; add one in settings",
+                ),
+                PlacementRefusal::NoExternalIngress(_) => f.write_str(
+                    "a pinning service cannot be your only storage — it fetches content from the network rather than receiving it; add your own IPFS node, or store on CipherBox as well",
                 ),
             },
             EngineError::ContentSizeMismatch { declared, observed } => write!(
@@ -1493,6 +1520,11 @@ pub struct Engine<T: SeamTypes> {
     /// resident for up to that wake past the engine (security rules 1/7); every
     /// shared cell below carrying key material is cleared the same way.
     tick_enc_subkey: Rc<RefCell<Option<X25519Secret>>>,
+    /// Where this session's bytes go, decided once at [`start`](Self::start)
+    /// from the vault settings load and shared with the drain. `None` until
+    /// then, and emptied on drop like [`tick_enc_subkey`](Self::tick_enc_subkey)
+    /// — the config it holds carries the member's provider bearer.
+    placement: Rc<RefCell<Option<PlacementDecision>>>,
     /// The one shared API client, built and logged in at [`start`](Self::start)
     /// and handed to the liveness loop so the access JWT is shared across
     /// publish/renew (no redundant 401→refresh). `None` until then.
@@ -1543,6 +1575,7 @@ impl<T: SeamTypes> Engine<T> {
                 alive: Rc::new(Cell::new(true)),
                 session: None,
                 tick_enc_subkey: Rc::new(RefCell::new(None)),
+                placement: Rc::new(RefCell::new(None)),
                 api: None,
                 started: false,
             },
@@ -1578,10 +1611,8 @@ impl<T: SeamTypes> Engine<T> {
         if secret.is_empty() {
             return Err(EngineError::InvalidSecret);
         }
-        // Pure derivation from the injected secret — no clock, no RNG — then
-        // the secret zeroizes on drop here, at its terminal owner.
+        // Pure derivation from the injected secret — no clock, no RNG.
         let session = SessionIdentity::derive(&secret)?;
-        drop(secret);
 
         // The one shared client for login, publish, and renewal. Login is
         // fail-closed: a rejected login returns before the session is committed
@@ -1598,6 +1629,26 @@ impl<T: SeamTypes> Engine<T> {
                 .await
                 .map_err(EngineError::from_api)?;
         }
+
+        // Where this session's bytes go. Server-free and ahead of any vault
+        // resolve, so a self-hosting owner never needs CipherBox to tell them
+        // where their own node is (blueprint/engine.md "Vault settings record");
+        // the profile's own budget bounds it, so an unreachable record plane
+        // degrades the decision rather than blocking start.
+        let settings = load_settings(
+            &self.seams.record_transport,
+            &self.gateway,
+            &self.seams.http,
+            &self.seams.floor_store,
+            &self.seams.snapshot_cache,
+            &self.seams.scheduler,
+            &self.profile,
+            secret.expose(),
+        )
+        .await;
+        *self.placement.borrow_mut() = Some(decide_placement(&settings));
+        // The secret zeroizes on drop here, at its terminal owner.
+        drop(secret);
 
         self.session = Some(session);
 
@@ -1637,9 +1688,10 @@ impl<T: SeamTypes> Engine<T> {
             Ok(outcome) => outcome,
             Err(err) => {
                 // Fail-closed symmetry with the login path: clear the derived
-                // session so no key material stays resident and the engine reports
-                // unstarted.
+                // session and the placement decision beside it, so no key material
+                // stays resident and the engine reports unstarted.
                 self.session = None;
+                *self.placement.borrow_mut() = None;
                 return Err(EngineError::from_cold_start(err));
             }
         };
@@ -1711,6 +1763,9 @@ impl<T: SeamTypes> Engine<T> {
         self.alive.set(false);
         if let Ok(mut enc_subkey) = self.tick_enc_subkey.try_borrow_mut() {
             *enc_subkey = None;
+        }
+        if let Ok(mut placement) = self.placement.try_borrow_mut() {
+            *placement = None;
         }
         if let Ok(mut held) = self.held_records.try_borrow_mut() {
             held.clear();
@@ -1907,6 +1962,7 @@ impl<T: SeamTypes> Engine<T> {
         let floors = self.seams.floor_store.clone();
         let http = self.seams.http.clone();
         let gateway = self.gateway.clone();
+        let placement = self.placement.clone();
         let held = self.held_records.clone();
         let base = self.snapshot.clone();
         let events = self.events.clone();
@@ -1932,6 +1988,12 @@ impl<T: SeamTypes> Engine<T> {
                 // emptied the cell if it is already gone.
                 let enc_subkey = tick_enc_subkey.borrow().clone();
                 let Some(enc_subkey) = enc_subkey else {
+                    return LivenessControl::Stop;
+                };
+                // The placement decision carries the member's BYO bearer, so the
+                // pass borrows it on the same terms as the enc subkey above.
+                let decision = placement.borrow().clone();
+                let Some(decision) = decision else {
                     return LivenessControl::Stop;
                 };
                 // Before the steady-state hold consults them: a floor raised
@@ -2053,6 +2115,7 @@ impl<T: SeamTypes> Engine<T> {
                         scheduler: &scheduler,
                         http: &http,
                         gateway: &gateway,
+                        placement: &decision,
                         profile: &profile,
                         entropy: &entropy,
                         base: &base,
@@ -2300,6 +2363,9 @@ impl<T: SeamTypes> Engine<T> {
                 check: error.check(),
             }
         })?;
+        // Sized in sealed bytes, which is what the hosted ingress counts, and
+        // run here because this is where the write already waits.
+        self.hosted_quota_pre_flight(requested).await?;
         let staged = self
             .seams
             .staging_store
@@ -2343,6 +2409,42 @@ impl<T: SeamTypes> Engine<T> {
             },
         );
         Ok(handle)
+    }
+
+    /// Refuse a write whose hosted leg the account quota cannot admit, before
+    /// the version is sealed and staged rather than at the drain.
+    ///
+    /// Two directions, deliberately different. The placement decision is
+    /// fail-closed: a session that cannot authenticate the member's choice
+    /// refuses rather than picking a destination. The quota probe is not: the
+    /// API upload endpoint is the authoritative gate and this is only a
+    /// fail-fast, so an unreachable or unconfigured API leaves the write to
+    /// queue offline like any other.
+    async fn hosted_quota_pre_flight(&self, requested: u64) -> Result<(), EngineError> {
+        let decision = self.placement.borrow().clone();
+        let placement = decision
+            .ok_or(EngineError::NotStarted)?
+            .map_err(|refusal| EngineError::NoPlacement { refusal })?;
+        let Some(api) = self.api.as_ref() else {
+            return Ok(());
+        };
+        let Ok(quota) = api.quota().await else {
+            return Ok(());
+        };
+        // The vaulted mode is the source of truth; the server flag is what it is
+        // reconciled against. Best-effort — a failed reconcile leaves the flag
+        // stale, which costs accounting, never correctness.
+        let byo = placement.mode() == PinMode::External;
+        if quota.advisory != byo {
+            let _ = api.set_byo(byo).await;
+        }
+        pre_flight_quota_check(requested, &quota, placement.mode()).map_err(|refused| {
+            EngineError::OverBudget {
+                cause: OverBudgetCause::AccountQuota,
+                requested,
+                available: refused.limit_bytes.saturating_sub(refused.used_bytes),
+            }
+        })
     }
 
     /// Feed the next slice of the file. Seals and stages every whole chunk it

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -49,11 +49,10 @@ pub use api::{
 pub use content::{
     ByoIpfsConfig, ByoKind, ContentDag, ContentKey, ContentPlane, ContentProfile, ContentVersion,
     ContentWriter, DAG_ROOT_CODEC, DagError, FinishedContent, Gateway, GatewayConfig,
-    GatewaySource, PinMode, Placement, PlacementDecision, PlacementRefusal, ProviderError,
-    PrunePlan, QuotaExceeded, ROOT_FORMAT_VERSION, ReadError, RetentionPolicy, RootManifest,
-    SealError, SealedChunk, SealedContent, assemble, decide_placement, decode_root, frame_and_seal,
-    leaf_range_for_byte_range, place_block, plan_prune, pre_flight_quota_check, read_block,
-    seal_one_chunk, test_connection, validate_byo_config,
+    GatewaySource, PinMode, ProviderError, PrunePlan, QuotaExceeded, ROOT_FORMAT_VERSION,
+    ReadError, RetentionPolicy, RootManifest, SealError, SealedChunk, SealedContent, assemble,
+    decode_root, frame_and_seal, leaf_range_for_byte_range, plan_prune, pre_flight_quota_check,
+    read_block, seal_one_chunk, test_connection, validate_byo_config,
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{
@@ -87,7 +86,8 @@ pub use rotation::{
 };
 pub use seams::{SeamError, SeamResult, SeamSet, SeamTypes};
 pub use settings::{
-    DefaultsReason, SettingsLoad, SettingsPublishError, VaultSettings, load_settings,
+    DefaultsReason, Placement, PlacementDecision, PlacementRefusal, SettingsLoad,
+    SettingsPublishError, VaultSettings, decide_placement, load_settings, placement_of,
     publish_settings, settings_name,
 };
 pub use storage_policy::{Headroom, StoragePlatform, StoragePolicy};

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -49,10 +49,11 @@ pub use api::{
 pub use content::{
     ByoIpfsConfig, ByoKind, ContentDag, ContentKey, ContentPlane, ContentProfile, ContentVersion,
     ContentWriter, DAG_ROOT_CODEC, DagError, FinishedContent, Gateway, GatewayConfig,
-    GatewaySource, PinMode, ProviderError, PrunePlan, QuotaExceeded, ROOT_FORMAT_VERSION,
-    ReadError, RetentionPolicy, RootManifest, SealError, SealedChunk, SealedContent, assemble,
-    decode_root, frame_and_seal, leaf_range_for_byte_range, plan_prune, pre_flight_quota_check,
-    read_block, seal_one_chunk, test_connection, validate_byo_config,
+    GatewaySource, PinMode, Placement, PlacementDecision, PlacementRefusal, ProviderError,
+    PrunePlan, QuotaExceeded, ROOT_FORMAT_VERSION, ReadError, RetentionPolicy, RootManifest,
+    SealError, SealedChunk, SealedContent, assemble, decide_placement, decode_root, frame_and_seal,
+    leaf_range_for_byte_range, place_block, plan_prune, pre_flight_quota_check, read_block,
+    seal_one_chunk, test_connection, validate_byo_config,
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -122,23 +122,23 @@ impl Placement {
     }
 }
 
-/// A provider's identity as the upload mark records it. The destination is the
-/// account the credential names, not the URL alone, so a config differing only
-/// in kind or bearer must tag apart. Hashed because the bearer is secret: the
-/// preimage never leaves this function, and only the digest reaches staging.
+/// A provider's identity as the upload mark records it: the kind, plus the
+/// endpoint naming the node or service the blocks land on.
+///
+/// The bearer is deliberately out of the preimage. It rotates while the
+/// destination stays put, and a mark that stops matching is not merely ignored —
+/// the leaves it covered are already released from staging, so under
+/// external-only a rotation would leave the version unpublishable. That mode is
+/// Kubo-only ([`placement_of`]), where the endpoint *is* the member's node and
+/// the bearer only fronts it. On a multi-tenant pin service two accounts do
+/// share an endpoint, but such a config only ever reaches
+/// [`Destinations::mirror_leg_holds`], which reports a gap and never fails an op.
 fn byo_tag(config: &ByoIpfsConfig) -> [u8; SECRET_LEN] {
-    let token = config
-        .access_token
-        .as_ref()
-        .map_or("", |token| token.as_str());
-    let mut tagged = Zeroizing::new(b"cipherbox/byo-destination\0".to_vec());
+    let mut tagged = b"cipherbox/byo-destination\0".to_vec();
+    // The kind is one fixed byte ahead of the endpoint, so no two configs share
+    // a preimage without sharing both fields.
     tagged.push(config.kind as u8);
-    // Length-prefixed: without it a differently-split endpoint/token pair
-    // concatenates to the same preimage.
-    tagged.extend_from_slice(&(config.endpoint.len() as u64).to_be_bytes());
     tagged.extend_from_slice(config.endpoint.as_bytes());
-    tagged.extend_from_slice(&(token.len() as u64).to_be_bytes());
-    tagged.extend_from_slice(token.as_bytes());
     hash(&tagged)
 }
 
@@ -226,6 +226,22 @@ impl Destinations {
     #[must_use]
     pub fn mirror_leg_holds(&self, earlier: &Self) -> bool {
         !self.hosted || self.external.is_none() || earlier.external == self.external
+    }
+
+    /// Drop the mirror from what a mark may claim, because the external leg did
+    /// not take some block the mark covers. Progress is one high-water prefix
+    /// under one destination set, so a mirror that missed anything inside that
+    /// prefix cannot be named by it — otherwise a later external-only session
+    /// reads [`required_legs_hold`](Self::required_legs_hold) as satisfied and
+    /// skips blocks that provider never received.
+    ///
+    /// Only a leg that cannot fail the op is droppable, which is why this is a
+    /// no-op without a hosted leg: the set must never narrow to no destination
+    /// at all, which [`decode`](Self::decode) rejects.
+    pub fn mirror_missed(&mut self) {
+        if self.hosted {
+            self.external = None;
+        }
     }
 }
 
@@ -1243,15 +1259,13 @@ mod tests {
     /// Placement is what the durable upload mark is keyed by, so two placements
     /// must not share destinations — a resumed version would otherwise read
     /// progress towards destinations these are not. One endpoint is not one
-    /// destination: the provider kind and the bearer name the account.
+    /// destination: the provider kind names it too.
     #[test]
     fn each_set_of_destinations_tags_itself_apart() {
         let one = "https://a.example";
         let variants = [
             Placement::Hosted,
             Placement::External(byo(one, ByoKind::Kubo, Some("tok"))),
-            Placement::External(byo(one, ByoKind::Kubo, Some("other-tok"))),
-            Placement::External(byo(one, ByoKind::Kubo, None)),
             Placement::External(byo("https://b.example", ByoKind::Kubo, Some("tok"))),
             Placement::Dual(byo(one, ByoKind::Kubo, Some("tok"))),
             Placement::Dual(byo(one, ByoKind::Psa, Some("tok"))),
@@ -1265,20 +1279,25 @@ mod tests {
         }
     }
 
-    /// The tag preimage is length-prefixed, so splitting the same bytes
-    /// differently across endpoint and bearer is a different destination.
+    /// Rotating the credential does not move the destination. The blocks are
+    /// still on that node, and re-tagging would strand every leaf already
+    /// released to it.
     #[test]
-    fn a_resplit_endpoint_and_bearer_are_not_one_destination() {
-        assert_ne!(
-            byo_tag(&byo("https://a.example/x", ByoKind::Kubo, Some("y"))),
-            byo_tag(&byo("https://a.example/", ByoKind::Kubo, Some("xy"))),
-        );
+    fn a_rotated_bearer_is_the_same_destination() {
+        let endpoint = "https://a.example";
+        let tag = |token| byo_tag(&byo(endpoint, ByoKind::Kubo, token));
+        assert_eq!(tag(Some("tok")), tag(Some("rotated")));
+        assert_eq!(tag(Some("tok")), tag(None));
     }
 
     /// A leaf released from staging is safe to skip only where the leg that can
     /// fail this op already holds it. The hosted leg is that leg everywhere but
     /// external-only, so switching the mirror on or off never strands a version
     /// whose bytes the hosted store already took.
+    ///
+    /// The `External` reading of a prior `Dual` mark rests on
+    /// [`Destinations::mirror_missed`]: a dual write only names its mirror in a
+    /// mark that mirror actually took.
     #[test]
     fn progress_carries_exactly_where_the_op_failing_leg_already_holds_the_bytes() {
         let one = byo("https://a.example", ByoKind::Kubo, Some("tok"));
@@ -1334,6 +1353,35 @@ mod tests {
         assert!(holds(&dual_one, &dual_one));
         assert!(holds(&Placement::Hosted, &dual_one));
         assert!(holds(&Placement::External(one), &Placement::Hosted));
+    }
+
+    /// A mirror that missed a block narrows the mark to the hosted leg, so a
+    /// later external-only session no longer reads it as progress — and the set
+    /// never narrows to no destination at all.
+    #[test]
+    fn a_missed_mirror_narrows_the_mark_to_the_hosted_leg() {
+        let one = byo("https://a.example", ByoKind::Kubo, Some("tok"));
+        let mut dual = Placement::Dual(one.clone()).destinations();
+        dual.mirror_missed();
+        assert_eq!(dual, Placement::Hosted.destinations());
+        assert!(
+            !Placement::External(one.clone())
+                .destinations()
+                .required_legs_hold(&dual)
+        );
+        assert!(
+            Placement::Dual(one.clone())
+                .destinations()
+                .required_legs_hold(&dual)
+        );
+
+        let mut external = Placement::External(one).destinations();
+        external.mirror_missed();
+        assert_eq!(
+            Destinations::decode(&external.encode()),
+            Some(external),
+            "the only leg there is never drops out of the set"
+        );
     }
 
     /// AGENTS.md rule 8: the reader accepts exactly what the writer can emit.

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -28,6 +28,8 @@ use cipherbox_core::error::{CodecError, Malformed};
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{open_settings_record, seal_settings_record};
+use cipherbox_core::suite::hash::hash;
+use cipherbox_core::suite::secret::SECRET_LEN;
 use cipherbox_core::suite::x25519::X25519Secret;
 use zeroize::Zeroizing;
 
@@ -71,12 +73,116 @@ impl Default for VaultSettings {
     }
 }
 
+// ---------------------------------------------------------------------------
+// The placement decision: which byte destinations a settings load authorises.
+// ---------------------------------------------------------------------------
+
+/// Where one write's bytes go, decided from the vault settings load and held
+/// for the session. The hosted leg is authoritative in both directions (#34 D1):
+/// only it can fail an op, and only it is quota-gated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Placement {
+    /// CipherBox's hosted pin store only.
+    Hosted,
+    /// The member's own provider only. No *content* block reaches the hosted
+    /// store; record heads and registration still traverse it
+    /// (blueprint/engine.md "Content plane").
+    External(ByoIpfsConfig),
+    /// Both legs.
+    Dual(ByoIpfsConfig),
+}
+
+impl Placement {
+    /// Whether this placement puts bytes in the hosted store — what the account
+    /// quota gates.
+    #[must_use]
+    pub fn has_hosted_leg(&self) -> bool {
+        !matches!(self, Self::External(_))
+    }
+
+    /// A fixed-width tag for the destinations this placement names. Durable
+    /// per-version upload progress is written under it, so a resumed version
+    /// never reads a previous session's progress towards *other* destinations as
+    /// progress towards these — the blocks that progress covers are released
+    /// from staging and can no longer be placed anywhere else.
+    #[must_use]
+    pub fn tag(&self) -> [u8; SECRET_LEN] {
+        let (mode, endpoint) = match self {
+            Self::Hosted => (b"hosted", ""),
+            Self::External(config) => (b"extrnl", config.endpoint.as_str()),
+            Self::Dual(config) => (b"dual\0\0", config.endpoint.as_str()),
+        };
+        let mut tagged = mode.to_vec();
+        tagged.extend_from_slice(endpoint.as_bytes());
+        hash(&tagged)
+    }
+}
+
+/// The session's placement decision, as the command path and the drain both
+/// read it: where bytes go, or why no destination could be authenticated.
+pub type PlacementDecision = Result<Placement, PlacementRefusal>;
+
+/// Why no byte destination could be decided. Every variant refuses the write:
+/// a placement that cannot be authenticated must not widen to the hosted
+/// default (blueprint/engine.md "Settings-load policy").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlacementRefusal {
+    /// The settings load degraded past a first run with no last-known-good copy,
+    /// so the member's own placement choice is unavailable.
+    SettingsUnavailable(DefaultsReason),
+    /// The mode names an external leg the settings carry no config for.
+    NoProvider,
+    /// External-only over a pin-by-CID provider, which has no byte ingress: no
+    /// leg would hold the block for it to fetch.
+    NoExternalIngress(ByoKind),
+}
+
+/// The byte destinations a settings load authorises.
+///
+/// The built-in defaults describe a first run and nothing else: every other
+/// degraded reason with no last-known-good copy refuses rather than resolving
+/// to [`PinMode::Hosted`] (blueprint/engine.md "Settings-load policy").
+///
+/// Residual, stated there too: `NoRecord` is a verdict about *this device*, so a
+/// record-plane adversary who withholds the record from a device that has never
+/// synced still gets the first-run default.
+pub fn decide_placement(load: &SettingsLoad) -> Result<Placement, PlacementRefusal> {
+    match load {
+        SettingsLoad::Resolved(settings) | SettingsLoad::Stale { settings, .. } => {
+            placement_of(settings)
+        }
+        SettingsLoad::Defaults(DefaultsReason::NoRecord) => Ok(Placement::Hosted),
+        SettingsLoad::Defaults(reason) => Err(PlacementRefusal::SettingsUnavailable(*reason)),
+    }
+}
+
+/// The byte destinations `settings` name, in the two places that must agree:
+/// the reader deciding where this session's bytes go, and the writer refusing
+/// to publish settings no reader could place under (AGENTS.md rule 8).
+pub fn placement_of(settings: &VaultSettings) -> Result<Placement, PlacementRefusal> {
+    let config = || settings.byo.clone().ok_or(PlacementRefusal::NoProvider);
+    match settings.pin_mode {
+        PinMode::Hosted => Ok(Placement::Hosted),
+        PinMode::Dual => Ok(Placement::Dual(config()?)),
+        PinMode::External => match config()? {
+            config @ ByoIpfsConfig {
+                kind: ByoKind::Kubo,
+                ..
+            } => Ok(Placement::External(config)),
+            config => Err(PlacementRefusal::NoExternalIngress(config.kind)),
+        },
+    }
+}
+
 /// Why a settings publish did not reach the network. Every variant is
 /// fail-closed: nothing is published.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SettingsPublishError {
     /// The BYO config is not one the Http seam may be pointed at.
     Byo(ProviderError),
+    /// The settings name a mode no reader could place bytes under, so
+    /// publishing them would strand every device on the account.
+    Placement(PlacementRefusal),
     /// Core refused to encode or seal the body.
     Codec(CodecError),
     /// The host could not supply the per-record HPKE ephemeral scalar.
@@ -249,6 +355,11 @@ where
     Sch: Scheduler + Clone + 'static,
 {
     validate(settings).map_err(SettingsPublishError::Byo)?;
+    // Rule 8, one layer out from the codec: `decide_placement` hard-refuses a
+    // mode with no usable byte destination, so a record carrying one would be a
+    // durable, account-wide refusal of every content write. Release-active, and
+    // the reader's own predicate rather than a restatement of it.
+    placement_of(settings).map_err(SettingsPublishError::Placement)?;
     let signer = kdf::settings_ipns_keypair(login_secret);
     let name = IpnsName::from_public_key(&signer.verifying_key());
     let revision = next_revision(floors, &name).await?;
@@ -712,6 +823,7 @@ fn kind_str(kind: ByoKind) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testkit::{FakeWorld, SeededEntropy, block_on};
 
     fn keep(n: u64) -> RetentionPolicy {
         RetentionPolicy::KeepLatest(NonZeroU64::new(n).expect("nonzero"))
@@ -855,6 +967,187 @@ mod tests {
                 BodyError::Byo(refused),
                 "{endpoint}: the reader must refuse what the writer refuses",
             );
+        }
+    }
+    // -----------------------------------------------------------------------
+    // Placement: what a settings load authorises, and what it refuses.
+    // -----------------------------------------------------------------------
+
+    fn placed(mode: PinMode, config: Option<ByoIpfsConfig>) -> VaultSettings {
+        VaultSettings {
+            pin_mode: mode,
+            byo: config,
+            ..VaultSettings::default()
+        }
+    }
+
+    fn kubo() -> ByoIpfsConfig {
+        byo("https://node.example", ByoKind::Kubo, Some("tok"))
+    }
+
+    #[test]
+    fn a_resolved_record_places_bytes_where_the_member_chose() {
+        for (mode, expected) in [
+            (PinMode::Hosted, Placement::Hosted),
+            (PinMode::External, Placement::External(kubo())),
+            (PinMode::Dual, Placement::Dual(kubo())),
+        ] {
+            let load = SettingsLoad::Resolved(placed(mode, Some(kubo())));
+            assert_eq!(decide_placement(&load).unwrap(), expected);
+        }
+    }
+
+    /// The last-known-good copy is the member's own choice, so it decides
+    /// placement exactly as a resolved record does — that is the whole point of
+    /// keeping it (blueprint/engine.md "Settings-load policy").
+    #[test]
+    fn a_stale_copy_decides_placement_like_a_resolved_record() {
+        let load = SettingsLoad::Stale {
+            settings: placed(
+                PinMode::External,
+                Some(byo("https://node.example", ByoKind::Kubo, None)),
+            ),
+            reason: DefaultsReason::Suppressed,
+        };
+        assert_eq!(
+            decide_placement(&load).unwrap(),
+            Placement::External(byo("https://node.example", ByoKind::Kubo, None))
+        );
+    }
+
+    /// The built-in defaults describe a first run and nothing else: every other
+    /// degraded reason refuses rather than widening an unknown choice onto the
+    /// hosted store.
+    #[test]
+    fn only_a_first_run_falls_back_to_the_hosted_default() {
+        assert_eq!(
+            decide_placement(&SettingsLoad::Defaults(DefaultsReason::NoRecord)).unwrap(),
+            Placement::Hosted
+        );
+        for reason in [
+            DefaultsReason::Suppressed,
+            DefaultsReason::RolledBack {
+                floor: 4,
+                sequence: 2,
+            },
+            DefaultsReason::RevisionRolledBack {
+                floor: 4,
+                revision: 2,
+            },
+            DefaultsReason::Expired,
+            DefaultsReason::TimedOut,
+            DefaultsReason::Unreadable,
+            DefaultsReason::FloorUnreadable,
+        ] {
+            assert_eq!(
+                decide_placement(&SettingsLoad::Defaults(reason)).unwrap_err(),
+                PlacementRefusal::SettingsUnavailable(reason),
+                "{reason:?} must not widen placement"
+            );
+        }
+    }
+
+    #[test]
+    fn a_mode_naming_an_external_leg_with_no_provider_is_refused() {
+        for mode in [PinMode::External, PinMode::Dual] {
+            let load = SettingsLoad::Resolved(placed(mode, None));
+            assert_eq!(
+                decide_placement(&load).unwrap_err(),
+                PlacementRefusal::NoProvider
+            );
+        }
+    }
+
+    /// A pinning service fetches content from the network rather than receiving
+    /// it, so external-only over one would publish a record naming bytes no leg
+    /// holds. Paired with a hosted leg it is exactly right.
+    #[test]
+    fn a_pin_by_cid_provider_cannot_be_the_only_byte_destination() {
+        for kind in [ByoKind::Psa, ByoKind::Pinata] {
+            let provider = Some(byo("https://node.example", kind, Some("tok")));
+            assert_eq!(
+                decide_placement(&SettingsLoad::Resolved(placed(
+                    PinMode::External,
+                    provider.clone()
+                )))
+                .unwrap_err(),
+                PlacementRefusal::NoExternalIngress(kind)
+            );
+            assert!(
+                decide_placement(&SettingsLoad::Resolved(placed(PinMode::Dual, provider))).is_ok(),
+                "{kind:?} is a fine second leg"
+            );
+        }
+    }
+
+    /// Rule 8: the publish path refuses the very shapes `decide_placement`
+    /// refuses, so no record can strand every device on the account.
+    #[test]
+    fn publishing_settings_no_reader_could_place_under_is_refused() {
+        let world = FakeWorld::new();
+        let device = world.device(b"alice");
+        for (settings, refusal) in [
+            (
+                placed(PinMode::External, None),
+                PlacementRefusal::NoProvider,
+            ),
+            (placed(PinMode::Dual, None), PlacementRefusal::NoProvider),
+            (
+                placed(
+                    PinMode::External,
+                    Some(byo("https://api.pinata.cloud", ByoKind::Pinata, Some("t"))),
+                ),
+                PlacementRefusal::NoExternalIngress(ByoKind::Pinata),
+            ),
+        ] {
+            let api = ApiClient::new(
+                device.http.clone(),
+                device.credential_store.clone(),
+                String::new(),
+            );
+            let outcome = block_on(publish_settings(
+                &device.record_store,
+                &api,
+                &device.floor_store,
+                &device.snapshot_cache,
+                &world.scheduler,
+                &SyncTimingProfile::CI,
+                &mut SeededEntropy::new(3),
+                &OrphanHeads::default(),
+                &[7u8; 32],
+                &settings,
+            ));
+            assert_eq!(
+                outcome.unwrap_err(),
+                SettingsPublishError::Placement(refusal),
+                "{settings:?} must never be published"
+            );
+            assert!(
+                device.http.requests().is_empty(),
+                "a refused publish never reaches the network"
+            );
+        }
+    }
+
+    /// Placement is what the durable upload mark is keyed by, so two placements
+    /// must not share a tag — a resumed version would otherwise read progress
+    /// towards destinations these are not.
+    #[test]
+    fn each_set_of_destinations_tags_itself_apart() {
+        let a = byo("https://a.example", ByoKind::Kubo, Some("tok"));
+        let b = byo("https://b.example", ByoKind::Kubo, Some("tok"));
+        let tags = [
+            Placement::Hosted,
+            Placement::External(a.clone()),
+            Placement::External(b.clone()),
+            Placement::Dual(a),
+            Placement::Dual(b),
+        ]
+        .map(|placement| placement.tag());
+        for (i, tag) in tags.iter().enumerate() {
+            for other in &tags[i + 1..] {
+                assert_ne!(tag, other, "distinct destinations, distinct tags");
+            }
         }
     }
 }

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -17,6 +17,7 @@
 //! ([`DefaultsReason`]) — silently reverting a member's placement choice to the
 //! hosted default is what an adversary who can withhold the record gains.
 
+use core::fmt;
 use core::future::{Future, poll_fn};
 use core::num::NonZeroU64;
 use core::pin::pin;
@@ -100,21 +101,131 @@ impl Placement {
         !matches!(self, Self::External(_))
     }
 
-    /// A fixed-width tag for the destinations this placement names. Durable
-    /// per-version upload progress is written under it, so a resumed version
-    /// never reads a previous session's progress towards *other* destinations as
-    /// progress towards these — the blocks that progress covers are released
-    /// from staging and can no longer be placed anywhere else.
+    /// The byte destinations this placement names, as durable upload progress
+    /// records them.
     #[must_use]
-    pub fn tag(&self) -> [u8; SECRET_LEN] {
-        let (mode, endpoint) = match self {
-            Self::Hosted => (b"hosted", ""),
-            Self::External(config) => (b"extrnl", config.endpoint.as_str()),
-            Self::Dual(config) => (b"dual\0\0", config.endpoint.as_str()),
+    pub fn destinations(&self) -> Destinations {
+        match self {
+            Self::Hosted => Destinations {
+                hosted: true,
+                external: None,
+            },
+            Self::External(config) => Destinations {
+                hosted: false,
+                external: Some(byo_tag(config)),
+            },
+            Self::Dual(config) => Destinations {
+                hosted: true,
+                external: Some(byo_tag(config)),
+            },
+        }
+    }
+}
+
+/// A provider's identity as the upload mark records it. The destination is the
+/// account the credential names, not the URL alone, so a config differing only
+/// in kind or bearer must tag apart. Hashed because the bearer is secret: the
+/// preimage never leaves this function, and only the digest reaches staging.
+fn byo_tag(config: &ByoIpfsConfig) -> [u8; SECRET_LEN] {
+    let token = config
+        .access_token
+        .as_ref()
+        .map_or("", |token| token.as_str());
+    let mut tagged = Zeroizing::new(b"cipherbox/byo-destination\0".to_vec());
+    tagged.push(config.kind as u8);
+    // Length-prefixed: without it a differently-split endpoint/token pair
+    // concatenates to the same preimage.
+    tagged.extend_from_slice(&(config.endpoint.len() as u64).to_be_bytes());
+    tagged.extend_from_slice(config.endpoint.as_bytes());
+    tagged.extend_from_slice(&(token.len() as u64).to_be_bytes());
+    tagged.extend_from_slice(token.as_bytes());
+    hash(&tagged)
+}
+
+/// The set of byte destinations one write's blocks go to. Durable per-version
+/// upload progress is written under it, so a resumed version reads a previous
+/// session's progress only where the destinations it must reach now already
+/// hold those blocks — progress releases them from staging, after which they
+/// can never be placed anywhere else.
+///
+/// The two legs are kept apart rather than folded into one tag because they
+/// fail differently: only the leg that can fail an op has to hold the released
+/// blocks for the version to publish (#34 D1).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Destinations {
+    hosted: bool,
+    external: Option<[u8; SECRET_LEN]>,
+}
+
+impl fmt::Debug for Destinations {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Destinations")
+            .field("hosted", &self.hosted)
+            .field("external", &self.external.map(|_| "<tag>"))
+            .finish()
+    }
+}
+
+impl Destinations {
+    /// The fixed width of the encoded form.
+    pub const LEN: usize = 2 + SECRET_LEN;
+
+    /// The wire form the upload mark carries.
+    #[must_use]
+    pub fn encode(&self) -> [u8; Self::LEN] {
+        let mut out = [0u8; Self::LEN];
+        out[0] = u8::from(self.hosted);
+        out[1] = u8::from(self.external.is_some());
+        if let Some(tag) = &self.external {
+            out[2..].copy_from_slice(tag);
+        }
+        out
+    }
+
+    /// Recover destinations from a stored mark, fail-closed: a leg flag outside
+    /// `{0, 1}`, a tag under an absent leg, or a set naming no destination at
+    /// all is not something [`encode`](Self::encode) can produce, so it says
+    /// nothing about where any block went.
+    #[must_use]
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        let bytes: [u8; Self::LEN] = bytes.try_into().ok()?;
+        let (hosted, external) = match (bytes[0], bytes[1]) {
+            (0, 1) => (false, true),
+            (1, 0) => (true, false),
+            (1, 1) => (true, true),
+            _ => return None,
         };
-        let mut tagged = mode.to_vec();
-        tagged.extend_from_slice(endpoint.as_bytes());
-        hash(&tagged)
+        let tag: [u8; SECRET_LEN] = bytes[2..].try_into().ok()?;
+        if !external && tag != [0u8; SECRET_LEN] {
+            return None;
+        }
+        Some(Self {
+            hosted,
+            external: external.then_some(tag),
+        })
+    }
+
+    /// Whether blocks already placed at `earlier` reached every leg that can
+    /// fail an op under *these* destinations — the hosted store, except under
+    /// external-only where the member's own provider is the only leg there is.
+    ///
+    /// This is what makes a leaf missing from staging safe to skip: it is not
+    /// that some destination once took it, but that the destination this
+    /// version must publish from holds it.
+    #[must_use]
+    pub fn required_legs_hold(&self, earlier: &Self) -> bool {
+        match self.hosted {
+            true => earlier.hosted,
+            false => self.external.is_some() && earlier.external == self.external,
+        }
+    }
+
+    /// Whether a dual write's best-effort mirror also holds those blocks. A
+    /// mirror that does not is reported, never fatal: it is the same gap a live
+    /// [`ProviderError`] on the external leg leaves.
+    #[must_use]
+    pub fn mirror_leg_holds(&self, earlier: &Self) -> bool {
+        !self.hosted || self.external.is_none() || earlier.external == self.external
     }
 }
 
@@ -1130,24 +1241,125 @@ mod tests {
     }
 
     /// Placement is what the durable upload mark is keyed by, so two placements
-    /// must not share a tag — a resumed version would otherwise read progress
-    /// towards destinations these are not.
+    /// must not share destinations — a resumed version would otherwise read
+    /// progress towards destinations these are not. One endpoint is not one
+    /// destination: the provider kind and the bearer name the account.
     #[test]
     fn each_set_of_destinations_tags_itself_apart() {
-        let a = byo("https://a.example", ByoKind::Kubo, Some("tok"));
-        let b = byo("https://b.example", ByoKind::Kubo, Some("tok"));
-        let tags = [
+        let one = "https://a.example";
+        let variants = [
             Placement::Hosted,
-            Placement::External(a.clone()),
-            Placement::External(b.clone()),
-            Placement::Dual(a),
-            Placement::Dual(b),
+            Placement::External(byo(one, ByoKind::Kubo, Some("tok"))),
+            Placement::External(byo(one, ByoKind::Kubo, Some("other-tok"))),
+            Placement::External(byo(one, ByoKind::Kubo, None)),
+            Placement::External(byo("https://b.example", ByoKind::Kubo, Some("tok"))),
+            Placement::Dual(byo(one, ByoKind::Kubo, Some("tok"))),
+            Placement::Dual(byo(one, ByoKind::Psa, Some("tok"))),
+            Placement::Dual(byo(one, ByoKind::Pinata, Some("tok"))),
         ]
-        .map(|placement| placement.tag());
-        for (i, tag) in tags.iter().enumerate() {
-            for other in &tags[i + 1..] {
+        .map(|placement| placement.destinations().encode());
+        for (i, tag) in variants.iter().enumerate() {
+            for other in &variants[i + 1..] {
                 assert_ne!(tag, other, "distinct destinations, distinct tags");
             }
         }
+    }
+
+    /// The tag preimage is length-prefixed, so splitting the same bytes
+    /// differently across endpoint and bearer is a different destination.
+    #[test]
+    fn a_resplit_endpoint_and_bearer_are_not_one_destination() {
+        assert_ne!(
+            byo_tag(&byo("https://a.example/x", ByoKind::Kubo, Some("y"))),
+            byo_tag(&byo("https://a.example/", ByoKind::Kubo, Some("xy"))),
+        );
+    }
+
+    /// A leaf released from staging is safe to skip only where the leg that can
+    /// fail this op already holds it. The hosted leg is that leg everywhere but
+    /// external-only, so switching the mirror on or off never strands a version
+    /// whose bytes the hosted store already took.
+    #[test]
+    fn progress_carries_exactly_where_the_op_failing_leg_already_holds_the_bytes() {
+        let one = byo("https://a.example", ByoKind::Kubo, Some("tok"));
+        let two = byo("https://b.example", ByoKind::Kubo, Some("tok"));
+        let carries = |here: &Placement, earlier: &Placement| {
+            here.destinations()
+                .required_legs_hold(&earlier.destinations())
+        };
+
+        let hosted = Placement::Hosted;
+        let dual_one = Placement::Dual(one.clone());
+        let dual_two = Placement::Dual(two.clone());
+        let external_one = Placement::External(one);
+        let external_two = Placement::External(two);
+
+        for (here, earlier) in [
+            (&dual_one, &hosted),
+            (&hosted, &dual_one),
+            (&dual_one, &dual_two),
+            (&external_one, &dual_one),
+            (&external_one, &external_one),
+        ] {
+            assert!(carries(here, earlier), "the required leg holds the bytes");
+        }
+        for (here, earlier) in [
+            (&hosted, &external_one),
+            (&dual_one, &external_one),
+            (&external_one, &hosted),
+            (&external_one, &external_two),
+            (&external_one, &dual_two),
+        ] {
+            assert!(
+                !carries(here, earlier),
+                "the required leg never received them"
+            );
+        }
+    }
+
+    /// A dual mirror that missed the released blocks is a gap to report, and
+    /// only dual has a mirror to gap.
+    #[test]
+    fn only_a_dual_mirror_can_gap() {
+        let one = byo("https://a.example", ByoKind::Kubo, Some("tok"));
+        let two = byo("https://b.example", ByoKind::Kubo, Some("tok"));
+        let holds = |here: &Placement, earlier: &Placement| {
+            here.destinations()
+                .mirror_leg_holds(&earlier.destinations())
+        };
+        let dual_one = Placement::Dual(one.clone());
+
+        assert!(!holds(&dual_one, &Placement::Hosted));
+        assert!(!holds(&dual_one, &Placement::Dual(two)));
+        assert!(holds(&dual_one, &dual_one));
+        assert!(holds(&Placement::Hosted, &dual_one));
+        assert!(holds(&Placement::External(one), &Placement::Hosted));
+    }
+
+    /// AGENTS.md rule 8: the reader accepts exactly what the writer can emit.
+    #[test]
+    fn destinations_decode_only_what_encode_can_produce() {
+        let one = byo("https://a.example", ByoKind::Kubo, Some("tok"));
+        for placement in [
+            Placement::Hosted,
+            Placement::External(one.clone()),
+            Placement::Dual(one),
+        ] {
+            let encoded = placement.destinations().encode();
+            assert_eq!(
+                Destinations::decode(&encoded),
+                Some(placement.destinations()),
+            );
+        }
+        let mut hosted = Placement::Hosted.destinations().encode();
+        hosted[2] = 1;
+        assert_eq!(
+            Destinations::decode(&hosted),
+            None,
+            "a tag under an absent external leg is not an encoding"
+        );
+        assert_eq!(Destinations::decode(&[0u8; Destinations::LEN]), None);
+        assert_eq!(Destinations::decode(&[2u8; Destinations::LEN]), None);
+        assert_eq!(Destinations::decode(&[]), None);
     }
 }

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -33,10 +33,7 @@ use futures_channel::mpsc;
 use zeroize::Zeroizing;
 
 use crate::api::{ApiClient, ApiError, QUOTA_EXCEEDED, REGISTRY_BATCH_REFUSED, UPLOAD_TOO_LARGE};
-use crate::content::{
-    Gateway, Placement, PlacementDecision, ProviderError, SealedContent, place_block,
-    pre_flight_quota_check,
-};
+use crate::content::{Gateway, ProviderError, SealedContent, place_block, pre_flight_quota_check};
 use crate::entropy::Entropy;
 use crate::facade::{BlockProgress, Event, NodeId, OpPhase};
 use crate::gate::floor;
@@ -61,6 +58,7 @@ use crate::seams::{
     StagingStore,
 };
 use crate::session::SessionIdentity;
+use crate::settings::{Placement, PlacementDecision};
 use crate::sync::cancel::UploadCancels;
 use crate::sync::model::{Snapshot, collation_key};
 use crate::sync::op::{NewNode, Op, OpKind, StagedContent};
@@ -352,9 +350,8 @@ pub(crate) struct Drain<'a, T, H: Http, C: CredentialStore, F, S, St, Sch> {
     pub(crate) scheduler: &'a Sch,
     pub(crate) http: &'a H,
     pub(crate) gateway: &'a Gateway,
-    /// Where this session's bytes go, decided once from the vault settings load.
-    /// An `Err` holds every content op — the drain publishes no version it
-    /// cannot place (blueprint/engine.md "Settings-load policy").
+    /// Where this session's bytes go. An `Err` holds every content op — the
+    /// drain publishes no version it cannot place.
     pub(crate) placement: &'a PlacementDecision,
     pub(crate) profile: &'a SyncTimingProfile,
     /// Seal nonces enter as injected entropy; the drain reads no RNG of its own.
@@ -434,9 +431,8 @@ struct UploadedVersion {
     /// Every content CID the registration names: the root first, then the
     /// leaves in file order.
     content_cids: Vec<String>,
-    /// A dual write's external leg that did not take the bytes. The op still
-    /// publishes — only the hosted leg can fail it — so this rides out as a
-    /// per-op report rather than being swallowed.
+    /// A dual write's external leg that did not take the bytes, reported rather
+    /// than swallowed ([`OpPhase::ExternalPinFailed`]).
     external_failure: Option<ProviderError>,
 }
 
@@ -650,7 +646,8 @@ where
         let Ok(quota) = self.api.quota().await else {
             return false;
         };
-        if pre_flight_quota_check(blocked.needed_bytes, &quota, placement.mode()).is_err() {
+        if pre_flight_quota_check(blocked.needed_bytes, &quota, placement.has_hosted_leg()).is_err()
+        {
             return false;
         }
         self.clear_block();
@@ -1494,8 +1491,7 @@ where
         if !self.cancels.borrow_mut().enter_publish(applied.op_id) {
             return Err(Halt::Cancelled);
         }
-        // Reported once per op, not per block: the version published and is
-        // retrievable, but it is not on the member's own node (#34 D1).
+        // Once per op, not per block.
         if let Some(error) = &uploaded.external_failure {
             self.emit_upload(
                 applied,
@@ -1553,7 +1549,9 @@ where
         // mark this pass keeps: past it, a missing block is loss, and the
         // version can never be assembled.
         let leaves = content.leaf_cids().len();
-        let uploaded = self.upload_mark(&staged.root_cid, leaves).await?;
+        let uploaded = self
+            .upload_mark(placement, &staged.root_cid, leaves)
+            .await?;
         // The root manifest is block zero and goes up last, so the version's
         // whole block count is its leaves plus one.
         let total = blocks(leaves + 1);
@@ -1570,17 +1568,17 @@ where
             self.cancel_checkpoint(applied.op_id).await?;
             match self.staged_block(leaf_cid).await? {
                 Some(block) => {
-                    external_failure = self
-                        .upload_block(placement, leaf_cid, &block)
-                        .await?
-                        .or(external_failure);
+                    // First failure wins: the report names one leg, not the
+                    // last block that happened to miss it.
+                    let missed = self.upload_block(placement, leaf_cid, &block).await?;
+                    external_failure = external_failure.or(missed);
                     self.cancels.borrow_mut().confirmed(applied.op_id, leaf_cid);
                     // A leaf a lost release left staged behind the mark is
                     // re-uploaded here, and must not drag the mark back down
                     // over the leaves past it — those are released, so an
                     // uncovered one reads as loss.
                     if index + 1 > uploaded {
-                        self.mark_uploaded(&staged.root_cid, index + 1, leaves)
+                        self.mark_uploaded(placement, &staged.root_cid, index + 1, leaves)
                             .await?;
                     }
                     self.staging
@@ -1599,10 +1597,10 @@ where
         // The root goes up last and stays staged until the publish confirms: it
         // is the manifest every retry re-derives the plan from, so releasing it
         // before the record lands would strand a fully-uploaded version.
-        external_failure = self
+        let missed = self
             .upload_block(placement, &staged.root_cid, &root_block)
-            .await?
-            .or(external_failure);
+            .await?;
+        external_failure = external_failure.or(missed);
         self.cancels
             .borrow_mut()
             .confirmed(applied.op_id, &staged.root_cid);
@@ -1647,13 +1645,20 @@ where
 
     /// How many of this version's `leaves` a previous pass durably confirmed
     /// ([`decode_upload_mark`]).
-    async fn upload_mark(&self, root_cid: &[u8], leaves: usize) -> Result<usize, Halt> {
+    async fn upload_mark(
+        &self,
+        placement: &Placement,
+        root_cid: &[u8],
+        leaves: usize,
+    ) -> Result<usize, Halt> {
         Ok(self
             .staging
             .staged_bytes(UPLOAD_MARK_KEY)
             .await
             .map_err(seam)?
-            .map_or(0, |stored| decode_upload_mark(&stored, root_cid, leaves)))
+            .map_or(0, |stored| {
+                decode_upload_mark(&stored, &placement.tag(), root_cid, leaves)
+            }))
     }
 
     /// Record that `count` of this version's `leaves` have uploaded. A
@@ -1663,11 +1668,13 @@ where
     /// read those uploaded bytes as loss.
     async fn mark_uploaded(
         &self,
+        placement: &Placement,
         root_cid: &[u8],
         count: usize,
         leaves: usize,
     ) -> Result<(), Halt> {
-        let mark = encode_upload_mark(root_cid, count, leaves).ok_or(Halt::Unclassified)?;
+        let mark = encode_upload_mark(&placement.tag(), root_cid, count, leaves)
+            .ok_or(Halt::Unclassified)?;
         self.staging
             .put_staged_bytes(UPLOAD_MARK_KEY, &mark)
             .await
@@ -1692,34 +1699,39 @@ where
     /// confirmed [`UploadResult`](crate::UploadResult), which is what makes the
     /// still-staged set a suffix.
     ///
-    /// The hosted leg is authoritative: it alone can fail the op. A dual write's
-    /// external leg is reported instead of failing the op, because under
-    /// strict-FIFO stop-at-first-failure an offline home node would stall every
-    /// later mutation in the vault (#34 D1). Under `External` the member's
-    /// provider *is* the byte path, so its refusal is the op's.
+    /// Only the hosted leg can fail the op — see [`OpPhase::ExternalPinFailed`]
+    /// for why a dual write's mirror is reported instead.
     async fn upload_block(
         &self,
         placement: &Placement,
         cid: &[u8],
         block: &[u8],
     ) -> Result<Option<ProviderError>, Halt> {
-        if !matches!(placement, Placement::External(_)) {
-            self.api
-                .upload(&encode_content_cid_str(cid), block)
-                .await
-                .map(drop)
-                .map_err(|error| classify_upload(error, block.len() as u64))?;
+        match placement {
+            Placement::Hosted => {
+                self.hosted_upload(cid, block).await?;
+                Ok(None)
+            }
+            Placement::External(config) => {
+                place_block(config, cid, block, self.http)
+                    .await
+                    .map_err(|_| Halt::UploadAttempt)?;
+                Ok(None)
+            }
+            Placement::Dual(config) => {
+                self.hosted_upload(cid, block).await?;
+                Ok(place_block(config, cid, block, self.http).await.err())
+            }
         }
-        let Some(config) = placement.external() else {
-            return Ok(None);
-        };
-        match place_block(config, cid, block, self.http).await {
-            Ok(()) => Ok(None),
-            Err(error) => match placement {
-                Placement::Dual(_) => Ok(Some(error)),
-                _ => Err(Halt::UploadAttempt),
-            },
-        }
+    }
+
+    /// One block to the hosted ingress, under its own content address.
+    async fn hosted_upload(&self, cid: &[u8], block: &[u8]) -> Result<(), Halt> {
+        self.api
+            .upload(&encode_content_cid_str(cid), block)
+            .await
+            .map(drop)
+            .map_err(|error| classify_upload(error, block.len() as u64))
     }
 
     /// Drop every staged block of an op's version — on a landed publish, and on
@@ -2262,23 +2274,34 @@ fn classify_publish(error: RecordPublishError, refused_bytes: u64) -> Halt {
 /// reached — AGENTS.md rule 8's release-active mirror of
 /// [`decode_upload_mark`]'s bound, so a mark the reader discards as corrupt can
 /// never be written.
-fn encode_upload_mark(root_cid: &[u8], count: usize, leaves: usize) -> Option<Vec<u8>> {
+fn encode_upload_mark(
+    placement: &[u8],
+    root_cid: &[u8],
+    count: usize,
+    leaves: usize,
+) -> Option<Vec<u8>> {
     let claim = u32::try_from(count).ok().filter(|_| count <= leaves)?;
-    let mut mark = root_cid.to_vec();
+    let mut mark = placement.to_vec();
+    mark.extend_from_slice(root_cid);
     mark.extend_from_slice(&claim.to_be_bytes());
     Some(mark)
 }
 
-/// How many of `root_cid`'s `leaves` the stored mark claims. A mark naming
-/// another version has nothing to say about this one, and one claiming more
-/// leaves than the version has is proof of a torn or rotted mark — both read as
-/// no progress, so every absent leaf stays loss rather than being covered by
-/// bytes already known to be corrupt.
-fn decode_upload_mark(stored: &[u8], root_cid: &[u8], leaves: usize) -> usize {
-    let Some((root, count)) = stored.split_at_checked(stored.len().saturating_sub(4)) else {
+/// How many of `root_cid`'s `leaves` the stored mark claims, under `placement`.
+/// A mark naming another version — or the same version's blocks sent to *other*
+/// destinations, which are released from staging and can no longer be placed
+/// here — has nothing to say about this one, and one claiming more leaves than
+/// the version has is proof of a torn or rotted mark. All read as no progress,
+/// so every absent leaf stays loss rather than being covered by bytes this
+/// placement never received.
+fn decode_upload_mark(stored: &[u8], placement: &[u8], root_cid: &[u8], leaves: usize) -> usize {
+    let Some((named, count)) = stored.split_at_checked(stored.len().saturating_sub(4)) else {
         return 0;
     };
-    if root != root_cid {
+    if named.len() != placement.len() + root_cid.len()
+        || &named[..placement.len()] != placement
+        || &named[placement.len()..] != root_cid
+    {
         return 0;
     }
     let count = <[u8; 4]>::try_from(count).map_or(0, |c| u32::from_be_bytes(c) as usize);
@@ -2381,7 +2404,8 @@ fn provider_failure(error: &ProviderError) -> &'static str {
         ProviderError::AddressMismatch => {
             "your own IPFS provider stored the block at a different address"
         }
-        _ => "your own IPFS provider did not accept the block",
+        ProviderError::NoVerdict => "your own IPFS provider gave no usable answer",
+        _ => "your own IPFS provider refused the config it was given",
     }
 }
 
@@ -2449,31 +2473,63 @@ mod tests {
     #[test]
     fn a_mark_claiming_more_leaves_than_the_version_has_is_refused_on_both_sides() {
         const ROOT: &[u8] = b"root-cid";
+        const HERE: &[u8] = b"placement-a";
         let planted = |count: u32| {
-            let mut mark = ROOT.to_vec();
+            let mut mark = HERE.to_vec();
+            mark.extend_from_slice(ROOT);
             mark.extend_from_slice(&count.to_be_bytes());
             mark
         };
         for count in [4usize, 5, usize::try_from(u32::MAX).expect("64-bit")] {
             assert!(
-                encode_upload_mark(ROOT, count, 3).is_none(),
+                encode_upload_mark(HERE, ROOT, count, 3).is_none(),
                 "{count}: the writer refuses what the reader discards",
             );
             assert_eq!(
-                decode_upload_mark(&planted(u32::try_from(count).unwrap_or(u32::MAX)), ROOT, 3),
+                decode_upload_mark(
+                    &planted(u32::try_from(count).unwrap_or(u32::MAX)),
+                    HERE,
+                    ROOT,
+                    3
+                ),
                 0,
                 "{count}: a corrupt mark covers no leaf at all",
             );
         }
         // The in-range case still round-trips, so the bound is the only change.
         assert_eq!(
-            decode_upload_mark(&encode_upload_mark(ROOT, 2, 3).expect("in range"), ROOT, 3),
+            decode_upload_mark(
+                &encode_upload_mark(HERE, ROOT, 2, 3).expect("in range"),
+                HERE,
+                ROOT,
+                3
+            ),
             2,
         );
         assert_eq!(
-            decode_upload_mark(&planted(2), b"another-root", 3),
+            decode_upload_mark(&planted(2), HERE, b"another-root", 3),
             0,
             "a mark naming another version has nothing to say about this one",
+        );
+    }
+
+    /// Progress towards one set of destinations is not progress towards
+    /// another: the blocks it covers were released from staging, so reading it
+    /// under a new placement would publish a version that placement never
+    /// received.
+    #[test]
+    fn a_mark_written_under_other_destinations_covers_nothing_here() {
+        const ROOT: &[u8] = b"root-cid";
+        let elsewhere = encode_upload_mark(b"placement-a", ROOT, 2, 3).expect("in range");
+        assert_eq!(
+            decode_upload_mark(&elsewhere, b"placement-b", ROOT, 3),
+            0,
+            "another placement's progress covers no leaf here",
+        );
+        assert_eq!(
+            decode_upload_mark(&elsewhere, b"placement-a", ROOT, 3),
+            2,
+            "and its own still does",
         );
     }
 

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -1638,7 +1638,6 @@ where
                 Some(block) => {
                     self.upload_block(placement, &mut mirror, applied.op_id, leaf_cid, &block)
                         .await?;
-                    self.cancels.borrow_mut().confirmed(applied.op_id, leaf_cid);
                     if mirror.missed() {
                         reached.mirror_missed();
                     }
@@ -1674,9 +1673,6 @@ where
             &root_block,
         )
         .await?;
-        self.cancels
-            .borrow_mut()
-            .confirmed(applied.op_id, &staged.root_cid);
         emit(OpPhase::UploadCompleted, total);
 
         let content_cids = registry_cids(&staged.root_cid, content.leaf_cids());
@@ -1791,25 +1787,41 @@ where
         block: &[u8],
     ) -> Result<(), Halt> {
         match placement {
-            Placement::Hosted => self.hosted_upload(cid, block).await,
-            Placement::External(config) => place_block(config, cid, block, self.http)
-                .await
-                .map_err(classify_placement),
+            Placement::Hosted => {
+                self.hosted_upload(cid, block).await?;
+                self.charged(op_id, cid);
+            }
+            Placement::External(config) => {
+                place_block(config, cid, block, self.http)
+                    .await
+                    .map_err(classify_placement)?;
+                self.charged(op_id, cid);
+            }
             Placement::Dual(config) => {
                 self.hosted_upload(cid, block).await?;
+                self.charged(op_id, cid);
                 while !mirror.missed() {
                     // The budget spans several provider deadlines, so a cancel
                     // gets to run between them rather than only at the block
-                    // boundary below.
+                    // boundary. The charge above is already recorded, so one
+                    // landing here still retires these bytes.
                     self.cancel_checkpoint(op_id).await?;
                     match place_block(config, cid, block, self.http).await {
-                        Ok(()) => return Ok(()),
+                        Ok(()) => break,
                         Err(error) => mirror.refused(error),
                     }
                 }
-                Ok(())
             }
         }
+        Ok(())
+    }
+
+    /// Record one block as on the network for `op_id`, which is the only
+    /// evidence a cancel has that this upload charged for it
+    /// ([`UploadCancels`]). Written the instant the leg that charges confirms,
+    /// so no later await can abandon the upload with the charge unrecorded.
+    fn charged(&self, op_id: OpId, cid: &[u8]) {
+        self.cancels.borrow_mut().confirmed(op_id, cid);
     }
 
     /// One block to the hosted ingress, under its own content address.

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -33,7 +33,10 @@ use futures_channel::mpsc;
 use zeroize::Zeroizing;
 
 use crate::api::{ApiClient, ApiError, QUOTA_EXCEEDED, REGISTRY_BATCH_REFUSED, UPLOAD_TOO_LARGE};
-use crate::content::{Gateway, SealedContent, pre_flight_quota_check};
+use crate::content::{
+    Gateway, Placement, PlacementDecision, ProviderError, SealedContent, place_block,
+    pre_flight_quota_check,
+};
 use crate::entropy::Entropy;
 use crate::facade::{BlockProgress, Event, NodeId, OpPhase};
 use crate::gate::floor;
@@ -349,6 +352,10 @@ pub(crate) struct Drain<'a, T, H: Http, C: CredentialStore, F, S, St, Sch> {
     pub(crate) scheduler: &'a Sch,
     pub(crate) http: &'a H,
     pub(crate) gateway: &'a Gateway,
+    /// Where this session's bytes go, decided once from the vault settings load.
+    /// An `Err` holds every content op — the drain publishes no version it
+    /// cannot place (blueprint/engine.md "Settings-load policy").
+    pub(crate) placement: &'a PlacementDecision,
     pub(crate) profile: &'a SyncTimingProfile,
     /// Seal nonces enter as injected entropy; the drain reads no RNG of its own.
     pub(crate) entropy: &'a RefCell<Box<dyn Entropy>>,
@@ -427,6 +434,10 @@ struct UploadedVersion {
     /// Every content CID the registration names: the root first, then the
     /// leaves in file order.
     content_cids: Vec<String>,
+    /// A dual write's external leg that did not take the bytes. The op still
+    /// publishes — only the hosted leg can fail it — so this rides out as a
+    /// per-op report rather than being swallowed.
+    external_failure: Option<ProviderError>,
 }
 
 /// One record as this pass published it.
@@ -633,10 +644,13 @@ where
             self.clear_block();
             return true;
         }
+        let Ok(placement) = self.placement.as_ref() else {
+            return false;
+        };
         let Ok(quota) = self.api.quota().await else {
             return false;
         };
-        if pre_flight_quota_check(blocked.needed_bytes, &quota).is_err() {
+        if pre_flight_quota_check(blocked.needed_bytes, &quota, placement.mode()).is_err() {
             return false;
         }
         self.clear_block();
@@ -1480,6 +1494,16 @@ where
         if !self.cancels.borrow_mut().enter_publish(applied.op_id) {
             return Err(Halt::Cancelled);
         }
+        // Reported once per op, not per block: the version published and is
+        // retrievable, but it is not on the member's own node (#34 D1).
+        if let Some(error) = &uploaded.external_failure {
+            self.emit_upload(
+                applied,
+                OpPhase::ExternalPinFailed,
+                None,
+                Some(provider_failure(error)),
+            );
+        }
         Ok(uploaded)
     }
 
@@ -1491,6 +1515,11 @@ where
         applied: &AppliedOp,
         staged: &StagedContent,
     ) -> Result<UploadedVersion, Halt> {
+        // Resolved before any byte moves: a session that cannot authenticate the
+        // member's placement choice holds its content ops rather than picking a
+        // destination for them.
+        let placement = self.placement.as_ref().map_err(|_| Halt::Unclassified)?;
+        let mut external_failure = None;
         let root_block = self
             .staged_block(&staged.root_cid)
             .await?
@@ -1541,7 +1570,10 @@ where
             self.cancel_checkpoint(applied.op_id).await?;
             match self.staged_block(leaf_cid).await? {
                 Some(block) => {
-                    self.upload_block(leaf_cid, &block).await?;
+                    external_failure = self
+                        .upload_block(placement, leaf_cid, &block)
+                        .await?
+                        .or(external_failure);
                     self.cancels.borrow_mut().confirmed(applied.op_id, leaf_cid);
                     // A leaf a lost release left staged behind the mark is
                     // re-uploaded here, and must not drag the mark back down
@@ -1567,7 +1599,10 @@ where
         // The root goes up last and stays staged until the publish confirms: it
         // is the manifest every retry re-derives the plan from, so releasing it
         // before the record lands would strand a fully-uploaded version.
-        self.upload_block(&staged.root_cid, &root_block).await?;
+        external_failure = self
+            .upload_block(placement, &staged.root_cid, &root_block)
+            .await?
+            .or(external_failure);
         self.cancels
             .borrow_mut()
             .confirmed(applied.op_id, &staged.root_cid);
@@ -1577,6 +1612,7 @@ where
         Ok(UploadedVersion {
             version: content.version(*key, applied.op.authored_at.0),
             content_cids,
+            external_failure,
         })
     }
 
@@ -1650,17 +1686,40 @@ where
         Ok(Some(block))
     }
 
-    /// Upload one block to the pin provider under `cid`, its staging key and
-    /// own content address, so the ingress pins it where the published record
-    /// points. A block is only ever removed from staging on a confirmed
-    /// [`UploadResult`](crate::UploadResult), which is what makes the
+    /// Upload one block to every leg `placement` names, under `cid` — its
+    /// staging key and own content address — so each provider pins it where the
+    /// published record points. A block is only ever removed from staging on a
+    /// confirmed [`UploadResult`](crate::UploadResult), which is what makes the
     /// still-staged set a suffix.
-    async fn upload_block(&self, cid: &[u8], block: &[u8]) -> Result<(), Halt> {
-        self.api
-            .upload(&encode_content_cid_str(cid), block)
-            .await
-            .map(drop)
-            .map_err(|error| classify_upload(error, block.len() as u64))
+    ///
+    /// The hosted leg is authoritative: it alone can fail the op. A dual write's
+    /// external leg is reported instead of failing the op, because under
+    /// strict-FIFO stop-at-first-failure an offline home node would stall every
+    /// later mutation in the vault (#34 D1). Under `External` the member's
+    /// provider *is* the byte path, so its refusal is the op's.
+    async fn upload_block(
+        &self,
+        placement: &Placement,
+        cid: &[u8],
+        block: &[u8],
+    ) -> Result<Option<ProviderError>, Halt> {
+        if !matches!(placement, Placement::External(_)) {
+            self.api
+                .upload(&encode_content_cid_str(cid), block)
+                .await
+                .map(drop)
+                .map_err(|error| classify_upload(error, block.len() as u64))?;
+        }
+        let Some(config) = placement.external() else {
+            return Ok(None);
+        };
+        match place_block(config, cid, block, self.http).await {
+            Ok(()) => Ok(None),
+            Err(error) => match placement {
+                Placement::Dual(_) => Ok(Some(error)),
+                _ => Err(Halt::UploadAttempt),
+            },
+        }
     }
 
     /// Drop every staged block of an op's version — on a landed publish, and on
@@ -2310,6 +2369,19 @@ fn upload_failure(halt: Halt) -> Option<&'static str> {
             Some("the network refused the payload")
         }
         Halt::Permanent(_) => Some("the staged version can never publish"),
+    }
+}
+
+/// The key-free classification an [`OpPhase::ExternalPinFailed`] carries. It
+/// names the leg, never the endpoint or the bearer the config carries.
+fn provider_failure(error: &ProviderError) -> &'static str {
+    match error {
+        ProviderError::Unreachable => "your own IPFS provider could not be reached",
+        ProviderError::Rejected { .. } => "your own IPFS provider refused the block",
+        ProviderError::AddressMismatch => {
+            "your own IPFS provider stored the block at a different address"
+        }
+        _ => "your own IPFS provider did not accept the block",
     }
 }
 

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -58,7 +58,7 @@ use crate::seams::{
     StagingStore,
 };
 use crate::session::SessionIdentity;
-use crate::settings::{Placement, PlacementDecision};
+use crate::settings::{Destinations, Placement, PlacementDecision};
 use crate::sync::cancel::UploadCancels;
 use crate::sync::model::{Snapshot, collation_key};
 use crate::sync::op::{NewNode, Op, OpKind, StagedContent};
@@ -434,6 +434,9 @@ struct UploadedVersion {
     /// A dual write's external leg that did not take the bytes, reported rather
     /// than swallowed ([`OpPhase::ExternalPinFailed`]).
     external_failure: Option<ProviderError>,
+    /// The mirror is short of blocks a previous pass released to a provider
+    /// this session's settings no longer name ([`Resume::mirror_gap`]).
+    mirror_gap: bool,
 }
 
 /// One record as this pass published it.
@@ -643,11 +646,17 @@ where
         let Ok(placement) = self.placement.as_ref() else {
             return false;
         };
+        // Only the hosted leg is quota-gated, so no answer the quota endpoint
+        // could give bears on a hold under a placement without one — and an
+        // endpoint that will not answer would park the head on that question.
+        if !placement.has_hosted_leg() {
+            self.clear_block();
+            return true;
+        }
         let Ok(quota) = self.api.quota().await else {
             return false;
         };
-        if pre_flight_quota_check(blocked.needed_bytes, &quota, placement.has_hosted_leg()).is_err()
-        {
+        if pre_flight_quota_check(blocked.needed_bytes, &quota, true).is_err() {
             return false;
         }
         self.clear_block();
@@ -1491,14 +1500,15 @@ where
         if !self.cancels.borrow_mut().enter_publish(applied.op_id) {
             return Err(Halt::Cancelled);
         }
-        // Once per op, not per block.
-        if let Some(error) = &uploaded.external_failure {
-            self.emit_upload(
-                applied,
-                OpPhase::ExternalPinFailed,
-                None,
-                Some(provider_failure(error)),
-            );
+        // Once per op, not per block. A live refusal outranks the standing gap:
+        // it is the condition the member can still act on.
+        let mirror = uploaded
+            .external_failure
+            .as_ref()
+            .map(provider_failure)
+            .or_else(|| uploaded.mirror_gap.then_some(MIRROR_GAP));
+        if let Some(reason) = mirror {
+            self.emit_upload(applied, OpPhase::ExternalPinFailed, None, Some(reason));
         }
         Ok(uploaded)
     }
@@ -1549,7 +1559,10 @@ where
         // mark this pass keeps: past it, a missing block is loss, and the
         // version can never be assembled.
         let leaves = content.leaf_cids().len();
-        let uploaded = self
+        let Resume {
+            uploaded,
+            mirror_gap,
+        } = self
             .upload_mark(placement, &staged.root_cid, leaves)
             .await?;
         // The root manifest is block zero and goes up last, so the version's
@@ -1611,6 +1624,7 @@ where
             version: content.version(*key, applied.op.authored_at.0),
             content_cids,
             external_failure,
+            mirror_gap,
         })
     }
 
@@ -1643,21 +1657,22 @@ where
         });
     }
 
-    /// How many of this version's `leaves` a previous pass durably confirmed
+    /// What a previous pass durably confirmed of this version's `leaves`
     /// ([`decode_upload_mark`]).
     async fn upload_mark(
         &self,
         placement: &Placement,
         root_cid: &[u8],
         leaves: usize,
-    ) -> Result<usize, Halt> {
+    ) -> Result<Resume, Halt> {
+        let here = placement.destinations();
         Ok(self
             .staging
             .staged_bytes(UPLOAD_MARK_KEY)
             .await
             .map_err(seam)?
-            .map_or(0, |stored| {
-                decode_upload_mark(&stored, &placement.tag(), root_cid, leaves)
+            .map_or(Resume::default(), |stored| {
+                decode_upload_mark(&stored, &here, root_cid, leaves)
             }))
     }
 
@@ -1673,7 +1688,7 @@ where
         count: usize,
         leaves: usize,
     ) -> Result<(), Halt> {
-        let mark = encode_upload_mark(&placement.tag(), root_cid, count, leaves)
+        let mark = encode_upload_mark(&placement.destinations(), root_cid, count, leaves)
             .ok_or(Halt::Unclassified)?;
         self.staging
             .put_staged_bytes(UPLOAD_MARK_KEY, &mark)
@@ -1715,7 +1730,7 @@ where
             Placement::External(config) => {
                 place_block(config, cid, block, self.http)
                     .await
-                    .map_err(|_| Halt::UploadAttempt)?;
+                    .map_err(classify_placement)?;
                 Ok(None)
             }
             Placement::Dual(config) => {
@@ -2269,43 +2284,67 @@ fn classify_publish(error: RecordPublishError, refused_bytes: u64) -> Halt {
     }
 }
 
-/// The upload mark's wire form: the version root CID followed by a big-endian
-/// `u32` leaf count. `None` where the count is not one this version could have
-/// reached — AGENTS.md rule 8's release-active mirror of
-/// [`decode_upload_mark`]'s bound, so a mark the reader discards as corrupt can
-/// never be written.
+/// The upload mark's wire form: the destinations the progress was made towards,
+/// the version root CID, then a big-endian `u32` leaf count. `None` where the
+/// count is not one this version could have reached — AGENTS.md rule 8's
+/// release-active mirror of [`decode_upload_mark`]'s bound, so a mark the reader
+/// discards as corrupt can never be written.
 fn encode_upload_mark(
-    placement: &[u8],
+    destinations: &Destinations,
     root_cid: &[u8],
     count: usize,
     leaves: usize,
 ) -> Option<Vec<u8>> {
     let claim = u32::try_from(count).ok().filter(|_| count <= leaves)?;
-    let mut mark = placement.to_vec();
+    let mut mark = destinations.encode().to_vec();
     mark.extend_from_slice(root_cid);
     mark.extend_from_slice(&claim.to_be_bytes());
     Some(mark)
 }
 
-/// How many of `root_cid`'s `leaves` the stored mark claims, under `placement`.
-/// A mark naming another version — or the same version's blocks sent to *other*
-/// destinations, which are released from staging and can no longer be placed
-/// here — has nothing to say about this one, and one claiming more leaves than
-/// the version has is proof of a torn or rotted mark. All read as no progress,
-/// so every absent leaf stays loss rather than being covered by bytes this
-/// placement never received.
-fn decode_upload_mark(stored: &[u8], placement: &[u8], root_cid: &[u8], leaves: usize) -> usize {
+/// What a stored upload mark says about resuming this version at `here`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct Resume {
+    /// Leaves already released from staging that the leg which can fail this op
+    /// holds, so their absence is progress rather than loss.
+    uploaded: usize,
+    /// Leaves a dual write's mirror will never hold, because they were released
+    /// to a provider these destinations do not name.
+    mirror_gap: bool,
+}
+
+/// Read the stored mark against the destinations this pass must reach.
+///
+/// A mark naming another version, or one claiming more leaves than the version
+/// has, is a torn or superseded mark and covers nothing. So is a mark whose
+/// destinations do not include the leg that can fail this op: those leaves were
+/// released to somewhere else, and no absence is excused by bytes this leg never
+/// received. A mirror the mark leaves short is reported, not fatal — a dual
+/// write's external leg never fails the op.
+fn decode_upload_mark(
+    stored: &[u8],
+    here: &Destinations,
+    root_cid: &[u8],
+    leaves: usize,
+) -> Resume {
     let Some((named, count)) = stored.split_at_checked(stored.len().saturating_sub(4)) else {
-        return 0;
+        return Resume::default();
     };
-    if named.len() != placement.len() + root_cid.len()
-        || &named[..placement.len()] != placement
-        || &named[placement.len()..] != root_cid
+    if named.len() != Destinations::LEN + root_cid.len() || &named[Destinations::LEN..] != root_cid
     {
-        return 0;
+        return Resume::default();
     }
+    let Some(earlier) = Destinations::decode(&named[..Destinations::LEN]) else {
+        return Resume::default();
+    };
     let count = <[u8; 4]>::try_from(count).map_or(0, |c| u32::from_be_bytes(c) as usize);
-    if count > leaves { 0 } else { count }
+    if count == 0 || count > leaves || !here.required_legs_hold(&earlier) {
+        return Resume::default();
+    }
+    Resume {
+        uploaded: count,
+        mirror_gap: !here.mirror_leg_holds(&earlier),
+    }
 }
 
 /// The op-id high-water stored at `key`; `None` when nothing has been marked on
@@ -2369,6 +2408,18 @@ fn classify_upload(error: ApiError, refused_bytes: u64) -> Halt {
     }
 }
 
+/// Classify an external-only placement failure for the valve, on the same
+/// positive-evidence rule [`classify_upload`] applies to the hosted leg: a
+/// transport failure carries no verdict about these bytes, and charging the
+/// attempt budget for one would spend the version's five tries on a condition
+/// that repairs itself. Everything the provider *answered* is charged.
+fn classify_placement(error: ProviderError) -> Halt {
+    match error {
+        ProviderError::Unreachable => Halt::Unclassified,
+        _ => Halt::UploadAttempt,
+    }
+}
+
 /// A block count as [`BlockProgress`] carries it; the root manifest's own
 /// ceiling bounds a version's leaves far below `u32::MAX`.
 fn blocks(count: usize) -> u32 {
@@ -2395,8 +2446,17 @@ fn upload_failure(halt: Halt) -> Option<&'static str> {
     }
 }
 
+/// An [`OpPhase::ExternalPinFailed`] for a mirror that no request could have
+/// filled: the blocks left staging for the provider the settings named at the
+/// time, and only the leg that can fail the op still holds them.
+const MIRROR_GAP: &str = "your own IPFS provider changed while this upload was in flight, so it never received \
+     the blocks already sent";
+
 /// The key-free classification an [`OpPhase::ExternalPinFailed`] carries. It
 /// names the leg, never the endpoint or the bearer the config carries.
+///
+/// Exhaustive by construction: a new [`ProviderError`] must be attributed here
+/// rather than falling into whichever wording happened to be the catch-all.
 fn provider_failure(error: &ProviderError) -> &'static str {
     match error {
         ProviderError::Unreachable => "your own IPFS provider could not be reached",
@@ -2405,7 +2465,15 @@ fn provider_failure(error: &ProviderError) -> &'static str {
             "your own IPFS provider stored the block at a different address"
         }
         ProviderError::NoVerdict => "your own IPFS provider gave no usable answer",
-        _ => "your own IPFS provider refused the config it was given",
+        // Policy verdicts reached before any request is built, so the member's
+        // own settings are what to fix, not their node.
+        ProviderError::InvalidEndpoint
+        | ProviderError::InsecureTransport
+        | ProviderError::BlockedAddress
+        | ProviderError::InvalidCredential => "your own IPFS provider settings were refused",
+        ProviderError::MalformedBlockAddress => {
+            "the block's address is not one any provider can be told to store"
+        }
     }
 }
 
@@ -2467,69 +2535,171 @@ mod tests {
         }
     }
 
+    const ROOT: &[u8] = b"root-cid";
+
+    fn byo(endpoint: &str) -> crate::content::ByoIpfsConfig {
+        crate::content::ByoIpfsConfig {
+            endpoint: endpoint.to_owned(),
+            kind: crate::content::ByoKind::Kubo,
+            access_token: None,
+        }
+    }
+
     /// AGENTS.md rule 8 for the upload mark: one bound, both directions. The
     /// encode guard returns `None` in every build rather than asserting, and the
     /// reader reaches the same verdict on bytes planted past it.
     #[test]
     fn a_mark_claiming_more_leaves_than_the_version_has_is_refused_on_both_sides() {
-        const ROOT: &[u8] = b"root-cid";
-        const HERE: &[u8] = b"placement-a";
+        let here = Placement::Hosted.destinations();
         let planted = |count: u32| {
-            let mut mark = HERE.to_vec();
+            let mut mark = here.encode().to_vec();
             mark.extend_from_slice(ROOT);
             mark.extend_from_slice(&count.to_be_bytes());
             mark
         };
         for count in [4usize, 5, usize::try_from(u32::MAX).expect("64-bit")] {
             assert!(
-                encode_upload_mark(HERE, ROOT, count, 3).is_none(),
+                encode_upload_mark(&here, ROOT, count, 3).is_none(),
                 "{count}: the writer refuses what the reader discards",
             );
             assert_eq!(
                 decode_upload_mark(
                     &planted(u32::try_from(count).unwrap_or(u32::MAX)),
-                    HERE,
+                    &here,
                     ROOT,
                     3
                 ),
-                0,
+                Resume::default(),
                 "{count}: a corrupt mark covers no leaf at all",
             );
         }
         // The in-range case still round-trips, so the bound is the only change.
         assert_eq!(
             decode_upload_mark(
-                &encode_upload_mark(HERE, ROOT, 2, 3).expect("in range"),
-                HERE,
+                &encode_upload_mark(&here, ROOT, 2, 3).expect("in range"),
+                &here,
                 ROOT,
                 3
             ),
-            2,
+            Resume {
+                uploaded: 2,
+                mirror_gap: false
+            },
         );
         assert_eq!(
-            decode_upload_mark(&planted(2), HERE, b"another-root", 3),
-            0,
+            decode_upload_mark(&planted(2), &here, b"another-root", 3),
+            Resume::default(),
             "a mark naming another version has nothing to say about this one",
         );
     }
 
-    /// Progress towards one set of destinations is not progress towards
-    /// another: the blocks it covers were released from staging, so reading it
-    /// under a new placement would publish a version that placement never
-    /// received.
+    /// A leaf released from staging is excused only where the leg that can fail
+    /// this op already holds it. Turning the mirror on or off leaves the hosted
+    /// store holding everything it held, so the version resumes; moving the leg
+    /// that must hold the bytes leaves the mark covering nothing, and the hole
+    /// guard reports the loss it is.
     #[test]
-    fn a_mark_written_under_other_destinations_covers_nothing_here() {
-        const ROOT: &[u8] = b"root-cid";
-        let elsewhere = encode_upload_mark(b"placement-a", ROOT, 2, 3).expect("in range");
+    fn a_resumed_mark_covers_only_what_the_op_failing_leg_already_holds() {
+        let one = Placement::Dual(byo("https://one.example"));
+        let two = Placement::Dual(byo("https://two.example"));
+        let external = Placement::External(byo("https://one.example"));
+        let full = Resume {
+            uploaded: 2,
+            mirror_gap: false,
+        };
+        let gapped = Resume {
+            uploaded: 2,
+            mirror_gap: true,
+        };
+
+        let resume = |here: &Placement, earlier: &Placement| {
+            let mark = encode_upload_mark(&earlier.destinations(), ROOT, 2, 3).expect("in range");
+            decode_upload_mark(&mark, &here.destinations(), ROOT, 3)
+        };
+
+        assert_eq!(resume(&Placement::Hosted, &one), full);
+        assert_eq!(resume(&one, &one), full);
+        assert_eq!(resume(&external, &one), full);
         assert_eq!(
-            decode_upload_mark(&elsewhere, b"placement-b", ROOT, 3),
-            0,
-            "another placement's progress covers no leaf here",
+            resume(&one, &Placement::Hosted),
+            gapped,
+            "the hosted store holds them; only the new mirror does not"
         );
+        assert_eq!(resume(&one, &two), gapped);
         assert_eq!(
-            decode_upload_mark(&elsewhere, b"placement-a", ROOT, 3),
-            2,
-            "and its own still does",
+            resume(&external, &two),
+            Resume::default(),
+            "external-only publishes from the provider that never took them"
+        );
+        assert_eq!(resume(&external, &Placement::Hosted), Resume::default());
+        assert_eq!(resume(&Placement::Hosted, &external), Resume::default());
+    }
+
+    /// A mark claiming nothing releases nothing, so a placement change over it
+    /// is not a gap to report.
+    #[test]
+    fn an_empty_mark_gaps_no_mirror() {
+        let mark =
+            encode_upload_mark(&Placement::Hosted.destinations(), ROOT, 0, 3).expect("in range");
+        assert_eq!(
+            decode_upload_mark(
+                &mark,
+                &Placement::Dual(byo("https://one.example")).destinations(),
+                ROOT,
+                3
+            ),
+            Resume::default(),
+        );
+    }
+
+    /// The mark's destination prefix is read fail-closed: bytes no encode could
+    /// have produced excuse no absent leaf.
+    #[test]
+    fn a_mark_opening_on_unencodable_destinations_covers_nothing() {
+        let here = Placement::Hosted.destinations();
+        let mut mark = encode_upload_mark(&here, ROOT, 2, 3).expect("in range");
+        mark[0] = 3;
+        assert_eq!(decode_upload_mark(&mark, &here, ROOT, 3), Resume::default());
+    }
+
+    /// A transport failure carries no verdict about these bytes, so it must not
+    /// spend the version's attempt budget — the hosted leg's own rule
+    /// ([`classify_upload`]) applied to the member's provider.
+    #[test]
+    fn only_an_answered_placement_charges_the_attempt_budget() {
+        assert_eq!(
+            classify_placement(ProviderError::Unreachable),
+            Halt::Unclassified,
+        );
+        for answered in [
+            ProviderError::NoVerdict,
+            ProviderError::Rejected { status: 500 },
+            ProviderError::AddressMismatch,
+            ProviderError::InvalidCredential,
+        ] {
+            assert_eq!(classify_placement(answered), Halt::UploadAttempt);
+        }
+    }
+
+    /// The report names what the member must fix. A verdict reached before any
+    /// request is built is their own settings, not their node.
+    #[test]
+    fn a_policy_verdict_is_attributed_to_the_settings_not_the_node() {
+        for settings in [
+            ProviderError::InvalidEndpoint,
+            ProviderError::InsecureTransport,
+            ProviderError::BlockedAddress,
+            ProviderError::InvalidCredential,
+        ] {
+            assert_eq!(
+                provider_failure(&settings),
+                "your own IPFS provider settings were refused",
+            );
+        }
+        assert_ne!(
+            provider_failure(&ProviderError::MalformedBlockAddress),
+            "your own IPFS provider settings were refused",
+            "a block this plane cannot address is not a settings mistake",
         );
     }
 

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -439,6 +439,51 @@ struct UploadedVersion {
     mirror_gap: bool,
 }
 
+/// Attempts one op may spend on the member's own provider before its mirror is
+/// abandoned for that version. A dual write completes when hosted succeeds and
+/// external has either succeeded or exhausted its attempts (#34 D1), so the leg
+/// needs attempts to spend — one refusal is a blip, not a verdict.
+const MIRROR_ATTEMPTS: u32 = 3;
+
+/// A dual write's best-effort mirror leg, carried across one op's blocks.
+///
+/// The budget is per op rather than per block because a provider that is down
+/// refuses every block alike: spending a fresh budget on each would stall the
+/// whole pass behind one dead endpoint, and a version the mirror has already
+/// missed a block of is not one it can serve whatever the rest do.
+struct MirrorLeg {
+    /// Attempts left to spend. Reaching zero is what abandons the mirror: the
+    /// block that spent the last one never landed on it.
+    attempts: u32,
+    /// The first refusal, reported once the leg is abandoned.
+    refusal: Option<ProviderError>,
+}
+
+impl MirrorLeg {
+    fn new() -> Self {
+        Self {
+            attempts: MIRROR_ATTEMPTS,
+            refusal: None,
+        }
+    }
+
+    /// Whether the mirror is short of this version. Refusals a later attempt
+    /// recovered from are not: the block reached the provider.
+    fn missed(&self) -> bool {
+        self.attempts == 0
+    }
+
+    fn refused(&mut self, error: ProviderError) {
+        self.attempts = self.attempts.saturating_sub(1);
+        self.refusal.get_or_insert(error);
+    }
+
+    /// The refusal to report, which is one only where the mirror stayed short.
+    fn failure(self) -> Option<ProviderError> {
+        self.missed().then_some(self.refusal).flatten()
+    }
+}
+
 /// One record as this pass published it.
 struct Published {
     /// The sequence the self-adopt authenticated.
@@ -1035,6 +1080,7 @@ where
         let name = applied.effective_name.clone().ok_or(Halt::Unclassified)?;
         self.ensure_folder(scope, pass, parent).await?;
 
+        let mut shortfall = None;
         let (body, content_cids) = match node {
             NewNode::Folder => (NewNodeBody::Folder, Vec::new()),
             NewNode::File { content: None } => (
@@ -1047,6 +1093,7 @@ where
                 content: Some(staged),
             } => {
                 let uploaded = self.upload_version(scope, applied, staged).await?;
+                shortfall = mirror_shortfall(&uploaded);
                 (
                     NewNodeBody::File {
                         versions: vec![uploaded.version],
@@ -1096,6 +1143,7 @@ where
         .await
         .map_err(Halt::from)?;
         self.release_staged_blocks(&applied.op).await;
+        self.emit_mirror_shortfall(applied, shortfall);
         // Held only once the parent names it: a record nothing references is
         // not one the liveness loop should keep alive.
         self.hold(child_id.0, published.held);
@@ -1422,6 +1470,7 @@ where
             return Err(Halt::Unclassified);
         };
         let uploaded = self.upload_version(scope, applied, staged).await?;
+        let shortfall = mirror_shortfall(&uploaded);
         // Newest first, head is current (`crates/core/src/seal/body.rs`).
         versions.insert(0, uploaded.version);
         // Every retained version's root stays registered under this name, so a
@@ -1457,6 +1506,7 @@ where
             .await
             .map_err(Halt::from)?;
         self.release_staged_blocks(&applied.op).await;
+        self.emit_mirror_shortfall(applied, shortfall);
         if let Some(node) = self.base.borrow_mut().node_mut(target) {
             node.record_sequence = published.sequence;
             node.mtime = Some(modified_at);
@@ -1500,17 +1550,16 @@ where
         if !self.cancels.borrow_mut().enter_publish(applied.op_id) {
             return Err(Halt::Cancelled);
         }
-        // Once per op, not per block. A live refusal outranks the standing gap:
-        // it is the condition the member can still act on.
-        let mirror = uploaded
-            .external_failure
-            .as_ref()
-            .map(provider_failure)
-            .or_else(|| uploaded.mirror_gap.then_some(MIRROR_GAP));
-        if let Some(reason) = mirror {
+        Ok(uploaded)
+    }
+
+    /// Tell the member their mirror is short of this version — after the record
+    /// published, because [`OpPhase::ExternalPinFailed`] promises the content is
+    /// retrievable, which is only true once the record naming it is live.
+    fn emit_mirror_shortfall(&self, applied: &AppliedOp, reason: Option<&'static str>) {
+        if let Some(reason) = reason {
             self.emit_upload(applied, OpPhase::ExternalPinFailed, None, Some(reason));
         }
-        Ok(uploaded)
     }
 
     /// One version's blocks, uploaded and pinned: the `Version` its record
@@ -1525,7 +1574,10 @@ where
         // member's placement choice holds its content ops rather than picking a
         // destination for them.
         let placement = self.placement.as_ref().map_err(|_| Halt::Unclassified)?;
-        let mut external_failure = None;
+        // What the mark may claim, narrowed as the mirror misses blocks the mark
+        // covers ([`Destinations::mirror_missed`]).
+        let mut reached = placement.destinations();
+        let mut mirror = MirrorLeg::new();
         let root_block = self
             .staged_block(&staged.root_cid)
             .await?
@@ -1565,6 +1617,9 @@ where
         } = self
             .upload_mark(placement, &staged.root_cid, leaves)
             .await?;
+        if mirror_gap {
+            reached.mirror_missed();
+        }
         // The root manifest is block zero and goes up last, so the version's
         // whole block count is its leaves plus one.
         let total = blocks(leaves + 1);
@@ -1581,17 +1636,18 @@ where
             self.cancel_checkpoint(applied.op_id).await?;
             match self.staged_block(leaf_cid).await? {
                 Some(block) => {
-                    // First failure wins: the report names one leg, not the
-                    // last block that happened to miss it.
-                    let missed = self.upload_block(placement, leaf_cid, &block).await?;
-                    external_failure = external_failure.or(missed);
+                    self.upload_block(placement, &mut mirror, applied.op_id, leaf_cid, &block)
+                        .await?;
                     self.cancels.borrow_mut().confirmed(applied.op_id, leaf_cid);
+                    if mirror.missed() {
+                        reached.mirror_missed();
+                    }
                     // A leaf a lost release left staged behind the mark is
                     // re-uploaded here, and must not drag the mark back down
                     // over the leaves past it — those are released, so an
                     // uncovered one reads as loss.
                     if index + 1 > uploaded {
-                        self.mark_uploaded(placement, &staged.root_cid, index + 1, leaves)
+                        self.mark_uploaded(&reached, &staged.root_cid, index + 1, leaves)
                             .await?;
                     }
                     self.staging
@@ -1610,10 +1666,14 @@ where
         // The root goes up last and stays staged until the publish confirms: it
         // is the manifest every retry re-derives the plan from, so releasing it
         // before the record lands would strand a fully-uploaded version.
-        let missed = self
-            .upload_block(placement, &staged.root_cid, &root_block)
-            .await?;
-        external_failure = external_failure.or(missed);
+        self.upload_block(
+            placement,
+            &mut mirror,
+            applied.op_id,
+            &staged.root_cid,
+            &root_block,
+        )
+        .await?;
         self.cancels
             .borrow_mut()
             .confirmed(applied.op_id, &staged.root_cid);
@@ -1623,7 +1683,7 @@ where
         Ok(UploadedVersion {
             version: content.version(*key, applied.op.authored_at.0),
             content_cids,
-            external_failure,
+            external_failure: mirror.failure(),
             mirror_gap,
         })
     }
@@ -1676,20 +1736,23 @@ where
             }))
     }
 
-    /// Record that `count` of this version's `leaves` have uploaded. A
-    /// high-water mark, written *before* the leaf is released: it may
-    /// over-claim a leaf still staged, which the next pass re-uploads, but must
-    /// never lag or regress below one already released — the hole guard would
-    /// read those uploaded bytes as loss.
+    /// Record that `count` of this version's `leaves` have uploaded to
+    /// `reached`. A high-water mark, written *before* the leaf is released: it
+    /// may over-claim a leaf still staged, which the next pass re-uploads, but
+    /// must never lag or regress below one already released — the hole guard
+    /// would read those uploaded bytes as loss.
+    ///
+    /// `reached` is what the destinations *took*, not what the placement named:
+    /// a mark may only claim a leg that actually holds every leaf it covers.
     async fn mark_uploaded(
         &self,
-        placement: &Placement,
+        reached: &Destinations,
         root_cid: &[u8],
         count: usize,
         leaves: usize,
     ) -> Result<(), Halt> {
-        let mark = encode_upload_mark(&placement.destinations(), root_cid, count, leaves)
-            .ok_or(Halt::Unclassified)?;
+        let mark =
+            encode_upload_mark(reached, root_cid, count, leaves).ok_or(Halt::Unclassified)?;
         self.staging
             .put_staged_bytes(UPLOAD_MARK_KEY, &mark)
             .await
@@ -1715,27 +1778,36 @@ where
     /// still-staged set a suffix.
     ///
     /// Only the hosted leg can fail the op — see [`OpPhase::ExternalPinFailed`]
-    /// for why a dual write's mirror is reported instead.
+    /// for why a dual write's mirror is reported instead. That mirror retries
+    /// within the op out of `mirror`'s shared budget ([`MirrorLeg`]); an
+    /// external-only write has no second leg to absorb a refusal, so its
+    /// retries are the op-level valve's.
     async fn upload_block(
         &self,
         placement: &Placement,
+        mirror: &mut MirrorLeg,
+        op_id: OpId,
         cid: &[u8],
         block: &[u8],
-    ) -> Result<Option<ProviderError>, Halt> {
+    ) -> Result<(), Halt> {
         match placement {
-            Placement::Hosted => {
-                self.hosted_upload(cid, block).await?;
-                Ok(None)
-            }
-            Placement::External(config) => {
-                place_block(config, cid, block, self.http)
-                    .await
-                    .map_err(classify_placement)?;
-                Ok(None)
-            }
+            Placement::Hosted => self.hosted_upload(cid, block).await,
+            Placement::External(config) => place_block(config, cid, block, self.http)
+                .await
+                .map_err(classify_placement),
             Placement::Dual(config) => {
                 self.hosted_upload(cid, block).await?;
-                Ok(place_block(config, cid, block, self.http).await.err())
+                while !mirror.missed() {
+                    // The budget spans several provider deadlines, so a cancel
+                    // gets to run between them rather than only at the block
+                    // boundary below.
+                    self.cancel_checkpoint(op_id).await?;
+                    match place_block(config, cid, block, self.http).await {
+                        Ok(()) => return Ok(()),
+                        Err(error) => mirror.refused(error),
+                    }
+                }
+                Ok(())
             }
         }
     }
@@ -2451,6 +2523,16 @@ fn upload_failure(halt: Halt) -> Option<&'static str> {
 /// time, and only the leg that can fail the op still holds them.
 const MIRROR_GAP: &str = "your own IPFS provider changed while this upload was in flight, so it never received \
      the blocks already sent";
+
+/// What this version's mirror is short by. A live refusal outranks the standing
+/// gap: it is the condition the member can still act on.
+fn mirror_shortfall(uploaded: &UploadedVersion) -> Option<&'static str> {
+    uploaded
+        .external_failure
+        .as_ref()
+        .map(provider_failure)
+        .or_else(|| uploaded.mirror_gap.then_some(MIRROR_GAP))
+}
 
 /// The key-free classification an [`OpPhase::ExternalPinFailed`] carries. It
 /// names the leg, never the endpoint or the bearer the config carries.

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -7,7 +7,7 @@
 
 use core::task::{Context, Poll, Waker};
 use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, encode_content_cid_str};
@@ -194,6 +194,9 @@ struct Blocks {
     /// block under, and whether it can be reached at all.
     member_node: Arc<Mutex<BTreeMap<String, Vec<u8>>>>,
     member_node_down: Arc<AtomicBool>,
+    /// Requests the member's node refuses before answering normally again — the
+    /// transient blip a mirror retry inside the op exists for.
+    member_node_refusals: Arc<AtomicUsize>,
     /// The 400 body every `POST /registry/register` answers with instead of
     /// acking.
     register_refusal: Arc<Mutex<Option<Vec<u8>>>>,
@@ -271,6 +274,15 @@ impl Blocks {
     fn member_node_reply(&self, request: &HttpRequest) -> SeamResult<HttpResponse> {
         if self.member_node_down.load(Ordering::Relaxed) {
             return Err(SeamError::new("the member's node is offline"));
+        }
+        if self
+            .member_node_refusals
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |left| {
+                left.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(SeamError::new("the member's node refused this attempt"));
         }
         assert!(
             request.url.contains("mhtype=blake3&mhlen=32"),
@@ -6156,6 +6168,216 @@ fn a_dual_write_places_the_same_block_set_on_both_legs() {
         )),
         "both legs took it, so there is no partial outcome to report"
     );
+}
+
+/// One refusal from the member's node is a blip, not a verdict: the op spends
+/// another of its attempts and the mirror ends up whole, with nothing to report.
+#[test]
+fn a_mirror_refusal_the_op_retries_past_leaves_nothing_to_report() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    seed_settings(&world, &alice, &blocks, PinMode::Dual);
+
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    blocks.member_node_refusals.store(1, Ordering::Relaxed);
+    write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<_>>(),
+    )
+    .expect("the write commits");
+    tick(&world, &engine, &mut tasks);
+
+    let photo = child_id(&engine, ROOT, "photo.bin");
+    let mut registered = registered_content_cids(&alice, &write_name(photo));
+    registered.sort();
+    registered.dedup();
+    assert_eq!(
+        blocks.member_node_cids(),
+        registered,
+        "the retry put the refused block on the member's node"
+    );
+    assert!(
+        !events_so_far(&mut events).iter().any(|event| matches!(
+            event,
+            Event::OpProgress {
+                phase: OpPhase::ExternalPinFailed,
+                ..
+            }
+        )),
+        "a refusal the op recovered from is not a shortfall"
+    );
+}
+
+/// `ExternalPinFailed` promises the version published and its content is
+/// retrievable — only the member's own node is short of it. A pass whose
+/// registration is still being refused has published nothing, so it has no such
+/// promise to make yet.
+#[test]
+fn a_mirror_shortfall_is_reported_only_once_the_record_published() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    seed_settings(&world, &alice, &blocks, PinMode::Dual);
+
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    blocks.member_node_down.store(true, Ordering::Relaxed);
+    blocks.refuse_register(proxy_400());
+    let op_id = write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<_>>(),
+    )
+    .expect("the write commits");
+    tick(&world, &engine, &mut tasks);
+
+    let shortfalls = |events: &mut EventStream| {
+        events_so_far(events)
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    Event::OpProgress {
+                        op_id: Some(id),
+                        phase: OpPhase::ExternalPinFailed,
+                        ..
+                    } if *id == op_id
+                )
+            })
+            .count()
+    };
+    assert_eq!(
+        shortfalls(&mut events),
+        0,
+        "the blocks went up, but no record names them yet"
+    );
+
+    blocks.accept_registrations();
+    tick(&world, &engine, &mut tasks);
+    assert_eq!(
+        published(&world.record_store, child_id(&engine, ROOT, "photo.bin")).0,
+        1,
+        "the retry published the version"
+    );
+    assert_eq!(
+        shortfalls(&mut events),
+        1,
+        "and only now is the mirror's shortfall the member's to act on"
+    );
+}
+
+/// The attempt budget is the op's, not each block's: a node that is simply down
+/// refuses every block alike, and re-asking it once per block would stall the
+/// whole pass behind one dead endpoint.
+#[test]
+fn a_dead_mirror_costs_the_op_a_bounded_number_of_attempts() {
+    let plaintext: Vec<u8> = (0..200u8).collect();
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    seed_settings(&world, &alice, &blocks, PinMode::Dual);
+
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let before = alice.http.requests().len();
+    blocks.member_node_down.store(true, Ordering::Relaxed);
+    write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &plaintext,
+    )
+    .expect("the write commits");
+    tick(&world, &engine, &mut tasks);
+
+    let attempts = alice.http.requests()[before..]
+        .iter()
+        .filter(|request| request.url.starts_with(MEMBER_NODE))
+        .count();
+    assert!(
+        attempts > 1,
+        "the mirror leg retried inside the op rather than giving up on one refusal"
+    );
+    assert!(
+        attempts < frame_version(&plaintext).0.len(),
+        "and stopped well short of asking a dead node once per block"
+    );
+}
+
+/// A dual write's mark may name the mirror only where the mirror actually took
+/// the bytes. Otherwise an external-only session resuming that version reads
+/// blocks it never received as progress, skips them, and publishes a manifest
+/// naming content the member's node cannot serve.
+#[test]
+fn a_dual_mark_names_the_mirror_only_where_the_mirror_took_the_bytes() {
+    let plaintext: Vec<u8> = (0..200u8).collect();
+    // `(the member's node was up for the dual session, the resume publishes)`.
+    for (mirror_up, survives) in [(true, true), (false, false)] {
+        let world = FakeWorld::new();
+        let blocks = Blocks::default();
+        seed_account(&world, &blocks);
+        let alice = world.device(b"alice");
+        seed_settings(&world, &alice, &blocks, PinMode::Dual);
+
+        let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+        blocks.member_node_down.store(!mirror_up, Ordering::Relaxed);
+        // The process dies two leaves in, with those two already released.
+        alice
+            .staging_store
+            .interrupt_staged_write_after(UPLOAD_MARK_KEY, 2);
+        write_file(
+            &mut engine,
+            WriteTarget::NewFile {
+                parent: ROOT,
+                name: "photo.bin".into(),
+            },
+            &plaintext,
+        )
+        .expect("the write commits");
+        let (root_cid, _) = staged_version(&alice);
+        tick(&world, &engine, &mut tasks);
+        assert_eq!(
+            upload_mark(&alice),
+            Some((root_cid, 2)),
+            "mirror up {mirror_up}: two leaves left staging either way"
+        );
+        drop(engine);
+
+        // The member moves to external-only, and their node is reachable now.
+        blocks.member_node_down.store(false, Ordering::Relaxed);
+        seed_settings(&world, &alice, &blocks, PinMode::External);
+        let (engine, mut events_after, mut tasks) = boot(&world, &blocks, &alice, 43);
+        tick(&world, &engine, &mut tasks);
+        tick(&world, &engine, &mut tasks);
+
+        let dead_lettered = |events: &mut EventStream| {
+            events_so_far(events).iter().any(|event| {
+                matches!(
+                    event,
+                    Event::DeadLetter {
+                        reason: DeadLetterReason::ContentUnrecoverable,
+                        ..
+                    }
+                )
+            })
+        };
+        let lost = dead_lettered(&mut events) || dead_lettered(&mut events_after);
+        assert_eq!(
+            !lost, survives,
+            "mirror up {mirror_up}: the resume follows whether that node holds the released leaves"
+        );
+    }
 }
 
 /// The pre-flight's whole point: a hosted write the account cannot admit is

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -35,7 +35,7 @@ use cipherbox_engine::seams::{
     BoxedTask, FloorStore, HttpRequest, HttpResponse, OpId, RecordTransport, SeamError, SeamResult,
     StagingStore, UnixMillis,
 };
-use cipherbox_engine::settings::{VaultSettings, publish_settings, settings_name};
+use cipherbox_engine::settings::{Destinations, VaultSettings, publish_settings, settings_name};
 use cipherbox_engine::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
 use cipherbox_engine::sync::{
     DRAINED_OP_MARK_PREFIX, PUBLISHED_OP_MARK_PREFIX, StagedContent, UPLOAD_MARK_KEY, op_mark_key,
@@ -50,8 +50,8 @@ use cipherbox_engine::testkit::{
 use cipherbox_engine::{
     ApiBaseUrl, ApiClient, BlockProgress, Command, ContentProfile, DeadLetter, DeadLetterReason,
     DefaultsReason, Engine, EngineError, Event, EventStream, GatewayConfig, LoginSecret,
-    MAX_OPEN_STREAMS, NodeId, NodeKind, Op, OpPhase, OverBudgetCause, PlacementRefusal, RecordSeal,
-    StoragePolicy, SyncTimingProfile, WriteTarget, stage_op,
+    MAX_OPEN_STREAMS, NodeId, NodeKind, Op, OpPhase, OverBudgetCause, Placement, PlacementRefusal,
+    RecordSeal, StoragePolicy, SyncTimingProfile, WriteTarget, stage_op,
 };
 
 const SECRET: [u8; 32] = [7u8; 32];
@@ -61,8 +61,8 @@ const ROOT: NodeId = NodeId(SCOPE);
 /// The sole v2 re-point payload version (`facade::POINTER_PAYLOAD_VERSION`).
 const POINTER_PAYLOAD_VERSION: u64 = 1;
 const TTL_NANOS: u64 = 2_000_000_000;
-/// The BLAKE3 placement tag the upload mark is keyed by (`Placement::tag`).
-const PLACEMENT_TAG_LEN: usize = 32;
+/// The destination set the upload mark opens on.
+const DESTINATIONS_LEN: usize = Destinations::LEN;
 const EOL: &str = "2099-01-01T00:00:00Z";
 
 fn owner_identity() -> EcdsaSigner {
@@ -197,6 +197,11 @@ struct Blocks {
     /// The 400 body every `POST /registry/register` answers with instead of
     /// acking.
     register_refusal: Arc<Mutex<Option<Vec<u8>>>>,
+    /// Whether `GET /account/quota` is reachable at all: the transport failure
+    /// a flaky API leg gives, not a verdict.
+    quota_down: Arc<AtomicBool>,
+    /// The same for `PATCH /account/byo`.
+    byo_down: Arc<AtomicBool>,
 }
 
 impl Blocks {
@@ -333,6 +338,12 @@ impl Blocks {
             // and only once those bytes really address to it.
             self.put_declared(&declared, block);
             return ok(format!("{{\"cid\":\"{declared}\",\"size\":{size}}}").into_bytes());
+        }
+        if url.ends_with("/account/quota") && self.quota_down.load(Ordering::Relaxed) {
+            return Err(SeamError::new("the quota endpoint is unreachable"));
+        }
+        if url.ends_with("/account/byo") && self.byo_down.load(Ordering::Relaxed) {
+            return Err(SeamError::new("the byo endpoint is unreachable"));
         }
         if url.ends_with("/account/quota") {
             let (used, limit) = self
@@ -1717,10 +1728,12 @@ fn a_corrupt_upload_mark_is_no_progress_rather_than_blanket_coverage() {
     )
     .unwrap();
 
-    // A mark naming this very version and claiming more leaves than it has.
+    // A mark under this session's own destinations, naming this very version
+    // and claiming more leaves than it has.
     let version = evict_leaf(&alice, |leaves| leaves / 2);
     let (root_cid, _) = staged_version(&alice);
-    let mut corrupt = root_cid;
+    let mut corrupt = Placement::Hosted.destinations().encode().to_vec();
+    corrupt.extend_from_slice(&root_cid);
     corrupt.extend_from_slice(&u32::MAX.to_be_bytes());
     block_on(
         alice
@@ -1785,13 +1798,13 @@ fn evict_leaf(device: &FakeDevice, index: impl Fn(usize) -> usize) -> Vec<Vec<u8
         .collect()
 }
 
-/// The durable upload mark as [`UPLOAD_MARK_KEY`] holds it, minus the placement
-/// tag it opens on: the version root it names and the leaf count it claims.
+/// The durable upload mark as [`UPLOAD_MARK_KEY`] holds it, minus the
+/// destinations it opens on: the version root it names and the leaf count it
+/// claims.
 fn upload_mark(device: &FakeDevice) -> Option<(Vec<u8>, u32)> {
     let stored = block_on(device.staging_store.staged_bytes(UPLOAD_MARK_KEY)).unwrap()?;
     let (named, count) = stored.split_at(stored.len() - 4);
-    // The mark opens on the placement tag its progress was written under.
-    let root = &named[PLACEMENT_TAG_LEN..];
+    let root = &named[DESTINATIONS_LEN..];
     Some((root.to_vec(), u32::from_be_bytes(count.try_into().unwrap())))
 }
 
@@ -4364,7 +4377,7 @@ fn a_cancelled_versions_upload_mark_never_counts_towards_the_next_one() {
         .unwrap()
         .expect("the cancelled pass left its progress mark behind");
     assert!(
-        mark[PLACEMENT_TAG_LEN..].starts_with(&root_cid),
+        mark[DESTINATIONS_LEN..].starts_with(&root_cid),
         "the residue names the cancelled root, so the next version must not read it as progress"
     );
 
@@ -5885,6 +5898,144 @@ fn an_external_write_places_every_block_on_the_members_node_and_none_on_the_host
     );
 }
 
+/// Leaves already released from staging can never be placed again, so a
+/// placement changed mid-upload is decided on one question: does the leg this
+/// version must now publish from already hold them?
+///
+/// Dropping the mirror leaves the hosted store holding everything it held, so
+/// the version resumes. Moving off the leg that holds them does not, and the
+/// hole guard reports the loss rather than publishing a manifest naming blocks
+/// the new destination will never serve.
+#[test]
+fn a_placement_changed_mid_upload_resumes_only_where_the_bytes_already_are() {
+    let plaintext: Vec<u8> = (0..200u8).collect();
+    let leaves = frame_version(&plaintext).0.len();
+    assert!(
+        leaves > 2,
+        "a multi-leaf version, so the resume point is real"
+    );
+
+    // `(started under, resumed under, the version still publishes)`.
+    for (before, after, survives) in [
+        (PinMode::Dual, PinMode::Hosted, true),
+        (PinMode::Dual, PinMode::Dual, true),
+        (PinMode::External, PinMode::Hosted, false),
+    ] {
+        let world = FakeWorld::new();
+        let blocks = Blocks::default();
+        seed_account(&world, &blocks);
+        let alice = world.device(b"alice");
+        seed_settings(&world, &alice, &blocks, before);
+
+        let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+        // The mark for leaf 2 never lands: the process died the instant after
+        // that leaf uploaded and the two before it were released.
+        alice
+            .staging_store
+            .interrupt_staged_write_after(UPLOAD_MARK_KEY, 2);
+        write_file(
+            &mut engine,
+            WriteTarget::NewFile {
+                parent: ROOT,
+                name: "photo.bin".into(),
+            },
+            &plaintext,
+        )
+        .expect("the write commits");
+        let (root_cid, _) = staged_version(&alice);
+        tick(&world, &engine, &mut tasks);
+        assert_eq!(
+            upload_mark(&alice),
+            Some((root_cid, 2)),
+            "{before:?}: two leaves left staging for the destinations of the day"
+        );
+        drop(engine);
+
+        // The member changes their mind while the version is half-placed.
+        seed_settings(&world, &alice, &blocks, after);
+        let (engine, mut events_after, mut tasks) = boot(&world, &blocks, &alice, 43);
+        tick(&world, &engine, &mut tasks);
+        tick(&world, &engine, &mut tasks);
+
+        let dead_lettered = |events: &mut EventStream| {
+            events_so_far(events).iter().any(|event| {
+                matches!(
+                    event,
+                    Event::DeadLetter {
+                        reason: DeadLetterReason::ContentUnrecoverable,
+                        ..
+                    }
+                )
+            })
+        };
+        let lost = dead_lettered(&mut events) || dead_lettered(&mut events_after);
+        assert_eq!(
+            !lost, survives,
+            "{before:?} -> {after:?}: the verdict follows where the released bytes are"
+        );
+        if survives {
+            drop(engine);
+            assert_round_trips(&world, &blocks, "photo.bin", &plaintext);
+        }
+    }
+}
+
+/// An external placement puts no byte in the hosted store, so nothing the quota
+/// endpoint could say bears on a hold under one. The hold clears without asking
+/// — an unanswerable probe must not park the queue head on a question with no
+/// answer to wait for.
+#[test]
+fn a_hold_under_an_external_placement_clears_without_a_quota_probe() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    seed_settings(&world, &alice, &blocks, PinMode::External);
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+
+    // The record head block still traverses the hosted ingress, so it is what
+    // the account quota can refuse under an external placement.
+    blocks.refuse_upload(Box::new(|_| Some(upload_413(Some("QUOTA_EXCEEDED")))));
+    create(&mut engine, "photos");
+    tick(&world, &engine, &mut tasks);
+    assert!(
+        block_on(engine.snapshot(ROOT))
+            .expect("a snapshot")
+            .blocked
+            .is_some(),
+        "the refused head block held the op"
+    );
+
+    blocks.accept_uploads();
+    blocks.quota_down.store(true, Ordering::Relaxed);
+    let probes = || {
+        alice
+            .http
+            .requests()
+            .iter()
+            .filter(|request| request.url.ends_with("/account/quota"))
+            .count()
+    };
+    let before = probes();
+    tick(&world, &engine, &mut tasks);
+
+    let view = block_on(engine.snapshot(ROOT)).expect("a snapshot");
+    assert!(
+        view.blocked.is_none(),
+        "an unreachable quota endpoint never gates a placement it does not cover"
+    );
+    assert_eq!(
+        probes(),
+        before,
+        "and the hold clears without asking a question it cannot use"
+    );
+    assert_eq!(
+        published_names(&world.record_store, &blocks, ROOT),
+        vec!["photos".to_owned()],
+        "the head drained once the stale hold was gone"
+    );
+}
+
 /// Dual runs both legs and only the hosted one can fail the op: an offline home
 /// node must not stall every later mutation in the vault. The outcome is
 /// reported per op rather than swallowed.
@@ -6101,6 +6252,64 @@ fn the_session_reconciles_the_accounts_byo_flag_to_the_vaulted_mode() {
     let (mut engine_b, _events, _tasks) = boot(&world, &blocks, &bob, 43);
     write(&mut engine_b, "photo3.bin");
     assert_eq!(toggles(&bob), 0, "nothing to reconcile once they agree");
+}
+
+/// The once-a-session guard latches on the reconcile *landing*, not on the
+/// attempt. The hosted ingress rejects a BYO account, so a flag left disagreeing
+/// by one transient PATCH failure would fail every hosted upload the session
+/// makes until the process restarts.
+#[test]
+fn a_byo_reconcile_that_did_not_land_is_retried_by_the_next_write() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    // The account carries the flag an external session set; this one is hosted.
+    blocks.advisory_quota.store(true, Ordering::Relaxed);
+    blocks.byo_down.store(true, Ordering::Relaxed);
+
+    let (mut engine, _events, _tasks) = boot(&world, &blocks, &alice, 42);
+    let toggles = || {
+        alice
+            .http
+            .requests()
+            .iter()
+            .filter(|request| request.url.ends_with("/account/byo"))
+            .count()
+    };
+    let write = |engine: &mut Engine<FakeSeamTypes>, name: &str| {
+        write_file(
+            engine,
+            WriteTarget::NewFile {
+                parent: ROOT,
+                name: name.to_owned(),
+            },
+            &(0..200u8).collect::<Vec<_>>(),
+        )
+        .expect("the write commits")
+    };
+
+    write(&mut engine, "photo.bin");
+    assert_eq!(toggles(), 1, "the session tried to reconcile");
+    assert!(
+        blocks.advisory_quota.load(Ordering::Relaxed),
+        "and the account still disagrees with the vaulted mode"
+    );
+
+    blocks.byo_down.store(false, Ordering::Relaxed);
+    write(&mut engine, "photo2.bin");
+    assert_eq!(toggles(), 2, "so the next write tries again");
+    assert!(
+        !blocks.advisory_quota.load(Ordering::Relaxed),
+        "and this one landed"
+    );
+
+    write(&mut engine, "photo3.bin");
+    assert_eq!(
+        toggles(),
+        2,
+        "a landed reconcile closes the window for good"
+    );
 }
 
 /// A settings load that cannot authenticate the member's choice refuses the

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -7,6 +7,7 @@
 
 use core::task::{Context, Poll, Waker};
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, encode_content_cid_str};
@@ -22,14 +23,19 @@ use cipherbox_core::suite::x25519::X25519Secret;
 use zeroize::Zeroizing;
 
 use cipherbox_engine::api::REGISTRY_BATCH_REFUSED;
-use cipherbox_engine::content::{DAG_ROOT_CODEC, GatewaySource, SealedChunk, decode_root};
+use cipherbox_engine::content::{
+    ByoIpfsConfig, ByoKind, DAG_ROOT_CODEC, GatewaySource, PinMode, RetentionPolicy, SealedChunk,
+    decode_root,
+};
 use cipherbox_engine::facade::PendingClass;
+use cipherbox_engine::net::OrphanHeads;
 use cipherbox_engine::net::author::{AuthoredHead, EnvelopeAuthoring, author_child_envelope};
 use cipherbox_engine::net::{ChildAdopter, REGISTRY_BATCH_MAX, ResolveOutcome, resolve};
 use cipherbox_engine::seams::{
     BoxedTask, FloorStore, HttpRequest, HttpResponse, OpId, RecordTransport, SeamError, SeamResult,
     StagingStore, UnixMillis,
 };
+use cipherbox_engine::settings::{VaultSettings, publish_settings, settings_name};
 use cipherbox_engine::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
 use cipherbox_engine::sync::{
     DRAINED_OP_MARK_PREFIX, PUBLISHED_OP_MARK_PREFIX, StagedContent, UPLOAD_MARK_KEY, op_mark_key,
@@ -42,9 +48,10 @@ use cipherbox_engine::testkit::{
     OwnerRootSpec, SeededEntropy, block_on, frame_version as frame, owner_root_fixture,
 };
 use cipherbox_engine::{
-    ApiBaseUrl, BlockProgress, Command, ContentProfile, DeadLetter, DeadLetterReason, Engine,
-    EngineError, Event, EventStream, GatewayConfig, LoginSecret, MAX_OPEN_STREAMS, NodeId,
-    NodeKind, Op, OpPhase, RecordSeal, StoragePolicy, SyncTimingProfile, WriteTarget, stage_op,
+    ApiBaseUrl, ApiClient, BlockProgress, Command, ContentProfile, DeadLetter, DeadLetterReason,
+    DefaultsReason, Engine, EngineError, Event, EventStream, GatewayConfig, LoginSecret,
+    MAX_OPEN_STREAMS, NodeId, NodeKind, Op, OpPhase, OverBudgetCause, PlacementRefusal, RecordSeal,
+    StoragePolicy, SyncTimingProfile, WriteTarget, stage_op,
 };
 
 const SECRET: [u8; 32] = [7u8; 32];
@@ -133,12 +140,58 @@ fn proxy_413() -> SeamResult<HttpResponse> {
     })
 }
 
+/// The member's own IPFS node, as their vault settings name it.
+const MEMBER_NODE: &str = "https://kubo.member.test";
+
+/// The one file part out of a `multipart/form-data` body, framed against the
+/// boundary the request's own `Content-Type` declares. Deliberately strict: the
+/// point of the fake is to catch framing the real Kubo would reject.
+fn multipart_file(request: &HttpRequest) -> Vec<u8> {
+    let content_type = request
+        .headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("Content-Type"))
+        .map(|(_, value)| value.clone())
+        .expect("a multipart body declares its content type");
+    let boundary = content_type
+        .split("boundary=")
+        .nth(1)
+        .expect("the content type names the boundary")
+        .to_owned();
+    let body = request.body.clone().expect("a block/put carries a body");
+    let head = format!("--{boundary}\r\n");
+    let tail = format!("\r\n--{boundary}--\r\n");
+    let body = std::str::from_utf8(&body[..head.len()])
+        .ok()
+        .filter(|opening| *opening == head)
+        .map(|_| &body[head.len()..])
+        .expect("the body opens on the declared boundary");
+    let body = body
+        .strip_suffix(tail.as_bytes())
+        .expect("the body closes on the declared boundary");
+    // Past the part headers: the blank line that ends them is the file's start.
+    let start = body
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .expect("the part headers end")
+        + 4;
+    body[start..].to_vec()
+}
+
 #[derive(Clone, Default)]
 struct Blocks {
     store: Arc<Mutex<BTreeMap<String, Vec<u8>>>>,
     on_upload: Arc<Mutex<Option<UploadHook>>>,
-    /// What `GET /account/quota` reports, as `(usedBytes, limitBytes)`.
+    /// What `GET /account/quota` reports, as `(usedBytes, limitBytes)`. Unset is
+    /// an account with room, so only a test about the quota scripts one.
     quota: Arc<Mutex<Option<(u64, u64)>>>,
+    /// The account's server-side BYO flag, which `GET /account/quota` reports as
+    /// `advisory` and `PATCH /account/byo` moves.
+    advisory_quota: Arc<AtomicBool>,
+    /// The member's own node: what it holds, keyed by the address it stored each
+    /// block under, and whether it can be reached at all.
+    member_node: Arc<Mutex<BTreeMap<String, Vec<u8>>>>,
+    member_node_down: Arc<AtomicBool>,
     /// The 400 body every `POST /registry/register` answers with instead of
     /// acking.
     register_refusal: Arc<Mutex<Option<Vec<u8>>>>,
@@ -203,6 +256,49 @@ impl Blocks {
         *self.register_refusal.lock().expect("lock") = None;
     }
 
+    /// Answer the member's own Kubo node: store the block the `block/put` body
+    /// carries under the address that node computes for it, and answer with that
+    /// address — the same put-and-compare the hosted ingress runs, so a
+    /// mis-framed body or a wrong codec shows up as a disagreeing address rather
+    /// than passing silently.
+    fn member_node_reply(&self, request: &HttpRequest) -> SeamResult<HttpResponse> {
+        if self.member_node_down.load(Ordering::Relaxed) {
+            return Err(SeamError::new("the member's node is offline"));
+        }
+        assert!(
+            request.url.contains("mhtype=blake3&mhlen=32"),
+            "a block/put must name the frozen content-plane hash: {}",
+            request.url
+        );
+        let codec = if request.url.contains("cid-codec=raw") {
+            CONTENT_CID_CODEC
+        } else {
+            assert!(request.url.contains("cid-codec=dag-cbor"), "a known codec");
+            DAG_ROOT_CODEC
+        };
+        let block = multipart_file(request);
+        let cid = encode_content_cid_str(&compute_cid(codec, &block));
+        self.member_node
+            .lock()
+            .expect("lock")
+            .insert(cid.clone(), block);
+        Ok(HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: format!("{{\"Key\":\"{cid}\",\"Size\":0}}\n").into_bytes(),
+        })
+    }
+
+    /// Every address the member's own node holds.
+    fn member_node_cids(&self) -> Vec<String> {
+        self.member_node
+            .lock()
+            .expect("lock")
+            .keys()
+            .cloned()
+            .collect()
+    }
+
     /// Answer one engine HTTP call: a content upload lands its bytes here and
     /// echoes their address, a registry call acks, and a gateway GET serves the
     /// block back. Enqueued as many times as the pass needs, so no test depends
@@ -241,11 +337,28 @@ impl Blocks {
                 .quota
                 .lock()
                 .expect("lock")
-                .expect("the test scripted a quota before the drain probed it");
+                .unwrap_or((0, u64::MAX / 2));
+            let advisory = self.advisory_quota.load(Ordering::Relaxed);
             return ok(format!(
-                "{{\"usedBytes\":{used},\"limitBytes\":{limit},\"advisory\":false}}"
+                "{{\"usedBytes\":{used},\"limitBytes\":{limit},\"advisory\":{advisory}}}"
             )
             .into_bytes());
+        }
+        if url.starts_with(MEMBER_NODE) {
+            return self.member_node_reply(request);
+        }
+        if url.ends_with("/account/byo") {
+            let enabled = serde_json::from_slice::<serde_json::Value>(
+                request
+                    .body
+                    .as_deref()
+                    .expect("a byo toggle carries a body"),
+            )
+            .expect("a byo body is JSON")["byo"]
+                .as_bool()
+                .expect("the toggle names a boolean");
+            self.advisory_quota.store(enabled, Ordering::Relaxed);
+            return ok(Vec::new());
         }
         if url.ends_with("/registry/register") {
             if let Some(body) = self.register_refusal.lock().expect("lock").clone() {
@@ -2152,6 +2265,10 @@ fn a_permanently_refused_upload_reports_the_attempt_and_the_dead_letter() {
 /// An over-quota refusal is a hold, not a failed attempt: the op and its
 /// reservation stand until a probe finds room, and the host reads it from the
 /// snapshot rather than from a failure it cannot act on.
+///
+/// The account fills *after* the write is admitted, which is the only way the
+/// drain sees a 413 at all now that the command path pre-flights the quota —
+/// and exactly why that pre-flight can never be the enforcement.
 #[test]
 fn an_over_quota_upload_holds_the_op_without_reporting_a_failure() {
     let world = FakeWorld::new();
@@ -2160,8 +2277,6 @@ fn an_over_quota_upload_holds_the_op_without_reporting_a_failure() {
 
     let alice = world.device(b"alice");
     let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
-    blocks.refuse_upload(Box::new(|_| Some(upload_413(Some("QUOTA_EXCEEDED")))));
-    blocks.set_quota(1_000, 1_000);
     let op_id = write_file(
         &mut engine,
         WriteTarget::NewFile {
@@ -2171,6 +2286,8 @@ fn an_over_quota_upload_holds_the_op_without_reporting_a_failure() {
         &(0..200u8).collect::<Vec<_>>(),
     )
     .expect("the write commits");
+    blocks.refuse_upload(Box::new(|_| Some(upload_413(Some("QUOTA_EXCEEDED")))));
+    blocks.set_quota(1_000, 1_000);
     tick(&world, &engine, &mut tasks);
 
     let emitted = events_so_far(&mut events);
@@ -5670,4 +5787,341 @@ fn publish_next_record(
     for endpoint in records.endpoints() {
         records.seed_record(&endpoint, write_name(folder).as_str(), record.clone());
     }
+}
+
+// ---------------------------------------------------------------------------
+// The pin-provider layer: where a version's bytes go, decided from the vault
+// settings record and dispatched across the hosted and external legs.
+// ---------------------------------------------------------------------------
+
+/// The member's own node, as a BYO config naming it.
+fn member_node(kind: ByoKind) -> ByoIpfsConfig {
+    ByoIpfsConfig {
+        endpoint: MEMBER_NODE.to_owned(),
+        kind,
+        access_token: Some(Zeroizing::new("member-token".to_owned())),
+    }
+}
+
+/// Publish the account's vault settings record from `device`, so a cold start on
+/// it decides placement from the member's own choice rather than the first-run
+/// defaults.
+fn seed_settings(world: &FakeWorld, device: &FakeDevice, blocks: &Blocks, mode: PinMode) {
+    serve_http(device, blocks, 8);
+    let api = ApiClient::new(
+        device.http.clone(),
+        device.credential_store.clone(),
+        String::new(),
+    );
+    block_on(publish_settings(
+        &device.record_store,
+        &api,
+        &device.floor_store,
+        &device.snapshot_cache,
+        &world.scheduler,
+        &SyncTimingProfile::CI,
+        &mut SeededEntropy::new(9),
+        &OrphanHeads::default(),
+        &SECRET,
+        &VaultSettings {
+            pin_mode: mode,
+            byo: Some(member_node(ByoKind::Kubo)),
+            retention: RetentionPolicy::KeepAll,
+        },
+    ))
+    .expect("the settings record publishes");
+}
+
+/// `External` means what it says: not one byte reaches CipherBox's store, and
+/// the hosted quota — full here — never gates a write it will never see.
+#[test]
+fn an_external_write_places_every_block_on_the_members_node_and_none_on_the_hosted_store() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    seed_settings(&world, &alice, &blocks, PinMode::External);
+    blocks.set_quota(1_000, 1_000);
+
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    let plaintext = (0..200u8).collect::<Vec<_>>();
+    write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &plaintext,
+    )
+    .expect("a full hosted quota does not gate an external write");
+    tick(&world, &engine, &mut tasks);
+
+    let photo = child_id(&engine, ROOT, "photo.bin");
+    let mut registered = registered_content_cids(&alice, &write_name(photo));
+    registered.sort();
+    registered.dedup();
+    assert!(
+        !registered.is_empty(),
+        "every mode still registers for union-liveness accounting"
+    );
+    assert_eq!(
+        blocks.member_node_cids(),
+        registered,
+        "the member's node holds exactly the block set the registration names"
+    );
+    let hosted = uploaded_cids(&alice);
+    assert!(
+        registered.iter().all(|cid| !hosted.contains(cid)),
+        "not one of the version's blocks took the hosted path"
+    );
+    assert_eq!(
+        published(&world.record_store, photo).0,
+        1,
+        "the version still published its own record"
+    );
+}
+
+/// Dual runs both legs and only the hosted one can fail the op: an offline home
+/// node must not stall every later mutation in the vault. The outcome is
+/// reported per op rather than swallowed.
+#[test]
+fn a_dual_write_publishes_and_reports_the_leg_the_members_node_did_not_take() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    seed_settings(&world, &alice, &blocks, PinMode::Dual);
+
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    blocks.member_node_down.store(true, Ordering::Relaxed);
+    let op_id = write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<_>>(),
+    )
+    .expect("the write commits");
+    tick(&world, &engine, &mut tasks);
+
+    let photo = child_id(&engine, ROOT, "photo.bin");
+    assert_eq!(
+        published(&world.record_store, photo).0,
+        1,
+        "the hosted leg landed, so the version published"
+    );
+    assert!(
+        !uploaded_cids(&alice).is_empty(),
+        "the hosted leg took the bytes"
+    );
+    assert!(
+        blocks.member_node_cids().is_empty(),
+        "the offline node took none"
+    );
+    let emitted = events_so_far(&mut events);
+    assert_eq!(
+        emitted
+            .iter()
+            .filter(|event| matches!(
+                event,
+                Event::OpProgress {
+                    op_id: Some(id),
+                    phase: OpPhase::ExternalPinFailed,
+                    ..
+                } if *id == op_id
+            ))
+            .count(),
+        1,
+        "the partial outcome is reported once for the op, not once per block"
+    );
+    assert!(
+        !emitted.iter().any(|event| matches!(
+            event,
+            Event::OpProgress {
+                phase: OpPhase::UploadFailed,
+                ..
+            }
+        )),
+        "a mirror that did not take the bytes is not a failed upload"
+    );
+    assert!(
+        block_on(engine.snapshot(ROOT))
+            .expect("a snapshot")
+            .dead_letters
+            .is_empty(),
+        "and never a dead letter"
+    );
+}
+
+/// A dual write whose home node is up mirrors every block, and the hosted leg
+/// still holds the whole set.
+#[test]
+fn a_dual_write_places_the_same_block_set_on_both_legs() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    seed_settings(&world, &alice, &blocks, PinMode::Dual);
+
+    let (mut engine, mut events, mut tasks) = boot(&world, &blocks, &alice, 42);
+    write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<_>>(),
+    )
+    .expect("the write commits");
+    tick(&world, &engine, &mut tasks);
+
+    let photo = child_id(&engine, ROOT, "photo.bin");
+    let mut registered = registered_content_cids(&alice, &write_name(photo));
+    registered.sort();
+    registered.dedup();
+    assert!(!registered.is_empty(), "the version has blocks");
+    let hosted = uploaded_cids(&alice);
+    assert!(
+        registered.iter().all(|cid| hosted.contains(cid)),
+        "the hosted leg took every block"
+    );
+    assert_eq!(
+        blocks.member_node_cids(),
+        registered,
+        "and the member's node holds the same addresses, under its own hashing"
+    );
+    assert!(
+        !events_so_far(&mut events).iter().any(|event| matches!(
+            event,
+            Event::OpProgress {
+                phase: OpPhase::ExternalPinFailed,
+                ..
+            }
+        )),
+        "both legs took it, so there is no partial outcome to report"
+    );
+}
+
+/// The pre-flight's whole point: a hosted write the account cannot admit is
+/// refused before the version is sealed and staged, not after a whole upload's
+/// worth of work at the drain.
+#[test]
+fn a_hosted_write_over_quota_is_refused_at_command_time() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    let (mut engine, _events, _tasks) = boot(&world, &blocks, &alice, 42);
+    blocks.set_quota(900, 1_000);
+
+    let refused = block_on(engine.begin_write(
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        200,
+    ))
+    .expect_err("the account cannot admit it");
+    assert!(
+        matches!(
+            refused,
+            EngineError::OverBudget {
+                cause: OverBudgetCause::AccountQuota,
+                available: 100,
+                ..
+            }
+        ),
+        "the refusal names the account quota and the room left: {refused:?}"
+    );
+    assert!(
+        block_on(alice.staging_store.queued_ops())
+            .expect("the queue reads")
+            .is_empty(),
+        "nothing was staged or journaled"
+    );
+    assert!(
+        uploaded_cids(&alice).is_empty(),
+        "and no byte was offered to the ingress"
+    );
+}
+
+/// The command path reconciles the account's server-side flag against the
+/// vaulted mode, which is the source of truth — the flag is an accounting
+/// display, never the gate.
+#[test]
+fn the_command_path_reconciles_the_accounts_byo_flag_against_the_vaulted_mode() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    seed_settings(&world, &alice, &blocks, PinMode::External);
+
+    let (mut engine, _events, _tasks) = boot(&world, &blocks, &alice, 42);
+    assert!(
+        !blocks.advisory_quota.load(Ordering::Relaxed),
+        "the account starts classified as hosted"
+    );
+    write_file(
+        &mut engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        &(0..200u8).collect::<Vec<_>>(),
+    )
+    .expect("the write commits");
+    assert!(
+        blocks.advisory_quota.load(Ordering::Relaxed),
+        "an external mode moved the account onto advisory accounting"
+    );
+    let toggles = alice
+        .http
+        .requests()
+        .iter()
+        .filter(|request| request.url.ends_with("/account/byo"))
+        .count();
+    assert_eq!(toggles, 1, "and only while the two disagreed");
+}
+
+/// A settings load that cannot authenticate the member's choice refuses the
+/// write rather than placing it on the hosted default — the widening that
+/// blueprint/engine.md's settings-load policy exists to prevent.
+#[test]
+fn a_withheld_settings_record_refuses_the_write_instead_of_widening_it() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    // A durable floor for the settings name and no record to meet it: this
+    // device adopted one before, so its absence now is suppression.
+    block_on(
+        alice
+            .floor_store
+            .raise_sequence_floor(settings_name(&SECRET).as_str().as_bytes(), 3),
+    )
+    .expect("the floor raises");
+
+    let (mut engine, _events, _tasks) = boot(&world, &blocks, &alice, 42);
+    let refused = block_on(engine.begin_write(
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        200,
+    ))
+    .expect_err("no placement could be authenticated");
+    assert!(
+        matches!(
+            refused,
+            EngineError::NoPlacement {
+                refusal: PlacementRefusal::SettingsUnavailable(DefaultsReason::Suppressed),
+            }
+        ),
+        "the refusal says which rule bit: {refused:?}"
+    );
+    assert!(
+        uploaded_cids(&alice).is_empty(),
+        "and no byte went anywhere"
+    );
 }

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -981,6 +981,30 @@ fn write_file(
     block_on(engine.commit_write(handle))
 }
 
+/// One committed file under the root, for tests about what a write *triggers*
+/// rather than what it stores.
+fn write_photo(engine: &mut Engine<FakeSeamTypes>, name: &str) -> OpId {
+    write_file(
+        engine,
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: name.to_owned(),
+        },
+        &(0..200u8).collect::<Vec<_>>(),
+    )
+    .expect("the write commits")
+}
+
+/// How many times this device asked the API to move the account's BYO flag.
+fn byo_toggles(device: &FakeDevice) -> usize {
+    device
+        .http
+        .requests()
+        .iter()
+        .filter(|request| request.url.ends_with("/account/byo"))
+        .count()
+}
+
 /// Alice publishes `plaintext` as `clip.bin` under the root, handing back her
 /// engine and pump tasks so a caller can republish over it.
 fn publish_clip(
@@ -6485,42 +6509,22 @@ fn the_session_reconciles_the_accounts_byo_flag_to_the_vaulted_mode() {
     );
 
     let (mut engine, _events, _tasks) = boot(&world, &blocks, &alice, 42);
-    let toggles = |device: &FakeDevice| {
-        device
-            .http
-            .requests()
-            .iter()
-            .filter(|request| request.url.ends_with("/account/byo"))
-            .count()
-    };
-    let write = |engine: &mut Engine<FakeSeamTypes>, name: &str| {
-        write_file(
-            engine,
-            WriteTarget::NewFile {
-                parent: ROOT,
-                name: name.to_owned(),
-            },
-            &(0..200u8).collect::<Vec<_>>(),
-        )
-        .expect("the write commits")
-    };
-
-    write(&mut engine, "photo.bin");
+    write_photo(&mut engine, "photo.bin");
     assert!(
         blocks.advisory_quota.load(Ordering::Relaxed),
         "an external mode moved the account onto advisory accounting"
     );
-    assert_eq!(toggles(&alice), 1, "and only while the two disagreed");
+    assert_eq!(byo_toggles(&alice), 1, "and only while the two disagreed");
 
     // The mode is fixed for the session, so no later write re-derives it.
-    write(&mut engine, "photo2.bin");
-    assert_eq!(toggles(&alice), 1, "at most once a session");
+    write_photo(&mut engine, "photo2.bin");
+    assert_eq!(byo_toggles(&alice), 1, "at most once a session");
 
     // A second device on the same settings finds the flag already right.
     let bob = world.device(b"alice-second-device");
     let (mut engine_b, _events, _tasks) = boot(&world, &blocks, &bob, 43);
-    write(&mut engine_b, "photo3.bin");
-    assert_eq!(toggles(&bob), 0, "nothing to reconcile once they agree");
+    write_photo(&mut engine_b, "photo3.bin");
+    assert_eq!(byo_toggles(&bob), 0, "nothing to reconcile once they agree");
 }
 
 /// The once-a-session guard latches on the reconcile *landing*, not on the
@@ -6538,44 +6542,24 @@ fn a_byo_reconcile_that_did_not_land_is_retried_by_the_next_write() {
     blocks.byo_down.store(true, Ordering::Relaxed);
 
     let (mut engine, _events, _tasks) = boot(&world, &blocks, &alice, 42);
-    let toggles = || {
-        alice
-            .http
-            .requests()
-            .iter()
-            .filter(|request| request.url.ends_with("/account/byo"))
-            .count()
-    };
-    let write = |engine: &mut Engine<FakeSeamTypes>, name: &str| {
-        write_file(
-            engine,
-            WriteTarget::NewFile {
-                parent: ROOT,
-                name: name.to_owned(),
-            },
-            &(0..200u8).collect::<Vec<_>>(),
-        )
-        .expect("the write commits")
-    };
-
-    write(&mut engine, "photo.bin");
-    assert_eq!(toggles(), 1, "the session tried to reconcile");
+    write_photo(&mut engine, "photo.bin");
+    assert_eq!(byo_toggles(&alice), 1, "the session tried to reconcile");
     assert!(
         blocks.advisory_quota.load(Ordering::Relaxed),
         "and the account still disagrees with the vaulted mode"
     );
 
     blocks.byo_down.store(false, Ordering::Relaxed);
-    write(&mut engine, "photo2.bin");
-    assert_eq!(toggles(), 2, "so the next write tries again");
+    write_photo(&mut engine, "photo2.bin");
+    assert_eq!(byo_toggles(&alice), 2, "so the next write tries again");
     assert!(
         !blocks.advisory_quota.load(Ordering::Relaxed),
         "and this one landed"
     );
 
-    write(&mut engine, "photo3.bin");
+    write_photo(&mut engine, "photo3.bin");
     assert_eq!(
-        toggles(),
+        byo_toggles(&alice),
         2,
         "a landed reconcile closes the window for good"
     );

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -61,6 +61,8 @@ const ROOT: NodeId = NodeId(SCOPE);
 /// The sole v2 re-point payload version (`facade::POINTER_PAYLOAD_VERSION`).
 const POINTER_PAYLOAD_VERSION: u64 = 1;
 const TTL_NANOS: u64 = 2_000_000_000;
+/// The BLAKE3 placement tag the upload mark is keyed by (`Placement::tag`).
+const PLACEMENT_TAG_LEN: usize = 32;
 const EOL: &str = "2099-01-01T00:00:00Z";
 
 fn owner_identity() -> EcdsaSigner {
@@ -1783,11 +1785,13 @@ fn evict_leaf(device: &FakeDevice, index: impl Fn(usize) -> usize) -> Vec<Vec<u8
         .collect()
 }
 
-/// The durable upload mark as [`UPLOAD_MARK_KEY`] holds it: the version root it
-/// names and the leaf count it claims.
+/// The durable upload mark as [`UPLOAD_MARK_KEY`] holds it, minus the placement
+/// tag it opens on: the version root it names and the leaf count it claims.
 fn upload_mark(device: &FakeDevice) -> Option<(Vec<u8>, u32)> {
     let stored = block_on(device.staging_store.staged_bytes(UPLOAD_MARK_KEY)).unwrap()?;
-    let (root, count) = stored.split_at(stored.len() - 4);
+    let (named, count) = stored.split_at(stored.len() - 4);
+    // The mark opens on the placement tag its progress was written under.
+    let root = &named[PLACEMENT_TAG_LEN..];
     Some((root.to_vec(), u32::from_be_bytes(count.try_into().unwrap())))
 }
 
@@ -4360,7 +4364,7 @@ fn a_cancelled_versions_upload_mark_never_counts_towards_the_next_one() {
         .unwrap()
         .expect("the cancelled pass left its progress mark behind");
     assert!(
-        mark.starts_with(&root_cid),
+        mark[PLACEMENT_TAG_LEN..].starts_with(&root_cid),
         "the residue names the cancelled root, so the next version must not read it as progress"
     );
 
@@ -6046,42 +6050,57 @@ fn a_hosted_write_over_quota_is_refused_at_command_time() {
     );
 }
 
-/// The command path reconciles the account's server-side flag against the
-/// vaulted mode, which is the source of truth — the flag is an accounting
-/// display, never the gate.
+/// The account's server-side flag is reconciled to the vaulted mode, which is
+/// the source of truth — the flag is an accounting display, never the gate.
 #[test]
-fn the_command_path_reconciles_the_accounts_byo_flag_against_the_vaulted_mode() {
+fn the_session_reconciles_the_accounts_byo_flag_to_the_vaulted_mode() {
     let world = FakeWorld::new();
     let blocks = Blocks::default();
     seed_account(&world, &blocks);
     let alice = world.device(b"alice");
     seed_settings(&world, &alice, &blocks, PinMode::External);
-
-    let (mut engine, _events, _tasks) = boot(&world, &blocks, &alice, 42);
     assert!(
         !blocks.advisory_quota.load(Ordering::Relaxed),
         "the account starts classified as hosted"
     );
-    write_file(
-        &mut engine,
-        WriteTarget::NewFile {
-            parent: ROOT,
-            name: "photo.bin".into(),
-        },
-        &(0..200u8).collect::<Vec<_>>(),
-    )
-    .expect("the write commits");
+
+    let (mut engine, _events, _tasks) = boot(&world, &blocks, &alice, 42);
+    let toggles = |device: &FakeDevice| {
+        device
+            .http
+            .requests()
+            .iter()
+            .filter(|request| request.url.ends_with("/account/byo"))
+            .count()
+    };
+    let write = |engine: &mut Engine<FakeSeamTypes>, name: &str| {
+        write_file(
+            engine,
+            WriteTarget::NewFile {
+                parent: ROOT,
+                name: name.to_owned(),
+            },
+            &(0..200u8).collect::<Vec<_>>(),
+        )
+        .expect("the write commits")
+    };
+
+    write(&mut engine, "photo.bin");
     assert!(
         blocks.advisory_quota.load(Ordering::Relaxed),
         "an external mode moved the account onto advisory accounting"
     );
-    let toggles = alice
-        .http
-        .requests()
-        .iter()
-        .filter(|request| request.url.ends_with("/account/byo"))
-        .count();
-    assert_eq!(toggles, 1, "and only while the two disagreed");
+    assert_eq!(toggles(&alice), 1, "and only while the two disagreed");
+
+    // The mode is fixed for the session, so no later write re-derives it.
+    write(&mut engine, "photo2.bin");
+    assert_eq!(toggles(&alice), 1, "at most once a session");
+
+    // A second device on the same settings finds the flag already right.
+    let bob = world.device(b"alice-second-device");
+    let (mut engine_b, _events, _tasks) = boot(&world, &blocks, &bob, 43);
+    write(&mut engine_b, "photo3.bin");
+    assert_eq!(toggles(&bob), 0, "nothing to reconcile once they agree");
 }
 
 /// A settings load that cannot authenticate the member's choice refuses the

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -5519,6 +5519,20 @@ fn stage_a_second_version(
     (engine, tasks, version)
 }
 
+/// Whether this stream carries the verdict a version whose released blocks are
+/// gone ends on — the hole guard's, not a mere failed attempt.
+fn content_lost(events: &mut EventStream) -> bool {
+    events_so_far(events).iter().any(|event| {
+        matches!(
+            event,
+            Event::DeadLetter {
+                reason: DeadLetterReason::ContentUnrecoverable,
+                ..
+            }
+        )
+    })
+}
+
 /// Tick until the drain dead-letters something, and report how many passes that
 /// took — the budget is finite, but spending it takes more than one pass.
 fn tick_until_dead_lettered(
@@ -5969,18 +5983,7 @@ fn a_placement_changed_mid_upload_resumes_only_where_the_bytes_already_are() {
         tick(&world, &engine, &mut tasks);
         tick(&world, &engine, &mut tasks);
 
-        let dead_lettered = |events: &mut EventStream| {
-            events_so_far(events).iter().any(|event| {
-                matches!(
-                    event,
-                    Event::DeadLetter {
-                        reason: DeadLetterReason::ContentUnrecoverable,
-                        ..
-                    }
-                )
-            })
-        };
-        let lost = dead_lettered(&mut events) || dead_lettered(&mut events_after);
+        let lost = content_lost(&mut events) || content_lost(&mut events_after);
         assert_eq!(
             !lost, survives,
             "{before:?} -> {after:?}: the verdict follows where the released bytes are"
@@ -6315,6 +6318,61 @@ fn a_dead_mirror_costs_the_op_a_bounded_number_of_attempts() {
     );
 }
 
+/// The hosted leg charges the account the instant a block lands, and the only
+/// evidence a cancel has to retire it by is the confirmed set. So no block may
+/// reach the hosted store without entering that set first — including under
+/// dual, where the mirror's retries put awaits between the two.
+#[test]
+fn a_cancel_while_the_mirror_retries_still_retires_the_hosted_blocks() {
+    let plaintext: Vec<u8> = (0..200u8).collect();
+    for polls in 1..14 {
+        let world = FakeWorld::new();
+        let blocks = Blocks::default();
+        seed_account(&world, &blocks);
+        let alice = world.device(b"alice");
+        seed_settings(&world, &alice, &blocks, PinMode::Dual);
+
+        let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+        // A mirror that refuses every attempt is what puts the cancel window
+        // between the hosted upload and the end of the block.
+        blocks.member_node_down.store(true, Ordering::Relaxed);
+        let op_id = write_file(
+            &mut engine,
+            WriteTarget::NewFile {
+                parent: ROOT,
+                name: "photo.bin".into(),
+            },
+            &plaintext,
+        )
+        .expect("the write commits");
+        let version: Vec<String> = queued_version(&alice, op_id)
+            .iter()
+            .map(|cid| encode_content_cid_str(cid))
+            .collect();
+
+        world.scheduler.advance(engine.profile().poll_cadence);
+        for _ in 0..polls {
+            poll_once(&mut tasks);
+        }
+        if block_on(engine.command(Command::CancelUpload { op_id })).is_err() {
+            // Past publish entry, where a cancel is refused by design.
+            continue;
+        }
+        poll_each(&mut tasks);
+
+        let retired: Vec<String> = retire_batches(&alice).into_iter().flatten().collect();
+        for cid in uploaded_cids(&alice)
+            .iter()
+            .filter(|cid| version.contains(cid))
+        {
+            assert!(
+                retired.contains(cid),
+                "polls {polls}: the hosted store took {cid} and the cancel left it charged"
+            );
+        }
+    }
+}
+
 /// A dual write's mark may name the mirror only where the mirror actually took
 /// the bytes. Otherwise an external-only session resuming that version reads
 /// blocks it never received as progress, skips them, and publishes a manifest
@@ -6361,18 +6419,7 @@ fn a_dual_mark_names_the_mirror_only_where_the_mirror_took_the_bytes() {
         tick(&world, &engine, &mut tasks);
         tick(&world, &engine, &mut tasks);
 
-        let dead_lettered = |events: &mut EventStream| {
-            events_so_far(events).iter().any(|event| {
-                matches!(
-                    event,
-                    Event::DeadLetter {
-                        reason: DeadLetterReason::ContentUnrecoverable,
-                        ..
-                    }
-                )
-            })
-        };
-        let lost = dead_lettered(&mut events) || dead_lettered(&mut events_after);
+        let lost = content_lost(&mut events) || content_lost(&mut events_after);
         assert_eq!(
             !lost, survives,
             "mirror up {mirror_up}: the resume follows whether that node holds the released leaves"

--- a/crates/fuse/src/error.rs
+++ b/crates/fuse/src/error.rs
@@ -67,6 +67,12 @@ impl From<EngineError> for VfsError {
             }
             EngineError::OverBudget { cause, .. } => VfsError::OverBudget(cause),
             EngineError::ContentUnavailable { message } => VfsError::Unavailable { message },
+            // Retryable once the vault settings resolve or are saved again, and
+            // not a storage verdict: the device has room, the engine simply does
+            // not know where the member wants the bytes.
+            error @ EngineError::NoPlacement { .. } => VfsError::Unavailable {
+                message: error.to_string(),
+            },
             // Retryable once the mount closes a stream, not a storage verdict.
             error @ EngineError::TooManyStreams => VfsError::Unavailable {
                 message: error.to_string(),

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -477,6 +477,7 @@ fn engine_error(error: EngineError) -> JsValue {
         EngineError::UnsupportedContentFormat { .. } => "unsupportedContentFormat",
         EngineError::Unimplemented { .. } => "unimplemented",
         EngineError::OverBudget { .. } => "overBudget",
+        EngineError::NoPlacement { .. } => "noPlacement",
         EngineError::ContentSizeMismatch { .. } => "contentSizeMismatch",
         EngineError::UnknownWriteHandle => "unknownWriteHandle",
         EngineError::UnknownStreamHandle => "unknownStreamHandle",

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -232,6 +232,9 @@ pub enum OpPhase {
     UploadFailed,
     /// The user cancelled the upload.
     UploadCancelled,
+    /// The version published, but the member's own IPFS provider did not take
+    /// it. No retry is queued.
+    ExternalPinFailed,
 }
 
 impl From<facade::OpPhase> for OpPhase {
@@ -245,6 +248,7 @@ impl From<facade::OpPhase> for OpPhase {
             facade::OpPhase::UploadCompleted => OpPhase::UploadCompleted,
             facade::OpPhase::UploadFailed => OpPhase::UploadFailed,
             facade::OpPhase::UploadCancelled => OpPhase::UploadCancelled,
+            facade::OpPhase::ExternalPinFailed => OpPhase::ExternalPinFailed,
         }
     }
 }

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -39,6 +39,7 @@ export const fakeWasmEnums = {
     UploadCompleted: 5,
     UploadFailed: 6,
     UploadCancelled: 7,
+    ExternalPinFailed: 8,
   },
   DeadLetterReason: {
     TargetGone: 0,

--- a/packages/client/src/worker/commandCodec.ts
+++ b/packages/client/src/worker/commandCodec.ts
@@ -131,6 +131,8 @@ function opPhase(wasm: EngineWasm, phase: number | undefined): OpProgressPhase {
       return 'uploadFailed';
     case wasm.OpPhase.UploadCancelled:
       return 'uploadCancelled';
+    case wasm.OpPhase.ExternalPinFailed:
+      return 'externalPinFailed';
     default:
       // Fail closed: an unmapped value means a JS/WASM version mismatch, not a
       // safe-to-ignore state (the event pump turns this throw into a fatal).

--- a/packages/client/src/worker/engineWasm.ts
+++ b/packages/client/src/worker/engineWasm.ts
@@ -152,6 +152,7 @@ export interface EngineWasm {
     readonly UploadCompleted: number;
     readonly UploadFailed: number;
     readonly UploadCancelled: number;
+    readonly ExternalPinFailed: number;
   };
   Staleness: {
     readonly Fresh: number;

--- a/packages/client/src/worker/protocol.ts
+++ b/packages/client/src/worker/protocol.ts
@@ -39,7 +39,8 @@ export type OpProgressPhase =
   | 'uploadProgress'
   | 'uploadCompleted'
   | 'uploadFailed'
-  | 'uploadCancelled';
+  | 'uploadCancelled'
+  | 'externalPinFailed';
 
 /** One ancestor step in a snapshot's breadcrumb trail, as data. */
 export interface BreadcrumbDescriptor {


### PR DESCRIPTION
Wires `PinMode` across all three modes and fixes the advisory-quota bypass. Before this, `PinMode` had no consumer on the byte path — every version's blocks went to the hosted ingress whatever the member chose — and `pre_flight_quota_check` short-circuited on the server's `advisory` flag.

## The placement decision

Decided once at `start` from the vault settings load, held for the session in a cell the engine empties on drop (it carries the member's provider bearer, so it is treated like `tick_enc_subkey`), and read by both the command path and the drain. It lives in `settings.rs`, beside the load it reads.

A degraded load **never widens placement**: only `Defaults(NoRecord)` — a first run — falls back to `PinMode::Hosted`. Every other reason with no last-known-good copy returns `PlacementRefusal::SettingsUnavailable` and refuses the write. That is the consumer #928 wrote the last-known-good path for.

Symmetrically, **a publish refuses settings no reader could place under**. `publish_settings` runs the consumer's own predicate, so a record naming an external leg with no provider — or external-only over a pin-by-CID provider — is never signed. Left unchecked that record is a durable, account-wide refusal of every content write, recoverable only by publishing a new one (AGENTS.md rule 8).

## Concrete dispatch

`place_block` dispatches over the `Http` seam per provider kind:

- **Kubo** takes the bytes under exactly the caller's address — `POST /api/v0/block/put?cid-codec=<raw|dag-cbor>&mhtype=blake3&mhlen=32&pin=true&allow-big-block=true`, multipart — and the address it answers with is decoded and held to the one it was given. This mirrors the hosted ingress's own put-and-compare (`apps/api/src/registry/pin-store.ts`) from #906. `allow-big-block` is there because a DAG root inlines a CID per leaf and so passes Kubo's 1 MiB advisory long before the flat-DAG ceiling does; the block is content-addressed and self-verifying, so the advice does not apply.
- **PSA / Pinata** are pin-by-CID services: they fetch the block from the network rather than receive it, and their byte ingress re-chunks under a different multihash, so neither can preserve an address. They are asked to pin the CID.

The multipart boundary is derived from the block's own content address, so the delimiter cannot occur in the payload it frames — that would take a block carrying the base32 of its own BLAKE3 digest. This removes the escape/collision path rather than guarding it, and it holds a fortiori for the dag-cbor root, whose CID links are binary and never the base32 text.

**Design decision worth review:** external-only over a pin-by-CID provider is a `PlacementRefusal::NoExternalIngress`. With no hosted leg nothing would hold the block for the service to fetch, so the published record would name bytes that exist nowhere. v1 papered over this by round-tripping through the CipherBox relay and then unpinning (`client.ts:2690-2711`), which both defeats "never put my bytes in CipherBox's store" and leaked quota when the unpin failed.

**Scope boundary:** only content versions dispatch. A record head block still takes the hosted path, because `publish_record` compares the ingress's returned address against the head block's own and the republisher re-PUTs from the hosted store.

## Dual and the partial outcome

Both legs run; only the hosted one can fail the op, because under strict-FIFO stop-at-first-failure a both-must-succeed rule would let an offline home node stall every later mutation in the vault. The external leg's outcome rides out as one `OpPhase::ExternalPinFailed` per op — not per block, and never swallowed the way v1's bare `catch {}` did. Under `External` the member's provider *is* the byte path, so its refusal is the op's.

Durable upload progress is **keyed by the placement it was written under**. A resumed version's confirmed prefix is no longer on the device, so progress towards one set of destinations can never be read as progress towards another; a mode changed between sessions re-fetches rather than publishing a version the new placement never received.

## The quota pre-flight — #705

`pre_flight_quota_check` now takes whether *this write* has a hosted leg and gates on that. `quota.advisory` is demoted to a display hint — it lags the vaulted mode, so gating on it both admits a hosted upload the ingress then refuses and refuses an external one it would never see.

The pre-flight moved to command time, in `begin_write`, sized in **sealed** bytes. Two directions, deliberately different:

- The **placement** decision is fail-closed — no authenticated choice, no write.
- The **quota probe** is not. The API upload endpoint stays the authoritative gate, so an unreachable or unconfigured API leaves the write to queue offline like any other.

The account's `byo` flag is reconciled to the vaulted mode at most once a session (`byo=true` is exactly `External`; `Hosted` and `Dual` both run `byo=false`, since dual has no server representation). Latched, so two devices cannot flap an account-wide flag per file.

## Tests

`crates/engine/tests/write_plane.rs` gains a fake member node that parses the multipart body, recomputes the address under the declared `cid-codec`, and answers with it — so mis-framing or a wrong codec surfaces as a disagreeing address rather than passing silently. Covering the three acceptance criteria plus three:

- an external write places every block on the member's node and none of them on the hosted store, with the hosted quota full
- a dual write with an unreachable provider publishes and reports the partial outcome exactly once, with no dead letter
- a dual write with a reachable provider places the same block set on both legs
- a hosted write over quota is refused at command time, having staged and journaled nothing
- the session reconciles the account's BYO flag once, and a second device with nothing to reconcile sends nothing
- a withheld settings record refuses the write instead of widening it

Plus unit coverage for every placement arm, the rule-8 publish refusals, placement-tag distinctness, a mark written under other destinations covering nothing, each provider kind's request shape, the address-mismatch and no-verdict rejections, and every byte of the frozen CID framing refused before the seam. `an_over_quota_upload_holds_the_op_without_reporting_a_failure` now fills the account *after* the write is admitted, which is the only way the drain sees a 413 now — and exactly why the pre-flight can never be the enforcement.

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` all ran on `git diff main...HEAD`. Folded back in the second commit:

- **rule 8** — the publish-side placement refusal above (crypto, HIGH)
- **placement-blind upload mark** — a version resumed after a mode change was publishing and registering leaves the new placement never received (security, MEDIUM)
- **reachable panic** — `content_address` screened the codec byte and length but not the rest of the frozen framing, so a malformed address reached `encode_content_cid_str`'s release-active assert instead of returning the documented verdict (both, MEDIUM/LOW)
- **Kubo 1 MiB `block/put` cap** on DAG roots (crypto, MEDIUM)
- **address compared as decoded bytes**, not as a string, so a node spelling the same CID in another multibase is a match (crypto)
- **`Placement::External`'s doc overclaimed** — record heads and registration still traverse the hosted plane (both)
- **altitude** — placement moved to `settings.rs`, leaving the module arrow one-way; `mode`/`external` collapsed into `has_hosted_leg` plus one exhaustive match per block; the bearer is no longer cloned per write (simplify)
- comment trims, exact-variant test assertions, a trivially-passing assertion deleted

Deferred with dependency edges, each because closing it is its own design decision rather than a tightening of this one: #1084 (a withheld record still reaches the first-run default on a device that has never synced — needs positive evidence the account never published settings, which no device-local seam carries), #1085 (placement is frozen for the session, so a revoked provider keeps receiving blocks until restart), #1086 (the `Http` seam follows redirects where its sibling record transport refuses them — two lines, but it also carries the API client and wants a deployment check first). Both residuals are stated in `blueprint/engine.md`.

## Issue-body correction

The issue says `PinMode`, `ByoIpfsConfig` and `pre_flight_quota_check` are re-exported "with zero callers anywhere". That was stale: `pre_flight_quota_check` was already called at `crates/engine/src/sync/drain.rs:639`, and `PinMode`/`ByoIpfsConfig` were consumed by the settings record at `crates/engine/src/settings.rs:36,57,59`. The byte path was the gap, not the whole surface.

## Beyond the owned files

Four downstream surfaces broke on the new `OpPhase` and `EngineError` variants and are fixed minimally: the FUSE errno mapping (`NoPlacement` is retryable availability, not a storage verdict), the wasm `OpPhase`/error-code bridges, and the TS phase union plus its two declaration mirrors. All are exhaustive-by-construction sites that fail closed, so none could be left.

## Gate

`Engine Tests`, `Contract Suite`.

Closes #871
Closes #705
Part of #655


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire pin-provider placement layer across hosted, external, and dual-write modes
> - Adds a `Placement` enum (`Hosted`, `External`, `Dual`) computed once per session from vault settings and stored on the `Engine`; writes are refused with `EngineError::NoPlacement` if placement cannot be resolved.
> - `Drain.upload_blocks` now dispatches per-block uploads to the correct destination(s): hosted-only hits the hosted ingress, external-only posts to the member's provider (Kubo block/put or pin-by-CID), and dual-write does both with up to 3 mirror retries without failing the op.
> - Adds `pre_flight_quota_check` gating to `begin_write`; external-only writes bypass hosted quota entirely; dual/hosted writes enforce quota before staging.
> - Upload progress marks now encode which destination legs were reached, enabling destination-aware resume; marks from a different placement do not credit the new required leg and may surface a mirror gap.
> - Partial external pin failures are reported as `OpPhase::ExternalPinFailed` after publish confirms, surfaced through WASM, the client worker, and FUSE as `VfsError::Unavailable`.
> - `publish_settings` now refuses configurations that have no usable byte destination (e.g. External mode with a non-Kubo provider), returning `SettingsPublishError::Placement`.
> - Risk: existing stored upload marks lack a destinations prefix and will be treated as corrupt/no-progress on first resume after this change, causing re-upload of any in-flight versions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc47da7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hosted, external, and dual content placement with destination-aware resume/progress tracking.
  * Enabled BYO member-provider placement for block uploads and CID-based pinning (including mismatch validation).
  * Added reporting for successful hosted publication when external pinning fails.

* **Bug Fixes**
  * Improved fail-closed behavior when placement settings or required providers are unavailable.
  * Added more robust provider response classification and content address validation.

* **Documentation**
  * Updated placement fallback, provider routing, retry/completion rules, and quota gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->