### PR TITLE
fix: move the engine event stream off the origin-wide channel and watch follower presence locks

### DIFF
--- a/blueprint/web-client.md
+++ b/blueprint/web-client.md
@@ -92,21 +92,31 @@ mechanism; the invariant — one engine writer per origin — is D4's):
   exactly the failover primitive needed.
 - **Followers are thin mirrors, not engines**: a non-leader tab spawns no
   worker and holds no keys. It renders view projections served by the leader
-  and sends commands as data. Election, the port rendezvous, and the one-way
-  event stream ride a `BroadcastChannel` as plain structured-clone data — every
-  context on the origin holds that channel, so no plaintext, key material or
-  user-supplied name may touch it (an `EventDescriptor` still carries node ids,
-  IPNS names and block counts). Everything else takes a different wire: each
-  follower dials the leader a private `MessagePort` through the Service Worker
-  (the only cross-tab route for a transferable) and drives commands, uploads,
-  reads and its focus report over that, buffers transferred rather than cloned.
-  The leadership token gating the port is itself broadcast, so it bounds
-  accidental and passive delivery, never a same-origin context that read the
-  beacon — same origin remains the trust boundary. A tab with no Service Worker
-  mirrors nothing: it fails closed rather than fall back to the shared channel.
-  The leader probes each port for the tab behind it and reclaims the handles of
-  one that stops answering, so a crashed follower does not pin a content version
-  — and its key — for the rest of the leadership.
+  and sends commands as data. Election and the port rendezvous ride a
+  `BroadcastChannel` as plain structured-clone data — every context on the
+  origin holds that channel, so nothing that names or measures vault content may
+  touch it: no plaintext, no key material, no user-supplied name, and no node id,
+  IPNS name, routing key or block count. Everything else takes a different wire:
+  each follower dials the leader a private `MessagePort` through the Service
+  Worker (the only cross-tab route for a transferable) and drives commands,
+  uploads, reads and its focus report over that, buffers transferred rather than
+  cloned, with the one-way `EventDescriptor` stream fanned back down the same
+  ports. A follower therefore mirrors events only once its port is adopted; it
+  brokers eagerly at each leadership change, and a missed event costs staleness,
+  never correctness. The leadership token gating the port is itself broadcast, so
+  it bounds accidental and passive delivery, never a same-origin context that
+  read the beacon — same origin remains the trust boundary. A tab with no Service
+  Worker mirrors nothing: it fails closed rather than fall back to the shared
+  channel.
+- **Follower death is structural, not a heartbeat**: every tab holds a Web Lock
+  naming itself (`cipherbox-presence:<clientId>`) from before it greets the
+  leader until it dies, and the leader requests that same lock for each follower
+  it adopts. The browser grants that request at exactly the moment the tab
+  closes, crashes or is discarded, so the leader reclaims the follower's focus
+  entry, write handles and read streams on that turn — a frozen or bfcached tab,
+  which answers no probe, is never a false positive, and no crashed follower pins
+  a content version, and its key, for the rest of the leadership. The watch is
+  keyed on the client, so a tab that re-brokers a port keeps its handles.
 - **Failover**: the lock releases → some follower acquires it, spawns a fresh
   engine worker, and rehydrates from the durable seams (floors, op queue,
   staged bytes, snapshot cache — all origin-shared). Ops journal durably

--- a/blueprint/web-client.md
+++ b/blueprint/web-client.md
@@ -113,10 +113,14 @@ mechanism; the invariant — one engine writer per origin — is D4's):
   leader until it dies, and the leader requests that same lock for each follower
   it adopts. The browser grants that request at exactly the moment the tab
   closes, crashes or is discarded, so the leader reclaims the follower's focus
-  entry, write handles and read streams on that turn — a frozen or bfcached tab,
-  which answers no probe, is never a false positive, and no crashed follower pins
-  a content version, and its key, for the rest of the leadership. The watch is
-  keyed on the client, so a tab that re-brokers a port keeps its handles.
+  entry, write handles and read streams on that turn — a frozen tab, which
+  answers no probe, is never a false positive, and no crashed follower pins a
+  content version, and its key, for the rest of the leadership. The watch is
+  keyed on the client, so a tab that re-brokers a port keeps its handles. Holding
+  that lock costs the tab back/forward-cache eligibility — a browser does not
+  restore a page that held a Web Lock — and that is the intended trade: a back
+  navigation re-elects and re-brokers from a fresh page, which a restored mirror
+  would have had to do anyway.
 - **Failover**: the lock releases → some follower acquires it, spawns a fresh
   engine worker, and rehydrates from the durable seams (floors, op queue,
   staged bytes, snapshot cache — all origin-shared). Ops journal durably

--- a/packages/client/src/broadcast.ts
+++ b/packages/client/src/broadcast.ts
@@ -1,10 +1,10 @@
 /**
  * The cross-tab broadcast wire (blueprint/web-client.md "Followers are thin
- * mirrors"). The `BroadcastChannel` carries election, the port rendezvous, and
- * the one-way event stream — nothing else. Every value-bearing exchange, in both
- * directions, rides the follower's private port ([`PortRequest`](PortRequest)):
- * command arguments and upload chunks up, snapshot projections and file
- * plaintext down. The channel exists to rendezvous that port.
+ * mirrors"). The `BroadcastChannel` carries election and the port rendezvous —
+ * nothing else. Every exchange that names or measures vault content, in either
+ * direction, rides the follower's private port: command arguments and upload
+ * chunks up, snapshot projections, file plaintext and the engine event stream
+ * down. The channel exists to rendezvous that port.
  *
  * Security shape, structural not by discipline:
  * - The login **secret never crosses** — the keyless follower transport takes no
@@ -15,10 +15,10 @@
  *   on it is cloned into every same-origin context that opened it. The port
  *   moves upload buffers instead, so a chunk's plaintext leaves the follower's
  *   heap rather than being copied to every bystander.
- * - What a bystanding same-origin context still sees on the channel, stated
- *   exactly: no key bytes, no plaintext, no user-supplied names — but per-tab
- *   `clientId`s and the `EventDescriptor` stream, whose variants carry node ids,
- *   IPNS names, op ids and block counts. Same origin remains the trust boundary.
+ * - What a bystanding same-origin context sees on the channel, stated exactly:
+ *   per-tab `clientId`s, the leadership token and the port-host address. No key
+ *   bytes, no plaintext, no user-supplied names, and no node id, IPNS name,
+ *   routing key or block count. Same origin remains the trust boundary.
  */
 
 import type {
@@ -68,8 +68,6 @@ export type WireWrite =
 export type PortRequest =
   /** Names the sender, binding the port to a client the leader can reclaim it for. */
   | { type: 'cb:portHello'; clientId: string }
-  /** Answers `cb:portPing`; the leader's proof this tab is still alive. */
-  | { type: 'cb:portPong' }
   /** This tab's currently open folder (for the leader's focus-window union). */
   | { type: 'cb:portFocus'; node: Uint8Array | null }
   /** A correlated read; the leader answers with a matching `cb:portResult`. */
@@ -86,7 +84,9 @@ export type PortRequest =
  * `readStream` result is the plaintext buffer itself, transferred rather than
  * cloned; a snapshot carries the descriptor; a SIWE challenge the nonce string;
  * `openContentStream` and `beginWrite` the handle they minted; `commitWrite` the
- * durable op id.
+ * durable op id. Nothing here carries the leadership token but the adoption
+ * itself: the port is private to one leadership, so holding the far end *is* the
+ * proof the token stands in for on the channel.
  */
 export type PortResponse =
   /** The leader adopted this port, naming the leadership that answers on it. */
@@ -94,8 +94,12 @@ export type PortResponse =
   /** The leader is dropping this port. A closed `MessagePort` fires no event on
    * the far side, so without this a read would wait on a wire that is gone. */
   | { type: 'cb:portClosed' }
-  /** Liveness probe: a port that stops answering has lost the tab behind it. */
-  | { type: 'cb:portPing' }
+  /**
+   * One engine event, fanned out to every adopted port in emission order. It
+   * takes the port rather than the channel because its variants name nodes,
+   * IPNS names and routing keys and count a version's blocks.
+   */
+  | { type: 'cb:portEvent'; event: EventDescriptor }
   | {
       type: 'cb:portResult';
       requestId: number;
@@ -117,9 +121,8 @@ export type FollowerMessage =
  * Leader → follower messages. Every one carries the current leadership's
  * `token` — an unguessable per-leadership capability minted at election. Same
  * origin is the trust boundary, but any same-origin context can post a forged
- * `cb:event` or `cb:portHost`; followers reject any leader message whose token
- * isn't the active leader's, so a non-leader cannot inject an event or divert
- * the port rendezvous.
+ * `cb:portHost`; followers reject any leader message whose token isn't the
+ * active leader's, so a non-leader cannot divert the port rendezvous.
  */
 export type LeaderMessage =
   /** The current leader announces itself (on election and on demand). */
@@ -127,14 +130,22 @@ export type LeaderMessage =
   /** The current leader is stepping down (graceful teardown); re-arm the gate. */
   | { type: 'cb:leaderGone'; token: string }
   /** Where a follower may open its private port to this leadership. */
-  | { type: 'cb:portHost'; token: string; address: string }
-  /** One engine event, fanned out to every follower in emission order. */
-  | { type: 'cb:event'; token: string; event: EventDescriptor };
+  | { type: 'cb:portHost'; token: string; address: string };
 
 export type BroadcastMessage = FollowerMessage | LeaderMessage;
 
 /** The channel name pairing the broadcast wire with the `cipherbox-engine` lock. */
 export const BROADCAST_CHANNEL_NAME = 'cipherbox-engine';
+
+/**
+ * The Web Lock a tab holds for its whole life, so the leader can watch for its
+ * death: the browser releases it on close, crash or discard, and the leader's
+ * queued request for the same name is granted at exactly that moment. Namespaced
+ * away from the engine lock, which elects rather than reports presence.
+ */
+export function presenceLockName(clientId: string): string {
+  return `cipherbox-presence:${clientId}`;
+}
 
 /** A per-tab identity for command correlation. Injectable for deterministic tests. */
 export function newClientId(): string {

--- a/packages/client/src/broadcast.ts
+++ b/packages/client/src/broadcast.ts
@@ -119,10 +119,10 @@ export type FollowerMessage =
 
 /**
  * Leader → follower messages. Every one carries the current leadership's
- * `token` — an unguessable per-leadership capability minted at election. Same
- * origin is the trust boundary, but any same-origin context can post a forged
- * `cb:portHost`; followers reject any leader message whose token isn't the
- * active leader's, so a non-leader cannot divert the port rendezvous.
+ * `token` — an unguessable per-leadership capability minted at election, which
+ * followers check before acting on a beacon or a port rendezvous. The token is
+ * itself broadcast, so it bounds accidental and passive delivery, never a
+ * same-origin context that read the beacon: same origin is the trust boundary.
  */
 export type LeaderMessage =
   /** The current leader announces itself (on election and on demand). */
@@ -142,6 +142,8 @@ export const BROADCAST_CHANNEL_NAME = 'cipherbox-engine';
  * death: the browser releases it on close, crash or discard, and the leader's
  * queued request for the same name is granted at exactly that moment. Namespaced
  * away from the engine lock, which elects rather than reports presence.
+ * `navigator.locks.query()` reads these names origin-wide, so a name carries a
+ * `clientId` and nothing else — never a node id, a name or a count.
  */
 export function presenceLockName(clientId: string): string {
   return `cipherbox-presence:${clientId}`;

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -12,7 +12,7 @@ import {
   FakeChannelPort,
   FakeCourierNetwork,
   FakeEngineTransport,
-  FakeLockManager,
+  collect,
 } from './testkit.js';
 import type { EngineTransport } from './transport.js';
 import type { EventDescriptor, SnapshotDescriptor } from './worker/protocol.js';
@@ -20,28 +20,13 @@ import type { EventDescriptor, SnapshotDescriptor } from './worker/protocol.js';
 const after = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 const tick = (): Promise<void> => after(0);
 
-/**
- * One origin's `navigator.locks`, shared by every relay and follower on that
- * bus: presence watches only mean anything when leader and follower request the
- * same lock names against the same manager.
- */
-const locksOf = new WeakMap<FakeBus, FakeLockManager>();
-
-function locksFor(bus: FakeBus): FakeLockManager {
-  const existing = locksOf.get(bus);
-  if (existing) return existing;
-  const created = new FakeLockManager();
-  locksOf.set(bus, created);
-  return created;
-}
-
 function relayOn(
   bus: FakeBus,
   transport: EngineTransport,
   courier: PortCourier,
   options?: LeaderRelayOptions
 ): LeaderRelay {
-  return new LeaderRelay(bus.channel(), transport, courier, locksFor(bus), options);
+  return new LeaderRelay(bus.channel(), transport, courier, bus.locks, options);
 }
 
 function followerOn(
@@ -50,7 +35,7 @@ function followerOn(
   courier: PortCourier,
   options?: BroadcastTransportOptions
 ): BroadcastTransport {
-  return new BroadcastTransport(bus.channel(), clientId, courier, locksFor(bus), options);
+  return new BroadcastTransport(bus.channel(), clientId, courier, bus.locks, options);
 }
 
 /**
@@ -59,7 +44,7 @@ function followerOn(
  */
 function livePresence(bus: FakeBus, clientId: string): () => void {
   let release: (() => void) | null = null;
-  void locksFor(bus).request(
+  void bus.locks.request(
     presenceLockName(clientId),
     { mode: 'exclusive' },
     () =>
@@ -70,29 +55,15 @@ function livePresence(bus: FakeBus, clientId: string): () => void {
   return () => release?.();
 }
 
-/** Every byte and every string anywhere in a message, so a leak scan can see it. */
-function collect(message: unknown): { type: string; bytesHex: string; text: string } {
-  const bytes: number[] = [];
-  const strings: string[] = [];
-  const walk = (node: unknown): void => {
-    if (node instanceof ArrayBuffer) bytes.push(...new Uint8Array(node));
-    else if (ArrayBuffer.isView(node))
-      bytes.push(...new Uint8Array(node.buffer, node.byteOffset, node.byteLength));
-    else if (typeof node === 'string') strings.push(node);
-    else if (Array.isArray(node)) for (const entry of node) walk(entry);
-    else if (node && typeof node === 'object') for (const entry of Object.values(node)) walk(entry);
-  };
-  walk(message);
-  const type = (message as { type?: unknown })?.type;
-  return {
-    type: typeof type === 'string' ? type : '(untyped)',
-    bytesHex: hex(Uint8Array.from(bytes)),
-    text: strings.join(' '),
-  };
+function hex(bytes: Uint8Array): string {
+  let out = '';
+  for (const byte of bytes) out += byte.toString(16).padStart(2, '0');
+  return out;
 }
 
-function hex(bytes: Uint8Array): string {
-  return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+/** Settles a tab's presence request in failure, as a stolen lock does. */
+function losePresence(bus: FakeBus, clientId: string): void {
+  bus.locks.fail(presenceLockName(clientId), new Error('presence lock stolen'));
 }
 
 function wire(): {
@@ -124,12 +95,7 @@ describe('broadcast transport ↔ leader relay', () => {
     const leaderChannel = bus.channel();
     leaderChannel.addEventListener('message', (event) => posted.push(event.data));
     // A relay makes a leader "present" so start resolves.
-    new LeaderRelay(
-      leaderChannel,
-      new FakeEngineTransport(),
-      ports.courier('leader'),
-      locksFor(bus)
-    );
+    new LeaderRelay(leaderChannel, new FakeEngineTransport(), ports.courier('leader'), bus.locks);
     const follower = followerOn(bus, 'f', ports.courier('f'));
 
     // The keyless follower transport receives no secret at all — `start` has no
@@ -811,36 +777,107 @@ describe('broadcast transport ↔ leader relay', () => {
     await follower.pushChunk(handle, Uint8Array.of(7).buffer);
     await follower.commitWrite(handle);
 
+    // One of every variant, each field distinctive, so the scan below covers the
+    // whole union rather than the two variants that happen to carry bytes.
     const node = new Uint8Array(16).fill(0xa7);
     const ipnsName = Uint8Array.of(0xbe, 0xef, 0xca, 0xfe);
-    engine.emit({
-      kind: 'opProgress',
-      opId: 42n,
-      node,
-      phase: 'uploadProgress',
-      blocksConfirmed: 3,
-      blocksTotal: 9,
-      error: null,
-    });
-    engine.emit({ kind: 'withheldUpdateEscalation', ipnsName });
-    engine.emit({ kind: 'renewalFailed', routingKey: 'k51-routing-key', detail: 'no peers' });
+    const emitted: EventDescriptor[] = [
+      { kind: 'snapshotUpdated' },
+      { kind: 'stalenessChanged', staleness: 'reconciling' },
+      { kind: 'withheldUpdateEscalation', ipnsName },
+      { kind: 'deadLetter', opId: 606060n, reason: 'undecodable' },
+      { kind: 'attributableAbuse', description: 'abuse-707070' },
+      { kind: 'renewalFailed', routingKey: 'k51-routing-key', detail: 'no peers' },
+      {
+        kind: 'opProgress',
+        opId: 424242n,
+        node,
+        phase: 'uploadProgress',
+        blocksConfirmed: 30003,
+        blocksTotal: 90009,
+        error: null,
+      },
+    ];
+    for (const event of emitted) engine.emit(event);
     await tick();
 
     // The follower still sees the whole stream, in emission order.
-    expect(events.map((event) => event.kind)).toEqual([
-      'opProgress',
-      'withheldUpdateEscalation',
-      'renewalFailed',
+    expect(events).toEqual(emitted);
+
+    // The bystander saw no event, and not one value any variant carries — bytes,
+    // strings, ids and counts alike — so a descriptor field added later cannot
+    // ride the channel unnoticed.
+    const seen = overheard.map((message) => ({
+      type: (message as { type?: string }).type,
+      ...collect(message),
+    }));
+    expect([...new Set(seen.map((message) => message.type))].sort()).toEqual([
+      'cb:hello',
+      'cb:leader',
+      'cb:portHost',
+      'cb:portWanted',
     ]);
-    // The bystander saw no event, and none of the bytes or strings one carries:
-    // a descriptor field added later cannot ride the channel unnoticed.
-    const seen = overheard.map(collect);
-    expect(seen.map((message) => message.type)).not.toContain('cb:portEvent');
     const bytes = seen.map((message) => message.bytesHex).join('|');
-    expect(bytes).not.toContain(hex(node));
-    expect(bytes).not.toContain(hex(ipnsName));
     const text = seen.map((message) => message.text).join(' ');
-    expect(text).not.toContain('k51-routing-key');
+    for (const needle of [hex(node), hex(ipnsName)]) expect(bytes).not.toContain(needle);
+    for (const needle of [
+      'k51-routing-key',
+      'abuse-707070',
+      'undecodable',
+      'reconciling',
+      '424242',
+      '606060',
+      '30003',
+      '90009',
+    ]) {
+      expect(text).not.toContain(needle);
+    }
+  });
+
+  it('re-brokers when the leader drops its port, so the event stream resumes', async () => {
+    const bus = new FakeBus();
+    const ports = new FakeCourierNetwork();
+    const engine = new FakeEngineTransport();
+    relayOn(bus, engine, ports.courier('leader'));
+    const follower = followerOn(bus, 'f', ports.courier('f'));
+    const events: EventDescriptor[] = [];
+    follower.subscribe((event) => events.push(event));
+    await follower.snapshot(null);
+
+    // Any same-origin context can post an unauthenticated farewell; the leader
+    // reclaims the live tab's port under the same leadership. The event stream
+    // is one-way, so nothing else would re-dial: this tab would mirror no
+    // further event for the rest of that leadership.
+    bus.channel().postMessage({ type: 'cb:bye', clientId: 'f' });
+    await after(20);
+    engine.emit({ kind: 'snapshotUpdated' });
+    await after(20);
+
+    expect(events).toEqual([{ kind: 'snapshotUpdated' }]);
+  });
+
+  it('refuses to greet again once its presence lock is lost', async () => {
+    const bus = new FakeBus();
+    const ports = new FakeCourierNetwork();
+    const engine = new FakeEngineTransport();
+    relayOn(bus, engine, ports.courier('leader'));
+    const follower = followerOn(bus, 'f', ports.courier('f'), { portTimeoutMs: 50 });
+    await follower.snapshot(null);
+    const greetings = (): number =>
+      ports.messages.filter((m) => (m as { type?: string }).type === 'cb:portHello').length;
+    expect(greetings()).toBe(1);
+
+    // The tab's presence request settles in failure — a stolen lock, or a
+    // document the browser will not grant one to.
+    losePresence(bus, 'f');
+    await tick();
+
+    // Greeting on a name it no longer holds would invite the leader's watch to
+    // reclaim it live, over and over; it fails closed instead.
+    bus.channel().postMessage({ type: 'cb:bye', clientId: 'f' });
+    await after(20);
+    await expect(follower.snapshot(null)).rejects.toThrow();
+    expect(greetings()).toBe(1);
   });
 
   it('rejects a forged response bearing a wrong or absent leader token, and takes no event off the channel (P1-4)', async () => {

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -52,7 +52,12 @@ function livePresence(bus: FakeBus, clientId: string): () => void {
         release = resolve;
       })
   );
-  return () => release?.();
+  // Killing before the grant would stage no death at all, and the test asserting
+  // the reclaim would pass on a presence that was never held.
+  return () => {
+    if (!release) throw new Error(`presence for ${clientId} was never granted`);
+    release();
+  };
 }
 
 function hex(bytes: Uint8Array): string {
@@ -1386,8 +1391,8 @@ describe('leader relay follower presence', () => {
     });
     await tick();
 
-    // A discarded or bfcached tab runs no handler at all, so it could answer no
-    // probe — but it still holds its presence lock, so it is never a candidate.
+    // A frozen tab runs no handler at all, so it could answer no probe — but it
+    // still holds its presence lock, so it is never a candidate.
     await after(30);
 
     expect(engine.closedStreams).toEqual([]);

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -13,6 +13,7 @@ import {
   FakeCourierNetwork,
   FakeEngineTransport,
   collect,
+  hex,
 } from './testkit.js';
 import type { EngineTransport } from './transport.js';
 import type { EventDescriptor, SnapshotDescriptor } from './worker/protocol.js';
@@ -58,12 +59,6 @@ function livePresence(bus: FakeBus, clientId: string): () => void {
     if (!release) throw new Error(`presence for ${clientId} was never granted`);
     release();
   };
-}
-
-function hex(bytes: Uint8Array): string {
-  let out = '';
-  for (const byte of bytes) out += byte.toString(16).padStart(2, '0');
-  return out;
 }
 
 /** Settles a tab's presence request in failure, as a stolen lock does. */

--- a/packages/client/src/broadcastTransport.test.ts
+++ b/packages/client/src/broadcastTransport.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { BroadcastTransport } from './broadcastTransport.js';
+import { presenceLockName } from './broadcast.js';
+import { BroadcastTransport, type BroadcastTransportOptions } from './broadcastTransport.js';
 import { EngineRequestError } from './correlatedTransport.js';
 import { LeaderRelay, type LeaderRelayOptions } from './leaderRelay.js';
 import { unavailableCourier } from './portCourier.js';
@@ -11,11 +12,88 @@ import {
   FakeChannelPort,
   FakeCourierNetwork,
   FakeEngineTransport,
+  FakeLockManager,
 } from './testkit.js';
+import type { EngineTransport } from './transport.js';
 import type { EventDescriptor, SnapshotDescriptor } from './worker/protocol.js';
 
 const after = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 const tick = (): Promise<void> => after(0);
+
+/**
+ * One origin's `navigator.locks`, shared by every relay and follower on that
+ * bus: presence watches only mean anything when leader and follower request the
+ * same lock names against the same manager.
+ */
+const locksOf = new WeakMap<FakeBus, FakeLockManager>();
+
+function locksFor(bus: FakeBus): FakeLockManager {
+  const existing = locksOf.get(bus);
+  if (existing) return existing;
+  const created = new FakeLockManager();
+  locksOf.set(bus, created);
+  return created;
+}
+
+function relayOn(
+  bus: FakeBus,
+  transport: EngineTransport,
+  courier: PortCourier,
+  options?: LeaderRelayOptions
+): LeaderRelay {
+  return new LeaderRelay(bus.channel(), transport, courier, locksFor(bus), options);
+}
+
+function followerOn(
+  bus: FakeBus,
+  clientId: string,
+  courier: PortCourier,
+  options?: BroadcastTransportOptions
+): BroadcastTransport {
+  return new BroadcastTransport(bus.channel(), clientId, courier, locksFor(bus), options);
+}
+
+/**
+ * Holds a tab's presence lock as a live tab does — from before it greets until
+ * the returned `kill` stands in for the tab dying.
+ */
+function livePresence(bus: FakeBus, clientId: string): () => void {
+  let release: (() => void) | null = null;
+  void locksFor(bus).request(
+    presenceLockName(clientId),
+    { mode: 'exclusive' },
+    () =>
+      new Promise<void>((resolve) => {
+        release = resolve;
+      })
+  );
+  return () => release?.();
+}
+
+/** Every byte and every string anywhere in a message, so a leak scan can see it. */
+function collect(message: unknown): { type: string; bytesHex: string; text: string } {
+  const bytes: number[] = [];
+  const strings: string[] = [];
+  const walk = (node: unknown): void => {
+    if (node instanceof ArrayBuffer) bytes.push(...new Uint8Array(node));
+    else if (ArrayBuffer.isView(node))
+      bytes.push(...new Uint8Array(node.buffer, node.byteOffset, node.byteLength));
+    else if (typeof node === 'string') strings.push(node);
+    else if (Array.isArray(node)) for (const entry of node) walk(entry);
+    else if (node && typeof node === 'object') for (const entry of Object.values(node)) walk(entry);
+  };
+  walk(message);
+  const type = (message as { type?: unknown })?.type;
+  return {
+    type: typeof type === 'string' ? type : '(untyped)',
+    bytesHex: hex(Uint8Array.from(bytes)),
+    text: strings.join(' '),
+  };
+}
+
+function hex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
 
 function wire(): {
   bus: FakeBus;
@@ -27,8 +105,8 @@ function wire(): {
   const bus = new FakeBus();
   const ports = new FakeCourierNetwork();
   const engine = new FakeEngineTransport();
-  const relay = new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
-  const follower = new BroadcastTransport(bus.channel(), 'follower-1', ports.courier('follower-1'));
+  const relay = relayOn(bus, engine, ports.courier('leader'));
+  const follower = followerOn(bus, 'follower-1', ports.courier('follower-1'));
   return { bus, ports, engine, relay, follower };
 }
 
@@ -46,8 +124,13 @@ describe('broadcast transport ↔ leader relay', () => {
     const leaderChannel = bus.channel();
     leaderChannel.addEventListener('message', (event) => posted.push(event.data));
     // A relay makes a leader "present" so start resolves.
-    new LeaderRelay(leaderChannel, new FakeEngineTransport(), ports.courier('leader'));
-    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
+    new LeaderRelay(
+      leaderChannel,
+      new FakeEngineTransport(),
+      ports.courier('leader'),
+      locksFor(bus)
+    );
+    const follower = followerOn(bus, 'f', ports.courier('f'));
 
     // The keyless follower transport receives no secret at all — `start` has no
     // secret parameter; it resolves once a leader beacon arrives.
@@ -72,14 +155,14 @@ describe('broadcast transport ↔ leader relay', () => {
     await engine.start(sentinel.buffer.slice(0));
 
     const ports = new FakeCourierNetwork();
-    new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
+    relayOn(bus, engine, ports.courier('leader'));
 
     // Capture both leader→follower wires: the channel (events) and the port.
     const leaderPosts: unknown[] = [];
     const spy = bus.channel();
     spy.addEventListener('message', (event) => leaderPosts.push(event.data));
 
-    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
+    const follower = followerOn(bus, 'f', ports.courier('f'));
     await follower.start();
 
     // A command whose engine handling rejects: the relay forwards the failure as
@@ -146,14 +229,14 @@ describe('broadcast transport ↔ leader relay', () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
     const engine = new FakeEngineTransport();
-    new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
+    relayOn(bus, engine, ports.courier('leader'));
 
     // A same-origin context that opened the engine channel and does nothing else.
     const observed: unknown[] = [];
     const eavesdropper = bus.channel();
     eavesdropper.addEventListener('message', (event) => observed.push(event.data));
 
-    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
+    const follower = followerOn(bus, 'f', ports.courier('f'));
     const plaintext = Uint8Array.from({ length: 64 }, (_, i) => (i * 29 + 13) & 0xff);
     const handle = await follower.beginWrite(
       { parent: new Uint8Array(16), name: 'payslip.pdf' },
@@ -327,9 +410,9 @@ describe('broadcast transport ↔ leader relay', () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
     const engine = new FakeEngineTransport();
-    new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
-    const owner = new BroadcastTransport(bus.channel(), 'owner', ports.courier('owner'));
-    const other = new BroadcastTransport(bus.channel(), 'other', ports.courier('other'));
+    relayOn(bus, engine, ports.courier('leader'));
+    const owner = followerOn(bus, 'owner', ports.courier('owner'));
+    const other = followerOn(bus, 'other', ports.courier('other'));
     await owner.start();
     await other.start();
 
@@ -346,8 +429,8 @@ describe('broadcast transport ↔ leader relay', () => {
     const ports = new FakeCourierNetwork();
     const engineA = new FakeEngineTransport();
     engineA.respondReadStream = () => new Promise(() => undefined); // leader A never answers
-    const relayA = new LeaderRelay(bus.channel(), engineA, ports.courier('leaderA'));
-    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
+    const relayA = relayOn(bus, engineA, ports.courier('leaderA'));
+    const follower = followerOn(bus, 'f', ports.courier('f'));
     await follower.start();
 
     const handle = await follower.openContentStream(new Uint8Array(16));
@@ -359,7 +442,7 @@ describe('broadcast transport ↔ leader relay', () => {
     // The next leader serves the retry, so the swap costs a retry, never a hang.
     const engineB = new FakeEngineTransport();
     engineB.respondReadStream = () => Promise.resolve(new Uint8Array([1, 2]).buffer);
-    new LeaderRelay(bus.channel(), engineB, ports.courier('leaderB'));
+    relayOn(bus, engineB, ports.courier('leaderB'));
     const reopened = await follower.openContentStream(new Uint8Array(16));
     const retried = await follower.readStream(reopened, 0, 2);
     expect([...new Uint8Array(retried)]).toEqual([1, 2]);
@@ -390,14 +473,14 @@ describe('broadcast transport ↔ leader relay', () => {
     engine.respondReadStream = (_handle, offset, length) =>
       Promise.resolve(plaintext.slice(offset, offset + length).buffer);
     engine.respondSnapshot = () => Promise.resolve(emptySnapshot(new Uint8Array(16).fill(8)));
-    new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
+    relayOn(bus, engine, ports.courier('leader'));
 
     // A same-origin context that opened the engine channel and does nothing else.
     const observed: unknown[] = [];
     const eavesdropper = bus.channel();
     eavesdropper.addEventListener('message', (event) => observed.push(event.data));
 
-    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
+    const follower = followerOn(bus, 'f', ports.courier('f'));
     await follower.snapshot(new Uint8Array(16));
     const handle = await follower.openContentStream(new Uint8Array(16).fill(6));
     for (let offset = 0; offset < 96; offset += 32) {
@@ -426,8 +509,8 @@ describe('broadcast transport ↔ leader relay', () => {
     const engine = new FakeEngineTransport();
     engine.respond = () => new Promise(() => undefined); // the real leader never answers
     engine.respondSnapshot = () => Promise.resolve(emptySnapshot(new Uint8Array(16).fill(2)));
-    new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
-    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'), {
+    relayOn(bus, engine, ports.courier('leader'));
+    const follower = followerOn(bus, 'f', ports.courier('f'), {
       portTimeoutMs: 40,
     });
     await follower.start();
@@ -475,8 +558,8 @@ describe('broadcast transport ↔ leader relay', () => {
   it('adopts a port greeting with the real broadcast token, whoever sent it', async () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
-    new LeaderRelay(bus.channel(), new FakeEngineTransport(), ports.courier('leader'));
-    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'), {
+    relayOn(bus, new FakeEngineTransport(), ports.courier('leader'));
+    const follower = followerOn(bus, 'f', ports.courier('f'), {
       portTimeoutMs: 40,
     });
 
@@ -512,8 +595,8 @@ describe('broadcast transport ↔ leader relay', () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
     const engine = new FakeEngineTransport();
-    new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
-    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
+    relayOn(bus, engine, ports.courier('leader'));
+    const follower = followerOn(bus, 'f', ports.courier('f'));
     await follower.snapshot(null); // brokers and adopts the port
 
     engine.respondSnapshot = () => new Promise(() => undefined); // never answers
@@ -533,8 +616,8 @@ describe('broadcast transport ↔ leader relay', () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
     const engine = new FakeEngineTransport();
-    new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
-    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
+    relayOn(bus, engine, ports.courier('leader'));
+    const follower = followerOn(bus, 'f', ports.courier('f'));
     await follower.snapshot(null); // brokers and adopts the port
 
     const plaintext = Uint8Array.of(1, 2, 3, 4);
@@ -561,7 +644,7 @@ describe('broadcast transport ↔ leader relay', () => {
   it('reclaims a dialed port that never named the follower behind it', async () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
-    new LeaderRelay(bus.channel(), new FakeEngineTransport(), ports.courier('leader'), {
+    relayOn(bus, new FakeEngineTransport(), ports.courier('leader'), {
       namingTimeoutMs: 5,
     });
 
@@ -577,8 +660,8 @@ describe('broadcast transport ↔ leader relay', () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
     const engine = new FakeEngineTransport();
-    new LeaderRelay(bus.channel(), engine, unavailableCourier);
-    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'), {
+    relayOn(bus, engine, unavailableCourier);
+    const follower = followerOn(bus, 'f', ports.courier('f'), {
       portTimeoutMs: 20,
     });
     await follower.start();
@@ -591,13 +674,13 @@ describe('broadcast transport ↔ leader relay', () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
     const engine = new FakeEngineTransport();
-    new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
-    const first = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
+    relayOn(bus, engine, ports.courier('leader'));
+    const first = followerOn(bus, 'f', ports.courier('f'));
     await first.snapshot(null);
     first.close(); // posts `cb:bye`, so the leader reclaims that port
     await tick();
 
-    const second = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
+    const second = followerOn(bus, 'f', ports.courier('f'));
     await expect(second.snapshot(null)).resolves.toMatchObject({ staleness: 'fresh' });
     expect(engine.snapshots).toHaveLength(2);
   });
@@ -607,8 +690,8 @@ describe('broadcast transport ↔ leader relay', () => {
     const ports = new FakeCourierNetwork();
     const engineA = new FakeEngineTransport();
     engineA.respondSnapshot = () => new Promise(() => undefined); // leader A never answers
-    const relayA = new LeaderRelay(bus.channel(), engineA, ports.courier('leaderA'));
-    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
+    const relayA = relayOn(bus, engineA, ports.courier('leaderA'));
+    const follower = followerOn(bus, 'f', ports.courier('f'));
     await follower.start();
 
     const inFlight = follower.snapshot(new Uint8Array(16));
@@ -619,7 +702,7 @@ describe('broadcast transport ↔ leader relay', () => {
     // A read issued with no leader parks, then resolves against the next leader.
     const queued = follower.snapshot(new Uint8Array(16).fill(4));
     const engineB = new FakeEngineTransport();
-    new LeaderRelay(bus.channel(), engineB, ports.courier('leaderB'));
+    relayOn(bus, engineB, ports.courier('leaderB'));
     await expect(queued).resolves.toMatchObject({ staleness: 'fresh' });
     expect(engineB.snapshots).toHaveLength(1);
   });
@@ -642,7 +725,9 @@ describe('broadcast transport ↔ leader relay', () => {
       },
     };
 
-    const relay = new LeaderRelay(bus.channel(), engine, courier);
+    const relay = relayOn(bus, engine, courier);
+    livePresence(bus, 'f');
+    await tick();
     deliver!(far);
     far.receive({ type: 'cb:portHello', clientId: 'f' }); // named, so it outlives the naming timeout
     await tick();
@@ -660,8 +745,8 @@ describe('broadcast transport ↔ leader relay', () => {
     const ports = new FakeCourierNetwork();
     const engineA = new FakeEngineTransport();
     engineA.respond = () => new Promise(() => undefined); // leader A never answers
-    const relayA = new LeaderRelay(bus.channel(), engineA, ports.courier('leaderA'));
-    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
+    const relayA = relayOn(bus, engineA, ports.courier('leaderA'));
+    const follower = followerOn(bus, 'f', ports.courier('f'));
     await follower.start(); // leader A present
 
     const inFlight = follower.command({ kind: 'manualRefresh' }, []);
@@ -683,18 +768,88 @@ describe('broadcast transport ↔ leader relay', () => {
 
     // A fresh leader is elected → the queued command resolves against it.
     const engineB = new FakeEngineTransport();
-    new LeaderRelay(bus.channel(), engineB, ports.courier('leaderB'));
+    relayOn(bus, engineB, ports.courier('leaderB'));
     await queued;
     expect(engineB.commands.map((c) => c.kind)).toEqual(['manualRefresh']);
   });
 
-  it('rejects a forged response/event bearing a wrong or absent leader token (P1-4)', async () => {
+  it('holds its presence before it greets, so the leader never watches a free name', async () => {
+    const bus = new FakeBus();
+    const ports = new FakeCourierNetwork();
+    const engine = new FakeEngineTransport();
+    // Something else holds this tab's presence name, so its grant is delayed —
+    // as a contended or merely slow grant would be in a real browser.
+    const squatter = livePresence(bus, 'f');
+    await tick();
+    relayOn(bus, engine, ports.courier('leader'));
+    const follower = followerOn(bus, 'f', ports.courier('f'), { portTimeoutMs: 200 });
+
+    const read = follower.snapshot(null);
+    await after(20);
+    // Greeting here would have the leader watch a name this tab does not hold,
+    // and be granted at once against a live tab.
+    expect(engine.snapshots).toEqual([]);
+
+    squatter();
+    await expect(read).resolves.toMatchObject({ staleness: 'fresh' });
+  });
+
+  it('fans engine events over the private port, putting no descriptor on the channel', async () => {
+    const bus = new FakeBus();
+    const ports = new FakeCourierNetwork();
+    const engine = new FakeEngineTransport();
+    relayOn(bus, engine, ports.courier('leader'));
+    // A same-origin context that drives no engine and only opened the channel.
+    const overheard: unknown[] = [];
+    bus.channel().addEventListener('message', (event) => overheard.push(event.data));
+
+    const follower = followerOn(bus, 'f', ports.courier('f'));
+    const events: EventDescriptor[] = [];
+    follower.subscribe((event) => events.push(event));
+    // A full write cycle, so the channel sees every rendezvous a real one does.
+    const handle = await follower.beginWrite({ node: new Uint8Array(16).fill(1) }, 1);
+    await follower.pushChunk(handle, Uint8Array.of(7).buffer);
+    await follower.commitWrite(handle);
+
+    const node = new Uint8Array(16).fill(0xa7);
+    const ipnsName = Uint8Array.of(0xbe, 0xef, 0xca, 0xfe);
+    engine.emit({
+      kind: 'opProgress',
+      opId: 42n,
+      node,
+      phase: 'uploadProgress',
+      blocksConfirmed: 3,
+      blocksTotal: 9,
+      error: null,
+    });
+    engine.emit({ kind: 'withheldUpdateEscalation', ipnsName });
+    engine.emit({ kind: 'renewalFailed', routingKey: 'k51-routing-key', detail: 'no peers' });
+    await tick();
+
+    // The follower still sees the whole stream, in emission order.
+    expect(events.map((event) => event.kind)).toEqual([
+      'opProgress',
+      'withheldUpdateEscalation',
+      'renewalFailed',
+    ]);
+    // The bystander saw no event, and none of the bytes or strings one carries:
+    // a descriptor field added later cannot ride the channel unnoticed.
+    const seen = overheard.map(collect);
+    expect(seen.map((message) => message.type)).not.toContain('cb:portEvent');
+    const bytes = seen.map((message) => message.bytesHex).join('|');
+    expect(bytes).not.toContain(hex(node));
+    expect(bytes).not.toContain(hex(ipnsName));
+    const text = seen.map((message) => message.text).join(' ');
+    expect(text).not.toContain('k51-routing-key');
+  });
+
+  it('rejects a forged response bearing a wrong or absent leader token, and takes no event off the channel (P1-4)', async () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
     const engine = new FakeEngineTransport();
     engine.respond = () => new Promise(() => undefined); // the real leader never answers
-    new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
-    const follower = new BroadcastTransport(bus.channel(), 'f', ports.courier('f'));
+    relayOn(bus, engine, ports.courier('leader'));
+    const follower = followerOn(bus, 'f', ports.courier('f'));
     await follower.start();
 
     const pending = follower.command({ kind: 'manualRefresh' }, []);
@@ -717,7 +872,8 @@ describe('broadcast transport ↔ leader relay', () => {
     });
     attacker.postMessage({ type: 'cb:response', clientId: 'f', requestId: 1, ok: true });
 
-    // A forged event with a wrong token must not reach subscribers either.
+    // The channel is not an event wire at all: an event posted on it reaches no
+    // subscriber, forged token or not.
     const events: EventDescriptor[] = [];
     follower.subscribe((event) => events.push(event));
     attacker.postMessage({
@@ -744,12 +900,16 @@ async function portBench(options: LeaderRelayOptions = {}): Promise<{
   relay: LeaderRelay;
   /** The relay's end: `receive` injects a follower step, `posted` records replies. */
   leaderPort: FakeChannelPort;
+  /** Ends the tab behind that port, releasing the presence lock it holds. */
+  kill: () => void;
 }> {
   const bus = new FakeBus();
   const ports = new FakeCourierNetwork();
   const engine = new FakeEngineTransport();
-  const relay = new LeaderRelay(bus.channel(), engine, ports.courier('leader'), options);
-  return { bus, ports, engine, relay, leaderPort: await dialLeader(ports, 'f1') };
+  const relay = relayOn(bus, engine, ports.courier('leader'), options);
+  const kill = livePresence(bus, 'f1');
+  await tick(); // the tab holds its presence before it greets
+  return { bus, ports, engine, relay, leaderPort: await dialLeader(ports, 'f1'), kill };
 }
 
 /** Dials the relay a fresh named port, returning the relay's end of it. */
@@ -775,7 +935,7 @@ describe('leader relay write handles', () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
     const engine = new FakeEngineTransport();
-    const relay = new LeaderRelay(bus.channel(), engine, ports.courier('leader'));
+    const relay = relayOn(bus, engine, ports.courier('leader'));
     return { bus, ports, engine, relay };
   }
 
@@ -784,7 +944,7 @@ describe('leader relay write handles', () => {
 
   it('applies pipelined chunks for one handle in send order', async () => {
     const { bus, ports, engine } = bench();
-    const follower = new BroadcastTransport(bus.channel(), 'f1', ports.courier('f1'));
+    const follower = followerOn(bus, 'f1', ports.courier('f1'));
     const applied: number[] = [];
     // Later chunks settle faster: unserialized they would overtake earlier ones,
     // scrambling the plaintext while every integrity check still passes.
@@ -803,7 +963,7 @@ describe('leader relay write handles', () => {
 
   it('keeps distinct handles concurrent', async () => {
     const { bus, ports, engine } = bench();
-    const follower = new BroadcastTransport(bus.channel(), 'f1', ports.courier('f1'));
+    const follower = followerOn(bus, 'f1', ports.courier('f1'));
     let releaseFirst!: () => void;
     engine.pushChunk = (handle) =>
       handle === 1n ? new Promise<void>((resolve) => (releaseFirst = resolve)) : Promise.resolve();
@@ -826,8 +986,8 @@ describe('leader relay write handles', () => {
 
   it('rejects a write step against a handle the sender does not own', async () => {
     const { bus, ports, engine } = bench();
-    const owner = new BroadcastTransport(bus.channel(), 'owner', ports.courier('owner'));
-    const other = new BroadcastTransport(bus.channel(), 'other', ports.courier('other'));
+    const owner = followerOn(bus, 'owner', ports.courier('owner'));
+    const other = followerOn(bus, 'other', ports.courier('other'));
     const handle = await owner.beginWrite({ node: node(4) }, 4);
 
     await expect(other.pushChunk(handle, chunk(9))).rejects.toMatchObject({
@@ -845,8 +1005,8 @@ describe('leader relay write handles', () => {
 
   it('aborts a departing client handles and leaves the other client alone', async () => {
     const { bus, ports, engine } = bench();
-    const leaving = new BroadcastTransport(bus.channel(), 'leaving', ports.courier('leaving'));
-    const staying = new BroadcastTransport(bus.channel(), 'staying', ports.courier('staying'));
+    const leaving = followerOn(bus, 'leaving', ports.courier('leaving'));
+    const staying = followerOn(bus, 'staying', ports.courier('staying'));
     engine.writeHandle = 1n;
     const orphan = await leaving.beginWrite({ node: node(1) }, 4);
     engine.writeHandle = 2n;
@@ -862,7 +1022,7 @@ describe('leader relay write handles', () => {
 
   it('keeps serving a live follower after a cb:bye it never sent', async () => {
     const { bus, ports, engine } = bench();
-    const follower = new BroadcastTransport(bus.channel(), 'f1', ports.courier('f1'));
+    const follower = followerOn(bus, 'f1', ports.courier('f1'));
     await follower.beginWrite({ node: node(1) }, 4);
 
     // Any same-origin context can forge this. It costs the tab its open handles,
@@ -916,8 +1076,8 @@ describe('leader relay write handles', () => {
     });
     await tick();
 
-    // The same live tab re-brokers — its port timed out, or the sweep took it —
-    // so neither handle can ever reach the entry it was asked for.
+    // The same live tab re-brokers, so neither handle can ever reach the entry
+    // it was asked for.
     const rebrokered = await dialLeader(ports, 'f1');
     await tick();
     mintWrite(7n);
@@ -1137,7 +1297,7 @@ describe('leader relay write handles', () => {
 
   it('releases every open handle when the leader steps down', async () => {
     const { bus, ports, engine, relay } = bench();
-    const follower = new BroadcastTransport(bus.channel(), 'f1', ports.courier('f1'));
+    const follower = followerOn(bus, 'f1', ports.courier('f1'));
     const handle = await follower.beginWrite({ node: node(5) }, 4);
 
     relay.close();
@@ -1147,13 +1307,11 @@ describe('leader relay write handles', () => {
   });
 });
 
-describe('leader relay follower liveness', () => {
+describe('leader relay follower presence', () => {
   const node = (fill: number): Uint8Array => new Uint8Array(16).fill(fill);
-  // Two sweeps' worth of silence at `livenessMisses: 1`.
-  const REAPED = 30;
 
   it('reclaims the handles and port of a follower that died without a cb:bye', async () => {
-    const { engine, leaderPort } = await portBench({ livenessIntervalMs: 5, livenessMisses: 1 });
+    const { engine, leaderPort, kill } = await portBench();
     engine.writeHandle = 3n;
     engine.streamHandle = 4n;
     leaderPort.receive({
@@ -1168,19 +1326,21 @@ describe('leader relay follower liveness', () => {
     });
     await tick();
 
-    // The tab is gone: it answers no probe and sends no farewell.
-    await after(REAPED);
+    // The tab is gone: no farewell, just the browser releasing its presence lock.
+    kill();
+    await tick();
 
-    // The pinned content version — and the key resident with it — is released,
-    // as is the write handle's staging reservation and the port itself.
+    // Reclaimed on the turn the lock released — no probe interval to wait out.
+    // The pinned content version, and the key resident with it, is released, as
+    // is the write handle's staging reservation and the port itself.
     expect(engine.closedStreams).toEqual([4n]);
     expect(engine.aborts).toEqual([3n]);
     expect(replies(leaderPort, 'cb:portClosed')).toHaveLength(1);
     expect(leaderPort.closed).toBe(true);
   });
 
-  it('never reclaims a live but quiet follower that answers the probe', async () => {
-    const { engine, leaderPort } = await portBench({ livenessIntervalMs: 5, livenessMisses: 1 });
+  it('never reclaims a live but frozen follower that answers nothing at all', async () => {
+    const { engine, leaderPort } = await portBench();
     engine.streamHandle = 4n;
     leaderPort.receive({
       type: 'cb:portStream',
@@ -1189,14 +1349,9 @@ describe('leader relay follower liveness', () => {
     });
     await tick();
 
-    // A tab mid-playback issues no new request for a while, but answers every
-    // probe from its message handler — tearing it down would drop the playback.
-    leaderPort.peer!.addEventListener('message', (event) => {
-      if ((event.data as { type?: string }).type === 'cb:portPing') {
-        leaderPort.receive({ type: 'cb:portPong' });
-      }
-    });
-    await after(REAPED);
+    // A discarded or bfcached tab runs no handler at all, so it could answer no
+    // probe — but it still holds its presence lock, so it is never a candidate.
+    await after(30);
 
     expect(engine.closedStreams).toEqual([]);
     expect(leaderPort.closed).toBe(false);
@@ -1210,30 +1365,71 @@ describe('leader relay follower liveness', () => {
     expect(engine.reads).toEqual([{ handle: 4n, offset: 0, length: 8 }]);
   });
 
-  it('never probes a port that has not named the follower behind it', async () => {
+  it('keeps the handles of a follower that re-brokers while its tab lives', async () => {
+    const { engine, ports, leaderPort } = await portBench();
+    engine.streamHandle = 4n;
+    leaderPort.receive({
+      type: 'cb:portStream',
+      requestId: 1,
+      stream: { kind: 'openContentStream', node: node(2) },
+    });
+    await tick();
+
+    // The same tab dials a fresh port; its presence never lapsed, so the watch
+    // stands and the stream it opened is still its own.
+    const rebrokered = await dialLeader(ports, 'f1');
+    await tick();
+    rebrokered.receive({
+      type: 'cb:portStream',
+      requestId: 2,
+      stream: { kind: 'readStream', handle: 4n, offset: 0, length: 8 },
+    });
+    await tick();
+
+    expect(engine.closedStreams).toEqual([]);
+    expect(engine.reads).toEqual([{ handle: 4n, offset: 0, length: 8 }]);
+  });
+
+  it('reclaims a follower that greets while holding no presence at all', async () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
-    // Far beyond the wait, so only the sweep can act on this port: a naming
-    // timeout firing mid-assertion would close it and read as a sweep failure.
-    new LeaderRelay(bus.channel(), new FakeEngineTransport(), ports.courier('leader'), {
-      namingTimeoutMs: 10_000,
-      livenessIntervalMs: 5,
-      livenessMisses: 1,
-    });
+    const engine = new FakeEngineTransport();
+    relayOn(bus, engine, ports.courier('leader'));
 
-    // The naming timeout owns an unnamed port; the sweep must leave it alone
-    // rather than reclaim it under a `clientId` it does not have.
+    // Nothing holds `ghost`'s presence name, so the leader's watch is granted at
+    // once: a greeting is only as good as the lock behind it.
+    const ghost = await dialLeader(ports, 'ghost');
+    await tick();
+
+    expect(replies(ghost, 'cb:portClosed')).toHaveLength(1);
+    expect(ghost.closed).toBe(true);
+  });
+
+  it('leaves an unnamed port to the naming timeout, watching no presence for it', async () => {
+    const bus = new FakeBus();
+    const ports = new FakeCourierNetwork();
+    relayOn(bus, new FakeEngineTransport(), ports.courier('leader'), { namingTimeoutMs: 10_000 });
+
+    // A port that named no client cannot be watched under a `clientId` it does
+    // not have; the naming timeout owns it instead.
     const squatter = (await ports.courier('squatter').connect('leader')) as FakeChannelPort;
-    await after(REAPED);
+    await after(30);
     expect(squatter.peer!.posted).toEqual([]);
     expect(squatter.peer!.closed).toBe(false);
   });
 
-  it('stops probing once the leader steps down', async () => {
-    const { relay, leaderPort } = await portBench({ livenessIntervalMs: 5, livenessMisses: 4 });
+  it('stops watching a follower once the leader steps down', async () => {
+    const { engine, relay, kill } = await portBench();
+    engine.streamHandle = 4n;
     relay.close();
-    await after(REAPED);
+    await tick();
+    const closedOnStepDown = [...engine.closedStreams];
 
-    expect(replies(leaderPort, 'cb:portPing')).toEqual([]);
+    // The tab dies after the step-down; a retired watch must not fire against a
+    // relay that is gone.
+    kill();
+    await after(30);
+
+    expect(engine.closedStreams).toEqual(closedOnStepDown);
   });
 });

--- a/packages/client/src/broadcastTransport.ts
+++ b/packages/client/src/broadcastTransport.ts
@@ -30,6 +30,7 @@
 import {
   presenceLockName,
   type BroadcastChannelLike,
+  type FollowerMessage,
   type LeaderMessage,
   type PortRequest,
   type PortResponse,
@@ -38,6 +39,7 @@ import {
   type WireWrite,
 } from './broadcast.js';
 import { CorrelatedTransport } from './correlatedTransport.js';
+import { asError } from './errorMessage.js';
 import type { LockManagerLike } from './leadership.js';
 import type { MessagePortLike, PortCourier } from './portRelay.js';
 import type {
@@ -88,11 +90,12 @@ export class BroadcastTransport extends CorrelatedTransport {
   private readonly portTimeoutMs: number;
   private readonly onLeadershipChange: () => void;
 
-  // Settles once this tab holds its presence lock; the greeting waits on it, so
-  // the leader's death watch can never be granted against a live tab.
   private readonly presenceHeld: Promise<void>;
   private readonly presenceRequest = new AbortController();
   private releasePresence: (() => void) | null = null;
+  // Set if the presence request ever settles in failure — including a lock
+  // stolen out from under a live tab, which the browser reports here.
+  private presenceLost: Error | null = null;
 
   private readonly onMessage = (event: MessageEvent): void => this.receive(event.data);
 
@@ -110,13 +113,10 @@ export class BroadcastTransport extends CorrelatedTransport {
     this.armLeaderReady();
     this.channel.addEventListener('message', this.onMessage);
     // Announce ourselves so a live leader replies with a `leader` beacon.
-    this.channel.postMessage({ type: 'cb:hello', clientId: this.clientId });
+    this.post({ type: 'cb:hello', clientId: this.clientId });
   }
 
-  /**
-   * Takes the lock naming this tab and holds it until `close()` or until the
-   * browser releases it on the tab's death — the leader's death signal.
-   */
+  /** Takes the lock naming this tab; the browser releases it when the tab dies. */
   private holdPresence(locks: LockManagerLike): Promise<void> {
     const held = new Promise<void>((resolve, reject) => {
       void locks
@@ -130,7 +130,10 @@ export class BroadcastTransport extends CorrelatedTransport {
             });
           }
         )
-        .catch((error: unknown) => reject(asError(error)));
+        .catch((error: unknown) => {
+          this.presenceLost = asError(error);
+          reject(this.presenceLost);
+        });
     });
     // A broker re-observes this rejection; swallow the unobserved-rejection warn.
     held.catch(() => undefined);
@@ -235,9 +238,8 @@ export class BroadcastTransport extends CorrelatedTransport {
     // in force when a read first asked for a port.
     const generation = this.portGeneration;
     if (this.closed) throw retryError();
-    // Before the greeting, never after: a leader that watched this tab's
-    // presence name while it held nothing would be granted at once and reclaim
-    // a live tab.
+    // Before the greeting, never after: a leader watching a presence name this
+    // tab does not hold is granted at once and reclaims a live tab.
     await this.awaitPresence();
     const port = await this.courier.connect(await this.awaitHost());
     const release = this.bindPort(port);
@@ -279,6 +281,9 @@ export class BroadcastTransport extends CorrelatedTransport {
       if (message.type === 'cb:portClosed') {
         this.dropPort(retryError());
         this.rejectPending(retryError());
+        // The event stream is one-way, so nothing else would re-dial: without
+        // this a dropped port silently ends it until the next request.
+        void this.ensurePort().catch(() => undefined);
         return;
       }
       if (message.type !== 'cb:portResult') return;
@@ -294,8 +299,11 @@ export class BroadcastTransport extends CorrelatedTransport {
     };
   }
 
-  /** This tab's presence lock, under the brokerage timeout like every step. */
+  /** This tab's presence, under the brokerage timeout like every other step. */
   private awaitPresence(): Promise<void> {
+    // A presence that was held and then lost must not latch resolved: greeting
+    // on a name this tab no longer holds invites the leader to reclaim it live.
+    if (this.presenceLost) return Promise.reject(this.presenceLost);
     return this.awaitBrokerage<void>('this tab holds no presence lock', (settle) => {
       void this.presenceHeld.then(settle, (error: unknown) =>
         this.abortBrokerage?.(asError(error))
@@ -307,7 +315,7 @@ export class BroadcastTransport extends CorrelatedTransport {
   private awaitHost(): Promise<string> {
     return this.awaitBrokerage<string>('the leader published no port host', (settle) => {
       this.settleHost = settle;
-      this.channel.postMessage({ type: 'cb:portWanted', clientId: this.clientId });
+      this.post({ type: 'cb:portWanted', clientId: this.clientId });
     });
   }
 
@@ -379,17 +387,21 @@ export class BroadcastTransport extends CorrelatedTransport {
     this.rejectLeaderReady(error);
     this.fail(error);
     this.dropPort(error);
-    // Held → released; still queued → withdrawn. Either way this tab stops
-    // claiming a presence the leader would go on watching.
+    // Held → released; still queued → withdrawn.
     this.releasePresence?.();
     this.releasePresence = null;
     this.presenceRequest.abort();
     try {
-      this.channel.postMessage({ type: 'cb:bye', clientId: this.clientId });
+      this.post({ type: 'cb:bye', clientId: this.clientId });
     } catch {
       // The channel may already be torn down; teardown proceeds regardless.
     }
     this.channel.removeEventListener('message', this.onMessage);
+  }
+
+  /** Every follower→leader channel post, so the union is a constraint, not a note. */
+  private post(message: FollowerMessage): void {
+    this.channel.postMessage(message);
   }
 
   private armLeaderReady(): void {
@@ -455,8 +467,4 @@ export class BroadcastTransport extends CorrelatedTransport {
 
 function retryError(): Error {
   return new Error('leader changed; retry');
-}
-
-function asError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/client/src/broadcastTransport.ts
+++ b/packages/client/src/broadcastTransport.ts
@@ -14,15 +14,21 @@
  * rendezvous, and lets the follower reject forgeries from a non-leader
  * same-origin context.
  *
- * Every value-bearing exchange takes a different wire: the channel only
- * rendezvouses a private `MessagePort` this tab dials to the leader, and command
- * arguments, upload chunks, snapshots and plaintext windows all cross it — so a
- * same-origin context that merely opened the channel is no longer a receiver.
- * The rendezvous is as authenticated as the `cb:leader` beacon and no more: same
- * origin remains the trust boundary.
+ * Every exchange that names or measures vault content takes a different wire:
+ * the channel only rendezvouses a private `MessagePort` this tab dials to the
+ * leader, and command arguments, upload chunks, snapshots, plaintext windows and
+ * the engine event stream all cross it — so a same-origin context that merely
+ * opened the channel is no longer a receiver. The rendezvous is as authenticated
+ * as the `cb:leader` beacon and no more: same origin remains the trust boundary.
+ *
+ * The tab also holds a **presence lock** for its whole life, released by the
+ * browser when it dies; the leader watches that release to reclaim what this tab
+ * held. It is taken before the greeting, so the leader never watches a name no
+ * one holds.
  */
 
 import {
+  presenceLockName,
   type BroadcastChannelLike,
   type LeaderMessage,
   type PortRequest,
@@ -32,6 +38,7 @@ import {
   type WireWrite,
 } from './broadcast.js';
 import { CorrelatedTransport } from './correlatedTransport.js';
+import type { LockManagerLike } from './leadership.js';
 import type { MessagePortLike, PortCourier } from './portRelay.js';
 import type {
   CommandDescriptor,
@@ -81,21 +88,53 @@ export class BroadcastTransport extends CorrelatedTransport {
   private readonly portTimeoutMs: number;
   private readonly onLeadershipChange: () => void;
 
+  // Settles once this tab holds its presence lock; the greeting waits on it, so
+  // the leader's death watch can never be granted against a live tab.
+  private readonly presenceHeld: Promise<void>;
+  private readonly presenceRequest = new AbortController();
+  private releasePresence: (() => void) | null = null;
+
   private readonly onMessage = (event: MessageEvent): void => this.receive(event.data);
 
   constructor(
     private readonly channel: BroadcastChannelLike,
     private readonly clientId: string,
     private readonly courier: PortCourier,
+    locks: LockManagerLike,
     options: BroadcastTransportOptions = {}
   ) {
     super();
     this.portTimeoutMs = options.portTimeoutMs ?? DEFAULT_PORT_TIMEOUT_MS;
     this.onLeadershipChange = options.onLeadershipChange ?? ((): void => undefined);
+    this.presenceHeld = this.holdPresence(locks);
     this.armLeaderReady();
     this.channel.addEventListener('message', this.onMessage);
     // Announce ourselves so a live leader replies with a `leader` beacon.
     this.channel.postMessage({ type: 'cb:hello', clientId: this.clientId });
+  }
+
+  /**
+   * Takes the lock naming this tab and holds it until `close()` or until the
+   * browser releases it on the tab's death — the leader's death signal.
+   */
+  private holdPresence(locks: LockManagerLike): Promise<void> {
+    const held = new Promise<void>((resolve, reject) => {
+      void locks
+        .request(
+          presenceLockName(this.clientId),
+          { signal: this.presenceRequest.signal, mode: 'exclusive' },
+          () => {
+            resolve();
+            return new Promise<void>((release) => {
+              this.releasePresence = release;
+            });
+          }
+        )
+        .catch((error: unknown) => reject(asError(error)));
+    });
+    // A broker re-observes this rejection; swallow the unobserved-rejection warn.
+    held.catch(() => undefined);
+    return held;
   }
 
   /**
@@ -196,6 +235,10 @@ export class BroadcastTransport extends CorrelatedTransport {
     // in force when a read first asked for a port.
     const generation = this.portGeneration;
     if (this.closed) throw retryError();
+    // Before the greeting, never after: a leader that watched this tab's
+    // presence name while it held nothing would be granted at once and reclaim
+    // a live tab.
+    await this.awaitPresence();
     const port = await this.courier.connect(await this.awaitHost());
     const release = this.bindPort(port);
     try {
@@ -228,10 +271,9 @@ export class BroadcastTransport extends CorrelatedTransport {
         return;
       }
       if (!adopted) return;
-      if (message.type === 'cb:portPing') {
-        // Answered from the message handler, not a timer, so a throttled
-        // background tab still proves it is alive to the leader's sweep.
-        port.postMessage({ type: 'cb:portPong' } satisfies PortRequest);
+      if (message.type === 'cb:portEvent') {
+        const { event } = message as Extract<PortResponse, { type: 'cb:portEvent' }>;
+        this.emit(event);
         return;
       }
       if (message.type === 'cb:portClosed') {
@@ -250,6 +292,15 @@ export class BroadcastTransport extends CorrelatedTransport {
       port.removeEventListener('message', listener);
       port.close();
     };
+  }
+
+  /** This tab's presence lock, under the brokerage timeout like every step. */
+  private awaitPresence(): Promise<void> {
+    return this.awaitBrokerage<void>('this tab holds no presence lock', (settle) => {
+      void this.presenceHeld.then(settle, (error: unknown) =>
+        this.abortBrokerage?.(asError(error))
+      );
+    });
   }
 
   /** Asks where this leadership takes follower ports, for this leadership only. */
@@ -328,6 +379,11 @@ export class BroadcastTransport extends CorrelatedTransport {
     this.rejectLeaderReady(error);
     this.fail(error);
     this.dropPort(error);
+    // Held → released; still queued → withdrawn. Either way this tab stops
+    // claiming a presence the leader would go on watching.
+    this.releasePresence?.();
+    this.releasePresence = null;
+    this.presenceRequest.abort();
     try {
       this.channel.postMessage({ type: 'cb:bye', clientId: this.clientId });
     } catch {
@@ -359,12 +415,6 @@ export class BroadcastTransport extends CorrelatedTransport {
         const host = message as Extract<LeaderMessage, { type: 'cb:portHost' }>;
         if (!this.fromActiveLeader(host.token) || typeof host.address !== 'string') return;
         this.settleHost?.(host.address);
-        return;
-      }
-      case 'cb:event': {
-        const event = message as Extract<LeaderMessage, { type: 'cb:event' }>;
-        if (!this.fromActiveLeader(event.token)) return; // forged / stale event
-        this.emit(event.event);
         return;
       }
     }
@@ -405,4 +455,8 @@ export class BroadcastTransport extends CorrelatedTransport {
 
 function retryError(): Error {
   return new Error('leader changed; retry');
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/client/src/engineClient.test.ts
+++ b/packages/client/src/engineClient.test.ts
@@ -5,6 +5,7 @@ import { EngineClient, type EngineClientConfig } from './engineClient.js';
 import { LeaderRelay } from './leaderRelay.js';
 import type { LockManagerLike } from './leadership.js';
 import {
+  abortError,
   FakeBus,
   FakeCourierNetwork,
   FakeEngineTransport,
@@ -26,9 +27,7 @@ function pinnedFollower(locks: FakeLockManager): LockManagerLike {
     request: (name, options, callback) =>
       name === BROADCAST_CHANNEL_NAME
         ? new Promise((_resolve, reject) => {
-            options.signal?.addEventListener('abort', () =>
-              reject(new DOMException('aborted', 'AbortError'))
-            );
+            options.signal?.addEventListener('abort', () => reject(abortError()));
           })
         : locks.request(name, options, callback),
   };
@@ -36,8 +35,8 @@ function pinnedFollower(locks: FakeLockManager): LockManagerLike {
 
 /** A shared origin: one lock manager, one broadcast bus, one worker registry. */
 function origin() {
-  const locks = new FakeLockManager();
   const bus = new FakeBus();
+  const locks = bus.locks;
   const ports = new FakeCourierNetwork();
   let tabs = 0;
   const workers: FakeEngineWorker[] = [];
@@ -433,11 +432,10 @@ describe('EngineClient leadership + transport swap', () => {
   it('refuses a stream handle across a leader change while this tab stays a follower', async () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
-    const locks = new FakeLockManager();
     const engineA = new FakeEngineTransport();
-    const relayA = new LeaderRelay(bus.channel(), engineA, ports.courier('leaderA'), locks);
+    const relayA = new LeaderRelay(bus.channel(), engineA, ports.courier('leaderA'), bus.locks);
     const follower = new EngineClient({
-      locks: pinnedFollower(locks),
+      locks: pinnedFollower(bus.locks),
       createChannel: () => bus.channel(),
       spawnWorker: () => {
         throw new Error('follower never spawns');
@@ -452,7 +450,7 @@ describe('EngineClient leadership + transport swap', () => {
     await tick();
 
     const engineB = new FakeEngineTransport();
-    const relayB = new LeaderRelay(bus.channel(), engineB, ports.courier('leaderB'), locks);
+    const relayB = new LeaderRelay(bus.channel(), engineB, ports.courier('leaderB'), bus.locks);
     for (let i = 0; i < 4; i += 1) await tick();
     expect(follower.currentRole()).toBe('follower');
 

--- a/packages/client/src/engineClient.test.ts
+++ b/packages/client/src/engineClient.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { BROADCAST_CHANNEL_NAME } from './broadcast.js';
 import { EngineClient, type EngineClientConfig } from './engineClient.js';
 import { LeaderRelay } from './leaderRelay.js';
 import type { LockManagerLike } from './leadership.js';
@@ -15,17 +16,23 @@ import type { EventDescriptor } from './worker/protocol.js';
 const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
 
 /**
- * Pins a tab as a follower: the lock is never granted, so it is never promoted.
- * The request still settles on abort, so `dispose()` can await its election.
+ * Pins a tab as a follower: the engine lock is never granted, so it is never
+ * promoted. The request still settles on abort, so `dispose()` can await its
+ * election. Every other name — the tab's presence lock — takes the origin's own
+ * manager, which the leader relay watches.
  */
-const neverGrant: LockManagerLike = {
-  request: (_name, options) =>
-    new Promise((_resolve, reject) => {
-      options.signal?.addEventListener('abort', () =>
-        reject(new DOMException('aborted', 'AbortError'))
-      );
-    }),
-};
+function pinnedFollower(locks: FakeLockManager): LockManagerLike {
+  return {
+    request: (name, options, callback) =>
+      name === BROADCAST_CHANNEL_NAME
+        ? new Promise((_resolve, reject) => {
+            options.signal?.addEventListener('abort', () =>
+              reject(new DOMException('aborted', 'AbortError'))
+            );
+          })
+        : locks.request(name, options, callback),
+  };
+}
 
 /** A shared origin: one lock manager, one broadcast bus, one worker registry. */
 function origin() {
@@ -426,10 +433,11 @@ describe('EngineClient leadership + transport swap', () => {
   it('refuses a stream handle across a leader change while this tab stays a follower', async () => {
     const bus = new FakeBus();
     const ports = new FakeCourierNetwork();
+    const locks = new FakeLockManager();
     const engineA = new FakeEngineTransport();
-    const relayA = new LeaderRelay(bus.channel(), engineA, ports.courier('leaderA'));
+    const relayA = new LeaderRelay(bus.channel(), engineA, ports.courier('leaderA'), locks);
     const follower = new EngineClient({
-      locks: neverGrant,
+      locks: pinnedFollower(locks),
       createChannel: () => bus.channel(),
       spawnWorker: () => {
         throw new Error('follower never spawns');
@@ -444,7 +452,7 @@ describe('EngineClient leadership + transport swap', () => {
     await tick();
 
     const engineB = new FakeEngineTransport();
-    const relayB = new LeaderRelay(bus.channel(), engineB, ports.courier('leaderB'));
+    const relayB = new LeaderRelay(bus.channel(), engineB, ports.courier('leaderB'), locks);
     for (let i = 0; i < 4; i += 1) await tick();
     expect(follower.currentRole()).toBe('follower');
 

--- a/packages/client/src/engineClient.ts
+++ b/packages/client/src/engineClient.ts
@@ -113,7 +113,6 @@ export class EngineClient implements EngineTransport {
   private readonly channel: BroadcastChannelLike;
   private readonly clientId: string;
   private readonly courier: PortCourier;
-  private readonly locks: LockManagerLike;
   private readonly election: LeaderElection;
 
   private role: EngineClientRole = 'follower';
@@ -134,7 +133,6 @@ export class EngineClient implements EngineTransport {
     this.clientId = config.clientId ?? newClientId();
     this.channel = (config.createChannel ?? defaultChannel)();
     this.courier = config.courier ?? defaultCourier();
-    this.locks = config.locks;
 
     this.installFollower();
 
@@ -147,7 +145,7 @@ export class EngineClient implements EngineTransport {
       );
 
     this.election = new LeaderElection(
-      this.locks,
+      config.locks,
       config.lockName ?? BROADCAST_CHANNEL_NAME,
       () => this.becomeLeader(),
       config.onError
@@ -290,9 +288,15 @@ export class EngineClient implements EngineTransport {
     // Leadership moving between two *other* tabs replaces the engine without
     // replacing this transport, so the handle fence rides the same signal as the
     // transport's own port fence.
-    const follower = new BroadcastTransport(this.channel, this.clientId, this.courier, this.locks, {
-      onLeadershipChange: () => this.retireHandles(),
-    });
+    const follower = new BroadcastTransport(
+      this.channel,
+      this.clientId,
+      this.courier,
+      this.config.locks,
+      {
+        onLeadershipChange: () => this.retireHandles(),
+      }
+    );
     this.swapCurrent(follower);
     this.innerUnsub = follower.subscribe((event) => this.fanOut(event));
     return follower;
@@ -355,7 +359,7 @@ export class EngineClient implements EngineTransport {
       this.role = 'leader';
       this.swapCurrent(local);
       this.innerUnsub = local.subscribe((event) => this.fanOut(event));
-      this.relay = new LeaderRelay(this.channel, local, this.courier, this.locks);
+      this.relay = new LeaderRelay(this.channel, local, this.courier, this.config.locks);
       if (this.ownFocus) this.relay.reportLocalFocus(this.clientId, this.ownFocus);
     } catch (error) {
       this.abortPromotion(local, error);

--- a/packages/client/src/engineClient.ts
+++ b/packages/client/src/engineClient.ts
@@ -113,6 +113,7 @@ export class EngineClient implements EngineTransport {
   private readonly channel: BroadcastChannelLike;
   private readonly clientId: string;
   private readonly courier: PortCourier;
+  private readonly locks: LockManagerLike;
   private readonly election: LeaderElection;
 
   private role: EngineClientRole = 'follower';
@@ -133,6 +134,7 @@ export class EngineClient implements EngineTransport {
     this.clientId = config.clientId ?? newClientId();
     this.channel = (config.createChannel ?? defaultChannel)();
     this.courier = config.courier ?? defaultCourier();
+    this.locks = config.locks;
 
     this.installFollower();
 
@@ -145,7 +147,7 @@ export class EngineClient implements EngineTransport {
       );
 
     this.election = new LeaderElection(
-      config.locks,
+      this.locks,
       config.lockName ?? BROADCAST_CHANNEL_NAME,
       () => this.becomeLeader(),
       config.onError
@@ -288,7 +290,7 @@ export class EngineClient implements EngineTransport {
     // Leadership moving between two *other* tabs replaces the engine without
     // replacing this transport, so the handle fence rides the same signal as the
     // transport's own port fence.
-    const follower = new BroadcastTransport(this.channel, this.clientId, this.courier, {
+    const follower = new BroadcastTransport(this.channel, this.clientId, this.courier, this.locks, {
       onLeadershipChange: () => this.retireHandles(),
     });
     this.swapCurrent(follower);
@@ -353,7 +355,7 @@ export class EngineClient implements EngineTransport {
       this.role = 'leader';
       this.swapCurrent(local);
       this.innerUnsub = local.subscribe((event) => this.fanOut(event));
-      this.relay = new LeaderRelay(this.channel, local, this.courier);
+      this.relay = new LeaderRelay(this.channel, local, this.courier, this.locks);
       if (this.ownFocus) this.relay.reportLocalFocus(this.clientId, this.ownFocus);
     } catch (error) {
       this.abortPromotion(local, error);

--- a/packages/client/src/errorMessage.ts
+++ b/packages/client/src/errorMessage.ts
@@ -2,3 +2,8 @@
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+/** Renders an unknown throw as an `Error`, so a rejection carries a stack. */
+export function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/client/src/leaderRelay.ts
+++ b/packages/client/src/leaderRelay.ts
@@ -5,31 +5,36 @@
  *
  * - follower command / read / write step → the leader's worker → correlated
  *   result back, all over that follower's private `PortCourier` port;
- * - every engine event → fanned out to all followers over the channel, in
- *   emission order;
+ * - every engine event → fanned out over those same ports, in emission order;
  * - each tab's open folder → the leader's **focus-window union**, so freshness
  *   follows whichever tab is focused (the RefreshHintSource seam, cross-tab).
  *
- * No plaintext, key material or user-supplied name touches the
- * `BroadcastChannel` in either direction: it carries election, the port
- * rendezvous, and the `EventDescriptor` stream (see `broadcast.ts` for what an
- * event still exposes). One port per follower per leadership.
+ * Nothing that names or measures vault content touches the `BroadcastChannel`
+ * in either direction: it carries election and the port rendezvous only. One
+ * port per follower per leadership.
  */
 
-import type {
-  BroadcastChannelLike,
-  FollowerMessage,
-  LeaderMessage,
-  PortRequest,
-  PortResponse,
-  WireRead,
-  WireStream,
-  WireWrite,
+import {
+  presenceLockName,
+  type BroadcastChannelLike,
+  type FollowerMessage,
+  type LeaderMessage,
+  type PortRequest,
+  type PortResponse,
+  type WireRead,
+  type WireStream,
+  type WireWrite,
 } from './broadcast.js';
 import { EngineRequestError, unknownHandle, type HandleKind } from './correlatedTransport.js';
+import type { LockManagerLike } from './leadership.js';
 import type { MessagePortLike, PortCourier } from './portRelay.js';
 import type { EngineTransport } from './transport.js';
-import type { SnapshotDescriptor, StreamHandle, WriteHandle } from './worker/protocol.js';
+import type {
+  EventDescriptor,
+  SnapshotDescriptor,
+  StreamHandle,
+  WriteHandle,
+} from './worker/protocol.js';
 import { WriteQueue } from './writeQueue.js';
 
 /** One follower's private port, with the listener bound to it. */
@@ -39,24 +44,14 @@ interface PortEntry {
   clientId: string | null;
   /** Reclaims a port that never named itself, so an unnamed one cannot pile up. */
   readonly naming: ReturnType<typeof setTimeout>;
-  /** Consecutive liveness sweeps this port has not answered. */
-  missed: number;
 }
 
 export interface LeaderRelayOptions {
   /** How long a freshly dialed port has to name the follower behind it. */
   namingTimeoutMs?: number;
-  /** How often the leader probes each named port for the tab behind it. */
-  livenessIntervalMs?: number;
-  /** Consecutive unanswered probes before a follower is presumed dead. */
-  livenessMisses?: number;
 }
 
 const DEFAULT_NAMING_TIMEOUT_MS = 5000;
-// Generous by design: a backgrounded tab's timers are throttled, and a
-// false positive tears down a live tab's in-flight media playback.
-const DEFAULT_LIVENESS_INTERVAL_MS = 15_000;
-const DEFAULT_LIVENESS_MISSES = 4;
 
 /**
  * Wipes the upload chunk a write payload carries. A chunk arrives transferred,
@@ -153,15 +148,17 @@ export class LeaderRelay {
   // open pins a content version (and its key) in the leader's engine.
   private readonly streamOwners = new Map<StreamHandle, string>();
   private readonly ports = new Set<PortEntry>();
+  // One presence watch per named follower, keyed on the client rather than the
+  // port so a re-brokering tab keeps the watch it already proved alive under.
+  private readonly presence = new Map<string, AbortController>();
   private readonly namingTimeoutMs: number;
-  private readonly livenessMisses: number;
-  private readonly liveness: ReturnType<typeof setInterval>;
   private readonly unsubscribe: () => void;
   private readonly unsubscribePorts: () => void;
   private closed = false;
   // An unguessable per-leadership capability. It stamps every leader→follower
-  // message so followers reject forged acks/events from a non-leader same-origin
-  // context (integrity defense-in-depth; same-origin is the trust boundary).
+  // message so followers reject a forged beacon or port rendezvous from a
+  // non-leader same-origin context (integrity defense-in-depth; same-origin is
+  // the trust boundary).
   private readonly token = globalThis.crypto.randomUUID();
   private readonly onMessage = (event: MessageEvent): void => this.receive(event.data);
 
@@ -169,19 +166,13 @@ export class LeaderRelay {
     private readonly channel: BroadcastChannelLike,
     private readonly transport: EngineTransport,
     private readonly courier: PortCourier,
+    private readonly locks: LockManagerLike,
     options: LeaderRelayOptions = {}
   ) {
     this.namingTimeoutMs = options.namingTimeoutMs ?? DEFAULT_NAMING_TIMEOUT_MS;
-    this.livenessMisses = options.livenessMisses ?? DEFAULT_LIVENESS_MISSES;
-    this.liveness = setInterval(
-      () => this.sweepLiveness(),
-      options.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS
-    );
     this.channel.addEventListener('message', this.onMessage);
     this.unsubscribePorts = this.courier.onPort((port) => this.adoptPort(port));
-    this.unsubscribe = this.transport.subscribe((event) => {
-      this.post({ type: 'cb:event', token: this.token, event });
-    });
+    this.unsubscribe = this.transport.subscribe((event) => this.fanOut(event));
     // Announce leadership so followers (existing or newly-elected-away) reconnect.
     this.post({ type: 'cb:leader', token: this.token });
   }
@@ -202,7 +193,8 @@ export class LeaderRelay {
     // Detach before latching: `postPort` drops messages once closed, so the
     // `cb:portClosed` notice has to go out while the relay is still open.
     this.unsubscribePorts();
-    clearInterval(this.liveness);
+    for (const watch of this.presence.values()) watch.abort();
+    this.presence.clear();
     for (const entry of [...this.ports]) this.detachPort(entry);
     this.closed = true;
     this.releaseHandles(null);
@@ -226,34 +218,51 @@ export class LeaderRelay {
     }
   }
 
+  /** Every engine event, to every adopted port, in emission order. */
+  private fanOut(event: EventDescriptor): void {
+    for (const entry of this.ports) {
+      if (entry.clientId !== null) this.postPort(entry.port, { type: 'cb:portEvent', event });
+    }
+  }
+
   /**
    * Abandons everything a follower held: its focus, its write and stream
-   * handles, and its port. Driven by `cb:bye` and by the liveness sweep, which
+   * handles, and its port. Driven by `cb:bye` and by the presence watch, which
    * is the only signal a crashed tab leaves behind.
    */
   private reclaim(clientId: string): void {
+    this.retirePresence(clientId);
     if (this.focus.remove(clientId)) this.refreshHint();
     this.releaseHandles(clientId);
     this.detachPortOf(clientId);
   }
 
   /**
-   * Probes each named port and reclaims the follower behind one that has stopped
-   * answering — the only signal a tab that died without `cb:bye` leaves behind.
-   * The probe is answered from a message handler, not a timer, and any port
-   * traffic at all resets the count, so a throttled or mid-playback tab is never
-   * a candidate.
+   * Watches for the death of the tab behind a named port. The follower holds its
+   * presence lock from before it greets until its tab closes, crashes or is
+   * discarded, so this request is granted at exactly the moment the tab is gone
+   * — an event-driven death signal, in place of a probe a live-but-frozen tab
+   * would fail. A follower that greets without holding the lock is granted
+   * immediately and reclaimed, so the greeting cannot outlive the presence.
    */
-  private sweepLiveness(): void {
-    for (const entry of [...this.ports]) {
-      if (entry.clientId === null) continue; // the naming timeout owns unnamed ports
-      if (entry.missed >= this.livenessMisses) {
-        this.reclaim(entry.clientId);
-        continue;
-      }
-      entry.missed += 1;
-      this.postPort(entry.port, { type: 'cb:portPing' });
-    }
+  private watchPresence(clientId: string): void {
+    if (this.presence.has(clientId)) return;
+    const watch = new AbortController();
+    this.presence.set(clientId, watch);
+    void this.locks
+      .request(presenceLockName(clientId), { signal: watch.signal, mode: 'exclusive' }, () => {
+        this.reclaim(clientId);
+        // Released at once: the watch is the grant, not a lock to hold.
+        return Promise.resolve();
+      })
+      .catch(() => undefined); // an aborted watch is the retirement path
+  }
+
+  private retirePresence(clientId: string): void {
+    const watch = this.presence.get(clientId);
+    if (!watch) return;
+    this.presence.delete(clientId);
+    watch.abort();
   }
 
   /**
@@ -281,7 +290,6 @@ export class LeaderRelay {
       clientId: null,
       listener: (event) => this.onPortMessage(entry, event.data),
       naming: setTimeout(() => this.detachPort(entry), this.namingTimeoutMs),
-      missed: 0,
     };
     port.addEventListener('message', entry.listener);
     port.start?.();
@@ -302,9 +310,6 @@ export class LeaderRelay {
    */
   private serve(entry: PortEntry, message: PortRequest | { type?: unknown }): boolean {
     if (this.closed) return false;
-    // Any traffic at all proves the tab behind this port is still running.
-    entry.missed = 0;
-    if (message.type === 'cb:portPong') return true;
     if (message.type === 'cb:portHello') {
       const { clientId } = message as Extract<PortRequest, { type: 'cb:portHello' }>;
       if (entry.clientId !== null || typeof clientId !== 'string') return false;
@@ -313,6 +318,7 @@ export class LeaderRelay {
       this.detachPortOf(clientId);
       clearTimeout(entry.naming);
       entry.clientId = clientId;
+      this.watchPresence(clientId);
       this.postPort(entry.port, { type: 'cb:portReady', token: this.token });
       return true;
     }

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -371,6 +371,13 @@ export function abortError(): DOMException {
   return new DOMException('aborted', 'AbortError');
 }
 
+/** Renders bytes as one lowercase hex run, the form a leak scan searches. */
+export function hex(bytes: Iterable<number>): string {
+  let out = '';
+  for (const byte of bytes) out += byte.toString(16).padStart(2, '0');
+  return out;
+}
+
 /**
  * Every byte and every string anywhere in a message, flattened so a leak scan
  * can search them: `bytesHex` catches payloads and node ids, `text` catches
@@ -399,9 +406,7 @@ export function collect(value: unknown): { bytesHex: string; text: string } {
     else if (node && typeof node === 'object') for (const entry of Object.values(node)) walk(entry);
   };
   walk(value);
-  let bytesHex = '';
-  for (const byte of found) bytesHex += byte.toString(16).padStart(2, '0');
-  return { bytesHex, text: strings.join(' ') };
+  return { bytesHex: hex(found), text: strings.join(' ') };
 }
 
 /** A minimal in-process EngineTransport for relay/orchestrator tests. */

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -272,68 +272,83 @@ export class FakeCourierNetwork {
   }
 }
 
-interface Held {
-  release: () => void;
-  done: Promise<unknown>;
+/** One lock name's state: at most one holder, FIFO queue behind it. */
+interface FakeLock {
+  held: boolean;
+  readonly queue: Array<() => void>;
 }
 
-/** An origin-exclusive lock: at most one holder at a time, FIFO queue behind it. */
+/**
+ * `navigator.locks` for the unit suite: one exclusive lock **per name**, FIFO
+ * behind the holder, granted on a later turn like the real API — a tab's
+ * presence lock and the engine election lock are separate names, and a queued
+ * request is granted only when the holder lets go.
+ */
 export class FakeLockManager implements LockManagerLike {
-  private held: Held | null = null;
-  private readonly queue: Array<() => void> = [];
+  private readonly locks = new Map<string, FakeLock>();
 
   request(
     name: string,
     options: { signal?: AbortSignal; mode?: 'exclusive' },
     callback: LockRequestCallback
   ): Promise<unknown> {
+    const lock = this.lock(name);
     return new Promise<unknown>((resolveRequest, rejectRequest) => {
       const signal = options.signal;
       const grant = (): void => {
         if (signal?.aborted) {
-          rejectRequest(new DOMException('aborted', 'AbortError'));
-          this.next();
+          rejectRequest(abortError());
+          this.next(name);
           return;
         }
-        const done = Promise.resolve(callback({ name }));
-        this.held = { release: () => undefined, done };
-        void done.then(
+        lock.held = true;
+        void Promise.resolve(callback({ name })).then(
           (value) => {
-            this.held = null;
+            lock.held = false;
             resolveRequest(value);
-            this.next();
+            this.next(name);
           },
-          (error) => {
-            this.held = null;
+          (error: unknown) => {
+            lock.held = false;
             rejectRequest(error);
-            this.next();
+            this.next(name);
           }
         );
       };
 
-      const enqueue = (): void => {
-        this.queue.push(grant);
-        if (!this.held) this.next();
-      };
-
-      if (signal) {
-        signal.addEventListener('abort', () => {
-          const index = this.queue.indexOf(grant);
-          if (index >= 0) {
-            this.queue.splice(index, 1);
-            rejectRequest(new DOMException('aborted', 'AbortError'));
-          }
-        });
-      }
-      enqueue();
+      signal?.addEventListener('abort', () => {
+        const index = lock.queue.indexOf(grant);
+        if (index >= 0) {
+          lock.queue.splice(index, 1);
+          rejectRequest(abortError());
+        }
+      });
+      lock.queue.push(grant);
+      this.next(name);
     });
   }
 
-  private next(): void {
-    if (this.held || this.queue.length === 0) return;
-    const grant = this.queue.shift();
-    grant?.();
+  private lock(name: string): FakeLock {
+    const existing = this.locks.get(name);
+    if (existing) return existing;
+    const created: FakeLock = { held: false, queue: [] };
+    this.locks.set(name, created);
+    return created;
   }
+
+  private next(name: string): void {
+    const lock = this.lock(name);
+    if (lock.held || lock.queue.length === 0) return;
+    // A real grant never lands synchronously inside `request`.
+    queueMicrotask(() => {
+      if (lock.held) return;
+      lock.queue.shift()?.();
+    });
+  }
+}
+
+function abortError(): DOMException {
+  return new DOMException('aborted', 'AbortError');
 }
 
 /** A minimal in-process EngineTransport for relay/orchestrator tests. */

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -343,7 +343,9 @@ export class FakeLockManager implements LockManagerLike {
   /** Settles this name's holder in failure, as a stolen lock does. */
   fail(name: string, error: Error): void {
     const lock = this.lock(name);
-    lock.fail?.(error);
+    // Silence here would let a fail-closed test assert a loss it never staged.
+    if (!lock.fail) throw new Error(`no holder to fail for lock "${name}"`);
+    lock.fail(error);
   }
 
   private lock(name: string): FakeLock {
@@ -386,6 +388,14 @@ export function collect(value: unknown): { bytesHex: string; text: string } {
     // Counts and ids are values a scan has to see: a block count is a size proxy.
     else if (typeof node === 'number' || typeof node === 'bigint') strings.push(String(node));
     else if (Array.isArray(node)) for (const entry of node) walk(entry);
+    // A container the scan cannot open is a blind spot that reads as clean, so
+    // the keyed and set forms structured clone carries are opened too.
+    else if (node instanceof Map)
+      for (const [key, entry] of node) {
+        walk(key);
+        walk(entry);
+      }
+    else if (node instanceof Set) for (const entry of node) walk(entry);
     else if (node && typeof node === 'object') for (const entry of Object.values(node)) walk(entry);
   };
   walk(value);

--- a/packages/client/src/testkit.ts
+++ b/packages/client/src/testkit.ts
@@ -133,8 +133,12 @@ export class StubEngineHost implements EngineHostLike {
   }
 }
 
-/** A same-origin broadcast bus: a posted message reaches every *other* channel. */
+/**
+ * A same-origin broadcast bus: a posted message reaches every *other* channel.
+ * One bus is one origin, so it also carries that origin's lock manager.
+ */
 export class FakeBus {
+  readonly locks = new FakeLockManager();
   private readonly channels = new Set<FakeChannel>();
 
   channel(): FakeChannel {
@@ -275,6 +279,8 @@ export class FakeCourierNetwork {
 /** One lock name's state: at most one holder, FIFO queue behind it. */
 interface FakeLock {
   held: boolean;
+  /** Settles the current holder's callback in failure (`fail`). */
+  fail: ((error: Error) => void) | null;
   readonly queue: Array<() => void>;
 }
 
@@ -302,14 +308,20 @@ export class FakeLockManager implements LockManagerLike {
           return;
         }
         lock.held = true;
-        void Promise.resolve(callback({ name })).then(
+        // Raced, not chained: a steal has to beat a holder that never settles.
+        const stolen = new Promise<never>((_resolve, rejectHold) => {
+          lock.fail = rejectHold;
+        });
+        void Promise.race([Promise.resolve(callback({ name })), stolen]).then(
           (value) => {
             lock.held = false;
+            lock.fail = null;
             resolveRequest(value);
             this.next(name);
           },
           (error: unknown) => {
             lock.held = false;
+            lock.fail = null;
             rejectRequest(error);
             this.next(name);
           }
@@ -328,10 +340,16 @@ export class FakeLockManager implements LockManagerLike {
     });
   }
 
+  /** Settles this name's holder in failure, as a stolen lock does. */
+  fail(name: string, error: Error): void {
+    const lock = this.lock(name);
+    lock.fail?.(error);
+  }
+
   private lock(name: string): FakeLock {
     const existing = this.locks.get(name);
     if (existing) return existing;
-    const created: FakeLock = { held: false, queue: [] };
+    const created: FakeLock = { held: false, fail: null, queue: [] };
     this.locks.set(name, created);
     return created;
   }
@@ -347,8 +365,33 @@ export class FakeLockManager implements LockManagerLike {
   }
 }
 
-function abortError(): DOMException {
+export function abortError(): DOMException {
   return new DOMException('aborted', 'AbortError');
+}
+
+/**
+ * Every byte and every string anywhere in a message, flattened so a leak scan
+ * can search them: `bytesHex` catches payloads and node ids, `text` catches
+ * names, routing keys and codes.
+ */
+export function collect(value: unknown): { bytesHex: string; text: string } {
+  const found: number[] = [];
+  const strings: string[] = [];
+  const walk = (node: unknown): void => {
+    if (node instanceof ArrayBuffer) for (const byte of new Uint8Array(node)) found.push(byte);
+    else if (ArrayBuffer.isView(node)) {
+      const view = new Uint8Array(node.buffer, node.byteOffset, node.byteLength);
+      for (const byte of view) found.push(byte);
+    } else if (typeof node === 'string') strings.push(node);
+    // Counts and ids are values a scan has to see: a block count is a size proxy.
+    else if (typeof node === 'number' || typeof node === 'bigint') strings.push(String(node));
+    else if (Array.isArray(node)) for (const entry of node) walk(entry);
+    else if (node && typeof node === 'object') for (const entry of Object.values(node)) walk(entry);
+  };
+  walk(value);
+  let bytesHex = '';
+  for (const byte of found) bytesHex += byte.toString(16).padStart(2, '0');
+  return { bytesHex, text: strings.join(' ') };
 }
 
 /** A minimal in-process EngineTransport for relay/orchestrator tests. */

--- a/packages/client/test/browser/journalEngine.worker.ts
+++ b/packages/client/test/browser/journalEngine.worker.ts
@@ -42,8 +42,8 @@ async function journal(kind: string): Promise<void> {
 }
 
 class JournalHost extends StubEngineHost {
-  private readonly events: EventDescriptor[] = [];
-  private wake: (() => void) | null = null;
+  private readonly queued: EventDescriptor[] = [];
+  private readonly waiters: Array<(event: EventDescriptor) => void> = [];
   private nextHandle = 1n;
   // Op ids are a separate id space from write handles; keep them disjoint so a
   // client that conflates the two cannot pass against this fake.
@@ -102,20 +102,16 @@ class JournalHost extends StubEngineHost {
     return Promise.resolve();
   }
 
-  async nextEvent(): Promise<EventDescriptor | null> {
-    if (this.events.length === 0) {
-      await new Promise<void>((resolve) => {
-        this.wake = resolve;
-      });
-    }
-    return this.events.shift() ?? null;
+  nextEvent(): Promise<EventDescriptor | null> {
+    const next = this.queued.shift();
+    if (next) return Promise.resolve(next);
+    return new Promise((resolve) => this.waiters.push(resolve));
   }
 
   private publish(event: EventDescriptor): void {
-    this.events.push(event);
-    const wake = this.wake;
-    this.wake = null;
-    wake?.();
+    const waiter = this.waiters.shift();
+    if (waiter) waiter(event);
+    else this.queued.push(event);
   }
 }
 

--- a/packages/client/test/browser/journalEngine.worker.ts
+++ b/packages/client/test/browser/journalEngine.worker.ts
@@ -42,6 +42,8 @@ async function journal(kind: string): Promise<void> {
 }
 
 class JournalHost extends StubEngineHost {
+  private readonly events: EventDescriptor[] = [];
+  private wake: (() => void) | null = null;
   private nextHandle = 1n;
   // Op ids are a separate id space from write handles; keep them disjoint so a
   // client that conflates the two cannot pass against this fake.
@@ -80,7 +82,19 @@ class JournalHost extends StubEngineHost {
     if (write.received !== write.size) throw new Error('content size mismatch');
     this.open.delete(handle);
     await journal('commitWrite');
-    return this.nextOpId++;
+    const opId = this.nextOpId++;
+    // A descriptor carrying the metadata the spec scans every wire for: a node
+    // id and a block count, as the real engine reports an upload.
+    this.publish({
+      kind: 'opProgress',
+      opId,
+      node: new Uint8Array(16).fill(0xa7),
+      phase: 'uploadCompleted',
+      blocksConfirmed: 4,
+      blocksTotal: 4,
+      error: null,
+    });
+    return opId;
   }
 
   abortWrite(handle: bigint): Promise<void> {
@@ -88,9 +102,20 @@ class JournalHost extends StubEngineHost {
     return Promise.resolve();
   }
 
-  nextEvent(): Promise<EventDescriptor | null> {
-    // No engine events in this fake; park the pump forever.
-    return new Promise<EventDescriptor | null>(() => undefined);
+  async nextEvent(): Promise<EventDescriptor | null> {
+    if (this.events.length === 0) {
+      await new Promise<void>((resolve) => {
+        this.wake = resolve;
+      });
+    }
+    return this.events.shift() ?? null;
+  }
+
+  private publish(event: EventDescriptor): void {
+    this.events.push(event);
+    const wake = this.wake;
+    this.wake = null;
+    wake?.();
   }
 }
 

--- a/packages/client/test/browser/leadership.spec.ts
+++ b/packages/client/test/browser/leadership.spec.ts
@@ -356,6 +356,12 @@ test.describe('tab leadership over real Web Locks + BroadcastChannel', () => {
     const seenText = observed.map((message) => message.text).join(' ');
     expect(seenText).not.toContain(filename);
     expect(seenText).not.toContain('rothko-appraisal');
+    // And the strings and counts it carried, so a string-valued descriptor field
+    // added later cannot leak here either. A block count or a one-digit op id
+    // would match a digit inside a clientId, so only distinctive values count.
+    const needles = progress!.text.split(' ').filter((value) => value.length >= 4);
+    expect(needles.length).toBeGreaterThan(0);
+    for (const needle of needles) expect(seenText).not.toContain(needle);
 
     await a.dispose();
     await b.dispose();

--- a/packages/client/test/browser/leadership.spec.ts
+++ b/packages/client/test/browser/leadership.spec.ts
@@ -1,6 +1,12 @@
 import { expect, test, type BrowserContext, type Page } from '@playwright/test';
 
-import type { DownloadResult, ObservedMessage, RangeResult, SnapshotResult } from './leadership.js';
+import type {
+  DownloadResult,
+  ObservedEvent,
+  ObservedMessage,
+  RangeResult,
+  SnapshotResult,
+} from './leadership.js';
 import { hex } from './hexUtil.js';
 import { fixtureSlice, LEADER_SEED } from './mediaFixture.js';
 
@@ -22,6 +28,7 @@ interface LeadershipHarness {
   }): Promise<void>;
   cbObserve(channelName: string): void;
   cbObserved(): ObservedMessage[];
+  cbEvents(): ObservedEvent[];
   cbReadStream(offset: number, length: number): Promise<RangeResult>;
   cbRole(): string;
   cbStart(): Promise<string>;
@@ -57,6 +64,7 @@ function harness(page: Page): {
   ): Promise<void>;
   observe(channelName: string): Promise<void>;
   observed(): Promise<ObservedMessage[]>;
+  events(): Promise<ObservedEvent[]>;
   readStream(offset: number, length: number): Promise<RangeResult>;
   role(): Promise<string>;
   start(): Promise<string>;
@@ -85,6 +93,7 @@ function harness(page: Page): {
         channelName
       ),
     observed: () => page.evaluate(() => (window as unknown as LeadershipHarness).cbObserved()),
+    events: () => page.evaluate(() => (window as unknown as LeadershipHarness).cbEvents()),
     readStream: (offset, length) =>
       page.evaluate(
         (args) => (window as unknown as LeadershipHarness).cbReadStream(args.offset, args.length),
@@ -314,14 +323,21 @@ test.describe('tab leadership over real Web Locks + BroadcastChannel', () => {
     expect(await follower.upload(filename, hex(plaintext))).toBe('ok');
     expect(await follower.createNode('rothko-appraisal', 'folder')).toBe('ok');
 
+    // The commit emitted an engine event carrying a node id and a block count;
+    // the follower received it over its private port.
+    await expect
+      .poll(async () => (await follower.events()).map((event) => event.kind))
+      .toContain('opProgress');
+    const progress = (await follower.events()).find((event) => event.kind === 'opProgress')!;
+    expect(progress.bytesHex.length).toBeGreaterThan(0);
+
     const observed = await eavesdropper.observed();
     expect(observed.length).toBeGreaterThan(0);
-    // The channel carries election, the port rendezvous, and key-free events —
-    // no write step and no command, so no argument can ride one.
+    // The channel carries election and the port rendezvous — no write step, no
+    // command and no event, so no argument and no descriptor can ride one.
     for (const type of new Set(observed.map((message) => message.type))) {
       expect([
         'cb:bye',
-        'cb:event',
         'cb:hello',
         'cb:leader',
         'cb:leaderGone',
@@ -329,8 +345,11 @@ test.describe('tab leadership over real Web Locks + BroadcastChannel', () => {
         'cb:portWanted',
       ]).toContain(type);
     }
-    const seenBytes = observed.map((message) => message.bytesHex).join('');
+    const seenBytes = observed.map((message) => message.bytesHex).join('|');
     expect(seenBytes).not.toContain(hex(plaintext.slice(0, 16)));
+    // Whatever bytes that descriptor carried, the bystander saw none of them —
+    // so a field added to `EventDescriptor` later cannot leak here unnoticed.
+    expect(seenBytes).not.toContain(progress.bytesHex);
     const seenText = observed.map((message) => message.text).join(' ');
     expect(seenText).not.toContain(filename);
     expect(seenText).not.toContain('rothko-appraisal');

--- a/packages/client/test/browser/leadership.spec.ts
+++ b/packages/client/test/browser/leadership.spec.ts
@@ -325,11 +325,14 @@ test.describe('tab leadership over real Web Locks + BroadcastChannel', () => {
 
     // The commit emitted an engine event carrying a node id and a block count;
     // the follower received it over its private port.
+    let progress: ObservedEvent | undefined;
     await expect
-      .poll(async () => (await follower.events()).map((event) => event.kind))
-      .toContain('opProgress');
-    const progress = (await follower.events()).find((event) => event.kind === 'opProgress')!;
-    expect(progress.bytesHex.length).toBeGreaterThan(0);
+      .poll(async () => {
+        progress = (await follower.events()).find((event) => event.kind === 'opProgress');
+        return progress !== undefined;
+      })
+      .toBe(true);
+    expect(progress!.bytesHex.length).toBeGreaterThan(0);
 
     const observed = await eavesdropper.observed();
     expect(observed.length).toBeGreaterThan(0);
@@ -349,7 +352,7 @@ test.describe('tab leadership over real Web Locks + BroadcastChannel', () => {
     expect(seenBytes).not.toContain(hex(plaintext.slice(0, 16)));
     // Whatever bytes that descriptor carried, the bystander saw none of them —
     // so a field added to `EventDescriptor` later cannot leak here unnoticed.
-    expect(seenBytes).not.toContain(progress.bytesHex);
+    expect(seenBytes).not.toContain(progress!.bytesHex);
     const seenText = observed.map((message) => message.text).join(' ');
     expect(seenText).not.toContain(filename);
     expect(seenText).not.toContain('rothko-appraisal');

--- a/packages/client/test/browser/leadership.ts
+++ b/packages/client/test/browser/leadership.ts
@@ -41,6 +41,13 @@ export interface ObservedMessage {
   text: string;
 }
 
+/** One engine event this tab's facade received, flattened the same way. */
+export interface ObservedEvent {
+  kind: string;
+  bytesHex: string;
+  text: string;
+}
+
 /** A page.evaluate-safe download projection; `code` is the engine's stable error code. */
 export interface DownloadResult {
   bytes?: number[];
@@ -69,6 +76,7 @@ declare global {
     cbCreate(options: HarnessOptions): Promise<void>;
     cbObserve(channelName: string): void;
     cbObserved(): ObservedMessage[];
+    cbEvents(): ObservedEvent[];
     cbReadStream(offset: number, length: number): Promise<RangeResult>;
     cbRole(): string;
     cbStart(): Promise<string>;
@@ -87,6 +95,7 @@ declare global {
 
 let client: EngineClient | null = null;
 const observed: ObservedMessage[] = [];
+const events: ObservedEvent[] = [];
 
 const rootNode = new Uint8Array(16);
 
@@ -140,8 +149,12 @@ window.cbCreate = async ({ lockName, channelName, worker }: HarnessOptions): Pro
     // Failover re-derivation: a real login re-exports this from Core Kit.
     secretSource: { provideSecret: () => Promise.resolve(secret()) },
   });
+  client.subscribe((event) => events.push({ kind: event.kind, ...collect(event) }));
   await awaitElection(client, lockName);
 };
+
+/** Every engine event this tab's facade received, in arrival order. */
+window.cbEvents = (): ObservedEvent[] => events;
 
 window.cbRole = (): string => client?.currentRole() ?? 'none';
 

--- a/packages/client/test/browser/leadership.ts
+++ b/packages/client/test/browser/leadership.ts
@@ -129,6 +129,9 @@ window.cbCreate = async ({ lockName, channelName, worker }: HarnessOptions): Pro
     // Failover re-derivation: a real login re-exports this from Core Kit.
     secretSource: { provideSecret: () => Promise.resolve(secret()) },
   });
+  // A fresh client observes a fresh stream: a prior client's events are not its
+  // own, and a leak poll that matched one would pass for the wrong reason.
+  events.length = 0;
   client.subscribe((event) => events.push({ kind: event.kind, ...collect(event) }));
   await awaitElection(client, lockName);
 };

--- a/packages/client/test/browser/leadership.ts
+++ b/packages/client/test/browser/leadership.ts
@@ -8,6 +8,7 @@
  * kill-the-leader failover with no accepted-op loss.
  */
 import { EngineClient } from '../../src/engineClient.js';
+import { collect } from '../../src/testkit.js';
 import type { PendingClass } from '../../src/worker/protocol.js';
 import { awaitElection } from './election.js';
 import { hex, unhex } from './hexUtil.js';
@@ -98,27 +99,6 @@ const observed: ObservedMessage[] = [];
 const events: ObservedEvent[] = [];
 
 const rootNode = new Uint8Array(16);
-
-/**
- * Every byte and every string anywhere in a message, flattened so a plaintext or
- * argument search can scan them: `bytesHex` catches upload and read payloads,
- * `text` catches names, contact codes and signatures.
- */
-function collect(value: unknown): { bytesHex: string; text: string } {
-  const found: number[] = [];
-  const strings: string[] = [];
-  const walk = (node: unknown): void => {
-    if (node instanceof ArrayBuffer) for (const byte of new Uint8Array(node)) found.push(byte);
-    else if (ArrayBuffer.isView(node)) {
-      const view = new Uint8Array(node.buffer, node.byteOffset, node.byteLength);
-      for (const byte of view) found.push(byte);
-    } else if (typeof node === 'string') strings.push(node);
-    else if (Array.isArray(node)) for (const entry of node) walk(entry);
-    else if (node && typeof node === 'object') for (const entry of Object.values(node)) walk(entry);
-  };
-  walk(value);
-  return { bytesHex: hex(Uint8Array.from(found)), text: strings.join(' ') };
-}
 
 function settle(error: unknown): string {
   if (error === undefined) return 'ok';


### PR DESCRIPTION
## What

Two changes to the same three files, so they ship together.

### The leader no longer broadcasts vault metadata

`LeaderRelay` posted every `EventDescriptor` on the origin-wide `BroadcastChannel` as `cb:event`. The leadership token stamped it but did not confine it: any same-origin context that opened the channel — an XSS foothold, an injected bundle, a stray iframe — read every node id, IPNS name, routing key, op id and block count the stream carries. That is the structural metadata a zero-knowledge design withholds from everyone but the user.

The stream now rides each follower's private `MessagePort` as `cb:portEvent` (option 1 in the issue). The channel carries election and the port rendezvous only, in both directions.

- No token on the port message: the port is private to one leadership, and the follower already ignores everything on it until adoption, which is token-gated by `cb:portReady`.
- A follower mirrors events once its port is adopted. It brokers eagerly at every leadership change, and now also re-brokers when the leader drops its port — without that, a one-way stream has nothing to re-dial it.

### Follower death is structural, not a heartbeat

Every tab holds an exclusive Web Lock named `cipherbox-presence:<clientId>` from before it greets the leader until the browser releases it on close, crash or discard. The leader requests that same lock with an `AbortSignal` for each follower it adopts; the grant *is* the death signal.

- A killed tab is reclaimed on the turn its lock releases, not after up to a minute of missed probes — so its staging reservation and the content version its read stream pinned, with the key resident alongside, are freed at once.
- A frozen, discarded or bfcached tab answers no probe but still holds its lock, so it is never a false positive.
- The watch is keyed on the client, not the port, so a tab that re-brokers keeps its handles.
- `cb:portPing`/`cb:portPong`, `livenessIntervalMs` and `livenessMisses` are gone, along with both magic constants.
- A tab that greets while holding no presence is granted immediately and reclaimed: the greeting is only as good as the lock behind it. A tab whose lock is lost after the fact fails closed rather than greeting on a name it no longer holds.

`FakeLockManager` now models per-name locks, granted on a later turn like the real API, with a steal path.

## Verification

Run in this worktree:

- **Client Browser Suite** (`pnpm --filter @cipherbox/client test:browser`) — 32/32 in real Chromium, over real `navigator.locks` and a real `BroadcastChannel`. Every follower path in that suite now acquires a real presence lock and is watched by a real leader-side request.
- **Unit suite** (`pnpm --filter @cipherbox/client test`) — 374/374.
- `pnpm typecheck`, `pnpm lint`, `pnpm lint:tracker-refs` — clean.

The confidentiality claim is asserted, not stated. In `test/browser/leadership.spec.ts`, a third tab that drives no engine opens the channel and records every message, flattened to all its bytes and all its strings. During a follower's full upload-and-refresh cycle the leader's engine now emits a real `opProgress` descriptor carrying a node id, and the test asserts:

1. the follower received that event (over its port), and
2. the observed channel type set is exactly `cb:bye`, `cb:hello`, `cb:leader`, `cb:leaderGone`, `cb:portHost`, `cb:portWanted`, and
3. the bystander saw none of the bytes **that descriptor actually carried** — the needle is derived from the received event, not hardcoded, so a field added to `EventDescriptor` later cannot leak unnoticed.

Both halves were mutation-checked against the real browser: re-posting the event on the channel fails (2); smuggling the same descriptor under an allowed message type still fails (3). The unit suite mirrors it, emitting one of every `EventDescriptor` variant and scanning the channel for every byte, string, id and count.

The presence tests were mutation-checked the same way — disabling the watch, greeting before the lock is held, dropping the fail-closed guard and dropping the re-broker each turn a specific test red.

## Notes

- `blueprint/web-client.md` disclosed the old behaviour deliberately; that paragraph is rewritten, and a new bullet states the presence-lock invariant.
- `engineClient.ts` is touched only to thread `config.locks` into both the relay and the follower transport.
- Not done, deliberately: the presence name stays the `clientId` rather than a fresh per-transport id. A same-origin context can squat or steal that name and deny a tab its mirroring — which is inside the declared trust boundary and now fails closed, where the pre-existing forged `cb:bye` was a one-shot with the same reach. Worth revisiting if the trust model ever tightens.
- `navigator.locks.query()` makes presence lock names readable origin-wide. A name carries a `clientId` and nothing else — the same disclosure the channel already makes — and that is now stated where the name is minted.

Closes #1052
Closes #1038


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move engine event delivery off BroadcastChannel onto private MessagePorts and replace ping/pong liveness with Web Lock presence detection
> - Engine `EventDescriptor` values are now fanned out to each follower over its private `MessagePort` via `cb:portEvent` instead of being broadcast on the origin-wide `BroadcastChannel`, so no event payload is ever visible to other origins or tabs.
> - Follower tabs acquire an exclusive Web Lock (`cipherbox-presence:<clientId>`) on construction; the leader watches for that lock to be released to detect tab death, replacing the old periodic ping/pong probing.
> - `LeaderRelay` gains `watchPresence`/`retirePresence` helpers and a `fanOut` method; `BroadcastTransport` gains `holdPresence`/`awaitPresence` and gates port brokerage on lock acquisition.
> - `FakeLockManager` in [testkit.ts](https://github.com/FSM1/cipher-box/pull/1082/files#diff-46a6657d66ece0e8d0fb728c6a3cc77c505e8680da9b3c5f505961d49677e672) is reworked to support per-name exclusive locks, abort semantics, and `fail()` for simulating stolen locks, enabling new presence-aware unit and browser tests.
> - Behavioral Change: frozen-but-live tabs are no longer false-positive reclaimed; crashed tabs are reclaimed without a `cb:bye`; holding a presence lock disables BFCache for the tab.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e0c172.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Sensitive vault identifiers, metadata, commands, and events are no longer exposed through shared browser messaging.
  * Upload progress and engine events are delivered through private communication channels.

* **Reliability**
  * Improved coordination between browser tabs, including safer recovery when connections close or leadership changes.
  * Tab termination now triggers faster cleanup of active reads, writes, and focus state.
  * Frozen or background tabs are less likely to be incorrectly treated as disconnected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->