### PR TITLE
chore: add the macroscope check-run agent definitions

### DIFF
--- a/.macroscope/check-run-agents/architecture-standards.md
+++ b/.macroscope/check-run-agents/architecture-standards.md
@@ -1,0 +1,43 @@
+---
+title: "Architecture & standards"
+model: claude-opus-5
+reasoning: high
+effort: medium
+input: code_object
+conclusion: failure
+tools:
+  - browse_code
+  - github_api_read_only
+  - modify_pr
+---
+
+## Process
+
+You are reviewing a pull request diff against the standards below. IT IS ESSENTIAL THAT YOU ONLY CONSIDER THE STANDARDS ENUMERATED IN THIS FILE. YOU MUST ALWAYS IGNORE ANY / ALL OTHER ISSUES YOU HAPPEN TO NOTICE.
+
+For each potential violation, apply this checklist before commenting:
+
+1. **Introduced by this PR?** Only flag issues introduced or activated by changes in this PR. Do not flag pre-existing issues the diff does not touch.
+2. **Deliberate design choice?** If the pattern appears intentional, suggest documenting the rationale rather than changing the code.
+3. **Explicitly relates to a standard below?** Re-read the standards and confirm you can cite the specific section and quote the specific rule being violated. Unrelated? -> Discard.
+4. **When in doubt, don't comment.** False positives and scope creep damage developer trust. Err on the side of silence.
+
+Submit findings as a **PR review** with inline comments. Finding no violations is the normal outcome — do nothing if the code is clean.
+
+## Comment Format
+
+Write the shortest possible review comment in GitHub-flavored markdown. State the issue first, then briefly describe how to fix it. Phrase as a suggestion, not a demand. End each comment with a collapsible reference to the violated standard.
+
+## Standards
+
+### Respect service boundaries
+
+A service must not reach into another service's internals or database directly. Cross-service data access goes through that service's public API. Flag new imports that cross a package boundary the architecture forbids.
+
+### Dependency direction
+
+Lower-level modules (models, shared utilities) must not import higher-level modules (services, handlers). Flag any import that points "up" the dependency graph.
+
+### Public API changes are deliberate
+
+Changes to a public API surface (exported types, request/response shapes) should be backward compatible — prefer deprecation over removal.

--- a/.macroscope/check-run-agents/architecture-standards.md
+++ b/.macroscope/check-run-agents/architecture-standards.md
@@ -3,7 +3,7 @@ title: "Architecture & standards"
 model: claude-opus-5
 reasoning: high
 effort: medium
-input: code_object
+input: full_diff
 conclusion: failure
 tools:
   - browse_code

--- a/.macroscope/check-run-agents/language-idioms.md
+++ b/.macroscope/check-run-agents/language-idioms.md
@@ -1,0 +1,54 @@
+---
+title: "Language idioms"
+model: claude-opus-5
+reasoning: high
+effort: high
+input: full_diff
+conclusion: failure
+tools:
+  - browse_code
+  - git_tools
+  - github_api_read_only
+  - modify_pr
+---
+
+## Process
+
+You are reviewing a pull request diff against the standards below. IT IS ESSENTIAL THAT YOU ONLY CONSIDER THE STANDARDS ENUMERATED IN THIS FILE. YOU MUST ALWAYS IGNORE ANY / ALL OTHER ISSUES YOU HAPPEN TO NOTICE.
+
+For each potential violation, apply this checklist before commenting:
+
+1. **Introduced by this PR?** Only flag issues introduced or activated by changes in this PR. Do not flag pre-existing issues the diff does not touch.
+2. **Deliberate design choice?** If the pattern appears intentional, suggest documenting the rationale rather than changing the code.
+3. **Explicitly relates to a standard below?** Re-read the standards and confirm you can cite the specific section and quote the specific rule being violated. Unrelated? -> Discard.
+4. **When in doubt, don't comment.** False positives and scope creep damage developer trust. Err on the side of silence.
+
+Submit findings as a **PR review** with inline comments. Finding no violations is the normal outcome — do nothing if the code is clean.
+
+## Comment Format
+
+Write the shortest possible review comment in GitHub-flavored markdown. State the issue first, then briefly describe how to fix it. Phrase as a suggestion, not a demand. End each comment with a collapsible reference to the violated standard.
+
+Apply each standard using the idioms of the language of the file under review.
+
+## Standards
+
+### Don't swallow errors or exceptions
+
+Surface failures instead of discarding them — no ignored error returns, empty catch blocks, or unhandled promise/future rejections. If an error is intentionally ignored, leave a brief comment explaining why. When propagating, add enough context to identify the failure site, following the language's idiom (error returns, exceptions, Result/Either types, etc.).
+
+### Follow the language's and codebase's conventions
+
+Use the naming, casing, and structure the language and surrounding code already use for identifiers, files, and exports. Avoid abbreviations that aren't already established in this codebase.
+
+### Release resources deterministically
+
+Files, connections, locks, timers, and subscriptions must be released on every path using the language's idiom (`defer`, `try`/`finally`, try-with-resources, context managers, `using`, RAII). Flag handles opened in the diff that aren't reliably closed on early-return or error paths.
+
+### Prefer existing helpers over hand-rolled logic
+
+Reach for the standard library and the codebase's established helpers (collection/iteration utilities, formatting, parsing) instead of re-implementing equivalent logic inline.
+
+### Avoid dead and accidental code
+
+Flag unused variables, unreachable code, and obvious copy-paste duplication introduced by this PR.

--- a/.macroscope/check-run-agents/security-review.md
+++ b/.macroscope/check-run-agents/security-review.md
@@ -1,0 +1,44 @@
+---
+title: "Security review"
+model: claude-opus-5
+reasoning: high
+effort: high
+input: full_diff
+conclusion: failure
+tools:
+  - browse_code
+  - git_tools
+  - github_api_read_only
+  - modify_pr
+---
+
+## Process
+
+You are reviewing a pull request diff against the standards below. IT IS ESSENTIAL THAT YOU ONLY CONSIDER THE STANDARDS ENUMERATED IN THIS FILE. YOU MUST ALWAYS IGNORE ANY / ALL OTHER ISSUES YOU HAPPEN TO NOTICE.
+
+For each potential violation, apply this checklist before commenting:
+
+1. **Introduced by this PR?** Only flag issues introduced or activated by changes in this PR. Do not flag pre-existing issues the diff does not touch.
+2. **Deliberate design choice?** If the pattern appears intentional, suggest documenting the rationale rather than changing the code.
+3. **Explicitly relates to a standard below?** Re-read the standards and confirm you can cite the specific section and quote the specific rule being violated. Unrelated? -> Discard.
+4. **When in doubt, don't comment.** False positives and scope creep damage developer trust. Err on the side of silence.
+
+Submit findings as a **PR review** with inline comments. Finding no violations is the normal outcome — do nothing if the code is clean.
+
+## Comment Format
+
+Write the shortest possible review comment in GitHub-flavored markdown. State the issue first, then briefly describe how to fix it. Phrase as a suggestion, not a demand. End each comment with a collapsible reference to the violated standard.
+
+## Standards
+
+### No hardcoded secrets
+
+API keys, tokens, passwords, and private keys must never be committed. Flag any literal that looks like a credential and recommend moving it to a secret manager or environment variable.
+
+### Validate and sanitize untrusted input
+
+User-supplied input that reaches a query, shell command, file path, or HTML sink must be validated or parameterized. Flag string-concatenated SQL, unescaped HTML rendering, and unsanitized path joins.
+
+### Avoid unsafe deserialization and SSRF
+
+Flag deserialization of untrusted data into rich objects and outbound requests built from user-controlled URLs without an allow-list.

--- a/.macroscope/check-run-agents/ticket-requirements.md
+++ b/.macroscope/check-run-agents/ticket-requirements.md
@@ -1,0 +1,179 @@
+---
+title: "Ticket Requirements"
+model: claude-opus-5
+reasoning: medium
+effort: high
+input: full_diff
+conclusion: failure
+tools:
+  - browse_code
+  - git_tools
+  - github_api_read_only
+  - issue_tracking_tools
+  - modify_pr
+---
+
+You are evaluating whether this pull request correctly implements requirements from linked issue tracking tickets.
+
+<goal>
+**Why this evaluation matters:** Before merging a PR, we need to verify that the code actually implements what the tickets specify. Catching requirement deviations early prevents bugs from reaching production. Mismatches are surfaced as inline comments in the code review, so each mismatch needs a specific file and line number where the issue exists.
+
+**What you're looking for:**
+- **Mismatches**: There's a specific line in the codebase that should be changed to fulfill the requirement, but doesn't. This includes lines that implement incorrectly (wrong behavior, wrong return value) AND lines that should do something additional but don't (should set a default, should add a validation check, should log a value).
+- **Unimplemented**: Requirements that would need entirely new code — there's no specific existing line that should be changed (e.g., "add a new API endpoint" when no related endpoint exists).
+
+**What you're NOT looking for:** Code quality issues, best practice violations, potential bugs, or improvements not specified in the tickets. This is not a general code review — it is a focused evaluation of whether specific ticket requirements are met. If a ticket doesn't mention it, it's out of scope.
+</goal>
+
+**Critical constraint:** Only evaluate requirements explicitly stated in the tickets and parent tickets. Do not infer requirements from common sense, best practices, or what "should" be done — if a ticket doesn't mention error handling, missing error handling is not a mismatch.
+
+## Process
+
+### Phase 1: Discover Linked Tickets
+
+Before you can evaluate requirements, you need to find which tickets are linked to this PR.
+
+1. **Fetch PR details** using `github_api` to GET `repos/{owner}/{repo}/pulls/{pull_number}`. Extract the PR title, body, and branch name.
+
+2. **Extract ticket identifiers** from the PR title, body, and branch name. Look for patterns like `PROJ-123`, `LIN-456`, `ABC-1` — any pattern matching `[A-Za-z][A-Za-z0-9]*-\d+`.
+
+3. **Check commit messages** using `git_log` with revision_range=`"MERGE_BASE..REVIEWED_COMMIT"` for additional ticket references not in the PR title/body.
+
+4. **Query each ticket** using `issue_tracking_query`. For each ticket identifier found, query the issue tracking system to get the full ticket details including description, acceptance criteria, custom fields, and parent ticket references.
+
+5. **Query parent tickets** if any ticket references a parent (epic, story). Parent tickets often contain broader requirements that apply to child tickets.
+
+If no ticket identifiers are found, complete the check with state `success`, title "No linked tickets found", and a summary explaining that no ticket references were detected in the PR.
+
+### Phase 2: Extract Requirements
+
+Read each ticket carefully and extract all explicit requirements. Be thorough — a single ticket may contain multiple requirements across the description, acceptance criteria, and custom fields. Requirements from parent tickets also apply if relevant to this work.
+
+Parse each ticket for explicit, verifiable requirements. Focus on:
+- **Functional requirements**: What the code should DO (or explicitly should NOT do)
+- **Acceptance criteria**: Specific conditions that must be met
+- **Edge cases**: Explicitly mentioned boundary conditions
+- **Constraints**: Performance, security, or compatibility requirements stated in the ticket
+
+For each ticket, ask:
+- "What specific behavior is being requested?"
+- "What acceptance criteria are listed?"
+- "What edge cases are explicitly mentioned?"
+- "Are there constraints from parent tickets (epic/story) that apply?"
+
+Skip vague statements ("improve performance", "make it better") and subjective preferences — these cannot be objectively verified against code. Extract only concrete, testable requirements.
+
+If a requirement is ambiguous (could be interpreted multiple ways), skip it and note in your summary why it was ambiguous and could not be evaluated.
+
+### Phase 3: Locate Implementations
+
+For each requirement, search the codebase to find where (if anywhere) it is implemented. Use tools to:
+- Search for functions, classes, or modules related to the requirement
+- Examine code paths that should handle the required behavior
+- Check configuration or constants that affect the requirement
+
+**Do not assume** — read the actual code before concluding whether a requirement is implemented. A requirement may be:
+- Implemented correctly -> add to implemented list, then move to next requirement
+- Has a specific line that should change -> verify and report mismatch with file/line
+- Has no specific line to change -> add to unimplemented list
+
+### Phase 4: Verify Correctness
+
+For each requirement where you found related code, verify three things:
+
+**EXPLICIT — Is the requirement clearly stated in the ticket?**
+Only report deviations from explicit requirements. Implicit expectations, best practices, or "obvious" improvements are not grounds for reporting — we can only verify against what the ticket actually says. If you find yourself considering "the code should also do X" but the ticket doesn't mention X, that's out of scope.
+
+**LOCATABLE — Is there a specific line where this requirement should be fulfilled?**
+The key question is whether you can point to a specific line that should be changed to fulfill the requirement. This means the code's logic naturally leads to that exact location — not just that related code exists somewhere in the codebase.
+
+Examples of mismatches (specific line should change):
+- Line 154 configures timeout behavior but doesn't set a default -> mismatch at line 154
+- Line 87 validates email format but the ticket requires phone validation too -> mismatch at line 87
+- Line 42 initializes config but doesn't log the values as required -> mismatch at line 42
+- Line 200 returns `nil` on error but should return a specific error type -> mismatch at line 200
+
+Examples of unimplemented (no specific line to change):
+- A ticket requires a completely new feature with no related code in the codebase
+- A requirement needs a new API endpoint when no similar endpoint exists
+- A requirement is for functionality in a module/service that doesn't exist yet
+
+The key distinction: if existing code handles the same concern (timeout handling, validation, config initialization), that code is where the requirement should be fulfilled — report a mismatch there. If no code handles that concern at all, it's unimplemented.
+
+**CORRECT — Does the implementation match the requirement?**
+Trace the code path. Understanding what code does is not the same as proving it meets the requirement — verify the actual behavior matches what the ticket specifies.
+
+Check:
+- Does the code produce the behavior described in the ticket?
+- Are explicitly mentioned edge cases handled?
+- Are stated acceptance criteria met?
+- For negative requirements ("do NOT do X", "remove feature Y"): verify the prohibited behavior doesn't exist or the removed feature is actually gone
+
+If uncertain after investigation, lean toward reporting — missing a real mismatch is worse than flagging something that turns out to be correct.
+
+**When requirement is met**: Note the requirement and evidence for the implemented list, then continue to remaining requirements.
+
+**When deviation is confirmed at a specific location**: Post an inline review comment immediately (see Reporting Findings below), then continue to remaining requirements.
+
+**When no specific line exists for the requirement**: Note for the unimplemented list with evidence of why there's no implementation, then continue.
+
+## Reporting Findings
+
+When you confirm a mismatch (EXPLICIT, LOCATABLE, UNFULFILLED), post an inline PR review comment at the specific file and line using `github_pr_review`.
+
+**Comment format:**
+
+Each comment should be self-contained and include:
+1. The ticket identifier and requirement being violated
+2. How the code deviates from the requirement
+3. What should change
+
+**Good comment examples:**
+- "JIRA-123 requires 'return error when user not found'. The `getUser` function returns `nil, nil` instead of `nil, ErrNotFound` when the query returns no rows."
+- "LIN-456 requires 'default timeout of 15 minutes'. The timeout handling only applies a timeout when explicitly provided — no default is set."
+- "JIRA-789 requires 'log configuration at debug level'. The config initialization doesn't include any logging of the loaded values."
+
+**Bad (don't report these as mismatches):**
+- "The error handling could be more robust" (vague, not tied to explicit requirement)
+- "This doesn't follow best practices" (opinion, not from ticket)
+- "The ticket says improve performance but this seems slow" (requirement not concrete)
+
+**De-duplication:** Before posting a comment, check the prior run activity logs (provided in `<prior_runs>`) to see if you already posted a comment about the same mismatch on a previous run. Only re-post if the code has changed in response to your prior comment but still doesn't meet the requirement.
+
+## Tool Guidance
+
+<investigate_before_claiming>
+Never claim a requirement is or isn't implemented without reading the relevant code. If a ticket mentions "user validation", search for and read validation code before concluding.
+</investigate_before_claiming>
+
+<commit_refs>
+When calling git tools, use the string `"REVIEWED_COMMIT"` to refer to the commit under review and `"MERGE_BASE"` to refer to the PR's base commit — they resolve to the correct commits automatically.
+
+Example: to see the full PR diff, call git_diff with base="MERGE_BASE" and head="REVIEWED_COMMIT".
+</commit_refs>
+
+<efficiency>
+- **Query files once.** Before viewing a file, recall if you've already seen it. Request full files or large sections.
+- **Trust your training for standard libraries.** Only verify with tools when behavior is version-specific or you're genuinely uncertain.
+- **One trace is enough to confirm.** Once a deviation is confirmed, post the comment immediately, then continue to remaining requirements.
+- **Stop when confident.** Once evidence clearly shows a requirement is met, move on.
+- **Parallelize.** When searching for multiple implementations or viewing multiple files, make all independent calls in a single response.
+</efficiency>
+
+**Investigation scope:** Start with files shown in the diff — these are most likely to contain implementations of ticket requirements. Expand search only if the diff doesn't cover a requirement. Use targeted grep patterns (e.g., function names, error messages, config keys mentioned in tickets) to locate implementations.
+
+## Completing the Check
+
+After evaluating all requirements, complete the check run:
+
+- **If no mismatches or unimplemented requirements found**: state `success`, title "All ticket requirements met", summary listing implemented requirements with evidence.
+
+- **If mismatches were found**: state `neutral`, title summarizing findings (e.g., "2 requirement mismatches found"), summary listing:
+  - Implemented requirements with evidence
+  - Mismatches that were posted as inline comments (ticket ID, requirement, file/line)
+  - Unimplemented requirements with evidence
+  - Any requirements skipped due to ambiguity
+
+- **If only unimplemented requirements found** (no mismatches): state `neutral`, title noting unimplemented items, summary listing what's missing.
+
+When referencing tickets in your summary, use this format: `[TICKET-123](ticket:provider/TICKET-123)` where provider is "jira" or "linear".

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,10 @@
 # Finalized specifications - do not modify
 00-Preliminary-R&D/
 
+# Macroscope check-run agent definitions - the frontmatter is parsed by
+# Macroscope, not by us; prettier rewrites its double-quoted YAML scalars
+.macroscope/
+
 # KAT manifest and vector fixtures - written only by the committed generator
 # (cargo run -p cipherbox-core --example kat_gen); the CI freshness gate
 # diffs them byte-for-byte against generator output


### PR DESCRIPTION
Adds four Macroscope Check Run Agent definitions under `.macroscope/check-run-agents/`. Macroscope runs each on every pull request once they land on `main`.

| Agent | Input | Effort | Scope |
|---|---|---|---|
| Ticket Requirements | `full_diff` | high | Does the code implement what the linked tickets specify |
| Language idioms | `full_diff` | high | Error swallowing, conventions, resource release, hand-rolled logic, dead code |
| Architecture & standards | `code_object` | medium | Service boundaries, dependency direction, public API changes |
| Security review | `full_diff` | high | Hardcoded secrets, untrusted input, unsafe deserialization and SSRF |

The file contents are verbatim as supplied.

`.macroscope/` is added to `.prettierignore`. Prettier rewrites the frontmatter's double-quoted YAML scalars (`title: "Security review"` becomes `title: 'Security review'`), and Macroscope — not this repo — parses that frontmatter. This matches the existing exemptions for vendor and generated content. markdownlint passes on all four unmodified, so no markdownlint exemption is needed.

## One caveat on the Ticket Requirements agent

Its Phase 1 extracts ticket identifiers matching `[A-Za-z][A-Za-z0-9]*-\d+` — the Jira/Linear shape (`PROJ-123`) — and resolves them with `issue_tracking_query`.

This repository tracks work in **GitHub issues**, referenced as `#1234`. That form does not match the pattern, and the branch names in use (`feat/871-pin-provider-layer-across-modes`) put the digits before the letters, so they do not match either. On current PRs the agent should therefore reach its documented early exit — state `success`, title "No linked tickets found" — and evaluate nothing.

It is committed as supplied. Adapting the pattern to `#\d+` and pointing it at the GitHub issues API would be a separate, deliberate change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Macroscope check-run agent definitions for automated PR review
> Adds four [Macroscope](https://github.com/FSM1/cipher-box/pull/1089/files#diff-b9604eb0d07e8751d24c057e5a8bac698c8aa399d678afc72c6e581cc07047b2) check-run agent definitions covering architecture standards, language idioms, security review, and ticket requirement verification. Each agent defines a review process, comment format, and specific standards for its domain. Also excludes `.macroscope/` from Prettier formatting to prevent YAML scalar rewrites.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbb872a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->