### PR TITLE
feat: implement the write wave publisher over the real net seams

### DIFF
--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -57,4 +57,4 @@ pub(crate) use resolve::{
 };
 pub use retire::{OrphanHeads, orphaned_head, retire, root_retire_ready};
 pub use revival::{ReviveError, ReviveRequest, revive};
-pub use rotation::{OwnerRotationKeys, OwnerRotationNet};
+pub use rotation::{OwnerRotationKeys, OwnerRotationNet, WriteWaveNet};

--- a/crates/engine/src/net/mod.rs
+++ b/crates/engine/src/net/mod.rs
@@ -48,7 +48,10 @@ pub use liveness::{
     eol_republish, keyless_re_put, run_liveness_loop,
 };
 pub use pointer_fetch::RecordPointerFetch;
-pub use publish::{PublishError, PublishOutcome, PublishReceipt, PublishRequest, publish};
+pub use publish::{
+    InlineRecordRequest, PublishError, PublishOutcome, PublishReceipt, PublishRequest, publish,
+    publish_inline,
+};
 pub use record_publish::{PreflightError, RecordPublishError};
 pub use register::register;
 pub use resolve::{AdoptOutcome, Adopter, OwnScopeMaterial, ResolveOutcome, Resolved, resolve};

--- a/crates/engine/src/net/publish.rs
+++ b/crates/engine/src/net/publish.rs
@@ -147,6 +147,71 @@ pub enum PublishError {
     },
 }
 
+/// One record the pipeline is about to sign: the name it publishes under, its
+/// signer, the `Value` bytes, and the registration that must land first. The
+/// shape both entry points reduce to, so the publish laws are stated once.
+struct Publishable<'a> {
+    name: &'a IpnsName,
+    signer: &'a Ed25519Signer,
+    value: Vec<u8>,
+    registration: NameRegistration,
+    min_current_sequence: Option<u64>,
+}
+
+/// One record whose `Value` is the payload itself rather than an `/ipfs/` head
+/// pointer — the pointer plane's shape, which
+/// [`RecordPointerFetch`](super::pointer_fetch::RecordPointerFetch) reads back
+/// verbatim.
+pub struct InlineRecordRequest<'a> {
+    /// The IPNS name being published (its Ed25519 key is [`Self::signer`]'s).
+    pub name: &'a IpnsName,
+    /// The name's Ed25519 signing key.
+    pub signer: &'a Ed25519Signer,
+    /// The record `Value` bytes.
+    pub value: &'a [u8],
+    /// Raises the CAS expected-current sequence, exactly as
+    /// [`PublishRequest::min_current_sequence`] does.
+    pub min_current_sequence: Option<u64>,
+}
+
+/// Publish an inline-value record. Same pipeline as [`publish`], same laws;
+/// only the record `Value` differs.
+pub async fn publish_inline<T, H, C, F, Sch>(
+    transport: &T,
+    api: &ApiClient<H, C>,
+    floors: &F,
+    scheduler: &Sch,
+    profile: &SyncTimingProfile,
+    request: &InlineRecordRequest<'_>,
+) -> Result<PublishReceipt, PublishError>
+where
+    T: RecordTransport + Clone + 'static,
+    H: Http,
+    C: CredentialStore,
+    F: FloorStore,
+    Sch: Scheduler + Clone + 'static,
+{
+    run(
+        transport,
+        api,
+        floors,
+        scheduler,
+        profile,
+        Publishable {
+            name: request.name,
+            signer: request.signer,
+            value: request.value.to_vec(),
+            registration: NameRegistration {
+                ipns_name: request.name.as_str().to_owned(),
+                head_cid: None,
+                content_cids: Vec::new(),
+            },
+            min_current_sequence: request.min_current_sequence,
+        },
+    )
+    .await
+}
+
 /// Run the publish pipeline for `request`. Register-first and fail-closed:
 /// on a registration failure nothing is PUT.
 pub async fn publish<T, H, C, F, Sch>(
@@ -170,10 +235,41 @@ where
     if request.head_cid.is_empty() {
         return Err(PublishError::EmptyHeadCid);
     }
+    run(
+        transport,
+        api,
+        floors,
+        scheduler,
+        profile,
+        Publishable {
+            name: request.name,
+            signer: request.signer,
+            value: request.value(),
+            registration: request.registration(),
+            min_current_sequence: request.min_current_sequence,
+        },
+    )
+    .await
+}
 
+async fn run<T, H, C, F, Sch>(
+    transport: &T,
+    api: &ApiClient<H, C>,
+    floors: &F,
+    scheduler: &Sch,
+    profile: &SyncTimingProfile,
+    request: Publishable<'_>,
+) -> Result<PublishReceipt, PublishError>
+where
+    T: RecordTransport + Clone + 'static,
+    H: Http,
+    C: CredentialStore,
+    F: FloorStore,
+    Sch: Scheduler + Clone + 'static,
+{
     // Register-first, fail-closed: the record never reaches the transport unless
     // the registration succeeds (#24 D6 / #34 D2).
-    register(api, std::slice::from_ref(&request.registration()))
+    register(api, std::slice::from_ref(&request.registration))
         .await
         .map_err(PublishError::Register)?;
 
@@ -194,8 +290,7 @@ where
     let ttl_nanos = u64::try_from(profile.record_ttl.as_nanos()).unwrap_or(u64::MAX);
     let eol = eol::eol_from(scheduler.now());
     let record_bytes =
-        IpnsRecord::create_v2(request.signer, &request.value(), sequence, ttl_nanos, &eol)
-            .marshal();
+        IpnsRecord::create_v2(request.signer, &request.value, sequence, ttl_nanos, &eol).marshal();
     if record_bytes.len() > MAX_RECORD_BYTES {
         return Err(PublishError::RecordTooLarge {
             size: record_bytes.len(),

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -15,35 +15,46 @@
 use core::cell::RefCell;
 use std::collections::BTreeMap;
 
-use cipherbox_core::ipns::IpnsName;
+use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
     AadContext, ChildScopeRef, Envelope, GrantSection, PreservedFields, ReadBody,
     STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_WRITE_BODY, WriteBody, decode_write_body, open_owner_blob,
-    unseal,
+    sign_grant_set, unseal,
 };
-use cipherbox_core::suite::ecdsa::EcdsaVerifier;
+use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
 use cipherbox_core::suite::ed25519::Ed25519Signer;
 use cipherbox_core::suite::secret::SECRET_LEN;
 use cipherbox_core::suite::x25519::X25519Secret;
 use zeroize::Zeroizing;
 
 use super::adopter::RootAdopter;
-use super::author::{AuthorError, ENVELOPE_V, EnvelopeAuthoring, author_scope_root_with_section};
+use super::author::{
+    AuthorError, ENVELOPE_V, EnvelopeAuthoring, author_child_envelope,
+    author_scope_root_with_section,
+};
+use super::child::ChildAdopter;
+use super::eol;
+use super::fanout::{MAX_RECORD_BYTES, fanout_put};
 use super::publish::PublishOutcome;
 use super::record_publish::{HeadBinding, RecordPublishRequest, preflight, publish_record};
-use crate::api::ApiClient;
+use super::register::register;
+use super::retire::{retire, root_retire_ready};
+use crate::api::{ApiClient, NameRegistration};
 use crate::content::Gateway;
 use crate::entropy::Entropy;
-use crate::gate::{GateError, RejectionReason, floor};
+use crate::gate::{GateError, GateStage, RejectionReason, floor};
 use crate::net::fanout_get_verify;
+use crate::net::resolve::Adopter;
 use crate::profile::SyncTimingProfile;
 use crate::rotation::{
-    CascadeResealResolver, CascadeTarget, ChildIndexResolver, ResealedScopeRoot, ResolveFailure,
-    ScopeRootPublishError, ScopeRootPublisher,
+    CascadeResealResolver, CascadeTarget, ChildIndexResolver, RepointChannel, RepublishedNode,
+    ResealedScopeRoot, ResolveFailure, ScopeRootPublishError, ScopeRootPublisher,
+    WritePublishError, WriteWavePublisher,
 };
 use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
 use crate::session::SessionIdentity;
+use crate::sync::pointer::{scope_pointer_name, scope_pointer_signer};
 
 /// The owner key material the rotation edges run under. The owner is the
 /// terminal owner of its own key material, so nothing here is zeroized.
@@ -686,6 +697,435 @@ where
     }
 }
 
+/// The write-plane name wave's transport edge (blueprint/engine.md
+/// "rotateScopeWrite"): the owner arm of [`WriteWavePublisher`] over the same net
+/// plane the read-plane seams above run on.
+///
+/// The wave hands this no authoring material — only routing identity and the one
+/// write seed that signs at the new name ([`RepublishedNode`]) — so every
+/// republish re-resolves the node at its current name through the adoption gate,
+/// rewrites the child names the wave moved, and re-seals under the **unchanged**
+/// read key at the **unchanged** read epoch. The read plane's clock never moves
+/// here (#38 D1).
+pub struct WriteWaveNet<'a, T, H: Http, C: CredentialStore, F, Sch, E> {
+    /// The record-plane transport: fan-out GET for the re-resolve, CAS PUT for
+    /// the republish.
+    pub transport: &'a T,
+    /// The API client: register-first, the head-block upload, and retirement.
+    pub api: &'a ApiClient<H, C>,
+    /// Content read sources for the head block.
+    pub gateway: &'a Gateway,
+    /// The HTTP seam the content fetch rides.
+    pub http: &'a H,
+    /// The durable floors the adoption gate reads and advances.
+    pub floors: &'a F,
+    /// The scheduler the publish pipeline's background re-PUT rides.
+    pub scheduler: &'a Sch,
+    /// The publish pipeline's timing policy.
+    pub profile: &'a SyncTimingProfile,
+    /// Injected entropy — the per-seal nonce source (determinism law).
+    pub entropy: &'a RefCell<E>,
+    /// The scope under rotation; every record the wave touches must claim it.
+    pub scope_id: [u8; 16],
+    /// The scope's read override seed. A write rotation cuts no read key, so the
+    /// same seed derives every per-node read key on both sides of the wave.
+    pub read_scope_seed: &'a [u8; SECRET_LEN],
+    /// The rotating root's own ancestor node seed, required when it is itself an
+    /// interior scope root (its record carries an ascent link the gate verifies
+    /// against a reader-derived keypair).
+    pub parent_node_seed: Option<&'a [u8; SECRET_LEN]>,
+    /// The owner material: opens the root's owner blob, anchors the gate, and
+    /// re-signs the grant-set commitment — which binds `ipnsName`, so a root that
+    /// moves without a re-sign is a record this build's own gate rejects.
+    pub owner: &'a EcdsaSigner,
+    /// Opens each scope root's owner blob on the gated re-resolve.
+    pub owner_enc_secret: &'a X25519Secret,
+    /// Derives the scope pointer's name and its record signer (owner-only).
+    pub owner_pointer_seed: &'a [u8; SECRET_LEN],
+    /// The root name the wave is moving off. It lingers serving the tombstone, so
+    /// [`WriteWaveNet::retire`] refuses a batch naming it.
+    pub current_root_name: &'a IpnsName,
+}
+
+/// One node's current record as the gate authenticated it, plus what a republish
+/// at the new name needs: the body to rewrite, the read epoch and key it re-seals
+/// under, the envelope fields carried forward byte-stable (#27 D10), and the
+/// scope root's section.
+struct WaveSource {
+    read_body: ReadBody,
+    read_epoch: u64,
+    read_key: Zeroizing<[u8; SECRET_LEN]>,
+    unknown: PreservedFields,
+    epoch_tag_unknown: PreservedFields,
+    /// `Some` only for the scope root — interior nodes carry no grant section.
+    section: Option<GrantSection>,
+}
+
+/// Rewrite the in-scope child names the wave moved, or refuse.
+///
+/// Fail-closed both ways: a mapped child the body does not carry means the
+/// subtree enumeration and the published body disagree, and publishing either
+/// half of that disagreement strands a subtree behind a name nothing resolves.
+/// Refs the map does not name — a descendant scope root, which rotates under its
+/// own write scope seed — keep their names.
+fn rewrite_child_names(
+    body: &mut ReadBody,
+    child_names: &BTreeMap<[u8; 16], IpnsName>,
+) -> Result<(), WritePublishError> {
+    let ReadBody::Folder { children, .. } = body else {
+        return if child_names.is_empty() {
+            Ok(())
+        } else {
+            Err(WritePublishError::Rejected)
+        };
+    };
+    let mut rewritten = 0usize;
+    for child in children.iter_mut() {
+        if let Some(name) = child_names.get(&child.id) {
+            child.ipns_name = name.as_str().as_bytes().to_vec();
+            rewritten += 1;
+        }
+    }
+    if rewritten != child_names.len() {
+        return Err(WritePublishError::Rejected);
+    }
+    Ok(())
+}
+
+/// Carry a gate verdict into the wave on rule 6's axis: a rejection is a trust
+/// violation no retry clears, a seam failure is availability.
+fn wave_verdict(error: GateError) -> WritePublishError {
+    match error {
+        GateError::Rejected(_) => WritePublishError::Rejected,
+        GateError::Seam(_) => WritePublishError::NotLanded,
+    }
+}
+
+impl<T, H: Http, C: CredentialStore, F, Sch, E> WriteWaveNet<'_, T, H, C, F, Sch, E>
+where
+    T: RecordTransport,
+    F: FloorStore,
+{
+    /// The freshest verified record at `name`, or an availability stall.
+    async fn record_at(&self, name: &IpnsName) -> Result<Vec<u8>, WritePublishError> {
+        fanout_get_verify(self.transport, name)
+            .await
+            .map(|(_, bytes)| bytes)
+            .ok_or(WritePublishError::NotLanded)
+    }
+
+    /// Gate an interior node's current record and open it for re-authoring.
+    ///
+    /// The adopt advances the per-name sequence floor, so a wave that already
+    /// gated these bytes lands on the at-floor re-open instead — which is also
+    /// the only child path that keeps the envelope's preserved fields.
+    async fn interior_source(
+        &self,
+        node_id: [u8; 16],
+        name: &IpnsName,
+        record_bytes: &[u8],
+    ) -> Result<WaveSource, WritePublishError> {
+        let adopter = ChildAdopter::new(
+            self.gateway,
+            self.http,
+            self.floors,
+            self.scope_id,
+            Zeroizing::new(*self.read_scope_seed),
+            node_id,
+        );
+        if let Err(error) = adopter.adopt(name, record_bytes).await
+            && !matches!(
+                error,
+                GateError::Rejected(ref r) if r.stage == GateStage::Sequence
+            )
+        {
+            return Err(wave_verdict(error));
+        }
+        let (adopted, envelope) = adopter
+            .open_carried_at_floor(name, record_bytes)
+            .await
+            .map_err(wave_verdict)?;
+        if envelope.v != ENVELOPE_V {
+            return Err(WritePublishError::Rejected);
+        }
+        Ok(WaveSource {
+            read_body: adopted.read_body,
+            read_epoch: adopted.epoch,
+            read_key: self.node_read_key(&node_id),
+            unknown: envelope.unknown,
+            epoch_tag_unknown: envelope.epoch_tag_unknown,
+            section: None,
+        })
+    }
+
+    /// Gate the scope root's current record and open it for re-authoring. The
+    /// read key comes from the seed the root's own owner blob carries, never the
+    /// caller's copy — the record must reopen under the key readers re-derive.
+    async fn root_source(
+        &self,
+        name: &IpnsName,
+        record_bytes: &[u8],
+    ) -> Result<WaveSource, WritePublishError> {
+        let identity = self.owner.verifying_key();
+        let mut adopter = RootAdopter::new(
+            self.gateway,
+            self.http,
+            self.floors,
+            self.owner_enc_secret,
+            &identity,
+            self.scope_id,
+        );
+        if let Some(seed) = self.parent_node_seed {
+            adopter = adopter.under_parent_node_seed(Zeroizing::new(*seed));
+        }
+        let (candidate, outcome) = adopter
+            .adopt_root(name, record_bytes)
+            .await
+            .map_err(wave_verdict)?;
+        if candidate.envelope.v != ENVELOPE_V {
+            return Err(WritePublishError::Rejected);
+        }
+        let read_scope_seed = outcome
+            .read_scope_seed
+            .ok_or(WritePublishError::NotLanded)?;
+        let node_seed = kdf::node_seed(&read_scope_seed, &self.scope_id);
+        Ok(WaveSource {
+            read_body: outcome.adopted.read_body,
+            read_epoch: outcome.adopted.epoch,
+            read_key: Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes()),
+            unknown: candidate.envelope.unknown,
+            epoch_tag_unknown: candidate.envelope.epoch_tag_unknown,
+            section: Some(candidate.grant_section),
+        })
+    }
+
+    /// `nodeSeed(readScopeSeed, node) -> readKey` — the frozen edges every reader
+    /// re-derives for an interior node.
+    fn node_read_key(&self, node_id: &[u8; 16]) -> Zeroizing<[u8; SECRET_LEN]> {
+        let node_seed = kdf::node_seed(self.read_scope_seed, node_id);
+        Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes())
+    }
+
+    /// The moved root's grant section: the commitment re-signed over the name the
+    /// record now publishes under (blueprint/engine.md "rotateScopeWrite" — an
+    /// owner-only write rotation re-signs the commitment). Everything else rides
+    /// verbatim; `ipnsName` is not in any structure's AAD (#39 D7), so the
+    /// section's own signatures still recompute.
+    fn resigned_section(
+        &self,
+        section: &GrantSection,
+        new_name: &IpnsName,
+    ) -> Result<GrantSection, WritePublishError> {
+        let mut section = section.clone();
+        section.commitment.ipns_name = new_name.as_str().as_bytes().to_vec();
+        section.commitment_sig = sign_grant_set(self.owner, &section.commitment)
+            .map_err(|_| WritePublishError::Rejected)?
+            .to_compact();
+        Ok(section)
+    }
+}
+
+impl<T, H: Http, C: CredentialStore, F, Sch, E> WriteWaveNet<'_, T, H, C, F, Sch, E>
+where
+    T: RecordTransport + Clone + 'static,
+    F: FloorStore,
+    Sch: Scheduler + Clone + 'static,
+    E: Entropy,
+{
+    /// Author and CAS-publish `node`'s rewritten record at its new name, signing
+    /// under the one write seed the wave handed for it.
+    async fn publish_moved(
+        &self,
+        node: &RepublishedNode,
+        source: WaveSource,
+    ) -> Result<(), WritePublishError> {
+        let WaveSource {
+            mut read_body,
+            read_epoch,
+            read_key,
+            unknown,
+            epoch_tag_unknown,
+            section,
+        } = source;
+        rewrite_child_names(&mut read_body, &node.child_names)?;
+
+        let mut nonce = [0u8; 24];
+        self.entropy
+            .borrow_mut()
+            .fill(&mut nonce)
+            .map_err(|_| WritePublishError::NotLanded)?;
+        let authoring = EnvelopeAuthoring {
+            node_id: node.node_id,
+            scope_id: self.scope_id,
+            epoch: read_epoch,
+            read_key: &read_key,
+            nonce: &nonce,
+            body: &read_body,
+            carried_unknown: unknown,
+            carried_epoch_tag_unknown: epoch_tag_unknown,
+        };
+        let head = match section {
+            Some(section) => author_scope_root_with_section(
+                authoring,
+                &node.new_name,
+                &self.resigned_section(&section, &node.new_name)?,
+                &self.owner.verifying_key(),
+            ),
+            None => author_child_envelope(authoring),
+        }
+        .map_err(|refusal| {
+            if refusal.is_trust_refusal() {
+                WritePublishError::Rejected
+            } else {
+                WritePublishError::NotLanded
+            }
+        })?;
+
+        let binding = HeadBinding {
+            node_id: node.node_id,
+            scope_id: self.scope_id,
+            epoch: read_epoch,
+        };
+        let preflighted =
+            preflight(&binding, &read_key, &head).map_err(|_| WritePublishError::NotLanded)?;
+        let signer = kdf::ipns_keypair(node.write_seed.as_bytes());
+        let receipt = publish_record(
+            self.transport,
+            self.api,
+            self.floors,
+            self.scheduler,
+            self.profile,
+            &RecordPublishRequest {
+                name: &node.new_name,
+                signer: &signer,
+                head: &preflighted,
+                content_cids: Vec::new(),
+                min_current_sequence: None,
+            },
+        )
+        .await
+        .map_err(|_| WritePublishError::NotLanded)?;
+        match receipt.outcome {
+            PublishOutcome::Published { .. } => Ok(()),
+            PublishOutcome::LostRace { .. } => Err(WritePublishError::LostRace),
+            PublishOutcome::Unconfirmed { .. } => Err(WritePublishError::NotLanded),
+        }
+    }
+
+    /// Flip the canonical scope pointer to the sealed re-point `block`.
+    ///
+    /// The record's `Value` is the sealed block itself, not an `/ipfs/` head
+    /// pointer ([`RecordPointerFetch`](super::pointer_fetch::RecordPointerFetch)
+    /// reads it back that way), which is the one shape the record publish
+    /// pipeline cannot express — so the pipeline's own laws are restated here:
+    /// register-first, sequence strictly above anything already at the name, and
+    /// success only on reading our own bytes back.
+    async fn publish_scope_pointer(&self, block: &[u8]) -> Result<(), WritePublishError> {
+        let name = scope_pointer_name(self.owner_pointer_seed, &self.scope_id);
+        register(
+            self.api,
+            &[NameRegistration {
+                ipns_name: name.as_str().to_owned(),
+                head_cid: None,
+                content_cids: Vec::new(),
+            }],
+        )
+        .await
+        .map_err(|_| WritePublishError::RegistryFull)?;
+
+        // Nothing gates a pointer record, so its durable sequence floor may never
+        // have moved; the freshest record on the network is the other lower bound
+        // a second rotation must clear.
+        let durable = floor::sequence_floor(self.floors, name.as_str().as_bytes())
+            .await
+            .map_err(|_| WritePublishError::NotLanded)?
+            .unwrap_or(0);
+        let observed = fanout_get_verify(self.transport, &name)
+            .await
+            .map_or(0, |(record, _)| record.sequence);
+        let sequence = durable.max(observed) + 1;
+
+        let ttl_nanos = u64::try_from(self.profile.record_ttl.as_nanos()).unwrap_or(u64::MAX);
+        let eol = eol::eol_from(self.scheduler.now());
+        let signer = scope_pointer_signer(self.owner_pointer_seed, &self.scope_id);
+        let record_bytes =
+            IpnsRecord::create_v2(&signer, block, sequence, ttl_nanos, &eol).marshal();
+        // A record past the fan-out cap is one this client can never re-resolve,
+        // so its floor would never advance and the name would lapse at EOL.
+        if record_bytes.len() > MAX_RECORD_BYTES {
+            return Err(WritePublishError::Rejected);
+        }
+        if !fanout_put(self.transport, name.as_str(), &record_bytes)
+            .await
+            .any_acked()
+        {
+            return Err(WritePublishError::NotLanded);
+        }
+        match fanout_get_verify(self.transport, &name).await {
+            Some((record, bytes)) if record.sequence == sequence && bytes == record_bytes => Ok(()),
+            Some((record, _)) if record.sequence > sequence => Err(WritePublishError::LostRace),
+            _ => Err(WritePublishError::NotLanded),
+        }
+    }
+}
+
+impl<T, H: Http, C: CredentialStore, F, Sch, E> WriteWavePublisher
+    for WriteWaveNet<'_, T, H, C, F, Sch, E>
+where
+    T: RecordTransport + Clone + 'static,
+    F: FloorStore,
+    Sch: Scheduler + Clone + 'static,
+    E: Entropy,
+{
+    async fn is_republished(&self, new_name: &IpnsName) -> Result<bool, WritePublishError> {
+        Ok(fanout_get_verify(self.transport, new_name).await.is_some())
+    }
+
+    async fn republish(&self, node: &RepublishedNode) -> Result<(), WritePublishError> {
+        let record_bytes = self.record_at(&node.current_name).await?;
+        let source = if node.is_root {
+            self.root_source(&node.current_name, &record_bytes).await?
+        } else {
+            self.interior_source(node.node_id, &node.current_name, &record_bytes)
+                .await?
+        };
+        self.publish_moved(node, source).await
+    }
+
+    async fn retire(&self, old_names: &[IpnsName]) -> Result<(), WritePublishError> {
+        // Retirement is irreversible and the old root serves the tombstone every
+        // lagging reader chases, so refuse the batch release-active while the
+        // migration window is still open (security rule 8).
+        if !root_retire_ready() && old_names.iter().any(|name| name == self.current_root_name) {
+            return Err(WritePublishError::Rejected);
+        }
+        let targets: Vec<String> = old_names
+            .iter()
+            .map(|name| name.as_str().to_owned())
+            .collect();
+        retire(self.api, &targets)
+            .await
+            .map_err(|_| WritePublishError::NotLanded)
+    }
+
+    async fn publish_repoint(
+        &self,
+        channel: RepointChannel,
+        block: &[u8],
+    ) -> Result<(), WritePublishError> {
+        match channel {
+            RepointChannel::ScopePointer => self.publish_scope_pointer(block).await,
+            // Neither accelerator has a wire shape yet — the mailbox re-point
+            // payload is unspecified and no tombstone record exists — and this
+            // build never signs bytes it cannot decode (security rule 8). Both
+            // carry nothing load-bearing, so the wave completes without them.
+            RepointChannel::Mailbox | RepointChannel::Tombstone => {
+                Err(WritePublishError::NotLanded)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -694,11 +1134,12 @@ mod tests {
     use crate::content::dag::root_block_cid;
     use cipherbox_core::ipns::{IpnsRecord, VerifiedRecord};
     use cipherbox_core::seal::{
-        AscentLink, GrantSetCommitment, STRUCT_TAG_ASCENT_LINK, decode_envelope,
-        decode_grant_section, encode_envelope, encode_grant_section, grant_section_bytes,
-        open_ascent_link, open_read_body, seal_read_body, set_grant_section, sign_grant_set,
+        AscentLink, ChildRef, GrantSetCommitment, NodeKind, STRUCT_TAG_ASCENT_LINK,
+        decode_envelope, decode_grant_section, encode_envelope, encode_grant_section,
+        grant_section_bytes, open_ascent_link, open_read_body, seal_read_body, set_grant_section,
+        sign_grant_set, verify_grant_set,
     };
-    use cipherbox_core::suite::ecdsa::EcdsaSigner;
+    use cipherbox_core::suite::ecdsa::EcdsaSignature;
     use cipherbox_core::suite::ed25519::Ed25519Signer;
     use cipherbox_core::suite::secret::ct_eq;
 
@@ -706,7 +1147,8 @@ mod tests {
     use crate::content::GatewaySource;
     use crate::rotation::{
         CascadeError, CascadeOutcome, CommittedSet, PrevEpochSeed, ResealSeeds, RotateScopePlan,
-        ScopeRootIdentity, cascade_rotate_scope, enumerate_eager_set, reseal_scope_root,
+        ScopeRootIdentity, cascade_rotate_scope, derive_write_name, enumerate_eager_set,
+        reseal_scope_root,
         rotate_scope,
     };
     use crate::seams::{EndpointId, HttpResponse, SeamError, SeamResult};
@@ -2166,6 +2608,430 @@ mod tests {
             block_on(harness.net(&[]).publish_scope_root(&cut)),
             Err(ScopeRootPublishError::LostRace),
             "a lost CAS race is reported, never a silent drop",
+        );
+    }
+
+    // --- The write-plane name wave ([`WriteWaveNet`]) ---
+
+    /// The write scope seed the wave moves TO — every new name derives from it.
+    const FRESH_WRITE_SCOPE_SEED: [u8; 32] = [0xa5; 32];
+
+    type Wave<'a, T> = WriteWaveNet<
+        'a,
+        T,
+        ScriptedHttp,
+        InMemoryCredentialStore,
+        InMemoryFloorStore,
+        VirtualScheduler,
+        SeededEntropy,
+    >;
+
+    fn wave<'a, T: RecordTransport + Clone>(
+        harness: &'a Harness<T>,
+        owner: &'a EcdsaSigner,
+        current_root: &'a IpnsName,
+    ) -> Wave<'a, T> {
+        WriteWaveNet {
+            transport: &harness.transport,
+            api: &harness.api,
+            gateway: &harness.gateway,
+            http: &harness.http,
+            floors: &harness.floors,
+            scheduler: &harness.world.scheduler,
+            profile: &harness.profile,
+            entropy: &harness.entropy,
+            scope_id: SCOPE,
+            read_scope_seed: &OWNER_ROOT_SCOPE_SEED,
+            parent_node_seed: None,
+            owner,
+            owner_enc_secret: &harness.enc_secret,
+            owner_pointer_seed: &OWNER_POINTER_SEED,
+            current_root_name: current_root,
+        }
+    }
+
+    /// The pre-wave root name: derived from the write scope seed the fixtures
+    /// publish under.
+    fn old_root_name() -> IpnsName {
+        derive_write_name(&OWNER_ROOT_WRITE_SCOPE_SEED, &SCOPE)
+    }
+
+    fn folder(children: Vec<ChildRef>) -> ReadBody {
+        ReadBody::Folder {
+            created_at: 0,
+            modified_at: 0,
+            children,
+            unknown: PreservedFields::new(),
+        }
+    }
+
+    fn ref_to(id: [u8; 16], name: &IpnsName) -> ChildRef {
+        ChildRef {
+            id,
+            name: format!("node-{:02x}", id[0]),
+            ipns_name: name.as_str().as_bytes().to_vec(),
+            kind: NodeKind::Folder,
+            link_counter: 1,
+            unknown: PreservedFields::new(),
+        }
+    }
+
+    /// Stage one **interior** node: its read body sealed under the scope's own
+    /// per-node read key, the head block served, and the signed record seeded at
+    /// its pre-wave write-plane name.
+    fn stage_node<T: RecordTransport + Clone>(
+        harness: &Harness<T>,
+        node_id: [u8; 16],
+        body: &ReadBody,
+    ) -> IpnsName {
+        let node_seed = kdf::node_seed(&OWNER_ROOT_SCOPE_SEED, &node_id);
+        let read_key = *kdf::read_key(node_seed.as_bytes()).as_bytes();
+        let envelope = seal_read_body(
+            &read_key,
+            &[19u8; 24],
+            ENVELOPE_V,
+            node_id,
+            SCOPE,
+            OWNER_ROOT_EPOCH,
+            body,
+        )
+        .expect("the interior body seals");
+        let block = encode_envelope(&envelope).expect("the head encodes");
+        let cid = root_block_cid(&block);
+        harness
+            .blocks
+            .lock()
+            .expect("lock")
+            .insert(cid.clone(), block);
+        let name = derive_write_name(&OWNER_ROOT_WRITE_SCOPE_SEED, &node_id);
+        let record = record_for(&node_id, &cid, 1);
+        for endpoint in harness.store.endpoints() {
+            harness
+                .store
+                .seed_record(&endpoint, name.as_str(), record.clone());
+        }
+        name
+    }
+
+    /// The order the wave would issue for `node_id`.
+    fn order(
+        node_id: [u8; 16],
+        current_name: &IpnsName,
+        child_names: BTreeMap<[u8; 16], IpnsName>,
+        is_root: bool,
+    ) -> RepublishedNode {
+        RepublishedNode {
+            node_id,
+            current_name: current_name.clone(),
+            new_name: derive_write_name(&FRESH_WRITE_SCOPE_SEED, &node_id),
+            child_names,
+            write_seed: kdf::write_seed(&FRESH_WRITE_SCOPE_SEED, &node_id),
+            write_epoch: OWNER_ROOT_EPOCH + 1,
+            is_root,
+        }
+    }
+
+    fn one_child(id: [u8; 16], name: &IpnsName) -> BTreeMap<[u8; 16], IpnsName> {
+        BTreeMap::from([(id, name.clone())])
+    }
+
+    /// The read body a **read-only** holder opens at `name`: it derives per-node
+    /// read keys from the scope read seed alone — no write seed, so it can derive
+    /// no name and must follow the child refs it is handed.
+    fn read_only_open<T: RecordTransport + Clone>(
+        harness: &Harness<T>,
+        node_id: [u8; 16],
+        name: &IpnsName,
+    ) -> ReadBody {
+        let (_, envelope) = published_head(harness, name);
+        assert_eq!(envelope.id, node_id, "the record is the node it claims");
+        assert_eq!(
+            envelope.epoch, OWNER_ROOT_EPOCH,
+            "the read epoch never moves"
+        );
+        let node_seed = kdf::node_seed(&OWNER_ROOT_SCOPE_SEED, &node_id);
+        let read_key = *kdf::read_key(node_seed.as_bytes()).as_bytes();
+        open_read_body(&envelope, &read_key).expect("reopens under the unchanged read key")
+    }
+
+    fn child_names_of(body: &ReadBody) -> Vec<Vec<u8>> {
+        match body {
+            ReadBody::Folder { children, .. } => {
+                children.iter().map(|c| c.ipns_name.clone()).collect()
+            }
+            ReadBody::File { .. } => Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_republished_folder_names_its_children_at_their_new_names() {
+        let harness = Harness::plain();
+        let leaf_id = [0x0a; 16];
+        let leaf_old = stage_node(&harness, leaf_id, &folder(Vec::new()));
+        let parent_id = [0x0b; 16];
+        let parent_old = stage_node(
+            &harness,
+            parent_id,
+            &folder(vec![ref_to(leaf_id, &leaf_old)]),
+        );
+
+        let owner = owner_identity();
+        let current_root = old_root_name();
+        let net = wave(&harness, &owner, &current_root);
+
+        let leaf = order(leaf_id, &leaf_old, BTreeMap::new(), false);
+        block_on(net.republish(&leaf)).expect("the leaf republishes");
+        let parent = order(
+            parent_id,
+            &parent_old,
+            one_child(leaf_id, &leaf.new_name),
+            false,
+        );
+        block_on(net.republish(&parent)).expect("the parent republishes");
+
+        let body = read_only_open(&harness, parent_id, &parent.new_name);
+        assert_eq!(
+            child_names_of(&body),
+            vec![leaf.new_name.as_str().as_bytes().to_vec()],
+            "the parent names its child at the name the wave moved it to"
+        );
+        assert_ne!(
+            child_names_of(&body)[0],
+            leaf_old.as_str().as_bytes().to_vec(),
+            "no retired name survives in the republished body"
+        );
+    }
+
+    #[test]
+    fn a_read_only_holder_descends_the_whole_subtree_after_the_wave() {
+        // Depth greater than one, so a root-only pass cannot satisfy it: a holder
+        // with the scope READ seed and no write seed starts at the re-pointed root
+        // and must reach every node by following rewritten child refs alone.
+        let harness = Harness::plain();
+        let leaf_id = [0x0c; 16];
+        let leaf_old = stage_node(&harness, leaf_id, &folder(Vec::new()));
+        let mid_id = [0x0d; 16];
+        let mid_old = stage_node(&harness, mid_id, &folder(vec![ref_to(leaf_id, &leaf_old)]));
+        let root = owner_root_fixture(OwnerRootSpec {
+            owner_identity: &owner_identity(),
+            owner_enc: &owner_enc().public(),
+            scope_id: SCOPE,
+            root_id: SCOPE,
+            children: vec![ref_to(mid_id, &mid_old)],
+            child_scope_index: Vec::new(),
+            parent_node_seed: None,
+            owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+        });
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+
+        let owner = owner_identity();
+        let net = wave(&harness, &owner, &root.name);
+
+        // Child-first, root last — exactly the wave's own order.
+        let leaf = order(leaf_id, &leaf_old, BTreeMap::new(), false);
+        block_on(net.republish(&leaf)).expect("leaf");
+        let mid = order(mid_id, &mid_old, one_child(leaf_id, &leaf.new_name), false);
+        block_on(net.republish(&mid)).expect("mid");
+        let new_root = order(SCOPE, &root.name, one_child(mid_id, &mid.new_name), true);
+        block_on(net.republish(&new_root)).expect("root");
+
+        // The read-only descent: root -> mid -> leaf, by child refs alone.
+        let mut name = new_root.new_name.clone();
+        let mut node_id = SCOPE;
+        for expected in [mid_id, leaf_id] {
+            let body = read_only_open(&harness, node_id, &name);
+            let refs = child_names_of(&body);
+            assert_eq!(refs.len(), 1, "one child at each level");
+            name = IpnsName::parse(core::str::from_utf8(&refs[0]).expect("utf8 name"))
+                .expect("a canonical child name");
+            node_id = expected;
+            assert_eq!(
+                name,
+                derive_write_name(&FRESH_WRITE_SCOPE_SEED, &expected),
+                "the ref names the node's post-wave name"
+            );
+        }
+        // The deepest node is reachable and carries no stale ref.
+        assert!(child_names_of(&read_only_open(&harness, leaf_id, &name)).is_empty());
+    }
+
+    #[test]
+    fn a_moved_root_re_signs_its_commitment_over_the_new_name() {
+        // The grant-set commitment binds `ipnsName`, so a root that moves without
+        // a re-sign is a record this build's own gate rejects at stage 2.
+        let harness = Harness::plain();
+        let leaf_id = [0x0e; 16];
+        let leaf_old = stage_node(&harness, leaf_id, &folder(Vec::new()));
+        let root = owner_root_fixture(OwnerRootSpec {
+            owner_identity: &owner_identity(),
+            owner_enc: &owner_enc().public(),
+            scope_id: SCOPE,
+            root_id: SCOPE,
+            children: vec![ref_to(leaf_id, &leaf_old)],
+            child_scope_index: Vec::new(),
+            parent_node_seed: None,
+            owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+        });
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+
+        let owner = owner_identity();
+        let net = wave(&harness, &owner, &root.name);
+        let leaf = order(leaf_id, &leaf_old, BTreeMap::new(), false);
+        block_on(net.republish(&leaf)).expect("leaf");
+        let moved = order(SCOPE, &root.name, one_child(leaf_id, &leaf.new_name), true);
+        block_on(net.republish(&moved)).expect("the root moves");
+
+        let section = published_section(&harness, &moved.new_name);
+        assert_eq!(
+            section.commitment.ipns_name,
+            moved.new_name.as_str().as_bytes(),
+            "the commitment names the record's new name"
+        );
+        assert_ne!(
+            section.commitment.ipns_name,
+            root.name.as_str().as_bytes(),
+            "and no longer the name it moved off"
+        );
+        let sig = EcdsaSignature::from_compact(&section.commitment_sig).expect("a compact sig");
+        verify_grant_set(&owner.verifying_key(), &section.commitment, &sig)
+            .expect("the re-signed commitment verifies under the owner identity");
+        assert_eq!(
+            section.owner_blob, root.grant_section.owner_blob,
+            "the seed-bearing structures ride verbatim — a name wave re-keys nothing"
+        );
+    }
+
+    #[test]
+    fn a_child_name_the_body_does_not_carry_is_refused_fail_closed() {
+        // The subtree enumeration and the published body disagreeing means one of
+        // them is wrong; publishing either half strands a subtree behind a name
+        // nothing resolves.
+        let harness = Harness::plain();
+        let node_id = [0x1a; 16];
+        let current = stage_node(&harness, node_id, &folder(Vec::new()));
+        let owner = owner_identity();
+        let current_root = old_root_name();
+        let net = wave(&harness, &owner, &current_root);
+
+        let stray = derive_write_name(&FRESH_WRITE_SCOPE_SEED, &[0x1b; 16]);
+        let bogus = order(node_id, &current, one_child([0x1b; 16], &stray), false);
+        assert_eq!(
+            block_on(net.republish(&bogus)),
+            Err(WritePublishError::Rejected)
+        );
+    }
+
+    #[test]
+    fn the_read_epoch_floor_never_moves_across_a_republish() {
+        // Each plane's clock is authored by its own authority (#38 D1): a name wave
+        // advances the WRITE epoch, and a same-epoch metadata rewrite must raise no
+        // read-epoch floor.
+        let harness = Harness::plain();
+        let node_id = [0x2a; 16];
+        let current = stage_node(&harness, node_id, &folder(Vec::new()));
+        let before =
+            block_on(floor::read_epoch_floor(&harness.floors, &SCOPE)).expect("floor read");
+
+        let owner = owner_identity();
+        let current_root = old_root_name();
+        let net = wave(&harness, &owner, &current_root);
+        block_on(net.republish(&order(node_id, &current, BTreeMap::new(), false)))
+            .expect("republish");
+
+        assert_eq!(
+            block_on(floor::read_epoch_floor(&harness.floors, &SCOPE)).expect("floor read"),
+            before,
+            "an interior name-wave republish moves no read-epoch floor"
+        );
+    }
+
+    #[test]
+    fn retire_refuses_a_batch_naming_the_lingering_root() {
+        // Retirement is irreversible and the old root serves the tombstone every
+        // lagging reader chases, so the guard is release-active, not a debug assert.
+        let harness = Harness::plain();
+        let owner = owner_identity();
+        let current_root = old_root_name();
+        let net = wave(&harness, &owner, &current_root);
+        let interior = derive_write_name(&OWNER_ROOT_WRITE_SCOPE_SEED, &[0x3a; 16]);
+
+        assert_eq!(
+            block_on(net.retire(&[interior.clone(), current_root.clone()])),
+            Err(WritePublishError::Rejected)
+        );
+        block_on(net.retire(&[interior])).expect("an interior-only batch retires");
+    }
+
+    #[test]
+    fn the_canonical_repoint_lands_on_the_scope_pointer_record() {
+        let harness = Harness::plain();
+        let owner = owner_identity();
+        let current_root = old_root_name();
+        let net = wave(&harness, &owner, &current_root);
+        let block = b"a-sealed-repoint-object".to_vec();
+
+        block_on(net.publish_repoint(RepointChannel::ScopePointer, &block))
+            .expect("the pointer flips");
+
+        let name = scope_pointer_name(&OWNER_POINTER_SEED, &SCOPE);
+        let record = harness
+            .store
+            .record_at(&harness.store.endpoints()[0], name.as_str())
+            .expect("a record at the scope pointer");
+        let verified = IpnsRecord::unmarshal(&record)
+            .and_then(|record| record.verify(&name))
+            .expect("the pointer record verifies under its own name");
+        assert_eq!(
+            verified.value, block,
+            "the pointer's value IS the sealed re-point block, not an /ipfs/ head"
+        );
+        assert_eq!(verified.sequence, 1, "a first publish embeds sequence 1");
+
+        // A second rotation must clear what is already at the name.
+        block_on(net.publish_repoint(RepointChannel::ScopePointer, b"a-second-repoint"))
+            .expect("the second flip");
+        let record = harness
+            .store
+            .record_at(&harness.store.endpoints()[0], name.as_str())
+            .expect("a record at the scope pointer");
+        let verified = IpnsRecord::unmarshal(&record)
+            .and_then(|record| record.verify(&name))
+            .expect("verifies");
+        assert_eq!(verified.sequence, 2);
+    }
+
+    #[test]
+    fn the_accelerator_channels_report_that_they_did_not_land() {
+        // No mailbox re-point payload and no tombstone record shape exist, and this
+        // build never signs bytes it cannot decode — so both refuse rather than
+        // claiming a delivery the wave would then report as complete.
+        let harness = Harness::plain();
+        let owner = owner_identity();
+        let current_root = old_root_name();
+        let net = wave(&harness, &owner, &current_root);
+        for channel in [RepointChannel::Mailbox, RepointChannel::Tombstone] {
+            assert_eq!(
+                block_on(net.publish_repoint(channel, b"block")),
+                Err(WritePublishError::NotLanded)
+            );
+        }
+    }
+
+    #[test]
+    fn is_republished_answers_from_published_state_alone() {
+        let harness = Harness::plain();
+        let node_id = [0x4a; 16];
+        let current = stage_node(&harness, node_id, &folder(Vec::new()));
+        let owner = owner_identity();
+        let current_root = old_root_name();
+        let net = wave(&harness, &owner, &current_root);
+        let node = order(node_id, &current, BTreeMap::new(), false);
+
+        assert!(!block_on(net.is_republished(&node.new_name)).expect("query"));
+        block_on(net.republish(&node)).expect("republish");
+        assert!(
+            block_on(net.is_republished(&node.new_name)).expect("query"),
+            "a resumed wave skips this node off published state, with no in-memory carry"
         );
     }
 }

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -48,9 +48,9 @@ use crate::net::resolve::Adopter;
 use crate::profile::SyncTimingProfile;
 use crate::rotation::{
     CascadeResealResolver, CascadeTarget, ChildIndexResolver, CommittedSet, RepointChannel,
-    RepublishedNode, ResealSeeds, ResealedScopeRoot, ResolveFailure, ScopeRootIdentity,
-    ScopeRootPublishError, ScopeRootPublisher, WritePublishError, WriteWavePublisher,
-    reseal_scope_root,
+    RepublishedNode, ResealError, ResealSeeds, ResealedScopeRoot, ResolveFailure,
+    ScopeRootIdentity, ScopeRootPublishError, ScopeRootPublisher, WritePublishError,
+    WriteWavePublisher, reseal_scope_root,
 };
 use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
 use crate::session::SessionIdentity;
@@ -840,6 +840,24 @@ fn wave_verdict(error: GateError) -> WritePublishError {
     }
 }
 
+/// The same axis for the re-seal that mints a moved root's section. Every
+/// variant but one is this build's own fail-closed verdict on material the wave
+/// already gated — the committed set, the ledger it must equal, the carried
+/// links the decoder already bounded — so re-sealing the same inputs reaches it
+/// again. Entropy is the injected seam failing, not a verdict on any of that.
+/// Matched exhaustively: a new variant must be classified here, not defaulted.
+fn reseal_verdict(error: ResealError) -> WritePublishError {
+    match error {
+        ResealError::Entropy(_) => WritePublishError::NotLanded,
+        ResealError::LedgerDivergesFromCommitment
+        | ResealError::SignerNotCommitted
+        | ResealError::UnusableRecipientKey
+        | ResealError::AscentLinkMismatch
+        | ResealError::TooManyHistoryLinks
+        | ResealError::Encode(_) => WritePublishError::Rejected,
+    }
+}
+
 /// The same axis for the publish pipeline. A CID the API echoes back wrong, and
 /// the pipeline's own release-active encode refusals, are deterministic on the
 /// bytes this pass built — a retry re-uploads and re-charges a head block
@@ -1075,7 +1093,7 @@ where
             },
             &plane.section.history_links,
         )
-        .map_err(|_| WritePublishError::Rejected)
+        .map_err(reseal_verdict)
     }
 
     /// Author and CAS-publish `node`'s rewritten record at its new name, signing
@@ -1305,6 +1323,8 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use crate::content::dag::root_block_cid;
+    use crate::entropy::EntropyError;
+    use cipherbox_core::error::{CodecError, Malformed};
     use cipherbox_core::ipns::{IpnsRecord, VerifiedRecord};
     use cipherbox_core::seal::{
         AscentLink, ChildRef, GrantSetCommitment, NodeKind, STRUCT_TAG_ASCENT_LINK,
@@ -3301,5 +3321,32 @@ mod tests {
             block_on(net.is_republished(&node.new_name)).expect("query"),
             "a resumed wave skips this node off published state, with no in-memory carry"
         );
+    }
+
+    #[test]
+    fn a_reseal_seam_failure_stays_retryable_and_a_trust_failure_does_not() {
+        assert_eq!(
+            reseal_verdict(ResealError::Entropy(EntropyError::new("seam down"))),
+            WritePublishError::NotLanded,
+            "the entropy seam being down is availability, not a verdict on the section"
+        );
+
+        for terminal in [
+            ResealError::LedgerDivergesFromCommitment,
+            ResealError::SignerNotCommitted,
+            ResealError::UnusableRecipientKey,
+            ResealError::AscentLinkMismatch,
+            ResealError::TooManyHistoryLinks,
+            ResealError::Encode(CodecError::Malformed(Malformed::DepthExceeded {
+                offset: 0,
+            })),
+        ] {
+            let check = terminal.check();
+            assert_eq!(
+                reseal_verdict(terminal),
+                WritePublishError::Rejected,
+                "{check} is deterministic on inputs the wave already gated; retrying never converges"
+            );
+        }
     }
 }

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -15,7 +15,7 @@
 use core::cell::RefCell;
 use std::collections::BTreeMap;
 
-use cipherbox_core::ipns::{IpnsName, IpnsRecord};
+use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
     AadContext, ChildScopeRef, Envelope, GrantSection, PreservedFields, ReadBody,
@@ -34,23 +34,23 @@ use super::author::{
     author_scope_root_with_section,
 };
 use super::child::ChildAdopter;
-use super::eol;
-use super::fanout::{MAX_RECORD_BYTES, fanout_put};
-use super::publish::PublishOutcome;
-use super::record_publish::{HeadBinding, RecordPublishRequest, preflight, publish_record};
-use super::register::register;
+use super::publish::{InlineRecordRequest, PublishError, PublishOutcome, publish_inline};
+use super::record_publish::{
+    HeadBinding, RecordPublishError, RecordPublishRequest, preflight, publish_record,
+};
 use super::retire::{retire, root_retire_ready};
-use crate::api::{ApiClient, NameRegistration};
+use crate::api::ApiClient;
 use crate::content::Gateway;
 use crate::entropy::Entropy;
-use crate::gate::{GateError, GateStage, RejectionReason, floor};
+use crate::gate::{GateError, RejectionReason, floor};
 use crate::net::fanout_get_verify;
 use crate::net::resolve::Adopter;
 use crate::profile::SyncTimingProfile;
 use crate::rotation::{
-    CascadeResealResolver, CascadeTarget, ChildIndexResolver, RepointChannel, RepublishedNode,
-    ResealedScopeRoot, ResolveFailure, ScopeRootPublishError, ScopeRootPublisher,
-    WritePublishError, WriteWavePublisher,
+    CascadeResealResolver, CascadeTarget, ChildIndexResolver, CommittedSet, RepointChannel,
+    RepublishedNode, ResealSeeds, ResealedScopeRoot, ResolveFailure, ScopeRootIdentity,
+    ScopeRootPublishError, ScopeRootPublisher, WritePublishError, WriteWavePublisher,
+    reseal_scope_root,
 };
 use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
 use crate::session::SessionIdentity;
@@ -454,23 +454,13 @@ where
         ) else {
             return Err(ResolveFailure::Unavailable);
         };
-        let write_seed = kdf::write_seed(write_scope_seed, &scope_id);
-        let write_key = kdf::write_key(write_seed.as_bytes());
-        let env = &root.envelope;
-        let ctx = AadContext {
-            v: env.v,
-            id: env.id,
-            scope: env.scope,
-            epoch: write_epoch,
-            struct_tag: STRUCT_TAG_WRITE_BODY,
-        };
-        // The gate authenticated this structure's detached signature; the unseal
-        // is what proves it is *this* scope's write-body at *this* write epoch.
-        let plaintext = Zeroizing::new(
-            unseal(write_key.as_bytes(), &ctx, &root.section.write_body.sealed)
-                .map_err(|_| ResolveFailure::Rejected)?,
-        );
-        let body = decode_write_body(&plaintext).map_err(|_| ResolveFailure::Rejected)?;
+        let body = open_write_body(
+            &root.envelope,
+            &root.section,
+            &scope_id,
+            write_scope_seed,
+            write_epoch,
+        )?;
         Ok((body, write_epoch))
     }
 
@@ -738,19 +728,55 @@ pub struct WriteWaveNet<'a, T, H: Http, C: CredentialStore, F, Sch, E> {
     /// re-signs the grant-set commitment — which binds `ipnsName`, so a root that
     /// moves without a re-sign is a record this build's own gate rejects.
     pub owner: &'a EcdsaSigner,
-    /// Opens each scope root's owner blob on the gated re-resolve.
+    /// Opens each scope root's owner blob on the gated re-resolve, and the
+    /// owner-blob recipient every re-seal wraps to.
     pub owner_enc_secret: &'a X25519Secret,
+    /// The two per-scope derivations the root's re-seal needs, and no wider
+    /// capability (the same narrowing [`OwnerRotationKeys`] makes).
+    pub scope_keys: &'a dyn OwnerScopeKeys,
     /// Derives the scope pointer's name and its record signer (owner-only).
     pub owner_pointer_seed: &'a [u8; SECRET_LEN],
     /// The root name the wave is moving off. It lingers serving the tombstone, so
     /// [`WriteWaveNet::retire`] refuses a batch naming it.
     pub current_root_name: &'a IpnsName,
+    /// The root read this pass gated and has not yet republished
+    /// ([`GatedWaveRoot`]). One rotation pass per net.
+    pub gated_root: GatedWaveRoot,
+}
+
+/// The scope root's gated read, held across a failed publish.
+///
+/// Adoption advances the durable **sequence** floor, so a second gated read of
+/// the same root record rejects as not-newer (`gate/adoption.rs` stage 4) — and
+/// the root gate has no at-floor re-open. Holding the read is what makes
+/// `republish` idempotent for the root, which the wave's resume contract
+/// requires: a pass that gated the root and then failed to PUT retries off this
+/// slot rather than re-reading a record its own floor now refuses.
+#[derive(Default)]
+pub struct GatedWaveRoot {
+    inner: RefCell<Option<(IpnsName, WaveSource)>>,
+}
+
+impl GatedWaveRoot {
+    fn take(&self, name: &IpnsName) -> Option<WaveSource> {
+        let mut parked = self.inner.borrow_mut();
+        match parked.as_ref() {
+            Some((parked_name, _)) if parked_name == name => {
+                parked.take().map(|(_, source)| source)
+            }
+            _ => None,
+        }
+    }
+
+    fn park(&self, name: &IpnsName, source: WaveSource) {
+        *self.inner.borrow_mut() = Some((name.clone(), source));
+    }
 }
 
 /// One node's current record as the gate authenticated it, plus what a republish
 /// at the new name needs: the body to rewrite, the read epoch and key it re-seals
-/// under, the envelope fields carried forward byte-stable (#27 D10), and the
-/// scope root's section.
+/// under, and the envelope fields carried forward byte-stable (#27 D10).
+#[derive(Clone)]
 struct WaveSource {
     read_body: ReadBody,
     read_epoch: u64,
@@ -758,7 +784,20 @@ struct WaveSource {
     unknown: PreservedFields,
     epoch_tag_unknown: PreservedFields,
     /// `Some` only for the scope root — interior nodes carry no grant section.
-    section: Option<GrantSection>,
+    root: Option<RootPlane>,
+}
+
+/// The scope root's own plane as this pass read it: the section it carries, the
+/// read seed its own owner blob yielded, and the write body the re-seal rebuilds
+/// with the wave's fresh write scope seed.
+#[derive(Clone)]
+struct RootPlane {
+    section: GrantSection,
+    read_scope_seed: Zeroizing<[u8; SECRET_LEN]>,
+    write_body: WriteBody,
+    /// The write epoch the section was sealed at — the floor the wave advances
+    /// past.
+    write_epoch: u64,
 }
 
 /// Rewrite the in-scope child names the wave moved, or refuse.
@@ -801,19 +840,26 @@ fn wave_verdict(error: GateError) -> WritePublishError {
     }
 }
 
+/// The same axis for the publish pipeline. A CID the API echoes back wrong, and
+/// the pipeline's own release-active encode refusals, are deterministic on the
+/// bytes this pass built — a retry re-uploads and re-charges a head block
+/// forever without converging.
+fn publish_record_verdict(error: RecordPublishError) -> WritePublishError {
+    match error {
+        RecordPublishError::HeadCidMismatch { .. } => WritePublishError::Rejected,
+        RecordPublishError::Publish(PublishError::Register(_)) => WritePublishError::RegistryFull,
+        RecordPublishError::Publish(
+            PublishError::EmptyHeadCid | PublishError::RecordTooLarge { .. },
+        ) => WritePublishError::Rejected,
+        _ => WritePublishError::NotLanded,
+    }
+}
+
 impl<T, H: Http, C: CredentialStore, F, Sch, E> WriteWaveNet<'_, T, H, C, F, Sch, E>
 where
     T: RecordTransport,
     F: FloorStore,
 {
-    /// The freshest verified record at `name`, or an availability stall.
-    async fn record_at(&self, name: &IpnsName) -> Result<Vec<u8>, WritePublishError> {
-        fanout_get_verify(self.transport, name)
-            .await
-            .map(|(_, bytes)| bytes)
-            .ok_or(WritePublishError::NotLanded)
-    }
-
     /// Gate an interior node's current record and open it for re-authoring.
     ///
     /// The adopt advances the per-name sequence floor, so a wave that already
@@ -833,13 +879,18 @@ where
             Zeroizing::new(*self.read_scope_seed),
             node_id,
         );
-        if let Err(error) = adopter.adopt(name, record_bytes).await
-            && !matches!(
-                error,
-                GateError::Rejected(ref r) if r.stage == GateStage::Sequence
-            )
-        {
-            return Err(wave_verdict(error));
+        match adopter.adopt(name, record_bytes).await {
+            Ok(_) => {}
+            // Our own current record at exactly the floor — the at-floor re-open
+            // below is the path for it. A strictly older sequence is a replay and
+            // stays a fail-closed violation (`net/resolve.rs` splits it the same
+            // way).
+            Err(GateError::Rejected(rejection))
+                if matches!(
+                    rejection.reason,
+                    RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor
+                ) => {}
+            Err(error) => return Err(wave_verdict(error)),
         }
         let (adopted, envelope) = adopter
             .open_carried_at_floor(name, record_bytes)
@@ -851,16 +902,17 @@ where
         Ok(WaveSource {
             read_body: adopted.read_body,
             read_epoch: adopted.epoch,
-            read_key: self.node_read_key(&node_id),
+            read_key: read_key_for(self.read_scope_seed, &node_id),
             unknown: envelope.unknown,
             epoch_tag_unknown: envelope.epoch_tag_unknown,
-            section: None,
+            root: None,
         })
     }
 
-    /// Gate the scope root's current record and open it for re-authoring. The
-    /// read key comes from the seed the root's own owner blob carries, never the
-    /// caller's copy — the record must reopen under the key readers re-derive.
+    /// Gate the scope root's current record and open it for re-authoring, plus
+    /// the write plane the re-seal rebuilds. Both keys come from the seeds the
+    /// root's own blobs carry, never the caller's copies — the record must reopen
+    /// under the keys readers re-derive.
     async fn root_source(
         &self,
         name: &IpnsName,
@@ -882,47 +934,85 @@ where
             .adopt_root(name, record_bytes)
             .await
             .map_err(wave_verdict)?;
-        if candidate.envelope.v != ENVELOPE_V {
+        let envelope = candidate.envelope;
+        // The root gate binds `envelope.scope` but not `envelope.id`, and every
+        // AAD this republish authors binds the id — so a root whose record claims
+        // another node would be re-sealed under a key no reader re-derives.
+        if envelope.v != ENVELOPE_V || envelope.id != self.scope_id {
             return Err(WritePublishError::Rejected);
         }
         let read_scope_seed = outcome
             .read_scope_seed
             .ok_or(WritePublishError::NotLanded)?;
-        let node_seed = kdf::node_seed(&read_scope_seed, &self.scope_id);
+        let write_scope_seed = outcome
+            .write_scope_seed
+            .ok_or(WritePublishError::NotLanded)?;
+        let write_epoch = floor::write_epoch_floor(self.floors, &self.scope_id)
+            .await
+            .map_err(|_| WritePublishError::NotLanded)?
+            .ok_or(WritePublishError::NotLanded)?;
+        let write_body = open_write_body(
+            &envelope,
+            &candidate.grant_section,
+            &self.scope_id,
+            &write_scope_seed,
+            write_epoch,
+        )
+        .map_err(|failure| match failure {
+            ResolveFailure::Unavailable => WritePublishError::NotLanded,
+            _ => WritePublishError::Rejected,
+        })?;
         Ok(WaveSource {
             read_body: outcome.adopted.read_body,
             read_epoch: outcome.adopted.epoch,
-            read_key: Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes()),
-            unknown: candidate.envelope.unknown,
-            epoch_tag_unknown: candidate.envelope.epoch_tag_unknown,
-            section: Some(candidate.grant_section),
+            read_key: read_key_for(&read_scope_seed, &envelope.id),
+            unknown: envelope.unknown,
+            epoch_tag_unknown: envelope.epoch_tag_unknown,
+            root: Some(RootPlane {
+                section: candidate.grant_section,
+                read_scope_seed,
+                write_body,
+                write_epoch,
+            }),
         })
     }
+}
 
-    /// `nodeSeed(readScopeSeed, node) -> readKey` — the frozen edges every reader
-    /// re-derives for an interior node.
-    fn node_read_key(&self, node_id: &[u8; 16]) -> Zeroizing<[u8; SECRET_LEN]> {
-        let node_seed = kdf::node_seed(self.read_scope_seed, node_id);
-        Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes())
-    }
+/// `nodeSeed(scopeReadSeed, node) -> readKey` — the frozen edges every reader
+/// re-derives for a node in the scope.
+fn read_key_for(
+    scope_read_seed: &[u8; SECRET_LEN],
+    node_id: &[u8; 16],
+) -> Zeroizing<[u8; SECRET_LEN]> {
+    let node_seed = kdf::node_seed(scope_read_seed, node_id);
+    Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes())
+}
 
-    /// The moved root's grant section: the commitment re-signed over the name the
-    /// record now publishes under (blueprint/engine.md "rotateScopeWrite" — an
-    /// owner-only write rotation re-signs the commitment). Everything else rides
-    /// verbatim; `ipnsName` is not in any structure's AAD (#39 D7), so the
-    /// section's own signatures still recompute.
-    fn resigned_section(
-        &self,
-        section: &GrantSection,
-        new_name: &IpnsName,
-    ) -> Result<GrantSection, WritePublishError> {
-        let mut section = section.clone();
-        section.commitment.ipns_name = new_name.as_str().as_bytes().to_vec();
-        section.commitment_sig = sign_grant_set(self.owner, &section.commitment)
-            .map_err(|_| WritePublishError::Rejected)?
-            .to_compact();
-        Ok(section)
-    }
+/// Unseal a gated scope root's write body under `write_scope_seed` at
+/// `write_epoch` — the AAD epoch the owner-write-blob's own recovery bound. The
+/// gate authenticated the structure's detached signature; the unseal is what
+/// proves it is *this* scope's write body at *this* write epoch.
+fn open_write_body(
+    envelope: &Envelope,
+    section: &GrantSection,
+    scope_id: &[u8; 16],
+    write_scope_seed: &[u8; SECRET_LEN],
+    write_epoch: u64,
+) -> Result<WriteBody, ResolveFailure> {
+    let write_seed = kdf::write_seed(write_scope_seed, scope_id);
+    let write_key = kdf::write_key(write_seed.as_bytes());
+    let ctx = AadContext {
+        v: envelope.v,
+        id: envelope.id,
+        scope: envelope.scope,
+        epoch: write_epoch,
+        struct_tag: STRUCT_TAG_WRITE_BODY,
+    };
+    let plaintext = Zeroizing::new(
+        unseal(write_key.as_bytes(), &ctx, &section.write_body.sealed)
+            .map_err(|_| ResolveFailure::Rejected)?,
+    );
+    decode_write_body(&plaintext).map_err(|_| ResolveFailure::Rejected)
 }
 
 impl<T, H: Http, C: CredentialStore, F, Sch, E> WriteWaveNet<'_, T, H, C, F, Sch, E>
@@ -932,20 +1022,83 @@ where
     Sch: Scheduler + Clone + 'static,
     E: Entropy,
 {
+    /// The moved root's grant section, re-minted for the wave.
+    ///
+    /// The root's section is the only channel that carries `writeScopeSeed` to
+    /// anyone — the owner-write blob and every write grantee's blob — so a root
+    /// republished with the section carried verbatim would move every name while
+    /// handing out the seed that derives the retired ones, and its write body
+    /// would stay sealed below the write-epoch floor the re-point is about to
+    /// raise. Re-seal is the general mechanism
+    /// ([`reseal_scope_root`](crate::rotation::reseal_scope_root)): same override
+    /// seed and read epoch (a name wave cuts no read key, so `prev` mints no
+    /// history link), fresh write scope seed, advanced write epoch, new name.
+    fn reseal_root(
+        &self,
+        node: &RepublishedNode,
+        plane: &RootPlane,
+        fresh_write_scope_seed: &[u8; SECRET_LEN],
+        read_epoch: u64,
+    ) -> Result<GrantSection, WritePublishError> {
+        let mut commitment = plane.section.commitment.clone();
+        commitment.ipns_name = node.new_name.as_str().as_bytes().to_vec();
+        let commitment_sig = sign_grant_set(self.owner, &commitment)
+            .map_err(|_| WritePublishError::Rejected)?
+            .to_compact();
+        let owner_enc_pub = self.owner_enc_secret.public();
+        let pseudonym_signer = self.scope_keys.writer_pseudonym(&self.scope_id);
+        let pointer_read_key = self.scope_keys.pointer_read_key(&self.scope_id);
+        reseal_scope_root(
+            &mut *self.entropy.borrow_mut(),
+            &ScopeRootIdentity {
+                v: ENVELOPE_V,
+                scope_id: self.scope_id,
+                ipns_name: node.new_name.as_str().as_bytes(),
+                owner_enc_pub: &owner_enc_pub,
+                parent_node_seed: self.parent_node_seed,
+                pseudonym_signer: &pseudonym_signer,
+            },
+            &ResealSeeds {
+                override_seed: &plane.read_scope_seed,
+                read_epoch,
+                prev: None,
+                write_scope_seed: fresh_write_scope_seed,
+                write_epoch: node.write_epoch,
+                pointer_read_key: &pointer_read_key,
+            },
+            &CommittedSet {
+                commitment: &commitment,
+                commitment_sig: &commitment_sig,
+                grant_ledger: &plane.write_body.grant_ledger,
+                write_history_link: &plane.write_body.write_history_link,
+                direct_child_scope_index: &plane.write_body.direct_child_scope_index,
+            },
+            &plane.section.history_links,
+        )
+        .map_err(|_| WritePublishError::Rejected)
+    }
+
     /// Author and CAS-publish `node`'s rewritten record at its new name, signing
-    /// under the one write seed the wave handed for it.
+    /// under the one narrow capability the wave handed for it.
     async fn publish_moved(
         &self,
         node: &RepublishedNode,
         source: WaveSource,
     ) -> Result<(), WritePublishError> {
+        // The signer IS the name's key, so a record published at a name it does
+        // not open would be one no resolver can verify (`IpnsRecord::verify`).
+        // Release-active: this path owner-signs a commitment over `new_name` and
+        // uploads the head block before it ever reaches the transport.
+        if IpnsName::from_public_key(&node.signer.verifying_key()) != node.new_name {
+            return Err(WritePublishError::Rejected);
+        }
         let WaveSource {
             mut read_body,
             read_epoch,
             read_key,
             unknown,
             epoch_tag_unknown,
-            section,
+            root,
         } = source;
         rewrite_child_names(&mut read_body, &node.child_names)?;
 
@@ -964,13 +1117,26 @@ where
             carried_unknown: unknown,
             carried_epoch_tag_unknown: epoch_tag_unknown,
         };
-        let head = match section {
-            Some(section) => author_scope_root_with_section(
-                authoring,
-                &node.new_name,
-                &self.resigned_section(&section, &node.new_name)?,
-                &self.owner.verifying_key(),
-            ),
+        let head = match root {
+            Some(plane) => {
+                let fresh = node
+                    .write_scope_seed
+                    .as_ref()
+                    .ok_or(WritePublishError::Rejected)?;
+                // The write floor is monotonic and the re-point raises it to
+                // `node.write_epoch`; sealing the section at or below the floor
+                // publishes a root whose write plane can never be reopened.
+                if node.write_epoch <= plane.write_epoch || node.node_id != self.scope_id {
+                    return Err(WritePublishError::Rejected);
+                }
+                let section = self.reseal_root(node, &plane, fresh.as_bytes(), read_epoch)?;
+                author_scope_root_with_section(
+                    authoring,
+                    &node.new_name,
+                    &section,
+                    &self.owner.verifying_key(),
+                )
+            }
             None => author_child_envelope(authoring),
         }
         .map_err(|refusal| {
@@ -986,9 +1152,10 @@ where
             scope_id: self.scope_id,
             epoch: read_epoch,
         };
+        // A preflight refusal is this build's own verdict on the bytes it just
+        // authored: re-authoring the same inputs reaches it again (rule 6).
         let preflighted =
-            preflight(&binding, &read_key, &head).map_err(|_| WritePublishError::NotLanded)?;
-        let signer = kdf::ipns_keypair(node.write_seed.as_bytes());
+            preflight(&binding, &read_key, &head).map_err(|_| WritePublishError::Rejected)?;
         let receipt = publish_record(
             self.transport,
             self.api,
@@ -997,14 +1164,14 @@ where
             self.profile,
             &RecordPublishRequest {
                 name: &node.new_name,
-                signer: &signer,
+                signer: &node.signer,
                 head: &preflighted,
                 content_cids: Vec::new(),
                 min_current_sequence: None,
             },
         )
         .await
-        .map_err(|_| WritePublishError::NotLanded)?;
+        .map_err(publish_record_verdict)?;
         match receipt.outcome {
             PublishOutcome::Published { .. } => Ok(()),
             PublishOutcome::LostRace { .. } => Err(WritePublishError::LostRace),
@@ -1014,57 +1181,47 @@ where
 
     /// Flip the canonical scope pointer to the sealed re-point `block`.
     ///
-    /// The record's `Value` is the sealed block itself, not an `/ipfs/` head
-    /// pointer ([`RecordPointerFetch`](super::pointer_fetch::RecordPointerFetch)
-    /// reads it back that way), which is the one shape the record publish
-    /// pipeline cannot express — so the pipeline's own laws are restated here:
-    /// register-first, sequence strictly above anything already at the name, and
-    /// success only on reading our own bytes back.
+    /// The record's `Value` is the block itself rather than an `/ipfs/` head
+    /// ([`RecordPointerFetch`](super::pointer_fetch::RecordPointerFetch) reads it
+    /// back that way), so this rides [`publish_inline`] and inherits every law of
+    /// the pipeline. Nothing gates a pointer record, so no adopt ever raises its
+    /// sequence floor: the freshest record on the network is the lower bound a
+    /// second rotation must clear, and a confirmed flip raises the floor itself.
     async fn publish_scope_pointer(&self, block: &[u8]) -> Result<(), WritePublishError> {
         let name = scope_pointer_name(self.owner_pointer_seed, &self.scope_id);
-        register(
-            self.api,
-            &[NameRegistration {
-                ipns_name: name.as_str().to_owned(),
-                head_cid: None,
-                content_cids: Vec::new(),
-            }],
-        )
-        .await
-        .map_err(|_| WritePublishError::RegistryFull)?;
-
-        // Nothing gates a pointer record, so its durable sequence floor may never
-        // have moved; the freshest record on the network is the other lower bound
-        // a second rotation must clear.
-        let durable = floor::sequence_floor(self.floors, name.as_str().as_bytes())
-            .await
-            .map_err(|_| WritePublishError::NotLanded)?
-            .unwrap_or(0);
+        let signer = scope_pointer_signer(self.owner_pointer_seed, &self.scope_id);
         let observed = fanout_get_verify(self.transport, &name)
             .await
             .map_or(0, |(record, _)| record.sequence);
-        let sequence = durable.max(observed) + 1;
-
-        let ttl_nanos = u64::try_from(self.profile.record_ttl.as_nanos()).unwrap_or(u64::MAX);
-        let eol = eol::eol_from(self.scheduler.now());
-        let signer = scope_pointer_signer(self.owner_pointer_seed, &self.scope_id);
-        let record_bytes =
-            IpnsRecord::create_v2(&signer, block, sequence, ttl_nanos, &eol).marshal();
-        // A record past the fan-out cap is one this client can never re-resolve,
-        // so its floor would never advance and the name would lapse at EOL.
-        if record_bytes.len() > MAX_RECORD_BYTES {
-            return Err(WritePublishError::Rejected);
-        }
-        if !fanout_put(self.transport, name.as_str(), &record_bytes)
-            .await
-            .any_acked()
-        {
-            return Err(WritePublishError::NotLanded);
-        }
-        match fanout_get_verify(self.transport, &name).await {
-            Some((record, bytes)) if record.sequence == sequence && bytes == record_bytes => Ok(()),
-            Some((record, _)) if record.sequence > sequence => Err(WritePublishError::LostRace),
-            _ => Err(WritePublishError::NotLanded),
+        let receipt = publish_inline(
+            self.transport,
+            self.api,
+            self.floors,
+            self.scheduler,
+            self.profile,
+            &InlineRecordRequest {
+                name: &name,
+                signer: &signer,
+                value: block,
+                min_current_sequence: Some(observed),
+            },
+        )
+        .await
+        .map_err(|error| match error {
+            PublishError::Register(_) => WritePublishError::RegistryFull,
+            PublishError::EmptyHeadCid | PublishError::RecordTooLarge { .. } => {
+                WritePublishError::Rejected
+            }
+            _ => WritePublishError::NotLanded,
+        })?;
+        match receipt.outcome {
+            PublishOutcome::Published { sequence } => {
+                floor::advance_sequence_on_unseal(self.floors, name.as_str().as_bytes(), sequence)
+                    .await
+                    .map_err(|_| WritePublishError::NotLanded)
+            }
+            PublishOutcome::LostRace { .. } => Err(WritePublishError::LostRace),
+            PublishOutcome::Unconfirmed { .. } => Err(WritePublishError::NotLanded),
         }
     }
 }
@@ -1082,20 +1239,36 @@ where
     }
 
     async fn republish(&self, node: &RepublishedNode) -> Result<(), WritePublishError> {
-        let record_bytes = self.record_at(&node.current_name).await?;
-        let source = if node.is_root {
-            self.root_source(&node.current_name, &record_bytes).await?
-        } else {
-            self.interior_source(node.node_id, &node.current_name, &record_bytes)
-                .await?
+        let source = match self.gated_root.take(&node.current_name) {
+            Some(parked) => parked,
+            None => {
+                let record_bytes = fanout_get_verify(self.transport, &node.current_name)
+                    .await
+                    .map(|(_, bytes)| bytes)
+                    .ok_or(WritePublishError::NotLanded)?;
+                if node.is_root {
+                    self.root_source(&node.current_name, &record_bytes).await?
+                } else {
+                    self.interior_source(node.node_id, &node.current_name, &record_bytes)
+                        .await?
+                }
+            }
         };
-        self.publish_moved(node, source).await
+        // The interior path re-opens its own record at the floor, so only the
+        // root's read has to survive a failed publish.
+        let held = node.is_root.then(|| source.clone());
+        let published = self.publish_moved(node, source).await;
+        if published.is_err()
+            && let Some(source) = held
+        {
+            self.gated_root.park(&node.current_name, source);
+        }
+        published
     }
 
     async fn retire(&self, old_names: &[IpnsName]) -> Result<(), WritePublishError> {
-        // Retirement is irreversible and the old root serves the tombstone every
-        // lagging reader chases, so refuse the batch release-active while the
-        // migration window is still open (security rule 8).
+        // Irreversible, and the old root serves the tombstone every lagging
+        // reader chases (`net/retire.rs::root_retire_ready`).
         if !root_retire_ready() && old_names.iter().any(|name| name == self.current_root_name) {
             return Err(WritePublishError::Rejected);
         }
@@ -1135,13 +1308,13 @@ mod tests {
     use cipherbox_core::ipns::{IpnsRecord, VerifiedRecord};
     use cipherbox_core::seal::{
         AscentLink, ChildRef, GrantSetCommitment, NodeKind, STRUCT_TAG_ASCENT_LINK,
-        decode_envelope, decode_grant_section, encode_envelope, encode_grant_section,
-        grant_section_bytes, open_ascent_link, open_read_body, seal_read_body, set_grant_section,
-        sign_grant_set, verify_grant_set,
+        STRUCT_TAG_OWNER_WRITE_BLOB, decode_envelope, decode_grant_section, encode_envelope,
+        encode_grant_section, grant_section_bytes, open_ascent_link, open_owner_write_blob,
+        open_read_body, seal_read_body, set_grant_section, sign_grant_set, verify_grant_set,
     };
     use cipherbox_core::suite::ecdsa::EcdsaSignature;
     use cipherbox_core::suite::ed25519::Ed25519Signer;
-    use cipherbox_core::suite::secret::ct_eq;
+    use cipherbox_core::suite::secret::{SecretBytes, ct_eq};
 
     use super::*;
     use crate::content::GatewaySource;
@@ -2616,6 +2789,20 @@ mod tests {
     /// The write scope seed the wave moves TO — every new name derives from it.
     const FRESH_WRITE_SCOPE_SEED: [u8; 32] = [0xa5; 32];
 
+    /// The wave's owner arm. `writer_pseudonym` must be the signer the fixture's
+    /// commitment names, or the re-seal refuses (`ResealError::SignerNotCommitted`).
+    struct WaveSeeds;
+
+    impl OwnerScopeKeys for WaveSeeds {
+        fn writer_pseudonym(&self, _scope_id: &[u8; 16]) -> Ed25519Signer {
+            Ed25519Signer::from_seed(OWNER_ROOT_PSEUDONYM_SEED)
+        }
+
+        fn pointer_read_key(&self, scope_id: &[u8; 16]) -> Zeroizing<[u8; SECRET_LEN]> {
+            Zeroizing::new(*kdf::pointer_read_key(&OWNER_POINTER_SEED, scope_id).as_bytes())
+        }
+    }
+
     type Wave<'a, T> = WriteWaveNet<
         'a,
         T,
@@ -2645,6 +2832,8 @@ mod tests {
             parent_node_seed: None,
             owner,
             owner_enc_secret: &harness.enc_secret,
+            scope_keys: &WaveSeeds,
+            gated_root: GatedWaveRoot::default(),
             owner_pointer_seed: &OWNER_POINTER_SEED,
             current_root_name: current_root,
         }
@@ -2725,7 +2914,10 @@ mod tests {
             current_name: current_name.clone(),
             new_name: derive_write_name(&FRESH_WRITE_SCOPE_SEED, &node_id),
             child_names,
-            write_seed: kdf::write_seed(&FRESH_WRITE_SCOPE_SEED, &node_id),
+            signer: kdf::ipns_keypair(
+                kdf::write_seed(&FRESH_WRITE_SCOPE_SEED, &node_id).as_bytes(),
+            ),
+            write_scope_seed: is_root.then(|| SecretBytes::new(FRESH_WRITE_SCOPE_SEED)),
             write_epoch: OWNER_ROOT_EPOCH + 1,
             is_root,
         }
@@ -2895,9 +3087,85 @@ mod tests {
         let sig = EcdsaSignature::from_compact(&section.commitment_sig).expect("a compact sig");
         verify_grant_set(&owner.verifying_key(), &section.commitment, &sig)
             .expect("the re-signed commitment verifies under the owner identity");
+        // The root's section is the only channel that carries `writeScopeSeed`,
+        // so the wave must re-mint the write plane under the fresh seed at the
+        // advanced write epoch — otherwise every name moves while the published
+        // seed still derives the retired ones.
+        let owner_write_blob = section
+            .owner_write_blob
+            .as_ref()
+            .expect("the moved root carries an owner-write blob");
+        let aad = AadContext {
+            v: ENVELOPE_V,
+            id: SCOPE,
+            scope: SCOPE,
+            epoch: OWNER_ROOT_EPOCH + 1,
+            struct_tag: STRUCT_TAG_OWNER_WRITE_BLOB,
+        };
+        let payload = open_owner_write_blob(
+            &owner_enc(),
+            &owner_write_blob.enc,
+            &aad,
+            &owner_write_blob.ciphertext,
+        )
+        .expect("the owner reopens its write blob at the NEW write epoch");
         assert_eq!(
-            section.owner_blob, root.grant_section.owner_blob,
-            "the seed-bearing structures ride verbatim — a name wave re-keys nothing"
+            payload.write_scope_seed(),
+            &FRESH_WRITE_SCOPE_SEED,
+            "the published seed is the one the wave derived every new name from"
+        );
+        assert_eq!(payload.write_epoch, OWNER_ROOT_EPOCH + 1);
+
+        // The read plane is untouched: the override seed the owner blob carries
+        // is the pre-wave one, at the unchanged read epoch.
+        assert_eq!(
+            published_override_seed(&harness, &moved.new_name, SCOPE, OWNER_ROOT_EPOCH),
+            OWNER_ROOT_SCOPE_SEED,
+            "a name wave re-keys no read seed"
+        );
+    }
+
+    #[test]
+    fn a_failed_root_publish_leaves_the_root_republishable() {
+        // The root gate advances the durable sequence floor and there is no
+        // at-floor root re-open, so a pass that gated the root and then failed to
+        // publish must retry off the read it already holds — otherwise a wave
+        // interrupted between the two can never be resumed and the write revoke
+        // it carries is stuck for good.
+        let harness = Harness::plain();
+        let root = owner_root_fixture(OwnerRootSpec {
+            owner_identity: &owner_identity(),
+            owner_enc: &owner_enc().public(),
+            scope_id: SCOPE,
+            root_id: SCOPE,
+            children: Vec::new(),
+            child_scope_index: Vec::new(),
+            parent_node_seed: None,
+            owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+        });
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+
+        let owner = owner_identity();
+        let net = wave(&harness, &owner, &root.name);
+
+        // A root order the publisher refuses *after* the gated read: no fresh
+        // write scope seed means the section cannot be re-minted.
+        let mut seedless = order(SCOPE, &root.name, BTreeMap::new(), true);
+        seedless.write_scope_seed = None;
+        assert_eq!(
+            block_on(net.republish(&seedless)),
+            Err(WritePublishError::Rejected)
+        );
+
+        // The retry succeeds off the held read, where a second gated read would
+        // reject as not-newer against the floor the first one advanced.
+        let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
+        block_on(net.republish(&moved)).expect("the retried root republish");
+        assert_eq!(
+            published_section(&harness, &moved.new_name)
+                .commitment
+                .ipns_name,
+            moved.new_name.as_str().as_bytes()
         );
     }
 

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -854,6 +854,7 @@ fn reseal_verdict(error: ResealError) -> WritePublishError {
         | ResealError::UnusableRecipientKey
         | ResealError::AscentLinkMismatch
         | ResealError::TooManyHistoryLinks
+        | ResealError::TooManyCommittedGrants
         | ResealError::Encode(_) => WritePublishError::Rejected,
     }
 }
@@ -1341,8 +1342,7 @@ mod tests {
     use crate::rotation::{
         CascadeError, CascadeOutcome, CommittedSet, PrevEpochSeed, ResealSeeds, RotateScopePlan,
         ScopeRootIdentity, cascade_rotate_scope, derive_write_name, enumerate_eager_set,
-        reseal_scope_root,
-        rotate_scope,
+        reseal_scope_root, rotate_scope,
     };
     use crate::seams::{EndpointId, HttpResponse, SeamError, SeamResult};
     use crate::testkit::fakes::{
@@ -3337,6 +3337,7 @@ mod tests {
             ResealError::UnusableRecipientKey,
             ResealError::AscentLinkMismatch,
             ResealError::TooManyHistoryLinks,
+            ResealError::TooManyCommittedGrants,
             ResealError::Encode(CodecError::Malformed(Malformed::DepthExceeded {
                 offset: 0,
             })),

--- a/crates/engine/src/rotation/mod.rs
+++ b/crates/engine/src/rotation/mod.rs
@@ -26,11 +26,10 @@
 //!   wave (root re-pointed last) with the three-channel re-point, register-first
 //!   inventory swap, and root linger. The write-plane sibling of `rotate_scope`.
 //!
-//! [`ChildIndexResolver`], [`CascadeResealResolver`] and [`ScopeRootPublisher`]
-//! have production implementations over the real transport in
-//! [`crate::net::rotation`]. [`SweepResolver`] and the write-plane
-//! [`WriteSubtreeResolver`] and [`WriteWavePublisher`] have no production
-//! implementation yet; tests fake them.
+//! [`ChildIndexResolver`], [`CascadeResealResolver`], [`ScopeRootPublisher`] and
+//! [`WriteWavePublisher`] have production implementations over the real transport
+//! in [`crate::net::rotation`]. [`SweepResolver`] and [`WriteSubtreeResolver`]
+//! have no production implementation yet; tests fake them.
 
 pub mod cascade;
 pub mod eager_set;

--- a/crates/engine/src/rotation/rotate_write.rs
+++ b/crates/engine/src/rotation/rotate_write.rs
@@ -13,11 +13,7 @@
 //! fresh write scope seed moves every node to a fresh name under a fresh signing
 //! key. The read plane's **keys** are untouched — override seeds, read keys, and
 //! `minReadEpoch` carry verbatim, and no rotation path re-encrypts content bytes
-//! (#26 D6). Read-body *metadata* is not: every `ChildRef.ipnsName` in the subtree
-//! names a node the wave moves, and a read-only survivor derives no write name, so
-//! each parent's read body is rewritten and re-sealed under its unchanged read key
-//! at its unchanged read epoch (blueprint/engine.md "rotateScopeWrite"). The
-//! republish is therefore not byte-stable.
+//! (#26 D6). Read-body *metadata* is not: see [`RepublishedNode::child_names`].
 //!
 //! # Ordering is the safety property (#34 D4)
 //!
@@ -27,13 +23,12 @@
 //! batch-retire only **after** the root re-point; the old root name lingers past
 //! the migration window.
 //!
-//! # Three-channel re-point (#38 D3)
+//! # Re-point channels (#38 D3)
 //!
-//! The owner-identity-signed re-point object publishes to the scope pointer record
-//! (canonical), the mailbox, and the old root name's tombstone (feeding the
-//! depth-guarded `movedTo` chase). `writeEpoch` advances here; `minReadEpoch` is
-//! carried unchanged, so each plane's clock stays authored by its owning authority
-//! (#38 D1).
+//! The owner-identity-signed re-point object flips the canonical scope pointer
+//! record, then goes out on the two accelerator channels (see [`RepointChannel`]).
+//! `writeEpoch` advances here; `minReadEpoch` is carried unchanged, so each plane's
+//! clock stays authored by its owning authority (#38 D1).
 //!
 //! # Crash recovery from published records only (#26 D8)
 //!
@@ -66,6 +61,7 @@ use cipherbox_core::kdf;
 use cipherbox_core::payload::RepointObject;
 use cipherbox_core::seal::{GrantSetCommitment, verify_grant_set};
 use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaSigner, SIGNATURE_LEN as ECDSA_SIG_LEN};
+use cipherbox_core::suite::ed25519::Ed25519Signer;
 use cipherbox_core::suite::secret::{SECRET_LEN, SecretBytes};
 
 use super::eager_set::ResolveFailure;
@@ -113,7 +109,7 @@ const REPOINT_ACCELERATORS: [RepointChannel; 2] =
 /// [`Self::current_name`] and rewrites what moved, so the wave drags neither
 /// O(subtree) bodies nor per-node read keys through this primitive
 /// (blueprint/engine.md "rotateScopeWrite").
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct RepublishedNode {
     /// The node id being republished.
     pub node_id: [u8; 16],
@@ -123,16 +119,23 @@ pub struct RepublishedNode {
     /// The freshly derived `ipnsName` the record is published at.
     pub new_name: IpnsName,
     /// Each in-scope direct child's freshly derived name, keyed by child node id.
-    /// The publisher rewrites the matching `ChildRef.ipnsName` and re-seals the
-    /// read body: a read-only survivor holds no `writeScopeSeed` and can derive
-    /// no name, so without the rewrite it reaches the new root and stops. Empty
-    /// for a leaf. Child-first ordering makes every entry known before the parent
+    ///
+    /// A read-only survivor holds no `writeScopeSeed` and can derive no name, so
+    /// the wave rewrites the matching `ChildRef.ipnsName` and re-seals the parent's
+    /// read body under its unchanged read key at its unchanged read epoch — without
+    /// it a read-only holder reaches the new root and cannot descend. Empty for a
+    /// leaf; child-first ordering makes every entry known before the parent
     /// publishes.
     pub child_names: BTreeMap<[u8; 16], IpnsName>,
-    /// `writeSeed(freshWriteScopeSeed, node_id)` — the capability that signs at
-    /// [`Self::new_name`], and nothing wider: the wave's scope seed never leaves
-    /// the orchestrator, so the publisher can derive no other node's name.
-    pub write_seed: SecretBytes,
+    /// Signs the record at [`Self::new_name`] — the narrow per-name capability
+    /// (the shape `net/liveness.rs` holds for the same reason), never the seed it
+    /// derives from, so the publisher can derive no other node's name.
+    pub signer: Ed25519Signer,
+    /// The wave's fresh write scope seed, carried **only** for the scope root:
+    /// the root's grant section is the sole channel that distributes it (the
+    /// owner-write blob and every write grantee's blob), and a root republished
+    /// without it strands the whole write plane on the retired names.
+    pub write_scope_seed: Option<SecretBytes>,
     /// The write epoch the record publishes at (bumped for the whole scope).
     pub write_epoch: u64,
     /// Whether this is the scope root (re-pointed last, old name lingers).
@@ -156,24 +159,21 @@ pub trait WriteSubtreeResolver {
 /// mapping to the API pin/name registry and `/routing/v1` transport
 /// (`net/rotation.rs::WriteWaveNet`).
 ///
-/// Register-first is **not** a method here. The publish pipeline registers the
-/// name it is about to PUT and blocks on it (#28 D5), so the trait offers no way
-/// to reach the transport with an unregistered name — the ordering law is
-/// structural rather than an orchestrator convention.
-///
 /// Contract the orchestrator relies on and the fake honours:
 ///
 /// - **republish / retire are idempotent** — a resumed wave re-publishes and
 ///   re-retires the same names harmlessly.
 /// - **`is_republished` reads published state only** — it is how a resumed wave
 ///   skips already-done nodes without any in-memory checkpoint.
+/// - **`republish` registers the name it PUTs**, first and fail-closed
+///   (`net/publish.rs`, #28 D5) — the never-orphan ordering law.
 pub trait WriteWavePublisher {
     /// Whether a record is already published at `new_name` — the resume query,
     /// answered from published state only (no in-memory carry across a crash).
     async fn is_republished(&self, new_name: &IpnsName) -> Result<bool, WritePublishError>;
 
     /// Register-first then CAS-publish `node`'s record at its freshly derived
-    /// name, rewriting the child refs [`RepublishedNode::child_names`] names.
+    /// name, rewriting [`RepublishedNode::child_names`] into its read body.
     async fn republish(&self, node: &RepublishedNode) -> Result<(), WritePublishError>;
 
     /// Batch-retire interior old names at wave completion. MUST run only **after**
@@ -188,10 +188,10 @@ pub trait WriteWavePublisher {
     ) -> Result<(), WritePublishError>;
 }
 
-/// Why one write-plane transport op did not durably land. Every variant aborts
-/// the wave — it never claims completion on a dropped effect — but only
-/// [`Self::Rejected`] is a trust verdict a retry cannot clear (rule 6: a
-/// fail-closed rejection is never laundered into an availability stall).
+/// Why one write-plane op did not durably land. Only [`Self::Rejected`] is a
+/// trust verdict a retry cannot clear (rule 6: a fail-closed rejection is never
+/// laundered into an availability stall), and it aborts the wave on every
+/// channel; the rest abort every stage except an accelerator re-point.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WritePublishError {
     /// The register / PUT did not land; nothing durable. Retryable.
@@ -312,7 +312,7 @@ pub enum WriteRotateError {
     /// A write-plane transport op did not land. Names the stage so a retry knows
     /// where the wave stopped (it re-derives and resumes from published state).
     Publish {
-        /// The wave stage that failed (`register` / `republish` / `retire` /
+        /// The wave stage that failed (`republish` / `retire` /
         /// `repoint-<channel>`).
         stage: &'static str,
         /// The offending node id, or the scope id for the retire/re-point stages.
@@ -538,8 +538,8 @@ where
     )
     .await?;
 
-    // 7) Three-channel re-point: seal the owner-signed re-point object and publish
-    //    it in `REPOINT_CHANNELS` order.
+    // 7) Seal the owner-signed re-point object; flip the canonical pointer, then
+    //    the accelerators.
     let repoint = build_repoint_object(
         scope_id,
         new_root_name.clone(),
@@ -568,8 +568,19 @@ where
         })?;
     let mut repoint_accelerators = Vec::with_capacity(REPOINT_ACCELERATORS.len());
     for channel in REPOINT_ACCELERATORS {
-        if publisher.publish_repoint(channel, &block).await.is_ok() {
-            repoint_accelerators.push(channel);
+        match publisher.publish_repoint(channel, &block).await {
+            Ok(()) => repoint_accelerators.push(channel),
+            // An accelerator carries nothing load-bearing, so an availability
+            // failure is reported, not fatal. A `Rejected` is not availability:
+            // the publisher refused to sign, and rule 6 forbids absorbing that.
+            Err(WritePublishError::Rejected) => {
+                return Err(WriteRotateError::Publish {
+                    stage: repoint_stage(channel),
+                    node_id: scope_id,
+                    error: WritePublishError::Rejected,
+                });
+            }
+            Err(_) => {}
         }
     }
 
@@ -632,7 +643,8 @@ async fn republish_node<P: WriteWavePublisher>(
             current_name: node.current_name.clone(),
             new_name: new_name.clone(),
             child_names,
-            write_seed: kdf::write_seed(write_scope_seed, &node_id),
+            signer: kdf::ipns_keypair(kdf::write_seed(write_scope_seed, &node_id).as_bytes()),
+            write_scope_seed: is_root.then(|| SecretBytes::new(*write_scope_seed)),
             write_epoch,
             is_root,
         })
@@ -833,16 +845,14 @@ mod tests {
         }
         fn failing_after(state: WaveState, n: usize) -> Self {
             Self {
-                state,
                 fail_republish_after: Some(n),
-                refuse_channel: None,
+                ..Self::new(state)
             }
         }
         fn refusing(state: WaveState, channel: RepointChannel) -> Self {
             Self {
-                state,
-                fail_republish_after: None,
                 refuse_channel: Some(channel),
+                ..Self::new(state)
             }
         }
     }
@@ -1127,15 +1137,17 @@ mod tests {
                 assert_eq!(mapped, &by_id[kid].new_name);
                 assert_eq!(mapped, &derive_write_name(&seed, kid));
             }
-            // The write seed is the node's own, and nothing wider: it signs at the
-            // new name and derives no other node's.
-            assert_eq!(order.write_seed, kdf::write_seed(&seed, &order.node_id));
+            // The capability is the node's own, and nothing wider: it signs at
+            // the new name and derives no other node's.
             assert_eq!(
-                IpnsName::from_public_key(
-                    &kdf::ipns_keypair(order.write_seed.as_bytes()).verifying_key()
-                ),
+                IpnsName::from_public_key(&order.signer.verifying_key()),
                 order.new_name,
-                "the handed seed signs at the handed name"
+                "the handed signer is the new name's key"
+            );
+            assert_eq!(
+                order.write_scope_seed.is_some(),
+                order.is_root,
+                "only the root carries the scope seed its section distributes"
             );
             assert_eq!(order.current_name, old_name_of(&order.node_id));
         }

--- a/crates/engine/src/rotation/rotate_write.rs
+++ b/crates/engine/src/rotation/rotate_write.rs
@@ -11,8 +11,13 @@
 //! `ipnsName`, the IPNS signing keypair, and `writeKey` all derive from
 //! `writeSeed(node) = KDF(writeScopeSeed, node.id)` (CONTEXT.md "Write seed"), so a
 //! fresh write scope seed moves every node to a fresh name under a fresh signing
-//! key. The read plane is untouched — override seeds, read keys, and `minReadEpoch`
-//! carry verbatim, and no rotation path re-encrypts content bytes (#26 D6).
+//! key. The read plane's **keys** are untouched — override seeds, read keys, and
+//! `minReadEpoch` carry verbatim, and no rotation path re-encrypts content bytes
+//! (#26 D6). Read-body *metadata* is not: every `ChildRef.ipnsName` in the subtree
+//! names a node the wave moves, and a read-only survivor derives no write name, so
+//! each parent's read body is rewritten and re-sealed under its unchanged read key
+//! at its unchanged read epoch (blueprint/engine.md "rotateScopeWrite"). The
+//! republish is therefore not byte-stable.
 //!
 //! # Ordering is the safety property (#34 D4)
 //!
@@ -50,9 +55,9 @@
 //! [`build_repoint_object`]'s two encode-side invariants are release-active, never
 //! a `debug_assert!` (AGENTS.md rule 8). Entropy enters only through the
 //! [`Entropy`] seam; the impure edges are the injected [`WriteSubtreeResolver`] and
-//! [`WriteWavePublisher`] (network wiring not landed, faked in this slice).
+//! [`WriteWavePublisher`] (`net/rotation.rs` holds the production publisher).
 
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use zeroize::Zeroizing;
 
@@ -61,7 +66,7 @@ use cipherbox_core::kdf;
 use cipherbox_core::payload::RepointObject;
 use cipherbox_core::seal::{GrantSetCommitment, verify_grant_set};
 use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaSigner, SIGNATURE_LEN as ECDSA_SIG_LEN};
-use cipherbox_core::suite::secret::SECRET_LEN;
+use cipherbox_core::suite::secret::{SECRET_LEN, SecretBytes};
 
 use super::eager_set::ResolveFailure;
 use crate::entropy::{Entropy, EntropyError};
@@ -97,25 +102,37 @@ pub enum RepointChannel {
     Tombstone,
 }
 
-/// The three channels in canonical publish order: pointer first (the authoritative
-/// switch), then the two accelerators.
-const REPOINT_CHANNELS: [RepointChannel; 3] = [
-    RepointChannel::ScopePointer,
-    RepointChannel::Mailbox,
-    RepointChannel::Tombstone,
-];
+/// The two accelerator channels, published after the canonical
+/// [`RepointChannel::ScopePointer`] flip.
+const REPOINT_ACCELERATORS: [RepointChannel; 2] =
+    [RepointChannel::Mailbox, RepointChannel::Tombstone];
 
-/// One node re-published at its freshly derived name — the record the publisher
-/// CAS-installs. Assembling the record bytes (read-body carried verbatim, write-
-/// body re-sealed at the new write epoch for the root) and IPNS-signing them under
-/// the node's fresh write keypair is not landed; this slice
-/// fakes the publish and carries only the routing identity.
+/// The order to republish one node at its freshly derived name. It carries
+/// routing identity and the narrowest key material the publish needs — never the
+/// record's authoring material: the publisher re-resolves the node at
+/// [`Self::current_name`] and rewrites what moved, so the wave drags neither
+/// O(subtree) bodies nor per-node read keys through this primitive
+/// (blueprint/engine.md "rotateScopeWrite").
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RepublishedNode {
     /// The node id being republished.
     pub node_id: [u8; 16],
+    /// The node's current (pre-wave) `ipnsName` — where the publisher does its
+    /// gated read of the record it is about to succeed.
+    pub current_name: IpnsName,
     /// The freshly derived `ipnsName` the record is published at.
     pub new_name: IpnsName,
+    /// Each in-scope direct child's freshly derived name, keyed by child node id.
+    /// The publisher rewrites the matching `ChildRef.ipnsName` and re-seals the
+    /// read body: a read-only survivor holds no `writeScopeSeed` and can derive
+    /// no name, so without the rewrite it reaches the new root and stops. Empty
+    /// for a leaf. Child-first ordering makes every entry known before the parent
+    /// publishes.
+    pub child_names: BTreeMap<[u8; 16], IpnsName>,
+    /// `writeSeed(freshWriteScopeSeed, node_id)` — the capability that signs at
+    /// [`Self::new_name`], and nothing wider: the wave's scope seed never leaves
+    /// the orchestrator, so the publisher can derive no other node's name.
+    pub write_seed: SecretBytes,
     /// The write epoch the record publishes at (bumped for the whole scope).
     pub write_epoch: u64,
     /// Whether this is the scope root (re-pointed last, old name lingers).
@@ -134,27 +151,29 @@ pub trait WriteSubtreeResolver {
     async fn resolve_node(&self, node_id: &[u8; 16]) -> Result<WriteScopeNode, ResolveFailure>;
 }
 
-/// The write edge of the name wave: register-first name enrollment, CAS republish,
-/// batch retire, and the three-channel re-point — the analogue of the cascade's
-/// `ScopeRootPublisher`, mapping to the API pin/name registry and `/routing/v1`
-/// transport. That wiring is not landed; tests fake it.
+/// The write edge of the name wave: CAS republish, batch retire, and the
+/// three-channel re-point — the analogue of the cascade's `ScopeRootPublisher`,
+/// mapping to the API pin/name registry and `/routing/v1` transport
+/// (`net/rotation.rs::WriteWaveNet`).
+///
+/// Register-first is **not** a method here. The publish pipeline registers the
+/// name it is about to PUT and blocks on it (#28 D5), so the trait offers no way
+/// to reach the transport with an unregistered name — the ordering law is
+/// structural rather than an orchestrator convention.
 ///
 /// Contract the orchestrator relies on and the fake honours:
 ///
-/// - **register / retire are idempotent** — a resumed wave re-registers and
+/// - **republish / retire are idempotent** — a resumed wave re-publishes and
 ///   re-retires the same names harmlessly.
 /// - **`is_republished` reads published state only** — it is how a resumed wave
 ///   skips already-done nodes without any in-memory checkpoint.
 pub trait WriteWavePublisher {
-    /// Register-first: enroll `new_name` in the name registry (idempotent). MUST
-    /// precede retiring the predecessor it replaces — never orphan a name.
-    async fn register(&self, new_name: &IpnsName) -> Result<(), WritePublishError>;
-
     /// Whether a record is already published at `new_name` — the resume query,
     /// answered from published state only (no in-memory carry across a crash).
     async fn is_republished(&self, new_name: &IpnsName) -> Result<bool, WritePublishError>;
 
-    /// CAS-publish `node`'s record at its freshly derived name.
+    /// Register-first then CAS-publish `node`'s record at its freshly derived
+    /// name, rewriting the child refs [`RepublishedNode::child_names`] names.
     async fn republish(&self, node: &RepublishedNode) -> Result<(), WritePublishError>;
 
     /// Batch-retire interior old names at wave completion. MUST run only **after**
@@ -169,8 +188,10 @@ pub trait WriteWavePublisher {
     ) -> Result<(), WritePublishError>;
 }
 
-/// Why one write-plane transport op did not durably land. All variants mean the
-/// wave must abort — it never claims completion on a dropped effect.
+/// Why one write-plane transport op did not durably land. Every variant aborts
+/// the wave — it never claims completion on a dropped effect — but only
+/// [`Self::Rejected`] is a trust verdict a retry cannot clear (rule 6: a
+/// fail-closed rejection is never laundered into an availability stall).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WritePublishError {
     /// The register / PUT did not land; nothing durable. Retryable.
@@ -181,6 +202,11 @@ pub enum WritePublishError {
     /// Register-first was rejected by the name registry (quota). Retryable once
     /// capacity frees.
     RegistryFull,
+    /// The publisher's own fail-closed verdict on the bytes it was about to sign
+    /// or the effect it was about to make irreversible — a gate rejection on the
+    /// re-resolve, a read body whose children disagree with the wave, or a retire
+    /// batch naming the lingering root. Re-running reaches the same verdict.
+    Rejected,
 }
 
 impl core::fmt::Display for WritePublishError {
@@ -189,6 +215,7 @@ impl core::fmt::Display for WritePublishError {
             WritePublishError::NotLanded => f.write_str("write-plane record did not land"),
             WritePublishError::LostRace => f.write_str("write-plane publish lost the CAS race"),
             WritePublishError::RegistryFull => f.write_str("name registry rejected register-first"),
+            WritePublishError::Rejected => f.write_str("write-plane publish refused fail-closed"),
         }
     }
 }
@@ -226,14 +253,19 @@ pub struct RotateScopeWritePlan<'a> {
 }
 
 /// A completed write rotation. Holding one is proof the whole subtree was
-/// republished, the root re-pointed on all three channels, and interior old names
-/// retired — an incomplete wave returns [`WriteRotateError`] instead.
+/// republished, the **canonical** re-point landed, and interior old names retired
+/// — an incomplete wave returns [`WriteRotateError`] instead.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WriteRotationOutcome {
     /// The new write epoch the scope was cut to (`current_write_epoch + 1`).
     pub new_write_epoch: u64,
     /// The scope root's new `ipnsName` (`currentRootName` in the re-point object).
     pub new_root_name: IpnsName,
+    /// Which accelerator channels the re-point actually reached, in publish
+    /// order. Nothing on them is load-bearing (see [`RepointChannel`]), so a
+    /// refused accelerator leaves the wave complete and is reported rather than
+    /// aborting a rotation whose canonical re-point already flipped the pointer.
+    pub repoint_accelerators: Vec<RepointChannel>,
     /// The number of interior (non-root) nodes in the scope's subtree — the wave
     /// covers all of them, though a resumed wave may have republished some in a
     /// prior run (skipped via `is_republished`), and a post-flip-crash resume
@@ -356,7 +388,8 @@ impl WriteRotateError {
             | WriteRotateError::EpochExhausted
             | WriteRotateError::WriteEpochNotAdvancing
             | WriteRotateError::IdentityRepoint => false,
-            WriteRotateError::Entropy(_) | WriteRotateError::Publish { .. } => true,
+            WriteRotateError::Entropy(_) => true,
+            WriteRotateError::Publish { error, .. } => *error != WritePublishError::Rejected,
             WriteRotateError::Resolve { reason, .. } => *reason == ResolveFailure::Unavailable,
             WriteRotateError::Repoint(e) => matches!(e, PointerError::Entropy(_)),
         }
@@ -470,12 +503,20 @@ where
         .split_first()
         .expect("collect_subtree always yields at least the root");
 
-    // 5) Child-first wave over the descendants (deepest first): register-first, then
-    //    republish unless already done (resume skips it via published state).
+    // 5) Child-first wave over the descendants (deepest first): republish unless
+    //    already done (resume skips it via published state).
     let mut interior_old_names: Vec<IpnsName> = Vec::with_capacity(descendants.len());
     for node in descendants.iter().rev() {
         let new_name = derive_write_name(&write_scope_seed, &node.node_id);
-        republish_node(publisher, node.node_id, &new_name, new_write_epoch, false).await?;
+        republish_node(
+            publisher,
+            &write_scope_seed,
+            node,
+            &new_name,
+            new_write_epoch,
+            false,
+        )
+        .await?;
         // Retire only a superseded name, never one a node still lives at: on a
         // post-flip resume the resolver reports the already-migrated (new) name as
         // current, and retiring it would orphan a live descendant (never orphan).
@@ -489,7 +530,8 @@ where
     let new_root_name = derive_write_name(&write_scope_seed, &root.node_id);
     republish_node(
         publisher,
-        root.node_id,
+        &write_scope_seed,
+        root,
         &new_root_name,
         new_write_epoch,
         true,
@@ -516,15 +558,19 @@ where
         &repoint,
     )
     .map_err(WriteRotateError::Repoint)?;
-    for channel in REPOINT_CHANNELS {
-        publisher
-            .publish_repoint(channel, &block)
-            .await
-            .map_err(|error| WriteRotateError::Publish {
-                stage: repoint_stage(channel),
-                node_id: scope_id,
-                error,
-            })?;
+    publisher
+        .publish_repoint(RepointChannel::ScopePointer, &block)
+        .await
+        .map_err(|error| WriteRotateError::Publish {
+            stage: repoint_stage(RepointChannel::ScopePointer),
+            node_id: scope_id,
+            error,
+        })?;
+    let mut repoint_accelerators = Vec::with_capacity(REPOINT_ACCELERATORS.len());
+    for channel in REPOINT_ACCELERATORS {
+        if publisher.publish_repoint(channel, &block).await.is_ok() {
+            repoint_accelerators.push(channel);
+        }
     }
 
     // 8) Batch-retire the interior old names — only now, after the re-point flipped
@@ -543,56 +589,55 @@ where
     Ok(WriteRotationOutcome {
         new_write_epoch,
         new_root_name,
+        repoint_accelerators,
         interior_node_count: descendants.len(),
     })
 }
 
-/// Register-first then CAS-republish one node at `new_name`, skipping the
-/// republish when published state already carries it (the resume idempotence).
+/// CAS-republish one node at `new_name`, skipping the republish when published
+/// state already carries it (the resume idempotence).
 async fn republish_node<P: WriteWavePublisher>(
     publisher: &P,
-    node_id: [u8; 16],
+    write_scope_seed: &[u8; SECRET_LEN],
+    node: &WriteScopeNode,
     new_name: &IpnsName,
     write_epoch: u64,
     is_root: bool,
 ) -> Result<(), WriteRotateError> {
-    // Register-first: enroll the new name BEFORE its predecessor is ever retired.
-    publisher
-        .register(new_name)
-        .await
-        .map_err(|error| WriteRotateError::Publish {
-            stage: "register",
-            node_id,
-            error,
-        })?;
+    let node_id = node.node_id;
+    let publish_error = |error| WriteRotateError::Publish {
+        stage: "republish",
+        node_id,
+        error,
+    };
 
     // Resume: skip a node whose new-name record already landed on a prior run.
-    let already =
-        publisher
-            .is_republished(new_name)
-            .await
-            .map_err(|error| WriteRotateError::Publish {
-                stage: "republish",
-                node_id,
-                error,
-            })?;
-    if already {
+    if publisher
+        .is_republished(new_name)
+        .await
+        .map_err(publish_error)?
+    {
         return Ok(());
     }
+
+    let child_names = node
+        .child_node_ids
+        .iter()
+        .map(|child| (*child, derive_write_name(write_scope_seed, child)))
+        .collect();
 
     publisher
         .republish(&RepublishedNode {
             node_id,
+            current_name: node.current_name.clone(),
             new_name: new_name.clone(),
+            child_names,
+            write_seed: kdf::write_seed(write_scope_seed, &node_id),
             write_epoch,
             is_root,
         })
         .await
-        .map_err(|error| WriteRotateError::Publish {
-            stage: "republish",
-            node_id,
-            error,
-        })
+        .map_err(publish_error)
 }
 
 /// The `repoint-<channel>` publish-stage label for an error.
@@ -691,7 +736,6 @@ mod tests {
     /// are asserted over.
     #[derive(Debug, Clone, PartialEq, Eq)]
     enum Event {
-        Register(String),
         Republish { node_id: [u8; 16], is_root: bool },
         Retire(Vec<String>),
         Repoint(RepointChannel),
@@ -761,18 +805,22 @@ mod tests {
     #[derive(Clone, Default)]
     struct WaveState {
         published: Rc<RefCell<HashSet<String>>>,
-        registered: Rc<RefCell<HashSet<String>>>,
         retired: Rc<RefCell<HashSet<String>>>,
         events: Rc<RefCell<Vec<Event>>>,
         republish_calls: Rc<RefCell<HashMap<String, usize>>>,
         repoint_channels: Rc<RefCell<Vec<RepointChannel>>>,
+        /// Every order the wave issued, in call order — the rewrite material the
+        /// concrete publisher acts on.
+        orders: Rc<RefCell<Vec<RepublishedNode>>>,
     }
 
     /// A fake publisher over shared [`WaveState`], optionally scripted to fail once
-    /// a given number of republish calls have landed (to crash a wave mid-flight).
+    /// a given number of republish calls have landed (to crash a wave mid-flight),
+    /// or to refuse a given re-point channel.
     struct FakePublisher {
         state: WaveState,
         fail_republish_after: Option<usize>,
+        refuse_channel: Option<RepointChannel>,
     }
 
     impl FakePublisher {
@@ -780,29 +828,26 @@ mod tests {
             Self {
                 state,
                 fail_republish_after: None,
+                refuse_channel: None,
             }
         }
         fn failing_after(state: WaveState, n: usize) -> Self {
             Self {
                 state,
                 fail_republish_after: Some(n),
+                refuse_channel: None,
+            }
+        }
+        fn refusing(state: WaveState, channel: RepointChannel) -> Self {
+            Self {
+                state,
+                fail_republish_after: None,
+                refuse_channel: Some(channel),
             }
         }
     }
 
     impl WriteWavePublisher for FakePublisher {
-        async fn register(&self, new_name: &IpnsName) -> Result<(), WritePublishError> {
-            self.state
-                .registered
-                .borrow_mut()
-                .insert(new_name.as_str().to_owned());
-            self.state
-                .events
-                .borrow_mut()
-                .push(Event::Register(new_name.as_str().to_owned()));
-            Ok(())
-        }
-
         async fn is_republished(&self, new_name: &IpnsName) -> Result<bool, WritePublishError> {
             Ok(self.state.published.borrow().contains(new_name.as_str()))
         }
@@ -818,11 +863,6 @@ mod tests {
                     }
                 }
             }
-            // Register-first invariant: a name is registered before it is published.
-            assert!(
-                self.state.registered.borrow().contains(&key),
-                "republish before register — orphaned name"
-            );
             *self
                 .state
                 .republish_calls
@@ -830,6 +870,7 @@ mod tests {
                 .entry(key.clone())
                 .or_insert(0) += 1;
             self.state.published.borrow_mut().insert(key);
+            self.state.orders.borrow_mut().push(node.clone());
             self.state.events.borrow_mut().push(Event::Republish {
                 node_id: node.node_id,
                 is_root: node.is_root,
@@ -851,6 +892,9 @@ mod tests {
             channel: RepointChannel,
             _block: &[u8],
         ) -> Result<(), WritePublishError> {
+            if self.refuse_channel == Some(channel) {
+                return Err(WritePublishError::NotLanded);
+            }
             self.state.repoint_channels.borrow_mut().push(channel);
             self.state.events.borrow_mut().push(Event::Repoint(channel));
             Ok(())
@@ -973,6 +1017,10 @@ mod tests {
             ],
             "all three channels, pointer first"
         );
+        assert_eq!(
+            outcome.repoint_accelerators,
+            vec![RepointChannel::Mailbox, RepointChannel::Tombstone]
+        );
 
         // Retire is LAST, after the re-point, and the old ROOT name is never retired.
         let retire_pos = events
@@ -992,10 +1040,7 @@ mod tests {
     }
 
     #[test]
-    fn register_first_never_orphans_a_name() {
-        // No interior name is retired before the pointer flips, and every republished
-        // node was registered first (the publisher's own assert also enforces the
-        // per-node ordering).
+    fn no_interior_name_retires_before_the_pointer_flips() {
         let owner = owner();
         let (c, sig) = commitment(&owner);
         let resolver = tree();
@@ -1025,16 +1070,162 @@ mod tests {
             first_retire.map(|r| r > first_repoint).unwrap_or(true),
             "no interior name is retired before the pointer flips (never orphan)"
         );
-        let registers = events
+        assert_eq!(
+            events
+                .iter()
+                .filter(|ev| matches!(ev, Event::Republish { .. }))
+                .count(),
+            5
+        );
+    }
+
+    #[test]
+    fn every_order_carries_the_derived_names_of_its_in_scope_children() {
+        // ADR 0004: a read-only survivor derives no write name, so the wave must
+        // hand each parent its children's freshly derived names for the read-body
+        // rewrite. Child-first ordering makes them known before the parent's turn.
+        let owner = owner();
+        let (c, sig) = commitment(&owner);
+        let resolver = tree();
+        let state = WaveState::default();
+        let publisher = FakePublisher::new(state.clone());
+        let current_root = old_name_of(&SCOPE);
+        let seed = [0x5e; 32];
+
+        block_on(async {
+            let mut e = SeededEntropy::new(11);
+            rotate_scope_write(
+                &mut e,
+                &resolver,
+                &publisher,
+                &plan(&owner, &c, &sig, &current_root, Some(&seed)),
+            )
+            .await
+        })
+        .expect("rotation succeeds");
+
+        let orders = state.orders.borrow();
+        let by_id: HashMap<[u8; 16], &RepublishedNode> =
+            orders.iter().map(|o| (o.node_id, o)).collect();
+        let expected_children: HashMap<[u8; 16], Vec<[u8; 16]>> = resolver
+            .nodes
             .iter()
-            .filter(|ev| matches!(ev, Event::Register(_)))
-            .count();
-        let republishes = events
-            .iter()
-            .filter(|ev| matches!(ev, Event::Republish { .. }))
-            .count();
-        assert_eq!(registers, 5);
-        assert_eq!(republishes, 5);
+            .map(|(id, kids)| (*id, kids.clone()))
+            .collect();
+
+        for order in orders.iter() {
+            let kids = &expected_children[&order.node_id];
+            assert_eq!(
+                order.child_names.len(),
+                kids.len(),
+                "one rewrite entry per in-scope child"
+            );
+            for kid in kids {
+                let mapped = &order.child_names[kid];
+                // The name the parent will write is exactly the name the child was
+                // republished at — the whole point of the child-first ordering.
+                assert_eq!(mapped, &by_id[kid].new_name);
+                assert_eq!(mapped, &derive_write_name(&seed, kid));
+            }
+            // The write seed is the node's own, and nothing wider: it signs at the
+            // new name and derives no other node's.
+            assert_eq!(order.write_seed, kdf::write_seed(&seed, &order.node_id));
+            assert_eq!(
+                IpnsName::from_public_key(
+                    &kdf::ipns_keypair(order.write_seed.as_bytes()).verifying_key()
+                ),
+                order.new_name,
+                "the handed seed signs at the handed name"
+            );
+            assert_eq!(order.current_name, old_name_of(&order.node_id));
+        }
+    }
+
+    #[test]
+    fn a_refused_accelerator_leaves_the_wave_complete() {
+        // The mailbox and the tombstone carry nothing load-bearing, so a wave whose
+        // canonical pointer flip landed must not be re-run for them — it reports
+        // which accelerators it reached instead.
+        let owner = owner();
+        let (c, sig) = commitment(&owner);
+        let resolver = tree();
+        let state = WaveState::default();
+        let publisher = FakePublisher::refusing(state.clone(), RepointChannel::Mailbox);
+        let current_root = old_name_of(&SCOPE);
+
+        let outcome = block_on(async {
+            let mut e = SeededEntropy::new(21);
+            rotate_scope_write(
+                &mut e,
+                &resolver,
+                &publisher,
+                &plan(&owner, &c, &sig, &current_root, None),
+            )
+            .await
+        })
+        .expect("a refused accelerator does not abort the wave");
+
+        assert_eq!(
+            outcome.repoint_accelerators,
+            vec![RepointChannel::Tombstone]
+        );
+        assert_eq!(
+            *state.repoint_channels.borrow(),
+            vec![RepointChannel::ScopePointer, RepointChannel::Tombstone]
+        );
+        assert_eq!(
+            state.retired.borrow().len(),
+            4,
+            "the wave still completes its retirement"
+        );
+    }
+
+    #[test]
+    fn a_refused_canonical_repoint_aborts_before_any_retire() {
+        // The scope pointer is the authoritative switch: without it the old names
+        // are still the live ones, so retiring them would orphan the subtree.
+        let owner = owner();
+        let (c, sig) = commitment(&owner);
+        let resolver = tree();
+        let state = WaveState::default();
+        let publisher = FakePublisher::refusing(state.clone(), RepointChannel::ScopePointer);
+        let current_root = old_name_of(&SCOPE);
+
+        let err = block_on(async {
+            let mut e = SeededEntropy::new(22);
+            rotate_scope_write(
+                &mut e,
+                &resolver,
+                &publisher,
+                &plan(&owner, &c, &sig, &current_root, None),
+            )
+            .await
+        })
+        .expect_err("the canonical channel is not optional");
+        assert_eq!(err.check(), "publish-failed");
+        assert!(
+            state.retired.borrow().is_empty(),
+            "nothing retires while the old names are still the live ones"
+        );
+    }
+
+    #[test]
+    fn a_fail_closed_publish_refusal_is_not_retryable() {
+        // Rule 6: a publisher's own trust verdict must not be laundered into an
+        // availability stall a retry loop keeps charging.
+        for (error, retryable) in [
+            (WritePublishError::NotLanded, true),
+            (WritePublishError::LostRace, true),
+            (WritePublishError::RegistryFull, true),
+            (WritePublishError::Rejected, false),
+        ] {
+            let err = WriteRotateError::Publish {
+                stage: "republish",
+                node_id: SCOPE,
+                error,
+            };
+            assert_eq!(err.is_retryable(), retryable);
+        }
     }
 
     #[test]
@@ -1110,6 +1301,20 @@ mod tests {
             calls.values().all(|&n| n == 1),
             "no node republished twice — resume is idempotent off published records"
         );
+        // Across both runs every node was ordered with its children's post-wave
+        // names, so a resume leaves no stale child name behind.
+        let orders = state.orders.borrow();
+        let published: HashMap<[u8; 16], IpnsName> = orders
+            .iter()
+            .map(|o| (o.node_id, o.new_name.clone()))
+            .collect();
+        for order in orders.iter() {
+            for (child, name) in &order.child_names {
+                assert_eq!(name, &published[child]);
+            }
+        }
+        drop(orders);
+
         // The wave completed: pointer flipped on all three channels, interior retired.
         assert_eq!(state.repoint_channels.borrow().len(), 3);
         assert_eq!(state.retired.borrow().len(), 4);


### PR DESCRIPTION
Lands the production `WriteWavePublisher` — `net::rotation::WriteWaveNet` — over `RecordTransport` + `ApiClient`, and reshapes the wave's order type for what ADR 0004 settled.

Part of #1026.

## What this does

**ADR 0004 D1 — the publisher re-resolves.** `RepublishedNode` gains `current_name` (mirroring the landed `ScopeRootPublisher` precedent, which already says in code that the read body and preserved envelope fields come from the node's own gated record), plus:

- `child_names: BTreeMap<[u8; 16], IpnsName>` — the in-scope child rewrite map. Public data the orchestrator already derives; child-first ordering makes every entry known before the parent publishes.
- `signer: Ed25519Signer` — the narrow per-name capability that signs at `new_name`, the same shape `net/liveness.rs` holds for the same reason. Never the seed it derives from, so the publisher can derive no other node's name.
- `write_scope_seed: Option<SecretBytes>` — the wave's fresh write scope seed, carried for the **root alone**, because the root's grant section is the only channel that distributes it.

**ADR 0004 D2 — the read body is not carried verbatim.** Every republish rewrites its in-scope `ChildRef.ipnsName`s and re-seals the body under the **unchanged** read key at the **unchanged** read epoch. A mapped child the body does not carry is a fail-closed `Rejected`. Core's own `assert_children_unique` still runs on the re-seal, so a rewrite that collided two names cannot be signed.

**The moved root is re-keyed, not carried.** The root routes through the existing `reseal_scope_root` mechanism — same override seed and read epoch, `prev: None` so no history link is minted, fresh write scope seed, advanced write epoch, new name, commitment re-signed over that name. See the review section below for why carrying it verbatim was a ship-blocker.

**Register-first is now structural.** `WriteWavePublisher::register` is gone. The record publish pipeline registers the name it is about to PUT and blocks on it (#28 D5), so the trait no longer offers any way to reach the transport with an unregistered name.

**Canonical vs accelerator re-point.** `RepointChannel`'s own doc already said the mailbox and tombstone "are verifiable accelerators — nothing on them is load-bearing for safety", but the wave aborted on any of the three. Now the scope-pointer flip is fatal, and the accelerators are attempted and reported in `WriteRotationOutcome::repoint_accelerators` — except a `Rejected`, which is the publisher refusing to sign and still aborts (rule 6).

**The scope-pointer flip rides the real publish pipeline.** `net/publish.rs` gains `publish_inline` for a record whose `Value` is the payload rather than an `/ipfs/` head; `publish` and it share one core, so the register-first / sequence / size-cap / confirm laws are stated once.

## Review gates

`/simplify` (4 angles), `/security-review` and `/crypto-privacy-review` all ran on `git diff main...HEAD`. The security and crypto passes independently reached the same HIGH, and both are fixed in the second commit.

**HIGH — the wave published its fresh `writeScopeSeed` nowhere.** The root's section rode verbatim except for the commitment, so `owner_write_blob`, `write_body` and every write grantee's blob still carried the **old** seed at the **old** write epoch — while the re-point raised the write-epoch floor past them. After one rotation the scope was permanently write-dead: `recover_write_scope_seed` fails its AAD and returns keyless, surviving grantees derive only retired names, and the owner's own write-plane recovery — hence its revocation primitive — fails closed. Silent (`Ok(WriteRotationOutcome)`) and irreversible (interior names already retired, floors monotonic). Fixed by the `reseal_scope_root` route above; asserted by reopening the published owner-write blob at the new epoch and checking the seed is the one every new name derives from.

**Blocking, found by `/security-review`** — the root gate advances the durable sequence floor and `RootAdopter` has no at-floor re-open, so a pass that gated the root and then failed to publish could never retry: `republish` returned a non-retryable `Rejected` forever. Reproduced, then fixed by holding the gated read across a failed publish (`GatedWaveRoot`) — the same parking this file already does for the identical reason. Pinned by `a_failed_root_publish_leaves_the_root_republishable`.

Also folded in: `publish_scope_pointer` restated the publish pipeline and silently dropped the background re-PUT and the fail-closed floor-read law (now `publish_inline`, and it raises the pointer's sequence floor on a confirmed flip, which nothing else does); release-active guards binding the signer to the name it publishes at, the root's record id to the scope, and the write epoch to a strict advance; deterministic publish/preflight refusals reclassified off the retryable path; the at-floor tolerance narrowed to the exact `SequenceNotNewer { floor, sequence } if sequence == floor` predicate `net/resolve.rs` uses; `GrantSection` no longer deep-cloned; several doc trims.

## Ancestry-seed hazard: does not apply here

The cross-PR HIGH aimed at the wiring PRs — thread the **pre-cut** ancestor seed, because a cascade retry after the root's cut gates descendants under a fresh post-cut seed and strands them — does not apply to this diff. Verified against the code, not assumed:

- This diff never calls `RotationAncestry::rooted_at`; the only ancestry it threads is `WriteWaveNet::parent_node_seed`, the **rotating root's own** ancestor node seed, passed straight to `RootAdopter::under_parent_node_seed`.
- A write rotation mints no read override seed — `rotate_scope_write` mints only a write scope seed, and the re-seal reuses the gated root's existing `override_seed` at the unchanged read epoch. There is therefore no pre-cut/post-cut divergence for the ancestor seed to be on the wrong side of.
- Ascent links live only on scope roots (`GrantSection.ascent_link`); interior nodes carry no grant section at all, so the wave gates no descendant scope root.

Nothing in this diff leans on the old `GatedRoots` "a second read is impossible" claim either — `WriteWaveNet` does not use `GatedRoots`; its own `GatedWaveRoot` exists for the root-retry case above and is documented on its own terms.

## Errors in the issue body

- **`OwnerRotationNet::publish_scope_root` is not an inherent method.** It is the `ScopeRootPublisher` trait impl at `net/rotation.rs:561`. The precedent it cites is real; the name is not.
- **"add `current_name` … and let the concrete publisher do the gated read" is necessary but not sufficient.** The publisher also needs the signing capability at the new name, the children's new names, and — for the root — the wave's scope seed, none of which it can derive on its own.
- **`RepublishedNode`'s doc claimed a "read-body carried verbatim" republish** — the claim ADR 0004 overturns. Fixed, along with the module header's "The read plane is untouched", true of keys, seeds and `minReadEpoch` but not of read-body bytes.
- **Scope item 2's `publish_repoint` "across the three channels" is not deliverable.** See below.
- Scope item 4 said `retire` must never include the old root name; that was already true in the orchestrator, and `WriteWaveNet::retire` now mirrors it release-active.

## Deliberately not done

- **The mailbox and tombstone re-point channels.** Neither has a wire shape: there is no tombstone record type, author, decoder or reader anywhere in `crates/engine` (`movedTo` appears only in doc comments), and `mailbox::post_sealed` seals internally, so feeding it an already-`seal_repoint`ed block would double-seal into a format nothing opens. This build does not sign bytes it cannot decode, so both return `NotLanded` rather than inventing a format. Both are accelerators; the wave completes without them.
- **Content-CID re-registration under the new name.** `publish_record` is called with `content_cids: Vec::new()`, matching the landed `publish_scope_root`. Moving a name's held content pins is `net/liveness.rs` + `net/resolve.rs` held-record bookkeeping.
- **The scope pointer name never joins the liveness set,** so it is not covered by `keyless_re_put`/`eol_renew_pass` and lapses at its 90-day EOL. Fixing it means `HeldRecord.head_cid` becomes an inline-or-head value — `net/liveness.rs`, out of this PR's scope.
- **A bidirectional child-rewrite coverage check.** `rewrite_child_names` refuses a mapped child the body does not carry, but cannot refuse a body child the enumeration missed: a `ChildRef` carries no scope-root marker, so "in-scope child" and "descendant scope root" are indistinguishable from the body alone. The obligation is documented on `WriteSubtreeResolver::resolve_node`, whose production implementation is a separate issue. Note the wave never retires a name it did not enumerate, so a missed child is left in place rather than orphaned.
- **Binding `WriteWaveNet`'s `scope_id` / `owner_pointer_seed` / `current_root_name` to the plan's.** They are independent today and nothing checks they agree; there is no point where both are visible to check. Worth a construction-site helper when the wave is wired.

## Files touched outside the stated ownership set

`net/publish.rs` (adds `publish_inline` + the shared core; no existing call site changed) and `net/mod.rs` (re-exports). Both were needed to stop restating the publish pipeline, and neither is owned by a sibling in this wave.

## Tests

`rotation/rotate_write.rs` — the child-name map matches each child's own `new_name` and `derive_write_name`; the handed signer is the new name's key and only the root carries the scope seed; a refused accelerator leaves the wave complete while a `Rejected` one aborts; a refused canonical flip aborts before any retire; a `Rejected` publish is not retryable; a resumed wave leaves no stale child name.

`net/rotation.rs` — over the real gate and transport: a republished folder names its children at their new names; a read-only holder (scope read seed, no write seed) descends root → mid → leaf by rewritten refs alone; a moved root re-signs its commitment, republishes the **fresh** write scope seed in an owner-write blob that reopens at the new write epoch, and leaves the read override seed untouched; a failed root publish leaves the root republishable; an unmatched child name is refused; the read-epoch floor never moves; retire refuses the lingering root; the canonical re-point lands at the scope pointer with the sealed block as the record value, sequences 1 then 2; the accelerators report that they did not land.

Gates green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets` (silent), `cargo test -p cipherbox-engine -p cipherbox-core` (20 suites, 703 engine unit tests), the same suite under `--release` so the release-active guards are exercised, `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown`, `pnpm lint:tracker-refs`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `WriteWaveNet` as the production write-wave publisher over real network seams
> - Adds `WriteWaveNet` in [rotation.rs](https://github.com/FSM1/cipher-box/pull/1101/files#diff-d37e98e69d8d281a4e324a10d5954a5e73147013e3aa1330558044fce6b7773d), implementing the `WriteWavePublisher` trait with full support for republishing nodes, publishing scope pointer repoints, and retiring old names.
> - Introduces `publish_inline` and `InlineRecordRequest` in [publish.rs](https://github.com/FSM1/cipher-box/pull/1101/files#diff-c60df0f90c63f5091f6c4c5fd08c5a3b45f658f7a49ee5986917ab8f63b026f3), sharing the existing register-first pipeline for inline-value IPNS records.
> - Redesigns `RepublishedNode` in [rotate_write.rs](https://github.com/FSM1/cipher-box/pull/1101/files#diff-9589c2d06962de0b3797081b6b997eac51d602aabf618afc8a1e5e1ea64b035c) to carry the prior name, per-node signer, child-id-to-new-name map, and root-only write scope seed; removes the separate `register()` step from the orchestrator.
> - Canonical scope pointer flip must succeed before accelerator channels (Mailbox, Tombstone) are attempted; accelerator failures are tolerated unless the error is `Rejected`, and which accelerators landed is reported in `WriteRotationOutcome`.
> - Risk: `WritePublishError::Rejected` is now non-retryable, so a fail-closed refusal from the publisher permanently aborts the rotation rather than being retried.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73dc6dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for publishing inline record values with configurable names and sequencing.
  - Introduced write-plane rotation across record trees, including child-name updates, secure signing, scope repointing, and retirement.
  - Added recovery and retry handling for concurrent updates and interrupted rotations.

- **Bug Fixes**
  - Invalid versions, mismatched names, missing records, stale updates, and rejected publications now fail safely.
  - Canonical pointer failures remain blocking, while optional accelerator failures are handled gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->