### PR TITLE
feat: consume the scope-exit rotation triggers

### DIFF
--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -59,7 +59,7 @@ use crate::sync::boot::{ColdStartError, ColdStartOutcome, ColdStartParams, cold_
 use crate::sync::cancel::UploadCancels;
 use crate::sync::drain::{Drain, DrainReport, DrainScope, published_op_mark};
 use crate::sync::model::{NodeMeta, Snapshot, collation_key};
-use crate::sync::op::{NewNode, Op, OpKind, Replaced, StagedContent};
+use crate::sync::op::{NewNode, Op, OpKind, Replaced, ScopeCrossing, StagedContent};
 use crate::sync::overlay::apply_overlay;
 use crate::sync::pointer::PointerFetch;
 use crate::sync::project::project_child_version;
@@ -2218,15 +2218,15 @@ impl<T: SeamTypes> Engine<T> {
             Command::Relink { node, new_parent } => {
                 let rendered = self.render().await?;
                 let (from_parent, base_sequence) = self.relocation_anchors(&rendered, node);
-                // trailing bools: cross_scope=false, exits_granted_source=false — intra-scope pure relink
+                // This session holds one scope, so every relocation it can form
+                // stays inside it.
                 let op = Op::relink(
                     node,
                     from_parent,
                     new_parent,
                     base_sequence,
                     authored_at,
-                    false,
-                    false,
+                    ScopeCrossing::Intra,
                 );
                 self.stage_and_notify(&op).await
             }
@@ -2253,6 +2253,7 @@ impl<T: SeamTypes> Engine<T> {
                     replacing,
                     base_sequence,
                     authored_at,
+                    ScopeCrossing::Intra,
                 );
                 self.stage_and_notify(&op).await
             }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -81,8 +81,9 @@ pub use profile::SyncTimingProfile;
 pub use rotation::{
     ChildIndexResolver, CommittedSet, EagerSet, EnumerationError, PrevEpochSeed, ResealError,
     ResealSeeds, ResealedScopeRoot, ResolveFailure, RevokeError, RevokedCommittedSet, RotateError,
-    RotateScopePlan, RotationOutcome, RotationTrigger, ScopeRootIdentity, ScopeRootPublishError,
-    ScopeRootPublisher, enumerate_eager_set, reseal_scope_root, revoke_read_grant, rotate_scope,
+    RotateScopePlan, RotationOutcome, RotationTrigger, ScopeExitReport, ScopeExitRotator,
+    ScopeRootIdentity, ScopeRootPublishError, ScopeRootPublisher, consume_scope_exit_triggers,
+    enumerate_eager_set, reseal_scope_root, revoke_read_grant, rotate_scope,
 };
 pub use seams::{SeamError, SeamResult, SeamSet, SeamTypes};
 pub use settings::{
@@ -95,7 +96,7 @@ pub use sync::{
     AppliedOp, BlockedOp, Connectivity, DeadLetterReason, DropReason, FocusTarget, FocusWindow,
     HeadReconciliation, Link, NewNode, NodeMeta, Op, OpKind, OpRecordError, OpResolution,
     PointerError, PointerFetch, RecordClass, RecordReader, RecordSeal, Repair, Replaced,
-    ReplayReport, SessionRole, Snapshot, StagedContent, TickCause, TickControl,
+    ReplayReport, ScopeCrossing, SessionRole, Snapshot, StagedContent, TickCause, TickControl,
     VaultPointerAdoption, apply_overlay, apply_repairs, classify, decode_queue, encode_op_record,
     focus_set, observed_repair, rebase_one, reconcile_head, record_content_root_cid, replay,
     resolve_vault_pointer, stage_op,

--- a/crates/engine/src/rotation/mod.rs
+++ b/crates/engine/src/rotation/mod.rs
@@ -10,7 +10,9 @@
 //!   the [`cascade`] (each eager-set descendant, fresh seed), and by the sweep.
 //! - [`rotate`] — `rotateScope`, the read-plane root cut: mint a fresh override
 //!   seed, re-seal, publish CAS, raise `minReadEpoch`, enqueue the sweep.
-//! - [`trigger`] — the read-revoke / scope-exit / manual trigger surface.
+//! - [`trigger`] — the read-revoke / scope-exit / manual trigger surface, and
+//!   the driver that turns a replay's queued scope-exit triggers into one flat
+//!   `rotateScope` per source scope root.
 //! - [`sweep`] — the lazy-wave epoch-lag convergence pass (metadata-only,
 //!   existing seed, `prev = None`) plus its idle-cadence driver and the
 //!   direct-child-scope index self-heal. It does **not** mint fresh descendant
@@ -28,8 +30,9 @@
 //!
 //! [`ChildIndexResolver`], [`CascadeResealResolver`], [`ScopeRootPublisher`] and
 //! [`WriteWavePublisher`] have production implementations over the real transport
-//! in [`crate::net::rotation`]. [`SweepResolver`] and [`WriteSubtreeResolver`]
-//! have no production implementation yet; tests fake them.
+//! in [`crate::net::rotation`]. [`SweepResolver`], [`ScopeExitRotator`] and
+//! [`WriteSubtreeResolver`] have no production implementation yet; tests fake
+//! them.
 
 pub mod cascade;
 pub mod eager_set;
@@ -59,4 +62,7 @@ pub use rotate_write::{
     build_repoint_object, derive_write_name, rotate_scope_write,
 };
 pub use sweep::{SweepError, SweepOutcome, SweepResolver, SweepTarget, run_sweep, sweep_pass};
-pub use trigger::{RevokeError, RevokedCommittedSet, RotationTrigger, revoke_read_grant};
+pub use trigger::{
+    RevokeError, RevokedCommittedSet, RotationTrigger, ScopeExitReport, ScopeExitRotator,
+    consume_scope_exit_triggers, revoke_read_grant,
+};

--- a/crates/engine/src/rotation/trigger.rs
+++ b/crates/engine/src/rotation/trigger.rs
@@ -30,6 +30,9 @@ use cipherbox_core::seal::{
 };
 use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaSigner, SIGNATURE_LEN as ECDSA_SIG_LEN};
 
+use super::rotate::{RotateError, RotationOutcome};
+use crate::facade::NodeId;
+
 /// Which trigger fired a rotation — a host-facing classifier carrying no key
 /// material. Scope-exit and manual rotations re-seal the unchanged committed set;
 /// read-revoke first applies [`revoke_read_grant`].
@@ -53,6 +56,64 @@ impl RotationTrigger {
             RotationTrigger::Manual => "manual",
         }
     }
+}
+
+/// The scope-exit rotation edge: cut one scope root that a grantee just left.
+///
+/// The pure driver ([`consume_scope_exit_triggers`]) owns the ordering and the
+/// retention law; this seam owns assembling the root's
+/// [`RotateScopePlan`](super::rotate::RotateScopePlan) from its resolved record
+/// and running [`rotate_scope`](super::rotate::rotate_scope) over the live
+/// plane. The grantee-arm implementation over the real transport is not landed.
+pub trait ScopeExitRotator {
+    /// Run the flat, grantee-triggered [`RotationTrigger::ScopeExit`] cut at
+    /// `scope_root`. `Err` means nothing was cut.
+    async fn rotate_on_scope_exit(
+        &self,
+        scope_root: NodeId,
+    ) -> Result<RotationOutcome, RotateError>;
+}
+
+/// What one pass of [`consume_scope_exit_triggers`] cut, and what it did not.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopeExitReport {
+    /// The scope roots this pass durably cut, in the order it cut them.
+    pub rotated: Vec<(NodeId, RotationOutcome)>,
+    /// The scope roots whose rotation failed, with why. Each is still a live
+    /// trigger: the caller re-drives it rather than treating the pass as done.
+    pub failed: Vec<(NodeId, RotateError)>,
+}
+
+impl ScopeExitReport {
+    /// Whether every queued trigger was cut — the only state in which the
+    /// caller may consider the scope exits settled.
+    pub fn is_complete(&self) -> bool {
+        self.failed.is_empty()
+    }
+}
+
+/// Drive one [`RotationTrigger::ScopeExit`] rotation per queued scope root.
+///
+/// `roots` is [`ReplayReport::scope_exit_triggers`](crate::sync::ReplayReport),
+/// already deduped to one entry per source scope root. A failure neither
+/// short-circuits the pass nor is swallowed: the remaining roots still rotate
+/// and the failed one comes back in [`ScopeExitReport::failed`], because a
+/// scope exit that never rotates leaves a revokee holding a live seed.
+pub async fn consume_scope_exit_triggers<R: ScopeExitRotator>(
+    rotator: &R,
+    roots: &[NodeId],
+) -> ScopeExitReport {
+    let mut report = ScopeExitReport {
+        rotated: Vec::new(),
+        failed: Vec::new(),
+    };
+    for root in roots {
+        match rotator.rotate_on_scope_exit(*root).await {
+            Ok(outcome) => report.rotated.push((*root, outcome)),
+            Err(e) => report.failed.push((*root, e)),
+        }
+    }
+    report
 }
 
 /// The owner-only committed-set cut produced by [`revoke_read_grant`]: the new
@@ -161,9 +222,89 @@ pub fn revoke_read_grant(
 
 #[cfg(test)]
 mod tests {
+    use core::cell::RefCell;
+
     use super::*;
+    use crate::testkit::block_on;
     use cipherbox_core::seal::{GrantSetEntry, Permission, PreservedFields, verify_grant_set};
     use cipherbox_core::suite::ecdsa::EcdsaSignature;
+
+    /// Records the roots it was asked to cut, failing the ones named in
+    /// `refuse` — the driver's only view of the rotation edge.
+    struct FakeRotator {
+        seen: RefCell<Vec<NodeId>>,
+        refuse: Vec<NodeId>,
+    }
+
+    impl FakeRotator {
+        fn refusing(refuse: &[NodeId]) -> Self {
+            Self {
+                seen: RefCell::new(Vec::new()),
+                refuse: refuse.to_vec(),
+            }
+        }
+    }
+
+    impl ScopeExitRotator for FakeRotator {
+        async fn rotate_on_scope_exit(
+            &self,
+            scope_root: NodeId,
+        ) -> Result<RotationOutcome, RotateError> {
+            self.seen.borrow_mut().push(scope_root);
+            if self.refuse.contains(&scope_root) {
+                return Err(RotateError::Publish(
+                    super::super::rotate::ScopeRootPublishError::NotPublished,
+                ));
+            }
+            Ok(RotationOutcome {
+                new_read_epoch: 2,
+                epoch_floor: 2,
+            })
+        }
+    }
+
+    fn node(b: u8) -> NodeId {
+        NodeId([b; 16])
+    }
+
+    #[test]
+    fn each_queued_root_is_cut_once_in_order() {
+        let rotator = FakeRotator::refusing(&[]);
+        let roots = [node(1), node(2)];
+        let report = block_on(consume_scope_exit_triggers(&rotator, &roots));
+
+        assert_eq!(*rotator.seen.borrow(), roots);
+        assert_eq!(
+            report.rotated.iter().map(|(r, _)| *r).collect::<Vec<_>>(),
+            roots
+        );
+        assert!(report.is_complete());
+    }
+
+    #[test]
+    fn a_failed_rotation_surfaces_and_the_rest_still_cut() {
+        // A swallowed failure is a revokee left holding a live seed, and a
+        // short-circuit would strand every later root behind it.
+        let rotator = FakeRotator::refusing(&[node(2)]);
+        let report = block_on(consume_scope_exit_triggers(
+            &rotator,
+            &[node(1), node(2), node(3)],
+        ));
+
+        assert_eq!(*rotator.seen.borrow(), [node(1), node(2), node(3)]);
+        assert_eq!(
+            report.rotated.iter().map(|(r, _)| *r).collect::<Vec<_>>(),
+            [node(1), node(3)]
+        );
+        assert_eq!(
+            report.failed.iter().map(|(r, _)| *r).collect::<Vec<_>>(),
+            [node(2)]
+        );
+        assert!(
+            !report.is_complete(),
+            "an unsettled trigger keeps the pass incomplete"
+        );
+    }
 
     fn owner() -> EcdsaSigner {
         EcdsaSigner::from_scalar(&[0x33; 32]).unwrap()

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -16,7 +16,9 @@
 //! What the pass does when a publish will not succeed is the failure valve
 //! ([`Halt`]).
 //!
-//! Out of this slice: cross-scope re-seal with the scope-exit rotation trigger.
+//! A cross-scope relocation halts rather than publishing: its destination-epoch
+//! re-seal is not a plan this driver authors. Its scope-exit trigger still
+//! reaches [`DrainReport::scope_exit_triggers`].
 
 use core::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
@@ -61,7 +63,7 @@ use crate::session::SessionIdentity;
 use crate::settings::{Destinations, Placement, PlacementDecision};
 use crate::sync::cancel::UploadCancels;
 use crate::sync::model::{Snapshot, collation_key};
-use crate::sync::op::{NewNode, Op, OpKind, StagedContent};
+use crate::sync::op::{NewNode, Op, OpKind, ScopeCrossing, StagedContent};
 use crate::sync::overlay::apply_overlay;
 use crate::sync::project::project_folder;
 use crate::sync::rebase::{AppliedOp, DeadLetterReason, decode_queue, replay};
@@ -118,6 +120,13 @@ pub(crate) struct DrainReport {
     /// Ops removed as restore residue: already drained on this device, so the
     /// queue that holds them is older than the completion record.
     pub(crate) restore_residue: Vec<OpId>,
+    /// The granted source scope roots this pass's replay exited, deduped — the
+    /// input to
+    /// [`consume_scope_exit_triggers`](crate::rotation::consume_scope_exit_triggers).
+    /// A cross-scope relocation never publishes, so its op is still queued when
+    /// the pass ends and the next pass re-derives the trigger: the durable
+    /// queue is what makes the intent durable.
+    pub(crate) scope_exit_triggers: Vec<NodeId>,
 }
 
 impl DrainReport {
@@ -580,8 +589,13 @@ where
             let base = self.base.borrow();
             let ops: Vec<Op> = queued.iter().map(|(_, op)| op.clone()).collect();
             let local = apply_overlay(&base, &ops);
-            replay(&base, &local, queued)
+            // This session holds one scope, so its root is the only scope root
+            // a full-depth exit walk can land on.
+            replay(&base, &local, queued, &[scope.root])
         };
+        report
+            .scope_exit_triggers
+            .clone_from(&rebased.scope_exit_triggers);
 
         for (op_id, reason) in &rebased.dead_letters {
             let Some((_, op)) = queued.iter().find(|(id, _)| id == op_id) else {
@@ -1026,8 +1040,7 @@ where
             OpKind::Relink {
                 from_parent,
                 new_parent,
-                cross_scope: false,
-                ..
+                crossing: ScopeCrossing::Intra,
             } => {
                 let plan = MovePlan {
                     from_parent: *from_parent,
@@ -1042,6 +1055,7 @@ where
                 from_parent,
                 new_parent,
                 replacing,
+                crossing: ScopeCrossing::Intra,
                 ..
             } => {
                 let plan = MovePlan {
@@ -1062,7 +1076,11 @@ where
                 self.publish_update_content(scope, pass, applied, content)
                     .await
             }
-            OpKind::Relink { .. } => Err(Halt::Unclassified),
+            // A cross-scope relocation re-seals the moved subtree at the
+            // destination epoch — a plan this driver does not author. Publishing
+            // it as a plain ref move would carry the subtree into the
+            // destination still sealed at the source epoch.
+            OpKind::Relink { .. } | OpKind::Move { .. } => Err(Halt::Unclassified),
         }
     }
 

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -17,8 +17,9 @@
 //! ([`Halt`]).
 //!
 //! A cross-scope relocation halts rather than publishing: its destination-epoch
-//! re-seal is not a plan this driver authors. Its scope-exit trigger still
-//! reaches [`DrainReport::scope_exit_triggers`].
+//! re-seal is not a plan this driver authors. Its scope-exit trigger reaches
+//! [`ReplayReport::scope_exit_triggers`](crate::sync::ReplayReport) all the
+//! same, off the same [`replay`] this pass runs.
 
 use core::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
@@ -120,13 +121,6 @@ pub(crate) struct DrainReport {
     /// Ops removed as restore residue: already drained on this device, so the
     /// queue that holds them is older than the completion record.
     pub(crate) restore_residue: Vec<OpId>,
-    /// The granted source scope roots this pass's replay exited, deduped — the
-    /// input to
-    /// [`consume_scope_exit_triggers`](crate::rotation::consume_scope_exit_triggers).
-    /// A cross-scope relocation never publishes, so its op is still queued when
-    /// the pass ends and the next pass re-derives the trigger: the durable
-    /// queue is what makes the intent durable.
-    pub(crate) scope_exit_triggers: Vec<NodeId>,
 }
 
 impl DrainReport {
@@ -593,9 +587,6 @@ where
             // a full-depth exit walk can land on.
             replay(&base, &local, queued, &[scope.root])
         };
-        report
-            .scope_exit_triggers
-            .clone_from(&rebased.scope_exit_triggers);
 
         for (op_id, reason) in &rebased.dead_letters {
             let Some((_, op)) = queued.iter().find(|(id, _)| id == op_id) else {

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -11,10 +11,11 @@
 //! the five per-op race rules — and a terminally unrebasable op dead-letters
 //! with its staged bytes preserved rather than being silently dropped.
 //!
-//! Out of this slice, by design: scope-exit rotation
-//! *triggering* — a cross-scope relink out of a granted scope **queues** the
-//! trigger event ([`rebase::ReplayReport::scope_exit_triggers`]); the rotation
-//! primitives themselves land with the rotation slice.
+//! A cross-scope relocation out of a granted scope resolves its source scope
+//! root full-depth and queues one trigger per root
+//! ([`rebase::ReplayReport::scope_exit_triggers`]);
+//! [`consume_scope_exit_triggers`](crate::rotation::consume_scope_exit_triggers)
+//! cuts them.
 
 pub mod boot;
 pub(crate) mod cancel;
@@ -36,7 +37,7 @@ pub use drain::{
     op_mark_key,
 };
 pub use model::{Link, NodeMeta, Snapshot, collation_key, suffix_name};
-pub use op::{NewNode, Op, OpDecodeError, OpKind, Replaced, StagedContent};
+pub use op::{NewNode, Op, OpDecodeError, OpKind, Replaced, ScopeCrossing, StagedContent};
 pub use overlay::apply_overlay;
 pub use pointer::{
     ConsultReason, PointerError, PointerFetch, SessionRole, VaultPointerAdoption, open_repoint,

--- a/crates/engine/src/sync/op.rs
+++ b/crates/engine/src/sync/op.rs
@@ -118,13 +118,6 @@ pub enum ScopeCrossing {
     ExitsGrantedSource,
 }
 
-impl ScopeCrossing {
-    /// Whether the moved subtree must re-seal at the destination scope's epoch.
-    pub fn is_cross_scope(self) -> bool {
-        !matches!(self, ScopeCrossing::Intra)
-    }
-}
-
 /// The six intent-op mutations (#33 D6).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OpKind {

--- a/crates/engine/src/sync/op.rs
+++ b/crates/engine/src/sync/op.rs
@@ -100,6 +100,31 @@ impl NewNode {
     }
 }
 
+/// Where a relocation lands relative to the source scope — the one field both
+/// relocation ops carry (blueprint/engine.md "Sync core: Ops", #26 D1/D7).
+///
+/// One value rather than a `cross_scope`/`exits_granted_source` pair: an exit
+/// from a granted source is cross-scope by definition, so the pair could encode
+/// an incoherent op the decoder would have to reject. Here it is unrepresentable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ScopeCrossing {
+    /// Stays inside one scope: a pure relink, no re-seal, no trigger.
+    Intra,
+    /// Leaves a scope that grants nobody: the moved subtree re-seals at the
+    /// destination epoch, and nothing rotates.
+    Cross,
+    /// Leaves a **granted** source scope: the destination re-seal plus a
+    /// scope-exit rotation trigger for the source scope root.
+    ExitsGrantedSource,
+}
+
+impl ScopeCrossing {
+    /// Whether the moved subtree must re-seal at the destination scope's epoch.
+    pub fn is_cross_scope(self) -> bool {
+        !matches!(self, ScopeCrossing::Intra)
+    }
+}
+
 /// The six intent-op mutations (#33 D6).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OpKind {
@@ -124,10 +149,7 @@ pub enum OpKind {
         /// The new name as entered.
         new_name: String,
     },
-    /// Move a node to a new parent. Intra-scope this is a pure relink;
-    /// cross-scope it re-seals the subtree at the destination epoch and, when
-    /// it leaves a granted source scope, **queues a scope-exit rotation
-    /// trigger** — this slice queues the trigger only, it does not rotate.
+    /// Move a node to a new parent.
     Relink {
         /// The source parent the move was formed against — the presence
         /// condition for the source-remove and the move-race detector
@@ -135,11 +157,8 @@ pub enum OpKind {
         from_parent: NodeId,
         /// The destination parent.
         new_parent: NodeId,
-        /// Whether the move crosses a scope boundary.
-        cross_scope: bool,
-        /// Whether the move leaves a granted source scope (a scope-exit
-        /// rotation trigger for the source).
-        exits_granted_source: bool,
+        /// Where the destination sits relative to the source scope.
+        crossing: ScopeCrossing,
     },
     /// Relink **and** rename a node in one entry, optionally replacing the node
     /// already at the destination name. One kernel rename is one of these, so
@@ -155,6 +174,10 @@ pub enum OpKind {
         new_name: String,
         /// The destination node this move vacates, if any.
         replacing: Option<Replaced>,
+        /// Where the destination sits relative to the source scope. A kernel
+        /// rename is the desktop's whole move surface, so a scope exit reaches
+        /// the engine through this op as readily as through [`Self::Relink`].
+        crossing: ScopeCrossing,
     },
     /// Write a new file version (fresh per-version content key).
     UpdateContent {
@@ -224,8 +247,7 @@ impl Op {
         new_parent: NodeId,
         base_sequence: u64,
         authored_at: UnixMillis,
-        cross_scope: bool,
-        exits_granted_source: bool,
+        crossing: ScopeCrossing,
     ) -> Self {
         Self {
             target,
@@ -234,13 +256,13 @@ impl Op {
             kind: OpKind::Relink {
                 from_parent,
                 new_parent,
-                cross_scope,
-                exits_granted_source,
+                crossing,
             },
         }
     }
 
     /// A combined `move` op.
+    #[allow(clippy::too_many_arguments)]
     pub fn move_node(
         target: NodeId,
         from_parent: NodeId,
@@ -249,6 +271,7 @@ impl Op {
         replacing: Option<Replaced>,
         base_sequence: u64,
         authored_at: UnixMillis,
+        crossing: ScopeCrossing,
     ) -> Self {
         Self {
             target,
@@ -259,6 +282,7 @@ impl Op {
                 new_parent,
                 new_name: new_name.into(),
                 replacing,
+                crossing,
             },
         }
     }
@@ -290,6 +314,26 @@ impl Op {
             | OpKind::UpdateContent { content } => Some(content),
             _ => None,
         }
+    }
+
+    /// The parent this op moved its target out of when the move left a granted
+    /// source scope — the node the full-depth scope-root walk starts from
+    /// ([`crate::sync::rebase`]). `None` for every other op.
+    pub fn scope_exit_source(&self) -> Option<NodeId> {
+        let (from_parent, crossing) = match &self.kind {
+            OpKind::Relink {
+                from_parent,
+                crossing,
+                ..
+            }
+            | OpKind::Move {
+                from_parent,
+                crossing,
+                ..
+            } => (from_parent, crossing),
+            _ => return None,
+        };
+        matches!(crossing, ScopeCrossing::ExitsGrantedSource).then_some(*from_parent)
     }
 
     /// The pending class this op puts its target in — a staged content write
@@ -387,7 +431,14 @@ mod tests {
             ),
             Op::delete(id(2), 4, at(1_001), 7),
             Op::rename(id(3), "b.txt", 5, at(1_002)),
-            Op::relink(id(4), id(0), id(9), 6, at(1_003), true, true),
+            Op::relink(
+                id(4),
+                id(0),
+                id(9),
+                6,
+                at(1_003),
+                ScopeCrossing::ExitsGrantedSource,
+            ),
             Op::update_content(id(5), staged(b"stage2", 12), 8, at(1_004)),
             Op::move_node(
                 id(6),
@@ -400,8 +451,18 @@ mod tests {
                 }),
                 9,
                 at(1_005),
+                ScopeCrossing::Intra,
             ),
-            Op::move_node(id(6), id(0), id(9), "c.txt", None, 9, at(1_005)),
+            Op::move_node(
+                id(6),
+                id(0),
+                id(9),
+                "c.txt",
+                None,
+                9,
+                at(1_005),
+                ScopeCrossing::Intra,
+            ),
         ];
         for op in ops {
             assert_eq!(Op::decode_body(&op.encode_body()).unwrap(), op);
@@ -464,8 +525,18 @@ mod tests {
             Op::create(id(1), id(0), "d", NewNode::Folder, 1, at(1)).pending_class(),
             Op::delete(id(2), 1, at(1), 1).pending_class(),
             Op::rename(id(3), "b", 1, at(1)).pending_class(),
-            Op::relink(id(4), id(0), id(9), 1, at(1), false, false).pending_class(),
-            Op::move_node(id(4), id(0), id(9), "b", None, 1, at(1)).pending_class(),
+            Op::relink(id(4), id(0), id(9), 1, at(1), ScopeCrossing::Intra).pending_class(),
+            Op::move_node(
+                id(4),
+                id(0),
+                id(9),
+                "b",
+                None,
+                1,
+                at(1),
+                ScopeCrossing::Intra,
+            )
+            .pending_class(),
             Op::update_content(id(5), staged(b"k", 1), 1, at(1)).pending_class(),
         ];
         assert_eq!(

--- a/crates/engine/src/sync/op.rs
+++ b/crates/engine/src/sync/op.rs
@@ -432,6 +432,7 @@ mod tests {
                 at(1_003),
                 ScopeCrossing::ExitsGrantedSource,
             ),
+            Op::relink(id(8), id(0), id(9), 7, at(1_006), ScopeCrossing::Cross),
             Op::update_content(id(5), staged(b"stage2", 12), 8, at(1_004)),
             Op::move_node(
                 id(6),

--- a/crates/engine/src/sync/overlay.rs
+++ b/crates/engine/src/sync/overlay.rs
@@ -10,6 +10,8 @@
 //! local divergence from the remote snapshot.
 
 use crate::sync::model::{NodeMeta, Snapshot};
+#[cfg(test)]
+use crate::sync::op::ScopeCrossing;
 use crate::sync::op::{Op, OpKind};
 
 /// Apply the pending op queue onto `base` in FIFO order, returning the rendered
@@ -168,7 +170,7 @@ mod tests {
         base.link(id(0), id(1), 1);
         base.link(id(0), id(2), 1);
 
-        let ops = vec![Op::relink(id(2), id(0), id(1), 1, AT, false, false)];
+        let ops = vec![Op::relink(id(2), id(0), id(1), 1, AT, ScopeCrossing::Intra)];
         let view = apply_overlay(&base, &ops);
         assert_eq!(view.parent_of(id(2)), Some(id(1)));
         assert_eq!(view.children(id(0)).len(), 1, "moved out of root");
@@ -196,6 +198,7 @@ mod tests {
             replacing,
             1,
             AT,
+            ScopeCrossing::Intra,
         )];
         let view = apply_overlay(&base, &ops);
 
@@ -225,6 +228,7 @@ mod tests {
                 replacing,
                 1,
                 AT,
+                ScopeCrossing::Intra,
             )],
         );
 

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -300,8 +300,6 @@ pub fn rebase_one(
     op: &Op,
     scope_roots: &[crate::facade::NodeId],
 ) -> OpResolution {
-    // Resolved off the pre-move base: after the relink the target hangs under
-    // the destination, and the scope it *left* is no longer walkable from it.
     let scope_exit_trigger = op
         .scope_exit_source()
         .map(|from_parent| source_scope_root(working, from_parent, scope_roots));
@@ -1121,70 +1119,6 @@ mod tests {
                 scope_exit_trigger: Some(id(0)),
             }
         );
-    }
-
-    #[test]
-    fn an_intra_scope_relocation_fires_no_trigger() {
-        let mut base = granted_scope();
-        with_node(&mut base, id(12), id(7), "moved", NodeKind::File);
-        let local = base.clone();
-        for op in [
-            Op::relink(id(7), id(12), id(11), 1, AT, ScopeCrossing::Intra),
-            Op::move_node(
-                id(7),
-                id(12),
-                id(11),
-                "r.txt",
-                None,
-                1,
-                AT,
-                ScopeCrossing::Intra,
-            ),
-        ] {
-            let res = rebase_one(&mut base.clone(), &local, &op, NESTED_ROOTS);
-            assert!(
-                matches!(
-                    res,
-                    OpResolution::Applied {
-                        scope_exit_trigger: None,
-                        ..
-                    }
-                ),
-                "the non-trigger list holds for {:?}",
-                op.kind
-            );
-        }
-    }
-
-    #[test]
-    fn many_ops_exiting_one_scope_queue_exactly_one_trigger() {
-        let mut base = granted_scope();
-        for node in [id(7), id(8), id(9)] {
-            with_node(&mut base, id(12), node, "moved", NodeKind::File);
-        }
-        let ops: Vec<(OpId, Op)> = [id(7), id(8), id(9)]
-            .into_iter()
-            .enumerate()
-            .map(|(n, node)| {
-                (
-                    OpId(n as u64),
-                    Op::move_node(
-                        node,
-                        id(12),
-                        id(6),
-                        format!("m{n}.txt"),
-                        None,
-                        1,
-                        AT,
-                        ScopeCrossing::ExitsGrantedSource,
-                    ),
-                )
-            })
-            .collect();
-
-        let report = replay(&base, &base, &ops, NESTED_ROOTS);
-        assert_eq!(report.applied.len(), 3);
-        assert_eq!(report.scope_exit_triggers, vec![id(5)]);
     }
 
     #[test]

--- a/crates/engine/src/sync/rebase.rs
+++ b/crates/engine/src/sync/rebase.rs
@@ -28,6 +28,8 @@ use crate::seams::OpId;
 use crate::sync::model::{NodeMeta, Snapshot, collation_key, suffix_name};
 #[cfg(test)]
 use crate::sync::op::NewNode;
+#[cfg(test)]
+use crate::sync::op::ScopeCrossing;
 use crate::sync::op::{Op, OpKind, Replaced};
 use crate::sync::record::{RecordClass, RecordReader};
 
@@ -46,9 +48,10 @@ pub enum OpResolution {
         effective_name: Option<String>,
         /// The add/add auto-suffix fired.
         suffixed: bool,
-        /// A cross-scope relink that left a granted source scope: the source
-        /// scope root whose scope-exit rotation is **queued** (this slice does
-        /// not rotate).
+        /// The granted source scope root this op exited, resolved full-depth
+        /// ([`source_scope_root`]) — the root a
+        /// [`ScopeExit`](crate::rotation::RotationTrigger::ScopeExit) rotation
+        /// must cut.
         scope_exit_trigger: Option<crate::facade::NodeId>,
     },
     /// The op was dropped as a no-op or a lost race.
@@ -130,7 +133,9 @@ pub struct ReplayReport {
     pub dropped: Vec<(OpId, DropReason)>,
     /// Dead-lettered ops — surfaced to the host; staged bytes preserved.
     pub dead_letters: Vec<(OpId, DeadLetterReason)>,
-    /// Scope-exit rotation triggers this replay queued (the source scope roots).
+    /// The granted source scope roots this replay exited, deduped and in
+    /// first-seen order: N ops leaving one scope are one rotation, never N
+    /// (blueprint/engine.md "Rotation primitives: Triggers").
     pub scope_exit_triggers: Vec<crate::facade::NodeId>,
 }
 
@@ -225,24 +230,32 @@ impl QueueScanMemo {
 /// Replay `ops` FIFO onto the gate-passing base. `local` (the pre-rebase
 /// overlay view) supplies node metadata for the edit-resurrects-a-delete case
 /// — the only rule that must re-materialize a node the gate-passing base no
-/// longer carries.
-pub fn replay(gate_passing: &Snapshot, local: &Snapshot, ops: &[(OpId, Op)]) -> ReplayReport {
+/// longer carries. `scope_roots` is the scope-root policy the full-depth
+/// scope-exit walk resolves against ([`source_scope_root`]).
+pub fn replay(
+    gate_passing: &Snapshot,
+    local: &Snapshot,
+    ops: &[(OpId, Op)],
+    scope_roots: &[crate::facade::NodeId],
+) -> ReplayReport {
     // The one necessary clone: rebase advances `working` but must never mutate
     // the caller's gate-passing base.
     let mut working = gate_passing.clone();
     let mut applied = Vec::new();
     let mut dropped = Vec::new();
     let mut dead_letters = Vec::new();
-    let mut scope_exit_triggers = Vec::new();
+    let mut scope_exit_triggers: Vec<crate::facade::NodeId> = Vec::new();
 
     for (op_id, op) in ops {
-        match rebase_one(&mut working, local, op) {
+        match rebase_one(&mut working, local, op, scope_roots) {
             OpResolution::Applied {
                 effective_name,
                 suffixed,
                 scope_exit_trigger,
             } => {
-                if let Some(scope_root) = scope_exit_trigger {
+                if let Some(scope_root) = scope_exit_trigger
+                    && !scope_exit_triggers.contains(&scope_root)
+                {
                     scope_exit_triggers.push(scope_root);
                 }
                 applied.push(AppliedOp {
@@ -268,7 +281,7 @@ pub fn replay(gate_passing: &Snapshot, local: &Snapshot, ops: &[(OpId, Op)]) -> 
 
 impl OpResolution {
     /// An applied op that carries no resolved name and no auto-suffix (delete,
-    /// move, content edit); `scope_exit_trigger` is the queued source scope
+    /// relink, content edit); `scope_exit_trigger` is the resolved source scope
     /// root, if any.
     fn applied(scope_exit_trigger: Option<crate::facade::NodeId>) -> Self {
         OpResolution::Applied {
@@ -281,7 +294,17 @@ impl OpResolution {
 
 /// Rebase one op onto the mutable working base and apply it. Returns the
 /// resolution and, on `Applied`, mutates `working` to reflect it.
-pub fn rebase_one(working: &mut Snapshot, local: &Snapshot, op: &Op) -> OpResolution {
+pub fn rebase_one(
+    working: &mut Snapshot,
+    local: &Snapshot,
+    op: &Op,
+    scope_roots: &[crate::facade::NodeId],
+) -> OpResolution {
+    // Resolved off the pre-move base: after the relink the target hangs under
+    // the destination, and the scope it *left* is no longer walkable from it.
+    let scope_exit_trigger = op
+        .scope_exit_source()
+        .map(|from_parent| source_scope_root(working, from_parent, scope_roots));
     match &op.kind {
         OpKind::Create { parent, name, node } => {
             rebase_create(working, op, *parent, name, node.kind())
@@ -291,23 +314,44 @@ pub fn rebase_one(working: &mut Snapshot, local: &Snapshot, op: &Op) -> OpResolu
         OpKind::Relink {
             from_parent,
             new_parent,
-            exits_granted_source,
             ..
-        } => rebase_relink(
-            working,
-            op,
-            *from_parent,
-            *new_parent,
-            *exits_granted_source,
-        ),
+        } => rebase_relink(working, op, *from_parent, *new_parent, scope_exit_trigger),
         OpKind::Move {
             from_parent,
             new_parent,
             new_name,
             replacing,
-        } => rebase_move(working, op, *from_parent, *new_parent, new_name, *replacing),
+            ..
+        } => rebase_move(
+            working,
+            op,
+            *from_parent,
+            *new_parent,
+            new_name,
+            *replacing,
+            scope_exit_trigger,
+        ),
         OpKind::UpdateContent { .. } => rebase_update_content(working, local, op),
     }
+}
+
+/// The granted scope root a move exited, walking `from_parent` and then its
+/// ancestors nearest-first — **full-depth** detection, so a move out of depth N
+/// names the same root as a move out of depth 1 (blueprint/engine.md "Rotation
+/// primitives: Triggers"; the one-level check is the v1 coverage hole).
+///
+/// A chain that reaches no listed root falls back to the snapshot root: a
+/// scope exit that rotates nothing leaves a revokee holding a live seed, and
+/// over-rotating an enclosing root only costs a wave.
+fn source_scope_root(
+    working: &Snapshot,
+    from_parent: crate::facade::NodeId,
+    scope_roots: &[crate::facade::NodeId],
+) -> crate::facade::NodeId {
+    core::iter::once(from_parent)
+        .chain(working.ancestors(from_parent))
+        .find(|node| scope_roots.contains(node))
+        .unwrap_or(working.root)
 }
 
 /// Add vs add: always visible; the rebasing loser auto-suffixes.
@@ -390,13 +434,12 @@ fn rebase_relink(
     op: &Op,
     from_parent: crate::facade::NodeId,
     new_parent: crate::facade::NodeId,
-    exits_granted_source: bool,
+    scope_exit_trigger: Option<crate::facade::NodeId>,
 ) -> OpResolution {
     if let Some(dead_letter) = relocation_guards(working, op, new_parent) {
         return dead_letter;
     }
 
-    let scope_exit_trigger = exits_granted_source.then_some(from_parent);
     match working.parent_of(op.target) {
         // Already at the destination — our move (or an identical concurrent one)
         // already landed.
@@ -453,6 +496,7 @@ fn rebase_move(
     new_parent: crate::facade::NodeId,
     new_name: &str,
     replacing: Option<Replaced>,
+    scope_exit_trigger: Option<crate::facade::NodeId>,
 ) -> OpResolution {
     if let Some(dead_letter) = relocation_guards(working, op, new_parent) {
         return dead_letter;
@@ -518,7 +562,7 @@ fn rebase_move(
     OpResolution::Applied {
         effective_name: Some(effective),
         suffixed,
-        scope_exit_trigger: None,
+        scope_exit_trigger,
     }
 }
 
@@ -720,6 +764,10 @@ mod tests {
         NodeId([b; 16])
     }
 
+    /// The one scope root these fixtures hang under — the full-depth
+    /// scope-exit walk resolves against it.
+    const SCOPE_ROOTS: &[NodeId] = &[NodeId([0; 16])];
+
     fn tree() -> Snapshot {
         Snapshot::new(id(0))
     }
@@ -737,7 +785,7 @@ mod tests {
 
         // The delete snapshotted the target at sequence 3.
         let local = base.clone();
-        let res = rebase_one(&mut base, &local, &Op::delete(id(1), 1, AT, 3));
+        let res = rebase_one(&mut base, &local, &Op::delete(id(1), 1, AT, 3), SCOPE_ROOTS);
         assert_eq!(res, OpResolution::Dropped(DropReason::TargetAdvanced));
         assert!(base.contains(id(1)), "edit wins — the node survives");
     }
@@ -749,7 +797,7 @@ mod tests {
         base.node_mut(id(1)).unwrap().record_sequence = 3;
 
         let local = base.clone();
-        let res = rebase_one(&mut base, &local, &Op::delete(id(1), 1, AT, 3));
+        let res = rebase_one(&mut base, &local, &Op::delete(id(1), 1, AT, 3), SCOPE_ROOTS);
         assert!(matches!(res, OpResolution::Applied { .. }));
         assert!(!base.contains(id(1)));
     }
@@ -765,6 +813,7 @@ mod tests {
             &mut working,
             &local,
             &Op::update_content(id(1), staged_k(), 1, AT),
+            SCOPE_ROOTS,
         );
         assert!(matches!(res, OpResolution::Applied { .. }));
         assert!(working.contains(id(1)), "the edit resurrected the node");
@@ -786,6 +835,7 @@ mod tests {
             &mut working,
             &local,
             &Op::update_content(id(1), staged_k(), 1, AT),
+            SCOPE_ROOTS,
         );
         assert_eq!(
             res,
@@ -848,6 +898,7 @@ mod tests {
             &mut gate_passing.clone(),
             &local,
             &Op::update_content(id(1), staged_k(), 1, AT),
+            SCOPE_ROOTS,
         );
         assert_eq!(
             res,
@@ -873,6 +924,7 @@ mod tests {
                 1,
                 AT,
             ),
+            SCOPE_ROOTS,
         );
         assert_eq!(
             res,
@@ -895,7 +947,12 @@ mod tests {
         base.node_mut(id(1)).unwrap().name = "other.txt".into();
 
         let local = base.clone();
-        let res = rebase_one(&mut base, &local, &Op::rename(id(1), "final.txt", 1, AT));
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::rename(id(1), "final.txt", 1, AT),
+            SCOPE_ROOTS,
+        );
         assert!(matches!(
             res,
             OpResolution::Applied {
@@ -920,7 +977,8 @@ mod tests {
         let res = rebase_one(
             &mut base,
             &local,
-            &Op::relink(id(2), id(0), id(1), 1, AT, false, false),
+            &Op::relink(id(2), id(0), id(1), 1, AT, ScopeCrossing::Intra),
+            SCOPE_ROOTS,
         );
         assert!(matches!(res, OpResolution::Applied { .. }));
         assert_eq!(base.parent_of(id(2)), Some(id(1)), "dest-linked");
@@ -942,7 +1000,8 @@ mod tests {
         let res = rebase_one(
             &mut base,
             &local,
-            &Op::relink(id(3), id(0), id(1), 1, AT, false, false),
+            &Op::relink(id(3), id(0), id(1), 1, AT, ScopeCrossing::Intra),
+            SCOPE_ROOTS,
         );
         assert_eq!(res, OpResolution::Dropped(DropReason::MoveRaceLost));
         assert_eq!(
@@ -953,28 +1012,201 @@ mod tests {
         assert!(base.children(id(1)).is_empty(), "no dest-add residue");
     }
 
-    #[test]
-    fn cross_scope_move_out_of_a_granted_scope_queues_a_trigger_only() {
+    /// `granted` (id 5) is a scope root holding a chain `a`/`b`/`c` down to
+    /// depth 3, beside a sibling destination outside it.
+    fn granted_scope() -> Snapshot {
         let mut base = tree();
         with_node(&mut base, id(0), id(5), "granted", NodeKind::Folder);
-        with_node(&mut base, id(5), id(6), "dest", NodeKind::Folder);
-        with_node(&mut base, id(5), id(7), "moved", NodeKind::File);
+        with_node(&mut base, id(0), id(6), "dest", NodeKind::Folder);
+        with_node(&mut base, id(5), id(10), "a", NodeKind::Folder);
+        with_node(&mut base, id(10), id(11), "b", NodeKind::Folder);
+        with_node(&mut base, id(11), id(12), "c", NodeKind::Folder);
+        base
+    }
 
+    /// The scope roots for [`granted_scope`]: the vault root and the granted
+    /// scope nested under it.
+    const NESTED_ROOTS: &[NodeId] = &[NodeId([0; 16]), NodeId([5; 16])];
+
+    #[test]
+    fn a_scope_exit_names_the_granted_root_at_depth_one_and_at_depth_n() {
+        // The v1 coverage hole: a one-level check names `from_parent`, which is
+        // the scope root only for the depth-1 move.
+        for (from_parent, depth) in [(id(5), 1), (id(12), 4)] {
+            let mut base = granted_scope();
+            with_node(&mut base, from_parent, id(7), "moved", NodeKind::File);
+            let local = base.clone();
+            let res = rebase_one(
+                &mut base,
+                &local,
+                &Op::relink(
+                    id(7),
+                    from_parent,
+                    id(6),
+                    1,
+                    AT,
+                    ScopeCrossing::ExitsGrantedSource,
+                ),
+                NESTED_ROOTS,
+            );
+            assert_eq!(
+                res,
+                OpResolution::Applied {
+                    effective_name: None,
+                    suffixed: false,
+                    scope_exit_trigger: Some(id(5)),
+                },
+                "an exit from depth {depth} names the granted scope root"
+            );
+        }
+    }
+
+    #[test]
+    fn a_cross_scope_move_with_rename_queues_the_same_trigger() {
+        // A kernel rename journals `Move`, not `Relink`, so the desktop's whole
+        // move surface would be blind to a scope exit if this did not fire.
+        let mut base = granted_scope();
+        with_node(&mut base, id(12), id(7), "moved", NodeKind::File);
         let local = base.clone();
         let res = rebase_one(
             &mut base,
             &local,
-            &Op::relink(id(7), id(5), id(6), 1, AT, true, true),
+            &Op::move_node(
+                id(7),
+                id(12),
+                id(6),
+                "renamed.txt",
+                None,
+                1,
+                AT,
+                ScopeCrossing::ExitsGrantedSource,
+            ),
+            NESTED_ROOTS,
+        );
+        assert_eq!(
+            res,
+            OpResolution::Applied {
+                effective_name: Some("renamed.txt".to_owned()),
+                suffixed: false,
+                scope_exit_trigger: Some(id(5)),
+            }
+        );
+    }
+
+    #[test]
+    fn a_source_chain_reaching_no_listed_root_falls_back_to_the_snapshot_root() {
+        // Rotating an enclosing root over-rotates; rotating nothing would leave
+        // a revokee holding a live seed.
+        let mut base = granted_scope();
+        with_node(&mut base, id(12), id(7), "moved", NodeKind::File);
+        let local = base.clone();
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::relink(
+                id(7),
+                id(12),
+                id(6),
+                1,
+                AT,
+                ScopeCrossing::ExitsGrantedSource,
+            ),
+            &[],
         );
         assert_eq!(
             res,
             OpResolution::Applied {
                 effective_name: None,
                 suffixed: false,
-                scope_exit_trigger: Some(id(5)),
-            },
-            "the trigger is queued; no rotation happens in this slice"
+                scope_exit_trigger: Some(id(0)),
+            }
         );
+    }
+
+    #[test]
+    fn an_intra_scope_relocation_fires_no_trigger() {
+        let mut base = granted_scope();
+        with_node(&mut base, id(12), id(7), "moved", NodeKind::File);
+        let local = base.clone();
+        for op in [
+            Op::relink(id(7), id(12), id(11), 1, AT, ScopeCrossing::Intra),
+            Op::move_node(
+                id(7),
+                id(12),
+                id(11),
+                "r.txt",
+                None,
+                1,
+                AT,
+                ScopeCrossing::Intra,
+            ),
+        ] {
+            let res = rebase_one(&mut base.clone(), &local, &op, NESTED_ROOTS);
+            assert!(
+                matches!(
+                    res,
+                    OpResolution::Applied {
+                        scope_exit_trigger: None,
+                        ..
+                    }
+                ),
+                "the non-trigger list holds for {:?}",
+                op.kind
+            );
+        }
+    }
+
+    #[test]
+    fn many_ops_exiting_one_scope_queue_exactly_one_trigger() {
+        let mut base = granted_scope();
+        for node in [id(7), id(8), id(9)] {
+            with_node(&mut base, id(12), node, "moved", NodeKind::File);
+        }
+        let ops: Vec<(OpId, Op)> = [id(7), id(8), id(9)]
+            .into_iter()
+            .enumerate()
+            .map(|(n, node)| {
+                (
+                    OpId(n as u64),
+                    Op::move_node(
+                        node,
+                        id(12),
+                        id(6),
+                        format!("m{n}.txt"),
+                        None,
+                        1,
+                        AT,
+                        ScopeCrossing::ExitsGrantedSource,
+                    ),
+                )
+            })
+            .collect();
+
+        let report = replay(&base, &base, &ops, NESTED_ROOTS);
+        assert_eq!(report.applied.len(), 3);
+        assert_eq!(report.scope_exit_triggers, vec![id(5)]);
+    }
+
+    #[test]
+    fn a_move_that_loses_its_race_queues_no_trigger() {
+        // The exit never happened here, so there is nothing to rotate for.
+        let mut base = granted_scope();
+        with_node(&mut base, id(11), id(7), "moved", NodeKind::File);
+        let local = base.clone();
+        let res = rebase_one(
+            &mut base,
+            &local,
+            &Op::relink(
+                id(7),
+                id(12),
+                id(6),
+                1,
+                AT,
+                ScopeCrossing::ExitsGrantedSource,
+            ),
+            NESTED_ROOTS,
+        );
+        assert_eq!(res, OpResolution::Dropped(DropReason::MoveRaceLost));
     }
 
     /// The `(base, local)` pair for a move over `dir`/`f` plus an occupied
@@ -1002,7 +1234,17 @@ mod tests {
         let res = rebase_one(
             &mut base,
             &local,
-            &Op::move_node(id(2), id(0), id(1), "target.txt", replacing(1), 1, AT),
+            &Op::move_node(
+                id(2),
+                id(0),
+                id(1),
+                "target.txt",
+                replacing(1),
+                1,
+                AT,
+                ScopeCrossing::Intra,
+            ),
+            SCOPE_ROOTS,
         );
         assert_eq!(
             res,
@@ -1028,7 +1270,17 @@ mod tests {
         let res = rebase_one(
             &mut base,
             &local,
-            &Op::move_node(id(2), id(0), id(1), "target.txt", replacing(1), 1, AT),
+            &Op::move_node(
+                id(2),
+                id(0),
+                id(1),
+                "target.txt",
+                replacing(1),
+                1,
+                AT,
+                ScopeCrossing::Intra,
+            ),
+            SCOPE_ROOTS,
         );
         assert_eq!(
             res,
@@ -1054,7 +1306,17 @@ mod tests {
         let res = rebase_one(
             &mut base,
             &local,
-            &Op::move_node(id(2), id(0), id(1), "target.txt", replacing(1), 1, AT),
+            &Op::move_node(
+                id(2),
+                id(0),
+                id(1),
+                "target.txt",
+                replacing(1),
+                1,
+                AT,
+                ScopeCrossing::Intra,
+            ),
+            SCOPE_ROOTS,
         );
         assert_eq!(
             res,
@@ -1079,7 +1341,17 @@ mod tests {
         let res = rebase_one(
             &mut base,
             &local,
-            &Op::move_node(id(2), id(0), id(1), "target.txt", replacing(1), 1, AT),
+            &Op::move_node(
+                id(2),
+                id(0),
+                id(1),
+                "target.txt",
+                replacing(1),
+                1,
+                AT,
+                ScopeCrossing::Intra,
+            ),
+            SCOPE_ROOTS,
         );
         assert!(matches!(
             res,
@@ -1116,7 +1388,9 @@ mod tests {
                 }),
                 1,
                 AT,
+                ScopeCrossing::Intra,
             ),
+            SCOPE_ROOTS,
         );
         assert!(matches!(res, OpResolution::Applied { .. }));
         assert!(base.contains(id(2)), "the target survives its own replace");
@@ -1132,7 +1406,17 @@ mod tests {
         let res = rebase_one(
             &mut base,
             &local,
-            &Op::move_node(id(2), id(0), id(0), "g.txt", None, 1, AT),
+            &Op::move_node(
+                id(2),
+                id(0),
+                id(0),
+                "g.txt",
+                None,
+                1,
+                AT,
+                ScopeCrossing::Intra,
+            ),
+            SCOPE_ROOTS,
         );
         assert!(matches!(
             res,
@@ -1162,7 +1446,17 @@ mod tests {
         let res = rebase_one(
             &mut base,
             &local,
-            &Op::move_node(id(2), id(0), id(1), "target.txt", replacing(1), 1, AT),
+            &Op::move_node(
+                id(2),
+                id(0),
+                id(1),
+                "target.txt",
+                replacing(1),
+                1,
+                AT,
+                ScopeCrossing::Intra,
+            ),
+            SCOPE_ROOTS,
         );
         assert_eq!(res, OpResolution::Dropped(DropReason::MoveRaceLost));
         assert_eq!(
@@ -1183,7 +1477,17 @@ mod tests {
             let res = rebase_one(
                 &mut working,
                 &base,
-                &Op::move_node(target, id(0), dest, "target.txt", replacing(1), 1, AT),
+                &Op::move_node(
+                    target,
+                    id(0),
+                    dest,
+                    "target.txt",
+                    replacing(1),
+                    1,
+                    AT,
+                    ScopeCrossing::Intra,
+                ),
+                SCOPE_ROOTS,
             );
             assert_eq!(res, OpResolution::DeadLetter(reason));
             assert_eq!(working, base, "a dead letter changes nothing");
@@ -1202,7 +1506,17 @@ mod tests {
         let res = rebase_one(
             &mut base,
             &local,
-            &Op::move_node(id(2), id(0), id(1), "target.txt", replacing(1), 1, AT),
+            &Op::move_node(
+                id(2),
+                id(0),
+                id(1),
+                "target.txt",
+                replacing(1),
+                1,
+                AT,
+                ScopeCrossing::Intra,
+            ),
+            SCOPE_ROOTS,
         );
         assert_eq!(res, OpResolution::Dropped(DropReason::AlreadySatisfied));
     }
@@ -1241,6 +1555,7 @@ mod tests {
                 1,
                 AT,
             ),
+            SCOPE_ROOTS,
         );
         assert_eq!(res, OpResolution::DeadLetter(DeadLetterReason::TargetGone));
     }
@@ -1256,7 +1571,8 @@ mod tests {
             let res = rebase_one(
                 &mut base.clone(),
                 &local,
-                &Op::relink(id(1), id(0), dest, 1, AT, false, false),
+                &Op::relink(id(1), id(0), dest, 1, AT, ScopeCrossing::Intra),
+                SCOPE_ROOTS,
             );
             assert_eq!(
                 res,
@@ -1306,7 +1622,7 @@ mod tests {
                 ),
             ), // dead-letter
         ];
-        let report = replay(&gate_passing, &gate_passing, &ops);
+        let report = replay(&gate_passing, &gate_passing, &ops, SCOPE_ROOTS);
 
         assert_eq!(report.applied.len(), 2);
         assert!(report.applied[1].suffixed);

--- a/crates/engine/tests/sync.rs
+++ b/crates/engine/tests/sync.rs
@@ -9,6 +9,7 @@
 //! cold-start-adopts-nothing sequence each get a narrative here, driven only
 //! through the engine's public sync surface.
 
+use core::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -21,13 +22,17 @@ use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid};
 use cipherbox_core::suite::x25519::X25519Secret;
 use cipherbox_engine::gate::floor;
 use cipherbox_engine::profile::SyncTimingProfile;
+use cipherbox_engine::rotation::{
+    RotateError, RotationOutcome, ScopeExitReport, ScopeExitRotator, ScopeRootPublishError,
+    consume_scope_exit_triggers,
+};
 use cipherbox_engine::seams::{SeamResult, StagingStore, UnixMillis};
 use cipherbox_engine::sync::model::NodeMeta;
 use cipherbox_engine::sync::pointer::{seal_repoint, vault_pointer_name};
 use cipherbox_engine::sync::{
     self, Connectivity, DeadLetterReason, DropReason, NewNode, Op, OpResolution, PointerFetch,
-    RecordReader, RecordSeal, SessionRole, Snapshot, StagedContent, apply_repairs, classify,
-    decode_queue, observed_repair, rebase_one, replay, resolve_vault_pointer, stage_op,
+    RecordReader, RecordSeal, ScopeCrossing, SessionRole, Snapshot, StagedContent, apply_repairs,
+    classify, decode_queue, observed_repair, rebase_one, replay, resolve_vault_pointer, stage_op,
     withheld_escalation,
 };
 use cipherbox_engine::testkit::fakes::{InMemoryFloorStore, InMemoryStagingStore};
@@ -71,6 +76,10 @@ fn id(b: u8) -> NodeId {
     NodeId([b; 16])
 }
 
+/// The one scope root these fixtures hang under — the full-depth scope-exit
+/// walk resolves against it.
+const SCOPE_ROOTS: &[NodeId] = &[NodeId([0; 16])];
+
 fn with_child(snap: &mut Snapshot, parent: NodeId, node: NodeId, name: &str, kind: NodeKind) {
     snap.upsert_node(NodeMeta::new(node, name, kind));
     snap.link(parent, node, 1);
@@ -91,7 +100,7 @@ fn race_1_delete_vs_concurrent_edit_edit_wins() {
     base.node_mut(id(1)).unwrap().record_sequence = 6;
     let local = base.clone();
 
-    let res = rebase_one(&mut base, &local, &Op::delete(id(1), 1, AT, 3));
+    let res = rebase_one(&mut base, &local, &Op::delete(id(1), 1, AT, 3), SCOPE_ROOTS);
     assert_eq!(res, OpResolution::Dropped(DropReason::TargetAdvanced));
     assert!(
         base.contains(id(1)),
@@ -112,6 +121,7 @@ fn race_1_reverse_edit_resurrects_a_concurrently_deleted_node() {
         &mut working,
         &local,
         &Op::update_content(id(1), staged(b"v2"), 1, AT),
+        SCOPE_ROOTS,
     );
     assert!(matches!(res, OpResolution::Applied { .. }));
     assert!(
@@ -129,7 +139,12 @@ fn race_2_rename_vs_rename_serialized_by_parent_cas_higher_writer_wins() {
     base.node_mut(id(1)).unwrap().name = "other.txt".into();
     let local = base.clone();
 
-    let res = rebase_one(&mut base, &local, &Op::rename(id(1), "mine.txt", 1, AT));
+    let res = rebase_one(
+        &mut base,
+        &local,
+        &Op::rename(id(1), "mine.txt", 1, AT),
+        SCOPE_ROOTS,
+    );
     assert!(matches!(
         res,
         OpResolution::Applied {
@@ -159,6 +174,7 @@ fn race_3_add_vs_add_name_collision_auto_suffixes_the_loser() {
             1,
             AT,
         ),
+        SCOPE_ROOTS,
     );
     assert_eq!(
         res,
@@ -181,7 +197,8 @@ fn race_4_move_dest_first_then_presence_conditional_source_remove() {
     let res = rebase_one(
         &mut base,
         &local,
-        &Op::relink(id(2), id(0), id(1), 1, AT, false, false),
+        &Op::relink(id(2), id(0), id(1), 1, AT, ScopeCrossing::Intra),
+        SCOPE_ROOTS,
     );
     assert!(matches!(res, OpResolution::Applied { .. }));
     assert_eq!(base.parent_of(id(2)), Some(id(1)), "dest-linked");
@@ -206,7 +223,8 @@ fn race_4_move_race_loser_undoes_its_dest_add() {
     let res = rebase_one(
         &mut base,
         &local,
-        &Op::relink(id(3), id(0), id(1), 1, AT, false, false),
+        &Op::relink(id(3), id(0), id(1), 1, AT, ScopeCrossing::Intra),
+        SCOPE_ROOTS,
     );
     assert_eq!(res, OpResolution::Dropped(DropReason::MoveRaceLost));
     assert_eq!(
@@ -280,7 +298,7 @@ fn offline_queue_replays_fifo_onto_gate_passing_state() {
         assert_eq!(scan.retained, 0);
 
         let base = Snapshot::new(id(0));
-        let report = replay(&base, &base, &scan.mine);
+        let report = replay(&base, &base, &scan.mine, SCOPE_ROOTS);
 
         assert_eq!(report.applied.len(), 3, "every op replayed in FIFO order");
         assert_eq!(report.rebased.node(id(1)).unwrap().name, "notes-v2.txt");
@@ -323,7 +341,7 @@ fn revoked_while_offline_dead_letters_with_staged_bytes_preserved() {
         let gate_passing = Snapshot::new(id(0)); // no id(5)
         let raw = store.queued_ops().await.unwrap();
         let scan = decode_queue(&RecordReader::new(&me), &raw);
-        let report = replay(&gate_passing, &gate_passing, &scan.mine);
+        let report = replay(&gate_passing, &gate_passing, &scan.mine, SCOPE_ROOTS);
 
         // The op terminally dead-letters — nothing silently dropped.
         assert_eq!(report.applied.len(), 0);
@@ -623,4 +641,175 @@ fn state_law_renders_the_snapshot_plus_the_pending_overlay() {
     // The gate-passing snapshot is the only source of truth and is untouched.
     assert!(!base.contains(id(2)));
     assert_eq!(base.node(id(1)).unwrap().name, "confirmed.txt");
+}
+
+// ---------------------------------------------------------------------------
+// Scope-exit rotation triggers — full-depth detection, one rotation per source
+// scope root, and a failure that surfaces (blueprint/engine.md "Rotation
+// primitives: Triggers").
+// ---------------------------------------------------------------------------
+
+/// A granted scope root (id 5) under the vault root, holding a chain down to
+/// depth 3, beside a destination folder outside it.
+fn granted_scope_tree() -> Snapshot {
+    let mut base = Snapshot::new(id(0));
+    with_child(&mut base, id(0), id(5), "granted", NodeKind::Folder);
+    with_child(&mut base, id(0), id(6), "outside", NodeKind::Folder);
+    with_child(&mut base, id(5), id(10), "a", NodeKind::Folder);
+    with_child(&mut base, id(10), id(11), "b", NodeKind::Folder);
+    with_child(&mut base, id(11), id(12), "c", NodeKind::Folder);
+    base
+}
+
+/// The vault root plus the granted scope root nested under it.
+const GRANTED_ROOTS: &[NodeId] = &[NodeId([0; 16]), NodeId([5; 16])];
+
+/// Records every root it is asked to cut, refusing the ones named.
+struct RecordingRotator {
+    seen: RefCell<Vec<NodeId>>,
+    refuse: Vec<NodeId>,
+}
+
+impl RecordingRotator {
+    fn refusing(refuse: &[NodeId]) -> Self {
+        Self {
+            seen: RefCell::new(Vec::new()),
+            refuse: refuse.to_vec(),
+        }
+    }
+}
+
+impl ScopeExitRotator for RecordingRotator {
+    async fn rotate_on_scope_exit(
+        &self,
+        scope_root: NodeId,
+    ) -> Result<RotationOutcome, RotateError> {
+        self.seen.borrow_mut().push(scope_root);
+        if self.refuse.contains(&scope_root) {
+            return Err(RotateError::Publish(ScopeRootPublishError::NotPublished));
+        }
+        Ok(RotationOutcome {
+            new_read_epoch: 2,
+            epoch_floor: 2,
+        })
+    }
+}
+
+/// Replay `ops` off the durable queue and drive whatever scope exits it found.
+/// `placements` seeds each moved file where the op was formed against it.
+fn exits_of(
+    placements: &[(NodeId, NodeId)],
+    ops: &[Op],
+    rotator: &RecordingRotator,
+) -> (Vec<NodeId>, ScopeExitReport) {
+    let store = InMemoryStagingStore::default();
+    let me = owner();
+    block_on(async {
+        for (n, op) in ops.iter().enumerate() {
+            stage_op(&store, seal(&me, n as u8), op).await.unwrap();
+        }
+        let raw = store.queued_ops().await.unwrap();
+        let scan = decode_queue(&RecordReader::new(&me), &raw);
+        let mut base = granted_scope_tree();
+        for (target, parent) in placements {
+            with_child(&mut base, *parent, *target, "m.txt", NodeKind::File);
+        }
+        let report = replay(&base, &base, &scan.mine, GRANTED_ROOTS);
+        let triggers = report.scope_exit_triggers.clone();
+        let cut = consume_scope_exit_triggers(rotator, &triggers).await;
+        (triggers, cut)
+    })
+}
+
+/// A file at `parent` moved out to `outside`, exiting the granted source.
+fn exiting_move(target: NodeId, parent: NodeId, name: &str) -> Op {
+    Op::move_node(
+        target,
+        parent,
+        id(6),
+        name,
+        None,
+        1,
+        AT,
+        ScopeCrossing::ExitsGrantedSource,
+    )
+}
+
+#[test]
+fn a_scope_exit_rotates_the_source_scope_root_at_depth_one_and_at_depth_n() {
+    for (parent, depth) in [(id(5), 1), (id(12), 4)] {
+        let rotator = RecordingRotator::refusing(&[]);
+        let (triggers, cut) = exits_of(
+            &[(id(7), parent)],
+            &[exiting_move(id(7), parent, "m.txt")],
+            &rotator,
+        );
+
+        assert_eq!(
+            triggers,
+            vec![id(5)],
+            "a move out of depth {depth} names the granted scope root, not its parent"
+        );
+        assert_eq!(*rotator.seen.borrow(), vec![id(5)]);
+        assert!(cut.is_complete());
+    }
+}
+
+#[test]
+fn many_ops_exiting_one_scope_rotate_it_exactly_once() {
+    let rotator = RecordingRotator::refusing(&[]);
+    let placements = [(id(7), id(5)), (id(8), id(11)), (id(9), id(12))];
+    let ops: Vec<Op> = placements
+        .into_iter()
+        .enumerate()
+        .map(|(n, (target, parent))| exiting_move(target, parent, &format!("m{n}.txt")))
+        .collect();
+
+    let (triggers, cut) = exits_of(&placements, &ops, &rotator);
+
+    assert_eq!(triggers, vec![id(5)], "three exits, one source scope root");
+    assert_eq!(*rotator.seen.borrow(), vec![id(5)]);
+    assert_eq!(cut.rotated.len(), 1);
+}
+
+#[test]
+fn an_intra_scope_move_rotates_nothing() {
+    let rotator = RecordingRotator::refusing(&[]);
+    let (triggers, cut) = exits_of(
+        &[(id(7), id(12))],
+        &[Op::move_node(
+            id(7),
+            id(12),
+            id(11),
+            "m.txt",
+            None,
+            1,
+            AT,
+            ScopeCrossing::Intra,
+        )],
+        &rotator,
+    );
+
+    assert!(triggers.is_empty(), "the non-trigger list holds");
+    assert!(rotator.seen.borrow().is_empty());
+    assert!(cut.is_complete());
+}
+
+#[test]
+fn a_failed_scope_exit_rotation_surfaces_and_keeps_its_trigger() {
+    let rotator = RecordingRotator::refusing(&[id(5)]);
+    let (triggers, cut) = exits_of(
+        &[(id(7), id(12))],
+        &[exiting_move(id(7), id(12), "m.txt")],
+        &rotator,
+    );
+
+    assert_eq!(triggers, vec![id(5)]);
+    assert!(cut.rotated.is_empty());
+    assert_eq!(
+        cut.failed.iter().map(|(root, _)| *root).collect::<Vec<_>>(),
+        vec![id(5)],
+        "the trigger comes back rather than being swallowed"
+    );
+    assert!(!cut.is_complete());
 }


### PR DESCRIPTION
## What this lands

The queued scope-exit triggers are no longer dropped on the floor, and the two
detection holes that would have let a trigger slip are closed.

- **Full-depth detection.** `rebase` now resolves the *granted source scope
  root* by walking the source parent and then its ancestors nearest-first
  against an injected scope-root policy (`replay`/`rebase_one` take
  `scope_roots: &[NodeId]`). It previously named `from_parent` — correct only
  when the moved node was a direct child of the scope root, which is exactly the
  v1 one-level coverage hole `blueprint/engine.md` calls out (`#26 D7`). A chain
  that reaches no listed root falls back to the snapshot root: over-rotating an
  enclosing root costs a wave, rotating nothing leaves a revokee holding a live
  seed.
- **Dedupe.** `replay` queues one trigger per source scope root, first-seen
  order — N ops leaving one scope are one rotation.
- **The consumer.** `rotation/trigger.rs` gains the `ScopeExitRotator` seam and
  `consume_scope_exit_triggers`, which cuts one root per queued trigger, never
  short-circuits, and returns every failure in `ScopeExitReport::failed` instead
  of swallowing it. The grantee-arm implementation over the live transport is
  not landed, so the seam is faked in tests — the same pattern `SweepResolver`
  and `WriteSubtreeResolver` already follow (`rotation/mod.rs`).
- **`OpKind::Move` now carries scope-crossing.** See the scope decision below.
- **`ScopeCrossing` replaces the `cross_scope` / `exits_granted_source` bool
  pair** on both relocation ops. "Exits a granted source but is not cross-scope"
  is incoherent; as a pair it was representable and a decoder would have had to
  reject it. As one value it is unrepresentable, so no encode/decode symmetry
  check is needed — the illegal state is gone from the type rather than guarded
  at both ends.
- **The drain** hands `replay` its scope root and halts a cross-scope `Move` the
  way it already halted a cross-scope `Relink`. Publishing a cross-scope
  relocation through the plain ref-move plan would carry the moved subtree into
  the destination still sealed at the source epoch.

## `OpKind::Move` — in scope, deliberately

The issue does not mention it, but `OpKind::Move` had no scope-exit field at
all, so a cross-scope move-with-rename could not queue a trigger. **This is in
scope and is fixed here.** A kernel rename journals exactly one `Move`
(`blueprint/desktop.md`), so `Move` — not `Relink` — is the desktop's entire
move surface. Leaving it blind would have kept precisely the class of silent
miss this issue exists to close: an exit that never rotates. It is an `Op`
schema change; v2 is greenfield and pre-cutover, and an op a build cannot parse
is `Retained`, never replayed and never removed (`sync/record.rs`), so the
change fails closed.

## Errors in the issue body, verified against the code

- **Line drift.** `scope_exit_triggers` is declared at `sync/rebase.rs:134`, not
  133, and populated at `:246`, not 245. The deferral note is `sync/mod.rs:14-17`,
  not just `:16`.
- **"The rebase side already detects the trigger" is not true.** The flag was
  never set by any production caller: `facade.rs:2222` was the *only*
  `Op::relink` construction outside tests and hard-coded `false, false`.
  Detection was effectively greenfield.
- **The orchestrating brief's claim that `sync/drain.rs:964` also hard-codes the
  flag is wrong.** `drain.rs` never constructs a relink op; `:1029` is a
  *pattern match* on `cross_scope: false`, not a construction. `facade.rs:2222`
  was the single hard-coded site.
- **"Retire the `sync/mod.rs:16` deferral note once the consumer exists"** — the
  note is rewritten rather than deleted, because deleting it outright would read
  as an all-clear the code does not support (see residuals).

## Known residuals — deliberately not done

- **No production `ScopeExitRotator`.** Assembling a `RotateScopePlan` needs the
  scope root's committed set, current override seed, history links and pointer
  read key, none of which the sync layer holds; the grantee-arm net that
  resolves them is not landed. This is the issue's own stated dependency. Hence
  `Part of #1018`, not `Closes`.
- **The engine is still single-scope**, so `facade.rs` authors
  `ScopeCrossing::Intra` for every relocation and no production path yet reaches
  `ExitsGrantedSource`. The scope-root policy is injected as a parameter, so the
  detection is exercised at depth 1 and depth N under a multi-scope fixture and
  gains nothing when the real scope map arrives.
- **`DrainReport` carries no trigger field.** An earlier draft added one; with no
  rotator to hand it to it was written and never read, and the facade cannot
  author a cross-scope op, so no test could reach it. Untestable plumbing was
  dropped in the review pass; `ReplayReport::scope_exit_triggers` — which the
  drain's own `replay` call produces — stays the surface.
- **`AlreadySatisfied` drops a scope-exiting op without queuing its trigger.**
  Unreachable today: a cross-scope relocation cannot publish, so gate-passing
  state can never show *our own* scope exit as already satisfied. The pass that
  lands cross-scope publishing must handle this branch, or a trigger is lost
  there.
- **Durability of the intent is the durable op queue.** A cross-scope relocation
  halts the pass (`Halt::Unclassified`), which charges nothing and leaves the op
  at the head of the queue, so every pass re-derives the trigger until it
  settles. No separate durable trigger store was added; one would have been a
  second source of truth for state the queue already holds.

## `facade.rs`

Touched minimally and only as forced by the type change: the two `Op::relink` /
`Op::move_node` construction sites now pass `ScopeCrossing::Intra`, one import,
and a stale trailing-bools comment replaced. No logic change. Flagging it since
`facade.rs` is a hot file this wave.

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` were run as
rigorous manual passes against `git diff main...HEAD` — the slash-command
subagents were unavailable in this environment (concurrency limit), so no gate
was skipped, none was run as a skill.

**`/simplify`** — four findings, all folded into the second commit: an unread
`DrainReport` field, an uncalled `ScopeCrossing::is_cross_scope`, a comment on
`rebase_one` whose stated rationale was about walking from the target (which the
code does not do), and two rebase unit tests the sync narratives already state
end-to-end.

**`/security-review`** — the trigger is a revocation-boundary surface, so the
questions were who can influence it and in which direction it fails.

- *Influence*: `ScopeCrossing` is authored only by the facade and rides an
  HPKE-to-self sealed, owner-tagged op record. A store co-tenant's record
  classifies as `Retained`, never `Mine`, so an attacker cannot inject a forged
  scope-exit — nor suppress one beyond the pre-existing queue-integrity residual
  `blueprint/engine.md` already documents.
- *Fallback direction*: over-rotate, never under-rotate. `Snapshot::ancestors` is
  cycle-guarded, so a malformed link cycle terminates rather than looping.
- *Applied-vs-queued*: every `OpResolution` branch was walked. Applied exits
  queue a trigger; `MoveRaceLost`, the relocation guards and `SuffixExhausted`
  queue none, and in each the exit did not happen. `AlreadySatisfied` is the one
  asymmetry, recorded above as a residual.
- *Dedupe*: collapses only equal roots. Two exits from distinct scopes that both
  hit the snapshot-root fallback do collapse — but in that state the engine knows
  neither scope, so it could not have rotated them separately either.
- *DoS*: trigger and scope-root vectors are bounded by distinct scope roots, so
  the linear `contains` scans are over single-digit collections.
- *Determinism*: no clock or RNG added; the scope-root policy enters as a
  parameter.

**`/crypto-privacy-review`** — the diff touches no primitive, no key or seal
material, and no trust-boundary read. `RotationOutcome` carries epochs only, and
`RotateError::check()` is an existing key-material-free classifier. No zeroize
ownership changed. Recorded rather than skipped.

## Gates run locally

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets`,
`cargo test -p cipherbox-engine -p cipherbox-core` (20 targets, all green),
`cargo check --workspace --all-targets`,
`cargo check -p cipherbox-wasm --target wasm32-unknown-unknown`, and
`node scripts/check-tracker-refs.mjs`.

Part of #1018


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add scope-exit rotation trigger consumption with `ScopeCrossing` classification for relocation ops
> - Introduces `ScopeCrossing` enum in [`sync/op.rs`](https://github.com/FSM1/cipher-box/pull/1103/files#diff-1446e839d1e2d23d053dc1688ed217910161cfb299565c5a86ce2372bc5c1ffe) to replace boolean flags on `Relink` and `Move` op variants, encoding intra/cross/exiting-granted-source semantics explicitly.
> - Adds `consume_scope_exit_triggers` in [`rotation/trigger.rs`](https://github.com/FSM1/cipher-box/pull/1103/files#diff-5dba1beebd4cfb61e574efe0c30c5e460dd3752b76a4b320200a7a2db6202e25) that iterates scope-root triggers in order, calling `ScopeExitRotator::rotate_on_scope_exit` for each without short-circuiting on failure.
> - Updates `replay` in [`sync/rebase.rs`](https://github.com/FSM1/cipher-box/pull/1103/files#diff-1fc181ef0406c58cf318ec1da43d8831ee841715ed4f3179e23a0b076ddc8850) to accept a scope-root policy slice and compute deduplicated scope-exit triggers via full-depth `source_scope_root` resolution.
> - Updates `Drain::drain_queue` in [`sync/drain.rs`](https://github.com/FSM1/cipher-box/pull/1103/files#diff-2dbe80269b4dfac050f51bbaedb9a173236f92de78f9951dd049c549f45f08a5) to pass scope roots to `replay` and halt with `Err(Halt::Unclassified)` on any cross-scope relocation.
> - Risk: callers of `Op::relink`, `Op::move_node`, `rebase_one`, and `replay` must now pass `ScopeCrossing` and scope-root arguments; existing call sites without updates will not compile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f236de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic processing for scope-exit rotations after content moves.
  * Reports completed rotations and preserves failed rotations for retry.
  * Processes multiple scope exits in order while preventing duplicate triggers.
  * Exposed rotation status and scope-crossing details through the public API.

* **Bug Fixes**
  * Improved handling of nested and cross-scope moves.
  * Correctly identifies source scopes during deep relocations.
  * Rotation failures are reported without stopping subsequent processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->