### PR TITLE
fix: make the rotation gated read idempotent at the sequence floor

### DIFF
--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -23,9 +23,10 @@ use cipherbox_core::error::{CodecError, Malformed, TrustViolation};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
-    AadContext, Envelope, ReadBody, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB,
-    SignedOwnerBlob, SignedOwnerWriteBlob, decode_envelope, decode_grant_section,
-    grant_section_bytes, open_owner_blob, open_owner_write_blob, open_read_body,
+    AadContext, Envelope, GrantSection, ReadBody, STRUCT_TAG_OWNER_BLOB,
+    STRUCT_TAG_OWNER_WRITE_BLOB, SignedOwnerBlob, SignedOwnerWriteBlob, decode_envelope,
+    decode_grant_section, grant_section_bytes, open_owner_blob, open_owner_write_blob,
+    open_read_body,
 };
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
 use cipherbox_core::suite::x25519::X25519Secret;
@@ -181,7 +182,7 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
             .recover_own_scope_root(name, record_bytes)
             .await?
             .map(|root| OwnScopeMaterial {
-                node_id: root.candidate.envelope.id,
+                node_id: root.envelope.id,
                 read_scope_seed: root.read_scope_seed,
                 write_scope_seed: root.write_scope_seed,
             }))
@@ -189,11 +190,13 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
 }
 
 /// The owner's own scope root as recovered at exactly the durable sequence
-/// floor: the authenticated candidate plus what a gate pass surfaces from it.
-/// Terminal owner of the recovered seeds — they zeroize when it drops.
+/// floor: what a gate pass surfaces, off the candidate the rejected adopt
+/// authenticated. Terminal owner of the recovered seeds — they zeroize on drop.
 pub(crate) struct RecoveredScopeRoot {
-    /// The candidate the rejected adopt authenticated through stages 1-3.
-    pub(crate) candidate: Candidate,
+    /// The record's envelope.
+    pub(crate) envelope: Envelope,
+    /// Its grant section, authenticated by the gate's stages 1-3.
+    pub(crate) grant_section: GrantSection,
     /// The read-body the recovery re-unsealed under the recovered seed.
     pub(crate) read_body: ReadBody,
     /// The scope read seed this record's own owner blob wraps.
@@ -206,8 +209,8 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
     /// Recover the owner's own scope root from a record the gate rejected at
     /// **exactly** the durable sequence floor. The caller establishes that
     /// equality from the rejection ([`RejectionReason::SequenceNotNewer`] with
-    /// `sequence == floor`, [`floor::Strictness::AtFloor`]); a strictly lower
-    /// sequence is a replay and never reaches here.
+    /// `sequence == floor`); a strictly lower sequence is a replay and never
+    /// reaches here.
     ///
     /// Fail-OPEN, never a trust verdict: anything unproved yields `Ok(None)`
     /// (a `Current` never hardens — [`Adopter::recover_own_scope_material`]).
@@ -221,9 +224,9 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
             return Ok(None);
         }
         // Only the candidate the rejected [`Adopter::adopt`] cached for these
-        // exact bytes is eligible. That candidate reached the floor stages, so
-        // the gate's stages 1-3 authenticated the grant section it carries;
-        // re-assembling here would run none of them.
+        // exact bytes is eligible. Nothing but a sequence-stage verdict is ever
+        // cached, so the gate's stages 1-3 authenticated the grant section it
+        // carries; re-assembling here would run none of them.
         let Some(candidate) = self
             .assembled
             .borrow_mut()
@@ -232,16 +235,36 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
         else {
             return Ok(None);
         };
-        let env = &candidate.envelope;
         // Stages 4/5 did NOT run: `floor::check` returns `SequenceNotNewer`
-        // before it reads the epoch floor. Re-impose what they would have —
-        // scope binding and the read-epoch floor — or a forgery-window writer
-        // re-serving a pre-rotation section at the floor would hand back the
-        // revoked epoch's read seed.
-        let epoch_floor = floor::read_epoch_floor(self.floors, &self.root_scope_id)
-            .await?
-            .unwrap_or(0);
-        if env.scope != self.root_scope_id || env.epoch < epoch_floor {
+        // before it reads the epoch floor. Re-impose both here rather than
+        // trusting the caller's reading of the rejection — `AtFloor` admits only
+        // the exact sequence floor, so a replay below it recovers nothing, and
+        // the read-epoch floor still bars a forgery-window writer re-serving a
+        // pre-rotation section at the floor.
+        let Ok(sequence) = IpnsRecord::unmarshal(&candidate.record_bytes)
+            .and_then(|record| record.verify(name))
+            .map(|verified| verified.sequence)
+        else {
+            return Ok(None);
+        };
+        let env = &candidate.envelope;
+        if let Err(rejected) = floor::check(
+            self.floors,
+            name.as_str().as_bytes(),
+            &self.root_scope_id,
+            sequence,
+            env.epoch,
+            floor::Strictness::AtFloor,
+        )
+        .await
+        {
+            return match rejected {
+                GateError::Seam(seam) => Err(seam),
+                GateError::Rejected(_) => Ok(None),
+            };
+        }
+        // Stage 6's reader-scope binding, which did not run either.
+        if env.scope != self.root_scope_id {
             return Ok(None);
         }
         let Ok(read_scope_seed) =
@@ -267,7 +290,8 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
             },
         };
         Ok(Some(RecoveredScopeRoot {
-            candidate,
+            envelope: candidate.envelope,
+            grant_section: candidate.grant_section,
             read_body,
             read_scope_seed,
             write_scope_seed,
@@ -324,8 +348,20 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
             Ok(pass) => pass,
             Err(err) => {
                 // Keep the candidate for the equal-floor recovery path — it
-                // re-resolves the same head CID otherwise.
-                *self.assembled.borrow_mut() = Some(candidate);
+                // re-resolves the same head CID otherwise. Only a sequence-stage
+                // verdict is kept: that is the one rejection reached with stages
+                // 1-3 already passed, and the recovery reads seeds straight out
+                // of the grant section those stages authenticate. Caching a
+                // stage-1/2/3 rejection would let a forged section reach it.
+                if matches!(
+                    err,
+                    GateError::Rejected(GateRejection {
+                        stage: GateStage::Sequence,
+                        ..
+                    })
+                ) {
+                    *self.assembled.borrow_mut() = Some(candidate);
+                }
                 return Err(err);
             }
         };
@@ -954,6 +990,60 @@ mod tests {
             .expect("recovery is fail-open, never an error")
             .expect("our own current root recovers");
         assert_eq!(recovered.read_body, adopted);
+    }
+
+    /// The recovery enforces its own equal-floor precondition rather than
+    /// trusting the caller's reading of the rejection: a record strictly below
+    /// the sequence floor is a replay and recovers no seed.
+    #[test]
+    fn equal_floor_recovery_refuses_a_record_below_the_sequence_floor() {
+        let fx = Fixture::build(Some(OWB_WRITE_EPOCH));
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        block_on(floors.raise_sequence_floor(fx.name.as_str().as_bytes(), 9)).unwrap();
+        let gw = gateway();
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+
+        let record = fx.record(1);
+        assert!(block_on(adopter.adopt(&fx.name, &record)).is_err());
+        assert!(
+            block_on(adopter.recover_own_scope_root(&fx.name, &record))
+                .expect("fail-open")
+                .is_none(),
+            "a replay below the floor is not our own current record",
+        );
+    }
+
+    /// The candidate cache is the recovery's whole claim to stages 1-3, so only
+    /// a sequence-stage verdict may populate it. A record rejected earlier — here
+    /// an unrecognised owner identity, gate stage 2 — must leave nothing behind,
+    /// or a forged grant section would reach the seed recovery unauthenticated.
+    #[test]
+    fn a_pre_floor_rejection_caches_no_candidate_for_the_recovery() {
+        let fx = Fixture::build(Some(OWB_WRITE_EPOCH));
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        let gw = gateway();
+        let impostor = EcdsaSigner::from_scalar(&[0x22; 32])
+            .expect("valid scalar")
+            .verifying_key();
+        let adopter = fx.adopter(&http, &floors, &impostor, &gw);
+
+        let record = fx.record(1);
+        match block_on(adopter.adopt(&fx.name, &record)) {
+            Err(GateError::Rejected(r)) => assert_eq!(r.stage, GateStage::CommitmentVerify),
+            other => panic!("expected a commitment rejection, got {:?}", other.is_ok()),
+        }
+        assert!(
+            block_on(adopter.recover_own_scope_root(&fx.name, &record))
+                .expect("fail-open")
+                .is_none(),
+            "a candidate that never cleared the commitment stage is not recoverable",
+        );
     }
 
     #[test]

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -1036,7 +1036,8 @@ mod tests {
         let record = fx.record(1);
         match block_on(adopter.adopt(&fx.name, &record)) {
             Err(GateError::Rejected(r)) => assert_eq!(r.stage, GateStage::CommitmentVerify),
-            other => panic!("expected a commitment rejection, got {:?}", other.is_ok()),
+            Err(GateError::Seam(e)) => panic!("expected a commitment rejection, got seam {e}"),
+            Ok(_) => panic!("an unrecognised owner identity must be rejected"),
         }
         assert!(
             block_on(adopter.recover_own_scope_root(&fx.name, &record))

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -23,9 +23,9 @@ use cipherbox_core::error::{CodecError, Malformed, TrustViolation};
 use cipherbox_core::ipns::{IpnsName, IpnsRecord};
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
-    AadContext, Envelope, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB, SignedOwnerBlob,
-    SignedOwnerWriteBlob, decode_envelope, decode_grant_section, grant_section_bytes,
-    open_owner_blob, open_owner_write_blob, open_read_body,
+    AadContext, Envelope, ReadBody, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB,
+    SignedOwnerBlob, SignedOwnerWriteBlob, decode_envelope, decode_grant_section,
+    grant_section_bytes, open_owner_blob, open_owner_write_blob, open_read_body,
 };
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
 use cipherbox_core::suite::x25519::X25519Secret;
@@ -177,13 +177,49 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
         name: &IpnsName,
         record_bytes: &[u8],
     ) -> Result<Option<OwnScopeMaterial>, SeamError> {
+        Ok(self
+            .recover_own_scope_root(name, record_bytes)
+            .await?
+            .map(|root| OwnScopeMaterial {
+                node_id: root.candidate.envelope.id,
+                read_scope_seed: root.read_scope_seed,
+                write_scope_seed: root.write_scope_seed,
+            }))
+    }
+}
+
+/// The owner's own scope root as recovered at exactly the durable sequence
+/// floor: the authenticated candidate plus what a gate pass surfaces from it.
+/// Terminal owner of the recovered seeds — they zeroize when it drops.
+pub(crate) struct RecoveredScopeRoot {
+    /// The candidate the rejected adopt authenticated through stages 1-3.
+    pub(crate) candidate: Candidate,
+    /// The read-body the recovery re-unsealed under the recovered seed.
+    pub(crate) read_body: ReadBody,
+    /// The scope read seed this record's own owner blob wraps.
+    pub(crate) read_scope_seed: Zeroizing<[u8; 32]>,
+    /// The scope write seed, `None` when the root is held keyless.
+    pub(crate) write_scope_seed: Option<Zeroizing<[u8; 32]>>,
+}
+
+impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
+    /// Recover the owner's own scope root from a record the gate rejected at
+    /// **exactly** the durable sequence floor. The caller establishes that
+    /// equality from the rejection ([`RejectionReason::SequenceNotNewer`] with
+    /// `sequence == floor`, [`floor::Strictness::AtFloor`]); a strictly lower
+    /// sequence is a replay and never reaches here.
+    ///
+    /// Fail-OPEN, never a trust verdict: anything unproved yields `Ok(None)`
+    /// (a `Current` never hardens — [`Adopter::recover_own_scope_material`]).
+    pub(crate) async fn recover_own_scope_root(
+        &self,
+        name: &IpnsName,
+        record_bytes: &[u8],
+    ) -> Result<Option<RecoveredScopeRoot>, SeamError> {
         // Steady state — see [`Self::holding`].
         if self.held_current.as_deref() == Some(record_bytes) {
             return Ok(None);
         }
-        // Recovery is fail-open, never a trust verdict: anything unproved yields
-        // `Ok(None)`, held keyless (a `Current` never hardens).
-        //
         // Only the candidate the rejected [`Adopter::adopt`] cached for these
         // exact bytes is eligible. That candidate reached the floor stages, so
         // the gate's stages 1-3 authenticated the grant section it carries;
@@ -218,9 +254,9 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
         // this scope's seed.
         let node_seed = kdf::node_seed(&read_scope_seed, &env.id);
         let read_key = Zeroizing::new(*kdf::read_key(node_seed.as_bytes()).as_bytes());
-        if open_read_body(env, &read_key).is_err() {
+        let Ok(read_body) = open_read_body(env, &read_key) else {
             return Ok(None);
-        }
+        };
         let write_scope_seed = match &candidate.grant_section.owner_write_blob {
             None => None,
             // Map a recovery seam to availability, never a trust verdict.
@@ -230,8 +266,9 @@ impl<H: Http, F: FloorStore> Adopter for RootAdopter<'_, H, F> {
                 Err(GateError::Rejected(_)) => return Ok(None),
             },
         };
-        Ok(Some(OwnScopeMaterial {
-            node_id: env.id,
+        Ok(Some(RecoveredScopeRoot {
+            candidate,
+            read_body,
             read_scope_seed,
             write_scope_seed,
         }))
@@ -879,6 +916,44 @@ mod tests {
         // The recovered seed reproduces the record's IPNS routing name.
         let signer = SessionIdentity::write_name_signer(&seed, &fx.root_id);
         assert_eq!(IpnsName::from_public_key(&signer.verifying_key()), fx.name);
+    }
+
+    /// The equal-floor recovery re-unseals the very body the gate's stage 6
+    /// produces, so a caller that republishes our own current record (the
+    /// rotation's gated read) carries it forward byte-for-byte.
+    #[test]
+    fn recovery_returns_the_read_body_the_gate_would_have_unsealed() {
+        let fx = Fixture::build(Some(OWB_WRITE_EPOCH));
+        let gw = gateway();
+
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        let adopted = block_on(
+            fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw)
+                .adopt(&fx.name, &fx.record(1)),
+        )
+        .expect("a record above the floor adopts")
+        .adopted
+        .read_body;
+
+        let http = ScriptedHttp::default();
+        http.enqueue_response(ok_response(fx.head_block.clone()));
+        let floors = InMemoryFloorStore::default();
+        seed_write_floor(&floors, &fx.scope_id, OWB_WRITE_EPOCH);
+        let adopter = fx.adopter(&http, &floors, &fx.owner_identity_verifier, &gw);
+        block_on(floors.raise_sequence_floor(fx.name.as_str().as_bytes(), 1)).unwrap();
+        let record = fx.record(1);
+        assert!(
+            block_on(adopter.adopt(&fx.name, &record)).is_err(),
+            "an equal-floor record must reject at the sequence stage"
+        );
+
+        let recovered = block_on(adopter.recover_own_scope_root(&fx.name, &record))
+            .expect("recovery is fail-open, never an error")
+            .expect("our own current root recovers");
+        assert_eq!(recovered.read_body, adopted);
     }
 
     #[test]

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -35,7 +35,7 @@ use super::record_publish::{HeadBinding, RecordPublishRequest, preflight, publis
 use crate::api::ApiClient;
 use crate::content::Gateway;
 use crate::entropy::Entropy;
-use crate::gate::{GateError, GateRejection, RejectionReason, floor};
+use crate::gate::{GateError, RejectionReason, floor};
 use crate::net::fanout_get_verify;
 use crate::profile::SyncTimingProfile;
 use crate::rotation::{
@@ -179,8 +179,14 @@ struct Ancestry {
 }
 
 impl RotationAncestry {
-    /// Seed the walk at the rotating root: its own override seed, plus the
-    /// parent edge for each entry of its caller-held direct-child-scope index.
+    /// Seed the walk at the rotating root: the override seed its descendants'
+    /// **published** records sealed their ascent links under, plus the parent
+    /// edge for each entry of its caller-held direct-child-scope index.
+    ///
+    /// After the root's own cut has landed that is the root's **pre-cut** seed,
+    /// not the plan's current one — a descendant that never republished still
+    /// carries the previous derivation, and gating it under the post-cut seed
+    /// fails closed at the ascent link.
     pub fn rooted_at(
         scope_id: [u8; 16],
         override_seed: &[u8; SECRET_LEN],
@@ -338,24 +344,23 @@ fn nonce<E: Entropy>(entropy: &RefCell<E>) -> Result<[u8; 24], ScopeRootPublishE
     Ok(nonce)
 }
 
-/// The rejection arm of a rotation's gated read, resolved at the durable
+/// The rejection arm of a rotation's gated read, recovered at the durable
 /// sequence floor.
 ///
 /// Adopting a scope root raises that name's sequence floor, so re-reading the
-/// **unchanged** record rejects as not-newer. The rotation reads in order to
-/// re-key, and a pass that aborts before publishing must be able to read again —
-/// otherwise one transient failure leaves the scope permanently unrotatable and
-/// the revoke can never complete. Only the exact floor recovers, through the
-/// adopter's equal-floor path; a strictly lower sequence stays a replay and
-/// every other rejection stays a fail-closed trust violation (rule 6).
+/// **unchanged** record rejects as not-newer — and a rotation reads in order to
+/// re-key, so a pass that aborts before publishing must be able to read again or
+/// the revoke can never complete. Only the exact floor recovers; a strictly
+/// lower sequence is a replay, and every other rejection stays a fail-closed
+/// trust violation (rule 6).
 async fn reread_at_floor<H: Http, F: FloorStore>(
     adopter: &RootAdopter<'_, H, F>,
     name: &IpnsName,
     record_bytes: &[u8],
-    rejection: &GateRejection,
+    reason: &RejectionReason,
 ) -> Result<GatedScopeRoot, ResolveFailure> {
     if !matches!(
-        rejection.reason,
+        reason,
         RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor
     ) {
         return Err(ResolveFailure::Rejected);
@@ -364,12 +369,11 @@ async fn reread_at_floor<H: Http, F: FloorStore>(
         .recover_own_scope_root(name, record_bytes)
         .await
         .map_err(|_| ResolveFailure::Unavailable)?
-        // The recovery is fail-open by contract; for the rotation an unproved
-        // record is the gate's original verdict, never an availability stall.
+        // The recovery is fail-open; the rotation keeps the gate's own verdict.
         .ok_or(ResolveFailure::Rejected)?;
     Ok(GatedScopeRoot {
-        envelope: recovered.candidate.envelope,
-        section: recovered.candidate.grant_section,
+        envelope: recovered.envelope,
+        section: recovered.grant_section,
         read_body: recovered.read_body,
         read_scope_seed: recovered.read_scope_seed,
         write_scope_seed: recovered.write_scope_seed,
@@ -385,9 +389,8 @@ where
     /// under `scope_id` — the caller's own trusted label, imposed on the gate so
     /// a record claiming another scope is a transplant it rejects
     /// ([`ChildIndexResolver::direct_child_index`]'s binding obligation).
-    ///
-    /// Idempotent: a record already at this name's sequence floor re-reads
-    /// through [`reread_at_floor`] rather than rejecting.
+    /// Idempotent: a record at this name's own sequence floor recovers through
+    /// [`reread_at_floor`].
     async fn gated_root(
         &self,
         scope_id: [u8; 16],
@@ -417,7 +420,7 @@ where
             }),
             Err(GateError::Seam(_)) => Err(ResolveFailure::Unavailable),
             Err(GateError::Rejected(rejection)) => {
-                reread_at_floor(&adopter, name, &record_bytes, &rejection).await
+                reread_at_floor(&adopter, name, &record_bytes, &rejection.reason).await
             }
         }
     }
@@ -495,8 +498,8 @@ where
     ///   owner-write-blob's AAD binds — below it the root publishes write-plane
     ///   dead, and floors are monotonic, so it can never be rotated back.
     ///
-    /// Runs **after** this pass's gated read of the scope root, whose adoption
-    /// advances the read-epoch floor: measured before it, the floor comparison
+    /// Runs **after** this pass's gated read of the scope root, which may itself
+    /// advance the read-epoch floor: measured before it, the floor comparison
     /// would miss a cut minted below the epoch that read just adopted.
     async fn check_publishable(
         &self,
@@ -931,13 +934,23 @@ mod tests {
         }
 
         /// The wiring rooted at the vault root, whose own record carries no
-        /// ascent link — the ancestry the walk extends from.
-        fn net(&self, root_child_index: &[ChildScopeRef]) -> Net<'_, T> {
+        /// ascent link — the ancestry the walk extends from. `ascent_seed` is
+        /// the seed the descendants' **published** records sealed their ascent
+        /// links under ([`RotationAncestry::rooted_at`]).
+        fn net_under(
+            &self,
+            ascent_seed: &[u8; 32],
+            root_child_index: &[ChildScopeRef],
+        ) -> Net<'_, T> {
             self.net_rooted(RotationAncestry::rooted_at(
                 SCOPE,
-                &OWNER_ROOT_SCOPE_SEED,
+                ascent_seed,
                 root_child_index,
             ))
+        }
+
+        fn net(&self, root_child_index: &[ChildScopeRef]) -> Net<'_, T> {
+            self.net_under(&OWNER_ROOT_SCOPE_SEED, root_child_index)
         }
 
         fn net_rooted(&self, ancestry: RotationAncestry) -> Net<'_, T> {
@@ -1746,6 +1759,57 @@ mod tests {
         assert!(ct_eq(&again.write_scope_seed, &first.write_scope_seed));
     }
 
+    /// The equal-floor re-read is no way around the ascent link: a reader that
+    /// cannot place the descendant under its parent stays rejected even once the
+    /// record sits at its own sequence floor. The gate reaches the ascent link
+    /// (stage 3) before the sequence floor (stage 4), so the re-read never sees
+    /// a `SequenceNotNewer` verdict to recover from.
+    #[test]
+    fn a_scope_root_at_the_floor_off_the_ancestry_is_still_rejected() {
+        let (_, child, child_ref) = owner_tree();
+        let harness = Harness::plain();
+        harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
+        let index = vec![child_ref.clone()];
+
+        block_on(harness.net(&index).resolve(&child_ref)).expect("the first read raises the floor");
+        assert_eq!(
+            block_on(
+                harness
+                    .net_rooted(RotationAncestry::default())
+                    .resolve(&child_ref)
+            )
+            .err(),
+            Some(ResolveFailure::Rejected),
+        );
+    }
+
+    /// The ancestry seed is what the descendants' **published** ascent links
+    /// were sealed under, never the rotating root's post-cut seed — the trap a
+    /// retry that reused the plan's own `current_override_seed` would fall into,
+    /// which would fail closed at the gate and strand the descendant again.
+    #[test]
+    fn a_descendant_gated_under_the_post_cut_root_seed_is_rejected() {
+        let (_, child, child_ref) = owner_tree();
+        let harness = Harness::plain();
+        harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
+        let index = vec![child_ref.clone()];
+
+        assert_eq!(
+            block_on(harness.net_under(&[0xab; 32], &index).resolve(&child_ref)).err(),
+            Some(ResolveFailure::Rejected),
+            "a post-cut root seed derives the wrong ascent authority",
+        );
+        assert!(
+            block_on(
+                harness
+                    .net_under(&OWNER_ROOT_SCOPE_SEED, &index)
+                    .resolve(&child_ref)
+            )
+            .is_ok(),
+            "the seed its published ascent link was sealed under still gates it",
+        );
+    }
+
     /// A record strictly **below** the durable sequence floor is a replay, not
     /// our own current record: the equal-floor re-read must not launder it into
     /// a rotatable target.
@@ -1863,10 +1927,16 @@ mod tests {
     /// publisher, rooted at `SCOPE`. The plan re-seals the root the harness
     /// staged, so its committed set and signer come off that fixture rather than
     /// being rebuilt beside it.
+    ///
+    /// `override_seed` is the root's own current seed the plan re-keys from;
+    /// `ascent_seed` is what the descendants' published ascent links were sealed
+    /// under. They diverge on a retry after the root's cut already landed — see
+    /// [`RotationAncestry::rooted_at`].
     fn cascade_pass<T>(
         harness: &Harness<T>,
         root: &OwnerRootFixture,
         override_seed: &[u8; 32],
+        ascent_seed: &[u8; 32],
         read_epoch: u64,
         index: &[ChildScopeRef],
         entropy_seed: u64,
@@ -1878,7 +1948,7 @@ mod tests {
         let owner_enc_pub = owner_enc().public();
         let pointer_read_key = OwnerSeeds.pointer_read_key(&SCOPE);
         let mut entropy = SeededEntropy::new(entropy_seed);
-        let net = harness.net(index);
+        let net = harness.net_under(ascent_seed, index);
         block_on(cascade_rotate_scope(
             &mut entropy,
             &harness.floors,
@@ -1927,6 +1997,7 @@ mod tests {
         let outcome = cascade_pass(
             &harness,
             &root,
+            &OWNER_ROOT_SCOPE_SEED,
             &OWNER_ROOT_SCOPE_SEED,
             OWNER_ROOT_EPOCH,
             &index,
@@ -2008,6 +2079,7 @@ mod tests {
             &harness,
             &root,
             &OWNER_ROOT_SCOPE_SEED,
+            &OWNER_ROOT_SCOPE_SEED,
             OWNER_ROOT_EPOCH,
             &index,
             41,
@@ -2021,12 +2093,15 @@ mod tests {
 
         // The retry rebuilds the plan from current state, as the module contract
         // requires: the root already advanced to its own fresh seed and epoch.
+        // The ancestry stays on the PRE-cut seed — the descendant never
+        // republished, so its ascent link still carries that derivation.
         *refusing.lock().expect("lock") = false;
         let root_fresh = published_override_seed(&harness, &root.name, SCOPE, OWNER_ROOT_EPOCH + 1);
         let outcome = cascade_pass(
             &harness,
             &root,
             &root_fresh,
+            &OWNER_ROOT_SCOPE_SEED,
             OWNER_ROOT_EPOCH + 1,
             &index,
             43,
@@ -2059,6 +2134,7 @@ mod tests {
         let outcome = cascade_pass(
             &harness,
             &root,
+            &OWNER_ROOT_SCOPE_SEED,
             &OWNER_ROOT_SCOPE_SEED,
             OWNER_ROOT_EPOCH,
             &index,

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -1000,56 +1000,6 @@ mod tests {
         }
     }
 
-    impl Harness<FlakyPut> {
-        fn flaky(key: &str, refusing: &Arc<Mutex<bool>>) -> Self {
-            let key = key.to_owned();
-            let refusing = Arc::clone(refusing);
-            Self::build(move |store| FlakyPut {
-                inner: store,
-                key,
-                refusing,
-            })
-        }
-    }
-
-    /// A transport whose PUTs at one name fail while `refusing` is set — the
-    /// transient publish failure a cascade retry has to survive.
-    #[derive(Clone)]
-    struct FlakyPut {
-        inner: InMemoryRecordStore,
-        key: String,
-        refusing: Arc<Mutex<bool>>,
-    }
-
-    impl RecordTransport for FlakyPut {
-        fn endpoints(&self) -> Vec<EndpointId> {
-            self.inner.endpoints()
-        }
-
-        async fn get_record(
-            &self,
-            endpoint: &EndpointId,
-            routing_key: &str,
-            max_bytes: usize,
-        ) -> SeamResult<Option<Vec<u8>>> {
-            self.inner
-                .get_record(endpoint, routing_key, max_bytes)
-                .await
-        }
-
-        async fn put_record(
-            &self,
-            endpoint: &EndpointId,
-            routing_key: &str,
-            record: &[u8],
-        ) -> SeamResult<()> {
-            if routing_key == self.key && *self.refusing.lock().expect("lock") {
-                return Err(SeamError::new("endpoint down"));
-            }
-            self.inner.put_record(endpoint, routing_key, record).await
-        }
-    }
-
     /// The concurrent writer's record, keyed by the name it lands at.
     type Winner = Arc<Mutex<Option<(String, Vec<u8>)>>>;
 
@@ -2069,8 +2019,8 @@ mod tests {
     #[test]
     fn a_cascade_that_aborts_after_resolving_a_descendant_completes_on_retry() {
         let (root, child, child_ref) = owner_tree();
-        let refusing = Arc::new(Mutex::new(true));
-        let harness = Harness::flaky(child.name.as_str(), &refusing);
+        let harness = Harness::plain();
+        harness.store.fail_put_for(child.name.as_str());
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
         harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
         let index = vec![child_ref];
@@ -2095,7 +2045,7 @@ mod tests {
         // requires: the root already advanced to its own fresh seed and epoch.
         // The ancestry stays on the PRE-cut seed — the descendant never
         // republished, so its ascent link still carries that derivation.
-        *refusing.lock().expect("lock") = false;
+        harness.store.heal_put_for(child.name.as_str());
         let root_fresh = published_override_seed(&harness, &root.name, SCOPE, OWNER_ROOT_EPOCH + 1);
         let outcome = cascade_pass(
             &harness,

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -35,7 +35,7 @@ use super::record_publish::{HeadBinding, RecordPublishRequest, preflight, publis
 use crate::api::ApiClient;
 use crate::content::Gateway;
 use crate::entropy::Entropy;
-use crate::gate::{GateError, floor};
+use crate::gate::{GateError, GateRejection, RejectionReason, floor};
 use crate::net::fanout_get_verify;
 use crate::profile::SyncTimingProfile;
 use crate::rotation::{
@@ -104,13 +104,11 @@ pub struct OwnerRotationNet<'a, T, H: Http, C: CredentialStore, F, Sch, E> {
 
 /// The one scope root this pass gated and has not yet republished.
 ///
-/// Adoption advances the durable **sequence** floor, so a second read of the
-/// same record rejects as not-newer (`gate/adoption.rs` stage 4). A cascade
-/// resolves a descendant and then immediately publishes its re-key, which would
-/// be two reads of one record — so the resolve parks what the publish needs and
-/// the publish takes it. One slot, because that hand-off is the only contract:
-/// a second park evicts the first rather than retaining every descendant's
-/// record for the length of the walk.
+/// A cascade resolves a descendant and then immediately publishes its re-key,
+/// which would otherwise fetch and gate the same record twice — so the resolve
+/// parks what the publish needs and the publish takes it. One slot, because
+/// that hand-off is the only contract: a second park evicts the first rather
+/// than retaining every descendant's record for the length of the walk.
 #[derive(Default)]
 pub struct GatedRoots {
     inner: RefCell<Option<(IpnsName, RepublishBase)>>,
@@ -340,16 +338,56 @@ fn nonce<E: Entropy>(entropy: &RefCell<E>) -> Result<[u8; 24], ScopeRootPublishE
     Ok(nonce)
 }
 
+/// The rejection arm of a rotation's gated read, resolved at the durable
+/// sequence floor.
+///
+/// Adopting a scope root raises that name's sequence floor, so re-reading the
+/// **unchanged** record rejects as not-newer. The rotation reads in order to
+/// re-key, and a pass that aborts before publishing must be able to read again —
+/// otherwise one transient failure leaves the scope permanently unrotatable and
+/// the revoke can never complete. Only the exact floor recovers, through the
+/// adopter's equal-floor path; a strictly lower sequence stays a replay and
+/// every other rejection stays a fail-closed trust violation (rule 6).
+async fn reread_at_floor<H: Http, F: FloorStore>(
+    adopter: &RootAdopter<'_, H, F>,
+    name: &IpnsName,
+    record_bytes: &[u8],
+    rejection: &GateRejection,
+) -> Result<GatedScopeRoot, ResolveFailure> {
+    if !matches!(
+        rejection.reason,
+        RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor
+    ) {
+        return Err(ResolveFailure::Rejected);
+    }
+    let recovered = adopter
+        .recover_own_scope_root(name, record_bytes)
+        .await
+        .map_err(|_| ResolveFailure::Unavailable)?
+        // The recovery is fail-open by contract; for the rotation an unproved
+        // record is the gate's original verdict, never an availability stall.
+        .ok_or(ResolveFailure::Rejected)?;
+    Ok(GatedScopeRoot {
+        envelope: recovered.candidate.envelope,
+        section: recovered.candidate.grant_section,
+        read_body: recovered.read_body,
+        read_scope_seed: recovered.read_scope_seed,
+        write_scope_seed: recovered.write_scope_seed,
+    })
+}
+
 impl<T, H: Http, C: CredentialStore, F, Sch, E> OwnerRotationNet<'_, T, H, C, F, Sch, E>
 where
     T: RecordTransport,
     F: FloorStore,
 {
-    /// The root this pass already gated ([`GatedRoots`]), else the freshest
-    /// verified record at `name` run through the adoption gate under
-    /// `scope_id` — the caller's own trusted label, imposed
-    /// on the gate so a record claiming another scope is a transplant it
-    /// rejects ([`ChildIndexResolver::direct_child_index`]'s binding obligation).
+    /// The freshest verified record at `name` run through the adoption gate
+    /// under `scope_id` — the caller's own trusted label, imposed on the gate so
+    /// a record claiming another scope is a transplant it rejects
+    /// ([`ChildIndexResolver::direct_child_index`]'s binding obligation).
+    ///
+    /// Idempotent: a record already at this name's sequence floor re-reads
+    /// through [`reread_at_floor`] rather than rejecting.
     async fn gated_root(
         &self,
         scope_id: [u8; 16],
@@ -369,22 +407,19 @@ where
         if let Some(seed) = self.ancestry.parent_node_seed(&scope_id) {
             adopter = adopter.under_parent_node_seed(seed);
         }
-        let (candidate, outcome) =
-            adopter
-                .adopt_root(name, &record_bytes)
-                .await
-                .map_err(|error| match error {
-                    GateError::Rejected(_) => ResolveFailure::Rejected,
-                    GateError::Seam(_) => ResolveFailure::Unavailable,
-                })?;
-        let read_scope_seed = outcome.read_scope_seed.ok_or(ResolveFailure::Unavailable)?;
-        Ok(GatedScopeRoot {
-            envelope: candidate.envelope,
-            section: candidate.grant_section,
-            read_body: outcome.adopted.read_body,
-            read_scope_seed,
-            write_scope_seed: outcome.write_scope_seed,
-        })
+        match adopter.adopt_root(name, &record_bytes).await {
+            Ok((candidate, outcome)) => Ok(GatedScopeRoot {
+                envelope: candidate.envelope,
+                section: candidate.grant_section,
+                read_body: outcome.adopted.read_body,
+                read_scope_seed: outcome.read_scope_seed.ok_or(ResolveFailure::Unavailable)?,
+                write_scope_seed: outcome.write_scope_seed,
+            }),
+            Err(GateError::Seam(_)) => Err(ResolveFailure::Unavailable),
+            Err(GateError::Rejected(rejection)) => {
+                reread_at_floor(&adopter, name, &record_bytes, &rejection).await
+            }
+        }
     }
 
     /// Unseal a gated scope root's write-body under the owner's recovered write
@@ -667,8 +702,9 @@ mod tests {
     use super::*;
     use crate::content::GatewaySource;
     use crate::rotation::{
-        CommittedSet, PrevEpochSeed, ResealSeeds, RotateScopePlan, ScopeRootIdentity,
-        cascade_rotate_scope, enumerate_eager_set, reseal_scope_root, rotate_scope,
+        CascadeError, CascadeOutcome, CommittedSet, PrevEpochSeed, ResealSeeds, RotateScopePlan,
+        ScopeRootIdentity, cascade_rotate_scope, enumerate_eager_set, reseal_scope_root,
+        rotate_scope,
     };
     use crate::seams::{EndpointId, HttpResponse, SeamError, SeamResult};
     use crate::testkit::fakes::{
@@ -778,7 +814,7 @@ mod tests {
     /// answer from `blocks`, `/content/upload` files the bytes under the CID the
     /// caller declared, and the registry acks.
     fn serve_plane(http: &ScriptedHttp, blocks: &Blocks) {
-        for _ in 0..64 {
+        for _ in 0..256 {
             let blocks = Arc::clone(blocks);
             http.enqueue_derived(move |request| {
                 if request.url.contains("/content/upload") {
@@ -948,6 +984,56 @@ mod tests {
                 inner: store,
                 winner: Arc::new(Mutex::new(Some((key, winner)))),
             })
+        }
+    }
+
+    impl Harness<FlakyPut> {
+        fn flaky(key: &str, refusing: &Arc<Mutex<bool>>) -> Self {
+            let key = key.to_owned();
+            let refusing = Arc::clone(refusing);
+            Self::build(move |store| FlakyPut {
+                inner: store,
+                key,
+                refusing,
+            })
+        }
+    }
+
+    /// A transport whose PUTs at one name fail while `refusing` is set — the
+    /// transient publish failure a cascade retry has to survive.
+    #[derive(Clone)]
+    struct FlakyPut {
+        inner: InMemoryRecordStore,
+        key: String,
+        refusing: Arc<Mutex<bool>>,
+    }
+
+    impl RecordTransport for FlakyPut {
+        fn endpoints(&self) -> Vec<EndpointId> {
+            self.inner.endpoints()
+        }
+
+        async fn get_record(
+            &self,
+            endpoint: &EndpointId,
+            routing_key: &str,
+            max_bytes: usize,
+        ) -> SeamResult<Option<Vec<u8>>> {
+            self.inner
+                .get_record(endpoint, routing_key, max_bytes)
+                .await
+        }
+
+        async fn put_record(
+            &self,
+            endpoint: &EndpointId,
+            routing_key: &str,
+            record: &[u8],
+        ) -> SeamResult<()> {
+            if routing_key == self.key && *self.refusing.lock().expect("lock") {
+                return Err(SeamError::new("endpoint down"));
+            }
+            self.inner.put_record(endpoint, routing_key, record).await
         }
     }
 
@@ -1635,21 +1721,53 @@ mod tests {
         );
     }
 
-    /// What [`GatedRoots`] exists for: discard the parked read and the record
-    /// the pass already adopted is unreadable.
+    /// The rotation's gated read is idempotent. Adopting the record raised this
+    /// name's sequence floor, so without the equal-floor re-read a second pass
+    /// over the unchanged record would reject it — and the scope could never be
+    /// re-keyed again.
     #[test]
-    fn a_scope_root_this_pass_already_adopted_cannot_be_read_again() {
+    fn a_scope_root_this_pass_already_adopted_re_reads_at_the_sequence_floor() {
         let (_, child, child_ref) = owner_tree();
         let harness = Harness::plain();
         harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
         let net = harness.net(core::slice::from_ref(&child_ref));
 
-        block_on(net.resolve(&child_ref)).expect("the first read");
+        let first = block_on(net.resolve(&child_ref)).expect("the first read");
         net.gated
             .take(&child.name)
             .expect("the resolve parked its gated read for the publish");
+
+        let again = block_on(net.resolve(&child_ref)).expect("the unchanged record re-reads");
+        assert_eq!(again.current_read_epoch, first.current_read_epoch);
+        assert!(
+            ct_eq(&again.override_seed, &first.override_seed),
+            "the re-read recovers the same read seed the adopt did",
+        );
+        assert!(ct_eq(&again.write_scope_seed, &first.write_scope_seed));
+    }
+
+    /// A record strictly **below** the durable sequence floor is a replay, not
+    /// our own current record: the equal-floor re-read must not launder it into
+    /// a rotatable target.
+    #[test]
+    fn a_scope_root_below_the_sequence_floor_stays_a_fail_closed_rejection() {
+        let (_, child, child_ref) = owner_tree();
+        let harness = Harness::plain();
+        harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
+        block_on(floor::advance_sequence_on_unseal(
+            &harness.floors,
+            child.name.as_str().as_bytes(),
+            9,
+        ))
+        .expect("raise the sequence floor above the staged record");
+
         assert_eq!(
-            block_on(net.resolve(&child_ref)).err(),
+            block_on(
+                harness
+                    .net(core::slice::from_ref(&child_ref))
+                    .resolve(&child_ref)
+            )
+            .err(),
             Some(ResolveFailure::Rejected),
         );
     }
@@ -1741,27 +1859,27 @@ mod tests {
         );
     }
 
-    /// The whole owner-revocation cascade over the production resolver and
-    /// publisher: both levels re-keyed with **fresh** seeds, and the descendant's
-    /// ascent link re-sealed under the root's newly minted derivation — the
-    /// top-down thread that actually locks a revoked reader out.
-    #[test]
-    fn the_cascade_composes_over_the_production_resolver_and_publisher() {
-        let (root, child, child_ref) = owner_tree();
-        let harness = Harness::plain();
-        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
-        harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
-
-        // The plan re-seals the root the harness staged, so its committed set and
-        // signer come off that fixture rather than being rebuilt beside it.
+    /// One owner-revocation cascade pass over the production resolver and
+    /// publisher, rooted at `SCOPE`. The plan re-seals the root the harness
+    /// staged, so its committed set and signer come off that fixture rather than
+    /// being rebuilt beside it.
+    fn cascade_pass<T>(
+        harness: &Harness<T>,
+        root: &OwnerRootFixture,
+        override_seed: &[u8; 32],
+        read_epoch: u64,
+        index: &[ChildScopeRef],
+        entropy_seed: u64,
+    ) -> Result<CascadeOutcome, CascadeError>
+    where
+        T: RecordTransport + Clone + 'static,
+    {
         let pseudonym = OwnerSeeds.writer_pseudonym(&SCOPE);
         let owner_enc_pub = owner_enc().public();
         let pointer_read_key = OwnerSeeds.pointer_read_key(&SCOPE);
-        let index = vec![child_ref.clone()];
-        let mut entropy = SeededEntropy::new(41);
-        let net = harness.net(&index);
-
-        let outcome = block_on(cascade_rotate_scope(
+        let mut entropy = SeededEntropy::new(entropy_seed);
+        let net = harness.net(index);
+        block_on(cascade_rotate_scope(
             &mut entropy,
             &harness.floors,
             &harness.world.scheduler,
@@ -1781,10 +1899,10 @@ mod tests {
                     commitment_sig: &root.grant_section.commitment_sig,
                     grant_ledger: &[],
                     write_history_link: &[],
-                    direct_child_scope_index: &index,
+                    direct_child_scope_index: index,
                 },
-                current_override_seed: &OWNER_ROOT_SCOPE_SEED,
-                current_read_epoch: OWNER_ROOT_EPOCH,
+                current_override_seed: override_seed,
+                current_read_epoch: read_epoch,
                 write_scope_seed: &OWNER_ROOT_WRITE_SCOPE_SEED,
                 write_epoch: OWNER_ROOT_EPOCH,
                 pointer_read_key: &pointer_read_key,
@@ -1792,6 +1910,28 @@ mod tests {
             },
             || Box::pin(async {}),
         ))
+    }
+
+    /// The whole owner-revocation cascade over the production resolver and
+    /// publisher: both levels re-keyed with **fresh** seeds, and the descendant's
+    /// ascent link re-sealed under the root's newly minted derivation — the
+    /// top-down thread that actually locks a revoked reader out.
+    #[test]
+    fn the_cascade_composes_over_the_production_resolver_and_publisher() {
+        let (root, child, child_ref) = owner_tree();
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
+        let index = vec![child_ref];
+
+        let outcome = cascade_pass(
+            &harness,
+            &root,
+            &OWNER_ROOT_SCOPE_SEED,
+            OWNER_ROOT_EPOCH,
+            &index,
+            41,
+        )
         .expect("the cascade completes");
 
         assert_eq!(
@@ -1848,6 +1988,84 @@ mod tests {
             open_ascent_link(&stale_parent_seed, &ctx, &link).is_err(),
             "the pre-cascade derivation no longer opens it — the revocation",
         );
+    }
+
+    /// The cascade's own retry contract, end to end: a descendant whose publish
+    /// never lands leaves it resolved-but-unpublished, and the retry has to read
+    /// it again. Without the equal-floor re-read the second pass rejected the
+    /// unchanged record — a retryable abort that could never succeed, leaving
+    /// the revoked reader in that subtree for good.
+    #[test]
+    fn a_cascade_that_aborts_after_resolving_a_descendant_completes_on_retry() {
+        let (root, child, child_ref) = owner_tree();
+        let refusing = Arc::new(Mutex::new(true));
+        let harness = Harness::flaky(child.name.as_str(), &refusing);
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
+        let index = vec![child_ref];
+
+        let aborted = cascade_pass(
+            &harness,
+            &root,
+            &OWNER_ROOT_SCOPE_SEED,
+            OWNER_ROOT_EPOCH,
+            &index,
+            41,
+        )
+        .expect_err("the descendant's record never lands");
+        assert_eq!(aborted.scope_id(), CHILD_SCOPE);
+        assert!(
+            aborted.is_retryable(),
+            "a PUT no endpoint took is availability, not a trust verdict",
+        );
+
+        // The retry rebuilds the plan from current state, as the module contract
+        // requires: the root already advanced to its own fresh seed and epoch.
+        *refusing.lock().expect("lock") = false;
+        let root_fresh = published_override_seed(&harness, &root.name, SCOPE, OWNER_ROOT_EPOCH + 1);
+        let outcome = cascade_pass(
+            &harness,
+            &root,
+            &root_fresh,
+            OWNER_ROOT_EPOCH + 1,
+            &index,
+            43,
+        )
+        .expect("the retry completes");
+
+        assert_eq!(outcome.descendant_count(), 1);
+        let child_fresh =
+            published_override_seed(&harness, &child.name, CHILD_SCOPE, OWNER_ROOT_EPOCH + 1);
+        assert!(
+            !ct_eq(&child_fresh, &OWNER_ROOT_SCOPE_SEED),
+            "the descendant was re-keyed on the retry, not left on its cached seed",
+        );
+    }
+
+    /// Enumerating the eager set adopts every descendant record and publishes
+    /// none of them, so the cascade that follows re-reads each at its own
+    /// sequence floor.
+    #[test]
+    fn a_cascade_after_an_eager_set_enumeration_still_completes() {
+        let (root, child, child_ref) = owner_tree();
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        harness.stage(CHILD_SCOPE, &child, Some(OWNER_ROOT_EPOCH));
+        let index = vec![child_ref];
+
+        block_on(enumerate_eager_set(SCOPE, &index, &harness.net(&index)))
+            .expect("every reachable descendant resolved");
+
+        let outcome = cascade_pass(
+            &harness,
+            &root,
+            &OWNER_ROOT_SCOPE_SEED,
+            OWNER_ROOT_EPOCH,
+            &index,
+            41,
+        )
+        .expect("the cascade still completes over already-adopted descendants");
+        assert_eq!(outcome.descendant_count(), 1);
     }
 
     /// The verified record now standing at `name` and the head envelope it


### PR DESCRIPTION
## The defect

`OwnerRotationNet::gated_root` runs `RootAdopter::adopt_root`, whose gate pass commits the floor law — raising the per-name **sequence** floor to the record's sequence. `floor::check` runs at `Strictness::StrictlyNewer`, so any later read of that same, unchanged record returns `SequenceNotNewer` → `GateError::Rejected` → `ResolveFailure::Rejected`, which `CascadeError::is_retryable` correctly reports as fatal.

A cascade that resolved a descendant and then aborted before publishing it therefore stranded that descendant permanently: nothing else publishes at its name, so the floor never moves and the scope can never be re-resolved. Since the fresh-seed cascade is the only thing that completes an owner read-revocation, one transient mid-cascade failure converted into a permanent revocation hole — a revoked reader kept access to that subtree for good. The same shape hit `enumerate_eager_set`, which adopts every descendant record and publishes none, so a cascade run after an enumeration was dead on arrival.

Mechanism verified against the code at `3d087d673`; all three headline tests fail against the pre-fix behaviour and pass after.

## The fix

Route exactly one rejection — `SequenceNotNewer { floor, sequence }` where `sequence == floor`, i.e. our own current record re-read — through the adopter's pre-existing equal-floor recovery, the same path `net/resolve.rs` already uses for `ResolveOutcome::Current`. `recover_own_scope_material` is widened into `recover_own_scope_root`, which also surfaces the envelope, grant section, and the read body it was already unsealing and discarding; the old method projects down to `OwnScopeMaterial`.

Nothing about the gate is weakened:

- The recovery is reachable only from a candidate the failed `adopt` cached, and `adopt_root` now caches **only on a sequence-stage verdict** — the one rejection reached with stages 1-3 already passed (record verify, owner-signed commitment and its `ipnsName` binding, every grant-section structure signature, and the ascent-link derive-and-verify against the reader's own ancestor seed).
- It runs `floor::check` at `Strictness::AtFloor` itself, so the equal-floor precondition is enforced locally rather than inherited from the caller, and the read-epoch (revocation) floor is re-imposed in the same call.
- It re-imposes stage 6's reader-scope binding and re-runs the unseal: the seed recovered from the owner blob must derive the key this record's own body opens under.
- A sequence strictly **below** the floor is still a replay and still `Rejected`. Every other gate rejection is untouched — notably an ascent-link failure, which the gate reaches at stage 3, before any sequence verdict exists to recover from.
- The recovery is fail-open by contract (`Ok(None)`); the rotation maps that back to the gate's original `Rejected`, so an unproved record never becomes an availability stall (rule 6) and a genuine rejection still names the offending scope.

Both arms leave the durable sequence floor equal to the observed record sequence, so `publish` still mints `floor + 1` and the CAS slot is unchanged — no `min_current_sequence` plumbing is needed.

### Why option 2, not the issue's preferred option 1

1. **It is weaker.** Leaving the floor un-advanced after a read that cryptographically proved a record at sequence *S* means a later resolve of a replayed record at *S-1* — a real, owner-signed, previously-published record — would pass stage 4. The equal-floor recovery keeps the floor advanced and opens no such rollback window.
2. **It is not implementable inside this PR's file ownership.** `gate::adopt_deferred` returns a `PendingAdoption` whose `Adopted` (and so the read body the rotation must republish) is private and reachable only via `commit` — the very floor advance option 1 tries to skip. Exposing it means editing `crates/engine/src/gate/adoption.rs`, which belongs to a sibling PR this wave.

## Where the issue body is wrong

- **`CascadeError::Floor` does not brick anything.** The issue lists a `Floor` seam error alongside `NotPublished` and an entropy hiccup as a path into the trap. It is not one: `rekey_one` raises the floor strictly *after* a confirmed publish, so on retry the record at that name is the newly published one at a strictly higher sequence and adopts normally. Only aborts before the publish lands reach the equal-floor case.
- **"reports a retryable error that can never succeed"** contradicts the issue's own earlier, correct statement. The second attempt reports `CascadeError::Resolve { Rejected }`, which `is_retryable()` reports as **fatal**. The symptom is a hard permanent failure naming the descendant, not an infinite retry.
- **`RecordPublishRequest.min_current_sequence` is not load-bearing** under this fix, though the issue presents it as central to the preferred option.

## Review gates

`/simplify`, `/security-review`, and `/crypto-privacy-review` all run; findings folded into the second commit.

**Applied**

- Carry only the two record fields the callers use rather than a whole `Candidate`; narrow `reread_at_floor` to the rejection reason. (simplify)
- Gate the candidate cache on `GateStage::Sequence`. Both reviewers independently found that `adopt_root` cached on *any* gate error, so the recovery's "stages 1-3 authenticated this section" claim held only because both call sites happened to filter on `SequenceNotNewer` — a third caller would have handed out the scope override seed for a record that never cleared commitment verify. Now structural. (security M1 / crypto MEDIUM 1)
- Run `floor::check(.., AtFloor)` inside the recovery instead of trusting the caller, subsuming the open-coded read-epoch floor read. (both)
- Restate `check_publishable`'s ordering rationale, which claimed the gated read always advances the read-epoch floor — untrue on the recovery arm. (both, LOW)
- Document the **ancestry-seed invariant** on `RotationAncestry::rooted_at`: the seed a walk gates descendants under is the one their *published* ascent links were sealed under, which after a root cut is no longer the plan's `current_override_seed`. The cascade harness now passes it explicitly rather than reading a module constant, and two negatives pin it. (crypto HIGH — see below)

**Considered and deliberately not applied**

- *Pin the equal-floor arm to record identity, not sequence* (crypto MEDIUM 2). The concern is real — `sequence == floor` admits any record at that sequence, and the rotation now re-seals and signs the recovered `read_body`. But the suggested mitigation (require the bytes to equal a cached last-known-good) reintroduces the exact bug this PR fixes: a cold device has no cache, so the rotation would brick again. The residual exposure also is not new in class — a writer who can fork at the same sequence can already fork at a *higher* one, which the ordinary adopt arm takes; and a read revoke leaves the write plane unchanged by design. Left as-is.
- *Narrow `recover_write_scope_seed`'s return type to drop a dead `Rejected` match arm* (security L2). Pre-existing and untouched by this diff; leaving it out of scope.
- *Zeroize move residue across the new struct boundary* (crypto LOW). Inherent to a `Zeroizing` move in Rust and identical to the pre-existing `adopt_root` → `AdoptOutcome` path; the reviewer explicitly did not recommend a change.

### Note for the wiring PRs

The crypto review's HIGH is a hazard for **un-landed wiring**, not a defect in this diff: `OwnerRotationNet` has no production constructor yet. The trap is that the obvious wiring, `RotationAncestry::rooted_at(scope_id, plan.current_override_seed, ..)`, is correct for a *first* cascade pass (the two seeds coincide) and silently wrong on a *retry* after the root's cut landed — descendants that never republished still carry ascent links under the pre-cut derivation, so gating them under the fresh seed fails closed at stage 3 and strands them exactly as before. That is now documented on `rooted_at` and pinned by `a_descendant_gated_under_the_post_cut_root_seed_is_rejected`.

## Tests

Red before, green after:

- `a_scope_root_this_pass_already_adopted_re_reads_at_the_sequence_floor` — replaces the test that asserted the defect as intended behaviour; the re-read recovers the same read and write seeds.
- `a_cascade_that_aborts_after_resolving_a_descendant_completes_on_retry` — a `FlakyPut` transport refuses PUTs at the descendant's name, the cascade aborts retryably naming that scope, and a second pass completes and re-keys the descendant to a fresh seed.
- `a_cascade_after_an_eager_set_enumeration_still_completes` — the issue's second gate criterion.
- `equal_floor_recovery_refuses_a_record_below_the_sequence_floor` and `a_pre_floor_rejection_caches_no_candidate_for_the_recovery` — red without the two hardenings above.

Green both before and after, guarding the fail-closed arms: `a_scope_root_below_the_sequence_floor_stays_a_fail_closed_rejection`, `a_scope_root_at_the_floor_off_the_ancestry_is_still_rejected`, `a_descendant_gated_under_the_post_cut_root_seed_is_rejected`, `recovery_returns_the_read_body_the_gate_would_have_unsealed`.

Local gates, all on the committed tree with a clean `git status` before and after: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets`, `cargo test --workspace`, `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown`, `node scripts/check-tracker-refs.mjs`.

## Deliberately not done

- **`GatedRoots` is kept.** With the read idempotent the hand-off is no longer load-bearing — the publish's fallback re-read now works where it previously always failed — but it still halves the record-plane round trips in a cascade over a deep tree, so removing it would be a performance regression rather than a simplification. Its doc no longer claims a second read is impossible.
- `crates/engine/src/gate/floor.rs` and `crates/engine/src/rotation/cascade.rs` are unchanged: `Strictness::AtFloor` already expressed exactly the comparison this needs, and the cascade's module-doc promise ("the retry re-resolves current state and rebuilds the plan") is now simply true.

Closes #1054


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make rotation gated read idempotent at the sequence floor
> - Adds `reread_at_floor` helper in [rotation.rs](https://github.com/FSM1/cipher-box/pull/1104/files#diff-d37e98e69d8d281a4e324a10d5954a5e73147013e3aa1330558044fce6b7773d) that recovers a `GatedScopeRoot` when a `SequenceNotNewer` rejection occurs at exactly the durable sequence floor, avoiding spurious re-adoption.
> - Adds `recover_own_scope_root` method in [adopter.rs](https://github.com/FSM1/cipher-box/pull/1104/files#diff-332408a918ac0f6527e3cb302aeb684c7c3bb5e4cb49d9ea4162068a5f9e84e8) that re-verifies and re-unseals the owner's own scope root record only when it sits exactly at the floor, returning envelope, grant section, read body, and seeds.
> - Fixes `adopt_root` to cache the assembled candidate only on sequence-stage rejections; pre-sequence rejections no longer pollute the recovery cache.
> - Behavioral Change: gated reads that previously failed with a rejection at the sequence floor now succeed via recovery instead of returning an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55acee0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of scope data, including read access information and associated credentials.
  * Strengthened validation of sequence ordering, read-epoch requirements, scope binding, and replay protection.
  * Improved rotation handling for records at the current sequence boundary.
  * Preserved safe failure behavior for replayed or untrusted records.

* **Reliability**
  * Improved retry behavior for interrupted rotation operations.
  * Added support for consistent rereads and more reliable enumeration of available entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->