### PR TITLE
fix(ci): pin the staging host key on every deploy SSH connection

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -20,16 +20,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # appleboy's actions skip host-key verification when `fingerprint` is empty,
-      # so an unset variable would silently restore the trust-on-first-use hole.
+      # appleboy's actions skip host-key verification entirely when `fingerprint`
+      # is empty, so a missing or malformed value must fail the job here rather
+      # than open an unverified connection.
       - name: Require a pinned host key
         env:
           SSH_HOST_FINGERPRINT: ${{ vars.SSH_HOST_FINGERPRINT }}
         run: |
-          if [ -z "$SSH_HOST_FINGERPRINT" ]; then
-            echo '::error::the staging environment needs the SSH_HOST_FINGERPRINT variable (ssh-keyscan -t ed25519 HOST | ssh-keygen -lf -)'
-            exit 1
-          fi
+          case "$SSH_HOST_FINGERPRINT" in
+            SHA256:?*) ;;
+            *)
+              echo "::error::the staging environment needs SSH_HOST_FINGERPRINT set to the host key's SHA256 fingerprint: ssh-keyscan HOST | ssh-keygen -lf - | cut -d' ' -f2"
+              exit 1
+              ;;
+          esac
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -20,6 +20,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # appleboy's actions skip host-key verification when `fingerprint` is empty,
+      # so an unset variable would silently restore the trust-on-first-use hole.
+      - name: Require a pinned host key
+        env:
+          SSH_HOST_FINGERPRINT: ${{ vars.SSH_HOST_FINGERPRINT }}
+        run: |
+          if [ -z "$SSH_HOST_FINGERPRINT" ]; then
+            echo '::error::the staging environment needs the SSH_HOST_FINGERPRINT variable (ssh-keyscan -t ed25519 HOST | ssh-keygen -lf -)'
+            exit 1
+          fi
+
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -40,6 +51,7 @@ jobs:
           host: ${{ vars.HOST }}
           username: ${{ vars.USER }}
           key: ${{ secrets.SSH_KEY }}
+          fingerprint: ${{ vars.SSH_HOST_FINGERPRINT }}
           source: 'landing/dist/*'
           target: /tmp/cipherbox-landing
           strip_components: 2
@@ -51,6 +63,7 @@ jobs:
           host: ${{ vars.HOST }}
           username: ${{ vars.USER }}
           key: ${{ secrets.SSH_KEY }}
+          fingerprint: ${{ vars.SSH_HOST_FINGERPRINT }}
           capture_stdout: true
           script: |
             set -euo pipefail

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -389,16 +389,20 @@ jobs:
           name: web-dist
           path: web-dist/
 
-      # appleboy's actions skip host-key verification when `fingerprint` is empty,
-      # so an unset variable would silently restore the trust-on-first-use hole.
+      # appleboy's actions skip host-key verification entirely when `fingerprint`
+      # is empty, so a missing or malformed value must fail the job here rather
+      # than open an unverified connection.
       - name: Require a pinned host key
         env:
           SSH_HOST_FINGERPRINT: ${{ vars.SSH_HOST_FINGERPRINT }}
         run: |
-          if [ -z "$SSH_HOST_FINGERPRINT" ]; then
-            echo '::error::the staging environment needs the SSH_HOST_FINGERPRINT variable (ssh-keyscan -t ed25519 HOST | ssh-keygen -lf -)'
-            exit 1
-          fi
+          case "$SSH_HOST_FINGERPRINT" in
+            SHA256:?*) ;;
+            *)
+              echo "::error::the staging environment needs SSH_HOST_FINGERPRINT set to the host key's SHA256 fingerprint: ssh-keyscan HOST | ssh-keygen -lf - | cut -d' ' -f2"
+              exit 1
+              ;;
+          esac
 
       - name: Generate .env.staging
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -389,6 +389,17 @@ jobs:
           name: web-dist
           path: web-dist/
 
+      # appleboy's actions skip host-key verification when `fingerprint` is empty,
+      # so an unset variable would silently restore the trust-on-first-use hole.
+      - name: Require a pinned host key
+        env:
+          SSH_HOST_FINGERPRINT: ${{ vars.SSH_HOST_FINGERPRINT }}
+        run: |
+          if [ -z "$SSH_HOST_FINGERPRINT" ]; then
+            echo '::error::the staging environment needs the SSH_HOST_FINGERPRINT variable (ssh-keyscan -t ed25519 HOST | ssh-keygen -lf -)'
+            exit 1
+          fi
+
       - name: Generate .env.staging
         run: |
           cat > .env.staging << 'ENVEOF'
@@ -431,6 +442,7 @@ jobs:
           host: ${{ vars.HOST }}
           username: ${{ vars.USER }}
           key: ${{ secrets.SSH_KEY }}
+          fingerprint: ${{ vars.SSH_HOST_FINGERPRINT }}
           source: '.env.staging,docker/docker-compose.staging.yml,docker/Caddyfile,docker/alloy-config.river,docker/ipfs-init/001-provide-strategy.sh'
           target: /opt/cipherbox
           strip_components: 0
@@ -441,6 +453,7 @@ jobs:
           host: ${{ vars.HOST }}
           username: ${{ vars.USER }}
           key: ${{ secrets.SSH_KEY }}
+          fingerprint: ${{ vars.SSH_HOST_FINGERPRINT }}
           script: |
             # Move files to correct locations
             mv /opt/cipherbox/.env.staging /opt/cipherbox/docker/.env.staging 2>/dev/null || true
@@ -462,6 +475,7 @@ jobs:
           host: ${{ vars.HOST }}
           username: ${{ vars.USER }}
           key: ${{ secrets.SSH_KEY }}
+          fingerprint: ${{ vars.SSH_HOST_FINGERPRINT }}
           source: 'web-dist/*'
           target: /opt/cipherbox/web
           strip_components: 1
@@ -473,6 +487,7 @@ jobs:
           host: ${{ vars.HOST }}
           username: ${{ vars.USER }}
           key: ${{ secrets.SSH_KEY }}
+          fingerprint: ${{ vars.SSH_HOST_FINGERPRINT }}
           script: |
             set -euo pipefail
             cd /opt/cipherbox/docker


### PR DESCRIPTION
## What

The SCP and SSH steps in `deploy-staging.yml` (4 calls) and `deploy-landing.yml` (2 calls) passed no
`fingerprint`, so appleboy's actions accepted whatever host key answered. That is a MITM window on a
connection that carries the root deploy credential and writes `.env.staging`.

The exposure is not theoretical: the VPS was reimaged **2026-07-07** and regenerated all three host
keys (`uptime -s` = 10:28:48, host-key file mtimes 10:28). Every deploy since would have connected
across that change without failing. Nothing noticed because there have been no v1 deployments since
the v2 work started.

## The change

- `fingerprint: ${{ vars.SSH_HOST_FINGERPRINT }}` on all six action calls.
- A guard step in each job that fails when the variable is unset. This is the load-bearing half:
  appleboy skips verification entirely when `fingerprint` is empty, so a missing variable would
  silently restore the hole rather than break the deploy.

## The variable

`SSH_HOST_FINGERPRINT` is set at the **`staging` environment** scope (both jobs declare
`environment: staging`), to the ed25519 host key's SHA256 fingerprint. It was verified out-of-band
against the Hostinger serial console before being pinned — not trusted from a scan alone.

Rotating the host key means updating this variable in the same change.

## Why the host now offers only one key

Review caught that the first version of this change would have failed every deploy closed.
`easyssh-proxy` never sets `ssh.ClientConfig.HostKeyAlgorithms`, so Go's default preference order
applies — and Ed25519 is **last** in it. Offering the staging host Go's exact list negotiates
`rsa-sha2-256`, so a client pinning the Ed25519 fingerprint would have compared it against the RSA
key and refused to connect.

Pinning the RSA fingerprint instead would work today but is brittle: both actions `curl` the
`drone-ssh`/`drone-scp` binary at run time with no pin on the download, so the bundled x/crypto
preference order can change without any change in this repo.

Fixed host-side instead. `/etc/ssh/sshd_config.d/10-hostkey-ed25519.conf` now names
`ssh_host_ed25519_key` as the only `HostKey`, so the negotiated key is the pinned key by
construction, whatever a client prefers. Verified after reload: offering Go's exact list now
negotiates `ssh-ed25519` and matches the pinned value. The RSA and ECDSA key files are untouched on
disk — reverting is deleting one drop-in file.

## Out of scope, worth knowing

Both actions are composite wrappers whose `entrypoint.sh` downloads the `drone-ssh`/`drone-scp`
binary at run time with no checksum or signature check. The `uses:` SHA pin therefore does not pin
the code that actually opens the connection. This PR closes the host-key MITM window; it does not
close that one.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin SSH host key fingerprint on every deploy connection in staging and landing workflows
> - Adds a `Require a pinned host key` validation step to both [deploy-staging.yml](https://github.com/FSM1/cipher-box/pull/1114/files#diff-98b468326a86981405fb6e13c66ea8cd0032c4c7e4f2816fbc42a1fa9b32e991) and [deploy-landing.yml](https://github.com/FSM1/cipher-box/pull/1114/files#diff-916a77266553245c40d4305c30be457c5198a41ab682b36c2c2a4deb87711b70) that checks `SSH_HOST_FINGERPRINT` matches the `SHA256:` format, failing early if it is missing or malformed.
> - Passes `fingerprint: ${{ vars.SSH_HOST_FINGERPRINT }}` to all `appleboy/scp-action` and `appleboy/ssh-action` steps so every SCP/SSH connection verifies the host key.
> - Behavioral Change: deploys now fail before any remote action if `SSH_HOST_FINGERPRINT` is not set as a repo/environment variable in the expected format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cc0980.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->