### PR TITLE
feat: implement the concrete WriteSubtreeResolver over the real seams

### DIFF
--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -13,7 +13,8 @@
 //! pipeline stays the only path to the transport.
 
 use core::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, BTreeSet};
 
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
@@ -50,7 +51,7 @@ use crate::rotation::{
     CascadeResealResolver, CascadeTarget, ChildIndexResolver, CommittedSet, RepointChannel,
     RepublishedNode, ResealError, ResealSeeds, ResealedScopeRoot, ResolveFailure,
     ScopeRootIdentity, ScopeRootPublishError, ScopeRootPublisher, WritePublishError,
-    WriteWavePublisher, reseal_scope_root,
+    WriteScopeNode, WriteSubtreeResolver, WriteWavePublisher, reseal_scope_root,
 };
 use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
 use crate::session::SessionIdentity;
@@ -688,8 +689,9 @@ where
 }
 
 /// The write-plane name wave's transport edge (blueprint/engine.md
-/// "rotateScopeWrite"): the owner arm of [`WriteWavePublisher`] over the same net
-/// plane the read-plane seams above run on.
+/// "rotateScopeWrite"): the owner arm of both [`WriteSubtreeResolver`] and
+/// [`WriteWavePublisher`] over the same net plane the read-plane seams above run
+/// on.
 ///
 /// The wave hands this no authoring material — only routing identity and the one
 /// write seed that signs at the new name ([`RepublishedNode`]) — so every
@@ -742,6 +744,72 @@ pub struct WriteWaveNet<'a, T, H: Http, C: CredentialStore, F, Sch, E> {
     /// The root read this pass gated and has not yet republished
     /// ([`GatedWaveRoot`]). One rotation pass per net.
     pub gated_root: GatedWaveRoot,
+    /// The subtree index the enumeration builds as it descends
+    /// ([`WaveSubtree`]). One rotation pass per net.
+    pub subtree: WaveSubtree,
+}
+
+/// The write scope's node index, as this pass's own gated reads discovered it.
+///
+/// A node id locates nothing on its own — only a gated parent's read body names
+/// its children — so the enumeration's descent is what supplies every name below
+/// the root, and no caller-supplied label ever chooses where a node is read.
+#[derive(Default)]
+pub struct WaveSubtree {
+    inner: RefCell<Discovered>,
+}
+
+#[derive(Default)]
+struct Discovered {
+    names: BTreeMap<[u8; 16], IpnsName>,
+    /// The root's directly-descendant scope roots: each rotates under its own
+    /// write scope seed, so the wave stops at them (`grants/child_index.rs`).
+    child_scopes: BTreeSet<[u8; 16]>,
+}
+
+impl WaveSubtree {
+    /// The name a gated parent gave `node_id`.
+    fn name(&self, node_id: &[u8; 16]) -> Option<IpnsName> {
+        self.inner.borrow().names.get(node_id).cloned()
+    }
+
+    fn record_child_scopes(&self, index: &[ChildScopeRef]) {
+        self.inner
+            .borrow_mut()
+            .child_scopes
+            .extend(index.iter().map(|child| child.scope_id));
+    }
+
+    /// Record `body`'s in-scope children at the names it gives them and return
+    /// their ids for the walk to descend into.
+    ///
+    /// Two parents naming one id at **different** names is the read plane's C2
+    /// conflict ([`ResolveFailure::ConflictingChildLabel`]): rotating the one
+    /// picked would leave the other name live, so the walk aborts instead.
+    fn record_children(&self, body: &ReadBody) -> Result<Vec<[u8; 16]>, ResolveFailure> {
+        let ReadBody::Folder { children, .. } = body else {
+            return Ok(Vec::new());
+        };
+        let mut inner = self.inner.borrow_mut();
+        let mut ids = Vec::with_capacity(children.len());
+        for child in children {
+            if inner.child_scopes.contains(&child.id) {
+                continue;
+            }
+            let name = scope_name(&child.ipns_name)?;
+            match inner.names.entry(child.id) {
+                Entry::Occupied(seen) if *seen.get() != name => {
+                    return Err(ResolveFailure::ConflictingChildLabel);
+                }
+                Entry::Occupied(_) => {}
+                Entry::Vacant(slot) => {
+                    slot.insert(name);
+                }
+            }
+            ids.push(child.id);
+        }
+        Ok(ids)
+    }
 }
 
 /// The scope root's gated read, held across a failed publish.
@@ -837,6 +905,27 @@ fn wave_verdict(error: GateError) -> WritePublishError {
     match error {
         GateError::Rejected(_) => WritePublishError::Rejected,
         GateError::Seam(_) => WritePublishError::NotLanded,
+    }
+}
+
+/// The same axis for a read the wave shares with the read-plane rotation edges.
+fn wave_read_verdict(failure: ResolveFailure) -> WritePublishError {
+    match failure {
+        ResolveFailure::Unavailable => WritePublishError::NotLanded,
+        ResolveFailure::Rejected | ResolveFailure::ConflictingChildLabel => {
+            WritePublishError::Rejected
+        }
+    }
+}
+
+/// The same axis back out to the subtree enumeration: only a fail-closed refusal
+/// is a rejection, so no trust verdict is laundered into a retryable stall.
+fn subtree_verdict(error: WritePublishError) -> ResolveFailure {
+    match error {
+        WritePublishError::Rejected => ResolveFailure::Rejected,
+        WritePublishError::NotLanded
+        | WritePublishError::LostRace
+        | WritePublishError::RegistryFull => ResolveFailure::Unavailable,
     }
 }
 
@@ -949,46 +1038,55 @@ where
         if let Some(seed) = self.parent_node_seed {
             adopter = adopter.under_parent_node_seed(Zeroizing::new(*seed));
         }
-        let (candidate, outcome) = adopter
-            .adopt_root(name, record_bytes)
-            .await
-            .map_err(wave_verdict)?;
-        let envelope = candidate.envelope;
+        // Adopting the root raises this name's sequence floor, so the pass that
+        // enumerated it reads its own record back through the at-floor recovery
+        // — a wave must be able to re-read the root it has not yet re-pointed.
+        let gated = match adopter.adopt_root(name, record_bytes).await {
+            Ok((candidate, outcome)) => GatedScopeRoot {
+                envelope: candidate.envelope,
+                section: candidate.grant_section,
+                read_body: outcome.adopted.read_body,
+                read_scope_seed: outcome
+                    .read_scope_seed
+                    .ok_or(WritePublishError::NotLanded)?,
+                write_scope_seed: outcome.write_scope_seed,
+            },
+            Err(GateError::Seam(_)) => return Err(WritePublishError::NotLanded),
+            Err(GateError::Rejected(rejection)) => {
+                reread_at_floor(&adopter, name, record_bytes, &rejection.reason)
+                    .await
+                    .map_err(wave_read_verdict)?
+            }
+        };
+        let envelope = gated.envelope;
         // The root gate binds `envelope.scope` but not `envelope.id`, and every
         // AAD this republish authors binds the id — so a root whose record claims
         // another node would be re-sealed under a key no reader re-derives.
         if envelope.v != ENVELOPE_V || envelope.id != self.scope_id {
             return Err(WritePublishError::Rejected);
         }
-        let read_scope_seed = outcome
-            .read_scope_seed
-            .ok_or(WritePublishError::NotLanded)?;
-        let write_scope_seed = outcome
-            .write_scope_seed
-            .ok_or(WritePublishError::NotLanded)?;
+        let read_scope_seed = gated.read_scope_seed;
+        let write_scope_seed = gated.write_scope_seed.ok_or(WritePublishError::NotLanded)?;
         let write_epoch = floor::write_epoch_floor(self.floors, &self.scope_id)
             .await
             .map_err(|_| WritePublishError::NotLanded)?
             .ok_or(WritePublishError::NotLanded)?;
         let write_body = open_write_body(
             &envelope,
-            &candidate.grant_section,
+            &gated.section,
             &self.scope_id,
             &write_scope_seed,
             write_epoch,
         )
-        .map_err(|failure| match failure {
-            ResolveFailure::Unavailable => WritePublishError::NotLanded,
-            _ => WritePublishError::Rejected,
-        })?;
+        .map_err(wave_read_verdict)?;
         Ok(WaveSource {
-            read_body: outcome.adopted.read_body,
-            read_epoch: outcome.adopted.epoch,
+            read_body: gated.read_body,
+            read_epoch: envelope.epoch,
             read_key: read_key_for(&read_scope_seed, &envelope.id),
             unknown: envelope.unknown,
             epoch_tag_unknown: envelope.epoch_tag_unknown,
             root: Some(RootPlane {
-                section: candidate.grant_section,
+                section: gated.section,
                 read_scope_seed,
                 write_body,
                 write_epoch,
@@ -1245,6 +1343,48 @@ where
     }
 }
 
+impl<T, H: Http, C: CredentialStore, F, Sch, E> WriteSubtreeResolver
+    for WriteWaveNet<'_, T, H, C, F, Sch, E>
+where
+    T: RecordTransport,
+    F: FloorStore,
+{
+    async fn resolve_node(&self, node_id: &[u8; 16]) -> Result<WriteScopeNode, ResolveFailure> {
+        let is_root = *node_id == self.scope_id;
+        let current_name = if is_root {
+            self.current_root_name.clone()
+        } else {
+            self.subtree.name(node_id).ok_or(ResolveFailure::Rejected)?
+        };
+        let Some((_, record_bytes)) = fanout_get_verify(self.transport, &current_name).await else {
+            return Err(ResolveFailure::Unavailable);
+        };
+        let source = if is_root {
+            self.root_source(&current_name, &record_bytes).await
+        } else {
+            self.interior_source(*node_id, &current_name, &record_bytes)
+                .await
+        }
+        .map_err(subtree_verdict)?;
+
+        if let Some(plane) = &source.root {
+            self.subtree
+                .record_child_scopes(&plane.write_body.direct_child_scope_index);
+        }
+        let child_node_ids = self.subtree.record_children(&source.read_body)?;
+        // The enumeration's read of the root is the one its republish runs off
+        // ([`GatedWaveRoot`]); an interior node re-opens its own record instead.
+        if is_root {
+            self.gated_root.park(&current_name, source);
+        }
+        Ok(WriteScopeNode {
+            node_id: *node_id,
+            current_name,
+            child_node_ids,
+        })
+    }
+}
+
 impl<T, H: Http, C: CredentialStore, F, Sch, E> WriteWavePublisher
     for WriteWaveNet<'_, T, H, C, F, Sch, E>
 where
@@ -1341,10 +1481,12 @@ mod tests {
     use crate::content::GatewaySource;
     use crate::rotation::{
         CascadeError, CascadeOutcome, CommittedSet, PrevEpochSeed, ResealSeeds, RotateScopePlan,
-        ScopeRootIdentity, cascade_rotate_scope, derive_write_name, enumerate_eager_set,
-        reseal_scope_root, rotate_scope,
+        RotateScopeWritePlan, ScopeRootIdentity, WriteRotateError, cascade_rotate_scope,
+        derive_write_name, enumerate_eager_set, reseal_scope_root, rotate_scope,
+        rotate_scope_write,
     };
     use crate::seams::{EndpointId, HttpResponse, SeamError, SeamResult};
+    use crate::sync::pointer::open_repoint;
     use crate::testkit::fakes::{
         InMemoryCredentialStore, InMemoryFloorStore, InMemoryRecordStore, ScriptedHttp,
         VirtualScheduler,
@@ -2854,6 +2996,7 @@ mod tests {
             owner_enc_secret: &harness.enc_secret,
             scope_keys: &WaveSeeds,
             gated_root: GatedWaveRoot::default(),
+            subtree: WaveSubtree::default(),
             owner_pointer_seed: &OWNER_POINTER_SEED,
             current_root_name: current_root,
         }
@@ -3349,5 +3492,321 @@ mod tests {
                 "{check} is deterministic on inputs the wave already gated; retrying never converges"
             );
         }
+    }
+
+    // --- the subtree enumeration: the wave's read edge ---------------------
+
+    const MID: [u8; 16] = [0x60; 16];
+    const LEAF: [u8; 16] = [0x61; 16];
+
+    /// A scope whose root names `MID` (which names `LEAF`) plus a descendant
+    /// scope root the wave must stop at, with the scope root staged and gated.
+    ///
+    /// The descendant scope root's own record is deliberately never served: a
+    /// walk that descended into it would stall on an unresolvable node.
+    fn staged_scope(harness: &Harness<InMemoryRecordStore>) -> (OwnerRootFixture, IpnsName) {
+        let leaf_old = stage_node(harness, LEAF, &folder(Vec::new()));
+        let mid_old = stage_node(harness, MID, &folder(vec![ref_to(LEAF, &leaf_old)]));
+        let descendant = interior(CHILD_SCOPE, &OWNER_ROOT_SCOPE_SEED, Vec::new());
+        let root = owner_root_fixture(OwnerRootSpec {
+            owner_identity: &owner_identity(),
+            owner_enc: &owner_enc().public(),
+            scope_id: SCOPE,
+            root_id: SCOPE,
+            children: vec![ref_to(MID, &mid_old), ref_to(CHILD_SCOPE, &descendant.name)],
+            child_scope_index: vec![child_ref(CHILD_SCOPE, &descendant)],
+            parent_node_seed: None,
+            owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+        });
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        (root, mid_old)
+    }
+
+    /// A root whose read body names one child, staged and gated.
+    fn staged_root_naming(
+        harness: &Harness<InMemoryRecordStore>,
+        children: Vec<ChildRef>,
+    ) -> OwnerRootFixture {
+        let root = owner_root_fixture(OwnerRootSpec {
+            owner_identity: &owner_identity(),
+            owner_enc: &owner_enc().public(),
+            scope_id: SCOPE,
+            root_id: SCOPE,
+            children,
+            child_scope_index: Vec::new(),
+            parent_node_seed: None,
+            owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+        });
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        root
+    }
+
+    /// The wave the write-plane rotation runs, pinned to a known fresh seed so
+    /// every derived name in the assertions is computable.
+    fn write_plan<'a>(
+        root: &'a OwnerRootFixture,
+        owner: &'a EcdsaSigner,
+    ) -> RotateScopeWritePlan<'a> {
+        RotateScopeWritePlan {
+            scope_id: SCOPE,
+            payload_version: 1,
+            owner_pointer_seed: &OWNER_POINTER_SEED,
+            commitment: &root.grant_section.commitment,
+            commitment_sig: &root.grant_section.commitment_sig,
+            owner_identity_signer: owner,
+            current_write_epoch: OWNER_ROOT_EPOCH,
+            min_read_epoch: OWNER_ROOT_EPOCH,
+            current_root_name: &root.name,
+            resume_write_scope_seed: Some(&FRESH_WRITE_SCOPE_SEED),
+        }
+    }
+
+    /// Whether anything at all was published at `name`.
+    fn published_at<T: RecordTransport + Clone>(harness: &Harness<T>, name: &IpnsName) -> bool {
+        harness
+            .store
+            .record_at(&harness.store.endpoints()[0], name.as_str())
+            .is_some()
+    }
+
+    #[test]
+    fn the_enumeration_descends_gated_records_and_stops_at_a_descendant_scope_root() {
+        let harness = Harness::plain();
+        let (root, mid_old) = staged_scope(&harness);
+        let owner = owner_identity();
+        let net = wave(&harness, &owner, &root.name);
+
+        let resolved = block_on(net.resolve_node(&SCOPE)).expect("the root resolves");
+        assert_eq!(
+            resolved,
+            WriteScopeNode {
+                node_id: SCOPE,
+                current_name: root.name.clone(),
+                child_node_ids: vec![MID],
+            },
+            "a descendant scope root rotates under its own write scope seed, so \
+             the wave never descends into it"
+        );
+
+        let mid = block_on(net.resolve_node(&MID)).expect("the child resolves");
+        assert_eq!(
+            mid.current_name, mid_old,
+            "at the name its gated parent gave"
+        );
+        assert_eq!(mid.child_node_ids, vec![LEAF]);
+        assert_eq!(
+            block_on(net.resolve_node(&LEAF))
+                .expect("the leaf resolves")
+                .child_node_ids,
+            Vec::<[u8; 16]>::new()
+        );
+    }
+
+    #[test]
+    fn a_node_no_gated_record_named_has_no_name_to_read_at() {
+        // The enumeration's own descent is the only source of a node's name, so
+        // an id nothing gated named is a fail-closed refusal, not a fetch.
+        let harness = Harness::plain();
+        let (root, _) = staged_scope(&harness);
+        let owner = owner_identity();
+        let net = wave(&harness, &owner, &root.name);
+
+        assert_eq!(
+            block_on(net.resolve_node(&[0xee; 16])),
+            Err(ResolveFailure::Rejected)
+        );
+    }
+
+    #[test]
+    fn one_id_named_at_two_names_aborts_rather_than_picking() {
+        // Rotating whichever name was seen first would leave the other live under
+        // a root that claims to have moved.
+        let harness = Harness::plain();
+        let elsewhere = derive_write_name(&FRESH_WRITE_SCOPE_SEED, &LEAF);
+        let leaf_old = stage_node(&harness, LEAF, &folder(Vec::new()));
+        let mid_old = stage_node(&harness, MID, &folder(vec![ref_to(LEAF, &elsewhere)]));
+        let root = staged_root_naming(
+            &harness,
+            vec![ref_to(MID, &mid_old), ref_to(LEAF, &leaf_old)],
+        );
+        let owner = owner_identity();
+        let net = wave(&harness, &owner, &root.name);
+
+        block_on(net.resolve_node(&SCOPE)).expect("the root resolves");
+        assert_eq!(
+            block_on(net.resolve_node(&MID)),
+            Err(ResolveFailure::ConflictingChildLabel)
+        );
+    }
+
+    #[test]
+    fn a_gate_rejected_node_aborts_the_wave_and_is_never_reported_as_staleness() {
+        // A record that cannot be authoritatively obtained must not be laundered
+        // into a retryable stall (rule 6), and a truncated enumeration would
+        // re-point the root over interior nodes that never moved.
+        let harness = Harness::plain();
+        let served = stage_node(&harness, LEAF, &folder(Vec::new()));
+        // The root names a node id at a record that claims a different id — the
+        // transplant the child gate refuses.
+        let root = staged_root_naming(&harness, vec![ref_to(MID, &served)]);
+        let owner = owner_identity();
+        let net = wave(&harness, &owner, &root.name);
+        let mut entropy = SeededEntropy::new(13);
+
+        let error = block_on(rotate_scope_write(
+            &mut entropy,
+            &net,
+            &net,
+            &write_plan(&root, &owner),
+        ))
+        .expect_err("the wave aborts");
+        assert_eq!(
+            error,
+            WriteRotateError::Resolve {
+                node_id: MID,
+                reason: ResolveFailure::Rejected,
+            }
+        );
+        assert!(!error.is_retryable(), "a gate verdict no retry can clear");
+        assert!(
+            !published_at(&harness, &scope_pointer_name(&OWNER_POINTER_SEED, &SCOPE)),
+            "the root is never re-pointed over a subtree the wave could not enumerate"
+        );
+        assert!(!published_at(
+            &harness,
+            &derive_write_name(&FRESH_WRITE_SCOPE_SEED, &SCOPE)
+        ));
+    }
+
+    #[test]
+    fn an_unresolvable_node_aborts_the_wave_rather_than_truncating_the_subtree() {
+        let harness = Harness::plain();
+        let unserved = derive_write_name(&OWNER_ROOT_WRITE_SCOPE_SEED, &LEAF);
+        let root = staged_root_naming(&harness, vec![ref_to(LEAF, &unserved)]);
+        let owner = owner_identity();
+        let net = wave(&harness, &owner, &root.name);
+        let mut entropy = SeededEntropy::new(13);
+
+        let error = block_on(rotate_scope_write(
+            &mut entropy,
+            &net,
+            &net,
+            &write_plan(&root, &owner),
+        ))
+        .expect_err("the wave aborts");
+        assert_eq!(
+            error,
+            WriteRotateError::Resolve {
+                node_id: LEAF,
+                reason: ResolveFailure::Unavailable,
+            }
+        );
+        assert!(error.is_retryable(), "no host served it — availability");
+        assert!(
+            !published_at(&harness, &scope_pointer_name(&OWNER_POINTER_SEED, &SCOPE)),
+            "an incomplete enumeration never reaches the re-point"
+        );
+    }
+
+    #[test]
+    fn the_production_edges_carry_the_whole_wave_from_enumeration_to_re_point() {
+        let harness = Harness::plain();
+        let (root, mid_old) = staged_scope(&harness);
+        let owner = owner_identity();
+        let net = wave(&harness, &owner, &root.name);
+        let mut entropy = SeededEntropy::new(13);
+
+        let outcome = block_on(rotate_scope_write(
+            &mut entropy,
+            &net,
+            &net,
+            &write_plan(&root, &owner),
+        ))
+        .expect("the wave completes over the production seams");
+
+        assert_eq!(outcome.new_write_epoch, OWNER_ROOT_EPOCH + 1);
+        assert_eq!(
+            outcome.new_root_name,
+            derive_write_name(&FRESH_WRITE_SCOPE_SEED, &SCOPE)
+        );
+        assert_eq!(
+            outcome.interior_node_count, 2,
+            "MID and LEAF, and not the descendant scope root"
+        );
+        assert!(
+            outcome.repoint_accelerators.is_empty(),
+            "neither accelerator has a wire shape to publish on"
+        );
+
+        // The canonical flip carries the owner-signed re-point object.
+        let pointer = scope_pointer_name(&OWNER_POINTER_SEED, &SCOPE);
+        let block = harness
+            .store
+            .record_at(&harness.store.endpoints()[0], pointer.as_str())
+            .and_then(|bytes| IpnsRecord::unmarshal(&bytes).ok()?.verify(&pointer).ok())
+            .expect("the pointer record verifies under its own name")
+            .value;
+        let repoint = open_repoint(
+            kdf::pointer_read_key(&OWNER_POINTER_SEED, &SCOPE).as_bytes(),
+            1,
+            &SCOPE,
+            &owner.verifying_key(),
+            &block,
+        )
+        .expect("the re-point object opens under the owner's pointer key");
+        assert_eq!(repoint.current_root, outcome.new_root_name);
+        assert_eq!(repoint.prev_root, Some(root.name.clone()));
+
+        // A read-only holder follows the re-point and descends by child refs
+        // alone — the proof every interior node moved and every parent was
+        // rewritten.
+        let mut name = outcome.new_root_name.clone();
+        let mut node_id = SCOPE;
+        for expected in [MID, LEAF] {
+            let refs = child_names_of(&read_only_open(&harness, node_id, &name));
+            let next = refs
+                .iter()
+                .map(|bytes| core::str::from_utf8(bytes).expect("a utf8 name"))
+                .find(|text| {
+                    *text == derive_write_name(&FRESH_WRITE_SCOPE_SEED, &expected).as_str()
+                })
+                .expect("the parent names the child at the name the wave moved it to");
+            name = IpnsName::parse(next).expect("a canonical name");
+            node_id = expected;
+        }
+        assert_ne!(name, mid_old, "no retired name survives the descent");
+
+        // The descendant scope root keeps its own name: it rotates under its own
+        // write scope seed, not this wave's.
+        let descendant = interior(CHILD_SCOPE, &OWNER_ROOT_SCOPE_SEED, Vec::new());
+        assert!(
+            child_names_of(&read_only_open(&harness, SCOPE, &outcome.new_root_name))
+                .contains(&descendant.name.as_str().as_bytes().to_vec())
+        );
+    }
+
+    #[test]
+    fn a_resumed_wave_re_resolves_the_subtree_from_published_records_alone() {
+        // A crash leaves the durable floors raised, so the resumed pass reads its
+        // own un-re-pointed root back through the at-floor recovery rather than a
+        // second adopt — with no in-memory carry from the pass that raised them.
+        let harness = Harness::plain();
+        let (root, _) = staged_scope(&harness);
+        let owner = owner_identity();
+
+        let first = wave(&harness, &owner, &root.name);
+        let before: Vec<WriteScopeNode> = [SCOPE, MID, LEAF]
+            .into_iter()
+            .map(|id| block_on(first.resolve_node(&id)).expect("the first pass enumerates"))
+            .collect();
+        drop(first);
+
+        let resumed = wave(&harness, &owner, &root.name);
+        let after: Vec<WriteScopeNode> = [SCOPE, MID, LEAF]
+            .into_iter()
+            .map(|id| block_on(resumed.resolve_node(&id)).expect("the resumed pass enumerates"))
+            .collect();
+
+        assert_eq!(before, after);
     }
 }

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -392,6 +392,29 @@ async fn reread_at_floor<H: Http, F: FloorStore>(
     })
 }
 
+/// Gate `record_bytes` as a scope root under the label `adopter` carries,
+/// recovering this reader's own already-adopted record through
+/// [`reread_at_floor`]. The one ladder every rotation arm's root read runs.
+async fn gated_scope_root<H: Http, F: FloorStore>(
+    adopter: &RootAdopter<'_, H, F>,
+    name: &IpnsName,
+    record_bytes: &[u8],
+) -> Result<GatedScopeRoot, ResolveFailure> {
+    match adopter.adopt_root(name, record_bytes).await {
+        Ok((candidate, outcome)) => Ok(GatedScopeRoot {
+            envelope: candidate.envelope,
+            section: candidate.grant_section,
+            read_body: outcome.adopted.read_body,
+            read_scope_seed: outcome.read_scope_seed.ok_or(ResolveFailure::Unavailable)?,
+            write_scope_seed: outcome.write_scope_seed,
+        }),
+        Err(GateError::Seam(_)) => Err(ResolveFailure::Unavailable),
+        Err(GateError::Rejected(rejection)) => {
+            reread_at_floor(adopter, name, record_bytes, &rejection.reason).await
+        }
+    }
+}
+
 impl<T, H: Http, C: CredentialStore, F, Sch, E> OwnerRotationNet<'_, T, H, C, F, Sch, E>
 where
     T: RecordTransport,
@@ -422,19 +445,7 @@ where
         if let Some(seed) = self.ancestry.parent_node_seed(&scope_id) {
             adopter = adopter.under_parent_node_seed(seed);
         }
-        match adopter.adopt_root(name, &record_bytes).await {
-            Ok((candidate, outcome)) => Ok(GatedScopeRoot {
-                envelope: candidate.envelope,
-                section: candidate.grant_section,
-                read_body: outcome.adopted.read_body,
-                read_scope_seed: outcome.read_scope_seed.ok_or(ResolveFailure::Unavailable)?,
-                write_scope_seed: outcome.write_scope_seed,
-            }),
-            Err(GateError::Seam(_)) => Err(ResolveFailure::Unavailable),
-            Err(GateError::Rejected(rejection)) => {
-                reread_at_floor(&adopter, name, &record_bytes, &rejection.reason).await
-            }
-        }
+        gated_scope_root(&adopter, name, &record_bytes).await
     }
 
     /// Unseal a gated scope root's write-body under the owner's recovered write
@@ -749,11 +760,9 @@ pub struct WriteWaveNet<'a, T, H: Http, C: CredentialStore, F, Sch, E> {
     pub subtree: WaveSubtree,
 }
 
-/// The write scope's node index, as this pass's own gated reads discovered it.
-///
-/// A node id locates nothing on its own — only a gated parent's read body names
-/// its children — so the enumeration's descent is what supplies every name below
-/// the root, and no caller-supplied label ever chooses where a node is read.
+/// The write scope's node index, as this pass's own gated reads discovered it: a
+/// node id locates nothing on its own — only a gated parent's read body names
+/// its children.
 #[derive(Default)]
 pub struct WaveSubtree {
     inner: RefCell<Discovered>,
@@ -762,8 +771,9 @@ pub struct WaveSubtree {
 #[derive(Default)]
 struct Discovered {
     names: BTreeMap<[u8; 16], IpnsName>,
-    /// The root's directly-descendant scope roots: each rotates under its own
-    /// write scope seed, so the wave stops at them (`grants/child_index.rs`).
+    /// The directly-descendant scope roots the pass **proved**: each rotates
+    /// under its own write scope seed, so the wave stops at them
+    /// (`grants/child_index.rs`).
     child_scopes: BTreeSet<[u8; 16]>,
 }
 
@@ -773,11 +783,10 @@ impl WaveSubtree {
         self.inner.borrow().names.get(node_id).cloned()
     }
 
-    fn record_child_scopes(&self, index: &[ChildScopeRef]) {
-        self.inner
-            .borrow_mut()
-            .child_scopes
-            .extend(index.iter().map(|child| child.scope_id));
+    /// Mark `scope_id` as the boundary of a proven descendant scope root
+    /// ([`WriteWaveNet::record_scope_boundary`]).
+    fn record_child_scope(&self, scope_id: [u8; 16]) {
+        self.inner.borrow_mut().child_scopes.insert(scope_id);
     }
 
     /// Record `body`'s in-scope children at the names it gives them and return
@@ -812,14 +821,13 @@ impl WaveSubtree {
     }
 }
 
-/// The scope root's gated read, held across a failed publish.
+/// The scope root's gated read, held from the enumeration that proved it to the
+/// republish that moves it, and re-parked when that publish fails.
 ///
-/// Adoption advances the durable **sequence** floor, so a second gated read of
-/// the same root record rejects as not-newer (`gate/adoption.rs` stage 4) — and
-/// the root gate has no at-floor re-open. Holding the read is what makes
-/// `republish` idempotent for the root, which the wave's resume contract
-/// requires: a pass that gated the root and then failed to PUT retries off this
-/// slot rather than re-reading a record its own floor now refuses.
+/// The root is the one record the wave both reads and re-signs, so a re-fetch
+/// between those two points would let a still-committed writer interpose a
+/// section of its own for the wave to carry forward. Pinning the read keeps the
+/// section the wave re-seals the one it proved.
 #[derive(Default)]
 pub struct GatedWaveRoot {
     inner: RefCell<Option<(IpnsName, WaveSource)>>,
@@ -1038,26 +1046,9 @@ where
         if let Some(seed) = self.parent_node_seed {
             adopter = adopter.under_parent_node_seed(Zeroizing::new(*seed));
         }
-        // Adopting the root raises this name's sequence floor, so the pass that
-        // enumerated it reads its own record back through the at-floor recovery
-        // — a wave must be able to re-read the root it has not yet re-pointed.
-        let gated = match adopter.adopt_root(name, record_bytes).await {
-            Ok((candidate, outcome)) => GatedScopeRoot {
-                envelope: candidate.envelope,
-                section: candidate.grant_section,
-                read_body: outcome.adopted.read_body,
-                read_scope_seed: outcome
-                    .read_scope_seed
-                    .ok_or(WritePublishError::NotLanded)?,
-                write_scope_seed: outcome.write_scope_seed,
-            },
-            Err(GateError::Seam(_)) => return Err(WritePublishError::NotLanded),
-            Err(GateError::Rejected(rejection)) => {
-                reread_at_floor(&adopter, name, record_bytes, &rejection.reason)
-                    .await
-                    .map_err(wave_read_verdict)?
-            }
-        };
+        let gated = gated_scope_root(&adopter, name, record_bytes)
+            .await
+            .map_err(wave_read_verdict)?;
         let envelope = gated.envelope;
         // The root gate binds `envelope.scope` but not `envelope.id`, and every
         // AAD this republish authors binds the id — so a root whose record claims
@@ -1092,6 +1083,52 @@ where
                 write_epoch,
             }),
         })
+    }
+
+    /// Prove each claimed directly-descendant scope root before the enumeration
+    /// stops at it, and record the proven boundary.
+    ///
+    /// `directChildScopeIndex` is authored by any committed writer — including
+    /// the grantee this rotation is cutting — so an entry naming an ordinary
+    /// in-scope node would carve that node out of the wave and leave it live at
+    /// a name the revokee's retired write scope seed still derives. Only the
+    /// owner-signed commitment names a scope root's own `ipnsName`, so the root
+    /// gate is the proof, over the seed the root's own owner blob yielded
+    /// (`OwnerRotationNet::gated_write_plane` gates the same index).
+    async fn record_scope_boundary(
+        &self,
+        index: &[ChildScopeRef],
+        read_scope_seed: &[u8; SECRET_LEN],
+    ) -> Result<(), ResolveFailure> {
+        let identity = self.owner.verifying_key();
+        for child in index {
+            let name = scope_name(&child.ipns_name)?;
+            let Some((_, record_bytes)) = fanout_get_verify(self.transport, &name).await else {
+                return Err(ResolveFailure::Unavailable);
+            };
+            let parent_node_seed = kdf::node_seed(read_scope_seed, &child.scope_id);
+            let adopter = RootAdopter::new(
+                self.gateway,
+                self.http,
+                self.floors,
+                self.owner_enc_secret,
+                &identity,
+                child.scope_id,
+            )
+            .under_parent_node_seed(Zeroizing::new(*parent_node_seed.as_bytes()));
+            // The gate binds `envelope.scope` to the label above; a scope root's
+            // node id is its scope id, and only this binds it.
+            if gated_scope_root(&adopter, &name, &record_bytes)
+                .await?
+                .envelope
+                .id
+                != child.scope_id
+            {
+                return Err(ResolveFailure::Rejected);
+            }
+            self.subtree.record_child_scope(child.scope_id);
+        }
+        Ok(())
     }
 }
 
@@ -1368,12 +1405,14 @@ where
         .map_err(subtree_verdict)?;
 
         if let Some(plane) = &source.root {
-            self.subtree
-                .record_child_scopes(&plane.write_body.direct_child_scope_index);
+            self.record_scope_boundary(
+                &plane.write_body.direct_child_scope_index,
+                &plane.read_scope_seed,
+            )
+            .await?;
         }
         let child_node_ids = self.subtree.record_children(&source.read_body)?;
-        // The enumeration's read of the root is the one its republish runs off
-        // ([`GatedWaveRoot`]); an interior node re-opens its own record instead.
+        // The republish runs off this read ([`GatedWaveRoot`]).
         if is_root {
             self.gated_root.park(&current_name, source);
         }
@@ -3290,11 +3329,10 @@ mod tests {
 
     #[test]
     fn a_failed_root_publish_leaves_the_root_republishable() {
-        // The root gate advances the durable sequence floor and there is no
-        // at-floor root re-open, so a pass that gated the root and then failed to
-        // publish must retry off the read it already holds — otherwise a wave
-        // interrupted between the two can never be resumed and the write revoke
-        // it carries is stuck for good.
+        // A pass that gated the root and then failed to publish retries off the
+        // read it already holds — otherwise a wave interrupted between the two
+        // re-reads a record whose section a still-committed writer may have
+        // replaced in the meantime.
         let harness = Harness::plain();
         let root = owner_root_fixture(OwnerRootSpec {
             owner_identity: &owner_identity(),
@@ -3499,33 +3537,49 @@ mod tests {
     const MID: [u8; 16] = [0x60; 16];
     const LEAF: [u8; 16] = [0x61; 16];
 
-    /// A scope whose root names `MID` (which names `LEAF`) plus a descendant
-    /// scope root the wave must stop at, with the scope root staged and gated.
-    ///
-    /// The descendant scope root's own record is deliberately never served: a
-    /// walk that descended into it would stall on an unresolvable node.
-    fn staged_scope(harness: &Harness<InMemoryRecordStore>) -> (OwnerRootFixture, IpnsName) {
-        let leaf_old = stage_node(harness, LEAF, &folder(Vec::new()));
-        let mid_old = stage_node(harness, MID, &folder(vec![ref_to(LEAF, &leaf_old)]));
-        let descendant = interior(CHILD_SCOPE, &OWNER_ROOT_SCOPE_SEED, Vec::new());
-        let root = owner_root_fixture(OwnerRootSpec {
-            owner_identity: &owner_identity(),
-            owner_enc: &owner_enc().public(),
-            scope_id: SCOPE,
-            root_id: SCOPE,
-            children: vec![ref_to(MID, &mid_old), ref_to(CHILD_SCOPE, &descendant.name)],
-            child_scope_index: vec![child_ref(CHILD_SCOPE, &descendant)],
-            parent_node_seed: None,
-            owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
-        });
-        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
-        (root, mid_old)
+    /// `MID` (naming `LEAF`) and a real descendant scope root, all staged and
+    /// gate-passing, under a root carrying `index`.
+    struct StagedScope {
+        root: OwnerRootFixture,
+        mid_name: IpnsName,
+        descendant: OwnerRootFixture,
     }
 
-    /// A root whose read body names one child, staged and gated.
-    fn staged_root_naming(
+    fn staged_scope_with_index(
+        harness: &Harness<InMemoryRecordStore>,
+        index: impl FnOnce(&OwnerRootFixture, &IpnsName) -> Vec<ChildScopeRef>,
+    ) -> StagedScope {
+        let leaf_old = stage_node(harness, LEAF, &folder(Vec::new()));
+        let mid_name = stage_node(harness, MID, &folder(vec![ref_to(LEAF, &leaf_old)]));
+        let descendant = interior(CHILD_SCOPE, &OWNER_ROOT_SCOPE_SEED, Vec::new());
+        harness.stage(CHILD_SCOPE, &descendant, Some(OWNER_ROOT_EPOCH));
+        let root = staged_root(
+            harness,
+            vec![
+                ref_to(MID, &mid_name),
+                ref_to(CHILD_SCOPE, &descendant.name),
+            ],
+            index(&descendant, &mid_name),
+        );
+        StagedScope {
+            root,
+            mid_name,
+            descendant,
+        }
+    }
+
+    fn staged_scope(harness: &Harness<InMemoryRecordStore>) -> StagedScope {
+        staged_scope_with_index(harness, |descendant, _| {
+            vec![child_ref(CHILD_SCOPE, descendant)]
+        })
+    }
+
+    /// A staged, gate-passing scope root naming `children` and committing
+    /// `child_scope_index`.
+    fn staged_root(
         harness: &Harness<InMemoryRecordStore>,
         children: Vec<ChildRef>,
+        child_scope_index: Vec<ChildScopeRef>,
     ) -> OwnerRootFixture {
         let root = owner_root_fixture(OwnerRootSpec {
             owner_identity: &owner_identity(),
@@ -3533,7 +3587,7 @@ mod tests {
             scope_id: SCOPE,
             root_id: SCOPE,
             children,
-            child_scope_index: Vec::new(),
+            child_scope_index,
             parent_node_seed: None,
             owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
         });
@@ -3541,8 +3595,7 @@ mod tests {
         root
     }
 
-    /// The wave the write-plane rotation runs, pinned to a known fresh seed so
-    /// every derived name in the assertions is computable.
+    /// Pinned to a known fresh seed so every derived name is computable.
     fn write_plan<'a>(
         root: &'a OwnerRootFixture,
         owner: &'a EcdsaSigner,
@@ -3561,7 +3614,6 @@ mod tests {
         }
     }
 
-    /// Whether anything at all was published at `name`.
     fn published_at<T: RecordTransport + Clone>(harness: &Harness<T>, name: &IpnsName) -> bool {
         harness
             .store
@@ -3572,25 +3624,24 @@ mod tests {
     #[test]
     fn the_enumeration_descends_gated_records_and_stops_at_a_descendant_scope_root() {
         let harness = Harness::plain();
-        let (root, mid_old) = staged_scope(&harness);
+        let staged = staged_scope(&harness);
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let net = wave(&harness, &owner, &staged.root.name);
 
         let resolved = block_on(net.resolve_node(&SCOPE)).expect("the root resolves");
         assert_eq!(
             resolved,
             WriteScopeNode {
                 node_id: SCOPE,
-                current_name: root.name.clone(),
+                current_name: staged.root.name.clone(),
                 child_node_ids: vec![MID],
             },
-            "a descendant scope root rotates under its own write scope seed, so \
-             the wave never descends into it"
+            "the wave never descends into the descendant scope root"
         );
 
         let mid = block_on(net.resolve_node(&MID)).expect("the child resolves");
         assert_eq!(
-            mid.current_name, mid_old,
+            mid.current_name, staged.mid_name,
             "at the name its gated parent gave"
         );
         assert_eq!(mid.child_node_ids, vec![LEAF]);
@@ -3603,13 +3654,36 @@ mod tests {
     }
 
     #[test]
-    fn a_node_no_gated_record_named_has_no_name_to_read_at() {
-        // The enumeration's own descent is the only source of a node's name, so
-        // an id nothing gated named is a fail-closed refusal, not a fetch.
+    fn a_planted_index_entry_never_exempts_an_ordinary_node_from_the_wave() {
         let harness = Harness::plain();
-        let (root, _) = staged_scope(&harness);
+        let staged = staged_scope_with_index(&harness, |descendant, mid_name| {
+            vec![
+                child_ref(CHILD_SCOPE, descendant),
+                // MID is an ordinary interior folder, named at its real name.
+                ChildScopeRef {
+                    scope_id: MID,
+                    ipns_name: mid_name.as_str().as_bytes().to_vec(),
+                    unknown: PreservedFields::new(),
+                },
+            ]
+        });
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let net = wave(&harness, &owner, &staged.root.name);
+
+        assert_eq!(
+            block_on(net.resolve_node(&SCOPE)),
+            Err(ResolveFailure::Rejected),
+            "MID's record carries no owner-signed commitment naming it a scope \
+             root, so the claimed boundary is refused rather than honoured"
+        );
+    }
+
+    #[test]
+    fn a_node_no_gated_record_named_has_no_name_to_read_at() {
+        let harness = Harness::plain();
+        let staged = staged_scope(&harness);
+        let owner = owner_identity();
+        let net = wave(&harness, &owner, &staged.root.name);
 
         assert_eq!(
             block_on(net.resolve_node(&[0xee; 16])),
@@ -3619,15 +3693,14 @@ mod tests {
 
     #[test]
     fn one_id_named_at_two_names_aborts_rather_than_picking() {
-        // Rotating whichever name was seen first would leave the other live under
-        // a root that claims to have moved.
         let harness = Harness::plain();
         let elsewhere = derive_write_name(&FRESH_WRITE_SCOPE_SEED, &LEAF);
         let leaf_old = stage_node(&harness, LEAF, &folder(Vec::new()));
         let mid_old = stage_node(&harness, MID, &folder(vec![ref_to(LEAF, &elsewhere)]));
-        let root = staged_root_naming(
+        let root = staged_root(
             &harness,
             vec![ref_to(MID, &mid_old), ref_to(LEAF, &leaf_old)],
+            Vec::new(),
         );
         let owner = owner_identity();
         let net = wave(&harness, &owner, &root.name);
@@ -3641,14 +3714,11 @@ mod tests {
 
     #[test]
     fn a_gate_rejected_node_aborts_the_wave_and_is_never_reported_as_staleness() {
-        // A record that cannot be authoritatively obtained must not be laundered
-        // into a retryable stall (rule 6), and a truncated enumeration would
-        // re-point the root over interior nodes that never moved.
         let harness = Harness::plain();
         let served = stage_node(&harness, LEAF, &folder(Vec::new()));
         // The root names a node id at a record that claims a different id — the
         // transplant the child gate refuses.
-        let root = staged_root_naming(&harness, vec![ref_to(MID, &served)]);
+        let root = staged_root(&harness, vec![ref_to(MID, &served)], Vec::new());
         let owner = owner_identity();
         let net = wave(&harness, &owner, &root.name);
         let mut entropy = SeededEntropy::new(13);
@@ -3682,7 +3752,7 @@ mod tests {
     fn an_unresolvable_node_aborts_the_wave_rather_than_truncating_the_subtree() {
         let harness = Harness::plain();
         let unserved = derive_write_name(&OWNER_ROOT_WRITE_SCOPE_SEED, &LEAF);
-        let root = staged_root_naming(&harness, vec![ref_to(LEAF, &unserved)]);
+        let root = staged_root(&harness, vec![ref_to(LEAF, &unserved)], Vec::new());
         let owner = owner_identity();
         let net = wave(&harness, &owner, &root.name);
         let mut entropy = SeededEntropy::new(13);
@@ -3711,16 +3781,16 @@ mod tests {
     #[test]
     fn the_production_edges_carry_the_whole_wave_from_enumeration_to_re_point() {
         let harness = Harness::plain();
-        let (root, mid_old) = staged_scope(&harness);
+        let staged = staged_scope(&harness);
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let net = wave(&harness, &owner, &staged.root.name);
         let mut entropy = SeededEntropy::new(13);
 
         let outcome = block_on(rotate_scope_write(
             &mut entropy,
             &net,
             &net,
-            &write_plan(&root, &owner),
+            &write_plan(&staged.root, &owner),
         ))
         .expect("the wave completes over the production seams");
 
@@ -3755,11 +3825,10 @@ mod tests {
         )
         .expect("the re-point object opens under the owner's pointer key");
         assert_eq!(repoint.current_root, outcome.new_root_name);
-        assert_eq!(repoint.prev_root, Some(root.name.clone()));
+        assert_eq!(repoint.prev_root, Some(staged.root.name.clone()));
 
-        // A read-only holder follows the re-point and descends by child refs
-        // alone — the proof every interior node moved and every parent was
-        // rewritten.
+        // A read-only holder descends by child refs alone — the proof every
+        // interior node moved and every parent was rewritten.
         let mut name = outcome.new_root_name.clone();
         let mut node_id = SCOPE;
         for expected in [MID, LEAF] {
@@ -3774,34 +3843,35 @@ mod tests {
             name = IpnsName::parse(next).expect("a canonical name");
             node_id = expected;
         }
-        assert_ne!(name, mid_old, "no retired name survives the descent");
+        assert_ne!(
+            name, staged.mid_name,
+            "no retired name survives the descent"
+        );
 
-        // The descendant scope root keeps its own name: it rotates under its own
-        // write scope seed, not this wave's.
-        let descendant = interior(CHILD_SCOPE, &OWNER_ROOT_SCOPE_SEED, Vec::new());
         assert!(
             child_names_of(&read_only_open(&harness, SCOPE, &outcome.new_root_name))
-                .contains(&descendant.name.as_str().as_bytes().to_vec())
+                .contains(&staged.descendant.name.as_str().as_bytes().to_vec()),
+            "the descendant scope root keeps the name its own wave will move"
         );
     }
 
     #[test]
     fn a_resumed_wave_re_resolves_the_subtree_from_published_records_alone() {
         // A crash leaves the durable floors raised, so the resumed pass reads its
-        // own un-re-pointed root back through the at-floor recovery rather than a
-        // second adopt — with no in-memory carry from the pass that raised them.
+        // own un-re-pointed root back with no in-memory carry from the pass that
+        // raised them.
         let harness = Harness::plain();
-        let (root, _) = staged_scope(&harness);
+        let staged = staged_scope(&harness);
         let owner = owner_identity();
 
-        let first = wave(&harness, &owner, &root.name);
+        let first = wave(&harness, &owner, &staged.root.name);
         let before: Vec<WriteScopeNode> = [SCOPE, MID, LEAF]
             .into_iter()
             .map(|id| block_on(first.resolve_node(&id)).expect("the first pass enumerates"))
             .collect();
         drop(first);
 
-        let resumed = wave(&harness, &owner, &root.name);
+        let resumed = wave(&harness, &owner, &staged.root.name);
         let after: Vec<WriteScopeNode> = [SCOPE, MID, LEAF]
             .into_iter()
             .map(|id| block_on(resumed.resolve_node(&id)).expect("the resumed pass enumerates"))

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -917,6 +917,11 @@ fn wave_verdict(error: GateError) -> WritePublishError {
 }
 
 /// The same axis for a read the wave shares with the read-plane rotation edges.
+///
+/// [`ResolveFailure::ConflictingChildLabel`] is retryable to the cascade and the
+/// sweep because the write-rotation re-point wave repairs both parent indexes.
+/// This *is* that wave, so it has nothing left to wait for: retrying here spins
+/// on a conflict only this run can clear.
 fn wave_read_verdict(failure: ResolveFailure) -> WritePublishError {
     match failure {
         ResolveFailure::Unavailable => WritePublishError::NotLanded,

--- a/crates/engine/src/rotation/mod.rs
+++ b/crates/engine/src/rotation/mod.rs
@@ -28,11 +28,11 @@
 //!   wave (root re-pointed last) with the three-channel re-point, register-first
 //!   inventory swap, and root linger. The write-plane sibling of `rotate_scope`.
 //!
-//! [`ChildIndexResolver`], [`CascadeResealResolver`], [`ScopeRootPublisher`] and
-//! [`WriteWavePublisher`] have production implementations over the real transport
-//! in [`crate::net::rotation`]. [`SweepResolver`], [`ScopeExitRotator`] and
-//! [`WriteSubtreeResolver`] have no production implementation yet; tests fake
-//! them.
+//! [`ChildIndexResolver`], [`CascadeResealResolver`], [`ScopeRootPublisher`],
+//! [`WriteSubtreeResolver`] and [`WriteWavePublisher`] have production
+//! implementations over the real transport in [`crate::net::rotation`].
+//! [`SweepResolver`] and [`ScopeExitRotator`] have no production implementation
+//! yet; tests fake them.
 
 pub mod cascade;
 pub mod eager_set;

--- a/crates/engine/src/rotation/rotate_write.rs
+++ b/crates/engine/src/rotation/rotate_write.rs
@@ -50,7 +50,7 @@
 //! [`build_repoint_object`]'s two encode-side invariants are release-active, never
 //! a `debug_assert!` (AGENTS.md rule 8). Entropy enters only through the
 //! [`Entropy`] seam; the impure edges are the injected [`WriteSubtreeResolver`] and
-//! [`WriteWavePublisher`] (`net/rotation.rs` holds the production publisher).
+//! [`WriteWavePublisher`] (`net/rotation.rs` holds both production arms).
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
@@ -144,9 +144,8 @@ pub struct RepublishedNode {
 
 /// Resolve the write scope's subtree from published records — the read edge, the
 /// analogue of the cascade's `CascadeResealResolver`. Resolve + adoption-gate +
-/// unseal live behind this trait; the real network/gate wiring is not landed and
-/// tests fake it. A resolve either yields the node or a fail-closed
-/// [`ResolveFailure`].
+/// unseal live behind this trait (`net/rotation.rs::WriteWaveNet`). A resolve
+/// either yields the node or a fail-closed [`ResolveFailure`].
 pub trait WriteSubtreeResolver {
     /// Resolve `node_id`'s current write-plane node (its name + children), or a
     /// fail-closed [`ResolveFailure`] if its record cannot be authoritatively


### PR DESCRIPTION
## What

`WriteSubtreeResolver` — the write-plane name wave's **read edge** — had no production implementation. Every implementor (`FakeResolver`, `PostFlipResolver`, `FailingResolver`) lived inside `rotate_write.rs`'s `#[cfg(test)]` module, so `rotate_scope_write` compiled green and could not run in production. This lands the concrete resolver over the real seams.

`WriteWaveNet` now implements it alongside the `WriteWavePublisher` it already carried, so one value serves both edges of the wave — the shape `OwnerRotationNet` already uses for `ChildIndexResolver` / `CascadeResealResolver` / `ScopeRootPublisher`.

## How

- **Resolve + adoption-gate + unseal reuse the wave's own reads.** `resolve_node` runs `root_source` for the scope root and `interior_source` for everything below it, so every record the enumeration consumes passes the adoption gate under the caller's own scope/node label — no parallel gated read was grown.
- **Names come only from a gated parent.** `WaveSubtree` records each child's name as the descent gates its parent, so no caller-supplied label ever chooses where a node is read, and an id nothing gated named is a fail-closed refusal rather than a fetch. One id named at two **different** names aborts with `ConflictingChildLabel` — picking either would rotate one name and leave the other live. A benign `#33 D5` dual link names the child identically in both parents and is unaffected.
- **`child_node_ids` stops at a *proven* descendant scope root** — see the security section below.
- **Verdicts keep rule 6's split in both directions.** `subtree_verdict` carries only a fail-closed refusal across as `ResolveFailure::Rejected`; availability stays availability. An unresolvable node aborts the wave before the root is re-pointed, so a truncated enumeration can never leave a revokee holding a live write name under a root that claims to have moved.

### Two defects fixed along the way

**1. A resumed wave could never re-read its own root.** `root_source` now falls back to the at-floor recovery (`reread_at_floor` — the path `OwnerRotationNet::gated_root` already takes) when the root's record comes back at exactly the sequence floor its previous adopt raised. Without it the second `adopt_root` rejects as not-newer and the rotation is permanently stuck on a `Rejected` verdict no retry clears. `a_resumed_wave_re_resolves_the_subtree_from_published_records_alone` fails with `Rejected` if the fallback is removed.

**2. An unverified `directChildScopeIndex` carved nodes out of the revocation.** The `/security-review` and `/crypto-privacy-review` gates independently found the same fail-open in the first draft of this PR. That field is sealed under the root's `writeKey` and authenticated by any **committed write pseudonym** (`committed_write_pseudonyms` admits every `Permission::Write` entry, not just the owner) — so the grantee a write revoke is cutting can author it. An entry naming an ordinary in-scope node made the wave skip that node: never republished, its `ChildRef.ipnsName` left untouched by the parent's rewrite, its old name never retired. The revokee kept a live write name under a root claiming to have moved — permanently, not for the wave-bounded forgery window the residuals accept.

Only the owner-signed grant-set commitment names a scope root's own `ipnsName`, so `record_scope_boundary` now gates each claimed entry through the root gate and refuses a boundary it cannot prove. The read plane already gates this same index; the write plane used it to *exclude*, which is the direction that had to fail closed.

## Tests

New, in `net/rotation.rs` against the fake network world (the existing `Test` gate — no new suite):

- `the_enumeration_descends_gated_records_and_stops_at_a_descendant_scope_root`
- `a_planted_index_entry_never_exempts_an_ordinary_node_from_the_wave` — the fix above
- `a_node_no_gated_record_named_has_no_name_to_read_at`
- `one_id_named_at_two_names_aborts_rather_than_picking`
- `a_gate_rejected_node_aborts_the_wave_and_is_never_reported_as_staleness` — asserts the scope pointer and the new root name carry **nothing**
- `an_unresolvable_node_aborts_the_wave_rather_than_truncating_the_subtree`
- `the_production_edges_carry_the_whole_wave_from_enumeration_to_re_point` — full `rotate_scope_write` over the production resolver *and* publisher, then a read-only holder descends root → mid → leaf by rewritten child refs alone while the descendant scope root keeps its own name
- `a_resumed_wave_re_resolves_the_subtree_from_published_records_alone`

## Review gates

All three ran on this diff. Beyond the HIGH above, `/simplify` produced the `gated_scope_root` extraction (the adopt/at-floor ladder was written three times once this branch added the third) and corrected two doc blocks this branch falsified — `GatedWaveRoot`'s rationale and a test comment both claimed the root gate has no at-floor re-open, which is precisely what this branch adds.

Two suggestions were verified wrong and rejected: replacing the `read_scope_seed` unwrap with `unwrap_or_default()` (would derive a read key from an all-zero seed) and flattening `RefCell<Discovered>` into two cells (`RotationAncestry` in the same file establishes that convention).

## Gates

| Gate | Exit |
| --- | --- |
| `cargo fmt --all --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace` | 0 |
| `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` | 0 |

No TypeScript surface is touched.

## Out of scope

Two review findings land in `#1101`'s code rather than this read edge, and both are filed blocking #1019 — the production caller — so the write revoke cannot ship over them:

- #1129 — the re-seal mints grant blobs from the record's committed set, not the owner-verified plan commitment
- #1130 — the root republish checks the write-epoch floor against an enumeration-time snapshot

`rotate_scope_write` still has no production caller; that is #1019.

Closes #1108


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement production `WriteSubtreeResolver` over real seams in write-wave enumeration
> - Implements `WriteSubtreeResolver::resolve_node` on `WriteWaveNet` to enumerate nodes from published records, halting at proven descendant scope roots and failing on conflicting child labels.
> - Adds `WaveSubtree` to track discovered node names and proven descendant scope boundaries per enumeration pass, with conflict detection via `record_children`.
> - Adds `WriteWaveNet::record_scope_boundary` to validate claimed descendant scope roots by gating each against the parent-derived seed before stopping enumeration.
> - Extracts `gated_scope_root` helper to commonize root adoption/gating logic and normalize `GateError` to `ResolveFailure` across callers.
> - Adds `wave_read_verdict` and `subtree_verdict` utilities to consistently translate between `ResolveFailure` and `WritePublishError` on read and enumeration paths.
> - Risk: `read_epoch` is now taken from `envelope.epoch` rather than `outcome.adopted.epoch`; absent `read_scope_seed` now yields `NotLanded` via earlier gating rather than a separate code path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42018af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved write rotation to discover complete in-scope trees while respecting authenticated descendant boundaries.
  * Added validation for scope boundaries and conflicting labels during rotation.
  * Rotation now resolves nodes from published records before republishing.

* **Bug Fixes**
  * Improved handling of unavailable or rejected records and resumed rotation walks.
  * Standardized error reporting across rotation and subtree-resolution steps.

* **Documentation**
  * Updated rotation documentation to reflect live subtree resolution and publishing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->