### PR TITLE
fix: end an idle media body on a signal and re-broker on a worker restart

### DIFF
--- a/packages/client/src/media/service.test.ts
+++ b/packages/client/src/media/service.test.ts
@@ -83,14 +83,14 @@ interface Setup {
   channels: FakeChannel[];
 }
 
-function setup(): Setup {
+function setup(override?: MediaReader): Setup {
   const container = new FakeContainer();
   const worker = new FakeWorker();
   const channels: FakeChannel[] = [];
   const service = new MediaService({
     container,
     scriptUrl: '/sw.js',
-    reader,
+    reader: override ?? reader,
     origin: ORIGIN,
     createChannel: () => {
       const channel = new FakeChannel();
@@ -102,6 +102,9 @@ function setup(): Setup {
 }
 
 const brokeredPort = (channels: FakeChannel[]): FakePort => channels[channels.length - 1].port1;
+
+/** Drains the broker's pump and pin-release chains, which run over several ticks. */
+const settled = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe('MediaService', () => {
   it('registers the worker at the root scope and offers a port to the controller', async () => {
@@ -198,6 +201,46 @@ describe('MediaService', () => {
     expect(worker.offers).toHaveLength(2);
     expect(worker.offers[1].transfer).toEqual([channels[1].port2]);
     expect(brokeredPort(channels).started).toBe(true);
+  });
+
+  it('releases the engine stream a killed worker left pinned, on its successor asking to re-broker', async () => {
+    const closed: bigint[] = [];
+    let opens = 0;
+    const { container, worker, service, channels } = setup({
+      openContentStream: () => {
+        opens += 1;
+        return Promise.resolve(7n);
+      },
+      readStream: (_handle, _offset, length) => Promise.resolve(new ArrayBuffer(length)),
+      closeStream: (handle) => {
+        closed.push(handle);
+        return Promise.resolve();
+      },
+    });
+    container.controller = worker;
+    await service.start();
+    const url = service.createStreamUrl({
+      node: new Uint8Array([9]),
+      size: 8,
+      mimeType: 'audio/o',
+    });
+    const ticket = url.slice('/stream/'.length);
+    const port = channels[0].port2;
+    port.postMessage({ type: 'cb:media:open', requestId: 1, ticket, range: null });
+    port.postMessage({ type: 'cb:media:pull', requestId: 1 });
+    await settled();
+
+    // The worker is killed mid-playback, so no `cb:media:close` ever arrives:
+    // nothing on this side may reclaim a cursor that is still legitimately held.
+    expect(opens).toBe(1);
+    expect(closed).toEqual([]);
+
+    // Its replacement holds no ports and asks every tab to re-broker.
+    container.emit('message', { type: MEDIA_PORT_REQUEST });
+    await settled();
+
+    expect(closed).toEqual([7n]);
+    expect(channels).toHaveLength(2);
   });
 
   it('ignores an unrelated message from the worker', async () => {

--- a/packages/client/src/sw/install.test.ts
+++ b/packages/client/src/sw/install.test.ts
@@ -70,6 +70,11 @@ class FakeScope implements ServiceWorkerScopeLike {
 class FakePipe implements MediaPipeLike {
   readonly adopted: Array<{ port: MessagePortLike; clientId?: string }> = [];
   readonly responded: Array<{ url: string; clientId?: string }> = [];
+  portRequests = 0;
+
+  async requestPorts(): Promise<void> {
+    this.portRequests += 1;
+  }
 
   handles(url: URL): boolean {
     return url.pathname.startsWith('/stream/');
@@ -132,6 +137,17 @@ describe('installServiceWorker', () => {
     expect([...scope.caches.cache(APP_SHELL_CACHE).entries.keys()]).toEqual([
       `${ORIGIN}/index.html`,
     ]);
+  });
+
+  it('asks the tabs to re-broker as soon as the worker starts', async () => {
+    const scope = new FakeScope();
+    const pipe = new FakePipe();
+
+    // No `install` or `activate`: a worker the browser restarted gets neither,
+    // and the cursors its predecessor pinned are waiting on this ask.
+    installServiceWorker(scope, { pipe, fetchFn: failingFetch });
+
+    expect(pipe.portRequests).toBe(1);
   });
 
   it('answers a stream request from the media pipe, naming the client that asked', async () => {

--- a/packages/client/src/sw/install.test.ts
+++ b/packages/client/src/sw/install.test.ts
@@ -150,6 +150,39 @@ describe('installServiceWorker', () => {
     expect(pipe.portRequests).toBe(1);
   });
 
+  it('holds the fetch that restarted the worker open until the re-broker finishes', async () => {
+    const scope = new FakeScope();
+    const pipe = new FakePipe();
+    let finishRebroker = (): void => {};
+    pipe.requestPorts = () =>
+      new Promise<void>((resolve) => {
+        finishRebroker = resolve;
+      });
+
+    installServiceWorker(scope, { pipe, fetchFn: failingFetch });
+
+    // Script evaluation is not an event, so without this the browser may stop
+    // the worker again before the ask reaches the tabs.
+    const extended: Promise<unknown>[] = [];
+    scope.dispatch('fetch', {
+      request: new Request(`${ORIGIN}/stream/tkt`),
+      respondWith: () => {},
+      waitUntil: (promise) => void extended.push(promise),
+    });
+
+    expect(extended).toHaveLength(1);
+    let settled = false;
+    void Promise.all(extended).then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    finishRebroker();
+    await Promise.all(extended);
+    expect(settled).toBe(true);
+  });
+
   it('answers a stream request from the media pipe, naming the client that asked', async () => {
     const { scope, pipe } = await wire(manifestFetch('["/index.html"]'));
 

--- a/packages/client/src/sw/install.ts
+++ b/packages/client/src/sw/install.ts
@@ -27,6 +27,8 @@ export interface FetchEventLike {
   /** The window client that issued the request; empty when the browser knows none. */
   readonly clientId?: string;
   respondWith(response: Response | Promise<Response>): void;
+  /** Optional so a caller's fake event need not supply one. */
+  waitUntil?(promise: Promise<unknown>): void;
 }
 
 /** The client that sent a message; its `id` is the one `FetchEventLike.clientId` carries. */

--- a/packages/client/src/sw/install.ts
+++ b/packages/client/src/sw/install.ts
@@ -86,7 +86,7 @@ export function installServiceWorker(
   // A restarted worker gets no fresh `install`, so it re-learns the shell here.
   let learning = refresh().catch(ignore);
   // It gets no fresh `activate` either — see `MediaPipe.requestPorts`.
-  void pipe.requestPorts().catch(ignore);
+  const recovering = pipe.requestPorts().catch(ignore);
 
   scope.addEventListener('install', (event) => {
     void scope.skipWaiting();
@@ -105,6 +105,9 @@ export function installServiceWorker(
   });
 
   scope.addEventListener('fetch', (event) => {
+    // Script evaluation is not an event, so a worker the browser restarted to
+    // dispatch this fetch may be stopped again before the re-broker finishes.
+    event.waitUntil?.(recovering);
     const request = event.request;
     if (pipe.handles(new URL(request.url))) {
       event.respondWith(pipe.respond(request, event.clientId));

--- a/packages/client/src/sw/install.ts
+++ b/packages/client/src/sw/install.ts
@@ -85,9 +85,8 @@ export function installServiceWorker(
   };
   // A restarted worker gets no fresh `install`, so it re-learns the shell here.
   let learning = refresh().catch(ignore);
-  // It gets no fresh `activate` either, and it holds none of the ports its
-  // predecessor served — the tabs must re-broker to release those cursors.
-  void pipe.requestPorts();
+  // It gets no fresh `activate` either — see `MediaPipe.requestPorts`.
+  void pipe.requestPorts().catch(ignore);
 
   scope.addEventListener('install', (event) => {
     void scope.skipWaiting();

--- a/packages/client/src/sw/install.ts
+++ b/packages/client/src/sw/install.ts
@@ -61,7 +61,7 @@ export interface ServiceWorkerScopeLike extends MediaPipeScopeLike {
 }
 
 /** The pipe surface the fetch and message listeners drive. */
-export type MediaPipeLike = Pick<MediaPipe, 'handles' | 'respond' | 'adoptPort'>;
+export type MediaPipeLike = Pick<MediaPipe, 'handles' | 'respond' | 'adoptPort' | 'requestPorts'>;
 
 export interface ServiceWorkerDeps {
   pipe?: MediaPipeLike;
@@ -85,6 +85,9 @@ export function installServiceWorker(
   };
   // A restarted worker gets no fresh `install`, so it re-learns the shell here.
   let learning = refresh().catch(ignore);
+  // It gets no fresh `activate` either, and it holds none of the ports its
+  // predecessor served — the tabs must re-broker to release those cursors.
+  void pipe.requestPorts();
 
   scope.addEventListener('install', (event) => {
     void scope.skipWaiting();

--- a/packages/client/src/sw/pipe.test.ts
+++ b/packages/client/src/sw/pipe.test.ts
@@ -64,6 +64,19 @@ function stalledPort(): FakePort {
   });
 }
 
+/** Streams one window and then sits between pulls, as a buffered element does. */
+async function idleBody(
+  pipe: MediaPipe,
+  port: FakePort,
+  clientId?: string
+): Promise<{ reader: ReadableStreamDefaultReader<Uint8Array>; requestId: number }> {
+  const response = await pipe.respond(streamRequest(), clientId);
+  const reader = response.body!.getReader();
+  expect((await reader.read()).value).toEqual(new Uint8Array([1]));
+  const open = port.sent.find((message) => message.type === 'cb:media:open')!;
+  return { reader, requestId: open.requestId };
+}
+
 const streamRequest = (ticket = 'tkt', range: string | null = 'bytes=0-4'): Request =>
   new Request(`${ORIGIN}/stream/${ticket}`, {
     headers: range === null ? undefined : { range },
@@ -349,19 +362,6 @@ describe('MediaPipe.respond', () => {
 });
 
 describe('MediaPipe idle bodies', () => {
-  /** Streams one window and then sits between pulls, as a buffered element does. */
-  async function idleBody(
-    pipe: MediaPipe,
-    port: FakePort,
-    clientId?: string
-  ): Promise<{ reader: ReadableStreamDefaultReader<Uint8Array>; requestId: number }> {
-    const response = await pipe.respond(streamRequest(), clientId);
-    const reader = response.body!.getReader();
-    expect((await reader.read()).value).toEqual(new Uint8Array([1]));
-    const open = port.sent.find((message) => message.type === 'cb:media:open')!;
-    return { reader, requestId: open.requestId };
-  }
-
   it('ends an idle body as soon as the tab withdraws the stream', async () => {
     const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
     const port = streamingPort([new Uint8Array([1]), new Uint8Array([2])]);
@@ -447,9 +447,7 @@ describe('MediaPipe.requestPorts', () => {
     const pipe = new MediaPipe(scope, TIMEOUTS);
     const port = streamingPort([new Uint8Array([1]), new Uint8Array([2])]);
     pipe.adoptPort(port, 'tab-a');
-    const response = await pipe.respond(streamRequest(), 'tab-a');
-    const reader = response.body!.getReader();
-    await reader.read();
+    const { reader } = await idleBody(pipe, port, 'tab-a');
 
     await pipe.requestPorts();
 

--- a/packages/client/src/sw/pipe.test.ts
+++ b/packages/client/src/sw/pipe.test.ts
@@ -348,6 +348,117 @@ describe('MediaPipe.respond', () => {
   });
 });
 
+describe('MediaPipe idle bodies', () => {
+  /** Streams one window and then sits between pulls, as a buffered element does. */
+  async function idleBody(
+    pipe: MediaPipe,
+    port: FakePort,
+    clientId?: string
+  ): Promise<{ reader: ReadableStreamDefaultReader<Uint8Array>; requestId: number }> {
+    const response = await pipe.respond(streamRequest(), clientId);
+    const reader = response.body!.getReader();
+    expect((await reader.read()).value).toEqual(new Uint8Array([1]));
+    const open = port.sent.find((message) => message.type === 'cb:media:open')!;
+    return { reader, requestId: open.requestId };
+  }
+
+  it('ends an idle body as soon as the tab withdraws the stream', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = streamingPort([new Uint8Array([1]), new Uint8Array([2])]);
+    pipe.adoptPort(port);
+    const { reader, requestId } = await idleBody(pipe, port);
+
+    // What `MediaBroker.revoke` posts: unsolicited, with no pull in flight.
+    port.deliver({ type: 'cb:media:error', requestId, message: 'the stream was revoked' });
+
+    // No timers advanced: the body must not wait out the pull deadline.
+    await expect(reader.read()).rejects.toThrow('the stream was revoked');
+    expect(port.sent).toContainEqual({ type: 'cb:media:close', requestId });
+  });
+
+  it('ends an idle body as soon as its port is replaced', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = streamingPort([new Uint8Array([1]), new Uint8Array([2])]);
+    pipe.adoptPort(port, 'tab-a');
+    const { reader } = await idleBody(pipe, port, 'tab-a');
+
+    pipe.adoptPort(new FakePort(), 'tab-a');
+
+    await expect(reader.read()).rejects.toThrow(/media port replaced/);
+  });
+
+  it('ignores an unsolicited error posted on a port that owns no such body', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const own = streamingPort([new Uint8Array([1]), new Uint8Array([2])]);
+    const other = new FakePort();
+    pipe.adoptPort(own, 'tab-a');
+    pipe.adoptPort(other, 'tab-b');
+    const { reader, requestId } = await idleBody(pipe, own, 'tab-a');
+
+    other.deliver({ type: 'cb:media:error', requestId, message: 'not yours to fail' });
+
+    expect((await reader.read()).value).toEqual(new Uint8Array([2]));
+  });
+
+  it('ignores an unsolicited error for a body that already ended', async () => {
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const port = streamingPort([new Uint8Array([1]), new Uint8Array([2])]);
+    pipe.adoptPort(port);
+    const { reader, requestId } = await idleBody(pipe, port);
+    await reader.cancel();
+
+    expect(() =>
+      port.deliver({ type: 'cb:media:error', requestId, message: 'too late' })
+    ).not.toThrow();
+    expect(port.countOf('cb:media:close')).toBe(1);
+  });
+
+  it('retries the open as soon as the port it was sent on is replaced', async () => {
+    vi.useFakeTimers();
+    const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);
+    const silent = new FakePort();
+    pipe.adoptPort(silent, 'tab-a');
+
+    const pending = pipe.respond(streamRequest(), 'tab-a');
+    // Flushes the open onto the port without spending any of its deadline.
+    await vi.advanceTimersByTimeAsync(0);
+    const live = streamingPort([new Uint8Array([7])]);
+    pipe.adoptPort(live, 'tab-a');
+
+    const response = await pending;
+    expect(response.status).toBe(206);
+    expect(silent.countOf('cb:media:open')).toBe(1);
+    expect(live.countOf('cb:media:open')).toBe(1);
+  });
+});
+
+describe('MediaPipe.requestPorts', () => {
+  it('asks every window client to re-broker when the worker holds no port', async () => {
+    const scope = new FakeScope();
+    const pipe = new MediaPipe(scope, TIMEOUTS);
+
+    await pipe.requestPorts();
+
+    expect(scope.brokeredTo).toEqual(['tab-a', 'tab-b']);
+  });
+
+  it('asks nobody while it holds a port, leaving a paused body its cursor', async () => {
+    const scope = new FakeScope();
+    const pipe = new MediaPipe(scope, TIMEOUTS);
+    const port = streamingPort([new Uint8Array([1]), new Uint8Array([2])]);
+    pipe.adoptPort(port, 'tab-a');
+    const response = await pipe.respond(streamRequest(), 'tab-a');
+    const reader = response.body!.getReader();
+    await reader.read();
+
+    await pipe.requestPorts();
+
+    expect(scope.brokered).toEqual([]);
+    expect(port.countOf('cb:media:close')).toBe(0);
+    expect((await reader.read()).value).toEqual(new Uint8Array([2]));
+  });
+});
+
 describe('MediaPipe.adoptPort', () => {
   it('closes the port it replaces and starts the new one', () => {
     const pipe = new MediaPipe(new FakeScope(), TIMEOUTS);

--- a/packages/client/src/sw/pipe.ts
+++ b/packages/client/src/sw/pipe.ts
@@ -13,7 +13,7 @@ import {
 } from '../media/protocol.js';
 import { safeMimeType } from '../media/range.js';
 import type { MessagePortLike } from '../portRelay.js';
-import type { ClientsLike } from './clients.js';
+import type { ClientsLike, WindowClientLike } from './clients.js';
 
 /** The subset of a Service Worker global scope the pipe drives. */
 export interface MediaPipeScopeLike {
@@ -35,6 +35,9 @@ const DEFAULT_PULL_TIMEOUT_MS = 30000;
 /** One entry for every offer and request without a client identity; a real client id is never empty. */
 const ANONYMOUS_CLIENT = '';
 
+/** Why a body reading over a superseded or discarded port ends. */
+const PORT_REPLACED = 'media port replaced';
+
 type MediaHeadResponse = Extract<MediaResponse, { type: 'cb:media:head' }>;
 
 /** A client's end of the pipe, with the listener bound to it. */
@@ -49,6 +52,14 @@ interface ResponseSink {
   readonly deliver: (response: MediaResponse) => void;
 }
 
+/** A response body still streaming, and the port it reads from. */
+interface BodyEntry {
+  readonly port: MessagePortLike;
+  readonly controller: ReadableStreamDefaultController<Uint8Array>;
+  /** Resolves the pull in flight; a body ended between pulls has none. */
+  pulling: (() => void) | null;
+}
+
 export class MediaPipe {
   /**
    * One port per client: a tab's registry only knows the tickets that tab
@@ -59,10 +70,11 @@ export class MediaPipe {
   private readonly portWaiters = new Set<(adopted: string) => void>();
   private readonly sinks = new Map<number, ResponseSink>();
   /**
-   * Every response body still streaming and the port it reads from; a sink
-   * exists only between a pull and its answer.
+   * Every response body still streaming, held with its stream controller so an
+   * idle one can be ended now: a sink exists only between a pull and its answer,
+   * and a buffered media element may go a long time without pulling again.
    */
-  private readonly bodies = new Map<number, MessagePortLike>();
+  private readonly bodies = new Map<number, BodyEntry>();
   /** The armed pull deadline per request, so a cancel can disarm its own. */
   private readonly pullTimers = new Map<number, ReturnType<typeof setTimeout>>();
   private nextRequestId = 1;
@@ -93,6 +105,20 @@ export class MediaPipe {
     // Insertion order is adoption order, which the anonymous fallback reads.
     this.ports.set(clientId, { port, listener });
     for (const waiter of [...this.portWaiters]) waiter(clientId);
+  }
+
+  /**
+   * Asks every window client for a fresh channel, for a worker instance that
+   * holds none. A terminated worker runs no `detachPort`, so the cursors its
+   * bodies pinned — and the engine streams and content keys behind them — are
+   * released only when the tab re-brokers, which serving a new port does.
+   */
+  async requestPorts(): Promise<void> {
+    if (this.ports.size > 0) return;
+    const clients = await this.scope.clients.matchAll({ type: 'window' });
+    // A port adopted across the await already carries the tab's re-broker.
+    if (this.ports.size > 0) return;
+    this.askForPort(clients);
   }
 
   async respond(request: Request, clientId: string = ANONYMOUS_CLIENT): Promise<Response> {
@@ -133,9 +159,16 @@ export class MediaPipe {
     const response = asResponse(event.data);
     if (response === null) return;
     const sink = this.sinks.get(response.requestId);
-    // An unknown or already-settled id is stale traffic; another client's id is
-    // not this port's to answer.
-    if (sink?.port === port) sink.deliver(response);
+    if (sink !== undefined) {
+      // An id another client owns is not this port's to answer.
+      if (sink.port === port) sink.deliver(response);
+      return;
+    }
+    // Nothing is listening between a pull and its answer, so an unsolicited
+    // failure — a revoked ticket — has to reach the body directly.
+    if (response.type !== 'cb:media:error') return;
+    if (this.bodies.get(response.requestId)?.port !== port) return;
+    this.closeBody(response.requestId)?.controller.error(new Error(response.message));
   }
 
   private open(
@@ -152,10 +185,12 @@ export class MediaPipe {
       this.sinks.set(requestId, {
         port,
         deliver: (response) => {
-          if (response.type !== 'cb:media:head') return;
+          // An error answers the open as unusable — a dead port fails it now
+          // rather than at the response deadline, so the retry re-brokers at once.
+          if (response.type !== 'cb:media:head' && response.type !== 'cb:media:error') return;
           clearTimeout(timer);
           this.sinks.delete(requestId);
-          resolve(response);
+          resolve(response.type === 'cb:media:head' ? response : null);
         },
       });
       this.post(port, { type: 'cb:media:open', requestId, ticket, range });
@@ -164,26 +199,40 @@ export class MediaPipe {
 
   /** A zero high-water mark keeps exactly one window in flight: pull on demand. */
   private body(port: MessagePortLike, requestId: number): ReadableStream<Uint8Array> {
-    this.bodies.set(requestId, port);
     return new ReadableStream<Uint8Array>(
       {
+        // `start` runs inside this constructor, so the controller is held before
+        // the response can be read from.
+        start: (controller) => void this.bodies.set(requestId, { port, controller, pulling: null }),
         pull: (controller) => this.pullWindow(port, requestId, controller),
-        cancel: () => {
-          // The pull this cancels leaves its timer armed, and that timer discards
-          // the port — taking every other body streaming on it down too.
-          this.clearPull(requestId);
-          this.sinks.delete(requestId);
-          this.closeBody(port, requestId);
-        },
+        cancel: () => void this.closeBody(requestId),
       },
       { highWaterMark: 0 }
     );
   }
 
-  /** Ends a body and tells the tab to release the cursor and pin behind it. */
-  private closeBody(port: MessagePortLike, requestId: number): void {
+  /**
+   * Forgets a body and everything keyed to its request, or answers null when
+   * another path already ended it: the map entry is the token that makes ending
+   * a body exactly-once. Disarming the pull deadline is part of that — left
+   * armed it discards the port, taking every sibling body on it down too.
+   */
+  private takeBody(requestId: number): BodyEntry | null {
+    const body = this.bodies.get(requestId);
+    if (body === undefined) return null;
     this.bodies.delete(requestId);
-    this.post(port, { type: 'cb:media:close', requestId });
+    this.clearPull(requestId);
+    this.sinks.delete(requestId);
+    body.pulling?.();
+    body.pulling = null;
+    return body;
+  }
+
+  /** Takes a body and tells the tab to release the cursor and pin behind it. */
+  private closeBody(requestId: number): BodyEntry | null {
+    const body = this.takeBody(requestId);
+    if (body !== null) this.post(body.port, { type: 'cb:media:close', requestId });
+    return body;
   }
 
   private pullWindow(
@@ -192,9 +241,17 @@ export class MediaPipe {
     controller: ReadableStreamDefaultController<Uint8Array>
   ): Promise<void> {
     return new Promise<void>((resolve) => {
+      const body = this.bodies.get(requestId);
+      // Already ended out of band; the stream is settled and wants no window.
+      if (body === undefined) {
+        resolve();
+        return;
+      }
+      body.pulling = resolve;
       const settle = (finish: () => void): void => {
         this.clearPull(requestId);
         this.sinks.delete(requestId);
+        body.pulling = null;
         finish();
         resolve();
       };
@@ -202,8 +259,8 @@ export class MediaPipe {
       // never settles and the response hangs open forever.
       const timer = setTimeout(() => {
         settle(() => {
+          this.closeBody(requestId)?.controller.error(new Error('media pull timed out'));
           this.discardPort(port);
-          controller.error(new Error('media pull timed out'));
         });
       }, this.pullTimeoutMs);
       this.pullTimers.set(requestId, timer);
@@ -215,12 +272,13 @@ export class MediaPipe {
               settle(() => controller.enqueue(new Uint8Array(response.chunk)));
               return;
             case 'cb:media:end':
-              this.bodies.delete(requestId);
-              settle(() => controller.close());
+              // A completed window sequence left the tab nothing to release.
+              settle(() => this.takeBody(requestId)?.controller.close());
               return;
             case 'cb:media:error':
-              this.bodies.delete(requestId);
-              settle(() => controller.error(new Error(response.message)));
+              settle(() =>
+                this.closeBody(requestId)?.controller.error(new Error(response.message))
+              );
               return;
             default:
               return;
@@ -239,9 +297,12 @@ export class MediaPipe {
     // its channel, and the superseded broker drops the cursors of live bodies.
     // An unidentified client has no target, so it falls back to asking everyone.
     const owner = clients.filter((client) => client.id === clientId);
-    const targets = clientId !== ANONYMOUS_CLIENT && owner.length > 0 ? owner : clients;
-    for (const client of targets) client.postMessage({ type: MEDIA_PORT_REQUEST });
+    this.askForPort(clientId !== ANONYMOUS_CLIENT && owner.length > 0 ? owner : clients);
     return this.waitForPort(clientId);
+  }
+
+  private askForPort(targets: readonly WindowClientLike[]): void {
+    for (const client of targets) client.postMessage({ type: MEDIA_PORT_REQUEST });
   }
 
   /** Only an unidentified client may borrow a port, and only the newest offered. */
@@ -295,18 +356,21 @@ export class MediaPipe {
     this.ports.delete(clientId);
     // `MessagePort` has no close event, so this is the tab's only notice that
     // the bodies reading over this port are gone and their pins are free.
-    // Posted before the port is disentangled, or it never leaves.
-    for (const [requestId, bound] of [...this.bodies]) {
-      if (bound === entry.port) this.closeBody(entry.port, requestId);
+    // Posted before the port is disentangled, or it never leaves. Ending each
+    // body here rather than at its next pull is what keeps an idle one — a
+    // media element that has buffered enough — off the pull deadline.
+    for (const [requestId, body] of [...this.bodies]) {
+      if (body.port !== entry.port) continue;
+      this.closeBody(requestId)?.controller.error(new Error(PORT_REPLACED));
     }
     entry.port.removeEventListener('message', entry.listener);
     entry.port.close();
-    // Bodies still pulling on the dead port would hang forever; failing them
-    // makes the media element re-request, which re-brokers and re-buffers.
+    // What is left is an `open` still waiting on the dead port; failing it makes
+    // the response re-broker and retry instead of waiting out its deadline.
     for (const [requestId, sink] of [...this.sinks]) {
       if (sink.port !== entry.port) continue;
       this.sinks.delete(requestId);
-      sink.deliver({ type: 'cb:media:error', requestId, message: 'media port replaced' });
+      sink.deliver({ type: 'cb:media:error', requestId, message: PORT_REPLACED });
     }
   }
 }

--- a/packages/client/src/sw/pipe.ts
+++ b/packages/client/src/sw/pipe.ts
@@ -13,7 +13,7 @@ import {
 } from '../media/protocol.js';
 import { safeMimeType } from '../media/range.js';
 import type { MessagePortLike } from '../portRelay.js';
-import type { ClientsLike, WindowClientLike } from './clients.js';
+import type { ClientsLike } from './clients.js';
 
 /** The subset of a Service Worker global scope the pipe drives. */
 export interface MediaPipeScopeLike {
@@ -35,9 +35,6 @@ const DEFAULT_PULL_TIMEOUT_MS = 30000;
 /** One entry for every offer and request without a client identity; a real client id is never empty. */
 const ANONYMOUS_CLIENT = '';
 
-/** Why a body reading over a superseded or discarded port ends. */
-const PORT_REPLACED = 'media port replaced';
-
 type MediaHeadResponse = Extract<MediaResponse, { type: 'cb:media:head' }>;
 
 /** A client's end of the pipe, with the listener bound to it. */
@@ -52,12 +49,11 @@ interface ResponseSink {
   readonly deliver: (response: MediaResponse) => void;
 }
 
-/** A response body still streaming, and the port it reads from. */
 interface BodyEntry {
   readonly port: MessagePortLike;
   readonly controller: ReadableStreamDefaultController<Uint8Array>;
-  /** Resolves the pull in flight; a body ended between pulls has none. */
-  pulling: (() => void) | null;
+  /** The deadline and resolver of the pull in flight; a body between pulls has none. */
+  pull: { readonly timer: ReturnType<typeof setTimeout>; readonly resolve: () => void } | null;
 }
 
 export class MediaPipe {
@@ -75,8 +71,6 @@ export class MediaPipe {
    * and a buffered media element may go a long time without pulling again.
    */
   private readonly bodies = new Map<number, BodyEntry>();
-  /** The armed pull deadline per request, so a cancel can disarm its own. */
-  private readonly pullTimers = new Map<number, ReturnType<typeof setTimeout>>();
   private nextRequestId = 1;
   private readonly brokerTimeoutMs: number;
   private readonly responseTimeoutMs: number;
@@ -114,11 +108,10 @@ export class MediaPipe {
    * released only when the tab re-brokers, which serving a new port does.
    */
   async requestPorts(): Promise<void> {
-    if (this.ports.size > 0) return;
     const clients = await this.scope.clients.matchAll({ type: 'window' });
-    // A port adopted across the await already carries the tab's re-broker.
+    // A port held by now is a tab that already re-brokered.
     if (this.ports.size > 0) return;
-    this.askForPort(clients);
+    for (const client of clients) client.postMessage({ type: MEDIA_PORT_REQUEST });
   }
 
   async respond(request: Request, clientId: string = ANONYMOUS_CLIENT): Promise<Response> {
@@ -168,7 +161,7 @@ export class MediaPipe {
     // failure — a revoked ticket — has to reach the body directly.
     if (response.type !== 'cb:media:error') return;
     if (this.bodies.get(response.requestId)?.port !== port) return;
-    this.closeBody(response.requestId)?.controller.error(new Error(response.message));
+    this.failBody(response.requestId, response.message);
   }
 
   private open(
@@ -201,45 +194,49 @@ export class MediaPipe {
   private body(port: MessagePortLike, requestId: number): ReadableStream<Uint8Array> {
     return new ReadableStream<Uint8Array>(
       {
-        // `start` runs inside this constructor, so the controller is held before
-        // the response can be read from.
-        start: (controller) => void this.bodies.set(requestId, { port, controller, pulling: null }),
-        pull: (controller) => this.pullWindow(port, requestId, controller),
-        cancel: () => void this.closeBody(requestId),
+        start: (controller) => void this.bodies.set(requestId, { port, controller, pull: null }),
+        pull: () => this.pullWindow(requestId),
+        cancel: () => void this.releaseBody(requestId),
       },
       { highWaterMark: 0 }
     );
   }
 
+  /** Ends the pull in flight, if any: its deadline, its sink and its promise. */
+  private finishPull(requestId: number, body: BodyEntry): void {
+    this.sinks.delete(requestId);
+    if (body.pull === null) return;
+    clearTimeout(body.pull.timer);
+    body.pull.resolve();
+    body.pull = null;
+  }
+
   /**
-   * Forgets a body and everything keyed to its request, or answers null when
-   * another path already ended it: the map entry is the token that makes ending
-   * a body exactly-once. Disarming the pull deadline is part of that — left
-   * armed it discards the port, taking every sibling body on it down too.
+   * Forgets a body, or answers null when another path already ended it: the map
+   * entry is the token that makes ending a body exactly-once. A pull deadline
+   * left armed would discard the port, taking every sibling body on it down too.
    */
   private takeBody(requestId: number): BodyEntry | null {
     const body = this.bodies.get(requestId);
     if (body === undefined) return null;
     this.bodies.delete(requestId);
-    this.clearPull(requestId);
-    this.sinks.delete(requestId);
-    body.pulling?.();
-    body.pulling = null;
+    this.finishPull(requestId, body);
     return body;
   }
 
   /** Takes a body and tells the tab to release the cursor and pin behind it. */
-  private closeBody(requestId: number): BodyEntry | null {
+  private releaseBody(requestId: number): BodyEntry | null {
     const body = this.takeBody(requestId);
     if (body !== null) this.post(body.port, { type: 'cb:media:close', requestId });
     return body;
   }
 
-  private pullWindow(
-    port: MessagePortLike,
-    requestId: number,
-    controller: ReadableStreamDefaultController<Uint8Array>
-  ): Promise<void> {
+  /** Fails a body now, rather than at a pull an idle reader may never make. */
+  private failBody(requestId: number, message: string): void {
+    this.releaseBody(requestId)?.controller.error(new Error(message));
+  }
+
+  private pullWindow(requestId: number): Promise<void> {
     return new Promise<void>((resolve) => {
       const body = this.bodies.get(requestId);
       // Already ended out of band; the stream is settled and wants no window.
@@ -247,23 +244,20 @@ export class MediaPipe {
         resolve();
         return;
       }
-      body.pulling = resolve;
+      const { port, controller } = body;
       const settle = (finish: () => void): void => {
-        this.clearPull(requestId);
-        this.sinks.delete(requestId);
-        body.pulling = null;
+        this.finishPull(requestId, body);
         finish();
-        resolve();
       };
       // A tab that died mid-stream swallows the pull; without this the body
       // never settles and the response hangs open forever.
       const timer = setTimeout(() => {
         settle(() => {
-          this.closeBody(requestId)?.controller.error(new Error('media pull timed out'));
+          this.failBody(requestId, 'media pull timed out');
           this.discardPort(port);
         });
       }, this.pullTimeoutMs);
-      this.pullTimers.set(requestId, timer);
+      body.pull = { timer, resolve };
       this.sinks.set(requestId, {
         port,
         deliver: (response) => {
@@ -276,9 +270,7 @@ export class MediaPipe {
               settle(() => this.takeBody(requestId)?.controller.close());
               return;
             case 'cb:media:error':
-              settle(() =>
-                this.closeBody(requestId)?.controller.error(new Error(response.message))
-              );
+              settle(() => this.failBody(requestId, response.message));
               return;
             default:
               return;
@@ -297,12 +289,9 @@ export class MediaPipe {
     // its channel, and the superseded broker drops the cursors of live bodies.
     // An unidentified client has no target, so it falls back to asking everyone.
     const owner = clients.filter((client) => client.id === clientId);
-    this.askForPort(clientId !== ANONYMOUS_CLIENT && owner.length > 0 ? owner : clients);
-    return this.waitForPort(clientId);
-  }
-
-  private askForPort(targets: readonly WindowClientLike[]): void {
+    const targets = clientId !== ANONYMOUS_CLIENT && owner.length > 0 ? owner : clients;
     for (const client of targets) client.postMessage({ type: MEDIA_PORT_REQUEST });
+    return this.waitForPort(clientId);
   }
 
   /** Only an unidentified client may borrow a port, and only the newest offered. */
@@ -331,13 +320,6 @@ export class MediaPipe {
     });
   }
 
-  private clearPull(requestId: number): void {
-    const timer = this.pullTimers.get(requestId);
-    if (timer === undefined) return;
-    clearTimeout(timer);
-    this.pullTimers.delete(requestId);
-  }
-
   private post(port: MessagePortLike, message: MediaRequest): void {
     port.postMessage(message);
   }
@@ -354,23 +336,21 @@ export class MediaPipe {
     const entry = this.ports.get(clientId);
     if (!entry) return;
     this.ports.delete(clientId);
+    const replaced = 'media port replaced';
     // `MessagePort` has no close event, so this is the tab's only notice that
     // the bodies reading over this port are gone and their pins are free.
-    // Posted before the port is disentangled, or it never leaves. Ending each
-    // body here rather than at its next pull is what keeps an idle one — a
-    // media element that has buffered enough — off the pull deadline.
+    // Posted before the port is disentangled, or it never leaves.
     for (const [requestId, body] of [...this.bodies]) {
-      if (body.port !== entry.port) continue;
-      this.closeBody(requestId)?.controller.error(new Error(PORT_REPLACED));
+      if (body.port === entry.port) this.failBody(requestId, replaced);
     }
     entry.port.removeEventListener('message', entry.listener);
     entry.port.close();
-    // What is left is an `open` still waiting on the dead port; failing it makes
-    // the response re-broker and retry instead of waiting out its deadline.
+    // Failing an `open` still waiting on this port re-brokers its retry instead
+    // of waiting out the response deadline.
     for (const [requestId, sink] of [...this.sinks]) {
       if (sink.port !== entry.port) continue;
       this.sinks.delete(requestId);
-      sink.deliver({ type: 'cb:media:error', requestId, message: PORT_REPLACED });
+      sink.deliver({ type: 'cb:media:error', requestId, message: replaced });
     }
   }
 }


### PR DESCRIPTION
Both issues rewrite `packages/client/src/sw/pipe.ts`, so they ship as one diff: split across two PRs they would merge textually clean into a broken combination.

## \#1063 — an idle body can be ended now, not at the pull deadline

`MediaPipe` kept a `ResponseSink` per request only between a pull and its answer, and the body stream runs at `highWaterMark: 0`. A media element that had buffered enough had no pull in flight, so in that window nothing could reach its body:

- an unsolicited `cb:media:error` — what `MediaBroker.revoke` posts when a stream URL is withdrawn — was dropped, and the body only failed on a pull that never came;
- `detachPort` posted `cb:media:close` for every body on a dying port, but an idle one still stalled the full 30 s `pullTimeoutMs`, whose expiry then called `discardPort` and took every sibling body on that port down with it.

The `bodies` map now holds each body's `ReadableStreamDefaultController` alongside its port, captured in the stream's `start`. One private `takeBody` drops everything keyed to a request — the entry, its armed pull deadline, its sink, and the resolver of any pull in flight — and answers `null` when some other path already ended it. That map entry is the token that makes ending a body **exactly-once**, so a revoke, a detach, a cancel and a pull answer are all safe in any interleaving: no double-`close()` on a controller, no orphaned pull promise, no orphaned deadline.

An `open` still waiting on a port that dies now fails with the port instead of waiting out `responseTimeoutMs`, so `respond`'s existing retry re-brokers immediately.

## \#1097 — a killed worker's cursors are reclaimed by a signal, not a timer

A terminated Service Worker runs no `detachPort`, and its replacement has no record of the bodies it served, so `adoptPort` → `detachPort` posts nothing either. Every stranded tab-side cursor kept a `MediaBroker` pin — and the engine stream and its live content key behind it — until the tab happened to re-broker. `lingerMs`/`reclaimIdle` never help: they only act on pins with zero cursors.

`MediaPipe.requestPorts()` asks every window client to re-broker, and `installServiceWorker` calls it as the worker script evaluates. That is the only signal available: a restarted worker fires no `install` and no `activate` — the same reason the app-shell precache already re-learns at that point.

Idempotence and the "do not reclaim a paused body" requirement fall out of two existing facts rather than new machinery:

- the tab-side `MediaBroker.serve` already calls `close()`, dropping every cursor and pin, so an extra re-broker after a spurious kill converges rather than duplicating or double-ending anything;
- `requestPorts` returns early while the pipe holds any port, and re-checks after its `matchAll`. A live worker therefore never broadcasts, so a paused `<video>` that is still legitimately holding a body open is untouched. A fresh instance can only be reached when no response body was pending, since the browser keeps a worker alive for a streaming response.

Explicitly **not** done, per the issue: no per-cursor idle timer, and no timeout was lengthened or retried — both bugs are fixed with an explicit signal.

## Tests

All in suites the required **Test** gate already runs (`pnpm test` → `packages/client` vitest).

`pipe.test.ts`
- an idle body ends at once when the tab withdraws the stream, and the tab is told to release the cursor
- an idle body ends at once when its port is replaced
- an unsolicited error posted on a port that owns no such body is ignored
- an unsolicited error for a body that already ended is a no-op, not a double-close
- an open retries at once when its port is replaced — under fake timers that are never advanced, so waiting out a deadline hangs the test instead of passing it
- `requestPorts` asks every window client when the worker holds no port
- `requestPorts` asks nobody while it holds one, and the paused body keeps its cursor and resumes

`service.test.ts`
- an engine stream a killed worker left pinned is released when its successor asks the tab to re-broker, asserted against `closeStream`; the same test asserts nothing reclaimed it while it was still legitimately held

`install.test.ts`
- the worker asks the tabs to re-broker on startup, with no `install` or `activate` dispatched

Each new mechanism was checked by mutation: reverting the out-of-band error routing, the detach-time controller error, or the `requestPorts` broadcast each turns the matching test red.

## Review gates

`/security-review` on the branch diff: no findings. It traced the three guards on the out-of-band error branch (sink-present early return, error-only, port identity), confirmed `open` resolving `null` cannot smuggle a head past the status/header/`safeMimeType`/CSP clamps or steer the retry cross-tab, confirmed the broadcast is unreachable from untrusted input, and confirmed no new plaintext retention.

`/simplify` findings folded in as a second commit: the pull deadline moved off its own map onto the body entry it is keyed with, `failBody` replaced a four-times-repeated take-then-error idiom, `pullWindow` dropped two parameters that aliased fields of the entry it looks up, the extracted one-line broadcast helper went back inline, a redundant pre-`await` guard and several narrating comments went away, and the startup `requestPorts` call no longer drops a `matchAll` rejection.

One finding deliberately **not** taken: two reviewers flagged that a worker restarted by a media fetch broadcasts twice — once at startup, once from `acquirePort` — costing an extra `MessageChannel` and one aborted `open`. Verified the cost is bounded to that: both asks are posted back to back, so the tab handles them before the worker's `open` can arrive, and no cursor or engine stream is torn down. `respond`'s two-attempt retry is the designed handler for a port that dies mid-`open`, and this PR is what makes that retry immediate rather than deadline-bound. Every dedupe formulation needs per-ask scope tracking to avoid starving a second tab waiting on a narrower ask — more protocol state than one in-process round trip is worth.

Closes #1063
Closes #1097


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix idle media body termination on signal and re-broker media ports on worker restart
> - Idle response bodies in `MediaPipe` now terminate immediately on unsolicited `cb:media:error` or when their owning port is replaced, rather than hanging until the next pull.
> - On startup, the service worker calls `pipe.requestPorts()` to ask all window clients to re-broker media ports, and keeps the worker alive on the first fetch until re-brokering completes via `waitUntil`.
> - Pull timeouts in `MediaPipe.pullWindow` now fail only the affected body and trigger re-brokering, avoiding collateral failure of sibling bodies.
> - `MediaPipe.open` now resolves with `null` on `cb:media:error` so callers can retry immediately instead of waiting for the response timeout.
> - Behavioral Change: detaching a port now immediately fails all bodies and pending opens tied to that port rather than letting them hang.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9e28b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media playback reliability when workers restart or streams are replaced.
  * Streams now close promptly when revoked, canceled, or affected by errors.
  * Improved recovery and retry behavior for interrupted media requests.
  * Prevented active playback from being disrupted during media port re-brokering.
  * Service worker startup now proactively restores media connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->