### PR TITLE
feat: convert invite claims into personal grants

### DIFF
--- a/crates/engine/src/grants/invite.rs
+++ b/crates/engine/src/grants/invite.rs
@@ -25,8 +25,12 @@
 
 use cipherbox_core::codec::{Map, Value, decode, encode_fixed_depth};
 use cipherbox_core::error::{CodecError, Malformed};
-use cipherbox_core::seal::{GrantLedgerEntry, GrantSetCommitment, Permission, verify_grant_set};
-use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaSigner, EcdsaVerifier};
+use cipherbox_core::seal::{
+    GrantLedgerEntry, GrantSetCommitment, MAX_GRANT_BLOBS, Permission, verify_grant_set,
+};
+use cipherbox_core::suite::ecdsa::{
+    EcdsaSignature, EcdsaSigner, EcdsaVerifier, IDENTITY_PUBLIC_LEN,
+};
 use cipherbox_core::suite::secret::{SECRET_LEN, SecretBytes};
 use cipherbox_core::suite::x25519::{X25519Public, X25519Secret};
 use cipherbox_core::{ipns::IpnsName, kdf};
@@ -100,6 +104,13 @@ pub enum InviteError {
     /// Conversion exists to re-anchor a bearer link to a contact-anchored
     /// identity, so anchoring back to the ephemeral half is refused.
     ClaimantIsTheEphemeralHalf,
+    /// The claim handed back the owner's own contact bundle, which the invite URL
+    /// carries. The owner is not a grantee of its own scope.
+    ClaimantIsTheOwner,
+    /// The set is at the grant-set ceiling
+    /// ([`MAX_GRANT_BLOBS`](cipherbox_core::seal::MAX_GRANT_BLOBS)); one more row
+    /// could only ever mint a record its own decoder refuses.
+    GrantSetFull,
     /// The claimant's encryption subkey is non-contributory, so no blinded tag
     /// binds a grant to it.
     UnusableClaimantKey,
@@ -126,6 +137,8 @@ impl InviteError {
             Self::LinkExpired => "link-expired",
             Self::ClaimantContact(_) => "claimant-contact-invalid",
             Self::ClaimantIsTheEphemeralHalf => "claimant-is-the-ephemeral-half",
+            Self::ClaimantIsTheOwner => "claimant-is-the-owner",
+            Self::GrantSetFull => "grant-set-full",
             Self::UnusableClaimantKey => "unusable-claimant-key",
             Self::DuplicateTag => "duplicate-tag",
             Self::Authority(v) => v.check(),
@@ -226,12 +239,38 @@ impl LinkCapability {
     }
 }
 
-/// A minted invite link: the rows the owner commits, plus the capability flag
-/// the host renders and revocation must respect.
+/// One invite link as the owner recorded it at mint — **owner-local state, never
+/// network bytes**.
+///
+/// A published ledger row is deliberately byte-shaped like a personal grantee's,
+/// so nothing in a resolved record says "this row is an invite", and the fields
+/// that would say so (`recipientIdentityPk`, `expiresAt`) sit outside the owner's
+/// signature and are re-authorable by any write-grantee. Conversion therefore
+/// decides *what may be claimed* from this record and never from the record it
+/// converts against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecordedInvite {
+    /// The link's blinded tag.
+    pub tag: [u8; 32],
+    /// The ephemeral identity a fragment holder signs its claim with.
+    pub ephemeral_identity_pk: [u8; IDENTITY_PUBLIC_LEN],
+    /// The ephemeral encryption subkey the link's blob is sealed to.
+    pub ephemeral_enc_pk: [u8; SECRET_LEN],
+    /// The deadline as minted. This copy is the authority: the published
+    /// `expiresAt` is a cooperating-reader hint a write-grantee can strip or
+    /// forge ([`GrantLedgerEntry::expires_at`]).
+    pub expires_at: Option<UnixMillis>,
+}
+
+/// A minted invite link: the rows the owner commits, the record the owner keeps,
+/// and the capability flag the host renders and revocation must respect.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MintedInvite {
     /// The link's blinded tag, commitment entry and ledger row.
     pub row: GrantRow,
+    /// The owner-local record [`convert_invite_claim`] and
+    /// [`revoke_invite_link`] act on. Persist it with the link.
+    pub link: RecordedInvite,
     /// What the link hands out.
     pub capability: LinkCapability,
 }
@@ -252,7 +291,7 @@ pub fn mint_invite_grant(
     permission: Permission,
     expires_at: Option<UnixMillis>,
 ) -> Result<MintedInvite, InviteError> {
-    let expires_at = match expires_at {
+    let deadline = match expires_at {
         Some(deadline) => Some(NonZeroU64::new(deadline.0).ok_or(InviteError::InvalidExpiry)?),
         None => None,
     };
@@ -266,8 +305,14 @@ pub fn mint_invite_grant(
         permission,
     )
     .ok_or(InviteError::UnusableInviteeKey)?;
-    row.ledger_entry.expires_at = expires_at;
+    row.ledger_entry.expires_at = deadline;
     Ok(MintedInvite {
+        link: RecordedInvite {
+            tag: row.tag,
+            ephemeral_identity_pk: invitee.identity_pk().to_sec1(),
+            ephemeral_enc_pk: invitee.enc_public().to_bytes(),
+            expires_at,
+        },
         row,
         capability: LinkCapability::of(permission),
     })
@@ -298,7 +343,8 @@ impl InviteClaim {
     }
 
     /// Decode a claim (strict det-CBOR). A missing or mistyped field is
-    /// [`Malformed`].
+    /// [`Malformed`]. Unknown fields are dropped rather than preserved: this is a
+    /// consume-once engine payload, not a re-sealed shared structure.
     pub fn decode(bytes: &[u8]) -> Result<Self, CodecError> {
         let value = decode(bytes)?;
         let map = value.as_map()?;
@@ -318,11 +364,15 @@ impl InviteClaim {
 
 /// Post a claim to the owner's mailbox, sealed to the owner's encryption subkey
 /// and signed — as the mailbox sender — with the link's ephemeral identity key.
-/// That signature is what [`convert_invite_claim`] binds to the ephemeral public
-/// half the ledger commits, so only a fragment holder can claim.
+/// That signature is what [`convert_invite_claim`] binds to the ephemeral half the
+/// owner recorded, so only a fragment holder can claim.
 ///
 /// `owner` is the contact bundle the invite URL carries; `ephemeral_scalar` is
 /// fresh-per-call HPKE entropy from the injected seam.
+///
+/// Residual: the post is an authenticated API call addressed to the owner's
+/// identity key, so the transport learns claimant→owner even for claims the owner
+/// never converts. Inherent to the mailbox; the payload itself stays sealed.
 #[allow(clippy::too_many_arguments)]
 pub async fn post_invite_claim<M: Mailbox>(
     mailbox: &M,
@@ -350,7 +400,9 @@ pub async fn post_invite_claim<M: Mailbox>(
 /// the commitment, and the encryption subkey secret every blinded tag derives
 /// from. Holding both is what makes a caller the owner.
 pub struct OwnerAuthority<'a> {
-    /// Owner identity signer — the key whose signature authorises the set.
+    /// Owner identity signer. Nothing here signs with it — it is the capability
+    /// token itself, since verifying the commitment against a *supplied* public
+    /// key would prove nothing about who is calling.
     pub identity_signer: &'a EcdsaSigner,
     /// Owner encryption subkey secret — the pairwise ECDH half.
     pub enc_secret: &'a X25519Secret,
@@ -359,8 +411,14 @@ pub struct OwnerAuthority<'a> {
 /// A scope root's owner-signed grant set as resolved: the commitment, its
 /// signature, and the write-body ledger it must reproduce. The scope root's
 /// `ipnsName` is the commitment's own, so no caller supplies one.
+///
+/// Must be the **currently adopted** record's set. The commitment is deliberately
+/// epoch-free (`CONTEXT.md`), so a stale one still verifies and re-signing it
+/// resurrects every tag cut since; the adoption gate's floor law is what keeps a
+/// served-stale record out.
 pub struct CommittedScope<'a> {
-    /// The scope id the writer pseudonyms bind.
+    /// The scope id the writer pseudonyms bind. Must be the scope the commitment
+    /// belongs to — no field of the commitment carries it.
     pub scope_id: &'a [u8; 16],
     /// The owner-signed grant-set commitment.
     pub commitment: &'a GrantSetCommitment,
@@ -384,45 +442,64 @@ impl OwnerAuthority<'_> {
     }
 }
 
+/// What converting a claim did to the owner-signed set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaimOutcome {
+    /// The claimant had no grant on this scope; one was appended.
+    Granted,
+    /// The claimant already held a read grant and claimed a write link, so the
+    /// committed entry was raised to write. A claim never lowers a permission.
+    Upgraded,
+    /// The claimant already held this grant — a redelivered claim. The set comes
+    /// back untouched and needs no republish.
+    Unchanged,
+}
+
 /// A claim converted into a personal grant.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConvertedClaim {
-    /// The personal grant minted for the claimant's contact-anchored identity.
+    /// The personal grant for the claimant's contact-anchored identity, at the
+    /// permission the returned commitment carries. It inherits no deadline: the
+    /// link expires, the grants it produced do not.
     pub row: GrantRow,
     /// The grant-set commitment the owner re-signs. The link's own entry stays,
     /// so one link yields a grant per claimant until it expires or is revoked.
     pub commitment: GrantSetCommitment,
     /// The grant ledger matching it.
     pub ledger: Vec<GrantLedgerEntry>,
-    /// `false` when the claimant already held a grant at this tag — a
-    /// redelivered claim, which changes nothing and needs no republish.
-    pub newly_granted: bool,
+    /// What this conversion changed.
+    pub outcome: ClaimOutcome,
 }
 
 /// Convert a sender-verified invite claim into a personal grant for the
 /// claimant's contact-anchored identity.
 ///
-/// The link's row commits the ephemeral public half, which is structurally a
-/// login identity rather than a contact-anchored one; re-anchoring is the whole
-/// point of conversion, so the minted grant binds the claimant's imported
-/// contact and never the ephemeral half. `now` is the injected
-/// [`Scheduler::now`](crate::seams::Scheduler::now) instant.
+/// `links` is the owner's own record of the live links on this scope
+/// ([`RecordedInvite`]); a claim converts only against one of those. Nothing in a
+/// resolved record marks a row as an invite, and the row fields that could
+/// (`recipientIdentityPk`, `expiresAt`) sit outside the owner's signature, so
+/// deciding claimability from the record would let any committed grantee — or any
+/// write-grantee re-authoring the ledger — drive the owner into signing a grant
+/// for an identity the owner never approved.
+///
+/// The ephemeral identity a link commits is structurally a login identity rather
+/// than a contact-anchored one; re-anchoring is the whole point of conversion, so
+/// the minted grant binds the claimant's imported contact and never the ephemeral
+/// half. `now` is the injected [`Scheduler::now`](crate::seams::Scheduler::now)
+/// instant. The owner's recorded deadline is the authority — the published one is
+/// honoured as well, but only ever to shorten a link, since a write-grantee can
+/// re-author that field.
 ///
 /// The caller signs and publishes the returned set, and acks the mailbox item
-/// only once that is durable (`mailbox` ack-after-durable) — a redelivery then
-/// converts to the same tag and changes nothing.
-///
-/// Residual: a ledger row's `recipientIdentityPk` sits outside the owner-signed
-/// commitment ([`enforce_committed_ledger`]), so a write-grantee re-authoring the
-/// write-body can point a committed row at an ephemeral identity it holds and
-/// have a claim convert at that row's committed permission. It gains no
-/// permission it does not already hold — only an extra committed tag surviving a
-/// cut of its original one. Pinned by
-/// `a_write_grantee_can_retarget_a_committed_row_at_an_ephemeral_identity`, so
-/// tightening this has to update that test.
+/// only once that is durable (`mailbox` ack-after-durable). The transport is
+/// integrity-untrusted and may redeliver: a redelivered claim already converted is
+/// [`ClaimOutcome::Unchanged`], but one whose grant the owner has since cut reads
+/// as a fresh claim, so a caller that revoked a converted grantee must drop claims
+/// deriving that tag rather than re-converting them.
 pub fn convert_invite_claim(
     owner: &OwnerAuthority<'_>,
     scope: &CommittedScope<'_>,
+    links: &[RecordedInvite],
     item: &VerifiedMailboxItem,
     now: UnixMillis,
 ) -> Result<ConvertedClaim, InviteError> {
@@ -433,25 +510,27 @@ pub fn convert_invite_claim(
         return Err(InviteError::ScopeMismatch);
     }
 
-    // The seal's inner sender signature is already verified; binding it to the
-    // ephemeral half this owner committed is what makes it a claim on this link.
+    // The seal's inner sender signature is already verified; binding it to a link
+    // the owner recorded is what makes it a claim rather than a re-share.
     // Ambiguity is refused rather than resolved to the first match.
     let sender = item.sender_identity.to_sec1();
-    let mut matches = scope
-        .ledger
-        .iter()
-        .filter(|e| e.recipient_identity_pk == sender);
+    let mut matches = links.iter().filter(|l| l.ephemeral_identity_pk == sender);
     let link = matches.next().ok_or(InviteError::LinkNotCommitted)?;
     if matches.next().is_some() {
         return Err(InviteError::LinkNotCommitted);
     }
+    if link.expires_at.is_some_and(|deadline| now.0 >= deadline.0) {
+        return Err(InviteError::LinkExpired);
+    }
+    // Re-derive the record's tag, so a link recorded against another scope root
+    // cannot be replayed here.
     let link_enc =
-        X25519Public::from_bytes(link.recipient_enc_pk).ok_or(InviteError::LinkNotCommitted)?;
+        X25519Public::from_bytes(link.ephemeral_enc_pk).ok_or(InviteError::LinkNotCommitted)?;
     if recipient_blinded_tag(owner.enc_secret, &link_enc, name) != Some(link.tag) {
         return Err(InviteError::LinkNotCommitted);
     }
-    // The owner-signed entry carries the authoritative permission; a write-
-    // grantee can re-author the ledger row's copy of it.
+    // The owner-signed entry carries the authoritative permission, and its
+    // absence is the link's revocation signal.
     let permission = scope
         .commitment
         .entries
@@ -459,17 +538,29 @@ pub fn convert_invite_claim(
         .find(|e| e.tag == link.tag)
         .map(|e| e.permission)
         .ok_or(InviteError::LinkNotCommitted)?;
-    if !entry_is_live(link, now) {
+    // The published deadline is honoured too, so an expired row is inert here
+    // before any prune reaches it. Only ever an additional restriction: a
+    // write-grantee re-authoring this field can shorten a link, never extend one.
+    if scope
+        .ledger
+        .iter()
+        .any(|e| e.tag == link.tag && !entry_is_live(e, now))
+    {
         return Err(InviteError::LinkExpired);
     }
 
     let contact = import_contact(&claim.contact_code).map_err(InviteError::ClaimantContact)?;
-    if contact.identity_pk() == item.sender_identity
-        || contact.enc_subkey().to_bytes() == link.recipient_enc_pk
+    if contact.identity_pk().to_sec1() == link.ephemeral_identity_pk
+        || contact.enc_subkey().to_bytes() == link.ephemeral_enc_pk
     {
         return Err(InviteError::ClaimantIsTheEphemeralHalf);
     }
-    let row = mint_grant_row(
+    // The invite URL carries the owner's own bundle; handing it back would file a
+    // self-grant that consumes a slot and reads as a grantee in the host's UI.
+    if contact.enc_subkey() == owner.enc_secret.public() {
+        return Err(InviteError::ClaimantIsTheOwner);
+    }
+    let mut row = mint_grant_row(
         owner.enc_secret,
         &contact.identity_pk(),
         &contact.enc_subkey(),
@@ -479,19 +570,41 @@ pub fn convert_invite_claim(
     )
     .ok_or(InviteError::UnusableClaimantKey)?;
 
-    let newly_granted = !scope.ledger.iter().any(|e| e.tag == row.tag);
     let mut commitment = scope.commitment.clone();
     let mut ledger = scope.ledger.to_vec();
-    if newly_granted {
-        commitment.entries.push(row.commitment_entry.clone());
-        ledger.push(row.ledger_entry.clone());
-    }
+    // The blinded tag does not depend on permission, so an existing grantee
+    // claiming a write link is an upgrade of the entry already committed.
+    let outcome = match commitment.entries.iter().position(|e| e.tag == row.tag) {
+        None => {
+            commitment.entries.push(row.commitment_entry.clone());
+            ledger.push(row.ledger_entry.clone());
+            ClaimOutcome::Granted
+        }
+        Some(i)
+            if commitment.entries[i].permission == Permission::Read
+                && permission == Permission::Write =>
+        {
+            commitment.entries[i].permission = Permission::Write;
+            for entry in ledger.iter_mut().filter(|e| e.tag == row.tag) {
+                entry.permission = Permission::Write;
+            }
+            ClaimOutcome::Upgraded
+        }
+        Some(i) => {
+            // A claim never lowers what the owner already committed; report the
+            // grant that stands, not the one the link would have minted.
+            let held = commitment.entries[i].permission;
+            row.commitment_entry.permission = held;
+            row.ledger_entry.permission = held;
+            ClaimOutcome::Unchanged
+        }
+    };
     check_publishable(&commitment, &ledger)?;
     Ok(ConvertedClaim {
         row,
         commitment,
         ledger,
-        newly_granted,
+        outcome,
     })
 }
 
@@ -517,30 +630,32 @@ impl InviteRevocation {
     }
 }
 
-/// Cut an invite link out of the owner-signed grant set. Owner-only.
+/// Cut an invite link out of the owner-signed grant set. Owner-only, and only a
+/// link the owner recorded — a tag that is merely committed belongs to some
+/// grantee and is not this function's to cut.
 ///
-/// Grants already converted from the link are untouched — revoking a link ends
+/// Grants already converted from the link are untouched: revoking a link ends
 /// future claims, not the personal grants it already produced.
 pub fn revoke_invite_link(
     owner: &OwnerAuthority<'_>,
     scope: &CommittedScope<'_>,
-    tag: &[u8; 32],
+    link: &RecordedInvite,
 ) -> Result<InviteRevocation, InviteError> {
     owner.authorise(scope)?;
     let capability = scope
         .commitment
         .entries
         .iter()
-        .find(|e| &e.tag == tag)
+        .find(|e| e.tag == link.tag)
         .map(|e| LinkCapability::of(e.permission))
         .ok_or(InviteError::LinkNotCommitted)?;
 
     let mut commitment = scope.commitment.clone();
-    commitment.entries.retain(|e| &e.tag != tag);
+    commitment.entries.retain(|e| e.tag != link.tag);
     let ledger: Vec<GrantLedgerEntry> = scope
         .ledger
         .iter()
-        .filter(|e| &e.tag != tag)
+        .filter(|e| e.tag != link.tag)
         .cloned()
         .collect();
     check_publishable(&commitment, &ledger)?;
@@ -551,14 +666,18 @@ pub fn revoke_invite_link(
     })
 }
 
-/// The produce-side mirror of what a resolver hard-rejects: duplicate tags (core
-/// rejects them at decode and before signing) and a ledger that diverges from
-/// the commitment (the adoption gate's owner-authority check). Release-active,
-/// so no build can emit a set its own readers refuse.
+/// The produce-side mirror of what a resolver hard-rejects: the grant-set
+/// ceiling, duplicate tags, and a ledger diverging from the commitment (core
+/// rejects the first two at decode and before signing; the third is the adoption
+/// gate's owner-authority check). Release-active, so no build can emit a set its
+/// own readers refuse.
 fn check_publishable(
     commitment: &GrantSetCommitment,
     ledger: &[GrantLedgerEntry],
 ) -> Result<(), InviteError> {
+    if commitment.entries.len() > MAX_GRANT_BLOBS || ledger.len() > MAX_GRANT_BLOBS {
+        return Err(InviteError::GrantSetFull);
+    }
     if !tags_are_unique(commitment.entries.iter().map(|e| e.tag))
         || !tags_are_unique(ledger.iter().map(|e| e.tag))
     {
@@ -575,18 +694,15 @@ fn tags_are_unique(tags: impl Iterator<Item = [u8; 32]>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::grants::{
-        PublishedGrantBlob, enforce_committed_ledger, entry_is_live, live_entry,
-        recipient_blinded_tag, self_locate,
-    };
+    use crate::grants::{PublishedGrantBlob, enforce_committed_ledger, self_locate};
     use crate::rotation::{
         CommittedSet, ResealError, ResealSeeds, ScopeRootIdentity, reseal_scope_root,
     };
     use crate::testkit::SeededEntropy;
     use cipherbox_core::seal::{
-        AadContext, GrantLedgerEntry, GrantSection, GrantSetCommitment, PreservedFields,
-        STRUCT_TAG_GRANT_BLOB, SignedGrantBlob, StructureSigInput, encode_grant_section,
-        open_grant_blob, sign_grant_set, verify_structure,
+        AadContext, GrantLedgerEntry, GrantSection, GrantSetCommitment, GrantSetEntry,
+        PreservedFields, STRUCT_TAG_GRANT_BLOB, SignedGrantBlob, StructureSigInput,
+        encode_grant_section, open_grant_blob, sign_grant_set, verify_structure,
     };
     use cipherbox_core::suite::contact::ContactCode;
     use cipherbox_core::suite::ecdsa::IDENTITY_PUBLIC_LEN;
@@ -1099,7 +1215,25 @@ mod tests {
         }
     }
 
-    /// A claimant's own keypair and the contact code binding the two halves.
+    /// A minted link over `SCOPE`, keyed by its fragment secret.
+    fn link(secret: u8, permission: Permission, expires_at: Option<UnixMillis>) -> MintedInvite {
+        mint_invite_grant(
+            &owner_enc(),
+            &EphemeralInvitee::from_secret(&[secret; 32]).expect("valid"),
+            &SCOPE,
+            &WRITE_SCOPE_SEED,
+            permission,
+            expires_at,
+        )
+        .expect("mints")
+    }
+
+    /// The ephemeral signer a fragment holder reconstructs to sign its claim.
+    fn link_signer(secret: u8) -> EcdsaSigner {
+        EcdsaSigner::from_scalar(&[secret; 32]).expect("valid scalar")
+    }
+
+    /// A claimant's own keypair; the contact code binds the two halves.
     fn claimant(seed: u8) -> (EcdsaSigner, X25519Secret) {
         (
             EcdsaSigner::from_scalar(&[seed; 32]).expect("valid scalar"),
@@ -1111,8 +1245,7 @@ mod tests {
         ContactCode::create(identity, enc.public()).encode()
     }
 
-    /// A claim as the mailbox hands it over: sender-verified, and signed by the
-    /// link's ephemeral identity unless `sender` says otherwise.
+    /// A claim as the mailbox hands it over: sender-verified, signed by `sender`.
     fn claim_item(sender: &EcdsaSigner, contact_code: Vec<u8>) -> VerifiedMailboxItem {
         claim_item_for(sender, contact_code, scope_name())
     }
@@ -1133,38 +1266,24 @@ mod tests {
         }
     }
 
-    /// The ephemeral signer behind an invite secret — what a fragment holder
-    /// reconstructs to sign its claim.
-    fn link_signer(invitee: &EphemeralInvitee) -> EcdsaSigner {
-        EcdsaSigner::from_scalar(invitee.secret().as_bytes()).expect("valid scalar")
-    }
-
     #[test]
     fn one_link_converts_two_claimants_into_two_grants_and_stays_live() {
-        let minted = invitee();
-        let link = mint_invite_grant(
-            &owner_enc(),
-            &minted,
-            &SCOPE,
-            &WRITE_SCOPE_SEED,
-            Permission::Read,
-            None,
-        )
-        .expect("mints");
-        let (commitment, sig, ledger) = committed(&[link.row.clone()]);
+        let l = link(0x4e, Permission::Read, None);
+        let (commitment, sig, ledger) = committed(&[l.row.clone()]);
         let keys = Owner::new();
         let owner = keys.authority();
-        let signer = link_signer(&minted);
+        let signer = link_signer(0x4e);
 
         let (a_id, a_enc) = claimant(0x61);
         let first = convert_invite_claim(
             &owner,
             &committed_scope(&commitment, &sig, &ledger),
+            &[l.link],
             &claim_item(&signer, contact_code(&a_id, &a_enc)),
             UnixMillis(0),
         )
         .expect("converts");
-        assert!(first.newly_granted);
+        assert_eq!(first.outcome, ClaimOutcome::Granted);
 
         // The second claimant converts against the set the first produced: the
         // link's own entry is still there, so the link stays claimable.
@@ -1173,6 +1292,7 @@ mod tests {
         let second = convert_invite_claim(
             &owner,
             &committed_scope(&first.commitment, &second_sig, &first.ledger),
+            &[l.link],
             &claim_item(&signer, contact_code(&b_id, &b_enc)),
             UnixMillis(0),
         )
@@ -1186,33 +1306,25 @@ mod tests {
                 .commitment
                 .entries
                 .iter()
-                .any(|e| e.tag == link.row.tag),
+                .any(|e| e.tag == l.link.tag),
             "the link itself stays live until it expires or is revoked",
         );
     }
 
     #[test]
     fn a_converted_grant_anchors_to_the_claimants_contact_never_the_ephemeral_half() {
-        let minted = invitee();
-        let link = mint_invite_grant(
-            &owner_enc(),
-            &minted,
-            &SCOPE,
-            &WRITE_SCOPE_SEED,
-            Permission::Write,
-            None,
-        )
-        .expect("mints");
-        let (commitment, sig, ledger) = committed(&[link.row.clone()]);
+        let l = link(0x4e, Permission::Write, None);
+        let (commitment, sig, ledger) = committed(&[l.row.clone()]);
         let keys = Owner::new();
         let owner = keys.authority();
         let scope = committed_scope(&commitment, &sig, &ledger);
-        let signer = link_signer(&minted);
+        let signer = link_signer(0x4e);
         let (id, enc) = claimant(0x63);
 
         let converted = convert_invite_claim(
             &owner,
             &scope,
+            &[l.link],
             &claim_item(&signer, contact_code(&id, &enc)),
             UnixMillis(0),
         )
@@ -1228,7 +1340,7 @@ mod tests {
         );
         assert_ne!(
             converted.row.ledger_entry.recipient_identity_pk,
-            minted.identity_pk().to_sec1(),
+            l.link.ephemeral_identity_pk,
         );
         assert_eq!(
             converted.row.commitment_entry.permission,
@@ -1237,103 +1349,203 @@ mod tests {
         );
         assert_eq!(
             converted.row.ledger_entry.expires_at, None,
-            "the personal grant is not the link and carries no link deadline",
+            "the link expires; the grants it produced do not",
         );
         // The claimant may not hand back the link's own throwaway identity: it
         // self-signs a perfectly valid contact code, and re-anchoring is the
         // whole point of conversion.
+        let eph_enc = X25519Secret::from_scalar([0u8; 32]);
+        for (code, why) in [
+            (
+                contact_code(&signer, &eph_enc),
+                "claimant-is-the-ephemeral-half",
+            ),
+            (
+                contact_code(&id, &X25519Secret::from_scalar([0x11; 32])),
+                "claimant-is-the-owner",
+            ),
+        ] {
+            assert_eq!(
+                convert_invite_claim(
+                    &owner,
+                    &scope,
+                    &[l.link],
+                    &claim_item(&signer, code),
+                    UnixMillis(0)
+                )
+                .unwrap_err()
+                .check(),
+                why,
+            );
+        }
+    }
+
+    #[test]
+    fn only_a_link_the_owner_recorded_can_be_claimed() {
+        // An ordinary grantee posts a well-formed, honestly-signed claim naming a
+        // sockpuppet contact. Its row is byte-shaped like a link's, so nothing in
+        // the record distinguishes them — only the owner's own record does.
+        let grantee_identity = EcdsaSigner::from_scalar(&[0x7a; 32]).expect("valid scalar");
+        let grantee_enc = X25519Secret::from_scalar([0x7b; 32]);
+        let grantee = mint_grant_row(
+            &owner_enc(),
+            &grantee_identity.verifying_key(),
+            &grantee_enc.public(),
+            &SCOPE,
+            &scope_name(),
+            Permission::Write,
+        )
+        .expect("contributory");
+        let l = link(0x4e, Permission::Read, None);
+        let (commitment, sig, mut ledger) = committed(&[grantee, l.row.clone()]);
+        let keys = Owner::new();
+        let owner = keys.authority();
+        let (id, enc) = claimant(0x7c);
+
         assert_eq!(
             convert_invite_claim(
                 &owner,
-                &scope,
-                &claim_item(&signer, contact_code(&signer, minted.enc_secret())),
+                &committed_scope(&commitment, &sig, &ledger),
+                &[l.link],
+                &claim_item(&grantee_identity, contact_code(&id, &enc)),
                 UnixMillis(0),
             )
             .unwrap_err()
             .check(),
-            "claimant-is-the-ephemeral-half",
+            "link-not-committed",
+            "a grantee cannot re-delegate its own row as if it were a link",
         );
-    }
 
-    #[test]
-    fn a_claim_signed_by_an_uncommitted_key_is_refused() {
-        let minted = invitee();
-        let link = invite(Permission::Read, None);
-        let (commitment, sig, ledger) = committed(&[link]);
-        let keys = Owner::new();
-        let owner = keys.authority();
-        let scope = committed_scope(&commitment, &sig, &ledger);
-        let (id, enc) = claimant(0x64);
-
-        // A different ephemeral identity than the one the ledger commits.
-        let forger = link_signer(&EphemeralInvitee::from_secret(&[0x4f; 32]).expect("valid"));
+        // Nor by re-authoring the ledger: a write-grantee pointing a committed
+        // row's recipientIdentityPk — a field outside the owner's signature — at
+        // an ephemeral identity it holds still matches no recorded link.
+        ledger[0].recipient_identity_pk = link_signer(0x4f).verifying_key().to_sec1();
         assert_eq!(
             convert_invite_claim(
                 &owner,
-                &scope,
-                &claim_item(&forger, contact_code(&id, &enc)),
+                &committed_scope(&commitment, &sig, &ledger),
+                &[l.link],
+                &claim_item(&link_signer(0x4f), contact_code(&id, &enc)),
                 UnixMillis(0),
             )
             .unwrap_err()
             .check(),
             "link-not-committed",
         );
-        // The committed one converts, so the reject above isolates the signer.
+    }
+
+    #[test]
+    fn a_claim_signed_by_an_uncommitted_key_is_refused() {
+        let l = link(0x4e, Permission::Read, None);
+        let (commitment, sig, ledger) = committed(&[l.row.clone()]);
+        let keys = Owner::new();
+        let owner = keys.authority();
+        let scope = committed_scope(&commitment, &sig, &ledger);
+        let (id, enc) = claimant(0x64);
+
+        // A different ephemeral identity than the one the owner recorded.
+        assert_eq!(
+            convert_invite_claim(
+                &owner,
+                &scope,
+                &[l.link],
+                &claim_item(&link_signer(0x4f), contact_code(&id, &enc)),
+                UnixMillis(0),
+            )
+            .unwrap_err()
+            .check(),
+            "link-not-committed",
+        );
+        // The recorded one converts, so the reject above isolates the signer.
         assert!(
             convert_invite_claim(
                 &owner,
                 &scope,
-                &claim_item(&link_signer(&minted), contact_code(&id, &enc)),
+                &[l.link],
+                &claim_item(&link_signer(0x4e), contact_code(&id, &enc)),
                 UnixMillis(0),
             )
             .is_ok()
+        );
+        // A link the owner revoked from the committed set no longer converts.
+        let (cut, cut_sig, cut_ledger) = committed(&[]);
+        assert_eq!(
+            convert_invite_claim(
+                &owner,
+                &committed_scope(&cut, &cut_sig, &cut_ledger),
+                &[l.link],
+                &claim_item(&link_signer(0x4e), contact_code(&id, &enc)),
+                UnixMillis(0),
+            )
+            .unwrap_err()
+            .check(),
+            "link-not-committed",
         );
     }
 
     #[test]
     fn a_claim_against_an_expired_link_is_refused_at_the_deadline() {
-        let minted = invitee();
-        let link = mint_invite_grant(
-            &owner_enc(),
-            &minted,
-            &SCOPE,
-            &WRITE_SCOPE_SEED,
-            Permission::Read,
-            Some(EXPIRES_AT),
-        )
-        .expect("mints");
-        let (commitment, sig, ledger) = committed(&[link.row.clone()]);
+        let l = link(0x4e, Permission::Read, Some(EXPIRES_AT));
+        let (commitment, sig, ledger) = committed(&[l.row.clone()]);
         let keys = Owner::new();
         let owner = keys.authority();
         let scope = committed_scope(&commitment, &sig, &ledger);
         let (id, enc) = claimant(0x65);
-        let item = claim_item(&link_signer(&minted), contact_code(&id, &enc));
+        let item = claim_item(&link_signer(0x4e), contact_code(&id, &enc));
 
         assert!(
-            convert_invite_claim(&owner, &scope, &item, UnixMillis(EXPIRES_AT.0 - 1)).is_ok(),
+            convert_invite_claim(
+                &owner,
+                &scope,
+                &[l.link],
+                &item,
+                UnixMillis(EXPIRES_AT.0 - 1)
+            )
+            .is_ok(),
             "live one tick before the deadline",
         );
         assert_eq!(
-            convert_invite_claim(&owner, &scope, &item, EXPIRES_AT)
+            convert_invite_claim(&owner, &scope, &[l.link], &item, EXPIRES_AT)
                 .unwrap_err()
                 .check(),
             "link-expired",
         );
-        // And the row is inert on the read path at the same instant, with no
-        // prune having touched the ledger.
-        assert!(live_entry(&ledger, &link.row.tag, EXPIRES_AT).is_none());
-        assert_eq!(ledger.len(), 1, "nothing was pruned");
+        assert_eq!(ledger.len(), 1, "the expired row is inert, not pruned");
+
+        // A stripped published deadline does not extend the link: the owner's own
+        // record is the authority.
+        let mut stripped = ledger.clone();
+        stripped[0].expires_at = None;
+        assert_eq!(
+            convert_invite_claim(
+                &owner,
+                &committed_scope(&commitment, &sig, &stripped),
+                &[l.link],
+                &item,
+                EXPIRES_AT,
+            )
+            .unwrap_err()
+            .check(),
+            "link-expired",
+        );
+
+        // And a published deadline alone makes the row inert before any prune.
+        let unrecorded = link(0x4e, Permission::Read, None);
+        assert_eq!(
+            convert_invite_claim(&owner, &scope, &[unrecorded.link], &item, EXPIRES_AT)
+                .unwrap_err()
+                .check(),
+            "link-expired",
+        );
     }
 
     #[test]
     fn a_non_owner_can_neither_convert_nor_revoke() {
-        let minted = invitee();
-        let link = invite(Permission::Read, None);
-        let tag = link.tag;
-        let (commitment, sig, ledger) = committed(&[link]);
+        let l = link(0x4e, Permission::Read, None);
+        let (commitment, sig, ledger) = committed(&[l.row.clone()]);
         let scope = committed_scope(&commitment, &sig, &ledger);
         let (id, enc) = claimant(0x66);
-        let item = claim_item(&link_signer(&minted), contact_code(&id, &enc));
+        let item = claim_item(&link_signer(0x4e), contact_code(&id, &enc));
 
         // A stranger's identity key never signed this committed set.
         let rogue_id = EcdsaSigner::from_scalar(&[0x34; 32]).expect("valid scalar");
@@ -1343,20 +1555,20 @@ mod tests {
             enc_secret: &owner_e,
         };
         assert_eq!(
-            convert_invite_claim(&rogue, &scope, &item, UnixMillis(0))
+            convert_invite_claim(&rogue, &scope, &[l.link], &item, UnixMillis(0))
                 .unwrap_err()
                 .check(),
             "not-owner",
         );
         assert_eq!(
-            revoke_invite_link(&rogue, &scope, &tag)
+            revoke_invite_link(&rogue, &scope, &l.link)
                 .unwrap_err()
                 .check(),
             "not-owner",
         );
 
         // Defense in depth: the owner identity with a foreign encryption subkey
-        // cannot re-derive the committed link tag either.
+        // cannot re-derive the recorded link tag either.
         let owner_id = owner_identity();
         let foreign_enc = X25519Secret::from_scalar([0x12; 32]);
         let half = OwnerAuthority {
@@ -1364,7 +1576,7 @@ mod tests {
             enc_secret: &foreign_enc,
         };
         assert_eq!(
-            convert_invite_claim(&half, &scope, &item, UnixMillis(0))
+            convert_invite_claim(&half, &scope, &[l.link], &item, UnixMillis(0))
                 .unwrap_err()
                 .check(),
             "link-not-committed",
@@ -1373,37 +1585,20 @@ mod tests {
 
     #[test]
     fn a_write_link_is_bearer_and_a_ledger_cut_alone_revokes_nothing() {
-        let read = mint_invite_grant(
-            &owner_enc(),
-            &EphemeralInvitee::from_secret(&[0x71; 32]).expect("valid"),
-            &SCOPE,
-            &WRITE_SCOPE_SEED,
-            Permission::Read,
-            None,
-        )
-        .expect("mints");
-        let write = mint_invite_grant(
-            &owner_enc(),
-            &EphemeralInvitee::from_secret(&[0x72; 32]).expect("valid"),
-            &SCOPE,
-            &WRITE_SCOPE_SEED,
-            Permission::Write,
-            None,
-        )
-        .expect("mints");
+        let read = link(0x71, Permission::Read, None);
+        let write = link(0x72, Permission::Write, None);
         assert!(
             write.capability.is_bearer_write(),
             "a write link hands out an extractable subtree signing key",
         );
         assert!(!read.capability.is_bearer_write());
-        let (read_link, write_link) = (read.row, write.row);
 
         let keys = Owner::new();
         let owner = keys.authority();
-        let (commitment, sig, ledger) = committed(&[read_link.clone(), write_link.clone()]);
+        let (commitment, sig, ledger) = committed(&[read.row.clone(), write.row.clone()]);
         let scope = committed_scope(&commitment, &sig, &ledger);
 
-        let cut = revoke_invite_link(&owner, &scope, &write_link.tag).expect("cuts");
+        let cut = revoke_invite_link(&owner, &scope, &write.link).expect("cuts");
         assert!(
             !cut.is_complete(),
             "a write link is not revoked until rotate_scope_write runs",
@@ -1413,25 +1608,23 @@ mod tests {
             !cut.commitment
                 .entries
                 .iter()
-                .any(|e| e.tag == write_link.tag)
+                .any(|e| e.tag == write.row.tag)
         );
-        assert!(!cut.ledger.iter().any(|e| e.tag == write_link.tag));
+        assert!(!cut.ledger.iter().any(|e| e.tag == write.row.tag));
         assert!(
-            cut.commitment
-                .entries
-                .iter()
-                .any(|e| e.tag == read_link.tag),
+            cut.commitment.entries.iter().any(|e| e.tag == read.row.tag),
             "the other grantee is untouched",
         );
 
         assert!(
-            revoke_invite_link(&owner, &scope, &read_link.tag)
+            revoke_invite_link(&owner, &scope, &read.link)
                 .expect("cuts")
                 .is_complete(),
             "a read link's cut plus a read rotation is the whole revocation",
         );
+        let unknown = link(0x73, Permission::Read, None);
         assert_eq!(
-            revoke_invite_link(&owner, &scope, &[0x77; 32])
+            revoke_invite_link(&owner, &scope, &unknown.link)
                 .unwrap_err()
                 .check(),
             "link-not-committed",
@@ -1439,58 +1632,18 @@ mod tests {
     }
 
     #[test]
-    fn a_write_grantee_can_retarget_a_committed_row_at_an_ephemeral_identity() {
-        // The honest bound on conversion: `recipientIdentityPk` sits outside the
-        // owner-signed commitment, so a write-grantee re-authoring the write-body
-        // can make a committed row answer to an ephemeral identity it holds. It
-        // gains no permission it does not already hold — only an extra tag.
-        // Pins the residual so tightening it must update this test.
-        let victim_identity = EcdsaSigner::from_scalar(&[0x7a; 32]).expect("valid scalar");
-        let victim_enc = X25519Secret::from_scalar([0x7b; 32]);
-        let victim = mint_grant_row(
-            &owner_enc(),
-            &victim_identity.verifying_key(),
-            &victim_enc.public(),
-            &SCOPE,
-            &scope_name(),
-            Permission::Write,
-        )
-        .expect("contributory");
-        let (commitment, sig, mut ledger) = committed(&[victim.clone()]);
-
-        let attacker = invitee();
-        ledger[0].recipient_identity_pk = attacker.identity_pk().to_sec1();
-
-        let keys = Owner::new();
-        let owner = keys.authority();
-        let (id, enc) = claimant(0x7c);
-        let converted = convert_invite_claim(
-            &owner,
-            &committed_scope(&commitment, &sig, &ledger),
-            &claim_item(&link_signer(&attacker), contact_code(&id, &enc)),
-            UnixMillis(0),
-        )
-        .expect("converts — the residual");
-        assert_eq!(
-            converted.row.commitment_entry.permission,
-            Permission::Write,
-            "the retargeted row's committed permission, not an escalation past it",
-        );
-    }
-
-    #[test]
     fn a_redelivered_claim_converts_to_the_same_grant_and_changes_nothing() {
-        let minted = invitee();
-        let link = invite(Permission::Read, None);
-        let (commitment, sig, ledger) = committed(&[link]);
+        let l = link(0x4e, Permission::Read, None);
+        let (commitment, sig, ledger) = committed(&[l.row.clone()]);
         let keys = Owner::new();
         let owner = keys.authority();
         let (id, enc) = claimant(0x67);
-        let item = claim_item(&link_signer(&minted), contact_code(&id, &enc));
+        let item = claim_item(&link_signer(0x4e), contact_code(&id, &enc));
 
         let first = convert_invite_claim(
             &owner,
             &committed_scope(&commitment, &sig, &ledger),
+            &[l.link],
             &item,
             UnixMillis(0),
         )
@@ -1500,30 +1653,89 @@ mod tests {
         let again = convert_invite_claim(
             &owner,
             &committed_scope(&first.commitment, &resigned, &first.ledger),
+            &[l.link],
             &item,
             UnixMillis(0),
         )
         .expect("converts");
 
-        assert!(!again.newly_granted);
+        assert_eq!(again.outcome, ClaimOutcome::Unchanged);
         assert_eq!(again.commitment, first.commitment);
         assert_eq!(again.ledger, first.ledger);
     }
 
     #[test]
-    fn a_claim_naming_another_scope_root_is_refused() {
-        let minted = invitee();
-        let link = invite(Permission::Read, None);
-        let (commitment, sig, ledger) = committed(&[link]);
+    fn claiming_a_write_link_upgrades_an_existing_read_grant_and_never_lowers_one() {
+        let read_link = link(0x4e, Permission::Read, None);
+        let write_link = link(0x4f, Permission::Write, None);
         let keys = Owner::new();
         let owner = keys.authority();
         let (id, enc) = claimant(0x68);
+
+        let (commitment, sig, ledger) = committed(&[read_link.row.clone(), write_link.row.clone()]);
+        let read_grant = convert_invite_claim(
+            &owner,
+            &committed_scope(&commitment, &sig, &ledger),
+            &[read_link.link],
+            &claim_item(&link_signer(0x4e), contact_code(&id, &enc)),
+            UnixMillis(0),
+        )
+        .expect("converts");
+        assert_eq!(read_grant.outcome, ClaimOutcome::Granted);
+
+        // Same claimant, same tag, now claiming the write link.
+        let resigned = sign_grant_set(&owner_identity(), &read_grant.commitment).expect("signs");
+        let upgraded = convert_invite_claim(
+            &owner,
+            &committed_scope(&read_grant.commitment, &resigned, &read_grant.ledger),
+            &[write_link.link],
+            &claim_item(&link_signer(0x4f), contact_code(&id, &enc)),
+            UnixMillis(0),
+        )
+        .expect("converts");
+        assert_eq!(upgraded.outcome, ClaimOutcome::Upgraded);
+        let committed_permission = |c: &GrantSetCommitment, tag: [u8; 32]| {
+            c.entries.iter().find(|e| e.tag == tag).unwrap().permission
+        };
+        assert_eq!(
+            committed_permission(&upgraded.commitment, upgraded.row.tag),
+            Permission::Write,
+        );
+        assert_eq!(
+            upgraded.row.commitment_entry.permission,
+            committed_permission(&upgraded.commitment, upgraded.row.tag),
+            "the reported row never contradicts the returned commitment",
+        );
+
+        // Claiming the read link back does not lower the write grant.
+        let resigned = sign_grant_set(&owner_identity(), &upgraded.commitment).expect("signs");
+        let held = convert_invite_claim(
+            &owner,
+            &committed_scope(&upgraded.commitment, &resigned, &upgraded.ledger),
+            &[read_link.link],
+            &claim_item(&link_signer(0x4e), contact_code(&id, &enc)),
+            UnixMillis(0),
+        )
+        .expect("converts");
+        assert_eq!(held.outcome, ClaimOutcome::Unchanged);
+        assert_eq!(held.row.commitment_entry.permission, Permission::Write);
+        assert_eq!(held.commitment, upgraded.commitment);
+    }
+
+    #[test]
+    fn a_claim_naming_another_scope_root_is_refused() {
+        let l = link(0x4e, Permission::Read, None);
+        let (commitment, sig, ledger) = committed(&[l.row.clone()]);
+        let keys = Owner::new();
+        let owner = keys.authority();
+        let (id, enc) = claimant(0x69);
         assert_eq!(
             convert_invite_claim(
                 &owner,
                 &committed_scope(&commitment, &sig, &ledger),
+                &[l.link],
                 &claim_item_for(
-                    &link_signer(&minted),
+                    &link_signer(0x4e),
                     contact_code(&id, &enc),
                     b"k51elsewhere".to_vec(),
                 ),
@@ -1536,22 +1748,35 @@ mod tests {
     }
 
     #[test]
-    fn a_claimant_contact_code_with_a_broken_binding_is_refused() {
-        let minted = invitee();
-        let link = invite(Permission::Read, None);
-        let (commitment, sig, ledger) = committed(&[link]);
+    fn a_malformed_or_unbindable_claim_is_refused() {
+        let l = link(0x4e, Permission::Read, None);
+        let (commitment, sig, ledger) = committed(&[l.row.clone()]);
         let keys = Owner::new();
         let owner = keys.authority();
-        let (id, enc) = claimant(0x69);
+        let scope = committed_scope(&commitment, &sig, &ledger);
+        let (id, enc) = claimant(0x6b);
+
+        let junk = VerifiedMailboxItem {
+            item_id: "claim-1".to_string(),
+            sender_identity: link_signer(0x4e).verifying_key(),
+            payload: b"not det-cbor".to_vec(),
+        };
+        assert_eq!(
+            convert_invite_claim(&owner, &scope, &[l.link], &junk, UnixMillis(0))
+                .unwrap_err()
+                .check(),
+            "malformed-claim",
+        );
+
         let mut code = contact_code(&id, &enc);
         let last = code.len() - 1;
         code[last] ^= 0x01;
-
         assert_eq!(
             convert_invite_claim(
                 &owner,
-                &committed_scope(&commitment, &sig, &ledger),
-                &claim_item(&link_signer(&minted), code),
+                &scope,
+                &[l.link],
+                &claim_item(&link_signer(0x4e), code),
                 UnixMillis(0),
             )
             .unwrap_err()
@@ -1562,59 +1787,63 @@ mod tests {
 
     #[test]
     fn a_conversion_that_would_publish_an_unreadable_set_returns_err() {
-        // Encode-side symmetry: core rejects a duplicate-tag commitment at decode
-        // and before signing, and the gate rejects a ledger that diverges from
-        // the commitment. Both are refused here rather than signed — a `return
-        // Err`, not an assertion a release build strips.
-        let minted = invitee();
-        let link = invite(Permission::Read, None);
+        // Encode-side symmetry: core rejects a duplicate-tag commitment and one
+        // past the grant-set ceiling at decode and before signing, and the gate
+        // rejects a ledger that diverges from the commitment. All three are
+        // refused here rather than signed — a `return Err`, not an assertion a
+        // release build strips.
+        let l = link(0x4e, Permission::Read, None);
         let keys = Owner::new();
         let owner = keys.authority();
         let (id, enc) = claimant(0x6a);
-        let item = claim_item(&link_signer(&minted), contact_code(&id, &enc));
-
-        // The claimant's tag is already committed but absent from the ledger, so
-        // appending it would file two commitment entries under one tag.
-        let claimant_row = mint_grant_row(
-            &owner_enc(),
-            &id.verifying_key(),
-            &enc.public(),
-            &SCOPE,
-            &scope_name(),
-            Permission::Read,
-        )
-        .expect("contributory");
-        let (mut commitment, _, ledger) = committed(&[link.clone(), claimant_row]);
-        let ledger: Vec<GrantLedgerEntry> = ledger.into_iter().take(1).collect();
-        let sig = sign_grant_set(&owner_identity(), &commitment).expect("signs");
-        assert_eq!(
-            convert_invite_claim(
-                &owner,
-                &committed_scope(&commitment, &sig, &ledger),
-                &item,
-                UnixMillis(0),
-            )
-            .unwrap_err()
-            .check(),
-            "duplicate-tag",
-        );
+        let item = claim_item(&link_signer(0x4e), contact_code(&id, &enc));
 
         // A ledger the commitment does not cover diverges once the new row lands.
-        commitment.entries.truncate(1);
-        let sig = sign_grant_set(&owner_identity(), &commitment).expect("signs");
-        let mut stray = link.ledger_entry.clone();
+        let (commitment, sig, _) = committed(&[l.row.clone()]);
+        let mut stray = l.row.ledger_entry.clone();
         stray.tag = [0x7e; 32];
         stray.recipient_identity_pk = [0x02; IDENTITY_PUBLIC_LEN];
         assert_eq!(
             convert_invite_claim(
                 &owner,
-                &committed_scope(&commitment, &sig, &[link.ledger_entry.clone(), stray]),
+                &committed_scope(&commitment, &sig, &[l.row.ledger_entry.clone(), stray]),
+                &[l.link],
                 &item,
                 UnixMillis(0),
             )
             .unwrap_err()
             .check(),
             "ledger-diverges-from-commitment",
+        );
+
+        // A set already at the ceiling cannot take one more row.
+        let mut full_commitment = commitment.clone();
+        let mut full_ledger = vec![l.row.ledger_entry.clone()];
+        for i in 1..MAX_GRANT_BLOBS {
+            let mut tag = [0u8; 32];
+            tag[..8].copy_from_slice(&(i as u64).to_be_bytes());
+            full_commitment
+                .entries
+                .push(GrantSetEntry::new(tag, Permission::Read, [0x02; 32]));
+            full_ledger.push(GrantLedgerEntry::new(
+                [0x02; IDENTITY_PUBLIC_LEN],
+                [0x11; 32],
+                Permission::Read,
+                tag,
+            ));
+        }
+        let full_sig = sign_grant_set(&owner_identity(), &full_commitment).expect("signs");
+        assert_eq!(
+            convert_invite_claim(
+                &owner,
+                &committed_scope(&full_commitment, &full_sig, &full_ledger),
+                &[l.link],
+                &item,
+                UnixMillis(0),
+            )
+            .unwrap_err()
+            .check(),
+            "grant-set-full",
         );
     }
 

--- a/crates/engine/src/grants/invite.rs
+++ b/crates/engine/src/grants/invite.rs
@@ -408,6 +408,10 @@ pub struct ConvertedClaim {
 /// contact and never the ephemeral half. `now` is the injected
 /// [`Scheduler::now`](crate::seams::Scheduler::now) instant.
 ///
+/// The caller signs and publishes the returned set, and acks the mailbox item
+/// only once that is durable (`mailbox` ack-after-durable) — a redelivery then
+/// converts to the same tag and changes nothing.
+///
 /// Residual: a ledger row's `recipientIdentityPk` sits outside the owner-signed
 /// commitment ([`enforce_committed_ledger`]), so a write-grantee re-authoring the
 /// write-body can point a committed row at an ephemeral identity it holds and

--- a/crates/engine/src/grants/invite.rs
+++ b/crates/engine/src/grants/invite.rs
@@ -542,15 +542,17 @@ fn check_publishable(
     commitment: &GrantSetCommitment,
     ledger: &[GrantLedgerEntry],
 ) -> Result<(), InviteError> {
-    let mut seen = BTreeSet::new();
-    if !commitment.entries.iter().all(|e| seen.insert(e.tag)) {
-        return Err(InviteError::DuplicateTag);
-    }
-    let mut seen = BTreeSet::new();
-    if !ledger.iter().all(|e| seen.insert(e.tag)) {
+    if !tags_are_unique(commitment.entries.iter().map(|e| e.tag))
+        || !tags_are_unique(ledger.iter().map(|e| e.tag))
+    {
         return Err(InviteError::DuplicateTag);
     }
     enforce_committed_ledger(commitment, ledger).map_err(InviteError::Authority)
+}
+
+fn tags_are_unique(tags: impl Iterator<Item = [u8; 32]>) -> bool {
+    let mut seen = BTreeSet::new();
+    tags.into_iter().all(|t| seen.insert(t))
 }
 
 #[cfg(test)]
@@ -1044,6 +1046,41 @@ mod tests {
         )
     }
 
+    /// The owner's two halves, held so an [`OwnerAuthority`] can borrow them.
+    struct Owner {
+        identity: EcdsaSigner,
+        enc: X25519Secret,
+    }
+
+    impl Owner {
+        fn new() -> Self {
+            Self {
+                identity: owner_identity(),
+                enc: owner_enc(),
+            }
+        }
+
+        fn authority(&self) -> OwnerAuthority<'_> {
+            OwnerAuthority {
+                identity_signer: &self.identity,
+                enc_secret: &self.enc,
+            }
+        }
+    }
+
+    fn committed_scope<'a>(
+        commitment: &'a GrantSetCommitment,
+        commitment_sig: &'a EcdsaSignature,
+        ledger: &'a [GrantLedgerEntry],
+    ) -> CommittedScope<'a> {
+        CommittedScope {
+            scope_id: &SCOPE,
+            commitment,
+            commitment_sig,
+            ledger,
+        }
+    }
+
     /// A claimant's own keypair and the contact code binding the two halves.
     fn claimant(seed: u8) -> (EcdsaSigner, X25519Secret) {
         (
@@ -1097,23 +1134,14 @@ mod tests {
         )
         .expect("mints");
         let (commitment, sig, ledger) = committed(&[link.row.clone()]);
-        let owner_id = owner_identity();
-        let owner_e = owner_enc();
-        let owner = OwnerAuthority {
-            identity_signer: &owner_id,
-            enc_secret: &owner_e,
-        };
+        let keys = Owner::new();
+        let owner = keys.authority();
         let signer = link_signer(&minted);
 
         let (a_id, a_enc) = claimant(0x61);
         let first = convert_invite_claim(
             &owner,
-            &CommittedScope {
-                scope_id: &SCOPE,
-                commitment: &commitment,
-                commitment_sig: &sig,
-                ledger: &ledger,
-            },
+            &committed_scope(&commitment, &sig, &ledger),
             &claim_item(&signer, contact_code(&a_id, &a_enc)),
             UnixMillis(0),
         )
@@ -1126,12 +1154,7 @@ mod tests {
         let (b_id, b_enc) = claimant(0x62);
         let second = convert_invite_claim(
             &owner,
-            &CommittedScope {
-                scope_id: &SCOPE,
-                commitment: &first.commitment,
-                commitment_sig: &second_sig,
-                ledger: &first.ledger,
-            },
+            &committed_scope(&first.commitment, &second_sig, &first.ledger),
             &claim_item(&signer, contact_code(&b_id, &b_enc)),
             UnixMillis(0),
         )
@@ -1163,18 +1186,9 @@ mod tests {
         )
         .expect("mints");
         let (commitment, sig, ledger) = committed(&[link.row.clone()]);
-        let owner_id = owner_identity();
-        let owner_e = owner_enc();
-        let owner = OwnerAuthority {
-            identity_signer: &owner_id,
-            enc_secret: &owner_e,
-        };
-        let scope = CommittedScope {
-            scope_id: &SCOPE,
-            commitment: &commitment,
-            commitment_sig: &sig,
-            ledger: &ledger,
-        };
+        let keys = Owner::new();
+        let owner = keys.authority();
+        let scope = committed_scope(&commitment, &sig, &ledger);
         let signer = link_signer(&minted);
         let (id, enc) = claimant(0x63);
 
@@ -1228,18 +1242,9 @@ mod tests {
         let minted = invitee();
         let link = invite(Permission::Read, None);
         let (commitment, sig, ledger) = committed(&[link]);
-        let owner_id = owner_identity();
-        let owner_e = owner_enc();
-        let owner = OwnerAuthority {
-            identity_signer: &owner_id,
-            enc_secret: &owner_e,
-        };
-        let scope = CommittedScope {
-            scope_id: &SCOPE,
-            commitment: &commitment,
-            commitment_sig: &sig,
-            ledger: &ledger,
-        };
+        let keys = Owner::new();
+        let owner = keys.authority();
+        let scope = committed_scope(&commitment, &sig, &ledger);
         let (id, enc) = claimant(0x64);
 
         // A different ephemeral identity than the one the ledger commits.
@@ -1280,18 +1285,9 @@ mod tests {
         )
         .expect("mints");
         let (commitment, sig, ledger) = committed(&[link.row.clone()]);
-        let owner_id = owner_identity();
-        let owner_e = owner_enc();
-        let owner = OwnerAuthority {
-            identity_signer: &owner_id,
-            enc_secret: &owner_e,
-        };
-        let scope = CommittedScope {
-            scope_id: &SCOPE,
-            commitment: &commitment,
-            commitment_sig: &sig,
-            ledger: &ledger,
-        };
+        let keys = Owner::new();
+        let owner = keys.authority();
+        let scope = committed_scope(&commitment, &sig, &ledger);
         let (id, enc) = claimant(0x65);
         let item = claim_item(&link_signer(&minted), contact_code(&id, &enc));
 
@@ -1317,12 +1313,7 @@ mod tests {
         let link = invite(Permission::Read, None);
         let tag = link.tag;
         let (commitment, sig, ledger) = committed(&[link]);
-        let scope = CommittedScope {
-            scope_id: &SCOPE,
-            commitment: &commitment,
-            commitment_sig: &sig,
-            ledger: &ledger,
-        };
+        let scope = committed_scope(&commitment, &sig, &ledger);
         let (id, enc) = claimant(0x66);
         let item = claim_item(&link_signer(&minted), contact_code(&id, &enc));
 
@@ -1389,19 +1380,10 @@ mod tests {
         assert!(!read.capability.is_bearer_write());
         let (read_link, write_link) = (read.row, write.row);
 
-        let owner_id = owner_identity();
-        let owner_e = owner_enc();
-        let owner = OwnerAuthority {
-            identity_signer: &owner_id,
-            enc_secret: &owner_e,
-        };
+        let keys = Owner::new();
+        let owner = keys.authority();
         let (commitment, sig, ledger) = committed(&[read_link.clone(), write_link.clone()]);
-        let scope = CommittedScope {
-            scope_id: &SCOPE,
-            commitment: &commitment,
-            commitment_sig: &sig,
-            ledger: &ledger,
-        };
+        let scope = committed_scope(&commitment, &sig, &ledger);
 
         let cut = revoke_invite_link(&owner, &scope, &write_link.tag).expect("cuts");
         assert!(
@@ -1443,23 +1425,14 @@ mod tests {
         let minted = invitee();
         let link = invite(Permission::Read, None);
         let (commitment, sig, ledger) = committed(&[link]);
-        let owner_id = owner_identity();
-        let owner_e = owner_enc();
-        let owner = OwnerAuthority {
-            identity_signer: &owner_id,
-            enc_secret: &owner_e,
-        };
+        let keys = Owner::new();
+        let owner = keys.authority();
         let (id, enc) = claimant(0x67);
         let item = claim_item(&link_signer(&minted), contact_code(&id, &enc));
 
         let first = convert_invite_claim(
             &owner,
-            &CommittedScope {
-                scope_id: &SCOPE,
-                commitment: &commitment,
-                commitment_sig: &sig,
-                ledger: &ledger,
-            },
+            &committed_scope(&commitment, &sig, &ledger),
             &item,
             UnixMillis(0),
         )
@@ -1468,12 +1441,7 @@ mod tests {
         let resigned = sign_grant_set(&owner_identity(), &first.commitment).expect("signs");
         let again = convert_invite_claim(
             &owner,
-            &CommittedScope {
-                scope_id: &SCOPE,
-                commitment: &first.commitment,
-                commitment_sig: &resigned,
-                ledger: &first.ledger,
-            },
+            &committed_scope(&first.commitment, &resigned, &first.ledger),
             &item,
             UnixMillis(0),
         )
@@ -1489,22 +1457,13 @@ mod tests {
         let minted = invitee();
         let link = invite(Permission::Read, None);
         let (commitment, sig, ledger) = committed(&[link]);
-        let owner_id = owner_identity();
-        let owner_e = owner_enc();
-        let owner = OwnerAuthority {
-            identity_signer: &owner_id,
-            enc_secret: &owner_e,
-        };
+        let keys = Owner::new();
+        let owner = keys.authority();
         let (id, enc) = claimant(0x68);
         assert_eq!(
             convert_invite_claim(
                 &owner,
-                &CommittedScope {
-                    scope_id: &SCOPE,
-                    commitment: &commitment,
-                    commitment_sig: &sig,
-                    ledger: &ledger,
-                },
+                &committed_scope(&commitment, &sig, &ledger),
                 &claim_item_for(
                     &link_signer(&minted),
                     contact_code(&id, &enc),
@@ -1523,12 +1482,8 @@ mod tests {
         let minted = invitee();
         let link = invite(Permission::Read, None);
         let (commitment, sig, ledger) = committed(&[link]);
-        let owner_id = owner_identity();
-        let owner_e = owner_enc();
-        let owner = OwnerAuthority {
-            identity_signer: &owner_id,
-            enc_secret: &owner_e,
-        };
+        let keys = Owner::new();
+        let owner = keys.authority();
         let (id, enc) = claimant(0x69);
         let mut code = contact_code(&id, &enc);
         let last = code.len() - 1;
@@ -1537,12 +1492,7 @@ mod tests {
         assert_eq!(
             convert_invite_claim(
                 &owner,
-                &CommittedScope {
-                    scope_id: &SCOPE,
-                    commitment: &commitment,
-                    commitment_sig: &sig,
-                    ledger: &ledger,
-                },
+                &committed_scope(&commitment, &sig, &ledger),
                 &claim_item(&link_signer(&minted), code),
                 UnixMillis(0),
             )
@@ -1560,12 +1510,8 @@ mod tests {
         // Err`, not an assertion a release build strips.
         let minted = invitee();
         let link = invite(Permission::Read, None);
-        let owner_id = owner_identity();
-        let owner_e = owner_enc();
-        let owner = OwnerAuthority {
-            identity_signer: &owner_id,
-            enc_secret: &owner_e,
-        };
+        let keys = Owner::new();
+        let owner = keys.authority();
         let (id, enc) = claimant(0x6a);
         let item = claim_item(&link_signer(&minted), contact_code(&id, &enc));
 
@@ -1586,12 +1532,7 @@ mod tests {
         assert_eq!(
             convert_invite_claim(
                 &owner,
-                &CommittedScope {
-                    scope_id: &SCOPE,
-                    commitment: &commitment,
-                    commitment_sig: &sig,
-                    ledger: &ledger,
-                },
+                &committed_scope(&commitment, &sig, &ledger),
                 &item,
                 UnixMillis(0),
             )
@@ -1608,12 +1549,7 @@ mod tests {
         assert_eq!(
             convert_invite_claim(
                 &owner,
-                &CommittedScope {
-                    scope_id: &SCOPE,
-                    commitment: &commitment,
-                    commitment_sig: &sig,
-                    ledger: &[link.ledger_entry.clone(), stray],
-                },
+                &committed_scope(&commitment, &sig, &[link.ledger_entry.clone(), stray]),
                 &item,
                 UnixMillis(0),
             )

--- a/crates/engine/src/grants/invite.rs
+++ b/crates/engine/src/grants/invite.rs
@@ -642,6 +642,18 @@ pub fn revoke_invite_link(
     link: &RecordedInvite,
 ) -> Result<InviteRevocation, InviteError> {
     owner.authorise(scope)?;
+    // Re-derive the record's tag on the same rule as `convert_invite_claim`, so a
+    // record from another scope root cannot cut an ordinary grantee's entry.
+    let link_enc =
+        X25519Public::from_bytes(link.ephemeral_enc_pk).ok_or(InviteError::LinkNotCommitted)?;
+    if recipient_blinded_tag(
+        owner.enc_secret,
+        &link_enc,
+        scope.commitment.ipns_name.as_slice(),
+    ) != Some(link.tag)
+    {
+        return Err(InviteError::LinkNotCommitted);
+    }
     let capability = scope
         .commitment
         .entries
@@ -1467,6 +1479,20 @@ mod tests {
             )
             .is_ok()
         );
+        // Two records answering to one ephemeral identity refuse rather than
+        // resolve to the first match.
+        assert_eq!(
+            convert_invite_claim(
+                &owner,
+                &scope,
+                &[l.link, l.link],
+                &claim_item(&link_signer(0x4e), contact_code(&id, &enc)),
+                UnixMillis(0),
+            )
+            .unwrap_err()
+            .check(),
+            "link-not-committed",
+        );
         // A link the owner revoked from the committed set no longer converts.
         let (cut, cut_sig, cut_ledger) = committed(&[]);
         assert_eq!(
@@ -1625,6 +1651,18 @@ mod tests {
         let unknown = link(0x73, Permission::Read, None);
         assert_eq!(
             revoke_invite_link(&owner, &scope, &unknown.link)
+                .unwrap_err()
+                .check(),
+            "link-not-committed",
+        );
+        // A record carrying a committed tag its own ephemeral key does not derive
+        // is refused, so an owner-side mix-up cannot cut an ordinary grantee.
+        let mixed = RecordedInvite {
+            tag: read.row.tag,
+            ..unknown.link
+        };
+        assert_eq!(
+            revoke_invite_link(&owner, &scope, &mixed)
                 .unwrap_err()
                 .check(),
             "link-not-committed",

--- a/crates/engine/src/grants/invite.rs
+++ b/crates/engine/src/grants/invite.rs
@@ -407,6 +407,15 @@ pub struct ConvertedClaim {
 /// point of conversion, so the minted grant binds the claimant's imported
 /// contact and never the ephemeral half. `now` is the injected
 /// [`Scheduler::now`](crate::seams::Scheduler::now) instant.
+///
+/// Residual: a ledger row's `recipientIdentityPk` sits outside the owner-signed
+/// commitment ([`enforce_committed_ledger`]), so a write-grantee re-authoring the
+/// write-body can point a committed row at an ephemeral identity it holds and
+/// have a claim convert at that row's committed permission. It gains no
+/// permission it does not already hold — only an extra committed tag surviving a
+/// cut of its original one. Pinned by
+/// `a_write_grantee_can_retarget_a_committed_row_at_an_ephemeral_identity`, so
+/// tightening this has to update that test.
 pub fn convert_invite_claim(
     owner: &OwnerAuthority<'_>,
     scope: &CommittedScope<'_>,
@@ -422,12 +431,16 @@ pub fn convert_invite_claim(
 
     // The seal's inner sender signature is already verified; binding it to the
     // ephemeral half this owner committed is what makes it a claim on this link.
+    // Ambiguity is refused rather than resolved to the first match.
     let sender = item.sender_identity.to_sec1();
-    let link = scope
+    let mut matches = scope
         .ledger
         .iter()
-        .find(|e| e.recipient_identity_pk == sender)
-        .ok_or(InviteError::LinkNotCommitted)?;
+        .filter(|e| e.recipient_identity_pk == sender);
+    let link = matches.next().ok_or(InviteError::LinkNotCommitted)?;
+    if matches.next().is_some() {
+        return Err(InviteError::LinkNotCommitted);
+    }
     let link_enc =
         X25519Public::from_bytes(link.recipient_enc_pk).ok_or(InviteError::LinkNotCommitted)?;
     if recipient_blinded_tag(owner.enc_secret, &link_enc, name) != Some(link.tag) {
@@ -572,6 +585,7 @@ mod tests {
         open_grant_blob, sign_grant_set, verify_structure,
     };
     use cipherbox_core::suite::contact::ContactCode;
+    use cipherbox_core::suite::ecdsa::IDENTITY_PUBLIC_LEN;
     use cipherbox_core::suite::ed25519::{Ed25519Signature, Ed25519Signer};
     use cipherbox_core::suite::secret::ct_eq;
 
@@ -1421,6 +1435,46 @@ mod tests {
     }
 
     #[test]
+    fn a_write_grantee_can_retarget_a_committed_row_at_an_ephemeral_identity() {
+        // The honest bound on conversion: `recipientIdentityPk` sits outside the
+        // owner-signed commitment, so a write-grantee re-authoring the write-body
+        // can make a committed row answer to an ephemeral identity it holds. It
+        // gains no permission it does not already hold — only an extra tag.
+        // Pins the residual so tightening it must update this test.
+        let victim_identity = EcdsaSigner::from_scalar(&[0x7a; 32]).expect("valid scalar");
+        let victim_enc = X25519Secret::from_scalar([0x7b; 32]);
+        let victim = mint_grant_row(
+            &owner_enc(),
+            &victim_identity.verifying_key(),
+            &victim_enc.public(),
+            &SCOPE,
+            &scope_name(),
+            Permission::Write,
+        )
+        .expect("contributory");
+        let (commitment, sig, mut ledger) = committed(&[victim.clone()]);
+
+        let attacker = invitee();
+        ledger[0].recipient_identity_pk = attacker.identity_pk().to_sec1();
+
+        let keys = Owner::new();
+        let owner = keys.authority();
+        let (id, enc) = claimant(0x7c);
+        let converted = convert_invite_claim(
+            &owner,
+            &committed_scope(&commitment, &sig, &ledger),
+            &claim_item(&link_signer(&attacker), contact_code(&id, &enc)),
+            UnixMillis(0),
+        )
+        .expect("converts — the residual");
+        assert_eq!(
+            converted.row.commitment_entry.permission,
+            Permission::Write,
+            "the retargeted row's committed permission, not an escalation past it",
+        );
+    }
+
+    #[test]
     fn a_redelivered_claim_converts_to_the_same_grant_and_changes_nothing() {
         let minted = invitee();
         let link = invite(Permission::Read, None);
@@ -1546,6 +1600,7 @@ mod tests {
         let sig = sign_grant_set(&owner_identity(), &commitment).expect("signs");
         let mut stray = link.ledger_entry.clone();
         stray.tag = [0x7e; 32];
+        stray.recipient_identity_pk = [0x02; IDENTITY_PUBLIC_LEN];
         assert_eq!(
             convert_invite_claim(
                 &owner,

--- a/crates/engine/src/grants/invite.rs
+++ b/crates/engine/src/grants/invite.rs
@@ -17,20 +17,33 @@
 //! so the link is honestly bearer and multi-claim. Its deadline lives on
 //! [`GrantLedgerEntry::expires_at`], which states what a deadline does and does
 //! not guarantee.
+//!
+//! A holder claims by posting an [`InviteClaim`] to the owner's mailbox signed
+//! with the ephemeral identity; [`convert_invite_claim`] re-anchors it to the
+//! claimant's imported contact as an ordinary personal grant, leaving the link
+//! itself live.
 
-use cipherbox_core::seal::Permission;
-use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
+use cipherbox_core::codec::{Map, Value, decode, encode_fixed_depth};
+use cipherbox_core::error::{CodecError, Malformed};
+use cipherbox_core::seal::{GrantLedgerEntry, GrantSetCommitment, Permission, verify_grant_set};
+use cipherbox_core::suite::ecdsa::{EcdsaSignature, EcdsaSigner, EcdsaVerifier};
 use cipherbox_core::suite::secret::{SECRET_LEN, SecretBytes};
 use cipherbox_core::suite::x25519::{X25519Public, X25519Secret};
 use cipherbox_core::{ipns::IpnsName, kdf};
 use core::fmt;
 use core::num::NonZeroU64;
+use std::collections::BTreeSet;
 use zeroize::Zeroizing;
 
 use crate::entropy::{Entropy, EntropyError};
-use crate::grants::{GrantRow, mint_grant_row};
+use crate::grants::contact::import_contact;
+use crate::grants::{
+    AuthorityViolation, Contact, GrantRow, enforce_committed_ledger, entry_is_live, mint_grant_row,
+    recipient_blinded_tag,
+};
+use crate::mailbox::{VerifiedMailboxItem, post_sealed};
 use crate::rotation::derive_write_name;
-use crate::seams::UnixMillis;
+use crate::seams::{Mailbox, SeamResult, UnixMillis};
 
 /// The throwaway identity an invite link's grant is wrapped to.
 ///
@@ -67,6 +80,35 @@ pub enum InviteError {
     /// would silently mint a link that never expires
     /// ([`Malformed::InvalidExpiry`](cipherbox_core::error::Malformed::InvalidExpiry)).
     InvalidExpiry,
+    /// The claim payload did not decode.
+    MalformedClaim(CodecError),
+    /// The claim names a different scope root than the committed set it is
+    /// converted against.
+    ScopeMismatch,
+    /// The caller's identity key did not sign the committed set it is acting on,
+    /// so it is not this scope's owner. Minting, converting and revoking are all
+    /// owner-only.
+    NotOwner,
+    /// No live owner-committed link answers to the claim's ephemeral identity —
+    /// the row is absent, uncommitted, or not this owner's ECDH partner.
+    LinkNotCommitted,
+    /// The link's ledger row is past its deadline, so it grants nothing.
+    LinkExpired,
+    /// The claimant's contact code failed its mandatory binding verify.
+    ClaimantContact(CodecError),
+    /// The claim asked to be anchored to the link's own throwaway identity.
+    /// Conversion exists to re-anchor a bearer link to a contact-anchored
+    /// identity, so anchoring back to the ephemeral half is refused.
+    ClaimantIsTheEphemeralHalf,
+    /// The claimant's encryption subkey is non-contributory, so no blinded tag
+    /// binds a grant to it.
+    UnusableClaimantKey,
+    /// The produced set would file two rows under one tag — the shape core's
+    /// decoder and [`sign_grant_set`](cipherbox_core::seal::sign_grant_set)
+    /// reject, refused here rather than signed.
+    DuplicateTag,
+    /// The produced ledger and commitment do not agree.
+    Authority(AuthorityViolation),
 }
 
 impl InviteError {
@@ -77,6 +119,16 @@ impl InviteError {
             Self::InvalidSecret => "invalid-invite-secret",
             Self::UnusableInviteeKey => "unusable-invitee-key",
             Self::InvalidExpiry => "invalid-expiry",
+            Self::MalformedClaim(_) => "malformed-claim",
+            Self::ScopeMismatch => "claim-scope-mismatch",
+            Self::NotOwner => "not-owner",
+            Self::LinkNotCommitted => "link-not-committed",
+            Self::LinkExpired => "link-expired",
+            Self::ClaimantContact(_) => "claimant-contact-invalid",
+            Self::ClaimantIsTheEphemeralHalf => "claimant-is-the-ephemeral-half",
+            Self::UnusableClaimantKey => "unusable-claimant-key",
+            Self::DuplicateTag => "duplicate-tag",
+            Self::Authority(v) => v.check(),
         }
     }
 }
@@ -143,7 +195,48 @@ impl EphemeralInvitee {
     }
 }
 
-/// Mint an invite link's [`GrantRow`] over the scope root at `scope_id`.
+/// What a minted link hands out, as the host must present it.
+///
+/// Every invite link is bearer — the fragment secret is the whole capability —
+/// so what a host must not get wrong is what *ending* one costs, and that is
+/// what this names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkCapability {
+    /// A read link: cutting its tag from the owner-signed set and rotating the
+    /// read plane ends it.
+    Read,
+    /// A write link: the blob hands the fragment holder an extractable subtree
+    /// signing key, so it stays usable until `rotate_scope_write` runs. Pruning
+    /// the ledger revokes nothing (blueprint/engine.md "Invites").
+    BearerWrite,
+}
+
+impl LinkCapability {
+    /// The capability a link at `permission` hands out.
+    pub fn of(permission: Permission) -> Self {
+        match permission {
+            Permission::Read => Self::Read,
+            Permission::Write => Self::BearerWrite,
+        }
+    }
+
+    /// Whether the link hands out an extractable subtree signing key.
+    pub fn is_bearer_write(&self) -> bool {
+        matches!(self, Self::BearerWrite)
+    }
+}
+
+/// A minted invite link: the rows the owner commits, plus the capability flag
+/// the host renders and revocation must respect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MintedInvite {
+    /// The link's blinded tag, commitment entry and ledger row.
+    pub row: GrantRow,
+    /// What the link hands out.
+    pub capability: LinkCapability,
+}
+
+/// Mint an invite link over the scope root at `scope_id`.
 ///
 /// Owner-only by construction: it takes the owner's encryption subkey secret for
 /// the pairwise ECDH, and only the owner's identity signature over the resulting
@@ -158,7 +251,7 @@ pub fn mint_invite_grant(
     write_scope_seed: &[u8; SECRET_LEN],
     permission: Permission,
     expires_at: Option<UnixMillis>,
-) -> Result<GrantRow, InviteError> {
+) -> Result<MintedInvite, InviteError> {
     let expires_at = match expires_at {
         Some(deadline) => Some(NonZeroU64::new(deadline.0).ok_or(InviteError::InvalidExpiry)?),
         None => None,
@@ -174,15 +267,298 @@ pub fn mint_invite_grant(
     )
     .ok_or(InviteError::UnusableInviteeKey)?;
     row.ledger_entry.expires_at = expires_at;
-    Ok(row)
+    Ok(MintedInvite {
+        row,
+        capability: LinkCapability::of(permission),
+    })
+}
+
+/// The claim a link holder posts to the owner's mailbox: which scope root the
+/// link points at, and the claimant's own contact code to be anchored to.
+///
+/// Opaque application bytes inside the HPKE seal — app framing, not crypto. Its
+/// authentication is the seal's inner sender signature, which the claimant makes
+/// with the link's ephemeral identity key ([`post_invite_claim`]); the contact
+/// code inside is self-authenticating and imported fail-closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InviteClaim {
+    /// The scope root's opaque `ipnsName` the link points at.
+    pub scope_root_name: Vec<u8>,
+    /// The claimant's contact code — `{identityPk, encSubkey, bindingSig}`.
+    pub contact_code: Vec<u8>,
+}
+
+impl InviteClaim {
+    /// Encode to det-CBOR (canonical key order).
+    pub fn encode(&self) -> Vec<u8> {
+        let mut m = Map::new();
+        m.insert("contactCode", Value::Bytes(self.contact_code.clone()));
+        m.insert("scopeRootName", Value::Bytes(self.scope_root_name.clone()));
+        encode_fixed_depth(&Value::Map(m))
+    }
+
+    /// Decode a claim (strict det-CBOR). A missing or mistyped field is
+    /// [`Malformed`].
+    pub fn decode(bytes: &[u8]) -> Result<Self, CodecError> {
+        let value = decode(bytes)?;
+        let map = value.as_map()?;
+        let field = |name: &'static str| -> Result<Vec<u8>, CodecError> {
+            Ok(map
+                .get(name)
+                .ok_or(CodecError::from(Malformed::MissingField { field: name }))?
+                .as_bytes()?
+                .to_vec())
+        };
+        Ok(Self {
+            scope_root_name: field("scopeRootName")?,
+            contact_code: field("contactCode")?,
+        })
+    }
+}
+
+/// Post a claim to the owner's mailbox, sealed to the owner's encryption subkey
+/// and signed — as the mailbox sender — with the link's ephemeral identity key.
+/// That signature is what [`convert_invite_claim`] binds to the ephemeral public
+/// half the ledger commits, so only a fragment holder can claim.
+///
+/// `owner` is the contact bundle the invite URL carries; `ephemeral_scalar` is
+/// fresh-per-call HPKE entropy from the injected seam.
+#[allow(clippy::too_many_arguments)]
+pub async fn post_invite_claim<M: Mailbox>(
+    mailbox: &M,
+    owner: &Contact,
+    invitee: &EphemeralInvitee,
+    ephemeral_scalar: &[u8; 32],
+    v: u64,
+    claim: &InviteClaim,
+    idempotency_key: &str,
+) -> SeamResult<()> {
+    post_sealed(
+        mailbox,
+        &owner.enc_subkey(),
+        &owner.identity_pk(),
+        ephemeral_scalar,
+        v,
+        &invitee.identity,
+        &claim.encode(),
+        idempotency_key,
+    )
+    .await
+}
+
+/// The owner's authority over a scope's grant set: the identity key that signs
+/// the commitment, and the encryption subkey secret every blinded tag derives
+/// from. Holding both is what makes a caller the owner.
+pub struct OwnerAuthority<'a> {
+    /// Owner identity signer — the key whose signature authorises the set.
+    pub identity_signer: &'a EcdsaSigner,
+    /// Owner encryption subkey secret — the pairwise ECDH half.
+    pub enc_secret: &'a X25519Secret,
+}
+
+/// A scope root's owner-signed grant set as resolved: the commitment, its
+/// signature, and the write-body ledger it must reproduce. The scope root's
+/// `ipnsName` is the commitment's own, so no caller supplies one.
+pub struct CommittedScope<'a> {
+    /// The scope id the writer pseudonyms bind.
+    pub scope_id: &'a [u8; 16],
+    /// The owner-signed grant-set commitment.
+    pub commitment: &'a GrantSetCommitment,
+    /// The commitment's owner signature.
+    pub commitment_sig: &'a EcdsaSignature,
+    /// The authoritative grant ledger.
+    pub ledger: &'a [GrantLedgerEntry],
+}
+
+impl OwnerAuthority<'_> {
+    /// Fail closed unless this caller's identity key signed the committed set it
+    /// is about to change. Every commitment change is owner-only, and
+    /// `mint_invite_grant` gets that from its arguments where these two do not.
+    fn authorise(&self, scope: &CommittedScope<'_>) -> Result<(), InviteError> {
+        verify_grant_set(
+            &self.identity_signer.verifying_key(),
+            scope.commitment,
+            scope.commitment_sig,
+        )
+        .map_err(|_| InviteError::NotOwner)
+    }
+}
+
+/// A claim converted into a personal grant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConvertedClaim {
+    /// The personal grant minted for the claimant's contact-anchored identity.
+    pub row: GrantRow,
+    /// The grant-set commitment the owner re-signs. The link's own entry stays,
+    /// so one link yields a grant per claimant until it expires or is revoked.
+    pub commitment: GrantSetCommitment,
+    /// The grant ledger matching it.
+    pub ledger: Vec<GrantLedgerEntry>,
+    /// `false` when the claimant already held a grant at this tag — a
+    /// redelivered claim, which changes nothing and needs no republish.
+    pub newly_granted: bool,
+}
+
+/// Convert a sender-verified invite claim into a personal grant for the
+/// claimant's contact-anchored identity.
+///
+/// The link's row commits the ephemeral public half, which is structurally a
+/// login identity rather than a contact-anchored one; re-anchoring is the whole
+/// point of conversion, so the minted grant binds the claimant's imported
+/// contact and never the ephemeral half. `now` is the injected
+/// [`Scheduler::now`](crate::seams::Scheduler::now) instant.
+pub fn convert_invite_claim(
+    owner: &OwnerAuthority<'_>,
+    scope: &CommittedScope<'_>,
+    item: &VerifiedMailboxItem,
+    now: UnixMillis,
+) -> Result<ConvertedClaim, InviteError> {
+    owner.authorise(scope)?;
+    let claim = InviteClaim::decode(&item.payload).map_err(InviteError::MalformedClaim)?;
+    let name = scope.commitment.ipns_name.as_slice();
+    if claim.scope_root_name != name {
+        return Err(InviteError::ScopeMismatch);
+    }
+
+    // The seal's inner sender signature is already verified; binding it to the
+    // ephemeral half this owner committed is what makes it a claim on this link.
+    let sender = item.sender_identity.to_sec1();
+    let link = scope
+        .ledger
+        .iter()
+        .find(|e| e.recipient_identity_pk == sender)
+        .ok_or(InviteError::LinkNotCommitted)?;
+    let link_enc =
+        X25519Public::from_bytes(link.recipient_enc_pk).ok_or(InviteError::LinkNotCommitted)?;
+    if recipient_blinded_tag(owner.enc_secret, &link_enc, name) != Some(link.tag) {
+        return Err(InviteError::LinkNotCommitted);
+    }
+    // The owner-signed entry carries the authoritative permission; a write-
+    // grantee can re-author the ledger row's copy of it.
+    let permission = scope
+        .commitment
+        .entries
+        .iter()
+        .find(|e| e.tag == link.tag)
+        .map(|e| e.permission)
+        .ok_or(InviteError::LinkNotCommitted)?;
+    if !entry_is_live(link, now) {
+        return Err(InviteError::LinkExpired);
+    }
+
+    let contact = import_contact(&claim.contact_code).map_err(InviteError::ClaimantContact)?;
+    if contact.identity_pk() == item.sender_identity
+        || contact.enc_subkey().to_bytes() == link.recipient_enc_pk
+    {
+        return Err(InviteError::ClaimantIsTheEphemeralHalf);
+    }
+    let row = mint_grant_row(
+        owner.enc_secret,
+        &contact.identity_pk(),
+        &contact.enc_subkey(),
+        scope.scope_id,
+        name,
+        permission,
+    )
+    .ok_or(InviteError::UnusableClaimantKey)?;
+
+    let newly_granted = !scope.ledger.iter().any(|e| e.tag == row.tag);
+    let mut commitment = scope.commitment.clone();
+    let mut ledger = scope.ledger.to_vec();
+    if newly_granted {
+        commitment.entries.push(row.commitment_entry.clone());
+        ledger.push(row.ledger_entry.clone());
+    }
+    check_publishable(&commitment, &ledger)?;
+    Ok(ConvertedClaim {
+        row,
+        commitment,
+        ledger,
+        newly_granted,
+    })
+}
+
+/// The owner-signed cut a link revocation makes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InviteRevocation {
+    /// The grant-set commitment the owner re-signs, without the link's entry.
+    pub commitment: GrantSetCommitment,
+    /// The grant ledger matching it.
+    pub ledger: Vec<GrantLedgerEntry>,
+    /// What the revoked link handed out.
+    pub capability: LinkCapability,
+}
+
+impl InviteRevocation {
+    /// Whether publishing this cut with a read rotation is the whole revocation.
+    ///
+    /// `false` for a write link: its fragment holder keeps an extractable
+    /// subtree signing key until `rotate_scope_write` runs, so the cut alone has
+    /// revoked nothing and a host must report the link as not yet revoked.
+    pub fn is_complete(&self) -> bool {
+        !self.capability.is_bearer_write()
+    }
+}
+
+/// Cut an invite link out of the owner-signed grant set. Owner-only.
+///
+/// Grants already converted from the link are untouched — revoking a link ends
+/// future claims, not the personal grants it already produced.
+pub fn revoke_invite_link(
+    owner: &OwnerAuthority<'_>,
+    scope: &CommittedScope<'_>,
+    tag: &[u8; 32],
+) -> Result<InviteRevocation, InviteError> {
+    owner.authorise(scope)?;
+    let capability = scope
+        .commitment
+        .entries
+        .iter()
+        .find(|e| &e.tag == tag)
+        .map(|e| LinkCapability::of(e.permission))
+        .ok_or(InviteError::LinkNotCommitted)?;
+
+    let mut commitment = scope.commitment.clone();
+    commitment.entries.retain(|e| &e.tag != tag);
+    let ledger: Vec<GrantLedgerEntry> = scope
+        .ledger
+        .iter()
+        .filter(|e| &e.tag != tag)
+        .cloned()
+        .collect();
+    check_publishable(&commitment, &ledger)?;
+    Ok(InviteRevocation {
+        commitment,
+        ledger,
+        capability,
+    })
+}
+
+/// The produce-side mirror of what a resolver hard-rejects: duplicate tags (core
+/// rejects them at decode and before signing) and a ledger that diverges from
+/// the commitment (the adoption gate's owner-authority check). Release-active,
+/// so no build can emit a set its own readers refuse.
+fn check_publishable(
+    commitment: &GrantSetCommitment,
+    ledger: &[GrantLedgerEntry],
+) -> Result<(), InviteError> {
+    let mut seen = BTreeSet::new();
+    if !commitment.entries.iter().all(|e| seen.insert(e.tag)) {
+        return Err(InviteError::DuplicateTag);
+    }
+    let mut seen = BTreeSet::new();
+    if !ledger.iter().all(|e| seen.insert(e.tag)) {
+        return Err(InviteError::DuplicateTag);
+    }
+    enforce_committed_ledger(commitment, ledger).map_err(InviteError::Authority)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::grants::{
-        PublishedGrantBlob, enforce_committed_ledger, entry_is_live, recipient_blinded_tag,
-        self_locate,
+        PublishedGrantBlob, enforce_committed_ledger, entry_is_live, live_entry,
+        recipient_blinded_tag, self_locate,
     };
     use crate::rotation::{
         CommittedSet, ResealError, ResealSeeds, ScopeRootIdentity, reseal_scope_root,
@@ -193,6 +569,7 @@ mod tests {
         STRUCT_TAG_GRANT_BLOB, SignedGrantBlob, StructureSigInput, encode_grant_section,
         open_grant_blob, sign_grant_set, verify_structure,
     };
+    use cipherbox_core::suite::contact::ContactCode;
     use cipherbox_core::suite::ed25519::{Ed25519Signature, Ed25519Signer};
     use cipherbox_core::suite::secret::ct_eq;
 
@@ -237,6 +614,7 @@ mod tests {
             expires_at,
         )
         .expect("mints")
+        .row
     }
 
     /// Re-seal a scope root committing exactly `grants` under `committed`'s
@@ -403,7 +781,8 @@ mod tests {
             Permission::Read,
             Some(EXPIRES_AT),
         )
-        .expect("mints");
+        .expect("mints")
+        .row;
         let section =
             scope_root(&[invite.clone()], &owner_pseudonym(), &owner_pseudonym()).expect("reseal");
 
@@ -516,7 +895,8 @@ mod tests {
             Permission::Read,
             None,
         )
-        .expect("mints");
+        .expect("mints")
+        .row;
         let elsewhere = mint_invite_grant(
             &owner_enc(),
             &minted,
@@ -525,7 +905,8 @@ mod tests {
             Permission::Read,
             None,
         )
-        .expect("mints");
+        .expect("mints")
+        .row;
         assert_ne!(here.tag, elsewhere.tag);
         // The pseudonym binds the scope id, not the name, so it is shared.
         assert_eq!(
@@ -545,7 +926,8 @@ mod tests {
             Permission::Write,
             None,
         )
-        .expect("mints");
+        .expect("mints")
+        .row;
         let section =
             scope_root(&[row.clone()], &owner_pseudonym(), &owner_pseudonym()).expect("reseal");
         let blob = blob_at(&section, &row.tag);
@@ -574,7 +956,8 @@ mod tests {
             Permission::Read,
             None,
         )
-        .expect("mints");
+        .expect("mints")
+        .row;
         let section =
             scope_root(&[row.clone()], &owner_pseudonym(), &owner_pseudonym()).expect("reseal");
         let blob = blob_at(&section, &row.tag);
@@ -640,6 +1023,627 @@ mod tests {
             format!("{:?}", EphemeralInvitee::from_secret(&[0xab; 32]).unwrap()),
             "EphemeralInvitee { secret: SecretBytes(redacted), \
              identity: EcdsaSigner(redacted), enc_subkey: X25519Secret(redacted) }",
+        );
+    }
+
+    // -- claim conversion, expiry and bearer flagging -----------------------
+
+    /// The owner-signed set committing exactly `rows`.
+    fn committed(rows: &[GrantRow]) -> (GrantSetCommitment, EcdsaSignature, Vec<GrantLedgerEntry>) {
+        let commitment = GrantSetCommitment {
+            ipns_name: scope_name(),
+            owner_pseudonym_pk: owner_pseudonym().verifying_key().to_bytes(),
+            entries: rows.iter().map(|r| r.commitment_entry.clone()).collect(),
+            unknown: PreservedFields::new(),
+        };
+        let sig = sign_grant_set(&owner_identity(), &commitment).expect("signs");
+        (
+            commitment,
+            sig,
+            rows.iter().map(|r| r.ledger_entry.clone()).collect(),
+        )
+    }
+
+    /// A claimant's own keypair and the contact code binding the two halves.
+    fn claimant(seed: u8) -> (EcdsaSigner, X25519Secret) {
+        (
+            EcdsaSigner::from_scalar(&[seed; 32]).expect("valid scalar"),
+            X25519Secret::from_scalar([seed ^ 0xff; 32]),
+        )
+    }
+
+    fn contact_code(identity: &EcdsaSigner, enc: &X25519Secret) -> Vec<u8> {
+        ContactCode::create(identity, enc.public()).encode()
+    }
+
+    /// A claim as the mailbox hands it over: sender-verified, and signed by the
+    /// link's ephemeral identity unless `sender` says otherwise.
+    fn claim_item(sender: &EcdsaSigner, contact_code: Vec<u8>) -> VerifiedMailboxItem {
+        claim_item_for(sender, contact_code, scope_name())
+    }
+
+    fn claim_item_for(
+        sender: &EcdsaSigner,
+        contact_code: Vec<u8>,
+        scope_root_name: Vec<u8>,
+    ) -> VerifiedMailboxItem {
+        VerifiedMailboxItem {
+            item_id: "claim-1".to_string(),
+            sender_identity: sender.verifying_key(),
+            payload: InviteClaim {
+                scope_root_name,
+                contact_code,
+            }
+            .encode(),
+        }
+    }
+
+    /// The ephemeral signer behind an invite secret — what a fragment holder
+    /// reconstructs to sign its claim.
+    fn link_signer(invitee: &EphemeralInvitee) -> EcdsaSigner {
+        EcdsaSigner::from_scalar(invitee.secret().as_bytes()).expect("valid scalar")
+    }
+
+    #[test]
+    fn one_link_converts_two_claimants_into_two_grants_and_stays_live() {
+        let minted = invitee();
+        let link = mint_invite_grant(
+            &owner_enc(),
+            &minted,
+            &SCOPE,
+            &WRITE_SCOPE_SEED,
+            Permission::Read,
+            None,
+        )
+        .expect("mints");
+        let (commitment, sig, ledger) = committed(&[link.row.clone()]);
+        let owner_id = owner_identity();
+        let owner_e = owner_enc();
+        let owner = OwnerAuthority {
+            identity_signer: &owner_id,
+            enc_secret: &owner_e,
+        };
+        let signer = link_signer(&minted);
+
+        let (a_id, a_enc) = claimant(0x61);
+        let first = convert_invite_claim(
+            &owner,
+            &CommittedScope {
+                scope_id: &SCOPE,
+                commitment: &commitment,
+                commitment_sig: &sig,
+                ledger: &ledger,
+            },
+            &claim_item(&signer, contact_code(&a_id, &a_enc)),
+            UnixMillis(0),
+        )
+        .expect("converts");
+        assert!(first.newly_granted);
+
+        // The second claimant converts against the set the first produced: the
+        // link's own entry is still there, so the link stays claimable.
+        let second_sig = sign_grant_set(&owner_identity(), &first.commitment).expect("signs");
+        let (b_id, b_enc) = claimant(0x62);
+        let second = convert_invite_claim(
+            &owner,
+            &CommittedScope {
+                scope_id: &SCOPE,
+                commitment: &first.commitment,
+                commitment_sig: &second_sig,
+                ledger: &first.ledger,
+            },
+            &claim_item(&signer, contact_code(&b_id, &b_enc)),
+            UnixMillis(0),
+        )
+        .expect("converts");
+
+        assert_ne!(first.row.tag, second.row.tag, "two independent grants");
+        assert_eq!(second.commitment.entries.len(), 3);
+        assert_eq!(second.ledger.len(), 3);
+        assert!(
+            second
+                .commitment
+                .entries
+                .iter()
+                .any(|e| e.tag == link.row.tag),
+            "the link itself stays live until it expires or is revoked",
+        );
+    }
+
+    #[test]
+    fn a_converted_grant_anchors_to_the_claimants_contact_never_the_ephemeral_half() {
+        let minted = invitee();
+        let link = mint_invite_grant(
+            &owner_enc(),
+            &minted,
+            &SCOPE,
+            &WRITE_SCOPE_SEED,
+            Permission::Write,
+            None,
+        )
+        .expect("mints");
+        let (commitment, sig, ledger) = committed(&[link.row.clone()]);
+        let owner_id = owner_identity();
+        let owner_e = owner_enc();
+        let owner = OwnerAuthority {
+            identity_signer: &owner_id,
+            enc_secret: &owner_e,
+        };
+        let scope = CommittedScope {
+            scope_id: &SCOPE,
+            commitment: &commitment,
+            commitment_sig: &sig,
+            ledger: &ledger,
+        };
+        let signer = link_signer(&minted);
+        let (id, enc) = claimant(0x63);
+
+        let converted = convert_invite_claim(
+            &owner,
+            &scope,
+            &claim_item(&signer, contact_code(&id, &enc)),
+            UnixMillis(0),
+        )
+        .expect("converts");
+
+        assert_eq!(
+            converted.row.ledger_entry.recipient_identity_pk,
+            id.verifying_key().to_sec1(),
+        );
+        assert_eq!(
+            converted.row.ledger_entry.recipient_enc_pk,
+            enc.public().to_bytes()
+        );
+        assert_ne!(
+            converted.row.ledger_entry.recipient_identity_pk,
+            minted.identity_pk().to_sec1(),
+        );
+        assert_eq!(
+            converted.row.commitment_entry.permission,
+            Permission::Write,
+            "the converted grant inherits the link's committed permission",
+        );
+        assert_eq!(
+            converted.row.ledger_entry.expires_at, None,
+            "the personal grant is not the link and carries no link deadline",
+        );
+        // The claimant may not hand back the link's own throwaway identity: it
+        // self-signs a perfectly valid contact code, and re-anchoring is the
+        // whole point of conversion.
+        assert_eq!(
+            convert_invite_claim(
+                &owner,
+                &scope,
+                &claim_item(&signer, contact_code(&signer, minted.enc_secret())),
+                UnixMillis(0),
+            )
+            .unwrap_err()
+            .check(),
+            "claimant-is-the-ephemeral-half",
+        );
+    }
+
+    #[test]
+    fn a_claim_signed_by_an_uncommitted_key_is_refused() {
+        let minted = invitee();
+        let link = invite(Permission::Read, None);
+        let (commitment, sig, ledger) = committed(&[link]);
+        let owner_id = owner_identity();
+        let owner_e = owner_enc();
+        let owner = OwnerAuthority {
+            identity_signer: &owner_id,
+            enc_secret: &owner_e,
+        };
+        let scope = CommittedScope {
+            scope_id: &SCOPE,
+            commitment: &commitment,
+            commitment_sig: &sig,
+            ledger: &ledger,
+        };
+        let (id, enc) = claimant(0x64);
+
+        // A different ephemeral identity than the one the ledger commits.
+        let forger = link_signer(&EphemeralInvitee::from_secret(&[0x4f; 32]).expect("valid"));
+        assert_eq!(
+            convert_invite_claim(
+                &owner,
+                &scope,
+                &claim_item(&forger, contact_code(&id, &enc)),
+                UnixMillis(0),
+            )
+            .unwrap_err()
+            .check(),
+            "link-not-committed",
+        );
+        // The committed one converts, so the reject above isolates the signer.
+        assert!(
+            convert_invite_claim(
+                &owner,
+                &scope,
+                &claim_item(&link_signer(&minted), contact_code(&id, &enc)),
+                UnixMillis(0),
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn a_claim_against_an_expired_link_is_refused_at_the_deadline() {
+        let minted = invitee();
+        let link = mint_invite_grant(
+            &owner_enc(),
+            &minted,
+            &SCOPE,
+            &WRITE_SCOPE_SEED,
+            Permission::Read,
+            Some(EXPIRES_AT),
+        )
+        .expect("mints");
+        let (commitment, sig, ledger) = committed(&[link.row.clone()]);
+        let owner_id = owner_identity();
+        let owner_e = owner_enc();
+        let owner = OwnerAuthority {
+            identity_signer: &owner_id,
+            enc_secret: &owner_e,
+        };
+        let scope = CommittedScope {
+            scope_id: &SCOPE,
+            commitment: &commitment,
+            commitment_sig: &sig,
+            ledger: &ledger,
+        };
+        let (id, enc) = claimant(0x65);
+        let item = claim_item(&link_signer(&minted), contact_code(&id, &enc));
+
+        assert!(
+            convert_invite_claim(&owner, &scope, &item, UnixMillis(EXPIRES_AT.0 - 1)).is_ok(),
+            "live one tick before the deadline",
+        );
+        assert_eq!(
+            convert_invite_claim(&owner, &scope, &item, EXPIRES_AT)
+                .unwrap_err()
+                .check(),
+            "link-expired",
+        );
+        // And the row is inert on the read path at the same instant, with no
+        // prune having touched the ledger.
+        assert!(live_entry(&ledger, &link.row.tag, EXPIRES_AT).is_none());
+        assert_eq!(ledger.len(), 1, "nothing was pruned");
+    }
+
+    #[test]
+    fn a_non_owner_can_neither_convert_nor_revoke() {
+        let minted = invitee();
+        let link = invite(Permission::Read, None);
+        let tag = link.tag;
+        let (commitment, sig, ledger) = committed(&[link]);
+        let scope = CommittedScope {
+            scope_id: &SCOPE,
+            commitment: &commitment,
+            commitment_sig: &sig,
+            ledger: &ledger,
+        };
+        let (id, enc) = claimant(0x66);
+        let item = claim_item(&link_signer(&minted), contact_code(&id, &enc));
+
+        // A stranger's identity key never signed this committed set.
+        let rogue_id = EcdsaSigner::from_scalar(&[0x34; 32]).expect("valid scalar");
+        let owner_e = owner_enc();
+        let rogue = OwnerAuthority {
+            identity_signer: &rogue_id,
+            enc_secret: &owner_e,
+        };
+        assert_eq!(
+            convert_invite_claim(&rogue, &scope, &item, UnixMillis(0))
+                .unwrap_err()
+                .check(),
+            "not-owner",
+        );
+        assert_eq!(
+            revoke_invite_link(&rogue, &scope, &tag)
+                .unwrap_err()
+                .check(),
+            "not-owner",
+        );
+
+        // Defense in depth: the owner identity with a foreign encryption subkey
+        // cannot re-derive the committed link tag either.
+        let owner_id = owner_identity();
+        let foreign_enc = X25519Secret::from_scalar([0x12; 32]);
+        let half = OwnerAuthority {
+            identity_signer: &owner_id,
+            enc_secret: &foreign_enc,
+        };
+        assert_eq!(
+            convert_invite_claim(&half, &scope, &item, UnixMillis(0))
+                .unwrap_err()
+                .check(),
+            "link-not-committed",
+        );
+    }
+
+    #[test]
+    fn a_write_link_is_bearer_and_a_ledger_cut_alone_revokes_nothing() {
+        let read = mint_invite_grant(
+            &owner_enc(),
+            &EphemeralInvitee::from_secret(&[0x71; 32]).expect("valid"),
+            &SCOPE,
+            &WRITE_SCOPE_SEED,
+            Permission::Read,
+            None,
+        )
+        .expect("mints");
+        let write = mint_invite_grant(
+            &owner_enc(),
+            &EphemeralInvitee::from_secret(&[0x72; 32]).expect("valid"),
+            &SCOPE,
+            &WRITE_SCOPE_SEED,
+            Permission::Write,
+            None,
+        )
+        .expect("mints");
+        assert!(
+            write.capability.is_bearer_write(),
+            "a write link hands out an extractable subtree signing key",
+        );
+        assert!(!read.capability.is_bearer_write());
+        let (read_link, write_link) = (read.row, write.row);
+
+        let owner_id = owner_identity();
+        let owner_e = owner_enc();
+        let owner = OwnerAuthority {
+            identity_signer: &owner_id,
+            enc_secret: &owner_e,
+        };
+        let (commitment, sig, ledger) = committed(&[read_link.clone(), write_link.clone()]);
+        let scope = CommittedScope {
+            scope_id: &SCOPE,
+            commitment: &commitment,
+            commitment_sig: &sig,
+            ledger: &ledger,
+        };
+
+        let cut = revoke_invite_link(&owner, &scope, &write_link.tag).expect("cuts");
+        assert!(
+            !cut.is_complete(),
+            "a write link is not revoked until rotate_scope_write runs",
+        );
+        assert_eq!(cut.capability, LinkCapability::BearerWrite);
+        assert!(
+            !cut.commitment
+                .entries
+                .iter()
+                .any(|e| e.tag == write_link.tag)
+        );
+        assert!(!cut.ledger.iter().any(|e| e.tag == write_link.tag));
+        assert!(
+            cut.commitment
+                .entries
+                .iter()
+                .any(|e| e.tag == read_link.tag),
+            "the other grantee is untouched",
+        );
+
+        assert!(
+            revoke_invite_link(&owner, &scope, &read_link.tag)
+                .expect("cuts")
+                .is_complete(),
+            "a read link's cut plus a read rotation is the whole revocation",
+        );
+        assert_eq!(
+            revoke_invite_link(&owner, &scope, &[0x77; 32])
+                .unwrap_err()
+                .check(),
+            "link-not-committed",
+        );
+    }
+
+    #[test]
+    fn a_redelivered_claim_converts_to_the_same_grant_and_changes_nothing() {
+        let minted = invitee();
+        let link = invite(Permission::Read, None);
+        let (commitment, sig, ledger) = committed(&[link]);
+        let owner_id = owner_identity();
+        let owner_e = owner_enc();
+        let owner = OwnerAuthority {
+            identity_signer: &owner_id,
+            enc_secret: &owner_e,
+        };
+        let (id, enc) = claimant(0x67);
+        let item = claim_item(&link_signer(&minted), contact_code(&id, &enc));
+
+        let first = convert_invite_claim(
+            &owner,
+            &CommittedScope {
+                scope_id: &SCOPE,
+                commitment: &commitment,
+                commitment_sig: &sig,
+                ledger: &ledger,
+            },
+            &item,
+            UnixMillis(0),
+        )
+        .expect("converts");
+
+        let resigned = sign_grant_set(&owner_identity(), &first.commitment).expect("signs");
+        let again = convert_invite_claim(
+            &owner,
+            &CommittedScope {
+                scope_id: &SCOPE,
+                commitment: &first.commitment,
+                commitment_sig: &resigned,
+                ledger: &first.ledger,
+            },
+            &item,
+            UnixMillis(0),
+        )
+        .expect("converts");
+
+        assert!(!again.newly_granted);
+        assert_eq!(again.commitment, first.commitment);
+        assert_eq!(again.ledger, first.ledger);
+    }
+
+    #[test]
+    fn a_claim_naming_another_scope_root_is_refused() {
+        let minted = invitee();
+        let link = invite(Permission::Read, None);
+        let (commitment, sig, ledger) = committed(&[link]);
+        let owner_id = owner_identity();
+        let owner_e = owner_enc();
+        let owner = OwnerAuthority {
+            identity_signer: &owner_id,
+            enc_secret: &owner_e,
+        };
+        let (id, enc) = claimant(0x68);
+        assert_eq!(
+            convert_invite_claim(
+                &owner,
+                &CommittedScope {
+                    scope_id: &SCOPE,
+                    commitment: &commitment,
+                    commitment_sig: &sig,
+                    ledger: &ledger,
+                },
+                &claim_item_for(
+                    &link_signer(&minted),
+                    contact_code(&id, &enc),
+                    b"k51elsewhere".to_vec(),
+                ),
+                UnixMillis(0),
+            )
+            .unwrap_err()
+            .check(),
+            "claim-scope-mismatch",
+        );
+    }
+
+    #[test]
+    fn a_claimant_contact_code_with_a_broken_binding_is_refused() {
+        let minted = invitee();
+        let link = invite(Permission::Read, None);
+        let (commitment, sig, ledger) = committed(&[link]);
+        let owner_id = owner_identity();
+        let owner_e = owner_enc();
+        let owner = OwnerAuthority {
+            identity_signer: &owner_id,
+            enc_secret: &owner_e,
+        };
+        let (id, enc) = claimant(0x69);
+        let mut code = contact_code(&id, &enc);
+        let last = code.len() - 1;
+        code[last] ^= 0x01;
+
+        assert_eq!(
+            convert_invite_claim(
+                &owner,
+                &CommittedScope {
+                    scope_id: &SCOPE,
+                    commitment: &commitment,
+                    commitment_sig: &sig,
+                    ledger: &ledger,
+                },
+                &claim_item(&link_signer(&minted), code),
+                UnixMillis(0),
+            )
+            .unwrap_err()
+            .check(),
+            "claimant-contact-invalid",
+        );
+    }
+
+    #[test]
+    fn a_conversion_that_would_publish_an_unreadable_set_returns_err() {
+        // Encode-side symmetry: core rejects a duplicate-tag commitment at decode
+        // and before signing, and the gate rejects a ledger that diverges from
+        // the commitment. Both are refused here rather than signed — a `return
+        // Err`, not an assertion a release build strips.
+        let minted = invitee();
+        let link = invite(Permission::Read, None);
+        let owner_id = owner_identity();
+        let owner_e = owner_enc();
+        let owner = OwnerAuthority {
+            identity_signer: &owner_id,
+            enc_secret: &owner_e,
+        };
+        let (id, enc) = claimant(0x6a);
+        let item = claim_item(&link_signer(&minted), contact_code(&id, &enc));
+
+        // The claimant's tag is already committed but absent from the ledger, so
+        // appending it would file two commitment entries under one tag.
+        let claimant_row = mint_grant_row(
+            &owner_enc(),
+            &id.verifying_key(),
+            &enc.public(),
+            &SCOPE,
+            &scope_name(),
+            Permission::Read,
+        )
+        .expect("contributory");
+        let (mut commitment, _, ledger) = committed(&[link.clone(), claimant_row]);
+        let ledger: Vec<GrantLedgerEntry> = ledger.into_iter().take(1).collect();
+        let sig = sign_grant_set(&owner_identity(), &commitment).expect("signs");
+        assert_eq!(
+            convert_invite_claim(
+                &owner,
+                &CommittedScope {
+                    scope_id: &SCOPE,
+                    commitment: &commitment,
+                    commitment_sig: &sig,
+                    ledger: &ledger,
+                },
+                &item,
+                UnixMillis(0),
+            )
+            .unwrap_err()
+            .check(),
+            "duplicate-tag",
+        );
+
+        // A ledger the commitment does not cover diverges once the new row lands.
+        commitment.entries.truncate(1);
+        let sig = sign_grant_set(&owner_identity(), &commitment).expect("signs");
+        let mut stray = link.ledger_entry.clone();
+        stray.tag = [0x7e; 32];
+        assert_eq!(
+            convert_invite_claim(
+                &owner,
+                &CommittedScope {
+                    scope_id: &SCOPE,
+                    commitment: &commitment,
+                    commitment_sig: &sig,
+                    ledger: &[link.ledger_entry.clone(), stray],
+                },
+                &item,
+                UnixMillis(0),
+            )
+            .unwrap_err()
+            .check(),
+            "ledger-diverges-from-commitment",
+        );
+    }
+
+    #[test]
+    fn the_claim_payload_round_trips_byte_stable_and_rejects_a_missing_field() {
+        let claim = InviteClaim {
+            scope_root_name: b"k51scoperoot".to_vec(),
+            contact_code: b"contact".to_vec(),
+        };
+        let bytes = claim.encode();
+        let decoded = InviteClaim::decode(&bytes).expect("decodes");
+        assert_eq!(decoded, claim);
+        assert_eq!(decoded.encode(), bytes, "byte-stable");
+
+        let mut m = cipherbox_core::codec::decode(&bytes)
+            .unwrap()
+            .as_map()
+            .unwrap()
+            .clone();
+        m.remove("contactCode");
+        let short = cipherbox_core::codec::encode(&Value::Map(m)).unwrap();
+        assert_eq!(
+            InviteClaim::decode(&short).unwrap_err().check(),
+            "missing-field"
         );
     }
 }

--- a/crates/engine/src/grants/ledger.rs
+++ b/crates/engine/src/grants/ledger.rs
@@ -83,21 +83,6 @@ pub fn entry_is_live(entry: &GrantLedgerEntry, now: UnixMillis) -> bool {
     }
 }
 
-/// The read path's view of a resolved grant ledger: the row filed under `tag`,
-/// or `None` once it is past its deadline at `now`. An expired row is inert
-/// here — before and independently of the prune that eventually removes it — so
-/// a reader never depends on the owner having observed the expiry yet.
-pub fn live_entry<'a>(
-    ledger: &'a [GrantLedgerEntry],
-    tag: &[u8; 32],
-    now: UnixMillis,
-) -> Option<&'a GrantLedgerEntry> {
-    ledger
-        .iter()
-        .find(|e| &e.tag == tag)
-        .filter(|e| entry_is_live(e, now))
-}
-
 /// The rows one grantee contributes to a scope root: the blinded tag, the entry
 /// the owner signs into the grant-set commitment, and the authoritative ledger
 /// row.
@@ -281,25 +266,6 @@ mod tests {
             "dies at, not after"
         );
         assert!(!entry_is_live(&entry, UnixMillis(1_001)));
-    }
-
-    #[test]
-    fn an_expired_row_reads_as_no_grant_on_the_read_path() {
-        let live = ledger_entry([0x21; 32], Permission::Read);
-        let mut expiring = ledger_entry([0x22; 32], Permission::Write);
-        expiring.expires_at = NonZeroU64::new(1_000);
-        let ledger = vec![live, expiring];
-
-        assert!(live_entry(&ledger, &[0x22; 32], UnixMillis(999)).is_some());
-        assert!(
-            live_entry(&ledger, &[0x22; 32], UnixMillis(1_000)).is_none(),
-            "the row is still in the ledger but grants nothing once expired",
-        );
-        assert!(
-            live_entry(&ledger, &[0x21; 32], UnixMillis(u64::MAX)).is_some(),
-            "a deadline-free sibling is untouched",
-        );
-        assert!(live_entry(&ledger, &[0x99; 32], UnixMillis(0)).is_none());
     }
 
     #[test]

--- a/crates/engine/src/grants/ledger.rs
+++ b/crates/engine/src/grants/ledger.rs
@@ -83,6 +83,21 @@ pub fn entry_is_live(entry: &GrantLedgerEntry, now: UnixMillis) -> bool {
     }
 }
 
+/// The read path's view of a resolved grant ledger: the row filed under `tag`,
+/// or `None` once it is past its deadline at `now`. An expired row is inert
+/// here — before and independently of the prune that eventually removes it — so
+/// a reader never depends on the owner having observed the expiry yet.
+pub fn live_entry<'a>(
+    ledger: &'a [GrantLedgerEntry],
+    tag: &[u8; 32],
+    now: UnixMillis,
+) -> Option<&'a GrantLedgerEntry> {
+    ledger
+        .iter()
+        .find(|e| &e.tag == tag)
+        .filter(|e| entry_is_live(e, now))
+}
+
 /// The rows one grantee contributes to a scope root: the blinded tag, the entry
 /// the owner signs into the grant-set commitment, and the authoritative ledger
 /// row.
@@ -266,6 +281,25 @@ mod tests {
             "dies at, not after"
         );
         assert!(!entry_is_live(&entry, UnixMillis(1_001)));
+    }
+
+    #[test]
+    fn an_expired_row_reads_as_no_grant_on_the_read_path() {
+        let live = ledger_entry([0x21; 32], Permission::Read);
+        let mut expiring = ledger_entry([0x22; 32], Permission::Write);
+        expiring.expires_at = NonZeroU64::new(1_000);
+        let ledger = vec![live, expiring];
+
+        assert!(live_entry(&ledger, &[0x22; 32], UnixMillis(999)).is_some());
+        assert!(
+            live_entry(&ledger, &[0x22; 32], UnixMillis(1_000)).is_none(),
+            "the row is still in the ledger but grants nothing once expired",
+        );
+        assert!(
+            live_entry(&ledger, &[0x21; 32], UnixMillis(u64::MAX)).is_some(),
+            "a deadline-free sibling is untouched",
+        );
+        assert!(live_entry(&ledger, &[0x99; 32], UnixMillis(0)).is_none());
     }
 
     #[test]

--- a/crates/engine/src/grants/mod.rs
+++ b/crates/engine/src/grants/mod.rs
@@ -33,13 +33,13 @@ pub use create::{
     ParentScopePlan, create_read_grant,
 };
 pub use invite::{
-    CommittedScope, ConvertedClaim, EphemeralInvitee, InviteClaim, InviteError, InviteRevocation,
-    LinkCapability, MintedInvite, OwnerAuthority, convert_invite_claim, mint_invite_grant,
-    post_invite_claim, revoke_invite_link,
+    ClaimOutcome, CommittedScope, ConvertedClaim, EphemeralInvitee, InviteClaim, InviteError,
+    InviteRevocation, LinkCapability, MintedInvite, OwnerAuthority, RecordedInvite,
+    convert_invite_claim, mint_invite_grant, post_invite_claim, revoke_invite_link,
 };
 pub use ledger::{
     AuthorityViolation, GrantRow, PublishedGrantBlob, enforce_committed_ledger, entry_is_live,
-    live_entry, mint_grant_row, recipient_blinded_tag, self_locate,
+    mint_grant_row, recipient_blinded_tag, self_locate,
 };
 pub use owner_entry::{AbuseEvent, OwnerEntry, OwnerSeedCache, OwnerSeedEntry, cross_check};
 pub use revocation::{ResolutionClass, ResolutionFacts, classify};

--- a/crates/engine/src/grants/mod.rs
+++ b/crates/engine/src/grants/mod.rs
@@ -6,9 +6,9 @@
 //! contact import, the accept flow, revocation classification, and the owner seed
 //! cross-check. Read-grant *creation* ([`create`]) composes the sweep + re-seal +
 //! mailbox primitives into the owner-side mint; [`invite`] mints the ephemeral
-//! identity a bearer link's grant is wrapped to. Write grants, claim conversion,
-//! and revoke *actions* are not implemented here. Every trust decision is a
-//! composed core verdict or the adoption gate's; this layer holds no crypto.
+//! identity a bearer link's grant is wrapped to and converts its claims into
+//! personal grants. Write grants are not implemented here. Every trust decision
+//! is a composed core verdict or the adoption gate's; this layer holds no crypto.
 
 pub mod accept;
 pub mod child_index;
@@ -32,10 +32,14 @@ pub use create::{
     CreateGrantError, CreateGrantOutcome, GrantRecipient, GranteeScopePlan, OwnerGrantKeys,
     ParentScopePlan, create_read_grant,
 };
-pub use invite::{EphemeralInvitee, InviteError, mint_invite_grant};
+pub use invite::{
+    CommittedScope, ConvertedClaim, EphemeralInvitee, InviteClaim, InviteError, InviteRevocation,
+    LinkCapability, MintedInvite, OwnerAuthority, convert_invite_claim, mint_invite_grant,
+    post_invite_claim, revoke_invite_link,
+};
 pub use ledger::{
     AuthorityViolation, GrantRow, PublishedGrantBlob, enforce_committed_ledger, entry_is_live,
-    mint_grant_row, recipient_blinded_tag, self_locate,
+    live_entry, mint_grant_row, recipient_blinded_tag, self_locate,
 };
 pub use owner_entry::{AbuseEvent, OwnerEntry, OwnerSeedCache, OwnerSeedEntry, cross_check};
 pub use revocation::{ResolutionClass, ResolutionFacts, classify};

--- a/crates/engine/tests/invite_claims.rs
+++ b/crates/engine/tests/invite_claims.rs
@@ -14,8 +14,8 @@ use cipherbox_core::suite::ed25519::Ed25519Signer;
 use cipherbox_core::suite::x25519::X25519Secret;
 
 use cipherbox_engine::grants::{
-    CommittedScope, EphemeralInvitee, InviteClaim, OwnerAuthority, convert_invite_claim,
-    import_contact, mint_invite_grant, post_invite_claim,
+    ClaimOutcome, CommittedScope, EphemeralInvitee, InviteClaim, OwnerAuthority, RecordedInvite,
+    convert_invite_claim, import_contact, mint_invite_grant, post_invite_claim,
 };
 use cipherbox_engine::mailbox::poll_verified;
 use cipherbox_engine::rotation::derive_write_name;
@@ -27,6 +27,8 @@ const V: u64 = 2;
 const SCOPE: [u8; 16] = [0x5c; 16];
 const WRITE_SCOPE_SEED: [u8; 32] = [0x55; 32];
 const EPH_MAILBOX: [u8; 32] = [0x71; 32];
+const EPH_FORGED: [u8; 32] = [0x72; 32];
+const EPH_TRANSPORT: [u8; 32] = [0x73; 32];
 
 fn owner_enc() -> X25519Secret {
     X25519Secret::from_scalar([0x11; 32])
@@ -48,12 +50,13 @@ fn owner_contact_code() -> Vec<u8> {
     ContactCode::create(&owner_identity(), owner_enc().public()).encode()
 }
 
-/// The published set committing one invite link, and the link's ephemeral
-/// identity reconstructed from the fragment secret the claimant would read.
+/// The published set committing one invite link, the owner's record of it, and
+/// the ephemeral identity a fragment holder reconstructs.
 struct Link {
     commitment: GrantSetCommitment,
     commitment_sig: cipherbox_core::suite::ecdsa::EcdsaSignature,
     ledger: Vec<cipherbox_core::seal::GrantLedgerEntry>,
+    recorded: RecordedInvite,
     invitee: EphemeralInvitee,
 }
 
@@ -114,6 +117,7 @@ fn link(permission: Permission) -> Link {
         commitment,
         commitment_sig,
         ledger: vec![minted.row.ledger_entry],
+        recorded: minted.link,
         invitee,
     }
 }
@@ -156,12 +160,13 @@ fn a_link_holder_claims_over_the_mailbox_and_the_owner_converts_it() {
     let converted = convert_invite_claim(
         &keys.authority(),
         &l.scope(),
+        &[l.recorded],
         &items[0],
         cipherbox_engine::seams::UnixMillis(0),
     )
     .expect("converts");
 
-    assert!(converted.newly_granted);
+    assert_eq!(converted.outcome, ClaimOutcome::Granted);
     assert_eq!(
         converted.row.ledger_entry.recipient_identity_pk,
         claimant_identity.verifying_key().to_sec1(),
@@ -186,7 +191,7 @@ fn a_claim_signed_by_a_key_the_link_does_not_commit_never_becomes_a_grant() {
         &forger_box,
         &owner_contact,
         &stranger,
-        &EPH_MAILBOX,
+        &EPH_FORGED,
         V,
         &InviteClaim {
             scope_root_name: scope_name(),
@@ -197,7 +202,7 @@ fn a_claim_signed_by_a_key_the_link_does_not_commit_never_becomes_a_grant() {
     .expect("posts");
 
     // The mailbox authenticates it — the forger signed honestly, just with a key
-    // the ledger does not commit — so the fail-closed reject is conversion's.
+    // the owner never recorded — so the fail-closed reject is conversion's.
     let items = block_on(poll_verified(&owner_box, &owner_enc(), V)).expect("polls");
     assert_eq!(items.len(), 1);
 
@@ -206,6 +211,7 @@ fn a_claim_signed_by_a_key_the_link_does_not_commit_never_becomes_a_grant() {
         convert_invite_claim(
             &keys.authority(),
             &l.scope(),
+            &[l.recorded],
             &items[0],
             cipherbox_engine::seams::UnixMillis(0),
         )
@@ -231,7 +237,7 @@ fn the_transport_sees_no_claim_field_in_the_clear() {
         &holder_box,
         &owner_contact,
         &l.invitee,
-        &EPH_MAILBOX,
+        &EPH_TRANSPORT,
         V,
         &InviteClaim {
             scope_root_name: scope_name(),

--- a/crates/engine/tests/invite_claims.rs
+++ b/crates/engine/tests/invite_claims.rs
@@ -255,6 +255,12 @@ fn the_transport_sees_no_claim_field_in_the_clear() {
         &claimant_identity.verifying_key().to_sec1(),
         scope_name().as_slice(),
     ] {
+        // `windows` yields nothing when the payload is shorter than the needle,
+        // which would pass the scan below without scanning anything.
+        assert!(
+            sealed.len() >= secret.len(),
+            "the sealed payload is too short for this scan to mean anything",
+        );
         assert!(
             !sealed.windows(secret.len()).any(|w| w == secret),
             "the transport must carry no claim field in the clear",

--- a/crates/engine/tests/invite_claims.rs
+++ b/crates/engine/tests/invite_claims.rs
@@ -1,0 +1,242 @@
+//! Invite claim delivery end to end over the mailbox seam: a link holder posts
+//! a sealed, ephemeral-key-signed claim and the owner converts it into a
+//! personal grant anchored to the claimant's contact.
+//!
+//! The unit suite in `grants::invite` covers conversion's reject rows against
+//! hand-built items; this suite runs the same conversion over the real
+//! [`Mailbox`] seam so the sender authentication a claim depends on is the
+//! transport's own, not a test double's.
+
+use cipherbox_core::seal::{GrantSetCommitment, Permission, PreservedFields, sign_grant_set};
+use cipherbox_core::suite::contact::ContactCode;
+use cipherbox_core::suite::ecdsa::EcdsaSigner;
+use cipherbox_core::suite::ed25519::Ed25519Signer;
+use cipherbox_core::suite::x25519::X25519Secret;
+
+use cipherbox_engine::grants::{
+    CommittedScope, EphemeralInvitee, InviteClaim, OwnerAuthority, convert_invite_claim,
+    import_contact, mint_invite_grant, post_invite_claim,
+};
+use cipherbox_engine::mailbox::poll_verified;
+use cipherbox_engine::rotation::derive_write_name;
+use cipherbox_engine::seams::Mailbox;
+use cipherbox_engine::testkit::block_on;
+use cipherbox_engine::testkit::fakes::InMemoryMailboxHub;
+
+const V: u64 = 2;
+const SCOPE: [u8; 16] = [0x5c; 16];
+const WRITE_SCOPE_SEED: [u8; 32] = [0x55; 32];
+const EPH_MAILBOX: [u8; 32] = [0x71; 32];
+
+fn owner_enc() -> X25519Secret {
+    X25519Secret::from_scalar([0x11; 32])
+}
+
+fn owner_identity() -> EcdsaSigner {
+    EcdsaSigner::from_scalar(&[0x33; 32]).expect("valid scalar")
+}
+
+fn scope_name() -> Vec<u8> {
+    derive_write_name(&WRITE_SCOPE_SEED, &SCOPE)
+        .as_str()
+        .as_bytes()
+        .to_vec()
+}
+
+/// The owner's contact bundle, exactly as an invite URL carries it.
+fn owner_contact_code() -> Vec<u8> {
+    ContactCode::create(&owner_identity(), owner_enc().public()).encode()
+}
+
+/// The published set committing one invite link, and the link's ephemeral
+/// identity reconstructed from the fragment secret the claimant would read.
+struct Link {
+    commitment: GrantSetCommitment,
+    commitment_sig: cipherbox_core::suite::ecdsa::EcdsaSignature,
+    ledger: Vec<cipherbox_core::seal::GrantLedgerEntry>,
+    invitee: EphemeralInvitee,
+}
+
+fn link(permission: Permission) -> Link {
+    let invitee = EphemeralInvitee::from_secret(&[0x4e; 32]).expect("valid");
+    let minted = mint_invite_grant(
+        &owner_enc(),
+        &invitee,
+        &SCOPE,
+        &WRITE_SCOPE_SEED,
+        permission,
+        None,
+    )
+    .expect("mints");
+    let commitment = GrantSetCommitment {
+        ipns_name: scope_name(),
+        owner_pseudonym_pk: Ed25519Signer::from_seed([0x22; 32])
+            .verifying_key()
+            .to_bytes(),
+        entries: vec![minted.row.commitment_entry.clone()],
+        unknown: PreservedFields::new(),
+    };
+    let commitment_sig = sign_grant_set(&owner_identity(), &commitment).expect("signs");
+    Link {
+        commitment,
+        commitment_sig,
+        ledger: vec![minted.row.ledger_entry],
+        invitee,
+    }
+}
+
+#[test]
+fn a_link_holder_claims_over_the_mailbox_and_the_owner_converts_it() {
+    let hub = InMemoryMailboxHub::default();
+    let owner_address = owner_identity().verifying_key().to_sec1();
+    let owner_box = hub.mailbox_for(&owner_address);
+    let holder_box = hub.mailbox_for(b"holder-outbox");
+
+    let l = link(Permission::Read);
+    let claimant_identity = EcdsaSigner::from_scalar(&[0x61; 32]).expect("valid scalar");
+    let claimant_enc = X25519Secret::from_scalar([0x62; 32]);
+    let owner_contact = import_contact(&owner_contact_code()).expect("valid bundle");
+
+    block_on(post_invite_claim(
+        &holder_box,
+        &owner_contact,
+        &l.invitee,
+        &EPH_MAILBOX,
+        V,
+        &InviteClaim {
+            scope_root_name: scope_name(),
+            contact_code: ContactCode::create(&claimant_identity, claimant_enc.public()).encode(),
+        },
+        "claim-1",
+    ))
+    .expect("posts");
+
+    let items = block_on(poll_verified(&owner_box, &owner_enc(), V)).expect("polls");
+    assert_eq!(items.len(), 1);
+    assert_eq!(
+        items[0].sender_identity,
+        l.invitee.identity_pk(),
+        "the claim authenticates as the link's ephemeral identity",
+    );
+
+    let owner_id = owner_identity();
+    let owner_e = owner_enc();
+    let converted = convert_invite_claim(
+        &OwnerAuthority {
+            identity_signer: &owner_id,
+            enc_secret: &owner_e,
+        },
+        &CommittedScope {
+            scope_id: &SCOPE,
+            commitment: &l.commitment,
+            commitment_sig: &l.commitment_sig,
+            ledger: &l.ledger,
+        },
+        &items[0],
+        cipherbox_engine::seams::UnixMillis(0),
+    )
+    .expect("converts");
+
+    assert!(converted.newly_granted);
+    assert_eq!(
+        converted.row.ledger_entry.recipient_identity_pk,
+        claimant_identity.verifying_key().to_sec1(),
+    );
+    assert_eq!(converted.commitment.entries.len(), 2, "the link stays live");
+}
+
+#[test]
+fn a_claim_signed_by_a_key_the_link_does_not_commit_never_becomes_a_grant() {
+    let hub = InMemoryMailboxHub::default();
+    let owner_address = owner_identity().verifying_key().to_sec1();
+    let owner_box = hub.mailbox_for(&owner_address);
+    let forger_box = hub.mailbox_for(b"forger-outbox");
+
+    let l = link(Permission::Read);
+    let stranger = EphemeralInvitee::from_secret(&[0x4f; 32]).expect("valid");
+    let claimant_identity = EcdsaSigner::from_scalar(&[0x63; 32]).expect("valid scalar");
+    let claimant_enc = X25519Secret::from_scalar([0x64; 32]);
+    let owner_contact = import_contact(&owner_contact_code()).expect("valid bundle");
+
+    block_on(post_invite_claim(
+        &forger_box,
+        &owner_contact,
+        &stranger,
+        &EPH_MAILBOX,
+        V,
+        &InviteClaim {
+            scope_root_name: scope_name(),
+            contact_code: ContactCode::create(&claimant_identity, claimant_enc.public()).encode(),
+        },
+        "forged-1",
+    ))
+    .expect("posts");
+
+    // The mailbox authenticates it — the forger signed honestly, just with a key
+    // the ledger does not commit — so the fail-closed reject is conversion's.
+    let items = block_on(poll_verified(&owner_box, &owner_enc(), V)).expect("polls");
+    assert_eq!(items.len(), 1);
+
+    let owner_id = owner_identity();
+    let owner_e = owner_enc();
+    assert_eq!(
+        convert_invite_claim(
+            &OwnerAuthority {
+                identity_signer: &owner_id,
+                enc_secret: &owner_e,
+            },
+            &CommittedScope {
+                scope_id: &SCOPE,
+                commitment: &l.commitment,
+                commitment_sig: &l.commitment_sig,
+                ledger: &l.ledger,
+            },
+            &items[0],
+            cipherbox_engine::seams::UnixMillis(0),
+        )
+        .unwrap_err()
+        .check(),
+        "link-not-committed",
+    );
+}
+
+#[test]
+fn the_transport_sees_no_claim_field_in_the_clear() {
+    let hub = InMemoryMailboxHub::default();
+    let owner_address = owner_identity().verifying_key().to_sec1();
+    let holder_box = hub.mailbox_for(b"holder-outbox");
+
+    let l = link(Permission::Read);
+    let claimant_identity = EcdsaSigner::from_scalar(&[0x65; 32]).expect("valid scalar");
+    let claimant_enc = X25519Secret::from_scalar([0x66; 32]);
+    let contact_code = ContactCode::create(&claimant_identity, claimant_enc.public()).encode();
+    let owner_contact = import_contact(&owner_contact_code()).expect("valid bundle");
+
+    block_on(post_invite_claim(
+        &holder_box,
+        &owner_contact,
+        &l.invitee,
+        &EPH_MAILBOX,
+        V,
+        &InviteClaim {
+            scope_root_name: scope_name(),
+            contact_code: contact_code.clone(),
+        },
+        "claim-1",
+    ))
+    .expect("posts");
+
+    let sealed = block_on(hub.mailbox_for(&owner_address).poll()).expect("polls")[0]
+        .sealed_payload
+        .clone();
+    for secret in [
+        contact_code.as_slice(),
+        &claimant_identity.verifying_key().to_sec1(),
+        scope_name().as_slice(),
+    ] {
+        assert!(
+            !sealed.windows(secret.len()).any(|w| w == secret),
+            "the transport must carry no claim field in the clear",
+        );
+    }
+}

--- a/crates/engine/tests/invite_claims.rs
+++ b/crates/engine/tests/invite_claims.rs
@@ -57,6 +57,39 @@ struct Link {
     invitee: EphemeralInvitee,
 }
 
+impl Link {
+    fn scope(&self) -> CommittedScope<'_> {
+        CommittedScope {
+            scope_id: &SCOPE,
+            commitment: &self.commitment,
+            commitment_sig: &self.commitment_sig,
+            ledger: &self.ledger,
+        }
+    }
+}
+
+/// The owner's two halves, held so an `OwnerAuthority` can borrow them.
+struct Owner {
+    identity: EcdsaSigner,
+    enc: X25519Secret,
+}
+
+impl Owner {
+    fn new() -> Self {
+        Self {
+            identity: owner_identity(),
+            enc: owner_enc(),
+        }
+    }
+
+    fn authority(&self) -> OwnerAuthority<'_> {
+        OwnerAuthority {
+            identity_signer: &self.identity,
+            enc_secret: &self.enc,
+        }
+    }
+}
+
 fn link(permission: Permission) -> Link {
     let invitee = EphemeralInvitee::from_secret(&[0x4e; 32]).expect("valid");
     let minted = mint_invite_grant(
@@ -119,19 +152,10 @@ fn a_link_holder_claims_over_the_mailbox_and_the_owner_converts_it() {
         "the claim authenticates as the link's ephemeral identity",
     );
 
-    let owner_id = owner_identity();
-    let owner_e = owner_enc();
+    let keys = Owner::new();
     let converted = convert_invite_claim(
-        &OwnerAuthority {
-            identity_signer: &owner_id,
-            enc_secret: &owner_e,
-        },
-        &CommittedScope {
-            scope_id: &SCOPE,
-            commitment: &l.commitment,
-            commitment_sig: &l.commitment_sig,
-            ledger: &l.ledger,
-        },
+        &keys.authority(),
+        &l.scope(),
         &items[0],
         cipherbox_engine::seams::UnixMillis(0),
     )
@@ -177,20 +201,11 @@ fn a_claim_signed_by_a_key_the_link_does_not_commit_never_becomes_a_grant() {
     let items = block_on(poll_verified(&owner_box, &owner_enc(), V)).expect("polls");
     assert_eq!(items.len(), 1);
 
-    let owner_id = owner_identity();
-    let owner_e = owner_enc();
+    let keys = Owner::new();
     assert_eq!(
         convert_invite_claim(
-            &OwnerAuthority {
-                identity_signer: &owner_id,
-                enc_secret: &owner_e,
-            },
-            &CommittedScope {
-                scope_id: &SCOPE,
-                commitment: &l.commitment,
-                commitment_sig: &l.commitment_sig,
-                ledger: &l.ledger,
-            },
+            &keys.authority(),
+            &l.scope(),
             &items[0],
             cipherbox_engine::seams::UnixMillis(0),
         )


### PR DESCRIPTION
## What

Completes the invite slice. The ephemeral-key grant blob (`EphemeralInvitee`, `mint_invite_grant`) and the ledger expiry field already landed, so this PR is the remainder: claim-to-grant conversion, expiry enforcement, and bearer write-link flagging.

### Claim-to-grant conversion

- `InviteClaim` is the mailbox payload the grants layer frames — `{scopeRootName, contactCode}`, det-CBOR, opaque application bytes inside the seal.
- `post_invite_claim` seals it to the owner's encryption subkey and signs it, **as the mailbox sender**, with the link's ephemeral identity key. That is the blueprint's "sealed, ephemeral-key-signed mailbox request" verbatim: `open_mailbox_payload` verifies the inner sender signature fail-closed, and `poll_verified` drops anything that does not.
- `convert_invite_claim` binds that verified sender to a `RecordedInvite` — **owner-local state minted alongside the row** — imports the claimant's contact code fail-closed, and mints a personal grant through the same `mint_grant_row` every contact grant uses.
- The converted grant anchors to the **claimant's contact-anchored identity**, never the ephemeral half. A claim handing back the link's own self-signed contact code, or the owner's own bundle from the invite URL, is refused.
- Multi-claim: the link's commitment entry and ledger row survive conversion, so one link yields a grant per claimant until it expires or is revoked.
- Permission comes from the **owner-signed commitment entry**, never the write-grantee-mutable ledger row. A claimant who already holds a read grant and claims a write link is **upgraded** on both surfaces; a claim never lowers a committed permission, and `ConvertedClaim.row` can never contradict `ConvertedClaim.commitment`. `ClaimOutcome` reports which of the three happened.

### Why claimability comes from owner-local state

Both review gates independently found the same HIGH against the first draft, which located the link by scanning the resolved ledger for a row whose `recipientIdentityPk` matched the mailbox sender.

Nothing in a published record marks a row as an invite — that byte-shape parity is the design — and the fields that could say so sit **outside** the owner's signature (`enforce_committed_ledger` compares `(tag, permission)` only). So any committed grantee could post an honestly-signed claim naming a sockpuppet contact and have its own row convert, and a write-grantee could reach the same sink by re-authoring `recipientIdentityPk` on someone else's row. Either way the owner signs a grant for an identity it never approved, and that grant survives the rotation that revokes the attacker's own tag — a revocation-completeness break, not merely a re-share.

`RecordedInvite` fixes it at the root: conversion and revocation decide **what may be claimed** from the owner's own record and never from the record they act on. `revoke_invite_link` likewise cuts only a recorded link, so a mis-plumbed tag cannot silently revoke a personal grantee.

### Expiry

The owner's recorded deadline is the authority. The published `expiresAt` is honoured as well — an expired row is inert here, before any prune reaches it — but only ever to shorten a link, because a write-grantee can re-author that field. Both directions are pinned at the exact deadline instant, including a stripped published deadline failing to extend a link.

### Bearer write-link flagging

`mint_invite_grant` returns `MintedInvite { row, link, capability }`. `LinkCapability::BearerWrite` says the link hands out an extractable subtree signing key. `revoke_invite_link` reports `is_complete() == false` for a write link: the fragment holder keeps that key until `rotate_scope_write` runs, so a host can never read a ledger prune as a revocation.

### Fail-closed encode/decode symmetry

`check_publishable` is the produce-side mirror of what a resolver hard-rejects — the `MAX_GRANT_BLOBS` ceiling and duplicate tags (core rejects both at decode and inside `sign_grant_set`) and a ledger diverging from the commitment (the adoption gate's owner-authority check). It returns `Err`, release-active, and every arm is covered by a test that fires in a release build. The ceiling matters here specifically: a bearer link is multi-claim and contact codes are free to mint, so without it a link could walk a scope's grant set to the point where nothing can be signed.

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` all ran on `git diff main...HEAD`. Folded in: the HIGH above; the `MAX_GRANT_BLOBS` symmetry gap; the silent permission-upgrade drop; the owner-contact-as-claimant case; ambiguous-lookup refusal instead of first-match; `CommittedScope` must be the adopted record's set; `OwnerAuthority::identity_signer` documented as a capability token rather than a signing key; the claim replay contract; the claimant-to-owner linkage the transport learns; `InviteClaim`'s app-framing decode policy; distinct HPKE ephemeral scalars in the fixtures. `live_entry` was dropped — it had no consumer.

Filed rather than fixed here, both with a dependency edge on this issue:

- \#1127 — `reseal_scope_root` seals to `recipientEncPk` straight from the ledger with no tag re-derivation, so a write-grantee swapping that field redirects every future honest re-seal. Out of this PR's file ownership and strictly more severe than anything in the diff.
- \#1128 — an invite claim has no freshness, so a server-retained item redelivered after the owner cut the converted grant reads as a fresh claim. Needs a durable owner-side store this slice does not own; the caller contract is documented on `convert_invite_claim` meanwhile.

## Deliberately out of scope

- The rotation this drives. `revoke_invite_link` returns the cut plus the requirement; wiring `rotate_scope`/`rotate_scope_write` behind it belongs to the rotation slice, and `crates/engine/src/rotation/` and `grants/create.rs` are untouched.
- The discovered-link-expiry trigger, which consumes `entry_is_live` in its own slice.
- The facade `CreateInviteLink` / claim command arms.
- The `expiresAt`-outside-the-commitment residual raised on the part-(a) crypto review stands, still pinned by `a_write_grantee_may_strip_a_deadline_without_failing_owner_authority`. This PR adds no unattended prune, so the induced-revocation direction stays shut: nothing here re-signs a commitment because a deadline passed, and the owner's own recorded deadline is what gates a claim.

## Gate

`Engine Tests` (`cargo test -p cipherbox-engine`) — the unit suite in `grants::invite` plus a new `crates/engine/tests/invite_claims.rs` running the claim over the real mailbox seam. New coverage:

- two independent claimants each convert to their own personal grant; the link stays live
- a converted grant is anchored to the claimant's contact, not the ephemeral half
- only a link the owner recorded can be claimed — an ordinary grantee's row cannot, nor can a ledger row a write-grantee retargeted at an ephemeral identity
- a claim signed by a key the owner never recorded is refused fail-closed, as is one against a link cut from the committed set
- expiry at the exact deadline instant, from the owner's record and from the published row, with nothing pruned
- a non-owner can neither convert nor revoke; nor can the owner identity paired with a foreign encryption subkey
- a write link is flagged bearer and its ledger cut alone reports as not-yet-revoked
- upgrade, no-op and never-lower claim outcomes
- malformed claims and broken contact bindings
- the produce-side ceiling, duplicate-tag and divergence rejects
- the transport carries no claim field in the clear

## Gates run

| Command | Exit |
| --- | --- |
| `cargo fmt --all --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace` | 0 |
| `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` | 0 |
| `node scripts/check-tracker-refs.mjs` | 0 |

Closes #1015


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Convert invite claims into personal grants in the grants module
> - Adds `convert_invite_claim` to convert mailbox-delivered invite claims into personal `GrantRow` entries, enforcing expiry, owner authority, claimant identity, and upgrade semantics (read→write).
> - Adds `post_invite_claim` so invitees can post sealed, ephemeral-signed claims to the owner's mailbox via the `Mailbox` seam.
> - Adds `revoke_invite_link` to remove a link from the committed set, returning `InviteRevocation` which signals whether additional write-key rotation is needed.
> - Changes `mint_invite_grant` return type from `GrantRow` to `MintedInvite`, which bundles the network row with owner-local `RecordedInvite` metadata and a `LinkCapability` classification.
> - Adds `check_publishable` to enforce capacity (`MAX_GRANT_BLOBS`), tag uniqueness, and ledger authority before any set is published.
> - Risk: `mint_invite_grant` callers must update to access the grant row via `MintedInvite.row`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 576dedf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure bearer-link invites with capability classification and owner-controlled lifecycle management.
  * Invitees can claim links and convert them into personal, contact-anchored grants.
  * Added invite expiry, revocation, authorization, duplicate detection, and validation.
  * Added secure claim delivery through the mailbox flow.

* **Bug Fixes**
  * Invalid, unauthorized, expired, malformed, or oversized claims now fail safely.

* **Tests**
  * Added end-to-end coverage for successful claims, authorization failures, expiry, revocation, and protected transport contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->