### PR TITLE
feat: add the vault browser selection model and bound the session check

### DIFF
--- a/apps/web/src/auth/CoreKitProvider.tsx
+++ b/apps/web/src/auth/CoreKitProvider.tsx
@@ -2,16 +2,10 @@ import { createContext, useContext, useEffect, useRef, useState, type ReactNode 
 import { errorMessage } from '../lib/errorMessage';
 import type { CoreKitSession } from './coreKit';
 
-/**
- * Whether this tab knows if it has a session. `unavailable` is a verdict, not a
- * stage on the way to `ready`: a route gating on it has its answer.
- */
+/** Whether this tab knows if it has a session. */
 export type CoreKitStatus = 'checking' | 'ready' | 'unavailable';
 
-/**
- * How long the mount-time restore may run before the tab calls Core Kit
- * unreachable. Generous, so a slow-but-working restore still lands `ready`.
- */
+/** Generous, so a slow-but-working restore still lands `ready`. */
 const RESTORE_DEADLINE_MS = 10_000;
 
 const UNREACHABLE = 'the login provider is not responding — check your connection and reload';
@@ -59,8 +53,7 @@ export function CoreKitProvider({ createSession, children }: CoreKitProviderProp
     }
 
     // A restore that never settles would hold every route gating on this at
-    // `checking` forever; the deadline turns that silence into a verdict, and a
-    // restore that lands late still promotes the tab back to `ready`.
+    // `checking` forever, so silence past the deadline is a verdict.
     const deadline = setTimeout(() => {
       if (live) setValue({ session: null, status: 'unavailable', error: UNREACHABLE });
     }, RESTORE_DEADLINE_MS);

--- a/apps/web/src/auth/CoreKitProvider.tsx
+++ b/apps/web/src/auth/CoreKitProvider.tsx
@@ -2,12 +2,25 @@ import { createContext, useContext, useEffect, useRef, useState, type ReactNode 
 import { errorMessage } from '../lib/errorMessage';
 import type { CoreKitSession } from './coreKit';
 
+/**
+ * Whether this tab knows if it has a session. `unavailable` is a verdict, not a
+ * stage on the way to `ready`: a route gating on it has its answer.
+ */
+export type CoreKitStatus = 'checking' | 'ready' | 'unavailable';
+
+/**
+ * How long the mount-time restore may run before the tab calls Core Kit
+ * unreachable. Generous, so a slow-but-working restore still lands `ready`.
+ */
+const RESTORE_DEADLINE_MS = 10_000;
+
+const UNREACHABLE = 'the login provider is not responding — check your connection and reload';
+
 export interface CoreKitContextValue {
   /** `null` until the session is built and its restore attempt has settled. */
   session: CoreKitSession | null;
-  /** True while the mount-time session restore is still in flight. */
-  isRestoring: boolean;
-  /** Why Core Kit is unusable at all — a missing or rejected build config. */
+  status: CoreKitStatus;
+  /** Why Core Kit is unusable at all — a bad build config, or silence. */
   error: string | null;
 }
 
@@ -28,7 +41,7 @@ export interface CoreKitProviderProps {
 export function CoreKitProvider({ createSession, children }: CoreKitProviderProps) {
   const [value, setValue] = useState<CoreKitContextValue>({
     session: null,
-    isRestoring: true,
+    status: 'checking',
     error: null,
   });
   const factory = useRef(createSession);
@@ -41,20 +54,33 @@ export function CoreKitProvider({ createSession, children }: CoreKitProviderProp
       session.current ??= factory.current();
       restore.current ??= session.current.restore();
     } catch (error) {
-      setValue({ session: null, isRestoring: false, error: errorMessage(error) });
+      setValue({ session: null, status: 'unavailable', error: errorMessage(error) });
       return;
     }
 
-    const settled = { session: session.current, isRestoring: false, error: null };
+    // A restore that never settles would hold every route gating on this at
+    // `checking` forever; the deadline turns that silence into a verdict, and a
+    // restore that lands late still promotes the tab back to `ready`.
+    const deadline = setTimeout(() => {
+      if (live) setValue({ session: null, status: 'unavailable', error: UNREACHABLE });
+    }, RESTORE_DEADLINE_MS);
+
+    const settled: CoreKitContextValue = {
+      session: session.current,
+      status: 'ready',
+      error: null,
+    };
     // A failed restore just means there is no session to resume; the methods
     // below still work, and a real breakage surfaces when one is used.
-    restore.current.then(
-      () => live && setValue(settled),
-      () => live && setValue(settled)
-    );
+    const settle = () => {
+      clearTimeout(deadline);
+      if (live) setValue(settled);
+    };
+    restore.current.then(settle, settle);
 
     return () => {
       live = false;
+      clearTimeout(deadline);
     };
   }, []);
 

--- a/apps/web/src/auth/useAuth.ts
+++ b/apps/web/src/auth/useAuth.ts
@@ -19,8 +19,7 @@ export interface Auth {
   isReady: boolean;
   /**
    * True once the tab knows it has no session — the check settled signed out,
-   * or Core Kit could never answer it. Gating a route on `isReady` alone hangs
-   * that tab forever on an answer that is not coming.
+   * or Core Kit could never answer it.
    */
   isSignedOut: boolean;
   /** True while a restore, login, or logout is in flight. */

--- a/apps/web/src/auth/useAuth.ts
+++ b/apps/web/src/auth/useAuth.ts
@@ -17,6 +17,12 @@ export interface Auth {
   isAuthenticated: boolean;
   /** True while the tab is still assembling its engine or Core Kit session. */
   isReady: boolean;
+  /**
+   * True once the tab knows it has no session — the check settled signed out,
+   * or Core Kit could never answer it. Gating a route on `isReady` alone hangs
+   * that tab forever on an answer that is not coming.
+   */
+  isSignedOut: boolean;
   /** True while a restore, login, or logout is in flight. */
   isBusy: boolean;
   /** The last failure, already stripped of anything secret-shaped. */
@@ -42,13 +48,14 @@ export function useAuth(): Auth {
   const client = useEngine();
   const secrets = useLoginSecretSource();
   const rebuildEngine = useRebuildEngine();
-  const { session, isRestoring, error: coreKitError } = useCoreKit();
+  const { session, status, error: coreKitError } = useCoreKit();
   const { isAuthenticated } = useAuthState();
 
   const [isBusy, setIsBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const isReady = client !== null && session !== null && !isRestoring;
+  const isReady = client !== null && session !== null && status === 'ready';
+  const isSignedOut = !isAuthenticated && (isReady || status === 'unavailable');
 
   /** Serializes the auth transitions; a collision rejects rather than no-ops. */
   const exclusively = useCallback(async (step: () => Promise<void>): Promise<void> => {
@@ -153,6 +160,7 @@ export function useAuth(): Auth {
   return {
     isAuthenticated,
     isReady,
+    isSignedOut,
     isBusy,
     error: error ?? coreKitError,
     loginWithGoogle,

--- a/apps/web/src/components/file-browser/ConfirmDeleteDialog.tsx
+++ b/apps/web/src/components/file-browser/ConfirmDeleteDialog.tsx
@@ -3,7 +3,7 @@ import { describeRows } from '../../vault/selection';
 import { Modal } from '../ui/Modal';
 
 interface ConfirmDeleteDialogProps {
-  /** What the delete will retire; each row becomes a command of its own. */
+  /** The rows the delete will retire, named as one or counted as many. */
   rows: ListingRow[];
   onClose: () => void;
   onConfirm: () => void;
@@ -20,17 +20,16 @@ export function ConfirmDeleteDialog({
   error,
 }: ConfirmDeleteDialogProps) {
   const what = describeRows(rows);
-  // A single row is named, so it is quoted; a count is not a name.
-  const single = rows.length === 1;
-  const target = single ? `"${what}"` : what;
-  const inside = rows.some((row) => row.kind === 'folder')
-    ? ` and everything inside${single ? ' it' : ''}`
-    : '';
+  const recursive = rows.some((row) => row.kind === 'folder');
+  const message =
+    rows.length === 1
+      ? `delete "${what}"${recursive ? ' and everything inside it' : ''}?`
+      : `delete ${what}${recursive ? ' and everything inside' : ''}?`;
 
   return (
     <Modal onClose={onClose} title={`delete ${what}`} error={error} busy={busy}>
       <div className="dialog-content" data-testid="delete-dialog">
-        <p className="dialog-message">{`delete ${target}${inside}?`}</p>
+        <p className="dialog-message">{message}</p>
         <div className="dialog-actions">
           <button type="button" className="dialog-button" onClick={onClose} disabled={busy}>
             cancel

--- a/apps/web/src/components/file-browser/ConfirmDeleteDialog.tsx
+++ b/apps/web/src/components/file-browser/ConfirmDeleteDialog.tsx
@@ -1,8 +1,10 @@
 import type { ListingRow } from '../../vault/listing';
+import { describeRows } from '../../vault/selection';
 import { Modal } from '../ui/Modal';
 
 interface ConfirmDeleteDialogProps {
-  row: ListingRow;
+  /** What the delete will retire; each row becomes a command of its own. */
+  rows: ListingRow[];
   onClose: () => void;
   onConfirm: () => void;
   busy: boolean;
@@ -11,20 +13,24 @@ interface ConfirmDeleteDialogProps {
 }
 
 export function ConfirmDeleteDialog({
-  row,
+  rows,
   onClose,
   onConfirm,
   busy,
   error,
 }: ConfirmDeleteDialogProps) {
+  const what = describeRows(rows);
+  // A single row is named, so it is quoted; a count is not a name.
+  const single = rows.length === 1;
+  const target = single ? `"${what}"` : what;
+  const inside = rows.some((row) => row.kind === 'folder')
+    ? ` and everything inside${single ? ' it' : ''}`
+    : '';
+
   return (
-    <Modal onClose={onClose} title={`delete ${row.name}`} error={error} busy={busy}>
+    <Modal onClose={onClose} title={`delete ${what}`} error={error} busy={busy}>
       <div className="dialog-content" data-testid="delete-dialog">
-        <p className="dialog-message">
-          {row.kind === 'folder'
-            ? `delete "${row.name}" and everything inside it?`
-            : `delete "${row.name}"?`}
-        </p>
+        <p className="dialog-message">{`delete ${target}${inside}?`}</p>
         <div className="dialog-actions">
           <button type="button" className="dialog-button" onClick={onClose} disabled={busy}>
             cancel

--- a/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
@@ -455,6 +455,73 @@ describe('the vault browser selection', () => {
     expect(engine.facade.download.mock.calls).toEqual([[NOTE], [PICTURE]]);
   });
 
+  it('runs one batch download at a time, however often the button is clicked', async () => {
+    const pending: ((bytes: ArrayBuffer) => void)[] = [];
+    const engine = fakeEngine(() => new Promise<ArrayBuffer>((resolve) => pending.push(resolve)));
+    renderBrowser(engine);
+    await landSnapshot(
+      engine,
+      folderView({ children: [file(NOTE, 'notes.txt'), file(PICTURE, 'shot.png')] })
+    );
+
+    fireEvent.click(screen.getByTestId('select-all'));
+    fireEvent.click(screen.getByTestId('selection-download'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // A second loop would hand the user a duplicate of every file, and would
+    // let a move or delete land between two reads of the same batch.
+    const bar = screen.getByTestId('selection-action-bar');
+    for (const action of ['download', 'move', 'delete']) {
+      expect((screen.getByTestId(`selection-${action}`) as HTMLButtonElement).disabled).toBe(true);
+    }
+    fireEvent.click(screen.getByTestId('selection-download'));
+    expect(engine.facade.download.mock.calls).toEqual([[NOTE]]);
+    expect(bar).toBeDefined();
+
+    await act(async () => {
+      pending[0](new ArrayBuffer(0));
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(pending).toHaveLength(2));
+    await act(async () => {
+      pending[1](new ArrayBuffer(0));
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect((screen.getByTestId('selection-download') as HTMLButtonElement).disabled).toBe(false)
+    );
+    expect(engine.facade.download.mock.calls).toEqual([[NOTE], [PICTURE]]);
+  });
+
+  it('retires only the nodes a partly refused batch was accepted for', async () => {
+    const engine = fakeEngine();
+    engine.facade.delete
+      .mockImplementationOnce(() => Promise.resolve())
+      .mockImplementationOnce(() => Promise.reject(new Error('the op queue is full')));
+    renderBrowser(engine);
+    await landSnapshot(engine, listing());
+
+    fireEvent.click(screen.getByTestId('select-all'));
+    fireEvent.click(screen.getByTestId('selection-delete'));
+    fireEvent.click(screen.getByTestId('delete-confirm'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('dialog-error').textContent).toBe('the op queue is full')
+    );
+    // The dialog stays up over what was refused only: retrying it must not
+    // journal a second delete for the node the engine already took.
+    expect(count()).toBe('notes.txt selected');
+    expect(screen.getByTestId('delete-dialog').textContent).toContain('"notes.txt"');
+
+    fireEvent.click(screen.getByTestId('delete-confirm'));
+    await waitFor(() => expect(engine.facade.delete.mock.calls).toEqual([[DOCS], [NOTE], [NOTE]]));
+    await waitFor(() => expect(screen.queryByTestId('delete-dialog')).toBeNull());
+    expect(screen.queryByTestId('selection-action-bar')).toBeNull();
+  });
+
   it('retires only the rows a command acted on, not the whole selection', async () => {
     const engine = fakeEngine();
     renderBrowser(engine);

--- a/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
@@ -248,7 +248,7 @@ describe('the vault browser write path', () => {
     const frames: { atHome: boolean; destination: string | null }[] = [];
 
     function Probe() {
-      const picker = useFolderPicker(DOCS, toHex(NOTE));
+      const picker = useFolderPicker(DOCS, new Set([toHex(NOTE)]));
       frames.push({
         atHome: picker.atHome,
         destination: picker.destination === null ? null : toHex(picker.destination),
@@ -361,6 +361,121 @@ describe('the vault browser write path', () => {
       await Promise.resolve();
     });
     await waitFor(() => expect(screen.queryByTestId('create-folder-dialog')).toBeNull());
+  });
+});
+
+describe('the vault browser selection', () => {
+  const select = (name: string) => fireEvent.click(screen.getByLabelText(`select ${name}`));
+  const count = () => screen.queryByTestId('selection-count')?.textContent ?? null;
+
+  it('counts the rows toggled on, and empties on clear', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, listing());
+
+    expect(screen.queryByTestId('selection-action-bar')).toBeNull();
+
+    select('notes.txt');
+    expect(count()).toBe('notes.txt selected');
+    select('documents');
+    expect(count()).toBe('1 file, 1 folder selected');
+    select('notes.txt');
+    expect(count()).toBe('documents selected');
+
+    fireEvent.click(screen.getByTestId('selection-clear'));
+    expect(screen.queryByTestId('selection-action-bar')).toBeNull();
+  });
+
+  it('takes the whole listing from the header, and gives it back', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, listing());
+
+    fireEvent.click(screen.getByTestId('select-all'));
+    expect(count()).toBe('1 file, 1 folder selected');
+
+    fireEvent.click(screen.getByTestId('select-all'));
+    expect(screen.queryByTestId('selection-action-bar')).toBeNull();
+  });
+
+  it('dispatches one delete per selected node', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, listing());
+
+    fireEvent.click(screen.getByTestId('select-all'));
+    fireEvent.click(screen.getByTestId('selection-delete'));
+    fireEvent.click(screen.getByTestId('delete-confirm'));
+
+    await waitFor(() => expect(engine.facade.delete).toHaveBeenCalledTimes(2));
+    expect(engine.facade.delete.mock.calls).toEqual([[DOCS], [NOTE]]);
+    await waitFor(() => expect(screen.queryByTestId('selection-action-bar')).toBeNull());
+  });
+
+  it('dispatches one relink per selected node, all to the picked destination', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(
+      engine,
+      folderView({ children: [file(NOTE, 'notes.txt'), file(PICTURE, 'shot.png')] })
+    );
+
+    fireEvent.click(screen.getByTestId('select-all'));
+    fireEvent.click(screen.getByTestId('selection-move'));
+    await settlePickerRead(engine, listing());
+
+    fireEvent.click(screen.getByTestId('move-dialog-folder'));
+    await settlePickerRead(
+      engine,
+      folderView({ folder: DOCS, folderName: 'documents', ancestors: [{ id: ROOT, name: '' }] })
+    );
+    fireEvent.click(screen.getByTestId('move-confirm'));
+
+    await waitFor(() => expect(engine.facade.relink).toHaveBeenCalledTimes(2));
+    expect(engine.facade.relink.mock.calls).toEqual([
+      [NOTE, DOCS],
+      [PICTURE, DOCS],
+    ]);
+  });
+
+  it('reads every selected file and leaves the folders alone', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(
+      engine,
+      folderView({
+        children: [folder(DOCS, 'documents'), file(NOTE, 'notes.txt'), file(PICTURE, 'shot.png')],
+      })
+    );
+
+    fireEvent.click(screen.getByTestId('select-all'));
+    fireEvent.click(screen.getByTestId('selection-download'));
+
+    await waitFor(() => expect(engine.facade.download).toHaveBeenCalledTimes(2));
+    expect(engine.facade.download.mock.calls).toEqual([[NOTE], [PICTURE]]);
+  });
+
+  it('starts over when the route moves to another folder', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, listing());
+
+    fireEvent.click(screen.getByTestId('select-all'));
+    expect(count()).toBe('1 file, 1 folder selected');
+
+    fireEvent.doubleClick(screen.getByText('documents'));
+    await landSnapshot(
+      engine,
+      folderView({
+        folder: DOCS,
+        folderName: 'documents',
+        children: [file(PICTURE, 'shot.png')],
+        ancestors: [{ id: ROOT, name: '' }],
+      })
+    );
+
+    expect(screen.getByText('shot.png')).toBeDefined();
+    expect(screen.queryByTestId('selection-action-bar')).toBeNull();
   });
 });
 

--- a/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
@@ -455,6 +455,21 @@ describe('the vault browser selection', () => {
     expect(engine.facade.download.mock.calls).toEqual([[NOTE], [PICTURE]]);
   });
 
+  it('retires only the rows a command acted on, not the whole selection', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, listing());
+
+    fireEvent.click(screen.getByTestId('select-all'));
+    // A command raised from one row's own menu is about that row, not the batch.
+    openRowMenu('notes.txt');
+    chooseMenuItem('delete');
+    fireEvent.click(screen.getByTestId('delete-confirm'));
+
+    await waitFor(() => expect(engine.facade.delete.mock.calls).toEqual([[NOTE]]));
+    await waitFor(() => expect(count()).toBe('documents selected'));
+  });
+
   it('starts over when the route moves to another folder', async () => {
     const engine = fakeEngine();
     renderBrowser(engine);

--- a/apps/web/src/components/file-browser/FileBrowserActions.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.tsx
@@ -10,6 +10,7 @@ import { useFileDownload } from '../../hooks/useFileDownload';
 import { useVaultActions } from '../../hooks/useVaultActions';
 import type { ListingRow } from '../../vault/listing';
 import { previewKind } from '../../vault/previewKind';
+import { useSelection } from '../../vault/selection';
 import { ConfirmDeleteDialog } from './ConfirmDeleteDialog';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 import { DetailsDialog } from './DetailsDialog';
@@ -17,11 +18,16 @@ import { FileList } from './FileList';
 import { FilePreviewDialog } from './FilePreviewDialog';
 import { MoveDialog } from './MoveDialog';
 import { NamePromptDialog } from './NamePromptDialog';
+import { SelectionActionBar } from './SelectionActionBar';
 import { TextEditorDialog } from './TextEditorDialog';
 
 type Dialog =
   | { kind: 'create' }
-  | { kind: 'rename' | 'move' | 'delete' | 'details' | 'preview' | 'edit'; row: ListingRow };
+  | { kind: 'rename' | 'details' | 'preview' | 'edit'; row: ListingRow }
+  // Batch and single-row commands are the same dialog over a different count.
+  | { kind: 'move' | 'delete'; rows: ListingRow[] };
+
+const toNodeId = (row: ListingRow): Uint8Array => row.id;
 
 interface FileBrowserActionsProps {
   rows: ListingRow[];
@@ -43,6 +49,7 @@ export function FileBrowserActions({
   const menu = useContextMenu();
   const actions = useVaultActions();
   const downloads = useFileDownload();
+  const selection = useSelection(rows, folder);
   const failure = actions.error ?? downloads.error;
 
   const close = () => setDialog(null);
@@ -50,11 +57,19 @@ export function FileBrowserActions({
    * A dispatch the engine accepted closes its dialog; a rejected one stays up.
    * The banner reports one failure, so a dispatch also retires the last read's.
    */
-  const closeOnSuccess = (dispatched: Promise<boolean>) => {
+  const closeOnSuccess = (dispatched: Promise<boolean>, andThen?: () => void) => {
     downloads.clearError();
     void dispatched.then((accepted) => {
-      if (accepted) close();
+      if (!accepted) return;
+      close();
+      andThen?.();
     });
+  };
+
+  const downloadSelection = async (): Promise<void> => {
+    for (const row of selection.rows) {
+      if (row.kind === 'file') await downloads.save(row.id, row.name, row.bytes);
+    }
   };
 
   const menuItems = (row: ListingRow): ContextMenuItem[] => {
@@ -74,12 +89,12 @@ export function FileBrowserActions({
     }
     items.push(
       { label: 'rename', onSelect: () => setDialog({ kind: 'rename', row }) },
-      { label: 'move to...', onSelect: () => setDialog({ kind: 'move', row }) },
+      { label: 'move to...', onSelect: () => setDialog({ kind: 'move', rows: [row] }) },
       { label: 'details', onSelect: () => setDialog({ kind: 'details', row }) },
       {
         label: 'delete',
         destructive: true,
-        onSelect: () => setDialog({ kind: 'delete', row }),
+        onSelect: () => setDialog({ kind: 'delete', rows: [row] }),
       }
     );
     return items;
@@ -98,6 +113,14 @@ export function FileBrowserActions({
           [+ NEW FOLDER]
         </button>
       </div>
+      <SelectionActionBar
+        rows={selection.rows}
+        busy={actions.busy !== null}
+        onClear={selection.clear}
+        onDownload={() => void downloadSelection()}
+        onMove={() => setDialog({ kind: 'move', rows: selection.rows })}
+        onDelete={() => setDialog({ kind: 'delete', rows: selection.rows })}
+      />
       {failure !== null && (
         <p className="file-browser-error" role="alert" data-testid="vault-action-error">
           {failure}
@@ -108,6 +131,7 @@ export function FileBrowserActions({
       {(rows.length > 0 || showParentRow) && (
         <FileList
           rows={rows}
+          selection={selection}
           showParentRow={showParentRow}
           onOpen={onOpen}
           onNavigateUp={onNavigateUp}
@@ -155,21 +179,25 @@ export function FileBrowserActions({
       )}
       {dialog?.kind === 'move' && (
         <MoveDialog
-          row={dialog.row}
+          rows={dialog.rows}
           parent={folder}
           onClose={close}
           busy={actions.busy === 'relink'}
           error={actions.error}
-          onConfirm={(newParent) => closeOnSuccess(actions.move(dialog.row.id, newParent))}
+          onConfirm={(newParent) =>
+            closeOnSuccess(actions.move(dialog.rows.map(toNodeId), newParent), selection.clear)
+          }
         />
       )}
       {dialog?.kind === 'delete' && (
         <ConfirmDeleteDialog
-          row={dialog.row}
+          rows={dialog.rows}
           onClose={close}
           busy={actions.busy === 'delete'}
           error={actions.error}
-          onConfirm={() => closeOnSuccess(actions.remove(dialog.row.id))}
+          onConfirm={() =>
+            closeOnSuccess(actions.remove(dialog.rows.map(toNodeId)), selection.clear)
+          }
         />
       )}
       {dialog?.kind === 'details' && <DetailsDialog row={dialog.row} onClose={close} />}

--- a/apps/web/src/components/file-browser/FileBrowserActions.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.tsx
@@ -24,10 +24,7 @@ import { TextEditorDialog } from './TextEditorDialog';
 type Dialog =
   | { kind: 'create' }
   | { kind: 'rename' | 'details' | 'preview' | 'edit'; row: ListingRow }
-  // Batch and single-row commands are the same dialog over a different count.
   | { kind: 'move' | 'delete'; rows: ListingRow[] };
-
-const toNodeId = (row: ListingRow): Uint8Array => row.id;
 
 interface FileBrowserActionsProps {
   rows: ListingRow[];
@@ -54,15 +51,16 @@ export function FileBrowserActions({
 
   const close = () => setDialog(null);
   /**
-   * A dispatch the engine accepted closes its dialog; a rejected one stays up.
-   * The banner reports one failure, so a dispatch also retires the last read's.
+   * A dispatch the engine accepted closes its dialog and retires the rows it
+   * acted on; a rejected one stays up. The banner reports one failure, so a
+   * dispatch also retires the last read's.
    */
-  const closeOnSuccess = (dispatched: Promise<boolean>, andThen?: () => void) => {
+  const closeOnSuccess = (dispatched: Promise<boolean>, acted: ListingRow[] = []) => {
     downloads.clearError();
     void dispatched.then((accepted) => {
       if (!accepted) return;
       close();
-      andThen?.();
+      selection.drop(acted.map((row) => row.key));
     });
   };
 
@@ -185,7 +183,13 @@ export function FileBrowserActions({
           busy={actions.busy === 'relink'}
           error={actions.error}
           onConfirm={(newParent) =>
-            closeOnSuccess(actions.move(dialog.rows.map(toNodeId), newParent), selection.clear)
+            closeOnSuccess(
+              actions.move(
+                dialog.rows.map((row) => row.id),
+                newParent
+              ),
+              dialog.rows
+            )
           }
         />
       )}
@@ -196,7 +200,7 @@ export function FileBrowserActions({
           busy={actions.busy === 'delete'}
           error={actions.error}
           onConfirm={() =>
-            closeOnSuccess(actions.remove(dialog.rows.map(toNodeId)), selection.clear)
+            closeOnSuccess(actions.remove(dialog.rows.map((row) => row.id)), dialog.rows)
           }
         />
       )}

--- a/apps/web/src/components/file-browser/FileBrowserActions.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.tsx
@@ -5,9 +5,10 @@
  */
 
 import { useState } from 'react';
+import { toHex } from '@cipherbox/client';
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useFileDownload } from '../../hooks/useFileDownload';
-import { useVaultActions } from '../../hooks/useVaultActions';
+import { useVaultActions, type BatchOutcome } from '../../hooks/useVaultActions';
 import type { ListingRow } from '../../vault/listing';
 import { previewKind } from '../../vault/previewKind';
 import { useSelection } from '../../vault/selection';
@@ -43,6 +44,7 @@ export function FileBrowserActions({
   onNavigateUp,
 }: FileBrowserActionsProps) {
   const [dialog, setDialog] = useState<Dialog | null>(null);
+  const [downloading, setDownloading] = useState(false);
   const menu = useContextMenu();
   const actions = useVaultActions();
   const downloads = useFileDownload();
@@ -51,22 +53,46 @@ export function FileBrowserActions({
 
   const close = () => setDialog(null);
   /**
-   * A dispatch the engine accepted closes its dialog and retires the rows it
-   * acted on; a rejected one stays up. The banner reports one failure, so a
-   * dispatch also retires the last read's.
+   * A dispatch the engine accepted closes its dialog; a refused one stays up.
+   * The banner reports one failure, so a dispatch also retires the last read's.
    */
-  const closeOnSuccess = (dispatched: Promise<boolean>, acted: ListingRow[] = []) => {
+  const closeOnSuccess = (dispatched: Promise<boolean>) => {
     downloads.clearError();
     void dispatched.then((accepted) => {
-      if (!accepted) return;
-      close();
-      selection.drop(acted.map((row) => row.key));
+      if (accepted) close();
+    });
+  };
+
+  /**
+   * A batch retires only what the engine took, from both the selection and the
+   * dialog: a retry must not re-dispatch an accepted node, which the engine
+   * would journal a second time and dead-letter.
+   */
+  const closeOnBatch = (dispatched: Promise<BatchOutcome>) => {
+    downloads.clearError();
+    void dispatched.then((outcome) => {
+      const retired = outcome.accepted.map(toHex);
+      selection.drop(retired);
+      if (outcome.ok) {
+        close();
+        return;
+      }
+      setDialog((current) => {
+        if (current?.kind !== 'move' && current?.kind !== 'delete') return current;
+        const gone = new Set(retired);
+        return { ...current, rows: current.rows.filter((row) => !gone.has(row.key)) };
+      });
     });
   };
 
   const downloadSelection = async (): Promise<void> => {
-    for (const row of selection.rows) {
-      if (row.kind === 'file') await downloads.save(row.id, row.name, row.bytes);
+    setDownloading(true);
+    try {
+      for (const row of selection.rows) {
+        if (row.kind === 'file') await downloads.save(row.id, row.name, row.bytes);
+      }
+    } finally {
+      setDownloading(false);
     }
   };
 
@@ -113,7 +139,7 @@ export function FileBrowserActions({
       </div>
       <SelectionActionBar
         rows={selection.rows}
-        busy={actions.busy !== null}
+        busy={actions.busy !== null || downloading}
         onClear={selection.clear}
         onDownload={() => void downloadSelection()}
         onMove={() => setDialog({ kind: 'move', rows: selection.rows })}
@@ -183,12 +209,11 @@ export function FileBrowserActions({
           busy={actions.busy === 'relink'}
           error={actions.error}
           onConfirm={(newParent) =>
-            closeOnSuccess(
+            closeOnBatch(
               actions.move(
                 dialog.rows.map((row) => row.id),
                 newParent
-              ),
-              dialog.rows
+              )
             )
           }
         />
@@ -199,9 +224,7 @@ export function FileBrowserActions({
           onClose={close}
           busy={actions.busy === 'delete'}
           error={actions.error}
-          onConfirm={() =>
-            closeOnSuccess(actions.remove(dialog.rows.map((row) => row.id)), dialog.rows)
-          }
+          onConfirm={() => closeOnBatch(actions.remove(dialog.rows.map((row) => row.id)))}
         />
       )}
       {dialog?.kind === 'details' && <DetailsDialog row={dialog.row} onClose={close} />}

--- a/apps/web/src/components/file-browser/FileList.tsx
+++ b/apps/web/src/components/file-browser/FileList.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import type { ListingRow } from '../../vault/listing';
 import type { Selection } from '../../vault/selection';
 import { FileListItem } from './FileListItem';
@@ -23,6 +24,13 @@ export function FileList({
   onRowMenu,
 }: FileListProps) {
   const partial = selection.rows.length > 0 && !selection.allSelected;
+  // `indeterminate` is a DOM property with no attribute, so it is written here.
+  const markPartial = useCallback(
+    (node: HTMLInputElement | null) => {
+      if (node) node.indeterminate = partial;
+    },
+    [partial]
+  );
 
   return (
     <div className="file-list" role="grid" data-testid="file-list">
@@ -32,9 +40,7 @@ export function FileList({
             type="checkbox"
             className="file-list-select-all"
             checked={selection.allSelected}
-            ref={(node) => {
-              if (node) node.indeterminate = partial;
-            }}
+            ref={markPartial}
             disabled={rows.length === 0}
             aria-label="select all"
             data-testid="select-all"

--- a/apps/web/src/components/file-browser/FileList.tsx
+++ b/apps/web/src/components/file-browser/FileList.tsx
@@ -1,9 +1,11 @@
 import type { ListingRow } from '../../vault/listing';
+import type { Selection } from '../../vault/selection';
 import { FileListItem } from './FileListItem';
 import { ParentDirRow } from './ParentDirRow';
 
 interface FileListProps {
   rows: ListingRow[];
+  selection: Selection;
   /** False at the vault root, which has no parent to step up to. */
   showParentRow: boolean;
   onOpen: (node: Uint8Array) => void;
@@ -12,11 +14,32 @@ interface FileListProps {
 }
 
 /** The routed folder's direct children, in columns. */
-export function FileList({ rows, showParentRow, onOpen, onNavigateUp, onRowMenu }: FileListProps) {
+export function FileList({
+  rows,
+  selection,
+  showParentRow,
+  onOpen,
+  onNavigateUp,
+  onRowMenu,
+}: FileListProps) {
+  const partial = selection.rows.length > 0 && !selection.allSelected;
+
   return (
     <div className="file-list" role="grid" data-testid="file-list">
       <div className="file-list-header" role="row">
         <div className="file-list-header-name" role="columnheader">
+          <input
+            type="checkbox"
+            className="file-list-select-all"
+            checked={selection.allSelected}
+            ref={(node) => {
+              if (node) node.indeterminate = partial;
+            }}
+            disabled={rows.length === 0}
+            aria-label="select all"
+            data-testid="select-all"
+            onChange={selection.toggleAll}
+          />
           [NAME]
         </div>
         <div className="file-list-header-size" role="columnheader">
@@ -29,7 +52,14 @@ export function FileList({ rows, showParentRow, onOpen, onNavigateUp, onRowMenu 
       <div className="file-list-body" role="rowgroup">
         {showParentRow && <ParentDirRow onActivate={onNavigateUp} />}
         {rows.map((row) => (
-          <FileListItem key={row.key} row={row} onOpen={onOpen} onRowMenu={onRowMenu} />
+          <FileListItem
+            key={row.key}
+            row={row}
+            selected={selection.has(row.key)}
+            onToggle={selection.toggle}
+            onOpen={onOpen}
+            onRowMenu={onRowMenu}
+          />
         ))}
       </div>
     </div>

--- a/apps/web/src/components/file-browser/FileListItem.tsx
+++ b/apps/web/src/components/file-browser/FileListItem.tsx
@@ -2,6 +2,9 @@ import type { ListingRow } from '../../vault/listing';
 
 interface FileListItemProps {
   row: ListingRow;
+  selected: boolean;
+  /** Adds or drops this row from the batch selection. */
+  onToggle: (key: string) => void;
   /** Opens a folder. */
   onOpen: (node: Uint8Array) => void;
   /** Raises the row's action menu, anchored on the event that asked for it. */
@@ -9,7 +12,7 @@ interface FileListItemProps {
 }
 
 /** One direct child: kind marker, name, size, mtime, and its queue status. */
-export function FileListItem({ row, onOpen, onRowMenu }: FileListItemProps) {
+export function FileListItem({ row, selected, onToggle, onOpen, onRowMenu }: FileListItemProps) {
   const isFolder = row.kind === 'folder';
   const open = () => {
     if (isFolder) onOpen(row.id);
@@ -17,7 +20,7 @@ export function FileListItem({ row, onOpen, onRowMenu }: FileListItemProps) {
 
   return (
     <div
-      className="file-list-item"
+      className={`file-list-item${selected ? ' file-list-item--selected' : ''}`}
       data-node-id={row.key}
       data-testid="file-list-item"
       role="row"
@@ -34,6 +37,17 @@ export function FileListItem({ row, onOpen, onRowMenu }: FileListItemProps) {
       }}
     >
       <div className="file-list-item-row-top" role="gridcell">
+        {/* Its own click, not the row's: selecting must not also open. */}
+        <input
+          type="checkbox"
+          className="file-list-item-select"
+          checked={selected}
+          aria-label={`select ${row.name}`}
+          data-testid="file-list-item-select"
+          onClick={(event) => event.stopPropagation()}
+          onDoubleClick={(event) => event.stopPropagation()}
+          onChange={() => onToggle(row.key)}
+        />
         <span className="file-list-item-icon" aria-hidden="true">
           {row.icon}
         </span>

--- a/apps/web/src/components/file-browser/MoveDialog.tsx
+++ b/apps/web/src/components/file-browser/MoveDialog.tsx
@@ -1,10 +1,13 @@
+import { useMemo } from 'react';
 import { useFolderPicker } from '../../hooks/useFolderPicker';
 import type { ListingRow } from '../../vault/listing';
+import { describeRows } from '../../vault/selection';
 import { Modal } from '../ui/Modal';
 
 interface MoveDialogProps {
-  row: ListingRow;
-  /** The folder the row is in today; moving into it would be a no-op. */
+  /** What the move will relink; each row becomes a command of its own. */
+  rows: ListingRow[];
+  /** The folder the rows are in today; moving into it would be a no-op. */
   parent: Uint8Array | null;
   onClose: () => void;
   onConfirm: (newParent: Uint8Array) => void;
@@ -14,13 +17,14 @@ interface MoveDialogProps {
 }
 
 /** Picks a destination by walking the vault one folder at a time. */
-export function MoveDialog({ row, parent, onClose, onConfirm, busy, error }: MoveDialogProps) {
-  const picker = useFolderPicker(parent, row.key);
+export function MoveDialog({ rows, parent, onClose, onConfirm, busy, error }: MoveDialogProps) {
+  const excluded = useMemo(() => new Set(rows.map((row) => row.key)), [rows]);
+  const picker = useFolderPicker(parent, excluded);
   const destination = picker.destination;
   const canMove = !busy && destination !== null && !picker.atHome;
 
   return (
-    <Modal onClose={onClose} title={`move ${row.name}`} error={error} busy={busy}>
+    <Modal onClose={onClose} title={`move ${describeRows(rows)}`} error={error} busy={busy}>
       <div className="dialog-content" data-testid="move-dialog">
         <p className="dialog-label">
           {'destination: '}

--- a/apps/web/src/components/file-browser/MoveDialog.tsx
+++ b/apps/web/src/components/file-browser/MoveDialog.tsx
@@ -5,7 +5,7 @@ import { describeRows } from '../../vault/selection';
 import { Modal } from '../ui/Modal';
 
 interface MoveDialogProps {
-  /** What the move will relink; each row becomes a command of its own. */
+  /** The rows the move will relink, named as one or counted as many. */
   rows: ListingRow[];
   /** The folder the rows are in today; moving into it would be a no-op. */
   parent: Uint8Array | null;

--- a/apps/web/src/components/file-browser/ParentDirRow.tsx
+++ b/apps/web/src/components/file-browser/ParentDirRow.tsx
@@ -18,6 +18,8 @@ export function ParentDirRow({ onActivate }: ParentDirRowProps) {
       data-testid="parent-dir-row"
     >
       <div className="file-list-item-row-top" role="gridcell">
+        {/* Holds the selection column open: `[..]` is not a selectable row. */}
+        <span className="file-list-item-select-gap" aria-hidden="true" />
         <span className="file-list-item-icon" aria-hidden="true">
           [..]
         </span>

--- a/apps/web/src/components/file-browser/ParentDirRow.tsx
+++ b/apps/web/src/components/file-browser/ParentDirRow.tsx
@@ -18,7 +18,9 @@ export function ParentDirRow({ onActivate }: ParentDirRowProps) {
       data-testid="parent-dir-row"
     >
       <div className="file-list-item-row-top" role="gridcell">
-        {/* Holds the selection column open: `[..]` is not a selectable row. */}
+        {/* `[..]` is not selectable, so it holds the column open instead. A
+            flex item, not padding: it inherits the row's gap rather than
+            restating it. */}
         <span className="file-list-item-select-gap" aria-hidden="true" />
         <span className="file-list-item-icon" aria-hidden="true">
           [..]

--- a/apps/web/src/components/file-browser/SelectionActionBar.tsx
+++ b/apps/web/src/components/file-browser/SelectionActionBar.tsx
@@ -1,0 +1,79 @@
+import type { ListingRow } from '../../vault/listing';
+import { describeRows } from '../../vault/selection';
+
+interface SelectionActionBarProps {
+  /** The selected rows; the bar renders nothing for an empty selection. */
+  rows: ListingRow[];
+  /** True while a command is in flight, which disables every action. */
+  busy: boolean;
+  onClear: () => void;
+  onDownload: () => void;
+  onMove: () => void;
+  onDelete: () => void;
+}
+
+/** The batch commands, over whatever the listing has selected. */
+export function SelectionActionBar({
+  rows,
+  busy,
+  onClear,
+  onDownload,
+  onMove,
+  onDelete,
+}: SelectionActionBarProps) {
+  if (rows.length === 0) return null;
+  const files = rows.filter((row) => row.kind === 'file').length;
+
+  return (
+    <div
+      className="selection-action-bar"
+      role="toolbar"
+      aria-label="selection actions"
+      data-testid="selection-action-bar"
+    >
+      <span className="selection-action-bar-count" data-testid="selection-count">
+        {`${describeRows(rows)} selected`}
+      </span>
+      <div className="selection-action-bar-actions">
+        {files > 0 && (
+          <button
+            type="button"
+            className="file-browser-toolbar-button"
+            onClick={onDownload}
+            disabled={busy}
+            data-testid="selection-download"
+          >
+            [DOWNLOAD]
+          </button>
+        )}
+        <button
+          type="button"
+          className="file-browser-toolbar-button"
+          onClick={onMove}
+          disabled={busy}
+          data-testid="selection-move"
+        >
+          [MOVE]
+        </button>
+        <button
+          type="button"
+          className="file-browser-toolbar-button selection-action-bar-delete"
+          onClick={onDelete}
+          disabled={busy}
+          data-testid="selection-delete"
+        >
+          [DELETE]
+        </button>
+        <button
+          type="button"
+          className="selection-action-bar-clear"
+          onClick={onClear}
+          disabled={busy}
+          data-testid="selection-clear"
+        >
+          [clear]
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/file-browser/SelectionActionBar.tsx
+++ b/apps/web/src/components/file-browser/SelectionActionBar.tsx
@@ -22,7 +22,7 @@ export function SelectionActionBar({
   onDelete,
 }: SelectionActionBarProps) {
   if (rows.length === 0) return null;
-  const files = rows.filter((row) => row.kind === 'file').length;
+  const hasFiles = rows.some((row) => row.kind === 'file');
 
   return (
     <div
@@ -35,7 +35,7 @@ export function SelectionActionBar({
         {`${describeRows(rows)} selected`}
       </span>
       <div className="selection-action-bar-actions">
-        {files > 0 && (
+        {hasFiles && (
           <button
             type="button"
             className="file-browser-toolbar-button"

--- a/apps/web/src/hooks/useFolderPicker.test.tsx
+++ b/apps/web/src/hooks/useFolderPicker.test.tsx
@@ -9,7 +9,7 @@ const HOME = new Uint8Array(16).fill(1);
 const NEXT = new Uint8Array(16).fill(2);
 
 function Picker() {
-  useFolderPicker(HOME, '');
+  useFolderPicker(HOME, new Set());
   return null;
 }
 

--- a/apps/web/src/hooks/useFolderPicker.ts
+++ b/apps/web/src/hooks/useFolderPicker.ts
@@ -29,11 +29,14 @@ export interface FolderPicker {
 
 /**
  * @param openOn the folder to start the walk on, captured on mount
- * @param excludedKey a subtree the picker must not offer, by hex node id —
- * hiding the node hides everything under it, since the walk only descends
+ * @param excludedKeys subtrees the picker must not offer, by hex node id —
+ * hiding a node hides everything under it, since the walk only descends
  * through what it lists
  */
-export function useFolderPicker(openOn: Uint8Array | null, excludedKey: string): FolderPicker {
+export function useFolderPicker(
+  openOn: Uint8Array | null,
+  excludedKeys: ReadonlySet<string>
+): FolderPicker {
   const client = useEngine();
   const store = useSnapshotStore();
   const home = useRef(openOn).current;
@@ -79,9 +82,9 @@ export function useFolderPicker(openOn: Uint8Array | null, excludedKey: string):
   const folders = useMemo(
     () =>
       listingRows(listing?.children ?? []).filter(
-        (row) => row.kind === 'folder' && row.key !== excludedKey
+        (row) => row.kind === 'folder' && !excludedKeys.has(row.key)
       ),
-    [listing, excludedKey]
+    [listing, excludedKeys]
   );
 
   return {

--- a/apps/web/src/hooks/useVaultActions.ts
+++ b/apps/web/src/hooks/useVaultActions.ts
@@ -34,8 +34,6 @@ export interface VaultActions {
   remove(nodes: readonly Uint8Array[]): Promise<BatchOutcome>;
 }
 
-const NOT_READY = 'the engine is not ready yet';
-
 export function useVaultActions(): VaultActions {
   const client = useEngine();
   const [busy, setBusy] = useState<VaultCommand | null>(null);
@@ -61,7 +59,7 @@ export function useVaultActions(): VaultActions {
   const dispatchOrFail = useCallback(
     (command: VaultCommand, dispatch: (facade: EngineFacade) => Promise<void>) => {
       if (client === null) {
-        setError(NOT_READY);
+        setError('the engine is not ready yet');
         return Promise.resolve(false);
       }
       return run(command, () => dispatch(client.facade));
@@ -80,27 +78,22 @@ export function useVaultActions(): VaultActions {
       nodes: readonly Uint8Array[],
       dispatch: (facade: EngineFacade, node: Uint8Array) => Promise<void>
     ): Promise<BatchOutcome> => {
-      if (client === null) {
-        setError(NOT_READY);
-        return { ok: false, accepted: [] };
-      }
-      setBusy(command);
-      setError(null);
       const accepted: Uint8Array[] = [];
-      const refusals: unknown[] = [];
-      for (const node of nodes) {
-        try {
-          await dispatch(client.facade, node);
-          accepted.push(node);
-        } catch (failure: unknown) {
-          refusals.push(failure);
+      const ok = await dispatchOrFail(command, async (facade) => {
+        const refusals: unknown[] = [];
+        for (const node of nodes) {
+          try {
+            await dispatch(facade, node);
+            accepted.push(node);
+          } catch (failure: unknown) {
+            refusals.push(failure);
+          }
         }
-      }
-      setBusy(null);
-      if (refusals.length > 0) setError(errorMessage(refusals[0]));
-      return { ok: refusals.length === 0, accepted };
+        if (refusals.length > 0) throw refusals[0];
+      });
+      return { ok, accepted };
     },
-    [client]
+    [dispatchOrFail]
   );
 
   return {

--- a/apps/web/src/hooks/useVaultActions.ts
+++ b/apps/web/src/hooks/useVaultActions.ts
@@ -13,34 +13,28 @@ import { useEngine } from '../providers/EngineProvider';
 /** Which command is in flight, or `null` when the browser is idle. */
 export type VaultCommand = 'create' | 'rename' | 'relink' | 'delete';
 
+/** Which nodes a batch dispatch was accepted for; the rest were refused. */
+export interface BatchOutcome {
+  /** `true` when the engine accepted every node. */
+  ok: boolean;
+  /** The nodes the engine accepted, in listing order. */
+  accepted: readonly Uint8Array[];
+}
+
 export interface VaultActions {
   busy: VaultCommand | null;
   /** The last dispatch's failure, cleared by the next dispatch. */
   error: string | null;
-  /** Every action resolves `true` once the engine accepted every command. */
+  /** A single-node action resolves `true` once the engine accepted it. */
   createFolder(parent: Uint8Array, name: string): Promise<boolean>;
   rename(node: Uint8Array, newName: string): Promise<boolean>;
   /** One `facade.relink` per node — a batch is not a command of its own. */
-  move(nodes: readonly Uint8Array[], newParent: Uint8Array): Promise<boolean>;
+  move(nodes: readonly Uint8Array[], newParent: Uint8Array): Promise<BatchOutcome>;
   /** One `facade.delete` per node. */
-  remove(nodes: readonly Uint8Array[]): Promise<boolean>;
+  remove(nodes: readonly Uint8Array[]): Promise<BatchOutcome>;
 }
 
-/**
- * Dispatches one command per node in listing order. Every node is attempted
- * even after one is refused — the nodes are independent, and the snapshot is
- * what reports which of them the engine took.
- */
-async function perNode(
-  nodes: readonly Uint8Array[],
-  dispatch: (node: Uint8Array) => Promise<void>
-): Promise<void> {
-  const refusals: unknown[] = [];
-  for (const node of nodes) {
-    await dispatch(node).catch((failure: unknown) => refusals.push(failure));
-  }
-  if (refusals.length > 0) throw refusals[0];
-}
+const NOT_READY = 'the engine is not ready yet';
 
 export function useVaultActions(): VaultActions {
   const client = useEngine();
@@ -67,12 +61,46 @@ export function useVaultActions(): VaultActions {
   const dispatchOrFail = useCallback(
     (command: VaultCommand, dispatch: (facade: EngineFacade) => Promise<void>) => {
       if (client === null) {
-        setError('the engine is not ready yet');
+        setError(NOT_READY);
         return Promise.resolve(false);
       }
       return run(command, () => dispatch(client.facade));
     },
     [client, run]
+  );
+
+  /**
+   * Dispatches one command per node in listing order, attempting every node
+   * even after one is refused — the nodes are independent. The outcome names
+   * the accepted ones so the caller can retire exactly those.
+   */
+  const runBatch = useCallback(
+    async (
+      command: VaultCommand,
+      nodes: readonly Uint8Array[],
+      dispatch: (facade: EngineFacade, node: Uint8Array) => Promise<void>
+    ): Promise<BatchOutcome> => {
+      if (client === null) {
+        setError(NOT_READY);
+        return { ok: false, accepted: [] };
+      }
+      setBusy(command);
+      setError(null);
+      const accepted: Uint8Array[] = [];
+      const refusals: unknown[] = [];
+      for (const node of nodes) {
+        try {
+          await dispatch(client.facade, node);
+          accepted.push(node);
+        } catch (failure: unknown) {
+          refusals.push(failure);
+        }
+      }
+      setBusy(null);
+      if (refusals.length > 0) setError(errorMessage(refusals[0]));
+      return { ok: refusals.length === 0, accepted };
+    },
+    [client]
   );
 
   return {
@@ -88,15 +116,12 @@ export function useVaultActions(): VaultActions {
     ),
     move: useCallback(
       (nodes, newParent) =>
-        dispatchOrFail('relink', (facade) =>
-          perNode(nodes, (node) => facade.relink(node, newParent))
-        ),
-      [dispatchOrFail]
+        runBatch('relink', nodes, (facade, node) => facade.relink(node, newParent)),
+      [runBatch]
     ),
     remove: useCallback(
-      (nodes) =>
-        dispatchOrFail('delete', (facade) => perNode(nodes, (node) => facade.delete(node))),
-      [dispatchOrFail]
+      (nodes) => runBatch('delete', nodes, (facade, node) => facade.delete(node)),
+      [runBatch]
     ),
   };
 }

--- a/apps/web/src/hooks/useVaultActions.ts
+++ b/apps/web/src/hooks/useVaultActions.ts
@@ -17,11 +17,29 @@ export interface VaultActions {
   busy: VaultCommand | null;
   /** The last dispatch's failure, cleared by the next dispatch. */
   error: string | null;
-  /** Every action resolves `true` once the engine accepted the command. */
+  /** Every action resolves `true` once the engine accepted every command. */
   createFolder(parent: Uint8Array, name: string): Promise<boolean>;
   rename(node: Uint8Array, newName: string): Promise<boolean>;
-  move(node: Uint8Array, newParent: Uint8Array): Promise<boolean>;
-  remove(node: Uint8Array): Promise<boolean>;
+  /** One `facade.relink` per node — a batch is not a command of its own. */
+  move(nodes: readonly Uint8Array[], newParent: Uint8Array): Promise<boolean>;
+  /** One `facade.delete` per node. */
+  remove(nodes: readonly Uint8Array[]): Promise<boolean>;
+}
+
+/**
+ * Dispatches one command per node in listing order. Every node is attempted
+ * even after one is refused — the nodes are independent, and the snapshot is
+ * what reports which of them the engine took.
+ */
+async function perNode(
+  nodes: readonly Uint8Array[],
+  dispatch: (node: Uint8Array) => Promise<void>
+): Promise<void> {
+  const refusals: unknown[] = [];
+  for (const node of nodes) {
+    await dispatch(node).catch((failure: unknown) => refusals.push(failure));
+  }
+  if (refusals.length > 0) throw refusals[0];
 }
 
 export function useVaultActions(): VaultActions {
@@ -69,11 +87,15 @@ export function useVaultActions(): VaultActions {
       [dispatchOrFail]
     ),
     move: useCallback(
-      (node, newParent) => dispatchOrFail('relink', (facade) => facade.relink(node, newParent)),
+      (nodes, newParent) =>
+        dispatchOrFail('relink', (facade) =>
+          perNode(nodes, (node) => facade.relink(node, newParent))
+        ),
       [dispatchOrFail]
     ),
     remove: useCallback(
-      (node) => dispatchOrFail('delete', (facade) => facade.delete(node)),
+      (nodes) =>
+        dispatchOrFail('delete', (facade) => perNode(nodes, (node) => facade.delete(node))),
       [dispatchOrFail]
     ),
   };

--- a/apps/web/src/routes/FilesPage.test.tsx
+++ b/apps/web/src/routes/FilesPage.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { authStore } from '../stores/auth.store';
+import { authWrapper, fakeCoreKitSession, fakeEngineClient } from '../test/authFakes';
+import { FilesPage } from './FilesPage';
+
+/** Longer than the provider's restore deadline, so the wait is over. */
+const PAST_DEADLINE_MS = 30_000;
+
+function renderDeepLink(coreKit: ReturnType<typeof fakeCoreKitSession>) {
+  const Wrapper = authWrapper(fakeEngineClient().client, coreKit.session);
+  render(
+    <Wrapper>
+      <MemoryRouter initialEntries={['/files']}>
+        <Routes>
+          <Route path="/" element={<p>FRONT DOOR</p>} />
+          <Route path="/files/:nodeId?" element={<FilesPage />} />
+        </Routes>
+      </MemoryRouter>
+    </Wrapper>
+  );
+}
+
+const frontDoor = () => screen.queryByText('FRONT DOOR');
+
+describe('the vault route with no session', () => {
+  beforeEach(() => authStore.signedOut());
+  afterEach(() => vi.useRealTimers());
+
+  it('returns an unauthenticated deep link to the front door', async () => {
+    renderDeepLink(fakeCoreKitSession());
+
+    await waitFor(() => expect(frontDoor()).not.toBeNull());
+  });
+
+  it('returns the deep link to the front door when the session provider never resolves', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    renderDeepLink(fakeCoreKitSession({ restore: () => new Promise<void>(() => undefined) }));
+
+    // The redirect must not depend on the provider ever answering.
+    expect(frontDoor()).toBeNull();
+    await vi.advanceTimersByTimeAsync(PAST_DEADLINE_MS);
+
+    await waitFor(() => expect(frontDoor()).not.toBeNull());
+  });
+
+  it('keeps showing progress while the check is genuinely still in flight', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let land!: () => void;
+    renderDeepLink(
+      fakeCoreKitSession({ restore: () => new Promise<void>((resolve) => (land = resolve)) })
+    );
+
+    await waitFor(() => expect(screen.queryByTestId('files-signing-in')).not.toBeNull());
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(frontDoor()).toBeNull();
+    expect(screen.queryByTestId('files-signing-in')).not.toBeNull();
+    land();
+  });
+});

--- a/apps/web/src/routes/FilesPage.tsx
+++ b/apps/web/src/routes/FilesPage.tsx
@@ -9,12 +9,12 @@ import { AppShell } from '../components/layout/AppShell';
  * on facade auth state (blueprint/web-client.md "Composition").
  */
 export function FilesPage() {
-  const { isAuthenticated, isReady } = useAuth();
+  const { isAuthenticated, isSignedOut } = useAuth();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (isReady && !isAuthenticated) navigate('/');
-  }, [isAuthenticated, isReady, navigate]);
+    if (isSignedOut) navigate('/');
+  }, [isSignedOut, navigate]);
 
   return (
     <AppShell>

--- a/apps/web/src/styles/vault-actions.css
+++ b/apps/web/src/styles/vault-actions.css
@@ -35,6 +35,80 @@
 }
 
 /* ==========================================================================
+   Selection
+   ========================================================================== */
+
+.file-list-item-select,
+.file-list-select-all,
+.file-list-item-select-gap {
+  flex-shrink: 0;
+  width: 13px;
+  height: 13px;
+  margin: 0 var(--spacing-xs) 0 0;
+  accent-color: var(--color-green-primary);
+  cursor: pointer;
+}
+
+.file-list-item-select-gap {
+  cursor: inherit;
+}
+
+.file-list-select-all:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.file-list-item--selected {
+  background-color: var(--color-green-darker);
+}
+
+.selection-action-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: var(--border-thickness) solid var(--color-green-primary);
+  background-color: var(--color-green-darker);
+}
+
+.selection-action-bar-count {
+  flex: 1;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+}
+
+.selection-action-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.selection-action-bar-delete:hover:not(:disabled) {
+  color: var(--color-error);
+  border-color: var(--color-error);
+  box-shadow: none;
+}
+
+.selection-action-bar-clear {
+  padding: 0 var(--spacing-xs);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-dim);
+  cursor: pointer;
+  background: none;
+  border: none;
+}
+
+.selection-action-bar-clear:hover:not(:disabled),
+.selection-action-bar-clear:focus-visible {
+  color: var(--color-text-primary);
+  text-decoration: underline;
+}
+
+/* ==========================================================================
    Row Menu Trigger
    ========================================================================== */
 

--- a/apps/web/src/styles/vault-actions.css
+++ b/apps/web/src/styles/vault-actions.css
@@ -38,19 +38,28 @@
    Selection
    ========================================================================== */
 
+.file-list {
+  --selection-box: 13px;
+}
+
 .file-list-item-select,
 .file-list-select-all,
 .file-list-item-select-gap {
   flex-shrink: 0;
-  width: 13px;
-  height: 13px;
-  margin: 0 var(--spacing-xs) 0 0;
+  width: var(--selection-box);
+  height: var(--selection-box);
+  margin: 0;
   accent-color: var(--color-green-primary);
+}
+
+.file-list-item-select,
+.file-list-select-all {
   cursor: pointer;
 }
 
-.file-list-item-select-gap {
-  cursor: inherit;
+/* The header row has no flex gap of its own to inherit. */
+.file-list-select-all {
+  margin-right: var(--spacing-xs);
 }
 
 .file-list-select-all:disabled {

--- a/apps/web/src/test/authFakes.tsx
+++ b/apps/web/src/test/authFakes.tsx
@@ -74,12 +74,17 @@ export interface CoreKitCalls {
 }
 
 export function fakeCoreKitSession(
-  options: { loggedIn?: boolean; email?: () => string | null } = {}
+  options: {
+    loggedIn?: boolean;
+    email?: () => string | null;
+    /** Stands in for the mount-time restore; omit for one that settles at once. */
+    restore?: () => Promise<void>;
+  } = {}
 ) {
   const calls: CoreKitCalls = { logins: [], exports: 0, logouts: 0 };
   let loggedIn = options.loggedIn ?? false;
   const session: CoreKitSession = {
-    restore: () => Promise.resolve(),
+    restore: options.restore ?? (() => Promise.resolve()),
     isLoggedIn: () => loggedIn,
     login(method, email) {
       calls.logins.push({ method, email });

--- a/apps/web/src/vault/selection.ts
+++ b/apps/web/src/vault/selection.ts
@@ -5,9 +5,11 @@
  * leaves the selection with it.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toHex } from '@cipherbox/client';
 import type { ListingRow } from './listing';
+
+const EMPTY: ReadonlySet<string> = new Set();
 
 export interface Selection {
   /** The selected rows, in listing order. */
@@ -16,6 +18,8 @@ export interface Selection {
   toggle(key: string): void;
   /** Selects every listed row, or clears once they all already are. */
   toggleAll(): void;
+  /** Retires the rows a command has just acted on, and nothing else. */
+  drop(keys: readonly string[]): void;
   clear(): void;
   allSelected: boolean;
 }
@@ -31,32 +35,28 @@ export function useSelection(rows: ListingRow[], folder: Uint8Array | null): Sel
   useEffect(() => setKeys(EMPTY), [folderKey]);
 
   const selected = useMemo(() => rows.filter((row) => keys.has(row.key)), [keys, rows]);
-
-  const toggleAll = useCallback(() => {
-    setKeys((current) =>
-      rows.length > 0 && rows.every((row) => current.has(row.key))
-        ? EMPTY
-        : new Set(rows.map((row) => row.key))
-    );
-  }, [rows]);
+  const allSelected = rows.length > 0 && selected.length === rows.length;
+  const clear = () => setKeys(EMPTY);
 
   return {
     rows: selected,
-    allSelected: rows.length > 0 && selected.length === rows.length,
-    has: useCallback((key: string) => keys.has(key), [keys]),
-    toggle: useCallback((key: string) => {
+    allSelected,
+    clear,
+    has: (key) => keys.has(key),
+    toggle: (key) =>
       setKeys((current) => {
         const next = new Set(current);
         if (!next.delete(key)) next.add(key);
         return next;
-      });
-    }, []),
-    toggleAll,
-    clear: useCallback(() => setKeys(EMPTY), []),
+      }),
+    toggleAll: () => (allSelected ? clear() : setKeys(new Set(rows.map((row) => row.key)))),
+    drop: (dropped) =>
+      setKeys((current) => {
+        const next = new Set(current);
+        return dropped.filter((key) => next.delete(key)).length > 0 ? next : current;
+      }),
   };
 }
-
-const EMPTY: ReadonlySet<string> = new Set();
 
 /** How a command names what it acts on: one row by name, several by count. */
 export function describeRows(rows: readonly ListingRow[]): string {

--- a/apps/web/src/vault/selection.ts
+++ b/apps/web/src/vault/selection.ts
@@ -1,0 +1,73 @@
+/**
+ * Which listed rows a batch command will act on. Selection is UI-owned state
+ * carrying node ids only (blueprint/web-client.md "UI state law"): it is held as
+ * hex keys and read back through the listing, so a row the engine has retired
+ * leaves the selection with it.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toHex } from '@cipherbox/client';
+import type { ListingRow } from './listing';
+
+export interface Selection {
+  /** The selected rows, in listing order. */
+  rows: ListingRow[];
+  has(key: string): boolean;
+  toggle(key: string): void;
+  /** Selects every listed row, or clears once they all already are. */
+  toggleAll(): void;
+  clear(): void;
+  allSelected: boolean;
+}
+
+/**
+ * @param rows the listing on screen
+ * @param folder the folder that listing belongs to; a change to it starts over
+ */
+export function useSelection(rows: ListingRow[], folder: Uint8Array | null): Selection {
+  const [keys, setKeys] = useState<ReadonlySet<string>>(EMPTY);
+  const folderKey = folder === null ? '' : toHex(folder);
+
+  useEffect(() => setKeys(EMPTY), [folderKey]);
+
+  const selected = useMemo(() => rows.filter((row) => keys.has(row.key)), [keys, rows]);
+
+  const toggleAll = useCallback(() => {
+    setKeys((current) =>
+      rows.length > 0 && rows.every((row) => current.has(row.key))
+        ? EMPTY
+        : new Set(rows.map((row) => row.key))
+    );
+  }, [rows]);
+
+  return {
+    rows: selected,
+    allSelected: rows.length > 0 && selected.length === rows.length,
+    has: useCallback((key: string) => keys.has(key), [keys]),
+    toggle: useCallback((key: string) => {
+      setKeys((current) => {
+        const next = new Set(current);
+        if (!next.delete(key)) next.add(key);
+        return next;
+      });
+    }, []),
+    toggleAll,
+    clear: useCallback(() => setKeys(EMPTY), []),
+  };
+}
+
+const EMPTY: ReadonlySet<string> = new Set();
+
+/** How a command names what it acts on: one row by name, several by count. */
+export function describeRows(rows: readonly ListingRow[]): string {
+  if (rows.length === 1) return rows[0].name;
+  const files = rows.filter((row) => row.kind === 'file').length;
+  return [plural(files, 'file'), plural(rows.length - files, 'folder')]
+    .filter((part) => part !== null)
+    .join(', ');
+}
+
+function plural(count: number, noun: string): string | null {
+  if (count === 0) return null;
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}

--- a/tests/web-e2e/README.md
+++ b/tests/web-e2e/README.md
@@ -10,7 +10,8 @@ Normative source: [`blueprint/testing.md`](../../blueprint/testing.md).
 ## What it covers
 
 - the front door renders every built login method
-- a tab with no session lists no vault contents
+- an unauthenticated deep link is returned to the front door and lists no vault
+  contents
 - a cold start reaches a settled, empty vault at its root; the chrome renders
   it, and the event taps saw the snapshot that produced it
 - signing out returns the tab to the front door

--- a/tests/web-e2e/page-objects/files.page.ts
+++ b/tests/web-e2e/page-objects/files.page.ts
@@ -20,11 +20,6 @@ export class FilesPage {
     return this.page.getByTestId('status-indicator');
   }
 
-  /** What the route renders in place of the vault when no session backs it. */
-  get checkingSession(): Locator {
-    return this.page.getByTestId('files-signing-in');
-  }
-
   async goto(): Promise<void> {
     await this.page.goto('/files');
   }

--- a/tests/web-e2e/tests/smoke.spec.ts
+++ b/tests/web-e2e/tests/smoke.spec.ts
@@ -12,11 +12,12 @@ test('the front door offers every built login method', async ({ page }) => {
   await expect(login.walletButton).toBeVisible();
 });
 
-test('a tab with no session lists nothing', async ({ page }) => {
+test('an unauthenticated deep link lands on the front door', async ({ page }) => {
   const files = new FilesPage(page);
   await files.goto();
 
-  await expect(files.checkingSession).toBeVisible();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(new LoginPage(page).googleButton).toBeVisible();
   await expect(files.browser).toHaveCount(0);
 });
 


### PR DESCRIPTION
Two file-disjoint items on the `#642` web track.

Closes #1091
Closes #1087
Part of #642

## 1091 — the vault browser selection model

`v2` had no selection at all: the per-row context menu covered the four mutations, so nothing in `apps/web` tracked a set of chosen rows. This adds one.

- **Selection state** (`apps/web/src/vault/selection.ts`) — per-row toggle, select-all from the list header, clear. It is UI-owned state carrying node ids only, per the blueprint's UI state law: the selection is held as hex keys and the selected *rows* are read back out of the listing, so a row the engine has retired leaves the selection with it rather than lingering as a phantom in the count. A routed folder change starts over.
- **`SelectionActionBar`** — rebuilt against `ListingRow`, not v1's `FolderChild`. Count, clear, and batch download / move / delete; download only appears when the selection contains a file.
- **Batch dispatch** — `useVaultActions.move` and `.remove` now take a set of nodes and dispatch **one facade command per node**, sequentially, under a single busy/error envelope. A batch is not a command of its own, and there is no client-side listing patching — the snapshot reports which of them the engine took. Every node is attempted even after one is refused, and the first refusal is what surfaces.
- **Batch download** reuses `useFileDownload`.
- The move and delete dialogs now take a set of rows rather than one; the row menu drives the same dialogs with a single-row set, so batch and single share one code path instead of growing a second pair of dialogs. `useFolderPicker` correspondingly excludes every selected subtree instead of a single one — a batch move never offers one of the moved folders as its own destination.

## 1087 — an unauthenticated deep link that hangs

`FilesPage` gated its redirect on `isReady`, which only became true once Core Kit settled. If Core Kit is unconfigured or its network is unreachable, `isReady` stayed false forever and an unauthenticated tab rendered `// CHECKING SESSION...` indefinitely. It was never a security hole — the vault stayed gated on `isAuthenticated` — but the tab had no recovery path and no error.

An `else` branch cannot catch a promise that never settles, so the fix is a bound rather than a branch:

- `CoreKitProvider` gives the mount-time restore a deadline and reports a `'checking' | 'ready' | 'unavailable'` status. Silence past the deadline becomes `unavailable` — a verdict, not a stage on the way to `ready`. A restore that lands *after* the deadline still promotes the tab back to `ready`, so the tab self-heals rather than staying poisoned.
- The deadline is generous, so it does not race a slow-but-working restore; a tab genuinely still checking keeps showing progress and does not redirect early.
- `useAuth` exposes `isSignedOut`: the check settled signed out, **or** it could never be made. `FilesPage` gates the redirect on that instead of on `isReady`.
- "Still checking" and "could not check" no longer render identically — the unresolvable case redirects to the front door, which names the reason and offers the way in. The wallet method is deliberately not offered as a Core-Kit-down fallback: `siweLogin` authenticates an account but does not cold-start a vault, so it would be a path that fails.

The two smoke assertions weakened by this bug are restored: the spec now asserts unconditionally that an unauthenticated deep link lands on the front door, and it fails if the redirect regresses.

This overlaps #914 (derive auth state from the engine instead of a tab-local store), which would subsume it — the root cause is that route authorisation depends on a third-party SDK's readiness rather than on the engine's own session state. #914 needs a new facade auth event and is not scheduled; this hang is live today, so it ships as the small fix and #914 can replace the mechanism wholesale later.

## Tests

New behaviour, all in gates that already block a merge:

- `apps/web/src/routes/FilesPage.test.tsx` (**Test** gate) — the stalled-provider case, asserted with the restore *stalled* rather than merely absent: a `restore()` that never settles still reaches the front door once the deadline passes, and a check that is genuinely in flight keeps showing progress and does not redirect early. Verified non-vacuous — the stall test fails when the deadline is moved out of reach.
- `apps/web/src/components/file-browser/FileBrowserActions.test.tsx` (**Test** gate) — toggling rows updates the count and clear empties it; select-all takes and gives back the listing; batch delete dispatches one `facade.delete` per selected node; batch move dispatches one `facade.relink` per selected node, all to the picked destination; batch download reads every selected file and leaves folders alone; selection resets across a folder change.
- `tests/web-e2e/tests/smoke.spec.ts` (**Web E2E Smoke** gate) — the restored unconditional redirect assertion.

No web unit tests were added for anything the SDK already covers.

## Verified at runtime

Driven in Chrome against a live stack — local API, Postgres, the hermetic `/routing/v1` record store — with the dev bundle's e2e hook cold-starting a real vault.

- `/files` with no session and no Core Kit config redirects to `/` and the front door states why (`browser` absent, `path` `/`).
- Selecting two files and a folder renders `2 files, 1 folder selected`, the toolbar exposes download / move / delete / clear, selected rows highlight, and the header checkbox goes indeterminate.
- Batch move: the dialog titles itself `move 2 files, 1 folder`, offers only the three non-selected folders as destinations (the selected folder is excluded from its own destination list), and on confirm all three nodes leave the source listing and the selection clears.
- Selecting two rows and then opening another folder clears the selection.
- Batch delete: the prompt reads `delete 2 files, 1 folder and everything inside?`, and confirming empties the folder and clears the selection.
- With both rows selected, deleting one through *its own* row menu prompts `delete "alpha" and everything inside it?` and leaves the bar reading `beta selected` — the narrowed retire, confirmed in the browser and not only in the unit gate.
- The `[..]` row's icon and a listed row's icon share an x-offset to the pixel, and the header checkbox aligns with the row checkboxes.

The *stalled* Core Kit case is asserted in the unit gate rather than in the browser — reaching it at runtime needs a configured Web3Auth client whose network is then held open, which would put a third-party dependency inside a merge gate.

## Gates

`pnpm install`, `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm lint:tracker-refs` — all exit 0.

## Review gates

`/simplify` (reuse, simplification, efficiency, altitude), `/security-review`, and `/crypto-privacy-review` all ran on `main...HEAD`. The crypto gate ran because the diff touches the session/trust boundary, even though it adds no crypto.

**Security:** no findings. The bound is fail-closed in the only direction it can move — `isSignedOut` is a strict conjunct on `!isAuthenticated`, so it can only ever fire the redirect *more* often, and `unavailable` always carries a null session so it can never satisfy `isReady`. Vault content is still gated on `isAuthenticated`, unchanged.

**Crypto/privacy:** no crypto in the diff, no key/seed/login-secret exposure, and the handoff path is untouched. The hex/`Uint8Array` split was checked rather than assumed: `ListingRow.key` (hex) is only ever compared against other hex, and every facade call takes `ListingRow.id` (`Uint8Array`).

**Folded in:**

- A command raised from one row's context menu no longer wipes an unrelated multi-selection. The selection now retires exactly the rows a command acted on, and the new test fails under the previous blanket clear.
- Dropped the `useCallback` wrappers and the `toNodeId` indirection the selection hook did not need, and collapsed its four spellings of "all selected" into one.
- Hoisted the indeterminate `ref` callback, so the header checkbox stops detaching and re-attaching on every list render.
- Sized the selection column from one CSS variable rather than three hand-matched literals.
- Trimmed the comments that restated the code beneath them.

**Pushed back on, with evidence:**

- *"Replace the parent row's placeholder span with CSS padding."* Applied and measured: it mis-aligns the `[..]` row by exactly the row's flex `gap`, because padding does not participate in it. Re-deriving the gap inside a `calc()` is the fragile version. Reverted to a flex-item placeholder, which inherits the gap by construction, with the width now coming from the shared variable — which was the reviewer's real complaint.
- *"Keep the session handle on the `unavailable` verdict so `logout()` stays reachable."* Sound in principle, unreachable in fact: `unavailable` and `isAuthenticated` cannot coexist (authentication requires `ready`, and the status never returns to `unavailable` afterwards), so no logout can be dispatched in that state. Nulling the session is also the honest encoding — on the deadline path the restore has not settled, which is exactly what the field's own doc says `null` means.

**Deliberately out of scope:**

- Bounding the live stream-ticket set that a large batch download can open — filed as #1126, blocked by this issue, since the fix has to distinguish a finished transfer from one still being read and that is a change to `useFileDownload`'s ticket lifetime, not to selection.
- `React.memo` on the list rows. The two reviews pull opposite ways here — memoizing wants stable callback identities, simplifying wants fewer of them — and there is no measured problem on a listing bounded by one folder's direct children. Left alone rather than adding machinery for it.
- Retrying a partially-refused batch re-dispatches the whole captured set. Narrow enough (it needs a confirm click after an error) that guarding it would add a concept for less than it costs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added multi-select support for files and folders.
  - Added bulk download, move, delete, and clear-selection actions.
  - Added select-all controls, selection counts, and selected-row highlighting.
  - Improved deletion and move dialogs with multi-item descriptions.
  - Failed batch operations remain selected for retry.

- **Bug Fixes**
  - Unauthenticated deep links now redirect to the front door.
  - Session restoration timeouts now show an unavailable state and prevent indefinite loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add vault browser multi-select with batch move, delete, and download actions
> - Adds a selection model in [`selection.ts`](https://github.com/FSM1/cipher-box/pull/1122/files#diff-63b1d7d3e030745fd1ebfb68b89b4fa051420cf801e807057ed591b9850191a4) with `useSelection` and `describeRows`, tracking selected rows per folder and resetting on navigation.
> - Adds a `SelectionActionBar` toolbar for batch Download, Move, Delete, and Clear actions, disabled while an operation is in flight.
> - Updates `FileList` and `FileListItem` with per-row checkboxes and a select-all header; selected rows are visually highlighted without triggering navigation.
> - Updates `useVaultActions` to run move and delete in batches, reporting accepted nodes via `BatchOutcome` and retiring only accepted nodes on partial failure.
> - Bounds the CoreKit session restore to a 10s deadline in `CoreKitProvider`; sets status `'unavailable'` on timeout and exposes `isSignedOut` from `useAuth` so `FilesPage` can redirect to `/` without waiting for a ready state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 158760c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->