### PR TITLE
fix: fail closed on the transferred upload chunk and on an unknown worker command

### DIFF
--- a/packages/client/src/worker/commandCodec.test.ts
+++ b/packages/client/src/worker/commandCodec.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { fakeWasmEnums } from '../testkit.js';
 import { buildCommand, readEvent, readSnapshot } from './commandCodec.js';
+import type { CommandDescriptor } from './protocol.js';
 import type { EngineWasm, WasmEvent, WasmSnapshotView } from './engineWasm.js';
 
 /**
@@ -53,6 +54,58 @@ describe('buildCommand', () => {
     buildCommand(wasm, { kind: 'cancelUpload', opId: 2n ** 60n });
 
     expect(calls).toEqual([[2n ** 60n]]);
+  });
+
+  /** Every builder succeeds, so only the codec's own checks can reject. */
+  const permissiveWasm = {
+    ...fakeWasmEnums,
+    NodeId: { fromBytes: (bytes: Uint8Array) => ({ bytes }) },
+    Command: new Proxy({}, { get: () => () => ({}) }),
+  } as unknown as EngineWasm;
+
+  const refuses =
+    (descriptor: unknown): (() => unknown) =>
+    () =>
+      buildCommand(permissiveWasm, descriptor as CommandDescriptor);
+
+  it('fails closed on an unknown command kind', () => {
+    expect(refuses({ kind: 'telepathy' })).toThrow('unknown command kind: telepathy');
+  });
+
+  it('rejects a wrong-typed string field rather than letting wasm-bindgen coerce it', () => {
+    expect(refuses({ kind: 'rename', node: new Uint8Array(16), newName: 12345 })).toThrow(
+      'invalid command field newName: number'
+    );
+    expect(
+      refuses({ kind: 'create', parent: new Uint8Array(16), name: null, nodeKind: 'file' })
+    ).toThrow('invalid command field name: null');
+  });
+
+  it('rejects a wrong-typed byte-array field', () => {
+    expect(
+      refuses({
+        kind: 'grant',
+        node: new Uint8Array(16),
+        recipientIdentityPublicKey: 'deadbeef',
+        permission: 'read',
+      })
+    ).toThrow('invalid command field recipientIdentityPublicKey: string');
+    expect(refuses({ kind: 'delete', node: [1, 2, 3] })).toThrow('invalid command field node');
+  });
+
+  it('rejects an unknown node kind or permission rather than defaulting one', () => {
+    expect(
+      refuses({ kind: 'create', parent: new Uint8Array(16), name: 'a', nodeKind: 'symlink' })
+    ).toThrow('invalid command field nodeKind: string');
+    expect(
+      refuses({ kind: 'createInviteLink', node: new Uint8Array(16), permission: 'admin' })
+    ).toThrow('invalid command field permission: string');
+  });
+
+  it('rejects an op id that is not the engine bigint', () => {
+    expect(refuses({ kind: 'cancelUpload', opId: 7 })).toThrow(
+      'invalid command field opId: number'
+    );
   });
 });
 

--- a/packages/client/src/worker/commandCodec.test.ts
+++ b/packages/client/src/worker/commandCodec.test.ts
@@ -56,6 +56,34 @@ describe('buildCommand', () => {
     expect(calls).toEqual([[2n ** 60n]]);
   });
 
+  it('maps the second literal of each mirror enum, not just the first', () => {
+    const calls: unknown[][] = [];
+    const record = (...args: unknown[]): object => {
+      calls.push(args);
+      return {};
+    };
+    const wasm = {
+      ...fakeWasmEnums,
+      NodeId: { fromBytes: (bytes: Uint8Array) => ({ bytes }) },
+      Command: { create: record, createInviteLink: record },
+    } as unknown as EngineWasm;
+
+    buildCommand(wasm, {
+      kind: 'create',
+      parent: new Uint8Array(16),
+      name: 'docs',
+      nodeKind: 'folder',
+    });
+    buildCommand(wasm, {
+      kind: 'createInviteLink',
+      node: new Uint8Array(16),
+      permission: 'write',
+    });
+
+    expect(calls[0][2]).toBe(fakeWasmEnums.NodeKind.Folder);
+    expect(calls[1][1]).toBe(fakeWasmEnums.Permission.Write);
+  });
+
   /** Every builder succeeds, so only the codec's own checks can reject. */
   const permissiveWasm = {
     ...fakeWasmEnums,

--- a/packages/client/src/worker/commandCodec.ts
+++ b/packages/client/src/worker/commandCodec.ts
@@ -15,7 +15,6 @@ import type {
   NodeKind,
   OpProgressPhase,
   PendingClass,
-  Permission,
   SnapshotDescriptor,
   Staleness,
 } from './protocol.js';
@@ -28,71 +27,117 @@ import type {
   WasmSnapshotView,
 } from './engineWasm.js';
 
-function nodeId(wasm: EngineWasm, bytes: Uint8Array): WasmNodeId {
-  return wasm.NodeId.fromBytes(bytes);
+/**
+ * A descriptor crosses a realm boundary as plain data, so its fields arrive
+ * untrusted however they are typed here: a version-skewed peer can carry a
+ * wrong-typed one, and wasm-bindgen would coerce it — a `12345` newName
+ * marshalled as `"12345"` — rather than reject it. Every field the builders
+ * read is checked, so the only wrong-typed field is a rejected command.
+ */
+function invalidField(field: string, value: unknown): Error {
+  return new Error(`invalid command field ${field}: ${value === null ? 'null' : typeof value}`);
 }
 
-function nodeKind(wasm: EngineWasm, kind: NodeKind): number {
-  return kind === 'file' ? wasm.NodeKind.File : wasm.NodeKind.Folder;
+function bytes(value: unknown, field: string): Uint8Array {
+  if (!(value instanceof Uint8Array)) throw invalidField(field, value);
+  return value;
 }
 
-function permission(wasm: EngineWasm, level: Permission): number {
-  return level === 'read' ? wasm.Permission.Read : wasm.Permission.Write;
+function text(value: unknown, field: string): string {
+  if (typeof value !== 'string') throw invalidField(field, value);
+  return value;
+}
+
+function opId(value: unknown, field: string): bigint {
+  if (typeof value !== 'bigint') throw invalidField(field, value);
+  return value;
+}
+
+function nodeId(wasm: EngineWasm, value: unknown, field: string): WasmNodeId {
+  return wasm.NodeId.fromBytes(bytes(value, field));
+}
+
+function nodeKind(wasm: EngineWasm, value: unknown): number {
+  if (value === 'file') return wasm.NodeKind.File;
+  if (value === 'folder') return wasm.NodeKind.Folder;
+  throw invalidField('nodeKind', value);
+}
+
+function permission(wasm: EngineWasm, value: unknown): number {
+  if (value === 'read') return wasm.Permission.Read;
+  if (value === 'write') return wasm.Permission.Write;
+  throw invalidField('permission', value);
 }
 
 export function buildCommand(wasm: EngineWasm, descriptor: CommandDescriptor): WasmCommand {
   switch (descriptor.kind) {
     case 'create':
       return wasm.Command.create(
-        nodeId(wasm, descriptor.parent),
-        descriptor.name,
+        nodeId(wasm, descriptor.parent, 'parent'),
+        text(descriptor.name, 'name'),
         nodeKind(wasm, descriptor.nodeKind)
       );
     case 'delete':
-      return wasm.Command.delete(nodeId(wasm, descriptor.node));
+      return wasm.Command.delete(nodeId(wasm, descriptor.node, 'node'));
     case 'rename':
-      return wasm.Command.rename(nodeId(wasm, descriptor.node), descriptor.newName);
+      return wasm.Command.rename(
+        nodeId(wasm, descriptor.node, 'node'),
+        text(descriptor.newName, 'newName')
+      );
     case 'relink':
-      return wasm.Command.relink(nodeId(wasm, descriptor.node), nodeId(wasm, descriptor.newParent));
+      return wasm.Command.relink(
+        nodeId(wasm, descriptor.node, 'node'),
+        nodeId(wasm, descriptor.newParent, 'newParent')
+      );
     case 'cancelUpload':
-      return wasm.Command.cancelUpload(descriptor.opId);
+      return wasm.Command.cancelUpload(opId(descriptor.opId, 'opId'));
     case 'setFocus':
       return wasm.Command.setFocus(
-        descriptor.node === null ? undefined : nodeId(wasm, descriptor.node)
+        descriptor.node === null ? undefined : nodeId(wasm, descriptor.node, 'node')
       );
     case 'manualRefresh':
       return wasm.Command.manualRefresh();
     case 'importContact':
-      return wasm.Command.importContact(descriptor.contactCode);
+      return wasm.Command.importContact(bytes(descriptor.contactCode, 'contactCode'));
     case 'grant':
       return wasm.Command.grant(
-        nodeId(wasm, descriptor.node),
-        descriptor.recipientIdentityPublicKey,
+        nodeId(wasm, descriptor.node, 'node'),
+        bytes(descriptor.recipientIdentityPublicKey, 'recipientIdentityPublicKey'),
         permission(wasm, descriptor.permission)
       );
     case 'revoke':
       return wasm.Command.revoke(
-        nodeId(wasm, descriptor.node),
-        descriptor.recipientIdentityPublicKey
+        nodeId(wasm, descriptor.node, 'node'),
+        bytes(descriptor.recipientIdentityPublicKey, 'recipientIdentityPublicKey')
       );
     case 'downgrade':
       return wasm.Command.downgrade(
-        nodeId(wasm, descriptor.node),
-        descriptor.recipientIdentityPublicKey
+        nodeId(wasm, descriptor.node, 'node'),
+        bytes(descriptor.recipientIdentityPublicKey, 'recipientIdentityPublicKey')
       );
     case 'createInviteLink':
       return wasm.Command.createInviteLink(
-        nodeId(wasm, descriptor.node),
+        nodeId(wasm, descriptor.node, 'node'),
         permission(wasm, descriptor.permission)
       );
     case 'acceptShare':
-      return wasm.Command.acceptShare(descriptor.sealedSharePointer);
+      return wasm.Command.acceptShare(bytes(descriptor.sealedSharePointer, 'sealedSharePointer'));
     case 'rotateNow':
-      return wasm.Command.rotateNow(nodeId(wasm, descriptor.node));
+      return wasm.Command.rotateNow(nodeId(wasm, descriptor.node, 'node'));
     case 'siweLogin':
-      return wasm.Command.siweLogin(descriptor.message, descriptor.signature);
+      return wasm.Command.siweLogin(
+        text(descriptor.message, 'message'),
+        bytes(descriptor.signature, 'signature')
+      );
     case 'logout':
       return wasm.Command.logout();
+    default: {
+      // Fail closed: an unmapped kind means a peer built against a different
+      // protocol, not a command to guess at. The `never` binding makes adding
+      // a kind without a builder a compile error.
+      const unmapped: never = descriptor;
+      throw new Error(`unknown command kind: ${String((unmapped as CommandDescriptor).kind)}`);
+    }
   }
 }
 

--- a/packages/client/src/worker/commandCodec.ts
+++ b/packages/client/src/worker/commandCodec.ts
@@ -31,8 +31,8 @@ import type {
  * A descriptor crosses a realm boundary as plain data, so its fields arrive
  * untrusted however they are typed here: a version-skewed peer can carry a
  * wrong-typed one, and wasm-bindgen would coerce it — a `12345` newName
- * marshalled as `"12345"` — rather than reject it. Every field the builders
- * read is checked, so the only wrong-typed field is a rejected command.
+ * marshalled as `"12345"` — rather than reject it. Hence the checkers below
+ * take `unknown`, and every field a builder reads passes through one.
  */
 function invalidField(field: string, value: unknown): Error {
   return new Error(`invalid command field ${field}: ${value === null ? 'null' : typeof value}`);
@@ -67,6 +67,15 @@ function permission(wasm: EngineWasm, value: unknown): number {
   if (value === 'read') return wasm.Permission.Read;
   if (value === 'write') return wasm.Permission.Write;
   throw invalidField('permission', value);
+}
+
+/**
+ * Exhaustiveness bound: adding a command kind without a builder fails the
+ * build, and a sender off the union gets a refusal rather than the `undefined`
+ * command the wasm glue merely happens to reject.
+ */
+function unknownCommand(descriptor: never): Error {
+  return new Error(`unknown command kind: ${String((descriptor as CommandDescriptor).kind)}`);
 }
 
 export function buildCommand(wasm: EngineWasm, descriptor: CommandDescriptor): WasmCommand {
@@ -131,13 +140,8 @@ export function buildCommand(wasm: EngineWasm, descriptor: CommandDescriptor): W
       );
     case 'logout':
       return wasm.Command.logout();
-    default: {
-      // Fail closed: an unmapped kind means a peer built against a different
-      // protocol, not a command to guess at. The `never` binding makes adding
-      // a kind without a builder a compile error.
-      const unmapped: never = descriptor;
-      throw new Error(`unknown command kind: ${String((unmapped as CommandDescriptor).kind)}`);
-    }
+    default:
+      throw unknownCommand(descriptor);
   }
 }
 

--- a/packages/client/src/worker/engineHost.test.ts
+++ b/packages/client/src/worker/engineHost.test.ts
@@ -42,6 +42,18 @@ function recordingWasm(): { wasm: EngineWasm; constructed: Constructed[] } {
   return { wasm, constructed };
 }
 
+/** A host whose WASM `pushChunk` hands the view it was given to `onPush`. */
+function pushingHost(onPush: (chunk: Uint8Array) => Promise<void>): EngineHost {
+  const wasm = {
+    EngineHandle: class {
+      pushChunk(_handle: bigint, chunk: Uint8Array): Promise<void> {
+        return onPush(chunk);
+      }
+    },
+  } as unknown as EngineWasm;
+  return new EngineHost(wasm, {}, { apiBaseUrl: 'https://api.example.test' });
+}
+
 describe('EngineHost', () => {
   it('hands the engine the API base URL so cold start can log in', () => {
     const { wasm, constructed } = recordingWasm();
@@ -91,5 +103,30 @@ describe('EngineHost', () => {
 
     expect(constructed[0].acceleratorBaseUrl).toBeUndefined();
     expect(constructed[0].publicGateways).toBeUndefined();
+  });
+
+  it('wipes the transferred upload chunk once WASM has copied it', async () => {
+    const plaintext = Uint8Array.of(1, 2, 3, 4);
+    let copied: Uint8Array | undefined;
+    const host = pushingHost((chunk) => {
+      copied = Uint8Array.from(chunk);
+      return Promise.resolve();
+    });
+
+    await host.pushChunk(7n, plaintext.buffer as ArrayBuffer);
+
+    expect(copied).toEqual(Uint8Array.of(1, 2, 3, 4));
+    expect(plaintext).toEqual(new Uint8Array(4));
+  });
+
+  it('wipes the transferred upload chunk when the push rejects', async () => {
+    const plaintext = Uint8Array.of(5, 6, 7, 8);
+    const host = pushingHost(() => Promise.reject(new Error('staging full')));
+
+    await expect(host.pushChunk(7n, plaintext.buffer as ArrayBuffer)).rejects.toThrow(
+      'staging full'
+    );
+
+    expect(plaintext).toEqual(new Uint8Array(4));
   });
 });

--- a/packages/client/src/worker/engineHost.ts
+++ b/packages/client/src/worker/engineHost.ts
@@ -26,7 +26,8 @@ export interface EngineHostLike {
   command(command: CommandDescriptor): Promise<void>;
   /** Opens a write handle for `size` plaintext bytes; the engine reserves them. */
   beginWrite(target: WriteTarget, size: number): Promise<WriteHandle>;
-  /** Takes ownership of `chunk`: the host scrubs the plaintext once it lands. */
+  /** Takes ownership of `chunk`: the host is its terminal owner, so it scrubs the
+   * plaintext to bound the lifetime of a copy no caller can reach. */
   pushChunk(handle: WriteHandle, chunk: ArrayBuffer): Promise<void>;
   /** Closes the handle and journals its op; resolves with the durable op id. */
   commitWrite(handle: WriteHandle): Promise<bigint>;

--- a/packages/client/src/worker/engineHost.ts
+++ b/packages/client/src/worker/engineHost.ts
@@ -26,6 +26,7 @@ export interface EngineHostLike {
   command(command: CommandDescriptor): Promise<void>;
   /** Opens a write handle for `size` plaintext bytes; the engine reserves them. */
   beginWrite(target: WriteTarget, size: number): Promise<WriteHandle>;
+  /** Takes ownership of `chunk`: the host scrubs the plaintext once it lands. */
   pushChunk(handle: WriteHandle, chunk: ArrayBuffer): Promise<void>;
   /** Closes the handle and journals its op; resolves with the durable op id. */
   commitWrite(handle: WriteHandle): Promise<bigint>;
@@ -113,9 +114,15 @@ export class EngineHost implements EngineHostLike {
   }
 
   async pushChunk(handle: WriteHandle, chunk: ArrayBuffer): Promise<void> {
-    // The handle copies into WASM memory synchronously; a view over the
-    // transferred buffer is safe here.
-    await this.handle.pushChunk(handle, new Uint8Array(chunk));
+    // The chunk arrives by transfer, so the worker is its terminal owner: the
+    // handle copies it into WASM memory synchronously, and the JS-side
+    // plaintext is scrubbed rather than left for the collector.
+    const view = new Uint8Array(chunk);
+    try {
+      await this.handle.pushChunk(handle, view);
+    } finally {
+      view.fill(0);
+    }
   }
 
   commitWrite(handle: WriteHandle): Promise<bigint> {

--- a/packages/client/src/worker/engineHost.ts
+++ b/packages/client/src/worker/engineHost.ts
@@ -81,15 +81,25 @@ export class EngineHost implements EngineHostLike {
     );
   }
 
-  async start(secret: ArrayBuffer): Promise<void> {
-    // The engine copies the secret into its `Zeroizing` store; scrub the
-    // worker's transferred copy immediately after so no plaintext lingers.
-    const view = new Uint8Array(secret);
+  /**
+   * Runs `use` over `buffer`, scrubbing it once the call settles — including
+   * when it rejects. Buffers reaching the host arrive by transfer, making the
+   * worker their terminal owner, and the engine below copies what it keeps.
+   */
+  private async scrubbing(
+    buffer: ArrayBuffer,
+    use: (view: Uint8Array) => Promise<unknown>
+  ): Promise<void> {
+    const view = new Uint8Array(buffer);
     try {
-      await this.handle.start(view);
+      await use(view);
     } finally {
       view.fill(0);
     }
+  }
+
+  start(secret: ArrayBuffer): Promise<void> {
+    return this.scrubbing(secret, (view) => this.handle.start(view));
   }
 
   async command(command: CommandDescriptor): Promise<void> {
@@ -113,16 +123,8 @@ export class EngineHost implements EngineHostLike {
     );
   }
 
-  async pushChunk(handle: WriteHandle, chunk: ArrayBuffer): Promise<void> {
-    // The chunk arrives by transfer, so the worker is its terminal owner: the
-    // handle copies it into WASM memory synchronously, and the JS-side
-    // plaintext is scrubbed rather than left for the collector.
-    const view = new Uint8Array(chunk);
-    try {
-      await this.handle.pushChunk(handle, view);
-    } finally {
-      view.fill(0);
-    }
+  pushChunk(handle: WriteHandle, chunk: ArrayBuffer): Promise<void> {
+    return this.scrubbing(chunk, (view) => this.handle.pushChunk(handle, view));
   }
 
   commitWrite(handle: WriteHandle): Promise<bigint> {


### PR DESCRIPTION
Two fail-closed fixes in the engine worker, in one PR. Both live in
`packages/client/src/worker/**`, touch disjoint files, and share one review lens,
so they are reviewed together rather than as two branches of a hundred lines each.

---

# Part 1 — #1037, wipe the transferred upload chunk

`EngineHost.pushChunk` receives the upload chunk by transfer, so the worker realm is its terminal owner — nothing upstream still holds the buffer. wasm-bindgen marshals the `Uint8Array` view into a `Vec<u8>` synchronously, before `push_chunk` returns its promise, so once the call has been made the JS-side copy is pure residue.

It was left for the collector. This wipes it.

## What changed

- `EngineHost` grows one private `scrubbing` helper: it runs a call over a view of the buffer and fills the view with zeroes in a `finally`, so the failure path scrubs too. `start` already did this inline for the login secret; `pushChunk` now shares the same helper rather than repeating the idiom.
- `EngineHostLike.pushChunk` states the ownership transfer, so an implementer knows the buffer is the host's to scrub.

The engine keeps its own copy in a `Zeroizing<Vec<u8>>` for the duration of the push, so scrubbing after the call settles rather than between the marshal and the await opens no new window.

## Tests

`packages/client/src/worker/engineHost.test.ts` gains two cases: a chunk handed to the host is all zeroes after a resolved push and after a rejected one, with the WASM-side copy asserted to have seen the real bytes so the wipe cannot pass by wiping too early.

## Not in this PR

The crypto-privacy pass found the same residue class on the sending side: `EngineClient.pushChunk` and `CorrelatedTransport.request` drop a chunk they refuse *before* any transfer, so it is never detached and never wiped. Those files are outside this batch's ownership — filed as #1155.

## Gates

`pnpm typecheck` 0, `pnpm test` 0, `pnpm lint` 0, `pnpm lint:tracker-refs` 0.

---

# Part 2 — #1051, fail closed on an unknown or wrong-typed command

`buildCommand` switched over `CommandDescriptor` with no `default` arm, so an unknown `kind` fell out returning `undefined` and only failed because the wasm-bindgen glue happened to reject it — fail-closed by accident, and inconsistent with the three sibling switches in the same file that already fail closed deliberately.

The sharper case was a **known** kind carrying a wrong-typed field. `{ kind: 'rename', node: <16 bytes>, newName: 12345 }` reached `wasm.Command.rename(nodeId, 12345)` and wasm-bindgen's `USVString` marshalling coerced it, renaming the node to `"12345"` instead of rejecting the command. Reachable from a version-skewed follower build: the private-port relay validates the command *shape* and deliberately leaves field validation to the codec, so that division only holds if the codec enforces it.

## What changed

- Every field the builders read is checked against the type the protocol declares — byte arrays must be a real `Uint8Array`, strings a real string, `opId` a real `bigint`. The checkers take `unknown`, because the descriptor arrives as plain data across a realm boundary and its static type is a claim, not a guarantee.
- `nodeKind` and `permission` no longer fall through to `Folder`/`Write` on an unrecognised literal; they reject it. That was the same silent-coercion class, one layer down.
- A `default` arm binds the descriptor to `never` and throws. Verified by temporarily adding a seventeenth kind to `CommandDescriptor`: `tsc` fails with `Type '{ kind: "probeNewKind"; … }' is not assignable to type 'never'` at that binding, so a new kind cannot be added without a builder.

Valid commands are unaffected — every check passes through the value it validated.

## Tests

`packages/client/src/worker/commandCodec.test.ts` gains five refusal cases driven against a permissive fake whose every builder succeeds, so only the codec's own checks can reject: an unknown kind, a numeric `newName` and a null `name`, a string where a public key belongs and an array where a node id belongs, an unrecognised `nodeKind` and `permission`, and a number `opId`. A sixth asserts the accept side of both mirror enums — `'folder'` and `'write'`, not only the literal each mapper tests first.

## Not in this PR

The byte and string arguments of `beginWrite`, `snapshot`, `download` and `openContentStream` reach WASM from the same untrusted message with the same coercion, and `passArray8ToWasm0` turns a 16-character string into sixteen zero bytes rather than rejecting it. That is #1154, which reuses the checkers this PR introduces.

## Gates

`pnpm typecheck` 0, `pnpm test` 0, `pnpm lint` 0, `pnpm lint:tracker-refs` 0.

---

Closes #1037
Closes #1051


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail closed on invalid worker commands and transferred upload chunks
> - `buildCommand` in [commandCodec.ts](https://github.com/FSM1/cipher-box/pull/1145/files#diff-a2427e8ca2b1c7e229ffba009773c8fe15f5821745326cf1413e23275371319a) now strictly validates all descriptor fields, throwing descriptive errors for wrong-typed strings, non-`Uint8Array` byte fields, non-bigint `opId`, unknown node kinds, unknown permissions, and unknown command kinds instead of silently falling through or relying on wasm-bindgen coercion.
> - `EngineHost.pushChunk` in [engineHost.ts](https://github.com/FSM1/cipher-box/pull/1145/files#diff-25210c9231a2d0b9f72a4dc05fb431e4f740fe3dc44fe309b12877a29a5ef9f7) now zeros the provided `ArrayBuffer` after the WASM call completes, using a new `scrubbing` helper that guarantees zeroing even when the call rejects.
> - Behavioral Change: callers passing wrong-typed fields to `buildCommand` or unknown command kinds will now receive thrown errors rather than silent misbehavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45f85cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Reliability**
  - Strengthened command validation to reject unknown commands, invalid fields, unsupported values, and malformed operation IDs.
  - Upload data is now securely cleared from memory after processing, including when operations fail.
  - Updated upload behavior documentation to clarify that submitted plaintext buffers are scrubbed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->