### PR TITLE
feat: bound the live stream tickets and surface a recoverable stream refusal

### DIFF
--- a/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
@@ -745,7 +745,17 @@ describe('the vault browser read path over the streaming pipe', () => {
   const originalClick = HTMLAnchorElement.prototype.click;
   /** Whether the browser opens the save the ticket was minted for. */
   let fetched = true;
+  /** Set by a test that drives the transfers itself, keyed by ticket url. */
+  let transfers: Map<string, (read: boolean) => void> | null = null;
   const streamListeners = new Set<(failure: MediaStreamFailure) => void>();
+
+  /** The browser finished reading this ticket. */
+  const endTransfer = async (url: string): Promise<void> => {
+    await act(async () => {
+      transfers?.get(url)?.(fetched);
+      await Promise.resolve();
+    });
+  };
 
   /** Stands in for the broker giving up on a read. */
   const reportStreamError = (failure: MediaStreamFailure): void => {
@@ -770,6 +780,7 @@ describe('the vault browser read path over the streaming pipe', () => {
     revoked.length = 0;
     clicked.length = 0;
     fetched = true;
+    transfers = null;
     streamListeners.clear();
     mediaControl.create = () =>
       ({
@@ -780,7 +791,11 @@ describe('the vault browser read path over the streaming pipe', () => {
           minted.push(source);
           return `/stream/ticket-${minted.length}`;
         },
-        whenStreamIdle: () => Promise.resolve(fetched),
+        whenStreamIdle: (url: string) => {
+          const held = transfers;
+          if (held === null) return Promise.resolve(fetched);
+          return new Promise<boolean>((resolve) => held.set(url, resolve));
+        },
         onStreamError: (listener: (failure: MediaStreamFailure) => void) => {
           streamListeners.add(listener);
           return () => streamListeners.delete(listener);
@@ -824,14 +839,24 @@ describe('the vault browser read path over the streaming pipe', () => {
 
   it('saves a selection one ticket at a time', async () => {
     const engine = fakeEngine();
+    transfers = new Map();
     renderBrowser(engine);
     await landSnapshot(engine, twoFiles());
 
     fireEvent.click(screen.getByTestId('select-all'));
     fireEvent.click(screen.getByTestId('selection-download'));
 
+    await waitFor(() => expect(minted).toHaveLength(1));
+    expect(revoked).toEqual([]);
+
+    await endTransfer('/stream/ticket-1');
+
     await waitFor(() => expect(minted).toHaveLength(2));
-    expect(revoked).toEqual(['/stream/ticket-1', '/stream/ticket-2']);
+    expect(revoked).toEqual(['/stream/ticket-1']);
+
+    await endTransfer('/stream/ticket-2');
+
+    await waitFor(() => expect(revoked).toEqual(['/stream/ticket-1', '/stream/ticket-2']));
   });
 
   it('stops a batch at the first save the browser refuses', async () => {
@@ -961,6 +986,23 @@ describe('the vault browser read path over the streaming pipe', () => {
 
     expect(screen.getByTestId('media-player-error').textContent).toBe('playback failed');
     expect(screen.queryByTestId('media-player-retry')).toBeNull();
+  });
+
+  it('keeps the retry when the element reports the refusal it was already told about', async () => {
+    await playAudio();
+
+    reportStreamError({
+      url: '/stream/ticket-1',
+      message: 'too many read streams are already open',
+      recoverable: true,
+    });
+    // Ending the body is what the element sees, and it cannot classify it.
+    fireEvent.error(screen.getByTestId('media-player-audio'));
+
+    expect(screen.getByTestId('media-player-error').textContent).toContain(
+      'too many streams are open right now'
+    );
+    expect(screen.getByTestId('media-player-retry')).toBeDefined();
   });
 
   it('buffers a pdf, which the pipe would serve under an opaque type', async () => {

--- a/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
@@ -756,6 +756,7 @@ describe('the vault browser read path over the streaming pipe', () => {
           minted.push(source);
           return `/stream/ticket-${minted.length}`;
         },
+        whenStreamIdle: () => Promise.resolve(),
         revokeStreamUrl: (url: string) => {
           revoked.push(url);
           return true;

--- a/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
@@ -3,6 +3,7 @@ import {
   type EngineClient,
   type EventDescriptor,
   type MediaService,
+  type MediaStreamFailure,
   type SnapshotDescriptor,
 } from '@cipherbox/client';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -744,12 +745,19 @@ describe('the vault browser read path over the streaming pipe', () => {
   const originalClick = HTMLAnchorElement.prototype.click;
   /** Whether the browser opens the save the ticket was minted for. */
   let fetched = true;
+  const streamListeners = new Set<(failure: MediaStreamFailure) => void>();
+
+  /** Stands in for the broker giving up on a read, which is always tab-side. */
+  const reportStreamError = (failure: MediaStreamFailure): void => {
+    for (const listener of streamListeners) listener(failure);
+  };
 
   beforeEach(() => {
     minted.length = 0;
     revoked.length = 0;
     clicked.length = 0;
     fetched = true;
+    streamListeners.clear();
     mediaControl.create = () =>
       ({
         streaming: true,
@@ -760,6 +768,10 @@ describe('the vault browser read path over the streaming pipe', () => {
           return `/stream/ticket-${minted.length}`;
         },
         whenStreamIdle: () => Promise.resolve(fetched),
+        onStreamError: (listener: (failure: MediaStreamFailure) => void) => {
+          streamListeners.add(listener);
+          return () => streamListeners.delete(listener);
+        },
         revokeStreamUrl: (url: string) => {
           revoked.push(url);
           return true;
@@ -870,6 +882,94 @@ describe('the vault browser read path over the streaming pipe', () => {
 
     await waitFor(() => expect(screen.getByTestId('preview-image')).toBeDefined());
     expect(engine.facade.download).not.toHaveBeenCalled();
+  });
+
+  it('plays a video off a ticket and never buffers it', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(
+      engine,
+      folderView({ children: [file(PICTURE, 'clip.mp4', { size: 64n * 1024n * 1024n })] })
+    );
+
+    openRowMenu('clip.mp4');
+    chooseMenuItem('preview');
+
+    const player = await screen.findByTestId('media-player-video');
+    expect(player.getAttribute('src')).toBe('/stream/ticket-1');
+    expect(minted[0].mimeType).toBe('video/mp4');
+    expect(engine.facade.download).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByLabelText('close'));
+    await waitFor(() => expect(revoked).toEqual(['/stream/ticket-1']));
+  });
+
+  it('offers a retry for a ceiling refusal and a bare failure for a fault', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+
+    openRowMenu('song.mp3');
+    chooseMenuItem('preview');
+    await screen.findByTestId('media-player-audio');
+
+    act(() => {
+      reportStreamError({
+        url: '/stream/ticket-1',
+        message: 'too many read streams are already open',
+        recoverable: true,
+      });
+    });
+    expect(screen.getByTestId('media-player-error').textContent).toContain(
+      'too many streams are open right now'
+    );
+
+    // The ticket is still live, so a retry is a fresh read of the same URL.
+    fireEvent.click(screen.getByTestId('media-player-retry'));
+    expect(screen.queryByTestId('media-player-error')).toBeNull();
+    expect(revoked).toEqual([]);
+    expect(screen.getByTestId('media-player-audio').getAttribute('src')).toBe('/stream/ticket-1');
+
+    act(() => {
+      reportStreamError({
+        url: '/stream/ticket-1',
+        message: 'the adoption gate refused the record',
+        recoverable: false,
+      });
+    });
+    expect(screen.getByTestId('media-player-error').textContent).toBe(
+      'the adoption gate refused the record'
+    );
+    expect(screen.queryByTestId('media-player-retry')).toBeNull();
+  });
+
+  it('ignores a refusal on another tab-mate stream', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+
+    openRowMenu('song.mp3');
+    chooseMenuItem('preview');
+    await screen.findByTestId('media-player-audio');
+
+    act(() => {
+      reportStreamError({ url: '/stream/ticket-9', message: 'not mine', recoverable: true });
+    });
+
+    expect(screen.queryByTestId('media-player-error')).toBeNull();
+  });
+
+  it('reports a playback failure the pipe never named', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+
+    openRowMenu('song.mp3');
+    chooseMenuItem('preview');
+    fireEvent.error(await screen.findByTestId('media-player-audio'));
+
+    expect(screen.getByTestId('media-player-error').textContent).toBe('playback failed');
+    expect(screen.queryByTestId('media-player-retry')).toBeNull();
   });
 
   it('buffers a pdf, which the pipe would serve under an opaque type', async () => {

--- a/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
@@ -747,10 +747,23 @@ describe('the vault browser read path over the streaming pipe', () => {
   let fetched = true;
   const streamListeners = new Set<(failure: MediaStreamFailure) => void>();
 
-  /** Stands in for the broker giving up on a read, which is always tab-side. */
+  /** Stands in for the broker giving up on a read. */
   const reportStreamError = (failure: MediaStreamFailure): void => {
-    for (const listener of streamListeners) listener(failure);
+    act(() => {
+      for (const listener of streamListeners) listener(failure);
+    });
   };
+
+  /** Opens the preview of one audio file and waits for the player. */
+  async function playAudio(): Promise<void> {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+
+    openRowMenu('song.mp3');
+    chooseMenuItem('preview');
+    await screen.findByTestId('media-player-audio');
+  }
 
   beforeEach(() => {
     minted.length = 0;
@@ -905,37 +918,27 @@ describe('the vault browser read path over the streaming pipe', () => {
   });
 
   it('offers a retry for a ceiling refusal and a bare failure for a fault', async () => {
-    const engine = fakeEngine();
-    renderBrowser(engine);
-    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+    await playAudio();
 
-    openRowMenu('song.mp3');
-    chooseMenuItem('preview');
-    await screen.findByTestId('media-player-audio');
-
-    act(() => {
-      reportStreamError({
-        url: '/stream/ticket-1',
-        message: 'too many read streams are already open',
-        recoverable: true,
-      });
+    reportStreamError({
+      url: '/stream/ticket-1',
+      message: 'too many read streams are already open',
+      recoverable: true,
     });
     expect(screen.getByTestId('media-player-error').textContent).toContain(
       'too many streams are open right now'
     );
 
-    // The ticket is still live, so a retry is a fresh read of the same URL.
     fireEvent.click(screen.getByTestId('media-player-retry'));
     expect(screen.queryByTestId('media-player-error')).toBeNull();
+    // The pipe refused a read; it did not withdraw the capability.
     expect(revoked).toEqual([]);
     expect(screen.getByTestId('media-player-audio').getAttribute('src')).toBe('/stream/ticket-1');
 
-    act(() => {
-      reportStreamError({
-        url: '/stream/ticket-1',
-        message: 'the adoption gate refused the record',
-        recoverable: false,
-      });
+    reportStreamError({
+      url: '/stream/ticket-1',
+      message: 'the adoption gate refused the record',
+      recoverable: false,
     });
     expect(screen.getByTestId('media-player-error').textContent).toBe(
       'the adoption gate refused the record'
@@ -943,30 +946,18 @@ describe('the vault browser read path over the streaming pipe', () => {
     expect(screen.queryByTestId('media-player-retry')).toBeNull();
   });
 
-  it('ignores a refusal on another tab-mate stream', async () => {
-    const engine = fakeEngine();
-    renderBrowser(engine);
-    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+  it('ignores a refusal reported for another stream', async () => {
+    await playAudio();
 
-    openRowMenu('song.mp3');
-    chooseMenuItem('preview');
-    await screen.findByTestId('media-player-audio');
-
-    act(() => {
-      reportStreamError({ url: '/stream/ticket-9', message: 'not mine', recoverable: true });
-    });
+    reportStreamError({ url: '/stream/ticket-9', message: 'not mine', recoverable: true });
 
     expect(screen.queryByTestId('media-player-error')).toBeNull();
   });
 
   it('reports a playback failure the pipe never named', async () => {
-    const engine = fakeEngine();
-    renderBrowser(engine);
-    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+    await playAudio();
 
-    openRowMenu('song.mp3');
-    chooseMenuItem('preview');
-    fireEvent.error(await screen.findByTestId('media-player-audio'));
+    fireEvent.error(screen.getByTestId('media-player-audio'));
 
     expect(screen.getByTestId('media-player-error').textContent).toBe('playback failed');
     expect(screen.queryByTestId('media-player-retry')).toBeNull();

--- a/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
@@ -742,11 +742,14 @@ describe('the vault browser read path over the streaming pipe', () => {
   const revoked: string[] = [];
   const clicked: { href: string | null; download: string }[] = [];
   const originalClick = HTMLAnchorElement.prototype.click;
+  /** Whether the browser opens the save the ticket was minted for. */
+  let fetched = true;
 
   beforeEach(() => {
     minted.length = 0;
     revoked.length = 0;
     clicked.length = 0;
+    fetched = true;
     mediaControl.create = () =>
       ({
         streaming: true,
@@ -756,7 +759,7 @@ describe('the vault browser read path over the streaming pipe', () => {
           minted.push(source);
           return `/stream/ticket-${minted.length}`;
         },
-        whenStreamIdle: () => Promise.resolve(),
+        whenStreamIdle: () => Promise.resolve(fetched),
         revokeStreamUrl: (url: string) => {
           revoked.push(url);
           return true;
@@ -786,6 +789,42 @@ describe('the vault browser read path over the streaming pipe', () => {
     expect(engine.facade.download).not.toHaveBeenCalled();
     expect(minted).toEqual([{ node: NOTE, size: 12, mimeType: 'application/octet-stream' }]);
     expect(clicked).toEqual([{ href: '/stream/ticket-1', download: 'notes.txt' }]);
+    // The ticket serves plaintext to anything same-origin that can name it, so
+    // it dies with the transfer rather than with the view.
+    await waitFor(() => expect(revoked).toEqual(['/stream/ticket-1']));
+  });
+
+  const twoFiles = () =>
+    folderView({ children: [file(NOTE, 'notes.txt'), file(PICTURE, 'shot.png')] });
+
+  it('saves a selection one ticket at a time', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, twoFiles());
+
+    fireEvent.click(screen.getByTestId('select-all'));
+    fireEvent.click(screen.getByTestId('selection-download'));
+
+    await waitFor(() => expect(minted).toHaveLength(2));
+    expect(revoked).toEqual(['/stream/ticket-1', '/stream/ticket-2']);
+  });
+
+  it('stops a batch at the first save the browser refuses', async () => {
+    const engine = fakeEngine();
+    fetched = false;
+    renderBrowser(engine);
+    await landSnapshot(engine, twoFiles());
+
+    fireEvent.click(screen.getByTestId('select-all'));
+    fireEvent.click(screen.getByTestId('selection-download'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('vault-action-error').textContent).toBe(
+        'the browser did not start the download'
+      )
+    );
+    // Grinding through the rest would burn the start deadline once per file.
+    expect(minted).toHaveLength(1);
   });
 
   it('buffers a save whose size the engine has not projected', async () => {

--- a/apps/web/src/components/file-browser/FileBrowserActions.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.tsx
@@ -88,8 +88,11 @@ export function FileBrowserActions({
   const downloadSelection = async (): Promise<void> => {
     setDownloading(true);
     try {
+      // One save at a time, and none after a refusal: a browser that blocks the
+      // second download blocks every one after it.
       for (const row of selection.rows) {
-        if (row.kind === 'file') await downloads.save(row.id, row.name, row.bytes);
+        if (row.kind !== 'file') continue;
+        if (!(await downloads.save(row.id, row.name, row.bytes))) break;
       }
     } finally {
       setDownloading(false);

--- a/apps/web/src/components/file-browser/FilePreviewDialog.tsx
+++ b/apps/web/src/components/file-browser/FilePreviewDialog.tsx
@@ -1,6 +1,7 @@
 import { useFilePreview, type FilePreview } from '../../hooks/useFilePreview';
 import type { ListingRow } from '../../vault/listing';
 import { Modal } from '../ui/Modal';
+import { MediaPlayer } from './MediaPlayer';
 
 interface FilePreviewDialogProps {
   row: ListingRow;
@@ -44,6 +45,9 @@ function PreviewContent({ preview, name }: { preview: FilePreview; name: string 
         {preview.message}
       </p>
     );
+  }
+  if (preview.status === 'audio' || preview.status === 'video') {
+    return <MediaPlayer url={preview.url} kind={preview.status} name={name} />;
   }
   if (preview.status === 'image') {
     return (

--- a/apps/web/src/components/file-browser/MediaPlayer.tsx
+++ b/apps/web/src/components/file-browser/MediaPlayer.tsx
@@ -1,0 +1,86 @@
+/**
+ * Playback over a stream ticket. A body the pipe errors reaches the element as
+ * an untyped network failure, so the reason comes from the engine code the
+ * media service reports, not from the element's own `error` event.
+ */
+
+import { useEffect, useState } from 'react';
+import type { MediaStreamFailure } from '@cipherbox/client';
+import { useMediaService } from '../../providers/EngineProvider';
+
+interface MediaPlayerProps {
+  url: string;
+  kind: 'audio' | 'video';
+  name: string;
+}
+
+/**
+ * What the player has to say about a stream that stopped. `recoverable` is a
+ * ceiling the engine expects a later read to clear, so it carries a retry.
+ */
+type Refusal = { kind: 'recoverable' | 'fault'; message: string };
+
+const CEILING_NOTICE = 'too many streams are open right now';
+
+const FAULT_NOTICE = 'playback failed';
+
+export function MediaPlayer({ url, kind, name }: MediaPlayerProps) {
+  const media = useMediaService();
+  const [refusal, setRefusal] = useState<Refusal | null>(null);
+  // A retry remounts the element rather than reusing one the browser has given
+  // up on. The ticket is still live: the pipe refused a read, it did not
+  // withdraw the capability.
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    if (media === null) return;
+    return media.onStreamError((failure: MediaStreamFailure) => {
+      if (failure.url !== url) return;
+      setRefusal(
+        failure.recoverable
+          ? { kind: 'recoverable', message: CEILING_NOTICE }
+          : { kind: 'fault', message: failure.message }
+      );
+    });
+  }, [media, url]);
+
+  const props = {
+    className: `media-player-${kind}`,
+    src: url,
+    controls: true,
+    preload: 'metadata' as const,
+    'aria-label': name,
+    'data-testid': `media-player-${kind}`,
+    // The element reports a failure the pipe never named — an unsupported
+    // container, a decode refusal — with no code to classify it by.
+    onError: () => setRefusal((held) => held ?? { kind: 'fault', message: FAULT_NOTICE }),
+  };
+
+  return (
+    <div className="media-player" data-testid="media-player">
+      {kind === 'video' ? <video key={attempt} {...props} /> : <audio key={attempt} {...props} />}
+      {refusal !== null && (
+        <p
+          className={`media-player-notice media-player-notice--${refusal.kind}`}
+          role="alert"
+          data-testid="media-player-error"
+        >
+          {refusal.message}
+          {refusal.kind === 'recoverable' && (
+            <button
+              type="button"
+              className="dialog-button"
+              onClick={() => {
+                setRefusal(null);
+                setAttempt((run) => run + 1);
+              }}
+              data-testid="media-player-retry"
+            >
+              retry
+            </button>
+          )}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/file-browser/MediaPlayer.tsx
+++ b/apps/web/src/components/file-browser/MediaPlayer.tsx
@@ -1,9 +1,3 @@
-/**
- * Playback over a stream ticket. A body the pipe errors reaches the element as
- * an untyped network failure, so the reason comes from the engine code the
- * media service reports, not from the element's own `error` event.
- */
-
 import { useEffect, useState } from 'react';
 import type { MediaStreamFailure } from '@cipherbox/client';
 import { useMediaService } from '../../providers/EngineProvider';
@@ -14,33 +8,27 @@ interface MediaPlayerProps {
   name: string;
 }
 
-/**
- * What the player has to say about a stream that stopped. `recoverable` is a
- * ceiling the engine expects a later read to clear, so it carries a retry.
- */
-type Refusal = { kind: 'recoverable' | 'fault'; message: string };
+type Refusal = { recoverable: boolean; message: string };
 
 const CEILING_NOTICE = 'too many streams are open right now';
 
 const FAULT_NOTICE = 'playback failed';
 
+/** Playback over a stream ticket, with what stopped it when something does. */
 export function MediaPlayer({ url, kind, name }: MediaPlayerProps) {
   const media = useMediaService();
   const [refusal, setRefusal] = useState<Refusal | null>(null);
-  // A retry remounts the element rather than reusing one the browser has given
-  // up on. The ticket is still live: the pipe refused a read, it did not
-  // withdraw the capability.
+  // The browser will not re-read a src it has given up on; only a remount will.
   const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
     if (media === null) return;
     return media.onStreamError((failure: MediaStreamFailure) => {
       if (failure.url !== url) return;
-      setRefusal(
-        failure.recoverable
-          ? { kind: 'recoverable', message: CEILING_NOTICE }
-          : { kind: 'fault', message: failure.message }
-      );
+      setRefusal({
+        recoverable: failure.recoverable,
+        message: failure.recoverable ? CEILING_NOTICE : failure.message,
+      });
     });
   }, [media, url]);
 
@@ -51,34 +39,36 @@ export function MediaPlayer({ url, kind, name }: MediaPlayerProps) {
     preload: 'metadata' as const,
     'aria-label': name,
     'data-testid': `media-player-${kind}`,
-    // The element reports a failure the pipe never named — an unsupported
-    // container, a decode refusal — with no code to classify it by.
-    onError: () => setRefusal((held) => held ?? { kind: 'fault', message: FAULT_NOTICE }),
+    // A named reason from the pipe outranks the element's unclassifiable one.
+    onError: () => setRefusal((held) => held ?? { recoverable: false, message: FAULT_NOTICE }),
   };
 
   return (
     <div className="media-player" data-testid="media-player">
       {kind === 'video' ? <video key={attempt} {...props} /> : <audio key={attempt} {...props} />}
-      {refusal !== null && (
+      {refusal?.recoverable === true && (
+        <div className="file-browser-notice" role="status" data-testid="media-player-error">
+          <span className="file-browser-notice-message">{refusal.message}</span>
+          <button
+            type="button"
+            className="file-browser-notice-retry"
+            onClick={() => {
+              setRefusal(null);
+              setAttempt((run) => run + 1);
+            }}
+            data-testid="media-player-retry"
+          >
+            [retry]
+          </button>
+        </div>
+      )}
+      {refusal?.recoverable === false && (
         <p
-          className={`media-player-notice media-player-notice--${refusal.kind}`}
+          className="preview-status preview-status--error"
           role="alert"
           data-testid="media-player-error"
         >
           {refusal.message}
-          {refusal.kind === 'recoverable' && (
-            <button
-              type="button"
-              className="dialog-button"
-              onClick={() => {
-                setRefusal(null);
-                setAttempt((run) => run + 1);
-              }}
-              data-testid="media-player-retry"
-            >
-              retry
-            </button>
-          )}
         </p>
       )}
     </div>

--- a/apps/web/src/components/file-browser/MediaPlayer.tsx
+++ b/apps/web/src/components/file-browser/MediaPlayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import type { MediaStreamFailure } from '@cipherbox/client';
 import { useMediaService } from '../../providers/EngineProvider';
 
@@ -21,7 +21,9 @@ export function MediaPlayer({ url, kind, name }: MediaPlayerProps) {
   // The browser will not re-read a src it has given up on; only a remount will.
   const [attempt, setAttempt] = useState(0);
 
-  useEffect(() => {
+  // Subscribed in the commit that mounts the element: the pipe replays nothing,
+  // so a refusal reported before this runs is lost.
+  useLayoutEffect(() => {
     if (media === null) return;
     return media.onStreamError((failure: MediaStreamFailure) => {
       if (failure.url !== url) return;

--- a/apps/web/src/hooks/useFileDownload.test.ts
+++ b/apps/web/src/hooks/useFileDownload.test.ts
@@ -20,7 +20,7 @@ const NODE = new Uint8Array(16).fill(3);
 function fakePipe() {
   const live = new Set<string>();
   const minted: string[] = [];
-  const waiting = new Map<string, () => void>();
+  const waiting = new Map<string, (read: boolean) => void>();
 
   const service = {
     streaming: true,
@@ -33,7 +33,7 @@ function fakePipe() {
       return url;
     },
     whenStreamIdle: (url: string) =>
-      new Promise<void>((resolve) => {
+      new Promise<boolean>((resolve) => {
         waiting.set(url, resolve);
       }),
     revokeStreamUrl: (url: string) => live.delete(url),
@@ -43,10 +43,10 @@ function fakePipe() {
     service,
     live,
     minted,
-    /** The browser finished — or gave up on — the transfer for this ticket. */
-    finish: async (url: string): Promise<void> => {
+    /** The transfer for this ticket ended, or the browser never began it. */
+    finish: async (url: string, read = true): Promise<void> => {
       await act(async () => {
-        waiting.get(url)?.();
+        waiting.get(url)?.(read);
         await Promise.resolve();
       });
     },
@@ -95,10 +95,10 @@ describe('bounding the tickets a streamed save leaves live', () => {
     mediaControl.create = () => pipe.service;
     const { result } = mount(fakeEngine());
 
-    let saved = false;
+    let saved: boolean | null = null;
     await act(async () => {
-      void result.current.save(NODE, 'notes.txt', 12n).then(() => {
-        saved = true;
+      void result.current.save(NODE, 'notes.txt', 12n).then((ok) => {
+        saved = ok;
       });
       await Promise.resolve();
     });
@@ -106,12 +106,31 @@ describe('bounding the tickets a streamed save leaves live', () => {
     // Revoking before the browser has read the bytes cancels the save.
     expect(clicked).toEqual(['/stream/ticket-1']);
     expect([...pipe.live]).toEqual(['/stream/ticket-1']);
-    expect(saved).toBe(false);
+    expect(saved).toBeNull();
 
     await pipe.finish('/stream/ticket-1');
 
     await waitFor(() => expect(saved).toBe(true));
     expect([...pipe.live]).toEqual([]);
+  });
+
+  it('reports a save the browser never fetched, and says so', async () => {
+    const pipe = fakePipe();
+    mediaControl.create = () => pipe.service;
+    const { result } = mount(fakeEngine());
+
+    let saved: boolean | null = null;
+    await act(async () => {
+      void result.current.save(NODE, 'notes.txt', 12n).then((ok) => {
+        saved = ok;
+      });
+      await Promise.resolve();
+    });
+    await pipe.finish('/stream/ticket-1', false);
+
+    await waitFor(() => expect(saved).toBe(false));
+    expect(pipe.live.size).toBe(0);
+    expect(result.current.error).toBe('the browser did not start the download');
   });
 
   it('leaves one live ticket however many files a caller saves in a loop', async () => {

--- a/apps/web/src/hooks/useFileDownload.test.ts
+++ b/apps/web/src/hooks/useFileDownload.test.ts
@@ -203,7 +203,7 @@ describe('the buffered fallback', () => {
     const revoked: string[] = [];
     URL.createObjectURL = vi.fn(() => `blob:fake/${++minted}`);
     URL.revokeObjectURL = vi.fn((url: string) => revoked.push(url));
-    const { result } = mount(fakeEngine(() => Promise.resolve(new ArrayBuffer(4))));
+    const { result, unmount } = mount(fakeEngine(() => Promise.resolve(new ArrayBuffer(4))));
 
     vi.useFakeTimers();
     try {
@@ -215,7 +215,15 @@ describe('the buffered fallback', () => {
       expect(revoked).toEqual([]);
 
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(60_000);
+        await vi.advanceTimersByTimeAsync(999);
+      });
+      expect(revoked).toEqual([]);
+
+      unmount();
+      expect(revoked).toEqual([]);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
       });
       expect(revoked).toEqual(['blob:fake/1', 'blob:fake/2']);
     } finally {

--- a/apps/web/src/hooks/useFileDownload.test.ts
+++ b/apps/web/src/hooks/useFileDownload.test.ts
@@ -1,0 +1,206 @@
+import { createElement, type ReactNode } from 'react';
+import type { EngineClient, MediaService } from '@cipherbox/client';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EngineProvider } from '../providers/EngineProvider';
+import { useFileDownload } from './useFileDownload';
+
+/** The pipe this tab gets; `null` is the browser without a Service Worker. */
+const mediaControl = { create: (): MediaService | null => null };
+vi.mock('../engine/createMediaService', () => ({
+  createMediaService: () => mediaControl.create(),
+}));
+
+const NODE = new Uint8Array(16).fill(3);
+
+/**
+ * A pipe whose tickets only go idle when the test says so, which is what a
+ * transfer still in flight looks like to the hook.
+ */
+function fakePipe() {
+  const live = new Set<string>();
+  const minted: string[] = [];
+  const waiting = new Map<string, () => void>();
+
+  const service = {
+    streaming: true,
+    start: () => Promise.resolve(),
+    dispose: () => Promise.resolve(),
+    createStreamUrl: () => {
+      const url = `/stream/ticket-${minted.length + 1}`;
+      minted.push(url);
+      live.add(url);
+      return url;
+    },
+    whenStreamIdle: (url: string) =>
+      new Promise<void>((resolve) => {
+        waiting.set(url, resolve);
+      }),
+    revokeStreamUrl: (url: string) => live.delete(url),
+  } as unknown as MediaService;
+
+  return {
+    service,
+    live,
+    minted,
+    /** The browser finished — or gave up on — the transfer for this ticket. */
+    finish: async (url: string): Promise<void> => {
+      await act(async () => {
+        waiting.get(url)?.();
+        await Promise.resolve();
+      });
+    },
+  };
+}
+
+function fakeEngine(
+  download: () => Promise<ArrayBuffer> = () => Promise.resolve(new ArrayBuffer(0))
+) {
+  return {
+    facade: {
+      subscribe: () => () => undefined,
+      snapshot: () => new Promise<never>(() => undefined),
+      setFocus: () => Promise.resolve(),
+      download: vi.fn(download),
+    },
+    reportFocus: () => undefined,
+    dispose: () => Promise.resolve(),
+  } as unknown as EngineClient;
+}
+
+function mount(client: EngineClient) {
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(EngineProvider, { createClient: () => client, children });
+  return renderHook(() => useFileDownload(), { wrapper });
+}
+
+const clicked: string[] = [];
+const originalClick = HTMLAnchorElement.prototype.click;
+
+beforeEach(() => {
+  clicked.length = 0;
+  HTMLAnchorElement.prototype.click = function click(this: HTMLAnchorElement) {
+    clicked.push(this.getAttribute('href') ?? '');
+  };
+});
+
+afterEach(() => {
+  HTMLAnchorElement.prototype.click = originalClick;
+  mediaControl.create = () => null;
+});
+
+describe('bounding the tickets a streamed save leaves live', () => {
+  it('holds the ticket for the whole transfer and drops it the moment it ends', async () => {
+    const pipe = fakePipe();
+    mediaControl.create = () => pipe.service;
+    const { result } = mount(fakeEngine());
+
+    let saved = false;
+    await act(async () => {
+      void result.current.save(NODE, 'notes.txt', 12n).then(() => {
+        saved = true;
+      });
+      await Promise.resolve();
+    });
+
+    // Revoking before the browser has read the bytes cancels the save.
+    expect(clicked).toEqual(['/stream/ticket-1']);
+    expect([...pipe.live]).toEqual(['/stream/ticket-1']);
+    expect(saved).toBe(false);
+
+    await pipe.finish('/stream/ticket-1');
+
+    await waitFor(() => expect(saved).toBe(true));
+    expect([...pipe.live]).toEqual([]);
+  });
+
+  it('leaves one live ticket however many files a caller saves in a loop', async () => {
+    const pipe = fakePipe();
+    mediaControl.create = () => pipe.service;
+    const { result } = mount(fakeEngine());
+
+    const names = ['a.bin', 'b.bin', 'c.bin', 'd.bin', 'e.bin'];
+    let done = false;
+    await act(async () => {
+      void (async () => {
+        for (const name of names) await result.current.save(NODE, name, 12n);
+        done = true;
+      })();
+      await Promise.resolve();
+    });
+
+    for (let file = 1; file <= names.length; file += 1) {
+      expect(pipe.live.size).toBe(1);
+      expect(pipe.minted).toHaveLength(file);
+      await pipe.finish(`/stream/ticket-${file}`);
+    }
+
+    await waitFor(() => expect(done).toBe(true));
+    expect(pipe.live.size).toBe(0);
+  });
+
+  it('revokes a transfer still running when the tab drops the hook', async () => {
+    const pipe = fakePipe();
+    mediaControl.create = () => pipe.service;
+    const { result, unmount } = mount(fakeEngine());
+
+    await act(async () => {
+      void result.current.save(NODE, 'notes.txt', 12n);
+      await Promise.resolve();
+    });
+    expect(pipe.live.size).toBe(1);
+
+    unmount();
+    expect(pipe.live.size).toBe(0);
+  });
+});
+
+describe('the buffered fallback', () => {
+  const originalCreate = URL.createObjectURL;
+  const originalRevoke = URL.revokeObjectURL;
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreate;
+    URL.revokeObjectURL = originalRevoke;
+  });
+
+  it('reads through the facade and reports a refusal instead of saving', async () => {
+    const engine = fakeEngine(() => Promise.reject(new Error('the record is gone')));
+    const { result } = mount(engine);
+
+    await act(async () => {
+      await result.current.save(NODE, 'notes.txt', 12n);
+    });
+
+    expect(clicked).toEqual([]);
+    expect(result.current.error).toBe('the record is gone');
+
+    act(() => result.current.clearError());
+    expect(result.current.error).toBeNull();
+  });
+
+  it('revokes each blob url on its own timer rather than at unmount', async () => {
+    let minted = 0;
+    const revoked: string[] = [];
+    URL.createObjectURL = vi.fn(() => `blob:fake/${++minted}`);
+    URL.revokeObjectURL = vi.fn((url: string) => revoked.push(url));
+    const { result } = mount(fakeEngine(() => Promise.resolve(new ArrayBuffer(4))));
+
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        await result.current.save(NODE, 'a.bin', null);
+        await result.current.save(NODE, 'b.bin', null);
+      });
+      expect(clicked).toEqual(['blob:fake/1', 'blob:fake/2']);
+      expect(revoked).toEqual([]);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(revoked).toEqual(['blob:fake/1', 'blob:fake/2']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/hooks/useFileDownload.ts
+++ b/apps/web/src/hooks/useFileDownload.ts
@@ -19,9 +19,21 @@ const OPAQUE = 'application/octet-stream';
  */
 const REVOKE_AFTER_MS = 1_000;
 
+/**
+ * How long a ticket may go without delivering a window before its transfer
+ * counts as over. A stalled read fails at the pipe's own pull deadline well
+ * before this, so it only ever catches a save the browser never began.
+ */
+const STREAM_STALL_MS = 45_000;
+
 export interface FileDownload {
   error: string | null;
-  /** @param size the engine's byte count; `null` forces the buffered read. */
+  /**
+   * Resolves when the file's bytes have stopped moving, so a caller saving a
+   * selection can serialize on it.
+   *
+   * @param size the engine's byte count; `null` forces the buffered read.
+   */
   save(node: Uint8Array, name: string, size: bigint | null): Promise<void>;
   /** Drops a failure the user has moved on from. */
   clearError(): void;
@@ -31,14 +43,15 @@ export function useFileDownload(): FileDownload {
   const client = useEngine();
   const media = useMediaService();
   const [error, setError] = useState<string | null>(null);
-  const tickets = useRef<string[]>([]);
+  const tickets = useRef(new Set<string>());
 
-  // A streamed save reads for as long as the transfer lasts, so its ticket
-  // cannot be dropped on a timer the way a fully materialized blob URL can.
+  // Only a save still transferring at unmount reaches here; every other ticket
+  // is dropped by the save that minted it.
   useEffect(() => {
     const held = tickets.current;
     return () => {
-      for (const url of held.splice(0)) media?.revokeStreamUrl(url);
+      for (const url of [...held]) media?.revokeStreamUrl(url);
+      held.clear();
     };
   }, [media]);
 
@@ -52,8 +65,16 @@ export function useFileDownload(): FileDownload {
 
       const ticket = streamTicket(media, node, size, OPAQUE);
       if (ticket !== null) {
-        tickets.current.push(ticket);
+        tickets.current.add(ticket);
         saveToDisk(ticket, name);
+        // Resolving only when the bytes stop is what bounds the live set: a
+        // caller looping over a selection holds one ticket, not one per file.
+        try {
+          await media?.whenStreamIdle(ticket, STREAM_STALL_MS);
+        } finally {
+          tickets.current.delete(ticket);
+          media?.revokeStreamUrl(ticket);
+        }
         return;
       }
 

--- a/apps/web/src/hooks/useFileDownload.ts
+++ b/apps/web/src/hooks/useFileDownload.ts
@@ -19,22 +19,21 @@ const OPAQUE = 'application/octet-stream';
  */
 const REVOKE_AFTER_MS = 1_000;
 
-/**
- * How long a ticket may go without delivering a window before its transfer
- * counts as over. A stalled read fails at the pipe's own pull deadline well
- * before this, so it only ever catches a save the browser never began.
- */
-const STREAM_STALL_MS = 45_000;
+/** How long a minted ticket waits for the browser to open the save it triggered. */
+const STREAM_START_MS = 30_000;
+
+const NEVER_FETCHED = 'the browser did not start the download';
 
 export interface FileDownload {
   error: string | null;
   /**
-   * Resolves when the file's bytes have stopped moving, so a caller saving a
-   * selection can serialize on it.
+   * Resolves once the file's bytes have stopped moving, with whether it reached
+   * the browser at all — false is a refusal, and a caller working through a
+   * selection should stop rather than repeat it per file.
    *
    * @param size the engine's byte count; `null` forces the buffered read.
    */
-  save(node: Uint8Array, name: string, size: bigint | null): Promise<void>;
+  save(node: Uint8Array, name: string, size: bigint | null): Promise<boolean>;
   /** Drops a failure the user has moved on from. */
   clearError(): void;
 }
@@ -45,37 +44,38 @@ export function useFileDownload(): FileDownload {
   const [error, setError] = useState<string | null>(null);
   const tickets = useRef(new Set<string>());
 
-  // Only a save still transferring at unmount reaches here; every other ticket
-  // is dropped by the save that minted it.
+  // Unmount cuts a transfer that is still running, and its ticket has no timer
+  // of its own to fall back on.
   useEffect(() => {
     const held = tickets.current;
     return () => {
-      for (const url of [...held]) media?.revokeStreamUrl(url);
+      for (const url of held) media?.revokeStreamUrl(url);
       held.clear();
     };
   }, [media]);
 
   const save = useCallback(
-    async (node: Uint8Array, name: string, size: bigint | null): Promise<void> => {
+    async (node: Uint8Array, name: string, size: bigint | null): Promise<boolean> => {
       if (client === null) {
         setError('the engine is not ready yet');
-        return;
+        return false;
       }
       setError(null);
 
-      const ticket = streamTicket(media, node, size, OPAQUE);
-      if (ticket !== null) {
-        tickets.current.add(ticket);
-        saveToDisk(ticket, name);
-        // Resolving only when the bytes stop is what bounds the live set: a
-        // caller looping over a selection holds one ticket, not one per file.
-        try {
-          await media?.whenStreamIdle(ticket, STREAM_STALL_MS);
-        } finally {
-          tickets.current.delete(ticket);
-          media?.revokeStreamUrl(ticket);
+      if (media !== null) {
+        const ticket = streamTicket(media, node, size, OPAQUE);
+        if (ticket !== null) {
+          tickets.current.add(ticket);
+          saveToDisk(ticket, name);
+          try {
+            const read = await media.whenStreamIdle(ticket, STREAM_START_MS);
+            if (!read) setError(NEVER_FETCHED);
+            return read;
+          } finally {
+            tickets.current.delete(ticket);
+            media.revokeStreamUrl(ticket);
+          }
         }
-        return;
       }
 
       try {
@@ -83,8 +83,10 @@ export function useFileDownload(): FileDownload {
         const url = URL.createObjectURL(new Blob([bytes], { type: OPAQUE }));
         saveToDisk(url, name);
         setTimeout(() => URL.revokeObjectURL(url), REVOKE_AFTER_MS);
+        return true;
       } catch (failure: unknown) {
         setError(errorMessage(failure));
+        return false;
       }
     },
     [client, media]

--- a/apps/web/src/hooks/useFilePreview.ts
+++ b/apps/web/src/hooks/useFilePreview.ts
@@ -1,8 +1,8 @@
 /**
- * One file's plaintext, held only while its preview is on screen. An image is
- * pulled range by range through the Service Worker byte pipe, so nothing of it
- * is held in the tab; the shapes that must be decoded whole read through the
- * facade under a byte budget, and every URL is dropped on close.
+ * One file's plaintext, held only while its preview is on screen. Playback and
+ * images are pulled range by range through the Service Worker byte pipe, so
+ * nothing of them is held in the tab; the shapes that must be decoded whole read
+ * through the facade under a byte budget, and every URL is dropped on close.
  */
 
 import { useEffect, useState } from 'react';
@@ -10,19 +10,24 @@ import { fromHex } from '@cipherbox/client';
 import { errorMessage } from '../lib/errorMessage';
 import { streamTicket } from '../lib/streamTicket';
 import { useEngine, useMediaService } from '../providers/EngineProvider';
-import { previewKind, previewMime, type PreviewKind } from '../vault/previewKind';
+import { previewKind, previewMime } from '../vault/previewKind';
 
 /** What a preview may pull into the tab: a memory ceiling, and a decode budget. */
 const MAX_BUFFERED_BYTES = 32n * 1024n * 1024n;
 
 const TOO_LARGE = 'too large to preview - download it instead';
 
+const NEEDS_PIPE = 'playback needs the streaming pipe - download it instead';
+
 export type FilePreview =
   | { status: 'loading' }
   | { status: 'error'; message: string }
   | { status: 'image'; url: string }
   | { status: 'pdf'; url: string }
-  | { status: 'text'; text: string };
+  | { status: 'text'; text: string }
+  /** A ticket URL the player reads range by range; never a buffered blob. */
+  | { status: 'audio'; url: string }
+  | { status: 'video'; url: string };
 
 /**
  * @param key the file's node id as lowercase hex, so the read keys on a value
@@ -52,8 +57,22 @@ export function useFilePreview(key: string, name: string, size: bigint | null): 
     }
 
     const node = fromHex(key);
-    // The pipe declares media types only, and an image is the one preview shape
-    // that is one (packages/client/src/media/range.ts `safeMimeType`).
+    // Playback is a seek-driven ranged read; buffering the whole file into the
+    // tab is exactly what the pipe exists to avoid, so there is no fallback.
+    if (kind === 'audio' || kind === 'video') {
+      const ticket = streamTicket(media, node, size, previewMime(name));
+      if (ticket === null) {
+        setPreview({ status: 'error', message: NEEDS_PIPE });
+        return;
+      }
+      setPreview({ status: kind, url: ticket });
+      return () => {
+        media?.revokeStreamUrl(ticket);
+      };
+    }
+
+    // The pipe declares media types only, and an image is the one buffered
+    // preview shape that is one (packages/client/src/media/range.ts `safeMimeType`).
     if (kind === 'image') {
       const ticket = streamTicket(media, node, size, previewMime(name));
       if (ticket !== null) {
@@ -99,7 +118,7 @@ export function useFilePreview(key: string, name: string, size: bigint | null): 
   return preview;
 }
 
-function render(kind: Exclude<PreviewKind, 'none'>, bytes: ArrayBuffer, name: string): FilePreview {
+function render(kind: 'image' | 'pdf' | 'text', bytes: ArrayBuffer, name: string): FilePreview {
   if (kind === 'text') {
     try {
       return { status: 'text', text: new TextDecoder('utf-8', { fatal: true }).decode(bytes) };

--- a/apps/web/src/hooks/useFilePreview.ts
+++ b/apps/web/src/hooks/useFilePreview.ts
@@ -25,7 +25,6 @@ export type FilePreview =
   | { status: 'image'; url: string }
   | { status: 'pdf'; url: string }
   | { status: 'text'; text: string }
-  /** A ticket URL the player reads range by range; never a buffered blob. */
   | { status: 'audio'; url: string }
   | { status: 'video'; url: string };
 
@@ -57,29 +56,21 @@ export function useFilePreview(key: string, name: string, size: bigint | null): 
     }
 
     const node = fromHex(key);
-    // Playback is a seek-driven ranged read; buffering the whole file into the
-    // tab is exactly what the pipe exists to avoid, so there is no fallback.
-    if (kind === 'audio' || kind === 'video') {
-      const ticket = streamTicket(media, node, size, previewMime(name));
-      if (ticket === null) {
-        setPreview({ status: 'error', message: NEEDS_PIPE });
-        return;
-      }
-      setPreview({ status: kind, url: ticket });
-      return () => {
-        media?.revokeStreamUrl(ticket);
-      };
-    }
-
-    // The pipe declares media types only, and an image is the one buffered
-    // preview shape that is one (packages/client/src/media/range.ts `safeMimeType`).
-    if (kind === 'image') {
+    // The pipe declares media types only, so these are the shapes it can serve
+    // (packages/client/src/media/range.ts `safeMimeType`).
+    if (kind === 'image' || kind === 'audio' || kind === 'video') {
       const ticket = streamTicket(media, node, size, previewMime(name));
       if (ticket !== null) {
-        setPreview({ status: 'image', url: ticket });
+        setPreview({ status: kind, url: ticket });
         return () => {
           media?.revokeStreamUrl(ticket);
         };
+      }
+      // Playback is a seek-driven ranged read; only an image is small enough to
+      // fall back to a buffered one.
+      if (kind !== 'image') {
+        setPreview({ status: 'error', message: NEEDS_PIPE });
+        return;
       }
     }
 

--- a/apps/web/src/styles/dialogs.css
+++ b/apps/web/src/styles/dialogs.css
@@ -306,6 +306,41 @@
   object-fit: contain;
 }
 
+.media-player {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  width: 100%;
+  align-items: center;
+}
+
+.media-player-video {
+  max-width: 100%;
+  max-height: 60vh;
+  background-color: var(--color-background);
+}
+
+.media-player-audio {
+  width: 100%;
+}
+
+.media-player-notice {
+  display: flex;
+  gap: var(--spacing-xs);
+  align-items: center;
+  margin: 0;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+}
+
+.media-player-notice--recoverable {
+  color: var(--color-text-secondary);
+}
+
+.media-player-notice--fault {
+  color: var(--color-error);
+}
+
 .preview-pdf {
   width: 100%;
   height: 60vh;

--- a/apps/web/src/styles/dialogs.css
+++ b/apps/web/src/styles/dialogs.css
@@ -324,23 +324,6 @@
   width: 100%;
 }
 
-.media-player-notice {
-  display: flex;
-  gap: var(--spacing-xs);
-  align-items: center;
-  margin: 0;
-  font-family: var(--font-family-mono);
-  font-size: var(--font-size-sm);
-}
-
-.media-player-notice--recoverable {
-  color: var(--color-text-secondary);
-}
-
-.media-player-notice--fault {
-  color: var(--color-error);
-}
-
 .preview-pdf {
   width: 100%;
   height: 60vh;

--- a/apps/web/src/vault/previewKind.ts
+++ b/apps/web/src/vault/previewKind.ts
@@ -5,7 +5,7 @@
  * document (a blob URL inherits this origin).
  */
 
-export type PreviewKind = 'image' | 'pdf' | 'text' | 'none';
+export type PreviewKind = 'image' | 'pdf' | 'text' | 'audio' | 'video' | 'none';
 
 /** Blobs the preview builds are typed from here, so nothing else can be. */
 const PREVIEWABLE: Record<string, { kind: PreviewKind; mime: string }> = {
@@ -17,6 +17,15 @@ const PREVIEWABLE: Record<string, { kind: PreviewKind; mime: string }> = {
   bmp: { kind: 'image', mime: 'image/bmp' },
   avif: { kind: 'image', mime: 'image/avif' },
   pdf: { kind: 'pdf', mime: 'application/pdf' },
+  mp4: { kind: 'video', mime: 'video/mp4' },
+  m4v: { kind: 'video', mime: 'video/mp4' },
+  webm: { kind: 'video', mime: 'video/webm' },
+  ogv: { kind: 'video', mime: 'video/ogg' },
+  mp3: { kind: 'audio', mime: 'audio/mpeg' },
+  m4a: { kind: 'audio', mime: 'audio/mp4' },
+  wav: { kind: 'audio', mime: 'audio/wav' },
+  flac: { kind: 'audio', mime: 'audio/flac' },
+  oga: { kind: 'audio', mime: 'audio/ogg' },
   txt: { kind: 'text', mime: 'text/plain' },
   md: { kind: 'text', mime: 'text/plain' },
   json: { kind: 'text', mime: 'text/plain' },

--- a/packages/client/src/correlatedTransport.ts
+++ b/packages/client/src/correlatedTransport.ts
@@ -76,7 +76,7 @@ export function unknownHandle(kind: HandleKind): EngineRequestError {
  * Delivers one event to every listener, isolating a throwing subscriber so it
  * cannot drop the event for the rest.
  */
-export function fanOut(listeners: Iterable<EngineEventListener>, event: EventDescriptor): void {
+export function fanOut<TEvent>(listeners: Iterable<(event: TEvent) => void>, event: TEvent): void {
   for (const listener of listeners) {
     try {
       listener(event);

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -36,6 +36,7 @@ export type { PortCourier, MessagePortLike } from './portRelay.js';
 
 // The tab side of the Service Worker byte pipe.
 export { MediaService } from './media/service.js';
+export type { MediaStreamFailure } from './media/service.js';
 export type { MediaReader } from './media/broker.js';
 
 // The one hex codec in TypeScript, for hosts that receive hex-encoded bytes

--- a/packages/client/src/media/broker.test.ts
+++ b/packages/client/src/media/broker.test.ts
@@ -563,79 +563,71 @@ describe('MediaBroker', () => {
 
 describe('MediaBroker.whenIdle', () => {
   /** Records the settlement without awaiting it, so pending can be asserted. */
-  function watch(promise: Promise<void>): () => boolean {
-    let done = false;
-    void promise.then(() => {
-      done = true;
+  function watch(promise: Promise<boolean>): () => boolean | null {
+    let outcome: boolean | null = null;
+    void promise.then((read) => {
+      outcome = read;
     });
-    return () => done;
+    return () => outcome;
   }
 
-  it('stays pending while a body is still reading the ticket', async () => {
-    const h = harness(20, { lingerMs: 50 });
-    const idle = watch(h.broker.whenIdle(h.ticket, 10_000));
-
+  const startRead = async (h: Harness): Promise<void> => {
     h.send({ type: 'cb:media:open', requestId: 1, ticket: h.ticket, range: null });
     await waitFor(() => h.received.length === 1, 'head');
     h.send({ type: 'cb:media:pull', requestId: 1 });
     await waitFor(() => h.received.length === 2, 'chunk');
+  };
 
-    expect(idle()).toBe(false);
+  it('never expires a ticket a body has claimed, however long it goes unread', async () => {
+    const h = harness(20, { lingerMs: 10_000 });
+    // A deadline far shorter than the gap the reader then leaves.
+    const idle = watch(h.broker.whenIdle(h.ticket, 5));
+    await startRead(h);
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(idle()).toBeNull();
   });
 
   it('resolves once the last body ends, without waiting out the pin linger', async () => {
     const h = harness(20, { lingerMs: 10_000 });
     const idle = watch(h.broker.whenIdle(h.ticket, 10_000));
-
-    h.send({ type: 'cb:media:open', requestId: 1, ticket: h.ticket, range: null });
-    await waitFor(() => h.received.length === 1, 'head');
-    h.send({ type: 'cb:media:pull', requestId: 1 });
-    await waitFor(() => h.received.length === 2, 'chunk');
-    expect(idle()).toBe(false);
+    await startRead(h);
+    expect(idle()).toBeNull();
 
     h.send({ type: 'cb:media:close', requestId: 1 });
-    await waitFor(idle, 'the ticket to go idle');
+    await waitFor(() => idle() !== null, 'the ticket to go idle');
+    expect(idle()).toBe(true);
   });
 
-  it('gives up on a ticket no body ever claims', async () => {
+  it('reports a ticket no body ever claims as unread', async () => {
     const h = harness(20);
-    await h.broker.whenIdle(h.ticket, 1);
-  });
-
-  it('re-arms the deadline for as long as windows keep arriving', async () => {
-    const h = harness(20, { lingerMs: 50 });
-    const idle = watch(h.broker.whenIdle(h.ticket, 40));
-
-    h.send({ type: 'cb:media:open', requestId: 1, ticket: h.ticket, range: null });
-    await waitFor(() => h.received.length === 1, 'head');
-    // Four windows spaced past a deadline that never re-armed would expire.
-    for (let pull = 0; pull < 4; pull += 1) {
-      await new Promise((resolve) => setTimeout(resolve, 25));
-      h.send({ type: 'cb:media:pull', requestId: 1 });
-      await waitFor(() => h.received.length === pull + 2, `chunk ${pull}`);
-      expect(idle()).toBe(false);
-    }
+    expect(await h.broker.whenIdle(h.ticket, 1)).toBe(false);
   });
 
   it('settles a waiter when the ticket is revoked out from under the read', async () => {
     const h = harness(20, { lingerMs: 10_000 });
     const idle = watch(h.broker.whenIdle(h.ticket, 10_000));
-
-    h.send({ type: 'cb:media:open', requestId: 1, ticket: h.ticket, range: null });
-    await waitFor(() => h.received.length === 1, 'head');
+    await startRead(h);
     h.broker.revoke(h.ticket);
 
-    await waitFor(idle, 'the revoked ticket to settle');
+    await waitFor(() => idle() !== null, 'the revoked ticket to settle');
+    expect(idle()).toBe(true);
   });
 
-  it('settles every waiter when the broker loses its port', async () => {
+  it('re-arms rather than settling when the port is replaced mid-save', async () => {
+    // A killed worker re-brokers and re-opens; retiring the ticket here would
+    // 404 the retry the pipe is about to make.
     const h = harness(20, { lingerMs: 10_000 });
-    const idle = watch(h.broker.whenIdle(h.ticket, 10_000));
+    const idle = watch(h.broker.whenIdle(h.ticket, 40));
 
-    h.send({ type: 'cb:media:open', requestId: 1, ticket: h.ticket, range: null });
-    await waitFor(() => h.received.length === 1, 'head');
-    h.broker.close();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const next = new MessageChannel();
+    h.broker.serve(next.port1);
+    await new Promise((resolve) => setTimeout(resolve, 25));
 
-    await waitFor(idle, 'the closed broker to settle its waiters');
+    expect(idle()).toBeNull();
+    next.port1.close();
+    next.port2.close();
   });
 });

--- a/packages/client/src/media/broker.test.ts
+++ b/packages/client/src/media/broker.test.ts
@@ -560,3 +560,82 @@ describe('MediaBroker', () => {
     next.port2.close();
   });
 });
+
+describe('MediaBroker.whenIdle', () => {
+  /** Records the settlement without awaiting it, so pending can be asserted. */
+  function watch(promise: Promise<void>): () => boolean {
+    let done = false;
+    void promise.then(() => {
+      done = true;
+    });
+    return () => done;
+  }
+
+  it('stays pending while a body is still reading the ticket', async () => {
+    const h = harness(20, { lingerMs: 50 });
+    const idle = watch(h.broker.whenIdle(h.ticket, 10_000));
+
+    h.send({ type: 'cb:media:open', requestId: 1, ticket: h.ticket, range: null });
+    await waitFor(() => h.received.length === 1, 'head');
+    h.send({ type: 'cb:media:pull', requestId: 1 });
+    await waitFor(() => h.received.length === 2, 'chunk');
+
+    expect(idle()).toBe(false);
+  });
+
+  it('resolves once the last body ends, without waiting out the pin linger', async () => {
+    const h = harness(20, { lingerMs: 10_000 });
+    const idle = watch(h.broker.whenIdle(h.ticket, 10_000));
+
+    h.send({ type: 'cb:media:open', requestId: 1, ticket: h.ticket, range: null });
+    await waitFor(() => h.received.length === 1, 'head');
+    h.send({ type: 'cb:media:pull', requestId: 1 });
+    await waitFor(() => h.received.length === 2, 'chunk');
+    expect(idle()).toBe(false);
+
+    h.send({ type: 'cb:media:close', requestId: 1 });
+    await waitFor(idle, 'the ticket to go idle');
+  });
+
+  it('gives up on a ticket no body ever claims', async () => {
+    const h = harness(20);
+    await h.broker.whenIdle(h.ticket, 1);
+  });
+
+  it('re-arms the deadline for as long as windows keep arriving', async () => {
+    const h = harness(20, { lingerMs: 50 });
+    const idle = watch(h.broker.whenIdle(h.ticket, 40));
+
+    h.send({ type: 'cb:media:open', requestId: 1, ticket: h.ticket, range: null });
+    await waitFor(() => h.received.length === 1, 'head');
+    // Four windows spaced past a deadline that never re-armed would expire.
+    for (let pull = 0; pull < 4; pull += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      h.send({ type: 'cb:media:pull', requestId: 1 });
+      await waitFor(() => h.received.length === pull + 2, `chunk ${pull}`);
+      expect(idle()).toBe(false);
+    }
+  });
+
+  it('settles a waiter when the ticket is revoked out from under the read', async () => {
+    const h = harness(20, { lingerMs: 10_000 });
+    const idle = watch(h.broker.whenIdle(h.ticket, 10_000));
+
+    h.send({ type: 'cb:media:open', requestId: 1, ticket: h.ticket, range: null });
+    await waitFor(() => h.received.length === 1, 'head');
+    h.broker.revoke(h.ticket);
+
+    await waitFor(idle, 'the revoked ticket to settle');
+  });
+
+  it('settles every waiter when the broker loses its port', async () => {
+    const h = harness(20, { lingerMs: 10_000 });
+    const idle = watch(h.broker.whenIdle(h.ticket, 10_000));
+
+    h.send({ type: 'cb:media:open', requestId: 1, ticket: h.ticket, range: null });
+    await waitFor(() => h.received.length === 1, 'head');
+    h.broker.close();
+
+    await waitFor(idle, 'the closed broker to settle its waiters');
+  });
+});

--- a/packages/client/src/media/broker.ts
+++ b/packages/client/src/media/broker.ts
@@ -21,11 +21,25 @@ export interface MediaReader {
  */
 const DEFAULT_PIN_LINGER_MS = 5000;
 
+/**
+ * A read this broker gave up on. The engine's code rides along because a
+ * ceiling refusal a later read can clear is not a fault, and a message string
+ * is not a classification.
+ */
+export interface MediaFailure {
+  readonly ticket: string;
+  /** `null` where the failure did not come from the engine. */
+  readonly code: string | null;
+  readonly message: string;
+}
+
 export interface MediaBrokerOptions {
   /** The plaintext window read per pull. */
   windowBytes?: number;
   /** How long a ticket's engine stream outlives its last cursor. */
   lingerMs?: number;
+  /** Told about every read this broker ends with an error. */
+  onFailure?: (failure: MediaFailure) => void;
 }
 
 /**
@@ -79,6 +93,7 @@ export class MediaBroker {
   private readonly idleWaiters = new Map<string, Set<IdleWaiter>>();
   private readonly windowBytes: number;
   private readonly lingerMs: number;
+  private readonly onFailure: ((failure: MediaFailure) => void) | null;
   private port: MessagePortLike | null = null;
   private listener: ((event: MessageEvent) => void) | null = null;
 
@@ -89,6 +104,7 @@ export class MediaBroker {
   ) {
     this.windowBytes = options.windowBytes ?? MEDIA_WINDOW_BYTES;
     this.lingerMs = options.lingerMs ?? DEFAULT_PIN_LINGER_MS;
+    this.onFailure = options.onFailure ?? null;
   }
 
   /** The pipe carries one port; a fresh offer supersedes the port it replaces. */
@@ -425,7 +441,11 @@ export class MediaBroker {
   private fail(port: MessagePortLike, requestId: number, cursor: Cursor, error: unknown): void {
     if (!this.isCurrent(requestId, cursor)) return;
     this.drop(requestId);
-    post(port, { type: 'cb:media:error', requestId, message: errorMessage(error) });
+    const message = errorMessage(error);
+    post(port, { type: 'cb:media:error', requestId, message });
+    // The body error the Service Worker raises reaches the media element as a
+    // bare network failure, so the reason has to travel tab-side instead.
+    this.onFailure?.({ ticket: cursor.ticket, code: engineErrorCode(error) ?? null, message });
   }
 }
 

--- a/packages/client/src/media/broker.ts
+++ b/packages/client/src/media/broker.ts
@@ -40,6 +40,17 @@ interface Pin {
   linger: ReturnType<typeof setTimeout> | null;
 }
 
+/**
+ * A holder waiting for a ticket to stop being read. The deadline re-arms on
+ * every sign of progress, so it expires only on a ticket no body ever claimed or
+ * one whose reader went away without saying so.
+ */
+interface IdleWaiter {
+  readonly resolve: () => void;
+  readonly stallMs: number;
+  timer: ReturnType<typeof setTimeout>;
+}
+
 /** An open engine stream and the memo it came from, so a failure can drop it. */
 interface Pinned {
   readonly handle: StreamHandle;
@@ -67,6 +78,7 @@ interface Cursor {
 export class MediaBroker {
   private readonly cursors = new Map<number, Cursor>();
   private readonly pins = new Map<string, Pin>();
+  private readonly idleWaiters = new Map<string, Set<IdleWaiter>>();
   private readonly windowBytes: number;
   private readonly lingerMs: number;
   private port: MessagePortLike | null = null;
@@ -102,6 +114,51 @@ export class MediaBroker {
     this.cursors.clear();
     for (const pin of this.pins.values()) void this.discard(pin);
     this.pins.clear();
+    for (const ticket of [...this.idleWaiters.keys()]) this.settleIdle(ticket);
+  }
+
+  /**
+   * Resolves once no response body is reading `ticket`: its last body ended, or
+   * `stallMs` passed with no window delivered. A ticket is a bearer capability
+   * to plaintext, so its holder needs this to know when dropping it can no
+   * longer cut a transfer short.
+   */
+  whenIdle(ticket: string, stallMs: number): Promise<void> {
+    return new Promise((resolve) => {
+      const waiter: IdleWaiter = {
+        resolve,
+        stallMs,
+        timer: setTimeout(() => this.expire(ticket, waiter), stallMs),
+      };
+      const waiters = this.idleWaiters.get(ticket);
+      if (waiters === undefined) this.idleWaiters.set(ticket, new Set([waiter]));
+      else waiters.add(waiter);
+    });
+  }
+
+  private expire(ticket: string, waiter: IdleWaiter): void {
+    const waiters = this.idleWaiters.get(ticket);
+    waiters?.delete(waiter);
+    if (waiters?.size === 0) this.idleWaiters.delete(ticket);
+    waiter.resolve();
+  }
+
+  /** Restarts every stall deadline on `ticket`: a reader is demonstrably alive. */
+  private bump(ticket: string): void {
+    for (const waiter of this.idleWaiters.get(ticket) ?? []) {
+      clearTimeout(waiter.timer);
+      waiter.timer = setTimeout(() => this.expire(ticket, waiter), waiter.stallMs);
+    }
+  }
+
+  private settleIdle(ticket: string): void {
+    const waiters = this.idleWaiters.get(ticket);
+    if (waiters === undefined) return;
+    this.idleWaiters.delete(ticket);
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timer);
+      waiter.resolve();
+    }
   }
 
   /**
@@ -117,6 +174,7 @@ export class MediaBroker {
         post(this.port, { type: 'cb:media:error', requestId, message: 'the stream was revoked' });
       }
     }
+    this.settleIdle(ticket);
     const pin = this.pins.get(ticket);
     if (pin === undefined) return;
     this.pins.delete(ticket);
@@ -130,10 +188,12 @@ export class MediaBroker {
     this.cursors.delete(requestId);
     cursor.pin.cursors -= 1;
     if (cursor.pin.cursors > 0) return;
+    this.settleIdle(cursor.ticket);
     cursor.pin.linger = setTimeout(() => this.evict(cursor.ticket), this.lingerMs);
   }
 
   private acquire(ticket: string): Pin {
+    this.bump(ticket);
     const held = this.pins.get(ticket);
     if (held === undefined) {
       const pin: Pin = { stream: null, cursors: 1, linger: null };
@@ -349,6 +409,7 @@ export class MediaBroker {
       return;
     }
     cursor.offset = offset + delivered;
+    this.bump(cursor.ticket);
     // A short read means the live version is smaller than the head promised;
     // ending here is a clean EOF, where under-delivering content-length is a
     // network error to the media element.

--- a/packages/client/src/media/broker.ts
+++ b/packages/client/src/media/broker.ts
@@ -21,16 +21,12 @@ export interface MediaReader {
  */
 const DEFAULT_PIN_LINGER_MS = 5000;
 
-/**
- * A read this broker gave up on. The engine's code rides along because a
- * ceiling refusal a later read can clear is not a fault, and a message string
- * is not a classification.
- */
+/** A read this broker gave up on, classified by the engine's code. */
 export interface MediaFailure {
   readonly ticket: string;
-  /** `null` where the failure did not come from the engine. */
-  readonly code: string | null;
   readonly message: string;
+  /** See {@link isRecoverableEngineError}. */
+  readonly recoverable: boolean;
 }
 
 export interface MediaBrokerOptions {
@@ -443,9 +439,11 @@ export class MediaBroker {
     this.drop(requestId);
     const message = errorMessage(error);
     post(port, { type: 'cb:media:error', requestId, message });
-    // The body error the Service Worker raises reaches the media element as a
-    // bare network failure, so the reason has to travel tab-side instead.
-    this.onFailure?.({ ticket: cursor.ticket, code: engineErrorCode(error) ?? null, message });
+    this.onFailure?.({
+      ticket: cursor.ticket,
+      message,
+      recoverable: isRecoverableEngineError(engineErrorCode(error)),
+    });
   }
 }
 

--- a/packages/client/src/media/broker.ts
+++ b/packages/client/src/media/broker.ts
@@ -40,15 +40,13 @@ interface Pin {
   linger: ReturnType<typeof setTimeout> | null;
 }
 
-/**
- * A holder waiting for a ticket to stop being read. The deadline re-arms on
- * every sign of progress, so it expires only on a ticket no body ever claimed or
- * one whose reader went away without saying so.
- */
+/** A holder waiting for a ticket to stop being read. */
 interface IdleWaiter {
-  readonly resolve: () => void;
-  readonly stallMs: number;
-  timer: ReturnType<typeof setTimeout>;
+  readonly resolve: (read: boolean) => void;
+  readonly startWithinMs: number;
+  /** Set once a body claims the ticket, which is what the deadline waits for. */
+  read: boolean;
+  timer: ReturnType<typeof setTimeout> | null;
 }
 
 /** An open engine stream and the memo it came from, so a failure can drop it. */
@@ -114,41 +112,50 @@ export class MediaBroker {
     this.cursors.clear();
     for (const pin of this.pins.values()) void this.discard(pin);
     this.pins.clear();
-    for (const ticket of [...this.idleWaiters.keys()]) this.settleIdle(ticket);
+    // A replaced port is how a killed worker recovers: its bodies re-open on the
+    // port that replaces this one, so waiters get a fresh deadline, not an end.
+    for (const [ticket, waiters] of this.idleWaiters) {
+      for (const waiter of waiters) this.arm(ticket, waiter);
+    }
   }
 
   /**
-   * Resolves once no response body is reading `ticket`: its last body ended, or
-   * `stallMs` passed with no window delivered. A ticket is a bearer capability
-   * to plaintext, so its holder needs this to know when dropping it can no
-   * longer cut a transfer short.
+   * Resolves once no response body is reading `ticket`, with whether one ever
+   * did. A ticket is a bearer capability to plaintext, so its holder needs this
+   * to know when dropping it can no longer cut a transfer short.
+   *
+   * @param startWithinMs how long to wait for a body to claim the ticket. A
+   * claimed ticket has no deadline — a reader between windows is still reading.
    */
-  whenIdle(ticket: string, stallMs: number): Promise<void> {
+  whenIdle(ticket: string, startWithinMs: number): Promise<boolean> {
     return new Promise((resolve) => {
       const waiter: IdleWaiter = {
         resolve,
-        stallMs,
-        timer: setTimeout(() => this.expire(ticket, waiter), stallMs),
+        startWithinMs,
+        read: (this.pins.get(ticket)?.cursors ?? 0) > 0,
+        timer: null,
       };
+      this.arm(ticket, waiter);
       const waiters = this.idleWaiters.get(ticket);
       if (waiters === undefined) this.idleWaiters.set(ticket, new Set([waiter]));
       else waiters.add(waiter);
     });
   }
 
+  private arm(ticket: string, waiter: IdleWaiter): void {
+    if (waiter.timer !== null) clearTimeout(waiter.timer);
+    waiter.timer = setTimeout(() => this.expire(ticket, waiter), waiter.startWithinMs);
+  }
+
   private expire(ticket: string, waiter: IdleWaiter): void {
+    if ((this.pins.get(ticket)?.cursors ?? 0) > 0) {
+      this.arm(ticket, waiter);
+      return;
+    }
     const waiters = this.idleWaiters.get(ticket);
     waiters?.delete(waiter);
     if (waiters?.size === 0) this.idleWaiters.delete(ticket);
-    waiter.resolve();
-  }
-
-  /** Restarts every stall deadline on `ticket`: a reader is demonstrably alive. */
-  private bump(ticket: string): void {
-    for (const waiter of this.idleWaiters.get(ticket) ?? []) {
-      clearTimeout(waiter.timer);
-      waiter.timer = setTimeout(() => this.expire(ticket, waiter), waiter.stallMs);
-    }
+    waiter.resolve(waiter.read);
   }
 
   private settleIdle(ticket: string): void {
@@ -156,8 +163,8 @@ export class MediaBroker {
     if (waiters === undefined) return;
     this.idleWaiters.delete(ticket);
     for (const waiter of waiters) {
-      clearTimeout(waiter.timer);
-      waiter.resolve();
+      if (waiter.timer !== null) clearTimeout(waiter.timer);
+      waiter.resolve(waiter.read);
     }
   }
 
@@ -193,7 +200,7 @@ export class MediaBroker {
   }
 
   private acquire(ticket: string): Pin {
-    this.bump(ticket);
+    for (const waiter of this.idleWaiters.get(ticket) ?? []) waiter.read = true;
     const held = this.pins.get(ticket);
     if (held === undefined) {
       const pin: Pin = { stream: null, cursors: 1, linger: null };
@@ -409,7 +416,6 @@ export class MediaBroker {
       return;
     }
     cursor.offset = offset + delivered;
-    this.bump(cursor.ticket);
     // A short read means the live version is smaller than the head promised;
     // ending here is a clean EOF, where under-delivering content-length is a
     // network error to the media element.

--- a/packages/client/src/media/registry.ts
+++ b/packages/client/src/media/registry.ts
@@ -30,6 +30,11 @@ export class StreamRegistry {
     // another's head.
     if (this.sources.has(ticket)) throw new Error('a stream ticket must be minted once');
     this.sources.set(ticket, source);
+    return this.urlFor(ticket);
+  }
+
+  /** The URL a media element requests for `ticket`, live or not. */
+  urlFor(ticket: string): string {
     return `${STREAM_PATH_PREFIX}${ticket}`;
   }
 

--- a/packages/client/src/media/service.test.ts
+++ b/packages/client/src/media/service.test.ts
@@ -187,6 +187,22 @@ describe('MediaService', () => {
     expect(service.revokeStreamUrl(`${ORIGIN}${url}`)).toBe(false);
   });
 
+  it('has nothing to wait for on a url naming no live ticket', async () => {
+    const { container, worker, service } = setup();
+    container.controller = worker;
+    await service.start();
+    const url = service.createStreamUrl({
+      node: new Uint8Array([9]),
+      size: 8,
+      mimeType: 'audio/o',
+    });
+    service.revokeStreamUrl(url);
+
+    // A deadline long enough that only an immediate resolve can finish the test.
+    await service.whenStreamIdle(url, 60_000);
+    await service.whenStreamIdle('https://elsewhere.example/stream/x', 60_000);
+  });
+
   it('re-brokers a fresh channel and closes the old one when the worker asks for a port', async () => {
     const { container, worker, service, channels } = setup();
     container.controller = worker;

--- a/packages/client/src/media/service.test.ts
+++ b/packages/client/src/media/service.test.ts
@@ -199,8 +199,8 @@ describe('MediaService', () => {
     service.revokeStreamUrl(url);
 
     // A deadline long enough that only an immediate resolve can finish the test.
-    await service.whenStreamIdle(url, 60_000);
-    await service.whenStreamIdle('https://elsewhere.example/stream/x', 60_000);
+    expect(await service.whenStreamIdle(url, 60_000)).toBe(false);
+    expect(await service.whenStreamIdle('https://elsewhere.example/stream/x', 60_000)).toBe(false);
   });
 
   it('re-brokers a fresh channel and closes the old one when the worker asks for a port', async () => {

--- a/packages/client/src/media/service.test.ts
+++ b/packages/client/src/media/service.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import { EngineRequestError } from '../correlatedTransport.js';
 import { FakePort } from '../sw/testDoubles.js';
 import type { MediaReader } from './broker.js';
 import { MEDIA_PORT_OFFER, MEDIA_PORT_REQUEST, type MediaResponse } from './protocol.js';
 import {
   MediaService,
+  type MediaStreamFailure,
   type ServiceWorkerContainerLike,
   type ServiceWorkerLike,
   type ServiceWorkerRegistrationLike,
@@ -257,6 +259,52 @@ describe('MediaService', () => {
 
     expect(closed).toEqual([7n]);
     expect(channels).toHaveLength(2);
+  });
+
+  it('classifies a refused read for the holder of the url it refused on', async () => {
+    const refusals = [
+      new EngineRequestError('too many read streams are already open', 'tooManyStreams'),
+      new EngineRequestError('the adoption gate refused the record', 'trustViolation'),
+    ];
+    const { container, worker, service, channels } = setup({
+      openContentStream: () => Promise.reject(refusals.shift() ?? new Error('spent')),
+      readStream: (_handle, _offset, length) => Promise.resolve(new ArrayBuffer(length)),
+      closeStream: () => Promise.resolve(),
+    });
+    container.controller = worker;
+    await service.start();
+
+    const seen: MediaStreamFailure[] = [];
+    const stop = service.onStreamError((failure) => seen.push(failure));
+    const read = async (requestId: number): Promise<string> => {
+      const url = service.createStreamUrl({
+        node: new Uint8Array([9]),
+        size: 8,
+        mimeType: 'audio/o',
+      });
+      const port = channels[0].port2;
+      port.postMessage({
+        type: 'cb:media:open',
+        requestId,
+        ticket: url.slice('/stream/'.length),
+        range: null,
+      });
+      port.postMessage({ type: 'cb:media:pull', requestId });
+      await settled();
+      return url;
+    };
+
+    const ceiling = await read(1);
+    const verdict = await read(2);
+    stop();
+    await read(3);
+
+    // A ceiling is not a verdict: only one of these is worth trying again, and
+    // the difference is the engine's code, not the wording.
+    expect(seen).toEqual([
+      { url: ceiling, message: 'too many read streams are already open', recoverable: true },
+      { url: verdict, message: 'the adoption gate refused the record', recoverable: false },
+    ]);
   });
 
   it('ignores an unrelated message from the worker', async () => {

--- a/packages/client/src/media/service.test.ts
+++ b/packages/client/src/media/service.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from 'vitest';
 import { EngineRequestError } from '../correlatedTransport.js';
 import { FakePort } from '../sw/testDoubles.js';
 import type { MediaReader } from './broker.js';
-import { MEDIA_PORT_OFFER, MEDIA_PORT_REQUEST, type MediaResponse } from './protocol.js';
+import {
+  MEDIA_PORT_OFFER,
+  MEDIA_PORT_REQUEST,
+  STREAM_PATH_PREFIX,
+  type MediaResponse,
+} from './protocol.js';
 import {
   MediaService,
   type MediaStreamFailure,
@@ -267,9 +272,8 @@ describe('MediaService', () => {
       new EngineRequestError('the adoption gate refused the record', 'trustViolation'),
     ];
     const { container, worker, service, channels } = setup({
+      ...reader,
       openContentStream: () => Promise.reject(refusals.shift() ?? new Error('spent')),
-      readStream: (_handle, _offset, length) => Promise.resolve(new ArrayBuffer(length)),
-      closeStream: () => Promise.resolve(),
     });
     container.controller = worker;
     await service.start();
@@ -286,7 +290,7 @@ describe('MediaService', () => {
       port.postMessage({
         type: 'cb:media:open',
         requestId,
-        ticket: url.slice('/stream/'.length),
+        ticket: url.slice(STREAM_PATH_PREFIX.length),
         range: null,
       });
       port.postMessage({ type: 'cb:media:pull', requestId });
@@ -299,8 +303,6 @@ describe('MediaService', () => {
     stop();
     await read(3);
 
-    // A ceiling is not a verdict: only one of these is worth trying again, and
-    // the difference is the engine's code, not the wording.
     expect(seen).toEqual([
       { url: ceiling, message: 'too many read streams are already open', recoverable: true },
       { url: verdict, message: 'the adoption gate refused the record', recoverable: false },

--- a/packages/client/src/media/service.ts
+++ b/packages/client/src/media/service.ts
@@ -91,16 +91,12 @@ export class MediaService {
     return this.registry.register(source);
   }
 
-  /**
-   * Resolves once nothing is reading `url` — its transfer ended, or `stallMs`
-   * passed with no window delivered. A holder that revokes on this drops a
-   * ticket as soon as its bytes stop rather than holding plaintext addressable
-   * for the life of the tab.
-   */
-  whenStreamIdle(url: string, stallMs: number): Promise<void> {
+  /** {@link MediaBroker.whenIdle} for a ticket named by its URL. */
+  whenStreamIdle(url: string, startWithinMs: number): Promise<boolean> {
     const ticket = ticketFromUrl(url, this.origin);
-    if (ticket === null || this.registry.lookup(ticket) === undefined) return Promise.resolve();
-    return this.broker.whenIdle(ticket, stallMs);
+    if (ticket === null || this.registry.lookup(ticket) === undefined)
+      return Promise.resolve(false);
+    return this.broker.whenIdle(ticket, startWithinMs);
   }
 
   /** False when the URL named no live ticket of this tab's. */

--- a/packages/client/src/media/service.ts
+++ b/packages/client/src/media/service.ts
@@ -4,27 +4,22 @@
  * ticket URLs the UI hands to a media element.
  */
 
-import { isRecoverableEngineError } from '../correlatedTransport.js';
+import { fanOut } from '../correlatedTransport.js';
 import { MediaBroker, type MediaFailure, type MediaReader } from './broker.js';
 import {
   MEDIA_PORT_OFFER,
   MEDIA_PORT_REQUEST,
-  STREAM_PATH_PREFIX,
   ticketFromUrl,
   type MediaPortOffer,
 } from './protocol.js';
 import { StreamRegistry, type MediaSource } from './registry.js';
 
+const noop = (): void => undefined;
+
 /** A stream that stopped, told to whoever holds the URL it stopped on. */
-export interface MediaStreamFailure {
+export interface MediaStreamFailure extends Omit<MediaFailure, 'ticket'> {
   /** The URL `createStreamUrl` returned, so a holder can match its own. */
   readonly url: string;
-  readonly message: string;
-  /**
-   * The engine refused over a ceiling a later read can clear rather than over a
-   * verdict, so the same request is worth making again.
-   */
-  readonly recoverable: boolean;
 }
 
 /** The `ServiceWorker` surface the offer needs. */
@@ -92,17 +87,13 @@ export class MediaService {
    * to hear it here.
    */
   onStreamError(listener: (failure: MediaStreamFailure) => void): () => void {
+    if (this.disposed) return noop;
     this.failureListeners.add(listener);
     return () => this.failureListeners.delete(listener);
   }
 
-  private report(failure: MediaFailure): void {
-    const reported: MediaStreamFailure = {
-      url: `${STREAM_PATH_PREFIX}${failure.ticket}`,
-      message: failure.message,
-      recoverable: isRecoverableEngineError(failure.code ?? undefined),
-    };
-    for (const listener of [...this.failureListeners]) listener(reported);
+  private report({ ticket, ...failure }: MediaFailure): void {
+    fanOut(this.failureListeners, { ...failure, url: this.registry.urlFor(ticket) });
   }
 
   /**

--- a/packages/client/src/media/service.ts
+++ b/packages/client/src/media/service.ts
@@ -4,14 +4,28 @@
  * ticket URLs the UI hands to a media element.
  */
 
-import { MediaBroker, type MediaReader } from './broker.js';
+import { isRecoverableEngineError } from '../correlatedTransport.js';
+import { MediaBroker, type MediaFailure, type MediaReader } from './broker.js';
 import {
   MEDIA_PORT_OFFER,
   MEDIA_PORT_REQUEST,
+  STREAM_PATH_PREFIX,
   ticketFromUrl,
   type MediaPortOffer,
 } from './protocol.js';
 import { StreamRegistry, type MediaSource } from './registry.js';
+
+/** A stream that stopped, told to whoever holds the URL it stopped on. */
+export interface MediaStreamFailure {
+  /** The URL `createStreamUrl` returned, so a holder can match its own. */
+  readonly url: string;
+  readonly message: string;
+  /**
+   * The engine refused over a ceiling a later read can clear rather than over a
+   * verdict, so the same request is worth making again.
+   */
+  readonly recoverable: boolean;
+}
 
 /** The `ServiceWorker` surface the offer needs. */
 export interface ServiceWorkerLike {
@@ -55,6 +69,7 @@ export class MediaService {
   private readonly broker: MediaBroker;
   private readonly origin: string;
   private readonly createChannel: () => MessageChannel;
+  private readonly failureListeners = new Set<(failure: MediaStreamFailure) => void>();
   private registration: ServiceWorkerRegistrationLike | null = null;
   private channel: MessageChannel | null = null;
   private startup: Promise<void> | null = null;
@@ -63,8 +78,31 @@ export class MediaService {
   constructor(private readonly config: MediaServiceConfig) {
     this.origin = config.origin ?? globalThis.location.origin;
     this.registry = new StreamRegistry(this.origin);
-    this.broker = new MediaBroker(this.registry, config.reader);
+    this.broker = new MediaBroker(this.registry, config.reader, {
+      onFailure: (failure) => this.report(failure),
+    });
     this.createChannel = config.createChannel ?? ((): MessageChannel => new MessageChannel());
+  }
+
+  /**
+   * Subscribes to the streams that stop mid-read. Returns the unsubscribe.
+   *
+   * A response body that errors reaches a media element as an untyped network
+   * failure, so a player that wants to tell a ceiling refusal from a fault has
+   * to hear it here.
+   */
+  onStreamError(listener: (failure: MediaStreamFailure) => void): () => void {
+    this.failureListeners.add(listener);
+    return () => this.failureListeners.delete(listener);
+  }
+
+  private report(failure: MediaFailure): void {
+    const reported: MediaStreamFailure = {
+      url: `${STREAM_PATH_PREFIX}${failure.ticket}`,
+      message: failure.message,
+      recoverable: isRecoverableEngineError(failure.code ?? undefined),
+    };
+    for (const listener of [...this.failureListeners]) listener(reported);
   }
 
   /**
@@ -114,6 +152,7 @@ export class MediaService {
     const container = this.config.container;
     container.removeEventListener('controllerchange', this.onControllerChange);
     container.removeEventListener('message', this.onMessage);
+    this.failureListeners.clear();
     this.registry.clear();
     this.broker.close();
     this.brokerTo(null);

--- a/packages/client/src/media/service.ts
+++ b/packages/client/src/media/service.ts
@@ -91,6 +91,18 @@ export class MediaService {
     return this.registry.register(source);
   }
 
+  /**
+   * Resolves once nothing is reading `url` — its transfer ended, or `stallMs`
+   * passed with no window delivered. A holder that revokes on this drops a
+   * ticket as soon as its bytes stop rather than holding plaintext addressable
+   * for the life of the tab.
+   */
+  whenStreamIdle(url: string, stallMs: number): Promise<void> {
+    const ticket = ticketFromUrl(url, this.origin);
+    if (ticket === null || this.registry.lookup(ticket) === undefined) return Promise.resolve();
+    return this.broker.whenIdle(ticket, stallMs);
+  }
+
   /** False when the URL named no live ticket of this tab's. */
   revokeStreamUrl(url: string): boolean {
     const ticket = ticketFromUrl(url, this.origin);


### PR DESCRIPTION
Two changes to the media and streaming path, in one PR. They were developed as
separate branches and conflicted with each other in
`apps/web/src/components/file-browser/FileBrowserActions.test.tsx`, where both add
a method to the same hand-rolled `MediaService` fake. Combining them resolves that
conflict here — keeping both sides — instead of deferring it to whichever branch
merged second.

They also share `packages/client/src/media/broker.ts`, `service.ts` and
`service.test.ts`, which auto-merge cleanly and are easier to review as one state.

---

# Part 1 — #1126, bound the live stream tickets a batch download can open

## What

A streamed save pushed its ticket onto `tickets.current` and revoked it only in the unmount cleanup. Every live ticket is a same-origin URL that serves that node's plaintext on demand, so a select-all over a folder of 500 files left 500 plaintext-addressable URLs live for as long as the view stayed mounted.

The set is now bounded by ticket **lifetime** rather than by a cap, so nothing is ever revoked out from under a transfer.

## How

`MediaBroker` already knows when a ticket stops being read — it counts cursors per pin. It now exposes that:

- `MediaBroker.whenIdle(ticket, startWithinMs)` resolves when the ticket's last body ends, or when it is revoked, and reports whether a body ever claimed it.
- The deadline covers only the window before a body claims the ticket. **A claimed ticket has no deadline**: a reader between windows is still reading, and the pipe deliberately arms no deadline between pulls, so anything shorter would revoke a paused or Save-As-blocked download mid-file. An expiry that finds a live cursor re-arms.
- Resolving on the cursor count reaching zero, not on pin eviction, keeps the 5s playback linger out of the wait: a finished download settles at once while the pin still lingers for a seek.
- `MediaBroker.close` **re-arms** its waiters rather than settling them. A replaced port is how a killed worker recovers, and the pipe re-opens against the port that replaces it, so settling there would revoke the ticket before the retry could name it.
- `MediaService.whenStreamIdle(url, startWithinMs)` maps a URL back to its ticket; a URL naming no live ticket has nothing to wait for.

`useFileDownload.save` awaits that and revokes in a `finally`. Three consequences:

- The ticket dies the moment its bytes stop, instead of at unmount.
- `save` resolves when the file has actually been written, so `downloadSelection`'s sequential `await` loop holds **one** live ticket across a whole selection instead of one per file. That also keeps a large batch off the engine's open-stream ceiling.
- `save` resolves `false` for a save the browser never began — a browser that blocks the second automatic download blocks every one after it, so the batch stops there and says so rather than burning the start deadline once per selected file.

The unmount cleanup stays as the last-resort sweep for a save still transferring when the tab drops the hook.

## Buffered fallback

Unchanged, and bounded by the same serialization: `save` awaits the facade read before the next one starts, so the one-second blob revokes no longer overlap N-wide.

## Gate

- A batch download over a large selection leaves a bounded number of live stream tickets — `useFileDownload.test.ts` walks a five-file loop asserting exactly one live ticket at every step, and `FileBrowserActions.test.tsx` asserts a select-all batch mints and revokes one ticket per file.
- A transfer still in flight is never revoked out from under itself — asserted, not assumed: the ticket stays live and `save` stays pending until the transfer settles; `broker.test.ts` asserts a claimed ticket never expires however long its reader goes unread, and that a port replacement re-arms rather than settles.

## Verification

`pnpm typecheck` 0, `pnpm test` 0, `pnpm lint` 0, `pnpm lint:tracker-refs` 0. No Rust surface in this change.

Review gates: `/simplify` and `/security-review` both run on `git diff main...HEAD`. The security pass found the two real defects fixed in the second commit — the `close` settle and the stall deadline expiring on a live body — plus the refused-batch grind, also fixed. Comment duplication and the dead optional-chaining that `/simplify` flagged are folded in.

---

# Part 2 — #1064, give the media player a surface for a recoverable stream refusal

## What

`EngineError::TooManyStreams` is reachable only through the media pipe, and the pipe had nowhere to say so. `MediaBroker` handles the ceiling itself — it gives back the streams held only by the pin linger and retries the refused open once — but if that retry also fails, the body errors and the media element sees a bare network failure with no explanation and no affordance.

There was also no player: audio and video were not preview kinds at all, so the surface had no host.

## How the reason reaches the UI

A `ReadableStream` error on a response body reaches a media element as an untyped network failure — the code cannot ride the body out to the `<video>`. So it travels tab-side, where the broker already is:

- `MediaBroker` takes an `onFailure` seam and reports every read it gives up on as a `MediaFailure` carrying the engine's code (`engineErrorCode`), not a message string.
- `MediaService.onStreamError(listener)` classifies that with `isRecoverableEngineError` and hands the holder of the stream URL a `MediaStreamFailure` — `{ url, message, recoverable }`. It is the same classifier the vault browser already uses for a snapshot pull, so a ceiling and a verdict are told apart in exactly one place.

## The player

`MediaPlayer` renders the element over the ticket URL and subscribes to failures on that URL:

- **recoverable** — a notice plus a `retry` that remounts the element against the same ticket. The pipe refused a read; it did not withdraw the capability, so the ticket is still live and nothing is re-minted.
- **fault** — the engine's own message, terminal, no retry.
- The element's own `error` event is the floor for a failure the pipe never named (an unsupported container, a decode refusal). A classified refusal that already landed wins over it.

Audio and video join `previewKind`, streamed range by range with **no buffered fallback**: decoding a video whole into the tab is precisely what the pipe exists to avoid, and without a controlling Service Worker the preview refuses and points at download.

## Deviation from the issue

The issue expects `cb:media:error` to carry the engine's code across the port. Re-checked against the tree: that would be a dead field. The only `cb:media:error` that carries an engine code is raised by `MediaBroker.fail`, which runs **in the tab** — the same context as the player — and the round trip through the Service Worker can only lose information, because the pipe's sole action on it is to error a body whose error the media element cannot read. `MediaPipe`'s own failures ('media pull timed out', 'media port replaced') have no engine code to carry. So the code is reported tab-side and the wire is left alone.

## Gate

`packages/client/src/media/service.test.ts` drives two real refusals through the broker — `tooManyStreams` and `trustViolation` — and asserts each is reported against the URL it refused on with the right `recoverable` verdict, and that unsubscribing stops it. `FileBrowserActions.test.tsx` asserts the video plays off a ticket without a facade read, that a ceiling refusal renders a retry that keeps the ticket, that a fault does not, that another stream's refusal is ignored, and that the element's own error still reports.

## Verification

`pnpm typecheck` 0, `pnpm test` 0, `pnpm lint` 0, `pnpm lint:tracker-refs` 0. No Rust surface in this change.

Review gates: `/simplify` and `/security-review` both run on `git diff main...HEAD`. Security found nothing at or above the bar — the report carries no plaintext or key material, `safeMimeType` plus `nosniff` and the `no-store` clamp still bound what a ticket can render as, the classifier is a single-code equality so nothing widens into it, and the listener unsubscribes on unmount and on an engine rebuild. Its one nit and the `/simplify` findings are folded into the second commit: the broker classifies rather than round-tripping a raw code, the fan-out reuses `fanOut` so a throwing subscriber cannot drop the event, `onStreamError` refuses a subscription after `dispose`, `StreamRegistry` owns the ticket-URL shape, the three streamed preview branches became one, and the player reuses the vault browser's existing recoverable-refusal notice instead of a second dialect.

Runtime verification is not reachable from a unit harness — the surface needs a logged-in vault, a controlling Service Worker, and the engine at its open-stream ceiling. To check it by hand: bring up the local stack, upload an `.mp4`, open its preview, confirm playback streams over `/stream/<ticket>` with no facade `download`, then hold `MAX_OPEN_STREAMS` open from other tickets and seek — the notice with `[retry]` should appear over the player and the retry should recover once a stream frees.

---

Closes #1126
Closes #1064


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound live stream tickets and surface recoverable stream refusals with retry
> - `MediaBroker.whenIdle(ticket, startWithinMs)` tracks whether a ticket was ever read, resolving `false` if the browser never fetched it; idle waiters survive port replacements via re-arming on `close()`.
> - `MediaService` gains `onStreamError` subscription API and `whenStreamIdle(url, ms)`, emitting classified (`recoverable` vs fatal) failure events to listeners.
> - `useFileDownload.save` now returns `Promise<boolean>` and awaits stream completion before revoking the ticket; batch selection downloads stop at the first browser refusal.
> - `useFilePreview` and `FilePreviewDialog` support audio/video previews via stream tickets, falling back to an error when the streaming pipe is unavailable.
> - New `MediaPlayer` component displays audio/video with a retry button for recoverable ceiling refusals and a fault message for non-recoverable errors.
> - Behavioral Change: `downloads.save` API now returns a boolean; callers that previously ignored the return value will silently continue, but batch downloads now halt on first refusal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c27b32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added audio and video previews with responsive playback controls.
  - Added retry options and clearer messages for recoverable or failed media playback.
  - Added streaming support for audio and video previews.

- **Bug Fixes**
  - Batch downloads now run sequentially, skip non-file items, and stop when a download cannot start.
  - Improved download cleanup and error handling to prevent stale download sessions.
  - Improved handling of interrupted or unavailable media streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->