### PR TITLE
chore(ci): build the engine wasm once per run and cache the host build tree

### DIFF
--- a/.github/actions/mock-ipns-routing/action.yml
+++ b/.github/actions/mock-ipns-routing/action.yml
@@ -1,0 +1,18 @@
+name: Start the mock /routing/v1 record store
+description: Build and boot the hermetic mock-ipns-routing store, then wait for it to answer on :3001.
+
+runs:
+  using: composite
+  steps:
+    # The promoted mock-ipns-routing tool is the hermetic /routing/v1 record
+    # store (blueprint/testing.md). It is not a pnpm workspace member, so it
+    # installs and builds with its own npm.
+    - name: Start the mock /routing/v1 record store
+      shell: bash
+      run: |
+        cd tools/mock-ipns-routing
+        npm ci
+        npm run build
+        node dist/index.js > /tmp/mock-ipns-routing.log 2>&1 &
+        curl -fsS --retry 30 --retry-connrefused --retry-delay 1 http://localhost:3001/health \
+          || { echo '--- mock-ipns-routing log ---'; cat /tmp/mock-ipns-routing.log; exit 1; }

--- a/.github/actions/wasm-bindgen-cli/action.yml
+++ b/.github/actions/wasm-bindgen-cli/action.yml
@@ -20,13 +20,18 @@ runs:
     # The CLI and the locked wasm-bindgen crate share a glue schema, so a
     # version skew fails the run; derive the version from Cargo.lock. The
     # binary is cached in ~/.cargo/bin, where a bare `cargo install` errors
-    # "already exists": skip on a match, --force to overwrite a stale one.
+    # "already exists": skip on an exact match, --force to overwrite a stale
+    # one. An unreadable version aborts rather than installing whatever floats.
     - name: Install wasm-bindgen-cli matching Cargo.lock
       shell: bash
       run: |
         WB_VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
+        if [ -z "${WB_VERSION}" ]; then
+          echo "::error::no wasm-bindgen version found in Cargo.lock"
+          exit 1
+        fi
         echo "wasm-bindgen ${WB_VERSION}"
-        if wasm-bindgen --version 2>/dev/null | grep -qw "${WB_VERSION}"; then
+        if [ "$(wasm-bindgen --version 2>/dev/null | awk '{print $2}')" = "${WB_VERSION}" ]; then
           echo "wasm-bindgen-cli ${WB_VERSION} already present (cache hit); skipping install"
         else
           cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked --force

--- a/.github/actions/wasm-bindgen-cli/action.yml
+++ b/.github/actions/wasm-bindgen-cli/action.yml
@@ -1,0 +1,33 @@
+name: Install wasm-bindgen-cli
+description: Add the wasm rustup targets and install wasm-bindgen-cli at the version Cargo.lock pins.
+
+inputs:
+  targets:
+    description: Space-separated rustup targets to add.
+    required: false
+    default: wasm32-unknown-unknown
+
+runs:
+  using: composite
+  steps:
+    - name: Add wasm targets
+      shell: bash
+      env:
+        TARGETS: ${{ inputs.targets }}
+      # Word splitting is the point: `targets` carries a space-separated list.
+      run: rustup target add ${TARGETS}
+
+    # The CLI and the locked wasm-bindgen crate share a glue schema, so a
+    # version skew fails the run; derive the version from Cargo.lock. The
+    # binary is cached in ~/.cargo/bin, where a bare `cargo install` errors
+    # "already exists": skip on a match, --force to overwrite a stale one.
+    - name: Install wasm-bindgen-cli matching Cargo.lock
+      shell: bash
+      run: |
+        WB_VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
+        echo "wasm-bindgen ${WB_VERSION}"
+        if wasm-bindgen --version 2>/dev/null | grep -qw "${WB_VERSION}"; then
+          echo "wasm-bindgen-cli ${WB_VERSION} already present (cache hit); skipping install"
+        else
+          cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked --force
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,14 +224,16 @@ jobs:
 
       - uses: ./.github/actions/wasm-bindgen-cli
 
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: 'package.json'
 
-      # The script behind `@cipherbox/web run build:wasm`, which has no npm
-      # dependencies — so this job needs no pnpm install.
+      # No `pnpm install`: the script this runs shells out to cargo and
+      # wasm-bindgen and pulls in no npm dependency.
       - name: Build the engine WASM
-        run: node apps/web/scripts/build-wasm.mjs
+        run: pnpm --filter @cipherbox/web run build:wasm
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -242,11 +244,16 @@ jobs:
 
   # The bundle that fingerprints the engine artifact. It consumes the module
   # `wasm-engine` produced, so it carries no Rust toolchain at all.
+  #
+  # Gated on `lint` rather than the usual `!failure()`: branch protection
+  # requires this context by name, and a skipped required context counts as a
+  # pass. So a failed `wasm-engine` must leave this job running and failing at
+  # the download, not skipped and green.
   web-bundle:
     name: Web Bundle
     needs: [changes, lint, wasm-engine]
     if: |
-      !failure() && !cancelled() &&
+      !cancelled() && needs.lint.result == 'success' &&
       needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -873,11 +880,13 @@ jobs:
             exit 1
           fi
 
+  # Same fail-closed gating as web-bundle: a failed `wasm-engine` must surface
+  # as a failed suite, not a skipped one.
   web-e2e:
     name: Web E2E Smoke
     needs: [changes, lint, wasm-engine]
     if: |
-      !failure() && !cancelled() &&
+      !cancelled() && needs.lint.result == 'success' &&
       (needs.changes.outputs.web == 'true' || needs.changes.outputs.e2e == 'true')
     permissions:
       contents: read
@@ -888,33 +897,24 @@ jobs:
   # Single always-reporting gate for the smoke slice, mirroring
   # contract-suite-result: branch protection requires this stable context, so a
   # PR that touches nothing the suite covers is not blocked forever while a real
-  # smoke failure still fails this gate. It covers the engine build too, because
-  # a `wasm-engine` failure only *skips* the suite, which would otherwise read
-  # as a pass.
+  # smoke failure still fails this gate.
   web-e2e-result:
     name: Web E2E Smoke Result
-    needs: [wasm-engine, web-e2e]
+    needs: web-e2e
     if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Require the engine build and smoke slice to pass or be skipped
+      - name: Require the smoke slice to pass or be skipped
         env:
-          WASM_ENGINE_RESULT: ${{ needs.wasm-engine.result }}
           WEB_E2E_RESULT: ${{ needs.web-e2e.result }}
         run: |
-          status=0
-          for entry in "wasm-engine=${WASM_ENGINE_RESULT}" "web-e2e=${WEB_E2E_RESULT}"; do
-            job="${entry%%=*}"
-            result="${entry#*=}"
-            echo "${job} result: ${result}"
-            if [ "${result}" = 'failure' ] || [ "${result}" = 'cancelled' ]; then
-              echo "::error::${job} ${result}"
-              status=1
-            fi
-          done
-          exit "${status}"
+          echo "web-e2e result: ${WEB_E2E_RESULT}"
+          if [ "${WEB_E2E_RESULT}" = 'failure' ] || [ "${WEB_E2E_RESULT}" = 'cancelled' ]; then
+            echo "::error::web-e2e ${WEB_E2E_RESULT}"
+            exit 1
+          fi
 
   desktop-build:
     name: Desktop Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
               - 'package.json'
               - 'tsconfig*.json'
               - '.github/workflows/ci.yml'
+              - '.github/actions/**'
             rust:
               - 'crates/**'
               - 'Cargo.toml'
@@ -50,6 +51,7 @@ jobs:
               - 'rust-toolchain.toml'
               - '.cargo/config.toml'
               - '.github/workflows/ci.yml'
+              - '.github/actions/**'
             web:
               - 'apps/web/**'
               - 'packages/client/**'
@@ -63,6 +65,7 @@ jobs:
               - 'package.json'
               - 'tsconfig*.json'
               - '.github/workflows/ci.yml'
+              - '.github/actions/**'
             # What the smoke slice depends on *beyond* `web` — it drives the
             # browser against a live API and the hermetic record store. Its job
             # runs on `web || e2e`, so widening `web` widens the gate too.
@@ -181,18 +184,67 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # apps/web is built by `Web Bundle`, which carries the Rust toolchain its
-      # WASM artifact needs. `!cipher-box` drops the root project, whose own
-      # `build` script would recurse back into every package.
+      # apps/web is built by `Web Bundle`, which has the engine WASM its bundle
+      # embeds. `!cipher-box` drops the root project, whose own `build` script
+      # would recurse back into every package.
       - name: Build packages
         run: pnpm --filter '!@cipherbox/web' --filter '!cipher-box' run build
 
-  # apps/web's production WASM artifact and the bundle that fingerprints it
-  # (blueprint/web-client.md "WASM packaging"). Split out of `Build` so a change
-  # that touches neither the web app nor the crates pays no Rust toolchain.
+  # The engine's browser artifact (blueprint/web-client.md "WASM packaging"),
+  # built once per run. Every job that ships or exercises the browser engine
+  # consumes this artifact, so a run's bundle and its e2e slice are the same
+  # bytes by construction rather than by coincidence.
+  wasm-engine:
+    name: Web Engine WASM
+    needs: [changes, lint]
+    if: |
+      !failure() && !cancelled() &&
+      (needs.changes.outputs.web == 'true' || needs.changes.outputs.e2e == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # `target/release` is the host tree: under `--target wasm32-…` cargo puts
+      # proc macros and build scripts there, so omitting it recompiles them on
+      # every run. The native `target/<triple>` subtrees the cargo jobs cache
+      # stay out — dead weight here, and a fourth full copy would push the
+      # repo's other cargo caches out under LRU.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+            target/release
+            target/wasm32-unknown-unknown
+          key: wasm-engine-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: wasm-engine-cargo-
+
+      - uses: ./.github/actions/wasm-bindgen-cli
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: 'package.json'
+
+      # The script behind `@cipherbox/web run build:wasm`, which has no npm
+      # dependencies — so this job needs no pnpm install.
+      - name: Build the engine WASM
+        run: node apps/web/scripts/build-wasm.mjs
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: web-engine-wasm
+          path: apps/web/src/wasm
+          if-no-files-found: error
+          retention-days: 1
+
+  # The bundle that fingerprints the engine artifact. It consumes the module
+  # `wasm-engine` produced, so it carries no Rust toolchain at all.
   web-bundle:
     name: Web Bundle
-    needs: [changes, lint]
+    needs: [changes, lint, wasm-engine]
     if: |
       !failure() && !cancelled() &&
       needs.changes.outputs.web == 'true'
@@ -202,22 +254,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Only the browser target's build tree: the native `target/` subtrees the
-      # cargo jobs cache are dead weight here, and a fourth full copy would push
-      # the repo's other cargo caches out under LRU.
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-            target/wasm32-unknown-unknown
-          key: web-bundle-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: web-bundle-cargo-
-
-      - name: Add wasm target
-        run: rustup target add wasm32-unknown-unknown
-
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -225,23 +261,16 @@ jobs:
           node-version-file: 'package.json'
           cache: 'pnpm'
 
-      # wasm-bindgen-cli generates the engine glue and must match the locked
-      # wasm-bindgen version exactly (a schema mismatch fails the run).
-      - name: Install wasm-bindgen-cli (matching Cargo.lock)
-        run: |
-          WB_VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          echo "wasm-bindgen ${WB_VERSION}"
-          if wasm-bindgen --version 2>/dev/null | grep -qw "${WB_VERSION}"; then
-            echo "wasm-bindgen-cli ${WB_VERSION} already present (cache hit); skipping install"
-          else
-            cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked --force
-          fi
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: web-engine-wasm
+          path: apps/web/src/wasm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build the web bundle
-        run: pnpm --filter @cipherbox/web run build
+        run: pnpm --filter @cipherbox/web run build:bundle
 
       - name: Bundle carries the fingerprinted engine artifact
         run: ls apps/web/dist/assets/cipherbox_wasm-*.js apps/web/dist/assets/cipherbox_wasm_bg-*.wasm
@@ -540,30 +569,16 @@ jobs:
           key: core-kats-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: core-kats-cargo-
 
-      - name: Add wasm targets
-        run: rustup target add wasm32-wasip1 wasm32-unknown-unknown
+      # wasm-bindgen-test-runner drives the wasm32-unknown-unknown legs in Node.
+      - uses: ./.github/actions/wasm-bindgen-cli
+        with:
+          targets: wasm32-wasip1 wasm32-unknown-unknown
 
       - uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: 'package.json'
-
-      # wasm-bindgen-test-runner drives the wasm32-unknown-unknown tests in
-      # Node and must match the locked wasm-bindgen version exactly (a schema
-      # mismatch fails the run); derive the version from Cargo.lock. The binary
-      # is cached in ~/.cargo/bin: skip the install when the cached binary
-      # already matches (a bare `cargo install` errors "already exists" on a
-      # cache hit), otherwise install with --force to overwrite a stale one.
-      - name: Install wasm-bindgen-cli (matching Cargo.lock)
-        run: |
-          WB_VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          echo "wasm-bindgen ${WB_VERSION}"
-          if wasm-bindgen --version 2>/dev/null | grep -qw "${WB_VERSION}"; then
-            echo "wasm-bindgen-cli ${WB_VERSION} already present (cache hit); skipping install"
-          else
-            cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked --force
-          fi
 
       - name: KAT vectors fresh (committed generator is the only writer)
         run: |
@@ -644,8 +659,8 @@ jobs:
           key: client-browser-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: client-browser-cargo-
 
-      - name: Add wasm target
-        run: rustup target add wasm32-unknown-unknown
+      # wasm-bindgen-cli drives the conformance module build.
+      - uses: ./.github/actions/wasm-bindgen-cli
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
@@ -653,18 +668,6 @@ jobs:
         with:
           node-version-file: 'package.json'
           cache: 'pnpm'
-
-      # wasm-bindgen-cli drives the conformance module build and must match the
-      # locked wasm-bindgen version exactly (a schema mismatch fails the run).
-      - name: Install wasm-bindgen-cli (matching Cargo.lock)
-        run: |
-          WB_VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          echo "wasm-bindgen ${WB_VERSION}"
-          if wasm-bindgen --version 2>/dev/null | grep -qw "${WB_VERSION}"; then
-            echo "wasm-bindgen-cli ${WB_VERSION} already present (cache hit); skipping install"
-          else
-            cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked --force
-          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -828,17 +831,7 @@ jobs:
           cargo fmt -p cipherbox-contract --check
           cargo clippy -p cipherbox-contract --all-targets -- -D warnings
 
-      # The promoted mock-ipns-routing tool is the hermetic /routing/v1 record
-      # store (blueprint/testing.md). It is not a pnpm workspace member, so it
-      # installs and builds with its own npm.
-      - name: Start the mock /routing/v1 record store
-        run: |
-          cd tools/mock-ipns-routing
-          npm ci
-          npm run build
-          node dist/index.js > /tmp/mock-ipns-routing.log 2>&1 &
-          curl -fsS --retry 30 --retry-connrefused --retry-delay 1 http://localhost:3001/health \
-            || { echo '--- mock-ipns-routing log ---'; cat /tmp/mock-ipns-routing.log; exit 1; }
+      - uses: ./.github/actions/mock-ipns-routing
 
       - name: Apply migrations to a fresh database
         run: pnpm --filter @cipherbox/api migration:run
@@ -882,35 +875,46 @@ jobs:
 
   web-e2e:
     name: Web E2E Smoke
-    needs: [changes, lint]
+    needs: [changes, lint, wasm-engine]
     if: |
       !failure() && !cancelled() &&
       (needs.changes.outputs.web == 'true' || needs.changes.outputs.e2e == 'true')
     permissions:
       contents: read
     uses: ./.github/workflows/web-e2e.yml
+    with:
+      wasm-artifact: web-engine-wasm
 
   # Single always-reporting gate for the smoke slice, mirroring
   # contract-suite-result: branch protection requires this stable context, so a
   # PR that touches nothing the suite covers is not blocked forever while a real
-  # smoke failure still fails this gate.
+  # smoke failure still fails this gate. It covers the engine build too, because
+  # a `wasm-engine` failure only *skips* the suite, which would otherwise read
+  # as a pass.
   web-e2e-result:
     name: Web E2E Smoke Result
-    needs: web-e2e
+    needs: [wasm-engine, web-e2e]
     if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Require the smoke slice to pass or be skipped
+      - name: Require the engine build and smoke slice to pass or be skipped
         env:
+          WASM_ENGINE_RESULT: ${{ needs.wasm-engine.result }}
           WEB_E2E_RESULT: ${{ needs.web-e2e.result }}
         run: |
-          echo "web-e2e result: ${WEB_E2E_RESULT}"
-          if [ "${WEB_E2E_RESULT}" = 'failure' ] || [ "${WEB_E2E_RESULT}" = 'cancelled' ]; then
-            echo "::error::web-e2e ${WEB_E2E_RESULT}"
-            exit 1
-          fi
+          status=0
+          for entry in "wasm-engine=${WASM_ENGINE_RESULT}" "web-e2e=${WEB_E2E_RESULT}"; do
+            job="${entry%%=*}"
+            result="${entry#*=}"
+            echo "${job} result: ${result}"
+            if [ "${result}" = 'failure' ] || [ "${result}" = 'cancelled' ]; then
+              echo "::error::${job} ${result}"
+              status=1
+            fi
+          done
+          exit "${status}"
 
   desktop-build:
     name: Desktop Build

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -70,8 +70,7 @@ jobs:
           ref: ${{ inputs.staging_tag || github.ref_name }}
 
       # apps/web compiles crates/wasm into the engine artifact it bundles.
-      - name: Add wasm target
-        run: rustup target add wasm32-unknown-unknown
+      - uses: ./.github/actions/wasm-bindgen-cli
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
@@ -79,14 +78,6 @@ jobs:
         with:
           node-version-file: 'package.json'
           cache: 'pnpm'
-
-      # wasm-bindgen-cli generates the engine glue and must match the locked
-      # wasm-bindgen version exactly (a schema mismatch fails the run).
-      - name: Install wasm-bindgen-cli (matching Cargo.lock)
-        run: |
-          WB_VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          echo "wasm-bindgen ${WB_VERSION}"
-          cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -1,8 +1,9 @@
 # The web e2e smoke slice (blueprint/testing.md). The suite runs against the
-# production static build, so this workflow carries the wasm toolchain
-# `ci.yml`'s `Web Bundle` job carries — the web bundle compiles crates/wasm.
-# It builds that bundle twice: once as it ships, once with `VITE_E2E_HOOK` for
-# the introspection seam. The suite asserts the shipping one carries no hook.
+# production static build, so it needs the engine WASM: a caller passes
+# `wasm-artifact` to hand over the module its run already built, and only a
+# standalone dispatch falls back to building one here. It builds the bundle
+# twice: once as it ships, once with `VITE_E2E_HOOK` for the introspection
+# seam. The suite asserts the shipping one carries no hook.
 name: Web E2E Tests
 
 on:
@@ -13,6 +14,14 @@ on:
         description: 'Git ref to checkout (tag, branch, or SHA)'
         required: false
         type: string
+      wasm-artifact:
+        description: >-
+          Name of a run artifact holding a prebuilt engine WASM module. Set it
+          and the suite tests exactly those bytes; leave it empty and this job
+          builds the module itself, which is what a standalone dispatch needs.
+        required: false
+        default: ''
+        type: string
 
 permissions: {}
 
@@ -20,8 +29,8 @@ jobs:
   web-e2e:
     name: Web E2E Smoke
     runs-on: ubuntu-latest
-    # The suite itself runs in seconds; the budget is the cold-cache wasm build
-    # and the wasm-bindgen-cli install ahead of it.
+    # The suite itself runs in seconds; the budget covers a standalone
+    # dispatch, where a cold-cache wasm build runs ahead of it.
     timeout-minutes: 45
     permissions:
       contents: read
@@ -68,24 +77,26 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
 
-      # Only the browser target's build tree, matching `Web Bundle`: the native
-      # subtrees the cargo jobs cache are dead weight for a wasm-only build.
+      # `target/release` is the host tree — under `--target wasm32-…` cargo puts
+      # proc macros and build scripts there, so omitting it recompiles them.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: inputs.wasm-artifact == ''
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin
+            target/release
             target/wasm32-unknown-unknown
           key: web-e2e-cargo-${{ hashFiles('Cargo.lock') }}
-          # `Web Bundle` caches the same paths off the same lockfile, so fall
-          # back to its entry rather than paying a cold wasm build twice.
+          # `Web Engine WASM` caches the same paths off the same lockfile, so
+          # fall back to its entry rather than paying a cold wasm build twice.
           restore-keys: |
             web-e2e-cargo-
-            web-bundle-cargo-
+            wasm-engine-cargo-
 
-      - name: Add wasm target
-        run: rustup target add wasm32-unknown-unknown
+      - uses: ./.github/actions/wasm-bindgen-cli
+        if: inputs.wasm-artifact == ''
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
@@ -94,32 +105,10 @@ jobs:
           node-version-file: 'package.json'
           cache: 'pnpm'
 
-      # wasm-bindgen-cli generates the engine glue and must match the locked
-      # wasm-bindgen version exactly (a schema mismatch fails the run).
-      - name: Install wasm-bindgen-cli (matching Cargo.lock)
-        run: |
-          WB_VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          echo "wasm-bindgen ${WB_VERSION}"
-          if wasm-bindgen --version 2>/dev/null | grep -qw "${WB_VERSION}"; then
-            echo "wasm-bindgen-cli ${WB_VERSION} already present (cache hit); skipping install"
-          else
-            cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked --force
-          fi
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # The promoted mock-ipns-routing tool is the hermetic /routing/v1 record
-      # store (blueprint/testing.md). It is not a pnpm workspace member, so it
-      # installs and builds with its own npm.
-      - name: Start the mock /routing/v1 record store
-        run: |
-          cd tools/mock-ipns-routing
-          npm ci
-          npm run build
-          node dist/index.js > /tmp/mock-ipns-routing.log 2>&1 &
-          curl -fsS --retry 30 --retry-connrefused --retry-delay 1 http://localhost:3001/health \
-            || { echo '--- mock-ipns-routing log ---'; cat /tmp/mock-ipns-routing.log; exit 1; }
+      - uses: ./.github/actions/mock-ipns-routing
 
       - name: Apply migrations to a fresh database
         run: pnpm --filter @cipherbox/api migration:run
@@ -131,9 +120,16 @@ jobs:
           curl -fsS --retry 60 --retry-connrefused --retry-delay 1 http://localhost:3000/health \
             || { echo '--- API log ---'; cat /tmp/api.log; exit 1; }
 
-      # The engine WASM is built once and consumed by both bundles; only the
-      # hook flag differs between them.
+      # One engine module feeds both bundles below; only the hook flag differs
+      # between them.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: inputs.wasm-artifact != ''
+        with:
+          name: ${{ inputs.wasm-artifact }}
+          path: apps/web/src/wasm
+
       - name: Build the engine WASM
+        if: inputs.wasm-artifact == ''
         run: pnpm --filter @cipherbox/web run build:wasm
 
       - name: Build the shipping bundle

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -1,9 +1,9 @@
 # The web e2e smoke slice (blueprint/testing.md). The suite runs against the
 # production static build, so it needs the engine WASM: a caller passes
-# `wasm-artifact` to hand over the module its run already built, and only a
-# standalone dispatch falls back to building one here. It builds the bundle
-# twice: once as it ships, once with `VITE_E2E_HOOK` for the introspection
-# seam. The suite asserts the shipping one carries no hook.
+# `wasm-artifact` to hand over the module its run already built, and a caller
+# that does not gets the module built here. It builds the bundle twice: once as
+# it ships, once with `VITE_E2E_HOOK` for the introspection seam. The suite
+# asserts the shipping one carries no hook.
 name: Web E2E Tests
 
 on:
@@ -77,8 +77,14 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
 
-      # `target/release` is the host tree — under `--target wasm32-…` cargo puts
-      # proc macros and build scripts there, so omitting it recompiles them.
+      # Fail fast on a missing or malformed handover, before the stack boots.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: inputs.wasm-artifact != ''
+        with:
+          name: ${{ inputs.wasm-artifact }}
+          path: apps/web/src/wasm
+
+      # Same path set as `ci.yml`'s `Web Engine WASM` cache, for the same reason.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         if: inputs.wasm-artifact == ''
         with:
@@ -89,11 +95,7 @@ jobs:
             target/release
             target/wasm32-unknown-unknown
           key: web-e2e-cargo-${{ hashFiles('Cargo.lock') }}
-          # `Web Engine WASM` caches the same paths off the same lockfile, so
-          # fall back to its entry rather than paying a cold wasm build twice.
-          restore-keys: |
-            web-e2e-cargo-
-            wasm-engine-cargo-
+          restore-keys: web-e2e-cargo-
 
       - uses: ./.github/actions/wasm-bindgen-cli
         if: inputs.wasm-artifact == ''
@@ -122,12 +124,6 @@ jobs:
 
       # One engine module feeds both bundles below; only the hook flag differs
       # between them.
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        if: inputs.wasm-artifact != ''
-        with:
-          name: ${{ inputs.wasm-artifact }}
-          path: apps/web/src/wasm
-
       - name: Build the engine WASM
         if: inputs.wasm-artifact == ''
         run: pnpm --filter @cipherbox/web run build:wasm

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -35,5 +35,7 @@ jobs:
       # (known-vulnerable-actions) depend on the GitHub advisories API and a
       # 503 there aborts the whole gate with "no audit was performed".
       # Dependabot covers action-version advisories separately.
+      # `.github/actions/` is in scope too: a composite action's `uses:` refs
+      # are as much of a supply-chain surface as a workflow's.
       - name: Run zizmor
-        run: zizmor --no-online-audits .github/workflows/
+        run: zizmor --no-online-audits .github/workflows/ .github/actions/


### PR DESCRIPTION
## 1. The engine WASM is built once per run

A new `Web Engine WASM` job compiles `crates/wasm` and uploads the wasm-bindgen output as the `web-engine-wasm` run artifact. Both consumers download it:

- `Web Bundle` now carries no Rust toolchain at all — no rustup target, no `wasm-bindgen-cli`, no cargo cache. It downloads the module and runs `build:bundle`.
- `web-e2e.yml` takes a new optional `wasm-artifact` input. `ci.yml` passes it, so the smoke slice provably exercises the bytes the bundle job produced. Left empty — standalone `workflow_dispatch`, `ci-e2e.yml`, `tag-staging.yml` — the job builds the module itself, so those callers are unchanged.

Both consumers gate on `lint` rather than the usual `!failure()`. Branch protection requires `Web Bundle` and `Web E2E Smoke Result` **by name**, and a skipped required context counts as a pass — so a failed producer must leave the consumers running and failing at the download, not skipped and green. Run 31183649713 confirms it end to end: `Web Engine WASM` failed, and `Web Bundle` went red on `Unable to download artifact(s): Artifact not found for name: web-engine-wasm` rather than skipping.

## 2. The wasm cargo cache omitted the host build tree

The cache covered `target/wasm32-unknown-unknown` only. Under `--target wasm32-...` cargo writes proc macros and build scripts to the **host** tree at `target/release`, so that tree was cold on every run — and a missing proc-macro dylib forces a rebuild of the proc macro and every build-script dependency chain behind it.

Both wasm caches now list `target/release`. The key prefix moved to `wasm-engine-cargo-` because `actions/cache` does not re-save on an exact key hit, so a stale entry under the old prefix would never have picked up the new paths.

| warm cache, PR touching one engine file | crates recompiled | build step |
| --- | --- | --- |
| before, run 31178772656 | 63 | 37s |
| after, run 31184508213 | 3 | 13s |

## 3. `.github/actions/`

Two composite actions collapse blocks that had already drifted across five jobs in four workflows:

- `.github/actions/wasm-bindgen-cli` — adds the rustup targets and installs `wasm-bindgen-cli` at the version `Cargo.lock` pins. Used by `Web Engine WASM`, `Core KATs`, `Client Browser Suite`, `web-e2e.yml`, and `deploy-staging.yml`. The staging copy had drifted: it lacked the cache-hit skip and re-ran a full `cargo install` on every deploy. The version check is now an exact string compare with an explicit abort on an unreadable lockfile — it was a `grep -qw` regex that an empty version would have satisfied against any installed binary.
- `.github/actions/mock-ipns-routing` — builds and boots the hermetic `/routing/v1` store and waits on its health endpoint. Used by `Contract Suite` and `web-e2e.yml`.

`desktop-e2e.yml` keeps its own inline copy: it is a three-OS matrix that splits build and start across steps for env ordering, it is dispatch-gated, and no PR gate would have exercised the conversion.

The zizmor gate now audits `.github/actions/` alongside `.github/workflows/` — a composite action's `uses:` refs are the same supply-chain surface. `.github/actions/**` was added to the `ts`, `rust` and `web` paths filters so a composite-action change re-runs the gates that consume it.

## Measurements

All from real runs on this PR against runs on other PRs from the same hour.

Cold cargo cache — the case every newly opened PR hits, see follow-up below:

| | before, run 31181193884 | after, run 31182939871 |
| --- | --- | --- |
| `Web Engine WASM` | — | 158s |
| `Web Bundle` | 179s | 30s |
| `Web E2E Smoke` | 243s | 105s |
| **runner minutes** | **422s** | **293s** &nbsp;(-31%) |
| wall-clock after `Lint` | 246s | 292s &nbsp;(+46s) |

Warm cargo cache:

| | before, run 31178772656 | after, run 31184508213 |
| --- | --- | --- |
| `Web Engine WASM` | — | 45s |
| `Web Bundle` | 76s | 27s |
| `Web E2E Smoke` | 149s | 137s |
| **runner minutes** | **225s** | **209s** &nbsp;(-7%) |

### On the wall-clock gate

Gates 1 and 2 are met. Gate 3 — "total CI wall-clock for a web-touching PR is measurably lower" — is **not** met on a cold cache: it is 46s worse. The reason is measured rather than guessed. `Web Engine WASM` is 158s cold, of which **104s is `cargo install wasm-bindgen-cli` building the CLI from source** and only 31s is the actual engine build. That install used to run twice in parallel; it now runs once, but on the critical path of two jobs.

Two follow-ups turn the runner-minute win into a wall-clock win, both filed with a dependency edge on this issue:

- FSM1/cipher-box#1152 — install `wasm-bindgen-cli` from a prebuilt binary. Attempted here and reverted: `taiki-e/install-action` is rejected by this repository's allowed-actions patterns, so the fix needs an allowlist decision rather than more code. That alone would take the producer from 158s to ~54s cold.
- FSM1/cipher-box#1153 — seed the cargo caches from `main`. `ci.yml` triggers on `pull_request` only and GitHub scopes a cache entry to the ref that wrote it, so every PR's first run is cache-cold on every cargo job. Verified against the live cache list: 39 entries, exactly one on `refs/heads/main`.

## Verification

A CI change cannot be proven from a worktree, so this was driven off the runs above. Additionally:

- `zizmor 1.25.2 --no-online-audits .github/workflows/ .github/actions/` — no findings.
- `node scripts/check-tracker-refs.mjs` — clean.
- Confirmed locally that `cargo build -p cipherbox-wasm --release --target wasm32-unknown-unknown` populates `target/release/{build,deps}` with 61 MB of host proc-macro and build-script artifacts, separately from `target/wasm32-unknown-unknown` — the tree the old cache omitted.
- Confirmed `pnpm --filter @cipherbox/web run build:wasm` runs with no `node_modules` present, which is why `Web Engine WASM` needs no `pnpm install`.

## Follow-up for a repo admin

`Web Engine WASM` is worth adding to the required-contexts list. It is path-filtered, so it reports `skipped` on a PR that touches nothing web-related, which satisfies branch protection. The consumers' fail-closed gating already covers the hole without it.

Closes #1088


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build engine WASM once per CI run and cache the host build tree
> - Introduces a dedicated `wasm-engine` job in [ci.yml](.github/workflows/ci.yml) that builds the browser engine WASM once, uploads it as the `web-engine-wasm` artifact, and shares it with downstream `web-bundle` and `web-e2e` jobs instead of rebuilding it in each job.
> - Adds two reusable composite actions: [wasm-bindgen-cli](.github/actions/wasm-bindgen-cli/action.yml) installs `wasm-bindgen-cli` pinned to the version in `Cargo.lock`, and [mock-ipns-routing](.github/actions/mock-ipns-routing/action.yml) starts the hermetic mock `/routing/v1` record store.
> - Updates [web-e2e.yml](.github/workflows/web-e2e.yml) to accept an optional `wasm-artifact` input and skip the local engine build when a prebuilt artifact is provided.
> - Expands change-detection path filters and the [zizmor.yml](.github/workflows/zizmor.yml) static audit scope to cover `.github/actions/**`.
> - Behavioral Change: `web-bundle` and `web-e2e` jobs now fail-closed on a failed `wasm-engine` job rather than being skipped as green.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b093f7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD Improvements**
  * Added reusable automation for WASM toolchain setup and mock IPNS routing.
  * Centralized WASM engine builds and shared the resulting artifact across browser packaging and end-to-end testing.
  * Improved caching and workflow failure visibility.
  * Updated staging and end-to-end workflows to use the shared setup.
* **Security**
  * Extended automated workflow audits to include composite actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->