### PR TITLE
fix: derive the cold-seed anchor role from authenticated scope identity

### DIFF
--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -118,15 +118,35 @@ impl std::error::Error for ColdSeedError {}
 /// never a security hole, since no rollback is accepted and the write-epoch
 /// check stays unconditionally sound. `Shared` therefore never runs the
 /// read-epoch check; only `Root` does.
+///
+/// The role is never an argument: [`cold_seed_checked`] derives it from the
+/// scope's authenticated identity, so no caller — and therefore no transport —
+/// can claim `Shared` for the vault anchor to suppress the read-epoch check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AnchorRole {
     /// The vault/root anchor: read-epoch check runs (alongside write-epoch).
     Root,
     /// A shared scope: read-epoch check skipped; only write-epoch runs.
-    ///
-    /// A production `Shared` caller MUST select this role from authenticated
-    /// scope identity, never a network/`RepointObject` field.
     Shared,
+}
+
+impl AnchorRole {
+    /// Select the role from authenticated scope identity: the session's own
+    /// vault anchor is [`AnchorRole::Root`], every other scope is
+    /// [`AnchorRole::Shared`].
+    ///
+    /// Both operands are trusted. `session_root_scope_id` is session state
+    /// derived from the login secret, and a [`RepointObject`]'s `scope_id` is
+    /// sealed into the pointer payload AAD and covered by the owner signature —
+    /// so an untrusted transport can neither forge a scope id nor transplant a
+    /// shared scope's re-point onto the vault anchor.
+    fn for_scope(session_root_scope_id: &[u8; 16], scope_id: &[u8; 16]) -> Self {
+        if scope_id == session_root_scope_id {
+            AnchorRole::Root
+        } else {
+            AnchorRole::Shared
+        }
+    }
 }
 
 /// Suffix that distinguishes a scope's write-epoch floor key from its
@@ -309,7 +329,10 @@ pub async fn cold_seed<F: FloorStore>(floors: &F, repoint: &RepointObject) -> Se
 /// regresses does it advance the floors via the monotonic-max [`cold_seed`].
 ///
 /// The read-epoch check runs under [`AnchorRole::Root`] only; the write-epoch
-/// check is unconditional — see [`AnchorRole`] for why.
+/// check is unconditional — see [`AnchorRole`] for why. The role is derived from
+/// the re-point's own scope id against `session_root_scope_id` (the session's
+/// vault anchor, from the derived session identity), never supplied by the
+/// caller.
 ///
 /// Check-then-advance is deliberately not a CAS pair: the engine is the single
 /// writer (blueprint/engine.md "Facade"), and the monotonic-max store backstops
@@ -317,9 +340,9 @@ pub async fn cold_seed<F: FloorStore>(floors: &F, repoint: &RepointObject) -> Se
 pub async fn cold_seed_checked<F: FloorStore>(
     floors: &F,
     repoint: &RepointObject,
-    role: AnchorRole,
+    session_root_scope_id: &[u8; 16],
 ) -> Result<(), ColdSeedError> {
-    if role == AnchorRole::Root {
+    if AnchorRole::for_scope(session_root_scope_id, &repoint.scope_id) == AnchorRole::Root {
         if let Some(floor) = read_epoch_floor(floors, &repoint.scope_id)
             .await
             .map_err(ColdSeedError::Seam)?
@@ -368,6 +391,9 @@ mod tests {
     use crate::testkit::fakes::InMemoryFloorStore;
 
     const SCOPE: [u8; 16] = [7u8; 16];
+    /// A scope id that is not the session's vault anchor — cold-seeding it is a
+    /// shared-scope seed.
+    const SHARED_SCOPE: [u8; 16] = [8u8; 16];
     const NAME: &[u8] = b"k51-scope-root-name";
 
     #[test]
@@ -454,13 +480,13 @@ mod tests {
         let floors = InMemoryFloorStore::default();
         block_on(async {
             // A fresh (unseeded) scope adopts the owner-vouched anchor.
-            cold_seed_checked(&floors, &repoint(SCOPE, 5, 3), AnchorRole::Root)
+            cold_seed_checked(&floors, &repoint(SCOPE, 5, 3), &SCOPE)
                 .await
                 .unwrap();
             assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(5));
             assert_eq!(write_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(3));
             // Re-seeding at or above the floor advances monotonically.
-            cold_seed_checked(&floors, &repoint(SCOPE, 7, 3), AnchorRole::Root)
+            cold_seed_checked(&floors, &repoint(SCOPE, 7, 3), &SCOPE)
                 .await
                 .unwrap();
             assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(7));
@@ -471,11 +497,11 @@ mod tests {
     fn cold_seed_checked_rejects_a_read_epoch_regression_fail_closed() {
         let floors = InMemoryFloorStore::default();
         block_on(async {
-            cold_seed_checked(&floors, &repoint(SCOPE, 5, 3), AnchorRole::Root)
+            cold_seed_checked(&floors, &repoint(SCOPE, 5, 3), &SCOPE)
                 .await
                 .unwrap();
             // A rolled-back re-point vouching a lower minReadEpoch is fail-closed.
-            let err = cold_seed_checked(&floors, &repoint(SCOPE, 4, 3), AnchorRole::Root)
+            let err = cold_seed_checked(&floors, &repoint(SCOPE, 4, 3), &SCOPE)
                 .await
                 .expect_err("read-epoch regression is a trust violation");
             assert_eq!(
@@ -494,10 +520,10 @@ mod tests {
     fn cold_seed_checked_rejects_a_write_epoch_regression_fail_closed() {
         let floors = InMemoryFloorStore::default();
         block_on(async {
-            cold_seed_checked(&floors, &repoint(SCOPE, 5, 6), AnchorRole::Root)
+            cold_seed_checked(&floors, &repoint(SCOPE, 5, 6), &SCOPE)
                 .await
                 .unwrap();
-            let err = cold_seed_checked(&floors, &repoint(SCOPE, 5, 4), AnchorRole::Root)
+            let err = cold_seed_checked(&floors, &repoint(SCOPE, 5, 4), &SCOPE)
                 .await
                 .expect_err("write-epoch regression is a trust violation");
             assert_eq!(
@@ -511,32 +537,53 @@ mod tests {
         });
     }
 
-    /// The read-epoch regression check is unrepresentable for a shared scope:
-    /// under [`AnchorRole::Shared`] a `minReadEpoch` far below the durable
-    /// read-epoch floor (the legitimate steady state once grantee lazy rotation
-    /// has unseal-advanced that floor) seeds cleanly instead of false-positiving
-    /// into a fail-closed DoS. The same input under `Root` is fail-closed.
+    /// The role follows the re-point's own scope id against the session's vault
+    /// anchor, so a shared scope can never be seeded as `Root` nor the vault
+    /// anchor as `Shared`.
+    #[test]
+    fn the_anchor_role_follows_the_scopes_position_not_the_caller() {
+        assert_eq!(AnchorRole::for_scope(&SCOPE, &SCOPE), AnchorRole::Root);
+        assert_eq!(
+            AnchorRole::for_scope(&SCOPE, &SHARED_SCOPE),
+            AnchorRole::Shared
+        );
+    }
+
+    /// The read-epoch regression check is unrepresentable for a shared scope: a
+    /// `minReadEpoch` far below the durable read-epoch floor (the legitimate
+    /// steady state once grantee lazy rotation has unseal-advanced that floor)
+    /// seeds cleanly instead of false-positiving into a fail-closed DoS. The
+    /// same numbers at the vault anchor are fail-closed.
     #[test]
     fn cold_seed_checked_shared_scope_skips_the_read_epoch_check() {
         let floors = InMemoryFloorStore::default();
         block_on(async {
-            // Grantee lazy rotation has driven the read-epoch floor to 9.
+            // Grantee lazy rotation has driven both scopes' read-epoch floor to 9.
+            advance_on_unseal(&floors, &SHARED_SCOPE, NAME, 1, 9)
+                .await
+                .unwrap();
             advance_on_unseal(&floors, &SCOPE, NAME, 1, 9)
                 .await
                 .unwrap();
 
             // A shared-scope cold-seed vouching minReadEpoch 4 (< floor 9) is the
             // normal steady state — it must NOT fire the read-epoch check.
-            cold_seed_checked(&floors, &repoint(SCOPE, 4, 2), AnchorRole::Shared)
+            cold_seed_checked(&floors, &repoint(SHARED_SCOPE, 4, 2), &SCOPE)
                 .await
                 .expect("shared-scope cold-seed never runs the read-epoch check");
             // The monotonic-max floor is unmoved by the lower vouched read epoch;
             // the write-epoch floor still seeds.
-            assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(9));
-            assert_eq!(write_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(2));
+            assert_eq!(
+                read_epoch_floor(&floors, &SHARED_SCOPE).await.unwrap(),
+                Some(9)
+            );
+            assert_eq!(
+                write_epoch_floor(&floors, &SHARED_SCOPE).await.unwrap(),
+                Some(2)
+            );
 
-            // The identical input at the root anchor IS a fail-closed rollback.
-            let err = cold_seed_checked(&floors, &repoint(SCOPE, 4, 2), AnchorRole::Root)
+            // The identical input at the vault anchor IS a fail-closed rollback.
+            let err = cold_seed_checked(&floors, &repoint(SCOPE, 4, 2), &SCOPE)
                 .await
                 .expect_err("the read-epoch check is sound and active at the root anchor");
             assert_eq!(
@@ -552,17 +599,23 @@ mod tests {
     /// Skipping the read-epoch *check* for a shared scope must not skip the
     /// unconditional `cold_seed`: a fresh (None) shared scope still seeds its
     /// read-epoch floor to `minReadEpoch` via the monotonic-max raise, exactly
-    /// as `Root` does. Guards a future refactor from dropping the seed for
-    /// `Shared`.
+    /// as the vault anchor does. Guards a future refactor from dropping the seed
+    /// for a shared scope.
     #[test]
     fn cold_seed_checked_shared_scope_seeds_a_fresh_read_epoch_floor() {
         let floors = InMemoryFloorStore::default();
         block_on(async {
-            cold_seed_checked(&floors, &repoint(SCOPE, 5, 3), AnchorRole::Shared)
+            cold_seed_checked(&floors, &repoint(SHARED_SCOPE, 5, 3), &SCOPE)
                 .await
                 .expect("a fresh shared scope seeds without running the read-epoch check");
-            assert_eq!(read_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(5));
-            assert_eq!(write_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(3));
+            assert_eq!(
+                read_epoch_floor(&floors, &SHARED_SCOPE).await.unwrap(),
+                Some(5)
+            );
+            assert_eq!(
+                write_epoch_floor(&floors, &SHARED_SCOPE).await.unwrap(),
+                Some(3)
+            );
         });
     }
 
@@ -572,10 +625,10 @@ mod tests {
     fn cold_seed_checked_shared_scope_still_rejects_a_write_epoch_regression() {
         let floors = InMemoryFloorStore::default();
         block_on(async {
-            cold_seed_checked(&floors, &repoint(SCOPE, 5, 6), AnchorRole::Shared)
+            cold_seed_checked(&floors, &repoint(SHARED_SCOPE, 5, 6), &SCOPE)
                 .await
                 .unwrap();
-            let err = cold_seed_checked(&floors, &repoint(SCOPE, 5, 4), AnchorRole::Shared)
+            let err = cold_seed_checked(&floors, &repoint(SHARED_SCOPE, 5, 4), &SCOPE)
                 .await
                 .expect_err("write-epoch regression is fail-closed for every role");
             assert_eq!(

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -45,7 +45,7 @@ use crate::seams::{FloorRaise, FloorStore, SeamError, SeamResult};
 /// staleness (the floor law: revocation boundaries cannot be rolled back).
 ///
 /// Where the read-epoch comparison is sound — and where it must not run — is
-/// [`AnchorRole`]'s contract.
+/// [`cold_seed_checked`]'s contract.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FloorRegression {
     /// The re-point's `minReadEpoch` is strictly below the durable read-epoch
@@ -103,51 +103,6 @@ impl core::fmt::Display for ColdSeedError {
 }
 
 impl std::error::Error for ColdSeedError {}
-
-/// The scope role a cold-seed runs against — the gate on the read-epoch
-/// (revocation) regression check, which is sound **only at the root/vault
-/// anchor**.
-///
-/// At the root scope the read epoch is owner-authored, so
-/// [`advance_on_unseal`] raises the read-epoch floor in lockstep with the owner
-/// clock and a vouched `minReadEpoch` below the durable floor is an unambiguous
-/// owner rollback (correct fail-closed). At a **shared** scope a grantee's
-/// legitimate lazy-rotation unseal-advances that same floor *past* the
-/// owner-authored `minReadEpoch`, so the identical comparison would
-/// false-positive into a self-inflicted fail-closed **DoS** (a bricked boot) —
-/// never a security hole, since no rollback is accepted and the write-epoch
-/// check stays unconditionally sound. `Shared` therefore never runs the
-/// read-epoch check; only `Root` does.
-///
-/// The role is never an argument: [`cold_seed_checked`] derives it from the
-/// scope's authenticated identity, so no caller — and therefore no transport —
-/// can claim `Shared` for the vault anchor to suppress the read-epoch check.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AnchorRole {
-    /// The vault/root anchor: read-epoch check runs (alongside write-epoch).
-    Root,
-    /// A shared scope: read-epoch check skipped; only write-epoch runs.
-    Shared,
-}
-
-impl AnchorRole {
-    /// Select the role from authenticated scope identity: the session's own
-    /// vault anchor is [`AnchorRole::Root`], every other scope is
-    /// [`AnchorRole::Shared`].
-    ///
-    /// Both operands are trusted. `session_root_scope_id` is session state
-    /// derived from the login secret, and a [`RepointObject`]'s `scope_id` is
-    /// sealed into the pointer payload AAD and covered by the owner signature —
-    /// so an untrusted transport can neither forge a scope id nor transplant a
-    /// shared scope's re-point onto the vault anchor.
-    fn for_scope(session_root_scope_id: &[u8; 16], scope_id: &[u8; 16]) -> Self {
-        if scope_id == session_root_scope_id {
-            AnchorRole::Root
-        } else {
-            AnchorRole::Shared
-        }
-    }
-}
 
 /// Suffix that distinguishes a scope's write-epoch floor key from its
 /// read-epoch floor key inside the [`FloorStore`] epoch namespace. The
@@ -322,17 +277,22 @@ pub async fn cold_seed<F: FloorStore>(floors: &F, repoint: &RepointObject) -> Se
 /// the single checked cold-seed seam production uses.
 ///
 /// Reads the durable floors and rejects before any write if the owner-vouched
-/// re-point would move one backward: a re-point whose `writeEpoch` (any role),
-/// or whose `minReadEpoch` (root anchor only, see below), is strictly below the
-/// durable floor is a rolled-back pointer (a replay past a revocation
+/// re-point would move one backward: a re-point whose `writeEpoch` (any scope),
+/// or whose `minReadEpoch` (the vault anchor only, see below), is strictly below
+/// the durable floor is a rolled-back pointer (a replay past a revocation
 /// boundary), a trust violation never mere staleness. Only when nothing
 /// regresses does it advance the floors via the monotonic-max [`cold_seed`].
 ///
-/// The read-epoch check runs under [`AnchorRole::Root`] only; the write-epoch
-/// check is unconditional — see [`AnchorRole`] for why. The role is derived from
-/// the re-point's own scope id against `session_root_scope_id` (the session's
-/// vault anchor, from the derived session identity), never supplied by the
-/// caller.
+/// The read-epoch check runs **only at the vault anchor**, and this function
+/// selects that from the re-point's own scope id against `session_root_scope_id`
+/// — never from a caller, so no wiring can suppress it. At the vault anchor the
+/// read epoch is owner-authored, so a vouched `minReadEpoch` below the durable
+/// floor is an unambiguous owner rollback. At a shared scope a grantee's
+/// legitimate lazy rotation unseal-advances that same floor *past* the
+/// owner-authored `minReadEpoch`, so the identical comparison would
+/// false-positive into a self-inflicted bricked boot. Either way no rollback is
+/// accepted: the write-epoch check stays unconditional and every advance is
+/// monotonic-max.
 ///
 /// Check-then-advance is deliberately not a CAS pair: the engine is the single
 /// writer (blueprint/engine.md "Facade"), and the monotonic-max store backstops
@@ -342,7 +302,7 @@ pub async fn cold_seed_checked<F: FloorStore>(
     repoint: &RepointObject,
     session_root_scope_id: &[u8; 16],
 ) -> Result<(), ColdSeedError> {
-    if AnchorRole::for_scope(session_root_scope_id, &repoint.scope_id) == AnchorRole::Root {
+    if repoint.scope_id == *session_root_scope_id {
         if let Some(floor) = read_epoch_floor(floors, &repoint.scope_id)
             .await
             .map_err(ColdSeedError::Seam)?
@@ -391,8 +351,6 @@ mod tests {
     use crate::testkit::fakes::InMemoryFloorStore;
 
     const SCOPE: [u8; 16] = [7u8; 16];
-    /// A scope id that is not the session's vault anchor — cold-seeding it is a
-    /// shared-scope seed.
     const SHARED_SCOPE: [u8; 16] = [8u8; 16];
     const NAME: &[u8] = b"k51-scope-root-name";
 
@@ -535,18 +493,6 @@ mod tests {
             );
             assert_eq!(write_epoch_floor(&floors, &SCOPE).await.unwrap(), Some(6));
         });
-    }
-
-    /// The role follows the re-point's own scope id against the session's vault
-    /// anchor, so a shared scope can never be seeded as `Root` nor the vault
-    /// anchor as `Shared`.
-    #[test]
-    fn the_anchor_role_follows_the_scopes_position_not_the_caller() {
-        assert_eq!(AnchorRole::for_scope(&SCOPE, &SCOPE), AnchorRole::Root);
-        assert_eq!(
-            AnchorRole::for_scope(&SCOPE, &SHARED_SCOPE),
-            AnchorRole::Shared
-        );
     }
 
     /// The read-epoch regression check is unrepresentable for a shared scope: a

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -208,8 +208,6 @@ where
 
     // Step 2 — floor cold-seed, fail-closed on regression: a re-point that would
     // move either floor backward is a rolled-back pointer, a trust violation.
-    // The anchor role is derived from the session's own root scope id, never
-    // chosen here (see `floor::AnchorRole`).
     floor::cold_seed_checked(floors, &adoption.repoint, &params.root_scope_id)
         .await
         .map_err(|e| match e {
@@ -564,43 +562,11 @@ mod tests {
         });
     }
 
+    /// The floors a first cold start seeds are the ones a rolled-back re-point
+    /// trips on the next boot: the replay is validly owner-signed, so only the
+    /// floor law catches it.
     #[test]
     fn floor_regression_is_fail_closed_and_emits_nothing() {
-        block_on(async {
-            let pointers = ScriptedPointers::default();
-            let root_name = IpnsName::from_public_key(&root_signer().verifying_key());
-            // The re-point vouches a lower minReadEpoch than the durable floor.
-            pointers.seal_index(&owner(), 0, &repoint(root_name.clone(), 2, 1));
-
-            let floors = InMemoryFloorStore::default();
-            floors.raise_epoch_floor(&ROOT_SCOPE, 5).await.unwrap();
-
-            let (out, events) = run(
-                &pointers,
-                &ScriptedAdopter::adopting(),
-                &floors,
-                &transport_with_root_record(&root_name),
-                &InMemorySnapshotCache::default(),
-                &pending_create(),
-            )
-            .await;
-            assert_eq!(
-                out,
-                Err(ColdStartError::FloorRegression(
-                    FloorRegression::ReadEpoch {
-                        floor: 5,
-                        vouched: 2,
-                    }
-                ))
-            );
-            assert!(events.is_empty(), "a trust violation never paints");
-        });
-    }
-
-    /// End-to-end: the floors a first cold start seeds are the ones a rolled-back
-    /// re-point trips on the next boot — no floor pre-seeding in the fixture.
-    #[test]
-    fn a_rolled_back_repoint_is_fail_closed_against_the_floors_a_prior_boot_seeded() {
         block_on(async {
             let pointers = ScriptedPointers::default();
             let root_name = IpnsName::from_public_key(&root_signer().verifying_key());
@@ -614,13 +580,11 @@ mod tests {
                 &floors,
                 &transport,
                 &InMemorySnapshotCache::default(),
-                &[],
+                &pending_create(),
             )
             .await;
             first.expect("the first boot seeds the floors");
 
-            // The owner-signed index is replaced by an older, still validly signed
-            // re-point: a replay the signature alone cannot detect.
             pointers.seal_index(&owner(), 0, &repoint(root_name.clone(), 2, 3));
             let (second, events) = run(
                 &pointers,
@@ -628,7 +592,7 @@ mod tests {
                 &floors,
                 &transport,
                 &InMemorySnapshotCache::default(),
-                &[],
+                &pending_create(),
             )
             .await;
             assert_eq!(

--- a/crates/engine/src/sync/boot.rs
+++ b/crates/engine/src/sync/boot.rs
@@ -208,10 +208,9 @@ where
 
     // Step 2 — floor cold-seed, fail-closed on regression: a re-point that would
     // move either floor backward is a rolled-back pointer, a trust violation.
-    // The vault pointer is the root/vault anchor, so the read-epoch check is
-    // sound here (`AnchorRole::Root`); a shared-scope cold-seed would pass
-    // `Shared`.
-    floor::cold_seed_checked(floors, &adoption.repoint, floor::AnchorRole::Root)
+    // The anchor role is derived from the session's own root scope id, never
+    // chosen here (see `floor::AnchorRole`).
+    floor::cold_seed_checked(floors, &adoption.repoint, &params.root_scope_id)
         .await
         .map_err(|e| match e {
             ColdSeedError::Seam(seam) => ColdStartError::Seam(seam),
@@ -587,6 +586,53 @@ mod tests {
             .await;
             assert_eq!(
                 out,
+                Err(ColdStartError::FloorRegression(
+                    FloorRegression::ReadEpoch {
+                        floor: 5,
+                        vouched: 2,
+                    }
+                ))
+            );
+            assert!(events.is_empty(), "a trust violation never paints");
+        });
+    }
+
+    /// End-to-end: the floors a first cold start seeds are the ones a rolled-back
+    /// re-point trips on the next boot — no floor pre-seeding in the fixture.
+    #[test]
+    fn a_rolled_back_repoint_is_fail_closed_against_the_floors_a_prior_boot_seeded() {
+        block_on(async {
+            let pointers = ScriptedPointers::default();
+            let root_name = IpnsName::from_public_key(&root_signer().verifying_key());
+            pointers.seal_index(&owner(), 0, &repoint(root_name.clone(), 5, 3));
+
+            let floors = InMemoryFloorStore::default();
+            let transport = transport_with_root_record(&root_name);
+            let (first, _) = run(
+                &pointers,
+                &ScriptedAdopter::adopting(),
+                &floors,
+                &transport,
+                &InMemorySnapshotCache::default(),
+                &[],
+            )
+            .await;
+            first.expect("the first boot seeds the floors");
+
+            // The owner-signed index is replaced by an older, still validly signed
+            // re-point: a replay the signature alone cannot detect.
+            pointers.seal_index(&owner(), 0, &repoint(root_name.clone(), 2, 3));
+            let (second, events) = run(
+                &pointers,
+                &ScriptedAdopter::adopting(),
+                &floors,
+                &transport,
+                &InMemorySnapshotCache::default(),
+                &[],
+            )
+            .await;
+            assert_eq!(
+                second,
                 Err(ColdStartError::FloorRegression(
                     FloorRegression::ReadEpoch {
                         floor: 5,

--- a/crates/engine/tests/sync.rs
+++ b/crates/engine/tests/sync.rs
@@ -28,7 +28,7 @@ use cipherbox_engine::rotation::{
 };
 use cipherbox_engine::seams::{SeamResult, StagingStore, UnixMillis};
 use cipherbox_engine::sync::model::NodeMeta;
-use cipherbox_engine::sync::pointer::{seal_repoint, vault_pointer_name};
+use cipherbox_engine::sync::pointer::{open_repoint, seal_repoint, vault_pointer_name};
 use cipherbox_engine::sync::{
     self, Connectivity, DeadLetterReason, DropReason, NewNode, Op, OpResolution, PointerFetch,
     RecordReader, RecordSeal, ScopeCrossing, SessionRole, Snapshot, StagedContent, apply_repairs,
@@ -607,6 +607,48 @@ fn cold_start_adopts_nothing_until_the_floor_seeds_from_the_pointer() {
             "the floor seeded from the owner-signed re-point anchor"
         );
     });
+}
+
+/// `floor::cold_seed_checked` picks the vault anchor by an opened re-point's
+/// `scopeId`. That is sound only because the pointer seal derives its AAD from
+/// that same field, so a re-point opens under no other scope id — pinned here
+/// rather than left to the encoder.
+#[test]
+fn a_repoint_opens_only_under_the_scope_id_it_names() {
+    let owner = EcdsaSigner::from_scalar(&[3u8; 32]).unwrap();
+    let read_key = kdf::pointer_read_key(
+        kdf::owner_pointer_seed(LOGIN_SECRET).as_bytes(),
+        &ROOT_SCOPE,
+    );
+    let mut entropy = SeededEntropy::new(1);
+    let block = seal_repoint(
+        SessionRole::Owner,
+        &mut entropy,
+        read_key.as_bytes(),
+        1,
+        &owner,
+        &repoint(5, 3),
+    )
+    .unwrap();
+
+    let opened = open_repoint(
+        read_key.as_bytes(),
+        1,
+        &ROOT_SCOPE,
+        &owner.verifying_key(),
+        &block,
+    )
+    .expect("a re-point opens under the scope id it names");
+    assert_eq!(opened.scope_id, ROOT_SCOPE);
+
+    open_repoint(
+        read_key.as_bytes(),
+        1,
+        &[9u8; 16],
+        &owner.verifying_key(),
+        &block,
+    )
+    .expect_err("the seal AAD binds the re-point to the scope id it names");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/engine/tests/sync.rs
+++ b/crates/engine/tests/sync.rs
@@ -595,7 +595,7 @@ fn cold_start_adopts_nothing_until_the_floor_seeds_from_the_pointer() {
         assert_eq!(adopted.index, 0);
         // The vault pointer is the root anchor: cold-seed through the same
         // checked, fail-closed seam production's `cold_start` uses.
-        floor::cold_seed_checked(&floors, &adopted.repoint, floor::AnchorRole::Root)
+        floor::cold_seed_checked(&floors, &adopted.repoint, &ROOT_SCOPE)
             .await
             .unwrap();
 


### PR DESCRIPTION
## What

`gate::floor::cold_seed_checked` took the `AnchorRole` as a caller-supplied
argument. The read-epoch (revocation) regression check runs only under
`AnchorRole::Root`, so any caller that could pick `Shared` for the vault anchor
would suppress that check. #774's security and crypto-privacy reviews flagged
this (INFO-1) as the invariant a future shared-scope cold-seed caller must
preserve.

This removes the choice rather than documenting it. The role is now derived
inside `cold_seed_checked` from the re-point's own `scope_id` against the
session's root scope id:

- `session_root_scope_id` is session state derived from the login secret.
- `RepointObject::scope_id` is sealed into the pointer-payload AAD
  (`pointer_ctx(v, object.scope_id)`) and covered by the owner's ECDSA
  signature over the object bytes, so a transport can neither forge it nor
  transplant a shared scope's re-point onto the vault anchor.

Neither operand is network-selectable, and `AnchorRole` is no longer nameable
by any caller — the invariant is structural, not a convention.

Also lands INFO-2: an end-to-end `boot::cold_start` test that seeds the floors
through a first real boot and then trips `ColdStartError::FloorRegression` on a
rolled-back but still validly owner-signed re-point at the same index. The
existing coverage pre-seeded the floor directly, so it never exercised the
seed-then-regress sequence.

## Not in this change

No production `AnchorRole::Shared` caller is wired, because the grantee-plane
shared-scope resolve does not exist yet: `sync::pointer::scope_pointer_name`
derives the scope pointer name from the **owner's** `ownerPointerSeed`, which a
grantee does not hold, and no wire field carries that name to a grantee.
`grants::accept` persists a `pointerReadKey` per share but nothing reads it
back, `sync::pointer::open_repoint` has no non-test caller, and
`Command::AcceptShare` still returns `EngineError::Unimplemented`. Wiring the
caller therefore means designing grantee-side pointer-name delivery, which is
its own slice. What this change guarantees is that when that slice lands, it
cannot get the role wrong.

## Gates

| Gate | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace` | 0 |
| `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` | 0 |


## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` all ran on
`git diff main...HEAD`. Folded in:

- **simplify (real):** `AnchorRole` became dead public surface once the role
  stopped being an argument. Inlined the comparison into `cold_seed_checked`
  and deleted the enum, its `impl`, and the unit test that asserted the private
  helper rather than behaviour. The read-epoch-soundness rationale is now stated
  once, on `cold_seed_checked`.
- **simplify (real):** the same rationale was restated four times. Now once.
- **simplify (nit):** the new end-to-end test overlapped
  `floor_regression_is_fail_closed_and_emits_nothing`. Merged into one test that
  seeds the floors through a real first boot and then replays a validly signed
  older re-point.
- **security MED / crypto-privacy MED, same mechanism:** the derivation rests on
  `RepointObject::scope_id` equalling the AAD scope its block was opened under,
  and only the encoder enforced that. Verified the mechanism: `seal_pointer_payload`
  derives the AAD from `object.scope_id`, and the AEAD tag covers the AAD, so a
  block whose inner `scopeId` disagreed with the AAD could not open at all. A
  decode-side equality check in `crates/core` would therefore be unreachable and
  could carry no reject vector, which the crate's reject-coverage law requires of
  every check. Pinned behaviourally instead: `a_repoint_opens_only_under_the_scope_id_it_names`
  in `crates/engine/tests/sync.rs`.
- **security LOW:** root scope ids are the constant `[0u8;16]` for every account,
  so scope ids are not globally distinguishing at the root. That is the defect
  tracked separately as the second-account epoch-floor lockout; not introduced
  here and not in scope for this change.

Closes #775
