### PR TITLE
fix: narrow the settings first-run carve-out to a device with no mark of a record

### DIFF
--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -247,17 +247,30 @@ degraded outcome applies a different policy rather than showing stale data.
   can report is the one this device last authenticated, never the built-in
   default. A rollback takes the same path — pinning last-known-good is what
   the gate already owes a rejected record.
-- **No last-known-good copy fails the placement decision closed.** The
-  built-in defaults describe a first run — no record anywhere, no durable
-  floor. Residual: that is a verdict about _this device_, so a record-plane
-  adversary who withholds the record from one that has never synced still
-  reaches the first-run default; closing it needs positive evidence that the
-  account has never published settings, which no device-local seam carries. Under any other reason, with no cached copy to fall back on, a
-  placement decision refuses the hosted upload rather than resolving to
-  `PinMode::Hosted`; the member is told their settings are unavailable. A
-  consumer that branches only on the resolved case, letting the degraded ones
-  fall through to the defaults, reintroduces exactly the widening this policy
-  exists to prevent.
+- **No last-known-good copy fails the placement decision closed.** Under every
+  reason but one, with no cached copy to fall back on, a placement decision
+  refuses the hosted upload rather than resolving to `PinMode::Hosted`; the
+  member is told their settings are unavailable. A consumer that branches only
+  on the resolved case, letting the degraded ones fall through to the defaults,
+  reintroduces exactly the widening this policy exists to prevent.
+- **The one arm that still authorises a write is named for what it assumes.**
+  The built-in defaults stand in for a first run, and the reason that carries
+  them says so: `UnprovenFirstRun`. It is reached only when no endpoint served a
+  record _and_ this device holds no durable mark of one — neither the per-name
+  sequence floor, nor the adopted body revision, nor the mint counter. The three
+  are read together and fail closed together, so a floor store that took one
+  raise and lost another can never downgrade a suppression into a first run.
+  The mint counter is the load-bearing one: it rises _before_ the PUT, so a save
+  that never confirmed still refuses every later widening — the moment a
+  placement change is least confirmed is the moment reverting it is most
+  valuable to an adversary.
+  Residual: absence is still only ever a verdict about _this device_, so a
+  record-plane adversary who withholds the record from one that holds none of
+  the three marks reaches the assumed default. Closing that needs positive
+  account-scoped evidence that settings were never published. The account's
+  advisory BYO flag is the one such signal a fresh device already reads, but it
+  is read after the placement decision is made and is spent reconciling the flag
+  the other way, so wiring it is a change to the pre-flight, not to this policy.
 - **A lapsed EOL is refused here, and only here.** Plane-wide an EOL lapse is
   an availability event recovered by revival (above), because a gate-level
   rejection would lock every grantee out of a dormant owner's vault — a read

--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -254,23 +254,19 @@ degraded outcome applies a different policy rather than showing stale data.
   on the resolved case, letting the degraded ones fall through to the defaults,
   reintroduces exactly the widening this policy exists to prevent.
 - **The one arm that still authorises a write is named for what it assumes.**
-  The built-in defaults stand in for a first run, and the reason that carries
-  them says so: `UnprovenFirstRun`. It is reached only when no endpoint served a
+  The built-in defaults stand in for a first run, and the reason carrying them
+  says so: `UnprovenFirstRun`. It is reached only when no endpoint served a
   record _and_ this device holds no durable mark of one — neither the per-name
-  sequence floor, nor the adopted body revision, nor the mint counter. The three
-  are read together and fail closed together, so a floor store that took one
-  raise and lost another can never downgrade a suppression into a first run.
-  The mint counter is the load-bearing one: it rises _before_ the PUT, so a save
-  that never confirmed still refuses every later widening — the moment a
-  placement change is least confirmed is the moment reverting it is most
-  valuable to an adversary.
-  Residual: absence is still only ever a verdict about _this device_, so a
-  record-plane adversary who withholds the record from one that holds none of
-  the three marks reaches the assumed default. Closing that needs positive
-  account-scoped evidence that settings were never published. The account's
-  advisory BYO flag is the one such signal a fresh device already reads, but it
-  is read after the placement decision is made and is spent reconciling the flag
-  the other way, so wiring it is a change to the pre-flight, not to this policy.
+  sequence floor nor the publish mint counter, and an unreadable floor is never
+  read as an absent one. The mint counter is what the sequence floor misses: it
+  is raised before the PUT, so a save that reached the network and never
+  confirmed still refuses every later widening — the member expressed a choice
+  this device could not authenticate. Residual: absence remains a
+  verdict about _this device_, so an adversary who withholds the record from one
+  holding no mark at all reaches the assumed default. Closing that needs
+  positive account-scoped evidence that settings were never published, and the
+  only such signal in reach is the account's advisory BYO flag, which the
+  placement decision does not see.
 - **A lapsed EOL is refused here, and only here.** Plane-wide an EOL lapse is
   an availability event recovered by revival (above), because a gate-level
   rejection would lock every grantee out of a dormant owner's vault — a read

--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -256,17 +256,28 @@ degraded outcome applies a different policy rather than showing stale data.
 - **The one arm that still authorises a write is named for what it assumes.**
   The built-in defaults stand in for a first run, and the reason carrying them
   says so: `UnprovenFirstRun`. It is reached only when no endpoint served a
-  record _and_ this device holds no durable mark of one — neither the per-name
-  sequence floor nor the publish mint counter, and an unreadable floor is never
-  read as an absent one. The mint counter is what the sequence floor misses: it
-  is raised before the PUT, so a save that reached the network and never
-  confirmed still refuses every later widening — the member expressed a choice
-  this device could not authenticate. Residual: absence remains a
-  verdict about _this device_, so an adversary who withholds the record from one
-  holding no mark at all reaches the assumed default. Closing that needs
-  positive account-scoped evidence that settings were never published, and the
-  only such signal in reach is the account's advisory BYO flag, which the
-  placement decision does not see.
+  record _and_ this device holds none of the three durable marks a settings
+  record leaves: the per-name sequence floor, the adopted body revision, and the
+  publish mint counter. An unreadable mark is never read as an absent one. Two
+  of the three are what the sequence floor alone misses. The mint counter is
+  raised before the PUT, so it outlives any save that got as far as minting a
+  revision — a member who expressed a placement choice this device could not
+  authenticate is never talked back onto the default, which is precisely when
+  that reversal is cheapest. The adopted revision is raised by a store write
+  separate from the sequence floor's and not atomic with it, so it outlives a
+  lost one. Residual: absence remains a verdict about _this device_, and every
+  fresh install on an account that already published settings holds no mark
+  until its first successful resolve, so an adversary who withholds the record
+  from one reaches the assumed default. Closing that needs positive
+  account-scoped evidence that settings were never published, and the only such
+  signal in reach is the account's advisory BYO flag — which the placement
+  decision does not see, and which this very arm _clears_: an assumed placement
+  reaches the hosted quota pre-flight, whose reconcile then PATCHes the account
+  to `byo=false`. So the flag is not a standing witness today, and when it is
+  wired it may only ever be read in the restricting direction — `advisory` set
+  means never assume the default. The inverse would be a server-controlled
+  widening on an untrusted signal, and an assumed placement must not latch
+  account-scoped state in the first place.
 - **A lapsed EOL is refused here, and only here.** Plane-wide an EOL lapse is
   an availability event recovered by revival (above), because a gate-level
   rejection would lock every grantee out of a dormant owner's vault — a read

--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -265,19 +265,11 @@ degraded outcome applies a different policy rather than showing stale data.
   authenticate is never talked back onto the default, which is precisely when
   that reversal is cheapest. The adopted revision is raised by a store write
   separate from the sequence floor's and not atomic with it, so it outlives a
-  lost one. Residual: absence remains a verdict about _this device_, and every
-  fresh install on an account that already published settings holds no mark
-  until its first successful resolve, so an adversary who withholds the record
-  from one reaches the assumed default. Closing that needs positive
-  account-scoped evidence that settings were never published, and the only such
-  signal in reach is the account's advisory BYO flag — which the placement
-  decision does not see, and which this very arm _clears_: an assumed placement
-  reaches the hosted quota pre-flight, whose reconcile then PATCHes the account
-  to `byo=false`. So the flag is not a standing witness today, and when it is
-  wired it may only ever be read in the restricting direction — `advisory` set
+  lost one. Absence is a verdict about _this device_ only, so an assumed
+  placement must never latch account-scoped state, and the account's advisory
+  BYO flag may only ever be read in the restricting direction — `advisory` set
   means never assume the default. The inverse would be a server-controlled
-  widening on an untrusted signal, and an assumed placement must not latch
-  account-scoped state in the first place.
+  widening on an untrusted signal.
 - **A lapsed EOL is refused here, and only here.** Plane-wide an EOL lapse is
   an availability event recovered by revival (above), because a gate-level
   rejection would lock every grantee out of a dormant owner's vault — a read

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -49,8 +49,8 @@ use crate::net::record_publish::{
 use crate::net::retire::{OrphanHeads, orphaned_head};
 use crate::profile::SyncTimingProfile;
 use crate::seams::{
-    CredentialStore, FloorStore, Http, RecordTransport, Scheduler, SeamError, SnapshotCache,
-    UnixMillis,
+    CredentialStore, FloorStore, Http, RecordTransport, Scheduler, SeamError, SeamResult,
+    SnapshotCache, UnixMillis,
 };
 
 /// The owner's client configuration, sealed into the vault settings record.
@@ -266,19 +266,24 @@ pub enum PlacementRefusal {
 
 /// The byte destinations a settings load authorises.
 ///
-/// The built-in defaults describe a first run and nothing else: every other
-/// degraded reason with no last-known-good copy refuses rather than resolving
-/// to [`PinMode::Hosted`] (blueprint/engine.md "Settings-load policy").
+/// The built-in defaults describe an unproven first run and nothing else: every
+/// other degraded reason with no last-known-good copy refuses rather than
+/// resolving to [`PinMode::Hosted`] (blueprint/engine.md "Settings-load
+/// policy"). The assumed placement is read off [`VaultSettings::default`] so it
+/// cannot drift from the documented default it stands in for.
 ///
-/// Residual, stated there too: `NoRecord` is a verdict about *this device*, so a
-/// record-plane adversary who withholds the record from a device that has never
-/// synced still gets the first-run default.
+/// Residual, stated there too: absence of a settings record is only ever a
+/// verdict about *this device*, so a record-plane adversary who withholds it
+/// from one that holds no [`SettingsTraces`] still reaches the first-run
+/// default. What narrows that window is the trace set, not this decision.
 pub fn decide_placement(load: &SettingsLoad) -> Result<Placement, PlacementRefusal> {
     match load {
         SettingsLoad::Resolved(settings) | SettingsLoad::Stale { settings, .. } => {
             placement_of(settings)
         }
-        SettingsLoad::Defaults(DefaultsReason::NoRecord) => Ok(Placement::Hosted),
+        SettingsLoad::Defaults(DefaultsReason::UnprovenFirstRun) => {
+            placement_of(&VaultSettings::default())
+        }
         SettingsLoad::Defaults(reason) => Err(PlacementRefusal::SettingsUnavailable(*reason)),
     }
 }
@@ -331,19 +336,23 @@ pub enum SettingsPublishError {
 
 /// Why a load did not use the published record, carried by both degraded
 /// outcomes. Reported rather than collapsed, because the reasons are not
-/// equally benign: `NoRecord` is a first run, while `Suppressed` and
-/// `RolledBack` are what an adversary who controls the record plane produces,
-/// and reverting a member's placement choice to the hosted default is exactly
-/// what they gain by it.
+/// equally benign: `UnprovenFirstRun` is the one that still authorises a write,
+/// while `Suppressed` and `RolledBack` are what an adversary who controls the
+/// record plane produces, and reverting a member's placement choice to the
+/// hosted default is exactly what they gain by it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DefaultsReason {
-    /// No endpoint served a record, and this device has no durable floor for
-    /// the name. Floor evidence only: a cached last-known-good block can
-    /// accompany this, since the floor advance is not gated on the cache write.
-    NoRecord,
-    /// No usable record, but the durable sequence floor proves one was adopted
-    /// here before: the record is being withheld or its head block is
-    /// unreachable.
+    /// No endpoint served a record, and this device holds no durable mark of
+    /// one ([`SettingsTraces`]). Named for what it is rather than what it looks
+    /// like: absence here is a statement about *this device*, never a proof
+    /// that the account has never published, so the first run it reports is
+    /// assumed and not established. Floor and mint evidence only — a cached
+    /// last-known-good block can accompany it, since neither raise is gated on
+    /// the cache write.
+    UnprovenFirstRun,
+    /// No usable record, but a durable mark proves this device already adopted
+    /// a settings record, or already tried to publish one: the record is being
+    /// withheld or its head block is unreachable.
     Suppressed,
     /// A record below the durable sequence floor — a replay, not staleness.
     RolledBack {
@@ -418,6 +427,43 @@ fn prefixed_key(prefix: &[u8], name: &IpnsName) -> Vec<u8> {
     let mut key = prefix.to_vec();
     key.extend_from_slice(name.as_str().as_bytes());
     key
+}
+
+/// Every durable mark a settings record leaves on this device. Read together,
+/// because [`DefaultsReason::UnprovenFirstRun`] is the one degraded outcome that
+/// still authorises a write, and the only thing separating it from
+/// [`DefaultsReason::Suppressed`] is whether *any* of these was ever raised.
+#[derive(Debug, Clone, Copy)]
+struct SettingsTraces {
+    /// The per-name sequence floor: a record was adopted here.
+    sequence: Option<u64>,
+    /// The adopted body revision: a body opened and cleared its bar here.
+    adopted_revision: Option<u64>,
+    /// The mint counter, raised **before** the PUT, so it survives a publish
+    /// that never confirmed — the member expressed a choice this device could
+    /// not authenticate, which is the moment a withheld record is most valuable
+    /// to an adversary.
+    minted_revision: Option<u64>,
+}
+
+impl SettingsTraces {
+    fn any(&self) -> bool {
+        self.sequence
+            .or(self.adopted_revision)
+            .or(self.minted_revision)
+            .is_some()
+    }
+}
+
+/// Read all three marks. A floor the host cannot read is never treated as no
+/// floor: the whole set fails closed together, so a partial read can never
+/// downgrade a suppression into a first run.
+async fn settings_traces<F: FloorStore>(floors: &F, name: &IpnsName) -> SeamResult<SettingsTraces> {
+    Ok(SettingsTraces {
+        sequence: floor::sequence_floor(floors, name.as_str().as_bytes()).await?,
+        adopted_revision: floor::sequence_floor(floors, &revision_adopted_key(name)).await?,
+        minted_revision: floor::sequence_floor(floors, &revision_mint_key(name)).await?,
+    })
 }
 
 /// Mint the next body revision, advancing the durable counter **before** the
@@ -657,15 +703,13 @@ where
     // The settings record belongs to no scope and carries no epoch, so the
     // per-name sequence floor and the adopted body revision are its whole floor
     // law. A floor the host cannot read is never treated as no floor.
-    let Ok(durable) = floor::sequence_floor(floors, key).await else {
+    let Ok(traces) = settings_traces(floors, name).await else {
         return Err(DefaultsReason::FloorUnreadable);
     };
     let Some((verified, record_bytes)) = fanout_get_verify(transport, name).await else {
-        // A durable floor is proof this account has published settings, so
-        // finding none now is a suppression rather than a first run.
-        return Err(match durable {
-            Some(_) => DefaultsReason::Suppressed,
-            None => DefaultsReason::NoRecord,
+        return Err(match traces.any() {
+            true => DefaultsReason::Suppressed,
+            false => DefaultsReason::UnprovenFirstRun,
         });
     };
     // The reader of this record is always its signer, so a lapsed EOL is a
@@ -675,7 +719,7 @@ where
         return Err(DefaultsReason::Expired);
     }
     let sequence = verified.sequence;
-    let floor = durable.unwrap_or(0);
+    let floor = traces.sequence.unwrap_or(0);
     if sequence < floor {
         return Err(DefaultsReason::RolledBack { floor, sequence });
     }
@@ -687,10 +731,7 @@ where
     };
     let body = open_settings_head(enc_secret, &block).ok_or(DefaultsReason::Unreadable)?;
     let adopted_key = revision_adopted_key(name);
-    let Ok(adopted) = floor::sequence_floor(floors, &adopted_key).await else {
-        return Err(DefaultsReason::FloorUnreadable);
-    };
-    let adopted = adopted.unwrap_or(0);
+    let adopted = traces.adopted_revision.unwrap_or(0);
     // The revision arbitrates only what the sequence cannot: a fork *at* the
     // sequence this device already adopted. A strictly newer record won its CAS
     // against the network, and holding it to a device-local revision counter
@@ -1142,13 +1183,13 @@ mod tests {
         );
     }
 
-    /// The built-in defaults describe a first run and nothing else: every other
-    /// degraded reason refuses rather than widening an unknown choice onto the
-    /// hosted store.
+    /// The built-in defaults describe an unproven first run and nothing else:
+    /// every other degraded reason refuses rather than widening an unknown
+    /// choice onto the hosted store.
     #[test]
-    fn only_a_first_run_falls_back_to_the_hosted_default() {
+    fn only_an_unproven_first_run_falls_back_to_the_hosted_default() {
         assert_eq!(
-            decide_placement(&SettingsLoad::Defaults(DefaultsReason::NoRecord)).unwrap(),
+            decide_placement(&SettingsLoad::Defaults(DefaultsReason::UnprovenFirstRun)).unwrap(),
             Placement::Hosted
         );
         for reason in [

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -334,13 +334,14 @@ pub enum SettingsPublishError {
 /// hosted default is exactly what they gain by it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DefaultsReason {
-    /// No endpoint served a record, and this device holds no durable mark of
-    /// one: neither the sequence floor nor the publish mint counter. Named for
-    /// what it is rather than what it looks like — absence is a statement about
-    /// *this device*, never proof that the account has never published, so the
-    /// first run it reports is assumed and not established. Durable-mark
-    /// evidence only: a cached last-known-good block can accompany it, since no
-    /// raise is gated on the cache write.
+    /// No endpoint served a record, and this device holds none of the three
+    /// durable marks one leaves: the sequence floor, the adopted body revision,
+    /// or the publish mint counter. Named for what it is rather than what it
+    /// looks like — absence is a statement about *this device*, never proof
+    /// that the account has never published, so the first run it reports is
+    /// assumed and not established. Durable-mark evidence only: a cached
+    /// last-known-good block can accompany it, since no raise is gated on the
+    /// cache write.
     UnprovenFirstRun,
     /// No usable record, but a durable mark proves this device already adopted
     /// a settings record, or already tried to publish one: the record is being
@@ -662,16 +663,19 @@ where
         return Err(DefaultsReason::FloorUnreadable);
     };
     let Some((verified, record_bytes)) = fanout_get_verify(transport, name).await else {
-        // The mint counter joins the sequence floor only here, because only
-        // here does their absence still authorise a write. [`next_revision`]
-        // raises it before the PUT, so it outlives a save that never confirmed:
-        // an unconfirmed publish is still a durable mark of a member's choice,
-        // and the moment that choice is least confirmed is the moment reverting
-        // it is most valuable.
-        let Ok(minted) = floor::sequence_floor(floors, &revision_mint_key(name)).await else {
+        // The other two marks join the sequence floor only here, because only
+        // here does their absence still authorise a write, and each is raised
+        // where the sequence floor is not. The mint counter is raised ahead of
+        // everything a publish can fail at, so it outlives any save that got as
+        // far as minting a revision. The adopted revision is raised by a
+        // separate, non-atomic store write, so it can outlive a lost one.
+        let (Ok(minted), Ok(adopted)) = (
+            floor::sequence_floor(floors, &revision_mint_key(name)).await,
+            floor::sequence_floor(floors, &revision_adopted_key(name)).await,
+        ) else {
             return Err(DefaultsReason::FloorUnreadable);
         };
-        return Err(match durable.or(minted) {
+        return Err(match durable.or(minted).or(adopted) {
             Some(_) => DefaultsReason::Suppressed,
             None => DefaultsReason::UnprovenFirstRun,
         });
@@ -958,6 +962,7 @@ fn kind_str(kind: ByoKind) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::content::GatewayConfig;
     use crate::testkit::{FakeWorld, SeededEntropy, block_on};
 
     fn keep(n: u64) -> RetentionPolicy {
@@ -1212,6 +1217,121 @@ mod tests {
                 decide_placement(&SettingsLoad::Resolved(placed(PinMode::Dual, provider))).is_ok(),
                 "{kind:?} is a fine second leg"
             );
+        }
+    }
+
+    /// The three marks a settings record leaves are raised by separate,
+    /// non-atomic store writes, and the adopt path discards each raise's error.
+    /// So a device can hold any one of them alone, and each alone is proof it
+    /// adopted or attempted a record: a withheld one is suppression, never the
+    /// first run that would widen placement onto the hosted store.
+    ///
+    /// Reached with no record served and no cached copy, so only the marks can
+    /// answer.
+    #[test]
+    fn any_durable_mark_alone_refuses_a_withheld_record() {
+        let world = FakeWorld::new();
+        let secret = [4u8; 32];
+        let name = settings_name(&secret);
+        let gateway = GatewayConfig {
+            accelerator: None,
+            public_fallbacks: Vec::new(),
+        }
+        .into_gateway();
+
+        let marks = [
+            name.as_str().as_bytes().to_vec(),
+            revision_adopted_key(&name),
+            revision_mint_key(&name),
+        ];
+        for mark in &marks {
+            let device = world.device(b"cold");
+            block_on(device.floor_store.raise_sequence_floor(mark, 3)).expect("the mark raises");
+            let load = block_on(load_settings(
+                &device.record_store,
+                &gateway,
+                &device.http,
+                &device.floor_store,
+                &device.snapshot_cache,
+                &world.scheduler,
+                &SyncTimingProfile::CI,
+                &secret,
+            ));
+            assert_eq!(
+                load,
+                SettingsLoad::Defaults(DefaultsReason::Suppressed),
+                "one mark alone must not read as a first run",
+            );
+            assert_eq!(
+                decide_placement(&load).unwrap_err(),
+                PlacementRefusal::SettingsUnavailable(DefaultsReason::Suppressed),
+            );
+        }
+
+        // The same device with none of them is the arm that still authorises.
+        let bare = world.device(b"cold");
+        assert_eq!(
+            block_on(load_settings(
+                &bare.record_store,
+                &gateway,
+                &bare.http,
+                &bare.floor_store,
+                &bare.snapshot_cache,
+                &world.scheduler,
+                &SyncTimingProfile::CI,
+                &secret,
+            )),
+            SettingsLoad::Defaults(DefaultsReason::UnprovenFirstRun),
+        );
+
+        // A mark the host cannot read is never read as an absent one, or the
+        // store that answers "I don't know" would widen placement.
+        let unreadable = world.device(b"cold");
+        assert_eq!(
+            block_on(load_settings(
+                &unreadable.record_store,
+                &gateway,
+                &unreadable.http,
+                &UnreadableBeyondTheName(name),
+                &unreadable.snapshot_cache,
+                &world.scheduler,
+                &SyncTimingProfile::CI,
+                &secret,
+            )),
+            SettingsLoad::Defaults(DefaultsReason::FloorUnreadable),
+        );
+    }
+
+    /// A floor store that answers for the bare settings name and fails on the
+    /// prefixed marks, so the reads this module added are the ones that fail.
+    struct UnreadableBeyondTheName(IpnsName);
+
+    impl FloorStore for UnreadableBeyondTheName {
+        async fn epoch_floor(&self, _scope_id: &[u8]) -> crate::seams::SeamResult<Option<u64>> {
+            Err(SeamError::new("unreadable"))
+        }
+
+        async fn raise_epoch_floor(
+            &self,
+            _scope_id: &[u8],
+            _epoch: u64,
+        ) -> crate::seams::SeamResult<u64> {
+            Err(SeamError::new("unreadable"))
+        }
+
+        async fn sequence_floor(&self, ipns_name: &[u8]) -> crate::seams::SeamResult<Option<u64>> {
+            match ipns_name == self.0.as_str().as_bytes() {
+                true => Ok(None),
+                false => Err(SeamError::new("unreadable")),
+            }
+        }
+
+        async fn raise_sequence_floor(
+            &self,
+            _ipns_name: &[u8],
+            _sequence: u64,
+        ) -> crate::seams::SeamResult<u64> {
+            Err(SeamError::new("unreadable"))
         }
     }
 

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -49,8 +49,8 @@ use crate::net::record_publish::{
 use crate::net::retire::{OrphanHeads, orphaned_head};
 use crate::profile::SyncTimingProfile;
 use crate::seams::{
-    CredentialStore, FloorStore, Http, RecordTransport, Scheduler, SeamError, SeamResult,
-    SnapshotCache, UnixMillis,
+    CredentialStore, FloorStore, Http, RecordTransport, Scheduler, SeamError, SnapshotCache,
+    UnixMillis,
 };
 
 /// The owner's client configuration, sealed into the vault settings record.
@@ -266,24 +266,16 @@ pub enum PlacementRefusal {
 
 /// The byte destinations a settings load authorises.
 ///
-/// The built-in defaults describe an unproven first run and nothing else: every
-/// other degraded reason with no last-known-good copy refuses rather than
-/// resolving to [`PinMode::Hosted`] (blueprint/engine.md "Settings-load
-/// policy"). The assumed placement is read off [`VaultSettings::default`] so it
-/// cannot drift from the documented default it stands in for.
-///
-/// Residual, stated there too: absence of a settings record is only ever a
-/// verdict about *this device*, so a record-plane adversary who withholds it
-/// from one that holds no [`SettingsTraces`] still reaches the first-run
-/// default. What narrows that window is the trace set, not this decision.
+/// [`DefaultsReason::UnprovenFirstRun`] is the one degraded reason that still
+/// authorises a write; every other one with no last-known-good copy refuses
+/// rather than resolving to [`PinMode::Hosted`] (blueprint/engine.md
+/// "Settings-load policy", which also states the residual that arm carries).
 pub fn decide_placement(load: &SettingsLoad) -> Result<Placement, PlacementRefusal> {
     match load {
         SettingsLoad::Resolved(settings) | SettingsLoad::Stale { settings, .. } => {
             placement_of(settings)
         }
-        SettingsLoad::Defaults(DefaultsReason::UnprovenFirstRun) => {
-            placement_of(&VaultSettings::default())
-        }
+        SettingsLoad::Defaults(DefaultsReason::UnprovenFirstRun) => Ok(Placement::Hosted),
         SettingsLoad::Defaults(reason) => Err(PlacementRefusal::SettingsUnavailable(*reason)),
     }
 }
@@ -343,12 +335,12 @@ pub enum SettingsPublishError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DefaultsReason {
     /// No endpoint served a record, and this device holds no durable mark of
-    /// one ([`SettingsTraces`]). Named for what it is rather than what it looks
-    /// like: absence here is a statement about *this device*, never a proof
-    /// that the account has never published, so the first run it reports is
-    /// assumed and not established. Floor and mint evidence only — a cached
-    /// last-known-good block can accompany it, since neither raise is gated on
-    /// the cache write.
+    /// one: neither the sequence floor nor the publish mint counter. Named for
+    /// what it is rather than what it looks like — absence is a statement about
+    /// *this device*, never proof that the account has never published, so the
+    /// first run it reports is assumed and not established. Durable-mark
+    /// evidence only: a cached last-known-good block can accompany it, since no
+    /// raise is gated on the cache write.
     UnprovenFirstRun,
     /// No usable record, but a durable mark proves this device already adopted
     /// a settings record, or already tried to publish one: the record is being
@@ -427,43 +419,6 @@ fn prefixed_key(prefix: &[u8], name: &IpnsName) -> Vec<u8> {
     let mut key = prefix.to_vec();
     key.extend_from_slice(name.as_str().as_bytes());
     key
-}
-
-/// Every durable mark a settings record leaves on this device. Read together,
-/// because [`DefaultsReason::UnprovenFirstRun`] is the one degraded outcome that
-/// still authorises a write, and the only thing separating it from
-/// [`DefaultsReason::Suppressed`] is whether *any* of these was ever raised.
-#[derive(Debug, Clone, Copy)]
-struct SettingsTraces {
-    /// The per-name sequence floor: a record was adopted here.
-    sequence: Option<u64>,
-    /// The adopted body revision: a body opened and cleared its bar here.
-    adopted_revision: Option<u64>,
-    /// The mint counter, raised **before** the PUT, so it survives a publish
-    /// that never confirmed — the member expressed a choice this device could
-    /// not authenticate, which is the moment a withheld record is most valuable
-    /// to an adversary.
-    minted_revision: Option<u64>,
-}
-
-impl SettingsTraces {
-    fn any(&self) -> bool {
-        self.sequence
-            .or(self.adopted_revision)
-            .or(self.minted_revision)
-            .is_some()
-    }
-}
-
-/// Read all three marks. A floor the host cannot read is never treated as no
-/// floor: the whole set fails closed together, so a partial read can never
-/// downgrade a suppression into a first run.
-async fn settings_traces<F: FloorStore>(floors: &F, name: &IpnsName) -> SeamResult<SettingsTraces> {
-    Ok(SettingsTraces {
-        sequence: floor::sequence_floor(floors, name.as_str().as_bytes()).await?,
-        adopted_revision: floor::sequence_floor(floors, &revision_adopted_key(name)).await?,
-        minted_revision: floor::sequence_floor(floors, &revision_mint_key(name)).await?,
-    })
 }
 
 /// Mint the next body revision, advancing the durable counter **before** the
@@ -703,13 +658,22 @@ where
     // The settings record belongs to no scope and carries no epoch, so the
     // per-name sequence floor and the adopted body revision are its whole floor
     // law. A floor the host cannot read is never treated as no floor.
-    let Ok(traces) = settings_traces(floors, name).await else {
+    let Ok(durable) = floor::sequence_floor(floors, key).await else {
         return Err(DefaultsReason::FloorUnreadable);
     };
     let Some((verified, record_bytes)) = fanout_get_verify(transport, name).await else {
-        return Err(match traces.any() {
-            true => DefaultsReason::Suppressed,
-            false => DefaultsReason::UnprovenFirstRun,
+        // The mint counter joins the sequence floor only here, because only
+        // here does their absence still authorise a write. [`next_revision`]
+        // raises it before the PUT, so it outlives a save that never confirmed:
+        // an unconfirmed publish is still a durable mark of a member's choice,
+        // and the moment that choice is least confirmed is the moment reverting
+        // it is most valuable.
+        let Ok(minted) = floor::sequence_floor(floors, &revision_mint_key(name)).await else {
+            return Err(DefaultsReason::FloorUnreadable);
+        };
+        return Err(match durable.or(minted) {
+            Some(_) => DefaultsReason::Suppressed,
+            None => DefaultsReason::UnprovenFirstRun,
         });
     };
     // The reader of this record is always its signer, so a lapsed EOL is a
@@ -719,7 +683,7 @@ where
         return Err(DefaultsReason::Expired);
     }
     let sequence = verified.sequence;
-    let floor = traces.sequence.unwrap_or(0);
+    let floor = durable.unwrap_or(0);
     if sequence < floor {
         return Err(DefaultsReason::RolledBack { floor, sequence });
     }
@@ -731,7 +695,10 @@ where
     };
     let body = open_settings_head(enc_secret, &block).ok_or(DefaultsReason::Unreadable)?;
     let adopted_key = revision_adopted_key(name);
-    let adopted = traces.adopted_revision.unwrap_or(0);
+    let Ok(adopted) = floor::sequence_floor(floors, &adopted_key).await else {
+        return Err(DefaultsReason::FloorUnreadable);
+    };
+    let adopted = adopted.unwrap_or(0);
     // The revision arbitrates only what the sequence cannot: a fork *at* the
     // sequence this device already adopted. A strictly newer record won its CAS
     // against the network, and holding it to a device-local revision counter

--- a/crates/engine/tests/vault_settings.rs
+++ b/crates/engine/tests/vault_settings.rs
@@ -499,8 +499,8 @@ fn a_missing_settings_record_yields_defaults_not_an_error() {
 
     assert_eq!(
         load,
-        SettingsLoad::Defaults(DefaultsReason::NoRecord),
-        "no record and no durable floor is a first run, not a suppression",
+        SettingsLoad::Defaults(DefaultsReason::UnprovenFirstRun),
+        "no record and no durable mark of one is an assumed first run",
     );
     assert_eq!(
         VaultSettings::default(),
@@ -511,6 +511,69 @@ fn a_missing_settings_record_yields_defaults_not_an_error() {
         },
         "the documented defaults: hosted pinning, no member provider, keep all",
     );
+}
+
+/// A publish attempt raises the mint counter before the PUT, so a device whose
+/// save never confirmed still carries a durable mark of the member's choice.
+/// Withholding the record from that device is suppression, not a first run —
+/// otherwise the moment a placement change is least confirmed is the moment it
+/// is cheapest to revert.
+#[test]
+fn a_settings_publish_that_never_confirmed_is_still_a_mark_of_a_choice() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    let device = world.device(b"me");
+    let api = ApiClient::new(
+        device.http.clone(),
+        device.credential_store.clone(),
+        "http://api.test",
+    );
+    serve_http(&device, &blocks, 4);
+    assert_eq!(
+        block_on(publish_settings(
+            &AcksNothingBack,
+            &api,
+            &device.floor_store,
+            &device.snapshot_cache,
+            &world.scheduler,
+            &SyncTimingProfile::CI,
+            &mut SeededEntropy::new(6),
+            &OrphanHeads::default(),
+            &SECRET,
+            &external_only(),
+        ))
+        .unwrap_err(),
+        SettingsPublishError::Unconfirmed,
+        "the attempt reaches the network and comes back unconfirmed",
+    );
+
+    // `Defaults` rather than `Stale`: nothing was cached, so the verdict rests
+    // on the mint counter alone.
+    assert_eq!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Defaults(DefaultsReason::Suppressed),
+        "the mint counter outlives the attempt, so absence is no longer credible",
+    );
+}
+
+/// The adopt-side marks are raised by two separate, non-atomic floor writes. A
+/// store that took one and lost the other must still refuse: any surviving mark
+/// proves this device adopted a record, and a first run has none of them.
+#[test]
+fn any_surviving_adopt_mark_alone_refuses_a_withheld_record() {
+    for key in [b"settings-revision/".as_slice(), b"".as_slice()] {
+        let world = FakeWorld::new();
+        let device = world.device(b"me");
+        let mut floor_key = key.to_vec();
+        floor_key.extend_from_slice(settings_name(&SECRET).as_str().as_bytes());
+        block_on(device.floor_store.raise_sequence_floor(&floor_key, 3)).expect("the floor raises");
+
+        assert_eq!(
+            load(&world, &device, &Blocks::default(), &SECRET),
+            SettingsLoad::Defaults(DefaultsReason::Suppressed),
+            "{key:?} alone is proof this device adopted settings before",
+        );
+    }
 }
 
 /// A transport whose GET never settles — the shape of an unresolvable name.
@@ -908,7 +971,7 @@ fn a_cached_copy_that_does_not_authenticate_is_not_used() {
                 &SyncTimingProfile::CI,
                 &SECRET,
             )),
-            SettingsLoad::Defaults(DefaultsReason::NoRecord),
+            SettingsLoad::Defaults(DefaultsReason::UnprovenFirstRun),
             "a cached copy is re-opened on every read, never trusted for being cached",
         );
     }
@@ -1042,7 +1105,7 @@ fn a_second_account_on_the_device_never_sees_the_first_accounts_cached_settings(
             &SyncTimingProfile::CI,
             &OTHER_SECRET,
         )),
-        SettingsLoad::Defaults(DefaultsReason::NoRecord),
+        SettingsLoad::Defaults(DefaultsReason::UnprovenFirstRun),
         "another account's copy is both keyed and sealed out of reach",
     );
 }

--- a/crates/engine/tests/vault_settings.rs
+++ b/crates/engine/tests/vault_settings.rs
@@ -181,6 +181,37 @@ fn publish(
     .expect("the settings record publishes");
 }
 
+/// Publish `settings` from `device` over a transport that acks nothing back:
+/// the attempt reaches the network, uploads its head block, and comes home
+/// unconfirmed.
+fn publish_unconfirmed(
+    world: &FakeWorld,
+    device: &FakeDevice,
+    blocks: &Blocks,
+    settings: &VaultSettings,
+    entropy_seed: u64,
+) -> SettingsPublishError {
+    serve_http(device, blocks, 4);
+    let api = ApiClient::new(
+        device.http.clone(),
+        device.credential_store.clone(),
+        "http://api.test",
+    );
+    block_on(publish_settings(
+        &AcksNothingBack,
+        &api,
+        &device.floor_store,
+        &device.snapshot_cache,
+        &world.scheduler,
+        &SyncTimingProfile::CI,
+        &mut SeededEntropy::new(entropy_seed),
+        &OrphanHeads::default(),
+        &SECRET,
+        settings,
+    ))
+    .expect_err("a transport that acks nothing back never confirms")
+}
+
 /// Put `body` on the block plane and publish a record anchoring it at the
 /// account's settings name and `sequence`, bypassing the publish path. The
 /// ephemeral varies with the sequence: two bodies sealed under one key must
@@ -391,27 +422,9 @@ impl RecordTransport for AcksNothingBack {
 fn an_unconfirmed_publish_is_reported_and_never_advances_the_floor() {
     let world = FakeWorld::new();
     let device = world.device(b"me");
-    let api = ApiClient::new(
-        device.http.clone(),
-        device.credential_store.clone(),
-        "http://api.test",
-    );
-    serve_http(&device, &Blocks::default(), 4);
+    let outcome = publish_unconfirmed(&world, &device, &Blocks::default(), &configured(), 3);
 
-    let outcome = block_on(publish_settings(
-        &AcksNothingBack,
-        &api,
-        &device.floor_store,
-        &device.snapshot_cache,
-        &world.scheduler,
-        &SyncTimingProfile::CI,
-        &mut SeededEntropy::new(3),
-        &OrphanHeads::default(),
-        &SECRET,
-        &configured(),
-    ));
-
-    assert_eq!(outcome.unwrap_err(), SettingsPublishError::Unconfirmed);
+    assert_eq!(outcome, SettingsPublishError::Unconfirmed);
     assert_eq!(
         block_on(
             device
@@ -513,38 +526,27 @@ fn a_missing_settings_record_yields_defaults_not_an_error() {
     );
 }
 
-/// A publish attempt raises the mint counter before the PUT, so a device whose
-/// save never confirmed still carries a durable mark of the member's choice.
-/// Withholding the record from that device is suppression, not a first run —
-/// otherwise the moment a placement change is least confirmed is the moment it
-/// is cheapest to revert.
+/// The mint counter is the only mark a save that never confirmed leaves, and it
+/// is enough: withholding the record from that device is suppression, not a
+/// first run.
 #[test]
 fn a_settings_publish_that_never_confirmed_is_still_a_mark_of_a_choice() {
     let world = FakeWorld::new();
     let blocks = Blocks::default();
     let device = world.device(b"me");
-    let api = ApiClient::new(
-        device.http.clone(),
-        device.credential_store.clone(),
-        "http://api.test",
-    );
-    serve_http(&device, &blocks, 4);
     assert_eq!(
-        block_on(publish_settings(
-            &AcksNothingBack,
-            &api,
-            &device.floor_store,
-            &device.snapshot_cache,
-            &world.scheduler,
-            &SyncTimingProfile::CI,
-            &mut SeededEntropy::new(6),
-            &OrphanHeads::default(),
-            &SECRET,
-            &external_only(),
-        ))
-        .unwrap_err(),
+        publish_unconfirmed(&world, &device, &blocks, &external_only(), 6),
         SettingsPublishError::Unconfirmed,
-        "the attempt reaches the network and comes back unconfirmed",
+    );
+    assert_eq!(
+        block_on(
+            device
+                .floor_store
+                .sequence_floor(settings_name(&SECRET).as_str().as_bytes())
+        )
+        .expect("read"),
+        None,
+        "the adopt-side marks stayed where they were",
     );
 
     // `Defaults` rather than `Stale`: nothing was cached, so the verdict rests
@@ -554,26 +556,6 @@ fn a_settings_publish_that_never_confirmed_is_still_a_mark_of_a_choice() {
         SettingsLoad::Defaults(DefaultsReason::Suppressed),
         "the mint counter outlives the attempt, so absence is no longer credible",
     );
-}
-
-/// The adopt-side marks are raised by two separate, non-atomic floor writes. A
-/// store that took one and lost the other must still refuse: any surviving mark
-/// proves this device adopted a record, and a first run has none of them.
-#[test]
-fn any_surviving_adopt_mark_alone_refuses_a_withheld_record() {
-    for key in [b"settings-revision/".as_slice(), b"".as_slice()] {
-        let world = FakeWorld::new();
-        let device = world.device(b"me");
-        let mut floor_key = key.to_vec();
-        floor_key.extend_from_slice(settings_name(&SECRET).as_str().as_bytes());
-        block_on(device.floor_store.raise_sequence_floor(&floor_key, 3)).expect("the floor raises");
-
-        assert_eq!(
-            load(&world, &device, &Blocks::default(), &SECRET),
-            SettingsLoad::Defaults(DefaultsReason::Suppressed),
-            "{key:?} alone is proof this device adopted settings before",
-        );
-    }
 }
 
 /// A transport whose GET never settles — the shape of an unresolvable name.

--- a/crates/engine/tests/vault_settings.rs
+++ b/crates/engine/tests/vault_settings.rs
@@ -556,6 +556,14 @@ fn a_settings_publish_that_never_confirmed_is_still_a_mark_of_a_choice() {
         SettingsLoad::Defaults(DefaultsReason::Suppressed),
         "the mint counter outlives the attempt, so absence is no longer credible",
     );
+
+    // The refusal is a state the member can leave: saving again, successfully,
+    // puts the record where every later load can authenticate it.
+    publish(&world, &device, &blocks, &SECRET, &external_only());
+    assert_eq!(
+        load(&world, &device, &blocks, &SECRET),
+        SettingsLoad::Resolved(external_only()),
+    );
 }
 
 /// A transport whose GET never settles — the shape of an unresolvable name.

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -6866,8 +6866,8 @@ fn a_settings_save_that_never_landed_refuses_the_write_instead_of_widening_it() 
         },
     ))
     .expect_err("the save does not reach the network");
-    // The refused save tried to upload its own head block; only what the write
-    // adds on top of that is this test's subject.
+    // The refused save tried to upload its own head block; what the write adds
+    // on top of that is the byte-destination property under test.
     let before = uploaded_cids(&alice).len();
 
     let (mut engine, _events, _tasks) = boot(&world, &blocks, &alice, 42);

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -6831,3 +6831,68 @@ fn an_edit_from_a_device_that_never_read_the_file_resolves_its_anchor() {
         "the version this device wrote is the head"
     );
 }
+
+/// The member picks "never put my bytes in CipherBox's store" and the save does
+/// not land. The revision mint counter rose before the PUT, so the next cold
+/// start on this device refuses the write rather than reading the missing
+/// record as a first run — the moment a placement change is least confirmed is
+/// the moment reverting it is most valuable to a record-plane adversary.
+#[test]
+fn a_settings_save_that_never_landed_refuses_the_write_instead_of_widening_it() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+
+    // No HTTP is scripted, so the head-block upload fails and nothing is ever
+    // published at the settings name.
+    let api = ApiClient::new(
+        alice.http.clone(),
+        alice.credential_store.clone(),
+        String::new(),
+    );
+    block_on(publish_settings(
+        &alice.record_store,
+        &api,
+        &alice.floor_store,
+        &alice.snapshot_cache,
+        &world.scheduler,
+        &SyncTimingProfile::CI,
+        &mut SeededEntropy::new(9),
+        &OrphanHeads::default(),
+        &SECRET,
+        &VaultSettings {
+            pin_mode: PinMode::External,
+            byo: Some(member_node(ByoKind::Kubo)),
+            retention: RetentionPolicy::KeepAll,
+        },
+    ))
+    .expect_err("the save does not reach the network");
+    // The refused save tried to upload its own head block; only what the write
+    // adds on top of that is this test's subject.
+    let before = uploaded_cids(&alice).len();
+
+    let (mut engine, _events, _tasks) = boot(&world, &blocks, &alice, 42);
+    let refused = block_on(engine.begin_write(
+        WriteTarget::NewFile {
+            parent: ROOT,
+            name: "photo.bin".into(),
+        },
+        200,
+    ))
+    .expect_err("no placement could be authenticated");
+    assert!(
+        matches!(
+            refused,
+            EngineError::NoPlacement {
+                refusal: PlacementRefusal::SettingsUnavailable(DefaultsReason::Suppressed),
+            }
+        ),
+        "an attempted save is a durable mark of a choice: {refused:?}"
+    );
+    assert_eq!(
+        uploaded_cids(&alice).len(),
+        before,
+        "and no content byte went to the hosted store"
+    );
+}

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -6833,10 +6833,8 @@ fn an_edit_from_a_device_that_never_read_the_file_resolves_its_anchor() {
 }
 
 /// The member picks "never put my bytes in CipherBox's store" and the save does
-/// not land. The revision mint counter rose before the PUT, so the next cold
-/// start on this device refuses the write rather than reading the missing
-/// record as a first run — the moment a placement change is least confirmed is
-/// the moment reverting it is most valuable to a record-plane adversary.
+/// not land. The next cold start refuses the write rather than reading the
+/// missing record as a first run.
 #[test]
 fn a_settings_save_that_never_landed_refuses_the_write_instead_of_widening_it() {
     let world = FakeWorld::new();

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -35,7 +35,9 @@ use cipherbox_engine::seams::{
     BoxedTask, FloorStore, HttpRequest, HttpResponse, OpId, RecordTransport, SeamError, SeamResult,
     StagingStore, UnixMillis,
 };
-use cipherbox_engine::settings::{Destinations, VaultSettings, publish_settings, settings_name};
+use cipherbox_engine::settings::{
+    Destinations, SettingsPublishError, VaultSettings, publish_settings, settings_name,
+};
 use cipherbox_engine::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
 use cipherbox_engine::sync::{
     DRAINED_OP_MARK_PREFIX, PUBLISHED_OP_MARK_PREFIX, StagedContent, UPLOAD_MARK_KEY, op_mark_key,
@@ -6849,7 +6851,7 @@ fn a_settings_save_that_never_landed_refuses_the_write_instead_of_widening_it() 
         alice.credential_store.clone(),
         String::new(),
     );
-    block_on(publish_settings(
+    let refused_save = block_on(publish_settings(
         &alice.record_store,
         &api,
         &alice.floor_store,
@@ -6866,6 +6868,12 @@ fn a_settings_save_that_never_landed_refuses_the_write_instead_of_widening_it() 
         },
     ))
     .expect_err("the save does not reach the network");
+    // Scoped to a publish failure: an earlier refusal would leave the mint
+    // counter raised without ever attempting the head block this test counts.
+    assert!(
+        matches!(refused_save, SettingsPublishError::Publish(_)),
+        "the head-block publish must be what failed, got {refused_save:?}"
+    );
     // The refused save tried to upload its own head block; what the write adds
     // on top of that is the byte-destination property under test.
     let before = uploaded_cids(&alice).len();


### PR DESCRIPTION
## The gap

A member picks `PinMode::External` — "never put my bytes in CipherBox's store" — and signs in on a device that has never synced. An adversary who controls the record-plane leg withholds the vault settings record. `decide_placement` read that as a first run and resolved it to `Placement::Hosted`: every sealed block goes to the hosted ingress, and the session reconciles the account's `byo` flag back to `false`.

## What this changes

The first-run carve-out was derived from the per-name sequence floor alone — a mark only a *confirmed adopt* raises. A settings record leaves three durable marks on a device, and the two the sequence floor misses are exactly the ones that matter:

- **The publish mint counter.** `next_revision` raises it ahead of everything a publish can fail at, precisely so a retry cannot re-mint the same value. So a member who saved a placement choice that never landed still carries durable proof of it — and that is the moment reverting the choice is cheapest, since the device has nothing to authenticate against.
- **The adopted body revision.** The adopt path raises it and the sequence floor as two separate, error-discarding store writes &#40;`let _ = advance_sequence_on_unseal&#40;..&#41;` twice&#41;, and `FloorStore::commit_floors` is documented non-atomic. A device that took the second and lost the first demonstrably adopted a record; with its cached copy evicted it was read as a first run.

All three are now read on the withheld branch, and an unreadable mark is never read as an absent one — the reads fail closed to `FloorUnreadable`, which already refuses. Any mark present makes a missing record `Suppressed`.

`DefaultsReason::NoRecord` is renamed `UnprovenFirstRun`. The old name asserted something about the *account*; the value only ever proves something about *this device*, and this is the one degraded outcome that still authorises a write, so the name now says which of the two it is.

No gate moved: the record-bearing path reads the same values in the same order, and the extra reads live only in the branch where no record came back.

## What it does not close

A device holding none of the three marks still reaches the assumed default — absence of a settings record is not cryptographically provable. That is every fresh install on an account that already published settings, until its first successful resolve. The residual is restated in `blueprint/engine.md` rather than dropped.

The one account-scoped signal a fresh device already reads is the API's advisory BYO flag, and the crypto review turned up that it is worse than "not consulted": `hosted_quota_pre_flight` reads it *after* the placement decision is fixed, and on exactly this arm — an assumed `Placement::Hosted` — its reconcile PATCHes the account to `byo=false`. So the residual path clears the account-wide flag on the strength of a placement no device authenticated, which also removes the server-side backstop that would have rejected the hosted upload. Two fixes belong there and both live in `crates/engine/src/facade.rs`, which this batch does not own:

1. Gate the `set_byo` reconcile on an *authenticated* placement. An assumed one must never latch account-scoped state.
2. Consult the flag in the restricting direction only — `advisory` set means never assume the default. The inverse would be a server-controlled widening on an untrusted signal.

`self.placement` is also computed once in `start` and never recomputed, so a successful in-session settings save will not clear a refusal until restart. Same file.

Refusing `UnprovenFirstRun` outright is not available while nothing publishes a settings record: `publish_settings` has no production caller, so "no record" is the universal state and a blanket refusal would refuse every content write on every account. For the same reason the mint-counter half of this hardening is dormant until a settings-save command is wired — the adopted-revision and unreadable-mark halves are live now.

## Tests

- `settings.rs` — each of the three marks alone refuses a withheld record and refuses the placement; none of them is the arm that still authorises; a mark the host cannot read yields `FloorUnreadable`. In-crate, so the floor keys come from their constructors rather than a duplicated prefix literal.
- `vault_settings.rs` — a publish that comes back `Unconfirmed` leaves the sequence floor untouched, still makes a later withheld record `Suppressed`, and the state has an exit: saving again successfully resolves.
- `write_plane.rs` &#40;appended&#41; — end to end through `Engine::begin_write`: a settings save that never landed refuses the write with `SettingsUnavailable&#40;Suppressed&#41;` and puts no content byte in the hosted store.

## Gates

`cargo fmt --all --check` 0 · `cargo clippy --workspace --all-targets -D warnings` 0 · `cargo test --workspace` 0 · `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` 0 · `lint:tracker-refs` 0.

Closes #1084


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Narrow settings first-run carve-out to devices with no durable marks
> - Replaces `DefaultsReason::NoRecord` with `DefaultsReason::UnprovenFirstRun`, which is only returned when all three durable marks (sequence floor, mint counter, adopted revision) are absent, indicating a true first run.
> - `load_settings` now reads all three marks when no record is served; presence of any mark yields `Suppressed`, absence of all yields `UnprovenFirstRun`, and unreadable marks yield `FloorUnreadable`.
> - `decide_placement` now only authorizes `Placement::Hosted` for `UnprovenFirstRun`; all other default reasons return `PlacementRefusal::SettingsUnavailable`.
> - Behavioral Change: a cold start after an unconfirmed publish (which advances the mint counter) now refuses writes rather than widening placement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b8d124.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved first-run detection so hosted placement is available only when no prior settings activity can be established.
  * Devices with existing or unreadable settings records now avoid unsafe default placement.
  * Unconfirmed settings saves correctly prevent hosted placement during subsequent startups.
  * Confirmed settings saves restore normal placement behavior.

* **Documentation**
  * Clarified first-run, degraded-state, and bring-your-own evidence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->