### PR TITLE
feat: carry a payload-bearing outcome out of the facade command surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,7 @@ name = "cipherbox-wasm"
 version = "0.0.0"
 dependencies = [
  "async-lock",
+ "cipherbox-core",
  "cipherbox-engine",
  "console_error_panic_hook",
  "getrandom 0.3.4",

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -39,7 +39,7 @@ use crate::content::{
 };
 use crate::entropy::Entropy;
 use crate::gate::{GateError, floor};
-use crate::grants::import_contact;
+use crate::grants::{Contact, import_contact};
 use crate::net::retire::{OrphanHeads, retire};
 use crate::net::{
     Adopter, ChildAdopter, ChildResolveError, EolRenewResult, FolderRefresh, HeldMaterial,
@@ -551,25 +551,7 @@ impl fmt::Debug for Command {
     }
 }
 
-/// A contact code the engine verified at import: the two public keys the
-/// bundle's binding signature tied together (`CONTEXT.md` "Contact code").
-///
-/// Both halves are public material — the identity key is what a host names as
-/// `recipient_identity_public_key` on a grant command, and the encryption
-/// subkey is what a grant blob seals to.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ImportedContact {
-    /// Compressed SEC1 secp256k1 identity public key (33 bytes).
-    pub identity_public_key: Vec<u8>,
-    /// X25519 encryption subkey (32 bytes).
-    pub enc_public_key: Vec<u8>,
-}
-
 /// What a command hands back to its caller.
-///
-/// An op id alone cannot answer every command: the grant, share, and rotation
-/// arms each produce a value only the caller can act on, so the return type
-/// carries the payload rather than reducing it to `Option<OpId>`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CommandOutcome {
     /// The command completed and queued nothing; any further effect arrives on
@@ -582,8 +564,9 @@ pub enum CommandOutcome {
         /// The durable queue id.
         op_id: OpId,
     },
-    /// [`Command::ImportContact`] verified a contact code.
-    ContactImported(ImportedContact),
+    /// [`Command::ImportContact`] verified a contact code. Holding the
+    /// [`Contact`] is itself the proof its binding signature verified.
+    ContactImported(Contact),
 }
 
 impl CommandOutcome {
@@ -2233,9 +2216,6 @@ impl<T: SeamTypes> Engine<T> {
     /// share, and rotation arms whose slices have not landed stay
     /// [`EngineError::Unimplemented`].
     ///
-    /// The [`CommandOutcome`] carries whatever the arm produced — the staged
-    /// op's durable queue id, a verified contact — so a host never has to
-    /// reconstruct it from the event stream.
     pub async fn command(&mut self, command: Command) -> Result<CommandOutcome, EngineError> {
         if !self.started {
             return Err(EngineError::NotStarted);
@@ -2323,20 +2303,11 @@ impl<T: SeamTypes> Engine<T> {
                 }
                 Ok(CommandOutcome::Done)
             }
-            Command::ImportContact { contact_code } => {
-                let contact = import_contact(&contact_code).map_err(|err| {
-                    // An unverifiable bundle is a fail-closed rejection, never a
-                    // retryable stall: the binding signature is the only thing
-                    // tying the encryption subkey to the identity key (#34 D6).
-                    EngineError::TrustViolation {
-                        message: format!("contact code rejected: {}", err.check()),
-                    }
-                })?;
-                Ok(CommandOutcome::ContactImported(ImportedContact {
-                    identity_public_key: contact.identity_pk().to_sec1().to_vec(),
-                    enc_public_key: contact.enc_subkey().to_bytes().to_vec(),
-                }))
-            }
+            Command::ImportContact { contact_code } => import_contact(&contact_code)
+                .map(CommandOutcome::ContactImported)
+                .map_err(|err| EngineError::TrustViolation {
+                    message: format!("contact code {}: {}", err.class(), err.check()),
+                }),
             Command::SiweLogin { message, signature } => {
                 let api = self.api.as_ref().ok_or(EngineError::NotStarted)?;
                 api.siwe_login(&message, &hex_lower(&signature))

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -39,6 +39,7 @@ use crate::content::{
 };
 use crate::entropy::Entropy;
 use crate::gate::{GateError, floor};
+use crate::grants::import_contact;
 use crate::net::retire::{OrphanHeads, retire};
 use crate::net::{
     Adopter, ChildAdopter, ChildResolveError, EolRenewResult, FolderRefresh, HeldMaterial,
@@ -547,6 +548,51 @@ impl Command {
 impl fmt::Debug for Command {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Command({})", self.name())
+    }
+}
+
+/// A contact code the engine verified at import: the two public keys the
+/// bundle's binding signature tied together (`CONTEXT.md` "Contact code").
+///
+/// Both halves are public material — the identity key is what a host names as
+/// `recipient_identity_public_key` on a grant command, and the encryption
+/// subkey is what a grant blob seals to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportedContact {
+    /// Compressed SEC1 secp256k1 identity public key (33 bytes).
+    pub identity_public_key: Vec<u8>,
+    /// X25519 encryption subkey (32 bytes).
+    pub enc_public_key: Vec<u8>,
+}
+
+/// What a command hands back to its caller.
+///
+/// An op id alone cannot answer every command: the grant, share, and rotation
+/// arms each produce a value only the caller can act on, so the return type
+/// carries the payload rather than reducing it to `Option<OpId>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommandOutcome {
+    /// The command completed and queued nothing; any further effect arrives on
+    /// the event stream.
+    Done,
+    /// An intent op reached the durable queue under this id — the same id a
+    /// later [`Event::OpProgress`] or [`Event::DeadLetter`] carries, so a host
+    /// can correlate them back to the call that made it.
+    Queued {
+        /// The durable queue id.
+        op_id: OpId,
+    },
+    /// [`Command::ImportContact`] verified a contact code.
+    ContactImported(ImportedContact),
+}
+
+impl CommandOutcome {
+    /// The staged op's durable queue id, for a command that queued one.
+    pub fn op_id(&self) -> Option<OpId> {
+        match self {
+            CommandOutcome::Queued { op_id } => Some(*op_id),
+            _ => None,
+        }
     }
 }
 
@@ -2183,14 +2229,14 @@ impl<T: SeamTypes> Engine<T> {
     /// The metadata intent ops (create/delete/rename/relink) stage onto the
     /// durable op queue via [`stage_op`] and emit [`Event::SnapshotUpdated`];
     /// the base sequence each op carries is read from the rendered view (state
-    /// law), so an op rebases against the state the host saw. Content sealing,
-    /// grants, rotation, and auth land with their own slices and stay
+    /// law), so an op rebases against the state the host saw. The grant,
+    /// share, and rotation arms whose slices have not landed stay
     /// [`EngineError::Unimplemented`].
     ///
-    /// Returns the durable queue id of the staged op, so a host can correlate a
-    /// later [`Event::DeadLetter`] or [`Event::OpProgress`] back to the call
-    /// that made it; `None` for a command that queues nothing.
-    pub async fn command(&mut self, command: Command) -> Result<Option<OpId>, EngineError> {
+    /// The [`CommandOutcome`] carries whatever the arm produced — the staged
+    /// op's durable queue id, a verified contact — so a host never has to
+    /// reconstruct it from the event stream.
+    pub async fn command(&mut self, command: Command) -> Result<CommandOutcome, EngineError> {
         if !self.started {
             return Err(EngineError::NotStarted);
         }
@@ -2262,7 +2308,10 @@ impl<T: SeamTypes> Engine<T> {
                 );
                 self.stage_and_notify(&op).await
             }
-            Command::CancelUpload { op_id } => self.cancel_upload(op_id).await.map(|()| None),
+            Command::CancelUpload { op_id } => self
+                .cancel_upload(op_id)
+                .await
+                .map(|()| CommandOutcome::Done),
             Command::SetFocus { node } => {
                 self.focus.borrow_mut().open_folder = node;
                 // Navigation is the tick model's second trigger source (#33 D2):
@@ -2272,14 +2321,28 @@ impl<T: SeamTypes> Engine<T> {
                 if self.refresh_focus_on_access(authored_at).await {
                     let _ = self.events.unbounded_send(Event::SnapshotUpdated);
                 }
-                Ok(None)
+                Ok(CommandOutcome::Done)
+            }
+            Command::ImportContact { contact_code } => {
+                let contact = import_contact(&contact_code).map_err(|err| {
+                    // An unverifiable bundle is a fail-closed rejection, never a
+                    // retryable stall: the binding signature is the only thing
+                    // tying the encryption subkey to the identity key (#34 D6).
+                    EngineError::TrustViolation {
+                        message: format!("contact code rejected: {}", err.check()),
+                    }
+                })?;
+                Ok(CommandOutcome::ContactImported(ImportedContact {
+                    identity_public_key: contact.identity_pk().to_sec1().to_vec(),
+                    enc_public_key: contact.enc_subkey().to_bytes().to_vec(),
+                }))
             }
             Command::SiweLogin { message, signature } => {
                 let api = self.api.as_ref().ok_or(EngineError::NotStarted)?;
                 api.siwe_login(&message, &hex_lower(&signature))
                     .await
                     .map_err(EngineError::from_api)?;
-                Ok(None)
+                Ok(CommandOutcome::Done)
             }
             other => Err(EngineError::Unimplemented {
                 command: other.name(),
@@ -3259,7 +3322,7 @@ impl<T: SeamTypes> Engine<T> {
 
     /// Stage a metadata op and emit [`Event::SnapshotUpdated`] on success,
     /// returning the durable queue id the drain will report the op under.
-    async fn stage_and_notify(&mut self, op: &Op) -> Result<Option<OpId>, EngineError> {
+    async fn stage_and_notify(&mut self, op: &Op) -> Result<CommandOutcome, EngineError> {
         let seal = self.record_seal()?;
         let op_id = stage_op(&self.seams.staging_store, seal, op)
             .await
@@ -3267,7 +3330,7 @@ impl<T: SeamTypes> Engine<T> {
         // Best-effort push-invalidation trigger; a dropped receiver (host torn
         // down) is fine.
         let _ = self.events.unbounded_send(Event::SnapshotUpdated);
-        Ok(Some(op_id))
+        Ok(CommandOutcome::Queued { op_id })
     }
 
     /// Sealing inputs for one durable op record: the session's enc-subkey plus

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -22,6 +22,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
 use cipherbox_core::content::encode_content_cid_str;
+use cipherbox_core::error::CodecError;
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::seal::{ReadBody, Version, seal_content_key};
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
@@ -552,7 +553,11 @@ impl fmt::Debug for Command {
 }
 
 /// What a command hands back to its caller.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `Debug` is hand-written like [`Command`]'s: a peer's identity key is a
+/// stable cross-service identifier for a third party, and a derived `{:?}`
+/// would put it in host logs.
+#[derive(Clone, PartialEq, Eq)]
 pub enum CommandOutcome {
     /// The command completed and queued nothing; any further effect arrives on
     /// the event stream.
@@ -567,6 +572,16 @@ pub enum CommandOutcome {
     /// [`Command::ImportContact`] verified a contact code. Holding the
     /// [`Contact`] is itself the proof its binding signature verified.
     ContactImported(Contact),
+}
+
+impl fmt::Debug for CommandOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CommandOutcome::Done => f.write_str("CommandOutcome(done)"),
+            CommandOutcome::Queued { op_id } => write!(f, "CommandOutcome(queued {})", op_id.0),
+            CommandOutcome::ContactImported(_) => f.write_str("CommandOutcome(contactImported)"),
+        }
+    }
 }
 
 impl CommandOutcome {
@@ -708,6 +723,14 @@ pub enum EngineError {
     TrustViolation {
         /// The verdict classification; never carries key material.
         message: String,
+    },
+    /// Host-supplied bytes this build could not decode — a truncated paste, a
+    /// mis-scanned code, an over-cap payload. A refusal of the input, never a
+    /// trust verdict about the peer who authored it: collapsing the two would
+    /// tell a host a garbled scan came from a forger.
+    MalformedInput {
+        /// The check that fired; never key material and never input bytes.
+        check: &'static str,
     },
     /// The content's DAG root declared a format version this build cannot
     /// read; see [`DagError::UnsupportedFormat`](crate::DagError).
@@ -883,6 +906,7 @@ impl fmt::Display for EngineError {
                 write!(f, "content unavailable: {message}")
             }
             EngineError::TrustViolation { message } => write!(f, "trust violation: {message}"),
+            EngineError::MalformedInput { check } => write!(f, "malformed input: {check}"),
             EngineError::UnsupportedContentFormat { version } => write!(
                 f,
                 "content format version {version} is not supported by this client"
@@ -1430,6 +1454,15 @@ impl Drop for StreamSlot {
 /// root manifest carrying a CID per MiB of file, which an unbounded table turns
 /// into a memory and key-pinning DoS ([`EngineError::TooManyStreams`]).
 pub const MAX_OPEN_STREAMS: usize = 256;
+
+/// The largest contact code [`Command::ImportContact`] will decode.
+///
+/// The bundle is three fixed-width keys — a real one is under 200 bytes — and
+/// the bytes arrive as an unbounded host paste or camera scan. Decoding is
+/// linear in length, but a decoded `Value` costs far more than the byte it came
+/// from, so the cap is what stops a paste from exhausting the engine worker
+/// (the resolve path bounds its own reads the same way).
+pub const MAX_CONTACT_CODE_BYTES: usize = 1024;
 
 /// The engine's live read streams, bounded by [`MAX_OPEN_STREAMS`].
 #[derive(Default)]
@@ -2303,11 +2336,23 @@ impl<T: SeamTypes> Engine<T> {
                 }
                 Ok(CommandOutcome::Done)
             }
-            Command::ImportContact { contact_code } => import_contact(&contact_code)
-                .map(CommandOutcome::ContactImported)
-                .map_err(|err| EngineError::TrustViolation {
-                    message: format!("contact code {}: {}", err.class(), err.check()),
-                }),
+            Command::ImportContact { contact_code } => {
+                if contact_code.len() > MAX_CONTACT_CODE_BYTES {
+                    return Err(EngineError::MalformedInput {
+                        check: "contact-code-too-large",
+                    });
+                }
+                import_contact(&contact_code)
+                    .map(CommandOutcome::ContactImported)
+                    .map_err(|err| match err {
+                        CodecError::Trust(_) => EngineError::TrustViolation {
+                            message: format!("contact code rejected: {}", err.check()),
+                        },
+                        CodecError::Malformed(_) => {
+                            EngineError::MalformedInput { check: err.check() }
+                        }
+                    })
+            }
             Command::SiweLogin { message, signature } => {
                 let api = self.api.as_ref().ok_or(EngineError::NotStarted)?;
                 api.siwe_login(&message, &hex_lower(&signature))

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -57,9 +57,9 @@ pub use content::{
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{
     ApiBaseUrl, BlankApiBaseUrl, BlockProgress, Breadcrumb, Command, CommandOutcome, DeadLetter,
-    Engine, EngineError, EngineView, Event, EventStream, LoginSecret, MAX_OPEN_STREAMS, NodeAttrs,
-    NodeId, NodeKind, OpPhase, OverBudgetCause, Permission, SnapshotChild, SnapshotView, Staleness,
-    StatFs, StreamHandle, WriteHandle, WriteTarget,
+    Engine, EngineError, EngineView, Event, EventStream, LoginSecret, MAX_CONTACT_CODE_BYTES,
+    MAX_OPEN_STREAMS, NodeAttrs, NodeId, NodeKind, OpPhase, OverBudgetCause, Permission,
+    SnapshotChild, SnapshotView, Staleness, StatFs, StreamHandle, WriteHandle, WriteTarget,
 };
 pub use gate::{
     Adopted, Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -56,10 +56,10 @@ pub use content::{
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{
-    ApiBaseUrl, BlankApiBaseUrl, BlockProgress, Breadcrumb, Command, DeadLetter, Engine,
-    EngineError, EngineView, Event, EventStream, LoginSecret, MAX_OPEN_STREAMS, NodeAttrs, NodeId,
-    NodeKind, OpPhase, OverBudgetCause, Permission, SnapshotChild, SnapshotView, Staleness, StatFs,
-    StreamHandle, WriteHandle, WriteTarget,
+    ApiBaseUrl, BlankApiBaseUrl, BlockProgress, Breadcrumb, Command, CommandOutcome, DeadLetter,
+    Engine, EngineError, EngineView, Event, EventStream, ImportedContact, LoginSecret,
+    MAX_OPEN_STREAMS, NodeAttrs, NodeId, NodeKind, OpPhase, OverBudgetCause, Permission,
+    SnapshotChild, SnapshotView, Staleness, StatFs, StreamHandle, WriteHandle, WriteTarget,
 };
 pub use gate::{
     Adopted, Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -57,9 +57,9 @@ pub use content::{
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{
     ApiBaseUrl, BlankApiBaseUrl, BlockProgress, Breadcrumb, Command, CommandOutcome, DeadLetter,
-    Engine, EngineError, EngineView, Event, EventStream, ImportedContact, LoginSecret,
-    MAX_OPEN_STREAMS, NodeAttrs, NodeId, NodeKind, OpPhase, OverBudgetCause, Permission,
-    SnapshotChild, SnapshotView, Staleness, StatFs, StreamHandle, WriteHandle, WriteTarget,
+    Engine, EngineError, EngineView, Event, EventStream, LoginSecret, MAX_OPEN_STREAMS, NodeAttrs,
+    NodeId, NodeKind, OpPhase, OverBudgetCause, Permission, SnapshotChild, SnapshotView, Staleness,
+    StatFs, StreamHandle, WriteHandle, WriteTarget,
 };
 pub use gate::{
     Adopted, Candidate, GateError, GateRejection, GateStage, ReaderContext, RejectionReason,

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -9,8 +9,7 @@ use cipherbox_engine::seams::{HttpResponse, Scheduler, UnixMillis};
 use cipherbox_engine::testkit::{FakeDevice, FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
 use cipherbox_engine::{
     ApiBaseUrl, Command, CommandOutcome, ContentProfile, Engine, EngineError, EventStream,
-    GatewayConfig, ImportedContact, LoginSecret, NodeId, Permission, StoragePolicy,
-    SyncTimingProfile,
+    GatewayConfig, LoginSecret, NodeId, Permission, StoragePolicy, SyncTimingProfile,
 };
 
 fn new_engine(device: &FakeDevice) -> (Engine<FakeSeamTypes>, EventStream) {
@@ -168,15 +167,9 @@ fn unimplemented_commands_return_their_typed_error() {
 
 /// A contact code the peer signed itself: the bundle a real import receives
 /// out of band.
-fn contact_code(scalar: [u8; 32]) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+fn contact_code(scalar: [u8; 32]) -> Vec<u8> {
     let identity = EcdsaSigner::from_scalar(&scalar).expect("valid identity scalar");
-    let enc_subkey = kdf::enc_subkey(&scalar).public();
-    let code = ContactCode::create(&identity, enc_subkey);
-    (
-        code.encode(),
-        identity.verifying_key().to_sec1().to_vec(),
-        enc_subkey.to_bytes().to_vec(),
-    )
+    ContactCode::create(&identity, kdf::enc_subkey(&scalar).public()).encode()
 }
 
 #[test]
@@ -185,19 +178,22 @@ fn importing_a_contact_returns_the_bound_public_keys() {
     let device = world.device(b"alice-pk");
     let (mut engine, _events) = new_engine(&device);
     block_on(engine.start(secret())).unwrap();
-    let (code, identity_public_key, enc_public_key) = contact_code([3u8; 32]);
+    let scalar = [3u8; 32];
 
-    assert_eq!(
-        block_on(engine.command(Command::ImportContact { contact_code: code })),
-        Ok(CommandOutcome::ContactImported(ImportedContact {
-            identity_public_key,
-            enc_public_key,
-        })),
-    );
+    let outcome = block_on(engine.command(Command::ImportContact {
+        contact_code: contact_code(scalar),
+    }));
+
+    let CommandOutcome::ContactImported(contact) = outcome.expect("the code imports") else {
+        panic!("importing a contact answers with the contact");
+    };
+    let identity = EcdsaSigner::from_scalar(&scalar).expect("valid identity scalar");
+    assert_eq!(contact.identity_pk(), identity.verifying_key());
+    assert_eq!(contact.enc_subkey(), kdf::enc_subkey(&scalar).public());
 }
 
 /// The binding signature is the only thing tying the encryption subkey to the
-/// identity key, so a code that fails it is a trust violation — never a
+/// identity key, so a code that fails it is refused outright — never a
 /// degraded import that hands back an unbound subkey (#34 D6).
 #[test]
 fn a_contact_code_that_fails_its_binding_is_refused() {
@@ -205,22 +201,25 @@ fn a_contact_code_that_fails_its_binding_is_refused() {
     let device = world.device(b"alice-pk");
     let (mut engine, _events) = new_engine(&device);
     block_on(engine.start(secret())).unwrap();
-    let (mut code, _, honest_enc_public_key) = contact_code([3u8; 32]);
-    let (_, _, other_enc_public_key) = contact_code([4u8; 32]);
+    let mut code = contact_code([3u8; 32]);
+    let honest = kdf::enc_subkey(&[3u8; 32]).public().to_bytes();
+    let forged = kdf::enc_subkey(&[4u8; 32]).public().to_bytes();
     let at = code
-        .windows(honest_enc_public_key.len())
-        .position(|window| window == honest_enc_public_key)
+        .windows(honest.len())
+        .position(|window| window == honest)
         .expect("the encoded code carries the subkey it bound");
-    code[at..at + other_enc_public_key.len()].copy_from_slice(&other_enc_public_key);
+    code[at..at + forged.len()].copy_from_slice(&forged);
 
     assert_eq!(
         block_on(engine.command(Command::ImportContact { contact_code: code })),
         Err(EngineError::TrustViolation {
-            message: "contact code rejected: subkey-binding-invalid".to_owned(),
+            message: "contact code trust: subkey-binding-invalid".to_owned(),
         }),
     );
 }
 
+/// A bundle that does not decode is refused too, and says so: the class tells
+/// a host whether the code is garbled or forged.
 #[test]
 fn a_malformed_contact_code_is_refused() {
     let world = FakeWorld::new();
@@ -232,9 +231,12 @@ fn a_malformed_contact_code_is_refused() {
         contact_code: b"not a contact bundle".to_vec(),
     }));
 
+    let Err(EngineError::TrustViolation { message }) = result else {
+        panic!("an undecodable bundle is refused, never imported: {result:?}");
+    };
     assert!(
-        matches!(result, Err(EngineError::TrustViolation { .. })),
-        "a bundle that does not decode is refused, never imported: {result:?}"
+        message.starts_with("contact code malformed: "),
+        "the refusal names the codec class and check: {message}"
     );
 }
 

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -1,12 +1,16 @@
 //! Facade skeleton surface: lifecycle law, typed unimplemented commands,
 //! and event-stream plumbing over a fully faked seam set.
 
+use cipherbox_core::kdf;
+use cipherbox_core::suite::contact::ContactCode;
+use cipherbox_core::suite::ecdsa::EcdsaSigner;
 use cipherbox_engine::net::RE_PUT_INTERVAL;
 use cipherbox_engine::seams::{HttpResponse, Scheduler, UnixMillis};
 use cipherbox_engine::testkit::{FakeDevice, FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
 use cipherbox_engine::{
-    ApiBaseUrl, Command, ContentProfile, Engine, EngineError, EventStream, GatewayConfig,
-    LoginSecret, NodeId, Permission, StoragePolicy, SyncTimingProfile,
+    ApiBaseUrl, Command, CommandOutcome, ContentProfile, Engine, EngineError, EventStream,
+    GatewayConfig, ImportedContact, LoginSecret, NodeId, Permission, StoragePolicy,
+    SyncTimingProfile,
 };
 
 fn new_engine(device: &FakeDevice) -> (Engine<FakeSeamTypes>, EventStream) {
@@ -32,12 +36,6 @@ fn unimplemented_commands() -> Vec<(Command, &'static str)> {
     let node = NodeId([1; 16]);
     vec![
         (Command::ManualRefresh, "manualRefresh"),
-        (
-            Command::ImportContact {
-                contact_code: b"contact-bundle".to_vec(),
-            },
-            "importContact",
-        ),
         (
             Command::Grant {
                 node,
@@ -168,6 +166,78 @@ fn unimplemented_commands_return_their_typed_error() {
     }
 }
 
+/// A contact code the peer signed itself: the bundle a real import receives
+/// out of band.
+fn contact_code(scalar: [u8; 32]) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    let identity = EcdsaSigner::from_scalar(&scalar).expect("valid identity scalar");
+    let enc_subkey = kdf::enc_subkey(&scalar).public();
+    let code = ContactCode::create(&identity, enc_subkey);
+    (
+        code.encode(),
+        identity.verifying_key().to_sec1().to_vec(),
+        enc_subkey.to_bytes().to_vec(),
+    )
+}
+
+#[test]
+fn importing_a_contact_returns_the_bound_public_keys() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (mut engine, _events) = new_engine(&device);
+    block_on(engine.start(secret())).unwrap();
+    let (code, identity_public_key, enc_public_key) = contact_code([3u8; 32]);
+
+    assert_eq!(
+        block_on(engine.command(Command::ImportContact { contact_code: code })),
+        Ok(CommandOutcome::ContactImported(ImportedContact {
+            identity_public_key,
+            enc_public_key,
+        })),
+    );
+}
+
+/// The binding signature is the only thing tying the encryption subkey to the
+/// identity key, so a code that fails it is a trust violation — never a
+/// degraded import that hands back an unbound subkey (#34 D6).
+#[test]
+fn a_contact_code_that_fails_its_binding_is_refused() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (mut engine, _events) = new_engine(&device);
+    block_on(engine.start(secret())).unwrap();
+    let (mut code, _, honest_enc_public_key) = contact_code([3u8; 32]);
+    let (_, _, other_enc_public_key) = contact_code([4u8; 32]);
+    let at = code
+        .windows(honest_enc_public_key.len())
+        .position(|window| window == honest_enc_public_key)
+        .expect("the encoded code carries the subkey it bound");
+    code[at..at + other_enc_public_key.len()].copy_from_slice(&other_enc_public_key);
+
+    assert_eq!(
+        block_on(engine.command(Command::ImportContact { contact_code: code })),
+        Err(EngineError::TrustViolation {
+            message: "contact code rejected: subkey-binding-invalid".to_owned(),
+        }),
+    );
+}
+
+#[test]
+fn a_malformed_contact_code_is_refused() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (mut engine, _events) = new_engine(&device);
+    block_on(engine.start(secret())).unwrap();
+
+    let result = block_on(engine.command(Command::ImportContact {
+        contact_code: b"not a contact bundle".to_vec(),
+    }));
+
+    assert!(
+        matches!(result, Err(EngineError::TrustViolation { .. })),
+        "a bundle that does not decode is refused, never imported: {result:?}"
+    );
+}
+
 /// Focus is recorded whatever the window resolves to: a node absent from
 /// gate-passing state has nothing to descend into, which is not an error.
 #[test]
@@ -181,11 +251,11 @@ fn set_focus_records_a_window_with_nothing_to_resolve() {
         block_on(engine.command(Command::SetFocus {
             node: Some(NodeId([1; 16]))
         })),
-        Ok(None)
+        Ok(CommandOutcome::Done)
     );
     assert_eq!(
         block_on(engine.command(Command::SetFocus { node: None })),
-        Ok(None)
+        Ok(CommandOutcome::Done)
     );
 }
 

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -9,7 +9,8 @@ use cipherbox_engine::seams::{HttpResponse, Scheduler, UnixMillis};
 use cipherbox_engine::testkit::{FakeDevice, FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
 use cipherbox_engine::{
     ApiBaseUrl, Command, CommandOutcome, ContentProfile, Engine, EngineError, EventStream,
-    GatewayConfig, LoginSecret, NodeId, Permission, StoragePolicy, SyncTimingProfile,
+    GatewayConfig, LoginSecret, MAX_CONTACT_CODE_BYTES, NodeId, Permission, StoragePolicy,
+    SyncTimingProfile,
 };
 
 fn new_engine(device: &FakeDevice) -> (Engine<FakeSeamTypes>, EventStream) {
@@ -213,15 +214,15 @@ fn a_contact_code_that_fails_its_binding_is_refused() {
     assert_eq!(
         block_on(engine.command(Command::ImportContact { contact_code: code })),
         Err(EngineError::TrustViolation {
-            message: "contact code trust: subkey-binding-invalid".to_owned(),
+            message: "contact code rejected: subkey-binding-invalid".to_owned(),
         }),
     );
 }
 
-/// A bundle that does not decode is refused too, and says so: the class tells
-/// a host whether the code is garbled or forged.
+/// A bundle that does not decode is refused too, but as bad input — a host
+/// told a garbled scan came from a forger would accuse the wrong party.
 #[test]
-fn a_malformed_contact_code_is_refused() {
+fn a_malformed_contact_code_is_refused_without_a_trust_verdict() {
     let world = FakeWorld::new();
     let device = world.device(b"alice-pk");
     let (mut engine, _events) = new_engine(&device);
@@ -231,12 +232,44 @@ fn a_malformed_contact_code_is_refused() {
         contact_code: b"not a contact bundle".to_vec(),
     }));
 
-    let Err(EngineError::TrustViolation { message }) = result else {
-        panic!("an undecodable bundle is refused, never imported: {result:?}");
-    };
     assert!(
-        message.starts_with("contact code malformed: "),
-        "the refusal names the codec class and check: {message}"
+        matches!(result, Err(EngineError::MalformedInput { .. })),
+        "an undecodable bundle is refused, never imported: {result:?}"
+    );
+}
+
+/// The bundle is three fixed-width keys, and the bytes are an unbounded host
+/// paste: an over-cap payload never reaches the decoder.
+#[test]
+fn an_oversized_contact_code_is_refused_before_it_is_decoded() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (mut engine, _events) = new_engine(&device);
+    block_on(engine.start(secret())).unwrap();
+
+    assert_eq!(
+        block_on(engine.command(Command::ImportContact {
+            contact_code: vec![0x80; MAX_CONTACT_CODE_BYTES + 1],
+        })),
+        Err(EngineError::MalformedInput {
+            check: "contact-code-too-large",
+        }),
+    );
+}
+
+/// The lifecycle check outranks the trust decision: a valid code still yields
+/// no contact before `start`.
+#[test]
+fn a_contact_import_before_start_never_verifies() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (mut engine, _events) = new_engine(&device);
+
+    assert_eq!(
+        block_on(engine.command(Command::ImportContact {
+            contact_code: contact_code([3u8; 32]),
+        })),
+        Err(EngineError::NotStarted),
     );
 }
 

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -48,10 +48,10 @@ use cipherbox_engine::testkit::{
     OwnerRootSpec, SeededEntropy, block_on, frame_version as frame, owner_root_fixture,
 };
 use cipherbox_engine::{
-    ApiBaseUrl, ApiClient, BlockProgress, Command, ContentProfile, DeadLetter, DeadLetterReason,
-    DefaultsReason, Engine, EngineError, Event, EventStream, GatewayConfig, LoginSecret,
-    MAX_OPEN_STREAMS, NodeId, NodeKind, Op, OpPhase, OverBudgetCause, Placement, PlacementRefusal,
-    RecordSeal, StoragePolicy, SyncTimingProfile, WriteTarget, stage_op,
+    ApiBaseUrl, ApiClient, BlockProgress, Command, CommandOutcome, ContentProfile, DeadLetter,
+    DeadLetterReason, DefaultsReason, Engine, EngineError, Event, EventStream, GatewayConfig,
+    LoginSecret, MAX_OPEN_STREAMS, NodeId, NodeKind, Op, OpPhase, OverBudgetCause, Placement,
+    PlacementRefusal, RecordSeal, StoragePolicy, SyncTimingProfile, WriteTarget, stage_op,
 };
 
 const SECRET: [u8; 32] = [7u8; 32];
@@ -730,7 +730,8 @@ fn a_folder_create_publishes_and_resolves_back() {
         name: "photos".into(),
         kind: NodeKind::Folder,
     }))
-    .expect("a metadata create stages");
+    .expect("a metadata create stages")
+    .op_id();
     assert!(
         op_id.is_some(),
         "a staged op is addressable by its queue id"
@@ -2410,7 +2411,8 @@ fn an_op_the_completion_record_already_covers_never_republishes() {
         name: "photos".into(),
         kind: NodeKind::Folder,
     }))
-    .unwrap();
+    .unwrap()
+    .op_id();
     assert_eq!(op_id, Some(OpId(1)), "the create reclaims the covered id");
 
     let mut tasks = world.scheduler.take_spawned_tasks();
@@ -2785,7 +2787,8 @@ fn a_rename_of_a_still_queued_create_publishes_child_before_parent() {
         name: "photos".into(),
         kind: NodeKind::Folder,
     }))
-    .unwrap();
+    .unwrap()
+    .op_id();
     assert!(op.is_some());
     let node = child_id(&engine, ROOT, "photos");
     // Renamed while the create is still queued: both drain in one pass.
@@ -3304,6 +3307,7 @@ fn relink_whose_source_remove_is_refused(
         new_parent: photos,
     }))
     .unwrap()
+    .op_id()
     .expect("a relink journals an op")
 }
 
@@ -4768,6 +4772,7 @@ fn a_delete_whose_self_adopt_failed_still_marks_the_op_published() {
 
     let op_id = block_on(engine.command(Command::Delete { node: doomed }))
         .unwrap()
+        .op_id()
         .expect("the delete queues");
     assert_a_failed_root_adopt_still_marks(&world, &alice, &engine, &mut tasks, &root_name, op_id);
     assert_restart_drops_without_republishing(&world, &blocks, &alice);
@@ -4791,6 +4796,7 @@ fn a_rename_whose_self_adopt_failed_still_marks_the_op_published() {
         new_name: "after".into(),
     }))
     .unwrap()
+    .op_id()
     .expect("the rename queues");
     assert_a_failed_root_adopt_still_marks(&world, &alice, &engine, &mut tasks, &root_name, op_id);
     assert_restart_drops_without_republishing(&world, &blocks, &alice);
@@ -4817,6 +4823,7 @@ fn a_cross_folder_moves_source_remove_is_the_record_that_marks() {
         replacing: None,
     }))
     .unwrap()
+    .op_id()
     .expect("the move queues");
     assert_a_failed_root_adopt_still_marks(&world, &alice, &engine, &mut tasks, &root_name, op_id);
     assert_eq!(
@@ -4852,6 +4859,7 @@ fn a_cross_folder_moves_dest_add_never_marks_on_its_own() {
         replacing: None,
     }))
     .unwrap()
+    .op_id()
     .expect("the move queues");
     tick(&world, &engine, &mut tasks);
 
@@ -4904,6 +4912,7 @@ fn a_retried_cross_folder_move_marks_when_its_source_remove_lands() {
         replacing: None,
     }))
     .unwrap()
+    .op_id()
     .expect("the move queues");
     tick(&world, &engine, &mut tasks);
     assert_eq!(
@@ -4990,6 +4999,7 @@ fn another_identitys_drained_mark_never_discards_this_ones_queued_op() {
         kind: NodeKind::Folder,
     }))
     .unwrap()
+    .op_id()
     .expect("the create queues");
 
     let stranger = kdf::enc_subkey(&[9u8; 32]);
@@ -5033,7 +5043,7 @@ fn another_identitys_published_mark_never_retires_this_ones_queued_op() {
 
     assert_eq!(
         block_on(engine.command(Command::CancelUpload { op_id })),
-        Ok(None),
+        Ok(CommandOutcome::Done),
         "the stranger's mark says nothing about this identity's op"
     );
 
@@ -5083,6 +5093,7 @@ fn a_cancel_of_a_metadata_op_is_refused() {
         kind: NodeKind::Folder,
     }))
     .unwrap()
+    .op_id()
     .expect("the create queues");
 
     assert_eq!(
@@ -5670,6 +5681,7 @@ fn create(engine: &mut Engine<FakeSeamTypes>, name: &str) -> OpId {
         kind: NodeKind::Folder,
     }))
     .expect("a metadata create stages")
+    .op_id()
     .expect("a create queues an op")
 }
 

--- a/crates/fuse/src/error.rs
+++ b/crates/fuse/src/error.rs
@@ -83,6 +83,7 @@ impl From<EngineError> for VfsError {
             // Past the flat-DAG ceiling: no amount of free space stores a file
             // this large as one version, so it is not a budget verdict.
             EngineError::ContentTooLarge { .. } => VfsError::Invalid,
+            EngineError::MalformedInput { .. } => VfsError::Invalid,
             EngineError::Seam { message }
             | EngineError::Entropy { message }
             | EngineError::Auth { message } => VfsError::Internal { message },

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -44,6 +44,9 @@ async-lock = "3"
 # engine's `GatewaySource` — the credential never sits in a plain `String`.
 zeroize.workspace = true
 
-# The boundary tests run under wasm-bindgen-test-runner.
+# The boundary tests run under wasm-bindgen-test-runner. Core is a test-only
+# dependency: the contact-code round-trip needs a signed bundle to import, and
+# no engine API mints one. It never enters the cdylib.
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
+cipherbox-core.workspace = true
 wasm-bindgen-test = "0.3"

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -493,9 +493,15 @@ fn engine_error(error: EngineError) -> JsValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cipherbox_engine::facade::{CommandOutcome as Outcome, ImportedContact};
+    use cipherbox_core::kdf;
+    use cipherbox_core::suite::contact::ContactCode;
+    use cipherbox_core::suite::ecdsa::EcdsaSigner;
+    use cipherbox_engine::facade::CommandOutcome as Outcome;
+    use cipherbox_engine::import_contact;
     use js_sys::BigInt;
     use wasm_bindgen_test::wasm_bindgen_test;
+
+    const CONTACT_SCALAR: [u8; 32] = [3u8; 32];
 
     fn crossed(outcome: Outcome) -> JsValue {
         CommandOutcome::from_facade(outcome).into()
@@ -503,6 +509,16 @@ mod tests {
 
     fn field(outcome: &JsValue, name: &str) -> JsValue {
         Reflect::get(outcome, &JsValue::from_str(name)).expect("outcome getter is readable")
+    }
+
+    fn bytes(value: JsValue) -> Vec<u8> {
+        value.unchecked_into::<Uint8Array>().to_vec()
+    }
+
+    fn imported_contact() -> Outcome {
+        let identity = EcdsaSigner::from_scalar(&CONTACT_SCALAR).expect("valid identity scalar");
+        let code = ContactCode::create(&identity, kdf::enc_subkey(&CONTACT_SCALAR).public());
+        Outcome::ContactImported(import_contact(&code.encode()).expect("the code imports"))
     }
 
     /// `command()` resolves with the id an `opProgress`/`deadLetter` event
@@ -541,47 +557,34 @@ mod tests {
     /// answer for them.
     #[wasm_bindgen_test]
     fn an_imported_contact_crosses_with_both_public_keys() {
-        let imported = crossed(Outcome::ContactImported(ImportedContact {
-            identity_public_key: vec![2u8; 33],
-            enc_public_key: vec![7u8; 32],
-        }));
+        let identity = EcdsaSigner::from_scalar(&CONTACT_SCALAR).expect("valid identity scalar");
+        let imported = crossed(imported_contact());
 
         assert_eq!(
-            field(&imported, "identityPublicKey")
-                .unchecked_into::<Uint8Array>()
-                .to_vec(),
-            vec![2u8; 33],
+            bytes(field(&imported, "identityPublicKey")),
+            identity.verifying_key().to_sec1().to_vec(),
         );
         assert_eq!(
-            field(&imported, "encPublicKey")
-                .unchecked_into::<Uint8Array>()
+            bytes(field(&imported, "encPublicKey")),
+            kdf::enc_subkey(&CONTACT_SCALAR)
+                .public()
+                .to_bytes()
                 .to_vec(),
-            vec![7u8; 32],
         );
         assert!(field(&imported, "opId").is_undefined());
         assert!(field(&crossed(Outcome::Done), "identityPublicKey").is_undefined());
     }
 
-    /// Hosts branch on `kind`, so the three arms must be distinguishable
-    /// without inspecting the payload getters.
+    /// Hosts switch on `kind`, so each arm's discriminant is a stable string
+    /// literal — the marshalling `Event::kind` already uses.
     #[wasm_bindgen_test]
-    fn each_outcome_kind_crosses_distinctly() {
-        let kinds = [
-            field(&crossed(Outcome::Done), "kind"),
-            field(&crossed(Outcome::Queued { op_id: OpId(1) }), "kind"),
-            field(
-                &crossed(Outcome::ContactImported(ImportedContact {
-                    identity_public_key: vec![2u8; 33],
-                    enc_public_key: vec![7u8; 32],
-                })),
-                "kind",
-            ),
-        ];
-
-        for (index, kind) in kinds.iter().enumerate() {
-            for other in &kinds[index + 1..] {
-                assert!(*kind != *other, "outcome kinds must not collide");
-            }
+    fn each_outcome_kind_crosses_as_its_stable_name() {
+        for (outcome, name) in [
+            (Outcome::Done, "done"),
+            (Outcome::Queued { op_id: OpId(1) }, "queued"),
+            (imported_contact(), "contactImported"),
+        ] {
+            assert_eq!(field(&crossed(outcome), "kind"), JsValue::from_str(name));
         }
     }
 

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -36,7 +36,7 @@ use crate::seams_bridge::{
     RecordTransportAdapter, RefreshHintSourceAdapter, SchedulerAdapter, SnapshotCacheAdapter,
     StagingStoreAdapter,
 };
-use crate::{Command, Event, NodeId, SnapshotView};
+use crate::{Command, CommandOutcome, Event, NodeId, SnapshotView};
 
 /// The web host's concrete seam family (blueprint/engine.md `SeamTypes`): every
 /// engine seam is a JS-object adapter from `seams_bridge`.
@@ -216,20 +216,20 @@ impl EngineHandle {
     }
 
     /// Executes one engine command — the single write entry point. Consumes the
-    /// command value. Resolves with the staged op's durable queue id (the same
-    /// `u64` an `opProgress`/`deadLetter` event carries), or `undefined` for a
-    /// command that queues nothing; rejects with the engine error.
+    /// command value. Resolves with the [`CommandOutcome`] the arm produced —
+    /// the staged op's durable queue id, a verified contact — or rejects with
+    /// the engine error.
     pub fn command(&self, command: Command) -> Promise {
         let engine = self.engine.clone();
         let facade_command = command.into_facade();
         future_to_promise(async move {
-            let op_id = engine
+            let outcome = engine
                 .write()
                 .await
                 .command(facade_command)
                 .await
                 .map_err(engine_error)?;
-            Ok(op_id_value(op_id))
+            Ok(CommandOutcome::from_facade(outcome).into())
         })
     }
 
@@ -453,13 +453,6 @@ impl EngineHandle {
     }
 }
 
-/// A staged op id as the boundary spells it. Op ids run the whole `u64` range,
-/// so they cross as `bigint` — the same marshalling the `opId` getter on
-/// `opProgress`/`deadLetter` uses, or a client could not correlate the two.
-fn op_id_value(op_id: Option<OpId>) -> JsValue {
-    op_id.map_or(JsValue::UNDEFINED, |op| JsValue::from(op.0))
-}
-
 /// Renders an engine error as a rejection value: a `js_sys::Error` whose
 /// message is the diagnostic `Display` string (no key material — redacted by
 /// construction) and whose `code` property is the stable camelCase variant
@@ -500,8 +493,17 @@ fn engine_error(error: EngineError) -> JsValue {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cipherbox_engine::facade::{CommandOutcome as Outcome, ImportedContact};
     use js_sys::BigInt;
     use wasm_bindgen_test::wasm_bindgen_test;
+
+    fn crossed(outcome: Outcome) -> JsValue {
+        CommandOutcome::from_facade(outcome).into()
+    }
+
+    fn field(outcome: &JsValue, name: &str) -> JsValue {
+        Reflect::get(outcome, &JsValue::from_str(name)).expect("outcome getter is readable")
+    }
 
     /// `command()` resolves with the id an `opProgress`/`deadLetter` event
     /// later carries, so both must cross as the same JS type — an f64 `number`
@@ -509,12 +511,17 @@ mod tests {
     /// past 2^53.
     #[wasm_bindgen_test]
     fn a_staged_op_id_crosses_as_a_bigint() {
-        let value = op_id_value(Some(OpId(u64::MAX)));
+        let op_id = field(
+            &crossed(Outcome::Queued {
+                op_id: OpId(u64::MAX),
+            }),
+            "opId",
+        );
 
-        assert_eq!(value.js_typeof(), JsValue::from_str("bigint"));
+        assert_eq!(op_id.js_typeof(), JsValue::from_str("bigint"));
         assert_eq!(
             String::from(
-                value
+                op_id
                     .unchecked_into::<BigInt>()
                     .to_string(10)
                     .expect("bigint renders in base 10")
@@ -523,10 +530,59 @@ mod tests {
         );
     }
 
-    /// A command that queues nothing resolves `undefined`, never `0n`.
+    /// A command that queues nothing carries no op id, never `0n`.
     #[wasm_bindgen_test]
-    fn a_command_that_queues_nothing_crosses_as_undefined() {
-        assert!(op_id_value(None).is_undefined());
+    fn a_command_that_queues_nothing_carries_no_op_id() {
+        assert!(field(&crossed(Outcome::Done), "opId").is_undefined());
+    }
+
+    /// The verified contact's two public keys are the whole point of the
+    /// import, so both must survive the boundary — and no other kind may
+    /// answer for them.
+    #[wasm_bindgen_test]
+    fn an_imported_contact_crosses_with_both_public_keys() {
+        let imported = crossed(Outcome::ContactImported(ImportedContact {
+            identity_public_key: vec![2u8; 33],
+            enc_public_key: vec![7u8; 32],
+        }));
+
+        assert_eq!(
+            field(&imported, "identityPublicKey")
+                .unchecked_into::<Uint8Array>()
+                .to_vec(),
+            vec![2u8; 33],
+        );
+        assert_eq!(
+            field(&imported, "encPublicKey")
+                .unchecked_into::<Uint8Array>()
+                .to_vec(),
+            vec![7u8; 32],
+        );
+        assert!(field(&imported, "opId").is_undefined());
+        assert!(field(&crossed(Outcome::Done), "identityPublicKey").is_undefined());
+    }
+
+    /// Hosts branch on `kind`, so the three arms must be distinguishable
+    /// without inspecting the payload getters.
+    #[wasm_bindgen_test]
+    fn each_outcome_kind_crosses_distinctly() {
+        let kinds = [
+            field(&crossed(Outcome::Done), "kind"),
+            field(&crossed(Outcome::Queued { op_id: OpId(1) }), "kind"),
+            field(
+                &crossed(Outcome::ContactImported(ImportedContact {
+                    identity_public_key: vec![2u8; 33],
+                    enc_public_key: vec![7u8; 32],
+                })),
+                "kind",
+            ),
+        ];
+
+        for (index, kind) in kinds.iter().enumerate() {
+            for other in &kinds[index + 1..] {
+                assert!(*kind != *other, "outcome kinds must not collide");
+            }
+        }
     }
 
     #[wasm_bindgen_test]

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -467,6 +467,7 @@ fn engine_error(error: EngineError) -> JsValue {
         EngineError::NotAFile => "notAFile",
         EngineError::ContentUnavailable { .. } => "contentUnavailable",
         EngineError::TrustViolation { .. } => "trustViolation",
+        EngineError::MalformedInput { .. } => "malformedInput",
         EngineError::UnsupportedContentFormat { .. } => "unsupportedContentFormat",
         EngineError::Unimplemented { .. } => "unimplemented",
         EngineError::OverBudget { .. } => "overBudget",

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -20,6 +20,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+use cipherbox_engine::Contact;
 use cipherbox_engine::facade;
 use wasm_bindgen::prelude::*;
 
@@ -263,19 +264,6 @@ impl From<facade::OpPhase> for OpPhase {
 // `bigint`, absent projections as `undefined`.
 // ---------------------------------------------------------------------------
 
-/// Which arm a command took. The payload getters on [`CommandOutcome`] are
-/// `undefined` for every kind that does not carry them.
-#[wasm_bindgen]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CommandOutcomeKind {
-    /// Completed, nothing to carry back.
-    Done,
-    /// An intent op reached the durable queue.
-    Queued,
-    /// A contact code was verified.
-    ContactImported,
-}
-
 /// What a command handed back across the worker boundary.
 #[wasm_bindgen]
 pub struct CommandOutcome {
@@ -284,37 +272,39 @@ pub struct CommandOutcome {
 
 #[wasm_bindgen]
 impl CommandOutcome {
-    /// Which arm ran, and therefore which payload getters are populated.
+    /// The outcome discriminant, as a stable string literal.
     #[wasm_bindgen(getter)]
-    pub fn kind(&self) -> CommandOutcomeKind {
+    pub fn kind(&self) -> String {
         match self.inner {
-            facade::CommandOutcome::Done => CommandOutcomeKind::Done,
-            facade::CommandOutcome::Queued { .. } => CommandOutcomeKind::Queued,
-            facade::CommandOutcome::ContactImported(_) => CommandOutcomeKind::ContactImported,
+            facade::CommandOutcome::Done => "done",
+            facade::CommandOutcome::Queued { .. } => "queued",
+            facade::CommandOutcome::ContactImported(_) => "contactImported",
         }
+        .to_owned()
     }
 
-    /// The staged op's durable queue id. Crosses as the same `bigint` an
+    /// `queued`: the staged op's durable queue id, as the same `bigint` an
     /// `opProgress`/`deadLetter` event carries, so the two compare equal and
-    /// an id past 2^53 survives.
+    /// an id past 2^53 survives; otherwise `undefined`.
     #[wasm_bindgen(getter, js_name = opId)]
     pub fn op_id(&self) -> Option<u64> {
         self.inner.op_id().map(|op_id| op_id.0)
     }
 
-    /// The imported contact's compressed SEC1 identity public key — what a
-    /// grant command names as its recipient.
+    /// `contactImported`: the compressed SEC1 identity public key a grant
+    /// command names as its recipient; otherwise `undefined`.
     #[wasm_bindgen(getter, js_name = identityPublicKey)]
     pub fn identity_public_key(&self) -> Option<Vec<u8>> {
         self.contact()
-            .map(|contact| contact.identity_public_key.clone())
+            .map(|contact| contact.identity_pk().to_sec1().to_vec())
     }
 
-    /// The imported contact's X25519 encryption subkey, as the verified
-    /// binding signature tied it to the identity key.
+    /// `contactImported`: the X25519 encryption subkey the verified binding
+    /// signature tied to that identity key; otherwise `undefined`.
     #[wasm_bindgen(getter, js_name = encPublicKey)]
     pub fn enc_public_key(&self) -> Option<Vec<u8>> {
-        self.contact().map(|contact| contact.enc_public_key.clone())
+        self.contact()
+            .map(|contact| contact.enc_subkey().to_bytes().to_vec())
     }
 }
 
@@ -324,7 +314,7 @@ impl CommandOutcome {
         Self { inner }
     }
 
-    fn contact(&self) -> Option<&facade::ImportedContact> {
+    fn contact(&self) -> Option<&Contact> {
         match &self.inner {
             facade::CommandOutcome::ContactImported(contact) => Some(contact),
             _ => None,

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -264,7 +264,8 @@ impl From<facade::OpPhase> for OpPhase {
 // `bigint`, absent projections as `undefined`.
 // ---------------------------------------------------------------------------
 
-/// What a command handed back across the worker boundary.
+/// The result of one `Engine::command` call. Read `kind`, then the matching
+/// payload getter.
 #[wasm_bindgen]
 pub struct CommandOutcome {
     inner: facade::CommandOutcome,

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -263,6 +263,75 @@ impl From<facade::OpPhase> for OpPhase {
 // `bigint`, absent projections as `undefined`.
 // ---------------------------------------------------------------------------
 
+/// Which arm a command took. The payload getters on [`CommandOutcome`] are
+/// `undefined` for every kind that does not carry them.
+#[wasm_bindgen]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandOutcomeKind {
+    /// Completed, nothing to carry back.
+    Done,
+    /// An intent op reached the durable queue.
+    Queued,
+    /// A contact code was verified.
+    ContactImported,
+}
+
+/// What a command handed back across the worker boundary.
+#[wasm_bindgen]
+pub struct CommandOutcome {
+    inner: facade::CommandOutcome,
+}
+
+#[wasm_bindgen]
+impl CommandOutcome {
+    /// Which arm ran, and therefore which payload getters are populated.
+    #[wasm_bindgen(getter)]
+    pub fn kind(&self) -> CommandOutcomeKind {
+        match self.inner {
+            facade::CommandOutcome::Done => CommandOutcomeKind::Done,
+            facade::CommandOutcome::Queued { .. } => CommandOutcomeKind::Queued,
+            facade::CommandOutcome::ContactImported(_) => CommandOutcomeKind::ContactImported,
+        }
+    }
+
+    /// The staged op's durable queue id. Crosses as the same `bigint` an
+    /// `opProgress`/`deadLetter` event carries, so the two compare equal and
+    /// an id past 2^53 survives.
+    #[wasm_bindgen(getter, js_name = opId)]
+    pub fn op_id(&self) -> Option<u64> {
+        self.inner.op_id().map(|op_id| op_id.0)
+    }
+
+    /// The imported contact's compressed SEC1 identity public key — what a
+    /// grant command names as its recipient.
+    #[wasm_bindgen(getter, js_name = identityPublicKey)]
+    pub fn identity_public_key(&self) -> Option<Vec<u8>> {
+        self.contact()
+            .map(|contact| contact.identity_public_key.clone())
+    }
+
+    /// The imported contact's X25519 encryption subkey, as the verified
+    /// binding signature tied it to the identity key.
+    #[wasm_bindgen(getter, js_name = encPublicKey)]
+    pub fn enc_public_key(&self) -> Option<Vec<u8>> {
+        self.contact().map(|contact| contact.enc_public_key.clone())
+    }
+}
+
+impl CommandOutcome {
+    /// Wraps an engine command outcome. Never exported to JS.
+    pub fn from_facade(inner: facade::CommandOutcome) -> Self {
+        Self { inner }
+    }
+
+    fn contact(&self) -> Option<&facade::ImportedContact> {
+        match &self.inner {
+            facade::CommandOutcome::ContactImported(contact) => Some(contact),
+            _ => None,
+        }
+    }
+}
+
 /// One ancestor step in a [`SnapshotView`]'s breadcrumb trail.
 #[wasm_bindgen]
 pub struct Breadcrumb {


### PR DESCRIPTION
## What this changes

`Engine::command` returned `Result<Option<OpId>, EngineError>`, a shape that can
only answer for the metadata intent ops. Every grant, share, and rotation arm
produces something a host must receive — a verified contact, an invite fragment,
a rotation's outcome — and `Option<OpId>` carries none of it.

The return type is now `CommandOutcome`:

- `Done` — completed, nothing to carry back
- `Queued { op_id }` — an intent op reached the durable queue
- `ContactImported(Contact)` — a verified contact code

`CommandOutcome::op_id()` keeps the correlation an `opProgress`/`deadLetter`
event needs. This is the shape change the issue asked to land early rather than
last, so the siblings that touch `facade.rs`, `wasm/src/host.rs` and
`fuse/src/ops.rs` rebase through it once, at the front of the wave.

`Command::ImportContact` is wired onto `grants::import_contact`. The binding
signature verify is mandatory and fail-closed, and the arm answers with the
`Contact` itself — a type with no public constructor, so holding one is the
proof its binding verified. Every downstream grant consumer is already typed on
`Contact`; flattening it to raw key bytes at the facade would have thrown that
away.

Refusals stay on the right side of the trust line. `crates/core` keeps the
`trust` and `malformed` codec classes disjoint precisely because contact import
is the union case, so a bad binding is a `TrustViolation` and an undecodable
bundle is the new `EngineError::MalformedInput { check }` — a host told a
garbled scan came from a forger would accuse the wrong party. `contact_code` is
also capped at `MAX_CONTACT_CODE_BYTES` before it reaches the decoder: a real
bundle is three fixed-width keys, the bytes arrive as an unbounded paste or
camera scan, and the decode runs inside the engine's single-writer lock.

At the WASM boundary the outcome crosses as a `CommandOutcome` class with a
`kind` discriminant — a stable camelCase string, matching `Event::kind` on the
same boundary — and per-kind payload getters. The op id still crosses as a
`bigint`, so it still compares equal to the id an event carries.

## What is NOT wired, and why

The other six arms in the issue's table stay `EngineError::Unimplemented`, and
the facade suite asserts that explicitly alongside `manualRefresh` and `logout`.
Each is blocked on a dependency that is not landed, not on facade plumbing:

- **`RotateNow` / `Revoke` / `Downgrade`** need an `OwnerScopeKeys`
  implementation over the session identity. Its `writer_pseudonym` edge takes
  *pairwise material*, and no production code anywhere derives the owner's half
  of it — every `owner_pseudonym_pk` producer in the tree is a test fixture or a
  caller-supplied signer. Choosing that binding is a KDF-catalog decision, not
  facade wiring, and must not be guessed at inside this PR.
  `rotate_scope` additionally wants a sweep task, and `SweepResolver` still has
  no production implementation.
- **`Grant`** needs `create_read_grant`, which takes a `SweepResolver`
  (unimplemented in production) plus the recipient's encryption subkey. The
  command names only `recipient_identity_public_key`, so the engine needs a
  contact book it does not have.
- **`CreateInviteLink`** can mint a row, but `RecordedInvite` is the owner's
  own authority over the link and there is no seam that persists it — a minted
  link would be unclaimable. The claim-to-grant conversion is also not landed,
  as the issue notes.
- **`AcceptShare`** needs a `ReceivedShareStore`, which is a grants-layer seam
  deliberately outside the nine host seams. Adding a tenth host seam changes
  `SeamSet` and therefore every host.

Each is a real blocker with a checkable condition, so they are reported rather
than faked behind a different typed error.

## Files touched

- `crates/engine/src/facade.rs` — `CommandOutcome`, `MalformedInput`,
  `MAX_CONTACT_CODE_BYTES`, the `ImportContact` arm, the return-type change
- `crates/engine/src/lib.rs` — additive re-exports
- `crates/wasm/src/lib.rs` — the boundary `CommandOutcome`
- `crates/wasm/src/host.rs` — `command()` resolves the outcome; the new error code
- `crates/wasm/Cargo.toml` — core as a wasm-target dev-dependency, so the
  boundary test can sign a real contact code; it never enters the cdylib
- `crates/engine/tests/facade.rs` — contact-import coverage, still-unimplemented list
- `crates/engine/tests/write_plane.rs` — mechanical `.op_id()` at the sites that
  read a queue id; no restructuring
- `crates/fuse/src/error.rs` — one match arm. That `From<EngineError>` impl is
  deliberately exhaustive with no wildcard, so a new variant is a compile error
  there by design rather than a silent degrade.

`crates/fuse/src/ops.rs` needed no change: its `command` helper already discards
the value, so the signature change passes through it. `packages/client` needed
none either — `engineHost.command` returns `Promise<void>` and discards, which
also means the imported contact is not yet readable from TS.

## Gates

| Gate | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace` | 0 |
| `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown --all-targets` | 0 |

Does **not** close #1016. This PR lands the command-outcome shape change and the `ImportContact` arm.
The six remaining arms are blocked on five missing production implementations, now filed as #1163,
#1164, #1165, #1166 and the already-open #1025, all wired as `blocked_by` edges on #1016. #1016 closes
when those arms are wired, not when this merges.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return a typed `CommandOutcome` from the engine facade command surface
> - Replaces `Result<Option<OpId>, EngineError>` with `Result<CommandOutcome, EngineError>` in `Engine::command`, adding variants `Done`, `Queued { op_id }`, and `ContactImported(Contact)`.
> - Implements `Command::ImportContact` in the engine, enforcing a 1024-byte cap (`MAX_CONTACT_CODE_BYTES`) and mapping codec errors to new `EngineError::MalformedInput` or `EngineError::TrustViolation`.
> - Exposes a JS `CommandOutcome` wrapper via WASM with a `kind` discriminant and field getters for `op_id`, `identity_public_key`, and `enc_public_key`; also adds a `malformedInput` error code to the WASM error surface.
> - The FUSE layer maps `EngineError::MalformedInput` to `VfsError::Invalid` instead of falling through to internal.
> - Behavioral Change: callers of `Engine::command` (including WASM hosts) must handle the new structured outcome type rather than a bare `Option<OpId>`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e1696e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commands now provide clear outcomes, including completion status, queued operation IDs, and imported contact details.
  * Added WebAssembly support for inspecting command outcome types, operation IDs, and imported contact keys.
  * Contact imports now enforce a maximum code size of 1,024 bytes.

* **Bug Fixes**
  * Improved handling and reporting of malformed or invalid contact codes.
  * Invalid input is now consistently surfaced as an invalid request across supported interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->