### PR TITLE
feat: implement the fuse content write path over sealed spill files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,7 @@ version = "0.0.0"
 dependencies = [
  "cipherbox-core",
  "cipherbox-engine",
+ "tempfile",
  "zeroize",
 ]
 

--- a/blueprint/desktop.md
+++ b/blueprint/desktop.md
@@ -66,8 +66,9 @@ headless e2e seam.
 - **`crates/fuse`** — the FS core and its host adapters: the inode/handle
   model, the vfs-operation surface, read/write paths over the facade, and one
   adapter per mount technology (FUSE-T SMB, Linux FUSE, WinFsp; FSKit
-  successor). Depends on the engine facade only — no direct core, transport,
-  or API access.
+  successor). Depends on the engine facade only — no transport or API access,
+  and the one direct use of `crates/core` is the AEAD the spill file seals
+  under, since the FS core never implements crypto of its own.
 
 ## Engine wiring
 

--- a/crates/desktop-seams/src/lib.rs
+++ b/crates/desktop-seams/src/lib.rs
@@ -46,7 +46,7 @@ mod staging_store;
 pub use credential_store::KeyringCredentialStore;
 pub use floor_store::FileFloorStore;
 pub use http::ReqwestHttp;
-pub use paths::account_data_dir;
+pub use paths::{account_data_dir, spill_dir};
 pub use record_transport::ReqwestRecordTransport;
 pub use scheduler::TokioScheduler;
 pub use snapshot_cache::FileSnapshotCache;

--- a/crates/desktop-seams/src/paths.rs
+++ b/crates/desktop-seams/src/paths.rs
@@ -29,9 +29,8 @@ pub fn account_data_dir(data_local_dir: &Path, account_id: &str) -> SeamResult<P
 /// handle's sealed spill file lives (blueprint/desktop.md "Reads, writes, and
 /// the never-block law").
 ///
-/// Ciphertext under a key that never leaves memory, so nothing here survives a
-/// crash as anything readable — but it is still engine-private state, not a
-/// temp dir the rest of the machine writes to.
+/// Engine-private state under the account root, not a shared temp dir — the
+/// mount owns everything in it and sweeps the whole directory on open.
 pub fn spill_dir(account_data_dir: &Path) -> PathBuf {
     account_data_dir.join("spill")
 }

--- a/crates/desktop-seams/src/paths.rs
+++ b/crates/desktop-seams/src/paths.rs
@@ -25,6 +25,17 @@ pub fn account_data_dir(data_local_dir: &Path, account_id: &str) -> SeamResult<P
     Ok(data_local_dir.join("cipherbox").join(account_id))
 }
 
+/// The mount's spill area inside an account's data dir: where a writable file
+/// handle's sealed spill file lives (blueprint/desktop.md "Reads, writes, and
+/// the never-block law").
+///
+/// Ciphertext under a key that never leaves memory, so nothing here survives a
+/// crash as anything readable — but it is still engine-private state, not a
+/// temp dir the rest of the machine writes to.
+pub fn spill_dir(account_data_dir: &Path) -> PathBuf {
+    account_data_dir.join("spill")
+}
+
 /// True only when `account_id` is exactly one `Normal` path component with no
 /// embedded separator on any platform — so `..`, `.`, `/tmp`, `a/b`, `C:\tmp`,
 /// and the empty string are all rejected.
@@ -47,6 +58,15 @@ mod tests {
     fn composes_the_cipherbox_account_root() {
         let dir = account_data_dir(Path::new("/var/lib"), "acct-42").unwrap();
         assert_eq!(dir, PathBuf::from("/var/lib/cipherbox/acct-42"));
+    }
+
+    #[test]
+    fn the_spill_area_sits_inside_the_account_root() {
+        let dir = account_data_dir(Path::new("/var/lib"), "acct-42").unwrap();
+        assert_eq!(
+            spill_dir(&dir),
+            PathBuf::from("/var/lib/cipherbox/acct-42/spill")
+        );
     }
 
     #[test]

--- a/crates/fuse/Cargo.toml
+++ b/crates/fuse/Cargo.toml
@@ -8,8 +8,7 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
-# The spill file seals its blocks with core's AEAD — the projection implements
-# no crypto of its own.
+# The spill file seals its blocks with core's AEAD.
 cipherbox-core.workspace = true
 cipherbox-engine.workspace = true
 zeroize.workspace = true

--- a/crates/fuse/Cargo.toml
+++ b/crates/fuse/Cargo.toml
@@ -8,6 +8,9 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
+# The spill file seals its blocks with core's AEAD — the projection implements
+# no crypto of its own.
+cipherbox-core.workspace = true
 cipherbox-engine.workspace = true
 zeroize.workspace = true
 
@@ -15,6 +18,5 @@ zeroize.workspace = true
 # The vfs suite drives a real engine over the in-memory seam fakes and the
 # virtual clock — no kernel, no network, no wall clock.
 cipherbox-engine = { workspace = true, features = ["test-kit"] }
-# The read suite publishes a real account fixture, which is authored with the
-# same primitives a client uses.
-cipherbox-core.workspace = true
+# Spill files are real files; the suite gives each mount a throwaway dir.
+tempfile = "3"

--- a/crates/fuse/src/cache.rs
+++ b/crates/fuse/src/cache.rs
@@ -22,9 +22,11 @@ type BlockKey = (StreamHandle, u64);
 /// How much plaintext one mount may hold, and at what granularity.
 ///
 /// `block_bytes` is chosen to match the content plane's chunk framing so a
-/// cache block maps onto one sealed chunk. Only performance rests on it: a
-/// smaller block would make every miss fetch a whole leaf and keep a fraction
-/// of it, but the engine clamps every window to the pinned version either way.
+/// cache block maps onto one sealed chunk. It is the mount's one framing width:
+/// a spill file's slot stride is the same number, so a written block and a read
+/// block are the same unit. Only performance rests on the choice — a smaller
+/// block would make every miss fetch a whole leaf and keep a fraction of it,
+/// but the engine clamps every window to the pinned version either way.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CacheBudget {
     max_bytes: usize,

--- a/crates/fuse/src/lib.rs
+++ b/crates/fuse/src/lib.rs
@@ -21,6 +21,7 @@ mod handle;
 mod inode;
 mod name;
 mod ops;
+mod spill;
 
 pub use adapter::{CacheTtls, HostAdapter, HostCapabilities, Invalidation};
 pub use cache::CacheBudget;
@@ -29,3 +30,4 @@ pub use handle::{Access, HandleId, HandleTable, OpenFile};
 pub use inode::{InodeTable, ROOT_INO};
 pub use name::{MAX_NAME_BYTES, NameError, is_emittable, is_platform_junk, validate_name};
 pub use ops::{Attributes, DirEntry, OperationCore};
+pub use spill::SpillArea;

--- a/crates/fuse/src/ops.rs
+++ b/crates/fuse/src/ops.rs
@@ -12,7 +12,8 @@ use std::collections::{BTreeSet, HashMap};
 
 use cipherbox_engine::seams::SeamTypes;
 use cipherbox_engine::{
-    Command, Engine, EngineView, NodeAttrs, NodeId, NodeKind, StatFs, StreamHandle,
+    Command, Engine, EngineView, NodeAttrs, NodeId, NodeKind, StatFs, StreamHandle, WriteHandle,
+    WriteTarget,
 };
 
 use zeroize::Zeroizing;
@@ -23,6 +24,7 @@ use crate::error::VfsError;
 use crate::handle::{Access, HandleId, HandleTable, OpenFile};
 use crate::inode::{InodeTable, ROOT_INO};
 use crate::name::{is_emittable, is_platform_junk, validate_name};
+use crate::spill::{SpillArea, SpillFile};
 
 /// A node as the kernel sees it.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -52,6 +54,40 @@ pub struct DirEntry {
     pub kind: NodeKind,
 }
 
+/// What the base version still contributes to the file a handle's writes are
+/// building.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Base {
+    /// The file starts empty for this handle — created by this mount, or
+    /// truncated to nothing — so no byte of it is ever fetched.
+    Empty,
+    /// Bytes the spill does not hold come from the node's head version.
+    Version,
+}
+
+/// One writable handle's uncommitted content: the sealed spill its writes
+/// landed in, and the file they leave behind.
+struct Pending {
+    /// Minted on the first write — a handle that only creates or truncates
+    /// spills no bytes and pays for no file.
+    spill: Option<SpillFile>,
+    /// Plaintext length of the version release will journal.
+    len: u64,
+    base: Base,
+    /// Whether an `updateContent` op is still owed for what the spill holds.
+    dirty: bool,
+}
+
+impl Pending {
+    /// The block the spill holds at `index`, if any.
+    fn block(&mut self, index: u64) -> Result<Option<Zeroizing<Vec<u8>>>, VfsError> {
+        match &mut self.spill {
+            Some(spill) => spill.block(index),
+            None => Ok(None),
+        }
+    }
+}
+
 /// The operation core for one mount session: the engine it projects, the host
 /// adapter it pushes invalidation to, and the session's inode and handle maps.
 pub struct OperationCore<T: SeamTypes, A: HostAdapter> {
@@ -60,6 +96,11 @@ pub struct OperationCore<T: SeamTypes, A: HostAdapter> {
     inodes: InodeTable,
     handles: HandleTable,
     cache: ChunkCache,
+    spill: SpillArea,
+    /// Per writable handle, the writes it has taken but not yet journaled.
+    /// Kept beside the handle table rather than in it so an open handle stays
+    /// the copyable identity record it is.
+    pending: HashMap<HandleId, Pending>,
     /// Per node, the `contentCid` of the newest version this mount has bound a
     /// read stream to. The kernel's page cache for that node's inode can only
     /// hold bytes this mount served, so a bind at a different version is
@@ -69,14 +110,17 @@ pub struct OperationCore<T: SeamTypes, A: HostAdapter> {
 
 impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
     /// Mount `engine` behind `adapter`, holding at most `cache`'s worth of
-    /// plaintext. The engine must already be started.
-    pub fn new(engine: Engine<T>, adapter: A, cache: CacheBudget) -> Self {
+    /// plaintext and spilling writes into `spill`. The engine must already be
+    /// started.
+    pub fn new(engine: Engine<T>, adapter: A, cache: CacheBudget, spill: SpillArea) -> Self {
         Self {
             engine,
             adapter,
             inodes: InodeTable::new(),
             handles: HandleTable::new(),
             cache: ChunkCache::new(cache),
+            spill,
+            pending: HashMap::new(),
             streamed: HashMap::new(),
         }
     }
@@ -152,6 +196,19 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
     ) -> Result<(Attributes, HandleId), VfsError> {
         let attrs = self.make(parent, name, NodeKind::File).await?;
         let handle = self.handles.open(attrs.node, access);
+        // The node was empty a moment ago and nothing else can have published
+        // content for it, so this handle's writes never fetch a base version.
+        if access.writable() {
+            self.pending.insert(
+                handle,
+                Pending {
+                    spill: None,
+                    len: 0,
+                    base: Base::Empty,
+                    dirty: false,
+                },
+            );
+        }
         Ok((attrs, handle))
     }
 
@@ -251,6 +308,15 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
         offset: u64,
         size: u32,
     ) -> Result<Vec<u8>, VfsError> {
+        let open = self.handles.get(handle).ok_or(VfsError::BadHandle)?;
+        if !matches!(open.access, Access::Read | Access::ReadWrite) {
+            return Err(VfsError::BadHandle);
+        }
+        // A handle holding writes reads what it wrote, not what the network
+        // still serves — the op carrying those bytes may not even be journaled.
+        if self.pending.contains_key(&handle) {
+            return self.read_pending(handle, offset, size).await;
+        }
         let stream = self.stream_for(handle).await?;
         let block_bytes = self.cache.block_bytes();
         let end = offset.saturating_add(u64::from(size));
@@ -290,34 +356,346 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
         Ok(core::mem::take(&mut *out))
     }
 
-    /// Close a file handle, releasing the stream it pinned and the plaintext
-    /// that stream cached.
-    pub fn release(&mut self, handle: HandleId) -> Result<(), VfsError> {
+    /// Land `data` at `offset` in the handle's sealed spill file, reporting how
+    /// many bytes it took.
+    ///
+    /// Nothing crosses the facade here: the bytes sit under a per-handle key
+    /// this process holds only in memory until [`flush`](Self::flush) or
+    /// [`release`](Self::release) turns them into one `updateContent` op
+    /// (blueprint/desktop.md "Reads, writes, and the never-block law").
+    pub async fn write(
+        &mut self,
+        handle: HandleId,
+        offset: u64,
+        data: &[u8],
+    ) -> Result<u32, VfsError> {
+        let open = self.handles.get(handle).ok_or(VfsError::BadHandle)?;
+        if !open.access.writable() {
+            return Err(VfsError::BadHandle);
+        }
+        let took = u32::try_from(data.len()).map_err(|_| VfsError::Invalid)?;
+        let end = offset
+            .checked_add(data.len() as u64)
+            .ok_or(VfsError::Invalid)?;
+        self.begin_pending(handle, open.node).await?;
+
+        let block_bytes = self.cache.block_bytes();
+        let mut cursor = offset;
+        let mut rest = data;
+        while !rest.is_empty() {
+            let index = cursor / block_bytes;
+            let within = (cursor - index * block_bytes) as usize;
+            let take = (block_bytes as usize - within).min(rest.len());
+            // A block the write replaces whole owes the base version nothing,
+            // so a full overwrite never fetches the file it is replacing.
+            let mut block = if within == 0 && take as u64 == block_bytes {
+                Zeroizing::new(vec![0u8; block_bytes as usize])
+            } else {
+                self.version_block(handle, index).await?
+            };
+            block[within..within + take].copy_from_slice(&rest[..take]);
+            self.spill_mut(handle)?.put(index, &block)?;
+            cursor += take as u64;
+            rest = &rest[take..];
+        }
+
+        let pending = self.pending.get_mut(&handle).ok_or(VfsError::BadHandle)?;
+        pending.len = pending.len.max(end);
+        pending.dirty = true;
+        Ok(took)
+    }
+
+    /// Set a file's length.
+    ///
+    /// On an open writable handle this is a spill-file operation: the new
+    /// length rides into the one `updateContent` op that handle's release
+    /// journals. With no handle it becomes its own op, so a bare `truncate(2)`
+    /// is never silently lost. An `O_TRUNC` open is the first form — the
+    /// adapter opens the handle, then truncates it to zero.
+    pub async fn truncate(
+        &mut self,
+        ino: u64,
+        size: u64,
+        handle: Option<HandleId>,
+    ) -> Result<(), VfsError> {
+        let view = self.render().await?;
+        let node = self.node_of(ino)?;
+        if view.attrs(node).ok_or(VfsError::NotFound)?.kind != NodeKind::File {
+            return Err(VfsError::IsADirectory);
+        }
+        let Some(handle) = handle else {
+            let handle = self.handles.open(node, Access::Write);
+            let truncated = self.truncate_handle(handle, size).await;
+            let released = self.release(handle).await;
+            return truncated.and(released);
+        };
+        if self.handle(handle)?.node != node {
+            return Err(VfsError::BadHandle);
+        }
+        self.truncate_handle(handle, size).await
+    }
+
+    /// Journal what a handle has written as one `updateContent` op.
+    ///
+    /// The kernel is acked only once that op is durable in the staging store,
+    /// so a failing queue refuses the write instead of losing it — the v1 INV-1
+    /// no-false-ack discipline (blueprint/desktop.md "release"). `close(2)`
+    /// returns what this returns.
+    pub async fn flush(&mut self, handle: HandleId) -> Result<(), VfsError> {
+        self.commit(handle).await
+    }
+
+    /// `fsync` means what [`flush`](Self::flush) means here: one op carries the
+    /// whole file, and the durable op queue is the mount's only durability
+    /// layer.
+    pub async fn fsync(&mut self, handle: HandleId) -> Result<(), VfsError> {
+        self.commit(handle).await
+    }
+
+    /// Close a file handle: journal anything it still owes, then release the
+    /// stream it pinned, the plaintext that stream cached, and its spill.
+    pub async fn release(&mut self, handle: HandleId) -> Result<(), VfsError> {
+        let committed = self.commit(handle).await;
         let open = self.handles.close(handle).ok_or(VfsError::BadHandle)?;
+        // Dropping the spill removes its file, and the key that could open it
+        // zeroizes with the handle.
+        self.pending.remove(&handle);
         self.release_stream(open);
-        Ok(())
+        committed
     }
 
     /// Tear the mount down: every pinned stream released and every cached
-    /// plaintext block zeroized.
+    /// plaintext block zeroized. Writes a handle never flushed die with their
+    /// spill — unopenable ciphertext and no half-formed op.
     pub fn unmount(&mut self) {
         for open in self.handles.drain() {
             self.release_stream(open);
         }
+        self.pending.clear();
         self.cache.clear();
         self.streamed.clear();
     }
 
+    /// Give `handle` a write state if it has none, sized to the file it is
+    /// about to modify.
+    async fn begin_pending(&mut self, handle: HandleId, node: NodeId) -> Result<(), VfsError> {
+        if self.pending.contains_key(&handle) {
+            return Ok(());
+        }
+        let len = self.base_len(handle, node).await?;
+        self.pending.insert(
+            handle,
+            Pending {
+                spill: None,
+                len,
+                base: Base::Version,
+                dirty: false,
+            },
+        );
+        Ok(())
+    }
+
+    /// The plaintext length of the version a handle's writes start from.
+    ///
+    /// An unprojected size is unknown, never zero: resolving the head is what
+    /// projects it, and reading it as zero would drop the file's untouched tail
+    /// on the first partial write.
+    async fn base_len(&mut self, handle: HandleId, node: NodeId) -> Result<u64, VfsError> {
+        if let Some(size) = self.render().await?.attrs(node).and_then(|meta| meta.size) {
+            return Ok(size);
+        }
+        self.stream_for(handle).await?;
+        self.render()
+            .await?
+            .attrs(node)
+            .and_then(|meta| meta.size)
+            .ok_or_else(|| VfsError::Unavailable {
+                message: "content size is not projected".to_owned(),
+            })
+    }
+
+    async fn truncate_handle(&mut self, handle: HandleId, size: u64) -> Result<(), VfsError> {
+        let open = self.handles.get(handle).ok_or(VfsError::BadHandle)?;
+        if !open.access.writable() {
+            return Err(VfsError::BadHandle);
+        }
+        if !self.pending.contains_key(&handle) {
+            // Truncating everything away resolves nothing: no byte of the
+            // version being replaced can survive it.
+            let pending = if size == 0 {
+                Pending {
+                    spill: None,
+                    len: 0,
+                    base: Base::Empty,
+                    dirty: false,
+                }
+            } else {
+                Pending {
+                    spill: None,
+                    len: self.base_len(handle, open.node).await?,
+                    base: Base::Version,
+                    dirty: false,
+                }
+            };
+            self.pending.insert(handle, pending);
+        }
+        let pending = self.pending.get_mut(&handle).ok_or(VfsError::BadHandle)?;
+        if let Some(spill) = pending.spill.as_mut() {
+            spill.truncate(size)?;
+        }
+        pending.len = size;
+        if size == 0 {
+            pending.base = Base::Empty;
+        }
+        pending.dirty = true;
+        Ok(())
+    }
+
+    /// Turn what a handle holds into exactly one `updateContent` op. A handle
+    /// that owes nothing journals nothing.
+    async fn commit(&mut self, handle: HandleId) -> Result<(), VfsError> {
+        let open = self.handles.get(handle).ok_or(VfsError::BadHandle)?;
+        let Some(pending) = self.pending.get(&handle) else {
+            return Ok(());
+        };
+        if !pending.dirty {
+            return Ok(());
+        }
+        let len = pending.len;
+        let write = self
+            .engine
+            .begin_write(WriteTarget::Version { node: open.node }, len)
+            .await?;
+        if let Err(error) = self.push_version(handle, write, len).await {
+            self.engine.abort_write(write).await;
+            return Err(error);
+        }
+        self.engine.commit_write(write).await?;
+        if let Some(pending) = self.pending.get_mut(&handle) {
+            pending.dirty = false;
+        }
+        let ino = self.inodes.ino_for(open.node);
+        self.adapter.invalidate(Invalidation::Attributes { ino });
+        Ok(())
+    }
+
+    /// Feed the whole version through the open write handle, one block at a
+    /// time, so peak plaintext is one block however large the file.
+    async fn push_version(
+        &mut self,
+        handle: HandleId,
+        write: WriteHandle,
+        len: u64,
+    ) -> Result<(), VfsError> {
+        let block_bytes = self.cache.block_bytes();
+        let mut offset = 0;
+        while offset < len {
+            let index = offset / block_bytes;
+            let take = block_bytes.min(len - offset) as usize;
+            let block = self.version_block(handle, index).await?;
+            self.engine.push_chunk(write, &block[..take]).await?;
+            offset += take as u64;
+        }
+        Ok(())
+    }
+
+    /// Read a range of the file a handle's writes are building.
+    async fn read_pending(
+        &mut self,
+        handle: HandleId,
+        offset: u64,
+        size: u32,
+    ) -> Result<Vec<u8>, VfsError> {
+        let len = self.pending.get(&handle).ok_or(VfsError::BadHandle)?.len;
+        let block_bytes = self.cache.block_bytes();
+        let end = offset.saturating_add(u64::from(size)).min(len);
+        let mut out = Zeroizing::new(Vec::new());
+        let mut cursor = offset;
+        while cursor < end {
+            let index = cursor / block_bytes;
+            let within = (cursor - index * block_bytes) as usize;
+            let take = (block_bytes - within as u64).min(end - cursor) as usize;
+            let block = self.version_block(handle, index).await?;
+            grow_wiping(&mut out, take);
+            out.extend_from_slice(&block[within..within + take]);
+            cursor += take as u64;
+        }
+        Ok(core::mem::take(&mut *out))
+    }
+
+    /// Block `index` of the version a handle's writes are building: its spill
+    /// block if it took one, else the base version's bytes, else the zeros a
+    /// hole reads as. Always a whole block wide.
+    async fn version_block(
+        &mut self,
+        handle: HandleId,
+        index: u64,
+    ) -> Result<Zeroizing<Vec<u8>>, VfsError> {
+        let held = self
+            .pending
+            .get_mut(&handle)
+            .ok_or(VfsError::BadHandle)?
+            .block(index)?;
+        if let Some(block) = held {
+            return Ok(block);
+        }
+        let block_bytes = self.cache.block_bytes();
+        let mut out = Zeroizing::new(vec![0u8; block_bytes as usize]);
+        if self.pending.get(&handle).ok_or(VfsError::BadHandle)?.base == Base::Empty {
+            return Ok(out);
+        }
+        let at = index.checked_mul(block_bytes).ok_or(VfsError::Invalid)?;
+        let stream = self.stream_for(handle).await?;
+        let base = Zeroizing::new(self.engine.read_stream(stream, at, block_bytes).await?);
+        let take = base.len().min(out.len());
+        out[..take].copy_from_slice(&base[..take]);
+        Ok(out)
+    }
+
+    /// The handle's spill file, minted on first use.
+    fn spill_mut(&mut self, handle: HandleId) -> Result<&mut SpillFile, VfsError> {
+        let block_bytes = self.cache.block_bytes();
+        let empty = match self.pending.get(&handle) {
+            Some(pending) => pending.spill.is_none(),
+            None => return Err(VfsError::BadHandle),
+        };
+        if empty {
+            let spill = self.spill.create(block_bytes)?;
+            self.pending
+                .get_mut(&handle)
+                .ok_or(VfsError::BadHandle)?
+                .spill = Some(spill);
+        }
+        self.pending
+            .get_mut(&handle)
+            .and_then(|pending| pending.spill.as_mut())
+            .ok_or(VfsError::BadHandle)
+    }
+
+    /// The length a handle with unjournaled writes will publish for `node` —
+    /// the file's real length until its op reaches the queue.
+    fn pending_len(&self, node: NodeId) -> Option<u64> {
+        self.pending
+            .iter()
+            .filter(|(handle, pending)| {
+                pending.dirty
+                    && self
+                        .handles
+                        .get(**handle)
+                        .is_some_and(|open| open.node == node)
+            })
+            .map(|(_, pending)| pending.len)
+            .max()
+    }
+
     /// The read stream pinning `handle`'s content version, opened on first use:
-    /// a handle opened to write, or on a file whose bytes are never read, pays
-    /// neither the resolve nor a slot against the engine's stream ceiling.
+    /// a handle on a file whose bytes are never read, and one whose writes
+    /// replace every block, pays neither the resolve nor a slot against the
+    /// engine's stream ceiling.
     async fn stream_for(&mut self, handle: HandleId) -> Result<StreamHandle, VfsError> {
         let open = self.handles.get(handle).ok_or(VfsError::BadHandle)?;
         if let Some(stream) = open.stream {
             return Ok(stream);
-        }
-        if !matches!(open.access, Access::Read | Access::ReadWrite) {
-            return Err(VfsError::BadHandle);
         }
         let stream = self.engine.open_content_stream(open.node).await?;
         if !self.handles.attach_stream(handle, stream) {
@@ -394,11 +772,12 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
     }
 
     fn attributes(&mut self, meta: &NodeAttrs) -> Attributes {
+        let size = self.pending_len(meta.id).or(meta.size);
         Attributes {
             ino: self.inodes.ino_for(meta.id),
             node: meta.id,
             kind: meta.kind,
-            size: meta.size,
+            size,
             mtime_millis: meta.mtime,
         }
     }

--- a/crates/fuse/src/ops.rs
+++ b/crates/fuse/src/ops.rs
@@ -537,6 +537,10 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
             pending.dirty = false;
         }
         let ino = self.inodes.ino_for(open.node);
+        // Nothing re-binds this inode, so the pages this commit replaced would
+        // stay live. Data before attributes: a kernel that learns the new size
+        // first serves those pages as the new version.
+        self.adapter.invalidate(Invalidation::Data { ino });
         self.adapter.invalidate(Invalidation::Attributes { ino });
         Ok(())
     }
@@ -641,9 +645,11 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
     }
 
     /// The read stream pinning `handle`'s content version, opened on first use:
-    /// a handle on a file whose bytes are never read, and one whose writes
-    /// replace every block, pays neither the resolve nor a slot against the
-    /// engine's stream ceiling.
+    /// a handle on a file whose bytes are never read pays neither the resolve
+    /// nor a slot against the engine's stream ceiling. A writer earns that only
+    /// over an already-projected size whose blocks its writes replace whole — an
+    /// unprojected size resolves regardless, because only the resolve yields the
+    /// base length.
     async fn stream_for(&mut self, handle: HandleId) -> Result<StreamHandle, VfsError> {
         let open = self.handles.get(handle).ok_or(VfsError::BadHandle)?;
         if let Some(stream) = open.stream {

--- a/crates/fuse/src/ops.rs
+++ b/crates/fuse/src/ops.rs
@@ -54,17 +54,6 @@ pub struct DirEntry {
     pub kind: NodeKind,
 }
 
-/// What the base version still contributes to the file a handle's writes are
-/// building.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Base {
-    /// The file starts empty for this handle — created by this mount, or
-    /// truncated to nothing — so no byte of it is ever fetched.
-    Empty,
-    /// Bytes the spill does not hold come from the node's head version.
-    Version,
-}
-
 /// One writable handle's uncommitted content: the sealed spill its writes
 /// landed in, and the file they leave behind.
 struct Pending {
@@ -73,17 +62,23 @@ struct Pending {
     spill: Option<SpillFile>,
     /// Plaintext length of the version release will journal.
     len: u64,
-    base: Base,
+    /// How far into the file the base version may still contribute bytes.
+    /// Clamped by every truncate: bytes a shrink removed must read as the zeros
+    /// of a hole if the file grows again, never as the version's own plaintext.
+    base_len: u64,
     /// Whether an `updateContent` op is still owed for what the spill holds.
     dirty: bool,
 }
 
 impl Pending {
-    /// The block the spill holds at `index`, if any.
-    fn block(&mut self, index: u64) -> Result<Option<Zeroizing<Vec<u8>>>, VfsError> {
-        match &mut self.spill {
-            Some(spill) => spill.block(index),
-            None => Ok(None),
+    /// A handle's write state over a file of `len` bytes, all of which the base
+    /// version still holds.
+    fn over(len: u64) -> Self {
+        Self {
+            spill: None,
+            len,
+            base_len: len,
+            dirty: false,
         }
     }
 }
@@ -98,8 +93,6 @@ pub struct OperationCore<T: SeamTypes, A: HostAdapter> {
     cache: ChunkCache,
     spill: SpillArea,
     /// Per writable handle, the writes it has taken but not yet journaled.
-    /// Kept beside the handle table rather than in it so an open handle stays
-    /// the copyable identity record it is.
     pending: HashMap<HandleId, Pending>,
     /// Per node, the `contentCid` of the newest version this mount has bound a
     /// read stream to. The kernel's page cache for that node's inode can only
@@ -196,18 +189,8 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
     ) -> Result<(Attributes, HandleId), VfsError> {
         let attrs = self.make(parent, name, NodeKind::File).await?;
         let handle = self.handles.open(attrs.node, access);
-        // The node was empty a moment ago and nothing else can have published
-        // content for it, so this handle's writes never fetch a base version.
         if access.writable() {
-            self.pending.insert(
-                handle,
-                Pending {
-                    spill: None,
-                    len: 0,
-                    base: Base::Empty,
-                    dirty: false,
-                },
-            );
+            self.pending.insert(handle, Pending::over(0));
         }
         Ok((attrs, handle))
     }
@@ -374,6 +357,10 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
             return Err(VfsError::BadHandle);
         }
         let took = u32::try_from(data.len()).map_err(|_| VfsError::Invalid)?;
+        // POSIX: a zero-length write changes nothing, not even the length.
+        if data.is_empty() {
+            return Ok(0);
+        }
         let end = offset
             .checked_add(data.len() as u64)
             .ok_or(VfsError::Invalid)?;
@@ -386,15 +373,14 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
             let index = cursor / block_bytes;
             let within = (cursor - index * block_bytes) as usize;
             let take = (block_bytes as usize - within).min(rest.len());
-            // A block the write replaces whole owes the base version nothing,
-            // so a full overwrite never fetches the file it is replacing.
-            let mut block = if within == 0 && take as u64 == block_bytes {
-                Zeroizing::new(vec![0u8; block_bytes as usize])
+            // A block the write replaces whole owes the base version nothing.
+            if within == 0 && take as u64 == block_bytes {
+                self.spill_mut(handle)?.put(index, &rest[..take])?;
             } else {
-                self.version_block(handle, index).await?
-            };
-            block[within..within + take].copy_from_slice(&rest[..take]);
-            self.spill_mut(handle)?.put(index, &block)?;
+                let mut block = self.version_block(handle, index).await?;
+                block[within..within + take].copy_from_slice(&rest[..take]);
+                self.spill_mut(handle)?.put(index, &block)?;
+            }
             cursor += take as u64;
             rest = &rest[take..];
         }
@@ -409,9 +395,8 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
     ///
     /// On an open writable handle this is a spill-file operation: the new
     /// length rides into the one `updateContent` op that handle's release
-    /// journals. With no handle it becomes its own op, so a bare `truncate(2)`
-    /// is never silently lost. An `O_TRUNC` open is the first form — the
-    /// adapter opens the handle, then truncates it to zero.
+    /// journals, which is also how an adapter carries `O_TRUNC`. With no handle
+    /// it becomes its own op, so a bare `truncate(2)` is never silently lost.
     pub async fn truncate(
         &mut self,
         ino: u64,
@@ -457,8 +442,6 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
     pub async fn release(&mut self, handle: HandleId) -> Result<(), VfsError> {
         let committed = self.commit(handle).await;
         let open = self.handles.close(handle).ok_or(VfsError::BadHandle)?;
-        // Dropping the spill removes its file, and the key that could open it
-        // zeroizes with the handle.
         self.pending.remove(&handle);
         self.release_stream(open);
         committed
@@ -483,15 +466,7 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
             return Ok(());
         }
         let len = self.base_len(handle, node).await?;
-        self.pending.insert(
-            handle,
-            Pending {
-                spill: None,
-                len,
-                base: Base::Version,
-                dirty: false,
-            },
-        );
+        self.pending.insert(handle, Pending::over(len));
         Ok(())
     }
 
@@ -519,34 +494,21 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
         if !open.access.writable() {
             return Err(VfsError::BadHandle);
         }
-        if !self.pending.contains_key(&handle) {
+        if size == 0 {
             // Truncating everything away resolves nothing: no byte of the
             // version being replaced can survive it.
-            let pending = if size == 0 {
-                Pending {
-                    spill: None,
-                    len: 0,
-                    base: Base::Empty,
-                    dirty: false,
-                }
-            } else {
-                Pending {
-                    spill: None,
-                    len: self.base_len(handle, open.node).await?,
-                    base: Base::Version,
-                    dirty: false,
-                }
-            };
-            self.pending.insert(handle, pending);
+            self.pending
+                .entry(handle)
+                .or_insert_with(|| Pending::over(0));
+        } else {
+            self.begin_pending(handle, open.node).await?;
         }
         let pending = self.pending.get_mut(&handle).ok_or(VfsError::BadHandle)?;
         if let Some(spill) = pending.spill.as_mut() {
             spill.truncate(size)?;
         }
         pending.len = size;
-        if size == 0 {
-            pending.base = Base::Empty;
-        }
+        pending.base_len = pending.base_len.min(size);
         pending.dirty = true;
         Ok(())
     }
@@ -614,11 +576,9 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
         while cursor < end {
             let index = cursor / block_bytes;
             let within = (cursor - index * block_bytes) as usize;
-            let take = (block_bytes - within as u64).min(end - cursor) as usize;
+            let want = (end - cursor) as usize;
             let block = self.version_block(handle, index).await?;
-            grow_wiping(&mut out, take);
-            out.extend_from_slice(&block[within..within + take]);
-            cursor += take as u64;
+            cursor += take_from(&mut out, &block, within, want) as u64;
         }
         Ok(core::mem::take(&mut *out))
     }
@@ -631,22 +591,24 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
         handle: HandleId,
         index: u64,
     ) -> Result<Zeroizing<Vec<u8>>, VfsError> {
-        let held = self
-            .pending
-            .get_mut(&handle)
-            .ok_or(VfsError::BadHandle)?
-            .block(index)?;
-        if let Some(block) = held {
+        let block_bytes = self.cache.block_bytes();
+        let pending = self.pending.get_mut(&handle).ok_or(VfsError::BadHandle)?;
+        let base_len = pending.base_len;
+        if let Some(spill) = pending.spill.as_mut()
+            && let Some(block) = spill.block(index)?
+        {
             return Ok(block);
         }
-        let block_bytes = self.cache.block_bytes();
         let mut out = Zeroizing::new(vec![0u8; block_bytes as usize]);
-        if self.pending.get(&handle).ok_or(VfsError::BadHandle)?.base == Base::Empty {
+        let at = index.checked_mul(block_bytes).ok_or(VfsError::Invalid)?;
+        if at >= base_len {
             return Ok(out);
         }
-        let at = index.checked_mul(block_bytes).ok_or(VfsError::Invalid)?;
+        // Clamped to the floor a truncate left: past it the version's own bytes
+        // are gone, and the file reads as the hole they left.
+        let want = block_bytes.min(base_len - at);
         let stream = self.stream_for(handle).await?;
-        let base = Zeroizing::new(self.engine.read_stream(stream, at, block_bytes).await?);
+        let base = Zeroizing::new(self.engine.read_stream(stream, at, want).await?);
         let take = base.len().min(out.len());
         out[..take].copy_from_slice(&base[..take]);
         Ok(out)
@@ -655,21 +617,11 @@ impl<T: SeamTypes, A: HostAdapter> OperationCore<T, A> {
     /// The handle's spill file, minted on first use.
     fn spill_mut(&mut self, handle: HandleId) -> Result<&mut SpillFile, VfsError> {
         let block_bytes = self.cache.block_bytes();
-        let empty = match self.pending.get(&handle) {
-            Some(pending) => pending.spill.is_none(),
-            None => return Err(VfsError::BadHandle),
-        };
-        if empty {
-            let spill = self.spill.create(block_bytes)?;
-            self.pending
-                .get_mut(&handle)
-                .ok_or(VfsError::BadHandle)?
-                .spill = Some(spill);
+        let pending = self.pending.get_mut(&handle).ok_or(VfsError::BadHandle)?;
+        if pending.spill.is_none() {
+            pending.spill = Some(self.spill.create(block_bytes)?);
         }
-        self.pending
-            .get_mut(&handle)
-            .and_then(|pending| pending.spill.as_mut())
-            .ok_or(VfsError::BadHandle)
+        pending.spill.as_mut().ok_or(VfsError::BadHandle)
     }
 
     /// The length a handle with unjournaled writes will publish for `node` —

--- a/crates/fuse/src/spill.rs
+++ b/crates/fuse/src/spill.rs
@@ -249,6 +249,9 @@ fn open_private(path: &Path) -> io::Result<File> {
         .open(path)
 }
 
+/// Off unix the file inherits the parent's ACL. Confidentiality rests on the
+/// seal, not the mode: every block is ciphertext under a per-handle key that
+/// only ever exists in memory.
 #[cfg(not(unix))]
 fn open_private(path: &Path) -> io::Result<File> {
     OpenOptions::new()
@@ -264,6 +267,8 @@ fn restrict_dir(dir: &Path) -> io::Result<()> {
     fs::set_permissions(dir, fs::Permissions::from_mode(0o700))
 }
 
+/// Off unix the directory keeps the permissions it was created with; it holds
+/// nothing but sealed blocks, for the reason given on `open_private`.
 #[cfg(not(unix))]
 fn restrict_dir(_dir: &Path) -> io::Result<()> {
     Ok(())

--- a/crates/fuse/src/spill.rs
+++ b/crates/fuse/src/spill.rs
@@ -4,9 +4,9 @@
 //!
 //! The sealing key is minted per handle from injected entropy, lives only in
 //! this process's memory, and dies with the handle — a crash leaves ciphertext
-//! whose key is gone, which is what replaces v1's plaintext `cb-write-*` files.
-//! Nonces are a per-file counter: the key is fresh per handle, so a counter is
-//! unique under it by construction and needs no further entropy.
+//! whose key is gone. Nonces are a per-file counter: the key is fresh per
+//! handle, so a counter is unique under it by construction and needs no further
+//! entropy.
 
 use std::collections::BTreeSet;
 use std::fs::{self, File, OpenOptions};
@@ -28,13 +28,12 @@ const SPILL_AAD_DOMAIN: &[u8] = b"cipherbox/spill/v1";
 pub struct SpillArea {
     dir: PathBuf,
     entropy: Box<dyn Entropy>,
-    minted: u64,
 }
 
 impl SpillArea {
     /// Open the spill area at `dir`, creating it and sweeping whatever a
-    /// previous run left behind. That debris is unopenable — its key died with
-    /// that process — so it is deleted rather than overwritten.
+    /// previous run left behind. That debris is deleted rather than
+    /// overwritten.
     pub fn open(dir: PathBuf, entropy: Box<dyn Entropy>) -> io::Result<Self> {
         fs::create_dir_all(&dir)?;
         restrict_dir(&dir)?;
@@ -44,34 +43,40 @@ impl SpillArea {
                 fs::remove_file(entry.path())?;
             }
         }
-        Ok(Self {
-            dir,
-            entropy,
-            minted: 0,
-        })
+        Ok(Self { dir, entropy })
     }
 
     /// Mint a spill file under a fresh per-handle key, framed in `block_bytes`
     /// plaintext blocks.
     pub(crate) fn create(&mut self, block_bytes: u64) -> Result<SpillFile, VfsError> {
+        // A zero-wide block would divide by zero on every framing decision and
+        // let `put` accept an empty plaintext as a whole block.
+        if block_bytes == 0 {
+            return Err(VfsError::Internal {
+                message: "a spill needs a non-zero block size".to_owned(),
+            });
+        }
         let mut key = Zeroizing::new([0u8; KEY_LEN]);
-        self.entropy
-            .fill(key.as_mut_slice())
-            .map_err(|error| VfsError::Internal {
-                message: error.message().to_owned(),
-            })?;
-        self.minted += 1;
-        let path = self
-            .dir
-            .join(format!("spill.{}.{}", std::process::id(), self.minted));
+        self.fill(key.as_mut_slice())?;
+        // Named from entropy, not a counter: two areas over one dir would mint
+        // the same counter and each would then unlink the other's live spill.
+        let mut suffix = [0u8; 8];
+        self.fill(&mut suffix)?;
+        let path = self.dir.join(format!("spill.{}", hex(&suffix)));
         let file = open_private(&path).map_err(spill_io)?;
         Ok(SpillFile {
             path,
-            file,
+            file: Some(file),
             key,
             block_bytes,
             blocks: BTreeSet::new(),
             next_nonce: 0,
+        })
+    }
+
+    fn fill(&mut self, dest: &mut [u8]) -> Result<(), VfsError> {
+        self.entropy.fill(dest).map_err(|error| VfsError::Internal {
+            message: error.message().to_owned(),
         })
     }
 }
@@ -79,10 +84,12 @@ impl SpillArea {
 /// One handle's spill: a slot per plaintext block, each sealed on its own.
 pub(crate) struct SpillFile {
     path: PathBuf,
-    file: File,
+    /// Taken on drop so the handle is closed before the path is unlinked —
+    /// Windows refuses to delete a file it is still holding open.
+    file: Option<File>,
     key: Zeroizing<[u8; KEY_LEN]>,
     block_bytes: u64,
-    /// The block indices this spill actually holds. A slot outside the set is
+    /// The block indices this spill claims. A slot outside the set is
     /// uninitialized, never zero bytes: the caller falls back to the base
     /// version for it.
     blocks: BTreeSet<u64>,
@@ -97,10 +104,10 @@ impl SpillFile {
             return Ok(None);
         }
         let mut sealed = vec![0u8; self.slot_bytes()];
-        self.file
-            .seek(SeekFrom::Start(self.slot_offset(index)?))
-            .map_err(spill_io)?;
-        self.file.read_exact(&mut sealed).map_err(spill_io)?;
+        let at = self.slot_offset(index)?;
+        let file = self.file()?;
+        file.seek(SeekFrom::Start(at)).map_err(spill_io)?;
+        file.read_exact(&mut sealed).map_err(spill_io)?;
         let (nonce, ciphertext) = sealed.split_at(NONCE_LEN);
         let nonce: &[u8; NONCE_LEN] = nonce.try_into().expect("split_at NONCE_LEN");
         let plaintext = aead::decrypt(&self.key, nonce, &block_aad(index), ciphertext).ok_or(
@@ -119,14 +126,23 @@ impl SpillFile {
                 message: "a spill block must be sealed whole".to_owned(),
             });
         }
+        let at = self.slot_offset(index)?;
         let nonce = self.next_nonce()?;
-        let sealed = aead::encrypt(&self.key, &nonce, &block_aad(index), plaintext);
-        self.file
-            .seek(SeekFrom::Start(self.slot_offset(index)?))
-            .map_err(spill_io)?;
-        self.file.write_all(&nonce).map_err(spill_io)?;
-        self.file.write_all(&sealed).map_err(spill_io)?;
+        let mut slot = Vec::with_capacity(self.slot_bytes());
+        slot.extend_from_slice(&nonce);
+        slot.extend(aead::encrypt(
+            &self.key,
+            &nonce,
+            &block_aad(index),
+            plaintext,
+        ));
+        // Claimed before the bytes land: a write that dies half-way leaves a
+        // slot the AEAD rejects, so the commit fails closed rather than quietly
+        // substituting the base version for a block the caller wrote.
         self.blocks.insert(index);
+        let file = self.file()?;
+        file.seek(SeekFrom::Start(at)).map_err(spill_io)?;
+        file.write_all(&slot).map_err(spill_io)?;
         Ok(())
     }
 
@@ -134,18 +150,27 @@ impl SpillFile {
     /// tail of the block `len` falls inside is zeroed, so a later write past
     /// `len` reads holes as zeros rather than as the bytes truncate removed.
     pub(crate) fn truncate(&mut self, len: u64) -> Result<(), VfsError> {
-        let last = len / self.block_bytes;
-        self.blocks.retain(|index| *index <= last);
-        let within = (len % self.block_bytes) as usize;
+        let block_bytes = self.block_bytes;
+        self.blocks
+            .retain(|index| index.saturating_mul(block_bytes) < len);
+        let within = (len % block_bytes) as usize;
         if within == 0 {
-            self.blocks.remove(&last);
             return Ok(());
         }
+        let last = len / block_bytes;
         if let Some(mut block) = self.block(last)? {
             block[within..].fill(0);
             self.put(last, &block)?;
         }
         Ok(())
+    }
+
+    /// The open handle, or the fail-closed verdict for a spill already torn
+    /// down.
+    fn file(&mut self) -> Result<&mut File, VfsError> {
+        self.file.as_mut().ok_or(VfsError::Internal {
+            message: "the spill file is closed".to_owned(),
+        })
     }
 
     fn slot_bytes(&self) -> usize {
@@ -181,10 +206,21 @@ impl SpillFile {
 
 impl Drop for SpillFile {
     /// The spill dies with the handle. The ciphertext is not overwritten: the
-    /// key was memory-only and goes with it.
+    /// key was memory-only and goes with it. The handle is closed first —
+    /// Windows refuses to unlink a file it is still holding open.
     fn drop(&mut self) {
+        drop(self.file.take());
         let _ = fs::remove_file(&self.path);
     }
+}
+
+/// Lowercase hex, for a filename component drawn from entropy.
+fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
 }
 
 /// The AAD binding one spill block to its slot.
@@ -297,11 +333,10 @@ mod tests {
         spill.put(0, b"abcdefgh").unwrap();
         let slot = fs::read(&spill.path).unwrap();
         // Transplant slot 0's bytes into slot 1 and claim the spill holds it.
-        spill
-            .file
-            .seek(SeekFrom::Start(spill.slot_offset(1).unwrap()))
-            .unwrap();
-        spill.file.write_all(&slot).unwrap();
+        let at = spill.slot_offset(1).unwrap();
+        let file = spill.file().unwrap();
+        file.seek(SeekFrom::Start(at)).unwrap();
+        file.write_all(&slot).unwrap();
         spill.blocks.insert(1);
         assert!(
             matches!(spill.block(1), Err(VfsError::Internal { .. })),
@@ -365,6 +400,15 @@ mod tests {
         fs::write(&debris, b"unopenable ciphertext").unwrap();
         let _area = area(dir.path());
         assert!(!debris.exists());
+    }
+
+    #[test]
+    fn a_zero_block_size_spill_is_refused_at_creation() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            area(dir.path()).create(0),
+            Err(VfsError::Internal { .. })
+        ));
     }
 
     #[test]

--- a/crates/fuse/src/spill.rs
+++ b/crates/fuse/src/spill.rs
@@ -1,0 +1,389 @@
+//! Per-handle sealed spill files: where a kernel write lands before release
+//! turns it into one `updateContent` op (blueprint/desktop.md "Reads, writes,
+//! and the never-block law").
+//!
+//! The sealing key is minted per handle from injected entropy, lives only in
+//! this process's memory, and dies with the handle — a crash leaves ciphertext
+//! whose key is gone, which is what replaces v1's plaintext `cb-write-*` files.
+//! Nonces are a per-file counter: the key is fresh per handle, so a counter is
+//! unique under it by construction and needs no further entropy.
+
+use std::collections::BTreeSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use cipherbox_core::suite::aead::{self, KEY_LEN, NONCE_LEN, TAG_LEN};
+use cipherbox_engine::Entropy;
+use zeroize::Zeroizing;
+
+use crate::error::VfsError;
+
+/// AAD domain for a spill block. The block index rides in the AAD, so a slot
+/// moved to another offset in the same file no longer opens.
+const SPILL_AAD_DOMAIN: &[u8] = b"cipherbox/spill/v1";
+
+/// The engine data dir's spill area: where every handle's sealed spill file is
+/// minted, and the one place the per-handle keys come from.
+pub struct SpillArea {
+    dir: PathBuf,
+    entropy: Box<dyn Entropy>,
+    minted: u64,
+}
+
+impl SpillArea {
+    /// Open the spill area at `dir`, creating it and sweeping whatever a
+    /// previous run left behind. That debris is unopenable — its key died with
+    /// that process — so it is deleted rather than overwritten.
+    pub fn open(dir: PathBuf, entropy: Box<dyn Entropy>) -> io::Result<Self> {
+        fs::create_dir_all(&dir)?;
+        restrict_dir(&dir)?;
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            if entry.file_type()?.is_file() {
+                fs::remove_file(entry.path())?;
+            }
+        }
+        Ok(Self {
+            dir,
+            entropy,
+            minted: 0,
+        })
+    }
+
+    /// Mint a spill file under a fresh per-handle key, framed in `block_bytes`
+    /// plaintext blocks.
+    pub(crate) fn create(&mut self, block_bytes: u64) -> Result<SpillFile, VfsError> {
+        let mut key = Zeroizing::new([0u8; KEY_LEN]);
+        self.entropy
+            .fill(key.as_mut_slice())
+            .map_err(|error| VfsError::Internal {
+                message: error.message().to_owned(),
+            })?;
+        self.minted += 1;
+        let path = self
+            .dir
+            .join(format!("spill.{}.{}", std::process::id(), self.minted));
+        let file = open_private(&path).map_err(spill_io)?;
+        Ok(SpillFile {
+            path,
+            file,
+            key,
+            block_bytes,
+            blocks: BTreeSet::new(),
+            next_nonce: 0,
+        })
+    }
+}
+
+/// One handle's spill: a slot per plaintext block, each sealed on its own.
+pub(crate) struct SpillFile {
+    path: PathBuf,
+    file: File,
+    key: Zeroizing<[u8; KEY_LEN]>,
+    block_bytes: u64,
+    /// The block indices this spill actually holds. A slot outside the set is
+    /// uninitialized, never zero bytes: the caller falls back to the base
+    /// version for it.
+    blocks: BTreeSet<u64>,
+    next_nonce: u64,
+}
+
+impl SpillFile {
+    /// The plaintext of block `index`, `None` when the spill never took it.
+    /// Always a whole block wide.
+    pub(crate) fn block(&mut self, index: u64) -> Result<Option<Zeroizing<Vec<u8>>>, VfsError> {
+        if !self.blocks.contains(&index) {
+            return Ok(None);
+        }
+        let mut sealed = vec![0u8; self.slot_bytes()];
+        self.file
+            .seek(SeekFrom::Start(self.slot_offset(index)?))
+            .map_err(spill_io)?;
+        self.file.read_exact(&mut sealed).map_err(spill_io)?;
+        let (nonce, ciphertext) = sealed.split_at(NONCE_LEN);
+        let nonce: &[u8; NONCE_LEN] = nonce.try_into().expect("split_at NONCE_LEN");
+        let plaintext = aead::decrypt(&self.key, nonce, &block_aad(index), ciphertext).ok_or(
+            VfsError::Internal {
+                message: "a spill block did not open".to_owned(),
+            },
+        )?;
+        Ok(Some(Zeroizing::new(plaintext)))
+    }
+
+    /// Seal a whole block of plaintext into slot `index`, replacing whatever
+    /// the slot held.
+    pub(crate) fn put(&mut self, index: u64, plaintext: &[u8]) -> Result<(), VfsError> {
+        if plaintext.len() as u64 != self.block_bytes {
+            return Err(VfsError::Internal {
+                message: "a spill block must be sealed whole".to_owned(),
+            });
+        }
+        let nonce = self.next_nonce()?;
+        let sealed = aead::encrypt(&self.key, &nonce, &block_aad(index), plaintext);
+        self.file
+            .seek(SeekFrom::Start(self.slot_offset(index)?))
+            .map_err(spill_io)?;
+        self.file.write_all(&nonce).map_err(spill_io)?;
+        self.file.write_all(&sealed).map_err(spill_io)?;
+        self.blocks.insert(index);
+        Ok(())
+    }
+
+    /// Forget everything at or past `len`: whole blocks are dropped, and the
+    /// tail of the block `len` falls inside is zeroed, so a later write past
+    /// `len` reads holes as zeros rather than as the bytes truncate removed.
+    pub(crate) fn truncate(&mut self, len: u64) -> Result<(), VfsError> {
+        let last = len / self.block_bytes;
+        self.blocks.retain(|index| *index <= last);
+        let within = (len % self.block_bytes) as usize;
+        if within == 0 {
+            self.blocks.remove(&last);
+            return Ok(());
+        }
+        if let Some(mut block) = self.block(last)? {
+            block[within..].fill(0);
+            self.put(last, &block)?;
+        }
+        Ok(())
+    }
+
+    fn slot_bytes(&self) -> usize {
+        NONCE_LEN + self.block_bytes as usize + TAG_LEN
+    }
+
+    /// Where slot `index` starts. Fails closed past the addressable file: a
+    /// wrapped offset would alias one block onto another's slot.
+    fn slot_offset(&self, index: u64) -> Result<u64, VfsError> {
+        index
+            .checked_mul(self.slot_bytes() as u64)
+            .ok_or_else(|| VfsError::Internal {
+                message: "spill offset is not addressable".to_owned(),
+            })
+    }
+
+    /// The next nonce for this file's key. Fails closed rather than wrapping:
+    /// a repeated nonce under one XChaCha20-Poly1305 key breaks both
+    /// confidentiality and integrity.
+    fn next_nonce(&mut self) -> Result<[u8; NONCE_LEN], VfsError> {
+        let counter = self.next_nonce;
+        self.next_nonce = self
+            .next_nonce
+            .checked_add(1)
+            .ok_or_else(|| VfsError::Internal {
+                message: "spill nonce space exhausted".to_owned(),
+            })?;
+        let mut nonce = [0u8; NONCE_LEN];
+        nonce[..8].copy_from_slice(&counter.to_le_bytes());
+        Ok(nonce)
+    }
+}
+
+impl Drop for SpillFile {
+    /// The spill dies with the handle. The ciphertext is not overwritten: the
+    /// key was memory-only and goes with it.
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// The AAD binding one spill block to its slot.
+fn block_aad(index: u64) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(SPILL_AAD_DOMAIN.len() + 8);
+    aad.extend_from_slice(SPILL_AAD_DOMAIN);
+    aad.extend_from_slice(&index.to_le_bytes());
+    aad
+}
+
+/// Spill I/O never carries a path or a byte of content into the message.
+fn spill_io(error: io::Error) -> VfsError {
+    VfsError::Internal {
+        message: format!("spill file: {}", error.kind()),
+    }
+}
+
+#[cfg(unix)]
+fn open_private(path: &Path) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_private(path: &Path) -> io::Result<File> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(path)
+}
+
+#[cfg(unix)]
+fn restrict_dir(dir: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(dir, fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(not(unix))]
+fn restrict_dir(_dir: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use cipherbox_engine::testkit::SeededEntropy;
+
+    use super::*;
+
+    /// The plaintext a spill holds at `index`, as a plain vector.
+    fn held(spill: &mut SpillFile, index: u64) -> Option<Vec<u8>> {
+        spill
+            .block(index)
+            .expect("the block opens")
+            .map(|b| b.to_vec())
+    }
+
+    fn area(dir: &Path) -> SpillArea {
+        SpillArea::open(dir.to_path_buf(), Box::new(SeededEntropy::new(7))).expect("spill area")
+    }
+
+    #[test]
+    fn a_block_round_trips_through_its_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spill = area(dir.path()).create(8).unwrap();
+        assert_eq!(held(&mut spill, 0), None, "an unwritten slot is absent");
+        spill.put(3, b"abcdefgh").unwrap();
+        assert_eq!(held(&mut spill, 3), Some(b"abcdefgh".to_vec()));
+        assert_eq!(held(&mut spill, 2), None, "slots are independent");
+    }
+
+    #[test]
+    fn a_rewritten_block_never_repeats_a_nonce() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spill = area(dir.path()).create(8).unwrap();
+        spill.put(0, b"aaaaaaaa").unwrap();
+        let first = fs::read(&spill.path).unwrap();
+        spill.put(0, b"aaaaaaaa").unwrap();
+        let second = fs::read(&spill.path).unwrap();
+        assert_ne!(
+            first[..NONCE_LEN],
+            second[..NONCE_LEN],
+            "the same plaintext resealed must use a fresh nonce"
+        );
+    }
+
+    #[test]
+    fn plaintext_never_reaches_the_slot_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spill = area(dir.path()).create(16).unwrap();
+        spill.put(0, b"secret-plaintext").unwrap();
+        let bytes = fs::read(&spill.path).unwrap();
+        assert!(
+            !bytes
+                .windows(b"secret-plaintext".len())
+                .any(|window| window == b"secret-plaintext"),
+            "a spill file must hold ciphertext only"
+        );
+    }
+
+    #[test]
+    fn a_slot_moved_to_another_index_does_not_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spill = area(dir.path()).create(8).unwrap();
+        spill.put(0, b"abcdefgh").unwrap();
+        let slot = fs::read(&spill.path).unwrap();
+        // Transplant slot 0's bytes into slot 1 and claim the spill holds it.
+        spill
+            .file
+            .seek(SeekFrom::Start(spill.slot_offset(1).unwrap()))
+            .unwrap();
+        spill.file.write_all(&slot).unwrap();
+        spill.blocks.insert(1);
+        assert!(
+            matches!(spill.block(1), Err(VfsError::Internal { .. })),
+            "the block index is bound by the AAD"
+        );
+    }
+
+    #[test]
+    fn two_files_from_one_area_get_different_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut area = area(dir.path());
+        let mut first = area.create(8).unwrap();
+        let mut second = area.create(8).unwrap();
+        first.put(0, b"abcdefgh").unwrap();
+        second.put(0, b"abcdefgh").unwrap();
+        assert_ne!(*first.key, *second.key);
+        assert_ne!(
+            fs::read(&first.path).unwrap(),
+            fs::read(&second.path).unwrap(),
+            "one plaintext under two per-handle keys must not seal alike"
+        );
+    }
+
+    #[test]
+    fn truncation_drops_whole_blocks_and_zeroes_the_partial_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spill = area(dir.path()).create(8).unwrap();
+        spill.put(0, b"abcdefgh").unwrap();
+        spill.put(1, b"ijklmnop").unwrap();
+        spill.truncate(11).unwrap();
+        assert_eq!(held(&mut spill, 0), Some(b"abcdefgh".to_vec()));
+        assert_eq!(
+            held(&mut spill, 1),
+            Some(b"ijk\0\0\0\0\0".to_vec()),
+            "bytes past the new length must not survive as content"
+        );
+
+        spill.truncate(8).unwrap();
+        assert_eq!(
+            held(&mut spill, 1),
+            None,
+            "a block wholly past the new length is dropped"
+        );
+    }
+
+    #[test]
+    fn dropping_a_spill_removes_its_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spill = area(dir.path()).create(8).unwrap();
+        spill.put(0, b"abcdefgh").unwrap();
+        let path = spill.path.clone();
+        assert!(path.exists());
+        drop(spill);
+        assert!(!path.exists(), "a released handle leaves no spill behind");
+    }
+
+    #[test]
+    fn opening_the_area_sweeps_a_previous_runs_debris() {
+        let dir = tempfile::tempdir().unwrap();
+        let debris = dir.path().join("spill.1.1");
+        fs::write(&debris, b"unopenable ciphertext").unwrap();
+        let _area = area(dir.path());
+        assert!(!debris.exists());
+    }
+
+    #[test]
+    fn an_unaddressable_slot_is_refused_rather_than_wrapped() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spill = area(dir.path()).create(8).unwrap();
+        assert!(matches!(
+            spill.put(u64::MAX, &[0u8; 8]),
+            Err(VfsError::Internal { .. })
+        ));
+    }
+
+    #[test]
+    fn a_partial_block_is_refused_rather_than_padded() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spill = area(dir.path()).create(8).unwrap();
+        assert!(matches!(
+            spill.put(0, b"short"),
+            Err(VfsError::Internal { .. })
+        ));
+    }
+}

--- a/crates/fuse/tests/fuse_op_core.rs
+++ b/crates/fuse/tests/fuse_op_core.rs
@@ -915,8 +915,9 @@ fn the_bytes_a_handle_wrote_read_back_through_it() {
 }
 
 #[test]
-fn a_write_into_the_spill_never_parks() {
-    // The never-block law: landing bytes locally waits on nothing at all.
+fn a_write_into_a_created_handles_spill_never_parks() {
+    // The never-block law over a handle `create` already sized: `begin_pending`
+    // has nothing left to resolve, so the bytes land locally.
     let (mut core, _adapter) = mount();
     let handle = writing_handle(&mut core);
     let Poll::Ready(outcome) = poll_once(core.write(handle, 0, b"bytes")) else {
@@ -1838,6 +1839,68 @@ mod published {
         assert!(
             mount.adapter.drain().is_empty(),
             "a bind on the version already served repaints nothing"
+        );
+    }
+
+    #[test]
+    fn a_commit_repaints_the_pages_of_the_version_it_replaced() {
+        let plaintext = clip_bytes();
+        let mut mount = mount_published(&plaintext, CacheBudget::CI);
+        let ino = mount.ino;
+        // A second handle has already served this version's bytes, so the kernel
+        // holds pages the commit is about to invalidate. Nothing re-binds it.
+        let reader = opened(&mut mount);
+        block_on(mount.core.read(reader, 0, 8)).expect("the reader serves the published version");
+
+        let writer = block_on(mount.core.open(ino, Access::ReadWrite)).expect("the file opens");
+        block_on(mount.core.write(writer, 3, b"EDIT")).expect("the write lands");
+        mount.adapter.drain();
+        block_on(mount.core.release(writer)).expect("the release commits");
+
+        let pushed = mount.adapter.drain();
+        let data = pushed
+            .iter()
+            .position(|seen| seen == &Invalidation::Data { ino });
+        let attrs = pushed
+            .iter()
+            .position(|seen| seen == &Invalidation::Attributes { ino });
+        assert!(
+            data.is_some(),
+            "a commit must drop the pages of the version it replaced, got {pushed:?}"
+        );
+        assert!(
+            data < attrs,
+            "the new size must not reach the kernel while it still holds the old pages: {pushed:?}"
+        );
+    }
+
+    #[test]
+    fn a_write_on_a_reopened_handle_never_parks_once_the_size_is_projected() {
+        let plaintext = clip_bytes();
+        let mut mount = mount_published(&plaintext, CacheBudget::CI);
+        let ino = mount.ino;
+        assert!(
+            block_on(mount.core.getattr(ino))
+                .expect("the published file renders")
+                .size
+                .is_some(),
+            "the projected size is what leaves the write nothing to resolve"
+        );
+        let handle = block_on(mount.core.open(ino, Access::ReadWrite)).expect("the file opens");
+
+        let whole_block = vec![0xab; chunk() as usize];
+        let Poll::Ready(outcome) = poll_once(mount.core.write(handle, 0, &whole_block)) else {
+            panic!("a write on a reopened handle parked instead of landing in the spill");
+        };
+        assert_eq!(outcome.expect("the write lands"), whole_block.len() as u32);
+        assert!(
+            mount
+                .core
+                .handle(handle)
+                .expect("the handle is open")
+                .stream
+                .is_none(),
+            "a write that replaces whole blocks must not have resolved the content"
         );
     }
 }

--- a/crates/fuse/tests/fuse_op_core.rs
+++ b/crates/fuse/tests/fuse_op_core.rs
@@ -9,6 +9,7 @@ use std::cell::RefCell;
 use std::future::Future;
 use std::path::Path;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll, Waker};
 
 use cipherbox_engine::seams::StagingStore;
@@ -23,12 +24,20 @@ use cipherbox_fuse::{
     NameError, OperationCore, ROOT_INO, SpillArea, VfsError,
 };
 
-/// A spill area in a throwaway directory. The directory itself is left behind
-/// deliberately — a mount outlives any scope a `TempDir` guard could have, and
-/// every spill file inside it is removed when its handle closes.
+/// A spill area in a throwaway directory the mount outlives, so the directory
+/// is kept rather than guarded; every spill file inside it still goes with its
+/// handle.
 fn spill_area() -> SpillArea {
-    let dir = tempfile::tempdir().expect("a spill dir").keep();
-    SpillArea::open(dir, Box::new(SeededEntropy::new(11))).expect("the spill area opens")
+    spill_area_at(&tempfile::tempdir().expect("a spill dir").keep())
+}
+
+/// A spill area over `dir`, seeded so two areas in one test never draw the same
+/// per-handle keys.
+fn spill_area_at(dir: &Path) -> SpillArea {
+    static SEED: AtomicU64 = AtomicU64::new(11);
+    let seed = SEED.fetch_add(1, Ordering::Relaxed);
+    SpillArea::open(dir.to_path_buf(), Box::new(SeededEntropy::new(seed)))
+        .expect("the spill area opens")
 }
 
 /// A mount that records what it was told to invalidate.
@@ -120,6 +129,16 @@ fn seed_child(
         .lookup(parent, name)
         .expect("seeded child is rendered")
         .id
+}
+
+/// A mount over `engine` whose invalidations nothing inspects.
+fn mount_over(engine: Engine<FakeSeamTypes>) -> Core {
+    OperationCore::new(
+        engine,
+        RecordingAdapter::push_capable(),
+        CacheBudget::CI,
+        spill_area(),
+    )
 }
 
 /// Mount over an engine seeded with the given root children.
@@ -378,12 +397,7 @@ fn a_durable_queue_outage_never_destroys_the_destination_a_rename_did_not_replac
         let (mut engine, root, staging) = started_engine_with_staging();
         let source = seed_child(&mut engine, root, "new.txt", NodeKind::File);
         let victim = seed_child(&mut engine, root, "target.txt", NodeKind::File);
-        let mut core = OperationCore::new(
-            engine,
-            RecordingAdapter::push_capable(),
-            CacheBudget::CI,
-            spill_area(),
-        );
+        let mut core = mount_over(engine);
         staging.fail_enqueue_after(budget);
 
         let outcome = block_on(core.rename(ROOT_INO, "new.txt", ROOT_INO, "target.txt"));
@@ -409,12 +423,7 @@ fn renaming_a_node_onto_itself_journals_nothing() {
     // journal entry — proven by refusing every durable write.
     let (mut engine, root, staging) = started_engine_with_staging();
     seed_child(&mut engine, root, "f.txt", NodeKind::File);
-    let mut core = OperationCore::new(
-        engine,
-        RecordingAdapter::push_capable(),
-        CacheBudget::CI,
-        spill_area(),
-    );
+    let mut core = mount_over(engine);
     staging.fail_enqueue_after(0);
 
     block_on(core.rename(ROOT_INO, "f.txt", ROOT_INO, "f.txt")).expect("a no-op rename succeeds");
@@ -430,12 +439,7 @@ fn replacing_a_junk_holding_folder_keeps_the_destination_entry_when_the_queue_fa
     let source = seed_child(&mut engine, root, "dir", NodeKind::Folder);
     let victim = seed_child(&mut engine, root, "target", NodeKind::Folder);
     seed_child(&mut engine, victim, ".DS_Store", NodeKind::File);
-    let mut core = OperationCore::new(
-        engine,
-        RecordingAdapter::push_capable(),
-        CacheBudget::CI,
-        spill_area(),
-    );
+    let mut core = mount_over(engine);
     // The junk delete lands; the move that would unlink the folder does not.
     staging.fail_enqueue_after(1);
 
@@ -689,12 +693,7 @@ fn seeded_junk_folder() -> Core {
     let (mut engine, root) = started_engine();
     let dir = seed_child(&mut engine, root, "dir", NodeKind::Folder);
     seed_child(&mut engine, dir, ".DS_Store", NodeKind::File);
-    OperationCore::new(
-        engine,
-        RecordingAdapter::push_capable(),
-        CacheBudget::CI,
-        spill_area(),
-    )
+    mount_over(engine)
 }
 
 /// A `dir` holding one junk-prefixed folder, which itself holds a real file.
@@ -703,12 +702,7 @@ fn seeded_nested_junk_folder() -> Core {
     let dir = seed_child(&mut engine, root, "dir", NodeKind::Folder);
     let junk = seed_child(&mut engine, dir, ".Trash-1000", NodeKind::Folder);
     seed_child(&mut engine, junk, "buried.txt", NodeKind::File);
-    OperationCore::new(
-        engine,
-        RecordingAdapter::push_capable(),
-        CacheBudget::CI,
-        spill_area(),
-    )
+    mount_over(engine)
 }
 
 // --- structurally impossible moves ---
@@ -783,13 +777,11 @@ fn a_read_through_a_write_only_handle_is_refused() {
 /// the caller's, so a test can look at the ciphertext a write leaves there.
 fn mount_spilling_into(dir: &Path) -> (Core, InMemoryStagingStore) {
     let (engine, _root, staging) = started_engine_with_staging();
-    let spill = SpillArea::open(dir.to_path_buf(), Box::new(SeededEntropy::new(11)))
-        .expect("the spill area opens");
     let core = OperationCore::new(
         engine,
         RecordingAdapter::push_capable(),
         CacheBudget::CI,
-        spill,
+        spill_area_at(dir),
     );
     (core, staging)
 }
@@ -813,8 +805,9 @@ fn spill_files(dir: &Path) -> Vec<Vec<u8>> {
 
 /// A mount holding one writable handle on a fresh `f.txt`, with the create op
 /// already spent.
-fn writing_handle(core: &mut Core, access: Access) -> HandleId {
-    let (_attrs, handle) = block_on(core.create(ROOT_INO, "f.txt", access)).expect("the create");
+fn writing_handle(core: &mut Core) -> HandleId {
+    let (_attrs, handle) =
+        block_on(core.create(ROOT_INO, "f.txt", Access::ReadWrite)).expect("the create");
     handle
 }
 
@@ -839,7 +832,7 @@ fn a_write_on_a_read_only_handle_is_refused() {
 fn releasing_a_handle_that_never_wrote_journals_nothing() {
     let dir = tempfile::tempdir().expect("a spill dir");
     let (mut core, staging) = mount_spilling_into(dir.path());
-    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let handle = writing_handle(&mut core);
     let after_create = queued(&staging);
 
     block_on(core.release(handle)).expect("the handle closes");
@@ -859,7 +852,7 @@ fn releasing_a_handle_that_never_wrote_journals_nothing() {
 fn a_write_then_release_journals_exactly_one_update() {
     let dir = tempfile::tempdir().expect("a spill dir");
     let (mut core, staging) = mount_spilling_into(dir.path());
-    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let handle = writing_handle(&mut core);
     let after_create = queued(&staging);
     let plaintext = b"SECRET-1 spanning more than one framing block";
 
@@ -888,9 +881,7 @@ fn a_write_then_release_journals_exactly_one_update() {
 #[test]
 fn a_write_past_the_addressable_end_is_refused_rather_than_wrapped() {
     let (mut core, _adapter) = mount();
-    let handle = writing_handle(&mut core, Access::ReadWrite);
-    // An offset whose slot cannot be addressed fails closed rather than
-    // wrapping onto another block's slot.
+    let handle = writing_handle(&mut core);
     assert!(block_on(core.write(handle, u64::MAX - 4, b"xy")).is_err());
     assert_eq!(
         block_on(core.write(handle, u64::MAX, b"xy")),
@@ -902,7 +893,7 @@ fn a_write_past_the_addressable_end_is_refused_rather_than_wrapped() {
 #[test]
 fn the_bytes_a_handle_wrote_read_back_through_it() {
     let (mut core, _adapter) = mount();
-    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let handle = writing_handle(&mut core);
     let plaintext = b"the quick brown fox jumps over the lazy dog";
     block_on(core.write(handle, 0, plaintext)).expect("the write lands");
 
@@ -927,7 +918,7 @@ fn the_bytes_a_handle_wrote_read_back_through_it() {
 fn a_write_into_the_spill_never_parks() {
     // The never-block law: landing bytes locally waits on nothing at all.
     let (mut core, _adapter) = mount();
-    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let handle = writing_handle(&mut core);
     let Poll::Ready(outcome) = poll_once(core.write(handle, 0, b"bytes")) else {
         panic!("a write parked instead of landing in the spill");
     };
@@ -938,7 +929,7 @@ fn a_write_into_the_spill_never_parks() {
 fn a_write_is_refused_rather_than_acked_when_the_queue_cannot_journal_it() {
     let dir = tempfile::tempdir().expect("a spill dir");
     let (mut core, staging) = mount_spilling_into(dir.path());
-    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let handle = writing_handle(&mut core);
     let after_create = queued(&staging);
     // Every further durable write fails: the op can never reach the platter.
     staging.fail_enqueue_after(0);
@@ -962,7 +953,7 @@ fn a_write_is_refused_rather_than_acked_when_the_queue_cannot_journal_it() {
 fn a_spill_file_holds_no_plaintext() {
     let dir = tempfile::tempdir().expect("a spill dir");
     let (mut core, _staging) = mount_spilling_into(dir.path());
-    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let handle = writing_handle(&mut core);
 
     block_on(core.write(handle, 0, b"SECRET-1")).expect("the write lands");
 
@@ -1000,7 +991,7 @@ fn two_handles_on_one_node_seal_under_different_keys() {
 fn a_released_handle_leaves_no_spill_behind() {
     let dir = tempfile::tempdir().expect("a spill dir");
     let (mut core, _staging) = mount_spilling_into(dir.path());
-    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let handle = writing_handle(&mut core);
     block_on(core.write(handle, 0, b"SECRET-1")).expect("the write lands");
     assert_eq!(spill_files(dir.path()).len(), 1);
 
@@ -1018,7 +1009,7 @@ fn a_crash_between_the_spill_and_the_release_loses_the_write() {
     // holding the only copy of the spill key is what dies.
     let dir = tempfile::tempdir().expect("a spill dir");
     let (mut core, staging) = mount_spilling_into(dir.path());
-    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let handle = writing_handle(&mut core);
     let after_create = queued(&staging);
     block_on(core.write(handle, 0, b"SECRET-1")).expect("the write lands");
 
@@ -1040,7 +1031,7 @@ fn a_crash_between_the_spill_and_the_release_loses_the_write() {
 fn a_second_flush_with_nothing_new_to_say_journals_nothing() {
     let dir = tempfile::tempdir().expect("a spill dir");
     let (mut core, staging) = mount_spilling_into(dir.path());
-    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let handle = writing_handle(&mut core);
     let after_create = queued(&staging);
 
     block_on(core.write(handle, 0, b"SECRET-1")).expect("the write lands");
@@ -1059,7 +1050,7 @@ fn a_second_flush_with_nothing_new_to_say_journals_nothing() {
 fn truncating_an_open_handle_to_zero_is_never_silently_lost() {
     let dir = tempfile::tempdir().expect("a spill dir");
     let (mut core, staging) = mount_spilling_into(dir.path());
-    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let handle = writing_handle(&mut core);
     block_on(core.write(handle, 0, b"bytes that go away")).expect("the write lands");
     block_on(core.flush(handle)).expect("the flush commits");
     let after_write = queued(&staging);
@@ -1085,7 +1076,7 @@ fn truncating_an_open_handle_to_zero_is_never_silently_lost() {
 fn a_truncate_with_no_open_handle_journals_its_own_op() {
     let dir = tempfile::tempdir().expect("a spill dir");
     let (mut core, staging) = mount_spilling_into(dir.path());
-    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let handle = writing_handle(&mut core);
     block_on(core.write(handle, 0, b"bytes that go away")).expect("the write lands");
     block_on(core.release(handle)).expect("the release commits");
     let after_write = queued(&staging);
@@ -1108,6 +1099,33 @@ fn a_truncate_with_no_open_handle_journals_its_own_op() {
 }
 
 #[test]
+fn a_zero_length_write_changes_nothing() {
+    let dir = tempfile::tempdir().expect("a spill dir");
+    let (mut core, staging) = mount_spilling_into(dir.path());
+    let handle = writing_handle(&mut core);
+    let after_create = queued(&staging);
+
+    assert_eq!(
+        block_on(core.write(handle, 1 << 40, b"")).expect("no bytes"),
+        0
+    );
+
+    assert_eq!(
+        block_on(core.lookup(ROOT_INO, "f.txt"))
+            .expect("the file")
+            .size,
+        None,
+        "a zero-length write must not extend the file"
+    );
+    block_on(core.release(handle)).expect("the release closes");
+    assert_eq!(
+        queued(&staging),
+        after_create,
+        "nor may it owe an op for a length it never wrote"
+    );
+}
+
+#[test]
 fn truncating_a_directory_is_refused() {
     let (mut core, _adapter) = mount();
     let dir = block_on(core.mkdir(ROOT_INO, "dir")).unwrap();
@@ -1120,7 +1138,7 @@ fn truncating_a_directory_is_refused() {
 #[test]
 fn the_size_a_lookup_reports_follows_an_unjournaled_write() {
     let (mut core, _adapter) = mount();
-    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let handle = writing_handle(&mut core);
     block_on(core.write(handle, 0, b"twelve bytes")).expect("the write lands");
 
     let file = block_on(core.lookup(ROOT_INO, "f.txt")).expect("the file");
@@ -1448,7 +1466,7 @@ mod published {
     /// the shell writing while the mount is up.
     fn publish_version(mount: &mut Mount, plaintext: &[u8]) {
         let node = mount.node;
-        let cadence = {
+        {
             let engine = mount.core.engine_mut();
             let handle =
                 block_on(engine.begin_write(WriteTarget::Version { node }, plaintext.len() as u64))
@@ -1457,8 +1475,13 @@ mod published {
                 block_on(engine.push_chunk(handle, slice)).expect("the slice lands");
             }
             block_on(engine.commit_write(handle)).expect("the write commits");
-            engine.profile().poll_cadence
-        };
+        }
+        advance_and_pump(mount);
+    }
+
+    /// Let the engine drain and publish what the mount just journaled.
+    fn advance_and_pump(mount: &mut Mount) {
+        let cadence = mount.core.engine_mut().profile().poll_cadence;
         mount.world.scheduler.advance(cadence);
         pump(&mut mount.tasks);
     }
@@ -1707,13 +1730,6 @@ mod published {
         );
     }
 
-    /// Let the engine drain and publish what the mount just journaled.
-    fn drain(mount: &mut Mount) {
-        let cadence = mount.core.engine_mut().profile().poll_cadence;
-        mount.world.scheduler.advance(cadence);
-        pump(&mut mount.tasks);
-    }
-
     #[test]
     fn a_patch_over_a_published_version_keeps_the_bytes_it_did_not_touch() {
         // The whole round trip: a partial write merges over the published
@@ -1727,7 +1743,7 @@ mod published {
         let at = chunk() + 3;
         block_on(mount.core.write(handle, at, patch)).expect("the write lands");
         block_on(mount.core.release(handle)).expect("the release commits");
-        drain(&mut mount);
+        advance_and_pump(&mut mount);
 
         let mut expected = plaintext.clone();
         expected[at as usize..at as usize + patch.len()].copy_from_slice(patch);
@@ -1735,6 +1751,51 @@ mod published {
         let read = block_on(mount.core.read(reader, 0, expected.len() as u32))
             .expect("the published patch reads back");
         assert_eq!(read, expected);
+    }
+
+    #[test]
+    fn bytes_a_shrink_removed_never_come_back_when_the_file_grows_again() {
+        // Truncating is how a member destroys a file's tail. Those bytes must
+        // not be re-sealed into the next version by a later extension.
+        let plaintext = clip_bytes();
+        let mut mount = mount_published(&plaintext, CacheBudget::CI);
+        let ino = mount.ino;
+        let handle = block_on(mount.core.open(ino, Access::ReadWrite)).expect("the file opens");
+
+        block_on(mount.core.truncate(ino, 4, Some(handle))).expect("the shrink");
+        block_on(mount.core.truncate(ino, 32, Some(handle))).expect("the regrow");
+        block_on(mount.core.release(handle)).expect("the release commits");
+        advance_and_pump(&mut mount);
+
+        let mut expected = plaintext[..4].to_vec();
+        expected.resize(32, 0);
+        let reader = opened(&mut mount);
+        assert_eq!(
+            block_on(mount.core.read(reader, 0, 32)).expect("the read"),
+            expected,
+            "a regrown file reads the shrink's gap as a hole, not as the old bytes"
+        );
+    }
+
+    #[test]
+    fn a_write_past_a_shrink_reads_the_gap_as_zeros() {
+        let plaintext = clip_bytes();
+        let mut mount = mount_published(&plaintext, CacheBudget::CI);
+        let ino = mount.ino;
+        let handle = block_on(mount.core.open(ino, Access::ReadWrite)).expect("the file opens");
+
+        block_on(mount.core.truncate(ino, 4, Some(handle))).expect("the shrink");
+        block_on(mount.core.write(handle, 6, b"xy")).expect("the write past the gap");
+        block_on(mount.core.release(handle)).expect("the release commits");
+        advance_and_pump(&mut mount);
+
+        let mut expected = plaintext[..4].to_vec();
+        expected.extend_from_slice(b"\0\0xy");
+        let reader = opened(&mut mount);
+        assert_eq!(
+            block_on(mount.core.read(reader, 0, 16)).expect("the read"),
+            expected
+        );
     }
 
     #[test]
@@ -1747,7 +1808,7 @@ mod published {
         let tail = b"appended";
         block_on(mount.core.write(handle, plaintext.len() as u64, tail)).expect("the append lands");
         block_on(mount.core.release(handle)).expect("the release commits");
-        drain(&mut mount);
+        advance_and_pump(&mut mount);
 
         let mut expected = plaintext.clone();
         expected.extend_from_slice(tail);

--- a/crates/fuse/tests/fuse_op_core.rs
+++ b/crates/fuse/tests/fuse_op_core.rs
@@ -7,9 +7,11 @@
 
 use std::cell::RefCell;
 use std::future::Future;
+use std::path::Path;
 use std::rc::Rc;
 use std::task::{Context, Poll, Waker};
 
+use cipherbox_engine::seams::StagingStore;
 use cipherbox_engine::testkit::fakes::InMemoryStagingStore;
 use cipherbox_engine::testkit::{FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
 use cipherbox_engine::{
@@ -18,8 +20,16 @@ use cipherbox_engine::{
 };
 use cipherbox_fuse::{
     Access, CacheBudget, HandleId, HostAdapter, HostCapabilities, Invalidation, MAX_NAME_BYTES,
-    NameError, OperationCore, ROOT_INO, VfsError,
+    NameError, OperationCore, ROOT_INO, SpillArea, VfsError,
 };
+
+/// A spill area in a throwaway directory. The directory itself is left behind
+/// deliberately — a mount outlives any scope a `TempDir` guard could have, and
+/// every spill file inside it is removed when its handle closes.
+fn spill_area() -> SpillArea {
+    let dir = tempfile::tempdir().expect("a spill dir").keep();
+    SpillArea::open(dir, Box::new(SeededEntropy::new(11))).expect("the spill area opens")
+}
 
 /// A mount that records what it was told to invalidate.
 #[derive(Clone, Default)]
@@ -118,7 +128,7 @@ fn mount_seeded(adapter: RecordingAdapter, root_children: &[(&str, NodeKind)]) -
     for (name, kind) in root_children {
         seed_child(&mut engine, root, name, *kind);
     }
-    OperationCore::new(engine, adapter, CacheBudget::CI)
+    OperationCore::new(engine, adapter, CacheBudget::CI, spill_area())
 }
 
 /// Poll a future exactly once. `Ready` proves the operation reached its answer
@@ -247,9 +257,9 @@ fn create_opens_a_handle_that_releases_exactly_once() {
     assert_eq!(core.handle(handle).unwrap().node, attrs.node);
     assert!(core.handle(handle).unwrap().access.writable());
 
-    assert_eq!(core.release(handle), Ok(()));
+    assert_eq!(block_on(core.release(handle)), Ok(()));
     assert_eq!(core.handle(handle), Err(VfsError::BadHandle));
-    assert_eq!(core.release(handle), Err(VfsError::BadHandle));
+    assert_eq!(block_on(core.release(handle)), Err(VfsError::BadHandle));
 }
 
 #[test]
@@ -261,7 +271,7 @@ fn opening_a_directory_is_refused_and_opening_a_file_is_not() {
         Err(VfsError::IsADirectory)
     );
     let (file, handle) = block_on(core.create(ROOT_INO, "f.txt", Access::Read)).unwrap();
-    core.release(handle).unwrap();
+    block_on(core.release(handle)).unwrap();
     let reopened = block_on(core.open(file.ino, Access::Read)).unwrap();
     assert_eq!(core.handle(reopened).unwrap().node, file.node);
 }
@@ -368,8 +378,12 @@ fn a_durable_queue_outage_never_destroys_the_destination_a_rename_did_not_replac
         let (mut engine, root, staging) = started_engine_with_staging();
         let source = seed_child(&mut engine, root, "new.txt", NodeKind::File);
         let victim = seed_child(&mut engine, root, "target.txt", NodeKind::File);
-        let mut core =
-            OperationCore::new(engine, RecordingAdapter::push_capable(), CacheBudget::CI);
+        let mut core = OperationCore::new(
+            engine,
+            RecordingAdapter::push_capable(),
+            CacheBudget::CI,
+            spill_area(),
+        );
         staging.fail_enqueue_after(budget);
 
         let outcome = block_on(core.rename(ROOT_INO, "new.txt", ROOT_INO, "target.txt"));
@@ -395,7 +409,12 @@ fn renaming_a_node_onto_itself_journals_nothing() {
     // journal entry — proven by refusing every durable write.
     let (mut engine, root, staging) = started_engine_with_staging();
     seed_child(&mut engine, root, "f.txt", NodeKind::File);
-    let mut core = OperationCore::new(engine, RecordingAdapter::push_capable(), CacheBudget::CI);
+    let mut core = OperationCore::new(
+        engine,
+        RecordingAdapter::push_capable(),
+        CacheBudget::CI,
+        spill_area(),
+    );
     staging.fail_enqueue_after(0);
 
     block_on(core.rename(ROOT_INO, "f.txt", ROOT_INO, "f.txt")).expect("a no-op rename succeeds");
@@ -411,7 +430,12 @@ fn replacing_a_junk_holding_folder_keeps_the_destination_entry_when_the_queue_fa
     let source = seed_child(&mut engine, root, "dir", NodeKind::Folder);
     let victim = seed_child(&mut engine, root, "target", NodeKind::Folder);
     seed_child(&mut engine, victim, ".DS_Store", NodeKind::File);
-    let mut core = OperationCore::new(engine, RecordingAdapter::push_capable(), CacheBudget::CI);
+    let mut core = OperationCore::new(
+        engine,
+        RecordingAdapter::push_capable(),
+        CacheBudget::CI,
+        spill_area(),
+    );
     // The junk delete lands; the move that would unlink the folder does not.
     staging.fail_enqueue_after(1);
 
@@ -665,7 +689,12 @@ fn seeded_junk_folder() -> Core {
     let (mut engine, root) = started_engine();
     let dir = seed_child(&mut engine, root, "dir", NodeKind::Folder);
     seed_child(&mut engine, dir, ".DS_Store", NodeKind::File);
-    OperationCore::new(engine, RecordingAdapter::push_capable(), CacheBudget::CI)
+    OperationCore::new(
+        engine,
+        RecordingAdapter::push_capable(),
+        CacheBudget::CI,
+        spill_area(),
+    )
 }
 
 /// A `dir` holding one junk-prefixed folder, which itself holds a real file.
@@ -674,7 +703,12 @@ fn seeded_nested_junk_folder() -> Core {
     let dir = seed_child(&mut engine, root, "dir", NodeKind::Folder);
     let junk = seed_child(&mut engine, dir, ".Trash-1000", NodeKind::Folder);
     seed_child(&mut engine, junk, "buried.txt", NodeKind::File);
-    OperationCore::new(engine, RecordingAdapter::push_capable(), CacheBudget::CI)
+    OperationCore::new(
+        engine,
+        RecordingAdapter::push_capable(),
+        CacheBudget::CI,
+        spill_area(),
+    )
 }
 
 // --- structurally impossible moves ---
@@ -740,6 +774,381 @@ fn a_read_through_a_write_only_handle_is_refused() {
     assert_eq!(
         block_on(core.read(HandleId(9999), 0, 16)),
         Err(VfsError::BadHandle)
+    );
+}
+
+// --- the content write path ---
+
+/// A mount spilling into `dir`, plus the durable queue behind it. The dir is
+/// the caller's, so a test can look at the ciphertext a write leaves there.
+fn mount_spilling_into(dir: &Path) -> (Core, InMemoryStagingStore) {
+    let (engine, _root, staging) = started_engine_with_staging();
+    let spill = SpillArea::open(dir.to_path_buf(), Box::new(SeededEntropy::new(11)))
+        .expect("the spill area opens");
+    let core = OperationCore::new(
+        engine,
+        RecordingAdapter::push_capable(),
+        CacheBudget::CI,
+        spill,
+    );
+    (core, staging)
+}
+
+/// How many ops the durable queue holds.
+fn queued(staging: &InMemoryStagingStore) -> usize {
+    block_on(staging.queued_ops())
+        .expect("the queue reads")
+        .len()
+}
+
+/// Every spill file's bytes, in a stable order.
+fn spill_files(dir: &Path) -> Vec<Vec<u8>> {
+    let mut files: Vec<Vec<u8>> = std::fs::read_dir(dir)
+        .expect("the spill dir reads")
+        .map(|entry| std::fs::read(entry.expect("an entry").path()).expect("spill bytes"))
+        .collect();
+    files.sort();
+    files
+}
+
+/// A mount holding one writable handle on a fresh `f.txt`, with the create op
+/// already spent.
+fn writing_handle(core: &mut Core, access: Access) -> HandleId {
+    let (_attrs, handle) = block_on(core.create(ROOT_INO, "f.txt", access)).expect("the create");
+    handle
+}
+
+#[test]
+fn a_write_on_a_read_only_handle_is_refused() {
+    let (mut core, _adapter) = mount();
+    let (file, _reader) = block_on(core.create(ROOT_INO, "f.txt", Access::ReadWrite)).unwrap();
+    let handle = block_on(core.open(file.ino, Access::Read)).expect("the file opens");
+
+    assert_eq!(
+        block_on(core.write(handle, 0, b"denied")),
+        Err(VfsError::BadHandle),
+        "a read-only handle must refuse a write, not accept and drop it"
+    );
+    assert_eq!(
+        block_on(core.write(HandleId(9999), 0, b"denied")),
+        Err(VfsError::BadHandle)
+    );
+}
+
+#[test]
+fn releasing_a_handle_that_never_wrote_journals_nothing() {
+    let dir = tempfile::tempdir().expect("a spill dir");
+    let (mut core, staging) = mount_spilling_into(dir.path());
+    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let after_create = queued(&staging);
+
+    block_on(core.release(handle)).expect("the handle closes");
+
+    assert_eq!(
+        queued(&staging),
+        after_create,
+        "a handle with nothing to say owes no op"
+    );
+    assert!(
+        spill_files(dir.path()).is_empty(),
+        "a handle that never wrote mints no spill file"
+    );
+}
+
+#[test]
+fn a_write_then_release_journals_exactly_one_update() {
+    let dir = tempfile::tempdir().expect("a spill dir");
+    let (mut core, staging) = mount_spilling_into(dir.path());
+    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let after_create = queued(&staging);
+    let plaintext = b"SECRET-1 spanning more than one framing block";
+
+    assert_eq!(
+        block_on(core.write(handle, 0, plaintext)).expect("the write lands"),
+        plaintext.len() as u32
+    );
+    assert_eq!(queued(&staging), after_create, "a write journals nothing");
+
+    block_on(core.release(handle)).expect("the release commits");
+
+    assert_eq!(
+        queued(&staging),
+        after_create + 1,
+        "a whole file is one op, however many blocks it took"
+    );
+    // A queued `updateContent` is what projects a new size onto the node.
+    assert_eq!(
+        block_on(core.lookup(ROOT_INO, "f.txt"))
+            .expect("the file")
+            .size,
+        Some(plaintext.len() as u64)
+    );
+}
+
+#[test]
+fn a_write_past_the_addressable_end_is_refused_rather_than_wrapped() {
+    let (mut core, _adapter) = mount();
+    let handle = writing_handle(&mut core, Access::ReadWrite);
+    // An offset whose slot cannot be addressed fails closed rather than
+    // wrapping onto another block's slot.
+    assert!(block_on(core.write(handle, u64::MAX - 4, b"xy")).is_err());
+    assert_eq!(
+        block_on(core.write(handle, u64::MAX, b"xy")),
+        Err(VfsError::Invalid),
+        "a window that cannot even be expressed is invalid"
+    );
+}
+
+#[test]
+fn the_bytes_a_handle_wrote_read_back_through_it() {
+    let (mut core, _adapter) = mount();
+    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let plaintext = b"the quick brown fox jumps over the lazy dog";
+    block_on(core.write(handle, 0, plaintext)).expect("the write lands");
+
+    assert_eq!(
+        block_on(core.read(handle, 0, plaintext.len() as u32)).expect("the read"),
+        plaintext.to_vec(),
+        "a handle reads what it wrote, before any op is journaled"
+    );
+    // Sparse: a write past the end leaves a hole, which reads as zeros.
+    block_on(core.write(handle, 64, b"tail")).expect("the far write lands");
+    let whole = block_on(core.read(handle, 0, 128)).expect("the read");
+    assert_eq!(whole.len(), 68);
+    assert_eq!(&whole[..plaintext.len()], plaintext);
+    assert_eq!(
+        &whole[plaintext.len()..64],
+        &vec![0u8; 64 - plaintext.len()]
+    );
+    assert_eq!(&whole[64..], b"tail");
+}
+
+#[test]
+fn a_write_into_the_spill_never_parks() {
+    // The never-block law: landing bytes locally waits on nothing at all.
+    let (mut core, _adapter) = mount();
+    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let Poll::Ready(outcome) = poll_once(core.write(handle, 0, b"bytes")) else {
+        panic!("a write parked instead of landing in the spill");
+    };
+    outcome.expect("the write lands");
+}
+
+#[test]
+fn a_write_is_refused_rather_than_acked_when_the_queue_cannot_journal_it() {
+    let dir = tempfile::tempdir().expect("a spill dir");
+    let (mut core, staging) = mount_spilling_into(dir.path());
+    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let after_create = queued(&staging);
+    // Every further durable write fails: the op can never reach the platter.
+    staging.fail_enqueue_after(0);
+
+    block_on(core.write(handle, 0, b"unacked bytes")).expect("the write lands in the spill");
+    block_on(core.flush(handle)).expect_err("a flush that cannot journal must not ack");
+    block_on(core.release(handle)).expect_err("nor may the release");
+
+    assert_eq!(
+        queued(&staging),
+        after_create,
+        "a refused write leaves no half-formed op behind"
+    );
+    assert!(
+        spill_files(dir.path()).is_empty(),
+        "the handle's spill still dies with it"
+    );
+}
+
+#[test]
+fn a_spill_file_holds_no_plaintext() {
+    let dir = tempfile::tempdir().expect("a spill dir");
+    let (mut core, _staging) = mount_spilling_into(dir.path());
+    let handle = writing_handle(&mut core, Access::ReadWrite);
+
+    block_on(core.write(handle, 0, b"SECRET-1")).expect("the write lands");
+
+    let files = spill_files(dir.path());
+    assert_eq!(files.len(), 1, "one writable handle, one spill file");
+    assert!(
+        !files[0]
+            .windows(b"SECRET-1".len())
+            .any(|window| window == b"SECRET-1"),
+        "the spill file must be sealed at rest"
+    );
+}
+
+#[test]
+fn two_handles_on_one_node_seal_under_different_keys() {
+    let dir = tempfile::tempdir().expect("a spill dir");
+    let (mut core, _staging) = mount_spilling_into(dir.path());
+    let (file, first) = block_on(core.create(ROOT_INO, "f.txt", Access::ReadWrite)).unwrap();
+    let second = block_on(core.open(file.ino, Access::Write)).expect("a second handle");
+    // The second handle opened `O_TRUNC`, so it too starts from nothing.
+    block_on(core.truncate(file.ino, 0, Some(second))).expect("the truncate");
+
+    block_on(core.write(first, 0, b"SECRET-1")).expect("the first write");
+    block_on(core.write(second, 0, b"SECRET-1")).expect("the second write");
+
+    let files = spill_files(dir.path());
+    assert_eq!(files.len(), 2);
+    assert_ne!(
+        files[0], files[1],
+        "one plaintext under two per-handle keys must not seal alike"
+    );
+}
+
+#[test]
+fn a_released_handle_leaves_no_spill_behind() {
+    let dir = tempfile::tempdir().expect("a spill dir");
+    let (mut core, _staging) = mount_spilling_into(dir.path());
+    let handle = writing_handle(&mut core, Access::ReadWrite);
+    block_on(core.write(handle, 0, b"SECRET-1")).expect("the write lands");
+    assert_eq!(spill_files(dir.path()).len(), 1);
+
+    block_on(core.release(handle)).expect("the release commits");
+
+    assert!(
+        spill_files(dir.path()).is_empty(),
+        "the spill and the key that opens it go with the handle"
+    );
+}
+
+#[test]
+fn a_crash_between_the_spill_and_the_release_loses_the_write() {
+    // "Crash" is the mount going away with the handle still open: the process
+    // holding the only copy of the spill key is what dies.
+    let dir = tempfile::tempdir().expect("a spill dir");
+    let (mut core, staging) = mount_spilling_into(dir.path());
+    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let after_create = queued(&staging);
+    block_on(core.write(handle, 0, b"SECRET-1")).expect("the write lands");
+
+    core.unmount();
+    drop(core);
+
+    assert_eq!(
+        queued(&staging),
+        after_create,
+        "an unreleased write journals no partial op"
+    );
+    assert!(
+        spill_files(dir.path()).is_empty(),
+        "nothing openable survives the mount"
+    );
+}
+
+#[test]
+fn a_second_flush_with_nothing_new_to_say_journals_nothing() {
+    let dir = tempfile::tempdir().expect("a spill dir");
+    let (mut core, staging) = mount_spilling_into(dir.path());
+    let handle = writing_handle(&mut core, Access::ReadWrite);
+    let after_create = queued(&staging);
+
+    block_on(core.write(handle, 0, b"SECRET-1")).expect("the write lands");
+    block_on(core.flush(handle)).expect("the flush commits");
+    block_on(core.fsync(handle)).expect("an fsync with nothing new");
+    block_on(core.release(handle)).expect("the release closes");
+
+    assert_eq!(
+        queued(&staging),
+        after_create + 1,
+        "one file's worth of writes is one op, however often it is flushed"
+    );
+}
+
+#[test]
+fn truncating_an_open_handle_to_zero_is_never_silently_lost() {
+    let dir = tempfile::tempdir().expect("a spill dir");
+    let (mut core, staging) = mount_spilling_into(dir.path());
+    let handle = writing_handle(&mut core, Access::ReadWrite);
+    block_on(core.write(handle, 0, b"bytes that go away")).expect("the write lands");
+    block_on(core.flush(handle)).expect("the flush commits");
+    let after_write = queued(&staging);
+
+    let file = block_on(core.lookup(ROOT_INO, "f.txt")).expect("the file");
+    block_on(core.truncate(file.ino, 0, Some(handle))).expect("the truncate");
+    block_on(core.release(handle)).expect("the release commits");
+
+    assert_eq!(
+        queued(&staging),
+        after_write + 1,
+        "a truncate on an open handle rides that handle's own op"
+    );
+    assert_eq!(
+        block_on(core.lookup(ROOT_INO, "f.txt"))
+            .expect("the file")
+            .size,
+        Some(0)
+    );
+}
+
+#[test]
+fn a_truncate_with_no_open_handle_journals_its_own_op() {
+    let dir = tempfile::tempdir().expect("a spill dir");
+    let (mut core, staging) = mount_spilling_into(dir.path());
+    let handle = writing_handle(&mut core, Access::ReadWrite);
+    block_on(core.write(handle, 0, b"bytes that go away")).expect("the write lands");
+    block_on(core.release(handle)).expect("the release commits");
+    let after_write = queued(&staging);
+
+    let file = block_on(core.lookup(ROOT_INO, "f.txt")).expect("the file");
+    block_on(core.truncate(file.ino, 0, None)).expect("the truncate");
+
+    assert_eq!(
+        queued(&staging),
+        after_write + 1,
+        "nothing else would ever journal this length"
+    );
+    assert_eq!(
+        block_on(core.lookup(ROOT_INO, "f.txt"))
+            .expect("the file")
+            .size,
+        Some(0)
+    );
+    assert!(spill_files(dir.path()).is_empty());
+}
+
+#[test]
+fn truncating_a_directory_is_refused() {
+    let (mut core, _adapter) = mount();
+    let dir = block_on(core.mkdir(ROOT_INO, "dir")).unwrap();
+    assert_eq!(
+        block_on(core.truncate(dir.ino, 0, None)),
+        Err(VfsError::IsADirectory)
+    );
+}
+
+#[test]
+fn the_size_a_lookup_reports_follows_an_unjournaled_write() {
+    let (mut core, _adapter) = mount();
+    let handle = writing_handle(&mut core, Access::ReadWrite);
+    block_on(core.write(handle, 0, b"twelve bytes")).expect("the write lands");
+
+    let file = block_on(core.lookup(ROOT_INO, "f.txt")).expect("the file");
+    assert_eq!(
+        file.size,
+        Some(12),
+        "a program that stats what it just wrote must not see the old length"
+    );
+    assert_eq!(
+        block_on(core.getattr(file.ino)).expect("attrs").size,
+        Some(12)
+    );
+}
+
+#[test]
+fn a_partial_write_over_an_unreadable_base_fails_closed() {
+    // The file exists but its content plane has published nothing this mount
+    // can resolve, so the bytes a partial write would keep are unknown. Guessing
+    // zero would silently truncate what the version holds.
+    let (mut core, _adapter) = mount();
+    let (file, handle) = block_on(core.create(ROOT_INO, "f.txt", Access::ReadWrite)).unwrap();
+    block_on(core.release(handle)).expect("the create closes");
+    let reopened = block_on(core.open(file.ino, Access::Write)).expect("the file opens");
+
+    let outcome = block_on(core.write(reopened, 3, b"patch"));
+    assert!(
+        matches!(outcome, Err(VfsError::Unavailable { .. })),
+        "expected an availability verdict, got {outcome:?}"
     );
 }
 
@@ -1020,7 +1429,7 @@ mod published {
         pump(&mut tasks);
 
         let adapter = RecordingAdapter::push_capable();
-        let mut core = OperationCore::new(engine, adapter.clone(), budget);
+        let mut core = OperationCore::new(engine, adapter.clone(), budget, spill_area());
         let published =
             block_on(core.lookup(ROOT_INO, CLIP)).expect("the published file is rendered");
         adapter.drain();
@@ -1204,7 +1613,7 @@ mod published {
                     .unwrap_or_else(|err| panic!("round {round}: {err}")),
                 plaintext[..8]
             );
-            mount.core.release(handle).expect("the handle closes");
+            block_on(mount.core.release(handle)).expect("the handle closes");
             assert_eq!(
                 mount.core.cached_plaintext_bytes(),
                 0,
@@ -1252,7 +1661,7 @@ mod published {
             block_on(mount.core.read(first, 0, 8)).unwrap(),
             plaintext[..8]
         );
-        mount.core.release(first).expect("the first handle closes");
+        block_on(mount.core.release(first)).expect("the first handle closes");
 
         assert_eq!(
             block_on(mount.core.read(second, 0, 8)).unwrap(),
@@ -1270,7 +1679,7 @@ mod published {
             block_on(mount.core.read(first, 0, 8)).expect("the first version reads"),
             plaintext[..8]
         );
-        mount.core.release(first).expect("the handle closes");
+        block_on(mount.core.release(first)).expect("the handle closes");
         mount.adapter.drain();
 
         let edited: Vec<u8> = plaintext.iter().map(|byte| byte ^ 0xff).collect();
@@ -1295,6 +1704,57 @@ mod published {
         assert!(
             pushed.contains(&Invalidation::Data { ino }),
             "expected a data invalidation for ino {ino}, got {pushed:?}"
+        );
+    }
+
+    /// Let the engine drain and publish what the mount just journaled.
+    fn drain(mount: &mut Mount) {
+        let cadence = mount.core.engine_mut().profile().poll_cadence;
+        mount.world.scheduler.advance(cadence);
+        pump(&mut mount.tasks);
+    }
+
+    #[test]
+    fn a_patch_over_a_published_version_keeps_the_bytes_it_did_not_touch() {
+        // The whole round trip: a partial write merges over the published
+        // version, releases as one op, publishes, and reads back.
+        let plaintext = clip_bytes();
+        let mut mount = mount_published(&plaintext, CacheBudget::CI);
+        let handle =
+            block_on(mount.core.open(mount.ino, Access::ReadWrite)).expect("the file opens");
+
+        let patch = b"PATCHED!";
+        let at = chunk() + 3;
+        block_on(mount.core.write(handle, at, patch)).expect("the write lands");
+        block_on(mount.core.release(handle)).expect("the release commits");
+        drain(&mut mount);
+
+        let mut expected = plaintext.clone();
+        expected[at as usize..at as usize + patch.len()].copy_from_slice(patch);
+        let reader = opened(&mut mount);
+        let read = block_on(mount.core.read(reader, 0, expected.len() as u32))
+            .expect("the published patch reads back");
+        assert_eq!(read, expected);
+    }
+
+    #[test]
+    fn a_write_extending_a_published_version_reads_back_whole() {
+        let plaintext = clip_bytes();
+        let mut mount = mount_published(&plaintext, CacheBudget::CI);
+        let handle =
+            block_on(mount.core.open(mount.ino, Access::ReadWrite)).expect("the file opens");
+
+        let tail = b"appended";
+        block_on(mount.core.write(handle, plaintext.len() as u64, tail)).expect("the append lands");
+        block_on(mount.core.release(handle)).expect("the release commits");
+        drain(&mut mount);
+
+        let mut expected = plaintext.clone();
+        expected.extend_from_slice(tail);
+        let reader = opened(&mut mount);
+        assert_eq!(
+            block_on(mount.core.read(reader, 0, expected.len() as u32)).expect("the read"),
+            expected
         );
     }
 


### PR DESCRIPTION
## What this is

The fuse content write path: `write`, `flush`, `fsync`, `truncate` and a `release` that journals. Before this, `release` closed a handle and emitted zero ops, and nothing in `crates/fuse` ever reached `begin_write` / `push_chunk` / `commit_write`.

## The spill file

Bytes land in a per-handle sealed spill file in the engine data dir, exactly as `blueprint/desktop.md` "Reads, writes, and the never-block law" specifies:

- XChaCha20-Poly1305 under a random per-handle key, minted from an **injected** entropy source (`SpillArea::open(dir, entropy)`) — the projection never calls an RNG.
- The key lives only in process memory, is never persisted or logged, and zeroizes with the handle.
- Nonces are a per-file counter. The key is fresh per handle, so a counter is unique under it by construction, and a rewritten block never repeats one.
- One slot per framing block, `nonce || ciphertext||tag`, with the block index in the AAD so a slot transplanted to another offset fails to open.
- A crash leaves ciphertext whose key died with the process — v1's plaintext `cb-write-*` class is gone structurally, so the spill is deleted rather than zero-overwritten. `SpillArea::open` sweeps a previous run's debris.

Sealing uses `crates/core`'s AEAD; the fuse crate implements no crypto of its own.

## Ops and the ack

`flush` / `fsync` / `release` turn what a handle holds into **exactly one** `updateContent` op. The version is assembled block by block — the spill's block if it took one, else the base version's bytes, else the zeros a hole reads as — and fed through `push_chunk`, so peak plaintext is one block however large the file. A block a write replaces whole never fetches the version it replaces.

The kernel is acked only once `commit_write` has journaled the op durably in the StagingStore. A queue that cannot journal makes `flush` and `release` fail, and the op queue is left exactly as it was — no half-formed op, no false ack.

## Decisions worth reviewing

- **`truncate` on an open writable handle is a spill-file operation**, folded into that handle's one op; with no handle it becomes its own op, so a bare `truncate(2)` is never silently lost. `O_TRUNC` is the first form: the adapter opens the handle, then truncates it to zero. Truncating to zero resolves nothing, so `> file` needs no network. A shrink also lowers the floor the base version may contribute from, so bytes it removed never come back if the file grows again.
- **A partial write over a version whose size is unprojected fails closed.** An unprojected size is unknown, not zero; guessing zero would drop the file's untouched tail. The mount resolves the head to project it and surfaces an availability verdict if it cannot. The consequence: appending to a file whose `updateContent` is staged but not yet published is refused until it publishes, because the engine's content read plane resolves published heads only.
- **A handle holding writes reads what it wrote**, and `lookup`/`getattr` report the length those writes leave, so a program that stats or re-reads what it just wrote does not see the old file.
- Writes on a read-only handle are refused rather than accepted and dropped, which `Access::writable` previously had no caller to do.

## Coverage

`fuse-op-core` gains the write path end to end, plus spill unit tests in `crates/fuse/src/spill.rs` (the gate runs `cargo test -p cipherbox-fuse`, so both are in it):

- a write then release journals exactly one op, and the projected size proves it was an `updateContent`
- a partial write over a **real published version** merges, publishes, and reads back with the untouched bytes intact; an extending write likewise
- a `fail_enqueue_after(0)` outage refuses the write rather than acking it, leaving the queue untouched
- the spill file holds no plaintext; two handles on one node seal one plaintext differently
- a released handle leaves no spill behind, and an unreleased write dies with the mount, journaling nothing
- a write on a read-only handle is refused; a write into the spill never parks
- a truncate to zero on an open handle rides that handle's op; with no handle it journals its own
- release with no writes journals nothing, and repeated flushes journal one op

## What the review gates changed

The three mandatory gates ran on this diff and found one real defect plus a set of hardening items, all folded in:

- **A shrink recorded no floor on the base version.** After `ftruncate(fd, 4)`, any range at or past 4 that a later write or regrow re-covered was served from the version being replaced, so bytes a member truncated away were re-sealed into the next version and published. `Pending` now carries a `base_len` clamped by every truncate, which the assembler consults — and which collapses the old `Base` enum away. Two regression tests over a real published version cover it.
- A zero-length write no longer extends the file.
- A spill closes its file handle before unlinking, so the Windows leg really leaves nothing behind.
- Spill files are named from entropy rather than a per-area counter, so two areas over one directory cannot unlink each other's live spill.
- A slot is claimed before its bytes land, so a half-written slot fails closed instead of quietly falling back to the base version for a block the caller wrote.
- A zero block size is refused at creation rather than dividing by zero later.

Rejected with reason: binding a slot generation into the AAD. It defends only against an attacker who can write the `0600` spill file, who by the same access can read the plaintext out of the mount or the process — the local uid is not a boundary this system defends.

`blueprint/desktop.md` said `crates/fuse` depends on the engine facade alone, which its own writes section contradicts by requiring the FS core to seal spill files. The narrower statement is amended to carve out core's AEAD.

## Not verified here

The FUSE mount itself cannot be exercised in this environment — macFUSE-versus-FUSE-T linking breaks a local mount — so no kernel drove these paths. What needs a real mount: that a host adapter maps `O_TRUNC` to open-then-truncate, that `close(2)` surfaces the flush error, and the spill's behaviour under a real 1 MiB framing block rather than CI's 16-byte one.

`SpillArea` also has no production construction site yet — there is no host adapter implementation either, so the mount is not wired at the Tauri shell. Whoever lands that must construct the spill area from the same production `getrandom` source the engine uses; the counter-nonce argument rests on it.

Closes #1110


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement write path for FUSE content using sealed per-handle spill files
> - Adds [`SpillArea`](https://github.com/FSM1/cipher-box/pull/1156/files#diff-8c187649a923f505b0b5897190930f7ba9180f3c344d2cf0a43322a40262886e) and `SpillFile` to manage a per-account spill directory with per-handle XChaCha20-Poly1305 AEAD encryption; keys are in-memory only and files are swept on mount open.
> - Extends [`OperationCore`](https://github.com/FSM1/cipher-box/pull/1156/files#diff-834a07934f65af6c3242ecfb2a1fa631b663a231047220640bcf5ee2202706ac) with `write`, `truncate`, `flush`, and `fsync` operations that buffer writes to spill files and commit a single `updateContent` op per handle on flush or release.
> - Partial block writes merge from the base file version; `attributes()` reports the projected size for unjournaled writes.
> - Adds `spill_dir` path utility to [`desktop-seams`](https://github.com/FSM1/cipher-box/pull/1156/files#diff-61b2f3a6bf857bd9c1b1882be8e2cfd93da0af7bd9f599b3e0e08112c51d2909) and promotes `cipherbox-core` to a runtime dependency of the fuse crate.
> - Risk: `release` is now async; callers must be updated accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ace6f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added encrypted, per-handle spill storage for pending file changes.
  * Writable files now support staged writes, reads, truncation, flushing, syncing, and release before committing changes.
  * Added support for sparse writes, zero-filled gaps, and accurate pending file sizes.
  * Spill data is automatically secured, cleaned up, and discarded when appropriate.

* **Bug Fixes**
  * Improved validation for invalid handles, offsets, sizes, and unsupported file operations.
  * Added safeguards against tampered or unavailable spill data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->