### PR TITLE
feat: give the media player a surface for a recoverable stream refusal

### DIFF
--- a/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
@@ -3,6 +3,7 @@ import {
   type EngineClient,
   type EventDescriptor,
   type MediaService,
+  type MediaStreamFailure,
   type SnapshotDescriptor,
 } from '@cipherbox/client';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -742,11 +743,18 @@ describe('the vault browser read path over the streaming pipe', () => {
   const revoked: string[] = [];
   const clicked: { href: string | null; download: string }[] = [];
   const originalClick = HTMLAnchorElement.prototype.click;
+  const streamListeners = new Set<(failure: MediaStreamFailure) => void>();
+
+  /** Stands in for the broker giving up on a read, which is always tab-side. */
+  const reportStreamError = (failure: MediaStreamFailure): void => {
+    for (const listener of streamListeners) listener(failure);
+  };
 
   beforeEach(() => {
     minted.length = 0;
     revoked.length = 0;
     clicked.length = 0;
+    streamListeners.clear();
     mediaControl.create = () =>
       ({
         streaming: true,
@@ -755,6 +763,10 @@ describe('the vault browser read path over the streaming pipe', () => {
         createStreamUrl: (source: { node: Uint8Array; size: number; mimeType: string }) => {
           minted.push(source);
           return `/stream/ticket-${minted.length}`;
+        },
+        onStreamError: (listener: (failure: MediaStreamFailure) => void) => {
+          streamListeners.add(listener);
+          return () => streamListeners.delete(listener);
         },
         revokeStreamUrl: (url: string) => {
           revoked.push(url);
@@ -830,6 +842,94 @@ describe('the vault browser read path over the streaming pipe', () => {
 
     await waitFor(() => expect(screen.getByTestId('preview-image')).toBeDefined());
     expect(engine.facade.download).not.toHaveBeenCalled();
+  });
+
+  it('plays a video off a ticket and never buffers it', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(
+      engine,
+      folderView({ children: [file(PICTURE, 'clip.mp4', { size: 64n * 1024n * 1024n })] })
+    );
+
+    openRowMenu('clip.mp4');
+    chooseMenuItem('preview');
+
+    const player = await screen.findByTestId('media-player-video');
+    expect(player.getAttribute('src')).toBe('/stream/ticket-1');
+    expect(minted[0].mimeType).toBe('video/mp4');
+    expect(engine.facade.download).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByLabelText('close'));
+    await waitFor(() => expect(revoked).toEqual(['/stream/ticket-1']));
+  });
+
+  it('offers a retry for a ceiling refusal and a bare failure for a fault', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+
+    openRowMenu('song.mp3');
+    chooseMenuItem('preview');
+    await screen.findByTestId('media-player-audio');
+
+    act(() => {
+      reportStreamError({
+        url: '/stream/ticket-1',
+        message: 'too many read streams are already open',
+        recoverable: true,
+      });
+    });
+    expect(screen.getByTestId('media-player-error').textContent).toContain(
+      'too many streams are open right now'
+    );
+
+    // The ticket is still live, so a retry is a fresh read of the same URL.
+    fireEvent.click(screen.getByTestId('media-player-retry'));
+    expect(screen.queryByTestId('media-player-error')).toBeNull();
+    expect(revoked).toEqual([]);
+    expect(screen.getByTestId('media-player-audio').getAttribute('src')).toBe('/stream/ticket-1');
+
+    act(() => {
+      reportStreamError({
+        url: '/stream/ticket-1',
+        message: 'the adoption gate refused the record',
+        recoverable: false,
+      });
+    });
+    expect(screen.getByTestId('media-player-error').textContent).toBe(
+      'the adoption gate refused the record'
+    );
+    expect(screen.queryByTestId('media-player-retry')).toBeNull();
+  });
+
+  it('ignores a refusal on another tab-mate stream', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+
+    openRowMenu('song.mp3');
+    chooseMenuItem('preview');
+    await screen.findByTestId('media-player-audio');
+
+    act(() => {
+      reportStreamError({ url: '/stream/ticket-9', message: 'not mine', recoverable: true });
+    });
+
+    expect(screen.queryByTestId('media-player-error')).toBeNull();
+  });
+
+  it('reports a playback failure the pipe never named', async () => {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+
+    openRowMenu('song.mp3');
+    chooseMenuItem('preview');
+    fireEvent.error(await screen.findByTestId('media-player-audio'));
+
+    expect(screen.getByTestId('media-player-error').textContent).toBe('playback failed');
+    expect(screen.queryByTestId('media-player-retry')).toBeNull();
   });
 
   it('buffers a pdf, which the pipe would serve under an opaque type', async () => {

--- a/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
+++ b/apps/web/src/components/file-browser/FileBrowserActions.test.tsx
@@ -745,10 +745,23 @@ describe('the vault browser read path over the streaming pipe', () => {
   const originalClick = HTMLAnchorElement.prototype.click;
   const streamListeners = new Set<(failure: MediaStreamFailure) => void>();
 
-  /** Stands in for the broker giving up on a read, which is always tab-side. */
+  /** Stands in for the broker giving up on a read. */
   const reportStreamError = (failure: MediaStreamFailure): void => {
-    for (const listener of streamListeners) listener(failure);
+    act(() => {
+      for (const listener of streamListeners) listener(failure);
+    });
   };
+
+  /** Opens the preview of one audio file and waits for the player. */
+  async function playAudio(): Promise<void> {
+    const engine = fakeEngine();
+    renderBrowser(engine);
+    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+
+    openRowMenu('song.mp3');
+    chooseMenuItem('preview');
+    await screen.findByTestId('media-player-audio');
+  }
 
   beforeEach(() => {
     minted.length = 0;
@@ -865,37 +878,27 @@ describe('the vault browser read path over the streaming pipe', () => {
   });
 
   it('offers a retry for a ceiling refusal and a bare failure for a fault', async () => {
-    const engine = fakeEngine();
-    renderBrowser(engine);
-    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+    await playAudio();
 
-    openRowMenu('song.mp3');
-    chooseMenuItem('preview');
-    await screen.findByTestId('media-player-audio');
-
-    act(() => {
-      reportStreamError({
-        url: '/stream/ticket-1',
-        message: 'too many read streams are already open',
-        recoverable: true,
-      });
+    reportStreamError({
+      url: '/stream/ticket-1',
+      message: 'too many read streams are already open',
+      recoverable: true,
     });
     expect(screen.getByTestId('media-player-error').textContent).toContain(
       'too many streams are open right now'
     );
 
-    // The ticket is still live, so a retry is a fresh read of the same URL.
     fireEvent.click(screen.getByTestId('media-player-retry'));
     expect(screen.queryByTestId('media-player-error')).toBeNull();
+    // The pipe refused a read; it did not withdraw the capability.
     expect(revoked).toEqual([]);
     expect(screen.getByTestId('media-player-audio').getAttribute('src')).toBe('/stream/ticket-1');
 
-    act(() => {
-      reportStreamError({
-        url: '/stream/ticket-1',
-        message: 'the adoption gate refused the record',
-        recoverable: false,
-      });
+    reportStreamError({
+      url: '/stream/ticket-1',
+      message: 'the adoption gate refused the record',
+      recoverable: false,
     });
     expect(screen.getByTestId('media-player-error').textContent).toBe(
       'the adoption gate refused the record'
@@ -903,30 +906,18 @@ describe('the vault browser read path over the streaming pipe', () => {
     expect(screen.queryByTestId('media-player-retry')).toBeNull();
   });
 
-  it('ignores a refusal on another tab-mate stream', async () => {
-    const engine = fakeEngine();
-    renderBrowser(engine);
-    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+  it('ignores a refusal reported for another stream', async () => {
+    await playAudio();
 
-    openRowMenu('song.mp3');
-    chooseMenuItem('preview');
-    await screen.findByTestId('media-player-audio');
-
-    act(() => {
-      reportStreamError({ url: '/stream/ticket-9', message: 'not mine', recoverable: true });
-    });
+    reportStreamError({ url: '/stream/ticket-9', message: 'not mine', recoverable: true });
 
     expect(screen.queryByTestId('media-player-error')).toBeNull();
   });
 
   it('reports a playback failure the pipe never named', async () => {
-    const engine = fakeEngine();
-    renderBrowser(engine);
-    await landSnapshot(engine, folderView({ children: [file(NOTE, 'song.mp3')] }));
+    await playAudio();
 
-    openRowMenu('song.mp3');
-    chooseMenuItem('preview');
-    fireEvent.error(await screen.findByTestId('media-player-audio'));
+    fireEvent.error(screen.getByTestId('media-player-audio'));
 
     expect(screen.getByTestId('media-player-error').textContent).toBe('playback failed');
     expect(screen.queryByTestId('media-player-retry')).toBeNull();

--- a/apps/web/src/components/file-browser/FilePreviewDialog.tsx
+++ b/apps/web/src/components/file-browser/FilePreviewDialog.tsx
@@ -1,6 +1,7 @@
 import { useFilePreview, type FilePreview } from '../../hooks/useFilePreview';
 import type { ListingRow } from '../../vault/listing';
 import { Modal } from '../ui/Modal';
+import { MediaPlayer } from './MediaPlayer';
 
 interface FilePreviewDialogProps {
   row: ListingRow;
@@ -44,6 +45,9 @@ function PreviewContent({ preview, name }: { preview: FilePreview; name: string 
         {preview.message}
       </p>
     );
+  }
+  if (preview.status === 'audio' || preview.status === 'video') {
+    return <MediaPlayer url={preview.url} kind={preview.status} name={name} />;
   }
   if (preview.status === 'image') {
     return (

--- a/apps/web/src/components/file-browser/MediaPlayer.tsx
+++ b/apps/web/src/components/file-browser/MediaPlayer.tsx
@@ -1,0 +1,86 @@
+/**
+ * Playback over a stream ticket. A body the pipe errors reaches the element as
+ * an untyped network failure, so the reason comes from the engine code the
+ * media service reports, not from the element's own `error` event.
+ */
+
+import { useEffect, useState } from 'react';
+import type { MediaStreamFailure } from '@cipherbox/client';
+import { useMediaService } from '../../providers/EngineProvider';
+
+interface MediaPlayerProps {
+  url: string;
+  kind: 'audio' | 'video';
+  name: string;
+}
+
+/**
+ * What the player has to say about a stream that stopped. `recoverable` is a
+ * ceiling the engine expects a later read to clear, so it carries a retry.
+ */
+type Refusal = { kind: 'recoverable' | 'fault'; message: string };
+
+const CEILING_NOTICE = 'too many streams are open right now';
+
+const FAULT_NOTICE = 'playback failed';
+
+export function MediaPlayer({ url, kind, name }: MediaPlayerProps) {
+  const media = useMediaService();
+  const [refusal, setRefusal] = useState<Refusal | null>(null);
+  // A retry remounts the element rather than reusing one the browser has given
+  // up on. The ticket is still live: the pipe refused a read, it did not
+  // withdraw the capability.
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    if (media === null) return;
+    return media.onStreamError((failure: MediaStreamFailure) => {
+      if (failure.url !== url) return;
+      setRefusal(
+        failure.recoverable
+          ? { kind: 'recoverable', message: CEILING_NOTICE }
+          : { kind: 'fault', message: failure.message }
+      );
+    });
+  }, [media, url]);
+
+  const props = {
+    className: `media-player-${kind}`,
+    src: url,
+    controls: true,
+    preload: 'metadata' as const,
+    'aria-label': name,
+    'data-testid': `media-player-${kind}`,
+    // The element reports a failure the pipe never named — an unsupported
+    // container, a decode refusal — with no code to classify it by.
+    onError: () => setRefusal((held) => held ?? { kind: 'fault', message: FAULT_NOTICE }),
+  };
+
+  return (
+    <div className="media-player" data-testid="media-player">
+      {kind === 'video' ? <video key={attempt} {...props} /> : <audio key={attempt} {...props} />}
+      {refusal !== null && (
+        <p
+          className={`media-player-notice media-player-notice--${refusal.kind}`}
+          role="alert"
+          data-testid="media-player-error"
+        >
+          {refusal.message}
+          {refusal.kind === 'recoverable' && (
+            <button
+              type="button"
+              className="dialog-button"
+              onClick={() => {
+                setRefusal(null);
+                setAttempt((run) => run + 1);
+              }}
+              data-testid="media-player-retry"
+            >
+              retry
+            </button>
+          )}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/file-browser/MediaPlayer.tsx
+++ b/apps/web/src/components/file-browser/MediaPlayer.tsx
@@ -1,9 +1,3 @@
-/**
- * Playback over a stream ticket. A body the pipe errors reaches the element as
- * an untyped network failure, so the reason comes from the engine code the
- * media service reports, not from the element's own `error` event.
- */
-
 import { useEffect, useState } from 'react';
 import type { MediaStreamFailure } from '@cipherbox/client';
 import { useMediaService } from '../../providers/EngineProvider';
@@ -14,33 +8,27 @@ interface MediaPlayerProps {
   name: string;
 }
 
-/**
- * What the player has to say about a stream that stopped. `recoverable` is a
- * ceiling the engine expects a later read to clear, so it carries a retry.
- */
-type Refusal = { kind: 'recoverable' | 'fault'; message: string };
+type Refusal = { recoverable: boolean; message: string };
 
 const CEILING_NOTICE = 'too many streams are open right now';
 
 const FAULT_NOTICE = 'playback failed';
 
+/** Playback over a stream ticket, with what stopped it when something does. */
 export function MediaPlayer({ url, kind, name }: MediaPlayerProps) {
   const media = useMediaService();
   const [refusal, setRefusal] = useState<Refusal | null>(null);
-  // A retry remounts the element rather than reusing one the browser has given
-  // up on. The ticket is still live: the pipe refused a read, it did not
-  // withdraw the capability.
+  // The browser will not re-read a src it has given up on; only a remount will.
   const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
     if (media === null) return;
     return media.onStreamError((failure: MediaStreamFailure) => {
       if (failure.url !== url) return;
-      setRefusal(
-        failure.recoverable
-          ? { kind: 'recoverable', message: CEILING_NOTICE }
-          : { kind: 'fault', message: failure.message }
-      );
+      setRefusal({
+        recoverable: failure.recoverable,
+        message: failure.recoverable ? CEILING_NOTICE : failure.message,
+      });
     });
   }, [media, url]);
 
@@ -51,34 +39,36 @@ export function MediaPlayer({ url, kind, name }: MediaPlayerProps) {
     preload: 'metadata' as const,
     'aria-label': name,
     'data-testid': `media-player-${kind}`,
-    // The element reports a failure the pipe never named — an unsupported
-    // container, a decode refusal — with no code to classify it by.
-    onError: () => setRefusal((held) => held ?? { kind: 'fault', message: FAULT_NOTICE }),
+    // A named reason from the pipe outranks the element's unclassifiable one.
+    onError: () => setRefusal((held) => held ?? { recoverable: false, message: FAULT_NOTICE }),
   };
 
   return (
     <div className="media-player" data-testid="media-player">
       {kind === 'video' ? <video key={attempt} {...props} /> : <audio key={attempt} {...props} />}
-      {refusal !== null && (
+      {refusal?.recoverable === true && (
+        <div className="file-browser-notice" role="status" data-testid="media-player-error">
+          <span className="file-browser-notice-message">{refusal.message}</span>
+          <button
+            type="button"
+            className="file-browser-notice-retry"
+            onClick={() => {
+              setRefusal(null);
+              setAttempt((run) => run + 1);
+            }}
+            data-testid="media-player-retry"
+          >
+            [retry]
+          </button>
+        </div>
+      )}
+      {refusal?.recoverable === false && (
         <p
-          className={`media-player-notice media-player-notice--${refusal.kind}`}
+          className="preview-status preview-status--error"
           role="alert"
           data-testid="media-player-error"
         >
           {refusal.message}
-          {refusal.kind === 'recoverable' && (
-            <button
-              type="button"
-              className="dialog-button"
-              onClick={() => {
-                setRefusal(null);
-                setAttempt((run) => run + 1);
-              }}
-              data-testid="media-player-retry"
-            >
-              retry
-            </button>
-          )}
         </p>
       )}
     </div>

--- a/apps/web/src/hooks/useFilePreview.ts
+++ b/apps/web/src/hooks/useFilePreview.ts
@@ -1,8 +1,8 @@
 /**
- * One file's plaintext, held only while its preview is on screen. An image is
- * pulled range by range through the Service Worker byte pipe, so nothing of it
- * is held in the tab; the shapes that must be decoded whole read through the
- * facade under a byte budget, and every URL is dropped on close.
+ * One file's plaintext, held only while its preview is on screen. Playback and
+ * images are pulled range by range through the Service Worker byte pipe, so
+ * nothing of them is held in the tab; the shapes that must be decoded whole read
+ * through the facade under a byte budget, and every URL is dropped on close.
  */
 
 import { useEffect, useState } from 'react';
@@ -10,19 +10,24 @@ import { fromHex } from '@cipherbox/client';
 import { errorMessage } from '../lib/errorMessage';
 import { streamTicket } from '../lib/streamTicket';
 import { useEngine, useMediaService } from '../providers/EngineProvider';
-import { previewKind, previewMime, type PreviewKind } from '../vault/previewKind';
+import { previewKind, previewMime } from '../vault/previewKind';
 
 /** What a preview may pull into the tab: a memory ceiling, and a decode budget. */
 const MAX_BUFFERED_BYTES = 32n * 1024n * 1024n;
 
 const TOO_LARGE = 'too large to preview - download it instead';
 
+const NEEDS_PIPE = 'playback needs the streaming pipe - download it instead';
+
 export type FilePreview =
   | { status: 'loading' }
   | { status: 'error'; message: string }
   | { status: 'image'; url: string }
   | { status: 'pdf'; url: string }
-  | { status: 'text'; text: string };
+  | { status: 'text'; text: string }
+  /** A ticket URL the player reads range by range; never a buffered blob. */
+  | { status: 'audio'; url: string }
+  | { status: 'video'; url: string };
 
 /**
  * @param key the file's node id as lowercase hex, so the read keys on a value
@@ -52,8 +57,22 @@ export function useFilePreview(key: string, name: string, size: bigint | null): 
     }
 
     const node = fromHex(key);
-    // The pipe declares media types only, and an image is the one preview shape
-    // that is one (packages/client/src/media/range.ts `safeMimeType`).
+    // Playback is a seek-driven ranged read; buffering the whole file into the
+    // tab is exactly what the pipe exists to avoid, so there is no fallback.
+    if (kind === 'audio' || kind === 'video') {
+      const ticket = streamTicket(media, node, size, previewMime(name));
+      if (ticket === null) {
+        setPreview({ status: 'error', message: NEEDS_PIPE });
+        return;
+      }
+      setPreview({ status: kind, url: ticket });
+      return () => {
+        media?.revokeStreamUrl(ticket);
+      };
+    }
+
+    // The pipe declares media types only, and an image is the one buffered
+    // preview shape that is one (packages/client/src/media/range.ts `safeMimeType`).
     if (kind === 'image') {
       const ticket = streamTicket(media, node, size, previewMime(name));
       if (ticket !== null) {
@@ -99,7 +118,7 @@ export function useFilePreview(key: string, name: string, size: bigint | null): 
   return preview;
 }
 
-function render(kind: Exclude<PreviewKind, 'none'>, bytes: ArrayBuffer, name: string): FilePreview {
+function render(kind: 'image' | 'pdf' | 'text', bytes: ArrayBuffer, name: string): FilePreview {
   if (kind === 'text') {
     try {
       return { status: 'text', text: new TextDecoder('utf-8', { fatal: true }).decode(bytes) };

--- a/apps/web/src/hooks/useFilePreview.ts
+++ b/apps/web/src/hooks/useFilePreview.ts
@@ -25,7 +25,6 @@ export type FilePreview =
   | { status: 'image'; url: string }
   | { status: 'pdf'; url: string }
   | { status: 'text'; text: string }
-  /** A ticket URL the player reads range by range; never a buffered blob. */
   | { status: 'audio'; url: string }
   | { status: 'video'; url: string };
 
@@ -57,29 +56,21 @@ export function useFilePreview(key: string, name: string, size: bigint | null): 
     }
 
     const node = fromHex(key);
-    // Playback is a seek-driven ranged read; buffering the whole file into the
-    // tab is exactly what the pipe exists to avoid, so there is no fallback.
-    if (kind === 'audio' || kind === 'video') {
-      const ticket = streamTicket(media, node, size, previewMime(name));
-      if (ticket === null) {
-        setPreview({ status: 'error', message: NEEDS_PIPE });
-        return;
-      }
-      setPreview({ status: kind, url: ticket });
-      return () => {
-        media?.revokeStreamUrl(ticket);
-      };
-    }
-
-    // The pipe declares media types only, and an image is the one buffered
-    // preview shape that is one (packages/client/src/media/range.ts `safeMimeType`).
-    if (kind === 'image') {
+    // The pipe declares media types only, so these are the shapes it can serve
+    // (packages/client/src/media/range.ts `safeMimeType`).
+    if (kind === 'image' || kind === 'audio' || kind === 'video') {
       const ticket = streamTicket(media, node, size, previewMime(name));
       if (ticket !== null) {
-        setPreview({ status: 'image', url: ticket });
+        setPreview({ status: kind, url: ticket });
         return () => {
           media?.revokeStreamUrl(ticket);
         };
+      }
+      // Playback is a seek-driven ranged read; only an image is small enough to
+      // fall back to a buffered one.
+      if (kind !== 'image') {
+        setPreview({ status: 'error', message: NEEDS_PIPE });
+        return;
       }
     }
 

--- a/apps/web/src/styles/dialogs.css
+++ b/apps/web/src/styles/dialogs.css
@@ -306,6 +306,41 @@
   object-fit: contain;
 }
 
+.media-player {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  width: 100%;
+  align-items: center;
+}
+
+.media-player-video {
+  max-width: 100%;
+  max-height: 60vh;
+  background-color: var(--color-background);
+}
+
+.media-player-audio {
+  width: 100%;
+}
+
+.media-player-notice {
+  display: flex;
+  gap: var(--spacing-xs);
+  align-items: center;
+  margin: 0;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+}
+
+.media-player-notice--recoverable {
+  color: var(--color-text-secondary);
+}
+
+.media-player-notice--fault {
+  color: var(--color-error);
+}
+
 .preview-pdf {
   width: 100%;
   height: 60vh;

--- a/apps/web/src/styles/dialogs.css
+++ b/apps/web/src/styles/dialogs.css
@@ -324,23 +324,6 @@
   width: 100%;
 }
 
-.media-player-notice {
-  display: flex;
-  gap: var(--spacing-xs);
-  align-items: center;
-  margin: 0;
-  font-family: var(--font-family-mono);
-  font-size: var(--font-size-sm);
-}
-
-.media-player-notice--recoverable {
-  color: var(--color-text-secondary);
-}
-
-.media-player-notice--fault {
-  color: var(--color-error);
-}
-
 .preview-pdf {
   width: 100%;
   height: 60vh;

--- a/apps/web/src/vault/previewKind.ts
+++ b/apps/web/src/vault/previewKind.ts
@@ -5,7 +5,7 @@
  * document (a blob URL inherits this origin).
  */
 
-export type PreviewKind = 'image' | 'pdf' | 'text' | 'none';
+export type PreviewKind = 'image' | 'pdf' | 'text' | 'audio' | 'video' | 'none';
 
 /** Blobs the preview builds are typed from here, so nothing else can be. */
 const PREVIEWABLE: Record<string, { kind: PreviewKind; mime: string }> = {
@@ -17,6 +17,15 @@ const PREVIEWABLE: Record<string, { kind: PreviewKind; mime: string }> = {
   bmp: { kind: 'image', mime: 'image/bmp' },
   avif: { kind: 'image', mime: 'image/avif' },
   pdf: { kind: 'pdf', mime: 'application/pdf' },
+  mp4: { kind: 'video', mime: 'video/mp4' },
+  m4v: { kind: 'video', mime: 'video/mp4' },
+  webm: { kind: 'video', mime: 'video/webm' },
+  ogv: { kind: 'video', mime: 'video/ogg' },
+  mp3: { kind: 'audio', mime: 'audio/mpeg' },
+  m4a: { kind: 'audio', mime: 'audio/mp4' },
+  wav: { kind: 'audio', mime: 'audio/wav' },
+  flac: { kind: 'audio', mime: 'audio/flac' },
+  oga: { kind: 'audio', mime: 'audio/ogg' },
   txt: { kind: 'text', mime: 'text/plain' },
   md: { kind: 'text', mime: 'text/plain' },
   json: { kind: 'text', mime: 'text/plain' },

--- a/packages/client/src/correlatedTransport.ts
+++ b/packages/client/src/correlatedTransport.ts
@@ -76,7 +76,7 @@ export function unknownHandle(kind: HandleKind): EngineRequestError {
  * Delivers one event to every listener, isolating a throwing subscriber so it
  * cannot drop the event for the rest.
  */
-export function fanOut(listeners: Iterable<EngineEventListener>, event: EventDescriptor): void {
+export function fanOut<TEvent>(listeners: Iterable<(event: TEvent) => void>, event: TEvent): void {
   for (const listener of listeners) {
     try {
       listener(event);

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -36,6 +36,7 @@ export type { PortCourier, MessagePortLike } from './portRelay.js';
 
 // The tab side of the Service Worker byte pipe.
 export { MediaService } from './media/service.js';
+export type { MediaStreamFailure } from './media/service.js';
 export type { MediaReader } from './media/broker.js';
 
 // The one hex codec in TypeScript, for hosts that receive hex-encoded bytes

--- a/packages/client/src/media/broker.ts
+++ b/packages/client/src/media/broker.ts
@@ -21,11 +21,25 @@ export interface MediaReader {
  */
 const DEFAULT_PIN_LINGER_MS = 5000;
 
+/**
+ * A read this broker gave up on. The engine's code rides along because a
+ * ceiling refusal a later read can clear is not a fault, and a message string
+ * is not a classification.
+ */
+export interface MediaFailure {
+  readonly ticket: string;
+  /** `null` where the failure did not come from the engine. */
+  readonly code: string | null;
+  readonly message: string;
+}
+
 export interface MediaBrokerOptions {
   /** The plaintext window read per pull. */
   windowBytes?: number;
   /** How long a ticket's engine stream outlives its last cursor. */
   lingerMs?: number;
+  /** Told about every read this broker ends with an error. */
+  onFailure?: (failure: MediaFailure) => void;
 }
 
 /**
@@ -69,6 +83,7 @@ export class MediaBroker {
   private readonly pins = new Map<string, Pin>();
   private readonly windowBytes: number;
   private readonly lingerMs: number;
+  private readonly onFailure: ((failure: MediaFailure) => void) | null;
   private port: MessagePortLike | null = null;
   private listener: ((event: MessageEvent) => void) | null = null;
 
@@ -79,6 +94,7 @@ export class MediaBroker {
   ) {
     this.windowBytes = options.windowBytes ?? MEDIA_WINDOW_BYTES;
     this.lingerMs = options.lingerMs ?? DEFAULT_PIN_LINGER_MS;
+    this.onFailure = options.onFailure ?? null;
   }
 
   /** The pipe carries one port; a fresh offer supersedes the port it replaces. */
@@ -358,7 +374,11 @@ export class MediaBroker {
   private fail(port: MessagePortLike, requestId: number, cursor: Cursor, error: unknown): void {
     if (!this.isCurrent(requestId, cursor)) return;
     this.drop(requestId);
-    post(port, { type: 'cb:media:error', requestId, message: errorMessage(error) });
+    const message = errorMessage(error);
+    post(port, { type: 'cb:media:error', requestId, message });
+    // The body error the Service Worker raises reaches the media element as a
+    // bare network failure, so the reason has to travel tab-side instead.
+    this.onFailure?.({ ticket: cursor.ticket, code: engineErrorCode(error) ?? null, message });
   }
 }
 

--- a/packages/client/src/media/broker.ts
+++ b/packages/client/src/media/broker.ts
@@ -21,16 +21,12 @@ export interface MediaReader {
  */
 const DEFAULT_PIN_LINGER_MS = 5000;
 
-/**
- * A read this broker gave up on. The engine's code rides along because a
- * ceiling refusal a later read can clear is not a fault, and a message string
- * is not a classification.
- */
+/** A read this broker gave up on, classified by the engine's code. */
 export interface MediaFailure {
   readonly ticket: string;
-  /** `null` where the failure did not come from the engine. */
-  readonly code: string | null;
   readonly message: string;
+  /** See {@link isRecoverableEngineError}. */
+  readonly recoverable: boolean;
 }
 
 export interface MediaBrokerOptions {
@@ -376,9 +372,11 @@ export class MediaBroker {
     this.drop(requestId);
     const message = errorMessage(error);
     post(port, { type: 'cb:media:error', requestId, message });
-    // The body error the Service Worker raises reaches the media element as a
-    // bare network failure, so the reason has to travel tab-side instead.
-    this.onFailure?.({ ticket: cursor.ticket, code: engineErrorCode(error) ?? null, message });
+    this.onFailure?.({
+      ticket: cursor.ticket,
+      message,
+      recoverable: isRecoverableEngineError(engineErrorCode(error)),
+    });
   }
 }
 

--- a/packages/client/src/media/registry.ts
+++ b/packages/client/src/media/registry.ts
@@ -30,6 +30,11 @@ export class StreamRegistry {
     // another's head.
     if (this.sources.has(ticket)) throw new Error('a stream ticket must be minted once');
     this.sources.set(ticket, source);
+    return this.urlFor(ticket);
+  }
+
+  /** The URL a media element requests for `ticket`, live or not. */
+  urlFor(ticket: string): string {
     return `${STREAM_PATH_PREFIX}${ticket}`;
   }
 

--- a/packages/client/src/media/service.test.ts
+++ b/packages/client/src/media/service.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from 'vitest';
 import { EngineRequestError } from '../correlatedTransport.js';
 import { FakePort } from '../sw/testDoubles.js';
 import type { MediaReader } from './broker.js';
-import { MEDIA_PORT_OFFER, MEDIA_PORT_REQUEST, type MediaResponse } from './protocol.js';
+import {
+  MEDIA_PORT_OFFER,
+  MEDIA_PORT_REQUEST,
+  STREAM_PATH_PREFIX,
+  type MediaResponse,
+} from './protocol.js';
 import {
   MediaService,
   type MediaStreamFailure,
@@ -251,9 +256,8 @@ describe('MediaService', () => {
       new EngineRequestError('the adoption gate refused the record', 'trustViolation'),
     ];
     const { container, worker, service, channels } = setup({
+      ...reader,
       openContentStream: () => Promise.reject(refusals.shift() ?? new Error('spent')),
-      readStream: (_handle, _offset, length) => Promise.resolve(new ArrayBuffer(length)),
-      closeStream: () => Promise.resolve(),
     });
     container.controller = worker;
     await service.start();
@@ -270,7 +274,7 @@ describe('MediaService', () => {
       port.postMessage({
         type: 'cb:media:open',
         requestId,
-        ticket: url.slice('/stream/'.length),
+        ticket: url.slice(STREAM_PATH_PREFIX.length),
         range: null,
       });
       port.postMessage({ type: 'cb:media:pull', requestId });
@@ -283,8 +287,6 @@ describe('MediaService', () => {
     stop();
     await read(3);
 
-    // A ceiling is not a verdict: only one of these is worth trying again, and
-    // the difference is the engine's code, not the wording.
     expect(seen).toEqual([
       { url: ceiling, message: 'too many read streams are already open', recoverable: true },
       { url: verdict, message: 'the adoption gate refused the record', recoverable: false },

--- a/packages/client/src/media/service.test.ts
+++ b/packages/client/src/media/service.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import { EngineRequestError } from '../correlatedTransport.js';
 import { FakePort } from '../sw/testDoubles.js';
 import type { MediaReader } from './broker.js';
 import { MEDIA_PORT_OFFER, MEDIA_PORT_REQUEST, type MediaResponse } from './protocol.js';
 import {
   MediaService,
+  type MediaStreamFailure,
   type ServiceWorkerContainerLike,
   type ServiceWorkerLike,
   type ServiceWorkerRegistrationLike,
@@ -241,6 +243,52 @@ describe('MediaService', () => {
 
     expect(closed).toEqual([7n]);
     expect(channels).toHaveLength(2);
+  });
+
+  it('classifies a refused read for the holder of the url it refused on', async () => {
+    const refusals = [
+      new EngineRequestError('too many read streams are already open', 'tooManyStreams'),
+      new EngineRequestError('the adoption gate refused the record', 'trustViolation'),
+    ];
+    const { container, worker, service, channels } = setup({
+      openContentStream: () => Promise.reject(refusals.shift() ?? new Error('spent')),
+      readStream: (_handle, _offset, length) => Promise.resolve(new ArrayBuffer(length)),
+      closeStream: () => Promise.resolve(),
+    });
+    container.controller = worker;
+    await service.start();
+
+    const seen: MediaStreamFailure[] = [];
+    const stop = service.onStreamError((failure) => seen.push(failure));
+    const read = async (requestId: number): Promise<string> => {
+      const url = service.createStreamUrl({
+        node: new Uint8Array([9]),
+        size: 8,
+        mimeType: 'audio/o',
+      });
+      const port = channels[0].port2;
+      port.postMessage({
+        type: 'cb:media:open',
+        requestId,
+        ticket: url.slice('/stream/'.length),
+        range: null,
+      });
+      port.postMessage({ type: 'cb:media:pull', requestId });
+      await settled();
+      return url;
+    };
+
+    const ceiling = await read(1);
+    const verdict = await read(2);
+    stop();
+    await read(3);
+
+    // A ceiling is not a verdict: only one of these is worth trying again, and
+    // the difference is the engine's code, not the wording.
+    expect(seen).toEqual([
+      { url: ceiling, message: 'too many read streams are already open', recoverable: true },
+      { url: verdict, message: 'the adoption gate refused the record', recoverable: false },
+    ]);
   });
 
   it('ignores an unrelated message from the worker', async () => {

--- a/packages/client/src/media/service.ts
+++ b/packages/client/src/media/service.ts
@@ -4,14 +4,28 @@
  * ticket URLs the UI hands to a media element.
  */
 
-import { MediaBroker, type MediaReader } from './broker.js';
+import { isRecoverableEngineError } from '../correlatedTransport.js';
+import { MediaBroker, type MediaFailure, type MediaReader } from './broker.js';
 import {
   MEDIA_PORT_OFFER,
   MEDIA_PORT_REQUEST,
+  STREAM_PATH_PREFIX,
   ticketFromUrl,
   type MediaPortOffer,
 } from './protocol.js';
 import { StreamRegistry, type MediaSource } from './registry.js';
+
+/** A stream that stopped, told to whoever holds the URL it stopped on. */
+export interface MediaStreamFailure {
+  /** The URL `createStreamUrl` returned, so a holder can match its own. */
+  readonly url: string;
+  readonly message: string;
+  /**
+   * The engine refused over a ceiling a later read can clear rather than over a
+   * verdict, so the same request is worth making again.
+   */
+  readonly recoverable: boolean;
+}
 
 /** The `ServiceWorker` surface the offer needs. */
 export interface ServiceWorkerLike {
@@ -55,6 +69,7 @@ export class MediaService {
   private readonly broker: MediaBroker;
   private readonly origin: string;
   private readonly createChannel: () => MessageChannel;
+  private readonly failureListeners = new Set<(failure: MediaStreamFailure) => void>();
   private registration: ServiceWorkerRegistrationLike | null = null;
   private channel: MessageChannel | null = null;
   private startup: Promise<void> | null = null;
@@ -63,8 +78,31 @@ export class MediaService {
   constructor(private readonly config: MediaServiceConfig) {
     this.origin = config.origin ?? globalThis.location.origin;
     this.registry = new StreamRegistry(this.origin);
-    this.broker = new MediaBroker(this.registry, config.reader);
+    this.broker = new MediaBroker(this.registry, config.reader, {
+      onFailure: (failure) => this.report(failure),
+    });
     this.createChannel = config.createChannel ?? ((): MessageChannel => new MessageChannel());
+  }
+
+  /**
+   * Subscribes to the streams that stop mid-read. Returns the unsubscribe.
+   *
+   * A response body that errors reaches a media element as an untyped network
+   * failure, so a player that wants to tell a ceiling refusal from a fault has
+   * to hear it here.
+   */
+  onStreamError(listener: (failure: MediaStreamFailure) => void): () => void {
+    this.failureListeners.add(listener);
+    return () => this.failureListeners.delete(listener);
+  }
+
+  private report(failure: MediaFailure): void {
+    const reported: MediaStreamFailure = {
+      url: `${STREAM_PATH_PREFIX}${failure.ticket}`,
+      message: failure.message,
+      recoverable: isRecoverableEngineError(failure.code ?? undefined),
+    };
+    for (const listener of [...this.failureListeners]) listener(reported);
   }
 
   /**
@@ -106,6 +144,7 @@ export class MediaService {
     const container = this.config.container;
     container.removeEventListener('controllerchange', this.onControllerChange);
     container.removeEventListener('message', this.onMessage);
+    this.failureListeners.clear();
     this.registry.clear();
     this.broker.close();
     this.brokerTo(null);

--- a/packages/client/src/media/service.ts
+++ b/packages/client/src/media/service.ts
@@ -4,27 +4,22 @@
  * ticket URLs the UI hands to a media element.
  */
 
-import { isRecoverableEngineError } from '../correlatedTransport.js';
+import { fanOut } from '../correlatedTransport.js';
 import { MediaBroker, type MediaFailure, type MediaReader } from './broker.js';
 import {
   MEDIA_PORT_OFFER,
   MEDIA_PORT_REQUEST,
-  STREAM_PATH_PREFIX,
   ticketFromUrl,
   type MediaPortOffer,
 } from './protocol.js';
 import { StreamRegistry, type MediaSource } from './registry.js';
 
+const noop = (): void => undefined;
+
 /** A stream that stopped, told to whoever holds the URL it stopped on. */
-export interface MediaStreamFailure {
+export interface MediaStreamFailure extends Omit<MediaFailure, 'ticket'> {
   /** The URL `createStreamUrl` returned, so a holder can match its own. */
   readonly url: string;
-  readonly message: string;
-  /**
-   * The engine refused over a ceiling a later read can clear rather than over a
-   * verdict, so the same request is worth making again.
-   */
-  readonly recoverable: boolean;
 }
 
 /** The `ServiceWorker` surface the offer needs. */
@@ -92,17 +87,13 @@ export class MediaService {
    * to hear it here.
    */
   onStreamError(listener: (failure: MediaStreamFailure) => void): () => void {
+    if (this.disposed) return noop;
     this.failureListeners.add(listener);
     return () => this.failureListeners.delete(listener);
   }
 
-  private report(failure: MediaFailure): void {
-    const reported: MediaStreamFailure = {
-      url: `${STREAM_PATH_PREFIX}${failure.ticket}`,
-      message: failure.message,
-      recoverable: isRecoverableEngineError(failure.code ?? undefined),
-    };
-    for (const listener of [...this.failureListeners]) listener(reported);
+  private report({ ticket, ...failure }: MediaFailure): void {
+    fanOut(this.failureListeners, { ...failure, url: this.registry.urlFor(ticket) });
   }
 
   /**


### PR DESCRIPTION
## What

`EngineError::TooManyStreams` is reachable only through the media pipe, and the pipe had nowhere to say so. `MediaBroker` handles the ceiling itself — it gives back the streams held only by the pin linger and retries the refused open once — but if that retry also fails, the body errors and the media element sees a bare network failure with no explanation and no affordance.

There was also no player: audio and video were not preview kinds at all, so the surface had no host.

## How the reason reaches the UI

A `ReadableStream` error on a response body reaches a media element as an untyped network failure — the code cannot ride the body out to the `<video>`. So it travels tab-side, where the broker already is:

- `MediaBroker` takes an `onFailure` seam and reports every read it gives up on as a `MediaFailure` carrying the engine's code (`engineErrorCode`), not a message string.
- `MediaService.onStreamError(listener)` classifies that with `isRecoverableEngineError` and hands the holder of the stream URL a `MediaStreamFailure` — `{ url, message, recoverable }`. It is the same classifier the vault browser already uses for a snapshot pull, so a ceiling and a verdict are told apart in exactly one place.

## The player

`MediaPlayer` renders the element over the ticket URL and subscribes to failures on that URL:

- **recoverable** — a notice plus a `retry` that remounts the element against the same ticket. The pipe refused a read; it did not withdraw the capability, so the ticket is still live and nothing is re-minted.
- **fault** — the engine's own message, terminal, no retry.
- The element's own `error` event is the floor for a failure the pipe never named (an unsupported container, a decode refusal). A classified refusal that already landed wins over it.

Audio and video join `previewKind`, streamed range by range with **no buffered fallback**: decoding a video whole into the tab is precisely what the pipe exists to avoid, and without a controlling Service Worker the preview refuses and points at download.

## Deviation from the issue

The issue expects `cb:media:error` to carry the engine's code across the port. Re-checked against the tree: that would be a dead field. The only `cb:media:error` that carries an engine code is raised by `MediaBroker.fail`, which runs **in the tab** — the same context as the player — and the round trip through the Service Worker can only lose information, because the pipe's sole action on it is to error a body whose error the media element cannot read. `MediaPipe`'s own failures ('media pull timed out', 'media port replaced') have no engine code to carry. So the code is reported tab-side and the wire is left alone.

## Gate

`packages/client/src/media/service.test.ts` drives two real refusals through the broker — `tooManyStreams` and `trustViolation` — and asserts each is reported against the URL it refused on with the right `recoverable` verdict, and that unsubscribing stops it. `FileBrowserActions.test.tsx` asserts the video plays off a ticket without a facade read, that a ceiling refusal renders a retry that keeps the ticket, that a fault does not, that another stream's refusal is ignored, and that the element's own error still reports.

## Verification

`pnpm typecheck` 0, `pnpm test` 0, `pnpm lint` 0, `pnpm lint:tracker-refs` 0. No Rust surface in this change.

Review gates: `/simplify` and `/security-review` both run on `git diff main...HEAD`. Security found nothing at or above the bar — the report carries no plaintext or key material, `safeMimeType` plus `nosniff` and the `no-store` clamp still bound what a ticket can render as, the classifier is a single-code equality so nothing widens into it, and the listener unsubscribes on unmount and on an engine rebuild. Its one nit and the `/simplify` findings are folded into the second commit: the broker classifies rather than round-tripping a raw code, the fan-out reuses `fanOut` so a throwing subscriber cannot drop the event, `onStreamError` refuses a subscription after `dispose`, `StreamRegistry` owns the ticket-URL shape, the three streamed preview branches became one, and the player reuses the vault browser's existing recoverable-refusal notice instead of a second dialect.

Runtime verification is not reachable from a unit harness — the surface needs a logged-in vault, a controlling Service Worker, and the engine at its open-stream ceiling. To check it by hand: bring up the local stack, upload an `.mp4`, open its preview, confirm playback streams over `/stream/<ticket>` with no facade `download`, then hold `MAX_OPEN_STREAMS` open from other tickets and seek — the notice with `[retry]` should appear over the player and the retry should recover once a stream frees.

Closes #1064
