### PR TITLE
chore: scope the wasm host OpId import to its test module

### DIFF
--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -19,7 +19,6 @@ use std::rc::Rc;
 
 use async_lock::{Mutex, RwLock};
 use cipherbox_engine::facade::{ApiBaseUrl, Engine, EngineError, EventStream, LoginSecret};
-use cipherbox_engine::seams::OpId;
 use cipherbox_engine::{
     ContentProfile, Entropy, EntropyError, GatewayConfig, GatewaySource, SeamSet, SeamTypes,
     StoragePlatform, StoragePolicy, StreamHandle, SyncTimingProfile, WriteHandle, WriteTarget,
@@ -499,6 +498,7 @@ mod tests {
     use cipherbox_core::suite::ecdsa::EcdsaSigner;
     use cipherbox_engine::facade::CommandOutcome as Outcome;
     use cipherbox_engine::import_contact;
+    use cipherbox_engine::seams::OpId;
     use js_sys::BigInt;
     use wasm_bindgen_test::wasm_bindgen_test;
 


### PR DESCRIPTION
`OpId` is imported at the top of `crates/wasm/src/host.rs` but used only inside the `#[cfg(test)]` module, so a non-test `wasm32` build warns on it. Moved into the test module.

## Why no gate caught it

Neither of the two Rust gates can see this warning:

- `cargo clippy --workspace --all-targets -- -D warnings` denies warnings, but `--workspace` never builds `wasm32-unknown-unknown`.
- `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` builds the right target, but without `-D warnings`.

So the warning has been live on `main` for some time. It is not introduced by any recent change — `host.rs:22` is byte-identical across the whole of wave 7.

Found while confirming that a wave-7 branch had not introduced it.

## Verification

- Before: `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` reports `warning: unused import: cipherbox_engine::seams::OpId` at `crates/wasm/src/host.rs:22`.
- After: the same command reports 0 warnings.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` both pass; clippy's `--all-targets` compiles the test module, which is what proves `OpId` still resolves there.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope `OpId` import to the test module in `host.rs`
> Moves the `cipherbox_engine::seams::OpId` import in [host.rs](https://github.com/FSM1/cipher-box/pull/1171/files#diff-9534adda6f8ba736b285170c544e60d617b2f7d2a976d687805e4ddfefbfaf93) from the top-level module into the `tests` module, where it is actually used.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 521d8ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up an unused import without changing runtime behavior.
  * Updated test-only imports to keep internal checks compiling correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->