### PR TITLE
ci: prebuild wasm-bindgen-cli and fix the web e2e smoke flake

### DIFF
--- a/.github/actions/wasm-bindgen-cli/action.yml
+++ b/.github/actions/wasm-bindgen-cli/action.yml
@@ -17,22 +17,39 @@ runs:
       # Word splitting is the point: `targets` carries a space-separated list.
       run: rustup target add ${TARGETS}
 
-    # The CLI and the locked wasm-bindgen crate share a glue schema, so a
-    # version skew fails the run; derive the version from Cargo.lock. The
-    # binary is cached in ~/.cargo/bin, where a bare `cargo install` errors
-    # "already exists": skip on an exact match, --force to overwrite a stale
-    # one. An unreadable version aborts rather than installing whatever floats.
-    - name: Install wasm-bindgen-cli matching Cargo.lock
+    # The CLI and the locked wasm-bindgen crate share a glue schema, so a version
+    # skew fails the run.
+    - name: Read the wasm-bindgen version Cargo.lock pins
+      id: locked
       shell: bash
       run: |
-        WB_VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
-        if [ -z "${WB_VERSION}" ]; then
-          echo "::error::no wasm-bindgen version found in Cargo.lock"
+        VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
+        # install-action splits its tool input on whitespace and commas, so a
+        # version carrying either would install a second, unpinned crate.
+        if ! printf '%s' "${VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "::error::unusable wasm-bindgen version in Cargo.lock: ${VERSION}"
           exit 1
         fi
-        echo "wasm-bindgen ${WB_VERSION}"
-        if [ "$(wasm-bindgen --version 2>/dev/null | awk '{print $2}')" = "${WB_VERSION}" ]; then
-          echo "wasm-bindgen-cli ${WB_VERSION} already present (cache hit); skipping install"
-        else
-          cargo install wasm-bindgen-cli --version "${WB_VERSION}" --locked --force
+        echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+    # No fallback: the default `cargo-binstall` would both want `github.token`
+    # and, on a version the pinned manifest lacks, silently trade the archive's
+    # sha256 for an unverified source build — the from-source cost this replaced.
+    # A bump ahead of the pin should fail loudly and be fixed by bumping the pin.
+    - name: Install wasm-bindgen-cli
+      uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+      with:
+        tool: wasm-bindgen-cli@${{ steps.locked.outputs.version }}
+        fallback: none
+
+    # install-action prints the installed version but asserts nothing about it.
+    - name: Verify the CLI on PATH matches Cargo.lock
+      shell: bash
+      env:
+        EXPECTED: ${{ steps.locked.outputs.version }}
+      run: |
+        ACTUAL=$(wasm-bindgen --version | awk '{print $2}')
+        if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+          echo "::error::wasm-bindgen-cli ${ACTUAL} is on PATH but Cargo.lock pins ${EXPECTED}"
+          exit 1
         fi

--- a/.github/actions/wasm-bindgen-cli/action.yml
+++ b/.github/actions/wasm-bindgen-cli/action.yml
@@ -23,7 +23,19 @@ runs:
       id: locked
       shell: bash
       run: |
-        VERSION=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
+        FOUND=$(awk '
+          /^\[\[package\]\]$/       { hit = 0 }
+          /^name = "wasm-bindgen"$/ { hit = 1; next }
+          hit && /^version = /      { gsub(/^version = "|"$/, ""); print; hit = 0 }
+        ' Cargo.lock)
+        # The PATH check below compares against this same value, so picking one
+        # of several silently would pass its own safety net.
+        COUNT=$(printf '%s' "${FOUND}" | grep -c . || true)
+        if [ "${COUNT:-0}" -ne 1 ]; then
+          echo "::error::Cargo.lock must pin exactly one wasm-bindgen package, found ${COUNT}"
+          exit 1
+        fi
+        VERSION="${FOUND}"
         # install-action splits its tool input on whitespace and commas, so a
         # version carrying either would install a second, unpinned crate.
         if ! printf '%s' "${VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.cargo/bin
             target/release
             target/wasm32-unknown-unknown
           key: wasm-engine-cargo-${{ hashFiles('Cargo.lock') }}
@@ -571,7 +570,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.cargo/bin
             target
           key: core-kats-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: core-kats-cargo-
@@ -661,7 +659,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.cargo/bin
             target
           key: client-browser-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: client-browser-cargo-

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -56,7 +56,6 @@ jobs:
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
       DB_DATABASE: cipherbox_test
-      NODE_ENV: test
       JWT_SECRET: web-e2e-jwt-secret
       # Every test cold-starts its own account from one runner IP, so the
       # per-IP auth bucket would otherwise cap how many specs can exist.
@@ -111,8 +110,13 @@ jobs:
 
       - uses: ./.github/actions/mock-ipns-routing
 
+      # `NODE_ENV` stays on the API's own steps. Vite reads it to decide whether a
+      # build is a production one, so job-wide it would hand the suite a
+      # development bundle of the app it is meant to test as it ships.
       - name: Apply migrations to a fresh database
         run: pnpm --filter @cipherbox/api migration:run
+        env:
+          NODE_ENV: test
 
       - name: Build and boot the API
         run: |
@@ -120,6 +124,8 @@ jobs:
           node apps/api/dist/main.js > /tmp/api.log 2>&1 &
           curl -fsS --retry 60 --retry-connrefused --retry-delay 1 http://localhost:3000/health \
             || { echo '--- API log ---'; cat /tmp/api.log; exit 1; }
+        env:
+          NODE_ENV: test
 
       # One engine module feeds both bundles below; only the hook flag differs
       # between them.

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -91,7 +91,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.cargo/bin
             target/release
             target/wasm32-unknown-unknown
           key: web-e2e-cargo-${{ hashFiles('Cargo.lock') }}

--- a/tests/web-e2e/fixtures.ts
+++ b/tests/web-e2e/fixtures.ts
@@ -1,0 +1,41 @@
+import { test as base } from '@playwright/test';
+
+export { expect } from '@playwright/test';
+
+/**
+ * A browser target that dies mid-test surfaces only as whatever call was in
+ * flight, and Playwright salvages no browser-side artifact from it. These taps
+ * record the browser's account while the page is alive and name the death.
+ */
+export const test = base.extend({
+  page: async ({ page }, use, testInfo) => {
+    const started = Date.now();
+    const events: string[] = [];
+    let died: string | undefined;
+
+    const record = (event: string) => events.push(`${Date.now() - started}ms ${event}`);
+
+    page.on('console', (message) => record(`console.${message.type()}: ${message.text()}`));
+    page.on('pageerror', (error) => record(`pageerror: ${error.message}`));
+    page.on('requestfailed', (request) =>
+      record(`requestfailed: ${request.url()} ${request.failure()?.errorText ?? ''}`)
+    );
+    page.on('crash', () => {
+      died ??= 'the page crashed';
+      record('crash');
+    });
+    page.on('close', () => {
+      died ??= 'the page closed';
+      record('close');
+    });
+
+    await use(page);
+
+    if (testInfo.status === testInfo.expectedStatus) return;
+    await testInfo.attach('browser-events', {
+      body: events.join('\n'),
+      contentType: 'text/plain',
+    });
+    if (died) throw new Error(`${died} during the test; the failure above is a symptom of that`);
+  },
+});

--- a/tests/web-e2e/page-objects/vault.page.ts
+++ b/tests/web-e2e/page-objects/vault.page.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from 'node:crypto';
 import { expect, type Page } from '@playwright/test';
 import type { IntrospectedView, Plain } from '@web/engine/introspection';
 import type { EventDescriptor } from '@cipherbox/client';
@@ -21,14 +20,15 @@ export class VaultPage {
    * Cold-starts a vault nobody else in the run shares and follows the app's own
    * redirect onto it. The login secret is a fresh 32-byte scalar, and the API
    * creates its account on first challenge login — so per-test isolation costs
-   * no fixture setup.
+   * no fixture setup. It is minted in the page because an `evaluate` argument is
+   * recorded verbatim in the trace this suite uploads from a public repo.
    */
   async coldStart(): Promise<void> {
-    const secret = randomBytes(32).toString('hex');
-    await this.page.evaluate(
-      (loginSecretHex) => window.__CIPHERBOX_ENGINE__!.signIn(loginSecretHex),
-      secret
-    );
+    await this.page.evaluate(async () => {
+      const secret = crypto.getRandomValues(new Uint8Array(32));
+      const hex = Array.from(secret, (byte) => byte.toString(16).padStart(2, '0')).join('');
+      await window.__CIPHERBOX_ENGINE__!.signIn(hex);
+    });
     await this.page.waitForURL('**/files');
   }
 

--- a/tests/web-e2e/playwright.config.ts
+++ b/tests/web-e2e/playwright.config.ts
@@ -37,6 +37,10 @@ export default defineConfig({
   timeout: 120_000,
   reporter: isCi ? [['list'], ['html', { open: 'never' }]] : 'list',
   use: {
+    // Chrome's own headless, not Playwright's default `chrome-headless-shell`:
+    // the shell segfaults on a page that registers a Service Worker, killing the
+    // browser under whichever assertion is in flight.
+    channel: 'chromium',
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
   },

--- a/tests/web-e2e/tests/release-bundle.spec.ts
+++ b/tests/web-e2e/tests/release-bundle.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../fixtures';
 import { LoginPage } from '../page-objects/login.page';
 
 /** The build-flag invariant, asserted on the artifact rather than on the source. */
@@ -8,4 +8,12 @@ test('the release bundle exposes no introspection hook', async ({ page }) => {
   await expect(new LoginPage(page).googleButton).toBeVisible();
 
   expect(await page.evaluate(() => '__CIPHERBOX_ENGINE__' in window)).toBe(false);
+});
+
+test('the release bundle registers the built service worker', async ({ page }) => {
+  await page.goto('/');
+
+  await expect
+    .poll(() => page.evaluate(() => navigator.serviceWorker.controller?.scriptURL ?? null))
+    .toMatch(/\/sw\.js$/);
 });

--- a/tests/web-e2e/tests/smoke.spec.ts
+++ b/tests/web-e2e/tests/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../fixtures';
 import { FilesPage } from '../page-objects/files.page';
 import { LoginPage } from '../page-objects/login.page';
 import { VaultPage } from '../page-objects/vault.page';
@@ -10,6 +10,14 @@ test('the front door offers every built login method', async ({ page }) => {
   await expect(login.googleButton).toBeVisible();
   await expect(login.emailInput).toBeVisible();
   await expect(login.walletButton).toBeVisible();
+});
+
+test('the tab comes under the app-shell service worker', async ({ page }) => {
+  await page.goto('/');
+
+  await expect
+    .poll(() => page.evaluate(() => navigator.serviceWorker.controller?.scriptURL ?? null))
+    .toMatch(/\/sw\.js$/);
 });
 
 test('an unauthenticated deep link lands on the front door', async ({ page }) => {


### PR DESCRIPTION
## wasm-bindgen-cli from a prebuilt binary

`.github/actions/wasm-bindgen-cli` built the CLI from source with `cargo install` — 104s cache-cold, in all five jobs that touch wasm, on the critical path of the producer job the wasm consumers wait on.

The allowed-actions patterns now permit `taiki-e/*`, so the composite takes the issue's preferred option 1: `taiki-e/install-action`, SHA-pinned, over upstream's checksum-verified release archive. That archive carries `wasm-bindgen-test-runner` alongside the CLI, which `Core KATs` needs. **Measured on this PR's own runs: the whole composite takes 11-16s**, against a 15s gate that previously covered a 104s install alone.

Held invariants:

- the version still derives from `Cargo.lock`, and is now required to be a bare three-part version. It becomes an install-action tool spec, and that input splits on whitespace and commas, so a version carrying either would install a second, unpinned crate from source;
- **no fallback.** The default `cargo-binstall` wants `github.token`, and on a version the pinned manifest lacks it would silently trade the archive's sha256 for an unverified source build — the from-source cost this change exists to remove. A bump ahead of the pin should fail loudly and be fixed by bumping the pin;
- a step asserts the CLI PATH resolves is the locked one. install-action prints the installed version but asserts nothing about it, and a skew would otherwise surface as a wasm-bindgen glue-schema failure several jobs downstream.

`~/.cargo/bin` leaves the four cargo cache path lists — it held only the from-source build, and the archive installs to its own directory.

Closes #1152

## The smoke slice flake

### It is not a first-paint race

`page.goto('/')` completed cleanly in both archived failures (609ms and 595ms, `waitUntil: load`) and the next call died about a second later. The `toBeVisible` failure **aborted** at 1321ms against a call log announcing a 5000ms timeout, so no larger timeout could have saved it. The sign-out failure died inside `page.waitForFunction` — which **is** a readiness wait, so adding one would not have helped either. Playwright salvaged no page snapshot, no screenshot and no browser-side trace from either.

### Root cause

**The browser segfaults.** With `DEBUG=pw:browser` on a probe run:

```
[pid=9576][err] Received signal 11 SEGV_MAPERR 0000000001b0
```

Playwright's default `chrome-headless-shell` is a separate binary from Chrome, and it faults on a page that registers a Service Worker. Whichever call is in flight when the browser dies reports the failure — which is why the same `googleButton` locator passes in one test and fails in another in the same run.

### Evidence

I could not reproduce this locally — 16 clean runs, then 200 executions at `--workers=2` with the box CPU-saturated, all green. So I probed the real environment on throwaway branches at `--repeat-each=25`, three runs of 125 executions each:

| probe | runs failed |
| --- | --- |
| unchanged | **2 of 3** |
| after the `NODE_ENV` fix below, still on the shell | **2 of 3** |
| `serviceWorkers: 'block'`, still on the shell | 0 of 3 |
| `channel: 'chromium'` | **0 of 3** |

Blocking Service Workers isolates the trigger but drops production behaviour from a gate whose premise is that the artifact which ships is the artifact tested. Running Chrome's own headless keeps the Service Worker and is what Playwright recommends for testing. No timeout was raised; `retries: 0` is untouched.

For scale: over the gate's whole life — it was created on 2026-08-05 by #1078, so there is no earlier period to compare against — 126 executions, 116 that ran, 8 failures, of which 2 were infra (a TS build error, a missing wasm artifact). That is **6 genuine flakes in 114 executions, 5.3%**.

### Two other defects the investigation turned up

**The suite was testing development bundles.** `NODE_ENV: test` sat at job scope in `web-e2e.yml`, so it covered both `build:bundle` steps, and Vite reads `NODE_ENV` to decide whether a build is a production one. `release-bundle.spec.ts`, whose entire subject is the shipping artifact, was asserting against a development build. In a development build `import.meta.env.DEV` is true, so the app asks for the dev-only Service Worker entry `/src/sw.ts`, which no bundle contains, and `vite preview` answers it from the SPA fallback as `text/html`. Reproduced locally:

```
### dev build (NODE_ENV=test)
189ms serviceworker http://localhost:4199/src/sw.ts
194ms console.error The script has an unsupported MIME type ('text/html').
controller: false

### production build
122ms serviceworker http://localhost:4199/sw.js
controller: true
```

`NODE_ENV` moves onto the API's own steps, and two tests now assert the tab comes under `/sw.js`. Red-proved in a single run against the two bundles side by side: `[release]` (production) passed, `[e2e]` (built with `NODE_ENV=test`) failed with `Received has value: null`.

**The per-test login secret was published.** It crossed as a `page.evaluate` argument, which Playwright records verbatim into a trace this public repo uploads with 7-day retention. It is now minted in the page.

### Making a recurrence legible

`tests/web-e2e/fixtures.ts` taps `console`, `pageerror`, `requestfailed`, `crash` and `close`, attaches the record to a failure and fails with the cause rather than leaving the symptom to stand alone. It is what surfaced the MIME error in CI, and it is why the next occurrence names the death instead of `Received: undefined`.

Closes #1169

## Verification

- `pnpm typecheck` / `pnpm lint` / `pnpm lint:tracker-refs` / `pnpm test` / `cargo fmt --all -- --check` — all exit 0.
- `zizmor --no-online-audits .github/workflows/ .github/actions/` on the CI-pinned 1.25.2 — no findings.
- Locally, against real Postgres, the mock routing store and a real API: green at `--workers=2 --repeat-each=10`.
- In CI: 375 executions of this content at `--repeat-each=25`, no failures.

Self-review gates run on this diff: `/simplify` and `/security-review`. Both produced real findings that are folded in — the version-guard injection vector, dropping the installer fallback, and the login secret in the trace all came from the security pass. No crypto surface is touched, so `/crypto-privacy-review` does not apply.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prebuild wasm-bindgen-cli via install-action and fix web e2e smoke flake
> - Replaces the ad-hoc `cargo install` flow in [action.yml](.github/actions/wasm-bindgen-cli/action.yml) with `taiki-e/install-action`, pinning the version parsed from `Cargo.lock` and verifying it after install.
> - Removes `~/.cargo/bin` from CI cache paths in [ci.yml](.github/workflows/ci.yml) and [web-e2e.yml](.github/workflows/web-e2e.yml) so cached artifacts no longer conflict with the prebuilt binary.
> - Scopes `NODE_ENV: test` to only the migration and API boot steps in the web e2e workflow instead of the entire job, fixing the smoke flake.
> - Adds a Playwright fixture in [fixtures.ts](tests/web-e2e/fixtures.ts) that collects browser console, error, and crash events and attaches them to the report on failure.
> - Moves secret generation in `VaultPage.coldStart` from Node's `randomBytes` to in-browser `crypto.getRandomValues` to avoid passing secrets across the evaluate boundary.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3c54b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebAssembly CLI version validation and verification during builds.
  * Fixed browser end-to-end test reliability by explicitly selecting the supported Chromium channel.
  * Ensured application pages are controlled by the expected service worker.

* **Tests**
  * Added detailed diagnostics for browser console errors, failed requests, crashes, and unexpected page closures.
  * Expanded end-to-end coverage for service worker registration and control.
  * Improved browser-based login secret generation for test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->